### PR TITLE
fix(service): ServiceError carries the granular SM CALL_STATUS_TYPE (no more NotFound resurrection)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Fixed
+
+- SM call-status fidelity: service-layer "does not exist" failures now carry
+  their granular `CALL_STATUS_TYPE` (`ehr_id_does_not_exist`,
+  `composition_does_not_exist`, `template_does_not_exist`,
+  `object_version_does_not_exist`, …) end-to-end instead of resurfacing as
+  the generic `versioned_object_does_not_exist` after crossing the service
+  boundary. HTTP status codes are unchanged (every does-not-exist status was
+  and remains `404`); some `404` body messages are now the precise
+  construction-site text.
+
 ## [3.5.0] - 2026-07-21
 
 ### Changed

--- a/app/ehrbase/src/extensions/events/subscription.rs
+++ b/app/ehrbase/src/extensions/events/subscription.rs
@@ -23,7 +23,7 @@ use uuid::Uuid;
 
 use crate::service::EhrbaseService;
 use crate::service::error::ServiceError;
-use crate::service::status::SmError;
+use crate::service::status::{CallStatusType, SmError};
 
 impl EhrbaseService {
     /// Map an `event_subscription` row to its PHI-free JSON record (NULL
@@ -71,7 +71,12 @@ impl EhrbaseService {
         .bind(id)
         .fetch_optional(&self.pool)
         .await?
-        .ok_or_else(|| ServiceError::NotFound(format!("event subscription {id}")))?;
+        .ok_or_else(|| {
+            ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!("event subscription {id}"),
+            )
+        })?;
         Self::subscription_row(&row)
     }
 
@@ -115,7 +120,12 @@ impl EhrbaseService {
         .bind(enabled_flag(body))
         .fetch_optional(&self.pool)
         .await?
-        .ok_or_else(|| ServiceError::NotFound(format!("event subscription {id}")))?;
+        .ok_or_else(|| {
+            ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!("event subscription {id}"),
+            )
+        })?;
         Self::subscription_row(&row)
     }
 
@@ -132,7 +142,10 @@ impl EhrbaseService {
             .await?
             .rows_affected();
         if deleted == 0 {
-            return Err(ServiceError::NotFound(format!("event subscription {id}")));
+            return Err(ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!("event subscription {id}"),
+            ));
         }
         Ok(())
     }

--- a/app/ehrbase/src/extensions/fhir/mod.rs
+++ b/app/ehrbase/src/extensions/fhir/mod.rs
@@ -117,7 +117,12 @@ impl EhrbaseService {
         .bind(id)
         .fetch_optional(&self.pool)
         .await?
-        .ok_or_else(|| ServiceError::NotFound(format!("FHIR mapping {id}")))?;
+        .ok_or_else(|| {
+            ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!("FHIR mapping {id}"),
+            )
+        })?;
         Self::mapping_row(&row)
     }
 
@@ -170,7 +175,12 @@ impl EhrbaseService {
         .fetch_optional(&self.pool)
         .await
         .map_err(map_insert_error)?
-        .ok_or_else(|| ServiceError::NotFound(format!("FHIR mapping {id}")))?;
+        .ok_or_else(|| {
+            ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!("FHIR mapping {id}"),
+            )
+        })?;
         Self::mapping_row(&row)
     }
 
@@ -182,7 +192,10 @@ impl EhrbaseService {
             .await?
             .rows_affected();
         if deleted == 0 {
-            return Err(ServiceError::NotFound(format!("FHIR mapping {id}")));
+            return Err(ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!("FHIR mapping {id}"),
+            ));
         }
         Ok(())
     }

--- a/app/ehrbase/src/extensions/tenancy.rs
+++ b/app/ehrbase/src/extensions/tenancy.rs
@@ -28,7 +28,7 @@ use uuid::Uuid;
 use crate::extensions::tenant_context::TenantContext;
 use crate::service::EhrbaseService;
 use crate::service::error::ServiceError;
-use crate::service::status::SmError;
+use crate::service::status::{CallStatusType, SmError};
 
 /// The reserved default tenant: the nil uuid, owner of every row created while
 /// tenancy is off. Matches `ext.current_tenant_id()`'s fallback
@@ -68,9 +68,12 @@ impl EhrbaseService {
             .bind(id)
             .fetch_optional(&self.pool)
             .await?;
-        row.as_ref()
-            .map(Self::tenant_row)
-            .ok_or_else(|| ServiceError::NotFound(format!("tenant {id}")))?
+        row.as_ref().map(Self::tenant_row).ok_or_else(|| {
+            ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!("tenant {id}"),
+            )
+        })?
     }
 
     /// Create a tenant from `{name, system_id}` (both required, non-empty).
@@ -105,9 +108,12 @@ impl EhrbaseService {
         .await
         .map_err(map_insert_error)?;
         self.invalidate_tenant_cache();
-        row.as_ref()
-            .map(Self::tenant_row)
-            .ok_or_else(|| ServiceError::NotFound(format!("tenant {id}")))?
+        row.as_ref().map(Self::tenant_row).ok_or_else(|| {
+            ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!("tenant {id}"),
+            )
+        })?
     }
 
     /// Delete a tenant — only when it is not the reserved default and owns no
@@ -149,7 +155,10 @@ impl EhrbaseService {
             .execute(&mut *tx)
             .await?;
         if deleted.rows_affected() == 0 {
-            return Err(ServiceError::NotFound(format!("tenant {id}")));
+            return Err(ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!("tenant {id}"),
+            ));
         }
         tx.commit().await?;
         self.invalidate_tenant_cache();

--- a/app/ehrbase/src/service/admin/archive.rs
+++ b/app/ehrbase/src/service/admin/archive.rs
@@ -22,7 +22,7 @@ use uuid::Uuid;
 use crate::ids::EhrId;
 use crate::service::EhrbaseService;
 use crate::service::error::ServiceError;
-use crate::service::status::SmError;
+use crate::service::status::{CallStatusType, SmError};
 
 impl EhrbaseService {
     /// SM `archive_ehrs`: mark every versioned object of each EHR as archived
@@ -73,7 +73,10 @@ impl EhrbaseService {
                 .fetch_one(&mut *tx)
                 .await?;
             if !exists {
-                return Err(ServiceError::NotFound(format!("EHR {ehr_id}")));
+                return Err(ServiceError::sm(
+                    CallStatusType::EhrIdDoesNotExist,
+                    format!("EHR {ehr_id}"),
+                ));
             }
         }
         for &ehr_id in ehr_ids {
@@ -104,7 +107,10 @@ impl EhrbaseService {
             .fetch_optional(&mut *tx)
             .await?;
             if !kind.as_deref().is_some_and(super::is_party_kind) {
-                return Err(ServiceError::NotFound(format!("party {party_id}")));
+                return Err(ServiceError::sm(
+                    CallStatusType::PartyIdDoesNotExist,
+                    format!("party {party_id}"),
+                ));
             }
         }
         for &party_id in party_ids {

--- a/app/ehrbase/src/service/admin/delete.rs
+++ b/app/ehrbase/src/service/admin/delete.rs
@@ -15,7 +15,7 @@ use uuid::Uuid;
 use crate::ids::{EhrId, VoId};
 use crate::service::EhrbaseService;
 use crate::service::error::ServiceError;
-use crate::service::status::SmError;
+use crate::service::status::{CallStatusType, SmError};
 
 impl EhrbaseService {
     /// SM `physical_ehr_delete`: physically delete one EHR and every trace of
@@ -111,7 +111,10 @@ impl EhrbaseService {
         .fetch_optional(&mut *tx)
         .await?;
         let Some(stored) = stored else {
-            return Err(ServiceError::NotFound(format!("template {template_id}")));
+            return Err(ServiceError::sm(
+                CallStatusType::TemplateDoesNotExist,
+                format!("template {template_id}"),
+            ));
         };
         // Physical deletes never orphan clinical data (docs/architecture.md
         // §Storage — no openEHR spec governs the FK graph, our own design).
@@ -203,7 +206,10 @@ impl EhrbaseService {
         if deleted.rows_affected() == 0 {
             // `has_ehr(ehr_id)` is false → `ehr_id_does_not_exist`. Rolls back
             // (nothing was written), so the audit capture above is discarded.
-            return Err(ServiceError::NotFound(format!("EHR {ehr_id}")));
+            return Err(ServiceError::sm(
+                CallStatusType::EhrIdDoesNotExist,
+                format!("EHR {ehr_id}"),
+            ));
         }
 
         // The referencing vo_version/contribution rows are gone, so the audit
@@ -391,7 +397,10 @@ impl EhrbaseService {
                 .await?;
         if !kind.as_deref().is_some_and(super::is_party_kind) {
             // `party_id_does_not_exist` → NotFound (→ 404). Rolls back cleanly.
-            return Err(ServiceError::NotFound(format!("party {party_id}")));
+            return Err(ServiceError::sm(
+                CallStatusType::PartyIdDoesNotExist,
+                format!("party {party_id}"),
+            ));
         }
 
         // Every PARTY_RELATIONSHIP VO referencing the party as source/target, in

--- a/app/ehrbase/src/service/definition/adl14.rs
+++ b/app/ehrbase/src/service/definition/adl14.rs
@@ -151,15 +151,10 @@ impl EhrbaseService {
         &self,
         an_opt_id: String,
     ) -> Result<Vec<String>, SmError> {
-        // Preserve the granular SM status through the lossy ServiceError
-        // round-trip (the same boundary re-raise the TDD import uses).
-        let xml = match self.opt_get(&an_opt_id).await {
-            Ok(xml) => xml,
-            Err(ServiceError::NotFound(m)) => {
-                return Err(SmError::new(CallStatusType::TemplateDoesNotExist, m));
-            }
-            Err(e) => return Err(e.into()),
-        };
+        // `opt_get` names `template_does_not_exist` at construction and
+        // `ServiceError` round-trips the granular status losslessly — no
+        // boundary re-raise needed.
+        let xml = self.opt_get(&an_opt_id).await?;
         let opt = openehr_its::opt14::from_xml(&xml).map_err(|e| {
             ServiceError::Unprocessable(format!("stored OPT no longer parses: {e:?}"))
         })?;

--- a/app/ehrbase/src/service/definition/adl2.rs
+++ b/app/ehrbase/src/service/definition/adl2.rs
@@ -432,12 +432,15 @@ impl EhrbaseService {
             })
             .max_by(|a, b| cmp_version(version_of(a), version_of(b)))
             .ok_or_else(|| {
-                ServiceError::NotFound(format!(
-                    "ADL2 template {template_id}{}",
-                    version
-                        .map(|v| format!(" at version {v}"))
-                        .unwrap_or_default()
-                ))
+                ServiceError::sm(
+                    CallStatusType::TemplateDoesNotExist,
+                    format!(
+                        "ADL2 template {template_id}{}",
+                        version
+                            .map(|v| format!(" at version {v}"))
+                            .unwrap_or_default()
+                    ),
+                )
             })
     }
 

--- a/app/ehrbase/src/service/definition/query.rs
+++ b/app/ehrbase/src/service/definition/query.rs
@@ -229,7 +229,12 @@ impl EhrbaseService {
         .bind(version)
         .fetch_optional(&self.pool)
         .await?
-        .ok_or_else(|| ServiceError::NotFound(format!("stored query {qualified}")))?;
+        .ok_or_else(|| {
+            ServiceError::sm(
+                CallStatusType::ArtefactDoesNotExist,
+                format!("stored query {qualified}"),
+            )
+        })?;
         descriptor_from_row(&row)
     }
 
@@ -321,9 +326,10 @@ impl EhrbaseService {
         .await?
         .rows_affected();
         if deleted == 0 {
-            return Err(ServiceError::NotFound(format!(
-                "stored query {qualified_name} at version {version}"
-            )));
+            return Err(ServiceError::sm(
+                CallStatusType::ArtefactDoesNotExist,
+                format!("stored query {qualified_name} at version {version}"),
+            ));
         }
         Ok(())
     }
@@ -507,7 +513,12 @@ impl EhrbaseService {
         }
         .fetch_optional(&self.pool)
         .await?
-        .ok_or_else(|| ServiceError::NotFound(format!("stored query {qualified_name}")))?;
+        .ok_or_else(|| {
+            ServiceError::sm(
+                CallStatusType::ArtefactDoesNotExist,
+                format!("stored query {qualified_name}"),
+            )
+        })?;
 
         stored_query_json(&row)
     }

--- a/app/ehrbase/src/service/demographic/api.rs
+++ b/app/ehrbase/src/service/demographic/api.rs
@@ -241,14 +241,9 @@ impl EhrbaseService {
     ///   assembling the `ORIGINAL_VERSION`.
     pub async fn get_party_at_version(&self, a_party_version_id: String) -> Result<Value, SmError> {
         let (vo_id, tree) = parse_version_uid(&a_party_version_id)?;
-        match self.party_version(vo_id, tree).await {
-            Ok(v) => Ok(v),
-            // A specific version miss is `object_version_does_not_exist`.
-            Err(ServiceError::NotFound(m)) => {
-                Err(SmError::new(CallStatusType::ObjectVersionDoesNotExist, m))
-            }
-            Err(e) => Err(e.into()),
-        }
+        // The version-addressed read carries `object_version_does_not_exist`
+        // itself (`ServiceError` round-trips the granular status losslessly).
+        Ok(self.party_version(vo_id, tree).await?)
     }
 
     /// `update_party` (`i_party.adoc`): commit a new version of an existing
@@ -392,8 +387,12 @@ impl EhrbaseService {
         let meta = current.as_ref().map(CurrentParty::resource_meta);
         ensure_full_ovid_if_match(Some(&if_match), meta.as_ref())?;
         let expected = expected_from_if_match(&if_match)?;
-        let current =
-            current.ok_or_else(|| ServiceError::NotFound(format!("{} {vo_id}", kind.rm_type())))?;
+        let current = current.ok_or_else(|| {
+            ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!("{} {vo_id}", kind.rm_type()),
+            )
+        })?;
         Ok(self
             .commit_party_update(current, body, expected, update_audit.as_ref())
             .await?)
@@ -434,8 +433,12 @@ impl EhrbaseService {
             Some(raw) => expected_from_if_match(raw)?.or(path_version),
             None => path_version,
         };
-        let current =
-            current.ok_or_else(|| ServiceError::NotFound(format!("{} {vo_id}", kind.rm_type())))?;
+        let current = current.ok_or_else(|| {
+            ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!("{} {vo_id}", kind.rm_type()),
+            )
+        })?;
         Ok(self
             .commit_party_delete(current, expected, update_audit.as_ref())
             .await?)
@@ -749,13 +752,9 @@ impl EhrbaseService {
         a_party_rel_version_id: String,
     ) -> Result<Value, SmError> {
         let (vo_id, tree) = parse_version_uid(&a_party_rel_version_id)?;
-        match self.relationship_version(vo_id, tree).await {
-            Ok(v) => Ok(v),
-            Err(ServiceError::NotFound(m)) => {
-                Err(SmError::new(CallStatusType::ObjectVersionDoesNotExist, m))
-            }
-            Err(e) => Err(e.into()),
-        }
+        // The version-addressed read carries `object_version_does_not_exist`
+        // itself (`ServiceError` round-trips the granular status losslessly).
+        Ok(self.relationship_version(vo_id, tree).await?)
     }
 
     /// `update_party_relationship` (`i_party_relationship.adoc`): commit a new
@@ -881,8 +880,12 @@ impl EhrbaseService {
         let meta = current.as_ref().map(CurrentRelationship::resource_meta);
         ensure_full_ovid_if_match(Some(&if_match), meta.as_ref())?;
         let expected = expected_from_if_match(&if_match)?;
-        let current =
-            current.ok_or_else(|| ServiceError::NotFound(format!("PARTY_RELATIONSHIP {vo_id}")))?;
+        let current = current.ok_or_else(|| {
+            ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!("PARTY_RELATIONSHIP {vo_id}"),
+            )
+        })?;
         Ok(self
             .commit_relationship_update(current, body, expected, update_audit.as_ref())
             .await?)
@@ -920,8 +923,12 @@ impl EhrbaseService {
             Some(raw) => expected_from_if_match(raw)?.or(path_version),
             None => path_version,
         };
-        let current =
-            current.ok_or_else(|| ServiceError::NotFound(format!("PARTY_RELATIONSHIP {vo_id}")))?;
+        let current = current.ok_or_else(|| {
+            ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!("PARTY_RELATIONSHIP {vo_id}"),
+            )
+        })?;
         Ok(self
             .commit_relationship_delete(current, expected, update_audit.as_ref())
             .await?)

--- a/app/ehrbase/src/service/demographic/contribution.rs
+++ b/app/ehrbase/src/service/demographic/contribution.rs
@@ -21,6 +21,7 @@ use uuid::Uuid;
 use crate::service::EhrbaseService;
 use crate::service::error::ServiceError;
 use crate::service::response::{ResourceMeta, ServiceResponse};
+use crate::service::status::CallStatusType;
 use crate::storage::version_repo;
 use crate::versioning::audit::audit_details;
 use crate::versioning::contribution::commit_version_set;
@@ -52,7 +53,10 @@ impl EhrbaseService {
             version_repo::contribution::contribution_audit(&self.pool, contribution_id, None)
                 .await?
                 .ok_or_else(|| {
-                    ServiceError::NotFound(format!("demographic CONTRIBUTION {contribution_id}"))
+                    ServiceError::sm(
+                        CallStatusType::ContributionDoesNotExist,
+                        format!("demographic CONTRIBUTION {contribution_id}"),
+                    )
                 })?;
 
         // The refs helper also unions the versions this contribution's

--- a/app/ehrbase/src/service/demographic/party.rs
+++ b/app/ehrbase/src/service/demographic/party.rs
@@ -16,6 +16,7 @@ use crate::service::demographic::types::PartyKind;
 use crate::service::demographic::validate::validate_party_body;
 use crate::service::error::ServiceError;
 use crate::service::response::{ResourceMeta, ServiceResponse};
+use crate::service::status::CallStatusType;
 use crate::service::version_update::UpdateAudit;
 use crate::versioning::CommitEnv;
 use crate::versioning::audit::change_type;
@@ -65,17 +66,28 @@ impl EhrbaseService {
         version: Option<TreeId>,
         at: Option<jiff::Timestamp>,
     ) -> Result<VersionRead, ServiceError> {
+        // The granular SM status: a version-addressed read that misses is
+        // `object_version_does_not_exist`, a current read is the generic
+        // `versioned_object_does_not_exist` (`i_party.adoc` declares exactly
+        // these per call).
+        let miss = || {
+            ServiceError::sm(
+                if version.is_some() || at.is_some() {
+                    CallStatusType::ObjectVersionDoesNotExist
+                } else {
+                    CallStatusType::VersionedObjectDoesNotExist
+                },
+                format!("{} {vo_id}", kind.rm_type()),
+            )
+        };
         // The stored kind (constant per versioned object) must match the route.
         let stored = object_kind(&self.pool, vo_id).await?;
         if stored != Some(support::kind_of(kind)) {
-            return Err(ServiceError::NotFound(format!(
-                "{} {vo_id}",
-                kind.rm_type()
-            )));
+            return Err(miss());
         }
         support::load_ehrless(&self.pool, vo_id, version, at)
             .await?
-            .ok_or_else(|| ServiceError::NotFound(format!("{} {vo_id}", kind.rm_type())))
+            .ok_or_else(miss)
     }
 
     /// Confirm a live party of the expected kind exists (not deleted) — the
@@ -87,10 +99,10 @@ impl EhrbaseService {
     ) -> Result<(), ServiceError> {
         let read = self.load_party_version(kind, vo_id, None, None).await?;
         if read.deleted() {
-            return Err(ServiceError::NotFound(format!(
-                "{} {vo_id} is deleted",
-                kind.rm_type()
-            )));
+            return Err(ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!("{} {vo_id} is deleted", kind.rm_type()),
+            ));
         }
         Ok(())
     }
@@ -103,16 +115,28 @@ impl EhrbaseService {
         object_kind(&self.pool, vo_id)
             .await?
             .and_then(support::party_kind_of)
-            .ok_or_else(|| ServiceError::NotFound(format!("versioned party {vo_id}")))
+            .ok_or_else(|| {
+                ServiceError::sm(
+                    CallStatusType::VersionedObjectDoesNotExist,
+                    format!("versioned party {vo_id}"),
+                )
+            })
     }
 
     /// Confirm `vo_id` is some party (any of the five kinds) — the check for the
     /// kind-agnostic `versioned_party` reads. A non-party id (COMPOSITION, …) or
-    /// unknown id is `404` (`versioned_object_does_not_exist`).
-    pub(super) async fn ensure_any_party(&self, vo_id: VoId) -> Result<(), ServiceError> {
+    /// unknown id is `404`, reported with the caller-supplied granular SM
+    /// status (`versioned_object_does_not_exist` for object-addressed reads,
+    /// `object_version_does_not_exist` for version-addressed ones —
+    /// `i_party.adoc` declares exactly those per call).
+    pub(super) async fn ensure_any_party(
+        &self,
+        vo_id: VoId,
+        miss: CallStatusType,
+    ) -> Result<(), ServiceError> {
         match object_kind(&self.pool, vo_id).await? {
             Some(k) if k.is_party() => Ok(()),
-            _ => Err(ServiceError::NotFound(format!("versioned party {vo_id}"))),
+            _ => Err(ServiceError::sm(miss, format!("versioned party {vo_id}"))),
         }
     }
 
@@ -228,10 +252,12 @@ impl EhrbaseService {
         expected: Option<TreeId>,
         update_audit: Option<&UpdateAudit>,
     ) -> Result<ServiceResponse, ServiceError> {
-        let current = self
-            .party_current(kind, vo_id)
-            .await?
-            .ok_or_else(|| ServiceError::NotFound(format!("{} {vo_id}", kind.rm_type())))?;
+        let current = self.party_current(kind, vo_id).await?.ok_or_else(|| {
+            ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!("{} {vo_id}", kind.rm_type()),
+            )
+        })?;
         self.commit_party_update(current, body, expected, update_audit)
             .await
     }
@@ -250,11 +276,10 @@ impl EhrbaseService {
     ) -> Result<ServiceResponse, ServiceError> {
         let kind = current.kind;
         if current.deleted {
-            return Err(ServiceError::NotFound(format!(
-                "{} {} is deleted",
-                kind.rm_type(),
-                current.vo_id
-            )));
+            return Err(ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!("{} {} is deleted", kind.rm_type(), current.vo_id),
+            ));
         }
         validate_party_body(kind, &body)?;
 
@@ -303,10 +328,12 @@ impl EhrbaseService {
         expected: Option<TreeId>,
         update_audit: Option<&UpdateAudit>,
     ) -> Result<ServiceResponse, ServiceError> {
-        let current = self
-            .party_current(kind, vo_id)
-            .await?
-            .ok_or_else(|| ServiceError::NotFound(format!("{} {vo_id}", kind.rm_type())))?;
+        let current = self.party_current(kind, vo_id).await?.ok_or_else(|| {
+            ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!("{} {vo_id}", kind.rm_type()),
+            )
+        })?;
         self.commit_party_delete(current, expected, update_audit)
             .await
     }

--- a/app/ehrbase/src/service/demographic/relationship.rs
+++ b/app/ehrbase/src/service/demographic/relationship.rs
@@ -27,6 +27,7 @@ use crate::service::demographic::support;
 use crate::service::demographic::validate::validate_relationship_body;
 use crate::service::error::ServiceError;
 use crate::service::response::{ResourceMeta, ServiceResponse};
+use crate::service::status::CallStatusType;
 use crate::service::version_update::UpdateAudit;
 use crate::versioning::audit::change_type;
 use crate::versioning::change::WriteEnvelope;
@@ -72,24 +73,45 @@ impl EhrbaseService {
         version: Option<TreeId>,
         at: Option<jiff::Timestamp>,
     ) -> Result<VersionRead, ServiceError> {
+        // The granular SM status: a version-addressed read that misses is
+        // `object_version_does_not_exist`, a current read the generic
+        // `versioned_object_does_not_exist` (`i_party_relationship.adoc`
+        // mirrors `i_party.adoc` here).
+        let miss = || {
+            ServiceError::sm(
+                if version.is_some() || at.is_some() {
+                    CallStatusType::ObjectVersionDoesNotExist
+                } else {
+                    CallStatusType::VersionedObjectDoesNotExist
+                },
+                format!("PARTY_RELATIONSHIP {vo_id}"),
+            )
+        };
         if object_kind(&self.pool, vo_id).await? != Some(Kind::PartyRelationship) {
-            return Err(ServiceError::NotFound(format!(
-                "PARTY_RELATIONSHIP {vo_id}"
-            )));
+            return Err(miss());
         }
         support::load_ehrless(&self.pool, vo_id, version, at)
             .await?
-            .ok_or_else(|| ServiceError::NotFound(format!("PARTY_RELATIONSHIP {vo_id}")))
+            .ok_or_else(miss)
     }
 
     /// Confirm `vo_id` is a relationship (any version) — the check for the
-    /// `versioned_party_relationship` reads. A non-relationship id is `404`.
-    async fn ensure_any_relationship(&self, vo_id: VoId) -> Result<(), ServiceError> {
+    /// `versioned_party_relationship` reads. A non-relationship id is `404`,
+    /// reported with the caller-supplied granular SM status
+    /// (`versioned_object_does_not_exist` for object-addressed reads,
+    /// `object_version_does_not_exist` for version-addressed ones —
+    /// `i_party_relationship.adoc` mirrors `i_party.adoc` here).
+    async fn ensure_any_relationship(
+        &self,
+        vo_id: VoId,
+        miss: CallStatusType,
+    ) -> Result<(), ServiceError> {
         match object_kind(&self.pool, vo_id).await? {
             Some(Kind::PartyRelationship) => Ok(()),
-            _ => Err(ServiceError::NotFound(format!(
-                "versioned party relationship {vo_id}"
-            ))),
+            _ => Err(ServiceError::sm(
+                miss,
+                format!("versioned party relationship {vo_id}"),
+            )),
         }
     }
 
@@ -198,10 +220,12 @@ impl EhrbaseService {
         expected: Option<TreeId>,
         update_audit: Option<&UpdateAudit>,
     ) -> Result<ServiceResponse, ServiceError> {
-        let current = self
-            .relationship_current(vo_id)
-            .await?
-            .ok_or_else(|| ServiceError::NotFound(format!("PARTY_RELATIONSHIP {vo_id}")))?;
+        let current = self.relationship_current(vo_id).await?.ok_or_else(|| {
+            ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!("PARTY_RELATIONSHIP {vo_id}"),
+            )
+        })?;
         self.commit_relationship_update(current, body, expected, update_audit)
             .await
     }
@@ -217,10 +241,10 @@ impl EhrbaseService {
         update_audit: Option<&UpdateAudit>,
     ) -> Result<ServiceResponse, ServiceError> {
         if current.deleted {
-            return Err(ServiceError::NotFound(format!(
-                "PARTY_RELATIONSHIP {} is deleted",
-                current.vo_id
-            )));
+            return Err(ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!("PARTY_RELATIONSHIP {} is deleted", current.vo_id),
+            ));
         }
         validate_relationship_body(&body)?;
 
@@ -317,7 +341,8 @@ impl EhrbaseService {
     /// analogy with the EHR group (assembly + owner NOTE in
     /// `support::versioned_wrapper`).
     pub(super) async fn versioned_relationship(&self, vo_id: VoId) -> Result<Value, ServiceError> {
-        self.ensure_any_relationship(vo_id).await?;
+        self.ensure_any_relationship(vo_id, CallStatusType::VersionedObjectDoesNotExist)
+            .await?;
         self.versioned_wrapper(
             vo_id,
             "VERSIONED_OBJECT",
@@ -334,7 +359,8 @@ impl EhrbaseService {
         &self,
         vo_id: VoId,
     ) -> Result<Value, ServiceError> {
-        self.ensure_any_relationship(vo_id).await?;
+        self.ensure_any_relationship(vo_id, CallStatusType::VersionedObjectDoesNotExist)
+            .await?;
         self.demographic_revision_history(vo_id).await
     }
 
@@ -345,7 +371,10 @@ impl EhrbaseService {
         vo_id: VoId,
         version: TreeId,
     ) -> Result<Value, ServiceError> {
-        self.ensure_any_relationship(vo_id).await?;
+        // Version-addressed: `object_version_does_not_exist` is the declared
+        // does-not-exist code (`i_party_relationship.adoc`, as `i_party.adoc`).
+        self.ensure_any_relationship(vo_id, CallStatusType::ObjectVersionDoesNotExist)
+            .await?;
         self.demographic_original_version(vo_id, version, "party relationship")
             .await
     }
@@ -357,7 +386,8 @@ impl EhrbaseService {
         vo_id: VoId,
         at: Option<jiff::Timestamp>,
     ) -> Result<ServiceResponse, ServiceError> {
-        self.ensure_any_relationship(vo_id).await?;
+        self.ensure_any_relationship(vo_id, CallStatusType::VersionedObjectDoesNotExist)
+            .await?;
         self.demographic_original_version_at(vo_id, at, "party relationship")
             .await
     }

--- a/app/ehrbase/src/service/demographic/support.rs
+++ b/app/ehrbase/src/service/demographic/support.rs
@@ -19,6 +19,7 @@ use crate::service::EhrbaseService;
 use crate::service::demographic::types::PartyKind;
 use crate::service::error::ServiceError;
 use crate::service::response::{ResourceMeta, ServiceResponse};
+use crate::service::status::CallStatusType;
 use crate::service::version_update::UpdateAudit;
 use crate::storage::version_repo;
 use crate::versioning::audit::{AuditInput, audit_details};
@@ -221,7 +222,12 @@ impl EhrbaseService {
     ) -> Result<Value, ServiceError> {
         let time_created = version_repo::meta::time_created(&self.pool, vo_id)
             .await?
-            .ok_or_else(|| ServiceError::NotFound(format!("{label} {vo_id}")))?;
+            .ok_or_else(|| {
+                ServiceError::sm(
+                    CallStatusType::VersionedObjectDoesNotExist,
+                    format!("{label} {vo_id}"),
+                )
+            })?;
         Ok(json!({
             "_type": type_name,
             "uid": { "_type": "HIER_OBJECT_ID", "value": vo_id.to_string() },
@@ -271,7 +277,12 @@ impl EhrbaseService {
     ) -> Result<Value, ServiceError> {
         let read = load_ehrless(&self.pool, vo_id, Some(version), None)
             .await?
-            .ok_or_else(|| ServiceError::NotFound(format!("{label} {vo_id} v{version}")))?;
+            .ok_or_else(|| {
+                ServiceError::sm(
+                    CallStatusType::ObjectVersionDoesNotExist,
+                    format!("{label} {vo_id} v{version}"),
+                )
+            })?;
         let signer = CommitEnv::signing_ctx(self).signer;
         original_version(&read, signer)
     }
@@ -293,7 +304,12 @@ impl EhrbaseService {
     ) -> Result<ServiceResponse, ServiceError> {
         let read = load_ehrless(&self.pool, vo_id, None, at)
             .await?
-            .ok_or_else(|| ServiceError::NotFound(format!("{label} {vo_id} version at time")))?;
+            .ok_or_else(|| {
+                ServiceError::sm(
+                    CallStatusType::ObjectVersionDoesNotExist,
+                    format!("{label} {vo_id} version at time"),
+                )
+            })?;
         let meta = ResourceMeta::new(
             String::new(),
             object_version_id(vo_id, &read.creating_system_id, read.tree),

--- a/app/ehrbase/src/service/demographic/tags.rs
+++ b/app/ehrbase/src/service/demographic/tags.rs
@@ -14,6 +14,7 @@ use crate::ids::VoId;
 use crate::service::EhrbaseService;
 use crate::service::demographic::types::PartyKind;
 use crate::service::error::ServiceError;
+use crate::service::status::CallStatusType;
 use crate::storage::tag_repo;
 
 impl EhrbaseService {
@@ -98,7 +99,10 @@ impl EhrbaseService {
         key: &str,
     ) -> Result<(), ServiceError> {
         if !tag_repo::delete_tag(&self.pool, None, vo_id, key).await? {
-            return Err(ServiceError::NotFound(format!("item tag {key:?}")));
+            return Err(ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!("item tag {key:?}"),
+            ));
         }
         Ok(())
     }

--- a/app/ehrbase/src/service/demographic/versioned.rs
+++ b/app/ehrbase/src/service/demographic/versioned.rs
@@ -15,6 +15,7 @@ use crate::ids::VoId;
 use crate::service::EhrbaseService;
 use crate::service::error::ServiceError;
 use crate::service::response::ServiceResponse;
+use crate::service::status::CallStatusType;
 use crate::versioning::object_version_id::TreeId;
 
 impl EhrbaseService {
@@ -23,7 +24,8 @@ impl EhrbaseService {
     /// (for a locally-created party, v1); the `owner_id` NOTE lives in
     /// `support::versioned_wrapper`.
     pub(super) async fn versioned_party(&self, vo_id: VoId) -> Result<Value, ServiceError> {
-        self.ensure_any_party(vo_id).await?;
+        self.ensure_any_party(vo_id, CallStatusType::VersionedObjectDoesNotExist)
+            .await?;
         self.versioned_wrapper(vo_id, "VERSIONED_PARTY", "PARTY", "versioned party")
             .await
     }
@@ -32,7 +34,8 @@ impl EhrbaseService {
     /// `OBJECT_VERSION_ID` and the change's `AUDIT_DETAILS` (RM common master04
     /// §Revision History). A non-party id is `404`.
     pub(super) async fn party_revision_history(&self, vo_id: VoId) -> Result<Value, ServiceError> {
-        self.ensure_any_party(vo_id).await?;
+        self.ensure_any_party(vo_id, CallStatusType::VersionedObjectDoesNotExist)
+            .await?;
         self.demographic_revision_history(vo_id).await
     }
 
@@ -43,7 +46,10 @@ impl EhrbaseService {
         vo_id: VoId,
         version: TreeId,
     ) -> Result<Value, ServiceError> {
-        self.ensure_any_party(vo_id).await?;
+        // Version-addressed: `i_party.adoc` `get_party_at_version` declares
+        // `object_version_does_not_exist` as its only does-not-exist code.
+        self.ensure_any_party(vo_id, CallStatusType::ObjectVersionDoesNotExist)
+            .await?;
         self.demographic_original_version(vo_id, version, "party")
             .await
     }
@@ -55,7 +61,8 @@ impl EhrbaseService {
         vo_id: VoId,
         at: Option<jiff::Timestamp>,
     ) -> Result<ServiceResponse, ServiceError> {
-        self.ensure_any_party(vo_id).await?;
+        self.ensure_any_party(vo_id, CallStatusType::VersionedObjectDoesNotExist)
+            .await?;
         self.demographic_original_version_at(vo_id, at, "party")
             .await
     }

--- a/app/ehrbase/src/service/ehr/composition.rs
+++ b/app/ehrbase/src/service/ehr/composition.rs
@@ -11,7 +11,7 @@
 
 use crate::ids::{EhrId, VoId};
 use crate::service::response::{ResourceMeta, ServiceResponse};
-use crate::service::status::SmError;
+use crate::service::status::{CallStatusType, SmError};
 use crate::service::version_update::UpdateVersion;
 use openehr_base::prelude::ObjectVersionId;
 use serde_json::Value;
@@ -109,7 +109,12 @@ impl EhrbaseService {
             None => read_current(&self.pool, vo_id).await?,
         }
         .filter(|r| r.ehr_id == Some(ehr_id))
-        .ok_or_else(|| ServiceError::NotFound(format!("COMPOSITION {vo_id}")))?;
+        .ok_or_else(|| {
+            ServiceError::sm(
+                CallStatusType::CompositionDoesNotExist,
+                format!("COMPOSITION {vo_id}"),
+            )
+        })?;
 
         if read.deleted() {
             return Ok(ServiceResponse::plain(Value::Null));
@@ -133,7 +138,12 @@ impl EhrbaseService {
         let read = version_at(&self.pool, vo_id, at)
             .await?
             .filter(|r| r.ehr_id == Some(ehr_id))
-            .ok_or_else(|| ServiceError::NotFound(format!("COMPOSITION {vo_id}")))?;
+            .ok_or_else(|| {
+                ServiceError::sm(
+                    CallStatusType::CompositionDoesNotExist,
+                    format!("COMPOSITION {vo_id}"),
+                )
+            })?;
         if read.deleted() {
             return Ok(ServiceResponse::plain(Value::Null));
         }
@@ -156,7 +166,12 @@ impl EhrbaseService {
         crate::storage::version_repo::meta::vo_owner(&self.pool, vo_id)
             .await?
             .filter(|owner| *owner == Some(ehr_id))
-            .ok_or_else(|| ServiceError::NotFound(format!("COMPOSITION {vo_id}")))?;
+            .ok_or_else(|| {
+                ServiceError::sm(
+                    CallStatusType::CompositionDoesNotExist,
+                    format!("COMPOSITION {vo_id}"),
+                )
+            })?;
         versioned_object(&self.pool, vo_id, ehr_id, "VERSIONED_COMPOSITION").await
     }
 
@@ -187,7 +202,12 @@ impl EhrbaseService {
         let read = read_version(&self.pool, vo_id, version)
             .await?
             .filter(|r| r.ehr_id == Some(ehr_id))
-            .ok_or_else(|| ServiceError::NotFound(format!("COMPOSITION {vo_id} v{version}")))?;
+            .ok_or_else(|| {
+                ServiceError::sm(
+                    CallStatusType::ObjectVersionDoesNotExist,
+                    format!("COMPOSITION {vo_id} v{version}"),
+                )
+            })?;
         original_version(&read, self.signer())
     }
 
@@ -210,7 +230,12 @@ impl EhrbaseService {
             None => read_current(&self.pool, vo_id).await?,
         }
         .filter(|r| r.ehr_id == Some(ehr_id))
-        .ok_or_else(|| ServiceError::NotFound(format!("COMPOSITION {vo_id} version at time")))?;
+        .ok_or_else(|| {
+            ServiceError::sm(
+                CallStatusType::ObjectVersionDoesNotExist,
+                format!("COMPOSITION {vo_id} version at time"),
+            )
+        })?;
         let meta = self.version_meta(
             ehr_id,
             vo_id,
@@ -253,7 +278,10 @@ impl EhrbaseService {
                 .await?
                 .filter(|m| m.ehr_id == Some(ehr_id))
         else {
-            return Err(ServiceError::NotFound(format!("COMPOSITION {vo_id}")));
+            return Err(ServiceError::sm(
+                CallStatusType::CompositionDoesNotExist,
+                format!("COMPOSITION {vo_id}"),
+            ));
         };
         // The full-`OBJECT_VERSION_ID` `If-Match` compare, built from
         // the same merged read (ITS-REST overview §Concurrency control).
@@ -286,9 +314,10 @@ impl EhrbaseService {
         // The lifecycle (deleted → 404, RM common master06 §Logical Deletion)
         // and the content-write guard are checked from the threaded pre-read.
         if current.lifecycle_state == crate::versioning::lifecycle::state::DELETED {
-            return Err(ServiceError::NotFound(format!(
-                "COMPOSITION {vo_id} is deleted"
-            )));
+            return Err(ServiceError::sm(
+                CallStatusType::CompositionDoesNotExist,
+                format!("COMPOSITION {vo_id} is deleted"),
+            ));
         }
         // is_modifiable = False forbids content writes (RM ehr master04 §EHR
         // Active Status) — folded from the standalone `ensure_content_writable`
@@ -434,7 +463,12 @@ impl EhrbaseService {
             crate::storage::version_repo::meta::current_composition_meta(&self.pool, vo_id)
                 .await?
                 .filter(|m| m.ehr_id == Some(ehr_id))
-                .ok_or_else(|| ServiceError::NotFound(format!("COMPOSITION {vo_id}")))?;
+                .ok_or_else(|| {
+                    ServiceError::sm(
+                        CallStatusType::CompositionDoesNotExist,
+                        format!("COMPOSITION {vo_id}"),
+                    )
+                })?;
         if current.lifecycle_state == crate::versioning::lifecycle::state::DELETED {
             return Err(ServiceError::BadRequest(format!(
                 "COMPOSITION {vo_id} is already deleted"
@@ -495,7 +529,10 @@ impl EhrbaseService {
         if crate::storage::version_repo::meta::ehr_exists(&self.pool, ehr_id).await? {
             Ok(())
         } else {
-            Err(ServiceError::NotFound(format!("EHR {ehr_id}")))
+            Err(ServiceError::sm(
+                CallStatusType::EhrIdDoesNotExist,
+                format!("EHR {ehr_id}"),
+            ))
         }
     }
 
@@ -519,7 +556,10 @@ impl EhrbaseService {
         let (exists, is_modifiable) =
             crate::storage::ehr_repo::ehr_writability(&self.pool, ehr_id).await?;
         if !exists {
-            return Err(ServiceError::NotFound(format!("EHR {ehr_id}")));
+            return Err(ServiceError::sm(
+                CallStatusType::EhrIdDoesNotExist,
+                format!("EHR {ehr_id}"),
+            ));
         }
         // `None` (no current EHR_STATUS) is treated as modifiable, so the guard
         // never spuriously blocks — identical to `ensure_content_writable`.

--- a/app/ehrbase/src/service/ehr/directory.rs
+++ b/app/ehrbase/src/service/ehr/directory.rs
@@ -20,7 +20,7 @@
 use crate::ids::{EhrId, VoId};
 use crate::service::response::ResourceMeta;
 use crate::service::response::ServiceResponse;
-use crate::service::status::SmError;
+use crate::service::status::{CallStatusType, SmError};
 use crate::service::version_update::UpdateVersion;
 use openehr_base::prelude::ObjectVersionId;
 use serde_json::Value;
@@ -118,7 +118,12 @@ impl EhrbaseService {
             None => read_current(&self.pool, vo_id).await?,
         }
         .filter(|r| r.ehr_id == Some(ehr_id))
-        .ok_or_else(|| ServiceError::NotFound(format!("directory for EHR {ehr_id}")))?;
+        .ok_or_else(|| {
+            ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!("directory for EHR {ehr_id}"),
+            )
+        })?;
         if read.deleted() {
             return Ok(ServiceResponse::plain(Value::Null));
         }
@@ -134,7 +139,12 @@ impl EhrbaseService {
             None => Ok(ServiceResponse::new(folder, meta)),
             Some(path) => select_subfolder(&folder, path)
                 .map(|sub| ServiceResponse::new(sub, meta))
-                .ok_or_else(|| ServiceError::NotFound(format!("folder path {path:?}"))),
+                .ok_or_else(|| {
+                    ServiceError::sm(
+                        CallStatusType::VersionedObjectDoesNotExist,
+                        format!("folder path {path:?}"),
+                    )
+                }),
         }
     }
 
@@ -158,14 +168,23 @@ impl EhrbaseService {
         let read = read_version(&self.pool, vo_id, version)
             .await?
             .filter(|r| r.ehr_id == Some(ehr_id))
-            .ok_or_else(|| ServiceError::NotFound(format!("directory {vo_id} v{version}")))?;
+            .ok_or_else(|| {
+                ServiceError::sm(
+                    CallStatusType::VersionDoesNotExist,
+                    format!("directory {vo_id} v{version}"),
+                )
+            })?;
         if read.deleted() {
             return Ok(ServiceResponse::plain(Value::Null));
         }
         let mut response = self.version_response(ehr_id, vo_id, read);
         if let Some(path) = path.map(str::trim).filter(|p| !p.is_empty() && *p != "/") {
-            response.body = select_subfolder(&response.body, path)
-                .ok_or_else(|| ServiceError::NotFound(format!("folder path {path:?}")))?;
+            response.body = select_subfolder(&response.body, path).ok_or_else(|| {
+                ServiceError::sm(
+                    CallStatusType::VersionedObjectDoesNotExist,
+                    format!("folder path {path:?}"),
+                )
+            })?;
         }
         Ok(response)
     }
@@ -375,9 +394,12 @@ impl EhrbaseService {
 
     /// The EHR's directory versioned-object id, or `NotFound`.
     async fn directory_vo(&self, ehr_id: EhrId) -> Result<VoId, ServiceError> {
-        self.directory_vo_opt(ehr_id)
-            .await?
-            .ok_or_else(|| ServiceError::NotFound(format!("directory for EHR {ehr_id}")))
+        self.directory_vo_opt(ehr_id).await?.ok_or_else(|| {
+            ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!("directory for EHR {ehr_id}"),
+            )
+        })
     }
 }
 
@@ -483,7 +505,11 @@ impl EhrbaseService {
         // write so neither the slot JOIN nor the writability probe is re-run.
         let Some((vo_id, is_modifiable, latest)) = self.directory_meta_with_vo(an_ehr_id).await?
         else {
-            return Err(ServiceError::NotFound(format!("directory for EHR {an_ehr_id}")).into());
+            return Err(ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!("directory for EHR {an_ehr_id}"),
+            )
+            .into());
         };
         ensure_if_match(a_dir_struct.preceding_version_uid.as_ref(), Some(&latest))?;
         let expected = a_dir_struct
@@ -512,7 +538,11 @@ impl EhrbaseService {
     ) -> Result<(), SmError> {
         let Some((vo_id, is_modifiable, latest)) = self.directory_meta_with_vo(an_ehr_id).await?
         else {
-            return Err(ServiceError::NotFound(format!("directory for EHR {an_ehr_id}")).into());
+            return Err(ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!("directory for EHR {an_ehr_id}"),
+            )
+            .into());
         };
         ensure_if_match(preceding_version_uid.as_ref(), Some(&latest))?;
         let expected = preceding_version_uid

--- a/app/ehrbase/src/service/ehr/service.rs
+++ b/app/ehrbase/src/service/ehr/service.rs
@@ -12,7 +12,7 @@ use crate::ids::EhrId;
 use crate::service::ehr::handle::EhrSummary;
 use crate::service::ehr_index::types::SubjectRef;
 use crate::service::response::{ResourceMeta, ServiceResponse};
-use crate::service::status::SmError;
+use crate::service::status::{CallStatusType, SmError};
 use serde_json::{Value, json};
 use uuid::Uuid;
 
@@ -217,7 +217,10 @@ impl EhrbaseService {
         let ehr_id = crate::storage::ehr_repo::ehr_id_by_subject(&self.pool, subject_id, namespace)
             .await?
             .ok_or_else(|| {
-                ServiceError::NotFound(format!("EHR for subject {subject_id}@{namespace}"))
+                ServiceError::sm(
+                    CallStatusType::EhrIdDoesNotExist,
+                    format!("EHR for subject {subject_id}@{namespace}"),
+                )
             })?;
         self.ehr_summary(ehr_id).await
     }
@@ -241,12 +244,17 @@ impl EhrbaseService {
         // Identity) — the stored per-EHR value, never the live config.
         let read = crate::storage::ehr_repo::ehr_summary_read(&self.pool, ehr_id)
             .await?
-            .ok_or_else(|| ServiceError::NotFound(format!("EHR {ehr_id}")))?;
+            .ok_or_else(|| {
+                ServiceError::sm(CallStatusType::EhrIdDoesNotExist, format!("EHR {ehr_id}"))
+            })?;
         let stored_system_id = read.system_id;
         let time_created = read.time_created;
-        let status = read
-            .status
-            .ok_or_else(|| ServiceError::NotFound(format!("EHR_STATUS for EHR {ehr_id}")))?;
+        let status = read.status.ok_or_else(|| {
+            ServiceError::sm(
+                CallStatusType::EhrIdDoesNotExist,
+                format!("EHR_STATUS for EHR {ehr_id}"),
+            )
+        })?;
         let status_version = TreeId::from_columns(
             status.trunk_version,
             status.branch_number,
@@ -323,7 +331,9 @@ impl EhrbaseService {
         let (stored_system_id, time_created) =
             crate::storage::ehr_repo::ehr_header(&self.pool, ehr_id)
                 .await?
-                .ok_or_else(|| ServiceError::NotFound(format!("EHR {ehr_id}")))?;
+                .ok_or_else(|| {
+                    ServiceError::sm(CallStatusType::EhrIdDoesNotExist, format!("EHR {ehr_id}"))
+                })?;
 
         // Copy of EHR.ehr_status: the current EHR_STATUS (bare, with its uid).
         let ehr_status = self.status_at(ehr_id, None).await?.body;

--- a/app/ehrbase/src/service/ehr/status.rs
+++ b/app/ehrbase/src/service/ehr/status.rs
@@ -11,7 +11,7 @@
 
 use crate::ids::{EhrId, VoId};
 use crate::service::response::{ResourceMeta, ServiceResponse};
-use crate::service::status::SmError;
+use crate::service::status::{CallStatusType, SmError};
 use crate::service::version_update::UpdateVersion;
 use serde_json::Value;
 use sqlx::PgConnection;
@@ -42,12 +42,22 @@ impl EhrbaseService {
         let (vo_id, _) = self
             .current_vo(ehr_id, Kind::EhrStatus)
             .await?
-            .ok_or_else(|| ServiceError::NotFound(format!("EHR_STATUS for EHR {ehr_id}")))?;
+            .ok_or_else(|| {
+                ServiceError::sm(
+                    CallStatusType::EhrIdDoesNotExist,
+                    format!("EHR_STATUS for EHR {ehr_id}"),
+                )
+            })?;
         let read = match at {
             Some(at) => version_at(&self.pool, vo_id, at).await?,
             None => read_current(&self.pool, vo_id).await?,
         }
-        .ok_or_else(|| ServiceError::NotFound(format!("EHR_STATUS for EHR {ehr_id}")))?;
+        .ok_or_else(|| {
+            ServiceError::sm(
+                CallStatusType::EhrIdDoesNotExist,
+                format!("EHR_STATUS for EHR {ehr_id}"),
+            )
+        })?;
         Ok(self.version_response(ehr_id, vo_id, read))
     }
 
@@ -67,7 +77,12 @@ impl EhrbaseService {
         let read = read_version(&self.pool, vo_id, version)
             .await?
             .filter(|r| r.ehr_id == Some(ehr_id))
-            .ok_or_else(|| ServiceError::NotFound(format!("EHR_STATUS {vo_id} v{version}")))?;
+            .ok_or_else(|| {
+                ServiceError::sm(
+                    CallStatusType::ObjectVersionDoesNotExist,
+                    format!("EHR_STATUS {vo_id} v{version}"),
+                )
+            })?;
         Ok(self.version_response(ehr_id, vo_id, read))
     }
 
@@ -153,10 +168,18 @@ impl EhrbaseService {
         let (vo_id, _) = self
             .current_vo(ehr_id, Kind::EhrStatus)
             .await?
-            .ok_or_else(|| ServiceError::NotFound(format!("EHR_STATUS for EHR {ehr_id}")))?;
-        let read = read_current(&self.pool, vo_id)
-            .await?
-            .ok_or_else(|| ServiceError::NotFound(format!("EHR_STATUS for EHR {ehr_id}")))?;
+            .ok_or_else(|| {
+                ServiceError::sm(
+                    CallStatusType::EhrIdDoesNotExist,
+                    format!("EHR_STATUS for EHR {ehr_id}"),
+                )
+            })?;
+        let read = read_current(&self.pool, vo_id).await?.ok_or_else(|| {
+            ServiceError::sm(
+                CallStatusType::EhrIdDoesNotExist,
+                format!("EHR_STATUS for EHR {ehr_id}"),
+            )
+        })?;
         let current = self.version_response(ehr_id, vo_id, read);
         let preceding = current
             .meta
@@ -187,7 +210,12 @@ impl EhrbaseService {
         let (vo_id, _) = self
             .current_vo(ehr_id, Kind::EhrStatus)
             .await?
-            .ok_or_else(|| ServiceError::NotFound(format!("EHR_STATUS for EHR {ehr_id}")))?;
+            .ok_or_else(|| {
+                ServiceError::sm(
+                    CallStatusType::EhrIdDoesNotExist,
+                    format!("EHR_STATUS for EHR {ehr_id}"),
+                )
+            })?;
         versioned_object(&self.pool, vo_id, ehr_id, "VERSIONED_EHR_STATUS").await
     }
 
@@ -203,7 +231,12 @@ impl EhrbaseService {
         let (vo_id, _) = self
             .current_vo(ehr_id, Kind::EhrStatus)
             .await?
-            .ok_or_else(|| ServiceError::NotFound(format!("EHR_STATUS for EHR {ehr_id}")))?;
+            .ok_or_else(|| {
+                ServiceError::sm(
+                    CallStatusType::EhrIdDoesNotExist,
+                    format!("EHR_STATUS for EHR {ehr_id}"),
+                )
+            })?;
         revision_history(&self.pool, ehr_id, vo_id).await
     }
 
@@ -221,7 +254,12 @@ impl EhrbaseService {
         let read = read_version(&self.pool, vo_id, version)
             .await?
             .filter(|r| r.ehr_id == Some(ehr_id))
-            .ok_or_else(|| ServiceError::NotFound(format!("EHR_STATUS {vo_id} v{version}")))?;
+            .ok_or_else(|| {
+                ServiceError::sm(
+                    CallStatusType::ObjectVersionDoesNotExist,
+                    format!("EHR_STATUS {vo_id} v{version}"),
+                )
+            })?;
         original_version(&read, self.signer())
     }
 
@@ -240,13 +278,21 @@ impl EhrbaseService {
         let (vo_id, _) = self
             .current_vo(ehr_id, Kind::EhrStatus)
             .await?
-            .ok_or_else(|| ServiceError::NotFound(format!("EHR_STATUS for EHR {ehr_id}")))?;
+            .ok_or_else(|| {
+                ServiceError::sm(
+                    CallStatusType::EhrIdDoesNotExist,
+                    format!("EHR_STATUS for EHR {ehr_id}"),
+                )
+            })?;
         let read = match at {
             Some(at) => version_at(&self.pool, vo_id, at).await?,
             None => read_current(&self.pool, vo_id).await?,
         }
         .ok_or_else(|| {
-            ServiceError::NotFound(format!("EHR_STATUS version at time for EHR {ehr_id}"))
+            ServiceError::sm(
+                CallStatusType::ObjectVersionDoesNotExist,
+                format!("EHR_STATUS version at time for EHR {ehr_id}"),
+            )
         })?;
         let meta = self.version_meta(
             ehr_id,
@@ -631,7 +677,11 @@ impl EhrbaseService {
         // `current_vo`). No current EHR_STATUS ⇒ NotFound (404), the same
         // outcome the prior `current_vo`-inside-the-write path produced.
         let Some((vo_id, latest)) = self.ehr_status_meta_with_vo(an_ehr_id).await? else {
-            return Err(ServiceError::NotFound(format!("EHR_STATUS for EHR {an_ehr_id}")).into());
+            return Err(ServiceError::sm(
+                CallStatusType::EhrIdDoesNotExist,
+                format!("EHR_STATUS for EHR {an_ehr_id}"),
+            )
+            .into());
         };
         ensure_if_match(a_status.preceding_version_uid.as_ref(), Some(&latest))?;
         let if_match = a_status

--- a/app/ehrbase/src/service/ehr/tags.rs
+++ b/app/ehrbase/src/service/ehr/tags.rs
@@ -13,7 +13,7 @@
 //! (storage seam — our own design).
 
 use crate::ids::{EhrId, VoId};
-use crate::service::status::SmError;
+use crate::service::status::{CallStatusType, SmError};
 use serde_json::{Value, json};
 
 use crate::service::EhrbaseService;
@@ -90,10 +90,13 @@ impl EhrbaseService {
         // here.
         let owner = crate::storage::version_repo::meta::vo_owner(&self.pool, target_vo_id).await?;
         if owner != Some(Some(ehr_id)) {
-            return Err(ServiceError::NotFound(format!(
-                "tag target {target_vo_id} does not exist in EHR {ehr_id} \
-                 (tag targets can only be within the same EHR)"
-            )));
+            return Err(ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!(
+                    "tag target {target_vo_id} does not exist in EHR {ehr_id} \
+                     (tag targets can only be within the same EHR)"
+                ),
+            ));
         }
         // Validate every tag before writing; the `replace_tags` upsert arm
         // covers same-key repetition (last-wins) in the EHR scope.
@@ -147,7 +150,10 @@ impl EhrbaseService {
         if !crate::storage::tag_repo::delete_tag(&self.pool, Some(ehr_id), target_vo_id, key)
             .await?
         {
-            return Err(ServiceError::NotFound(format!("item tag {key:?}")));
+            return Err(ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!("item tag {key:?}"),
+            ));
         }
         Ok(())
     }

--- a/app/ehrbase/src/service/ehr/uri.rs
+++ b/app/ehrbase/src/service/ehr/uri.rs
@@ -27,6 +27,7 @@ use uuid::Uuid;
 use crate::ids::{EhrId, VoId};
 use crate::service::EhrbaseService;
 use crate::service::error::ServiceError;
+use crate::service::status::CallStatusType;
 use crate::versioning::Kind;
 use crate::versioning::object_version_id::{TreeId, components};
 use crate::versioning::read::{read_current, read_version};
@@ -48,9 +49,10 @@ impl EhrbaseService {
     pub async fn resolve_ehr_uri(&self, uri: &EhrUri) -> Result<Value, ServiceError> {
         let mut items = self.resolve_ehr_uri_items(uri).await?;
         match items.len() {
-            0 => Err(ServiceError::NotFound(format!(
-                "ehr: URI {uri} resolved to no item"
-            ))),
+            0 => Err(ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!("ehr: URI {uri} resolved to no item"),
+            )),
             1 => Ok(items.remove(0)),
             n => Err(ServiceError::BadRequest(format!(
                 "ehr: URI {uri} path is not unique ({n} matches); item_at_path requires \
@@ -74,11 +76,14 @@ impl EhrbaseService {
         if let Some(system) = &uri.system_id
             && !system.eq_ignore_ascii_case(&self.effective_system_id())
         {
-            return Err(ServiceError::NotFound(format!(
-                "ehr: URI names foreign system {system:?}; only the local system \
-                 ({}) is resolvable",
-                self.effective_system_id()
-            )));
+            return Err(ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!(
+                    "ehr: URI names foreign system {system:?}; only the local system \
+                     ({}) is resolvable",
+                    self.effective_system_id()
+                ),
+            ));
         }
         // A relative URI (no ehr_id) carries no EHR context to resolve against.
         let ehr_id = EhrId(uri.ehr_id.ok_or_else(|| {
@@ -128,7 +133,10 @@ impl EhrbaseService {
             let vo_id = match attribute.as_str() {
                 "directory" | "folders" => {
                     self.directory_vo_opt(ehr_id).await?.ok_or_else(|| {
-                        ServiceError::NotFound(format!("{attribute} for EHR {ehr_id}"))
+                        ServiceError::sm(
+                            CallStatusType::VersionedObjectDoesNotExist,
+                            format!("{attribute} for EHR {ehr_id}"),
+                        )
                     })?
                 }
                 "ehr_status" | "ehr_access" => {
@@ -140,7 +148,10 @@ impl EhrbaseService {
                     self.current_vo(ehr_id, kind)
                         .await?
                         .ok_or_else(|| {
-                            ServiceError::NotFound(format!("{attribute} for EHR {ehr_id}"))
+                            ServiceError::sm(
+                                CallStatusType::VersionedObjectDoesNotExist,
+                                format!("{attribute} for EHR {ehr_id}"),
+                            )
                         })?
                         .0
                 }
@@ -163,13 +174,17 @@ impl EhrbaseService {
         }
         .filter(|r| r.ehr_id == Some(ehr_id))
         .ok_or_else(|| {
-            ServiceError::NotFound(format!("versioned object {vo_id} in EHR {ehr_id}"))
+            ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!("versioned object {vo_id} in EHR {ehr_id}"),
+            )
         })?;
 
         if read.deleted() {
-            return Err(ServiceError::NotFound(format!(
-                "versioned object {vo_id} is deleted"
-            )));
+            return Err(ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!("versioned object {vo_id} is deleted"),
+            ));
         }
         Ok(self.version_response(ehr_id, vo_id, read).body)
     }

--- a/app/ehrbase/src/service/ehr_index/mod.rs
+++ b/app/ehrbase/src/service/ehr_index/mod.rs
@@ -194,8 +194,13 @@ mod tests {
         let subj_sm: SmError = IndexError::SubjectDoesNotExist(subject).into();
         assert_eq!(subj_sm.status, CallStatusType::SubjectIdDoesNotExist);
 
-        // A generic service fault still routes through the shared table (404).
-        let svc: SmError = IndexError::Service(ServiceError::NotFound("x".into())).into();
+        // A generic service miss still routes through the shared table (404),
+        // carrying the status it was constructed with.
+        let svc: SmError = IndexError::Service(ServiceError::sm(
+            CallStatusType::VersionedObjectDoesNotExist,
+            "x",
+        ))
+        .into();
         assert_eq!(svc.status, CallStatusType::VersionedObjectDoesNotExist);
     }
 

--- a/app/ehrbase/src/service/error.rs
+++ b/app/ehrbase/src/service/error.rs
@@ -16,9 +16,15 @@ use super::status::{CallStatusType, SmError};
 /// boundary so the REST layer stays free of persistence concerns.
 #[derive(Debug, thiserror::Error)]
 pub enum ServiceError {
-    /// The requested resource does not exist.
+    /// The requested resource does not exist. Carries the granular SM
+    /// does-not-exist status ([`CallStatusType`] `*_does_not_exist` family,
+    /// `master03-common_package.adoc` §Representing Call Status) so the
+    /// [`SmError`] conversion below restores it losslessly — construct via
+    /// [`ServiceError::sm`] naming the precise status; extension resources the
+    /// SM has no status for (tenants, event subscriptions, FHIR mappings, item
+    /// tags) use the generic `versioned_object_does_not_exist`.
     #[error("{0} not found")]
-    NotFound(String),
+    NotFound(SmError),
     /// The request is malformed at the semantic level (e.g. a stale/invalid
     /// `preceding_version_uid`, or an operation on an already-deleted object) —
     /// ITS-REST `400 Bad Request` (`400_already_deleted.yaml`).
@@ -79,6 +85,9 @@ impl ServiceError {
                 ServiceError::Internal(m)
             }
             S::PreconditionViolation | S::InvalidIdPattern => ServiceError::BadRequest(m),
+            // The does-not-exist family keeps its granular status inside the
+            // variant, so the `SmError` round-trip below is lossless — no
+            // per-method boundary re-raise needed.
             S::ObjectVersionDoesNotExist
             | S::VersionedObjectDoesNotExist
             | S::EhrIdDoesNotExist
@@ -89,7 +98,9 @@ impl ServiceError {
             | S::TemplateDoesNotExist
             | S::VersionDoesNotExist
             | S::SubjectIdDoesNotExist
-            | S::VersionedCompositionDoesNotExist => ServiceError::NotFound(m),
+            | S::VersionedCompositionDoesNotExist => {
+                ServiceError::NotFound(SmError::new(status, m))
+            }
             S::VersionMismatch => ServiceError::VersionConflict(m),
             S::EhrCreateFailDuplicateId
             | S::CompositionAlreadyExists
@@ -128,7 +139,7 @@ impl From<ServiceError> for SmError {
     ///
     /// | `ServiceError`            | `CallStatusType`             | HTTP |
     /// |---------------------------|------------------------------|------|
-    /// | `NotFound`                | `VersionedObjectDoesNotExist`| 404  |
+    /// | `NotFound`                | its carried granular status  | 404  |
     /// | `VersionConflict`         | `VersionMismatch`            | 412  |
     /// | `Conflict`                | `CompositionAlreadyExists`   | 409  |
     /// | `Unprocessable`           | `ContentInvalid`             | 422  |
@@ -137,10 +148,10 @@ impl From<ServiceError> for SmError {
     /// | `Storage`/`Database`      | classified: 409/503/500      |      |
     /// | `Json`/`Signing`/`Internal` | `Exception`                | 500  |
     ///
-    /// `NotFound` cannot recover the concrete resource kind, so it maps to the
-    /// generic `versioned_object_does_not_exist` (all 404s); a chapter that
-    /// knows the precise kind constructs its own `SmError` instead (e.g. the
-    /// EHR-index chapter's `IndexError`). `Conflict` maps to a representative
+    /// `NotFound` carries the granular does-not-exist [`SmError`] it was
+    /// constructed with ([`ServiceError::sm`]), so the round-trip restores the
+    /// precise status — `ehr_id_does_not_exist` stays `ehr_id_does_not_exist`,
+    /// never a resurrected generic. `Conflict` maps to a representative
     /// already-exists status (all 409s).
     ///
     /// NOTE (wire): the structured per-path violations of `ValidationFailed`
@@ -154,7 +165,9 @@ impl From<ServiceError> for SmError {
     fn from(e: ServiceError) -> Self {
         use super::status::CallStatusType as S;
         match e {
-            ServiceError::NotFound(m) => SmError::new(S::VersionedObjectDoesNotExist, m),
+            // Lossless: the granular does-not-exist status travels inside the
+            // variant (see `ServiceError::sm`).
+            ServiceError::NotFound(e) => e,
             ServiceError::VersionConflict(m) => SmError::new(S::VersionMismatch, m),
             ServiceError::Conflict(m) => SmError::new(S::CompositionAlreadyExists, m),
             ServiceError::Unprocessable(m) => SmError::new(S::ContentInvalid, m),
@@ -182,7 +195,9 @@ impl From<ServiceError> for SmError {
 impl From<ServiceError> for ApiError {
     fn from(e: ServiceError) -> Self {
         match e {
-            ServiceError::NotFound(m) => ApiError::NotFound(m),
+            // Every does-not-exist status is a wire 404; the message is the
+            // carried `SmError`'s text (unchanged from construction).
+            ServiceError::NotFound(e) => ApiError::NotFound(e.message),
             ServiceError::BadRequest(m) => ApiError::BadRequest(m),
             ServiceError::Conflict(m) => ApiError::Conflict(m),
             ServiceError::VersionConflict(m) => ApiError::PreconditionFailed(m),
@@ -280,6 +295,46 @@ mod tests {
         for (status, expected) in rows {
             let got = ApiError::from(ServiceError::sm(status, "m")).status();
             assert_eq!(got, expected, "row {} diverged", status.sm_name());
+        }
+    }
+
+    /// Every granular does-not-exist status must survive the
+    /// `ServiceError` round-trip verbatim — `ServiceError::sm(s, m)` back
+    /// through `From<ServiceError> for SmError` yields `s`, never a
+    /// resurrected generic `versioned_object_does_not_exist` (the #141-era
+    /// lossy seam). The SM models these as distinct `CALL_STATUS_TYPE`
+    /// codes (`master03-common_package.adoc` §Representing Call Status).
+    #[test]
+    fn does_not_exist_statuses_round_trip_losslessly() {
+        let granular = [
+            S::ObjectVersionDoesNotExist,
+            S::VersionedObjectDoesNotExist,
+            S::EhrIdDoesNotExist,
+            S::PartyIdDoesNotExist,
+            S::CompositionDoesNotExist,
+            S::ContributionDoesNotExist,
+            S::ArtefactDoesNotExist,
+            S::TemplateDoesNotExist,
+            S::VersionDoesNotExist,
+            S::SubjectIdDoesNotExist,
+            S::VersionedCompositionDoesNotExist,
+        ];
+        for status in granular {
+            let service_err = ServiceError::sm(status, "m");
+            assert!(
+                matches!(service_err, ServiceError::NotFound(_)),
+                "{} must classify as NotFound",
+                status.sm_name()
+            );
+            let restored = crate::service::status::SmError::from(service_err);
+            assert_eq!(
+                restored.status,
+                status,
+                "{} resurrected as {}",
+                status.sm_name(),
+                restored.status.sm_name()
+            );
+            assert_eq!(restored.message, "m", "message must survive unchanged");
         }
     }
 }

--- a/app/ehrbase/src/service/message/export.rs
+++ b/app/ehrbase/src/service/message/export.rs
@@ -355,7 +355,10 @@ impl EhrbaseService {
             let read = read_version_by_ordinal(&self.pool, vo_id, *sv)
                 .await?
                 .ok_or_else(|| {
-                    ServiceError::NotFound(format!("version {vo_id}::{sv} for extract"))
+                    ServiceError::sm(
+                        CallStatusType::ObjectVersionDoesNotExist,
+                        format!("version {vo_id}::{sv} for extract"),
+                    )
                 })?;
             let mut version = original_version(&read, self.signer())?;
             if !sel.include_multimedia {

--- a/app/ehrbase/src/service/message/tdd.rs
+++ b/app/ehrbase/src/service/message/tdd.rs
@@ -214,22 +214,12 @@ impl EhrbaseService {
         }
 
         // Precondition: the referenced operational template is provisioned. An
-        // unknown template_id is `template_does_not_exist` (this rejects the
-        // corpus `..__invalid_opt_doesnt_exist` TDD). A stored-but-unbuildable
-        // template surfaces through `web_template_for` as content_invalid.
-        match self.get_template_xml(&envelope.template_id).await {
-            Ok(_) => {}
-            Err(ServiceError::NotFound(_)) => {
-                return Err(SmError::new(
-                    CallStatusType::TemplateDoesNotExist,
-                    format!(
-                        "TDD references operational template {:?}, which is not provisioned",
-                        envelope.template_id
-                    ),
-                ));
-            }
-            Err(e) => return Err(e.into()),
-        }
+        // unknown template_id is `template_does_not_exist` — the template store
+        // names that status at construction and `ServiceError` round-trips it
+        // losslessly (this rejects the corpus `..__invalid_opt_doesnt_exist`
+        // TDD). A stored-but-unbuildable template surfaces through
+        // `web_template_for` as content_invalid.
+        let _stored_xml = self.get_template_xml(&envelope.template_id).await?;
         let web_template = self.web_template_for(&envelope.template_id).await?;
 
         // OPT-guided body → canonical COMPOSITION. A body that does not conform

--- a/app/ehrbase/src/templates/store.rs
+++ b/app/ehrbase/src/templates/store.rs
@@ -154,7 +154,12 @@ impl EhrbaseService {
         .bind(template_id)
         .fetch_optional(&self.pool)
         .await?
-        .ok_or_else(|| ServiceError::NotFound(format!("template {template_id}")))
+        .ok_or_else(|| {
+            ServiceError::sm(
+                crate::service::status::CallStatusType::TemplateDoesNotExist,
+                format!("template {template_id}"),
+            )
+        })
     }
 
     /// List every stored template's metadata descriptor (by `template_id`) —

--- a/app/ehrbase/src/versioning/attestation.rs
+++ b/app/ehrbase/src/versioning/attestation.rs
@@ -16,6 +16,7 @@ use uuid::Uuid;
 
 use crate::ids::{EhrId, VoId};
 use crate::service::error::ServiceError;
+use crate::service::status::CallStatusType;
 use crate::versioning::Kind;
 use crate::versioning::audit::{audit_details, change_type};
 use crate::versioning::change::Committed;
@@ -67,10 +68,10 @@ pub(crate) async fn attest(
     )
     .await?;
     let Some(target) = target.filter(|t| t.ehr_id == ehr_id) else {
-        return Err(ServiceError::NotFound(format!(
-            "{} version {vo_id}::{expected}",
-            kind.as_str()
-        )));
+        return Err(ServiceError::sm(
+            CallStatusType::ObjectVersionDoesNotExist,
+            format!("{} version {vo_id}::{expected}", kind.as_str()),
+        ));
     };
     crate::storage::version_repo::attestation::insert_attestation(
         tx,

--- a/app/ehrbase/src/versioning/change.rs
+++ b/app/ehrbase/src/versioning/change.rs
@@ -16,6 +16,7 @@ use uuid::Uuid;
 
 use crate::ids::{EhrId, VoId};
 use crate::service::error::ServiceError;
+use crate::service::status::CallStatusType;
 use crate::storage::codec::{decompose, reassemble};
 use crate::storage::row::NodeRow;
 use crate::versioning::attestation::{self, PendingAttest};
@@ -262,19 +263,19 @@ async fn next_version(
                 "expected version {tree}, which does not exist (current is {})",
                 current.tree
             ))),
-            _ => Err(ServiceError::NotFound(format!(
-                "{} {vo_id} in EHR {ehr_id:?}",
-                kind.as_str()
-            ))),
+            _ => Err(ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!("{} {vo_id} in EHR {ehr_id:?}", kind.as_str()),
+            )),
         };
     };
     // For an EHR-scoped object the stored owner must match; for a demographic
     // party both stored and expected owner are `None`, which compares equal.
     if tip.ehr_id != ehr_id || tip.kind != kind {
-        return Err(ServiceError::NotFound(format!(
-            "{} {vo_id} in EHR {ehr_id:?}",
-            kind.as_str()
-        )));
+        return Err(ServiceError::sm(
+            CallStatusType::VersionedObjectDoesNotExist,
+            format!("{} {vo_id} in EHR {ehr_id:?}", kind.as_str()),
+        ));
     }
     if !tip.open {
         return Err(ServiceError::VersionConflict(format!(

--- a/app/ehrbase/src/versioning/contribution.rs
+++ b/app/ehrbase/src/versioning/contribution.rs
@@ -16,6 +16,7 @@ use uuid::Uuid;
 use crate::ids::{EhrId, VoId};
 use crate::service::error::ServiceError;
 use crate::service::list::Page;
+use crate::service::status::CallStatusType;
 use crate::versioning::attestation::PendingAttest;
 use crate::versioning::audit::{
     AuditInput, audit_details, change_type, change_type_code, validate_commit_audit,
@@ -813,7 +814,12 @@ pub(crate) async fn get_contribution(
         Some(ehr_id),
     )
     .await?
-    .ok_or_else(|| ServiceError::NotFound(format!("CONTRIBUTION {contribution_id}")))?;
+    .ok_or_else(|| {
+        ServiceError::sm(
+            CallStatusType::ContributionDoesNotExist,
+            format!("CONTRIBUTION {contribution_id}"),
+        )
+    })?;
     let time_committed = audit.time_committed;
 
     // CONTRIBUTION.versions lists the affected VERSION objects (master06
@@ -832,7 +838,12 @@ pub(crate) async fn get_contribution(
         if resolve_refs {
             let loaded = read::read_version(pool, vo_id, tree)
                 .await?
-                .ok_or_else(|| ServiceError::NotFound(format!("VERSION {vo_id}::{tree}")))?;
+                .ok_or_else(|| {
+                    ServiceError::sm(
+                        CallStatusType::ObjectVersionDoesNotExist,
+                        format!("VERSION {vo_id}::{tree}"),
+                    )
+                })?;
             versions.push(original_version(&loaded, signer)?);
         } else {
             versions.push(json!({
@@ -914,7 +925,10 @@ async fn ensure_ehr_exists(pool: &sqlx::PgPool, ehr_id: EhrId) -> Result<(), Ser
     if crate::storage::version_repo::meta::ehr_exists(pool, ehr_id).await? {
         Ok(())
     } else {
-        Err(ServiceError::NotFound(format!("EHR {ehr_id}")))
+        Err(ServiceError::sm(
+            CallStatusType::EhrIdDoesNotExist,
+            format!("EHR {ehr_id}"),
+        ))
     }
 }
 

--- a/app/ehrbase/src/versioning/wire.rs
+++ b/app/ehrbase/src/versioning/wire.rs
@@ -15,6 +15,7 @@ use uuid::Uuid;
 
 use crate::ids::{EhrId, VoId};
 use crate::service::error::ServiceError;
+use crate::service::status::CallStatusType;
 use crate::versioning::audit::{AuditInput, OPENEHR, audit_details};
 use crate::versioning::integrity;
 use crate::versioning::lifecycle::lifecycle_rubric;
@@ -43,13 +44,17 @@ pub(crate) async fn revision_history(
     vo_id: VoId,
 ) -> Result<Value, ServiceError> {
     let rows = crate::storage::version_repo::meta::all_version_meta(pool, vo_id).await?;
-    let first = rows
-        .first()
-        .ok_or_else(|| ServiceError::NotFound(format!("versioned object {vo_id}")))?;
+    let first = rows.first().ok_or_else(|| {
+        ServiceError::sm(
+            CallStatusType::VersionedObjectDoesNotExist,
+            format!("versioned object {vo_id}"),
+        )
+    })?;
     if first.ehr_id != Some(ehr_id) {
-        return Err(ServiceError::NotFound(format!(
-            "versioned object {vo_id} in EHR {ehr_id}"
-        )));
+        return Err(ServiceError::sm(
+            CallStatusType::VersionedObjectDoesNotExist,
+            format!("versioned object {vo_id} in EHR {ehr_id}"),
+        ));
     }
 
     // Attestations for the object, keyed by version, in commit order.
@@ -115,7 +120,12 @@ pub(crate) async fn versioned_object(
 ) -> Result<Value, ServiceError> {
     let time_created = crate::storage::version_repo::meta::time_created(pool, vo_id)
         .await?
-        .ok_or_else(|| ServiceError::NotFound(format!("versioned object {vo_id}")))?;
+        .ok_or_else(|| {
+            ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!("versioned object {vo_id}"),
+            )
+        })?;
     Ok(json!({
         "_type": rm_type,
         "uid": { "_type": "HIER_OBJECT_ID", "value": vo_id.to_string() },

--- a/app/ehrbase/tests/service_admin.rs
+++ b/app/ehrbase/tests/service_admin.rs
@@ -232,18 +232,19 @@ async fn admin_delete_unknown_ehr_is_not_found() {
     let db = testkit::db().await.expect("testkit database");
     let svc = EhrbaseService::new(db.pool());
 
-    // `has_ehr` is false → `ehr_id_does_not_exist` → NotFound (→ HTTP 404).
+    // `has_ehr` is false → `ehr_id_does_not_exist` (→ HTTP 404), preserved
+    // through the ServiceError round-trip.
     let missing = Uuid::now_v7().to_string();
     let res = svc.admin_ehr_delete(missing).await;
     assert!(
         matches!(
             res,
             Err(SmError {
-                status: CallStatusType::VersionedObjectDoesNotExist,
+                status: CallStatusType::EhrIdDoesNotExist,
                 ..
             })
         ),
-        "unknown EHR must be NotFound, got {res:?}"
+        "unknown EHR must be ehr_id_does_not_exist, got {res:?}"
     );
 
     // A malformed id is a 400.
@@ -363,14 +364,12 @@ async fn template_rows(pool: &PgPool, template_id: &str) -> i64 {
         .expect("template count")
 }
 
-fn is_not_found(res: &Result<(), SmError>) -> bool {
-    matches!(
-        res,
-        Err(SmError {
-            status: CallStatusType::VersionedObjectDoesNotExist,
-            ..
-        })
-    )
+/// Whether the call failed with the expected granular does-not-exist status
+/// (a wire `404`; the `ServiceError` round-trip preserves the status the
+/// construction site named — `master03-common_package.adoc` §Representing
+/// Call Status).
+fn is_not_found(res: &Result<(), SmError>, status: CallStatusType) -> bool {
+    matches!(res, Err(SmError { status: got, .. }) if *got == status)
 }
 
 #[tokio::test]
@@ -385,8 +384,8 @@ async fn admin_template_delete_happy_unknown_and_referenced() {
         .admin_template_delete("no-such-template.v9".to_owned())
         .await;
     assert!(
-        is_not_found(&res),
-        "unknown template → NotFound, got {res:?}"
+        is_not_found(&res, CallStatusType::TemplateDoesNotExist),
+        "unknown template → template_does_not_exist, got {res:?}"
     );
 
     // Upload a template; it is deletable while unreferenced, case-insensitively.
@@ -463,8 +462,8 @@ async fn admin_query_delete_exact_version_and_unknown() {
         .admin_query_delete(name.to_owned(), "9.9.9".to_owned())
         .await;
     assert!(
-        is_not_found(&res),
-        "unknown version → NotFound, got {res:?}"
+        is_not_found(&res, CallStatusType::ArtefactDoesNotExist),
+        "unknown version → artefact_does_not_exist, got {res:?}"
     );
 
     // Exact-version delete succeeds (case-insensitive on the name); the row is
@@ -476,8 +475,8 @@ async fn admin_query_delete_exact_version_and_unknown() {
         .admin_query_delete(name.to_owned(), "1.0.0".to_owned())
         .await;
     assert!(
-        is_not_found(&again),
-        "already-deleted version → NotFound, got {again:?}"
+        is_not_found(&again, CallStatusType::ArtefactDoesNotExist),
+        "already-deleted version → artefact_does_not_exist, got {again:?}"
     );
 }
 
@@ -783,17 +782,18 @@ async fn physical_party_delete_cascades_relationships_and_spares_partner() {
     .expect("orphan audits after");
     assert_eq!(orphan_audits_after, 0, "no orphaned audits after cascade");
 
-    // An unknown party id → 404 (party_id_does_not_exist).
+    // An unknown party id → 404 (party_id_does_not_exist), preserved through
+    // the ServiceError round-trip.
     let unknown = svc.physical_party_delete(Uuid::now_v7().to_string()).await;
     assert!(
         matches!(
             unknown,
             Err(SmError {
-                status: CallStatusType::VersionedObjectDoesNotExist,
+                status: CallStatusType::PartyIdDoesNotExist,
                 ..
             })
         ),
-        "unknown party must be NotFound, got {unknown:?}"
+        "unknown party must be party_id_does_not_exist, got {unknown:?}"
     );
 
     // A malformed id → 400.
@@ -886,7 +886,7 @@ async fn archive_marks_vos_idempotently_and_reads_stay_unchanged() {
         matches!(
             res,
             Err(SmError {
-                status: CallStatusType::VersionedObjectDoesNotExist,
+                status: CallStatusType::EhrIdDoesNotExist,
                 ..
             })
         ),
@@ -898,12 +898,12 @@ async fn archive_marks_vos_idempotently_and_reads_stay_unchanged() {
         .expect("after");
     assert_eq!(before, after, "all-or-nothing: nothing archived on failure");
 
-    // Unknown party → 404.
+    // Unknown party → 404 (`party_id_does_not_exist`).
     let bad_party = svc.archive_parties(vec![Uuid::now_v7().to_string()]).await;
     assert!(matches!(
         bad_party,
         Err(SmError {
-            status: CallStatusType::VersionedObjectDoesNotExist,
+            status: CallStatusType::PartyIdDoesNotExist,
             ..
         })
     ));

--- a/app/ehrbase/tests/service_contribution.rs
+++ b/app/ehrbase/tests/service_contribution.rs
@@ -425,13 +425,14 @@ async fn contribution_listing_count_and_ehr_summary() {
     let db = testkit::db().await.expect("testkit database");
     let svc = EhrbaseService::new(db.pool());
 
-    // Unknown EHR → NotFound (SM ehr_does_not_exist) for every native call.
+    // Unknown EHR → NotFound (SM `ehr_id_does_not_exist`, carried granularly
+    // through the ServiceError round-trip) for every native call.
     let ghost = "00000000-0000-7000-8000-0000000000ff";
     assert!(matches!(
         svc.list_contributions(ghost.parse().expect("uuid"), None, Page::all())
             .await,
         Err(SmError {
-            status: CallStatusType::VersionedObjectDoesNotExist,
+            status: CallStatusType::EhrIdDoesNotExist,
             ..
         })
     ));
@@ -439,14 +440,14 @@ async fn contribution_listing_count_and_ehr_summary() {
         svc.contribution_count(ghost.parse().expect("uuid"), None)
             .await,
         Err(SmError {
-            status: CallStatusType::VersionedObjectDoesNotExist,
+            status: CallStatusType::EhrIdDoesNotExist,
             ..
         })
     ));
     assert!(matches!(
         svc.get_ehr(ghost.parse().expect("uuid")).await,
         Err(SmError {
-            status: CallStatusType::VersionedObjectDoesNotExist,
+            status: CallStatusType::EhrIdDoesNotExist,
             ..
         })
     ));
@@ -562,13 +563,14 @@ async fn ehr_contribution_list_page_extension() {
     let db = testkit::db().await.expect("testkit database");
     let svc = EhrbaseService::new(db.pool());
 
-    // Unknown EHR → NotFound (404), like the sibling EHR reads.
+    // Unknown EHR → NotFound (404, SM `ehr_id_does_not_exist`), like the
+    // sibling EHR reads.
     let ghost = "00000000-0000-7000-8000-0000000000ee";
     assert!(matches!(
         svc.ehr_contribution_list_page(ghost.parse().expect("uuid"), 0, 20)
             .await,
         Err(SmError {
-            status: CallStatusType::VersionedObjectDoesNotExist,
+            status: CallStatusType::EhrIdDoesNotExist,
             ..
         })
     ));
@@ -997,8 +999,8 @@ async fn contribution_supplied_uid() {
 /// The combined EHR-existence + content-writability create gate
 /// (`ensure_ehr_content_writable`) preserves the pre-fold error surface after
 /// the two separate pool reads were collapsed into one `ehr_writability` round
-/// trip: an unknown EHR still maps to `VersionedObjectDoesNotExist` (404, never
-/// a DB error or a conflict), and a deactivated EHR (`EHR_STATUS.is_modifiable =
+/// trip: an unknown EHR still maps to a `NotFound` (404, `ehr_id_does_not_exist`
+/// — never a DB error or a conflict), and a deactivated EHR (`EHR_STATUS.is_modifiable =
 /// false`) still maps to a conflict (409) — RM ehr master04 §EHR Creation /
 /// §EHR Active Status.
 #[tokio::test]
@@ -1006,7 +1008,7 @@ async fn create_composition_gate_error_surface_survives_the_writability_fold() {
     let db = testkit::db().await.expect("testkit database");
     let svc = EhrbaseService::new(db.pool());
 
-    // (1) Unknown EHR → 404 VersionedObjectDoesNotExist (the existence signal of
+    // (1) Unknown EHR → 404 `ehr_id_does_not_exist` (the existence signal of
     // the folded query), never a conflict and never a driver error.
     let ghost = "00000000-0000-7000-8000-0000000000fe"
         .parse::<ehrbase::ids::EhrId>()

--- a/app/ehrbase/tests/service_definition.rs
+++ b/app/ehrbase/tests/service_definition.rs
@@ -134,7 +134,7 @@ async fn archetype_errors() {
         matches!(
             missing,
             SmError {
-                status: CallStatusType::VersionedObjectDoesNotExist,
+                status: CallStatusType::ArtefactDoesNotExist,
                 ..
             }
         ),
@@ -148,7 +148,7 @@ async fn archetype_errors() {
         matches!(
             del_missing,
             SmError {
-                status: CallStatusType::VersionedObjectDoesNotExist,
+                status: CallStatusType::ArtefactDoesNotExist,
                 ..
             }
         ),
@@ -253,7 +253,7 @@ async fn adl14_convert_to_adl2_migration_round_trip() {
         matches!(
             missing,
             SmError {
-                status: CallStatusType::VersionedObjectDoesNotExist,
+                status: CallStatusType::ArtefactDoesNotExist,
                 ..
             }
         ),
@@ -509,7 +509,7 @@ async fn opt_errors() {
         matches!(
             get_missing,
             SmError {
-                status: CallStatusType::VersionedObjectDoesNotExist,
+                status: CallStatusType::TemplateDoesNotExist,
                 ..
             }
         ),
@@ -520,7 +520,7 @@ async fn opt_errors() {
         matches!(
             del_missing,
             SmError {
-                status: CallStatusType::VersionedObjectDoesNotExist,
+                status: CallStatusType::TemplateDoesNotExist,
                 ..
             }
         ),
@@ -702,7 +702,7 @@ async fn adl2_errors() {
         matches!(
             missing,
             SmError {
-                status: CallStatusType::VersionedObjectDoesNotExist,
+                status: CallStatusType::ArtefactDoesNotExist,
                 ..
             }
         ),
@@ -716,7 +716,7 @@ async fn adl2_errors() {
         matches!(
             del_missing,
             SmError {
-                status: CallStatusType::VersionedObjectDoesNotExist,
+                status: CallStatusType::ArtefactDoesNotExist,
                 ..
             }
         ),
@@ -840,7 +840,7 @@ async fn query_valid_store_list_match_delete() {
         matches!(
             del_missing,
             SmError {
-                status: CallStatusType::VersionedObjectDoesNotExist,
+                status: CallStatusType::ArtefactDoesNotExist,
                 ..
             }
         ),

--- a/app/ehrbase/tests/service_ehr.rs
+++ b/app/ehrbase/tests/service_ehr.rs
@@ -1356,7 +1356,7 @@ async fn version_get_at_time_returns_the_original_version() {
         matches!(
             too_early,
             Err(SmError {
-                status: CallStatusType::VersionedObjectDoesNotExist,
+                status: CallStatusType::ObjectVersionDoesNotExist,
                 ..
             })
         ),

--- a/app/ehrbase/tests/service_template.rs
+++ b/app/ehrbase/tests/service_template.rs
@@ -132,8 +132,9 @@ async fn get_unknown_template_is_not_found() {
     let svc = EhrbaseService::new(db.pool());
     // NOTE: `get_opt` is UUID-keyed at the SM seam, so an unknown
     // OPT is expressed as an absent (well-formed) uuid → 404
-    // (`versioned_object_does_not_exist`); the template_id → uuid resolution the
-    // old template_id-keyed GET did is now an adapter concern.
+    // (`template_does_not_exist`, `definition_call_status_type.adoc`); the
+    // template_id → uuid resolution the old template_id-keyed GET did is now
+    // an adapter concern.
     let err = svc
         .get_opt(uuid::Uuid::now_v7().to_string())
         .await
@@ -142,7 +143,7 @@ async fn get_unknown_template_is_not_found() {
         matches!(
             err,
             SmError {
-                status: CallStatusType::VersionedObjectDoesNotExist,
+                status: CallStatusType::TemplateDoesNotExist,
                 ..
             }
         ),
@@ -281,7 +282,7 @@ async fn example_for_unknown_template_is_not_found() {
         matches!(
             err,
             SmError {
-                status: CallStatusType::VersionedObjectDoesNotExist,
+                status: CallStatusType::TemplateDoesNotExist,
                 ..
             }
         ),

--- a/docs/conformance/ehrbase-rs/CONFORMANCE_CERTIFICATE.md
+++ b/docs/conformance/ehrbase-rs/CONFORMANCE_CERTIFICATE.md
@@ -5,19 +5,19 @@
 - **Assessor:** self-assessment via the ehrbase-rs Conformance Catalogue (ECC) framework
 - **This is NOT an official openEHR conformance certification.** No official openEHR certification program exists; this artefact is a self-assessment produced by an independent framework.
 - **Machine-computed:** every verdict below is a pure function of the attached run (`results.json`) — never hand-asserted.
-- **ECC framework version:** 3.4.0 · catalogue `inventory/ecc-catalog.tsv`
+- **ECC framework version:** 3.5.0 · catalogue `inventory/ecc-catalog.tsv`
 - **Machine record:** `results.json` (this directory)
-- **Run date:** 2026-07-20T22:15:20.205377Z
+- **Run date:** 2026-07-21T08:31:42.09722Z
 
 ## System Under Test (SUT)
 
 | | |
 |---|---|
-| Solution | ehrbase-rs ehrbase-rs 3.4.0 @ `http://localhost:8080/ehrbase/rest/openehr/v1` |
+| Solution | ehrbase-rs ehrbase-rs 3.5.0 @ `http://localhost:8080/ehrbase/rest/openehr/v1` |
 | Vendor | ehrbase-rs |
 | Assessor | self-assessment via the ehrbase-rs Conformance Catalogue (ECC) framework |
 | Infrastructure | reference corpus openEHR/specifications-CNF@33251d2a; SUT auth mode basic |
-| Date | 2026-07-20T22:15:20.205377Z |
+| Date | 2026-07-21T08:31:42.09722Z |
 
 ## Scope of Test
 

--- a/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
@@ -7,14 +7,14 @@
 
 | Field | Value |
 |---|---|
-| Product | ehrbase-rs ehrbase-rs 3.4.0 |
+| Product | ehrbase-rs ehrbase-rs 3.5.0 |
 | SUT class | ours (ehrbase-rs) |
 | Base URL | `http://localhost:8080/ehrbase/rest/openehr/v1` |
 | Auth mode | basic |
 | Edition policy | pinned (release-1.1.0) |
 | Spec versions | RM 1.2.0 · ITS-REST Release-1.1.0 · AQL 1.1.0 · TERM 3.1.0 |
 | Reference corpus | openEHR/specifications-CNF@33251d2a |
-| Run started | 2026-07-20T22:15:20.205377Z |
+| Run started | 2026-07-21T08:31:42.09722Z |
 
 **402 case×format executions · 384 passed · 0 failed · 0 errored · 0 skipped · 18 not applicable.**
 

--- a/docs/conformance/ehrbase-rs/CONFORMANCE_STATEMENT.md
+++ b/docs/conformance/ehrbase-rs/CONFORMANCE_STATEMENT.md
@@ -7,12 +7,12 @@
 
 | Field | Value |
 |---|---|
-| Product | ehrbase-rs ehrbase-rs 3.4.0 |
+| Product | ehrbase-rs ehrbase-rs 3.5.0 |
 | SUT class | ours (ehrbase-rs) |
 | Base URL | `http://localhost:8080/ehrbase/rest/openehr/v1` |
 | Auth mode | basic |
 | Edition policy | pinned (release-1.1.0) |
-| Run started | 2026-07-20T22:15:20.205377Z |
+| Run started | 2026-07-21T08:31:42.09722Z |
 | Reference corpus | openEHR/specifications-CNF@33251d2a |
 
 ## Supported specification versions

--- a/docs/conformance/ehrbase-rs/results.json
+++ b/docs/conformance/ehrbase-rs/results.json
@@ -3,7 +3,7 @@
     "base_url": "http://localhost:8080/ehrbase/rest/openehr/v1",
     "product": {
       "name": "ehrbase-rs",
-      "version": "ehrbase-rs 3.4.0"
+      "version": "ehrbase-rs 3.5.0"
     },
     "kind": "ours",
     "edition_policy": {
@@ -21,7 +21,7 @@
     "repo": "openEHR/specifications-CNF",
     "commit": "33251d2a"
   },
-  "started": "2026-07-20T22:15:20.205377Z",
+  "started": "2026-07-21T08:31:42.09722Z",
   "selection": {
     "filter": null,
     "profile": null,
@@ -90,7 +90,7 @@
       "citation": "CNF master06-func_tc_ehr §has_ehr; ITS-REST 1.1.0 EHR API ehr_get.yaml 200; RM 1.2.0 ehr §EHR",
       "schedule_ref": "I_EHR_SERVICE.has_ehr-existing_ehr_id (master06 §has_ehr)",
       "binding": "PUT /ehr/{ehr_id}; GET /ehr/{ehr_id}",
-      "duration_ms": 41
+      "duration_ms": 56
     },
     {
       "ecc_id": "ECC-EHR-002",
@@ -135,7 +135,7 @@
       "citation": "CNF master06-func_tc_ehr §has_ehr; ITS-REST 1.1.0 EHR API ehr_get_by_subject.yaml 404; RM 1.2.0 ehr §EHR",
       "schedule_ref": "I_EHR_SERVICE.has_ehr-non_existing_subject_id (master06 §has_ehr)",
       "binding": "GET /ehr?subject_id&subject_namespace",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "ecc_id": "ECC-EHR-005",
@@ -151,7 +151,7 @@
       "citation": "CNF master06-func_tc_ehr §create_ehr + §Test Data Sets class 1.a; ITS-REST 1.1.0 EHR API ehr_create.yaml/ehr_create_with_id.yaml 201; RM 1.2.0 ehr §EHR_STATUS",
       "schedule_ref": "I_EHR_SERVICE.create_ehr-main (master06 §create_ehr)",
       "binding": "POST /ehr; PUT /ehr/{ehr_id}",
-      "duration_ms": 94
+      "duration_ms": 64
     },
     {
       "ecc_id": "ECC-EHR-006",
@@ -166,7 +166,7 @@
       "citation": "CNF master06-func_tc_ehr §create_ehr; ITS-REST 1.1.0 EHR API ehr_create_with_id.yaml 409; RM 1.2.0 ehr §EHR",
       "schedule_ref": "I_EHR_SERVICE.create_ehr-same_ehr_twice (master06 §create_ehr)",
       "binding": "PUT /ehr/{ehr_id}",
-      "duration_ms": 2
+      "duration_ms": 1
     },
     {
       "ecc_id": "ECC-EHR-007",
@@ -181,7 +181,7 @@
       "citation": "CNF master06-func_tc_ehr §create_ehr; ITS-REST 1.1.0 EHR API ehr_create.yaml 409; RM 1.2.0 ehr §EHR (one EHR per subject)",
       "schedule_ref": "I_EHR_SERVICE.create_ehr-two_ehrs_same_patient (master06 §create_ehr)",
       "binding": "POST /ehr",
-      "duration_ms": 3
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-EHR-008",
@@ -196,7 +196,7 @@
       "citation": "CNF master06-func_tc_ehr §get_ehr; ITS-REST 1.1.0 EHR API ehr_get.yaml 200; RM 1.2.0 ehr §EHR",
       "schedule_ref": "I_EHR_SERVICE.get_ehr-existing_ehr_by_ehr_id (master06 §get_ehr)",
       "binding": "GET /ehr/{ehr_id}",
-      "duration_ms": 5
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-EHR-009",
@@ -211,7 +211,7 @@
       "citation": "CNF master06-func_tc_ehr §get_ehr; ITS-REST 1.1.0 EHR API ehr_get_by_subject.yaml 200; RM 1.2.0 ehr §EHR_STATUS subject identity",
       "schedule_ref": "I_EHR_SERVICE.get_ehr-existing_ehr_by_subject_id (master06 §get_ehr)",
       "binding": "GET /ehr?subject_id&subject_namespace",
-      "duration_ms": 7
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-EHR-010",
@@ -226,7 +226,7 @@
       "citation": "CNF master06-func_tc_ehr §get_ehr; ITS-REST 1.1.0 EHR API ehr_get.yaml 404; RM 1.2.0 ehr §EHR",
       "schedule_ref": "I_EHR_SERVICE.get_ehr-get_ehr_by_invalid_ehr_id (master06 §get_ehr)",
       "binding": "GET /ehr/{ehr_id}",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "ecc_id": "ECC-EHR-011",
@@ -241,7 +241,7 @@
       "citation": "CNF master06-func_tc_ehr §get_ehr; ITS-REST 1.1.0 EHR API ehr_get_by_subject.yaml 404; RM 1.2.0 ehr §EHR",
       "schedule_ref": "I_EHR_SERVICE.get_ehr-get_ehr_by_invalid_subject_id (master06 §get_ehr)",
       "binding": "GET /ehr?subject_id&subject_namespace",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "ecc_id": "ECC-STA-001",
@@ -271,7 +271,7 @@
       "citation": "CNF master06-func_tc_ehr §get_ehr_status; ITS-REST 1.1.0 EHR_STATUS API ehr_status_get.yaml 404; RM 1.2.0 ehr §EHR_STATUS",
       "schedule_ref": "I_EHR_STATUS.get_ehr_status-bad_ehr (master06 §get_ehr_status)",
       "binding": "GET /ehr/{ehr_id}/ehr_status",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "ecc_id": "ECC-STA-003",
@@ -286,7 +286,7 @@
       "citation": "CNF master06-func_tc_ehr §set_ehr_queryable; ITS-REST 1.1.0 EHR_STATUS API ehr_status_update.yaml 200; RM 1.2.0 ehr §EHR_STATUS.is_queryable",
       "schedule_ref": "I_EHR_STATUS.set_ehr_queryable-existing_ehr (master06 §set_ehr_queryable)",
       "binding": "PUT /ehr/{ehr_id}/ehr_status",
-      "duration_ms": 18
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-STA-004",
@@ -301,7 +301,7 @@
       "citation": "CNF master06-func_tc_ehr §set_ehr_queryable; ITS-REST 1.1.0 EHR_STATUS API ehr_status_update.yaml 4xx; RM 1.2.0 ehr §EHR_STATUS",
       "schedule_ref": "I_EHR_STATUS.set_ehr_queryable-bad_ehr (master06 §set_ehr_queryable)",
       "binding": "PUT /ehr/{ehr_id}/ehr_status",
-      "duration_ms": 6
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-STA-005",
@@ -316,7 +316,7 @@
       "citation": "CNF master06-func_tc_ehr §set_ehr_modifiable; ITS-REST 1.1.0 EHR_STATUS API ehr_status_update.yaml 200; RM 1.2.0 ehr §EHR_STATUS.is_modifiable",
       "schedule_ref": "I_EHR_STATUS.set_ehr_modifiable-existing_ehr (master06 §set_ehr_modifiable)",
       "binding": "PUT /ehr/{ehr_id}/ehr_status",
-      "duration_ms": 7
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-STA-006",
@@ -361,7 +361,7 @@
       "citation": "CNF master06-func_tc_ehr §clear_ehr_queryable; ITS-REST 1.1.0 EHR_STATUS API ehr_status_update.yaml 4xx; RM 1.2.0 ehr §EHR_STATUS",
       "schedule_ref": "I_EHR_STATUS.clear_ehr_queryable-bad_ehr (master06 §clear_ehr_queryable)",
       "binding": "PUT /ehr/{ehr_id}/ehr_status",
-      "duration_ms": 2
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-STA-009",
@@ -391,7 +391,7 @@
       "citation": "CNF master06-func_tc_ehr §clear_ehr_modifiable; ITS-REST 1.1.0 EHR_STATUS API ehr_status_update.yaml 4xx; RM 1.2.0 ehr §EHR_STATUS",
       "schedule_ref": "I_EHR_STATUS.clear_ehr_modifiable-bad_ehr (master06 §clear_ehr_modifiable)",
       "binding": "PUT /ehr/{ehr_id}/ehr_status",
-      "duration_ms": 3
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-EHR-012",
@@ -407,7 +407,7 @@
       "citation": "CNF master06-func_tc_ehr §Test Data Sets class 2 (invalid EHR_STATUS shapes); ITS-REST 1.1.0 EHR API ehr_create.yaml 400/422; RM ehr master04 §EHR Status + common §PARTY_SELF",
       "ecc_original": "data-set class 2 (master06 §Test Data Sets, invalid EHR_STATUS shapes); no single master06 test case enumerates class 2",
       "binding": "POST /ehr",
-      "duration_ms": 11
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-EHR-013",
@@ -437,7 +437,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.create_composition-event (master07 §create_composition)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 10
+      "duration_ms": 11
     },
     {
       "ecc_id": "ECC-COM-001",
@@ -467,7 +467,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.create_composition-persistent (master07 §create_composition)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 9
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-COM-002",
@@ -482,7 +482,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.create_composition-persistent (master07 §create_composition)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 7
+      "duration_ms": 5
     },
     {
       "ecc_id": "ECC-COM-003",
@@ -497,7 +497,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.create_composition-same_opt_twice (master07 §create_composition)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 9
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-COM-004",
@@ -542,7 +542,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.create_composition-event_bad_opt (master07 §create_composition)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 6
+      "duration_ms": 5
     },
     {
       "ecc_id": "ECC-COM-007",
@@ -557,7 +557,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.create_composition-event_bad_ehr (master07 §create_composition)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 4
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-COM-032",
@@ -572,7 +572,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.has_composition (master07 §has_composition)",
       "binding": "GET /ehr/{ehr_id}/composition/{uid_based_id}",
-      "duration_ms": 11
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-COM-011",
@@ -617,7 +617,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.get_composition_latest (master07 §get_composition_latest)",
       "binding": "GET /ehr/{ehr_id}/composition/{uid_based_id}",
-      "duration_ms": 19
+      "duration_ms": 11
     },
     {
       "ecc_id": "ECC-COM-008",
@@ -632,7 +632,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.get_composition_latest (master07 §get_composition_latest)",
       "binding": "GET /ehr/{ehr_id}/composition/{uid_based_id}",
-      "duration_ms": 18
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-COM-009",
@@ -647,7 +647,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.get_composition_latest-bad_composition (master07 §get_composition_latest)",
       "binding": "GET /ehr/{ehr_id}/composition/{uid_based_id}",
-      "duration_ms": 2
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-COM-010",
@@ -677,7 +677,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.get_composition_at_time (master07 §get_composition_at_time)",
       "binding": "GET /ehr/{ehr_id}/composition/{uid_based_id}?version_at_time",
-      "duration_ms": 13
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-COM-013",
@@ -692,7 +692,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.get_composition_at_time (master07 §get_composition_at_time)",
       "binding": "GET /ehr/{ehr_id}/composition/{uid_based_id}?version_at_time",
-      "duration_ms": 15
+      "duration_ms": 11
     },
     {
       "ecc_id": "ECC-COM-014",
@@ -707,7 +707,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.get_composition_at_time-no_time_arg (master07 §get_composition_at_time)",
       "binding": "GET /ehr/{ehr_id}/composition/{uid_based_id}",
-      "duration_ms": 14
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-COM-014",
@@ -722,7 +722,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.get_composition_at_time-no_time_arg (master07 §get_composition_at_time)",
       "binding": "GET /ehr/{ehr_id}/composition/{uid_based_id}",
-      "duration_ms": 15
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-COM-015",
@@ -737,7 +737,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.get_composition_at_time-bad_composition (master07 §get_composition_at_time)",
       "binding": "GET /ehr/{ehr_id}/composition/{uid_based_id}?version_at_time",
-      "duration_ms": 3
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-COM-016",
@@ -752,7 +752,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.get_composition_at_time-bad_ehr (master07 §get_composition_at_time)",
       "binding": "GET /ehr/{ehr_id}/composition/{uid_based_id}?version_at_time",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "ecc_id": "ECC-COM-017",
@@ -768,7 +768,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.get_composition_at_times (master07 §get_composition_at_time)",
       "binding": "GET /ehr/{ehr_id}/composition/{uid_based_id}?version_at_time",
-      "duration_ms": 136
+      "duration_ms": 124
     },
     {
       "ecc_id": "ECC-COM-018",
@@ -783,7 +783,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.get_composition_version (master07 §get_composition_version)",
       "binding": "GET /ehr/{ehr_id}/composition/{version_uid}",
-      "duration_ms": 25
+      "duration_ms": 16
     },
     {
       "ecc_id": "ECC-COM-018",
@@ -798,7 +798,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.get_composition_version (master07 §get_composition_version)",
       "binding": "GET /ehr/{ehr_id}/composition/{version_uid}",
-      "duration_ms": 20
+      "duration_ms": 17
     },
     {
       "ecc_id": "ECC-COM-019",
@@ -813,7 +813,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.get_composition_version-bad_version (master07 §get_composition_version)",
       "binding": "GET /ehr/{ehr_id}/composition/{version_uid}",
-      "duration_ms": 10
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-COM-020",
@@ -828,7 +828,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.get_composition_version-bad_ehr (master07 §get_composition_version)",
       "binding": "GET /ehr/{ehr_id}/composition/{version_uid}",
-      "duration_ms": 10
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-COM-021",
@@ -844,7 +844,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_{create,get,update,delete}.yaml + versioned_composition_get.yaml; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT + change_control",
       "schedule_ref": "I_EHR_COMPOSITION.get_composition_versions (master07 §get_composition_version)",
       "binding": "GET /ehr/{ehr_id}/composition/{version_uid}",
-      "duration_ms": 26
+      "duration_ms": 15
     },
     {
       "ecc_id": "ECC-COM-022",
@@ -859,7 +859,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API versioned_composition_get.yaml 200; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT (version-family XML)",
       "schedule_ref": "I_EHR_COMPOSITION.get_versioned_composition (master07 §get_versioned_composition)",
       "binding": "GET /ehr/{ehr_id}/versioned_composition/{versioned_object_uid}",
-      "duration_ms": 10
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-COM-022",
@@ -874,7 +874,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API versioned_composition_get.yaml 200; RM 1.2.0 ehr §COMPOSITION, common §VERSIONED_OBJECT (version-family XML)",
       "schedule_ref": "I_EHR_COMPOSITION.get_versioned_composition (master07 §get_versioned_composition)",
       "binding": "GET /ehr/{ehr_id}/versioned_composition/{versioned_object_uid}",
-      "duration_ms": 10
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-COM-023",
@@ -889,7 +889,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API versioned_composition_get.yaml 404; RM 1.2.0 common §VERSIONED_OBJECT",
       "schedule_ref": "I_EHR_COMPOSITION.get_versioned_composition-non_existent (master07 §get_versioned_composition)",
       "binding": "GET /ehr/{ehr_id}/versioned_composition/{versioned_object_uid}",
-      "duration_ms": 3
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-COM-024",
@@ -919,7 +919,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_update.yaml 200; RM common §Version tree; TERM SupportTerminology audit_change_type 249 creation / 251 modification",
       "schedule_ref": "I_EHR_COMPOSITION.update_composition-event (master07 §update_composition)",
       "binding": "PUT /ehr/{ehr_id}/composition/{uid_based_id}",
-      "duration_ms": 19
+      "duration_ms": 17
     },
     {
       "ecc_id": "ECC-COM-026",
@@ -949,7 +949,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_update.yaml 400/404/412/422 (non-existent preceding version)",
       "schedule_ref": "I_EHR_COMPOSITION.update_composition-non_existent (master07 §update_composition)",
       "binding": "PUT /ehr/{ehr_id}/composition/{uid_based_id}",
-      "duration_ms": 15
+      "duration_ms": 14
     },
     {
       "ecc_id": "ECC-COM-028",
@@ -964,7 +964,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_update.yaml 422 (template_id mismatch); RM 1.2.0 ehr §COMPOSITION",
       "schedule_ref": "I_EHR_COMPOSITION.update_composition-wrong_template (master07 §update_composition)",
       "binding": "PUT /ehr/{ehr_id}/composition/{uid_based_id}",
-      "duration_ms": 12
+      "duration_ms": 11
     },
     {
       "ecc_id": "ECC-COM-029",
@@ -979,7 +979,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_delete.yaml 204 + composition_get.yaml 204_because_deleted/404; master07 §delete_composition (logical delete: VERSION.lifecycle_state = openehr::523|deleted|)",
       "schedule_ref": "I_EHR_COMPOSITION.delete_composition-event (master07 §delete_composition)",
       "binding": "DELETE /ehr/{ehr_id}/composition/{uid_based_id}",
-      "duration_ms": 13
+      "duration_ms": 11
     },
     {
       "ecc_id": "ECC-COM-030",
@@ -1009,7 +1009,7 @@
       "citation": "ITS-REST 1.1.0 COMPOSITION API composition_delete.yaml 400/404/409/412 (non-existent COMPOSITION)",
       "schedule_ref": "I_EHR_COMPOSITION.delete_composition-non_existent (master07 §delete_composition)",
       "binding": "DELETE /ehr/{ehr_id}/composition/{uid_based_id}",
-      "duration_ms": 12
+      "duration_ms": 11
     },
     {
       "ecc_id": "ECC-CTB-001",
@@ -1024,7 +1024,7 @@
       "citation": "master08 §valid_composition; ITS-REST contribution_create 201_CONTRIBUTION; RM common master06 §Version",
       "schedule_ref": "I_EHR_CONTRIBUTION.commit_contribution-valid_composition (master08 §Test Cases)",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 14
+      "duration_ms": 15
     },
     {
       "ecc_id": "ECC-CTB-002",
@@ -1054,7 +1054,7 @@
       "citation": "master08 §empty (General B.4 empty CONTRIBUTION); ITS-REST contribution_create 400_CONTRIBUTION",
       "schedule_ref": "I_EHR_CONTRIBUTION.commit_contribution-empty (master08 §Test Cases)",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 6
+      "duration_ms": 5
     },
     {
       "ecc_id": "ECC-CTB-004",
@@ -1070,7 +1070,7 @@
       "citation": "master08 §multiple versions table D (if any COMPOSITION is invalid the whole commit fails); RM common master06 §Contributions (atomic)",
       "schedule_ref": "I_EHR_CONTRIBUTION.commit_contribution-valid_invalid_compositions (master08 §Test Cases D)",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 11
+      "duration_ms": 15
     },
     {
       "ecc_id": "ECC-CTB-005",
@@ -1085,7 +1085,7 @@
       "citation": "master08 §non_exiting_opt (COMPOSITION B.2.b referenced OPT not loaded); ITS-REST contribution_create 400_CONTRIBUTION",
       "schedule_ref": "I_EHR_CONTRIBUTION.commit_contribution-non_exiting_opt (master08 §Test Cases)",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 9
+      "duration_ms": 10
     },
     {
       "ecc_id": "ECC-CTB-006",
@@ -1100,7 +1100,7 @@
       "citation": "master08 §event_composition (creation then modification → version 2); RM common master06 §Version tree",
       "schedule_ref": "I_EHR_CONTRIBUTION.commit_contribution-event_composition (master08 §Test Cases)",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 16
+      "duration_ms": 23
     },
     {
       "ecc_id": "ECC-CTB-007",
@@ -1115,7 +1115,7 @@
       "citation": "master08 §persistent_composition (COMPOSITION B.1.c; create then modify → version 2); RM common master06 §Version tree",
       "schedule_ref": "I_EHR_CONTRIBUTION.commit_contribution-persistent_composition (master08 §Test Cases)",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 20
+      "duration_ms": 17
     },
     {
       "ecc_id": "ECC-CTB-008",
@@ -1130,7 +1130,7 @@
       "citation": "master08 §delete (VERSIONED_OBJECT logically deleted); RM common master06 §Change control (deleted VERSION data Void, logical delete)",
       "schedule_ref": "I_EHR_CONTRIBUTION.commit_contribution-delete (master08 §Test Cases)",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 14
+      "duration_ms": 16
     },
     {
       "ecc_id": "ECC-CTB-009",
@@ -1145,7 +1145,7 @@
       "citation": "master08 §two_commits_second_invalid (only one VERSION remains); RM common master06 §Contributions (atomic)",
       "schedule_ref": "I_EHR_CONTRIBUTION.commit_contribution-two_commits_second_invalid (master08 §Test Cases)",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 14
+      "duration_ms": 13
     },
     {
       "ecc_id": "ECC-CTB-010",
@@ -1176,7 +1176,7 @@
       "citation": "master08 §EHR_STATUS Accepted Cases 15-row matrix (is_modifiable × is_queryable × subject.external_ref), scenario 1 default EHR_STATUS",
       "schedule_ref": "I_EHR_CONTRIBUTION.commit_contribution-minimal_ehr_status (master08 §EHR_STATUS CONTRIBUTION Commit)",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 125
+      "duration_ms": 99
     },
     {
       "ecc_id": "ECC-CTB-012",
@@ -1192,7 +1192,7 @@
       "citation": "master08 §EHR_STATUS Accepted Cases scenario 2 (EHR created by providing an EHR_STATUS), 15-row matrix",
       "schedule_ref": "I_EHR_CONTRIBUTION.commit_contribution-full_ehr_status (master08 §EHR_STATUS CONTRIBUTION Commit)",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 157
+      "duration_ms": 105
     },
     {
       "ecc_id": "ECC-CTB-013",
@@ -1207,7 +1207,7 @@
       "citation": "master08 §EHR_STATUS Reject 1 (change_type ∈ {creation, deleted} rejected — STATUS already exists, cannot be deleted)",
       "schedule_ref": "I_EHR_CONTRIBUTION.commit_contribution-ehr_status_invalid_change_type (master08 §EHR_STATUS CONTRIBUTION Commit)",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 3
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-CTB-014",
@@ -1237,7 +1237,7 @@
       "citation": "master08 §valid_directory (creation to an EHR with no directory); RM ehr master04 §Folders",
       "schedule_ref": "I_EHR_CONTRIBUTION.commit_contribution-valid_directory (master08 §FOLDER CONTRIBUTION Commit)",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 8
+      "duration_ms": 10
     },
     {
       "ecc_id": "ECC-CTB-016",
@@ -1252,7 +1252,7 @@
       "citation": "master08 §fail_create_existing_directory (root FOLDER already present); ITS-REST contribution_create 409",
       "schedule_ref": "I_EHR_CONTRIBUTION.commit_contribution-fail_create_existing_directory (master08 §FOLDER CONTRIBUTION Commit)",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 5
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-CTB-017",
@@ -1267,7 +1267,7 @@
       "citation": "master08 §fail_modify_non_existing_directory (modify a directory that does not exist)",
       "schedule_ref": "I_EHR_CONTRIBUTION.commit_contribution-fail_modify_non_existing_directory (master08 §FOLDER CONTRIBUTION Commit)",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 3
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-CTB-018",
@@ -1282,7 +1282,7 @@
       "citation": "master08 §update_existing_directory (modify/amend an existing directory → new FOLDER version)",
       "schedule_ref": "I_EHR_CONTRIBUTION.commit_contribution-update_existing_directory (master08 §FOLDER CONTRIBUTION Commit)",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 6
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-CTB-019",
@@ -1297,7 +1297,7 @@
       "citation": "master08 §get_contribution existing; ITS-REST contribution_get 200_CONTRIBUTION",
       "schedule_ref": "I_EHR_CONTRIBUTION.get_contribution-existing (master08 §get_contribution)",
       "binding": "GET /ehr/{ehr_id}/contribution/{contribution_uid}",
-      "duration_ms": 6
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-CTB-020",
@@ -1327,7 +1327,7 @@
       "citation": "master08 §get_contribution bad_ehr (error); ITS-REST contribution_get 404_CONTRIBUTION",
       "schedule_ref": "I_EHR_CONTRIBUTION.get_contribution-bad_ehr (master08 §get_contribution)",
       "binding": "GET /ehr/{ehr_id}/contribution/{contribution_uid}",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "ecc_id": "ECC-CTB-022",
@@ -1342,7 +1342,7 @@
       "citation": "master08 §get_contribution bad_contribution (error); ITS-REST contribution_get 404_CONTRIBUTION",
       "schedule_ref": "I_EHR_CONTRIBUTION.get_contribution-bad_contribution (master08 §get_contribution)",
       "binding": "GET /ehr/{ehr_id}/contribution/{contribution_uid}",
-      "duration_ms": 5
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-CTB-023",
@@ -1357,7 +1357,7 @@
       "citation": "master08 §has_contribution existing (→true); realized 200 via ITS-REST contribution_get",
       "schedule_ref": "I_EHR_CONTRIBUTION.has_contribution-existing (master08 §has_contribution)",
       "binding": "GET /ehr/{ehr_id}/contribution/{contribution_uid}",
-      "duration_ms": 5
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-CTB-024",
@@ -1372,7 +1372,7 @@
       "citation": "master08 §has_contribution bad_contribution (→false); realized 404 via ITS-REST contribution_get",
       "schedule_ref": "I_EHR_CONTRIBUTION.has_contribution-bad_contribution (master08 §has_contribution)",
       "binding": "GET /ehr/{ehr_id}/contribution/{contribution_uid}",
-      "duration_ms": 5
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-CTB-025",
@@ -1402,7 +1402,7 @@
       "citation": "master08 §has_contribution empty_ehr (→false); realized 404 via ITS-REST contribution_get (element-2 collapse)",
       "schedule_ref": "I_EHR_CONTRIBUTION.has_contribution-empty_ehr (master08 §has_contribution)",
       "binding": "GET /ehr/{ehr_id}/contribution/{contribution_uid}",
-      "duration_ms": 1
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-CTB-027",
@@ -1417,7 +1417,7 @@
       "citation": "master08 §list_contributions-empty (retrieve an empty list); SM I_EHR_CONTRIBUTION.list_contributions; no ITS-REST binding — ehrbase-rs extension (GET /ehr/{ehr_id}/contribution → {rows,total}); RM common master06 §Contributions (initial EHR_STATUS is committed within a CONTRIBUTION → empty-list realized via the beyond-end page)",
       "schedule_ref": "I_EHR_CONTRIBUTION.list_contributions-empty (master08 §list_contributions)",
       "binding": "GET /ehr/{ehr_id}/contribution",
-      "duration_ms": 9
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-CTB-028",
@@ -1447,7 +1447,7 @@
       "citation": "master08 §list_contributions-post_commit (list reflects a committed VERSION<COMPOSITION>); SM I_EHR_CONTRIBUTION.list_contributions; no ITS-REST binding — ehrbase-rs extension (GET /ehr/{ehr_id}/contribution)",
       "schedule_ref": "I_EHR_CONTRIBUTION.list_contributions-post_commit (master08 §list_contributions)",
       "binding": "GET /ehr/{ehr_id}/contribution",
-      "duration_ms": 5
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-CTB-030",
@@ -1477,7 +1477,7 @@
       "citation": "master08 §list_contributions-ehr_containing_ehr_status (list reflects a committed VERSION<EHR_STATUS>); SM I_EHR_CONTRIBUTION.list_contributions; no ITS-REST binding — ehrbase-rs extension (GET /ehr/{ehr_id}/contribution)",
       "schedule_ref": "I_EHR_CONTRIBUTION.list_contributions-ehr_containing_ehr_status (master08 §list_contributions)",
       "binding": "GET /ehr/{ehr_id}/contribution",
-      "duration_ms": 12
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-DIR-012",
@@ -1492,7 +1492,7 @@
       "citation": "master09 §has_directory empty_ehr (→false); realized 404 via directory_get_at_time",
       "schedule_ref": "I_EHR_DIRECTORY.has_directory-empty_ehr (master09 §has_directory)",
       "binding": "GET /ehr/{ehr_id}/directory",
-      "duration_ms": 5
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-DIR-013",
@@ -1538,7 +1538,7 @@
       "citation": "master09 §has_path ehr_root_directory data set {'/'→true, random→false}",
       "schedule_ref": "I_EHR_DIRECTORY.has_path-ehr_root_directory (master09 §has_path)",
       "binding": "GET /ehr/{ehr_id}/directory",
-      "duration_ms": 7
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-DIR-016",
@@ -1554,7 +1554,7 @@
       "citation": "master09 §has_path folder_structure 12-row path table over the reference tree (true + →false rows)",
       "schedule_ref": "I_EHR_DIRECTORY.has_path-folder_structure (master09 §has_path)",
       "binding": "GET /ehr/{ehr_id}/directory",
-      "duration_ms": 12
+      "duration_ms": 11
     },
     {
       "ecc_id": "ECC-DIR-017",
@@ -1569,7 +1569,7 @@
       "citation": "master09 §has_path empty_ehr (→false); realized 404",
       "schedule_ref": "I_EHR_DIRECTORY.has_path-empty_ehr (master09 §has_path)",
       "binding": "GET /ehr/{ehr_id}/directory",
-      "duration_ms": 3
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-DIR-018",
@@ -1584,7 +1584,7 @@
       "citation": "master09 §has_path bad_ehr (→error); realized 404",
       "schedule_ref": "I_EHR_DIRECTORY.has_path-bad_ehr (master09 §has_path)",
       "binding": "GET /ehr/{ehr_id}/directory",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "ecc_id": "ECC-DIR-001",
@@ -1614,7 +1614,7 @@
       "citation": "master09 §create_directory ehr_with_directory (already exists → conflict); ITS-REST 409",
       "schedule_ref": "I_EHR_DIRECTORY.create_directory-ehr_with_directory (master09 §create_directory)",
       "binding": "POST /ehr/{ehr_id}/directory",
-      "duration_ms": 10
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-DIR-003",
@@ -1629,7 +1629,7 @@
       "citation": "master09 §create_directory bad_ehr; ITS-REST directory_create 404_unknown_ehr_id",
       "schedule_ref": "I_EHR_DIRECTORY.create_directory-bad_ehr (master09 §create_directory)",
       "binding": "POST /ehr/{ehr_id}/directory",
-      "duration_ms": 2
+      "duration_ms": 1
     },
     {
       "ecc_id": "ECC-DIR-022",
@@ -1644,7 +1644,7 @@
       "citation": "master09 §get_directory empty_ehr (NOTE: REST 4xx); ITS-REST directory_get_at_time 404",
       "schedule_ref": "I_EHR_DIRECTORY.get_directory-empty_ehr (master09 §get_directory)",
       "binding": "GET /ehr/{ehr_id}/directory",
-      "duration_ms": 4
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-DIR-004",
@@ -1659,7 +1659,7 @@
       "citation": "master09 §get_directory ehr_root_directory; ITS-REST directory_get_at_time 200_FOLDER_retrieved",
       "schedule_ref": "I_EHR_DIRECTORY.get_directory-ehr_root_directory (master09 §get_directory)",
       "binding": "GET /ehr/{ehr_id}/directory",
-      "duration_ms": 8
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-DIR-023",
@@ -1674,7 +1674,7 @@
       "citation": "master09 §get_directory directory_with_structure (return the full structure); RM ehr master04 §Folders — body fidelity",
       "schedule_ref": "I_EHR_DIRECTORY.get_directory-directory_with_structure (master09 §get_directory)",
       "binding": "GET /ehr/{ehr_id}/directory",
-      "duration_ms": 8
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-DIR-005",
@@ -1704,7 +1704,7 @@
       "citation": "master09 §get_directory_at_time ehr_with_directory (current time → current)",
       "schedule_ref": "I_EHR_DIRECTORY.get_directory_at_time-ehr_with_directory (master09 §get_directory_at_time)",
       "binding": "GET /ehr/{ehr_id}/directory",
-      "duration_ms": 9
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-DIR-007",
@@ -1764,7 +1764,7 @@
       "citation": "master09 §delete_directory ehr_with_directory (new deleted version); ITS-REST directory_delete 204_deleted; RM common master06 §Change control (logical delete)",
       "schedule_ref": "I_EHR_DIRECTORY.delete_directory-ehr_with_directory (master09 §delete_directory)",
       "binding": "DELETE /ehr/{ehr_id}/directory",
-      "duration_ms": 8
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-DIR-011",
@@ -1779,7 +1779,7 @@
       "citation": "master09 §delete_directory bad_ehr (→error); ITS-REST directory_delete 404_unknown_ehr_id",
       "schedule_ref": "I_EHR_DIRECTORY.delete_directory-bad_ehr (master09 §delete_directory)",
       "binding": "DELETE /ehr/{ehr_id}/directory",
-      "duration_ms": 7
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-DIR-019",
@@ -1794,7 +1794,7 @@
       "citation": "master09 §has_directory_version empty_ehr (→false); realized 404",
       "schedule_ref": "I_EHR_DIRECTORY.has_directory_version-empty_ehr (master09 §has_directory_version)",
       "binding": "GET /ehr/{ehr_id}/directory/{version_uid}",
-      "duration_ms": 9
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-DIR-020",
@@ -1810,7 +1810,7 @@
       "citation": "master09 §has_directory_version directory_with_two_versions (BOTH versions →true)",
       "schedule_ref": "I_EHR_DIRECTORY.has_directory_version-directory_with_two_versions (master09 §has_directory_version)",
       "binding": "GET /ehr/{ehr_id}/directory/{version_uid}",
-      "duration_ms": 13
+      "duration_ms": 11
     },
     {
       "ecc_id": "ECC-DIR-021",
@@ -1856,7 +1856,7 @@
       "citation": "master09 §get_directory_at_time ehr_with_directory_versions (before→empty; between v1/v2→v1; current→v2)",
       "schedule_ref": "I_EHR_DIRECTORY.get_directory_at_time-ehr_with_directory_versions (master09 §get_directory_at_time)",
       "binding": "GET /ehr/{ehr_id}/directory",
-      "duration_ms": 3037
+      "duration_ms": 3043
     },
     {
       "ecc_id": "ECC-DIR-026",
@@ -1871,7 +1871,7 @@
       "citation": "master09 §get_directory_at_time ehr_with_directory_versions_empty_time (→current latest v2)",
       "schedule_ref": "I_EHR_DIRECTORY.get_directory_at_time-ehr_with_directory_versions_empty_time (master09 §get_directory_at_time)",
       "binding": "GET /ehr/{ehr_id}/directory",
-      "duration_ms": 21
+      "duration_ms": 24
     },
     {
       "ecc_id": "ECC-DIR-027",
@@ -1886,7 +1886,7 @@
       "citation": "master09 §get_directory_at_time empty_ehr (→empty); realized 404",
       "schedule_ref": "I_EHR_DIRECTORY.get_directory_at_time-empty_ehr (master09 §get_directory_at_time)",
       "binding": "GET /ehr/{ehr_id}/directory",
-      "duration_ms": 4
+      "duration_ms": 5
     },
     {
       "ecc_id": "ECC-DIR-028",
@@ -1901,7 +1901,7 @@
       "citation": "master09 §get_directory_at_time empty_ehr_empty_time (→empty); realized 404",
       "schedule_ref": "I_EHR_DIRECTORY.get_directory_at_time-empty_ehr_empty_time (master09 §get_directory_at_time)",
       "binding": "GET /ehr/{ehr_id}/directory",
-      "duration_ms": 4
+      "duration_ms": 5
     },
     {
       "ecc_id": "ECC-DIR-029",
@@ -1916,7 +1916,7 @@
       "citation": "master09 §get_directory_at_time multiple_versions_first (time AFTER v1 but BEFORE v2 must return v1, highest priority)",
       "schedule_ref": "I_EHR_DIRECTORY.get_directory_at_time-multiple_versions_first (master09 §get_directory_at_time)",
       "binding": "GET /ehr/{ehr_id}/directory",
-      "duration_ms": 3035
+      "duration_ms": 3033
     },
     {
       "ecc_id": "ECC-DIR-030",
@@ -1931,7 +1931,7 @@
       "citation": "master09 §get_directory_at_version bad_ehr (→error); realized 404",
       "schedule_ref": "I_EHR_DIRECTORY.get_directory_at_version-bad_ehr (master09 §get_directory_at_version)",
       "binding": "GET /ehr/{ehr_id}/directory/{version_uid}",
-      "duration_ms": 13
+      "duration_ms": 10
     },
     {
       "ecc_id": "ECC-DIR-031",
@@ -1947,7 +1947,7 @@
       "citation": "master09 §get_directory_at_version directory_with_two_versions (v1 uid→v1, v2 uid→v2; body fidelity)",
       "schedule_ref": "I_EHR_DIRECTORY.get_directory_at_version-directory_with_two_versions (master09 §get_directory_at_version)",
       "binding": "GET /ehr/{ehr_id}/directory/{version_uid}",
-      "duration_ms": 18
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-DIR-032",
@@ -1962,7 +1962,7 @@
       "citation": "master09 §get_directory_at_version empty_ehr (→error); realized 404",
       "schedule_ref": "I_EHR_DIRECTORY.get_directory_at_version-empty_ehr (master09 §get_directory_at_version)",
       "binding": "GET /ehr/{ehr_id}/directory/{version_uid}",
-      "duration_ms": 11
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-DIR-033",
@@ -1977,7 +1977,7 @@
       "citation": "master09 §get_versioned_directory empty_ehr; rebound to directory_get_by_version_id (no versioned_directory resource in the tested OAS); RM common master06 §VERSIONED_OBJECT",
       "schedule_ref": "I_EHR_DIRECTORY.get_versioned_directory-empty_ehr (master09 §get_versioned_directory)",
       "binding": "GET /ehr/{ehr_id}/directory/{version_uid}",
-      "duration_ms": 12
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-DIR-034",
@@ -1993,7 +1993,7 @@
       "citation": "master09 §get_versioned_directory directory_with_two_versions (references the two versions → both reachable); RM common master06 §VERSIONED_OBJECT",
       "schedule_ref": "I_EHR_DIRECTORY.get_versioned_directory-directory_with_two_versions (master09 §get_versioned_directory)",
       "binding": "GET /ehr/{ehr_id}/directory/{version_uid}",
-      "duration_ms": 16
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-DIR-035",
@@ -2008,7 +2008,7 @@
       "citation": "master09 §get_versioned_directory bad_ehr (→error); realized 404",
       "schedule_ref": "I_EHR_DIRECTORY.get_versioned_directory-bad_ehr (master09 §get_versioned_directory)",
       "binding": "GET /ehr/{ehr_id}/directory/{version_uid}",
-      "duration_ms": 8
+      "duration_ms": 5
     },
     {
       "ecc_id": "ECC-DIR-036",
@@ -2023,7 +2023,7 @@
       "citation": "master09 §update_directory empty_ehr (no directory → error); ITS-REST directory_update 404 (412 If-Match form)",
       "schedule_ref": "I_EHR_DIRECTORY.update_directory-empty_ehr (master09 §update_directory)",
       "binding": "PUT /ehr/{ehr_id}/directory",
-      "duration_ms": 14
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-DIR-037",
@@ -2038,7 +2038,7 @@
       "citation": "master09 §delete_directory empty_ehr (no directory → error); ITS-REST directory_delete 404 (412 If-Match form)",
       "schedule_ref": "I_EHR_DIRECTORY.delete_directory-empty_ehr (master09 §delete_directory)",
       "binding": "DELETE /ehr/{ehr_id}/directory",
-      "duration_ms": 12
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-TPL-011",
@@ -2053,7 +2053,7 @@
       "citation": "CNF master04 §I_DEFINITION_ADL14; ITS-REST 1.1.0 DEFINITION ADL 1.4 API (upload/get/validate); AM 1.4 §OPERATIONAL_TEMPLATE",
       "schedule_ref": "I_DEFINITION_ADL14.validate_opt-valid_opt (master04 §validate_opt)",
       "binding": "POST /definition/template/adl1.4 (validate-via-upload, §validate_opt NOTE)",
-      "duration_ms": 2
+      "duration_ms": 1
     },
     {
       "ecc_id": "ECC-TPL-012",
@@ -2069,7 +2069,7 @@
       "citation": "CNF master04 §I_DEFINITION_ADL14; ITS-REST 1.1.0 DEFINITION ADL 1.4 API (upload/get/validate); AM 1.4 §OPERATIONAL_TEMPLATE",
       "schedule_ref": "I_DEFINITION_ADL14.validate_opt-invalid_opt (master04 §validate_opt)",
       "binding": "POST /definition/template/adl1.4 (validate-via-upload, §validate_opt NOTE)",
-      "duration_ms": 47
+      "duration_ms": 46
     },
     {
       "ecc_id": "ECC-TPL-001",
@@ -2084,7 +2084,7 @@
       "citation": "CNF master04 §upload_opt; ITS-REST 1.1.0 DEFINITION ADL 1.4 API §upload OPT; AM 1.4 §OPERATIONAL_TEMPLATE; CORE Adl14ArchetypeProvisioning evidenced via the OPT (archetypes embedded in the OPT)",
       "schedule_ref": "I_DEFINITION_ADL14.upload_opt-valid_opt (master04 §upload_opt)",
       "binding": "POST /definition/template/adl1.4",
-      "duration_ms": 5
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-TPL-002",
@@ -2100,7 +2100,7 @@
       "citation": "CNF master04 §I_DEFINITION_ADL14; ITS-REST 1.1.0 DEFINITION ADL 1.4 API (upload/get/validate); AM 1.4 §OPERATIONAL_TEMPLATE",
       "schedule_ref": "I_DEFINITION_ADL14.upload_opt-invalid_opt (master04 §upload_opt)",
       "binding": "POST /definition/template/adl1.4",
-      "duration_ms": 24
+      "duration_ms": 16
     },
     {
       "ecc_id": "ECC-TPL-004",
@@ -2115,7 +2115,7 @@
       "citation": "CNF master04 §I_DEFINITION_ADL14; ITS-REST 1.1.0 DEFINITION ADL 1.4 API (upload/get/validate); AM 1.4 §OPERATIONAL_TEMPLATE",
       "schedule_ref": "I_DEFINITION_ADL14.upload_opt-valid_opt_twice_conflict (master04 §upload_opt)",
       "binding": "POST /definition/template/adl1.4",
-      "duration_ms": 4
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-TPL-005",
@@ -2130,7 +2130,7 @@
       "citation": "CNF master04 §I_DEFINITION_ADL14; ITS-REST 1.1.0 DEFINITION ADL 1.4 API (upload/get/validate); AM 1.4 §OPERATIONAL_TEMPLATE",
       "schedule_ref": "I_DEFINITION_ADL14.upload_opt-valid_opt_twice_no_conflict (master04 §upload_opt)",
       "binding": "POST /definition/template/adl1.4",
-      "duration_ms": 4
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-TPL-006",
@@ -2145,7 +2145,7 @@
       "citation": "CNF master04 §get_opt-retrieve_single (retrieved OPT == uploaded OPT NOTE); ITS-REST 1.1.0 DEFINITION ADL 1.4 API §get OPT; AM 1.4 §OPERATIONAL_TEMPLATE",
       "schedule_ref": "I_DEFINITION_ADL14.get_opt-retrieve_single (master04 §get_opt)",
       "binding": "GET /definition/template/adl1.4/{template_id}",
-      "duration_ms": 7
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-TPL-009",
@@ -2160,7 +2160,7 @@
       "citation": "CNF master04 §I_DEFINITION_ADL14; ITS-REST 1.1.0 DEFINITION ADL 1.4 API (upload/get/validate); AM 1.4 §OPERATIONAL_TEMPLATE",
       "schedule_ref": "I_DEFINITION_ADL14.get_opt-retrieve_fail (master04 §get_opt)",
       "binding": "GET /definition/template/adl1.4/{template_id}",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "ecc_id": "ECC-TPL-007",
@@ -2175,7 +2175,7 @@
       "citation": "CNF master04 §I_DEFINITION_ADL14; ITS-REST 1.1.0 DEFINITION ADL 1.4 API (upload/get/validate); AM 1.4 §OPERATIONAL_TEMPLATE",
       "schedule_ref": "I_DEFINITION_ADL14.get_opt-retrieve_latest_version (master04 §get_opt)",
       "binding": "GET /definition/template/adl1.4/{template_id}",
-      "duration_ms": 6
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-TPL-008",
@@ -2190,7 +2190,7 @@
       "citation": "CNF master04 §I_DEFINITION_ADL14; ITS-REST 1.1.0 DEFINITION ADL 1.4 API (upload/get/validate); AM 1.4 §OPERATIONAL_TEMPLATE",
       "schedule_ref": "I_DEFINITION_ADL14.get_opt-retrieve_specific_version (master04 §get_opt)",
       "binding": "GET /definition/template/adl1.4/{template_id}/{version}",
-      "duration_ms": 3
+      "duration_ms": 1
     },
     {
       "ecc_id": "ECC-TPL-010",
@@ -2205,7 +2205,7 @@
       "citation": "CNF master04 §get_opts-retrieve_all (all loaded OPTs returned, latest-only); ITS-REST 1.1.0 DEFINITION ADL 1.4 API §list OPTs; AM 1.4 §OPERATIONAL_TEMPLATE",
       "schedule_ref": "I_DEFINITION_ADL14.get_opts-retrieve_all (master04 §get_opts)",
       "binding": "GET /definition/template/adl1.4",
-      "duration_ms": 4
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-TPL-003",
@@ -2220,7 +2220,7 @@
       "citation": "CNF master04 §get_opts-retrieve_all_no_opts (empty server → empty set, no failure); ITS-REST 1.1.0 DEFINITION ADL 1.4 API §list OPTs",
       "schedule_ref": "I_DEFINITION_ADL14.get_opts-retrieve_all_no_opts (master04 §get_opts)",
       "binding": "GET /definition/template/adl1.4",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "ecc_id": "ECC-TPL-017",
@@ -2235,7 +2235,7 @@
       "citation": "ITS-REST development definition_template_adl1.4_example_get (GET /definition/template/adl1.4/{template_id}/example — the `required` example is \"expected to be committable without adjustment\"); CNF master15-content_tc_composition.adoc L38 (a generated instance must be RM/template-valid); AM 1.4 master04-constraint_model_package.adoc §Valid_value",
       "ecc_original": "CNF master04/master15 define no example-generation/commit case; the ITS-REST example operation is non-normative. ECC-derived: asserts the operation's own committable-`required` contract end-to-end (upload OPT → GET example → commit 201).",
       "binding": "GET /definition/template/adl1.4/{template_id}/example → POST /ehr/{ehr_id}/composition",
-      "duration_ms": 226
+      "duration_ms": 219
     },
     {
       "ecc_id": "ECC-TPL-014",
@@ -2280,7 +2280,7 @@
       "citation": "master04 §delete_opt-delete_specific_version; no version-addressed resource on the admin route, so a template underpinning a specific committed version is refused (409 with a reference count — physical delete never orphans committed data); SM I_DEFINITION_ADL14.delete_opt(); no ITS-REST ADL 1.4 DELETE binding — ehrbase-rs extension (DELETE /admin/template/{template_id})",
       "schedule_ref": "I_DEFINITION_ADL14.delete_opt-delete_specific_version (master04 §delete_opt)",
       "binding": "DELETE /admin/template/{template_id}",
-      "duration_ms": 6
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-TPL-013",
@@ -2295,7 +2295,7 @@
       "citation": "master04 §delete_opt-delete_non_existing (delete an OPT that does not exist → 404); SM I_DEFINITION_ADL14.delete_opt(); no ITS-REST ADL 1.4 DELETE binding — ehrbase-rs extension (DELETE /admin/template/{template_id})",
       "schedule_ref": "I_DEFINITION_ADL14.delete_opt-delete_non_existing (master04 §delete_opt)",
       "binding": "DELETE /admin/template/{template_id}",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "ecc_id": "ECC-SQR-001",
@@ -2310,7 +2310,7 @@
       "citation": "ITS-REST 1.1.0 DEFINITION QUERY API §store/get stored query; AQL 1.1 (master05 stub — case id only)",
       "ecc_original": "schedule stub (master05 is TBD); derived from ITS-REST 1.1.0 DEFINITION QUERY + AQL 1.1 — I_DEFINITION_QUERY.valid_query-valid (master05:54, A.3.a)",
       "binding": "PUT /definition/query/{qualified_query_name}/{version}",
-      "duration_ms": 4
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-SQR-007",
@@ -2325,7 +2325,7 @@
       "citation": "ITS-REST 1.1.0 DEFINITION QUERY API §store/get stored query; AQL 1.1 (master05 stub — case id only)",
       "ecc_original": "schedule stub (master05 is TBD); derived from ITS-REST 1.1.0 DEFINITION QUERY + AQL 1.1 — I_DEFINITION_QUERY.valid_query-invalid (master05:67, A.3.b)",
       "binding": "PUT /definition/query/{qualified_query_name}/{version}",
-      "duration_ms": 1
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-SQR-006",
@@ -2355,7 +2355,7 @@
       "citation": "ITS-REST 1.1.0 DEFINITION QUERY API §store/get stored query; AQL 1.1 (master05 stub — case id only)",
       "ecc_original": "schedule stub (master05 is TBD); derived from ITS-REST 1.1.0 DEFINITION QUERY + AQL 1.1 — I_DEFINITION_QUERY.has_query-xxx (master05:37, placeholder id; slug descriptivised)",
       "binding": "GET /definition/query/{qualified_query_name}/{version}",
-      "duration_ms": 1
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-SQR-002",
@@ -2400,7 +2400,7 @@
       "citation": "schedule stub (master05 is TBD); SM I_DEFINITION_QUERY.list_queries() (bare collection); no ITS-REST binding — ehrbase-rs extension: Release-1.0.3 and Release-1.1.0 expose GET /definition/query/{qualified_query_name}, and we additionally serve the bare GET /definition/query (empty-prefix of that route → 200, a JSON array of every stored query)",
       "ecc_original": "schedule stub (master05 is TBD); derived from ITS-REST 1.1.0 DEFINITION QUERY + AQL 1.1 — I_DEFINITION_QUERY.list_queries-select_items (master05:123)",
       "binding": "GET /definition/query",
-      "duration_ms": 1
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-QRY-001",
@@ -2430,7 +2430,7 @@
       "citation": "CNF master11 §I_QUERY_SERVICE (stub, xx flow); ITS-REST 1.1.0 QUERY API §execute_ad_hoc_query (200_QUERY.yaml RESULT_SET); AQL 1.1",
       "ecc_original": "I_QUERY_SERVICE.execute_ad_hoc_query-empty_db (master11:83, A.1.z, stub xx flow)",
       "binding": "POST /query/aql",
-      "duration_ms": 4
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-QRY-003",
@@ -2490,7 +2490,7 @@
       "citation": "AQL 1.1 (invalid syntax); ITS-REST 1.1.0 QUERY API §execute_ad_hoc_query 400_QUERY.yaml; reference: CNF query corpus aql_queries_invalid",
       "ecc_original": "schedule stub (master11 is TBD — no invalid-query case); AQL 1.1 negative-rejection evidence",
       "binding": "POST /query/aql",
-      "duration_ms": 1
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-QRY-014",
@@ -2520,7 +2520,7 @@
       "citation": "AQL 1.1 + the vendored golden RESULT_SETs; ITS-REST 1.1.0 QUERY API §execute_ad_hoc_query 200_QUERY.yaml; reference: CNF query corpus expected_results",
       "ecc_original": "schedule stub (master11 is TBD); golden RESULT_SET diffs derived from AQL 1.1 + the vendored corpus",
       "binding": "POST /query/aql",
-      "duration_ms": 168
+      "duration_ms": 164
     },
     {
       "ecc_id": "ECC-QRY-007",
@@ -2535,7 +2535,7 @@
       "citation": "AQL 1.1 + the vendored golden RESULT_SETs; ITS-REST 1.1.0 QUERY API §execute_ad_hoc_query 200_QUERY.yaml; reference: CNF query corpus expected_results",
       "ecc_original": "schedule stub (master11 is TBD); golden RESULT_SET diffs derived from AQL 1.1 + the vendored corpus",
       "binding": "POST /query/aql",
-      "duration_ms": 192
+      "duration_ms": 159
     },
     {
       "ecc_id": "ECC-QRY-008",
@@ -2550,7 +2550,7 @@
       "citation": "AQL 1.1 + the vendored golden RESULT_SETs; ITS-REST 1.1.0 QUERY API §execute_ad_hoc_query 200_QUERY.yaml; reference: CNF query corpus expected_results",
       "ecc_original": "schedule stub (master11 is TBD); golden RESULT_SET diffs derived from AQL 1.1 + the vendored corpus",
       "binding": "POST /query/aql",
-      "duration_ms": 55
+      "duration_ms": 43
     },
     {
       "ecc_id": "ECC-QRY-009",
@@ -2565,7 +2565,7 @@
       "citation": "AQL 1.1 + the vendored golden RESULT_SETs; ITS-REST 1.1.0 QUERY API §execute_ad_hoc_query 200_QUERY.yaml; reference: CNF query corpus expected_results",
       "ecc_original": "schedule stub (master11 is TBD); golden RESULT_SET diffs derived from AQL 1.1 + the vendored corpus",
       "binding": "POST /query/aql",
-      "duration_ms": 158
+      "duration_ms": 97
     },
     {
       "ecc_id": "ECC-QRY-010",
@@ -2580,7 +2580,7 @@
       "citation": "AQL 1.1 + the vendored golden RESULT_SETs; ITS-REST 1.1.0 QUERY API §execute_ad_hoc_query 200_QUERY.yaml; reference: CNF query corpus expected_results",
       "ecc_original": "schedule stub (master11 is TBD); golden RESULT_SET diffs derived from AQL 1.1 + the vendored corpus",
       "binding": "POST /query/aql",
-      "duration_ms": 206
+      "duration_ms": 158
     },
     {
       "ecc_id": "ECC-QRY-011",
@@ -2595,7 +2595,7 @@
       "citation": "AQL 1.1 + the vendored golden RESULT_SETs; ITS-REST 1.1.0 QUERY API §execute_ad_hoc_query 200_QUERY.yaml; reference: CNF query corpus expected_results",
       "ecc_original": "schedule stub (master11 is TBD); golden RESULT_SET diffs derived from AQL 1.1 + the vendored corpus",
       "binding": "POST /query/aql",
-      "duration_ms": 152
+      "duration_ms": 143
     },
     {
       "ecc_id": "ECC-QRY-012",
@@ -2610,7 +2610,7 @@
       "citation": "AQL 1.1 + the vendored golden RESULT_SETs; ITS-REST 1.1.0 QUERY API §execute_ad_hoc_query 200_QUERY.yaml; reference: CNF query corpus expected_results",
       "ecc_original": "schedule stub (master11 is TBD); golden RESULT_SET diffs derived from AQL 1.1 + the vendored corpus",
       "binding": "POST /query/aql",
-      "duration_ms": 44
+      "duration_ms": 47
     },
     {
       "ecc_id": "ECC-QRY-013",
@@ -2625,7 +2625,7 @@
       "citation": "AQL 1.1 + the vendored golden RESULT_SETs; ITS-REST 1.1.0 QUERY API §execute_ad_hoc_query 200_QUERY.yaml; reference: CNF query corpus expected_results",
       "ecc_original": "schedule stub (master11 is TBD); golden RESULT_SET diffs derived from AQL 1.1 + the vendored corpus",
       "binding": "POST /query/aql",
-      "duration_ms": 61
+      "duration_ms": 58
     },
     {
       "ecc_id": "ECC-QRY-015",
@@ -2655,7 +2655,7 @@
       "citation": "AQL 1.1 removed TIMEWINDOW (QUERY master00-amendment_record SPECQUERY-20); ITS-REST 1.1.0 QUERY API §execute_ad_hoc_query 400_QUERY.yaml — invalid AQL must be rejected",
       "ecc_original": "schedule stub (master11 is TBD); TIMEWINDOW golden, spec-supersedes-corpus (adjudications/ecc-own.toml)",
       "binding": "POST /query/aql",
-      "duration_ms": 2
+      "duration_ms": 1
     },
     {
       "ecc_id": "ECC-QRY-017",
@@ -2700,7 +2700,7 @@
       "citation": "AQL 1.1 grammar orders orderByClause? limitClause? (AqlParser.g4); a LIMIT-before-ORDER-BY query is invalid AQL — corpus-dialect defect (adjudications/ecc-own.toml)",
       "ecc_original": "schedule stub (master11 is TBD); LIMIT-before-ORDER-BY golden, corpus-dialect (adjudications/ecc-own.toml)",
       "binding": "POST /query/aql",
-      "duration_ms": 1
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-QRY-020",
@@ -2715,7 +2715,7 @@
       "citation": "AQL 1.1 grammar orders orderByClause? limitClause? (AqlParser.g4); a LIMIT-before-ORDER-BY query is invalid AQL — corpus-dialect defect (adjudications/ecc-own.toml)",
       "ecc_original": "schedule stub (master11 is TBD); LIMIT-before-ORDER-BY golden, corpus-dialect (adjudications/ecc-own.toml)",
       "binding": "POST /query/aql",
-      "duration_ms": 1
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-QRY-021",
@@ -2730,7 +2730,7 @@
       "citation": "AQL 1.1 grammar orders orderByClause? limitClause? (AqlParser.g4); a LIMIT-before-ORDER-BY query is invalid AQL — corpus-dialect defect (adjudications/ecc-own.toml)",
       "ecc_original": "schedule stub (master11 is TBD); LIMIT-before-ORDER-BY golden, corpus-dialect (adjudications/ecc-own.toml)",
       "binding": "POST /query/aql",
-      "duration_ms": 1
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-QRY-022",
@@ -2791,7 +2791,7 @@
       "citation": "RM 1.2.0 composition §COMPOSITION.content/context (content List 0..1, context 0..1, Category_validity only); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422 validation)",
       "schedule_ref": "CONT-COMP.content_card_any-context_any (master15 §COMPOSITION Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 43
+      "duration_ms": 34
     },
     {
       "ecc_id": "ECC-VAL-002",
@@ -2807,7 +2807,7 @@
       "citation": "RM 1.2.0 composition §COMPOSITION.content/context (content List 0..1, context 0..1, Category_validity only); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422 validation)",
       "schedule_ref": "CONT-COMP.content_card_1plus-context_any (master15 §COMPOSITION Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 36
+      "duration_ms": 30
     },
     {
       "ecc_id": "ECC-VAL-003",
@@ -2823,7 +2823,7 @@
       "citation": "RM 1.2.0 composition §COMPOSITION.content/context (content List 0..1, context 0..1, Category_validity only); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422 validation)",
       "schedule_ref": "CONT-COMP.content_card_3plus-context_any (master15 §COMPOSITION Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 27
+      "duration_ms": 24
     },
     {
       "ecc_id": "ECC-VAL-004",
@@ -2855,7 +2855,7 @@
       "citation": "RM 1.2.0 composition §COMPOSITION.content/context (content List 0..1, context 0..1, Category_validity only); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422 validation)",
       "schedule_ref": "CONT-COMP.content_card_mand-context_any (master15 §COMPOSITION Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 24
+      "duration_ms": 23
     },
     {
       "ecc_id": "ECC-VAL-006",
@@ -2871,7 +2871,7 @@
       "citation": "RM 1.2.0 composition §COMPOSITION.content/context (content List 0..1, context 0..1, Category_validity only); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422 validation)",
       "schedule_ref": "CONT-COMP.content_card_3to5-context_any (master15 §COMPOSITION Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 34
+      "duration_ms": 25
     },
     {
       "ecc_id": "ECC-VAL-007",
@@ -2887,7 +2887,7 @@
       "citation": "RM 1.2.0 composition §COMPOSITION.content/context (content List 0..1, context 0..1, Category_validity only); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422 validation)",
       "schedule_ref": "CONT-COMP.content_card_any-context_mand (master15 §COMPOSITION Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 29
+      "duration_ms": 24
     },
     {
       "ecc_id": "ECC-VAL-008",
@@ -2903,7 +2903,7 @@
       "citation": "RM 1.2.0 composition §COMPOSITION.content/context (content List 0..1, context 0..1, Category_validity only); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422 validation)",
       "schedule_ref": "CONT-COMP.content_card_1plus-context_mand (master15 §COMPOSITION Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 27
+      "duration_ms": 23
     },
     {
       "ecc_id": "ECC-VAL-009",
@@ -2919,7 +2919,7 @@
       "citation": "RM 1.2.0 composition §COMPOSITION.content/context (content List 0..1, context 0..1, Category_validity only); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422 validation)",
       "schedule_ref": "CONT-COMP.content_card_3plus-context_mand (master15 §COMPOSITION Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 26
+      "duration_ms": 19
     },
     {
       "ecc_id": "ECC-VAL-010",
@@ -2935,7 +2935,7 @@
       "citation": "RM 1.2.0 composition §COMPOSITION.content/context (content List 0..1, context 0..1, Category_validity only); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422 validation)",
       "schedule_ref": "CONT-COMP.content_card_opt-context_mand (master15 §COMPOSITION Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 30
+      "duration_ms": 34
     },
     {
       "ecc_id": "ECC-VAL-011",
@@ -2951,7 +2951,7 @@
       "citation": "RM 1.2.0 composition §COMPOSITION.content/context (content List 0..1, context 0..1, Category_validity only); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422 validation)",
       "schedule_ref": "CONT-COMP.content_card_mand-context_mand (master15 §COMPOSITION Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 23
+      "duration_ms": 18
     },
     {
       "ecc_id": "ECC-VAL-012",
@@ -2967,7 +2967,7 @@
       "citation": "RM 1.2.0 composition §COMPOSITION.content/context (content List 0..1, context 0..1, Category_validity only); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422 validation)",
       "schedule_ref": "CONT-COMP.content_card_3to5-context_mand (master15 §COMPOSITION Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 23
+      "duration_ms": 22
     },
     {
       "ecc_id": "ECC-VAL-013",
@@ -2983,7 +2983,7 @@
       "citation": "RM 1.2.0 ehr §OBSERVATION (data 1..1; state/protocol 0..1); AM aom14 §C_ATTRIBUTE existence; ITS-REST 1.1.0 composition_create (201 / 422 validation)",
       "schedule_ref": "ENTRY.CONT-OBS-state_ex_opt-protocol_ex_opt (master16 §OBSERVATION Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 14
+      "duration_ms": 13
     },
     {
       "ecc_id": "ECC-VAL-014",
@@ -2999,7 +2999,7 @@
       "citation": "RM 1.2.0 ehr §OBSERVATION (data 1..1; state/protocol 0..1); AM aom14 §C_ATTRIBUTE existence; ITS-REST 1.1.0 composition_create (201 / 422 validation)",
       "schedule_ref": "ENTRY.CONT-OBS-state_ex_opt-protocol_ex_mand (master16 §OBSERVATION Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 12
+      "duration_ms": 15
     },
     {
       "ecc_id": "ECC-VAL-015",
@@ -3031,7 +3031,7 @@
       "citation": "RM 1.2.0 ehr §OBSERVATION (data 1..1; state/protocol 0..1); AM aom14 §C_ATTRIBUTE existence; ITS-REST 1.1.0 composition_create (201 / 422 validation)",
       "schedule_ref": "ENTRY.CONT-OBS-state_ex_mand-protocol_ex_mand (master16 §OBSERVATION Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 14
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-VAL-017",
@@ -3047,7 +3047,7 @@
       "citation": "RM 1.2.0 data_structures §HISTORY (events cardinality; summary existence; Events_valid: ≥1 event OR summary); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-HIST-events_card_any-summary_ex_opt (master16 §HISTORY Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 15
+      "duration_ms": 13
     },
     {
       "ecc_id": "ECC-VAL-018",
@@ -3095,7 +3095,7 @@
       "citation": "RM 1.2.0 data_structures §HISTORY (events cardinality; summary existence; Events_valid: ≥1 event OR summary); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-HIST-events_card_opt-summary_ex_opt (master16 §HISTORY Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 13
+      "duration_ms": 15
     },
     {
       "ecc_id": "ECC-VAL-021",
@@ -3127,7 +3127,7 @@
       "citation": "RM 1.2.0 data_structures §HISTORY (events cardinality; summary existence; Events_valid: ≥1 event OR summary); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-HIST-events_card_3to5-summary_ex_opt (master16 §HISTORY Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 11
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-VAL-023",
@@ -3143,7 +3143,7 @@
       "citation": "RM 1.2.0 data_structures §HISTORY (events cardinality; summary existence; Events_valid: ≥1 event OR summary); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-HIST-events_card_any-summary_ex_mand (master16 §HISTORY Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 12
+      "duration_ms": 10
     },
     {
       "ecc_id": "ECC-VAL-024",
@@ -3159,7 +3159,7 @@
       "citation": "RM 1.2.0 data_structures §HISTORY (events cardinality; summary existence; Events_valid: ≥1 event OR summary); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-HIST-events_card_1plus-summary_ex_mand (master16 §HISTORY Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 14
+      "duration_ms": 11
     },
     {
       "ecc_id": "ECC-VAL-025",
@@ -3175,7 +3175,7 @@
       "citation": "RM 1.2.0 data_structures §HISTORY (events cardinality; summary existence; Events_valid: ≥1 event OR summary); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-HIST-events_card_3plus-summary_ex_mand (master16 §HISTORY Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 14
+      "duration_ms": 10
     },
     {
       "ecc_id": "ECC-VAL-026",
@@ -3191,7 +3191,7 @@
       "citation": "RM 1.2.0 data_structures §HISTORY (events cardinality; summary existence; Events_valid: ≥1 event OR summary); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-HIST-events_card_opt-summary_ex_mand (master16 §HISTORY Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 10
+      "duration_ms": 13
     },
     {
       "ecc_id": "ECC-VAL-027",
@@ -3207,7 +3207,7 @@
       "citation": "RM 1.2.0 data_structures §HISTORY (events cardinality; summary existence; Events_valid: ≥1 event OR summary); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-HIST-events_card_mand-summary_ex_mand (master16 §HISTORY Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 10
+      "duration_ms": 11
     },
     {
       "ecc_id": "ECC-VAL-028",
@@ -3223,7 +3223,7 @@
       "citation": "RM 1.2.0 data_structures §HISTORY (events cardinality; summary existence; Events_valid: ≥1 event OR summary); AM aom14 §C_ATTRIBUTE cardinality/existence; ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-HIST-events_card_3to5-summary_ex_mand (master16 §HISTORY Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 12
+      "duration_ms": 10
     },
     {
       "ecc_id": "ECC-VAL-029",
@@ -3255,7 +3255,7 @@
       "citation": "RM 1.2.0 data_structures §EVENT/POINT_EVENT/INTERVAL_EVENT (state 0..1; INTERVAL_EVENT.width/math_function mandatory); AM aom14 §type narrowing; ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-EVENT-state_ex_mand (master16 §EVENT Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 12
+      "duration_ms": 13
     },
     {
       "ecc_id": "ECC-VAL-031",
@@ -3287,7 +3287,7 @@
       "citation": "RM 1.2.0 data_structures §EVENT/POINT_EVENT/INTERVAL_EVENT (state 0..1; INTERVAL_EVENT.width/math_function mandatory); AM aom14 §type narrowing; ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-EVENT-type_point_event (master16 §EVENT Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 10
+      "duration_ms": 9
     },
     {
       "ecc_id": "ECC-VAL-033",
@@ -3319,7 +3319,7 @@
       "citation": "RM 1.2.0 data_structures §ITEM_STRUCTURE (ITEM_TREE/LIST/TABLE/SINGLE); AM aom14 §type narrowing (Class not allowed); ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-ITEM_STR-type_any (master16 §ITEM_STRUCTURE Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 29
+      "duration_ms": 32
     },
     {
       "ecc_id": "ECC-VAL-035",
@@ -3335,7 +3335,7 @@
       "citation": "RM 1.2.0 data_structures §ITEM_STRUCTURE (ITEM_TREE/LIST/TABLE/SINGLE); AM aom14 §type narrowing (Class not allowed); ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-ITEM_STR-type_item_tree (master16 §ITEM_STRUCTURE Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 14
+      "duration_ms": 17
     },
     {
       "ecc_id": "ECC-VAL-036",
@@ -3351,7 +3351,7 @@
       "citation": "RM 1.2.0 data_structures §ITEM_STRUCTURE (ITEM_TREE/LIST/TABLE/SINGLE); AM aom14 §type narrowing (Class not allowed); ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-ITEM_STR-type_item_list (master16 §ITEM_STRUCTURE Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 16
+      "duration_ms": 14
     },
     {
       "ecc_id": "ECC-VAL-037",
@@ -3367,7 +3367,7 @@
       "citation": "RM 1.2.0 data_structures §ITEM_STRUCTURE (ITEM_TREE/LIST/TABLE/SINGLE); AM aom14 §type narrowing (Class not allowed); ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-ITEM_STR-type_item_table (master16 §ITEM_STRUCTURE Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 15
+      "duration_ms": 16
     },
     {
       "ecc_id": "ECC-VAL-038",
@@ -3383,7 +3383,7 @@
       "citation": "RM 1.2.0 data_structures §ITEM_STRUCTURE (ITEM_TREE/LIST/TABLE/SINGLE); AM aom14 §type narrowing (Class not allowed); ITS-REST 1.1.0 composition_create (201 / 422)",
       "schedule_ref": "ENTRY.CONT-ITEM_STR-type_item_single (master16 §ITEM_STRUCTURE Test Cases)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 12
+      "duration_ms": 13
     },
     {
       "ecc_id": "ECC-VAL-039",
@@ -3399,7 +3399,7 @@
       "citation": "RM 1.2.0 data_types §DV_BOOLEAN; AM 1.4 C_BOOLEAN; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_BOOLEAN.anything_allowed (master17.1 §DV_BOOLEAN)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 33
+      "duration_ms": 27
     },
     {
       "ecc_id": "ECC-VAL-040",
@@ -3415,7 +3415,7 @@
       "citation": "RM 1.2.0 data_types §DV_BOOLEAN; AM 1.4 C_BOOLEAN {true}; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_BOOLEAN.only_true_allowed (master17.1 §DV_BOOLEAN)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 35
+      "duration_ms": 28
     },
     {
       "ecc_id": "ECC-VAL-041",
@@ -3431,7 +3431,7 @@
       "citation": "RM 1.2.0 data_types §DV_BOOLEAN; AM 1.4 C_BOOLEAN {false}; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_BOOLEAN.only_false_allowed (master17.1 §DV_BOOLEAN)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 33
+      "duration_ms": 27
     },
     {
       "ecc_id": "ECC-VAL-042",
@@ -3447,7 +3447,7 @@
       "citation": "RM 1.2.0 data_types §DV_IDENTIFIER; AM 1.4 C_STRING.pattern on id; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_IDENTIFIER.validate_all_pattern (master17.1 §DV_IDENTIFIER)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 32
+      "duration_ms": 27
     },
     {
       "ecc_id": "ECC-VAL-043",
@@ -3463,7 +3463,7 @@
       "citation": "RM 1.2.0 data_types §DV_IDENTIFIER; AM 1.4 C_STRING.list on id; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_IDENTIFIER.validate_all_list (master17.1 §DV_IDENTIFIER)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 30
+      "duration_ms": 28
     },
     {
       "ecc_id": "ECC-VAL-044",
@@ -3479,7 +3479,7 @@
       "citation": "RM 1.2.0 data_types §DV_TEXT; AM 1.4 C_STRING open; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_TEXT.validate_open (master17.2 §DV_TEXT; heading duplicated, 2nd C_STRING.pattern table folded)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 22
+      "duration_ms": 21
     },
     {
       "ecc_id": "ECC-VAL-045",
@@ -3495,7 +3495,7 @@
       "citation": "RM 1.2.0 data_types §DV_TEXT; AM 1.4 C_STRING.list; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_TEXT.validate_list (master17.2 §DV_TEXT)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 34
+      "duration_ms": 27
     },
     {
       "ecc_id": "ECC-VAL-046",
@@ -3511,7 +3511,7 @@
       "citation": "RM 1.2.0 data_types §DV_CODED_TEXT; AM 1.4 C_CODE_PHRASE open; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_CODED_TEXT.validate_open (master17.2 §DV_CODED_TEXT)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 22
+      "duration_ms": 21
     },
     {
       "ecc_id": "ECC-VAL-047",
@@ -3527,7 +3527,7 @@
       "citation": "RM 1.2.0 data_types §DV_CODED_TEXT; AM 1.4 C_CODE_PHRASE local code_list; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_CODED_TEXT.validate_local_codes (master17.2 §DV_CODED_TEXT)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 26
+      "duration_ms": 25
     },
     {
       "ecc_id": "ECC-VAL-048",
@@ -3543,7 +3543,7 @@
       "citation": "RM 1.2.0 data_types §DV_CODED_TEXT; AM 1.4 C_CODE_PHRASE external terminology; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_CODED_TEXT.validate_ext_term (master17.2 §DV_CODED_TEXT; direct C_CODE_PHRASE substitutes the CONSTRAINT_REF binding path)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 30
+      "duration_ms": 27
     },
     {
       "ecc_id": "ECC-VAL-049",
@@ -3575,7 +3575,7 @@
       "citation": "RM 1.2.0 data_types §DV_ORDINAL; AM 1.4 C_DV_ORDINAL.list; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_ORDINAL.validate_constraint (master17.3 §DV_ORDINAL)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 21
+      "duration_ms": 20
     },
     {
       "ecc_id": "ECC-VAL-051",
@@ -3591,7 +3591,7 @@
       "citation": "RM 1.2.0 data_types §DV_SCALE (RM ≥ 1.1.0, SPECRM-19); AM 1.4 open; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_SCALE.validate_open (master17.3 §DV_SCALE; RM ≥ 1.1.0)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 29
+      "duration_ms": 27
     },
     {
       "ecc_id": "ECC-VAL-052",
@@ -3607,7 +3607,7 @@
       "citation": "RM 1.2.0 data_types §DV_SCALE (RM ≥ 1.1.0); AM 1.4 C_REAL.list on value (no C_DV_SCALE in AM 1.4, SPECPR-381); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_SCALE.validate_constraint (master17.3 §DV_SCALE; RM ≥ 1.1.0, C_REAL substitute)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 32
+      "duration_ms": 27
     },
     {
       "ecc_id": "ECC-VAL-053",
@@ -3623,7 +3623,7 @@
       "citation": "RM 1.2.0 data_types §DV_COUNT; AM 1.4 C_INTEGER open; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_COUNT.validate_open (master17.3 §DV_COUNT)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 23
+      "duration_ms": 20
     },
     {
       "ecc_id": "ECC-VAL-054",
@@ -3639,7 +3639,7 @@
       "citation": "RM 1.2.0 data_types §DV_COUNT; AM 1.4 C_INTEGER.range; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_COUNT.validate_range (master17.3 §DV_COUNT)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 28
+      "duration_ms": 30
     },
     {
       "ecc_id": "ECC-VAL-055",
@@ -3671,7 +3671,7 @@
       "citation": "RM 1.2.0 data_types §DV_QUANTITY; AM 1.4 C_DV_QUANTITY open; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_QUANTITY.validate_open (master17.3 §DV_QUANTITY)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 20
+      "duration_ms": 23
     },
     {
       "ecc_id": "ECC-VAL-057",
@@ -3703,7 +3703,7 @@
       "citation": "RM 1.2.0 data_types §DV_QUANTITY; AM 1.4 C_DV_QUANTITY units list; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_QUANTITY.validate_property_units (master17.3 §DV_QUANTITY)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 21
+      "duration_ms": 54
     },
     {
       "ecc_id": "ECC-VAL-059",
@@ -3719,7 +3719,7 @@
       "citation": "RM 1.2.0 data_types §DV_QUANTITY; AM 1.4 C_DV_QUANTITY units list + magnitude range; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_QUANTITY.validate_property_units_mag (master17.3 §DV_QUANTITY)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 23
+      "duration_ms": 26
     },
     {
       "ecc_id": "ECC-VAL-060",
@@ -3735,7 +3735,7 @@
       "citation": "RM 1.2.0 data_types §DV_PROPORTION (kind invariants); AM 1.4 open; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_PROPORTION.validate_open (master17.3 §DV_PROPORTION; 14 kind-invariant rejects untested, RM-mandatory numerator only)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 20
+      "duration_ms": 22
     },
     {
       "ecc_id": "ECC-VAL-061",
@@ -3751,7 +3751,7 @@
       "citation": "RM 1.2.0 data_types §DV_PROPORTION (ratio kind 0); AM 1.4 C_INTEGER.list on type; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_PROPORTION.validate_ratio (master17.3 §DV_PROPORTION)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 29
+      "duration_ms": 28
     },
     {
       "ecc_id": "ECC-VAL-062",
@@ -3767,7 +3767,7 @@
       "citation": "RM 1.2.0 data_types §DV_PROPORTION (unitary kind 1); AM 1.4 C_INTEGER.list on type; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_PROPORTION.validate_unitary (master17.3 §DV_PROPORTION)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 28
+      "duration_ms": 32
     },
     {
       "ecc_id": "ECC-VAL-063",
@@ -3783,7 +3783,7 @@
       "citation": "RM 1.2.0 data_types §DV_PROPORTION (percent kind 2); AM 1.4 C_INTEGER.list on type; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_PROPORTION.validate_percent (master17.3 §DV_PROPORTION)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 29
+      "duration_ms": 28
     },
     {
       "ecc_id": "ECC-VAL-064",
@@ -3799,7 +3799,7 @@
       "citation": "RM 1.2.0 data_types §DV_PROPORTION (fraction kind 3); AM 1.4 C_INTEGER.list on type; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_PROPORTION.validate_fraction (master17.3 §DV_PROPORTION)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 30
+      "duration_ms": 28
     },
     {
       "ecc_id": "ECC-VAL-065",
@@ -3815,7 +3815,7 @@
       "citation": "RM 1.2.0 data_types §DV_PROPORTION (integer_fraction kind 4); AM 1.4 C_INTEGER.list on type; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_PROPORTION.validate_integer_fraction (master17.3 §DV_PROPORTION)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 29
+      "duration_ms": 28
     },
     {
       "ecc_id": "ECC-VAL-066",
@@ -3831,7 +3831,7 @@
       "citation": "RM 1.2.0 data_types §DV_PROPORTION; AM 1.4 C_INTEGER.list {3,4} on type; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_PROPORTION.validate_any_fraction (master17.3 §DV_PROPORTION)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 14
+      "duration_ms": 12
     },
     {
       "ecc_id": "ECC-VAL-067",
@@ -3863,7 +3863,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_COUNT>; BASE foundation_types §Interval invariants; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_COUNT.validate_open (master17.3 §DV_INTERVAL<DV_COUNT>; bound C_INTEGER constraint inexpressible → RM Interval invariant triple)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 47
+      "duration_ms": 44
     },
     {
       "ecc_id": "ECC-VAL-069",
@@ -3879,7 +3879,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_COUNT>; BASE foundation_types §Interval (lower ≤ upper); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_COUNT.validate_lower_upper (master17.3; bound constraint inexpressible → RM lower ≤ upper)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 28
+      "duration_ms": 33
     },
     {
       "ecc_id": "ECC-VAL-070",
@@ -3911,7 +3911,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_QUANTITY>; BASE foundation_types §Interval invariants; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_QUANTITY.validate_open (master17.3; bound C_DV_QUANTITY.list inexpressible → RM Interval invariant triple)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 42
+      "duration_ms": 47
     },
     {
       "ecc_id": "ECC-VAL-072",
@@ -3927,7 +3927,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_QUANTITY>; BASE foundation_types §Interval (lower ≤ upper); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_QUANTITY.validate_upper_lower (master17.3; bound constraint inexpressible → RM lower ≤ upper)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 27
+      "duration_ms": 28
     },
     {
       "ecc_id": "ECC-VAL-073",
@@ -3943,7 +3943,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DATE_TIME>; BASE foundation_types §Interval invariants; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_DATE_TIME.validate_open (master17.3; temporal bound inexpressible → RM Interval invariant triple)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 41
+      "duration_ms": 48
     },
     {
       "ecc_id": "ECC-VAL-074",
@@ -3959,7 +3959,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DATE_TIME>; BASE foundation_types §Interval (lower ≤ upper); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_DATE_TIME.validate_lower_upper_constraint (master17.3, 68-row table; C_DATE_TIME bounds inexpressible → RM lower ≤ upper)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 28
+      "duration_ms": 32
     },
     {
       "ecc_id": "ECC-VAL-075",
@@ -3975,7 +3975,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DATE_TIME>; BASE foundation_types §Interval (lower ≤ upper); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_DATE_TIME.validate_lower_upper_range (master17.3; C_DATE_TIME.range bounds inexpressible → RM lower ≤ upper)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 28
+      "duration_ms": 34
     },
     {
       "ecc_id": "ECC-VAL-076",
@@ -3991,7 +3991,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DATE>; BASE foundation_types §Interval invariants; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_DATE.validate_open (master17.3; temporal bound inexpressible → RM Interval invariant triple)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 43
+      "duration_ms": 44
     },
     {
       "ecc_id": "ECC-VAL-077",
@@ -4007,7 +4007,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DATE>; BASE foundation_types §Interval (lower ≤ upper); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_DATE.validate_lower_upper_constraint (master17.3; C_DATE bounds inexpressible → RM lower ≤ upper)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 29
+      "duration_ms": 33
     },
     {
       "ecc_id": "ECC-VAL-078",
@@ -4039,7 +4039,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_TIME>; BASE foundation_types §Interval invariants; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_TIME.validate_open (master17.3; temporal bound inexpressible → RM Interval invariant triple)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 44
+      "duration_ms": 47
     },
     {
       "ecc_id": "ECC-VAL-080",
@@ -4071,7 +4071,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_TIME>; BASE foundation_types §Interval (lower ≤ upper); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_TIME.validate_lower_upper_range (master17.3; C_TIME.range bounds inexpressible → RM lower ≤ upper)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 29
+      "duration_ms": 28
     },
     {
       "ecc_id": "ECC-VAL-082",
@@ -4087,7 +4087,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DURATION>; BASE foundation_types §Interval invariants; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_DURATION.validate_open (master17.3; temporal bound inexpressible → RM Interval invariant triple)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 43
+      "duration_ms": 49
     },
     {
       "ecc_id": "ECC-VAL-083",
@@ -4103,7 +4103,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DURATION>; BASE foundation_types §Interval (lower ≤ upper); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_DURATION.validate_constraint (master17.3, 35-row table; C_DURATION bounds inexpressible → RM lower ≤ upper)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 27
+      "duration_ms": 28
     },
     {
       "ecc_id": "ECC-VAL-084",
@@ -4119,7 +4119,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_DURATION>; BASE foundation_types §Interval (lower ≤ upper); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_DURATION.validate_range (master17.3; C_DURATION.range bounds inexpressible → RM lower ≤ upper)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 29
+      "duration_ms": 28
     },
     {
       "ecc_id": "ECC-VAL-085",
@@ -4135,7 +4135,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_ORDINAL>; BASE foundation_types §Interval invariants; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_ORDINAL.validate_open (master17.3; bound constraint inexpressible → RM Interval invariant triple)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 42
+      "duration_ms": 47
     },
     {
       "ecc_id": "ECC-VAL-086",
@@ -4151,7 +4151,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_ORDINAL>; BASE foundation_types §Interval (lower ≤ upper); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_ORDINAL.validate_constraint (master17.3; C_DV_ORDINAL bounds inexpressible → RM lower ≤ upper)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 28
+      "duration_ms": 30
     },
     {
       "ecc_id": "ECC-VAL-087",
@@ -4167,7 +4167,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_SCALE> (RM ≥ 1.1.0); BASE foundation_types §Interval invariants; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_SCALE.validate_open (master17.3; RM ≥ 1.1.0; bound inexpressible → RM Interval invariant triple)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 44
+      "duration_ms": 42
     },
     {
       "ecc_id": "ECC-VAL-088",
@@ -4199,7 +4199,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; BASE foundation_types §Interval invariants; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_PROPORTION.validate_open (master17.3, 18-row table; bound inexpressible → RM Interval invariant triple)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 44
+      "duration_ms": 50
     },
     {
       "ecc_id": "ECC-VAL-090",
@@ -4215,7 +4215,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; BASE foundation_types §Interval (lower ≤ upper); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_PROPORTION.validate_ratio (master17.3, 12-row table; proportion-kind bound inexpressible → RM lower ≤ upper)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 32
+      "duration_ms": 29
     },
     {
       "ecc_id": "ECC-VAL-091",
@@ -4231,7 +4231,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; BASE foundation_types §Interval (lower ≤ upper); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_PROPORTION.validate_unitary (master17.3, 12-row table; proportion-kind bound inexpressible → RM lower ≤ upper)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 28
+      "duration_ms": 29
     },
     {
       "ecc_id": "ECC-VAL-092",
@@ -4263,7 +4263,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; BASE foundation_types §Interval (lower ≤ upper); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_PROPORTION.validate_fraction (master17.3, 12-row table; proportion-kind bound inexpressible → RM lower ≤ upper)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 29
+      "duration_ms": 27
     },
     {
       "ecc_id": "ECC-VAL-094",
@@ -4279,7 +4279,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; BASE foundation_types §Interval (lower ≤ upper); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_PROPORTION.validate_integer_fraction (master17.3, 12-row table; proportion-kind bound inexpressible → RM lower ≤ upper)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 31
+      "duration_ms": 27
     },
     {
       "ecc_id": "ECC-VAL-095",
@@ -4295,7 +4295,7 @@
       "citation": "RM 1.2.0 data_types §DV_INTERVAL<DV_PROPORTION>; BASE foundation_types §Interval (lower ≤ upper); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_INTERVAL_DV_PROPORTION.validate_ratio_range (master17.3, 18-row table; proportion-kind bound inexpressible → RM lower ≤ upper)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 33
+      "duration_ms": 27
     },
     {
       "ecc_id": "ECC-VAL-096",
@@ -4311,7 +4311,7 @@
       "citation": "RM 1.2.0 data_types §DV_DURATION; AM 1.4 open; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_DURATION.validate_open (master17.4 §DV_DURATION)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 21
+      "duration_ms": 20
     },
     {
       "ecc_id": "ECC-VAL-097",
@@ -4343,7 +4343,7 @@
       "citation": "RM 1.2.0 data_types §DV_DURATION; AM 1.4 C_DURATION.range; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_DURATION.validate_range (master17.4 §DV_DURATION; open finding: temporal enforcement)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 29
+      "duration_ms": 27
     },
     {
       "ecc_id": "ECC-VAL-099",
@@ -4359,7 +4359,7 @@
       "citation": "RM 1.2.0 data_types §DV_DURATION; AM 1.4 C_DURATION.pattern + range; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_DURATION.validate_fields_range (master17.4 §DV_DURATION; open finding: temporal enforcement)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 34
+      "duration_ms": 28
     },
     {
       "ecc_id": "ECC-VAL-100",
@@ -4375,7 +4375,7 @@
       "citation": "RM 1.2.0 data_types §DV_TIME; AM 1.4 open; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_TIME.validate_open (master17.4 §DV_TIME; ISO8601-validity rows not driven, RM-mandatory value only)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 21
+      "duration_ms": 20
     },
     {
       "ecc_id": "ECC-VAL-101",
@@ -4391,7 +4391,7 @@
       "citation": "RM 1.2.0 data_types §DV_TIME; AM 1.4 C_TIME.pattern; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_TIME.validate_constraint (master17.4 §DV_TIME, 70-row table; open finding: temporal enforcement)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 29
+      "duration_ms": 31
     },
     {
       "ecc_id": "ECC-VAL-102",
@@ -4407,7 +4407,7 @@
       "citation": "RM 1.2.0 data_types §DV_TIME; AM 1.4 C_TIME.range; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_TIME.validate_range (master17.4 §DV_TIME, 200-row table — largest; open finding: temporal enforcement)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 32
+      "duration_ms": 29
     },
     {
       "ecc_id": "ECC-VAL-103",
@@ -4423,7 +4423,7 @@
       "citation": "RM 1.2.0 data_types §DV_DATE; AM 1.4 open; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_DATE.validate_open (master17.4 §DV_DATE; ISO8601-validity rows not driven, RM-mandatory value only)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 22
+      "duration_ms": 20
     },
     {
       "ecc_id": "ECC-VAL-104",
@@ -4439,7 +4439,7 @@
       "citation": "RM 1.2.0 data_types §DV_DATE; AM 1.4 C_DATE.pattern; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_DATE.validate_constraint (master17.4 §DV_DATE; open finding: temporal enforcement)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 29
+      "duration_ms": 86
     },
     {
       "ecc_id": "ECC-VAL-105",
@@ -4455,7 +4455,7 @@
       "citation": "RM 1.2.0 data_types §DV_DATE; AM 1.4 C_DATE.range; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_DATE.validate_range (master17.4 §DV_DATE; open finding: temporal enforcement)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 29
+      "duration_ms": 28
     },
     {
       "ecc_id": "ECC-VAL-119",
@@ -4486,7 +4486,7 @@
       "citation": "RM 1.2.0 data_types §DV_DATE_TIME; AM 1.4 open; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_DATE_TIME.validate_open (master17.4 §DV_DATE_TIME; RM-mandatory value only)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 24
+      "duration_ms": 20
     },
     {
       "ecc_id": "ECC-VAL-107",
@@ -4502,7 +4502,7 @@
       "citation": "RM 1.2.0 data_types §DV_DATE_TIME; AM 1.4 C_DATE_TIME.pattern (yyyy-mm-ddTHH:MM:SS); ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_DATE_TIME.validate_constraint (master17.4 §DV_DATE_TIME, 176-row table; explicit open finding: SUT accepts the partial value the table rejects)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 24
+      "duration_ms": 21
     },
     {
       "ecc_id": "ECC-VAL-108",
@@ -4566,7 +4566,7 @@
       "citation": "RM 1.2.0 data_types §DV_MULTIMEDIA; AM 1.4 open; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_MULTIMEDIA.validate_open (master17.6 §DV_MULTIMEDIA; size-mandatory + media-type-codeset rows not driven)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 20
+      "duration_ms": 19
     },
     {
       "ecc_id": "ECC-VAL-112",
@@ -4582,7 +4582,7 @@
       "citation": "RM 1.2.0 data_types §DV_MULTIMEDIA; AM 1.4 C_CODE_PHRASE on media_type; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_MULTIMEDIA.validate_media_type (master17.6 §DV_MULTIMEDIA; size C_INTEGER half of the table not driven)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 89
+      "duration_ms": 28
     },
     {
       "ecc_id": "ECC-VAL-113",
@@ -4598,7 +4598,7 @@
       "citation": "RM 1.2.0 data_types §DV_URI (RFC3986 validity); AM 1.4 open; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_URI.validate_open (master17.7 §DV_URI; headline is RFC3986 validity, ECC drives RM-mandatory value only)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 22
+      "duration_ms": 20
     },
     {
       "ecc_id": "ECC-VAL-114",
@@ -4614,7 +4614,7 @@
       "citation": "RM 1.2.0 data_types §DV_URI; AM 1.4 C_STRING.pattern; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_URI.validate_pattern (master17.7 §DV_URI)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 31
+      "duration_ms": 28
     },
     {
       "ecc_id": "ECC-VAL-115",
@@ -4630,7 +4630,7 @@
       "citation": "RM 1.2.0 data_types §DV_URI; AM 1.4 C_STRING.list; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_URI.validate_list (master17.7 §DV_URI)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 30
+      "duration_ms": 28
     },
     {
       "ecc_id": "ECC-VAL-116",
@@ -4646,7 +4646,7 @@
       "citation": "RM 1.2.0 data_types §DV_EHR_URI (ehr: scheme); AM 1.4 open; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_EHR_URI.validate_open (master17.7 §DV_EHR_URI; headline is the ehr: scheme rule, ECC drives RM-mandatory value only)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 30
+      "duration_ms": 29
     },
     {
       "ecc_id": "ECC-VAL-117",
@@ -4662,7 +4662,7 @@
       "citation": "RM 1.2.0 data_types §DV_EHR_URI; AM 1.4 C_STRING.pattern; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_EHR_URI.validate_pattern (master17.7 §DV_EHR_URI)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 30
+      "duration_ms": 28
     },
     {
       "ecc_id": "ECC-VAL-118",
@@ -4678,7 +4678,7 @@
       "citation": "RM 1.2.0 data_types §DV_EHR_URI; AM 1.4 C_STRING.list; ITS-REST 1.1.0 composition_create (201/422)",
       "schedule_ref": "DV_EHR_URI.validate_list (master17.7 §DV_EHR_URI)",
       "binding": "POST /ehr/{ehr_id}/composition",
-      "duration_ms": 29
+      "duration_ms": 27
     },
     {
       "ecc_id": "ECC-DEM-001",
@@ -4693,7 +4693,7 @@
       "citation": "CNF master10 §create_party (TBD stub); ITS-REST DEVELOPMENT demographic person_create 201; SM I_DEMOGRAPHIC_SERVICE.create_party; RM 1.2.0 demographic §PERSON",
       "ecc_original": "schedule stub (master10 §create_party TBD); derived from SM I_DEMOGRAPHIC_SERVICE.create_party + RM Demographic IM",
       "binding": "POST /demographic/person",
-      "duration_ms": 1
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-DEM-021",
@@ -4723,7 +4723,7 @@
       "citation": "CNF master10 §get_party (TBD stub); ITS-REST DEVELOPMENT demographic person_get 200; SM I_DEMOGRAPHIC_SERVICE.get_party; RM 1.2.0 demographic §PERSON",
       "ecc_original": "schedule stub (master10 §get_party TBD); derived from SM I_DEMOGRAPHIC_SERVICE.get_party + RM Demographic IM",
       "binding": "GET /demographic/person/{uid_based_id}",
-      "duration_ms": 2
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-DEM-007",
@@ -4768,7 +4768,7 @@
       "citation": "CNF master10 §get_party_at_version (TBD stub); ITS-REST DEVELOPMENT demographic person_get (OVID) 200; SM I_DEMOGRAPHIC_SERVICE.get_party_at_version; RM common §OBJECT_VERSION_ID",
       "ecc_original": "schedule stub (master10 §get_party_at_version TBD); derived from SM I_DEMOGRAPHIC_SERVICE.get_party_at_version + RM common Versioning",
       "binding": "GET /demographic/person/{version_uid}",
-      "duration_ms": 3
+      "duration_ms": 1
     },
     {
       "ecc_id": "ECC-DEM-025",
@@ -4843,7 +4843,7 @@
       "citation": "CNF master10 §create_party (TBD stub); ITS-REST DEVELOPMENT demographic agent_create 201; SM I_DEMOGRAPHIC_SERVICE.create_party; RM 1.2.0 demographic §AGENT",
       "ecc_original": "schedule stub (master10 §create_party TBD); derived from SM I_DEMOGRAPHIC_SERVICE.create_party + RM Demographic IM",
       "binding": "POST /demographic/agent",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "ecc_id": "ECC-DEM-010",
@@ -4903,7 +4903,7 @@
       "citation": "CNF master10 §get_party (TBD stub); ITS-REST DEVELOPMENT demographic group_get 200; SM I_DEMOGRAPHIC_SERVICE.get_party; RM 1.2.0 demographic §GROUP",
       "ecc_original": "schedule stub (master10 §get_party TBD); derived from SM I_DEMOGRAPHIC_SERVICE.get_party + RM Demographic IM",
       "binding": "GET /demographic/group/{uid_based_id}",
-      "duration_ms": 2
+      "duration_ms": 1
     },
     {
       "ecc_id": "ECC-DEM-014",
@@ -4948,7 +4948,7 @@
       "citation": "CNF master10 §get_party (TBD stub); ITS-REST DEVELOPMENT demographic organisation_get 200; SM I_DEMOGRAPHIC_SERVICE.get_party; RM 1.2.0 demographic §ORGANISATION",
       "ecc_original": "schedule stub (master10 §get_party TBD); derived from SM I_DEMOGRAPHIC_SERVICE.get_party + RM Demographic IM",
       "binding": "GET /demographic/organisation/{uid_based_id}",
-      "duration_ms": 1
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-DEM-017",
@@ -4963,7 +4963,7 @@
       "citation": "CNF master10 §delete_party (TBD stub); ITS-REST DEVELOPMENT demographic organisation_delete 200/204; SM I_DEMOGRAPHIC_SERVICE.delete_party",
       "ecc_original": "schedule stub (master10 §delete_party TBD); derived from SM I_DEMOGRAPHIC_SERVICE.delete_party + RM Demographic IM",
       "binding": "DELETE /demographic/organisation/{uid_based_id}",
-      "duration_ms": 2
+      "duration_ms": 1
     },
     {
       "ecc_id": "ECC-DEM-018",
@@ -5023,7 +5023,7 @@
       "citation": "ITS-REST DEVELOPMENT demographic versioned_party_get 200; RM common §VERSIONED_OBJECT — no master10 SM operation names this wire resource",
       "ecc_original": "extension: VERSIONED_PARTY read (RM common Versioning); no master10 SM operation",
       "binding": "GET /demographic/versioned_party/{versioned_object_uid}",
-      "duration_ms": 2
+      "duration_ms": 1
     },
     {
       "ecc_id": "ECC-DEM-023",
@@ -5128,7 +5128,7 @@
       "citation": "CNF master10 §delete_party_relationship (TBD stub); SM I_PARTY_RELATIONSHIP.delete_party_relationship — ehrbase-rs extension wire",
       "ecc_original": "schedule stub (master10 §delete_party_relationship TBD); derived from SM I_PARTY_RELATIONSHIP — ehrbase-rs extension wire",
       "binding": "DELETE /demographic/party_relationship/{uid_based_id} (ehrbase-rs extension)",
-      "duration_ms": 3
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-DEM-031",
@@ -5143,7 +5143,7 @@
       "citation": "CNF master10 §get_party_relationship_at_version (TBD stub); SM I_PARTY_RELATIONSHIP.get_party_relationship_at_version; RM common §OBJECT_VERSION_ID — ehrbase-rs extension wire",
       "ecc_original": "schedule stub (master10 §get_party_relationship_at_version TBD); derived from SM I_PARTY_RELATIONSHIP + RM common OBJECT_VERSION_ID — ehrbase-rs extension wire",
       "binding": "GET /demographic/versioned_party_relationship/{versioned_object_uid}/version/{version_uid} (ehrbase-rs extension)",
-      "duration_ms": 4
+      "duration_ms": 3
     },
     {
       "ecc_id": "ECC-ADM-001",
@@ -5233,7 +5233,7 @@
       "citation": "CNF master12 §physical_ehr_delete (TBD stub); ITS-REST DEVELOPMENT admin admin_ehr_delete_all.yaml + ehr_id_Admin.yaml optional selector — instrument-encodes-server-behaviour: an absent ehr_id deletes ALL EHRs (a globally destructive design reading, gated to disposable SUTs)",
       "ecc_original": "schedule stub (master12 §physical_ehr_delete TBD); derived from SM I_ADMIN_SERVICE.physical_ehr_delete + ADMIN OAS admin_ehr_delete[_all].yaml",
       "binding": "DELETE /admin/ehr/all",
-      "duration_ms": 51
+      "duration_ms": 50
     },
     {
       "ecc_id": "ECC-ADM-007",
@@ -5578,7 +5578,7 @@
       "citation": "profiles master03 §Non-Functional Signing (STANDARD); RM common master06 §Version (signature slot) + RFC 8785 canonical form; no openEHR spec governs the digest — ehrbase-rs extension",
       "ecc_original": "extension: sha256: digest recompute is an ehrbase-rs feature (RFC 8785 canonical form); profiles master03 §Non-Functional Signing STANDARD; RM common master06 §Version signature slot",
       "binding": "GET /ehr/{ehr_id}/versioned_composition/{versioned_object_uid}/version/{version_uid}",
-      "duration_ms": 12
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-SIG-003",
@@ -5593,7 +5593,7 @@
       "citation": "profiles master03 §Non-Functional Signing (STANDARD); RM common master06 §Version (signature slot on every versioned object); ehrbase-rs extension",
       "ecc_original": "extension: version signing rides every versioned-object write (ehrbase-rs); profiles master03 §Non-Functional Signing STANDARD; RM common master06 §Version signature slot",
       "binding": "PUT /ehr/{ehr_id}/ehr_status; POST /ehr/{ehr_id}/contribution; POST /ehr/{ehr_id}/directory",
-      "duration_ms": 18
+      "duration_ms": 16
     },
     {
       "ecc_id": "ECC-SIG-004",
@@ -5608,7 +5608,7 @@
       "citation": "profiles master03 §Non-Functional Signing (STANDARD); RM common master06 §Version (client-supplied signature stored verbatim, never re-signed); ehrbase-rs extension",
       "ecc_original": "extension: client-supplied signatures win (ehrbase-rs); profiles master03 §Non-Functional Signing STANDARD; RM common master06 §Version signature slot",
       "binding": "POST /ehr/{ehr_id}/contribution",
-      "duration_ms": 6
+      "duration_ms": 5
     },
     {
       "ecc_id": "ECC-SIG-005",
@@ -5623,7 +5623,7 @@
       "citation": "profiles master03 §Non-Functional Signing (STANDARD); RM common master06 §Version (signature slot); ehrbase-rs extension — pgp mode, RFC 4880 detached signature",
       "ecc_original": "extension: pgp signing mode is an ehrbase-rs feature (RFC 4880); profiles master03 §Non-Functional Signing STANDARD; RM common master06 §Version signature slot",
       "binding": "GET /ehr/{ehr_id}/versioned_composition/{versioned_object_uid}/version/{version_uid}",
-      "duration_ms": 37
+      "duration_ms": 34
     },
     {
       "ecc_id": "ECC-TS-001",
@@ -5638,7 +5638,7 @@
       "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.1.0 QUERY API execute_ad_hoc_query; profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS)",
       "ecc_original": "no CNF schedule chapter for terminology integration; profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS) + QUERY master03 §TERMINOLOGY 748-767; the 'openehr' bundle flavour is an ehrbase-rs AQL engine extension",
       "binding": "POST /query/aql",
-      "duration_ms": 2
+      "duration_ms": 1
     },
     {
       "ecc_id": "ECC-TS-002",
@@ -5653,7 +5653,7 @@
       "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.1.0 QUERY API execute_ad_hoc_query; profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS)",
       "ecc_original": "no CNF schedule chapter for terminology integration; profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS) + QUERY master03 §TERMINOLOGY 748-767; the 'openehr' bundle flavour is an ehrbase-rs AQL engine extension",
       "binding": "POST /query/aql",
-      "duration_ms": 9
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-TS-003",
@@ -5668,7 +5668,7 @@
       "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.1.0 QUERY API execute_ad_hoc_query; profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS)",
       "ecc_original": "no CNF schedule chapter for terminology integration; profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS) + QUERY master03 §TERMINOLOGY 748-767; the 'openehr' bundle flavour is an ehrbase-rs AQL engine extension",
       "binding": "POST /query/aql",
-      "duration_ms": 9
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-TS-004",
@@ -5713,7 +5713,7 @@
       "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.1.0 QUERY API execute_ad_hoc_query; profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS)",
       "ecc_original": "no CNF schedule chapter for terminology integration; profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS) + QUERY master03 §TERMINOLOGY 748-767; the FHIR service_api path realizes the spec mechanism (generic, not an extension)",
       "binding": "POST /query/aql",
-      "duration_ms": 2
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-TS-007",
@@ -5728,7 +5728,7 @@
       "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.1.0 QUERY API execute_ad_hoc_query; profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS)",
       "ecc_original": "no CNF schedule chapter for terminology integration; profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS); a fault-injecting tx cannot be wired into an external SUT over the HTTP-only ECC — fault→500 proven off-wire (MSG precedent)",
       "binding": "POST /query/aql",
-      "duration_ms": 2004
+      "duration_ms": 2006
     },
     {
       "ecc_id": "ECC-TS-008",
@@ -5743,7 +5743,7 @@
       "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.1.0 QUERY API execute_ad_hoc_query; profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS)",
       "ecc_original": "no CNF schedule chapter for terminology integration; profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS); a fault-injecting tx cannot be wired into an external SUT over the HTTP-only ECC — fault→500 proven off-wire (MSG precedent)",
       "binding": "POST /query/aql",
-      "duration_ms": 2
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-TS-009",
@@ -5758,7 +5758,7 @@
       "citation": "QUERY master03 §Functions/Other functions/TERMINOLOGY (lines 748–767); AQL 1.1; ITS-REST 1.1.0 QUERY API execute_ad_hoc_query; profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS)",
       "ecc_original": "no CNF schedule chapter for terminology integration; profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS); a fault-injecting tx cannot be wired into an external SUT over the HTTP-only ECC — fault→500 proven off-wire (MSG precedent)",
       "binding": "POST /query/aql",
-      "duration_ms": 1
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-SF-001",
@@ -5773,7 +5773,7 @@
       "citation": "ITS-REST simplified_formats master04 §Flat format + master05 §RM Mapping; Resources.md §Simplified Formats (application/openehr.wt.flat+json); Requests_and_responses.md §openehr-template-id",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no simplified-formats chapter; ECC-derived from the STABLE ITS-REST Simplified Formats specification (docs/specs/openehr/ITS-REST/docs/simplified_formats/ + specifications/docs/overview/Resources.md §Simplified Formats)",
       "binding": "POST /ehr/{ehr_id}/composition (Content-Type application/openehr.wt.flat+json) → GET /ehr/{ehr_id}/composition/{uid_based_id} (Accept flat/json/structured)",
-      "duration_ms": 17
+      "duration_ms": 19
     },
     {
       "ecc_id": "ECC-SF-002",
@@ -5788,7 +5788,7 @@
       "citation": "ITS-REST simplified_formats master04 §Structured format + master05 §RM Mapping; Resources.md §Simplified Formats (application/openehr.wt.structured+json); Requests_and_responses.md §openehr-template-id",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no simplified-formats chapter; ECC-derived from the STABLE ITS-REST Simplified Formats specification (docs/specs/openehr/ITS-REST/docs/simplified_formats/ + specifications/docs/overview/Resources.md §Simplified Formats)",
       "binding": "POST /ehr/{ehr_id}/composition (Content-Type application/openehr.wt.structured+json) → GET /ehr/{ehr_id}/composition/{uid_based_id} (Accept structured/json/flat)",
-      "duration_ms": 22
+      "duration_ms": 15
     },
     {
       "ecc_id": "ECC-SF-003",
@@ -5803,7 +5803,7 @@
       "citation": "Resources.md §Data representation (RFC 9110 §12.5.1 quality-value negotiation) + §Simplified Formats (Content-Type MUST be present unless 204)",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no simplified-formats chapter; ECC-derived from the STABLE ITS-REST Simplified Formats specification (docs/specs/openehr/ITS-REST/docs/simplified_formats/ + specifications/docs/overview/Resources.md §Simplified Formats)",
       "binding": "GET /ehr/{ehr_id}/composition/{uid_based_id} (Accept with q-values)",
-      "duration_ms": 10
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-SF-004",
@@ -5818,7 +5818,7 @@
       "citation": "Resources.md §Simplified Formats NOTE (deprecated .schema+json) + §Alternative data formats (legacy nc.flat/tds2) + the 406 MUST rule (\"If the service cannot fulfill this aspect of the request, it MUST respond with 406 Not Acceptable\")",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no simplified-formats chapter; ECC-derived from the STABLE ITS-REST Simplified Formats specification (docs/specs/openehr/ITS-REST/docs/simplified_formats/ + specifications/docs/overview/Resources.md §Simplified Formats)",
       "binding": "GET /ehr/{ehr_id}/composition/{uid_based_id} + GET /definition/template/adl1.4/{template_id}/example (Accept a retired type)",
-      "duration_ms": 17
+      "duration_ms": 14
     },
     {
       "ecc_id": "ECC-SF-005",
@@ -5833,7 +5833,7 @@
       "citation": "Resources.md §Simplified Formats NOTE (deprecated .schema+json) + §Alternative data formats (legacy nc.flat/tds2) + the 415 MUST rule (\"If the service cannot process the request payload as the simplified format is not supported, it MUST respond with 415 Unsupported Media Type\")",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no simplified-formats chapter; ECC-derived from the STABLE ITS-REST Simplified Formats specification (docs/specs/openehr/ITS-REST/docs/simplified_formats/ + specifications/docs/overview/Resources.md §Simplified Formats)",
       "binding": "POST /ehr/{ehr_id}/composition + POST /ehr/{ehr_id}/contribution (Content-Type a retired type)",
-      "duration_ms": 8
+      "duration_ms": 5
     },
     {
       "ecc_id": "ECC-SF-006",
@@ -5848,7 +5848,7 @@
       "citation": "Requests_and_responses.md §openehr-template-id (\"MUST be used whenever committing COMPOSITION using a Simplified Format which does not support TEMPLATE_ID under archetype_details.template_id\") + §HTTP status codes row 422 (well-formed but unprocessable)",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no simplified-formats chapter; ECC-derived from the STABLE ITS-REST Simplified Formats specification (docs/specs/openehr/ITS-REST/docs/simplified_formats/ + specifications/docs/overview/Resources.md §Simplified Formats)",
       "binding": "POST /ehr/{ehr_id}/composition (Content-Type flat, no openehr-template-id header)",
-      "duration_ms": 7
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-SF-007",
@@ -5863,7 +5863,7 @@
       "citation": "ITS-REST simplified_formats master04 §Validation (\"Field identifiers match WT metadata structure\"); Requests_and_responses.md §HTTP status codes row 422",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no simplified-formats chapter; ECC-derived from the STABLE ITS-REST Simplified Formats specification (docs/specs/openehr/ITS-REST/docs/simplified_formats/ + specifications/docs/overview/Resources.md §Simplified Formats)",
       "binding": "POST /ehr/{ehr_id}/composition (Content-Type flat, unknown field id)",
-      "duration_ms": 7
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-SF-008",
@@ -5878,7 +5878,7 @@
       "citation": "ITS-REST simplified_formats master04 §Open Value-Sets and the |other Suffix (\"|other is mutually exclusive with |code, |value and |terminology on the same leaf path; servers MUST reject combinations\"); Requests_and_responses.md §HTTP status codes row 422",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no simplified-formats chapter; ECC-derived from the STABLE ITS-REST Simplified Formats specification (docs/specs/openehr/ITS-REST/docs/simplified_formats/ + specifications/docs/overview/Resources.md §Simplified Formats)",
       "binding": "POST /ehr/{ehr_id}/composition (Content-Type flat, |other + |code on one leaf)",
-      "duration_ms": 7
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-SF-009",
@@ -5893,7 +5893,7 @@
       "citation": "Resources.md §Simplified Formats (application/openehr.wt+json = the OPT as a Web Template JSON document); ITS-REST simplified_formats master04 §Node ID Generation Rules (WT tree shape)",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no simplified-formats chapter; ECC-derived from the STABLE ITS-REST Simplified Formats specification (docs/specs/openehr/ITS-REST/docs/simplified_formats/ + specifications/docs/overview/Resources.md §Simplified Formats)",
       "binding": "GET /definition/template/adl1.4/{template_id} (Accept application/openehr.wt+json)",
-      "duration_ms": 5
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-SF-010",
@@ -5908,7 +5908,7 @@
       "citation": "Resources.md §Data representation + §Simplified Formats (the LOCATABLE example is negotiable across canonical JSON/XML and the FLAT/STRUCTURED simplified forms); the Content-Type MUST match the negotiated format",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no simplified-formats chapter; ECC-derived from the STABLE ITS-REST Simplified Formats specification (docs/specs/openehr/ITS-REST/docs/simplified_formats/ + specifications/docs/overview/Resources.md §Simplified Formats)",
       "binding": "GET /definition/template/adl1.4/{template_id}/example (Accept json/xml/flat/structured)",
-      "duration_ms": 8
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-SF-011",
@@ -5923,7 +5923,7 @@
       "citation": "Resources.md §Simplified Formats 406 MUST rule (the example endpoint offers canonical JSON/XML + FLAT/STRUCTURED only; the Web Template media type is not a LOCATABLE representation)",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no simplified-formats chapter; ECC-derived from the STABLE ITS-REST Simplified Formats specification (docs/specs/openehr/ITS-REST/docs/simplified_formats/ + specifications/docs/overview/Resources.md §Simplified Formats)",
       "binding": "GET /definition/template/adl1.4/{template_id}/example (Accept application/openehr.wt+json)",
-      "duration_ms": 4
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-SF-012",
@@ -5938,7 +5938,7 @@
       "citation": "ITS-REST contribution_create.yaml + contribution_get.yaml §Simplified Formats (the CONTRIBUTION envelope stays canonical JSON; each versions[i].data COMPOSITION is simplified); simplified_formats master05 §scope (COMPOSITION + contained classes only)",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no simplified-formats chapter; ECC-derived from the STABLE ITS-REST Simplified Formats specification (docs/specs/openehr/ITS-REST/docs/simplified_formats/ + specifications/docs/overview/Resources.md §Simplified Formats)",
       "binding": "POST /ehr/{ehr_id}/contribution (Content-Type flat) → GET /ehr/{ehr_id}/contribution/{contribution_uid} (Accept flat)",
-      "duration_ms": 11
+      "duration_ms": 7
     },
     {
       "ecc_id": "ECC-SF-013",
@@ -5953,7 +5953,7 @@
       "citation": "ITS-REST simplified_formats master05 §scope (mappings exist for COMPOSITION and its contained classes only; EHR_STATUS is not templated) + Resources.md §Simplified Formats 406/415 MUST rules",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no simplified-formats chapter; ECC-derived from the STABLE ITS-REST Simplified Formats specification (docs/specs/openehr/ITS-REST/docs/simplified_formats/ + specifications/docs/overview/Resources.md §Simplified Formats)",
       "binding": "GET /ehr/{ehr_id}/ehr_status (Accept flat) + PUT /ehr/{ehr_id}/ehr_status (Content-Type flat)",
-      "duration_ms": 2
+      "duration_ms": 1
     },
     {
       "ecc_id": "ECC-SF-014",
@@ -5983,7 +5983,7 @@
       "citation": "ITS-REST simplified_formats master05 §scope (demographic PARTY types are not templated) + Resources.md §Simplified Formats 406/415 MUST rules",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no simplified-formats chapter; ECC-derived from the STABLE ITS-REST Simplified Formats specification (docs/specs/openehr/ITS-REST/docs/simplified_formats/ + specifications/docs/overview/Resources.md §Simplified Formats)",
       "binding": "GET /demographic/person/{uid} (Accept flat) + POST /demographic/person (Content-Type flat)",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "ecc_id": "ECC-SF-016",
@@ -5998,7 +5998,7 @@
       "citation": "ITS-REST simplified_formats master06 §time (ctx/time sets COMPOSITION.context.start_time) + §setting (ctx/setting defaults to openehr::238|other care| when not set)",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no simplified-formats chapter; ECC-derived from the STABLE ITS-REST Simplified Formats specification (docs/specs/openehr/ITS-REST/docs/simplified_formats/ + specifications/docs/overview/Resources.md §Simplified Formats)",
       "binding": "POST /ehr/{ehr_id}/composition (Content-Type flat, ctx/time set) → GET /ehr/{ehr_id}/composition/{uid_based_id} (Accept application/json)",
-      "duration_ms": 10
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-ADL2-001",
@@ -6013,7 +6013,7 @@
       "citation": "ITS-REST definition_template_adl2_upload.yaml (text/plain source) + 201_Template_adl2_upload.yaml (Location + Prefer: minimal empty / representation source / identifier TemplateIdentifier JSON)",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no ADL 2 test case (master04 I_DEFINITION_ADL2 has no upstream cases); ECC-derived from the DEVELOPMENT-status ITS-REST DEFINITION ADL2 operation YAMLs (docs/specs/openehr/ITS-REST/specifications/operations/definition_template_adl2_*.yaml). ADL 2 is OPTIONAL for openEHR conformance (docs/VERSIONS.md ITS-REST DEVELOPMENT row) — OPTIONS-tier, never CORE/STANDARD-gating.",
       "binding": "POST /definition/template/adl2 (Prefer return=minimal|representation|identifier)",
-      "duration_ms": 7
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-ADL2-002",
@@ -6028,7 +6028,7 @@
       "citation": "ITS-REST definition_template_adl2_upload.yaml §409 (409_template_already_exists.yaml — a template with the same template_id already exists)",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no ADL 2 test case (master04 I_DEFINITION_ADL2 has no upstream cases); ECC-derived from the DEVELOPMENT-status ITS-REST DEFINITION ADL2 operation YAMLs (docs/specs/openehr/ITS-REST/specifications/operations/definition_template_adl2_*.yaml). ADL 2 is OPTIONAL for openEHR conformance (docs/VERSIONS.md ITS-REST DEVELOPMENT row) — OPTIONS-tier, never CORE/STANDARD-gating.",
       "binding": "POST /definition/template/adl2 (same HRID twice)",
-      "duration_ms": 2
+      "duration_ms": 1
     },
     {
       "ecc_id": "ECC-ADL2-003",
@@ -6073,7 +6073,7 @@
       "citation": "ITS-REST definition_template_adl2_upload.yaml; AOM2 master05-specialisation §Specialisation (a specialised archetype is validated against its flat parent, resolved from the repository)",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no ADL 2 test case (master04 I_DEFINITION_ADL2 has no upstream cases); ECC-derived from the DEVELOPMENT-status ITS-REST DEFINITION ADL2 operation YAMLs (docs/specs/openehr/ITS-REST/specifications/operations/definition_template_adl2_*.yaml). ADL 2 is OPTIONAL for openEHR conformance (docs/VERSIONS.md ITS-REST DEVELOPMENT row) — OPTIONS-tier, never CORE/STANDARD-gating.",
       "binding": "POST /definition/template/adl2 (parent) → POST /definition/template/adl2 (specialised child)",
-      "duration_ms": 2
+      "duration_ms": 1
     },
     {
       "ecc_id": "ECC-ADL2-006",
@@ -6088,7 +6088,7 @@
       "citation": "ITS-REST definition_template_adl2_get.yaml + 200_Template_adl2_retrieved.yaml (text/plain source | application/json OperationalTemplateV2) + Accept_Template_adl2.yaml (application/xml has no declared response body → 406)",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no ADL 2 test case (master04 I_DEFINITION_ADL2 has no upstream cases); ECC-derived from the DEVELOPMENT-status ITS-REST DEFINITION ADL2 operation YAMLs (docs/specs/openehr/ITS-REST/specifications/operations/definition_template_adl2_*.yaml). ADL 2 is OPTIONAL for openEHR conformance (docs/VERSIONS.md ITS-REST DEVELOPMENT row) — OPTIONS-tier, never CORE/STANDARD-gating.",
       "binding": "GET /definition/template/adl2/{template_id} (Accept text/plain | application/json | application/xml)",
-      "duration_ms": 4
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-ADL2-007",
@@ -6133,7 +6133,7 @@
       "citation": "ITS-REST definition_template_adl2_example_get.yaml + 200_Template_example_retrieved.yaml (LOCATABLE oneOf) + Accept_LOCATABLE.yaml (json / xml / wt.flat+json / wt.structured+json)",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no ADL 2 test case (master04 I_DEFINITION_ADL2 has no upstream cases); ECC-derived from the DEVELOPMENT-status ITS-REST DEFINITION ADL2 operation YAMLs (docs/specs/openehr/ITS-REST/specifications/operations/definition_template_adl2_*.yaml). ADL 2 is OPTIONAL for openEHR conformance (docs/VERSIONS.md ITS-REST DEVELOPMENT row) — OPTIONS-tier, never CORE/STANDARD-gating.",
       "binding": "GET /definition/template/adl2/{template_id}/example (Accept json/xml/flat/structured)",
-      "duration_ms": 7
+      "duration_ms": 6
     },
     {
       "ecc_id": "ECC-ADL2-010",
@@ -6148,7 +6148,7 @@
       "citation": "ITS-REST definition_template_adl2_example_get.yaml + example_type.yaml (input|output) + example_detail_level.yaml (required|medium|complete) + 400.yaml (out-of-enum → 400)",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no ADL 2 test case (master04 I_DEFINITION_ADL2 has no upstream cases); ECC-derived from the DEVELOPMENT-status ITS-REST DEFINITION ADL2 operation YAMLs (docs/specs/openehr/ITS-REST/specifications/operations/definition_template_adl2_*.yaml). ADL 2 is OPTIONAL for openEHR conformance (docs/VERSIONS.md ITS-REST DEVELOPMENT row) — OPTIONS-tier, never CORE/STANDARD-gating.",
       "binding": "GET /definition/template/adl2/{template_id}/example?type=&detail_level=",
-      "duration_ms": 6
+      "duration_ms": 4
     },
     {
       "ecc_id": "ECC-ADL2-011",
@@ -6163,7 +6163,7 @@
       "citation": "ITS-REST definition_template_adl2_example_get.yaml §404 (404_unknown_template_id.yaml) + §406 (406.yaml) + Accept_LOCATABLE.yaml",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no ADL 2 test case (master04 I_DEFINITION_ADL2 has no upstream cases); ECC-derived from the DEVELOPMENT-status ITS-REST DEFINITION ADL2 operation YAMLs (docs/specs/openehr/ITS-REST/specifications/operations/definition_template_adl2_*.yaml). ADL 2 is OPTIONAL for openEHR conformance (docs/VERSIONS.md ITS-REST DEVELOPMENT row) — OPTIONS-tier, never CORE/STANDARD-gating.",
       "binding": "GET /definition/template/adl2/{template_id}/example",
-      "duration_ms": 3
+      "duration_ms": 2
     },
     {
       "ecc_id": "ECC-ADL2-012",
@@ -6178,7 +6178,7 @@
       "citation": "ITS-REST definition_template_adl2_list.yaml + 200_TemplateList_adl2.yaml + schemas/definition/TemplateMetadata.yaml (template_id / concept / archetype_id / created_timestamp)",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no ADL 2 test case (master04 I_DEFINITION_ADL2 has no upstream cases); ECC-derived from the DEVELOPMENT-status ITS-REST DEFINITION ADL2 operation YAMLs (docs/specs/openehr/ITS-REST/specifications/operations/definition_template_adl2_*.yaml). ADL 2 is OPTIONAL for openEHR conformance (docs/VERSIONS.md ITS-REST DEVELOPMENT row) — OPTIONS-tier, never CORE/STANDARD-gating.",
       "binding": "GET /definition/template/adl2",
-      "duration_ms": 2
+      "duration_ms": 1
     },
     {
       "ecc_id": "ECC-AQT-001",
@@ -6193,7 +6193,7 @@
       "citation": "QUERY master03-syntax §Functions/Other functions/TERMINOLOGY (lines 699–767); AQL 1.1; ITS-REST 1.1.0 QUERY API execute_ad_hoc_query (200_QUERY / 400_QUERY); profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS)",
       "ecc_original": "the CNF Platform Conformance Test Schedule defines no terminology-function test case (master05/master11 name none); ECC-derived from QUERY master03-syntax §TERMINOLOGY + profiles master03 §Functional Querying 'AQL & terminology' (OPTIONS).",
       "binding": "POST /ehr/{ehr_id}/composition; POST /query/aql (matches TERMINOLOGY('expand', …))",
-      "duration_ms": 10
+      "duration_ms": 8
     },
     {
       "ecc_id": "ECC-AQT-002",


### PR DESCRIPTION
Closes #189

## What

The `ServiceError` ↔ `SmError` seam was lossy: every `*_does_not_exist` `CALL_STATUS_TYPE` collapsed into `ServiceError::NotFound(String)` and resurrected at the SM boundary as the generic `versioned_object_does_not_exist`, forcing per-method boundary re-raises (the TDD import and the OPT converter) and silently misreporting the SM status on every un-patched path.

## How

- **`ServiceError::NotFound` now carries `SmError`** (the contract's "status field on NotFound" option): `ServiceError::sm` routes all eleven does-not-exist statuses into the variant losslessly, and `From<ServiceError> for SmError` returns the carried error verbatim (`master03-common_package.adoc` §Representing Call Status).
- **Every direct `NotFound` construction site names its precise status**, adjudicated against the SM interface declarations: `i_ehr_status.adoc` (`ehr_id_does_not_exist` throughout), `i_ehr_composition.adoc` (`composition_does_not_exist` / `object_version_does_not_exist` / `versioned_composition_does_not_exist`), `i_ehr_directory.adoc` (`version_does_not_exist` for the at-version read), `i_party.adoc` (`versioned_object_does_not_exist` vs `object_version_does_not_exist` per call — `ensure_any_party`/`ensure_any_relationship` now take the caller's granular miss status so version-addressed reads report `object_version_does_not_exist` exactly as declared). Extension resources the SM has no status for (tenants, event subscriptions, FHIR mappings, item tags) keep the documented generic `versioned_object_does_not_exist`.
- **All four boundary re-raises deleted**: `adl14.rs` opt-convert, `tdd.rs` prepare, and both demographic `get_*_at_version` re-raises — the producers carry the status now. A sweep found no other stopgaps of that shape (the one remaining `NotFound` match is the deliberate contribution-commit 404→400 scope translation, which ITS-REST mandates).

## Wire proof (exit criterion 3)

- HTTP statuses unchanged by construction: every does-not-exist status maps to `404` in both the service-side table test and the adapter's `sm_api_error` row set; the status-mapping table test rows are untouched.
- New `does_not_exist_statuses_round_trip_losslessly` test pins the seam per status.
- Status-pinning tests updated from the generic collapse to the granular statuses their own comments already documented (e.g. "`has_ehr` is false → `ehr_id_does_not_exist`" now asserts exactly that).
- Full ECC run: **402 executed · 384 passed · 0 failed · 18 N/A — zero drift** vs the committed baseline (artifact diff is run metadata only).

## Gates

- `cargo clippy --workspace --all-targets --all-features` — clean (0 warnings)
- `cargo nextest run --workspace` — 2303/2303 passed
- `bash scripts/conformance.sh` — zero drift (artifacts committed)
- Changelog `[Unreleased]` → Fixed entry added