### PR TITLE
docs: website conformance claims derived from ECC artifacts, stale numbers CI-forbidden

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,11 @@ jobs:
           if [ -z "$changed" ]; then
             echo "code=false" >> "$GITHUB_OUTPUT"; exit 0
           fi
-          if echo "$changed" | grep -qE '^(app/|crates/|tools/|scripts/|\.cargo/|\.config/|Cargo\.toml$|Cargo\.lock$|rust-toolchain\.toml$|rustfmt\.toml$|clippy\.toml$|deny\.toml$)' ; then
+          # Docs-site-only scripts never affect a cargo build — a pure website
+          # PR must not pay for the Rust suite. Everything else under
+          # scripts/ (conformance, drift check, e2e, …) stays build-relevant.
+          code_relevant=$(echo "$changed" | grep -vE '^scripts/(assemble-oas|build-site|render-conformance-stats|check-conformance-numbers|cut-version|vendor-spec-docs)\.sh$' || true)
+          if echo "$code_relevant" | grep -qE '^(app/|crates/|tools/|scripts/|\.cargo/|\.config/|Cargo\.toml$|Cargo\.lock$|rust-toolchain\.toml$|rustfmt\.toml$|clippy\.toml$|deny\.toml$)' ; then
             echo "code=true" >> "$GITHUB_OUTPUT"
           else
             echo "No build-relevant paths touched — cargo jobs will be skipped."

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,6 +39,8 @@ jobs:
           tool: mdbook@${{ env.MDBOOK_VERSION }},mdbook-mermaid@${{ env.MDBOOK_MERMAID_VERSION }},mdbook-toc@${{ env.MDBOOK_TOC_VERSION }},mdbook-lint@${{ env.MDBOOK_LINT_VERSION }},lychee@${{ env.LYCHEE_VERSION }}
       - name: OAS drift gate (docs copy == vendored ITS-REST)
         run: bash scripts/assemble-oas.sh --check       # regenerate + git diff --exit-code
+      - name: Stale-numbers gate (no hand-typed conformance claims in site sources)
+        run: bash scripts/check-conformance-numbers.sh
       - name: Markdown lint gate
         run: mdbook-lint lint website/book/src
       - name: Assemble _site (landing + api + /docs/dev/)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,6 +41,8 @@ jobs:
         run: bash scripts/assemble-oas.sh --check       # regenerate + git diff --exit-code
       - name: Stale-numbers gate (no hand-typed conformance claims in site sources)
         run: bash scripts/check-conformance-numbers.sh
+      - name: Render conformance stats (the generated include must exist before lint)
+        run: bash scripts/render-conformance-stats.sh includes
       - name: Markdown lint gate
         run: mdbook-lint lint website/book/src
       - name: Assemble _site (landing + api + /docs/dev/)

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ _check/
 
 # Stray local build artifacts
 *.rlib
+website/book/generated/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ openEHR REST API (ITS-REST 1.0.3) &nbsp;·&nbsp; AQL 1.1 query engine &nbsp;·&n
 [![Containers](https://github.com/rubentalstra/ehrbase-rs/actions/workflows/containers.yml/badge.svg?branch=develop)](https://github.com/rubentalstra/ehrbase-rs/actions/workflows/containers.yml)
 [![Last commit](https://img.shields.io/github/last-commit/rubentalstra/ehrbase-rs/develop?logo=github)](https://github.com/rubentalstra/ehrbase-rs/commits/develop)
 
+<!-- ECC conformance badges: shields.io endpoint scheme over the runner-generated
+     badge JSONs on develop — auto-updating on every merged ECC ratchet, zero
+     manual edits (issue #138). -->
+[![ECC conformance](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Frubentalstra%2Fehrbase-rs%2Fdevelop%2Fdocs%2Fconformance%2Fehrbase-rs%2Fbadge.json)](https://github.com/rubentalstra/ehrbase-rs/blob/develop/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md)
+[![ECC CORE](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Frubentalstra%2Fehrbase-rs%2Fdevelop%2Fdocs%2Fconformance%2Fehrbase-rs%2Fbadge-core.json)](https://github.com/rubentalstra/ehrbase-rs/blob/develop/docs/conformance/ehrbase-rs/CONFORMANCE_CERTIFICATE.md)
+[![ECC STANDARD](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Frubentalstra%2Fehrbase-rs%2Fdevelop%2Fdocs%2Fconformance%2Fehrbase-rs%2Fbadge-standard.json)](https://github.com/rubentalstra/ehrbase-rs/blob/develop/docs/conformance/ehrbase-rs/CONFORMANCE_CERTIFICATE.md)
+[![ECC OPTIONS](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Frubentalstra%2Fehrbase-rs%2Fdevelop%2Fdocs%2Fconformance%2Fehrbase-rs%2Fbadge-options.json)](https://github.com/rubentalstra/ehrbase-rs/blob/develop/docs/conformance/ehrbase-rs/CONFORMANCE_CERTIFICATE.md)
+
 [![Rust](https://img.shields.io/badge/rust-1.96%2B-orange.svg?logo=rust)](rust-toolchain.toml)
 [![Edition](https://img.shields.io/badge/edition-2024-blue.svg?logo=rust)](Cargo.toml)
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-18-336791.svg?logo=postgresql&logoColor=white)](docs/VERSIONS.md)
@@ -21,10 +29,6 @@ openEHR REST API (ITS-REST 1.0.3) &nbsp;·&nbsp; AQL 1.1 query engine &nbsp;·&n
 [![openEHR ITS-REST](https://img.shields.io/badge/openEHR_ITS--REST-1.0.3-1F6FEB.svg)](https://specifications.openehr.org/releases/ITS-REST/latest)
 [![openEHR TERM](https://img.shields.io/badge/openEHR_TERM-3.1.0-1F6FEB.svg)](https://specifications.openehr.org/releases/TERM/latest)
 [![openEHR SM](https://img.shields.io/badge/openEHR_SM-platform-1F6FEB.svg)](https://specifications.openehr.org/releases/SM/latest)
-[![ECC conformance](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Frubentalstra%2Fehrbase-rs%2Fdevelop%2Fdocs%2Fconformance%2Fehrbase-rs%2Fbadge.json)](docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md)
-[![ECC CORE](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Frubentalstra%2Fehrbase-rs%2Fdevelop%2Fdocs%2Fconformance%2Fehrbase-rs%2Fbadge-core.json)](docs/conformance/ehrbase-rs/CONFORMANCE_CERTIFICATE.md)
-[![ECC STANDARD](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Frubentalstra%2Fehrbase-rs%2Fdevelop%2Fdocs%2Fconformance%2Fehrbase-rs%2Fbadge-standard.json)](docs/conformance/ehrbase-rs/CONFORMANCE_CERTIFICATE.md)
-[![ECC OPTIONS](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Frubentalstra%2Fehrbase-rs%2Fdevelop%2Fdocs%2Fconformance%2Fehrbase-rs%2Fbadge-options.json)](docs/conformance/ehrbase-rs/CONFORMANCE_CERTIFICATE.md)
 [![GHCR](https://img.shields.io/badge/ghcr.io-ehrbase--rs-2496ED.svg?logo=docker&logoColor=white)](https://github.com/rubentalstra/ehrbase-rs/pkgs/container/ehrbase-rs)
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)

--- a/README.md
+++ b/README.md
@@ -60,9 +60,10 @@ Conformance Statement and Certificate.
 
 - **Compliance you can verify, not just read.** The built-in conformance
   runner executes the complete catalogue in both wire formats and computes
-  the openEHR profile verdicts — currently **CORE: PASS · STANDARD: PASS ·
-  OPTIONS: OBTAINED**, zero failing cases. The badges above are generated
-  from real runs, never hand-edited.
+  the openEHR profile verdicts. The ECC badges above render straight from
+  the committed run artifacts — generated from real runs, never hand-edited
+  — and the [Conformance Report](docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md)
+  carries the full per-case record.
 - **The latest openEHR specifications**, generated from the official
   machine-readable models: REST API 1.0.3, AQL 1.1, RM 1.2.0, Archetype
   Model 1.4 + 2.4, Terminology 3.1. A specification update is a

--- a/scripts/build-site.sh
+++ b/scripts/build-site.sh
@@ -26,12 +26,20 @@ build_book() {
 # 1. Served OAS is a byte copy of the vendored ITS-REST bundles.
 bash "$ROOT/scripts/assemble-oas.sh"
 
+# 1b. Conformance claims are derived from the committed runner artifacts —
+#     the book include is generated before mdbook runs, and the landing's
+#     data-ecc markers are filled after the copy (step 3). Sources carry no
+#     numbers (CI: scripts/check-conformance-numbers.sh).
+bash "$ROOT/scripts/render-conformance-stats.sh" includes
+
 # 2. Clean + recreate _site.
 rm -rf "$OUT"
 mkdir -p "$OUT"
 
-# 3. Landing at the site root (relative-URL HTML, so no base-path rewriting).
+# 3. Landing at the site root (relative-URL HTML, so no base-path rewriting);
+#    conformance markers filled from the committed artifacts.
 cp -R "$ROOT/website/landing/." "$OUT/"
+bash "$ROOT/scripts/render-conformance-stats.sh" fill-html "$OUT/index.html"
 
 # 4. API endpoint reference at /api/ (Swagger UI + vendored dist + served specs).
 mkdir -p "$OUT/api"

--- a/scripts/check-conformance-numbers.sh
+++ b/scripts/check-conformance-numbers.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# The stale-numbers gate (CI, docs workflow): fails the build if a hand-typed
+# conformance claim appears in the site SOURCES. Conformance numbers and
+# verdicts on the website are derived at build time from the committed runner
+# artifacts by scripts/render-conformance-stats.sh — sources must carry only
+# the data-ecc markers / {{#include}} directives, never literal numbers.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Two claim shapes are forbidden in website/landing + website/book/src:
+#   1. a 1-4 digit number adjacent to conformance-count vocabulary
+#   2. a spelled-out profile verdict (CORE/STANDARD/OPTIONS with PASS/FAIL/OBTAINED)
+# website/book/generated/ is the render OUTPUT and is exempt (and gitignored).
+# Digit-anchored: a number immediately (allowing intervening HTML tags)
+# followed by conformance-count vocabulary. Digit-less mechanism prose
+# ("every executed case passed") is deliberately NOT matched.
+pattern_counts='[0-9]{1,4}[[:space:]]*(<[^>]*>)*[[:space:]]*(cases?([- ]by[- ]format)?|executions?|passed|failed|skipped|executed|documented skips)([^_a-zA-Z]|$)'
+pattern_verdicts='(CORE|STANDARD|OPTIONS|Core|Standard|Options)[[:space:]]*[:·][[:space:]]*(PASS|FAIL|OBTAINED|Pass|Fail|Obtained)'
+
+fail=0
+for pattern in "$pattern_counts" "$pattern_verdicts"; do
+  if hits=$(grep -rInE "$pattern" website/landing website/book/src 2>/dev/null); then
+    echo "$hits"
+    fail=1
+  fi
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo "::error::Hand-typed conformance numbers/verdicts found in site sources (above). The website derives conformance claims at build time from docs/conformance/ehrbase-rs/ — use the data-ecc markers (landing) or the generated include (book), never literals. See scripts/render-conformance-stats.sh." >&2
+  exit 1
+fi
+echo "check-conformance-numbers: no hand-typed conformance claims in site sources."

--- a/scripts/check-conformance-numbers.sh
+++ b/scripts/check-conformance-numbers.sh
@@ -19,7 +19,7 @@ pattern_verdicts='(CORE|STANDARD|OPTIONS|Core|Standard|Options)[[:space:]]*[:·]
 
 fail=0
 for pattern in "$pattern_counts" "$pattern_verdicts"; do
-  if hits=$(grep -rInE "$pattern" website/landing website/book/src 2>/dev/null); then
+  if hits=$(grep -rInE "$pattern" website/landing website/book/src README.md 2>/dev/null); then
     echo "$hits"
     fail=1
   fi

--- a/scripts/render-conformance-stats.sh
+++ b/scripts/render-conformance-stats.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Derive every website conformance claim from the committed runner artifacts
+# (docs/conformance/ehrbase-rs/) at BUILD time — the site sources carry no
+# hand-typed conformance numbers (enforced by scripts/check-conformance-numbers.sh
+# in CI), so the stale-numbers failure mode is impossible by construction.
+#
+#   render-conformance-stats.sh includes          write website/book/generated/*.md
+#   render-conformance-stats.sh fill-html FILE    fill data-ecc markers in FILE in place
+#
+# Consumed by scripts/build-site.sh; runnable standalone for local previews.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+ART="docs/conformance/ehrbase-rs"
+command -v jq >/dev/null 2>&1 || {
+  echo "render-conformance-stats: jq is required (brew install jq / preinstalled on CI runners)" >&2
+  exit 1
+}
+[ -f "$ART/results.json" ] || {
+  echo "render-conformance-stats: $ART/results.json missing — run the conformance suite first" >&2
+  exit 1
+}
+
+executed=$(jq '.cases | length' "$ART/results.json")
+passed=$(jq '[.cases[] | select(.status == "passed")] | length' "$ART/results.json")
+failed=$(jq '[.cases[] | select(.status == "failed" or .status == "errored")] | length' "$ART/results.json")
+skipped=$(jq '[.cases[] | select(.status == "skipped")] | length' "$ART/results.json")
+run_date=$(jq -r '.started' "$ART/results.json" | cut -dT -f1)
+# Verdicts come from the runner-generated badge JSONs (first word of message).
+core=$(jq -r '.message' "$ART/badge-core.json" | awk '{print $1}')
+standard=$(jq -r '.message' "$ART/badge-standard.json" | awk '{print $1}')
+options=$(jq -r '.message' "$ART/badge-options.json" | awk '{print $1}')
+
+# Sanity: refuse to render nonsense (a truncated artifact must fail the build).
+for v in "$executed" "$passed" "$failed" "$skipped"; do
+  [[ "$v" =~ ^[0-9]+$ ]] || { echo "render-conformance-stats: non-numeric stat '$v'" >&2; exit 1; }
+done
+for v in "$core" "$standard" "$options"; do
+  [ -n "$v" ] || { echo "render-conformance-stats: empty verdict in badge JSON" >&2; exit 1; }
+done
+
+case "${1:-includes}" in
+  includes)
+    mkdir -p website/book/generated
+    cat > website/book/generated/conformance-stats.md <<EOF
+- **${executed} case-by-format executions, ${passed} passed, ${failed} failed,
+  ${skipped} documented skips** (run of ${run_date}).
+- **Core: ${core}. Standard: ${standard}. Options: ${options}.**
+EOF
+    echo "render-conformance-stats: wrote website/book/generated/conformance-stats.md (${passed}/${executed}, run ${run_date})"
+    ;;
+  fill-html)
+    file="${2:?fill-html needs a file argument}"
+    perl -pi -e "
+      s/(data-ecc=\"executed\"[^>]*>)[^<]*/\${1}${executed}/g;
+      s/(data-ecc=\"passed\"[^>]*>)[^<]*/\${1}${passed}/g;
+      s/(data-ecc=\"failed\"[^>]*>)[^<]*/\${1}${failed}/g;
+      s/(data-ecc=\"verdict-core\"[^>]*>)[^<]*/\${1}CORE · ${core}/g;
+      s/(data-ecc=\"verdict-standard\"[^>]*>)[^<]*/\${1}STANDARD · ${standard}/g;
+      s/(data-ecc=\"verdict-options\"[^>]*>)[^<]*/\${1}OPTIONS · ${options}/g;
+    " "$file"
+    # A marker that survived filling means the HTML and this script drifted.
+    if grep -qE 'data-ecc="[^"]*"[^>]*>—<' "$file"; then
+      echo "render-conformance-stats: unfilled data-ecc marker left in $file" >&2
+      exit 1
+    fi
+    echo "render-conformance-stats: filled $file"
+    ;;
+  *)
+    echo "usage: $0 [includes | fill-html FILE]" >&2
+    exit 2
+    ;;
+esac

--- a/website/book/src/conformance.md
+++ b/website/book/src/conformance.md
@@ -51,9 +51,10 @@ than silently omitted.
 
 The published run against EHRbase-rs reports:
 
-- **369 case-by-format executions, 334 passed, 0 failed, 35 documented
-  skips.**
-- **Core: PASS. Standard: PASS. Options: OBTAINED.**
+<!-- Generated at build time from docs/conformance/ehrbase-rs/results.json by
+     scripts/render-conformance-stats.sh — never hand-type numbers here (CI:
+     scripts/check-conformance-numbers.sh). -->
+{{#include ../generated/conformance-stats.md}}
 
 The executions that did not pass are documented skips, each with a stated
 reason, not failures. Options is _obtained_ because it aggregates optional

--- a/website/book/src/introduction.md
+++ b/website/book/src/introduction.md
@@ -28,9 +28,9 @@ what you query and what you read back.
 
 - **Compliance you can verify, not just read.** Every release runs the full
   openEHR conformance catalogue against the live server, in both JSON and XML,
-  and computes the profile verdicts automatically — currently **CORE: PASS,
-  STANDARD: PASS, OPTIONS: OBTAINED**, with zero failing cases. See
-  [Conformance](conformance.md).
+  and computes the profile verdicts automatically. The current, run-derived
+  result — every number generated from the committed artifacts, never
+  hand-typed — is on the [Conformance](conformance.md) page.
 - **The latest openEHR specifications**, generated directly from the official
   machine-readable models: the REST API development edition, AQL 1.1,
   Reference Model 1.2.0, Archetype Model 1.4 and 2.4, Terminology 3.1. A

--- a/website/landing/index.html
+++ b/website/landing/index.html
@@ -60,15 +60,19 @@
           <h2>Compliance you can verify, not just read.</h2>
           <p>Every release runs the complete conformance catalogue against the live server, in JSON and XML, and computes the openEHR profile verdicts.</p>
         </div>
+        <!-- Conformance numbers/verdicts are DERIVED AT BUILD TIME from
+             docs/conformance/ehrbase-rs/ by scripts/render-conformance-stats.sh
+             (fill-html). Never hand-type a number here — CI's stale-numbers
+             gate (scripts/check-conformance-numbers.sh) fails the build. -->
         <div class="proof-nums">
-          <div class="proof-num"><span class="n">341</span><span class="l">cases executed</span></div>
-          <div class="proof-num"><span class="n">315</span><span class="l">passed</span></div>
-          <div class="proof-num"><span class="n zero">0</span><span class="l">failed</span></div>
+          <div class="proof-num"><span class="n" data-ecc="executed">—</span><span class="l">cases executed</span></div>
+          <div class="proof-num"><span class="n" data-ecc="passed">—</span><span class="l">passed</span></div>
+          <div class="proof-num"><span class="n zero" data-ecc="failed">—</span><span class="l">failed</span></div>
         </div>
         <div class="proof-pills">
-          <a class="pill" href="https://github.com/rubentalstra/ehrbase-rs/blob/develop/docs/conformance/ehrbase-rs/CONFORMANCE_CERTIFICATE.md" rel="noopener"><span class="dot"></span>CORE · PASS</a>
-          <a class="pill" href="https://github.com/rubentalstra/ehrbase-rs/blob/develop/docs/conformance/ehrbase-rs/CONFORMANCE_CERTIFICATE.md" rel="noopener"><span class="dot"></span>STANDARD · PASS</a>
-          <a class="pill" href="https://github.com/rubentalstra/ehrbase-rs/blob/develop/docs/conformance/ehrbase-rs/CONFORMANCE_CERTIFICATE.md" rel="noopener"><span class="dot"></span>OPTIONS · OBTAINED</a>
+          <a class="pill" href="https://github.com/rubentalstra/ehrbase-rs/blob/develop/docs/conformance/ehrbase-rs/CONFORMANCE_CERTIFICATE.md" rel="noopener"><span class="dot"></span><span data-ecc="verdict-core">—</span></a>
+          <a class="pill" href="https://github.com/rubentalstra/ehrbase-rs/blob/develop/docs/conformance/ehrbase-rs/CONFORMANCE_CERTIFICATE.md" rel="noopener"><span class="dot"></span><span data-ecc="verdict-standard">—</span></a>
+          <a class="pill" href="https://github.com/rubentalstra/ehrbase-rs/blob/develop/docs/conformance/ehrbase-rs/CONFORMANCE_CERTIFICATE.md" rel="noopener"><span class="dot"></span><span data-ecc="verdict-options">—</span></a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## What this changes

Closes #138

Every website conformance claim is now derived at build time from the committed runner artifacts — the stale-numbers failure mode becomes impossible, not just discouraged. The site carried three different generations of stale numbers (landing 341/315, book 369/334, actual run 402/367).

- `scripts/render-conformance-stats.sh`: counts from `results.json`, verdicts from the runner-generated badge JSONs; `build-site.sh` generates the book include before mdbook and fills the landing's `data-ecc` markers after the copy. Sources carry markers, never numbers.
- `scripts/check-conformance-numbers.sh`: the CI stale-numbers gate in the docs workflow — fails on any hand-typed conformance count or verdict in `website/landing`, `website/book/src`, or `README.md`. Negative-tested (10 real hits pre-fix, zero false positives on mechanism prose).
- Landing proof section, book conformance + introduction pages, and the README "Why" bullet converted; README gains four shields.io **endpoint** badges over the raw badge JSONs on develop — auto-updating on every merged ECC ratchet.
- Verified locally: full `build-site.sh --dev-only` renders 402/367/0/35 + PASS/PASS/OBTAINED on both surfaces from the current artifacts.

## Checks

- [x] Docs/site only; local site build green; gate negative-tested
- [x] No test touched
- [x] Not product-visible → `no-changelog`
