### PR TITLE
docs: next-session orchestrator prompt

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,12 @@
+# cargo-audit configuration (CI runs plain `cargo audit`).
+# Keep this ignore list in lockstep with [advisories].ignore in deny.toml.
+
+[advisories]
+ignore = [
+  # 2026-07-07: Marvin attack timing sidechannel in `rsa` (via openidconnect →
+  # ehrbase-rest OIDC auth). No fixed release exists upstream; we only *verify*
+  # RS256 ID-token signatures (public-key operation) and never hold RSA private
+  # keys, so the private-key timing oracle does not apply. Re-check when
+  # rsa > 0.9 ships. https://rustsec.org/advisories/RUSTSEC-2023-0071
+  "RUSTSEC-2023-0071",
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  # Flip repository variable PORT_STRICT to "true" at Phase P17 (make-it-compile)
-  # to make the compile/clippy/test jobs REQUIRED. Until then they are advisory.
+  # ADR-006 retired the "phases need not compile" gate: every job here is
+  # REQUIRED. (The historical PORT_STRICT advisory switch is gone.)
 
 jobs:
   # ── Always required: formatting ──────────────────────────────────────────────
@@ -76,15 +76,12 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-audit
-      # Cargo.lock is not committed (see .gitignore); audit needs one to scan.
-      - run: cargo generate-lockfile
+      # Cargo.lock IS committed (workspace ships a binary); audit the real pins.
       - run: cargo audit
 
-  # ── Advisory until P17: clippy ──────────────────────────────────────────────
   clippy:
     name: clippy
     runs-on: ubuntu-latest
-    continue-on-error: ${{ vars.PORT_STRICT != 'true' }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -96,7 +93,6 @@ jobs:
   codegen-drift:
     name: codegen drift
     runs-on: ubuntu-latest
-    continue-on-error: ${{ vars.PORT_STRICT != 'true' }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -105,11 +101,10 @@ jobs:
       - name: Regenerate and diff
         run: bash scripts/check-codegen-drift.sh
 
-  # ── Advisory until P17: build + tests against PostgreSQL 18.4 ────────────────
+  # ── Build + tests against PostgreSQL 18.4 ────────────────────────────────────
   test:
     name: build & test (pg18)
     runs-on: ubuntu-latest
-    continue-on-error: ${{ vars.PORT_STRICT != 'true' }}
     services:
       postgres:
         image: postgres:18.4
@@ -128,8 +123,10 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Enable required extensions
+        # libxml2-utils provides xmllint — the C14N XML parity gate shells out
+        # to it (serialization.md); the runner image does not ship it.
         run: |
-          sudo apt-get update && sudo apt-get install -y postgresql-client
+          sudo apt-get update && sudo apt-get install -y postgresql-client libxml2-utils
           PGPASSWORD=openehr psql -h localhost -U openehr -d openehr_test \
             -c 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp"; CREATE EXTENSION IF NOT EXISTS pgcrypto; CREATE EXTENSION IF NOT EXISTS pg_trgm;'
       - uses: taiki-e/install-action@v2
@@ -140,11 +137,9 @@ jobs:
       - run: cargo nextest run --workspace --all-features --no-tests=pass
       - run: cargo test --workspace --doc
 
-  # ── Advisory until P17: coverage ────────────────────────────────────────────
   coverage:
     name: coverage
     runs-on: ubuntu-latest
-    continue-on-error: ${{ vars.PORT_STRICT != 'true' }}
     services:
       postgres:
         image: postgres:18.4
@@ -160,6 +155,8 @@ jobs:
       DATABASE_URL: postgres://openehr:openehr@localhost:5432/openehr_test
     steps:
       - uses: actions/checkout@v7
+      - name: Install xmllint (C14N parity gate)
+        run: sudo apt-get update && sudo apt-get install -y libxml2-utils
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: llvm-tools-preview
@@ -172,11 +169,10 @@ jobs:
           name: coverage-lcov
           path: lcov.info
 
-  # ── Advisory: unused dependencies ───────────────────────────────────────────
+  # ── Unused dependencies ──────────────────────────────────────────────────────
   unused-deps:
     name: cargo-machete
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v7
       - uses: taiki-e/install-action@v2

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,4 +1,20 @@
 # .github/workflows/containers.yml
+#
+# Container images, built for speed (docs/design/container-images.md):
+#
+#   1. The `ehrbase` binary is compiled OUTSIDE Docker, natively per
+#      architecture (amd64 on ubuntu-24.04, arm64 on ubuntu-24.04-arm — no
+#      QEMU emulation anywhere), inside a rust:*-slim-bookworm job container
+#      so the binary links against the same glibc (Debian 12 / 2.36) as the
+#      distroless cc-debian12 runtime image. Swatinem/rust-cache makes warm
+#      builds incremental.
+#   2. The image build itself is a COPY-only packaging step
+#      (docker/Dockerfile.runtime) — a multi-arch buildx push that takes
+#      seconds because no code runs inside the build.
+#   3. The smoke test pulls the pushed image by digest instead of rebuilding.
+#
+# docker/Dockerfile (multi-stage, from-source) remains the local/compose path;
+# CI does not use it.
 name: Containers
 
 on:
@@ -37,26 +53,80 @@ jobs:
               - 'docker/postgres/**'
               - '.github/workflows/containers.yml'
 
-  # ── Application image (always built; multi-arch) ────────────────────────────
-  app-image:
-    name: app image
-    runs-on: ubuntu-latest
+  # ── Compile the server binary natively per arch (no QEMU, no in-Docker cargo) ─
+  binary:
+    name: binary (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - platform: amd64
+            runner: ubuntu-24.04
+          - platform: arm64
+            runner: ubuntu-24.04-arm
+    # Debian 12 (bookworm) container so the produced binary targets glibc 2.36,
+    # matching gcr.io/distroless/cc-debian12 exactly. The tag must equal the
+    # rust-toolchain.toml channel — verified below, never assumed.
+    container: rust:1.96.1-slim-bookworm
     steps:
       - uses: actions/checkout@v7
 
-      - name: Verify Dockerfile RUST_VERSION matches rust-toolchain.toml
+      - name: Verify toolchain pins (container + Dockerfile == rust-toolchain.toml)
         shell: bash
         run: |
           set -euo pipefail
           channel=$(grep -E '^channel' rust-toolchain.toml | sed -E 's/.*"(.*)".*/\1/')
+          have=$(rustc --version | awk '{print $2}')
           arg=$(grep -E '^ARG RUST_VERSION=' docker/Dockerfile | head -1 | cut -d= -f2)
-          echo "rust-toolchain channel=$channel  Dockerfile RUST_VERSION=$arg"
+          echo "rust-toolchain=$channel  container-rustc=$have  Dockerfile ARG=$arg"
+          if [ "$channel" != "$have" ]; then
+            echo "::error::Job container rustc ($have) != rust-toolchain.toml ($channel). Bump the container: tag in containers.yml."
+            exit 1
+          fi
           if [ "$channel" != "$arg" ]; then
-            echo "::error::Toolchain pin drift: rust-toolchain.toml=$channel Dockerfile=$arg"
+            echo "::error::docker/Dockerfile RUST_VERSION ($arg) != rust-toolchain.toml ($channel)."
             exit 1
           fi
 
-      - uses: docker/setup-qemu-action@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: containers-${{ matrix.platform }}
+
+      - name: Build (release, native)
+        run: cargo build --release --locked -p ehrbase
+
+      - name: Strip
+        run: strip target/release/ehrbase
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ehrbase-${{ matrix.platform }}
+          path: target/release/ehrbase
+          if-no-files-found: error
+          retention-days: 1
+
+  # ── Package + push the multi-arch app image (COPY-only; seconds) ────────────
+  app-image:
+    name: app image
+    runs-on: ubuntu-24.04
+    needs: binary
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: ehrbase-amd64
+          path: bin/amd64
+      - uses: actions/download-artifact@v8
+        with:
+          name: ehrbase-arm64
+          path: bin/arm64
+
+      # No QEMU: the runtime Dockerfile is COPY-only, so a multi-arch build
+      # executes no foreign-arch code.
       - uses: docker/setup-buildx-action@v4
 
       - uses: docker/login-action@v4
@@ -77,11 +147,12 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
-      - name: Build and push
+      - name: Package and push
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
-          file: docker/Dockerfile
+          file: docker/Dockerfile.runtime
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
@@ -89,15 +160,14 @@ jobs:
           build-args: |
             VERSION=${{ steps.meta.outputs.version }}
             REVISION=${{ github.sha }}
-          cache-from: type=gha,scope=app
-          cache-to: type=gha,mode=max,scope=app
           provenance: true
           sbom: true
 
   # ── PostgreSQL image (only on docker/postgres changes or tags; multi-arch) ──
+  # COPY-only on top of postgres:18.4, so multi-arch needs no QEMU either.
   postgres-image:
     name: postgres image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: changes
     if: >-
       needs.changes.outputs.postgres == 'true' ||
@@ -105,7 +175,6 @@ jobs:
       github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v7
-      - uses: docker/setup-qemu-action@v4
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v4
         with:
@@ -134,38 +203,30 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=postgres
-          cache-to: type=gha,mode=max,scope=postgres
           provenance: true
           sbom: true
 
-  # ── Smoke test (amd64): compose both up, exercise the API, prove idempotency ─
+  # ── Smoke test (amd64): pull the pushed image, compose up, exercise the API ──
   smoke:
     name: compose smoke (amd64)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: app-image
     steps:
       - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
 
-      - name: Build app image (amd64, load)
-        uses: docker/build-push-action@v7
+      - uses: docker/login-action@v4
         with:
-          context: .
-          file: docker/Dockerfile
-          platforms: linux/amd64
-          load: true
-          tags: ehrbase-rs:smoke
-          cache-from: type=gha,scope=app
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build postgres image (amd64, load)
-        uses: docker/build-push-action@v7
-        with:
-          context: docker/postgres
-          file: docker/postgres/Dockerfile
-          platforms: linux/amd64
-          load: true
-          tags: ehrbase-rs-postgres:smoke
+      - name: Pull pushed app image (by digest)
+        run: |
+          docker pull "${APP_IMAGE}@${{ needs.app-image.outputs.digest }}"
+          docker tag  "${APP_IMAGE}@${{ needs.app-image.outputs.digest }}" ehrbase-rs:smoke
+
+      - name: Build postgres image (amd64; COPY-only, seconds)
+        run: docker build -t ehrbase-rs-postgres:smoke docker/postgres
 
       - name: Smoke test
         shell: bash

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -3,7 +3,7 @@
 # Container images, built for speed (docs/design/container-images.md):
 #
 #   1. The `ehrbase` binary is compiled OUTSIDE Docker, natively per
-#      architecture (amd64 on ubuntu-24.04, arm64 on ubuntu-24.04-arm — no
+#      architecture (amd64 on ubuntu-26.04, arm64 on ubuntu-26.04-arm — no
 #      QEMU emulation anywhere), inside a rust:*-slim-bookworm job container
 #      so the binary links against the same glibc (Debian 12 / 2.36) as the
 #      distroless cc-debian12 runtime image. Swatinem/rust-cache makes warm
@@ -62,9 +62,9 @@ jobs:
       matrix:
         include:
           - platform: amd64
-            runner: ubuntu-24.04
+            runner: ubuntu-26.04
           - platform: arm64
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-26.04-arm
     # Debian 12 (bookworm) container so the produced binary targets glibc 2.36,
     # matching gcr.io/distroless/cc-debian12 exactly. The tag must equal the
     # rust-toolchain.toml channel — verified below, never assumed.
@@ -109,7 +109,7 @@ jobs:
   # ── Package + push the multi-arch app image (COPY-only; seconds) ────────────
   app-image:
     name: app image
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     needs: binary
     outputs:
       digest: ${{ steps.build.outputs.digest }}
@@ -167,7 +167,7 @@ jobs:
   # COPY-only on top of postgres:18.4, so multi-arch needs no QEMU either.
   postgres-image:
     name: postgres image
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     needs: changes
     if: >-
       needs.changes.outputs.postgres == 'true' ||
@@ -209,7 +209,7 @@ jobs:
   # ── Smoke test (amd64): pull the pushed image, compose up, exercise the API ──
   smoke:
     name: compose smoke (amd64)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     needs: app-image
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,53 +26,34 @@ jobs:
           #   manifest-file: .release-please-manifest.json
 
   # Build the server binary and attach it when a GitHub Release is published.
+  # Native runner per arch (no cross toolchain, no QEMU) — same strategy as
+  # .github/workflows/containers.yml, which handles the GHCR images on tags.
   build-binaries:
     if: github.event_name == 'release'
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - runner: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
-          - os: ubuntu-latest
+          - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v7
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          target: ${{ matrix.target }}
-      - name: Install cross linker (aarch64)
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
       - name: Build server
-        run: cargo build --release --target ${{ matrix.target }} -p openehr-server
+        run: cargo build --release --locked -p ehrbase
       - name: Package
         shell: bash
+        env:
+          TAG: ${{ github.event.release.tag_name }}
         run: |
-          bin="openehr-server"
-          out="${bin}-${{ github.event.release.tag_name }}-${{ matrix.target }}.tar.gz"
-          tar -C "target/${{ matrix.target }}/release" -czf "$out" "$bin"
+          out="ehrbase-${TAG}-${{ matrix.target }}.tar.gz"
+          strip target/release/ehrbase
+          tar -C target/release -czf "$out" ehrbase
           echo "ASSET=$out" >> "$GITHUB_ENV"
       - name: Upload to release
         uses: softprops/action-gh-release@v3
         with:
           files: ${{ env.ASSET }}
-
-  # OPTIONAL: container image to GHCR (needs a Dockerfile at repo root).
-  # Uncomment when a Dockerfile exists.
-  # container:
-  #   if: github.event_name == 'release'
-  #   runs-on: ubuntu-latest
-  #   permissions: { contents: read, packages: write }
-  #   steps:
-  #     - uses: actions/checkout@v7
-  #     - uses: docker/login-action@v4
-  #       with: { registry: ghcr.io, username: ${{ github.actor }}, password: ${{ secrets.GITHUB_TOKEN }} }
-  #     - uses: docker/build-push-action@v7
-  #       with:
-  #         push: true
-  #         tags: ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }},ghcr.io/${{ github.repository }}:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: ubuntu-24.04
+          - runner: ubuntu-26.04
             target: x86_64-unknown-linux-gnu
-          - runner: ubuntu-24.04-arm
+          - runner: ubuntu-26.04-arm
             target: aarch64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1225,7 +1225,6 @@ dependencies = [
  "openehr-term",
  "opentelemetry",
  "opentelemetry-otlp",
- "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "reqwest 0.13.4",
  "sea-query",
@@ -1255,7 +1254,6 @@ dependencies = [
  "openehr-its",
  "quick-xml",
  "rustls",
- "rustls-pemfile",
  "serde",
  "thiserror 2.0.18",
  "tokio",
@@ -2891,10 +2889,8 @@ version = "0.1.0"
 dependencies = [
  "indexmap 2.14.0",
  "insta",
- "jiff",
  "moka",
  "openehr-am",
- "openehr-base",
  "openehr-its",
  "openehr-rm",
  "openehr-term",
@@ -2911,7 +2907,6 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "axum",
- "base64 0.22.1",
  "http",
  "indexmap 2.14.0",
  "jsonschema",
@@ -3064,12 +3059,6 @@ dependencies = [
  "tonic",
  "tonic-prost",
 ]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.32.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c913ac17a6c451661ee255f4625d143e51647ae78ebd969b75e41c4442f4fe47"
 
 [[package]]
 name = "opentelemetry_sdk"
@@ -4060,15 +4049,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,6 @@ cedar-policy = "4"                  # alternative policy engine (verify latest)
 # ── TLS / crypto foundations ─────────────────────────────────────────────────
 rustls = "0.23"
 tokio-rustls = "0.26"
-rustls-pemfile = "2"
 webpki-roots = "1.0.8"
 rand = "0.10.1"
 getrandom = "0.4.3"

--- a/crates/ehrbase-audit/Cargo.toml
+++ b/crates/ehrbase-audit/Cargo.toml
@@ -17,7 +17,6 @@ quick-xml = { workspace = true }
 tokio = { workspace = true }
 tokio-rustls = { workspace = true }
 rustls = { workspace = true }
-rustls-pemfile = { workspace = true }
 
 # Time (ISO-8601 UTC EventDateTime + syslog TIMESTAMP).
 jiff = { workspace = true }

--- a/crates/ehrbase-audit/src/syslog.rs
+++ b/crates/ehrbase-audit/src/syslog.rs
@@ -302,8 +302,10 @@ pub fn add_roots(roots: &mut rustls::RootCertStore, pem: &[u8]) -> io::Result<()
 }
 
 fn load_certs(pem: &[u8]) -> io::Result<Vec<rustls::pki_types::CertificateDer<'static>>> {
-    let mut reader = io::BufReader::new(pem);
-    let certs: Vec<_> = rustls_pemfile::certs(&mut reader).collect::<Result<_, _>>()?;
+    use rustls::pki_types::pem::PemObject;
+    let certs: Vec<_> = rustls::pki_types::CertificateDer::pem_slice_iter(pem)
+        .collect::<Result<_, _>>()
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
     if certs.is_empty() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -314,9 +316,9 @@ fn load_certs(pem: &[u8]) -> io::Result<Vec<rustls::pki_types::CertificateDer<'s
 }
 
 fn load_key(pem: &[u8]) -> io::Result<rustls::pki_types::PrivateKeyDer<'static>> {
-    let mut reader = io::BufReader::new(pem);
-    rustls_pemfile::private_key(&mut reader)?
-        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "no private key found in PEM"))
+    use rustls::pki_types::pem::PemObject;
+    rustls::pki_types::PrivateKeyDer::from_pem_slice(pem)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
 }
 
 #[cfg(test)]

--- a/crates/ehrbase-audit/tests/tls_roundtrip.rs
+++ b/crates/ehrbase-audit/tests/tls_roundtrip.rs
@@ -92,14 +92,11 @@ F9DV18ILppscP5wy0SP20/U=
 ";
 
 fn server_config() -> Arc<rustls::ServerConfig> {
-    let mut cert_reader = std::io::BufReader::new(TEST_LEAF_PEM);
-    let certs: Vec<_> = rustls_pemfile::certs(&mut cert_reader)
+    use rustls::pki_types::pem::PemObject;
+    let certs: Vec<_> = rustls::pki_types::CertificateDer::pem_slice_iter(TEST_LEAF_PEM)
         .collect::<Result<_, _>>()
         .expect("certs");
-    let mut key_reader = std::io::BufReader::new(TEST_LEAF_KEY_PEM);
-    let key = rustls_pemfile::private_key(&mut key_reader)
-        .expect("key parse")
-        .expect("key present");
+    let key = rustls::pki_types::PrivateKeyDer::from_pem_slice(TEST_LEAF_KEY_PEM).expect("key");
 
     let provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
     let config = rustls::ServerConfig::builder_with_provider(provider)

--- a/crates/ehrbase/Cargo.toml
+++ b/crates/ehrbase/Cargo.toml
@@ -26,7 +26,6 @@ tracing-opentelemetry.workspace = true
 opentelemetry.workspace = true
 opentelemetry_sdk.workspace = true
 opentelemetry-otlp.workspace = true
-opentelemetry-semantic-conventions.workspace = true
 metrics.workspace = true
 metrics-exporter-prometheus.workspace = true
 jiff-sqlx.workspace = true
@@ -72,5 +71,6 @@ opentelemetry_sdk = { workspace = true, features = ["rt-tokio", "testing"] }
 workspace = true
 
 [package.metadata.cargo-machete]
-# Scaffolded dependency graph (ADR-004 / phase 0R); these internal crates are wired now and consumed when this crate is ported (P6+).
-ignored = ["ehrbase-compat", "ehrbase-rest", "openehr-am", "openehr-base", "openehr-flat", "openehr-its", "openehr-lang", "openehr-query", "openehr-rm", "openehr-term"]
+# Wired for later phases, not consumed yet: ehrbase-compat (P17 EhrScape),
+# openehr-am (ADL2), openehr-lang (BMM at runtime).
+ignored = ["ehrbase-compat", "openehr-am", "openehr-lang"]

--- a/crates/openehr-flat/Cargo.toml
+++ b/crates/openehr-flat/Cargo.toml
@@ -13,14 +13,12 @@ publish = false
 openehr-rm = { path = "../openehr-rm" }
 openehr-its = { path = "../openehr-its" }
 openehr-am = { path = "../openehr-am" }
-openehr-base = { path = "../openehr-base" }
 openehr-term = { path = "../openehr-term" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 indexmap = { workspace = true }
 moka = { workspace = true }
 thiserror = { workspace = true }
-jiff = { workspace = true }
 regex = { workspace = true }
 
 [dev-dependencies]
@@ -34,6 +32,5 @@ ehrbase-quirks = []
 workspace = true
 
 [package.metadata.cargo-machete]
-# `openehr-am`/`openehr-term` are wired for the (later) FLAT/terminology paths; the
-# WebTemplate builder (this PR) resolves labels from the archetype rubrics like Better does.
-ignored = ["openehr-am", "openehr-term"]
+# `openehr-am` is wired for the (later) FLAT/ADL2 paths; not consumed yet.
+ignored = ["openehr-am"]

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -15,7 +15,6 @@ serde_json.workspace = true
 quick-xml.workspace = true
 thiserror.workspace = true
 jsonschema.workspace = true
-base64.workspace = true
 uuid.workspace = true
 # The generated `opt14` model keeps `StringDictionaryItem` groups in
 # document order (XSD ordered sequence; F-09-05) — order-preserving map.

--- a/deny.toml
+++ b/deny.toml
@@ -5,7 +5,14 @@
 version = 2
 # Fail on any RustSec advisory. Add exceptions explicitly and dated.
 yanked = "deny"
-ignore = []
+ignore = [
+  # 2026-07-07: Marvin attack timing sidechannel in `rsa` (pulled in via
+  # openidconnect → ehrbase-rest OIDC auth). No fixed release exists upstream;
+  # we only *verify* RS256 ID-token signatures (public-key operation) and never
+  # hold RSA private keys, so the private-key timing oracle does not apply.
+  # Re-check when rsa > 0.9 ships. https://rustsec.org/advisories/RUSTSEC-2023-0071
+  { id = "RUSTSEC-2023-0071", reason = "no fix upstream; RSA used for signature verification only (no private keys held)" },
+]
 
 [licenses]
 version = 2
@@ -21,6 +28,11 @@ allow = [
   "Unicode-3.0",
   "MPL-2.0",
   "CC0-1.0",
+  # MIT No Attribution (borrow-or-share, via fluent-uri → sqlx).
+  "MIT-0",
+  # Community Data License Agreement — Permissive 2.0 (webpki-roots: the
+  # Mozilla CA bundle data). Permissive, Apache-2.0-compatible.
+  "CDLA-Permissive-2.0",
 ]
 confidence-threshold = 0.9
 exceptions = []

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,41 +1,39 @@
 # syntax=docker/dockerfile:1
 #
-# Multi-stage build for the `ehrbase` server binary (ADR-006/008).
+# From-source multi-stage build for the `ehrbase` server binary (ADR-006/008).
+# This is the LOCAL/compose path (`docker compose build`, `docker build -f
+# docker/Dockerfile .`); CI packages prebuilt native binaries with
+# docker/Dockerfile.runtime instead (see .github/workflows/containers.yml).
 #
-#   build context : the repository root  (`docker build -f docker/Dockerfile .`)
-#   builder       : rust:${RUST_VERSION}-slim-bookworm + cargo-chef dependency
-#                   layer caching → `cargo build --release --locked -p ehrbase`
-#   runtime       : gcr.io/distroless/cc-debian12:nonroot (shell-less, non-root)
+#   builder : rust:${RUST_VERSION}-slim-bookworm, single `cargo build` with
+#             BuildKit cache mounts for the registry and target dir — repeat
+#             local builds are incremental, and nothing (cargo-chef, a second
+#             dependency compile) runs besides the one real build.
+#   runtime : gcr.io/distroless/cc-debian12:nonroot (shell-less, non-root;
+#             glibc 2.36 matches the bookworm builder).
 #
 # The toolchain is single-sourced from rust-toolchain.toml; RUST_VERSION must
 # equal its `channel` (CI cross-checks the two so they never drift).
 
 ARG RUST_VERSION=1.96.1
 
-# ── chef: rust base with cargo-chef installed ───────────────────────────────
-FROM rust:${RUST_VERSION}-slim-bookworm AS chef
+# ── builder: one cached compile ──────────────────────────────────────────────
+FROM rust:${RUST_VERSION}-slim-bookworm AS builder
 WORKDIR /app
-RUN cargo install cargo-chef --locked
-# The binary is pure-Rust (rustls, no OpenSSL); cargo-chef cook/build need no
-# extra system libraries beyond the slim base.
-
-# ── planner: distil the dependency graph into a recipe ──────────────────────
-FROM chef AS planner
 COPY . .
-RUN cargo chef prepare --recipe-path recipe.json
+# The binary is pure-Rust (rustls, no OpenSSL); no system libraries are needed
+# beyond the slim base. Cache mounts persist the crates.io registry and the
+# incremental target dir across builds; the binary is copied out of the mount
+# before it unmounts.
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/app/target,sharing=locked \
+    cargo build --release --locked -p ehrbase \
+    && cp target/release/ehrbase /usr/local/bin/ehrbase \
+    && strip /usr/local/bin/ehrbase
 
-# ── builder: cook deps (cached), then build the workspace binary ────────────
-FROM chef AS builder
-COPY --from=planner /app/recipe.json recipe.json
-# This layer is cached and only re-runs when the dependency set changes.
-RUN cargo chef cook --release --recipe-path recipe.json
-COPY . .
-RUN cargo build --release --locked -p ehrbase \
-    && strip target/release/ehrbase
-
-# ── runtime: distroless cc (glibc + CA certs), non-root ─────────────────────
+# ── runtime: distroless cc (glibc + CA certs), non-root ──────────────────────
 FROM gcr.io/distroless/cc-debian12:nonroot AS runtime
-COPY --from=builder /app/target/release/ehrbase /usr/local/bin/ehrbase
+COPY --from=builder /usr/local/bin/ehrbase /usr/local/bin/ehrbase
 
 EXPOSE 8080
 

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1
+#
+# CI packaging Dockerfile — COPY-only, no compilation (containers.yml).
+#
+# The `ehrbase` binaries are built natively per architecture on the CI runners
+# (inside rust:*-slim-bookworm, so they target Debian 12 glibc 2.36 — exactly
+# what this distroless base ships) and land in the build context as
+# bin/amd64/ehrbase and bin/arm64/ehrbase. Because no RUN executes, a
+# multi-arch buildx of this file needs no QEMU and finishes in seconds.
+#
+# For local from-source builds use docker/Dockerfile (the compose default).
+
+FROM gcr.io/distroless/cc-debian12:nonroot
+
+# amd64 | arm64 — supplied by buildx per platform.
+ARG TARGETARCH
+COPY --chmod=0755 bin/${TARGETARCH}/ehrbase /usr/local/bin/ehrbase
+
+EXPOSE 8080
+
+# Shell-less image: the healthcheck is the binary's own subcommand, which
+# probes /rest/status and exits 0 (2xx) / 1 otherwise.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD ["/usr/local/bin/ehrbase", "healthcheck"]
+
+ENTRYPOINT ["/usr/local/bin/ehrbase"]
+
+# OCI image labels. CI (docker/metadata-action) overrides source/revision/
+# version/created at build time; these are sensible static defaults.
+ARG VERSION="0.1.0"
+ARG REVISION=""
+LABEL org.opencontainers.image.title="ehrbase-rs" \
+      org.opencontainers.image.description="Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.0.3 + AQL 1.1)" \
+      org.opencontainers.image.source="https://github.com/rubentalstra/ehrbase-rs" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${REVISION}"

--- a/docker/Dockerfile.runtime.dockerignore
+++ b/docker/Dockerfile.runtime.dockerignore
@@ -1,0 +1,5 @@
+# Context trimming for docker/Dockerfile.runtime (context is the repo root in
+# CI, after the binary artifacts are downloaded). Only the prebuilt binaries
+# enter the build context.
+*
+!bin/

--- a/docs/design/container-images.md
+++ b/docs/design/container-images.md
@@ -81,11 +81,12 @@ emulation is 10–20× slower than native, and the original pipeline did exactly
 that (twice: cargo-chef cook + build), then rebuilt the image a third time in
 the smoke job. The rewrite:
 
-1. **`binary (amd64|arm64)`** — matrix over native runners (`ubuntu-24.04`,
-   `ubuntu-24.04-arm`; free for public repos), each inside a
+1. **`binary (amd64|arm64)`** — matrix over native runners (`ubuntu-26.04`,
+   `ubuntu-26.04-arm`; free for public repos), each inside a
    `rust:1.96.1-slim-bookworm` **job container** so the binary links Debian 12
    glibc 2.36 — exactly the distroless runtime's libc (building on the Ubuntu
-   24.04 host would link glibc 2.39 and not run on the runtime image).
+   host directly would link a newer glibc and not run on the runtime image;
+   this also makes the host Ubuntu version irrelevant to the binary).
    `Swatinem/rust-cache` (per-platform shared key) makes warm builds
    incremental; a verify step asserts container rustc == `rust-toolchain.toml`
    == the Dockerfile ARG. Binaries are stripped and uploaded as artifacts.

--- a/docs/design/container-images.md
+++ b/docs/design/container-images.md
@@ -1,6 +1,9 @@
 # Container images — application + preconfigured PostgreSQL (GHCR)
 
-- **Status:** design → implementing (2026-07-06)
+- **Status:** implemented (2026-07-06); **CI build architecture rewritten for
+  speed (2026-07-07)** — §3 describes the current native-runner pipeline (the
+  original QEMU + cargo-chef-in-Docker pipeline took ~50 min per push and was
+  replaced wholesale).
 - **Prior art:** official EHRbase ships `ehrbase/ehrbase` (the server) and
   `ehrbase/ehrbase-v2-postgres` (a PostgreSQL image with roles/schemas/
   extensions pre-created so the app user needs no superuser). We ship the same
@@ -14,18 +17,24 @@
 | Application | `ghcr.io/rubentalstra/ehrbase-rs` | the `ehrbase` binary (axum server), config via `EHRBASE_*` env |
 | Database | `ghcr.io/rubentalstra/ehrbase-rs-postgres` | `postgres:18.4` + init scripts: roles, database, schemas, required extensions |
 
-## 1. Application image (`docker/Dockerfile`)
+## 1. Application image
 
-**Multi-stage, multi-arch (amd64 + arm64):**
+Two Dockerfiles, one runtime shape:
 
-1. **Planner/builder** — `rust:1.96-slim-bookworm` (must match
-   `rust-toolchain.toml`; the Dockerfile ARG-pins it and CI cross-checks so the
-   two never drift) with **`cargo-chef`**: `chef prepare` → `chef cook`
-   (dependency layer cached independently of source changes) → `cargo build
-   --release -p ehrbase`. `mold` not needed in release CI; `--locked` builds
-   (Cargo.lock is currently gitignored — **decision: commit Cargo.lock**; it is
-   a binary deliverable, reproducibility wins and the workspace ships a server,
-   not a library).
+- **`docker/Dockerfile`** — the from-source path (local dev + the compose
+  quickstart). `rust:1.96.1-slim-bookworm` builder (ARG-pinned to
+  `rust-toolchain.toml`; CI cross-checks so the two never drift), a **single
+  `cargo build --release --locked -p ehrbase`** with BuildKit cache mounts for
+  the registry + target dir (cargo-chef was dropped: it compiled itself and
+  the dependency graph a second time for no gain over cache mounts), then the
+  distroless runtime stage.
+- **`docker/Dockerfile.runtime`** — the CI packaging path: **COPY-only** (no
+  RUN), expects prebuilt native binaries at `bin/{amd64,arm64}/ehrbase` in the
+  context. A multi-arch buildx of it executes no foreign-arch code, so it
+  needs no QEMU and finishes in seconds.
+
+Runtime (both files):
+
 2. **Runtime** — `gcr.io/distroless/cc-debian12:nonroot`. The binary is pure
    Rust (rustls, no OpenSSL), so distroless-cc suffices (needs only libc/CA
    certs, both present). Runs as `nonroot`; `EXPOSE 8080`;
@@ -65,20 +74,39 @@ into the image would couple the two images' release cycles for zero gain —
 the EHRbase precedent (init-scripts only) is also the correct call here.
 The image README says exactly this.
 
-## 3. CI/CD (`.github/workflows/containers.yml`)
+## 3. CI/CD (`.github/workflows/containers.yml`) — native-runner pipeline (2026-07-07)
 
-- Triggers: push to `develop` (tags `develop`, `sha-<short>`), version tags
-  `v*` (tags `latest`, `X.Y.Z`, `X.Y`), manual dispatch.
-- Jobs: `docker/build-push-action` + `buildx` QEMU matrix (linux/amd64,
-  linux/arm64), GHCR login via `GITHUB_TOKEN` (`packages: write`), layer cache
-  `type=gha`.
-- The app image build runs the test suite? **No** — tests run in the existing
-  CI; the container workflow only builds what a green commit produced
-  (`needs:`-gate it on the test workflow where trigger context allows).
-- Metadata via `docker/metadata-action`; SBOM + provenance attestations on
-  (`provenance: true`, `sbom: true`) — free with buildx.
-- Postgres image builds on changes under `docker/postgres/**` + the same tag
-  events, same multi-arch matrix.
+Designed around one fact: compiling the Rust workspace under QEMU arm64
+emulation is 10–20× slower than native, and the original pipeline did exactly
+that (twice: cargo-chef cook + build), then rebuilt the image a third time in
+the smoke job. The rewrite:
+
+1. **`binary (amd64|arm64)`** — matrix over native runners (`ubuntu-24.04`,
+   `ubuntu-24.04-arm`; free for public repos), each inside a
+   `rust:1.96.1-slim-bookworm` **job container** so the binary links Debian 12
+   glibc 2.36 — exactly the distroless runtime's libc (building on the Ubuntu
+   24.04 host would link glibc 2.39 and not run on the runtime image).
+   `Swatinem/rust-cache` (per-platform shared key) makes warm builds
+   incremental; a verify step asserts container rustc == `rust-toolchain.toml`
+   == the Dockerfile ARG. Binaries are stripped and uploaded as artifacts.
+2. **`app image`** — downloads both artifacts, one COPY-only multi-arch
+   buildx push of `docker/Dockerfile.runtime` (seconds; no QEMU, no gha layer
+   cache needed). Metadata via `docker/metadata-action`; `provenance: true`,
+   `sbom: true`.
+3. **`postgres image`** — unchanged trigger logic (changes under
+   `docker/postgres/**` or tags), but QEMU dropped: the Dockerfile is
+   COPY-only on `postgres:18.4`, so multi-arch needs no emulation.
+4. **`smoke`** — **pulls the pushed app image by digest** (no rebuild) and
+   does a plain amd64 `docker build` of the postgres image (seconds), then
+   runs `docker/smoke-test.sh`.
+
+Triggers unchanged: push to `develop` (tags `develop`, `sha-<short>`), version
+tags `v*` (`latest`, `X.Y.Z`, `X.Y`), manual dispatch. Tests still live in the
+main CI workflow, not here.
+
+Expected wall clock: warm ≈ 4–8 min (binary compile dominates), cold ≈ 15–20
+min — vs ~50 min+ for the QEMU pipeline. The two arch builds run in parallel,
+so wall clock ≈ the slower native compile + ~1 min packaging + smoke.
 
 ## 4. Quickstart compose (`docker-compose.yml`, repo root)
 

--- a/docs/enterprise/access-control.md
+++ b/docs/enterprise/access-control.md
@@ -1,0 +1,602 @@
+# RBAC + ABAC Access Control — Rust-native design
+
+- **Status:** designed, ready to implement (2026-07-07)
+- **Stage:** Stage 2 capability, owner-prioritized into Stage 1 (same route as the
+  ATNA audit trail — see `PORT_MASTER_PLAN.md` §11.2, `docs/enterprise/v1-vs-v2-delta.md` §1)
+- **Owner:** —
+- **Prior art (not a port target):** EHRbase v1 (`reference/v1` = v0.32.0) ABAC
+  (`application/.../abac/*`) + the v1/v2 Spring Security RBAC config. The exact
+  v1 semantics were extracted from the git ref on 2026-07-07 and are summarized
+  in §2/§3 below; we replicate the *behaviour and the external wire contract*,
+  fix its documented defects, and implement natively (ADR-006/008 discipline:
+  prior art, not an oracle).
+- **Related docs:** `docs/enterprise/atna-audit.md` (the integration pattern this
+  design copies: leaf crate + tower/dispatch hook + data-driven table +
+  total-coverage guard), `docs/enterprise/v1-vs-v2-delta.md` (archaeology).
+- **Out of scope here:** multi-tenancy (its own Stage 2 design; the tenant
+  attribute slot in §5.3 is reserved for it), openEHR `EHR_ACCESS`-driven
+  policies (v1 never enforced them either; see §10), demographic-API policies
+  beyond the coarse RBAC gate.
+
+---
+
+## 1. Goals and shape
+
+Two independent, composable layers:
+
+1. **RBAC (coarse, always on when auth is enabled).** Every generated ITS-REST
+   operation is classified (Admin / Management / Clinical / Public) in a static,
+   total-coverage-guarded table; a role model (default `USER`/`ADMIN`, extracted
+   from JWT claims or Basic-auth config) gates each class. This replaces today's
+   placeholder path-string check (`Authenticator::authorize_admin`,
+   `crates/ehrbase-rest/src/auth/mod.rs:161-173`, marked
+   `// TODO(port): Stage 2 RBAC`).
+2. **ABAC (fine-grained, opt-in `authz.abac.enabled`).** A policy decision point
+   (PDP) is consulted per clinical operation with resolved attributes
+   (organization, patient, template). Two interchangeable PDP engines behind one
+   trait:
+   - **Embedded Cedar** (`cedar-policy` 4.x) — the default; policies live in
+     files, no external service needed.
+   - **Remote PDP** — byte-compatible with the EHRbase v1 external
+     policy-server contract (§2), for deployments that already run one.
+
+Non-goals: row-level security in Postgres, per-node filtering, policy
+administration UI.
+
+### 1.1 Why Cedar over casbin (decision record)
+
+Both are already pinned in the workspace (`casbin = "2"`, `cedar-policy = "4"`,
+root `Cargo.toml` — the ADR-006 "decide at S2" candidates). Decision: **Cedar**,
+verified 2026-07-07 (cedar-policy 4.11.2, updated 2026-06; casbin 2.20.0,
+updated 2026-02).
+
+- Cedar has a **typed schema**: principals/actions/resources are declared, and
+  policies are validated against the schema at load time — a healthcare CDR
+  wants "this policy references a resource attribute that doesn't exist" to be
+  a boot-time error, not a silent always-deny.
+- One language expresses **both RBAC and ABAC** (role membership = principal
+  groups; attribute conditions = `when` clauses), so advanced deployments can
+  push the coarse layer into policies later without a second engine.
+- The evaluator is small, formally modeled, and **deny-by-default with forbid
+  overriding permit** — the right defaults for clinical data.
+- casbin's model is stringly-typed tuples + a matcher DSL in config; it is
+  runtime-flexible but unverifiable, and its Rust port trails the Go original.
+
+The `PolicyEngine` trait (§5.4) keeps this swappable; if a deployment demands
+casbin, it is one new impl, not a redesign. Record this as an ADR
+(`/write-adr "Cedar as the embedded authorization engine"`) when
+implementation starts; this section is the content.
+
+---
+
+## 2. Prior art: exact EHRbase v1 semantics (extracted from `reference/v1`)
+
+What v1 actually did — the parity baseline. (Full extraction in the 2026-07-07
+investigation; verbatim quotes from `application/.../abac/AbacConfig.java` and
+`CustomMethodSecurityExpressionRoot.java`.)
+
+### 2.1 The external-PDP wire contract (we keep this, byte-compatible)
+
+- **Request:** `POST {abac.server}{policy-name}` — the policy name is appended
+  as a path segment to the configured base URL (which ends in a slash, e.g.
+  `http://pdp:3001/rest/v1/policy/execute/name/` + `has_consent_template`).
+  Body: a **flat JSON object** with only the configured/resolved parameters,
+  keys exactly `"organization"`, `"patient"`, `"template"`. Header
+  `Content-Type: application/json`. No auth forwarded.
+- **Response:** HTTP **200 = permit**; any other status = deny. The response
+  body is ignored entirely.
+- **Errors are fail-closed:** connection/IO failure → HTTP 500 to the caller
+  (request not served). Deny → 403. There is no fail-open mode; we keep that.
+- **Multi-valued fan-out:** when patient and/or template resolve to *sets*
+  (query, contribution), v1 sends **one POST per combination** (full cartesian
+  product) and requires **all** to return 200; the first non-200 denies.
+
+### 2.2 Attribute resolution (v1)
+
+- `organization` ← JWT claim named by `abac.organizationClaim` (default
+  `organization_id`). Configured-but-missing claim → error (500).
+- `patient` ← JWT claim named by `abac.patientClaim` (default `patient_id`).
+  **Local gate before any PDP call:** for non-query resources the claim must
+  equal the target EHR's subject external-ref id (`getSubjectExtRef(ehr_id)`),
+  except a subject-less EHR (`null`) passes. Mismatch → immediate deny (403),
+  no PDP call. For queries, *every* EHR id in the result set must map to a
+  subject external ref equal to the claim (logical AND) or deny.
+- `template` ← per resource type: composition create/update → parse the request
+  body's `archetype_details/template_id/value`; composition delete → retrieve
+  the preceding version and read its template id; composition read (post) →
+  from the response body; contribution → the set of template ids across all
+  versions in the payload; query → the set of template ids in the result. EHR
+  and EHR_STATUS policies configuring `template` → hard error.
+- ABAC required JWT auth (Basic → "no JWT available" error).
+
+### 2.3 Enforcement coverage (v1) and its defects
+
+Pre-checks (`@PreAuthorize`): composition create/update/delete, contribution
+create, EHR get (by id + by subject), EHR_STATUS get/get-by-version/update,
+versioned-EHR_STATUS reads. Post-checks (`@PostAuthorize`): composition get,
+versioned-composition reads, **all query execution** (attributes read from the
+executed result set).
+
+Defects we deliberately fix (each a `// PORT NOTE:` in code):
+
+1. **The query result-set hack.** v1 extracted patient/template for query
+   post-checks from the *SELECT columns* — the check only worked if the AQL
+   happened to select `ehr_id/value` / `archetype_details/template_id/value`,
+   otherwise **500**. We own the AQL engine: the executor knows the touched VO
+   roots regardless of the projection (§6.4). No dependency on what the query
+   selects.
+2. **Method security coupled to the ABAC flag.** v1's service-layer
+   `hasRole('ADMIN')` checks were only active when `abac.enabled=true`
+   (the `@EnableGlobalMethodSecurity` bean was conditional on it). Our RBAC
+   layer is unconditional.
+3. **Coverage gaps.** v1 never checked EHR create, DIRECTORY/FOLDER, or
+   DEFINITION ops. Our classification table covers **every** generated
+   operation (total-coverage guard); ABAC adds a `DIRECTORY` resource family
+   (new, marked as an extension over v1).
+4. **No timeouts on the PDP client.** Ours has explicit connect/request
+   timeouts (fail-closed on expiry).
+
+### 2.4 RBAC (v1/v2, retained behaviour)
+
+- Roles `USER` / `ADMIN`. Basic auth: two configured users, one role each.
+  OAuth: authorities from `realm_access.roles` (Keycloak) **and** the
+  space-separated `scope` claim, upper-cased; the role names to match are
+  configurable (`oauth2UserRole`/`oauth2AdminRole`, default USER/ADMIN).
+- URL rules: `/rest/admin/**` and management endpoints → ADMIN; management
+  access is tri-state (`ADMIN_ONLY` | `PRIVATE` | `PUBLIC`); everything else →
+  any authenticated user.
+
+---
+
+## 3. Current-code integration map (verified 2026-07-07)
+
+The seams this design binds to, as the code stands today:
+
+| Fact | Where |
+|---|---|
+| `Principal { subject, scopes, method }` — **no roles/claims retained** | `crates/ehrbase-rest/src/auth/mod.rs:26-42`; JWT reduction in `auth/jwt.rs` |
+| Principal inserted into request extensions + `REQUEST_PRINCIPAL` task-local + republished on the response | `auth/mod.rs:198-251` (`middleware`), `current_principal()` at `:191` |
+| Placeholder admin gate (path-segment == "admin" + one scope) | `auth/mod.rs:161-178` — **replaced by this design** |
+| Generated routes: `(&str method, &str path-template, &str operation_id)` per API group; ~96 ops | `crates/openehr-its/src/rest/generated/{ehr,query,definition,admin,demographic}.rs` (`ROUTES`) |
+| Generic dispatch choke point — has `op` id + resolved path params (`RequestParts.path: IndexMap`) + `AppState`; already inserts `AuditOpId(op)` | `crates/ehrbase-rest/src/dispatch/mod.rs:100-141` (`mount`) |
+| `Backend` seam (`EhrService + DefinitionApi + WebTemplateService + QueryService`) on `AppState` | `crates/ehrbase-rest/src/backend.rs:485-507`, `state.rs:33` |
+| EHR subject lookup: promoted `ehr.subject_id`/`subject_namespace` columns; forward resolver precedent (`SubjectResolver` closure, binary-owned) | `crates/ehrbase/src/service/ehr.rs:77-93`; `crates/ehrbase/src/main.rs:197-213` |
+| `vo_version.template_id` **stored but not read back** (`VersionRead` lacks it) | written at `service/vobject.rs:449,459`; `VersionRead` at `:88-105`; reads at `:594-632` |
+| AQL EHR scoping: `SqlCtx { ehr_id: Option<Uuid>, .. }` → `WHERE vo.ehr_id = $x` on every VO root | `crates/ehrbase/src/aql/sql.rs:63-67, 383-388`; `service/aql_query.rs:76-81` |
+| ATNA audit layer sits **outside** auth; any inner 403 with `Principal` on the response extensions is audited automatically | `crates/ehrbase-rest/src/audit.rs:98-115`; convention at `auth/mod.rs:218-220` |
+| Config precedent: standalone `AuditConfig` (`EHRBASE_ATNA_*`), loaded in `main.rs:83`, threaded as `Option<AuditSender>` | `crates/ehrbase-audit/src/config.rs`, `main.rs:175-192` |
+| `casbin = "2"` + `cedar-policy = "4"` pinned, unconsumed | root `Cargo.toml:80-81` |
+
+---
+
+## 4. Architecture overview
+
+```
+                 ┌────────────────────────────── ehrbase-rest ─────────────────────────────┐
+ request ──► ATNA audit layer ──► auth middleware ──► [RBAC gate] ──► dispatch mount ──► handler
+                 ▲                  (Principal+roles)     │              │ [ABAC pre-check]     │
+                 │ observes 403/401                       │              │        │             ▼
+                 │                                        │              │        │      ServiceResponse
+                 └── deny = 403 + Principal on resp ◄─────┴──────────────┴────────┤ [ABAC post-check]
+                                                                                  ▼
+                                                                     ehrbase-authz::PolicyEngine
+                                                                     ├─ CedarEngine (embedded)
+                                                                     └─ RemotePdp   (v1 wire contract)
+```
+
+- **RBAC gate** runs inside the auth middleware (it already has the Principal
+  and runs before dispatch), using the operation classification resolved from
+  the request path via axum's `MatchedPath` + a route-template → op-id map
+  built once from the generated `ROUTES` tables.
+- **ABAC pre-checks** run in the generic `mount` closure — the one place with
+  the machine-readable `operation_id`, the resolved path params, and
+  `AppState` — before `dispatch()` is called. No per-operation code.
+- **ABAC post-checks** (composition reads, query) run after the backend call,
+  where the `ServiceResponse`/`ResourceMeta`/result set is available.
+- Every deny is a 403 carrying the `Principal` on the response extensions —
+  the ATNA layer audits it with zero new audit code.
+
+### 4.1 Crate layout
+
+New workspace crate **`crates/ehrbase-authz`** (application layer, hand-written,
+`thiserror`; leaf like `ehrbase-audit` — no `ehrbase-*` deps):
+
+```
+crates/ehrbase-authz/src/
+├── lib.rs
+├── config.rs      # AuthzConfig (figment-compatible serde; EHRBASE_AUTHZ_*)
+├── roles.rs       # Role model + extraction rules (claim paths → roles)
+├── classify.rs    # operation_id → OperationClass table (total-coverage-guarded)
+├── request.rs     # AuthzRequest / Decision / ResourceKind / Attribute types
+├── engine.rs      # PolicyEngine trait (the PDP seam)
+├── cedar.rs       # CedarEngine: schema, entity building, policy loading
+└── remote.rs      # RemotePdp: the v1-compatible HTTP client (reqwest)
+```
+
+Dependencies: `cedar-policy` (workspace), `reqwest` (workspace, rustls),
+`serde`/`serde_json`, `thiserror`, `tracing`, `metrics`, `figment` (config),
+`indexmap`. Dev-deps: `wiremock`, `insta`, `openehr-its` (path dep, **dev-only**,
+for the total-coverage guard over `ROUTES` — same trick as `ehrbase-audit`).
+
+`ehrbase-rest` gains: the extended `Principal`, the RBAC gate, the ABAC PEP in
+dispatch, and an `Option<Arc<AuthzHandle>>` on `AppState` beside `audit`
+(`state.rs:31-39`). `ehrbase` (binary) gains: `AuthzConfig::load()`, engine
+construction, and the attribute resolvers (DB lookups stay in the binary, like
+the audit `SubjectResolver`). Dependency arrows stay downward:
+`ehrbase-rest → ehrbase-authz`, `ehrbase → ehrbase-authz`.
+
+---
+
+## 5. The pieces, precisely
+
+### 5.1 Principal extension (prerequisite)
+
+`crates/ehrbase-rest/src/auth/mod.rs`:
+
+```rust
+pub struct Principal {
+    pub subject: String,
+    pub scopes: Vec<String>,
+    pub roles: Vec<String>,                       // NEW — normalized, upper-cased
+    pub claims: serde_json::Map<String, Value>,   // NEW — retained JWT claims (Bearer only; empty for Basic)
+    pub method: AuthMethod,
+}
+```
+
+- `auth/jwt.rs`: retain the validated claim set; extract roles from (a)
+  `realm_access.roles` (Keycloak array) and (b) the space-separated `scope`
+  claim — both upper-cased — matching v1's converter; the claim paths are
+  configurable (`authz.rbac.role_claims`, default `["realm_access.roles",
+  "scope"]`). Scopes stay as-is (they already feed the old admin gate; keep
+  populating them for back-compat).
+- `auth/basic.rs` + `AuthConfig`: each configured Basic user gains a
+  `roles: Vec<String>` (defaults: the existing user → `["USER"]`, admin user →
+  `["ADMIN"]`, preserving current behaviour).
+- Claims retention is what makes ABAC work under Bearer; ABAC under Basic is
+  rejected exactly as v1 did (typed error → 403 with a clear body, not 500).
+
+### 5.2 RBAC: operation classification + role gate
+
+`ehrbase-authz::classify`:
+
+```rust
+pub enum OperationClass { Public, Clinical, Management, Admin }
+pub fn class_of(operation_id: &str) -> Option<OperationClass>  // static table
+```
+
+- Data-driven table keyed by the generated operation ids (all ~96), plus the
+  non-generated surface (status/health/swagger/management) classified by route.
+  **Total-coverage guard:** a dev-test walks every op id in every generated
+  `ROUTES` table and asserts it is classified — a new generated operation fails
+  the build until classified (identical pattern to
+  `ehrbase-audit/src/table.rs` §8.3 of the ATNA doc).
+- Gate rules (evaluated in the auth middleware, unconditionally — fixing v1
+  defect #2):
+  - `Admin` (the `admin_*` ops) → requires `authz.rbac.admin_role` (default `ADMIN`).
+  - `Management` → tri-state `authz.rbac.management_access`:
+    `admin_only` (default) | `private` (any authenticated) | `public`.
+  - `Clinical` → any authenticated principal (`USER` or `ADMIN` — i.e. at
+    least one configured role; principals with zero roles are denied when
+    RBAC is enabled).
+  - `Public` → no check (root/status/health per current router).
+- Deny → 403 + `Principal` on the response extensions (ATNA picks it up).
+- `authz.rbac.enabled` defaults to `true` whenever auth is enabled; disabling
+  restores today's behaviour (auth only + the legacy admin path gate removed).
+- The old `authorize_admin`/`is_admin_path`/`admin_scope` path hack is deleted;
+  config keeps accepting `admin_scope` as a deprecated alias that maps to a
+  role grant (a scope named X already surfaces as role X via the scope→role
+  extraction, so migration is automatic).
+
+### 5.3 ABAC: the authorization request
+
+`ehrbase-authz::request`:
+
+```rust
+pub enum ResourceKind { Ehr, EhrStatus, Composition, Contribution, Query, Directory }
+
+pub struct AuthzRequest<'a> {
+    pub operation_id: &'a str,          // the generated op id (the "action")
+    pub kind: ResourceKind,
+    pub ehr_id: Option<Uuid>,
+    pub organization: Option<String>,   // resolved JWT claim
+    pub patient: Option<Patients>,      // String or Set (query)
+    pub template: Option<Templates>,    // String or Set (contribution/query)
+    // reserved: tenant (multi-tenancy design will occupy this slot)
+}
+
+pub enum Decision { Permit, Deny }
+```
+
+`ResourceKind` is derived from the operation-id prefix (`ehr_*`,
+`ehr_status_*`/`versioned_ehr_status_*`, `composition_*`/`versioned_composition_*`,
+`contribution_*`, `query_execute_*`, `directory_*`) — one function beside
+`classify`, covered by the same guard. `Directory` is our extension (v1 defect
+#3); its default policy config is absent = unchecked, preserving v1 parity
+unless the operator opts in.
+
+### 5.4 The PDP seam
+
+`ehrbase-authz::engine`:
+
+```rust
+#[async_trait]
+pub trait PolicyEngine: Send + Sync + std::fmt::Debug {
+    async fn decide(&self, req: &AuthzRequest<'_>) -> Result<Decision, AuthzError>;
+}
+```
+
+- `AuthzError` (engine unreachable, policy load failure, malformed attributes)
+  is **fail-closed**: the PEP maps it to 500 (v1 parity), never Permit.
+- Multi-valued attributes: the **engine** owns fan-out semantics. `RemotePdp`
+  implements v1's cartesian product (one POST per combination, all must
+  permit, short-circuit deny). `CedarEngine` evaluates one query per
+  combination against the in-memory policy set (cheap) with the same
+  all-must-permit rule, so both engines are behaviourally identical.
+
+### 5.5 `RemotePdp` (v1 wire contract, byte-compatible)
+
+- `reqwest` (workspace, rustls) client with explicit timeouts
+  (`authz.abac.remote.connect_timeout_ms` default 2000,
+  `request_timeout_ms` default 5000 — v1 defect #4 fixed).
+- URL = `server` (must end with `/`, validated at boot) + the configured
+  policy name for the resource kind. Body = flat JSON with only the resolved
+  keys `organization` / `patient` / `template`. Permit iff status 200.
+- Per-kind policy config mirrors v1:
+  `authz.abac.policy.{ehr,ehr_status,composition,contribution,query,directory}`
+  each `{ name, parameters: [organization|patient|template] }`. Configuring
+  `template` for `ehr`/`ehr_status` is a boot-time config error (v1 made it a
+  runtime 500).
+
+### 5.6 `CedarEngine` (embedded, default)
+
+- **Schema** (shipped, `cedar-policy` validated at load):
+  - Principal `User` with attrs `organization?: String`, `patient?: String`,
+    `roles: Set<String>`, `scopes: Set<String>`.
+  - Actions: one Cedar action per `ResourceKind` × access mode
+    (`"composition.create"`, `"composition.read"`, `"query.execute"`, …),
+    derived from the op classification — *not* 96 raw op ids; op ids map onto
+    these action names in `cedar.rs` (table beside `classify`, guarded by the
+    same coverage test).
+  - Resources: `Ehr { subject?: String }`, `Composition { template: String,
+    subject?: String }`, `Query { }` (the per-combination evaluation puts the
+    candidate patient/template on the resource), `Directory { subject?: String }`.
+- **Policies** from `authz.abac.cedar.policy_dir` (`*.cedar` files), parsed +
+  schema-validated at boot; invalid policy set → refuse to start (fail-closed
+  at the earliest possible moment). Optional periodic reload
+  (`authz.abac.cedar.reload_secs`, default off) with swap-on-valid semantics
+  (`arc-swap`).
+- Deny-by-default; `forbid` overrides `permit` (Cedar semantics — document in
+  the shipped example policies).
+- Shipped examples reproducing v1's defaults (`has_consent_patient`,
+  `has_consent_template`) as commented `.cedar` files under
+  `crates/ehrbase-authz/examples/policies/`.
+
+### 5.7 The patient gate (local, before any engine call)
+
+v1's subject-match check is **not** policy — it is a hard invariant we keep in
+the PEP (both engines behind it):
+
+- Non-query: if `authz.abac.patient_claim` is configured, resolve the target
+  EHR's subject external-ref id (via the resolver, §6.1). Claim ≠ subject and
+  subject non-null → **immediate 403**, no engine call. Subject null → pass
+  (v1 parity; a subject-less EHR is not patient-scoped).
+- Query: every distinct EHR touched by the executed result must map to a
+  subject equal to the claim, else 403 (§6.4).
+- Missing configured claim on the token → 403 with typed detail (v1 threw 500;
+  PORT NOTE the improvement).
+
+---
+
+## 6. Attribute resolution (Rust-native)
+
+DB lookups live in the **binary** as resolver closures handed to the REST
+layer at boot — the audit `SubjectResolver` precedent (`main.rs:197-213`) —
+packaged as one struct:
+
+```rust
+pub struct AuthzResolvers {
+    /// ehr_id → EHR subject external-ref id (promoted ehr.subject_id column).
+    pub subject: Arc<dyn Fn(Uuid) -> BoxFuture<'static, Result<Option<String>, E>> + Send + Sync>,
+    /// composition version → template_id (vo_version.template_id).
+    pub template_of_version: Arc<dyn Fn(Uuid /*vo_id*/, Option<i32>) -> … + Send + Sync>,
+}
+```
+
+### 6.1 `subject` — one indexed `SELECT subject_id FROM ehr WHERE id = $1`
+(the exact query the audit resolver already runs).
+
+### 6.2 `template` for compositions — from storage, not body re-parsing
+
+`vo_version.template_id` is already **written** on every composition commit
+(`service/vobject.rs:449,459`) but not read back. Add `template_id:
+Option<String>` to `VersionRead` (`vobject.rs:88-105`) and the two SELECTs
+(`read_current`/`read_version`, `vobject.rs:594-632`) — a contained change that
+gives every post-check and the delete pre-check the template id without
+touching payload bytes (v1 re-parsed request/response bodies; we don't need
+to). For composition **create/update pre-checks** the template id is read from
+the incoming payload the same way validation already does
+(`service/composition.rs:311-315`, JSON pointer
+`/archetype_details/template_id/value`; the XML path goes through the existing
+`FromXml` parse that dispatch performs anyway — resolve *after* body
+deserialization inside the dispatch arm boundary, see §7.2).
+
+### 6.3 `template` set for contributions — from the parsed contribution
+payload (all versions' `archetype_details/template_id/value`), computed in the
+pre-check after deserialization. Missing on any COMPOSITION version → treat as
+unresolvable → 403 (fail-closed).
+
+### 6.4 Query attributes — engine-computed, projection-independent (fixes v1 defect #1)
+
+Two mechanisms, both in `crates/ehrbase/src/aql/`:
+
+- **Pre-execution scope (cheap, always):** when the caller is patient-scoped
+  (patient claim configured), resolve the patient's EHR set is unnecessary —
+  instead thread the *subject* predicate into the SQL: extend `SqlCtx`
+  (`aql/sql.rs:63-67`) from `ehr_id: Option<Uuid>` to also carry
+  `subject_scope: Option<String>`, adding
+  `AND <vo-root>.ehr_id IN (SELECT id FROM ehr WHERE subject_id = $s)` to the
+  same VO-root predicate site (`sql.rs:383-388`). Rows the caller may not see
+  are never fetched. (`PERF(port)`: replace the IN-subquery with a join if
+  measured hot at P20.)
+- **Post-execution attribute collection (for the PDP call):** the executor
+  (`aql/exec.rs:44-80`) knows each result row's VO root; collect the distinct
+  `ehr_id` set and distinct `template_id` set of the touched versions during
+  result assembly (both are columns on `vo_version`/the fetched rows — no
+  dependency on what the query SELECTs). Surface them on the query result
+  context handed back through `QueryService`, and run the ABAC post-check
+  (patient gate over the EHR set + PDP fan-out over the template set) before
+  the RESULT_SET is serialized. Empty result → nothing to check → permit
+  (v1 behaviour: empty sets skip the fan-out loop).
+
+The pre-execution scope makes the post-check patient gate a no-op in practice
+(rows are pre-filtered), but both are kept: the post-check is the
+belt-and-suspenders guarantee and the template attributes are needed for the
+PDP call regardless.
+
+---
+
+## 7. Enforcement matrix (ours)
+
+Pre = in dispatch `mount` before the backend call; Post = after the backend
+call, before response serialization. Families map to the generated op ids via
+the §5.3 prefix rules; the guard test asserts every clinical op id appears
+here or in the explicit `UNCHECKED` allowlist (with a reason).
+
+| Family (op-id prefix) | Check | Attributes | v1 parity note |
+|---|---|---|---|
+| `ehr_create`, `ehr_create_with_id` | **Pre** | organization, patient (claim only — no EHR exists yet) | extension (v1 unchecked) |
+| `ehr_get_by_id`, `ehr_get_by_subject` | **Pre** | organization, patient (subject gate; for by-subject the request param is the subject, as v1) | parity |
+| `ehr_status_*`, `versioned_ehr_status_*` | **Pre** | organization, patient | parity (template illegal) |
+| `composition_create`, `composition_update` | **Pre** | organization, patient, template (from request body) | parity |
+| `composition_delete` | **Pre** | organization, patient, template (from `vo_version.template_id` of the preceding version) | parity, cleaner source |
+| `composition_get*` (incl. versioned reads) | **Post** | organization, patient, template (from `VersionRead.template_id`) | parity |
+| `contribution_create` | **Pre** | organization, patient, template-set (from payload) | parity |
+| `contribution_get` | **Post** | organization, patient | extension (v1 unchecked) |
+| `query_execute_*` (ad-hoc + stored) | **Pre-scope + Post** | organization; patient/template sets engine-computed (§6.4) | parity, defect #1 fixed |
+| `directory_*` | **Pre** | organization, patient | extension; unchecked unless a `directory` policy is configured |
+| `definition_*`, `demographic_*`, admin, management | RBAC only | — | parity (v1 ABAC never covered these) |
+
+Every ABAC deny and every RBAC deny: **403**, problem-details body per the
+ITS-REST error shape already used by `ApiError`, `Principal` attached to the
+response extensions (audited by ATNA for free). Engine failure: **500**
+(fail-closed).
+
+---
+
+## 8. Configuration
+
+Standalone `AuthzConfig` (the `AuditConfig` precedent): own prefix
+`EHRBASE_AUTHZ_`, optional TOML via `EHRBASE_AUTHZ_CONFIG`, nested keys split
+on `__`, all defaults valid, master switches.
+
+| Key | Env | Default | Meaning |
+|---|---|---|---|
+| `rbac.enabled` | `EHRBASE_AUTHZ_RBAC__ENABLED` | `true` | coarse role gate (active only when auth is enabled) |
+| `rbac.admin_role` | … | `ADMIN` | role required for Admin-class ops |
+| `rbac.user_role` | … | `USER` | baseline clinical role |
+| `rbac.role_claims` | … | `["realm_access.roles","scope"]` | JWT claim paths mined for roles |
+| `rbac.management_access` | … | `admin_only` | `admin_only` \| `private` \| `public` |
+| `abac.enabled` | `EHRBASE_AUTHZ_ABAC__ENABLED` | `false` | master ABAC switch |
+| `abac.engine` | … | `cedar` | `cedar` \| `remote` |
+| `abac.organization_claim` | … | `organization_id` | JWT claim for `organization` |
+| `abac.patient_claim` | … | `patient_id` | JWT claim for `patient` (enables the subject gate) |
+| `abac.cedar.policy_dir` | … | — (required for cedar) | directory of `.cedar` files |
+| `abac.cedar.reload_secs` | … | off | optional policy hot-reload |
+| `abac.remote.server` | … | — (required for remote) | PDP base URL, must end `/` |
+| `abac.remote.connect_timeout_ms` / `request_timeout_ms` | … | 2000 / 5000 | PDP client timeouts |
+| `abac.policy.<kind>.name` / `.parameters` | … | unset | per-resource policy (remote engine; kinds: ehr, ehr_status, composition, contribution, query, directory) |
+
+Boot validation (hard errors): `template` parameter on ehr/ehr_status; remote
+server without trailing `/`; cedar dir missing/unparseable/schema-invalid;
+ABAC enabled with auth disabled.
+
+Binary wiring: `main.rs` loads `AuthzConfig` beside `AuditConfig`, builds
+`Option<Arc<AuthzHandle>>` (`None` when everything disabled) where
+`AuthzHandle = { config-derived rules, Arc<dyn PolicyEngine>, AuthzResolvers }`,
+and threads it into `serve_full`/`AppState` beside `audit`.
+
+---
+
+## 9. Testing (binding)
+
+Same rigor as the ATNA plan (§8.5 there):
+
+1. **Total-coverage guards** (dev-tests in `ehrbase-authz` against
+   `openehr-its::ROUTES`): (a) every generated op id has an `OperationClass`;
+   (b) every clinical op id is in the §7 matrix or the `UNCHECKED` allowlist
+   with a reason string. New generated ops fail the build until classified.
+2. **Role extraction unit tests:** Keycloak-shaped `realm_access.roles`,
+   scope-claim mining, upper-casing, Basic-user role config, zero-role deny.
+3. **RemotePdp contract tests (`wiremock`):** URL = base + policy name; flat
+   JSON body with exactly the configured keys; 200→permit, 401/403/500→deny;
+   connect error / timeout → `AuthzError` (→ 500 at the PEP); cartesian
+   fan-out order + short-circuit (patient set × template set); all-must-permit.
+4. **CedarEngine tests:** schema validation rejects a bad policy at load;
+   the shipped example policies permit/deny golden cases (insta on the
+   decision + diagnostics); forbid-overrides-permit; per-combination fan-out
+   equivalence with RemotePdp (same `AuthzRequest` corpus, same decisions —
+   a differential test between the two engines).
+5. **Patient-gate unit tests:** claim==subject pass, mismatch deny (no engine
+   call — assert via a counting mock engine), null-subject pass, missing
+   claim → 403.
+6. **e2e over the real axum app (testcontainers PG18):** Bearer principal with
+   patient claim: composition create permitted for own EHR, 403 for another
+   patient's EHR (and the ATNA UDP listener sees the deny record — reuse the
+   audit e2e harness); composition get post-check deny; AQL query returns only
+   the caller's EHR rows under `subject_scope` and the post-check attributes
+   are computed for a projection that selects neither `ehr_id/value` nor
+   template (the v1-defect regression test); admin op 403 for USER role /
+   200 for ADMIN; RBAC-disabled fallback preserves today's behaviour.
+7. **Config boot-validation tests** per §8.
+
+---
+
+## 10. Relationship to openEHR EHR_ACCESS
+
+openEHR's `EHR_ACCESS` object is the RM-native per-EHR access-control slot.
+v1 never enforced it and the RM leaves the `ACCESS_CONTROL_SETTINGS` subtree
+deliberately unspecified (RM common IM — access control model is
+implementation-defined). We already create a default `EHR_ACCESS` per EHR
+(`service/ehr.rs:411-417`). This design keeps policy **outside** the RM object
+(Cedar files / external PDP); a future iteration may project per-EHR settings
+into `EHR_ACCESS.settings` for interoperability, but no CNF test exercises it
+and it is explicitly out of scope here. `// PORT NOTE:` this in the PEP.
+
+---
+
+## 11. Implementation plan (hand this to the implementer)
+
+Ordered, compiling+tested increments; each step cites its governing sections.
+Branch `claude/s2-access-control`. Hard rules apply (no test weakening, no
+`// @generated` edits, `thiserror` in libs, no `unwrap` outside tests).
+
+1. **Principal extension** (§5.1): `roles` + `claims` on `Principal`; jwt/basic
+   producers + `AuthConfig` roles; unit tests (§9.2). Nothing consumes roles
+   yet — behaviour unchanged.
+2. **`ehrbase-authz` crate scaffold** (§4.1): types (`request.rs`),
+   `classify.rs` table + both total-coverage guards (§9.1), `config.rs` +
+   boot validation (§8, §9.7). `/crate-scaffold ehrbase-authz` then fill.
+3. **RBAC gate** (§5.2): wire classification into the auth middleware via a
+   route-template→op-id map from `ROUTES`; replace `authorize_admin`
+   (delete `is_admin_path`); deprecated `admin_scope` alias; e2e admin
+   gate tests (§9.6 subset). Ship this as its own PR — it is independently
+   valuable and removes the TODO.
+4. **PDP seam + RemotePdp** (§5.4, §5.5): trait, fan-out semantics, reqwest
+   client, wiremock contract suite (§9.3).
+5. **CedarEngine** (§5.6): schema, action mapping (guarded), policy loading +
+   validation, example policies, differential tests vs RemotePdp (§9.4).
+6. **Resolvers + template read-back** (§6): `template_id` into `VersionRead`
+   + the two SELECTs; `AuthzResolvers` in the binary; unit tests.
+7. **ABAC PEP — non-query** (§5.7, §7): patient gate + pre/post checks in
+   dispatch `mount` per the matrix; 403/500 mapping; ATNA deny e2e (§9.5,
+   §9.6).
+8. **ABAC PEP — query** (§6.4): `SqlCtx.subject_scope` + executor attribute
+   collection + post-check; the projection-independence regression test.
+9. **Docs + close-out:** config reference into the deploy docs; `/write-adr`
+   for the Cedar decision (§1.1); update `docs/enterprise/v1-vs-v2-delta.md`
+   §1 status; workspace gate (`cargo nextest run --workspace`, clippy, fmt,
+   deny/audit/machete green).
+
+Estimated shape: steps 1–3 are one bounded PR (RBAC); steps 4–8 the ABAC PR
+(or two: engines, then PEP). Everything is behind config defaults that
+preserve current behaviour until an operator opts in.

--- a/docs/plans/next-session-prompt.md
+++ b/docs/plans/next-session-prompt.md
@@ -1,0 +1,64 @@
+# Next-session orchestrator prompt (P17 + audit backlog + CNF runner)
+
+Copy-paste the block below into a fresh Fable 5 session. Authored 2026-07-07,
+right after PR #21 (P16 AQL engine + ATNA + containers + observability) and
+PR #22 (CI action bumps) merged to `develop`.
+
+---
+
+You are Fable 5 and you are the ORCHESTRATOR — you plan, design, review, and keep
+the critical path in-session; implementation fans out to Opus agents
+(model: 'opus'), MAXIMUM 2 AGENTS RUNNING AT THE SAME TIME. Commit each agent's
+verified result before launching the next. The openEHR specs at
+docs/specs/openehr/ are the ONLY authority — never EHRbase/Archie/Better
+behaviour (they are Java prior art, we do it the Rust way and better). Full
+clean rewrites over patches, no stubs, no wrappers, no shortcuts — modern
+idiomatic Rust best practices everywhere.
+
+Read first: CLAUDE.md, docs/plans/current-phase.md, docs/ADRs/ADR-008,
+docs/spec-audit/SPEC_AUDIT.md, docs/design/aql-engine.md.
+
+Work these, in order, on a claude/phase-17-* branch:
+
+1. P17 — FLAT/EhrScape (docs/plans/phase-17-flat-ehrscape.md): wire the
+   openehr-flat FLAT/STRUCTURED converters through ehrbase-compat as the
+   EhrScape-compatible surface (/rest/ecis/v1/*), plus the FLAT composition
+   endpoints on the main API, on top of the existing WebTemplateService seam
+   and ServiceResponse envelope. Design the compat surface yourself before
+   delegating — it must reuse the service layer, never duplicate it.
+
+2. The now-unblocked spec-audit findings: docs/spec-audit/findings/ still has
+   ~82 open items — triage them yourself first. The area-03 QUERY-execution
+   findings were deferred "until P16" and P16 is DONE (the AQL engine +
+   /query/* endpoints exist) — fix everything that is now implementable.
+   Also sweep the remaining minor findings per area; tick checkboxes + update
+   SPEC_AUDIT.md counts as you go.
+
+3. Start P19 early — the CNF conformance runner (scripts/conformance.sh +
+   a Rust runner crate or test harness): execute the vendored openEHR CNF
+   Platform Conformance Test Schedule (docs/specs/openehr/CNF/ — the Robot
+   suites + fixtures) against our running server (docker compose or
+   testcontainers). This is the ADR-008 acceptance instrument and must be
+   wired BEFORE more features land. Produce a per-chapter pass/fail report
+   committed as docs/conformance/RESULTS.md; every failure becomes a tracked
+   finding with a spec citation. Do not weaken or skip failing cases — they
+   are the backlog.
+
+Discipline: compiling + clippy-clean + tested per increment (cargo nextest,
+testcontainers PG18); never hand-edit // @generated files (fix the emitter and
+regenerate); never weaken a test; tick phase checkboxes; commit as
+'phase-17: <task>' (or 'spec-audit:'/'conformance:' for items 2/3); no AI
+attribution anywhere. When all three are green: update docs/PROGRESS.md +
+current-phase.md, push, open a PR to develop, and give me the summary with
+per-area counts.
+
+---
+
+## Rationale (for the human)
+
+- **P17** is the official next phase in the build order.
+- **The audit backlog** has items that were only blocked on the AQL engine
+  existing; P16 closing unblocked them.
+- **The CNF runner** is what ADR-008 calls the acceptance instrument — every
+  feature added before it exists is unverified against the real conformance
+  oracle, so pulling it forward from P19 is the highest-leverage move.


### PR DESCRIPTION
Adds the copy-paste orchestrator prompt for the next working session (P17 FLAT/EhrScape, the now-unblocked spec-audit findings, and the pulled-forward CNF conformance runner), with rationale.