### PR TITLE
docs: repo-wide accuracy sweep against the shipped v3.5.0 state

### DIFF
--- a/.claude/rules/aql-engine.md
+++ b/.claude/rules/aql-engine.md
@@ -34,7 +34,7 @@ needed) → **AST → typed query IR** (our own Rust enums) → **IR → SQL** (
 `jsonb_path_query_first` + jsonpath item methods + `openehr_magnitude` for
 typed leaf comparison/ordering, `JSON_TABLE` for array unnesting, GIN
 `jsonb_ops` `$.**` equality anchors as pre-filters) → execute (`sqlx`) →
-assemble `RESULT_SET` (schema 1.0.3). Keep the IR a distinct pass — that is
+assemble `RESULT_SET` (schema 1.1.0). Keep the IR a distinct pass — that is
 what keeps the hard cases tractable — and do **not** collapse it away.
 
 Versioning semantics: `LATEST_VERSION` = the current partial index;

--- a/.claude/rules/changelog.md
+++ b/.claude/rules/changelog.md
@@ -34,6 +34,6 @@ optional:
 - **Versioning split:** the product (workspace, `ehrbase-*`, tools,
   `openehr-flat`, codegen tooling) follows the product SemVer (3.x line).
   The `openehr-*` **spec crates** carry the version of the openEHR
-  specification they implement (BASE 1.3.0, RM 1.2.0, AM 2.4.0, TERM 3.1.0,
-  LANG 1.0.0, QUERY 1.1.0, ITS 1.0.3 — see `docs/VERSIONS.md`); bump them
+  specification they implement (BASE 1.3.0, RM 1.2.0, AM 2.4.0, ADL 2.4.0, TERM 3.1.0,
+  LANG 1.0.0, QUERY 1.1.0, ITS 1.1.0 — see `docs/VERSIONS.md`); bump them
   only on a spec-pin bump, never with the product version.

--- a/.claude/rules/codegen.md
+++ b/.claude/rules/codegen.md
@@ -44,8 +44,8 @@ generated crates exist to guarantee. Cross-component subtype extension
 emitter at the DOWNSTREAM crate boundary (an extender-level enum composing
 the upstream variants + the downstream leaves) — upstream crates never
 gain downstream variants (dependency arrows point one way). If the emitter
-fix is large, register a worklist row; the workaround is still forbidden.
-Existing workarounds get removal rows on discovery.
+fix is large, register a tracker issue; the workaround is still forbidden.
+Existing workarounds get a removal issue on discovery.
 
 **Never hand-edit a `// @generated` file.** To change generated output, edit the
 emitter (`tools/openehr-codegen/src/`, the `load/`→`analyze/`→`plan/`→`render/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ A pure-Rust, **openEHR-spec-conformant** CDR (ITS-REST 1.1.0 + AQL 1.1) in a sin
 
 Single workspace. **Crate naming:** `openehr-*` = the openEHR **specification** (generated from the vendored BMM/XSD/OAS — treat as `// @generated`); `ehrbase-*` = the **application** (idiomatic Rust of our own design consuming the `openehr-*` crates). The formerly in-tree EHRbase Java reference was removed with the greenfield pivot (git history / upstream repos are the prior-art record).
 
-- `crates/openehr-base`, `openehr-rm`, `openehr-am`, `openehr-term`, `openehr-lang` — **generated** spec crates (`openehr-codegen -- emit`). `openehr-its` — canonical JSON + **generated** XML (`emit-xml`) + **generated** ITS-REST contract (`emit-rest`) + hand-written runtimes. `openehr-query` — hand-written AQL lexer/parser/AST. `openehr-flat` — FLAT/STRUCTURED (hand-written). `openehr-codegen` (BMM/XSD/OAS→Rust generator) is the hand-written tooling.
+- `crates/openehr-base`, `openehr-rm`, `openehr-am`, `openehr-term`, `openehr-lang` — **generated** spec crates (`openehr-codegen -- emit`). `openehr-its` — canonical JSON + **generated** XML (`emit-xml`) + **generated** ITS-REST contract (`emit-rest`) + hand-written runtimes. `openehr-query` — hand-written AQL lexer/parser/AST. `openehr-adl` — hand-written ADL 2.4 engine (ADL2/cADL/ODIN parser, AOM2 validation, flattener, OPT2, ADL 1.4→2 conversion) over `openehr-am::am24`. `openehr-flat` — FLAT/STRUCTURED (hand-written). `openehr-codegen` (BMM/XSD/OAS→Rust generator) is the hand-written tooling.
 - `app/*` — the application, **four crates**: `ehrbase` (the platform **library**: storage, service layer [one module per SM chapter, concrete `EhrbaseService` methods — no traits], AQL engine, versioning, config tree, telemetry, `signing` + `system_log`), `ehrbase-rest` (ITS-REST protocol adapter + auth + the `access` authz module, calling the concrete service directly — depends on `ehrbase`), `ehrbase-server` (the wiring-only binary; bin name stays `ehrbase`), and `ehrbase-admin-ui` (the Leptos SSR admin console — a standalone binary/OCI image that consumes the CDR STRICTLY over ITS-REST; may depend on `crates/openehr-*`, NEVER on `app/ehrbase`/`app/ehrbase-rest`; gates via `/ui-gates`, rules in `.claude/rules/leptos-ui.md`). **Zero re-exports (owner hard rule 2026-07-16): import every name from its defining module.** `tools/*` — dev/verification tooling, **not part of the app**: `conformance` (the ECC runner), `benchmark`, and `testkit` (the shared test-database harness — one PG18 server + template-database cloning; every DB-backed test uses `testkit::db()`, never a per-test container). Workspace `members = ["crates/*", "app/*", "tools/*"]`. The service layer follows the openEHR **SM Platform Service Model** (SM component map in `docs/architecture.md`, vendored SM spec at `docs/specs/openehr/SM/`).
 - `docs/` — plans (`docs/plans/`: deep working plans, linked from their tracker issues), VERSIONS, architecture, postgres-features, `endpoint-map.md` (every endpoint traced to its SQL), conformance (generated reports), benchmarks; the forward product roadmap is the root `ROADMAP.md`. **`docs/specs/openehr/` — the vendored openEHR spec text + CNF test schedule (the conformance oracle; see its README + `/spec-lookup`).**
 - `.claude/` — rules, skills, hooks, agents, **`memory/`** (the persistent agent memory, moved in-repo 2026-07-12 so it is visible and versioned; the harness memory dir under `~/.claude/projects/` is a symlink to it — never break that link). Agent defs (`spec-researcher`, `spec-conformance-reviewer`, `implementer`, `ui-implementer`, `leptos-reviewer`) are the delegation targets for the Model-orchestration section below; the orchestrator keeps the critical path in-session.
@@ -35,7 +35,7 @@ change.
 - **Hand-written spec behaviour** (invariants, spec functions) lives in sibling `*_impl.rs` files the generator never rewrites.
 - **Hand-written tooling** (edit freely, normal Rust): `openehr-lang` (ODIN + BMM reader), `openehr-codegen` (emitter).
 - **Partly generated:** `openehr-its` — the XML `ToXml`/`FromXml` impls (`emit-xml`) and the ITS-REST contract (`emit-rest`) are generated into `src/xml/generated/` + `src/rest/generated/`; the hand-written parts are the runtimes (`xml/runtime.rs`, `rest/runtime.rs`), the canonical-JSON entry points + validation, and the fidelity gates.
-- **NOT generated** (hand-written): `openehr-term` (terminology bundle + XML assets + access logic — BMM only has ~6 interface classes), `openehr-query` (AQL lexer/parser/AST), `openehr-flat` (Simplified Formats), and the `ehrbase-*` application crates (idiomatic Rust of our own design on the generated crates).
+- **NOT generated** (hand-written): `openehr-term` (terminology bundle + XML assets + access logic — BMM only has ~6 interface classes), `openehr-query` (AQL lexer/parser/AST), `openehr-adl` (the ADL 2.4 engine), `openehr-flat` (Simplified Formats), and the `ehrbase-*` application crates (idiomatic Rust of our own design on the generated crates).
 - **Pinned spec versions:** RM 1.2.0, BASE 1.3.0, TERM 3.1.0, AM 1.4.0 + 2.4.0 (see `docs/VERSIONS.md` — incl. the release ladder and pin-honesty column). **Version policy (owner 2026-07-20):** single pin per component (openEHR minors are compatible supersets within a major); dual generations only across major boundaries — AM's `am14`/`am24` is the one live, spec-mandated case; ITS-REST is single-version, always the latest RELEASED API. Full policy: `docs/VERSIONS.md` §Spec version policy.
 
 ## Issue workflow (the loop)
@@ -125,7 +125,7 @@ cargo clippy --workspace --all-targets --all-features   # the EXACT CI flags —
 cargo fmt --all
 cargo audit && cargo deny check
 # conformance runner (the acceptance instrument) — present and green:
-bash scripts/conformance.sh   # compose up --build → full ECC → docs/conformance/ (341 executed · 315 passed · 0 failed at B6 close)
+bash scripts/conformance.sh   # compose up --build → full ECC → docs/conformance/ (402 executed · 384 passed · 0 failed · 18 N/A · 0 skipped at the v3.5.0 close)
 # admin-console gates: /ui-gates (both-target clippy, nextest, leptosfmt, cargo-leptos build)
 bash scripts/ui-e2e.sh        # the browser journey battery against the composed stack (merge gate in CI)
 ```
@@ -177,11 +177,12 @@ Compile status: the **generated** spec crates `openehr-base`, `openehr-rm`,
 `openehr-codegen` (hand-written tooling), `openehr-term`
 (hand-written), `openehr-query` (AQL parser), and `openehr-its` (canonical
 JSON/XML + generated ITS-REST contract; all fidelity gates green) all compile +
-clippy-clean. The `ehrbase-*` application crates are built compiling per phase:
-the Stage-1 app build P09–P15 is **done** (persistence, greenfield storage,
-REST+auth, service layer, templates, WebTemplate/FLAT/STRUCTURED, validation);
-the remaining work is P16–P20 (+P99) — AQL engine, FLAT/EhrScape wiring,
-integration, conformance, optimization, cutover.
+clippy-clean. The `ehrbase-*` application crates: **the Stage-1 CDR is
+shipped** (v3.5.0 — persistence, greenfield storage, REST + auth incl.
+RBAC/ABAC, the full SM service layer, templates, WebTemplate/FLAT/STRUCTURED,
+validation, the AQL engine, the admin console) with the ECC baseline green
+(402 executed · 384 passed · 0 failed); the EhrScape surface was cut, not
+built. Remaining work is tracked exclusively on GitHub Issues.
 
 ## Conventions
 
@@ -205,10 +206,10 @@ integration, conformance, optimization, cutover.
 - **Keep the changelog** (`CHANGELOG.md`, Keep a Changelog 1.1.0): every PR with user-visible changes adds an `[Unreleased]` entry in the same PR — CI (`changelog-guard`) enforces it; releases are cut from the changelog (see `.claude/rules/changelog.md`). The `openehr-*` spec crates are versioned by the spec they implement; the product/workspace follows its own SemVer (3.x).
 - **User docs track the product.** Any PR that changes the REST surface, configuration (`EHRBASE_*`), the CLI, deployment artifacts (compose/Helm/containers), or other user-visible behaviour must update the matching `website/book/src` page in the same PR (see `.claude/rules/docs-website.md`). Never hand-edit `website/api/spec/**` — run `scripts/assemble-oas.sh` (CI drift gate).
 - **Never weaken, skip, or delete a test** to make a build pass, and never edit a test to route around a bug it exposes.
-- **Reliability hard rules are machine-enforced** (`.claude/rules/reliability.md`, owner 2026-07-17): every safety rule pairs with the lint/CI check that fails on violation — a rule without a failing check is a wish. Register: `docs/plans/design-principles.md`.
+- **Reliability hard rules are machine-enforced** (`.claude/rules/reliability.md`, owner 2026-07-17): every safety rule pairs with the lint/CI check that fails on violation — a rule without a failing check is a wish. The rules + their enforcement register live in `.claude/rules/reliability.md` itself.
 - **Record progress on the tracker (tick issue checkboxes / comment / open issues for new work) and commit before ending a session.** A `Stop` hook enforces this.
 - **Application phases build as compiling, tested increments** on top of the generated `openehr-*` crates — do not defer compilation. (The old "phases need not compile" rule applied only to the retired hand-transcription era.)
-- The v1 enterprise code (RBAC and others) is a Stage 2 concern. Do not build it during Stage 1; it lives only as the read-only `reference/v1` git ref until then.
+- RBAC/ABAC authz (`ehrbase-rest::access`) and multi-tenancy are SHIPPED — they were built greenfield, not restored. The remaining v1 enterprise archaeology (plugin system and any other unrestored capability) stays a Stage 2/3 concern; `reference/v1` remains a read-only git ref consulted only for that work.
 
 ## References
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,14 @@
 # Contributing to EHRbase-rs
 
 Thank you for your interest in contributing. This document covers the practical
-rules; the architectural ground rules live in [`docs/ADRs/`](docs/ADRs/) and
-[`docs/architecture.md`](docs/architecture.md).
+rules; the architectural ground rules live in
+[`docs/architecture.md`](docs/architecture.md) and the root `CLAUDE.md`.
 
 ## Before you start
 
-- **Read [ADR-008](docs/ADRs/ADR-008-greenfield-pg18-storage.md) first**, then
-  [ADR-004](docs/ADRs/ADR-004-spec-driven-codegen.md)/[ADR-005](docs/ADRs/ADR-005-its-codegen.md)
-  (the generated spec layer) and
-  [ADR-006](docs/ADRs/ADR-006-application-port-philosophy.md) (the application
-  philosophy). They explain the two-layer split every change must respect.
+- **Read [`docs/architecture.md`](docs/architecture.md) first** — it explains
+  the two-layer split (generated `openehr-*` spec crates, hand-written
+  `ehrbase-*` application) every change must respect.
 - For anything spec-facing (RM semantics, REST wire behaviour, AQL, canonical
   JSON/XML, templates, terminology), **the vendored openEHR specification text at
   [`docs/specs/openehr/`](docs/specs/openehr/) is the authority** — cite the spec
@@ -65,7 +63,7 @@ CI runs the same set; nothing is advisory.
 - Tests accompany behaviour changes. Snapshot changes (`insta`) must be reviewed,
   not blindly accepted.
 - Commit messages describe the change itself (conventional-commit style subjects
-  like `phase-17: …`, `fix: …`, `docs: …` are used throughout the history).
+  like `feat: …`, `fix: …`, `docs: …` are used throughout the history).
 
 ## Reporting issues
 

--- a/README.md
+++ b/README.md
@@ -219,10 +219,11 @@ flowchart TB
         openehr["openehr-base · openehr-rm · openehr-am · openehr-term · openehr-lang (BMM · ODIN · BEL)<br/>openehr-its (native canonical JSON/XML codecs + ITS-REST contract)<br/>openehr-adl (ADL 1.4 + 2.4 engine: parser · AOM2 validation · flattener · OPT2)<br/>openehr-query (AQL parser) · openehr-flat (WebTemplate · FLAT · STRUCTURED)"]
     end
 
-    subgraph app ["app/* — the application (three crates, three roles)"]
+    subgraph app ["app/* — the application (four crates, four roles)"]
         rest["ehrbase-rest<br/>ITS-REST 1.1.0 protocol adapter (axum)<br/>+ access (authn · RBAC/ABAC) + wire mapping"]
         core["ehrbase<br/>the platform library: PG18 node storage · versioning ·<br/>AQL→SQL engine · validation · signing ·<br/>eventing · FHIR · multimedia — one service module<br/>per SM Platform Service Model chapter"]
         bin["ehrbase-server<br/>the wiring-only binary"]
+        adminui["ehrbase-admin-ui<br/>the Leptos SSR admin console (own OCI image,<br/>consumes the CDR strictly over ITS-REST)"]
     end
 
     subgraph tools ["tools/* — generation + verification (not shipped)"]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,7 +12,7 @@ artifacts: conformance in `docs/conformance/`, benchmarks in
 ## What the product is
 
 A pure-Rust, headless, API-first openEHR CDR on PostgreSQL 18: ITS-REST
-1.0.3 at the API, AQL 1.1 as the query language, RM 1.2.0 as the domain
+1.1.0 at the API, AQL 1.1 as the query language, RM 1.2.0 as the domain
 model — the spec layer generated from the official machine-readable specs,
 the application our own design on top (`docs/architecture.md`). Conformance
 is machine-verified per release by the built-in ECC runner; performance is

--- a/app/ehrbase-rest/examples/policies/README.md
+++ b/app/ehrbase-rest/examples/policies/README.md
@@ -1,7 +1,8 @@
 # Example Cedar policies
 
 Illustrative embedded-Cedar policies for the ehrbase-rs ABAC layer
-(`docs/design/access-control.md` §5.6). Point `abac.cedar.policy_dir` at a
+(no openEHR spec governs authorization — our own design; the shipped rules
+live in `.claude/rules/auth.md`). Point `abac.cedar.policy_dir` at a
 copy of this directory (or your own) to try the embedded engine.
 
 `consent.cedar` reproduces the *shape* of EHRbase v1's external consent checks

--- a/app/ehrbase/CLAUDE.md
+++ b/app/ehrbase/CLAUDE.md
@@ -1,6 +1,6 @@
 # `ehrbase` — the platform library
 
-The application core (three app crates, zero re-exports): storage, the service layer
+The application core (four app crates, zero re-exports): storage, the service layer
 (one module per SM chapter — concrete `EhrbaseService` methods, no trait
 catalog), AQL engine, versioning, the full configuration tree
 (`ehrbase::config`), telemetry, plus the `signing` (VERSION.signature) and

--- a/deploy/helm/golden/README.md
+++ b/deploy/helm/golden/README.md
@@ -4,7 +4,7 @@ These are the committed `helm template` outputs the chart is expected to
 produce, used by `deploy/helm/validate.sh` (and CI) to catch unintended drift.
 
 - `default.yaml` — `ci/default-values.yaml` (chart defaults + an external-Secret
-  DB DSN; all optional integrations OFF, the ADR-013 security posture on).
+  DB DSN; all optional integrations OFF, the hardened default security posture on).
 - `all-features.yaml` — `ci/all-features-values.yaml` (every optional
   integration enabled, separate management port, autoscaling, egress policy,
   mounted config files).

--- a/docker/benchmark/README.md
+++ b/docker/benchmark/README.md
@@ -1,6 +1,6 @@
 # Benchmark comparison stack — ehrbase-rs vs. EHRbase (Java)
 
-The dual-stack environment for `docs/design/benchmarking.md`. Two servers, each
+The dual-stack environment for the benchmark harness (`tools/benchmark/` — the pre-registered workload, CO-corrected latency, and config-parity method are documented in the tool itself). Two servers, each
 with its own PostgreSQL, on distinct ports; both configured with HTTP Basic auth
 (`ehrbase` / `ehrbase`) so the harness drives them through the identical
 credential path.
@@ -13,7 +13,7 @@ credential path.
 ## Run
 
 ```shell
-# Full comparison (honest one-at-a-time protocol, §3.1):
+# Full comparison (honest one-at-a-time protocol):
 docker/benchmark/run.sh                 # ≥5 runs per scenario — publishable
 docker/benchmark/run.sh --smoke         # fast, proves the pipeline
 docker/benchmark/run.sh --only rs       # just ehrbase-rs
@@ -27,14 +27,14 @@ the **host machine auto-captured** (a number is not comparable across hardware).
 
 ## Honesty notes (see the design)
 
-- **PG-version confound** (§3.3): ehrbase-rs runs on PG 18, EHRbase Java on the
+- **PG-version confound**: ehrbase-rs runs on PG 18, EHRbase Java on the
   PG 16 its image ships. This is the "recommended" deployment comparison. To
   isolate the engine from the database, add a controlled run with both on PG 16
   (a follow-up; the design describes it).
-- **JVM warmup** (§4.2): the harness discards a warmup phase, applied identically
+- **JVM warmup**: the harness discards a warmup phase, applied identically
   to both — the JVM is warmed, not handicapped. EHRbase Java also needs ~60–90 s
   to *boot* before it is ready; the runner waits for `/rest/status`.
-- **Config parity** (§3.4): Basic auth on both, template-overwrite on both,
+- **Config parity**: Basic auth on both, template-overwrite on both,
   default connection pools. Record any residual asymmetry in the report.
 - Pin and record the exact image **digests** in the environment block before
   publishing any claim.

--- a/docker/postgres/README.md
+++ b/docker/postgres/README.md
@@ -2,7 +2,7 @@
 
 A preconfigured PostgreSQL 18 image for ehrbase-rs, mirroring the official
 `ehrbase/ehrbase-v2-postgres` two-image model built fresh for this stack
-(ADR-008). It is `postgres:18.4` plus one-time init scripts.
+(the greenfield PG18 storage design, `docs/architecture.md` §Storage). It is `postgres:18.4` plus one-time init scripts.
 
 ## What the init scripts create
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@ cites an ADR; the only citable references are the vendored specs and official
 external documentation.** (The current design in brief: the spec + ITS layer is
 generated from the vendored machine-readable specs by `openehr-codegen`; the
 application is idiomatic Rust of our own design on those crates, with its own
-PG18-native storage and typed AQL engine, three app crates with zero
+PG18-native storage and typed AQL engine, four app crates with zero
 re-exports, an SM-aligned service layer, and enterprise capabilities —
 eventing, multi-tenancy, FHIR connectors, multimedia externalization;
 acceptance is the openEHR conformance suite. See `architecture.md`.)
@@ -62,7 +62,7 @@ acceptance is the openEHR conformance suite. See `architecture.md`.)
 - `conformance/` — ECC run artifacts, one directory per SUT (`ehrbase-rs/`,
   `ehrbase-java/`, …): `CONFORMANCE_REPORT.md`, `CONFORMANCE_STATEMENT.md`,
   `CONFORMANCE_CERTIFICATE.md`, `results.json`, badges; the SUT-independent
-  `CATALOG.md` at the root. Current (ehrbase-rs): **370 executed · 335
-  passed · 0 failed — CORE PASS / STANDARD PASS**.
+  `CATALOG.md` at the root. Current (ehrbase-rs): **402 executed · 384
+  passed · 0 failed · 18 N/A — CORE PASS / STANDARD PASS**.
 - `benchmarks/` — `REPORT.md` + `results.json` + `COMPARISON.md` from the
   benchmark harness (`tools/benchmark`), regenerated per measured pair.

--- a/docs/VERSIONS.md
+++ b/docs/VERSIONS.md
@@ -19,7 +19,7 @@ pre-releases until production sign-off.
 
 The `openehr-*` **spec crates** are versioned by the openEHR specification
 they implement (the pins below): `openehr-base` 1.3.0, `openehr-rm` 1.2.0,
-`openehr-am` 2.4.0, `openehr-term` 3.1.0, `openehr-lang` 1.0.0,
+`openehr-am` 2.4.0, `openehr-adl` 2.4.0, `openehr-term` 3.1.0, `openehr-lang` 1.0.0,
 `openehr-query` 1.1.0, `openehr-its` 1.1.0. They bump only on a spec-pin
 bump, never with the product version.
 
@@ -136,7 +136,7 @@ This is a fork; its import point is recorded so provenance is unambiguous:
 
 The original design reasoning was authored against v2.31.0. By the time this
 fork's Phase 0 reorganization ran, upstream had advanced to v2.33.0, and that
-is the tree actually imported into the Cargo workspace. (Per **ADR-008** the
+is the tree actually imported into the Cargo workspace. (With the greenfield storage pivot the
 in-tree EHRbase Java was later removed and behaviour-parity was retired for
 openEHR CNF conformance; EHRbase v2.33.0 remains the *prior-art* reference, not
 a parity oracle.)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,7 +12,7 @@ PostgreSQL-18-native internals. Two layers:
    on that foundation.** The server, storage, service layer, AQL
    execution engine, validation, and auth — proper crates, our own algorithms,
    the openEHR specifications as the authority. EHRbase and other CDRs are
-   prior art, not an oracle. This is the remaining Stage-1 work.
+   prior art, not an oracle. Shipped as of v3.5.0.
 
 Authoritative roadmap: the root **`ROADMAP.md`**; the open-items tracker is
 GitHub Issues (root `CLAUDE.md` §Issue workflow), with `docs/plans/` (deep
@@ -26,7 +26,7 @@ spec + ITS layer is generated from the vendored machine-readable specs
 own design on those generated crates, with its own PG18-native storage (one
 `node` table + one temporal `vo_version` table) and its own typed AQL engine,
 and acceptance measured by the openEHR conformance suite (EHRbase is prior art,
-not an oracle); the application is three crates with zero re-exports, and its
+not an oracle); the application is four crates with zero re-exports, and its
 service layer follows the openEHR SM Platform Service Model (one module per SM
 chapter, concrete methods).
 
@@ -116,9 +116,10 @@ envelope is documented per construct; rejections are explicit typed errors.
 Base path `/ehrbase/rest/openehr/v1`, implementing the generated ITS-REST
 1.1.0 server traits over `axum` with a `tower-http` middleware stack and
 content negotiation (canonical JSON/XML via `openehr-its`). Extensions: admin
-API, `/rest/status`, `/management/*`, item tags, EhrScape compatibility
-(a feature-gated `ehrscape` adapter module in `ehrbase-rest`). **Auth (Stage 1):** Basic + OAuth2/OIDC via
-`argon2`/`jsonwebtoken`/`oauth2`/`openidconnect`; RBAC is Stage 2.
+API, `/rest/status`, `/management/*`, item tags (the EhrScape surface was
+cut, not built). **Auth:** Basic + OAuth2/OIDC via
+`argon2`/`jsonwebtoken`/`oauth2`/`openidconnect`; authorization is the
+shipped RBAC/ABAC `access` module in `ehrbase-rest`.
 
 ## Templates, validation, FLAT
 
@@ -156,8 +157,10 @@ columns for hot extractions. See `docs/postgres-features.md`.
 Three physical directories (consolidated 2026-07-16):
 **`app/*`** holds the application — `ehrbase` (the platform **library**),
 `ehrbase-rest` (the ITS-REST protocol adapter, which calls the concrete
-`EhrbaseService` directly), and `ehrbase-server` (the wiring-only binary; the
-bin is still named `ehrbase`); **`tools/*`** holds the dev/verification
+`EhrbaseService` directly), `ehrbase-server` (the wiring-only binary; the
+bin is still named `ehrbase`), and `ehrbase-admin-ui` (the Leptos SSR admin
+console — its own binary/OCI image, consuming the CDR strictly over
+ITS-REST); **`tools/*`** holds the dev/verification
 tooling that is *not* part of the shipped application (`conformance` — the
 ECC runner, `benchmark`, `testkit` — the shared test-database harness, and
 `openehr-codegen` — the BMM/XSD/OAS → Rust generator); **`crates/*`** holds the
@@ -200,6 +203,7 @@ The service layer realizes the openEHR **SM Platform Service Model**
 | `openehr-lang` | BMM/P_BMM object model | generated |
 | `openehr-its` | Canonical JSON/XML + ITS-REST contract + runtimes + gates | generated + hand-written |
 | `openehr-query` | AQL 1.1 lexer + parser + AST | hand-written |
+| `openehr-adl` | ADL 2.4 engine: ADL2/cADL/ODIN parser, AOM2 validation, flattener, OPT2, ADL 1.4→2 conversion | hand-written |
 | `openehr-flat` | FLAT / STRUCTURED / Web Template | hand-written |
 | `openehr-codegen` | BMM/XSD/OAS → Rust generator (+ `emit-rm-model`) | tooling |
 | `ehrbase-rest` | ITS-REST protocol adapter (axum) + auth + ATNA audit middleware; `access` module = RBAC/ABAC authz; calls the concrete `EhrbaseService` | application |
@@ -218,8 +222,9 @@ The service layer realizes the openEHR **SM Platform Service Model**
   compiling, tested increments; the per-phase build record is the closed
   issues + PR descriptions (+ the retired `docs/PROGRESS.md` in git
   history).
-- **Stage 2**: enterprise capabilities — RBAC/attribute authz, plugin system,
-  multi-tenancy (`reference/v1` archaeology).
+- **Stage 2**: remaining enterprise capabilities — the plugin system and any
+  other unrestored capability (`reference/v1` archaeology; RBAC/ABAC and
+  multi-tenancy already shipped greenfield in Stage 1).
 - **Stage 3**: refinement, performance, new capabilities.
 
 ## Verification
@@ -228,7 +233,7 @@ The service layer realizes the openEHR **SM Platform Service Model**
   round-trip + ITS-JSON schema validation; XML round-trips.
 - **Conformance suite** (`scripts/conformance.sh` — present): the ECC catalogue
   (Docker-composed SUT, both formats) — the acceptance instrument;
-  the standing baseline: 341 executed · 315 passed · 0 failed,
+  the standing baseline: 402 executed · 384 passed · 0 failed · 18 N/A,
   CORE/STANDARD PASS.
 - **Drift check** (`scripts/check-codegen-drift.sh` + CI): the generated layer
   is always in sync with the vendored specs.

--- a/docs/postgres-features.md
+++ b/docs/postgres-features.md
@@ -33,7 +33,7 @@ we run the latest patch (18.4) for the fixes.
 | Feature | What it enables for EHRbase-RS |
 |---|---|
 | **`uuidv7()` (native)** | Timestamp-ordered UUIDs for `OBJECT_VERSION_ID`/row keys — index-friendly, no `uuid` crate round-trip for DB-generated ids (P09). |
-| **Temporal `PRIMARY KEY`/`UNIQUE`/`FOREIGN KEY` `WITHOUT OVERLAPS`** | Enforce non-overlapping validity on the one temporal `vo_version` table (ADR-008 — `sys_period tstzrange`, no current/`_history` pairs) at the DB — a natural fit for openEHR versioning (P09/P10/P12). |
+| **Temporal `PRIMARY KEY`/`UNIQUE`/`FOREIGN KEY` `WITHOUT OVERLAPS`** | Enforce non-overlapping validity on the one temporal `vo_version` table (the greenfield storage design — `sys_period tstzrange`, no current/`_history` pairs; see `docs/architecture.md` §Storage) at the DB — a natural fit for openEHR versioning (P09/P10/P12). |
 | **`RETURNING OLD/NEW`** in INSERT/UPDATE/DELETE/MERGE | One-statement audit capture (write + return prior value) for the `audit`/`contribution` rows on every version write (P12). |
 | **Virtual generated columns** | Cheap read-time derived columns (e.g. a JSONB leaf) without storage — candidate indexes/filters for AQL hot paths (P16/P20). |
 | **B-tree skip scan** | Multicolumn indexes usable when a leading column is unconstrained — fewer indexes for the row-per-locatable + AQL access patterns. |

--- a/website/README.md
+++ b/website/README.md
@@ -2,9 +2,9 @@
 
 This directory holds the public documentation site published to
 **https://rubentalstra.github.io/ehrbase-rs/** (GitHub Pages, project sub-path
-`/ehrbase-rs/`). The authoritative specification for the whole site — toolchain
-pins, URL scheme, versioning machinery, design tokens, content map — is the
-phase file [`docs/plans/w1-docs-website.md`](../docs/plans/w1-docs-website.md).
+`/ehrbase-rs/`). The site conventions — toolchain pins, URL scheme,
+versioning machinery, design tokens, content map — are documented in
+`.claude/rules/docs-website.md` and this file.
 
 ## Layout
 
@@ -35,4 +35,4 @@ branch plus `/docs/latest/`, exactly as CI does before deploy.
   run `scripts/assemble-oas.sh` (the served OAS is a byte copy of the vendored
   ITS-REST bundles, drift-gated in CI).
 - Authoring voice is end-user and task-first; never publish internal trees
-  (ADRs, plans, blueprint, spec oracle) — see the phase file §4.
+  (plans, rules, the vendored spec oracle).

--- a/website/book/src/installation/configuration.md
+++ b/website/book/src/installation/configuration.md
@@ -526,7 +526,7 @@ For production, set at least:
 - **`server.cors_permissive`** stays `false`; **`server.swagger_ui`** per posture.
 - **`management.*`** per posture (a dedicated `port` is recommended so
   `/management` is never reachable on the clinical listener).
-- **TLS everywhere a transport supports it** — `atna.transport = "tls"`,
+- **TLS everywhere a transport supports it** — `audit.syslog.transport = "tls"`,
   `events.tls`, `fhir.outbound.tls`, HTTPS S3.
 - **real secrets via env or `*_file`**, never inline.
 
@@ -575,7 +575,7 @@ below maps every old spelling to its replacement.
 | `EHRBASE_MANAGEMENT_*` | `management.*` (`EHRBASE__MANAGEMENT__*`) | **boot error** — use the new spelling |
 | `EHRBASE_MANAGEMENT_ENDPOINTS_<EP>` | `management.endpoints.<ep>` (`EHRBASE__MANAGEMENT__ENDPOINTS__<EP>`) | **boot error** — use the new spelling |
 | `EHRBASE_AUTHZ_RBAC__*` / `EHRBASE_AUTHZ_ABAC__*` | `authz.rbac.*` / `authz.abac.*` (`EHRBASE__AUTHZ__…`) | **boot error** — use the new spelling |
-| `EHRBASE_ATNA_<KEY>` | `atna.<key>` (`EHRBASE__ATNA__<KEY>`) | **boot error** — use the new spelling |
+| `EHRBASE_ATNA_<KEY>` | `audit.<key>` (`EHRBASE__AUDIT__<KEY>`) | **boot error** — use the new spelling |
 | `EHRBASE_SIGNING_<KEY>` | `signing.<key>` (`EHRBASE__SIGNING__<KEY>`) | **boot error** — use the new spelling |
 | `EHRBASE_EVENTS_<KEY>` | `events.<key>` (`EHRBASE__EVENTS__<KEY>`) | **boot error** — use the new spelling |
 | `EHRBASE_FHIR_OUTBOUND_<KEY>` | `fhir.outbound.<key>` (`EHRBASE__FHIR__OUTBOUND__<KEY>`) | **boot error** — use the new spelling |

--- a/website/book/src/installation/kubernetes.md
+++ b/website/book/src/installation/kubernetes.md
@@ -24,7 +24,7 @@ kubectl -n ehrbase create secret generic ehrbase-db \
 
 helm install ehrbase-rs deploy/helm/ehrbase-rs -n ehrbase \
   --set database.existingSecret=ehrbase-db \
-  --set image.tag=3.0.0
+  --set image.tag=3.5.0
 ```
 
 Always pin `image.tag` to an immutable version or, better, a `@sha256` digest —
@@ -62,8 +62,8 @@ Some settings do not fit cleanly in environment variables — the Basic-auth use
 store, a full OIDC block, RBAC role-claim lists, ABAC policies, the external
 terminology provider map, ATNA TLS certificates, and the PGP signing key. Supply
 these as files via `config.files`, which the chart mounts read-only from a
-Secret at `/etc/ehrbase/<key>`; point the matching `EHRBASE_*_CONFIG` /
-`*_PATH` variable at the file through `extraEnv`. Secret-bearing scalar values
+Secret at `/etc/ehrbase/<key>`; point the matching in-TOML `*_file` /
+`*_path` key (or its `EHRBASE__…` env override) at the mounted path. Secret-bearing scalar values
 (DB DSN, HMAC secret, broker URLs, S3 keys, PGP passphrase) go into the chart's
 Secret, never the ConfigMap.
 
@@ -133,7 +133,7 @@ config env prefix:
 | FHIR outbound → AMQP | `fhirOutbound.enabled` | ⚠ **Carries PHI** (the mapped FHIR resource). Separate exchange; TLS broker only. |
 | S3 multimedia | `multimedia.enabled` | ⚠ Offloaded blobs are PHI. Private, encrypted, HTTPS bucket. |
 | External terminology | `externalTerminology.enabled` | FHIR terminology server; provider map via a mounted TOML. |
-| ATNA system log | `atna.enabled` | Use `transport: tls` for PHI-adjacent audit. |
+| ATNA system log | `audit.enabled` | Use `audit.syslog.transport: tls` for PHI-adjacent audit. |
 | Version signing | `signing.*` | On by default (`digest`). `pgp` mode fails closed at boot without a usable key. |
 | OTLP telemetry | `telemetry.otel.*` | Unset endpoint ⇒ the OTel layer is not installed (zero overhead). |
 

--- a/website/book/src/security.md
+++ b/website/book/src/security.md
@@ -12,11 +12,11 @@ described here in terms of the environment variables you actually set.
 
 Configuration follows the same pattern throughout: the server reads defaults,
 then the single `ehrbase.toml` file, then environment variables, with `__`
-separating nested keys. The three security configuration groups live in
-distinct sections of `ehrbase.toml` — `[auth]` (authentication), `[server]`
-(tenancy, under `[server.tenancy]`), `[authz]` (authorization), and `[atna]`
-(audit) — and any key can be overridden with the matching `EHRBASE_*`
-environment variable shown below.
+separating nested keys. The security configuration groups live in
+distinct sections of `ehrbase.toml` — `[auth]` (authentication), `[tenancy]`
+(multi-tenancy), `[authz]` (authorization), and `[audit]`
+(the ATNA audit trail) — and any key can be overridden with the matching
+`EHRBASE_*` environment variable shown below.
 
 ## Authentication
 

--- a/website/book/src/using-the-api/index.md
+++ b/website/book/src/using-the-api/index.md
@@ -26,7 +26,7 @@ with `EHRBASE__SERVER__BASE_PATH` (see the
 [configuration reference](../installation/configuration.md)).
 
 The public, unauthenticated status probe lives just outside the base path at
-`/ehrbase/rest/status`, and interactive docs at `/ehrbase/swagger-ui` when
+`/ehrbase/rest/status`, and interactive docs at `/ehrbase/rest/swagger-ui` when
 enabled.
 
 An `OPTIONS` request to the API base path (also answered at `/`) returns the


### PR DESCRIPTION
Two exhaustive audits (repo markdown + website sources) verified every hand-written page against the current state: conformance 402/384/0/18, benchmarks per the committed v3.5.0 pair, upstream 2.34.0, ITS-REST 1.1.0, four app crates, openehr-adl, shipped RBAC/ABAC + tenancy, retired ADR/design/worklist layers.

Fixed: three distinct stale conformance baselines, ITS-REST 1.0.3 leftovers, three-crates claims + missing ehrbase-admin-ui/openehr-adl entries, the stale P16–P20 remaining-work framing, EhrScape recorded as cut, dead ADR/docs-design/plan-file references (incl. CONTRIBUTING.md's four broken ADR links), and seven website configuration errors ([atna]→[audit], [server.tenancy]→[tenancy], the removed EHRBASE_*_CONFIG pattern, tag 3.0.0→3.5.0, the Swagger UI path).

Deliberately untouched after verification: RBAC/ABAC docs (shipped in code — the 'Stage 2' claim was the stale side), the 2.33.0 benchmark measurement labels (what the committed pair ran), Swagger UI 5.32.8 (confirmed in the vendored bundle), and all generated number includes. Docs-only; no Rust changes.