### PR TITLE
ci: fix asset-less releases — binary matrix chained in the same run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,32 +4,53 @@
 #   1. A `vX.Y.Z` tag push publishes a GitHub Release whose notes are the
 #      matching `## [X.Y.Z]` section — the job FAILS if CHANGELOG.md has no
 #      such section, so a release can never ship without its changelog.
-#   2. Publishing the release triggers the binary build matrix, which
-#      attaches per-arch server tarballs.
-# (Replaced the never-firing release-please job — it triggered on pushes to
-# a `main` branch that does not exist, and its conventional-commit changelog
-# conflicted with the hand-curated Keep a Changelog discipline.)
+#   2. The binary matrix runs in the SAME workflow run (needs:
+#      publish-release) and attaches per-arch server tarballs. It must NOT
+#      hang off a `release: published` trigger: releases published with
+#      GITHUB_TOKEN deliberately do not fire workflow events (GitHub's
+#      anti-recursion rule), which is exactly the bug that left v3.0.0
+#      asset-less on first cut.
+#   3. `workflow_dispatch` with a tag input re-runs the pipeline for an
+#      existing tag (e.g. to backfill assets).
 name: Release
 
 on:
   push:
     tags: ["v*"]
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing vX.Y.Z tag to (re)publish and build assets for"
+        required: true
+        type: string
 
 permissions:
   contents: write
 
 jobs:
   publish-release:
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
     steps:
+      - id: tag
+        name: Resolve the release tag
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            tag="${{ inputs.tag }}"
+          else
+            tag="${GITHUB_REF_NAME}"
+          fi
+          case "$tag" in v*) ;; *) echo "::error::'$tag' is not a vX.Y.Z tag" >&2; exit 1;; esac
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
       - name: Extract the changelog section for this tag
         run: |
           set -euo pipefail
-          version="${GITHUB_REF_NAME#v}"
+          version="${TAG#v}"
           if ! grep -q "^## \[$version\]" CHANGELOG.md; then
             echo "::error::CHANGELOG.md has no section for $version — releases are changelog-driven (Keep a Changelog). Add '## [$version] - YYYY-MM-DD' first." >&2
             exit 1
@@ -45,30 +66,34 @@ jobs:
             exit 1
           fi
           echo "Release notes for $version:"; cat release-notes.md
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
       - name: Verify the tag matches the workspace version
         run: |
           set -euo pipefail
-          version="${GITHUB_REF_NAME#v}"
+          version="${TAG#v}"
           manifest=$(grep -m1 '^version = ' Cargo.toml | cut -d'"' -f2)
           if [ "$manifest" != "$version" ]; then
-            echo "::error::Tag $GITHUB_REF_NAME does not match workspace version $manifest in Cargo.toml." >&2
+            echo "::error::Tag $TAG does not match workspace version $manifest in Cargo.toml." >&2
             exit 1
           fi
-      - name: Publish the GitHub release
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+      - name: Publish (or update) the GitHub release
         uses: softprops/action-gh-release@v3
         with:
-          name: ${{ github.ref_name }}
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: ${{ steps.tag.outputs.tag }}
           body_path: release-notes.md
           # Every release is a pre-release until the first production
           # sign-off (owner decision 2026-07-11); flip to
-          # `contains(github.ref_name, '-')` at that point.
+          # `contains(<tag>, '-')` at that point.
           prerelease: true
 
-  # Build the server binary and attach it when a GitHub Release is published.
   # Native runner per arch (no cross toolchain, no QEMU) — same strategy as
   # .github/workflows/containers.yml, which handles the GHCR images on tags.
   build-binaries:
-    if: github.event_name == 'release'
+    needs: publish-release
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -80,13 +105,15 @@ jobs:
             target: aarch64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.publish-release.outputs.tag }}
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Build server
         run: cargo build --release --locked -p ehrbase
       - name: Package
         shell: bash
         env:
-          TAG: ${{ github.event.release.tag_name }}
+          TAG: ${{ needs.publish-release.outputs.tag }}
         run: |
           out="ehrbase-${TAG}-${{ matrix.target }}.tar.gz"
           strip target/release/ehrbase
@@ -95,4 +122,5 @@ jobs:
       - name: Upload to release
         uses: softprops/action-gh-release@v3
         with:
+          tag_name: ${{ needs.publish-release.outputs.tag }}
           files: ${{ env.ASSET }}


### PR DESCRIPTION
Releases published with GITHUB_TOKEN don't emit `release: published` events (GitHub's anti-recursion rule), so the v3.0.0 asset build never triggered. The binary matrix now runs via `needs: publish-release` inside the same tag-push run, checking out the tag explicitly; a `workflow_dispatch` tag input re-runs the pipeline for an existing tag to backfill assets. CI-only change (`no-changelog`).