### PR TITLE
release: v3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+## [3.0.2] - 2026-07-15
+
 ### Changed
 
 - The benchmark instrument measures both comparison stacks under a fairer,
@@ -541,6 +543,7 @@ but has not yet run in production.
 - Helm chart with security-hardened defaults (non-root, read-only rootfs,
   seccomp, default-deny NetworkPolicy) and golden-render validation.
 
-[unreleased]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.0.1...HEAD
+[unreleased]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.0.2...HEAD
+[3.0.2]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.0.1...v3.0.2
 [3.0.1]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.0.0...v3.0.1
 [3.0.0]: https://github.com/rubentalstra/ehrbase-rs/releases/tag/v3.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,7 +634,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "benchmark"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "conformance"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2053,7 +2053,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -2119,7 +2119,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase-rest"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -2164,7 +2164,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase-sm"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "async-trait",
  "jiff",
@@ -4380,7 +4380,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-codegen"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "roxmltree",
  "serde_json",
@@ -4389,7 +4389,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-derive"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4400,7 +4400,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-flat"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "fancy-regex",
  "indexmap 2.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "3"                      # resolver v3 (edition 2024)
 members = ["crates/*", "app/*", "tools/*"]
 
 [workspace.package]
-version = "3.0.1"
+version = "3.0.2"
 edition = "2024"
 rust-version = "1.96"
 license = "Apache-2.0"

--- a/deploy/helm/ehrbase-rs/Chart.yaml
+++ b/deploy/helm/ehrbase-rs/Chart.yaml
@@ -9,9 +9,9 @@ description: >-
 type: application
 
 # Chart versioning is independent of the application version.
-version: 3.0.1
+version: 3.0.2
 # The default container image tag (informational; overridable via image.tag).
-appVersion: "3.0.1"
+appVersion: "3.0.2"
 
 # PDB (policy/v1, GA 1.21), HPA (autoscaling/v2, GA 1.23), and the
 # seccompProfile pod field (GA 1.27) all resolve cleanly at 1.25+.

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -9,10 +9,10 @@ kind: NetworkPolicy
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.1
+    helm.sh/chart: ehrbase-rs-3.0.2
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.1"
+    app.kubernetes.io/version: "3.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -55,10 +55,10 @@ kind: PodDisruptionBudget
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.1
+    helm.sh/chart: ehrbase-rs-3.0.2
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.1"
+    app.kubernetes.io/version: "3.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -74,10 +74,10 @@ kind: ServiceAccount
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.1
+    helm.sh/chart: ehrbase-rs-3.0.2
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.1"
+    app.kubernetes.io/version: "3.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
   annotations:
@@ -93,10 +93,10 @@ kind: Secret
 metadata:
   name: ehrbase-rs-env
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.1
+    helm.sh/chart: ehrbase-rs-3.0.2
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.1"
+    app.kubernetes.io/version: "3.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 type: Opaque
@@ -117,10 +117,10 @@ kind: Secret
 metadata:
   name: ehrbase-rs-config
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.1
+    helm.sh/chart: ehrbase-rs-3.0.2
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.1"
+    app.kubernetes.io/version: "3.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 type: Opaque
@@ -136,10 +136,10 @@ kind: ConfigMap
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.1
+    helm.sh/chart: ehrbase-rs-3.0.2
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.1"
+    app.kubernetes.io/version: "3.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 data:
@@ -285,10 +285,10 @@ kind: Service
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.1
+    helm.sh/chart: ehrbase-rs-3.0.2
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.1"
+    app.kubernetes.io/version: "3.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -312,10 +312,10 @@ kind: Deployment
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.1
+    helm.sh/chart: ehrbase-rs-3.0.2
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.1"
+    app.kubernetes.io/version: "3.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -327,7 +327,7 @@ spec:
     metadata:
       annotations:
         # Roll pods when the rendered ehrbase.toml changes.
-        checksum/config: f106c18afbf5d007a90948cc1c5ee78c872c1edbbf3c416e46ea0bfed8bce9a6
+        checksum/config: 54c6a9296375f7108ed14fe8131f12d169c90b5a791e7bde21b2e410a82a64dc
         prometheus.io/scrape: "true"
         prometheus.io/port: "9100"
         prometheus.io/path: "/management/prometheus"
@@ -348,7 +348,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ehrbase
-          image: "ghcr.io/rubentalstra/ehrbase-rs:3.0.1"
+          image: "ghcr.io/rubentalstra/ehrbase-rs:3.0.2"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -467,10 +467,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.1
+    helm.sh/chart: ehrbase-rs-3.0.2
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.1"
+    app.kubernetes.io/version: "3.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -500,10 +500,10 @@ kind: Ingress
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.1
+    helm.sh/chart: ehrbase-rs-3.0.2
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.1"
+    app.kubernetes.io/version: "3.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -9,10 +9,10 @@ kind: NetworkPolicy
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.1
+    helm.sh/chart: ehrbase-rs-3.0.2
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.1"
+    app.kubernetes.io/version: "3.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -33,10 +33,10 @@ kind: PodDisruptionBudget
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.1
+    helm.sh/chart: ehrbase-rs-3.0.2
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.1"
+    app.kubernetes.io/version: "3.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -52,10 +52,10 @@ kind: ServiceAccount
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.1
+    helm.sh/chart: ehrbase-rs-3.0.2
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.1"
+    app.kubernetes.io/version: "3.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 automountServiceAccountToken: false
@@ -66,10 +66,10 @@ kind: ConfigMap
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.1
+    helm.sh/chart: ehrbase-rs-3.0.2
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.1"
+    app.kubernetes.io/version: "3.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 data:
@@ -162,10 +162,10 @@ kind: Service
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.1
+    helm.sh/chart: ehrbase-rs-3.0.2
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.1"
+    app.kubernetes.io/version: "3.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -185,10 +185,10 @@ kind: Deployment
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.1
+    helm.sh/chart: ehrbase-rs-3.0.2
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.1"
+    app.kubernetes.io/version: "3.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -201,7 +201,7 @@ spec:
     metadata:
       annotations:
         # Roll pods when the rendered ehrbase.toml changes.
-        checksum/config: 3f572465eefa86ef031e9152e68782e688a0d0e29f186b51b9510f73e3295677
+        checksum/config: 3bf0b723b61503bc653df58ac3cd28d78e894c76693a959b9bfd97677b669c5a
       labels:
         app.kubernetes.io/name: ehrbase-rs
         app.kubernetes.io/instance: ehrbase-rs
@@ -219,7 +219,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ehrbase
-          image: "ghcr.io/rubentalstra/ehrbase-rs:3.0.1"
+          image: "ghcr.io/rubentalstra/ehrbase-rs:3.0.2"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
Cuts v3.0.2: `[Unreleased]` → `[3.0.2] - 2026-07-15`, workspace + Helm versions bumped, goldens regenerated.

Release content (see #96): P20 hot-path elimination with full receipts, the native utoipa-axum REST surface + fixed Swagger UI, and the W-13 single-`ehrbase.toml` configuration redesign. Verified: ECC 370·335·0 zero drift, workspace 1642/1642, live image walkthrough.

After merge: `v3.0.2` tagged on the merge commit; the release workflow publishes from the changelog section.