### PR TITLE
release: cut v3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+## [3.0.3] - 2026-07-16
+
 ### Changed
 
 - The served OpenAPI documents now categorize operations the way the
@@ -561,7 +563,8 @@ but has not yet run in production.
 - Helm chart with security-hardened defaults (non-root, read-only rootfs,
   seccomp, default-deny NetworkPolicy) and golden-render validation.
 
-[unreleased]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.0.2...HEAD
+[unreleased]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.0.3...HEAD
+[3.0.3]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.0.2...v3.0.3
 [3.0.2]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.0.1...v3.0.2
 [3.0.1]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.0.0...v3.0.1
 [3.0.0]: https://github.com/rubentalstra/ehrbase-rs/releases/tag/v3.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,7 +634,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "benchmark"
-version = "3.0.2"
+version = "3.0.3"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "conformance"
-version = "3.0.2"
+version = "3.0.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2053,7 +2053,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase"
-version = "3.0.2"
+version = "3.0.3"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -2118,7 +2118,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase-rest"
-version = "3.0.2"
+version = "3.0.3"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -2163,7 +2163,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase-sm"
-version = "3.0.2"
+version = "3.0.3"
 dependencies = [
  "async-trait",
  "jiff",
@@ -4379,7 +4379,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-codegen"
-version = "3.0.2"
+version = "3.0.3"
 dependencies = [
  "roxmltree",
  "serde_json",
@@ -4388,7 +4388,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-derive"
-version = "3.0.2"
+version = "3.0.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4399,7 +4399,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-flat"
-version = "3.0.2"
+version = "3.0.3"
 dependencies = [
  "fancy-regex",
  "indexmap 2.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "3"                      # resolver v3 (edition 2024)
 members = ["crates/*", "app/*", "tools/*"]
 
 [workspace.package]
-version = "3.0.2"
+version = "3.0.3"
 edition = "2024"
 rust-version = "1.96"
 license = "Apache-2.0"

--- a/deploy/helm/ehrbase-rs/Chart.yaml
+++ b/deploy/helm/ehrbase-rs/Chart.yaml
@@ -9,9 +9,9 @@ description: >-
 type: application
 
 # Chart versioning is independent of the application version.
-version: 3.0.2
+version: 3.0.3
 # The default container image tag (informational; overridable via image.tag).
-appVersion: "3.0.2"
+appVersion: "3.0.3"
 
 # PDB (policy/v1, GA 1.21), HPA (autoscaling/v2, GA 1.23), and the
 # seccompProfile pod field (GA 1.27) all resolve cleanly at 1.25+.

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -9,10 +9,10 @@ kind: NetworkPolicy
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.2
+    helm.sh/chart: ehrbase-rs-3.0.3
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.2"
+    app.kubernetes.io/version: "3.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -55,10 +55,10 @@ kind: PodDisruptionBudget
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.2
+    helm.sh/chart: ehrbase-rs-3.0.3
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.2"
+    app.kubernetes.io/version: "3.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -74,10 +74,10 @@ kind: ServiceAccount
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.2
+    helm.sh/chart: ehrbase-rs-3.0.3
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.2"
+    app.kubernetes.io/version: "3.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
   annotations:
@@ -93,10 +93,10 @@ kind: Secret
 metadata:
   name: ehrbase-rs-env
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.2
+    helm.sh/chart: ehrbase-rs-3.0.3
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.2"
+    app.kubernetes.io/version: "3.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 type: Opaque
@@ -117,10 +117,10 @@ kind: Secret
 metadata:
   name: ehrbase-rs-config
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.2
+    helm.sh/chart: ehrbase-rs-3.0.3
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.2"
+    app.kubernetes.io/version: "3.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 type: Opaque
@@ -136,10 +136,10 @@ kind: ConfigMap
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.2
+    helm.sh/chart: ehrbase-rs-3.0.3
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.2"
+    app.kubernetes.io/version: "3.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 data:
@@ -285,10 +285,10 @@ kind: Service
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.2
+    helm.sh/chart: ehrbase-rs-3.0.3
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.2"
+    app.kubernetes.io/version: "3.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -312,10 +312,10 @@ kind: Deployment
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.2
+    helm.sh/chart: ehrbase-rs-3.0.3
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.2"
+    app.kubernetes.io/version: "3.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -327,7 +327,7 @@ spec:
     metadata:
       annotations:
         # Roll pods when the rendered ehrbase.toml changes.
-        checksum/config: 54c6a9296375f7108ed14fe8131f12d169c90b5a791e7bde21b2e410a82a64dc
+        checksum/config: 97e3572089ca5aa537e72f89b17b7a81a76ceb4974d4852f530b6272988c1ebb
         prometheus.io/scrape: "true"
         prometheus.io/port: "9100"
         prometheus.io/path: "/management/prometheus"
@@ -348,7 +348,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ehrbase
-          image: "ghcr.io/rubentalstra/ehrbase-rs:3.0.2"
+          image: "ghcr.io/rubentalstra/ehrbase-rs:3.0.3"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -467,10 +467,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.2
+    helm.sh/chart: ehrbase-rs-3.0.3
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.2"
+    app.kubernetes.io/version: "3.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -500,10 +500,10 @@ kind: Ingress
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.2
+    helm.sh/chart: ehrbase-rs-3.0.3
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.2"
+    app.kubernetes.io/version: "3.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -9,10 +9,10 @@ kind: NetworkPolicy
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.2
+    helm.sh/chart: ehrbase-rs-3.0.3
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.2"
+    app.kubernetes.io/version: "3.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -33,10 +33,10 @@ kind: PodDisruptionBudget
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.2
+    helm.sh/chart: ehrbase-rs-3.0.3
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.2"
+    app.kubernetes.io/version: "3.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -52,10 +52,10 @@ kind: ServiceAccount
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.2
+    helm.sh/chart: ehrbase-rs-3.0.3
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.2"
+    app.kubernetes.io/version: "3.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 automountServiceAccountToken: false
@@ -66,10 +66,10 @@ kind: ConfigMap
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.2
+    helm.sh/chart: ehrbase-rs-3.0.3
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.2"
+    app.kubernetes.io/version: "3.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 data:
@@ -162,10 +162,10 @@ kind: Service
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.2
+    helm.sh/chart: ehrbase-rs-3.0.3
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.2"
+    app.kubernetes.io/version: "3.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -185,10 +185,10 @@ kind: Deployment
 metadata:
   name: ehrbase-rs
   labels:
-    helm.sh/chart: ehrbase-rs-3.0.2
+    helm.sh/chart: ehrbase-rs-3.0.3
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.0.2"
+    app.kubernetes.io/version: "3.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -201,7 +201,7 @@ spec:
     metadata:
       annotations:
         # Roll pods when the rendered ehrbase.toml changes.
-        checksum/config: 3bf0b723b61503bc653df58ac3cd28d78e894c76693a959b9bfd97677b669c5a
+        checksum/config: 579f135ec431ab6aa2f06ff9fe2cd232db99543b8a2afded76ca83d847ce1284
       labels:
         app.kubernetes.io/name: ehrbase-rs
         app.kubernetes.io/instance: ehrbase-rs
@@ -219,7 +219,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ehrbase
-          image: "ghcr.io/rubentalstra/ehrbase-rs:3.0.2"
+          image: "ghcr.io/rubentalstra/ehrbase-rs:3.0.3"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
Cuts v3.0.3: the reference-style OpenAPI categorization + Swagger per-family selector, and the CI hardening fixes (deterministic corpus fixtures, yanked spin bumps, paste advisory ignore, per-family docs route fix). Changelog section added, workspace 3.0.2 -> 3.0.3, Helm chart/appVersion bumped, goldens regenerated (ALL CHECKS PASSED). Tag v3.0.3 follows the merge.