### PR TITLE
w1: drop the accidentally-committed _check symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ lcov.info
 /website/book/book
 /docs-dist
 /.latest-src
+_check/

--- a/_check/ehrbase-rs
+++ b/_check/ehrbase-rs
@@ -1,1 +1,0 @@
-/Users/rubentalstra/RustroverProjects/ehrbase-rs/_site


### PR DESCRIPTION
The local link-check staging symlink slipped into PR #57 via git add -A; removed and `_check/` gitignored.