### PR TITLE
release: v3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+## [3.0.1] - 2026-07-14
+
 ### Added
 
 - The server now prints an ASCII-art startup banner to stdout before the
@@ -464,5 +466,6 @@ but has not yet run in production.
 - Helm chart with security-hardened defaults (non-root, read-only rootfs,
   seccomp, default-deny NetworkPolicy) and golden-render validation.
 
-[unreleased]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.0.0...HEAD
+[unreleased]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.0.1...HEAD
+[3.0.1]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.0.0...v3.0.1
 [3.0.0]: https://github.com/rubentalstra/ehrbase-rs/releases/tag/v3.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,7 +623,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "benchmark"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -1257,7 +1257,7 @@ dependencies = [
 
 [[package]]
 name = "conformance"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1958,7 +1958,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2022,7 +2022,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase-rest"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase-sm"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "async-trait",
  "jiff",
@@ -4233,7 +4233,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-codegen"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "roxmltree",
  "serde_json",
@@ -4242,7 +4242,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-derive"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4253,7 +4253,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-flat"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "fancy-regex",
  "indexmap 2.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "3"                      # resolver v3 (edition 2024)
 members = ["crates/*", "app/*", "tools/*"]
 
 [workspace.package]
-version = "3.0.0"
+version = "3.0.1"
 edition = "2024"
 rust-version = "1.96"
 license = "Apache-2.0"

--- a/deploy/helm/ehrbase-rs/Chart.yaml
+++ b/deploy/helm/ehrbase-rs/Chart.yaml
@@ -9,9 +9,9 @@ description: >-
 type: application
 
 # Chart versioning is independent of the application version.
-version: 3.0.0
+version: 3.0.1
 # The default container image tag (informational; overridable via image.tag).
-appVersion: "3.0.0"
+appVersion: "3.0.1"
 
 # PDB (policy/v1, GA 1.21), HPA (autoscaling/v2, GA 1.23), and the
 # seccompProfile pod field (GA 1.27) all resolve cleanly at 1.25+.

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -9,10 +9,10 @@ kind: NetworkPolicy
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.0
+    helm.sh/chart: ehrbase-rs-3.0.1
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.0"
+    app.kubernetes.io/version: "3.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -55,10 +55,10 @@ kind: PodDisruptionBudget
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.0
+    helm.sh/chart: ehrbase-rs-3.0.1
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.0"
+    app.kubernetes.io/version: "3.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -74,10 +74,10 @@ kind: ServiceAccount
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.0
+    helm.sh/chart: ehrbase-rs-3.0.1
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.0"
+    app.kubernetes.io/version: "3.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
   annotations:
@@ -93,10 +93,10 @@ kind: Secret
 metadata:
   name: ehrbase-rs-env
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.0
+    helm.sh/chart: ehrbase-rs-3.0.1
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.0"
+    app.kubernetes.io/version: "3.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 type: Opaque
@@ -116,10 +116,10 @@ kind: Secret
 metadata:
   name: ehrbase-rs-config
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.0
+    helm.sh/chart: ehrbase-rs-3.0.1
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.0"
+    app.kubernetes.io/version: "3.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 type: Opaque
@@ -141,10 +141,10 @@ kind: ConfigMap
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.0
+    helm.sh/chart: ehrbase-rs-3.0.1
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.0"
+    app.kubernetes.io/version: "3.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 data:
@@ -246,10 +246,10 @@ kind: Service
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.0
+    helm.sh/chart: ehrbase-rs-3.0.1
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.0"
+    app.kubernetes.io/version: "3.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -273,10 +273,10 @@ kind: Deployment
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.0
+    helm.sh/chart: ehrbase-rs-3.0.1
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.0"
+    app.kubernetes.io/version: "3.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -288,7 +288,7 @@ spec:
     metadata:
       annotations:
         # Roll pods when the non-secret config changes.
-        checksum/config: a4bb3107995058f4c2c784da76fef4a76b345aa78d9c74f2f3c089e3f6479474
+        checksum/config: 206341529c713c57e44dace164c2a3af4865404e117c43e8e982cc2f7166c124
         prometheus.io/scrape: "true"
         prometheus.io/port: "9100"
         prometheus.io/path: "/management/prometheus"
@@ -309,7 +309,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ehrbase
-          image: "ghcr.io/rubentalstra/ehrbase-rs:3.0.0"
+          image: "ghcr.io/rubentalstra/ehrbase-rs:3.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -424,10 +424,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.0
+    helm.sh/chart: ehrbase-rs-3.0.1
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.0"
+    app.kubernetes.io/version: "3.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -457,10 +457,10 @@ kind: Ingress
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.0
+    helm.sh/chart: ehrbase-rs-3.0.1
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.0"
+    app.kubernetes.io/version: "3.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -9,10 +9,10 @@ kind: NetworkPolicy
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.0
+    helm.sh/chart: ehrbase-rs-3.0.1
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.0"
+    app.kubernetes.io/version: "3.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -33,10 +33,10 @@ kind: PodDisruptionBudget
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.0
+    helm.sh/chart: ehrbase-rs-3.0.1
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.0"
+    app.kubernetes.io/version: "3.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -52,10 +52,10 @@ kind: ServiceAccount
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.0
+    helm.sh/chart: ehrbase-rs-3.0.1
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.0"
+    app.kubernetes.io/version: "3.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 automountServiceAccountToken: false
@@ -66,10 +66,10 @@ kind: ConfigMap
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.0
+    helm.sh/chart: ehrbase-rs-3.0.1
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.0"
+    app.kubernetes.io/version: "3.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 data:
@@ -145,10 +145,10 @@ kind: Service
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.0
+    helm.sh/chart: ehrbase-rs-3.0.1
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.0"
+    app.kubernetes.io/version: "3.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -168,10 +168,10 @@ kind: Deployment
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.0
+    helm.sh/chart: ehrbase-rs-3.0.1
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.0"
+    app.kubernetes.io/version: "3.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -184,7 +184,7 @@ spec:
     metadata:
       annotations:
         # Roll pods when the non-secret config changes.
-        checksum/config: e7d00eb3e544bee9d28e4eb05df35adc853af896798004d28f036ee4ec850d37
+        checksum/config: ecfd98843634aaa3ce855735e4c14bc2254d2b74a5fb318f45adbf0dae31ac5f
       labels:
         app.kubernetes.io/name: ehrbase-rs
         app.kubernetes.io/instance: ehrbase-rs
@@ -202,7 +202,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ehrbase
-          image: "ghcr.io/rubentalstra/ehrbase-rs:3.0.0"
+          image: "ghcr.io/rubentalstra/ehrbase-rs:3.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
Cuts the v3.0.1 release: the `[Unreleased]` changelog section becomes `[3.0.1] - 2026-07-14`, the workspace version and Helm `version`/`appVersion` bump to 3.0.1, and the golden renders are regenerated (`deploy/helm/validate.sh --update`, all checks passed).

After merge, `v3.0.1` is tagged on the merge commit; the release workflow publishes the GitHub Release from the matching changelog section (prerelease until production sign-off).

Release content: the P20 optimization phase (see #87) — measured ehrbase-rs knee 161.9 → 396.9 req/s (2.45×) on the fully-populated workload, composition validation ~8× faster with byte-identical outcomes, ECC 370·335·0 CORE+STANDARD PASS held at zero drift.