### PR TITLE
feat(bench): auto-extending knee ladder + sustained-only knee charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,24 +272,23 @@ on official openEHR CKM templates. Both directions always published.
 
 ### Maximum sustained throughput
 
-**622 req/s vs 434 req/s — ehrbase-rs sustains 1.4× upstream's load**, and
-carries **15,420 vs 10,744 completed clinical events per minute** doing it
+**631 req/s vs 475 req/s — ehrbase-rs sustains 1.3× upstream's load**, and
+carries **15,642 vs 11,755 completed clinical events per minute** doing it
 (the knee: the highest load holding p99 ≤ 1 s and errors ≤ 0.1%, measured
-back-to-back on the same host, same payloads, full config parity). And 622
-is a floor, not a ceiling: the ladder's top step still **sustained** for
-ehrbase-rs, while upstream's knee sits at L=44:
+back-to-back on the same host, same payloads, full config parity). Both
+knees are breach-resolved — the ladder auto-extends until a real SLO breach
+bounds every knee from above, so neither figure is a guess:
 
 | | Max sustained | Clinical events/min | p99 at the knee |
 |---|--:|--:|--:|
-| **ehrbase-rs** | **622 req/s** (37,341 req/min) | **15,420** | **91 ms** |
-| EHRbase 2.33.0 (Java) | 434 req/s (26,052 req/min) | 10,744 | 873 ms |
+| **ehrbase-rs** | **631 req/s** (37,890 req/min) | **15,642** | **205 ms** |
+| EHRbase 2.34.0 (Java) | 475 req/s (28,500 req/min) | 11,755 | 575 ms |
 
 ![Max sustained req/s at the SLO](docs/benchmarks/charts/comparison-knee.svg)
 
-One rung past upstream's knee (L=48), ehrbase-rs answers with a **51 ms**
-p99 at 0.005% errors — upstream breaches there with a **20.7-second** p99
-and 0.39% errors. At the ladder's top step (L=64), ehrbase-rs still holds a
-91 ms p99; upstream never reaches it. Full
+At L=64 — a third past upstream's knee — ehrbase-rs still holds a **205 ms**
+p99 at 0.03% errors; upstream starts breaching at L=52 (a **26-second** p99
+at 6.8% errors) and never reaches a rung ehrbase-rs cannot sustain. Full
 ladders: [ehrbase-rs](docs/benchmarks/ehrbase-rs/KNEE.md) ·
 [upstream](docs/benchmarks/ehrbase-java/KNEE.md).
 

--- a/docs/benchmarks/COMPARISON.md
+++ b/docs/benchmarks/COMPARISON.md
@@ -40,8 +40,8 @@
 
 | | Knee L | Sustained req/s | Sustained req/min | Clinical events/min | p99 at knee |
 |---|--:|--:|--:|--:|--:|
-| **ehrbase-rs** | 64 | 622.4 | 37341 | 15420 | 91.2 ms |
-| **ehrbase-java** | 44 | 434.2 | 26052 | 10744 | 873.0 ms |
+| **ehrbase-rs** | 64 | 631.5 | 37890 | 15642 | 204.7 ms |
+| **ehrbase-java** | 48 | 475.0 | 28500 | 11755 | 575.5 ms |
 
 ![Max sustained req/s at the SLO](charts/comparison-knee.svg)
 

--- a/docs/benchmarks/charts/comparison-knee.svg
+++ b/docs/benchmarks/charts/comparison-knee.svg
@@ -18,8 +18,8 @@ text { fill: #c3c2b7; }
 <text x="16" y="22" class="title">Max sustained req/s at the SLO</text>
 <text x="160.0" y="52.0" text-anchor="end">ehrbase-rs</text>
 <rect class="s1" x="170" y="42.0" width="450.0" height="12" rx="4"/>
-<text class="muted" x="626.0" y="52.0">622.4 req/s</text>
+<text class="muted" x="626.0" y="52.0">631.5 req/s</text>
 <text x="160.0" y="78.0" text-anchor="end">ehrbase-java</text>
-<rect class="s2" x="170" y="68.0" width="313.9" height="12" rx="4"/>
-<text class="muted" x="489.9" y="78.0">434.2 req/s</text>
+<rect class="s2" x="170" y="68.0" width="338.5" height="12" rx="4"/>
+<text class="muted" x="514.5" y="78.0">475.0 req/s</text>
 </svg>

--- a/docs/benchmarks/ehrbase-java/KNEE.md
+++ b/docs/benchmarks/ehrbase-java/KNEE.md
@@ -2,28 +2,28 @@
 
 > Generated from `knee.json` (never hand-typed). Scale **10k**. The `hour` rate shape is driven at an ascending load-factor ladder on short fixed windows; the ladder stops at the first step past the SLO (p99 > 1 s) or the 0.1% error-rate flag. Latencies are coordinated-omission-corrected against planned send times.
 
-**Knee: L = 44 → 434.2 req/s (26052 req/min) at p99 872959 µs** (the last sustainable step; SLO p99 ≤ 1 s, error ≤ 0.1%) — sustaining 10744.0 clinical events/min.
+**Knee: L = 48 → 475.0 req/s (28500 req/min) at p99 575487 µs** (the last sustainable step; SLO p99 ≤ 1 s, error ≤ 0.1%) — sustaining 11755.0 clinical events/min.
 
 ## Ladder
 
 | L | req/s | error rate | p99 (µs) | requests | dispatch lag (ms) | verdict |
 |--:|--:|--:|--:|--:|--:|---|
-| 1 | 10.1 | 0.000% | 64767 | 1209 | 11 | sustained |
-| 2 | 20.1 | 0.000% | 45119 | 2416 | 9 | sustained |
-| 4 | 40.1 | 0.000% | 36351 | 4817 | 30 | sustained |
-| 8 | 80.5 | 0.000% | 26975 | 9663 | 7 | sustained |
-| 16 | 160.5 | 0.005% | 18751 | 19263 | 12 | sustained |
-| 32 | 316.2 | 0.008% | 24767 | 37940 | 18 | sustained |
-| 40 | 400.4 | 0.017% | 68735 | 48054 | 45 | sustained |
-| 44 | 434.2 | 0.073% | 872959 | 52103 | 14 | sustained |
-| 46 | 461.5 | 0.115% | 949759 | 55385 | 36 | SLO breached |
-| 48 | 477.9 | 0.389% | 20742143 | 57352 | 15 | SLO breached |
+| 1 | 10.1 | 0.000% | 60575 | 1209 | 13 | sustained |
+| 2 | 20.1 | 0.000% | 39743 | 2416 | 9 | sustained |
+| 4 | 40.1 | 0.000% | 34335 | 4817 | 14 | sustained |
+| 8 | 80.5 | 0.000% | 33023 | 9663 | 24 | sustained |
+| 16 | 160.5 | 0.005% | 108671 | 19263 | 44 | sustained |
+| 32 | 316.2 | 0.011% | 44607 | 37939 | 12 | sustained |
+| 48 | 475.0 | 0.061% | 575487 | 56999 | 48 | sustained |
+| 52 | 486.9 | 6.807% | 26361855 | 58422 | 10 | SLO breached |
+| 56 | 478.3 | 13.586% | 28426239 | 57398 | 11 | SLO breached |
+| 64 | 540.6 | 14.420% | 28934143 | 64872 | 26 | SLO breached |
 
 ![Knee — sustained req/s vs p99 latency](charts/knee.svg)
 
 ## Limitations
 
-- **Single run per step** (no inter-run variance): the ≥5-run protocol (benchmarking.md §4.4) is the publication step; these numbers are indicative, not certified.
+- **Single run per step** (no inter-run variance): a multi-run protocol with coefficient of variation is the certification bar; these numbers are indicative, not certified.
 - **Same-host load generator:** the generator competes for CPU with the SUT at high load, so the measured knee is a **lower bound** on the SUT's real capacity — an isolated load generator would push it higher.
 - Provisioning is re-applied idempotently at each step; scale seeding runs once before the ladder.
 

--- a/docs/benchmarks/ehrbase-java/charts/knee.svg
+++ b/docs/benchmarks/ehrbase-java/charts/knee.svg
@@ -18,46 +18,41 @@ text { fill: #c3c2b7; }
 <text x="16" y="22" class="title">Knee — sustained req/s vs p99 latency (log scale)</text>
 <line class="grid" x1="64" y1="210.0" x2="660" y2="210.0"/>
 <text class="muted" x="56.0" y="214.0" text-anchor="end">10.0ms</text>
-<line class="grid" x1="64" y1="169.5" x2="660" y2="169.5"/>
-<text class="muted" x="56.0" y="173.5" text-anchor="end">100.0ms</text>
+<line class="grid" x1="64" y1="185.6" x2="660" y2="185.6"/>
+<text class="muted" x="56.0" y="189.6" text-anchor="end">20.0ms</text>
+<line class="grid" x1="64" y1="153.4" x2="660" y2="153.4"/>
+<text class="muted" x="56.0" y="157.4" text-anchor="end">50.0ms</text>
 <line class="grid" x1="64" y1="129.0" x2="660" y2="129.0"/>
-<text class="muted" x="56.0" y="133.0" text-anchor="end">1.0s</text>
-<line class="grid" x1="64" y1="88.5" x2="660" y2="88.5"/>
-<text class="muted" x="56.0" y="92.5" text-anchor="end">10.0s</text>
+<text class="muted" x="56.0" y="133.0" text-anchor="end">100.0ms</text>
+<line class="grid" x1="64" y1="104.6" x2="660" y2="104.6"/>
+<text class="muted" x="56.0" y="108.6" text-anchor="end">200.0ms</text>
+<line class="grid" x1="64" y1="72.4" x2="660" y2="72.4"/>
+<text class="muted" x="56.0" y="76.4" text-anchor="end">500.0ms</text>
 <line class="grid" x1="64" y1="48.0" x2="660" y2="48.0"/>
-<text class="muted" x="56.0" y="52.0" text-anchor="end">100.0s</text>
-<line class="s2s" x1="64" y1="129.0" x2="660" y2="129.0" stroke-dasharray="4 3"/>
-<text class="muted" x="620.0" y="125.0">SLO 1s</text>
-<text class="muted" x="660" y="228.0" text-anchor="end">478 req/s</text>
-<polyline class="s1s" fill="none" stroke-width="2" points="76.6,177.1 89.1,183.5 114.1,187.3 164.4,192.5 264.2,198.9 458.3,194.0 563.4,176.1 605.5,131.4 639.6,129.9 660.0,75.7"/>
-<circle class="s1" cx="76.6" cy="177.1" r="3.5"/>
-<text x="82.6" y="173.1">L=1</text>
-<text class="muted" x="82.6" y="189.1">64.8ms</text>
-<circle class="s1" cx="89.1" cy="183.5" r="3.5"/>
-<text x="95.1" y="179.5">L=2</text>
-<text class="muted" x="95.1" y="195.5">45.1ms</text>
-<circle class="s1" cx="114.1" cy="187.3" r="3.5"/>
-<text x="120.1" y="183.3">L=4</text>
-<text class="muted" x="120.1" y="199.3">36.4ms</text>
-<circle class="s1" cx="164.4" cy="192.5" r="3.5"/>
-<text x="170.4" y="188.5">L=8</text>
-<text class="muted" x="170.4" y="204.5">27.0ms</text>
-<circle class="s1" cx="264.2" cy="198.9" r="3.5"/>
-<text x="270.2" y="194.9">L=16</text>
-<text class="muted" x="270.2" y="210.9">18.8ms</text>
-<circle class="s1" cx="458.3" cy="194.0" r="3.5"/>
-<text x="464.3" y="190.0">L=32</text>
-<text class="muted" x="464.3" y="206.0">24.8ms</text>
-<circle class="s1" cx="563.4" cy="176.1" r="3.5"/>
-<text x="569.4" y="172.1">L=40</text>
-<text class="muted" x="569.4" y="188.1">68.7ms</text>
-<circle class="s1" cx="605.5" cy="131.4" r="3.5"/>
-<text x="611.5" y="127.4">L=44</text>
-<text class="muted" x="611.5" y="143.4">873.0ms</text>
-<circle class="s1" cx="639.6" cy="129.9" r="3.5"/>
-<text x="645.6" y="125.9">L=46</text>
-<text class="muted" x="645.6" y="141.9">949.8ms</text>
-<circle class="s1" cx="660.0" cy="75.7" r="3.5"/>
-<text x="666.0" y="71.7">L=48</text>
-<text class="muted" x="666.0" y="87.7">20.7s</text>
+<text class="muted" x="56.0" y="52.0" text-anchor="end">1.0s</text>
+<line class="s2s" x1="64" y1="48.0" x2="660" y2="48.0" stroke-dasharray="4 3"/>
+<text class="muted" x="620.0" y="44.0">SLO 1s</text>
+<text class="muted" x="660" y="228.0" text-anchor="end">475 req/s</text>
+<polyline class="s1s" fill="none" stroke-width="2" points="76.6,146.6 89.3,161.5 114.4,166.6 165.0,168.0 265.4,126.1 460.7,157.4 660.0,67.4"/>
+<circle class="s1" cx="76.6" cy="146.6" r="3.5"/>
+<text x="82.6" y="142.6">L=1</text>
+<text class="muted" x="82.6" y="158.6">60.6ms</text>
+<circle class="s1" cx="89.3" cy="161.5" r="3.5"/>
+<text x="95.3" y="157.5">L=2</text>
+<text class="muted" x="95.3" y="173.5">39.7ms</text>
+<circle class="s1" cx="114.4" cy="166.6" r="3.5"/>
+<text x="120.4" y="162.6">L=4</text>
+<text class="muted" x="120.4" y="178.6">34.3ms</text>
+<circle class="s1" cx="165.0" cy="168.0" r="3.5"/>
+<text x="171.0" y="164.0">L=8</text>
+<text class="muted" x="171.0" y="180.0">33.0ms</text>
+<circle class="s1" cx="265.4" cy="126.1" r="3.5"/>
+<text x="271.4" y="122.1">L=16</text>
+<text class="muted" x="271.4" y="138.1">108.7ms</text>
+<circle class="s1" cx="460.7" cy="157.4" r="3.5"/>
+<text x="466.7" y="153.4">L=32</text>
+<text class="muted" x="466.7" y="169.4">44.6ms</text>
+<circle class="s1" cx="660.0" cy="67.4" r="3.5"/>
+<text x="666.0" y="63.4">L=48</text>
+<text class="muted" x="666.0" y="79.4">575.5ms</text>
 </svg>

--- a/docs/benchmarks/ehrbase-java/knee.json
+++ b/docs/benchmarks/ehrbase-java/knee.json
@@ -13,16 +13,16 @@
       "load_factor": 1.0,
       "rps": 10.075,
       "error_rate": 0.0,
-      "p99_us": 64767,
+      "p99_us": 60575,
       "requests": 1209,
       "events_per_min": 250.00000000000003,
-      "max_dispatch_lag_ms": 11
+      "max_dispatch_lag_ms": 13
     },
     {
       "load_factor": 2.0,
       "rps": 20.133333333333333,
       "error_rate": 0.0,
-      "p99_us": 45119,
+      "p99_us": 39743,
       "requests": 2416,
       "events_per_min": 498.5,
       "max_dispatch_lag_ms": 9
@@ -31,83 +31,84 @@
       "load_factor": 4.0,
       "rps": 40.141666666666666,
       "error_rate": 0.0,
-      "p99_us": 36351,
+      "p99_us": 34335,
       "requests": 4817,
       "events_per_min": 993.0,
-      "max_dispatch_lag_ms": 30
+      "max_dispatch_lag_ms": 14
     },
     {
       "load_factor": 8.0,
       "rps": 80.525,
       "error_rate": 0.0,
-      "p99_us": 26975,
+      "p99_us": 33023,
       "requests": 9663,
       "events_per_min": 1993.0,
-      "max_dispatch_lag_ms": 7
+      "max_dispatch_lag_ms": 24
     },
     {
       "load_factor": 16.0,
       "rps": 160.525,
       "error_rate": 0.00005191029900332226,
-      "p99_us": 18751,
+      "p99_us": 108671,
       "requests": 19263,
       "events_per_min": 3980.9999999999995,
-      "max_dispatch_lag_ms": 12
+      "max_dispatch_lag_ms": 44
     },
     {
       "load_factor": 32.0,
-      "rps": 316.1666666666667,
-      "error_rate": 0.0000790659673721108,
-      "p99_us": 24767,
-      "requests": 37940,
-      "events_per_min": 7839.5,
-      "max_dispatch_lag_ms": 18
-    },
-    {
-      "load_factor": 40.0,
-      "rps": 400.45,
-      "error_rate": 0.0001664516665973118,
-      "p99_us": 68735,
-      "requests": 48054,
-      "events_per_min": 9914.0,
-      "max_dispatch_lag_ms": 45
-    },
-    {
-      "load_factor": 44.0,
-      "rps": 434.19166666666666,
-      "error_rate": 0.0007287930803014902,
-      "p99_us": 872959,
-      "requests": 52103,
-      "events_per_min": 10744.0,
-      "max_dispatch_lag_ms": 14
-    },
-    {
-      "load_factor": 46.0,
-      "rps": 461.5416666666667,
-      "error_rate": 0.0011542137820339411,
-      "p99_us": 949759,
-      "requests": 55385,
-      "events_per_min": 11413.0,
-      "max_dispatch_lag_ms": 36
+      "rps": 316.15833333333336,
+      "error_rate": 0.00010542128982948106,
+      "p99_us": 44607,
+      "requests": 37939,
+      "events_per_min": 7839.0,
+      "max_dispatch_lag_ms": 12
     },
     {
       "load_factor": 48.0,
-      "rps": 477.93333333333334,
-      "error_rate": 0.003890509934695012,
-      "p99_us": 20742143,
-      "requests": 57352,
-      "events_per_min": 11775.5,
-      "max_dispatch_lag_ms": 15
+      "rps": 474.9916666666667,
+      "error_rate": 0.0006136690395202862,
+      "p99_us": 575487,
+      "requests": 56999,
+      "events_per_min": 11755.0,
+      "max_dispatch_lag_ms": 48
+    },
+    {
+      "load_factor": 52.0,
+      "rps": 486.85,
+      "error_rate": 0.06806616790824546,
+      "p99_us": 26361855,
+      "requests": 58422,
+      "events_per_min": 11900.0,
+      "max_dispatch_lag_ms": 10
+    },
+    {
+      "load_factor": 56.0,
+      "rps": 478.31666666666666,
+      "error_rate": 0.1358586010659119,
+      "p99_us": 28426239,
+      "requests": 57398,
+      "events_per_min": 11621.5,
+      "max_dispatch_lag_ms": 11
+    },
+    {
+      "load_factor": 64.0,
+      "rps": 540.6,
+      "error_rate": 0.14420273603947073,
+      "p99_us": 28934143,
+      "requests": 64872,
+      "events_per_min": 13136.0,
+      "max_dispatch_lag_ms": 26
     }
   ],
   "knee": {
-    "load_factor": 44.0,
-    "rps": 434.19166666666666,
-    "error_rate": 0.0007287930803014902,
-    "p99_us": 872959,
-    "requests": 52103,
-    "events_per_min": 10744.0,
-    "max_dispatch_lag_ms": 14
+    "load_factor": 48.0,
+    "rps": 474.9916666666667,
+    "error_rate": 0.0006136690395202862,
+    "p99_us": 575487,
+    "requests": 56999,
+    "events_per_min": 11755.0,
+    "max_dispatch_lag_ms": 48
   },
-  "sut_died": false
+  "sut_died": false,
+  "ladder_capped": false
 }

--- a/docs/benchmarks/ehrbase-rs/KNEE.md
+++ b/docs/benchmarks/ehrbase-rs/KNEE.md
@@ -2,26 +2,29 @@
 
 > Generated from `knee.json` (never hand-typed). Scale **10k**. The `hour` rate shape is driven at an ascending load-factor ladder on short fixed windows; the ladder stops at the first step past the SLO (p99 > 1 s) or the 0.1% error-rate flag. Latencies are coordinated-omission-corrected against planned send times.
 
-**Knee: L = 64 → 622.4 req/s (37341 req/min) at p99 91199 µs** (the last sustainable step; SLO p99 ≤ 1 s, error ≤ 0.1%) — sustaining 15419.5 clinical events/min.
+**Knee: L = 64 → 631.5 req/s (37890 req/min) at p99 204671 µs** (the last sustainable step; SLO p99 ≤ 1 s, error ≤ 0.1%) — sustaining 15642.0 clinical events/min.
 
 ## Ladder
 
 | L | req/s | error rate | p99 (µs) | requests | dispatch lag (ms) | verdict |
 |--:|--:|--:|--:|--:|--:|---|
-| 1 | 10.1 | 0.000% | 38047 | 1209 | 9 | sustained |
-| 2 | 20.1 | 0.000% | 33023 | 2416 | 5 | sustained |
-| 4 | 40.1 | 0.000% | 25343 | 4817 | 4 | sustained |
-| 8 | 80.5 | 0.000% | 22991 | 9663 | 16 | sustained |
-| 16 | 160.5 | 0.005% | 15599 | 19263 | 30 | sustained |
-| 32 | 316.2 | 0.008% | 18159 | 37940 | 18 | sustained |
-| 48 | 479.8 | 0.005% | 50815 | 57573 | 11 | sustained |
-| 64 | 622.4 | 0.021% | 91199 | 74682 | 16 | sustained |
+| 1 | 10.1 | 0.000% | 50399 | 1209 | 11 | sustained |
+| 2 | 20.1 | 0.000% | 29039 | 2416 | 11 | sustained |
+| 4 | 40.1 | 0.000% | 26575 | 4817 | 45 | sustained |
+| 8 | 80.5 | 0.000% | 26447 | 9663 | 15 | sustained |
+| 16 | 160.5 | 0.000% | 16831 | 19264 | 26 | sustained |
+| 32 | 316.2 | 0.008% | 50751 | 37940 | 17 | sustained |
+| 64 | 631.5 | 0.032% | 204671 | 75779 | 12 | sustained |
+| 72 | 557.1 | 22.509% | 26509311 | 66855 | 486 | SLO breached |
+| 80 | 620.5 | 21.771% | 28196863 | 74464 | 269 | SLO breached |
+| 96 | 637.1 | 34.621% | 28573695 | 76450 | 13 | SLO breached |
+| 128 | 575.2 | 53.477% | 28491775 | 69022 | 107 | SLO breached |
 
 ![Knee — sustained req/s vs p99 latency](charts/knee.svg)
 
 ## Limitations
 
-- **Single run per step** (no inter-run variance): the ≥5-run protocol (benchmarking.md §4.4) is the publication step; these numbers are indicative, not certified.
+- **Single run per step** (no inter-run variance): a multi-run protocol with coefficient of variation is the certification bar; these numbers are indicative, not certified.
 - **Same-host load generator:** the generator competes for CPU with the SUT at high load, so the measured knee is a **lower bound** on the SUT's real capacity — an isolated load generator would push it higher.
 - Provisioning is re-applied idempotently at each step; scale seeding runs once before the ladder.
 

--- a/docs/benchmarks/ehrbase-rs/charts/knee.svg
+++ b/docs/benchmarks/ehrbase-rs/charts/knee.svg
@@ -18,36 +18,41 @@ text { fill: #c3c2b7; }
 <text x="16" y="22" class="title">Knee — sustained req/s vs p99 latency (log scale)</text>
 <line class="grid" x1="64" y1="210.0" x2="660" y2="210.0"/>
 <text class="muted" x="56.0" y="214.0" text-anchor="end">10.0ms</text>
-<line class="grid" x1="64" y1="161.2" x2="660" y2="161.2"/>
-<text class="muted" x="56.0" y="165.2" text-anchor="end">20.0ms</text>
-<line class="grid" x1="64" y1="96.8" x2="660" y2="96.8"/>
-<text class="muted" x="56.0" y="100.8" text-anchor="end">50.0ms</text>
+<line class="grid" x1="64" y1="185.6" x2="660" y2="185.6"/>
+<text class="muted" x="56.0" y="189.6" text-anchor="end">20.0ms</text>
+<line class="grid" x1="64" y1="153.4" x2="660" y2="153.4"/>
+<text class="muted" x="56.0" y="157.4" text-anchor="end">50.0ms</text>
+<line class="grid" x1="64" y1="129.0" x2="660" y2="129.0"/>
+<text class="muted" x="56.0" y="133.0" text-anchor="end">100.0ms</text>
+<line class="grid" x1="64" y1="104.6" x2="660" y2="104.6"/>
+<text class="muted" x="56.0" y="108.6" text-anchor="end">200.0ms</text>
+<line class="grid" x1="64" y1="72.4" x2="660" y2="72.4"/>
+<text class="muted" x="56.0" y="76.4" text-anchor="end">500.0ms</text>
 <line class="grid" x1="64" y1="48.0" x2="660" y2="48.0"/>
-<text class="muted" x="56.0" y="52.0" text-anchor="end">100.0ms</text>
-<text class="muted" x="660" y="228.0" text-anchor="end">622 req/s</text>
-<polyline class="s1s" fill="none" stroke-width="2" points="73.6,116.0 83.3,126.0 102.4,144.6 141.1,151.4 217.7,178.7 366.8,168.0 523.5,95.6 660.0,54.5"/>
-<circle class="s1" cx="73.6" cy="116.0" r="3.5"/>
-<text x="79.6" y="112.0">L=1</text>
-<text class="muted" x="79.6" y="128.0">38.0ms</text>
-<circle class="s1" cx="83.3" cy="126.0" r="3.5"/>
-<text x="89.3" y="122.0">L=2</text>
-<text class="muted" x="89.3" y="138.0">33.0ms</text>
-<circle class="s1" cx="102.4" cy="144.6" r="3.5"/>
-<text x="108.4" y="140.6">L=4</text>
-<text class="muted" x="108.4" y="156.6">25.3ms</text>
-<circle class="s1" cx="141.1" cy="151.4" r="3.5"/>
-<text x="147.1" y="147.4">L=8</text>
-<text class="muted" x="147.1" y="163.4">23.0ms</text>
-<circle class="s1" cx="217.7" cy="178.7" r="3.5"/>
-<text x="223.7" y="174.7">L=16</text>
-<text class="muted" x="223.7" y="190.7">15.6ms</text>
-<circle class="s1" cx="366.8" cy="168.0" r="3.5"/>
-<text x="372.8" y="164.0">L=32</text>
-<text class="muted" x="372.8" y="180.0">18.2ms</text>
-<circle class="s1" cx="523.5" cy="95.6" r="3.5"/>
-<text x="529.5" y="91.6">L=48</text>
-<text class="muted" x="529.5" y="107.6">50.8ms</text>
-<circle class="s1" cx="660.0" cy="54.5" r="3.5"/>
-<text x="666.0" y="50.5">L=64</text>
-<text class="muted" x="666.0" y="66.5">91.2ms</text>
+<text class="muted" x="56.0" y="52.0" text-anchor="end">1.0s</text>
+<line class="s2s" x1="64" y1="48.0" x2="660" y2="48.0" stroke-dasharray="4 3"/>
+<text class="muted" x="620.0" y="44.0">SLO 1s</text>
+<text class="muted" x="660" y="228.0" text-anchor="end">631 req/s</text>
+<polyline class="s1s" fill="none" stroke-width="2" points="73.5,153.1 83.0,172.5 101.9,175.6 140.0,175.8 215.5,191.7 362.4,152.9 660.0,103.8"/>
+<circle class="s1" cx="73.5" cy="153.1" r="3.5"/>
+<text x="79.5" y="149.1">L=1</text>
+<text class="muted" x="79.5" y="165.1">50.4ms</text>
+<circle class="s1" cx="83.0" cy="172.5" r="3.5"/>
+<text x="89.0" y="168.5">L=2</text>
+<text class="muted" x="89.0" y="184.5">29.0ms</text>
+<circle class="s1" cx="101.9" cy="175.6" r="3.5"/>
+<text x="107.9" y="171.6">L=4</text>
+<text class="muted" x="107.9" y="187.6">26.6ms</text>
+<circle class="s1" cx="140.0" cy="175.8" r="3.5"/>
+<text x="146.0" y="171.8">L=8</text>
+<text class="muted" x="146.0" y="187.8">26.4ms</text>
+<circle class="s1" cx="215.5" cy="191.7" r="3.5"/>
+<text x="221.5" y="187.7">L=16</text>
+<text class="muted" x="221.5" y="203.7">16.8ms</text>
+<circle class="s1" cx="362.4" cy="152.9" r="3.5"/>
+<text x="368.4" y="148.9">L=32</text>
+<text class="muted" x="368.4" y="164.9">50.8ms</text>
+<circle class="s1" cx="660.0" cy="103.8" r="3.5"/>
+<text x="666.0" y="99.8">L=64</text>
+<text class="muted" x="666.0" y="115.8">204.7ms</text>
 </svg>

--- a/docs/benchmarks/ehrbase-rs/knee.json
+++ b/docs/benchmarks/ehrbase-rs/knee.json
@@ -13,83 +13,111 @@
       "load_factor": 1.0,
       "rps": 10.075,
       "error_rate": 0.0,
-      "p99_us": 38047,
+      "p99_us": 50399,
       "requests": 1209,
       "events_per_min": 250.00000000000003,
-      "max_dispatch_lag_ms": 9
+      "max_dispatch_lag_ms": 11
     },
     {
       "load_factor": 2.0,
       "rps": 20.133333333333333,
       "error_rate": 0.0,
-      "p99_us": 33023,
+      "p99_us": 29039,
       "requests": 2416,
       "events_per_min": 498.5,
-      "max_dispatch_lag_ms": 5
+      "max_dispatch_lag_ms": 11
     },
     {
       "load_factor": 4.0,
       "rps": 40.141666666666666,
       "error_rate": 0.0,
-      "p99_us": 25343,
+      "p99_us": 26575,
       "requests": 4817,
       "events_per_min": 993.0,
-      "max_dispatch_lag_ms": 4
+      "max_dispatch_lag_ms": 45
     },
     {
       "load_factor": 8.0,
       "rps": 80.525,
       "error_rate": 0.0,
-      "p99_us": 22991,
+      "p99_us": 26447,
       "requests": 9663,
       "events_per_min": 1993.0,
-      "max_dispatch_lag_ms": 16
+      "max_dispatch_lag_ms": 15
     },
     {
       "load_factor": 16.0,
-      "rps": 160.525,
-      "error_rate": 0.00005191029900332226,
-      "p99_us": 15599,
-      "requests": 19263,
-      "events_per_min": 3980.9999999999995,
-      "max_dispatch_lag_ms": 30
+      "rps": 160.53333333333333,
+      "error_rate": 0.0,
+      "p99_us": 16831,
+      "requests": 19264,
+      "events_per_min": 3981.5,
+      "max_dispatch_lag_ms": 26
     },
     {
       "load_factor": 32.0,
       "rps": 316.1666666666667,
       "error_rate": 0.0000790659673721108,
-      "p99_us": 18159,
+      "p99_us": 50751,
       "requests": 37940,
       "events_per_min": 7839.5,
-      "max_dispatch_lag_ms": 18
-    },
-    {
-      "load_factor": 48.0,
-      "rps": 479.775,
-      "error_rate": 0.000052105043768236766,
-      "p99_us": 50815,
-      "requests": 57573,
-      "events_per_min": 11883.5,
-      "max_dispatch_lag_ms": 11
+      "max_dispatch_lag_ms": 17
     },
     {
       "load_factor": 64.0,
-      "rps": 622.35,
-      "error_rate": 0.00021419582853623927,
-      "p99_us": 91199,
-      "requests": 74682,
-      "events_per_min": 15419.5,
-      "max_dispatch_lag_ms": 16
+      "rps": 631.4916666666667,
+      "error_rate": 0.0003166101605477356,
+      "p99_us": 204671,
+      "requests": 75779,
+      "events_per_min": 15642.0,
+      "max_dispatch_lag_ms": 12
+    },
+    {
+      "load_factor": 72.0,
+      "rps": 557.125,
+      "error_rate": 0.2250851936852354,
+      "p99_us": 26509311,
+      "requests": 66855,
+      "events_per_min": 13396.0,
+      "max_dispatch_lag_ms": 486
+    },
+    {
+      "load_factor": 80.0,
+      "rps": 620.5333333333333,
+      "error_rate": 0.21770830050322,
+      "p99_us": 28196863,
+      "requests": 74464,
+      "events_per_min": 14928.0,
+      "max_dispatch_lag_ms": 269
+    },
+    {
+      "load_factor": 96.0,
+      "rps": 637.0833333333334,
+      "error_rate": 0.34620680218586714,
+      "p99_us": 28573695,
+      "requests": 76450,
+      "events_per_min": 14698.5,
+      "max_dispatch_lag_ms": 13
+    },
+    {
+      "load_factor": 128.0,
+      "rps": 575.1833333333333,
+      "error_rate": 0.5347667834995956,
+      "p99_us": 28491775,
+      "requests": 69022,
+      "events_per_min": 12500.0,
+      "max_dispatch_lag_ms": 107
     }
   ],
   "knee": {
     "load_factor": 64.0,
-    "rps": 622.35,
-    "error_rate": 0.00021419582853623927,
-    "p99_us": 91199,
-    "requests": 74682,
-    "events_per_min": 15419.5,
-    "max_dispatch_lag_ms": 16
+    "rps": 631.4916666666667,
+    "error_rate": 0.0003166101605477356,
+    "p99_us": 204671,
+    "requests": 75779,
+    "events_per_min": 15642.0,
+    "max_dispatch_lag_ms": 12
   },
-  "sut_died": false
+  "sut_died": false,
+  "ladder_capped": false
 }

--- a/tools/benchmark/src/bin/bench.rs
+++ b/tools/benchmark/src/bin/bench.rs
@@ -7,10 +7,12 @@
 //!              [--seed U64] [--app-container NAME] [--db-container NAME]
 //!              [--db-user U] [--db-name D] [--no-seed] [--out DIR]
 //! bench knee   --sut … --scale … [--ward-size N] [--seed U64]
-//!              [--steps "1,2,4,8,16,32"] [--step-window 120] [--warmup 15]
+//!              [--steps "1,2,4,8,16,32,64,128"] [--max-load 1024]
+//!              [--step-window 120] [--warmup 15]
 //!              [--app-container NAME] [--db-container NAME] [--no-seed] [--out DIR]
 //! bench seed   --sut … --scale … [--seed U64]
 //! bench report --from results.json [--out DIR]
+//! bench knee-report --from knee.json [--out DIR]
 //! bench compare --from a.json --from b.json [--knee-from a-knee.json …] [--out DIR]
 //! ```
 //!
@@ -23,7 +25,10 @@
 //! `knee` provisions + seeds once, then drives the `hour` rate shape at an
 //! ascending load-factor ladder on short fixed windows, stops
 //! at the first step past the SLO (p99 > 1 s) or the 0.1% error flag, and writes
-//! `knee.json` + `KNEE.md` + `charts/knee.svg`. Exit: `0` ok · `2` failure.
+//! `knee.json` + `KNEE.md` + `charts/knee.svg`. A ladder that ends with its top
+//! step still sustained auto-extends (doubling) up to `--max-load`; ending
+//! without a breach flags the result `ladder_capped` (a lower bound, not a
+//! knee). Exit: `0` ok · `2` failure.
 // Benchmark CLI: progress/diagnostics on the console ARE this tool's user
 // interface (.claude/rules/reliability.md §tools).
 #![allow(clippy::print_stdout, clippy::print_stderr)]
@@ -75,6 +80,8 @@ enum Command {
     Seed(SeedArgs),
     /// Re-render the artefact set from an existing results.json.
     Report(ReportArgs),
+    /// Re-render the knee artefact set from an existing knee.json.
+    KneeReport(ReportArgs),
     /// Render the cross-SUT comparison (Markdown + charts) from two runs.
     Compare(CompareArgs),
 }
@@ -157,6 +164,13 @@ struct KneeArgs {
     /// ladder (`0` disables refinement).
     #[arg(long, default_value_t = 3)]
     bisections: u32,
+    /// Auto-extension safety cap: when the configured ladder ends with its
+    /// top step still sustained, the ladder keeps doubling the load factor
+    /// until a breach, a generator-bound step, or this cap — a knee is only
+    /// a knee once a breach bounds it from above. Ending at the cap flags
+    /// the result `ladder_capped` (a lower bound, not a knee).
+    #[arg(long, default_value_t = 1024.0)]
+    max_load: f64,
     /// The fixed per-step measurement window (seconds).
     #[arg(long, default_value_t = 120)]
     step_window: u64,
@@ -310,6 +324,7 @@ async fn main() {
         Command::Knee(args) => cmd_knee(args).await,
         Command::Seed(args) => cmd_seed(args).await,
         Command::Report(args) => cmd_report(&args),
+        Command::KneeReport(args) => cmd_knee_report(&args),
         Command::Compare(args) => cmd_compare(&args),
     };
     std::process::exit(code);
@@ -829,6 +844,7 @@ async fn cmd_knee(args: KneeArgs) -> i32 {
     let mut steps_out: Vec<KneeStep> = Vec::new();
     let mut knee: Option<KneeStep> = None;
     let mut sut_died = false;
+    let mut ladder_capped = false;
     let mut queue: std::collections::VecDeque<f64> = ladder.into_iter().collect();
     let mut bisections_left = args.bisections;
     let mut last_breached: Option<f64> = None;
@@ -931,7 +947,7 @@ async fn cmd_knee(args: KneeArgs) -> i32 {
             }
             continue;
         }
-        knee = Some(step);
+        knee = Some(step.clone());
         // A sustained refinement step: probe upward toward the known breach.
         if let Some(hi) = last_breached
             && queue.is_empty()
@@ -942,6 +958,36 @@ async fn cmd_knee(args: KneeArgs) -> i32 {
                 queue.push_back(mid);
             } else {
                 eprintln!("bench: ladder stops");
+                break;
+            }
+        }
+        // The configured ladder is exhausted with NO breach ever observed: a
+        // knee is only a knee once a breach bounds it from above, so keep
+        // doubling until a breach, a generator-bound step (further offered
+        // load would bound the instrument, not the SUT), or the safety cap.
+        if last_breached.is_none() && queue.is_empty() {
+            if step.generator_bound() {
+                ladder_capped = true;
+                eprintln!(
+                    "bench: ladder ends GENERATOR-BOUND at L={load_factor} with no breach observed — \
+                     the result is a LOWER BOUND, not a knee (an isolated load generator would push further)"
+                );
+                break;
+            }
+            if let Some(next) = report::knee::extend_step(load_factor, args.max_load) {
+                eprintln!(
+                    "bench: ladder exhausted while still sustained — auto-extending to L={next} \
+                     (cap {})",
+                    args.max_load
+                );
+                queue.push_back(next);
+            } else {
+                ladder_capped = true;
+                eprintln!(
+                    "bench: ladder capped at --max-load {} with no breach observed — \
+                     the result is a LOWER BOUND, not a knee",
+                    args.max_load
+                );
                 break;
             }
         }
@@ -963,6 +1009,7 @@ async fn cmd_knee(args: KneeArgs) -> i32 {
         steps: steps_out,
         knee,
         sut_died,
+        ladder_capped,
     };
 
     let out_dir = args.out.join(&descriptor.name);
@@ -1019,6 +1066,27 @@ async fn cmd_seed(args: SeedArgs) -> i32 {
             2
         }
     }
+}
+
+fn cmd_knee_report(args: &ReportArgs) -> i32 {
+    let results = match report::knee::from_file(&args.from) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("error reading {}: {e}", args.from.display());
+            return 2;
+        }
+    };
+    let out_dir = args.out.join(&results.sut.name);
+    if let Err(e) = report::knee::write_all(&results, &out_dir) {
+        eprintln!("error writing artefacts: {e}");
+        return 2;
+    }
+    eprintln!(
+        "regenerated knee artefacts in {} from {}",
+        out_dir.display(),
+        args.from.display()
+    );
+    0
 }
 
 fn cmd_report(args: &ReportArgs) -> i32 {

--- a/tools/benchmark/src/report/compare.rs
+++ b/tools/benchmark/src/report/compare.rs
@@ -246,9 +246,16 @@ fn knee_section(md: &mut String, charts: &mut Vec<(String, String)>, knees: &[Kn
     for k in [a, b] {
         match &k.knee {
             Some(step) => md.push_str(&format!(
-                "| **{}** | {} | {:.1} | {:.0} | {:.0} | {} |\n",
+                "| **{}** | {}{} | {:.1} | {:.0} | {:.0} | {} |\n",
                 k.sut.name,
                 step.load_factor,
+                // A capped ladder never observed a breach: the figure is a
+                // lower bound on capacity, not a knee — say so in-table.
+                if k.ladder_capped {
+                    " (≥ — ladder-capped, a lower bound)"
+                } else {
+                    ""
+                },
                 step.rps,
                 step.rps * 60.0,
                 step.events_per_min,
@@ -549,6 +556,7 @@ mod tests {
             steps: vec![step.clone()],
             knee: Some(step),
             sut_died: false,
+            ladder_capped: false,
         }
     }
 

--- a/tools/benchmark/src/report/knee.rs
+++ b/tools/benchmark/src/report/knee.rs
@@ -2,7 +2,12 @@
 //! probe. The `hour` rate shape is driven at an ascending load-factor ladder,
 //! each step on a short fixed window (open-loop, ramping, fixed duration per
 //! step); the ladder stops at the first step past the SLO (p99 > 1 s) or the
-//! error-rate flag (> 0.1%), and the last sustainable step is the knee.
+//! error-rate flag (> 0.1%), and the last sustainable step is the knee. A
+//! ladder that exhausts its configured steps while still sustained
+//! auto-extends (doubling the load factor) until a breach, a generator-bound
+//! step, or the `--max-load` cap — a knee is only a knee once a breach
+//! bounds it from above; anything else is flagged `ladder_capped` (a lower
+//! bound, not a knee).
 //!
 //! `knee.json` is the machine record; `KNEE.md` + `charts/knee.svg` are
 //! generated from it, never hand-typed. Measured only — the honesty limitations
@@ -70,6 +75,17 @@ impl KneeStep {
     }
 }
 
+/// The next auto-extension step after a ladder exhausted its configured steps
+/// with the top step still sustained: double the last sustained load factor,
+/// or `None` once past `max_load` (the safety cap). Doubling continues the
+/// default ladder's geometric shape, and the post-breach bisection refines
+/// the interval it opens.
+#[must_use]
+pub fn extend_step(last_sustained: f64, max_load: f64) -> Option<f64> {
+    let next = last_sustained * 2.0;
+    (next <= max_load).then_some(next)
+}
+
 /// The knee/saturation machine record (`knee.json`).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct KneeResults {
@@ -88,6 +104,12 @@ pub struct KneeResults {
     /// first-class finding, surfaced loudly in `KNEE.md`.
     #[serde(default)]
     pub sut_died: bool,
+    /// The ladder ended with its top executed step still sustained — no SLO
+    /// breach was ever observed (the auto-extension hit `--max-load` or a
+    /// generator-bound step). The `knee` field is then a **lower bound** on
+    /// capacity, not a knee; surfaced loudly in `KNEE.md`.
+    #[serde(default)]
+    pub ladder_capped: bool,
 }
 
 impl KneeResults {
@@ -130,11 +152,16 @@ pub fn from_file(path: &Path) -> Result<KneeResults, BenchError> {
     Ok(serde_json::from_str(&text)?)
 }
 
-/// The chart points `(rps, p99_us, load_factor)` in ladder order.
+/// The chart points `(rps, p99_us, load_factor)` in ladder order: SUSTAINED
+/// steps only. Breached steps carry multi-second p99s (a saturated SUT
+/// answers in tens of seconds) that stretch the latency axis until the whole
+/// sustained curve flattens into noise — the chart shows the capacity curve,
+/// the table below it still lists every breached probe.
 fn chart_points(results: &KneeResults) -> Vec<(f64, u64, f64)> {
     results
         .steps
         .iter()
+        .filter(|s| !ladder_should_stop(s.p99_us, s.error_rate))
         .map(|s| (s.rps, s.p99_us, s.load_factor))
         .collect()
 }
@@ -158,8 +185,13 @@ pub fn render_markdown(r: &KneeResults) -> String {
 
     match &r.knee {
         Some(step) => m.push_str(&format!(
-            "**Knee: L = {} → {} at p99 {} µs** (the last sustainable step; \
+            "**{}: L = {} → {} at p99 {} µs** (the last sustainable step; \
              SLO p99 ≤ 1 s, error ≤ 0.1%){}.\n\n",
+            if r.ladder_capped {
+                "Top sustained step (ladder-capped — a lower bound, NOT the knee)"
+            } else {
+                "Knee"
+            },
             step.load_factor,
             super::fmt_rate(step.rps),
             step.p99_us,
@@ -186,6 +218,15 @@ pub fn render_markdown(r: &KneeResults) -> String {
              longer answered HTTP at all (a crash, e.g. OOM-killed; not mere saturation). \
              The knee above is where it *stopped surviving*, not where it merely slowed. \
              This is a finding about the SUT's overload behaviour.\n\n",
+        );
+    }
+    if r.ladder_capped {
+        m.push_str(
+            "> [!WARNING]\n> **Ladder-capped — this is a LOWER BOUND, not a knee.** The top \
+             executed step was still sustained; no SLO breach was observed, so the SUT's \
+             real knee lies above the figure reported here (the auto-extension stopped at \
+             the `--max-load` cap or a generator-bound step). Re-run with a higher cap or \
+             an isolated load generator to resolve it.\n\n",
         );
     }
     m.push_str("## Ladder\n\n");
@@ -222,9 +263,9 @@ pub fn render_markdown(r: &KneeResults) -> String {
 
     m.push_str("## Limitations\n\n");
     m.push_str(
-        "- **Single run per step** (no inter-run variance): the ≥5-run protocol \
-         (benchmarking.md §4.4) is the publication step; these numbers are \
-         indicative, not certified.\n",
+        "- **Single run per step** (no inter-run variance): a multi-run protocol \
+         with coefficient of variation is the certification bar; these numbers \
+         are indicative, not certified.\n",
     );
     m.push_str(
         "- **Same-host load generator:** the generator competes for CPU with the \
@@ -282,6 +323,7 @@ mod tests {
             steps: vec![s1, s2.clone(), breach],
             knee: Some(s2),
             sut_died: false,
+            ladder_capped: false,
         }
     }
 
@@ -338,6 +380,52 @@ mod tests {
         );
         // Absent (pre-25b) data stays silent — the base fixture has 0.0.
         assert!(!render_markdown(&results()).contains("clinical events/min"));
+    }
+
+    #[test]
+    fn chart_keeps_only_sustained_steps() {
+        let mut r = results();
+        // Extra deep-past-saturation probes (pre-refinement rungs): 20 s and
+        // 44 s p99s that would wreck the latency axis.
+        r.steps.push(step(6.0, 130.0, 0.08, 20_000_000, 7800));
+        r.steps.push(step(8.0, 110.0, 0.38, 44_000_000, 6600));
+        let pts = chart_points(&r);
+        let ls: Vec<f64> = pts.iter().map(|(_, _, l)| *l).collect();
+        assert_eq!(
+            ls,
+            vec![1.0, 2.0],
+            "the chart is the sustained capacity curve — every breached probe \
+             (incl. the base fixture's L=4 breach) stays table-only"
+        );
+    }
+
+    #[test]
+    fn extension_doubles_until_the_cap() {
+        assert_eq!(extend_step(64.0, 1024.0), Some(128.0));
+        assert_eq!(extend_step(512.0, 1024.0), Some(1024.0), "cap inclusive");
+        assert_eq!(extend_step(1024.0, 1024.0), None, "past the cap stops");
+        assert_eq!(extend_step(600.0, 1024.0), None, "next step would exceed");
+    }
+
+    #[test]
+    fn capped_run_is_flagged_a_lower_bound_not_a_knee() {
+        let mut r = results();
+        // A capped run: every step sustained, no breach row.
+        r.steps.pop();
+        r.ladder_capped = true;
+        let md = render_markdown(&r);
+        assert!(
+            md.contains("ladder-capped — a lower bound, NOT the knee"),
+            "the headline must not call a capped result a knee\n{md}"
+        );
+        assert!(
+            md.contains("Ladder-capped — this is a LOWER BOUND"),
+            "the warning block names the cap\n{md}"
+        );
+        // A breach-resolved run keeps the plain knee headline and no warning.
+        let resolved = render_markdown(&results());
+        assert!(resolved.contains("**Knee: L = 2"));
+        assert!(!resolved.contains("LOWER BOUND"));
     }
 
     #[test]


### PR DESCRIPTION
Fixes the two instrument defects the owner caught on the v3.5.0 pair:

1. **The ladder never went past its configured top step.** A knee is only a knee once a breach bounds it from above — the ladder now auto-extends (doubling) past an exhausted-but-sustained configuration until a real breach, a generator-bound step, or the new `--max-load` cap (default 1024); an unresolved run is flagged `ladder_capped` and rendered as a LOWER BOUND everywhere (KNEE.md headline + warning, comparison table marker).
2. **Breached probes wrecked the knee SVG.** Saturated SUTs answer in tens of seconds; those points stretched the latency axis until the sustained curve was unreadable. The chart now plots sustained steps only — the ladder table keeps every breached probe.

Plus `bench knee-report --from knee.json` (re-render without re-driving) and the fresh breach-resolved pair (quiet host, 10k, upstream 2.34.0): **ehrbase-rs L=64 → 631.5 req/s p99 205 ms** vs **upstream L=48 → 475.0 req/s p99 575 ms** — 1.3×, with 72/80/96/128 resp. 52/56/64 breached above the knees. README updated to the resolved numbers.

Gates: clippy 0 (CI flags), 112/112 nextest, three new unit tests. Tooling-only Rust changes (tools/benchmark).