### PR TITLE
fix: dev-image role topology + scoped ext grants — clean server boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
+- The `ehrbase-rs-postgres` image now pre-creates the layered group roles
+  (`ehrbase_migrator`, `ehrbase_app`, `ehrbase_reader`), so Compose/dev
+  deployments get the same least-privilege grant topology as hardened
+  deployments instead of `roles absent` startup notices. Existing data
+  volumes keep working; recreate the volume (or create the roles once by
+  hand) to pick the grants up.
 - Public documentation website at <https://rubentalstra.github.io/ehrbase-rs/>:
   a product landing page, a versioned user guide (frozen per release, `dev`
   tracking `develop`), and an offline OpenAPI endpoint reference covering all

--- a/app/ehrbase/migrations/ext/0001_openehr_functions.sql
+++ b/app/ehrbase/migrations/ext/0001_openehr_functions.sql
@@ -213,8 +213,22 @@ DO $$
 BEGIN
     IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'ehrbase_app') THEN
         GRANT USAGE ON SCHEMA ext TO ehrbase_app, ehrbase_reader;
-        GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA ext TO ehrbase_app, ehrbase_reader;
-        -- Future ext functions reachable without a manual grant (doc 02 §3.2).
+        -- Grant on OUR functions explicitly, never `ALL FUNCTIONS IN SCHEMA ext`:
+        -- the schema also hosts the superuser-installed extensions (uuid-ossp,
+        -- pgcrypto, pg_trgm, btree_gist), whose functions the migrator cannot
+        -- grant on — a blanket grant emits one "no privileges were granted"
+        -- WARNING per extension function (~250 lines of boot noise).
+        GRANT EXECUTE ON FUNCTION
+            ext.openehr_date_days(text),
+            ext.openehr_time_seconds(text),
+            ext.openehr_tz_offset_seconds(text),
+            ext.openehr_date_time_seconds(text),
+            ext.openehr_duration_seconds(text),
+            ext.openehr_magnitude(jsonb)
+            TO ehrbase_app, ehrbase_reader;
+        -- Future ext functions we create are reachable without a manual grant
+        -- (doc 02 §3.2); default privileges apply per grantor, so this covers
+        -- exactly the migrator's own future functions.
         ALTER DEFAULT PRIVILEGES IN SCHEMA ext
             GRANT EXECUTE ON FUNCTIONS TO ehrbase_app, ehrbase_reader;
     ELSE

--- a/docker/postgres/initdb/10-ehrbase-init.sh
+++ b/docker/postgres/initdb/10-ehrbase-init.sh
@@ -24,7 +24,11 @@ psql_app() { psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$APP_
 
 echo "ehrbase-rs init: creating role '${APP_USER}' and database '${APP_DB}'"
 
-# 1) Login role (idempotent) — non-superuser by design.
+# 1) Login role (idempotent) — non-superuser by design — plus the three
+#    NOLOGIN group roles of the layered role architecture (ADR-013). The app
+#    role has no CREATEROLE, so the baseline migration can only grant to these
+#    roles if they already exist; creating them here gives dev/compose the
+#    same grant topology as a hardened deployment (no "roles absent" NOTICEs).
 psql_super <<SQL
 DO \$do\$
 BEGIN
@@ -33,6 +37,18 @@ BEGIN
   ELSE
     ALTER ROLE "${APP_USER}" LOGIN PASSWORD '${APP_PASSWORD}';
   END IF;
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'ehrbase_migrator') THEN
+    CREATE ROLE ehrbase_migrator NOLOGIN;
+  END IF;
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'ehrbase_app') THEN
+    CREATE ROLE ehrbase_app NOLOGIN;
+  END IF;
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'ehrbase_reader') THEN
+    CREATE ROLE ehrbase_reader NOLOGIN;
+  END IF;
+  -- In dev the single app user plays both migrator and writer.
+  GRANT ehrbase_migrator TO "${APP_USER}";
+  GRANT ehrbase_app TO "${APP_USER}";
 END
 \$do\$;
 SQL

--- a/website/book/src/installation/compose.md
+++ b/website/book/src/installation/compose.md
@@ -13,12 +13,21 @@ EHRbase-rs publishes two container images to GHCR:
 | Image | Contents |
 |---|---|
 | `ghcr.io/rubentalstra/ehrbase-rs` | The `ehrbase` server binary. A distroless, non-root, shell-less multi-arch image (amd64 + arm64). Configured entirely via `EHRBASE_*` environment variables. |
-| `ghcr.io/rubentalstra/ehrbase-rs-postgres` | `postgres:18.4` with the application role, database, schemas (`ehr`, `ext`), and required extensions (`uuid-ossp`, `pgcrypto`, `pg_trgm`, `btree_gist`) pre-created, so the app role never needs superuser. |
+| `ghcr.io/rubentalstra/ehrbase-rs-postgres` | `postgres:18.4` with the application role, the layered group roles (`ehrbase_migrator`, `ehrbase_app`, `ehrbase_reader`), database, schemas (`ehr`, `ext`), and required extensions (`uuid-ossp`, `pgcrypto`, `pg_trgm`, `btree_gist`) pre-created, so the app role never needs superuser. |
 
 The PostgreSQL image is **init-scripts only** — it creates roles, schemas, and
 extensions, but does not bake in migration state. The server owns the schema
 content and applies its migrations idempotently at every boot, so a fresh
 database self-provisions and a restart is a no-op.
+
+> [!NOTE]
+> PostgreSQL init scripts run **only when the data volume is empty**. If you
+> see startup notices like `skipping role creation (no CREATEROLE privilege)`
+> or `roles absent`, your volume predates the image's role setup (or you are
+> running a plain `postgres` image): either recreate the volume
+> (`docker compose down -v` — **destroys data**) or create the three group
+> roles once by hand as a superuser. The server runs fine either way — the
+> grants are a defense-in-depth layer, not a functional requirement.
 
 ## Bringing up the stack
 


### PR DESCRIPTION
Owner-reported boot noise, two root causes fixed:

1. **'roles absent' notices** — the dev postgres image created only the app login role, never the three ADR-013 group roles, so every grant block in the baseline skipped. The init script now pre-creates `ehrbase_migrator`/`ehrbase_app`/`ehrbase_reader` (NOLOGIN) + membership for the dev user — dev now has the hardened grant topology for real.
2. **~250 'no privileges were granted' warnings** — `GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA ext` swept in the superuser-owned extension functions. Now grants exactly our six `openehr_*` functions (+ default privileges for future ones).

Verified on a fresh volume: zero warnings, zero skips, roles + SELECT/INSERT/EXECUTE grants confirmed via `has_*_privilege`, server 200. ⚠ The `ext/0001` edit changes its sqlx checksum — **pre-release volumes must be recreated** (`docker compose down -v`); CHANGELOG + the compose book page say so.