### PR TITLE
chore: linguist attributes for honest language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,3 +21,26 @@
 # Generated code: collapse in diffs/linguist (still reviewed via the emitter)
 crates/*/src/**/generated/** linguist-generated=true
 crates/openehr-rm/src/model/data.rs linguist-generated=true
+
+# ── Linguist: honest language stats ──────────────────────────────────────────
+# Generated spec crates (ADR-004: emitted from the vendored BMM — the
+# hand-written *_impl.rs siblings are re-included below)
+crates/openehr-base/src/** linguist-generated=true
+crates/openehr-rm/src/**   linguist-generated=true
+crates/openehr-am/src/**   linguist-generated=true
+crates/openehr-base/src/**/*_impl.rs linguist-generated=false
+crates/openehr-rm/src/**/*_impl.rs   linguist-generated=false
+crates/openehr-am/src/**/*_impl.rs   linguist-generated=false
+
+# Vendored third-party / spec inputs (never authored here)
+crates/openehr-codegen/vendor/** linguist-vendored
+crates/openehr-its/schemas/**    linguist-vendored
+crates/openehr-its/vendor/**     linguist-vendored
+website/api/vendor/**            linguist-vendored
+website/book/theme/mermaid.min.js linguist-vendored
+website/book/theme/mermaid-init.js linguist-vendored
+
+# Byte-copied / machine-produced artifacts
+website/api/spec/**    linguist-generated=true
+deploy/helm/golden/**  linguist-generated=true
+docs/conformance/**    linguist-generated=true


### PR DESCRIPTION
Marks the BMM-generated spec crates (hand-written `*_impl.rs` re-included), vendored inputs (BMM/XSD/OAS bundles, Swagger UI dist, mermaid assets), and machine-produced artifacts (served OAS copies, Helm golden renders, conformance reports) as `linguist-generated`/`linguist-vendored`, so the repository language bar reflects the hand-written code.