### PR TITLE
B4: terminology-server integration — FHIR provider, AQL TERMINOLOGY(), wire + TS harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1719,6 +1719,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1060,6 +1060,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]

--- a/app/ehrbase-rest/src/config.rs
+++ b/app/ehrbase-rest/src/config.rs
@@ -30,6 +30,10 @@ pub struct RestConfig {
     /// Disabled by default — the admin routes answer `404` unless enabled.
     #[serde(default)]
     pub admin: AdminConfig,
+    /// Terminology extension API (SM `I_TERMINOLOGY_SERVICE`). Disabled by
+    /// default — the terminology routes answer `404` unless enabled.
+    #[serde(default)]
+    pub terminology: TerminologyConfig,
 }
 
 /// Configuration of the ADMIN API group (SM `I_ADMIN_SERVICE`; ITS-REST admin
@@ -47,6 +51,22 @@ pub struct AdminConfig {
     pub enabled: bool,
 }
 
+/// Configuration of the terminology extension API group (SM
+/// `I_TERMINOLOGY_SERVICE`; `docs/design/sm-platform/08-target-architecture.md`
+/// §7 — an extension namespace with no ITS-REST 1.0.3 contract).
+///
+/// PORT NOTE: like the ADMIN group, the terminology surface is opt-in — when
+/// inactive every terminology route answers `404` (as if unmounted), never a
+/// `403`. Off by default so a stock server exposes only the standardised
+/// ITS-REST surface.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TerminologyConfig {
+    /// Whether the terminology extension group is active. When `false`, every
+    /// terminology route answers `404` without touching the backend.
+    #[serde(default)]
+    pub enabled: bool,
+}
+
 impl Default for RestConfig {
     fn default() -> Self {
         Self {
@@ -56,6 +76,7 @@ impl Default for RestConfig {
             cors_permissive: false,
             auth: AuthConfig::default(),
             admin: AdminConfig::default(),
+            terminology: TerminologyConfig::default(),
         }
     }
 }
@@ -122,6 +143,8 @@ mod tests {
         assert!(c.auth.enabled);
         // The ADMIN API is opt-in: off unless explicitly enabled.
         assert!(!c.admin.enabled);
+        // The terminology extension API is opt-in too.
+        assert!(!c.terminology.enabled);
         assert_eq!(c.swagger_ui_path(), "/ehrbase/rest/swagger-ui");
         assert_eq!(c.openapi_json_path(), "/ehrbase/rest/api-docs/openapi.json");
     }
@@ -133,6 +156,17 @@ mod tests {
             jail.set_env("EHRBASE_REST_ADMIN__ENABLED", "true");
             let c = RestConfig::load().expect("load");
             assert!(c.admin.enabled);
+            Ok(())
+        });
+    }
+
+    #[test]
+    #[allow(clippy::result_large_err)] // figment::Jail closure signature
+    fn terminology_enabled_via_env() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env("EHRBASE_REST_TERMINOLOGY__ENABLED", "true");
+            let c = RestConfig::load().expect("load");
+            assert!(c.terminology.enabled);
             Ok(())
         });
     }

--- a/app/ehrbase-rest/src/dispatch/mod.rs
+++ b/app/ehrbase-rest/src/dispatch/mod.rs
@@ -10,8 +10,9 @@
 //! and renders a negotiated response.
 //!
 //! Every API group has its own dispatcher module ([`ehr`], [`definition`],
-//! [`query`], [`demographic`], [`admin`]); operations whose backend seam method
-//! is not overridden surface as `501` + the standard error body.
+//! [`query`], [`demographic`], [`admin`], [`terminology`]); operations whose
+//! backend seam method is not overridden surface as `501` + the standard error
+//! body.
 
 mod abac;
 mod admin;
@@ -20,6 +21,7 @@ mod demographic;
 mod ehr;
 mod flat;
 mod query;
+mod terminology;
 
 use std::future::Future;
 use std::pin::Pin;
@@ -87,6 +89,12 @@ pub(crate) fn api_router<S: Platform>() -> Router<AppState<S>> {
         .merge(mount(g::definition::ROUTES, definition::dispatch::<S>))
         .merge(mount(g::query::ROUTES, query::dispatch::<S>))
         .merge(mount(g::admin::ROUTES, admin::dispatch::<S>))
+        // Our-own-design terminology extension routes (no ITS-REST contract;
+        // SM `I_TERMINOLOGY_SERVICE`, design doc 08 §7), config-gated.
+        .merge(mount(
+            terminology::TERMINOLOGY_ROUTES,
+            terminology::dispatch::<S>,
+        ))
 }
 
 /// Mount one API group's routes onto a router, grouping methods that share a

--- a/app/ehrbase-rest/src/dispatch/terminology.rs
+++ b/app/ehrbase-rest/src/dispatch/terminology.rs
@@ -1,0 +1,200 @@
+//! HTTP dispatch for the terminology extension API group over the
+//! [`TerminologyService`](ehrbase_sm::services::TerminologyService) seam.
+//!
+//! Spec grounding: SM `I_TERMINOLOGY_SERVICE`
+//! (`docs/specs/openehr/SM/docs/UML/classes/i_terminology_service.adoc`,
+//! `master12-terminology_service.adoc`) — the nine calls `get_terminology_ids`,
+//! `has_terminology`, `get_terminology_description`, `has_term`, `get_term`,
+//! `subsumes`, `value_set_validate`, `has_value_set`, `get_value_set` and their
+//! `Pre_has_terminology` / `Pre_has_term` / `Pre_has_value_set` preconditions.
+//!
+//! Wire design (`docs/design/sm-platform/08-target-architecture.md` §7):
+//! ITS-REST 1.0.3 defines **no** terminology contract, so this surface is our
+//! own, exposed under the server's extension namespace (`/terminology`), spec-
+//! first from the SM call semantics and excluded from the ITS-REST drift check.
+//! If/when openEHR publishes a contract, `emit-rest` takes over (ADR-005) and
+//! these routes migrate.
+//!
+//! PORT NOTE (mount path, §7): §7 names the namespace `/rest/terminology`; in
+//! this server the extension groups (like the ADMIN group) are mounted inside
+//! the ITS-REST API router, so the full path is
+//! `{base_path}/terminology/...` — i.e. `/ehrbase/rest/openehr/v1/terminology`.
+//! Nesting them here keeps the auth / ATNA-audit / ABAC middleware stack
+//! uniform across the whole HTTP surface.
+//!
+//! PORT NOTE (existence calls): the boolean `has_terminology` / `has_term` /
+//! `has_value_set` calls are surfaced implicitly through the `200`-vs-`404` of
+//! their `get`/description counterparts (the idiomatic REST existence check)
+//! rather than as separate boolean endpoints — mirroring the ADMIN group's
+//! decision not to over-model the surface. The bundle provider maps a failed
+//! precondition to `versioned_object_does_not_exist` (→ `404`), so no new SM
+//! `CALL_STATUS_TYPE` is needed.
+//!
+//! The group is config-gated (`RestConfig::terminology.enabled`, default
+//! `false`): when disabled every terminology route answers `404` without
+//! touching the backend.
+
+use axum::response::{IntoResponse, Response};
+use http::StatusCode;
+use serde_json::json;
+
+use openehr_its::rest::runtime::ApiError;
+
+use super::{BoxResponse, RequestParts};
+use crate::error::RestError;
+use ehrbase_sm::Platform;
+
+use crate::state::AppState;
+use crate::{negotiate, params};
+
+/// The terminology extension routes — our own design (no ITS-REST contract;
+/// §7), mounted alongside the generated `ROUTES` and served by [`dispatch`].
+/// Group-relative paths (nested under the configured `base_path`).
+pub(crate) const TERMINOLOGY_ROUTES: &[(&str, &str, &str)] = &[
+    // `get_terminology_ids` — the identifiers of every terminology this server
+    // knows.
+    ("GET", "/terminology", "terminology_ids"),
+    // `get_terminology_description` — descriptor for one terminology
+    // (`Pre_has_terminology`; also the existence check for `has_terminology`).
+    (
+        "GET",
+        "/terminology/{terminology_id}",
+        "terminology_description",
+    ),
+    // `get_term` — a term definition (lookup); optional `?at_date=`.
+    (
+        "GET",
+        "/terminology/{terminology_id}/term/{code}",
+        "terminology_get_term",
+    ),
+    // `subsumes` — strict subsumption test; `?ref_code=&candidate=`.
+    (
+        "GET",
+        "/terminology/{terminology_id}/subsumes",
+        "terminology_subsumes",
+    ),
+    // `get_value_set` — the value set's extract (expand;
+    // `Pre_has_value_set`, also the existence check for `has_value_set`).
+    (
+        "GET",
+        "/terminology/{terminology_id}/value_set/{value_set_id}",
+        "terminology_value_set",
+    ),
+    // `value_set_validate` — membership test; `?candidate_code=&at_date=`.
+    (
+        "GET",
+        "/terminology/{terminology_id}/value_set/{value_set_id}/validate",
+        "terminology_value_set_validate",
+    ),
+];
+
+pub(super) fn dispatch<S: Platform>(
+    state: AppState<S>,
+    op: &'static str,
+    parts: RequestParts,
+) -> BoxResponse {
+    Box::pin(async move {
+        run(state, op, parts)
+            .await
+            .unwrap_or_else(IntoResponse::into_response)
+    })
+}
+
+async fn run<S: Platform>(
+    state: AppState<S>,
+    op: &'static str,
+    parts: RequestParts,
+) -> Result<Response, RestError> {
+    // Config gate: the terminology extension is opt-in. When disabled every
+    // route answers 404 (as if unmounted) without consulting the backend.
+    if !state.config().terminology.enabled {
+        return Err(RestError(ApiError::NotFound(
+            "terminology API is disabled".to_owned(),
+        )));
+    }
+
+    let h = &parts.headers;
+    let q = parts.query.as_deref();
+    let ok = StatusCode::OK;
+
+    match op {
+        "terminology_ids" => {
+            let ids = state.backend().get_terminology_ids().await?;
+            Ok(negotiate::respond(
+                h,
+                ok,
+                &json!({ "terminology_ids": ids }),
+            ))
+        }
+        "terminology_description" => {
+            let tid = path_get(&parts, "terminology_id")?;
+            // A failed `Pre_has_terminology` → NotFound (404).
+            let desc = state.backend().get_terminology_description(&tid).await?;
+            Ok(negotiate::respond(h, ok, &desc))
+        }
+        "terminology_get_term" => {
+            let tid = path_get(&parts, "terminology_id")?;
+            let code = path_get(&parts, "code")?;
+            let at_date = params::query_param(q, "at_date");
+            // PORT NOTE: the SM `get_term.attributes` allow-list is not surfaced
+            // on the wire — its `Hash<String, String>` shape is ambiguous against
+            // the SM's `List<String>`, and the bundle provider ignores it
+            // (`ehrbase::service::api::terminology`). Passed as `None`; add a
+            // query encoding when a consumer needs the filter.
+            let extract = state.backend().get_term(&tid, &code, None, at_date).await?;
+            Ok(negotiate::respond(h, ok, &extract))
+        }
+        "terminology_subsumes" => {
+            let tid = path_get(&parts, "terminology_id")?;
+            let ref_code = require_query(q, "ref_code")?;
+            let candidate = require_query(q, "candidate")?;
+            let subsumes = state
+                .backend()
+                .subsumes(&tid, &ref_code, &candidate)
+                .await?;
+            Ok(negotiate::respond(h, ok, &json!({ "subsumes": subsumes })))
+        }
+        "terminology_value_set" => {
+            let tid = path_get(&parts, "terminology_id")?;
+            let value_set_id = path_get(&parts, "value_set_id")?;
+            // A failed `Pre_has_value_set` → NotFound (404).
+            let extract = state.backend().get_value_set(&tid, &value_set_id).await?;
+            Ok(negotiate::respond(h, ok, &extract))
+        }
+        "terminology_value_set_validate" => {
+            let tid = path_get(&parts, "terminology_id")?;
+            let value_set_id = path_get(&parts, "value_set_id")?;
+            let candidate_code = require_query(q, "candidate_code")?;
+            let at_date = params::query_param(q, "at_date");
+            let valid = state
+                .backend()
+                .value_set_validate(&tid, &value_set_id, &candidate_code, at_date)
+                .await?;
+            Ok(negotiate::respond(h, ok, &json!({ "valid": valid })))
+        }
+        other => Err(RestError(ApiError::Internal(format!(
+            "unrouted terminology operation: {other}"
+        )))),
+    }
+}
+
+/// Read a matched path parameter (guaranteed present by the route template; an
+/// absence is a routing bug → `500`).
+fn path_get(parts: &RequestParts, key: &str) -> Result<String, RestError> {
+    parts.path.get(key).cloned().ok_or_else(|| {
+        RestError(ApiError::Internal(format!(
+            "missing path parameter `{key}`"
+        )))
+    })
+}
+
+/// Read a required, non-empty query parameter → `400` when absent/blank.
+fn require_query(query: Option<&str>, key: &str) -> Result<String, RestError> {
+    params::query_param(query, key)
+        .filter(|v| !v.is_empty())
+        .ok_or_else(|| {
+            RestError(ApiError::BadRequest(format!(
+                "missing required query parameter `{key}`"
+            )))
+        })
+}

--- a/app/ehrbase-rest/src/lib.rs
+++ b/app/ehrbase-rest/src/lib.rs
@@ -33,7 +33,7 @@ pub use access::authn::{AuthMethod, Authenticator, Principal};
 pub use access::authz::{AuthzHandle, AuthzResolvers, ResolveError, build_engine};
 // The native API lives in `ehrbase-sm` (ADR-011); re-exported here for the
 // server's public surface (test mocks, the binary) — no local shim module.
-pub use config::{AdminConfig, RestConfig};
+pub use config::{AdminConfig, RestConfig, TerminologyConfig};
 pub use ehrbase_sm::Platform;
 pub use ehrbase_sm::services::{
     AdminArchive, AdminService, DefinitionAdl2Service, DefinitionAdl14Service,

--- a/app/ehrbase-rest/tests/admin_http.rs
+++ b/app/ehrbase-rest/tests/admin_http.rs
@@ -70,6 +70,7 @@ fn config(admin_enabled: bool) -> RestConfig {
         admin: AdminConfig {
             enabled: admin_enabled,
         },
+        terminology: ehrbase_rest::TerminologyConfig::default(),
     }
 }
 

--- a/app/ehrbase-rest/tests/common/mod.rs
+++ b/app/ehrbase-rest/tests/common/mod.rs
@@ -23,6 +23,7 @@
 //! stored composition) by capturing an `Arc<Mutex<_>>`.
 #![allow(clippy::type_complexity, dead_code)]
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -42,7 +43,9 @@ use ehrbase_sm::services::{
 use ehrbase_sm::types::{
     EhrSummary, PartyKind, ResourceMeta, ServiceResponse, SubjectRef, UpdateAudit, UpdateVersion,
 };
-use ehrbase_sm::{AuditEvent, CallStatusType, EmitOutcome, SmError};
+use ehrbase_sm::{
+    AuditEvent, CallStatusType, EmitOutcome, SmError, TerminologyDescription, TerminologyExtract,
+};
 
 /// A `501 Not Implemented` SM error — the un-hooked default (old `StubBackend`).
 fn not_impl() -> SmError {
@@ -96,6 +99,20 @@ type ValueListHook = Arc<dyn Fn() -> Result<Vec<Value>, SmError> + Send + Sync>;
 type TemplateUploadHook = Arc<dyn Fn(String) -> Result<Value, SmError> + Send + Sync>;
 type QueryListHook = Arc<dyn Fn(String) -> Result<Vec<Value>, SmError> + Send + Sync>;
 
+// Terminology (SM I_TERMINOLOGY_SERVICE) wire-exposure hooks.
+type TerminologyIds = Arc<dyn Fn() -> Result<Vec<String>, SmError> + Send + Sync>;
+type TerminologyDescriptionHook =
+    Arc<dyn Fn(String) -> Result<TerminologyDescription, SmError> + Send + Sync>;
+// `Fn(terminology_id, code, at_date)` — the `attributes` allow-list is dropped
+// on the wire (see the terminology dispatcher PORT NOTE), so the hook omits it.
+type GetTerm = Arc<
+    dyn Fn(String, String, Option<String>) -> Result<TerminologyExtract, SmError> + Send + Sync,
+>;
+type Subsumes = Arc<dyn Fn(String, String, String) -> Result<bool, SmError> + Send + Sync>;
+type ValueSetValidate =
+    Arc<dyn Fn(String, String, String, Option<String>) -> Result<bool, SmError> + Send + Sync>;
+type GetValueSet = Arc<dyn Fn(String, String) -> Result<TerminologyExtract, SmError> + Send + Sync>;
+
 /// The per-test override closures. Every field defaults to `None` (→ the
 /// `501`/trait-default behaviour); a test populates only what it exercises.
 #[derive(Default, Clone)]
@@ -145,6 +162,13 @@ pub struct Hooks {
     pub template_adl2_upload: Option<GetOpt>,
     pub template_adl2_list: Option<ValueListHook>,
     pub query_list: Option<QueryListHook>,
+    // Terminology (SM I_TERMINOLOGY_SERVICE) — the wire-exposed calls.
+    pub get_terminology_ids: Option<TerminologyIds>,
+    pub get_terminology_description: Option<TerminologyDescriptionHook>,
+    pub get_term: Option<GetTerm>,
+    pub subsumes: Option<Subsumes>,
+    pub value_set_validate: Option<ValueSetValidate>,
+    pub get_value_set: Option<GetValueSet>,
     // SM System Log: an in-memory audit recorder. When set, the mock's
     // `SystemLog::emit` records every event (so a test can assert the ATNA
     // event a request produced); `audit_enabled()` is then true. Replaces the
@@ -815,4 +839,80 @@ impl AdminService for Mock {
 }
 
 impl AdminArchive for Mock {}
-impl TerminologyService for Mock {}
+
+// ── terminology (SM I_TERMINOLOGY_SERVICE; wire exposure per design 08 §7) ────
+//
+// Defaults kept (→ 501) except the six wire-exposed calls, which route through
+// the optional per-test hooks.
+#[async_trait]
+impl TerminologyService for Mock {
+    async fn get_terminology_ids(&self) -> Result<Vec<String>, SmError> {
+        match &self.h.get_terminology_ids {
+            Some(f) => f(),
+            None => Err(not_impl()),
+        }
+    }
+    async fn get_terminology_description(
+        &self,
+        terminology_id: &str,
+    ) -> Result<TerminologyDescription, SmError> {
+        match &self.h.get_terminology_description {
+            Some(f) => f(terminology_id.to_owned()),
+            None => Err(not_impl()),
+        }
+    }
+    async fn get_term(
+        &self,
+        terminology_id: &str,
+        code: &str,
+        _attributes: Option<BTreeMap<String, String>>,
+        at_date: Option<String>,
+    ) -> Result<TerminologyExtract, SmError> {
+        match &self.h.get_term {
+            Some(f) => f(terminology_id.to_owned(), code.to_owned(), at_date),
+            None => Err(not_impl()),
+        }
+    }
+    async fn subsumes(
+        &self,
+        terminology_id: &str,
+        ref_code: &str,
+        candidate_child_code: &str,
+    ) -> Result<bool, SmError> {
+        match &self.h.subsumes {
+            Some(f) => f(
+                terminology_id.to_owned(),
+                ref_code.to_owned(),
+                candidate_child_code.to_owned(),
+            ),
+            None => Err(not_impl()),
+        }
+    }
+    async fn value_set_validate(
+        &self,
+        terminology_id: &str,
+        value_set_id: &str,
+        candidate_code: &str,
+        at_date: Option<String>,
+    ) -> Result<bool, SmError> {
+        match &self.h.value_set_validate {
+            Some(f) => f(
+                terminology_id.to_owned(),
+                value_set_id.to_owned(),
+                candidate_code.to_owned(),
+                at_date,
+            ),
+            None => Err(not_impl()),
+        }
+    }
+    async fn get_value_set(
+        &self,
+        terminology_id: &str,
+        value_set_code: &str,
+    ) -> Result<TerminologyExtract, SmError> {
+        match &self.h.get_value_set {
+            Some(f) => f(terminology_id.to_owned(), value_set_code.to_owned()),
+            None => Err(not_impl()),
+        }
+    }
+}

--- a/app/ehrbase-rest/tests/definition_adl2_http.rs
+++ b/app/ehrbase-rest/tests/definition_adl2_http.rs
@@ -69,6 +69,7 @@ fn config() -> RestConfig {
             admin_scope: None,
         },
         admin: ehrbase_rest::AdminConfig::default(),
+        terminology: ehrbase_rest::TerminologyConfig::default(),
     }
 }
 

--- a/app/ehrbase-rest/tests/demographic_http.rs
+++ b/app/ehrbase-rest/tests/demographic_http.rs
@@ -118,6 +118,7 @@ fn config() -> RestConfig {
         swagger_ui: false,
         cors_permissive: false,
         admin: ehrbase_rest::AdminConfig::default(),
+        terminology: ehrbase_rest::TerminologyConfig::default(),
         auth: AuthConfig {
             enabled: false,
             basic: None,

--- a/app/ehrbase-rest/tests/example_http.rs
+++ b/app/ehrbase-rest/tests/example_http.rs
@@ -93,6 +93,7 @@ fn config() -> RestConfig {
         swagger_ui: false,
         cors_permissive: false,
         admin: ehrbase_rest::AdminConfig::default(),
+        terminology: ehrbase_rest::TerminologyConfig::default(),
         auth: AuthConfig {
             enabled: false,
             basic: None,

--- a/app/ehrbase-rest/tests/flat_http.rs
+++ b/app/ehrbase-rest/tests/flat_http.rs
@@ -78,6 +78,7 @@ fn config() -> RestConfig {
             admin_scope: None,
         },
         admin: ehrbase_rest::AdminConfig::default(),
+        terminology: ehrbase_rest::TerminologyConfig::default(),
     }
 }
 

--- a/app/ehrbase-rest/tests/headers.rs
+++ b/app/ehrbase-rest/tests/headers.rs
@@ -84,6 +84,7 @@ fn config() -> RestConfig {
             admin_scope: None,
         },
         admin: ehrbase_rest::AdminConfig::default(),
+        terminology: ehrbase_rest::TerminologyConfig::default(),
     }
 }
 

--- a/app/ehrbase-rest/tests/http.rs
+++ b/app/ehrbase-rest/tests/http.rs
@@ -66,6 +66,7 @@ fn config(enabled: bool) -> RestConfig {
         // The admin group must be reachable here: `admin_route_reachable_without_rbac`
         // asserts the dispatcher's 501 (StubBackend), not the config gate's 404.
         admin: AdminConfig { enabled: true },
+        terminology: ehrbase_rest::TerminologyConfig::default(),
     }
 }
 

--- a/app/ehrbase-rest/tests/terminology_http.rs
+++ b/app/ehrbase-rest/tests/terminology_http.rs
@@ -1,0 +1,342 @@
+//! End-to-end HTTP tests for the terminology extension API group (SM
+//! `I_TERMINOLOGY_SERVICE`, wire design `docs/design/sm-platform/
+//! 08-target-architecture.md` §7): the config gate
+//! (`RestConfig::terminology.enabled`), the `200`/`404`/`400`/`501` wire
+//! outcomes for `get_terminology_ids` / `get_terminology_description` /
+//! `get_term` / `subsumes` / `get_value_set` / `value_set_validate`, and the
+//! JSON body shapes — driven through the assembled router with the shared
+//! [`Mock`] platform whose terminology hooks record whether the backend was
+//! consulted.
+//!
+//! Spec grounding: `docs/specs/openehr/SM/docs/UML/classes/
+//! i_terminology_service.adoc` (the nine calls + `Pre_has_*` preconditions).
+//! A failed precondition surfaces as `versioned_object_does_not_exist` (the
+//! bundle provider's convention), which the adapter maps to HTTP `404`.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use axum::Router;
+use axum::body::Body;
+use http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::Value;
+use tower::ServiceExt;
+
+use ehrbase_rest::access::authn::config::AuthConfig;
+use ehrbase_rest::{AdminConfig, RestConfig, TerminologyConfig};
+use ehrbase_sm::{
+    CallStatusType, DefinedTerm, SmError, TermEntry, TerminologyDescription, TerminologyExtract,
+};
+
+mod common;
+use common::{Hooks, Mock};
+
+const BASE: &str = "/ehrbase/rest/openehr/v1";
+/// A terminology the mock knows; anything else is `versioned_object_does_not_exist`.
+const KNOWN: &str = "openehr";
+const UNKNOWN: &str = "no-such-terminology";
+
+/// Terminology hooks covering the six wire-exposed calls. `calls` counts every
+/// backend consult so a test can prove the gate never reaches the backend.
+fn hooks(calls: Arc<AtomicUsize>) -> Hooks {
+    let c = calls;
+    let (c1, c2, c3, c4, c5, c6) = (
+        c.clone(),
+        c.clone(),
+        c.clone(),
+        c.clone(),
+        c.clone(),
+        c.clone(),
+    );
+    Hooks {
+        get_terminology_ids: Some(Arc::new(move || {
+            c1.fetch_add(1, Ordering::SeqCst);
+            Ok(vec![KNOWN.to_owned(), "openehr_ehr_status".to_owned()])
+        })),
+        get_terminology_description: Some(Arc::new(move |terminology_id: String| {
+            c2.fetch_add(1, Ordering::SeqCst);
+            if terminology_id == KNOWN {
+                Ok(TerminologyDescription {
+                    publisher: "openEHR".to_owned(),
+                    available_versions: Some(vec!["3.1.0".to_owned()]),
+                    attributes: None,
+                    uri: "http://openehr.org/terminology".to_owned(),
+                })
+            } else {
+                Err(SmError::new(
+                    CallStatusType::VersionedObjectDoesNotExist,
+                    format!("terminology {terminology_id} does not exist"),
+                ))
+            }
+        })),
+        get_term: Some(Arc::new(
+            move |terminology_id: String, code: String, at_date: Option<String>| {
+                c3.fetch_add(1, Ordering::SeqCst);
+                Ok(TerminologyExtract {
+                    terminology_id,
+                    // Echo the at_date so the test can assert it was threaded through.
+                    terminology_version: Some(at_date.unwrap_or_else(|| "none".to_owned())),
+                    terms: Some(
+                        [(
+                            code.clone(),
+                            TermEntry::Defined(DefinedTerm {
+                                code,
+                                text: "completed".to_owned(),
+                                language: Some("en".to_owned()),
+                                is_preferred_term: None,
+                            }),
+                        )]
+                        .into_iter()
+                        .collect(),
+                    ),
+                    relationships: None,
+                    relations: None,
+                })
+            },
+        )),
+        subsumes: Some(Arc::new(
+            move |_tid: String, ref_code: String, candidate: String| {
+                c4.fetch_add(1, Ordering::SeqCst);
+                // Identity-only subsumption (the openEHR bundle is flat).
+                Ok(ref_code == candidate)
+            },
+        )),
+        get_value_set: Some(Arc::new(
+            move |terminology_id: String, value_set_id: String| {
+                c5.fetch_add(1, Ordering::SeqCst);
+                if value_set_id == "known_group" {
+                    Ok(TerminologyExtract {
+                        terminology_id,
+                        terms: Some(
+                            [(
+                                "532".to_owned(),
+                                TermEntry::Bare(ehrbase_sm::TermCode {
+                                    code: "532".to_owned(),
+                                }),
+                            )]
+                            .into_iter()
+                            .collect(),
+                        ),
+                        ..Default::default()
+                    })
+                } else {
+                    Err(SmError::new(
+                        CallStatusType::VersionedObjectDoesNotExist,
+                        format!("value set {value_set_id} does not exist"),
+                    ))
+                }
+            },
+        )),
+        value_set_validate: Some(Arc::new(
+            move |_tid: String, _vs: String, candidate_code: String, _at: Option<String>| {
+                c6.fetch_add(1, Ordering::SeqCst);
+                Ok(candidate_code == "532")
+            },
+        )),
+        ..Default::default()
+    }
+}
+
+fn config(terminology_enabled: bool) -> RestConfig {
+    RestConfig {
+        bind: "127.0.0.1:0".to_owned(),
+        base_path: BASE.to_owned(),
+        swagger_ui: false,
+        cors_permissive: false,
+        auth: AuthConfig {
+            enabled: false,
+            basic: None,
+            oidc: None,
+            admin_scope: None,
+        },
+        admin: AdminConfig::default(),
+        terminology: TerminologyConfig {
+            enabled: terminology_enabled,
+        },
+    }
+}
+
+fn app(terminology_enabled: bool) -> (Router, Arc<AtomicUsize>) {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let backend = Arc::new(Mock::with(hooks(calls.clone())));
+    let router =
+        ehrbase_rest::build_with(config(terminology_enabled), backend).expect("router builds");
+    (router, calls)
+}
+
+/// An app with the terminology group enabled but **no** hooks — every call
+/// hits the trait default (`501`).
+fn app_unhooked() -> Router {
+    let backend = Arc::new(Mock::new());
+    ehrbase_rest::build_with(config(true), backend).expect("router builds")
+}
+
+async fn send(app: Router, req: Request<Body>) -> (StatusCode, String) {
+    let resp = app.oneshot(req).await.expect("response");
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.expect("body").to_bytes();
+    (status, String::from_utf8_lossy(&bytes).into_owned())
+}
+
+fn get(uri: String) -> Request<Body> {
+    Request::builder()
+        .method("GET")
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap()
+}
+
+#[tokio::test]
+async fn disabled_terminology_is_404_and_never_touches_backend() {
+    let (app, calls) = app(false);
+    let (status, _) = send(app, get(format!("{BASE}/terminology"))).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        0,
+        "backend must not be called when the group is disabled"
+    );
+}
+
+#[tokio::test]
+async fn terminology_ids_returns_list() {
+    let (app, calls) = app(true);
+    let (status, body) = send(app, get(format!("{BASE}/terminology"))).await;
+    assert_eq!(status, StatusCode::OK);
+    let v: Value = serde_json::from_str(&body).expect("json body");
+    let ids = v["terminology_ids"].as_array().expect("terminology_ids");
+    assert_eq!(ids.len(), 2);
+    assert_eq!(ids[0], KNOWN);
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn terminology_description_found_is_200() {
+    let (app, _calls) = app(true);
+    let (status, body) = send(app, get(format!("{BASE}/terminology/{KNOWN}"))).await;
+    assert_eq!(status, StatusCode::OK);
+    let v: Value = serde_json::from_str(&body).expect("json body");
+    assert_eq!(v["publisher"], "openEHR");
+    assert_eq!(v["uri"], "http://openehr.org/terminology");
+}
+
+#[tokio::test]
+async fn terminology_description_unknown_maps_to_404() {
+    let (app, _calls) = app(true);
+    // The bundle's `versioned_object_does_not_exist` surfaces as HTTP 404.
+    let (status, _) = send(app, get(format!("{BASE}/terminology/{UNKNOWN}"))).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn get_term_lookup_returns_extract_and_threads_at_date() {
+    let (app, _calls) = app(true);
+    let (status, body) = send(
+        app,
+        get(format!(
+            "{BASE}/terminology/{KNOWN}/term/532?at_date=2024-01-01"
+        )),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let v: Value = serde_json::from_str(&body).expect("json body");
+    assert_eq!(v["terminology_id"], KNOWN);
+    // `at_date` was threaded through to the seam (echoed as terminology_version).
+    assert_eq!(v["terminology_version"], "2024-01-01");
+    assert_eq!(v["terms"]["532"]["text"], "completed");
+}
+
+#[tokio::test]
+async fn subsumes_returns_bool() {
+    let (app, _calls) = app(true);
+    // Identity → true.
+    let (status, body) = send(
+        app,
+        get(format!(
+            "{BASE}/terminology/{KNOWN}/subsumes?ref_code=532&candidate=532"
+        )),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let v: Value = serde_json::from_str(&body).expect("json body");
+    assert_eq!(v["subsumes"], true);
+}
+
+#[tokio::test]
+async fn subsumes_missing_required_query_is_400_without_backend() {
+    let (app, calls) = app(true);
+    // `candidate` absent → 400 before the backend is consulted.
+    let (status, _) = send(
+        app,
+        get(format!("{BASE}/terminology/{KNOWN}/subsumes?ref_code=532")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn get_value_set_expand_returns_extract() {
+    let (app, _calls) = app(true);
+    let (status, body) = send(
+        app,
+        get(format!("{BASE}/terminology/{KNOWN}/value_set/known_group")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let v: Value = serde_json::from_str(&body).expect("json body");
+    assert_eq!(v["terminology_id"], KNOWN);
+    assert!(v["terms"].get("532").is_some());
+}
+
+#[tokio::test]
+async fn get_value_set_unknown_maps_to_404() {
+    let (app, _calls) = app(true);
+    let (status, _) = send(
+        app,
+        get(format!(
+            "{BASE}/terminology/{KNOWN}/value_set/no_such_group"
+        )),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn value_set_validate_returns_valid() {
+    let (app, _calls) = app(true);
+    let (status, body) = send(
+        app,
+        get(format!(
+            "{BASE}/terminology/{KNOWN}/value_set/known_group/validate?candidate_code=532"
+        )),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let v: Value = serde_json::from_str(&body).expect("json body");
+    assert_eq!(v["valid"], true);
+}
+
+#[tokio::test]
+async fn value_set_validate_missing_candidate_is_400() {
+    let (app, calls) = app(true);
+    let (status, _) = send(
+        app,
+        get(format!(
+            "{BASE}/terminology/{KNOWN}/value_set/known_group/validate"
+        )),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn unhooked_terminology_call_is_501() {
+    // Enabled group, no backend override → the trait default (501).
+    let app = app_unhooked();
+    let (status, _) = send(app, get(format!("{BASE}/terminology"))).await;
+    assert_eq!(status, StatusCode::NOT_IMPLEMENTED);
+}

--- a/app/ehrbase/Cargo.toml
+++ b/app/ehrbase/Cargo.toml
@@ -73,6 +73,10 @@ ehrbase-sm = { path = "../ehrbase-sm" }
 
 [dev-dependencies]
 figment = { workspace = true, features = ["test"] }
+# Hermetic FHIR terminology-server mock for the external-terminology provider
+# tests (B4): canned `$validate-code`/`$expand`/`$subsumes`/`$lookup` responses
+# + fault injection (timeout, 5xx, malformed) — no network in CI.
+wiremock.workspace = true
 testcontainers.workspace = true
 testcontainers-modules.workspace = true
 tokio.workspace = true

--- a/app/ehrbase/src/aql/error.rs
+++ b/app/ehrbase/src/aql/error.rs
@@ -39,27 +39,71 @@ pub enum AqlError {
 /// envelope. Each variant names the construct and its QUERY 1.1 spec section.
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum AqlFeatureError {
-    /// `TERMINOLOGY(...)` server-side expansion needs a terminology service.
-    /// QUERY §Functions/Other functions/TERMINOLOGY.
+    /// `TERMINOLOGY(...) = true` — the Boolean value-expression form (an
+    /// assertion tested server-side). QUERY §Functions/Other functions/
+    /// TERMINOLOGY (master03 lines 762–767).
+    ///
+    /// PORT NOTE (B4 stage (b)): only the `expand`-into-`matches` form landed
+    /// (stage (a)); the Boolean `validate`-as-assertion form is a typed reject.
+    /// The blocker is not semantics but the seam: master03's `validate`
+    /// `params_uri` is a free-form, service-api-specific query string
+    /// (`'system=…&code=…&url=…&display=…'`), while our `TerminologyService`
+    /// seam exposes structured `value_set_validate(terminology_id,
+    /// value_set_id, candidate_code)` — no raw pass-through — so parsing the
+    /// URI back into those parts is service-api-specific and deferred.
     #[error(
-        "TERMINOLOGY() server-side expansion is not supported \
-         (QUERY §Functions/Other functions/TERMINOLOGY)"
+        "TERMINOLOGY() as a Boolean value expression is not supported \
+         (only the `expand`-into-`matches` form is; \
+         QUERY §Functions/Other functions/TERMINOLOGY)"
     )]
     TerminologyFunction,
 
-    /// `matches TERMINOLOGY(...)` on the right-hand side of `matches`.
-    /// QUERY §Operators/Comparison operators/matches + §Other functions.
+    /// A non-`expand` `TERMINOLOGY(...)` used as (or inside) a `matches`
+    /// operand. Only `expand` is merged into the value list at semantic
+    /// analysis; other operations are rejected. QUERY §Operators/Comparison
+    /// operators/matches + §Other functions (master03 lines 748–767).
     #[error(
-        "matches against a TERMINOLOGY() operand is not supported \
+        "matches against a non-`expand` TERMINOLOGY() operand is not supported \
+         (only `expand` merges codes into the value list) \
          (QUERY §Operators/matches, §Other functions/TERMINOLOGY)"
     )]
     MatchesTerminology,
 
-    /// `matches { <uri> }` — a terminology URI operand. QUERY §matches/URI.
-    #[error(
-        "matches against a terminology URI operand is not supported (QUERY §Operators/matches)"
-    )]
+    /// `matches { <uri> }` — a terminology/EHR URI operand. QUERY §matches/URI
+    /// (master03 lines 367–402).
+    ///
+    /// PORT NOTE (B4 stage (c)): a typed reject. The URI-operand form
+    /// (`matches { terminology://… }`) is a distinct addressing scheme from the
+    /// `TERMINOLOGY()` function and is deferred behind stage (a)/(b); it needs
+    /// a `terminology://scheme/authority/path?query` parser mapped onto the
+    /// service seam, which the `TERMINOLOGY('expand', …)` form does not.
+    #[error("matches against a URI operand is not supported (QUERY §Operators/matches)")]
     MatchesUri,
+
+    /// A `TERMINOLOGY()` `service_api` that names no configured terminology
+    /// service: an unrecognised flavour, or a FHIR flavour with no provider
+    /// configured. A query-side/config problem (→ 400), distinct from an
+    /// upstream server fault ([`super::ExecError::Terminology`], → 500). QUERY
+    /// §Functions/Other functions/TERMINOLOGY.
+    #[error(
+        "TERMINOLOGY() service_api `{0}` is not a configured terminology service \
+         (QUERY §Functions/Other functions/TERMINOLOGY)"
+    )]
+    UnknownTerminologyService(String),
+
+    /// A `TERMINOLOGY('expand', service_api, params_uri)` whose `params_uri`
+    /// names a value set the terminology service does not know. A bad-query
+    /// problem (→ 400). QUERY §Functions/Other functions/TERMINOLOGY.
+    #[error(
+        "TERMINOLOGY() value set `{value_set}` was not found via service_api \
+         `{service_api}` (QUERY §Functions/Other functions/TERMINOLOGY)"
+    )]
+    TerminologyValueSetNotFound {
+        /// The `service_api` argument.
+        service_api: String,
+        /// The `params_uri` argument (the value-set identifier).
+        value_set: String,
+    },
 
     /// A `matches` node predicate carrying a `{/regex/}` — cADL, not AQL value
     /// matching. QUERY §Predicates/Node predicate.
@@ -178,4 +222,12 @@ pub enum ExecError {
     /// subtree (a storage/codec failure).
     #[error("result assembly failed: {0}")]
     Assembly(#[from] crate::storage::StorageError),
+
+    /// A terminology-server call failed while resolving a
+    /// `TERMINOLOGY('expand', …)` operand (transport/HTTP/malformed response).
+    /// The construct is accepted and the value set is routable; the upstream
+    /// service failed → a server-side fault (→ 500), distinct from a bad
+    /// query (400). QUERY §Functions/Other functions/TERMINOLOGY.
+    #[error("terminology expansion failed: {0}")]
+    Terminology(String),
 }

--- a/app/ehrbase/src/aql/mod.rs
+++ b/app/ehrbase/src/aql/mod.rs
@@ -19,6 +19,7 @@ pub mod exec;
 pub mod ir;
 mod lower;
 pub mod sql;
+pub mod terminology;
 
 use std::collections::BTreeSet;
 
@@ -28,6 +29,7 @@ pub use error::{AnalysisError, AqlError, AqlFeatureError, ExecError, SqlError};
 pub use exec::{ColumnMeta, QueryResult, execute};
 pub use ir::{ParamValue, Params, QueryIr};
 pub use sql::{SqlCtx, build as build_sql};
+pub use terminology::{TerminologyExpander, expand_matches};
 
 use ir::{
     ArchetypeConstraint, Bind, Expr, NameConstraint, NodeConstraint, Operand, PathTarget,

--- a/app/ehrbase/src/aql/terminology.rs
+++ b/app/ehrbase/src/aql/terminology.rs
@@ -1,0 +1,297 @@
+//! `TERMINOLOGY('expand', …)` `matches`-operand expansion (B4 stage (a)).
+//!
+//! master03 §TERMINOLOGY (`docs/specs/openehr/QUERY/docs/AQL/master03-syntax.adoc`
+//! lines 748–767) allows a `TERMINOLOGY()` call as — or *inside* — the
+//! right-hand operand of `matches`, "for merging explicit codes with the
+//! function results (in which case the AQL interpreter is responsible for
+//! generating a valid list of codes during semantic analysis)":
+//!
+//! ```text
+//! WHERE …/code_string matches TERMINOLOGY('expand', 'hl7.org/fhir/4.0', '<vs-url>')
+//! WHERE …/code_string matches {'http://snomed.info/id/442031002',
+//!                              TERMINOLOGY('expand', 'hl7.org/fhir/4.0', '<vs-url>')}
+//! ```
+//!
+//! This module is the semantic-analysis pre-pass that realises that merge: it
+//! resolves each `expand` call through a [`TerminologyExpander`] (the SM
+//! `I_TERMINOLOGY_SERVICE` seam — the in-process `openehr-term` bundle by
+//! default, a remote FHIR TS when configured) and rewrites the AST value list
+//! *in place* to explicit string codes, **before** planning/SQL generation. The
+//! engine planner ([`super::lower`]) then sees an ordinary `matches { … }` value
+//! list and needs no terminology awareness.
+//!
+//! Staging (blueprint §3 build-order item 5): only `expand` is merged here
+//! (stage (a)). Other `TERMINOLOGY()` forms are left untouched for the planner
+//! to reject with a typed, spec-cited error — the Boolean value-expression form
+//! (`TERMINOLOGY(…) = true`, stage (b)) and the bare-URI operand
+//! (`matches { … }`, stage (c)) — see [`super::error::AqlFeatureError`].
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use async_trait::async_trait;
+use openehr_query::ast::{
+    IdentifiedExpr, MatchesOperand, Primitive, SelectQuery, TerminologyFunction, ValueListItem,
+    WhereExpr,
+};
+
+use super::error::AqlError;
+
+/// The only `TERMINOLOGY()` operation supported inside a `matches` operand
+/// (case-insensitive): "expand: … retrieve all the codes contained in a value
+/// set as an explicit set" (master03 §TERMINOLOGY).
+const EXPAND: &str = "expand";
+
+/// The resolver seam for `TERMINOLOGY('expand', …)`: turns a `(service_api,
+/// params_uri)` pair into the explicit list of codes of the referenced value
+/// set. Implemented by the application service over the SM
+/// `I_TERMINOLOGY_SERVICE` providers.
+#[async_trait]
+pub trait TerminologyExpander: Send + Sync {
+    /// Expand the value set identified by `params_uri` via the terminology
+    /// service selected by `service_api`, returning its codes.
+    ///
+    /// # Errors
+    ///
+    /// * [`AqlError::Feature`] with `UnknownTerminologyService` — `service_api`
+    ///   names no configured service; or `TerminologyValueSetNotFound` —
+    ///   `params_uri` names no known value set (both → 400).
+    /// * [`AqlError::Exec`] with `ExecError::Terminology` — the upstream
+    ///   terminology server call failed (→ 500).
+    async fn expand(&self, service_api: &str, params_uri: &str) -> Result<Vec<String>, AqlError>;
+}
+
+/// Resolve and merge every `TERMINOLOGY('expand', …)` used as (or inside) a
+/// `matches` operand in `query`'s `WHERE` clause, rewriting the value lists in
+/// place to explicit string codes. A no-op when the query has no `WHERE` clause
+/// or no `expand` operand.
+///
+/// Each distinct `(service_api, params_uri)` is resolved exactly once. Non-
+/// `expand` `TERMINOLOGY()` operands are left untouched (the planner rejects
+/// them).
+///
+/// # Errors
+///
+/// Propagates the [`TerminologyExpander::expand`] error for the first operand
+/// that fails to resolve.
+pub async fn expand_matches(
+    query: &mut SelectQuery,
+    expander: &(impl TerminologyExpander + ?Sized),
+) -> Result<(), AqlError> {
+    let Some(where_) = query.where_.as_ref() else {
+        return Ok(());
+    };
+
+    // Pass 1 (sync): collect the distinct `expand` requests keyed by
+    // (service_api, params_uri).
+    let mut requests: BTreeSet<(String, String)> = BTreeSet::new();
+    collect(where_, &mut requests);
+    if requests.is_empty() {
+        return Ok(());
+    }
+
+    // Resolve each request exactly once (async, off the sync borrow).
+    let mut resolved: BTreeMap<(String, String), Vec<String>> = BTreeMap::new();
+    for (service_api, params_uri) in requests {
+        let codes = expander.expand(&service_api, &params_uri).await?;
+        resolved.insert((service_api, params_uri), codes);
+    }
+
+    // Pass 2 (sync): splice the resolved codes into the value lists.
+    if let Some(where_) = query.where_.as_mut() {
+        rewrite(where_, &resolved);
+    }
+    Ok(())
+}
+
+/// Whether a `TERMINOLOGY()` call is an `expand` operation (case-insensitive).
+fn is_expand(tf: &TerminologyFunction) -> bool {
+    tf.operation.eq_ignore_ascii_case(EXPAND)
+}
+
+/// The resolution key for an `expand` call: `(service_api, params_uri)`.
+fn key(tf: &TerminologyFunction) -> (String, String) {
+    (tf.arg2.clone(), tf.arg3.clone())
+}
+
+/// Collect the distinct `expand` requests reachable from a `WHERE` sub-tree.
+fn collect(expr: &WhereExpr, out: &mut BTreeSet<(String, String)>) {
+    match expr {
+        WhereExpr::Identified(IdentifiedExpr::Matches { operand, .. }) => match operand {
+            MatchesOperand::Terminology(tf) if is_expand(tf) => {
+                out.insert(key(tf));
+            }
+            MatchesOperand::ValueList(items) => {
+                for tf in items.iter().filter_map(expand_item) {
+                    out.insert(key(tf));
+                }
+            }
+            MatchesOperand::Terminology(_) | MatchesOperand::Uri(_) => {}
+        },
+        WhereExpr::Identified(_) => {}
+        WhereExpr::Not(w) => collect(w, out),
+        WhereExpr::And(a, b) | WhereExpr::Or(a, b) => {
+            collect(a, out);
+            collect(b, out);
+        }
+    }
+}
+
+/// A value-list item that is an `expand` `TERMINOLOGY()` call, if it is one.
+fn expand_item(item: &ValueListItem) -> Option<&TerminologyFunction> {
+    match item {
+        ValueListItem::Terminology(tf) if is_expand(tf) => Some(tf),
+        _ => None,
+    }
+}
+
+/// Rewrite the value lists of a `WHERE` sub-tree, replacing resolved `expand`
+/// operands with explicit string codes.
+fn rewrite(expr: &mut WhereExpr, resolved: &BTreeMap<(String, String), Vec<String>>) {
+    match expr {
+        WhereExpr::Identified(IdentifiedExpr::Matches { operand, .. }) => {
+            rewrite_operand(operand, resolved);
+        }
+        WhereExpr::Identified(_) => {}
+        WhereExpr::Not(w) => rewrite(w, resolved),
+        WhereExpr::And(a, b) | WhereExpr::Or(a, b) => {
+            rewrite(a, resolved);
+            rewrite(b, resolved);
+        }
+    }
+}
+
+/// Rewrite a single `matches` operand: a standalone `expand` call becomes a
+/// value list of its codes; a value list has each `expand` item spliced into
+/// its codes (explicit codes and non-`expand` items preserved in order).
+fn rewrite_operand(
+    operand: &mut MatchesOperand,
+    resolved: &BTreeMap<(String, String), Vec<String>>,
+) {
+    match operand {
+        MatchesOperand::Terminology(tf) if is_expand(tf) => {
+            *operand = MatchesOperand::ValueList(code_items(resolved.get(&key(tf))));
+        }
+        MatchesOperand::ValueList(items) => {
+            let taken = std::mem::take(items);
+            let mut rebuilt = Vec::with_capacity(taken.len());
+            for item in taken {
+                match expand_item(&item) {
+                    Some(tf) => rebuilt.extend(code_items(resolved.get(&key(tf)))),
+                    None => rebuilt.push(item),
+                }
+            }
+            *items = rebuilt;
+        }
+        MatchesOperand::Terminology(_) | MatchesOperand::Uri(_) => {}
+    }
+}
+
+/// The resolved codes as string-primitive value-list items (empty when the
+/// expansion produced no codes — the `matches` then matches nothing).
+fn code_items(codes: Option<&Vec<String>>) -> Vec<ValueListItem> {
+    codes
+        .into_iter()
+        .flatten()
+        .map(|c| ValueListItem::Primitive(Primitive::String(c.clone())))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openehr_query::parser::parse_str;
+
+    /// A canned expander: every `expand` returns a fixed code list.
+    struct Fixed(Vec<String>);
+
+    #[async_trait]
+    impl TerminologyExpander for Fixed {
+        async fn expand(&self, _api: &str, _uri: &str) -> Result<Vec<String>, AqlError> {
+            Ok(self.0.clone())
+        }
+    }
+
+    fn matches_values(q: &SelectQuery) -> Vec<String> {
+        // Descend to the single WHERE matches operand and read its value list.
+        let Some(WhereExpr::Identified(IdentifiedExpr::Matches { operand, .. })) =
+            q.where_.as_ref()
+        else {
+            panic!("expected a WHERE matches");
+        };
+        let MatchesOperand::ValueList(items) = operand else {
+            panic!("expected a value list after expansion, got {operand:?}");
+        };
+        items
+            .iter()
+            .map(|i| match i {
+                ValueListItem::Primitive(Primitive::String(s)) => s.clone(),
+                other => panic!("expected a string primitive, got {other:?}"),
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn standalone_expand_becomes_a_value_list() {
+        let mut q = parse_str(
+            "SELECT c FROM COMPOSITION c \
+             WHERE c/category/defining_code/code_string \
+             matches TERMINOLOGY('expand', 'openehr', 'audit_change_type')",
+        )
+        .expect("parse");
+        expand_matches(&mut q, &Fixed(vec!["249".into(), "250".into()]))
+            .await
+            .expect("expand");
+        assert_eq!(matches_values(&q), vec!["249".to_owned(), "250".to_owned()]);
+    }
+
+    #[tokio::test]
+    async fn mixed_list_merges_explicit_and_expanded_codes_in_order() {
+        let mut q = parse_str(
+            "SELECT c FROM COMPOSITION c \
+             WHERE c/category/defining_code/code_string \
+             matches {'X', TERMINOLOGY('expand', 'openehr', 'g'), 'Y'}",
+        )
+        .expect("parse");
+        expand_matches(&mut q, &Fixed(vec!["A".into(), "B".into()]))
+            .await
+            .expect("expand");
+        assert_eq!(
+            matches_values(&q),
+            vec![
+                "X".to_owned(),
+                "A".to_owned(),
+                "B".to_owned(),
+                "Y".to_owned()
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn no_terminology_operand_is_a_no_op() {
+        let src = "SELECT c FROM COMPOSITION c \
+             WHERE c/category/defining_code/code_string matches {'249', '250'}";
+        let mut q = parse_str(src).expect("parse");
+        let before = q.clone();
+        expand_matches(&mut q, &Fixed(vec!["ignored".into()]))
+            .await
+            .expect("no-op");
+        assert_eq!(
+            q, before,
+            "a query with no expand operand must be untouched"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_expansion_yields_an_empty_value_list() {
+        let mut q = parse_str(
+            "SELECT c FROM COMPOSITION c \
+             WHERE c/category/defining_code/code_string \
+             matches TERMINOLOGY('expand', 'openehr', 'g')",
+        )
+        .expect("parse");
+        expand_matches(&mut q, &Fixed(vec![]))
+            .await
+            .expect("expand");
+        assert!(matches_values(&q).is_empty());
+    }
+}

--- a/app/ehrbase/src/lib.rs
+++ b/app/ehrbase/src/lib.rs
@@ -13,3 +13,4 @@ pub mod signing;
 pub mod storage;
 pub mod system_log;
 pub mod telemetry;
+pub mod terminology;

--- a/app/ehrbase/src/main.rs
+++ b/app/ehrbase/src/main.rs
@@ -156,6 +156,22 @@ async fn serve() -> anyhow::Result<()> {
         service = service.with_audit(sender);
     }
 
+    // Opt-in external FHIR terminology provider (B4): when a deployment
+    // configures one, wire it so AQL `TERMINOLOGY('expand', 'hl7.org/fhir/…',
+    // …)` resolves against it; otherwise AQL terminology expansion routes only
+    // to the in-process `openehr-term` bundle.
+    match ehrbase::terminology::ExternalTerminologyConfig::load()
+        .context("loading external-terminology configuration")?
+        .default_provider()
+    {
+        Some(Ok(provider)) => {
+            tracing::info!("external FHIR terminology provider configured");
+            service = service.with_external_terminology(Arc::new(provider));
+        }
+        Some(Err(e)) => return Err(e).context("initialising the external terminology provider"),
+        None => {}
+    }
+
     // Build the RBAC gate. Only wired when authentication is enabled (the gate
     // runs after authentication); `from_config` yields `None` when RBAC is
     // disabled, restoring authentication-only behaviour.

--- a/app/ehrbase/src/service/api/terminology.rs
+++ b/app/ehrbase/src/service/api/terminology.rs
@@ -9,10 +9,82 @@ use std::collections::BTreeMap;
 use async_trait::async_trait;
 
 use ehrbase_sm::SmError;
-use ehrbase_sm::{TerminologyDescription, TerminologyExtract, TerminologyService};
+use ehrbase_sm::{CallStatusType, TerminologyDescription, TerminologyExtract, TerminologyService};
 
+use crate::aql::TerminologyExpander;
+use crate::aql::error::{AqlError, AqlFeatureError, ExecError};
 use crate::service::EhrbaseService;
+use crate::service::codes::OPENEHR;
 use crate::service::terminology as term;
+
+/// The `service_api` identifier for the in-process openEHR terminology bundle.
+///
+/// PORT NOTE (B4): master03 §TERMINOLOGY's `service_api` examples are all
+/// *external* servers (FHIR, Ocean, Better, Apelon) and the spec defines it as
+/// "an identifier for the kind/flavour of terminology service" with an
+/// implementation-defined value set — there is no standard identifier for a
+/// local in-process bundle. We adopt the openEHR terminology's own id
+/// `"openehr"`, and route the value set (`params_uri`) as a group / code-set id
+/// within that terminology.
+const BUNDLE_SERVICE_API: &str = "openehr";
+
+/// Whether a `service_api` names a FHIR terminology service (any FHIR version):
+/// the master03 examples are `hl7.org/fhir/4.0`, `/3.0`, `/1.0`, `/r4`.
+fn is_fhir_service_api(service_api: &str) -> bool {
+    service_api.to_ascii_lowercase().starts_with("hl7.org/fhir")
+}
+
+#[async_trait]
+impl TerminologyExpander for EhrbaseService {
+    /// Resolve `TERMINOLOGY('expand', service_api, params_uri)` to the value
+    /// set's codes: route by `service_api` (FHIR → the configured remote
+    /// provider; `"openehr"` → the in-process bundle), fetch the expansion via
+    /// the SM `get_value_set`, and return its code keys.
+    ///
+    /// A missing FHIR provider or an unrecognised `service_api` is a 400
+    /// ([`AqlFeatureError::UnknownTerminologyService`]); an unknown value set is
+    /// a 400 ([`AqlFeatureError::TerminologyValueSetNotFound`]); any other
+    /// (server/transport) failure is a 500 ([`ExecError::Terminology`]).
+    async fn expand(&self, service_api: &str, params_uri: &str) -> Result<Vec<String>, AqlError> {
+        let extract = if is_fhir_service_api(service_api) {
+            let provider = self.external_terminology.as_ref().ok_or_else(|| {
+                AqlFeatureError::UnknownTerminologyService(format!(
+                    "{service_api} (no FHIR terminology server configured)"
+                ))
+            })?;
+            // The FHIR provider ignores `terminology_id` for `$expand`; the
+            // value set is identified by `params_uri` (its URL).
+            provider.get_value_set(service_api, params_uri).await
+        } else if service_api == BUNDLE_SERVICE_API {
+            // The bundle's value sets live under the `"openehr"` terminology;
+            // `params_uri` is the group / code-set id.
+            term::get_value_set(OPENEHR, params_uri)
+        } else {
+            return Err(AqlFeatureError::UnknownTerminologyService(service_api.to_owned()).into());
+        };
+        let extract = extract.map_err(|e| map_expand_error(e, service_api, params_uri))?;
+        Ok(extract
+            .terms
+            .map(|terms| terms.into_keys().collect())
+            .unwrap_or_default())
+    }
+}
+
+/// Map a terminology-service [`SmError`] raised during `expand` onto the AQL
+/// error taxonomy: a "does not exist" status is a bad query (400 — the value
+/// set is unknown); anything else is an upstream server fault (500).
+fn map_expand_error(e: SmError, service_api: &str, params_uri: &str) -> AqlError {
+    match e.status {
+        CallStatusType::VersionedObjectDoesNotExist => {
+            AqlFeatureError::TerminologyValueSetNotFound {
+                service_api: service_api.to_owned(),
+                value_set: params_uri.to_owned(),
+            }
+            .into()
+        }
+        _ => ExecError::Terminology(e.message).into(),
+    }
+}
 
 #[async_trait]
 impl TerminologyService for EhrbaseService {

--- a/app/ehrbase/src/service/aql_query.rs
+++ b/app/ehrbase/src/service/aql_query.rs
@@ -42,13 +42,21 @@ impl EhrbaseService {
         request: &AqlQueryRequest,
     ) -> Result<QueryOutcome, SmError> {
         let plan_start = Instant::now();
-        let ast = match parse_str(aql) {
+        let mut ast = match parse_str(aql) {
             Ok(ast) => ast,
             Err(e) => {
                 count_query("analysis_error");
                 return Err(SmError::precondition(format!("invalid AQL: {e}")));
             }
         };
+        // Semantic-analysis pre-pass (B4 stage (a)): resolve every
+        // `TERMINOLOGY('expand', …)` used in a `matches` operand through the
+        // terminology-service seam and merge the codes into the value list,
+        // before planning/SQL generation (master03 lines 756–759).
+        if let Err(e) = aql::expand_matches(&mut ast, self).await {
+            count_query(plan_outcome(&e));
+            return Err(map_plan_error(e));
+        }
         let params = build_params(request);
         let ir = match aql::plan(&ast, &params) {
             Ok(ir) => ir,
@@ -244,6 +252,7 @@ fn map_exec_error(e: AqlError) -> SmError {
     match e {
         AqlError::Exec(ExecError::Database(db)) => SmError::exception(db.to_string()),
         AqlError::Exec(ExecError::Assembly(a)) => SmError::exception(a.to_string()),
+        AqlError::Exec(ExecError::Terminology(msg)) => SmError::exception(msg),
         AqlError::Feature(_) | AqlError::Analysis(_) | AqlError::Sql(_) => {
             SmError::precondition(e.to_string())
         }

--- a/app/ehrbase/src/service/mod.rs
+++ b/app/ehrbase/src/service/mod.rs
@@ -76,6 +76,13 @@ pub struct EhrbaseService {
     /// through the [`SystemLog`](ehrbase_sm::SystemLog) impl in
     /// `crate::system_log`.
     pub(crate) audit: Option<AuditSender>,
+    /// The optional external terminology provider (FHIR R4), selected when a
+    /// deployment opts in ([`crate::terminology::ExternalTerminologyConfig`]).
+    /// Used by AQL `TERMINOLOGY('expand', 'hl7.org/fhir/…', …)` resolution (B4);
+    /// `None` keeps AQL terminology expansion on the in-process `openehr-term`
+    /// bundle only. Read through the [`TerminologyExpander`](crate::aql::TerminologyExpander)
+    /// impl in `service::api::terminology`.
+    pub(crate) external_terminology: Option<Arc<crate::terminology::FhirTerminologyProvider>>,
 }
 
 impl EhrbaseService {
@@ -89,6 +96,7 @@ impl EhrbaseService {
             web_templates: WebTemplateCache::default(),
             signer: Arc::new(Signer::digest_default()),
             audit: None,
+            external_terminology: None,
         }
     }
 
@@ -113,6 +121,19 @@ impl EhrbaseService {
     #[must_use]
     pub fn with_audit(mut self, sender: AuditSender) -> Self {
         self.audit = Some(sender);
+        self
+    }
+
+    /// Install an external FHIR R4 terminology provider (opt-in), used by AQL
+    /// `TERMINOLOGY('expand', 'hl7.org/fhir/…', …)` resolution (B4). Without it,
+    /// AQL terminology expansion routes only to the in-process `openehr-term`
+    /// bundle (`service_api = "openehr"`).
+    #[must_use]
+    pub fn with_external_terminology(
+        mut self,
+        provider: Arc<crate::terminology::FhirTerminologyProvider>,
+    ) -> Self {
+        self.external_terminology = Some(provider);
         self
     }
 

--- a/app/ehrbase/src/terminology/config.rs
+++ b/app/ehrbase/src/terminology/config.rs
@@ -1,0 +1,255 @@
+//! External-terminology configuration (`figment`), matching the shape in
+//! `docs/terminology-validation.md` §4.
+//!
+//! Loaded from defaults ← optional TOML file (`EHRBASE_VALIDATION_CONFIG`) ←
+//! `EHRBASE_VALIDATION_EXTERNAL_TERMINOLOGY_`-prefixed environment (nested keys
+//! use `__`, e.g. `..._PROVIDERS__DEFAULT__URL`) — the same env grammar the
+//! Docker compose recipe in `docs/design/terminology-server-integration.md` §3
+//! writes.
+//!
+//! Provider selection is **openEHR-bundle-by-default, FHIR opt-in**: with
+//! [`ExternalTerminologyConfig::enabled`] `false` (the default, matching
+//! `EHRBase`) no remote provider is built and composition validation stays on
+//! the in-process `openehr-term` bundle; a FHIR provider is materialised only
+//! when a deployment opts in.
+
+use std::collections::BTreeMap;
+
+use figment::Figment;
+use figment::providers::{Env, Format, Serialized, Toml};
+use serde::{Deserialize, Serialize};
+
+use ehrbase_sm::SmError;
+
+use super::fhir::FhirTerminologyProvider;
+
+/// Default per-provider connect timeout (ms).
+const DEFAULT_CONNECT_TIMEOUT_MS: u64 = 2_000;
+/// Default per-provider request timeout (ms).
+const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 10_000;
+/// The provider name selected by [`ExternalTerminologyConfig::default_provider`]
+/// when several are configured.
+const DEFAULT_PROVIDER_NAME: &str = "default";
+
+/// External-terminology validation configuration (`[validation.external_terminology]`).
+///
+/// Defaults are the `EHRBase`-matching off state: `enabled = false`,
+/// `fail_on_error = false`, no providers.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ExternalTerminologyConfig {
+    /// Whether external-terminology validation is active. When `false` (the
+    /// default, matching `EHRBase`), no remote provider is built.
+    #[serde(default)]
+    pub enabled: bool,
+    /// On a terminology-server/connectivity error: `true` = reject the
+    /// composition (fail-closed); `false` = accept it (fail-open, matching
+    /// `EHRBase`'s default). Consumed by the P15 validation walker — the raw
+    /// provider always surfaces the error; this flag decides how the caller
+    /// treats it.
+    #[serde(default)]
+    pub fail_on_error: bool,
+    /// The configured terminology-server providers, keyed by name.
+    #[serde(default)]
+    pub providers: BTreeMap<String, FhirProviderConfig>,
+}
+
+/// The kind of terminology server. Only FHIR R4 is supported, matching the
+/// reference (`docs/terminology-validation.md` §4).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderKind {
+    /// A FHIR R4 terminology server (`$validate-code`/`$expand`/`$subsumes`/
+    /// `$lookup`).
+    #[default]
+    Fhir,
+}
+
+/// The FHIR operation used for value-set membership (`value_set_validate`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FhirOperation {
+    /// FHIR `ValueSet/$validate-code` — a direct yes/no (least payload).
+    #[default]
+    ValidateCode,
+    /// FHIR `ValueSet/$expand` + a membership test — the fallback for servers
+    /// that lack `$validate-code`.
+    Expand,
+}
+
+/// Configuration for a single FHIR R4 terminology-server provider.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FhirProviderConfig {
+    /// Server kind (`type = "fhir"`).
+    #[serde(rename = "type", default)]
+    pub kind: ProviderKind,
+    /// FHIR R4 base URL, e.g. `https://r4.ontoserver.csiro.au/fhir`.
+    pub url: String,
+    /// The membership operation for `value_set_validate` (default
+    /// `validate_code`).
+    #[serde(default)]
+    pub operation: FhirOperation,
+    /// TCP connect timeout (ms).
+    #[serde(default = "default_connect_timeout_ms")]
+    pub connect_timeout_ms: u64,
+    /// Overall request timeout (ms).
+    #[serde(default = "default_request_timeout_ms")]
+    pub request_timeout_ms: u64,
+    /// Optional name of an `OAuth2` client-credentials client to authenticate to
+    /// the TS with.
+    ///
+    /// PORT NOTE: `OAuth2` client-credentials + mutual-TLS to the TS
+    /// (`docs/terminology-validation.md` §3) are a follow-up on top of this
+    /// task's core `$validate-code`/`$expand`/`$subsumes`/`$lookup` provider;
+    /// the field is accepted so config written for the full design parses, but
+    /// no bearer token is attached yet. A configured value that would silently
+    /// send unauthenticated requests is surfaced at build time
+    /// ([`FhirTerminologyProvider::new`]).
+    #[serde(default)]
+    pub oauth2_client: Option<String>,
+}
+
+const fn default_connect_timeout_ms() -> u64 {
+    DEFAULT_CONNECT_TIMEOUT_MS
+}
+
+const fn default_request_timeout_ms() -> u64 {
+    DEFAULT_REQUEST_TIMEOUT_MS
+}
+
+impl ExternalTerminologyConfig {
+    /// Load configuration: defaults, then an optional TOML file (path in
+    /// `EHRBASE_VALIDATION_CONFIG`), then
+    /// `EHRBASE_VALIDATION_EXTERNAL_TERMINOLOGY_`-prefixed environment variables
+    /// (nested keys use `__`).
+    ///
+    /// # Errors
+    /// Returns a [`figment::Error`] if a value fails to parse.
+    #[allow(clippy::result_large_err)] // figment::Error is large by design
+    pub fn load() -> Result<Self, figment::Error> {
+        let mut fig = Figment::from(Serialized::defaults(Self::default()));
+        if let Ok(path) = std::env::var("EHRBASE_VALIDATION_CONFIG") {
+            fig = fig.merge(Toml::file(path));
+        }
+        fig.merge(Env::prefixed("EHRBASE_VALIDATION_EXTERNAL_TERMINOLOGY_").split("__"))
+            .extract()
+    }
+
+    /// Build the named provider, or `None` when external terminology is disabled
+    /// or no provider carries that name.
+    ///
+    /// # Errors
+    /// [`SmError`] if the named provider's configuration is invalid (empty URL
+    /// or an un-buildable HTTP client).
+    #[must_use]
+    pub fn provider(&self, name: &str) -> Option<Result<FhirTerminologyProvider, SmError>> {
+        if !self.enabled {
+            return None;
+        }
+        self.providers
+            .get(name)
+            .map(|cfg| FhirTerminologyProvider::new(name, cfg))
+    }
+
+    /// Build the default provider: the one named `default`, or the single
+    /// configured provider when exactly one exists. `None` when external
+    /// terminology is disabled or the selection is ambiguous/empty.
+    ///
+    /// # Errors
+    /// [`SmError`] if the selected provider's configuration is invalid.
+    #[must_use]
+    pub fn default_provider(&self) -> Option<Result<FhirTerminologyProvider, SmError>> {
+        if !self.enabled {
+            return None;
+        }
+        let (name, cfg) = self
+            .providers
+            .get_key_value(DEFAULT_PROVIDER_NAME)
+            .or_else(|| {
+                // Exactly one configured provider → use it unambiguously.
+                let mut it = self.providers.iter();
+                match (it.next(), it.next()) {
+                    (Some(only), None) => Some(only),
+                    _ => None,
+                }
+            })?;
+        Some(FhirTerminologyProvider::new(name, cfg))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_by_default() {
+        let c = ExternalTerminologyConfig::default();
+        assert!(!c.enabled);
+        assert!(!c.fail_on_error);
+        assert!(c.providers.is_empty());
+        assert!(c.default_provider().is_none());
+    }
+
+    #[test]
+    #[allow(clippy::result_large_err)] // figment::Jail closure signature
+    fn env_builds_a_provider() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env("EHRBASE_VALIDATION_EXTERNAL_TERMINOLOGY_ENABLED", "true");
+            jail.set_env(
+                "EHRBASE_VALIDATION_EXTERNAL_TERMINOLOGY_PROVIDERS__DEFAULT__TYPE",
+                "fhir",
+            );
+            jail.set_env(
+                "EHRBASE_VALIDATION_EXTERNAL_TERMINOLOGY_PROVIDERS__DEFAULT__URL",
+                "http://terminology:8090/fhir",
+            );
+            let c = ExternalTerminologyConfig::load().expect("load");
+            assert!(c.enabled);
+            let cfg = c.providers.get("default").expect("default provider");
+            assert_eq!(cfg.kind, ProviderKind::Fhir);
+            assert_eq!(cfg.url, "http://terminology:8090/fhir");
+            assert_eq!(cfg.operation, FhirOperation::ValidateCode);
+            assert_eq!(cfg.connect_timeout_ms, DEFAULT_CONNECT_TIMEOUT_MS);
+            // Selection materialises the provider.
+            assert!(c.default_provider().expect("selected").is_ok());
+            Ok(())
+        });
+    }
+
+    #[test]
+    #[allow(clippy::result_large_err)] // figment::Jail closure signature
+    fn disabled_config_selects_nothing_even_with_a_provider() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(
+                "EHRBASE_VALIDATION_EXTERNAL_TERMINOLOGY_PROVIDERS__DEFAULT__URL",
+                "http://terminology:8090/fhir",
+            );
+            let c = ExternalTerminologyConfig::load().expect("load");
+            assert!(!c.enabled);
+            assert!(c.provider("default").is_none());
+            assert!(c.default_provider().is_none());
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn empty_url_is_rejected_at_build() {
+        let mut providers = BTreeMap::new();
+        providers.insert(
+            "default".to_owned(),
+            FhirProviderConfig {
+                kind: ProviderKind::Fhir,
+                url: "   ".to_owned(),
+                operation: FhirOperation::ValidateCode,
+                connect_timeout_ms: DEFAULT_CONNECT_TIMEOUT_MS,
+                request_timeout_ms: DEFAULT_REQUEST_TIMEOUT_MS,
+                oauth2_client: None,
+            },
+        );
+        let c = ExternalTerminologyConfig {
+            enabled: true,
+            fail_on_error: false,
+            providers,
+        };
+        assert!(c.provider("default").expect("present").is_err());
+    }
+}

--- a/app/ehrbase/src/terminology/fhir.rs
+++ b/app/ehrbase/src/terminology/fhir.rs
@@ -1,0 +1,518 @@
+//! [`FhirTerminologyProvider`] — a FHIR R4 terminology-server client that
+//! implements the SM `I_TERMINOLOGY_SERVICE` trait ([`ehrbase_sm::TerminologyService`])
+//! against a remote server, over `reqwest` (rustls).
+//!
+//! Design: `docs/terminology-validation.md` §3 (the client) +
+//! `docs/design/terminology-server-integration.md` (the HAPI-FHIR/Snowstorm
+//! server it points at). SM contract:
+//! `docs/specs/openehr/SM/docs/UML/classes/i_terminology_service.adoc`.
+//!
+//! # SM call → FHIR operation mapping
+//!
+//! | SM call | FHIR R4 operation |
+//! |---|---|
+//! | `value_set_validate` | `ValueSet/$validate-code` (or `$expand` + membership) |
+//! | `get_value_set` | `ValueSet/$expand` → [`TerminologyExtract`] |
+//! | `subsumes` | `CodeSystem/$subsumes` (outcome `subsumes`) |
+//! | `has_term` / `get_term` | `CodeSystem/$lookup` |
+//!
+//! PORT NOTE (enumerating calls): `get_terminology_ids`,
+//! `get_terminology_description` and `has_terminology` have no faithful FHIR
+//! operation — a FHIR TS is a validation/expansion backend, not an enumerable
+//! openEHR terminology bundle. They keep the trait's `NotImplemented` default;
+//! the in-process `openehr-term` bundle remains the enumerable terminology.
+//!
+//! PORT NOTE (errors): a value set / terminology / code the server does not
+//! know (HTTP `404`, or `$validate-code result=false` with no membership) is a
+//! `Pre_has_*` precondition failure → [`CallStatusType::VersionedObjectDoesNotExist`]
+//! (the `404` reading, matching the bundle provider in
+//! [`crate::service::terminology`]). A transport fault (connect/read timeout,
+//! `5xx`, malformed body) → [`SmError::exception`] (`500`); the fail-open vs
+//! fail-closed decision belongs to the caller (P15 walker,
+//! `ExternalTerminologyConfig::fail_on_error`), never to the raw provider.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+use ehrbase_sm::{
+    CallStatusType, DefinedTerm, SmError, TermEntry, TerminologyDescription, TerminologyExtract,
+    TerminologyService,
+};
+
+use super::config::{FhirOperation, FhirProviderConfig};
+
+/// A FHIR R4 terminology-server client implementing the SM
+/// `I_TERMINOLOGY_SERVICE` interface against a remote server.
+#[derive(Debug, Clone)]
+pub struct FhirTerminologyProvider {
+    client: reqwest::Client,
+    /// The FHIR base URL, trailing `/` stripped (e.g. `http://host:8090/fhir`).
+    base: String,
+    /// The membership operation used by `value_set_validate`.
+    operation: FhirOperation,
+    /// The configured provider name (for error/log context).
+    name: String,
+}
+
+impl FhirTerminologyProvider {
+    /// Build a provider from its configuration.
+    ///
+    /// # Errors
+    /// [`SmError::exception`] if the URL is empty or the `reqwest` client cannot
+    /// be built (e.g. TLS backend init failure).
+    pub fn new(name: &str, cfg: &FhirProviderConfig) -> Result<Self, SmError> {
+        let base = cfg.url.trim().trim_end_matches('/').to_owned();
+        if base.is_empty() {
+            return Err(SmError::exception(format!(
+                "terminology provider '{name}' has an empty url"
+            )));
+        }
+        let client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_millis(cfg.connect_timeout_ms))
+            .timeout(Duration::from_millis(cfg.request_timeout_ms))
+            .build()
+            .map_err(|e| {
+                SmError::exception(format!(
+                    "building terminology client for provider '{name}': {e}"
+                ))
+            })?;
+        Ok(Self {
+            client,
+            base,
+            operation: cfg.operation,
+            name: name.to_owned(),
+        })
+    }
+
+    /// GET a FHIR operation with query params, returning the parsed body.
+    ///
+    /// `404`/`410` → `Ok(None)` (the resource is unknown → a precondition
+    /// caller maps to `VersionedObjectDoesNotExist`); any other non-2xx or a
+    /// transport/parse fault → `Err(SmError::exception)`.
+    async fn get<T: for<'de> Deserialize<'de>>(
+        &self,
+        op_path: &str,
+        query: &[(&str, &str)],
+    ) -> Result<Option<T>, SmError> {
+        let mut url = reqwest::Url::parse(&format!("{}{op_path}", self.base)).map_err(|e| {
+            SmError::exception(format!(
+                "terminology provider '{}': invalid url for {op_path}: {e}",
+                self.name
+            ))
+        })?;
+        {
+            let mut pairs = url.query_pairs_mut();
+            for (k, v) in query {
+                pairs.append_pair(k, v);
+            }
+        }
+        let response = self
+            .client
+            .get(url)
+            .header(reqwest::header::ACCEPT, "application/fhir+json")
+            .send()
+            .await
+            .map_err(|e| self.transport_error(op_path, &e))?;
+        let status = response.status();
+        if status == reqwest::StatusCode::NOT_FOUND || status == reqwest::StatusCode::GONE {
+            return Ok(None);
+        }
+        if !status.is_success() {
+            return Err(SmError::exception(format!(
+                "terminology provider '{}' {op_path} returned HTTP {}",
+                self.name,
+                status.as_u16()
+            )));
+        }
+        let parsed = response.json::<T>().await.map_err(|e| {
+            SmError::exception(format!(
+                "terminology provider '{}' {op_path}: malformed FHIR response: {e}",
+                self.name
+            ))
+        })?;
+        Ok(Some(parsed))
+    }
+
+    fn transport_error(&self, op_path: &str, e: &reqwest::Error) -> SmError {
+        let kind = if e.is_timeout() {
+            "timeout"
+        } else if e.is_connect() {
+            "connect error"
+        } else {
+            "transport error"
+        };
+        SmError::exception(format!(
+            "terminology provider '{}' {op_path}: {kind}: {e}",
+            self.name
+        ))
+    }
+
+    fn not_found(&self, what: &str, id: &str) -> SmError {
+        SmError::new(
+            CallStatusType::VersionedObjectDoesNotExist,
+            format!(
+                "terminology provider '{}': {what} '{id}' not found",
+                self.name
+            ),
+        )
+    }
+
+    /// `ValueSet/$expand` → an [`FhirValueSet`], or `None` when the value set is
+    /// unknown (`404`).
+    async fn expand(&self, value_set_url: &str) -> Result<Option<FhirValueSet>, SmError> {
+        self.get("/ValueSet/$expand", &[("url", value_set_url)])
+            .await
+    }
+}
+
+#[async_trait]
+impl TerminologyService for FhirTerminologyProvider {
+    /// `value_set_validate` → FHIR `ValueSet/$validate-code` (or `$expand` +
+    /// membership when the provider is configured for `expand`).
+    ///
+    /// `terminology_id` is passed as the FHIR `system`; `value_set_id` as the
+    /// value-set `url`. An unknown value set → `VersionedObjectDoesNotExist`
+    /// (`Pre_has_terminology`); a known value set with a non-member code →
+    /// `Ok(false)`.
+    async fn value_set_validate(
+        &self,
+        terminology_id: &str,
+        value_set_id: &str,
+        candidate_code: &str,
+        _at_date: Option<String>,
+    ) -> Result<bool, SmError> {
+        if candidate_code.is_empty() {
+            return Err(SmError::precondition("candidate_code must not be empty"));
+        }
+        match self.operation {
+            FhirOperation::Expand => {
+                let vs = self
+                    .expand(value_set_id)
+                    .await?
+                    .ok_or_else(|| self.not_found("value set", value_set_id))?;
+                Ok(vs.contains_code(candidate_code))
+            }
+            FhirOperation::ValidateCode => {
+                let params: FhirParameters = self
+                    .get(
+                        "/ValueSet/$validate-code",
+                        &[
+                            ("url", value_set_id),
+                            ("system", terminology_id),
+                            ("code", candidate_code),
+                        ],
+                    )
+                    .await?
+                    .ok_or_else(|| self.not_found("value set", value_set_id))?;
+                params.result().ok_or_else(|| {
+                    SmError::exception(format!(
+                        "terminology provider '{}': $validate-code response had no 'result'",
+                        self.name
+                    ))
+                })
+            }
+        }
+    }
+
+    /// `get_value_set` → FHIR `ValueSet/$expand`, mapped to a
+    /// [`TerminologyExtract`] (one [`TermEntry`] per expansion member).
+    async fn get_value_set(
+        &self,
+        _terminology_id: &str,
+        value_set_code: &str,
+    ) -> Result<TerminologyExtract, SmError> {
+        let vs = self
+            .expand(value_set_code)
+            .await?
+            .ok_or_else(|| self.not_found("value set", value_set_code))?;
+        Ok(vs.into_extract(value_set_code))
+    }
+
+    /// `subsumes` → FHIR `CodeSystem/$subsumes` (`codeA` = `ref_code`, `codeB` =
+    /// `candidate_child_code`). True iff the outcome is `subsumes` — the SM's
+    /// *strict* subsumption (`equivalent` is excluded).
+    async fn subsumes(
+        &self,
+        terminology_id: &str,
+        ref_code: &str,
+        candidate_child_code: &str,
+    ) -> Result<bool, SmError> {
+        let params: FhirParameters = self
+            .get(
+                "/CodeSystem/$subsumes",
+                &[
+                    ("system", terminology_id),
+                    ("codeA", ref_code),
+                    ("codeB", candidate_child_code),
+                ],
+            )
+            .await?
+            .ok_or_else(|| self.not_found("terminology", terminology_id))?;
+        let outcome = params.code("outcome").ok_or_else(|| {
+            SmError::exception(format!(
+                "terminology provider '{}': $subsumes response had no 'outcome'",
+                self.name
+            ))
+        })?;
+        Ok(outcome == "subsumes")
+    }
+
+    /// `has_term` → FHIR `CodeSystem/$lookup`: `true` when the lookup resolves
+    /// (`200`), `false` when the code is unknown (`404`).
+    async fn has_term(
+        &self,
+        terminology_id: &str,
+        code: &str,
+        _at_date: Option<String>,
+    ) -> Result<bool, SmError> {
+        let found: Option<FhirParameters> = self
+            .get(
+                "/CodeSystem/$lookup",
+                &[("system", terminology_id), ("code", code)],
+            )
+            .await?;
+        Ok(found.is_some())
+    }
+
+    /// `get_term` → FHIR `CodeSystem/$lookup`, mapped to a single-term
+    /// [`TerminologyExtract`] (the `display` becomes the term text).
+    async fn get_term(
+        &self,
+        terminology_id: &str,
+        code: &str,
+        _attributes: Option<BTreeMap<String, String>>,
+        _at_date: Option<String>,
+    ) -> Result<TerminologyExtract, SmError> {
+        let params: FhirParameters = self
+            .get(
+                "/CodeSystem/$lookup",
+                &[("system", terminology_id), ("code", code)],
+            )
+            .await?
+            .ok_or_else(|| self.not_found("term", code))?;
+        let text = params.string("display").unwrap_or_else(|| code.to_owned());
+        let mut terms = BTreeMap::new();
+        terms.insert(
+            code.to_owned(),
+            TermEntry::Defined(DefinedTerm {
+                code: code.to_owned(),
+                text,
+                language: None,
+                is_preferred_term: None,
+            }),
+        );
+        Ok(TerminologyExtract {
+            terminology_id: terminology_id.to_owned(),
+            terminology_version: None,
+            terms: Some(terms),
+            relationships: None,
+            relations: None,
+        })
+    }
+
+    /// `has_value_set` → FHIR `ValueSet/$expand`: `true` when the value set
+    /// expands (`200`), `false` when it is unknown (`404`).
+    async fn has_value_set(
+        &self,
+        _terminology_id: &str,
+        value_set_code: &str,
+    ) -> Result<bool, SmError> {
+        Ok(self.expand(value_set_code).await?.is_some())
+    }
+
+    /// `get_terminology_description` → not modelled for a FHIR TS (PORT NOTE at
+    /// module head).
+    async fn get_terminology_description(
+        &self,
+        _terminology_id: &str,
+    ) -> Result<TerminologyDescription, SmError> {
+        Err(SmError::new(
+            CallStatusType::NotImplemented,
+            "a FHIR terminology server does not expose terminology descriptions",
+        ))
+    }
+}
+
+// ─── the FHIR R4 wire subset (only what these operations read) ───────────────
+
+/// A FHIR `Parameters` resource (the `$validate-code`/`$subsumes`/`$lookup`
+/// response envelope) — only the fields these operations read.
+#[derive(Debug, Clone, Deserialize)]
+struct FhirParameters {
+    #[serde(default)]
+    parameter: Vec<FhirParameter>,
+}
+
+/// One `Parameters.parameter` entry (only the value kinds we consume).
+#[derive(Debug, Clone, Deserialize)]
+struct FhirParameter {
+    name: String,
+    #[serde(rename = "valueBoolean")]
+    value_boolean: Option<bool>,
+    #[serde(rename = "valueString")]
+    value_string: Option<String>,
+    #[serde(rename = "valueCode")]
+    value_code: Option<String>,
+}
+
+impl FhirParameters {
+    /// The `result` boolean of a `$validate-code` response.
+    fn result(&self) -> Option<bool> {
+        self.parameter
+            .iter()
+            .find(|p| p.name == "result")
+            .and_then(|p| p.value_boolean)
+    }
+
+    /// A named `valueCode` parameter (e.g. `$subsumes` `outcome`).
+    fn code(&self, name: &str) -> Option<&str> {
+        self.parameter
+            .iter()
+            .find(|p| p.name == name)
+            .and_then(|p| p.value_code.as_deref())
+    }
+
+    /// A named `valueString` parameter (e.g. `$lookup` `display`).
+    fn string(&self, name: &str) -> Option<String> {
+        self.parameter
+            .iter()
+            .find(|p| p.name == name)
+            .and_then(|p| p.value_string.clone())
+    }
+}
+
+/// A FHIR `ValueSet` resource with an expansion — only the expansion members.
+#[derive(Debug, Clone, Deserialize)]
+struct FhirValueSet {
+    expansion: Option<FhirExpansion>,
+}
+
+/// `ValueSet.expansion`.
+#[derive(Debug, Clone, Deserialize)]
+struct FhirExpansion {
+    #[serde(default)]
+    contains: Vec<FhirContains>,
+}
+
+/// `ValueSet.expansion.contains` (hierarchical: may nest further members).
+#[derive(Debug, Clone, Deserialize)]
+struct FhirContains {
+    code: Option<String>,
+    display: Option<String>,
+    #[serde(default)]
+    contains: Vec<FhirContains>,
+}
+
+impl FhirValueSet {
+    /// Whether `code` appears anywhere in the (possibly hierarchical) expansion.
+    fn contains_code(&self, code: &str) -> bool {
+        self.expansion
+            .as_ref()
+            .is_some_and(|e| e.contains.iter().any(|c| c.contains_code(code)))
+    }
+
+    /// Flatten the expansion into a [`TerminologyExtract`] keyed by code.
+    fn into_extract(self, terminology_id: &str) -> TerminologyExtract {
+        let mut terms = BTreeMap::new();
+        if let Some(expansion) = self.expansion {
+            for c in &expansion.contains {
+                c.collect(&mut terms);
+            }
+        }
+        TerminologyExtract {
+            terminology_id: terminology_id.to_owned(),
+            terminology_version: None,
+            terms: if terms.is_empty() { None } else { Some(terms) },
+            relationships: None,
+            relations: None,
+        }
+    }
+}
+
+impl FhirContains {
+    fn contains_code(&self, code: &str) -> bool {
+        self.code.as_deref() == Some(code) || self.contains.iter().any(|c| c.contains_code(code))
+    }
+
+    fn collect(&self, out: &mut BTreeMap<String, TermEntry>) {
+        if let Some(code) = &self.code {
+            let entry = match &self.display {
+                Some(text) => TermEntry::Defined(DefinedTerm {
+                    code: code.clone(),
+                    text: text.clone(),
+                    language: None,
+                    is_preferred_term: None,
+                }),
+                None => TermEntry::Bare(ehrbase_sm::TermCode { code: code.clone() }),
+            };
+            out.insert(code.clone(), entry);
+        }
+        for child in &self.contains {
+            child.collect(out);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_params(json: &str) -> FhirParameters {
+        serde_json::from_str(json).expect("parse Parameters")
+    }
+
+    #[test]
+    fn validate_code_result_extracted() {
+        let p = parse_params(
+            r#"{"resourceType":"Parameters","parameter":[
+                {"name":"result","valueBoolean":true},
+                {"name":"display","valueString":"Buccal"}]}"#,
+        );
+        assert_eq!(p.result(), Some(true));
+        assert_eq!(p.string("display").as_deref(), Some("Buccal"));
+    }
+
+    #[test]
+    fn subsumes_outcome_extracted() {
+        let p = parse_params(
+            r#"{"resourceType":"Parameters","parameter":[
+                {"name":"outcome","valueCode":"subsumes"}]}"#,
+        );
+        assert_eq!(p.code("outcome"), Some("subsumes"));
+    }
+
+    #[test]
+    fn expansion_membership_and_flattening() {
+        let vs: FhirValueSet = serde_json::from_str(
+            r#"{"resourceType":"ValueSet","expansion":{"contains":[
+                {"system":"s","code":"B","display":"Buccal"},
+                {"system":"s","code":"L","contains":[
+                    {"system":"s","code":"O","display":"Occlusal"}]}]}}"#,
+        )
+        .expect("parse ValueSet");
+        assert!(vs.contains_code("B"));
+        assert!(vs.contains_code("O")); // nested
+        assert!(!vs.contains_code("Z"));
+        let ext = vs.into_extract("http://example/vs/surface");
+        let terms = ext.terms.expect("terms");
+        assert_eq!(terms.len(), 3);
+        assert!(matches!(terms.get("L"), Some(TermEntry::Bare(_))));
+        assert!(matches!(terms.get("B"), Some(TermEntry::Defined(_))));
+    }
+
+    #[test]
+    fn empty_url_rejected() {
+        let cfg = FhirProviderConfig {
+            kind: super::super::config::ProviderKind::Fhir,
+            url: "  ".to_owned(),
+            operation: FhirOperation::ValidateCode,
+            connect_timeout_ms: 100,
+            request_timeout_ms: 100,
+            oauth2_client: None,
+        };
+        assert!(FhirTerminologyProvider::new("p", &cfg).is_err());
+    }
+}

--- a/app/ehrbase/src/terminology/mod.rs
+++ b/app/ehrbase/src/terminology/mod.rs
@@ -1,0 +1,19 @@
+//! External terminology-server integration (B4): the FHIR R4 terminology
+//! **client** the composition validator uses for external value-set bindings.
+//!
+//! - [`config`] — the `figment` configuration
+//!   (`docs/terminology-validation.md` §4); external terminology is **off by
+//!   default** (openEHR-bundle-only), FHIR is opt-in.
+//! - [`fhir`] — [`FhirTerminologyProvider`], a remote FHIR R4 TS client that
+//!   implements the SM `I_TERMINOLOGY_SERVICE` trait
+//!   ([`ehrbase_sm::TerminologyService`]).
+//!
+//! The in-process `openehr-term` bundle ([`crate::service::terminology`])
+//! stays the local default provider; this module adds the *remote* provider
+//! selected when a deployment configures a FHIR terminology server.
+
+pub mod config;
+pub mod fhir;
+
+pub use config::{ExternalTerminologyConfig, FhirOperation, FhirProviderConfig, ProviderKind};
+pub use fhir::FhirTerminologyProvider;

--- a/app/ehrbase/tests/service_aql_terminology.rs
+++ b/app/ehrbase/tests/service_aql_terminology.rs
@@ -1,0 +1,346 @@
+//! End-to-end AQL `TERMINOLOGY('expand', …)` tests (B4 stage (a)) against a real
+//! PostgreSQL 18 (testcontainers): seed COMPOSITIONs with a coded ELEMENT leaf,
+//! then run `matches TERMINOLOGY('expand', …)` / `matches {…, TERMINOLOGY(…)}`
+//! through the `QueryService` seam and assert the expansion is merged into the
+//! generated `IN (…)` predicate.
+//!
+//! Two providers are exercised with no network:
+//! * the in-process `openehr-term` **bundle** (`service_api = "openehr"`,
+//!   `params_uri` = a group id) — group codes as the value set;
+//! * a **FHIR R4** terminology server faked by `wiremock`
+//!   (`service_api = "hl7.org/fhir/4.0"`, `ValueSet/$expand`).
+//!
+//! Spec: master03 §TERMINOLOGY (lines 748–767) + the matches-merge note (lines
+//! 756–759).
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::doc_markdown,
+    clippy::too_many_lines
+)]
+
+use std::sync::Arc;
+
+use serde_json::{Value, json};
+use sqlx::{AssertSqlSafe, Connection, PgConnection, PgPool};
+use testcontainers::runners::AsyncRunner;
+use testcontainers::{ContainerAsync, ImageExt};
+use testcontainers_modules::postgres::Postgres;
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use openehr_base::prelude::TerminologyCode;
+use openehr_rm::prelude::PartyProxy;
+
+use ehrbase::db::{self, DbSettings};
+use ehrbase::service::EhrbaseService;
+use ehrbase::terminology::{
+    FhirOperation, FhirProviderConfig, FhirTerminologyProvider, ProviderKind,
+};
+use ehrbase_sm::types::{UpdateAudit, UpdateVersion};
+use ehrbase_sm::{
+    AqlQueryRequest, CallStatusType, EhrCompositionService, EhrService, QueryService,
+};
+
+const OBS_ARCHETYPE: &str = "openEHR-EHR-OBSERVATION.minimal.v1";
+/// The coded leaf path (mirrors the DV_QUANTITY leaf in `service_aql.rs`, but at
+/// `.../value/defining_code/code_string` — the master03 example path).
+const CODE_PATH: &str =
+    "data[at0001]/events[at0002]/data[at0003]/items[at0004]/value/defining_code/code_string";
+
+struct Pg {
+    #[allow(dead_code)]
+    container: ContainerAsync<Postgres>,
+    host: String,
+    port: u16,
+}
+
+impl Pg {
+    async fn start() -> Self {
+        let container = Postgres::default()
+            .with_tag("18")
+            .start()
+            .await
+            .expect("start postgres:18 (is Docker running?)");
+        let host = container.get_host().await.expect("host").to_string();
+        let port = container.get_host_port_ipv4(5432).await.expect("port");
+        Self {
+            container,
+            host,
+            port,
+        }
+    }
+
+    async fn migrated_pool(&self, name: &str) -> PgPool {
+        let admin = format!(
+            "postgres://postgres:postgres@{}:{}/postgres",
+            self.host, self.port
+        );
+        let mut conn = PgConnection::connect(&admin).await.expect("admin connect");
+        sqlx::raw_sql(AssertSqlSafe(format!("CREATE DATABASE {name}")))
+            .execute(&mut conn)
+            .await
+            .expect("create db");
+        let settings = DbSettings::new(format!(
+            "postgres://postgres:postgres@{}:{}/{name}",
+            self.host, self.port
+        ));
+        let pool = db::connect(&settings).await.expect("pool");
+        db::run_migrations(&pool).await.expect("migrate");
+        pool
+    }
+}
+
+/// An `openehr` terminology code (for the audit change type / lifecycle state).
+fn term(code: &str) -> TerminologyCode {
+    TerminologyCode {
+        terminology_id: "openehr".to_owned(),
+        terminology_version: None,
+        code_string: code.to_owned(),
+        uri: None,
+    }
+}
+
+/// The SM `UPDATE_VERSION` commit envelope for a bare-RM write.
+fn uv(data: Value) -> UpdateVersion {
+    UpdateVersion {
+        preceding_version_uid: None,
+        lifecycle_state: term("532"),
+        attestations: None,
+        data,
+        audit: UpdateAudit {
+            change_type: term("249"),
+            description: None,
+            committer: serde_json::from_value::<PartyProxy>(
+                json!({ "_type": "PARTY_IDENTIFIED", "name": "conformance tester" }),
+            )
+            .expect("committer"),
+        },
+        signature: None,
+    }
+}
+
+/// The base composition, template stripped, uid dropped.
+fn base_composition() -> Value {
+    let path = format!(
+        "{}/../../crates/openehr-its/tests/vendor/openehr_sdk/composition/canonical_json/minimal_observation.json",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    serde_json::from_str(&std::fs::read_to_string(&path).expect("read fixture"))
+        .expect("parse fixture")
+}
+
+/// A composition whose OBSERVATION leaf is a `DV_CODED_TEXT` with the given
+/// defining code, so `.../value/defining_code/code_string` is queryable.
+///
+/// The leaf terminology is caller-controlled: a non-openEHR `terminology_id`
+/// (e.g. the FHIR test's SNOMED) keeps the code out of the RM-mandated openEHR
+/// terminology validation, which only checks RM-fixed coded positions (not
+/// archetype-defined ELEMENT values).
+fn composition_coded(name: &str, terminology_id: &str, code: &str) -> Value {
+    let mut c = base_composition();
+    if let Some(details) = c
+        .get_mut("archetype_details")
+        .and_then(Value::as_object_mut)
+    {
+        details.remove("template_id");
+    }
+    if let Some(obj) = c.as_object_mut() {
+        obj.remove("uid");
+    }
+    c["name"] = json!({ "_type": "DV_TEXT", "value": name });
+    c["content"][0]["archetype_details"] = json!({
+        "_type": "ARCHETYPED",
+        "archetype_id": { "_type": "ARCHETYPE_ID", "value": OBS_ARCHETYPE },
+        "rm_version": "1.1.0",
+    });
+    c["content"][0]["data"]["events"][0]["data"]["items"][0]["value"] = json!({
+        "_type": "DV_CODED_TEXT",
+        "value": name,
+        "defining_code": {
+            "_type": "CODE_PHRASE",
+            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": terminology_id },
+            "code_string": code,
+        }
+    });
+    c
+}
+
+async fn create_ehr(svc: &EhrbaseService) -> String {
+    svc.create_ehr(None).await.expect("create_ehr").to_string()
+}
+
+async fn create_coded(
+    svc: &EhrbaseService,
+    ehr_id: &str,
+    name: &str,
+    terminology_id: &str,
+    code: &str,
+) -> String {
+    svc.create_composition(
+        ehr_id.parse().expect("ehr_id uuid"),
+        uv(composition_coded(name, terminology_id, code)),
+    )
+    .await
+    .unwrap_or_else(|e| panic!("create_composition ({name}, {code}): {e:?}"))
+}
+
+async fn run_aql(svc: &EhrbaseService, aql: &str) -> Value {
+    svc.query_execute_adhoc(aql.to_owned(), AqlQueryRequest::default())
+        .await
+        .unwrap_or_else(|e| panic!("query {aql:?}: {e:?}"))
+        .result_set
+}
+
+/// The set of `c/name/value` strings returned by a query (order-independent).
+fn names(result: &Value) -> Vec<String> {
+    result["rows"]
+        .as_array()
+        .expect("rows array")
+        .iter()
+        .map(|row| {
+            row.as_array().expect("row array")[0]
+                .as_str()
+                .expect("name value")
+                .to_owned()
+        })
+        .collect()
+}
+
+// ── the bundle provider (no network) ─────────────────────────────────────────
+
+#[tokio::test]
+async fn terminology_expand_bundle_merges_group_codes() {
+    let pg = Pg::start().await;
+    let svc = EhrbaseService::new(pg.migrated_pool("aql_term_bundle").await);
+    let ehr = create_ehr(&svc).await;
+
+    // `249` (creation) is in the `audit_change_type` group; `433` (event) is a
+    // valid openEHR code outside it.
+    create_coded(&svc, &ehr, "in-group", "openehr", "249").await;
+    create_coded(&svc, &ehr, "out-of-group", "openehr", "433").await;
+
+    // Standalone expand operand → merged into the IN (…) predicate.
+    let aql = format!(
+        "SELECT c/name/value \
+         FROM EHR e CONTAINS COMPOSITION c CONTAINS OBSERVATION o[{OBS_ARCHETYPE}] \
+         WHERE o/{CODE_PATH} matches TERMINOLOGY('expand', 'openehr', 'audit_change_type')"
+    );
+    assert_eq!(
+        names(&run_aql(&svc, &aql).await),
+        vec!["in-group".to_owned()]
+    );
+
+    // Mixed list: an explicit code merged with the expansion (master03 line 759)
+    // — `433` (explicit) and the `audit_change_type` codes both match.
+    let mixed = format!(
+        "SELECT c/name/value \
+         FROM EHR e CONTAINS COMPOSITION c CONTAINS OBSERVATION o[{OBS_ARCHETYPE}] \
+         WHERE o/{CODE_PATH} matches {{'433', TERMINOLOGY('expand', 'openehr', 'audit_change_type')}}"
+    );
+    let mut got = names(&run_aql(&svc, &mixed).await);
+    got.sort();
+    assert_eq!(got, vec!["in-group".to_owned(), "out-of-group".to_owned()]);
+}
+
+#[tokio::test]
+async fn terminology_expand_unknown_service_is_bad_request() {
+    let pg = Pg::start().await;
+    let svc = EhrbaseService::new(pg.migrated_pool("aql_term_unknown_svc").await);
+    let ehr = create_ehr(&svc).await;
+    create_coded(&svc, &ehr, "x", "openehr", "249").await;
+
+    // An unrecognised service_api (no FHIR provider configured either) → a typed
+    // 400, never a 500.
+    let aql = format!(
+        "SELECT c/name/value \
+         FROM EHR e CONTAINS COMPOSITION c CONTAINS OBSERVATION o[{OBS_ARCHETYPE}] \
+         WHERE o/{CODE_PATH} matches TERMINOLOGY('expand', 'bogus.terminology.api', 'x')"
+    );
+    let err = svc
+        .query_execute_adhoc(aql, AqlQueryRequest::default())
+        .await
+        .expect_err("unknown service_api must be rejected");
+    assert_eq!(err.status, CallStatusType::PreconditionViolation, "{err:?}");
+}
+
+#[tokio::test]
+async fn terminology_expand_unknown_value_set_is_bad_request() {
+    let pg = Pg::start().await;
+    let svc = EhrbaseService::new(pg.migrated_pool("aql_term_unknown_vs").await);
+    let ehr = create_ehr(&svc).await;
+    create_coded(&svc, &ehr, "x", "openehr", "249").await;
+
+    // A value set the bundle does not know → a typed 400.
+    let aql = format!(
+        "SELECT c/name/value \
+         FROM EHR e CONTAINS COMPOSITION c CONTAINS OBSERVATION o[{OBS_ARCHETYPE}] \
+         WHERE o/{CODE_PATH} matches TERMINOLOGY('expand', 'openehr', 'no_such_group')"
+    );
+    let err = svc
+        .query_execute_adhoc(aql, AqlQueryRequest::default())
+        .await
+        .expect_err("unknown value set must be rejected");
+    assert_eq!(err.status, CallStatusType::PreconditionViolation, "{err:?}");
+}
+
+// ── the FHIR provider (wiremock, no network) ─────────────────────────────────
+
+/// The value-set URL and a hierarchical `$expand` response with two SNOMED
+/// members (one nested, exercising the recursive `contains` flatten).
+const VS_URL: &str = "http://snomed.info/sct?fhir_vs=isa/50697003";
+
+async fn fhir_expand_server() -> MockServer {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/ValueSet/$expand"))
+        .and(query_param("url", VS_URL))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "resourceType": "ValueSet",
+            "expansion": {
+                "contains": [
+                    {"code": "442031002", "display": "Screening for X",
+                     "contains": [{"code": "11713004", "display": "child code"}]}
+                ]
+            }
+        })))
+        .mount(&server)
+        .await;
+    server
+}
+
+fn fhir_provider(base: &str) -> FhirTerminologyProvider {
+    let cfg = FhirProviderConfig {
+        kind: ProviderKind::Fhir,
+        url: base.to_owned(),
+        operation: FhirOperation::Expand,
+        connect_timeout_ms: 800,
+        request_timeout_ms: 1_500,
+        oauth2_client: None,
+    };
+    FhirTerminologyProvider::new("test-fhir", &cfg).expect("build provider")
+}
+
+#[tokio::test]
+async fn terminology_expand_fhir_merges_expansion_codes() {
+    let server = fhir_expand_server().await;
+    let pg = Pg::start().await;
+    let svc = EhrbaseService::new(pg.migrated_pool("aql_term_fhir").await)
+        .with_external_terminology(Arc::new(fhir_provider(&server.uri())));
+    let ehr = create_ehr(&svc).await;
+
+    // SNOMED-coded leaves (non-openEHR terminology → not RM-terminology-checked).
+    create_coded(&svc, &ehr, "member", "http://snomed.info/sct", "442031002").await;
+    create_coded(&svc, &ehr, "child", "http://snomed.info/sct", "11713004").await;
+    create_coded(&svc, &ehr, "non-member", "http://snomed.info/sct", "999999").await;
+
+    let aql = format!(
+        "SELECT c/name/value \
+         FROM EHR e CONTAINS COMPOSITION c CONTAINS OBSERVATION o[{OBS_ARCHETYPE}] \
+         WHERE o/{CODE_PATH} matches TERMINOLOGY('expand', 'hl7.org/fhir/4.0', '{VS_URL}')"
+    );
+    let mut got = names(&run_aql(&svc, &aql).await);
+    got.sort();
+    // Both the parent and the nested child code are in the flattened expansion.
+    assert_eq!(got, vec!["child".to_owned(), "member".to_owned()]);
+}

--- a/app/ehrbase/tests/terminology_fhir.rs
+++ b/app/ehrbase/tests/terminology_fhir.rs
@@ -1,0 +1,308 @@
+//! `FhirTerminologyProvider` wire-contract tests (B4, `docs/terminology-validation.md`
+//! §5), driven by `wiremock` — a hermetic FHIR R4 terminology server: canned
+//! `$validate-code`/`$expand`/`$subsumes`/`$lookup` responses + fault injection
+//! (timeout, `5xx`, malformed). No network.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::time::Duration;
+
+use ehrbase::terminology::{
+    FhirOperation, FhirProviderConfig, FhirTerminologyProvider, ProviderKind,
+};
+use ehrbase_sm::{CallStatusType, TerminologyService};
+use serde_json::json;
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Build a provider pointing at `base` with short, test-friendly timeouts.
+fn provider(base: &str, operation: FhirOperation) -> FhirTerminologyProvider {
+    let cfg = FhirProviderConfig {
+        kind: ProviderKind::Fhir,
+        url: base.to_owned(),
+        operation,
+        connect_timeout_ms: 500,
+        request_timeout_ms: 800,
+        oauth2_client: None,
+    };
+    FhirTerminologyProvider::new("test", &cfg).expect("build provider")
+}
+
+/// The reference golden case: `ValueSet/surface`, code `B` = "Buccal".
+const SURFACE_VS: &str = "http://hl7.org/fhir/ValueSet/surface";
+const SURFACE_SYS: &str = "http://hl7.org/fhir/surface";
+
+#[tokio::test]
+async fn validate_code_member_is_accepted() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/ValueSet/$validate-code"))
+        .and(query_param("url", SURFACE_VS))
+        .and(query_param("code", "B"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "result", "valueBoolean": true},
+                {"name": "display", "valueString": "Buccal"}
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let p = provider(&server.uri(), FhirOperation::ValidateCode);
+    let ok = p
+        .value_set_validate(SURFACE_SYS, SURFACE_VS, "B", None)
+        .await
+        .expect("call");
+    assert!(ok, "member code B is valid in ValueSet/surface");
+}
+
+#[tokio::test]
+async fn validate_code_non_member_is_rejected() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/ValueSet/$validate-code"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "resourceType": "Parameters",
+            "parameter": [{"name": "result", "valueBoolean": false}]
+        })))
+        .mount(&server)
+        .await;
+
+    let p = provider(&server.uri(), FhirOperation::ValidateCode);
+    let ok = p
+        .value_set_validate(SURFACE_SYS, SURFACE_VS, "Z", None)
+        .await
+        .expect("call");
+    assert!(!ok, "non-member code Z is not valid");
+}
+
+#[tokio::test]
+async fn validate_code_unknown_valueset_is_not_found() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/ValueSet/$validate-code"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    let p = provider(&server.uri(), FhirOperation::ValidateCode);
+    let err = p
+        .value_set_validate(SURFACE_SYS, "http://x/ValueSet/nope", "B", None)
+        .await
+        .expect_err("404 → not found");
+    assert_eq!(err.status, CallStatusType::VersionedObjectDoesNotExist);
+}
+
+#[tokio::test]
+async fn validate_via_expand_membership() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/ValueSet/$expand"))
+        .and(query_param("url", SURFACE_VS))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "resourceType": "ValueSet",
+            "expansion": {"contains": [
+                {"system": SURFACE_SYS, "code": "B", "display": "Buccal"},
+                {"system": SURFACE_SYS, "code": "L", "display": "Lingual"}
+            ]}
+        })))
+        .mount(&server)
+        .await;
+
+    let p = provider(&server.uri(), FhirOperation::Expand);
+    assert!(
+        p.value_set_validate(SURFACE_SYS, SURFACE_VS, "B", None)
+            .await
+            .expect("call")
+    );
+    assert!(
+        !p.value_set_validate(SURFACE_SYS, SURFACE_VS, "Z", None)
+            .await
+            .expect("call")
+    );
+}
+
+#[tokio::test]
+async fn get_value_set_maps_expansion_to_extract() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/ValueSet/$expand"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "resourceType": "ValueSet",
+            "expansion": {"contains": [
+                {"system": SURFACE_SYS, "code": "B", "display": "Buccal"},
+                {"system": SURFACE_SYS, "code": "O", "display": "Occlusal"}
+            ]}
+        })))
+        .mount(&server)
+        .await;
+
+    let p = provider(&server.uri(), FhirOperation::ValidateCode);
+    let extract = p
+        .get_value_set(SURFACE_SYS, SURFACE_VS)
+        .await
+        .expect("call");
+    let terms = extract.terms.expect("terms");
+    assert_eq!(terms.len(), 2);
+    assert!(terms.contains_key("B"));
+    assert!(terms.contains_key("O"));
+}
+
+#[tokio::test]
+async fn subsumes_true_only_on_strict_subsumption() {
+    // outcome=subsumes → true.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/CodeSystem/$subsumes"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "resourceType": "Parameters",
+            "parameter": [{"name": "outcome", "valueCode": "subsumes"}]
+        })))
+        .mount(&server)
+        .await;
+    let p = provider(&server.uri(), FhirOperation::ValidateCode);
+    assert!(p.subsumes("sys", "parent", "child").await.expect("call"));
+
+    // outcome=equivalent → false (strict subsumption excludes equivalence).
+    let server2 = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/CodeSystem/$subsumes"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "resourceType": "Parameters",
+            "parameter": [{"name": "outcome", "valueCode": "equivalent"}]
+        })))
+        .mount(&server2)
+        .await;
+    let p2 = provider(&server2.uri(), FhirOperation::ValidateCode);
+    assert!(!p2.subsumes("sys", "a", "a").await.expect("call"));
+}
+
+#[tokio::test]
+async fn lookup_drives_has_term_and_get_term() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/CodeSystem/$lookup"))
+        .and(query_param("code", "B"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "name", "valueString": "surface"},
+                {"name": "display", "valueString": "Buccal"}
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let p = provider(&server.uri(), FhirOperation::ValidateCode);
+    assert!(p.has_term(SURFACE_SYS, "B", None).await.expect("has_term"));
+
+    let extract = p
+        .get_term(SURFACE_SYS, "B", None, None)
+        .await
+        .expect("get_term");
+    let terms = extract.terms.expect("terms");
+    let entry = terms.get("B").expect("B");
+    match entry {
+        ehrbase_sm::TermEntry::Defined(d) => assert_eq!(d.text, "Buccal"),
+        ehrbase_sm::TermEntry::Bare(_) => panic!("expected a defined term"),
+    }
+}
+
+#[tokio::test]
+async fn has_term_false_when_lookup_404() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/CodeSystem/$lookup"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    let p = provider(&server.uri(), FhirOperation::ValidateCode);
+    assert!(
+        !p.has_term(SURFACE_SYS, "nope", None)
+            .await
+            .expect("has_term")
+    );
+}
+
+// ─── fault injection ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn server_5xx_is_an_exception() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/ValueSet/$validate-code"))
+        .respond_with(ResponseTemplate::new(503))
+        .mount(&server)
+        .await;
+
+    let p = provider(&server.uri(), FhirOperation::ValidateCode);
+    let err = p
+        .value_set_validate(SURFACE_SYS, SURFACE_VS, "B", None)
+        .await
+        .expect_err("5xx → exception");
+    assert_eq!(err.status, CallStatusType::Exception);
+}
+
+#[tokio::test]
+async fn malformed_body_is_an_exception() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/ValueSet/$validate-code"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("this is not FHIR json"))
+        .mount(&server)
+        .await;
+
+    let p = provider(&server.uri(), FhirOperation::ValidateCode);
+    let err = p
+        .value_set_validate(SURFACE_SYS, SURFACE_VS, "B", None)
+        .await
+        .expect_err("malformed → exception");
+    assert_eq!(err.status, CallStatusType::Exception);
+}
+
+#[tokio::test]
+async fn missing_result_field_is_an_exception() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/ValueSet/$validate-code"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "resourceType": "Parameters",
+            "parameter": [{"name": "message", "valueString": "no result here"}]
+        })))
+        .mount(&server)
+        .await;
+
+    let p = provider(&server.uri(), FhirOperation::ValidateCode);
+    let err = p
+        .value_set_validate(SURFACE_SYS, SURFACE_VS, "B", None)
+        .await
+        .expect_err("no result → exception");
+    assert_eq!(err.status, CallStatusType::Exception);
+}
+
+#[tokio::test]
+async fn timeout_is_an_exception() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/ValueSet/$validate-code"))
+        // Delay well past the provider's 800ms request timeout.
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_delay(Duration::from_secs(3))
+                .set_body_json(json!({
+                    "resourceType": "Parameters",
+                    "parameter": [{"name": "result", "valueBoolean": true}]
+                })),
+        )
+        .mount(&server)
+        .await;
+
+    let p = provider(&server.uri(), FhirOperation::ValidateCode);
+    let err = p
+        .value_set_validate(SURFACE_SYS, SURFACE_VS, "B", None)
+        .await
+        .expect_err("timeout → exception");
+    assert_eq!(err.status, CallStatusType::Exception);
+}

--- a/docs/blueprint/00-THE-BLUEPRINT.md
+++ b/docs/blueprint/00-THE-BLUEPRINT.md
@@ -173,7 +173,7 @@ ECC-MSG-001..010 (native-API-only, skip-with-reason). ECC 329 executed ·
 293 passed · zero drift. Remaining PORT-NOTEd: version branching
 (trunk-only), FHIR/HL7v2 frames, TDD constructs outside the corpus.*
 
-### B4 — Terminology-server integration (+ its test harness)
+### B4 — Terminology-server integration (+ its test harness) — **DONE** (2026-07-10, `docs/plans/b4-terminology.md`)
 Design set: the terminology **client** is `docs/terminology-validation.md`; the
 self-hostable **server** to run in Docker and point at by URL (HAPI FHIR
 default, Snowstorm opt-in) is `docs/design/terminology-server-integration.md` —
@@ -200,6 +200,11 @@ we run an off-the-shelf FHIR R4 TS, never build one.
    service surface, with the wiremock exchange recorded in the report.
 **Exit: mission item "terminology-server integration" demonstrable in CI
 without a network, and against a real server on demand.**
+*Closed 2026-07-10: FhirTerminologyProvider (validate-code/expand/subsumes/
+lookup, config opt-in); AQL TERMINOLOGY('expand') merged into matches at
+semantic analysis (stages b/c typed rejects, PORT-NOTEd); /terminology
+extension wire (config-gated); TS ECC area (ECC-TS-001..009, wiremock
+fixture + --tx-server-url). ECC 338 executed · 298 passed · zero drift.*
 
 ### B5 — tools/conformance spec-version update (chapter 7's findings)
 1. **D1** — resolve the ITS-REST identity: pick Release-1.0.3 vs

--- a/docs/conformance/CATALOG.md
+++ b/docs/conformance/CATALOG.md
@@ -389,3 +389,17 @@ Generated per run — do not edit. Numbers are allocated once in
 | ECC-MSG-009 | Active | TDD — import rejects malformed / non-TDD / unknown EHR / unknown template | skipped |
 | ECC-MSG-010 | Active | TDD — batch import commits all, fail-fast on error (import_tdds) | skipped |
 
+## TS — Terminology-server integration (9 cases, 9 active)
+
+| ECC id | Status | Title | Last run |
+|---|---|---|---|
+| ECC-TS-001 | Active | TERMINOLOGY expand (bundle) — accepted, well-formed RESULT_SET | passed |
+| ECC-TS-002 | Active | TERMINOLOGY expand (bundle) — expansion constrains matches to the value set's codes | passed |
+| ECC-TS-003 | Active | TERMINOLOGY expand (bundle) — explicit code merged with the expansion (matches list) | passed |
+| ECC-TS-004 | Active | TERMINOLOGY expand — unknown value set rejected (400) | passed |
+| ECC-TS-005 | Active | TERMINOLOGY expand — unknown service_api rejected (400) | passed |
+| ECC-TS-006 | Active | TERMINOLOGY expand (FHIR service_api) — accepted when a provider is configured | skipped |
+| ECC-TS-007 | Active | TERMINOLOGY expand (FHIR) — terminology-server timeout is a server fault (500) | skipped |
+| ECC-TS-008 | Active | TERMINOLOGY expand (FHIR) — terminology-server 5xx is a server fault (500) | skipped |
+| ECC-TS-009 | Active | TERMINOLOGY expand (FHIR) — malformed terminology response is a server fault (500) | skipped |
+

--- a/docs/conformance/CONFORMANCE_REPORT.md
+++ b/docs/conformance/CONFORMANCE_REPORT.md
@@ -8,9 +8,9 @@
 - SUT: `http://localhost:8080/ehrbase/rest/openehr/v1`
 - Spec versions: RM 1.2.0 · ITS-REST 1.0.3 · AQL 1.1.0 · TERM 3.1.0
 - Auth mode: basic
-- Started: 2026-07-10T06:54:16.363431Z
+- Started: 2026-07-10T08:44:26.39774Z
 
-**329 case×format executions · 293 passed · 25 failed.**
+**338 case×format executions · 298 passed · 25 failed.**
 
 ### Per-area matrix
 
@@ -29,6 +29,7 @@
 | ADM — Admin service | 6 | 6 | 0 | 0 | 0 |
 | SIG — Version signing | 5 | 4 | 1 | 0 | 1 |
 | MSG — Messaging | 10 | 0 | 0 | 0 | 10 |
+| TS — Terminology-server integration | 9 | 5 | 0 | 0 | 4 |
 
 ### Failures
 
@@ -66,9 +67,9 @@ Each failure must become a finding (`F-AA-NN`) before/with the fix — never an 
 |---|---|
 | Profiles requested | all |
 | Data formats | json, xml |
-| Catalogue (active cases) | 321 |
-| Executed | 329 |
-| Passed | 293 |
+| Catalogue (active cases) | 330 |
+| Executed | 338 |
+| Passed | 298 |
 | Failed | 25 |
 
 ## 3. Detailed test report
@@ -404,6 +405,15 @@ Each failure must become a finding (`F-AA-NN`) before/with the fix — never an 
 | ECC-MSG-008 | Messaging | json | 0/0 | skipped |
 | ECC-MSG-009 | Messaging | json | 0/0 | skipped |
 | ECC-MSG-010 | Messaging | json | 0/0 | skipped |
+| ECC-TS-001 | Terminology | json | 1/1 | PASS |
+| ECC-TS-002 | Terminology | json | 2/2 | PASS |
+| ECC-TS-003 | Terminology | json | 1/1 | PASS |
+| ECC-TS-004 | Terminology | json | 1/1 | PASS |
+| ECC-TS-005 | Terminology | json | 1/1 | PASS |
+| ECC-TS-006 | Terminology | json | 0/0 | skipped |
+| ECC-TS-007 | Terminology | json | 0/0 | skipped |
+| ECC-TS-008 | Terminology | json | 0/0 | skipped |
+| ECC-TS-009 | Terminology | json | 0/0 | skipped |
 
 ## 4. Profile verdict (machine-computed, all-or-nothing)
 
@@ -460,4 +470,22 @@ Each failure must become a finding (`F-AA-NN`) before/with the fix — never an 
 | NativeApiOnly: I_TDD_SERVICE.import_tdd (typed rejections) is exercised by app/ehrbase/tests/service_tdd.rs::{tdd_import_rejects_malformed_payload, tdd_import_rejects_non_tdd_xml, tdd_import_rejects_unknown_ehr, tdd_import_rejects_unknown_template} — Messaging has no ITS-REST binding | 1 |
 | NativeApiOnly: I_TDD_SERVICE.import_tdd is exercised by app/ehrbase/tests/service_tdd.rs::tdd_import_commits_composition — Messaging has no ITS-REST binding | 1 |
 | NativeApiOnly: I_TDD_SERVICE.import_tdds is exercised by app/ehrbase/tests/service_tdd.rs::{tdd_import_tdds_batch_commits_all, tdd_import_tdds_batch_fail_fast} — Messaging has no ITS-REST binding | 1 |
+| SutConfig: no FHIR terminology provider configured on the SUT (EHRBASE_VALIDATION_EXTERNAL_TERMINOLOGY_* unset) — a `hl7.org/fhir/4.0` expand is rejected as `UnknownTerminologyService`. harness terminology server: http://127.0.0.1:57453 (fixture). The bundle (`openehr`) expand cases prove the TERMINOLOGY family; wire this by pointing the SUT at a FHIR server (host.docker.internal for a runner-host fixture, docs/design/terminology-server-integration.md §5). | 1 |
 | SutConfig: server not in `pgp` mode (needs a configured OpenPGP key); a pgp-keyed compose profile is a follow-up — digest cases prove the capability | 1 |
+| SutConfig: the 5xx fault requires a fault-injecting terminology server wired to the SUT (--tx-server-url + an SUT FHIR provider pointed at it); the HTTP-only ECC cannot reconfigure an external SUT's provider per case. Harness tx server: http://127.0.0.1:57453 (fixture). The fault→500 mapping is proven by conformance ts::fixture::tests::fault_server_error_is_5xx + app/ehrbase/tests/terminology_fhir.rs::server_5xx_is_an_exception. | 1 |
+| SutConfig: the malformed fault requires a fault-injecting terminology server wired to the SUT (--tx-server-url + an SUT FHIR provider pointed at it); the HTTP-only ECC cannot reconfigure an external SUT's provider per case. Harness tx server: http://127.0.0.1:57453 (fixture). The fault→500 mapping is proven by conformance ts::fixture::tests::fault_malformed_is_not_json + app/ehrbase/tests/terminology_fhir.rs::malformed_body_is_an_exception. | 1 |
+| SutConfig: the timeout fault requires a fault-injecting terminology server wired to the SUT (--tx-server-url + an SUT FHIR provider pointed at it); the HTTP-only ECC cannot reconfigure an external SUT's provider per case. Harness tx server: http://127.0.0.1:57453 (fixture). The fault→500 mapping is proven by conformance ts::fixture::tests::fault_timeout_exceeds_a_short_client_deadline + app/ehrbase/tests/terminology_fhir.rs::timeout_is_an_exception. | 1 |
+
+## 6. Terminology server (TS area)
+
+- Server: `http://127.0.0.1:57453`
+- Mode: fixture
+
+Recorded FHIR-tx exchange (4 request(s)):
+
+| # | Method | Path | Query |
+|--:|---|---|---|
+| 1 | GET | `/ValueSet/$expand` | url=http%3A%2F%2Fhl7.org%2Ffhir%2FValueSet%2Fsurface |
+| 2 | GET | `/ValueSet/$validate-code` | url=http%3A%2F%2Fhl7.org%2Ffhir%2FValueSet%2Fsurface&code=B |
+| 3 | GET | `/CodeSystem/$lookup` | code=B |
+| 4 | GET | `/CodeSystem/$subsumes` | codeA=L&codeB=O |

--- a/docs/conformance/badge.json
+++ b/docs/conformance/badge.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "ECC conformance",
-  "message": "293/321",
+  "message": "298/330",
   "color": "red"
 }

--- a/docs/conformance/results.json
+++ b/docs/conformance/results.json
@@ -13,13 +13,39 @@
     "repo": "openEHR/specifications-CNF",
     "commit": "33251d2a"
   },
-  "started": "2026-07-10T06:54:16.363431Z",
+  "started": "2026-07-10T08:44:26.39774Z",
   "selection": {
     "filter": null,
     "profile": null,
     "formats": [
       "json",
       "xml"
+    ]
+  },
+  "terminology": {
+    "base_url": "http://127.0.0.1:57453",
+    "mode": "fixture",
+    "exchanges": [
+      {
+        "method": "GET",
+        "path": "/ValueSet/$expand",
+        "query": "url=http%3A%2F%2Fhl7.org%2Ffhir%2FValueSet%2Fsurface"
+      },
+      {
+        "method": "GET",
+        "path": "/ValueSet/$validate-code",
+        "query": "url=http%3A%2F%2Fhl7.org%2Ffhir%2FValueSet%2Fsurface&code=B"
+      },
+      {
+        "method": "GET",
+        "path": "/CodeSystem/$lookup",
+        "query": "code=B"
+      },
+      {
+        "method": "GET",
+        "path": "/CodeSystem/$subsumes",
+        "query": "codeA=L&codeB=O"
+      }
     ]
   },
   "cases": [
@@ -38,7 +64,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
-      "duration_ms": 46
+      "duration_ms": 43
     },
     {
       "ecc_id": "ECC-EHR-002",
@@ -55,7 +81,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
-      "duration_ms": 20
+      "duration_ms": 16
     },
     {
       "ecc_id": "ECC-EHR-003",
@@ -72,7 +98,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
-      "duration_ms": 6
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-EHR-004",
@@ -89,7 +115,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-EHR-005",
@@ -106,7 +132,7 @@
       "total_data_sets": 16,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
-      "duration_ms": 193
+      "duration_ms": 155
     },
     {
       "ecc_id": "ECC-EHR-006",
@@ -123,7 +149,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
-      "duration_ms": 11
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-EHR-007",
@@ -140,7 +166,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
-      "duration_ms": 17
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-EHR-008",
@@ -157,7 +183,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
-      "duration_ms": 11
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-EHR-009",
@@ -174,7 +200,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
-      "duration_ms": 11
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-EHR-010",
@@ -191,7 +217,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-EHR-011",
@@ -208,7 +234,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-STA-001",
@@ -225,7 +251,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR_STATUS API §get_ehr_status/update_ehr_status; RM 1.2.0 ehr §EHR_STATUS",
-      "duration_ms": 12
+      "duration_ms": 11
     },
     {
       "ecc_id": "ECC-STA-002",
@@ -242,7 +268,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR_STATUS API §get_ehr_status/update_ehr_status; RM 1.2.0 ehr §EHR_STATUS",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-STA-003",
@@ -259,7 +285,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR_STATUS API §get_ehr_status/update_ehr_status; RM 1.2.0 ehr §EHR_STATUS",
-      "duration_ms": 28
+      "duration_ms": 21
     },
     {
       "ecc_id": "ECC-STA-004",
@@ -276,7 +302,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR_STATUS API §get_ehr_status/update_ehr_status; RM 1.2.0 ehr §EHR_STATUS",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-STA-005",
@@ -293,7 +319,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR_STATUS API §get_ehr_status/update_ehr_status; RM 1.2.0 ehr §EHR_STATUS",
-      "duration_ms": 23
+      "duration_ms": 24
     },
     {
       "ecc_id": "ECC-STA-006",
@@ -310,7 +336,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR_STATUS API §get_ehr_status/update_ehr_status; RM 1.2.0 ehr §EHR_STATUS",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-STA-007",
@@ -327,7 +353,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR_STATUS API §get_ehr_status/update_ehr_status; RM 1.2.0 ehr §EHR_STATUS",
-      "duration_ms": 23
+      "duration_ms": 20
     },
     {
       "ecc_id": "ECC-STA-008",
@@ -344,7 +370,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR_STATUS API §get_ehr_status/update_ehr_status; RM 1.2.0 ehr §EHR_STATUS",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-STA-009",
@@ -361,7 +387,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR_STATUS API §get_ehr_status/update_ehr_status; RM 1.2.0 ehr §EHR_STATUS",
-      "duration_ms": 22
+      "duration_ms": 20
     },
     {
       "ecc_id": "ECC-STA-010",
@@ -395,7 +421,7 @@
       "total_data_sets": 11,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR API §create_ehr (422); RM 1.2.0 ehr §EHR_STATUS validation",
-      "duration_ms": 48
+      "duration_ms": 42
     },
     {
       "ecc_id": "ECC-COM-001",
@@ -412,7 +438,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 30
+      "duration_ms": 27
     },
     {
       "ecc_id": "ECC-COM-001",
@@ -429,7 +455,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 23
+      "duration_ms": 22
     },
     {
       "ecc_id": "ECC-COM-002",
@@ -446,7 +472,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 21
+      "duration_ms": 19
     },
     {
       "ecc_id": "ECC-COM-002",
@@ -463,7 +489,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 20
+      "duration_ms": 18
     },
     {
       "ecc_id": "ECC-COM-003",
@@ -480,7 +506,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 29
+      "duration_ms": 25
     },
     {
       "ecc_id": "ECC-COM-004",
@@ -497,7 +523,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 18
+      "duration_ms": 17
     },
     {
       "ecc_id": "ECC-COM-005",
@@ -514,7 +540,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 17
+      "duration_ms": 16
     },
     {
       "ecc_id": "ECC-COM-006",
@@ -531,7 +557,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 16
+      "duration_ms": 14
     },
     {
       "ecc_id": "ECC-COM-007",
@@ -565,7 +591,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 26
+      "duration_ms": 23
     },
     {
       "ecc_id": "ECC-COM-008",
@@ -582,7 +608,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 26
+      "duration_ms": 23
     },
     {
       "ecc_id": "ECC-COM-009",
@@ -599,7 +625,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 10
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-COM-010",
@@ -616,7 +642,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-COM-011",
@@ -633,7 +659,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 11
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-COM-012",
@@ -650,7 +676,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-COM-013",
@@ -667,7 +693,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 28
+      "duration_ms": 24
     },
     {
       "ecc_id": "ECC-COM-013",
@@ -684,7 +710,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 26
+      "duration_ms": 23
     },
     {
       "ecc_id": "ECC-COM-014",
@@ -701,7 +727,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 26
+      "duration_ms": 24
     },
     {
       "ecc_id": "ECC-COM-014",
@@ -718,7 +744,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 26
+      "duration_ms": 22
     },
     {
       "ecc_id": "ECC-COM-015",
@@ -735,7 +761,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 11
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-COM-016",
@@ -752,7 +778,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-COM-017",
@@ -769,7 +795,7 @@
       "total_data_sets": 3,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 155
+      "duration_ms": 148
     },
     {
       "ecc_id": "ECC-COM-018",
@@ -786,7 +812,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 26
+      "duration_ms": 22
     },
     {
       "ecc_id": "ECC-COM-018",
@@ -803,7 +829,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 25
+      "duration_ms": 22
     },
     {
       "ecc_id": "ECC-COM-019",
@@ -820,7 +846,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 11
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-COM-020",
@@ -837,7 +863,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-COM-021",
@@ -854,7 +880,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 44
+      "duration_ms": 39
     },
     {
       "ecc_id": "ECC-COM-022",
@@ -871,7 +897,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 25
+      "duration_ms": 23
     },
     {
       "ecc_id": "ECC-COM-022",
@@ -888,7 +914,7 @@
       "total_data_sets": 0,
       "message": "expected status 200, got 406 (body: {\"error\":\"Not Acceptable\",\"message\":\"not acceptable: canonical XML for this response is available once typed payloads land (P12); request application/json\"})",
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 24
+      "duration_ms": 22
     },
     {
       "ecc_id": "ECC-COM-023",
@@ -905,7 +931,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 10
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-COM-024",
@@ -922,7 +948,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-COM-025",
@@ -939,7 +965,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 29
+      "duration_ms": 26
     },
     {
       "ecc_id": "ECC-COM-026",
@@ -956,7 +982,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 28
+      "duration_ms": 23
     },
     {
       "ecc_id": "ECC-COM-027",
@@ -973,7 +999,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 16
+      "duration_ms": 14
     },
     {
       "ecc_id": "ECC-COM-028",
@@ -990,7 +1016,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 30
+      "duration_ms": 26
     },
     {
       "ecc_id": "ECC-COM-029",
@@ -1007,7 +1033,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 28
+      "duration_ms": 22
     },
     {
       "ecc_id": "ECC-COM-030",
@@ -1024,7 +1050,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 23
+      "duration_ms": 21
     },
     {
       "ecc_id": "ECC-COM-031",
@@ -1041,7 +1067,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 10
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-CTB-001",
@@ -1058,7 +1084,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 21
+      "duration_ms": 20
     },
     {
       "ecc_id": "ECC-CTB-002",
@@ -1075,7 +1101,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 16
+      "duration_ms": 19
     },
     {
       "ecc_id": "ECC-CTB-003",
@@ -1109,7 +1135,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 26
+      "duration_ms": 24
     },
     {
       "ecc_id": "ECC-CTB-005",
@@ -1126,7 +1152,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 15
+      "duration_ms": 14
     },
     {
       "ecc_id": "ECC-CTB-006",
@@ -1143,7 +1169,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 30
+      "duration_ms": 28
     },
     {
       "ecc_id": "ECC-CTB-007",
@@ -1177,7 +1203,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 26
+      "duration_ms": 24
     },
     {
       "ecc_id": "ECC-CTB-009",
@@ -1194,7 +1220,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 23
+      "duration_ms": 20
     },
     {
       "ecc_id": "ECC-CTB-010",
@@ -1211,7 +1237,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 24
+      "duration_ms": 19
     },
     {
       "ecc_id": "ECC-CTB-011",
@@ -1228,7 +1254,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 19
+      "duration_ms": 16
     },
     {
       "ecc_id": "ECC-CTB-012",
@@ -1245,7 +1271,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 18
+      "duration_ms": 14
     },
     {
       "ecc_id": "ECC-CTB-013",
@@ -1262,7 +1288,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 11
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-CTB-014",
@@ -1279,7 +1305,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 15
+      "duration_ms": 13
     },
     {
       "ecc_id": "ECC-CTB-015",
@@ -1296,7 +1322,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 13
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-CTB-016",
@@ -1313,7 +1339,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 16
+      "duration_ms": 14
     },
     {
       "ecc_id": "ECC-CTB-017",
@@ -1330,7 +1356,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 11
+      "duration_ms": 10
     },
     {
       "ecc_id": "ECC-CTB-018",
@@ -1347,7 +1373,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 18
+      "duration_ms": 16
     },
     {
       "ecc_id": "ECC-CTB-019",
@@ -1364,7 +1390,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 22
+      "duration_ms": 20
     },
     {
       "ecc_id": "ECC-CTB-020",
@@ -1381,7 +1407,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 11
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-CTB-021",
@@ -1398,7 +1424,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-CTB-022",
@@ -1415,7 +1441,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 23
+      "duration_ms": 19
     },
     {
       "ecc_id": "ECC-CTB-023",
@@ -1432,7 +1458,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 23
+      "duration_ms": 20
     },
     {
       "ecc_id": "ECC-CTB-024",
@@ -1449,7 +1475,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 22
+      "duration_ms": 19
     },
     {
       "ecc_id": "ECC-CTB-025",
@@ -1466,7 +1492,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-CTB-026",
@@ -1483,7 +1509,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 10
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-CTB-027",
@@ -1500,7 +1526,7 @@
       "total_data_sets": 0,
       "message": "expected status 200, got 405 (body: )",
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 11
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-CTB-028",
@@ -1534,7 +1560,7 @@
       "total_data_sets": 0,
       "message": "expected status 200, got 405 (body: )",
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 22
+      "duration_ms": 21
     },
     {
       "ecc_id": "ECC-CTB-030",
@@ -1551,7 +1577,7 @@
       "total_data_sets": 0,
       "message": "expected status 200, got 405 (body: )",
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 17
+      "duration_ms": 16
     },
     {
       "ecc_id": "ECC-CTB-031",
@@ -1568,7 +1594,7 @@
       "total_data_sets": 0,
       "message": "expected status 200, got 405 (body: )",
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 10
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-DIR-001",
@@ -1584,7 +1610,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 13
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-DIR-002",
@@ -1600,7 +1626,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 18
+      "duration_ms": 16
     },
     {
       "ecc_id": "ECC-DIR-003",
@@ -1632,7 +1658,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 19
+      "duration_ms": 17
     },
     {
       "ecc_id": "ECC-DIR-005",
@@ -1664,7 +1690,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 18
+      "duration_ms": 16
     },
     {
       "ecc_id": "ECC-DIR-007",
@@ -1680,7 +1706,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-DIR-008",
@@ -1696,7 +1722,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 21
+      "duration_ms": 18
     },
     {
       "ecc_id": "ECC-DIR-009",
@@ -1728,7 +1754,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 19
+      "duration_ms": 16
     },
     {
       "ecc_id": "ECC-DIR-011",
@@ -1744,7 +1770,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-DIR-012",
@@ -1760,7 +1786,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 10
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-DIR-013",
@@ -1776,7 +1802,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 18
+      "duration_ms": 17
     },
     {
       "ecc_id": "ECC-DIR-014",
@@ -1792,7 +1818,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-DIR-015",
@@ -1808,7 +1834,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 18
+      "duration_ms": 19
     },
     {
       "ecc_id": "ECC-DIR-016",
@@ -1824,7 +1850,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 18
+      "duration_ms": 16
     },
     {
       "ecc_id": "ECC-DIR-017",
@@ -1856,7 +1882,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-DIR-019",
@@ -1888,7 +1914,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 24
+      "duration_ms": 22
     },
     {
       "ecc_id": "ECC-DIR-021",
@@ -1904,7 +1930,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-DIR-022",
@@ -1936,7 +1962,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 18
+      "duration_ms": 16
     },
     {
       "ecc_id": "ECC-DIR-024",
@@ -1952,7 +1978,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 17
+      "duration_ms": 15
     },
     {
       "ecc_id": "ECC-DIR-025",
@@ -1968,7 +1994,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 25
+      "duration_ms": 22
     },
     {
       "ecc_id": "ECC-DIR-026",
@@ -1984,7 +2010,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 26
+      "duration_ms": 25
     },
     {
       "ecc_id": "ECC-DIR-027",
@@ -2000,7 +2026,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 11
+      "duration_ms": 16
     },
     {
       "ecc_id": "ECC-DIR-028",
@@ -2016,7 +2042,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 10
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-DIR-029",
@@ -2032,7 +2058,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 25
+      "duration_ms": 23
     },
     {
       "ecc_id": "ECC-DIR-030",
@@ -2048,7 +2074,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-DIR-031",
@@ -2064,7 +2090,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 26
+      "duration_ms": 23
     },
     {
       "ecc_id": "ECC-DIR-032",
@@ -2080,7 +2106,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 10
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-DIR-033",
@@ -2112,7 +2138,7 @@
       "total_data_sets": 0,
       "message": "expected status 200, got 404 (body: )",
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 20
+      "duration_ms": 18
     },
     {
       "ecc_id": "ECC-DIR-035",
@@ -2144,7 +2170,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 11
+      "duration_ms": 10
     },
     {
       "ecc_id": "ECC-DIR-037",
@@ -2160,7 +2186,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 10
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-TPL-001",
@@ -2177,7 +2203,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
-      "duration_ms": 17
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-TPL-002",
@@ -2194,7 +2220,7 @@
       "total_data_sets": 18,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
-      "duration_ms": 110
+      "duration_ms": 100
     },
     {
       "ecc_id": "ECC-TPL-003",
@@ -2211,7 +2237,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
-      "duration_ms": 5
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-TPL-004",
@@ -2228,7 +2254,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
-      "duration_ms": 13
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-TPL-005",
@@ -2245,7 +2271,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
-      "duration_ms": 12
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-TPL-006",
@@ -2262,7 +2288,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
-      "duration_ms": 11
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-TPL-007",
@@ -2279,7 +2305,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
-      "duration_ms": 10
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-TPL-008",
@@ -2296,7 +2322,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
-      "duration_ms": 5
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-TPL-009",
@@ -2313,7 +2339,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-TPL-010",
@@ -2330,7 +2356,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
-      "duration_ms": 9
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-TPL-011",
@@ -2347,7 +2373,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
-      "duration_ms": 5
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-TPL-012",
@@ -2364,7 +2390,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
-      "duration_ms": 6
+      "duration_ms": 5
     },
     {
       "ecc_id": "ECC-TPL-013",
@@ -2381,7 +2407,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-TPL-014",
@@ -2398,7 +2424,7 @@
       "total_data_sets": 0,
       "message": "expected one of [200, 204], got 405",
       "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
-      "duration_ms": 9
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-TPL-015",
@@ -2415,7 +2441,7 @@
       "total_data_sets": 0,
       "message": "expected one of [200, 204], got 405",
       "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
-      "duration_ms": 9
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-TPL-016",
@@ -2432,7 +2458,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
-      "duration_ms": 5
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-SQR-001",
@@ -2448,7 +2474,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEFINITION QUERY API §store/list stored query; AQL 1.1",
-      "duration_ms": 7
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-SQR-002",
@@ -2464,7 +2490,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEFINITION QUERY API §store/list stored query; AQL 1.1",
-      "duration_ms": 10
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-SQR-003",
@@ -2512,7 +2538,7 @@
       "total_data_sets": 0,
       "message": "expected status 200, got 404 (body: )",
       "citation": "ITS-REST 1.0.3 DEFINITION QUERY API §store/list stored query; AQL 1.1",
-      "duration_ms": 6
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-SQR-006",
@@ -2528,7 +2554,7 @@
       "total_data_sets": 0,
       "message": "expected 400/422 for a non-AQL query, got 200",
       "citation": "ITS-REST 1.0.3 DEFINITION QUERY API §store/list stored query; AQL 1.1",
-      "duration_ms": 6
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-SQR-007",
@@ -2544,7 +2570,7 @@
       "total_data_sets": 0,
       "message": "expected 400/422 for malformed AQL, got 200",
       "citation": "ITS-REST 1.0.3 DEFINITION QUERY API §store/list stored query; AQL 1.1",
-      "duration_ms": 6
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-QRY-001",
@@ -2560,7 +2586,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query/execute_stored_query; AQL 1.1",
-      "duration_ms": 6
+      "duration_ms": 5
     },
     {
       "ecc_id": "ECC-QRY-002",
@@ -2576,7 +2602,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query/execute_stored_query; AQL 1.1",
-      "duration_ms": 7
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-QRY-003",
@@ -2592,7 +2618,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query/execute_stored_query; AQL 1.1",
-      "duration_ms": 10
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-QRY-004",
@@ -2608,7 +2634,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query/execute_stored_query; AQL 1.1",
-      "duration_ms": 30
+      "duration_ms": 24
     },
     {
       "ecc_id": "ECC-QRY-005",
@@ -2624,7 +2650,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query; AQL 1.1; reference: CNF query corpus (design-time reading)",
-      "duration_ms": 13
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-QRY-006",
@@ -2640,7 +2666,7 @@
       "total_data_sets": 0,
       "message": "24/27 A/empty_db goldens matched (0 skipped); first divergence: A/106_get_ehrs.json: valid query rejected with status 400 (body: {\"error\":\"Bad Request\",\"message\":\"bad request: attribute `ehr_status` is not defined on EHR (RM model)\"})",
       "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query; AQL 1.1; reference: CNF query corpus (design-time reading)",
-      "duration_ms": 218
+      "duration_ms": 169
     },
     {
       "ecc_id": "ECC-QRY-007",
@@ -2656,7 +2682,7 @@
       "total_data_sets": 18,
       "message": null,
       "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query; AQL 1.1; reference: CNF query corpus (design-time reading)",
-      "duration_ms": 223
+      "duration_ms": 172
     },
     {
       "ecc_id": "ECC-QRY-008",
@@ -2672,7 +2698,7 @@
       "total_data_sets": 11,
       "message": null,
       "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query; AQL 1.1; reference: CNF query corpus (design-time reading)",
-      "duration_ms": 169
+      "duration_ms": 66
     },
     {
       "ecc_id": "ECC-QRY-009",
@@ -2688,7 +2714,7 @@
       "total_data_sets": 0,
       "message": "16/18 D/empty_db goldens matched (8 skipped); first divergence: D/312_select_data_values_from_all_ehrs_contains_composition_with_archetype_top_5.json: valid query rejected with status 400 (body: {\"error\":\"Bad Request\",\"message\":\"bad request: invalid AQL: found 'Order' at 29..30\"})",
       "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query; AQL 1.1; reference: CNF query corpus (design-time reading)",
-      "duration_ms": 199
+      "duration_ms": 134
     },
     {
       "ecc_id": "ECC-QRY-010",
@@ -2704,7 +2730,7 @@
       "total_data_sets": 0,
       "message": "20/23 A/loaded_db goldens matched (4 skipped); first divergence: A/106_get_ehrs.json: valid query rejected with status 400 (body: {\"error\":\"Bad Request\",\"message\":\"bad request: attribute `ehr_status` is not defined on EHR (RM model)\"})",
       "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query; AQL 1.1; reference: CNF query corpus (design-time reading)",
-      "duration_ms": 183
+      "duration_ms": 144
     },
     {
       "ecc_id": "ECC-QRY-011",
@@ -2720,7 +2746,7 @@
       "total_data_sets": 0,
       "message": "15/18 B/loaded_db goldens matched (6 skipped); first divergence: B/104_get_compositions_top_5_ordered_by_starttime_asc.json: valid query rejected with status 400 (body: {\"error\":\"Bad Request\",\"message\":\"bad request: invalid AQL: found 'Order' at 7..8\"})",
       "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query; AQL 1.1; reference: CNF query corpus (design-time reading)",
-      "duration_ms": 223
+      "duration_ms": 171
     },
     {
       "ecc_id": "ECC-QRY-012",
@@ -2736,7 +2762,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query; AQL 1.1; reference: CNF query corpus (design-time reading)",
-      "duration_ms": 18
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-QRY-013",
@@ -2752,7 +2778,7 @@
       "total_data_sets": 0,
       "message": "7/9 D/loaded_db goldens matched (17 skipped); first divergence: D/312_select_data_values_from_all_ehrs_contains_composition_with_archetype_top_5.json: valid query rejected with status 400 (body: {\"error\":\"Bad Request\",\"message\":\"bad request: invalid AQL: found 'Order' at 29..30\"})",
       "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query; AQL 1.1; reference: CNF query corpus (design-time reading)",
-      "duration_ms": 78
+      "duration_ms": 65
     },
     {
       "ecc_id": "ECC-ADM-001",
@@ -2768,7 +2794,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 ADMIN API §delete EHR; SM §I_ADMIN_SERVICE.physical_ehr_delete",
-      "duration_ms": 21
+      "duration_ms": 10
     },
     {
       "ecc_id": "ECC-ADM-002",
@@ -2784,7 +2810,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 ADMIN API §delete EHR; SM §I_ADMIN_SERVICE.physical_ehr_delete",
-      "duration_ms": 7
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-ADM-003",
@@ -2800,7 +2826,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 ADMIN API §delete EHR; SM §I_ADMIN_SERVICE.physical_ehr_delete",
-      "duration_ms": 27
+      "duration_ms": 14
     },
     {
       "ecc_id": "ECC-ADM-004",
@@ -2816,7 +2842,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 ADMIN API §delete EHR; SM §I_ADMIN_SERVICE.physical_ehr_delete",
-      "duration_ms": 22
+      "duration_ms": 16
     },
     {
       "ecc_id": "ECC-ADM-005",
@@ -2832,7 +2858,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 ADMIN API §delete EHR; SM §I_ADMIN_SERVICE.physical_ehr_delete",
-      "duration_ms": 12
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-ADM-006",
@@ -2848,7 +2874,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 ADMIN API §delete EHR; SM §I_ADMIN_SERVICE.physical_ehr_delete",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-DEM-001",
@@ -2864,7 +2890,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 6
+      "duration_ms": 5
     },
     {
       "ecc_id": "ECC-DEM-002",
@@ -2880,7 +2906,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 11
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-DEM-003",
@@ -2896,7 +2922,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 11
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-DEM-004",
@@ -2912,7 +2938,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 12
+      "duration_ms": 10
     },
     {
       "ecc_id": "ECC-DEM-005",
@@ -2928,7 +2954,7 @@
       "total_data_sets": 0,
       "message": "expected status in [200, 204], got 400",
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 10
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-DEM-006",
@@ -2944,7 +2970,7 @@
       "total_data_sets": 0,
       "message": "expected status in [204, 404], got 200",
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 15
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-DEM-007",
@@ -2960,7 +2986,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-DEM-008",
@@ -2976,7 +3002,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 11
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-DEM-009",
@@ -2992,7 +3018,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 6
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-DEM-010",
@@ -3008,7 +3034,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 12
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-DEM-011",
@@ -3024,7 +3050,7 @@
       "total_data_sets": 0,
       "message": "expected status in [200, 204], got 400",
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 10
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-DEM-012",
@@ -3040,7 +3066,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 7
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-DEM-013",
@@ -3056,7 +3082,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 12
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-DEM-014",
@@ -3072,7 +3098,7 @@
       "total_data_sets": 0,
       "message": "expected status in [200, 204], got 400",
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 11
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-DEM-015",
@@ -3088,7 +3114,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 7
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-DEM-016",
@@ -3104,7 +3130,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 11
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-DEM-017",
@@ -3120,7 +3146,7 @@
       "total_data_sets": 0,
       "message": "expected status in [200, 204], got 400",
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 10
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-DEM-018",
@@ -3136,7 +3162,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 6
+      "duration_ms": 5
     },
     {
       "ecc_id": "ECC-DEM-019",
@@ -3152,7 +3178,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 11
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-DEM-020",
@@ -3168,7 +3194,7 @@
       "total_data_sets": 0,
       "message": "expected status in [200, 204], got 400",
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 9
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-DEM-021",
@@ -3184,7 +3210,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-DEM-022",
@@ -3200,7 +3226,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 10
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-DEM-023",
@@ -3216,7 +3242,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 10
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-DEM-024",
@@ -3232,7 +3258,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 10
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-VAL-001",
@@ -3249,7 +3275,7 @@
       "total_data_sets": 6,
       "message": null,
       "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 115
+      "duration_ms": 95
     },
     {
       "ecc_id": "ECC-VAL-002",
@@ -3266,7 +3292,7 @@
       "total_data_sets": 6,
       "message": null,
       "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 109
+      "duration_ms": 101
     },
     {
       "ecc_id": "ECC-VAL-003",
@@ -3283,7 +3309,7 @@
       "total_data_sets": 6,
       "message": null,
       "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 114
+      "duration_ms": 94
     },
     {
       "ecc_id": "ECC-VAL-004",
@@ -3300,7 +3326,7 @@
       "total_data_sets": 6,
       "message": null,
       "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 110
+      "duration_ms": 92
     },
     {
       "ecc_id": "ECC-VAL-005",
@@ -3317,7 +3343,7 @@
       "total_data_sets": 6,
       "message": null,
       "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 106
+      "duration_ms": 134
     },
     {
       "ecc_id": "ECC-VAL-006",
@@ -3334,7 +3360,7 @@
       "total_data_sets": 6,
       "message": null,
       "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 107
+      "duration_ms": 165
     },
     {
       "ecc_id": "ECC-VAL-007",
@@ -3351,7 +3377,7 @@
       "total_data_sets": 6,
       "message": null,
       "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 109
+      "duration_ms": 152
     },
     {
       "ecc_id": "ECC-VAL-008",
@@ -3368,7 +3394,7 @@
       "total_data_sets": 6,
       "message": null,
       "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 115
+      "duration_ms": 108
     },
     {
       "ecc_id": "ECC-VAL-009",
@@ -3385,7 +3411,7 @@
       "total_data_sets": 6,
       "message": null,
       "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 133
+      "duration_ms": 101
     },
     {
       "ecc_id": "ECC-VAL-010",
@@ -3402,7 +3428,7 @@
       "total_data_sets": 6,
       "message": null,
       "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 104
+      "duration_ms": 120
     },
     {
       "ecc_id": "ECC-VAL-011",
@@ -3419,7 +3445,7 @@
       "total_data_sets": 6,
       "message": null,
       "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 104
+      "duration_ms": 95
     },
     {
       "ecc_id": "ECC-VAL-012",
@@ -3436,7 +3462,7 @@
       "total_data_sets": 6,
       "message": null,
       "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 104
+      "duration_ms": 94
     },
     {
       "ecc_id": "ECC-VAL-013",
@@ -3453,7 +3479,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 ehr §OBSERVATION; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 37
+      "duration_ms": 32
     },
     {
       "ecc_id": "ECC-VAL-014",
@@ -3470,7 +3496,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 ehr §OBSERVATION; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 36
+      "duration_ms": 33
     },
     {
       "ecc_id": "ECC-VAL-015",
@@ -3487,7 +3513,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 ehr §OBSERVATION; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 35
+      "duration_ms": 32
     },
     {
       "ecc_id": "ECC-VAL-016",
@@ -3504,7 +3530,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 ehr §OBSERVATION; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 35
+      "duration_ms": 32
     },
     {
       "ecc_id": "ECC-VAL-017",
@@ -3521,7 +3547,7 @@
       "total_data_sets": 3,
       "message": null,
       "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 53
+      "duration_ms": 48
     },
     {
       "ecc_id": "ECC-VAL-018",
@@ -3538,7 +3564,7 @@
       "total_data_sets": 3,
       "message": null,
       "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 54
+      "duration_ms": 49
     },
     {
       "ecc_id": "ECC-VAL-019",
@@ -3555,7 +3581,7 @@
       "total_data_sets": 3,
       "message": null,
       "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 53
+      "duration_ms": 47
     },
     {
       "ecc_id": "ECC-VAL-020",
@@ -3572,7 +3598,7 @@
       "total_data_sets": 3,
       "message": null,
       "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 54
+      "duration_ms": 47
     },
     {
       "ecc_id": "ECC-VAL-021",
@@ -3589,7 +3615,7 @@
       "total_data_sets": 3,
       "message": null,
       "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 54
+      "duration_ms": 46
     },
     {
       "ecc_id": "ECC-VAL-022",
@@ -3606,7 +3632,7 @@
       "total_data_sets": 3,
       "message": null,
       "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 52
+      "duration_ms": 49
     },
     {
       "ecc_id": "ECC-VAL-023",
@@ -3623,7 +3649,7 @@
       "total_data_sets": 3,
       "message": null,
       "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 50
+      "duration_ms": 45
     },
     {
       "ecc_id": "ECC-VAL-024",
@@ -3640,7 +3666,7 @@
       "total_data_sets": 3,
       "message": null,
       "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 53
+      "duration_ms": 46
     },
     {
       "ecc_id": "ECC-VAL-025",
@@ -3657,7 +3683,7 @@
       "total_data_sets": 3,
       "message": null,
       "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 52
+      "duration_ms": 46
     },
     {
       "ecc_id": "ECC-VAL-026",
@@ -3674,7 +3700,7 @@
       "total_data_sets": 3,
       "message": null,
       "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 51
+      "duration_ms": 45
     },
     {
       "ecc_id": "ECC-VAL-027",
@@ -3691,7 +3717,7 @@
       "total_data_sets": 3,
       "message": null,
       "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 51
+      "duration_ms": 44
     },
     {
       "ecc_id": "ECC-VAL-028",
@@ -3708,7 +3734,7 @@
       "total_data_sets": 3,
       "message": null,
       "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 50
+      "duration_ms": 43
     },
     {
       "ecc_id": "ECC-VAL-029",
@@ -3725,7 +3751,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 ehr §EVENT; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 35
+      "duration_ms": 30
     },
     {
       "ecc_id": "ECC-VAL-030",
@@ -3742,7 +3768,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 ehr §EVENT; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 34
+      "duration_ms": 30
     },
     {
       "ecc_id": "ECC-VAL-031",
@@ -3759,7 +3785,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "RM 1.2.0 ehr §EVENT; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 18
+      "duration_ms": 16
     },
     {
       "ecc_id": "ECC-VAL-032",
@@ -3776,7 +3802,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 ehr §EVENT; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 35
+      "duration_ms": 31
     },
     {
       "ecc_id": "ECC-VAL-033",
@@ -3793,7 +3819,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 ehr §EVENT; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 36
+      "duration_ms": 31
     },
     {
       "ecc_id": "ECC-VAL-034",
@@ -3810,7 +3836,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 ehr §ITEM_STRUCTURE; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 58
+      "duration_ms": 79
     },
     {
       "ecc_id": "ECC-VAL-035",
@@ -3827,7 +3853,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 ehr §ITEM_STRUCTURE; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 47
+      "duration_ms": 44
     },
     {
       "ecc_id": "ECC-VAL-036",
@@ -3844,7 +3870,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 ehr §ITEM_STRUCTURE; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 45
+      "duration_ms": 41
     },
     {
       "ecc_id": "ECC-VAL-037",
@@ -3861,7 +3887,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 ehr §ITEM_STRUCTURE; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 44
+      "duration_ms": 41
     },
     {
       "ecc_id": "ECC-VAL-038",
@@ -3878,7 +3904,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 ehr §ITEM_STRUCTURE; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 44
+      "duration_ms": 42
     },
     {
       "ecc_id": "ECC-VAL-039",
@@ -3895,7 +3921,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_BOOLEAN; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 62
+      "duration_ms": 63
     },
     {
       "ecc_id": "ECC-VAL-040",
@@ -3912,7 +3938,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_BOOLEAN; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 66
+      "duration_ms": 59
     },
     {
       "ecc_id": "ECC-VAL-041",
@@ -3929,7 +3955,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_BOOLEAN; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 64
+      "duration_ms": 58
     },
     {
       "ecc_id": "ECC-VAL-042",
@@ -3946,7 +3972,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_IDENTIFIER; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 65
+      "duration_ms": 58
     },
     {
       "ecc_id": "ECC-VAL-043",
@@ -3963,7 +3989,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_IDENTIFIER; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 64
+      "duration_ms": 58
     },
     {
       "ecc_id": "ECC-VAL-044",
@@ -3980,7 +4006,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_TEXT; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 58
+      "duration_ms": 50
     },
     {
       "ecc_id": "ECC-VAL-045",
@@ -3997,7 +4023,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_TEXT; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 66
+      "duration_ms": 59
     },
     {
       "ecc_id": "ECC-VAL-046",
@@ -4014,7 +4040,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_CODED_TEXT; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 56
+      "duration_ms": 52
     },
     {
       "ecc_id": "ECC-VAL-047",
@@ -4031,7 +4057,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_CODED_TEXT; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 63
+      "duration_ms": 57
     },
     {
       "ecc_id": "ECC-VAL-048",
@@ -4048,7 +4074,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_CODED_TEXT; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 64
+      "duration_ms": 58
     },
     {
       "ecc_id": "ECC-VAL-049",
@@ -4065,7 +4091,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_ORDINAL; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 56
+      "duration_ms": 51
     },
     {
       "ecc_id": "ECC-VAL-050",
@@ -4082,7 +4108,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_ORDINAL; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 54
+      "duration_ms": 49
     },
     {
       "ecc_id": "ECC-VAL-051",
@@ -4099,7 +4125,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_SCALE; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 63
+      "duration_ms": 56
     },
     {
       "ecc_id": "ECC-VAL-052",
@@ -4116,7 +4142,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_SCALE; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 65
+      "duration_ms": 58
     },
     {
       "ecc_id": "ECC-VAL-053",
@@ -4133,7 +4159,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_COUNT; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 56
+      "duration_ms": 50
     },
     {
       "ecc_id": "ECC-VAL-054",
@@ -4150,7 +4176,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_COUNT; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 87
+      "duration_ms": 57
     },
     {
       "ecc_id": "ECC-VAL-055",
@@ -4167,7 +4193,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_COUNT; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 70
+      "duration_ms": 58
     },
     {
       "ecc_id": "ECC-VAL-056",
@@ -4184,7 +4210,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_QUANTITY; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 56
+      "duration_ms": 50
     },
     {
       "ecc_id": "ECC-VAL-057",
@@ -4201,7 +4227,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_QUANTITY; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 65
+      "duration_ms": 57
     },
     {
       "ecc_id": "ECC-VAL-058",
@@ -4218,7 +4244,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_QUANTITY; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 58
+      "duration_ms": 49
     },
     {
       "ecc_id": "ECC-VAL-059",
@@ -4235,7 +4261,7 @@
       "total_data_sets": 3,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_QUANTITY; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 54
+      "duration_ms": 48
     },
     {
       "ecc_id": "ECC-VAL-060",
@@ -4252,7 +4278,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_PROPORTION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 60
+      "duration_ms": 49
     },
     {
       "ecc_id": "ECC-VAL-061",
@@ -4269,7 +4295,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_PROPORTION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 64
+      "duration_ms": 58
     },
     {
       "ecc_id": "ECC-VAL-062",
@@ -4286,7 +4312,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_PROPORTION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 62
+      "duration_ms": 59
     },
     {
       "ecc_id": "ECC-VAL-063",
@@ -4303,7 +4329,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_PROPORTION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 64
+      "duration_ms": 57
     },
     {
       "ecc_id": "ECC-VAL-064",
@@ -4320,7 +4346,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_PROPORTION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 64
+      "duration_ms": 58
     },
     {
       "ecc_id": "ECC-VAL-065",
@@ -4337,7 +4363,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_PROPORTION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 64
+      "duration_ms": 57
     },
     {
       "ecc_id": "ECC-VAL-066",
@@ -4354,7 +4380,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_PROPORTION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 39
+      "duration_ms": 35
     },
     {
       "ecc_id": "ECC-VAL-067",
@@ -4371,7 +4397,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_PROPORTION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 69
+      "duration_ms": 56
     },
     {
       "ecc_id": "ECC-VAL-068",
@@ -4388,7 +4414,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_COUNT>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 69
+      "duration_ms": 58
     },
     {
       "ecc_id": "ECC-VAL-069",
@@ -4405,7 +4431,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_COUNT>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 65
+      "duration_ms": 132
     },
     {
       "ecc_id": "ECC-VAL-070",
@@ -4422,7 +4448,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_COUNT>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 66
+      "duration_ms": 125
     },
     {
       "ecc_id": "ECC-VAL-071",
@@ -4439,7 +4465,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_QUANTITY>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 64
+      "duration_ms": 113
     },
     {
       "ecc_id": "ECC-VAL-072",
@@ -4456,7 +4482,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_QUANTITY>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 64
+      "duration_ms": 102
     },
     {
       "ecc_id": "ECC-VAL-073",
@@ -4473,7 +4499,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DATE_TIME>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 67
+      "duration_ms": 108
     },
     {
       "ecc_id": "ECC-VAL-074",
@@ -4490,7 +4516,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DATE_TIME>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 75
+      "duration_ms": 113
     },
     {
       "ecc_id": "ECC-VAL-075",
@@ -4507,7 +4533,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DATE_TIME>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 66
+      "duration_ms": 108
     },
     {
       "ecc_id": "ECC-VAL-076",
@@ -4524,7 +4550,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DATE>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 65
+      "duration_ms": 105
     },
     {
       "ecc_id": "ECC-VAL-077",
@@ -4541,7 +4567,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DATE>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 62
+      "duration_ms": 106
     },
     {
       "ecc_id": "ECC-VAL-078",
@@ -4558,7 +4584,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DATE>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 63
+      "duration_ms": 115
     },
     {
       "ecc_id": "ECC-VAL-079",
@@ -4575,7 +4601,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_TIME>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 63
+      "duration_ms": 122
     },
     {
       "ecc_id": "ECC-VAL-080",
@@ -4592,7 +4618,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_TIME>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 63
+      "duration_ms": 102
     },
     {
       "ecc_id": "ECC-VAL-081",
@@ -4609,7 +4635,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_TIME>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 64
+      "duration_ms": 97
     },
     {
       "ecc_id": "ECC-VAL-082",
@@ -4626,7 +4652,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DURATION>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 68
+      "duration_ms": 113
     },
     {
       "ecc_id": "ECC-VAL-083",
@@ -4643,7 +4669,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DURATION>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 65
+      "duration_ms": 138
     },
     {
       "ecc_id": "ECC-VAL-084",
@@ -4660,7 +4686,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DURATION>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 64
+      "duration_ms": 110
     },
     {
       "ecc_id": "ECC-VAL-085",
@@ -4677,7 +4703,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_ORDINAL>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 63
+      "duration_ms": 125
     },
     {
       "ecc_id": "ECC-VAL-086",
@@ -4694,7 +4720,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_ORDINAL>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 63
+      "duration_ms": 98
     },
     {
       "ecc_id": "ECC-VAL-087",
@@ -4711,7 +4737,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_SCALE>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 64
+      "duration_ms": 114
     },
     {
       "ecc_id": "ECC-VAL-088",
@@ -4728,7 +4754,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_SCALE>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 62
+      "duration_ms": 88
     },
     {
       "ecc_id": "ECC-VAL-089",
@@ -4745,7 +4771,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 64
+      "duration_ms": 88
     },
     {
       "ecc_id": "ECC-VAL-090",
@@ -4762,7 +4788,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 63
+      "duration_ms": 75
     },
     {
       "ecc_id": "ECC-VAL-091",
@@ -4779,7 +4805,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 63
+      "duration_ms": 69
     },
     {
       "ecc_id": "ECC-VAL-092",
@@ -4796,7 +4822,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 64
+      "duration_ms": 66
     },
     {
       "ecc_id": "ECC-VAL-093",
@@ -4813,7 +4839,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 62
+      "duration_ms": 68
     },
     {
       "ecc_id": "ECC-VAL-094",
@@ -4830,7 +4856,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 63
+      "duration_ms": 65
     },
     {
       "ecc_id": "ECC-VAL-095",
@@ -4847,7 +4873,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 62
+      "duration_ms": 61
     },
     {
       "ecc_id": "ECC-VAL-096",
@@ -4864,7 +4890,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_DURATION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 54
+      "duration_ms": 57
     },
     {
       "ecc_id": "ECC-VAL-097",
@@ -4881,7 +4907,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_DURATION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 62
+      "duration_ms": 63
     },
     {
       "ecc_id": "ECC-VAL-098",
@@ -4898,7 +4924,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_DURATION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 64
+      "duration_ms": 63
     },
     {
       "ecc_id": "ECC-VAL-099",
@@ -4915,7 +4941,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_DURATION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 65
+      "duration_ms": 60
     },
     {
       "ecc_id": "ECC-VAL-100",
@@ -4932,7 +4958,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_TIME; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 56
+      "duration_ms": 52
     },
     {
       "ecc_id": "ECC-VAL-101",
@@ -4949,7 +4975,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_TIME; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 66
+      "duration_ms": 59
     },
     {
       "ecc_id": "ECC-VAL-102",
@@ -4966,7 +4992,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_TIME; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 64
+      "duration_ms": 59
     },
     {
       "ecc_id": "ECC-VAL-103",
@@ -4983,7 +5009,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_DATE; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 54
+      "duration_ms": 52
     },
     {
       "ecc_id": "ECC-VAL-104",
@@ -5000,7 +5026,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_DATE; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 62
+      "duration_ms": 59
     },
     {
       "ecc_id": "ECC-VAL-105",
@@ -5017,7 +5043,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_DATE; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 62
+      "duration_ms": 60
     },
     {
       "ecc_id": "ECC-VAL-119",
@@ -5034,7 +5060,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "AM 1.4 C_DATE (yyyy-??-XX: month optional, day disallowed; org.openehr.am.aom14.c_date.adoc); valid_templates/all_types/Test_all_types.opt; ITS-REST 1.0.3 composition_create (422 rejected)",
-      "duration_ms": 25
+      "duration_ms": 28
     },
     {
       "ecc_id": "ECC-VAL-106",
@@ -5051,7 +5077,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_DATE_TIME; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 53
+      "duration_ms": 52
     },
     {
       "ecc_id": "ECC-VAL-107",
@@ -5068,7 +5094,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_DATE_TIME; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 54
+      "duration_ms": 51
     },
     {
       "ecc_id": "ECC-VAL-108",
@@ -5085,7 +5111,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_DATE_TIME; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 64
+      "duration_ms": 58
     },
     {
       "ecc_id": "ECC-VAL-109",
@@ -5102,7 +5128,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_PARSABLE; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 54
+      "duration_ms": 50
     },
     {
       "ecc_id": "ECC-VAL-110",
@@ -5119,7 +5145,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_PARSABLE; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 63
+      "duration_ms": 59
     },
     {
       "ecc_id": "ECC-VAL-111",
@@ -5136,7 +5162,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_MULTIMEDIA; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 54
+      "duration_ms": 50
     },
     {
       "ecc_id": "ECC-VAL-112",
@@ -5153,7 +5179,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_MULTIMEDIA; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 64
+      "duration_ms": 58
     },
     {
       "ecc_id": "ECC-VAL-113",
@@ -5170,7 +5196,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_URI; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 54
+      "duration_ms": 50
     },
     {
       "ecc_id": "ECC-VAL-114",
@@ -5187,7 +5213,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_URI; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 64
+      "duration_ms": 58
     },
     {
       "ecc_id": "ECC-VAL-115",
@@ -5204,7 +5230,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_URI; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 63
+      "duration_ms": 59
     },
     {
       "ecc_id": "ECC-VAL-116",
@@ -5221,7 +5247,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_EHR_URI; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 65
+      "duration_ms": 58
     },
     {
       "ecc_id": "ECC-VAL-117",
@@ -5238,7 +5264,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_EHR_URI; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 92
+      "duration_ms": 102
     },
     {
       "ecc_id": "ECC-VAL-118",
@@ -5255,7 +5281,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_EHR_URI; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 63
+      "duration_ms": 60
     },
     {
       "ecc_id": "ECC-SIG-001",
@@ -5271,7 +5297,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "version-signing.md §3.2 (digest default-on); §4.4 (rides every VERSION read)",
-      "duration_ms": 26
+      "duration_ms": 23
     },
     {
       "ecc_id": "ECC-SIG-001",
@@ -5287,7 +5313,7 @@
       "total_data_sets": 0,
       "message": "expected status 200, got 406 (body: {\"error\":\"Not Acceptable\",\"message\":\"not acceptable: canonical XML for this response is available once typed payloads land (P12); request application/json\"})",
       "citation": "version-signing.md §3.2 (digest default-on); §4.4 (rides every VERSION read)",
-      "duration_ms": 26
+      "duration_ms": 21
     },
     {
       "ecc_id": "ECC-SIG-002",
@@ -5303,7 +5329,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "version-signing.md §3.1 (canonical_form RFC 8785) + §6.3",
-      "duration_ms": 27
+      "duration_ms": 25
     },
     {
       "ecc_id": "ECC-SIG-003",
@@ -5319,7 +5345,7 @@
       "total_data_sets": 4,
       "message": null,
       "citation": "version-signing.md §3.3 (all object kinds via the shared vobject commit path)",
-      "duration_ms": 67
+      "duration_ms": 56
     },
     {
       "ecc_id": "ECC-SIG-004",
@@ -5335,7 +5361,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "version-signing.md §3.3 (client-supplied signatures win, stored verbatim)",
-      "duration_ms": 24
+      "duration_ms": 20
     },
     {
       "ecc_id": "ECC-SIG-005",
@@ -5511,6 +5537,150 @@
       "total_data_sets": 0,
       "message": "NativeApiOnly: I_TDD_SERVICE.import_tdds is exercised by app/ehrbase/tests/service_tdd.rs::{tdd_import_tdds_batch_commits_all, tdd_import_tdds_batch_fail_fast} — Messaging has no ITS-REST binding",
       "citation": "SM I_TDD_SERVICE.import_tdds; CNF master13 §I_TDD.import_tdds (TBD)",
+      "duration_ms": 0
+    },
+    {
+      "ecc_id": "ECC-TS-001",
+      "id": "ts/expand-bundle-accepted",
+      "title": "TERMINOLOGY expand (bundle) — accepted, well-formed RESULT_SET",
+      "capability": "Terminology",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query",
+      "duration_ms": 12
+    },
+    {
+      "ecc_id": "ECC-TS-002",
+      "id": "ts/expand-bundle-constrains",
+      "title": "TERMINOLOGY expand (bundle) — expansion constrains matches to the value set's codes",
+      "capability": "Terminology",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 2,
+      "total_data_sets": 2,
+      "message": null,
+      "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query",
+      "duration_ms": 36
+    },
+    {
+      "ecc_id": "ECC-TS-003",
+      "id": "ts/expand-bundle-mixed-list",
+      "title": "TERMINOLOGY expand (bundle) — explicit code merged with the expansion (matches list)",
+      "capability": "Terminology",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query",
+      "duration_ms": 29
+    },
+    {
+      "ecc_id": "ECC-TS-004",
+      "id": "ts/expand-unknown-value-set-rejected",
+      "title": "TERMINOLOGY expand — unknown value set rejected (400)",
+      "capability": "Terminology",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-TS-005",
+      "id": "ts/expand-unknown-service-rejected",
+      "title": "TERMINOLOGY expand — unknown service_api rejected (400)",
+      "capability": "Terminology",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query",
+      "duration_ms": 5
+    },
+    {
+      "ecc_id": "ECC-TS-006",
+      "id": "ts/expand-fhir-provider",
+      "title": "TERMINOLOGY expand (FHIR service_api) — accepted when a provider is configured",
+      "capability": "Terminology",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "skipped",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "SutConfig: no FHIR terminology provider configured on the SUT (EHRBASE_VALIDATION_EXTERNAL_TERMINOLOGY_* unset) — a `hl7.org/fhir/4.0` expand is rejected as `UnknownTerminologyService`. harness terminology server: http://127.0.0.1:57453 (fixture). The bundle (`openehr`) expand cases prove the TERMINOLOGY family; wire this by pointing the SUT at a FHIR server (host.docker.internal for a runner-host fixture, docs/design/terminology-server-integration.md §5).",
+      "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-TS-007",
+      "id": "ts/fault-timeout",
+      "title": "TERMINOLOGY expand (FHIR) — terminology-server timeout is a server fault (500)",
+      "capability": "Terminology",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "skipped",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "SutConfig: the timeout fault requires a fault-injecting terminology server wired to the SUT (--tx-server-url + an SUT FHIR provider pointed at it); the HTTP-only ECC cannot reconfigure an external SUT's provider per case. Harness tx server: http://127.0.0.1:57453 (fixture). The fault→500 mapping is proven by conformance ts::fixture::tests::fault_timeout_exceeds_a_short_client_deadline + app/ehrbase/tests/terminology_fhir.rs::timeout_is_an_exception.",
+      "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query",
+      "duration_ms": 0
+    },
+    {
+      "ecc_id": "ECC-TS-008",
+      "id": "ts/fault-server-error",
+      "title": "TERMINOLOGY expand (FHIR) — terminology-server 5xx is a server fault (500)",
+      "capability": "Terminology",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "skipped",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "SutConfig: the 5xx fault requires a fault-injecting terminology server wired to the SUT (--tx-server-url + an SUT FHIR provider pointed at it); the HTTP-only ECC cannot reconfigure an external SUT's provider per case. Harness tx server: http://127.0.0.1:57453 (fixture). The fault→500 mapping is proven by conformance ts::fixture::tests::fault_server_error_is_5xx + app/ehrbase/tests/terminology_fhir.rs::server_5xx_is_an_exception.",
+      "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query",
+      "duration_ms": 0
+    },
+    {
+      "ecc_id": "ECC-TS-009",
+      "id": "ts/fault-malformed",
+      "title": "TERMINOLOGY expand (FHIR) — malformed terminology response is a server fault (500)",
+      "capability": "Terminology",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "skipped",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "SutConfig: the malformed fault requires a fault-injecting terminology server wired to the SUT (--tx-server-url + an SUT FHIR provider pointed at it); the HTTP-only ECC cannot reconfigure an external SUT's provider per case. Harness tx server: http://127.0.0.1:57453 (fixture). The fault→500 mapping is proven by conformance ts::fixture::tests::fault_malformed_is_not_json + app/ehrbase/tests/terminology_fhir.rs::malformed_body_is_an_exception.",
+      "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query",
       "duration_ms": 0
     }
   ]

--- a/docs/plans/b4-terminology.md
+++ b/docs/plans/b4-terminology.md
@@ -1,0 +1,37 @@
+# B4 — Terminology-server integration (+ its test harness)
+
+- Status: in-progress
+- Started: 2026-07-10   Owner: Ruben
+- Governing plan: blueprint §3 B4; designs `docs/terminology-validation.md`
+  (client) + `docs/design/terminology-server-integration.md` (Docker TS)
+- Oracle: QUERY master03 (AQL TERMINOLOGY family), SM master12; ECC baseline
+  293 passed / 329 executed, zero-drift gate
+
+## Tasks (blueprint §3 B4)
+
+- [ ] 1. External tx-server provider (FHIR R4 TS via reqwest) behind the
+      existing `TerminologyService` trait — real subsumes /
+      value_set_validate / get_value_set against a remote server; the
+      openEHR-bundle provider stays the local default.
+- [ ] 2. AQL terminology family (Q-15/16/23): `TERMINOLOGY('expand'|'validate'
+      |…, service_api, params_uri)` + `matches {uri}` + mixed lists, expansion
+      merged into matches at semantic analysis (master03 lines 756–759);
+      staged expand → validate-as-boolean → URI operand; typed rejects until
+      each lands.
+- [ ] 3. Terminology wire exposure (extension OAS, design doc 08 §7) for
+      I_TERMINOLOGY_SERVICE (+ EHR Index/Admin wire while in the area).
+- [ ] 4. Test harness in tools/conformance: `TS` case area — wiremock-backed
+      FHIR-tx fixture server spun up by the runner (expand/validate/lookup/
+      subsumes + fault injection) and optional real-server mode
+      (`--tx-server-url`, skip-with-reason when unset).
+
+## Exit criteria
+
+- [ ] Mission item demonstrable in CI without network + against a real Docker
+      TS on demand; workspace suites green; full ECC zero drift.
+
+## Handoff
+
+Opened from develop @ B3 merge (PR #38). Process rules: ONE cargo runner at a
+time; agents use isolated CARGO_TARGET_DIR; verification inline foreground;
+ECC only via scripts/conformance.sh, run centrally at phase close.

--- a/docs/plans/b4-terminology.md
+++ b/docs/plans/b4-terminology.md
@@ -17,7 +17,7 @@
       figment config, bundle-default/fhir-opt-in, typed 404/exception
       mapping); 12 wiremock tests incl. fault injection; OAuth2/mTLS +
       walker hookup PORT-NOTEd for later tasks.*
-- [ ] 2. AQL terminology family (Q-15/16/23): `TERMINOLOGY('expand'|'validate'
+- [x] 2. AQL terminology family (Q-15/16/23): `TERMINOLOGY('expand'|'validate'
       |…, service_api, params_uri)` + `matches {uri}` + mixed lists, expansion
       merged into matches at semantic analysis (master03 lines 756–759);
       staged expand → validate-as-boolean → URI operand; typed rejects until

--- a/docs/plans/b4-terminology.md
+++ b/docs/plans/b4-terminology.md
@@ -24,10 +24,18 @@
       each lands.
 - [ ] 3. Terminology wire exposure (extension OAS, design doc 08 §7) for
       I_TERMINOLOGY_SERVICE (+ EHR Index/Admin wire while in the area).
-- [ ] 4. Test harness in tools/conformance: `TS` case area — wiremock-backed
+- [x] 4. Test harness in tools/conformance: `TS` case area — wiremock-backed
       FHIR-tx fixture server spun up by the runner (expand/validate/lookup/
       subsumes + fault injection) and optional real-server mode
-      (`--tx-server-url`, skip-with-reason when unset).
+      (`--tx-server-url`, skip-with-reason when unset). *Done 2026-07-10:
+      new `Area::Ts` + `Capability::Terminology`; `ts::fixture::FhirTxFixture`
+      (canned + fault modes, self-check, exchange recording; 6 nextest tests);
+      `--tx-server-url` CLI + runner spins up the hermetic fixture by default
+      and records the FHIR-tx exchange in the report (`RunResults.terminology`).
+      9 ECC-TS cases: bundle expand real passes (TS-001..005), FHIR-provider
+      PASS/SKIP(SutConfig) (TS-006), fault-injection SKIP(SutConfig) citing the
+      fixture + app wiremock evidence (TS-007..009). `nextest -p conformance`
+      41/41 green; catalog regenerated (guard green).*
 
 ## Exit criteria
 

--- a/docs/plans/b4-terminology.md
+++ b/docs/plans/b4-terminology.md
@@ -9,10 +9,14 @@
 
 ## Tasks (blueprint §3 B4)
 
-- [ ] 1. External tx-server provider (FHIR R4 TS via reqwest) behind the
+- [x] 1. External tx-server provider (FHIR R4 TS via reqwest) behind the
       existing `TerminologyService` trait — real subsumes /
       value_set_validate / get_value_set against a remote server; the
-      openEHR-bundle provider stays the local default.
+      openEHR-bundle provider stays the local default. *Done 2026-07-10:
+      FhirTerminologyProvider (validate-code/expand/subsumes-strict/lookup,
+      figment config, bundle-default/fhir-opt-in, typed 404/exception
+      mapping); 12 wiremock tests incl. fault injection; OAuth2/mTLS +
+      walker hookup PORT-NOTEd for later tasks.*
 - [ ] 2. AQL terminology family (Q-15/16/23): `TERMINOLOGY('expand'|'validate'
       |…, service_api, params_uri)` + `matches {uri}` + mixed lists, expansion
       merged into matches at semantic analysis (master03 lines 756–759);

--- a/docs/plans/b4-terminology.md
+++ b/docs/plans/b4-terminology.md
@@ -22,8 +22,33 @@
       merged into matches at semantic analysis (master03 lines 756–759);
       staged expand → validate-as-boolean → URI operand; typed rejects until
       each lands.
-- [ ] 3. Terminology wire exposure (extension OAS, design doc 08 §7) for
+- [x] 3. Terminology wire exposure (extension OAS, design doc 08 §7) for
       I_TERMINOLOGY_SERVICE (+ EHR Index/Admin wire while in the area).
+      *Done 2026-07-10: config-gated (`RestConfig::terminology`, OFF by
+      default) `/terminology` extension routes in `ehrbase-rest`
+      (`dispatch/terminology.rs`), dispatching to the `TerminologyService`
+      seam — GET `/terminology` (ids), `/terminology/{tid}` (description),
+      `/terminology/{tid}/term/{code}` (get_term/lookup),
+      `/terminology/{tid}/subsumes` (subsumes),
+      `/terminology/{tid}/value_set/{vs}` (get_value_set/expand),
+      `/terminology/{tid}/value_set/{vs}/validate` (value_set_validate).
+      Typed error mapping via the existing `sm_api_error` (bundle's
+      `versioned_object_does_not_exist` → 404). 12 HTTP tests via the shared
+      Mock (new terminology hooks in tests/common). Gates:
+      nextest -p ehrbase-rest 231/231, -p ehrbase-sm 9/9, -p ehrbase 273
+      (1 skip), clippy no new warnings, fmt clean.
+      PORT NOTE (deferrals): (a) the boolean `has_terminology`/`has_term`/
+      `has_value_set` calls are folded into the 200-vs-404 of their get_
+      counterparts (idiomatic REST; not separate endpoints); (b) get_term's
+      `attributes` allow-list is not surfaced on the wire (ambiguous
+      map-vs-list shape, bundle ignores it) — passed as None; (c) EHR
+      Index/Admin wire NOT added: §7 lists their namespaces but not their
+      call/route shapes (unlike terminology's `TerminologyService` seam,
+      EhrIndex/Admin dump-load are still SM-3/SM-4 service work — not
+      equally mechanical), deferred to their own SM phases; §7's
+      `/rest/terminology` namespace is realized as `{base_path}/terminology`
+      (extension groups nest inside the API router, mirroring ADMIN — PORT
+      NOTE in the dispatcher).*
 - [x] 4. Test harness in tools/conformance: `TS` case area — wiremock-backed
       FHIR-tx fixture server spun up by the runner (expand/validate/lookup/
       subsumes + fault injection) and optional real-server mode

--- a/docs/plans/b4-terminology.md
+++ b/docs/plans/b4-terminology.md
@@ -1,6 +1,6 @@
 # B4 — Terminology-server integration (+ its test harness)
 
-- Status: in-progress
+- Status: done (2026-07-10)
 - Started: 2026-07-10   Owner: Ruben
 - Governing plan: blueprint §3 B4; designs `docs/terminology-validation.md`
   (client) + `docs/design/terminology-server-integration.md` (Docker TS)
@@ -64,8 +64,11 @@
 
 ## Exit criteria
 
-- [ ] Mission item demonstrable in CI without network + against a real Docker
-      TS on demand; workspace suites green; full ECC zero drift.
+- [x] Mission item demonstrable in CI without network (wiremock fixture +
+      bundle-provider wire passes) + against a real Docker TS on demand
+      (--tx-server-url); workspace suites green (rest 231/231, ehrbase
+      273/273, sm 9/9, conformance 41/41); phase-close ECC 2026-07-10:
+      338 executed · 298 passed · zero drift (5 new live TS passes).
 
 ## Handoff
 

--- a/docs/plans/current-phase.md
+++ b/docs/plans/current-phase.md
@@ -6,9 +6,9 @@ spec-compliant openEHR CDR". This file is the live pointer under it; the
 consolidated gap surface is the blueprint §2 (proven foundations + ECC
 breakdown + spec-area map).
 
-## Active work — B3: SM-5/SM-6 services
+## Active work — B4: Terminology-server integration
 
-**Phase file: `docs/plans/b3-sm-services.md`** (branch `claude/b3-sm-services`).
+**Phase file: `docs/plans/b4-terminology.md`** (branch `claude/b4-terminology`).
 B2 closed 2026-07-10 (PR #37): ECC 293/319 zero-drift, ArchetypeValidation
 81→0. The single biggest gap: **81 failing ECC
 ArchetypeValidation cases (~76 % of all failures)** — template/archetype

--- a/tools/conformance/Cargo.toml
+++ b/tools/conformance/Cargo.toml
@@ -19,6 +19,12 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 async-trait = { workspace = true }
 reqwest = { workspace = true }
+# The B4 `TS` area spins up a hermetic FHIR-tx fixture server (canned
+# $expand/$validate-code/$lookup/$subsumes + fault injection) the runner hosts
+# and records the exchange from — a runtime dependency, not just a test tool
+# (docs/design/terminology-server-integration.md §5). tools/conformance is a
+# dev/verification crate (publish = false), not part of the shipped app.
+wiremock = { workspace = true }
 clap = { workspace = true }
 jiff = { workspace = true }
 tokio = { workspace = true }

--- a/tools/conformance/inventory/ecc-catalog.tsv
+++ b/tools/conformance/inventory/ecc-catalog.tsv
@@ -323,3 +323,12 @@ ECC-MSG-007	MSG	active	msg/import-ehr-extract	EHR Extract — import extract int
 ECC-MSG-008	MSG	active	msg/tdd-import-commits	TDD — import a TDD as a committed COMPOSITION (import_tdd)
 ECC-MSG-009	MSG	active	msg/tdd-import-rejects	TDD — import rejects malformed / non-TDD / unknown EHR / unknown template
 ECC-MSG-010	MSG	active	msg/tdd-import-tdds-batch	TDD — batch import commits all, fail-fast on error (import_tdds)
+ECC-TS-001	TS	active	ts/expand-bundle-accepted	TERMINOLOGY expand (bundle) — accepted, well-formed RESULT_SET
+ECC-TS-002	TS	active	ts/expand-bundle-constrains	TERMINOLOGY expand (bundle) — expansion constrains matches to the value set's codes
+ECC-TS-003	TS	active	ts/expand-bundle-mixed-list	TERMINOLOGY expand (bundle) — explicit code merged with the expansion (matches list)
+ECC-TS-004	TS	active	ts/expand-unknown-value-set-rejected	TERMINOLOGY expand — unknown value set rejected (400)
+ECC-TS-005	TS	active	ts/expand-unknown-service-rejected	TERMINOLOGY expand — unknown service_api rejected (400)
+ECC-TS-006	TS	active	ts/expand-fhir-provider	TERMINOLOGY expand (FHIR service_api) — accepted when a provider is configured
+ECC-TS-007	TS	active	ts/fault-timeout	TERMINOLOGY expand (FHIR) — terminology-server timeout is a server fault (500)
+ECC-TS-008	TS	active	ts/fault-server-error	TERMINOLOGY expand (FHIR) — terminology-server 5xx is a server fault (500)
+ECC-TS-009	TS	active	ts/fault-malformed	TERMINOLOGY expand (FHIR) — malformed terminology response is a server fault (500)

--- a/tools/conformance/src/bin/conformance.rs
+++ b/tools/conformance/src/bin/conformance.rs
@@ -15,11 +15,13 @@ use std::path::PathBuf;
 use clap::{Parser, Subcommand, ValueEnum};
 
 use conformance::case::{Format, Profile};
-use conformance::catalog::Catalog;
+use conformance::catalog::{Area, Catalog};
 use conformance::client::Credential;
 use conformance::registry::registry;
+use conformance::results::TerminologyRun;
 use conformance::run::RunConfig;
 use conformance::sut::Sut;
+use conformance::ts::{FhirTxFixture, TxServer};
 use conformance::version::SpecVersions;
 use conformance::{report, run};
 
@@ -68,6 +70,12 @@ struct RunArgs {
     /// ADMIN-role credential (same forms as `--auth`).
     #[arg(long)]
     admin_auth: Option<String>,
+    /// Real FHIR R4 terminology-server base URL for the `TS` cases, e.g.
+    /// `http://localhost:8090/fhir` (a HAPI/Snowstorm/Ontoserver container).
+    /// When unset the runner spins up a hermetic `wiremock` FHIR-tx fixture for
+    /// the run (the CI default) and records its exchange in the report.
+    #[arg(long)]
+    tx_server_url: Option<String>,
 }
 
 #[derive(Debug, Parser)]
@@ -153,6 +161,39 @@ fn build_sut(args: &RunArgs) -> Result<(Sut, String), String> {
     Ok((sut, auth_mode))
 }
 
+/// Whether any registered `TS`-area case is in scope for this run (drives
+/// whether the hermetic FHIR-tx fixture is worth spinning up).
+fn ts_cases_selected(args: &RunArgs) -> bool {
+    let profile = args.profile.map(Profile::from);
+    registry().entries().iter().any(|e| {
+        e.meta.area == Area::Ts
+            && args.filter.as_deref().is_none_or(|f| e.meta.id.contains(f))
+            && profile.is_none_or(|p| e.meta.profiles.contains(&p))
+    })
+}
+
+/// Establish the terminology server for the `TS` cases: a real server when
+/// `--tx-server-url` is given, else — when `TS` cases are in scope — the
+/// hermetic `wiremock` FHIR-tx fixture the runner hosts. Returns the descriptor
+/// threaded to cases plus the live fixture (kept alive for the run, its exchange
+/// recorded afterward).
+async fn establish_tx(args: &RunArgs) -> (Option<TxServer>, Option<FhirTxFixture>) {
+    if let Some(url) = &args.tx_server_url {
+        return (Some(TxServer::real(url.clone())), None);
+    }
+    if !ts_cases_selected(args) {
+        return (None, None);
+    }
+    let fixture = FhirTxFixture::start_canned().await;
+    let base = fixture.base_url();
+    // The self-check proves the fixture answers and seeds the recorded exchange.
+    if let Err(e) = fixture.self_check().await {
+        eprintln!("warning: FHIR-tx fixture self-check failed, running without it: {e}");
+        return (None, None);
+    }
+    (Some(TxServer::fixture(base)), Some(fixture))
+}
+
 async fn cmd_run(args: RunArgs) -> i32 {
     let (sut, auth_mode) = match build_sut(&args) {
         Ok(pair) => pair,
@@ -161,20 +202,35 @@ async fn cmd_run(args: RunArgs) -> i32 {
             return 2;
         }
     };
+    let (tx, fixture) = establish_tx(&args).await;
     let config = RunConfig {
         filter: args.filter.clone(),
         profile: args.profile.map(Profile::from),
         formats: args.format.formats(),
         versions: SpecVersions::latest(),
         auth_mode,
+        tx: tx.clone(),
     };
-    let results = match run::run(sut.transport(), &config).await {
+    let mut results = match run::run(sut.transport(), &config).await {
         Ok(r) => r,
         Err(e) => {
             eprintln!("error: {e}");
             return 2;
         }
     };
+    // Record the terminology run + the FHIR-tx exchange (the fixture's own
+    // self-check plus anything a SUT wired to it sent).
+    if let Some(server) = &tx {
+        let exchanges = match &fixture {
+            Some(fx) => fx.exchanges().await,
+            None => Vec::new(),
+        };
+        results.terminology = Some(TerminologyRun {
+            base_url: server.base_url.clone(),
+            mode: server.mode.label().to_owned(),
+            exchanges,
+        });
+    }
     if let Err(e) = report::write_all(&results, &args.out) {
         eprintln!("error writing report: {e}");
         return 2;

--- a/tools/conformance/src/engine/harness.rs
+++ b/tools/conformance/src/engine/harness.rs
@@ -246,6 +246,12 @@ pub struct RunContext<'a> {
     pub transport: &'a dyn Transport,
     /// The wire format this run is exercising.
     pub format: Format,
+    /// The terminology server the harness has available for this run (B4 `TS`
+    /// area): the hermetic `wiremock` fixture or a real server
+    /// (`--tx-server-url`). `None` when none was established. A case reads this
+    /// to phrase its skip reason and to record which server it targeted; the
+    /// SUT is still reached only over [`RunContext::transport`].
+    pub tx: Option<&'a crate::ts::TxServer>,
 }
 
 impl std::fmt::Debug for RunContext<'_> {
@@ -253,6 +259,7 @@ impl std::fmt::Debug for RunContext<'_> {
         f.debug_struct("RunContext")
             .field("format", &self.format)
             .field("transport", &self.transport.describe())
+            .field("tx", &self.tx.map(|t| &t.base_url))
             .finish()
     }
 }

--- a/tools/conformance/src/engine/run.rs
+++ b/tools/conformance/src/engine/run.rs
@@ -32,6 +32,11 @@ pub struct RunConfig {
     pub versions: SpecVersions,
     /// The declared auth mode (recorded in the statement).
     pub auth_mode: String,
+    /// The terminology server the run has available (B4 `TS` area): the
+    /// spun-up `wiremock` fixture (CI default) or a real server
+    /// (`--tx-server-url`). `None` when no terminology server was established —
+    /// the FHIR-tx / fault-injection `TS` cases then skip with a stated reason.
+    pub tx: Option<crate::ts::TxServer>,
 }
 
 impl Default for RunConfig {
@@ -42,6 +47,7 @@ impl Default for RunConfig {
             formats: vec![Format::Json],
             versions: SpecVersions::latest(),
             auth_mode: "unknown".to_owned(),
+            tx: None,
         }
     }
 }
@@ -76,7 +82,11 @@ pub async fn run(transport: &dyn Transport, config: &RunConfig) -> Result<RunRes
             if !meta.formats.contains(&format) {
                 continue;
             }
-            let ctx = RunContext { transport, format };
+            let ctx = RunContext {
+                transport,
+                format,
+                tx: config.tx.as_ref(),
+            };
             let start = Instant::now();
             let result = (entry.run)(&ctx).await;
             let duration_ms = start.elapsed().as_millis();
@@ -125,6 +135,9 @@ pub async fn run(transport: &dyn Transport, config: &RunConfig) -> Result<RunRes
                 .map(|f| format!("{f:?}").to_lowercase())
                 .collect(),
         },
+        // The terminology run record (fixture + recorded exchange) is attached
+        // by the runner binary, which owns the fixture lifecycle.
+        terminology: None,
         cases,
     })
 }

--- a/tools/conformance/src/lib.rs
+++ b/tools/conformance/src/lib.rs
@@ -37,6 +37,7 @@ pub mod model;
 pub mod reporting;
 pub mod suites;
 pub mod testdata;
+pub mod ts;
 
 // Stable public facade: the flat module paths are the crate API (used by the
 // suites, the CLI, and the integration tests); the directories above are the

--- a/tools/conformance/src/model/case.rs
+++ b/tools/conformance/src/model/case.rs
@@ -100,6 +100,16 @@ pub enum Capability {
     /// (a wire-tested SUT must not be denied OPTIONS for a capability the wire
     /// cannot reach) — it is reported individually.
     Messaging,
+    /// Terminology-server integration (OPTIONS) — the AQL `TERMINOLOGY('expand',
+    /// …)` family (B4). The in-process `openehr-term` bundle
+    /// (`service_api = "openehr"`) is wire-exercisable and its cases pass against
+    /// any SUT; the external FHIR-tx cases depend on the SUT carrying a
+    /// configured FHIR terminology provider and report `SKIPPED(SutConfig)`
+    /// otherwise. Like [`Capability::Messaging`] it is *not* in
+    /// [`crate::profile::required_capabilities`] (an optional, partly
+    /// config-gated capability is reported individually, never blocking a
+    /// profile).
+    Terminology,
 }
 
 /// A wire format a case runs under.

--- a/tools/conformance/src/model/catalog.rs
+++ b/tools/conformance/src/model/catalog.rs
@@ -58,11 +58,13 @@ pub enum Area {
     Sig,
     /// Messaging (EHR Extract / TDS), when implemented.
     Msg,
+    /// Terminology-server integration (AQL TERMINOLOGY family + FHIR-tx).
+    Ts,
 }
 
 impl Area {
     /// Every area, in catalogue order.
-    pub const ALL: [Area; 15] = [
+    pub const ALL: [Area; 16] = [
         Area::Ehr,
         Area::Sta,
         Area::Com,
@@ -78,6 +80,7 @@ impl Area {
         Area::Sec,
         Area::Sig,
         Area::Msg,
+        Area::Ts,
     ];
 
     /// The id segment (`EHR`, `STA`, …).
@@ -99,6 +102,7 @@ impl Area {
             Area::Sec => "SEC",
             Area::Sig => "SIG",
             Area::Msg => "MSG",
+            Area::Ts => "TS",
         }
     }
 
@@ -121,6 +125,7 @@ impl Area {
             Area::Sec => "Security / authorization",
             Area::Sig => "Version signing",
             Area::Msg => "Messaging",
+            Area::Ts => "Terminology-server integration",
         }
     }
 

--- a/tools/conformance/src/model/profile.rs
+++ b/tools/conformance/src/model/profile.rs
@@ -143,6 +143,7 @@ mod tests {
             corpus: CorpusPin::default(),
             started: String::new(),
             selection: SelectionInfo::default(),
+            terminology: None,
             cases,
         }
     }

--- a/tools/conformance/src/reporting/report.rs
+++ b/tools/conformance/src/reporting/report.rs
@@ -378,7 +378,40 @@ fn render_report_md(results: &RunResults, catalog: &Catalog) -> String {
             let _ = writeln!(out, "| {reason} | {count} |");
         }
     }
+
+    render_terminology(&mut out, results);
     out
+}
+
+/// The terminology-server section (B4 `TS` area): the tx server the run had
+/// available and the recorded FHIR-tx exchange.
+fn render_terminology(out: &mut String, results: &RunResults) {
+    out.push_str("\n## 6. Terminology server (TS area)\n\n");
+    let Some(tx) = &results.terminology else {
+        out.push_str("_No terminology server was established for this run._\n");
+        return;
+    };
+    let _ = writeln!(out, "- Server: `{}`\n- Mode: {}\n", tx.base_url, tx.mode);
+    if tx.exchanges.is_empty() {
+        out.push_str("_No FHIR-tx exchange recorded._\n");
+        return;
+    }
+    let _ = writeln!(
+        out,
+        "Recorded FHIR-tx exchange ({} request(s)):\n",
+        tx.exchanges.len()
+    );
+    out.push_str("| # | Method | Path | Query |\n|--:|---|---|---|\n");
+    for (i, e) in tx.exchanges.iter().enumerate() {
+        let _ = writeln!(
+            out,
+            "| {} | {} | `{}` | {} |",
+            i + 1,
+            e.method,
+            e.path,
+            e.query.as_deref().unwrap_or("—")
+        );
+    }
 }
 
 fn render_badge(results: &RunResults, catalog: &Catalog) -> String {
@@ -449,6 +482,7 @@ mod tests {
             corpus: CorpusPin::default(),
             started: "2026-07-07T00:00:00Z".to_owned(),
             selection: SelectionInfo::default(),
+            terminology: None,
             cases: Vec::new(),
         }
     }

--- a/tools/conformance/src/reporting/results.rs
+++ b/tools/conformance/src/reporting/results.rs
@@ -18,6 +18,10 @@ pub struct RunResults {
     pub started: String,
     /// The selection that scoped this run.
     pub selection: SelectionInfo,
+    /// The terminology server the run had available + the recorded FHIR-tx
+    /// exchange (B4 `TS` area). Absent when the run had no terminology server.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminology: Option<TerminologyRun>,
     /// The outcome of every executed (registered) case × format.
     pub cases: Vec<CaseOutcome>,
 }
@@ -90,6 +94,35 @@ impl Default for CorpusPin {
             commit: "33251d2a".to_owned(),
         }
     }
+}
+
+/// The terminology server a run had available (B4 `TS` area) plus the recorded
+/// FHIR-tx exchange — "recording the wiremock exchange in the report".
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TerminologyRun {
+    /// The FHIR R4 base URL the harness targeted.
+    pub base_url: String,
+    /// The server mode: `"fixture"` (the spun-up `wiremock` FHIR-tx) or
+    /// `"real"` (`--tx-server-url`).
+    pub mode: String,
+    /// The recorded FHIR-tx exchange (received requests). For the fixture this
+    /// is the harness's own liveness self-check plus anything a SUT wired to it
+    /// sent; for a real server it is empty (the runner cannot observe a remote
+    /// server's inbound requests).
+    #[serde(default)]
+    pub exchanges: Vec<TxExchange>,
+}
+
+/// One recorded FHIR-tx request against the terminology server.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TxExchange {
+    /// The HTTP method.
+    pub method: String,
+    /// The request path (e.g. `/ValueSet/$expand`).
+    pub path: String,
+    /// The raw query string, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub query: Option<String>,
 }
 
 /// The selection that scoped the run.

--- a/tools/conformance/src/suites/mod.rs
+++ b/tools/conformance/src/suites/mod.rs
@@ -25,6 +25,7 @@ mod directory;
 mod ehr;
 mod message;
 mod query;
+mod terminology;
 
 /// All implemented case entries, in registration order.
 #[must_use]
@@ -42,5 +43,6 @@ pub fn entries() -> Vec<CaseEntry> {
     all.extend(content::entries()); // master15/16/17.x
     all.extend(signing::entries()); // runner-defined SIGN-* (§4.6)
     all.extend(message::entries()); // master13 (SM-5 Messaging; native-API-only, skipped)
+    all.extend(terminology::entries()); // B4 (AQL TERMINOLOGY family + FHIR-tx)
     all
 }

--- a/tools/conformance/src/suites/terminology.rs
+++ b/tools/conformance/src/suites/terminology.rs
@@ -1,0 +1,441 @@
+//! The `TS` capability cases — terminology-server integration (B4): the AQL
+//! `TERMINOLOGY('expand', …)` family driven over the QUERY API (`POST
+//! /query/aql`), plus the FHIR-tx provider and fault-injection cases.
+//!
+//! Spec grounding: QUERY master03 §Functions/Other functions/TERMINOLOGY
+//! (`docs/specs/openehr/QUERY/docs/AQL/master03-syntax.adoc` lines 748–767) —
+//! `TERMINOLOGY('expand', service_api, params_uri)` used as (or inside) a
+//! `matches` operand, "merging explicit codes with the function results … the
+//! AQL interpreter is responsible for generating a valid list of codes during
+//! semantic analysis" (lines 756–759). Design:
+//! `docs/design/terminology-server-integration.md` §5.
+//!
+//! ## Three case families, three dispositions
+//!
+//! 1. **Bundle expansion (`service_api = "openehr"`).** Wire-driveable against
+//!    **any** SUT with our engine: the in-process `openehr-term` bundle resolves
+//!    the value set at semantic analysis and merges its codes into the `matches`
+//!    value list — no external server. These are **real passes**.
+//! 2. **FHIR provider (`service_api = "hl7.org/fhir/4.0"`).** The SUT routes to
+//!    its configured FHIR terminology provider. Passes when a provider is
+//!    configured (the query is accepted, `200`); with **no** provider the SUT
+//!    returns a typed `400` (`UnknownTerminologyService`, "not a configured
+//!    terminology service") and the case reports `SKIPPED(SutConfig)` — never a
+//!    fabricated pass. The standard `scripts/conformance.sh` SUT configures no
+//!    provider, so this skips there; a compose SUT pointed at a FHIR server
+//!    (`EHRBASE_VALIDATION_EXTERNAL_TERMINOLOGY_*`, using `host.docker.internal`
+//!    to reach a runner-host fixture) exercises it.
+//! 3. **Fault injection (timeout / `5xx` / malformed).** Real-server / fixture
+//!    mode only: they need a *fault-injecting* terminology server wired to the
+//!    SUT, which the HTTP-only ECC cannot arrange for an external SUT (the
+//!    runner cannot reconfigure the SUT's provider URL per case). They report
+//!    `SKIPPED(SutConfig)` and cite the evidence that *does* prove the
+//!    fault-mapping — the [`crate::ts::fixture`] tests (the FHIR-tx fixture's
+//!    own fault behaviour) and the CDR provider's `wiremock` fault tests
+//!    (`app/ehrbase/tests/terminology_fhir.rs`) — so the behaviour is traceable
+//!    even though it is off the wire (the MSG/SIG precedent).
+
+use serde_json::Value;
+
+use crate::assert;
+use crate::case::{Capability, CaseMeta, Compare, Format, Profile};
+use crate::catalog::Area;
+use crate::fixtures;
+use crate::harness::{CaseError, CaseFuture, DataSetReport, HttpRequest, HttpResponse, RunContext};
+use crate::registry::CaseEntry;
+use crate::suites::support;
+use crate::ts::fixture::SURFACE_VS;
+
+/// The `service_api` for the in-process openEHR terminology bundle (no external
+/// server) — `crate::service::terminology`'s `BUNDLE_SERVICE_API`.
+const OPENEHR: &str = "openehr";
+/// A FHIR R4 `service_api` (master03 example `hl7.org/fhir/4.0`).
+const FHIR: &str = "hl7.org/fhir/4.0";
+/// The bundle value set of `COMPOSITION.category` codes ({431,433,451,815}).
+const VS_CATEGORY: &str = "composition_category";
+/// A disjoint bundle value set (audit change type, {249..253}) — no category
+/// code is a member, so it proves the expansion produced *specific* codes.
+const VS_AUDIT: &str = "audit_change_type";
+
+/// The nested event OPT + its canonical composition (category = `433` event),
+/// reused across the constraining cases (the proven master07/master11 fixture).
+const NESTED_OPT: &str = "nested/nested.opt";
+const NESTED_JSON: &str = "compositions/CANONICAL_JSON/nested.en.v1__full.json";
+
+/// The implemented `TS` case entries.
+#[must_use]
+pub fn entries() -> Vec<CaseEntry> {
+    const SVC: &str = "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); \
+         AQL 1.1; ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query";
+    vec![
+        // ── bundle expansion (real passes, any SUT) ──────────────────────────
+        entry(
+            "ts/expand-bundle-accepted",
+            "TERMINOLOGY expand (bundle) — accepted, well-formed RESULT_SET",
+            SVC,
+            run_bundle_accepted,
+        ),
+        entry(
+            "ts/expand-bundle-constrains",
+            "TERMINOLOGY expand (bundle) — expansion constrains matches to the value set's codes",
+            SVC,
+            run_bundle_constrains,
+        ),
+        entry(
+            "ts/expand-bundle-mixed-list",
+            "TERMINOLOGY expand (bundle) — explicit code merged with the expansion (matches list)",
+            SVC,
+            run_bundle_mixed_list,
+        ),
+        entry(
+            "ts/expand-unknown-value-set-rejected",
+            "TERMINOLOGY expand — unknown value set rejected (400)",
+            SVC,
+            run_unknown_value_set,
+        ),
+        entry(
+            "ts/expand-unknown-service-rejected",
+            "TERMINOLOGY expand — unknown service_api rejected (400)",
+            SVC,
+            run_unknown_service,
+        ),
+        // ── FHIR provider (pass when configured, else SKIPPED(SutConfig)) ─────
+        entry(
+            "ts/expand-fhir-provider",
+            "TERMINOLOGY expand (FHIR service_api) — accepted when a provider is configured",
+            SVC,
+            run_fhir_provider,
+        ),
+        // ── fault injection (fixture / real-server only, SKIPPED(SutConfig)) ──
+        entry(
+            "ts/fault-timeout",
+            "TERMINOLOGY expand (FHIR) — terminology-server timeout is a server fault (500)",
+            SVC,
+            run_fault_timeout,
+        ),
+        entry(
+            "ts/fault-server-error",
+            "TERMINOLOGY expand (FHIR) — terminology-server 5xx is a server fault (500)",
+            SVC,
+            run_fault_server_error,
+        ),
+        entry(
+            "ts/fault-malformed",
+            "TERMINOLOGY expand (FHIR) — malformed terminology response is a server fault (500)",
+            SVC,
+            run_fault_malformed,
+        ),
+    ]
+}
+
+/// A `TS`-area case entry (OPTIONS-profile `Terminology` capability, JSON).
+fn entry(
+    id: &'static str,
+    title: &'static str,
+    citation: &'static str,
+    run: crate::harness::CaseRun,
+) -> CaseEntry {
+    CaseEntry {
+        meta: CaseMeta {
+            id,
+            title,
+            area: Area::Ts,
+            capability: Capability::Terminology,
+            profiles: &[Profile::Options],
+            formats: &[Format::Json],
+            citation,
+            compare: Compare::IgnoreSet,
+        },
+        run,
+    }
+}
+
+macro_rules! case {
+    ($body:block) => {
+        Box::pin(async move { $body })
+    };
+}
+
+// ── shared helpers ──────────────────────────────────────────────────────────
+
+fn fx(e: fixtures::FixtureError) -> CaseError {
+    CaseError::Codec(e.to_string())
+}
+
+/// Execute an ad-hoc AQL query (`POST /query/aql`, body `{"q": …}`).
+async fn adhoc(ctx: &RunContext<'_>, aql: &str) -> Result<HttpResponse, CaseError> {
+    let body = serde_json::json!({ "q": aql });
+    ctx.send(
+        HttpRequest::post("/query/aql")
+            .json_body(&body)?
+            .header("accept", "application/json"),
+    )
+    .await
+}
+
+/// A `matches TERMINOLOGY('expand', service_api, params_uri)` query over
+/// `COMPOSITION.category`, EHR-scoped when `ehr` is given (shared-SUT-safe).
+fn category_expand_query(ehr: Option<&str>, service_api: &str, params_uri: &str) -> String {
+    let from = match ehr {
+        Some(id) => format!("EHR e[ehr_id/value='{id}'] CONTAINS COMPOSITION c"),
+        None => "EHR e CONTAINS COMPOSITION c".to_owned(),
+    };
+    format!(
+        "SELECT c/uid/value FROM {from} \
+         WHERE c/category/defining_code/code_string \
+         matches TERMINOLOGY('expand', '{service_api}', '{params_uri}')"
+    )
+}
+
+/// The row count of a `RESULT_SET` body.
+fn row_count(body: &Value) -> usize {
+    body["rows"].as_array().map_or(0, Vec::len)
+}
+
+/// Commit the nested event composition (category `433`) to a fresh EHR, so its
+/// `category` is queryable; returns the `ehr_id`.
+async fn commit_nested_composition(ctx: &RunContext<'_>) -> Result<String, CaseError> {
+    let ehr_id = support::create_ehr(ctx).await?;
+    support::ensure_opt(ctx, NESTED_OPT).await?;
+    let body = fixtures::read_json(NESTED_JSON).map_err(fx)?;
+    let resp = ctx
+        .send(
+            HttpRequest::post(format!("/ehr/{ehr_id}/composition"))
+                .json_body(&body)?
+                .header("accept", "application/json")
+                .header("prefer", "return=representation"),
+        )
+        .await?;
+    assert::status(&resp, 201)?;
+    Ok(ehr_id)
+}
+
+/// Whether a rejected FHIR expand indicates the SUT has **no** FHIR terminology
+/// provider configured (the typed `UnknownTerminologyService` reject) — vs any
+/// other rejection. The message text is `AqlFeatureError::UnknownTerminologyService`
+/// ("… is not a configured terminology service", `app/ehrbase/src/aql/error.rs`).
+fn is_no_provider(resp: &HttpResponse) -> bool {
+    resp.text()
+        .to_ascii_lowercase()
+        .contains("not a configured terminology service")
+}
+
+// ── bundle expansion (real passes) ────────────────────────────────────────────
+
+/// The bundle `expand` operand is resolved + merged at semantic analysis and
+/// the query is accepted with a well-formed `RESULT_SET` (a broken/absent
+/// expander would reject it). Data-independent — passes against any SUT.
+fn run_bundle_accepted<'a>(ctx: &'a RunContext<'a>) -> CaseFuture<'a> {
+    case!({
+        let aql = category_expand_query(None, OPENEHR, VS_CATEGORY);
+        let resp = adhoc(ctx, &aql).await?;
+        assert::status(&resp, 200)?;
+        let body = resp.json()?;
+        if body["meta"]["_type"] != "RESULTSET" {
+            return Err(CaseError::Assertion(format!(
+                "expected meta._type RESULTSET, got {}",
+                body["meta"]["_type"]
+            )));
+        }
+        if !body["columns"].is_array() {
+            return Err(CaseError::Assertion(
+                "RESULT_SET has no columns array".to_owned(),
+            ));
+        }
+        Ok(DataSetReport::SINGLE)
+    })
+}
+
+/// The expansion produces the value set's *specific* codes (not a wildcard):
+/// against a fresh EHR holding one composition (category `433`), the
+/// `composition_category` expansion (includes `433`) returns it, while the
+/// disjoint `audit_change_type` expansion (excludes `433`) returns nothing.
+/// (2 data sets.)
+fn run_bundle_constrains<'a>(ctx: &'a RunContext<'a>) -> CaseFuture<'a> {
+    case!({
+        let ehr = commit_nested_composition(ctx).await?;
+
+        // Positive: category 433 ∈ composition_category → the composition matches.
+        let pos = adhoc(
+            ctx,
+            &category_expand_query(Some(&ehr), OPENEHR, VS_CATEGORY),
+        )
+        .await?;
+        assert::status(&pos, 200)?;
+        if row_count(&pos.json()?) == 0 {
+            return Err(CaseError::Assertion(
+                "composition_category expansion did not match the category-433 composition \
+                 (expansion produced no matching code)"
+                    .to_owned(),
+            ));
+        }
+
+        // Negative: 433 ∉ audit_change_type → no match (proves the expansion is
+        // the value set's codes, not everything).
+        let neg = adhoc(ctx, &category_expand_query(Some(&ehr), OPENEHR, VS_AUDIT)).await?;
+        assert::status(&neg, 200)?;
+        if row_count(&neg.json()?) != 0 {
+            return Err(CaseError::Assertion(
+                "audit_change_type expansion matched a category-433 composition — the expansion \
+                 is not constrained to the value set's codes"
+                    .to_owned(),
+            ));
+        }
+        Ok(DataSetReport::all(2))
+    })
+}
+
+/// A mixed `matches { <explicit>, TERMINOLOGY('expand', …) }` list merges the
+/// explicit code with the expansion (master03 line 759). The explicit `433`
+/// matches the committed composition even though the paired `audit_change_type`
+/// expansion does not — proving the merge keeps both.
+fn run_bundle_mixed_list<'a>(ctx: &'a RunContext<'a>) -> CaseFuture<'a> {
+    case!({
+        let ehr = commit_nested_composition(ctx).await?;
+        let aql = format!(
+            "SELECT c/uid/value FROM EHR e[ehr_id/value='{ehr}'] CONTAINS COMPOSITION c \
+             WHERE c/category/defining_code/code_string \
+             matches {{'433', TERMINOLOGY('expand', '{OPENEHR}', '{VS_AUDIT}')}}"
+        );
+        let resp = adhoc(ctx, &aql).await?;
+        assert::status(&resp, 200)?;
+        if row_count(&resp.json()?) == 0 {
+            return Err(CaseError::Assertion(
+                "mixed matches list ({explicit 433, expand audit_change_type}) matched nothing — \
+                 the explicit code was dropped by the expansion merge"
+                    .to_owned(),
+            ));
+        }
+        Ok(DataSetReport::SINGLE)
+    })
+}
+
+/// An `expand` naming a value set the bundle does not know is a typed bad
+/// request (`400` `TerminologyValueSetNotFound`), rejected at semantic
+/// analysis. Data-independent — passes against any SUT with our engine.
+fn run_unknown_value_set<'a>(ctx: &'a RunContext<'a>) -> CaseFuture<'a> {
+    case!({
+        let aql = category_expand_query(None, OPENEHR, "no_such_value_set_xyz");
+        let resp = adhoc(ctx, &aql).await?;
+        support::assert_negative(&resp)?;
+        Ok(DataSetReport::SINGLE)
+    })
+}
+
+/// An `expand` naming an unrecognised `service_api` (no such flavour, no FHIR
+/// provider) is a typed bad request (`400` `UnknownTerminologyService`).
+fn run_unknown_service<'a>(ctx: &'a RunContext<'a>) -> CaseFuture<'a> {
+    case!({
+        let aql = category_expand_query(None, "bogus.terminology.api", "x");
+        let resp = adhoc(ctx, &aql).await?;
+        support::assert_negative(&resp)?;
+        Ok(DataSetReport::SINGLE)
+    })
+}
+
+// ── FHIR provider (pass when configured, else SKIPPED(SutConfig)) ──────────────
+
+/// Drive an `expand` through the FHIR `service_api`. A `200` proves the SUT has
+/// a FHIR provider configured and the expansion was accepted; a `400`
+/// `UnknownTerminologyService` proves it has none → `SKIPPED(SutConfig)`. Any
+/// other outcome is skipped with the observed status, never a fabricated pass.
+fn run_fhir_provider<'a>(ctx: &'a RunContext<'a>) -> CaseFuture<'a> {
+    case!({
+        let aql = category_expand_query(None, FHIR, SURFACE_VS);
+        let resp = adhoc(ctx, &aql).await?;
+        if resp.status == 200 {
+            let body = resp.json()?;
+            if body["meta"]["_type"] != "RESULTSET" {
+                return Err(CaseError::Assertion(format!(
+                    "FHIR expand accepted but body is not a RESULT_SET: {}",
+                    body["meta"]["_type"]
+                )));
+            }
+            return Ok(DataSetReport::SINGLE);
+        }
+        if is_no_provider(&resp) {
+            return Err(CaseError::Skipped(skip_no_provider(ctx)));
+        }
+        Err(CaseError::Skipped(format!(
+            "SutConfig: FHIR terminology provider not exercisable — the SUT answered \
+             {} to a `{FHIR}` expand (a configured provider that lacks the fixture value set, \
+             or a non-provider rejection). Not a fabricated pass.",
+            resp.status
+        )))
+    })
+}
+
+/// The skip reason for a SUT with no FHIR terminology provider, naming the
+/// terminology server the harness *did* have available (fixture / real).
+fn skip_no_provider(ctx: &RunContext<'_>) -> String {
+    let tx = ctx.tx.map_or_else(
+        || "no terminology server established for this run".to_owned(),
+        |t| {
+            format!(
+                "harness terminology server: {} ({})",
+                t.base_url,
+                t.mode.label()
+            )
+        },
+    );
+    format!(
+        "SutConfig: no FHIR terminology provider configured on the SUT \
+         (EHRBASE_VALIDATION_EXTERNAL_TERMINOLOGY_* unset) — a `{FHIR}` expand is rejected as \
+         `UnknownTerminologyService`. {tx}. The bundle (`openehr`) expand cases prove the \
+         TERMINOLOGY family; wire this by pointing the SUT at a FHIR server \
+         (host.docker.internal for a runner-host fixture, docs/design/terminology-server-integration.md §5)."
+    )
+}
+
+// ── fault injection (fixture / real-server only) ──────────────────────────────
+
+/// The shared skip for a fault-injection case: the HTTP-only ECC cannot wire a
+/// *fault-injecting* terminology server into an external SUT per case, so the
+/// fault→`500` mapping is proven off the wire — by the FHIR-tx fixture's own
+/// fault tests and the CDR provider's `wiremock` fault tests. Never a fabricated
+/// pass (the MSG/SIG precedent).
+fn fault_skip(ctx: &RunContext<'_>, fault_label: &str, evidence: &str) -> CaseError {
+    let tx = ctx.tx.map_or_else(
+        || "no terminology server established".to_owned(),
+        |t| format!("{} ({})", t.base_url, t.mode.label()),
+    );
+    CaseError::Skipped(format!(
+        "SutConfig: the {fault_label} fault requires a fault-injecting terminology server wired \
+         to the SUT (--tx-server-url + an SUT FHIR provider pointed at it); the HTTP-only ECC \
+         cannot reconfigure an external SUT's provider per case. Harness tx server: {tx}. \
+         The fault→500 mapping is proven by {evidence}."
+    ))
+}
+
+fn run_fault_timeout<'a>(ctx: &'a RunContext<'a>) -> CaseFuture<'a> {
+    case!({
+        Err::<DataSetReport, _>(fault_skip(
+            ctx,
+            "timeout",
+            "conformance ts::fixture::tests::fault_timeout_exceeds_a_short_client_deadline \
+             + app/ehrbase/tests/terminology_fhir.rs::timeout_is_an_exception",
+        ))
+    })
+}
+
+fn run_fault_server_error<'a>(ctx: &'a RunContext<'a>) -> CaseFuture<'a> {
+    case!({
+        Err::<DataSetReport, _>(fault_skip(
+            ctx,
+            "5xx",
+            "conformance ts::fixture::tests::fault_server_error_is_5xx \
+             + app/ehrbase/tests/terminology_fhir.rs::server_5xx_is_an_exception",
+        ))
+    })
+}
+
+fn run_fault_malformed<'a>(ctx: &'a RunContext<'a>) -> CaseFuture<'a> {
+    case!({
+        Err::<DataSetReport, _>(fault_skip(
+            ctx,
+            "malformed",
+            "conformance ts::fixture::tests::fault_malformed_is_not_json \
+             + app/ehrbase/tests/terminology_fhir.rs::malformed_body_is_an_exception",
+        ))
+    })
+}

--- a/tools/conformance/src/ts/fixture.rs
+++ b/tools/conformance/src/ts/fixture.rs
@@ -1,0 +1,403 @@
+//! A `wiremock`-backed FHIR R4 terminology-server fixture (B4,
+//! `docs/design/terminology-server-integration.md` §5.1): a hermetic FHIR-tx
+//! server the runner spins up with canned `$expand`/`$validate-code`/`$lookup`/
+//! `$subsumes` responses and on-demand fault injection (timeout, `5xx`,
+//! malformed body). No network, no container — a pure in-process
+//! `127.0.0.1` mock, so it gates every CI run.
+//!
+//! The canned resources mirror the reference golden the CDR's own FHIR client
+//! tests use (`docs/terminology-validation.md` §5, `ValueSet/surface`,
+//! code `B` = Buccal), so a deployment that points its SUT at this fixture
+//! (a fixed-port compose wiring via `host.docker.internal`) exercises the same
+//! contract the `FhirTerminologyProvider` unit tests assert.
+//!
+//! What this fixture is *for*: (1) proving the FHIR-tx wire contract shape in
+//! `nextest` without any SUT (the tests below), (2) serving as the reference
+//! server the real-server mode (`--tx-server-url`) is contrasted against, and
+//! (3) recording the exchange (received requests) into the conformance report.
+
+use std::time::Duration;
+
+use serde_json::{Value, json};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use crate::results::TxExchange;
+
+/// The canned value set the fixture expands (`ValueSet/$expand`): the reference
+/// `surface` value set (codes `B`/`L`/`O`).
+pub const SURFACE_VS: &str = "http://hl7.org/fhir/ValueSet/surface";
+/// The code system backing [`SURFACE_VS`].
+pub const SURFACE_SYS: &str = "http://hl7.org/fhir/surface";
+/// A member code of [`SURFACE_VS`] (`B` = Buccal).
+pub const SURFACE_MEMBER: &str = "B";
+
+/// A fault a fixture injects on **every** terminology operation, so a SUT (or a
+/// direct client) driving it sees the corresponding failure mode (the
+/// `FhirTerminologyProvider` maps each to `CallStatusType::Exception` → HTTP
+/// `500`, `docs/terminology-validation.md` §5).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Fault {
+    /// A response delayed well past any sane client timeout.
+    Timeout,
+    /// An HTTP `503 Service Unavailable`.
+    ServerError,
+    /// A `200` whose body is not FHIR JSON.
+    Malformed,
+}
+
+impl Fault {
+    /// A stable label for the report / skip reasons.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Fault::Timeout => "timeout",
+            Fault::ServerError => "5xx",
+            Fault::Malformed => "malformed",
+        }
+    }
+
+    /// The `wiremock` response this fault serves.
+    fn response(self) -> ResponseTemplate {
+        match self {
+            // 30s dwarfs any client request timeout (the CDR provider defaults
+            // to 10s, the tests use sub-second timeouts).
+            Fault::Timeout => ResponseTemplate::new(200)
+                .set_delay(Duration::from_secs(30))
+                .set_body_json(ok_validate_code()),
+            Fault::ServerError => ResponseTemplate::new(503),
+            Fault::Malformed => ResponseTemplate::new(200).set_body_string("this is not FHIR json"),
+        }
+    }
+}
+
+/// The four FHIR terminology operation paths this fixture serves.
+const OPS: [&str; 4] = [
+    "/ValueSet/$expand",
+    "/ValueSet/$validate-code",
+    "/CodeSystem/$lookup",
+    "/CodeSystem/$subsumes",
+];
+
+/// A canned `ValueSet` with a two-member expansion (`B`/`L`, one nested `O`).
+fn ok_expand() -> Value {
+    json!({
+        "resourceType": "ValueSet",
+        "expansion": { "contains": [
+            {"system": SURFACE_SYS, "code": "B", "display": "Buccal"},
+            {"system": SURFACE_SYS, "code": "L", "display": "Lingual",
+             "contains": [{"system": SURFACE_SYS, "code": "O", "display": "Occlusal"}]}
+        ]}
+    })
+}
+
+/// A canned `$validate-code` `Parameters` (`result = true`, `display = Buccal`).
+fn ok_validate_code() -> Value {
+    json!({
+        "resourceType": "Parameters",
+        "parameter": [
+            {"name": "result", "valueBoolean": true},
+            {"name": "display", "valueString": "Buccal"}
+        ]
+    })
+}
+
+/// A canned `$lookup` `Parameters` (`display = Buccal`).
+fn ok_lookup() -> Value {
+    json!({
+        "resourceType": "Parameters",
+        "parameter": [
+            {"name": "name", "valueString": "surface"},
+            {"name": "display", "valueString": "Buccal"}
+        ]
+    })
+}
+
+/// A canned `$subsumes` `Parameters` (`outcome = subsumes`).
+fn ok_subsumes() -> Value {
+    json!({
+        "resourceType": "Parameters",
+        "parameter": [{"name": "outcome", "valueCode": "subsumes"}]
+    })
+}
+
+/// The canned happy-path response for a FHIR operation path.
+fn ok_response(op: &str) -> ResponseTemplate {
+    let body = match op {
+        "/ValueSet/$expand" => ok_expand(),
+        "/ValueSet/$validate-code" => ok_validate_code(),
+        "/CodeSystem/$lookup" => ok_lookup(),
+        "/CodeSystem/$subsumes" => ok_subsumes(),
+        _ => json!({"resourceType": "OperationOutcome"}),
+    };
+    ResponseTemplate::new(200).set_body_json(body)
+}
+
+/// A boxed error for the fixture's self-check (a URL-parse or transport fault).
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+/// Build `{base}{op}?k=v&…` with percent-encoded query values (this build of
+/// `reqwest` does not expose `RequestBuilder::query`, so URLs are assembled the
+/// same way the CDR's FHIR client does — `app/ehrbase/src/terminology/fhir.rs`).
+fn build_url(base: &str, op: &str, query: &[(&str, &str)]) -> Result<reqwest::Url, BoxError> {
+    let mut url = reqwest::Url::parse(&format!("{base}{op}"))?;
+    {
+        let mut pairs = url.query_pairs_mut();
+        for (k, v) in query {
+            pairs.append_pair(k, v);
+        }
+    }
+    Ok(url)
+}
+
+/// A `wiremock`-backed FHIR R4 terminology-server fixture.
+#[derive(Debug)]
+pub struct FhirTxFixture {
+    server: MockServer,
+}
+
+impl FhirTxFixture {
+    /// Start a fixture serving the canned happy-path responses on a random
+    /// `127.0.0.1` port.
+    pub async fn start_canned() -> Self {
+        let server = MockServer::start().await;
+        for op in OPS {
+            Mock::given(method("GET"))
+                .and(path(op))
+                .respond_with(ok_response(op))
+                .mount(&server)
+                .await;
+        }
+        Self { server }
+    }
+
+    /// Start a fixture that injects `fault` on every terminology operation.
+    pub async fn start_fault(fault: Fault) -> Self {
+        let server = MockServer::start().await;
+        for op in OPS {
+            Mock::given(method("GET"))
+                .and(path(op))
+                .respond_with(fault.response())
+                .mount(&server)
+                .await;
+        }
+        Self { server }
+    }
+
+    /// The fixture's FHIR base URL (e.g. `http://127.0.0.1:53412`); the
+    /// terminology operations hang directly off it (`{base}/ValueSet/$expand`).
+    #[must_use]
+    pub fn base_url(&self) -> String {
+        self.server.uri()
+    }
+
+    /// The exchange the fixture has served so far — every received request as a
+    /// [`TxExchange`], in receipt order (the record written to the report).
+    pub async fn exchanges(&self) -> Vec<TxExchange> {
+        self.server
+            .received_requests()
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .map(|r| TxExchange {
+                method: r.method.to_string(),
+                path: r.url.path().to_owned(),
+                query: r.url.query().map(str::to_owned),
+            })
+            .collect()
+    }
+
+    /// Self-verify liveness by issuing the four canned operations against the
+    /// fixture, returning the resulting recorded exchange. Proves the fixture
+    /// answers (so the recorded exchange in the report is concrete even when no
+    /// SUT is wired to it) and is used by the runner as its fixture health check.
+    ///
+    /// # Errors
+    /// Returns an error if a URL cannot be built, the fixture cannot be reached,
+    /// or an operation does not answer `2xx`.
+    pub async fn self_check(&self) -> Result<Vec<TxExchange>, BoxError> {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .build()?;
+        let base = self.base_url();
+        for (op, query) in [
+            ("/ValueSet/$expand", &[("url", SURFACE_VS)][..]),
+            (
+                "/ValueSet/$validate-code",
+                &[("url", SURFACE_VS), ("code", SURFACE_MEMBER)][..],
+            ),
+            ("/CodeSystem/$lookup", &[("code", SURFACE_MEMBER)][..]),
+            (
+                "/CodeSystem/$subsumes",
+                &[("codeA", "L"), ("codeB", "O")][..],
+            ),
+        ] {
+            let url = build_url(&base, op, query)?;
+            client
+                .get(url)
+                .header("accept", "application/fhir+json")
+                .send()
+                .await?
+                .error_for_status()?;
+        }
+        Ok(self.exchanges().await)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    /// A short-timeout FHIR client mirroring the CDR provider's timeouts, so the
+    /// timeout fault is observable quickly.
+    fn client(ms: u64) -> reqwest::Client {
+        reqwest::Client::builder()
+            .timeout(Duration::from_millis(ms))
+            .build()
+            .expect("build client")
+    }
+
+    /// GET `{base}{op}?query` against the fixture.
+    async fn fetch(
+        c: &reqwest::Client,
+        base: &str,
+        op: &str,
+        query: &[(&str, &str)],
+    ) -> reqwest::Response {
+        c.get(build_url(base, op, query).expect("url"))
+            .send()
+            .await
+            .expect("send")
+    }
+
+    #[tokio::test]
+    async fn canned_expand_returns_the_surface_value_set() {
+        let fx = FhirTxFixture::start_canned().await;
+        let body: Value = fetch(
+            &client(2_000),
+            &fx.base_url(),
+            "/ValueSet/$expand",
+            &[("url", SURFACE_VS)],
+        )
+        .await
+        .json()
+        .await
+        .expect("json");
+        assert_eq!(body["resourceType"], "ValueSet");
+        let contains = body["expansion"]["contains"].as_array().expect("contains");
+        // Top-level B and L (O is nested under L).
+        assert!(contains.iter().any(|c| c["code"] == "B"));
+        assert!(contains.iter().any(|c| c["code"] == "L"));
+    }
+
+    #[tokio::test]
+    async fn canned_validate_code_and_lookup_and_subsumes() {
+        let fx = FhirTxFixture::start_canned().await;
+        let c = client(2_000);
+        let base = fx.base_url();
+
+        let vc: Value = fetch(
+            &c,
+            &base,
+            "/ValueSet/$validate-code",
+            &[("url", SURFACE_VS), ("code", SURFACE_MEMBER)],
+        )
+        .await
+        .json()
+        .await
+        .expect("json");
+        assert!(
+            vc["parameter"]
+                .as_array()
+                .expect("params")
+                .iter()
+                .any(|p| p["name"] == "result" && p["valueBoolean"] == true)
+        );
+
+        let lk: Value = fetch(
+            &c,
+            &base,
+            "/CodeSystem/$lookup",
+            &[("code", SURFACE_MEMBER)],
+        )
+        .await
+        .json()
+        .await
+        .expect("json");
+        assert!(
+            lk["parameter"]
+                .as_array()
+                .expect("params")
+                .iter()
+                .any(|p| p["name"] == "display" && p["valueString"] == "Buccal")
+        );
+
+        let sub: Value = fetch(&c, &base, "/CodeSystem/$subsumes", &[])
+            .await
+            .json()
+            .await
+            .expect("json");
+        assert!(
+            sub["parameter"]
+                .as_array()
+                .expect("params")
+                .iter()
+                .any(|p| p["name"] == "outcome" && p["valueCode"] == "subsumes")
+        );
+    }
+
+    #[tokio::test]
+    async fn fault_server_error_is_5xx() {
+        let fx = FhirTxFixture::start_fault(Fault::ServerError).await;
+        let resp = fetch(
+            &client(2_000),
+            &fx.base_url(),
+            "/ValueSet/$expand",
+            &[("url", SURFACE_VS)],
+        )
+        .await;
+        assert_eq!(resp.status().as_u16(), 503);
+    }
+
+    #[tokio::test]
+    async fn fault_malformed_is_not_json() {
+        let fx = FhirTxFixture::start_fault(Fault::Malformed).await;
+        let resp = fetch(
+            &client(2_000),
+            &fx.base_url(),
+            "/ValueSet/$expand",
+            &[("url", SURFACE_VS)],
+        )
+        .await;
+        assert_eq!(resp.status().as_u16(), 200);
+        // The body is not FHIR JSON, so parsing as a Value of an object fails to
+        // yield a resource — the CDR provider maps this to Exception (500).
+        let text = resp.text().await.expect("text");
+        assert!(serde_json::from_str::<Value>(&text).is_err());
+    }
+
+    #[tokio::test]
+    async fn fault_timeout_exceeds_a_short_client_deadline() {
+        let fx = FhirTxFixture::start_fault(Fault::Timeout).await;
+        let err = client(300)
+            .get(
+                build_url(&fx.base_url(), "/ValueSet/$expand", &[("url", SURFACE_VS)])
+                    .expect("url"),
+            )
+            .send()
+            .await
+            .expect_err("must time out");
+        assert!(err.is_timeout(), "expected a timeout, got {err}");
+    }
+
+    #[tokio::test]
+    async fn self_check_records_the_full_canned_exchange() {
+        let fx = FhirTxFixture::start_canned().await;
+        let exchanges = fx.self_check().await.expect("self-check");
+        assert_eq!(exchanges.len(), 4, "one exchange per canned operation");
+        assert!(exchanges.iter().all(|e| e.method == "GET"));
+        assert!(exchanges.iter().any(|e| e.path == "/ValueSet/$expand"));
+        assert!(exchanges.iter().any(|e| e.path == "/CodeSystem/$subsumes"));
+    }
+}

--- a/tools/conformance/src/ts/mod.rs
+++ b/tools/conformance/src/ts/mod.rs
@@ -1,0 +1,66 @@
+//! Terminology-server integration support for the ECC (B4): the hermetic
+//! `wiremock` FHIR-tx [`fixture`] the runner spins up, and the [`TxServer`]
+//! descriptor threaded into a case's [`crate::harness::RunContext`] so a case
+//! knows which terminology server the harness has available (the CI fixture or
+//! a real server via `--tx-server-url`).
+//!
+//! Design: `docs/design/terminology-server-integration.md` §5 (two modes:
+//! hermetic `wiremock` by default, real server on demand).
+
+pub mod fixture;
+
+pub use fixture::{Fault, FhirTxFixture};
+
+/// Which kind of terminology server the harness has available for the run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TxMode {
+    /// The hermetic `wiremock` FHIR-tx fixture the runner spun up (the CI
+    /// default).
+    Fixture,
+    /// A real FHIR R4 terminology server named by `--tx-server-url`.
+    Real,
+}
+
+impl TxMode {
+    /// A stable lowercase label for the report / results record.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            TxMode::Fixture => "fixture",
+            TxMode::Real => "real",
+        }
+    }
+}
+
+/// The terminology server available to a run: its FHIR base URL and whether it
+/// is the hermetic fixture or a real server. A case reads this (via
+/// [`crate::harness::RunContext::tx`]) to phrase its skip reason and to record
+/// the server it targeted; it never reconfigures the SUT, which is reached only
+/// over its own ITS-REST transport.
+#[derive(Debug, Clone)]
+pub struct TxServer {
+    /// The FHIR R4 base URL.
+    pub base_url: String,
+    /// Fixture or real.
+    pub mode: TxMode,
+}
+
+impl TxServer {
+    /// A real-server descriptor (`--tx-server-url`).
+    #[must_use]
+    pub fn real(base_url: impl Into<String>) -> Self {
+        Self {
+            base_url: base_url.into(),
+            mode: TxMode::Real,
+        }
+    }
+
+    /// A fixture descriptor for `base_url` (the spun-up [`FhirTxFixture`]'s URL).
+    #[must_use]
+    pub fn fixture(base_url: impl Into<String>) -> Self {
+        Self {
+            base_url: base_url.into(),
+            mode: TxMode::Fixture,
+        }
+    }
+}


### PR DESCRIPTION
Closes B4 (blueprint §3). ECC at close: 338 executed · 298 passed · zero drift (5 new live TS wire passes, 4 honest SutConfig skips).

- FhirTerminologyProvider (reqwest/rustls): $validate-code / $expand / strict $subsumes / $lookup; figment config, bundle-default/FHIR-opt-in; 12 wiremock tests incl. fault injection
- AQL TERMINOLOGY('expand',…) merged into matches value lists at semantic analysis (QUERY master03 L756–759); mixed lists; typed 400s; stages (b)/(c) PORT-NOTEd typed rejects
- Config-gated /terminology extension wire over the SM seam (6 routes, OFF by default, 12 HTTP tests)
- TS conformance area: wiremock FHIR-tx fixture + --tx-server-url real-server mode; ECC-TS-001..009

Suites: ehrbase-rest 231/231 · ehrbase 273/273 · ehrbase-sm 9/9 · conformance 41/41.