### PR TITLE
x1: ECC upstream-SUT mode + adjudication register (X1.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1268,6 +1268,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
+ "toml 1.1.2+spec-1.1.0",
  "uuid",
  "wiremock",
 ]
@@ -2247,7 +2248,7 @@ dependencies = [
  "pear",
  "serde",
  "tempfile",
- "toml",
+ "toml 0.8.23",
  "uncased",
  "version_check",
 ]
@@ -6040,6 +6041,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6943,9 +6953,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -6974,7 +6999,7 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.14.0",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.15",
@@ -7006,6 +7031,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,6 +173,7 @@ thiserror = "2"                    # v2 current
 anyhow = "1"                       # binaries only
 config = "0.15.25"                   # or figment
 figment = { version = "0.10", features = ["toml", "env"] }
+toml = "1"                         # standalone TOML parser (ECC upstream adjudication register, X1)
 dotenvy = "0.15"
 clap = { version = "4", features = ["derive", "env"] }
 parking_lot = "0.12"

--- a/docs/conformance/CONFORMANCE_CERTIFICATE.md
+++ b/docs/conformance/CONFORMANCE_CERTIFICATE.md
@@ -9,11 +9,11 @@
 
 | | |
 |---|---|
-| Solution | ehrbase-rs @ `http://localhost:8080/ehrbase/rest/openehr/v1` |
+| Solution | ehrbase-rs 3.0.0 @ `http://localhost:8080/ehrbase/rest/openehr/v1` |
 | Vendor | ehrbase-rs (self-assessed) |
 | Assessor | ehrbase-rs Conformance Catalogue (ECC) — self-assessment |
 | Infrastructure | reference corpus openEHR/specifications-CNF@33251d2a; SUT auth mode basic |
-| Date | 2026-07-11T06:26:52.947058Z |
+| Date | 2026-07-11T10:45:03.644171Z |
 
 ## Scope of Test
 

--- a/docs/conformance/CONFORMANCE_REPORT.md
+++ b/docs/conformance/CONFORMANCE_REPORT.md
@@ -5,36 +5,41 @@
 
 ## 1. SUT identity
 
+- Product: ehrbase-rs 3.0.0
 - SUT: `http://localhost:8080/ehrbase/rest/openehr/v1`
 - Spec versions: RM 1.2.0 · ITS-REST development@e8a093e · AQL 1.1.0 · TERM 3.1.0
 - Auth mode: basic
-- Started: 2026-07-11T06:26:52.947058Z
+- Started: 2026-07-11T10:45:03.644171Z
 
-**341 case×format executions · 315 passed · 0 failed.**
+**341 case×format executions · 315 passed · 0 failed · 0 not applicable.**
 
 ### Per-area matrix
 
-| Area | Catalogue (active) | Passed | Failed | Errored | Skipped |
-|---|--:|--:|--:|--:|--:|
-| EHR — EHR service | 13 | 13 | 0 | 0 | 0 |
-| STA — EHR_STATUS | 10 | 10 | 0 | 0 | 0 |
-| COM — COMPOSITION | 31 | 38 | 0 | 0 | 0 |
-| CTB — CONTRIBUTION (change sets) | 31 | 26 | 0 | 0 | 5 |
-| DIR — DIRECTORY (FOLDER) | 37 | 37 | 0 | 0 | 0 |
-| TPL — Template / OPT provisioning | 16 | 12 | 0 | 0 | 4 |
-| SQR — Stored-query provisioning | 7 | 5 | 0 | 0 | 2 |
-| QRY — AQL execution | 13 | 13 | 0 | 0 | 0 |
-| VAL — Content / archetype validation | 119 | 119 | 0 | 0 | 0 |
-| DEM — Demographic service | 24 | 24 | 0 | 0 | 0 |
-| ADM — Admin service | 6 | 6 | 0 | 0 | 0 |
-| SEC — Security / authorization | 2 | 2 | 0 | 0 | 0 |
-| SIG — Version signing | 5 | 5 | 0 | 0 | 1 |
-| MSG — Messaging | 10 | 0 | 0 | 0 | 10 |
-| TS — Terminology-server integration | 9 | 5 | 0 | 0 | 4 |
+| Area | Catalogue (active) | Passed | Failed | Errored | Skipped | N/A |
+|---|--:|--:|--:|--:|--:|--:|
+| EHR — EHR service | 13 | 13 | 0 | 0 | 0 | 0 |
+| STA — EHR_STATUS | 10 | 10 | 0 | 0 | 0 | 0 |
+| COM — COMPOSITION | 31 | 38 | 0 | 0 | 0 | 0 |
+| CTB — CONTRIBUTION (change sets) | 31 | 26 | 0 | 0 | 5 | 0 |
+| DIR — DIRECTORY (FOLDER) | 37 | 37 | 0 | 0 | 0 | 0 |
+| TPL — Template / OPT provisioning | 16 | 12 | 0 | 0 | 4 | 0 |
+| SQR — Stored-query provisioning | 7 | 5 | 0 | 0 | 2 | 0 |
+| QRY — AQL execution | 13 | 13 | 0 | 0 | 0 | 0 |
+| VAL — Content / archetype validation | 119 | 119 | 0 | 0 | 0 | 0 |
+| DEM — Demographic service | 24 | 24 | 0 | 0 | 0 | 0 |
+| ADM — Admin service | 6 | 6 | 0 | 0 | 0 | 0 |
+| SEC — Security / authorization | 2 | 2 | 0 | 0 | 0 | 0 |
+| SIG — Version signing | 5 | 5 | 0 | 0 | 1 | 0 |
+| MSG — Messaging | 10 | 0 | 0 | 0 | 10 | 0 |
+| TS — Terminology-server integration | 9 | 5 | 0 | 0 | 4 | 0 |
 
 ### Failures
 
 _No failures in this run._
+
+### Not applicable to this SUT (extensions / RM-version-sensitive)
+
+_None — every catalogued case applies to this SUT._
 
 ## 2. Scope of test
 
@@ -46,6 +51,7 @@ _No failures in this run._
 | Executed | 341 |
 | Passed | 315 |
 | Failed | 0 |
+| Not applicable | 0 |
 
 ## 3. Detailed test report
 
@@ -399,52 +405,52 @@ CORE/STANDARD are all-or-nothing (every capability must pass); OPTIONS is any-pa
 
 ### Core — **PASS**
 
-| Capability | Passed | Failed | Errored | Skipped | Verdict |
-|---|--:|--:|--:|--:|---|
-| Adl14ArchetypeProvisioning | 1 | 0 | 0 | 0 | pass |
-| Adl14OptProvisioning | 11 | 0 | 0 | 4 | pass |
-| EhrOperations | 12 | 0 | 0 | 0 | pass |
-| EhrStatus | 10 | 0 | 0 | 0 | pass |
-| CompositionOps | 34 | 0 | 0 | 0 | pass |
-| ChangeSets | 26 | 0 | 0 | 5 | pass |
-| Versioning | 7 | 0 | 0 | 0 | pass |
-| ArchetypeValidation | 119 | 0 | 0 | 0 | pass |
-| AnonymousEhrs | 1 | 0 | 0 | 0 | pass |
+| Capability | Passed | Failed | Errored | Skipped | N/A | Verdict |
+|---|--:|--:|--:|--:|--:|---|
+| Adl14ArchetypeProvisioning | 1 | 0 | 0 | 0 | 0 | pass |
+| Adl14OptProvisioning | 11 | 0 | 0 | 4 | 0 | pass |
+| EhrOperations | 12 | 0 | 0 | 0 | 0 | pass |
+| EhrStatus | 10 | 0 | 0 | 0 | 0 | pass |
+| CompositionOps | 34 | 0 | 0 | 0 | 0 | pass |
+| ChangeSets | 26 | 0 | 0 | 5 | 0 | pass |
+| Versioning | 7 | 0 | 0 | 0 | 0 | pass |
+| ArchetypeValidation | 119 | 0 | 0 | 0 | 0 | pass |
+| AnonymousEhrs | 1 | 0 | 0 | 0 | 0 | pass |
 
 ### Standard — **PASS**
 
-| Capability | Passed | Failed | Errored | Skipped | Verdict |
-|---|--:|--:|--:|--:|---|
-| Adl14ArchetypeProvisioning | 1 | 0 | 0 | 0 | pass |
-| Adl14OptProvisioning | 11 | 0 | 0 | 4 | pass |
-| EhrOperations | 12 | 0 | 0 | 0 | pass |
-| EhrStatus | 10 | 0 | 0 | 0 | pass |
-| CompositionOps | 34 | 0 | 0 | 0 | pass |
-| ChangeSets | 26 | 0 | 0 | 5 | pass |
-| Versioning | 7 | 0 | 0 | 0 | pass |
-| ArchetypeValidation | 119 | 0 | 0 | 0 | pass |
-| AnonymousEhrs | 1 | 0 | 0 | 0 | pass |
-| DirectoryOps | 34 | 0 | 0 | 0 | pass |
-| QueryProvisioning | 5 | 0 | 0 | 2 | pass |
-| AqlBasic | 13 | 0 | 0 | 0 | pass |
-| Signing | 5 | 0 | 0 | 1 | pass |
+| Capability | Passed | Failed | Errored | Skipped | N/A | Verdict |
+|---|--:|--:|--:|--:|--:|---|
+| Adl14ArchetypeProvisioning | 1 | 0 | 0 | 0 | 0 | pass |
+| Adl14OptProvisioning | 11 | 0 | 0 | 4 | 0 | pass |
+| EhrOperations | 12 | 0 | 0 | 0 | 0 | pass |
+| EhrStatus | 10 | 0 | 0 | 0 | 0 | pass |
+| CompositionOps | 34 | 0 | 0 | 0 | 0 | pass |
+| ChangeSets | 26 | 0 | 0 | 5 | 0 | pass |
+| Versioning | 7 | 0 | 0 | 0 | 0 | pass |
+| ArchetypeValidation | 119 | 0 | 0 | 0 | 0 | pass |
+| AnonymousEhrs | 1 | 0 | 0 | 0 | 0 | pass |
+| DirectoryOps | 34 | 0 | 0 | 0 | 0 | pass |
+| QueryProvisioning | 5 | 0 | 0 | 2 | 0 | pass |
+| AqlBasic | 13 | 0 | 0 | 0 | 0 | pass |
+| Signing | 5 | 0 | 0 | 1 | 0 | pass |
 
 ### Options — **OBTAINED** (any-passes)
 
-| Capability | Passed | Failed | Errored | Skipped | Verdict |
-|---|--:|--:|--:|--:|---|
-| Adl2Provisioning | 0 | 0 | 0 | 0 | not evidenced |
-| DemographicApi | 24 | 0 | 0 | 0 | pass |
-| AqlAdvanced | 0 | 0 | 0 | 0 | not evidenced |
-| Terminology | 5 | 0 | 0 | 4 | pass |
-| AdminApi | 6 | 0 | 0 | 0 | pass |
-| AdminActivityReport | 0 | 0 | 0 | 0 | not evidenced |
-| AdminPhysicalDeletion | 0 | 0 | 0 | 0 | not evidenced |
-| AdminEhrDumpLoad | 0 | 0 | 0 | 0 | not evidenced |
-| AdminBulkEhrLoad | 0 | 0 | 0 | 0 | not evidenced |
-| AdminEhrArchive | 0 | 0 | 0 | 0 | not evidenced |
-| AdminDemographicArchive | 0 | 0 | 0 | 0 | not evidenced |
-| Messaging | 0 | 0 | 0 | 10 | not evidenced |
+| Capability | Passed | Failed | Errored | Skipped | N/A | Verdict |
+|---|--:|--:|--:|--:|--:|---|
+| Adl2Provisioning | 0 | 0 | 0 | 0 | 0 | not evidenced |
+| DemographicApi | 24 | 0 | 0 | 0 | 0 | pass |
+| AqlAdvanced | 0 | 0 | 0 | 0 | 0 | not evidenced |
+| Terminology | 5 | 0 | 0 | 4 | 0 | pass |
+| AdminApi | 6 | 0 | 0 | 0 | 0 | pass |
+| AdminActivityReport | 0 | 0 | 0 | 0 | 0 | not evidenced |
+| AdminPhysicalDeletion | 0 | 0 | 0 | 0 | 0 | not evidenced |
+| AdminEhrDumpLoad | 0 | 0 | 0 | 0 | 0 | not evidenced |
+| AdminBulkEhrLoad | 0 | 0 | 0 | 0 | 0 | not evidenced |
+| AdminEhrArchive | 0 | 0 | 0 | 0 | 0 | not evidenced |
+| AdminDemographicArchive | 0 | 0 | 0 | 0 | 0 | not evidenced |
+| Messaging | 0 | 0 | 0 | 10 | 0 | not evidenced |
 
 ## 5. Deviations (skips), by reason
 
@@ -463,15 +469,15 @@ CORE/STANDARD are all-or-nothing (every capability must pass); OPTIONS is any-pa
 | SM I_DEFINITION_ADL14.delete_opt() (CNF master04:319) has no ITS-REST ADL 1.4 binding — ITS-REST development@e8a093e (and Release-1.0.3) define no DELETE verb on /definition/template/adl1.4/{id}; OPT deletion lives in the ADMIN API only | 4 |
 | SM I_DEFINITION_QUERY.list_queries() (CNF master05:93) has no ITS-REST binding — ITS-REST development@e8a093e (and Release-1.0.3) expose GET /definition/query/{qualified_query_name}, not a bare GET /definition/query collection | 2 |
 | SM I_EHR_CONTRIBUTION.list_contributions() (CNF master08:595) has no ITS-REST binding — ITS-REST development@e8a093e (and Release-1.0.3) define POST only on /ehr/{ehr_id}/contribution, with no GET collection resource; the list is a native-API concern, not wire-exercisable | 5 |
-| SutConfig: no FHIR terminology provider configured on the SUT (EHRBASE_VALIDATION_EXTERNAL_TERMINOLOGY_* unset) — a `hl7.org/fhir/4.0` expand is rejected as `UnknownTerminologyService`. harness terminology server: http://127.0.0.1:61365 (fixture). The bundle (`openehr`) expand cases prove the TERMINOLOGY family; wire this by pointing the SUT at a FHIR server (host.docker.internal for a runner-host fixture, docs/design/terminology-server-integration.md §5). | 1 |
+| SutConfig: no FHIR terminology provider configured on the SUT (EHRBASE_VALIDATION_EXTERNAL_TERMINOLOGY_* unset) — a `hl7.org/fhir/4.0` expand is rejected as `UnknownTerminologyService`. harness terminology server: http://127.0.0.1:64681 (fixture). The bundle (`openehr`) expand cases prove the TERMINOLOGY family; wire this by pointing the SUT at a FHIR server (host.docker.internal for a runner-host fixture, docs/design/terminology-server-integration.md §5). | 1 |
 | SutConfig: server not in `pgp` mode (needs a configured OpenPGP key); a pgp-keyed compose profile is a follow-up — digest cases prove the capability | 1 |
-| SutConfig: the 5xx fault requires a fault-injecting terminology server wired to the SUT (--tx-server-url + an SUT FHIR provider pointed at it); the HTTP-only ECC cannot reconfigure an external SUT's provider per case. Harness tx server: http://127.0.0.1:61365 (fixture). The fault→500 mapping is proven by conformance ts::fixture::tests::fault_server_error_is_5xx + app/ehrbase/tests/terminology_fhir.rs::server_5xx_is_an_exception. | 1 |
-| SutConfig: the malformed fault requires a fault-injecting terminology server wired to the SUT (--tx-server-url + an SUT FHIR provider pointed at it); the HTTP-only ECC cannot reconfigure an external SUT's provider per case. Harness tx server: http://127.0.0.1:61365 (fixture). The fault→500 mapping is proven by conformance ts::fixture::tests::fault_malformed_is_not_json + app/ehrbase/tests/terminology_fhir.rs::malformed_body_is_an_exception. | 1 |
-| SutConfig: the timeout fault requires a fault-injecting terminology server wired to the SUT (--tx-server-url + an SUT FHIR provider pointed at it); the HTTP-only ECC cannot reconfigure an external SUT's provider per case. Harness tx server: http://127.0.0.1:61365 (fixture). The fault→500 mapping is proven by conformance ts::fixture::tests::fault_timeout_exceeds_a_short_client_deadline + app/ehrbase/tests/terminology_fhir.rs::timeout_is_an_exception. | 1 |
+| SutConfig: the 5xx fault requires a fault-injecting terminology server wired to the SUT (--tx-server-url + an SUT FHIR provider pointed at it); the HTTP-only ECC cannot reconfigure an external SUT's provider per case. Harness tx server: http://127.0.0.1:64681 (fixture). The fault→500 mapping is proven by conformance ts::fixture::tests::fault_server_error_is_5xx + app/ehrbase/tests/terminology_fhir.rs::server_5xx_is_an_exception. | 1 |
+| SutConfig: the malformed fault requires a fault-injecting terminology server wired to the SUT (--tx-server-url + an SUT FHIR provider pointed at it); the HTTP-only ECC cannot reconfigure an external SUT's provider per case. Harness tx server: http://127.0.0.1:64681 (fixture). The fault→500 mapping is proven by conformance ts::fixture::tests::fault_malformed_is_not_json + app/ehrbase/tests/terminology_fhir.rs::malformed_body_is_an_exception. | 1 |
+| SutConfig: the timeout fault requires a fault-injecting terminology server wired to the SUT (--tx-server-url + an SUT FHIR provider pointed at it); the HTTP-only ECC cannot reconfigure an external SUT's provider per case. Harness tx server: http://127.0.0.1:64681 (fixture). The fault→500 mapping is proven by conformance ts::fixture::tests::fault_timeout_exceeds_a_short_client_deadline + app/ehrbase/tests/terminology_fhir.rs::timeout_is_an_exception. | 1 |
 
 ## 6. Terminology server (TS area)
 
-- Server: `http://127.0.0.1:61365`
+- Server: `http://127.0.0.1:64681`
 - Mode: fixture
 
 Recorded FHIR-tx exchange (4 request(s)):

--- a/docs/conformance/CONFORMANCE_STATEMENT.md
+++ b/docs/conformance/CONFORMANCE_STATEMENT.md
@@ -8,9 +8,10 @@
 
 | Field | Value |
 |---|---|
+| Product | ehrbase-rs 3.0.0 |
 | SUT | `http://localhost:8080/ehrbase/rest/openehr/v1` |
 | Auth mode | basic |
-| Run started | 2026-07-11T06:26:52.947058Z |
+| Run started | 2026-07-11T10:45:03.644171Z |
 | Reference corpus | openEHR/specifications-CNF@33251d2a |
 
 ## Supported specification versions

--- a/docs/conformance/results.json
+++ b/docs/conformance/results.json
@@ -1,6 +1,10 @@
 {
   "sut": {
     "base_url": "http://localhost:8080/ehrbase/rest/openehr/v1",
+    "product": {
+      "name": "ehrbase-rs",
+      "version": "3.0.0"
+    },
     "versions": {
       "rm": "1.2.0",
       "its_rest": "development@e8a093e",
@@ -13,7 +17,7 @@
     "repo": "openEHR/specifications-CNF",
     "commit": "33251d2a"
   },
-  "started": "2026-07-11T06:26:52.947058Z",
+  "started": "2026-07-11T10:45:03.644171Z",
   "selection": {
     "filter": null,
     "profile": null,
@@ -23,7 +27,7 @@
     ]
   },
   "terminology": {
-    "base_url": "http://127.0.0.1:61365",
+    "base_url": "http://127.0.0.1:64681",
     "mode": "fixture",
     "exchanges": [
       {
@@ -64,7 +68,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
-      "duration_ms": 42
+      "duration_ms": 201
     },
     {
       "ecc_id": "ECC-EHR-002",
@@ -81,7 +85,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
-      "duration_ms": 17
+      "duration_ms": 47
     },
     {
       "ecc_id": "ECC-EHR-003",
@@ -98,7 +102,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
-      "duration_ms": 3
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-EHR-004",
@@ -115,7 +119,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
-      "duration_ms": 3
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-EHR-005",
@@ -132,7 +136,7 @@
       "total_data_sets": 16,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
-      "duration_ms": 170
+      "duration_ms": 425
     },
     {
       "ecc_id": "ECC-EHR-006",
@@ -149,7 +153,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
-      "duration_ms": 11
+      "duration_ms": 28
     },
     {
       "ecc_id": "ECC-EHR-007",
@@ -166,7 +170,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
-      "duration_ms": 11
+      "duration_ms": 54
     },
     {
       "ecc_id": "ECC-EHR-008",
@@ -183,7 +187,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
-      "duration_ms": 9
+      "duration_ms": 84
     },
     {
       "ecc_id": "ECC-EHR-009",
@@ -200,7 +204,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
-      "duration_ms": 9
+      "duration_ms": 59
     },
     {
       "ecc_id": "ECC-EHR-010",
@@ -217,7 +221,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
-      "duration_ms": 3
+      "duration_ms": 10
     },
     {
       "ecc_id": "ECC-EHR-011",
@@ -234,7 +238,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
-      "duration_ms": 3
+      "duration_ms": 10
     },
     {
       "ecc_id": "ECC-STA-001",
@@ -251,7 +255,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR_STATUS API §get_ehr_status/update_ehr_status; RM 1.2.0 ehr §EHR_STATUS",
-      "duration_ms": 10
+      "duration_ms": 40
     },
     {
       "ecc_id": "ECC-STA-002",
@@ -268,7 +272,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR_STATUS API §get_ehr_status/update_ehr_status; RM 1.2.0 ehr §EHR_STATUS",
-      "duration_ms": 3
+      "duration_ms": 36
     },
     {
       "ecc_id": "ECC-STA-003",
@@ -285,7 +289,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR_STATUS API §get_ehr_status/update_ehr_status; RM 1.2.0 ehr §EHR_STATUS",
-      "duration_ms": 20
+      "duration_ms": 99
     },
     {
       "ecc_id": "ECC-STA-004",
@@ -302,7 +306,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR_STATUS API §get_ehr_status/update_ehr_status; RM 1.2.0 ehr §EHR_STATUS",
-      "duration_ms": 3
+      "duration_ms": 11
     },
     {
       "ecc_id": "ECC-STA-005",
@@ -319,7 +323,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR_STATUS API §get_ehr_status/update_ehr_status; RM 1.2.0 ehr §EHR_STATUS",
-      "duration_ms": 20
+      "duration_ms": 58
     },
     {
       "ecc_id": "ECC-STA-006",
@@ -336,7 +340,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR_STATUS API §get_ehr_status/update_ehr_status; RM 1.2.0 ehr §EHR_STATUS",
-      "duration_ms": 3
+      "duration_ms": 10
     },
     {
       "ecc_id": "ECC-STA-007",
@@ -353,7 +357,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR_STATUS API §get_ehr_status/update_ehr_status; RM 1.2.0 ehr §EHR_STATUS",
-      "duration_ms": 19
+      "duration_ms": 55
     },
     {
       "ecc_id": "ECC-STA-008",
@@ -370,7 +374,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR_STATUS API §get_ehr_status/update_ehr_status; RM 1.2.0 ehr §EHR_STATUS",
-      "duration_ms": 3
+      "duration_ms": 11
     },
     {
       "ecc_id": "ECC-STA-009",
@@ -387,7 +391,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR_STATUS API §get_ehr_status/update_ehr_status; RM 1.2.0 ehr §EHR_STATUS",
-      "duration_ms": 18
+      "duration_ms": 57
     },
     {
       "ecc_id": "ECC-STA-010",
@@ -404,7 +408,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR_STATUS API §get_ehr_status/update_ehr_status; RM 1.2.0 ehr §EHR_STATUS",
-      "duration_ms": 3
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-EHR-012",
@@ -421,7 +425,7 @@
       "total_data_sets": 11,
       "message": null,
       "citation": "ITS-REST 1.0.3 EHR API §create_ehr (422); RM 1.2.0 ehr §EHR_STATUS validation",
-      "duration_ms": 40
+      "duration_ms": 99
     },
     {
       "ecc_id": "ECC-EHR-013",
@@ -438,7 +442,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "CNF master03-profiles §Non-Functional (Anonymous EHRs — CORE+STANDARD); ITS-REST EHR API §create_ehr (no body); RM 1.2.0 ehr §EHR_STATUS",
-      "duration_ms": 9
+      "duration_ms": 22
     },
     {
       "ecc_id": "ECC-COM-001",
@@ -455,7 +459,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 28
+      "duration_ms": 54
     },
     {
       "ecc_id": "ECC-COM-001",
@@ -472,7 +476,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 32
+      "duration_ms": 38
     },
     {
       "ecc_id": "ECC-COM-002",
@@ -489,7 +493,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 21
+      "duration_ms": 36
     },
     {
       "ecc_id": "ECC-COM-002",
@@ -506,7 +510,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 18
+      "duration_ms": 30
     },
     {
       "ecc_id": "ECC-COM-003",
@@ -523,7 +527,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 24
+      "duration_ms": 41
     },
     {
       "ecc_id": "ECC-COM-004",
@@ -540,7 +544,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 15
+      "duration_ms": 27
     },
     {
       "ecc_id": "ECC-COM-005",
@@ -557,7 +561,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 15
+      "duration_ms": 24
     },
     {
       "ecc_id": "ECC-COM-006",
@@ -574,7 +578,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 16
+      "duration_ms": 20
     },
     {
       "ecc_id": "ECC-COM-007",
@@ -591,7 +595,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 8
+      "duration_ms": 11
     },
     {
       "ecc_id": "ECC-COM-008",
@@ -608,7 +612,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 22
+      "duration_ms": 35
     },
     {
       "ecc_id": "ECC-COM-008",
@@ -625,7 +629,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 22
+      "duration_ms": 34
     },
     {
       "ecc_id": "ECC-COM-009",
@@ -642,7 +646,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 8
+      "duration_ms": 17
     },
     {
       "ecc_id": "ECC-COM-010",
@@ -659,7 +663,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 3
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-COM-011",
@@ -676,7 +680,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 8
+      "duration_ms": 21
     },
     {
       "ecc_id": "ECC-COM-012",
@@ -693,7 +697,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 3
+      "duration_ms": 10
     },
     {
       "ecc_id": "ECC-COM-013",
@@ -710,7 +714,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 22
+      "duration_ms": 85
     },
     {
       "ecc_id": "ECC-COM-013",
@@ -727,7 +731,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 22
+      "duration_ms": 53
     },
     {
       "ecc_id": "ECC-COM-014",
@@ -744,7 +748,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 21
+      "duration_ms": 49
     },
     {
       "ecc_id": "ECC-COM-014",
@@ -761,7 +765,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 20
+      "duration_ms": 41
     },
     {
       "ecc_id": "ECC-COM-015",
@@ -778,7 +782,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 8
+      "duration_ms": 16
     },
     {
       "ecc_id": "ECC-COM-016",
@@ -795,7 +799,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 3
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-COM-017",
@@ -812,7 +816,7 @@
       "total_data_sets": 3,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 148
+      "duration_ms": 173
     },
     {
       "ecc_id": "ECC-COM-018",
@@ -829,7 +833,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 22
+      "duration_ms": 32
     },
     {
       "ecc_id": "ECC-COM-018",
@@ -846,7 +850,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 20
+      "duration_ms": 32
     },
     {
       "ecc_id": "ECC-COM-019",
@@ -863,7 +867,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 8
+      "duration_ms": 14
     },
     {
       "ecc_id": "ECC-COM-020",
@@ -880,7 +884,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 3
+      "duration_ms": 5
     },
     {
       "ecc_id": "ECC-COM-021",
@@ -897,7 +901,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 39
+      "duration_ms": 59
     },
     {
       "ecc_id": "ECC-COM-022",
@@ -914,7 +918,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST COMPOSITION API §get_versioned_composition; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT",
-      "duration_ms": 20
+      "duration_ms": 35
     },
     {
       "ecc_id": "ECC-COM-022",
@@ -931,7 +935,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST COMPOSITION API §get_versioned_composition; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT",
-      "duration_ms": 21
+      "duration_ms": 37
     },
     {
       "ecc_id": "ECC-COM-023",
@@ -948,7 +952,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST COMPOSITION API §get_versioned_composition (404); RM 1.2.0 common §VERSIONED_OBJECT",
-      "duration_ms": 8
+      "duration_ms": 17
     },
     {
       "ecc_id": "ECC-COM-024",
@@ -965,7 +969,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST COMPOSITION API §get_versioned_composition (404); RM 1.2.0 common §VERSIONED_OBJECT",
-      "duration_ms": 3
+      "duration_ms": 5
     },
     {
       "ecc_id": "ECC-COM-025",
@@ -982,7 +986,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 25
+      "duration_ms": 43
     },
     {
       "ecc_id": "ECC-COM-026",
@@ -999,7 +1003,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 23
+      "duration_ms": 38
     },
     {
       "ecc_id": "ECC-COM-027",
@@ -1016,7 +1020,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 13
+      "duration_ms": 23
     },
     {
       "ecc_id": "ECC-COM-028",
@@ -1033,7 +1037,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 25
+      "duration_ms": 37
     },
     {
       "ecc_id": "ECC-COM-029",
@@ -1050,7 +1054,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 21
+      "duration_ms": 42
     },
     {
       "ecc_id": "ECC-COM-030",
@@ -1067,7 +1071,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 23
+      "duration_ms": 29
     },
     {
       "ecc_id": "ECC-COM-031",
@@ -1084,7 +1088,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
-      "duration_ms": 8
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-CTB-001",
@@ -1101,7 +1105,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 19
+      "duration_ms": 26
     },
     {
       "ecc_id": "ECC-CTB-002",
@@ -1118,7 +1122,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 13
+      "duration_ms": 19
     },
     {
       "ecc_id": "ECC-CTB-003",
@@ -1135,7 +1139,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 11
+      "duration_ms": 15
     },
     {
       "ecc_id": "ECC-CTB-004",
@@ -1152,7 +1156,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 22
+      "duration_ms": 30
     },
     {
       "ecc_id": "ECC-CTB-005",
@@ -1169,7 +1173,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 15
+      "duration_ms": 17
     },
     {
       "ecc_id": "ECC-CTB-006",
@@ -1186,7 +1190,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 28
+      "duration_ms": 40
     },
     {
       "ecc_id": "ECC-CTB-007",
@@ -1203,7 +1207,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 24
+      "duration_ms": 38
     },
     {
       "ecc_id": "ECC-CTB-008",
@@ -1220,7 +1224,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 23
+      "duration_ms": 36
     },
     {
       "ecc_id": "ECC-CTB-009",
@@ -1237,7 +1241,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 20
+      "duration_ms": 31
     },
     {
       "ecc_id": "ECC-CTB-010",
@@ -1254,7 +1258,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 19
+      "duration_ms": 29
     },
     {
       "ecc_id": "ECC-CTB-011",
@@ -1271,7 +1275,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 16
+      "duration_ms": 23
     },
     {
       "ecc_id": "ECC-CTB-012",
@@ -1288,7 +1292,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 14
+      "duration_ms": 20
     },
     {
       "ecc_id": "ECC-CTB-013",
@@ -1305,7 +1309,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 9
+      "duration_ms": 15
     },
     {
       "ecc_id": "ECC-CTB-014",
@@ -1322,7 +1326,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 12
+      "duration_ms": 19
     },
     {
       "ecc_id": "ECC-CTB-015",
@@ -1339,7 +1343,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 12
+      "duration_ms": 18
     },
     {
       "ecc_id": "ECC-CTB-016",
@@ -1356,7 +1360,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 14
+      "duration_ms": 20
     },
     {
       "ecc_id": "ECC-CTB-017",
@@ -1373,7 +1377,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 11
+      "duration_ms": 16
     },
     {
       "ecc_id": "ECC-CTB-018",
@@ -1390,7 +1394,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 15
+      "duration_ms": 26
     },
     {
       "ecc_id": "ECC-CTB-019",
@@ -1407,7 +1411,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 18
+      "duration_ms": 29
     },
     {
       "ecc_id": "ECC-CTB-020",
@@ -1424,7 +1428,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 8
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-CTB-021",
@@ -1441,7 +1445,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 3
+      "duration_ms": 5
     },
     {
       "ecc_id": "ECC-CTB-022",
@@ -1458,7 +1462,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 18
+      "duration_ms": 28
     },
     {
       "ecc_id": "ECC-CTB-023",
@@ -1475,7 +1479,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 18
+      "duration_ms": 28
     },
     {
       "ecc_id": "ECC-CTB-024",
@@ -1492,7 +1496,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 18
+      "duration_ms": 28
     },
     {
       "ecc_id": "ECC-CTB-025",
@@ -1509,7 +1513,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 3
+      "duration_ms": 5
     },
     {
       "ecc_id": "ECC-CTB-026",
@@ -1526,7 +1530,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
-      "duration_ms": 8
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-CTB-027",
@@ -1632,7 +1636,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 13
+      "duration_ms": 21
     },
     {
       "ecc_id": "ECC-DIR-002",
@@ -1648,7 +1652,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 18
+      "duration_ms": 35
     },
     {
       "ecc_id": "ECC-DIR-003",
@@ -1664,7 +1668,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 3
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-DIR-004",
@@ -1680,7 +1684,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 14
+      "duration_ms": 39
     },
     {
       "ecc_id": "ECC-DIR-005",
@@ -1696,7 +1700,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 3
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-DIR-006",
@@ -1712,7 +1716,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 15
+      "duration_ms": 37
     },
     {
       "ecc_id": "ECC-DIR-007",
@@ -1728,7 +1732,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 3
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-DIR-008",
@@ -1744,7 +1748,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 19
+      "duration_ms": 54
     },
     {
       "ecc_id": "ECC-DIR-009",
@@ -1760,7 +1764,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 3
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-DIR-010",
@@ -1776,7 +1780,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 22
+      "duration_ms": 30
     },
     {
       "ecc_id": "ECC-DIR-011",
@@ -1792,7 +1796,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 3
+      "duration_ms": 5
     },
     {
       "ecc_id": "ECC-DIR-012",
@@ -1808,7 +1812,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 8
+      "duration_ms": 22
     },
     {
       "ecc_id": "ECC-DIR-013",
@@ -1824,7 +1828,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 15
+      "duration_ms": 30
     },
     {
       "ecc_id": "ECC-DIR-014",
@@ -1840,7 +1844,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 3
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-DIR-015",
@@ -1856,7 +1860,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 14
+      "duration_ms": 30
     },
     {
       "ecc_id": "ECC-DIR-016",
@@ -1872,7 +1876,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 14
+      "duration_ms": 28
     },
     {
       "ecc_id": "ECC-DIR-017",
@@ -1888,7 +1892,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 8
+      "duration_ms": 13
     },
     {
       "ecc_id": "ECC-DIR-018",
@@ -1904,7 +1908,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 3
+      "duration_ms": 5
     },
     {
       "ecc_id": "ECC-DIR-019",
@@ -1920,7 +1924,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 8
+      "duration_ms": 14
     },
     {
       "ecc_id": "ECC-DIR-020",
@@ -1936,7 +1940,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 21
+      "duration_ms": 33
     },
     {
       "ecc_id": "ECC-DIR-021",
@@ -1952,7 +1956,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 3
+      "duration_ms": 5
     },
     {
       "ecc_id": "ECC-DIR-022",
@@ -1968,7 +1972,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 9
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-DIR-023",
@@ -1984,7 +1988,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 17
+      "duration_ms": 22
     },
     {
       "ecc_id": "ECC-DIR-024",
@@ -2000,7 +2004,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 17
+      "duration_ms": 23
     },
     {
       "ecc_id": "ECC-DIR-025",
@@ -2016,7 +2020,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 24
+      "duration_ms": 31
     },
     {
       "ecc_id": "ECC-DIR-026",
@@ -2032,7 +2036,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 21
+      "duration_ms": 34
     },
     {
       "ecc_id": "ECC-DIR-027",
@@ -2048,7 +2052,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 8
+      "duration_ms": 13
     },
     {
       "ecc_id": "ECC-DIR-028",
@@ -2064,7 +2068,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 8
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-DIR-029",
@@ -2080,7 +2084,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 21
+      "duration_ms": 31
     },
     {
       "ecc_id": "ECC-DIR-030",
@@ -2096,7 +2100,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 3
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-DIR-031",
@@ -2112,7 +2116,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 20
+      "duration_ms": 34
     },
     {
       "ecc_id": "ECC-DIR-032",
@@ -2128,7 +2132,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 8
+      "duration_ms": 13
     },
     {
       "ecc_id": "ECC-DIR-033",
@@ -2145,7 +2149,7 @@
       "message": null,
       "citation": "CNF Robot I_EHR_DIRECTORY.get_versioned_directory-empty_ehr realized as GET /ehr/{ehr_id}/directory/{version_uid} (no versioned_directory resource in ITS-REST development@e8a093e/Release-1.0.3); RM 1.2.0 ehr §FOLDER, common §VERSIONED_OBJECT",
       "schedule_ref": "I_EHR_DIRECTORY.get_versioned_directory (CNF master09:670)",
-      "duration_ms": 8
+      "duration_ms": 13
     },
     {
       "ecc_id": "ECC-DIR-034",
@@ -2162,7 +2166,7 @@
       "message": null,
       "citation": "CNF Robot I_EHR_DIRECTORY.get_versioned_directory-directory_with_two_versions realized as GET /ehr/{ehr_id}/directory/{version_uid}; RM 1.2.0 ehr §FOLDER, common §VERSIONED_OBJECT",
       "schedule_ref": "I_EHR_DIRECTORY.get_versioned_directory (CNF master09:670)",
-      "duration_ms": 21
+      "duration_ms": 32
     },
     {
       "ecc_id": "ECC-DIR-035",
@@ -2179,7 +2183,7 @@
       "message": null,
       "citation": "CNF Robot I_EHR_DIRECTORY.get_versioned_directory-bad_ehr realized as GET /ehr/{ehr_id}/directory/{version_uid}; RM 1.2.0 ehr §FOLDER, common §VERSIONED_OBJECT",
       "schedule_ref": "I_EHR_DIRECTORY.get_versioned_directory (CNF master09:670)",
-      "duration_ms": 3
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-DIR-036",
@@ -2195,7 +2199,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 8
+      "duration_ms": 13
     },
     {
       "ecc_id": "ECC-DIR-037",
@@ -2211,7 +2215,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
-      "duration_ms": 8
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-TPL-001",
@@ -2228,7 +2232,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST DEFINITION ADL 1.4 API §upload OPT; AM 1.4 §OPERATIONAL_TEMPLATE; CORE Adl14ArchetypeProvisioning evidenced via OPT (archetypes embedded in the OPT)",
-      "duration_ms": 5
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-TPL-002",
@@ -2245,7 +2249,7 @@
       "total_data_sets": 18,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
-      "duration_ms": 94
+      "duration_ms": 135
     },
     {
       "ecc_id": "ECC-TPL-003",
@@ -2262,7 +2266,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
-      "duration_ms": 3
+      "duration_ms": 5
     },
     {
       "ecc_id": "ECC-TPL-004",
@@ -2279,7 +2283,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
-      "duration_ms": 7
+      "duration_ms": 11
     },
     {
       "ecc_id": "ECC-TPL-005",
@@ -2296,7 +2300,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
-      "duration_ms": 7
+      "duration_ms": 11
     },
     {
       "ecc_id": "ECC-TPL-006",
@@ -2313,7 +2317,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
-      "duration_ms": 7
+      "duration_ms": 16
     },
     {
       "ecc_id": "ECC-TPL-007",
@@ -2347,7 +2351,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
-      "duration_ms": 4
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-TPL-009",
@@ -2364,7 +2368,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
-      "duration_ms": 3
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-TPL-010",
@@ -2381,7 +2385,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
-      "duration_ms": 9
+      "duration_ms": 20
     },
     {
       "ecc_id": "ECC-TPL-011",
@@ -2398,7 +2402,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
-      "duration_ms": 3
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-TPL-012",
@@ -2415,7 +2419,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
-      "duration_ms": 5
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-TPL-013",
@@ -2503,7 +2507,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEFINITION QUERY API §store/list stored query; AQL 1.1",
-      "duration_ms": 6
+      "duration_ms": 11
     },
     {
       "ecc_id": "ECC-SQR-002",
@@ -2519,7 +2523,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEFINITION QUERY API §store/list stored query; AQL 1.1",
-      "duration_ms": 7
+      "duration_ms": 17
     },
     {
       "ecc_id": "ECC-SQR-003",
@@ -2535,7 +2539,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEFINITION QUERY API §store/list stored query; AQL 1.1",
-      "duration_ms": 9
+      "duration_ms": 13
     },
     {
       "ecc_id": "ECC-SQR-004",
@@ -2585,7 +2589,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEFINITION QUERY API §store/list stored query; AQL 1.1",
-      "duration_ms": 4
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-SQR-007",
@@ -2601,7 +2605,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEFINITION QUERY API §store/list stored query; AQL 1.1",
-      "duration_ms": 4
+      "duration_ms": 5
     },
     {
       "ecc_id": "ECC-QRY-001",
@@ -2617,7 +2621,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query/execute_stored_query; AQL 1.1",
-      "duration_ms": 6
+      "duration_ms": 10
     },
     {
       "ecc_id": "ECC-QRY-002",
@@ -2633,7 +2637,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query/execute_stored_query; AQL 1.1",
-      "duration_ms": 8
+      "duration_ms": 10
     },
     {
       "ecc_id": "ECC-QRY-003",
@@ -2649,7 +2653,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query/execute_stored_query; AQL 1.1",
-      "duration_ms": 7
+      "duration_ms": 14
     },
     {
       "ecc_id": "ECC-QRY-004",
@@ -2665,7 +2669,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query/execute_stored_query; AQL 1.1",
-      "duration_ms": 22
+      "duration_ms": 40
     },
     {
       "ecc_id": "ECC-QRY-005",
@@ -2681,7 +2685,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query; AQL 1.1; reference: CNF query corpus (design-time reading)",
-      "duration_ms": 10
+      "duration_ms": 14
     },
     {
       "ecc_id": "ECC-QRY-006",
@@ -2697,7 +2701,7 @@
       "total_data_sets": 25,
       "message": null,
       "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query; AQL 1.1; reference: CNF query corpus (design-time reading)",
-      "duration_ms": 242
+      "duration_ms": 354
     },
     {
       "ecc_id": "ECC-QRY-007",
@@ -2713,7 +2717,7 @@
       "total_data_sets": 18,
       "message": null,
       "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query; AQL 1.1; reference: CNF query corpus (design-time reading)",
-      "duration_ms": 261
+      "duration_ms": 292
     },
     {
       "ecc_id": "ECC-QRY-008",
@@ -2729,7 +2733,7 @@
       "total_data_sets": 11,
       "message": null,
       "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query; AQL 1.1; reference: CNF query corpus (design-time reading)",
-      "duration_ms": 95
+      "duration_ms": 110
     },
     {
       "ecc_id": "ECC-QRY-009",
@@ -2745,7 +2749,7 @@
       "total_data_sets": 16,
       "message": null,
       "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query; AQL 1.1; reference: CNF query corpus (design-time reading)",
-      "duration_ms": 186
+      "duration_ms": 177
     },
     {
       "ecc_id": "ECC-QRY-010",
@@ -2761,7 +2765,7 @@
       "total_data_sets": 21,
       "message": null,
       "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query; AQL 1.1; reference: CNF query corpus (design-time reading)",
-      "duration_ms": 183
+      "duration_ms": 208
     },
     {
       "ecc_id": "ECC-QRY-011",
@@ -2777,7 +2781,7 @@
       "total_data_sets": 15,
       "message": null,
       "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query; AQL 1.1; reference: CNF query corpus (design-time reading)",
-      "duration_ms": 190
+      "duration_ms": 206
     },
     {
       "ecc_id": "ECC-QRY-012",
@@ -2793,7 +2797,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query; AQL 1.1; reference: CNF query corpus (design-time reading)",
-      "duration_ms": 20
+      "duration_ms": 18
     },
     {
       "ecc_id": "ECC-QRY-013",
@@ -2809,7 +2813,7 @@
       "total_data_sets": 7,
       "message": null,
       "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query; AQL 1.1; reference: CNF query corpus (design-time reading)",
-      "duration_ms": 71
+      "duration_ms": 80
     },
     {
       "ecc_id": "ECC-ADM-001",
@@ -2825,7 +2829,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 ADMIN API §delete EHR; SM §I_ADMIN_SERVICE.physical_ehr_delete",
-      "duration_ms": 11
+      "duration_ms": 14
     },
     {
       "ecc_id": "ECC-ADM-002",
@@ -2841,7 +2845,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 ADMIN API §delete EHR; SM §I_ADMIN_SERVICE.physical_ehr_delete",
-      "duration_ms": 3
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-ADM-003",
@@ -2857,7 +2861,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 ADMIN API §delete EHR; SM §I_ADMIN_SERVICE.physical_ehr_delete",
-      "duration_ms": 14
+      "duration_ms": 18
     },
     {
       "ecc_id": "ECC-ADM-004",
@@ -2873,7 +2877,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 ADMIN API §delete EHR; SM §I_ADMIN_SERVICE.physical_ehr_delete",
-      "duration_ms": 16
+      "duration_ms": 21
     },
     {
       "ecc_id": "ECC-ADM-005",
@@ -2889,7 +2893,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 ADMIN API §delete EHR; SM §I_ADMIN_SERVICE.physical_ehr_delete",
-      "duration_ms": 9
+      "duration_ms": 13
     },
     {
       "ecc_id": "ECC-ADM-006",
@@ -2905,7 +2909,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 ADMIN API §delete EHR; SM §I_ADMIN_SERVICE.physical_ehr_delete",
-      "duration_ms": 3
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-DEM-001",
@@ -2921,7 +2925,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 9
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-DEM-002",
@@ -2937,7 +2941,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 8
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-DEM-003",
@@ -2953,7 +2957,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 9
+      "duration_ms": 11
     },
     {
       "ecc_id": "ECC-DEM-004",
@@ -2969,7 +2973,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 10
+      "duration_ms": 13
     },
     {
       "ecc_id": "ECC-DEM-005",
@@ -2985,7 +2989,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 9
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-DEM-006",
@@ -3001,7 +3005,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 12
+      "duration_ms": 16
     },
     {
       "ecc_id": "ECC-DEM-007",
@@ -3017,7 +3021,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 3
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-DEM-008",
@@ -3033,7 +3037,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 8
+      "duration_ms": 14
     },
     {
       "ecc_id": "ECC-DEM-009",
@@ -3049,7 +3053,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 5
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-DEM-010",
@@ -3065,7 +3069,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 9
+      "duration_ms": 11
     },
     {
       "ecc_id": "ECC-DEM-011",
@@ -3081,7 +3085,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 8
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-DEM-012",
@@ -3097,7 +3101,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 4
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-DEM-013",
@@ -3113,7 +3117,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 8
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-DEM-014",
@@ -3129,7 +3133,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 9
+      "duration_ms": 13
     },
     {
       "ecc_id": "ECC-DEM-015",
@@ -3145,7 +3149,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 4
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-DEM-016",
@@ -3161,7 +3165,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 8
+      "duration_ms": 11
     },
     {
       "ecc_id": "ECC-DEM-017",
@@ -3177,7 +3181,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 8
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-DEM-018",
@@ -3193,7 +3197,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 4
+      "duration_ms": 5
     },
     {
       "ecc_id": "ECC-DEM-019",
@@ -3209,7 +3213,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 8
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-DEM-020",
@@ -3225,7 +3229,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 8
+      "duration_ms": 13
     },
     {
       "ecc_id": "ECC-DEM-021",
@@ -3241,7 +3245,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 3
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-DEM-022",
@@ -3257,7 +3261,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 8
+      "duration_ms": 11
     },
     {
       "ecc_id": "ECC-DEM-023",
@@ -3273,7 +3277,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 8
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-DEM-024",
@@ -3289,7 +3293,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
-      "duration_ms": 8
+      "duration_ms": 11
     },
     {
       "ecc_id": "ECC-VAL-001",
@@ -3306,7 +3310,7 @@
       "total_data_sets": 6,
       "message": null,
       "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 89
+      "duration_ms": 126
     },
     {
       "ecc_id": "ECC-VAL-002",
@@ -3323,7 +3327,7 @@
       "total_data_sets": 6,
       "message": null,
       "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 84
+      "duration_ms": 115
     },
     {
       "ecc_id": "ECC-VAL-003",
@@ -3340,7 +3344,7 @@
       "total_data_sets": 6,
       "message": null,
       "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 82
+      "duration_ms": 115
     },
     {
       "ecc_id": "ECC-VAL-004",
@@ -3357,7 +3361,7 @@
       "total_data_sets": 6,
       "message": null,
       "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 88
+      "duration_ms": 114
     },
     {
       "ecc_id": "ECC-VAL-005",
@@ -3374,7 +3378,7 @@
       "total_data_sets": 6,
       "message": null,
       "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 85
+      "duration_ms": 111
     },
     {
       "ecc_id": "ECC-VAL-006",
@@ -3391,7 +3395,7 @@
       "total_data_sets": 6,
       "message": null,
       "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 84
+      "duration_ms": 114
     },
     {
       "ecc_id": "ECC-VAL-007",
@@ -3408,7 +3412,7 @@
       "total_data_sets": 6,
       "message": null,
       "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 81
+      "duration_ms": 115
     },
     {
       "ecc_id": "ECC-VAL-008",
@@ -3425,7 +3429,7 @@
       "total_data_sets": 6,
       "message": null,
       "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 82
+      "duration_ms": 113
     },
     {
       "ecc_id": "ECC-VAL-009",
@@ -3442,7 +3446,7 @@
       "total_data_sets": 6,
       "message": null,
       "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 82
+      "duration_ms": 124
     },
     {
       "ecc_id": "ECC-VAL-010",
@@ -3459,7 +3463,7 @@
       "total_data_sets": 6,
       "message": null,
       "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 80
+      "duration_ms": 120
     },
     {
       "ecc_id": "ECC-VAL-011",
@@ -3476,7 +3480,7 @@
       "total_data_sets": 6,
       "message": null,
       "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 82
+      "duration_ms": 109
     },
     {
       "ecc_id": "ECC-VAL-012",
@@ -3493,7 +3497,7 @@
       "total_data_sets": 6,
       "message": null,
       "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 81
+      "duration_ms": 115
     },
     {
       "ecc_id": "ECC-VAL-013",
@@ -3510,7 +3514,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 ehr §OBSERVATION; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 27
+      "duration_ms": 40
     },
     {
       "ecc_id": "ECC-VAL-014",
@@ -3527,7 +3531,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 ehr §OBSERVATION; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 29
+      "duration_ms": 41
     },
     {
       "ecc_id": "ECC-VAL-015",
@@ -3544,7 +3548,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 ehr §OBSERVATION; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 27
+      "duration_ms": 37
     },
     {
       "ecc_id": "ECC-VAL-016",
@@ -3561,7 +3565,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 ehr §OBSERVATION; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 28
+      "duration_ms": 36
     },
     {
       "ecc_id": "ECC-VAL-017",
@@ -3578,7 +3582,7 @@
       "total_data_sets": 3,
       "message": null,
       "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 43
+      "duration_ms": 60
     },
     {
       "ecc_id": "ECC-VAL-018",
@@ -3595,7 +3599,7 @@
       "total_data_sets": 3,
       "message": null,
       "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 50
+      "duration_ms": 62
     },
     {
       "ecc_id": "ECC-VAL-019",
@@ -3612,7 +3616,7 @@
       "total_data_sets": 3,
       "message": null,
       "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 42
+      "duration_ms": 68
     },
     {
       "ecc_id": "ECC-VAL-020",
@@ -3629,7 +3633,7 @@
       "total_data_sets": 3,
       "message": null,
       "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 43
+      "duration_ms": 70
     },
     {
       "ecc_id": "ECC-VAL-021",
@@ -3646,7 +3650,7 @@
       "total_data_sets": 3,
       "message": null,
       "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 48
+      "duration_ms": 66
     },
     {
       "ecc_id": "ECC-VAL-022",
@@ -3663,7 +3667,7 @@
       "total_data_sets": 3,
       "message": null,
       "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 43
+      "duration_ms": 61
     },
     {
       "ecc_id": "ECC-VAL-023",
@@ -3680,7 +3684,7 @@
       "total_data_sets": 3,
       "message": null,
       "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 43
+      "duration_ms": 58
     },
     {
       "ecc_id": "ECC-VAL-024",
@@ -3697,7 +3701,7 @@
       "total_data_sets": 3,
       "message": null,
       "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 42
+      "duration_ms": 62
     },
     {
       "ecc_id": "ECC-VAL-025",
@@ -3714,7 +3718,7 @@
       "total_data_sets": 3,
       "message": null,
       "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 42
+      "duration_ms": 58
     },
     {
       "ecc_id": "ECC-VAL-026",
@@ -3731,7 +3735,7 @@
       "total_data_sets": 3,
       "message": null,
       "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 42
+      "duration_ms": 58
     },
     {
       "ecc_id": "ECC-VAL-027",
@@ -3748,7 +3752,7 @@
       "total_data_sets": 3,
       "message": null,
       "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 40
+      "duration_ms": 56
     },
     {
       "ecc_id": "ECC-VAL-028",
@@ -3765,7 +3769,7 @@
       "total_data_sets": 3,
       "message": null,
       "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 41
+      "duration_ms": 58
     },
     {
       "ecc_id": "ECC-VAL-029",
@@ -3782,7 +3786,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 ehr §EVENT; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 27
+      "duration_ms": 41
     },
     {
       "ecc_id": "ECC-VAL-030",
@@ -3799,7 +3803,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 ehr §EVENT; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 27
+      "duration_ms": 42
     },
     {
       "ecc_id": "ECC-VAL-031",
@@ -3816,7 +3820,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "RM 1.2.0 ehr §EVENT; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 15
+      "duration_ms": 20
     },
     {
       "ecc_id": "ECC-VAL-032",
@@ -3833,7 +3837,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 ehr §EVENT; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 28
+      "duration_ms": 39
     },
     {
       "ecc_id": "ECC-VAL-033",
@@ -3850,7 +3854,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 ehr §EVENT; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 31
+      "duration_ms": 41
     },
     {
       "ecc_id": "ECC-VAL-034",
@@ -3867,7 +3871,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 ehr §ITEM_STRUCTURE; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 53
+      "duration_ms": 59
     },
     {
       "ecc_id": "ECC-VAL-035",
@@ -3884,7 +3888,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 ehr §ITEM_STRUCTURE; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 37
+      "duration_ms": 56
     },
     {
       "ecc_id": "ECC-VAL-036",
@@ -3901,7 +3905,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 ehr §ITEM_STRUCTURE; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 37
+      "duration_ms": 61
     },
     {
       "ecc_id": "ECC-VAL-037",
@@ -3918,7 +3922,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 ehr §ITEM_STRUCTURE; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 36
+      "duration_ms": 72
     },
     {
       "ecc_id": "ECC-VAL-038",
@@ -3935,7 +3939,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 ehr §ITEM_STRUCTURE; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 40
+      "duration_ms": 75
     },
     {
       "ecc_id": "ECC-VAL-039",
@@ -3952,7 +3956,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_BOOLEAN; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 54
+      "duration_ms": 95
     },
     {
       "ecc_id": "ECC-VAL-040",
@@ -3969,7 +3973,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_BOOLEAN; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 56
+      "duration_ms": 104
     },
     {
       "ecc_id": "ECC-VAL-041",
@@ -3986,7 +3990,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_BOOLEAN; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 51
+      "duration_ms": 97
     },
     {
       "ecc_id": "ECC-VAL-042",
@@ -4003,7 +4007,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_IDENTIFIER; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 50
+      "duration_ms": 102
     },
     {
       "ecc_id": "ECC-VAL-043",
@@ -4020,7 +4024,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_IDENTIFIER; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 55
+      "duration_ms": 92
     },
     {
       "ecc_id": "ECC-VAL-044",
@@ -4037,7 +4041,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_TEXT; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 43
+      "duration_ms": 86
     },
     {
       "ecc_id": "ECC-VAL-045",
@@ -4054,7 +4058,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_TEXT; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 57
+      "duration_ms": 72
     },
     {
       "ecc_id": "ECC-VAL-046",
@@ -4071,7 +4075,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_CODED_TEXT; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 44
+      "duration_ms": 63
     },
     {
       "ecc_id": "ECC-VAL-047",
@@ -4088,7 +4092,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_CODED_TEXT; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 55
+      "duration_ms": 64
     },
     {
       "ecc_id": "ECC-VAL-048",
@@ -4105,7 +4109,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_CODED_TEXT; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 53
+      "duration_ms": 70
     },
     {
       "ecc_id": "ECC-VAL-049",
@@ -4122,7 +4126,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_ORDINAL; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 45
+      "duration_ms": 63
     },
     {
       "ecc_id": "ECC-VAL-050",
@@ -4139,7 +4143,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_ORDINAL; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 51
+      "duration_ms": 61
     },
     {
       "ecc_id": "ECC-VAL-051",
@@ -4156,7 +4160,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_SCALE; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 53
+      "duration_ms": 73
     },
     {
       "ecc_id": "ECC-VAL-052",
@@ -4173,7 +4177,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_SCALE; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 49
+      "duration_ms": 71
     },
     {
       "ecc_id": "ECC-VAL-053",
@@ -4190,7 +4194,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_COUNT; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 61
+      "duration_ms": 59
     },
     {
       "ecc_id": "ECC-VAL-054",
@@ -4207,7 +4211,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_COUNT; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 52
+      "duration_ms": 74
     },
     {
       "ecc_id": "ECC-VAL-055",
@@ -4224,7 +4228,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_COUNT; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 50
+      "duration_ms": 80
     },
     {
       "ecc_id": "ECC-VAL-056",
@@ -4241,7 +4245,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_QUANTITY; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 43
+      "duration_ms": 61
     },
     {
       "ecc_id": "ECC-VAL-057",
@@ -4258,7 +4262,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_QUANTITY; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 52
+      "duration_ms": 66
     },
     {
       "ecc_id": "ECC-VAL-058",
@@ -4292,7 +4296,7 @@
       "total_data_sets": 3,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_QUANTITY; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 49
+      "duration_ms": 76
     },
     {
       "ecc_id": "ECC-VAL-060",
@@ -4309,7 +4313,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_PROPORTION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 48
+      "duration_ms": 58
     },
     {
       "ecc_id": "ECC-VAL-061",
@@ -4326,7 +4330,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_PROPORTION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 63
+      "duration_ms": 66
     },
     {
       "ecc_id": "ECC-VAL-062",
@@ -4343,7 +4347,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_PROPORTION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 51
+      "duration_ms": 68
     },
     {
       "ecc_id": "ECC-VAL-063",
@@ -4360,7 +4364,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_PROPORTION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 52
+      "duration_ms": 67
     },
     {
       "ecc_id": "ECC-VAL-064",
@@ -4377,7 +4381,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_PROPORTION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 52
+      "duration_ms": 75
     },
     {
       "ecc_id": "ECC-VAL-065",
@@ -4394,7 +4398,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_PROPORTION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 54
+      "duration_ms": 73
     },
     {
       "ecc_id": "ECC-VAL-066",
@@ -4411,7 +4415,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_PROPORTION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 38
+      "duration_ms": 46
     },
     {
       "ecc_id": "ECC-VAL-067",
@@ -4428,7 +4432,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_PROPORTION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 52
+      "duration_ms": 72
     },
     {
       "ecc_id": "ECC-VAL-068",
@@ -4445,7 +4449,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_COUNT>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 59
+      "duration_ms": 70
     },
     {
       "ecc_id": "ECC-VAL-069",
@@ -4462,7 +4466,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_COUNT>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 59
+      "duration_ms": 94
     },
     {
       "ecc_id": "ECC-VAL-070",
@@ -4479,7 +4483,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_COUNT>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 54
+      "duration_ms": 69
     },
     {
       "ecc_id": "ECC-VAL-071",
@@ -4496,7 +4500,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_QUANTITY>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 56
+      "duration_ms": 69
     },
     {
       "ecc_id": "ECC-VAL-072",
@@ -4513,7 +4517,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_QUANTITY>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 50
+      "duration_ms": 69
     },
     {
       "ecc_id": "ECC-VAL-073",
@@ -4530,7 +4534,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DATE_TIME>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 50
+      "duration_ms": 73
     },
     {
       "ecc_id": "ECC-VAL-074",
@@ -4547,7 +4551,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DATE_TIME>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 51
+      "duration_ms": 69
     },
     {
       "ecc_id": "ECC-VAL-075",
@@ -4564,7 +4568,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DATE_TIME>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 53
+      "duration_ms": 68
     },
     {
       "ecc_id": "ECC-VAL-076",
@@ -4581,7 +4585,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DATE>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 50
+      "duration_ms": 66
     },
     {
       "ecc_id": "ECC-VAL-077",
@@ -4598,7 +4602,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DATE>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 53
+      "duration_ms": 73
     },
     {
       "ecc_id": "ECC-VAL-078",
@@ -4615,7 +4619,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DATE>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 57
+      "duration_ms": 106
     },
     {
       "ecc_id": "ECC-VAL-079",
@@ -4632,7 +4636,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_TIME>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 50
+      "duration_ms": 70
     },
     {
       "ecc_id": "ECC-VAL-080",
@@ -4649,7 +4653,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_TIME>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 51
+      "duration_ms": 72
     },
     {
       "ecc_id": "ECC-VAL-081",
@@ -4666,7 +4670,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_TIME>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 51
+      "duration_ms": 85
     },
     {
       "ecc_id": "ECC-VAL-082",
@@ -4683,7 +4687,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DURATION>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 50
+      "duration_ms": 77
     },
     {
       "ecc_id": "ECC-VAL-083",
@@ -4700,7 +4704,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DURATION>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 51
+      "duration_ms": 72
     },
     {
       "ecc_id": "ECC-VAL-084",
@@ -4717,7 +4721,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DURATION>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 54
+      "duration_ms": 71
     },
     {
       "ecc_id": "ECC-VAL-085",
@@ -4734,7 +4738,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_ORDINAL>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 54
+      "duration_ms": 75
     },
     {
       "ecc_id": "ECC-VAL-086",
@@ -4751,7 +4755,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_ORDINAL>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 53
+      "duration_ms": 73
     },
     {
       "ecc_id": "ECC-VAL-087",
@@ -4768,7 +4772,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_SCALE>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 53
+      "duration_ms": 76
     },
     {
       "ecc_id": "ECC-VAL-088",
@@ -4785,7 +4789,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_SCALE>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 51
+      "duration_ms": 66
     },
     {
       "ecc_id": "ECC-VAL-089",
@@ -4802,7 +4806,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 54
+      "duration_ms": 81
     },
     {
       "ecc_id": "ECC-VAL-090",
@@ -4819,7 +4823,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 51
+      "duration_ms": 72
     },
     {
       "ecc_id": "ECC-VAL-091",
@@ -4836,7 +4840,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 50
+      "duration_ms": 72
     },
     {
       "ecc_id": "ECC-VAL-092",
@@ -4853,7 +4857,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 51
+      "duration_ms": 88
     },
     {
       "ecc_id": "ECC-VAL-093",
@@ -4870,7 +4874,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 51
+      "duration_ms": 77
     },
     {
       "ecc_id": "ECC-VAL-094",
@@ -4887,7 +4891,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 50
+      "duration_ms": 74
     },
     {
       "ecc_id": "ECC-VAL-095",
@@ -4904,7 +4908,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 52
+      "duration_ms": 117
     },
     {
       "ecc_id": "ECC-VAL-096",
@@ -4921,7 +4925,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_DURATION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 47
+      "duration_ms": 108
     },
     {
       "ecc_id": "ECC-VAL-097",
@@ -4938,7 +4942,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_DURATION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 62
+      "duration_ms": 112
     },
     {
       "ecc_id": "ECC-VAL-098",
@@ -4955,7 +4959,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_DURATION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 61
+      "duration_ms": 72
     },
     {
       "ecc_id": "ECC-VAL-099",
@@ -4972,7 +4976,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_DURATION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 51
+      "duration_ms": 70
     },
     {
       "ecc_id": "ECC-VAL-100",
@@ -4989,7 +4993,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_TIME; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 43
+      "duration_ms": 59
     },
     {
       "ecc_id": "ECC-VAL-101",
@@ -5006,7 +5010,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_TIME; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 51
+      "duration_ms": 68
     },
     {
       "ecc_id": "ECC-VAL-102",
@@ -5023,7 +5027,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_TIME; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 49
+      "duration_ms": 65
     },
     {
       "ecc_id": "ECC-VAL-103",
@@ -5040,7 +5044,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_DATE; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 43
+      "duration_ms": 57
     },
     {
       "ecc_id": "ECC-VAL-104",
@@ -5057,7 +5061,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_DATE; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 54
+      "duration_ms": 77
     },
     {
       "ecc_id": "ECC-VAL-105",
@@ -5074,7 +5078,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_DATE; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 52
+      "duration_ms": 68
     },
     {
       "ecc_id": "ECC-VAL-119",
@@ -5091,7 +5095,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "AM 1.4 C_DATE (yyyy-??-XX: month optional, day disallowed; org.openehr.am.aom14.c_date.adoc); valid_templates/all_types/Test_all_types.opt; ITS-REST 1.0.3 composition_create (422 rejected)",
-      "duration_ms": 25
+      "duration_ms": 27
     },
     {
       "ecc_id": "ECC-VAL-106",
@@ -5108,7 +5112,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_DATE_TIME; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 41
+      "duration_ms": 60
     },
     {
       "ecc_id": "ECC-VAL-107",
@@ -5125,7 +5129,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_DATE_TIME; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 43
+      "duration_ms": 63
     },
     {
       "ecc_id": "ECC-VAL-108",
@@ -5142,7 +5146,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_DATE_TIME; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 51
+      "duration_ms": 93
     },
     {
       "ecc_id": "ECC-VAL-109",
@@ -5159,7 +5163,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_PARSABLE; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 44
+      "duration_ms": 143
     },
     {
       "ecc_id": "ECC-VAL-110",
@@ -5176,7 +5180,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_PARSABLE; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 51
+      "duration_ms": 124
     },
     {
       "ecc_id": "ECC-VAL-111",
@@ -5193,7 +5197,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_MULTIMEDIA; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 45
+      "duration_ms": 71
     },
     {
       "ecc_id": "ECC-VAL-112",
@@ -5210,7 +5214,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_MULTIMEDIA; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 49
+      "duration_ms": 71
     },
     {
       "ecc_id": "ECC-VAL-113",
@@ -5227,7 +5231,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_URI; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 43
+      "duration_ms": 59
     },
     {
       "ecc_id": "ECC-VAL-114",
@@ -5244,7 +5248,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_URI; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 54
+      "duration_ms": 77
     },
     {
       "ecc_id": "ECC-VAL-115",
@@ -5261,7 +5265,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_URI; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 56
+      "duration_ms": 81
     },
     {
       "ecc_id": "ECC-VAL-116",
@@ -5278,7 +5282,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_EHR_URI; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 49
+      "duration_ms": 79
     },
     {
       "ecc_id": "ECC-VAL-117",
@@ -5295,7 +5299,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_EHR_URI; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 51
+      "duration_ms": 75
     },
     {
       "ecc_id": "ECC-VAL-118",
@@ -5312,7 +5316,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "RM 1.2.0 data_types §DV_EHR_URI; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
-      "duration_ms": 51
+      "duration_ms": 105
     },
     {
       "ecc_id": "ECC-SIG-001",
@@ -5328,7 +5332,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "version-signing.md §3.2 (digest default-on); §4.4 (rides every VERSION read)",
-      "duration_ms": 21
+      "duration_ms": 32
     },
     {
       "ecc_id": "ECC-SIG-001",
@@ -5344,7 +5348,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "version-signing.md §3.2 (digest default-on); §4.4 (rides every VERSION read)",
-      "duration_ms": 23
+      "duration_ms": 36
     },
     {
       "ecc_id": "ECC-SIG-002",
@@ -5360,7 +5364,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "version-signing.md §3.1 (canonical_form RFC 8785) + §6.3",
-      "duration_ms": 21
+      "duration_ms": 32
     },
     {
       "ecc_id": "ECC-SIG-003",
@@ -5376,7 +5380,7 @@
       "total_data_sets": 4,
       "message": null,
       "citation": "version-signing.md §3.3 (all object kinds via the shared vobject commit path)",
-      "duration_ms": 54
+      "duration_ms": 82
     },
     {
       "ecc_id": "ECC-SIG-004",
@@ -5392,7 +5396,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "version-signing.md §3.3 (client-supplied signatures win, stored verbatim)",
-      "duration_ms": 19
+      "duration_ms": 27
     },
     {
       "ecc_id": "ECC-SIG-005",
@@ -5594,7 +5598,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query",
-      "duration_ms": 10
+      "duration_ms": 14
     },
     {
       "ecc_id": "ECC-TS-002",
@@ -5610,7 +5614,7 @@
       "total_data_sets": 2,
       "message": null,
       "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query",
-      "duration_ms": 28
+      "duration_ms": 43
     },
     {
       "ecc_id": "ECC-TS-003",
@@ -5626,7 +5630,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query",
-      "duration_ms": 21
+      "duration_ms": 30
     },
     {
       "ecc_id": "ECC-TS-004",
@@ -5642,7 +5646,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query",
-      "duration_ms": 3
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-TS-005",
@@ -5658,7 +5662,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query",
-      "duration_ms": 3
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-TS-006",
@@ -5672,9 +5676,9 @@
       "status": "skipped",
       "passed_data_sets": 0,
       "total_data_sets": 0,
-      "message": "SutConfig: no FHIR terminology provider configured on the SUT (EHRBASE_VALIDATION_EXTERNAL_TERMINOLOGY_* unset) — a `hl7.org/fhir/4.0` expand is rejected as `UnknownTerminologyService`. harness terminology server: http://127.0.0.1:61365 (fixture). The bundle (`openehr`) expand cases prove the TERMINOLOGY family; wire this by pointing the SUT at a FHIR server (host.docker.internal for a runner-host fixture, docs/design/terminology-server-integration.md §5).",
+      "message": "SutConfig: no FHIR terminology provider configured on the SUT (EHRBASE_VALIDATION_EXTERNAL_TERMINOLOGY_* unset) — a `hl7.org/fhir/4.0` expand is rejected as `UnknownTerminologyService`. harness terminology server: http://127.0.0.1:64681 (fixture). The bundle (`openehr`) expand cases prove the TERMINOLOGY family; wire this by pointing the SUT at a FHIR server (host.docker.internal for a runner-host fixture, docs/design/terminology-server-integration.md §5).",
       "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query",
-      "duration_ms": 3
+      "duration_ms": 5
     },
     {
       "ecc_id": "ECC-TS-007",
@@ -5688,7 +5692,7 @@
       "status": "skipped",
       "passed_data_sets": 0,
       "total_data_sets": 0,
-      "message": "SutConfig: the timeout fault requires a fault-injecting terminology server wired to the SUT (--tx-server-url + an SUT FHIR provider pointed at it); the HTTP-only ECC cannot reconfigure an external SUT's provider per case. Harness tx server: http://127.0.0.1:61365 (fixture). The fault→500 mapping is proven by conformance ts::fixture::tests::fault_timeout_exceeds_a_short_client_deadline + app/ehrbase/tests/terminology_fhir.rs::timeout_is_an_exception.",
+      "message": "SutConfig: the timeout fault requires a fault-injecting terminology server wired to the SUT (--tx-server-url + an SUT FHIR provider pointed at it); the HTTP-only ECC cannot reconfigure an external SUT's provider per case. Harness tx server: http://127.0.0.1:64681 (fixture). The fault→500 mapping is proven by conformance ts::fixture::tests::fault_timeout_exceeds_a_short_client_deadline + app/ehrbase/tests/terminology_fhir.rs::timeout_is_an_exception.",
       "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query",
       "duration_ms": 0
     },
@@ -5704,7 +5708,7 @@
       "status": "skipped",
       "passed_data_sets": 0,
       "total_data_sets": 0,
-      "message": "SutConfig: the 5xx fault requires a fault-injecting terminology server wired to the SUT (--tx-server-url + an SUT FHIR provider pointed at it); the HTTP-only ECC cannot reconfigure an external SUT's provider per case. Harness tx server: http://127.0.0.1:61365 (fixture). The fault→500 mapping is proven by conformance ts::fixture::tests::fault_server_error_is_5xx + app/ehrbase/tests/terminology_fhir.rs::server_5xx_is_an_exception.",
+      "message": "SutConfig: the 5xx fault requires a fault-injecting terminology server wired to the SUT (--tx-server-url + an SUT FHIR provider pointed at it); the HTTP-only ECC cannot reconfigure an external SUT's provider per case. Harness tx server: http://127.0.0.1:64681 (fixture). The fault→500 mapping is proven by conformance ts::fixture::tests::fault_server_error_is_5xx + app/ehrbase/tests/terminology_fhir.rs::server_5xx_is_an_exception.",
       "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query",
       "duration_ms": 0
     },
@@ -5720,7 +5724,7 @@
       "status": "skipped",
       "passed_data_sets": 0,
       "total_data_sets": 0,
-      "message": "SutConfig: the malformed fault requires a fault-injecting terminology server wired to the SUT (--tx-server-url + an SUT FHIR provider pointed at it); the HTTP-only ECC cannot reconfigure an external SUT's provider per case. Harness tx server: http://127.0.0.1:61365 (fixture). The fault→500 mapping is proven by conformance ts::fixture::tests::fault_malformed_is_not_json + app/ehrbase/tests/terminology_fhir.rs::malformed_body_is_an_exception.",
+      "message": "SutConfig: the malformed fault requires a fault-injecting terminology server wired to the SUT (--tx-server-url + an SUT FHIR provider pointed at it); the HTTP-only ECC cannot reconfigure an external SUT's provider per case. Harness tx server: http://127.0.0.1:64681 (fixture). The fault→500 mapping is proven by conformance ts::fixture::tests::fault_malformed_is_not_json + app/ehrbase/tests/terminology_fhir.rs::malformed_body_is_an_exception.",
       "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query",
       "duration_ms": 0
     },
@@ -5751,7 +5755,7 @@
       "total_data_sets": 1,
       "message": null,
       "citation": "CNF SECURITY_TESTS/I_OAuth2_Keycloak (role-privileged access intent); ITS-REST ADMIN API §delete EHR — ADMIN-role-only (SM I_ADMIN_SERVICE)",
-      "duration_ms": 3
+      "duration_ms": 4
     }
   ]
 }

--- a/docs/plans/x1-comparison.md
+++ b/docs/plans/x1-comparison.md
@@ -440,16 +440,28 @@ filed upstream — not worked around).
 
 ## Tasks
 
-- [ ] **X1.1 ECC upstream-SUT mode + adjudication register.**
-  - [ ] `SutIdentity.product {name, version, image_digest}` + CLI flags;
+- [x] **X1.1 ECC upstream-SUT mode + adjudication register.** *(2026-07-11:
+  `SutIdentity.product{name,version,image_digest}` + `--sut-*` flags (default
+  `ehrbase-rs @ <workspace ver>`); `CaseStatus::NotApplicable` excluded from
+  pass/fail + capability math with its own report section + N/A columns;
+  `AdjudicationRegister` TOML loader (`extension`/`rm-version-sensitive` →
+  N/A, `defect` stays a failure) applied at the `engine/run.rs` executor seam
+  **only for non-ehrbase-rs SUTs**; Statement+Certificate suppressed (log
+  line) for non-self SUTs and their Solution/Vendor de-hard-coded;
+  `--admin-base-url` routes `/admin/*` to a sibling mount via
+  `SutClient::with_admin_base_url` (no case edits); seed register
+  `adjudications/ehrbase-java-2.34.toml` (DEM/SIG extensions, cited) + README.
+  67/67 nextest, conformance clippy-clean, no-register ehrbase-rs run is
+  zero-drift bar the new `product` field.)*
+  - [x] `SutIdentity.product {name, version, image_digest}` + CLI flags;
         threaded through report/statement; Certificate/Statement emitted
-        only for ehrbase-rs SUTs (`statement.rs:138-142` de-hard-coded).
-  - [ ] `CaseStatus::NotApplicable` (excluded from pass/fail + capability
+        only for ehrbase-rs SUTs (`statement.rs` de-hard-coded).
+  - [x] `CaseStatus::NotApplicable` (excluded from pass/fail + capability
         math, own report section).
-  - [ ] `--adjudications <file>` TOML register + loader, hooked in
-        `engine/run.rs:76-120`; dispositions `extension` /
+  - [x] `--adjudications <file>` TOML register + loader, hooked in
+        `engine/run.rs`; dispositions `extension` /
         `rm-version-sensitive` / `defect` per §3a.4, every entry cited.
-  - [ ] `--admin-base-url` for sibling-mounted admin APIs (`suites/admin.rs`
+  - [x] `--admin-base-url` for sibling-mounted admin APIs (`suites/admin.rs`
         + `security.rs:120`).
   - **Acceptance:** nextest + clippy green; a no-register ehrbase-rs run
     reproduces the standing baseline with **zero drift** (only the new

--- a/tools/conformance/Cargo.toml
+++ b/tools/conformance/Cargo.toml
@@ -26,6 +26,11 @@ reqwest = { workspace = true }
 # dev/verification crate (publish = false), not part of the shipped app.
 wiremock = { workspace = true }
 clap = { workspace = true }
+# The upstream fairness adjudication register (X1) is a committed TOML file
+# loaded at run time for non-ehrbase-rs SUTs; it only reclassifies cases
+# (extension / rm-version-sensitive → NotApplicable, defect → stays a failure),
+# never edits one.
+toml = { workspace = true }
 jiff = { workspace = true }
 tokio = { workspace = true }
 uuid = { workspace = true }

--- a/tools/conformance/adjudications/README.md
+++ b/tools/conformance/adjudications/README.md
@@ -1,0 +1,68 @@
+# ECC upstream fairness adjudication registers
+
+These committed TOML files (`<sut>.toml`) let the ECC runner report a fair
+verdict for a **non-`ehrbase-rs`** SUT. The ECC catalogue is *our own*
+instrument, authored against the pinned specs (RM 1.2.0, ITS-REST
+development@e8a093e) with adjudicated skips for *our* server; running it
+unmodified against another product would unfairly fail it on version skew and
+on our own extensions. A register **only reclassifies with a citation — it
+never edits, weakens, or skips a case** (honesty rule 10 / standing rule 3).
+
+A register is loaded with `--adjudications <file>` and applied **only** when the
+SUT product is not `ehrbase-rs` (set with `--sut-name`). For an `ehrbase-rs`
+SUT the register is ignored, so our own conformance baseline is never touched
+(the zero-drift gate). Running with no register is today's behaviour,
+byte-for-byte.
+
+## Dispositions
+
+| Disposition | Effect | When |
+|---|---|---|
+| `extension` | case → **NotApplicable** (excluded from pass/fail + capability math) | the case exercises an `ehrbase-rs` extension the SUT does not implement (demographic REST API, version signing, our TERMINOLOGY() AQL family, `/terminology`) |
+| `rm-version-sensitive` | case → **NotApplicable** | the request payload or response comparison depends on RM 1.2.0 shapes the SUT's older RM/ITS surface cannot be expected to produce |
+| `defect` | case **runs**; its natural outcome (a failure) **stands** | a genuine spec gap that survived triage — reported plainly with the spec citation |
+
+Every entry carries a **non-empty `reason` and `citation`** — the loader
+rejects a register that omits either.
+
+## File format
+
+```toml
+[meta]
+sut = "ehrbase-java"            # informational; the authoritative product identity is in results.json
+version = "2.34.0"
+description = "one line"
+
+# Area-wide rule: every case in the ECC area gets this disposition.
+# `area` is the ECC area tag (uppercase): EHR STA COM CTB DIR TPL SQR QRY VAL
+#   REST DEM ADM SEC SIG MSG TS  (see `catalog::Area::tag`).
+[[area]]
+area = "DEM"
+disposition = "extension"
+reason = "why this reclassification is fair"
+citation = "docs/…#… (a spec/research citation)"
+
+# Per-case rule (keyed by ECC id) — wins over an area-wide rule for that case.
+[[case]]
+ecc_id = "ECC-QRY-014"
+disposition = "rm-version-sensitive"
+reason = "…"
+citation = "docs/VERSIONS.md §RM-version divergence"
+```
+
+## Populating a register (the X1.2 triage process)
+
+The register is grown from a **real triage run**, never guessed:
+
+1. Run ECC against the upstream SUT (`--sut-name`, `--admin-base-url`, no
+   register yet). Every failure is a candidate.
+2. Triage each failure into exactly one disposition with a citation, or fix a
+   genuine runner-tolerance bug (the register never routes around a runner
+   defect).
+3. Commit the register; the *second* run is the published one.
+
+`extension` entries for whole areas the SUT structurally lacks (e.g. upstream
+EHRbase has no demographic REST API, and version signing is an `ehrbase-rs`
+feature) are the only entries knowable **without** a run — they are seeded here.
+`rm-version-sensitive` and `defect` entries require the triage run and are added
+in X1.2.

--- a/tools/conformance/adjudications/ehrbase-java-2.34.toml
+++ b/tools/conformance/adjudications/ehrbase-java-2.34.toml
@@ -1,0 +1,43 @@
+# ECC upstream fairness adjudication register — EHRbase (Java) 2.34.0.
+#
+# Applied only for a non-ehrbase-rs SUT (`--sut-name ehrbase-java`); only
+# reclassifies cases, never edits one. See ./README.md for the format and the
+# X1.2 triage process.
+#
+# STATUS (X1.1): this file is SEEDED with the extension-by-construction area
+# rules that are knowable WITHOUT a run — live-verified structural facts about
+# upstream (§2c). The `rm-version-sensitive` and `defect` entries require the
+# X1.2 triage run against the live upstream server and are appended there;
+# until then the register is deliberately conservative (it never pre-emptively
+# excuses a failure it has not observed).
+
+[meta]
+sut = "ehrbase-java"
+version = "2.34.0"
+description = "Upstream fairness adjudication register for EHRbase (Java) 2.34.0 (seed: extensions only)."
+
+# ── Extensions (by construction — no run required) ───────────────────────────
+
+# Upstream EHRbase implements no demographic REST API; every DEM case (our own
+# wire design for I_DEMOGRAPHIC_SERVICE) would 404 against it. Not a failure —
+# a route upstream does not offer.
+[[area]]
+area = "DEM"
+disposition = "extension"
+reason = "Upstream EHRbase exposes no demographic REST API; the DEM cases exercise ehrbase-rs's own demographic wire."
+citation = "docs/plans/x1-comparison.md §2a/§2c (upstream has no demographic API); docs/architecture.md (RM demographic — own wire design)"
+
+# Version signing (VERSION.signature; sha256 over the canonical form) is an
+# ehrbase-rs feature, not an ITS-REST 1.0.x contract element. Upstream does not
+# sign versions, so the SIG cases do not apply.
+[[area]]
+area = "SIG"
+disposition = "extension"
+reason = "Version signing is an ehrbase-rs extension (VERSION.signature); it is not part of the ITS-REST contract upstream implements."
+citation = "docs/plans/x1-comparison.md §2a (Sig — version signing is ours); docs/design/version-signing.md"
+
+# NOTE (X1.2): TS openEHR-bundle cases assume our TERMINOLOGY('expand','openehr',…)
+# AQL feature and are candidate `extension` entries, but the TS area also holds
+# generic FHIR-tx cases — so TS is triaged per-case in X1.2, not blanket-ruled
+# here. `rm-version-sensitive` (archie 3.13.0 / ITS-REST 1.0.2 wire skew) and
+# `defect` entries (e.g. ALL_VERSIONS rejection) are added from the triage run.

--- a/tools/conformance/src/bin/conformance.rs
+++ b/tools/conformance/src/bin/conformance.rs
@@ -3,9 +3,16 @@
 //! ```text
 //! conformance run   --base-url URL [--filter S] [--profile core|standard|options]
 //!                   [--format json|xml|both] [--out DIR] [--auth SPEC] [--admin-auth SPEC]
+//!                   [--admin-base-url URL] [--sut-name NAME] [--sut-version VER]
+//!                   [--sut-image-digest DIGEST] [--adjudications FILE]
 //! conformance list  [--filter S]
 //! conformance report --from results.json [--out DIR]
 //! ```
+//!
+//! An upstream (non-`ehrbase-rs`) run adds `--sut-name`/`--sut-version`/
+//! `--sut-image-digest` (recorded in the identity), `--admin-base-url` (the
+//! sibling admin mount), and `--adjudications <file>` (the committed fairness
+//! register). See `tools/conformance/adjudications/README.md`.
 //!
 //! Exit codes: `0` all selected cases pass · `1` failures (report still written)
 //! · `2` runner/SUT error.
@@ -14,11 +21,12 @@ use std::path::PathBuf;
 
 use clap::{Parser, Subcommand, ValueEnum};
 
+use conformance::adjudication::AdjudicationRegister;
 use conformance::case::{Format, Profile};
 use conformance::catalog::{Area, Catalog};
 use conformance::client::Credential;
 use conformance::registry::registry;
-use conformance::results::TerminologyRun;
+use conformance::results::{ProductIdentity, TerminologyRun};
 use conformance::run::RunConfig;
 use conformance::sut::Sut;
 use conformance::ts::{FhirTxFixture, TxServer};
@@ -37,6 +45,10 @@ struct Cli {
 }
 
 #[derive(Debug, Subcommand)]
+// `RunArgs` is the large variant (a full CLI arg set); boxing it fights clap's
+// `Args`/`Subcommand` derive, and a CLI command enum is constructed once, so the
+// size asymmetry is irrelevant here.
+#[allow(clippy::large_enum_variant)]
 enum Command {
     /// Run the selected cases against a SUT and write the report set.
     Run(RunArgs),
@@ -70,6 +82,31 @@ struct RunArgs {
     /// ADMIN-role credential (same forms as `--auth`).
     #[arg(long)]
     admin_auth: Option<String>,
+    /// Sibling admin-API base URL for a SUT that does not nest admin under the
+    /// openEHR base (upstream `EHRbase` serves it at `.../ehrbase/rest/admin`).
+    /// When set, `/admin/*` cases route here; unset nests admin under
+    /// `--base-url` as our own server does.
+    #[arg(long)]
+    admin_base_url: Option<String>,
+    /// The product name recorded in the run identity (default `ehrbase-rs`).
+    /// Set to e.g. `ehrbase-java` for an upstream run — this also gates the
+    /// Statement/Certificate (emitted only for `ehrbase-rs`) and enables the
+    /// adjudication register.
+    #[arg(long)]
+    sut_name: Option<String>,
+    /// The product version recorded in the run identity (default: this
+    /// workspace's version).
+    #[arg(long)]
+    sut_version: Option<String>,
+    /// The container image digest (`sha256:…`) recorded in the run identity.
+    #[arg(long)]
+    sut_image_digest: Option<String>,
+    /// The upstream fairness adjudication register (TOML) applied for a
+    /// non-`ehrbase-rs` SUT: `extension` / `rm-version-sensitive` entries report
+    /// as `NotApplicable`, `defect` entries stay failures. Ignored (with a log
+    /// line) for an `ehrbase-rs` SUT — our baseline is never touched.
+    #[arg(long)]
+    adjudications: Option<PathBuf>,
     /// Real FHIR R4 terminology-server base URL for the `TS` cases, e.g.
     /// `http://localhost:8090/fhir` (a HAPI/Snowstorm/Ontoserver container).
     /// When unset the runner spins up a hermetic `wiremock` FHIR-tx fixture for
@@ -157,7 +194,8 @@ fn build_sut(args: &RunArgs) -> Result<(Sut, String), String> {
         .as_deref()
         .and_then(|s| s.split_once(':').map(|(scheme, _)| scheme.to_owned()))
         .unwrap_or_else(|| "none".to_owned());
-    let sut = Sut::external(base_url, regular, admin).map_err(|e| e.to_string())?;
+    let sut = Sut::external(base_url, regular, admin, args.admin_base_url.clone())
+        .map_err(|e| e.to_string())?;
     Ok((sut, auth_mode))
 }
 
@@ -203,12 +241,49 @@ async fn cmd_run(args: RunArgs) -> i32 {
         }
     };
     let (tx, fixture) = establish_tx(&args).await;
+    let product = ProductIdentity {
+        name: args
+            .sut_name
+            .clone()
+            .unwrap_or_else(|| ProductIdentity::EHRBASE_RS.to_owned()),
+        version: args
+            .sut_version
+            .clone()
+            .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_owned()),
+        image_digest: args.sut_image_digest.clone(),
+    };
+    let adjudications = match &args.adjudications {
+        Some(path) => match AdjudicationRegister::load(path) {
+            Ok(reg) => {
+                if product.is_ehrbase_rs() {
+                    eprintln!(
+                        "conformance: --adjudications given but the SUT product is ehrbase-rs — \
+                         the register is ignored (our baseline is never reclassified, §3a.4)"
+                    );
+                } else {
+                    println!(
+                        "conformance: loaded adjudication register {} ({} rule(s))",
+                        path.display(),
+                        reg.len()
+                    );
+                }
+                Some(reg)
+            }
+            Err(e) => {
+                eprintln!("error loading adjudication register: {e}");
+                return 2;
+            }
+        },
+        None => None,
+    };
     let config = RunConfig {
         filter: args.filter.clone(),
         profile: args.profile.map(Profile::from),
         formats: args.format.formats(),
+        product,
         versions: SpecVersions::latest(),
         auth_mode,
+        adjudications,
         tx: tx.clone(),
     };
     let mut results = match run::run(sut.transport(), &config).await {

--- a/tools/conformance/src/engine/client.rs
+++ b/tools/conformance/src/engine/client.rs
@@ -51,6 +51,13 @@ pub struct SutClient {
     http: reqwest::Client,
     /// The ITS-REST base URL, e.g. `http://host:8080/ehrbase/rest/openehr/v1`.
     base_url: String,
+    /// An optional **sibling** base URL for the admin API, e.g.
+    /// `http://host:8091/ehrbase/rest/admin`. When set, a request whose path
+    /// starts with `/admin` is routed here (with the `/admin` prefix stripped)
+    /// instead of nested under `base_url`. Upstream `EHRbase` serves admin at a
+    /// sibling mount of `/rest/openehr`; our own server nests it under the
+    /// openEHR base, so this stays `None` for our runs (§3a.5) — zero drift.
+    admin_base_url: Option<String>,
     regular: Option<Credential>,
     admin: Option<Credential>,
 }
@@ -73,9 +80,32 @@ impl SutClient {
         Ok(Self {
             http,
             base_url,
+            admin_base_url: None,
             regular,
             admin,
         })
+    }
+
+    /// Route `/admin/*` requests to a sibling admin base URL (trailing slash
+    /// trimmed) instead of nesting them under [`base_url`](Self::base_url).
+    /// `None` (the default) keeps every request nested under the openEHR base —
+    /// the behaviour of every existing run (§3a.5).
+    #[must_use]
+    pub fn with_admin_base_url(mut self, admin_base_url: Option<String>) -> Self {
+        self.admin_base_url = admin_base_url.map(|u| u.trim_end_matches('/').to_owned());
+        self
+    }
+
+    /// Resolve a request path to a full URL. A path under `/admin` goes to the
+    /// sibling admin base when one is configured (the `/admin` prefix stripped),
+    /// else everything nests under `base_url`.
+    fn resolve_url(&self, path: &str) -> String {
+        if let Some(admin) = &self.admin_base_url
+            && let Some(rest) = path.strip_prefix("/admin")
+        {
+            return format!("{admin}{rest}");
+        }
+        format!("{}{}", self.base_url, path)
     }
 
     fn credential(&self, slot: AuthSlot) -> Option<&Credential> {
@@ -101,7 +131,7 @@ fn reqwest_method(method: Method) -> reqwest::Method {
 #[async_trait]
 impl Transport for SutClient {
     async fn send(&self, request: HttpRequest) -> Result<HttpResponse, TransportError> {
-        let url = format!("{}{}", self.base_url, request.path);
+        let url = self.resolve_url(&request.path);
         let mut builder = self.http.request(reqwest_method(request.method), &url);
         for (name, value) in &request.headers {
             builder = builder.header(name, value);
@@ -172,5 +202,40 @@ mod tests {
     fn trims_trailing_slash_in_base_url() {
         let c = SutClient::new("http://host/rest/", None, None).expect("client");
         assert_eq!(c.describe(), "http://host/rest");
+    }
+
+    #[test]
+    fn default_nests_admin_under_the_base() {
+        let c =
+            SutClient::new("http://host:8080/ehrbase/rest/openehr/v1", None, None).expect("client");
+        assert_eq!(
+            c.resolve_url("/admin/ehr/abc"),
+            "http://host:8080/ehrbase/rest/openehr/v1/admin/ehr/abc"
+        );
+        assert_eq!(
+            c.resolve_url("/ehr/abc"),
+            "http://host:8080/ehrbase/rest/openehr/v1/ehr/abc"
+        );
+    }
+
+    #[test]
+    fn admin_base_url_routes_admin_paths_to_the_sibling_mount() {
+        let c = SutClient::new("http://host:8091/ehrbase/rest/openehr/v1", None, None)
+            .expect("client")
+            .with_admin_base_url(Some("http://host:8091/ehrbase/rest/admin/".to_owned()));
+        // `/admin/ehr/abc` → the sibling admin mount, `/admin` prefix stripped.
+        assert_eq!(
+            c.resolve_url("/admin/ehr/abc"),
+            "http://host:8091/ehrbase/rest/admin/ehr/abc"
+        );
+        assert_eq!(
+            c.resolve_url("/admin/ehr/all?ehr_id=a&ehr_id=b"),
+            "http://host:8091/ehrbase/rest/admin/ehr/all?ehr_id=a&ehr_id=b"
+        );
+        // Non-admin paths still nest under the openEHR base.
+        assert_eq!(
+            c.resolve_url("/ehr/abc"),
+            "http://host:8091/ehrbase/rest/openehr/v1/ehr/abc"
+        );
     }
 }

--- a/tools/conformance/src/engine/run.rs
+++ b/tools/conformance/src/engine/run.rs
@@ -4,10 +4,13 @@
 
 use std::time::Instant;
 
+use crate::adjudication::AdjudicationRegister;
 use crate::case::{Format, Profile};
 use crate::harness::{CaseError, RunContext, Transport};
 use crate::registry::registry;
-use crate::results::{CaseOutcome, CaseStatus, CorpusPin, RunResults, SelectionInfo, SutIdentity};
+use crate::results::{
+    CaseOutcome, CaseStatus, CorpusPin, ProductIdentity, RunResults, SelectionInfo, SutIdentity,
+};
 use crate::version::SpecVersions;
 
 /// Errors raised while setting up a run (before any case executes).
@@ -27,11 +30,19 @@ pub struct RunConfig {
     pub profile: Option<Profile>,
     /// The formats to run (intersected per-case with the case's own formats).
     pub formats: Vec<Format>,
+    /// The product under test (recorded in the identity, §3a.1). Defaults to
+    /// `ehrbase-rs @ <workspace version>` so existing runs are unchanged.
+    pub product: ProductIdentity,
     /// The declared specification versions (recorded in the statement).
     /// Only [`SpecVersions::latest`] is supported today.
     pub versions: SpecVersions,
     /// The declared auth mode (recorded in the statement).
     pub auth_mode: String,
+    /// The upstream fairness adjudication register (§3a.4), applied **only** for
+    /// non-`ehrbase-rs` SUTs. `None` (the default, and every `ehrbase-rs` run)
+    /// means today's behaviour, byte-for-byte — the zero-drift gate on our own
+    /// baseline.
+    pub adjudications: Option<AdjudicationRegister>,
     /// The terminology server the run has available (B4 `TS` area): the
     /// spun-up `wiremock` fixture (CI default) or a real server
     /// (`--tx-server-url`). `None` when no terminology server was established —
@@ -45,8 +56,10 @@ impl Default for RunConfig {
             filter: None,
             profile: None,
             formats: vec![Format::Json],
+            product: ProductIdentity::default(),
             versions: SpecVersions::latest(),
             auth_mode: "unknown".to_owned(),
+            adjudications: None,
             tx: None,
         }
     }
@@ -71,6 +84,15 @@ pub async fn run(transport: &dyn Transport, config: &RunConfig) -> Result<RunRes
     // The ECC catalogue: every outcome carries our own case number.
     let catalog = crate::catalog::Catalog::load_default()?;
 
+    // The upstream fairness adjudication register (§3a.4) is consulted **only**
+    // for a non-`ehrbase-rs` SUT: our own product's verdict is never touched by
+    // a register, guaranteeing the zero-drift baseline regardless of flags.
+    let adjudications = if config.product.is_ehrbase_rs() {
+        None
+    } else {
+        config.adjudications.as_ref()
+    };
+
     // Execute the registered, selected cases.
     let mut cases = Vec::new();
     for entry in reg.entries() {
@@ -78,31 +100,60 @@ pub async fn run(transport: &dyn Transport, config: &RunConfig) -> Result<RunRes
         if !config.selects_id(meta.id) || !config.selects_profile(meta.profiles) {
             continue;
         }
+        let ecc_id = catalog
+            .by_primary_ref(meta.id)
+            .map(|e| e.ecc_id.clone())
+            .unwrap_or_default();
+        // An `extension` / `rm-version-sensitive` adjudication short-circuits the
+        // case to NotApplicable (never executed — running an extension route
+        // against a SUT that lacks it would only 404). A `defect` adjudication
+        // reclassifies nothing at runtime: the case runs and its failure stands.
+        let na = adjudications
+            .and_then(|r| r.lookup(&ecc_id, meta.area.tag()))
+            .filter(|adj| adj.disposition.is_not_applicable());
+
         for &format in &config.formats {
             if !meta.formats.contains(&format) {
                 continue;
             }
-            let ctx = RunContext {
-                transport,
-                format,
-                tx: config.tx.as_ref(),
-            };
-            let start = Instant::now();
-            let result = (entry.run)(&ctx).await;
-            let duration_ms = start.elapsed().as_millis();
-            let (status, passed_data_sets, total_data_sets, message) = match result {
-                Ok(report) => (CaseStatus::Passed, report.passed, report.total, None),
-                Err(CaseError::Assertion(msg)) => (CaseStatus::Failed, 0, 0, Some(msg)),
-                Err(CaseError::Skipped(msg)) => (CaseStatus::Skipped, 0, 0, Some(msg)),
-                Err(e @ (CaseError::Transport(_) | CaseError::Codec(_))) => {
-                    (CaseStatus::Errored, 0, 0, Some(e.to_string()))
-                }
-            };
+            let (status, passed_data_sets, total_data_sets, message, citation, duration_ms) =
+                if let Some(adj) = na {
+                    (
+                        CaseStatus::NotApplicable,
+                        0,
+                        0,
+                        Some(adj.reason.clone()),
+                        adj.citation.clone(),
+                        0,
+                    )
+                } else {
+                    let ctx = RunContext {
+                        transport,
+                        format,
+                        tx: config.tx.as_ref(),
+                    };
+                    let start = Instant::now();
+                    let result = (entry.run)(&ctx).await;
+                    let duration_ms = start.elapsed().as_millis();
+                    let (status, passed, total, message) = match result {
+                        Ok(report) => (CaseStatus::Passed, report.passed, report.total, None),
+                        Err(CaseError::Assertion(msg)) => (CaseStatus::Failed, 0, 0, Some(msg)),
+                        Err(CaseError::Skipped(msg)) => (CaseStatus::Skipped, 0, 0, Some(msg)),
+                        Err(e @ (CaseError::Transport(_) | CaseError::Codec(_))) => {
+                            (CaseStatus::Errored, 0, 0, Some(e.to_string()))
+                        }
+                    };
+                    (
+                        status,
+                        passed,
+                        total,
+                        message,
+                        meta.citation.to_owned(),
+                        duration_ms,
+                    )
+                };
             cases.push(CaseOutcome {
-                ecc_id: catalog
-                    .by_primary_ref(meta.id)
-                    .map(|e| e.ecc_id.clone())
-                    .unwrap_or_default(),
+                ecc_id: ecc_id.clone(),
                 id: meta.id.to_owned(),
                 title: meta.title.to_owned(),
                 capability: format!("{:?}", meta.capability),
@@ -112,7 +163,7 @@ pub async fn run(transport: &dyn Transport, config: &RunConfig) -> Result<RunRes
                 passed_data_sets,
                 total_data_sets,
                 message,
-                citation: meta.citation.to_owned(),
+                citation,
                 schedule_ref: meta.schedule_ref.map(str::to_owned),
                 duration_ms,
             });
@@ -122,6 +173,7 @@ pub async fn run(transport: &dyn Transport, config: &RunConfig) -> Result<RunRes
     Ok(RunResults {
         sut: SutIdentity {
             base_url: transport.describe(),
+            product: config.product.clone(),
             versions: config.versions.clone(),
             auth_mode: config.auth_mode.clone(),
         },
@@ -141,4 +193,94 @@ pub async fn run(transport: &dyn Transport, config: &RunConfig) -> Result<RunRes
         terminology: None,
         cases,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adjudication::AdjudicationRegister;
+    use crate::harness::{HttpRequest, HttpResponse, TransportError};
+
+    /// A transport that answers every request with `404` — so any *executed*
+    /// case fails/errors, letting a test distinguish "ran" from "short-circuited
+    /// to `NotApplicable`".
+    struct NotFound;
+
+    #[async_trait::async_trait]
+    impl Transport for NotFound {
+        async fn send(&self, _request: HttpRequest) -> Result<HttpResponse, TransportError> {
+            Ok(HttpResponse {
+                status: 404,
+                headers: Vec::new(),
+                body: Vec::new(),
+            })
+        }
+        fn describe(&self) -> String {
+            "mock://not-found".to_owned()
+        }
+    }
+
+    const DEM_EXTENSION: &str = r#"
+[[area]]
+area = "DEM"
+disposition = "extension"
+reason = "Upstream EHRbase has no demographic REST API."
+citation = "docs/plans/x1-comparison.md §2c"
+"#;
+
+    fn dem_config(product: ProductIdentity) -> RunConfig {
+        RunConfig {
+            filter: Some("dem/".to_owned()),
+            product,
+            adjudications: Some(AdjudicationRegister::parse(DEM_EXTENSION).expect("register")),
+            ..RunConfig::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn non_self_sut_extension_area_reports_not_applicable() {
+        let product = ProductIdentity {
+            name: "ehrbase-java".to_owned(),
+            version: "2.34.0".to_owned(),
+            image_digest: None,
+        };
+        let results = run(&NotFound, &dem_config(product)).await.expect("run ok");
+        assert!(!results.cases.is_empty(), "DEM cases must be selected");
+        for c in &results.cases {
+            assert_eq!(
+                c.status,
+                CaseStatus::NotApplicable,
+                "{} should be N/A under the extension register",
+                c.ecc_id
+            );
+            assert!(
+                c.citation.contains("x1-comparison"),
+                "N/A citation comes from the register"
+            );
+        }
+        // NotApplicable is excluded from the pass/fail denominators.
+        assert_eq!(results.passed(), 0);
+        assert_eq!(results.failed(), 0);
+        assert_eq!(results.not_applicable(), results.executed());
+        // The identity carries the upstream product.
+        assert_eq!(results.sut.product.name, "ehrbase-java");
+        assert!(!results.sut.is_ehrbase_rs());
+    }
+
+    #[tokio::test]
+    async fn self_sut_ignores_the_register_entirely() {
+        // Same register, but our own product: the register must be ignored, so
+        // the cases actually execute (against the 404 mock → not N/A). This is
+        // the zero-drift guarantee for our baseline.
+        let results = run(&NotFound, &dem_config(ProductIdentity::default()))
+            .await
+            .expect("run ok");
+        assert!(!results.cases.is_empty(), "DEM cases must be selected");
+        assert_eq!(
+            results.not_applicable(),
+            0,
+            "an ehrbase-rs SUT never reclassifies via the register"
+        );
+        assert!(results.sut.is_ehrbase_rs());
+    }
 }

--- a/tools/conformance/src/engine/sut.rs
+++ b/tools/conformance/src/engine/sut.rs
@@ -51,15 +51,20 @@ impl Sut {
 
     /// An external SUT at `base_url` with the given credential slots.
     ///
+    /// `admin_base_url`, when `Some`, routes `/admin/*` requests to a sibling
+    /// admin mount (e.g. upstream `EHRbase`'s `/ehrbase/rest/admin`, §3a.5); `None`
+    /// nests admin under `base_url` as every existing run does.
+    ///
     /// # Errors
     /// [`SutError::Transport`] if the HTTP client cannot be built.
     pub fn external(
         base_url: impl Into<String>,
         regular: Option<Credential>,
         admin: Option<Credential>,
+        admin_base_url: Option<String>,
     ) -> Result<Self, SutError> {
         Ok(Self {
-            client: SutClient::new(base_url, regular, admin)?,
+            client: SutClient::new(base_url, regular, admin)?.with_admin_base_url(admin_base_url),
         })
     }
 }

--- a/tools/conformance/src/lib.rs
+++ b/tools/conformance/src/lib.rs
@@ -44,6 +44,6 @@ pub mod ts;
 // suites, the CLI, and the integration tests); the directories above are the
 // maintenance layout.
 pub use engine::{assert, client, flow, harness, registry, run, sut};
-pub use model::{case, catalog, profile, provenance, version};
+pub use model::{adjudication, case, catalog, profile, provenance, version};
 pub use reporting::{report, results};
 pub use testdata::fixtures;

--- a/tools/conformance/src/model/adjudication.rs
+++ b/tools/conformance/src/model/adjudication.rs
@@ -1,0 +1,441 @@
+//! The upstream fairness adjudication register (X1, §3a.4): committed **data**,
+//! not code, that reclassifies conformance outcomes for a *non-`ehrbase-rs`*
+//! SUT — never edits a case.
+//!
+//! The ECC catalogue is our own instrument, authored against the pinned specs
+//! (RM 1.2.0, ITS-REST development@e8a093e) with adjudicated skips for *our*
+//! server. Running it unmodified against upstream `EHRbase` would unfairly fail
+//! it on version skew and on our own extensions. Before any upstream result is
+//! published, every upstream failure is triaged into a committed, cited
+//! register (`tools/conformance/adjudications/<sut>.toml`) and applied at the
+//! executor seam ([`crate::run`]). Three dispositions:
+//!
+//! - `extension` → the case exercises an `ehrbase-rs` extension the SUT does
+//!   not implement (e.g. the demographic REST API, version signing) → reported
+//!   [`NotApplicable`](crate::results::CaseStatus::NotApplicable).
+//! - `rm-version-sensitive` → the case's request payload or response comparison
+//!   depends on RM 1.2.0 shapes the SUT's older RM/ITS surface cannot produce →
+//!   [`NotApplicable`](crate::results::CaseStatus::NotApplicable), with the
+//!   RM/ITS-version citation.
+//! - `defect` → a genuine spec gap that survives triage → the case runs
+//!   normally and its natural outcome (a **failure**) stands, documented here
+//!   with the spec citation.
+//!
+//! **Hard rule (honesty rule 10 / standing rule 3):** the register only
+//! *reclassifies with a citation*; it never weakens, edits, or skips a case.
+//! Every entry carries a non-empty `reason` and `citation` — [`parse`] rejects
+//! a register that omits either. Running with no register is today's behaviour,
+//! byte-for-byte (the zero-drift gate on our own baseline).
+//!
+//! ## File format (TOML)
+//!
+//! ```toml
+//! [meta]
+//! sut = "ehrbase-java"        # informational; the product name lives in results.json
+//! version = "2.34.0"
+//! description = "Upstream fairness adjudication register for EHRbase (Java) 2.34.0."
+//!
+//! # An area-wide rule: every case in the area gets this disposition.
+//! [[area]]
+//! area = "DEM"                # the ECC area tag (see `catalog::Area::tag`)
+//! disposition = "extension"
+//! reason = "Upstream EHRbase has no demographic REST API."
+//! citation = "docs/plans/x1-comparison.md §2c"
+//!
+//! # A per-case rule (keyed by ECC id) — wins over an area-wide rule.
+//! [[case]]
+//! ecc_id = "ECC-QRY-014"
+//! disposition = "rm-version-sensitive"
+//! reason = "Response compares RM 1.2.0 shapes; upstream archie 3.13.0 emits RM 1.1.0-era wire."
+//! citation = "docs/VERSIONS.md §RM-version divergence"
+//! ```
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use serde::Deserialize;
+
+/// How a case is reclassified for a non-`ehrbase-rs` SUT.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Disposition {
+    /// An `ehrbase-rs` extension the SUT does not implement → `NotApplicable`.
+    Extension,
+    /// A comparison sensitive to the RM/ITS version the SUT predates →
+    /// `NotApplicable` (with the version citation).
+    RmVersionSensitive,
+    /// A genuine spec gap that survives triage → the case runs and its failure
+    /// stands (reclassifies nothing at runtime; documents the finding).
+    Defect,
+}
+
+impl Disposition {
+    /// Whether this disposition reclassifies the case to
+    /// [`NotApplicable`](crate::results::CaseStatus::NotApplicable) (so the
+    /// executor short-circuits and never runs it). `Defect` returns `false`:
+    /// the case runs and its natural outcome stands.
+    #[must_use]
+    pub const fn is_not_applicable(self) -> bool {
+        matches!(
+            self,
+            Disposition::Extension | Disposition::RmVersionSensitive
+        )
+    }
+}
+
+/// One adjudication: a disposition plus its mandatory reason and citation.
+#[derive(Debug, Clone)]
+pub struct Adjudication {
+    /// The disposition applied to the case(s).
+    pub disposition: Disposition,
+    /// The human-readable reason (why this reclassification is fair).
+    pub reason: String,
+    /// The spec / research citation backing the reason (never empty).
+    pub citation: String,
+}
+
+/// Register provenance (informational; the authoritative product identity is in
+/// `results.json`).
+#[derive(Debug, Clone, Default)]
+pub struct RegisterMeta {
+    /// The SUT the register was authored for (e.g. `"ehrbase-java"`).
+    pub sut: String,
+    /// The SUT version (e.g. `"2.34.0"`).
+    pub version: String,
+    /// A one-line description.
+    pub description: String,
+}
+
+/// A loaded, validated adjudication register.
+#[derive(Debug, Clone, Default)]
+pub struct AdjudicationRegister {
+    meta: RegisterMeta,
+    by_ecc_id: HashMap<String, Adjudication>,
+    by_area: HashMap<String, Adjudication>,
+}
+
+/// Errors raised loading/validating a register.
+#[derive(Debug, thiserror::Error)]
+pub enum AdjudicationError {
+    /// The register file could not be read.
+    #[error("adjudication register I/O at {path}: {source}")]
+    Io {
+        /// The offending path.
+        path: String,
+        /// The underlying error.
+        source: std::io::Error,
+    },
+    /// The TOML could not be parsed.
+    #[error("adjudication register TOML parse: {0}")]
+    Parse(String),
+    /// The register parsed but is not honest (a missing citation/reason, or a
+    /// duplicate/empty key).
+    #[error("adjudication register invalid: {0}")]
+    Invalid(String),
+}
+
+// ── The on-disk shape (serde) ────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct RegisterFile {
+    #[serde(default)]
+    meta: MetaFile,
+    #[serde(default)]
+    area: Vec<AreaRule>,
+    #[serde(default)]
+    case: Vec<CaseRule>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct MetaFile {
+    #[serde(default)]
+    sut: String,
+    #[serde(default)]
+    version: String,
+    #[serde(default)]
+    description: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct AreaRule {
+    area: String,
+    disposition: Disposition,
+    reason: String,
+    citation: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct CaseRule {
+    ecc_id: String,
+    disposition: Disposition,
+    reason: String,
+    citation: String,
+}
+
+impl AdjudicationRegister {
+    /// Load and validate a register from `path`.
+    ///
+    /// # Errors
+    /// [`AdjudicationError`] on I/O, parse, or validation failure.
+    pub fn load(path: &Path) -> Result<Self, AdjudicationError> {
+        let text = std::fs::read_to_string(path).map_err(|source| AdjudicationError::Io {
+            path: path.display().to_string(),
+            source,
+        })?;
+        Self::parse(&text)
+    }
+
+    /// Parse and validate a register from TOML text.
+    ///
+    /// # Errors
+    /// [`AdjudicationError::Parse`] on malformed TOML or an unknown disposition;
+    /// [`AdjudicationError::Invalid`] on an empty/duplicate key or a missing
+    /// reason/citation (honesty rule: every entry is cited).
+    pub fn parse(text: &str) -> Result<Self, AdjudicationError> {
+        let file: RegisterFile =
+            toml::from_str(text).map_err(|e| AdjudicationError::Parse(e.to_string()))?;
+
+        let mut by_area: HashMap<String, Adjudication> = HashMap::new();
+        for rule in file.area {
+            let key = rule.area.trim().to_owned();
+            require(&key, "area", &rule.reason, &rule.citation)?;
+            if by_area.contains_key(&key) {
+                return Err(AdjudicationError::Invalid(format!(
+                    "duplicate area rule for {key:?}"
+                )));
+            }
+            by_area.insert(
+                key,
+                Adjudication {
+                    disposition: rule.disposition,
+                    reason: rule.reason,
+                    citation: rule.citation,
+                },
+            );
+        }
+
+        let mut by_ecc_id: HashMap<String, Adjudication> = HashMap::new();
+        for rule in file.case {
+            let key = rule.ecc_id.trim().to_owned();
+            require(&key, "ecc_id", &rule.reason, &rule.citation)?;
+            if by_ecc_id.contains_key(&key) {
+                return Err(AdjudicationError::Invalid(format!(
+                    "duplicate case rule for {key:?}"
+                )));
+            }
+            by_ecc_id.insert(
+                key,
+                Adjudication {
+                    disposition: rule.disposition,
+                    reason: rule.reason,
+                    citation: rule.citation,
+                },
+            );
+        }
+
+        Ok(Self {
+            meta: RegisterMeta {
+                sut: file.meta.sut,
+                version: file.meta.version,
+                description: file.meta.description,
+            },
+            by_ecc_id,
+            by_area,
+        })
+    }
+
+    /// The register provenance.
+    #[must_use]
+    pub fn meta(&self) -> &RegisterMeta {
+        &self.meta
+    }
+
+    /// The number of registered rules (per-case + area-wide).
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.by_ecc_id.len() + self.by_area.len()
+    }
+
+    /// Whether the register has no rules.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.by_ecc_id.is_empty() && self.by_area.is_empty()
+    }
+
+    /// The adjudication for a case, if any: an exact `ecc_id` rule wins over an
+    /// area-wide rule (`area_tag` is [`crate::catalog::Area::tag`]).
+    #[must_use]
+    pub fn lookup(&self, ecc_id: &str, area_tag: &str) -> Option<&Adjudication> {
+        self.by_ecc_id
+            .get(ecc_id)
+            .or_else(|| self.by_area.get(area_tag))
+    }
+}
+
+/// Validate one rule's key/reason/citation are all present (honesty rule).
+fn require(
+    key: &str,
+    key_field: &str,
+    reason: &str,
+    citation: &str,
+) -> Result<(), AdjudicationError> {
+    if key.is_empty() {
+        return Err(AdjudicationError::Invalid(format!("empty {key_field}")));
+    }
+    if reason.trim().is_empty() {
+        return Err(AdjudicationError::Invalid(format!(
+            "{key} has no reason (every adjudication must be justified)"
+        )));
+    }
+    if citation.trim().is_empty() {
+        return Err(AdjudicationError::Invalid(format!(
+            "{key} has no citation (every adjudication must be cited)"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"
+[meta]
+sut = "ehrbase-java"
+version = "2.34.0"
+description = "test register"
+
+[[area]]
+area = "Dem"
+disposition = "extension"
+reason = "Upstream EHRbase has no demographic REST API."
+citation = "docs/plans/x1-comparison.md §2c"
+
+[[case]]
+ecc_id = "ECC-QRY-014"
+disposition = "rm-version-sensitive"
+reason = "Response compares RM 1.2.0 shapes."
+citation = "docs/VERSIONS.md §RM-version divergence"
+
+[[case]]
+ecc_id = "ECC-SQR-002"
+disposition = "defect"
+reason = "Upstream rejects ALL_VERSIONS."
+citation = "ADR-008 §2"
+"#;
+
+    #[test]
+    fn parses_meta_and_rules() {
+        let reg = AdjudicationRegister::parse(SAMPLE).expect("parse");
+        assert_eq!(reg.meta().sut, "ehrbase-java");
+        assert_eq!(reg.meta().version, "2.34.0");
+        assert_eq!(reg.len(), 3);
+        assert!(!reg.is_empty());
+    }
+
+    #[test]
+    fn per_case_rule_wins_over_area_rule() {
+        let text = r#"
+[[area]]
+area = "Qry"
+disposition = "extension"
+reason = "area rule"
+citation = "cite"
+
+[[case]]
+ecc_id = "ECC-QRY-001"
+disposition = "defect"
+reason = "case rule"
+citation = "cite"
+"#;
+        let reg = AdjudicationRegister::parse(text).expect("parse");
+        // The exact ecc_id rule wins.
+        assert_eq!(
+            reg.lookup("ECC-QRY-001", "Qry").expect("hit").disposition,
+            Disposition::Defect
+        );
+        // A different case in the same area falls back to the area rule.
+        assert_eq!(
+            reg.lookup("ECC-QRY-099", "Qry").expect("hit").disposition,
+            Disposition::Extension
+        );
+        // A case in another area with no rule misses.
+        assert!(reg.lookup("ECC-EHR-001", "Ehr").is_none());
+    }
+
+    #[test]
+    fn dispositions_map_to_not_applicable_correctly() {
+        assert!(Disposition::Extension.is_not_applicable());
+        assert!(Disposition::RmVersionSensitive.is_not_applicable());
+        assert!(!Disposition::Defect.is_not_applicable());
+    }
+
+    #[test]
+    fn rejects_missing_citation() {
+        let text = r#"
+[[case]]
+ecc_id = "ECC-DEM-001"
+disposition = "extension"
+reason = "no demographic API"
+citation = ""
+"#;
+        let err = AdjudicationRegister::parse(text).expect_err("must reject");
+        assert!(matches!(err, AdjudicationError::Invalid(_)), "{err:?}");
+        assert!(err.to_string().contains("citation"));
+    }
+
+    #[test]
+    fn rejects_missing_reason() {
+        let text = r#"
+[[area]]
+area = "Sig"
+disposition = "extension"
+reason = "   "
+citation = "cite"
+"#;
+        let err = AdjudicationRegister::parse(text).expect_err("must reject");
+        assert!(matches!(err, AdjudicationError::Invalid(_)), "{err:?}");
+        assert!(err.to_string().contains("reason"));
+    }
+
+    #[test]
+    fn rejects_unknown_disposition() {
+        let text = r#"
+[[case]]
+ecc_id = "ECC-EHR-001"
+disposition = "wontfix"
+reason = "r"
+citation = "c"
+"#;
+        let err = AdjudicationRegister::parse(text).expect_err("must reject");
+        assert!(matches!(err, AdjudicationError::Parse(_)), "{err:?}");
+    }
+
+    #[test]
+    fn rejects_duplicate_case_key() {
+        let text = r#"
+[[case]]
+ecc_id = "ECC-EHR-001"
+disposition = "defect"
+reason = "r"
+citation = "c"
+
+[[case]]
+ecc_id = "ECC-EHR-001"
+disposition = "extension"
+reason = "r"
+citation = "c"
+"#;
+        let err = AdjudicationRegister::parse(text).expect_err("must reject");
+        assert!(matches!(err, AdjudicationError::Invalid(_)), "{err:?}");
+        assert!(err.to_string().contains("duplicate"));
+    }
+
+    #[test]
+    fn empty_register_is_valid_and_empty() {
+        let reg = AdjudicationRegister::parse("").expect("parse empty");
+        assert!(reg.is_empty());
+        assert_eq!(reg.len(), 0);
+        assert!(reg.lookup("ECC-EHR-001", "Ehr").is_none());
+    }
+}

--- a/tools/conformance/src/model/mod.rs
+++ b/tools/conformance/src/model/mod.rs
@@ -1,5 +1,6 @@
 //! The domain model: case metadata and the ECC catalogue.
 
+pub mod adjudication;
 pub mod case;
 pub mod catalog;
 pub mod profile;

--- a/tools/conformance/src/model/profile.rs
+++ b/tools/conformance/src/model/profile.rs
@@ -111,6 +111,9 @@ pub struct CapabilityVerdict {
     pub errored: usize,
     /// Skipped outcomes (reported; do not pass a capability by themselves).
     pub skipped: usize,
+    /// Not-applicable outcomes (adjudicated extension / RM-version-sensitive —
+    /// reported but excluded from the pass formula entirely, §3a.3).
+    pub not_applicable: usize,
     /// Whether the capability passes: `passed ≥ 1 && failed == 0 && errored == 0`.
     pub pass: bool,
 }
@@ -159,6 +162,7 @@ pub fn verdict(profile: Profile, results: &RunResults) -> ProfileVerdict {
                 failed: 0,
                 errored: 0,
                 skipped: 0,
+                not_applicable: 0,
                 pass: false,
             };
             for case in results.cases.iter().filter(|c| c.capability == label) {
@@ -167,6 +171,10 @@ pub fn verdict(profile: Profile, results: &RunResults) -> ProfileVerdict {
                     CaseStatus::Failed => v.failed += 1,
                     CaseStatus::Errored => v.errored += 1,
                     CaseStatus::Skipped => v.skipped += 1,
+                    // NotApplicable is excluded from capability computation
+                    // entirely (§3a.3): it neither evidences nor breaks a
+                    // capability.
+                    CaseStatus::NotApplicable => v.not_applicable += 1,
                 }
             }
             v.pass = v.passed >= 1 && v.failed == 0 && v.errored == 0;
@@ -189,7 +197,7 @@ pub fn verdict(profile: Profile, results: &RunResults) -> ProfileVerdict {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::results::{CaseOutcome, CorpusPin, SelectionInfo, SutIdentity};
+    use crate::results::{CaseOutcome, CorpusPin, ProductIdentity, SelectionInfo, SutIdentity};
     use crate::version::SpecVersions;
 
     fn outcome(capability: &str, status: CaseStatus) -> CaseOutcome {
@@ -214,6 +222,7 @@ mod tests {
         RunResults {
             sut: SutIdentity {
                 base_url: "x".to_owned(),
+                product: ProductIdentity::default(),
                 versions: SpecVersions::latest(),
                 auth_mode: "none".to_owned(),
             },
@@ -285,6 +294,44 @@ mod tests {
             !v.pass,
             "no optional capability passed → OPTIONS not obtained"
         );
+    }
+
+    #[test]
+    fn not_applicable_is_excluded_from_capability_math() {
+        // A capability with one passing case and one NotApplicable case still
+        // passes: NotApplicable neither evidences nor breaks it (§3a.3). It is
+        // tallied separately for reporting only.
+        let r = results(vec![
+            outcome("EhrOperations", CaseStatus::Passed),
+            outcome("EhrOperations", CaseStatus::NotApplicable),
+        ]);
+        let v = verdict(Profile::Core, &r);
+        let ehr = v
+            .capabilities
+            .iter()
+            .find(|c| c.capability == "EhrOperations")
+            .expect("EhrOperations in CORE");
+        assert!(ehr.pass, "one pass + one N/A still passes the capability");
+        assert_eq!(ehr.passed, 1);
+        assert_eq!(ehr.not_applicable, 1);
+        assert_eq!(ehr.failed, 0);
+        assert_eq!(ehr.errored, 0);
+    }
+
+    #[test]
+    fn not_applicable_alone_does_not_evidence_a_capability() {
+        // A capability whose only case is NotApplicable is *not* evidenced (it
+        // has zero passes) — it reads "not evidenced", never "pass".
+        let r = results(vec![outcome("DemographicApi", CaseStatus::NotApplicable)]);
+        let v = verdict(Profile::Options, &r);
+        let dem = v
+            .capabilities
+            .iter()
+            .find(|c| c.capability == "DemographicApi")
+            .expect("DemographicApi in OPTIONS");
+        assert!(!dem.pass);
+        assert_eq!(dem.not_applicable, 1);
+        assert_eq!(dem.label(), "not evidenced");
     }
 
     #[test]

--- a/tools/conformance/src/reporting/report.rs
+++ b/tools/conformance/src/reporting/report.rs
@@ -69,17 +69,30 @@ pub fn write_all(results: &RunResults, out_dir: &Path) -> Result<(), ReportError
         &out_dir.join("CATALOG.md"),
         &render_catalog_md(results, &catalog),
     )?;
-    // The Conformance Statement + Certificate artefacts (R9/R10): both are pure
+    // The Conformance Statement + Certificate artefacts (R9/R10) are
+    // **self-assessment** artifacts of *our* product — emitted only when the SUT
+    // is `ehrbase-rs` (§3a.2, honesty rule 4). We never manufacture a
+    // conformance certificate for someone else's product; an upstream run gets
+    // `results.json` + report + catalogue only. Both artifacts are pure
     // functions of the machine verdicts, so `report --from results.json`
     // regenerates them identically to a live run.
-    write_file(
-        &out_dir.join("CONFORMANCE_STATEMENT.md"),
-        &crate::reporting::statement::render_statement_md(results),
-    )?;
-    write_file(
-        &out_dir.join("CONFORMANCE_CERTIFICATE.md"),
-        &crate::reporting::statement::render_certificate_md(results, &catalog),
-    )?;
+    if results.sut.is_ehrbase_rs() {
+        write_file(
+            &out_dir.join("CONFORMANCE_STATEMENT.md"),
+            &crate::reporting::statement::render_statement_md(results),
+        )?;
+        write_file(
+            &out_dir.join("CONFORMANCE_CERTIFICATE.md"),
+            &crate::reporting::statement::render_certificate_md(results, &catalog),
+        )?;
+    } else {
+        eprintln!(
+            "conformance: SUT product is `{}` (not ehrbase-rs) — suppressing the \
+             Conformance Statement + Certificate (self-assessment artifacts are \
+             never emitted for another product, §3a.2)",
+            results.sut.product.name
+        );
+    }
     write_file(
         &out_dir.join("badge.json"),
         &render_badge(results, &catalog),
@@ -117,6 +130,7 @@ struct AreaTally {
     failed: usize,
     errored: usize,
     skipped: usize,
+    not_applicable: usize,
 }
 
 fn tally_by_area(results: &RunResults, catalog: &Catalog) -> BTreeMap<Area, AreaTally> {
@@ -136,15 +150,21 @@ fn tally_by_area(results: &RunResults, catalog: &Catalog) -> BTreeMap<Area, Area
             CaseStatus::Failed => t.failed += 1,
             CaseStatus::Errored => t.errored += 1,
             CaseStatus::Skipped => t.skipped += 1,
+            CaseStatus::NotApplicable => t.not_applicable += 1,
         }
     }
     by
 }
 
 fn render_header(out: &mut String, results: &RunResults) {
+    let product = &results.sut.product;
+    let _ = write!(out, "- Product: {} {}", product.name, product.version);
+    if let Some(digest) = &product.image_digest {
+        let _ = write!(out, " (`{digest}`)");
+    }
     let _ = write!(
         out,
-        "- SUT: `{}`\n- Spec versions: RM {} · ITS-REST {} · AQL {} · TERM {}\n\
+        "\n- SUT: `{}`\n- Spec versions: RM {} · ITS-REST {} · AQL {} · TERM {}\n\
          - Auth mode: {}\n- Started: {}\n\n",
         results.sut.base_url,
         results.sut.versions.rm,
@@ -163,8 +183,8 @@ fn render_area_matrix(out: &mut String, results: &RunResults, catalog: &Catalog)
     let denominators = active_per_area(catalog);
 
     out.push_str("### Per-area matrix\n\n");
-    out.push_str("| Area | Catalogue (active) | Passed | Failed | Errored | Skipped |\n");
-    out.push_str("|---|--:|--:|--:|--:|--:|\n");
+    out.push_str("| Area | Catalogue (active) | Passed | Failed | Errored | Skipped | N/A |\n");
+    out.push_str("|---|--:|--:|--:|--:|--:|--:|\n");
     for area in Area::ALL {
         let denom = denominators.get(&area).copied().unwrap_or(0);
         if denom == 0 && !by.contains_key(&area) {
@@ -173,14 +193,15 @@ fn render_area_matrix(out: &mut String, results: &RunResults, catalog: &Catalog)
         let t = by.get(&area).copied().unwrap_or_default();
         let _ = writeln!(
             out,
-            "| {} — {} | {} | {} | {} | {} | {} |",
+            "| {} — {} | {} | {} | {} | {} | {} | {} |",
             area.tag(),
             area.title(),
             denom,
             t.passed,
             t.failed,
             t.errored,
-            t.skipped
+            t.skipped,
+            t.not_applicable
         );
     }
 
@@ -206,6 +227,52 @@ fn render_area_matrix(out: &mut String, results: &RunResults, catalog: &Catalog)
                 c.id,
                 c.format,
                 c.message.as_deref().unwrap_or("(no message)")
+            );
+        }
+        out.push('\n');
+    }
+
+    // Extensions / RM-version-sensitive routes adjudicated not-applicable to
+    // this SUT (§3a.3/§3a.4) — excluded from pass/fail, listed with the cited
+    // reason. One line per ECC id (formats collapsed).
+    let mut na_seen: BTreeMap<String, &crate::results::CaseOutcome> = BTreeMap::new();
+    let mut na_order: Vec<String> = Vec::new();
+    for c in results
+        .cases
+        .iter()
+        .filter(|c| c.status == CaseStatus::NotApplicable)
+    {
+        let key = if c.ecc_id.is_empty() {
+            c.id.clone()
+        } else {
+            c.ecc_id.clone()
+        };
+        na_seen.entry(key.clone()).or_insert_with(|| {
+            na_order.push(key.clone());
+            c
+        });
+    }
+    out.push_str("### Not applicable to this SUT (extensions / RM-version-sensitive)\n\n");
+    if na_order.is_empty() {
+        out.push_str("_None — every catalogued case applies to this SUT._\n\n");
+    } else {
+        out.push_str(
+            "Adjudicated in the committed register, not a conformance finding \
+             (excluded from pass/fail and capability math).\n\n",
+        );
+        for key in &na_order {
+            let c = na_seen[key];
+            let _ = writeln!(
+                out,
+                "- **{}** {} — {} _(cite: {})_",
+                c.ecc_id,
+                c.title,
+                c.message.as_deref().unwrap_or("(no reason)"),
+                if c.citation.is_empty() {
+                    "—"
+                } else {
+                    c.citation.as_str()
+                }
             );
         }
         out.push('\n');
@@ -286,10 +353,11 @@ fn render_report_md(results: &RunResults, catalog: &Catalog) -> String {
     render_header(&mut out, results);
     let _ = write!(
         out,
-        "**{} case×format executions · {} passed · {} failed.**\n\n",
+        "**{} case×format executions · {} passed · {} failed · {} not applicable.**\n\n",
         results.executed(),
         results.passed(),
         results.failed(),
+        results.not_applicable(),
     );
     render_area_matrix(&mut out, results, catalog);
 
@@ -316,10 +384,12 @@ fn render_report_md(results: &RunResults, catalog: &Catalog) -> String {
         .count();
     let _ = write!(
         out,
-        "| Catalogue (active cases) | {active} |\n| Executed | {} |\n| Passed | {} |\n| Failed | {} |\n\n",
+        "| Catalogue (active cases) | {active} |\n| Executed | {} |\n| Passed | {} |\n\
+         | Failed | {} |\n| Not applicable | {} |\n\n",
         results.executed(),
         results.passed(),
-        results.failed()
+        results.failed(),
+        results.not_applicable()
     );
 
     out.push_str("## 3. Detailed test report\n\n");
@@ -335,6 +405,7 @@ fn render_report_md(results: &RunResults, catalog: &Catalog) -> String {
                 CaseStatus::Failed => "**FAIL**",
                 CaseStatus::Errored => "ERROR",
                 CaseStatus::Skipped => "skipped",
+                CaseStatus::NotApplicable => "N/A",
             };
             let _ = writeln!(
                 out,
@@ -363,17 +434,18 @@ fn render_report_md(results: &RunResults, catalog: &Catalog) -> String {
             _ => "not claimable",
         };
         let _ = writeln!(out, "### {profile:?} — {outcome}\n");
-        out.push_str("| Capability | Passed | Failed | Errored | Skipped | Verdict |\n");
-        out.push_str("|---|--:|--:|--:|--:|---|\n");
+        out.push_str("| Capability | Passed | Failed | Errored | Skipped | N/A | Verdict |\n");
+        out.push_str("|---|--:|--:|--:|--:|--:|---|\n");
         for c in &v.capabilities {
             let _ = writeln!(
                 out,
-                "| {} | {} | {} | {} | {} | {} |",
+                "| {} | {} | {} | {} | {} | {} | {} |",
                 c.capability,
                 c.passed,
                 c.failed,
                 c.errored,
                 c.skipped,
+                c.not_applicable,
                 c.label()
             );
         }
@@ -488,13 +560,14 @@ fn render_profile_badge(profile: Profile, results: &RunResults) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::results::{CorpusPin, SelectionInfo, SutIdentity};
+    use crate::results::{CaseOutcome, CorpusPin, ProductIdentity, SelectionInfo, SutIdentity};
     use crate::version::SpecVersions;
 
     fn zero_state_results() -> RunResults {
         RunResults {
             sut: SutIdentity {
                 base_url: "http://sut".to_owned(),
+                product: ProductIdentity::default(),
                 versions: SpecVersions::latest(),
                 auth_mode: "none".to_owned(),
             },
@@ -540,5 +613,107 @@ mod tests {
         let back = from_results_file(&dir.join("results.json")).expect("read back");
         assert_eq!(back.executed(), 0);
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A non-ehrbase-rs SUT gets `results.json` + report + catalogue + badges,
+    /// but **no** Statement/Certificate (§3a.2) — those are self-assessment
+    /// artifacts of our own product only.
+    #[test]
+    fn upstream_sut_suppresses_statement_and_certificate() {
+        let mut r = zero_state_results();
+        r.sut.product = ProductIdentity {
+            name: "ehrbase-java".to_owned(),
+            version: "2.34.0".to_owned(),
+            image_digest: Some("sha256:cafe".to_owned()),
+        };
+        let dir = std::env::temp_dir().join(format!("ecc-upstream-{}", std::process::id()));
+        write_all(&r, &dir).expect("write");
+        // The machine record and the human/badge artifacts are still written.
+        for name in [
+            "results.json",
+            "CONFORMANCE_REPORT.md",
+            "CATALOG.md",
+            "badge.json",
+        ] {
+            assert!(
+                dir.join(name).exists(),
+                "{name} must be written for upstream"
+            );
+        }
+        // The self-assessment artifacts are suppressed.
+        assert!(
+            !dir.join("CONFORMANCE_STATEMENT.md").exists(),
+            "Statement must be suppressed for a non-ehrbase-rs SUT"
+        );
+        assert!(
+            !dir.join("CONFORMANCE_CERTIFICATE.md").exists(),
+            "Certificate must be suppressed for a non-ehrbase-rs SUT"
+        );
+        // The identity is recorded in results.json and survives a round-trip.
+        let back = from_results_file(&dir.join("results.json")).expect("read back");
+        assert_eq!(back.sut.product.name, "ehrbase-java");
+        assert_eq!(back.sut.product.version, "2.34.0");
+        assert_eq!(
+            back.sut.product.image_digest.as_deref(),
+            Some("sha256:cafe")
+        );
+        assert!(!back.sut.is_ehrbase_rs());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Our own product's identity is written into `results.json` and the report
+    /// header shows it (§3a.1).
+    #[test]
+    fn self_sut_identity_is_recorded_and_rendered() {
+        let r = zero_state_results();
+        let catalog = Catalog::default();
+        let report = render_report_md(&r, &catalog);
+        assert!(
+            report.contains(&format!(
+                "Product: ehrbase-rs {}",
+                env!("CARGO_PKG_VERSION")
+            )),
+            "the report header states the product identity"
+        );
+        let json = serde_json::to_string(&r).expect("serialize");
+        assert!(json.contains("\"product\""), "results.json carries product");
+        assert!(json.contains("ehrbase-rs"));
+    }
+
+    /// A `NotApplicable` outcome is excluded from pass/fail and rendered in its own
+    /// section with the cited reason.
+    #[test]
+    fn not_applicable_outcome_is_reported_separately() {
+        let mut r = zero_state_results();
+        r.sut.product = ProductIdentity {
+            name: "ehrbase-java".to_owned(),
+            version: "2.34.0".to_owned(),
+            image_digest: None,
+        };
+        r.cases.push(CaseOutcome {
+            ecc_id: "ECC-DEM-001".to_owned(),
+            id: "dem/create".to_owned(),
+            title: "Create a party".to_owned(),
+            capability: "DemographicApi".to_owned(),
+            profiles: vec!["Options".to_owned()],
+            format: "json".to_owned(),
+            status: CaseStatus::NotApplicable,
+            passed_data_sets: 0,
+            total_data_sets: 0,
+            message: Some("Upstream has no demographic REST API.".to_owned()),
+            citation: "docs/plans/x1-comparison.md §2c".to_owned(),
+            schedule_ref: None,
+            duration_ms: 0,
+        });
+        assert_eq!(r.passed(), 0);
+        assert_eq!(r.failed(), 0);
+        assert_eq!(r.not_applicable(), 1);
+        let catalog = Catalog::default();
+        let report = render_report_md(&r, &catalog);
+        assert!(report.contains("Not applicable to this SUT"));
+        assert!(report.contains("ECC-DEM-001"));
+        assert!(report.contains("no demographic REST API"));
+        assert!(report.contains("x1-comparison.md §2c"));
+        assert!(report.contains("· 1 not applicable"));
     }
 }

--- a/tools/conformance/src/reporting/results.rs
+++ b/tools/conformance/src/reporting/results.rs
@@ -56,6 +56,17 @@ impl RunResults {
             .count()
     }
 
+    /// Cases reported as not applicable to this SUT (an adjudicated extension /
+    /// RM-version-sensitive route — excluded from pass/fail and capability
+    /// math, §3a.3).
+    #[must_use]
+    pub fn not_applicable(&self) -> usize {
+        self.cases
+            .iter()
+            .filter(|c| c.status == CaseStatus::NotApplicable)
+            .count()
+    }
+
     /// The number of executed case×format outcomes (the run denominator; the
     /// catalogue denominator lives in `CATALOG.md`).
     #[must_use]
@@ -69,11 +80,67 @@ impl RunResults {
 pub struct SutIdentity {
     /// The ITS-REST base URL.
     pub base_url: String,
+    /// The product under test (name, version, image digest) — first-class so a
+    /// run's artifacts unambiguously state *which server* they measured (§3a.1).
+    /// `#[serde(default)]` keeps pre-X1 `results.json` files readable via
+    /// `report --from`.
+    #[serde(default)]
+    pub product: ProductIdentity,
     /// The declared specification versions (a property of the claim).
     #[serde(default)]
     pub versions: SpecVersions,
     /// The declared auth mode (e.g. `"basic (RBAC off)"`).
     pub auth_mode: String,
+}
+
+impl SutIdentity {
+    /// Whether the SUT is this project's own product (`ehrbase-rs`, case-
+    /// insensitive). The Conformance Statement + Certificate are self-assessment
+    /// artifacts emitted only for our own product (§3a.2), and the upstream
+    /// adjudication register is consulted only for non-self SUTs (§3a.4).
+    #[must_use]
+    pub fn is_ehrbase_rs(&self) -> bool {
+        self.product.is_ehrbase_rs()
+    }
+}
+
+/// The product under test: what server, which version, which image.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProductIdentity {
+    /// The product name (e.g. `"ehrbase-rs"`, `"ehrbase-java"`).
+    pub name: String,
+    /// The product version (e.g. the workspace version, or `"2.34.0"`).
+    pub version: String,
+    /// The container image digest (`sha256:…`) when the run targeted a pinned
+    /// image, else absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_digest: Option<String>,
+}
+
+impl ProductIdentity {
+    /// This project's own product name — the identity every existing run
+    /// defaults to, so our baseline stays stable.
+    pub const EHRBASE_RS: &'static str = "ehrbase-rs";
+
+    /// Whether this identity is our own product (`ehrbase-rs`, case-insensitive).
+    #[must_use]
+    pub fn is_ehrbase_rs(&self) -> bool {
+        self.name.eq_ignore_ascii_case(Self::EHRBASE_RS)
+    }
+}
+
+impl Default for ProductIdentity {
+    /// Defaults to `ehrbase-rs @ <this crate's version>` (= the workspace
+    /// version), so a run with no `--sut-*` flags — and any pre-X1
+    /// `results.json` reparsed via `report --from` — identifies as our own
+    /// product exactly as before.
+    fn default() -> Self {
+        Self {
+            name: Self::EHRBASE_RS.to_owned(),
+            version: env!("CARGO_PKG_VERSION").to_owned(),
+            image_digest: None,
+        }
+    }
 }
 
 /// The pinned reference corpus this framework was designed against
@@ -148,6 +215,13 @@ pub enum CaseStatus {
     Errored,
     /// The case was skipped for a stated reason.
     Skipped,
+    /// The case is not applicable to this SUT — an adjudicated extension route
+    /// or an RM-version-sensitive comparison the SUT cannot be expected to
+    /// satisfy (§3a.3/§3a.4). Excluded from pass/fail counts and from
+    /// capability computation; reported in its own section. Distinct from
+    /// `Skipped` (which is an in-run "could not determine" from a case's own
+    /// probe), this is a committed, cited adjudication about the SUT.
+    NotApplicable,
 }
 
 /// The outcome of one executed case in one format.

--- a/tools/conformance/src/reporting/statement.rs
+++ b/tools/conformance/src/reporting/statement.rs
@@ -45,6 +45,14 @@ pub fn render_statement_md(results: &RunResults) -> String {
     );
 
     out.push_str("## System under test\n\n| Field | Value |\n|---|---|\n");
+    let _ = writeln!(
+        out,
+        "| Product | {} {} |",
+        results.sut.product.name, results.sut.product.version
+    );
+    if let Some(digest) = &results.sut.product.image_digest {
+        let _ = writeln!(out, "| Image digest | `{digest}` |");
+    }
     let _ = writeln!(out, "| SUT | `{}` |", results.sut.base_url);
     let _ = writeln!(out, "| Auth mode | {} |", results.sut.auth_mode);
     let _ = writeln!(out, "| Run started | {} |", results.started);
@@ -132,13 +140,21 @@ pub fn render_certificate_md(results: &RunResults, catalog: &Catalog) -> String 
     );
 
     // ── System Under Test (SUT) ─────────────────────────────────────────────
+    // Solution/Vendor are driven by the recorded product identity, never
+    // hard-coded (§3a.1/§3a.2): this artifact is only emitted for an
+    // `ehrbase-rs` SUT (`report::write_all`), so the values below are our own,
+    // but they now read from the data rather than a literal.
+    let product = &results.sut.product;
     out.push_str("## System Under Test (SUT)\n\n| | |\n|---|---|\n");
     let _ = writeln!(
         out,
-        "| Solution | ehrbase-rs @ `{}` |",
-        results.sut.base_url
+        "| Solution | {} {} @ `{}` |",
+        product.name, product.version, results.sut.base_url
     );
-    out.push_str("| Vendor | ehrbase-rs (self-assessed) |\n");
+    if let Some(digest) = &product.image_digest {
+        let _ = writeln!(out, "| Image digest | `{digest}` |");
+    }
+    let _ = writeln!(out, "| Vendor | {} (self-assessed) |", product.name);
     out.push_str("| Assessor | ehrbase-rs Conformance Catalogue (ECC) — self-assessment |\n");
     let _ = writeln!(
         out,
@@ -321,7 +337,11 @@ fn merge_status(acc: Option<CaseStatus>, next: CaseStatus) -> CaseStatus {
         CaseStatus::Failed => 3,
         CaseStatus::Errored => 2,
         CaseStatus::Passed => 1,
-        CaseStatus::Skipped => 0,
+        // Skipped / NotApplicable are lowest salience: a passing format wins the
+        // merged row. (NotApplicable never reaches the certificate — it is only
+        // emitted for `ehrbase-rs` SUTs, which the register never touches — but
+        // the match stays exhaustive.)
+        CaseStatus::Skipped | CaseStatus::NotApplicable => 0,
     };
     match acc {
         Some(a) if rank(a) >= rank(next) => a,
@@ -336,13 +356,14 @@ fn verdict_word(status: CaseStatus) -> &'static str {
         CaseStatus::Failed => "**FAIL**",
         CaseStatus::Errored => "ERROR",
         CaseStatus::Skipped => "skipped",
+        CaseStatus::NotApplicable => "n/a",
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::results::{CaseOutcome, CorpusPin, SelectionInfo, SutIdentity};
+    use crate::results::{CaseOutcome, CorpusPin, ProductIdentity, SelectionInfo, SutIdentity};
     use crate::version::SpecVersions;
 
     fn outcome(ecc_id: &str, capability: &str, format: &str, status: CaseStatus) -> CaseOutcome {
@@ -367,6 +388,7 @@ mod tests {
         RunResults {
             sut: SutIdentity {
                 base_url: "http://sut".to_owned(),
+                product: ProductIdentity::default(),
                 versions: SpecVersions::latest(),
                 auth_mode: "basic".to_owned(),
             },
@@ -415,5 +437,36 @@ mod tests {
         // The two formats collapse to one row; the worse (FAIL) wins.
         assert!(cert.contains("ECC-EHR-001 — A case"));
         assert!(cert.contains("**FAIL**"));
+    }
+
+    #[test]
+    fn certificate_solution_and_vendor_are_data_driven_not_hard_coded() {
+        // The certificate no longer hard-codes `ehrbase-rs` as Solution/Vendor
+        // (§3a.1); it reads the recorded product identity. (In practice the
+        // certificate is only *emitted* for an ehrbase-rs SUT — the suppression
+        // lives in `report::write_all` — but the render must be honest either
+        // way.)
+        let cat = Catalog::default();
+        let mut r = results(vec![outcome(
+            "ECC-EHR-001",
+            "EhrOperations",
+            "json",
+            CaseStatus::Passed,
+        )]);
+        r.sut.product = ProductIdentity {
+            name: "ehrbase-java".to_owned(),
+            version: "2.34.0".to_owned(),
+            image_digest: Some("sha256:deadbeef".to_owned()),
+        };
+        let cert = render_certificate_md(&r, &cat);
+        assert!(
+            cert.contains("ehrbase-java 2.34.0"),
+            "Solution reads the product identity"
+        );
+        assert!(
+            cert.contains("| Vendor | ehrbase-java (self-assessed) |"),
+            "Vendor reads the product name, not a hard-coded ehrbase-rs"
+        );
+        assert!(cert.contains("sha256:deadbeef"), "image digest is shown");
     }
 }

--- a/tools/conformance/tests/adjudications.rs
+++ b/tools/conformance/tests/adjudications.rs
@@ -1,0 +1,32 @@
+//! Guard: every committed upstream adjudication register (`adjudications/*.toml`)
+//! must load and validate. A malformed or uncited register would otherwise only
+//! surface at an upstream run — CI catches it here.
+#![allow(clippy::expect_used)]
+
+use std::path::Path;
+
+use conformance::adjudication::AdjudicationRegister;
+
+#[test]
+fn committed_registers_load_and_validate() {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("adjudications");
+    let mut checked = 0;
+    for entry in std::fs::read_dir(&dir).expect("read adjudications/") {
+        let path = entry.expect("dir entry").path();
+        if path.extension().and_then(|e| e.to_str()) != Some("toml") {
+            continue;
+        }
+        let reg = AdjudicationRegister::load(&path)
+            .unwrap_or_else(|e| panic!("register {} is invalid: {e}", path.display()));
+        assert!(
+            !reg.is_empty(),
+            "register {} has no rules — remove it or add cited entries",
+            path.display()
+        );
+        checked += 1;
+    }
+    assert!(
+        checked >= 1,
+        "expected at least the seeded ehrbase-java register in adjudications/"
+    );
+}


### PR DESCRIPTION
X1.1 per docs/plans/x1-comparison.md §3a:

- **SUT product identity** (name/version/image digest) in results.json + report headers — defaults to ehrbase-rs @ workspace version.
- **Adjudication register** (committed TOML, per-case/per-area dispositions `extension`/`rm-version-sensitive`/`defect`, mandatory reason+citation) applied only for non-self SUTs → new `NotApplicable` status excluded from pass/fail/capability math, rendered as its own column. Seeded honestly with only the extension-by-construction facts (DEM, SIG); the rest is X1.2 triage.
- **Certificate/Statement suppressed for non-self SUTs** — fixes the falsely-labelled-certificate seam (Solution was hard-coded to ehrbase-rs).
- `--admin-base-url` for upstream's sibling admin mount; `--sut-*`/`--adjudications` CLI.
- 67 crate tests green; clippy clean; **full ECC zero-drift: 341 · 315 · 0 · 0 N/A** (scripts/conformance.sh unchanged, results re-baselined with the identity field only).