### PR TITLE
containers: admin-ui tools install as prebuilt binaries — no OpenSSL C build in the pipeline

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -216,23 +216,29 @@ jobs:
 
       # The site bundle (wasm32 + Tailwind CSS + JS glue) — built once, on
       # amd64 only; it is byte-identical regardless of the server arch.
+      # NEVER `cargo install cargo-leptos` here: it unconditionally builds
+      # OpenSSL from vendored C source (its cargo-generate dependency pins
+      # `vendored-openssl`), which needs perl/make and failed inside the slim
+      # image. Prebuilt release binaries keep the pipeline Rust-toolchain-only
+      # — the same taiki-e path the ci.yml ui-e2e job uses.
+      - name: Install curl for the tool downloads (amd64 only)
+        if: matrix.platform == 'amd64'
+        run: apt-get update && apt-get install -y --no-install-recommends curl ca-certificates
+
+      - uses: taiki-e/install-action@v2
+        if: matrix.platform == 'amd64'
+        with:
+          tool: cargo-leptos@0.3.7,wasm-bindgen@0.2.126
+
       - name: Build the site bundle (amd64 only)
         if: matrix.platform == 'amd64'
         shell: bash
         run: |
           set -euo pipefail
-          # perl (full, for FindBin) + make: `cargo install cargo-leptos`
-          # compiles openssl-sys from vendored source inside the slim image,
-          # and OpenSSL's Configure needs them (FindBin is absent from
-          # perl-base — the v3.1.1 admin-ui asset run failed exactly there).
-          apt-get update && apt-get install -y --no-install-recommends \
-            curl ca-certificates perl make
           rustup target add wasm32-unknown-unknown
           curl -sSfL -o /usr/local/bin/tailwindcss \
             https://github.com/tailwindlabs/tailwindcss/releases/download/v4.3.3/tailwindcss-linux-x64
           chmod +x /usr/local/bin/tailwindcss
-          cargo install cargo-leptos --version 0.3.7 --locked
-          cargo install wasm-bindgen-cli --version 0.2.126 --locked
           cd app/ehrbase-admin-ui
           LEPTOS_TAILWIND_VERSION=v4.3.3 cargo leptos build --release
 

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -221,7 +221,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          apt-get update && apt-get install -y --no-install-recommends curl ca-certificates
+          # perl (full, for FindBin) + make: `cargo install cargo-leptos`
+          # compiles openssl-sys from vendored source inside the slim image,
+          # and OpenSSL's Configure needs them (FindBin is absent from
+          # perl-base — the v3.1.1 admin-ui asset run failed exactly there).
+          apt-get update && apt-get install -y --no-install-recommends \
+            curl ca-certificates perl make
           rustup target add wasm32-unknown-unknown
           curl -sSfL -o /usr/local/bin/tailwindcss \
             https://github.com/tailwindlabs/tailwindcss/releases/download/v4.3.3/tailwindcss-linux-x64


### PR DESCRIPTION
The new `admin-ui-binary` job's site-bundle step failed on develop ([run 29636156881](https://github.com/rubentalstra/ehrbase-rs/actions/runs/29636156881)): `cargo install cargo-leptos 0.3.7` unconditionally compiles OpenSSL from vendored C source — its `cargo-generate` dependency pins the `vendored-openssl` feature (no feature flag removes it) — and OpenSSL's `Configure` needs perl's `FindBin`, which `rust:1.96.1-slim-bookworm`'s `perl-base` lacks.

Rather than installing perl + make to make a C build work, the step now installs **cargo-leptos and wasm-bindgen as prebuilt release binaries** via `taiki-e/install-action` — the exact path the `ui-e2e` job in ci.yml already uses. No OpenSSL, no C toolchain, and minutes faster. The product itself was always pure rustls; now the pipeline is C-build-free too.