### PR TITLE
Swagger: reference-style categorization + per-family spec selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,24 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Changed
+
+- The served OpenAPI documents now categorize operations the way the
+  official ITS-REST reference documents do: standard-group operations are
+  tagged by resource (EHR, EHR_STATUS, COMPOSITION, DIRECTORY, CONTRIBUTION,
+  ITEM_TAG; PERSON, AGENT, GROUP, ORGANISATION, ROLE, VERSIONED_PARTY;
+  ADL 1.4, ADL 2, Query) instead of one flat tag per API group, and the
+  Swagger UI spec selector offers one document per API family — the five
+  standardised openEHR groups and the seven server-extension families —
+  plus the complete composed surface, all filtered from the server's own
+  generated document.
+
+### Fixed
+
+- Duplicate-template-id fixture resolution in the validation corpus test is
+  now deterministic (sorted path order) instead of OS-dependent `read_dir`
+  order, fixing a Linux-only CI failure.
+
 ## [3.0.2] - 2026-07-15
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1447,7 +1447,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
 dependencies = [
  "digest 0.10.7",
- "spin 0.10.0",
+ "spin 0.10.1",
 ]
 
 [[package]]
@@ -2097,7 +2097,6 @@ dependencies = [
  "rustls",
  "sea-query",
  "sea-query-sqlx",
- "secrecy",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -2429,7 +2428,7 @@ checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -3660,7 +3659,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -6107,7 +6106,6 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
- "serde",
  "zeroize",
 ]
 
@@ -6544,18 +6542,18 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spki"

--- a/app/ehrbase-rest/src/api/admin/openapi_routes.rs
+++ b/app/ehrbase-rest/src/api/admin/openapi_routes.rs
@@ -29,7 +29,7 @@ pub(crate) fn routes<S: Platform>() -> OpenApiRouter<AppState<S>> {
 
 /// Physically delete every EHR named in the `ehr_id` query parameter.
 #[utoipa::path(
-    delete, path = "/admin/ehr/all", tag = "admin",
+    delete, path = "/admin/ehr/all", tag = "EHR",
     params(("ehr_id" = Vec<String>, Query, description = "The EHR ids to delete.")),
     responses((status = 204, description = "Deleted."))
 )]
@@ -49,7 +49,7 @@ pub(crate) async fn admin_ehr_delete_all<S: Platform>(
 
 /// Physically delete one EHR by id.
 #[utoipa::path(
-    delete, path = "/admin/ehr/{ehr_id}", tag = "admin",
+    delete, path = "/admin/ehr/{ehr_id}", tag = "EHR",
     params(("ehr_id" = String, Path, description = "The EHR id.")),
     responses((status = 204, description = "Deleted."))
 )]

--- a/app/ehrbase-rest/src/api/definition/openapi_routes.rs
+++ b/app/ehrbase-rest/src/api/definition/openapi_routes.rs
@@ -46,7 +46,7 @@ pub(crate) fn routes<S: Platform>() -> OpenApiRouter<AppState<S>> {
 
 /// List every stored ADL 1.4 operational template.
 #[utoipa::path(
-    get, path = "/definition/template/adl1.4", tag = "definition",
+    get, path = "/definition/template/adl1.4", tag = "ADL1.4",
     responses((status = 200, description = "The template ids.", body = serde_json::Value))
 )]
 pub(crate) async fn definition_template_adl1_4_list<S: Platform>(
@@ -65,7 +65,7 @@ pub(crate) async fn definition_template_adl1_4_list<S: Platform>(
 
 /// Upload an ADL 1.4 operational template (OPT XML).
 #[utoipa::path(
-    post, path = "/definition/template/adl1.4", tag = "definition",
+    post, path = "/definition/template/adl1.4", tag = "ADL1.4",
     responses((status = 201, description = "Template stored.", body = serde_json::Value))
 )]
 pub(crate) async fn definition_template_adl1_4_upload<S: Platform>(
@@ -84,7 +84,7 @@ pub(crate) async fn definition_template_adl1_4_upload<S: Platform>(
 
 /// Retrieve one ADL 1.4 template by id.
 #[utoipa::path(
-    get, path = "/definition/template/adl1.4/{template_id}", tag = "definition",
+    get, path = "/definition/template/adl1.4/{template_id}", tag = "ADL1.4",
     params(("template_id" = String, Path, description = "The template id.")),
     responses(
         (status = 200, description = "The template.", body = serde_json::Value),
@@ -107,7 +107,7 @@ pub(crate) async fn definition_template_adl1_4_get<S: Platform>(
 
 /// An example COMPOSITION for an ADL 1.4 template.
 #[utoipa::path(
-    get, path = "/definition/template/adl1.4/{template_id}/example", tag = "definition",
+    get, path = "/definition/template/adl1.4/{template_id}/example", tag = "ADL1.4",
     params(("template_id" = String, Path, description = "The template id.")),
     responses(
         (status = 200, description = "An example COMPOSITION.", body = serde_json::Value),
@@ -130,7 +130,7 @@ pub(crate) async fn definition_template_adl1_4_example_get<S: Platform>(
 
 /// List every stored ADL 2 template.
 #[utoipa::path(
-    get, path = "/definition/template/adl2", tag = "definition",
+    get, path = "/definition/template/adl2", tag = "ADL2",
     responses((status = 200, description = "The template ids.", body = serde_json::Value))
 )]
 pub(crate) async fn definition_template_adl2_list<S: Platform>(
@@ -149,7 +149,7 @@ pub(crate) async fn definition_template_adl2_list<S: Platform>(
 
 /// Upload an ADL 2 template.
 #[utoipa::path(
-    post, path = "/definition/template/adl2", tag = "definition",
+    post, path = "/definition/template/adl2", tag = "ADL2",
     responses((status = 201, description = "Template stored.", body = serde_json::Value))
 )]
 pub(crate) async fn definition_template_adl2_upload<S: Platform>(
@@ -168,7 +168,7 @@ pub(crate) async fn definition_template_adl2_upload<S: Platform>(
 
 /// Retrieve one ADL 2 template by id.
 #[utoipa::path(
-    get, path = "/definition/template/adl2/{template_id}", tag = "definition",
+    get, path = "/definition/template/adl2/{template_id}", tag = "ADL2",
     params(("template_id" = String, Path, description = "The template id.")),
     responses(
         (status = 200, description = "The template.", body = serde_json::Value),
@@ -191,7 +191,7 @@ pub(crate) async fn definition_template_adl2_get<S: Platform>(
 
 /// An example COMPOSITION for an ADL 2 template.
 #[utoipa::path(
-    get, path = "/definition/template/adl2/{template_id}/example", tag = "definition",
+    get, path = "/definition/template/adl2/{template_id}/example", tag = "ADL2",
     params(("template_id" = String, Path, description = "The template id.")),
     responses(
         (status = 200, description = "An example COMPOSITION.", body = serde_json::Value),
@@ -214,7 +214,7 @@ pub(crate) async fn definition_template_adl2_example_get<S: Platform>(
 
 /// Retrieve one ADL 2 template at a specific version.
 #[utoipa::path(
-    get, path = "/definition/template/adl2/{template_id}/{version}", tag = "definition",
+    get, path = "/definition/template/adl2/{template_id}/{version}", tag = "ADL2",
     params(
         ("template_id" = String, Path, description = "The template id."),
         ("version" = String, Path, description = "The template version.")
@@ -240,7 +240,7 @@ pub(crate) async fn definition_template_adl2_version_get<S: Platform>(
 
 /// List the stored versions of a named stored query.
 #[utoipa::path(
-    get, path = "/definition/query/{qualified_query_name}", tag = "definition",
+    get, path = "/definition/query/{qualified_query_name}", tag = "Query",
     params(("qualified_query_name" = String, Path, description = "The qualified stored-query name.")),
     responses(
         (status = 200, description = "The stored query versions.", body = serde_json::Value),
@@ -257,7 +257,7 @@ pub(crate) async fn definition_query_list<S: Platform>(
 
 /// Store a named AQL query (auto-versioned).
 #[utoipa::path(
-    put, path = "/definition/query/{qualified_query_name}", tag = "definition",
+    put, path = "/definition/query/{qualified_query_name}", tag = "Query",
     params(("qualified_query_name" = String, Path, description = "The qualified stored-query name.")),
     responses((status = 200, description = "Stored.", body = serde_json::Value))
 )]
@@ -277,7 +277,7 @@ pub(crate) async fn definition_query_store_yaml<S: Platform>(
 
 /// Retrieve a named stored query at a specific version.
 #[utoipa::path(
-    get, path = "/definition/query/{qualified_query_name}/{version}", tag = "definition",
+    get, path = "/definition/query/{qualified_query_name}/{version}", tag = "Query",
     params(
         ("qualified_query_name" = String, Path, description = "The qualified stored-query name."),
         ("version" = String, Path, description = "The stored-query version.")
@@ -303,7 +303,7 @@ pub(crate) async fn definition_query_version_get<S: Platform>(
 
 /// Store a named AQL query at a specific version.
 #[utoipa::path(
-    put, path = "/definition/query/{qualified_query_name}/{version}", tag = "definition",
+    put, path = "/definition/query/{qualified_query_name}/{version}", tag = "Query",
     params(
         ("qualified_query_name" = String, Path, description = "The qualified stored-query name."),
         ("version" = String, Path, description = "The stored-query version.")

--- a/app/ehrbase-rest/src/api/demographic/openapi_routes.rs
+++ b/app/ehrbase-rest/src/api/demographic/openapi_routes.rs
@@ -74,7 +74,7 @@ pub(crate) fn routes<S: Platform>() -> OpenApiRouter<AppState<S>> {
 
 /// Create an `AGENT`. 201 with the created resource.
 #[utoipa::path(
-    post, path = "/demographic/agent", tag = "demographic",
+    post, path = "/demographic/agent", tag = "AGENT",
     responses((status = 201, description = "Created.", body = serde_json::Value))
 )]
 pub(crate) async fn agent_create<S: Platform>(
@@ -87,7 +87,7 @@ pub(crate) async fn agent_create<S: Platform>(
 
 /// Read an `AGENT` by uid-based id. 404 when absent.
 #[utoipa::path(
-    get, path = "/demographic/agent/{uid_based_id}", tag = "demographic",
+    get, path = "/demographic/agent/{uid_based_id}", tag = "AGENT",
     params(("uid_based_id" = String, Path, description = "The party uid-based id.")),
     responses(
         (status = 200, description = "The AGENT (RM canonical JSON).", body = serde_json::Value),
@@ -104,7 +104,7 @@ pub(crate) async fn agent_get<S: Platform>(
 
 /// Update an `AGENT` (If-Match required). 200 with the updated resource.
 #[utoipa::path(
-    put, path = "/demographic/agent/{uid_based_id}", tag = "demographic",
+    put, path = "/demographic/agent/{uid_based_id}", tag = "AGENT",
     params(("uid_based_id" = String, Path, description = "The party uid-based id.")),
     responses((status = 200, description = "Updated.", body = serde_json::Value))
 )]
@@ -118,7 +118,7 @@ pub(crate) async fn agent_update<S: Platform>(
 
 /// Delete an `AGENT` (If-Match required).
 #[utoipa::path(
-    delete, path = "/demographic/agent/{uid_based_id}", tag = "demographic",
+    delete, path = "/demographic/agent/{uid_based_id}", tag = "AGENT",
     params(("uid_based_id" = String, Path, description = "The party uid-based id.")),
     responses((status = 204, description = "Deleted."))
 )]
@@ -134,7 +134,7 @@ pub(crate) async fn agent_delete<S: Platform>(
 
 /// Create a `GROUP`. 201 with the created resource.
 #[utoipa::path(
-    post, path = "/demographic/group", tag = "demographic",
+    post, path = "/demographic/group", tag = "GROUP",
     responses((status = 201, description = "Created.", body = serde_json::Value))
 )]
 pub(crate) async fn group_create<S: Platform>(
@@ -147,7 +147,7 @@ pub(crate) async fn group_create<S: Platform>(
 
 /// Read a `GROUP` by uid-based id. 404 when absent.
 #[utoipa::path(
-    get, path = "/demographic/group/{uid_based_id}", tag = "demographic",
+    get, path = "/demographic/group/{uid_based_id}", tag = "GROUP",
     params(("uid_based_id" = String, Path, description = "The party uid-based id.")),
     responses(
         (status = 200, description = "The GROUP (RM canonical JSON).", body = serde_json::Value),
@@ -164,7 +164,7 @@ pub(crate) async fn group_get<S: Platform>(
 
 /// Update a `GROUP` (If-Match required). 200 with the updated resource.
 #[utoipa::path(
-    put, path = "/demographic/group/{uid_based_id}", tag = "demographic",
+    put, path = "/demographic/group/{uid_based_id}", tag = "GROUP",
     params(("uid_based_id" = String, Path, description = "The party uid-based id.")),
     responses((status = 200, description = "Updated.", body = serde_json::Value))
 )]
@@ -178,7 +178,7 @@ pub(crate) async fn group_update<S: Platform>(
 
 /// Delete a `GROUP` (If-Match required).
 #[utoipa::path(
-    delete, path = "/demographic/group/{uid_based_id}", tag = "demographic",
+    delete, path = "/demographic/group/{uid_based_id}", tag = "GROUP",
     params(("uid_based_id" = String, Path, description = "The party uid-based id.")),
     responses((status = 204, description = "Deleted."))
 )]
@@ -194,7 +194,7 @@ pub(crate) async fn group_delete<S: Platform>(
 
 /// Create an `ORGANISATION`. 201 with the created resource.
 #[utoipa::path(
-    post, path = "/demographic/organisation", tag = "demographic",
+    post, path = "/demographic/organisation", tag = "ORGANISATION",
     responses((status = 201, description = "Created.", body = serde_json::Value))
 )]
 pub(crate) async fn organisation_create<S: Platform>(
@@ -207,7 +207,7 @@ pub(crate) async fn organisation_create<S: Platform>(
 
 /// Read an `ORGANISATION` by uid-based id. 404 when absent.
 #[utoipa::path(
-    get, path = "/demographic/organisation/{uid_based_id}", tag = "demographic",
+    get, path = "/demographic/organisation/{uid_based_id}", tag = "ORGANISATION",
     params(("uid_based_id" = String, Path, description = "The party uid-based id.")),
     responses(
         (status = 200, description = "The ORGANISATION (RM canonical JSON).", body = serde_json::Value),
@@ -224,7 +224,7 @@ pub(crate) async fn organisation_get<S: Platform>(
 
 /// Update an `ORGANISATION` (If-Match required). 200 with the updated resource.
 #[utoipa::path(
-    put, path = "/demographic/organisation/{uid_based_id}", tag = "demographic",
+    put, path = "/demographic/organisation/{uid_based_id}", tag = "ORGANISATION",
     params(("uid_based_id" = String, Path, description = "The party uid-based id.")),
     responses((status = 200, description = "Updated.", body = serde_json::Value))
 )]
@@ -238,7 +238,7 @@ pub(crate) async fn organisation_update<S: Platform>(
 
 /// Delete an `ORGANISATION` (If-Match required).
 #[utoipa::path(
-    delete, path = "/demographic/organisation/{uid_based_id}", tag = "demographic",
+    delete, path = "/demographic/organisation/{uid_based_id}", tag = "ORGANISATION",
     params(("uid_based_id" = String, Path, description = "The party uid-based id.")),
     responses((status = 204, description = "Deleted."))
 )]
@@ -254,7 +254,7 @@ pub(crate) async fn organisation_delete<S: Platform>(
 
 /// Create a `PERSON`. 201 with the created resource.
 #[utoipa::path(
-    post, path = "/demographic/person", tag = "demographic",
+    post, path = "/demographic/person", tag = "PERSON",
     responses((status = 201, description = "Created.", body = serde_json::Value))
 )]
 pub(crate) async fn person_create<S: Platform>(
@@ -267,7 +267,7 @@ pub(crate) async fn person_create<S: Platform>(
 
 /// Read a `PERSON` by uid-based id. 404 when absent.
 #[utoipa::path(
-    get, path = "/demographic/person/{uid_based_id}", tag = "demographic",
+    get, path = "/demographic/person/{uid_based_id}", tag = "PERSON",
     params(("uid_based_id" = String, Path, description = "The party uid-based id.")),
     responses(
         (status = 200, description = "The PERSON (RM canonical JSON).", body = serde_json::Value),
@@ -284,7 +284,7 @@ pub(crate) async fn person_get<S: Platform>(
 
 /// Update a `PERSON` (If-Match required). 200 with the updated resource.
 #[utoipa::path(
-    put, path = "/demographic/person/{uid_based_id}", tag = "demographic",
+    put, path = "/demographic/person/{uid_based_id}", tag = "PERSON",
     params(("uid_based_id" = String, Path, description = "The party uid-based id.")),
     responses((status = 200, description = "Updated.", body = serde_json::Value))
 )]
@@ -298,7 +298,7 @@ pub(crate) async fn person_update<S: Platform>(
 
 /// Delete a `PERSON` (If-Match required).
 #[utoipa::path(
-    delete, path = "/demographic/person/{uid_based_id}", tag = "demographic",
+    delete, path = "/demographic/person/{uid_based_id}", tag = "PERSON",
     params(("uid_based_id" = String, Path, description = "The party uid-based id.")),
     responses((status = 204, description = "Deleted."))
 )]
@@ -314,7 +314,7 @@ pub(crate) async fn person_delete<S: Platform>(
 
 /// Create a `ROLE`. 201 with the created resource.
 #[utoipa::path(
-    post, path = "/demographic/role", tag = "demographic",
+    post, path = "/demographic/role", tag = "ROLE",
     responses((status = 201, description = "Created.", body = serde_json::Value))
 )]
 pub(crate) async fn role_create<S: Platform>(
@@ -327,7 +327,7 @@ pub(crate) async fn role_create<S: Platform>(
 
 /// Read a `ROLE` by uid-based id. 404 when absent.
 #[utoipa::path(
-    get, path = "/demographic/role/{uid_based_id}", tag = "demographic",
+    get, path = "/demographic/role/{uid_based_id}", tag = "ROLE",
     params(("uid_based_id" = String, Path, description = "The party uid-based id.")),
     responses(
         (status = 200, description = "The ROLE (RM canonical JSON).", body = serde_json::Value),
@@ -344,7 +344,7 @@ pub(crate) async fn role_get<S: Platform>(
 
 /// Update a `ROLE` (If-Match required). 200 with the updated resource.
 #[utoipa::path(
-    put, path = "/demographic/role/{uid_based_id}", tag = "demographic",
+    put, path = "/demographic/role/{uid_based_id}", tag = "ROLE",
     params(("uid_based_id" = String, Path, description = "The party uid-based id.")),
     responses((status = 200, description = "Updated.", body = serde_json::Value))
 )]
@@ -358,7 +358,7 @@ pub(crate) async fn role_update<S: Platform>(
 
 /// Delete a `ROLE` (If-Match required).
 #[utoipa::path(
-    delete, path = "/demographic/role/{uid_based_id}", tag = "demographic",
+    delete, path = "/demographic/role/{uid_based_id}", tag = "ROLE",
     params(("uid_based_id" = String, Path, description = "The party uid-based id.")),
     responses((status = 204, description = "Deleted."))
 )]
@@ -374,7 +374,7 @@ pub(crate) async fn role_delete<S: Platform>(
 
 /// Read the `VERSIONED_PARTY` container. 404 when absent.
 #[utoipa::path(
-    get, path = "/demographic/versioned_party/{versioned_object_uid}", tag = "demographic",
+    get, path = "/demographic/versioned_party/{versioned_object_uid}", tag = "VERSIONED_PARTY",
     params(("versioned_object_uid" = String, Path, description = "The versioned-object uid.")),
     responses(
         (status = 200, description = "The VERSIONED_PARTY (RM canonical JSON).", body = serde_json::Value),
@@ -391,7 +391,7 @@ pub(crate) async fn versioned_party_get<S: Platform>(
 
 /// The party's `REVISION_HISTORY`. 404 when absent.
 #[utoipa::path(
-    get, path = "/demographic/versioned_party/{versioned_object_uid}/revision_history", tag = "demographic",
+    get, path = "/demographic/versioned_party/{versioned_object_uid}/revision_history", tag = "VERSIONED_PARTY",
     params(("versioned_object_uid" = String, Path, description = "The versioned-object uid.")),
     responses(
         (status = 200, description = "The REVISION_HISTORY (RM canonical JSON).", body = serde_json::Value),
@@ -414,7 +414,7 @@ pub(crate) async fn versioned_party_revision_history<S: Platform>(
 
 /// The party VERSION at a point in time (`?version_at_time=`). 404 when absent.
 #[utoipa::path(
-    get, path = "/demographic/versioned_party/{versioned_object_uid}/version", tag = "demographic",
+    get, path = "/demographic/versioned_party/{versioned_object_uid}/version", tag = "VERSIONED_PARTY",
     params(("versioned_object_uid" = String, Path, description = "The versioned-object uid.")),
     responses(
         (status = 200, description = "The VERSION (RM canonical JSON).", body = serde_json::Value),
@@ -437,7 +437,7 @@ pub(crate) async fn versioned_party_version_get_at_time<S: Platform>(
 
 /// A specific party VERSION by version uid. 404 when absent.
 #[utoipa::path(
-    get, path = "/demographic/versioned_party/{versioned_object_uid}/version/{version_uid}", tag = "demographic",
+    get, path = "/demographic/versioned_party/{versioned_object_uid}/version/{version_uid}", tag = "VERSIONED_PARTY",
     params(
         ("versioned_object_uid" = String, Path, description = "The versioned-object uid."),
         ("version_uid" = String, Path, description = "The OBJECT_VERSION_ID.")
@@ -465,7 +465,7 @@ pub(crate) async fn versioned_party_version_get_by_id<S: Platform>(
 
 /// Create a demographic `CONTRIBUTION`. 201 with the created resource.
 #[utoipa::path(
-    post, path = "/demographic/contribution", tag = "demographic",
+    post, path = "/demographic/contribution", tag = "CONTRIBUTION",
     responses((status = 201, description = "Created.", body = serde_json::Value))
 )]
 pub(crate) async fn contribution_create<S: Platform>(
@@ -478,7 +478,7 @@ pub(crate) async fn contribution_create<S: Platform>(
 
 /// Read a demographic `CONTRIBUTION` by uid. 404 when absent.
 #[utoipa::path(
-    get, path = "/demographic/contribution/{contribution_uid}", tag = "demographic",
+    get, path = "/demographic/contribution/{contribution_uid}", tag = "CONTRIBUTION",
     params(("contribution_uid" = String, Path, description = "The CONTRIBUTION uid.")),
     responses(
         (status = 200, description = "The CONTRIBUTION (RM canonical JSON).", body = serde_json::Value),
@@ -497,7 +497,7 @@ pub(crate) async fn contribution_get<S: Platform>(
 
 /// List every `ITEM_TAG` known to the demographic surface. 404 when absent.
 #[utoipa::path(
-    get, path = "/demographic/tags", tag = "demographic",
+    get, path = "/demographic/tags", tag = "ITEM_TAG",
     responses(
         (status = 200, description = "The ITEM_TAGs.", body = serde_json::Value),
         (status = 404, description = "Not found.", body = serde_json::Value)
@@ -513,7 +513,7 @@ pub(crate) async fn demographic_tags_get<S: Platform>(
 
 /// Read an `AGENT`'s `ITEM_TAGs`. 404 when absent.
 #[utoipa::path(
-    get, path = "/demographic/agent/{uid_based_id}/tags", tag = "demographic",
+    get, path = "/demographic/agent/{uid_based_id}/tags", tag = "ITEM_TAG",
     params(("uid_based_id" = String, Path, description = "The party uid-based id.")),
     responses(
         (status = 200, description = "The ITEM_TAGs.", body = serde_json::Value),
@@ -530,7 +530,7 @@ pub(crate) async fn agent_tags_get<S: Platform>(
 
 /// Upsert an `AGENT`'s `ITEM_TAGs`. 200 with the stored tags.
 #[utoipa::path(
-    put, path = "/demographic/agent/{uid_based_id}/tags", tag = "demographic",
+    put, path = "/demographic/agent/{uid_based_id}/tags", tag = "ITEM_TAG",
     params(("uid_based_id" = String, Path, description = "The party uid-based id.")),
     responses((status = 200, description = "Updated.", body = serde_json::Value))
 )]
@@ -544,7 +544,7 @@ pub(crate) async fn agent_tags_update<S: Platform>(
 
 /// Delete one `ITEM_TAG` from an `AGENT` by key.
 #[utoipa::path(
-    delete, path = "/demographic/agent/{uid_based_id}/tags/{key}", tag = "demographic",
+    delete, path = "/demographic/agent/{uid_based_id}/tags/{key}", tag = "ITEM_TAG",
     params(
         ("uid_based_id" = String, Path, description = "The party uid-based id."),
         ("key" = String, Path, description = "The ITEM_TAG key.")
@@ -561,7 +561,7 @@ pub(crate) async fn agent_tags_delete<S: Platform>(
 
 /// Read a `GROUP`'s `ITEM_TAGs`. 404 when absent.
 #[utoipa::path(
-    get, path = "/demographic/group/{uid_based_id}/tags", tag = "demographic",
+    get, path = "/demographic/group/{uid_based_id}/tags", tag = "ITEM_TAG",
     params(("uid_based_id" = String, Path, description = "The party uid-based id.")),
     responses(
         (status = 200, description = "The ITEM_TAGs.", body = serde_json::Value),
@@ -578,7 +578,7 @@ pub(crate) async fn group_tags_get<S: Platform>(
 
 /// Upsert a `GROUP`'s `ITEM_TAGs`. 200 with the stored tags.
 #[utoipa::path(
-    put, path = "/demographic/group/{uid_based_id}/tags", tag = "demographic",
+    put, path = "/demographic/group/{uid_based_id}/tags", tag = "ITEM_TAG",
     params(("uid_based_id" = String, Path, description = "The party uid-based id.")),
     responses((status = 200, description = "Updated.", body = serde_json::Value))
 )]
@@ -592,7 +592,7 @@ pub(crate) async fn group_tags_update<S: Platform>(
 
 /// Delete one `ITEM_TAG` from a `GROUP` by key.
 #[utoipa::path(
-    delete, path = "/demographic/group/{uid_based_id}/tags/{key}", tag = "demographic",
+    delete, path = "/demographic/group/{uid_based_id}/tags/{key}", tag = "ITEM_TAG",
     params(
         ("uid_based_id" = String, Path, description = "The party uid-based id."),
         ("key" = String, Path, description = "The ITEM_TAG key.")
@@ -609,7 +609,7 @@ pub(crate) async fn group_tags_delete<S: Platform>(
 
 /// Read an `ORGANISATION`'s `ITEM_TAGs`. 404 when absent.
 #[utoipa::path(
-    get, path = "/demographic/organisation/{uid_based_id}/tags", tag = "demographic",
+    get, path = "/demographic/organisation/{uid_based_id}/tags", tag = "ITEM_TAG",
     params(("uid_based_id" = String, Path, description = "The party uid-based id.")),
     responses(
         (status = 200, description = "The ITEM_TAGs.", body = serde_json::Value),
@@ -626,7 +626,7 @@ pub(crate) async fn organisation_tags_get<S: Platform>(
 
 /// Upsert an `ORGANISATION`'s `ITEM_TAGs`. 200 with the stored tags.
 #[utoipa::path(
-    put, path = "/demographic/organisation/{uid_based_id}/tags", tag = "demographic",
+    put, path = "/demographic/organisation/{uid_based_id}/tags", tag = "ITEM_TAG",
     params(("uid_based_id" = String, Path, description = "The party uid-based id.")),
     responses((status = 200, description = "Updated.", body = serde_json::Value))
 )]
@@ -646,7 +646,7 @@ pub(crate) async fn organisation_tags_update<S: Platform>(
 
 /// Delete one `ITEM_TAG` from an `ORGANISATION` by key.
 #[utoipa::path(
-    delete, path = "/demographic/organisation/{uid_based_id}/tags/{key}", tag = "demographic",
+    delete, path = "/demographic/organisation/{uid_based_id}/tags/{key}", tag = "ITEM_TAG",
     params(
         ("uid_based_id" = String, Path, description = "The party uid-based id."),
         ("key" = String, Path, description = "The ITEM_TAG key.")
@@ -669,7 +669,7 @@ pub(crate) async fn organisation_tags_delete<S: Platform>(
 
 /// Read a `PERSON`'s `ITEM_TAGs`. 404 when absent.
 #[utoipa::path(
-    get, path = "/demographic/person/{uid_based_id}/tags", tag = "demographic",
+    get, path = "/demographic/person/{uid_based_id}/tags", tag = "ITEM_TAG",
     params(("uid_based_id" = String, Path, description = "The party uid-based id.")),
     responses(
         (status = 200, description = "The ITEM_TAGs.", body = serde_json::Value),
@@ -686,7 +686,7 @@ pub(crate) async fn person_tags_get<S: Platform>(
 
 /// Upsert a `PERSON`'s `ITEM_TAGs`. 200 with the stored tags.
 #[utoipa::path(
-    put, path = "/demographic/person/{uid_based_id}/tags", tag = "demographic",
+    put, path = "/demographic/person/{uid_based_id}/tags", tag = "ITEM_TAG",
     params(("uid_based_id" = String, Path, description = "The party uid-based id.")),
     responses((status = 200, description = "Updated.", body = serde_json::Value))
 )]
@@ -700,7 +700,7 @@ pub(crate) async fn person_tags_update<S: Platform>(
 
 /// Delete one `ITEM_TAG` from a `PERSON` by key.
 #[utoipa::path(
-    delete, path = "/demographic/person/{uid_based_id}/tags/{key}", tag = "demographic",
+    delete, path = "/demographic/person/{uid_based_id}/tags/{key}", tag = "ITEM_TAG",
     params(
         ("uid_based_id" = String, Path, description = "The party uid-based id."),
         ("key" = String, Path, description = "The ITEM_TAG key.")
@@ -717,7 +717,7 @@ pub(crate) async fn person_tags_delete<S: Platform>(
 
 /// Read a `ROLE`'s `ITEM_TAGs`. 404 when absent.
 #[utoipa::path(
-    get, path = "/demographic/role/{uid_based_id}/tags", tag = "demographic",
+    get, path = "/demographic/role/{uid_based_id}/tags", tag = "ITEM_TAG",
     params(("uid_based_id" = String, Path, description = "The party uid-based id.")),
     responses(
         (status = 200, description = "The ITEM_TAGs.", body = serde_json::Value),
@@ -734,7 +734,7 @@ pub(crate) async fn role_tags_get<S: Platform>(
 
 /// Upsert a `ROLE`'s `ITEM_TAGs`. 200 with the stored tags.
 #[utoipa::path(
-    put, path = "/demographic/role/{uid_based_id}/tags", tag = "demographic",
+    put, path = "/demographic/role/{uid_based_id}/tags", tag = "ITEM_TAG",
     params(("uid_based_id" = String, Path, description = "The party uid-based id.")),
     responses((status = 200, description = "Updated.", body = serde_json::Value))
 )]
@@ -748,7 +748,7 @@ pub(crate) async fn role_tags_update<S: Platform>(
 
 /// Delete one `ITEM_TAG` from a `ROLE` by key.
 #[utoipa::path(
-    delete, path = "/demographic/role/{uid_based_id}/tags/{key}", tag = "demographic",
+    delete, path = "/demographic/role/{uid_based_id}/tags/{key}", tag = "ITEM_TAG",
     params(
         ("uid_based_id" = String, Path, description = "The party uid-based id."),
         ("key" = String, Path, description = "The ITEM_TAG key.")

--- a/app/ehrbase-rest/src/api/ehr/openapi_routes.rs
+++ b/app/ehrbase-rest/src/api/ehr/openapi_routes.rs
@@ -65,7 +65,7 @@ pub(crate) fn routes<S: Platform>() -> OpenApiRouter<AppState<S>> {
 
 /// Retrieve an EHR by subject (`GET /ehr`).
 #[utoipa::path(
-    get, path = "/ehr", tag = "ehr",
+    get, path = "/ehr", tag = "EHR",
     responses(
         (status = 200, description = "The EHR.", body = serde_json::Value),
         (status = 404, description = "Not found.", body = serde_json::Value)
@@ -87,7 +87,7 @@ pub(crate) async fn ehr_get_by_subject<S: Platform>(
 
 /// Create a new EHR (`POST /ehr`).
 #[utoipa::path(
-    post, path = "/ehr", tag = "ehr",
+    post, path = "/ehr", tag = "EHR",
     responses((status = 201, description = "Created.", body = serde_json::Value))
 )]
 pub(crate) async fn ehr_create<S: Platform>(
@@ -106,7 +106,7 @@ pub(crate) async fn ehr_create<S: Platform>(
 
 /// Retrieve an EHR by id (`GET /ehr/{ehr_id}`).
 #[utoipa::path(
-    get, path = "/ehr/{ehr_id}", tag = "ehr",
+    get, path = "/ehr/{ehr_id}", tag = "EHR",
     params(("ehr_id" = String, Path, description = "The EHR id.")),
     responses(
         (status = 200, description = "The EHR.", body = serde_json::Value),
@@ -129,7 +129,7 @@ pub(crate) async fn ehr_get_by_id<S: Platform>(
 
 /// Create an EHR with a client-supplied id (`PUT /ehr/{ehr_id}`).
 #[utoipa::path(
-    put, path = "/ehr/{ehr_id}", tag = "ehr",
+    put, path = "/ehr/{ehr_id}", tag = "EHR",
     params(("ehr_id" = String, Path, description = "The EHR id.")),
     responses((status = 200, description = "Created/updated.", body = serde_json::Value))
 )]
@@ -152,7 +152,7 @@ pub(crate) async fn ehr_create_with_id<S: Platform>(
 /// Retrieve an `EHR_STATUS` at a version id
 /// (`GET /ehr/{ehr_id}/ehr_status/{version_uid}`).
 #[utoipa::path(
-    get, path = "/ehr/{ehr_id}/ehr_status/{version_uid}", tag = "ehr",
+    get, path = "/ehr/{ehr_id}/ehr_status/{version_uid}", tag = "EHR_STATUS",
     params(
         ("ehr_id" = String, Path, description = "The EHR id."),
         ("version_uid" = String, Path, description = "The version uid.")
@@ -179,7 +179,7 @@ pub(crate) async fn ehr_status_get_by_version_id<S: Platform>(
 /// Retrieve the `EHR_STATUS` at a point in time
 /// (`GET /ehr/{ehr_id}/ehr_status`).
 #[utoipa::path(
-    get, path = "/ehr/{ehr_id}/ehr_status", tag = "ehr",
+    get, path = "/ehr/{ehr_id}/ehr_status", tag = "EHR_STATUS",
     params(("ehr_id" = String, Path, description = "The EHR id.")),
     responses(
         (status = 200, description = "The EHR_STATUS.", body = serde_json::Value),
@@ -202,7 +202,7 @@ pub(crate) async fn ehr_status_get_at_time<S: Platform>(
 
 /// Update the `EHR_STATUS` (`PUT /ehr/{ehr_id}/ehr_status`).
 #[utoipa::path(
-    put, path = "/ehr/{ehr_id}/ehr_status", tag = "ehr",
+    put, path = "/ehr/{ehr_id}/ehr_status", tag = "EHR_STATUS",
     params(("ehr_id" = String, Path, description = "The EHR id.")),
     responses((status = 200, description = "Updated.", body = serde_json::Value))
 )]
@@ -225,7 +225,7 @@ pub(crate) async fn ehr_status_update<S: Platform>(
 /// Retrieve the `VERSIONED_EHR_STATUS` container
 /// (`GET /ehr/{ehr_id}/versioned_ehr_status`).
 #[utoipa::path(
-    get, path = "/ehr/{ehr_id}/versioned_ehr_status", tag = "ehr",
+    get, path = "/ehr/{ehr_id}/versioned_ehr_status", tag = "EHR_STATUS",
     params(("ehr_id" = String, Path, description = "The EHR id.")),
     responses(
         (status = 200, description = "The VERSIONED_EHR_STATUS.", body = serde_json::Value),
@@ -249,7 +249,7 @@ pub(crate) async fn versioned_ehr_status_get<S: Platform>(
 /// Retrieve the `EHR_STATUS` revision history
 /// (`GET /ehr/{ehr_id}/versioned_ehr_status/revision_history`).
 #[utoipa::path(
-    get, path = "/ehr/{ehr_id}/versioned_ehr_status/revision_history", tag = "ehr",
+    get, path = "/ehr/{ehr_id}/versioned_ehr_status/revision_history", tag = "EHR_STATUS",
     params(("ehr_id" = String, Path, description = "The EHR id.")),
     responses(
         (status = 200, description = "The revision history.", body = serde_json::Value),
@@ -273,7 +273,7 @@ pub(crate) async fn versioned_ehr_status_revision_history<S: Platform>(
 /// Retrieve an `EHR_STATUS` version at a point in time
 /// (`GET /ehr/{ehr_id}/versioned_ehr_status/version`).
 #[utoipa::path(
-    get, path = "/ehr/{ehr_id}/versioned_ehr_status/version", tag = "ehr",
+    get, path = "/ehr/{ehr_id}/versioned_ehr_status/version", tag = "EHR_STATUS",
     params(("ehr_id" = String, Path, description = "The EHR id.")),
     responses(
         (status = 200, description = "The EHR_STATUS version.", body = serde_json::Value),
@@ -297,7 +297,7 @@ pub(crate) async fn versioned_ehr_status_version_get_at_time<S: Platform>(
 /// Retrieve an `EHR_STATUS` version by id
 /// (`GET /ehr/{ehr_id}/versioned_ehr_status/version/{version_uid}`).
 #[utoipa::path(
-    get, path = "/ehr/{ehr_id}/versioned_ehr_status/version/{version_uid}", tag = "ehr",
+    get, path = "/ehr/{ehr_id}/versioned_ehr_status/version/{version_uid}", tag = "EHR_STATUS",
     params(
         ("ehr_id" = String, Path, description = "The EHR id."),
         ("version_uid" = String, Path, description = "The version uid.")
@@ -325,7 +325,7 @@ pub(crate) async fn versioned_ehr_status_version_get_by_id<S: Platform>(
 
 /// Create a COMPOSITION (`POST /ehr/{ehr_id}/composition`).
 #[utoipa::path(
-    post, path = "/ehr/{ehr_id}/composition", tag = "ehr",
+    post, path = "/ehr/{ehr_id}/composition", tag = "COMPOSITION",
     params(("ehr_id" = String, Path, description = "The EHR id.")),
     responses((status = 201, description = "Created.", body = serde_json::Value))
 )]
@@ -346,7 +346,7 @@ pub(crate) async fn composition_create<S: Platform>(
 /// Retrieve a COMPOSITION
 /// (`GET /ehr/{ehr_id}/composition/{uid_based_id}`).
 #[utoipa::path(
-    get, path = "/ehr/{ehr_id}/composition/{uid_based_id}", tag = "ehr",
+    get, path = "/ehr/{ehr_id}/composition/{uid_based_id}", tag = "COMPOSITION",
     params(
         ("ehr_id" = String, Path, description = "The EHR id."),
         ("uid_based_id" = String, Path, description = "The composition uid.")
@@ -373,7 +373,7 @@ pub(crate) async fn composition_get<S: Platform>(
 /// Update a COMPOSITION
 /// (`PUT /ehr/{ehr_id}/composition/{uid_based_id}`).
 #[utoipa::path(
-    put, path = "/ehr/{ehr_id}/composition/{uid_based_id}", tag = "ehr",
+    put, path = "/ehr/{ehr_id}/composition/{uid_based_id}", tag = "COMPOSITION",
     params(
         ("ehr_id" = String, Path, description = "The EHR id."),
         ("uid_based_id" = String, Path, description = "The composition uid.")
@@ -397,7 +397,7 @@ pub(crate) async fn composition_update<S: Platform>(
 /// Delete a COMPOSITION
 /// (`DELETE /ehr/{ehr_id}/composition/{uid_based_id}`).
 #[utoipa::path(
-    delete, path = "/ehr/{ehr_id}/composition/{uid_based_id}", tag = "ehr",
+    delete, path = "/ehr/{ehr_id}/composition/{uid_based_id}", tag = "COMPOSITION",
     params(
         ("ehr_id" = String, Path, description = "The EHR id."),
         ("uid_based_id" = String, Path, description = "The composition uid.")
@@ -423,7 +423,7 @@ pub(crate) async fn composition_delete<S: Platform>(
 /// Retrieve the `VERSIONED_COMPOSITION` container
 /// (`GET /ehr/{ehr_id}/versioned_composition/{versioned_object_uid}`).
 #[utoipa::path(
-    get, path = "/ehr/{ehr_id}/versioned_composition/{versioned_object_uid}", tag = "ehr",
+    get, path = "/ehr/{ehr_id}/versioned_composition/{versioned_object_uid}", tag = "COMPOSITION",
     params(
         ("ehr_id" = String, Path, description = "The EHR id."),
         ("versioned_object_uid" = String, Path, description = "The versioned object uid.")
@@ -452,7 +452,7 @@ pub(crate) async fn versioned_composition_get<S: Platform>(
 #[utoipa::path(
     get,
     path = "/ehr/{ehr_id}/versioned_composition/{versioned_object_uid}/revision_history",
-    tag = "ehr",
+    tag = "COMPOSITION",
     params(
         ("ehr_id" = String, Path, description = "The EHR id."),
         ("versioned_object_uid" = String, Path, description = "The versioned object uid.")
@@ -481,7 +481,7 @@ pub(crate) async fn versioned_composition_revision_history<S: Platform>(
 #[utoipa::path(
     get,
     path = "/ehr/{ehr_id}/versioned_composition/{versioned_object_uid}/version",
-    tag = "ehr",
+    tag = "COMPOSITION",
     params(
         ("ehr_id" = String, Path, description = "The EHR id."),
         ("versioned_object_uid" = String, Path, description = "The versioned object uid.")
@@ -510,7 +510,7 @@ pub(crate) async fn versioned_composition_version_get_at_time<S: Platform>(
 #[utoipa::path(
     get,
     path = "/ehr/{ehr_id}/versioned_composition/{versioned_object_uid}/version/{version_uid}",
-    tag = "ehr",
+    tag = "COMPOSITION",
     params(
         ("ehr_id" = String, Path, description = "The EHR id."),
         ("versioned_object_uid" = String, Path, description = "The versioned object uid."),
@@ -540,7 +540,7 @@ pub(crate) async fn versioned_composition_version_get_by_id<S: Platform>(
 /// Retrieve the directory (FOLDER) at a point in time
 /// (`GET /ehr/{ehr_id}/directory`).
 #[utoipa::path(
-    get, path = "/ehr/{ehr_id}/directory", tag = "ehr",
+    get, path = "/ehr/{ehr_id}/directory", tag = "DIRECTORY",
     params(("ehr_id" = String, Path, description = "The EHR id.")),
     responses(
         (status = 200, description = "The DIRECTORY.", body = serde_json::Value),
@@ -563,7 +563,7 @@ pub(crate) async fn directory_get_at_time<S: Platform>(
 
 /// Update the directory (FOLDER) (`PUT /ehr/{ehr_id}/directory`).
 #[utoipa::path(
-    put, path = "/ehr/{ehr_id}/directory", tag = "ehr",
+    put, path = "/ehr/{ehr_id}/directory", tag = "DIRECTORY",
     params(("ehr_id" = String, Path, description = "The EHR id.")),
     responses((status = 200, description = "Updated.", body = serde_json::Value))
 )]
@@ -583,7 +583,7 @@ pub(crate) async fn directory_update<S: Platform>(
 
 /// Create the directory (FOLDER) (`POST /ehr/{ehr_id}/directory`).
 #[utoipa::path(
-    post, path = "/ehr/{ehr_id}/directory", tag = "ehr",
+    post, path = "/ehr/{ehr_id}/directory", tag = "DIRECTORY",
     params(("ehr_id" = String, Path, description = "The EHR id.")),
     responses((status = 201, description = "Created.", body = serde_json::Value))
 )]
@@ -603,7 +603,7 @@ pub(crate) async fn directory_create<S: Platform>(
 
 /// Delete the directory (FOLDER) (`DELETE /ehr/{ehr_id}/directory`).
 #[utoipa::path(
-    delete, path = "/ehr/{ehr_id}/directory", tag = "ehr",
+    delete, path = "/ehr/{ehr_id}/directory", tag = "DIRECTORY",
     params(("ehr_id" = String, Path, description = "The EHR id.")),
     responses((status = 204, description = "Deleted."))
 )]
@@ -624,7 +624,7 @@ pub(crate) async fn directory_delete<S: Platform>(
 /// Retrieve the directory (FOLDER) by version id
 /// (`GET /ehr/{ehr_id}/directory/{version_uid}`).
 #[utoipa::path(
-    get, path = "/ehr/{ehr_id}/directory/{version_uid}", tag = "ehr",
+    get, path = "/ehr/{ehr_id}/directory/{version_uid}", tag = "DIRECTORY",
     params(
         ("ehr_id" = String, Path, description = "The EHR id."),
         ("version_uid" = String, Path, description = "The version uid.")
@@ -652,7 +652,7 @@ pub(crate) async fn directory_get_by_version_id<S: Platform>(
 
 /// Create a CONTRIBUTION (`POST /ehr/{ehr_id}/contribution`).
 #[utoipa::path(
-    post, path = "/ehr/{ehr_id}/contribution", tag = "ehr",
+    post, path = "/ehr/{ehr_id}/contribution", tag = "CONTRIBUTION",
     params(("ehr_id" = String, Path, description = "The EHR id.")),
     responses((status = 201, description = "Created.", body = serde_json::Value))
 )]
@@ -673,7 +673,7 @@ pub(crate) async fn contribution_create<S: Platform>(
 /// Retrieve a CONTRIBUTION
 /// (`GET /ehr/{ehr_id}/contribution/{contribution_uid}`).
 #[utoipa::path(
-    get, path = "/ehr/{ehr_id}/contribution/{contribution_uid}", tag = "ehr",
+    get, path = "/ehr/{ehr_id}/contribution/{contribution_uid}", tag = "CONTRIBUTION",
     params(
         ("ehr_id" = String, Path, description = "The EHR id."),
         ("contribution_uid" = String, Path, description = "The contribution uid.")
@@ -701,7 +701,7 @@ pub(crate) async fn contribution_get<S: Platform>(
 
 /// Retrieve the EHR-level item tags (`GET /ehr/{ehr_id}/tags`).
 #[utoipa::path(
-    get, path = "/ehr/{ehr_id}/tags", tag = "ehr",
+    get, path = "/ehr/{ehr_id}/tags", tag = "ITEM_TAG",
     params(("ehr_id" = String, Path, description = "The EHR id.")),
     responses(
         (status = 200, description = "The item tags.", body = serde_json::Value),
@@ -725,7 +725,7 @@ pub(crate) async fn ehr_tags_get<S: Platform>(
 /// Retrieve a COMPOSITION's item tags
 /// (`GET /ehr/{ehr_id}/composition/{uid_based_id}/tags`).
 #[utoipa::path(
-    get, path = "/ehr/{ehr_id}/composition/{uid_based_id}/tags", tag = "ehr",
+    get, path = "/ehr/{ehr_id}/composition/{uid_based_id}/tags", tag = "ITEM_TAG",
     params(
         ("ehr_id" = String, Path, description = "The EHR id."),
         ("uid_based_id" = String, Path, description = "The composition uid.")
@@ -752,7 +752,7 @@ pub(crate) async fn composition_tags_get<S: Platform>(
 /// Replace a COMPOSITION's item tags
 /// (`PUT /ehr/{ehr_id}/composition/{uid_based_id}/tags`).
 #[utoipa::path(
-    put, path = "/ehr/{ehr_id}/composition/{uid_based_id}/tags", tag = "ehr",
+    put, path = "/ehr/{ehr_id}/composition/{uid_based_id}/tags", tag = "ITEM_TAG",
     params(
         ("ehr_id" = String, Path, description = "The EHR id."),
         ("uid_based_id" = String, Path, description = "The composition uid.")
@@ -776,7 +776,7 @@ pub(crate) async fn composition_tags_update<S: Platform>(
 /// Delete a COMPOSITION item tag by key
 /// (`DELETE /ehr/{ehr_id}/composition/{uid_based_id}/tags/{key}`).
 #[utoipa::path(
-    delete, path = "/ehr/{ehr_id}/composition/{uid_based_id}/tags/{key}", tag = "ehr",
+    delete, path = "/ehr/{ehr_id}/composition/{uid_based_id}/tags/{key}", tag = "ITEM_TAG",
     params(
         ("ehr_id" = String, Path, description = "The EHR id."),
         ("uid_based_id" = String, Path, description = "The composition uid."),
@@ -801,7 +801,7 @@ pub(crate) async fn composition_tags_delete<S: Platform>(
 /// Retrieve an `EHR_STATUS`'s item tags
 /// (`GET /ehr/{ehr_id}/ehr_status/{uid_based_id}/tags`).
 #[utoipa::path(
-    get, path = "/ehr/{ehr_id}/ehr_status/{uid_based_id}/tags", tag = "ehr",
+    get, path = "/ehr/{ehr_id}/ehr_status/{uid_based_id}/tags", tag = "ITEM_TAG",
     params(
         ("ehr_id" = String, Path, description = "The EHR id."),
         ("uid_based_id" = String, Path, description = "The EHR_STATUS uid.")
@@ -828,7 +828,7 @@ pub(crate) async fn ehr_status_tags_get<S: Platform>(
 /// Replace an `EHR_STATUS`'s item tags
 /// (`PUT /ehr/{ehr_id}/ehr_status/{uid_based_id}/tags`).
 #[utoipa::path(
-    put, path = "/ehr/{ehr_id}/ehr_status/{uid_based_id}/tags", tag = "ehr",
+    put, path = "/ehr/{ehr_id}/ehr_status/{uid_based_id}/tags", tag = "ITEM_TAG",
     params(
         ("ehr_id" = String, Path, description = "The EHR id."),
         ("uid_based_id" = String, Path, description = "The EHR_STATUS uid.")
@@ -852,7 +852,7 @@ pub(crate) async fn ehr_status_tags_update<S: Platform>(
 /// Delete an `EHR_STATUS` item tag by key
 /// (`DELETE /ehr/{ehr_id}/ehr_status/{uid_based_id}/tags/{key}`).
 #[utoipa::path(
-    delete, path = "/ehr/{ehr_id}/ehr_status/{uid_based_id}/tags/{key}", tag = "ehr",
+    delete, path = "/ehr/{ehr_id}/ehr_status/{uid_based_id}/tags/{key}", tag = "ITEM_TAG",
     params(
         ("ehr_id" = String, Path, description = "The EHR id."),
         ("uid_based_id" = String, Path, description = "The EHR_STATUS uid."),

--- a/app/ehrbase-rest/src/api/query/openapi_routes.rs
+++ b/app/ehrbase-rest/src/api/query/openapi_routes.rs
@@ -33,7 +33,7 @@ pub(crate) fn routes<S: Platform>() -> OpenApiRouter<AppState<S>> {
 
 /// Execute an ad-hoc AQL query supplied in the `q` query parameter.
 #[utoipa::path(
-    get, path = "/query/aql", tag = "query",
+    get, path = "/query/aql", tag = "Query",
     responses((status = 200, description = "The RESULT_SET.", body = serde_json::Value))
 )]
 pub(crate) async fn query_execute_adhoc_query<S: Platform>(
@@ -52,7 +52,7 @@ pub(crate) async fn query_execute_adhoc_query<S: Platform>(
 
 /// Execute an ad-hoc AQL query supplied in the request body.
 #[utoipa::path(
-    post, path = "/query/aql", tag = "query",
+    post, path = "/query/aql", tag = "Query",
     responses((status = 200, description = "The RESULT_SET.", body = serde_json::Value))
 )]
 pub(crate) async fn query_execute_adhoc_query_body<S: Platform>(
@@ -71,7 +71,7 @@ pub(crate) async fn query_execute_adhoc_query_body<S: Platform>(
 
 /// Execute a named stored query (parameters in the query string).
 #[utoipa::path(
-    get, path = "/query/{qualified_query_name}", tag = "query",
+    get, path = "/query/{qualified_query_name}", tag = "Query",
     params(("qualified_query_name" = String, Path, description = "The qualified stored-query name.")),
     responses(
         (status = 200, description = "The RESULT_SET.", body = serde_json::Value),
@@ -94,7 +94,7 @@ pub(crate) async fn query_execute_stored_query<S: Platform>(
 
 /// Execute a named stored query (parameters in the request body).
 #[utoipa::path(
-    post, path = "/query/{qualified_query_name}", tag = "query",
+    post, path = "/query/{qualified_query_name}", tag = "Query",
     params(("qualified_query_name" = String, Path, description = "The qualified stored-query name.")),
     responses(
         (status = 200, description = "The RESULT_SET.", body = serde_json::Value),
@@ -117,7 +117,7 @@ pub(crate) async fn query_execute_stored_query_body<S: Platform>(
 
 /// Execute a named stored query at a specific version (query-string params).
 #[utoipa::path(
-    get, path = "/query/{qualified_query_name}/{version}", tag = "query",
+    get, path = "/query/{qualified_query_name}/{version}", tag = "Query",
     params(
         ("qualified_query_name" = String, Path, description = "The qualified stored-query name."),
         ("version" = String, Path, description = "The stored-query version.")
@@ -143,7 +143,7 @@ pub(crate) async fn query_execute_stored_query_version<S: Platform>(
 
 /// Execute a named stored query at a specific version (body params).
 #[utoipa::path(
-    post, path = "/query/{qualified_query_name}/{version}", tag = "query",
+    post, path = "/query/{qualified_query_name}/{version}", tag = "Query",
     params(
         ("qualified_query_name" = String, Path, description = "The qualified stored-query name."),
         ("version" = String, Path, description = "The stored-query version.")

--- a/app/ehrbase-rest/src/extensions/openapi.rs
+++ b/app/ehrbase-rest/src/extensions/openapi.rs
@@ -81,11 +81,23 @@ const SECURITY_SCHEME: &str = "openehr_auth";
                        (status/health, management, SMART discovery, the OpenAPI endpoints)."
     ),
     tags(
-        (name = "ehr", description = "EHR API — EHR, EHR_STATUS, COMPOSITION, DIRECTORY, CONTRIBUTION, item tags (ITS-REST)."),
-        (name = "demographic", description = "Demographic API — PERSON/AGENT/GROUP/ORGANISATION/ROLE, versioned reads, contributions, tags (ITS-REST, DEVELOPMENT)."),
-        (name = "definition", description = "Definition API — ADL 1.4 / ADL 2 templates + stored AQL queries (ITS-REST)."),
-        (name = "query", description = "Query API — ad-hoc + stored AQL execution (ITS-REST)."),
-        (name = "admin", description = "Admin API — physical EHR delete (ITS-REST, DEVELOPMENT)."),
+        // ITS-REST resource tags (categorised exactly as the vendored group OAS
+        // documents do — one tag per RM resource, cross-referenced by path).
+        (name = "EHR", description = "Management of EHRs — create/retrieve; physical delete (Admin API)."),
+        (name = "EHR_STATUS", description = "Management of EHR_STATUS and its VERSIONED_EHR_STATUS reads."),
+        (name = "COMPOSITION", description = "Management of COMPOSITION and its VERSIONED_COMPOSITION reads."),
+        (name = "DIRECTORY", description = "Management of the directory (FOLDER) tree."),
+        (name = "CONTRIBUTION", description = "Management of CONTRIBUTION (EHR + demographic)."),
+        (name = "ITEM_TAG", description = "Management of ITEM_TAG sub-resources (EHR + demographic)."),
+        (name = "PERSON", description = "Management of the demographic PERSON (ITS-REST, DEVELOPMENT)."),
+        (name = "AGENT", description = "Management of the demographic AGENT (ITS-REST, DEVELOPMENT)."),
+        (name = "GROUP", description = "Management of the demographic GROUP (ITS-REST, DEVELOPMENT)."),
+        (name = "ORGANISATION", description = "Management of the demographic ORGANISATION (ITS-REST, DEVELOPMENT)."),
+        (name = "ROLE", description = "Management of the demographic ROLE (ITS-REST, DEVELOPMENT)."),
+        (name = "VERSIONED_PARTY", description = "Management of the VERSIONED_PARTY reads (ITS-REST, DEVELOPMENT)."),
+        (name = "ADL1.4", description = "Management of AOM/ADL 1.4 operational templates."),
+        (name = "ADL2", description = "Management of AOM2/ADL 2 templates."),
+        (name = "Query", description = "Ad-hoc + stored AQL execution and stored-query definitions (ITS-REST)."),
         (name = "status", description = "Public operational status + health (unauthenticated)."),
         (name = "smart", description = "SMART App Launch service discovery (config-gated: EHRBASE_REST_SMART__ENABLED)."),
         (name = "openapi", description = "`OpenAPI` document + Swagger UI discoverability (config-gated: EHRBASE_REST_SWAGGER_UI)."),
@@ -200,8 +212,11 @@ async fn openapi_json<S: Platform>(State(state): State<AppState<S>>) -> Response
     ([(header::CONTENT_TYPE, "application/json")], body).into_response()
 }
 
-/// The Swagger UI (HTML). The vendored ITS-REST bundles and this extension
-/// document are offered in the UI's spec selector.
+/// The Swagger UI (HTML). The spec selector offers one document per API family
+/// — the standardised ITS-REST groups (`openEHR — …`, selected by resource
+/// path) and the server's own extensions (`EHRbase — …`, selected by tag) —
+/// each filtered from the one server-generated composed document, plus that
+/// complete document last. Nothing vendored is served.
 #[utoipa::path(
     get, path = "/ehrbase/rest/swagger-ui", tag = "openapi",
     responses((status = 200, description = "The Swagger UI index.", content_type = "text/html"))
@@ -220,17 +235,247 @@ fn meta_openapi<S: Platform>() -> utoipa::openapi::OpenApi {
         .into_openapi()
 }
 
+// ── The spec-selector families ────────────────────────────────────────────────
+
+/// How a spec-selector family picks its operations out of the one composed
+/// server document.
+///
+/// The standardised ITS-REST groups categorise by **resource path** (their
+/// operations carry per-resource tags — `EHR`/`EHR_STATUS`/`COMPOSITION`/…,
+/// exactly as the vendored group OAS documents tag them — so a shared tag no
+/// longer identifies a group; the base-path-relative path root does). The
+/// server's own extensions have no shared path root and are still identified by
+/// **tag**.
+enum Members {
+    /// Operations whose base-path-relative path starts with `include` (on a
+    /// segment boundary) and starts with none of `exclude`.
+    Path {
+        include: &'static str,
+        exclude: &'static [&'static str],
+    },
+    /// Operations carrying one of these tags.
+    Tags(&'static [&'static str]),
+}
+
+/// Every API family offered as its own selector document:
+/// `(selector name, url slug, membership criterion)`. ALL of them are filtered
+/// from the one server-generated composed document — nothing vendored is served
+/// (the vendored ITS-REST bundles are reference material for authoring our
+/// schemas, never a served artifact) — so each family document inherits the
+/// config-driven security scheme and can never drift from the router.
+const FAMILIES: &[(&str, &str, Members)] = &[
+    // The standardised ITS-REST groups (our generated wire), by resource path.
+    (
+        "openEHR — EHR",
+        "ehr",
+        Members::Path {
+            include: "/ehr",
+            exclude: &[],
+        },
+    ),
+    (
+        "openEHR — Query",
+        "query",
+        Members::Path {
+            include: "/query",
+            exclude: &[],
+        },
+    ),
+    (
+        "openEHR — Definition",
+        "definition",
+        Members::Path {
+            include: "/definition",
+            exclude: &[],
+        },
+    ),
+    (
+        "openEHR — Demographic",
+        "demographic",
+        Members::Path {
+            include: "/demographic",
+            // The own-design PARTY_RELATIONSHIP extension shares the /demographic
+            // root but is its own family (below).
+            exclude: &["/demographic/party_relationship"],
+        },
+    ),
+    (
+        "openEHR — Admin",
+        "admin",
+        Members::Path {
+            include: "/admin/ehr",
+            exclude: &[],
+        },
+    ),
+    // The server's own extension families, by tag.
+    (
+        "EHRbase — Status & Management",
+        "management",
+        Members::Tags(&["status", "management", "openapi"]),
+    ),
+    (
+        "EHRbase — Terminology",
+        "terminology",
+        Members::Tags(&["terminology"]),
+    ),
+    (
+        "EHRbase — Party Relationships",
+        "relationships",
+        Members::Tags(&["demographic-relationship"]),
+    ),
+    (
+        "EHRbase — Event Subscriptions",
+        "events",
+        Members::Tags(&["event-subscription"]),
+    ),
+    (
+        "EHRbase — Multi-tenancy",
+        "tenancy",
+        Members::Tags(&["tenancy"]),
+    ),
+    ("EHRbase — FHIR Connector", "fhir", Members::Tags(&["fhir"])),
+    (
+        "EHRbase — SMART Discovery",
+        "smart",
+        Members::Tags(&["smart"]),
+    ),
+];
+
+/// Whether `rel` equals `prefix` or continues past it on a path-segment boundary
+/// (so `/ehr` matches `/ehr` and `/ehr/{id}`, never a hypothetical `/ehrx`).
+fn on_segment_boundary(rel: &str, prefix: &str) -> bool {
+    rel == prefix
+        || rel
+            .strip_prefix(prefix)
+            .is_some_and(|tail| tail.starts_with('/'))
+}
+
+/// A copy of `doc` keeping only the paths whose base-path-relative form is under
+/// `include` (segment-boundary) and under none of `exclude`. Whole path items
+/// are kept or dropped — an ITS-REST resource path belongs entirely to one group.
+fn filter_by_path(
+    doc: &utoipa::openapi::OpenApi,
+    base_path: &str,
+    include: &str,
+    exclude: &[&str],
+) -> utoipa::openapi::OpenApi {
+    let mut out = doc.clone();
+    out.paths.paths.retain(|path, _| {
+        let Some(rel) = path.strip_prefix(base_path) else {
+            return false;
+        };
+        on_segment_boundary(rel, include) && !exclude.iter().any(|ex| on_segment_boundary(rel, ex))
+    });
+    prune_tags(&mut out);
+    out
+}
+
+/// A copy of `doc` keeping only the operations tagged with one of `tags`
+/// (paths whose every operation is filtered away are dropped entirely).
+fn filter_by_tags(doc: &utoipa::openapi::OpenApi, tags: &[&str]) -> utoipa::openapi::OpenApi {
+    let mut out = doc.clone();
+    out.paths.paths.retain(|_, item| {
+        for op in [
+            &mut item.get,
+            &mut item.put,
+            &mut item.post,
+            &mut item.delete,
+            &mut item.options,
+            &mut item.head,
+            &mut item.patch,
+            &mut item.trace,
+        ] {
+            if let Some(inner) = op
+                && !inner
+                    .tags
+                    .as_ref()
+                    .is_some_and(|t| t.iter().any(|t| tags.contains(&t.as_str())))
+            {
+                *op = None;
+            }
+        }
+        item.get.is_some()
+            || item.put.is_some()
+            || item.post.is_some()
+            || item.delete.is_some()
+            || item.options.is_some()
+            || item.head.is_some()
+            || item.patch.is_some()
+            || item.trace.is_some()
+    });
+    prune_tags(&mut out);
+    out
+}
+
+/// Drop tag declarations no retained operation carries, so a family document's
+/// tag list shows exactly the resource groups it contains.
+fn prune_tags(doc: &mut utoipa::openapi::OpenApi) {
+    let mut used = std::collections::BTreeSet::new();
+    for item in doc.paths.paths.values() {
+        for op in [
+            &item.get,
+            &item.put,
+            &item.post,
+            &item.delete,
+            &item.options,
+            &item.head,
+            &item.patch,
+            &item.trace,
+        ] {
+            if let Some(inner) = op
+                && let Some(tags) = &inner.tags
+            {
+                for t in tags {
+                    used.insert(t.clone());
+                }
+            }
+        }
+    }
+    if let Some(doc_tags) = &mut doc.tags {
+        doc_tags.retain(|t| used.contains(&t.name));
+    }
+}
+
+/// One filtered extension-family document as JSON.
+async fn family_json<S: Platform>(
+    State(state): State<AppState<S>>,
+    Path(family): Path<String>,
+) -> Response {
+    let Some((name, _, members)) = FAMILIES.iter().find(|(_, slug, _)| *slug == family) else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    let cfg = state.config();
+    let full = extensions_document::<S>(cfg);
+    let mut doc = match members {
+        Members::Path { include, exclude } => {
+            filter_by_path(&full, &cfg.server.base_path, include, exclude)
+        }
+        Members::Tags(tags) => filter_by_tags(&full, tags),
+    };
+    doc.info.title = (*name).to_owned();
+    let body = serde_json::to_string(&doc).unwrap_or_else(|_| "{}".to_owned());
+    ([(header::CONTENT_TYPE, "application/json")], body).into_response()
+}
+
 // ── The Swagger router (serving; kept on the loop-free `serve()` mechanism) ───
 
-/// Build the docs router: the Swagger UI (loop-free) and the single
-/// `ehrbase-rest` extension-surface document (our own natively generated OAS).
-/// Config paths come from [`AppConfig`]. No vendored OAS is served (owner rule).
+/// Build the docs router: the Swagger UI (loop-free), the complete
+/// `openapi.json`, and one filtered JSON document per API family — ALL
+/// server-generated (nothing vendored is served). Config paths come from
+/// [`AppConfig`].
 pub(crate) fn swagger_router<S: Platform>(cfg: &AppConfig) -> Router<AppState<S>> {
     let ui_path = cfg.server.swagger_ui_path();
     let json_path = cfg.server.openapi_json_path();
+    let api_docs_root = api_docs_root(&json_path);
 
-    // Our own extension-surface document (utoipa-composed, config-driven auth).
-    let router = Router::new().route(&json_path, get(openapi_json::<S>));
+    // The complete composed document (tooling + the selector's full entry).
+    let mut router = Router::new().route(&json_path, get(openapi_json::<S>));
+
+    // One filtered document per API family (standard groups + extensions).
+    router = router.route(
+        &format!("{api_docs_root}/ehrbase-{{family}}.openapi.json"),
+        get(family_json::<S>),
+    );
 
     // The UI itself: assets straight from the embedded dist. The bare mount path
     // serves index.html (serve() maps "" to it) — no redirect, no loop.
@@ -244,12 +489,31 @@ pub(crate) fn swagger_router<S: Platform>(cfg: &AppConfig) -> Router<AppState<S>
     )
 }
 
-/// The Swagger UI spec-selector config: a single `ehrbase-rest` entry (our
-/// composed document). The URL must outlive the server, so the derived path is
-/// leaked once at construction (the UI config requires `'static`).
+/// The `api-docs` directory the documents live under (the parent of the
+/// configured `openapi.json` path).
+fn api_docs_root(json_path: &str) -> String {
+    json_path
+        .rsplit_once('/')
+        .map_or("/api-docs", |(dir, _)| dir)
+        .to_owned()
+}
+
+/// The Swagger UI spec-selector config: one entry per API family — the
+/// standardised groups (`openEHR — …`) and the server extensions
+/// (`EHRbase — …`), every one filtered from the server's own generated
+/// document — with the complete composed document last. URLs must outlive the
+/// server, so the derived paths are leaked once at construction (the UI
+/// config requires `'static`).
 fn swagger_config(cfg: &AppConfig) -> Arc<Config<'static>> {
     let json_path = cfg.server.openapi_json_path();
-    let urls: Vec<Url<'static>> = vec![Url::new("ehrbase-rest", json_path.leak())];
+    let root = api_docs_root(&json_path);
+
+    let mut urls: Vec<Url<'static>> = Vec::new();
+    for (name, slug, _) in FAMILIES {
+        let url = format!("{root}/ehrbase-{slug}.openapi.json");
+        urls.push(Url::new(*name, url.leak()));
+    }
+    urls.push(Url::new("EHRbase — Complete surface", json_path.leak()));
     Arc::new(Config::new(urls))
 }
 

--- a/app/ehrbase-rest/src/extensions/openapi.rs
+++ b/app/ehrbase-rest/src/extensions/openapi.rs
@@ -437,10 +437,7 @@ fn prune_tags(doc: &mut utoipa::openapi::OpenApi) {
 }
 
 /// One filtered extension-family document as JSON.
-async fn family_json<S: Platform>(
-    State(state): State<AppState<S>>,
-    Path(family): Path<String>,
-) -> Response {
+fn family_json<S: Platform>(state: &AppState<S>, family: &str) -> Response {
     let Some((name, _, members)) = FAMILIES.iter().find(|(_, slug, _)| *slug == family) else {
         return StatusCode::NOT_FOUND.into_response();
     };
@@ -452,7 +449,7 @@ async fn family_json<S: Platform>(
         }
         Members::Tags(tags) => filter_by_tags(&full, tags),
     };
-    doc.info.title = (*name).to_owned();
+    doc.info.title = (*name).to_string();
     let body = serde_json::to_string(&doc).unwrap_or_else(|_| "{}".to_owned());
     ([(header::CONTENT_TYPE, "application/json")], body).into_response()
 }
@@ -472,10 +469,18 @@ pub(crate) fn swagger_router<S: Platform>(cfg: &AppConfig) -> Router<AppState<S>
     let mut router = Router::new().route(&json_path, get(openapi_json::<S>));
 
     // One filtered document per API family (standard groups + extensions).
-    router = router.route(
-        &format!("{api_docs_root}/ehrbase-{{family}}.openapi.json"),
-        get(family_json::<S>),
-    );
+    // One static route per family: axum path captures span a whole segment,
+    // so a `{family}` embedded inside the `ehrbase-….openapi.json` filename
+    // cannot be a route parameter.
+    for (_, slug, _) in FAMILIES {
+        router =
+            router.route(
+                &format!("{api_docs_root}/ehrbase-{slug}.openapi.json"),
+                get(move |State(state): State<AppState<S>>| async move {
+                    family_json::<S>(&state, slug)
+                }),
+            );
+    }
 
     // The UI itself: assets straight from the embedded dist. The bare mount path
     // serves index.html (serve() maps "" to it) — no redirect, no loop.
@@ -511,7 +516,7 @@ fn swagger_config(cfg: &AppConfig) -> Arc<Config<'static>> {
     let mut urls: Vec<Url<'static>> = Vec::new();
     for (name, slug, _) in FAMILIES {
         let url = format!("{root}/ehrbase-{slug}.openapi.json");
-        urls.push(Url::new(*name, url.leak()));
+        urls.push(Url::new(name, url.leak()));
     }
     urls.push(Url::new("EHRbase — Complete surface", json_path.leak()));
     Arc::new(Config::new(urls))

--- a/app/ehrbase-rest/tests/extensions_openapi.rs
+++ b/app/ehrbase-rest/tests/extensions_openapi.rs
@@ -126,6 +126,52 @@ async fn every_documented_path_routes() {
     assert!(checked >= 40, "drove only {checked} documented operations");
 }
 
+// ── Test 3: every spec-selector family document is non-empty ──────────────────
+
+/// Every family the Swagger spec-selector offers must serve a non-empty
+/// document — the path-prefix criterion (standard ITS-REST groups) and the
+/// tag criterion (server extensions) must each match at least one operation on
+/// a fully-enabled server.
+#[tokio::test]
+async fn every_family_document_is_non_empty() {
+    let app = full_app();
+    // The family slugs offered by `FAMILIES` in `extensions::openapi` (private
+    // there; the selector URLs are the stable public contract).
+    for slug in [
+        "ehr",
+        "query",
+        "definition",
+        "demographic",
+        "admin",
+        "management",
+        "terminology",
+        "relationships",
+        "events",
+        "tenancy",
+        "fhir",
+        "smart",
+    ] {
+        let uri = format!("/ehrbase/rest/api-docs/ehrbase-{slug}.openapi.json");
+        let resp = app
+            .clone()
+            .oneshot(get(&uri))
+            .await
+            .expect("family response");
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "family {slug} must serve ({uri})"
+        );
+        let bytes = resp.into_body().collect().await.expect("body").to_bytes();
+        let v: Value = serde_json::from_slice(&bytes).expect("family json");
+        let paths = v["paths"].as_object().expect("paths object");
+        assert!(
+            !paths.is_empty(),
+            "family {slug} document has no paths (its selector criterion matched nothing)"
+        );
+    }
+}
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 fn is_method(key: &str) -> bool {

--- a/app/ehrbase/Cargo.toml
+++ b/app/ehrbase/Cargo.toml
@@ -70,7 +70,6 @@ base64.workspace = true
 # payloads to/from it.
 object_store.workspace = true
 bytes.workspace = true
-secrecy = { workspace = true, features = ["serde"] }
 # PORT NOTE: rPGP 0.20's `DetachedSignature::sign_binary_data` takes an
 # `rng: Rng + CryptoRng` from rand 0.8's rand_core 0.6; the workspace `rand`
 # pin (0.10) is a trait-incompatible major, so the `signing` module pins the

--- a/crates/openehr-flat/tests/validation.rs
+++ b/crates/openehr-flat/tests/validation.rs
@@ -46,9 +46,18 @@ fn opt_files(dir: &Path, out: &mut Vec<PathBuf>) {
 }
 
 /// `template_id` → `WebTemplate` for every parseable vendored OPT.
+///
+/// Several vendored fixtures share one template id (`Demo Vitals` has three
+/// variants), and `read_dir` order is OS-dependent — first-wins over an
+/// unspecified order made the winning variant differ between macOS and Linux
+/// (a CI-only corpus failure: Linux's order left a variant whose constraints
+/// flag the corpus node that the curation baseline accepts). Deterministic
+/// resolution: sorted paths, first wins — the ordering the `CLEAN_COMPOSITIONS`
+/// curation was verified against, identical on every OS.
 fn web_templates() -> HashMap<String, WebTemplate> {
     let mut opts = Vec::new();
     opt_files(&manifest_dir().join("tests/fixtures"), &mut opts);
+    opts.sort();
     let mut wts = HashMap::new();
     for p in &opts {
         let Ok(xml) = std::fs::read_to_string(p) else {

--- a/deny.toml
+++ b/deny.toml
@@ -21,6 +21,12 @@ ignore = [
   # path uses quick-xml 0.41 (fixed). Re-check on the next object_store release.
   { id = "RUSTSEC-2026-0194", reason = "via object_store 0.14.0 (latest) pinning quick-xml ^0.40; parses operator-configured S3 responses only" },
   { id = "RUSTSEC-2026-0195", reason = "via object_store 0.14.0 (latest) pinning quick-xml ^0.40; parses operator-configured S3 responses only" },
+  # 2026-07-15: `paste` (proc-macro) is archived/unmaintained — pulled in by
+  # utoipa-axum 0.2.0 (the LATEST release of the official utoipa axum
+  # bindings; no paste-free release exists). Compile-time-only token pasting,
+  # no runtime code, no attack surface. Re-check on the next utoipa-axum
+  # release. https://rustsec.org/advisories/RUSTSEC-2024-0436
+  { id = "RUSTSEC-2024-0436", reason = "compile-time proc-macro via utoipa-axum 0.2.0 (latest); no runtime surface" },
 ]
 
 [licenses]


### PR DESCRIPTION
The server-generated OpenAPI document now categorizes operations exactly like the reference ITS-REST group documents (used as reference only — nothing vendored is served): resource tags (EHR, EHR_STATUS, COMPOSITION, DIRECTORY, CONTRIBUTION, ITEM_TAG, the five party types, VERSIONED_PARTY, ADL1.4, ADL2, Query) and a spec selector with one document per API family (five openEHR groups + seven EHRbase extension families + the complete surface), all filtered from the one generated document.

CI is the gate for this PR (owner flow); every red gets fixed before merge. v3.0.3 follows on green.