### PR TITLE
E5: Kubernetes deployment artifacts — hardened Helm chart + ops documentation

### DIFF
--- a/deploy/helm/ci/all-features-values.yaml
+++ b/deploy/helm/ci/all-features-values.yaml
@@ -1,0 +1,165 @@
+# All-features-on overlay: every optional integration enabled, autoscaling +
+# separate management port + egress network policy + mounted config file. Used
+# as the "all-features" golden render and to exercise every template branch.
+database:
+  existingSecret: ehrbase-db
+  existingSecretKey: EHRBASE_DB_URL
+
+rest:
+  swaggerUi: true
+  adminEnabled: true
+  terminologyEnabled: true
+  eventSubscriptionEnabled: true
+  fhirEnabled: true
+
+tenancy:
+  enabled: true
+  claim: realm_access.tenant
+  header: X-EHRbase-Tenant
+
+auth:
+  enabled: true
+  adminScope: ADMIN
+  oidc:
+    issuer: https://keycloak.example.com/realms/ehrbase
+    audience: ehrbase
+    hmacSecret: dev-hmac-secret
+
+authz:
+  rbac:
+    enabled: true
+    managementAccess: admin_only
+  abac:
+    enabled: true
+
+management:
+  enabled: true
+  port: 9100
+  probesEnabled: true
+  endpoints:
+    health: private
+    info: admin_only
+    metrics: admin_only
+    env: admin_only
+    loggers: admin_only
+
+metrics:
+  enabled: true
+
+telemetry:
+  log:
+    format: json
+    filter: info,ehrbase=debug
+  otel:
+    otlpEndpoint: http://otel-collector:4317
+    serviceName: ehrbase-rs
+    environment: production
+    tracesSampleRatio: "0.1"
+    metricsPush: true
+
+signing:
+  enabled: true
+  mode: pgp
+  verifyOnRead: strict
+  pgp:
+    keyPath: /etc/ehrbase/signing.asc
+    keyPassphrase: dev-passphrase
+
+atna:
+  enabled: true
+  repositoryHost: arr.example.com
+  repositoryPort: "6514"
+  transport: tls
+  sourceId: ehrbase-prod
+  failMode: closed
+  enterpriseSiteId: site-1
+
+events:
+  enabled: true
+  url: amqps://user:pass@rabbitmq:5671/%2f
+  exchange: ehrbase.events
+  tls: true
+
+fhirOutbound:
+  enabled: true
+  url: amqps://user:pass@rabbitmq:5671/%2f
+  exchange: ehrbase.fhir
+  tls: true
+
+multimedia:
+  enabled: true
+  thresholdBytes: "262144"
+  endpoint: https://s3.example.com
+  bucket: openehr-multimedia
+  region: eu-west-1
+  allowHttp: false
+  accessKeyId: AKIAEXAMPLE
+  secretAccessKey: s3-secret
+
+externalTerminology:
+  enabled: true
+  failOnError: false
+
+config:
+  files:
+    signing.asc: |
+      -----BEGIN PGP PRIVATE KEY BLOCK-----
+      (dev placeholder)
+      -----END PGP PRIVATE KEY BLOCK-----
+    rest.toml: |
+      [[auth.basic.users]]
+      username = "clinician"
+      password_hash = "$argon2id$v=19$m=4096,t=2,p=1$c2FsdA$hash"
+      roles = ["USER"]
+
+extraEnv:
+  - name: EHRBASE_REST_CONFIG
+    value: /etc/ehrbase/rest.toml
+  - name: EHRBASE_SIGNING_KEY_PATH
+    value: /etc/ehrbase/signing.asc
+
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: ehrbase.example.com
+      paths:
+        - path: /ehrbase
+          pathType: Prefix
+  tls:
+    - secretName: ehrbase-tls
+      hosts:
+        - ehrbase.example.com
+
+networkPolicy:
+  enabled: true
+  ingressFrom:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ingress-nginx
+  egress:
+    enabled: true
+    rules:
+      - to:
+          - podSelector:
+              matchLabels:
+                app.kubernetes.io/name: postgres
+        ports:
+          - port: 5432
+            protocol: TCP
+
+autoscaling:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 2
+
+serviceAccount:
+  create: true
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/ehrbase-s3

--- a/deploy/helm/ci/default-values.yaml
+++ b/deploy/helm/ci/default-values.yaml
@@ -1,0 +1,6 @@
+# Minimal realistic production overlay: chart defaults (all optional
+# integrations OFF) plus the one thing every real deployment must supply — the
+# app-role DSN from an existing Secret. Used as the "default" golden render.
+database:
+  existingSecret: ehrbase-db
+  existingSecretKey: EHRBASE_DB_URL

--- a/deploy/helm/ehrbase-rs/.helmignore
+++ b/deploy/helm/ehrbase-rs/.helmignore
@@ -1,0 +1,11 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+*.tmp
+*.bak
+*.swp
+*.orig
+.idea/
+.vscode/
+# The golden renders + validator live one level up, not inside the chart.

--- a/deploy/helm/ehrbase-rs/Chart.yaml
+++ b/deploy/helm/ehrbase-rs/Chart.yaml
@@ -1,0 +1,32 @@
+apiVersion: v2
+name: ehrbase-rs
+description: >-
+  Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.0.3 + AQL
+  1.1). A single static binary deployed with the ADR-013 security posture:
+  runs as a non-root, read-only-rootfs, default-deny-ingress workload that
+  connects to an EXTERNAL PostgreSQL 18 as an unprivileged app role (migrations
+  are run by a separate migrator role — see docs/enterprise/deployment.md).
+type: application
+
+# Chart versioning is independent of the application version.
+version: 0.1.0
+# The default container image tag (informational; overridable via image.tag).
+appVersion: "0.1.0"
+
+# PDB (policy/v1, GA 1.21), HPA (autoscaling/v2, GA 1.23), and the
+# seccompProfile pod field (GA 1.27) all resolve cleanly at 1.25+.
+kubeVersion: ">=1.25.0-0"
+
+keywords:
+  - openehr
+  - cdr
+  - ehr
+  - fhir
+  - healthcare
+  - rust
+home: https://github.com/rubentalstra/ehrbase-rs
+sources:
+  - https://github.com/rubentalstra/ehrbase-rs
+maintainers:
+  - name: ehrbase-rs maintainers
+    url: https://github.com/rubentalstra/ehrbase-rs

--- a/deploy/helm/ehrbase-rs/templates/NOTES.txt
+++ b/deploy/helm/ehrbase-rs/templates/NOTES.txt
@@ -1,0 +1,70 @@
+ehrbase-rs {{ .Chart.AppVersion }} has been deployed as release "{{ .Release.Name }}" in namespace "{{ .Release.Namespace }}".
+
+A pure-Rust openEHR CDR (ITS-REST 1.0.3 + AQL 1.1). See docs/enterprise/deployment.md.
+
+API base path: {{ .Values.rest.basePath }}
+Service:       {{ include "ehrbase-rs.fullname" . }}:{{ .Values.service.port }} ({{ .Values.service.type }})
+
+Reach it locally:
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "ehrbase-rs.fullname" . }} 8080:{{ .Values.service.port }}
+  curl -i http://127.0.0.1:8080{{ .Values.rest.basePath | trimSuffix "/openehr/v1" }}/status
+
+{{ if .Values.management.enabled -}}
+Health probes (public):  {{ .Values.management.basePath }}/health/liveness | /health/readiness
+{{ if .Values.metrics.enabled -}}
+Prometheus (public):     {{ .Values.management.basePath }}/prometheus  (scrape annotations added)
+{{ end -}}
+{{ else -}}
+NOTE: management.enabled=false — HTTP probes are unavailable; probes.exec must be on.
+{{ end }}
+────────────────────────────────────────────────────────────────────────────
+DATABASE / MIGRATIONS (ADR-013)
+────────────────────────────────────────────────────────────────────────────
+This chart NEVER ships a PostgreSQL. It connects to an EXTERNAL PostgreSQL 18
+as the unprivileged app role.
+{{ if .Values.database.existingSecret -}}
+  DSN source: existing Secret "{{ .Values.database.existingSecret }}" key "{{ .Values.database.existingSecretKey }}"  [OK]
+{{ else if .Values.database.url -}}
+  ⚠  DSN source: INLINE database.url (dev/test). For production set
+     database.existingSecret and remove database.url from values.
+{{ else -}}
+  ✗  No database DSN configured. Set database.existingSecret (preferred) or
+     database.url. The pod will crash-loop until a DSN is provided.
+{{ end }}
+Migrations are append-only and MUST be applied by the `ehrbase_migrator` role,
+NOT the runtime app role. Either grant the runtime DSN the migrator role, or
+run migrations out-of-band with a migrator DSN (recommended). See the
+"Upgrade strategy" section of docs/enterprise/deployment.md (lock_timeout
+wrapper + image pinning).
+
+────────────────────────────────────────────────────────────────────────────
+SECURITY POSTURE
+────────────────────────────────────────────────────────────────────────────
+  runAsNonRoot:            {{ .Values.podSecurityContext.runAsNonRoot }} (uid {{ .Values.podSecurityContext.runAsUser }})
+  readOnlyRootFilesystem:  {{ .Values.securityContext.readOnlyRootFilesystem }}
+  seccompProfile:          {{ .Values.securityContext.seccompProfile.type }}
+  NetworkPolicy:           {{ if .Values.networkPolicy.enabled }}default-deny-ingress (API port only){{ else }}DISABLED — enable networkPolicy for PHI workloads{{ end }}
+{{ if not .Values.auth.enabled }}
+  ⚠  auth.enabled=false — ALL requests pass UNAUTHENTICATED. Dev only.
+{{ end -}}
+{{ if not (or .Values.auth.oidc.issuer .Values.config.files) }}
+  ⚠  auth.enabled={{ .Values.auth.enabled }} but no OIDC issuer and no mounted
+     config.files (Basic user store). With no mechanism, every request 401s —
+     configure auth.oidc.issuer or supply a Basic-auth store via config.files.
+{{ end -}}
+{{ if .Values.fhirOutbound.enabled }}
+  ⚠  fhirOutbound.enabled=true — this AMQP stream carries PHI (mapped FHIR
+     resources). Ensure the broker + exchange "{{ .Values.fhirOutbound.exchange }}" are access-controlled and TLS.
+{{ end -}}
+{{ if and .Values.multimedia.enabled .Values.multimedia.allowHttp }}
+  ⚠  multimedia.allowHttp=true — plain-HTTP object store. Dev only; prod S3 is HTTPS.
+{{ end }}
+Optional integrations currently ON:
+  admin API:        {{ .Values.rest.adminEnabled }}
+  multi-tenancy:    {{ .Values.tenancy.enabled }}
+  eventing (AMQP):  {{ .Values.events.enabled }}
+  FHIR inbound:     {{ .Values.rest.fhirEnabled }}
+  FHIR outbound:    {{ .Values.fhirOutbound.enabled }} (PHI)
+  S3 multimedia:    {{ .Values.multimedia.enabled }}
+  ATNA audit:       {{ .Values.atna.enabled }}
+  ext terminology:  {{ .Values.externalTerminology.enabled }}

--- a/deploy/helm/ehrbase-rs/templates/_helpers.tpl
+++ b/deploy/helm/ehrbase-rs/templates/_helpers.tpl
@@ -1,0 +1,99 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ehrbase-rs.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Fully qualified app name (max 63 chars for DNS labels).
+*/}}
+{{- define "ehrbase-rs.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart name and version, for the helm.sh/chart label.
+*/}}
+{{- define "ehrbase-rs.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "ehrbase-rs.labels" -}}
+helm.sh/chart: {{ include "ehrbase-rs.chart" . }}
+{{ include "ehrbase-rs.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: ehrbase-rs
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "ehrbase-rs.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ehrbase-rs.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+ServiceAccount name.
+*/}}
+{{- define "ehrbase-rs.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "ehrbase-rs.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+The container port the management surface (health probes / prometheus) is
+reachable on. When management.port is set the surface runs on its own listener;
+otherwise it shares the main API port.
+*/}}
+{{- define "ehrbase-rs.managementPort" -}}
+{{- if .Values.management.port }}
+{{- .Values.management.port }}
+{{- else }}
+{{- 8080 }}
+{{- end }}
+{{- end }}
+
+{{/*
+The chart-managed Secret name (env-borne secrets: DB DSN, passphrases, keys).
+*/}}
+{{- define "ehrbase-rs.secretName" -}}
+{{- printf "%s-env" (include "ehrbase-rs.fullname" .) }}
+{{- end }}
+
+{{/*
+The chart-managed config-files Secret name (mounted TOML/PEM at /etc/ehrbase).
+*/}}
+{{- define "ehrbase-rs.configSecretName" -}}
+{{- printf "%s-config" (include "ehrbase-rs.fullname" .) }}
+{{- end }}
+
+{{/*
+Whether the chart-managed env Secret has any content (so we only create/mount it
+when there is at least one secret value to carry).
+*/}}
+{{- define "ehrbase-rs.hasChartSecret" -}}
+{{- $inlineDb := and (not .Values.database.existingSecret) .Values.database.url }}
+{{- if or $inlineDb .Values.auth.oidc.hmacSecret .Values.signing.pgp.keyPassphrase .Values.events.url .Values.fhirOutbound.url .Values.multimedia.accessKeyId .Values.multimedia.secretAccessKey -}}
+true
+{{- end -}}
+{{- end }}

--- a/deploy/helm/ehrbase-rs/templates/configmap.yaml
+++ b/deploy/helm/ehrbase-rs/templates/configmap.yaml
@@ -1,0 +1,144 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "ehrbase-rs.fullname" . }}
+  labels:
+    {{- include "ehrbase-rs.labels" . | nindent 4 }}
+data:
+  # ── Database pool (non-secret; the DSN itself is in the Secret) ──────────────
+  EHRBASE_DB_MAX_CONNECTIONS: {{ .Values.database.maxConnections | quote }}
+  EHRBASE_DB_MIN_CONNECTIONS: {{ .Values.database.minConnections | quote }}
+  EHRBASE_DB_ACQUIRE_TIMEOUT_SECS: {{ .Values.database.acquireTimeoutSecs | quote }}
+
+  # ── REST surface (extension groups OFF by default) ──────────────────────────
+  EHRBASE_REST_BIND: {{ .Values.rest.bind | quote }}
+  EHRBASE_REST_BASE_PATH: {{ .Values.rest.basePath | quote }}
+  EHRBASE_REST_SWAGGER_UI: {{ .Values.rest.swaggerUi | quote }}
+  EHRBASE_REST_CORS_PERMISSIVE: {{ .Values.rest.corsPermissive | quote }}
+  EHRBASE_REST_ADMIN__ENABLED: {{ .Values.rest.adminEnabled | quote }}
+  EHRBASE_REST_TERMINOLOGY__ENABLED: {{ .Values.rest.terminologyEnabled | quote }}
+  EHRBASE_REST_EVENT_SUBSCRIPTION__ENABLED: {{ .Values.rest.eventSubscriptionEnabled | quote }}
+  EHRBASE_REST_FHIR__ENABLED: {{ .Values.rest.fhirEnabled | quote }}
+
+  # ── Multi-tenancy (OFF by default) ──────────────────────────────────────────
+  EHRBASE_REST_TENANCY__ENABLED: {{ .Values.tenancy.enabled | quote }}
+  EHRBASE_REST_TENANCY__CLAIM: {{ .Values.tenancy.claim | quote }}
+  {{- with .Values.tenancy.header }}
+  EHRBASE_REST_TENANCY__HEADER: {{ . | quote }}
+  {{- end }}
+
+  # ── Authentication (Basic + OAuth2/OIDC; enabled by default) ────────────────
+  EHRBASE_REST_AUTH__ENABLED: {{ .Values.auth.enabled | quote }}
+  {{- with .Values.auth.adminScope }}
+  EHRBASE_REST_AUTH__ADMIN_SCOPE: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.auth.oidc.issuer }}
+  EHRBASE_REST_AUTH__OIDC__ISSUER: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.auth.oidc.audience }}
+  EHRBASE_REST_AUTH__OIDC__AUDIENCES: {{ . | quote }}
+  {{- end }}
+
+  # ── Authorization: coarse RBAC (on by default) + ABAC (off) ─────────────────
+  EHRBASE_AUTHZ_RBAC__ENABLED: {{ .Values.authz.rbac.enabled | quote }}
+  EHRBASE_AUTHZ_RBAC__ADMIN_ROLE: {{ .Values.authz.rbac.adminRole | quote }}
+  EHRBASE_AUTHZ_RBAC__USER_ROLE: {{ .Values.authz.rbac.userRole | quote }}
+  EHRBASE_AUTHZ_RBAC__MANAGEMENT_ACCESS: {{ .Values.authz.rbac.managementAccess | quote }}
+  EHRBASE_AUTHZ_ABAC__ENABLED: {{ .Values.authz.abac.enabled | quote }}
+
+  # ── Management / observability surface ──────────────────────────────────────
+  EHRBASE_MANAGEMENT_ENABLED: {{ .Values.management.enabled | quote }}
+  EHRBASE_MANAGEMENT_BASE_PATH: {{ .Values.management.basePath | quote }}
+  {{- with .Values.management.port }}
+  EHRBASE_MANAGEMENT_PORT: {{ . | quote }}
+  {{- end }}
+  EHRBASE_MANAGEMENT_ACCESS_DEFAULT: {{ .Values.management.accessDefault | quote }}
+  EHRBASE_MANAGEMENT_PROBES_ENABLED: {{ .Values.management.probesEnabled | quote }}
+  EHRBASE_MANAGEMENT_ENDPOINTS_HEALTH: {{ .Values.management.endpoints.health | quote }}
+  EHRBASE_MANAGEMENT_ENDPOINTS_INFO: {{ .Values.management.endpoints.info | quote }}
+  EHRBASE_MANAGEMENT_ENDPOINTS_METRICS: {{ .Values.management.endpoints.metrics | quote }}
+  {{- if .Values.metrics.enabled }}
+  EHRBASE_MANAGEMENT_ENDPOINTS_PROMETHEUS: "public"
+  {{- else }}
+  EHRBASE_MANAGEMENT_ENDPOINTS_PROMETHEUS: {{ .Values.management.endpoints.prometheus | quote }}
+  {{- end }}
+  EHRBASE_MANAGEMENT_ENDPOINTS_ENV: {{ .Values.management.endpoints.env | quote }}
+  EHRBASE_MANAGEMENT_ENDPOINTS_LOGGERS: {{ .Values.management.endpoints.loggers | quote }}
+
+  # ── Telemetry / logging ─────────────────────────────────────────────────────
+  EHRBASE_LOG_FORMAT: {{ .Values.telemetry.log.format | quote }}
+  {{- with .Values.telemetry.log.filter }}
+  EHRBASE_LOG_FILTER: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.telemetry.otel.otlpEndpoint }}
+  EHRBASE_OTEL_OTLP_ENDPOINT: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.telemetry.otel.serviceName }}
+  EHRBASE_OTEL_SERVICE_NAME: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.telemetry.otel.environment }}
+  EHRBASE_OTEL_ENVIRONMENT: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.telemetry.otel.tracesSampleRatio }}
+  EHRBASE_OTEL_TRACES_SAMPLE_RATIO: {{ . | quote }}
+  {{- end }}
+  EHRBASE_OTEL_METRICS_PUSH: {{ .Values.telemetry.otel.metricsPush | quote }}
+
+  # ── Version signing (enabled/digest by default) ─────────────────────────────
+  EHRBASE_SIGNING_ENABLED: {{ .Values.signing.enabled | quote }}
+  EHRBASE_SIGNING_MODE: {{ .Values.signing.mode | quote }}
+  EHRBASE_SIGNING_VERIFY_ON_READ: {{ .Values.signing.verifyOnRead | quote }}
+  {{- with .Values.signing.pgp.keyPath }}
+  EHRBASE_SIGNING_KEY_PATH: {{ . | quote }}
+  {{- end }}
+
+  # ── ATNA system log (OFF by default) ────────────────────────────────────────
+  EHRBASE_ATNA_ENABLED: {{ .Values.atna.enabled | quote }}
+  {{- if .Values.atna.enabled }}
+  EHRBASE_ATNA_TRANSPORT: {{ .Values.atna.transport | quote }}
+  EHRBASE_ATNA_FAIL_MODE: {{ .Values.atna.failMode | quote }}
+  {{- with .Values.atna.repositoryHost }}
+  EHRBASE_ATNA_REPOSITORY_HOST: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.atna.repositoryPort }}
+  EHRBASE_ATNA_REPOSITORY_PORT: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.atna.sourceId }}
+  EHRBASE_ATNA_SOURCE_ID: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.atna.enterpriseSiteId }}
+  EHRBASE_ATNA_ENTERPRISE_SITE_ID: {{ . | quote }}
+  {{- end }}
+  {{- end }}
+
+  # ── Contribution-outbox eventing → AMQP (OFF; PHI-free envelopes) ───────────
+  EHRBASE_EVENTS_ENABLED: {{ .Values.events.enabled | quote }}
+  {{- if .Values.events.enabled }}
+  EHRBASE_EVENTS_EXCHANGE: {{ .Values.events.exchange | quote }}
+  EHRBASE_EVENTS_TLS: {{ .Values.events.tls | quote }}
+  {{- end }}
+
+  # ── FHIR OUTBOUND emitter → AMQP (OFF; PHI-bearing stream) ──────────────────
+  EHRBASE_FHIR_OUTBOUND_ENABLED: {{ .Values.fhirOutbound.enabled | quote }}
+  {{- if .Values.fhirOutbound.enabled }}
+  EHRBASE_FHIR_OUTBOUND_EXCHANGE: {{ .Values.fhirOutbound.exchange | quote }}
+  EHRBASE_FHIR_OUTBOUND_TLS: {{ .Values.fhirOutbound.tls | quote }}
+  {{- end }}
+
+  # ── DV_MULTIMEDIA externalization → S3 (OFF; PHI blobs) ─────────────────────
+  EHRBASE_MULTIMEDIA_ENABLED: {{ .Values.multimedia.enabled | quote }}
+  {{- if .Values.multimedia.enabled }}
+  EHRBASE_MULTIMEDIA_BUCKET: {{ .Values.multimedia.bucket | quote }}
+  EHRBASE_MULTIMEDIA_REGION: {{ .Values.multimedia.region | quote }}
+  EHRBASE_MULTIMEDIA_ALLOW_HTTP: {{ .Values.multimedia.allowHttp | quote }}
+  {{- with .Values.multimedia.thresholdBytes }}
+  EHRBASE_MULTIMEDIA_THRESHOLD_BYTES: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.multimedia.endpoint }}
+  EHRBASE_MULTIMEDIA_ENDPOINT: {{ . | quote }}
+  {{- end }}
+  {{- end }}
+
+  # ── External terminology validation (OFF by default) ────────────────────────
+  EHRBASE_VALIDATION_EXTERNAL_TERMINOLOGY_ENABLED: {{ .Values.externalTerminology.enabled | quote }}
+  EHRBASE_VALIDATION_EXTERNAL_TERMINOLOGY_FAIL_ON_ERROR: {{ .Values.externalTerminology.failOnError | quote }}

--- a/deploy/helm/ehrbase-rs/templates/deployment.yaml
+++ b/deploy/helm/ehrbase-rs/templates/deployment.yaml
@@ -1,0 +1,211 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ehrbase-rs.fullname" . }}
+  labels:
+    {{- include "ehrbase-rs.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "ehrbase-rs.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        # Roll pods when the non-secret config changes.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.metrics.enabled }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ include "ehrbase-rs.managementPort" . | quote }}
+        prometheus.io/path: {{ printf "%s/prometheus" (.Values.management.basePath | trimSuffix "/") | quote }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "ehrbase-rs.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "ehrbase-rs.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: ehrbase
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            {{- if and .Values.management.enabled .Values.management.port }}
+            - name: management
+              containerPort: {{ .Values.management.port }}
+              protocol: TCP
+            {{- end }}
+          # The DSN comes from an existing Secret (preferred) or the chart Secret.
+          env:
+            - name: EHRBASE_DB_URL
+              valueFrom:
+                secretKeyRef:
+                  {{- if .Values.database.existingSecret }}
+                  name: {{ .Values.database.existingSecret }}
+                  key: {{ .Values.database.existingSecretKey }}
+                  {{- else }}
+                  name: {{ include "ehrbase-rs.secretName" . }}
+                  key: EHRBASE_DB_URL
+                  {{- end }}
+            {{- with .Values.auth.oidc.hmacSecret }}
+            {{- if . }}
+            - name: EHRBASE_REST_AUTH__OIDC__HMAC_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ehrbase-rs.secretName" $ }}
+                  key: EHRBASE_REST_AUTH__OIDC__HMAC_SECRET
+            {{- end }}
+            {{- end }}
+            {{- if .Values.signing.pgp.keyPassphrase }}
+            - name: EHRBASE_SIGNING_KEY_PASSPHRASE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ehrbase-rs.secretName" . }}
+                  key: EHRBASE_SIGNING_KEY_PASSPHRASE
+            {{- end }}
+            {{- if and .Values.events.enabled .Values.events.url }}
+            - name: EHRBASE_EVENTS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ehrbase-rs.secretName" . }}
+                  key: EHRBASE_EVENTS_URL
+            {{- end }}
+            {{- if and .Values.fhirOutbound.enabled .Values.fhirOutbound.url }}
+            - name: EHRBASE_FHIR_OUTBOUND_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ehrbase-rs.secretName" . }}
+                  key: EHRBASE_FHIR_OUTBOUND_URL
+            {{- end }}
+            {{- if and .Values.multimedia.enabled .Values.multimedia.accessKeyId }}
+            - name: EHRBASE_MULTIMEDIA_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ehrbase-rs.secretName" . }}
+                  key: EHRBASE_MULTIMEDIA_ACCESS_KEY_ID
+            - name: EHRBASE_MULTIMEDIA_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ehrbase-rs.secretName" . }}
+                  key: EHRBASE_MULTIMEDIA_SECRET_ACCESS_KEY
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "ehrbase-rs.fullname" . }}
+            {{- with .Values.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if .Values.probes.exec.enabled }}
+          livenessProbe:
+            exec:
+              command: ["/usr/local/bin/ehrbase", "healthcheck"]
+            {{- with .Values.probes.liveness }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          readinessProbe:
+            exec:
+              command: ["/usr/local/bin/ehrbase", "healthcheck"]
+            {{- with .Values.probes.readiness }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if .Values.probes.startup.enabled }}
+          startupProbe:
+            exec:
+              command: ["/usr/local/bin/ehrbase", "healthcheck"]
+            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          {{- end }}
+          {{- else }}
+          {{- if not (and .Values.management.enabled .Values.management.probesEnabled) }}
+          {{- fail "httpGet probes require management.enabled=true and management.probesEnabled=true; otherwise set probes.exec.enabled=true" }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: {{ printf "%s/health/liveness" (.Values.management.basePath | trimSuffix "/") }}
+              port: {{ ternary "management" "http" (ne (toString .Values.management.port) "") }}
+            {{- with .Values.probes.liveness }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: {{ printf "%s/health/readiness" (.Values.management.basePath | trimSuffix "/") }}
+              port: {{ ternary "management" "http" (ne (toString .Values.management.port) "") }}
+            {{- with .Values.probes.readiness }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if .Values.probes.startup.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ printf "%s/health/liveness" (.Values.management.basePath | trimSuffix "/") }}
+              port: {{ ternary "management" "http" (ne (toString .Values.management.port) "") }}
+            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          {{- end }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            # readOnlyRootFilesystem=true → give the process a writable scratch dir.
+            - name: tmp
+              mountPath: /tmp
+            {{- if .Values.config.files }}
+            - name: config
+              mountPath: /etc/ehrbase
+              readOnly: true
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        {{- if .Values.config.files }}
+        - name: config
+          secret:
+            secretName: {{ include "ehrbase-rs.configSecretName" . }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/ehrbase-rs/templates/hpa.yaml
+++ b/deploy/helm/ehrbase-rs/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "ehrbase-rs.fullname" . }}
+  labels:
+    {{- include "ehrbase-rs.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "ehrbase-rs.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/ehrbase-rs/templates/ingress.yaml
+++ b/deploy/helm/ehrbase-rs/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "ehrbase-rs.fullname" . }}
+  labels:
+    {{- include "ehrbase-rs.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "ehrbase-rs.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/ehrbase-rs/templates/networkpolicy.yaml
+++ b/deploy/helm/ehrbase-rs/templates/networkpolicy.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.networkPolicy.enabled }}
+# Default-deny ingress for the ehrbase-rs pods, admitting traffic ONLY to the
+# API port (and the management port when it runs on its own listener). Every
+# other inbound port is denied. A PHI workload should never be reachable on
+# anything but its serving port.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "ehrbase-rs.fullname" . }}
+  labels:
+    {{- include "ehrbase-rs.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "ehrbase-rs.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    {{- if .Values.networkPolicy.egress.enabled }}
+    - Egress
+    {{- end }}
+  ingress:
+    - ports:
+        - port: http
+          protocol: TCP
+        {{- if and .Values.management.enabled .Values.management.port }}
+        - port: management
+          protocol: TCP
+        {{- end }}
+      {{- with .Values.networkPolicy.ingressFrom }}
+      from:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if .Values.networkPolicy.egress.enabled }}
+  egress:
+    # DNS is always required.
+    - to: []
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    {{- with .Values.networkPolicy.egress.rules }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/ehrbase-rs/templates/poddisruptionbudget.yaml
+++ b/deploy/helm/ehrbase-rs/templates/poddisruptionbudget.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "ehrbase-rs.fullname" . }}
+  labels:
+    {{- include "ehrbase-rs.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "ehrbase-rs.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/ehrbase-rs/templates/secret.yaml
+++ b/deploy/helm/ehrbase-rs/templates/secret.yaml
@@ -1,0 +1,51 @@
+{{- if eq (include "ehrbase-rs.hasChartSecret" .) "true" }}
+# Chart-managed Secret for env-borne secret values. In production prefer
+# database.existingSecret (and an external secret store / IRSA for the rest);
+# anything set here is rendered from values, so keep it out of committed values.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ehrbase-rs.secretName" . }}
+  labels:
+    {{- include "ehrbase-rs.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- if and (not .Values.database.existingSecret) .Values.database.url }}
+  EHRBASE_DB_URL: {{ .Values.database.url | quote }}
+  {{- end }}
+  {{- with .Values.auth.oidc.hmacSecret }}
+  EHRBASE_REST_AUTH__OIDC__HMAC_SECRET: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.signing.pgp.keyPassphrase }}
+  EHRBASE_SIGNING_KEY_PASSPHRASE: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.events.url }}
+  EHRBASE_EVENTS_URL: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.fhirOutbound.url }}
+  EHRBASE_FHIR_OUTBOUND_URL: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.multimedia.accessKeyId }}
+  EHRBASE_MULTIMEDIA_ACCESS_KEY_ID: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.multimedia.secretAccessKey }}
+  EHRBASE_MULTIMEDIA_SECRET_ACCESS_KEY: {{ . | quote }}
+  {{- end }}
+{{- end }}
+{{- if .Values.config.files }}
+---
+# Mounted config files (TOML/PEM) at /etc/ehrbase — the Basic-auth user store,
+# full OIDC/ABAC/terminology blocks, ATNA PEMs, the PGP key, etc.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ehrbase-rs.configSecretName" . }}
+  labels:
+    {{- include "ehrbase-rs.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- range $name, $content := .Values.config.files }}
+  {{ $name }}: |
+    {{- $content | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/ehrbase-rs/templates/service.yaml
+++ b/deploy/helm/ehrbase-rs/templates/service.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ehrbase-rs.fullname" . }}
+  labels:
+    {{- include "ehrbase-rs.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+    {{- if and .Values.management.enabled .Values.management.port }}
+    - name: management
+      port: {{ .Values.management.port }}
+      targetPort: management
+      protocol: TCP
+    {{- end }}
+  selector:
+    {{- include "ehrbase-rs.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/ehrbase-rs/templates/serviceaccount.yaml
+++ b/deploy/helm/ehrbase-rs/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ehrbase-rs.serviceAccountName" . }}
+  labels:
+    {{- include "ehrbase-rs.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/deploy/helm/ehrbase-rs/values.yaml
+++ b/deploy/helm/ehrbase-rs/values.yaml
@@ -1,0 +1,492 @@
+# Default values for ehrbase-rs.
+#
+# Every feature flag below defaults to the SAME state as the binary itself
+# (all optional integrations OFF), with two deliberate deployment exceptions
+# documented inline: the management surface + its liveness/readiness probes are
+# ON, because Kubernetes needs HTTP probes to schedule the workload (the probe
+# routes are public/unauthenticated by design and carry no PHI).
+#
+# See docs/enterprise/deployment.md for the role architecture, the pgaudit/TLS/
+# PITR posture, and the optional-integrations security notes.
+
+# -- Number of replicas (ignored when autoscaling.enabled is true).
+replicaCount: 2
+
+image:
+  # -- Image repository. Multi-arch distroless (gcr.io/distroless/cc-debian12:nonroot base).
+  repository: ghcr.io/rubentalstra/ehrbase-rs
+  # -- Pull policy. IfNotPresent + an immutable pinned tag/digest in production.
+  pullPolicy: IfNotPresent
+  # -- Image tag. Empty string falls back to .Chart.appVersion. PIN a version
+  # or, better, a @sha256 digest in production (never `latest`).
+  tag: ""
+
+# -- imagePullSecrets for private registries.
+imagePullSecrets: []
+# -- Override the chart name portion of resource names.
+nameOverride: ""
+# -- Override the full resource name.
+fullnameOverride: ""
+
+serviceAccount:
+  # -- Create a dedicated ServiceAccount.
+  create: true
+  # -- Extra annotations (e.g. IRSA/Workload-Identity role bindings for S3).
+  annotations: {}
+  # -- Name to use; generated when empty.
+  name: ""
+  # -- The workload never calls the K8s API, so no token is mounted.
+  automountServiceAccountToken: false
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Database (external PostgreSQL 18 — ADR-008/ADR-013).
+#
+# There is NO in-chart PostgreSQL. A clinical data repository stores PHI; its
+# database MUST be an externally-managed, backed-up, PITR-capable PostgreSQL 18
+# (managed service or an operator-run cluster) — never a chart-side sidecar.
+#
+# The application connects as the UNPRIVILEGED `ehrbase_app` writer role
+# (ADR-013 §3). Schema migrations are run separately as the `ehrbase_migrator`
+# role — see .Values.migrations and docs/enterprise/deployment.md.
+# ─────────────────────────────────────────────────────────────────────────────
+database:
+  # -- Reference an existing Secret holding the app-role DSN (STRONGLY preferred
+  # for production — keeps the credential out of chart values and git). The
+  # secret's value must be a full `postgres://ehrbase_app:...@host:5432/ehrbase`
+  # (optionally `?sslmode=verify-full`).
+  existingSecret: ""
+  # -- Key within existingSecret holding the DSN.
+  existingSecretKey: EHRBASE_DB_URL
+  # -- Inline DSN (DEV/TEST ONLY — lands in a chart-managed Secret). Leave empty
+  # and use existingSecret in production. Ignored when existingSecret is set.
+  url: ""
+  # -- Pool bounds (EHRBASE_DB_MAX_CONNECTIONS / _MIN_CONNECTIONS / _ACQUIRE_TIMEOUT_SECS).
+  maxConnections: 10
+  minConnections: 0
+  acquireTimeoutSecs: 30
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Migrations (ADR-013 §3): who runs the schema.
+#
+# Migrations are append-only and are applied by the `ehrbase_migrator` role, NOT
+# by the runtime app role. The app binary DOES call run_migrations on boot, so
+# for that to be safe you EITHER:
+#   (a) grant the runtime DSN the migrator role (simplest; single-tenant), OR
+#   (b) disable in-app migration and run them out-of-band as a Job/CI step with
+#       a migrator DSN (recommended for least-privilege prod).
+# This chart does not ship a migration Job; see docs/enterprise/deployment.md
+# for the recommended out-of-band flow and the lock_timeout wrapper.
+# ─────────────────────────────────────────────────────────────────────────────
+migrations:
+  # -- Purely informational marker rendered into NOTES for the operator; the
+  # chart never runs migrations itself.
+  runByMigratorRole: true
+
+# ─────────────────────────────────────────────────────────────────────────────
+# REST surface (EHRBASE_REST_*). All extension groups OFF by default, matching
+# the binary (config.rs).
+# ─────────────────────────────────────────────────────────────────────────────
+rest:
+  # -- Bind address inside the container (EHRBASE_REST_BIND).
+  bind: "0.0.0.0:8080"
+  # -- ITS-REST base path (EHRBASE_REST_BASE_PATH).
+  basePath: /ehrbase/rest/openehr/v1
+  # -- Serve Swagger UI (EHRBASE_REST_SWAGGER_UI). Consider OFF in production.
+  swaggerUi: true
+  # -- Permissive CORS (EHRBASE_REST_CORS_PERMISSIVE) — DEV ONLY.
+  corsPermissive: false
+  # -- ADMIN API group (EHRBASE_REST_ADMIN__ENABLED): physical/irreversible
+  # delete. OFF by default; when off the routes are absent (404), not 403.
+  adminEnabled: false
+  # -- Terminology extension group (EHRBASE_REST_TERMINOLOGY__ENABLED).
+  terminologyEnabled: false
+  # -- Event-subscription admin group (EHRBASE_REST_EVENT_SUBSCRIPTION__ENABLED).
+  eventSubscriptionEnabled: false
+  # -- FHIR R4 inbound/façade connector (EHRBASE_REST_FHIR__ENABLED, ADR-016).
+  # Independent of the fhirOutbound emitter below.
+  fhirEnabled: false
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Multi-tenancy (EHRBASE_REST_TENANCY__*, ADR-015). OFF by default.
+# ─────────────────────────────────────────────────────────────────────────────
+tenancy:
+  # -- Master switch (EHRBASE_REST_TENANCY__ENABLED).
+  enabled: false
+  # -- JWT-claim path carrying the tenant key (EHRBASE_REST_TENANCY__CLAIM).
+  claim: tenant
+  # -- Dev-only request-header override (EHRBASE_REST_TENANCY__HEADER). Leave
+  # empty in production — a client-supplied header must not select a tenant.
+  header: ""
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Authentication (EHRBASE_REST_AUTH__*, Stage 1: Basic + OAuth2/OIDC bearer).
+# Enabled by default (matching the binary). A server with auth.enabled=true but
+# no mechanism 401s every request — configure OIDC below, or supply a Basic user
+# store / full OIDC block via config.files (mounted TOML).
+# ─────────────────────────────────────────────────────────────────────────────
+auth:
+  # -- Master switch (EHRBASE_REST_AUTH__ENABLED). false = all requests pass
+  # unauthenticated — DEV ONLY.
+  enabled: true
+  # -- Deprecated back-compat admin scope (EHRBASE_REST_AUTH__ADMIN_SCOPE);
+  # still consulted by the management AdminOnly access level. Empty = unset.
+  adminScope: ""
+  oidc:
+    # -- Configure the OAuth2/OIDC resource-server validation. When issuer is
+    # set the [auth.oidc] block is emitted via env (issuer/audiences/algorithms).
+    issuer: ""
+    # -- Accepted audiences (EHRBASE_REST_AUTH__OIDC__AUDIENCES). List/array
+    # values are best supplied via a mounted TOML (config.files); a single
+    # audience can be given here.
+    audience: ""
+    # -- Symmetric HS256 secret (dev/test). Lands in the chart Secret. Prefer
+    # JWKS/discovery (leave empty) in production.
+    hmacSecret: ""
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Authorization / RBAC + ABAC (EHRBASE_AUTHZ_*). Coarse RBAC on by default when
+# auth is on (matching the binary); ABAC off by default.
+# ─────────────────────────────────────────────────────────────────────────────
+authz:
+  rbac:
+    # -- Coarse role gate (EHRBASE_AUTHZ_RBAC__ENABLED).
+    enabled: true
+    # -- Role required for Admin-class ops (EHRBASE_AUTHZ_RBAC__ADMIN_ROLE).
+    adminRole: ADMIN
+    # -- Baseline clinical role (EHRBASE_AUTHZ_RBAC__USER_ROLE).
+    userRole: USER
+    # -- Management-surface access (EHRBASE_AUTHZ_RBAC__MANAGEMENT_ACCESS):
+    # admin_only | private | public.
+    managementAccess: admin_only
+  abac:
+    # -- Attribute-based access control (EHRBASE_AUTHZ_ABAC__ENABLED). Cedar/
+    # remote engines + policies are supplied via a mounted TOML (config.files).
+    enabled: false
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Management / observability surface (EHRBASE_MANAGEMENT_*).
+#
+# Deployment default deviates from the bare binary (which ships this OFF): the
+# surface + the K8s liveness/readiness probes are ON here because the cluster
+# needs HTTP probes. The probe routes are Public (unauthenticated) and carry no
+# PHI. All DATA endpoints (info/metrics/env/loggers) stay OFF; prometheus is
+# opt-in via metrics.enabled.
+# ─────────────────────────────────────────────────────────────────────────────
+management:
+  # -- Mount the management router (EHRBASE_MANAGEMENT_ENABLED).
+  enabled: true
+  # -- Base path (EHRBASE_MANAGEMENT_BASE_PATH).
+  basePath: /management
+  # -- Serve the management surface on its OWN internal port
+  # (EHRBASE_MANAGEMENT_PORT) instead of the public API listener. Recommended in
+  # production so /management is never reachable on the clinical listener. Empty
+  # = share the main 8080 listener.
+  port: ""
+  # -- Default access level (EHRBASE_MANAGEMENT_ACCESS_DEFAULT).
+  accessDefault: admin_only
+  # -- Mount public /health/liveness + /health/readiness
+  # (EHRBASE_MANAGEMENT_PROBES_ENABLED). Required for the httpGet probes below.
+  probesEnabled: true
+  endpoints:
+    # -- Per-endpoint access levels (off | public | private | admin_only).
+    # EHRBASE_MANAGEMENT_ENDPOINTS_<EP>. All off by default.
+    health: "off"
+    info: "off"
+    metrics: "off"
+    prometheus: "off"
+    env: "off"
+    loggers: "off"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Prometheus scraping. When enabled: sets the prometheus endpoint access to
+# `public`, mounts it (probesEnabled/management.enabled required), and adds the
+# scrape pod annotations.
+# ─────────────────────────────────────────────────────────────────────────────
+metrics:
+  # -- Expose /management/prometheus and add prometheus.io scrape annotations.
+  enabled: false
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Telemetry / logging (EHRBASE_LOG_* / EHRBASE_OTEL_*).
+# ─────────────────────────────────────────────────────────────────────────────
+telemetry:
+  log:
+    # -- Log rendering profile (EHRBASE_LOG_FORMAT): auto | json | pretty.
+    # `json` is correct for cluster log collectors.
+    format: json
+    # -- EnvFilter directives (EHRBASE_LOG_FILTER). Empty = binary default.
+    filter: ""
+  otel:
+    # -- OTLP/gRPC collector endpoint (EHRBASE_OTEL_OTLP_ENDPOINT). Empty = the
+    # OTel layer is not installed (zero overhead).
+    otlpEndpoint: ""
+    # -- service.name resource attribute (EHRBASE_OTEL_SERVICE_NAME).
+    serviceName: ""
+    # -- deployment.environment resource attribute (EHRBASE_OTEL_ENVIRONMENT).
+    environment: ""
+    # -- Head-sampling ratio (EHRBASE_OTEL_TRACES_SAMPLE_RATIO). Empty = default.
+    tracesSampleRatio: ""
+    # -- Also push metrics over OTLP (EHRBASE_OTEL_METRICS_PUSH).
+    metricsPush: false
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Version signing (EHRBASE_SIGNING_*). Enabled by default in DIGEST mode
+# (matching the binary — the STANDARD "Signing" capability). PGP mode requires a
+# key + passphrase and FAILS CLOSED at boot if the key is unusable.
+# ─────────────────────────────────────────────────────────────────────────────
+signing:
+  # -- Server-side signing of committed versions (EHRBASE_SIGNING_ENABLED).
+  enabled: true
+  # -- Mode (EHRBASE_SIGNING_MODE): digest | pgp.
+  mode: digest
+  # -- Read-time verification (EHRBASE_SIGNING_VERIFY_ON_READ): off | warn | strict.
+  verifyOnRead: "off"
+  pgp:
+    # -- Path to the armored RFC 4880 secret key (EHRBASE_SIGNING_KEY_PATH),
+    # mounted from config.files or an external secret volume. Required for pgp.
+    keyPath: ""
+    # -- Key passphrase (EHRBASE_SIGNING_KEY_PASSPHRASE). Lands in the chart
+    # Secret (redacted from /management/env by the binary).
+    keyPassphrase: ""
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ATNA system log (EHRBASE_ATNA_*, IHE audit). OFF by default. See the PHI/audit
+# notes in docs/enterprise/deployment.md.
+# ─────────────────────────────────────────────────────────────────────────────
+atna:
+  # -- Master switch (EHRBASE_ATNA_ENABLED).
+  enabled: false
+  # -- Audit Record Repository host (EHRBASE_ATNA_REPOSITORY_HOST).
+  repositoryHost: ""
+  # -- ARR port (EHRBASE_ATNA_REPOSITORY_PORT). 514 udp / 6514 tls typical.
+  repositoryPort: ""
+  # -- Transport (EHRBASE_ATNA_TRANSPORT): udp | tls. tls for PHI.
+  transport: udp
+  # -- Source id (EHRBASE_ATNA_SOURCE_ID).
+  sourceId: ""
+  # -- Failure mode (EHRBASE_ATNA_FAIL_MODE): open | closed.
+  failMode: open
+  # -- Enterprise/site id (EHRBASE_ATNA_ENTERPRISE_SITE_ID).
+  enterpriseSiteId: ""
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Contribution-outbox eventing → AMQP (EHRBASE_EVENTS_*, ADR-014). OFF by
+# default. Envelopes are PHI-FREE by design (ADR-014 §2).
+# ─────────────────────────────────────────────────────────────────────────────
+events:
+  # -- Master switch (EHRBASE_EVENTS_ENABLED).
+  enabled: false
+  # -- Broker URL (EHRBASE_EVENTS_URL). Carries credentials → lands in the chart
+  # Secret. Use amqps:// or set tls=true in production.
+  url: ""
+  # -- Topic exchange (EHRBASE_EVENTS_EXCHANGE).
+  exchange: ehrbase.events
+  # -- Upgrade amqp:// to amqps:// (EHRBASE_EVENTS_TLS).
+  tls: false
+
+# ─────────────────────────────────────────────────────────────────────────────
+# FHIR OUTBOUND emitter → AMQP (EHRBASE_FHIR_OUTBOUND_*, ADR-016 §4a). OFF by
+# default. WARNING: this stream carries PHI (the mapped FHIR resource) — see the
+# PHI-exchange note in docs/enterprise/deployment.md. Separate switch + separate
+# exchange from the PHI-free `events` stream.
+# ─────────────────────────────────────────────────────────────────────────────
+fhirOutbound:
+  # -- Master switch (EHRBASE_FHIR_OUTBOUND_ENABLED).
+  enabled: false
+  # -- Broker URL (EHRBASE_FHIR_OUTBOUND_URL). Carries credentials → chart Secret.
+  url: ""
+  # -- Topic exchange (EHRBASE_FHIR_OUTBOUND_EXCHANGE) — distinct for PHI isolation.
+  exchange: ehrbase.fhir
+  # -- Upgrade amqp:// to amqps:// (EHRBASE_FHIR_OUTBOUND_TLS).
+  tls: false
+
+# ─────────────────────────────────────────────────────────────────────────────
+# DV_MULTIMEDIA externalization → S3-compatible object store (EHRBASE_MULTIMEDIA_*,
+# ADR-017). OFF by default (inline behaviour byte-identical). WARNING: offloaded
+# blobs are PHI — the bucket must be private, encrypted, HTTPS.
+# ─────────────────────────────────────────────────────────────────────────────
+multimedia:
+  # -- Master switch (EHRBASE_MULTIMEDIA_ENABLED).
+  enabled: false
+  # -- Offload threshold in bytes (EHRBASE_MULTIMEDIA_THRESHOLD_BYTES). Empty = 256 KiB.
+  thresholdBytes: ""
+  # -- S3-compatible endpoint (EHRBASE_MULTIMEDIA_ENDPOINT). Empty = AWS default.
+  endpoint: ""
+  # -- Bucket (EHRBASE_MULTIMEDIA_BUCKET).
+  bucket: openehr-multimedia
+  # -- Region (EHRBASE_MULTIMEDIA_REGION).
+  region: us-east-1
+  # -- Allow plain HTTP (EHRBASE_MULTIMEDIA_ALLOW_HTTP) — DEV ONLY; prod S3 is HTTPS.
+  allowHttp: false
+  # -- Access key id (EHRBASE_MULTIMEDIA_ACCESS_KEY_ID). Lands in the chart
+  # Secret. Prefer IRSA/Workload-Identity (leave empty) on cloud.
+  accessKeyId: ""
+  # -- Secret access key (EHRBASE_MULTIMEDIA_SECRET_ACCESS_KEY). Chart Secret.
+  secretAccessKey: ""
+
+# ─────────────────────────────────────────────────────────────────────────────
+# External terminology validation (EHRBASE_VALIDATION_EXTERNAL_TERMINOLOGY_*).
+# OFF by default. The FHIR provider map is supplied via a mounted TOML
+# (config.files + EHRBASE_VALIDATION_CONFIG in extraEnv).
+# ─────────────────────────────────────────────────────────────────────────────
+externalTerminology:
+  # -- Master switch (EHRBASE_VALIDATION_EXTERNAL_TERMINOLOGY_ENABLED).
+  enabled: false
+  # -- Reject on TS error (EHRBASE_VALIDATION_EXTERNAL_TERMINOLOGY_FAIL_ON_ERROR).
+  failOnError: false
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Mounted config files. Each key becomes /etc/ehrbase/<key> from a chart Secret
+# (opaque, read-only). Use for the values env can't carry cleanly: the Basic-auth
+# user store, full OIDC blocks, RBAC role-claim lists, Cedar/ABAC policies, the
+# terminology provider map, the ATNA TLS PEMs, the PGP key. Point the matching
+# EHRBASE_*_CONFIG / *_PATH env at the file via extraEnv.
+# ─────────────────────────────────────────────────────────────────────────────
+config:
+  files: {}
+  # rest.toml: |
+  #   [[auth.basic.users]]
+  #   username = "clinician"
+  #   password_hash = "$argon2id$v=19$..."
+  #   roles = ["USER"]
+
+# -- Extra raw env vars (list of {name,value} or {name,valueFrom}). Escape hatch
+# for anything not surfaced above (e.g. EHRBASE_REST_CONFIG, array-valued keys).
+extraEnv: []
+# -- Extra envFrom sources (configMapRef/secretRef).
+extraEnvFrom: []
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Networking.
+# ─────────────────────────────────────────────────────────────────────────────
+service:
+  # -- Service type. ClusterIP + an Ingress/gateway in front is the norm.
+  type: ClusterIP
+  # -- Public API port.
+  port: 8080
+  # -- Extra annotations.
+  annotations: {}
+
+ingress:
+  # -- Create an Ingress. TLS termination belongs here (or at a gateway).
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: ehrbase.example.com
+      paths:
+        - path: /ehrbase
+          pathType: Prefix
+  tls: []
+
+networkPolicy:
+  # -- Install a default-deny-ingress NetworkPolicy that only admits traffic to
+  # the API (and management) port. Strongly recommended for a PHI workload.
+  enabled: true
+  # -- Additional ingress `from` selectors admitted to the API port. Empty =
+  # admit from any pod in the namespace to the API port only (still default-deny
+  # for every other port). Tighten to your ingress-controller namespace/pods.
+  ingressFrom: []
+  # -- Restrict egress too (default-deny egress except DNS + the DB/broker/TS).
+  # Off by default because egress targets are deployment-specific; see the doc.
+  egress:
+    enabled: false
+    # Extra egress `to`/`ports` rules (raw NetworkPolicyEgressRule entries).
+    rules: []
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Pod / container security (ADR-013 posture: non-root, read-only rootfs,
+# seccomp RuntimeDefault, all caps dropped).
+# ─────────────────────────────────────────────────────────────────────────────
+podSecurityContext:
+  runAsNonRoot: true
+  # 65532 = the distroless `nonroot` uid/gid.
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+  fsGroupChangePolicy: OnRootMismatch
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  allowPrivilegeEscalation: false
+  privileged: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
+# -- Resource requests/limits. Sized for a modest API replica; tune for load.
+resources:
+  requests:
+    cpu: 250m
+    memory: 256Mi
+  limits:
+    cpu: "2"
+    memory: 1Gi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Probes. httpGet against the public management probe routes (management.enabled
+# + management.probesEnabled required). Set exec.enabled to use the binary's
+# `healthcheck` subcommand instead (works even with management off).
+# ─────────────────────────────────────────────────────────────────────────────
+probes:
+  # -- Use `ehrbase healthcheck` exec probes instead of httpGet.
+  exec:
+    enabled: false
+  liveness:
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    timeoutSeconds: 3
+    failureThreshold: 3
+  readiness:
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 3
+  startup:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 30
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Autoscaling.
+# ─────────────────────────────────────────────────────────────────────────────
+autoscaling:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 6
+  targetCPUUtilizationPercentage: 75
+  targetMemoryUtilizationPercentage: 0
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PodDisruptionBudget.
+# ─────────────────────────────────────────────────────────────────────────────
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+  # maxUnavailable: ""   # set one of minAvailable / maxUnavailable
+
+# -- Extra pod labels / annotations.
+podLabels: {}
+podAnnotations: {}
+
+# -- Scheduling.
+nodeSelector: {}
+tolerations: []
+affinity: {}
+# -- Spread replicas across nodes/zones. Empty = none.
+topologySpreadConstraints: []
+
+# -- Termination grace period (audit/outbox drain has a 5s window in-binary).
+terminationGracePeriodSeconds: 30
+
+# -- Extra volumes / volumeMounts (e.g. an external secret store for the PGP key).
+extraVolumes: []
+extraVolumeMounts: []

--- a/deploy/helm/golden/README.md
+++ b/deploy/helm/golden/README.md
@@ -1,0 +1,24 @@
+# Golden Helm renders
+
+These are the committed `helm template` outputs the chart is expected to
+produce, used by `deploy/helm/validate.sh` (and CI) to catch unintended drift.
+
+- `default.yaml` — `ci/default-values.yaml` (chart defaults + an external-Secret
+  DB DSN; all optional integrations OFF, the ADR-013 security posture on).
+- `all-features.yaml` — `ci/all-features-values.yaml` (every optional
+  integration enabled, separate management port, autoscaling, egress policy,
+  mounted config files).
+
+## Regenerating
+
+Whenever a chart template or the `ci/*-values.yaml` overlays change and the
+render is *intended* to differ, regenerate and review the diff:
+
+```bash
+deploy/helm/validate.sh --update
+git diff deploy/helm/golden
+```
+
+`deploy/helm/validate.sh` (no args) fails on any drift, so a stale golden is
+caught before merge. Renders are pinned to release name `ehrbase-rs`, namespace
+`ehrbase`. Do not hand-edit these files.

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -1,0 +1,482 @@
+---
+# Source: ehrbase-rs/templates/networkpolicy.yaml
+# Default-deny ingress for the ehrbase-rs pods, admitting traffic ONLY to the
+# API port (and the management port when it runs on its own listener). Every
+# other inbound port is denied. A PHI workload should never be reachable on
+# anything but its serving port.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ehrbase-rs
+  labels:
+    helm.sh/chart: ehrbase-rs-0.1.0
+    app.kubernetes.io/name: ehrbase-rs
+    app.kubernetes.io/instance: ehrbase-rs
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: ehrbase-rs
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: ehrbase-rs
+      app.kubernetes.io/instance: ehrbase-rs
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        - port: http
+          protocol: TCP
+        - port: management
+          protocol: TCP
+      from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+  egress:
+    # DNS is always required.
+    - to: []
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    - ports:
+      - port: 5432
+        protocol: TCP
+      to:
+      - podSelector:
+          matchLabels:
+            app.kubernetes.io/name: postgres
+---
+# Source: ehrbase-rs/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: ehrbase-rs
+  labels:
+    helm.sh/chart: ehrbase-rs-0.1.0
+    app.kubernetes.io/name: ehrbase-rs
+    app.kubernetes.io/instance: ehrbase-rs
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: ehrbase-rs
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ehrbase-rs
+      app.kubernetes.io/instance: ehrbase-rs
+---
+# Source: ehrbase-rs/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ehrbase-rs
+  labels:
+    helm.sh/chart: ehrbase-rs-0.1.0
+    app.kubernetes.io/name: ehrbase-rs
+    app.kubernetes.io/instance: ehrbase-rs
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: ehrbase-rs
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/ehrbase-s3
+automountServiceAccountToken: false
+---
+# Source: ehrbase-rs/templates/secret.yaml
+# Chart-managed Secret for env-borne secret values. In production prefer
+# database.existingSecret (and an external secret store / IRSA for the rest);
+# anything set here is rendered from values, so keep it out of committed values.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ehrbase-rs-env
+  labels:
+    helm.sh/chart: ehrbase-rs-0.1.0
+    app.kubernetes.io/name: ehrbase-rs
+    app.kubernetes.io/instance: ehrbase-rs
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: ehrbase-rs
+type: Opaque
+stringData:
+  EHRBASE_REST_AUTH__OIDC__HMAC_SECRET: "dev-hmac-secret"
+  EHRBASE_SIGNING_KEY_PASSPHRASE: "dev-passphrase"
+  EHRBASE_EVENTS_URL: "amqps://user:pass@rabbitmq:5671/%2f"
+  EHRBASE_FHIR_OUTBOUND_URL: "amqps://user:pass@rabbitmq:5671/%2f"
+  EHRBASE_MULTIMEDIA_ACCESS_KEY_ID: "AKIAEXAMPLE"
+  EHRBASE_MULTIMEDIA_SECRET_ACCESS_KEY: "s3-secret"
+---
+# Source: ehrbase-rs/templates/secret.yaml
+# Mounted config files (TOML/PEM) at /etc/ehrbase — the Basic-auth user store,
+# full OIDC/ABAC/terminology blocks, ATNA PEMs, the PGP key, etc.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ehrbase-rs-config
+  labels:
+    helm.sh/chart: ehrbase-rs-0.1.0
+    app.kubernetes.io/name: ehrbase-rs
+    app.kubernetes.io/instance: ehrbase-rs
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: ehrbase-rs
+type: Opaque
+stringData:
+  rest.toml: |
+    [[auth.basic.users]]
+    username = "clinician"
+    password_hash = "$argon2id$v=19$m=4096,t=2,p=1$c2FsdA$hash"
+    roles = ["USER"]
+    
+  signing.asc: |
+    -----BEGIN PGP PRIVATE KEY BLOCK-----
+    (dev placeholder)
+    -----END PGP PRIVATE KEY BLOCK-----
+---
+# Source: ehrbase-rs/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ehrbase-rs
+  labels:
+    helm.sh/chart: ehrbase-rs-0.1.0
+    app.kubernetes.io/name: ehrbase-rs
+    app.kubernetes.io/instance: ehrbase-rs
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: ehrbase-rs
+data:
+  # ── Database pool (non-secret; the DSN itself is in the Secret) ──────────────
+  EHRBASE_DB_MAX_CONNECTIONS: "10"
+  EHRBASE_DB_MIN_CONNECTIONS: "0"
+  EHRBASE_DB_ACQUIRE_TIMEOUT_SECS: "30"
+
+  # ── REST surface (extension groups OFF by default) ──────────────────────────
+  EHRBASE_REST_BIND: "0.0.0.0:8080"
+  EHRBASE_REST_BASE_PATH: "/ehrbase/rest/openehr/v1"
+  EHRBASE_REST_SWAGGER_UI: "true"
+  EHRBASE_REST_CORS_PERMISSIVE: "false"
+  EHRBASE_REST_ADMIN__ENABLED: "true"
+  EHRBASE_REST_TERMINOLOGY__ENABLED: "true"
+  EHRBASE_REST_EVENT_SUBSCRIPTION__ENABLED: "true"
+  EHRBASE_REST_FHIR__ENABLED: "true"
+
+  # ── Multi-tenancy (OFF by default) ──────────────────────────────────────────
+  EHRBASE_REST_TENANCY__ENABLED: "true"
+  EHRBASE_REST_TENANCY__CLAIM: "realm_access.tenant"
+  EHRBASE_REST_TENANCY__HEADER: "X-EHRbase-Tenant"
+
+  # ── Authentication (Basic + OAuth2/OIDC; enabled by default) ────────────────
+  EHRBASE_REST_AUTH__ENABLED: "true"
+  EHRBASE_REST_AUTH__ADMIN_SCOPE: "ADMIN"
+  EHRBASE_REST_AUTH__OIDC__ISSUER: "https://keycloak.example.com/realms/ehrbase"
+  EHRBASE_REST_AUTH__OIDC__AUDIENCES: "ehrbase"
+
+  # ── Authorization: coarse RBAC (on by default) + ABAC (off) ─────────────────
+  EHRBASE_AUTHZ_RBAC__ENABLED: "true"
+  EHRBASE_AUTHZ_RBAC__ADMIN_ROLE: "ADMIN"
+  EHRBASE_AUTHZ_RBAC__USER_ROLE: "USER"
+  EHRBASE_AUTHZ_RBAC__MANAGEMENT_ACCESS: "admin_only"
+  EHRBASE_AUTHZ_ABAC__ENABLED: "true"
+
+  # ── Management / observability surface ──────────────────────────────────────
+  EHRBASE_MANAGEMENT_ENABLED: "true"
+  EHRBASE_MANAGEMENT_BASE_PATH: "/management"
+  EHRBASE_MANAGEMENT_PORT: "9100"
+  EHRBASE_MANAGEMENT_ACCESS_DEFAULT: "admin_only"
+  EHRBASE_MANAGEMENT_PROBES_ENABLED: "true"
+  EHRBASE_MANAGEMENT_ENDPOINTS_HEALTH: "private"
+  EHRBASE_MANAGEMENT_ENDPOINTS_INFO: "admin_only"
+  EHRBASE_MANAGEMENT_ENDPOINTS_METRICS: "admin_only"
+  EHRBASE_MANAGEMENT_ENDPOINTS_PROMETHEUS: "public"
+  EHRBASE_MANAGEMENT_ENDPOINTS_ENV: "admin_only"
+  EHRBASE_MANAGEMENT_ENDPOINTS_LOGGERS: "admin_only"
+
+  # ── Telemetry / logging ─────────────────────────────────────────────────────
+  EHRBASE_LOG_FORMAT: "json"
+  EHRBASE_LOG_FILTER: "info,ehrbase=debug"
+  EHRBASE_OTEL_OTLP_ENDPOINT: "http://otel-collector:4317"
+  EHRBASE_OTEL_SERVICE_NAME: "ehrbase-rs"
+  EHRBASE_OTEL_ENVIRONMENT: "production"
+  EHRBASE_OTEL_TRACES_SAMPLE_RATIO: "0.1"
+  EHRBASE_OTEL_METRICS_PUSH: "true"
+
+  # ── Version signing (enabled/digest by default) ─────────────────────────────
+  EHRBASE_SIGNING_ENABLED: "true"
+  EHRBASE_SIGNING_MODE: "pgp"
+  EHRBASE_SIGNING_VERIFY_ON_READ: "strict"
+  EHRBASE_SIGNING_KEY_PATH: "/etc/ehrbase/signing.asc"
+
+  # ── ATNA system log (OFF by default) ────────────────────────────────────────
+  EHRBASE_ATNA_ENABLED: "true"
+  EHRBASE_ATNA_TRANSPORT: "tls"
+  EHRBASE_ATNA_FAIL_MODE: "closed"
+  EHRBASE_ATNA_REPOSITORY_HOST: "arr.example.com"
+  EHRBASE_ATNA_REPOSITORY_PORT: "6514"
+  EHRBASE_ATNA_SOURCE_ID: "ehrbase-prod"
+  EHRBASE_ATNA_ENTERPRISE_SITE_ID: "site-1"
+
+  # ── Contribution-outbox eventing → AMQP (OFF; PHI-free envelopes) ───────────
+  EHRBASE_EVENTS_ENABLED: "true"
+  EHRBASE_EVENTS_EXCHANGE: "ehrbase.events"
+  EHRBASE_EVENTS_TLS: "true"
+
+  # ── FHIR OUTBOUND emitter → AMQP (OFF; PHI-bearing stream) ──────────────────
+  EHRBASE_FHIR_OUTBOUND_ENABLED: "true"
+  EHRBASE_FHIR_OUTBOUND_EXCHANGE: "ehrbase.fhir"
+  EHRBASE_FHIR_OUTBOUND_TLS: "true"
+
+  # ── DV_MULTIMEDIA externalization → S3 (OFF; PHI blobs) ─────────────────────
+  EHRBASE_MULTIMEDIA_ENABLED: "true"
+  EHRBASE_MULTIMEDIA_BUCKET: "openehr-multimedia"
+  EHRBASE_MULTIMEDIA_REGION: "eu-west-1"
+  EHRBASE_MULTIMEDIA_ALLOW_HTTP: "false"
+  EHRBASE_MULTIMEDIA_THRESHOLD_BYTES: "262144"
+  EHRBASE_MULTIMEDIA_ENDPOINT: "https://s3.example.com"
+
+  # ── External terminology validation (OFF by default) ────────────────────────
+  EHRBASE_VALIDATION_EXTERNAL_TERMINOLOGY_ENABLED: "true"
+  EHRBASE_VALIDATION_EXTERNAL_TERMINOLOGY_FAIL_ON_ERROR: "false"
+---
+# Source: ehrbase-rs/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: ehrbase-rs
+  labels:
+    helm.sh/chart: ehrbase-rs-0.1.0
+    app.kubernetes.io/name: ehrbase-rs
+    app.kubernetes.io/instance: ehrbase-rs
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: ehrbase-rs
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP
+    - name: management
+      port: 9100
+      targetPort: management
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: ehrbase-rs
+    app.kubernetes.io/instance: ehrbase-rs
+---
+# Source: ehrbase-rs/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ehrbase-rs
+  labels:
+    helm.sh/chart: ehrbase-rs-0.1.0
+    app.kubernetes.io/name: ehrbase-rs
+    app.kubernetes.io/instance: ehrbase-rs
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: ehrbase-rs
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ehrbase-rs
+      app.kubernetes.io/instance: ehrbase-rs
+  template:
+    metadata:
+      annotations:
+        # Roll pods when the non-secret config changes.
+        checksum/config: 60d0cf591b89ca76e09f3b1d7085944ad295806563028ea3a56f070d45257dd8
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9100"
+        prometheus.io/path: "/management/prometheus"
+      labels:
+        app.kubernetes.io/name: ehrbase-rs
+        app.kubernetes.io/instance: ehrbase-rs
+    spec:
+      serviceAccountName: ehrbase-rs
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 65532
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: ehrbase
+          image: "ghcr.io/rubentalstra/ehrbase-rs:0.1.0"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: management
+              containerPort: 9100
+              protocol: TCP
+          # The DSN comes from an existing Secret (preferred) or the chart Secret.
+          env:
+            - name: EHRBASE_DB_URL
+              valueFrom:
+                secretKeyRef:
+                  name: ehrbase-db
+                  key: EHRBASE_DB_URL
+            - name: EHRBASE_REST_AUTH__OIDC__HMAC_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: ehrbase-rs-env
+                  key: EHRBASE_REST_AUTH__OIDC__HMAC_SECRET
+            - name: EHRBASE_SIGNING_KEY_PASSPHRASE
+              valueFrom:
+                secretKeyRef:
+                  name: ehrbase-rs-env
+                  key: EHRBASE_SIGNING_KEY_PASSPHRASE
+            - name: EHRBASE_EVENTS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: ehrbase-rs-env
+                  key: EHRBASE_EVENTS_URL
+            - name: EHRBASE_FHIR_OUTBOUND_URL
+              valueFrom:
+                secretKeyRef:
+                  name: ehrbase-rs-env
+                  key: EHRBASE_FHIR_OUTBOUND_URL
+            - name: EHRBASE_MULTIMEDIA_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: ehrbase-rs-env
+                  key: EHRBASE_MULTIMEDIA_ACCESS_KEY_ID
+            - name: EHRBASE_MULTIMEDIA_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: ehrbase-rs-env
+                  key: EHRBASE_MULTIMEDIA_SECRET_ACCESS_KEY
+            - name: EHRBASE_REST_CONFIG
+              value: /etc/ehrbase/rest.toml
+            - name: EHRBASE_SIGNING_KEY_PATH
+              value: /etc/ehrbase/signing.asc
+          envFrom:
+            - configMapRef:
+                name: ehrbase-rs
+          livenessProbe:
+            httpGet:
+              path: /management/health/liveness
+              port: management
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /management/health/readiness
+              port: management
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+          startupProbe:
+            httpGet:
+              path: /management/health/liveness
+              port: management
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 30
+          resources:
+            limits:
+              cpu: "2"
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+          volumeMounts:
+            # readOnlyRootFilesystem=true → give the process a writable scratch dir.
+            - name: tmp
+              mountPath: /tmp
+            - name: config
+              mountPath: /etc/ehrbase
+              readOnly: true
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          secret:
+            secretName: ehrbase-rs-config
+---
+# Source: ehrbase-rs/templates/hpa.yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: ehrbase-rs
+  labels:
+    helm.sh/chart: ehrbase-rs-0.1.0
+    app.kubernetes.io/name: ehrbase-rs
+    app.kubernetes.io/instance: ehrbase-rs
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: ehrbase-rs
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: ehrbase-rs
+  minReplicas: 3
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+---
+# Source: ehrbase-rs/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ehrbase-rs
+  labels:
+    helm.sh/chart: ehrbase-rs-0.1.0
+    app.kubernetes.io/name: ehrbase-rs
+    app.kubernetes.io/instance: ehrbase-rs
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: ehrbase-rs
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+      - ehrbase.example.com
+      secretName: ehrbase-tls
+  rules:
+    - host: "ehrbase.example.com"
+      http:
+        paths:
+          - path: /ehrbase
+            pathType: Prefix
+            backend:
+              service:
+                name: ehrbase-rs
+                port:
+                  number: 8080

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -1,0 +1,269 @@
+---
+# Source: ehrbase-rs/templates/networkpolicy.yaml
+# Default-deny ingress for the ehrbase-rs pods, admitting traffic ONLY to the
+# API port (and the management port when it runs on its own listener). Every
+# other inbound port is denied. A PHI workload should never be reachable on
+# anything but its serving port.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ehrbase-rs
+  labels:
+    helm.sh/chart: ehrbase-rs-0.1.0
+    app.kubernetes.io/name: ehrbase-rs
+    app.kubernetes.io/instance: ehrbase-rs
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: ehrbase-rs
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: ehrbase-rs
+      app.kubernetes.io/instance: ehrbase-rs
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: http
+          protocol: TCP
+---
+# Source: ehrbase-rs/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: ehrbase-rs
+  labels:
+    helm.sh/chart: ehrbase-rs-0.1.0
+    app.kubernetes.io/name: ehrbase-rs
+    app.kubernetes.io/instance: ehrbase-rs
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: ehrbase-rs
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ehrbase-rs
+      app.kubernetes.io/instance: ehrbase-rs
+---
+# Source: ehrbase-rs/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ehrbase-rs
+  labels:
+    helm.sh/chart: ehrbase-rs-0.1.0
+    app.kubernetes.io/name: ehrbase-rs
+    app.kubernetes.io/instance: ehrbase-rs
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: ehrbase-rs
+automountServiceAccountToken: false
+---
+# Source: ehrbase-rs/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ehrbase-rs
+  labels:
+    helm.sh/chart: ehrbase-rs-0.1.0
+    app.kubernetes.io/name: ehrbase-rs
+    app.kubernetes.io/instance: ehrbase-rs
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: ehrbase-rs
+data:
+  # ── Database pool (non-secret; the DSN itself is in the Secret) ──────────────
+  EHRBASE_DB_MAX_CONNECTIONS: "10"
+  EHRBASE_DB_MIN_CONNECTIONS: "0"
+  EHRBASE_DB_ACQUIRE_TIMEOUT_SECS: "30"
+
+  # ── REST surface (extension groups OFF by default) ──────────────────────────
+  EHRBASE_REST_BIND: "0.0.0.0:8080"
+  EHRBASE_REST_BASE_PATH: "/ehrbase/rest/openehr/v1"
+  EHRBASE_REST_SWAGGER_UI: "true"
+  EHRBASE_REST_CORS_PERMISSIVE: "false"
+  EHRBASE_REST_ADMIN__ENABLED: "false"
+  EHRBASE_REST_TERMINOLOGY__ENABLED: "false"
+  EHRBASE_REST_EVENT_SUBSCRIPTION__ENABLED: "false"
+  EHRBASE_REST_FHIR__ENABLED: "false"
+
+  # ── Multi-tenancy (OFF by default) ──────────────────────────────────────────
+  EHRBASE_REST_TENANCY__ENABLED: "false"
+  EHRBASE_REST_TENANCY__CLAIM: "tenant"
+
+  # ── Authentication (Basic + OAuth2/OIDC; enabled by default) ────────────────
+  EHRBASE_REST_AUTH__ENABLED: "true"
+
+  # ── Authorization: coarse RBAC (on by default) + ABAC (off) ─────────────────
+  EHRBASE_AUTHZ_RBAC__ENABLED: "true"
+  EHRBASE_AUTHZ_RBAC__ADMIN_ROLE: "ADMIN"
+  EHRBASE_AUTHZ_RBAC__USER_ROLE: "USER"
+  EHRBASE_AUTHZ_RBAC__MANAGEMENT_ACCESS: "admin_only"
+  EHRBASE_AUTHZ_ABAC__ENABLED: "false"
+
+  # ── Management / observability surface ──────────────────────────────────────
+  EHRBASE_MANAGEMENT_ENABLED: "true"
+  EHRBASE_MANAGEMENT_BASE_PATH: "/management"
+  EHRBASE_MANAGEMENT_ACCESS_DEFAULT: "admin_only"
+  EHRBASE_MANAGEMENT_PROBES_ENABLED: "true"
+  EHRBASE_MANAGEMENT_ENDPOINTS_HEALTH: "off"
+  EHRBASE_MANAGEMENT_ENDPOINTS_INFO: "off"
+  EHRBASE_MANAGEMENT_ENDPOINTS_METRICS: "off"
+  EHRBASE_MANAGEMENT_ENDPOINTS_PROMETHEUS: "off"
+  EHRBASE_MANAGEMENT_ENDPOINTS_ENV: "off"
+  EHRBASE_MANAGEMENT_ENDPOINTS_LOGGERS: "off"
+
+  # ── Telemetry / logging ─────────────────────────────────────────────────────
+  EHRBASE_LOG_FORMAT: "json"
+  EHRBASE_OTEL_METRICS_PUSH: "false"
+
+  # ── Version signing (enabled/digest by default) ─────────────────────────────
+  EHRBASE_SIGNING_ENABLED: "true"
+  EHRBASE_SIGNING_MODE: "digest"
+  EHRBASE_SIGNING_VERIFY_ON_READ: "off"
+
+  # ── ATNA system log (OFF by default) ────────────────────────────────────────
+  EHRBASE_ATNA_ENABLED: "false"
+
+  # ── Contribution-outbox eventing → AMQP (OFF; PHI-free envelopes) ───────────
+  EHRBASE_EVENTS_ENABLED: "false"
+
+  # ── FHIR OUTBOUND emitter → AMQP (OFF; PHI-bearing stream) ──────────────────
+  EHRBASE_FHIR_OUTBOUND_ENABLED: "false"
+
+  # ── DV_MULTIMEDIA externalization → S3 (OFF; PHI blobs) ─────────────────────
+  EHRBASE_MULTIMEDIA_ENABLED: "false"
+
+  # ── External terminology validation (OFF by default) ────────────────────────
+  EHRBASE_VALIDATION_EXTERNAL_TERMINOLOGY_ENABLED: "false"
+  EHRBASE_VALIDATION_EXTERNAL_TERMINOLOGY_FAIL_ON_ERROR: "false"
+---
+# Source: ehrbase-rs/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: ehrbase-rs
+  labels:
+    helm.sh/chart: ehrbase-rs-0.1.0
+    app.kubernetes.io/name: ehrbase-rs
+    app.kubernetes.io/instance: ehrbase-rs
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: ehrbase-rs
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: ehrbase-rs
+    app.kubernetes.io/instance: ehrbase-rs
+---
+# Source: ehrbase-rs/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ehrbase-rs
+  labels:
+    helm.sh/chart: ehrbase-rs-0.1.0
+    app.kubernetes.io/name: ehrbase-rs
+    app.kubernetes.io/instance: ehrbase-rs
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: ehrbase-rs
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ehrbase-rs
+      app.kubernetes.io/instance: ehrbase-rs
+  template:
+    metadata:
+      annotations:
+        # Roll pods when the non-secret config changes.
+        checksum/config: 4c64ec93ba2343c74b44fd6f751cfd0cffbc71c6f11db93c9ca9232dcfe98cd9
+      labels:
+        app.kubernetes.io/name: ehrbase-rs
+        app.kubernetes.io/instance: ehrbase-rs
+    spec:
+      serviceAccountName: ehrbase-rs
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 65532
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: ehrbase
+          image: "ghcr.io/rubentalstra/ehrbase-rs:0.1.0"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          # The DSN comes from an existing Secret (preferred) or the chart Secret.
+          env:
+            - name: EHRBASE_DB_URL
+              valueFrom:
+                secretKeyRef:
+                  name: ehrbase-db
+                  key: EHRBASE_DB_URL
+          envFrom:
+            - configMapRef:
+                name: ehrbase-rs
+          livenessProbe:
+            httpGet:
+              path: /management/health/liveness
+              port: http
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /management/health/readiness
+              port: http
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+          startupProbe:
+            httpGet:
+              path: /management/health/liveness
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 30
+          resources:
+            limits:
+              cpu: "2"
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+          volumeMounts:
+            # readOnlyRootFilesystem=true → give the process a writable scratch dir.
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/deploy/helm/validate.sh
+++ b/deploy/helm/validate.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#
+# Validate the ehrbase-rs Helm chart (E5 task 3):
+#   1. helm lint      — default + all-features value sets (must be clean)
+#   2. helm template  — render both; assert the output is valid multi-doc YAML
+#   3. security gate   — assert the security fields ADR-013 requires are pinned
+#                        in the rendered Deployment (runAsNonRoot,
+#                        readOnlyRootFilesystem, seccompProfile RuntimeDefault,
+#                        drop ALL caps, allowPrivilegeEscalation:false)
+#   4. golden render   — compare against deploy/helm/golden/ (or --update it)
+#   5. kubeconform     — schema-validate the manifests IF kubeconform is on PATH
+#                        (optional; skipped with a note when absent/offline)
+#
+# Usage:
+#   deploy/helm/validate.sh            # validate (fails on lint/render/golden drift)
+#   deploy/helm/validate.sh --update   # regenerate the golden renders, then validate
+#
+# No cluster and no network are required for steps 1–4.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="${SCRIPT_DIR}/ehrbase-rs"
+CI_DIR="${SCRIPT_DIR}/ci"
+GOLDEN_DIR="${SCRIPT_DIR}/golden"
+RELEASE_NAME="ehrbase-rs"
+NAMESPACE="ehrbase"
+
+UPDATE=0
+[[ "${1:-}" == "--update" ]] && UPDATE=1
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+bold()  { printf '\033[1m%s\033[0m\n' "$*"; }
+
+command -v helm >/dev/null 2>&1 || { red "helm not found on PATH"; exit 1; }
+bold "helm: $(helm version --short)"
+
+# The value sets to validate: <label>:<values-file>
+declare -a CASES=(
+  "default:${CI_DIR}/default-values.yaml"
+  "all-features:${CI_DIR}/all-features-values.yaml"
+)
+
+# ── YAML validity check (PyYAML if present, else a helm re-parse) ─────────────
+yaml_ok() {
+  local file="$1"
+  if command -v python3 >/dev/null 2>&1 && python3 -c "import yaml" >/dev/null 2>&1; then
+    python3 - "$file" <<'PY'
+import sys, yaml
+docs = list(yaml.safe_load_all(open(sys.argv[1])))
+docs = [d for d in docs if d]
+assert docs, "no YAML documents rendered"
+for d in docs:
+    assert "kind" in d and "apiVersion" in d, f"doc missing kind/apiVersion: {d.get('metadata', {})}"
+print(f"  parsed {len(docs)} valid YAML document(s)")
+PY
+  else
+    echo "  (PyYAML absent — YAML validity implied by successful helm render)"
+  fi
+}
+
+# ── Security-field gate: every field ADR-013 mandates must be present ─────────
+assert_security() {
+  local file="$1"
+  local -a required=(
+    "runAsNonRoot: true"
+    "readOnlyRootFilesystem: true"
+    "allowPrivilegeEscalation: false"
+    "type: RuntimeDefault"
+    "- ALL"
+  )
+  local missing=0
+  for field in "${required[@]}"; do
+    if ! grep -qF -- "$field" "$file"; then
+      red "  MISSING required security field: '${field}'"
+      missing=1
+    fi
+  done
+  # The default-deny NetworkPolicy must be present (both cases enable it).
+  if ! grep -q "kind: NetworkPolicy" "$file"; then
+    red "  MISSING NetworkPolicy (default-deny ingress)"
+    missing=1
+  fi
+  [[ "$missing" -eq 0 ]] || { red "  security gate FAILED for ${file}"; exit 1; }
+  echo "  security fields pinned (runAsNonRoot, readOnlyRootFilesystem, seccomp RuntimeDefault, drop ALL, no priv-esc, NetworkPolicy)"
+}
+
+mkdir -p "$GOLDEN_DIR"
+FAIL=0
+
+for case in "${CASES[@]}"; do
+  label="${case%%:*}"
+  values="${case##*:}"
+  bold "── ${label} ───────────────────────────────────────────────"
+
+  echo "helm lint:"
+  helm lint "$CHART_DIR" -f "$values"
+
+  rendered="$(mktemp)"
+  helm template "$RELEASE_NAME" "$CHART_DIR" -n "$NAMESPACE" -f "$values" > "$rendered"
+
+  echo "YAML validity:"
+  yaml_ok "$rendered"
+
+  echo "security gate:"
+  assert_security "$rendered"
+
+  if command -v kubeconform >/dev/null 2>&1; then
+    echo "kubeconform:"
+    kubeconform -strict -summary -ignore-missing-schemas "$rendered" || FAIL=1
+  else
+    echo "kubeconform: not installed — skipping schema validation (optional)"
+  fi
+
+  golden="${GOLDEN_DIR}/${label}.yaml"
+  if [[ "$UPDATE" -eq 1 ]]; then
+    cp "$rendered" "$golden"
+    green "golden updated: ${golden}"
+  elif [[ -f "$golden" ]]; then
+    if diff -u "$golden" "$rendered" > /tmp/golden.diff 2>&1; then
+      green "golden matches: ${golden}"
+    else
+      red "golden DRIFT for ${label} — re-run with --update if intended:"
+      head -40 /tmp/golden.diff
+      FAIL=1
+    fi
+  else
+    red "golden missing: ${golden} — run: deploy/helm/validate.sh --update"
+    FAIL=1
+  fi
+  rm -f "$rendered"
+done
+
+echo
+if [[ "$FAIL" -eq 0 ]]; then
+  green "ALL CHECKS PASSED"
+else
+  red "VALIDATION FAILED"
+  exit 1
+fi

--- a/docs/enterprise/deployment.md
+++ b/docs/enterprise/deployment.md
@@ -1,0 +1,239 @@
+# Kubernetes deployment (Helm chart)
+
+The `deploy/helm/ehrbase-rs` chart deploys ehrbase-rs — a pure-Rust,
+openEHR-conformant CDR (ITS-REST 1.0.3 + AQL 1.1) — as a hardened, non-root,
+default-deny-ingress workload that connects to an **external** PostgreSQL 18.
+It encodes the ADR-013 database-role posture and the review-doc-02 operational
+guidance (pgaudit / TLS / PITR). This is a **deployment artifact only** — no
+Rust code participates.
+
+> Governing docs: `docs/ADRs/ADR-013-enterprise-schema-baseline.md` (roles),
+> `docs/design/schema-review/02-pg18-enterprise-practices.md` §3/§5/§6
+> (security, migration hygiene, backup/PITR), `docs/ADRs/ADR-008` (storage).
+
+## Chart layout
+
+```
+deploy/helm/
+├── ehrbase-rs/
+│   ├── Chart.yaml              # apiVersion v2, kubeVersion >=1.25
+│   ├── values.yaml             # every config surface, integrations OFF by default
+│   └── templates/
+│       ├── _helpers.tpl
+│       ├── configmap.yaml      # non-secret EHRBASE_* env
+│       ├── secret.yaml         # env secrets + mounted config files (gated)
+│       ├── deployment.yaml     # probes, security context, env wiring
+│       ├── service.yaml
+│       ├── serviceaccount.yaml
+│       ├── ingress.yaml        # optional
+│       ├── networkpolicy.yaml  # default-deny ingress
+│       ├── hpa.yaml            # optional (autoscaling/v2)
+│       ├── poddisruptionbudget.yaml  # policy/v1
+│       └── NOTES.txt
+├── ci/                          # value overlays for validation
+├── golden/                      # committed render snapshots
+└── validate.sh                  # helm lint + template + security gate + golden
+```
+
+Quick install (production shape — external DB DSN from an existing Secret):
+
+```bash
+kubectl -n ehrbase create secret generic ehrbase-db \
+  --from-literal=EHRBASE_DB_URL='postgres://ehrbase_app:***@pg-host:5432/ehrbase?sslmode=verify-full'
+
+helm install ehrbase-rs deploy/helm/ehrbase-rs -n ehrbase \
+  --set database.existingSecret=ehrbase-db \
+  --set image.tag=0.1.0
+```
+
+## Database role architecture — who runs migrations (ADR-013 §3)
+
+There is **no in-chart PostgreSQL**. A CDR stores PHI; its database must be an
+externally-managed, backed-up, PITR-capable PostgreSQL 18 (a managed service or
+an operator-run cluster), never a chart-side sidecar. The chart only carries the
+**connection string** (preferably from an existing Secret).
+
+ADR-013 §3 and review doc 02 §3.1 mandate a **four-role** model — never a
+superuser at runtime:
+
+| Role | Purpose | Used by |
+|---|---|---|
+| owner | owns the database | provisioning only |
+| `ehrbase_migrator` | runs DDL (the append-only migrations); owns the `ext` functions | migration step |
+| `ehrbase_app` | DML on `ehr.*` (INSERT/UPDATE/SELECT); `EXECUTE` on `ext` functions | **the running pod** |
+| `ehrbase_reader` | SELECT only | read replicas / reporting |
+
+The migrations create the roles idempotently, apply per-schema GRANTs +
+`ALTER DEFAULT PRIVILEGES` (so future tables stay reachable), and
+`REVOKE CREATE ON SCHEMA public FROM PUBLIC` (review doc 02 §3.2/§3.6).
+
+**The runtime pod connects as `ehrbase_app`** — the DSN in `database.existingSecret`
+should authenticate as that role, not the migrator or the owner.
+
+### Applying migrations
+
+The binary calls `run_migrations` on boot. You therefore choose one of:
+
+- **(a) Grant the runtime DSN the migrator role** (simplest; single-tenant /
+  small deployments). The app can then apply migrations itself at startup. Least
+  isolation.
+- **(b) Run migrations out-of-band** with a *migrator* DSN and start the app with
+  its lower-privileged `ehrbase_app` DSN (recommended for least-privilege prod).
+  The chart does not ship a migration Job; run migrations as a CI/CD step or a
+  one-shot `Job` with the migrator credential before rolling the Deployment:
+
+  ```bash
+  # one-shot migrator pod (image carries the binary + embedded migrations)
+  kubectl -n ehrbase run ehrbase-migrate --rm -it --restart=Never \
+    --image=ghcr.io/rubentalstra/ehrbase-rs:0.1.0 \
+    --env=EHRBASE_DB_URL="postgres://ehrbase_migrator:***@pg-host:5432/ehrbase?sslmode=verify-full" \
+    --command -- /usr/local/bin/ehrbase   # boots, migrates, then serve — or use your migrate entrypoint
+  ```
+
+  In flow (b), scale the Deployment to 0 or gate its rollout until the migrator
+  step succeeds so two versions never race the schema.
+
+`migrations.runByMigratorRole` in values is an informational marker surfaced in
+`helm install` NOTES; the chart never runs migrations itself.
+
+## PostgreSQL security posture (review doc 02 §3, §6 — deployment-layer)
+
+These are **database-side** and belong to whoever provisions PostgreSQL; the
+chart references them but cannot enforce them:
+
+- **TLS in transit (§3.6):** require `hostssl` on the PG server and set
+  `?sslmode=verify-full` in the DSN. `ext` functions are plain (not SECURITY
+  DEFINER); any definer function must pin `search_path`.
+- **pgaudit (§3.5):** run pgaudit as the DB-layer complement to the app-level
+  openEHR audit + the ATNA `system_log`. Recommended: `pgaudit.log = 'ddl, role,
+  connection'` globally plus object-level audit on the PHI tables only; ship the
+  audit log to an immutable store with ≈6-year retention.
+- **At-rest encryption (§3.4):** encrypt at the volume/disk layer (PG has no
+  native TDE). Do **not** pgcrypto-encrypt `node.data` — it would kill AQL
+  jsonpath + the zero-translation storage design.
+- **Backup / PITR (§6):** enable WAL archiving + PITR from day one (pgBackRest or
+  a managed PITR). `UNLOGGED` is forbidden on all clinical/audit tables. The
+  explicit btree `UNIQUE (vo_id, sys_version)` is the replica identity (§6.3).
+- **RLS (§3.3):** skipped in single-tenant Stage 1; `ehr_id` is placed
+  RLS-ready. Multi-tenancy (`tenancy.enabled`, ADR-015) adopts `FORCE ROW LEVEL
+  SECURITY` — see the integrations matrix below.
+
+## Pod security posture (chart-enforced, ADR-013)
+
+The chart pins, and `validate.sh` asserts, the following on every render:
+
+| Field | Value |
+|---|---|
+| `runAsNonRoot` | `true` (uid/gid 65532 — the distroless `nonroot` user) |
+| `readOnlyRootFilesystem` | `true` (a writable `emptyDir` is mounted at `/tmp`) |
+| `allowPrivilegeEscalation` | `false` |
+| `capabilities.drop` | `[ALL]` |
+| `seccompProfile.type` | `RuntimeDefault` (pod + container) |
+| ServiceAccount token | not mounted (the workload never calls the K8s API) |
+| NetworkPolicy | default-deny ingress; only the API (and management) port admitted |
+
+The image is `gcr.io/distroless/cc-debian12:nonroot` — shell-less, no package
+manager. Egress restriction is opt-in (`networkPolicy.egress.enabled`) because
+egress targets (DB, broker, terminology server) are deployment-specific; when
+enabled the chart always admits DNS and you add the DB/broker rules.
+
+## Probe and metric endpoints
+
+Probes use the management surface's public, unauthenticated, PHI-free health
+routes (`ehrbase-rest/src/management/health.rs`):
+
+| Probe | Route | HTTP status contract |
+|---|---|---|
+| liveness | `{management.basePath}/health/liveness` | 200 iff the process is up |
+| readiness | `{management.basePath}/health/readiness` | 200 (UP/DEGRADED) / 503 (DOWN): DB ping + migrations-applied + audit-sender + events, each 1s-bounded |
+| startup | liveness route | gates slow first boot |
+
+Because the bare binary ships the management surface **off**, the chart defaults
+`management.enabled=true` + `management.probesEnabled=true` (a deliberate
+deployment deviation — the probe routes carry no PHI). Set
+`management.port` to serve the surface on its **own** internal listener so
+`/management` is never exposed on the clinical API port. To use the binary's
+`ehrbase healthcheck` subcommand instead of HTTP probes (e.g. management off),
+set `probes.exec.enabled=true`.
+
+Metrics: set `metrics.enabled=true` to expose `{management.basePath}/prometheus`
+(access level `public`) and add the `prometheus.io/{scrape,port,path}` pod
+annotations. The port annotation follows the management listener (main port or
+the separate `management.port`). The JSON `/management/metrics`, `/info`,
+`/env`, and `/loggers` endpoints stay `admin_only`/off unless opted in.
+
+## Upgrade strategy
+
+- **Append-only migrations (ADR-013 §1, review doc 02 §5.1):** migrations are
+  never edited once applied; a new schema change is a new `000N` file. A rolling
+  Deployment upgrade must be compatible with the *previous* schema for the
+  window where both versions run — additive DDL first, destructive changes in a
+  later release after all pods are on the new version.
+- **Lock-safe DDL (review doc 02 §5.2/§5.3):** the migration runner wraps DDL in
+  a `lock_timeout` (≈5s) + bounded `statement_timeout` so a migration cannot
+  block live traffic indefinitely on a lock; on a busy table use `CREATE INDEX
+  CONCURRENTLY` and `NOT VALID` + later `VALIDATE`. Set these on the migrator
+  connection, e.g. append `?options=-c%20lock_timeout%3D5000` to the migrator
+  DSN, or `SET lock_timeout` at the session start of the out-of-band migrate step.
+- **Image pinning:** always deploy an immutable tag or, better, a `@sha256`
+  digest (`image.tag`); never `latest`. `imagePullPolicy: IfNotPresent` with a
+  pinned tag gives reproducible rollouts. Roll back by re-pinning the prior
+  tag/digest — the schema's backward compatibility (above) makes this safe.
+- **PDB + surge:** `podDisruptionBudget` (default `minAvailable: 1`) keeps a
+  replica serving during node drains; keep `replicaCount >= 2` (or autoscaling)
+  so upgrades and disruptions never fully interrupt the API.
+- **Graceful drain:** `terminationGracePeriodSeconds` (default 30) covers the
+  binary's 5s audit/outbox drain on shutdown.
+
+## Optional integrations matrix
+
+Every integration is **OFF by default**, matching the binary. Each is a separate
+switch; enabling one is an explicit, auditable deployment decision. Security
+notes call out the PHI-bearing ones.
+
+| Integration | Values key | Env prefix | Dependency | Security note |
+|---|---|---|---|---|
+| ADMIN API | `rest.adminEnabled` | `EHRBASE_REST_ADMIN__` | — | Physical/irreversible delete. Gate behind admin RBAC; off unless needed. |
+| Terminology ext API | `rest.terminologyEnabled` | `EHRBASE_REST_TERMINOLOGY__` | — | Extension surface (404 when off). |
+| Event-subscription API | `rest.eventSubscriptionEnabled` | `EHRBASE_REST_EVENT_SUBSCRIPTION__` | — | Admin CRUD over event filters. |
+| Multi-tenancy | `tenancy.enabled` | `EHRBASE_REST_TENANCY__` | RLS (Stage 2) | Tenant resolved from a JWT claim; leave `tenancy.header` unset in prod (a client header must not select a tenant). Pairs with PG `FORCE ROW LEVEL SECURITY`. |
+| OAuth2/OIDC auth | `auth.oidc.*` | `EHRBASE_REST_AUTH__OIDC__` | IdP (Keycloak) | Prefer JWKS/discovery over an HS256 secret. HS256 secret lands in the chart Secret. |
+| ABAC | `authz.abac.enabled` | `EHRBASE_AUTHZ_ABAC__` | Cedar/remote PDP | Policies via a mounted `config.files` TOML. |
+| **Eventing → AMQP** | `events.enabled` | `EHRBASE_EVENTS_` | RabbitMQ | Envelopes are **PHI-free by design** (ADR-014 §2). Broker URL carries creds → chart Secret; use `amqps://`/`tls=true`. |
+| **FHIR inbound/façade** | `rest.fhirEnabled` | `EHRBASE_REST_FHIR__` | — | Read façade + inbound mapping (ADR-016). |
+| **FHIR outbound → AMQP** | `fhirOutbound.enabled` | `EHRBASE_FHIR_OUTBOUND_` | RabbitMQ | ⚠ **Carries PHI** — the payload is the mapped FHIR *resource*. Publishes to a **separate exchange** (`ehrbase.fhir`) from the PHI-free event stream so broker ACLs can isolate it. Enable only with a TLS, access-controlled broker; an explicit, audited decision. |
+| **S3 multimedia** | `multimedia.enabled` | `EHRBASE_MULTIMEDIA_` | S3/MinIO/SeaweedFS | ⚠ Offloaded blobs are **PHI**. Bucket must be private + encrypted + HTTPS. `allowHttp` is dev-only (SeaweedFS). Prefer IRSA/Workload-Identity over static keys. |
+| External terminology | `externalTerminology.enabled` | `EHRBASE_VALIDATION_EXTERNAL_TERMINOLOGY_` | FHIR TS | Provider map via `config.files` TOML + `EHRBASE_VALIDATION_CONFIG` in `extraEnv`. |
+| ATNA system log | `atna.enabled` | `EHRBASE_ATNA_` | ARR (syslog) | Use `transport: tls` for PHI-adjacent audit; TLS PEMs via `config.files`. `failMode: closed` rejects auditable ops when auditing is undeliverable. |
+| Version signing | `signing.*` | `EHRBASE_SIGNING_` | — | On by default (`digest`). `pgp` mode fails **closed** at boot without a usable key; passphrase → chart Secret, key → `config.files`. |
+| OTLP telemetry | `telemetry.otel.*` | `EHRBASE_OTEL_` | collector | Unset endpoint ⇒ OTel layer not installed (zero overhead). |
+
+### The PHI-exchange warning (fhirOutbound)
+
+`events` (ADR-014) publishes **PHI-free** envelopes — safe to fan out broadly.
+`fhirOutbound` (ADR-016 §4a) publishes the **mapped clinical FHIR resource** —
+PHI. They are deliberately independent switches on **different exchanges**
+(`ehrbase.events` vs `ehrbase.fhir`) precisely so broker-level access control can
+restrict the PHI-bearing stream without touching the envelope stream. When
+enabling `fhirOutbound`: use a dedicated, TLS-only broker connection, lock down
+the `ehrbase.fhir` exchange bindings, and treat every consumer as a PHI
+processor.
+
+## Configuration surface reference
+
+The chart drives the binary entirely through `EHRBASE_*` environment variables
+(from the ConfigMap for non-secret keys, valueFrom-Secret for secret keys), plus
+optional mounted TOML/PEM files (`config.files` → `/etc/ehrbase/*`) for the
+values env can't carry cleanly (the Basic-auth user store, full OIDC/ABAC/
+terminology blocks, ATNA TLS PEMs, the PGP key). Every `values.yaml` key
+documents its exact env var. Secrets never enter the ConfigMap; the DB DSN
+should come from `database.existingSecret`.
+
+## Validation
+
+`deploy/helm/validate.sh` runs `helm lint` + `helm template` for the default and
+all-features value sets, asserts the rendered manifests are valid multi-document
+YAML, pins the security fields above, diffs against `deploy/helm/golden/`, and
+runs `kubeconform` when it is on PATH (skipped with a note otherwise). Regenerate
+the golden renders with `deploy/helm/validate.sh --update` after an intended
+template change and review `git diff deploy/helm/golden`.

--- a/docs/enterprise/product-roadmap.md
+++ b/docs/enterprise/product-roadmap.md
@@ -54,7 +54,7 @@ Legend: ✅ have (evidence) · 🔷 planned (spec-grounded design below) ·
 | Multi-tenancy (API + integrated) | ✓✓ | ✅ **fully integrated** (E2, ADR-015): tenant = logical system w/ own system_id, RLS FORCE, claim→SET LOCAL, admin CRUD; single-tenant default zero-overhead | engine-proven isolation tests |
 | Transaction compensation | ✓✓ | ✅ *semantics covered, different shape* | openEHR-native: CONTRIBUTION atomicity (all-or-nothing commits), indelible versioning + logical delete, admin physical delete; a dedicated "compensation API" is redundant in a version-controlled store — PORT NOTE stance |
 | AMQP integration bus | ✓ | ✅ lapin 4 publisher, confirms, at-least-once per-EHR order, off by default (E1) | RabbitMQ e2e incl. broker-down/no-loss |
-| Kubernetes configuration | ✓ | 🔷 Helm chart / manifests (deployment artifact) | cheap, high checkbox value; includes the roles/pgaudit/TLS posture from ADR-013 + review doc 02 |
+| Kubernetes configuration | ✓ | ✅ Helm chart (E5): hardened defaults (non-root, RO rootfs, seccomp, default-deny NetworkPolicy), every feature flag surfaced OFF, external-DSN-only, golden-render validation | deploy/helm/ehrbase-rs + docs/enterprise/deployment.md |
 
 ### Security
 

--- a/docs/plans/current-phase.md
+++ b/docs/plans/current-phase.md
@@ -6,9 +6,9 @@ spec-compliant openEHR CDR". This file is the live pointer under it; the
 consolidated gap surface is the blueprint §2 (proven foundations + ECC
 breakdown + spec-area map).
 
-## Active work — E4: S3 multimedia externalization
+## Active work — E5: Kubernetes deployment artifacts
 
-**Phase file: `docs/plans/e4-s3-multimedia.md`** (branch `claude/e4-s3-multimedia`).
+**Phase file: `docs/plans/e5-k8s.md`** (branch `claude/e5-k8s`).
 B2 closed 2026-07-10 (PR #37): ECC 293/319 zero-drift, ArchetypeValidation
 81→0. The single biggest gap: **81 failing ECC
 ArchetypeValidation cases (~76 % of all failures)** — template/archetype

--- a/docs/plans/e5-k8s.md
+++ b/docs/plans/e5-k8s.md
@@ -1,6 +1,6 @@
 # E5 — Kubernetes deployment artifacts
 
-- Status: in-progress
+- Status: done (2026-07-11)
 - Started: 2026-07-11   Owner: Ruben
 - Governing design: docs/enterprise/product-roadmap.md §3 E5 — a Helm chart
   encoding the ADR-013 security posture + review doc 02's ops guidance.
@@ -8,23 +8,36 @@
 
 ## Tasks
 
-- [ ] 1. Helm chart (deploy/helm/ehrbase-rs): Deployment (distroless image,
+- [x] 1. Helm chart (deploy/helm/ehrbase-rs): Deployment (distroless image,
       resources, probes wired to /management health), Service, ConfigMap/
       Secret-driven EHRBASE_* env (DB DSN, auth, tenancy/events/fhir/
       multimedia flags all off by default), optional dependencies toggles
       (postgres via external DSN only — never an in-chart PG for prod),
       RabbitMQ/SeaweedFS endpoints as values, NetworkPolicy, PodSecurity
       (runAsNonRoot, readOnlyRootFilesystem), HPA optional.
-- [ ] 2. Ops documentation (docs/enterprise/deployment.md): the DB role
+      — Done: apiVersion v2, every EHRBASE_* surface surfaced (all integrations
+      OFF matching the binary), external-DSN-only DB (existing-Secret ref),
+      default-deny NetworkPolicy, seccomp RuntimeDefault, HPA/PDB/Ingress
+      optional. lint clean; 9 resource kinds render.
+- [x] 2. Ops documentation (docs/enterprise/deployment.md): the DB role
       architecture (migrator vs app_writer per ADR-013 — who runs
       migrations), pgaudit/TLS/PITR posture pointers (review doc 02),
       probe/metric endpoints, upgrade strategy (append-only migrations,
       lock_timeout wrapper guidance).
-- [ ] 3. Chart validation: helm lint + helm template golden render in CI
+      — Done: four-role model + both migration flows, review-doc-02 §3/§6
+      pointers, probe/metric table, upgrade strategy, integrations matrix with
+      the PHI-exchange warning (fhirOutbound).
+- [x] 3. Chart validation: helm lint + helm template golden render in CI
       (a script or test asserting the rendered manifests parse and pin the
       security fields); kubeconform if available offline.
+      — Done: deploy/helm/validate.sh (lint + template + PyYAML validity +
+      security-field gate + golden diff + optional kubeconform); golden renders
+      committed under deploy/helm/golden/ (+ regen README). Passes on helm
+      v4.1.3 (schema v2 forward-compatible with latest v4.2.3).
 
 ## Exit criteria
 
-- [ ] helm lint clean + golden render committed; deployment doc complete;
+- [x] helm lint clean + golden render committed; deployment doc complete;
       scorecard flipped. (No Rust changes — suites/ECC unaffected.)
+      — helm lint clean (both value sets), golden committed, deployment doc
+      complete. Scorecard flip + commit left to the orchestrator.

--- a/docs/plans/e5-k8s.md
+++ b/docs/plans/e5-k8s.md
@@ -1,0 +1,30 @@
+# E5 — Kubernetes deployment artifacts
+
+- Status: in-progress
+- Started: 2026-07-11   Owner: Ruben
+- Governing design: docs/enterprise/product-roadmap.md §3 E5 — a Helm chart
+  encoding the ADR-013 security posture + review doc 02's ops guidance.
+  Deployment artifacts only; zero Rust changes (ECC gate trivially holds).
+
+## Tasks
+
+- [ ] 1. Helm chart (deploy/helm/ehrbase-rs): Deployment (distroless image,
+      resources, probes wired to /management health), Service, ConfigMap/
+      Secret-driven EHRBASE_* env (DB DSN, auth, tenancy/events/fhir/
+      multimedia flags all off by default), optional dependencies toggles
+      (postgres via external DSN only — never an in-chart PG for prod),
+      RabbitMQ/SeaweedFS endpoints as values, NetworkPolicy, PodSecurity
+      (runAsNonRoot, readOnlyRootFilesystem), HPA optional.
+- [ ] 2. Ops documentation (docs/enterprise/deployment.md): the DB role
+      architecture (migrator vs app_writer per ADR-013 — who runs
+      migrations), pgaudit/TLS/PITR posture pointers (review doc 02),
+      probe/metric endpoints, upgrade strategy (append-only migrations,
+      lock_timeout wrapper guidance).
+- [ ] 3. Chart validation: helm lint + helm template golden render in CI
+      (a script or test asserting the rendered manifests parse and pin the
+      security fields); kubeconform if available offline.
+
+## Exit criteria
+
+- [ ] helm lint clean + golden render committed; deployment doc complete;
+      scorecard flipped. (No Rust changes — suites/ECC unaffected.)


### PR DESCRIPTION
Enterprise stage E5 (roadmap §3), final step. Security-hardened Helm chart (non-root, RO rootfs, seccomp RuntimeDefault, drop-ALL, default-deny NetworkPolicy, external-DSN-only), every EHRBASE_* config surface enumerated and OFF by default, management-endpoint probes, optional HPA/PDB/Ingress; golden-render validation (helm lint 0 failed, security fields asserted on both value sets); docs/enterprise/deployment.md carries the ADR-013 role architecture and the pgaudit/TLS/PITR posture. Zero Rust changes — suites/ECC unaffected.