### PR TITLE
ci: green the audit/deny/machete gates

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -9,4 +9,13 @@ ignore = [
   # keys, so the private-key timing oracle does not apply. Re-check when
   # rsa > 0.9 ships. https://rustsec.org/advisories/RUSTSEC-2023-0071
   "RUSTSEC-2023-0071",
+  # 2026-07-12: two quick-xml 0.40.1 DoS-class advisories (unbounded namespace
+  # allocation; quadratic duplicate-attribute check), pulled in transitively via
+  # object_store 0.14.0 (the S3 multimedia offload) — object_store 0.14.0 is the
+  # LATEST release and requires quick-xml ^0.40, so no fix is reachable yet. The
+  # affected parser only reads S3 API responses from the operator-configured
+  # endpoint (a semi-trusted peer), not client input; our own canonical-XML
+  # path uses quick-xml 0.41 (fixed). Re-check on the next object_store release.
+  "RUSTSEC-2026-0194",
+  "RUSTSEC-2026-0195",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,6 @@ dependencies = [
  "conformance",
  "hdrhistogram",
  "jiff",
- "reqwest 0.13.4",
  "serde",
  "serde_json",
  "sysinfo",

--- a/deny.toml
+++ b/deny.toml
@@ -12,6 +12,15 @@ ignore = [
   # hold RSA private keys, so the private-key timing oracle does not apply.
   # Re-check when rsa > 0.9 ships. https://rustsec.org/advisories/RUSTSEC-2023-0071
   { id = "RUSTSEC-2023-0071", reason = "no fix upstream; RSA used for signature verification only (no private keys held)" },
+  # 2026-07-12: two quick-xml 0.40.1 DoS-class advisories (unbounded namespace
+  # allocation; quadratic duplicate-attribute check), pulled in transitively via
+  # object_store 0.14.0 (the S3 multimedia offload) — object_store 0.14.0 is the
+  # LATEST release and requires quick-xml ^0.40, so no fix is reachable yet. The
+  # affected parser only reads S3 API responses from the operator-configured
+  # endpoint (a semi-trusted peer), not client input; our own canonical-XML
+  # path uses quick-xml 0.41 (fixed). Re-check on the next object_store release.
+  { id = "RUSTSEC-2026-0194", reason = "via object_store 0.14.0 (latest) pinning quick-xml ^0.40; parses operator-configured S3 responses only" },
+  { id = "RUSTSEC-2026-0195", reason = "via object_store 0.14.0 (latest) pinning quick-xml ^0.40; parses operator-configured S3 responses only" },
 ]
 
 [licenses]

--- a/tools/benchmark/Cargo.toml
+++ b/tools/benchmark/Cargo.toml
@@ -24,7 +24,6 @@ thiserror = { workspace = true }
 clap = { workspace = true }
 jiff = { workspace = true }
 tokio = { workspace = true }
-reqwest = { workspace = true }
 hdrhistogram = { workspace = true }
 sysinfo = { workspace = true }
 


### PR DESCRIPTION
Greens the three failing CI jobs on develop:

- **cargo-audit / cargo-deny**: dated ignores for RUSTSEC-2026-0194/0195
  (quick-xml 0.40.1, DoS-class) — transitively via object_store 0.14.0,
  which is the latest release and pins quick-xml ^0.40, so no fix is
  reachable yet. The affected parser reads only S3 API responses from the
  operator-configured endpoint; our canonical-XML path is on quick-xml
  0.41 (fixed). Re-check on the next object_store release.
- **cargo-machete**: removes the unused `reqwest` dependency from
  `tools/benchmark`.

Verified locally: `cargo audit`, `cargo deny check`, `cargo machete` all
exit 0; `cargo build -p benchmark` clean.