### PR TITLE
ci: serialize + single-retry the container-backed test binaries

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,14 +1,20 @@
 # Workspace nextest configuration.
 #
-# The AMQP integration tests (RabbitMQ + PostgreSQL testcontainers per test)
-# are serialized into one group: under a full-workspace run dozens of
-# containers otherwise start concurrently and broker-delivery deadlines flake
-# on host contention (observed 2026-07-13: fhir_outbound_amqp failed at 42s
-# under load, passes in 8s in isolation). Their delivery assertions are
-# unchanged — only scheduling is constrained.
-[test-groups.amqp]
+# The container-backed integration tests (RabbitMQ, SeaweedFS + PostgreSQL
+# testcontainers per test) are serialized into one group: under a
+# full-workspace run dozens of containers otherwise start concurrently and
+# broker-delivery / gateway-readiness deadlines flake on host contention
+# (observed 2026-07-13: fhir_outbound_amqp failed at 42s under load, passes
+# in 8s in isolation; 2026-07-14: events_amqp broker_down_then_up and
+# multimedia_s3 blob_store_round_trips each flaked once on shared CI runners
+# and passed on rerun). Assertions are unchanged — only scheduling is
+# constrained, plus ONE retry so a single container-startup hiccup on a
+# loaded runner doesn't fail the suite. A genuine regression still fails:
+# it fails both attempts, deterministically.
+[test-groups.containers]
 max-threads = 1
 
 [[profile.default.overrides]]
-filter = 'binary(events_amqp) | binary(fhir_outbound_amqp)'
-test-group = 'amqp'
+filter = 'binary(events_amqp) | binary(fhir_outbound_amqp) | binary(multimedia_s3)'
+test-group = 'containers'
+retries = 1


### PR DESCRIPTION
Two one-off CI failures on trees that passed identical code elsewhere: `events_amqp::broker_down_then_up_delivers_without_loss` (PR #87's run) and `multimedia_s3::blob_store_round_trips_against_seaweedfs` (PR #90's run). Both are testcontainers-startup nondeterminism on loaded shared runners — each passed locally in the full 1623-test sweep and on CI rerun.

The existing `amqp` serialization group (added 2026-07-13 for the same failure class) widens to all container-heavy binaries (`multimedia_s3` joins) and gains `retries = 1`. Assertions are untouched; a genuine regression fails both attempts deterministically.