### PR TITLE
release: v3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+## [3.6.0] - 2026-07-21
+
 ### Changed
 
 - OPT-1.4 → ADL2 conversion fidelity: `DV_ORDINAL`/`DV_QUANTITY` constraints
@@ -1070,7 +1072,8 @@ but has not yet run in production.
   seccomp, default-deny NetworkPolicy) and golden-render validation.
 
 
-[unreleased]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.5.0...HEAD
+[unreleased]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.6.0...HEAD
+[3.6.0]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.5.0...v3.6.0
 [3.5.0]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.4.0...v3.5.0
 [3.4.0]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.3.0...v3.4.0
 [3.3.0]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.2.0...v3.3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,7 +723,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "benchmark"
-version = "3.5.0"
+version = "3.6.0"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -1410,7 +1410,7 @@ dependencies = [
 
 [[package]]
 name = "conformance"
-version = "3.5.0"
+version = "3.6.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase"
-version = "3.5.0"
+version = "3.6.0"
 dependencies = [
  "assert_fs",
  "async-trait",
@@ -2389,7 +2389,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase-admin-ui"
-version = "3.5.0"
+version = "3.6.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2428,7 +2428,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase-rest"
-version = "3.5.0"
+version = "3.6.0"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -2481,7 +2481,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase-server"
-version = "3.5.0"
+version = "3.6.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-codegen"
-version = "3.5.0"
+version = "3.6.0"
 dependencies = [
  "roxmltree",
  "serde_json",
@@ -5300,7 +5300,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-flat"
-version = "3.5.0"
+version = "3.6.0"
 dependencies = [
  "fancy-regex",
  "indexmap 2.14.0",
@@ -8341,7 +8341,7 @@ dependencies = [
 
 [[package]]
 name = "testkit"
-version = "3.5.0"
+version = "3.6.0"
 dependencies = [
  "ehrbase",
  "sqlx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "3"                      # resolver v3 (edition 2024)
 members = ["crates/*", "app/*", "tools/*"]
 
 [workspace.package]
-version = "3.5.0"
+version = "3.6.0"
 edition = "2024"
 rust-version = "1.96"
 license = "Apache-2.0"

--- a/deploy/helm/ehrbase-rs/Chart.yaml
+++ b/deploy/helm/ehrbase-rs/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 # Chart versioning is independent of the application version.
 version: 3.2.0
 # The default container image tag (informational; overridable via image.tag).
-appVersion: "3.5.0"
+appVersion: "3.6.0"
 
 # PDB (policy/v1, GA 1.21), HPA (autoscaling/v2, GA 1.23), and the
 # seccompProfile pod field (GA 1.27) all resolve cleanly at 1.25+.

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.5.0"
+    app.kubernetes.io/version: "3.6.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -58,7 +58,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.5.0"
+    app.kubernetes.io/version: "3.6.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -77,7 +77,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.5.0"
+    app.kubernetes.io/version: "3.6.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
   annotations:
@@ -96,7 +96,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.5.0"
+    app.kubernetes.io/version: "3.6.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 type: Opaque
@@ -120,7 +120,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.5.0"
+    app.kubernetes.io/version: "3.6.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 type: Opaque
@@ -139,7 +139,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.5.0"
+    app.kubernetes.io/version: "3.6.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 data:
@@ -296,7 +296,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.5.0"
+    app.kubernetes.io/version: "3.6.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -323,7 +323,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.5.0"
+    app.kubernetes.io/version: "3.6.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -335,7 +335,7 @@ spec:
     metadata:
       annotations:
         # Roll pods when the rendered ehrbase.toml changes.
-        checksum/config: f0bb181a8c0447330ec90bdd67a29d63a50f5b827286c90d4147df53df5c3473
+        checksum/config: 18f9f5e8103ec218273d87f3fbfaf9a761f95fa6668590f07689ec7ff39256ed
         prometheus.io/scrape: "true"
         prometheus.io/port: "9100"
         prometheus.io/path: "/management/prometheus"
@@ -356,7 +356,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ehrbase
-          image: "ghcr.io/rubentalstra/ehrbase-rs:3.5.0"
+          image: "ghcr.io/rubentalstra/ehrbase-rs:3.6.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -478,7 +478,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.5.0"
+    app.kubernetes.io/version: "3.6.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -511,7 +511,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.5.0"
+    app.kubernetes.io/version: "3.6.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.5.0"
+    app.kubernetes.io/version: "3.6.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -36,7 +36,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.5.0"
+    app.kubernetes.io/version: "3.6.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -55,7 +55,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.5.0"
+    app.kubernetes.io/version: "3.6.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 automountServiceAccountToken: false
@@ -69,7 +69,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.5.0"
+    app.kubernetes.io/version: "3.6.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 data:
@@ -168,7 +168,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.5.0"
+    app.kubernetes.io/version: "3.6.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -191,7 +191,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.5.0"
+    app.kubernetes.io/version: "3.6.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -204,7 +204,7 @@ spec:
     metadata:
       annotations:
         # Roll pods when the rendered ehrbase.toml changes.
-        checksum/config: 9b03d7bf66f1a449bd91a5532100bcd850af80a4f3909b4ddf33e1b82e83f9f9
+        checksum/config: 3ab45f5e6d34b93e881ab7c5524e40d21ea5a5b275bdd3f7b6d2ea732b9a5966
       labels:
         app.kubernetes.io/name: ehrbase-rs
         app.kubernetes.io/instance: ehrbase-rs
@@ -222,7 +222,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ehrbase
-          image: "ghcr.io/rubentalstra/ehrbase-rs:3.5.0"
+          image: "ghcr.io/rubentalstra/ehrbase-rs:3.6.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
Cuts v3.6.0 per the changelog discipline: `[Unreleased]` renamed to `## [3.6.0] - 2026-07-21` (fresh empty `[Unreleased]` re-added, link references updated), workspace version + `Cargo.lock`, Helm `appVersion` and golden renders bumped (`deploy/helm/validate.sh --update` — all checks passed).

The release carries the two v3.6.0 milestone issues, both merged with zero-drift ECC runs (402 executed · 384 passed · 0 failed · 18 N/A):

- #189 — `ServiceError` carries the granular SM `CALL_STATUS_TYPE` (no more `NotFound` resurrection; all four boundary re-raises removed) — PR #199
- #188 — the OPT-1.4 → ADL2 conversion fidelity tail (attribute tuples, slot assertions, term bindings, defaults, temporal ranges, the conversion report; whole-OPT-corpus gate) — PR #208

After merge: annotated tag `v3.6.0` on the merge commit (the release workflow publishes from the matching changelog section), close the v3.6.0 milestone, ensure v3.7.0 exists.