### PR TITLE
w1: API reference polish — real spec version numbers, no filler bar

### DIFF
--- a/docs/plans/w1-docs-website.md
+++ b/docs/plans/w1-docs-website.md
@@ -517,7 +517,7 @@ copied.
 ### 5a. OAS drift gate — `scripts/assemble-oas.sh`
 
 Mirrors `scripts/check-codegen-drift.sh` (regenerate → `git diff --exit-code`).
-The served specs are a **byte copy** of the vendored `-html` bundles (which the
+The served specs are a **deterministic copy** of the vendored `-html` bundles (with the pinned ITS-REST release stamped over upstream's `info.version: latest` so Swagger UI shows a real version; Admin keeps its honest `development`) (which the
 codegen-drift gate already ties to upstream), so drift is caught at two hops:
 upstream → vendor (existing gate) → `website/api/spec/` (this gate).
 
@@ -655,7 +655,7 @@ trigger for release, containers, and docs alike.
 - **Endpoint viewer:** **Swagger UI** 5.32.8 (chosen) over Redoc 2.5.3 (single-spec)
   and Scalar (no clean pin / Node dist) — native multi-spec `urls` dropdown, fully
   offline, cleanly pinnable, matches the in-app `/ehrbase/swagger-ui`.
-- **Served OAS:** the 7 `-html` documentation bundles, byte-copied + drift-gated.
+- **Served OAS:** the 7 `-html` documentation bundles, copied + ITS-REST-version-stamped + drift-gated.
 - **SEO:** sitemap/robots emitted in assembly (mdbook-sitemap skipped — cross-section
   scope); canonical = `/docs/latest/`; `dev`/old versions disallowed.
 - **Version picker:** `additional-js` (not an `index.hbs` fork) — survives mdBook

--- a/scripts/assemble-oas.sh
+++ b/scripts/assemble-oas.sh
@@ -15,8 +15,13 @@ SRC="crates/openehr-its/vendor/rest-oas"
 DST="website/api/spec"
 OAS_GROUPS="ehr definition query demographic admin system overview"
 mkdir -p "$DST"
+# The upstream bundles carry `info.version: latest`; the served copy stamps the
+# pinned ITS-REST release (docs/VERSIONS.md) so Swagger UI shows a real version.
+# The Admin API is dev-branch-only upstream — its honest `development` stays.
+ITS_REST_VERSION="1.0.3"
 for group in $OAS_GROUPS; do
-  cp "$SRC/${group}-html.openapi.yaml" "$DST/${group}.openapi.yaml"
+  sed -e "1,10s/^  version: latest\$/  version: ${ITS_REST_VERSION}/" \
+    "$SRC/${group}-html.openapi.yaml" > "$DST/${group}.openapi.yaml"
 done
 if [[ "${1:-}" == "--check" ]]; then
   if ! git diff --quiet -- "$DST"; then

--- a/website/api/index.html
+++ b/website/api/index.html
@@ -12,7 +12,7 @@
     /* Brand chrome (design tokens per docs/plans/w1-docs-website.md §3a).
        Only the header bar is theme-aware; Swagger UI itself is light-only, so
        its container is pinned to a light surface and stays readable in dark OS
-       themes (noted in the sub-bar). */
+       themes. */
     :root {
       --rs-rust: #b7410e; --rs-rust-600: #9a360b; --rs-umber: #5a2408;
       --rs-bg: #ffffff; --rs-text: #1b1613; --rs-muted: #6b605a; --rs-border: #e7ddd6;
@@ -37,16 +37,11 @@
     .rs-header nav { margin-left: auto; display: flex; gap: 1.25rem; font-weight: 600; font-size: 0.95rem; }
     .rs-header nav a { color: var(--rs-muted); text-decoration: none; }
     .rs-header nav a:hover { color: var(--rs-rust); }
-    .rs-subbar {
-      padding: 0.5rem 1.25rem; font-size: 0.85rem; color: var(--rs-muted);
-      background: var(--rs-bg); border-bottom: 1px solid var(--rs-border);
-    }
     /* Keep Swagger UI on a light surface regardless of OS theme (it is light-only). */
     #swagger-ui { background: #ffffff; color-scheme: light; }
     /* Fold Swagger's own top bar branding into our palette. */
     .swagger-ui .topbar { background: #1e1815; }
     .swagger-ui .topbar .download-url-wrapper .select-label span { color: #f3ece8; }
-    .swagger-ui .info .title small.version-stamp { display: none; }
   </style>
 </head>
 <body>
@@ -62,11 +57,6 @@
       <a href="https://github.com/rubentalstra/ehrbase-rs" rel="noopener">GitHub ↗</a>
     </nav>
   </header>
-
-  <div class="rs-subbar">
-    openEHR ITS-REST 1.0.3 API, grouped by resource — pick a group from the
-    selector on the right. Rendered offline; Swagger UI uses a light theme.
-  </div>
 
   <div id="swagger-ui"></div>
 

--- a/website/api/spec/definition.openapi.yaml
+++ b/website/api/spec/definition.openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Definition API
-  version: latest
+  version: 1.0.3
   x-status: STABLE
   x-spec: definition
   contact:

--- a/website/api/spec/ehr.openapi.yaml
+++ b/website/api/spec/ehr.openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: EHR API
-  version: latest
+  version: 1.0.3
   x-status: STABLE
   x-spec: ehr
   contact:

--- a/website/api/spec/overview.openapi.yaml
+++ b/website/api/spec/overview.openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Overview
-  version: latest
+  version: 1.0.3
   x-status: STABLE
   x-spec: overview
   contact:

--- a/website/api/spec/query.openapi.yaml
+++ b/website/api/spec/query.openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Query API
-  version: latest
+  version: 1.0.3
   x-status: STABLE
   x-spec: query
   contact:

--- a/website/api/spec/system.openapi.yaml
+++ b/website/api/spec/system.openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: System API
-  version: latest
+  version: 1.0.3
   x-status: STABLE
   x-spec: system
   contact:


### PR DESCRIPTION
Owner feedback: (1) the explainer sub-bar added nothing — removed; (2) the API version showed 'latest' — that's upstream openEHR's literal `info.version`; the assembly script now stamps the pinned **ITS-REST 1.0.3** on the stable groups (Admin keeps its factual `development` — dev-branch-only upstream), and the previously-hidden Swagger version badge is shown again. Drift gate updated deterministically; phase-file wording aligned.