### PR TITLE
w1: phase close — documentation website live and recorded

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -103,12 +103,21 @@ Spec-grounded enterprise features from the B8 roadmap; each closed with ECC
 | E4 | S3 multimedia — DV_MULTIMEDIA externalization, verified re-inline, GC, blob dump/load (ADR-017) | 2026-07-11 | #47 |
 | E5 | Kubernetes deployment artifacts — hardened Helm chart, ops doc, golden-render validation | 2026-07-11 | #48 |
 
+## Post-arc phases
+
+| Phase | What | Closed | PR(s) |
+|---|---|---|---|
+| — | Release reset: v3.0.0 (product SemVer; spec crates carry spec versions), Keep-a-Changelog + guard, changelog-driven release workflow, inherited fork tags/branches removed | 2026-07-11 | #53, #55 |
+| — | Docs cleanup: 45 historical files pruned, references repointed | 2026-07-11 | #51 |
+| W1 | Public documentation website — mdBook on Pages: landing, versioned book (dev · latest · v3.0.0 via the `docs-dist` archive), offline OpenAPI reference (7 API groups), link + OAS-drift gates (both negative-tested), same-PR docs discipline | 2026-07-11 | #52, #54, #56, #57, #60, #62, #63 |
+
 ## Remaining
 
+- **X1 comparison** — honest EHRbase (Java) vs EHRbase-rs comparison page:
+  ECC run against upstream, benchmark overhaul, measured numbers only
+  (plan drafted, awaiting owner review — `docs/plans/x1-comparison.md`).
 - **P20 optimization** — PG18 AIO tuning, hot-read pipelining, `JSON_TABLE` codegen.
-- **P99 cutover** — final docs pass, tag the first release.
-- **Documentation-website initiative** — the current active effort (see
-  `docs/plans/current-phase.md`).
+- **P99 cutover** — final docs pass; the release machinery is already in place (v3.0.0 shipped as pre-release).
 
 **Stage 2** capabilities (RBAC/attribute authz via the `ehrbase-rest::access`
 module, multi-tenancy, plugin system) largely landed early through the E-arc;

--- a/docs/plans/current-phase.md
+++ b/docs/plans/current-phase.md
@@ -6,19 +6,22 @@ spec-compliant openEHR CDR". This file is the live pointer under it; the
 consolidated gap surface is the blueprint §2 (proven foundations + ECC
 breakdown + spec-area map).
 
-## Active work — W1: public documentation website
+## Active work — X1 comparison (plan review) → P20/P99
 
-**Phase file: `docs/plans/w1-docs-website.md`** (branch `claude/w1-docs-website`).
-mdBook (Rust-only toolchain, owner ruling 2026-07-11) on GitHub Pages: landing
-page + release-versioned book + static OpenAPI endpoint reference generated
-from the vendored ITS-REST contract, with drift gated in CI.
+**W1 (public documentation website) closed 2026-07-11** — the site is live at
+<https://rubentalstra.github.io/ehrbase-rs/> (landing + versioned book
+dev · latest · v3.0.0 + offline OpenAPI reference), drift-gated in CI
+(`docs/plans/w1-docs-website.md` for the full record).
 
-Context: the blueprint build arc (B1–B8) and the enterprise capabilities
-(E1–E5) are **closed** (E5 2026-07-11, PR #48). Full conformance holds:
-**ECC 341 executed · 315 passed · 0 failed — CORE PASS / STANDARD PASS**. The
-docs cleanup landed 2026-07-11 (PR #51 — 45 historical files pruned; everything
-flows through the blueprint + ADRs + `docs/architecture.md`). Per-phase record:
-`docs/PROGRESS.md`.
+Next up, in order:
+
+1. **X1 — the honest EHRbase vs EHRbase-rs comparison**
+   (`docs/plans/x1-comparison.md`, plan awaiting owner review): run upstream
+   EHRbase through the ECC suite (with a fairness adjudication register),
+   overhaul `tools/benchmark` (multi-SUT, percentiles, resource footprint),
+   publish a measured comparison page on the docs site. Owner rule: **no
+   false claims — measured numbers only.**
+2. **P20 — optimization**, **P99 — cutover** per the blueprint tail.
 
 ## Priority order (from the blueprint build order, §3)
 

--- a/docs/plans/w1-docs-website.md
+++ b/docs/plans/w1-docs-website.md
@@ -1,6 +1,6 @@
 # Phase W1 — Public documentation website (mdBook on GitHub Pages)
 
-- Status: in-progress
+- Status: done (2026-07-11)
 - Started: 2026-07-11   Owner: Ruben
 - Consumes: this specification (every version + capability below **live-verified
   2026-07-11** from crates.io / `gh release list` / official docs — see §7
@@ -633,12 +633,12 @@ trigger for release, containers, and docs alike.
 
 ## Exit criteria
 
-- [ ] Site live: landing + `/docs/dev/` + `/api/` endpoint reference, all under `/ehrbase-rs/`, dark/light correct.
-- [ ] CI gates green in steady state and **red on injected breakage** (link check + OAS drift), negative-tested once then reverted (W1.7).
-- [ ] Version cut proven by the dry run (W1.4); `latest` deep-linkable; frozen versions persist without rebuild.
-- [ ] `/api/` fully offline — zero runtime CDN/network requests (verified in the browser Network panel).
-- [ ] Docs discipline installed: CLAUDE.md rule + `.claude/rules/docs-website.md` + `/phase-done` item.
-- [ ] README points at the site; CHANGELOG `[Unreleased]` notes the docs site.
+- [x] Site live: landing + `/docs/dev/` + `/api/` endpoint reference, all under `/ehrbase-rs/`, dark/light correct. *(all URLs probed 200, 2026-07-11)*
+- [x] CI gates green in steady state and **red on injected breakage** (link check + OAS drift), negative-tested once then reverted (W1.7). *(link gate bit in production on the first deploy; OAS gate bit on a committed hand-edit)*
+- [x] Version cut proven (W1.4 — with the real v3.0.0, not a dry-run tag); `latest` deep-linkable (`/docs/latest/querying-aql.html` 200); frozen `/docs/v3.0.0/` materialized from docs-dist without rebuild.
+- [x] `/api/` fully offline — zero runtime CDN/network requests. *(verified by static audit of the built HTML — zero external script/css/img/font refs; the only externals are the canonical meta and a GitHub `<a>` nav link — plus local-server curl of every referenced asset; browser Network panel unavailable in this environment)*
+- [x] Docs discipline installed: CLAUDE.md rule + `.claude/rules/docs-website.md` + `/phase-done` step 3b.
+- [x] README points at the site; CHANGELOG `[Unreleased]` notes the docs site.
 
 ## Decisions made this phase
 
@@ -669,11 +669,13 @@ trigger for release, containers, and docs alike.
 
 ## Handoff for next session
 
-Spec fully worked out and live-verified (2026-07-11). Nothing FAILED verification;
-the two "would-be" plugins (admonish, alerts) are cleanly superseded by mdBook
-0.5's native admonitions, which is a *better* outcome than a plugin. Next action:
-**W1.1** — scaffold `website/` and the `docs.yml` build+deploy job. Toolchain pins
-live in `docs.yml` env (§2f); do not drift them from §1 without re-verifying.
+Closed 2026-07-11. The site is live at https://rubentalstra.github.io/ehrbase-rs/
+— landing, versioned book (dev · latest · v3.0.0), and the offline OpenAPI
+reference — with the drift discipline installed (same-PR docs rule, OAS byte-copy
+gate, lychee link gate, both negative-tested). Frozen versions live on the
+`docs-dist` orphan branch; every future `v*` tag cuts one automatically. Next:
+the X1 comparison phase (plan drafted, awaiting owner review) and the blueprint
+tail (P20 optimization, P99 cutover).
 
 ---
 


### PR DESCRIPTION
Closes W1: all exit criteria verified and ticked (site live with all six URLs probed 200, both anti-drift gates negative-tested, versioning proven with the real v3.0.0 cut, /api/ offline-audited, discipline installed, README+CHANGELOG linked). PROGRESS.md gains the post-arc table (release reset, docs cleanup, W1); current-phase.md advances to X1 (comparison plan, awaiting owner review) → P20/P99.