### PR TITLE
feat: VETDF external terminology-binding validation via the resolver seam

### DIFF
--- a/.claude/memory/concurrent-sessions-shared-tree.md
+++ b/.claude/memory/concurrent-sessions-shared-tree.md
@@ -27,6 +27,16 @@ first session's mid-edit files into its own commit.
 - Scope cargo gates to the crates you touched (`-p`), not `--workspace` — the
   other session may have a broken crate in flight (e.g. `ehrbase-conformance`).
 - For multi-file subagent work, use worktree isolation and merge branches back.
+- **Parallel implementation agents MUST get `isolation: "worktree"` on the
+  Agent call — never two agents in the main tree** (bitten 2026-07-20: two
+  agents told to "create a new branch" in one checkout fought over
+  HEAD/working files; one stashed the other's WIP incl. an untracked module
+  that survived only in `stash@{N}^3`, and the tree ended half-mixed).
+  Worktree agents run NO cargo (the one-./target rule: a worktree build
+  would mint a second tree) — they commit on their branch; the orchestrator
+  runs every gate at convergence. Recovery pattern if it ever happens
+  again: check `git stash list` FIRST (agents stash each other's work),
+  including each stash's `^3` untracked-files parent.
 - Don't "fix" broken files you didn't touch (e.g. a half-edited test file) —
   they're the other session's work in progress.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
+- ADL 2 archetype validation now enforces VETDF (external term-binding
+  validity): a term bound to an external terminology (SNOMED CT, LOINC, …)
+  that the configured terminology service reports as absent is rejected
+  `422` with the `VETDF` rule code. Bindings the service cannot verify (no
+  external provider configured, an unknown terminology, or a transport
+  fault) are not raised, per the spec's "subject to tool accessibility"
+  carve-out; archetype-internal (`local`/`openehr`) bindings are unaffected
+  (covered by VTTBK/VTCBK key validity).
 - ISO 8601 temporal ordering on the openEHR BASE time types
   (`Iso8601_date`/`_time`/`_date_time`/`_duration`): comparison with honest
   incomparability (partial-date range semantics, UTC normalization for

--- a/app/ehrbase/src/service/definition/adl2.rs
+++ b/app/ehrbase/src/service/definition/adl2.rs
@@ -10,10 +10,13 @@
 //! `I_DEFINITION_ADL2` is an admin surface — so parse-on-demand is cheap; the
 //! `openehr-adl` phases degrade gracefully when a parent is unresolved).
 
+use std::collections::HashMap;
+
 use openehr_adl::assemble::parse_artefact;
 use openehr_adl::meta::{ArtefactSummary, summarize};
 use openehr_adl::opt::create_opt;
 use openehr_adl::validate::rm::{ProductionRmModel, production_model_governs};
+use openehr_adl::validate::terminology::{TerminologyResolver, external_term_bindings};
 use openehr_adl::validate::{
     ArchetypeRepository, Severity, validate_source, validate_source_phase1,
 };
@@ -32,6 +35,35 @@ use crate::service::list::Page;
 use crate::service::status::{CallStatusType, SmError};
 
 use super::{compile_pattern, page_bounds, paginate};
+
+/// A memoised [`TerminologyResolver`] for ADL2 VETDF validation.
+///
+/// `openehr-adl` is a network-free spec engine: its VETDF check consults a
+/// *synchronous* [`TerminologyResolver`] seam, but a terminology lookup is
+/// *asynchronous*. So the service pre-resolves every external term binding of
+/// the uploaded archetype against its terminology service
+/// ([`EhrbaseService::has_term`], routed to the in-process bundle or the
+/// configured FHIR provider) and hands the validator this memoised map.
+///
+/// `code_exists` returns `Some(true)`/`Some(false)` for a binding the service
+/// could answer, and `None` for one it could not (no external provider
+/// configured, an unknown terminology, or a transport fault) — matching the
+/// VETDF "subject to tool accessibility; … no verification was possible"
+/// carve-out (AM ADL2 `master03-archetype_package.adoc` §Validity Rules).
+#[derive(Debug, Default)]
+struct AdlTerminologyResolver {
+    /// `(terminology_id, external target)` → the target's existence, for every
+    /// binding the terminology service could answer.
+    resolved: HashMap<(String, String), bool>,
+}
+
+impl TerminologyResolver for AdlTerminologyResolver {
+    fn code_exists(&self, terminology_id: &str, code: &str) -> Option<bool> {
+        self.resolved
+            .get(&(terminology_id.to_owned(), code.to_owned()))
+            .copied()
+    }
+}
 
 // ── SM Definitions native API (I_DEFINITION_ADL2) — the catalog contract ─────
 
@@ -243,12 +275,18 @@ impl EhrbaseService {
     /// `validationErrors[]` (`schemas/others/Error.yaml`). The openEHR
     /// [`ProductionRmModel`] governs openEHR-published archetypes; a foreign/test
     /// model skips the RM pass (`AOM2/master04.3` §Reference Model Type Matching
-    /// — a model this build does not carry would false-fire VCORM).
+    /// — a model this build does not carry would false-fire VCORM). External
+    /// term bindings are verified through the terminology-service resolver
+    /// (VETDF, `master03` §Validity Rules — see [`Self::adl2_terminology_resolver`]).
     async fn adl2_validate(&self, source: &str) -> Result<ArtefactSummary, ServiceError> {
         let archetype = parse_artefact(source).map_err(syntax_validation_failure)?;
         let repo = self.adl2_repository().await?;
         let issues = if production_model_governs(&archetype) {
-            validate_source(source, Some(&repo), &ProductionRmModel)
+            // VETDF: external term bindings are verified against the terminology
+            // service, pre-resolved here into the synchronous validator seam
+            // (`master03` §Validity Rules; see [`AdlTerminologyResolver`]).
+            let resolver = self.adl2_terminology_resolver(&archetype).await;
+            validate_source(source, Some(&repo), &ProductionRmModel, &resolver)
         } else {
             validate_source_phase1(source, Some(&repo))
         }
@@ -271,6 +309,29 @@ impl EhrbaseService {
             return Err(ServiceError::ValidationFailed(errors));
         }
         Ok(summarize(&archetype))
+    }
+
+    /// Pre-resolve every external term binding of `archetype` against the
+    /// terminology service, building the [`AdlTerminologyResolver`] the VETDF
+    /// check consults (see its docs — the seam is synchronous, a lookup is not).
+    ///
+    /// A binding the service cannot answer — no configured external provider, an
+    /// unknown terminology, or a transport fault — is left unresolved, so VETDF
+    /// is not raised for it (`master03` §Validity Rules "subject to tool
+    /// accessibility"). Only genuinely external terminologies are consulted; the
+    /// archetype-internal `local`/`openehr` ids are excluded by
+    /// [`external_term_bindings`] (their keys are covered by VTTBK/VTCBK).
+    async fn adl2_terminology_resolver(&self, archetype: &Archetype) -> AdlTerminologyResolver {
+        let mut resolved = HashMap::new();
+        for binding in external_term_bindings(archetype) {
+            if let Ok(exists) = self
+                .has_term(&binding.terminology_id, &binding.target, None)
+                .await
+            {
+                resolved.insert((binding.terminology_id, binding.target), exists);
+            }
+        }
+        AdlTerminologyResolver { resolved }
     }
 
     /// Store a validated ADL2 artefact. With `replace`, any case-variant of the

--- a/app/ehrbase/tests/adl2_vetdf.rs
+++ b/app/ehrbase/tests/adl2_vetdf.rs
@@ -1,0 +1,147 @@
+#![allow(
+    clippy::panic,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    let_underscore_drop
+)] // test assertions/diagnostics/fixtures
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+//! ADL2 VETDF validation over the terminology-service resolver seam, end to
+//! end (AM ADL2 `master03-archetype_package.adoc` §Validity Rules).
+//!
+//! An uploaded archetype whose external SNOMED CT term binding the (mocked)
+//! FHIR terminology server does not know (`CodeSystem/$lookup` → `404`) is
+//! rejected `422` with the VETDF rule code; one the server knows (`200`) is
+//! accepted. The terminology backend is a hermetic `wiremock` FHIR R4 server —
+//! no live network. Real `PostgreSQL` 18 via the shared testkit harness.
+
+use std::sync::Arc;
+
+use ehrbase::service::EhrbaseService;
+use ehrbase::service::status::CallStatusType;
+use ehrbase::service::terminology::config::{FhirOperation, FhirProviderConfig, ProviderKind};
+use ehrbase::service::terminology::fhir::FhirTerminologyProvider;
+use serde_json::json;
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const HRID: &str = "openEHR-EHR-OBSERVATION.vetdf.v1.0.0";
+const SNOMED_ID: &str = "SNOMED-CT";
+const SNOMED_TARGET: &str = "http://snomedct.info/id/271649006";
+
+/// A minimal spec-valid ADL2 archetype (the same shape the passing
+/// `service_definition` upload test uses) whose root node `id1` carries an
+/// external SNOMED CT term binding — the VETDF subject.
+fn archetype_with_external_binding() -> String {
+    "\
+archetype (adl_version=2.0.6; rm_release=1.1.0)
+    openEHR-EHR-OBSERVATION.vetdf.v1.0.0
+
+language
+    original_language = <[ISO_639-1::en]>
+
+description
+    lifecycle_state = <\"published\">
+    details = <
+        [\"en\"] = <
+            language = <[ISO_639-1::en]>
+        >
+    >
+
+definition
+    OBSERVATION[id1] matches { *}
+
+terminology
+    term_definitions = <
+        [\"en\"] = <
+            [\"id1\"] = <text = <\"Root\"> description = <\"Root.\">>
+        >
+    >
+    term_bindings = <
+        [\"SNOMED-CT\"] = <
+            [\"id1\"] = <http://snomedct.info/id/271649006>
+        >
+    >
+"
+    .to_owned()
+}
+
+/// Build a provider pointing at `base` with the response cache off (each test
+/// asserts a fresh remote answer).
+fn provider(base: &str) -> FhirTerminologyProvider {
+    let cfg = FhirProviderConfig {
+        kind: ProviderKind::Fhir,
+        url: base.to_owned(),
+        // has_term uses `CodeSystem/$lookup` regardless of the membership op.
+        operation: FhirOperation::ValidateCode,
+        connect_timeout_ms: 500,
+        request_timeout_ms: 800,
+        oauth2_client: None,
+        cache_ttl_secs: 0,
+        cache_capacity: 0,
+    };
+    FhirTerminologyProvider::new("test", &cfg).expect("build provider")
+}
+
+#[tokio::test]
+async fn unknown_external_binding_is_rejected_with_vetdf() {
+    let server = MockServer::start().await;
+    // The terminology server does not know the bound SNOMED CT code → 404.
+    Mock::given(method("GET"))
+        .and(path("/CodeSystem/$lookup"))
+        .and(query_param("system", SNOMED_ID))
+        .and(query_param("code", SNOMED_TARGET))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    let db = testkit::db().await.expect("testkit database");
+    let svc =
+        EhrbaseService::new(db.pool()).with_external_terminology(Arc::new(provider(&server.uri())));
+
+    let err = svc
+        .upload_artefact(archetype_with_external_binding())
+        .await
+        .expect_err("an unknown external term binding must be rejected");
+    assert_eq!(
+        err.status,
+        CallStatusType::ContentInvalid,
+        "VETDF is a content-invalid (422) failure"
+    );
+    assert!(
+        err.message.contains("VETDF"),
+        "the rejection carries the VETDF rule code: {}",
+        err.message
+    );
+    assert!(
+        !svc.has_artefact(HRID.to_owned()).await.unwrap(),
+        "a rejected artefact is not stored"
+    );
+}
+
+#[tokio::test]
+async fn known_external_binding_is_accepted() {
+    let server = MockServer::start().await;
+    // The terminology server knows the bound code → 200 (a $lookup resolves).
+    Mock::given(method("GET"))
+        .and(path("/CodeSystem/$lookup"))
+        .and(query_param("system", SNOMED_ID))
+        .and(query_param("code", SNOMED_TARGET))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "resourceType": "Parameters",
+            "parameter": [{"name": "display", "valueString": "Entire lung"}]
+        })))
+        .mount(&server)
+        .await;
+
+    let db = testkit::db().await.expect("testkit database");
+    let svc =
+        EhrbaseService::new(db.pool()).with_external_terminology(Arc::new(provider(&server.uri())));
+
+    svc.upload_artefact(archetype_with_external_binding())
+        .await
+        .expect("a known external term binding is accepted");
+    assert!(
+        svc.has_artefact(HRID.to_owned()).await.unwrap(),
+        "the accepted artefact is stored"
+    );
+}

--- a/crates/openehr-adl/src/validate/mod.rs
+++ b/crates/openehr-adl/src/validate/mod.rs
@@ -42,6 +42,7 @@ mod phase2;
 mod phase3;
 mod phase_flat;
 pub mod rm;
+pub mod terminology;
 
 use std::collections::HashMap;
 
@@ -159,13 +160,13 @@ pub enum ValidationCode {
     Vtcbk,
     /// VETDF — external term validity (`master03` §Validity Rules): a code bound
     /// to an *external* terminology (SNOMED CT, LOINC, …) must exist in that
-    /// terminology. This is the vocabulary variant; the check needs a live
-    /// terminology-service resolver, which `openehr-adl` (a network-free spec
-    /// engine) cannot hold — it is validated by the application's terminology
-    /// service via a resolver seam.
-    /// TODO: validate external term bindings once a terminology-service resolver
-    /// seam is threaded into the validator (the external-terminology-service
-    /// archetype-binding validation worklist item).
+    /// terminology. `openehr-adl` (a network-free spec engine) cannot hold a
+    /// live terminology-service client, so the check is threaded through the
+    /// [`terminology::TerminologyResolver`] seam: the application injects a
+    /// resolver over its terminology service and [`validate`] / [`validate_source`]
+    /// consult it. Entry points that take no resolver do not raise VETDF
+    /// (`master03` "subject to tool accessibility; … no verification was
+    /// possible").
     Vetdf,
     /// VTVSID — value-set id defined (`master07` §Validity Rules).
     Vtvsid,
@@ -721,11 +722,17 @@ pub fn validate_source_phase1_adl14(src: &str) -> Result<Vec<ValidationIssue>, V
 /// being checked first"): the RM pass runs on a structurally-sound archetype
 /// only. Source-level phase-1 checks (VOKU) are not included — use
 /// [`validate_source`] for those.
+///
+/// `resolver` verifies external term bindings (VETDF); pass
+/// [`terminology::NoTerminologyResolver`] when no terminology service is
+/// available (VETDF is then not raised — `master03` §Validity Rules "subject to
+/// tool accessibility").
 #[must_use]
 pub fn validate(
     archetype: &Archetype,
     repo: Option<&ArchetypeRepository>,
     rm: &dyn rm::RmModel,
+    resolver: &dyn terminology::TerminologyResolver,
 ) -> Vec<ValidationIssue> {
     let mut issues = validate_phase1(archetype, repo);
     if issues.iter().all(|i| i.severity != Severity::Error) {
@@ -733,6 +740,7 @@ pub fn validate(
     }
     run_phase2_spec(archetype, repo, rm, &mut issues);
     run_phase3(archetype, repo, &mut issues);
+    terminology::check_external_term_bindings(&view(archetype), resolver, &mut issues);
     issues
 }
 
@@ -811,6 +819,11 @@ fn run_phase3(
 /// checks) and — only if phase 1 is error-free — the phase-2 reference-model
 /// checks against `rm` (`master08` §Overview phase gate).
 ///
+/// `resolver` verifies external term bindings (VETDF); pass
+/// [`terminology::NoTerminologyResolver`] when no terminology service is
+/// available (VETDF is then not raised — `master03` §Validity Rules "subject to
+/// tool accessibility").
+///
 /// # Errors
 /// Returns the parse [`SyntaxError`]s if `src` does not parse into an
 /// [`Archetype`]; validation runs only on a successful parse.
@@ -818,6 +831,7 @@ pub fn validate_source(
     src: &str,
     repo: Option<&ArchetypeRepository>,
     rm: &dyn rm::RmModel,
+    resolver: &dyn terminology::TerminologyResolver,
 ) -> Result<Vec<ValidationIssue>, Vec<SyntaxError>> {
     let source = parse_source(src)?;
     let archetype = crate::assemble::assemble(&source, src)?;
@@ -833,6 +847,7 @@ pub fn validate_source(
         issues.extend(rm::validate_phase2_rm(&archetype, rm));
     }
     run_phase2_spec(&archetype, repo, rm, &mut issues);
+    terminology::check_external_term_bindings(&view(&archetype), resolver, &mut issues);
     Ok(issues)
 }
 

--- a/crates/openehr-adl/src/validate/terminology.rs
+++ b/crates/openehr-adl/src/validate/terminology.rs
@@ -1,0 +1,165 @@
+//! External terminology-service validation of ADL2 archetypes (VETDF).
+//!
+//! `docs/specs/openehr/AM/docs/AOM2/master03-archetype_package.adoc` §Validity
+//! Rules, VETDF: "external term validity. Each external term used within the
+//! archetype definition must exist in the relevant terminology (subject to tool
+//! accessibility; codes for inaccessible terminologies should be flagged with a
+//! warning indicating that no verification was possible)."
+//!
+//! `openehr-adl` is a network-free spec engine (no app/SQL/REST — see the crate
+//! `CLAUDE.md`), so it cannot hold a live terminology-service client. The check
+//! is threaded through a [`TerminologyResolver`] seam, exactly like the
+//! [`RmModel`](super::rm::RmModel) reference-model seam: the application injects
+//! a resolver backed by its terminology service (the in-process `openehr-term`
+//! bundle + any configured external FHIR TS), and the full-validation entry
+//! points ([`super::validate`] / [`super::validate_source`]) consult it. Every
+//! entry point that takes no resolver behaves as if a [`NoTerminologyResolver`]
+//! were supplied (VETDF is silently not raised — no verification was possible),
+//! matching the spec's "subject to tool accessibility" carve-out.
+//!
+//! The `_type` of a binding target and the terminology-id → resolver mapping are
+//! deliberately kept out of this crate: the resolver receives the binding
+//! target reference exactly as authored and owns all terminology-specific
+//! interpretation.
+
+use openehr_am::am24::aom2::archetype::archetype::Archetype;
+
+use super::{ArchetypeView, ValidationCode, ValidationIssue, view};
+
+/// The seam by which the application answers "does this code exist in this
+/// terminology?" for the ADL2 VETDF check, without `openehr-adl` holding a
+/// network client.
+///
+/// `code_exists` returns:
+/// - `Some(true)` — the term is known to exist in the terminology (no VETDF);
+/// - `Some(false)` — the term is definitely absent from the terminology
+///   (**VETDF is raised**);
+/// - `None` — the resolver cannot answer (the terminology is unknown or the
+///   service is unavailable). No VETDF is raised: a validator must not reject an
+///   archetype on an infrastructure gap, per the VETDF "subject to tool
+///   accessibility; … no verification was possible" carve-out
+///   (`master03-archetype_package.adoc` §Validity Rules).
+pub trait TerminologyResolver {
+    /// Whether `code` (the external term reference exactly as authored in the
+    /// binding — typically a URI for an external terminology) exists in the
+    /// terminology named by `terminology_id` (the outer binding key). `None` =
+    /// could not be determined (see the trait docs).
+    fn code_exists(&self, terminology_id: &str, code: &str) -> Option<bool>;
+}
+
+/// The default resolver: it can never answer, so VETDF is never raised.
+///
+/// Supplied implicitly by every validation entry point that takes no resolver,
+/// so those paths are byte-for-byte unchanged (the VETDF "no verification was
+/// possible" carve-out — `master03-archetype_package.adoc` §Validity Rules).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NoTerminologyResolver;
+
+impl TerminologyResolver for NoTerminologyResolver {
+    fn code_exists(&self, _terminology_id: &str, _code: &str) -> Option<bool> {
+        None
+    }
+}
+
+/// One external term binding extracted from an archetype's `term_bindings`: the
+/// external `terminology_id` (the outer binding key), the local `key` bound (an
+/// at/ac-code or a path), and the `target` external term reference (a URI).
+///
+/// Yielded by [`external_term_bindings`] so the application can pre-resolve the
+/// same set the validator will consult (the resolver seam is synchronous; a
+/// terminology lookup is async, so the app resolves ahead of time and hands the
+/// validator a memoised resolver).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExternalTermBinding {
+    /// The external terminology id (the outer `term_bindings` key), e.g.
+    /// `"SNOMED-CT"`, `"LOINC"`, `"ISO_639-1"`.
+    pub terminology_id: String,
+    /// The local binding key: an at/ac-code or an archetype path.
+    pub key: String,
+    /// The external term reference the key is bound to (a URI), e.g.
+    /// `"http://snomedct.info/id/12394009"`.
+    pub target: String,
+}
+
+/// Whether `terminology_id` names a *genuinely external* terminology — one whose
+/// term references VETDF must verify against a terminology service.
+///
+/// Excluded (returns `false`):
+/// - `"local"` — the archetype's own term definitions
+///   (`docs/specs/openehr/AM/docs/ADL2/master07.13-adl_terminology.adoc`
+///   §Terminology: archetype-local terms), never an external terminology;
+/// - `"openehr"` — the openEHR Terminology, treated here as archetype-internal:
+///   its binding *keys* are validated by VTTBK/VTCBK (`master07` §Validity
+///   Rules) and VETDF is scoped to third-party terminologies.
+///
+/// NOTE: openEHR publishes no enumeration of "external" terminology ids, so the
+/// `local`/`openehr` exclusion set is our own scoping decision (the two
+/// archetype-/openEHR-internal ids), not a spec-pinned list. The comparison is
+/// ASCII-case-insensitive, matching openEHR's case-insensitive identifier rules
+/// (`master03` §Lexical Conventions).
+fn is_external_terminology(terminology_id: &str) -> bool {
+    let id = terminology_id.to_ascii_lowercase();
+    id != "local" && id != "openehr"
+}
+
+/// Invoke `f(terminology_id, key, target)` for every external term binding in
+/// `v` — the single walk both [`external_term_bindings`] and
+/// [`check_external_term_bindings`] share, so the app pre-resolves exactly the
+/// set the validator consults.
+fn walk_external_bindings(v: &ArchetypeView<'_>, mut f: impl FnMut(&str, &str, &str)) {
+    let Some(bindings) = v.terminology.term_bindings.as_ref() else {
+        return;
+    };
+    for (terminology_id, entries) in bindings {
+        if !is_external_terminology(terminology_id) {
+            continue;
+        }
+        for (key, target) in entries {
+            f(terminology_id, key, target);
+        }
+    }
+}
+
+/// The external term bindings of `archetype` (`term_bindings` entries under a
+/// genuinely-external terminology id — see [`is_external_terminology`]).
+///
+/// The application iterates these to pre-resolve each `(terminology_id, target)`
+/// against its terminology service and build the [`TerminologyResolver`] the
+/// validator then consults for VETDF.
+#[must_use]
+pub fn external_term_bindings(archetype: &Archetype) -> Vec<ExternalTermBinding> {
+    let v = view(archetype);
+    let mut out = Vec::new();
+    walk_external_bindings(&v, |terminology_id, key, target| {
+        out.push(ExternalTermBinding {
+            terminology_id: terminology_id.to_owned(),
+            key: key.to_owned(),
+            target: target.to_owned(),
+        });
+    });
+    out
+}
+
+/// VETDF: raise an issue for every external term binding whose target the
+/// `resolver` reports as definitely absent (`Some(false)`).
+///
+/// `Some(true)` (exists) and `None` (could not verify) raise nothing —
+/// `master03-archetype_package.adoc` §Validity Rules, VETDF: an inaccessible
+/// terminology is flagged as unverifiable, not as invalid.
+pub(super) fn check_external_term_bindings(
+    v: &ArchetypeView<'_>,
+    resolver: &dyn TerminologyResolver,
+    issues: &mut Vec<ValidationIssue>,
+) {
+    walk_external_bindings(v, |terminology_id, key, target| {
+        if resolver.code_exists(terminology_id, target) == Some(false) {
+            issues.push(ValidationIssue::new(
+                ValidationCode::Vetdf,
+                format!(
+                    "external term {target:?} bound to {key:?} does not exist in terminology \
+                     {terminology_id:?}"
+                ),
+            ));
+        }
+    });
+}

--- a/crates/openehr-adl/tests/corpus_validity_phase2.rs
+++ b/crates/openehr-adl/tests/corpus_validity_phase2.rs
@@ -27,6 +27,7 @@ use std::path::{Path, PathBuf};
 
 use openehr_adl::assemble::parse_artefact;
 use openehr_adl::validate::rm::ProductionRmModel;
+use openehr_adl::validate::terminology::NoTerminologyResolver;
 use openehr_adl::validate::{
     ArchetypeRepository, FlatParent, Severity, resolve_flat_parent, validate_source,
 };
@@ -169,7 +170,7 @@ fn corpus_phase2_outcomes() {
             continue;
         }
 
-        let Ok(issues) = validate_source(&src, Some(&repo), &rm) else {
+        let Ok(issues) = validate_source(&src, Some(&repo), &rm, &NoTerminologyResolver) else {
             violations.push(format!("{name}: validate_source parse error"));
             continue;
         };

--- a/crates/openehr-adl/tests/corpus_validity_rm.rs
+++ b/crates/openehr-adl/tests/corpus_validity_rm.rs
@@ -29,6 +29,7 @@ use openehr_adl::validate::rm::{
     Bounds, EnumUnderlying, ProductionRmModel, RmAttr, RmEnum, RmModel, base_type_name,
     production_model_governs, validate_phase2_rm,
 };
+use openehr_adl::validate::terminology::NoTerminologyResolver;
 use openehr_adl::validate::{Severity, ValidationIssue, validate_source};
 use openehr_lang::odin::{OdinInterval, OdinKey, OdinValue};
 
@@ -393,7 +394,7 @@ fn corpus_rm_outcomes() {
         // Full gated validation (phase 1 → phase 2 RM); if phase 1 is unclean
         // the RM pass is gated off, so fall back to the ungated RM pass to keep
         // the assertion about the RM code meaningful.
-        let Ok(issues) = validate_source(&src, None, rm) else {
+        let Ok(issues) = validate_source(&src, None, rm, &NoTerminologyResolver) else {
             violations.push(format!("{name}: validate_source re-parse error"));
             continue;
         };

--- a/crates/openehr-adl/tests/vetdf_terminology.rs
+++ b/crates/openehr-adl/tests/vetdf_terminology.rs
@@ -1,0 +1,152 @@
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)] // test assertions
+//! VETDF external-terminology resolver-seam tests
+//! (AM ADL2 `master03-archetype_package.adoc` §Validity Rules).
+//!
+//! `openehr-adl` stays network-free: the VETDF check consults an injected
+//! [`TerminologyResolver`] rather than holding a live terminology client. These
+//! tests drive the public `validate_source` entry point with a stub resolver
+//! and assert the raise contract — `Some(false)` → VETDF; `Some(true)` / `None`
+//! / [`NoTerminologyResolver`] → no VETDF — and that the archetype-internal
+//! (`local`/`openehr`) bindings are never consulted (their keys are covered by
+//! VTTBK/VTCBK, `master07` §Validity Rules).
+
+use std::sync::Mutex;
+
+use openehr_adl::assemble::parse_artefact;
+use openehr_adl::validate::rm::ProductionRmModel;
+use openehr_adl::validate::terminology::{
+    NoTerminologyResolver, TerminologyResolver, external_term_bindings,
+};
+use openehr_adl::validate::{ValidationCode, validate_source};
+
+/// The external terminology id + target the fixture binds its root node to.
+const SNOMED_ID: &str = "SNOMED-CT";
+const SNOMED_TARGET: &str = "http://snomedct.info/id/271649006";
+
+/// A stub resolver: answers `answer` for every query, and records the
+/// `(terminology_id, code)` pairs it was consulted about.
+struct StubResolver {
+    answer: Option<bool>,
+    asked: Mutex<Vec<(String, String)>>,
+}
+
+impl StubResolver {
+    fn new(answer: Option<bool>) -> Self {
+        Self {
+            answer,
+            asked: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+impl TerminologyResolver for StubResolver {
+    fn code_exists(&self, terminology_id: &str, code: &str) -> Option<bool> {
+        self.asked
+            .lock()
+            .unwrap()
+            .push((terminology_id.to_owned(), code.to_owned()));
+        self.answer
+    }
+}
+
+/// A minimal, parseable ADL2 archetype binding its root node `id1` to both an
+/// external SNOMED CT target and an archetype-internal `openehr` target.
+fn fixture() -> String {
+    "\
+archetype (adl_version=2.0.6; rm_release=1.1.0)
+    openEHR-EHR-OBSERVATION.vetdf_seam_test.v1.0.0
+
+language
+    original_language = <[ISO_639-1::en]>
+
+description
+    lifecycle_state = <\"published\">
+    details = <
+        [\"en\"] = <
+            language = <[ISO_639-1::en]>
+        >
+    >
+
+definition
+    OBSERVATION[id1] matches { *}
+
+terminology
+    term_definitions = <
+        [\"en\"] = <
+            [\"id1\"] = <text = <\"Root\"> description = <\"Root.\">>
+        >
+    >
+    term_bindings = <
+        [\"SNOMED-CT\"] = <
+            [\"id1\"] = <http://snomedct.info/id/271649006>
+        >
+        [\"openehr\"] = <
+            [\"id1\"] = <http://openehr.org/internal>
+        >
+    >
+"
+    .to_owned()
+}
+
+/// True if `validate_source` (with `resolver`) raises VETDF on the fixture.
+fn has_vetdf(resolver: &dyn TerminologyResolver) -> bool {
+    let issues =
+        validate_source(&fixture(), None, &ProductionRmModel, resolver).expect("fixture parses");
+    issues.iter().any(|i| i.code == ValidationCode::Vetdf)
+}
+
+#[test]
+fn absent_external_code_raises_vetdf() {
+    // Some(false) — the code is definitely absent from the terminology → VETDF.
+    assert!(has_vetdf(&StubResolver::new(Some(false))));
+}
+
+#[test]
+fn present_external_code_does_not_raise_vetdf() {
+    // Some(true) — the code exists → no VETDF.
+    assert!(!has_vetdf(&StubResolver::new(Some(true))));
+}
+
+#[test]
+fn unverifiable_external_code_does_not_raise_vetdf() {
+    // None — the resolver could not answer (tool inaccessible) → no VETDF
+    // (`master03` §Validity Rules "no verification was possible").
+    assert!(!has_vetdf(&StubResolver::new(None)));
+}
+
+#[test]
+fn default_resolver_never_raises_vetdf() {
+    // The default always answers None, so behaviour is unchanged from before
+    // the seam existed.
+    assert!(!has_vetdf(&NoTerminologyResolver));
+}
+
+#[test]
+fn only_external_bindings_are_consulted() {
+    let stub = StubResolver::new(Some(true));
+    let _issues =
+        validate_source(&fixture(), None, &ProductionRmModel, &stub).expect("fixture parses");
+    let asked = stub.asked.lock().unwrap();
+    // The external SNOMED CT binding is consulted exactly as authored.
+    assert!(
+        asked.contains(&(SNOMED_ID.to_owned(), SNOMED_TARGET.to_owned())),
+        "external binding must reach the resolver: {asked:?}"
+    );
+    // The archetype-internal `openehr`/`local` bindings are never consulted.
+    assert!(
+        asked
+            .iter()
+            .all(|(tid, _)| tid != "openehr" && tid != "local"),
+        "internal bindings must not reach the resolver: {asked:?}"
+    );
+}
+
+#[test]
+fn external_term_bindings_excludes_internal_terminologies() {
+    let archetype = parse_artefact(&fixture()).expect("fixture parses");
+    let bindings = external_term_bindings(&archetype);
+    assert_eq!(bindings.len(), 1, "only the SNOMED CT binding is external");
+    assert_eq!(bindings[0].terminology_id, SNOMED_ID);
+    assert_eq!(bindings[0].target, SNOMED_TARGET);
+    assert_eq!(bindings[0].key, "id1");
+}

--- a/docs/conformance/ehrbase-rs/CONFORMANCE_CERTIFICATE.md
+++ b/docs/conformance/ehrbase-rs/CONFORMANCE_CERTIFICATE.md
@@ -7,7 +7,7 @@
 - **Machine-computed:** every verdict below is a pure function of the attached run (`results.json`) — never hand-asserted.
 - **ECC framework version:** 3.4.0 · catalogue `inventory/ecc-catalog.tsv`
 - **Machine record:** `results.json` (this directory)
-- **Run date:** 2026-07-20T20:46:30.858894Z
+- **Run date:** 2026-07-20T21:43:47.766557Z
 
 ## System Under Test (SUT)
 
@@ -17,7 +17,7 @@
 | Vendor | ehrbase-rs |
 | Assessor | self-assessment via the ehrbase-rs Conformance Catalogue (ECC) framework |
 | Infrastructure | reference corpus openEHR/specifications-CNF@33251d2a; SUT auth mode basic |
-| Date | 2026-07-20T20:46:30.858894Z |
+| Date | 2026-07-20T21:43:47.766557Z |
 
 ## Scope of Test
 

--- a/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
@@ -14,7 +14,7 @@
 | Edition policy | pinned (release-1.1.0) |
 | Spec versions | RM 1.2.0 · ITS-REST Release-1.1.0 · AQL 1.1.0 · TERM 3.1.0 |
 | Reference corpus | openEHR/specifications-CNF@33251d2a |
-| Run started | 2026-07-20T20:46:30.858894Z |
+| Run started | 2026-07-20T21:43:47.766557Z |
 
 **402 case×format executions · 384 passed · 0 failed · 0 errored · 0 skipped · 18 not applicable.**
 

--- a/docs/conformance/ehrbase-rs/CONFORMANCE_STATEMENT.md
+++ b/docs/conformance/ehrbase-rs/CONFORMANCE_STATEMENT.md
@@ -12,7 +12,7 @@
 | Base URL | `http://localhost:8080/ehrbase/rest/openehr/v1` |
 | Auth mode | basic |
 | Edition policy | pinned (release-1.1.0) |
-| Run started | 2026-07-20T20:46:30.858894Z |
+| Run started | 2026-07-20T21:43:47.766557Z |
 | Reference corpus | openEHR/specifications-CNF@33251d2a |
 
 ## Supported specification versions

--- a/docs/conformance/ehrbase-rs/results.json
+++ b/docs/conformance/ehrbase-rs/results.json
@@ -21,7 +21,7 @@
     "repo": "openEHR/specifications-CNF",
     "commit": "33251d2a"
   },
-  "started": "2026-07-20T20:46:30.858894Z",
+  "started": "2026-07-20T21:43:47.766557Z",
   "selection": {
     "filter": null,
     "profile": null,
@@ -90,7 +90,7 @@
       "citation": "CNF master06-func_tc_ehr §has_ehr; ITS-REST 1.1.0 EHR API ehr_get.yaml 200; RM 1.2.0 ehr §EHR",
       "schedule_ref": "I_EHR_SERVICE.has_ehr-existing_ehr_id (master06 §has_ehr)",
       "binding": "PUT /ehr/{ehr_id}; GET /ehr/{ehr_id}",
-      "duration_ms": 42
+      "duration_ms": 61
     },
     {
       "ecc_id": "ECC-EHR-002",
@@ -151,7 +151,7 @@
       "citation": "CNF master06-func_tc_ehr §create_ehr + §Test Data Sets class 1.a; ITS-REST 1.1.0 EHR API ehr_create.yaml/ehr_create_with_id.yaml 201; RM 1.2.0 ehr §EHR_STATUS",
       "schedule_ref": "I_EHR_SERVICE.create_ehr-main (master06 §create_ehr)",
       "binding": "POST /ehr; PUT /ehr/{ehr_id}",
-      "duration_ms": 72
+      "duration_ms": 59
     },
     {
       "ecc_id": "ECC-EHR-006",
@@ -181,7 +181,7 @@
       "citation": "CNF master06-func_tc_ehr §create_ehr; ITS-REST 1.1.0 EHR API ehr_create.yaml 409; RM 1.2.0 ehr §EHR (one EHR per subject)",
       "schedule_ref": "I_EHR_SERVICE.create_ehr-two_ehrs_same_patient (master06 §create_ehr)",
       "binding": "POST /ehr",
-      "duration_ms": 3
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-EHR-008",
@@ -196,7 +196,7 @@
       "citation": "CNF master06-func_tc_ehr §get_ehr; ITS-REST 1.1.0 EHR API ehr_get.yaml 200; RM 1.2.0 ehr §EHR",
       "schedule_ref": "I_EHR_SERVICE.get_ehr-existing_ehr_by_ehr_id (master06 §get_ehr)",
       "binding": "GET /ehr/{ehr_id}",
-      "duration_ms": 3
+      "duration_ms": 1
     },
     {
       "ecc_id": "ECC-EHR-009",
@@ -211,7 +211,7 @@
       "citation": "CNF master06-func_tc_ehr §get_ehr; ITS-REST 1.1.0 EHR API ehr_get_by_subject.yaml 200; RM 1.2.0 ehr §EHR_STATUS subject identity",
       "schedule_ref": "I_EHR_SERVICE.get_ehr-existing_ehr_by_subject_id (master06 §get_ehr)",
       "binding": "GET /ehr?subject_id&subject_namespace",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-EHR-010",
@@ -226,7 +226,7 @@
       "citation": "CNF master06-func_tc_ehr §get_ehr; ITS-REST 1.1.0 EHR API ehr_get.yaml 404; RM 1.2.0 ehr §EHR",
       "schedule_ref": "I_EHR_SERVICE.get_ehr-get_ehr_by_invalid_ehr_id (master06 §get_ehr)",
       "binding": "GET /ehr/{ehr_id}",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "ecc_id": "ECC-EHR-011",
@@ -241,7 +241,7 @@
       "citation": "CNF master06-func_tc_ehr §get_ehr; ITS-REST 1.1.0 EHR API ehr_get_by_subject.yaml 404; RM 1.2.0 ehr §EHR",
       "schedule_ref": "I_EHR_SERVICE.get_ehr-get_ehr_by_invalid_subject_id (master06 §get_ehr)",
       "binding": "GET /ehr?subject_id&subject_namespace",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "ecc_id": "ECC-STA-001",
@@ -256,7 +256,7 @@
       "citation": "CNF master06-func_tc_ehr §get_ehr_status; ITS-REST 1.1.0 EHR_STATUS API ehr_status_get.yaml 200; RM 1.2.0 ehr §EHR_STATUS (subject/is_queryable/is_modifiable)",
       "schedule_ref": "I_EHR_STATUS.get_ehr_status-get_by_ehr_id (master06 §get_ehr_status)",
       "binding": "GET /ehr/{ehr_id}/ehr_status",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-STA-002",
@@ -271,7 +271,7 @@
       "citation": "CNF master06-func_tc_ehr §get_ehr_status; ITS-REST 1.1.0 EHR_STATUS API ehr_status_get.yaml 404; RM 1.2.0 ehr §EHR_STATUS",
       "schedule_ref": "I_EHR_STATUS.get_ehr_status-bad_ehr (master06 §get_ehr_status)",
       "binding": "GET /ehr/{ehr_id}/ehr_status",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "ecc_id": "ECC-STA-003",
@@ -286,7 +286,7 @@
       "citation": "CNF master06-func_tc_ehr §set_ehr_queryable; ITS-REST 1.1.0 EHR_STATUS API ehr_status_update.yaml 200; RM 1.2.0 ehr §EHR_STATUS.is_queryable",
       "schedule_ref": "I_EHR_STATUS.set_ehr_queryable-existing_ehr (master06 §set_ehr_queryable)",
       "binding": "PUT /ehr/{ehr_id}/ehr_status",
-      "duration_ms": 8
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-STA-004",
@@ -301,7 +301,7 @@
       "citation": "CNF master06-func_tc_ehr §set_ehr_queryable; ITS-REST 1.1.0 EHR_STATUS API ehr_status_update.yaml 4xx; RM 1.2.0 ehr §EHR_STATUS",
       "schedule_ref": "I_EHR_STATUS.set_ehr_queryable-bad_ehr (master06 §set_ehr_queryable)",
       "binding": "PUT /ehr/{ehr_id}/ehr_status",
-      "duration_ms": 5
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-STA-005",
@@ -316,7 +316,7 @@
       "citation": "CNF master06-func_tc_ehr §set_ehr_modifiable; ITS-REST 1.1.0 EHR_STATUS API ehr_status_update.yaml 200; RM 1.2.0 ehr §EHR_STATUS.is_modifiable",
       "schedule_ref": "I_EHR_STATUS.set_ehr_modifiable-existing_ehr (master06 §set_ehr_modifiable)",
       "binding": "PUT /ehr/{ehr_id}/ehr_status",
-      "duration_ms": 8
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-STA-006",
@@ -346,7 +346,7 @@
       "citation": "CNF master06-func_tc_ehr §clear_ehr_queryable; ITS-REST 1.1.0 EHR_STATUS API ehr_status_update.yaml 200; RM 1.2.0 ehr §EHR_STATUS.is_queryable",
       "schedule_ref": "I_EHR_STATUS.clear_ehr_queryable-existing_ehr (master06 §clear_ehr_queryable)",
       "binding": "PUT /ehr/{ehr_id}/ehr_status",
-      "duration_ms": 8
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-STA-008",
@@ -361,7 +361,7 @@
       "citation": "CNF master06-func_tc_ehr §clear_ehr_queryable; ITS-REST 1.1.0 EHR_STATUS API ehr_status_update.yaml 4xx; RM 1.2.0 ehr §EHR_STATUS",
       "schedule_ref": "I_EHR_STATUS.clear_ehr_queryable-bad_ehr (master06 §clear_ehr_queryable)",
       "binding": "PUT /ehr/{ehr_id}/ehr_status",
-      "duration_ms": 8
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-STA-009",
@@ -376,7 +376,7 @@
       "citation": "CNF master06-func_tc_ehr §clear_ehr_modifiable; ITS-REST 1.1.0 EHR_STATUS API ehr_status_update.yaml 200; RM 1.2.0 ehr §EHR_STATUS.is_modifiable",
       "schedule_ref": "I_EHR_STATUS.clear_ehr_modifiable-existing_ehr (master06 §clear_ehr_modifiable)",
       "binding": "PUT /ehr/{ehr_id}/ehr_status",
-      "duration_ms": 7
+      "duration_ms": 5
     },
     {
       "ecc_id": "ECC-STA-010",
@@ -407,7 +407,7 @@
       "citation": "CNF master06-func_tc_ehr §Test Data Sets class 2 (invalid EHR_STATUS shapes); ITS-REST 1.1.0 EHR API ehr_create.yaml 400/422; RM ehr master04 §EHR Status + common §PARTY_SELF",
       "ecc_original": "data-set class 2 (master06 §Test Data Sets, invalid EHR_STATUS shapes); no single master06 test case enumerates class 2",
       "binding": "POST /ehr",
-      "duration_ms": 17
+      "duration_ms": 15
     },
     {
       "ecc_id": "ECC-EHR-013",
@@ -422,7 +422,7 @@
       "citation": "CNF master03-profiles §Non-Functional (Anonymous EHRs — CORE+STANDARD) + master06 §Test Data Sets class 1.b (default EHR_STATUS); ITS-REST 1.1.0 EHR API ehr_create.yaml (no body); RM ehr master04 §EHR Status, common §PARTY_SELF",
       "ecc_original": "extension: Anonymous EHRs non-functional capability (master03-profiles §Non-Functional); doubles as class 1.b default-EHR_STATUS coverage; no master06 functional test case",
       "binding": "POST /ehr",
-      "duration_ms": 3
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-COM-001",
@@ -437,7 +437,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.create_composition-event (master07 §create_composition)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 16
+      "duration_ms": 15
     },
     {
       "ecc_id": "ECC-COM-001",
@@ -452,7 +452,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.create_composition-event (master07 §create_composition)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 11
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-COM-002",
@@ -467,7 +467,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.create_composition-persistent (master07 §create_composition)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 10
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-COM-002",
@@ -482,7 +482,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.create_composition-persistent (master07 §create_composition)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 9
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-COM-003",
@@ -497,7 +497,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.create_composition-same_opt_twice (master07 §create_composition)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 11
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-COM-004",
@@ -512,7 +512,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.create_composition-invalid_event (master07 §create_composition)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 9
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-COM-005",
@@ -527,7 +527,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.create_composition-invalid_persistent (master07 §create_composition)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 4
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-COM-006",
@@ -542,7 +542,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.create_composition-event_bad_opt (master07 §create_composition)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 6
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-COM-007",
@@ -557,7 +557,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.create_composition-event_bad_ehr (master07 §create_composition)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 6
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-COM-032",
@@ -572,7 +572,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.has_composition (master07 §has_composition)",
       "binding": "GET /ehr/{ehr_id}/composition/{uid_based_id}",
-      "duration_ms": 14
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-COM-011",
@@ -587,7 +587,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.has_composition-bad_composition (master07 §has_composition)",
       "binding": "GET /ehr/{ehr_id}/composition/{uid_based_id}",
-      "duration_ms": 4
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-COM-012",
@@ -617,7 +617,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.get_composition_latest (master07 §get_composition_latest)",
       "binding": "GET /ehr/{ehr_id}/composition/{uid_based_id}",
-      "duration_ms": 20
+      "duration_ms": 18
     },
     {
       "ecc_id": "ECC-COM-008",
@@ -632,7 +632,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.get_composition_latest (master07 §get_composition_latest)",
       "binding": "GET /ehr/{ehr_id}/composition/{uid_based_id}",
-      "duration_ms": 22
+      "duration_ms": 19
     },
     {
       "ecc_id": "ECC-COM-009",
@@ -647,7 +647,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.get_composition_latest-bad_composition (master07 §get_composition_latest)",
       "binding": "GET /ehr/{ehr_id}/composition/{uid_based_id}",
-      "duration_ms": 3
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-COM-010",
@@ -662,7 +662,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.get_composition_latest-bad_ehr (master07 §get_composition_latest)",
       "binding": "GET /ehr/{ehr_id}/composition/{uid_based_id}",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "ecc_id": "ECC-COM-013",
@@ -677,7 +677,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.get_composition_at_time (master07 §get_composition_at_time)",
       "binding": "GET /ehr/{ehr_id}/composition/{uid_based_id}?version_at_time",
-      "duration_ms": 16
+      "duration_ms": 10
     },
     {
       "ecc_id": "ECC-COM-013",
@@ -692,37 +692,37 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.get_composition_at_time (master07 §get_composition_at_time)",
       "binding": "GET /ehr/{ehr_id}/composition/{uid_based_id}?version_at_time",
-      "duration_ms": 17
-    },
-    {
-      "ecc_id": "ECC-COM-014",
-      "id": "com/get-composition-at-time-no-time-arg",
-      "title": "Get composition at time — no time arg",
-      "capability": "CompositionOps",
-      "format": "json",
-      "status": "passed",
-      "passed_data_sets": 1,
-      "total_data_sets": 1,
-      "message": null,
-      "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
-      "schedule_ref": "I_EHR_COMPOSITION.get_composition_at_time-no_time_arg (master07 §get_composition_at_time)",
-      "binding": "GET /ehr/{ehr_id}/composition/{uid_based_id}",
-      "duration_ms": 12
-    },
-    {
-      "ecc_id": "ECC-COM-014",
-      "id": "com/get-composition-at-time-no-time-arg",
-      "title": "Get composition at time — no time arg",
-      "capability": "CompositionOps",
-      "format": "xml",
-      "status": "passed",
-      "passed_data_sets": 1,
-      "total_data_sets": 1,
-      "message": null,
-      "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
-      "schedule_ref": "I_EHR_COMPOSITION.get_composition_at_time-no_time_arg (master07 §get_composition_at_time)",
-      "binding": "GET /ehr/{ehr_id}/composition/{uid_based_id}",
       "duration_ms": 13
+    },
+    {
+      "ecc_id": "ECC-COM-014",
+      "id": "com/get-composition-at-time-no-time-arg",
+      "title": "Get composition at time — no time arg",
+      "capability": "CompositionOps",
+      "format": "json",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
+      "schedule_ref": "I_EHR_COMPOSITION.get_composition_at_time-no_time_arg (master07 §get_composition_at_time)",
+      "binding": "GET /ehr/{ehr_id}/composition/{uid_based_id}",
+      "duration_ms": 8
+    },
+    {
+      "ecc_id": "ECC-COM-014",
+      "id": "com/get-composition-at-time-no-time-arg",
+      "title": "Get composition at time — no time arg",
+      "capability": "CompositionOps",
+      "format": "xml",
+      "status": "passed",
+      "passed_data_sets": 1,
+      "total_data_sets": 1,
+      "message": null,
+      "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
+      "schedule_ref": "I_EHR_COMPOSITION.get_composition_at_time-no_time_arg (master07 §get_composition_at_time)",
+      "binding": "GET /ehr/{ehr_id}/composition/{uid_based_id}",
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-COM-015",
@@ -737,7 +737,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.get_composition_at_time-bad_composition (master07 §get_composition_at_time)",
       "binding": "GET /ehr/{ehr_id}/composition/{uid_based_id}?version_at_time",
-      "duration_ms": 3
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-COM-016",
@@ -752,7 +752,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.get_composition_at_time-bad_ehr (master07 §get_composition_at_time)",
       "binding": "GET /ehr/{ehr_id}/composition/{uid_based_id}?version_at_time",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "ecc_id": "ECC-COM-017",
@@ -768,7 +768,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.get_composition_at_times (master07 §get_composition_at_time)",
       "binding": "GET /ehr/{ehr_id}/composition/{uid_based_id}?version_at_time",
-      "duration_ms": 138
+      "duration_ms": 130
     },
     {
       "ecc_id": "ECC-COM-018",
@@ -783,7 +783,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.get_composition_version (master07 §get_composition_version)",
       "binding": "GET /ehr/{ehr_id}/composition/{version_uid}",
-      "duration_ms": 30
+      "duration_ms": 18
     },
     {
       "ecc_id": "ECC-COM-018",
@@ -798,7 +798,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.get_composition_version (master07 §get_composition_version)",
       "binding": "GET /ehr/{ehr_id}/composition/{version_uid}",
-      "duration_ms": 28
+      "duration_ms": 18
     },
     {
       "ecc_id": "ECC-COM-019",
@@ -813,7 +813,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.get_composition_version-bad_version (master07 §get_composition_version)",
       "binding": "GET /ehr/{ehr_id}/composition/{version_uid}",
-      "duration_ms": 14
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-COM-020",
@@ -828,7 +828,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.get_composition_version-bad_ehr (master07 §get_composition_version)",
       "binding": "GET /ehr/{ehr_id}/composition/{version_uid}",
-      "duration_ms": 13
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-COM-021",
@@ -844,7 +844,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.get_composition_versions (master07 §get_composition_version)",
       "binding": "GET /ehr/{ehr_id}/composition/{version_uid}",
-      "duration_ms": 28
+      "duration_ms": 21
     },
     {
       "ecc_id": "ECC-COM-022",
@@ -859,7 +859,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API versioned_composition_get.yaml 200; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT (version-family XML)",
       "schedule_ref": "I_EHR_COMPOSITION.get_versioned_composition (master07 §get_versioned_composition)",
       "binding": "GET /ehr/{ehr_id}/versioned_composition/{versioned_object_uid}",
-      "duration_ms": 12
+      "duration_ms": 10
     },
     {
       "ecc_id": "ECC-COM-022",
@@ -874,7 +874,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API versioned_composition_get.yaml 200; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT (version-family XML)",
       "schedule_ref": "I_EHR_COMPOSITION.get_versioned_composition (master07 §get_versioned_composition)",
       "binding": "GET /ehr/{ehr_id}/versioned_composition/{versioned_object_uid}",
-      "duration_ms": 10
+      "duration_ms": 11
     },
     {
       "ecc_id": "ECC-COM-023",
@@ -889,7 +889,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API versioned_composition_get.yaml 404; RM 1.2.0 common §VERSIONED_OBJECT",
       "schedule_ref": "I_EHR_COMPOSITION.get_versioned_composition-non_existent (master07 §get_versioned_composition)",
       "binding": "GET /ehr/{ehr_id}/versioned_composition/{versioned_object_uid}",
-      "duration_ms": 3
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-COM-024",
@@ -919,7 +919,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_update.yaml 200; RM common §Version tree; TERM SupportTerminology audit_change_type 249 creation / 251 modification",
       "schedule_ref": "I_EHR_COMPOSITION.update_composition-event (master07 §update_composition)",
       "binding": "PUT /ehr/{ehr_id}/composition/{uid_based_id}",
-      "duration_ms": 18
+      "duration_ms": 23
     },
     {
       "ecc_id": "ECC-COM-026",
@@ -934,7 +934,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_update.yaml 200; RM common §Version tree; TERM SupportTerminology audit_change_type 249 creation / 251 modification",
       "schedule_ref": "I_EHR_COMPOSITION.update_composition-persistent (master07 §update_composition)",
       "binding": "PUT /ehr/{ehr_id}/composition/{uid_based_id}",
-      "duration_ms": 18
+      "duration_ms": 16
     },
     {
       "ecc_id": "ECC-COM-027",
@@ -949,7 +949,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_update.yaml 400/404/412/422 (non-existent preceding version)",
       "schedule_ref": "I_EHR_COMPOSITION.update_composition-non_existent (master07 §update_composition)",
       "binding": "PUT /ehr/{ehr_id}/composition/{uid_based_id}",
-      "duration_ms": 12
+      "duration_ms": 15
     },
     {
       "ecc_id": "ECC-COM-028",
@@ -964,7 +964,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_update.yaml 422 (template_id mismatch); RM 1.2.0 ehr §COMPOSITION",
       "schedule_ref": "I_EHR_COMPOSITION.update_composition-wrong_template (master07 §update_composition)",
       "binding": "PUT /ehr/{ehr_id}/composition/{uid_based_id}",
-      "duration_ms": 14
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-COM-029",
@@ -979,7 +979,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_delete.yaml 204 + composition_get.yaml 204_because_deleted/404; master07 §delete_composition (logical delete: VERSION.lifecycle_state = openehr::523|deleted|)",
       "schedule_ref": "I_EHR_COMPOSITION.delete_composition-event (master07 §delete_composition)",
       "binding": "DELETE /ehr/{ehr_id}/composition/{uid_based_id}",
-      "duration_ms": 14
+      "duration_ms": 11
     },
     {
       "ecc_id": "ECC-COM-030",
@@ -1009,7 +1009,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_delete.yaml 400/404/409/412 (non-existent COMPOSITION)",
       "schedule_ref": "I_EHR_COMPOSITION.delete_composition-non_existent (master07 §delete_composition)",
       "binding": "DELETE /ehr/{ehr_id}/composition/{uid_based_id}",
-      "duration_ms": 16
+      "duration_ms": 11
     },
     {
       "ecc_id": "ECC-CTB-001",
@@ -1024,7 +1024,7 @@
       "citation": "master08 §valid_composition; ITS-REST contribution_create 201_CONTRIBUTION; RM common master06 §Version",
       "schedule_ref": "I_EHR_CONTRIBUTION.commit_contribution-valid_composition (master08 §Test Cases)",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 11
+      "duration_ms": 13
     },
     {
       "ecc_id": "ECC-CTB-002",
@@ -1039,7 +1039,7 @@
       "citation": "master08 §invalid_composition; ITS-REST contribution_create 400_CONTRIBUTION; RM ehr master07 §COMPOSITION.composer mandatory",
       "schedule_ref": "I_EHR_CONTRIBUTION.commit_contribution-invalid_composition (master08 §Test Cases)",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 7
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-CTB-003",
@@ -1070,7 +1070,7 @@
       "citation": "master08 §multiple versions table D (if any COMPOSITION is invalid the whole commit fails); RM common master06 §Contributions (atomic)",
       "schedule_ref": "I_EHR_CONTRIBUTION.commit_contribution-valid_invalid_compositions (master08 §Test Cases D)",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 10
+      "duration_ms": 14
     },
     {
       "ecc_id": "ECC-CTB-005",
@@ -1085,7 +1085,7 @@
       "citation": "master08 §non_exiting_opt (COMPOSITION B.2.b referenced OPT not loaded); ITS-REST contribution_create 400_CONTRIBUTION",
       "schedule_ref": "I_EHR_CONTRIBUTION.commit_contribution-non_exiting_opt (master08 §Test Cases)",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 7
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-CTB-006",
@@ -1100,7 +1100,7 @@
       "citation": "master08 §event_composition (creation then modification → version 2); RM common master06 §Version tree",
       "schedule_ref": "I_EHR_CONTRIBUTION.commit_contribution-event_composition (master08 §Test Cases)",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 13
+      "duration_ms": 17
     },
     {
       "ecc_id": "ECC-CTB-007",
@@ -1115,7 +1115,7 @@
       "citation": "master08 §persistent_composition (COMPOSITION B.1.c; create then modify → version 2); RM common master06 §Version tree",
       "schedule_ref": "I_EHR_CONTRIBUTION.commit_contribution-persistent_composition (master08 §Test Cases)",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 15
+      "duration_ms": 17
     },
     {
       "ecc_id": "ECC-CTB-008",
@@ -1130,7 +1130,7 @@
       "citation": "master08 §delete (VERSIONED_OBJECT logically deleted); RM common master06 §Change control (deleted VERSION data Void, logical delete)",
       "schedule_ref": "I_EHR_CONTRIBUTION.commit_contribution-delete (master08 §Test Cases)",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 12
+      "duration_ms": 16
     },
     {
       "ecc_id": "ECC-CTB-009",
@@ -1145,7 +1145,7 @@
       "citation": "master08 §two_commits_second_invalid (only one VERSION remains); RM common master06 §Contributions (atomic)",
       "schedule_ref": "I_EHR_CONTRIBUTION.commit_contribution-two_commits_second_invalid (master08 §Test Cases)",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 11
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-CTB-010",
@@ -1160,7 +1160,7 @@
       "citation": "master08 §two_commits_second_creation (only one 'create' per object); RM common master06 §Change control",
       "schedule_ref": "I_EHR_CONTRIBUTION.commit_contribution-two_commits_second_creation (master08 §Test Cases)",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 10
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-CTB-011",
@@ -1192,7 +1192,7 @@
       "citation": "master08 §EHR_STATUS Accepted Cases scenario 2 (EHR created by providing an EHR_STATUS), 15-row matrix",
       "schedule_ref": "I_EHR_CONTRIBUTION.commit_contribution-full_ehr_status (master08 §EHR_STATUS CONTRIBUTION Commit)",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 131
+      "duration_ms": 133
     },
     {
       "ecc_id": "ECC-CTB-013",
@@ -1207,7 +1207,7 @@
       "citation": "master08 §EHR_STATUS Reject 1 (change_type ∈ {creation, deleted} rejected — STATUS already exists, cannot be deleted)",
       "schedule_ref": "I_EHR_CONTRIBUTION.commit_contribution-ehr_status_invalid_change_type (master08 §EHR_STATUS CONTRIBUTION Commit)",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-CTB-014",
@@ -1222,7 +1222,7 @@
       "citation": "master08 §EHR_STATUS Reject 4 (invalid EHR_STATUS); ITS-REST contribution_create 400_CONTRIBUTION",
       "schedule_ref": "I_EHR_CONTRIBUTION.commit_contribution-invalid_ehr_status (master08 §EHR_STATUS CONTRIBUTION Commit)",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 9
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-CTB-015",
@@ -1237,7 +1237,7 @@
       "citation": "master08 §valid_directory (creation to an EHR with no directory); RM ehr master04 §Folders",
       "schedule_ref": "I_EHR_CONTRIBUTION.commit_contribution-valid_directory (master08 §FOLDER CONTRIBUTION Commit)",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 11
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-CTB-016",
@@ -1252,7 +1252,7 @@
       "citation": "master08 §fail_create_existing_directory (root FOLDER already present); ITS-REST contribution_create 409",
       "schedule_ref": "I_EHR_CONTRIBUTION.commit_contribution-fail_create_existing_directory (master08 §FOLDER CONTRIBUTION Commit)",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 9
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-CTB-017",
@@ -1267,7 +1267,7 @@
       "citation": "master08 §fail_modify_non_existing_directory (modify a directory that does not exist)",
       "schedule_ref": "I_EHR_CONTRIBUTION.commit_contribution-fail_modify_non_existing_directory (master08 §FOLDER CONTRIBUTION Commit)",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 6
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-CTB-018",
@@ -1282,7 +1282,7 @@
       "citation": "master08 §update_existing_directory (modify/amend an existing directory → new FOLDER version)",
       "schedule_ref": "I_EHR_CONTRIBUTION.commit_contribution-update_existing_directory (master08 §FOLDER CONTRIBUTION Commit)",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 12
+      "duration_ms": 11
     },
     {
       "ecc_id": "ECC-CTB-019",
@@ -1342,7 +1342,7 @@
       "citation": "master08 §get_contribution bad_contribution (error); ITS-REST contribution_get 404_CONTRIBUTION",
       "schedule_ref": "I_EHR_CONTRIBUTION.get_contribution-bad_contribution (master08 §get_contribution)",
       "binding": "GET /ehr/{ehr_id}/contribution/{contribution_uid}",
-      "duration_ms": 9
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-CTB-023",
@@ -1372,7 +1372,7 @@
       "citation": "master08 §has_contribution bad_contribution (→false); realized 404 via ITS-REST contribution_get",
       "schedule_ref": "I_EHR_CONTRIBUTION.has_contribution-bad_contribution (master08 §has_contribution)",
       "binding": "GET /ehr/{ehr_id}/contribution/{contribution_uid}",
-      "duration_ms": 9
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-CTB-025",
@@ -1387,7 +1387,7 @@
       "citation": "master08 §has_contribution bad_ehr (→error); realized 404 via ITS-REST contribution_get",
       "schedule_ref": "I_EHR_CONTRIBUTION.has_contribution-bad_ehr (master08 §has_contribution)",
       "binding": "GET /ehr/{ehr_id}/contribution/{contribution_uid}",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "ecc_id": "ECC-CTB-026",
@@ -1402,7 +1402,7 @@
       "citation": "master08 §has_contribution empty_ehr (→false); realized 404 via ITS-REST contribution_get (element-2 collapse)",
       "schedule_ref": "I_EHR_CONTRIBUTION.has_contribution-empty_ehr (master08 §has_contribution)",
       "binding": "GET /ehr/{ehr_id}/contribution/{contribution_uid}",
-      "duration_ms": 2
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-CTB-027",
@@ -1432,7 +1432,7 @@
       "citation": "master08 §list_contributions-non_existing_ehr (error: EHR with ehr_id doesn't exist); SM I_EHR_CONTRIBUTION.list_contributions; no ITS-REST binding — ehrbase-rs extension (GET /ehr/{ehr_id}/contribution → 404 unknown ehr_id)",
       "schedule_ref": "I_EHR_CONTRIBUTION.list_contributions-non_existing_ehr (master08 §list_contributions)",
       "binding": "GET /ehr/{ehr_id}/contribution",
-      "duration_ms": 2
+      "duration_ms": 0
     },
     {
       "ecc_id": "ECC-CTB-029",
@@ -1462,7 +1462,7 @@
       "citation": "master08 §list_contributions-ehr_containing_directory (list reflects a committed VERSION<FOLDER>); SM I_EHR_CONTRIBUTION.list_contributions; no ITS-REST binding — ehrbase-rs extension (GET /ehr/{ehr_id}/contribution)",
       "schedule_ref": "I_EHR_CONTRIBUTION.list_contributions-ehr_containing_directory (master08 §list_contributions)",
       "binding": "GET /ehr/{ehr_id}/contribution",
-      "duration_ms": 8
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-CTB-031",
@@ -1477,7 +1477,7 @@
       "citation": "master08 §list_contributions-ehr_containing_ehr_status (list reflects a committed VERSION<EHR_STATUS>); SM I_EHR_CONTRIBUTION.list_contributions; no ITS-REST binding — ehrbase-rs extension (GET /ehr/{ehr_id}/contribution)",
       "schedule_ref": "I_EHR_CONTRIBUTION.list_contributions-ehr_containing_ehr_status (master08 §list_contributions)",
       "binding": "GET /ehr/{ehr_id}/contribution",
-      "duration_ms": 10
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-DIR-012",
@@ -1554,7 +1554,7 @@
       "citation": "master09 §has_path folder_structure 12-row path table over the reference tree (true + →false rows)",
       "schedule_ref": "I_EHR_DIRECTORY.has_path-folder_structure (master09 §has_path)",
       "binding": "GET /ehr/{ehr_id}/directory",
-      "duration_ms": 17
+      "duration_ms": 11
     },
     {
       "ecc_id": "ECC-DIR-017",
@@ -1569,7 +1569,7 @@
       "citation": "master09 §has_path empty_ehr (→false); realized 404",
       "schedule_ref": "I_EHR_DIRECTORY.has_path-empty_ehr (master09 §has_path)",
       "binding": "GET /ehr/{ehr_id}/directory",
-      "duration_ms": 4
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-DIR-018",
@@ -1614,7 +1614,7 @@
       "citation": "master09 §create_directory ehr_with_directory (already exists → conflict); ITS-REST 409",
       "schedule_ref": "I_EHR_DIRECTORY.create_directory-ehr_with_directory (master09 §create_directory)",
       "binding": "POST /ehr/{ehr_id}/directory",
-      "duration_ms": 8
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-DIR-003",
@@ -1644,7 +1644,7 @@
       "citation": "master09 §get_directory empty_ehr (NOTE: REST 4xx); ITS-REST directory_get_at_time 404",
       "schedule_ref": "I_EHR_DIRECTORY.get_directory-empty_ehr (master09 §get_directory)",
       "binding": "GET /ehr/{ehr_id}/directory",
-      "duration_ms": 3
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-DIR-004",
@@ -1659,7 +1659,7 @@
       "citation": "master09 §get_directory ehr_root_directory; ITS-REST directory_get_at_time 200_FOLDER_retrieved",
       "schedule_ref": "I_EHR_DIRECTORY.get_directory-ehr_root_directory (master09 §get_directory)",
       "binding": "GET /ehr/{ehr_id}/directory",
-      "duration_ms": 13
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-DIR-023",
@@ -1674,7 +1674,7 @@
       "citation": "master09 §get_directory directory_with_structure (return the full structure); RM ehr master04 §Folders — body fidelity",
       "schedule_ref": "I_EHR_DIRECTORY.get_directory-directory_with_structure (master09 §get_directory)",
       "binding": "GET /ehr/{ehr_id}/directory",
-      "duration_ms": 10
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-DIR-005",
@@ -1704,7 +1704,7 @@
       "citation": "master09 §get_directory_at_time ehr_with_directory (current time → current)",
       "schedule_ref": "I_EHR_DIRECTORY.get_directory_at_time-ehr_with_directory (master09 §get_directory_at_time)",
       "binding": "GET /ehr/{ehr_id}/directory",
-      "duration_ms": 7
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-DIR-007",
@@ -1764,7 +1764,7 @@
       "citation": "master09 §delete_directory ehr_with_directory (new deleted version); ITS-REST directory_delete 204_deleted; RM common master06 §Change control (logical delete)",
       "schedule_ref": "I_EHR_DIRECTORY.delete_directory-ehr_with_directory (master09 §delete_directory)",
       "binding": "DELETE /ehr/{ehr_id}/directory",
-      "duration_ms": 10
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-DIR-011",
@@ -1779,7 +1779,7 @@
       "citation": "master09 §delete_directory bad_ehr (→error); ITS-REST directory_delete 404_unknown_ehr_id",
       "schedule_ref": "I_EHR_DIRECTORY.delete_directory-bad_ehr (master09 §delete_directory)",
       "binding": "DELETE /ehr/{ehr_id}/directory",
-      "duration_ms": 10
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-DIR-019",
@@ -1794,7 +1794,7 @@
       "citation": "master09 §has_directory_version empty_ehr (→false); realized 404",
       "schedule_ref": "I_EHR_DIRECTORY.has_directory_version-empty_ehr (master09 §has_directory_version)",
       "binding": "GET /ehr/{ehr_id}/directory/{version_uid}",
-      "duration_ms": 11
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-DIR-020",
@@ -1810,7 +1810,7 @@
       "citation": "master09 §has_directory_version directory_with_two_versions (BOTH versions →true)",
       "schedule_ref": "I_EHR_DIRECTORY.has_directory_version-directory_with_two_versions (master09 §has_directory_version)",
       "binding": "GET /ehr/{ehr_id}/directory/{version_uid}",
-      "duration_ms": 13
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-DIR-021",
@@ -1825,7 +1825,7 @@
       "citation": "master09 §has_directory_version bad_ehr (→error); realized 404",
       "schedule_ref": "I_EHR_DIRECTORY.has_directory_version-bad_ehr (master09 §has_directory_version)",
       "binding": "GET /ehr/{ehr_id}/directory/{version_uid}",
-      "duration_ms": 9
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-DIR-024",
@@ -1840,7 +1840,7 @@
       "citation": "master09 §get_directory_at_time ehr_with_directory_empty_time (→current)",
       "schedule_ref": "I_EHR_DIRECTORY.get_directory_at_time-ehr_with_directory_empty_time (master09 §get_directory_at_time)",
       "binding": "GET /ehr/{ehr_id}/directory",
-      "duration_ms": 6
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-DIR-025",
@@ -1856,7 +1856,7 @@
       "citation": "master09 §get_directory_at_time ehr_with_directory_versions (before→empty; between v1/v2→v1; current→v2)",
       "schedule_ref": "I_EHR_DIRECTORY.get_directory_at_time-ehr_with_directory_versions (master09 §get_directory_at_time)",
       "binding": "GET /ehr/{ehr_id}/directory",
-      "duration_ms": 3036
+      "duration_ms": 3027
     },
     {
       "ecc_id": "ECC-DIR-026",
@@ -1871,7 +1871,7 @@
       "citation": "master09 §get_directory_at_time ehr_with_directory_versions_empty_time (→current latest v2)",
       "schedule_ref": "I_EHR_DIRECTORY.get_directory_at_time-ehr_with_directory_versions_empty_time (master09 §get_directory_at_time)",
       "binding": "GET /ehr/{ehr_id}/directory",
-      "duration_ms": 21
+      "duration_ms": 15
     },
     {
       "ecc_id": "ECC-DIR-027",
@@ -1886,7 +1886,7 @@
       "citation": "master09 §get_directory_at_time empty_ehr (→empty); realized 404",
       "schedule_ref": "I_EHR_DIRECTORY.get_directory_at_time-empty_ehr (master09 §get_directory_at_time)",
       "binding": "GET /ehr/{ehr_id}/directory",
-      "duration_ms": 5
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-DIR-028",
@@ -1901,7 +1901,7 @@
       "citation": "master09 §get_directory_at_time empty_ehr_empty_time (→empty); realized 404",
       "schedule_ref": "I_EHR_DIRECTORY.get_directory_at_time-empty_ehr_empty_time (master09 §get_directory_at_time)",
       "binding": "GET /ehr/{ehr_id}/directory",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-DIR-029",
@@ -1916,7 +1916,7 @@
       "citation": "master09 §get_directory_at_time multiple_versions_first (time AFTER v1 but BEFORE v2 must return v1, highest priority)",
       "schedule_ref": "I_EHR_DIRECTORY.get_directory_at_time-multiple_versions_first (master09 §get_directory_at_time)",
       "binding": "GET /ehr/{ehr_id}/directory",
-      "duration_ms": 3039
+      "duration_ms": 3031
     },
     {
       "ecc_id": "ECC-DIR-030",
@@ -1931,7 +1931,7 @@
       "citation": "master09 §get_directory_at_version bad_ehr (→error); realized 404",
       "schedule_ref": "I_EHR_DIRECTORY.get_directory_at_version-bad_ehr (master09 §get_directory_at_version)",
       "binding": "GET /ehr/{ehr_id}/directory/{version_uid}",
-      "duration_ms": 15
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-DIR-031",
@@ -1947,7 +1947,7 @@
       "citation": "master09 §get_directory_at_version directory_with_two_versions (v1 uid→v1, v2 uid→v2; body fidelity)",
       "schedule_ref": "I_EHR_DIRECTORY.get_directory_at_version-directory_with_two_versions (master09 §get_directory_at_version)",
       "binding": "GET /ehr/{ehr_id}/directory/{version_uid}",
-      "duration_ms": 25
+      "duration_ms": 15
     },
     {
       "ecc_id": "ECC-DIR-032",
@@ -1962,7 +1962,7 @@
       "citation": "master09 §get_directory_at_version empty_ehr (→error); realized 404",
       "schedule_ref": "I_EHR_DIRECTORY.get_directory_at_version-empty_ehr (master09 §get_directory_at_version)",
       "binding": "GET /ehr/{ehr_id}/directory/{version_uid}",
-      "duration_ms": 18
+      "duration_ms": 13
     },
     {
       "ecc_id": "ECC-DIR-033",
@@ -1977,7 +1977,7 @@
       "citation": "master09 §get_versioned_directory empty_ehr; rebound to directory_get_by_version_id (no versioned_directory resource in the tested OAS); RM common master06 §VERSIONED_OBJECT",
       "schedule_ref": "I_EHR_DIRECTORY.get_versioned_directory-empty_ehr (master09 §get_versioned_directory)",
       "binding": "GET /ehr/{ehr_id}/directory/{version_uid}",
-      "duration_ms": 12
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-DIR-034",
@@ -1993,7 +1993,7 @@
       "citation": "master09 §get_versioned_directory directory_with_two_versions (references the two versions → both reachable); RM common master06 §VERSIONED_OBJECT",
       "schedule_ref": "I_EHR_DIRECTORY.get_versioned_directory-directory_with_two_versions (master09 §get_versioned_directory)",
       "binding": "GET /ehr/{ehr_id}/directory/{version_uid}",
-      "duration_ms": 15
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-DIR-035",
@@ -2008,7 +2008,7 @@
       "citation": "master09 §get_versioned_directory bad_ehr (→error); realized 404",
       "schedule_ref": "I_EHR_DIRECTORY.get_versioned_directory-bad_ehr (master09 §get_versioned_directory)",
       "binding": "GET /ehr/{ehr_id}/directory/{version_uid}",
-      "duration_ms": 8
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-DIR-036",
@@ -2023,7 +2023,7 @@
       "citation": "master09 §update_directory empty_ehr (no directory → error); ITS-REST directory_update 404 (412 If-Match form)",
       "schedule_ref": "I_EHR_DIRECTORY.update_directory-empty_ehr (master09 §update_directory)",
       "binding": "PUT /ehr/{ehr_id}/directory",
-      "duration_ms": 15
+      "duration_ms": 10
     },
     {
       "ecc_id": "ECC-DIR-037",
@@ -2038,7 +2038,7 @@
       "citation": "master09 §delete_directory empty_ehr (no directory → error); ITS-REST directory_delete 404 (412 If-Match form)",
       "schedule_ref": "I_EHR_DIRECTORY.delete_directory-empty_ehr (master09 §delete_directory)",
       "binding": "DELETE /ehr/{ehr_id}/directory",
-      "duration_ms": 21
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-TPL-011",
@@ -2053,7 +2053,7 @@
       "citation": "CNF master04 §I_DEFINITION_ADL14; ITS-REST 1.1.0 DEFINITION ADL 1.4 API (upload/get/validate); AM 1.4 §OPERATIONAL_TEMPLATE",
       "schedule_ref": "I_DEFINITION_ADL14.validate_opt-valid_opt (master04 §validate_opt)",
       "binding": "POST /definition/template/adl1.4 (validate-via-upload, §validate_opt NOTE)",
-      "duration_ms": 2
+      "duration_ms": 1
     },
     {
       "ecc_id": "ECC-TPL-012",
@@ -2069,7 +2069,7 @@
       "citation": "CNF master04 §I_DEFINITION_ADL14; ITS-REST 1.1.0 DEFINITION ADL 1.4 API (upload/get/validate); AM 1.4 §OPERATIONAL_TEMPLATE",
       "schedule_ref": "I_DEFINITION_ADL14.validate_opt-invalid_opt (master04 §validate_opt)",
       "binding": "POST /definition/template/adl1.4 (validate-via-upload, §validate_opt NOTE)",
-      "duration_ms": 23
+      "duration_ms": 48
     },
     {
       "ecc_id": "ECC-TPL-001",
@@ -2084,7 +2084,7 @@
       "citation": "CNF master04 §upload_opt; ITS-REST 1.1.0 DEFINITION ADL 1.4 API §upload OPT; AM 1.4 §OPERATIONAL_TEMPLATE; CORE Adl14ArchetypeProvisioning evidenced via the OPT (archetypes embedded in the OPT)",
       "schedule_ref": "I_DEFINITION_ADL14.upload_opt-valid_opt (master04 §upload_opt)",
       "binding": "POST /definition/template/adl1.4",
-      "duration_ms": 2
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-TPL-002",
@@ -2100,7 +2100,7 @@
       "citation": "CNF master04 §I_DEFINITION_ADL14; ITS-REST 1.1.0 DEFINITION ADL 1.4 API (upload/get/validate); AM 1.4 §OPERATIONAL_TEMPLATE",
       "schedule_ref": "I_DEFINITION_ADL14.upload_opt-invalid_opt (master04 §upload_opt)",
       "binding": "POST /definition/template/adl1.4",
-      "duration_ms": 18
+      "duration_ms": 22
     },
     {
       "ecc_id": "ECC-TPL-004",
@@ -2115,7 +2115,7 @@
       "citation": "CNF master04 §I_DEFINITION_ADL14; ITS-REST 1.1.0 DEFINITION ADL 1.4 API (upload/get/validate); AM 1.4 §OPERATIONAL_TEMPLATE",
       "schedule_ref": "I_DEFINITION_ADL14.upload_opt-valid_opt_twice_conflict (master04 §upload_opt)",
       "binding": "POST /definition/template/adl1.4",
-      "duration_ms": 3
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-TPL-005",
@@ -2130,7 +2130,7 @@
       "citation": "CNF master04 §I_DEFINITION_ADL14; ITS-REST 1.1.0 DEFINITION ADL 1.4 API (upload/get/validate); AM 1.4 §OPERATIONAL_TEMPLATE",
       "schedule_ref": "I_DEFINITION_ADL14.upload_opt-valid_opt_twice_no_conflict (master04 §upload_opt)",
       "binding": "POST /definition/template/adl1.4",
-      "duration_ms": 2
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-TPL-006",
@@ -2145,7 +2145,7 @@
       "citation": "CNF master04 §get_opt-retrieve_single (retrieved OPT == uploaded OPT NOTE); ITS-REST 1.1.0 DEFINITION ADL 1.4 API §get OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
       "schedule_ref": "I_DEFINITION_ADL14.get_opt-retrieve_single (master04 §get_opt)",
       "binding": "GET /definition/template/adl1.4/{template_id}",
-      "duration_ms": 3
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-TPL-009",
@@ -2160,7 +2160,7 @@
       "citation": "CNF master04 §I_DEFINITION_ADL14; ITS-REST 1.1.0 DEFINITION ADL 1.4 API (upload/get/validate); AM 1.4 §OPERATIONAL_TEMPLATE",
       "schedule_ref": "I_DEFINITION_ADL14.get_opt-retrieve_fail (master04 §get_opt)",
       "binding": "GET /definition/template/adl1.4/{template_id}",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "ecc_id": "ECC-TPL-007",
@@ -2175,7 +2175,7 @@
       "citation": "CNF master04 §I_DEFINITION_ADL14; ITS-REST 1.1.0 DEFINITION ADL 1.4 API (upload/get/validate); AM 1.4 §OPERATIONAL_TEMPLATE",
       "schedule_ref": "I_DEFINITION_ADL14.get_opt-retrieve_latest_version (master04 §get_opt)",
       "binding": "GET /definition/template/adl1.4/{template_id}",
-      "duration_ms": 3
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-TPL-008",
@@ -2190,7 +2190,7 @@
       "citation": "CNF master04 §I_DEFINITION_ADL14; ITS-REST 1.1.0 DEFINITION ADL 1.4 API (upload/get/validate); AM 1.4 §OPERATIONAL_TEMPLATE",
       "schedule_ref": "I_DEFINITION_ADL14.get_opt-retrieve_specific_version (master04 §get_opt)",
       "binding": "GET /definition/template/adl1.4/{template_id}/{version}",
-      "duration_ms": 2
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-TPL-010",
@@ -2205,7 +2205,7 @@
       "citation": "CNF master04 §get_opts-retrieve_all (all loaded OPTs returned, latest-only); ITS-REST 1.1.0 DEFINITION ADL 1.4 API §list OPTs; AM 1.4 §OPERATIONAL_TEMPLATE",
       "schedule_ref": "I_DEFINITION_ADL14.get_opts-retrieve_all (master04 §get_opts)",
       "binding": "GET /definition/template/adl1.4",
-      "duration_ms": 2
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-TPL-003",
@@ -2220,7 +2220,7 @@
       "citation": "CNF master04 §get_opts-retrieve_all_no_opts (empty server → empty set, no failure); ITS-REST 1.1.0 DEFINITION ADL 1.4 API §list OPTs",
       "schedule_ref": "I_DEFINITION_ADL14.get_opts-retrieve_all_no_opts (master04 §get_opts)",
       "binding": "GET /definition/template/adl1.4",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "ecc_id": "ECC-TPL-017",
@@ -2235,7 +2235,7 @@
       "citation": "ITS-REST development definition_template_adl1.4_example_get (GET /definition/template/adl1.4/{template_id}/example — the `required` example is \"expected to be committable without adjustment\"); CNF master15-content_tc_composition.adoc L38 (a generated instance must be RM/template-valid); AM 1.4 master04-constraint_model_package.adoc §Valid_value",
       "ecc_original": "CNF master04/master15 define no example-generation/commit case; the ITS-REST example operation is non-normative. ECC-derived: asserts the operation's own committable-`required` contract end-to-end (upload OPT → GET example → commit 201).",
       "binding": "GET /definition/template/adl1.4/{template_id}/example → POST /ehr/{ehr_id}/composition",
-      "duration_ms": 203
+      "duration_ms": 214
     },
     {
       "ecc_id": "ECC-TPL-014",
@@ -2250,7 +2250,7 @@
       "citation": "master04 §delete_opt-delete_existing (delete an existing OPT → 204, an unreferenced uniquified template); SM I_DEFINITION_ADL14.delete_opt(); no ITS-REST ADL 1.4 DELETE binding — ehrbase-rs extension (DELETE /admin/template/{template_id})",
       "schedule_ref": "I_DEFINITION_ADL14.delete_opt-delete_existing (master04 §delete_opt)",
       "binding": "DELETE /admin/template/{template_id}",
-      "duration_ms": 8
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-TPL-015",
@@ -2280,7 +2280,7 @@
       "citation": "master04 §delete_opt-delete_specific_version; no version-addressed resource on the admin route, so a template underpinning a specific committed version is refused (409 with a reference count — physical delete never orphans committed data); SM I_DEFINITION_ADL14.delete_opt(); no ITS-REST ADL 1.4 DELETE binding — ehrbase-rs extension (DELETE /admin/template/{template_id})",
       "schedule_ref": "I_DEFINITION_ADL14.delete_opt-delete_specific_version (master04 §delete_opt)",
       "binding": "DELETE /admin/template/{template_id}",
-      "duration_ms": 6
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-TPL-013",
@@ -2310,7 +2310,7 @@
       "citation": "ITS-REST 1.1.0 DEFINITION QUERY API §store/get stored query; AQL 1.1 (master05 stub — case id only)",
       "ecc_original": "schedule stub (master05 is TBD); derived from ITS-REST 1.1.0 DEFINITION QUERY + AQL 1.1 — I_DEFINITION_QUERY.valid_query-valid (master05:54, A.3.a)",
       "binding": "PUT /definition/query/{qualified_query_name}/{version}",
-      "duration_ms": 3
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-SQR-007",
@@ -2325,7 +2325,7 @@
       "citation": "ITS-REST 1.1.0 DEFINITION QUERY API §store/get stored query; AQL 1.1 (master05 stub — case id only)",
       "ecc_original": "schedule stub (master05 is TBD); derived from ITS-REST 1.1.0 DEFINITION QUERY + AQL 1.1 — I_DEFINITION_QUERY.valid_query-invalid (master05:67, A.3.b)",
       "binding": "PUT /definition/query/{qualified_query_name}/{version}",
-      "duration_ms": 1
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-SQR-006",
@@ -2415,7 +2415,7 @@
       "citation": "CNF master11 §I_QUERY_SERVICE (stub, xx flow); ITS-REST 1.1.0 QUERY API §execute_ad_hoc_query (200_QUERY.yaml RESULT_SET); AQL 1.1",
       "ecc_original": "I_QUERY_SERVICE.smoke_test (master11:48, stub xx flow)",
       "binding": "POST /query/aql",
-      "duration_ms": 2
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-QRY-002",
@@ -2430,7 +2430,7 @@
       "citation": "CNF master11 §I_QUERY_SERVICE (stub, xx flow); ITS-REST 1.1.0 QUERY API §execute_ad_hoc_query (200_QUERY.yaml RESULT_SET); AQL 1.1",
       "ecc_original": "I_QUERY_SERVICE.execute_ad_hoc_query-empty_db (master11:83, A.1.z, stub xx flow)",
       "binding": "POST /query/aql",
-      "duration_ms": 2
+      "duration_ms": 5
     },
     {
       "ecc_id": "ECC-QRY-003",
@@ -2475,7 +2475,7 @@
       "citation": "AQL 1.1 master03-syntax §Identified paths (COMPOSITION.uid.value → /uid/value); RM common master06 §Version identification (OBJECT_VERSION_ID); ITS-REST 1.1.0 QUERY API §execute_ad_hoc_query 200_QUERY.yaml RESULT_SET",
       "ecc_original": "schedule stub (master11 is TBD); the loaded-db case asserts only the projected column path — this case asserts the projected CELL equals the committed OBJECT_VERSION_ID (a null cell was a real, otherwise-invisible engine defect)",
       "binding": "POST /ehr/{ehr_id}/composition; POST /query/aql",
-      "duration_ms": 6
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-QRY-005",
@@ -2520,7 +2520,7 @@
       "citation": "AQL 1.1 + the vendored golden RESULT_SETs; ITS-REST 1.1.0 QUERY API §execute_ad_hoc_query 200_QUERY.yaml; reference: CNF query corpus expected_results",
       "ecc_original": "schedule stub (master11 is TBD); golden RESULT_SET diffs derived from AQL 1.1 + the vendored corpus",
       "binding": "POST /query/aql",
-      "duration_ms": 116
+      "duration_ms": 113
     },
     {
       "ecc_id": "ECC-QRY-007",
@@ -2535,7 +2535,7 @@
       "citation": "AQL 1.1 + the vendored golden RESULT_SETs; ITS-REST 1.1.0 QUERY API §execute_ad_hoc_query 200_QUERY.yaml; reference: CNF query corpus expected_results",
       "ecc_original": "schedule stub (master11 is TBD); golden RESULT_SET diffs derived from AQL 1.1 + the vendored corpus",
       "binding": "POST /query/aql",
-      "duration_ms": 154
+      "duration_ms": 163
     },
     {
       "ecc_id": "ECC-QRY-008",
@@ -2550,7 +2550,7 @@
       "citation": "AQL 1.1 + the vendored golden RESULT_SETs; ITS-REST 1.1.0 QUERY API §execute_ad_hoc_query 200_QUERY.yaml; reference: CNF query corpus expected_results",
       "ecc_original": "schedule stub (master11 is TBD); golden RESULT_SET diffs derived from AQL 1.1 + the vendored corpus",
       "binding": "POST /query/aql",
-      "duration_ms": 28
+      "duration_ms": 50
     },
     {
       "ecc_id": "ECC-QRY-009",
@@ -2565,7 +2565,7 @@
       "citation": "AQL 1.1 + the vendored golden RESULT_SETs; ITS-REST 1.1.0 QUERY API §execute_ad_hoc_query 200_QUERY.yaml; reference: CNF query corpus expected_results",
       "ecc_original": "schedule stub (master11 is TBD); golden RESULT_SET diffs derived from AQL 1.1 + the vendored corpus",
       "binding": "POST /query/aql",
-      "duration_ms": 64
+      "duration_ms": 107
     },
     {
       "ecc_id": "ECC-QRY-010",
@@ -2580,7 +2580,7 @@
       "citation": "AQL 1.1 + the vendored golden RESULT_SETs; ITS-REST 1.1.0 QUERY API §execute_ad_hoc_query 200_QUERY.yaml; reference: CNF query corpus expected_results",
       "ecc_original": "schedule stub (master11 is TBD); golden RESULT_SET diffs derived from AQL 1.1 + the vendored corpus",
       "binding": "POST /query/aql",
-      "duration_ms": 130
+      "duration_ms": 109
     },
     {
       "ecc_id": "ECC-QRY-011",
@@ -2595,7 +2595,7 @@
       "citation": "AQL 1.1 + the vendored golden RESULT_SETs; ITS-REST 1.1.0 QUERY API §execute_ad_hoc_query 200_QUERY.yaml; reference: CNF query corpus expected_results",
       "ecc_original": "schedule stub (master11 is TBD); golden RESULT_SET diffs derived from AQL 1.1 + the vendored corpus",
       "binding": "POST /query/aql",
-      "duration_ms": 132
+      "duration_ms": 165
     },
     {
       "ecc_id": "ECC-QRY-012",
@@ -2610,7 +2610,7 @@
       "citation": "AQL 1.1 + the vendored golden RESULT_SETs; ITS-REST 1.1.0 QUERY API §execute_ad_hoc_query 200_QUERY.yaml; reference: CNF query corpus expected_results",
       "ecc_original": "schedule stub (master11 is TBD); golden RESULT_SET diffs derived from AQL 1.1 + the vendored corpus",
       "binding": "POST /query/aql",
-      "duration_ms": 23
+      "duration_ms": 47
     },
     {
       "ecc_id": "ECC-QRY-013",
@@ -2625,7 +2625,7 @@
       "citation": "AQL 1.1 + the vendored golden RESULT_SETs; ITS-REST 1.1.0 QUERY API §execute_ad_hoc_query 200_QUERY.yaml; reference: CNF query corpus expected_results",
       "ecc_original": "schedule stub (master11 is TBD); golden RESULT_SET diffs derived from AQL 1.1 + the vendored corpus",
       "binding": "POST /query/aql",
-      "duration_ms": 30
+      "duration_ms": 54
     },
     {
       "ecc_id": "ECC-QRY-015",
@@ -2640,7 +2640,7 @@
       "citation": "AQL 1.1 removed TIMEWINDOW (QUERY master00-amendment_record SPECQUERY-20); ITS-REST 1.1.0 QUERY API §execute_ad_hoc_query 400_QUERY.yaml — invalid AQL must be rejected",
       "ecc_original": "schedule stub (master11 is TBD); TIMEWINDOW golden, spec-supersedes-corpus (adjudications/ecc-own.toml)",
       "binding": "POST /query/aql",
-      "duration_ms": 1
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-QRY-016",
@@ -2685,7 +2685,7 @@
       "citation": "AQL 1.1 grammar orders orderByClause? limitClause? (AqlParser.g4); a LIMIT-before-ORDER-BY query is invalid AQL — corpus-dialect defect (adjudications/ecc-own.toml)",
       "ecc_original": "schedule stub (master11 is TBD); LIMIT-before-ORDER-BY golden, corpus-dialect (adjudications/ecc-own.toml)",
       "binding": "POST /query/aql",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "ecc_id": "ECC-QRY-019",
@@ -2700,7 +2700,7 @@
       "citation": "AQL 1.1 grammar orders orderByClause? limitClause? (AqlParser.g4); a LIMIT-before-ORDER-BY query is invalid AQL — corpus-dialect defect (adjudications/ecc-own.toml)",
       "ecc_original": "schedule stub (master11 is TBD); LIMIT-before-ORDER-BY golden, corpus-dialect (adjudications/ecc-own.toml)",
       "binding": "POST /query/aql",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "ecc_id": "ECC-QRY-020",
@@ -2715,7 +2715,7 @@
       "citation": "AQL 1.1 grammar orders orderByClause? limitClause? (AqlParser.g4); a LIMIT-before-ORDER-BY query is invalid AQL — corpus-dialect defect (adjudications/ecc-own.toml)",
       "ecc_original": "schedule stub (master11 is TBD); LIMIT-before-ORDER-BY golden, corpus-dialect (adjudications/ecc-own.toml)",
       "binding": "POST /query/aql",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "ecc_id": "ECC-QRY-021",
@@ -2745,7 +2745,7 @@
       "citation": "AQL 1.1 grammar orders orderByClause? limitClause? (AqlParser.g4); a LIMIT-before-ORDER-BY query is invalid AQL — corpus-dialect defect (adjudications/ecc-own.toml)",
       "ecc_original": "schedule stub (master11 is TBD); LIMIT-before-ORDER-BY golden, corpus-dialect (adjudications/ecc-own.toml)",
       "binding": "POST /query/aql",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "ecc_id": "ECC-QRY-023",
@@ -2760,7 +2760,7 @@
       "citation": "AQL 1.1 grammar orders orderByClause? limitClause? (AqlParser.g4); a LIMIT-before-ORDER-BY query is invalid AQL — corpus-dialect defect (adjudications/ecc-own.toml)",
       "ecc_original": "schedule stub (master11 is TBD); LIMIT-before-ORDER-BY golden, corpus-dialect (adjudications/ecc-own.toml)",
       "binding": "POST /query/aql",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "ecc_id": "ECC-QRY-024",
@@ -2775,7 +2775,7 @@
       "citation": "AQL 1.1 grammar orders orderByClause? limitClause? (AqlParser.g4); a LIMIT-before-ORDER-BY query is invalid AQL — corpus-dialect defect (adjudications/ecc-own.toml)",
       "ecc_original": "schedule stub (master11 is TBD); LIMIT-before-ORDER-BY golden, corpus-dialect (adjudications/ecc-own.toml)",
       "binding": "POST /query/aql",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "ecc_id": "ECC-VAL-001",
@@ -2791,7 +2791,7 @@
       "citation": "RM 1.2.0 composition §COMPOSITION.content/context (content List 0..1, context 0..1, Category_validity only); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422 validation)",
       "schedule_ref": "CONT-COMP.content_card_any-context_any (master15 §COMPOSITION Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 29
+      "duration_ms": 46
     },
     {
       "ecc_id": "ECC-VAL-002",
@@ -2807,7 +2807,7 @@
       "citation": "RM 1.2.0 composition §COMPOSITION.content/context (content List 0..1, context 0..1, Category_validity only); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422 validation)",
       "schedule_ref": "CONT-COMP.content_card_1plus-context_any (master15 §COMPOSITION Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 26
+      "duration_ms": 35
     },
     {
       "ecc_id": "ECC-VAL-003",
@@ -2823,7 +2823,7 @@
       "citation": "RM 1.2.0 composition §COMPOSITION.content/context (content List 0..1, context 0..1, Category_validity only); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422 validation)",
       "schedule_ref": "CONT-COMP.content_card_3plus-context_any (master15 §COMPOSITION Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 20
+      "duration_ms": 32
     },
     {
       "ecc_id": "ECC-VAL-004",
@@ -2839,7 +2839,7 @@
       "citation": "RM 1.2.0 composition §COMPOSITION.content/context (content List 0..1, context 0..1, Category_validity only); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422 validation)",
       "schedule_ref": "CONT-COMP.content_card_opt-context_any (master15 §COMPOSITION Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 27
+      "duration_ms": 33
     },
     {
       "ecc_id": "ECC-VAL-005",
@@ -2855,7 +2855,7 @@
       "citation": "RM 1.2.0 composition §COMPOSITION.content/context (content List 0..1, context 0..1, Category_validity only); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422 validation)",
       "schedule_ref": "CONT-COMP.content_card_mand-context_any (master15 §COMPOSITION Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 28
+      "duration_ms": 29
     },
     {
       "ecc_id": "ECC-VAL-006",
@@ -2871,7 +2871,7 @@
       "citation": "RM 1.2.0 composition §COMPOSITION.content/context (content List 0..1, context 0..1, Category_validity only); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422 validation)",
       "schedule_ref": "CONT-COMP.content_card_3to5-context_any (master15 §COMPOSITION Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 31
+      "duration_ms": 32
     },
     {
       "ecc_id": "ECC-VAL-007",
@@ -2887,7 +2887,7 @@
       "citation": "RM 1.2.0 composition §COMPOSITION.content/context (content List 0..1, context 0..1, Category_validity only); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422 validation)",
       "schedule_ref": "CONT-COMP.content_card_any-context_mand (master15 §COMPOSITION Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 25
+      "duration_ms": 31
     },
     {
       "ecc_id": "ECC-VAL-008",
@@ -2903,7 +2903,7 @@
       "citation": "RM 1.2.0 composition §COMPOSITION.content/context (content List 0..1, context 0..1, Category_validity only); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422 validation)",
       "schedule_ref": "CONT-COMP.content_card_1plus-context_mand (master15 §COMPOSITION Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 22
+      "duration_ms": 30
     },
     {
       "ecc_id": "ECC-VAL-009",
@@ -2919,7 +2919,7 @@
       "citation": "RM 1.2.0 composition §COMPOSITION.content/context (content List 0..1, context 0..1, Category_validity only); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422 validation)",
       "schedule_ref": "CONT-COMP.content_card_3plus-context_mand (master15 §COMPOSITION Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 19
+      "duration_ms": 31
     },
     {
       "ecc_id": "ECC-VAL-010",
@@ -2935,7 +2935,7 @@
       "citation": "RM 1.2.0 composition §COMPOSITION.content/context (content List 0..1, context 0..1, Category_validity only); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422 validation)",
       "schedule_ref": "CONT-COMP.content_card_opt-context_mand (master15 §COMPOSITION Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 28
+      "duration_ms": 23
     },
     {
       "ecc_id": "ECC-VAL-011",
@@ -2951,7 +2951,7 @@
       "citation": "RM 1.2.0 composition §COMPOSITION.content/context (content List 0..1, context 0..1, Category_validity only); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422 validation)",
       "schedule_ref": "CONT-COMP.content_card_mand-context_mand (master15 §COMPOSITION Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 27
+      "duration_ms": 20
     },
     {
       "ecc_id": "ECC-VAL-012",
@@ -2967,7 +2967,7 @@
       "citation": "RM 1.2.0 composition §COMPOSITION.content/context (content List 0..1, context 0..1, Category_validity only); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422 validation)",
       "schedule_ref": "CONT-COMP.content_card_3to5-context_mand (master15 §COMPOSITION Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 27
+      "duration_ms": 22
     },
     {
       "ecc_id": "ECC-VAL-013",
@@ -2983,7 +2983,7 @@
       "citation": "RM 1.2.0 ehr §OBSERVATION (data 1..1; state/protocol 0..1); AM aom14 §C_ATTRIBUTE existence; ITS-REST 1.1.0 composition_create (201 / 422 validation)",
       "schedule_ref": "ENTRY.CONT-OBS-state_ex_opt-protocol_ex_opt (master16 §OBSERVATION Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 17
+      "duration_ms": 15
     },
     {
       "ecc_id": "ECC-VAL-014",
@@ -2999,7 +2999,7 @@
       "citation": "RM 1.2.0 ehr §OBSERVATION (data 1..1; state/protocol 0..1); AM aom14 §C_ATTRIBUTE existence; ITS-REST 1.1.0 composition_create (201 / 422 validation)",
       "schedule_ref": "ENTRY.CONT-OBS-state_ex_opt-protocol_ex_mand (master16 §OBSERVATION Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 15
+      "duration_ms": 16
     },
     {
       "ecc_id": "ECC-VAL-015",
@@ -3015,7 +3015,7 @@
       "citation": "RM 1.2.0 ehr §OBSERVATION (data 1..1; state/protocol 0..1); AM aom14 §C_ATTRIBUTE existence; ITS-REST 1.1.0 composition_create (201 / 422 validation)",
       "schedule_ref": "ENTRY.CONT-OBS-state_ex_mand-protocol_ex_opt (master16 §OBSERVATION Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 15
+      "duration_ms": 16
     },
     {
       "ecc_id": "ECC-VAL-016",
@@ -3031,7 +3031,7 @@
       "citation": "RM 1.2.0 ehr §OBSERVATION (data 1..1; state/protocol 0..1); AM aom14 §C_ATTRIBUTE existence; ITS-REST 1.1.0 composition_create (201 / 422 validation)",
       "schedule_ref": "ENTRY.CONT-OBS-state_ex_mand-protocol_ex_mand (master16 §OBSERVATION Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 15
+      "duration_ms": 13
     },
     {
       "ecc_id": "ECC-VAL-017",
@@ -3047,7 +3047,7 @@
       "citation": "RM 1.2.0 data_structures §HISTORY (events cardinality; summary existence; Events_valid: ≥1 event OR summary); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-HIST-events_card_any-summary_ex_opt (master16 §HISTORY Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 13
+      "duration_ms": 18
     },
     {
       "ecc_id": "ECC-VAL-018",
@@ -3063,7 +3063,7 @@
       "citation": "RM 1.2.0 data_structures §HISTORY (events cardinality; summary existence; Events_valid: ≥1 event OR summary); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-HIST-events_card_1plus-summary_ex_opt (master16 §HISTORY Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 12
+      "duration_ms": 18
     },
     {
       "ecc_id": "ECC-VAL-019",
@@ -3079,7 +3079,7 @@
       "citation": "RM 1.2.0 data_structures §HISTORY (events cardinality; summary existence; Events_valid: ≥1 event OR summary); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-HIST-events_card_3plus-summary_ex_opt (master16 §HISTORY Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 12
+      "duration_ms": 15
     },
     {
       "ecc_id": "ECC-VAL-020",
@@ -3095,7 +3095,7 @@
       "citation": "RM 1.2.0 data_structures §HISTORY (events cardinality; summary existence; Events_valid: ≥1 event OR summary); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-HIST-events_card_opt-summary_ex_opt (master16 §HISTORY Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 12
+      "duration_ms": 13
     },
     {
       "ecc_id": "ECC-VAL-021",
@@ -3111,7 +3111,7 @@
       "citation": "RM 1.2.0 data_structures §HISTORY (events cardinality; summary existence; Events_valid: ≥1 event OR summary); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-HIST-events_card_mand-summary_ex_opt (master16 §HISTORY Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 12
+      "duration_ms": 16
     },
     {
       "ecc_id": "ECC-VAL-022",
@@ -3127,7 +3127,7 @@
       "citation": "RM 1.2.0 data_structures §HISTORY (events cardinality; summary existence; Events_valid: ≥1 event OR summary); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-HIST-events_card_3to5-summary_ex_opt (master16 §HISTORY Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 12
+      "duration_ms": 16
     },
     {
       "ecc_id": "ECC-VAL-023",
@@ -3143,7 +3143,7 @@
       "citation": "RM 1.2.0 data_structures §HISTORY (events cardinality; summary existence; Events_valid: ≥1 event OR summary); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-HIST-events_card_any-summary_ex_mand (master16 §HISTORY Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 12
+      "duration_ms": 14
     },
     {
       "ecc_id": "ECC-VAL-024",
@@ -3159,7 +3159,7 @@
       "citation": "RM 1.2.0 data_structures §HISTORY (events cardinality; summary existence; Events_valid: ≥1 event OR summary); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-HIST-events_card_1plus-summary_ex_mand (master16 §HISTORY Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 10
+      "duration_ms": 13
     },
     {
       "ecc_id": "ECC-VAL-025",
@@ -3175,7 +3175,7 @@
       "citation": "RM 1.2.0 data_structures §HISTORY (events cardinality; summary existence; Events_valid: ≥1 event OR summary); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-HIST-events_card_3plus-summary_ex_mand (master16 §HISTORY Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 10
+      "duration_ms": 11
     },
     {
       "ecc_id": "ECC-VAL-026",
@@ -3191,7 +3191,7 @@
       "citation": "RM 1.2.0 data_structures §HISTORY (events cardinality; summary existence; Events_valid: ≥1 event OR summary); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-HIST-events_card_opt-summary_ex_mand (master16 §HISTORY Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 10
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-VAL-027",
@@ -3207,7 +3207,7 @@
       "citation": "RM 1.2.0 data_structures §HISTORY (events cardinality; summary existence; Events_valid: ≥1 event OR summary); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-HIST-events_card_mand-summary_ex_mand (master16 §HISTORY Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 12
+      "duration_ms": 14
     },
     {
       "ecc_id": "ECC-VAL-028",
@@ -3223,7 +3223,7 @@
       "citation": "RM 1.2.0 data_structures §HISTORY (events cardinality; summary existence; Events_valid: ≥1 event OR summary); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-HIST-events_card_3to5-summary_ex_mand (master16 §HISTORY Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 13
+      "duration_ms": 16
     },
     {
       "ecc_id": "ECC-VAL-029",
@@ -3239,7 +3239,7 @@
       "citation": "RM 1.2.0 data_structures §EVENT/POINT_EVENT/INTERVAL_EVENT (state 0..1; INTERVAL_EVENT.width/math_function mandatory); AM aom14 §type narrowing; ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-EVENT-state_ex_opt (master16 §EVENT Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 15
+      "duration_ms": 13
     },
     {
       "ecc_id": "ECC-VAL-030",
@@ -3255,7 +3255,7 @@
       "citation": "RM 1.2.0 data_structures §EVENT/POINT_EVENT/INTERVAL_EVENT (state 0..1; INTERVAL_EVENT.width/math_function mandatory); AM aom14 §type narrowing; ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-EVENT-state_ex_mand (master16 §EVENT Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 15
+      "duration_ms": 13
     },
     {
       "ecc_id": "ECC-VAL-031",
@@ -3271,7 +3271,7 @@
       "citation": "RM 1.2.0 data_structures §EVENT/POINT_EVENT/INTERVAL_EVENT (state 0..1; INTERVAL_EVENT.width/math_function mandatory); AM aom14 §type narrowing; ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-EVENT-type_any (master16 §EVENT Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 11
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-VAL-032",
@@ -3287,7 +3287,7 @@
       "citation": "RM 1.2.0 data_structures §EVENT/POINT_EVENT/INTERVAL_EVENT (state 0..1; INTERVAL_EVENT.width/math_function mandatory); AM aom14 §type narrowing; ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-EVENT-type_point_event (master16 §EVENT Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 11
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-VAL-033",
@@ -3303,7 +3303,7 @@
       "citation": "RM 1.2.0 data_structures §EVENT/POINT_EVENT/INTERVAL_EVENT (state 0..1; INTERVAL_EVENT.width/math_function mandatory); AM aom14 §type narrowing; ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-EVENT-type_interval_event (master16 §EVENT Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 9
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-VAL-034",
@@ -3319,7 +3319,7 @@
       "citation": "RM 1.2.0 data_structures §ITEM_STRUCTURE (ITEM_TREE/LIST/TABLE/SINGLE); AM aom14 §type narrowing (Class not allowed); ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-ITEM_STR-type_any (master16 §ITEM_STRUCTURE Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 22
+      "duration_ms": 27
     },
     {
       "ecc_id": "ECC-VAL-035",
@@ -3335,7 +3335,7 @@
       "citation": "RM 1.2.0 data_structures §ITEM_STRUCTURE (ITEM_TREE/LIST/TABLE/SINGLE); AM aom14 §type narrowing (Class not allowed); ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-ITEM_STR-type_item_tree (master16 §ITEM_STRUCTURE Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 16
+      "duration_ms": 18
     },
     {
       "ecc_id": "ECC-VAL-036",
@@ -3351,7 +3351,7 @@
       "citation": "RM 1.2.0 data_structures §ITEM_STRUCTURE (ITEM_TREE/LIST/TABLE/SINGLE); AM aom14 §type narrowing (Class not allowed); ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-ITEM_STR-type_item_list (master16 §ITEM_STRUCTURE Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 17
+      "duration_ms": 19
     },
     {
       "ecc_id": "ECC-VAL-037",
@@ -3367,7 +3367,7 @@
       "citation": "RM 1.2.0 data_structures §ITEM_STRUCTURE (ITEM_TREE/LIST/TABLE/SINGLE); AM aom14 §type narrowing (Class not allowed); ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-ITEM_STR-type_item_table (master16 §ITEM_STRUCTURE Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 15
+      "duration_ms": 19
     },
     {
       "ecc_id": "ECC-VAL-038",
@@ -3383,7 +3383,7 @@
       "citation": "RM 1.2.0 data_structures §ITEM_STRUCTURE (ITEM_TREE/LIST/TABLE/SINGLE); AM aom14 §type narrowing (Class not allowed); ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-ITEM_STR-type_item_single (master16 §ITEM_STRUCTURE Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 16
+      "duration_ms": 17
     },
     {
       "ecc_id": "ECC-VAL-039",
@@ -3415,7 +3415,7 @@
       "citation": "RM 1.2.0 data_types §DV_BOOLEAN; AM 1.4 C_BOOLEAN {true}; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_BOOLEAN.only_true_allowed (master17.1 §DV_BOOLEAN)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 34
+      "duration_ms": 31
     },
     {
       "ecc_id": "ECC-VAL-041",
@@ -3431,7 +3431,7 @@
       "citation": "RM 1.2.0 data_types §DV_BOOLEAN; AM 1.4 C_BOOLEAN {false}; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_BOOLEAN.only_false_allowed (master17.1 §DV_BOOLEAN)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 34
+      "duration_ms": 29
     },
     {
       "ecc_id": "ECC-VAL-042",
@@ -3447,7 +3447,7 @@
       "citation": "RM 1.2.0 data_types §DV_IDENTIFIER; AM 1.4 C_STRING.pattern on id; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_IDENTIFIER.validate_all_pattern (master17.1 §DV_IDENTIFIER)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 33
+      "duration_ms": 29
     },
     {
       "ecc_id": "ECC-VAL-043",
@@ -3463,7 +3463,7 @@
       "citation": "RM 1.2.0 data_types §DV_IDENTIFIER; AM 1.4 C_STRING.list on id; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_IDENTIFIER.validate_all_list (master17.1 §DV_IDENTIFIER)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 35
+      "duration_ms": 29
     },
     {
       "ecc_id": "ECC-VAL-044",
@@ -3479,7 +3479,7 @@
       "citation": "RM 1.2.0 data_types §DV_TEXT; AM 1.4 C_STRING open; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_TEXT.validate_open (master17.2 §DV_TEXT; heading duplicated, 2nd C_STRING.pattern table folded)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 30
+      "duration_ms": 23
     },
     {
       "ecc_id": "ECC-VAL-045",
@@ -3495,7 +3495,7 @@
       "citation": "RM 1.2.0 data_types §DV_TEXT; AM 1.4 C_STRING.list; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_TEXT.validate_list (master17.2 §DV_TEXT)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 32
+      "duration_ms": 31
     },
     {
       "ecc_id": "ECC-VAL-046",
@@ -3511,7 +3511,7 @@
       "citation": "RM 1.2.0 data_types §DV_CODED_TEXT; AM 1.4 C_CODE_PHRASE open; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_CODED_TEXT.validate_open (master17.2 §DV_CODED_TEXT)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 33
+      "duration_ms": 23
     },
     {
       "ecc_id": "ECC-VAL-047",
@@ -3527,7 +3527,7 @@
       "citation": "RM 1.2.0 data_types §DV_CODED_TEXT; AM 1.4 C_CODE_PHRASE local code_list; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_CODED_TEXT.validate_local_codes (master17.2 §DV_CODED_TEXT)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 50
+      "duration_ms": 26
     },
     {
       "ecc_id": "ECC-VAL-048",
@@ -3543,7 +3543,7 @@
       "citation": "RM 1.2.0 data_types §DV_CODED_TEXT; AM 1.4 C_CODE_PHRASE external terminology; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_CODED_TEXT.validate_ext_term (master17.2 §DV_CODED_TEXT; direct C_CODE_PHRASE substitutes the CONSTRAINT_REF binding path)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 40
+      "duration_ms": 27
     },
     {
       "ecc_id": "ECC-VAL-049",
@@ -3559,7 +3559,7 @@
       "citation": "RM 1.2.0 data_types §DV_ORDINAL; AM 1.4 C_DV_ORDINAL open; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_ORDINAL.validate_open (master17.3 §DV_ORDINAL)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 28
+      "duration_ms": 20
     },
     {
       "ecc_id": "ECC-VAL-050",
@@ -3575,7 +3575,7 @@
       "citation": "RM 1.2.0 data_types §DV_ORDINAL; AM 1.4 C_DV_ORDINAL.list; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_ORDINAL.validate_constraint (master17.3 §DV_ORDINAL)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 26
+      "duration_ms": 21
     },
     {
       "ecc_id": "ECC-VAL-051",
@@ -3591,7 +3591,7 @@
       "citation": "RM 1.2.0 data_types §DV_SCALE (RM ≥ 1.1.0, SPECRM-19); AM 1.4 open; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_SCALE.validate_open (master17.3 §DV_SCALE; RM ≥ 1.1.0)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 35
+      "duration_ms": 32
     },
     {
       "ecc_id": "ECC-VAL-052",
@@ -3607,7 +3607,7 @@
       "citation": "RM 1.2.0 data_types §DV_SCALE (RM ≥ 1.1.0); AM 1.4 C_REAL.list on value (no C_DV_SCALE in AM 1.4, SPECPR-381); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_SCALE.validate_constraint (master17.3 §DV_SCALE; RM ≥ 1.1.0, C_REAL substitute)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 32
+      "duration_ms": 35
     },
     {
       "ecc_id": "ECC-VAL-053",
@@ -3623,7 +3623,7 @@
       "citation": "RM 1.2.0 data_types §DV_COUNT; AM 1.4 C_INTEGER open; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_COUNT.validate_open (master17.3 §DV_COUNT)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 21
+      "duration_ms": 28
     },
     {
       "ecc_id": "ECC-VAL-054",
@@ -3655,7 +3655,7 @@
       "citation": "RM 1.2.0 data_types §DV_COUNT; AM 1.4 C_INTEGER.list; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_COUNT.validate_list (master17.3 §DV_COUNT)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 29
+      "duration_ms": 33
     },
     {
       "ecc_id": "ECC-VAL-056",
@@ -3671,7 +3671,7 @@
       "citation": "RM 1.2.0 data_types §DV_QUANTITY; AM 1.4 C_DV_QUANTITY open; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_QUANTITY.validate_open (master17.3 §DV_QUANTITY)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 23
+      "duration_ms": 24
     },
     {
       "ecc_id": "ECC-VAL-057",
@@ -3687,7 +3687,7 @@
       "citation": "RM 1.2.0 data_types §DV_QUANTITY; AM 1.4 C_DV_QUANTITY.property; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_QUANTITY.validate_property (master17.3 §DV_QUANTITY)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 31
+      "duration_ms": 32
     },
     {
       "ecc_id": "ECC-VAL-058",
@@ -3703,7 +3703,7 @@
       "citation": "RM 1.2.0 data_types §DV_QUANTITY; AM 1.4 C_DV_QUANTITY units list; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_QUANTITY.validate_property_units (master17.3 §DV_QUANTITY)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 21
+      "duration_ms": 22
     },
     {
       "ecc_id": "ECC-VAL-059",
@@ -3719,7 +3719,7 @@
       "citation": "RM 1.2.0 data_types §DV_QUANTITY; AM 1.4 C_DV_QUANTITY units list + magnitude range; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_QUANTITY.validate_property_units_mag (master17.3 §DV_QUANTITY)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 25
+      "duration_ms": 23
     },
     {
       "ecc_id": "ECC-VAL-060",
@@ -3751,7 +3751,7 @@
       "citation": "RM 1.2.0 data_types §DV_PROPORTION (ratio kind 0); AM 1.4 C_INTEGER.list on type; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_PROPORTION.validate_ratio (master17.3 §DV_PROPORTION)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 29
+      "duration_ms": 32
     },
     {
       "ecc_id": "ECC-VAL-062",
@@ -3767,7 +3767,7 @@
       "citation": "RM 1.2.0 data_types §DV_PROPORTION (unitary kind 1); AM 1.4 C_INTEGER.list on type; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_PROPORTION.validate_unitary (master17.3 §DV_PROPORTION)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 28
+      "duration_ms": 35
     },
     {
       "ecc_id": "ECC-VAL-063",
@@ -3783,7 +3783,7 @@
       "citation": "RM 1.2.0 data_types §DV_PROPORTION (percent kind 2); AM 1.4 C_INTEGER.list on type; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_PROPORTION.validate_percent (master17.3 §DV_PROPORTION)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 34
+      "duration_ms": 27
     },
     {
       "ecc_id": "ECC-VAL-064",
@@ -3799,7 +3799,7 @@
       "citation": "RM 1.2.0 data_types §DV_PROPORTION (fraction kind 3); AM 1.4 C_INTEGER.list on type; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_PROPORTION.validate_fraction (master17.3 §DV_PROPORTION)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 32
+      "duration_ms": 30
     },
     {
       "ecc_id": "ECC-VAL-065",
@@ -3815,7 +3815,7 @@
       "citation": "RM 1.2.0 data_types §DV_PROPORTION (integer_fraction kind 4); AM 1.4 C_INTEGER.list on type; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_PROPORTION.validate_integer_fraction (master17.3 §DV_PROPORTION)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 29
+      "duration_ms": 30
     },
     {
       "ecc_id": "ECC-VAL-066",
@@ -3831,7 +3831,7 @@
       "citation": "RM 1.2.0 data_types §DV_PROPORTION; AM 1.4 C_INTEGER.list {3,4} on type; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_PROPORTION.validate_any_fraction (master17.3 §DV_PROPORTION)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 9
+      "duration_ms": 10
     },
     {
       "ecc_id": "ECC-VAL-067",
@@ -3847,7 +3847,7 @@
       "citation": "RM 1.2.0 data_types §DV_PROPORTION; AM 1.4 C_REAL.range on numerator; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_PROPORTION.validate_ratio_range (master17.3 §DV_PROPORTION; denominator C_REAL.range table not driven)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 30
+      "duration_ms": 31
     },
     {
       "ecc_id": "ECC-VAL-068",
@@ -3863,7 +3863,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_COUNT>; BASE foundation_types §Interval invariants; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_COUNT.validate_open (master17.3 §DV_INTERVAL<DV_COUNT>; bound C_INTEGER constraint inexpressible → RM Interval invariant triple)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 44
+      "duration_ms": 48
     },
     {
       "ecc_id": "ECC-VAL-069",
@@ -3879,7 +3879,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_COUNT>; BASE foundation_types §Interval (lower ≤ upper); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_COUNT.validate_lower_upper (master17.3; bound constraint inexpressible → RM lower ≤ upper)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 33
+      "duration_ms": 28
     },
     {
       "ecc_id": "ECC-VAL-070",
@@ -3895,7 +3895,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_COUNT>; BASE foundation_types §Interval (lower ≤ upper); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_COUNT.validate_lower_upper_list (master17.3; C_INTEGER.list on bounds inexpressible → RM lower ≤ upper)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 39
+      "duration_ms": 30
     },
     {
       "ecc_id": "ECC-VAL-071",
@@ -3911,7 +3911,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_QUANTITY>; BASE foundation_types §Interval invariants; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_QUANTITY.validate_open (master17.3; bound C_DV_QUANTITY.list inexpressible → RM Interval invariant triple)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 46
+      "duration_ms": 43
     },
     {
       "ecc_id": "ECC-VAL-072",
@@ -3943,7 +3943,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DATE_TIME>; BASE foundation_types §Interval invariants; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_DATE_TIME.validate_open (master17.3; temporal bound inexpressible → RM Interval invariant triple)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 46
+      "duration_ms": 44
     },
     {
       "ecc_id": "ECC-VAL-074",
@@ -3959,7 +3959,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DATE_TIME>; BASE foundation_types §Interval (lower ≤ upper); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_DATE_TIME.validate_lower_upper_constraint (master17.3, 68-row table; C_DATE_TIME bounds inexpressible → RM lower ≤ upper)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 36
+      "duration_ms": 28
     },
     {
       "ecc_id": "ECC-VAL-075",
@@ -3975,7 +3975,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DATE_TIME>; BASE foundation_types §Interval (lower ≤ upper); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_DATE_TIME.validate_lower_upper_range (master17.3; C_DATE_TIME.range bounds inexpressible → RM lower ≤ upper)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 37
+      "duration_ms": 27
     },
     {
       "ecc_id": "ECC-VAL-076",
@@ -3991,7 +3991,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DATE>; BASE foundation_types §Interval invariants; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_DATE.validate_open (master17.3; temporal bound inexpressible → RM Interval invariant triple)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 53
+      "duration_ms": 43
     },
     {
       "ecc_id": "ECC-VAL-077",
@@ -4007,7 +4007,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DATE>; BASE foundation_types §Interval (lower ≤ upper); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_DATE.validate_lower_upper_constraint (master17.3; C_DATE bounds inexpressible → RM lower ≤ upper)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 29
+      "duration_ms": 28
     },
     {
       "ecc_id": "ECC-VAL-078",
@@ -4023,7 +4023,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DATE>; BASE foundation_types §Interval (lower ≤ upper); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_DATE.validate_lower_upper_range (master17.3; C_DATE.range bounds inexpressible → RM lower ≤ upper)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 36
+      "duration_ms": 30
     },
     {
       "ecc_id": "ECC-VAL-079",
@@ -4039,7 +4039,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_TIME>; BASE foundation_types §Interval invariants; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_TIME.validate_open (master17.3; temporal bound inexpressible → RM Interval invariant triple)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 44
+      "duration_ms": 41
     },
     {
       "ecc_id": "ECC-VAL-080",
@@ -4055,7 +4055,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_TIME>; BASE foundation_types §Interval (lower ≤ upper); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_TIME.validate_lower_upper_constraint (master17.3; C_TIME bounds inexpressible → RM lower ≤ upper)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 41
+      "duration_ms": 27
     },
     {
       "ecc_id": "ECC-VAL-081",
@@ -4071,7 +4071,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_TIME>; BASE foundation_types §Interval (lower ≤ upper); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_TIME.validate_lower_upper_range (master17.3; C_TIME.range bounds inexpressible → RM lower ≤ upper)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 35
+      "duration_ms": 26
     },
     {
       "ecc_id": "ECC-VAL-082",
@@ -4087,7 +4087,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DURATION>; BASE foundation_types §Interval invariants; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_DURATION.validate_open (master17.3; temporal bound inexpressible → RM Interval invariant triple)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 68
+      "duration_ms": 47
     },
     {
       "ecc_id": "ECC-VAL-083",
@@ -4103,7 +4103,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DURATION>; BASE foundation_types §Interval (lower ≤ upper); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_DURATION.validate_constraint (master17.3, 35-row table; C_DURATION bounds inexpressible → RM lower ≤ upper)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 29
+      "duration_ms": 27
     },
     {
       "ecc_id": "ECC-VAL-084",
@@ -4119,7 +4119,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DURATION>; BASE foundation_types §Interval (lower ≤ upper); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_DURATION.validate_range (master17.3; C_DURATION.range bounds inexpressible → RM lower ≤ upper)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 29
+      "duration_ms": 30
     },
     {
       "ecc_id": "ECC-VAL-085",
@@ -4135,7 +4135,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_ORDINAL>; BASE foundation_types §Interval invariants; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_ORDINAL.validate_open (master17.3; bound constraint inexpressible → RM Interval invariant triple)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 45
+      "duration_ms": 44
     },
     {
       "ecc_id": "ECC-VAL-086",
@@ -4167,7 +4167,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_SCALE> (RM ≥ 1.1.0); BASE foundation_types §Interval invariants; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_SCALE.validate_open (master17.3; RM ≥ 1.1.0; bound inexpressible → RM Interval invariant triple)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 45
+      "duration_ms": 54
     },
     {
       "ecc_id": "ECC-VAL-088",
@@ -4183,7 +4183,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_SCALE> (RM ≥ 1.1.0); BASE foundation_types §Interval (lower ≤ upper); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_SCALE.validate_constraint (master17.3; RM ≥ 1.1.0; bound inexpressible → RM lower ≤ upper)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 51
+      "duration_ms": 38
     },
     {
       "ecc_id": "ECC-VAL-089",
@@ -4199,7 +4199,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; BASE foundation_types §Interval invariants; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_PROPORTION.validate_open (master17.3, 18-row table; bound inexpressible → RM Interval invariant triple)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 45
+      "duration_ms": 43
     },
     {
       "ecc_id": "ECC-VAL-090",
@@ -4215,7 +4215,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; BASE foundation_types §Interval (lower ≤ upper); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_PROPORTION.validate_ratio (master17.3, 12-row table; proportion-kind bound inexpressible → RM lower ≤ upper)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 35
+      "duration_ms": 28
     },
     {
       "ecc_id": "ECC-VAL-091",
@@ -4231,7 +4231,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; BASE foundation_types §Interval (lower ≤ upper); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_PROPORTION.validate_unitary (master17.3, 12-row table; proportion-kind bound inexpressible → RM lower ≤ upper)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 30
+      "duration_ms": 31
     },
     {
       "ecc_id": "ECC-VAL-092",
@@ -4247,7 +4247,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; BASE foundation_types §Interval (lower ≤ upper); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_PROPORTION.validate_percentage (master17.3, 12-row table; proportion-kind bound inexpressible → RM lower ≤ upper)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 27
+      "duration_ms": 30
     },
     {
       "ecc_id": "ECC-VAL-093",
@@ -4263,7 +4263,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; BASE foundation_types §Interval (lower ≤ upper); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_PROPORTION.validate_fraction (master17.3, 12-row table; proportion-kind bound inexpressible → RM lower ≤ upper)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 28
+      "duration_ms": 27
     },
     {
       "ecc_id": "ECC-VAL-094",
@@ -4279,7 +4279,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; BASE foundation_types §Interval (lower ≤ upper); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_PROPORTION.validate_integer_fraction (master17.3, 12-row table; proportion-kind bound inexpressible → RM lower ≤ upper)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 27
+      "duration_ms": 29
     },
     {
       "ecc_id": "ECC-VAL-095",
@@ -4295,7 +4295,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; BASE foundation_types §Interval (lower ≤ upper); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_PROPORTION.validate_ratio_range (master17.3, 18-row table; proportion-kind bound inexpressible → RM lower ≤ upper)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 27
+      "duration_ms": 28
     },
     {
       "ecc_id": "ECC-VAL-096",
@@ -4311,7 +4311,7 @@
       "citation": "RM 1.2.0 data_types §DV_DURATION; AM 1.4 open; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_DURATION.validate_open (master17.4 §DV_DURATION)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 20
+      "duration_ms": 21
     },
     {
       "ecc_id": "ECC-VAL-097",
@@ -4327,7 +4327,7 @@
       "citation": "RM 1.2.0 data_types §DV_DURATION; AM 1.4 C_DURATION.pattern (allowed fields); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_DURATION.validate_fields (master17.4 §DV_DURATION; open finding: temporal enforcement — SUT reject reported, never masked)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 38
+      "duration_ms": 29
     },
     {
       "ecc_id": "ECC-VAL-098",
@@ -4343,7 +4343,7 @@
       "citation": "RM 1.2.0 data_types §DV_DURATION; AM 1.4 C_DURATION.range; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_DURATION.validate_range (master17.4 §DV_DURATION; open finding: temporal enforcement)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 32
+      "duration_ms": 29
     },
     {
       "ecc_id": "ECC-VAL-099",
@@ -4391,7 +4391,7 @@
       "citation": "RM 1.2.0 data_types §DV_TIME; AM 1.4 C_TIME.pattern; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_TIME.validate_constraint (master17.4 §DV_TIME, 70-row table; open finding: temporal enforcement)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 31
+      "duration_ms": 27
     },
     {
       "ecc_id": "ECC-VAL-102",
@@ -4407,7 +4407,7 @@
       "citation": "RM 1.2.0 data_types §DV_TIME; AM 1.4 C_TIME.range; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_TIME.validate_range (master17.4 §DV_TIME, 200-row table — largest; open finding: temporal enforcement)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 28
+      "duration_ms": 26
     },
     {
       "ecc_id": "ECC-VAL-103",
@@ -4423,7 +4423,7 @@
       "citation": "RM 1.2.0 data_types §DV_DATE; AM 1.4 open; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_DATE.validate_open (master17.4 §DV_DATE; ISO8601-validity rows not driven, RM-mandatory value only)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 21
+      "duration_ms": 20
     },
     {
       "ecc_id": "ECC-VAL-104",
@@ -4439,7 +4439,7 @@
       "citation": "RM 1.2.0 data_types §DV_DATE; AM 1.4 C_DATE.pattern; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_DATE.validate_constraint (master17.4 §DV_DATE; open finding: temporal enforcement)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 30
+      "duration_ms": 27
     },
     {
       "ecc_id": "ECC-VAL-105",
@@ -4455,7 +4455,7 @@
       "citation": "RM 1.2.0 data_types §DV_DATE; AM 1.4 C_DATE.range; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_DATE.validate_range (master17.4 §DV_DATE; open finding: temporal enforcement)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 29
+      "duration_ms": 61
     },
     {
       "ecc_id": "ECC-VAL-119",
@@ -4470,7 +4470,7 @@
       "citation": "AM 1.4 C_DATE (yyyy-??-XX: month optional, day disallowed; org.openehr.am.aom14.c_date.adoc); ITS-REST 1.1.0 composition_create (422 rejected)",
       "ecc_original": "no schedule case — ECC-authored negative guard for the corrected all_types fixture (§3, testdata/fixtures/REGISTER.md); the vendored all_types.composition.json carries a day-bearing DV_DATE at a leaf whose OPT C_DATE pattern disallows the day; a spec-correct validator must 422 it (archie is lenient)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 9
+      "duration_ms": 10
     },
     {
       "ecc_id": "ECC-VAL-106",
@@ -4502,7 +4502,7 @@
       "citation": "RM 1.2.0 data_types §DV_DATE_TIME; AM 1.4 C_DATE_TIME.pattern (yyyy-mm-ddTHH:MM:SS); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_DATE_TIME.validate_constraint (master17.4 §DV_DATE_TIME, 176-row table; explicit open finding: SUT accepts the partial value the table rejects)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 23
+      "duration_ms": 19
     },
     {
       "ecc_id": "ECC-VAL-108",
@@ -4518,7 +4518,7 @@
       "citation": "RM 1.2.0 data_types §DV_DATE_TIME; AM 1.4 C_DATE_TIME.range; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_DATE_TIME.validate_range (master17.4 §DV_DATE_TIME; open finding: temporal enforcement)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 43
+      "duration_ms": 26
     },
     {
       "ecc_id": "ECC-VAL-109",
@@ -4534,7 +4534,7 @@
       "citation": "RM 1.2.0 data_types §DV_PARSABLE; AM 1.4 open; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_PARSABLE.validate_open (master17.6 §DV_PARSABLE; formalism-mandatory row not driven)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 22
+      "duration_ms": 19
     },
     {
       "ecc_id": "ECC-VAL-110",
@@ -4550,7 +4550,7 @@
       "citation": "RM 1.2.0 data_types §DV_PARSABLE; AM 1.4 C_STRING.list on formalism; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_PARSABLE.validate_value_formalism (master17.6 §DV_PARSABLE; value C_STRING rows not driven)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 30
+      "duration_ms": 27
     },
     {
       "ecc_id": "ECC-VAL-111",
@@ -4566,7 +4566,7 @@
       "citation": "RM 1.2.0 data_types §DV_MULTIMEDIA; AM 1.4 open; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_MULTIMEDIA.validate_open (master17.6 §DV_MULTIMEDIA; size-mandatory + media-type-codeset rows not driven)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 22
+      "duration_ms": 19
     },
     {
       "ecc_id": "ECC-VAL-112",
@@ -4582,7 +4582,7 @@
       "citation": "RM 1.2.0 data_types §DV_MULTIMEDIA; AM 1.4 C_CODE_PHRASE on media_type; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_MULTIMEDIA.validate_media_type (master17.6 §DV_MULTIMEDIA; size C_INTEGER half of the table not driven)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 88
+      "duration_ms": 26
     },
     {
       "ecc_id": "ECC-VAL-113",
@@ -4598,7 +4598,7 @@
       "citation": "RM 1.2.0 data_types §DV_URI (RFC3986 validity); AM 1.4 open; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_URI.validate_open (master17.7 §DV_URI; headline is RFC3986 validity, ECC drives RM-mandatory value only)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 23
+      "duration_ms": 19
     },
     {
       "ecc_id": "ECC-VAL-114",
@@ -4614,7 +4614,7 @@
       "citation": "RM 1.2.0 data_types §DV_URI; AM 1.4 C_STRING.pattern; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_URI.validate_pattern (master17.7 §DV_URI)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 32
+      "duration_ms": 28
     },
     {
       "ecc_id": "ECC-VAL-115",
@@ -4630,7 +4630,7 @@
       "citation": "RM 1.2.0 data_types §DV_URI; AM 1.4 C_STRING.list; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_URI.validate_list (master17.7 §DV_URI)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 30
+      "duration_ms": 28
     },
     {
       "ecc_id": "ECC-VAL-116",
@@ -4646,7 +4646,7 @@
       "citation": "RM 1.2.0 data_types §DV_EHR_URI (ehr: scheme); AM 1.4 open; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_EHR_URI.validate_open (master17.7 §DV_EHR_URI; headline is the ehr: scheme rule, ECC drives RM-mandatory value only)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 29
+      "duration_ms": 33
     },
     {
       "ecc_id": "ECC-VAL-117",
@@ -4662,7 +4662,7 @@
       "citation": "RM 1.2.0 data_types §DV_EHR_URI; AM 1.4 C_STRING.pattern; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_EHR_URI.validate_pattern (master17.7 §DV_EHR_URI)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 31
+      "duration_ms": 33
     },
     {
       "ecc_id": "ECC-VAL-118",
@@ -4678,7 +4678,7 @@
       "citation": "RM 1.2.0 data_types §DV_EHR_URI; AM 1.4 C_STRING.list; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_EHR_URI.validate_list (master17.7 §DV_EHR_URI)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 31
+      "duration_ms": 27
     },
     {
       "ecc_id": "ECC-DEM-001",
@@ -4723,7 +4723,7 @@
       "citation": "CNF master10 §get_party (TBD stub); ITS-REST DEVELOPMENT demographic person_get 200; SM I_DEMOGRAPHIC_SERVICE.get_party; RM 1.2.0 demographic §PERSON",
       "ecc_original": "schedule stub (master10 §get_party TBD); derived from SM I_DEMOGRAPHIC_SERVICE.get_party + RM Demographic IM",
       "binding": "GET /demographic/person/{uid_based_id}",
-      "duration_ms": 3
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-DEM-007",
@@ -4768,7 +4768,7 @@
       "citation": "CNF master10 §get_party_at_version (TBD stub); ITS-REST DEVELOPMENT demographic person_get (OVID) 200; SM I_DEMOGRAPHIC_SERVICE.get_party_at_version; RM common §OBJECT_VERSION_ID",
       "ecc_original": "schedule stub (master10 §get_party_at_version TBD); derived from SM I_DEMOGRAPHIC_SERVICE.get_party_at_version + RM common Versioning",
       "binding": "GET /demographic/person/{version_uid}",
-      "duration_ms": 1
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-DEM-025",
@@ -4798,7 +4798,7 @@
       "citation": "CNF master10 §update_party (TBD stub); ITS-REST DEVELOPMENT demographic person_update 200/204; SM I_DEMOGRAPHIC_SERVICE.update_party; RM common §Concurrency (If-Match OVID)",
       "ecc_original": "schedule stub (master10 §update_party TBD); derived from SM I_DEMOGRAPHIC_SERVICE.update_party + RM Demographic IM",
       "binding": "PUT /demographic/person/{uid_based_id}",
-      "duration_ms": 2
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-DEM-008",
@@ -4813,7 +4813,7 @@
       "citation": "CNF master10 §update_party (TBD stub); ITS-REST DEVELOPMENT demographic person_update 400/409/412; SM I_DEMOGRAPHIC_SERVICE.update_party (stale OVID); ITS-REST overview §Concurrency control",
       "ecc_original": "schedule stub (master10 §update_party TBD); derived from SM I_DEMOGRAPHIC_SERVICE.update_party + RM Demographic IM",
       "binding": "PUT /demographic/person/{uid_based_id}",
-      "duration_ms": 1
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-DEM-005",
@@ -4828,7 +4828,7 @@
       "citation": "CNF master10 §delete_party (TBD stub); ITS-REST DEVELOPMENT demographic person_delete 200/204; SM I_DEMOGRAPHIC_SERVICE.delete_party",
       "ecc_original": "schedule stub (master10 §delete_party TBD); derived from SM I_DEMOGRAPHIC_SERVICE.delete_party + RM Demographic IM",
       "binding": "DELETE /demographic/person/{uid_based_id}",
-      "duration_ms": 1
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-DEM-009",
@@ -4858,7 +4858,7 @@
       "citation": "CNF master10 §get_party (TBD stub); ITS-REST DEVELOPMENT demographic agent_get 200; SM I_DEMOGRAPHIC_SERVICE.get_party; RM 1.2.0 demographic §AGENT",
       "ecc_original": "schedule stub (master10 §get_party TBD); derived from SM I_DEMOGRAPHIC_SERVICE.get_party + RM Demographic IM",
       "binding": "GET /demographic/agent/{uid_based_id}",
-      "duration_ms": 2
+      "duration_ms": 1
     },
     {
       "ecc_id": "ECC-DEM-011",
@@ -4903,7 +4903,7 @@
       "citation": "CNF master10 §get_party (TBD stub); ITS-REST DEVELOPMENT demographic group_get 200; SM I_DEMOGRAPHIC_SERVICE.get_party; RM 1.2.0 demographic §GROUP",
       "ecc_original": "schedule stub (master10 §get_party TBD); derived from SM I_DEMOGRAPHIC_SERVICE.get_party + RM Demographic IM",
       "binding": "GET /demographic/group/{uid_based_id}",
-      "duration_ms": 1
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-DEM-014",
@@ -4948,7 +4948,7 @@
       "citation": "CNF master10 §get_party (TBD stub); ITS-REST DEVELOPMENT demographic organisation_get 200; SM I_DEMOGRAPHIC_SERVICE.get_party; RM 1.2.0 demographic §ORGANISATION",
       "ecc_original": "schedule stub (master10 §get_party TBD); derived from SM I_DEMOGRAPHIC_SERVICE.get_party + RM Demographic IM",
       "binding": "GET /demographic/organisation/{uid_based_id}",
-      "duration_ms": 2
+      "duration_ms": 1
     },
     {
       "ecc_id": "ECC-DEM-017",
@@ -4963,7 +4963,7 @@
       "citation": "CNF master10 §delete_party (TBD stub); ITS-REST DEVELOPMENT demographic organisation_delete 200/204; SM I_DEMOGRAPHIC_SERVICE.delete_party",
       "ecc_original": "schedule stub (master10 §delete_party TBD); derived from SM I_DEMOGRAPHIC_SERVICE.delete_party + RM Demographic IM",
       "binding": "DELETE /demographic/organisation/{uid_based_id}",
-      "duration_ms": 1
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-DEM-018",
@@ -5008,7 +5008,7 @@
       "citation": "CNF master10 §delete_party (TBD stub); ITS-REST DEVELOPMENT demographic role_delete 200/204; SM I_DEMOGRAPHIC_SERVICE.delete_party",
       "ecc_original": "schedule stub (master10 §delete_party TBD); derived from SM I_DEMOGRAPHIC_SERVICE.delete_party + RM Demographic IM",
       "binding": "DELETE /demographic/role/{uid_based_id}",
-      "duration_ms": 1
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-DEM-022",
@@ -5068,7 +5068,7 @@
       "citation": "CNF master10 §create_party_relationship (TBD stub); SM I_PARTY_RELATIONSHIP.create_party_relationship; RM 1.2.0 demographic §PARTY_RELATIONSHIP — ehrbase-rs extension wire (no ITS-REST party_relationship path)",
       "ecc_original": "schedule stub (master10 §create_party_relationship TBD); derived from SM I_PARTY_RELATIONSHIP + RM PARTY_RELATIONSHIP — ehrbase-rs extension wire",
       "binding": "POST /demographic/party_relationship (ehrbase-rs extension)",
-      "duration_ms": 2
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-DEM-027",
@@ -5113,7 +5113,7 @@
       "citation": "CNF master10 §update_party_relationship (TBD stub); SM I_PARTY_RELATIONSHIP.update_party_relationship; ITS-REST overview §Concurrency (If-Match OVID) — ehrbase-rs extension wire",
       "ecc_original": "schedule stub (master10 §update_party_relationship TBD); derived from SM I_PARTY_RELATIONSHIP — ehrbase-rs extension wire",
       "binding": "PUT /demographic/party_relationship/{uid_based_id} (ehrbase-rs extension)",
-      "duration_ms": 4
+      "duration_ms": 5
     },
     {
       "ecc_id": "ECC-DEM-030",
@@ -5128,7 +5128,7 @@
       "citation": "CNF master10 §delete_party_relationship (TBD stub); SM I_PARTY_RELATIONSHIP.delete_party_relationship — ehrbase-rs extension wire",
       "ecc_original": "schedule stub (master10 §delete_party_relationship TBD); derived from SM I_PARTY_RELATIONSHIP — ehrbase-rs extension wire",
       "binding": "DELETE /demographic/party_relationship/{uid_based_id} (ehrbase-rs extension)",
-      "duration_ms": 3
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-DEM-031",
@@ -5143,7 +5143,7 @@
       "citation": "CNF master10 §get_party_relationship_at_version (TBD stub); SM I_PARTY_RELATIONSHIP.get_party_relationship_at_version; RM common §OBJECT_VERSION_ID — ehrbase-rs extension wire",
       "ecc_original": "schedule stub (master10 §get_party_relationship_at_version TBD); derived from SM I_PARTY_RELATIONSHIP + RM common OBJECT_VERSION_ID — ehrbase-rs extension wire",
       "binding": "GET /demographic/versioned_party_relationship/{versioned_object_uid}/version/{version_uid} (ehrbase-rs extension)",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-ADM-001",
@@ -5158,7 +5158,7 @@
       "citation": "CNF master12 §physical_ehr_delete (TBD stub); ITS-REST DEVELOPMENT admin admin_ehr_delete.yaml 204; SM I_ADMIN_SERVICE.physical_ehr_delete",
       "ecc_original": "schedule stub (master12 §physical_ehr_delete TBD); derived from SM I_ADMIN_SERVICE.physical_ehr_delete + ADMIN OAS admin_ehr_delete[_all].yaml",
       "binding": "DELETE /admin/ehr/{ehr_id}",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-ADM-002",
@@ -5173,7 +5173,7 @@
       "citation": "CNF master12 §physical_ehr_delete (TBD stub); ITS-REST DEVELOPMENT admin admin_ehr_delete.yaml 404; SM I_ADMIN_SERVICE.physical_ehr_delete",
       "ecc_original": "schedule stub (master12 §physical_ehr_delete TBD); derived from SM I_ADMIN_SERVICE.physical_ehr_delete + ADMIN OAS admin_ehr_delete[_all].yaml",
       "binding": "DELETE /admin/ehr/{ehr_id}",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "ecc_id": "ECC-ADM-003",
@@ -5203,7 +5203,7 @@
       "citation": "CNF master12 §physical_ehr_delete (TBD stub); ITS-REST DEVELOPMENT admin admin_ehr_delete_all.yaml 204 (204_deleted_hard, bodyless); SM I_ADMIN_SERVICE.physical_ehr_delete",
       "ecc_original": "schedule stub (master12 §physical_ehr_delete TBD); derived from SM I_ADMIN_SERVICE.physical_ehr_delete + ADMIN OAS admin_ehr_delete[_all].yaml",
       "binding": "DELETE /admin/ehr/all?ehr_id*",
-      "duration_ms": 3
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-ADM-005",
@@ -5218,7 +5218,7 @@
       "citation": "CNF master12 §physical_ehr_delete (TBD stub); ITS-REST DEVELOPMENT admin admin_ehr_delete_all.yaml — instrument-encodes-server-behaviour: a bulk set including a missing id still 204s (OAS declares no per-id failure)",
       "ecc_original": "schedule stub (master12 §physical_ehr_delete TBD); derived from SM I_ADMIN_SERVICE.physical_ehr_delete + ADMIN OAS admin_ehr_delete[_all].yaml",
       "binding": "DELETE /admin/ehr/all?ehr_id*",
-      "duration_ms": 2
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-ADM-006",
@@ -5233,7 +5233,7 @@
       "citation": "CNF master12 §physical_ehr_delete (TBD stub); ITS-REST DEVELOPMENT admin admin_ehr_delete_all.yaml + ehr_id_Admin.yaml optional selector — instrument-encodes-server-behaviour: an absent ehr_id deletes ALL EHRs (a globally destructive design reading, gated to disposable SUTs)",
       "ecc_original": "schedule stub (master12 §physical_ehr_delete TBD); derived from SM I_ADMIN_SERVICE.physical_ehr_delete + ADMIN OAS admin_ehr_delete[_all].yaml",
       "binding": "DELETE /admin/ehr/all",
-      "duration_ms": 56
+      "duration_ms": 61
     },
     {
       "ecc_id": "ECC-ADM-007",
@@ -5563,7 +5563,7 @@
       "citation": "profiles master03 §Non-Functional Signing (STANDARD); RM common master06 §Version (signature slot); no openEHR spec governs the sha256: digest — ehrbase-rs extension",
       "ecc_original": "extension: VERSION.signature is an ehrbase-rs feature (no openEHR spec governs the digest algorithm); profiles master03 §Non-Functional Signing STANDARD; RM common master06 §Version signature slot",
       "binding": "GET /ehr/{ehr_id}/versioned_composition/{versioned_object_uid}/version/{version_uid}",
-      "duration_ms": 10
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-SIG-002",
@@ -5578,7 +5578,7 @@
       "citation": "profiles master03 §Non-Functional Signing (STANDARD); RM common master06 §Version (signature slot) + RFC 8785 canonical form; no openEHR spec governs the digest — ehrbase-rs extension",
       "ecc_original": "extension: sha256: digest recompute is an ehrbase-rs feature (RFC 8785 canonical form); profiles master03 §Non-Functional Signing STANDARD; RM common master06 §Version signature slot",
       "binding": "GET /ehr/{ehr_id}/versioned_composition/{versioned_object_uid}/version/{version_uid}",
-      "duration_ms": 12
+      "duration_ms": 11
     },
     {
       "ecc_id": "ECC-SIG-003",
@@ -5593,7 +5593,7 @@
       "citation": "profiles master03 §Non-Functional Signing (STANDARD); RM common master06 §Version (signature slot on every versioned object); ehrbase-rs extension",
       "ecc_original": "extension: version signing rides every versioned-object write (ehrbase-rs); profiles master03 §Non-Functional Signing STANDARD; RM common master06 §Version signature slot",
       "binding": "PUT /ehr/{ehr_id}/ehr_status; POST /ehr/{ehr_id}/contribution; POST /ehr/{ehr_id}/directory",
-      "duration_ms": 41
+      "duration_ms": 25
     },
     {
       "ecc_id": "ECC-SIG-004",
@@ -5623,7 +5623,7 @@
       "citation": "profiles master03 §Non-Functional Signing (STANDARD); RM common master06 §Version (signature slot); ehrbase-rs extension — pgp mode, RFC 4880 detached signature",
       "ecc_original": "extension: pgp signing mode is an ehrbase-rs feature (RFC 4880); profiles master03 §Non-Functional Signing STANDARD; RM common master06 §Version signature slot",
       "binding": "GET /ehr/{ehr_id}/versioned_composition/{versioned_object_uid}/version/{version_uid}",
-      "duration_ms": 39
+      "duration_ms": 40
     },
     {
       "ecc_id": "ECC-TS-001",
@@ -5638,7 +5638,7 @@
       "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.1.0 QUERY API execute_ad_hoc_query; profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS)",
       "ecc_original": "no CNF schedule chapter for terminology integration; profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS) + QUERY master03 §TERMINOLOGY 748-767; the 'openehr' bundle flavour is an ehrbase-rs AQL engine extension",
       "binding": "POST /query/aql",
-      "duration_ms": 2
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-TS-002",
@@ -5653,7 +5653,7 @@
       "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.1.0 QUERY API execute_ad_hoc_query; profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS)",
       "ecc_original": "no CNF schedule chapter for terminology integration; profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS) + QUERY master03 §TERMINOLOGY 748-767; the 'openehr' bundle flavour is an ehrbase-rs AQL engine extension",
       "binding": "POST /query/aql",
-      "duration_ms": 13
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-TS-003",
@@ -5668,7 +5668,7 @@
       "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.1.0 QUERY API execute_ad_hoc_query; profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS)",
       "ecc_original": "no CNF schedule chapter for terminology integration; profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS) + QUERY master03 §TERMINOLOGY 748-767; the 'openehr' bundle flavour is an ehrbase-rs AQL engine extension",
       "binding": "POST /query/aql",
-      "duration_ms": 10
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-TS-004",
@@ -5713,7 +5713,7 @@
       "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.1.0 QUERY API execute_ad_hoc_query; profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS)",
       "ecc_original": "no CNF schedule chapter for terminology integration; profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS) + QUERY master03 §TERMINOLOGY 748-767; the FHIR service_api path realizes the spec mechanism (generic, not an extension)",
       "binding": "POST /query/aql",
-      "duration_ms": 4
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-TS-007",
@@ -5728,7 +5728,7 @@
       "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.1.0 QUERY API execute_ad_hoc_query; profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS)",
       "ecc_original": "no CNF schedule chapter for terminology integration; profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS); a fault-injecting tx cannot be wired into an external SUT over the HTTP-only ECC — fault→500 proven off-wire (MSG precedent)",
       "binding": "POST /query/aql",
-      "duration_ms": 2009
+      "duration_ms": 2007
     },
     {
       "ecc_id": "ECC-TS-008",
@@ -5743,7 +5743,7 @@
       "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.1.0 QUERY API execute_ad_hoc_query; profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS)",
       "ecc_original": "no CNF schedule chapter for terminology integration; profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS); a fault-injecting tx cannot be wired into an external SUT over the HTTP-only ECC — fault→500 proven off-wire (MSG precedent)",
       "binding": "POST /query/aql",
-      "duration_ms": 9
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-TS-009",
@@ -5773,7 +5773,7 @@
       "citation": "ITS-REST simplified_formats master04 §Flat format + master05 §RM Mapping; Resources.md §Simplified Formats (application/openehr.wt.flat+json); Requests_and_responses.md §openehr-template-id",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no simplified-formats chapter; ECC-derived from the STABLE ITS-REST Simplified Formats specification (docs/specs/openehr/ITS-REST/docs/simplified_formats/ + specifications/docs/overview/Resources.md §Simplified Formats)",
       "binding": "POST /ehr/{ehr_id}/composition (Content-Type application/openehr.wt.flat+json) → GET /ehr/{ehr_id}/composition/{uid_based_id} (Accept flat/json/structured)",
-      "duration_ms": 26
+      "duration_ms": 22
     },
     {
       "ecc_id": "ECC-SF-002",
@@ -5788,7 +5788,7 @@
       "citation": "ITS-REST simplified_formats master04 §Structured format + master05 §RM Mapping; Resources.md §Simplified Formats (application/openehr.wt.structured+json); Requests_and_responses.md §openehr-template-id",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no simplified-formats chapter; ECC-derived from the STABLE ITS-REST Simplified Formats specification (docs/specs/openehr/ITS-REST/docs/simplified_formats/ + specifications/docs/overview/Resources.md §Simplified Formats)",
       "binding": "POST /ehr/{ehr_id}/composition (Content-Type application/openehr.wt.structured+json) → GET /ehr/{ehr_id}/composition/{uid_based_id} (Accept structured/json/flat)",
-      "duration_ms": 31
+      "duration_ms": 19
     },
     {
       "ecc_id": "ECC-SF-003",
@@ -5803,7 +5803,7 @@
       "citation": "Resources.md §Data representation (RFC 9110 §12.5.1 quality-value negotiation) + §Simplified Formats (Content-Type MUST be present unless 204)",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no simplified-formats chapter; ECC-derived from the STABLE ITS-REST Simplified Formats specification (docs/specs/openehr/ITS-REST/docs/simplified_formats/ + specifications/docs/overview/Resources.md §Simplified Formats)",
       "binding": "GET /ehr/{ehr_id}/composition/{uid_based_id} (Accept with q-values)",
-      "duration_ms": 13
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-SF-004",
@@ -5818,7 +5818,7 @@
       "citation": "Resources.md §Simplified Formats NOTE (deprecated .schema+json) + §Alternative data formats (legacy nc.flat/tds2) + the 406 MUST rule (\"If the service cannot fulfill this aspect of the request, it MUST respond with 406 Not Acceptable\")",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no simplified-formats chapter; ECC-derived from the STABLE ITS-REST Simplified Formats specification (docs/specs/openehr/ITS-REST/docs/simplified_formats/ + specifications/docs/overview/Resources.md §Simplified Formats)",
       "binding": "GET /ehr/{ehr_id}/composition/{uid_based_id} + GET /definition/template/adl1.4/{template_id}/example (Accept a retired type)",
-      "duration_ms": 23
+      "duration_ms": 15
     },
     {
       "ecc_id": "ECC-SF-005",
@@ -5833,7 +5833,7 @@
       "citation": "Resources.md §Simplified Formats NOTE (deprecated .schema+json) + §Alternative data formats (legacy nc.flat/tds2) + the 415 MUST rule (\"If the service cannot process the request payload as the simplified format is not supported, it MUST respond with 415 Unsupported Media Type\")",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no simplified-formats chapter; ECC-derived from the STABLE ITS-REST Simplified Formats specification (docs/specs/openehr/ITS-REST/docs/simplified_formats/ + specifications/docs/overview/Resources.md §Simplified Formats)",
       "binding": "POST /ehr/{ehr_id}/composition + POST /ehr/{ehr_id}/contribution (Content-Type a retired type)",
-      "duration_ms": 10
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-SF-006",
@@ -5848,7 +5848,7 @@
       "citation": "Requests_and_responses.md §openehr-template-id (\"MUST be used whenever committing COMPOSITION using a Simplified Format which does not support TEMPLATE_ID under archetype_details.template_id\") + §HTTP status codes row 422 (well-formed but unprocessable)",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no simplified-formats chapter; ECC-derived from the STABLE ITS-REST Simplified Formats specification (docs/specs/openehr/ITS-REST/docs/simplified_formats/ + specifications/docs/overview/Resources.md §Simplified Formats)",
       "binding": "POST /ehr/{ehr_id}/composition (Content-Type flat, no openehr-template-id header)",
-      "duration_ms": 8
+      "duration_ms": 5
     },
     {
       "ecc_id": "ECC-SF-007",
@@ -5863,7 +5863,7 @@
       "citation": "ITS-REST simplified_formats master04 §Validation (\"Field identifiers match WT metadata structure\"); Requests_and_responses.md §HTTP status codes row 422",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no simplified-formats chapter; ECC-derived from the STABLE ITS-REST Simplified Formats specification (docs/specs/openehr/ITS-REST/docs/simplified_formats/ + specifications/docs/overview/Resources.md §Simplified Formats)",
       "binding": "POST /ehr/{ehr_id}/composition (Content-Type flat, unknown field id)",
-      "duration_ms": 8
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-SF-008",
@@ -5878,7 +5878,7 @@
       "citation": "ITS-REST simplified_formats master04 §Open Value-Sets and the |other Suffix (\"|other is mutually exclusive with |code, |value and |terminology on the same leaf path; servers MUST reject combinations\"); Requests_and_responses.md §HTTP status codes row 422",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no simplified-formats chapter; ECC-derived from the STABLE ITS-REST Simplified Formats specification (docs/specs/openehr/ITS-REST/docs/simplified_formats/ + specifications/docs/overview/Resources.md §Simplified Formats)",
       "binding": "POST /ehr/{ehr_id}/composition (Content-Type flat, |other + |code on one leaf)",
-      "duration_ms": 6
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-SF-009",
@@ -5893,7 +5893,7 @@
       "citation": "Resources.md §Simplified Formats (application/openehr.wt+json = the OPT as a Web Template JSON document); ITS-REST simplified_formats master04 §Node ID Generation Rules (WT tree shape)",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no simplified-formats chapter; ECC-derived from the STABLE ITS-REST Simplified Formats specification (docs/specs/openehr/ITS-REST/docs/simplified_formats/ + specifications/docs/overview/Resources.md §Simplified Formats)",
       "binding": "GET /definition/template/adl1.4/{template_id} (Accept application/openehr.wt+json)",
-      "duration_ms": 3
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-SF-010",
@@ -5908,7 +5908,7 @@
       "citation": "Resources.md §Data representation + §Simplified Formats (the LOCATABLE example is negotiable across canonical JSON/XML and the FLAT/STRUCTURED simplified forms); the Content-Type MUST match the negotiated format",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no simplified-formats chapter; ECC-derived from the STABLE ITS-REST Simplified Formats specification (docs/specs/openehr/ITS-REST/docs/simplified_formats/ + specifications/docs/overview/Resources.md §Simplified Formats)",
       "binding": "GET /definition/template/adl1.4/{template_id}/example (Accept json/xml/flat/structured)",
-      "duration_ms": 5
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-SF-011",
@@ -5923,7 +5923,7 @@
       "citation": "Resources.md §Simplified Formats 406 MUST rule (the example endpoint offers canonical JSON/XML + FLAT/STRUCTURED only; the Web Template media type is not a LOCATABLE representation)",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no simplified-formats chapter; ECC-derived from the STABLE ITS-REST Simplified Formats specification (docs/specs/openehr/ITS-REST/docs/simplified_formats/ + specifications/docs/overview/Resources.md §Simplified Formats)",
       "binding": "GET /definition/template/adl1.4/{template_id}/example (Accept application/openehr.wt+json)",
-      "duration_ms": 3
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-SF-012",
@@ -5938,7 +5938,7 @@
       "citation": "ITS-REST contribution_create.yaml + contribution_get.yaml §Simplified Formats (the CONTRIBUTION envelope stays canonical JSON; each versions[i].data COMPOSITION is simplified); simplified_formats master05 §scope (COMPOSITION + contained classes only)",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no simplified-formats chapter; ECC-derived from the STABLE ITS-REST Simplified Formats specification (docs/specs/openehr/ITS-REST/docs/simplified_formats/ + specifications/docs/overview/Resources.md §Simplified Formats)",
       "binding": "POST /ehr/{ehr_id}/contribution (Content-Type flat) → GET /ehr/{ehr_id}/contribution/{contribution_uid} (Accept flat)",
-      "duration_ms": 9
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-SF-013",
@@ -5998,7 +5998,7 @@
       "citation": "ITS-REST simplified_formats master06 §time (ctx/time sets COMPOSITION.context.start_time) + §setting (ctx/setting defaults to openehr::238|other care| when not set)",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no simplified-formats chapter; ECC-derived from the STABLE ITS-REST Simplified Formats specification (docs/specs/openehr/ITS-REST/docs/simplified_formats/ + specifications/docs/overview/Resources.md §Simplified Formats)",
       "binding": "POST /ehr/{ehr_id}/composition (Content-Type flat, ctx/time set) → GET /ehr/{ehr_id}/composition/{uid_based_id} (Accept application/json)",
-      "duration_ms": 7
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-ADL2-001",
@@ -6013,7 +6013,7 @@
       "citation": "ITS-REST definition_template_adl2_upload.yaml (text/plain source) + 201_Template_adl2_upload.yaml (Location + Prefer: minimal empty / representation source / identifier TemplateIdentifier JSON)",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no ADL 2 test case (master04 I_DEFINITION_ADL2 has no upstream cases); ECC-derived from the DEVELOPMENT-status ITS-REST DEFINITION ADL2 operation YAMLs (docs/specs/openehr/ITS-REST/specifications/operations/definition_template_adl2_*.yaml). ADL 2 is OPTIONAL for openEHR conformance (docs/VERSIONS.md ITS-REST DEVELOPMENT row) — OPTIONS-tier, never CORE/STANDARD-gating.",
       "binding": "POST /definition/template/adl2 (Prefer return=minimal|representation|identifier)",
-      "duration_ms": 6
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-ADL2-002",
@@ -6088,7 +6088,7 @@
       "citation": "ITS-REST definition_template_adl2_get.yaml + 200_Template_adl2_retrieved.yaml (text/plain source | application/json OperationalTemplateV2) + Accept_Template_adl2.yaml (application/xml has no declared response body → 406)",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no ADL 2 test case (master04 I_DEFINITION_ADL2 has no upstream cases); ECC-derived from the DEVELOPMENT-status ITS-REST DEFINITION ADL2 operation YAMLs (docs/specs/openehr/ITS-REST/specifications/operations/definition_template_adl2_*.yaml). ADL 2 is OPTIONAL for openEHR conformance (docs/VERSIONS.md ITS-REST DEVELOPMENT row) — OPTIONS-tier, never CORE/STANDARD-gating.",
       "binding": "GET /definition/template/adl2/{template_id} (Accept text/plain | application/json | application/xml)",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-ADL2-007",
@@ -6103,7 +6103,7 @@
       "citation": "ITS-REST definition_template_adl2_get.yaml §404 (404_unknown_template_id.yaml)",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no ADL 2 test case (master04 I_DEFINITION_ADL2 has no upstream cases); ECC-derived from the DEVELOPMENT-status ITS-REST DEFINITION ADL2 operation YAMLs (docs/specs/openehr/ITS-REST/specifications/operations/definition_template_adl2_*.yaml). ADL 2 is OPTIONAL for openEHR conformance (docs/VERSIONS.md ITS-REST DEVELOPMENT row) — OPTIONS-tier, never CORE/STANDARD-gating.",
       "binding": "GET /definition/template/adl2/{template_id}",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "ecc_id": "ECC-ADL2-008",
@@ -6118,7 +6118,7 @@
       "citation": "ITS-REST definition_template_adl2_version_get.yaml (deprecated but served) + 200_Template_adl2_retrieved.yaml + template_id_adl2.yaml (a partial template_id resolves to the latest matching major version)",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no ADL 2 test case (master04 I_DEFINITION_ADL2 has no upstream cases); ECC-derived from the DEVELOPMENT-status ITS-REST DEFINITION ADL2 operation YAMLs (docs/specs/openehr/ITS-REST/specifications/operations/definition_template_adl2_*.yaml). ADL 2 is OPTIONAL for openEHR conformance (docs/VERSIONS.md ITS-REST DEVELOPMENT row) — OPTIONS-tier, never CORE/STANDARD-gating.",
       "binding": "GET /definition/template/adl2/{template_id}/{version}",
-      "duration_ms": 3
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-ADL2-009",
@@ -6133,7 +6133,7 @@
       "citation": "ITS-REST definition_template_adl2_example_get.yaml + 200_Template_example_retrieved.yaml (LOCATABLE oneOf) + Accept_LOCATABLE.yaml (json / xml / wt.flat+json / wt.structured+json)",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no ADL 2 test case (master04 I_DEFINITION_ADL2 has no upstream cases); ECC-derived from the DEVELOPMENT-status ITS-REST DEFINITION ADL2 operation YAMLs (docs/specs/openehr/ITS-REST/specifications/operations/definition_template_adl2_*.yaml). ADL 2 is OPTIONAL for openEHR conformance (docs/VERSIONS.md ITS-REST DEVELOPMENT row) — OPTIONS-tier, never CORE/STANDARD-gating.",
       "binding": "GET /definition/template/adl2/{template_id}/example (Accept json/xml/flat/structured)",
-      "duration_ms": 7
+      "duration_ms": 5
     },
     {
       "ecc_id": "ECC-ADL2-010",
@@ -6148,7 +6148,7 @@
       "citation": "ITS-REST definition_template_adl2_example_get.yaml + example_type.yaml (input|output) + example_detail_level.yaml (required|medium|complete) + 400.yaml (out-of-enum → 400)",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no ADL 2 test case (master04 I_DEFINITION_ADL2 has no upstream cases); ECC-derived from the DEVELOPMENT-status ITS-REST DEFINITION ADL2 operation YAMLs (docs/specs/openehr/ITS-REST/specifications/operations/definition_template_adl2_*.yaml). ADL 2 is OPTIONAL for openEHR conformance (docs/VERSIONS.md ITS-REST DEVELOPMENT row) — OPTIONS-tier, never CORE/STANDARD-gating.",
       "binding": "GET /definition/template/adl2/{template_id}/example?type=&detail_level=",
-      "duration_ms": 6
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-ADL2-011",
@@ -6163,7 +6163,7 @@
       "citation": "ITS-REST definition_template_adl2_example_get.yaml §404 (404_unknown_template_id.yaml) + §406 (406.yaml) + Accept_LOCATABLE.yaml",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no ADL 2 test case (master04 I_DEFINITION_ADL2 has no upstream cases); ECC-derived from the DEVELOPMENT-status ITS-REST DEFINITION ADL2 operation YAMLs (docs/specs/openehr/ITS-REST/specifications/operations/definition_template_adl2_*.yaml). ADL 2 is OPTIONAL for openEHR conformance (docs/VERSIONS.md ITS-REST DEVELOPMENT row) — OPTIONS-tier, never CORE/STANDARD-gating.",
       "binding": "GET /definition/template/adl2/{template_id}/example",
-      "duration_ms": 3
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-ADL2-012",
@@ -6193,7 +6193,7 @@
       "citation": "QUERY master03-syntax §Functions/Other functions/TERMINOLOGY (lines 699–767); AQL 1.1; ITS-REST 1.1.0 QUERY API execute_ad_hoc_query (200_QUERY / 400_QUERY); profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS)",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no terminology-function test case (master05/master11 name none); ECC-derived from QUERY master03-syntax §TERMINOLOGY + profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS).",
       "binding": "POST /ehr/{ehr_id}/composition; POST /query/aql (matches TERMINOLOGY('expand', …))",
-      "duration_ms": 11
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-AQT-002",
@@ -6208,7 +6208,7 @@
       "citation": "QUERY master03-syntax §Functions/Other functions/TERMINOLOGY (lines 699–767); AQL 1.1; ITS-REST 1.1.0 QUERY API execute_ad_hoc_query (200_QUERY / 400_QUERY); profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS)",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no terminology-function test case (master05/master11 name none); ECC-derived from QUERY master03-syntax §TERMINOLOGY + profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS).",
       "binding": "POST /query/aql (matches TERMINOLOGY('lookup'|'map', …))",
-      "duration_ms": 2
+      "duration_ms": 1
     },
     {
       "ecc_id": "ECC-AQT-003",
@@ -6223,7 +6223,7 @@
       "citation": "QUERY master03-syntax §Functions/Other functions/TERMINOLOGY (lines 699–767); AQL 1.1; ITS-REST 1.1.0 QUERY API execute_ad_hoc_query (200_QUERY / 400_QUERY); profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS)",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no terminology-function test case (master05/master11 name none); ECC-derived from QUERY master03-syntax §TERMINOLOGY + profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS).",
       "binding": "POST /query/aql (SELECT TERMINOLOGY('expand', …))",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "ecc_id": "ECC-AQT-004",


### PR DESCRIPTION
## What this changes

Closes #140

**The VETDF external terminology-binding validation seam** (AM ADL2 master03 §Validity Rules): `openehr-adl` gains a network-free `TerminologyResolver` trait (`code_exists → Option<bool>`) threaded through full validation exactly like the existing `RmModel` seam — `Some(false)` raises `VETDF`, `Some(true)`/`None` never raise (a validator must not fail archetypes on infrastructure gaps), and openEHR-internal bindings never consult the resolver (VTTBK/VTCBK already cover them). The default `NoTerminologyResolver` keeps every existing caller's behaviour identical.

The app wires it at ADL2 upload validation: a memoised resolver over `EhrbaseService::has_term` (bundled terminology for its own ids; the configured external FHIR TS via `CodeSystem/$lookup` for SNOMED/LOINC-class ids; unconfigured/unreachable → unresolved → no raise). A bad external code now rejects the upload with the typed `VETDF` 422.

Proven: seam unit tests with a recording stub (raise/no-raise/never-consulted matrix) + hermetic wiremock round-trips (mock `$lookup` 404 ⇒ 422 VETDF and not stored; 200 ⇒ accepted) on a real PG via testkit.

## Gates

- [x] clippy zero (exact CI flags) · **nextest 2293/2293** (8 new tests) · fmt clean
- [x] **ECC zero-drift: 402 · 384 · 0 failed · 18 N/A · 0 skipped** — corpus outcomes unchanged (conservative-by-design)
- [x] Validation behaviour is user-visible → changelog entry included
