### PR TITLE
x1: enforce EHR_STATUS.subject as monomorphic PARTY_SELF (upstream-diff B1/B2)

### DIFF
--- a/app/ehrbase/src/service/composition.rs
+++ b/app/ehrbase/src/service/composition.rs
@@ -482,7 +482,7 @@ impl EhrbaseService {
     /// §"Incomplete Content") relaxes the archetype/template existence &
     /// cardinality **lower** limits to zero for COMPOSITIONs; RM invariants and
     /// terminology stay at full strictness ("data may be missing, but it may not
-    /// be wrong"). The direct endpoints have no lifecycle_state and always pass
+    /// be wrong"). The direct endpoints have no `lifecycle_state` and always pass
     /// `false`.
     pub(super) async fn validate_for_commit(
         &self,

--- a/app/ehrbase/src/service/ehr.rs
+++ b/app/ehrbase/src/service/ehr.rs
@@ -438,7 +438,7 @@ impl EhrbaseService {
     /// `master06-func_tc_ehr.adoc` §set/clear-modifiable tests the flag flip, not
     /// the write-block outcome), so the wire code is underdetermined. We return
     /// `409 Conflict` — the write conflicts with the current state of the target
-    /// resource (RFC 9110 §15.5.10), the closest HTTP semantics and EHRbase's
+    /// resource (RFC 9110 §15.5.10), the closest HTTP semantics and `EHRbase`'s
     /// prior-art behaviour — via [`ServiceError::Conflict`].
     pub(super) async fn ensure_content_writable(&self, ehr_id: Uuid) -> Result<(), ServiceError> {
         if self.ehr_is_modifiable(ehr_id).await? {
@@ -630,9 +630,14 @@ pub(super) fn committer() -> Value {
 /// - `name` present (`LOCATABLE.name 1..1`);
 /// - `archetype_node_id` present and non-empty (`Archetype_node_id_valid`);
 /// - `is_queryable` / `is_modifiable` present booleans (both `1..1`);
-/// - `subject` present (`EHR_STATUS.subject 1..1 PARTY_SELF`) and identifiable —
-///   it must carry a `_type` (its concrete `PARTY_PROXY` subtype) **or** an
-///   `external_ref` (an empty `{}` subject is neither);
+/// - `subject` present and typed `PARTY_SELF` (`EHR_STATUS.subject 1..1
+///   PARTY_SELF`). `PARTY_SELF` is monomorphic (no subtypes), so a foreign
+///   concrete `_type` in this slot (e.g. `PARTY_IDENTIFIED`) is invalid; the
+///   slot is enforced through the generated `PartySelf` type's own
+///   `#[derive(OpenEhrType)]` `_type` check rather than a hand-rolled string
+///   compare. An empty `{}` subject is a **valid anonymous** subject — RM ehr
+///   `master04 §EHR Status`: "the subject is represented by a `PARTY_SELF`
+///   object, enabling it to be made completely anonymous" — so it is accepted;
 /// - when `subject.external_ref` is present it is a valid `PARTY_REF`
 ///   (`OBJECT_REF`): a non-empty `id.value` (`Id_exists`) and a non-empty
 ///   `namespace` (`Namespace_valid`). A `NULL` `external_ref` is permitted (CNF
@@ -685,17 +690,34 @@ pub(super) fn validate_ehr_status(status: &Value) -> Result<(), ServiceError> {
 
     let subject = obj
         .get("subject")
-        .and_then(Value::as_object)
+        .filter(|v| v.is_object())
         .ok_or_else(|| unproc("EHR_STATUS.subject is mandatory (1..1 PARTY_SELF)".to_owned()))?;
-    let has_type = subject.get("_type").and_then(Value::as_str).is_some();
-    let external_ref = subject.get("external_ref").filter(|v| !v.is_null());
-    if !has_type && external_ref.is_none() {
-        return Err(unproc(
-            "EHR_STATUS.subject must be an identifiable PARTY_PROXY (carry a _type or \
-             an external_ref)"
-                .to_owned(),
-        ));
-    }
+
+    // `EHR_STATUS.subject` is typed `PARTY_SELF` (RM ehr master04 §EHR Status:
+    // "the subject is represented by a PARTY_SELF object"). `PARTY_SELF` is
+    // monomorphic — it has no subtypes — so a foreign concrete `_type` in this
+    // slot (e.g. `PARTY_IDENTIFIED`) is invalid. Enforce this through the
+    // generated type itself: `PartySelf`'s `#[derive(OpenEhrType)]` `Deserialize`
+    // rejects a mismatched `_type` (openehr-derive). An absent `_type` defaults
+    // to `PARTY_SELF` and an empty `{}` deserialises to an anonymous `PARTY_SELF`
+    // (`external_ref: None`) — the spec's "completely anonymous" subject — both
+    // of which this accepts.
+    //
+    // PORT NOTE (Fix 2/B1): scoped to `EHR_STATUS.subject` rather than a
+    // whole-`EhrStatus` typed deserialize — this keeps the RM-1.2.0-vs-corpus
+    // version skew off the commit-path guard (the surrounding structural and
+    // `PARTY_REF` invariant checks cover the other attributes), matching the
+    // demographic `typed_check` pattern (`service::demographic`).
+    serde_json::from_value::<openehr_rm::prelude::PartySelf>(subject.clone()).map_err(|e| {
+        unproc(format!(
+            "EHR_STATUS.subject must be a PARTY_SELF (RM ehr master04 §EHR Status): {e}"
+        ))
+    })?;
+
+    let external_ref = subject
+        .as_object()
+        .and_then(|s| s.get("external_ref"))
+        .filter(|v| !v.is_null());
     if let Some(external_ref) = external_ref {
         let ext = external_ref.as_object().ok_or_else(|| {
             unproc("EHR_STATUS.subject.external_ref must be a PARTY_REF object".to_owned())
@@ -744,7 +766,35 @@ mod tests {
     fn default_and_typical_ehr_status_are_accepted() {
         // The server's own default and a fully-identified subject both validate.
         validate_ehr_status(&default_ehr_status()).expect("default EHR_STATUS");
+        // A subject identified via `external_ref` is still a `PARTY_SELF`
+        // (RM ehr master04 §EHR Status: "the subject is represented by a
+        // PARTY_SELF object … or alternatively to include a patient identifier").
         let identified = json!({
+            "_type": "EHR_STATUS",
+            "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
+            "name": { "_type": "DV_TEXT", "value": "EHR Status" },
+            "subject": {
+                "_type": "PARTY_SELF",
+                "external_ref": {
+                    "_type": "PARTY_REF",
+                    "namespace": "conformance",
+                    "type": "PERSON",
+                    "id": { "_type": "GENERIC_ID", "value": "subj-1", "scheme": "id_scheme" }
+                }
+            },
+            "is_queryable": true,
+            "is_modifiable": false
+        });
+        validate_ehr_status(&identified).expect("identified PARTY_SELF EHR_STATUS");
+    }
+
+    /// A subject typed with a foreign concrete `PARTY_PROXY` subtype
+    /// (`PARTY_IDENTIFIED`) is rejected — `EHR_STATUS.subject` is monomorphic
+    /// `PARTY_SELF` (RM ehr master04 §EHR Status). Regression for the upstream
+    /// diff finding B1 (`docs/conformance/upstream-ehrbase/TRIAGE.md`).
+    #[test]
+    fn ehr_status_subject_wrong_type_is_rejected() {
+        let bad = json!({
             "_type": "EHR_STATUS",
             "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
             "name": { "_type": "DV_TEXT", "value": "EHR Status" },
@@ -758,16 +808,51 @@ mod tests {
                 }
             },
             "is_queryable": true,
-            "is_modifiable": false
+            "is_modifiable": true
         });
-        validate_ehr_status(&identified).expect("identified EHR_STATUS");
+        let err = validate_ehr_status(&bad).expect_err("PARTY_IDENTIFIED subject must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("PARTY_SELF") && msg.contains("PARTY_IDENTIFIED"),
+            "rejection should name the type mismatch, got: {msg}"
+        );
     }
 
-    /// Every vendored invalid `EHR_STATUS` data set (CNF master06 §Test Data Sets,
-    /// INVALID class 2) must be rejected. Posted verbatim (unadapted), exactly as
-    /// the conformance runner drives them.
+    /// An anonymous subject — empty `PARTY_SELF` (`{}`) or an explicit
+    /// `{"_type":"PARTY_SELF"}` with no `external_ref` — is accepted. RM ehr
+    /// master04 §EHR Status: `PARTY_SELF` "enabling it to be made completely
+    /// anonymous". Regression for the upstream diff finding B2.
+    #[test]
+    fn anonymous_ehr_status_subject_is_accepted() {
+        for subject in [json!({}), json!({ "_type": "PARTY_SELF" })] {
+            let status = json!({
+                "_type": "EHR_STATUS",
+                "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
+                "name": { "_type": "DV_TEXT", "value": "EHR Status" },
+                "subject": subject,
+                "is_queryable": true,
+                "is_modifiable": true
+            });
+            validate_ehr_status(&status).expect("anonymous PARTY_SELF EHR_STATUS");
+        }
+    }
+
+    /// Every vendored `EHR_STATUS` data set the CNF corpus labels invalid
+    /// (`master06 §Test Data Sets`, INVALID class 2) must be rejected — with one
+    /// spec-cited exception.
+    ///
+    /// `001_ehr_status_subject_empty.json` (`subject: {}`) is labelled "invalid"
+    /// by the corpus but is **spec-valid**: RM ehr master04 §EHR Status makes an
+    /// empty `PARTY_SELF` a *completely anonymous* subject. Per the vendored spec
+    /// oracle (the authority, ADR-008) this is a corpus mislabelling, handled here
+    /// as a documented adjudication (the fixture is asserted *accepted*, not
+    /// silently skipped). See `docs/conformance/upstream-ehrbase/TRIAGE.md` §B2.
+    /// The other ten fixtures stay asserted-rejected.
     #[test]
     fn every_invalid_ehr_status_fixture_is_rejected() {
+        // Corpus-vs-spec adjudication: an empty PARTY_SELF is a valid anonymous
+        // subject (master04), so this "invalid"-labelled fixture is spec-valid.
+        const SPEC_VALID_ANONYMOUS: &str = "001_ehr_status_subject_empty.json";
         let dir = concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/../../docs/specs/openehr/CNF/tests/platform/robot/_resources/test_data_sets/ehr/invalid"
@@ -780,11 +865,20 @@ mod tests {
             }
             let text = std::fs::read_to_string(&path).expect("read fixture");
             let status: Value = serde_json::from_str(&text).expect("parse fixture");
-            assert!(
-                validate_ehr_status(&status).is_err(),
-                "invalid EHR_STATUS fixture was accepted: {}",
-                path.display()
-            );
+            let is_anon = path.file_name().and_then(|n| n.to_str()) == Some(SPEC_VALID_ANONYMOUS);
+            if is_anon {
+                validate_ehr_status(&status).unwrap_or_else(|e| {
+                    panic!(
+                        "spec-valid anonymous EHR_STATUS ({SPEC_VALID_ANONYMOUS}) was rejected: {e}"
+                    )
+                });
+            } else {
+                assert!(
+                    validate_ehr_status(&status).is_err(),
+                    "invalid EHR_STATUS fixture was accepted: {}",
+                    path.display()
+                );
+            }
             checked += 1;
         }
         assert_eq!(checked, 11, "expected 11 invalid EHR_STATUS fixtures");

--- a/app/ehrbase/src/service/opt_validation.rs
+++ b/app/ehrbase/src/service/opt_validation.rs
@@ -66,10 +66,10 @@ const LOCATABLE_META_ATTRS: &[&str] = &[
 
 /// Legacy `(class, attribute)` pairs tolerated for prior-art OPT compatibility
 /// (PORT NOTE): `ELEMENT.null_flavor` is the archetype-tooling (US) spelling of
-/// RM `null_flavour` (org.openehr.rm.data_structures ELEMENT), and
+/// RM `null_flavour` (`org.openehr.rm.data_structures` ELEMENT), and
 /// `ITEM_TABLE.rotated` is an RM 1.0.x attribute removed from later RM
 /// releases — both appear in widely-deployed OPT 1.4 artifacts (the vendored
-/// RIPPLE / clinical_content corpus templates).
+/// RIPPLE / `clinical_content` corpus templates).
 const LEGACY_RM_ATTRS: &[(&str, &str)] = &[
     ("ELEMENT", "null_flavor"),
     ("ITEM_TABLE", "rotated"),
@@ -343,11 +343,11 @@ fn check_cardinality_occurrences(
 
 /// VATID: `check that all codes mentioned in `definition` are defined in
 /// terminology` (`AOM2/master08-validation.adoc` line 56). Applied to at-code
-/// `node_id`s (the addressable, sibling-identifying codes, AOM14/04 §Node_id).
-/// Empty node_ids (non-addressable leaves) and non-`at`/`id` codes are exempt.
+/// `node_id`s (the addressable, sibling-identifying codes, AOM14/04 §`Node_id`).
+/// Empty `node_ids` (non-addressable leaves) and non-`at`/`id` codes are exempt.
 /// The defined-code set is collected globally across the flattened OPT (the
 /// definition roots + every `component_ontologies` set), which is deliberately
-/// lenient about per-archetype scoping — it still catches a node_id that is
+/// lenient about per-archetype scoping — it still catches a `node_id` that is
 /// defined nowhere while never mis-rejecting a correctly-scoped code.
 fn check_node_id(node_id: &str, defined_at: &HashSet<String>) -> Result<(), Violation> {
     if !is_at_code(node_id) {
@@ -363,7 +363,7 @@ fn check_node_id(node_id: &str, defined_at: &HashSet<String>) -> Result<(), Viol
 }
 
 /// An addressable archetype term code: `at0000`, `at0001.1`, or the ADL2 `id`
-/// form. A bare, empty, or free-text node_id is not an at-code.
+/// form. A bare, empty, or free-text `node_id` is not an at-code.
 fn is_at_code(code: &str) -> bool {
     let rest = code
         .strip_prefix("at")

--- a/app/ehrbase/tests/service_ehr.rs
+++ b/app/ehrbase/tests/service_ehr.rs
@@ -588,6 +588,86 @@ async fn unknown_ehr_is_not_found() {
     assert!(svc.ehr_object(missing).await.is_err());
 }
 
+#[tokio::test]
+async fn ehr_status_subject_type_is_enforced_end_to_end() {
+    // RM ehr master04 §EHR Status: EHR_STATUS.subject is a (monomorphic)
+    // PARTY_SELF. Through the real service seam (the same path the REST layer
+    // calls), a foreign concrete _type (PARTY_IDENTIFIED) in that slot is a
+    // 422 (SM ContentInvalid) naming the mismatch — on both EHR create and
+    // EHR_STATUS PUT — while an anonymous empty PARTY_SELF is accepted.
+    // Regression for the upstream diff findings B1/B2
+    // (docs/conformance/upstream-ehrbase/TRIAGE.md).
+    let pg = Pg::start().await;
+    let svc = EhrbaseService::new(pg.migrated_pool("subjecttype").await);
+
+    let wrong_subject = json!({
+        "_type": "EHR_STATUS",
+        "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
+        "name": { "_type": "DV_TEXT", "value": "EHR Status" },
+        "subject": {
+            "_type": "PARTY_IDENTIFIED",
+            "external_ref": {
+                "_type": "PARTY_REF",
+                "namespace": "patients",
+                "type": "PERSON",
+                "id": { "_type": "HIER_OBJECT_ID", "value": "patient-xyz" }
+            }
+        },
+        "is_queryable": true,
+        "is_modifiable": true
+    });
+
+    // (1) EHR create with a PARTY_IDENTIFIED subject → 422 naming the mismatch.
+    let created = svc.create_ehr(Some(wrong_subject.clone())).await;
+    match created {
+        Err(SmError {
+            status: CallStatusType::ContentInvalid,
+            message,
+        }) => assert!(
+            message.contains("PARTY_SELF") && message.contains("PARTY_IDENTIFIED"),
+            "rejection should name the type mismatch, got: {message}"
+        ),
+        other => panic!("PARTY_IDENTIFIED subject on create must be 422, got {other:?}"),
+    }
+
+    // (2) EHR_STATUS PUT with a PARTY_IDENTIFIED subject → 422 naming the mismatch.
+    let ehr_uuid = svc.create_ehr(None).await.expect("ehr");
+    let status_v1 = svc
+        .get_ehr_status_at_time(ehr_uuid, None)
+        .await
+        .expect("status v1");
+    let ovid_v1 = uid(&status_v1).to_owned();
+    let mut put_body = wrong_subject;
+    put_body.as_object_mut().unwrap().remove("uid");
+    let put = svc
+        .replace_ehr_status(ehr_uuid, uv(put_body, "251", Some(&ovid_v1)))
+        .await;
+    match put {
+        Err(SmError {
+            status: CallStatusType::ContentInvalid,
+            message,
+        }) => assert!(
+            message.contains("PARTY_SELF") && message.contains("PARTY_IDENTIFIED"),
+            "PUT rejection should name the type mismatch, got: {message}"
+        ),
+        other => panic!("PARTY_IDENTIFIED subject on PUT must be 422, got {other:?}"),
+    }
+
+    // (3) An anonymous empty PARTY_SELF subject is accepted on create
+    // ("PARTY_SELF … enabling it to be made completely anonymous", master04).
+    let anonymous = json!({
+        "_type": "EHR_STATUS",
+        "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
+        "name": { "_type": "DV_TEXT", "value": "EHR Status" },
+        "subject": {},
+        "is_queryable": true,
+        "is_modifiable": true
+    });
+    svc.create_ehr(Some(anonymous))
+        .await
+        .expect("an anonymous PARTY_SELF EHR_STATUS is accepted");
+}
+
 /// A `DV_CODED_TEXT` audit change_type (openEHR audit change-type group).
 fn change_type(code: &str, value: &str) -> Value {
     json!({
@@ -861,8 +941,10 @@ async fn ehr_get_by_subject_finds_the_ehr() {
         "_type": "EHR_STATUS",
         "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
         "name": { "_type": "DV_TEXT", "value": "EHR Status" },
+        // EHR_STATUS.subject is PARTY_SELF (RM ehr master04); the subject is
+        // identified via its external_ref, not a PARTY_IDENTIFIED type.
         "subject": {
-            "_type": "PARTY_IDENTIFIED",
+            "_type": "PARTY_SELF",
             "external_ref": {
                 "_type": "PARTY_REF",
                 "namespace": "patients",
@@ -1222,8 +1304,10 @@ async fn duplicate_subject_ehr_creation_conflicts() {
             "_type": "EHR_STATUS",
             "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
             "name": { "_type": "DV_TEXT", "value": "EHR Status" },
+            // EHR_STATUS.subject is PARTY_SELF (RM ehr master04); identified by
+            // its external_ref.
             "subject": {
-                "_type": "PARTY_IDENTIFIED",
+                "_type": "PARTY_SELF",
                 "external_ref": {
                     "_type": "PARTY_REF",
                     "namespace": "patients",

--- a/crates/openehr-flat/src/validation/leaf.rs
+++ b/crates/openehr-flat/src/validation/leaf.rs
@@ -135,12 +135,12 @@ fn check_code_phrase(v: &mut Validator, instance: &Value, wt: &WebTemplateNode) 
 /// Integer}` (Real for `DV_SCALE`) entries, and validity requires the instance's
 /// **(symbol, value) PAIR** to match one entry — not the symbol alone nor the
 /// value alone (AOM 1.4 `AM/docs/UML/classes/org.openehr.am.aom14.ordinal.adoc`
-/// §ORDINAL / §C_ORDINAL; the pairing is normative per
+/// §ORDINAL / §`C_ORDINAL`; the pairing is normative per
 /// `AOM2/master04.3-constraint_model-second_order.adoc` §Tuple Constraints L19-21
 /// — "as pairs not just as allowable alternatives … which would incorrectly
 /// allow any mixing of the Integer and code values"; CNF
 /// `master17.3-content_tc_data_types-quantity.adoc` CONT-DV_ORDINAL/DV_SCALE-
-/// validate_constraint: a right symbol with a wrong value, or a right value with
+/// `validate_constraint`: a right symbol with a wrong value, or a right value with
 /// a wrong symbol, both reject). The `WebTemplate` `ordinal_input` carries each
 /// entry as a coded value whose `value` is the symbol code and whose `ordinal`
 /// (or `scale`) is the paired numeric value.
@@ -746,7 +746,7 @@ fn check_string_constraints(
 /// with `/`…`/`; the match is full-string (anchored).
 ///
 /// AOM 1.4 `C_STRING.valid_value` (`AM/docs/UML/classes/org.openehr.am.aom14.c_string.adoc`
-/// §valid_value; `master04-constraint_model_package.adoc` §Valid_value L60-62) is
+/// §`valid_value`; `master04-constraint_model_package.adoc` §`Valid_value` L60-62) is
 /// affirmative — a value is valid **iff** it matches the pattern, so a non-match
 /// must be reported (F-07-11: the former code returned `true` on a *compile*
 /// failure, silently accepting a value against a pattern it never evaluated).

--- a/crates/openehr-flat/src/validation/mod.rs
+++ b/crates/openehr-flat/src/validation/mod.rs
@@ -312,7 +312,7 @@ impl Validator {
     /// rule 2). A rejected node is not descended into (the walk already skips it).
     ///
     /// PORT NOTE (ADR-012): AOM 1.4 `valid_value`
-    /// (`AM/docs/AOM1.4/master04-constraint_model_package.adoc` §Valid_value
+    /// (`AM/docs/AOM1.4/master04-constraint_model_package.adoc` §`Valid_value`
     /// L60-62) is a positive-only cascade, silent on unmatched instance nodes;
     /// closed-world rejection follows the AOM2 direction + de-facto CDR behaviour
     /// and lands only behind the ECC zero-drift gate.

--- a/crates/openehr-flat/src/validation/tests.rs
+++ b/crates/openehr-flat/src/validation/tests.rs
@@ -703,7 +703,7 @@ fn cardinality_one_plus_empty_rejected() {
 }
 
 /// A bare mandatory attribute (existence `1..1`, no value constraint) must be
-/// present (master15 context_mand; AOM 1.4 §existence).
+/// present (master15 `context_mand`; AOM 1.4 §existence).
 #[test]
 fn bare_mandatory_attribute_absent_rejected() {
     let mut root = node("COMPOSITION", "");
@@ -722,7 +722,7 @@ fn bare_mandatory_attribute_absent_rejected() {
 
 /// A hoisted-wrapper slot narrowed to a concrete subtype rejects a sibling
 /// subtype and accepts the narrowed one; an abstract slot accepts any subtype
-/// (master16 §ITEM_STRUCTURE/§EVENT "Class not allowed").
+/// (master16 §`ITEM_STRUCTURE/§EVENT` "Class not allowed").
 #[test]
 fn slot_narrowing() {
     let mut eval = node("EVALUATION", "/content[at0001]");
@@ -754,7 +754,7 @@ fn slot_narrowing() {
     );
 }
 
-/// `C_INTEGER.list` on DV_COUNT.magnitude (master17.3 CONT-DV_COUNT-validate_list).
+/// `C_INTEGER.list` on `DV_COUNT.magnitude` (master17.3 CONT-DV_COUNT-validate_list).
 #[test]
 fn numeric_list_membership() {
     let mut count = node("DV_COUNT", "/value");
@@ -770,7 +770,7 @@ fn numeric_list_membership() {
     assert!(walk_only(&good, &count).is_empty());
 }
 
-/// DV_PROPORTION `type` kind membership (master17.3 CONT-DV_PROPORTION-*).
+/// `DV_PROPORTION` `type` kind membership (master17.3 CONT-DV_PROPORTION-*).
 #[test]
 fn proportion_kind_membership() {
     let mut prop = node("DV_PROPORTION", "/value");
@@ -790,7 +790,7 @@ fn proportion_kind_membership() {
     assert!(walk_only(&good, &prop).is_empty());
 }
 
-/// C_DATE pattern + range (master17.4 CONT-DV_DATE-validate_constraint/-range).
+/// `C_DATE` pattern + range (master17.4 CONT-DV_DATE-validate_constraint/-range).
 #[test]
 fn temporal_pattern_and_range() {
     let mut date = node("DV_DATE", "/value");
@@ -821,7 +821,7 @@ fn temporal_pattern_and_range() {
     assert!(walk_only(&ok, &date).is_empty());
 }
 
-/// C_TIME pattern: a partial time violates HH:MM:SS (master17.4 CONT-DV_TIME).
+/// `C_TIME` pattern: a partial time violates HH:MM:SS (master17.4 CONT-DV_TIME).
 #[test]
 fn time_pattern_partial_rejected() {
     let mut time = node("DV_TIME", "/value");
@@ -842,7 +842,7 @@ fn time_pattern_partial_rejected() {
     assert!(walk_only(&json!({"_type": "DV_TIME", "value": "22:18:16"}), &time).is_empty());
 }
 
-/// C_DURATION allowed fields + range (master17.4 CONT-DV_DURATION-*).
+/// `C_DURATION` allowed fields + range (master17.4 CONT-DV_DURATION-*).
 #[test]
 fn duration_fields_and_range() {
     let mut dur = node("DV_DURATION", "/value");
@@ -875,8 +875,8 @@ fn duration_fields_and_range() {
     assert!(walk_only(&json!({"_type": "DV_DURATION", "value": "PT30M"}), &dur).is_empty());
 }
 
-/// An enumerated **external** C_CODE_PHRASE list constrains membership
-/// (master17.2 CONT-DV_CODED_TEXT-validate_ext_term; AOM 1.4 §C_CODE_PHRASE).
+/// An enumerated **external** `C_CODE_PHRASE` list constrains membership
+/// (master17.2 CONT-DV_CODED_TEXT-validate_ext_term; AOM 1.4 §`C_CODE_PHRASE`).
 #[test]
 fn external_code_list_membership() {
     let mut coded = node("DV_CODED_TEXT", "/value");
@@ -900,8 +900,8 @@ fn external_code_list_membership() {
     assert!(walk_only(&other, &coded).is_empty());
 }
 
-/// C_CODE_PHRASE on a coded attribute outside `defining_code`
-/// (DV_MULTIMEDIA.media_type — master17.6 CONT-DV_MULTIMEDIA-validate_media_type).
+/// `C_CODE_PHRASE` on a coded attribute outside `defining_code`
+/// (`DV_MULTIMEDIA.media_type` — master17.6 CONT-DV_MULTIMEDIA-validate_media_type).
 #[test]
 fn media_type_code_list() {
     let mut mm = node("DV_MULTIMEDIA", "/value");
@@ -973,7 +973,7 @@ fn closed_world_rejects_foreign_content() {
 }
 
 /// A metadata value (no `archetype_node_id`, i.e. non-LOCATABLE) under a closed
-/// attribute is never flagged (ADR-012 rule 2 — the archetype_node_id
+/// attribute is never flagged (ADR-012 rule 2 — the `archetype_node_id`
 /// discriminator).
 #[test]
 fn closed_world_ignores_metadata_values() {

--- a/crates/openehr-flat/src/webtemplate/builder.rs
+++ b/crates/openehr-flat/src/webtemplate/builder.rs
@@ -876,9 +876,9 @@ fn existence_constraints(co: &CObject, node_path: &str) -> Vec<WebTemplateExiste
 /// alternative is lost.
 ///
 /// An attribute whose constraint children carry **no** `node_id` and has no slot
-/// is left OPEN — AOM 1.4 (`master04-constraint_model_package.adoc` §node_id
+/// is left OPEN — AOM 1.4 (`master04-constraint_model_package.adoc` §`node_id`
 /// L44: a near-leaf with no same-attribute siblings "can safely have no
-/// node_id") — matching the RM-metadata / plain-attribute carve-out (ADR-012
+/// `node_id`") — matching the RM-metadata / plain-attribute carve-out (ADR-012
 /// rule 2): `name`/`value`/`category`/`context` etc. hold non-LOCATABLE values
 /// that carry no `archetype_node_id` and so are never subject to sibling closure.
 fn closed_attributes(co: &CObject, node_path: &str) -> Vec<WebTemplateClosedAttribute> {

--- a/crates/openehr-flat/tests/validation.rs
+++ b/crates/openehr-flat/tests/validation.rs
@@ -102,9 +102,9 @@ fn kinds(msgs: &[ValidationMessage]) -> Vec<ValidationKind> {
 /// flags; those are excluded here, not silently tolerated.)
 ///
 /// The vendored corpus mixes openEHR reference data with **EHRbase-SDK** data,
-/// and EHRbase is *lenient*: some SDK fixtures omit RM-mandatory attributes that
+/// and `EHRbase` is *lenient*: some SDK fixtures omit RM-mandatory attributes that
 /// a strict validator rightly rejects. Per ADR-008 (openEHR spec conformance,
-/// not EHRbase parity) we do **not** tolerate that leniency, so such fixtures are
+/// not `EHRbase` parity) we do **not** tolerate that leniency, so such fixtures are
 /// excluded here with the exact spec violation named — they are not a valid
 /// oracle for "validates clean". Excluded on those grounds:
 /// - `rawdb_composition.json` — its `composer.external_ref` is a `PARTY_REF`

--- a/crates/openehr-rm/src/validate.rs
+++ b/crates/openehr-rm/src/validate.rs
@@ -137,7 +137,7 @@ fn in_range(s: &str, lo: u32, hi: u32) -> bool {
 /// divisible by 400 (BASE `Time_definitions`; the calendar `days_in_month`
 /// depends on it).
 fn is_leap_year(year: u32) -> bool {
-    (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
+    (year.is_multiple_of(4) && !year.is_multiple_of(100)) || year.is_multiple_of(400)
 }
 
 /// Calendar days in a given month of a given year — the `days_in_month (m, y)`

--- a/crates/openehr-rm/tests/type_dispatch.rs
+++ b/crates/openehr-rm/tests/type_dispatch.rs
@@ -11,7 +11,7 @@
 //! `_type`-less value to the base concrete type.
 
 use openehr_base::prelude::Uid;
-use openehr_rm::prelude::{DataValue, DvText};
+use openehr_rm::prelude::{DataValue, DvText, PartySelf};
 
 // ── F-04-01: a `_type`-less *abstract* slot value is rejected, not mis-typed ──
 
@@ -135,6 +135,39 @@ fn concrete_poly_slot_unknown_type_is_rejected() {
     assert!(
         msg.contains("DV_TEXT") && msg.contains("DV_QUANTITY"),
         "error should name the slot and the offending _type, got: {msg}"
+    );
+}
+
+// ── Monomorphic struct slot: a foreign `_type` is rejected (EHR_STATUS.subject) ─
+
+// `EHR_STATUS.subject : PARTY_SELF` is a *monomorphic* slot — `PARTY_SELF` has no
+// subtypes — so the generated `PartySelf` struct's `#[derive(OpenEhrType)]`
+// `Deserialize` must reject any non-`PARTY_SELF` `_type` (a `PARTY_IDENTIFIED`
+// payload in that slot is invalid canonical JSON), while tolerating an absent
+// `_type` (defaults to the declared type). RM ehr master04 §EHR Status.
+
+#[test]
+fn monomorphic_struct_slot_rejects_foreign_type() {
+    let err = serde_json::from_str::<PartySelf>(
+        r#"{"_type":"PARTY_IDENTIFIED","name":"Bob","identifiers":[]}"#,
+    )
+    .expect_err("a PARTY_IDENTIFIED payload must not deserialize as PARTY_SELF");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("PARTY_SELF") && msg.contains("PARTY_IDENTIFIED"),
+        "error should name the expected and offending types, got: {msg}"
+    );
+}
+
+#[test]
+fn monomorphic_struct_slot_accepts_matching_and_absent_type() {
+    // Explicit matching _type.
+    serde_json::from_str::<PartySelf>(r#"{"_type":"PARTY_SELF"}"#).expect("explicit PARTY_SELF");
+    // Absent _type defaults to the declared type (an anonymous PARTY_SELF).
+    let anon: PartySelf = serde_json::from_str(r"{}").expect("empty anonymous PARTY_SELF");
+    assert!(
+        anon.external_ref.is_none(),
+        "an empty PARTY_SELF is an anonymous subject with no external_ref"
     );
 }
 

--- a/docker/conformance/docker-compose.yml
+++ b/docker/conformance/docker-compose.yml
@@ -64,7 +64,7 @@ services:
     profiles: ["java"]
 
   ehrbase-java:
-    image: ${EHRBASE_JAVA_IMAGE:-ehrbase/ehrbase:2.33.0}
+    image: ${EHRBASE_JAVA_IMAGE:-ehrbase/ehrbase:2.34.0}
     depends_on:
       ehrbase-java-db:
         condition: service_healthy

--- a/docker/conformance/run.sh
+++ b/docker/conformance/run.sh
@@ -15,14 +15,14 @@ set -euo pipefail
 EDITION="${1:-}"
 case "$EDITION" in
   rs)   PORT=8090; PROFILE=rs;   ADMIN_USER=ehrbase ;;
-  java) PORT=8091; PROFILE=java; ADMIN_USER=ehrbase-admin ;;
+  java) PORT=8091; PROFILE=java; ADMIN_USER=ehrbase-admin; OUT_OVERRIDE=docs/conformance/upstream-ehrbase ;;
   *) echo "usage: $0 <rs|java>" >&2; exit 2 ;;
 esac
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$HERE/../.." && pwd)"
 BASE="http://localhost:${PORT}/ehrbase/rest/openehr/v1"
-OUT="docs/conformance/${EDITION}"
+OUT="${OUT_OVERRIDE:-docs/conformance/${EDITION}}"
 
 cd "$HERE"
 echo ">> [$EDITION] starting stack (docker compose --profile $PROFILE up -d)…"
@@ -44,10 +44,29 @@ fi
 
 echo ">> [$EDITION] running the CNF suite → $OUT …"
 cd "$ROOT"
+EXTRA_ARGS=()
+if [ "$EDITION" = "java" ]; then
+  # Upstream SUT identity + sibling-mounted admin (X1, docs/plans/x1-comparison.md).
+  #
+  # NOTE (owner ruling 2026-07-11): the fairness-adjudication register is
+  # DISABLED for now — the current objective is a RAW Java-vs-Rust-vs-spec diff
+  # to find compliance bugs in both servers (see docs/conformance/upstream-ehrbase/TRIAGE.md),
+  # so nothing is exempted. Re-enable by restoring the --adjudications line below
+  # when the public fairness comparison (X1.5) is built.
+  JAVA_DIGEST="$(docker inspect "${EHRBASE_JAVA_IMAGE:-ehrbase/ehrbase:2.34.0}" --format '{{index .RepoDigests 0}}' 2>/dev/null | cut -d@ -f2 || true)"
+  EXTRA_ARGS+=(
+    --sut-name ehrbase-java
+    --sut-version 2.34.0
+    --admin-base-url "http://localhost:${PORT}/ehrbase/rest/admin"
+    # --adjudications tools/conformance/adjudications/ehrbase-java-2.34.toml  # disabled — raw diff (owner 2026-07-11)
+  )
+  [ -n "$JAVA_DIGEST" ] && EXTRA_ARGS+=(--sut-image-digest "$JAVA_DIGEST")
+fi
 cargo run -p conformance --bin conformance -- \
   run --base-url "$BASE" \
   --auth "basic:ehrbase:ehrbase" \
   --admin-auth "basic:${ADMIN_USER}:ehrbase" \
+  ${EXTRA_ARGS+"${EXTRA_ARGS[@]}"} \
   --out "$OUT" || true   # exit 1 = there are findings; the report is still written
 
 echo ">> [$EDITION] tearing down…"

--- a/docs/conformance/upstream-ehrbase/CATALOG.md
+++ b/docs/conformance/upstream-ehrbase/CATALOG.md
@@ -1,0 +1,413 @@
+# The ehrbase-rs Conformance Catalogue (ECC)
+
+Generated per run — do not edit. Numbers are allocated once in
+`tools/conformance/inventory/ecc-catalog.tsv` and never reused.
+
+## EHR — EHR service (13 cases, 13 active)
+
+| ECC id | Status | Title | Last run |
+|---|---|---|---|
+| ECC-EHR-001 | Active | EHR existence check — existing EHR id | passed |
+| ECC-EHR-002 | Active | EHR existence check — existing subject id | failed |
+| ECC-EHR-003 | Active | EHR existence check — non existing EHR id | passed |
+| ECC-EHR-004 | Active | EHR existence check — non existing subject id | passed |
+| ECC-EHR-005 | Active | Create EHR — main | failed |
+| ECC-EHR-006 | Active | Create EHR — same EHR twice | passed |
+| ECC-EHR-007 | Active | Create EHR — two EHRs same patient | failed |
+| ECC-EHR-008 | Active | Get EHR — existing EHR by EHR id | failed |
+| ECC-EHR-009 | Active | Get EHR — existing EHR by subject id | failed |
+| ECC-EHR-010 | Active | Get EHR — get EHR by invalid EHR id | passed |
+| ECC-EHR-011 | Active | Get EHR — get EHR by invalid subject id | passed |
+| ECC-EHR-012 | Active | Create EHR — reject invalid EHR_STATUS data sets | failed |
+| ECC-EHR-013 | Active | Create anonymous (subject-less) EHR | failed |
+
+## STA — EHR_STATUS (10 cases, 10 active)
+
+| ECC id | Status | Title | Last run |
+|---|---|---|---|
+| ECC-STA-001 | Active | Get EHR_STATUS — get by EHR id | failed |
+| ECC-STA-002 | Active | Get EHR_STATUS — bad EHR | passed |
+| ECC-STA-003 | Active | Set EHR_STATUS is_queryable — existing EHR | failed |
+| ECC-STA-004 | Active | Set EHR_STATUS is_queryable — bad EHR | passed |
+| ECC-STA-005 | Active | Set EHR_STATUS is_modifiable — existing EHR | failed |
+| ECC-STA-006 | Active | Set EHR_STATUS is_modifiable — bad EHR | passed |
+| ECC-STA-007 | Active | Clear EHR_STATUS is_queryable — existing EHR | failed |
+| ECC-STA-008 | Active | Clear EHR_STATUS is_queryable — bad EHR | passed |
+| ECC-STA-009 | Active | Clear EHR_STATUS is_modifiable — existing EHR | failed |
+| ECC-STA-010 | Active | Clear EHR_STATUS is_modifiable — bad EHR | passed |
+
+## COM — COMPOSITION (31 cases, 31 active)
+
+| ECC id | Status | Title | Last run |
+|---|---|---|---|
+| ECC-COM-001 | Active | Create composition — event | failed |
+| ECC-COM-002 | Active | Create composition — persistent | failed |
+| ECC-COM-003 | Active | Create composition — same OPT twice | failed |
+| ECC-COM-004 | Active | Create composition — invalid event | failed |
+| ECC-COM-005 | Active | Create composition — invalid persistent | failed |
+| ECC-COM-006 | Active | Create composition — event bad OPT | passed |
+| ECC-COM-007 | Active | Create composition — event bad EHR | failed |
+| ECC-COM-008 | Active | Get latest composition | failed |
+| ECC-COM-009 | Active | Get latest composition — bad composition | passed |
+| ECC-COM-010 | Active | Get latest composition — bad EHR | passed |
+| ECC-COM-011 | Active | Composition existence check — bad composition | passed |
+| ECC-COM-012 | Active | Composition existence check — bad EHR | passed |
+| ECC-COM-013 | Active | Get composition at time | failed |
+| ECC-COM-014 | Active | Get composition at time — no time arg | failed |
+| ECC-COM-015 | Active | Get composition at time — bad composition | passed |
+| ECC-COM-016 | Active | Get composition at time — bad EHR | passed |
+| ECC-COM-017 | Active | Get composition at multiple times | failed |
+| ECC-COM-018 | Active | Get composition version | failed |
+| ECC-COM-019 | Active | Get composition version — bad version | passed |
+| ECC-COM-020 | Active | Get composition version — bad EHR | passed |
+| ECC-COM-021 | Active | Get composition versions | failed |
+| ECC-COM-022 | Active | Get versioned composition | failed |
+| ECC-COM-023 | Active | Get versioned composition — non existent | passed |
+| ECC-COM-024 | Active | Get versioned composition — bad EHR | passed |
+| ECC-COM-025 | Active | Update composition — event | failed |
+| ECC-COM-026 | Active | Update composition — persistent | failed |
+| ECC-COM-027 | Active | Update composition — non existent | failed |
+| ECC-COM-028 | Active | Update composition — wrong template | failed |
+| ECC-COM-029 | Active | Delete composition — event | failed |
+| ECC-COM-030 | Active | Delete composition — persistent | failed |
+| ECC-COM-031 | Active | Delete composition — non existent | passed |
+
+## CTB — CONTRIBUTION (change sets) (31 cases, 31 active)
+
+| ECC id | Status | Title | Last run |
+|---|---|---|---|
+| ECC-CTB-001 | Active | Commit contribution — valid composition | failed |
+| ECC-CTB-002 | Active | Commit contribution — invalid composition | failed |
+| ECC-CTB-003 | Active | Commit contribution — empty | passed |
+| ECC-CTB-004 | Active | Commit contribution — valid invalid compositions | failed |
+| ECC-CTB-005 | Active | Commit contribution — non exiting OPT | passed |
+| ECC-CTB-006 | Active | Commit contribution — event composition | failed |
+| ECC-CTB-007 | Active | Commit contribution — persistent composition | failed |
+| ECC-CTB-008 | Active | Commit contribution — delete | failed |
+| ECC-CTB-009 | Active | Commit contribution — two commits second invalid | failed |
+| ECC-CTB-010 | Active | Commit contribution — two commits second creation | failed |
+| ECC-CTB-011 | Active | Commit contribution — minimal EHR status | passed |
+| ECC-CTB-012 | Active | Commit contribution — full EHR status | passed |
+| ECC-CTB-013 | Active | Commit contribution — EHR status invalid change type | passed |
+| ECC-CTB-014 | Active | Commit contribution — invalid EHR status | passed |
+| ECC-CTB-015 | Active | Commit contribution — valid directory | passed |
+| ECC-CTB-016 | Active | Commit contribution — fail create existing directory | passed |
+| ECC-CTB-017 | Active | Commit contribution — fail modify non existing directory | passed |
+| ECC-CTB-018 | Active | Commit contribution — update existing directory | passed |
+| ECC-CTB-019 | Active | Get contribution — existing | failed |
+| ECC-CTB-020 | Active | Get contribution — empty EHR | passed |
+| ECC-CTB-021 | Active | Get contribution — bad EHR | passed |
+| ECC-CTB-022 | Active | Get contribution — bad contribution | failed |
+| ECC-CTB-023 | Active | Contribution existence check — existing | failed |
+| ECC-CTB-024 | Active | Contribution existence check — bad contribution | failed |
+| ECC-CTB-025 | Active | Contribution existence check — bad EHR | passed |
+| ECC-CTB-026 | Active | Contribution existence check — empty EHR | passed |
+| ECC-CTB-027 | Active | List contributions — empty | skipped |
+| ECC-CTB-028 | Active | List contributions — non existing EHR | skipped |
+| ECC-CTB-029 | Active | List contributions — post commit | skipped |
+| ECC-CTB-030 | Active | List contributions — EHR containing directory | skipped |
+| ECC-CTB-031 | Active | List contributions — EHR containing EHR status | skipped |
+
+## DIR — DIRECTORY (FOLDER) (37 cases, 37 active)
+
+| ECC id | Status | Title | Last run |
+|---|---|---|---|
+| ECC-DIR-001 | Active | Create directory — empty EHR | passed |
+| ECC-DIR-002 | Active | Create directory — EHR with directory | passed |
+| ECC-DIR-003 | Active | Create directory — bad EHR | passed |
+| ECC-DIR-004 | Active | Get directory — EHR root directory | passed |
+| ECC-DIR-005 | Active | Get directory — bad EHR | passed |
+| ECC-DIR-006 | Active | Get directory at time — EHR with directory | passed |
+| ECC-DIR-007 | Active | Get directory at time — bad EHR | passed |
+| ECC-DIR-008 | Active | Update directory — EHR with directory | passed |
+| ECC-DIR-009 | Active | Update directory — bad EHR | passed |
+| ECC-DIR-010 | Active | Delete directory — EHR with directory | passed |
+| ECC-DIR-011 | Active | Delete directory — bad EHR | passed |
+| ECC-DIR-012 | Active | Directory existence check — empty EHR | passed |
+| ECC-DIR-013 | Active | Directory existence check — EHR with directory | passed |
+| ECC-DIR-014 | Active | Directory existence check — bad EHR | passed |
+| ECC-DIR-015 | Active | Directory path existence check — EHR root directory | passed |
+| ECC-DIR-016 | Active | Directory path existence check — folder structure | passed |
+| ECC-DIR-017 | Active | Directory path existence check — empty EHR | passed |
+| ECC-DIR-018 | Active | Directory path existence check — bad EHR | passed |
+| ECC-DIR-019 | Active | Directory version existence check — empty EHR | passed |
+| ECC-DIR-020 | Active | Directory version existence check — directory with two versions | passed |
+| ECC-DIR-021 | Active | Directory version existence check — bad EHR | passed |
+| ECC-DIR-022 | Active | Get directory — empty EHR | passed |
+| ECC-DIR-023 | Active | Get directory — directory with structure | passed |
+| ECC-DIR-024 | Active | Get directory at time — EHR with directory empty time | passed |
+| ECC-DIR-025 | Active | Get directory at time — EHR with directory versions | passed |
+| ECC-DIR-026 | Active | Get directory at time — EHR with directory versions empty time | passed |
+| ECC-DIR-027 | Active | Get directory at time — empty EHR | passed |
+| ECC-DIR-028 | Active | Get directory at time — empty EHR empty time | passed |
+| ECC-DIR-029 | Active | Get directory at time — multiple versions first | passed |
+| ECC-DIR-030 | Active | Get directory at version — bad EHR | passed |
+| ECC-DIR-031 | Active | Get directory at version — directory with two versions | passed |
+| ECC-DIR-032 | Active | Get directory at version — empty EHR | passed |
+| ECC-DIR-033 | Active | Get versioned directory — empty EHR | passed |
+| ECC-DIR-034 | Active | Get versioned directory — directory with two versions | passed |
+| ECC-DIR-035 | Active | Get versioned directory — bad EHR | passed |
+| ECC-DIR-036 | Active | Update directory — empty EHR | passed |
+| ECC-DIR-037 | Active | Delete directory — empty EHR | passed |
+
+## TPL — Template / OPT provisioning (16 cases, 16 active)
+
+| ECC id | Status | Title | Last run |
+|---|---|---|---|
+| ECC-TPL-001 | Active | Upload OPT — valid OPT | failed |
+| ECC-TPL-002 | Active | Upload OPT — invalid OPT | passed |
+| ECC-TPL-003 | Active | List OPTs — retrieve all no OPTs | passed |
+| ECC-TPL-004 | Active | Upload OPT — valid OPT twice conflict | failed |
+| ECC-TPL-005 | Active | Upload OPT — valid OPT twice no conflict | failed |
+| ECC-TPL-006 | Active | Get OPT — retrieve single | failed |
+| ECC-TPL-007 | Active | Get OPT — retrieve latest version | failed |
+| ECC-TPL-008 | Active | Get OPT — retrieve specific version | failed |
+| ECC-TPL-009 | Active | Get OPT — retrieve fail | passed |
+| ECC-TPL-010 | Active | List OPTs — retrieve all | failed |
+| ECC-TPL-011 | Active | Validate OPT — valid OPT | failed |
+| ECC-TPL-012 | Active | Validate OPT — invalid OPT | passed |
+| ECC-TPL-013 | Active | Delete OPT — delete non existing | skipped |
+| ECC-TPL-014 | Active | Delete OPT — delete existing | skipped |
+| ECC-TPL-015 | Active | Delete OPT — delete latest version | skipped |
+| ECC-TPL-016 | Active | Delete OPT — delete specific version | skipped |
+
+## SQR — Stored-query provisioning (7 cases, 7 active)
+
+| ECC id | Status | Title | Last run |
+|---|---|---|---|
+| ECC-SQR-001 | Active | Store stored query — valid | passed |
+| ECC-SQR-002 | Active | List stored queries — non empty | passed |
+| ECC-SQR-003 | Active | Stored query existence check — xxx | passed |
+| ECC-SQR-004 | Active | List stored queries — empty | skipped |
+| ECC-SQR-005 | Active | List stored queries — select items | skipped |
+| ECC-SQR-006 | Active | Store stored query — bad formalism | passed |
+| ECC-SQR-007 | Active | Store stored query — invalid | passed |
+
+## QRY — AQL execution (13 cases, 13 active)
+
+| ECC id | Status | Title | Last run |
+|---|---|---|---|
+| ECC-QRY-001 | Active | Query service smoke test | passed |
+| ECC-QRY-002 | Active | Execute ad-hoc AQL query — empty db | failed |
+| ECC-QRY-003 | Active | Execute stored AQL query — empty db | failed |
+| ECC-QRY-004 | Active | Execute ad-hoc AQL query — loaded db | failed |
+| ECC-QRY-005 | Active | AQL corpus — invalid queries rejected | passed |
+| ECC-QRY-006 | Active | AQL corpus — A empty db | failed |
+| ECC-QRY-007 | Active | AQL corpus — B empty db | failed |
+| ECC-QRY-008 | Active | AQL corpus — C empty db | failed |
+| ECC-QRY-009 | Active | AQL corpus — D empty db | failed |
+| ECC-QRY-010 | Active | AQL corpus — A loaded db | failed |
+| ECC-QRY-011 | Active | AQL corpus — B loaded db | failed |
+| ECC-QRY-012 | Active | AQL corpus — C loaded db | passed |
+| ECC-QRY-013 | Active | AQL corpus — D loaded db | failed |
+
+## VAL — Content / archetype validation (119 cases, 119 active)
+
+| ECC id | Status | Title | Last run |
+|---|---|---|---|
+| ECC-VAL-001 | Active | Validate COMPOSITION — content card any context any | failed |
+| ECC-VAL-002 | Active | Validate COMPOSITION — content card 1plus context any | failed |
+| ECC-VAL-003 | Active | Validate COMPOSITION — content card 3plus context any | failed |
+| ECC-VAL-004 | Active | Validate COMPOSITION — content card OPT context any | failed |
+| ECC-VAL-005 | Active | Validate COMPOSITION — content card mand context any | failed |
+| ECC-VAL-006 | Active | Validate COMPOSITION — content card 3to5 context any | failed |
+| ECC-VAL-007 | Active | Validate COMPOSITION — content card any context mand | failed |
+| ECC-VAL-008 | Active | Validate COMPOSITION — content card 1plus context mand | failed |
+| ECC-VAL-009 | Active | Validate COMPOSITION — content card 3plus context mand | failed |
+| ECC-VAL-010 | Active | Validate COMPOSITION — content card OPT context mand | failed |
+| ECC-VAL-011 | Active | Validate COMPOSITION — content card mand context mand | failed |
+| ECC-VAL-012 | Active | Validate COMPOSITION — content card 3to5 context mand | failed |
+| ECC-VAL-013 | Active | Validate OBSERVATION — state ex OPT protocol ex OPT | failed |
+| ECC-VAL-014 | Active | Validate OBSERVATION — state ex OPT protocol ex mand | failed |
+| ECC-VAL-015 | Active | Validate OBSERVATION — state ex mand protocol ex OPT | failed |
+| ECC-VAL-016 | Active | Validate OBSERVATION — state ex mand protocol ex mand | failed |
+| ECC-VAL-017 | Active | Validate HISTORY — events card any summary ex OPT | failed |
+| ECC-VAL-018 | Active | Validate HISTORY — events card 1plus summary ex OPT | failed |
+| ECC-VAL-019 | Active | Validate HISTORY — events card 3plus summary ex OPT | failed |
+| ECC-VAL-020 | Active | Validate HISTORY — events card OPT summary ex OPT | failed |
+| ECC-VAL-021 | Active | Validate HISTORY — events card mand summary ex OPT | failed |
+| ECC-VAL-022 | Active | Validate HISTORY — events card 3to5 summary ex OPT | failed |
+| ECC-VAL-023 | Active | Validate HISTORY — events card any summary ex mand | failed |
+| ECC-VAL-024 | Active | Validate HISTORY — events card 1plus summary ex mand | failed |
+| ECC-VAL-025 | Active | Validate HISTORY — events card 3plus summary ex mand | failed |
+| ECC-VAL-026 | Active | Validate HISTORY — events card OPT summary ex mand | failed |
+| ECC-VAL-027 | Active | Validate HISTORY — events card mand summary ex mand | failed |
+| ECC-VAL-028 | Active | Validate HISTORY — events card 3to5 summary ex mand | failed |
+| ECC-VAL-029 | Active | Validate EVENT — state ex OPT | failed |
+| ECC-VAL-030 | Active | Validate EVENT — state ex mand | failed |
+| ECC-VAL-031 | Active | Validate EVENT — type any | failed |
+| ECC-VAL-032 | Active | Validate EVENT — type point event | failed |
+| ECC-VAL-033 | Active | Validate EVENT — type interval event | failed |
+| ECC-VAL-034 | Active | Validate ITEM_STRUCTURE — type any | failed |
+| ECC-VAL-035 | Active | Validate ITEM_STRUCTURE — type item tree | failed |
+| ECC-VAL-036 | Active | Validate ITEM_STRUCTURE — type item list | failed |
+| ECC-VAL-037 | Active | Validate ITEM_STRUCTURE — type item table | failed |
+| ECC-VAL-038 | Active | Validate ITEM_STRUCTURE — type item single | failed |
+| ECC-VAL-039 | Active | Validate DV_BOOLEAN — anything allowed | failed |
+| ECC-VAL-040 | Active | Validate DV_BOOLEAN — only true allowed | failed |
+| ECC-VAL-041 | Active | Validate DV_BOOLEAN — only false allowed | failed |
+| ECC-VAL-042 | Active | Validate DV_IDENTIFIER — all pattern | failed |
+| ECC-VAL-043 | Active | Validate DV_IDENTIFIER — all list | failed |
+| ECC-VAL-044 | Active | Validate DV_TEXT — open | failed |
+| ECC-VAL-045 | Active | Validate DV_TEXT — list | failed |
+| ECC-VAL-046 | Active | Validate DV_CODED_TEXT — open | failed |
+| ECC-VAL-047 | Active | Validate DV_CODED_TEXT — local codes | failed |
+| ECC-VAL-048 | Active | Validate DV_CODED_TEXT — ext term | failed |
+| ECC-VAL-049 | Active | Validate DV_ORDINAL — open | failed |
+| ECC-VAL-050 | Active | Validate DV_ORDINAL — constraint | failed |
+| ECC-VAL-051 | Active | Validate DV_SCALE — open | failed |
+| ECC-VAL-052 | Active | Validate DV_SCALE — constraint | failed |
+| ECC-VAL-053 | Active | Validate DV_COUNT — open | failed |
+| ECC-VAL-054 | Active | Validate DV_COUNT — range | failed |
+| ECC-VAL-055 | Active | Validate DV_COUNT — list | failed |
+| ECC-VAL-056 | Active | Validate DV_QUANTITY — open | failed |
+| ECC-VAL-057 | Active | Validate DV_QUANTITY — property | failed |
+| ECC-VAL-058 | Active | Validate DV_QUANTITY — property units | failed |
+| ECC-VAL-059 | Active | Validate DV_QUANTITY — property units mag | failed |
+| ECC-VAL-060 | Active | Validate DV_PROPORTION — open | failed |
+| ECC-VAL-061 | Active | Validate DV_PROPORTION — ratio | failed |
+| ECC-VAL-062 | Active | Validate DV_PROPORTION — unitary | failed |
+| ECC-VAL-063 | Active | Validate DV_PROPORTION — percent | failed |
+| ECC-VAL-064 | Active | Validate DV_PROPORTION — fraction | failed |
+| ECC-VAL-065 | Active | Validate DV_PROPORTION — integer fraction | failed |
+| ECC-VAL-066 | Active | Validate DV_PROPORTION — any fraction | failed |
+| ECC-VAL-067 | Active | Validate DV_PROPORTION — ratio range | failed |
+| ECC-VAL-068 | Active | Validate DV_INTERVAL<DV_COUNT> — open | failed |
+| ECC-VAL-069 | Active | Validate DV_INTERVAL<DV_COUNT> — lower upper | failed |
+| ECC-VAL-070 | Active | Validate DV_INTERVAL<DV_COUNT> — lower upper list | failed |
+| ECC-VAL-071 | Active | Validate DV_INTERVAL<DV_QUANTITY> — open | failed |
+| ECC-VAL-072 | Active | Validate DV_INTERVAL<DV_QUANTITY> — upper lower | failed |
+| ECC-VAL-073 | Active | Validate DV_INTERVAL<DV_DATE_TIME> — open | failed |
+| ECC-VAL-074 | Active | Validate DV_INTERVAL<DV_DATE_TIME> — lower upper constraint | failed |
+| ECC-VAL-075 | Active | Validate DV_INTERVAL<DV_DATE_TIME> — lower upper range | failed |
+| ECC-VAL-076 | Active | Validate DV_INTERVAL<DV_DATE> — open | failed |
+| ECC-VAL-077 | Active | Validate DV_INTERVAL<DV_DATE> — lower upper constraint | failed |
+| ECC-VAL-078 | Active | Validate DV_INTERVAL<DV_DATE> — lower upper range | failed |
+| ECC-VAL-079 | Active | Validate DV_INTERVAL<DV_TIME> — open | failed |
+| ECC-VAL-080 | Active | Validate DV_INTERVAL<DV_TIME> — lower upper constraint | failed |
+| ECC-VAL-081 | Active | Validate DV_INTERVAL<DV_TIME> — lower upper range | failed |
+| ECC-VAL-082 | Active | Validate DV_INTERVAL<DV_DURATION> — open | failed |
+| ECC-VAL-083 | Active | Validate DV_INTERVAL<DV_DURATION> — constraint | failed |
+| ECC-VAL-084 | Active | Validate DV_INTERVAL<DV_DURATION> — range | failed |
+| ECC-VAL-085 | Active | Validate DV_INTERVAL<DV_ORDINAL> — open | failed |
+| ECC-VAL-086 | Active | Validate DV_INTERVAL<DV_ORDINAL> — constraint | failed |
+| ECC-VAL-087 | Active | Validate DV_INTERVAL<DV_SCALE> — open | failed |
+| ECC-VAL-088 | Active | Validate DV_INTERVAL<DV_SCALE> — constraint | failed |
+| ECC-VAL-089 | Active | Validate DV_INTERVAL<DV_PROPORTION> — open | failed |
+| ECC-VAL-090 | Active | Validate DV_INTERVAL<DV_PROPORTION> — ratio | failed |
+| ECC-VAL-091 | Active | Validate DV_INTERVAL<DV_PROPORTION> — unitary | failed |
+| ECC-VAL-092 | Active | Validate DV_INTERVAL<DV_PROPORTION> — percentage | failed |
+| ECC-VAL-093 | Active | Validate DV_INTERVAL<DV_PROPORTION> — fraction | failed |
+| ECC-VAL-094 | Active | Validate DV_INTERVAL<DV_PROPORTION> — integer fraction | failed |
+| ECC-VAL-095 | Active | Validate DV_INTERVAL<DV_PROPORTION> — ratio range | failed |
+| ECC-VAL-096 | Active | Validate DV_DURATION — open | failed |
+| ECC-VAL-097 | Active | Validate DV_DURATION — fields | failed |
+| ECC-VAL-098 | Active | Validate DV_DURATION — range | failed |
+| ECC-VAL-099 | Active | Validate DV_DURATION — fields range | failed |
+| ECC-VAL-100 | Active | Validate DV_TIME — open | failed |
+| ECC-VAL-101 | Active | Validate DV_TIME — constraint | failed |
+| ECC-VAL-102 | Active | Validate DV_TIME — range | failed |
+| ECC-VAL-103 | Active | Validate DV_DATE — open | failed |
+| ECC-VAL-104 | Active | Validate DV_DATE — constraint | failed |
+| ECC-VAL-105 | Active | Validate DV_DATE — range | failed |
+| ECC-VAL-106 | Active | Validate DV_DATE_TIME — open | failed |
+| ECC-VAL-107 | Active | Validate DV_DATE_TIME — constraint | failed |
+| ECC-VAL-108 | Active | Validate DV_DATE_TIME — range | failed |
+| ECC-VAL-109 | Active | Validate DV_PARSABLE — open | failed |
+| ECC-VAL-110 | Active | Validate DV_PARSABLE — value formalism | failed |
+| ECC-VAL-111 | Active | Validate DV_MULTIMEDIA — open | failed |
+| ECC-VAL-112 | Active | Validate DV_MULTIMEDIA — media type | failed |
+| ECC-VAL-113 | Active | Validate DV_URI — open | failed |
+| ECC-VAL-114 | Active | Validate DV_URI — pattern | failed |
+| ECC-VAL-115 | Active | Validate DV_URI — list | failed |
+| ECC-VAL-116 | Active | Validate DV_EHR_URI — open | failed |
+| ECC-VAL-117 | Active | Validate DV_EHR_URI — pattern | failed |
+| ECC-VAL-118 | Active | Validate DV_EHR_URI — list | failed |
+| ECC-VAL-119 | Active | Validate DV_DATE — day disallowed by C_DATE pattern (defective vendored fixture rejected) | failed |
+
+## DEM — Demographic service (24 cases, 24 active)
+
+| ECC id | Status | Title | Last run |
+|---|---|---|---|
+| ECC-DEM-001 | Active | Demographic person create | failed |
+| ECC-DEM-002 | Active | Demographic person get | failed |
+| ECC-DEM-003 | Active | Demographic person get by version | failed |
+| ECC-DEM-004 | Active | Demographic person update | failed |
+| ECC-DEM-005 | Active | Demographic person delete | failed |
+| ECC-DEM-006 | Active | Demographic person get deleted | failed |
+| ECC-DEM-007 | Active | Demographic person get absent | passed |
+| ECC-DEM-008 | Active | Demographic person update bad if match | failed |
+| ECC-DEM-009 | Active | Demographic agent create | failed |
+| ECC-DEM-010 | Active | Demographic agent get | failed |
+| ECC-DEM-011 | Active | Demographic agent delete | failed |
+| ECC-DEM-012 | Active | Demographic group create | failed |
+| ECC-DEM-013 | Active | Demographic group get | failed |
+| ECC-DEM-014 | Active | Demographic group delete | failed |
+| ECC-DEM-015 | Active | Demographic organisation create | failed |
+| ECC-DEM-016 | Active | Demographic organisation get | failed |
+| ECC-DEM-017 | Active | Demographic organisation delete | failed |
+| ECC-DEM-018 | Active | Demographic role create | failed |
+| ECC-DEM-019 | Active | Demographic role get | failed |
+| ECC-DEM-020 | Active | Demographic role delete | failed |
+| ECC-DEM-021 | Active | Demographic create bad body | failed |
+| ECC-DEM-022 | Active | Demographic versioned party get | failed |
+| ECC-DEM-023 | Active | Demographic versioned party revision history | failed |
+| ECC-DEM-024 | Active | Demographic person tags | failed |
+
+## ADM — Admin service (6 cases, 6 active)
+
+| ECC id | Status | Title | Last run |
+|---|---|---|---|
+| ECC-ADM-001 | Active | Admin EHR delete | passed |
+| ECC-ADM-002 | Active | Admin EHR delete absent | passed |
+| ECC-ADM-003 | Active | Admin EHR delete idempotent | passed |
+| ECC-ADM-004 | Active | Admin EHR delete all | failed |
+| ECC-ADM-005 | Active | Admin EHR delete all partial | failed |
+| ECC-ADM-006 | Active | Admin EHR delete all empty | passed |
+
+## SEC — Security / authorization (2 cases, 2 active)
+
+| ECC id | Status | Title | Last run |
+|---|---|---|---|
+| ECC-SEC-001 | Active | Unauthenticated request to a protected route is refused (401) | passed |
+| ECC-SEC-002 | Active | Regular credential on an ADMIN-only route is forbidden (403) | passed |
+
+## SIG — Version signing (5 cases, 5 active)
+
+| ECC id | Status | Title | Last run |
+|---|---|---|---|
+| ECC-SIG-001 | Active | Version signing — digest present | failed |
+| ECC-SIG-002 | Active | Version signing — digest recomputes | failed |
+| ECC-SIG-003 | Active | Version signing — all kinds | failed |
+| ECC-SIG-004 | Active | Version signing — client verbatim | failed |
+| ECC-SIG-005 | Active | Version signing — pgp verifies | skipped |
+
+## MSG — Messaging (10 cases, 10 active)
+
+| ECC id | Status | Title | Last run |
+|---|---|---|---|
+| ECC-MSG-001 | Active | EHR Extract — export whole EHR (export_ehrs) | skipped |
+| ECC-MSG-002 | Active | EHR Extract — spec-driven export (export_ehr_extracts) | skipped |
+| ECC-MSG-003 | Active | EHR Extract — export of unknown EHR fails | skipped |
+| ECC-MSG-004 | Active | EHR Extract — import whole-EHR clone reusing source id (import_ehr) | skipped |
+| ECC-MSG-005 | Active | EHR Extract — import whole EHR into a caller-fixed id (import_ehr) | skipped |
+| ECC-MSG-006 | Active | EHR Extract — import into a duplicate target id fails | skipped |
+| ECC-MSG-007 | Active | EHR Extract — import extract into an existing EHR (import_ehr_extract) | skipped |
+| ECC-MSG-008 | Active | TDD — import a TDD as a committed COMPOSITION (import_tdd) | skipped |
+| ECC-MSG-009 | Active | TDD — import rejects malformed / non-TDD / unknown EHR / unknown template | skipped |
+| ECC-MSG-010 | Active | TDD — batch import commits all, fail-fast on error (import_tdds) | skipped |
+
+## TS — Terminology-server integration (9 cases, 9 active)
+
+| ECC id | Status | Title | Last run |
+|---|---|---|---|
+| ECC-TS-001 | Active | TERMINOLOGY expand (bundle) — accepted, well-formed RESULT_SET | failed |
+| ECC-TS-002 | Active | TERMINOLOGY expand (bundle) — expansion constrains matches to the value set's codes | failed |
+| ECC-TS-003 | Active | TERMINOLOGY expand (bundle) — explicit code merged with the expansion (matches list) | failed |
+| ECC-TS-004 | Active | TERMINOLOGY expand — unknown value set rejected (400) | passed |
+| ECC-TS-005 | Active | TERMINOLOGY expand — unknown service_api rejected (400) | passed |
+| ECC-TS-006 | Active | TERMINOLOGY expand (FHIR service_api) — accepted when a provider is configured | skipped |
+| ECC-TS-007 | Active | TERMINOLOGY expand (FHIR) — terminology-server timeout is a server fault (500) | skipped |
+| ECC-TS-008 | Active | TERMINOLOGY expand (FHIR) — terminology-server 5xx is a server fault (500) | skipped |
+| ECC-TS-009 | Active | TERMINOLOGY expand (FHIR) — malformed terminology response is a server fault (500) | skipped |
+

--- a/docs/conformance/upstream-ehrbase/CONFORMANCE_REPORT.md
+++ b/docs/conformance/upstream-ehrbase/CONFORMANCE_REPORT.md
@@ -1,0 +1,695 @@
+# ehrbase-rs Conformance Report (generated)
+
+> Generated from a conformance run — never hand-asserted. Scoped and
+> honest: the deviations section lists every skip with its reason.
+
+## 1. SUT identity
+
+- Product: ehrbase-java 2.34.0 (`sha256:89e52635fc72dca3eda368b601f3a7aa6cbaa24e7582f5ee00e953759626904d`)
+- SUT: `http://localhost:8091/ehrbase/rest/openehr/v1`
+- Spec versions: RM 1.2.0 · ITS-REST development@e8a093e · AQL 1.1.0 · TERM 3.1.0
+- Auth mode: basic
+- Started: 2026-07-11T11:30:31.367209Z
+
+**333 case×format executions · 95 passed · 212 failed · 0 not applicable.**
+
+### Per-area matrix
+
+| Area | Catalogue (active) | Passed | Failed | Errored | Skipped | N/A |
+|---|--:|--:|--:|--:|--:|--:|
+| EHR — EHR service | 13 | 6 | 7 | 0 | 0 | 0 |
+| STA — EHR_STATUS | 10 | 5 | 5 | 0 | 0 | 0 |
+| COM — COMPOSITION | 31 | 12 | 19 | 0 | 0 | 0 |
+| CTB — CONTRIBUTION (change sets) | 31 | 14 | 12 | 0 | 5 | 0 |
+| DIR — DIRECTORY (FOLDER) | 37 | 37 | 0 | 0 | 0 | 0 |
+| TPL — Template / OPT provisioning | 16 | 4 | 8 | 0 | 4 | 0 |
+| SQR — Stored-query provisioning | 7 | 5 | 0 | 0 | 2 | 0 |
+| QRY — AQL execution | 13 | 3 | 10 | 0 | 0 | 0 |
+| VAL — Content / archetype validation | 119 | 0 | 119 | 0 | 0 | 0 |
+| DEM — Demographic service | 24 | 1 | 23 | 0 | 0 | 0 |
+| ADM — Admin service | 6 | 4 | 2 | 0 | 0 | 0 |
+| SEC — Security / authorization | 2 | 2 | 0 | 0 | 0 | 0 |
+| SIG — Version signing | 5 | 0 | 4 | 0 | 1 | 0 |
+| MSG — Messaging | 10 | 0 | 0 | 0 | 10 | 0 |
+| TS — Terminology-server integration | 9 | 2 | 3 | 0 | 4 | 0 |
+
+### Failures
+
+Each failure must become a finding (`F-AA-NN`) before/with the fix — never an exclusion.
+
+- **ECC-EHR-002** EHR existence check — existing subject id (`ehr/has-ehr-existing-subject-id`, json): expected status 201, got 400 (body: {"error":"Bad Request","message":"JSON parse error: Could not resolve type id 'PARTY_IDENTIFIED' as a subtype of `com.nedap.archie.rm.generic.PartySelf`: Class `com.nedap.archie.rm.generic.PartyIdentified` not subtype of `com.nedap.archie.rm.generic.PartySelf`"})
+- **ECC-EHR-005** Create EHR — main (`ehr/create-ehr-main`, json): expected status 201, got 400 (body: {"error":"Bad Request","message":"JSON parse error: Could not resolve type id 'PARTY_IDENTIFIED' as a subtype of `com.nedap.archie.rm.generic.PartySelf`: Class `com.nedap.archie.rm.generic.PartyIdentified` not subtype of `com.nedap.archie.rm.generic.PartySelf`"})
+- **ECC-EHR-007** Create EHR — two EHRs same patient (`ehr/create-ehr-two-ehrs-same-patient`, json): expected status 201, got 400 (body: {"error":"Bad Request","message":"JSON parse error: Could not resolve type id 'PARTY_IDENTIFIED' as a subtype of `com.nedap.archie.rm.generic.PartySelf`: Class `com.nedap.archie.rm.generic.PartyIdentified` not subtype of `com.nedap.archie.rm.generic.PartySelf`"})
+- **ECC-EHR-008** Get EHR — existing EHR by EHR id (`ehr/get-ehr-existing-ehr-by-ehr-id`, json): returned EHR is not valid RM: missing field `ehr_access`
+- **ECC-EHR-009** Get EHR — existing EHR by subject id (`ehr/get-ehr-existing-ehr-by-subject-id`, json): expected status 201, got 400 (body: {"error":"Bad Request","message":"JSON parse error: Could not resolve type id 'PARTY_IDENTIFIED' as a subtype of `com.nedap.archie.rm.generic.PartySelf`: Class `com.nedap.archie.rm.generic.PartyIdentified` not subtype of `com.nedap.archie.rm.generic.PartySelf`"})
+- **ECC-STA-001** Get EHR_STATUS — get by EHR id (`sta/get-ehr-status-get-by-ehr-id`, json): returned EHR is not valid RM: missing field `ehr_access`
+- **ECC-STA-003** Set EHR_STATUS is_queryable — existing EHR (`sta/set-ehr-queryable-existing-ehr`, json): returned EHR is not valid RM: missing field `ehr_access`
+- **ECC-STA-005** Set EHR_STATUS is_modifiable — existing EHR (`sta/set-ehr-modifiable-existing-ehr`, json): returned EHR is not valid RM: missing field `ehr_access`
+- **ECC-STA-007** Clear EHR_STATUS is_queryable — existing EHR (`sta/clear-ehr-queryable-existing-ehr`, json): returned EHR is not valid RM: missing field `ehr_access`
+- **ECC-STA-009** Clear EHR_STATUS is_modifiable — existing EHR (`sta/clear-ehr-modifiable-existing-ehr`, json): returned EHR is not valid RM: missing field `ehr_access`
+- **ECC-EHR-012** Create EHR — reject invalid EHR_STATUS data sets (`ehr/create-ehr-invalid-status`, json): 9/11 invalid EHR_STATUS data sets were rejected (the rest were accepted)
+- **ECC-EHR-013** Create anonymous (subject-less) EHR (`ehr/create-anonymous-ehr`, json): returned EHR is not valid RM: missing field `ehr_access`
+- **ECC-COM-001** Create composition — event (`com/create-composition-event`, json): OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-COM-002** Create composition — persistent (`com/create-composition-persistent`, json): OPT minimal_persistent/persistent_minimal.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-COM-003** Create composition — same OPT twice (`com/create-composition-same-opt-twice`, json): OPT minimal_persistent/persistent_minimal.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-COM-004** Create composition — invalid event (`com/create-composition-invalid-event`, json): OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-COM-005** Create composition — invalid persistent (`com/create-composition-invalid-persistent`, json): OPT minimal_persistent/persistent_minimal.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-COM-007** Create composition — event bad EHR (`com/create-composition-event-bad-ehr`, json): OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-COM-008** Get latest composition (`com/get-composition-latest`, json): OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-COM-013** Get composition at time (`com/get-composition-at-time`, json): OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-COM-014** Get composition at time — no time arg (`com/get-composition-at-time-no-time-arg`, json): OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-COM-017** Get composition at multiple times (`com/get-composition-at-times`, json): OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-COM-018** Get composition version (`com/get-composition-version`, json): OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-COM-021** Get composition versions (`com/get-composition-versions`, json): OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-COM-022** Get versioned composition (`com/get-versioned-composition`, json): OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-COM-025** Update composition — event (`com/update-composition-event`, json): OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-COM-026** Update composition — persistent (`com/update-composition-persistent`, json): OPT minimal_persistent/persistent_minimal.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-COM-027** Update composition — non existent (`com/update-composition-non-existent`, json): OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-COM-028** Update composition — wrong template (`com/update-composition-wrong-template`, json): OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-COM-029** Delete composition — event (`com/delete-composition-event`, json): OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-COM-030** Delete composition — persistent (`com/delete-composition-persistent`, json): OPT minimal_persistent/persistent_minimal.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-CTB-001** Commit contribution — valid composition (`ctb/commit-contribution-valid-composition`, json): OPT minimal/minimal_evaluation.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-CTB-002** Commit contribution — invalid composition (`ctb/commit-contribution-invalid-composition`, json): OPT minimal/minimal_evaluation.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-CTB-004** Commit contribution — valid invalid compositions (`ctb/commit-contribution-valid-invalid-compositions`, json): OPT minimal/minimal_evaluation.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-CTB-006** Commit contribution — event composition (`ctb/commit-contribution-event-composition`, json): OPT minimal/minimal_admin.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-CTB-007** Commit contribution — persistent composition (`ctb/commit-contribution-persistent-composition`, json): OPT minimal_persistent/persistent_minimal.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-CTB-008** Commit contribution — delete (`ctb/commit-contribution-delete`, json): OPT minimal/minimal_admin.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-CTB-009** Commit contribution — two commits second invalid (`ctb/commit-contribution-two-commits-second-invalid`, json): OPT minimal/minimal_admin.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-CTB-010** Commit contribution — two commits second creation (`ctb/commit-contribution-two-commits-second-creation`, json): OPT minimal/minimal_admin.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-CTB-019** Get contribution — existing (`ctb/get-contribution-existing`, json): OPT minimal/minimal_admin.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-CTB-022** Get contribution — bad contribution (`ctb/get-contribution-bad-contribution`, json): OPT minimal/minimal_admin.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-CTB-023** Contribution existence check — existing (`ctb/has-contribution-existing`, json): OPT minimal/minimal_admin.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-CTB-024** Contribution existence check — bad contribution (`ctb/has-contribution-bad-contribution`, json): OPT minimal/minimal_admin.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-TPL-001** Upload OPT — valid OPT (provisions ADL 1.4 archetypes) (`tpl/upload-opt-valid-opt`, json): fresh valid OPT rejected with 406
+- **ECC-TPL-004** Upload OPT — valid OPT twice conflict (`tpl/upload-opt-valid-opt-twice-conflict`, json): provisioning minimal_evaluation.opt returned 406
+- **ECC-TPL-005** Upload OPT — valid OPT twice no conflict (`tpl/upload-opt-valid-opt-twice-no-conflict`, json): provisioning minimal_evaluation.opt returned 406
+- **ECC-TPL-006** Get OPT — retrieve single (`tpl/get-opt-retrieve-single`, json): provisioning minimal_evaluation.opt returned 406
+- **ECC-TPL-007** Get OPT — retrieve latest version (`tpl/get-opt-retrieve-latest-version`, json): provisioning minimal_evaluation.opt returned 406
+- **ECC-TPL-008** Get OPT — retrieve specific version (`tpl/get-opt-retrieve-specific-version`, json): provisioning minimal_evaluation.opt returned 406
+- **ECC-TPL-010** List OPTs — retrieve all (`tpl/get-opts-retrieve-all`, json): provisioning minimal_evaluation.opt returned 406
+- **ECC-TPL-011** Validate OPT — valid OPT (`tpl/validate-opt-valid-opt`, json): valid OPT not accepted: 406
+- **ECC-QRY-002** Execute ad-hoc AQL query — empty db (`qry/execute-ad-hoc-query-empty-db`, json): adhoc empty_db golden mismatch (suppressed via [meta_envelope_ignored,query_echo_ignored]): columns differ: golden=[{"name":"#0","path":"/ehr_id/value"}], served=[{"path":"e/ehr_id/value","name":"#0"}]
+- **ECC-QRY-003** Execute stored AQL query — empty db (`qry/execute-stored-query-empty-db`, json): stored empty_db golden mismatch (suppressed via [meta_envelope_ignored,query_echo_ignored]): columns differ: golden=[{"name":"#0","path":"/ehr_id/value"}], served=[{"path":"e/ehr_id/value","name":"#0"}]
+- **ECC-QRY-004** Execute ad-hoc AQL query — loaded db (`qry/execute-ad-hoc-query-loaded-db`, json): OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-QRY-006** AQL corpus — A empty db (`qry/corpus-a-empty-db`, json): 1/25 A/empty_db goldens matched (2 skipped); first divergence: A/100_get_ehrs.json (ColumnsOnly, suppressed via [meta_envelope_ignored,query_echo_ignored]): columns differ: golden=[{"name":"#0","path":"/ehr_id/value"}], served=[{"path":"e/ehr_id/value","name":"#0"}]
+- **ECC-QRY-007** AQL corpus — B empty db (`qry/corpus-b-empty-db`, json): 1/18 B/empty_db goldens matched (3 skipped); first divergence: B/100_get_compositions_from_all_ehrs.json (ColumnsOnly, suppressed via [meta_envelope_ignored,query_echo_ignored]): columns differ: golden=[{"name":"#0","path":"/"}], served=[{"path":"c","name":"#0"}]
+- **ECC-QRY-008** AQL corpus — C empty db (`qry/corpus-c-empty-db`, json): 1/11 C/empty_db goldens matched (0 skipped); first divergence: C/100_get_entries_empty_db.json (Full, suppressed via [meta_envelope_ignored,query_echo_ignored]): columns differ: golden=[{"name":"#0","path":"/"}], served=[{"path":"entry","name":"#0"}]
+- **ECC-QRY-009** AQL corpus — D empty db (`qry/corpus-d-empty-db`, json): 0/16 D/empty_db goldens matched (10 skipped); first divergence: D/200_select_data_values_from_all_ehrs_contains_composition.json (ColumnsOnly, suppressed via [meta_envelope_ignored,query_echo_ignored]): columns differ: golden=[{"name":"#0","path":"/ehr_id/value"},{"name":"#1","path":"/time_created/value"},{"name":"#2","path":"/system_id/value"}], served=[{"path":"e/ehr_id/value","name":"#0"},{"path":"e/time_created/value","name":"#1"},{"path":"e/system_id/value","name":"#2"}]
+- **ECC-QRY-010** AQL corpus — A loaded db (`qry/corpus-a-loaded-db`, json): 1/21 A/loaded_db goldens matched (6 skipped); first divergence: A/100_get_ehrs.json (ColumnsOnly, suppressed via [meta_envelope_ignored,query_echo_ignored]): columns differ: golden=[{"name":"#0","path":"/ehr_id/value"}], served=[{"path":"e/ehr_id/value","name":"#0"}]
+- **ECC-QRY-011** AQL corpus — B loaded db (`qry/corpus-b-loaded-db`, json): 1/15 B/loaded_db goldens matched (9 skipped); first divergence: B/100_get_compositions_from_all_ehrs.json (ColumnsOnly, suppressed via [meta_envelope_ignored,query_echo_ignored]): columns differ: golden=[{"name":"#0","path":"/"}], served=[{"path":"c","name":"#0"}]
+- **ECC-QRY-013** AQL corpus — D loaded db (`qry/corpus-d-loaded-db`, json): 0/7 D/loaded_db goldens matched (19 skipped); first divergence: D/200_select_data_values_from_all_ehrs_contains_composition.json (ColumnsOnly, suppressed via [meta_envelope_ignored,query_echo_ignored]): columns differ: golden=[{"name":"#0","path":"/ehr_id/value"},{"name":"#1","path":"/time_created/value"},{"name":"#2","path":"/system_id/value"}], served=[{"path":"e/ehr_id/value","name":"#0"},{"path":"e/time_created/value","name":"#1"},{"path":"e/system_id/value","name":"#2"}]
+- **ECC-ADM-004** Admin EHR delete all (`adm/ehr-delete-all`, json): expected status 200, got 400 (body: {"error":"Bad Request","message":"Invalid UUID string: all"})
+- **ECC-ADM-005** Admin EHR delete all partial (`adm/ehr-delete-all-partial`, json): expected status 200, got 400 (body: {"error":"Bad Request","message":"Invalid UUID string: all"})
+- **ECC-DEM-001** Demographic person create (`dem/person-create`, json): expected status 201, got 404 (body: {"error":"Not Found","message":"No resource found at path: rest/openehr/v1/demographic/person"})
+- **ECC-DEM-002** Demographic person get (`dem/person-get`, json): expected status 201, got 404 (body: {"error":"Not Found","message":"No resource found at path: rest/openehr/v1/demographic/person"})
+- **ECC-DEM-003** Demographic person get by version (`dem/person-get-by-version`, json): expected status 201, got 404 (body: {"error":"Not Found","message":"No resource found at path: rest/openehr/v1/demographic/person"})
+- **ECC-DEM-004** Demographic person update (`dem/person-update`, json): expected status 201, got 404 (body: {"error":"Not Found","message":"No resource found at path: rest/openehr/v1/demographic/person"})
+- **ECC-DEM-005** Demographic person delete (`dem/person-delete`, json): expected status 201, got 404 (body: {"error":"Not Found","message":"No resource found at path: rest/openehr/v1/demographic/person"})
+- **ECC-DEM-006** Demographic person get deleted (`dem/person-get-deleted`, json): expected status 201, got 404 (body: {"error":"Not Found","message":"No resource found at path: rest/openehr/v1/demographic/person"})
+- **ECC-DEM-008** Demographic person update bad if match (`dem/person-update-bad-if-match`, json): expected status 201, got 404 (body: {"error":"Not Found","message":"No resource found at path: rest/openehr/v1/demographic/person"})
+- **ECC-DEM-009** Demographic agent create (`dem/agent-create`, json): expected status 201, got 404 (body: {"error":"Not Found","message":"No resource found at path: rest/openehr/v1/demographic/agent"})
+- **ECC-DEM-010** Demographic agent get (`dem/agent-get`, json): expected status 201, got 404 (body: {"error":"Not Found","message":"No resource found at path: rest/openehr/v1/demographic/agent"})
+- **ECC-DEM-011** Demographic agent delete (`dem/agent-delete`, json): expected status 201, got 404 (body: {"error":"Not Found","message":"No resource found at path: rest/openehr/v1/demographic/agent"})
+- **ECC-DEM-012** Demographic group create (`dem/group-create`, json): expected status 201, got 404 (body: {"error":"Not Found","message":"No resource found at path: rest/openehr/v1/demographic/group"})
+- **ECC-DEM-013** Demographic group get (`dem/group-get`, json): expected status 201, got 404 (body: {"error":"Not Found","message":"No resource found at path: rest/openehr/v1/demographic/group"})
+- **ECC-DEM-014** Demographic group delete (`dem/group-delete`, json): expected status 201, got 404 (body: {"error":"Not Found","message":"No resource found at path: rest/openehr/v1/demographic/group"})
+- **ECC-DEM-015** Demographic organisation create (`dem/organisation-create`, json): expected status 201, got 404 (body: {"error":"Not Found","message":"No resource found at path: rest/openehr/v1/demographic/organisation"})
+- **ECC-DEM-016** Demographic organisation get (`dem/organisation-get`, json): expected status 201, got 404 (body: {"error":"Not Found","message":"No resource found at path: rest/openehr/v1/demographic/organisation"})
+- **ECC-DEM-017** Demographic organisation delete (`dem/organisation-delete`, json): expected status 201, got 404 (body: {"error":"Not Found","message":"No resource found at path: rest/openehr/v1/demographic/organisation"})
+- **ECC-DEM-018** Demographic role create (`dem/role-create`, json): expected status 201, got 404 (body: {"error":"Not Found","message":"No resource found at path: rest/openehr/v1/demographic/role"})
+- **ECC-DEM-019** Demographic role get (`dem/role-get`, json): expected status 201, got 404 (body: {"error":"Not Found","message":"No resource found at path: rest/openehr/v1/demographic/role"})
+- **ECC-DEM-020** Demographic role delete (`dem/role-delete`, json): expected status 201, got 404 (body: {"error":"Not Found","message":"No resource found at path: rest/openehr/v1/demographic/role"})
+- **ECC-DEM-021** Demographic create bad body (`dem/create-bad-body`, json): expected status in [400, 422], got 404
+- **ECC-DEM-022** Demographic versioned party get (`dem/versioned-party-get`, json): expected status 201, got 404 (body: {"error":"Not Found","message":"No resource found at path: rest/openehr/v1/demographic/person"})
+- **ECC-DEM-023** Demographic versioned party revision history (`dem/versioned-party-revision-history`, json): expected status 201, got 404 (body: {"error":"Not Found","message":"No resource found at path: rest/openehr/v1/demographic/person"})
+- **ECC-DEM-024** Demographic person tags (`dem/person-tags`, json): expected status 201, got 404 (body: {"error":"Not Found","message":"No resource found at path: rest/openehr/v1/demographic/person"})
+- **ECC-VAL-001** Validate COMPOSITION — content card any context any (`val/comp-content-card-any-context-any`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-002** Validate COMPOSITION — content card 1plus context any (`val/comp-content-card-1plus-context-any`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-003** Validate COMPOSITION — content card 3plus context any (`val/comp-content-card-3plus-context-any`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-004** Validate COMPOSITION — content card OPT context any (`val/comp-content-card-opt-context-any`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-005** Validate COMPOSITION — content card mand context any (`val/comp-content-card-mand-context-any`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-006** Validate COMPOSITION — content card 3to5 context any (`val/comp-content-card-3to5-context-any`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-007** Validate COMPOSITION — content card any context mand (`val/comp-content-card-any-context-mand`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-008** Validate COMPOSITION — content card 1plus context mand (`val/comp-content-card-1plus-context-mand`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-009** Validate COMPOSITION — content card 3plus context mand (`val/comp-content-card-3plus-context-mand`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-010** Validate COMPOSITION — content card OPT context mand (`val/comp-content-card-opt-context-mand`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-011** Validate COMPOSITION — content card mand context mand (`val/comp-content-card-mand-context-mand`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-012** Validate COMPOSITION — content card 3to5 context mand (`val/comp-content-card-3to5-context-mand`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-013** Validate OBSERVATION — state ex OPT protocol ex OPT (`val/obs-state-ex-opt-protocol-ex-opt`, json): OPT minimal_persistent/persistent_minimal.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-014** Validate OBSERVATION — state ex OPT protocol ex mand (`val/obs-state-ex-opt-protocol-ex-mand`, json): OPT minimal_persistent/persistent_minimal.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-015** Validate OBSERVATION — state ex mand protocol ex OPT (`val/obs-state-ex-mand-protocol-ex-opt`, json): OPT minimal_persistent/persistent_minimal.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-016** Validate OBSERVATION — state ex mand protocol ex mand (`val/obs-state-ex-mand-protocol-ex-mand`, json): OPT minimal_persistent/persistent_minimal.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-017** Validate HISTORY — events card any summary ex OPT (`val/hist-events-card-any-summary-ex-opt`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-018** Validate HISTORY — events card 1plus summary ex OPT (`val/hist-events-card-1plus-summary-ex-opt`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-019** Validate HISTORY — events card 3plus summary ex OPT (`val/hist-events-card-3plus-summary-ex-opt`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-020** Validate HISTORY — events card OPT summary ex OPT (`val/hist-events-card-opt-summary-ex-opt`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-021** Validate HISTORY — events card mand summary ex OPT (`val/hist-events-card-mand-summary-ex-opt`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-022** Validate HISTORY — events card 3to5 summary ex OPT (`val/hist-events-card-3to5-summary-ex-opt`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-023** Validate HISTORY — events card any summary ex mand (`val/hist-events-card-any-summary-ex-mand`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-024** Validate HISTORY — events card 1plus summary ex mand (`val/hist-events-card-1plus-summary-ex-mand`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-025** Validate HISTORY — events card 3plus summary ex mand (`val/hist-events-card-3plus-summary-ex-mand`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-026** Validate HISTORY — events card OPT summary ex mand (`val/hist-events-card-opt-summary-ex-mand`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-027** Validate HISTORY — events card mand summary ex mand (`val/hist-events-card-mand-summary-ex-mand`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-028** Validate HISTORY — events card 3to5 summary ex mand (`val/hist-events-card-3to5-summary-ex-mand`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-029** Validate EVENT — state ex OPT (`val/event-state-ex-opt`, json): OPT minimal_persistent/persistent_minimal.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-030** Validate EVENT — state ex mand (`val/event-state-ex-mand`, json): OPT minimal_persistent/persistent_minimal.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-031** Validate EVENT — type any (`val/event-type-any`, json): OPT minimal_persistent/persistent_minimal.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-032** Validate EVENT — type point event (`val/event-type-point-event`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-033** Validate EVENT — type interval event (`val/event-type-interval-event`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-034** Validate ITEM_STRUCTURE — type any (`val/item-str-type-any`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-035** Validate ITEM_STRUCTURE — type item tree (`val/item-str-type-item-tree`, json): OPT validation/clinical_content_validation.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-036** Validate ITEM_STRUCTURE — type item list (`val/item-str-type-item-list`, json): OPT validation/clinical_content_validation.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-037** Validate ITEM_STRUCTURE — type item table (`val/item-str-type-item-table`, json): OPT validation/clinical_content_validation.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-038** Validate ITEM_STRUCTURE — type item single (`val/item-str-type-item-single`, json): OPT validation/clinical_content_validation.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-039** Validate DV_BOOLEAN — anything allowed (`val/dv-boolean-anything-allowed`, json): OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-040** Validate DV_BOOLEAN — only true allowed (`val/dv-boolean-only-true-allowed`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-041** Validate DV_BOOLEAN — only false allowed (`val/dv-boolean-only-false-allowed`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-042** Validate DV_IDENTIFIER — all pattern (`val/dv-identifier-all-pattern`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-043** Validate DV_IDENTIFIER — all list (`val/dv-identifier-all-list`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-044** Validate DV_TEXT — open (`val/dv-text-open`, json): OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-045** Validate DV_TEXT — list (`val/dv-text-list`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-046** Validate DV_CODED_TEXT — open (`val/dv-coded-text-open`, json): OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-047** Validate DV_CODED_TEXT — local codes (`val/dv-coded-text-local-codes`, json): OPT all_types/Test_all_types_v2.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-048** Validate DV_CODED_TEXT — ext term (`val/dv-coded-text-ext-term`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-049** Validate DV_ORDINAL — open (`val/dv-ordinal-open`, json): OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-050** Validate DV_ORDINAL — constraint (`val/dv-ordinal-constraint`, json): OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-051** Validate DV_SCALE — open (`val/dv-scale-open`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-052** Validate DV_SCALE — constraint (`val/dv-scale-constraint`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-053** Validate DV_COUNT — open (`val/dv-count-open`, json): OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-054** Validate DV_COUNT — range (`val/dv-count-range`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-055** Validate DV_COUNT — list (`val/dv-count-list`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-056** Validate DV_QUANTITY — open (`val/dv-quantity-open`, json): OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-057** Validate DV_QUANTITY — property (`val/dv-quantity-property`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-058** Validate DV_QUANTITY — property units (`val/dv-quantity-property-units`, json): OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-059** Validate DV_QUANTITY — property units mag (`val/dv-quantity-property-units-mag`, json): OPT time_series/time_series.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-060** Validate DV_PROPORTION — open (`val/dv-proportion-open`, json): OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-061** Validate DV_PROPORTION — ratio (`val/dv-proportion-ratio`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-062** Validate DV_PROPORTION — unitary (`val/dv-proportion-unitary`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-063** Validate DV_PROPORTION — percent (`val/dv-proportion-percent`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-064** Validate DV_PROPORTION — fraction (`val/dv-proportion-fraction`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-065** Validate DV_PROPORTION — integer fraction (`val/dv-proportion-integer-fraction`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-066** Validate DV_PROPORTION — any fraction (`val/dv-proportion-any-fraction`, json): OPT minimal/minimal_action_2.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-067** Validate DV_PROPORTION — ratio range (`val/dv-proportion-ratio-range`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-068** Validate DV_INTERVAL<DV_COUNT> — open (`val/dv-interval-dv-count-open`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-069** Validate DV_INTERVAL<DV_COUNT> — lower upper (`val/dv-interval-dv-count-lower-upper`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-070** Validate DV_INTERVAL<DV_COUNT> — lower upper list (`val/dv-interval-dv-count-lower-upper-list`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-071** Validate DV_INTERVAL<DV_QUANTITY> — open (`val/dv-interval-dv-quantity-open`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-072** Validate DV_INTERVAL<DV_QUANTITY> — upper lower (`val/dv-interval-dv-quantity-upper-lower`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-073** Validate DV_INTERVAL<DV_DATE_TIME> — open (`val/dv-interval-dv-date-time-open`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-074** Validate DV_INTERVAL<DV_DATE_TIME> — lower upper constraint (`val/dv-interval-dv-date-time-lower-upper-constraint`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-075** Validate DV_INTERVAL<DV_DATE_TIME> — lower upper range (`val/dv-interval-dv-date-time-lower-upper-range`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-076** Validate DV_INTERVAL<DV_DATE> — open (`val/dv-interval-dv-date-open`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-077** Validate DV_INTERVAL<DV_DATE> — lower upper constraint (`val/dv-interval-dv-date-lower-upper-constraint`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-078** Validate DV_INTERVAL<DV_DATE> — lower upper range (`val/dv-interval-dv-date-lower-upper-range`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-079** Validate DV_INTERVAL<DV_TIME> — open (`val/dv-interval-dv-time-open`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-080** Validate DV_INTERVAL<DV_TIME> — lower upper constraint (`val/dv-interval-dv-time-lower-upper-constraint`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-081** Validate DV_INTERVAL<DV_TIME> — lower upper range (`val/dv-interval-dv-time-lower-upper-range`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-082** Validate DV_INTERVAL<DV_DURATION> — open (`val/dv-interval-dv-duration-open`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-083** Validate DV_INTERVAL<DV_DURATION> — constraint (`val/dv-interval-dv-duration-constraint`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-084** Validate DV_INTERVAL<DV_DURATION> — range (`val/dv-interval-dv-duration-range`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-085** Validate DV_INTERVAL<DV_ORDINAL> — open (`val/dv-interval-dv-ordinal-open`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-086** Validate DV_INTERVAL<DV_ORDINAL> — constraint (`val/dv-interval-dv-ordinal-constraint`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-087** Validate DV_INTERVAL<DV_SCALE> — open (`val/dv-interval-dv-scale-open`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-088** Validate DV_INTERVAL<DV_SCALE> — constraint (`val/dv-interval-dv-scale-constraint`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-089** Validate DV_INTERVAL<DV_PROPORTION> — open (`val/dv-interval-dv-proportion-open`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-090** Validate DV_INTERVAL<DV_PROPORTION> — ratio (`val/dv-interval-dv-proportion-ratio`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-091** Validate DV_INTERVAL<DV_PROPORTION> — unitary (`val/dv-interval-dv-proportion-unitary`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-092** Validate DV_INTERVAL<DV_PROPORTION> — percentage (`val/dv-interval-dv-proportion-percentage`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-093** Validate DV_INTERVAL<DV_PROPORTION> — fraction (`val/dv-interval-dv-proportion-fraction`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-094** Validate DV_INTERVAL<DV_PROPORTION> — integer fraction (`val/dv-interval-dv-proportion-integer-fraction`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-095** Validate DV_INTERVAL<DV_PROPORTION> — ratio range (`val/dv-interval-dv-proportion-ratio-range`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-096** Validate DV_DURATION — open (`val/dv-duration-open`, json): OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-097** Validate DV_DURATION — fields (`val/dv-duration-fields`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-098** Validate DV_DURATION — range (`val/dv-duration-range`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-099** Validate DV_DURATION — fields range (`val/dv-duration-fields-range`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-100** Validate DV_TIME — open (`val/dv-time-open`, json): OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-101** Validate DV_TIME — constraint (`val/dv-time-constraint`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-102** Validate DV_TIME — range (`val/dv-time-range`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-103** Validate DV_DATE — open (`val/dv-date-open`, json): OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-104** Validate DV_DATE — constraint (`val/dv-date-constraint`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-105** Validate DV_DATE — range (`val/dv-date-range`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-119** Validate DV_DATE — day disallowed by C_DATE pattern (defective vendored fixture rejected) (`val/dv-date-day-disallowed-pattern`, json): OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-106** Validate DV_DATE_TIME — open (`val/dv-date-time-open`, json): OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-107** Validate DV_DATE_TIME — constraint (`val/dv-date-time-constraint`, json): OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-108** Validate DV_DATE_TIME — range (`val/dv-date-time-range`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-109** Validate DV_PARSABLE — open (`val/dv-parsable-open`, json): OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-110** Validate DV_PARSABLE — value formalism (`val/dv-parsable-value-formalism`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-111** Validate DV_MULTIMEDIA — open (`val/dv-multimedia-open`, json): OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-112** Validate DV_MULTIMEDIA — media type (`val/dv-multimedia-media-type`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-113** Validate DV_URI — open (`val/dv-uri-open`, json): OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-114** Validate DV_URI — pattern (`val/dv-uri-pattern`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-115** Validate DV_URI — list (`val/dv-uri-list`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-116** Validate DV_EHR_URI — open (`val/dv-ehr-uri-open`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-117** Validate DV_EHR_URI — pattern (`val/dv-ehr-uri-pattern`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-VAL-118** Validate DV_EHR_URI — list (`val/dv-ehr-uri-list`, json): authored OPT upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-SIG-001** Version signing — digest present (`sig/digest-present`, json): OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-SIG-002** Version signing — digest recomputes (`sig/digest-recomputes`, json): OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-SIG-003** Version signing — all kinds (`sig/all-kinds`, json): served ORIGINAL_VERSION carries no `signature` (version-signing.md §4.4)
+- **ECC-SIG-004** Version signing — client verbatim (`sig/client-verbatim`, json): OPT minimal/minimal_admin.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-TS-001** TERMINOLOGY expand (bundle) — accepted, well-formed RESULT_SET (`ts/expand-bundle-accepted`, json): expected status 200, got 400 (body: {"error":"Bad Request","message":"Not implemented: Only primitive operands are supported"})
+- **ECC-TS-002** TERMINOLOGY expand (bundle) — expansion constrains matches to the value set's codes (`ts/expand-bundle-constrains`, json): OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)
+- **ECC-TS-003** TERMINOLOGY expand (bundle) — explicit code merged with the expansion (matches list) (`ts/expand-bundle-mixed-list`, json): OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)
+
+### Not applicable to this SUT (extensions / RM-version-sensitive)
+
+_None — every catalogued case applies to this SUT._
+
+## 2. Scope of test
+
+| Field | Value |
+|---|---|
+| Profiles requested | all |
+| Data formats | json |
+| Catalogue (active cases) | 333 |
+| Executed | 333 |
+| Passed | 95 |
+| Failed | 212 |
+| Not applicable | 0 |
+
+## 3. Detailed test report
+
+| ECC id | Capability | Format | Data sets | Result |
+|---|---|---|--:|---|
+| ECC-EHR-001 | EhrOperations | json | 1/1 | PASS |
+| ECC-EHR-002 | EhrOperations | json | 0/0 | **FAIL** |
+| ECC-EHR-003 | EhrOperations | json | 1/1 | PASS |
+| ECC-EHR-004 | EhrOperations | json | 1/1 | PASS |
+| ECC-EHR-005 | EhrOperations | json | 0/0 | **FAIL** |
+| ECC-EHR-006 | EhrOperations | json | 1/1 | PASS |
+| ECC-EHR-007 | EhrOperations | json | 0/0 | **FAIL** |
+| ECC-EHR-008 | EhrOperations | json | 0/0 | **FAIL** |
+| ECC-EHR-009 | EhrOperations | json | 0/0 | **FAIL** |
+| ECC-EHR-010 | EhrOperations | json | 1/1 | PASS |
+| ECC-EHR-011 | EhrOperations | json | 1/1 | PASS |
+| ECC-STA-001 | EhrStatus | json | 0/0 | **FAIL** |
+| ECC-STA-002 | EhrStatus | json | 1/1 | PASS |
+| ECC-STA-003 | EhrStatus | json | 0/0 | **FAIL** |
+| ECC-STA-004 | EhrStatus | json | 1/1 | PASS |
+| ECC-STA-005 | EhrStatus | json | 0/0 | **FAIL** |
+| ECC-STA-006 | EhrStatus | json | 1/1 | PASS |
+| ECC-STA-007 | EhrStatus | json | 0/0 | **FAIL** |
+| ECC-STA-008 | EhrStatus | json | 1/1 | PASS |
+| ECC-STA-009 | EhrStatus | json | 0/0 | **FAIL** |
+| ECC-STA-010 | EhrStatus | json | 1/1 | PASS |
+| ECC-EHR-012 | EhrOperations | json | 0/0 | **FAIL** |
+| ECC-EHR-013 | AnonymousEhrs | json | 0/0 | **FAIL** |
+| ECC-COM-001 | CompositionOps | json | 0/0 | **FAIL** |
+| ECC-COM-002 | CompositionOps | json | 0/0 | **FAIL** |
+| ECC-COM-003 | CompositionOps | json | 0/0 | **FAIL** |
+| ECC-COM-004 | CompositionOps | json | 0/0 | **FAIL** |
+| ECC-COM-005 | CompositionOps | json | 0/0 | **FAIL** |
+| ECC-COM-006 | CompositionOps | json | 1/1 | PASS |
+| ECC-COM-007 | CompositionOps | json | 0/0 | **FAIL** |
+| ECC-COM-008 | CompositionOps | json | 0/0 | **FAIL** |
+| ECC-COM-009 | CompositionOps | json | 1/1 | PASS |
+| ECC-COM-010 | CompositionOps | json | 1/1 | PASS |
+| ECC-COM-011 | CompositionOps | json | 1/1 | PASS |
+| ECC-COM-012 | CompositionOps | json | 1/1 | PASS |
+| ECC-COM-013 | CompositionOps | json | 0/0 | **FAIL** |
+| ECC-COM-014 | CompositionOps | json | 0/0 | **FAIL** |
+| ECC-COM-015 | CompositionOps | json | 1/1 | PASS |
+| ECC-COM-016 | CompositionOps | json | 1/1 | PASS |
+| ECC-COM-017 | CompositionOps | json | 0/0 | **FAIL** |
+| ECC-COM-018 | CompositionOps | json | 0/0 | **FAIL** |
+| ECC-COM-019 | CompositionOps | json | 1/1 | PASS |
+| ECC-COM-020 | CompositionOps | json | 1/1 | PASS |
+| ECC-COM-021 | CompositionOps | json | 0/0 | **FAIL** |
+| ECC-COM-022 | Versioning | json | 0/0 | **FAIL** |
+| ECC-COM-023 | Versioning | json | 1/1 | PASS |
+| ECC-COM-024 | Versioning | json | 1/1 | PASS |
+| ECC-COM-025 | CompositionOps | json | 0/0 | **FAIL** |
+| ECC-COM-026 | CompositionOps | json | 0/0 | **FAIL** |
+| ECC-COM-027 | CompositionOps | json | 0/0 | **FAIL** |
+| ECC-COM-028 | CompositionOps | json | 0/0 | **FAIL** |
+| ECC-COM-029 | CompositionOps | json | 0/0 | **FAIL** |
+| ECC-COM-030 | CompositionOps | json | 0/0 | **FAIL** |
+| ECC-COM-031 | CompositionOps | json | 1/1 | PASS |
+| ECC-CTB-001 | ChangeSets | json | 0/0 | **FAIL** |
+| ECC-CTB-002 | ChangeSets | json | 0/0 | **FAIL** |
+| ECC-CTB-003 | ChangeSets | json | 1/1 | PASS |
+| ECC-CTB-004 | ChangeSets | json | 0/0 | **FAIL** |
+| ECC-CTB-005 | ChangeSets | json | 1/1 | PASS |
+| ECC-CTB-006 | ChangeSets | json | 0/0 | **FAIL** |
+| ECC-CTB-007 | ChangeSets | json | 0/0 | **FAIL** |
+| ECC-CTB-008 | ChangeSets | json | 0/0 | **FAIL** |
+| ECC-CTB-009 | ChangeSets | json | 0/0 | **FAIL** |
+| ECC-CTB-010 | ChangeSets | json | 0/0 | **FAIL** |
+| ECC-CTB-011 | ChangeSets | json | 1/1 | PASS |
+| ECC-CTB-012 | ChangeSets | json | 1/1 | PASS |
+| ECC-CTB-013 | ChangeSets | json | 1/1 | PASS |
+| ECC-CTB-014 | ChangeSets | json | 1/1 | PASS |
+| ECC-CTB-015 | ChangeSets | json | 1/1 | PASS |
+| ECC-CTB-016 | ChangeSets | json | 1/1 | PASS |
+| ECC-CTB-017 | ChangeSets | json | 1/1 | PASS |
+| ECC-CTB-018 | ChangeSets | json | 1/1 | PASS |
+| ECC-CTB-019 | ChangeSets | json | 0/0 | **FAIL** |
+| ECC-CTB-020 | ChangeSets | json | 1/1 | PASS |
+| ECC-CTB-021 | ChangeSets | json | 1/1 | PASS |
+| ECC-CTB-022 | ChangeSets | json | 0/0 | **FAIL** |
+| ECC-CTB-023 | ChangeSets | json | 0/0 | **FAIL** |
+| ECC-CTB-024 | ChangeSets | json | 0/0 | **FAIL** |
+| ECC-CTB-025 | ChangeSets | json | 1/1 | PASS |
+| ECC-CTB-026 | ChangeSets | json | 1/1 | PASS |
+| ECC-CTB-027 | ChangeSets | json | 0/0 | skipped |
+| ECC-CTB-028 | ChangeSets | json | 0/0 | skipped |
+| ECC-CTB-029 | ChangeSets | json | 0/0 | skipped |
+| ECC-CTB-030 | ChangeSets | json | 0/0 | skipped |
+| ECC-CTB-031 | ChangeSets | json | 0/0 | skipped |
+| ECC-DIR-001 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-002 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-003 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-004 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-005 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-006 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-007 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-008 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-009 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-010 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-011 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-012 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-013 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-014 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-015 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-016 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-017 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-018 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-019 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-020 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-021 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-022 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-023 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-024 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-025 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-026 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-027 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-028 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-029 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-030 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-031 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-032 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-033 | Versioning | json | 1/1 | PASS |
+| ECC-DIR-034 | Versioning | json | 1/1 | PASS |
+| ECC-DIR-035 | Versioning | json | 1/1 | PASS |
+| ECC-DIR-036 | DirectoryOps | json | 1/1 | PASS |
+| ECC-DIR-037 | DirectoryOps | json | 1/1 | PASS |
+| ECC-TPL-001 | Adl14ArchetypeProvisioning | json | 0/0 | **FAIL** |
+| ECC-TPL-002 | Adl14OptProvisioning | json | 18/18 | PASS |
+| ECC-TPL-003 | Adl14OptProvisioning | json | 1/1 | PASS |
+| ECC-TPL-004 | Adl14OptProvisioning | json | 0/0 | **FAIL** |
+| ECC-TPL-005 | Adl14OptProvisioning | json | 0/0 | **FAIL** |
+| ECC-TPL-006 | Adl14OptProvisioning | json | 0/0 | **FAIL** |
+| ECC-TPL-007 | Adl14OptProvisioning | json | 0/0 | **FAIL** |
+| ECC-TPL-008 | Adl14OptProvisioning | json | 0/0 | **FAIL** |
+| ECC-TPL-009 | Adl14OptProvisioning | json | 1/1 | PASS |
+| ECC-TPL-010 | Adl14OptProvisioning | json | 0/0 | **FAIL** |
+| ECC-TPL-011 | Adl14OptProvisioning | json | 0/0 | **FAIL** |
+| ECC-TPL-012 | Adl14OptProvisioning | json | 1/1 | PASS |
+| ECC-TPL-013 | Adl14OptProvisioning | json | 0/0 | skipped |
+| ECC-TPL-014 | Adl14OptProvisioning | json | 0/0 | skipped |
+| ECC-TPL-015 | Adl14OptProvisioning | json | 0/0 | skipped |
+| ECC-TPL-016 | Adl14OptProvisioning | json | 0/0 | skipped |
+| ECC-SQR-001 | QueryProvisioning | json | 1/1 | PASS |
+| ECC-SQR-002 | QueryProvisioning | json | 1/1 | PASS |
+| ECC-SQR-003 | QueryProvisioning | json | 1/1 | PASS |
+| ECC-SQR-004 | QueryProvisioning | json | 0/0 | skipped |
+| ECC-SQR-005 | QueryProvisioning | json | 0/0 | skipped |
+| ECC-SQR-006 | QueryProvisioning | json | 1/1 | PASS |
+| ECC-SQR-007 | QueryProvisioning | json | 1/1 | PASS |
+| ECC-QRY-001 | AqlBasic | json | 1/1 | PASS |
+| ECC-QRY-002 | AqlBasic | json | 0/0 | **FAIL** |
+| ECC-QRY-003 | AqlBasic | json | 0/0 | **FAIL** |
+| ECC-QRY-004 | AqlBasic | json | 0/0 | **FAIL** |
+| ECC-QRY-005 | AqlBasic | json | 2/2 | PASS |
+| ECC-QRY-006 | AqlBasic | json | 0/0 | **FAIL** |
+| ECC-QRY-007 | AqlBasic | json | 0/0 | **FAIL** |
+| ECC-QRY-008 | AqlBasic | json | 0/0 | **FAIL** |
+| ECC-QRY-009 | AqlBasic | json | 0/0 | **FAIL** |
+| ECC-QRY-010 | AqlBasic | json | 0/0 | **FAIL** |
+| ECC-QRY-011 | AqlBasic | json | 0/0 | **FAIL** |
+| ECC-QRY-012 | AqlBasic | json | 1/1 | PASS |
+| ECC-QRY-013 | AqlBasic | json | 0/0 | **FAIL** |
+| ECC-ADM-001 | AdminApi | json | 1/1 | PASS |
+| ECC-ADM-002 | AdminApi | json | 1/1 | PASS |
+| ECC-ADM-003 | AdminApi | json | 1/1 | PASS |
+| ECC-ADM-004 | AdminApi | json | 0/0 | **FAIL** |
+| ECC-ADM-005 | AdminApi | json | 0/0 | **FAIL** |
+| ECC-ADM-006 | AdminApi | json | 1/1 | PASS |
+| ECC-DEM-001 | DemographicApi | json | 0/0 | **FAIL** |
+| ECC-DEM-002 | DemographicApi | json | 0/0 | **FAIL** |
+| ECC-DEM-003 | DemographicApi | json | 0/0 | **FAIL** |
+| ECC-DEM-004 | DemographicApi | json | 0/0 | **FAIL** |
+| ECC-DEM-005 | DemographicApi | json | 0/0 | **FAIL** |
+| ECC-DEM-006 | DemographicApi | json | 0/0 | **FAIL** |
+| ECC-DEM-007 | DemographicApi | json | 1/1 | PASS |
+| ECC-DEM-008 | DemographicApi | json | 0/0 | **FAIL** |
+| ECC-DEM-009 | DemographicApi | json | 0/0 | **FAIL** |
+| ECC-DEM-010 | DemographicApi | json | 0/0 | **FAIL** |
+| ECC-DEM-011 | DemographicApi | json | 0/0 | **FAIL** |
+| ECC-DEM-012 | DemographicApi | json | 0/0 | **FAIL** |
+| ECC-DEM-013 | DemographicApi | json | 0/0 | **FAIL** |
+| ECC-DEM-014 | DemographicApi | json | 0/0 | **FAIL** |
+| ECC-DEM-015 | DemographicApi | json | 0/0 | **FAIL** |
+| ECC-DEM-016 | DemographicApi | json | 0/0 | **FAIL** |
+| ECC-DEM-017 | DemographicApi | json | 0/0 | **FAIL** |
+| ECC-DEM-018 | DemographicApi | json | 0/0 | **FAIL** |
+| ECC-DEM-019 | DemographicApi | json | 0/0 | **FAIL** |
+| ECC-DEM-020 | DemographicApi | json | 0/0 | **FAIL** |
+| ECC-DEM-021 | DemographicApi | json | 0/0 | **FAIL** |
+| ECC-DEM-022 | DemographicApi | json | 0/0 | **FAIL** |
+| ECC-DEM-023 | DemographicApi | json | 0/0 | **FAIL** |
+| ECC-DEM-024 | DemographicApi | json | 0/0 | **FAIL** |
+| ECC-VAL-001 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-002 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-003 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-004 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-005 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-006 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-007 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-008 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-009 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-010 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-011 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-012 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-013 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-014 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-015 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-016 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-017 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-018 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-019 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-020 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-021 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-022 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-023 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-024 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-025 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-026 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-027 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-028 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-029 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-030 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-031 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-032 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-033 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-034 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-035 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-036 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-037 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-038 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-039 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-040 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-041 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-042 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-043 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-044 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-045 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-046 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-047 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-048 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-049 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-050 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-051 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-052 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-053 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-054 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-055 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-056 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-057 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-058 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-059 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-060 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-061 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-062 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-063 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-064 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-065 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-066 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-067 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-068 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-069 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-070 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-071 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-072 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-073 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-074 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-075 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-076 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-077 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-078 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-079 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-080 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-081 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-082 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-083 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-084 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-085 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-086 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-087 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-088 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-089 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-090 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-091 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-092 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-093 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-094 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-095 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-096 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-097 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-098 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-099 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-100 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-101 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-102 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-103 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-104 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-105 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-119 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-106 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-107 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-108 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-109 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-110 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-111 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-112 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-113 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-114 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-115 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-116 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-117 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-VAL-118 | ArchetypeValidation | json | 0/0 | **FAIL** |
+| ECC-SIG-001 | Signing | json | 0/0 | **FAIL** |
+| ECC-SIG-002 | Signing | json | 0/0 | **FAIL** |
+| ECC-SIG-003 | Signing | json | 0/0 | **FAIL** |
+| ECC-SIG-004 | Signing | json | 0/0 | **FAIL** |
+| ECC-SIG-005 | Signing | json | 0/0 | skipped |
+| ECC-MSG-001 | Messaging | json | 0/0 | skipped |
+| ECC-MSG-002 | Messaging | json | 0/0 | skipped |
+| ECC-MSG-003 | Messaging | json | 0/0 | skipped |
+| ECC-MSG-004 | Messaging | json | 0/0 | skipped |
+| ECC-MSG-005 | Messaging | json | 0/0 | skipped |
+| ECC-MSG-006 | Messaging | json | 0/0 | skipped |
+| ECC-MSG-007 | Messaging | json | 0/0 | skipped |
+| ECC-MSG-008 | Messaging | json | 0/0 | skipped |
+| ECC-MSG-009 | Messaging | json | 0/0 | skipped |
+| ECC-MSG-010 | Messaging | json | 0/0 | skipped |
+| ECC-TS-001 | Terminology | json | 0/0 | **FAIL** |
+| ECC-TS-002 | Terminology | json | 0/0 | **FAIL** |
+| ECC-TS-003 | Terminology | json | 0/0 | **FAIL** |
+| ECC-TS-004 | Terminology | json | 1/1 | PASS |
+| ECC-TS-005 | Terminology | json | 1/1 | PASS |
+| ECC-TS-006 | Terminology | json | 0/0 | skipped |
+| ECC-TS-007 | Terminology | json | 0/0 | skipped |
+| ECC-TS-008 | Terminology | json | 0/0 | skipped |
+| ECC-TS-009 | Terminology | json | 0/0 | skipped |
+| ECC-SEC-001 | Authentication | json | 1/1 | PASS |
+| ECC-SEC-002 | Authentication | json | 1/1 | PASS |
+
+## 4. Profile verdict (machine-computed)
+
+CORE/STANDARD are all-or-nothing (every capability must pass); OPTIONS is any-passes (obtained if ≥1 optional capability passes) — `master03-profiles.adoc`.
+
+### Core — not claimable
+
+| Capability | Passed | Failed | Errored | Skipped | N/A | Verdict |
+|---|--:|--:|--:|--:|--:|---|
+| Adl14ArchetypeProvisioning | 0 | 1 | 0 | 0 | 0 | fail |
+| Adl14OptProvisioning | 4 | 7 | 0 | 4 | 0 | fail |
+| EhrOperations | 6 | 6 | 0 | 0 | 0 | fail |
+| EhrStatus | 5 | 5 | 0 | 0 | 0 | fail |
+| CompositionOps | 10 | 18 | 0 | 0 | 0 | fail |
+| ChangeSets | 14 | 12 | 0 | 5 | 0 | fail |
+| Versioning | 5 | 1 | 0 | 0 | 0 | fail |
+| ArchetypeValidation | 0 | 119 | 0 | 0 | 0 | fail |
+| AnonymousEhrs | 0 | 1 | 0 | 0 | 0 | fail |
+
+### Standard — not claimable
+
+| Capability | Passed | Failed | Errored | Skipped | N/A | Verdict |
+|---|--:|--:|--:|--:|--:|---|
+| Adl14ArchetypeProvisioning | 0 | 1 | 0 | 0 | 0 | fail |
+| Adl14OptProvisioning | 4 | 7 | 0 | 4 | 0 | fail |
+| EhrOperations | 6 | 6 | 0 | 0 | 0 | fail |
+| EhrStatus | 5 | 5 | 0 | 0 | 0 | fail |
+| CompositionOps | 10 | 18 | 0 | 0 | 0 | fail |
+| ChangeSets | 14 | 12 | 0 | 5 | 0 | fail |
+| Versioning | 5 | 1 | 0 | 0 | 0 | fail |
+| ArchetypeValidation | 0 | 119 | 0 | 0 | 0 | fail |
+| AnonymousEhrs | 0 | 1 | 0 | 0 | 0 | fail |
+| DirectoryOps | 34 | 0 | 0 | 0 | 0 | pass |
+| QueryProvisioning | 5 | 0 | 0 | 2 | 0 | pass |
+| AqlBasic | 3 | 10 | 0 | 0 | 0 | fail |
+| Signing | 0 | 4 | 0 | 1 | 0 | fail |
+
+### Options — not obtained
+
+| Capability | Passed | Failed | Errored | Skipped | N/A | Verdict |
+|---|--:|--:|--:|--:|--:|---|
+| Adl2Provisioning | 0 | 0 | 0 | 0 | 0 | not evidenced |
+| DemographicApi | 1 | 23 | 0 | 0 | 0 | fail |
+| AqlAdvanced | 0 | 0 | 0 | 0 | 0 | not evidenced |
+| Terminology | 2 | 3 | 0 | 4 | 0 | fail |
+| AdminApi | 4 | 2 | 0 | 0 | 0 | fail |
+| AdminActivityReport | 0 | 0 | 0 | 0 | 0 | not evidenced |
+| AdminPhysicalDeletion | 0 | 0 | 0 | 0 | 0 | not evidenced |
+| AdminEhrDumpLoad | 0 | 0 | 0 | 0 | 0 | not evidenced |
+| AdminBulkEhrLoad | 0 | 0 | 0 | 0 | 0 | not evidenced |
+| AdminEhrArchive | 0 | 0 | 0 | 0 | 0 | not evidenced |
+| AdminDemographicArchive | 0 | 0 | 0 | 0 | 0 | not evidenced |
+| Messaging | 0 | 0 | 0 | 10 | 0 | not evidenced |
+
+## 5. Deviations (skips), by reason
+
+| Reason | Cases |
+|---|--:|
+| NativeApiOnly: I_EHR_EXTRACT_SERVICE.export_ehr_extracts is exercised by app/ehrbase/tests/service_extract.rs::export_ehr_extracts_honours_item_list_and_all_versions — Messaging has no ITS-REST binding | 1 |
+| NativeApiOnly: I_EHR_EXTRACT_SERVICE.export_ehrs (unknown EHR) is exercised by app/ehrbase/tests/service_extract.rs::export_ehrs_unknown_ehr_is_ehr_id_does_not_exist — Messaging has no ITS-REST binding | 1 |
+| NativeApiOnly: I_EHR_EXTRACT_SERVICE.export_ehrs is exercised by app/ehrbase/tests/service_extract.rs::export_ehrs_carries_every_versioned_object_latest_only — Messaging has no ITS-REST binding | 1 |
+| NativeApiOnly: I_EHR_EXTRACT_SERVICE.import_ehr (duplicate id) is exercised by app/ehrbase/tests/service_import.rs::import_ehr_duplicate_target_is_rejected — Messaging has no ITS-REST binding | 1 |
+| NativeApiOnly: I_EHR_EXTRACT_SERVICE.import_ehr (fixed id) is exercised by app/ehrbase/tests/service_import.rs::import_ehr_into_fixed_fresh_id — Messaging has no ITS-REST binding | 1 |
+| NativeApiOnly: I_EHR_EXTRACT_SERVICE.import_ehr is exercised by app/ehrbase/tests/service_import.rs::import_ehr_clone_into_fresh_target_reuses_source_id — Messaging has no ITS-REST binding | 1 |
+| NativeApiOnly: I_EHR_EXTRACT_SERVICE.import_ehr_extract is exercised by app/ehrbase/tests/service_import.rs::import_ehr_extract_adds_a_versioned_object_and_rejects_re_import — Messaging has no ITS-REST binding | 1 |
+| NativeApiOnly: I_TDD_SERVICE.import_tdd (typed rejections) is exercised by app/ehrbase/tests/service_tdd.rs::{tdd_import_rejects_malformed_payload, tdd_import_rejects_non_tdd_xml, tdd_import_rejects_unknown_ehr, tdd_import_rejects_unknown_template} — Messaging has no ITS-REST binding | 1 |
+| NativeApiOnly: I_TDD_SERVICE.import_tdd is exercised by app/ehrbase/tests/service_tdd.rs::tdd_import_commits_composition — Messaging has no ITS-REST binding | 1 |
+| NativeApiOnly: I_TDD_SERVICE.import_tdds is exercised by app/ehrbase/tests/service_tdd.rs::{tdd_import_tdds_batch_commits_all, tdd_import_tdds_batch_fail_fast} — Messaging has no ITS-REST binding | 1 |
+| SM I_DEFINITION_ADL14.delete_opt() (CNF master04:319) has no ITS-REST ADL 1.4 binding — ITS-REST development@e8a093e (and Release-1.0.3) define no DELETE verb on /definition/template/adl1.4/{id}; OPT deletion lives in the ADMIN API only | 4 |
+| SM I_DEFINITION_QUERY.list_queries() (CNF master05:93) has no ITS-REST binding — ITS-REST development@e8a093e (and Release-1.0.3) expose GET /definition/query/{qualified_query_name}, not a bare GET /definition/query collection | 2 |
+| SM I_EHR_CONTRIBUTION.list_contributions() (CNF master08:595) has no ITS-REST binding — ITS-REST development@e8a093e (and Release-1.0.3) define POST only on /ehr/{ehr_id}/contribution, with no GET collection resource; the list is a native-API concern, not wire-exercisable | 5 |
+| SutConfig: FHIR terminology provider not exercisable — the SUT answered 400 to a `hl7.org/fhir/4.0` expand (a configured provider that lacks the fixture value set, or a non-provider rejection). Not a fabricated pass. | 1 |
+| SutConfig: server not in `pgp` mode (needs a configured OpenPGP key); a pgp-keyed compose profile is a follow-up — digest cases prove the capability | 1 |
+| SutConfig: the 5xx fault requires a fault-injecting terminology server wired to the SUT (--tx-server-url + an SUT FHIR provider pointed at it); the HTTP-only ECC cannot reconfigure an external SUT's provider per case. Harness tx server: http://127.0.0.1:49886 (fixture). The fault→500 mapping is proven by conformance ts::fixture::tests::fault_server_error_is_5xx + app/ehrbase/tests/terminology_fhir.rs::server_5xx_is_an_exception. | 1 |
+| SutConfig: the malformed fault requires a fault-injecting terminology server wired to the SUT (--tx-server-url + an SUT FHIR provider pointed at it); the HTTP-only ECC cannot reconfigure an external SUT's provider per case. Harness tx server: http://127.0.0.1:49886 (fixture). The fault→500 mapping is proven by conformance ts::fixture::tests::fault_malformed_is_not_json + app/ehrbase/tests/terminology_fhir.rs::malformed_body_is_an_exception. | 1 |
+| SutConfig: the timeout fault requires a fault-injecting terminology server wired to the SUT (--tx-server-url + an SUT FHIR provider pointed at it); the HTTP-only ECC cannot reconfigure an external SUT's provider per case. Harness tx server: http://127.0.0.1:49886 (fixture). The fault→500 mapping is proven by conformance ts::fixture::tests::fault_timeout_exceeds_a_short_client_deadline + app/ehrbase/tests/terminology_fhir.rs::timeout_is_an_exception. | 1 |
+
+## 6. Terminology server (TS area)
+
+- Server: `http://127.0.0.1:49886`
+- Mode: fixture
+
+Recorded FHIR-tx exchange (4 request(s)):
+
+| # | Method | Path | Query |
+|--:|---|---|---|
+| 1 | GET | `/ValueSet/$expand` | url=http%3A%2F%2Fhl7.org%2Ffhir%2FValueSet%2Fsurface |
+| 2 | GET | `/ValueSet/$validate-code` | url=http%3A%2F%2Fhl7.org%2Ffhir%2FValueSet%2Fsurface&code=B |
+| 3 | GET | `/CodeSystem/$lookup` | code=B |
+| 4 | GET | `/CodeSystem/$subsumes` | codeA=L&codeB=O |

--- a/docs/conformance/upstream-ehrbase/TRIAGE.md
+++ b/docs/conformance/upstream-ehrbase/TRIAGE.md
@@ -1,0 +1,188 @@
+# EHRbase (Java) 2.34.0 vs ehrbase-rs — spec-grounded difference analysis
+
+**Objective (owner ruling, 2026-07-11, mid-run):** run our ECC catalogue
+against **upstream EHRbase Java 2.34.0** and, for every difference, decide
+**who is wrong against the official openEHR specs — Java or our Rust** — because
+our own server still has compliance bugs to fix. **Adjudication exemptions are
+removed for this run** (no fairness register applied): the numbers below are the
+**raw** diff so nothing is hidden.
+
+**Run:** 2026-07-11 · SUT `ehrbase-java` **2.34.0** (digest
+`sha256:89e52635fc72dca3eda368b601f3a7aa6cbaa24e7582f5ee00e953759626904d`) ·
+base `http://localhost:8091/ehrbase/rest/openehr/v1` · admin
+`/ehrbase/rest/admin` (`ADMINAPI_ACTIVE=true`) · Basic auth · **no
+`--adjudications`** (raw). Oracle: vendored specs at `docs/specs/openehr/`.
+No case was edited or weakened; our own baseline stays **341 / 315 / 0**.
+
+## 1. Raw numbers
+
+| Outcome | Count |
+|---|---:|
+| Passed | **95** |
+| Failed | **212** |
+| Skipped (suite self-skip: MSG native-only, etc.) | 26 |
+| **Total executed** | **333** |
+
+## 2. The difference ledger — who is wrong, per spec
+
+Every failing family, root cause verified live (§4), mapped to the responsible
+side against the vendored spec:
+
+| # | Difference | Cases | Who is wrong per spec | Spec citation |
+|---|---|---:|---|---|
+| **A** | Java omits mandatory `EHR.ehr_access` from the EHR resource | **7** | **JAVA** (our Rust is correct) | RM EHR `ehr_access` 1..1; ITS-JSON `EHR.required` (all RM releases) |
+| **B1** | Our Rust **accepts** `EHR_STATUS.subject._type = PARTY_IDENTIFIED` | **4** | **OUR RUST** (Java correctly rejects, 400) | RM `EHR_STATUS.subject : PARTY_SELF` |
+| **B2** | Our Rust rejects an empty (anonymous) `subject: {}` | **1** | **OUR RUST (likely)** — Java accepts; needs review | RM `master04` — "PARTY_SELF allows completely anonymous EHRs" |
+| **C** | AQL result-column `path` notation (`/ehr_id/value` vs `e/ehr_id/value`) | **9** | **NEITHER** — spec explicitly undefined | QUERY `master04-result_structure` §annotated results not defined |
+| **D** | OPT upload → `406` (our runner sends `Accept: application/json`) | **164** | **OUR RUNNER** (Java strict-correct; our server lenient) | ITS-REST upload op = `application/xml` only, no Accept param |
+| **E** | ehrbase-rs features Java does not implement (scope, not a bug) | **27** | neither — feature-scope difference | see §3 |
+
+212 = 7 (A) + 5 (B1+B2) + 9 (C) + 164 (D) + 27 (E).
+
+### The one thing this run CANNOT answer yet
+
+**Validation depth (the 119 VAL cases + 19 COM + 12 CTB + 8 TPL) is
+undeterminable** because all of it is blocked at the OPT-upload step by runner
+bug **D**. This is exactly the comparison the owner most wants (does Java — or
+our Rust — validate archetype constraints as deeply as the AM spec requires?).
+It only becomes visible after D is fixed and the suite re-run. Upstream is known
+to validate shallowly (blueprint §2.3 row 1), and our own VAL depth is partial
+too — **both sides likely have defects here that this run masks.**
+
+## 3. Category E — ehrbase-rs features Java lacks (27, not compliance bugs)
+
+| Feature | Cases | Evidence |
+|---|---:|---|
+| Demographic REST API (`I_DEMOGRAPHIC_SERVICE` wire) | 23 (DEM) | Java → `404 No resource found` |
+| Bulk `DELETE /admin/ehr/all` convenience | 2 (ADM-004/005) | Java → `400 Invalid UUID string: all` |
+| AQL `TERMINOLOGY('expand',…)` function | 1 (TS-001) | Java → `400 Not implemented: Only primitive operands are supported` |
+| Version signing (`VERSION.signature`) | 1 (SIG) | served `ORIGINAL_VERSION` carries no `signature` |
+
+(3 more SIG/TS cases fail on the OPT-upload runner bug D and are counted there.)
+These are scope differences: Java never claims these surfaces. They are *not*
+Java defects, and not our bugs — they are ehrbase-rs capabilities beyond the
+ITS-REST 1.0.x core. TERMINOLOGY() is an **optional** AQL capability
+(QUERY master03 lines 748-767); the others are ehrbase-rs extensions.
+
+## 4. Evidence (live curl, 2026-07-11)
+
+### A — `EHR.ehr_access` omitted → **Java defect, our Rust correct** (7)
+
+```
+POST /ehr (no body) → 201 ; GET /ehr/{id} → {_type, system_id, ehr_id, ehr_status, time_created}
+```
+No `ehr_access`. It is **`1..1` in the RM class model** and in the **`required`
+set of every vendored ITS-JSON EHR schema** (`openehr_rm_1.0.3_all.json`,
+`_1.0.4_`, `_1.1.0_`) and mandatory in the RM 1.1.0 XSD — so this is **not** an
+RM-version wire-skew artefact. ehrbase-rs emits it and is correct.
+*(EHR_ACCESS is deprecated-in-practice and Java drops it deliberately; the
+vendored spec still mandates it, so per the oracle it is a Java defect.)*
+- `docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.ehr.ehr.adoc` (ehr_access 1..1)
+- `crates/openehr-its/schemas/json/openehr_rm_1.1.0_all.json` (`EHR.required` ∋ `ehr_access`)
+
+Cases: EHR-008, EHR-013, STA-001, STA-003, STA-005, STA-007, STA-009.
+
+### B1 — `subject` = `PARTY_IDENTIFIED` accepted → **our Rust is wrong** (4)
+
+```
+POST /ehr  {EHR_STATUS.subject._type:"PARTY_IDENTIFIED"} → Java 400
+  "Class PartyIdentified not subtype of PartySelf"
+```
+`EHR_STATUS.subject` is **`PARTY_SELF` (1..1)** in every RM release; our
+generated type is literally `subject: PartySelf`. **Java is correct to reject;
+ehrbase-rs wrongly accepts** (our baseline passes EHR-002/005/007/009). This is
+a leniency bug in our canonical-JSON `_type` handling: a foreign concrete
+`_type` in a `PARTY_SELF` slot must be rejected. **Fix target:** the
+`OpenEhrType` deserialize / RM validation in `openehr-its` (likely affects any
+monomorphic slot that currently tolerates a wrong `_type`, not just PARTY_SELF).
+- `docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.ehr.ehr_status.adoc` (`subject: PARTY_SELF`)
+- `docs/specs/openehr/RM/docs/ehr/master04-ehr_package.adoc:44,219`
+
+*(The runner ALSO has a fixture bug here — `ehr_status_row` in
+`tools/conformance/src/suites/ehr.rs` builds `PARTY_IDENTIFIED`; the vendored
+corpus fixture uses `PARTY_SELF`. Fixing the fixture will stop our server
+passing on leniency, exposing B1 in our own suite.)*
+
+### B2 — anonymous `subject: {}` rejected → **our Rust likely wrong** (1, EHR-012)
+
+Java accepts 2 of 11 "invalid" fixtures; both acceptances are spec-defensible:
+- `001_ehr_status_subject_empty.json` — `subject: {}` = empty `PARTY_SELF` = a
+  **valid anonymous EHR** ("PARTY_SELF allows completely anonymous EHRs").
+- `000_ehr_status_type_missing.json` — a top-level `_type` inferable from the
+  `create_ehr` endpoint contract.
+
+Our baseline rejects all 11, so **ehrbase-rs may be over-strict on anonymous
+EHRs** — review against `master04-ehr_package.adoc:44,219` and relax if warranted.
+
+### C — AQL column `path` notation → **neither wrong** (9)
+
+```
+golden:   [{"name":"#0","path":"/ehr_id/value"}]
+Java:     [{"name":"#0","path":"e/ehr_id/value"}]
+```
+The AQL spec **explicitly does not define** result-set column descriptors:
+"annotated results … not formally defined by this specification … an artefact of
+the relevant API or service definition" —
+`docs/specs/openehr/QUERY/docs/AQL/master04-result_structure.adoc:5`. Both
+notations are valid; the ECC goldens encode *our* convention. (Deeper AQL
+divergences may hide behind this first reported one — normalise the notation in
+the comparison before drawing an AQL-depth conclusion.)
+Cases: QRY-002/003/006/007/008/009/010/011/013.
+
+### D — OPT upload `406` → **our runner bug; Java strict-correct** (164)
+
+```
+POST /definition/template/adl1.4  Content-Type: application/xml  Accept: application/json → 406
+POST /definition/template/adl1.4  Content-Type: application/xml  (no Accept)              → 201 (application/xml)
+```
+Our runner (`tools/conformance/src/suites/support.rs:56-58,88-90`) sends
+`Accept: application/json`. Per ITS-REST the upload endpoint **produces
+`application/xml` only** — it declares **no `Accept` parameter** and its `201`
+body is `OperationalTemplate`/xml:
+- `docs/specs/openehr/ITS-REST/specifications/operations/definition_template_adl1.4_upload.yaml`
+- `docs/specs/openehr/ITS-REST/specifications/responses/201_Template_adl1_4_upload.yaml`
+
+So Java's `406` is spec-correct; ehrbase-rs `2xx` is lenient. **Proof Java is
+otherwise functional** — after provisioning OPTs without the bad header:
+```
+POST /ehr/{id}/composition  nested.en.v1__full.json               → 201
+POST /ehr/{id}/composition  nested.en.v1__invalid_wrong_structure  → 400
+```
+Cases: all VAL (119), COM (19), CTB (12), TPL (8), QRY-004, + SIG/TS overflow.
+
+## 5. Action list
+
+**Fix in our Rust server (compliance — the owner's priority):**
+1. **B1** — reject a foreign concrete `_type` in a `PARTY_SELF` (and every
+   monomorphic-slot) canonical-JSON deserialize; today we silently accept
+   `PARTY_IDENTIFIED` as an `EHR_STATUS.subject`. *(openehr-its `_type`
+   validation / RM validation.)*
+2. **B2** — review anonymous-EHR handling; likely relax to accept `subject: {}`.
+3. **D (server side)** — decide the correct content-negotiation for OPT upload
+   (spec = `application/xml`); our leniency isn't wrong per se but should be
+   deliberate, not accidental.
+
+**Fix in our ECC runner (unblocks the real comparison):**
+4. **R1 / D** — OPT upload must send `Accept: application/xml` (or none), not
+   `application/json` (`suites/support.rs`). Unblocks 164 cases and the whole
+   VAL/COM/CTB/TPL depth comparison.
+5. **R2 / B1** — build `EHR_STATUS.subject` as a `PARTY_SELF` with `external_ref`
+   (`suites/ehr.rs ehr_status_row`), matching the vendored corpus.
+6. **R3 / C** — normalise the AQL result-column `path` notation in the golden
+   comparison (spec-undefined), so a valid alternative notation isn't a failure.
+
+**Genuine upstream (Java) finding, per spec:**
+7. **A** — Java omits the mandatory `EHR.ehr_access`. (Report; do not work around.)
+
+**Re-run after 4/5/6** to get the validation-depth verdict on both servers —
+that is where the remaining, most important, compliance differences live.
+
+## 6. Open questions for the orchestrator
+
+- **B2 / EHR-012**: is our anonymous-EHR rejection a bug, or is the corpus's
+  "invalid" labelling wrong? (Both readings are spec-plausible; leaning our bug.)
+- **VAL depth (blocked)**: after fixing D, how do Java and our Rust each compare
+  to the AM constraint-validation spec? Expect defects on **both** sides.
+- Whether to re-introduce fairness adjudications (extensions → N/A) for the
+  eventual public comparison page, or keep the raw diff as the working
+  instrument for the compliance rewrite. (Owner removed them for now.)

--- a/docs/conformance/upstream-ehrbase/badge-core.json
+++ b/docs/conformance/upstream-ehrbase/badge-core.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "ECC CORE",
+  "message": "0/9 capabilities",
+  "color": "red"
+}

--- a/docs/conformance/upstream-ehrbase/badge-options.json
+++ b/docs/conformance/upstream-ehrbase/badge-options.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "ECC OPTIONS",
+  "message": "0/12 capabilities",
+  "color": "red"
+}

--- a/docs/conformance/upstream-ehrbase/badge-standard.json
+++ b/docs/conformance/upstream-ehrbase/badge-standard.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "ECC STANDARD",
+  "message": "2/13 capabilities",
+  "color": "red"
+}

--- a/docs/conformance/upstream-ehrbase/badge.json
+++ b/docs/conformance/upstream-ehrbase/badge.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "ECC conformance",
+  "message": "95/333",
+  "color": "red"
+}

--- a/docs/conformance/upstream-ehrbase/results.json
+++ b/docs/conformance/upstream-ehrbase/results.json
@@ -1,0 +1,5626 @@
+{
+  "sut": {
+    "base_url": "http://localhost:8091/ehrbase/rest/openehr/v1",
+    "product": {
+      "name": "ehrbase-java",
+      "version": "2.34.0",
+      "image_digest": "sha256:89e52635fc72dca3eda368b601f3a7aa6cbaa24e7582f5ee00e953759626904d"
+    },
+    "versions": {
+      "rm": "1.2.0",
+      "its_rest": "development@e8a093e",
+      "aql": "1.1.0",
+      "term": "3.1.0"
+    },
+    "auth_mode": "basic"
+  },
+  "corpus": {
+    "repo": "openEHR/specifications-CNF",
+    "commit": "33251d2a"
+  },
+  "started": "2026-07-11T11:30:31.367209Z",
+  "selection": {
+    "filter": null,
+    "profile": null,
+    "formats": [
+      "json"
+    ]
+  },
+  "terminology": {
+    "base_url": "http://127.0.0.1:49886",
+    "mode": "fixture",
+    "exchanges": [
+      {
+        "method": "GET",
+        "path": "/ValueSet/$expand",
+        "query": "url=http%3A%2F%2Fhl7.org%2Ffhir%2FValueSet%2Fsurface"
+      },
+      {
+        "method": "GET",
+        "path": "/ValueSet/$validate-code",
+        "query": "url=http%3A%2F%2Fhl7.org%2Ffhir%2FValueSet%2Fsurface&code=B"
+      },
+      {
+        "method": "GET",
+        "path": "/CodeSystem/$lookup",
+        "query": "code=B"
+      },
+      {
+        "method": "GET",
+        "path": "/CodeSystem/$subsumes",
+        "query": "codeA=L&codeB=O"
+      }
+    ]
+  },
+  "cases": [
+    {
+      "ecc_id": "ECC-EHR-001",
+      "id": "ehr/has-ehr-existing-ehr-id",
+      "title": "EHR existence check — existing EHR id",
+      "capability": "EhrOperations",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
+      "duration_ms": 242
+    },
+    {
+      "ecc_id": "ECC-EHR-002",
+      "id": "ehr/has-ehr-existing-subject-id",
+      "title": "EHR existence check — existing subject id",
+      "capability": "EhrOperations",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "expected status 201, got 400 (body: {\"error\":\"Bad Request\",\"message\":\"JSON parse error: Could not resolve type id 'PARTY_IDENTIFIED' as a subtype of `com.nedap.archie.rm.generic.PartySelf`: Class `com.nedap.archie.rm.generic.PartyIdentified` not subtype of `com.nedap.archie.rm.generic.PartySelf`\"})",
+      "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
+      "duration_ms": 33
+    },
+    {
+      "ecc_id": "ECC-EHR-003",
+      "id": "ehr/has-ehr-non-existing-ehr-id",
+      "title": "EHR existence check — non existing EHR id",
+      "capability": "EhrOperations",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
+      "duration_ms": 7
+    },
+    {
+      "ecc_id": "ECC-EHR-004",
+      "id": "ehr/has-ehr-non-existing-subject-id",
+      "title": "EHR existence check — non existing subject id",
+      "capability": "EhrOperations",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
+      "duration_ms": 24
+    },
+    {
+      "ecc_id": "ECC-EHR-005",
+      "id": "ehr/create-ehr-main",
+      "title": "Create EHR — main",
+      "capability": "EhrOperations",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "expected status 201, got 400 (body: {\"error\":\"Bad Request\",\"message\":\"JSON parse error: Could not resolve type id 'PARTY_IDENTIFIED' as a subtype of `com.nedap.archie.rm.generic.PartySelf`: Class `com.nedap.archie.rm.generic.PartyIdentified` not subtype of `com.nedap.archie.rm.generic.PartySelf`\"})",
+      "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-EHR-006",
+      "id": "ehr/create-ehr-same-ehr-twice",
+      "title": "Create EHR — same EHR twice",
+      "capability": "EhrOperations",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
+      "duration_ms": 138
+    },
+    {
+      "ecc_id": "ECC-EHR-007",
+      "id": "ehr/create-ehr-two-ehrs-same-patient",
+      "title": "Create EHR — two EHRs same patient",
+      "capability": "EhrOperations",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "expected status 201, got 400 (body: {\"error\":\"Bad Request\",\"message\":\"JSON parse error: Could not resolve type id 'PARTY_IDENTIFIED' as a subtype of `com.nedap.archie.rm.generic.PartySelf`: Class `com.nedap.archie.rm.generic.PartyIdentified` not subtype of `com.nedap.archie.rm.generic.PartySelf`\"})",
+      "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-EHR-008",
+      "id": "ehr/get-ehr-existing-ehr-by-ehr-id",
+      "title": "Get EHR — existing EHR by EHR id",
+      "capability": "EhrOperations",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "returned EHR is not valid RM: missing field `ehr_access`",
+      "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
+      "duration_ms": 15
+    },
+    {
+      "ecc_id": "ECC-EHR-009",
+      "id": "ehr/get-ehr-existing-ehr-by-subject-id",
+      "title": "Get EHR — existing EHR by subject id",
+      "capability": "EhrOperations",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "expected status 201, got 400 (body: {\"error\":\"Bad Request\",\"message\":\"JSON parse error: Could not resolve type id 'PARTY_IDENTIFIED' as a subtype of `com.nedap.archie.rm.generic.PartySelf`: Class `com.nedap.archie.rm.generic.PartyIdentified` not subtype of `com.nedap.archie.rm.generic.PartySelf`\"})",
+      "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
+      "duration_ms": 8
+    },
+    {
+      "ecc_id": "ECC-EHR-010",
+      "id": "ehr/get-ehr-get-ehr-by-invalid-ehr-id",
+      "title": "Get EHR — get EHR by invalid EHR id",
+      "capability": "EhrOperations",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
+      "duration_ms": 6
+    },
+    {
+      "ecc_id": "ECC-EHR-011",
+      "id": "ehr/get-ehr-get-ehr-by-invalid-subject-id",
+      "title": "Get EHR — get EHR by invalid subject id",
+      "capability": "EhrOperations",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 EHR API §create_ehr/get_ehr; RM 1.2.0 ehr §EHR",
+      "duration_ms": 3
+    },
+    {
+      "ecc_id": "ECC-STA-001",
+      "id": "sta/get-ehr-status-get-by-ehr-id",
+      "title": "Get EHR_STATUS — get by EHR id",
+      "capability": "EhrStatus",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "returned EHR is not valid RM: missing field `ehr_access`",
+      "citation": "ITS-REST 1.0.3 EHR_STATUS API §get_ehr_status/update_ehr_status; RM 1.2.0 ehr §EHR_STATUS",
+      "duration_ms": 11
+    },
+    {
+      "ecc_id": "ECC-STA-002",
+      "id": "sta/get-ehr-status-bad-ehr",
+      "title": "Get EHR_STATUS — bad EHR",
+      "capability": "EhrStatus",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 EHR_STATUS API §get_ehr_status/update_ehr_status; RM 1.2.0 ehr §EHR_STATUS",
+      "duration_ms": 7
+    },
+    {
+      "ecc_id": "ECC-STA-003",
+      "id": "sta/set-ehr-queryable-existing-ehr",
+      "title": "Set EHR_STATUS is_queryable — existing EHR",
+      "capability": "EhrStatus",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "returned EHR is not valid RM: missing field `ehr_access`",
+      "citation": "ITS-REST 1.0.3 EHR_STATUS API §get_ehr_status/update_ehr_status; RM 1.2.0 ehr §EHR_STATUS",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-STA-004",
+      "id": "sta/set-ehr-queryable-bad-ehr",
+      "title": "Set EHR_STATUS is_queryable — bad EHR",
+      "capability": "EhrStatus",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 EHR_STATUS API §get_ehr_status/update_ehr_status; RM 1.2.0 ehr §EHR_STATUS",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-STA-005",
+      "id": "sta/set-ehr-modifiable-existing-ehr",
+      "title": "Set EHR_STATUS is_modifiable — existing EHR",
+      "capability": "EhrStatus",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "returned EHR is not valid RM: missing field `ehr_access`",
+      "citation": "ITS-REST 1.0.3 EHR_STATUS API §get_ehr_status/update_ehr_status; RM 1.2.0 ehr §EHR_STATUS",
+      "duration_ms": 15
+    },
+    {
+      "ecc_id": "ECC-STA-006",
+      "id": "sta/set-ehr-modifiable-bad-ehr",
+      "title": "Set EHR_STATUS is_modifiable — bad EHR",
+      "capability": "EhrStatus",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 EHR_STATUS API §get_ehr_status/update_ehr_status; RM 1.2.0 ehr §EHR_STATUS",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-STA-007",
+      "id": "sta/clear-ehr-queryable-existing-ehr",
+      "title": "Clear EHR_STATUS is_queryable — existing EHR",
+      "capability": "EhrStatus",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "returned EHR is not valid RM: missing field `ehr_access`",
+      "citation": "ITS-REST 1.0.3 EHR_STATUS API §get_ehr_status/update_ehr_status; RM 1.2.0 ehr §EHR_STATUS",
+      "duration_ms": 32
+    },
+    {
+      "ecc_id": "ECC-STA-008",
+      "id": "sta/clear-ehr-queryable-bad-ehr",
+      "title": "Clear EHR_STATUS is_queryable — bad EHR",
+      "capability": "EhrStatus",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 EHR_STATUS API §get_ehr_status/update_ehr_status; RM 1.2.0 ehr §EHR_STATUS",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-STA-009",
+      "id": "sta/clear-ehr-modifiable-existing-ehr",
+      "title": "Clear EHR_STATUS is_modifiable — existing EHR",
+      "capability": "EhrStatus",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "returned EHR is not valid RM: missing field `ehr_access`",
+      "citation": "ITS-REST 1.0.3 EHR_STATUS API §get_ehr_status/update_ehr_status; RM 1.2.0 ehr §EHR_STATUS",
+      "duration_ms": 11
+    },
+    {
+      "ecc_id": "ECC-STA-010",
+      "id": "sta/clear-ehr-modifiable-bad-ehr",
+      "title": "Clear EHR_STATUS is_modifiable — bad EHR",
+      "capability": "EhrStatus",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 EHR_STATUS API §get_ehr_status/update_ehr_status; RM 1.2.0 ehr §EHR_STATUS",
+      "duration_ms": 3
+    },
+    {
+      "ecc_id": "ECC-EHR-012",
+      "id": "ehr/create-ehr-invalid-status",
+      "title": "Create EHR — reject invalid EHR_STATUS data sets",
+      "capability": "EhrOperations",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "9/11 invalid EHR_STATUS data sets were rejected (the rest were accepted)",
+      "citation": "ITS-REST 1.0.3 EHR API §create_ehr (422); RM 1.2.0 ehr §EHR_STATUS validation",
+      "duration_ms": 154
+    },
+    {
+      "ecc_id": "ECC-EHR-013",
+      "id": "ehr/create-anonymous-ehr",
+      "title": "Create anonymous (subject-less) EHR",
+      "capability": "AnonymousEhrs",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "returned EHR is not valid RM: missing field `ehr_access`",
+      "citation": "CNF master03-profiles §Non-Functional (Anonymous EHRs — CORE+STANDARD); ITS-REST EHR API §create_ehr (no body); RM 1.2.0 ehr §EHR_STATUS",
+      "duration_ms": 17
+    },
+    {
+      "ecc_id": "ECC-COM-001",
+      "id": "com/create-composition-event",
+      "title": "Create composition — event",
+      "capability": "CompositionOps",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
+      "duration_ms": 35
+    },
+    {
+      "ecc_id": "ECC-COM-002",
+      "id": "com/create-composition-persistent",
+      "title": "Create composition — persistent",
+      "capability": "CompositionOps",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT minimal_persistent/persistent_minimal.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
+      "duration_ms": 19
+    },
+    {
+      "ecc_id": "ECC-COM-003",
+      "id": "com/create-composition-same-opt-twice",
+      "title": "Create composition — same OPT twice",
+      "capability": "CompositionOps",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT minimal_persistent/persistent_minimal.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
+      "duration_ms": 17
+    },
+    {
+      "ecc_id": "ECC-COM-004",
+      "id": "com/create-composition-invalid-event",
+      "title": "Create composition — invalid event",
+      "capability": "CompositionOps",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
+      "duration_ms": 17
+    },
+    {
+      "ecc_id": "ECC-COM-005",
+      "id": "com/create-composition-invalid-persistent",
+      "title": "Create composition — invalid persistent",
+      "capability": "CompositionOps",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT minimal_persistent/persistent_minimal.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
+      "duration_ms": 17
+    },
+    {
+      "ecc_id": "ECC-COM-006",
+      "id": "com/create-composition-event-bad-opt",
+      "title": "Create composition — event bad OPT",
+      "capability": "CompositionOps",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
+      "duration_ms": 63
+    },
+    {
+      "ecc_id": "ECC-COM-007",
+      "id": "com/create-composition-event-bad-ehr",
+      "title": "Create composition — event bad EHR",
+      "capability": "CompositionOps",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-COM-008",
+      "id": "com/get-composition-latest",
+      "title": "Get latest composition",
+      "capability": "CompositionOps",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
+      "duration_ms": 16
+    },
+    {
+      "ecc_id": "ECC-COM-009",
+      "id": "com/get-composition-latest-bad-composition",
+      "title": "Get latest composition — bad composition",
+      "capability": "CompositionOps",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
+      "duration_ms": 32
+    },
+    {
+      "ecc_id": "ECC-COM-010",
+      "id": "com/get-composition-latest-bad-ehr",
+      "title": "Get latest composition — bad EHR",
+      "capability": "CompositionOps",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
+      "duration_ms": 5
+    },
+    {
+      "ecc_id": "ECC-COM-011",
+      "id": "com/has-composition-bad-composition",
+      "title": "Composition existence check — bad composition",
+      "capability": "CompositionOps",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
+      "duration_ms": 20
+    },
+    {
+      "ecc_id": "ECC-COM-012",
+      "id": "com/has-composition-bad-ehr",
+      "title": "Composition existence check — bad EHR",
+      "capability": "CompositionOps",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-COM-013",
+      "id": "com/get-composition-at-time",
+      "title": "Get composition at time",
+      "capability": "CompositionOps",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-COM-014",
+      "id": "com/get-composition-at-time-no-time-arg",
+      "title": "Get composition at time — no time arg",
+      "capability": "CompositionOps",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
+      "duration_ms": 12
+    },
+    {
+      "ecc_id": "ECC-COM-015",
+      "id": "com/get-composition-at-time-bad-composition",
+      "title": "Get composition at time — bad composition",
+      "capability": "CompositionOps",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
+      "duration_ms": 36
+    },
+    {
+      "ecc_id": "ECC-COM-016",
+      "id": "com/get-composition-at-time-bad-ehr",
+      "title": "Get composition at time — bad EHR",
+      "capability": "CompositionOps",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
+      "duration_ms": 9
+    },
+    {
+      "ecc_id": "ECC-COM-017",
+      "id": "com/get-composition-at-times",
+      "title": "Get composition at multiple times",
+      "capability": "CompositionOps",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
+      "duration_ms": 17
+    },
+    {
+      "ecc_id": "ECC-COM-018",
+      "id": "com/get-composition-version",
+      "title": "Get composition version",
+      "capability": "CompositionOps",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
+      "duration_ms": 21
+    },
+    {
+      "ecc_id": "ECC-COM-019",
+      "id": "com/get-composition-version-bad-version",
+      "title": "Get composition version — bad version",
+      "capability": "CompositionOps",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
+      "duration_ms": 47
+    },
+    {
+      "ecc_id": "ECC-COM-020",
+      "id": "com/get-composition-version-bad-ehr",
+      "title": "Get composition version — bad EHR",
+      "capability": "CompositionOps",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
+      "duration_ms": 9
+    },
+    {
+      "ecc_id": "ECC-COM-021",
+      "id": "com/get-composition-versions",
+      "title": "Get composition versions",
+      "capability": "CompositionOps",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
+      "duration_ms": 17
+    },
+    {
+      "ecc_id": "ECC-COM-022",
+      "id": "com/get-versioned-composition",
+      "title": "Get versioned composition",
+      "capability": "Versioning",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST COMPOSITION API §get_versioned_composition; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT",
+      "duration_ms": 18
+    },
+    {
+      "ecc_id": "ECC-COM-023",
+      "id": "com/get-versioned-composition-non-existent",
+      "title": "Get versioned composition — non existent",
+      "capability": "Versioning",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST COMPOSITION API §get_versioned_composition (404); RM 1.2.0 common §VERSIONED_OBJECT",
+      "duration_ms": 20
+    },
+    {
+      "ecc_id": "ECC-COM-024",
+      "id": "com/get-versioned-composition-bad-ehr",
+      "title": "Get versioned composition — bad EHR",
+      "capability": "Versioning",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST COMPOSITION API §get_versioned_composition (404); RM 1.2.0 common §VERSIONED_OBJECT",
+      "duration_ms": 9
+    },
+    {
+      "ecc_id": "ECC-COM-025",
+      "id": "com/update-composition-event",
+      "title": "Update composition — event",
+      "capability": "CompositionOps",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
+      "duration_ms": 17
+    },
+    {
+      "ecc_id": "ECC-COM-026",
+      "id": "com/update-composition-persistent",
+      "title": "Update composition — persistent",
+      "capability": "CompositionOps",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT minimal_persistent/persistent_minimal.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
+      "duration_ms": 17
+    },
+    {
+      "ecc_id": "ECC-COM-027",
+      "id": "com/update-composition-non-existent",
+      "title": "Update composition — non existent",
+      "capability": "CompositionOps",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
+      "duration_ms": 14
+    },
+    {
+      "ecc_id": "ECC-COM-028",
+      "id": "com/update-composition-wrong-template",
+      "title": "Update composition — wrong template",
+      "capability": "CompositionOps",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-COM-029",
+      "id": "com/delete-composition-event",
+      "title": "Delete composition — event",
+      "capability": "CompositionOps",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
+      "duration_ms": 16
+    },
+    {
+      "ecc_id": "ECC-COM-030",
+      "id": "com/delete-composition-persistent",
+      "title": "Delete composition — persistent",
+      "capability": "CompositionOps",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT minimal_persistent/persistent_minimal.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
+      "duration_ms": 15
+    },
+    {
+      "ecc_id": "ECC-COM-031",
+      "id": "com/delete-composition-non-existent",
+      "title": "Delete composition — non existent",
+      "capability": "CompositionOps",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 COMPOSITION API §create/get/update/delete + versioned_composition; RM 1.2.0 ehr §COMPOSITION",
+      "duration_ms": 20
+    },
+    {
+      "ecc_id": "ECC-CTB-001",
+      "id": "ctb/commit-contribution-valid-composition",
+      "title": "Commit contribution — valid composition",
+      "capability": "ChangeSets",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT minimal/minimal_evaluation.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
+      "duration_ms": 7
+    },
+    {
+      "ecc_id": "ECC-CTB-002",
+      "id": "ctb/commit-contribution-invalid-composition",
+      "title": "Commit contribution — invalid composition",
+      "capability": "ChangeSets",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT minimal/minimal_evaluation.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-CTB-003",
+      "id": "ctb/commit-contribution-empty",
+      "title": "Commit contribution — empty",
+      "capability": "ChangeSets",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
+      "duration_ms": 80
+    },
+    {
+      "ecc_id": "ECC-CTB-004",
+      "id": "ctb/commit-contribution-valid-invalid-compositions",
+      "title": "Commit contribution — valid invalid compositions",
+      "capability": "ChangeSets",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT minimal/minimal_evaluation.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
+      "duration_ms": 5
+    },
+    {
+      "ecc_id": "ECC-CTB-005",
+      "id": "ctb/commit-contribution-non-exiting-opt",
+      "title": "Commit contribution — non exiting OPT",
+      "capability": "ChangeSets",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
+      "duration_ms": 20
+    },
+    {
+      "ecc_id": "ECC-CTB-006",
+      "id": "ctb/commit-contribution-event-composition",
+      "title": "Commit contribution — event composition",
+      "capability": "ChangeSets",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT minimal/minimal_admin.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-CTB-007",
+      "id": "ctb/commit-contribution-persistent-composition",
+      "title": "Commit contribution — persistent composition",
+      "capability": "ChangeSets",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT minimal_persistent/persistent_minimal.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
+      "duration_ms": 3
+    },
+    {
+      "ecc_id": "ECC-CTB-008",
+      "id": "ctb/commit-contribution-delete",
+      "title": "Commit contribution — delete",
+      "capability": "ChangeSets",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT minimal/minimal_admin.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
+      "duration_ms": 2
+    },
+    {
+      "ecc_id": "ECC-CTB-009",
+      "id": "ctb/commit-contribution-two-commits-second-invalid",
+      "title": "Commit contribution — two commits second invalid",
+      "capability": "ChangeSets",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT minimal/minimal_admin.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
+      "duration_ms": 2
+    },
+    {
+      "ecc_id": "ECC-CTB-010",
+      "id": "ctb/commit-contribution-two-commits-second-creation",
+      "title": "Commit contribution — two commits second creation",
+      "capability": "ChangeSets",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT minimal/minimal_admin.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
+      "duration_ms": 2
+    },
+    {
+      "ecc_id": "ECC-CTB-011",
+      "id": "ctb/commit-contribution-minimal-ehr-status",
+      "title": "Commit contribution — minimal EHR status",
+      "capability": "ChangeSets",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
+      "duration_ms": 109
+    },
+    {
+      "ecc_id": "ECC-CTB-012",
+      "id": "ctb/commit-contribution-full-ehr-status",
+      "title": "Commit contribution — full EHR status",
+      "capability": "ChangeSets",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
+      "duration_ms": 42
+    },
+    {
+      "ecc_id": "ECC-CTB-013",
+      "id": "ctb/commit-contribution-ehr-status-invalid-change-type",
+      "title": "Commit contribution — EHR status invalid change type",
+      "capability": "ChangeSets",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
+      "duration_ms": 22
+    },
+    {
+      "ecc_id": "ECC-CTB-014",
+      "id": "ctb/commit-contribution-invalid-ehr-status",
+      "title": "Commit contribution — invalid EHR status",
+      "capability": "ChangeSets",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
+      "duration_ms": 27
+    },
+    {
+      "ecc_id": "ECC-CTB-015",
+      "id": "ctb/commit-contribution-valid-directory",
+      "title": "Commit contribution — valid directory",
+      "capability": "ChangeSets",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
+      "duration_ms": 97
+    },
+    {
+      "ecc_id": "ECC-CTB-016",
+      "id": "ctb/commit-contribution-fail-create-existing-directory",
+      "title": "Commit contribution — fail create existing directory",
+      "capability": "ChangeSets",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
+      "duration_ms": 42
+    },
+    {
+      "ecc_id": "ECC-CTB-017",
+      "id": "ctb/commit-contribution-fail-modify-non-existing-directory",
+      "title": "Commit contribution — fail modify non existing directory",
+      "capability": "ChangeSets",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
+      "duration_ms": 27
+    },
+    {
+      "ecc_id": "ECC-CTB-018",
+      "id": "ctb/commit-contribution-update-existing-directory",
+      "title": "Commit contribution — update existing directory",
+      "capability": "ChangeSets",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
+      "duration_ms": 60
+    },
+    {
+      "ecc_id": "ECC-CTB-019",
+      "id": "ctb/get-contribution-existing",
+      "title": "Get contribution — existing",
+      "capability": "ChangeSets",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT minimal/minimal_admin.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
+      "duration_ms": 6
+    },
+    {
+      "ecc_id": "ECC-CTB-020",
+      "id": "ctb/get-contribution-empty-ehr",
+      "title": "Get contribution — empty EHR",
+      "capability": "ChangeSets",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
+      "duration_ms": 24
+    },
+    {
+      "ecc_id": "ECC-CTB-021",
+      "id": "ctb/get-contribution-bad-ehr",
+      "title": "Get contribution — bad EHR",
+      "capability": "ChangeSets",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
+      "duration_ms": 8
+    },
+    {
+      "ecc_id": "ECC-CTB-022",
+      "id": "ctb/get-contribution-bad-contribution",
+      "title": "Get contribution — bad contribution",
+      "capability": "ChangeSets",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT minimal/minimal_admin.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
+      "duration_ms": 10
+    },
+    {
+      "ecc_id": "ECC-CTB-023",
+      "id": "ctb/has-contribution-existing",
+      "title": "Contribution existence check — existing",
+      "capability": "ChangeSets",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT minimal/minimal_admin.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
+      "duration_ms": 5
+    },
+    {
+      "ecc_id": "ECC-CTB-024",
+      "id": "ctb/has-contribution-bad-contribution",
+      "title": "Contribution existence check — bad contribution",
+      "capability": "ChangeSets",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT minimal/minimal_admin.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
+      "duration_ms": 7
+    },
+    {
+      "ecc_id": "ECC-CTB-025",
+      "id": "ctb/has-contribution-bad-ehr",
+      "title": "Contribution existence check — bad EHR",
+      "capability": "ChangeSets",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
+      "duration_ms": 5
+    },
+    {
+      "ecc_id": "ECC-CTB-026",
+      "id": "ctb/has-contribution-empty-ehr",
+      "title": "Contribution existence check — empty EHR",
+      "capability": "ChangeSets",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 CONTRIBUTION API §commit_contribution/get_contribution; RM 1.2.0 common §CONTRIBUTION",
+      "duration_ms": 12
+    },
+    {
+      "ecc_id": "ECC-CTB-027",
+      "id": "ctb/list-contributions-empty",
+      "title": "List contributions — empty",
+      "capability": "ChangeSets",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "skipped",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "SM I_EHR_CONTRIBUTION.list_contributions() (CNF master08:595) has no ITS-REST binding — ITS-REST development@e8a093e (and Release-1.0.3) define POST only on /ehr/{ehr_id}/contribution, with no GET collection resource; the list is a native-API concern, not wire-exercisable",
+      "citation": "SM I_EHR_CONTRIBUTION.list_contributions (CNF master08:595) — no ITS-REST binding (POST-only on /ehr/{ehr_id}/contribution); skipped, see module docs",
+      "schedule_ref": "I_EHR_CONTRIBUTION.list_contributions (CNF master08:595)",
+      "duration_ms": 0
+    },
+    {
+      "ecc_id": "ECC-CTB-028",
+      "id": "ctb/list-contributions-non-existing-ehr",
+      "title": "List contributions — non existing EHR",
+      "capability": "ChangeSets",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "skipped",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "SM I_EHR_CONTRIBUTION.list_contributions() (CNF master08:595) has no ITS-REST binding — ITS-REST development@e8a093e (and Release-1.0.3) define POST only on /ehr/{ehr_id}/contribution, with no GET collection resource; the list is a native-API concern, not wire-exercisable",
+      "citation": "SM I_EHR_CONTRIBUTION.list_contributions (CNF master08:595) — no ITS-REST binding (POST-only on /ehr/{ehr_id}/contribution); skipped, see module docs",
+      "schedule_ref": "I_EHR_CONTRIBUTION.list_contributions (CNF master08:595)",
+      "duration_ms": 0
+    },
+    {
+      "ecc_id": "ECC-CTB-029",
+      "id": "ctb/list-contributions-post-commit",
+      "title": "List contributions — post commit",
+      "capability": "ChangeSets",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "skipped",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "SM I_EHR_CONTRIBUTION.list_contributions() (CNF master08:595) has no ITS-REST binding — ITS-REST development@e8a093e (and Release-1.0.3) define POST only on /ehr/{ehr_id}/contribution, with no GET collection resource; the list is a native-API concern, not wire-exercisable",
+      "citation": "SM I_EHR_CONTRIBUTION.list_contributions (CNF master08:595) — no ITS-REST binding (POST-only on /ehr/{ehr_id}/contribution); skipped, see module docs",
+      "schedule_ref": "I_EHR_CONTRIBUTION.list_contributions (CNF master08:595)",
+      "duration_ms": 0
+    },
+    {
+      "ecc_id": "ECC-CTB-030",
+      "id": "ctb/list-contributions-ehr-containing-directory",
+      "title": "List contributions — EHR containing directory",
+      "capability": "ChangeSets",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "skipped",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "SM I_EHR_CONTRIBUTION.list_contributions() (CNF master08:595) has no ITS-REST binding — ITS-REST development@e8a093e (and Release-1.0.3) define POST only on /ehr/{ehr_id}/contribution, with no GET collection resource; the list is a native-API concern, not wire-exercisable",
+      "citation": "SM I_EHR_CONTRIBUTION.list_contributions (CNF master08:595) — no ITS-REST binding (POST-only on /ehr/{ehr_id}/contribution); skipped, see module docs",
+      "schedule_ref": "I_EHR_CONTRIBUTION.list_contributions (CNF master08:595)",
+      "duration_ms": 0
+    },
+    {
+      "ecc_id": "ECC-CTB-031",
+      "id": "ctb/list-contributions-ehr-containing-ehr-status",
+      "title": "List contributions — EHR containing EHR status",
+      "capability": "ChangeSets",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "skipped",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "SM I_EHR_CONTRIBUTION.list_contributions() (CNF master08:595) has no ITS-REST binding — ITS-REST development@e8a093e (and Release-1.0.3) define POST only on /ehr/{ehr_id}/contribution, with no GET collection resource; the list is a native-API concern, not wire-exercisable",
+      "citation": "SM I_EHR_CONTRIBUTION.list_contributions (CNF master08:595) — no ITS-REST binding (POST-only on /ehr/{ehr_id}/contribution); skipped, see module docs",
+      "schedule_ref": "I_EHR_CONTRIBUTION.list_contributions (CNF master08:595)",
+      "duration_ms": 0
+    },
+    {
+      "ecc_id": "ECC-DIR-001",
+      "id": "dir/create-directory-empty-ehr",
+      "title": "Create directory — empty EHR",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 33
+    },
+    {
+      "ecc_id": "ECC-DIR-002",
+      "id": "dir/create-directory-ehr-with-directory",
+      "title": "Create directory — EHR with directory",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 30
+    },
+    {
+      "ecc_id": "ECC-DIR-003",
+      "id": "dir/create-directory-bad-ehr",
+      "title": "Create directory — bad EHR",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-DIR-004",
+      "id": "dir/get-directory-ehr-root-directory",
+      "title": "Get directory — EHR root directory",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 33
+    },
+    {
+      "ecc_id": "ECC-DIR-005",
+      "id": "dir/get-directory-bad-ehr",
+      "title": "Get directory — bad EHR",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 5
+    },
+    {
+      "ecc_id": "ECC-DIR-006",
+      "id": "dir/get-directory-at-time-ehr-with-directory",
+      "title": "Get directory at time — EHR with directory",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 58
+    },
+    {
+      "ecc_id": "ECC-DIR-007",
+      "id": "dir/get-directory-at-time-bad-ehr",
+      "title": "Get directory at time — bad EHR",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 36
+    },
+    {
+      "ecc_id": "ECC-DIR-008",
+      "id": "dir/update-directory-ehr-with-directory",
+      "title": "Update directory — EHR with directory",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 133
+    },
+    {
+      "ecc_id": "ECC-DIR-009",
+      "id": "dir/update-directory-bad-ehr",
+      "title": "Update directory — bad EHR",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 22
+    },
+    {
+      "ecc_id": "ECC-DIR-010",
+      "id": "dir/delete-directory-ehr-with-directory",
+      "title": "Delete directory — EHR with directory",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 155
+    },
+    {
+      "ecc_id": "ECC-DIR-011",
+      "id": "dir/delete-directory-bad-ehr",
+      "title": "Delete directory — bad EHR",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 31
+    },
+    {
+      "ecc_id": "ECC-DIR-012",
+      "id": "dir/has-directory-empty-ehr",
+      "title": "Directory existence check — empty EHR",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 50
+    },
+    {
+      "ecc_id": "ECC-DIR-013",
+      "id": "dir/has-directory-ehr-with-directory",
+      "title": "Directory existence check — EHR with directory",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 56
+    },
+    {
+      "ecc_id": "ECC-DIR-014",
+      "id": "dir/has-directory-bad-ehr",
+      "title": "Directory existence check — bad EHR",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 10
+    },
+    {
+      "ecc_id": "ECC-DIR-015",
+      "id": "dir/has-path-ehr-root-directory",
+      "title": "Directory path existence check — EHR root directory",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 54
+    },
+    {
+      "ecc_id": "ECC-DIR-016",
+      "id": "dir/has-path-folder-structure",
+      "title": "Directory path existence check — folder structure",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 135
+    },
+    {
+      "ecc_id": "ECC-DIR-017",
+      "id": "dir/has-path-empty-ehr",
+      "title": "Directory path existence check — empty EHR",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 53
+    },
+    {
+      "ecc_id": "ECC-DIR-018",
+      "id": "dir/has-path-bad-ehr",
+      "title": "Directory path existence check — bad EHR",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 15
+    },
+    {
+      "ecc_id": "ECC-DIR-019",
+      "id": "dir/has-directory-version-empty-ehr",
+      "title": "Directory version existence check — empty EHR",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 30
+    },
+    {
+      "ecc_id": "ECC-DIR-020",
+      "id": "dir/has-directory-version-directory-with-two-versions",
+      "title": "Directory version existence check — directory with two versions",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 123
+    },
+    {
+      "ecc_id": "ECC-DIR-021",
+      "id": "dir/has-directory-version-bad-ehr",
+      "title": "Directory version existence check — bad EHR",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 5
+    },
+    {
+      "ecc_id": "ECC-DIR-022",
+      "id": "dir/get-directory-empty-ehr",
+      "title": "Get directory — empty EHR",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 26
+    },
+    {
+      "ecc_id": "ECC-DIR-023",
+      "id": "dir/get-directory-directory-with-structure",
+      "title": "Get directory — directory with structure",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 72
+    },
+    {
+      "ecc_id": "ECC-DIR-024",
+      "id": "dir/get-directory-at-time-ehr-with-directory-empty-time",
+      "title": "Get directory at time — EHR with directory empty time",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 67
+    },
+    {
+      "ecc_id": "ECC-DIR-025",
+      "id": "dir/get-directory-at-time-ehr-with-directory-versions",
+      "title": "Get directory at time — EHR with directory versions",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 46
+    },
+    {
+      "ecc_id": "ECC-DIR-026",
+      "id": "dir/get-directory-at-time-ehr-with-directory-versions-empty-time",
+      "title": "Get directory at time — EHR with directory versions empty time",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 48
+    },
+    {
+      "ecc_id": "ECC-DIR-027",
+      "id": "dir/get-directory-at-time-empty-ehr",
+      "title": "Get directory at time — empty EHR",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 12
+    },
+    {
+      "ecc_id": "ECC-DIR-028",
+      "id": "dir/get-directory-at-time-empty-ehr-empty-time",
+      "title": "Get directory at time — empty EHR empty time",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-DIR-029",
+      "id": "dir/get-directory-at-time-multiple-versions-first",
+      "title": "Get directory at time — multiple versions first",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 46
+    },
+    {
+      "ecc_id": "ECC-DIR-030",
+      "id": "dir/get-directory-at-version-bad-ehr",
+      "title": "Get directory at version — bad EHR",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 3
+    },
+    {
+      "ecc_id": "ECC-DIR-031",
+      "id": "dir/get-directory-at-version-directory-with-two-versions",
+      "title": "Get directory at version — directory with two versions",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 45
+    },
+    {
+      "ecc_id": "ECC-DIR-032",
+      "id": "dir/get-directory-at-version-empty-ehr",
+      "title": "Get directory at version — empty EHR",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 11
+    },
+    {
+      "ecc_id": "ECC-DIR-033",
+      "id": "dir/get-versioned-directory-empty-ehr",
+      "title": "Get versioned directory — empty EHR",
+      "capability": "Versioning",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "CNF Robot I_EHR_DIRECTORY.get_versioned_directory-empty_ehr realized as GET /ehr/{ehr_id}/directory/{version_uid} (no versioned_directory resource in ITS-REST development@e8a093e/Release-1.0.3); RM 1.2.0 ehr §FOLDER, common §VERSIONED_OBJECT",
+      "schedule_ref": "I_EHR_DIRECTORY.get_versioned_directory (CNF master09:670)",
+      "duration_ms": 14
+    },
+    {
+      "ecc_id": "ECC-DIR-034",
+      "id": "dir/get-versioned-directory-directory-with-two-versions",
+      "title": "Get versioned directory — directory with two versions",
+      "capability": "Versioning",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "CNF Robot I_EHR_DIRECTORY.get_versioned_directory-directory_with_two_versions realized as GET /ehr/{ehr_id}/directory/{version_uid}; RM 1.2.0 ehr §FOLDER, common §VERSIONED_OBJECT",
+      "schedule_ref": "I_EHR_DIRECTORY.get_versioned_directory (CNF master09:670)",
+      "duration_ms": 50
+    },
+    {
+      "ecc_id": "ECC-DIR-035",
+      "id": "dir/get-versioned-directory-bad-ehr",
+      "title": "Get versioned directory — bad EHR",
+      "capability": "Versioning",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "CNF Robot I_EHR_DIRECTORY.get_versioned_directory-bad_ehr realized as GET /ehr/{ehr_id}/directory/{version_uid}; RM 1.2.0 ehr §FOLDER, common §VERSIONED_OBJECT",
+      "schedule_ref": "I_EHR_DIRECTORY.get_versioned_directory (CNF master09:670)",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-DIR-036",
+      "id": "dir/update-directory-empty-ehr",
+      "title": "Update directory — empty EHR",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 25
+    },
+    {
+      "ecc_id": "ECC-DIR-037",
+      "id": "dir/delete-directory-empty-ehr",
+      "title": "Delete directory — empty EHR",
+      "capability": "DirectoryOps",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DIRECTORY API §create/get/update/delete directory; RM 1.2.0 ehr §FOLDER",
+      "duration_ms": 43
+    },
+    {
+      "ecc_id": "ECC-TPL-001",
+      "id": "tpl/upload-opt-valid-opt",
+      "title": "Upload OPT — valid OPT (provisions ADL 1.4 archetypes)",
+      "capability": "Adl14ArchetypeProvisioning",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "fresh valid OPT rejected with 406",
+      "citation": "ITS-REST DEFINITION ADL 1.4 API §upload OPT; AM 1.4 §OPERATIONAL_TEMPLATE; CORE Adl14ArchetypeProvisioning evidenced via OPT (archetypes embedded in the OPT)",
+      "duration_ms": 5
+    },
+    {
+      "ecc_id": "ECC-TPL-002",
+      "id": "tpl/upload-opt-invalid-opt",
+      "title": "Upload OPT — invalid OPT",
+      "capability": "Adl14OptProvisioning",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 18,
+      "total_data_sets": 18,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
+      "duration_ms": 93
+    },
+    {
+      "ecc_id": "ECC-TPL-003",
+      "id": "tpl/get-opts-retrieve-all-no-opts",
+      "title": "List OPTs — retrieve all no OPTs",
+      "capability": "Adl14OptProvisioning",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
+      "duration_ms": 20
+    },
+    {
+      "ecc_id": "ECC-TPL-004",
+      "id": "tpl/upload-opt-valid-opt-twice-conflict",
+      "title": "Upload OPT — valid OPT twice conflict",
+      "capability": "Adl14OptProvisioning",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "provisioning minimal_evaluation.opt returned 406",
+      "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
+      "duration_ms": 3
+    },
+    {
+      "ecc_id": "ECC-TPL-005",
+      "id": "tpl/upload-opt-valid-opt-twice-no-conflict",
+      "title": "Upload OPT — valid OPT twice no conflict",
+      "capability": "Adl14OptProvisioning",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "provisioning minimal_evaluation.opt returned 406",
+      "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
+      "duration_ms": 8
+    },
+    {
+      "ecc_id": "ECC-TPL-006",
+      "id": "tpl/get-opt-retrieve-single",
+      "title": "Get OPT — retrieve single",
+      "capability": "Adl14OptProvisioning",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "provisioning minimal_evaluation.opt returned 406",
+      "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
+      "duration_ms": 2
+    },
+    {
+      "ecc_id": "ECC-TPL-007",
+      "id": "tpl/get-opt-retrieve-latest-version",
+      "title": "Get OPT — retrieve latest version",
+      "capability": "Adl14OptProvisioning",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "provisioning minimal_evaluation.opt returned 406",
+      "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
+      "duration_ms": 3
+    },
+    {
+      "ecc_id": "ECC-TPL-008",
+      "id": "tpl/get-opt-retrieve-specific-version",
+      "title": "Get OPT — retrieve specific version",
+      "capability": "Adl14OptProvisioning",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "provisioning minimal_evaluation.opt returned 406",
+      "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-TPL-009",
+      "id": "tpl/get-opt-retrieve-fail",
+      "title": "Get OPT — retrieve fail",
+      "capability": "Adl14OptProvisioning",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
+      "duration_ms": 42
+    },
+    {
+      "ecc_id": "ECC-TPL-010",
+      "id": "tpl/get-opts-retrieve-all",
+      "title": "List OPTs — retrieve all",
+      "capability": "Adl14OptProvisioning",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "provisioning minimal_evaluation.opt returned 406",
+      "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
+      "duration_ms": 3
+    },
+    {
+      "ecc_id": "ECC-TPL-011",
+      "id": "tpl/validate-opt-valid-opt",
+      "title": "Validate OPT — valid OPT",
+      "capability": "Adl14OptProvisioning",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "valid OPT not accepted: 406",
+      "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
+      "duration_ms": 6
+    },
+    {
+      "ecc_id": "ECC-TPL-012",
+      "id": "tpl/validate-opt-invalid-opt",
+      "title": "Validate OPT — invalid OPT",
+      "capability": "Adl14OptProvisioning",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DEFINITION ADL 1.4 API §upload/get/validate/delete OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
+      "duration_ms": 5
+    },
+    {
+      "ecc_id": "ECC-TPL-013",
+      "id": "tpl/delete-opt-delete-non-existing",
+      "title": "Delete OPT — delete non existing",
+      "capability": "Adl14OptProvisioning",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "skipped",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "SM I_DEFINITION_ADL14.delete_opt() (CNF master04:319) has no ITS-REST ADL 1.4 binding — ITS-REST development@e8a093e (and Release-1.0.3) define no DELETE verb on /definition/template/adl1.4/{id}; OPT deletion lives in the ADMIN API only",
+      "citation": "SM I_DEFINITION_ADL14.delete_opt() (CNF master04:319) — no ITS-REST ADL 1.4 binding (no DELETE on /definition/template/adl1.4/{id}; deletion is ADMIN-API-only); skipped, see module docs",
+      "schedule_ref": "I_DEFINITION_ADL14.delete_opt (CNF master04:319)",
+      "duration_ms": 0
+    },
+    {
+      "ecc_id": "ECC-TPL-014",
+      "id": "tpl/delete-opt-delete-existing",
+      "title": "Delete OPT — delete existing",
+      "capability": "Adl14OptProvisioning",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "skipped",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "SM I_DEFINITION_ADL14.delete_opt() (CNF master04:319) has no ITS-REST ADL 1.4 binding — ITS-REST development@e8a093e (and Release-1.0.3) define no DELETE verb on /definition/template/adl1.4/{id}; OPT deletion lives in the ADMIN API only",
+      "citation": "SM I_DEFINITION_ADL14.delete_opt() (CNF master04:319) — no ITS-REST ADL 1.4 binding (no DELETE on /definition/template/adl1.4/{id}; deletion is ADMIN-API-only); skipped, see module docs",
+      "schedule_ref": "I_DEFINITION_ADL14.delete_opt (CNF master04:319)",
+      "duration_ms": 0
+    },
+    {
+      "ecc_id": "ECC-TPL-015",
+      "id": "tpl/delete-opt-delete-latest-version",
+      "title": "Delete OPT — delete latest version",
+      "capability": "Adl14OptProvisioning",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "skipped",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "SM I_DEFINITION_ADL14.delete_opt() (CNF master04:319) has no ITS-REST ADL 1.4 binding — ITS-REST development@e8a093e (and Release-1.0.3) define no DELETE verb on /definition/template/adl1.4/{id}; OPT deletion lives in the ADMIN API only",
+      "citation": "SM I_DEFINITION_ADL14.delete_opt() (CNF master04:319) — no ITS-REST ADL 1.4 binding (no DELETE on /definition/template/adl1.4/{id}; deletion is ADMIN-API-only); skipped, see module docs",
+      "schedule_ref": "I_DEFINITION_ADL14.delete_opt (CNF master04:319)",
+      "duration_ms": 0
+    },
+    {
+      "ecc_id": "ECC-TPL-016",
+      "id": "tpl/delete-opt-delete-specific-version",
+      "title": "Delete OPT — delete specific version",
+      "capability": "Adl14OptProvisioning",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "skipped",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "SM I_DEFINITION_ADL14.delete_opt() (CNF master04:319) has no ITS-REST ADL 1.4 binding — ITS-REST development@e8a093e (and Release-1.0.3) define no DELETE verb on /definition/template/adl1.4/{id}; OPT deletion lives in the ADMIN API only",
+      "citation": "SM I_DEFINITION_ADL14.delete_opt() (CNF master04:319) — no ITS-REST ADL 1.4 binding (no DELETE on /definition/template/adl1.4/{id}; deletion is ADMIN-API-only); skipped, see module docs",
+      "schedule_ref": "I_DEFINITION_ADL14.delete_opt (CNF master04:319)",
+      "duration_ms": 0
+    },
+    {
+      "ecc_id": "ECC-SQR-001",
+      "id": "sqr/valid-query-valid",
+      "title": "Store stored query — valid",
+      "capability": "QueryProvisioning",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DEFINITION QUERY API §store/list stored query; AQL 1.1",
+      "duration_ms": 45
+    },
+    {
+      "ecc_id": "ECC-SQR-002",
+      "id": "sqr/list-queries-non-empty",
+      "title": "List stored queries — non empty",
+      "capability": "QueryProvisioning",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DEFINITION QUERY API §store/list stored query; AQL 1.1",
+      "duration_ms": 31
+    },
+    {
+      "ecc_id": "ECC-SQR-003",
+      "id": "sqr/has-query-xxx",
+      "title": "Stored query existence check — xxx",
+      "capability": "QueryProvisioning",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DEFINITION QUERY API §store/list stored query; AQL 1.1",
+      "duration_ms": 15
+    },
+    {
+      "ecc_id": "ECC-SQR-004",
+      "id": "sqr/list-queries-empty",
+      "title": "List stored queries — empty",
+      "capability": "QueryProvisioning",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "skipped",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "SM I_DEFINITION_QUERY.list_queries() (CNF master05:93) has no ITS-REST binding — ITS-REST development@e8a093e (and Release-1.0.3) expose GET /definition/query/{qualified_query_name}, not a bare GET /definition/query collection",
+      "citation": "SM I_DEFINITION_QUERY.list_queries (CNF master05:93) — no ITS-REST binding (list resource is GET /definition/query/{qualified_query_name}); skipped, see module docs",
+      "schedule_ref": "I_DEFINITION_QUERY.list_queries (CNF master05:93)",
+      "duration_ms": 0
+    },
+    {
+      "ecc_id": "ECC-SQR-005",
+      "id": "sqr/list-queries-select-items",
+      "title": "List stored queries — select items",
+      "capability": "QueryProvisioning",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "skipped",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "SM I_DEFINITION_QUERY.list_queries() (CNF master05:93) has no ITS-REST binding — ITS-REST development@e8a093e (and Release-1.0.3) expose GET /definition/query/{qualified_query_name}, not a bare GET /definition/query collection",
+      "citation": "SM I_DEFINITION_QUERY.list_queries (CNF master05:93) — no ITS-REST binding (list resource is GET /definition/query/{qualified_query_name}); skipped, see module docs",
+      "schedule_ref": "I_DEFINITION_QUERY.list_queries (CNF master05:93)",
+      "duration_ms": 0
+    },
+    {
+      "ecc_id": "ECC-SQR-006",
+      "id": "sqr/valid-query-bad-formalism",
+      "title": "Store stored query — bad formalism",
+      "capability": "QueryProvisioning",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DEFINITION QUERY API §store/list stored query; AQL 1.1",
+      "duration_ms": 10
+    },
+    {
+      "ecc_id": "ECC-SQR-007",
+      "id": "sqr/valid-query-invalid",
+      "title": "Store stored query — invalid",
+      "capability": "QueryProvisioning",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DEFINITION QUERY API §store/list stored query; AQL 1.1",
+      "duration_ms": 8
+    },
+    {
+      "ecc_id": "ECC-QRY-001",
+      "id": "qry/smoke-test",
+      "title": "Query service smoke test",
+      "capability": "AqlBasic",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query/execute_stored_query; AQL 1.1",
+      "duration_ms": 153
+    },
+    {
+      "ecc_id": "ECC-QRY-002",
+      "id": "qry/execute-ad-hoc-query-empty-db",
+      "title": "Execute ad-hoc AQL query — empty db",
+      "capability": "AqlBasic",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "adhoc empty_db golden mismatch (suppressed via [meta_envelope_ignored,query_echo_ignored]): columns differ: golden=[{\"name\":\"#0\",\"path\":\"/ehr_id/value\"}], served=[{\"path\":\"e/ehr_id/value\",\"name\":\"#0\"}]",
+      "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query/execute_stored_query; AQL 1.1",
+      "duration_ms": 35
+    },
+    {
+      "ecc_id": "ECC-QRY-003",
+      "id": "qry/execute-stored-query-empty-db",
+      "title": "Execute stored AQL query — empty db",
+      "capability": "AqlBasic",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "stored empty_db golden mismatch (suppressed via [meta_envelope_ignored,query_echo_ignored]): columns differ: golden=[{\"name\":\"#0\",\"path\":\"/ehr_id/value\"}], served=[{\"path\":\"e/ehr_id/value\",\"name\":\"#0\"}]",
+      "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query/execute_stored_query; AQL 1.1",
+      "duration_ms": 61
+    },
+    {
+      "ecc_id": "ECC-QRY-004",
+      "id": "qry/execute-ad-hoc-query-loaded-db",
+      "title": "Execute ad-hoc AQL query — loaded db",
+      "capability": "AqlBasic",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query/execute_stored_query; AQL 1.1",
+      "duration_ms": 14
+    },
+    {
+      "ecc_id": "ECC-QRY-005",
+      "id": "qry/corpus-invalid",
+      "title": "AQL corpus — invalid queries rejected",
+      "capability": "AqlBasic",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 2,
+      "total_data_sets": 2,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query; AQL 1.1; reference: CNF query corpus (design-time reading)",
+      "duration_ms": 17
+    },
+    {
+      "ecc_id": "ECC-QRY-006",
+      "id": "qry/corpus-a-empty-db",
+      "title": "AQL corpus — A empty db",
+      "capability": "AqlBasic",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "1/25 A/empty_db goldens matched (2 skipped); first divergence: A/100_get_ehrs.json (ColumnsOnly, suppressed via [meta_envelope_ignored,query_echo_ignored]): columns differ: golden=[{\"name\":\"#0\",\"path\":\"/ehr_id/value\"}], served=[{\"path\":\"e/ehr_id/value\",\"name\":\"#0\"}]",
+      "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query; AQL 1.1; reference: CNF query corpus (design-time reading)",
+      "duration_ms": 257
+    },
+    {
+      "ecc_id": "ECC-QRY-007",
+      "id": "qry/corpus-b-empty-db",
+      "title": "AQL corpus — B empty db",
+      "capability": "AqlBasic",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "1/18 B/empty_db goldens matched (3 skipped); first divergence: B/100_get_compositions_from_all_ehrs.json (ColumnsOnly, suppressed via [meta_envelope_ignored,query_echo_ignored]): columns differ: golden=[{\"name\":\"#0\",\"path\":\"/\"}], served=[{\"path\":\"c\",\"name\":\"#0\"}]",
+      "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query; AQL 1.1; reference: CNF query corpus (design-time reading)",
+      "duration_ms": 173
+    },
+    {
+      "ecc_id": "ECC-QRY-008",
+      "id": "qry/corpus-c-empty-db",
+      "title": "AQL corpus — C empty db",
+      "capability": "AqlBasic",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "1/11 C/empty_db goldens matched (0 skipped); first divergence: C/100_get_entries_empty_db.json (Full, suppressed via [meta_envelope_ignored,query_echo_ignored]): columns differ: golden=[{\"name\":\"#0\",\"path\":\"/\"}], served=[{\"path\":\"entry\",\"name\":\"#0\"}]",
+      "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query; AQL 1.1; reference: CNF query corpus (design-time reading)",
+      "duration_ms": 92
+    },
+    {
+      "ecc_id": "ECC-QRY-009",
+      "id": "qry/corpus-d-empty-db",
+      "title": "AQL corpus — D empty db",
+      "capability": "AqlBasic",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "0/16 D/empty_db goldens matched (10 skipped); first divergence: D/200_select_data_values_from_all_ehrs_contains_composition.json (ColumnsOnly, suppressed via [meta_envelope_ignored,query_echo_ignored]): columns differ: golden=[{\"name\":\"#0\",\"path\":\"/ehr_id/value\"},{\"name\":\"#1\",\"path\":\"/time_created/value\"},{\"name\":\"#2\",\"path\":\"/system_id/value\"}], served=[{\"path\":\"e/ehr_id/value\",\"name\":\"#0\"},{\"path\":\"e/time_created/value\",\"name\":\"#1\"},{\"path\":\"e/system_id/value\",\"name\":\"#2\"}]",
+      "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query; AQL 1.1; reference: CNF query corpus (design-time reading)",
+      "duration_ms": 133
+    },
+    {
+      "ecc_id": "ECC-QRY-010",
+      "id": "qry/corpus-a-loaded-db",
+      "title": "AQL corpus — A loaded db",
+      "capability": "AqlBasic",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "1/21 A/loaded_db goldens matched (6 skipped); first divergence: A/100_get_ehrs.json (ColumnsOnly, suppressed via [meta_envelope_ignored,query_echo_ignored]): columns differ: golden=[{\"name\":\"#0\",\"path\":\"/ehr_id/value\"}], served=[{\"path\":\"e/ehr_id/value\",\"name\":\"#0\"}]",
+      "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query; AQL 1.1; reference: CNF query corpus (design-time reading)",
+      "duration_ms": 97
+    },
+    {
+      "ecc_id": "ECC-QRY-011",
+      "id": "qry/corpus-b-loaded-db",
+      "title": "AQL corpus — B loaded db",
+      "capability": "AqlBasic",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "1/15 B/loaded_db goldens matched (9 skipped); first divergence: B/100_get_compositions_from_all_ehrs.json (ColumnsOnly, suppressed via [meta_envelope_ignored,query_echo_ignored]): columns differ: golden=[{\"name\":\"#0\",\"path\":\"/\"}], served=[{\"path\":\"c\",\"name\":\"#0\"}]",
+      "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query; AQL 1.1; reference: CNF query corpus (design-time reading)",
+      "duration_ms": 73
+    },
+    {
+      "ecc_id": "ECC-QRY-012",
+      "id": "qry/corpus-c-loaded-db",
+      "title": "AQL corpus — C loaded db",
+      "capability": "AqlBasic",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query; AQL 1.1; reference: CNF query corpus (design-time reading)",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-QRY-013",
+      "id": "qry/corpus-d-loaded-db",
+      "title": "AQL corpus — D loaded db",
+      "capability": "AqlBasic",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "0/7 D/loaded_db goldens matched (19 skipped); first divergence: D/200_select_data_values_from_all_ehrs_contains_composition.json (ColumnsOnly, suppressed via [meta_envelope_ignored,query_echo_ignored]): columns differ: golden=[{\"name\":\"#0\",\"path\":\"/ehr_id/value\"},{\"name\":\"#1\",\"path\":\"/time_created/value\"},{\"name\":\"#2\",\"path\":\"/system_id/value\"}], served=[{\"path\":\"e/ehr_id/value\",\"name\":\"#0\"},{\"path\":\"e/time_created/value\",\"name\":\"#1\"},{\"path\":\"e/system_id/value\",\"name\":\"#2\"}]",
+      "citation": "ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query; AQL 1.1; reference: CNF query corpus (design-time reading)",
+      "duration_ms": 34
+    },
+    {
+      "ecc_id": "ECC-ADM-001",
+      "id": "adm/ehr-delete",
+      "title": "Admin EHR delete",
+      "capability": "AdminApi",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 ADMIN API §delete EHR; SM §I_ADMIN_SERVICE.physical_ehr_delete",
+      "duration_ms": 16
+    },
+    {
+      "ecc_id": "ECC-ADM-002",
+      "id": "adm/ehr-delete-absent",
+      "title": "Admin EHR delete absent",
+      "capability": "AdminApi",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 ADMIN API §delete EHR; SM §I_ADMIN_SERVICE.physical_ehr_delete",
+      "duration_ms": 2
+    },
+    {
+      "ecc_id": "ECC-ADM-003",
+      "id": "adm/ehr-delete-idempotent",
+      "title": "Admin EHR delete idempotent",
+      "capability": "AdminApi",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 ADMIN API §delete EHR; SM §I_ADMIN_SERVICE.physical_ehr_delete",
+      "duration_ms": 14
+    },
+    {
+      "ecc_id": "ECC-ADM-004",
+      "id": "adm/ehr-delete-all",
+      "title": "Admin EHR delete all",
+      "capability": "AdminApi",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "expected status 200, got 400 (body: {\"error\":\"Bad Request\",\"message\":\"Invalid UUID string: all\"})",
+      "citation": "ITS-REST 1.0.3 ADMIN API §delete EHR; SM §I_ADMIN_SERVICE.physical_ehr_delete",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-ADM-005",
+      "id": "adm/ehr-delete-all-partial",
+      "title": "Admin EHR delete all partial",
+      "capability": "AdminApi",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "expected status 200, got 400 (body: {\"error\":\"Bad Request\",\"message\":\"Invalid UUID string: all\"})",
+      "citation": "ITS-REST 1.0.3 ADMIN API §delete EHR; SM §I_ADMIN_SERVICE.physical_ehr_delete",
+      "duration_ms": 7
+    },
+    {
+      "ecc_id": "ECC-ADM-006",
+      "id": "adm/ehr-delete-all-empty",
+      "title": "Admin EHR delete all empty",
+      "capability": "AdminApi",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 ADMIN API §delete EHR; SM §I_ADMIN_SERVICE.physical_ehr_delete",
+      "duration_ms": 2
+    },
+    {
+      "ecc_id": "ECC-DEM-001",
+      "id": "dem/person-create",
+      "title": "Demographic person create",
+      "capability": "DemographicApi",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "expected status 201, got 404 (body: {\"error\":\"Not Found\",\"message\":\"No resource found at path: rest/openehr/v1/demographic/person\"})",
+      "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
+      "duration_ms": 5
+    },
+    {
+      "ecc_id": "ECC-DEM-002",
+      "id": "dem/person-get",
+      "title": "Demographic person get",
+      "capability": "DemographicApi",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "expected status 201, got 404 (body: {\"error\":\"Not Found\",\"message\":\"No resource found at path: rest/openehr/v1/demographic/person\"})",
+      "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
+      "duration_ms": 1
+    },
+    {
+      "ecc_id": "ECC-DEM-003",
+      "id": "dem/person-get-by-version",
+      "title": "Demographic person get by version",
+      "capability": "DemographicApi",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "expected status 201, got 404 (body: {\"error\":\"Not Found\",\"message\":\"No resource found at path: rest/openehr/v1/demographic/person\"})",
+      "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
+      "duration_ms": 1
+    },
+    {
+      "ecc_id": "ECC-DEM-004",
+      "id": "dem/person-update",
+      "title": "Demographic person update",
+      "capability": "DemographicApi",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "expected status 201, got 404 (body: {\"error\":\"Not Found\",\"message\":\"No resource found at path: rest/openehr/v1/demographic/person\"})",
+      "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
+      "duration_ms": 1
+    },
+    {
+      "ecc_id": "ECC-DEM-005",
+      "id": "dem/person-delete",
+      "title": "Demographic person delete",
+      "capability": "DemographicApi",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "expected status 201, got 404 (body: {\"error\":\"Not Found\",\"message\":\"No resource found at path: rest/openehr/v1/demographic/person\"})",
+      "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
+      "duration_ms": 2
+    },
+    {
+      "ecc_id": "ECC-DEM-006",
+      "id": "dem/person-get-deleted",
+      "title": "Demographic person get deleted",
+      "capability": "DemographicApi",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "expected status 201, got 404 (body: {\"error\":\"Not Found\",\"message\":\"No resource found at path: rest/openehr/v1/demographic/person\"})",
+      "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
+      "duration_ms": 2
+    },
+    {
+      "ecc_id": "ECC-DEM-007",
+      "id": "dem/person-get-absent",
+      "title": "Demographic person get absent",
+      "capability": "DemographicApi",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
+      "duration_ms": 2
+    },
+    {
+      "ecc_id": "ECC-DEM-008",
+      "id": "dem/person-update-bad-if-match",
+      "title": "Demographic person update bad if match",
+      "capability": "DemographicApi",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "expected status 201, got 404 (body: {\"error\":\"Not Found\",\"message\":\"No resource found at path: rest/openehr/v1/demographic/person\"})",
+      "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
+      "duration_ms": 1
+    },
+    {
+      "ecc_id": "ECC-DEM-009",
+      "id": "dem/agent-create",
+      "title": "Demographic agent create",
+      "capability": "DemographicApi",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "expected status 201, got 404 (body: {\"error\":\"Not Found\",\"message\":\"No resource found at path: rest/openehr/v1/demographic/agent\"})",
+      "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
+      "duration_ms": 2
+    },
+    {
+      "ecc_id": "ECC-DEM-010",
+      "id": "dem/agent-get",
+      "title": "Demographic agent get",
+      "capability": "DemographicApi",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "expected status 201, got 404 (body: {\"error\":\"Not Found\",\"message\":\"No resource found at path: rest/openehr/v1/demographic/agent\"})",
+      "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
+      "duration_ms": 2
+    },
+    {
+      "ecc_id": "ECC-DEM-011",
+      "id": "dem/agent-delete",
+      "title": "Demographic agent delete",
+      "capability": "DemographicApi",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "expected status 201, got 404 (body: {\"error\":\"Not Found\",\"message\":\"No resource found at path: rest/openehr/v1/demographic/agent\"})",
+      "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
+      "duration_ms": 2
+    },
+    {
+      "ecc_id": "ECC-DEM-012",
+      "id": "dem/group-create",
+      "title": "Demographic group create",
+      "capability": "DemographicApi",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "expected status 201, got 404 (body: {\"error\":\"Not Found\",\"message\":\"No resource found at path: rest/openehr/v1/demographic/group\"})",
+      "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
+      "duration_ms": 2
+    },
+    {
+      "ecc_id": "ECC-DEM-013",
+      "id": "dem/group-get",
+      "title": "Demographic group get",
+      "capability": "DemographicApi",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "expected status 201, got 404 (body: {\"error\":\"Not Found\",\"message\":\"No resource found at path: rest/openehr/v1/demographic/group\"})",
+      "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
+      "duration_ms": 2
+    },
+    {
+      "ecc_id": "ECC-DEM-014",
+      "id": "dem/group-delete",
+      "title": "Demographic group delete",
+      "capability": "DemographicApi",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "expected status 201, got 404 (body: {\"error\":\"Not Found\",\"message\":\"No resource found at path: rest/openehr/v1/demographic/group\"})",
+      "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
+      "duration_ms": 2
+    },
+    {
+      "ecc_id": "ECC-DEM-015",
+      "id": "dem/organisation-create",
+      "title": "Demographic organisation create",
+      "capability": "DemographicApi",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "expected status 201, got 404 (body: {\"error\":\"Not Found\",\"message\":\"No resource found at path: rest/openehr/v1/demographic/organisation\"})",
+      "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
+      "duration_ms": 3
+    },
+    {
+      "ecc_id": "ECC-DEM-016",
+      "id": "dem/organisation-get",
+      "title": "Demographic organisation get",
+      "capability": "DemographicApi",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "expected status 201, got 404 (body: {\"error\":\"Not Found\",\"message\":\"No resource found at path: rest/openehr/v1/demographic/organisation\"})",
+      "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
+      "duration_ms": 3
+    },
+    {
+      "ecc_id": "ECC-DEM-017",
+      "id": "dem/organisation-delete",
+      "title": "Demographic organisation delete",
+      "capability": "DemographicApi",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "expected status 201, got 404 (body: {\"error\":\"Not Found\",\"message\":\"No resource found at path: rest/openehr/v1/demographic/organisation\"})",
+      "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
+      "duration_ms": 3
+    },
+    {
+      "ecc_id": "ECC-DEM-018",
+      "id": "dem/role-create",
+      "title": "Demographic role create",
+      "capability": "DemographicApi",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "expected status 201, got 404 (body: {\"error\":\"Not Found\",\"message\":\"No resource found at path: rest/openehr/v1/demographic/role\"})",
+      "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
+      "duration_ms": 3
+    },
+    {
+      "ecc_id": "ECC-DEM-019",
+      "id": "dem/role-get",
+      "title": "Demographic role get",
+      "capability": "DemographicApi",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "expected status 201, got 404 (body: {\"error\":\"Not Found\",\"message\":\"No resource found at path: rest/openehr/v1/demographic/role\"})",
+      "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
+      "duration_ms": 3
+    },
+    {
+      "ecc_id": "ECC-DEM-020",
+      "id": "dem/role-delete",
+      "title": "Demographic role delete",
+      "capability": "DemographicApi",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "expected status 201, got 404 (body: {\"error\":\"Not Found\",\"message\":\"No resource found at path: rest/openehr/v1/demographic/role\"})",
+      "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
+      "duration_ms": 3
+    },
+    {
+      "ecc_id": "ECC-DEM-021",
+      "id": "dem/create-bad-body",
+      "title": "Demographic create bad body",
+      "capability": "DemographicApi",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "expected status in [400, 422], got 404",
+      "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
+      "duration_ms": 3
+    },
+    {
+      "ecc_id": "ECC-DEM-022",
+      "id": "dem/versioned-party-get",
+      "title": "Demographic versioned party get",
+      "capability": "DemographicApi",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "expected status 201, got 404 (body: {\"error\":\"Not Found\",\"message\":\"No resource found at path: rest/openehr/v1/demographic/person\"})",
+      "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
+      "duration_ms": 2
+    },
+    {
+      "ecc_id": "ECC-DEM-023",
+      "id": "dem/versioned-party-revision-history",
+      "title": "Demographic versioned party revision history",
+      "capability": "DemographicApi",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "expected status 201, got 404 (body: {\"error\":\"Not Found\",\"message\":\"No resource found at path: rest/openehr/v1/demographic/person\"})",
+      "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
+      "duration_ms": 3
+    },
+    {
+      "ecc_id": "ECC-DEM-024",
+      "id": "dem/person-tags",
+      "title": "Demographic person tags",
+      "capability": "DemographicApi",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "expected status 201, got 404 (body: {\"error\":\"Not Found\",\"message\":\"No resource found at path: rest/openehr/v1/demographic/person\"})",
+      "citation": "ITS-REST 1.0.3 DEMOGRAPHIC API; SM §I_DEMOGRAPHIC_SERVICE; RM 1.2.0 demographic",
+      "duration_ms": 2
+    },
+    {
+      "ecc_id": "ECC-VAL-001",
+      "id": "val/comp-content-card-any-context-any",
+      "title": "Validate COMPOSITION — content card any context any",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 5
+    },
+    {
+      "ecc_id": "ECC-VAL-002",
+      "id": "val/comp-content-card-1plus-context-any",
+      "title": "Validate COMPOSITION — content card 1plus context any",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 5
+    },
+    {
+      "ecc_id": "ECC-VAL-003",
+      "id": "val/comp-content-card-3plus-context-any",
+      "title": "Validate COMPOSITION — content card 3plus context any",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-VAL-004",
+      "id": "val/comp-content-card-opt-context-any",
+      "title": "Validate COMPOSITION — content card OPT context any",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 3
+    },
+    {
+      "ecc_id": "ECC-VAL-005",
+      "id": "val/comp-content-card-mand-context-any",
+      "title": "Validate COMPOSITION — content card mand context any",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 7
+    },
+    {
+      "ecc_id": "ECC-VAL-006",
+      "id": "val/comp-content-card-3to5-context-any",
+      "title": "Validate COMPOSITION — content card 3to5 context any",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 5
+    },
+    {
+      "ecc_id": "ECC-VAL-007",
+      "id": "val/comp-content-card-any-context-mand",
+      "title": "Validate COMPOSITION — content card any context mand",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 3
+    },
+    {
+      "ecc_id": "ECC-VAL-008",
+      "id": "val/comp-content-card-1plus-context-mand",
+      "title": "Validate COMPOSITION — content card 1plus context mand",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-VAL-009",
+      "id": "val/comp-content-card-3plus-context-mand",
+      "title": "Validate COMPOSITION — content card 3plus context mand",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-VAL-010",
+      "id": "val/comp-content-card-opt-context-mand",
+      "title": "Validate COMPOSITION — content card OPT context mand",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-VAL-011",
+      "id": "val/comp-content-card-mand-context-mand",
+      "title": "Validate COMPOSITION — content card mand context mand",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 3
+    },
+    {
+      "ecc_id": "ECC-VAL-012",
+      "id": "val/comp-content-card-3to5-context-mand",
+      "title": "Validate COMPOSITION — content card 3to5 context mand",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §COMPOSITION.content/context; AM 1.4 archetype cardinality; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 3
+    },
+    {
+      "ecc_id": "ECC-VAL-013",
+      "id": "val/obs-state-ex-opt-protocol-ex-opt",
+      "title": "Validate OBSERVATION — state ex OPT protocol ex OPT",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT minimal_persistent/persistent_minimal.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §OBSERVATION; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-VAL-014",
+      "id": "val/obs-state-ex-opt-protocol-ex-mand",
+      "title": "Validate OBSERVATION — state ex OPT protocol ex mand",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT minimal_persistent/persistent_minimal.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §OBSERVATION; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 2
+    },
+    {
+      "ecc_id": "ECC-VAL-015",
+      "id": "val/obs-state-ex-mand-protocol-ex-opt",
+      "title": "Validate OBSERVATION — state ex mand protocol ex OPT",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT minimal_persistent/persistent_minimal.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §OBSERVATION; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 2
+    },
+    {
+      "ecc_id": "ECC-VAL-016",
+      "id": "val/obs-state-ex-mand-protocol-ex-mand",
+      "title": "Validate OBSERVATION — state ex mand protocol ex mand",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT minimal_persistent/persistent_minimal.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §OBSERVATION; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 3
+    },
+    {
+      "ecc_id": "ECC-VAL-017",
+      "id": "val/hist-events-card-any-summary-ex-opt",
+      "title": "Validate HISTORY — events card any summary ex OPT",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 3
+    },
+    {
+      "ecc_id": "ECC-VAL-018",
+      "id": "val/hist-events-card-1plus-summary-ex-opt",
+      "title": "Validate HISTORY — events card 1plus summary ex OPT",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-VAL-019",
+      "id": "val/hist-events-card-3plus-summary-ex-opt",
+      "title": "Validate HISTORY — events card 3plus summary ex OPT",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-VAL-020",
+      "id": "val/hist-events-card-opt-summary-ex-opt",
+      "title": "Validate HISTORY — events card OPT summary ex OPT",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-VAL-021",
+      "id": "val/hist-events-card-mand-summary-ex-opt",
+      "title": "Validate HISTORY — events card mand summary ex OPT",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-VAL-022",
+      "id": "val/hist-events-card-3to5-summary-ex-opt",
+      "title": "Validate HISTORY — events card 3to5 summary ex OPT",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 3
+    },
+    {
+      "ecc_id": "ECC-VAL-023",
+      "id": "val/hist-events-card-any-summary-ex-mand",
+      "title": "Validate HISTORY — events card any summary ex mand",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-VAL-024",
+      "id": "val/hist-events-card-1plus-summary-ex-mand",
+      "title": "Validate HISTORY — events card 1plus summary ex mand",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-VAL-025",
+      "id": "val/hist-events-card-3plus-summary-ex-mand",
+      "title": "Validate HISTORY — events card 3plus summary ex mand",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 5
+    },
+    {
+      "ecc_id": "ECC-VAL-026",
+      "id": "val/hist-events-card-opt-summary-ex-mand",
+      "title": "Validate HISTORY — events card OPT summary ex mand",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 5
+    },
+    {
+      "ecc_id": "ECC-VAL-027",
+      "id": "val/hist-events-card-mand-summary-ex-mand",
+      "title": "Validate HISTORY — events card mand summary ex mand",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 7
+    },
+    {
+      "ecc_id": "ECC-VAL-028",
+      "id": "val/hist-events-card-3to5-summary-ex-mand",
+      "title": "Validate HISTORY — events card 3to5 summary ex mand",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §HISTORY; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 6
+    },
+    {
+      "ecc_id": "ECC-VAL-029",
+      "id": "val/event-state-ex-opt",
+      "title": "Validate EVENT — state ex OPT",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT minimal_persistent/persistent_minimal.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §EVENT; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 3
+    },
+    {
+      "ecc_id": "ECC-VAL-030",
+      "id": "val/event-state-ex-mand",
+      "title": "Validate EVENT — state ex mand",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT minimal_persistent/persistent_minimal.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §EVENT; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 3
+    },
+    {
+      "ecc_id": "ECC-VAL-031",
+      "id": "val/event-type-any",
+      "title": "Validate EVENT — type any",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT minimal_persistent/persistent_minimal.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §EVENT; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 2
+    },
+    {
+      "ecc_id": "ECC-VAL-032",
+      "id": "val/event-type-point-event",
+      "title": "Validate EVENT — type point event",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §EVENT; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 6
+    },
+    {
+      "ecc_id": "ECC-VAL-033",
+      "id": "val/event-type-interval-event",
+      "title": "Validate EVENT — type interval event",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §EVENT; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 5
+    },
+    {
+      "ecc_id": "ECC-VAL-034",
+      "id": "val/item-str-type-any",
+      "title": "Validate ITEM_STRUCTURE — type any",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §ITEM_STRUCTURE; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 11
+    },
+    {
+      "ecc_id": "ECC-VAL-035",
+      "id": "val/item-str-type-item-tree",
+      "title": "Validate ITEM_STRUCTURE — type item tree",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT validation/clinical_content_validation.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §ITEM_STRUCTURE; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 5
+    },
+    {
+      "ecc_id": "ECC-VAL-036",
+      "id": "val/item-str-type-item-list",
+      "title": "Validate ITEM_STRUCTURE — type item list",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT validation/clinical_content_validation.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §ITEM_STRUCTURE; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 5
+    },
+    {
+      "ecc_id": "ECC-VAL-037",
+      "id": "val/item-str-type-item-table",
+      "title": "Validate ITEM_STRUCTURE — type item table",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT validation/clinical_content_validation.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §ITEM_STRUCTURE; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 6
+    },
+    {
+      "ecc_id": "ECC-VAL-038",
+      "id": "val/item-str-type-item-single",
+      "title": "Validate ITEM_STRUCTURE — type item single",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT validation/clinical_content_validation.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 ehr §ITEM_STRUCTURE; AM 1.4 archetype constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 8
+    },
+    {
+      "ecc_id": "ECC-VAL-039",
+      "id": "val/dv-boolean-anything-allowed",
+      "title": "Validate DV_BOOLEAN — anything allowed",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_BOOLEAN; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 8
+    },
+    {
+      "ecc_id": "ECC-VAL-040",
+      "id": "val/dv-boolean-only-true-allowed",
+      "title": "Validate DV_BOOLEAN — only true allowed",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_BOOLEAN; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 18
+    },
+    {
+      "ecc_id": "ECC-VAL-041",
+      "id": "val/dv-boolean-only-false-allowed",
+      "title": "Validate DV_BOOLEAN — only false allowed",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_BOOLEAN; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 18
+    },
+    {
+      "ecc_id": "ECC-VAL-042",
+      "id": "val/dv-identifier-all-pattern",
+      "title": "Validate DV_IDENTIFIER — all pattern",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_IDENTIFIER; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 21
+    },
+    {
+      "ecc_id": "ECC-VAL-043",
+      "id": "val/dv-identifier-all-list",
+      "title": "Validate DV_IDENTIFIER — all list",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_IDENTIFIER; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 18
+    },
+    {
+      "ecc_id": "ECC-VAL-044",
+      "id": "val/dv-text-open",
+      "title": "Validate DV_TEXT — open",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_TEXT; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 5
+    },
+    {
+      "ecc_id": "ECC-VAL-045",
+      "id": "val/dv-text-list",
+      "title": "Validate DV_TEXT — list",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_TEXT; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 18
+    },
+    {
+      "ecc_id": "ECC-VAL-046",
+      "id": "val/dv-coded-text-open",
+      "title": "Validate DV_CODED_TEXT — open",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_CODED_TEXT; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 5
+    },
+    {
+      "ecc_id": "ECC-VAL-047",
+      "id": "val/dv-coded-text-local-codes",
+      "title": "Validate DV_CODED_TEXT — local codes",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT all_types/Test_all_types_v2.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_CODED_TEXT; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 5
+    },
+    {
+      "ecc_id": "ECC-VAL-048",
+      "id": "val/dv-coded-text-ext-term",
+      "title": "Validate DV_CODED_TEXT — ext term",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_CODED_TEXT; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 15
+    },
+    {
+      "ecc_id": "ECC-VAL-049",
+      "id": "val/dv-ordinal-open",
+      "title": "Validate DV_ORDINAL — open",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_ORDINAL; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 5
+    },
+    {
+      "ecc_id": "ECC-VAL-050",
+      "id": "val/dv-ordinal-constraint",
+      "title": "Validate DV_ORDINAL — constraint",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_ORDINAL; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 7
+    },
+    {
+      "ecc_id": "ECC-VAL-051",
+      "id": "val/dv-scale-open",
+      "title": "Validate DV_SCALE — open",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_SCALE; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 15
+    },
+    {
+      "ecc_id": "ECC-VAL-052",
+      "id": "val/dv-scale-constraint",
+      "title": "Validate DV_SCALE — constraint",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_SCALE; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 16
+    },
+    {
+      "ecc_id": "ECC-VAL-053",
+      "id": "val/dv-count-open",
+      "title": "Validate DV_COUNT — open",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_COUNT; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 5
+    },
+    {
+      "ecc_id": "ECC-VAL-054",
+      "id": "val/dv-count-range",
+      "title": "Validate DV_COUNT — range",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_COUNT; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 14
+    },
+    {
+      "ecc_id": "ECC-VAL-055",
+      "id": "val/dv-count-list",
+      "title": "Validate DV_COUNT — list",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_COUNT; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 15
+    },
+    {
+      "ecc_id": "ECC-VAL-056",
+      "id": "val/dv-quantity-open",
+      "title": "Validate DV_QUANTITY — open",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_QUANTITY; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 7
+    },
+    {
+      "ecc_id": "ECC-VAL-057",
+      "id": "val/dv-quantity-property",
+      "title": "Validate DV_QUANTITY — property",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_QUANTITY; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 16
+    },
+    {
+      "ecc_id": "ECC-VAL-058",
+      "id": "val/dv-quantity-property-units",
+      "title": "Validate DV_QUANTITY — property units",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_QUANTITY; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 5
+    },
+    {
+      "ecc_id": "ECC-VAL-059",
+      "id": "val/dv-quantity-property-units-mag",
+      "title": "Validate DV_QUANTITY — property units mag",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT time_series/time_series.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_QUANTITY; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-VAL-060",
+      "id": "val/dv-proportion-open",
+      "title": "Validate DV_PROPORTION — open",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_PROPORTION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-VAL-061",
+      "id": "val/dv-proportion-ratio",
+      "title": "Validate DV_PROPORTION — ratio",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_PROPORTION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-VAL-062",
+      "id": "val/dv-proportion-unitary",
+      "title": "Validate DV_PROPORTION — unitary",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_PROPORTION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-VAL-063",
+      "id": "val/dv-proportion-percent",
+      "title": "Validate DV_PROPORTION — percent",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_PROPORTION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 14
+    },
+    {
+      "ecc_id": "ECC-VAL-064",
+      "id": "val/dv-proportion-fraction",
+      "title": "Validate DV_PROPORTION — fraction",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_PROPORTION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-VAL-065",
+      "id": "val/dv-proportion-integer-fraction",
+      "title": "Validate DV_PROPORTION — integer fraction",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_PROPORTION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-VAL-066",
+      "id": "val/dv-proportion-any-fraction",
+      "title": "Validate DV_PROPORTION — any fraction",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT minimal/minimal_action_2.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_PROPORTION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 2
+    },
+    {
+      "ecc_id": "ECC-VAL-067",
+      "id": "val/dv-proportion-ratio-range",
+      "title": "Validate DV_PROPORTION — ratio range",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_PROPORTION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-VAL-068",
+      "id": "val/dv-interval-dv-count-open",
+      "title": "Validate DV_INTERVAL<DV_COUNT> — open",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_COUNT>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-VAL-069",
+      "id": "val/dv-interval-dv-count-lower-upper",
+      "title": "Validate DV_INTERVAL<DV_COUNT> — lower upper",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_COUNT>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-VAL-070",
+      "id": "val/dv-interval-dv-count-lower-upper-list",
+      "title": "Validate DV_INTERVAL<DV_COUNT> — lower upper list",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_COUNT>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 14
+    },
+    {
+      "ecc_id": "ECC-VAL-071",
+      "id": "val/dv-interval-dv-quantity-open",
+      "title": "Validate DV_INTERVAL<DV_QUANTITY> — open",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_QUANTITY>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-VAL-072",
+      "id": "val/dv-interval-dv-quantity-upper-lower",
+      "title": "Validate DV_INTERVAL<DV_QUANTITY> — upper lower",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_QUANTITY>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-VAL-073",
+      "id": "val/dv-interval-dv-date-time-open",
+      "title": "Validate DV_INTERVAL<DV_DATE_TIME> — open",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DATE_TIME>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-VAL-074",
+      "id": "val/dv-interval-dv-date-time-lower-upper-constraint",
+      "title": "Validate DV_INTERVAL<DV_DATE_TIME> — lower upper constraint",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DATE_TIME>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-VAL-075",
+      "id": "val/dv-interval-dv-date-time-lower-upper-range",
+      "title": "Validate DV_INTERVAL<DV_DATE_TIME> — lower upper range",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DATE_TIME>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-VAL-076",
+      "id": "val/dv-interval-dv-date-open",
+      "title": "Validate DV_INTERVAL<DV_DATE> — open",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DATE>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 15
+    },
+    {
+      "ecc_id": "ECC-VAL-077",
+      "id": "val/dv-interval-dv-date-lower-upper-constraint",
+      "title": "Validate DV_INTERVAL<DV_DATE> — lower upper constraint",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DATE>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 15
+    },
+    {
+      "ecc_id": "ECC-VAL-078",
+      "id": "val/dv-interval-dv-date-lower-upper-range",
+      "title": "Validate DV_INTERVAL<DV_DATE> — lower upper range",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DATE>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-VAL-079",
+      "id": "val/dv-interval-dv-time-open",
+      "title": "Validate DV_INTERVAL<DV_TIME> — open",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_TIME>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 14
+    },
+    {
+      "ecc_id": "ECC-VAL-080",
+      "id": "val/dv-interval-dv-time-lower-upper-constraint",
+      "title": "Validate DV_INTERVAL<DV_TIME> — lower upper constraint",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_TIME>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 14
+    },
+    {
+      "ecc_id": "ECC-VAL-081",
+      "id": "val/dv-interval-dv-time-lower-upper-range",
+      "title": "Validate DV_INTERVAL<DV_TIME> — lower upper range",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_TIME>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-VAL-082",
+      "id": "val/dv-interval-dv-duration-open",
+      "title": "Validate DV_INTERVAL<DV_DURATION> — open",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DURATION>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 14
+    },
+    {
+      "ecc_id": "ECC-VAL-083",
+      "id": "val/dv-interval-dv-duration-constraint",
+      "title": "Validate DV_INTERVAL<DV_DURATION> — constraint",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DURATION>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-VAL-084",
+      "id": "val/dv-interval-dv-duration-range",
+      "title": "Validate DV_INTERVAL<DV_DURATION> — range",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DURATION>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-VAL-085",
+      "id": "val/dv-interval-dv-ordinal-open",
+      "title": "Validate DV_INTERVAL<DV_ORDINAL> — open",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_ORDINAL>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 15
+    },
+    {
+      "ecc_id": "ECC-VAL-086",
+      "id": "val/dv-interval-dv-ordinal-constraint",
+      "title": "Validate DV_INTERVAL<DV_ORDINAL> — constraint",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_ORDINAL>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 15
+    },
+    {
+      "ecc_id": "ECC-VAL-087",
+      "id": "val/dv-interval-dv-scale-open",
+      "title": "Validate DV_INTERVAL<DV_SCALE> — open",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_SCALE>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 15
+    },
+    {
+      "ecc_id": "ECC-VAL-088",
+      "id": "val/dv-interval-dv-scale-constraint",
+      "title": "Validate DV_INTERVAL<DV_SCALE> — constraint",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_SCALE>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 14
+    },
+    {
+      "ecc_id": "ECC-VAL-089",
+      "id": "val/dv-interval-dv-proportion-open",
+      "title": "Validate DV_INTERVAL<DV_PROPORTION> — open",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-VAL-090",
+      "id": "val/dv-interval-dv-proportion-ratio",
+      "title": "Validate DV_INTERVAL<DV_PROPORTION> — ratio",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-VAL-091",
+      "id": "val/dv-interval-dv-proportion-unitary",
+      "title": "Validate DV_INTERVAL<DV_PROPORTION> — unitary",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-VAL-092",
+      "id": "val/dv-interval-dv-proportion-percentage",
+      "title": "Validate DV_INTERVAL<DV_PROPORTION> — percentage",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-VAL-093",
+      "id": "val/dv-interval-dv-proportion-fraction",
+      "title": "Validate DV_INTERVAL<DV_PROPORTION> — fraction",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-VAL-094",
+      "id": "val/dv-interval-dv-proportion-integer-fraction",
+      "title": "Validate DV_INTERVAL<DV_PROPORTION> — integer fraction",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 18
+    },
+    {
+      "ecc_id": "ECC-VAL-095",
+      "id": "val/dv-interval-dv-proportion-ratio-range",
+      "title": "Validate DV_INTERVAL<DV_PROPORTION> — ratio range",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 15
+    },
+    {
+      "ecc_id": "ECC-VAL-096",
+      "id": "val/dv-duration-open",
+      "title": "Validate DV_DURATION — open",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_DURATION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 5
+    },
+    {
+      "ecc_id": "ECC-VAL-097",
+      "id": "val/dv-duration-fields",
+      "title": "Validate DV_DURATION — fields",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_DURATION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 15
+    },
+    {
+      "ecc_id": "ECC-VAL-098",
+      "id": "val/dv-duration-range",
+      "title": "Validate DV_DURATION — range",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_DURATION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-VAL-099",
+      "id": "val/dv-duration-fields-range",
+      "title": "Validate DV_DURATION — fields range",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_DURATION; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-VAL-100",
+      "id": "val/dv-time-open",
+      "title": "Validate DV_TIME — open",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_TIME; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-VAL-101",
+      "id": "val/dv-time-constraint",
+      "title": "Validate DV_TIME — constraint",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_TIME; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-VAL-102",
+      "id": "val/dv-time-range",
+      "title": "Validate DV_TIME — range",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_TIME; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 12
+    },
+    {
+      "ecc_id": "ECC-VAL-103",
+      "id": "val/dv-date-open",
+      "title": "Validate DV_DATE — open",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_DATE; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 3
+    },
+    {
+      "ecc_id": "ECC-VAL-104",
+      "id": "val/dv-date-constraint",
+      "title": "Validate DV_DATE — constraint",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_DATE; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 15
+    },
+    {
+      "ecc_id": "ECC-VAL-105",
+      "id": "val/dv-date-range",
+      "title": "Validate DV_DATE — range",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_DATE; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 14
+    },
+    {
+      "ecc_id": "ECC-VAL-119",
+      "id": "val/dv-date-day-disallowed-pattern",
+      "title": "Validate DV_DATE — day disallowed by C_DATE pattern (defective vendored fixture rejected)",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "AM 1.4 C_DATE (yyyy-??-XX: month optional, day disallowed; org.openehr.am.aom14.c_date.adoc); valid_templates/all_types/Test_all_types.opt; ITS-REST 1.0.3 composition_create (422 rejected)",
+      "duration_ms": 3
+    },
+    {
+      "ecc_id": "ECC-VAL-106",
+      "id": "val/dv-date-time-open",
+      "title": "Validate DV_DATE_TIME — open",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_DATE_TIME; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-VAL-107",
+      "id": "val/dv-date-time-constraint",
+      "title": "Validate DV_DATE_TIME — constraint",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_DATE_TIME; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 5
+    },
+    {
+      "ecc_id": "ECC-VAL-108",
+      "id": "val/dv-date-time-range",
+      "title": "Validate DV_DATE_TIME — range",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_DATE_TIME; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-VAL-109",
+      "id": "val/dv-parsable-open",
+      "title": "Validate DV_PARSABLE — open",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_PARSABLE; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-VAL-110",
+      "id": "val/dv-parsable-value-formalism",
+      "title": "Validate DV_PARSABLE — value formalism",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_PARSABLE; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-VAL-111",
+      "id": "val/dv-multimedia-open",
+      "title": "Validate DV_MULTIMEDIA — open",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_MULTIMEDIA; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-VAL-112",
+      "id": "val/dv-multimedia-media-type",
+      "title": "Validate DV_MULTIMEDIA — media type",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_MULTIMEDIA; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-VAL-113",
+      "id": "val/dv-uri-open",
+      "title": "Validate DV_URI — open",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT all_types/Test_all_types.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_URI; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 4
+    },
+    {
+      "ecc_id": "ECC-VAL-114",
+      "id": "val/dv-uri-pattern",
+      "title": "Validate DV_URI — pattern",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_URI; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-VAL-115",
+      "id": "val/dv-uri-list",
+      "title": "Validate DV_URI — list",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_URI; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 12
+    },
+    {
+      "ecc_id": "ECC-VAL-116",
+      "id": "val/dv-ehr-uri-open",
+      "title": "Validate DV_EHR_URI — open",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_EHR_URI; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 12
+    },
+    {
+      "ecc_id": "ECC-VAL-117",
+      "id": "val/dv-ehr-uri-pattern",
+      "title": "Validate DV_EHR_URI — pattern",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_EHR_URI; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 12
+    },
+    {
+      "ecc_id": "ECC-VAL-118",
+      "id": "val/dv-ehr-uri-list",
+      "title": "Validate DV_EHR_URI — list",
+      "capability": "ArchetypeValidation",
+      "profiles": [
+        "Core",
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "authored OPT upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "RM 1.2.0 data_types §DV_EHR_URI; AM 1.4 C_* constraint; ITS-REST 1.0.3 composition_create (201/422)",
+      "duration_ms": 12
+    },
+    {
+      "ecc_id": "ECC-SIG-001",
+      "id": "sig/digest-present",
+      "title": "Version signing — digest present",
+      "capability": "Signing",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "version-signing.md §3.2 (digest default-on); §4.4 (rides every VERSION read)",
+      "duration_ms": 1
+    },
+    {
+      "ecc_id": "ECC-SIG-002",
+      "id": "sig/digest-recomputes",
+      "title": "Version signing — digest recomputes",
+      "capability": "Signing",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "version-signing.md §3.1 (canonical_form RFC 8785) + §6.3",
+      "duration_ms": 1
+    },
+    {
+      "ecc_id": "ECC-SIG-003",
+      "id": "sig/all-kinds",
+      "title": "Version signing — all kinds",
+      "capability": "Signing",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "served ORIGINAL_VERSION carries no `signature` (version-signing.md §4.4)",
+      "citation": "version-signing.md §3.3 (all object kinds via the shared vobject commit path)",
+      "duration_ms": 41
+    },
+    {
+      "ecc_id": "ECC-SIG-004",
+      "id": "sig/client-verbatim",
+      "title": "Version signing — client verbatim",
+      "capability": "Signing",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT minimal/minimal_admin.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "version-signing.md §3.3 (client-supplied signatures win, stored verbatim)",
+      "duration_ms": 2
+    },
+    {
+      "ecc_id": "ECC-SIG-005",
+      "id": "sig/pgp-verifies",
+      "title": "Version signing — pgp verifies",
+      "capability": "Signing",
+      "profiles": [
+        "Standard"
+      ],
+      "format": "json",
+      "status": "skipped",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "SutConfig: server not in `pgp` mode (needs a configured OpenPGP key); a pgp-keyed compose profile is a follow-up — digest cases prove the capability",
+      "citation": "version-signing.md §3.2 (pgp mode, RFC 4880 detached signature)",
+      "duration_ms": 0
+    },
+    {
+      "ecc_id": "ECC-MSG-001",
+      "id": "msg/export-ehrs",
+      "title": "EHR Extract — export whole EHR (export_ehrs)",
+      "capability": "Messaging",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "skipped",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "NativeApiOnly: I_EHR_EXTRACT_SERVICE.export_ehrs is exercised by app/ehrbase/tests/service_extract.rs::export_ehrs_carries_every_versioned_object_latest_only — Messaging has no ITS-REST binding",
+      "citation": "SM I_EHR_EXTRACT_SERVICE.export_ehrs; RM EHR Extract IM master05 (X_VERSIONED_*), master09 (creation); CNF master13 §I_EHR_EXTRACT.export_ehrs (TBD)",
+      "schedule_ref": "I_EHR_EXTRACT_SERVICE.export_ehrs (CNF master13, TBD)",
+      "duration_ms": 0
+    },
+    {
+      "ecc_id": "ECC-MSG-002",
+      "id": "msg/export-ehr-extracts",
+      "title": "EHR Extract — spec-driven export (export_ehr_extracts)",
+      "capability": "Messaging",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "skipped",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "NativeApiOnly: I_EHR_EXTRACT_SERVICE.export_ehr_extracts is exercised by app/ehrbase/tests/service_extract.rs::export_ehr_extracts_honours_item_list_and_all_versions — Messaging has no ITS-REST binding",
+      "citation": "SM I_EHR_EXTRACT_SERVICE.export_ehr_extracts (EXTRACT_ENTITY_MANIFEST + EXTRACT_VERSION_SPEC); CNF master13 §I_EHR_EXTRACT.export_ehr_extracts (TBD)",
+      "schedule_ref": "I_EHR_EXTRACT_SERVICE.export_ehr_extracts (CNF master13, TBD)",
+      "duration_ms": 0
+    },
+    {
+      "ecc_id": "ECC-MSG-003",
+      "id": "msg/export-unknown-ehr",
+      "title": "EHR Extract — export of unknown EHR fails",
+      "capability": "Messaging",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "skipped",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "NativeApiOnly: I_EHR_EXTRACT_SERVICE.export_ehrs (unknown EHR) is exercised by app/ehrbase/tests/service_extract.rs::export_ehrs_unknown_ehr_is_ehr_id_does_not_exist — Messaging has no ITS-REST binding",
+      "citation": "SM I_EHR_EXTRACT_SERVICE.export_ehrs (ehr_id_does_not_exist precondition); CNF master13 §I_EHR_EXTRACT.export_ehr (TBD)",
+      "schedule_ref": "I_EHR_EXTRACT_SERVICE.export_ehrs (CNF master13, TBD)",
+      "duration_ms": 0
+    },
+    {
+      "ecc_id": "ECC-MSG-004",
+      "id": "msg/import-ehr-clone",
+      "title": "EHR Extract — import whole-EHR clone reusing source id (import_ehr)",
+      "capability": "Messaging",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "skipped",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "NativeApiOnly: I_EHR_EXTRACT_SERVICE.import_ehr is exercised by app/ehrbase/tests/service_import.rs::import_ehr_clone_into_fresh_target_reuses_source_id — Messaging has no ITS-REST binding",
+      "citation": "SM I_EHR_EXTRACT_SERVICE.import_ehr; RM common master06 §Copying Case 1 (reuse source EHR identifier); CNF master13 (TBD)",
+      "schedule_ref": "I_EHR_EXTRACT_SERVICE.import_ehr (CNF master13, TBD)",
+      "duration_ms": 0
+    },
+    {
+      "ecc_id": "ECC-MSG-005",
+      "id": "msg/import-ehr-fixed-id",
+      "title": "EHR Extract — import whole EHR into a caller-fixed id (import_ehr)",
+      "capability": "Messaging",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "skipped",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "NativeApiOnly: I_EHR_EXTRACT_SERVICE.import_ehr (fixed id) is exercised by app/ehrbase/tests/service_import.rs::import_ehr_into_fixed_fresh_id — Messaging has no ITS-REST binding",
+      "citation": "SM I_EHR_EXTRACT_SERVICE.import_ehr (same patient in another EHR service); RM common master06 §Copying; CNF master13 (TBD)",
+      "schedule_ref": "I_EHR_EXTRACT_SERVICE.import_ehr (CNF master13, TBD)",
+      "duration_ms": 0
+    },
+    {
+      "ecc_id": "ECC-MSG-006",
+      "id": "msg/import-ehr-duplicate",
+      "title": "EHR Extract — import into a duplicate target id fails",
+      "capability": "Messaging",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "skipped",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "NativeApiOnly: I_EHR_EXTRACT_SERVICE.import_ehr (duplicate id) is exercised by app/ehrbase/tests/service_import.rs::import_ehr_duplicate_target_is_rejected — Messaging has no ITS-REST binding",
+      "citation": "SM I_EHR_EXTRACT_SERVICE.import_ehr (ehr_create_fail_duplicate_id); CNF master13 (TBD)",
+      "schedule_ref": "I_EHR_EXTRACT_SERVICE.import_ehr (CNF master13, TBD)",
+      "duration_ms": 0
+    },
+    {
+      "ecc_id": "ECC-MSG-007",
+      "id": "msg/import-ehr-extract",
+      "title": "EHR Extract — import extract into an existing EHR (import_ehr_extract)",
+      "capability": "Messaging",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "skipped",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "NativeApiOnly: I_EHR_EXTRACT_SERVICE.import_ehr_extract is exercised by app/ehrbase/tests/service_import.rs::import_ehr_extract_adds_a_versioned_object_and_rejects_re_import — Messaging has no ITS-REST binding",
+      "citation": "SM I_EHR_EXTRACT_SERVICE.import_ehr_extract; RM common master06 §Copying Case 2 (first receipt clones VERSIONED_OBJECT; re-import is a conflict); CNF master13 (TBD)",
+      "schedule_ref": "I_EHR_EXTRACT_SERVICE.import_ehr_extract (CNF master13, TBD)",
+      "duration_ms": 0
+    },
+    {
+      "ecc_id": "ECC-MSG-008",
+      "id": "msg/tdd-import-commits",
+      "title": "TDD — import a TDD as a committed COMPOSITION (import_tdd)",
+      "capability": "Messaging",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "skipped",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "NativeApiOnly: I_TDD_SERVICE.import_tdd is exercised by app/ehrbase/tests/service_tdd.rs::tdd_import_commits_composition — Messaging has no ITS-REST binding",
+      "citation": "SM I_TDD_SERVICE.import_tdd; TDD → COMPOSITION over OPT/WebTemplate (openehr_flat::from_tdd); CNF master13 §I_TDD.import_tdd (TBD)",
+      "schedule_ref": "I_TDD_SERVICE.import_tdd (CNF master13, TBD)",
+      "duration_ms": 0
+    },
+    {
+      "ecc_id": "ECC-MSG-009",
+      "id": "msg/tdd-import-rejects",
+      "title": "TDD — import rejects malformed / non-TDD / unknown EHR / unknown template",
+      "capability": "Messaging",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "skipped",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "NativeApiOnly: I_TDD_SERVICE.import_tdd (typed rejections) is exercised by app/ehrbase/tests/service_tdd.rs::{tdd_import_rejects_malformed_payload, tdd_import_rejects_non_tdd_xml, tdd_import_rejects_unknown_ehr, tdd_import_rejects_unknown_template} — Messaging has no ITS-REST binding",
+      "citation": "SM I_TDD_SERVICE.import_tdd (typed envelope rejections); CNF master13 §I_TDD.import_tdd (TBD)",
+      "schedule_ref": "I_TDD_SERVICE.import_tdd (CNF master13, TBD)",
+      "duration_ms": 0
+    },
+    {
+      "ecc_id": "ECC-MSG-010",
+      "id": "msg/tdd-import-tdds-batch",
+      "title": "TDD — batch import commits all, fail-fast on error (import_tdds)",
+      "capability": "Messaging",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "skipped",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "NativeApiOnly: I_TDD_SERVICE.import_tdds is exercised by app/ehrbase/tests/service_tdd.rs::{tdd_import_tdds_batch_commits_all, tdd_import_tdds_batch_fail_fast} — Messaging has no ITS-REST binding",
+      "citation": "SM I_TDD_SERVICE.import_tdds; CNF master13 §I_TDD.import_tdds (TBD)",
+      "schedule_ref": "I_TDD_SERVICE.import_tdds (CNF master13, TBD)",
+      "duration_ms": 0
+    },
+    {
+      "ecc_id": "ECC-TS-001",
+      "id": "ts/expand-bundle-accepted",
+      "title": "TERMINOLOGY expand (bundle) — accepted, well-formed RESULT_SET",
+      "capability": "Terminology",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "expected status 200, got 400 (body: {\"error\":\"Bad Request\",\"message\":\"Not implemented: Only primitive operands are supported\"})",
+      "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query",
+      "duration_ms": 5
+    },
+    {
+      "ecc_id": "ECC-TS-002",
+      "id": "ts/expand-bundle-constrains",
+      "title": "TERMINOLOGY expand (bundle) — expansion constrains matches to the value set's codes",
+      "capability": "Terminology",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query",
+      "duration_ms": 8
+    },
+    {
+      "ecc_id": "ECC-TS-003",
+      "id": "ts/expand-bundle-mixed-list",
+      "title": "TERMINOLOGY expand (bundle) — explicit code merged with the expansion (matches list)",
+      "capability": "Terminology",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "failed",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "OPT nested/nested.opt upload returned 406 (expected 2xx or 409 already-present)",
+      "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query",
+      "duration_ms": 7
+    },
+    {
+      "ecc_id": "ECC-TS-004",
+      "id": "ts/expand-unknown-value-set-rejected",
+      "title": "TERMINOLOGY expand — unknown value set rejected (400)",
+      "capability": "Terminology",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query",
+      "duration_ms": 2
+    },
+    {
+      "ecc_id": "ECC-TS-005",
+      "id": "ts/expand-unknown-service-rejected",
+      "title": "TERMINOLOGY expand — unknown service_api rejected (400)",
+      "capability": "Terminology",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query",
+      "duration_ms": 3
+    },
+    {
+      "ecc_id": "ECC-TS-006",
+      "id": "ts/expand-fhir-provider",
+      "title": "TERMINOLOGY expand (FHIR service_api) — accepted when a provider is configured",
+      "capability": "Terminology",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "skipped",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "SutConfig: FHIR terminology provider not exercisable — the SUT answered 400 to a `hl7.org/fhir/4.0` expand (a configured provider that lacks the fixture value set, or a non-provider rejection). Not a fabricated pass.",
+      "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query",
+      "duration_ms": 3
+    },
+    {
+      "ecc_id": "ECC-TS-007",
+      "id": "ts/fault-timeout",
+      "title": "TERMINOLOGY expand (FHIR) — terminology-server timeout is a server fault (500)",
+      "capability": "Terminology",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "skipped",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "SutConfig: the timeout fault requires a fault-injecting terminology server wired to the SUT (--tx-server-url + an SUT FHIR provider pointed at it); the HTTP-only ECC cannot reconfigure an external SUT's provider per case. Harness tx server: http://127.0.0.1:49886 (fixture). The fault→500 mapping is proven by conformance ts::fixture::tests::fault_timeout_exceeds_a_short_client_deadline + app/ehrbase/tests/terminology_fhir.rs::timeout_is_an_exception.",
+      "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query",
+      "duration_ms": 0
+    },
+    {
+      "ecc_id": "ECC-TS-008",
+      "id": "ts/fault-server-error",
+      "title": "TERMINOLOGY expand (FHIR) — terminology-server 5xx is a server fault (500)",
+      "capability": "Terminology",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "skipped",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "SutConfig: the 5xx fault requires a fault-injecting terminology server wired to the SUT (--tx-server-url + an SUT FHIR provider pointed at it); the HTTP-only ECC cannot reconfigure an external SUT's provider per case. Harness tx server: http://127.0.0.1:49886 (fixture). The fault→500 mapping is proven by conformance ts::fixture::tests::fault_server_error_is_5xx + app/ehrbase/tests/terminology_fhir.rs::server_5xx_is_an_exception.",
+      "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query",
+      "duration_ms": 0
+    },
+    {
+      "ecc_id": "ECC-TS-009",
+      "id": "ts/fault-malformed",
+      "title": "TERMINOLOGY expand (FHIR) — malformed terminology response is a server fault (500)",
+      "capability": "Terminology",
+      "profiles": [
+        "Options"
+      ],
+      "format": "json",
+      "status": "skipped",
+      "passed_data_sets": 0,
+      "total_data_sets": 0,
+      "message": "SutConfig: the malformed fault requires a fault-injecting terminology server wired to the SUT (--tx-server-url + an SUT FHIR provider pointed at it); the HTTP-only ECC cannot reconfigure an external SUT's provider per case. Harness tx server: http://127.0.0.1:49886 (fixture). The fault→500 mapping is proven by conformance ts::fixture::tests::fault_malformed_is_not_json + app/ehrbase/tests/terminology_fhir.rs::malformed_body_is_an_exception.",
+      "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.0.3 QUERY API §execute_ad_hoc_query",
+      "duration_ms": 0
+    },
+    {
+      "ecc_id": "ECC-SEC-001",
+      "id": "sec/unauthenticated-401",
+      "title": "Unauthenticated request to a protected route is refused (401)",
+      "capability": "Authentication",
+      "profiles": [],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "CNF SECURITY_TESTS/I_OAuth2_Keycloak §06 (API endpoints are secured); ITS-REST EHR API §get_ehr (401 unauthenticated)",
+      "schedule_ref": "SECURITY_TESTS/I_OAuth2_Keycloak §06 API endpoints are secured",
+      "duration_ms": 36
+    },
+    {
+      "ecc_id": "ECC-SEC-002",
+      "id": "sec/forbidden-role-403",
+      "title": "Regular credential on an ADMIN-only route is forbidden (403)",
+      "capability": "Authentication",
+      "profiles": [],
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "CNF SECURITY_TESTS/I_OAuth2_Keycloak (role-privileged access intent); ITS-REST ADMIN API §delete EHR — ADMIN-role-only (SM I_ADMIN_SERVICE)",
+      "duration_ms": 3
+    }
+  ]
+}

--- a/docs/plans/a1-spec-audit-PROMPT.md
+++ b/docs/plans/a1-spec-audit-PROMPT.md
@@ -1,0 +1,171 @@
+# A1 — Full spec audit: the launch prompt
+
+This file IS the prompt for the A1 full-spec-audit session. Kick it off from a
+fresh Fable 5 session with the one-liner at the bottom; the session then reads
+this file and executes it verbatim. (Authored 2026-07-11 after the X1.2
+upstream diff exposed the PARTY_SELF leniency gap.)
+
+---
+
+Run the FULL openEHR spec audit of ehrbase-rs (repo root: the current working
+directory) as a multi-agent workflow — use the Workflow tool to orchestrate
+it. This is a deep, chapter-by-chapter audit of the ENTIRE vendored spec
+surface against the actual Rust code, not a fast scan. Token cost is
+accepted; correctness and durable logging are the priorities.
+
+## Why (context)
+
+The project claims openEHR conformance (own ECC suite: 341 executed · 315
+passed · 0 failed) — yet diffing against upstream EHRbase Java exposed a real
+RM violation the suite never caught: our server accepted
+`EHR_STATUS.subject` typed `PARTY_IDENTIFIED` where RM ehr master04 mandates
+`PARTY_SELF` (a monomorphic slot). The audit's job is to find every remaining
+gap of that kind: places where the code is MORE LENIENT than the spec
+(accepts what must be rejected), LESS capable (mandated behaviour missing),
+or WRONG (different semantics). A green test suite is NOT evidence — leniency
+hides in openehr-derive (de)serialization, the validation walker,
+hand-written `*_impl.rs` files, service logic in `app/`, and the REST layer.
+Generated crates (`// @generated`) encode structure only.
+
+## Ground rules (repo hard rules — non-negotiable)
+
+- The vendored spec text at `docs/specs/openehr/` is the ONLY authority.
+  Never answer from memory or from EHRbase behaviour. Every requirement and
+  finding cites file + section.
+- Never hand-edit a `// @generated` file (fix the emitter in
+  `crates/openehr-codegen` and regenerate).
+- Never weaken, skip, or delete a test. Never edit an ECC case to route
+  around a finding.
+- No AI/Claude attribution in any commit, PR, or file. Branches are
+  `claude/*`.
+- ONE cargo command at a time in the main session; any agent that must build
+  uses an isolated `CARGO_TARGET_DIR` under /tmp and deletes it afterwards.
+  Audit-phase agents are READ-ONLY on code.
+- Work on branch `claude/a1-spec-audit` cut from up-to-date `develop`. Read
+  `docs/plans/x1-comparison.md` and
+  `docs/conformance/upstream-ehrbase/TRIAGE.md` first for the PARTY_SELF
+  background; check whether branch `claude/x1-upstream-run` (or develop)
+  already fixed it — do not duplicate that work.
+
+## DURABLE LOGGING — the most important process requirement
+
+Every agent's findings must be persisted to disk the moment they exist, so
+nothing is lost to context limits or crashes. Structure (all files committed
+on the audit branch, incrementally — commit after each phase, not only at the
+end):
+
+```
+docs/spec-audit/README.md                  index: methodology, date, per-chapter status table
+docs/spec-audit/<chapter>/requirements.md  Phase-1 output: numbered requirements + citations
+docs/spec-audit/<chapter>/verification.md  Phase-2 output: per-requirement verdict table
+                                           (classification, code file:line evidence, severity,
+                                           negative-test-exists?, fix sketch)
+docs/spec-audit/<chapter>/skeptic.md       Phase-3 output: per-finding confirmed/refuted/
+                                           uncertain + reasoning
+docs/spec-audit/FINDINGS.md                the consolidated register: every confirmed defect
+                                           (id, severity, spec citation, code location, fix
+                                           status) + every uncertain finding with the exact
+                                           runtime probe it needs
+```
+
+Have each workflow agent BOTH return structured JSON (use schemas) AND Write
+its chapter file directly (distinct paths per chapter = no write conflicts).
+The orchestrator commits after each phase so partial progress survives
+anything.
+
+## The workflow (3 audit phases + orchestrated fix wave)
+
+**Phase 1 — Extract** (one agent per chapter, model 'opus', effort 'high',
+parallel via pipeline): Read the WHOLE chapter text. Extract
+machine-checkable normative requirements: class invariants, mandatory
+attributes + exact declared types (monomorphic slots especially),
+cardinality/occurrence rules, validity functions, mandated behaviours
+(versioning rules, status codes, header rules) and above all REJECTION
+DUTIES ("must reject X" rules are the highest value). Skip prose philosophy.
+Cap ~70/chapter, keep the highest-risk. Number them `<chapter>-R1`…
+
+**Phase 2 — Verify** (same pipeline, second stage, 'opus'/'high'): for each
+requirement, find the ENFORCEMENT SITE in the code (a struct field existing
+does not prove runtime rejection). Classify: `verified` (file:line of the
+enforcement) / `defect` (code contradicts spec or accepts what must be
+rejected) / `missing` / `partial` (enforced on some paths only — e.g.
+composition commit but not EHR_STATUS PUT) / `not-statically-checkable`
+(name the exact runtime probe). Also record whether a negative test exists
+for every "must reject" rule. Severity: critical (write-path integrity /
+missing mandated rejection) > major (conformance-visible) > minor.
+
+**Phase 3 — Skeptic** (barrier: collect all suspected defect/missing/partial
+findings, then one adversarial agent per chapter-with-findings,
+'opus'/'high'): try to REFUTE each finding — re-read the cited spec section
+(misread? SHOULD vs MUST? another clause relaxes it?), re-read the code (is
+it enforced in another layer: derive, walker, REST extractor, DB
+constraint?). `refuted` requires concrete evidence; survivors = `confirmed`;
+statically undecidable = `uncertain` + exact probe.
+
+**Fix wave** (after the workflow returns — orchestrator-controlled, NOT
+inside the workflow):
+
+1. Write FINDINGS.md; review every confirmed defect yourself; present the
+   owner a summary table (count by severity/chapter) BEFORE fixing.
+2. Fix confirmed defects in severity order via implementer agents (worktree
+   isolation if parallel; spec citations in every prompt; regression test per
+   fix — negative tests for every leniency fix). Derive/emitter-level fixes
+   (systemic `_type` strictness etc.) get extra care: run the FULL workspace
+   suite + the openehr-its fidelity gates; investigate any corpus fallout
+   honestly.
+3. Uncertain findings: write + run the named runtime probes (testcontainers
+   PG18), reclassify.
+4. Gates after the wave: `cargo nextest run --workspace` green; clippy clean;
+   full ECC via `scripts/conformance.sh` — pass/fail must only IMPROVE from
+   341/315/0; any newly-failing ECC case means our suite was asserting a bug —
+   fix the server, never the case.
+5. PR per logical chunk to develop, merge, then update `docs/PROGRESS.md` +
+   `docs/plans/` (phase file `a1-full-spec-audit.md`: create at start, tick
+   as you go) + `CHANGELOG.md` [Unreleased] for user-visible behaviour
+   changes (stricter validation IS user-visible).
+
+## Chapter map (spec paths under docs/specs/openehr/ · code map to start from)
+
+| # | Chapter | Spec | Code map |
+|---|---|---|---|
+| 1 | rm-common-change-control | RM/docs/common/master06 (+master05, audit parts) | app/ehrbase storage/service (vobject, contribution, versioning), openehr-rm/src/common |
+| 2 | rm-ehr | RM/docs/ehr/master03 + master04 (EHR, EHR_STATUS, EHR_ACCESS, VERSIONED_*) | app/ehrbase service, ehrbase-sm ehr*.rs, openehr-rm/src/ehr |
+| 3 | rm-composition | RM/docs/ehr/master05 + master06 (COMPOSITION/SECTION/ENTRY invariants) | openehr-rm composition+content, validation walker |
+| 4 | rm-data-structures | RM/docs/data_structures/master.adoc | openehr-rm/src/data_structures + *_impl.rs, validation |
+| 5 | rm-data-types-text-quantity | RM/docs/data_types/master03 + master04 (DV_TEXT/CODED_TEXT, DV_ORDERED/QUANTITY/PROPORTION/ORDINAL/SCALE incl. accuracy) | openehr-rm/src/data_types + *_impl.rs, ext.openehr_magnitude (migrations/ext/0001), validation |
+| 6 | rm-data-types-rest | RM/docs/data_types/master01+05+06+07+08 (basic, dates incl. partial precision, timespec, DV_MULTIMEDIA/PARSABLE, DV_URI) | same + app/ehrbase/src/multimedia |
+| 7 | rm-support | RM/docs/support/master.adoc (OBJECT_VERSION_ID etc, terminology interfaces) | openehr-rm/src/support + *_impl.rs, id handling in app |
+| 8 | rm-demographic | RM/docs/demographic/master.adoc | openehr-rm demographic, app demographic service + routes |
+| 9 | rm-ehr-extract | RM/docs/ehr_extract/master.adoc | openehr-rm ehr_extract, message/extract service (SM-5) |
+| 10 | rm-integration | RM/docs/integration/master.adoc (GENERIC_ENTRY, FEEDER_AUDIT) | openehr-rm integration, fhir service provenance |
+| 11 | base-foundation | BASE/docs/foundation_types/master.adoc (Interval/Multiplicity_interval/Cardinality functions, ISO8601 validity) | openehr-base foundation_types + *_impl.rs |
+| 12 | base-base-types | BASE/docs/base_types/master.adoc (base classes, TERMINOLOGY_CODE, identifier equality/case) | openehr-base base_types + *_impl.rs, storage canonicalisation |
+| 13 | am-aom14-opt | AM/docs AOM1.4/ADL1.4/OPT14 (C_OBJECT occurrences, C_ATTRIBUTE existence/cardinality, C_DV_*, ARCHETYPE_SLOT, CONSTRAINT_REF) | openehr-am am14+opt14, openehr-flat validation/webtemplate (the constraint evaluator) |
+| 14 | am-aom2-adl2 | AM AOM2+ADL2 masters (validity codes VCOC/VACMCO/VATID…) | openehr-am am24, ADL2 store + ingestion validity |
+| 15 | term | TERM/docs (+ support terminology interfaces) | openehr-term, terminology service + providers |
+| 16 | query-aql | QUERY/docs master03 + grammar (CONTAINS, paths, operators/matches, functions, ORDER BY over DV_ORDERED, LIMIT/OFFSET, parameters, TERMINOLOGY()) | openehr-query, app AQL engine (IR + SQL lowering) |
+| 17 | sm-platform | SM/docs/openehr_platform master02 (transactional equivalence) + master03..12 (interface pre/post-conditions, CALL_STATUS) | ehrbase-sm services (the literal catalog) + Platform impl |
+| 18 | sm-tdd | SM TDS/TDD docs | openehr-flat from_tdd, message import_tdd |
+| 19 | its-rest-general | vendored overview OAS + shared components (auth, negotiation, Prefer, ETag/Last-Modified/Location, openEHR-VERSION/AUDIT_DETAILS committal headers, status vocabulary) | ehrbase-rest (negotiation/headers/errors), openehr-its/src/rest |
+| 20 | its-rest-ehr-composition | ehr-html.openapi.yaml (every EHR/EHR_STATUS/VERSIONED_*/COMPOSITION/DIRECTORY/CONTRIBUTION op: params, schemas, status codes) | ehrbase-rest handlers + openehr-its rest/generated |
+| 21 | its-rest-query-definition-admin | query/definition/admin/demographic OAS bundles | ehrbase-rest handlers |
+| 22 | its-json | canonical JSON rules (_type discipline: when mandatory, subtype-in-supertype rules, MONOMORPHIC SLOT STRICTNESS, empty omission, number formats) | openehr-derive (the derive), openehr-its/src/json |
+| 23 | its-xml | XSDs + canonical XML (element order, xsi:type discipline, attributes, namespaces) | openehr-codegen xml emitter, openehr-its/src/xml |
+| 24 | cnf-cross-check | CNF/docs/platform_test_schedule + Robot fixtures: sample 20 normative cases NOT covered by our ECC catalogue (tools/conformance) and verify server behaviour statically | tools/conformance + the relevant handlers |
+
+## Final deliverable (single message at the end)
+
+The audit register summary: chapters audited, requirements
+extracted/verified counts, confirmed defects by severity with the top 10
+detailed (citation + location), what was fixed + gate results (workspace
+tests, ECC delta), uncertain findings still open with their probes, and the
+PR list.
+
+---
+
+## The small launch prompt (send this in the fresh session)
+
+> Read `docs/plans/a1-spec-audit-PROMPT.md` and execute it exactly as
+> written — it is the full brief for the A1 spec audit. Start now, work
+> autonomously through the audit phases, and pause for my review at the
+> point the brief marks (after FINDINGS.md, before the fix wave).

--- a/tools/conformance/src/suites/definition_adl14.rs
+++ b/tools/conformance/src/suites/definition_adl14.rs
@@ -404,7 +404,10 @@ async fn upload_opt(ctx: &RunContext<'_>, xml: String) -> Result<u16, CaseError>
         .send(
             HttpRequest::post("/definition/template/adl1.4")
                 .text_body(xml, "application/xml")
-                .header("accept", "application/json"),
+                // ITS-REST `definition_template_adl1.4_upload` produces
+                // `application/xml` only and declares no `Accept` parameter;
+                // `application/json` is a strict 406.
+                .header("accept", "application/xml"),
         )
         .await?;
     Ok(resp.status)

--- a/tools/conformance/src/suites/ehr.rs
+++ b/tools/conformance/src/suites/ehr.rs
@@ -437,8 +437,12 @@ fn ehr_status_row(row: (bool, bool, bool, bool), subject_id: &str) -> Value {
         "_type": "EHR_STATUS",
         "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
         "name": { "_type": "DV_TEXT", "value": "EHR Status" },
+        // EHR_STATUS.subject is a PARTY_SELF (RM ehr master04 §EHR Status), carrying
+        // an external_ref to identify the subject. A foreign concrete _type
+        // (PARTY_IDENTIFIED) in this monomorphic slot is invalid and the server
+        // now rejects it — this fixture must post the spec-correct PARTY_SELF.
         "subject": {
-            "_type": "PARTY_IDENTIFIED",
+            "_type": "PARTY_SELF",
             "external_ref": {
                 "_type": "PARTY_REF",
                 "namespace": "conformance",
@@ -678,10 +682,18 @@ fn run_clear_ehr_modifiable_bad<'a>(ctx: &'a RunContext<'a>) -> CaseFuture<'a> {
 fn run_create_ehr_invalid_status<'a>(ctx: &'a RunContext<'a>) -> CaseFuture<'a> {
     case!({
         let invalid = fixtures::ehr_invalid().map_err(|e| CaseError::Codec(e.to_string()))?;
+        // Corpus-vs-spec adjudication: `001_ehr_status_subject_empty.json`
+        // (`subject: {}`) is labelled "invalid" by the CNF corpus but is
+        // spec-valid — RM ehr master04 §EHR Status makes an empty PARTY_SELF a
+        // completely anonymous subject. Per the vendored spec oracle (ADR-008)
+        // this fixture must be *accepted*, not rejected; the other ten stay
+        // negative. See `docs/conformance/upstream-ehrbase/TRIAGE.md` §B2.
+        const SPEC_VALID_ANONYMOUS: &str = "001_ehr_status_subject_empty.json";
         let mut passed = 0u32;
         let mut total = 0u32;
         for fixture in invalid {
             total += 1;
+            let expect_accept = fixture.name == SPEC_VALID_ANONYMOUS;
             let body = fixture
                 .json()
                 .map_err(|e| CaseError::Codec(e.to_string()))?;
@@ -693,9 +705,15 @@ fn run_create_ehr_invalid_status<'a>(ctx: &'a RunContext<'a>) -> CaseFuture<'a> 
                         .header("prefer", "return=minimal"),
                 )
                 .await?;
-            // An invalid EHR_STATUS must be rejected (4xx): 400 (malformed) or
-            // 422 (RM/terminology validation).
-            if (400..500).contains(&resp.status) {
+            let ok = if expect_accept {
+                // Anonymous PARTY_SELF → EHR created (2xx).
+                (200..300).contains(&resp.status)
+            } else {
+                // An invalid EHR_STATUS must be rejected (4xx): 400 (malformed) or
+                // 422 (RM/terminology validation).
+                (400..500).contains(&resp.status)
+            };
+            if ok {
                 passed += 1;
             }
         }
@@ -703,7 +721,8 @@ fn run_create_ehr_invalid_status<'a>(ctx: &'a RunContext<'a>) -> CaseFuture<'a> 
             Ok(DataSetReport { passed, total })
         } else {
             Err(CaseError::Assertion(format!(
-                "{passed}/{total} invalid EHR_STATUS data sets were rejected (the rest were accepted)"
+                "{passed}/{total} EHR_STATUS data sets got the expected outcome \
+                 (10 invalid → 4xx, 1 spec-valid anonymous → 2xx)"
             )))
         }
     })

--- a/tools/conformance/src/suites/support.rs
+++ b/tools/conformance/src/suites/support.rs
@@ -55,7 +55,12 @@ pub async fn ensure_opt(ctx: &RunContext<'_>, opt_rel: &str) -> Result<(), CaseE
         .send(
             HttpRequest::post("/definition/template/adl1.4")
                 .text_body(xml, "application/xml")
-                .header("accept", "application/json"),
+                // ITS-REST `definition_template_adl1.4_upload` declares NO `Accept`
+                // parameter and produces `application/xml` only (the 201 body is an
+                // `OperationalTemplate`); requesting `application/json` is a strict
+                // 406 (see `operations/definition_template_adl1.4_upload.yaml` +
+                // `responses/201_Template_adl1_4_upload.yaml`).
+                .header("accept", "application/xml"),
         )
         .await?;
     if (200..300).contains(&resp.status) || resp.status == 409 {
@@ -87,7 +92,8 @@ pub async fn ensure_opt_xml(ctx: &RunContext<'_>, xml: &str) -> Result<(), CaseE
         .send(
             HttpRequest::post("/definition/template/adl1.4")
                 .text_body(xml.to_owned(), "application/xml")
-                .header("accept", "application/json"),
+                // XML-only upload endpoint (no `Accept` param) — see `ensure_opt`.
+                .header("accept", "application/xml"),
         )
         .await?;
     if (200..300).contains(&resp.status) || resp.status == 409 {


### PR DESCRIPTION
Fixes the compliance findings from the upstream EHRbase Java 2.34.0 diff (`docs/conformance/upstream-ehrbase/TRIAGE.md`):

- **B1** — `EHR_STATUS.subject` is a monomorphic `PARTY_SELF` slot (RM ehr master04 §EHR Status). `validate_ehr_status` now deserializes the subject through the generated `PartySelf` type, whose `OpenEhrType` `_type` check rejects a foreign concrete `_type` (e.g. `PARTY_IDENTIFIED`). Covered by unit tests plus an end-to-end service test on both EHR create and EHR_STATUS PUT.
- **B2** — an empty `{}` subject is the spec's *completely anonymous* `PARTY_SELF` and is now accepted. The CNF corpus fixture `001_ehr_status_subject_empty.json` is labelled invalid but is spec-valid — adjudicated in the fixture test and the ECC create-invalid-status case (asserted accepted; the other ten stay asserted-rejected).
- **R2** — ECC EHR fixtures (`ehr_status_row`) now post the spec-correct `PARTY_SELF` subject instead of `PARTY_IDENTIFIED`.
- **R1/D** — the conformance OPT upload now requests `Accept: application/xml`: the ITS-REST upload operation declares no `Accept` parameter and produces XML only (`operations/definition_template_adl1.4_upload.yaml`). Unblocks the VAL/COM/CTB/TPL depth comparison against upstream.
- `openehr-rm` `type_dispatch` tests pin the monomorphic-slot derive behaviour (foreign `_type` rejected, absent `_type` defaults to the declared type).
- Doc-comment backtick lint fixes riding along.