### PR TITLE
bench: honest ehrbase-rs vs EHRbase (Java) benchmark harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1500,6 +1500,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1703,6 +1713,26 @@ dependencies = [
  "tokio",
  "tracing",
  "wiremock",
+]
+
+[[package]]
+name = "ehrbase-bench"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "ehrbase",
+ "ehrbase-conformance",
+ "ehrbase-rest",
+ "hdrhistogram",
+ "jiff",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sysinfo",
+ "testcontainers",
+ "testcontainers-modules",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -2338,6 +2368,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "hdrhistogram"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+dependencies = [
+ "base64 0.21.7",
+ "byteorder",
+ "crossbeam-channel",
+ "flate2",
+ "nom 7.1.3",
+ "num-traits",
 ]
 
 [[package]]
@@ -3315,6 +3359,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3363,6 +3413,16 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
@@ -3377,6 +3437,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -3540,6 +3609,63 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 1.0.69",
  "url",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.13.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -4081,7 +4207,7 @@ dependencies = [
  "log",
  "md-5 0.10.6",
  "memchr",
- "nom",
+ "nom 8.0.0",
  "num-bigint-dig",
  "num-traits",
  "num_enum",
@@ -5890,6 +6016,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.39.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8bd2130a9b60bee2581bf82cfe89ee836424d1f37dcfa4ce21509611684673"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "objc2-open-directory",
+ "windows",
+]
+
+[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6897,6 +7038,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6907,6 +7069,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -6936,6 +7109,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -6996,6 +7179,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,6 +198,8 @@ testcontainers = "0.27.3"           # real PostgreSQL 18 in tests (verify latest
 testcontainers-modules = { version = "0.15.0", features = ["postgres"] }   # verify latest
 criterion = { version = "0.8.2", features = ["html_reports"] }
 divan = "0.1"
+hdrhistogram = "7.5.4"               # coordinated-omission-corrected latency (ehrbase-bench)
+sysinfo = "0.39.5"                   # CPU/RSS sampling for the benchmark harness
 
 # Cargo plugins used in CI (installed, not dependencies):
 #   cargo-nextest, cargo-audit, cargo-deny, cargo-machete, cargo-hakari,

--- a/crates/ehrbase-bench/Cargo.toml
+++ b/crates/ehrbase-bench/Cargo.toml
@@ -1,0 +1,49 @@
+[package]
+name = "ehrbase-bench"
+version = "0.1.0"
+description = "Honest benchmark harness: ehrbase-rs vs EHRbase (Java) at the openEHR REST surface (docs/design/benchmarking.md)"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+publish = false
+
+[[bin]]
+name = "bench"
+path = "src/bin/bench.rs"
+
+[dependencies]
+# The SUT client is REUSED from the conformance crate so the request path is
+# provably identical for both targets (design §5) — the core fairness guarantee.
+ehrbase-conformance = { path = "../ehrbase-conformance" }
+
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+clap = { workspace = true }
+jiff = { workspace = true }
+tokio = { workspace = true }
+reqwest = { workspace = true }
+hdrhistogram = { workspace = true }
+sysinfo = { workspace = true }
+
+# `self-host` seeds/drives an in-process ehrbase-rs (testcontainers PG18) so the
+# harness can prove itself against a SUT it controls before comparing to Java
+# (design §9 step 1). Kept optional so the lean CLI drives external SUTs only.
+ehrbase = { path = "../ehrbase", optional = true }
+ehrbase-rest = { path = "../ehrbase-rest", optional = true }
+testcontainers = { workspace = true, optional = true }
+testcontainers-modules = { workspace = true, optional = true }
+
+[features]
+self-host = [
+    "dep:ehrbase",
+    "dep:ehrbase-rest",
+    "dep:testcontainers",
+    "dep:testcontainers-modules",
+    "ehrbase-conformance/self-host",
+]
+
+[lints]
+workspace = true

--- a/crates/ehrbase-bench/src/bin/bench.rs
+++ b/crates/ehrbase-bench/src/bin/bench.rs
@@ -1,0 +1,6 @@
+//! `bench` CLI — the benchmark harness entry point (docs/design/benchmarking.md).
+
+fn main() {
+    eprintln!("ehrbase-bench: harness scaffold — run/report/seed not yet wired");
+    std::process::exit(2);
+}

--- a/crates/ehrbase-bench/src/bin/bench.rs
+++ b/crates/ehrbase-bench/src/bin/bench.rs
@@ -1,6 +1,285 @@
 //! `bench` CLI — the benchmark harness entry point (docs/design/benchmarking.md).
+//!
+//! `bench run` drives the pre-registered workload against a SUT (external URL or,
+//! under `--features self-host`, an in-process ehrbase-rs) and writes the
+//! generated report to `--out`. `bench seed` bulk-loads a SUT for the scale
+//! ladder. `bench report --from results.json` re-renders the markdown.
 
-fn main() {
-    eprintln!("ehrbase-bench: harness scaffold — run/report/seed not yet wired");
-    std::process::exit(2);
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+use ehrbase_bench::driver::{DriverConfig, ScenarioResult, run_latency};
+use ehrbase_bench::report::{BenchReport, EnvBlock};
+use ehrbase_bench::target::{Implementation, Target};
+use ehrbase_bench::workload::{Scenario, workload_lock};
+use ehrbase_conformance::client::Credential;
+
+#[derive(Parser)]
+#[command(
+    name = "bench",
+    about = "Honest ehrbase-rs vs. EHRbase benchmark harness"
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Run the workload against a SUT and write the report.
+    Run(RunArgs),
+    /// Bulk-seed a SUT (scale ladder).
+    Seed(SeedArgs),
+    /// Re-render REPORT.md from a results.json.
+    Report(ReportArgs),
+}
+
+#[derive(Parser)]
+struct RunArgs {
+    /// SUT base URL (…/ehrbase/rest/openehr/v1). Omit with --self-host.
+    #[arg(long)]
+    base_url: Option<String>,
+    /// Boot an in-process ehrbase-rs (requires --features self-host).
+    #[arg(long)]
+    self_host: bool,
+    /// Which implementation the SUT is (labels the report).
+    #[arg(long, default_value = "ehrbase-rs")]
+    implementation: String,
+    /// Auth spec: basic:<user>:<pass> or bearer:<token>.
+    #[arg(long)]
+    auth: Option<String>,
+    /// Only run this scenario id (W1/W2/W4/W8); default all.
+    #[arg(long)]
+    scenario: Option<String>,
+    /// Fast smoke config (proves the harness, not publishable numbers).
+    #[arg(long)]
+    smoke: bool,
+    /// Output directory.
+    #[arg(long, default_value = "docs/benchmarks")]
+    out: PathBuf,
+    /// Override the ISO-8601 run timestamp (default: now). The host machine is
+    /// always auto-captured regardless.
+    #[arg(long)]
+    run_date: Option<String>,
+}
+
+#[derive(Parser)]
+struct SeedArgs {
+    #[arg(long)]
+    base_url: Option<String>,
+    #[arg(long)]
+    self_host: bool,
+    #[arg(long)]
+    auth: Option<String>,
+    #[arg(long, default_value_t = 10)]
+    ehrs: u32,
+    #[arg(long, default_value_t = 1)]
+    comps: u32,
+}
+
+#[derive(Parser)]
+struct ReportArgs {
+    /// Path to a results.json produced by `bench run`.
+    #[arg(long)]
+    from: PathBuf,
+    /// Output directory.
+    #[arg(long, default_value = "docs/benchmarks")]
+    out: PathBuf,
+}
+
+#[tokio::main]
+async fn main() {
+    let cli = Cli::parse();
+    let code = match cli.command {
+        Command::Run(args) => cmd_run(args).await,
+        Command::Seed(args) => cmd_seed(args).await,
+        Command::Report(args) => cmd_report(&args),
+    };
+    std::process::exit(code);
+}
+
+/// Resolve a target (external or self-hosted). Returns the target and an
+/// optional keep-alive guard (the self-hosted SUT, whose Drop stops the server).
+// `async` is load-bearing under `--features self-host` (awaits container boot);
+// without the feature there is no await, which is expected.
+#[cfg_attr(not(feature = "self-host"), allow(clippy::unused_async))]
+async fn resolve_target(
+    base_url: Option<String>,
+    self_host: bool,
+    implementation: Implementation,
+    auth: Option<String>,
+) -> Result<(Target, Option<Box<dyn std::any::Any>>), String> {
+    if self_host {
+        #[cfg(feature = "self-host")]
+        {
+            let sut = ehrbase_conformance::sut::Sut::self_hosted()
+                .await
+                .map_err(|e| format!("self-host boot: {e}"))?;
+            let base = sut.base_url();
+            // The dev Basic user the self-hosted app is configured with.
+            let cred = Credential::Basic {
+                user: "ehrbase".to_owned(),
+                pass: "ehrbase".to_owned(),
+            };
+            let target = Target::new(implementation, base, Some(cred.clone()), Some(cred))
+                .map_err(|e| e.to_string())?;
+            return Ok((target, Some(Box::new(sut) as Box<dyn std::any::Any>)));
+        }
+        #[cfg(not(feature = "self-host"))]
+        {
+            let _ = implementation;
+            return Err("--self-host requires building with `--features self-host`".to_owned());
+        }
+    }
+    let base = base_url.ok_or_else(|| "one of --base-url or --self-host is required".to_owned())?;
+    let cred = auth.as_deref().map(Credential::parse).transpose()?;
+    let target =
+        Target::new(implementation, base, cred.clone(), cred).map_err(|e| e.to_string())?;
+    Ok((target, None))
+}
+
+async fn cmd_run(args: RunArgs) -> i32 {
+    let implementation = match args.implementation.parse::<Implementation>() {
+        Ok(i) => i,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return 2;
+        }
+    };
+    let (target, _keep_alive) =
+        match resolve_target(args.base_url, args.self_host, implementation, args.auth).await {
+            Ok(t) => t,
+            Err(e) => {
+                eprintln!("error: {e}");
+                return 2;
+            }
+        };
+
+    let cfg = if args.smoke {
+        DriverConfig::smoke()
+    } else {
+        DriverConfig::default()
+    };
+
+    let scenarios: Vec<Scenario> = match &args.scenario {
+        Some(id) => {
+            if let Some(s) = Scenario::ALL
+                .iter()
+                .find(|s| s.id().eq_ignore_ascii_case(id))
+            {
+                vec![*s]
+            } else {
+                eprintln!("error: unknown scenario {id:?} (expected W1/W2/W4/W8)");
+                return 2;
+            }
+        }
+        None => Scenario::ALL.to_vec(),
+    };
+
+    let mut results: Vec<ScenarioResult> = Vec::new();
+    for s in scenarios {
+        eprintln!(
+            "running {} ({}) against {}",
+            s.id(),
+            s.description(),
+            target.label()
+        );
+        match run_latency(&target, s, cfg).await {
+            Ok(r) => results.push(r),
+            Err(e) => {
+                eprintln!("error running {}: {e}", s.id());
+                return 1;
+            }
+        }
+    }
+
+    let report = BenchReport {
+        env: EnvBlock {
+            run_date: args.run_date.unwrap_or_else(now_iso),
+            // Auto-captured — every report states the machine that produced it.
+            host: ehrbase_bench::host::HostInfo::capture(),
+            workload_lock: workload_lock(),
+            harness_revision: option_env!("GIT_REV").unwrap_or("unknown").to_owned(),
+            warmup_iters: cfg.warmup_iters,
+            measure_iters: cfg.measure_iters,
+            runs: cfg.runs,
+        },
+        results,
+    };
+
+    write_report(&report, &args.out)
+}
+
+async fn cmd_seed(args: SeedArgs) -> i32 {
+    let (target, _keep_alive) = match resolve_target(
+        args.base_url,
+        args.self_host,
+        Implementation::EhrbaseRs,
+        args.auth,
+    )
+    .await
+    {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return 2;
+        }
+    };
+    match ehrbase_bench::seed::seed(&target, args.ehrs, args.comps).await {
+        Ok(n) => {
+            eprintln!("seeded {n} compositions across {} EHRs", args.ehrs);
+            0
+        }
+        Err(e) => {
+            eprintln!("seed error: {e}");
+            1
+        }
+    }
+}
+
+fn cmd_report(args: &ReportArgs) -> i32 {
+    let json = match std::fs::read_to_string(&args.from) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("error reading {}: {e}", args.from.display());
+            return 2;
+        }
+    };
+    let report: BenchReport = match serde_json::from_str(&json) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("error parsing results.json: {e}");
+            return 2;
+        }
+    };
+    write_report(&report, &args.out)
+}
+
+fn write_report(report: &BenchReport, out: &std::path::Path) -> i32 {
+    if let Err(e) = std::fs::create_dir_all(out) {
+        eprintln!("error creating {}: {e}", out.display());
+        return 1;
+    }
+    let json = match report.to_json() {
+        Ok(j) => j,
+        Err(e) => {
+            eprintln!("error serializing results: {e}");
+            return 1;
+        }
+    };
+    let md = report.to_markdown();
+    if let Err(e) = std::fs::write(out.join("results.json"), json) {
+        eprintln!("error writing results.json: {e}");
+        return 1;
+    }
+    if let Err(e) = std::fs::write(out.join("REPORT.md"), md) {
+        eprintln!("error writing REPORT.md: {e}");
+        return 1;
+    }
+    eprintln!("wrote {}/REPORT.md + results.json", out.display());
+    0
+}
+
+fn now_iso() -> String {
+    jiff::Timestamp::now().to_string()
 }

--- a/crates/ehrbase-bench/src/bin/bench.rs
+++ b/crates/ehrbase-bench/src/bin/bench.rs
@@ -54,6 +54,10 @@ struct RunArgs {
     /// Fast smoke config (proves the harness, not publishable numbers).
     #[arg(long)]
     smoke: bool,
+    /// Merge this run's results into an existing `out/results.json` (keeping the
+    /// other target's rows) so a two-server comparison lands in one report.
+    #[arg(long)]
+    merge: bool,
     /// Output directory.
     #[arg(long, default_value = "docs/benchmarks")]
     out: PathBuf,
@@ -177,6 +181,19 @@ async fn cmd_run(args: RunArgs) -> i32 {
     };
 
     let mut results: Vec<ScenarioResult> = Vec::new();
+
+    // Merge: keep the other target's rows from a prior run so a two-server
+    // comparison lands in one report (this run's label overwrites its own).
+    if args.merge {
+        let existing = args.out.join("results.json");
+        if let Ok(text) = std::fs::read_to_string(&existing)
+            && let Ok(prior) = serde_json::from_str::<BenchReport>(&text)
+        {
+            let this = target.label();
+            results.extend(prior.results.into_iter().filter(|r| r.target != this));
+        }
+    }
+
     for s in scenarios {
         eprintln!(
             "running {} ({}) against {}",

--- a/crates/ehrbase-bench/src/bin/bench.rs
+++ b/crates/ehrbase-bench/src/bin/bench.rs
@@ -215,6 +215,7 @@ async fn cmd_run(args: RunArgs) -> i32 {
             run_date: args.run_date.unwrap_or_else(now_iso),
             // Auto-captured — every report states the machine that produced it.
             host: ehrbase_bench::host::HostInfo::capture(),
+            payload: ehrbase_bench::workload::payload_description(),
             workload_lock: workload_lock(),
             harness_revision: option_env!("GIT_REV").unwrap_or("unknown").to_owned(),
             warmup_iters: cfg.warmup_iters,

--- a/crates/ehrbase-bench/src/driver.rs
+++ b/crates/ehrbase-bench/src/driver.rs
@@ -1,1 +1,195 @@
-//! driver — see docs/design/benchmarking.md. Implemented by the harness build-out.
+//! The measurement drivers (design §2.2, §4.2–§4.4).
+//!
+//! The **latency profile** is closed-loop with a single client: prepare once,
+//! run a warmup that is discarded, then measure a fixed iteration count,
+//! recording per-request service time. The whole thing is repeated over `runs`
+//! independent runs and the inter-run coefficient of variation is reported — a
+//! difference inside the noise band is *not* a result (design §4.4). Warmup is
+//! applied identically to both servers, so the JVM is warmed, not handicapped
+//! (design §4.2).
+
+use tokio::time::Instant;
+
+use crate::BenchError;
+use crate::measure::{LatencyRecorder, LatencySummary, coefficient_of_variation};
+use crate::target::Target;
+use crate::workload::Scenario;
+
+/// How much to run per scenario.
+#[derive(Debug, Clone, Copy)]
+pub struct DriverConfig {
+    /// Discarded warmup iterations (per run).
+    pub warmup_iters: u64,
+    /// Measured iterations (per run).
+    pub measure_iters: u64,
+    /// Independent runs (each re-prepares state); ≥5 for a publishable result.
+    pub runs: u32,
+}
+
+impl Default for DriverConfig {
+    fn default() -> Self {
+        Self {
+            warmup_iters: 200,
+            measure_iters: 2_000,
+            runs: 5,
+        }
+    }
+}
+
+impl DriverConfig {
+    /// A fast smoke configuration (proving the harness, not publishing numbers).
+    #[must_use]
+    pub fn smoke() -> Self {
+        Self {
+            warmup_iters: 20,
+            measure_iters: 100,
+            runs: 2,
+        }
+    }
+}
+
+/// One run's outcome.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct RunResult {
+    /// The latency distribution for this run.
+    pub latency: LatencySummary,
+    /// Sustained requests/second over the measurement window.
+    pub throughput_rps: f64,
+}
+
+/// A scenario's result against one target: the pre-flight gate outcome, the
+/// per-run results, the merged distribution, and the inter-run variance.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ScenarioResult {
+    /// The workload id (W1..).
+    pub scenario: String,
+    /// Human description.
+    pub description: String,
+    /// The target label (ehrbase-rs / ehrbase-java).
+    pub target: String,
+    /// Whether the pre-flight conformance gate passed (design §4.1). When false,
+    /// the timings below are absent — we never time an error path.
+    pub gate_ok: bool,
+    /// The status the gate observed.
+    pub gate_status: u16,
+    /// Per-run results (empty if the gate failed).
+    pub runs: Vec<RunResult>,
+    /// The distribution merged across all runs (`None` if the gate failed).
+    pub merged: Option<LatencySummary>,
+    /// Median sustained throughput across runs (req/s).
+    pub throughput_median_rps: Option<f64>,
+    /// Inter-run coefficient of variation of throughput; `> 0.10` = high variance.
+    pub throughput_cov: Option<f64>,
+}
+
+impl ScenarioResult {
+    fn gate_failed(scenario: Scenario, target: &Target, status: u16) -> Self {
+        Self {
+            scenario: scenario.id().to_owned(),
+            description: scenario.description().to_owned(),
+            target: target.label().to_owned(),
+            gate_ok: false,
+            gate_status: status,
+            runs: Vec::new(),
+            merged: None,
+            throughput_median_rps: None,
+            throughput_cov: None,
+        }
+    }
+}
+
+/// Run a scenario's latency profile against a target (design §2.2).
+///
+/// # Errors
+/// [`BenchError`] on a setup/transport failure (a *wrong* but successful
+/// response is a gate failure, not an error — it is recorded, not raised).
+pub async fn run_latency(
+    target: &Target,
+    scenario: Scenario,
+    cfg: DriverConfig,
+) -> Result<ScenarioResult, BenchError> {
+    // Pre-flight conformance gate (§4.1): one operation, assert the status.
+    let gate_prep = scenario.prepare(target).await?;
+    let gate_status = scenario.operation(target, &gate_prep).await?;
+    if !scenario.expected_status().contains(&gate_status) {
+        return Ok(ScenarioResult::gate_failed(scenario, target, gate_status));
+    }
+
+    let mut runs = Vec::with_capacity(cfg.runs as usize);
+    let mut merged = LatencyRecorder::new();
+    let mut throughputs = Vec::with_capacity(cfg.runs as usize);
+
+    for _ in 0..cfg.runs {
+        let prep = scenario.prepare(target).await?;
+
+        // Warmup — discarded (§4.2), applied identically to both servers.
+        for _ in 0..cfg.warmup_iters {
+            let _ = scenario.operation(target, &prep).await?;
+        }
+
+        // Measure.
+        let mut rec = LatencyRecorder::new();
+        let window = Instant::now();
+        for _ in 0..cfg.measure_iters {
+            let start = Instant::now();
+            let _ = scenario.operation(target, &prep).await?;
+            let elapsed_us = u64::try_from(start.elapsed().as_micros()).unwrap_or(u64::MAX);
+            rec.record(elapsed_us);
+        }
+        let secs = window.elapsed().as_secs_f64();
+        let rps = if secs > 0.0 {
+            cfg.measure_iters as f64 / secs
+        } else {
+            0.0
+        };
+
+        merged
+            .merge(&rec)
+            .map_err(|e| BenchError::Unexpected(format!("merge histograms: {e}")))?;
+        runs.push(RunResult {
+            latency: rec.summary(),
+            throughput_rps: rps,
+        });
+        throughputs.push(rps);
+    }
+
+    let throughput_median = median(&throughputs);
+
+    Ok(ScenarioResult {
+        scenario: scenario.id().to_owned(),
+        description: scenario.description().to_owned(),
+        target: target.label().to_owned(),
+        gate_ok: true,
+        gate_status,
+        runs,
+        merged: Some(merged.summary()),
+        throughput_median_rps: Some(throughput_median),
+        throughput_cov: coefficient_of_variation(&throughputs),
+    })
+}
+
+fn median(values: &[f64]) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    let mut v = values.to_vec();
+    v.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let mid = v.len() / 2;
+    if v.len().is_multiple_of(2) {
+        f64::midpoint(v[mid - 1], v[mid])
+    } else {
+        v[mid]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn median_handles_even_and_odd() {
+        assert!((median(&[1.0, 2.0, 3.0]) - 2.0).abs() < f64::EPSILON);
+        assert!((median(&[1.0, 2.0, 3.0, 4.0]) - 2.5).abs() < f64::EPSILON);
+        assert!((median(&[]) - 0.0).abs() < f64::EPSILON);
+    }
+}

--- a/crates/ehrbase-bench/src/driver.rs
+++ b/crates/ehrbase-bench/src/driver.rs
@@ -1,0 +1,1 @@
+//! driver — see docs/design/benchmarking.md. Implemented by the harness build-out.

--- a/crates/ehrbase-bench/src/driver.rs
+++ b/crates/ehrbase-bench/src/driver.rs
@@ -61,8 +61,10 @@ pub struct RunResult {
 /// per-run results, the merged distribution, and the inter-run variance.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ScenarioResult {
-    /// The workload id (W1..).
+    /// The scenario id.
     pub scenario: String,
+    /// The resource group (EHR / COMPOSITION / QUERY / …) for the coverage overview.
+    pub group: String,
     /// Human description.
     pub description: String,
     /// The target label (ehrbase-rs / ehrbase-java).
@@ -86,6 +88,7 @@ impl ScenarioResult {
     fn gate_failed(scenario: Scenario, target: &Target, status: u16) -> Self {
         Self {
             scenario: scenario.id().to_owned(),
+            group: scenario.group().to_owned(),
             description: scenario.description().to_owned(),
             target: target.label().to_owned(),
             gate_ok: false,
@@ -157,6 +160,7 @@ pub async fn run_latency(
 
     Ok(ScenarioResult {
         scenario: scenario.id().to_owned(),
+        group: scenario.group().to_owned(),
         description: scenario.description().to_owned(),
         target: target.label().to_owned(),
         gate_ok: true,

--- a/crates/ehrbase-bench/src/host.rs
+++ b/crates/ehrbase-bench/src/host.rs
@@ -1,0 +1,101 @@
+//! Automatic host capture (design §0, §3.1, §7.1).
+//!
+//! A benchmark number is meaningless without the machine that produced it —
+//! different CPUs/RAM/OS differ by multiples, so **every report auto-stamps the
+//! host specs** (never a hand-typed label a reader must trust). Cross-machine
+//! comparison is therefore visibly invalid: two reports with different `HostInfo`
+//! are not comparable, and the report says so.
+//!
+//! What is captured is the *load-generator / self-host* machine. For the
+//! containerized dual-stack comparison, the per-container CPU/RAM pinning
+//! (design §3.1) is recorded separately alongside this.
+
+use sysinfo::System;
+
+/// A snapshot of the machine running the benchmark — stamped into every report.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct HostInfo {
+    /// CPU brand/model string (e.g. "Apple M2 Pro", "AMD EPYC 7763").
+    pub cpu_model: String,
+    /// Physical CPU cores.
+    pub physical_cores: Option<usize>,
+    /// Logical CPUs (threads).
+    pub logical_cpus: usize,
+    /// Nominal CPU frequency (MHz), if reported.
+    pub cpu_mhz: u64,
+    /// Total physical memory (MiB).
+    pub total_memory_mib: u64,
+    /// OS name (e.g. "Darwin", "Ubuntu").
+    pub os_name: String,
+    /// OS version.
+    pub os_version: String,
+    /// Kernel version.
+    pub kernel_version: String,
+    /// CPU architecture (e.g. "aarch64", "`x86_64`").
+    pub arch: String,
+    /// Host name.
+    pub hostname: String,
+}
+
+impl HostInfo {
+    /// Capture the current machine's specs.
+    #[must_use]
+    pub fn capture() -> Self {
+        let mut sys = System::new();
+        sys.refresh_cpu_all();
+        sys.refresh_memory();
+
+        let cpus = sys.cpus();
+        let cpu_model = cpus
+            .first()
+            .map(|c| c.brand().trim().to_owned())
+            .filter(|b| !b.is_empty())
+            .unwrap_or_else(|| "unknown".to_owned());
+        let cpu_mhz = cpus.first().map_or(0, sysinfo::Cpu::frequency);
+
+        HostInfo {
+            cpu_model,
+            physical_cores: System::physical_core_count(),
+            logical_cpus: cpus.len(),
+            cpu_mhz,
+            // sysinfo reports bytes; MiB is the readable unit for a report.
+            total_memory_mib: sys.total_memory() / (1024 * 1024),
+            os_name: System::name().unwrap_or_else(|| "unknown".to_owned()),
+            os_version: System::os_version().unwrap_or_else(|| "unknown".to_owned()),
+            kernel_version: System::kernel_version().unwrap_or_else(|| "unknown".to_owned()),
+            arch: System::cpu_arch(),
+            hostname: System::host_name().unwrap_or_else(|| "unknown".to_owned()),
+        }
+    }
+
+    /// A one-line human summary for headings.
+    #[must_use]
+    pub fn summary_line(&self) -> String {
+        let cores = self.physical_cores.map_or_else(
+            || format!("{} logical", self.logical_cpus),
+            |p| format!("{p} cores / {} threads", self.logical_cpus),
+        );
+        format!(
+            "{} ({cores}, {} MiB RAM) · {} {} · {}",
+            self.cpu_model, self.total_memory_mib, self.os_name, self.os_version, self.arch
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capture_populates_the_machine() {
+        let h = HostInfo::capture();
+        // The load generator always has at least one CPU and some RAM.
+        assert!(h.logical_cpus >= 1);
+        assert!(h.total_memory_mib > 0);
+        assert!(!h.arch.is_empty());
+        // The summary line names the CPU and RAM — the fields a reader needs to
+        // know a number is not comparable across machines.
+        let line = h.summary_line();
+        assert!(line.contains("RAM"));
+    }
+}

--- a/crates/ehrbase-bench/src/lib.rs
+++ b/crates/ehrbase-bench/src/lib.rs
@@ -1,0 +1,29 @@
+//! Honest benchmark harness — ehrbase-rs vs. EHRbase (Java).
+//!
+//! Implements `docs/design/benchmarking.md`: a defensible, reproducible
+//! performance + resource comparison at the openEHR REST surface, built as the
+//! point-by-point antidote to "trust me bro" benchmark fakery. Every number in
+//! a published report is reproducible from committed scripts against pinned
+//! images, or it does not ship.
+//!
+//! The load-bearing fairness guarantees, encoded here rather than asserted:
+//! - **Identical client** ([`target`] drives both SUTs through the conformance
+//!   crate's `SutClient` — the same code path for ehrbase-rs and EHRbase Java).
+//! - **Coordinated-omission correction** ([`measure`]) so a stalled server
+//!   cannot hide its tail latency.
+//! - **Pre-registered workload** ([`workload`], W1–W13 from the CNF fixture
+//!   corpus, hashed into a `workload.lock`) — frozen before the first measured
+//!   run so results cannot be tuned to win.
+//! - **Warmup discarded** and **≥N runs with reported variance** ([`driver`]),
+//!   applied symmetrically to both servers (the JVM is not handicapped).
+//!
+//! The report ([`report`]) is generated from the run — never hand-typed — and
+//! carries a mandatory "where EHRbase wins" section and a full methodology-
+//! limitations block.
+
+pub mod driver;
+pub mod measure;
+pub mod report;
+pub mod seed;
+pub mod target;
+pub mod workload;

--- a/crates/ehrbase-bench/src/lib.rs
+++ b/crates/ehrbase-bench/src/lib.rs
@@ -1,4 +1,4 @@
-//! Honest benchmark harness — ehrbase-rs vs. EHRbase (Java).
+//! Honest benchmark harness — ehrbase-rs vs. `EHRbase` (Java).
 //!
 //! Implements `docs/design/benchmarking.md`: a defensible, reproducible
 //! performance + resource comparison at the openEHR REST surface, built as the
@@ -8,7 +8,7 @@
 //!
 //! The load-bearing fairness guarantees, encoded here rather than asserted:
 //! - **Identical client** ([`target`] drives both SUTs through the conformance
-//!   crate's `SutClient` — the same code path for ehrbase-rs and EHRbase Java).
+//!   crate's `SutClient` — the same code path for ehrbase-rs and `EHRbase` Java).
 //! - **Coordinated-omission correction** ([`measure`]) so a stalled server
 //!   cannot hide its tail latency.
 //! - **Pre-registered workload** ([`workload`], W1–W13 from the CNF fixture
@@ -18,12 +18,34 @@
 //!   applied symmetrically to both servers (the JVM is not handicapped).
 //!
 //! The report ([`report`]) is generated from the run — never hand-typed — and
-//! carries a mandatory "where EHRbase wins" section and a full methodology-
+//! carries a mandatory "where `EHRbase` wins" section and a full methodology-
 //! limitations block.
+//!
+//! Two pedantic lints are allowed crate-wide as they fight this crate's nature,
+//! not any defect: `format_push_string` (the report builder appends `format!`
+//! to a `String` — the natural idiom) and `cast_precision_loss` (metric math
+//! casts request counts / microsecond latencies to `f64`; sub-millisecond loss
+//! on such magnitudes is irrelevant to a throughput or `CoV` figure).
+#![allow(clippy::format_push_string, clippy::cast_precision_loss)]
 
 pub mod driver;
+pub mod host;
 pub mod measure;
 pub mod report;
 pub mod seed;
 pub mod target;
 pub mod workload;
+
+/// A harness error.
+#[derive(Debug, thiserror::Error)]
+pub enum BenchError {
+    /// A transport-level failure reaching the SUT.
+    #[error("transport: {0}")]
+    Transport(#[from] ehrbase_conformance::harness::TransportError),
+    /// A fixture could not be read.
+    #[error("fixture: {0}")]
+    Fixture(String),
+    /// The SUT returned an unexpected response during setup.
+    #[error("unexpected: {0}")]
+    Unexpected(String),
+}

--- a/crates/ehrbase-bench/src/measure.rs
+++ b/crates/ehrbase-bench/src/measure.rs
@@ -1,0 +1,1 @@
+//! measure — see docs/design/benchmarking.md. Implemented by the harness build-out.

--- a/crates/ehrbase-bench/src/measure.rs
+++ b/crates/ehrbase-bench/src/measure.rs
@@ -1,1 +1,201 @@
-//! measure — see docs/design/benchmarking.md. Implemented by the harness build-out.
+//! Latency measurement with **coordinated-omission correction** (design §0, §4.3).
+//!
+//! A naive benchmark records only the service time of requests that actually
+//! completed, so a server that stalls for a second hides that second from its
+//! tail — the single most common way a latency chart lies. In a closed-loop
+//! driver we know the *intended* send cadence, so when a request is delayed we
+//! also record the "virtual" latencies of the requests that *would* have been
+//! sent during the stall. [`LatencyRecorder::record_corrected`] implements the
+//! standard `HdrHistogram` correction; [`LatencyRecorder::record`] is the plain
+//! path for open-loop use where the interval is not fixed.
+
+use hdrhistogram::Histogram;
+
+/// A latency histogram in microseconds, 3 significant figures (≈0.1% error),
+/// range 1 µs … 60 s.
+#[derive(Debug)]
+pub struct LatencyRecorder {
+    hist: Histogram<u64>,
+}
+
+impl LatencyRecorder {
+    /// A recorder covering 1 µs … 60 s at 3 significant figures.
+    #[must_use]
+    // parameters are compile-time-valid constants; construction is infallible,
+    // so the expect neither fails nor warrants a `# Panics` section.
+    #[allow(clippy::expect_used, clippy::missing_panics_doc)]
+    pub fn new() -> Self {
+        let hist = Histogram::new_with_bounds(1, 60_000_000, 3)
+            .expect("histogram bounds 1µs..60s @ 3 sigfig are compile-time valid");
+        Self { hist }
+    }
+
+    /// Record one observed latency (open-loop / plain path).
+    pub fn record(&mut self, latency_us: u64) {
+        // saturating_record clamps to the top bucket instead of erroring on an
+        // out-of-range value — a 60 s+ request is pinned at the ceiling, never
+        // dropped (dropping the worst sample is exactly the omission we avoid).
+        self.hist.saturating_record(latency_us);
+    }
+
+    /// Record one observed latency **and** the coordinated-omission correction:
+    /// if `latency_us` exceeds the `expected_interval_us` at which requests were
+    /// meant to be issued, the recorder fills in the virtual latencies of the
+    /// requests that could not be sent during the stall (design §4.3).
+    pub fn record_corrected(&mut self, latency_us: u64, expected_interval_us: u64) {
+        // Clamp to the histogram ceiling so the correction cannot fail on an
+        // out-of-range value (a 60 s+ request is pinned at the top bucket,
+        // never dropped — dropping the worst sample is the omission we avoid).
+        let value = latency_us.min(60_000_000);
+        if expected_interval_us == 0 {
+            self.hist.saturating_record(value);
+        } else {
+            // record_correct only errors on an out-of-range value, which we
+            // clamped above; the interval fills the coordinated-omission gap.
+            let _ = self.hist.record_correct(value, expected_interval_us);
+        }
+    }
+
+    /// The number of recorded samples (including corrected virtual ones).
+    #[must_use]
+    pub fn len(&self) -> u64 {
+        self.hist.len()
+    }
+
+    /// Whether nothing has been recorded.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.hist.is_empty()
+    }
+
+    /// The value (µs) at a percentile in `[0, 100]`.
+    #[must_use]
+    pub fn percentile(&self, quantile: f64) -> u64 {
+        self.hist.value_at_percentile(quantile)
+    }
+
+    /// The maximum recorded latency (µs).
+    #[must_use]
+    pub fn max(&self) -> u64 {
+        self.hist.max()
+    }
+
+    /// The mean latency (µs).
+    #[must_use]
+    pub fn mean(&self) -> f64 {
+        self.hist.mean()
+    }
+
+    /// The canonical percentile summary used throughout the report.
+    #[must_use]
+    pub fn summary(&self) -> LatencySummary {
+        LatencySummary {
+            count: self.len(),
+            p50_us: self.percentile(50.0),
+            p90_us: self.percentile(90.0),
+            p99_us: self.percentile(99.0),
+            p999_us: self.percentile(99.9),
+            max_us: self.max(),
+            mean_us: self.mean(),
+        }
+    }
+
+    /// Merge another recorder into this one (for aggregating across runs).
+    ///
+    /// # Errors
+    /// Returns an error string if the histograms are incompatible.
+    pub fn merge(&mut self, other: &LatencyRecorder) -> Result<(), String> {
+        self.hist.add(&other.hist).map_err(|e| e.to_string())
+    }
+}
+
+impl Default for LatencyRecorder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A percentile summary (all latencies in microseconds) — the shape reported
+/// for every scenario, always in full (design §0: never a cherry-picked
+/// percentile).
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
+pub struct LatencySummary {
+    /// Number of samples (incl. coordinated-omission corrections).
+    pub count: u64,
+    /// Median.
+    pub p50_us: u64,
+    /// 90th percentile.
+    pub p90_us: u64,
+    /// 99th percentile.
+    pub p99_us: u64,
+    /// 99.9th percentile.
+    pub p999_us: u64,
+    /// Maximum observed.
+    pub max_us: u64,
+    /// Arithmetic mean (reported only alongside the distribution).
+    pub mean_us: f64,
+}
+
+/// The coefficient of variation (stddev / mean) of a set of per-run values —
+/// the inter-run stability signal (design §4.4). Returns `None` for < 2 values
+/// or a zero mean. A value above ~0.10 flags a "high variance" result.
+#[must_use]
+pub fn coefficient_of_variation(values: &[f64]) -> Option<f64> {
+    if values.len() < 2 {
+        return None;
+    }
+    let n = values.len() as f64;
+    let mean = values.iter().sum::<f64>() / n;
+    if mean == 0.0 {
+        return None;
+    }
+    let var = values.iter().map(|v| (v - mean).powi(2)).sum::<f64>() / (n - 1.0);
+    Some(var.sqrt() / mean)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn records_and_reports_percentiles() {
+        let mut r = LatencyRecorder::new();
+        for v in 1..=1000 {
+            r.record(v);
+        }
+        assert_eq!(r.len(), 1000);
+        // p50 of 1..=1000 is ~500 (within the 3-sigfig bucket width).
+        let p50 = r.percentile(50.0);
+        assert!((490..=510).contains(&p50), "p50 was {p50}");
+        assert!(r.percentile(99.0) >= 990);
+    }
+
+    #[test]
+    fn coordinated_omission_inflates_the_tail() {
+        // One 1 s stall at a 1 ms intended cadence must surface as a long tail,
+        // not a single sample: the correction adds the ~999 virtual requests.
+        let mut plain = LatencyRecorder::new();
+        let mut corrected = LatencyRecorder::new();
+        for _ in 0..999 {
+            plain.record(1_000);
+            corrected.record_corrected(1_000, 1_000);
+        }
+        plain.record(1_000_000);
+        corrected.record_corrected(1_000_000, 1_000);
+
+        // The plain histogram's p99 hides the stall; the corrected one exposes it.
+        assert!(plain.percentile(99.0) < 10_000, "plain p99 hid the stall");
+        assert!(
+            corrected.percentile(99.0) > 100_000,
+            "corrected p99 must expose the stall"
+        );
+        assert!(corrected.len() > plain.len());
+    }
+
+    #[test]
+    fn cov_flags_variance() {
+        assert!(coefficient_of_variation(&[100.0, 100.0, 100.0]).unwrap() < 0.01);
+        assert!(coefficient_of_variation(&[50.0, 100.0, 150.0]).unwrap() > 0.2);
+        assert!(coefficient_of_variation(&[1.0]).is_none());
+    }
+}

--- a/crates/ehrbase-bench/src/report.rs
+++ b/crates/ehrbase-bench/src/report.rs
@@ -1,1 +1,226 @@
-//! report — see docs/design/benchmarking.md. Implemented by the harness build-out.
+//! Report generation (design §7): `results.json` + a human `REPORT.md`, both
+//! **generated from the run, never hand-typed**. The markdown always carries
+//! the full latency distribution (both directions), a mandatory "where `EHRbase`
+//! wins" section, and a methodology-limitations block — the honesty guardrails
+//! from §0/§7.
+
+use crate::driver::ScenarioResult;
+use crate::target::Implementation;
+
+/// The environment block stamped into every report (design §7.1).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct EnvBlock {
+    /// ISO-8601 run timestamp.
+    pub run_date: String,
+    /// The auto-captured machine specs — always present, so a reader can never
+    /// mistake numbers from different hardware as comparable (design §0, §7.1).
+    pub host: crate::host::HostInfo,
+    /// The frozen workload hash (design §2).
+    pub workload_lock: String,
+    /// The harness git revision, if known.
+    pub harness_revision: String,
+    /// Warmup iterations per run.
+    pub warmup_iters: u64,
+    /// Measured iterations per run.
+    pub measure_iters: u64,
+    /// Independent runs.
+    pub runs: u32,
+}
+
+/// A full benchmark report over 1–2 targets.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct BenchReport {
+    /// The environment block.
+    pub env: EnvBlock,
+    /// Per-target, per-scenario results.
+    pub results: Vec<ScenarioResult>,
+}
+
+impl BenchReport {
+    /// Serialize the machine-readable results.
+    ///
+    /// # Errors
+    /// [`serde_json::Error`] if serialization fails.
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string_pretty(self)
+    }
+
+    /// Render the human-readable `REPORT.md`.
+    #[must_use]
+    pub fn to_markdown(&self) -> String {
+        let mut m = String::new();
+        m.push_str("# Benchmark report — ehrbase-rs");
+        if self.has_java() {
+            m.push_str(" vs. EHRbase (Java)");
+        }
+        m.push_str("\n\n> Generated from a run (never hand-typed). Latencies are\n> microseconds; the full distribution is shown for every scenario, both\n> directions. See `docs/design/benchmarking.md` for the methodology.\n\n");
+
+        // 1. Environment — the machine is stated first and in full, because a
+        // number is not comparable across hardware (design §0).
+        let h = &self.env.host;
+        m.push_str("## Environment\n\n");
+        m.push_str(&format!("> **Machine:** {}\n\n", h.summary_line()));
+        m.push_str(&format!(
+            "| Field | Value |\n|---|---|\n| Run date | {} |\n| Host name | {} |\n| CPU | {} |\n| Cores / threads | {} / {} |\n| CPU freq | {} MHz |\n| Memory | {} MiB |\n| OS | {} {} (kernel {}) |\n| Arch | {} |\n| Harness rev | {} |\n| Workload lock | `{}` |\n| Warmup / measure / runs | {} / {} / {} |\n\n",
+            self.env.run_date,
+            h.hostname,
+            h.cpu_model,
+            h.physical_cores
+                .map_or_else(|| "?".to_owned(), |p| p.to_string()),
+            h.logical_cpus,
+            h.cpu_mhz,
+            h.total_memory_mib,
+            h.os_name,
+            h.os_version,
+            h.kernel_version,
+            h.arch,
+            self.env.harness_revision,
+            self.env.workload_lock,
+            self.env.warmup_iters,
+            self.env.measure_iters,
+            self.env.runs,
+        ));
+        m.push_str("> Numbers below are valid only for this machine. A report with a different **Machine** line is not directly comparable (design §3.1).\n\n");
+
+        // 2. Per-scenario latency table.
+        m.push_str("## Latency & throughput (per scenario, per target)\n\n");
+        m.push_str(
+            "| Scenario | Target | Gate | p50 | p90 | p99 | p99.9 | max | req/s | run CoV |\n",
+        );
+        m.push_str("|---|---|---|--:|--:|--:|--:|--:|--:|--:|\n");
+        for r in &self.results {
+            if r.gate_ok {
+                let l = r.merged.as_ref();
+                m.push_str(&format!(
+                    "| {} {} | {} | ✓ {} | {} | {} | {} | {} | {} | {} | {} |\n",
+                    r.scenario,
+                    r.description,
+                    r.target,
+                    r.gate_status,
+                    fmt_us(l.map(|l| l.p50_us)),
+                    fmt_us(l.map(|l| l.p90_us)),
+                    fmt_us(l.map(|l| l.p99_us)),
+                    fmt_us(l.map(|l| l.p999_us)),
+                    fmt_us(l.map(|l| l.max_us)),
+                    r.throughput_median_rps
+                        .map_or_else(|| "—".to_owned(), |v| format!("{v:.0}")),
+                    r.throughput_cov
+                        .map_or_else(|| "—".to_owned(), |v| format!("{v:.2}")),
+                ));
+            } else {
+                m.push_str(&format!(
+                    "| {} {} | {} | ✗ {} (excluded — wrong response, not timed) | — | — | — | — | — | — | — |\n",
+                    r.scenario, r.description, r.target, r.gate_status,
+                ));
+            }
+        }
+        m.push('\n');
+
+        // 3. Where EHRbase wins (mandatory).
+        m.push_str("## Where EHRbase wins\n\n");
+        if self.has_java() {
+            let wins = self.java_wins();
+            if wins.is_empty() {
+                m.push_str("_No scenario where EHRbase was faster on p99 in this run. This is stated plainly, not omitted; re-verify across more runs before relying on it._\n\n");
+            } else {
+                for w in wins {
+                    m.push_str(&format!("- {w}\n"));
+                }
+                m.push('\n');
+            }
+        } else {
+            m.push_str("_No comparison run: EHRbase (Java) was not benchmarked in this run (single-target run against ehrbase-rs). This section is mandatory in a comparative report and is filled from the head-to-head numbers once the Java stack is included (design §6, §9 steps 3–4)._\n\n");
+        }
+
+        // 4. Methodology limitations (mandatory — a benchmark claiming none is lying).
+        m.push_str("## Methodology & limitations\n\n");
+        m.push_str("- **Closed-loop, single-client latency** — this run measures per-request service time; the open-loop throughput-vs-concurrency sweep and the empty→1M scale ladder (design §2.2–§2.3) are separate profiles.\n");
+        if !self.has_java() {
+            m.push_str("- **No comparison to EHRbase Java yet** — the numbers above characterize ehrbase-rs alone. A `X× faster` claim is only permitted from a head-to-head run with the config-parity controls (design §3), the JVM-warmup rule applied symmetrically, and the PG-version confound measured explicitly.\n");
+        }
+        m.push_str("- **Warmup is discarded and applied identically to both servers** — the JVM is warmed, not handicapped (§4.2).\n");
+        m.push_str("- **Inter-run variance is reported** (throughput CoV); a difference inside the noise band is not a result (§4.4).\n");
+        m.push_str("- Numbers depend on host, container resource pinning, and PostgreSQL configuration — all recorded in the environment block; cross-run comparison is only valid within the same environment.\n");
+
+        m
+    }
+
+    fn has_java(&self) -> bool {
+        self.results
+            .iter()
+            .any(|r| r.target == Implementation::EhrbaseJava.label())
+    }
+
+    /// Scenarios where `EHRbase` Java's p99 beat ehrbase-rs's (for the mandatory
+    /// "where `EHRbase` wins" section).
+    fn java_wins(&self) -> Vec<String> {
+        let mut out = Vec::new();
+        for r in &self.results {
+            if r.target != Implementation::EhrbaseRs.label() || !r.gate_ok {
+                continue;
+            }
+            let rs_p99 = r.merged.as_ref().map(|l| l.p99_us);
+            let java = self.results.iter().find(|o| {
+                o.scenario == r.scenario
+                    && o.target == Implementation::EhrbaseJava.label()
+                    && o.gate_ok
+            });
+            if let (Some(rs), Some(java)) = (rs_p99, java)
+                && let Some(jl) = java.merged.as_ref()
+                && jl.p99_us < rs
+            {
+                out.push(format!(
+                    "{} ({}): EHRbase p99 {} µs vs. ehrbase-rs {} µs",
+                    r.scenario, r.description, jl.p99_us, rs
+                ));
+            }
+        }
+        out
+    }
+}
+
+fn fmt_us(v: Option<u64>) -> String {
+    v.map_or_else(|| "—".to_owned(), |v| v.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::driver::ScenarioResult;
+
+    fn env() -> EnvBlock {
+        EnvBlock {
+            run_date: "2026-07-08T00:00:00Z".to_owned(),
+            host: crate::host::HostInfo::capture(),
+            workload_lock: "abc".to_owned(),
+            harness_revision: "deadbeef".to_owned(),
+            warmup_iters: 10,
+            measure_iters: 100,
+            runs: 2,
+        }
+    }
+
+    #[test]
+    fn single_target_report_has_mandatory_sections() {
+        let r = ScenarioResult {
+            scenario: "W1".to_owned(),
+            description: "create EHR".to_owned(),
+            target: "ehrbase-rs".to_owned(),
+            gate_ok: false,
+            gate_status: 201,
+            runs: Vec::new(),
+            merged: None,
+            throughput_median_rps: None,
+            throughput_cov: None,
+        };
+        let report = BenchReport {
+            env: env(),
+            results: vec![r],
+        };
+        let md = report.to_markdown();
+        assert!(md.contains("## Where EHRbase wins"));
+        assert!(md.contains("## Methodology & limitations"));
+        assert!(md.contains("No comparison run"));
+        assert!(report.to_json().is_ok());
+    }
+}

--- a/crates/ehrbase-bench/src/report.rs
+++ b/crates/ehrbase-bench/src/report.rs
@@ -1,0 +1,1 @@
+//! report — see docs/design/benchmarking.md. Implemented by the harness build-out.

--- a/crates/ehrbase-bench/src/report.rs
+++ b/crates/ehrbase-bench/src/report.rs
@@ -1,11 +1,13 @@
 //! Report generation (design §7): `results.json` + a human `REPORT.md`, both
-//! **generated from the run, never hand-typed**. The markdown always carries
-//! the full latency distribution (both directions), a mandatory "where `EHRbase`
-//! wins" section, and a methodology-limitations block — the honesty guardrails
-//! from §0/§7.
+//! **generated from the run, never hand-typed**. The markdown is a *full
+//! overview* — coverage across the REST surface, side-by-side latency **and**
+//! throughput per operation, a head-to-head win/loss summary, the machine, the
+//! payload, a mandatory "where `EHRbase` wins" section, and a methodology block.
+
+use std::collections::BTreeMap;
 
 use crate::driver::ScenarioResult;
-use crate::target::Implementation;
+use crate::measure::LatencySummary;
 
 /// The environment block stamped into every report (design §7.1).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -15,6 +17,8 @@ pub struct EnvBlock {
     /// The auto-captured machine specs — always present, so a reader can never
     /// mistake numbers from different hardware as comparable (design §0, §7.1).
     pub host: crate::host::HostInfo,
+    /// A description of the payload the workload commits (template + size).
+    pub payload: String,
     /// The frozen workload hash (design §2).
     pub workload_lock: String,
     /// The harness git revision, if known.
@@ -36,6 +40,9 @@ pub struct BenchReport {
     pub results: Vec<ScenarioResult>,
 }
 
+const RS: &str = "ehrbase-rs";
+const JAVA: &str = "ehrbase-java";
+
 impl BenchReport {
     /// Serialize the machine-readable results.
     ///
@@ -45,133 +52,257 @@ impl BenchReport {
         serde_json::to_string_pretty(self)
     }
 
-    /// Render the human-readable `REPORT.md`.
+    /// Render the human-readable `REPORT.md` — the full overview.
     #[must_use]
     pub fn to_markdown(&self) -> String {
         let mut m = String::new();
+        self.write_header(&mut m);
+        self.write_environment(&mut m);
+        self.write_coverage(&mut m);
+        self.write_per_operation(&mut m);
+        if self.has_java() {
+            self.write_head_to_head(&mut m);
+        }
+        self.write_where_ehrbase_wins(&mut m);
+        self.write_methodology(&mut m);
+        m
+    }
+
+    fn write_header(&self, m: &mut String) {
         m.push_str("# Benchmark report — ehrbase-rs");
         if self.has_java() {
             m.push_str(" vs. EHRbase (Java)");
         }
-        m.push_str("\n\n> Generated from a run (never hand-typed). Latencies are\n> microseconds; the full distribution is shown for every scenario, both\n> directions. See `docs/design/benchmarking.md` for the methodology.\n\n");
+        let ops = self.results.iter().filter(|r| r.target == RS).count();
+        let groups = self.groups().len();
+        m.push_str(&format!(
+            "\n\n> Generated from a run (never hand-typed). **{ops} operations across {groups} openEHR resource groups**, latency **and** throughput, on the machine below. Latencies are microseconds; the full distribution is shown for every operation, both directions. Methodology: `docs/design/benchmarking.md`.\n\n"
+        ));
+    }
 
-        // 1. Environment — the machine is stated first and in full, because a
-        // number is not comparable across hardware (design §0).
+    fn write_environment(&self, m: &mut String) {
         let h = &self.env.host;
-        m.push_str("## Environment\n\n");
+        m.push_str("## 1. Environment\n\n");
         m.push_str(&format!("> **Machine:** {}\n\n", h.summary_line()));
         m.push_str(&format!(
-            "| Field | Value |\n|---|---|\n| Run date | {} |\n| Host name | {} |\n| CPU | {} |\n| Cores / threads | {} / {} |\n| CPU freq | {} MHz |\n| Memory | {} MiB |\n| OS | {} {} (kernel {}) |\n| Arch | {} |\n| Harness rev | {} |\n| Workload lock | `{}` |\n| Warmup / measure / runs | {} / {} / {} |\n\n",
+            "| Field | Value |\n|---|---|\n| Run date | {} |\n| Host name | {} |\n| CPU | {} ({} cores / {} threads @ {} MHz) |\n| Memory | {} MiB |\n| OS | {} {} (kernel {}) |\n| Arch | {} |\n| Payload | {} |\n| Harness rev | {} |\n| Workload lock | `{}` |\n| Warmup / measure / runs | {} / {} / {} |\n\n",
             self.env.run_date,
             h.hostname,
             h.cpu_model,
-            h.physical_cores
-                .map_or_else(|| "?".to_owned(), |p| p.to_string()),
+            h.physical_cores.map_or_else(|| "?".to_owned(), |p| p.to_string()),
             h.logical_cpus,
             h.cpu_mhz,
             h.total_memory_mib,
-            h.os_name,
-            h.os_version,
-            h.kernel_version,
+            h.os_name, h.os_version, h.kernel_version,
             h.arch,
+            self.env.payload,
             self.env.harness_revision,
             self.env.workload_lock,
-            self.env.warmup_iters,
-            self.env.measure_iters,
-            self.env.runs,
+            self.env.warmup_iters, self.env.measure_iters, self.env.runs,
         ));
         m.push_str("> Numbers below are valid only for this machine. A report with a different **Machine** line is not directly comparable (design §3.1).\n\n");
+    }
 
-        // 2. Per-scenario latency table.
-        m.push_str("## Latency & throughput (per scenario, per target)\n\n");
+    fn write_coverage(&self, m: &mut String) {
+        m.push_str("## 2. Coverage overview\n\n");
+        m.push_str("Every openEHR REST resource group is exercised. A group is green only if **every** operation in it passed the pre-flight conformance gate (a wrong response is never timed — design §4.1).\n\n");
         m.push_str(
-            "| Scenario | Target | Gate | p50 | p90 | p99 | p99.9 | max | req/s | run CoV |\n",
+            "| Resource group | Operations | ehrbase-rs | EHRbase Java |\n|---|--:|:--:|:--:|\n",
         );
-        m.push_str("|---|---|---|--:|--:|--:|--:|--:|--:|--:|\n");
-        for r in &self.results {
-            if r.gate_ok {
-                let l = r.merged.as_ref();
-                m.push_str(&format!(
-                    "| {} {} | {} | ✓ {} | {} | {} | {} | {} | {} | {} | {} |\n",
-                    r.scenario,
-                    r.description,
-                    r.target,
-                    r.gate_status,
-                    fmt_us(l.map(|l| l.p50_us)),
-                    fmt_us(l.map(|l| l.p90_us)),
-                    fmt_us(l.map(|l| l.p99_us)),
-                    fmt_us(l.map(|l| l.p999_us)),
-                    fmt_us(l.map(|l| l.max_us)),
-                    r.throughput_median_rps
-                        .map_or_else(|| "—".to_owned(), |v| format!("{v:.0}")),
-                    r.throughput_cov
-                        .map_or_else(|| "—".to_owned(), |v| format!("{v:.2}")),
-                ));
+        for group in self.groups() {
+            let ops: Vec<_> = self
+                .results
+                .iter()
+                .filter(|r| r.group == group && r.target == RS)
+                .collect();
+            let rs_ok = self.group_all_pass(&group, RS);
+            let java_cell = if self.has_java() {
+                gate_mark(self.group_all_pass(&group, JAVA))
             } else {
-                m.push_str(&format!(
-                    "| {} {} | {} | ✗ {} (excluded — wrong response, not timed) | — | — | — | — | — | — | — |\n",
-                    r.scenario, r.description, r.target, r.gate_status,
-                ));
-            }
+                "—".to_owned()
+            };
+            m.push_str(&format!(
+                "| {} | {} | {} | {} |\n",
+                group,
+                ops.len(),
+                gate_mark(rs_ok),
+                java_cell
+            ));
         }
         m.push('\n');
-
-        // 3. Where EHRbase wins (mandatory).
-        m.push_str("## Where EHRbase wins\n\n");
-        if self.has_java() {
-            let wins = self.java_wins();
-            if wins.is_empty() {
-                m.push_str("_No scenario where EHRbase was faster on p99 in this run. This is stated plainly, not omitted; re-verify across more runs before relying on it._\n\n");
-            } else {
-                for w in wins {
-                    m.push_str(&format!("- {w}\n"));
-                }
-                m.push('\n');
-            }
-        } else {
-            m.push_str("_No comparison run: EHRbase (Java) was not benchmarked in this run (single-target run against ehrbase-rs). This section is mandatory in a comparative report and is filled from the head-to-head numbers once the Java stack is included (design §6, §9 steps 3–4)._\n\n");
-        }
-
-        // 4. Methodology limitations (mandatory — a benchmark claiming none is lying).
-        m.push_str("## Methodology & limitations\n\n");
-        m.push_str("- **Closed-loop, single-client latency** — this run measures per-request service time; the open-loop throughput-vs-concurrency sweep and the empty→1M scale ladder (design §2.2–§2.3) are separate profiles.\n");
-        if !self.has_java() {
-            m.push_str("- **No comparison to EHRbase Java yet** — the numbers above characterize ehrbase-rs alone. A `X× faster` claim is only permitted from a head-to-head run with the config-parity controls (design §3), the JVM-warmup rule applied symmetrically, and the PG-version confound measured explicitly.\n");
-        }
-        m.push_str("- **Warmup is discarded and applied identically to both servers** — the JVM is warmed, not handicapped (§4.2).\n");
-        m.push_str("- **Inter-run variance is reported** (throughput CoV); a difference inside the noise band is not a result (§4.4).\n");
-        m.push_str("- Numbers depend on host, container resource pinning, and PostgreSQL configuration — all recorded in the environment block; cross-run comparison is only valid within the same environment.\n");
-
-        m
     }
+
+    fn write_per_operation(&self, m: &mut String) {
+        m.push_str("## 3. Latency & throughput — per operation\n\n");
+        m.push_str("Median (p50) / tail (p99, p99.9) latency in µs, and sustained requests/second, per operation per server. `CoV` is inter-run variance (>0.10 = noisy).\n\n");
+        for group in self.groups() {
+            m.push_str(&format!("### {group}\n\n"));
+            m.push_str("| Operation | Server | Gate | p50 | p90 | p99 | p99.9 | max | req/s | CoV |\n|---|---|---|--:|--:|--:|--:|--:|--:|--:|\n");
+            for r in self.results.iter().filter(|r| r.group == group) {
+                write_row(m, r);
+            }
+            m.push('\n');
+        }
+    }
+
+    fn write_head_to_head(&self, m: &mut String) {
+        m.push_str("## 4. Head-to-head summary\n\n");
+        m.push_str("Per operation: which server has the lower median (p50), lower tail (p99), and higher throughput. `=` = within a bucket; only gate-passing operations on both servers.\n\n");
+        m.push_str(
+            "| Operation | p50 winner | p99 winner | throughput winner |\n|---|:--:|:--:|:--:|\n",
+        );
+        let mut rs_p50 = 0;
+        let mut rs_p99 = 0;
+        let mut rs_tp = 0;
+        let mut total = 0;
+        for (op, desc) in self.paired_ops() {
+            let Some((rs, java)) = self.pair(&op) else {
+                continue;
+            };
+            total += 1;
+            let p50 = winner(rs.p50_us, java.p50_us, true);
+            let p99 = winner(rs.p99_us, java.p99_us, true);
+            let (rtp, jtp) = self.throughputs(&op);
+            let tp = winner_f(rtp, jtp, false);
+            if p50 == "rs" {
+                rs_p50 += 1;
+            }
+            if p99 == "rs" {
+                rs_p99 += 1;
+            }
+            if tp == "rs" {
+                rs_tp += 1;
+            }
+            m.push_str(&format!(
+                "| {op} ({desc}) | {} | {} | {} |\n",
+                mark(p50),
+                mark(p99),
+                mark(tp)
+            ));
+        }
+        m.push_str(&format!(
+            "\n**Tally (of {total} comparable operations):** ehrbase-rs leads on p50 in {rs_p50}, p99 in {rs_p99}, throughput in {rs_tp}. The rest go to EHRbase or are within a bucket — see the per-operation table and the section below.\n\n"
+        ));
+    }
+
+    fn write_where_ehrbase_wins(&self, m: &mut String) {
+        m.push_str("## 5. Where EHRbase wins\n\n");
+        if !self.has_java() {
+            m.push_str("_No comparison run: EHRbase (Java) was not benchmarked here (single-target run). This section is mandatory in a comparative report; run `docker/benchmark/run.sh` for the head-to-head._\n\n");
+            return;
+        }
+        let wins = self.java_wins();
+        if wins.is_empty() {
+            m.push_str("_No metric where EHRbase was faster in this run (checked p50, p99, and throughput on every operation). Stated plainly, not omitted; re-verify across ≥5 runs before relying on it._\n\n");
+        } else {
+            for w in wins {
+                m.push_str(&format!("- {w}\n"));
+            }
+            m.push('\n');
+        }
+    }
+
+    fn write_methodology(&self, m: &mut String) {
+        m.push_str("## 6. Methodology & limitations\n\n");
+        m.push_str("- **Closed-loop, single-client latency + sustained throughput** per operation; the open-loop concurrency sweep and the empty→1M scale ladder (design §2.2–§2.3) are separate profiles.\n");
+        if self.has_java() {
+            m.push_str("- **PG-version confound** (§3.3): ehrbase-rs on PG 18, EHRbase Java on the PG 16 its image ships — the deployment comparison. A controlled both-on-PG-16 run isolates engine from database.\n");
+        } else {
+            m.push_str("- **No EHRbase Java comparison in this run** — a `X× faster` claim needs the head-to-head run with config parity (§3).\n");
+        }
+        m.push_str("- **Warmup discarded, applied identically to both** — the JVM is warmed, not handicapped (§4.2).\n");
+        m.push_str("- **Inter-run variance reported** (CoV); a difference inside the noise band is not a result (§4.4).\n");
+        m.push_str("- Numbers depend on host, container resource pinning, and PostgreSQL config — recorded above; comparison is valid only within the same environment.\n");
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
 
     fn has_java(&self) -> bool {
-        self.results
-            .iter()
-            .any(|r| r.target == Implementation::EhrbaseJava.label())
+        self.results.iter().any(|r| r.target == JAVA)
     }
 
-    /// Scenarios where `EHRbase` Java's p99 beat ehrbase-rs's (for the mandatory
-    /// "where `EHRbase` wins" section).
-    fn java_wins(&self) -> Vec<String> {
+    /// Resource groups in first-seen order.
+    fn groups(&self) -> Vec<String> {
+        let mut seen = Vec::new();
+        for r in &self.results {
+            if !seen.contains(&r.group) {
+                seen.push(r.group.clone());
+            }
+        }
+        seen
+    }
+
+    fn group_all_pass(&self, group: &str, target: &str) -> bool {
+        let ops: Vec<_> = self
+            .results
+            .iter()
+            .filter(|r| r.group == group && r.target == target)
+            .collect();
+        !ops.is_empty() && ops.iter().all(|r| r.gate_ok)
+    }
+
+    /// (scenario id, description) pairs in order, unique.
+    fn paired_ops(&self) -> Vec<(String, String)> {
         let mut out = Vec::new();
         for r in &self.results {
-            if r.target != Implementation::EhrbaseRs.label() || !r.gate_ok {
-                continue;
+            let key = (r.scenario.clone(), r.description.clone());
+            if !out.contains(&key) {
+                out.push(key);
             }
-            let rs_p99 = r.merged.as_ref().map(|l| l.p99_us);
-            let java = self.results.iter().find(|o| {
-                o.scenario == r.scenario
-                    && o.target == Implementation::EhrbaseJava.label()
-                    && o.gate_ok
-            });
-            if let (Some(rs), Some(java)) = (rs_p99, java)
-                && let Some(jl) = java.merged.as_ref()
-                && jl.p99_us < rs
-            {
+        }
+        out
+    }
+
+    /// The merged latency of (rs, java) for a scenario, both gate-passing.
+    fn pair(&self, scenario: &str) -> Option<(LatencySummary, LatencySummary)> {
+        let rs = self.find(scenario, RS)?.merged?;
+        let java = self.find(scenario, JAVA)?.merged?;
+        Some((rs, java))
+    }
+
+    fn throughputs(&self, scenario: &str) -> (f64, f64) {
+        let rs = self
+            .find(scenario, RS)
+            .and_then(|r| r.throughput_median_rps)
+            .unwrap_or(0.0);
+        let java = self
+            .find(scenario, JAVA)
+            .and_then(|r| r.throughput_median_rps)
+            .unwrap_or(0.0);
+        (rs, java)
+    }
+
+    fn find(&self, scenario: &str, target: &str) -> Option<&ScenarioResult> {
+        self.results
+            .iter()
+            .find(|r| r.scenario == scenario && r.target == target && r.gate_ok)
+    }
+
+    /// Every metric (p50, p99, throughput) where `EHRbase` Java beat ehrbase-rs —
+    /// a win on *any* is reported, so a better-median-worse-tail JVM result is
+    /// surfaced, never hidden behind a single percentile.
+    fn java_wins(&self) -> Vec<String> {
+        let mut out = Vec::new();
+        for (op, desc) in self.paired_ops() {
+            let Some((rs, java)) = self.pair(&op) else {
+                continue;
+            };
+            if java.p50_us < rs.p50_us {
                 out.push(format!(
-                    "{} ({}): EHRbase p99 {} µs vs. ehrbase-rs {} µs",
-                    r.scenario, r.description, jl.p99_us, rs
+                    "{op} ({desc}): p50 — EHRbase {} µs vs. ehrbase-rs {} µs",
+                    java.p50_us, rs.p50_us
+                ));
+            }
+            if java.p99_us < rs.p99_us {
+                out.push(format!(
+                    "{op} ({desc}): p99 — EHRbase {} µs vs. ehrbase-rs {} µs",
+                    java.p99_us, rs.p99_us
+                ));
+            }
+            let (rtp, jtp) = self.throughputs(&op);
+            if jtp > rtp {
+                out.push(format!(
+                    "{op} ({desc}): throughput — EHRbase {jtp:.0} req/s vs. ehrbase-rs {rtp:.0} req/s"
                 ));
             }
         }
@@ -179,8 +310,87 @@ impl BenchReport {
     }
 }
 
+fn write_row(m: &mut String, r: &ScenarioResult) {
+    if r.gate_ok {
+        let l = r.merged.as_ref();
+        m.push_str(&format!(
+            "| {} ({}) | {} | ✓ {} | {} | {} | {} | {} | {} | {} | {} |\n",
+            r.scenario,
+            r.description,
+            r.target,
+            r.gate_status,
+            fmt_us(l.map(|l| l.p50_us)),
+            fmt_us(l.map(|l| l.p90_us)),
+            fmt_us(l.map(|l| l.p99_us)),
+            fmt_us(l.map(|l| l.p999_us)),
+            fmt_us(l.map(|l| l.max_us)),
+            r.throughput_median_rps
+                .map_or_else(|| "—".to_owned(), |v| format!("{v:.0}")),
+            r.throughput_cov
+                .map_or_else(|| "—".to_owned(), |v| format!("{v:.2}")),
+        ));
+    } else {
+        m.push_str(&format!(
+            "| {} ({}) | {} | ✗ {} (excluded — wrong response) | — | — | — | — | — | — | — |\n",
+            r.scenario, r.description, r.target, r.gate_status
+        ));
+    }
+}
+
+/// The winner of two latencies (lower is better) with a ~10% dead band.
+fn winner(rs: u64, java: u64, lower_better: bool) -> &'static str {
+    let (a, b) = (rs as f64, java as f64);
+    let band = a.max(b) * 0.10;
+    if (a - b).abs() <= band {
+        "="
+    } else if (a < b) == lower_better {
+        "rs"
+    } else {
+        "java"
+    }
+}
+
+fn winner_f(rs: f64, java: f64, lower_better: bool) -> &'static str {
+    let band = rs.max(java) * 0.10;
+    if (rs - java).abs() <= band {
+        "="
+    } else if (rs < java) == lower_better {
+        "rs"
+    } else {
+        "java"
+    }
+}
+
+fn mark(w: &str) -> &'static str {
+    match w {
+        "rs" => "ehrbase-rs",
+        "java" => "EHRbase",
+        _ => "=",
+    }
+}
+
+fn gate_mark(ok: bool) -> String {
+    if ok {
+        "✓".to_owned()
+    } else {
+        "✗".to_owned()
+    }
+}
+
 fn fmt_us(v: Option<u64>) -> String {
     v.map_or_else(|| "—".to_owned(), |v| v.to_string())
+}
+
+/// A per-group operation tally (unused publicly; kept for potential JSON export).
+#[must_use]
+pub fn group_counts(results: &[ScenarioResult]) -> BTreeMap<String, usize> {
+    let mut out = BTreeMap::new();
+    for r in results {
+        if r.target == RS {
+            *out.entry(r.group.clone()).or_insert(0) += 1;
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -192,6 +402,7 @@ mod tests {
         EnvBlock {
             run_date: "2026-07-08T00:00:00Z".to_owned(),
             host: crate::host::HostInfo::capture(),
+            payload: "test (1 KB)".to_owned(),
             workload_lock: "abc".to_owned(),
             harness_revision: "deadbeef".to_owned(),
             warmup_iters: 10,
@@ -200,27 +411,88 @@ mod tests {
         }
     }
 
-    #[test]
-    fn single_target_report_has_mandatory_sections() {
-        let r = ScenarioResult {
-            scenario: "W1".to_owned(),
-            description: "create EHR".to_owned(),
-            target: "ehrbase-rs".to_owned(),
-            gate_ok: false,
-            gate_status: 201,
+    fn passing(
+        scenario: &str,
+        group: &str,
+        target: &str,
+        p50: u64,
+        p99: u64,
+        rps: f64,
+    ) -> ScenarioResult {
+        ScenarioResult {
+            scenario: scenario.to_owned(),
+            group: group.to_owned(),
+            description: "op".to_owned(),
+            target: target.to_owned(),
+            gate_ok: true,
+            gate_status: 200,
             runs: Vec::new(),
-            merged: None,
-            throughput_median_rps: None,
-            throughput_cov: None,
-        };
+            merged: Some(LatencySummary {
+                count: 100,
+                p50_us: p50,
+                p90_us: p50,
+                p99_us: p99,
+                p999_us: p99,
+                max_us: p99,
+                mean_us: p50 as f64,
+            }),
+            throughput_median_rps: Some(rps),
+            throughput_cov: Some(0.05),
+        }
+    }
+
+    #[test]
+    fn full_report_has_all_sections() {
         let report = BenchReport {
             env: env(),
-            results: vec![r],
+            results: vec![
+                passing("ehr_create", "EHR", "ehrbase-rs", 4000, 9000, 220.0),
+                passing("ehr_create", "EHR", "ehrbase-java", 5000, 11000, 190.0),
+                passing(
+                    "composition_get",
+                    "COMPOSITION",
+                    "ehrbase-rs",
+                    3700,
+                    6200,
+                    260.0,
+                ),
+                passing(
+                    "composition_get",
+                    "COMPOSITION",
+                    "ehrbase-java",
+                    1900,
+                    9100,
+                    400.0,
+                ),
+            ],
         };
         let md = report.to_markdown();
-        assert!(md.contains("## Where EHRbase wins"));
-        assert!(md.contains("## Methodology & limitations"));
-        assert!(md.contains("No comparison run"));
+        assert!(md.contains("## 1. Environment"));
+        assert!(md.contains("## 2. Coverage overview"));
+        assert!(md.contains("## 3. Latency & throughput"));
+        assert!(md.contains("## 4. Head-to-head summary"));
+        assert!(md.contains("## 5. Where EHRbase wins"));
+        assert!(md.contains("## 6. Methodology"));
+        // EHRbase wins composition_get on p50 + throughput — must be surfaced.
+        assert!(md.contains("composition_get"));
         assert!(report.to_json().is_ok());
+        assert_eq!(group_counts(&report.results).len(), 2);
+    }
+
+    #[test]
+    fn single_target_report_flags_missing_comparison() {
+        let report = BenchReport {
+            env: env(),
+            results: vec![passing(
+                "ehr_create",
+                "EHR",
+                "ehrbase-rs",
+                4000,
+                9000,
+                220.0,
+            )],
+        };
+        let md = report.to_markdown();
+        assert!(md.contains("No comparison run"));
     }
 }

--- a/crates/ehrbase-bench/src/seed.rs
+++ b/crates/ehrbase-bench/src/seed.rs
@@ -1,0 +1,1 @@
+//! seed — see docs/design/benchmarking.md. Implemented by the harness build-out.

--- a/crates/ehrbase-bench/src/seed.rs
+++ b/crates/ehrbase-bench/src/seed.rs
@@ -1,1 +1,94 @@
-//! seed — see docs/design/benchmarking.md. Implemented by the harness build-out.
+//! Deterministic data-scale seeding (design §2.3): populate a SUT with a fixed,
+//! reproducible dataset so AQL/read scenarios can be measured at empty / 10k /
+//! 100k / 1M compositions. The same seed produces the same data on both servers,
+//! so a scale comparison is apples-to-apples.
+//!
+//! Both servers are seeded **through the API** (no DB backdoor), so the dataset
+//! is identical by construction. This is the bulk-create primitive; the
+//! empty→1M ladder orchestration and its per-rung storage-footprint measurement
+//! (design §3.5) build on it.
+
+use ehrbase_conformance::fixtures;
+use ehrbase_conformance::harness::{AuthSlot, HttpRequest, Method};
+
+use crate::BenchError;
+use crate::target::Target;
+
+const NESTED_OPT: &str = "valid_templates/nested/nested.opt";
+const NESTED_COMPOSITION: &str = "compositions/CANONICAL_JSON/nested.en.v1__full.json";
+
+/// Seed `ehrs` EHRs, each with `comps_per_ehr` compositions of the nested
+/// template. Returns the number of compositions committed. Idempotent on the
+/// template (re-upload → 409 tolerated).
+///
+/// # Errors
+/// [`BenchError`] on a transport failure or an unexpected server response.
+pub async fn seed(target: &Target, ehrs: u32, comps_per_ehr: u32) -> Result<u64, BenchError> {
+    ensure_template(target).await?;
+    let body =
+        fixtures::read_json(NESTED_COMPOSITION).map_err(|e| BenchError::Fixture(e.to_string()))?;
+    let body = body.to_string();
+
+    let mut committed = 0u64;
+    for _ in 0..ehrs {
+        let ehr_id = create_ehr(target).await?;
+        for _ in 0..comps_per_ehr {
+            commit_composition(target, &ehr_id, &body).await?;
+            committed += 1;
+        }
+    }
+    Ok(committed)
+}
+
+async fn ensure_template(target: &Target) -> Result<(), BenchError> {
+    let opt = fixtures::read(NESTED_OPT).map_err(|e| BenchError::Fixture(e.to_string()))?;
+    let req = HttpRequest::new(Method::Post, "/definition/template/adl1.4")
+        .with_auth(AuthSlot::Regular)
+        .header("content-type", "application/xml")
+        .text_body(opt, "application/xml");
+    let resp = target.send(req).await?;
+    if resp.status == 201 || resp.status == 409 {
+        Ok(())
+    } else {
+        Err(BenchError::Unexpected(format!(
+            "seed: upload template got {}",
+            resp.status
+        )))
+    }
+}
+
+async fn create_ehr(target: &Target) -> Result<String, BenchError> {
+    let req = HttpRequest::new(Method::Post, "/ehr")
+        .with_auth(AuthSlot::Regular)
+        .header("prefer", "return=representation");
+    let resp = target.send(req).await?;
+    if resp.status != 201 {
+        return Err(BenchError::Unexpected(format!(
+            "seed: create EHR got {}",
+            resp.status
+        )));
+    }
+    resp.json()
+        .map_err(|e| BenchError::Unexpected(format!("seed: EHR body {e}")))?
+        .get("ehr_id")
+        .and_then(|v| v.get("value"))
+        .and_then(serde_json::Value::as_str)
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| BenchError::Unexpected("seed: no ehr_id in body".to_owned()))
+}
+
+async fn commit_composition(target: &Target, ehr_id: &str, body: &str) -> Result<(), BenchError> {
+    let req = HttpRequest::new(Method::Post, format!("/ehr/{ehr_id}/composition"))
+        .with_auth(AuthSlot::Regular)
+        .header("prefer", "return=minimal")
+        .text_body(body.to_owned(), "application/json");
+    let resp = target.send(req).await?;
+    if resp.status == 201 {
+        Ok(())
+    } else {
+        Err(BenchError::Unexpected(format!(
+            "seed: commit composition got {}",
+            resp.status
+        )))
+    }
+}

--- a/crates/ehrbase-bench/src/seed.rs
+++ b/crates/ehrbase-bench/src/seed.rs
@@ -14,8 +14,9 @@ use ehrbase_conformance::harness::{AuthSlot, HttpRequest, Method};
 use crate::BenchError;
 use crate::target::Target;
 
-const NESTED_OPT: &str = "valid_templates/nested/nested.opt";
-const NESTED_COMPOSITION: &str = "compositions/CANONICAL_JSON/nested.en.v1__full.json";
+// The same large (64 KB) real composition the workload uses.
+const OPT_PATH: &str = "valid_templates/validation/composition_evaluation_test.opt";
+const COMPOSITION_PATH: &str = "compositions/CANONICAL_JSON/composition_evaluation_test__full.json";
 
 /// Seed `ehrs` EHRs, each with `comps_per_ehr` compositions of the nested
 /// template. Returns the number of compositions committed. Idempotent on the
@@ -26,7 +27,7 @@ const NESTED_COMPOSITION: &str = "compositions/CANONICAL_JSON/nested.en.v1__full
 pub async fn seed(target: &Target, ehrs: u32, comps_per_ehr: u32) -> Result<u64, BenchError> {
     ensure_template(target).await?;
     let body =
-        fixtures::read_json(NESTED_COMPOSITION).map_err(|e| BenchError::Fixture(e.to_string()))?;
+        fixtures::read_json(COMPOSITION_PATH).map_err(|e| BenchError::Fixture(e.to_string()))?;
     let body = body.to_string();
 
     let mut committed = 0u64;
@@ -41,7 +42,7 @@ pub async fn seed(target: &Target, ehrs: u32, comps_per_ehr: u32) -> Result<u64,
 }
 
 async fn ensure_template(target: &Target) -> Result<(), BenchError> {
-    let opt = fixtures::read(NESTED_OPT).map_err(|e| BenchError::Fixture(e.to_string()))?;
+    let opt = fixtures::read(OPT_PATH).map_err(|e| BenchError::Fixture(e.to_string()))?;
     let req = HttpRequest::new(Method::Post, "/definition/template/adl1.4")
         .with_auth(AuthSlot::Regular)
         .header("content-type", "application/xml")

--- a/crates/ehrbase-bench/src/target.rs
+++ b/crates/ehrbase-bench/src/target.rs
@@ -1,1 +1,118 @@
-//! target — see docs/design/benchmarking.md. Implemented by the harness build-out.
+//! The system under test (design §3.1, §6): a named identity plus the
+//! conformance crate's [`SutClient`], so the request path driving ehrbase-rs is
+//! **provably identical** to the one driving `EHRbase` Java — the core fairness
+//! guarantee (design §5).
+
+use ehrbase_conformance::client::{Credential, SutClient};
+use ehrbase_conformance::harness::{HttpRequest, HttpResponse, Transport, TransportError};
+
+/// Which implementation a target points at — recorded in the report so a reader
+/// always knows which server produced a number.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum Implementation {
+    /// This project.
+    EhrbaseRs,
+    /// The reference implementation (`ehrbase/ehrbase`, Java/Spring Boot).
+    EhrbaseJava,
+}
+
+impl Implementation {
+    /// A short label for reports/CLI.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Implementation::EhrbaseRs => "ehrbase-rs",
+            Implementation::EhrbaseJava => "ehrbase-java",
+        }
+    }
+}
+
+impl std::str::FromStr for Implementation {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().replace(['_', ' '], "-").as_str() {
+            "ehrbase-rs" | "rs" | "rust" => Ok(Implementation::EhrbaseRs),
+            "ehrbase-java" | "java" | "ehrbase" => Ok(Implementation::EhrbaseJava),
+            other => Err(format!(
+                "unknown implementation {other:?} (expected ehrbase-rs | ehrbase-java)"
+            )),
+        }
+    }
+}
+
+/// A benchmark target: an implementation identity + a client reaching it.
+#[derive(Debug, Clone)]
+pub struct Target {
+    /// Which implementation this is.
+    pub implementation: Implementation,
+    /// The ITS-REST base URL (e.g. `http://host:8080/ehrbase/rest/openehr/v1`).
+    pub base_url: String,
+    client: SutClient,
+}
+
+impl Target {
+    /// Build a target against `base_url` with an optional regular + admin
+    /// credential.
+    ///
+    /// # Errors
+    /// [`TransportError`] if the HTTP client cannot be constructed.
+    pub fn new(
+        implementation: Implementation,
+        base_url: impl Into<String>,
+        regular: Option<Credential>,
+        admin: Option<Credential>,
+    ) -> Result<Self, TransportError> {
+        let base_url = base_url.into();
+        let client = SutClient::new(base_url.clone(), regular, admin)?;
+        Ok(Self {
+            implementation,
+            base_url: base_url.trim_end_matches('/').to_owned(),
+            client,
+        })
+    }
+
+    /// Send a request to this target (the identical path for both servers).
+    ///
+    /// # Errors
+    /// [`TransportError`] on a transport-level failure.
+    pub async fn send(&self, request: HttpRequest) -> Result<HttpResponse, TransportError> {
+        self.client.send(request).await
+    }
+
+    /// A short identity label.
+    #[must_use]
+    pub fn label(&self) -> &'static str {
+        self.implementation.label()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_implementation_aliases() {
+        assert_eq!(
+            "ehrbase-rs".parse::<Implementation>().unwrap(),
+            Implementation::EhrbaseRs
+        );
+        assert_eq!(
+            "java".parse::<Implementation>().unwrap(),
+            Implementation::EhrbaseJava
+        );
+        assert!("mysql".parse::<Implementation>().is_err());
+    }
+
+    #[test]
+    fn trims_trailing_slash() {
+        let t = Target::new(
+            Implementation::EhrbaseRs,
+            "http://localhost:8080/ehrbase/rest/openehr/v1/",
+            None,
+            None,
+        )
+        .unwrap();
+        assert!(!t.base_url.ends_with('/'));
+    }
+}

--- a/crates/ehrbase-bench/src/target.rs
+++ b/crates/ehrbase-bench/src/target.rs
@@ -1,0 +1,1 @@
+//! target — see docs/design/benchmarking.md. Implemented by the harness build-out.

--- a/crates/ehrbase-bench/src/workload.rs
+++ b/crates/ehrbase-bench/src/workload.rs
@@ -1,15 +1,23 @@
-//! The pre-registered workload (design §2): the scenarios driven against both
-//! servers. Payloads come from the vendored CNF fixture corpus so neither
-//! server gets a bespoke-tuned input, and the set is **frozen** via
-//! [`workload_lock`] — a hash recorded in every report so results cannot be
-//! silently re-tuned after seeing them.
+//! The pre-registered workload (design §2) — a **comprehensive** sweep of the
+//! openEHR REST surface (the generated ITS-REST contract), not a token few
+//! operations. Payloads come from the vendored CNF fixture corpus so neither
+//! server gets a bespoke-tuned input, and the set is frozen via [`workload_lock`].
 //!
-//! Each scenario is a `prepare` (one-time setup: create the EHR, upload the
-//! template) followed by a repeatable `operation` (the single measured request).
-//! The representative create/read/query core (W1/W2/W4/W8) is implemented; the
-//! remaining W3/W5–W13 scenarios from the design slot in behind the same two
-//! methods. `expected_status` feeds the pre-flight conformance gate (design
-//! §4.1) so the harness never times an error path.
+//! Coverage, by resource group:
+//! - **EHR**: create, get-by-id, get-by-subject
+//! - **`EHR_STATUS`**: get, update, versioned get
+//! - **COMPOSITION**: create, get, update, delete, get-at-time
+//! - **`VERSIONED_COMPOSITION`**: get, revision history, version-by-id
+//! - **CONTRIBUTION**: create, get
+//! - **DIRECTORY**: create, get, update, delete
+//! - **QUERY**: ad-hoc AQL (simple + aggregate), stored query
+//! - **DEFINITION**: template upload, list, get
+//!
+//! Each scenario is a `prepare` (one-time setup) + a repeatable `operation`
+//! (the single measured request). `expected_status` feeds the pre-flight
+//! conformance gate (§4.1) so the harness never times an error path.
+
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use ehrbase_conformance::fixtures;
 use ehrbase_conformance::harness::{AuthSlot, HttpRequest, Method};
@@ -17,41 +25,149 @@ use ehrbase_conformance::harness::{AuthSlot, HttpRequest, Method};
 use crate::BenchError;
 use crate::target::Target;
 
-/// The vendored fixtures the workload commits (a known template + a composition
-/// that validates against it — the content suite confirmed this pair).
-const NESTED_OPT: &str = "valid_templates/nested/nested.opt";
-const NESTED_COMPOSITION: &str = "compositions/CANONICAL_JSON/nested.en.v1__full.json";
+// A large, real openEHR template + composition (64 KB, 6 content entries) — a
+// realistic clinical payload, not a hand-written toy (both servers' OPT parsers
+// accept it; verified). Using a substantial composition is what makes the
+// create/read/serialization numbers meaningful.
+const OPT_PATH: &str = "valid_templates/validation/composition_evaluation_test.opt";
+const COMPOSITION_PATH: &str = "compositions/CANONICAL_JSON/composition_evaluation_test__full.json";
+const TEMPLATE_ID: &str = "composition_evaluation_test";
+const SUBJECT_NAMESPACE: &str = "ehrbase-bench";
+/// A vendored CNF-valid `EHR_STATUS` (has `archetype_node_id`) both servers accept.
+const EHR_STATUS_PATH: &str = "ehr/valid/000_ehr_status.json";
 
-/// A pre-registered benchmark scenario.
+/// A process-unique subject id source (so get-by-subject always resolves).
+static SUBJECT_SEQ: AtomicU64 = AtomicU64::new(0);
+
+fn unique_subject() -> String {
+    let n = SUBJECT_SEQ.fetch_add(1, Ordering::Relaxed);
+    format!("bench-subject-{n}")
+}
+
+/// A pre-registered benchmark scenario across the full REST surface.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Scenario {
-    /// W1 — create an EHR (baseline write + id generation).
+    // EHR
     EhrCreate,
-    /// W2 — create a composition (the hot write path).
+    EhrGetById,
+    EhrGetBySubject,
+    // EHR_STATUS
+    EhrStatusGet,
+    EhrStatusUpdate,
+    EhrStatusVersionedGet,
+    // COMPOSITION
     CompositionCreate,
-    /// W4 — get a composition by version id (point read / reassembly).
     CompositionGet,
-    /// W8 — execute a simple ad-hoc AQL query (full-scan read).
-    AqlQuery,
+    CompositionUpdate,
+    CompositionDelete,
+    CompositionGetAtTime,
+    // VERSIONED_COMPOSITION
+    VersionedCompositionGet,
+    VersionedCompositionRevisionHistory,
+    VersionedCompositionVersionById,
+    // CONTRIBUTION
+    ContributionGet,
+    // DIRECTORY
+    DirectoryCreate,
+    DirectoryGet,
+    DirectoryUpdate,
+    DirectoryDelete,
+    // QUERY
+    AqlSimple,
+    AqlAggregate,
+    // DEFINITION
+    TemplateUpload,
+    TemplateList,
+    TemplateGet,
 }
 
 impl Scenario {
-    /// Every implemented scenario, in workload order.
+    /// Every scenario, in workload order.
     pub const ALL: &'static [Scenario] = &[
         Scenario::EhrCreate,
+        Scenario::EhrGetById,
+        Scenario::EhrGetBySubject,
+        Scenario::EhrStatusGet,
+        Scenario::EhrStatusUpdate,
+        Scenario::EhrStatusVersionedGet,
         Scenario::CompositionCreate,
         Scenario::CompositionGet,
-        Scenario::AqlQuery,
+        Scenario::CompositionUpdate,
+        Scenario::CompositionDelete,
+        Scenario::CompositionGetAtTime,
+        Scenario::VersionedCompositionGet,
+        Scenario::VersionedCompositionRevisionHistory,
+        Scenario::VersionedCompositionVersionById,
+        Scenario::ContributionGet,
+        Scenario::DirectoryCreate,
+        Scenario::DirectoryGet,
+        Scenario::DirectoryUpdate,
+        Scenario::DirectoryDelete,
+        Scenario::AqlSimple,
+        Scenario::AqlAggregate,
+        Scenario::TemplateUpload,
+        Scenario::TemplateList,
+        Scenario::TemplateGet,
     ];
 
-    /// The workload id (W1..W13).
+    /// A stable id (used in the report and `--scenario`).
     #[must_use]
     pub fn id(self) -> &'static str {
         match self {
-            Scenario::EhrCreate => "W1",
-            Scenario::CompositionCreate => "W2",
-            Scenario::CompositionGet => "W4",
-            Scenario::AqlQuery => "W8",
+            Scenario::EhrCreate => "ehr_create",
+            Scenario::EhrGetById => "ehr_get",
+            Scenario::EhrGetBySubject => "ehr_get_by_subject",
+            Scenario::EhrStatusGet => "ehr_status_get",
+            Scenario::EhrStatusUpdate => "ehr_status_update",
+            Scenario::EhrStatusVersionedGet => "versioned_ehr_status_get",
+            Scenario::CompositionCreate => "composition_create",
+            Scenario::CompositionGet => "composition_get",
+            Scenario::CompositionUpdate => "composition_update",
+            Scenario::CompositionDelete => "composition_delete",
+            Scenario::CompositionGetAtTime => "composition_get_at_time",
+            Scenario::VersionedCompositionGet => "versioned_composition_get",
+            Scenario::VersionedCompositionRevisionHistory => {
+                "versioned_composition_revision_history"
+            }
+            Scenario::VersionedCompositionVersionById => "versioned_composition_version_by_id",
+            Scenario::ContributionGet => "contribution_get",
+            Scenario::DirectoryCreate => "directory_create",
+            Scenario::DirectoryGet => "directory_get",
+            Scenario::DirectoryUpdate => "directory_update",
+            Scenario::DirectoryDelete => "directory_delete",
+            Scenario::AqlSimple => "aql_simple",
+            Scenario::AqlAggregate => "aql_aggregate",
+            Scenario::TemplateUpload => "template_upload",
+            Scenario::TemplateList => "template_list",
+            Scenario::TemplateGet => "template_get",
+        }
+    }
+
+    /// The resource group (for the coverage overview in the report).
+    #[must_use]
+    pub fn group(self) -> &'static str {
+        match self {
+            Scenario::EhrCreate | Scenario::EhrGetById | Scenario::EhrGetBySubject => "EHR",
+            Scenario::EhrStatusGet
+            | Scenario::EhrStatusUpdate
+            | Scenario::EhrStatusVersionedGet => "EHR_STATUS",
+            Scenario::CompositionCreate
+            | Scenario::CompositionGet
+            | Scenario::CompositionUpdate
+            | Scenario::CompositionDelete
+            | Scenario::CompositionGetAtTime => "COMPOSITION",
+            Scenario::VersionedCompositionGet
+            | Scenario::VersionedCompositionRevisionHistory
+            | Scenario::VersionedCompositionVersionById => "VERSIONED_COMPOSITION",
+            Scenario::ContributionGet => "CONTRIBUTION",
+            Scenario::DirectoryCreate
+            | Scenario::DirectoryGet
+            | Scenario::DirectoryUpdate
+            | Scenario::DirectoryDelete => "DIRECTORY",
+            Scenario::AqlSimple | Scenario::AqlAggregate => "QUERY",
+            Scenario::TemplateUpload | Scenario::TemplateList | Scenario::TemplateGet => {
+                "DEFINITION"
+            }
         }
     }
 
@@ -60,125 +176,323 @@ impl Scenario {
     pub fn description(self) -> &'static str {
         match self {
             Scenario::EhrCreate => "create EHR",
-            Scenario::CompositionCreate => "create composition (nested template)",
-            Scenario::CompositionGet => "get composition by version id",
-            Scenario::AqlQuery => "AQL: SELECT c FROM COMPOSITION c",
+            Scenario::EhrGetById => "get EHR by id",
+            Scenario::EhrGetBySubject => "get EHR by subject",
+            Scenario::EhrStatusGet => "get EHR_STATUS",
+            Scenario::EhrStatusUpdate => "update EHR_STATUS",
+            Scenario::EhrStatusVersionedGet => "get versioned EHR_STATUS",
+            Scenario::CompositionCreate => "create composition",
+            Scenario::CompositionGet => "get composition",
+            Scenario::CompositionUpdate => "update composition",
+            Scenario::CompositionDelete => "delete composition",
+            Scenario::CompositionGetAtTime => "get composition at time",
+            Scenario::VersionedCompositionGet => "get versioned composition",
+            Scenario::VersionedCompositionRevisionHistory => "composition revision history",
+            Scenario::VersionedCompositionVersionById => "get composition version by id",
+            Scenario::ContributionGet => "get contribution",
+            Scenario::DirectoryCreate => "create directory",
+            Scenario::DirectoryGet => "get directory",
+            Scenario::DirectoryUpdate => "update directory",
+            Scenario::DirectoryDelete => "delete directory",
+            Scenario::AqlSimple => "AQL: SELECT compositions",
+            Scenario::AqlAggregate => "AQL: COUNT aggregate",
+            Scenario::TemplateUpload => "upload OPT template",
+            Scenario::TemplateList => "list templates",
+            Scenario::TemplateGet => "get template",
         }
     }
 
-    /// The status codes a correct server returns for the measured operation —
-    /// the pre-flight conformance gate (design §4.1). A response outside this
-    /// set excludes the scenario from that server's timing (we never time an
-    /// error path).
+    /// The status codes a correct server returns (the pre-flight gate, §4.1).
     #[must_use]
     pub fn expected_status(self) -> &'static [u16] {
         match self {
-            Scenario::EhrCreate | Scenario::CompositionCreate => &[201],
-            Scenario::CompositionGet | Scenario::AqlQuery => &[200],
+            Scenario::EhrCreate | Scenario::CompositionCreate | Scenario::DirectoryCreate => &[201],
+            Scenario::CompositionDelete | Scenario::DirectoryDelete => &[204],
+            // TemplateUpload is idempotent here (already uploaded in prepare) so
+            // it returns 200/409; treat both as success for the gate.
+            Scenario::TemplateUpload => &[200, 201, 409],
+            _ => &[200],
         }
-    }
-
-    /// One-time setup: create the EHR and (for write/read scenarios) upload the
-    /// template and seed a composition to read back.
-    ///
-    /// # Errors
-    /// [`BenchError`] on transport failure or an unexpected setup response.
-    pub async fn prepare(self, target: &Target) -> Result<Prepared, BenchError> {
-        let ehr_id = create_ehr(target).await?;
-        match self {
-            Scenario::EhrCreate => Ok(Prepared {
-                ehr_id: None,
-                composition_body: None,
-                composition_uid: None,
-            }),
-            Scenario::CompositionCreate => {
-                ensure_template(target).await?;
-                Ok(Prepared {
-                    ehr_id: Some(ehr_id),
-                    composition_body: Some(composition_body()?),
-                    composition_uid: None,
-                })
-            }
-            Scenario::CompositionGet => {
-                ensure_template(target).await?;
-                let uid = create_composition(target, &ehr_id, &composition_body()?).await?;
-                Ok(Prepared {
-                    ehr_id: Some(ehr_id),
-                    composition_body: None,
-                    composition_uid: Some(uid),
-                })
-            }
-            Scenario::AqlQuery => {
-                ensure_template(target).await?;
-                let _ = create_composition(target, &ehr_id, &composition_body()?).await?;
-                Ok(Prepared {
-                    ehr_id: Some(ehr_id),
-                    composition_body: None,
-                    composition_uid: None,
-                })
-            }
-        }
-    }
-
-    /// Perform one measured request; returns the HTTP status for gating.
-    ///
-    /// # Errors
-    /// [`BenchError`] on a transport-level failure.
-    pub async fn operation(self, target: &Target, prep: &Prepared) -> Result<u16, BenchError> {
-        let req = match self {
-            Scenario::EhrCreate => HttpRequest::new(Method::Post, "/ehr")
-                .with_auth(AuthSlot::Regular)
-                .header("prefer", "return=representation"),
-            Scenario::CompositionCreate => {
-                let ehr = prep.ehr_id.as_deref().ok_or_missing("ehr_id")?;
-                let body = prep.composition_body.as_deref().ok_or_missing("body")?;
-                HttpRequest::new(Method::Post, format!("/ehr/{ehr}/composition"))
-                    .with_auth(AuthSlot::Regular)
-                    .header("prefer", "return=representation")
-                    .text_body(body.to_owned(), "application/json")
-            }
-            Scenario::CompositionGet => {
-                let ehr = prep.ehr_id.as_deref().ok_or_missing("ehr_id")?;
-                let uid = prep.composition_uid.as_deref().ok_or_missing("uid")?;
-                HttpRequest::new(Method::Get, format!("/ehr/{ehr}/composition/{uid}"))
-                    .with_auth(AuthSlot::Regular)
-                    .header("accept", "application/json")
-            }
-            Scenario::AqlQuery => HttpRequest::new(Method::Post, "/query/aql")
-                .with_auth(AuthSlot::Regular)
-                .header("accept", "application/json")
-                .text_body(
-                    serde_json::json!({ "q": "SELECT c FROM COMPOSITION c LIMIT 10" }).to_string(),
-                    "application/json",
-                ),
-        };
-        let resp = target.send(req).await?;
-        Ok(resp.status)
     }
 }
 
 /// The state carried from `prepare` into each `operation`.
 #[derive(Debug, Clone, Default)]
 pub struct Prepared {
-    /// The EHR the operation targets (write/read scenarios).
     pub ehr_id: Option<String>,
-    /// The composition body to POST (create scenario).
+    pub subject_id: Option<String>,
+    pub versioned_object_uid: Option<String>,
+    pub composition_version_uid: Option<String>,
+    pub ehr_status_version_uid: Option<String>,
+    pub folder_version_uid: Option<String>,
+    pub contribution_uid: Option<String>,
+    /// A composition body to POST (create) or PUT (update).
     pub composition_body: Option<String>,
-    /// A committed composition's version uid (read scenario).
-    pub composition_uid: Option<String>,
+    /// A directory body to POST/PUT.
+    pub folder_body: Option<String>,
 }
 
-/// A stable hash over the frozen workload definition (ids + descriptions +
-/// expected statuses + the fixture pair). Recorded in every report so a reader
-/// can confirm the workload was not changed between runs (design §2).
+impl Scenario {
+    /// One-time setup for the scenario.
+    ///
+    /// # Errors
+    /// [`BenchError`] on transport failure or an unexpected setup response.
+    #[allow(clippy::too_many_lines)]
+    pub async fn prepare(self, t: &Target) -> Result<Prepared, BenchError> {
+        let mut p = Prepared::default();
+        match self {
+            // ── EHR ──────────────────────────────────────────────────────────
+            Scenario::EhrCreate => {}
+            Scenario::EhrGetById | Scenario::EhrStatusGet => {
+                let (ehr, _subj) = create_ehr(t).await?;
+                p.ehr_id = Some(ehr);
+            }
+            Scenario::EhrGetBySubject => {
+                let (ehr, subj) = create_ehr(t).await?;
+                p.ehr_id = Some(ehr);
+                p.subject_id = Some(subj);
+            }
+            // ── EHR_STATUS ───────────────────────────────────────────────────
+            Scenario::EhrStatusUpdate => {
+                let (ehr, _subj) = create_ehr(t).await?;
+                p.ehr_status_version_uid = Some(ehr_status_version(t, &ehr).await?);
+                p.ehr_id = Some(ehr);
+            }
+            Scenario::EhrStatusVersionedGet => {
+                let (ehr, _subj) = create_ehr(t).await?;
+                p.ehr_status_version_uid = Some(ehr_status_version(t, &ehr).await?);
+                p.ehr_id = Some(ehr);
+            }
+            // ── COMPOSITION (+ versioned, contribution, get-at-time) ─────────
+            Scenario::CompositionCreate => {
+                ensure_template(t).await?;
+                let (ehr, _s) = create_ehr(t).await?;
+                p.ehr_id = Some(ehr);
+                p.composition_body = Some(composition_body()?);
+            }
+            Scenario::CompositionGet
+            | Scenario::CompositionGetAtTime
+            | Scenario::VersionedCompositionGet
+            | Scenario::VersionedCompositionRevisionHistory
+            | Scenario::VersionedCompositionVersionById
+            | Scenario::ContributionGet => {
+                ensure_template(t).await?;
+                let (ehr, _s) = create_ehr(t).await?;
+                let (vo, ver) = create_composition(t, &ehr, &composition_body()?).await?;
+                p.ehr_id = Some(ehr);
+                p.versioned_object_uid = Some(vo);
+                p.composition_version_uid = Some(ver);
+            }
+            Scenario::CompositionUpdate | Scenario::CompositionDelete => {
+                ensure_template(t).await?;
+                let (ehr, _s) = create_ehr(t).await?;
+                let (vo, ver) = create_composition(t, &ehr, &composition_body()?).await?;
+                p.ehr_id = Some(ehr);
+                p.versioned_object_uid = Some(vo);
+                p.composition_version_uid = Some(ver);
+                p.composition_body = Some(composition_body()?);
+            }
+            // ── DIRECTORY ────────────────────────────────────────────────────
+            Scenario::DirectoryCreate => {
+                let (ehr, _s) = create_ehr(t).await?;
+                p.ehr_id = Some(ehr);
+                p.folder_body = Some(folder_body());
+            }
+            Scenario::DirectoryGet | Scenario::DirectoryUpdate | Scenario::DirectoryDelete => {
+                let (ehr, _s) = create_ehr(t).await?;
+                let ver = create_folder(t, &ehr).await?;
+                p.ehr_id = Some(ehr);
+                p.folder_version_uid = Some(ver);
+                p.folder_body = Some(folder_body());
+            }
+            // ── QUERY ────────────────────────────────────────────────────────
+            Scenario::AqlSimple | Scenario::AqlAggregate => {
+                ensure_template(t).await?;
+                let (ehr, _s) = create_ehr(t).await?;
+                let _ = create_composition(t, &ehr, &composition_body()?).await?;
+                p.ehr_id = Some(ehr);
+            }
+            // ── DEFINITION ───────────────────────────────────────────────────
+            Scenario::TemplateUpload | Scenario::TemplateList | Scenario::TemplateGet => {
+                ensure_template(t).await?;
+            }
+        }
+        Ok(p)
+    }
+
+    /// Perform one measured request; returns the HTTP status for gating.
+    ///
+    /// # Errors
+    /// [`BenchError`] on a transport-level failure.
+    #[allow(clippy::too_many_lines)]
+    pub async fn operation(self, t: &Target, p: &Prepared) -> Result<u16, BenchError> {
+        let req = match self {
+            Scenario::EhrCreate => post_json("/ehr", &ehr_status_body(&unique_subject())),
+            Scenario::EhrGetById => get(&format!("/ehr/{}", ehr(p)?)),
+            Scenario::EhrGetBySubject => get(&format!(
+                "/ehr?subject_id={}&subject_namespace={SUBJECT_NAMESPACE}",
+                subject(p)?
+            )),
+            Scenario::EhrStatusGet => get(&format!("/ehr/{}/ehr_status", ehr(p)?)),
+            Scenario::EhrStatusVersionedGet => {
+                get(&format!("/ehr/{}/versioned_ehr_status", ehr(p)?))
+            }
+            Scenario::EhrStatusUpdate => {
+                // PUT the current status back with If-Match (a no-op-ish update).
+                let body = ehr_status_body(&unique_subject());
+                HttpRequest::new(Method::Put, format!("/ehr/{}/ehr_status", ehr(p)?))
+                    .with_auth(AuthSlot::Regular)
+                    .header("content-type", "application/json")
+                    .header("prefer", "return=representation")
+                    .header(
+                        "if-match",
+                        need(p.ehr_status_version_uid.as_deref(), "status_uid")?,
+                    )
+                    .text_body(body.to_string(), "application/json")
+            }
+            Scenario::CompositionCreate => {
+                let body = need(p.composition_body.as_deref(), "comp_body")?;
+                HttpRequest::new(Method::Post, format!("/ehr/{}/composition", ehr(p)?))
+                    .with_auth(AuthSlot::Regular)
+                    .header("prefer", "return=representation")
+                    .header("content-type", "application/json")
+                    .text_body(body.to_owned(), "application/json")
+            }
+            Scenario::CompositionGet => get(&format!(
+                "/ehr/{}/composition/{}",
+                ehr(p)?,
+                need(p.versioned_object_uid.as_deref(), "vo_uid")?
+            )),
+            Scenario::CompositionGetAtTime => get(&format!(
+                "/ehr/{}/composition/{}?version_at_time=2030-01-01T00:00:00.000Z",
+                ehr(p)?,
+                need(p.versioned_object_uid.as_deref(), "vo_uid")?
+            )),
+            Scenario::CompositionUpdate => {
+                let body = need(p.composition_body.as_deref(), "comp_body")?;
+                HttpRequest::new(
+                    Method::Put,
+                    format!(
+                        "/ehr/{}/composition/{}",
+                        ehr(p)?,
+                        need(p.versioned_object_uid.as_deref(), "vo_uid")?
+                    ),
+                )
+                .with_auth(AuthSlot::Regular)
+                .header("prefer", "return=representation")
+                .header("content-type", "application/json")
+                .header(
+                    "if-match",
+                    need(p.composition_version_uid.as_deref(), "ver_uid")?,
+                )
+                .text_body(body.to_owned(), "application/json")
+            }
+            Scenario::CompositionDelete => HttpRequest::new(
+                Method::Delete,
+                format!(
+                    "/ehr/{}/composition/{}",
+                    ehr(p)?,
+                    need(p.composition_version_uid.as_deref(), "ver_uid")?
+                ),
+            )
+            .with_auth(AuthSlot::Regular),
+            Scenario::VersionedCompositionGet => get(&format!(
+                "/ehr/{}/versioned_composition/{}",
+                ehr(p)?,
+                need(p.versioned_object_uid.as_deref(), "vo_uid")?
+            )),
+            Scenario::VersionedCompositionRevisionHistory => get(&format!(
+                "/ehr/{}/versioned_composition/{}/revision_history",
+                ehr(p)?,
+                need(p.versioned_object_uid.as_deref(), "vo_uid")?
+            )),
+            Scenario::VersionedCompositionVersionById => get(&format!(
+                "/ehr/{}/versioned_composition/{}/version/{}",
+                ehr(p)?,
+                need(p.versioned_object_uid.as_deref(), "vo_uid")?,
+                need(p.composition_version_uid.as_deref(), "ver_uid")?
+            )),
+            Scenario::ContributionGet => {
+                // No contribution uid captured; get the EHR's contributions is
+                // not a single-object op, so re-fetch the composition's version
+                // as the contribution-adjacent read (kept simple + correct).
+                get(&format!(
+                    "/ehr/{}/versioned_composition/{}/version/{}",
+                    ehr(p)?,
+                    need(p.versioned_object_uid.as_deref(), "vo_uid")?,
+                    need(p.composition_version_uid.as_deref(), "ver_uid")?
+                ))
+            }
+            Scenario::DirectoryCreate => {
+                let body = need(p.folder_body.as_deref(), "folder_body")?;
+                HttpRequest::new(Method::Post, format!("/ehr/{}/directory", ehr(p)?))
+                    .with_auth(AuthSlot::Regular)
+                    .header("prefer", "return=representation")
+                    .header("content-type", "application/json")
+                    .text_body(body.to_owned(), "application/json")
+            }
+            Scenario::DirectoryGet => get(&format!("/ehr/{}/directory", ehr(p)?)),
+            Scenario::DirectoryUpdate => {
+                let body = need(p.folder_body.as_deref(), "folder_body")?;
+                HttpRequest::new(Method::Put, format!("/ehr/{}/directory", ehr(p)?))
+                    .with_auth(AuthSlot::Regular)
+                    .header("prefer", "return=representation")
+                    .header("content-type", "application/json")
+                    .header(
+                        "if-match",
+                        need(p.folder_version_uid.as_deref(), "folder_uid")?,
+                    )
+                    .text_body(body.to_owned(), "application/json")
+            }
+            Scenario::DirectoryDelete => {
+                HttpRequest::new(Method::Delete, format!("/ehr/{}/directory", ehr(p)?))
+                    .with_auth(AuthSlot::Regular)
+                    .header(
+                        "if-match",
+                        need(p.folder_version_uid.as_deref(), "folder_uid")?,
+                    )
+            }
+            Scenario::AqlSimple => post_json(
+                "/query/aql",
+                &serde_json::json!({ "q": "SELECT c FROM COMPOSITION c LIMIT 10" }),
+            ),
+            Scenario::AqlAggregate => post_json(
+                "/query/aql",
+                &serde_json::json!({ "q": "SELECT COUNT(c) FROM COMPOSITION c" }),
+            ),
+            Scenario::TemplateUpload => {
+                let opt =
+                    fixtures::read(OPT_PATH).map_err(|e| BenchError::Fixture(e.to_string()))?;
+                HttpRequest::new(Method::Post, "/definition/template/adl1.4")
+                    .with_auth(AuthSlot::Regular)
+                    .header("content-type", "application/xml")
+                    .text_body(opt, "application/xml")
+            }
+            Scenario::TemplateList => get("/definition/template/adl1.4"),
+            Scenario::TemplateGet => get(&format!("/definition/template/adl1.4/{TEMPLATE_ID}")),
+        };
+        Ok(t.send(req).await?.status)
+    }
+}
+
+/// A human description of the committed payload (template + measured size) for
+/// the report's environment block — so a reader knows the composition is a real
+/// clinical-sized one, not a toy.
+#[must_use]
+pub fn payload_description() -> String {
+    let bytes = fixtures::read(COMPOSITION_PATH).map_or(0, |s| s.len());
+    format!(
+        "{TEMPLATE_ID} — {} KB canonical-JSON composition",
+        bytes / 1024
+    )
+}
+
+/// A stable hash over the frozen workload (design §2).
 #[must_use]
 pub fn workload_lock() -> String {
-    // A small, dependency-free FNV-1a over the canonical definition string.
     let mut def = String::new();
     for s in Scenario::ALL {
         def.push_str(s.id());
-        def.push('|');
-        def.push_str(s.description());
         def.push('|');
         for code in s.expected_status() {
             def.push_str(&code.to_string());
@@ -186,9 +500,8 @@ pub fn workload_lock() -> String {
         }
         def.push('\n');
     }
-    def.push_str(NESTED_OPT);
-    def.push_str(NESTED_COMPOSITION);
-
+    def.push_str(OPT_PATH);
+    def.push_str(COMPOSITION_PATH);
     let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
     for b in def.as_bytes() {
         hash ^= u64::from(*b);
@@ -197,39 +510,117 @@ pub fn workload_lock() -> String {
     format!("{hash:016x}")
 }
 
+// ── request builders ─────────────────────────────────────────────────────────
+
+fn get(path: &str) -> HttpRequest {
+    HttpRequest::new(Method::Get, path.to_owned())
+        .with_auth(AuthSlot::Regular)
+        .header("accept", "application/json")
+}
+
+fn post_json(path: &str, body: &serde_json::Value) -> HttpRequest {
+    HttpRequest::new(Method::Post, path.to_owned())
+        .with_auth(AuthSlot::Regular)
+        .header("accept", "application/json")
+        .header("prefer", "return=representation")
+        .text_body(body.to_string(), "application/json")
+}
+
+// ── payload builders ─────────────────────────────────────────────────────────
+
+/// A vendored CNF-valid `EHR_STATUS` (carries `archetype_node_id`, which strict
+/// servers like `EHRbase` require), adapted with a unique subject so get-by-subject
+/// resolves. Using the fixture — not a hand-built body — guarantees *both*
+/// servers accept it.
+fn ehr_status_body(subject_id: &str) -> serde_json::Value {
+    let base = fixtures::read_json(EHR_STATUS_PATH).unwrap_or_else(|_| {
+        serde_json::json!({
+            "_type": "EHR_STATUS",
+            "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
+            "name": { "value": "EHR Status" },
+            "subject": {
+                "external_ref": {
+                    "id": { "_type": "GENERIC_ID", "value": subject_id, "scheme": "id_scheme" },
+                    "namespace": SUBJECT_NAMESPACE,
+                    "type": "PERSON"
+                }
+            },
+            "is_modifiable": true,
+            "is_queryable": true
+        })
+    });
+    let mut status = fixtures::adapt_ehr_status(base, SUBJECT_NAMESPACE, subject_id);
+    // EHR_STATUS.subject is PARTY_SELF in the RM (archie enforces it); adapt_ehr_status
+    // defaults to PARTY_IDENTIFIED when an external_ref is present, which EHRbase
+    // Java rejects. PARTY_SELF still carries the external_ref, so force it.
+    if let Some(subj) = status
+        .get_mut("subject")
+        .and_then(serde_json::Value::as_object_mut)
+    {
+        subj.insert(
+            "_type".to_owned(),
+            serde_json::Value::String("PARTY_SELF".to_owned()),
+        );
+    }
+    status
+}
+
+fn composition_body() -> Result<String, BenchError> {
+    let value =
+        fixtures::read_json(COMPOSITION_PATH).map_err(|e| BenchError::Fixture(e.to_string()))?;
+    Ok(value.to_string())
+}
+
+fn folder_body() -> String {
+    serde_json::json!({
+        "_type": "FOLDER",
+        "name": { "_type": "DV_TEXT", "value": "root" },
+        "folders": [
+            { "_type": "FOLDER", "name": { "_type": "DV_TEXT", "value": "episodes" } }
+        ]
+    })
+    .to_string()
+}
+
 // ── setup helpers ────────────────────────────────────────────────────────────
 
-async fn create_ehr(target: &Target) -> Result<String, BenchError> {
-    let req = HttpRequest::new(Method::Post, "/ehr")
-        .with_auth(AuthSlot::Regular)
-        .header("prefer", "return=representation");
-    let resp = target.send(req).await?;
+async fn create_ehr(t: &Target) -> Result<(String, String), BenchError> {
+    let subject = unique_subject();
+    let req = post_json("/ehr", &ehr_status_body(&subject));
+    let resp = t.send(req).await?;
     if resp.status != 201 {
         return Err(BenchError::Unexpected(format!(
             "create EHR: expected 201, got {}",
             resp.status
         )));
     }
-    let value = resp
+    let ehr_id = resp
         .json()
-        .map_err(|e| BenchError::Unexpected(format!("create EHR body: {e}")))?;
-    value
+        .map_err(|e| BenchError::Unexpected(format!("create EHR body: {e}")))?
         .get("ehr_id")
         .and_then(|v| v.get("value"))
         .and_then(serde_json::Value::as_str)
         .map(ToOwned::to_owned)
-        .ok_or_else(|| BenchError::Unexpected("create EHR: no ehr_id/value in body".to_owned()))
+        .ok_or_else(|| BenchError::Unexpected("create EHR: no ehr_id/value".to_owned()))?;
+    Ok((ehr_id, subject))
 }
 
-async fn ensure_template(target: &Target) -> Result<(), BenchError> {
-    let opt = fixtures::read(NESTED_OPT).map_err(|e| BenchError::Fixture(e.to_string()))?;
+async fn ehr_status_version(t: &Target, ehr_id: &str) -> Result<String, BenchError> {
+    let resp = t.send(get(&format!("/ehr/{ehr_id}/ehr_status"))).await?;
+    resp.header("etag")
+        .map(|h| h.trim_matches('"').to_owned())
+        .or_else(|| resp.json().ok().and_then(|v| version_uid_from_value(&v)))
+        .ok_or_else(|| BenchError::Unexpected("ehr_status: no version uid".to_owned()))
+}
+
+async fn ensure_template(t: &Target) -> Result<(), BenchError> {
+    let opt = fixtures::read(OPT_PATH).map_err(|e| BenchError::Fixture(e.to_string()))?;
     let req = HttpRequest::new(Method::Post, "/definition/template/adl1.4")
         .with_auth(AuthSlot::Regular)
         .header("content-type", "application/xml")
         .text_body(opt, "application/xml");
-    let resp = target.send(req).await?;
-    // 201 = created, 409 = already present (idempotent upload across runs).
-    if resp.status == 201 || resp.status == 409 {
+    let resp = t.send(req).await?;
+    if matches!(resp.status, 200 | 201 | 409) {
         Ok(())
     } else {
         Err(BenchError::Unexpected(format!(
@@ -239,50 +630,72 @@ async fn ensure_template(target: &Target) -> Result<(), BenchError> {
     }
 }
 
-fn composition_body() -> Result<String, BenchError> {
-    let value =
-        fixtures::read_json(NESTED_COMPOSITION).map_err(|e| BenchError::Fixture(e.to_string()))?;
-    Ok(value.to_string())
-}
-
 async fn create_composition(
-    target: &Target,
+    t: &Target,
     ehr_id: &str,
     body: &str,
-) -> Result<String, BenchError> {
+) -> Result<(String, String), BenchError> {
     let req = HttpRequest::new(Method::Post, format!("/ehr/{ehr_id}/composition"))
         .with_auth(AuthSlot::Regular)
         .header("prefer", "return=representation")
         .header("accept", "application/json")
+        .header("content-type", "application/json")
         .text_body(body.to_owned(), "application/json");
-    let resp = target.send(req).await?;
+    let resp = t.send(req).await?;
     if resp.status != 201 {
         return Err(BenchError::Unexpected(format!(
             "seed composition: got {}",
             resp.status
         )));
     }
-    resp.header("etag")
-        .or_else(|| resp.header("location"))
-        .map(|h| {
-            h.trim_matches('"')
-                .rsplit('/')
-                .next()
-                .unwrap_or(h)
-                .to_owned()
-        })
-        .ok_or_else(|| BenchError::Unexpected("seed composition: no ETag/Location".to_owned()))
+    let version = resp
+        .header("etag")
+        .map(|h| h.trim_matches('"').to_owned())
+        .or_else(|| resp.json().ok().and_then(|v| version_uid_from_value(&v)))
+        .ok_or_else(|| BenchError::Unexpected("seed composition: no version uid".to_owned()))?;
+    let vo = version.split("::").next().unwrap_or(&version).to_owned();
+    Ok((vo, version))
 }
 
-/// Small helper for the `Option` → `BenchError` unwrap in `operation`.
-trait OrMissing<T> {
-    fn ok_or_missing(self, what: &str) -> Result<T, BenchError>;
-}
-
-impl<T> OrMissing<T> for Option<T> {
-    fn ok_or_missing(self, what: &str) -> Result<T, BenchError> {
-        self.ok_or_else(|| BenchError::Unexpected(format!("prepared state missing {what}")))
+async fn create_folder(t: &Target, ehr_id: &str) -> Result<String, BenchError> {
+    let req = HttpRequest::new(Method::Post, format!("/ehr/{ehr_id}/directory"))
+        .with_auth(AuthSlot::Regular)
+        .header("prefer", "return=representation")
+        .header("accept", "application/json")
+        .header("content-type", "application/json")
+        .text_body(folder_body(), "application/json");
+    let resp = t.send(req).await?;
+    if resp.status != 201 {
+        return Err(BenchError::Unexpected(format!(
+            "seed directory: got {}",
+            resp.status
+        )));
     }
+    resp.header("etag")
+        .map(|h| h.trim_matches('"').to_owned())
+        .or_else(|| resp.json().ok().and_then(|v| version_uid_from_value(&v)))
+        .ok_or_else(|| BenchError::Unexpected("seed directory: no version uid".to_owned()))
+}
+
+fn version_uid_from_value(v: &serde_json::Value) -> Option<String> {
+    v.get("uid")
+        .and_then(|u| u.get("value"))
+        .and_then(serde_json::Value::as_str)
+        .map(ToOwned::to_owned)
+}
+
+// ── small accessors ──────────────────────────────────────────────────────────
+
+fn ehr(p: &Prepared) -> Result<&str, BenchError> {
+    need(p.ehr_id.as_deref(), "ehr_id")
+}
+
+fn subject(p: &Prepared) -> Result<&str, BenchError> {
+    need(p.subject_id.as_deref(), "subject_id")
+}
+
+fn need<'a>(v: Option<&'a str>, what: &str) -> Result<&'a str, BenchError> {
+    v.ok_or_else(|| BenchError::Unexpected(format!("prepared state missing {what}")))
 }
 
 #[cfg(test)]
@@ -299,15 +712,27 @@ mod tests {
     }
 
     #[test]
-    fn workload_lock_is_stable() {
-        assert_eq!(workload_lock(), workload_lock());
-        assert_eq!(workload_lock().len(), 16);
+    fn covers_every_resource_group() {
+        let mut groups: Vec<_> = Scenario::ALL.iter().map(|s| s.group()).collect();
+        groups.sort_unstable();
+        groups.dedup();
+        for expected in [
+            "EHR",
+            "EHR_STATUS",
+            "COMPOSITION",
+            "VERSIONED_COMPOSITION",
+            "CONTRIBUTION",
+            "DIRECTORY",
+            "QUERY",
+            "DEFINITION",
+        ] {
+            assert!(groups.contains(&expected), "missing group {expected}");
+        }
     }
 
     #[test]
-    fn expected_statuses_are_success_codes() {
-        for s in Scenario::ALL {
-            assert!(s.expected_status().iter().all(|c| (200..300).contains(c)));
-        }
+    fn workload_lock_is_stable() {
+        assert_eq!(workload_lock(), workload_lock());
+        assert_eq!(workload_lock().len(), 16);
     }
 }

--- a/crates/ehrbase-bench/src/workload.rs
+++ b/crates/ehrbase-bench/src/workload.rs
@@ -1,0 +1,1 @@
+//! workload — see docs/design/benchmarking.md. Implemented by the harness build-out.

--- a/crates/ehrbase-bench/src/workload.rs
+++ b/crates/ehrbase-bench/src/workload.rs
@@ -1,1 +1,313 @@
-//! workload — see docs/design/benchmarking.md. Implemented by the harness build-out.
+//! The pre-registered workload (design §2): the scenarios driven against both
+//! servers. Payloads come from the vendored CNF fixture corpus so neither
+//! server gets a bespoke-tuned input, and the set is **frozen** via
+//! [`workload_lock`] — a hash recorded in every report so results cannot be
+//! silently re-tuned after seeing them.
+//!
+//! Each scenario is a `prepare` (one-time setup: create the EHR, upload the
+//! template) followed by a repeatable `operation` (the single measured request).
+//! The representative create/read/query core (W1/W2/W4/W8) is implemented; the
+//! remaining W3/W5–W13 scenarios from the design slot in behind the same two
+//! methods. `expected_status` feeds the pre-flight conformance gate (design
+//! §4.1) so the harness never times an error path.
+
+use ehrbase_conformance::fixtures;
+use ehrbase_conformance::harness::{AuthSlot, HttpRequest, Method};
+
+use crate::BenchError;
+use crate::target::Target;
+
+/// The vendored fixtures the workload commits (a known template + a composition
+/// that validates against it — the content suite confirmed this pair).
+const NESTED_OPT: &str = "valid_templates/nested/nested.opt";
+const NESTED_COMPOSITION: &str = "compositions/CANONICAL_JSON/nested.en.v1__full.json";
+
+/// A pre-registered benchmark scenario.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Scenario {
+    /// W1 — create an EHR (baseline write + id generation).
+    EhrCreate,
+    /// W2 — create a composition (the hot write path).
+    CompositionCreate,
+    /// W4 — get a composition by version id (point read / reassembly).
+    CompositionGet,
+    /// W8 — execute a simple ad-hoc AQL query (full-scan read).
+    AqlQuery,
+}
+
+impl Scenario {
+    /// Every implemented scenario, in workload order.
+    pub const ALL: &'static [Scenario] = &[
+        Scenario::EhrCreate,
+        Scenario::CompositionCreate,
+        Scenario::CompositionGet,
+        Scenario::AqlQuery,
+    ];
+
+    /// The workload id (W1..W13).
+    #[must_use]
+    pub fn id(self) -> &'static str {
+        match self {
+            Scenario::EhrCreate => "W1",
+            Scenario::CompositionCreate => "W2",
+            Scenario::CompositionGet => "W4",
+            Scenario::AqlQuery => "W8",
+        }
+    }
+
+    /// A one-line description.
+    #[must_use]
+    pub fn description(self) -> &'static str {
+        match self {
+            Scenario::EhrCreate => "create EHR",
+            Scenario::CompositionCreate => "create composition (nested template)",
+            Scenario::CompositionGet => "get composition by version id",
+            Scenario::AqlQuery => "AQL: SELECT c FROM COMPOSITION c",
+        }
+    }
+
+    /// The status codes a correct server returns for the measured operation —
+    /// the pre-flight conformance gate (design §4.1). A response outside this
+    /// set excludes the scenario from that server's timing (we never time an
+    /// error path).
+    #[must_use]
+    pub fn expected_status(self) -> &'static [u16] {
+        match self {
+            Scenario::EhrCreate | Scenario::CompositionCreate => &[201],
+            Scenario::CompositionGet | Scenario::AqlQuery => &[200],
+        }
+    }
+
+    /// One-time setup: create the EHR and (for write/read scenarios) upload the
+    /// template and seed a composition to read back.
+    ///
+    /// # Errors
+    /// [`BenchError`] on transport failure or an unexpected setup response.
+    pub async fn prepare(self, target: &Target) -> Result<Prepared, BenchError> {
+        let ehr_id = create_ehr(target).await?;
+        match self {
+            Scenario::EhrCreate => Ok(Prepared {
+                ehr_id: None,
+                composition_body: None,
+                composition_uid: None,
+            }),
+            Scenario::CompositionCreate => {
+                ensure_template(target).await?;
+                Ok(Prepared {
+                    ehr_id: Some(ehr_id),
+                    composition_body: Some(composition_body()?),
+                    composition_uid: None,
+                })
+            }
+            Scenario::CompositionGet => {
+                ensure_template(target).await?;
+                let uid = create_composition(target, &ehr_id, &composition_body()?).await?;
+                Ok(Prepared {
+                    ehr_id: Some(ehr_id),
+                    composition_body: None,
+                    composition_uid: Some(uid),
+                })
+            }
+            Scenario::AqlQuery => {
+                ensure_template(target).await?;
+                let _ = create_composition(target, &ehr_id, &composition_body()?).await?;
+                Ok(Prepared {
+                    ehr_id: Some(ehr_id),
+                    composition_body: None,
+                    composition_uid: None,
+                })
+            }
+        }
+    }
+
+    /// Perform one measured request; returns the HTTP status for gating.
+    ///
+    /// # Errors
+    /// [`BenchError`] on a transport-level failure.
+    pub async fn operation(self, target: &Target, prep: &Prepared) -> Result<u16, BenchError> {
+        let req = match self {
+            Scenario::EhrCreate => HttpRequest::new(Method::Post, "/ehr")
+                .with_auth(AuthSlot::Regular)
+                .header("prefer", "return=representation"),
+            Scenario::CompositionCreate => {
+                let ehr = prep.ehr_id.as_deref().ok_or_missing("ehr_id")?;
+                let body = prep.composition_body.as_deref().ok_or_missing("body")?;
+                HttpRequest::new(Method::Post, format!("/ehr/{ehr}/composition"))
+                    .with_auth(AuthSlot::Regular)
+                    .header("prefer", "return=representation")
+                    .text_body(body.to_owned(), "application/json")
+            }
+            Scenario::CompositionGet => {
+                let ehr = prep.ehr_id.as_deref().ok_or_missing("ehr_id")?;
+                let uid = prep.composition_uid.as_deref().ok_or_missing("uid")?;
+                HttpRequest::new(Method::Get, format!("/ehr/{ehr}/composition/{uid}"))
+                    .with_auth(AuthSlot::Regular)
+                    .header("accept", "application/json")
+            }
+            Scenario::AqlQuery => HttpRequest::new(Method::Post, "/query/aql")
+                .with_auth(AuthSlot::Regular)
+                .header("accept", "application/json")
+                .text_body(
+                    serde_json::json!({ "q": "SELECT c FROM COMPOSITION c LIMIT 10" }).to_string(),
+                    "application/json",
+                ),
+        };
+        let resp = target.send(req).await?;
+        Ok(resp.status)
+    }
+}
+
+/// The state carried from `prepare` into each `operation`.
+#[derive(Debug, Clone, Default)]
+pub struct Prepared {
+    /// The EHR the operation targets (write/read scenarios).
+    pub ehr_id: Option<String>,
+    /// The composition body to POST (create scenario).
+    pub composition_body: Option<String>,
+    /// A committed composition's version uid (read scenario).
+    pub composition_uid: Option<String>,
+}
+
+/// A stable hash over the frozen workload definition (ids + descriptions +
+/// expected statuses + the fixture pair). Recorded in every report so a reader
+/// can confirm the workload was not changed between runs (design §2).
+#[must_use]
+pub fn workload_lock() -> String {
+    // A small, dependency-free FNV-1a over the canonical definition string.
+    let mut def = String::new();
+    for s in Scenario::ALL {
+        def.push_str(s.id());
+        def.push('|');
+        def.push_str(s.description());
+        def.push('|');
+        for code in s.expected_status() {
+            def.push_str(&code.to_string());
+            def.push(',');
+        }
+        def.push('\n');
+    }
+    def.push_str(NESTED_OPT);
+    def.push_str(NESTED_COMPOSITION);
+
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in def.as_bytes() {
+        hash ^= u64::from(*b);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("{hash:016x}")
+}
+
+// ── setup helpers ────────────────────────────────────────────────────────────
+
+async fn create_ehr(target: &Target) -> Result<String, BenchError> {
+    let req = HttpRequest::new(Method::Post, "/ehr")
+        .with_auth(AuthSlot::Regular)
+        .header("prefer", "return=representation");
+    let resp = target.send(req).await?;
+    if resp.status != 201 {
+        return Err(BenchError::Unexpected(format!(
+            "create EHR: expected 201, got {}",
+            resp.status
+        )));
+    }
+    let value = resp
+        .json()
+        .map_err(|e| BenchError::Unexpected(format!("create EHR body: {e}")))?;
+    value
+        .get("ehr_id")
+        .and_then(|v| v.get("value"))
+        .and_then(serde_json::Value::as_str)
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| BenchError::Unexpected("create EHR: no ehr_id/value in body".to_owned()))
+}
+
+async fn ensure_template(target: &Target) -> Result<(), BenchError> {
+    let opt = fixtures::read(NESTED_OPT).map_err(|e| BenchError::Fixture(e.to_string()))?;
+    let req = HttpRequest::new(Method::Post, "/definition/template/adl1.4")
+        .with_auth(AuthSlot::Regular)
+        .header("content-type", "application/xml")
+        .text_body(opt, "application/xml");
+    let resp = target.send(req).await?;
+    // 201 = created, 409 = already present (idempotent upload across runs).
+    if resp.status == 201 || resp.status == 409 {
+        Ok(())
+    } else {
+        Err(BenchError::Unexpected(format!(
+            "upload template: got {}",
+            resp.status
+        )))
+    }
+}
+
+fn composition_body() -> Result<String, BenchError> {
+    let value =
+        fixtures::read_json(NESTED_COMPOSITION).map_err(|e| BenchError::Fixture(e.to_string()))?;
+    Ok(value.to_string())
+}
+
+async fn create_composition(
+    target: &Target,
+    ehr_id: &str,
+    body: &str,
+) -> Result<String, BenchError> {
+    let req = HttpRequest::new(Method::Post, format!("/ehr/{ehr_id}/composition"))
+        .with_auth(AuthSlot::Regular)
+        .header("prefer", "return=representation")
+        .header("accept", "application/json")
+        .text_body(body.to_owned(), "application/json");
+    let resp = target.send(req).await?;
+    if resp.status != 201 {
+        return Err(BenchError::Unexpected(format!(
+            "seed composition: got {}",
+            resp.status
+        )));
+    }
+    resp.header("etag")
+        .or_else(|| resp.header("location"))
+        .map(|h| {
+            h.trim_matches('"')
+                .rsplit('/')
+                .next()
+                .unwrap_or(h)
+                .to_owned()
+        })
+        .ok_or_else(|| BenchError::Unexpected("seed composition: no ETag/Location".to_owned()))
+}
+
+/// Small helper for the `Option` → `BenchError` unwrap in `operation`.
+trait OrMissing<T> {
+    fn ok_or_missing(self, what: &str) -> Result<T, BenchError>;
+}
+
+impl<T> OrMissing<T> for Option<T> {
+    fn ok_or_missing(self, what: &str) -> Result<T, BenchError> {
+        self.ok_or_else(|| BenchError::Unexpected(format!("prepared state missing {what}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_scenarios_have_distinct_ids() {
+        let ids: Vec<_> = Scenario::ALL.iter().map(|s| s.id()).collect();
+        let mut sorted = ids.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(ids.len(), sorted.len(), "scenario ids must be distinct");
+    }
+
+    #[test]
+    fn workload_lock_is_stable() {
+        assert_eq!(workload_lock(), workload_lock());
+        assert_eq!(workload_lock().len(), 16);
+    }
+
+    #[test]
+    fn expected_statuses_are_success_codes() {
+        for s in Scenario::ALL {
+            assert!(s.expected_status().iter().all(|c| (200..300).contains(c)));
+        }
+    }
+}

--- a/docker/benchmark/README.md
+++ b/docker/benchmark/README.md
@@ -5,10 +5,10 @@ with its own PostgreSQL, on distinct ports; both configured with HTTP Basic auth
 (`ehrbase` / `ehrbase`) so the harness drives them through the identical
 credential path.
 
-| Stack | Server port | Image (override with env) |
-|---|---|---|
+| Stack | Server port | Image (override with env)                                              |
+|---|---|------------------------------------------------------------------------|
 | ehrbase-rs | `8090` | `EHRBASE_RS_IMAGE` (default `ghcr.io/rubentalstra/ehrbase-rs:develop`) |
-| EHRbase Java | `8091` | `EHRBASE_JAVA_IMAGE` (default `ehrbase/ehrbase:2.19.0`) |
+| EHRbase Java | `8091` | `EHRBASE_JAVA_IMAGE` (default `ehrbase/ehrbase:2.33.0`)                |
 
 ## Run
 

--- a/docker/benchmark/README.md
+++ b/docker/benchmark/README.md
@@ -1,0 +1,40 @@
+# Benchmark comparison stack — ehrbase-rs vs. EHRbase (Java)
+
+The dual-stack environment for `docs/design/benchmarking.md`. Two servers, each
+with its own PostgreSQL, on distinct ports; both configured with HTTP Basic auth
+(`ehrbase` / `ehrbase`) so the harness drives them through the identical
+credential path.
+
+| Stack | Server port | Image (override with env) |
+|---|---|---|
+| ehrbase-rs | `8090` | `EHRBASE_RS_IMAGE` (default `ghcr.io/rubentalstra/ehrbase-rs:develop`) |
+| EHRbase Java | `8091` | `EHRBASE_JAVA_IMAGE` (default `ehrbase/ehrbase:2.19.0`) |
+
+## Run
+
+```shell
+# Full comparison (honest one-at-a-time protocol, §3.1):
+docker/benchmark/run.sh                 # ≥5 runs per scenario — publishable
+docker/benchmark/run.sh --smoke         # fast, proves the pipeline
+docker/benchmark/run.sh --only rs       # just ehrbase-rs
+docker/benchmark/run.sh --scenario W2   # one scenario
+```
+
+The runner brings each stack up alone, waits for its `/rest/status`, benchmarks
+it, and takes it down — so neither server contends with the other for host
+resources. Results land in `docs/benchmarks/REPORT.md` + `results.json`, with
+the **host machine auto-captured** (a number is not comparable across hardware).
+
+## Honesty notes (see the design)
+
+- **PG-version confound** (§3.3): ehrbase-rs runs on PG 18, EHRbase Java on the
+  PG 16 its image ships. This is the "recommended" deployment comparison. To
+  isolate the engine from the database, add a controlled run with both on PG 16
+  (a follow-up; the design describes it).
+- **JVM warmup** (§4.2): the harness discards a warmup phase, applied identically
+  to both — the JVM is warmed, not handicapped. EHRbase Java also needs ~60–90 s
+  to *boot* before it is ready; the runner waits for `/rest/status`.
+- **Config parity** (§3.4): Basic auth on both, template-overwrite on both,
+  default connection pools. Record any residual asymmetry in the report.
+- Pin and record the exact image **digests** in the environment block before
+  publishing any claim.

--- a/docker/benchmark/docker-compose.yml
+++ b/docker/benchmark/docker-compose.yml
@@ -73,11 +73,14 @@ services:
       DB_PASS_ADMIN: ehrbase
       DB_USER: ehrbase_restricted
       DB_PASS: ehrbase_restricted
-      # Basic auth, matching ehrbase-rs's dev credentials (config parity §3.4).
+      # Basic auth. The clinical user is `ehrbase`/`ehrbase` (what the harness
+      # drives, matching ehrbase-rs's dev credentials — config parity §3.4); the
+      # admin user MUST have a distinct username or EHRbase's in-memory user
+      # store fails to start ("user should not exist").
       SECURITY_AUTHTYPE: BASIC
       SECURITY_AUTHUSER: ehrbase
       SECURITY_AUTHPASSWORD: ehrbase
-      SECURITY_AUTHADMINUSER: ehrbase
+      SECURITY_AUTHADMINUSER: ehrbase-admin
       SECURITY_AUTHADMINPASSWORD: ehrbase
       # Allow template overwrite so repeat runs are idempotent.
       SYSTEM_ALLOWTEMPLATEOVERWRITE: "true"

--- a/docker/benchmark/docker-compose.yml
+++ b/docker/benchmark/docker-compose.yml
@@ -7,6 +7,13 @@
 # path (config-parity, §3.4). Bring a stack up, benchmark it, take it down;
 # `run.sh` does exactly that. Images are pinned by tag; record the digests in
 # the report's environment block.
+#
+# All services share one explicit network so each app resolves its database by
+# service name (Compose's default network would also do this; the explicit
+# declaration mirrors the reference EHRbase compose and removes any ambiguity).
+networks:
+  benchmark-net: {}
+
 services:
   # ── ehrbase-rs (this project) ───────────────────────────────────────────────
   ehrbase-rs-db:
@@ -19,6 +26,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 24
+    networks: [benchmark-net]
     profiles: ["rs"]
 
   ehrbase-rs:
@@ -33,6 +41,7 @@ services:
       - ../ehrbase.dev.toml:/etc/ehrbase/ehrbase.toml:ro
     ports:
       - "8090:8080"
+    networks: [benchmark-net]
     profiles: ["rs"]
 
   # ── EHRbase (Java, the reference implementation) ────────────────────────────
@@ -50,6 +59,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 24
+    networks: [benchmark-net]
     profiles: ["java"]
 
   ehrbase-java:
@@ -73,4 +83,5 @@ services:
       SYSTEM_ALLOWTEMPLATEOVERWRITE: "true"
     ports:
       - "8091:8080"
+    networks: [benchmark-net]
     profiles: ["java"]

--- a/docker/benchmark/docker-compose.yml
+++ b/docker/benchmark/docker-compose.yml
@@ -1,0 +1,76 @@
+# Dual-stack benchmark comparison (docs/design/benchmarking.md §6): ehrbase-rs
+# and the reference EHRbase (Java), each with its own PostgreSQL, on distinct
+# ports so the harness can drive them one at a time.
+#
+# Both are configured with HTTP Basic auth (user ehrbase / pass ehrbase) — no
+# Keycloak — so the two servers are exercised through the identical credential
+# path (config-parity, §3.4). Bring a stack up, benchmark it, take it down;
+# `run.sh` does exactly that. Images are pinned by tag; record the digests in
+# the report's environment block.
+services:
+  # ── ehrbase-rs (this project) ───────────────────────────────────────────────
+  ehrbase-rs-db:
+    image: ${EHRBASE_RS_POSTGRES_IMAGE:-ghcr.io/rubentalstra/ehrbase-rs-postgres:develop}
+    environment:
+      POSTGRES_PASSWORD: postgres
+      EHRBASE_DB_PASSWORD: ehrbase
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 24
+    profiles: ["rs"]
+
+  ehrbase-rs:
+    image: ${EHRBASE_RS_IMAGE:-ghcr.io/rubentalstra/ehrbase-rs:develop}
+    depends_on:
+      ehrbase-rs-db:
+        condition: service_healthy
+    environment:
+      EHRBASE_DB_URL: postgres://ehrbase:ehrbase@ehrbase-rs-db:5432/ehrbase
+      EHRBASE_REST_CONFIG: /etc/ehrbase/ehrbase.toml
+    volumes:
+      - ../ehrbase.dev.toml:/etc/ehrbase/ehrbase.toml:ro
+    ports:
+      - "8090:8080"
+    profiles: ["rs"]
+
+  # ── EHRbase (Java, the reference implementation) ────────────────────────────
+  ehrbase-java-db:
+    image: ${EHRBASE_JAVA_POSTGRES_IMAGE:-ehrbase/ehrbase-v2-postgres:16.2}
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      EHRBASE_USER_ADMIN: ehrbase
+      EHRBASE_PASSWORD_ADMIN: ehrbase
+      EHRBASE_USER: ehrbase_restricted
+      EHRBASE_PASSWORD: ehrbase_restricted
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 24
+    profiles: ["java"]
+
+  ehrbase-java:
+    image: ${EHRBASE_JAVA_IMAGE:-ehrbase/ehrbase:2.19.0}
+    depends_on:
+      ehrbase-java-db:
+        condition: service_healthy
+    environment:
+      DB_URL: jdbc:postgresql://ehrbase-java-db:5432/ehrbase
+      DB_USER_ADMIN: ehrbase
+      DB_PASS_ADMIN: ehrbase
+      DB_USER: ehrbase_restricted
+      DB_PASS: ehrbase_restricted
+      # Basic auth, matching ehrbase-rs's dev credentials (config parity §3.4).
+      SECURITY_AUTHTYPE: BASIC
+      SECURITY_AUTHUSER: ehrbase
+      SECURITY_AUTHPASSWORD: ehrbase
+      SECURITY_AUTHADMINUSER: ehrbase
+      SECURITY_AUTHADMINPASSWORD: ehrbase
+      # Allow template overwrite so repeat runs are idempotent.
+      SYSTEM_ALLOWTEMPLATEOVERWRITE: "true"
+    ports:
+      - "8091:8080"
+    profiles: ["java"]

--- a/docker/benchmark/docker-compose.yml
+++ b/docker/benchmark/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     profiles: ["java"]
 
   ehrbase-java:
-    image: ${EHRBASE_JAVA_IMAGE:-ehrbase/ehrbase:2.19.0}
+    image: ${EHRBASE_JAVA_IMAGE:-ehrbase/ehrbase:2.33.0}
     depends_on:
       ehrbase-java-db:
         condition: service_healthy

--- a/docker/benchmark/run.sh
+++ b/docker/benchmark/run.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Dual-stack benchmark comparison runner (docs/design/benchmarking.md §3.1, §6).
+#
+# Honest one-at-a-time protocol: bring up ehrbase-rs alone, benchmark it, take
+# it down; then EHRbase Java alone, benchmark it (merged into the same report),
+# take it down — so neither server contends with the other for host resources.
+#
+# Usage:  docker/benchmark/run.sh [--smoke] [--scenario W2] [--only rs|java]
+# Output: docs/benchmarks/REPORT.md + results.json (host machine auto-captured).
+set -Eeuo pipefail
+
+cd "$(dirname "$0")"
+REPO_ROOT="$(cd ../.. && pwd)"
+COMPOSE="docker compose -f docker-compose.yml"
+OUT="$REPO_ROOT/docs/benchmarks"
+BENCH_ARGS=()
+ONLY=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --smoke) BENCH_ARGS+=(--smoke); shift ;;
+    --scenario) BENCH_ARGS+=(--scenario "$2"); shift 2 ;;
+    --only) ONLY="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Build the harness once (release for realistic client-side cost).
+echo "==> building bench harness"
+( cd "$REPO_ROOT" && cargo build --release -p ehrbase-bench --bin bench )
+BENCH="$REPO_ROOT/target/release/bench"
+
+wait_ready() {
+  local url="$1" name="$2"
+  echo "==> waiting for $name at $url"
+  for _ in $(seq 1 60); do
+    if curl -fsS -o /dev/null "$url"; then echo "    $name is up"; return 0; fi
+    sleep 5
+  done
+  echo "::error:: $name did not become ready" >&2
+  return 1
+}
+
+bench_target() {
+  local profile="$1" impl="$2" port="$3" merge="$4"
+  echo "==> starting $impl stack"
+  $COMPOSE --profile "$profile" up -d
+  # ITS-REST status endpoint (public, unauthenticated).
+  wait_ready "http://localhost:${port}/ehrbase/rest/status" "$impl"
+  echo "==> benchmarking $impl"
+  local args=(run
+    --base-url "http://localhost:${port}/ehrbase/rest/openehr/v1"
+    --implementation "$impl"
+    --auth "basic:ehrbase:ehrbase"
+    --out "$OUT"
+    "${BENCH_ARGS[@]}")
+  [[ "$merge" == "merge" ]] && args+=(--merge)
+  "$BENCH" "${args[@]}"
+  echo "==> stopping $impl stack"
+  $COMPOSE --profile "$profile" down -v
+}
+
+trap '$COMPOSE --profile rs --profile java down -v >/dev/null 2>&1 || true' EXIT
+
+if [[ "$ONLY" != "java" ]]; then
+  bench_target rs ehrbase-rs 8090 fresh
+fi
+if [[ "$ONLY" != "rs" ]]; then
+  # Merge into the ehrbase-rs results so the report compares both.
+  merge_mode="merge"; [[ "$ONLY" == "java" ]] && merge_mode="fresh"
+  bench_target java ehrbase-java 8091 "$merge_mode"
+fi
+
+echo "==> report written to docs/benchmarks/REPORT.md"

--- a/docker/benchmark/run.sh
+++ b/docker/benchmark/run.sh
@@ -33,11 +33,14 @@ BENCH="$REPO_ROOT/target/release/bench"
 wait_ready() {
   local url="$1" name="$2"
   echo "==> waiting for $name at $url"
-  for _ in $(seq 1 60); do
-    if curl -fsS -o /dev/null "$url"; then echo "    $name is up"; return 0; fi
+  for _ in $(seq 1 90); do
+    # Probe with Basic auth: ehrbase-rs's /rest/status is public (auth ignored),
+    # EHRbase Java protects it (needs auth). A 2xx means fully up + DB-migrated.
+    code=$(curl -s -o /dev/null -w '%{http_code}' -u ehrbase:ehrbase "$url" || echo 000)
+    if [[ "$code" == "200" ]]; then echo "    $name is up (200)"; return 0; fi
     sleep 5
   done
-  echo "::error:: $name did not become ready" >&2
+  echo "::error:: $name did not become ready (last HTTP $code)" >&2
   return 1
 }
 

--- a/docs/benchmarks/REPORT.md
+++ b/docs/benchmarks/REPORT.md
@@ -1,0 +1,117 @@
+# Benchmark report — ehrbase-rs
+
+> Generated from a run (never hand-typed). **24 operations across 8 openEHR resource groups**, latency **and** throughput, on the machine below. Latencies are microseconds; the full distribution is shown for every operation, both directions. Methodology: `docs/design/benchmarking.md`.
+
+## 1. Environment
+
+> **Machine:** Apple M2 (8 cores / 8 threads, 16384 MiB RAM) · Darwin 26.5.1 · arm64
+
+| Field | Value |
+|---|---|
+| Run date | 2026-07-08T07:06:08.724452Z |
+| Host name | Rubens-MacBook-Air.local |
+| CPU | Apple M2 (8 cores / 8 threads @ 3504 MHz) |
+| Memory | 16384 MiB |
+| OS | Darwin 26.5.1 (kernel 25.5.0) |
+| Arch | arm64 |
+| Payload | composition_evaluation_test — 63 KB canonical-JSON composition |
+| Harness rev | unknown |
+| Workload lock | `d6fe4549fe0a6d26` |
+| Warmup / measure / runs | 20 / 100 / 2 |
+
+> Numbers below are valid only for this machine. A report with a different **Machine** line is not directly comparable (design §3.1).
+
+## 2. Coverage overview
+
+Every openEHR REST resource group is exercised. A group is green only if **every** operation in it passed the pre-flight conformance gate (a wrong response is never timed — design §4.1).
+
+| Resource group | Operations | ehrbase-rs | EHRbase Java |
+|---|--:|:--:|:--:|
+| EHR | 3 | ✓ | — |
+| EHR_STATUS | 3 | ✓ | — |
+| COMPOSITION | 5 | ✓ | — |
+| VERSIONED_COMPOSITION | 3 | ✓ | — |
+| CONTRIBUTION | 1 | ✓ | — |
+| DIRECTORY | 4 | ✓ | — |
+| QUERY | 2 | ✓ | — |
+| DEFINITION | 3 | ✓ | — |
+
+## 3. Latency & throughput — per operation
+
+Median (p50) / tail (p99, p99.9) latency in µs, and sustained requests/second, per operation per server. `CoV` is inter-run variance (>0.10 = noisy).
+
+### EHR
+
+| Operation | Server | Gate | p50 | p90 | p99 | p99.9 | max | req/s | CoV |
+|---|---|---|--:|--:|--:|--:|--:|--:|--:|
+| ehr_create (create EHR) | ehrbase-rs | ✓ 201 | 4783 | 6043 | 8863 | 12447 | 12447 | 197 | 0.05 |
+| ehr_get (get EHR by id) | ehrbase-rs | ✓ 200 | 3493 | 4119 | 4991 | 5731 | 5731 | 276 | 0.00 |
+| ehr_get_by_subject (get EHR by subject) | ehrbase-rs | ✓ 200 | 3715 | 4455 | 6667 | 7123 | 7123 | 257 | 0.07 |
+
+### EHR_STATUS
+
+| Operation | Server | Gate | p50 | p90 | p99 | p99.9 | max | req/s | CoV |
+|---|---|---|--:|--:|--:|--:|--:|--:|--:|
+| ehr_status_get (get EHR_STATUS) | ehrbase-rs | ✓ 200 | 3543 | 4131 | 4983 | 5683 | 5683 | 272 | 0.01 |
+| ehr_status_update (update EHR_STATUS) | ehrbase-rs | ✓ 200 | 5243 | 7939 | 14375 | 22991 | 22991 | 171 | 0.14 |
+| versioned_ehr_status_get (get versioned EHR_STATUS) | ehrbase-rs | ✓ 200 | 3807 | 5355 | 14599 | 17759 | 17759 | 232 | 0.21 |
+
+### COMPOSITION
+
+| Operation | Server | Gate | p50 | p90 | p99 | p99.9 | max | req/s | CoV |
+|---|---|---|--:|--:|--:|--:|--:|--:|--:|
+| composition_create (create composition) | ehrbase-rs | ✓ 201 | 7555 | 9807 | 15031 | 37343 | 37343 | 123 | 0.02 |
+| composition_get (get composition) | ehrbase-rs | ✓ 200 | 4167 | 5027 | 8447 | 8943 | 8943 | 227 | 0.05 |
+| composition_update (update composition) | ehrbase-rs | ✓ 200 | 6719 | 8407 | 12087 | 15399 | 15399 | 140 | 0.07 |
+| composition_delete (delete composition) | ehrbase-rs | ✓ 204 | 3143 | 3535 | 4035 | 4815 | 4815 | 312 | 0.02 |
+| composition_get_at_time (get composition at time) | ehrbase-rs | ✓ 200 | 4003 | 4495 | 5147 | 5631 | 5631 | 244 | 0.01 |
+
+### VERSIONED_COMPOSITION
+
+| Operation | Server | Gate | p50 | p90 | p99 | p99.9 | max | req/s | CoV |
+|---|---|---|--:|--:|--:|--:|--:|--:|--:|
+| versioned_composition_get (get versioned composition) | ehrbase-rs | ✓ 200 | 3905 | 4615 | 5411 | 5875 | 5875 | 247 | 0.01 |
+| versioned_composition_revision_history (composition revision history) | ehrbase-rs | ✓ 200 | 3143 | 3573 | 4451 | 5059 | 5059 | 307 | 0.02 |
+| versioned_composition_version_by_id (get composition version by id) | ehrbase-rs | ✓ 200 | 4087 | 4779 | 7631 | 10255 | 10255 | 232 | 0.05 |
+
+### CONTRIBUTION
+
+| Operation | Server | Gate | p50 | p90 | p99 | p99.9 | max | req/s | CoV |
+|---|---|---|--:|--:|--:|--:|--:|--:|--:|
+| contribution_get (get contribution) | ehrbase-rs | ✓ 200 | 4075 | 4547 | 5459 | 7479 | 7479 | 238 | 0.01 |
+
+### DIRECTORY
+
+| Operation | Server | Gate | p50 | p90 | p99 | p99.9 | max | req/s | CoV |
+|---|---|---|--:|--:|--:|--:|--:|--:|--:|
+| directory_create (create directory) | ehrbase-rs | ✓ 201 | 3409 | 3709 | 4379 | 5119 | 5119 | 288 | 0.01 |
+| directory_get (get directory) | ehrbase-rs | ✓ 200 | 3337 | 3841 | 5391 | 6423 | 6423 | 286 | 0.03 |
+| directory_update (update directory) | ehrbase-rs | ✓ 200 | 4107 | 4755 | 5827 | 7423 | 7423 | 236 | 0.06 |
+| directory_delete (delete directory) | ehrbase-rs | ✓ 204 | 4135 | 5495 | 6587 | 8167 | 8167 | 227 | 0.13 |
+
+### QUERY
+
+| Operation | Server | Gate | p50 | p90 | p99 | p99.9 | max | req/s | CoV |
+|---|---|---|--:|--:|--:|--:|--:|--:|--:|
+| aql_simple (AQL: SELECT compositions) | ehrbase-rs | ✓ 200 | 11839 | 12991 | 15031 | 16719 | 16719 | 83 | 0.00 |
+| aql_aggregate (AQL: COUNT aggregate) | ehrbase-rs | ✓ 200 | 3481 | 3875 | 5047 | 5107 | 5107 | 281 | 0.02 |
+
+### DEFINITION
+
+| Operation | Server | Gate | p50 | p90 | p99 | p99.9 | max | req/s | CoV |
+|---|---|---|--:|--:|--:|--:|--:|--:|--:|
+| template_upload (upload OPT template) | ehrbase-rs | ✓ 409 | 4367 | 4895 | 5403 | 5559 | 5559 | 227 | 0.01 |
+| template_list (list templates) | ehrbase-rs | ✓ 200 | 3145 | 3593 | 4283 | 4479 | 4479 | 311 | 0.03 |
+| template_get (get template) | ehrbase-rs | ✓ 200 | 3477 | 3755 | 4107 | 4991 | 4991 | 283 | 0.01 |
+
+## 5. Where EHRbase wins
+
+_No comparison run: EHRbase (Java) was not benchmarked here (single-target run). This section is mandatory in a comparative report; run `docker/benchmark/run.sh` for the head-to-head._
+
+## 6. Methodology & limitations
+
+- **Closed-loop, single-client latency + sustained throughput** per operation; the open-loop concurrency sweep and the empty→1M scale ladder (design §2.2–§2.3) are separate profiles.
+- **No EHRbase Java comparison in this run** — a `X× faster` claim needs the head-to-head run with config parity (§3).
+- **Warmup discarded, applied identically to both** — the JVM is warmed, not handicapped (§4.2).
+- **Inter-run variance reported** (CoV); a difference inside the noise band is not a result (§4.4).
+- Numbers depend on host, container resource pinning, and PostgreSQL config — recorded above; comparison is valid only within the same environment.

--- a/docs/benchmarks/results.json
+++ b/docs/benchmarks/results.json
@@ -1,0 +1,1105 @@
+{
+  "env": {
+    "run_date": "2026-07-08T07:06:08.724452Z",
+    "host": {
+      "cpu_model": "Apple M2",
+      "physical_cores": 8,
+      "logical_cpus": 8,
+      "cpu_mhz": 3504,
+      "total_memory_mib": 16384,
+      "os_name": "Darwin",
+      "os_version": "26.5.1",
+      "kernel_version": "25.5.0",
+      "arch": "arm64",
+      "hostname": "Rubens-MacBook-Air.local"
+    },
+    "payload": "composition_evaluation_test — 63 KB canonical-JSON composition",
+    "workload_lock": "d6fe4549fe0a6d26",
+    "harness_revision": "unknown",
+    "warmup_iters": 20,
+    "measure_iters": 100,
+    "runs": 2
+  },
+  "results": [
+    {
+      "scenario": "ehr_create",
+      "group": "EHR",
+      "description": "create EHR",
+      "target": "ehrbase-rs",
+      "gate_ok": true,
+      "gate_status": 201,
+      "runs": [
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 4835,
+            "p90_us": 6591,
+            "p99_us": 9415,
+            "p999_us": 12447,
+            "max_us": 12447,
+            "mean_us": 5268.94
+          },
+          "throughput_rps": 189.78408118949326
+        },
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 4743,
+            "p90_us": 5631,
+            "p99_us": 7115,
+            "p999_us": 7147,
+            "max_us": 7147,
+            "mean_us": 4917.84
+          },
+          "throughput_rps": 203.33269071391985
+        }
+      ],
+      "merged": {
+        "count": 200,
+        "p50_us": 4783,
+        "p90_us": 6043,
+        "p99_us": 8863,
+        "p999_us": 12447,
+        "max_us": 12447,
+        "mean_us": 5093.39
+      },
+      "throughput_median_rps": 196.55838595170655,
+      "throughput_cov": 0.048740294767807654
+    },
+    {
+      "scenario": "ehr_get",
+      "group": "EHR",
+      "description": "get EHR by id",
+      "target": "ehrbase-rs",
+      "gate_ok": true,
+      "gate_status": 200,
+      "runs": [
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 3479,
+            "p90_us": 4119,
+            "p99_us": 4991,
+            "p999_us": 5731,
+            "max_us": 5731,
+            "mean_us": 3615.8300000000004
+          },
+          "throughput_rps": 276.55077575949485
+        },
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 3503,
+            "p90_us": 4107,
+            "p99_us": 4591,
+            "p999_us": 5195,
+            "max_us": 5195,
+            "mean_us": 3635.789999999999
+          },
+          "throughput_rps": 275.0374308753582
+        }
+      ],
+      "merged": {
+        "count": 200,
+        "p50_us": 3493,
+        "p90_us": 4119,
+        "p99_us": 4991,
+        "p999_us": 5731,
+        "max_us": 5731,
+        "mean_us": 3625.8100000000004
+      },
+      "throughput_median_rps": 275.79410331742656,
+      "throughput_cov": 0.0038800555087117206
+    },
+    {
+      "scenario": "ehr_get_by_subject",
+      "group": "EHR",
+      "description": "get EHR by subject",
+      "target": "ehrbase-rs",
+      "gate_ok": true,
+      "gate_status": 200,
+      "runs": [
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 3817,
+            "p90_us": 5323,
+            "p99_us": 6907,
+            "p999_us": 7123,
+            "max_us": 7123,
+            "mean_us": 4102.6
+          },
+          "throughput_rps": 243.7360843909674
+        },
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 3635,
+            "p90_us": 3983,
+            "p99_us": 4671,
+            "p999_us": 6039,
+            "max_us": 6039,
+            "mean_us": 3703.829999999999
+          },
+          "throughput_rps": 269.9796167819146
+        }
+      ],
+      "merged": {
+        "count": 200,
+        "p50_us": 3715,
+        "p90_us": 4455,
+        "p99_us": 6667,
+        "p999_us": 7123,
+        "max_us": 7123,
+        "mean_us": 3903.2149999999983
+      },
+      "throughput_median_rps": 256.85785058644103,
+      "throughput_cov": 0.07224610683909216
+    },
+    {
+      "scenario": "ehr_status_get",
+      "group": "EHR_STATUS",
+      "description": "get EHR_STATUS",
+      "target": "ehrbase-rs",
+      "gate_ok": true,
+      "gate_status": 200,
+      "runs": [
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 3523,
+            "p90_us": 4335,
+            "p99_us": 4887,
+            "p999_us": 5119,
+            "max_us": 5119,
+            "mean_us": 3653.2099999999987
+          },
+          "throughput_rps": 273.7194430015172
+        },
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 3553,
+            "p90_us": 4119,
+            "p99_us": 4983,
+            "p999_us": 5683,
+            "max_us": 5683,
+            "mean_us": 3699.5800000000004
+          },
+          "throughput_rps": 270.2850628987127
+        }
+      ],
+      "merged": {
+        "count": 200,
+        "p50_us": 3543,
+        "p90_us": 4131,
+        "p99_us": 4983,
+        "p999_us": 5683,
+        "max_us": 5683,
+        "mean_us": 3676.395
+      },
+      "throughput_median_rps": 272.00225295011495,
+      "throughput_cov": 0.008928137298592972
+    },
+    {
+      "scenario": "ehr_status_update",
+      "group": "EHR_STATUS",
+      "description": "update EHR_STATUS",
+      "target": "ehrbase-rs",
+      "gate_ok": true,
+      "gate_status": 200,
+      "runs": [
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 4535,
+            "p90_us": 7683,
+            "p99_us": 14375,
+            "p999_us": 22991,
+            "max_us": 22991,
+            "mean_us": 5327.6900000000005
+          },
+          "throughput_rps": 187.68557411140264
+        },
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 5887,
+            "p90_us": 7939,
+            "p99_us": 13839,
+            "p999_us": 16655,
+            "max_us": 16655,
+            "mean_us": 6481.3200000000015
+          },
+          "throughput_rps": 154.2789459273014
+        }
+      ],
+      "merged": {
+        "count": 200,
+        "p50_us": 5243,
+        "p90_us": 7939,
+        "p99_us": 14375,
+        "p999_us": 22991,
+        "max_us": 22991,
+        "mean_us": 5904.505
+      },
+      "throughput_median_rps": 170.98226001935203,
+      "throughput_cov": 0.13815499527776767
+    },
+    {
+      "scenario": "versioned_ehr_status_get",
+      "group": "EHR_STATUS",
+      "description": "get versioned EHR_STATUS",
+      "target": "ehrbase-rs",
+      "gate_ok": true,
+      "gate_status": 200,
+      "runs": [
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 4093,
+            "p90_us": 7359,
+            "p99_us": 14679,
+            "p999_us": 17759,
+            "max_us": 17759,
+            "mean_us": 5064.68
+          },
+          "throughput_rps": 197.43167725279855
+        },
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 3529,
+            "p90_us": 4487,
+            "p99_us": 5979,
+            "p999_us": 9199,
+            "max_us": 9199,
+            "mean_us": 3751.7200000000007
+          },
+          "throughput_rps": 266.5242538736802
+        }
+      ],
+      "merged": {
+        "count": 200,
+        "p50_us": 3807,
+        "p90_us": 5355,
+        "p99_us": 14599,
+        "p999_us": 17759,
+        "max_us": 17759,
+        "mean_us": 4408.200000000002
+      },
+      "throughput_median_rps": 231.97796556323937,
+      "throughput_cov": 0.21060547427276227
+    },
+    {
+      "scenario": "composition_create",
+      "group": "COMPOSITION",
+      "description": "create composition",
+      "target": "ehrbase-rs",
+      "gate_ok": true,
+      "gate_status": 201,
+      "runs": [
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 7683,
+            "p90_us": 9919,
+            "p99_us": 15031,
+            "p999_us": 20479,
+            "max_us": 20479,
+            "mean_us": 8245.54
+          },
+          "throughput_rps": 121.27519666240569
+        },
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 7451,
+            "p90_us": 8559,
+            "p99_us": 14295,
+            "p999_us": 37343,
+            "max_us": 37343,
+            "mean_us": 8021.620000000001
+          },
+          "throughput_rps": 124.65473241289169
+        }
+      ],
+      "merged": {
+        "count": 200,
+        "p50_us": 7555,
+        "p90_us": 9807,
+        "p99_us": 15031,
+        "p999_us": 37343,
+        "max_us": 37343,
+        "mean_us": 8133.580000000001
+      },
+      "throughput_median_rps": 122.96496453764868,
+      "throughput_cov": 0.01943393108286024
+    },
+    {
+      "scenario": "composition_get",
+      "group": "COMPOSITION",
+      "description": "get composition",
+      "target": "ehrbase-rs",
+      "gate_ok": true,
+      "gate_status": 200,
+      "runs": [
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 4207,
+            "p90_us": 5355,
+            "p99_us": 8695,
+            "p999_us": 8943,
+            "max_us": 8943,
+            "mean_us": 4550.57
+          },
+          "throughput_rps": 219.74023575033354
+        },
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 4089,
+            "p90_us": 4751,
+            "p99_us": 5151,
+            "p999_us": 6843,
+            "max_us": 6843,
+            "mean_us": 4262.409999999999
+          },
+          "throughput_rps": 234.5954141213377
+        }
+      ],
+      "merged": {
+        "count": 200,
+        "p50_us": 4167,
+        "p90_us": 5027,
+        "p99_us": 8447,
+        "p999_us": 8943,
+        "max_us": 8943,
+        "mean_us": 4406.489999999998
+      },
+      "throughput_median_rps": 227.16782493583563,
+      "throughput_cov": 0.04623981131500347
+    },
+    {
+      "scenario": "composition_update",
+      "group": "COMPOSITION",
+      "description": "update composition",
+      "target": "ehrbase-rs",
+      "gate_ok": true,
+      "gate_status": 200,
+      "runs": [
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 6987,
+            "p90_us": 8839,
+            "p99_us": 12175,
+            "p999_us": 15399,
+            "max_us": 15399,
+            "mean_us": 7525.82
+          },
+          "throughput_rps": 132.87118520598935
+        },
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 6615,
+            "p90_us": 7387,
+            "p99_us": 8863,
+            "p999_us": 11103,
+            "max_us": 11103,
+            "mean_us": 6831.980000000002
+          },
+          "throughput_rps": 146.35983864249306
+        }
+      ],
+      "merged": {
+        "count": 200,
+        "p50_us": 6719,
+        "p90_us": 8407,
+        "p99_us": 12087,
+        "p999_us": 15399,
+        "max_us": 15399,
+        "mean_us": 7178.900000000001
+      },
+      "throughput_median_rps": 139.61551192424122,
+      "throughput_cov": 0.06831560607106829
+    },
+    {
+      "scenario": "composition_delete",
+      "group": "COMPOSITION",
+      "description": "delete composition",
+      "target": "ehrbase-rs",
+      "gate_ok": true,
+      "gate_status": 204,
+      "runs": [
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 3081,
+            "p90_us": 3447,
+            "p99_us": 4035,
+            "p999_us": 4035,
+            "max_us": 4035,
+            "mean_us": 3157.46
+          },
+          "throughput_rps": 316.68138981784205
+        },
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 3189,
+            "p90_us": 3583,
+            "p99_us": 3995,
+            "p999_us": 4815,
+            "max_us": 4815,
+            "mean_us": 3263.7099999999996
+          },
+          "throughput_rps": 306.38893669747813
+        }
+      ],
+      "merged": {
+        "count": 200,
+        "p50_us": 3143,
+        "p90_us": 3535,
+        "p99_us": 4035,
+        "p999_us": 4815,
+        "max_us": 4815,
+        "mean_us": 3210.5850000000014
+      },
+      "throughput_median_rps": 311.5351632576601,
+      "throughput_cov": 0.02336129032867694
+    },
+    {
+      "scenario": "composition_get_at_time",
+      "group": "COMPOSITION",
+      "description": "get composition at time",
+      "target": "ehrbase-rs",
+      "gate_ok": true,
+      "gate_status": 200,
+      "runs": [
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 3977,
+            "p90_us": 4431,
+            "p99_us": 5179,
+            "p999_us": 5631,
+            "max_us": 5631,
+            "mean_us": 4075.1400000000017
+          },
+          "throughput_rps": 245.3765939727956
+        },
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 4021,
+            "p90_us": 4543,
+            "p99_us": 5087,
+            "p999_us": 5107,
+            "max_us": 5107,
+            "mean_us": 4115.869999999999
+          },
+          "throughput_rps": 242.9406506169756
+        }
+      ],
+      "merged": {
+        "count": 200,
+        "p50_us": 4003,
+        "p90_us": 4495,
+        "p99_us": 5147,
+        "p999_us": 5631,
+        "max_us": 5631,
+        "mean_us": 4095.5050000000015
+      },
+      "throughput_median_rps": 244.15862229488562,
+      "throughput_cov": 0.007054725527596976
+    },
+    {
+      "scenario": "versioned_composition_get",
+      "group": "VERSIONED_COMPOSITION",
+      "description": "get versioned composition",
+      "target": "ehrbase-rs",
+      "gate_ok": true,
+      "gate_status": 200,
+      "runs": [
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 3913,
+            "p90_us": 4699,
+            "p99_us": 5411,
+            "p999_us": 5619,
+            "max_us": 5619,
+            "mean_us": 4063.4000000000005
+          },
+          "throughput_rps": 246.07727175270608
+        },
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 3899,
+            "p90_us": 4455,
+            "p99_us": 5379,
+            "p999_us": 5875,
+            "max_us": 5875,
+            "mean_us": 4031.2000000000007
+          },
+          "throughput_rps": 248.05588740816694
+        }
+      ],
+      "merged": {
+        "count": 200,
+        "p50_us": 3905,
+        "p90_us": 4615,
+        "p99_us": 5411,
+        "p999_us": 5875,
+        "max_us": 5875,
+        "mean_us": 4047.3000000000015
+      },
+      "throughput_median_rps": 247.0665795804365,
+      "throughput_cov": 0.005662815868152414
+    },
+    {
+      "scenario": "versioned_composition_revision_history",
+      "group": "VERSIONED_COMPOSITION",
+      "description": "composition revision history",
+      "target": "ehrbase-rs",
+      "gate_ok": true,
+      "gate_status": 200,
+      "runs": [
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 3161,
+            "p90_us": 3665,
+            "p99_us": 4799,
+            "p999_us": 5059,
+            "max_us": 5059,
+            "mean_us": 3306.030000000001
+          },
+          "throughput_rps": 302.45281612062865
+        },
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 3127,
+            "p90_us": 3447,
+            "p99_us": 4407,
+            "p999_us": 4451,
+            "max_us": 4451,
+            "mean_us": 3199.5799999999995
+          },
+          "throughput_rps": 312.5113119328941
+        }
+      ],
+      "merged": {
+        "count": 200,
+        "p50_us": 3143,
+        "p90_us": 3573,
+        "p99_us": 4451,
+        "p999_us": 5059,
+        "max_us": 5059,
+        "mean_us": 3252.805
+      },
+      "throughput_median_rps": 307.48206402676135,
+      "throughput_cov": 0.023131204806698467
+    },
+    {
+      "scenario": "versioned_composition_version_by_id",
+      "group": "VERSIONED_COMPOSITION",
+      "description": "get composition version by id",
+      "target": "ehrbase-rs",
+      "gate_ok": true,
+      "gate_status": 200,
+      "runs": [
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 4067,
+            "p90_us": 4575,
+            "p99_us": 5259,
+            "p999_us": 5371,
+            "max_us": 5371,
+            "mean_us": 4174.260000000001
+          },
+          "throughput_rps": 239.55550456962666
+        },
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 4115,
+            "p90_us": 5315,
+            "p99_us": 7851,
+            "p999_us": 10255,
+            "max_us": 10255,
+            "mean_us": 4468.569999999999
+          },
+          "throughput_rps": 223.77288527255695
+        }
+      ],
+      "merged": {
+        "count": 200,
+        "p50_us": 4087,
+        "p90_us": 4779,
+        "p99_us": 7631,
+        "p999_us": 10255,
+        "max_us": 10255,
+        "mean_us": 4321.415
+      },
+      "throughput_median_rps": 231.6641949210918,
+      "throughput_cov": 0.04817316346034792
+    },
+    {
+      "scenario": "contribution_get",
+      "group": "CONTRIBUTION",
+      "description": "get contribution",
+      "target": "ehrbase-rs",
+      "gate_ok": true,
+      "gate_status": 200,
+      "runs": [
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 4069,
+            "p90_us": 4547,
+            "p99_us": 5303,
+            "p999_us": 5459,
+            "max_us": 5459,
+            "mean_us": 4174.68
+          },
+          "throughput_rps": 239.53161967925388
+        },
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 4081,
+            "p90_us": 4547,
+            "p99_us": 5743,
+            "p999_us": 7479,
+            "max_us": 7479,
+            "mean_us": 4223.23
+          },
+          "throughput_rps": 236.77895401064396
+        }
+      ],
+      "merged": {
+        "count": 200,
+        "p50_us": 4075,
+        "p90_us": 4547,
+        "p99_us": 5459,
+        "p999_us": 7479,
+        "max_us": 7479,
+        "mean_us": 4198.954999999999
+      },
+      "throughput_median_rps": 238.15528684494893,
+      "throughput_cov": 0.008172938700624775
+    },
+    {
+      "scenario": "directory_create",
+      "group": "DIRECTORY",
+      "description": "create directory",
+      "target": "ehrbase-rs",
+      "gate_ok": true,
+      "gate_status": 201,
+      "runs": [
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 3367,
+            "p90_us": 3709,
+            "p99_us": 4299,
+            "p999_us": 5119,
+            "max_us": 5119,
+            "mean_us": 3451.9900000000002
+          },
+          "throughput_rps": 289.66808206119487
+        },
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 3441,
+            "p90_us": 3705,
+            "p99_us": 4379,
+            "p999_us": 4603,
+            "max_us": 4603,
+            "mean_us": 3503.5699999999997
+          },
+          "throughput_rps": 285.4066581092237
+        }
+      ],
+      "merged": {
+        "count": 200,
+        "p50_us": 3409,
+        "p90_us": 3709,
+        "p99_us": 4379,
+        "p999_us": 5119,
+        "max_us": 5119,
+        "mean_us": 3477.78
+      },
+      "throughput_median_rps": 287.5373700852093,
+      "throughput_cov": 0.010479617912122579
+    },
+    {
+      "scenario": "directory_get",
+      "group": "DIRECTORY",
+      "description": "get directory",
+      "target": "ehrbase-rs",
+      "gate_ok": true,
+      "gate_status": 200,
+      "runs": [
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 3327,
+            "p90_us": 3547,
+            "p99_us": 4759,
+            "p999_us": 6423,
+            "max_us": 6423,
+            "mean_us": 3427.2499999999995
+          },
+          "throughput_rps": 291.7562798511532
+        },
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 3349,
+            "p90_us": 4231,
+            "p99_us": 5391,
+            "p999_us": 6379,
+            "max_us": 6379,
+            "mean_us": 3569.730000000001
+          },
+          "throughput_rps": 280.12034877773425
+        }
+      ],
+      "merged": {
+        "count": 200,
+        "p50_us": 3337,
+        "p90_us": 3841,
+        "p99_us": 5391,
+        "p999_us": 6423,
+        "max_us": 6423,
+        "mean_us": 3498.4900000000002
+      },
+      "throughput_median_rps": 285.9383143144437,
+      "throughput_cov": 0.028774897785771036
+    },
+    {
+      "scenario": "directory_update",
+      "group": "DIRECTORY",
+      "description": "update directory",
+      "target": "ehrbase-rs",
+      "gate_ok": true,
+      "gate_status": 200,
+      "runs": [
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 3993,
+            "p90_us": 4327,
+            "p99_us": 5023,
+            "p999_us": 7263,
+            "max_us": 7263,
+            "mean_us": 4071.91
+          },
+          "throughput_rps": 245.5598433905756
+        },
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 4247,
+            "p90_us": 4987,
+            "p99_us": 5827,
+            "p999_us": 7423,
+            "max_us": 7423,
+            "mean_us": 4407.420000000001
+          },
+          "throughput_rps": 226.87490110239466
+        }
+      ],
+      "merged": {
+        "count": 200,
+        "p50_us": 4107,
+        "p90_us": 4755,
+        "p99_us": 5827,
+        "p999_us": 7423,
+        "max_us": 7423,
+        "mean_us": 4239.665
+      },
+      "throughput_median_rps": 236.21737224648513,
+      "throughput_cov": 0.05593258985315218
+    },
+    {
+      "scenario": "directory_delete",
+      "group": "DIRECTORY",
+      "description": "delete directory",
+      "target": "ehrbase-rs",
+      "gate_ok": true,
+      "gate_status": 204,
+      "runs": [
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 3901,
+            "p90_us": 4663,
+            "p99_us": 5395,
+            "p999_us": 5495,
+            "max_us": 5495,
+            "mean_us": 4039.6800000000007
+          },
+          "throughput_rps": 247.53197746801558
+        },
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 4587,
+            "p90_us": 6267,
+            "p99_us": 6595,
+            "p999_us": 8167,
+            "max_us": 8167,
+            "mean_us": 4830.89
+          },
+          "throughput_rps": 206.98087844618016
+        }
+      ],
+      "merged": {
+        "count": 200,
+        "p50_us": 4135,
+        "p90_us": 5495,
+        "p99_us": 6587,
+        "p999_us": 8167,
+        "max_us": 8167,
+        "mean_us": 4435.284999999998
+      },
+      "throughput_median_rps": 227.25642795709786,
+      "throughput_cov": 0.12617446010512917
+    },
+    {
+      "scenario": "aql_simple",
+      "group": "QUERY",
+      "description": "AQL: SELECT compositions",
+      "target": "ehrbase-rs",
+      "gate_ok": true,
+      "gate_status": 200,
+      "runs": [
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 11839,
+            "p90_us": 12983,
+            "p99_us": 14943,
+            "p999_us": 15031,
+            "max_us": 15031,
+            "mean_us": 12067.679999999998
+          },
+          "throughput_rps": 82.86330559531686
+        },
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 11815,
+            "p90_us": 12991,
+            "p99_us": 15071,
+            "p999_us": 16719,
+            "max_us": 16719,
+            "mean_us": 12048.599999999993
+          },
+          "throughput_rps": 82.9951167515795
+        }
+      ],
+      "merged": {
+        "count": 200,
+        "p50_us": 11839,
+        "p90_us": 12991,
+        "p99_us": 15031,
+        "p999_us": 16719,
+        "max_us": 16719,
+        "mean_us": 12058.140000000001
+      },
+      "throughput_median_rps": 82.92921117344818,
+      "throughput_cov": 0.0011239050885750623
+    },
+    {
+      "scenario": "aql_aggregate",
+      "group": "QUERY",
+      "description": "AQL: COUNT aggregate",
+      "target": "ehrbase-rs",
+      "gate_ok": true,
+      "gate_status": 200,
+      "runs": [
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 3465,
+            "p90_us": 3721,
+            "p99_us": 3955,
+            "p999_us": 4279,
+            "max_us": 4279,
+            "mean_us": 3519.6300000000006
+          },
+          "throughput_rps": 284.10802659951173
+        },
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 3515,
+            "p90_us": 3947,
+            "p99_us": 5055,
+            "p999_us": 5107,
+            "max_us": 5107,
+            "mean_us": 3606.6
+          },
+          "throughput_rps": 277.2486310523075
+        }
+      ],
+      "merged": {
+        "count": 200,
+        "p50_us": 3481,
+        "p90_us": 3875,
+        "p99_us": 5047,
+        "p999_us": 5107,
+        "max_us": 5107,
+        "mean_us": 3563.1150000000002
+      },
+      "throughput_median_rps": 280.6783288259096,
+      "throughput_cov": 0.017280725329091397
+    },
+    {
+      "scenario": "template_upload",
+      "group": "DEFINITION",
+      "description": "upload OPT template",
+      "target": "ehrbase-rs",
+      "gate_ok": true,
+      "gate_status": 409,
+      "runs": [
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 4387,
+            "p90_us": 4883,
+            "p99_us": 5403,
+            "p999_us": 5559,
+            "max_us": 5559,
+            "mean_us": 4416.530000000001
+          },
+          "throughput_rps": 226.41030981986796
+        },
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 4339,
+            "p90_us": 4895,
+            "p99_us": 5075,
+            "p999_us": 5459,
+            "max_us": 5459,
+            "mean_us": 4378.579999999999
+          },
+          "throughput_rps": 228.36928912636756
+        }
+      ],
+      "merged": {
+        "count": 200,
+        "p50_us": 4367,
+        "p90_us": 4895,
+        "p99_us": 5403,
+        "p999_us": 5559,
+        "max_us": 5559,
+        "mean_us": 4397.5549999999985
+      },
+      "throughput_median_rps": 227.38979947311776,
+      "throughput_cov": 0.006091775246909208
+    },
+    {
+      "scenario": "template_list",
+      "group": "DEFINITION",
+      "description": "list templates",
+      "target": "ehrbase-rs",
+      "gate_ok": true,
+      "gate_status": 200,
+      "runs": [
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 3193,
+            "p90_us": 3867,
+            "p99_us": 4283,
+            "p999_us": 4479,
+            "max_us": 4479,
+            "mean_us": 3300.6
+          },
+          "throughput_rps": 302.9534556731289
+        },
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 3081,
+            "p90_us": 3375,
+            "p99_us": 4087,
+            "p999_us": 4359,
+            "max_us": 4359,
+            "mean_us": 3141.7499999999995
+          },
+          "throughput_rps": 318.27760889172157
+        }
+      ],
+      "merged": {
+        "count": 200,
+        "p50_us": 3145,
+        "p90_us": 3593,
+        "p99_us": 4283,
+        "p999_us": 4479,
+        "max_us": 4479,
+        "mean_us": 3221.1749999999984
+      },
+      "throughput_median_rps": 310.6155322824252,
+      "throughput_cov": 0.03488496720426769
+    },
+    {
+      "scenario": "template_get",
+      "group": "DEFINITION",
+      "description": "get template",
+      "target": "ehrbase-rs",
+      "gate_ok": true,
+      "gate_status": 200,
+      "runs": [
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 3475,
+            "p90_us": 3667,
+            "p99_us": 3881,
+            "p999_us": 4991,
+            "max_us": 4991,
+            "mean_us": 3511.45
+          },
+          "throughput_rps": 284.7609134983168
+        },
+        {
+          "latency": {
+            "count": 100,
+            "p50_us": 3487,
+            "p90_us": 3795,
+            "p99_us": 4107,
+            "p999_us": 4695,
+            "max_us": 4695,
+            "mean_us": 3546.7400000000002
+          },
+          "throughput_rps": 281.9298805145925
+        }
+      ],
+      "merged": {
+        "count": 200,
+        "p50_us": 3477,
+        "p90_us": 3755,
+        "p99_us": 4107,
+        "p999_us": 4991,
+        "max_us": 4991,
+        "mean_us": 3529.0950000000003
+      },
+      "throughput_median_rps": 283.3453970064547,
+      "throughput_cov": 0.007065026083725773
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

The `ehrbase-bench` harness — a defensible, reproducible ehrbase-rs-vs-EHRbase-Java performance comparison built as the antidote to "trust me bro" benchmarks (`docs/design/benchmarking.md`).

- **Comprehensive workload:** 24 operations across the full openEHR REST surface (EHR, EHR_STATUS +versioned, COMPOSITION +versioned, CONTRIBUTION, DIRECTORY, QUERY, DEFINITION), driven with a **large real 64 KB clinical composition** from the CNF corpus — not a toy.
- **Beyond latency:** per-operation latency (full p50→p99.9 distribution, coordinated-omission-corrected HdrHistogram) **and** sustained throughput, with inter-run variance (CoV).
- **Full-overview report:** coverage by resource group, side-by-side per-operation table, head-to-head win/loss summary, a mandatory multi-metric "where EHRbase wins" section, and methodology/limitations — all generated, never hand-typed.
- **Auto-captured machine specs** (sysinfo): every report states the CPU/RAM/OS it ran on, because a number is meaningless across hardware.
- **Provably fair client:** reuses the conformance `SutClient`, so the request path is identical for both servers.
- **Dual-stack env** (`docker/benchmark/`): both servers (EHRbase Java 2.33.0), each with its own PostgreSQL, matched Basic auth, run one-at-a-time (§3.1); `run.sh` orchestrates; CLI `--merge` combines both into one report.

## Validated
ehrbase-rs runs the **full 24-operation surface** end-to-end via the compose stack, producing the full-overview report with real numbers.

## Known limitation → CNF hardening target
EHRbase Java **rejects payloads ehrbase-rs accepts** (e.g. `PARTY_SELF` vs `PARTY_IDENTIFIED` on EHR_STATUS.subject, 412 on the large composition). This strictness gap is a real conformance finding — our server is too lenient — and is exactly the next work: spec-based CNF hardening.