### PR TITLE
feat: CNF 2.0 reference runner — artifact schemas in Rust (first workstream of #202)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,21 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
-## [3.6.0] - 2026-07-21
+### Added
+
+- CNF 2.0 reference runner (`tools/cnf-runner`), first increment: the typed
+  schedule-artifact model (case cores, per-ITS operation bindings, outcome +
+  selector vocabularies, the capability→family→tier matrix, corpus manifest,
+  ambiguity register — every closed vocabulary a Rust enum/newtype), a
+  published JSON-Schema set for all seven artifact families (committed under
+  `tools/cnf-runner/schemas/`, drift-guarded, vendorable by any runner), a
+  full cross-artifact validator (id uniqueness, SM-operation and spec-ref
+  resolution against the vendored specs, binding completeness, corpus
+  integrity, reference/sentinel and decision-table grammars, capability-tier
+  consistency), the `cnf-runner` CLI (`emit-schemas`, `validate`), and the
+  eight pilot case encodings as the first schedule artifacts. The existing
+  ECC (`tools/conformance`) is unchanged and remains the acceptance
+  instrument until the comparison gate.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,6 +1335,21 @@ dependencies = [
  "der",
  "spki",
  "x509-cert",
+]
+
+[[package]]
+name = "cnf-runner"
+version = "3.6.0"
+dependencies = [
+ "assert_fs",
+ "clap",
+ "jsonschema",
+ "regex",
+ "semver",
+ "serde",
+ "serde-saphyr",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2588,6 +2614,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "enum-ordinalize"
 version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3155,6 +3190,16 @@ dependencies = [
  "serde_json",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "granit-parser"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a8a3d7c6a0b0e077d7f8d21df7ec74ce97870ef25f40af4336df33b6cfdf1d4"
+dependencies = [
+ "arraydeque",
+ "smallvec",
 ]
 
 [[package]]
@@ -4894,6 +4939,12 @@ dependencies = [
  "cfg_aliases",
  "libc",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -7330,6 +7381,23 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-saphyr"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f585dc5cd9a358fd20811c238205b1bf009f061de1d0477263159631dd4cc92"
+dependencies = [
+ "annotate-snippets",
+ "base64 0.22.1",
+ "encoding_rs_io",
+ "granit-parser",
+ "nohash-hasher",
+ "num-traits",
+ "serde_core",
+ "smallvec",
+ "zmij",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,8 @@ serde_path_to_error = "0.1"
 quick-xml = { version = "0.41.0", features = ["serialize"] }   # verify latest 0.3x
 roxmltree = "0.21"                   # read-only XML DOM — XSD reader for the XML codegen (ADR-005)
 serde_norway = "0.9"                 # maintained serde_yaml fork — parse vendored OAS YAML for the REST codegen (ADR-005)
+serde-saphyr = "1.0.0-rc.1"          # pure-Rust YAML 1.2 front-end (no RUSTSEC; alias-expansion Budget) — the CNF 2.0 schedule authoring surface (tools/cnf-runner)
+semver = "1.0.28"                    # Cargo/semver requirement syntax for the CNF case `applies` spec-version ranges
 base64 = "0.22"
 rust_decimal = { version = "1", features = ["serde-with-str"] }   # BigDecimal replacement (DV_QUANTITY)
 rust_decimal_macros = "1"

--- a/tools/cnf-runner/CLAUDE.md
+++ b/tools/cnf-runner/CLAUDE.md
@@ -1,0 +1,30 @@
+# `cnf-runner` — the CNF 2.0 reference runner (tooling, not part of the app)
+
+The ground-up rebuild of the conformance instrument (#202, W1–W7): a
+data-driven interpreter over the CNF 2.0 machine-readable schedule. The
+schedule is the ONLY DSL — no cucumber, no Hurl, no second test-definition
+language, ever.
+
+- **Artifact families are the contract** (case cores, operation bindings,
+  vocabularies incl. the capability→family→tier matrix, corpus manifest,
+  ambiguity register, party artifacts statement/results/ixit). The committed
+  JSON Schemas under `schemas/` are the published norm — emission is
+  deterministic and drift-guarded by a nextest test; never hand-edit an
+  emitted schema.
+- **Every closed vocabulary is a Rust enum/newtype** (outcome kinds,
+  selectors, header matchers, capture sources, the `${…}` reference grammar,
+  dispositions, sentinels): illegal states unrepresentable. New vocabulary
+  values enter only by schedule release, never ad hoc.
+- **Cases speak SM + outcome kinds only** — nothing wire-level (no HTTP
+  status, header, or media type) in a case core; wire lives in per-ITS
+  operation bindings, each mapping cited to its OAS source.
+- **Expectations trace to spec text** (`docs/specs/openehr/CNF/`, `QUERY`,
+  `ITS-REST`) — never to observed SUT behaviour; EHRbase and ECC
+  (`tools/conformance`, running untouched until the W2 comparison gate) are
+  prior art, not oracles. Spec silences go through the ambiguity register
+  with a typed `disposition`, never private resolution.
+- **Verdicts are computed, never asserted** — pure functions of
+  (statement, results, catalogue, capability matrix).
+- Gates: `cargo clippy -p cnf-runner --all-targets` +
+  `cargo nextest run -p cnf-runner` (schema drift, pilot acceptance,
+  seeded-defect rejection, the §8.13-derived cross-artifact guards).

--- a/tools/cnf-runner/Cargo.toml
+++ b/tools/cnf-runner/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "cnf-runner"
+version.workspace = true
+description = "CNF 2.0 reference runner: typed schedule-artifact model, validator, and JSON-Schema emission (later: flow interpreter, party-artifact emission, performance machinery)"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+publish = false
+
+[[bin]]
+name = "cnf-runner"
+path = "src/bin/cnf-runner.rs"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+# YAML authoring front-end for the schedule artifacts: pure Rust, no RUSTSEC
+# advisories, alias-expansion Budget against untrusted case files.
+serde-saphyr = { workspace = true }
+# The published artifact schemas are the norm; every loaded artifact validates
+# against them before typed parsing.
+jsonschema = { workspace = true }
+# `applies` spec-version ranges use the Cargo/semver requirement grammar.
+semver = { workspace = true }
+regex = { workspace = true }
+thiserror = { workspace = true }
+clap = { workspace = true }
+
+[dev-dependencies]
+assert_fs = { workspace = true }
+
+[lints]
+workspace = true

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL14.list_opts.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL14.list_opts.yaml
@@ -1,0 +1,12 @@
+# Wire realization of I_DEFINITION_ADL14.list_opts for ITS-REST 1.1.0.
+# Sources: specifications/operations/definition_template_adl1.4_list.yaml (200).
+# Case ids keep the schedule's get_opts family per AMB-13.
+sm_operation: I_DEFINITION_ADL14.list_opts
+its: its-rest
+request:
+  method: GET
+  path: /definition/template/adl1.4
+  headers:
+    Accept: application/json
+outcomes:
+  ok: { status: 200, headers: { Content-Type: negotiated } }

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL14.upload_opt.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL14.upload_opt.yaml
@@ -1,0 +1,21 @@
+# Wire realization of I_DEFINITION_ADL14.upload_opt for ITS-REST 1.1.0.
+# Sources: specifications/operations/definition_template_adl1.4_upload.yaml,
+# responses/201_Template_adl1_4_upload.yaml, 409_template_already_exists.yaml.
+sm_operation: I_DEFINITION_ADL14.upload_opt
+its: its-rest
+request:
+  method: POST
+  path: /definition/template/adl1.4
+  body: opt_xml
+  headers:
+    Content-Type: application/xml         # the ONLY accepted upload type (operation enum)
+outcomes:
+  created: { status: 201 }                # 201_Template_adl1_4_upload.yaml
+  already_exists: { status: 409 }         # duplicate template_id — AMB-4
+  validation_failed:
+    status: 400
+    body: error_loose                     # AMB-1
+captures:
+  template_id:
+    from: body "template_id"              # implementation latitude (AMB-4 area)
+    fallback: header Location last-segment

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_COMPOSITION.create_composition.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_COMPOSITION.create_composition.yaml
@@ -1,0 +1,45 @@
+# Wire realization of I_EHR_COMPOSITION.create_composition for ITS-REST 1.1.0.
+# Sources: specifications/operations/composition_create.yaml,
+# responses/201_COMPOSITION.yaml, 404_unknown_ehr_id.yaml, 422.yaml;
+# format headers per Accept_LOCATABLE / ContentType_LOCATABLE.
+sm_operation: I_EHR_COMPOSITION.create_composition
+its: its-rest
+request:
+  method: POST
+  path: /ehr/{ehr_id}/composition
+  body: composition
+  headers:
+    Prefer: "return=representation"
+formats: [canonical-json, canonical-xml, wt-flat, wt-structured]
+format_headers:
+  wt-flat:
+    Content-Type: application/openehr.wt.flat+json
+    openehr-template-id: required
+  wt-structured:
+    Content-Type: application/openehr.wt.structured+json
+    openehr-template-id: required
+outcomes:
+  created:
+    status: 201                           # 201_COMPOSITION.yaml
+    headers:
+      ETag: 'pattern:W/"<versioned_object_uid>::<system_id>::1"'
+      Location: present
+      Content-Type: negotiated
+    body: prefer_conditional
+  not_found: { status: 404 }              # unknown ehr_id (404_unknown_ehr_id.yaml)
+  validation_failed:
+    status: 422                           # 422.yaml
+    body: error_loose                     # AMB-1
+  template_not_found:
+    status: 422                           # same wire code; kind distinguished by fixture
+    body: error_loose
+  missing_template_id: { status: 422 }    # simplified commit without openehr-template-id
+  unsupported_media: { status: 415 }      # overview negotiation rules (AMB-7 layering)
+captures:
+  version_uid:
+    from: header ETag
+    strip: weak-quotes
+  versioned_object_uid:
+    from: capture version_uid
+    transform: root-uid
+server_assigned: [uid, context/_uid, "composer/external_ref", territory/terminology_id]

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_COMPOSITION.get_composition_at_version.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_COMPOSITION.get_composition_at_version.yaml
@@ -1,0 +1,15 @@
+# Wire realization of I_EHR_COMPOSITION.get_composition_at_version for
+# ITS-REST 1.1.0.
+# Sources: specifications/operations/composition_get.yaml (200/204/404).
+sm_operation: I_EHR_COMPOSITION.get_composition_at_version
+its: its-rest
+request:
+  method: GET
+  path: /ehr/{ehr_id}/composition/{version_uid}
+formats: [canonical-json, canonical-xml, wt-flat, wt-structured]
+outcomes:
+  ok:
+    status: 200                           # 200_COMPOSITION_retrieved.yaml
+    headers: { Content-Type: negotiated }
+  ok_empty: { status: 204 }               # deleted at requested time (composition_get.yaml)
+  not_found: { status: 404 }

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_COMPOSITION.update_composition.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_COMPOSITION.update_composition.yaml
@@ -1,0 +1,33 @@
+# Wire realization of I_EHR_COMPOSITION.update_composition for ITS-REST 1.1.0.
+# Sources: specifications/operations/composition_update.yaml,
+# responses/200_COMPOSITION_updated.yaml / 204_version_updated.yaml,
+# 412_COMPOSITION.yaml; If-Match per overview Requests_and_responses.
+sm_operation: I_EHR_COMPOSITION.update_composition
+its: its-rest
+request:
+  method: PUT
+  path: /ehr/{ehr_id}/composition/{versioned_object_uid}
+  body: composition
+  headers:
+    If-Match: '"${preceding_version_uid}"'   # REQUIRED (If-Match.yaml); realizes SM preceding_version_uid (AMB-3)
+    Prefer: "return=representation"
+formats: [canonical-json, canonical-xml, wt-flat, wt-structured]
+outcomes:
+  updated:
+    status: 200                           # 204 when Prefer minimal (204_version_updated.yaml)
+    headers:
+      ETag: 'pattern:W/"<versioned_object_uid>::<system_id>::<n>"'
+    body: prefer_conditional
+  precondition_failed:
+    status: 412                           # 412_COMPOSITION.yaml, MUST
+    headers: { ETag: latest-version-uid }
+  precondition_missing: { status: 400 }   # If-Match absent -> SHOULD 400 (Requests_and_responses)
+  not_found: { status: 404 }              # unknown ehr_id or uid
+  version_not_found: { status: 404 }      # unknown preceding version — same 404 family
+  validation_failed: { status: 422, body: error_loose }
+  template_mismatch: { status: 422, body: error_loose }   # wrong-template update (master07)
+captures:
+  version_uid:
+    from: header ETag
+    strip: weak-quotes
+server_assigned: [uid, context/_uid]

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_CONTRIBUTION.commit_contribution.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_CONTRIBUTION.commit_contribution.yaml
@@ -1,0 +1,28 @@
+# Wire realization of I_EHR_CONTRIBUTION.commit_contribution for ITS-REST 1.1.0.
+# Sources: specifications/operations/contribution_create.yaml (201/400/404/409),
+# responses/201_CONTRIBUTION.yaml, 400_CONTRIBUTION.yaml.
+sm_operation: I_EHR_CONTRIBUTION.commit_contribution
+its: its-rest
+request:
+  method: POST
+  path: /ehr/{ehr_id}/contribution
+  body: contribution                      # CONTRIBUTION envelope: versions[] + audit
+  headers:
+    Prefer: "return=representation"
+formats: [canonical-json, canonical-xml]
+outcomes:
+  created:
+    status: 201                           # 201_CONTRIBUTION.yaml — the whole commit is one transaction
+    headers: { ETag: present, Location: present }
+    body: prefer_conditional
+  validation_failed:
+    status: 400                           # 400_CONTRIBUTION.yaml — aggregate rejection, nothing committed
+    body: error_loose                     # AMB-1
+  not_found: { status: 404 }
+  conflict: { status: 409 }
+captures:
+  contribution_uid:
+    from: body "uid.value"
+    fallback: header Location last-segment
+  version_uids:
+    from: body "versions[*].id.value"     # list capture: one element per committed VERSION

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_SERVICE.create_ehr.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_SERVICE.create_ehr.yaml
@@ -1,0 +1,30 @@
+# Wire realization of I_EHR_SERVICE.create_ehr for ITS-REST 1.1.0.
+# Sources: specifications/operations/ehr_create.yaml (+ ehr_create_with_id),
+# responses/201_EHR.yaml, 409_EHR.yaml; overview Requests_and_responses.
+sm_operation: I_EHR_SERVICE.create_ehr
+its: its-rest
+applies: { its_rest: ">=1.0.0" }
+request:
+  method: POST
+  path: /ehr
+  body: ehr_status?                       # optional EHR_STATUS (ehr_create.yaml)
+  headers:
+    Prefer: "return=representation"       # default is return=minimal (Prefer.yaml); ask for the body
+formats: [canonical-json, canonical-xml]  # EHR resource is canonical-only (Accept_canonical)
+outcomes:
+  created:
+    status: 201                           # 201_EHR.yaml
+    headers: { ETag: present, Location: present }
+    body: prefer_conditional              # oneOf [Ehr | {uid} | empty] per Prefer
+  already_exists:
+    status: 409                           # 409_EHR.yaml (subject/ehr_id conflict)
+  validation_failed:
+    status: 400                           # AMB-2: no 422 enumerated on EHR create
+captures:
+  ehr_id:
+    from: body "ehr_id.value"
+    fallback: header Location last-segment
+  version_uid:
+    from: header ETag
+    strip: weak-quotes
+server_assigned: [ehr_id, system_id, time_created, ehr_status/uid, ehr_access]

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_SERVICE.get_ehr.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_SERVICE.get_ehr.yaml
@@ -1,0 +1,11 @@
+# Wire realization of I_EHR_SERVICE.get_ehr for ITS-REST 1.1.0.
+# Sources: specifications/operations/ehr_get_by_id.yaml (200/404).
+sm_operation: I_EHR_SERVICE.get_ehr
+its: its-rest
+request:
+  method: GET
+  path: /ehr/{ehr_id}
+formats: [canonical-json, canonical-xml]
+outcomes:
+  ok: { status: 200, headers: { Content-Type: negotiated } }
+  not_found: { status: 404 }              # 404.yaml (unknown ehr_id)

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_STATUS.get_ehr_status.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_STATUS.get_ehr_status.yaml
@@ -1,0 +1,17 @@
+# Wire realization of I_EHR_STATUS.get_ehr_status for ITS-REST 1.1.0.
+# Sources: specifications/operations/ehr_status_get_at_time.yaml (200/400/404).
+sm_operation: I_EHR_STATUS.get_ehr_status
+its: its-rest
+request:
+  method: GET
+  path: /ehr/{ehr_id}/ehr_status
+formats: [canonical-json, canonical-xml]
+outcomes:
+  ok:
+    status: 200                           # 200_EHR_STATUS_retrieved.yaml
+    headers: { ETag: present, Content-Type: negotiated }
+  not_found: { status: 404 }
+captures:
+  status_version_uid:
+    from: header ETag
+    strip: weak-quotes

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_QUERY_SERVICE.execute_ad_hoc_query.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_QUERY_SERVICE.execute_ad_hoc_query.yaml
@@ -1,0 +1,24 @@
+# Wire realization of I_QUERY_SERVICE.execute_ad_hoc_query for ITS-REST 1.1.0.
+# Sources: specifications/operations query_execute (POST /query/aql),
+# responses/200_Query.yaml, 400_Query.yaml, 408_Query.yaml.
+sm_operation: I_QUERY_SERVICE.execute_ad_hoc_query
+its: its-rest
+request:
+  method: POST                            # spec-recommended over GET for parameterized queries
+  path: /query/aql
+  body:
+    q: "${q}"
+    query_parameters: "${query_parameters?}"
+    offset: "${offset?}"
+    fetch: "${fetch?}"
+  headers:
+    Content-Type: application/json
+    Accept: application/json
+formats: [canonical-json]
+outcomes:
+  ok:
+    status: 200                           # 200_Query.yaml
+    headers: { ETag: "present?" }
+    body: result_set_body
+  invalid_query: { status: 400 }          # 400_Query.yaml
+  timeout: { status: 408 }                # 408_Query.yaml

--- a/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
+++ b/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
@@ -1,0 +1,114 @@
+# The governed corpus manifest: verdict + defect live HERE, never only in a
+# filename; generated sets are committed deterministic recipe contracts
+# (corpus/recipes/*.md, digest-pinned).
+# TODO: replace the structural placeholder payloads with the spine-first
+#       authored corpus when the catalogue authoring lands (#202).
+cnf.opt.invalid.empty_file:
+  source: fixtures/opt/invalid/empty_file.opt
+  format: opt-xml
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "empty file"
+    spec_ref: "CNF platform_test_schedule master04 (upload_opt invalid data sets)"
+  provenance: "authored 2026-07-21 from the CNF master04 data-set description; structural placeholder pending corpus authoring"
+cnf.opt.invalid.empty_template_id:
+  source: fixtures/opt/invalid/empty_template_id.opt
+  format: opt-xml
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "empty template_id"
+    spec_ref: "CNF platform_test_schedule master04 (upload_opt invalid data sets); AM AOM1.4 (OPERATIONAL_TEMPLATE.template_id)"
+  provenance: "authored 2026-07-21 from the CNF master04 data-set description; structural placeholder pending corpus authoring"
+cnf.opt.invalid.removed_mandatory:
+  source: fixtures/opt/invalid/removed_mandatory.opt
+  format: opt-xml
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "removed mandatory elements (no definition)"
+    spec_ref: "CNF platform_test_schedule master04 (upload_opt invalid data sets); AM AOM1.4 (OPERATIONAL_TEMPLATE.definition is mandatory)"
+  provenance: "authored 2026-07-21 from the CNF master04 data-set description; structural placeholder pending corpus authoring"
+cnf.opt.invalid.multiple_elements:
+  source: fixtures/opt/invalid/multiple_elements.opt
+  format: opt-xml
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "multiple elements where upper bound is 1 (two template_id)"
+    spec_ref: "CNF platform_test_schedule master04 (upload_opt invalid data sets); AM AOM1.4 (OPERATIONAL_TEMPLATE.template_id 1..1)"
+  provenance: "authored 2026-07-21 from the CNF master04 data-set description; structural placeholder pending corpus authoring"
+cnf.opt.minimal_event:
+  source: templates/minimal_event.opt
+  format: opt-xml
+  rm_versions: [">=1.0.2"]
+  validity: { verdict: valid }
+  provenance: "authored 2026-07-21 (minimal event OPT); structural placeholder pending corpus authoring"
+cnf.opt.vitals:
+  source: templates/vitals.opt
+  format: opt-xml
+  rm_versions: [">=1.0.2"]
+  validity: { verdict: valid }
+  provenance: "authored 2026-07-21 (vital-signs OPT); structural placeholder pending corpus authoring"
+cnf.opt.blood_pressure:
+  source: templates/blood_pressure.opt
+  format: opt-xml
+  rm_versions: [">=1.0.2"]
+  validity: { verdict: valid }
+  provenance: "authored 2026-07-21 (blood-pressure OPT); structural placeholder pending corpus authoring"
+cnf.tpl.quantity_property_units_mag:
+  source: templates/quantity_property_units_mag.opt
+  format: opt-xml
+  rm_versions: [">=1.0.2"]
+  validity: { verdict: valid }
+  provenance: "authored 2026-07-21 (C_DV_QUANTITY constraint context: property=openehr::122, list=[cm 5.0..10.0, m]); structural placeholder pending corpus authoring"
+cnf.composition.minimal_event.v1:
+  source: fixtures/composition/minimal_event.v1.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity: { verdict: valid }
+  provenance: "authored 2026-07-21 (minimal event COMPOSITION, first content state); structural placeholder pending corpus authoring"
+cnf.composition.minimal_event.v2:
+  source: fixtures/composition/minimal_event.v2.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity: { verdict: valid }
+  provenance: "authored 2026-07-21 (minimal event COMPOSITION, updated content state); structural placeholder pending corpus authoring"
+cnf.composition.minimal_event.invalid_structure:
+  source: fixtures/composition/minimal_event.invalid_structure.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "OBSERVATION carries no data attribute"
+    spec_ref: "RM ehr (OBSERVATION.data is mandatory)"
+  provenance: "authored 2026-07-21 by removing OBSERVATION.data from the valid v1 payload"
+cnf.flat.vitals.minimal_ctx:
+  source: fixtures/flat/vitals.minimal_ctx.json
+  format: wt-flat
+  rm_versions: [">=1.0.2"]
+  validity: { verdict: valid }
+  provenance: "authored 2026-07-21 (FLAT vitals commit with minimal ctx per ITS-REST simplified_formats master06)"
+  views:
+    temperature_magnitude:
+      select: "$['vitals/body_temperature:0/any_event:0/temperature|magnitude']"
+cnf.ehr_status.provided:
+  generated_by: { recipe: ehr_status, digest: "sha256:31bc95b3be8f331997817d1739c65ac865da12a7f23a496d1518db548d44cd50" }
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity: { verdict: valid }
+  provenance: "generated set: EHR_STATUS instances synthesized per matrix row (recipe contract corpus/recipes/ehr_status.md)"
+  recipes:
+    ehr_status: { digest: "sha256:31bc95b3be8f331997817d1739c65ac865da12a7f23a496d1518db548d44cd50" }
+cnf.set.bp-10:
+  generated_by: { recipe: bp_series, digest: "sha256:bb8e67f6471c2f9769fbb4efd1643b20ff4f947daeab01416657d4009107e720" }
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity: { verdict: valid }
+  provenance: "generated set: 10 blood-pressure COMPOSITIONs, systolic 100..190 (recipe contract corpus/recipes/bp_series.md)"
+  views:
+    magnitude_ge_140_by_uid:
+      select: "committed uids of compositions"
+      where: "systolic magnitude >= 140"
+      order_by: "uid ascending"

--- a/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_event.invalid_structure.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_event.invalid_structure.json
@@ -1,0 +1,98 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "minimal event invalid"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "cnf.minimal_event"
+    },
+    "rm_version": "1.0.2"
+  },
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "NL"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_SELF"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2026-01-01T00:00:00Z"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "other care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "238"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "minimal observation"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.minimal.v1",
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_event.v1.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_event.v1.json
@@ -1,0 +1,146 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "minimal event v1"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "cnf.minimal_event"
+    },
+    "rm_version": "1.0.2"
+  },
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "NL"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_SELF"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2026-01-01T00:00:00Z"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "other care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "238"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "minimal observation"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.minimal.v1",
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "history"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2026-01-01T00:00:00Z"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "any event"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2026-01-01T00:00:00Z"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "tree"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "value"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_TEXT",
+                    "value": "first"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_event.v2.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_event.v2.json
@@ -1,0 +1,146 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "minimal event v2"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "cnf.minimal_event"
+    },
+    "rm_version": "1.0.2"
+  },
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "NL"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_SELF"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2026-01-01T00:00:00Z"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "other care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "238"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "minimal observation"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.minimal.v1",
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "history"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2026-01-01T00:00:00Z"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "any event"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2026-01-01T00:00:00Z"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "tree"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "value"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_TEXT",
+                    "value": "second"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/flat/vitals.minimal_ctx.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/flat/vitals.minimal_ctx.json
@@ -1,0 +1,7 @@
+{
+  "ctx/language": "en",
+  "ctx/territory": "NL",
+  "ctx/composer_self": true,
+  "vitals/body_temperature:0/any_event:0/temperature|magnitude": 37.2,
+  "vitals/body_temperature:0/any_event:0/temperature|unit": "Cel"
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/opt/invalid/empty_template_id.opt
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/opt/invalid/empty_template_id.opt
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<template xmlns="http://schemas.openehr.org/v1">
+  <template_id><value></value></template_id>
+  <concept>empty template id</concept>
+</template>

--- a/tools/cnf-runner/artifacts/corpus/fixtures/opt/invalid/multiple_elements.opt
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/opt/invalid/multiple_elements.opt
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<template xmlns="http://schemas.openehr.org/v1">
+  <template_id><value>cnf.invalid.multiple_elements</value></template_id>
+  <template_id><value>cnf.invalid.multiple_elements.second</value></template_id>
+  <concept>two template_id elements where the upper bound is 1</concept>
+</template>

--- a/tools/cnf-runner/artifacts/corpus/fixtures/opt/invalid/removed_mandatory.opt
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/opt/invalid/removed_mandatory.opt
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<template xmlns="http://schemas.openehr.org/v1">
+  <template_id><value>cnf.invalid.removed_mandatory</value></template_id>
+  <!-- mandatory definition element removed -->
+</template>

--- a/tools/cnf-runner/artifacts/corpus/recipes/bp_series.md
+++ b/tools/cnf-runner/artifacts/corpus/recipes/bp_series.md
@@ -1,0 +1,13 @@
+# Recipe `bp_series` — the generated blood-pressure query corpus
+
+Deterministic generated-set contract for `cnf.set.bp-10`.
+
+- 10 canonical-JSON COMPOSITIONs against the blood-pressure template
+  (`cnf.opt.blood_pressure`, openEHR-EHR-OBSERVATION.blood_pressure.v2).
+- Composition k (k = 0..9): systolic magnitude = 100 + 10k mmHg
+  (100..190), diastolic = 60 + 5k mmHg; event time =
+  2026-01-01T00:00:00Z + k hours; all other fields fixed.
+- Committed in index order into the case's EHR.
+- Views over the set are declarative projections evaluated on these values
+  (e.g. `magnitude_ge_140_by_uid`: the committed uids of the compositions
+  with systolic magnitude >= 140, ordered by uid ascending).

--- a/tools/cnf-runner/artifacts/corpus/recipes/ehr_status.md
+++ b/tools/cnf-runner/artifacts/corpus/recipes/ehr_status.md
@@ -1,0 +1,17 @@
+# Recipe `ehr_status` — EHR_STATUS synthesis from a create_ehr matrix row
+
+Deterministic `row -> RM fragment` contract (the runner implementation must
+match this spec; its digest pins the recipe version).
+
+- Input: one `create_ehr-main` matrix row binding `ehr_status`,
+  `is_queryable`, `is_modifiable`, `subject`, `other_details`, `ehr_id`.
+- `ehr_status = absent` => emit no EHR_STATUS at all (the class-1.a rows).
+- Otherwise emit a canonical-JSON `EHR_STATUS` (RM ehr, EHR_STATUS):
+  `is_queryable`/`is_modifiable` verbatim from the row;
+  `subject = provided` => a `PARTY_SELF` carrying an external ref with a
+  deterministic namespace `cnf` and id `subject-<row index>`;
+  `other_details = provided` => an `ITEM_TREE` with one fixed
+  `DV_TEXT` element (`"cnf other_details"`); `absent` => omitted.
+- `ehr_id = provided` => a fresh deterministic UUIDv5 over namespace
+  `cnf.create_ehr` and the row index; `absent` => omit (server assigns).
+- Seed: none required — the outputs are pure functions of the row.

--- a/tools/cnf-runner/artifacts/corpus/templates/blood_pressure.opt
+++ b/tools/cnf-runner/artifacts/corpus/templates/blood_pressure.opt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<template xmlns="http://schemas.openehr.org/v1">
+  <template_id><value>cnf.blood_pressure</value></template_id>
+  <concept>blood pressure series</concept>
+  <definition>
+    <rm_type_name>COMPOSITION</rm_type_name>
+    <node_id>at0000</node_id>
+  </definition>
+</template>

--- a/tools/cnf-runner/artifacts/corpus/templates/minimal_event.opt
+++ b/tools/cnf-runner/artifacts/corpus/templates/minimal_event.opt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<template xmlns="http://schemas.openehr.org/v1">
+  <template_id><value>cnf.minimal_event</value></template_id>
+  <concept>minimal event composition</concept>
+  <definition>
+    <rm_type_name>COMPOSITION</rm_type_name>
+    <node_id>at0000</node_id>
+  </definition>
+</template>

--- a/tools/cnf-runner/artifacts/corpus/templates/quantity_property_units_mag.opt
+++ b/tools/cnf-runner/artifacts/corpus/templates/quantity_property_units_mag.opt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<template xmlns="http://schemas.openehr.org/v1">
+  <template_id><value>cnf.quantity_property_units_mag</value></template_id>
+  <concept>C_DV_QUANTITY property/units/magnitude constraint</concept>
+  <definition>
+    <rm_type_name>COMPOSITION</rm_type_name>
+    <node_id>at0000</node_id>
+  </definition>
+</template>

--- a/tools/cnf-runner/artifacts/corpus/templates/vitals.opt
+++ b/tools/cnf-runner/artifacts/corpus/templates/vitals.opt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<template xmlns="http://schemas.openehr.org/v1">
+  <template_id><value>cnf.vitals</value></template_id>
+  <concept>vital signs</concept>
+  <definition>
+    <rm_type_name>COMPOSITION</rm_type_name>
+    <node_id>at0000</node_id>
+  </definition>
+</template>

--- a/tools/cnf-runner/artifacts/registers/ambiguities.yaml
+++ b/tools/cnf-runner/artifacts/registers/ambiguities.yaml
@@ -1,0 +1,114 @@
+# The ambiguity register: every entry a real, verified spec divergence or
+# silence with the normative handling a runner MUST apply. A runner that
+# resolves an ambiguity privately is non-conformant to the schedule.
+AMB-1:
+  ambiguity: >-
+    Error body shape diverges inside ITS-REST 1.1.0: prose says
+    {message, code, errors[DV_CODED_TEXT]} under Prefer: return=representation,
+    while the OAS Error.yaml says {message, validationErrors[string]} and is
+    wired only into 400. Most 4xx bodies are undefined.
+  source: "ITS-REST overview Requests_and_responses (Error handling) vs ITS-REST specifications/schemas Error.yaml"
+  handling: >-
+    error_loose: assert only that a `message` string is present (when Prefer
+    representation); never assert either full shape. SEC decision item: pick
+    one shape in ITS-REST 1.2.0.
+  disposition: loose_assert
+AMB-2:
+  ambiguity: >-
+    EHR create enumerates no 422 — EHR_STATUS validation failure has no
+    assigned code (ehr_create responses = 201/400/409).
+  source: "ITS-REST specifications/operations ehr_create.yaml"
+  handling: "Bind validation_failed -> 400 on EHR create; flag for upstream clarification."
+  disposition: fixed_handling
+AMB-3:
+  ambiguity: >-
+    The SM does not say where preceding_version_uid lives for update
+    (spec-ambiguity note in the schedule's COMPOSITION chapter preamble).
+  source: "CNF platform_test_schedule master07 (preamble); SM openehr_platform I_EHR_COMPOSITION"
+  handling: >-
+    Cases speak preceding_version_uid abstractly; the ITS-REST binding
+    realizes it as If-Match. SPECPR candidate.
+  disposition: fixed_handling
+AMB-4:
+  ambiguity: >-
+    ADL 1.4 templates have no formal versioning — duplicate template_id
+    handling is implementation-defined: conflict vs version-parameter.
+  source: "CNF platform_test_schedule master04 (NOTE on duplicate template_id)"
+  handling: >-
+    Two sibling cases carry option tags; the ICS options declaration selects
+    which applies — at least the declared behaviour MUST pass; the undeclared
+    sibling is not-applicable.
+  disposition: option_select
+  options: [adl14-duplicate-conflict, adl14-duplicate-versioned]
+AMB-5:
+  ambiguity: "Persistent-COMPOSITION uniqueness per EHR is under SEC debate."
+  source: "CNF platform_test_schedule master07 (NOTE on persistent compositions)"
+  handling: >-
+    Affected cases carry the flag; verdicts on them are reported but excluded
+    from profile computation until resolved.
+  disposition: report_only
+AMB-6:
+  ambiguity: >-
+    The `fetch` default is implementation-defined; `fetch` cannot combine
+    with AQL TOP.
+  source: "ITS-REST specifications/docs/query Request.md"
+  handling: >-
+    Cases always pass `fetch` explicitly; the TOP+fetch rejection is its own
+    case.
+  disposition: fixed_handling
+AMB-7:
+  ambiguity: "Additional non-conflicting status codes are permitted."
+  source: "ITS-REST overview Requests_and_responses (HTTP status codes)"
+  handling: >-
+    Bindings assert the expected code exactly for the expected outcome; they
+    never enumerate-reject other codes for other situations.
+  disposition: fixed_handling
+AMB-8:
+  ambiguity: >-
+    Empty-directory retrieval is empty-vs-error ambiguous: get_directory on
+    an EHR without one "should return an empty structure ... could be an
+    error status instead".
+  source: "CNF platform_test_schedule master09 (F.1/G.1/L.1)"
+  handling: "Sibling cases with option tags; the ICS declares the behaviour. Upstream clarification candidate."
+  disposition: option_select
+  options: [directory-empty-structure, directory-empty-error]
+AMB-9:
+  ambiguity: "EHR_STATUS `incomplete` lifecycle_state references SPECPR-368 (open upstream problem report)."
+  source: "CNF platform_test_schedule master08 (SPECPR-368 reference)"
+  handling: "Affected cases report but do not gate until SPECPR-368 resolves."
+  disposition: report_only
+AMB-10:
+  ambiguity: >-
+    Deleting a VERSIONED_OBJECT is under-specified: "needs further
+    specification at the openEHR Service Model".
+  source: "CNF platform_test_schedule master08"
+  handling: "No normative cases; statement-declared behaviour only."
+  disposition: statement_declared
+AMB-11:
+  ambiguity: >-
+    openehr::523|deleted| as a lifecycle_state code: the schedule reproduces
+    it, but the code assignment warrants terminology verification.
+  source: "CNF platform_test_schedule master07; TERM"
+  handling: "Cases assert the schedule's value; register flags it for TERM cross-check."
+  disposition: fixed_handling
+AMB-12:
+  ambiguity: >-
+    master06 mislabels its provided-status table "1.a" against its own class
+    list (1.a = no EHR_STATUS provided).
+  source: "CNF platform_test_schedule master06 (create_ehr data-set caption)"
+  handling: >-
+    The create_ehr-main encoding carries both classes; the conversion records
+    the caption defect; editorial fix upstream.
+  disposition: editorial
+AMB-13:
+  ambiguity: >-
+    CNF<->SM operation-name divergence for OPT retrieval: the schedule
+    anchors I_DEFINITION_ADL14.get_opts() and names its cases get_opts-*, but
+    the SM I_DEFINITION_ADL14 interface defines list_opts/opts_count — no
+    get_opts operation exists.
+  source: "CNF platform_test_schedule master04 (Service Model operation: I_DEFINITION_ADL14.get_opts()) vs SM docs/UML/classes/i_definition_adl14.adoc"
+  handling: >-
+    Official case ids keep the schedule's get_opts family (ids are never
+    renamed); sm_operation carries the resolvable I_DEFINITION_ADL14.list_opts.
+    Upstream editorial-alignment candidate.
+  disposition: fixed_handling

--- a/tools/cnf-runner/artifacts/schedule/CONT-DV_QUANTITY-validate_property_units_mag.yaml
+++ b/tools/cnf-runner/artifacts/schedule/CONT-DV_QUANTITY-validate_property_units_mag.yaml
@@ -1,0 +1,33 @@
+# Pilot 5 — the richest official decision table, verbatim rows; one
+# violation per row (the violates list form also covers multi-violation rows
+# used elsewhere in master17).
+id: CONT-DV_QUANTITY-validate_property_units_mag
+kind: content
+component: CONTENT
+rm_class: DV_QUANTITY
+capabilities: [ArchetypeValidation]
+profiles: [CORE]
+test_purpose: >-
+  A committed DV_QUANTITY is accepted iff it satisfies the C_DV_QUANTITY
+  property + units-list + per-unit magnitude-range constraints.
+description: "DV_QUANTITY against C_DV_QUANTITY with property, units and magnitude range"
+spec_refs:
+  - "CNF platform_test_schedule master17.3 §CONT-DV_QUANTITY-validate_property_units_mag"
+  - "AM AOM1.4 §C_DV_QUANTITY"
+  - "RM data_types §DV_QUANTITY"
+applies: { rm: ">=1.0.2" }
+constraint_context:
+  template: cnf.tpl.quantity_property_units_mag    # C_DV_QUANTITY: property=openehr::122, list=[cm 5.0..10.0, m]
+  path: "/content[openEHR-EHR-OBSERVATION.minimal.v1]/data/events/data/items/value"
+decision_table:
+  columns: [magnitude, units, expected, violates]
+  rows:
+    - [null, null, rejected, ["rm_schema: magnitude and units are mandatory"]]
+    - [null, "cm", rejected, ["rm_schema: magnitude is mandatory"]]
+    - [1.0, null, rejected, ["rm_schema: units is mandatory"]]
+    - [0.0, "mg", rejected, ["constraint(C_DV_QUANTITY.property): mg is not a length unit"]]
+    - [0.0, "cm", rejected, ["constraint(C_DV_QUANTITY.list): magnitude not in range for unit"]]
+    - [0.0, "km", rejected, ["constraint(C_DV_QUANTITY.list): km is not allowed"]]
+    - [1.0, "cm", rejected, ["constraint(C_DV_QUANTITY.list): magnitude not in range for unit"]]
+    - [5.7, "cm", accepted, []]
+    - [10.0, "cm", accepted, []]

--- a/tools/cnf-runner/artifacts/schedule/I_DEFINITION_ADL14.get_opts-retrieve_all_no_opts.yaml
+++ b/tools/cnf-runner/artifacts/schedule/I_DEFINITION_ADL14.get_opts-retrieve_all_no_opts.yaml
@@ -1,0 +1,23 @@
+# Official master04 case — the read side of the upload_opt-invalid_opt
+# verified_by link. Case id keeps the schedule's get_opts family while the
+# SM anchor is the resolvable list_opts (AMB-13).
+id: I_DEFINITION_ADL14.get_opts-retrieve_all_no_opts
+kind: functional
+component: DEFINITION_ADL14
+sm_operation: I_DEFINITION_ADL14.list_opts
+capabilities: [Adl14OptProvisioning]
+profiles: [CORE]
+test_purpose: "Retrieving all OPTs on an empty server returns an empty set and does not fail."
+description: "retrieve all loaded OPTs when none is loaded"
+spec_refs:
+  - "SM openehr_platform §I_DEFINITION_ADL14.list_opts"
+  - "CNF platform_test_schedule master04 §get_opts-retrieve_all_no_opts"
+applies: { rm: ">=1.0.2" }
+requires: { server: empty }              # "No OPTs should be loaded on the system"
+flow:
+  - step: 1
+    call: list_opts
+    expect: ok
+    assert:
+      - { assert: returns, equals: [] }  # "should return an empty set and should not fail"
+ambiguities: [AMB-13]

--- a/tools/cnf-runner/artifacts/schedule/I_DEFINITION_ADL14.upload_opt-invalid_opt.yaml
+++ b/tools/cnf-runner/artifacts/schedule/I_DEFINITION_ADL14.upload_opt-invalid_opt.yaml
@@ -1,0 +1,34 @@
+# Pilot 3 — fixture-set iteration with per-fixture defects; postcondition =
+# unchanged server.
+id: I_DEFINITION_ADL14.upload_opt-invalid_opt
+kind: functional
+component: DEFINITION_ADL14
+sm_operation: I_DEFINITION_ADL14.upload_opt
+capabilities: [Adl14OptProvisioning]
+exercises: [ArchetypeValidation]
+profiles: [CORE]
+test_purpose: "Invalid OPTs are rejected and leave the server state unchanged."
+description: "upload invalid OPTs"
+spec_refs:
+  - "SM openehr_platform §I_DEFINITION_ADL14.upload_opt"
+  - "CNF platform_test_schedule master04 §upload_opt data sets"
+applies: { rm: ">=1.0.2" }
+requires: { server: empty }
+parameters:
+  iteration: reset_per_row
+  fixture_set:                 # the official invalid-OPT data-set rows, one per defect
+    - { data_set: cnf.opt.invalid.empty_file, expected: validation_failed, defect: "empty file" }
+    - { data_set: cnf.opt.invalid.empty_template_id, expected: validation_failed, defect: "empty template_id" }
+    - { data_set: cnf.opt.invalid.removed_mandatory, expected: validation_failed, defect: "removed mandatory elements" }
+    - { data_set: cnf.opt.invalid.multiple_elements, expected: validation_failed, defect: "multiple elements where upper bound is 1" }
+flow:
+  - step: 1
+    call: upload_opt
+    with: { opt: "${ds:fixture}" }
+    expect: "${fixture.expected}"
+postconditions:
+  - assert: state
+    text: "No OPTs are loaded on the system"
+    verified_by: I_DEFINITION_ADL14.get_opts-retrieve_all_no_opts
+verified_by: [I_DEFINITION_ADL14.get_opts-retrieve_all_no_opts]
+ambiguities: [AMB-4]

--- a/tools/cnf-runner/artifacts/schedule/I_EHR_COMPOSITION.update_composition-event.yaml
+++ b/tools/cnf-runner/artifacts/schedule/I_EHR_COMPOSITION.update_composition-event.yaml
@@ -1,0 +1,52 @@
+# Pilot 4 — the versioning case: prerequisites, capture ->
+# preceding_version_uid replay, RM-level version assertions; the REST binding
+# realizes preceding_version_uid as If-Match per AMB-3.
+id: I_EHR_COMPOSITION.update_composition-event
+kind: functional
+component: EHR_COMPOSITION
+sm_operation: I_EHR_COMPOSITION.update_composition
+capabilities: [Versioning]
+exercises: [CompositionOps, ChangeSets]
+profiles: [CORE]
+test_purpose: >-
+  Updating an existing event COMPOSITION with the correct
+  preceding_version_uid creates a second VERSION with change_type MODIFY.
+description: "Update an existing event COMPOSITION"
+spec_refs:
+  - "SM openehr_platform §I_EHR_COMPOSITION.update_composition"
+  - "CNF platform_test_schedule master07 §update_composition-event"
+  - "RM common §change_control (VERSION.commit_audit.change_type)"
+applies: { rm: ">=1.0.2" }
+requires:
+  server: any
+  templates: [cnf.opt.minimal_event]
+  ehr: { commits: none }                 # mints ${ehr_id}
+data_sets: [cnf.composition.minimal_event.v1, cnf.composition.minimal_event.v2]
+flow:
+  - step: 1
+    call: create_composition
+    with: { ehr_id: "${ehr_id}", composition: "${ds:cnf.composition.minimal_event.v1}" }
+    expect: created
+    capture:
+      preceding_version_uid: created.version_uid
+      versioned_object_uid: created.versioned_object_uid
+  - step: 2
+    call: update_composition
+    with:
+      ehr_id: "${ehr_id}"
+      composition: "${ds:cnf.composition.minimal_event.v2}"
+      versioned_object_uid: "${versioned_object_uid}"
+      preceding_version_uid: "${preceding_version_uid}"   # ITS-REST: If-Match (AMB-3)
+    expect: updated
+    capture: { v2_uid: updated.version_uid }
+    assert:
+      - { assert: version, of: "${v2_uid}", uid_pattern: "${versioned_object_uid}::<system>::2" }
+postconditions:
+  - { assert: version, count: 2 }
+  - { assert: version, of: "${preceding_version_uid}", change_type: CREATE }
+  - { assert: version, of: "${v2_uid}", change_type: MODIFY }
+  # NOTE: a strengthening addition — CNF master07 places the "content check"
+  # in the get_composition cases, not in update_composition; kept here as
+  # extra rigor.
+  - { assert: equivalent, to: committed, ignoring: server_assigned }
+ambiguities: [AMB-3]

--- a/tools/cnf-runner/artifacts/schedule/I_EHR_CONTRIBUTION.commit_contribution-valid_invalid_compositions.yaml
+++ b/tools/cnf-runner/artifacts/schedule/I_EHR_CONTRIBUTION.commit_contribution-valid_invalid_compositions.yaml
@@ -1,0 +1,32 @@
+# Pilot 8 — one CONTRIBUTION carrying multiple VERSIONs, judged as a single
+# atomic transaction ("the whole commit should behave like a transaction and
+# fail" — master08).
+id: I_EHR_CONTRIBUTION.commit_contribution-valid_invalid_compositions
+kind: functional
+component: EHR_CONTRIBUTION
+sm_operation: I_EHR_CONTRIBUTION.commit_contribution
+capabilities: [ChangeSets]
+profiles: [CORE]
+test_purpose: >-
+  A CONTRIBUTION containing one valid and one invalid COMPOSITION is
+  rejected atomically — no VERSION of either is created.
+description: "One commit, multiple versions, one invalid — transactional rejection"
+spec_refs:
+  - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
+  - "CNF platform_test_schedule master08 §commit_contribution-valid_invalid_compositions (+ transaction note)"
+applies: { rm: ">=1.0.2" }
+requires:
+  server: any
+  templates: [cnf.opt.minimal_event]
+  ehr: { commits: none }                 # mints ${ehr_id}
+flow:
+  - step: 1
+    call: commit_contribution
+    with:
+      ehr_id: "${ehr_id}"
+      versions:                          # the bundled-payload construct
+        - { data: "${ds:cnf.composition.minimal_event.v1}", change_type: creation }
+        - { data: "${ds:cnf.composition.minimal_event.invalid_structure}", change_type: creation }
+    expect: validation_failed            # ONE aggregate outcome — the commit is a transaction
+postconditions:
+  - { assert: version, count: 0 }        # atomicity: nothing was committed

--- a/tools/cnf-runner/artifacts/schedule/I_EHR_SERVICE.create_ehr-main.yaml
+++ b/tools/cnf-runner/artifacts/schedule/I_EHR_SERVICE.create_ehr-main.yaml
@@ -1,0 +1,60 @@
+# Pilot 1 — the official create-EHR matrix (both valid data-set classes).
+id: I_EHR_SERVICE.create_ehr-main
+kind: functional
+component: EHR
+sm_operation: I_EHR_SERVICE.create_ehr
+capabilities: [EhrOperations]
+profiles: [CORE]
+test_purpose: >-
+  Creating an EHR succeeds for every valid EHR_STATUS variant, and for an
+  omitted EHR_STATUS the server creates the defaults (is_queryable=true,
+  is_modifiable=true, subject=PARTY_SELF).
+description: "Create new EHR"
+spec_refs:
+  - "SM openehr_platform §I_EHR_SERVICE.create_ehr"
+  - "CNF platform_test_schedule master06 §create_ehr data sets"
+applies: { rm: ">=1.0.2" }
+requires: { server: empty }
+parameters:
+  iteration: single_pass     # all EHRs coexist — the cross-row uniqueness
+                             # postcondition is only meaningful on shared state
+  matrix:
+    columns: [ehr_status, is_queryable, is_modifiable, subject, other_details, ehr_id]
+    rows:
+      # class 1.a — EHR_STATUS omitted (server defaults); with and without client ehr_id
+      - [absent, "-", "-", "-", "-", absent]
+      - [absent, "-", "-", "-", "-", provided]
+      # class 1.b — the official 16-row provided-status matrix, verbatim
+      # (the schedule's own caption mislabels this table "1.a" — AMB-12)
+      - [provided, true, true, provided, absent, absent]
+      - [provided, true, false, provided, absent, absent]
+      - [provided, false, true, provided, absent, absent]
+      - [provided, false, false, provided, absent, absent]
+      - [provided, true, true, provided, provided, absent]
+      - [provided, true, false, provided, provided, absent]
+      - [provided, false, true, provided, provided, absent]
+      - [provided, false, false, provided, provided, absent]
+      - [provided, true, true, provided, absent, provided]
+      - [provided, true, false, provided, absent, provided]
+      - [provided, false, true, provided, absent, provided]
+      - [provided, false, false, provided, absent, provided]
+      - [provided, true, true, provided, provided, provided]
+      - [provided, true, false, provided, provided, provided]
+      - [provided, false, true, provided, provided, provided]
+      - [provided, false, false, provided, provided, provided]
+flow:
+  - step: 1
+    call: create_ehr
+    with: { ehr_status: "${recipe:ehr_status(row)}", ehr_id: "${row.ehr_id}" }
+    expect: created
+    capture: { new_ehr_id: created.ehr_id }
+postconditions:
+  - { assert: unique, over: "${new_ehr_id}", aggregate: true }   # "ehr_id ... should be unique"
+  - assert: state
+    text: >-
+      EHR exists and is consistent with the data set used (class 1.a rows:
+      server defaults applied)
+    verified_by: I_EHR_STATUS.get_ehr_status-get_by_ehr_id
+verified_by: [I_EHR_STATUS.get_ehr_status-get_by_ehr_id]
+ambiguities: [AMB-12]
+data_sets: [cnf.ehr_status.provided]

--- a/tools/cnf-runner/artifacts/schedule/I_EHR_SERVICE.create_ehr-same_ehr_twice.yaml
+++ b/tools/cnf-runner/artifacts/schedule/I_EHR_SERVICE.create_ehr-same_ehr_twice.yaml
@@ -1,0 +1,40 @@
+# Pilot 2 — the state-carrying failure case; both ehr_id sources the
+# schedule distinguishes are the two matrix rows; the exactly-one-EHR
+# postcondition is verified in-case.
+id: I_EHR_SERVICE.create_ehr-same_ehr_twice
+kind: functional
+component: EHR
+sm_operation: I_EHR_SERVICE.create_ehr
+capabilities: [EhrOperations]
+profiles: [CORE]
+test_purpose: "ehr_id values are unique: re-creating an existing EHR is rejected."
+description: "Attempt to create same EHR twice"
+spec_refs:
+  - "SM openehr_platform §I_EHR_SERVICE.create_ehr"
+  - "CNF platform_test_schedule master06 §create_ehr-same_ehr_twice"
+applies: { rm: ">=1.0.2" }
+requires: { server: empty }
+parameters:
+  iteration: reset_per_row
+  matrix: { columns: [ehr_id], rows: [[absent], [provided]] }
+flow:
+  - step: 1
+    call: create_ehr
+    with: { ehr_id: "${row.ehr_id}" }
+    expect: created
+    capture: { first_ehr_id: created.ehr_id }   # server-assigned OR data-set value — both rows covered
+  - step: 2
+    call: create_ehr
+    with: { ehr_id: "${first_ehr_id}" }         # "should be read from the response" / "from the test data sets"
+    expect: already_exists
+  - step: 3                                     # in-case verification of the postcondition
+    call: get_ehr
+    with: { ehr_id: "${first_ehr_id}" }
+    expect: ok
+    assert:
+      - { assert: instance_of, rm_type: EHR }
+postconditions:
+  - assert: state
+    text: >-
+      Exactly one EHR exists — the one created in step 1 (verified by step 3
+      retrieving it unchanged)

--- a/tools/cnf-runner/artifacts/schedule/I_EHR_STATUS.get_ehr_status-get_by_ehr_id.yaml
+++ b/tools/cnf-runner/artifacts/schedule/I_EHR_STATUS.get_ehr_status-get_by_ehr_id.yaml
@@ -1,0 +1,29 @@
+# Official master06 case — the read side of the create_ehr-main verified_by
+# link (the master06 create->get pattern).
+id: I_EHR_STATUS.get_ehr_status-get_by_ehr_id
+kind: functional
+component: EHR
+sm_operation: I_EHR_STATUS.get_ehr_status
+capabilities: [EhrOperations]
+profiles: [CORE]
+test_purpose: >-
+  The EHR_STATUS of an existing EHR is retrievable by ehr_id and reflects
+  the rules under which the EHR was created (subject presence,
+  is_modifiable, is_queryable).
+description: "Get status of an existing EHR"
+spec_refs:
+  - "SM openehr_platform §I_EHR_STATUS.get_ehr_status"
+  - "CNF platform_test_schedule master06 §get_ehr_status-get_by_ehr_id"
+applies: { rm: ">=1.0.2" }
+requires:
+  server: any
+  ehr: { commits: any }                  # "An EHR with known ehr_id should exist" — mints ${ehr_id}
+flow:
+  - step: 1
+    call: get_ehr_status
+    with: { ehr_id: "${ehr_id}" }
+    expect: ok
+    assert:
+      - { assert: instance_of, rm_type: EHR_STATUS }
+      - { assert: field, path: "is_modifiable", exists: true }
+      - { assert: field, path: "is_queryable", exists: true }

--- a/tools/cnf-runner/artifacts/schedule/I_QUERY_SERVICE.execute_ad_hoc_query-where_magnitude.yaml
+++ b/tools/cnf-runner/artifacts/schedule/I_QUERY_SERVICE.execute_ad_hoc_query-where_magnitude.yaml
@@ -1,0 +1,41 @@
+# Pilot 7 — new-chapter candidate for the empty master11: deterministic,
+# RESULT_SET-shape-aware; bulk data load is precondition state via
+# requires.commit, never an un-anchored flow call. Id family follows the
+# official chapter (execute_ad_hoc_query).
+id: I_QUERY_SERVICE.execute_ad_hoc_query-where_magnitude
+kind: functional
+component: QUERY
+sm_operation: I_QUERY_SERVICE.execute_ad_hoc_query
+capabilities: [AqlBasic]
+profiles: [STANDARD]
+test_purpose: >-
+  An ad-hoc AQL query with a WHERE predicate on DV_QUANTITY.magnitude
+  returns exactly the matching compositions, as a spec-shaped RESULT_SET.
+description: "Ad-hoc AQL, WHERE on magnitude, ordered result"
+spec_refs:
+  - "QUERY AQL §WHERE, §ORDER BY"
+  - "ITS-REST query §Response (RESULT_SET: rows required; columns, meta optional)"
+applies: { rm: ">=1.0.2", aql: ">=1.1" }
+requires:
+  server: any
+  templates: [cnf.opt.blood_pressure]
+  ehr: { commits: none }                 # mints ${ehr_id}
+  commit: [cnf.set.bp-10]                # generated: 10 BP compositions, magnitudes 100..190
+flow:
+  - step: 1
+    call: execute_ad_hoc_query
+    with:
+      q: >-
+        SELECT c/uid/value AS uid FROM EHR e CONTAINS COMPOSITION c
+        CONTAINS OBSERVATION o [openEHR-EHR-OBSERVATION.blood_pressure.v2]
+        WHERE o/data[at0001]/events[at0006]/data[at0003]/items[at0004]/value/magnitude >= $mag
+        ORDER BY c/uid/value ASC
+      query_parameters: { mag: 140 }
+      fetch: 100               # AMB-6: fetch always explicit
+    expect: ok
+    assert:
+      - assert: result_set
+        match: ordered
+        rows: { from: "${ds:cnf.set.bp-10#magnitude_ge_140_by_uid}" }
+        columns: [{ name: uid }]
+ambiguities: [AMB-6]

--- a/tools/cnf-runner/artifacts/schedule/SF-FLAT-commit_roundtrip_ctx_defaults.yaml
+++ b/tools/cnf-runner/artifacts/schedule/SF-FLAT-commit_roundtrip_ctx_defaults.yaml
@@ -1,0 +1,59 @@
+# Pilot 6 — new-chapter candidate (simplified formats, categories 1+7); an
+# intrinsic-format case: formats are fixed roles per step, selected only when
+# required formats are within the run's tech profile.
+id: SF-FLAT-commit_roundtrip_ctx_defaults
+kind: functional
+component: SIMPLIFIED_FORMATS
+sm_operation: I_EHR_COMPOSITION.create_composition
+capabilities: [SimplifiedFormats]
+profiles: [OPTIONS]           # SHOULD-level per ITS-REST — never gates CORE/STANDARD
+test_purpose: >-
+  A FLAT composition committed with minimal ctx round-trips to canonical
+  JSON and STRUCTURED with equal clinical leaves, and the ctx defaults
+  (time -> start_time now(), setting -> openehr::238) are applied.
+description: "FLAT commit, three-format read-back, ctx defaulting"
+spec_refs:
+  - "ITS-REST simplified_formats master02 §MIME Types"
+  - "ITS-REST simplified_formats master04 §Field Identifiers, §Validation"
+  - "ITS-REST simplified_formats master06 §ctx defaults"
+  - "ITS-REST overview Requests_and_responses §openehr-template-id"
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+requires:
+  server: any
+  templates: [cnf.opt.vitals]
+  ehr: { commits: none }                 # mints ${ehr_id}
+data_sets: [cnf.flat.vitals.minimal_ctx]
+flow:
+  - step: 1
+    call: create_composition
+    format: wt-flat                      # intrinsic role; binding adds openehr-template-id
+    with: { ehr_id: "${ehr_id}", composition: "${ds:cnf.flat.vitals.minimal_ctx}" }
+    expect: created
+    capture: { version_uid: created.version_uid }
+  - step: 2
+    call: get_composition_at_version     # SM I_EHR_COMPOSITION.get_composition_at_version
+    format: canonical-json
+    with: { ehr_id: "${ehr_id}", version_uid: "${version_uid}" }
+    expect: ok
+    assert:
+      - { assert: instance_of, rm_type: COMPOSITION }
+      - { assert: field, path: "context/setting", equals: "openehr::238|other care|" }   # master06 default
+      - { assert: field, path: "context/start_time", exists: true }                      # ctx/time -> now()
+      - assert: field
+        path: "content[0]/data/events[0]/data/items[0]/value/magnitude"
+        equals: "${ds:cnf.flat.vitals.minimal_ctx#temperature_magnitude}"                # named view
+  - step: 3
+    call: get_composition_at_version
+    format: wt-flat
+    with: { ehr_id: "${ehr_id}", version_uid: "${version_uid}" }
+    expect: ok
+    capture: { flat_readback: ok.body }
+    assert:
+      - { assert: equivalent, to: committed, ignoring: [ctx_defaults, server_assigned] }
+  - step: 4
+    call: get_composition_at_version
+    format: wt-structured
+    with: { ehr_id: "${ehr_id}", version_uid: "${version_uid}" }
+    expect: ok
+    assert:
+      - { assert: equivalent, to: "${flat_readback}", ignoring: [] }   # FLAT<->STRUCTURED value-equality (master04)

--- a/tools/cnf-runner/artifacts/vocab/capability_matrix.yaml
+++ b/tools/cnf-runner/artifacts/vocab/capability_matrix.yaml
@@ -1,0 +1,19 @@
+# The machine-readable capability -> family -> tier matrix (the Profiles
+# book's capability x tier tables as data; the verdict machinery's input).
+# Seeded with the capabilities the pilot encodings bear verdicts for plus the
+# SEC-BASIC family; the full Profiles-book matrix lands with the catalogue
+# authoring.
+EhrOperations: { family: Platform, tier: CORE, required: true, source: "CNF profiles (Platform profile, EHR capability)" }
+CompositionOps: { family: Platform, tier: CORE, required: true, source: "CNF profiles (Platform profile, COMPOSITION capability)" }
+ChangeSets: { family: Platform, tier: CORE, required: true, source: "CNF profiles (Platform profile, CONTRIBUTION change sets)" }
+Versioning: { family: Platform, tier: CORE, required: true, source: "CNF profiles (Platform profile, version control); RM common (change_control)" }
+Adl14OptProvisioning: { family: Platform, tier: CORE, required: true, source: "CNF profiles (Platform profile, ADL 1.4 template provisioning)" }
+ArchetypeValidation: { family: Platform, tier: CORE, required: true, source: "CNF profiles (Platform profile, archetype-based validation)" }
+AqlBasic: { family: Platform, tier: STANDARD, required: true, source: "CNF profiles (Platform profile, AQL querying); QUERY AQL 1.1" }
+SimplifiedFormats: { family: Platform, tier: OPTIONS, required: false, source: "ITS-REST simplified_formats (SHOULD-level: OPTIONS profile, never gates CORE/STANDARD)" }
+Signing: { family: Platform, tier: STANDARD, required: false, source: "CNF profiles (Non-Functional, Signing); RM common (ORIGINAL_VERSION.signature)" }
+EhrDemographicSeparation: { family: Security, tier: SEC-BASIC, required: true, source: "RM ehr (EHR_STATUS.subject external refs / PARTY_SELF); 2017 schedule Security BASIC lineage" }
+AuthenticatedAccess: { family: Security, tier: SEC-BASIC, required: true, source: "ITS-REST overview Requests_and_responses (HTTP status codes: 401)" }
+AuthorizationSeparation: { family: Security, tier: SEC-BASIC, required: true, source: "ITS-REST overview Requests_and_responses (HTTP status codes: 403)" }
+AuditAccountability: { family: Security, tier: SEC-BASIC, required: true, source: "RM common (change_control commit_audit); ITS-REST overview (openehr-audit-details; time_committed is server-set)" }
+AnonymousEhrs: { family: Security, tier: SEC-BASIC, required: true, source: "CNF profiles (Non-Functional: anonymous EHR capability)" }

--- a/tools/cnf-runner/artifacts/vocab/outcomes.yaml
+++ b/tools/cnf-runner/artifacts/vocab/outcomes.yaml
@@ -1,0 +1,25 @@
+# The closed outcome-kind taxonomy (CNF 2.0 artifact family 3).
+# Cases speak ONLY these kinds; bindings map each kind to wire per operation.
+# Extensible only by schedule release. Meanings carry the schedule language
+# (CNF platform_test_schedule master04/06/07).
+created: { class: success, meaning: "New resource exists (\"positive response associated to the successful creation\")" }
+ok: { class: success, meaning: "Read/query succeeded with content" }
+ok_empty: { class: success, meaning: "Fulfilled with no content (e.g. composition logically deleted at requested time)" }
+updated: { class: success, meaning: "New version of existing resource created" }
+deleted: { class: success, meaning: "Logical delete performed (a new version, lifecycle_state = openehr::523|deleted|)" }
+stored: { class: success, meaning: "Definition stored (stored query PUT — wire 200, not 201)" }
+already_exists: { class: error, meaning: "Duplicate identity (\"an EHR with the provided ehr_id ... should be unique\"; duplicate template_id)" }
+not_found: { class: error, meaning: "Target does not exist (\"EHR with <ehr_id> does not exist\")" }
+version_not_found: { class: error, meaning: "preceding_version_uid does not exist" }
+precondition_failed: { class: error, meaning: "Version precondition evaluated false (stale preceding_version_uid)" }
+precondition_missing: { class: error, meaning: "Required version precondition absent" }
+validation_failed: { class: error, meaning: "Semantically invalid content (\"information about the errors in the provided COMPOSITION\")" }
+template_not_found: { class: error, meaning: "Referenced OPT not on server (\"information about the non-existent OPT\")" }
+template_mismatch: { class: error, meaning: "Content commits against a different template_id than the versioned object" }
+missing_template_id: { class: error, meaning: "Simplified-format commit without template identification" }
+already_deleted: { class: error, meaning: "Delete of an already-deleted version" }
+conflict: { class: error, meaning: "Other uniqueness/state conflict" }
+not_acceptable: { class: error, meaning: "No representation satisfies Accept" }
+unsupported_media: { class: error, meaning: "Payload media type unsupported" }
+invalid_query: { class: error, meaning: "Malformed/unprocessable AQL" }
+timeout: { class: error, meaning: "Server aborted at max execution time" }

--- a/tools/cnf-runner/artifacts/vocab/selectors.yaml
+++ b/tools/cnf-runner/artifacts/vocab/selectors.yaml
@@ -1,0 +1,15 @@
+# The closed body-selector + header-matcher vocabularies and the named
+# ignore-set registry the `equivalent` assertion resolves — normative, never
+# runner judgment.
+body_selectors: [prefer_conditional, error_loose, result_set_body, negotiated, present, absent]
+header_matchers: ["present", "present?", "absent", "negotiated", "latest-version-uid", "pattern:<regex>", "<literal>"]
+ignore_sets:
+  server_assigned:
+    per_binding: true
+    source: "ITS-REST overview Requests_and_responses (server-assigned attributes; membership enumerated per operation binding)"
+  ctx_defaults:
+    paths:
+      - context/start_time
+      - context/setting
+      - composer
+    source: "ITS-REST simplified_formats master06 (ctx defaults: time -> now(), setting -> openehr::238, composer defaults)"

--- a/tools/cnf-runner/schemas/ambiguity-register.schema.json
+++ b/tools/cnf-runner/schemas/ambiguity-register.schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:openehr:cnf:schema:ambiguity-register:0.1.0",
+  "title": "CNF 2.0 ambiguity register",
+  "description": "Every entry a real, verified spec divergence or silence with the normative handling a runner must apply. A runner that resolves an ambiguity privately is non-conformant to the schedule.",
+  "type": "object",
+  "minProperties": 1,
+  "propertyNames": {
+    "pattern": "^AMB-[0-9]+$"
+  },
+  "additionalProperties": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+      "ambiguity",
+      "source",
+      "handling",
+      "disposition"
+    ],
+    "properties": {
+      "ambiguity": {
+        "type": "string",
+        "minLength": 1
+      },
+      "source": {
+        "type": "string",
+        "minLength": 1
+      },
+      "handling": {
+        "type": "string",
+        "minLength": 1
+      },
+      "disposition": {
+        "enum": [
+          "loose_assert",
+          "fixed_handling",
+          "option_select",
+          "report_only",
+          "statement_declared",
+          "editorial"
+        ]
+      },
+      "options": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "pattern": "^[a-z0-9_-]+$"
+        }
+      }
+    },
+    "allOf": [
+      {
+        "if": {
+          "properties": {
+            "disposition": {
+              "const": "option_select"
+            }
+          }
+        },
+        "then": {
+          "required": [
+            "ambiguity",
+            "source",
+            "handling",
+            "disposition",
+            "options"
+          ],
+          "properties": {
+            "options": {
+              "minItems": 2
+            }
+          }
+        },
+        "else": {
+          "properties": {
+            "options": {
+              "maxItems": 0
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/tools/cnf-runner/schemas/capability-matrix.schema.json
+++ b/tools/cnf-runner/schemas/capability-matrix.schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:openehr:cnf:schema:capability-matrix:0.1.0",
+  "title": "CNF 2.0 capability matrix",
+  "description": "The machine-readable capability→family→tier matrix — the Profiles book's capability×tier tables as data, the input the verdict machinery computes from.",
+  "type": "object",
+  "minProperties": 1,
+  "propertyNames": {
+    "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+  },
+  "additionalProperties": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+      "family",
+      "tier",
+      "required"
+    ],
+    "properties": {
+      "family": {
+        "enum": [
+          "Platform",
+          "Enterprise",
+          "Security"
+        ]
+      },
+      "tier": {
+        "enum": [
+          "CORE",
+          "STANDARD",
+          "OPTIONS",
+          "SEC-BASIC",
+          "D",
+          "M",
+          "X"
+        ]
+      },
+      "required": {
+        "type": "boolean"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "oneOf": [
+      {
+        "properties": {
+          "family": {
+            "const": "Platform"
+          },
+          "tier": {
+            "enum": [
+              "CORE",
+              "STANDARD",
+              "OPTIONS"
+            ]
+          }
+        }
+      },
+      {
+        "properties": {
+          "family": {
+            "const": "Security"
+          },
+          "tier": {
+            "enum": [
+              "SEC-BASIC"
+            ]
+          }
+        }
+      },
+      {
+        "properties": {
+          "family": {
+            "const": "Enterprise"
+          },
+          "tier": {
+            "enum": [
+              "D",
+              "M",
+              "X"
+            ]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/tools/cnf-runner/schemas/case-core.schema.json
+++ b/tools/cnf-runner/schemas/case-core.schema.json
@@ -1,0 +1,533 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:openehr:cnf:schema:case-core:0.1.0",
+  "title": "CNF 2.0 case core",
+  "description": "One protocol-neutral test case (the Abstract Test Suite unit). Wire realization lives in the operation bindings; cases speak SM operations and outcome kinds only.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "kind",
+    "component",
+    "test_purpose",
+    "description",
+    "spec_refs",
+    "capabilities"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^\\S+$"
+    },
+    "kind": {
+      "enum": [
+        "functional",
+        "content"
+      ]
+    },
+    "status": {
+      "enum": [
+        "active",
+        "retired",
+        "draft"
+      ],
+      "default": "active"
+    },
+    "component": {
+      "enum": [
+        "EHR",
+        "EHR_COMPOSITION",
+        "EHR_CONTRIBUTION",
+        "EHR_DIRECTORY",
+        "DEFINITION_ADL14",
+        "DEFINITION_ADL2",
+        "DEFINITION_QUERY",
+        "QUERY",
+        "DEMOGRAPHIC",
+        "ADMIN",
+        "MESSAGING",
+        "CONTENT",
+        "SIMPLIFIED_FORMATS",
+        "PERFORMANCE"
+      ]
+    },
+    "sm_operation": {
+      "type": "string",
+      "pattern": "^I_[A-Z0-9_]+\\.[a-z][a-z0-9_]*$"
+    },
+    "rm_class": {
+      "type": "string"
+    },
+    "test_purpose": {
+      "type": "string",
+      "minLength": 1
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1
+    },
+    "spec_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "applies": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "rm": {
+          "type": "string"
+        },
+        "base": {
+          "type": "string"
+        },
+        "am": {
+          "type": "string"
+        },
+        "aql": {
+          "type": "string"
+        },
+        "its_rest": {
+          "type": "string"
+        },
+        "term": {
+          "type": "string"
+        }
+      }
+    },
+    "guards": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "capabilities": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+      }
+    },
+    "exercises": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+      }
+    },
+    "profiles": {
+      "type": "array",
+      "items": {
+        "enum": [
+          "CORE",
+          "STANDARD",
+          "OPTIONS",
+          "SEC-BASIC",
+          "D",
+          "M",
+          "X"
+        ]
+      }
+    },
+    "option": {
+      "type": "string",
+      "pattern": "^[a-z0-9_-]+$"
+    },
+    "formats": {
+      "type": "array",
+      "items": {
+        "enum": [
+          "canonical-json",
+          "canonical-xml",
+          "wt-flat",
+          "wt-structured",
+          "wt"
+        ]
+      }
+    },
+    "requires": {
+      "$ref": "#/$defs/requires"
+    },
+    "parameters": {
+      "$ref": "#/$defs/parameters"
+    },
+    "flow": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/flowStep"
+      }
+    },
+    "constraint_context": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "template",
+        "path"
+      ],
+      "properties": {
+        "template": {
+          "type": "string",
+          "pattern": "^[a-z0-9_-]+(\\.[a-z0-9_-]+)*$"
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "decision_table": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "columns",
+        "rows"
+      ],
+      "properties": {
+        "columns": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "rows": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "array"
+          }
+        }
+      }
+    },
+    "postconditions": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/assertion"
+      }
+    },
+    "verified_by": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^\\S+$"
+      }
+    },
+    "ambiguities": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^AMB-[0-9]+$"
+      }
+    },
+    "data_sets": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9_-]+(\\.[a-z0-9_-]+)*$"
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "functional"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "sm_operation",
+          "flow"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "content"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "rm_class",
+          "constraint_context",
+          "decision_table"
+        ]
+      }
+    }
+  ],
+  "$defs": {
+    "requires": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "server": {
+          "enum": [
+            "empty",
+            "any"
+          ]
+        },
+        "templates": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z0-9_-]+(\\.[a-z0-9_-]+)*$"
+          }
+        },
+        "ehr": {
+          "oneOf": [
+            {
+              "const": "none"
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "commits"
+              ],
+              "properties": {
+                "commits": {
+                  "enum": [
+                    "none",
+                    "any"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "directory": {
+          "oneOf": [
+            {
+              "const": "none"
+            },
+            {
+              "type": "string",
+              "pattern": "^[a-z0-9_-]+(\\.[a-z0-9_-]+)*$"
+            }
+          ]
+        },
+        "commit": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z0-9_-]+(\\.[a-z0-9_-]+)*$"
+          }
+        },
+        "instances": {
+          "type": "object",
+          "propertyNames": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/requires"
+          }
+        }
+      }
+    },
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "iteration"
+      ],
+      "properties": {
+        "iteration": {
+          "enum": [
+            "reset_per_row",
+            "single_pass"
+          ]
+        },
+        "matrix": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "columns"
+          ],
+          "properties": {
+            "columns": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string"
+              }
+            },
+            "rows": {
+              "type": "array",
+              "items": {
+                "type": "array"
+              }
+            },
+            "rows_from": {
+              "type": "string"
+            }
+          }
+        },
+        "fixture_set": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "data_set",
+              "expected"
+            ],
+            "properties": {
+              "data_set": {
+                "type": "string",
+                "pattern": "^[a-z0-9_-]+(\\.[a-z0-9_-]+)*$"
+              },
+              "expected": {
+                "enum": [
+                  "created",
+                  "ok",
+                  "ok_empty",
+                  "updated",
+                  "deleted",
+                  "stored",
+                  "already_exists",
+                  "not_found",
+                  "version_not_found",
+                  "precondition_failed",
+                  "precondition_missing",
+                  "validation_failed",
+                  "template_not_found",
+                  "template_mismatch",
+                  "missing_template_id",
+                  "already_deleted",
+                  "conflict",
+                  "not_acceptable",
+                  "unsupported_media",
+                  "invalid_query",
+                  "timeout"
+                ]
+              },
+              "defect": {
+                "type": "string"
+              },
+              "spec_ref": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "flowStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "step",
+        "call",
+        "expect"
+      ],
+      "properties": {
+        "step": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "call": {
+          "type": "string",
+          "minLength": 1
+        },
+        "on": {
+          "type": "string",
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+        },
+        "variant": {
+          "type": "string"
+        },
+        "format": {
+          "enum": [
+            "canonical-json",
+            "canonical-xml",
+            "wt-flat",
+            "wt-structured",
+            "wt"
+          ]
+        },
+        "with": {
+          "type": "object"
+        },
+        "expect": {
+          "oneOf": [
+            {
+              "enum": [
+                "created",
+                "ok",
+                "ok_empty",
+                "updated",
+                "deleted",
+                "stored",
+                "already_exists",
+                "not_found",
+                "version_not_found",
+                "precondition_failed",
+                "precondition_missing",
+                "validation_failed",
+                "template_not_found",
+                "template_mismatch",
+                "missing_template_id",
+                "already_deleted",
+                "conflict",
+                "not_acceptable",
+                "unsupported_media",
+                "invalid_query",
+                "timeout"
+              ]
+            },
+            {
+              "const": "${fixture.expected}"
+            }
+          ]
+        },
+        "capture": {
+          "type": "object",
+          "propertyNames": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+          },
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "assert": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/assertion"
+          }
+        }
+      }
+    },
+    "assertion": {
+      "type": "object",
+      "required": [
+        "assert"
+      ],
+      "properties": {
+        "assert": {
+          "enum": [
+            "instance_of",
+            "field",
+            "equivalent",
+            "version",
+            "result_set",
+            "unique",
+            "returns",
+            "message_exemplar",
+            "state"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tools/cnf-runner/schemas/corpus-manifest.schema.json
+++ b/tools/cnf-runner/schemas/corpus-manifest.schema.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:openehr:cnf:schema:corpus-manifest:0.1.0",
+  "title": "CNF 2.0 corpus manifest",
+  "description": "Every fixture and generated set is a manifest entry: adjudicated verdict + defect live here (never only in a filename); generated sets are committed seeded deterministic recipes.",
+  "type": "object",
+  "minProperties": 1,
+  "propertyNames": {
+    "pattern": "^[a-z0-9_-]+(\\.[a-z0-9_-]+)*$"
+  },
+  "additionalProperties": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+      "format",
+      "validity",
+      "provenance"
+    ],
+    "oneOf": [
+      {
+        "required": [
+          "source"
+        ],
+        "not": {
+          "required": [
+            "generated_by"
+          ]
+        }
+      },
+      {
+        "required": [
+          "generated_by"
+        ],
+        "not": {
+          "required": [
+            "source"
+          ]
+        }
+      }
+    ],
+    "properties": {
+      "source": {
+        "type": "string",
+        "minLength": 1
+      },
+      "generated_by": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "recipe",
+          "digest"
+        ],
+        "properties": {
+          "recipe": {
+            "type": "string",
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+          },
+          "digest": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
+      "format": {
+        "enum": [
+          "canonical-json",
+          "canonical-xml",
+          "wt-flat",
+          "wt-structured",
+          "opt-xml"
+        ]
+      },
+      "rm_versions": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "validity": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "verdict"
+        ],
+        "properties": {
+          "verdict": {
+            "enum": [
+              "valid",
+              "invalid"
+            ]
+          },
+          "defect": {
+            "type": "string",
+            "minLength": 1
+          },
+          "spec_ref": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "if": {
+          "properties": {
+            "verdict": {
+              "const": "invalid"
+            }
+          }
+        },
+        "then": {
+          "required": [
+            "verdict",
+            "defect",
+            "spec_ref"
+          ]
+        }
+      },
+      "placeholders": {
+        "type": "object",
+        "additionalProperties": {
+          "enum": [
+            "runtime-random"
+          ]
+        }
+      },
+      "provenance": {
+        "type": "string",
+        "minLength": 1
+      },
+      "views": {
+        "type": "object",
+        "propertyNames": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+        },
+        "additionalProperties": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "select"
+          ],
+          "properties": {
+            "select": {
+              "type": "string",
+              "minLength": 1
+            },
+            "where": {
+              "type": "string"
+            },
+            "order_by": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "recipes": {
+        "type": "object",
+        "propertyNames": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+        },
+        "additionalProperties": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "digest"
+          ],
+          "properties": {
+            "digest": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tools/cnf-runner/schemas/operation-binding.schema.json
+++ b/tools/cnf-runner/schemas/operation-binding.schema.json
@@ -1,0 +1,194 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:openehr:cnf:schema:operation-binding:0.1.0",
+  "title": "CNF 2.0 operation binding",
+  "description": "Per-ITS wire realization of one SM operation: request construction, outcome kind → wire expectation, logical capture → wire source. Every mapping cites its OAS source.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "sm_operation",
+    "its",
+    "request",
+    "outcomes"
+  ],
+  "properties": {
+    "sm_operation": {
+      "type": "string",
+      "pattern": "^I_[A-Z0-9_]+\\.[a-z][a-z0-9_]*$"
+    },
+    "its": {
+      "enum": [
+        "its-rest"
+      ]
+    },
+    "applies": {
+      "type": "object"
+    },
+    "request": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "method",
+        "path"
+      ],
+      "properties": {
+        "method": {
+          "enum": [
+            "GET",
+            "POST",
+            "PUT",
+            "DELETE",
+            "HEAD"
+          ]
+        },
+        "path": {
+          "type": "string",
+          "pattern": "^/"
+        },
+        "body": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            }
+          ]
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "formats": {
+      "type": "array",
+      "items": {
+        "enum": [
+          "canonical-json",
+          "canonical-xml",
+          "wt-flat",
+          "wt-structured",
+          "wt"
+        ]
+      }
+    },
+    "format_headers": {
+      "type": "object",
+      "propertyNames": {
+        "enum": [
+          "canonical-json",
+          "canonical-xml",
+          "wt-flat",
+          "wt-structured",
+          "wt"
+        ]
+      },
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      }
+    },
+    "outcomes": {
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": {
+        "enum": [
+          "created",
+          "ok",
+          "ok_empty",
+          "updated",
+          "deleted",
+          "stored",
+          "already_exists",
+          "not_found",
+          "version_not_found",
+          "precondition_failed",
+          "precondition_missing",
+          "validation_failed",
+          "template_not_found",
+          "template_mismatch",
+          "missing_template_id",
+          "already_deleted",
+          "conflict",
+          "not_acceptable",
+          "unsupported_media",
+          "invalid_query",
+          "timeout"
+        ]
+      },
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "status"
+        ],
+        "properties": {
+          "status": {
+            "type": "integer",
+            "minimum": 100,
+            "maximum": 599
+          },
+          "headers": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "body": {
+            "enum": [
+              "prefer_conditional",
+              "error_loose",
+              "result_set_body",
+              "negotiated",
+              "present",
+              "absent"
+            ]
+          }
+        }
+      }
+    },
+    "captures": {
+      "type": "object",
+      "propertyNames": {
+        "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "from"
+        ],
+        "properties": {
+          "from": {
+            "type": "string"
+          },
+          "strip": {
+            "enum": [
+              "weak-quotes"
+            ]
+          },
+          "transform": {
+            "enum": [
+              "root-uid"
+            ]
+          },
+          "fallback": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "server_assigned": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/tools/cnf-runner/schemas/outcomes.schema.json
+++ b/tools/cnf-runner/schemas/outcomes.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:openehr:cnf:schema:outcomes:0.1.0",
+  "title": "CNF 2.0 outcome-kind vocabulary",
+  "description": "The closed outcome taxonomy. Cases speak ONLY these kinds; bindings map each kind to wire per operation. Extension only by schedule release.",
+  "type": "object",
+  "propertyNames": {
+    "enum": [
+      "created",
+      "ok",
+      "ok_empty",
+      "updated",
+      "deleted",
+      "stored",
+      "already_exists",
+      "not_found",
+      "version_not_found",
+      "precondition_failed",
+      "precondition_missing",
+      "validation_failed",
+      "template_not_found",
+      "template_mismatch",
+      "missing_template_id",
+      "already_deleted",
+      "conflict",
+      "not_acceptable",
+      "unsupported_media",
+      "invalid_query",
+      "timeout"
+    ]
+  },
+  "required": [
+    "created",
+    "ok",
+    "ok_empty",
+    "updated",
+    "deleted",
+    "stored",
+    "already_exists",
+    "not_found",
+    "version_not_found",
+    "precondition_failed",
+    "precondition_missing",
+    "validation_failed",
+    "template_not_found",
+    "template_mismatch",
+    "missing_template_id",
+    "already_deleted",
+    "conflict",
+    "not_acceptable",
+    "unsupported_media",
+    "invalid_query",
+    "timeout"
+  ],
+  "additionalProperties": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+      "class",
+      "meaning"
+    ],
+    "properties": {
+      "class": {
+        "enum": [
+          "success",
+          "error"
+        ]
+      },
+      "meaning": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/tools/cnf-runner/schemas/selectors.schema.json
+++ b/tools/cnf-runner/schemas/selectors.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:openehr:cnf:schema:selectors:0.1.0",
+  "title": "CNF 2.0 selector vocabulary",
+  "description": "The closed body-selector and header-matcher vocabularies, plus the named ignore-set registry the `equivalent` assertion resolves (normative, never runner judgment).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "body_selectors",
+    "header_matchers",
+    "ignore_sets"
+  ],
+  "properties": {
+    "body_selectors": {
+      "const": [
+        "prefer_conditional",
+        "error_loose",
+        "result_set_body",
+        "negotiated",
+        "present",
+        "absent"
+      ]
+    },
+    "header_matchers": {
+      "const": [
+        "present",
+        "present?",
+        "absent",
+        "negotiated",
+        "latest-version-uid",
+        "pattern:<regex>",
+        "<literal>"
+      ]
+    },
+    "ignore_sets": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "server_assigned",
+        "ctx_defaults"
+      ],
+      "properties": {
+        "server_assigned": {
+          "$ref": "#/$defs/ignoreSet"
+        },
+        "ctx_defaults": {
+          "$ref": "#/$defs/ignoreSet"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "ignoreSet": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source"
+      ],
+      "properties": {
+        "paths": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "per_binding": {
+          "type": "boolean"
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/tools/cnf-runner/src/artifacts.rs
+++ b/tools/cnf-runner/src/artifacts.rs
@@ -1,0 +1,174 @@
+//! The loaded artifact set — one root directory laid out per the artifact
+//! families:
+//!
+//! ```text
+//! <root>/schedule/**/*.yaml        case cores
+//! <root>/bindings/<its>/*.yaml     operation bindings
+//! <root>/vocab/outcomes.yaml       outcome vocabulary
+//! <root>/vocab/selectors.yaml      selector vocabulary + ignore-sets
+//! <root>/vocab/capability_matrix.yaml
+//! <root>/corpus/MANIFEST.yaml      corpus manifest
+//! <root>/registers/ambiguities.yaml
+//! ```
+//!
+//! Loading never fails fast: every file error becomes a finding, so one
+//! validation run reports the whole tree.
+
+use std::path::{Path, PathBuf};
+
+use crate::load::{LoadError, compile_schema, load_artifact};
+use crate::model::binding::OperationBinding;
+use crate::model::capability::CapabilityMatrix;
+use crate::model::case::CaseCore;
+use crate::model::corpus::CorpusManifest;
+use crate::model::register::AmbiguityRegister;
+use crate::model::vocab_files::{OutcomesVocab, SelectorsVocab};
+use crate::schema;
+
+/// The fully-typed artifact set (files that failed to load are absent; their
+/// errors travel alongside).
+#[derive(Debug, Default)]
+pub struct ArtifactSet {
+    pub cases: Vec<(PathBuf, CaseCore)>,
+    pub bindings: Vec<(PathBuf, OperationBinding)>,
+    pub outcomes: Option<(PathBuf, OutcomesVocab)>,
+    pub selectors: Option<(PathBuf, SelectorsVocab)>,
+    pub matrix: Option<(PathBuf, CapabilityMatrix)>,
+    pub corpus: Option<(PathBuf, CorpusManifest)>,
+    pub register: Option<(PathBuf, AmbiguityRegister)>,
+    /// The corpus manifest's directory (source paths resolve against it).
+    pub corpus_dir: Option<PathBuf>,
+}
+
+/// A load pass over one artifact root.
+#[derive(Debug, Default)]
+pub struct Loaded {
+    pub set: ArtifactSet,
+    pub errors: Vec<LoadError>,
+}
+
+fn yaml_files_under(dir: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let mut stack = vec![dir.to_owned()];
+    while let Some(current) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&current) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().is_some_and(|e| e == "yaml" || e == "yml") {
+                files.push(path);
+            }
+        }
+    }
+    files.sort();
+    files
+}
+
+/// Load every artifact under `root`.
+///
+/// # Errors
+/// Only on a schema-compilation defect in [`crate::schema`] itself — a bug
+/// in this crate, not in the artifact tree. Tree problems come back as
+/// [`Loaded::errors`].
+pub fn load_root(root: &Path) -> Result<Loaded, LoadError> {
+    let case_schema = compile_schema(&schema::case_core_schema(), "case-core.schema.json")?;
+    let binding_schema = compile_schema(
+        &schema::operation_binding_schema(),
+        "operation-binding.schema.json",
+    )?;
+    let outcomes_schema = compile_schema(&schema::outcomes_schema(), "outcomes.schema.json")?;
+    let selectors_schema = compile_schema(&schema::selectors_schema(), "selectors.schema.json")?;
+    let matrix_schema = compile_schema(
+        &schema::capability_matrix_schema(),
+        "capability-matrix.schema.json",
+    )?;
+    let corpus_schema = compile_schema(
+        &schema::corpus_manifest_schema(),
+        "corpus-manifest.schema.json",
+    )?;
+    let register_schema = compile_schema(
+        &schema::ambiguity_register_schema(),
+        "ambiguity-register.schema.json",
+    )?;
+
+    let mut loaded = Loaded::default();
+
+    for path in yaml_files_under(&root.join("schedule")) {
+        match load_artifact::<CaseCore>(&path, &case_schema) {
+            Ok(case) => loaded.set.cases.push((path, case)),
+            Err(e) => loaded.errors.push(e),
+        }
+    }
+    for path in yaml_files_under(&root.join("bindings")) {
+        match load_artifact::<OperationBinding>(&path, &binding_schema) {
+            Ok(binding) => loaded.set.bindings.push((path, binding)),
+            Err(e) => loaded.errors.push(e),
+        }
+    }
+
+    let mut singleton = |rel: &str, out: &mut dyn FnMut(PathBuf, &Path) -> Option<LoadError>| {
+        let path = root.join(rel);
+        if path.exists()
+            && let Some(e) = out(path.clone(), &path)
+        {
+            loaded.errors.push(e);
+        }
+    };
+
+    singleton(
+        "vocab/outcomes.yaml",
+        &mut |path, p| match load_artifact::<OutcomesVocab>(p, &outcomes_schema) {
+            Ok(v) => {
+                loaded.set.outcomes = Some((path, v));
+                None
+            }
+            Err(e) => Some(e),
+        },
+    );
+    singleton(
+        "vocab/selectors.yaml",
+        &mut |path, p| match load_artifact::<SelectorsVocab>(p, &selectors_schema) {
+            Ok(v) => {
+                loaded.set.selectors = Some((path, v));
+                None
+            }
+            Err(e) => Some(e),
+        },
+    );
+    singleton(
+        "vocab/capability_matrix.yaml",
+        &mut |path, p| match load_artifact::<CapabilityMatrix>(p, &matrix_schema) {
+            Ok(v) => {
+                loaded.set.matrix = Some((path, v));
+                None
+            }
+            Err(e) => Some(e),
+        },
+    );
+    singleton(
+        "corpus/MANIFEST.yaml",
+        &mut |path, p| match load_artifact::<CorpusManifest>(p, &corpus_schema) {
+            Ok(v) => {
+                loaded.set.corpus_dir = path.parent().map(Path::to_owned);
+                loaded.set.corpus = Some((path, v));
+                None
+            }
+            Err(e) => Some(e),
+        },
+    );
+    singleton(
+        "registers/ambiguities.yaml",
+        &mut |path, p| match load_artifact::<AmbiguityRegister>(p, &register_schema) {
+            Ok(v) => {
+                loaded.set.register = Some((path, v));
+                None
+            }
+            Err(e) => Some(e),
+        },
+    );
+
+    Ok(loaded)
+}

--- a/tools/cnf-runner/src/bin/cnf-runner.rs
+++ b/tools/cnf-runner/src/bin/cnf-runner.rs
@@ -1,0 +1,100 @@
+//! The CNF 2.0 reference runner CLI.
+//!
+//! ```text
+//! cnf-runner emit-schemas --out DIR     write the published JSON-Schema set
+//! cnf-runner validate --root DIR [--specs DIR]
+//!                                       validate an artifact tree (all gates);
+//!                                       --specs enables the SM/spec-ref
+//!                                       resolution checks against the vendored
+//!                                       spec tree (docs/specs/openehr)
+//! ```
+//!
+//! Exit codes: `0` clean · `1` findings · `2` runner error.
+// Verification CLI: progress/diagnostics on the console ARE this tool's user
+// interface — the reliability deny-tier for shipped code deliberately relaxes
+// stdio here (.claude/rules/reliability.md §tools).
+#![allow(clippy::print_stdout, clippy::print_stderr)]
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::{Parser, Subcommand};
+
+use cnf_runner::artifacts::load_root;
+use cnf_runner::schema::{emit_all, render};
+use cnf_runner::validate::{Context, validate};
+
+#[derive(Parser)]
+#[command(name = "cnf-runner", about = "CNF 2.0 reference runner", version)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Write the published JSON-Schema set (byte-deterministic).
+    EmitSchemas {
+        /// Output directory (created if missing).
+        #[arg(long)]
+        out: PathBuf,
+    },
+    /// Validate one artifact tree through every machine gate.
+    Validate {
+        /// The artifact root (schedule/, bindings/, vocab/, corpus/, registers/).
+        #[arg(long)]
+        root: PathBuf,
+        /// The vendored openEHR spec tree; enables SM-operation and spec-ref
+        /// resolution.
+        #[arg(long)]
+        specs: Option<PathBuf>,
+    },
+}
+
+fn main() -> ExitCode {
+    match Cli::parse().command {
+        Command::EmitSchemas { out } => {
+            if let Err(e) = std::fs::create_dir_all(&out) {
+                eprintln!("cannot create {}: {e}", out.display());
+                return ExitCode::from(2);
+            }
+            for (name, schema) in emit_all() {
+                let path = out.join(name);
+                if let Err(e) = std::fs::write(&path, render(&schema)) {
+                    eprintln!("cannot write {}: {e}", path.display());
+                    return ExitCode::from(2);
+                }
+                println!("wrote {}", path.display());
+            }
+            ExitCode::SUCCESS
+        }
+        Command::Validate { root, specs } => {
+            let loaded = match load_root(&root) {
+                Ok(loaded) => loaded,
+                Err(e) => {
+                    eprintln!("runner defect: {e}");
+                    return ExitCode::from(2);
+                }
+            };
+            let findings = validate(&Context {
+                set: &loaded.set,
+                load_errors: &loaded.errors,
+                spec_root: specs.as_deref(),
+            });
+            for finding in &findings {
+                println!("{finding}");
+            }
+            println!(
+                "{} case(s), {} binding(s), {} finding(s)",
+                loaded.set.cases.len(),
+                loaded.set.bindings.len(),
+                findings.len()
+            );
+            if findings.is_empty() {
+                ExitCode::SUCCESS
+            } else {
+                ExitCode::from(1)
+            }
+        }
+    }
+}

--- a/tools/cnf-runner/src/ids.rs
+++ b/tools/cnf-runner/src/ids.rs
@@ -1,0 +1,303 @@
+//! Identifier newtypes for the schedule artifacts.
+//!
+//! Every identifier space in the CNF 2.0 artifact set is a distinct type so a
+//! swapped-argument mistake is a compile error, and each carries its lexical
+//! rule at parse time (CNF `platform_test_schedule/master03-overview.adoc`
+//! defines the case-id families; the rest are this framework's own closed
+//! grammars — no openEHR spec governs them: our own design).
+
+use std::fmt;
+
+use serde::de::Error as DeError;
+use serde::{Deserialize, Deserializer, Serialize};
+use thiserror::Error;
+
+/// Lexical error for any identifier newtype in this module.
+#[derive(Debug, Error)]
+#[error("invalid {kind}: {value:?} ({rule})")]
+pub struct IdError {
+    kind: &'static str,
+    value: String,
+    rule: &'static str,
+}
+
+fn is_ident(s: &str) -> bool {
+    let mut chars = s.chars();
+    chars
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+        && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+macro_rules! string_id {
+    ($(#[$doc:meta])* $name:ident, $kind:literal, $rule:literal, $check:expr) => {
+        $(#[$doc])*
+        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+        #[serde(transparent)]
+        pub struct $name(String);
+
+        impl $name {
+            /// Parse and lexically validate the identifier.
+            ///
+            /// # Errors
+            /// Returns [`IdError`] when the value violates the identifier's
+            /// lexical rule.
+            pub fn parse(value: &str) -> Result<Self, IdError> {
+                #[allow(clippy::redundant_closure_call)] // macro seam: the rule is a closure literal
+                if ($check)(value) {
+                    Ok(Self(value.to_owned()))
+                } else {
+                    Err(IdError { kind: $kind, value: value.to_owned(), rule: $rule })
+                }
+            }
+
+            /// The identifier text.
+            #[must_use]
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(&self.0)
+            }
+        }
+
+        impl std::str::FromStr for $name {
+            type Err = IdError;
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                Self::parse(s)
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+                let s = String::deserialize(deserializer)?;
+                Self::parse(&s).map_err(D::Error::custom)
+            }
+        }
+    };
+}
+
+string_id!(
+    /// A global CNF case id (`<SERVICE_COMPONENT>.<operation>-<variant>`,
+    /// `CONT-<TYPE>-<variant>`, `SF-<FORM>-<variant>`, …). Family membership
+    /// is checked by the validator; lexically an id is non-empty ASCII
+    /// without whitespace.
+    CaseId,
+    "case id",
+    "non-empty, ASCII, no whitespace",
+    |s: &str| !s.is_empty() && s.is_ascii() && !s.contains(char::is_whitespace)
+);
+
+string_id!(
+    /// A verdict-bearing capability name from the capability matrix
+    /// (e.g. `EhrOperations`).
+    CapabilityName,
+    "capability name",
+    "ASCII identifier",
+    is_ident
+);
+
+string_id!(
+    /// A corpus manifest key (`cnf.composition.minimal_event.v1`): lowercase
+    /// dotted segments.
+    CorpusKey,
+    "corpus key",
+    "dot-separated lowercase segments of [a-z0-9_-]",
+    |s: &str| {
+        !s.is_empty()
+            && s.split('.').all(|seg| {
+                !seg.is_empty()
+                    && seg.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '-')
+            })
+    }
+);
+
+string_id!(
+    /// An ambiguity-register id (`AMB-<n>`).
+    AmbiguityId,
+    "ambiguity id",
+    "AMB-<number>",
+    |s: &str| {
+        s.strip_prefix("AMB-").is_some_and(|n| !n.is_empty() && n.chars().all(|c| c.is_ascii_digit()))
+    }
+);
+
+string_id!(
+    /// An option tag realizing one branch of an `option_select` ambiguity
+    /// (e.g. `adl14-duplicate-conflict`).
+    OptionTag,
+    "option tag",
+    "non-empty [a-z0-9_-]",
+    |s: &str| !s.is_empty() && s.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '-')
+);
+
+string_id!(
+    /// A named projection over a corpus data set (referenced as
+    /// `${ds:<key>#<view>}`).
+    ViewName,
+    "view name",
+    "ASCII identifier",
+    is_ident
+);
+
+string_id!(
+    /// A named row-to-instance synthesis recipe (referenced as
+    /// `${recipe:<name>(row)}`).
+    RecipeName,
+    "recipe name",
+    "ASCII identifier",
+    is_ident
+);
+
+string_id!(
+    /// A named SUT instance from `ixit.json` (the flow `on:` selector;
+    /// default `sut`).
+    InstanceName,
+    "instance name",
+    "ASCII identifier",
+    is_ident
+);
+
+string_id!(
+    /// A case-scoped capture / `requires`-handle name (`ehr_id`, `v2_uid`).
+    CaptureName,
+    "capture name",
+    "ASCII identifier",
+    is_ident
+);
+
+/// An SM operation anchor: `I_<INTERFACE>.<operation>` — resolved by the
+/// validator against the vendored SM UML class exports
+/// (`docs/specs/openehr/SM/docs/UML/classes/`).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SmOperationRef {
+    interface: String,
+    operation: String,
+}
+
+impl SmOperationRef {
+    /// Parse `I_<INTERFACE>.<operation>`.
+    ///
+    /// # Errors
+    /// Returns [`IdError`] when the value is not an `I_…`-prefixed interface
+    /// name followed by exactly one `.` and an operation identifier.
+    pub fn parse(value: &str) -> Result<Self, IdError> {
+        let err = |rule| IdError {
+            kind: "SM operation",
+            value: value.to_owned(),
+            rule,
+        };
+        let (interface, operation) = value
+            .split_once('.')
+            .ok_or_else(|| err("must be I_<INTERFACE>.<operation>"))?;
+        if !interface.starts_with("I_")
+            || !interface
+                .chars()
+                .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
+        {
+            return Err(err("interface must be I_UPPER_SNAKE"));
+        }
+        if !operation
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_lowercase())
+            || !operation
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+        {
+            return Err(err("operation must be lower_snake"));
+        }
+        Ok(Self {
+            interface: interface.to_owned(),
+            operation: operation.to_owned(),
+        })
+    }
+
+    /// The SM interface name (`I_EHR_SERVICE`).
+    #[must_use]
+    pub fn interface(&self) -> &str {
+        &self.interface
+    }
+
+    /// The operation name (`create_ehr`).
+    #[must_use]
+    pub fn operation(&self) -> &str {
+        &self.operation
+    }
+
+    /// Build a reference to a sibling operation on the same interface (the
+    /// flow `call:` short form, which "resolves against `sm_operation`'s
+    /// interface" per the case-core contract).
+    #[must_use]
+    pub fn sibling(&self, operation: &str) -> Self {
+        Self {
+            interface: self.interface.clone(),
+            operation: operation.to_owned(),
+        }
+    }
+}
+
+impl fmt::Display for SmOperationRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}", self.interface, self.operation)
+    }
+}
+
+impl std::str::FromStr for SmOperationRef {
+    type Err = IdError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
+    }
+}
+
+impl Serialize for SmOperationRef {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for SmOperationRef {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Self::parse(&s).map_err(D::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sm_operation_parses_and_prints() {
+        let op = SmOperationRef::parse("I_EHR_SERVICE.create_ehr").unwrap();
+        assert_eq!(op.interface(), "I_EHR_SERVICE");
+        assert_eq!(op.operation(), "create_ehr");
+        assert_eq!(op.to_string(), "I_EHR_SERVICE.create_ehr");
+        assert_eq!(op.sibling("get_ehr").to_string(), "I_EHR_SERVICE.get_ehr");
+    }
+
+    #[test]
+    fn sm_operation_rejects_malformed() {
+        assert!(SmOperationRef::parse("EHR_SERVICE.create_ehr").is_err());
+        assert!(SmOperationRef::parse("I_EHR_SERVICE").is_err());
+        assert!(SmOperationRef::parse("I_EHR_SERVICE.CreateEhr").is_err());
+    }
+
+    #[test]
+    fn ambiguity_id_shape() {
+        assert!(AmbiguityId::parse("AMB-13").is_ok());
+        assert!(AmbiguityId::parse("AMB-").is_err());
+        assert!(AmbiguityId::parse("amb-1").is_err());
+    }
+
+    #[test]
+    fn corpus_key_shape() {
+        assert!(CorpusKey::parse("cnf.composition.minimal_event.v1").is_ok());
+        assert!(CorpusKey::parse("cnf.set.bp-10").is_ok());
+        assert!(CorpusKey::parse("Cnf.Upper").is_err());
+        assert!(CorpusKey::parse("cnf..double_dot").is_err());
+    }
+}

--- a/tools/cnf-runner/src/lib.rs
+++ b/tools/cnf-runner/src/lib.rs
@@ -1,0 +1,19 @@
+//! CNF 2.0 reference runner — the typed schedule-artifact model, validator,
+//! and JSON-Schema emission for the openEHR conformance framework.
+//!
+//! The conformance oracle is the vendored openEHR CNF component
+//! (`docs/specs/openehr/CNF/`); the artifact families this crate models are
+//! the machine-readable normative form of the Platform Conformance Test
+//! Schedule (case cores, operation bindings, vocabularies incl. the
+//! capability matrix, corpus manifest, ambiguity register). Every closed
+//! vocabulary is a Rust enum/newtype so illegal states are unrepresentable.
+
+pub mod artifacts;
+pub mod ids;
+pub mod literal;
+pub mod load;
+pub mod model;
+pub mod refgrammar;
+pub mod schema;
+pub mod validate;
+pub mod vocab;

--- a/tools/cnf-runner/src/literal.rs
+++ b/tools/cnf-runner/src/literal.rs
@@ -1,0 +1,412 @@
+//! The decision-table literal grammar and violation categories.
+//!
+//! The content chapters carry structured constraint literals in their
+//! decision tables (`CNF platform_test_schedule master15–17`): ranges
+//! `5.0..10.0`, lists `[cm 5.0..10.0, m]`, terminology codes
+//! `openehr::122 (length)` / `local::at0005`, ordinal tuples
+//! `1|[local::at0005]`, quantity literals `100 mg`. Violation categories
+//! name RM/schema rules, named RM invariants, ISO 8601 rules, and constraint
+//! clauses. The grammar is normative (published with the schemas); every
+//! table cell must parse against it.
+
+use std::fmt;
+
+use thiserror::Error;
+
+/// Literal-grammar parse error.
+#[derive(Debug, Error)]
+#[error("invalid decision-table literal {text:?}: {reason}")]
+pub struct LiteralError {
+    text: String,
+    reason: String,
+}
+
+impl LiteralError {
+    fn new(text: &str, reason: impl Into<String>) -> Self {
+        Self {
+            text: text.to_owned(),
+            reason: reason.into(),
+        }
+    }
+}
+
+/// A parsed decision-table literal.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Literal {
+    /// JSON null (a first-class cell value in the official `DV_QUANTITY` table).
+    Null,
+    Bool(bool),
+    Integer(i64),
+    Real(f64),
+    /// A plain string cell with no grammar-significant structure.
+    Text(String),
+    /// A numeric range `a..b`.
+    Range {
+        lo: f64,
+        hi: f64,
+    },
+    /// A list `[x, y, …]` of literals.
+    List(Vec<Literal>),
+    /// A unit-scoped range `cm 5.0..10.0` (inside `C_DV_QUANTITY` list cells).
+    UnitRange {
+        units: String,
+        lo: f64,
+        hi: f64,
+    },
+    /// A terminology code `openehr::122 (length)` / `local::at0005`.
+    TermCode {
+        terminology: String,
+        code: String,
+        rubric: Option<String>,
+    },
+    /// An ordinal tuple `1|[local::at0005]`.
+    Ordinal {
+        value: i64,
+        symbol: Box<Literal>,
+    },
+    /// A quantity literal `100 mg`.
+    Quantity {
+        magnitude: f64,
+        units: String,
+    },
+}
+
+impl Literal {
+    /// Parse a decision-table cell from its JSON value. Strings run through
+    /// the literal grammar; a string with grammar-significant markers
+    /// (`..`, `::`, `|`, `[`) MUST parse as the corresponding production.
+    ///
+    /// # Errors
+    /// Returns [`LiteralError`] when a structured-looking string fails its
+    /// production.
+    pub fn from_cell(value: &serde_json::Value) -> Result<Self, LiteralError> {
+        match value {
+            serde_json::Value::Null => Ok(Self::Null),
+            serde_json::Value::Bool(b) => Ok(Self::Bool(*b)),
+            serde_json::Value::Number(n) => n
+                .as_i64()
+                .map(Self::Integer)
+                .or_else(|| n.as_f64().map(Self::Real))
+                .ok_or_else(|| LiteralError::new(&n.to_string(), "number is neither i64 nor f64")),
+            serde_json::Value::String(s) => Self::from_text(s),
+            other => Err(LiteralError::new(
+                &other.to_string(),
+                "cell must be a scalar or grammar string",
+            )),
+        }
+    }
+
+    /// Parse a string cell through the grammar.
+    ///
+    /// # Errors
+    /// Returns [`LiteralError`] when the string carries grammar-significant
+    /// markers but fails the corresponding production.
+    pub fn from_text(s: &str) -> Result<Self, LiteralError> {
+        let t = s.trim();
+        if t.starts_with('[') {
+            return Self::parse_list(t);
+        }
+        if let Some((value, symbol)) = t.split_once('|') {
+            // Ordinal tuple `1|[local::at0005]` — only when the head is an integer.
+            if let Ok(value) = value.trim().parse::<i64>() {
+                let symbol = Self::from_text(symbol)?;
+                return Ok(Self::Ordinal {
+                    value,
+                    symbol: Box::new(symbol),
+                });
+            }
+        }
+        if t.contains("::") {
+            return Self::parse_term_code(t);
+        }
+        if t.contains("..") {
+            return Self::parse_scoped_range(t);
+        }
+        if let Some(q) = Self::try_quantity(t) {
+            return Ok(q);
+        }
+        Ok(Self::Text(t.to_owned()))
+    }
+
+    fn parse_list(t: &str) -> Result<Self, LiteralError> {
+        let inner = t
+            .strip_prefix('[')
+            .and_then(|rest| rest.strip_suffix(']'))
+            .ok_or_else(|| LiteralError::new(t, "unterminated list"))?;
+        let mut items = Vec::new();
+        for item in split_top_level(inner) {
+            let item = item.trim();
+            if item.is_empty() {
+                return Err(LiteralError::new(t, "empty list item"));
+            }
+            items.push(Self::from_text(item)?);
+        }
+        Ok(Self::List(items))
+    }
+
+    /// `a..b` or `units a..b`.
+    fn parse_scoped_range(t: &str) -> Result<Self, LiteralError> {
+        let (units, range) = match t.rsplit_once(' ') {
+            Some((units, range)) if range.contains("..") => (Some(units.trim()), range.trim()),
+            _ => (None, t),
+        };
+        let (lo, hi) = range
+            .split_once("..")
+            .ok_or_else(|| LiteralError::new(t, "range must be a..b"))?;
+        let lo: f64 = lo
+            .trim()
+            .parse()
+            .map_err(|_| LiteralError::new(t, "range lower bound is not a number"))?;
+        let hi: f64 = hi
+            .trim()
+            .parse()
+            .map_err(|_| LiteralError::new(t, "range upper bound is not a number"))?;
+        match units {
+            Some(units) if !units.is_empty() => Ok(Self::UnitRange {
+                units: units.to_owned(),
+                lo,
+                hi,
+            }),
+            _ => Ok(Self::Range { lo, hi }),
+        }
+    }
+
+    /// `openehr::122 (length)` / `local::at0005`.
+    fn parse_term_code(t: &str) -> Result<Self, LiteralError> {
+        let (terminology, rest) = t.split_once("::").ok_or_else(|| {
+            LiteralError::new(t, "terminology code must be <terminology>::<code>")
+        })?;
+        let terminology = terminology.trim();
+        if terminology.is_empty() || terminology.contains(char::is_whitespace) {
+            return Err(LiteralError::new(t, "terminology name must be one word"));
+        }
+        let (code, rubric) = match rest.split_once('(') {
+            Some((code, rubric)) => {
+                let rubric = rubric
+                    .strip_suffix(')')
+                    .ok_or_else(|| LiteralError::new(t, "unterminated rubric"))?;
+                (code.trim(), Some(rubric.trim().to_owned()))
+            }
+            None => (rest.trim(), None),
+        };
+        if code.is_empty() || code.contains(char::is_whitespace) {
+            return Err(LiteralError::new(t, "code must be one word"));
+        }
+        Ok(Self::TermCode {
+            terminology: terminology.to_owned(),
+            code: code.to_owned(),
+            rubric,
+        })
+    }
+
+    /// `100 mg` — a number followed by a unit word.
+    fn try_quantity(t: &str) -> Option<Self> {
+        let (magnitude, units) = t.split_once(' ')?;
+        let magnitude: f64 = magnitude.trim().parse().ok()?;
+        let units = units.trim();
+        if units.is_empty() || units.contains(char::is_whitespace) {
+            return None;
+        }
+        Some(Self::Quantity {
+            magnitude,
+            units: units.to_owned(),
+        })
+    }
+}
+
+/// Split on top-level commas (not inside nested brackets/parentheses).
+fn split_top_level(s: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut depth = 0_i32;
+    let mut start = 0_usize;
+    for (i, c) in s.char_indices() {
+        match c {
+            '[' | '(' => depth += 1,
+            ']' | ')' => depth -= 1,
+            ',' if depth == 0 => {
+                parts.push(s.get(start..i).unwrap_or_default());
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    parts.push(s.get(start..).unwrap_or_default());
+    parts
+}
+
+/// The closed violation-category taxonomy of content decision tables.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ViolationCategory {
+    /// RM/schema rule (mandatory fields, typing).
+    RmSchema,
+    /// A named RM invariant (`limits_consistent`).
+    RmInvariant,
+    /// An ISO 8601 rule.
+    Iso8601,
+    /// A constraint clause (`C_DV_QUANTITY.list`).
+    Constraint,
+}
+
+impl ViolationCategory {
+    fn parse(token: &str) -> Option<Self> {
+        match token {
+            "rm_schema" => Some(Self::RmSchema),
+            "rm_invariant" => Some(Self::RmInvariant),
+            "iso8601" => Some(Self::Iso8601),
+            "constraint" => Some(Self::Constraint),
+            _ => None,
+        }
+    }
+
+    /// The category token.
+    #[must_use]
+    pub fn token(self) -> &'static str {
+        match self {
+            Self::RmSchema => "rm_schema",
+            Self::RmInvariant => "rm_invariant",
+            Self::Iso8601 => "iso8601",
+            Self::Constraint => "constraint",
+        }
+    }
+}
+
+/// One entry of a `violates` cell:
+/// `<category>[(<argument>)]: <description>` — e.g.
+/// `constraint(C_DV_QUANTITY.list): magnitude not in range for unit` or
+/// `rm_schema: magnitude and units are mandatory`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ViolationRef {
+    /// The closed category.
+    pub category: ViolationCategory,
+    /// The named rule/invariant/clause, when the category takes one.
+    pub argument: Option<String>,
+    /// The human description.
+    pub description: String,
+}
+
+impl ViolationRef {
+    /// Parse one `violates` list entry.
+    ///
+    /// # Errors
+    /// Returns [`LiteralError`] on an unknown category, a malformed
+    /// argument, or a missing description.
+    pub fn parse(raw: &str) -> Result<Self, LiteralError> {
+        let (head, description) = raw.split_once(':').ok_or_else(|| {
+            LiteralError::new(raw, "violation must be <category>[(arg)]: <description>")
+        })?;
+        let description = description.trim();
+        if description.is_empty() {
+            return Err(LiteralError::new(raw, "violation description is empty"));
+        }
+        let head = head.trim();
+        let (token, argument) = match head.split_once('(') {
+            Some((token, arg)) => {
+                let arg = arg
+                    .strip_suffix(')')
+                    .ok_or_else(|| LiteralError::new(raw, "unterminated category argument"))?;
+                (token.trim(), Some(arg.trim().to_owned()))
+            }
+            None => (head, None),
+        };
+        let category = ViolationCategory::parse(token)
+            .ok_or_else(|| LiteralError::new(raw, "unknown violation category"))?;
+        match category {
+            ViolationCategory::RmInvariant
+            | ViolationCategory::Iso8601
+            | ViolationCategory::Constraint
+                if argument.is_none() =>
+            {
+                return Err(LiteralError::new(
+                    raw,
+                    "category requires a (name) argument",
+                ));
+            }
+            ViolationCategory::RmSchema if argument.is_some() => {
+                return Err(LiteralError::new(raw, "rm_schema takes no argument"));
+            }
+            _ => {}
+        }
+        Ok(Self {
+            category,
+            argument,
+            description: description.to_owned(),
+        })
+    }
+}
+
+impl fmt::Display for ViolationRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.argument {
+            Some(arg) => write!(f, "{}({arg}): {}", self.category.token(), self.description),
+            None => write!(f, "{}: {}", self.category.token(), self.description),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic)] // test assertions
+mod tests {
+    use super::*;
+
+    #[test]
+    fn official_literals_parse() {
+        assert!(matches!(
+            Literal::from_text("5.0..10.0").unwrap(),
+            Literal::Range { .. }
+        ));
+        let list = Literal::from_text("[cm 5.0..10.0, m]").unwrap();
+        let Literal::List(items) = list else {
+            panic!("expected list")
+        };
+        assert!(matches!(items.first(), Some(Literal::UnitRange { .. })));
+        assert!(matches!(items.get(1), Some(Literal::Text(t)) if t == "m"));
+        assert!(matches!(
+            Literal::from_text("openehr::122 (length)").unwrap(),
+            Literal::TermCode {
+                rubric: Some(_),
+                ..
+            }
+        ));
+        assert!(matches!(
+            Literal::from_text("local::at0005").unwrap(),
+            Literal::TermCode { rubric: None, .. }
+        ));
+        assert!(matches!(
+            Literal::from_text("1|[local::at0005]").unwrap(),
+            Literal::Ordinal { .. }
+        ));
+        assert!(matches!(
+            Literal::from_text("100 mg").unwrap(),
+            Literal::Quantity { .. }
+        ));
+        assert!(matches!(
+            Literal::from_cell(&serde_json::Value::Null).unwrap(),
+            Literal::Null
+        ));
+        assert!(matches!(
+            Literal::from_text("cm").unwrap(),
+            Literal::Text(_)
+        ));
+    }
+
+    #[test]
+    fn structured_looking_strings_must_parse() {
+        assert!(Literal::from_text("5.0..").is_err());
+        assert!(Literal::from_text("[cm 5.0..10.0, m").is_err());
+        assert!(Literal::from_text("openehr:: (length").is_err());
+    }
+
+    #[test]
+    fn violations_parse() {
+        let v =
+            ViolationRef::parse("constraint(C_DV_QUANTITY.list): magnitude not in range for unit")
+                .unwrap();
+        assert_eq!(v.category, ViolationCategory::Constraint);
+        assert_eq!(v.argument.as_deref(), Some("C_DV_QUANTITY.list"));
+        let v = ViolationRef::parse("rm_schema: magnitude and units are mandatory").unwrap();
+        assert_eq!(v.category, ViolationCategory::RmSchema);
+        assert!(ViolationRef::parse("rm_invariant: missing name").is_err());
+        assert!(ViolationRef::parse("bogus: nope").is_err());
+        assert!(ViolationRef::parse("rm_schema(arg): no args allowed").is_err());
+    }
+}

--- a/tools/cnf-runner/src/load.rs
+++ b/tools/cnf-runner/src/load.rs
@@ -1,0 +1,136 @@
+//! Artifact loading: YAML → JSON value (budgeted, duplicate-rejecting) →
+//! schema validation → typed model.
+//!
+//! Every artifact runs the same pipeline; a file that fails any stage is a
+//! typed [`LoadError`] naming the file, so validator reports are uniform
+//! across schema-level and model-level defects.
+
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+
+/// Loading error, one per file and stage.
+#[derive(Debug, Error)]
+pub enum LoadError {
+    /// Filesystem failure.
+    #[error("{path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    /// YAML parse failure (incl. budget breaches and duplicate keys).
+    #[error("{path}: YAML: {message}")]
+    Yaml { path: PathBuf, message: String },
+    /// JSON-Schema validation failure.
+    #[error("{path}: schema: {message}")]
+    Schema { path: PathBuf, message: String },
+    /// Typed-model parse failure (closed grammars, invariants).
+    #[error("{path}: model: {message}")]
+    Model { path: PathBuf, message: String },
+}
+
+impl LoadError {
+    /// The stage + message without the file path (for reports that already
+    /// name the artifact).
+    #[must_use]
+    pub fn detail(&self) -> String {
+        match self {
+            Self::Io { source, .. } => source.to_string(),
+            Self::Yaml { message, .. } => format!("YAML: {message}"),
+            Self::Schema { message, .. } => format!("schema: {message}"),
+            Self::Model { message, .. } => format!("model: {message}"),
+        }
+    }
+
+    /// The offending file.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        match self {
+            Self::Io { path, .. }
+            | Self::Yaml { path, .. }
+            | Self::Schema { path, .. }
+            | Self::Model { path, .. } => path,
+        }
+    }
+}
+
+fn saphyr_options() -> serde_saphyr::Options {
+    // Default carries the anti-bomb Budget; duplicate keys are always an
+    // authoring error in schedule artifacts.
+    let mut options = serde_saphyr::Options::default();
+    options.duplicate_keys = serde_saphyr::DuplicateKeyPolicy::Error;
+    // Only `true`/`false` are booleans: YAML 1.1 forms (`yes`/`on`) stay
+    // strings, so the flow `on:` selector key and matrix cells never coerce.
+    options.strict_booleans = true;
+    options
+}
+
+/// Parse one YAML file to a JSON value.
+///
+/// # Errors
+/// [`LoadError::Io`] / [`LoadError::Yaml`].
+pub fn yaml_file_to_value(path: &Path) -> Result<serde_json::Value, LoadError> {
+    let text = std::fs::read_to_string(path).map_err(|source| LoadError::Io {
+        path: path.to_owned(),
+        source,
+    })?;
+    serde_saphyr::from_str_with_options(&text, saphyr_options()).map_err(|e| LoadError::Yaml {
+        path: path.to_owned(),
+        message: e.to_string(),
+    })
+}
+
+/// Validate a value against a compiled schema.
+///
+/// # Errors
+/// [`LoadError::Schema`] carrying every violation (joined).
+pub fn validate_against(
+    validator: &jsonschema::Validator,
+    value: &serde_json::Value,
+    path: &Path,
+) -> Result<(), LoadError> {
+    let violations: Vec<String> = validator
+        .iter_errors(value)
+        .map(|e| format!("{}: {e}", e.instance_path()))
+        .collect();
+    if violations.is_empty() {
+        Ok(())
+    } else {
+        Err(LoadError::Schema {
+            path: path.to_owned(),
+            message: violations.join("; "),
+        })
+    }
+}
+
+/// Full pipeline for one artifact file.
+///
+/// # Errors
+/// Any [`LoadError`] stage.
+pub fn load_artifact<T: serde::de::DeserializeOwned>(
+    path: &Path,
+    validator: &jsonschema::Validator,
+) -> Result<T, LoadError> {
+    let value = yaml_file_to_value(path)?;
+    validate_against(validator, &value, path)?;
+    serde_json::from_value(value).map_err(|e| LoadError::Model {
+        path: path.to_owned(),
+        message: e.to_string(),
+    })
+}
+
+/// Compile a schema document (a defect here is a bug in
+/// [`crate::schema`], surfaced as a typed error, never a panic).
+///
+/// # Errors
+/// [`LoadError::Schema`] when the schema itself does not compile.
+pub fn compile_schema(
+    schema: &serde_json::Value,
+    name: &str,
+) -> Result<jsonschema::Validator, LoadError> {
+    jsonschema::validator_for(schema).map_err(|e| LoadError::Schema {
+        path: PathBuf::from(name),
+        message: format!("schema does not compile: {e}"),
+    })
+}

--- a/tools/cnf-runner/src/model/assertion.rs
+++ b/tools/cnf-runner/src/model/assertion.rs
@@ -1,0 +1,461 @@
+//! The typed assertion vocabulary (`flow[].assert` + `postconditions`).
+//!
+//! Nine assertion forms, closed by schedule release. Semantics per the
+//! CNF 2.0 artifact-set design: `equivalent` is the master07 "content
+//! check" with normative ignore-sets; `version` asserts RM versioning facts
+//! (`RM common §change_control`); `result_set` compares under the normative
+//! AQL `RESULT_SET` equivalence rules (QUERY master03/04 + the ITS-REST query
+//! schemas); `unique` is aggregate (evaluated once after all rows);
+//! `message_exemplar` is informative only, never pass/fail.
+
+use serde::de::Error as DeError;
+use serde::{Deserialize, Deserializer};
+
+use crate::ids::CaseId;
+use crate::model::value::TemplatedValue;
+use crate::refgrammar::{RefError, Template, ValueRef};
+use crate::vocab::{ChangeType, FormatName, IgnoreSetName, ResultSetMatch};
+
+/// The `equivalent` assertion's comparison target.
+#[derive(Debug, Clone, PartialEq)]
+pub enum EquivalentTarget {
+    /// The content committed earlier in this row (`to: committed`).
+    Committed,
+    /// A corpus data set or a capture (`to: ${ds:…}` / `to: ${capture}`).
+    Ref(ValueRef),
+}
+
+impl<'de> Deserialize<'de> for EquivalentTarget {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        if s == "committed" {
+            return Ok(Self::Committed);
+        }
+        let template = Template::parse(&s).map_err(D::Error::custom)?;
+        let reference = template.as_single_ref().ok_or_else(|| {
+            D::Error::custom("equivalent target must be `committed` or a single ${…} reference")
+        })?;
+        match reference {
+            ValueRef::DataSet { .. }
+            | ValueRef::Capture {
+                optional: false, ..
+            } => Ok(Self::Ref(reference.clone())),
+            _ => Err(D::Error::custom(
+                "equivalent target reference must be ${ds:…} or ${<capture>}",
+            )),
+        }
+    }
+}
+
+/// One `ignoring:` entry: a named normative ignore-set or an explicit path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IgnoreSpec {
+    /// A named set (`server_assigned` resolves from the operation's binding;
+    /// `ctx_defaults` from the selectors vocabulary).
+    Named(IgnoreSetName),
+    /// An explicit RM path.
+    Path(String),
+}
+
+impl<'de> Deserialize<'de> for IgnoreSpec {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        match s.as_str() {
+            "server_assigned" => Ok(Self::Named(IgnoreSetName::ServerAssigned)),
+            "ctx_defaults" => Ok(Self::Named(IgnoreSetName::CtxDefaults)),
+            _ if s.contains('/') => Ok(Self::Path(s)),
+            _ => Err(D::Error::custom(format!(
+                "ignoring entry {s:?} is neither a named ignore-set (server_assigned | ctx_defaults) nor an explicit path"
+            ))),
+        }
+    }
+}
+
+/// Scalar-or-list acceptance for `ignoring:`.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct IgnoreList(pub Vec<IgnoreSpec>);
+
+impl<'de> Deserialize<'de> for IgnoreList {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum OneOrMany {
+            One(IgnoreSpec),
+            Many(Vec<IgnoreSpec>),
+        }
+        Ok(match OneOrMany::deserialize(deserializer)? {
+            OneOrMany::One(one) => Self(vec![one]),
+            OneOrMany::Many(many) => Self(many),
+        })
+    }
+}
+
+/// A template that must be exactly one `${…}` reference.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SingleRef(pub ValueRef);
+
+impl<'de> Deserialize<'de> for SingleRef {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        let template = Template::parse(&s).map_err(D::Error::custom)?;
+        let reference = template
+            .as_single_ref()
+            .ok_or_else(|| D::Error::custom(format!("{s:?} must be a single ${{…}} reference")))?;
+        Ok(Self(reference.clone()))
+    }
+}
+
+/// Expected rows of a `result_set` assertion.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RowsSpec {
+    /// Rows from a named corpus view (`rows: { from: "${ds:<key>#<view>}" }`).
+    From(ValueRef),
+    /// Inline expected rows.
+    Inline(Vec<Vec<serde_json::Value>>),
+}
+
+impl<'de> Deserialize<'de> for RowsSpec {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct FromSpec {
+            from: SingleRef,
+        }
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Raw {
+            From(FromSpec),
+            Inline(Vec<Vec<serde_json::Value>>),
+        }
+        match Raw::deserialize(deserializer)? {
+            Raw::From(FromSpec { from }) => match from.0 {
+                reference @ ValueRef::DataSet { .. } => Ok(Self::From(reference)),
+                other => Err(D::Error::custom(format!(
+                    "result_set rows.from must be a ${{ds:…}} reference, got {other}"
+                ))),
+            },
+            Raw::Inline(rows) => Ok(Self::Inline(rows)),
+        }
+    }
+}
+
+/// A `result_set` column expectation (identity: the `AS` alias, else the
+/// 0-based index — ITS-REST `ResultSetColumn.yaml`).
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ColumnSpec {
+    /// The expected column name (alias).
+    pub name: String,
+}
+
+/// A typed assertion (tag: the `assert` field).
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(tag = "assert", rename_all = "snake_case", deny_unknown_fields)]
+pub enum Assertion {
+    /// Body parses as the named RM type and validates against the ITS schema
+    /// for the active format.
+    InstanceOf {
+        rm_type: String,
+        #[serde(default)]
+        format: Option<FormatName>,
+    },
+    /// RM-path-addressed field check; exactly one predicate.
+    Field {
+        path: String,
+        #[serde(default)]
+        equals: Option<TemplatedValue>,
+        #[serde(default)]
+        exists: Option<bool>,
+        #[serde(default)]
+        absent: Option<bool>,
+        #[serde(default)]
+        matches: Option<String>,
+    },
+    /// The master07 "content check": retrieved equals committed, modulo the
+    /// declared server-assigned set — normative per operation, never
+    /// runner-chosen.
+    Equivalent {
+        to: EquivalentTarget,
+        #[serde(default)]
+        ignoring: IgnoreList,
+    },
+    /// RM versioning facts.
+    Version {
+        #[serde(default)]
+        of: Option<SingleRef>,
+        #[serde(default)]
+        for_each: Option<SingleRef>,
+        #[serde(default)]
+        change_type: Option<ChangeType>,
+        #[serde(default)]
+        lifecycle_state: Option<String>,
+        #[serde(default)]
+        count: Option<u64>,
+        #[serde(default)]
+        uid_pattern: Option<Template>,
+    },
+    /// AQL results under the normative equivalence rules.
+    ResultSet {
+        #[serde(rename = "match")]
+        match_mode: ResultSetMatch,
+        #[serde(default)]
+        rows: Option<RowsSpec>,
+        #[serde(default)]
+        count: Option<u64>,
+        #[serde(default)]
+        columns: Option<Vec<ColumnSpec>>,
+    },
+    /// Values captured across rows are pairwise distinct. Aggregate:
+    /// evaluated once after all rows; requires `iteration: single_pass`.
+    Unique { over: SingleRef, aggregate: bool },
+    /// Scalar service returns (no RM body).
+    Returns {
+        #[serde(default)]
+        equals: Option<serde_json::Value>,
+        #[serde(default)]
+        matches: Option<String>,
+    },
+    /// Informative only — never a pass/fail criterion.
+    MessageExemplar { text: String },
+    /// A prose postcondition whose machine verification lives in a linked
+    /// case or an in-case verification step.
+    State {
+        text: String,
+        #[serde(default)]
+        verified_by: Option<CaseId>,
+    },
+}
+
+impl Assertion {
+    /// Structural invariants beyond serde shape.
+    ///
+    /// # Errors
+    /// Returns a message when a predicate-count or aggregate invariant is
+    /// violated.
+    pub fn check_invariants(&self) -> Result<(), String> {
+        match self {
+            Self::Field {
+                equals,
+                exists,
+                absent,
+                matches,
+                path,
+            } => {
+                let predicates = usize::from(equals.is_some())
+                    + usize::from(exists.is_some())
+                    + usize::from(absent.is_some())
+                    + usize::from(matches.is_some());
+                if predicates != 1 {
+                    return Err(format!(
+                        "field assertion on {path:?} must carry exactly one of equals | exists | absent | matches"
+                    ));
+                }
+                if let Some(re) = matches {
+                    regex::Regex::new(re).map_err(|e| format!("field matches regex: {e}"))?;
+                }
+            }
+            Self::Version {
+                of,
+                for_each,
+                change_type,
+                lifecycle_state,
+                count,
+                uid_pattern,
+            } => {
+                if of.is_some() && for_each.is_some() {
+                    return Err(
+                        "version assertion: `of` and `for_each` are mutually exclusive".to_owned(),
+                    );
+                }
+                if change_type.is_none()
+                    && lifecycle_state.is_none()
+                    && count.is_none()
+                    && uid_pattern.is_none()
+                {
+                    return Err("version assertion carries no fact (change_type | lifecycle_state | count | uid_pattern)".to_owned());
+                }
+                if count.is_none() && of.is_none() && for_each.is_none() {
+                    return Err(
+                        "version assertion needs `of`/`for_each` (only `count` may stand alone)"
+                            .to_owned(),
+                    );
+                }
+            }
+            Self::ResultSet {
+                match_mode,
+                rows,
+                count,
+                ..
+            } => match match_mode {
+                ResultSetMatch::Count => {
+                    if count.is_none() {
+                        return Err("result_set match:count requires `count`".to_owned());
+                    }
+                }
+                _ => {
+                    if rows.is_none() {
+                        return Err("result_set requires `rows` (except match:count)".to_owned());
+                    }
+                }
+            },
+            Self::Unique { aggregate, over } => {
+                if !aggregate {
+                    return Err(
+                        "unique is defined only as an aggregate assertion (aggregate: true)"
+                            .to_owned(),
+                    );
+                }
+                if !matches!(
+                    over.0,
+                    ValueRef::Capture {
+                        optional: false,
+                        ..
+                    }
+                ) {
+                    return Err("unique `over` must be a ${<capture>} reference".to_owned());
+                }
+            }
+            Self::Returns { equals, matches } => {
+                if equals.is_some() == matches.is_some() {
+                    return Err("returns must carry exactly one of equals | matches".to_owned());
+                }
+                if let Some(re) = matches {
+                    regex::Regex::new(re).map_err(|e| format!("returns matches regex: {e}"))?;
+                }
+            }
+            Self::InstanceOf { .. }
+            | Self::Equivalent { .. }
+            | Self::MessageExemplar { .. }
+            | Self::State { .. } => {}
+        }
+        Ok(())
+    }
+
+    /// Whether this assertion is evaluated once after all rows.
+    #[must_use]
+    pub fn is_aggregate(&self) -> bool {
+        matches!(self, Self::Unique { .. })
+    }
+}
+
+/// Every `${…}` reference used by an assertion (for the closed-grammar and
+/// resolution checks).
+#[must_use]
+pub fn assertion_refs(assertion: &Assertion) -> Vec<ValueRef> {
+    let mut out: Vec<ValueRef> = Vec::new();
+    match assertion {
+        Assertion::Field { equals, .. } => {
+            if let Some(v) = equals {
+                out.extend(v.refs().into_iter().cloned());
+            }
+        }
+        Assertion::Equivalent { to, .. } => {
+            if let EquivalentTarget::Ref(r) = to {
+                out.push(r.clone());
+            }
+        }
+        Assertion::Version {
+            of,
+            for_each,
+            uid_pattern,
+            ..
+        } => {
+            if let Some(SingleRef(r)) = of {
+                out.push(r.clone());
+            }
+            if let Some(SingleRef(r)) = for_each {
+                out.push(r.clone());
+            }
+            if let Some(t) = uid_pattern {
+                out.extend(t.refs().cloned());
+            }
+        }
+        Assertion::ResultSet { rows, .. } => {
+            if let Some(RowsSpec::From(r)) = rows {
+                out.push(r.clone());
+            }
+        }
+        Assertion::Unique { over, .. } => out.push(over.0.clone()),
+        Assertion::InstanceOf { .. }
+        | Assertion::Returns { .. }
+        | Assertion::MessageExemplar { .. }
+        | Assertion::State { .. } => {}
+    }
+    out
+}
+
+/// Parse-time hook so `RefError` conversion stays local to this module.
+impl From<RefError> for String {
+    fn from(e: RefError) -> Self {
+        e.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(v: serde_json::Value) -> Assertion {
+        serde_json::from_value(v).unwrap()
+    }
+
+    #[test]
+    fn pilot_assertions_parse() {
+        let a = parse(serde_json::json!({
+            "assert": "unique", "over": "${new_ehr_id}", "aggregate": true
+        }));
+        assert!(a.check_invariants().is_ok());
+        assert!(a.is_aggregate());
+
+        let a = parse(serde_json::json!({
+            "assert": "version", "of": "${v2_uid}",
+            "uid_pattern": "${versioned_object_uid}::<system>::2"
+        }));
+        assert!(a.check_invariants().is_ok());
+
+        let a = parse(serde_json::json!({ "assert": "version", "count": 2 }));
+        assert!(a.check_invariants().is_ok());
+
+        let a = parse(serde_json::json!({
+            "assert": "equivalent", "to": "committed", "ignoring": "server_assigned"
+        }));
+        assert!(a.check_invariants().is_ok());
+
+        let a = parse(serde_json::json!({
+            "assert": "result_set", "match": "ordered",
+            "rows": { "from": "${ds:cnf.set.bp-10#magnitude_ge_140_by_uid}" },
+            "columns": [{ "name": "uid" }]
+        }));
+        assert!(a.check_invariants().is_ok());
+    }
+
+    #[test]
+    fn invariants_bite() {
+        let a = parse(serde_json::json!({ "assert": "version", "of": "${v}" }));
+        assert!(a.check_invariants().is_err()); // no fact
+
+        let a = parse(serde_json::json!({
+            "assert": "field", "path": "x", "exists": true, "absent": true
+        }));
+        assert!(a.check_invariants().is_err()); // two predicates
+
+        let a = parse(serde_json::json!({
+            "assert": "unique", "over": "${x}", "aggregate": false
+        }));
+        assert!(a.check_invariants().is_err());
+
+        assert!(
+            serde_json::from_value::<Assertion>(serde_json::json!({
+                "assert": "equivalent", "to": "${row.thing}"
+            }))
+            .is_err()
+        ); // equivalent target must be ds/capture
+
+        assert!(
+            serde_json::from_value::<Assertion>(serde_json::json!({
+                "assert": "totally_new", "x": 1
+            }))
+            .is_err()
+        ); // closed vocabulary
+    }
+}

--- a/tools/cnf-runner/src/model/binding.rs
+++ b/tools/cnf-runner/src/model/binding.rs
@@ -1,0 +1,557 @@
+//! Operation bindings — the wire layer, one file per SM operation per ITS.
+//!
+//! A binding maps request construction, each outcome kind → wire
+//! expectation, and each logical capture → wire source; every mapping cites
+//! its OAS source (ITS-REST 1.1.0 `specifications/operations/*.yaml` +
+//! `responses/*.yaml`). The capture-source, header-matcher, and
+//! body-selector vocabularies are closed.
+
+use serde::de::Error as DeError;
+use serde::{Deserialize, Deserializer};
+
+use crate::ids::{CaptureName, SmOperationRef};
+use crate::model::case::Applies;
+use crate::refgrammar::Template;
+use crate::vocab::{FormatName, HttpMethod, ItsName, OutcomeKind};
+
+/// A wire location a capture reads from (closed grammar):
+/// `header <Name>` · `header <Name> last-segment` · `body "<path>"` ·
+/// `capture <name>`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WireFrom {
+    Header {
+        name: String,
+        last_segment: bool,
+    },
+    Body {
+        path: String,
+    },
+    /// Derive from another capture.
+    Capture(CaptureName),
+}
+
+impl WireFrom {
+    /// Parse the closed source grammar.
+    ///
+    /// # Errors
+    /// Returns a message when the text is outside the grammar.
+    pub fn parse(raw: &str) -> Result<Self, String> {
+        if let Some(rest) = raw.strip_prefix("header ") {
+            let (name, last_segment) = match rest.strip_suffix(" last-segment") {
+                Some(name) => (name, true),
+                None => (rest, false),
+            };
+            let name = name.trim();
+            if name.is_empty() || name.contains(char::is_whitespace) {
+                return Err(format!(
+                    "capture source {raw:?}: header name must be one token"
+                ));
+            }
+            return Ok(Self::Header {
+                name: name.to_owned(),
+                last_segment,
+            });
+        }
+        if let Some(rest) = raw.strip_prefix("body ") {
+            let path = rest
+                .trim()
+                .strip_prefix('"')
+                .and_then(|p| p.strip_suffix('"'))
+                .ok_or_else(|| format!("capture source {raw:?}: body path must be quoted"))?;
+            if path.is_empty() {
+                return Err(format!("capture source {raw:?}: empty body path"));
+            }
+            return Ok(Self::Body {
+                path: path.to_owned(),
+            });
+        }
+        if let Some(rest) = raw.strip_prefix("capture ") {
+            return CaptureName::parse(rest.trim())
+                .map(Self::Capture)
+                .map_err(|e| format!("capture source {raw:?}: {e}"));
+        }
+        Err(format!(
+            "capture source {raw:?} is outside the closed grammar (header … | body \"…\" | capture …)"
+        ))
+    }
+}
+
+impl<'de> Deserialize<'de> for WireFrom {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Self::parse(&s).map_err(D::Error::custom)
+    }
+}
+
+/// Post-extraction modifier: strip the weak-ETag wrapper.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+pub enum StripRule {
+    #[serde(rename = "weak-quotes")]
+    WeakQuotes,
+}
+
+/// Post-extraction transform: reduce an `OBJECT_VERSION_ID` to its root uid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+pub enum TransformRule {
+    #[serde(rename = "root-uid")]
+    RootUid,
+}
+
+/// One logical-capture wire mapping with optional modifiers.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WireCapture {
+    pub from: WireFrom,
+    #[serde(default)]
+    pub strip: Option<StripRule>,
+    #[serde(default)]
+    pub transform: Option<TransformRule>,
+    /// Tried when `from` yields nothing (e.g. body field under
+    /// `Prefer: return=minimal`, falling back to `Location`).
+    #[serde(default)]
+    pub fallback: Option<WireFrom>,
+}
+
+/// A header expectation on a wire outcome (closed matcher vocabulary):
+/// `present` · `present?` · `absent` · `negotiated` · `latest-version-uid` ·
+/// `pattern:<regex>` · a literal string.
+#[derive(Debug, Clone, PartialEq)]
+pub enum HeaderMatcher {
+    Present,
+    /// Assert only if the schedule row says so.
+    PresentOptional,
+    Absent,
+    /// Equals the negotiated media type.
+    Negotiated,
+    /// The stale-precondition 412 rule: `ETag` carries the latest version uid.
+    LatestVersionUid,
+    /// A pattern; `<name>` placeholders resolve from case variables before
+    /// matching (validated by compiling with placeholders wildcarded).
+    Pattern(String),
+    /// A literal value template.
+    Literal(Template),
+}
+
+impl<'de> Deserialize<'de> for HeaderMatcher {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Ok(match s.as_str() {
+            "present" => Self::Present,
+            "present?" => Self::PresentOptional,
+            "absent" => Self::Absent,
+            "negotiated" => Self::Negotiated,
+            "latest-version-uid" => Self::LatestVersionUid,
+            _ => {
+                if let Some(pattern) = s.strip_prefix("pattern:") {
+                    let probe = placeholder_wildcarded(pattern);
+                    regex::Regex::new(&probe).map_err(|e| {
+                        D::Error::custom(format!(
+                            "header pattern {pattern:?} does not compile: {e}"
+                        ))
+                    })?;
+                    Self::Pattern(pattern.to_owned())
+                } else {
+                    Self::Literal(Template::parse(&s).map_err(D::Error::custom)?)
+                }
+            }
+        })
+    }
+}
+
+/// Replace `<name>` placeholders with `.*` for the compile probe — the
+/// pattern text is a regex (`pattern:<regex>`), so everything else is left
+/// verbatim and must compile.
+fn placeholder_wildcarded(pattern: &str) -> String {
+    let mut out = String::new();
+    let mut rest = pattern;
+    while let Some(start) = rest.find('<') {
+        let (head, tail) = rest.split_at(start);
+        out.push_str(head);
+        if let Some(end) = tail.find('>') {
+            out.push_str(".*");
+            rest = tail.get(end + 1..).unwrap_or_default();
+        } else {
+            out.push_str(tail);
+            rest = "";
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+/// A response-body expectation (closed selector vocabulary).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+pub enum BodySelector {
+    /// Full resource | `{uid}` | empty, per `Prefer`
+    /// (ITS-REST `Requests_and_responses.md` §Prefer).
+    #[serde(rename = "prefer_conditional")]
+    PreferConditional,
+    /// AMB-1: assert at most that a `message` string is present.
+    #[serde(rename = "error_loose")]
+    ErrorLoose,
+    /// The `RESULT_SET` schema (named distinctly from the `result_set`
+    /// assertion).
+    #[serde(rename = "result_set_body")]
+    ResultSetBody,
+    /// Body media type equals the negotiated type.
+    #[serde(rename = "negotiated")]
+    Negotiated,
+    #[serde(rename = "present")]
+    Present,
+    #[serde(rename = "absent")]
+    Absent,
+}
+
+/// One outcome kind's wire expectation.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WireExpectation {
+    pub status: StatusCode,
+    #[serde(default, deserialize_with = "crate::model::de::optional_ordered_map")]
+    pub headers: Option<Vec<(String, HeaderMatcher)>>,
+    #[serde(default)]
+    pub body: Option<BodySelector>,
+}
+
+/// An HTTP status code, range-checked at parse.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StatusCode(u16);
+
+impl StatusCode {
+    /// The numeric code.
+    #[must_use]
+    pub fn value(self) -> u16 {
+        self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for StatusCode {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = u16::deserialize(deserializer)?;
+        if (100..=599).contains(&raw) {
+            Ok(Self(raw))
+        } else {
+            Err(D::Error::custom(format!("status {raw} outside 100..=599")))
+        }
+    }
+}
+
+/// The request payload of a binding.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RequestBody {
+    /// A named payload role (`composition`, `opt_xml`), optionally optional
+    /// (`ehr_status?`).
+    Named { name: String, optional: bool },
+    /// A structured body template (the query binding's
+    /// `{ q: ${q}, offset: ${offset?} … }`).
+    Structured(crate::model::value::TemplatedValue),
+}
+
+impl<'de> Deserialize<'de> for RequestBody {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        match &value {
+            serde_json::Value::String(s) => {
+                let (name, optional) = match s.strip_suffix('?') {
+                    Some(name) => (name, true),
+                    None => (s.as_str(), false),
+                };
+                if name.is_empty() || name.contains(char::is_whitespace) {
+                    return Err(D::Error::custom(format!(
+                        "request body role {s:?} must be one token"
+                    )));
+                }
+                Ok(Self::Named {
+                    name: name.to_owned(),
+                    optional,
+                })
+            }
+            serde_json::Value::Object(_) => crate::model::value::TemplatedValue::from_value(&value)
+                .map(Self::Structured)
+                .map_err(D::Error::custom),
+            _ => Err(D::Error::custom(
+                "request body must be a role name or a structured template",
+            )),
+        }
+    }
+}
+
+/// A request path with `{param}` placeholders resolved from case variables.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PathTemplate {
+    raw: String,
+    params: Vec<CaptureName>,
+}
+
+impl PathTemplate {
+    /// The authored path.
+    #[must_use]
+    pub fn raw(&self) -> &str {
+        &self.raw
+    }
+
+    /// The `{param}` names, in order.
+    #[must_use]
+    pub fn params(&self) -> &[CaptureName] {
+        &self.params
+    }
+}
+
+impl<'de> Deserialize<'de> for PathTemplate {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = String::deserialize(deserializer)?;
+        if !raw.starts_with('/') {
+            return Err(D::Error::custom(format!("path {raw:?} must start with /")));
+        }
+        let mut params = Vec::new();
+        let mut rest = raw.as_str();
+        while let Some(start) = rest.find('{') {
+            let tail = rest.get(start + 1..).unwrap_or_default();
+            let end = tail
+                .find('}')
+                .ok_or_else(|| D::Error::custom(format!("path {raw:?}: unterminated {{param}}")))?;
+            let name = tail.get(..end).unwrap_or_default();
+            params.push(CaptureName::parse(name).map_err(D::Error::custom)?);
+            rest = tail.get(end + 1..).unwrap_or_default();
+        }
+        Ok(Self { raw, params })
+    }
+}
+
+/// Request construction.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RequestSpec {
+    pub method: HttpMethod,
+    pub path: PathTemplate,
+    #[serde(default)]
+    pub body: Option<RequestBody>,
+    #[serde(default, deserialize_with = "crate::model::de::optional_ordered_map")]
+    pub headers: Option<Vec<(String, Template)>>,
+}
+
+/// A per-format extra-header requirement (`openehr-template-id: required`).
+#[derive(Debug, Clone, PartialEq)]
+pub enum FormatHeaderReq {
+    Required,
+    Literal(Template),
+}
+
+impl<'de> Deserialize<'de> for FormatHeaderReq {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        if s == "required" {
+            Ok(Self::Required)
+        } else {
+            Template::parse(&s)
+                .map(Self::Literal)
+                .map_err(D::Error::custom)
+        }
+    }
+}
+
+/// One binding file.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OperationBinding {
+    pub sm_operation: SmOperationRef,
+    pub its: ItsName,
+    #[serde(default)]
+    pub applies: Option<Applies>,
+    pub request: RequestSpec,
+    #[serde(default)]
+    pub formats: Vec<FormatName>,
+    #[serde(default, deserialize_with = "crate::model::de::optional_ordered_map")]
+    pub format_headers: Option<Vec<(FormatKey, FormatHeaderMap)>>,
+    #[serde(deserialize_with = "crate::model::de::ordered_map")]
+    pub outcomes: Vec<(OutcomeKey, WireExpectation)>,
+    #[serde(default, deserialize_with = "crate::model::de::optional_ordered_map")]
+    pub captures: Option<Vec<(CaptureName, WireCapture)>>,
+    /// The operation's server-assigned ignore-set membership (the paths the
+    /// `equivalent` assertion excludes as `server_assigned`).
+    #[serde(default)]
+    pub server_assigned: Vec<String>,
+}
+
+impl OperationBinding {
+    /// The wire expectation mapped for an outcome kind, if any.
+    #[must_use]
+    pub fn outcome(&self, kind: OutcomeKind) -> Option<&WireExpectation> {
+        self.outcomes
+            .iter()
+            .find(|(k, _)| k.0 == kind)
+            .map(|(_, e)| e)
+    }
+
+    /// Whether a logical capture has a wire source.
+    #[must_use]
+    pub fn maps_capture(&self, name: &CaptureName) -> bool {
+        self.captures
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .any(|(n, _)| n == name)
+    }
+}
+
+/// Newtype keys so [`crate::model::de::ordered_map`] can parse them from
+/// mapping keys.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OutcomeKey(pub OutcomeKind);
+
+impl std::str::FromStr for OutcomeKey {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        OutcomeKind::from_token(s)
+            .map(Self)
+            .ok_or_else(|| format!("{s:?} is not an outcome kind"))
+    }
+}
+
+impl std::fmt::Display for OutcomeKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.0.token())
+    }
+}
+
+/// Format key of `format_headers`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FormatKey(pub FormatName);
+
+impl std::str::FromStr for FormatKey {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_value(serde_json::Value::String(s.to_owned()))
+            .map(Self)
+            .map_err(|_| format!("{s:?} is not a format name"))
+    }
+}
+
+impl std::fmt::Display for FormatKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match serde_json::to_value(self.0) {
+            Ok(serde_json::Value::String(s)) => f.write_str(&s),
+            _ => f.write_str("?"),
+        }
+    }
+}
+
+/// The per-format header map.
+#[derive(Debug, Clone)]
+pub struct FormatHeaderMap(pub Vec<(String, FormatHeaderReq)>);
+
+impl<'de> Deserialize<'de> for FormatHeaderMap {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        crate::model::de::ordered_map(deserializer).map(Self)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic, clippy::indexing_slicing)] // test assertions/fixtures
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wire_from_grammar_is_closed() {
+        assert_eq!(
+            WireFrom::parse("header Location last-segment").unwrap(),
+            WireFrom::Header {
+                name: "Location".into(),
+                last_segment: true
+            }
+        );
+        assert_eq!(
+            WireFrom::parse("body \"ehr_id.value\"").unwrap(),
+            WireFrom::Body {
+                path: "ehr_id.value".into()
+            }
+        );
+        assert!(matches!(
+            WireFrom::parse("capture version_uid").unwrap(),
+            WireFrom::Capture(_)
+        ));
+        assert!(WireFrom::parse("body ehr_id.value").is_err()); // unquoted
+        assert!(WireFrom::parse("body-or-location").is_err()); // outside the grammar: express via fallback
+        assert!(WireFrom::parse("jsonpath $.x").is_err());
+    }
+
+    #[test]
+    fn header_matchers_parse() {
+        let m: HeaderMatcher = serde_json::from_value(serde_json::json!("present?")).unwrap();
+        assert_eq!(m, HeaderMatcher::PresentOptional);
+        let m: HeaderMatcher = serde_json::from_value(serde_json::json!(
+            "pattern:W/\"<versioned_object_uid>::<system_id>::1\""
+        ))
+        .unwrap();
+        assert!(matches!(m, HeaderMatcher::Pattern(_)));
+        let m: HeaderMatcher =
+            serde_json::from_value(serde_json::json!("\"${preceding_version_uid}\"")).unwrap();
+        assert!(matches!(m, HeaderMatcher::Literal(_)));
+        assert!(
+            serde_json::from_value::<HeaderMatcher>(serde_json::json!("pattern:([unclosed"))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn binding_parses_the_create_ehr_shape() {
+        let b: OperationBinding = serde_json::from_value(serde_json::json!({
+            "sm_operation": "I_EHR_SERVICE.create_ehr",
+            "its": "its-rest",
+            "request": {
+                "method": "POST",
+                "path": "/ehr",
+                "body": "ehr_status?",
+                "headers": { "Prefer": "return=representation" }
+            },
+            "formats": ["canonical-json", "canonical-xml"],
+            "outcomes": {
+                "created": { "status": 201,
+                             "headers": { "ETag": "present", "Location": "present" },
+                             "body": "prefer_conditional" },
+                "already_exists": { "status": 409 },
+                "validation_failed": { "status": 400 }
+            },
+            "captures": {
+                "ehr_id": { "from": "body \"ehr_id.value\"",
+                            "fallback": "header Location last-segment" },
+                "version_uid": { "from": "header ETag", "strip": "weak-quotes" }
+            },
+            "server_assigned": ["ehr_id", "system_id", "time_created"]
+        }))
+        .unwrap();
+        assert_eq!(b.sm_operation.to_string(), "I_EHR_SERVICE.create_ehr");
+        assert!(b.outcome(OutcomeKind::Created).is_some());
+        assert!(b.outcome(OutcomeKind::NotFound).is_none());
+        assert!(b.maps_capture(&CaptureName::parse("ehr_id").unwrap()));
+        assert!(matches!(
+            b.request.body,
+            Some(RequestBody::Named { optional: true, .. })
+        ));
+        assert_eq!(b.request.path.params().len(), 0);
+    }
+
+    #[test]
+    fn path_params_extract() {
+        let r: RequestSpec = serde_json::from_value(serde_json::json!({
+            "method": "PUT",
+            "path": "/ehr/{ehr_id}/composition/{versioned_object_uid}"
+        }))
+        .unwrap();
+        assert_eq!(r.path.params().len(), 2);
+        assert!(
+            serde_json::from_value::<RequestSpec>(serde_json::json!({
+                "method": "GET", "path": "/ehr/{unclosed"
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn duplicate_outcome_keys_rejected() {
+        // serde_json::Map deduplicates silently, so feed the YAML front-end.
+        let yaml = "sm_operation: I_EHR_SERVICE.create_ehr\nits: its-rest\nrequest: { method: POST, path: /ehr }\noutcomes:\n  created: { status: 201 }\n  created: { status: 200 }\n";
+        let result: Result<OperationBinding, _> = serde_saphyr::from_str(yaml);
+        assert!(result.is_err());
+    }
+}

--- a/tools/cnf-runner/src/model/capability.rs
+++ b/tools/cnf-runner/src/model/capability.rs
@@ -1,0 +1,90 @@
+//! The machine-readable capability→family→tier matrix
+//! (`vocab/capability_matrix.yaml`) — the Profiles book's capability×tier
+//! tables as data, the input the verdict machinery computes from.
+
+use serde::Deserialize;
+
+use crate::ids::CapabilityName;
+use crate::vocab::{Family, Tier};
+
+/// One matrix row.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CapabilityEntry {
+    pub family: Family,
+    /// Family-scoped tier; `tier.family()` must equal `family` (checked).
+    pub tier: Tier,
+    /// Whether the capability is required for its tier's profile verdict.
+    pub required: bool,
+    /// The Profiles-book (or proposal) anchor for the row.
+    #[serde(default)]
+    pub source: Option<String>,
+}
+
+/// The whole matrix, keyed by capability name, authored order preserved.
+#[derive(Debug, Clone)]
+pub struct CapabilityMatrix {
+    entries: Vec<(CapabilityName, CapabilityEntry)>,
+}
+
+impl CapabilityMatrix {
+    /// Look up a capability.
+    #[must_use]
+    pub fn get(&self, name: &CapabilityName) -> Option<&CapabilityEntry> {
+        self.entries.iter().find(|(n, _)| n == name).map(|(_, e)| e)
+    }
+
+    /// All rows in authored order.
+    #[must_use]
+    pub fn entries(&self) -> &[(CapabilityName, CapabilityEntry)] {
+        &self.entries
+    }
+
+    /// Family-scoping invariant: every row's tier belongs to its family.
+    ///
+    /// # Errors
+    /// Returns the offending capability names.
+    pub fn check_tier_scoping(&self) -> Result<(), Vec<String>> {
+        let bad: Vec<String> = self
+            .entries
+            .iter()
+            .filter(|(_, e)| e.tier.family() != e.family)
+            .map(|(n, e)| {
+                format!(
+                    "{n}: tier {:?} is not scoped to family {:?}",
+                    e.tier, e.family
+                )
+            })
+            .collect();
+        if bad.is_empty() { Ok(()) } else { Err(bad) }
+    }
+}
+
+impl<'de> Deserialize<'de> for CapabilityMatrix {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let entries = crate::model::de::ordered_map(deserializer)?;
+        Ok(Self { entries })
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)] // test assertions/fixtures
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tier_scoping_is_enforced() {
+        let m: CapabilityMatrix = serde_json::from_value(serde_json::json!({
+            "EhrOperations": { "family": "Platform", "tier": "CORE", "required": true },
+            "Signing": { "family": "Platform", "tier": "STANDARD", "required": false }
+        }))
+        .unwrap();
+        assert!(m.check_tier_scoping().is_ok());
+
+        let m: CapabilityMatrix = serde_json::from_value(serde_json::json!({
+            "AuditAccountability": { "family": "Platform", "tier": "SEC-BASIC", "required": true }
+        }))
+        .unwrap();
+        assert!(m.check_tier_scoping().is_err());
+    }
+}

--- a/tools/cnf-runner/src/model/case.rs
+++ b/tools/cnf-runner/src/model/case.rs
@@ -1,0 +1,480 @@
+//! The case core — one file per case, protocol-neutral
+//! (CNF 2.0 artifact-set design; shapes extracted from
+//! `CNF platform_test_schedule master03/04/06/07/08/09/15–17`).
+
+use serde::de::Error as DeError;
+use serde::{Deserialize, Deserializer};
+
+use crate::ids::{
+    AmbiguityId, CapabilityName, CaptureName, CaseId, CorpusKey, InstanceName, OptionTag,
+    SmOperationRef,
+};
+use crate::model::assertion::Assertion;
+use crate::model::value::TemplatedValue;
+use crate::refgrammar::CaptureValueSource;
+use crate::vocab::{
+    CaseKind, CaseStatus, Component, FormatName, Iteration, OutcomeKind, ServerState,
+    SpecComponent, Tier,
+};
+
+/// Spec-version applicability ranges (`applies:`); the range grammar is the
+/// Cargo/semver requirement syntax.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Applies {
+    #[serde(default)]
+    pub rm: Option<VersionRange>,
+    #[serde(default)]
+    pub base: Option<VersionRange>,
+    #[serde(default)]
+    pub am: Option<VersionRange>,
+    #[serde(default)]
+    pub aql: Option<VersionRange>,
+    #[serde(default)]
+    pub its_rest: Option<VersionRange>,
+    #[serde(default)]
+    pub term: Option<VersionRange>,
+}
+
+impl Applies {
+    /// The declared (component, range) pairs.
+    #[must_use]
+    pub fn entries(&self) -> Vec<(SpecComponent, &VersionRange)> {
+        [
+            (SpecComponent::Rm, &self.rm),
+            (SpecComponent::Base, &self.base),
+            (SpecComponent::Am, &self.am),
+            (SpecComponent::Aql, &self.aql),
+            (SpecComponent::ItsRest, &self.its_rest),
+            (SpecComponent::Term, &self.term),
+        ]
+        .into_iter()
+        .filter_map(|(c, r)| r.as_ref().map(|r| (c, r)))
+        .collect()
+    }
+}
+
+/// A semver requirement, validated at parse.
+#[derive(Debug, Clone)]
+pub struct VersionRange {
+    raw: String,
+    req: semver::VersionReq,
+}
+
+impl VersionRange {
+    /// The authored requirement text.
+    #[must_use]
+    pub fn raw(&self) -> &str {
+        &self.raw
+    }
+
+    /// The parsed requirement.
+    #[must_use]
+    pub fn req(&self) -> &semver::VersionReq {
+        &self.req
+    }
+}
+
+impl<'de> Deserialize<'de> for VersionRange {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = String::deserialize(deserializer)?;
+        let req = semver::VersionReq::parse(&raw)
+            .map_err(|e| D::Error::custom(format!("applies range {raw:?}: {e}")))?;
+        Ok(Self { raw, req })
+    }
+}
+
+/// The `requires.ehr` precondition.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EhrRequirement {
+    /// No EHR is provisioned.
+    None,
+    /// An EHR exists (mints `${ehr_id}`), with the stated commit state.
+    Exists { commits: CommitState },
+}
+
+/// Commit-state qualifier of a provisioned EHR.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CommitState {
+    None,
+    Any,
+}
+
+impl<'de> Deserialize<'de> for EhrRequirement {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Qualified {
+            commits: CommitState,
+        }
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Raw {
+            Word(String),
+            Qualified(Qualified),
+        }
+        match Raw::deserialize(deserializer)? {
+            Raw::Word(w) if w == "none" => Ok(Self::None),
+            Raw::Word(w) => Err(D::Error::custom(format!(
+                "requires.ehr must be `none` or {{ commits: none | any }}, got {w:?}"
+            ))),
+            Raw::Qualified(q) => Ok(Self::Exists { commits: q.commits }),
+        }
+    }
+}
+
+/// The `requires.directory` precondition.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DirectoryRequirement {
+    None,
+    /// A FOLDER tree provisioned in the EHR from the named corpus set.
+    Tree(CorpusKey),
+}
+
+impl<'de> Deserialize<'de> for DirectoryRequirement {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        if s == "none" {
+            return Ok(Self::None);
+        }
+        CorpusKey::parse(&s)
+            .map(Self::Tree)
+            .map_err(D::Error::custom)
+    }
+}
+
+/// Typed prerequisites — the schedule's precondition vocabulary. Every
+/// provisioned object mints a named handle usable as a flow variable.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Requires {
+    /// "The server should be empty (no EHRs, no commits, no OPTs)".
+    #[serde(default)]
+    pub server: Option<ServerState>,
+    /// Corpus template keys provisioned before the flow.
+    #[serde(default)]
+    pub templates: Vec<CorpusKey>,
+    /// EHR provisioning; `Exists` mints `${ehr_id}`.
+    #[serde(default)]
+    pub ehr: Option<EhrRequirement>,
+    /// A FOLDER tree provisioned in the EHR (master09).
+    #[serde(default)]
+    pub directory: Option<DirectoryRequirement>,
+    /// Corpus set keys pre-committed into the EHR by the runner (bulk setup
+    /// is precondition state, never an un-anchored flow call).
+    #[serde(default)]
+    pub commit: Vec<CorpusKey>,
+    /// Multi-instance cases state `requires` per named instance.
+    #[serde(default)]
+    pub instances: Option<std::collections::BTreeMap<InstanceName, Requires>>,
+}
+
+impl Requires {
+    /// The capture handles this block mints (`ehr_id` when an EHR is
+    /// provisioned).
+    #[must_use]
+    pub fn minted_handles(&self) -> Vec<CaptureName> {
+        let mut handles = Vec::new();
+        if matches!(self.ehr, Some(EhrRequirement::Exists { .. }))
+            && let Ok(handle) = CaptureName::parse("ehr_id")
+        {
+            handles.push(handle);
+        }
+        handles
+    }
+}
+
+/// A parameter-matrix cell: a reserved sentinel or a literal.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MatrixCell {
+    /// Omit the field entirely.
+    Absent,
+    /// Synthesize a valid value via the case's recipe.
+    Provided,
+    /// JSON null.
+    Null,
+    /// A literal value (strings validated as templates elsewhere; sentinel
+    /// words are reserved and never literals).
+    Literal(serde_json::Value),
+}
+
+impl<'de> Deserialize<'de> for MatrixCell {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        Ok(match &value {
+            serde_json::Value::Null => Self::Null,
+            serde_json::Value::String(s) if s == "absent" => Self::Absent,
+            serde_json::Value::String(s) if s == "provided" => Self::Provided,
+            _ => Self::Literal(value),
+        })
+    }
+}
+
+/// The inline value matrix (master06-style).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Matrix {
+    pub columns: Vec<String>,
+    /// Inline rows; each row binds `${row.<column>}`.
+    #[serde(default)]
+    pub rows: Vec<Vec<MatrixCell>>,
+    /// Optional bulk-row external table for large GENERATED matrices
+    /// (produced by a corpus recipe, never hand-edited).
+    #[serde(default)]
+    pub rows_from: Option<String>,
+}
+
+/// One fixture-set entry (master04-style external-fixture iteration).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FixtureEntry {
+    pub data_set: CorpusKey,
+    pub expected: OutcomeKind,
+    #[serde(default)]
+    pub defect: Option<String>,
+    #[serde(default)]
+    pub spec_ref: Option<String>,
+}
+
+/// The data-set dimension: one mechanism serves the functional matrices and
+/// the fixture sets. A "test" = one case × one data set
+/// (`CNF platform_test_schedule master03-overview.adoc`).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Parameters {
+    pub iteration: Iteration,
+    #[serde(default)]
+    pub matrix: Option<Matrix>,
+    #[serde(default)]
+    pub fixture_set: Option<Vec<FixtureEntry>>,
+}
+
+/// The step expectation: exactly one outcome kind, or the per-fixture
+/// override `${fixture.expected}`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExpectSpec {
+    Kind(OutcomeKind),
+    /// `${fixture.expected}` — resolved per fixture-set row.
+    FixtureExpected,
+}
+
+impl<'de> Deserialize<'de> for ExpectSpec {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        if s == "${fixture.expected}" {
+            return Ok(Self::FixtureExpected);
+        }
+        OutcomeKind::from_token(&s).map(Self::Kind).ok_or_else(|| {
+            D::Error::custom(format!(
+                "expect must be an outcome kind or ${{fixture.expected}}, got {s:?}"
+            ))
+        })
+    }
+}
+
+/// One ordered flow step.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FlowStep {
+    pub step: u32,
+    /// SM operation: short form resolves against `sm_operation`'s interface;
+    /// a full `I_X.y` form addresses another interface.
+    pub call: String,
+    /// Instance selector (default `sut`); Enterprise dual-instance cases
+    /// address ixit-declared instances.
+    #[serde(default)]
+    pub on: Option<InstanceName>,
+    /// Substep variant tag (the schedule's `1.1`, `3.2` iteration sources).
+    #[serde(default)]
+    pub variant: Option<String>,
+    /// Per-step format role (intrinsic-format cases only).
+    #[serde(default)]
+    pub format: Option<FormatName>,
+    #[serde(default, deserialize_with = "crate::model::de::optional_ordered_map")]
+    pub with: Option<Vec<(String, TemplatedValue)>>,
+    pub expect: ExpectSpec,
+    /// Logical captures; bindings map them to wire locations.
+    #[serde(default, deserialize_with = "crate::model::de::optional_ordered_map")]
+    pub capture: Option<Vec<(CaptureName, CaptureValueSource)>>,
+    /// Post-step typed assertions.
+    #[serde(default, rename = "assert")]
+    pub assertions: Vec<Assertion>,
+}
+
+/// The content decision-table context (the OPT carrying the constraint under
+/// test + the constrained node path).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConstraintContext {
+    pub template: CorpusKey,
+    pub path: String,
+}
+
+/// A content decision table (master15–17 shape). Each row is one committed
+/// instance + `expected: accepted | rejected` + `violates: […]`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DecisionTable {
+    pub columns: Vec<String>,
+    pub rows: Vec<Vec<serde_json::Value>>,
+}
+
+/// A content row verdict.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RowVerdict {
+    Accepted,
+    Rejected,
+}
+
+/// One case file — the Abstract Test Suite unit.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CaseCore {
+    pub id: CaseId,
+    pub kind: CaseKind,
+    #[serde(default)]
+    pub status: CaseStatus,
+    pub component: Component,
+    /// Functional cases: the SM anchor.
+    #[serde(default)]
+    pub sm_operation: Option<SmOperationRef>,
+    /// Content cases: the RM/AM class under test.
+    #[serde(default)]
+    pub rm_class: Option<String>,
+    /// The ISO/IEC 9646 test purpose — one narrow conformance requirement.
+    pub test_purpose: String,
+    /// The schedule's Description row.
+    pub description: String,
+    /// Citations (component + document + section); link-checked.
+    pub spec_refs: Vec<String>,
+    #[serde(default)]
+    pub applies: Applies,
+    /// Non-version run conditions, each spec-cited; a failed guard ⇒
+    /// `not-applicable` with citation.
+    #[serde(default)]
+    pub guards: Vec<String>,
+    /// The verdict-bearing capability names — kept MINIMAL (a case failure
+    /// marks every listed capability Failed).
+    #[serde(default)]
+    pub capabilities: Vec<CapabilityName>,
+    /// Informative coverage tags.
+    #[serde(default)]
+    pub exercises: Vec<CapabilityName>,
+    /// Profile tier(s) — derivable from the capability matrix, carried for
+    /// readability; consistency is CI-checked.
+    #[serde(default)]
+    pub profiles: Vec<Tier>,
+    /// For sibling cases realizing an ambiguity-register implementation
+    /// choice: the option tag the ICS `options` declaration selects.
+    #[serde(default)]
+    pub option: Option<OptionTag>,
+    /// Case-level format axis (cases parameterized over format).
+    #[serde(default)]
+    pub formats: Vec<FormatName>,
+    #[serde(default)]
+    pub requires: Requires,
+    #[serde(default)]
+    pub parameters: Option<Parameters>,
+    /// Ordered steps (functional cases).
+    #[serde(default)]
+    pub flow: Vec<FlowStep>,
+    /// Content cases: the constraint context + decision table.
+    #[serde(default)]
+    pub constraint_context: Option<ConstraintContext>,
+    #[serde(default)]
+    pub decision_table: Option<DecisionTable>,
+    /// Typed postconditions; default evaluation per parameter row,
+    /// `aggregate: true` once after all rows.
+    #[serde(default)]
+    pub postconditions: Vec<Assertion>,
+    /// Cases verifying this case's deeper postconditions through separate
+    /// reads (the master06 create→get pattern).
+    #[serde(default)]
+    pub verified_by: Vec<CaseId>,
+    /// Ambiguity-register entries this case is subject to.
+    #[serde(default)]
+    pub ambiguities: Vec<AmbiguityId>,
+    /// Corpus manifest keys used (in addition to `parameters`).
+    #[serde(default)]
+    pub data_sets: Vec<CorpusKey>,
+}
+
+// Custom deserialization for `with`/`capture` map fields preserving order:
+// YAML mappings arrive as JSON objects; serde_json's preserve_order keeps
+// authored order, and Vec<(K, V)> makes that explicit in the type.
+impl FlowStep {
+    /// The step's capture entries (empty when none).
+    #[must_use]
+    pub fn captures(&self) -> &[(CaptureName, CaptureValueSource)] {
+        self.capture.as_deref().unwrap_or_default()
+    }
+
+    /// The step's `with` entries (empty when none).
+    #[must_use]
+    pub fn with_entries(&self) -> &[(String, TemplatedValue)] {
+        self.with.as_deref().unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn requires_parses_the_schedule_vocabulary() {
+        let r: Requires = serde_json::from_value(serde_json::json!({
+            "server": "any",
+            "templates": ["cnf.opt.minimal_event"],
+            "ehr": { "commits": "none" },
+            "commit": ["cnf.set.bp-10"]
+        }))
+        .unwrap();
+        assert_eq!(r.server, Some(ServerState::Any));
+        assert!(matches!(
+            r.ehr,
+            Some(EhrRequirement::Exists {
+                commits: CommitState::None
+            })
+        ));
+        assert_eq!(r.minted_handles().len(), 1);
+
+        let r: Requires = serde_json::from_value(serde_json::json!({ "ehr": "none" })).unwrap();
+        assert!(matches!(r.ehr, Some(EhrRequirement::None)));
+        assert!(r.minted_handles().is_empty());
+
+        assert!(serde_json::from_value::<Requires>(serde_json::json!({ "ehr": "maybe" })).is_err());
+        assert!(serde_json::from_value::<Requires>(serde_json::json!({ "srv": "empty" })).is_err());
+    }
+
+    #[test]
+    fn matrix_cells_distinguish_sentinels() {
+        let m: Matrix = serde_json::from_value(serde_json::json!({
+            "columns": ["ehr_status", "is_queryable"],
+            "rows": [["absent", "-"], ["provided", true], [null, 1.5]]
+        }))
+        .unwrap();
+        assert!(matches!(m.rows[0][0], MatrixCell::Absent));
+        assert!(matches!(m.rows[0][1], MatrixCell::Literal(_)));
+        assert!(matches!(m.rows[1][0], MatrixCell::Provided));
+        assert!(matches!(
+            m.rows[1][1],
+            MatrixCell::Literal(serde_json::Value::Bool(true))
+        ));
+        assert!(matches!(m.rows[2][0], MatrixCell::Null));
+    }
+
+    #[test]
+    fn expect_spec_is_closed() {
+        assert!(matches!(
+            serde_json::from_value::<ExpectSpec>(serde_json::json!("created")).unwrap(),
+            ExpectSpec::Kind(OutcomeKind::Created)
+        ));
+        assert!(matches!(
+            serde_json::from_value::<ExpectSpec>(serde_json::json!("${fixture.expected}")).unwrap(),
+            ExpectSpec::FixtureExpected
+        ));
+        assert!(serde_json::from_value::<ExpectSpec>(serde_json::json!("http_201")).is_err());
+    }
+}

--- a/tools/cnf-runner/src/model/corpus.rs
+++ b/tools/cnf-runner/src/model/corpus.rs
@@ -1,0 +1,183 @@
+//! The governed corpus manifest (`corpus/MANIFEST.yaml`).
+//!
+//! Every fixture and generated set is a manifest entry: verdict + defect
+//! live in the manifest (never only in a filename), generated sets are
+//! committed seeded deterministic recipes, and adjudication happens in a
+//! register, never by silent edits.
+
+use serde::Deserialize;
+
+use crate::ids::{CorpusKey, RecipeName, ViewName};
+use crate::vocab::{CorpusFormat, FixtureVerdict, PlaceholderPolicy};
+
+/// The adjudicated validity of a fixture.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Validity {
+    pub verdict: FixtureVerdict,
+    /// Mandatory for invalid fixtures: why the payload is invalid.
+    #[serde(default)]
+    pub defect: Option<String>,
+    /// Mandatory for invalid fixtures: the violated spec rule.
+    #[serde(default)]
+    pub spec_ref: Option<String>,
+}
+
+/// A named declarative projection over the set, referenced as
+/// `${ds:<key>#<view>}` — evaluated over the corpus data,
+/// runner-independent.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ViewDecl {
+    /// Path expression over the set.
+    pub select: String,
+    #[serde(default, rename = "where")]
+    pub where_clause: Option<String>,
+    #[serde(default)]
+    pub order_by: Option<String>,
+}
+
+/// A named row-to-instance synthesis recipe: name + content digest so any
+/// runner can verify it executes the same recipe version.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RecipeDecl {
+    /// Content digest of the committed recipe implementation.
+    pub digest: String,
+}
+
+/// A generated set's producing recipe.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GeneratedBy {
+    pub recipe: RecipeName,
+    /// Content digest of the generator.
+    pub digest: String,
+}
+
+/// One corpus manifest entry.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CorpusEntry {
+    /// Fixture file path, relative to the manifest (static fixtures).
+    #[serde(default)]
+    pub source: Option<String>,
+    /// The committed, seeded, deterministic generator (generated sets).
+    #[serde(default)]
+    pub generated_by: Option<GeneratedBy>,
+    pub format: CorpusFormat,
+    #[serde(default)]
+    pub rm_versions: Vec<String>,
+    pub validity: Validity,
+    /// The `__AUTO-GENERATED__` convention, formalized.
+    #[serde(default, deserialize_with = "crate::model::de::optional_ordered_map")]
+    pub placeholders: Option<Vec<(String, PlaceholderPolicy)>>,
+    /// Where the payload came from and how it was re-adjudicated.
+    pub provenance: String,
+    #[serde(default, deserialize_with = "crate::model::de::optional_ordered_map")]
+    pub views: Option<Vec<(ViewName, ViewDecl)>>,
+    #[serde(default, deserialize_with = "crate::model::de::optional_ordered_map")]
+    pub recipes: Option<Vec<(RecipeName, RecipeDecl)>>,
+}
+
+impl CorpusEntry {
+    /// Entry-level invariants: exactly one payload origin; invalid fixtures
+    /// carry defect + `spec_ref`.
+    ///
+    /// # Errors
+    /// Returns a message naming the violated invariant.
+    pub fn check_invariants(&self) -> Result<(), String> {
+        match (&self.source, &self.generated_by) {
+            (Some(_), Some(_)) => {
+                return Err("entry declares both source and generated_by".to_owned());
+            }
+            (None, None) => {
+                return Err("entry declares neither source nor generated_by".to_owned());
+            }
+            _ => {}
+        }
+        if self.validity.verdict == FixtureVerdict::Invalid
+            && (self.validity.defect.is_none() || self.validity.spec_ref.is_none())
+        {
+            return Err(
+                "invalid fixture must carry validity.defect and validity.spec_ref".to_owned(),
+            );
+        }
+        Ok(())
+    }
+
+    /// A named view, if declared.
+    #[must_use]
+    pub fn view(&self, name: &ViewName) -> Option<&ViewDecl> {
+        self.views
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .find(|(n, _)| n == name)
+            .map(|(_, v)| v)
+    }
+}
+
+/// The whole manifest, keyed by corpus key.
+#[derive(Debug, Clone)]
+pub struct CorpusManifest {
+    entries: Vec<(CorpusKey, CorpusEntry)>,
+}
+
+impl CorpusManifest {
+    /// Look up an entry.
+    #[must_use]
+    pub fn get(&self, key: &CorpusKey) -> Option<&CorpusEntry> {
+        self.entries.iter().find(|(k, _)| k == key).map(|(_, e)| e)
+    }
+
+    /// All entries in authored order.
+    #[must_use]
+    pub fn entries(&self) -> &[(CorpusKey, CorpusEntry)] {
+        &self.entries
+    }
+}
+
+impl<'de> Deserialize<'de> for CorpusManifest {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let entries = crate::model::de::ordered_map(deserializer)?;
+        Ok(Self { entries })
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)] // test assertions/fixtures
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entry_invariants() {
+        let e: CorpusEntry = serde_json::from_value(serde_json::json!({
+            "source": "fixtures/ehr/invalid/007.json",
+            "format": "canonical-json",
+            "validity": { "verdict": "invalid",
+                          "defect": "RM/Schema: is_modifiable is mandatory",
+                          "spec_ref": "RM ehr §EHR_STATUS" },
+            "provenance": "openEHR CNF Robot corpus @33251d2a; re-adjudicated 2026-07-21"
+        }))
+        .unwrap();
+        assert!(e.check_invariants().is_ok());
+
+        let e: CorpusEntry = serde_json::from_value(serde_json::json!({
+            "source": "x.json",
+            "format": "canonical-json",
+            "validity": { "verdict": "invalid" },
+            "provenance": "p"
+        }))
+        .unwrap();
+        assert!(e.check_invariants().is_err()); // invalid without defect/spec_ref
+
+        let e: CorpusEntry = serde_json::from_value(serde_json::json!({
+            "format": "canonical-json",
+            "validity": { "verdict": "valid" },
+            "provenance": "p"
+        }))
+        .unwrap();
+        assert!(e.check_invariants().is_err()); // no origin
+    }
+}

--- a/tools/cnf-runner/src/model/de.rs
+++ b/tools/cnf-runner/src/model/de.rs
@@ -1,0 +1,79 @@
+//! Serde helpers: ordered maps as `Vec<(K, V)>` (authored key order is part
+//! of an artifact's meaning — flow `with:` payload order, capture order —
+//! and `serde_json`'s `preserve_order` feature carries it through the YAML
+//! front-end).
+
+use std::fmt;
+use std::marker::PhantomData;
+use std::str::FromStr;
+
+use serde::de::{DeserializeOwned, Error as DeError, MapAccess, Visitor};
+use serde::{Deserialize, Deserializer};
+
+/// Deserialize a mapping into `Vec<(K, V)>`, rejecting duplicate keys.
+///
+/// # Errors
+/// Fails on a non-mapping value, an unparsable key, or a duplicate key.
+pub(crate) fn ordered_map<'de, D, K, V>(deserializer: D) -> Result<Vec<(K, V)>, D::Error>
+where
+    D: Deserializer<'de>,
+    K: FromStr + PartialEq + fmt::Display,
+    K::Err: fmt::Display,
+    V: DeserializeOwned,
+{
+    struct MapVisitor<K, V>(PhantomData<(K, V)>);
+
+    impl<'de, K, V> Visitor<'de> for MapVisitor<K, V>
+    where
+        K: FromStr + PartialEq + fmt::Display,
+        K::Err: fmt::Display,
+        V: DeserializeOwned,
+    {
+        type Value = Vec<(K, V)>;
+
+        fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("a mapping")
+        }
+
+        fn visit_map<A: MapAccess<'de>>(self, mut access: A) -> Result<Self::Value, A::Error> {
+            let mut entries: Vec<(K, V)> = Vec::new();
+            while let Some((key, value)) = access.next_entry::<String, V>()? {
+                let key = K::from_str(&key).map_err(A::Error::custom)?;
+                if entries.iter().any(|(k, _)| *k == key) {
+                    return Err(A::Error::custom(format!("duplicate key {key}")));
+                }
+                entries.push((key, value));
+            }
+            Ok(entries)
+        }
+    }
+
+    deserializer.deserialize_map(MapVisitor(PhantomData))
+}
+
+/// [`ordered_map`] wrapped in `Option` for optional mapping fields.
+///
+/// # Errors
+/// As [`ordered_map`].
+pub(crate) fn optional_ordered_map<'de, D, K, V>(
+    deserializer: D,
+) -> Result<Option<Vec<(K, V)>>, D::Error>
+where
+    D: Deserializer<'de>,
+    K: FromStr + PartialEq + fmt::Display,
+    K::Err: fmt::Display,
+    V: DeserializeOwned,
+{
+    struct Wrapper<K, V>(Vec<(K, V)>);
+    impl<'de, K, V> Deserialize<'de> for Wrapper<K, V>
+    where
+        K: FromStr + PartialEq + fmt::Display,
+        K::Err: fmt::Display,
+        V: DeserializeOwned,
+    {
+        fn deserialize<D2: Deserializer<'de>>(deserializer: D2) -> Result<Self, D2::Error> {
+            ordered_map(deserializer).map(Wrapper)
+        }
+    }
+    Ok(Option::<Wrapper<K, V>>::deserialize(deserializer)?.map(|w| w.0))
+}

--- a/tools/cnf-runner/src/model/mod.rs
+++ b/tools/cnf-runner/src/model/mod.rs
@@ -1,0 +1,11 @@
+//! The typed artifact model — one module per artifact family.
+
+pub mod assertion;
+pub mod binding;
+pub mod capability;
+pub mod case;
+pub mod corpus;
+pub(crate) mod de;
+pub mod register;
+pub mod value;
+pub mod vocab_files;

--- a/tools/cnf-runner/src/model/register.rs
+++ b/tools/cnf-runner/src/model/register.rs
@@ -1,0 +1,111 @@
+//! The ambiguity register (`registers/ambiguities.yaml`) — every entry a
+//! real, verified spec divergence or silence with the normative handling a
+//! runner must apply. The register is normative: a runner that "resolves"
+//! an ambiguity privately is non-conformant to the schedule.
+
+use serde::Deserialize;
+
+use crate::ids::{AmbiguityId, OptionTag};
+use crate::vocab::Disposition;
+
+/// One register entry.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AmbiguityEntry {
+    /// The divergence/silence, with its source citation.
+    pub ambiguity: String,
+    /// Where it was verified (spec file/section).
+    pub source: String,
+    /// The normative handling a runner must apply.
+    pub handling: String,
+    /// The machine-readable branch the pipeline takes.
+    pub disposition: Disposition,
+    /// For `option_select` entries: the option tags the sibling cases carry
+    /// (the ICS `options` declaration selects among them).
+    #[serde(default)]
+    pub options: Vec<OptionTag>,
+}
+
+impl AmbiguityEntry {
+    /// Disposition-shape invariant: `option_select` entries enumerate ≥ 2
+    /// option tags; other dispositions carry none.
+    ///
+    /// # Errors
+    /// Returns a message naming the violated invariant.
+    pub fn check_invariants(&self) -> Result<(), String> {
+        match self.disposition {
+            Disposition::OptionSelect if self.options.len() < 2 => {
+                Err("option_select entry must enumerate at least two option tags".to_owned())
+            }
+            Disposition::OptionSelect => Ok(()),
+            _ if !self.options.is_empty() => Err(format!(
+                "disposition {:?} carries option tags (only option_select may)",
+                self.disposition
+            )),
+            _ => Ok(()),
+        }
+    }
+}
+
+/// The whole register, keyed by `AMB-<n>`.
+#[derive(Debug, Clone)]
+pub struct AmbiguityRegister {
+    entries: Vec<(AmbiguityId, AmbiguityEntry)>,
+}
+
+impl AmbiguityRegister {
+    /// Look up an entry.
+    #[must_use]
+    pub fn get(&self, id: &AmbiguityId) -> Option<&AmbiguityEntry> {
+        self.entries.iter().find(|(k, _)| k == id).map(|(_, e)| e)
+    }
+
+    /// All entries in authored order.
+    #[must_use]
+    pub fn entries(&self) -> &[(AmbiguityId, AmbiguityEntry)] {
+        &self.entries
+    }
+
+    /// Whether any entry declares the option tag.
+    #[must_use]
+    pub fn declares_option(&self, tag: &OptionTag) -> bool {
+        self.entries.iter().any(|(_, e)| e.options.contains(tag))
+    }
+}
+
+impl<'de> Deserialize<'de> for AmbiguityRegister {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let entries = crate::model::de::ordered_map(deserializer)?;
+        Ok(Self { entries })
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)] // test assertions/fixtures
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disposition_shapes() {
+        let r: AmbiguityRegister = serde_json::from_value(serde_json::json!({
+            "AMB-4": {
+                "ambiguity": "ADL 1.4 templates have no formal versioning — duplicate template_id handling is implementation-defined",
+                "source": "CNF platform_test_schedule master04 NOTE",
+                "handling": "sibling cases carry option tags; the ICS options declaration selects",
+                "disposition": "option_select",
+                "options": ["adl14-duplicate-conflict", "adl14-duplicate-versioned"]
+            }
+        }))
+        .unwrap();
+        let (_, entry) = &r.entries()[0];
+        assert!(entry.check_invariants().is_ok());
+        assert!(r.declares_option(&OptionTag::parse("adl14-duplicate-conflict").unwrap()));
+
+        let e: AmbiguityEntry = serde_json::from_value(serde_json::json!({
+            "ambiguity": "x", "source": "s", "handling": "h",
+            "disposition": "report_only", "options": ["stray"]
+        }))
+        .unwrap();
+        assert!(e.check_invariants().is_err());
+    }
+}

--- a/tools/cnf-runner/src/model/value.rs
+++ b/tools/cnf-runner/src/model/value.rs
@@ -1,0 +1,102 @@
+//! Templated values — the payload shapes of `flow[].with` and assertion
+//! operands.
+//!
+//! A value tree is JSON-shaped; every string in it is parsed as a
+//! [`Template`], so an illegal `${…}` reference anywhere in a case is a
+//! load-time error (the reference/sentinel grammar check of the schedule's
+//! CI gate list).
+
+use serde::de::Error as DeError;
+use serde::{Deserialize, Deserializer};
+
+use crate::refgrammar::{RefError, Template, ValueRef};
+
+/// A JSON-shaped value whose strings are reference templates.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TemplatedValue {
+    Null,
+    Bool(bool),
+    Number(serde_json::Number),
+    Text(Template),
+    Seq(Vec<TemplatedValue>),
+    /// Key order preserved as authored.
+    Map(Vec<(String, TemplatedValue)>),
+}
+
+impl TemplatedValue {
+    /// Convert from a parsed JSON value, validating every embedded string.
+    ///
+    /// # Errors
+    /// Returns [`RefError`] for any illegal `${…}` reference.
+    pub fn from_value(value: &serde_json::Value) -> Result<Self, RefError> {
+        Ok(match value {
+            serde_json::Value::Null => Self::Null,
+            serde_json::Value::Bool(b) => Self::Bool(*b),
+            serde_json::Value::Number(n) => Self::Number(n.clone()),
+            serde_json::Value::String(s) => Self::Text(Template::parse(s)?),
+            serde_json::Value::Array(items) => Self::Seq(
+                items
+                    .iter()
+                    .map(Self::from_value)
+                    .collect::<Result<_, _>>()?,
+            ),
+            serde_json::Value::Object(map) => Self::Map(
+                map.iter()
+                    .map(|(k, v)| Ok((k.clone(), Self::from_value(v)?)))
+                    .collect::<Result<_, RefError>>()?,
+            ),
+        })
+    }
+
+    /// Every reference anywhere in the tree.
+    #[must_use]
+    pub fn refs(&self) -> Vec<&ValueRef> {
+        let mut out = Vec::new();
+        self.collect_refs(&mut out);
+        out
+    }
+
+    fn collect_refs<'a>(&'a self, out: &mut Vec<&'a ValueRef>) {
+        match self {
+            Self::Text(t) => out.extend(t.refs()),
+            Self::Seq(items) => {
+                for item in items {
+                    item.collect_refs(out);
+                }
+            }
+            Self::Map(entries) => {
+                for (_, v) in entries {
+                    v.collect_refs(out);
+                }
+            }
+            Self::Null | Self::Bool(_) | Self::Number(_) => {}
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for TemplatedValue {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        Self::from_value(&value).map_err(D::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strings_validate_everywhere() {
+        let ok = serde_json::json!({
+            "versions": [
+                { "data": "${ds:cnf.composition.minimal_event.v1}", "change_type": "creation" },
+                { "data": "${ds:cnf.composition.minimal_event.v2}", "preceding_version_uid": "${v1}" }
+            ]
+        });
+        let v = TemplatedValue::from_value(&ok).unwrap();
+        assert_eq!(v.refs().len(), 3);
+
+        let bad = serde_json::json!({ "nested": [{ "x": "${step2.body}" }] });
+        assert!(TemplatedValue::from_value(&bad).is_err());
+    }
+}

--- a/tools/cnf-runner/src/model/vocab_files.rs
+++ b/tools/cnf-runner/src/model/vocab_files.rs
@@ -1,0 +1,238 @@
+//! The published vocabulary artifacts (`vocab/outcomes.yaml`,
+//! `vocab/selectors.yaml`).
+//!
+//! The Rust enums in [`crate::vocab`] are the compiled form; these files are
+//! the published normative form. The validator holds them equal in both
+//! directions (a kind in the file the enum lacks, or vice versa, is an
+//! error) so the artifact and the reference implementation cannot drift.
+
+use serde::Deserialize;
+
+use crate::vocab::{IgnoreSetName, OutcomeKind};
+
+/// One published outcome-kind row.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OutcomeRow {
+    /// `success` | `error`.
+    pub class: OutcomeClassToken,
+    /// The schedule language for the kind.
+    pub meaning: String,
+}
+
+/// The published class token.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OutcomeClassToken {
+    Success,
+    Error,
+}
+
+/// `vocab/outcomes.yaml` — kind token → row.
+#[derive(Debug, Clone)]
+pub struct OutcomesVocab {
+    entries: Vec<(String, OutcomeRow)>,
+}
+
+impl OutcomesVocab {
+    /// All entries in authored order.
+    #[must_use]
+    pub fn entries(&self) -> &[(String, OutcomeRow)] {
+        &self.entries
+    }
+
+    /// Two-way equality with the compiled enum, including class agreement.
+    ///
+    /// # Errors
+    /// Returns every drift found.
+    pub fn check_against_enum(&self) -> Result<(), Vec<String>> {
+        let mut findings = Vec::new();
+        for (token, row) in &self.entries {
+            match OutcomeKind::from_token(token) {
+                None => findings.push(format!("outcomes.yaml lists unknown kind {token:?}")),
+                Some(kind) => {
+                    let enum_class = matches!(kind.class(), crate::vocab::OutcomeClass::Success);
+                    let file_class = row.class == OutcomeClassToken::Success;
+                    if enum_class != file_class {
+                        findings.push(format!(
+                            "outcomes.yaml class for {token:?} disagrees with the compiled taxonomy"
+                        ));
+                    }
+                }
+            }
+        }
+        for kind in OutcomeKind::ALL {
+            if !self.entries.iter().any(|(t, _)| t == kind.token()) {
+                findings.push(format!("outcomes.yaml is missing kind {:?}", kind.token()));
+            }
+        }
+        if findings.is_empty() {
+            Ok(())
+        } else {
+            Err(findings)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for OutcomesVocab {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let entries = crate::model::de::ordered_map(deserializer)?;
+        Ok(Self { entries })
+    }
+}
+
+/// A named ignore-set declaration in `vocab/selectors.yaml`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct IgnoreSetDecl {
+    /// Enumerated paths (the `ctx_defaults` set); absent for per-binding
+    /// sets.
+    #[serde(default)]
+    pub paths: Vec<String>,
+    /// True when membership is enumerated per operation binding
+    /// (`server_assigned`).
+    #[serde(default)]
+    pub per_binding: bool,
+    /// Citation for the set's normative source.
+    pub source: String,
+}
+
+/// `vocab/selectors.yaml` — the published selector/matcher vocabularies +
+/// the named ignore-set registry.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SelectorsVocab {
+    /// The body-selector tokens (must equal the compiled enum).
+    pub body_selectors: Vec<String>,
+    /// The header-matcher forms (must equal the compiled vocabulary).
+    pub header_matchers: Vec<String>,
+    /// The named ignore-sets.
+    #[serde(deserialize_with = "crate::model::de::ordered_map")]
+    pub ignore_sets: Vec<(IgnoreSetKey, IgnoreSetDecl)>,
+}
+
+/// Key newtype for the ignore-set map.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IgnoreSetKey(pub IgnoreSetName);
+
+impl std::str::FromStr for IgnoreSetKey {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "server_assigned" => Ok(Self(IgnoreSetName::ServerAssigned)),
+            "ctx_defaults" => Ok(Self(IgnoreSetName::CtxDefaults)),
+            _ => Err(format!("{s:?} is not a named ignore-set")),
+        }
+    }
+}
+
+impl std::fmt::Display for IgnoreSetKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self.0 {
+            IgnoreSetName::ServerAssigned => "server_assigned",
+            IgnoreSetName::CtxDefaults => "ctx_defaults",
+        })
+    }
+}
+
+/// The compiled body-selector tokens, in vocabulary order.
+pub const BODY_SELECTOR_TOKENS: &[&str] = &[
+    "prefer_conditional",
+    "error_loose",
+    "result_set_body",
+    "negotiated",
+    "present",
+    "absent",
+];
+
+/// The compiled header-matcher forms, in vocabulary order.
+pub const HEADER_MATCHER_FORMS: &[&str] = &[
+    "present",
+    "present?",
+    "absent",
+    "negotiated",
+    "latest-version-uid",
+    "pattern:<regex>",
+    "<literal>",
+];
+
+impl SelectorsVocab {
+    /// Two-way equality with the compiled vocabularies, plus ignore-set
+    /// shape (per-binding sets carry no paths; enumerated sets carry some).
+    ///
+    /// # Errors
+    /// Returns every drift found.
+    pub fn check_against_enum(&self) -> Result<(), Vec<String>> {
+        let mut findings = Vec::new();
+        if self.body_selectors != BODY_SELECTOR_TOKENS {
+            findings.push(format!(
+                "selectors.yaml body_selectors {:?} != the compiled vocabulary {BODY_SELECTOR_TOKENS:?}",
+                self.body_selectors
+            ));
+        }
+        if self.header_matchers != HEADER_MATCHER_FORMS {
+            findings.push(format!(
+                "selectors.yaml header_matchers {:?} != the compiled vocabulary {HEADER_MATCHER_FORMS:?}",
+                self.header_matchers
+            ));
+        }
+        for (key, decl) in &self.ignore_sets {
+            match key.0 {
+                IgnoreSetName::ServerAssigned => {
+                    if !decl.per_binding || !decl.paths.is_empty() {
+                        findings.push(
+                            "server_assigned must be per_binding with no enumerated paths"
+                                .to_owned(),
+                        );
+                    }
+                }
+                IgnoreSetName::CtxDefaults => {
+                    if decl.per_binding || decl.paths.is_empty() {
+                        findings.push(
+                            "ctx_defaults must enumerate its paths (not per_binding)".to_owned(),
+                        );
+                    }
+                }
+            }
+        }
+        for name in [IgnoreSetName::ServerAssigned, IgnoreSetName::CtxDefaults] {
+            if !self.ignore_sets.iter().any(|(k, _)| k.0 == name) {
+                findings.push(format!("selectors.yaml is missing ignore-set {name:?}"));
+            }
+        }
+        if findings.is_empty() {
+            Ok(())
+        } else {
+            Err(findings)
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)] // test assertions/fixtures
+mod tests {
+    use super::*;
+
+    #[test]
+    fn outcomes_vocab_drift_bites() {
+        use std::fmt::Write;
+        let mut yaml = String::new();
+        for kind in OutcomeKind::ALL {
+            let class = match kind.class() {
+                crate::vocab::OutcomeClass::Success => "success",
+                crate::vocab::OutcomeClass::Error => "error",
+            };
+            let _ = writeln!(
+                yaml,
+                "{}: {{ class: {class}, meaning: \"m\" }}",
+                kind.token()
+            );
+        }
+        let vocab: OutcomesVocab = serde_saphyr::from_str(&yaml).unwrap();
+        assert!(vocab.check_against_enum().is_ok());
+
+        let short: OutcomesVocab =
+            serde_saphyr::from_str("created: { class: success, meaning: m }\n").unwrap();
+        assert!(short.check_against_enum().is_err());
+    }
+}

--- a/tools/cnf-runner/src/refgrammar.rs
+++ b/tools/cnf-runner/src/refgrammar.rs
@@ -1,0 +1,474 @@
+//! The closed `${…}` variable-reference grammar and the case-level capture
+//! grammar.
+//!
+//! Case cores speak these forms and nothing else (CNF 2.0 artifact-set
+//! design, case-core contract): `${row.<column>}`, `${fixture.<field>}`,
+//! `${<capture>}`, `${ds:<corpus key>}`, `${ds:<corpus key>#<view>}`,
+//! `${recipe:<name>(row)}`, and the temporal expressions
+//! `${time:before(<t>)}` / `${time:after(<t>)}` / `${time:between(<t1>,<t2>)}`.
+//! There is no `${stepN}` form. Binding request templates may additionally
+//! mark a reference optional (`${offset?}`). A string outside these forms is
+//! a validator error, never runner latitude.
+
+use std::fmt;
+
+use thiserror::Error;
+
+use crate::ids::{CaptureName, CorpusKey, IdError, RecipeName, ViewName};
+use crate::vocab::OutcomeKind;
+
+/// Reference-grammar parse error.
+#[derive(Debug, Error)]
+pub enum RefError {
+    /// A `${` without a closing `}`.
+    #[error("unterminated ${{…}} reference in {0:?}")]
+    Unterminated(String),
+    /// A reference body outside the closed grammar.
+    #[error("illegal reference ${{{0}}}: {1}")]
+    Illegal(String, String),
+    /// An embedded identifier failed its lexical rule.
+    #[error("in ${{{reference}}}: {source}")]
+    BadIdent {
+        /// The offending reference body.
+        reference: String,
+        /// The identifier error.
+        source: IdError,
+    },
+}
+
+/// The `${fixture.<field>}` fields — closed to the fixture-set entry
+/// bindings (`data_set`, `expected`, `defect`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FixtureField {
+    DataSet,
+    Expected,
+    Defect,
+}
+
+impl FixtureField {
+    fn parse(s: &str) -> Option<Self> {
+        match s {
+            "data_set" => Some(Self::DataSet),
+            "expected" => Some(Self::Expected),
+            "defect" => Some(Self::Defect),
+            _ => None,
+        }
+    }
+
+    /// The field token.
+    #[must_use]
+    pub fn token(self) -> &'static str {
+        match self {
+            Self::DataSet => "data_set",
+            Self::Expected => "expected",
+            Self::Defect => "defect",
+        }
+    }
+}
+
+/// A temporal at-time expression over captured commit instants. Resolution
+/// is fixed by the interpreter laws (before = t − 1 ms, after = t + 1 ms,
+/// between = midpoint) so two runners query identical instants.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TimeExpr {
+    Before(CaptureName),
+    After(CaptureName),
+    Between(CaptureName, CaptureName),
+}
+
+/// One parsed `${…}` reference.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ValueRef {
+    /// `${row.<column>}` — the current parameter-matrix row cell.
+    Row(String),
+    /// `${fixture.<field>}` — the current fixture-set entry.
+    Fixture(FixtureField),
+    /// `${<capture>}` — a case-scoped capture or `requires` handle.
+    /// `optional` is the binding-template `${name?}` marker.
+    Capture { name: CaptureName, optional: bool },
+    /// `${ds:<key>}` / `${ds:<key>#<view>}` — a corpus data set or a named
+    /// projection over it.
+    DataSet {
+        key: CorpusKey,
+        view: Option<ViewName>,
+    },
+    /// `${ds:fixture}` — the current fixture-set entry's payload (legal only
+    /// in cases carrying `parameters.fixture_set`).
+    FixtureDataSet,
+    /// `${recipe:<name>(row)}` — row-to-instance synthesis.
+    Recipe(RecipeName),
+    /// `${time:…}` — temporal reference.
+    Time(TimeExpr),
+}
+
+impl ValueRef {
+    /// Parse one reference body (the text between `${` and `}`).
+    ///
+    /// # Errors
+    /// Returns [`RefError`] when the body is outside the closed grammar.
+    pub fn parse(body: &str) -> Result<Self, RefError> {
+        let bad_ident = |source| RefError::BadIdent {
+            reference: body.to_owned(),
+            source,
+        };
+        let illegal = |why: &str| RefError::Illegal(body.to_owned(), why.to_owned());
+
+        if let Some(column) = body.strip_prefix("row.") {
+            if column.is_empty() || column.contains(char::is_whitespace) {
+                return Err(illegal("row column must be a non-empty name"));
+            }
+            return Ok(Self::Row(column.to_owned()));
+        }
+        if let Some(field) = body.strip_prefix("fixture.") {
+            return FixtureField::parse(field)
+                .map(Self::Fixture)
+                .ok_or_else(|| illegal("fixture field must be data_set | expected | defect"));
+        }
+        if body == "ds:fixture" {
+            return Ok(Self::FixtureDataSet);
+        }
+        if let Some(rest) = body.strip_prefix("ds:") {
+            let (key, view) = match rest.split_once('#') {
+                Some((key, view)) => (key, Some(ViewName::parse(view).map_err(bad_ident)?)),
+                None => (rest, None),
+            };
+            let key = CorpusKey::parse(key).map_err(bad_ident)?;
+            return Ok(Self::DataSet { key, view });
+        }
+        if let Some(rest) = body.strip_prefix("recipe:") {
+            let name = rest
+                .strip_suffix("(row)")
+                .ok_or_else(|| illegal("recipe reference must end in (row)"))?;
+            return Ok(Self::Recipe(RecipeName::parse(name).map_err(bad_ident)?));
+        }
+        if let Some(rest) = body.strip_prefix("time:") {
+            return Self::parse_time(rest).map(Self::Time).ok_or_else(|| {
+                illegal("time expression must be before(<t>) | after(<t>) | between(<t1>,<t2>)")
+            });
+        }
+        if body.contains(':') || body.contains('.') {
+            return Err(illegal(
+                "unknown reference form (closed grammar: row./fixture./ds:/recipe:/time:/<capture>)",
+            ));
+        }
+        let (name, optional) = match body.strip_suffix('?') {
+            Some(name) => (name, true),
+            None => (body, false),
+        };
+        Ok(Self::Capture {
+            name: CaptureName::parse(name).map_err(bad_ident)?,
+            optional,
+        })
+    }
+
+    fn parse_time(rest: &str) -> Option<TimeExpr> {
+        let inner = |prefix: &str| -> Option<&str> {
+            rest.strip_prefix(prefix)?
+                .strip_prefix('(')?
+                .strip_suffix(')')
+        };
+        if let Some(arg) = inner("before") {
+            return CaptureName::parse(arg.trim()).ok().map(TimeExpr::Before);
+        }
+        if let Some(arg) = inner("after") {
+            return CaptureName::parse(arg.trim()).ok().map(TimeExpr::After);
+        }
+        if let Some(args) = inner("between") {
+            let (a, b) = args.split_once(',')?;
+            return Some(TimeExpr::Between(
+                CaptureName::parse(a.trim()).ok()?,
+                CaptureName::parse(b.trim()).ok()?,
+            ));
+        }
+        None
+    }
+}
+
+impl fmt::Display for ValueRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Row(c) => write!(f, "${{row.{c}}}"),
+            Self::Fixture(field) => write!(f, "${{fixture.{}}}", field.token()),
+            Self::Capture { name, optional } => {
+                write!(f, "${{{name}{}}}", if *optional { "?" } else { "" })
+            }
+            Self::DataSet {
+                key,
+                view: Some(view),
+            } => write!(f, "${{ds:{key}#{view}}}"),
+            Self::DataSet { key, view: None } => write!(f, "${{ds:{key}}}"),
+            Self::FixtureDataSet => f.write_str("${ds:fixture}"),
+            Self::Recipe(name) => write!(f, "${{recipe:{name}(row)}}"),
+            Self::Time(TimeExpr::Before(t)) => write!(f, "${{time:before({t})}}"),
+            Self::Time(TimeExpr::After(t)) => write!(f, "${{time:after({t})}}"),
+            Self::Time(TimeExpr::Between(a, b)) => write!(f, "${{time:between({a},{b})}}"),
+        }
+    }
+}
+
+/// One segment of a templated string.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Segment {
+    /// Literal text.
+    Lit(String),
+    /// A `${…}` reference.
+    Ref(ValueRef),
+}
+
+/// A string value that may interleave literal text with `${…}` references
+/// (`"${versioned_object_uid}::<system>::2"`). Parsing validates every
+/// embedded reference against the closed grammar.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Template {
+    raw: String,
+    segments: Vec<Segment>,
+}
+
+impl Template {
+    /// Parse a raw string, validating every `${…}` occurrence.
+    ///
+    /// # Errors
+    /// Returns [`RefError`] on an unterminated or illegal reference.
+    pub fn parse(raw: &str) -> Result<Self, RefError> {
+        let mut segments = Vec::new();
+        let mut rest = raw;
+        while let Some(start) = rest.find("${") {
+            let (lit, tail) = rest.split_at(start);
+            if !lit.is_empty() {
+                segments.push(Segment::Lit(lit.to_owned()));
+            }
+            let body_and_more = tail.get(2..).unwrap_or_default();
+            let end = body_and_more
+                .find('}')
+                .ok_or_else(|| RefError::Unterminated(raw.to_owned()))?;
+            let body = body_and_more.get(..end).unwrap_or_default();
+            segments.push(Segment::Ref(ValueRef::parse(body)?));
+            rest = body_and_more.get(end + 1..).unwrap_or_default();
+        }
+        if !rest.is_empty() {
+            segments.push(Segment::Lit(rest.to_owned()));
+        }
+        Ok(Self {
+            raw: raw.to_owned(),
+            segments,
+        })
+    }
+
+    /// The raw authored text.
+    #[must_use]
+    pub fn raw(&self) -> &str {
+        &self.raw
+    }
+
+    /// The parsed segments.
+    #[must_use]
+    pub fn segments(&self) -> &[Segment] {
+        &self.segments
+    }
+
+    /// Every reference in the template, in order.
+    pub fn refs(&self) -> impl Iterator<Item = &ValueRef> {
+        self.segments.iter().filter_map(|s| match s {
+            Segment::Ref(r) => Some(r),
+            Segment::Lit(_) => None,
+        })
+    }
+
+    /// Whether the whole template is exactly one reference (no literal text).
+    #[must_use]
+    pub fn as_single_ref(&self) -> Option<&ValueRef> {
+        match self.segments.as_slice() {
+            [Segment::Ref(r)] => Some(r),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for Template {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.raw)
+    }
+}
+
+impl serde::Serialize for Template {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.raw)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Template {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Self::parse(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+/// What part of the step outcome a case-level capture reads. Sources are
+/// closed: a logical field mapped by the binding, the full response body, or
+/// the committed audit time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CaptureField {
+    /// `<outcome>.body` — the full response representation.
+    Body,
+    /// `<outcome>.commit_time` — the committed audit time (the anchor for
+    /// temporal at-time cases).
+    CommitTime,
+    /// `<outcome>.<field>` (`list` for the `<field>[]` list-capture form).
+    Field { name: CaptureName, list: bool },
+}
+
+/// A case-level capture source: `<outcome kind>.<capture field>`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CaptureValueSource {
+    /// The outcome kind whose mapping supplies the value.
+    pub outcome: OutcomeKind,
+    /// What is read.
+    pub field: CaptureField,
+}
+
+impl CaptureValueSource {
+    /// Parse `created.ehr_id`, `ok.body`, `created.version_uids[]`, ….
+    ///
+    /// # Errors
+    /// Returns [`RefError`] when the source is outside the closed grammar.
+    pub fn parse(raw: &str) -> Result<Self, RefError> {
+        let illegal = |why: &str| RefError::Illegal(raw.to_owned(), why.to_owned());
+        let (outcome, field) = raw
+            .split_once('.')
+            .ok_or_else(|| illegal("capture source must be <outcome>.<field>"))?;
+        let outcome = OutcomeKind::from_token(outcome)
+            .ok_or_else(|| illegal("capture source outcome must be an outcome kind"))?;
+        let field = match field {
+            "body" => CaptureField::Body,
+            "commit_time" => CaptureField::CommitTime,
+            other => {
+                let (name, list) = match other.strip_suffix("[]") {
+                    Some(name) => (name, true),
+                    None => (other, false),
+                };
+                CaptureField::Field {
+                    name: CaptureName::parse(name).map_err(|source| RefError::BadIdent {
+                        reference: raw.to_owned(),
+                        source,
+                    })?,
+                    list,
+                }
+            }
+        };
+        Ok(Self { outcome, field })
+    }
+}
+
+impl fmt::Display for CaptureValueSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let token = self.outcome.token();
+        match &self.field {
+            CaptureField::Body => write!(f, "{token}.body"),
+            CaptureField::CommitTime => write!(f, "{token}.commit_time"),
+            CaptureField::Field { name, list } => {
+                write!(f, "{token}.{name}{}", if *list { "[]" } else { "" })
+            }
+        }
+    }
+}
+
+impl serde::Serialize for CaptureValueSource {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for CaptureValueSource {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Self::parse(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_ref(body: &str) -> ValueRef {
+        ValueRef::parse(body).unwrap()
+    }
+
+    #[test]
+    fn closed_forms_parse() {
+        assert_eq!(parse_ref("row.ehr_id"), ValueRef::Row("ehr_id".into()));
+        assert_eq!(
+            parse_ref("fixture.expected"),
+            ValueRef::Fixture(FixtureField::Expected)
+        );
+        assert!(matches!(
+            parse_ref("first_ehr_id"),
+            ValueRef::Capture {
+                optional: false,
+                ..
+            }
+        ));
+        assert!(matches!(
+            parse_ref("offset?"),
+            ValueRef::Capture { optional: true, .. }
+        ));
+        assert!(matches!(
+            parse_ref("ds:cnf.set.bp-10"),
+            ValueRef::DataSet { view: None, .. }
+        ));
+        assert!(matches!(
+            parse_ref("ds:cnf.set.bp-10#magnitude_ge_140_by_uid"),
+            ValueRef::DataSet { view: Some(_), .. }
+        ));
+        assert!(matches!(
+            parse_ref("recipe:ehr_status(row)"),
+            ValueRef::Recipe(_)
+        ));
+        assert!(matches!(
+            parse_ref("time:before(t1)"),
+            ValueRef::Time(TimeExpr::Before(_))
+        ));
+        assert!(matches!(
+            parse_ref("time:between(t1,t2)"),
+            ValueRef::Time(TimeExpr::Between(..))
+        ));
+    }
+
+    #[test]
+    fn illegal_forms_rejected() {
+        assert!(ValueRef::parse("step2.body").is_err()); // no ${stepN} form
+        assert!(ValueRef::parse("fixture.payload").is_err());
+        assert!(ValueRef::parse("recipe:ehr_status").is_err());
+        assert!(ValueRef::parse("time:around(t1)").is_err());
+        assert!(ValueRef::parse("ds:Not.A.Key").is_err());
+    }
+
+    #[test]
+    fn templates_scan_all_refs() {
+        let t = Template::parse("${versioned_object_uid}::<system>::2").unwrap();
+        assert_eq!(t.refs().count(), 1);
+        assert!(t.as_single_ref().is_none());
+        assert!(Template::parse("${unclosed").is_err());
+        assert!(Template::parse("prefix ${step2.body} suffix").is_err());
+        let single = Template::parse("${ds:cnf.composition.minimal_event.v1}").unwrap();
+        assert!(single.as_single_ref().is_some());
+    }
+
+    #[test]
+    fn capture_sources() {
+        let s = CaptureValueSource::parse("created.version_uids[]").unwrap();
+        assert_eq!(s.outcome, OutcomeKind::Created);
+        assert!(matches!(s.field, CaptureField::Field { list: true, .. }));
+        assert!(matches!(
+            CaptureValueSource::parse("ok.body").unwrap().field,
+            CaptureField::Body
+        ));
+        assert!(matches!(
+            CaptureValueSource::parse("created.commit_time")
+                .unwrap()
+                .field,
+            CaptureField::CommitTime
+        ));
+        assert!(CaptureValueSource::parse("nonsense.ehr_id").is_err());
+        assert!(CaptureValueSource::parse("created").is_err());
+    }
+}

--- a/tools/cnf-runner/src/schema.rs
+++ b/tools/cnf-runner/src/schema.rs
@@ -1,0 +1,576 @@
+//! Deterministic JSON-Schema emission for the five schedule-artifact
+//! families (the set the upstream U1 proposal ships).
+//!
+//! The published schema files are the norm; this module is their single
+//! source. Emission is byte-deterministic: fixed insertion order (via
+//! `serde_json`'s `preserve_order`), two-space pretty printing, trailing
+//! newline. Every closed vocabulary in a schema derives from the compiled
+//! enums in [`crate::vocab`], so schema and reference implementation cannot
+//! drift. Draft: JSON Schema 2020-12. `$id`s are versioned URNs pending the
+//! upstream repository's canonical URLs.
+
+use serde::Serialize;
+use serde_json::{Value, json};
+
+use crate::model::vocab_files::{BODY_SELECTOR_TOKENS, HEADER_MATCHER_FORMS};
+use crate::vocab::{
+    CaseKind, CaseStatus, Component, CorpusFormat, Disposition, FormatName, HttpMethod, Iteration,
+    OutcomeKind, PlaceholderPolicy, ServerState, Tier,
+};
+
+/// The schema version stamped into every `$id` (bumps with the schedule
+/// release, independently of the product version).
+pub const SCHEMA_VERSION: &str = "0.1.0";
+
+const DRAFT: &str = "https://json-schema.org/draft/2020-12/schema";
+
+/// Serde token of one enum variant.
+fn token<T: Serialize>(v: &T) -> Value {
+    match serde_json::to_value(v) {
+        Ok(Value::String(s)) => Value::String(s),
+        // Unreachable for the vocab enums (all serialize to strings); a
+        // non-string token would be a defect in this module, surfaced by the
+        // emission tests, never silently emitted.
+        _ => Value::Null,
+    }
+}
+
+/// Serde tokens of a whole vocabulary.
+fn tokens<T: Serialize>(all: &[T]) -> Value {
+    Value::Array(all.iter().map(token).collect())
+}
+
+fn urn(name: &str) -> String {
+    format!("urn:openehr:cnf:schema:{name}:{SCHEMA_VERSION}")
+}
+
+const CASE_ID_PATTERN: &str = "^\\S+$";
+const SM_OPERATION_PATTERN: &str = "^I_[A-Z0-9_]+\\.[a-z][a-z0-9_]*$";
+const IDENT_PATTERN: &str = "^[A-Za-z_][A-Za-z0-9_]*$";
+const CORPUS_KEY_PATTERN: &str = "^[a-z0-9_-]+(\\.[a-z0-9_-]+)*$";
+const AMBIGUITY_ID_PATTERN: &str = "^AMB-[0-9]+$";
+const OPTION_TAG_PATTERN: &str = "^[a-z0-9_-]+$";
+
+fn string_array(item_pattern: Option<&str>) -> Value {
+    match item_pattern {
+        Some(p) => json!({ "type": "array", "items": { "type": "string", "pattern": p } }),
+        None => json!({ "type": "array", "items": { "type": "string" } }),
+    }
+}
+
+fn requires_def() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "server": { "enum": tokens(ServerState::ALL) },
+            "templates": string_array(Some(CORPUS_KEY_PATTERN)),
+            "ehr": { "oneOf": [
+                { "const": "none" },
+                { "type": "object", "additionalProperties": false,
+                  "required": ["commits"],
+                  "properties": { "commits": { "enum": ["none", "any"] } } }
+            ] },
+            "directory": { "oneOf": [
+                { "const": "none" },
+                { "type": "string", "pattern": CORPUS_KEY_PATTERN }
+            ] },
+            "commit": string_array(Some(CORPUS_KEY_PATTERN)),
+            "instances": { "type": "object",
+                "propertyNames": { "pattern": IDENT_PATTERN },
+                "additionalProperties": { "$ref": "#/$defs/requires" } }
+        }
+    })
+}
+
+fn parameters_def() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["iteration"],
+        "properties": {
+            "iteration": { "enum": tokens(Iteration::ALL) },
+            "matrix": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["columns"],
+                "properties": {
+                    "columns": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+                    "rows": { "type": "array", "items": { "type": "array" } },
+                    "rows_from": { "type": "string" }
+                }
+            },
+            "fixture_set": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["data_set", "expected"],
+                    "properties": {
+                        "data_set": { "type": "string", "pattern": CORPUS_KEY_PATTERN },
+                        "expected": { "enum": tokens(OutcomeKind::ALL) },
+                        "defect": { "type": "string" },
+                        "spec_ref": { "type": "string" }
+                    }
+                }
+            }
+        }
+    })
+}
+
+fn flow_step_def() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["step", "call", "expect"],
+        "properties": {
+            "step": { "type": "integer", "minimum": 1 },
+            "call": { "type": "string", "minLength": 1 },
+            "on": { "type": "string", "pattern": IDENT_PATTERN },
+            "variant": { "type": "string" },
+            "format": { "enum": tokens(FormatName::ALL) },
+            "with": { "type": "object" },
+            "expect": { "oneOf": [
+                { "enum": tokens(OutcomeKind::ALL) },
+                { "const": "${fixture.expected}" }
+            ] },
+            "capture": { "type": "object",
+                "propertyNames": { "pattern": IDENT_PATTERN },
+                "additionalProperties": { "type": "string" } },
+            "assert": { "type": "array", "items": { "$ref": "#/$defs/assertion" } }
+        }
+    })
+}
+
+fn assertion_def() -> Value {
+    // The schema pins the closed assertion-form vocabulary; per-form field
+    // shapes are enforced by the typed model (richer than JSON Schema can
+    // express — predicate exclusivity, reference grammar, aggregate rules).
+    json!({
+        "type": "object",
+        "required": ["assert"],
+        "properties": {
+            "assert": { "enum": [
+                "instance_of", "field", "equivalent", "version",
+                "result_set", "unique", "returns", "message_exemplar", "state"
+            ] }
+        }
+    })
+}
+
+/// `schedule/**` case cores (§ case-core contract).
+#[must_use]
+pub fn case_core_schema() -> Value {
+    json!({
+        "$schema": DRAFT,
+        "$id": urn("case-core"),
+        "title": "CNF 2.0 case core",
+        "description": "One protocol-neutral test case (the Abstract Test Suite unit). Wire realization lives in the operation bindings; cases speak SM operations and outcome kinds only.",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "kind", "component", "test_purpose", "description", "spec_refs", "capabilities"],
+        "properties": {
+            "id": { "type": "string", "pattern": CASE_ID_PATTERN },
+            "kind": { "enum": tokens(CaseKind::ALL) },
+            "status": { "enum": tokens(CaseStatus::ALL), "default": "active" },
+            "component": { "enum": tokens(Component::ALL) },
+            "sm_operation": { "type": "string", "pattern": SM_OPERATION_PATTERN },
+            "rm_class": { "type": "string" },
+            "test_purpose": { "type": "string", "minLength": 1 },
+            "description": { "type": "string", "minLength": 1 },
+            "spec_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+            "applies": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "rm": { "type": "string" }, "base": { "type": "string" },
+                    "am": { "type": "string" }, "aql": { "type": "string" },
+                    "its_rest": { "type": "string" }, "term": { "type": "string" }
+                }
+            },
+            "guards": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+            "capabilities": string_array(Some(IDENT_PATTERN)),
+            "exercises": string_array(Some(IDENT_PATTERN)),
+            "profiles": { "type": "array", "items": { "enum": tokens(Tier::ALL) } },
+            "option": { "type": "string", "pattern": OPTION_TAG_PATTERN },
+            "formats": { "type": "array", "items": { "enum": tokens(FormatName::ALL) } },
+            "requires": { "$ref": "#/$defs/requires" },
+            "parameters": { "$ref": "#/$defs/parameters" },
+            "flow": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/flowStep" } },
+            "constraint_context": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["template", "path"],
+                "properties": {
+                    "template": { "type": "string", "pattern": CORPUS_KEY_PATTERN },
+                    "path": { "type": "string", "minLength": 1 }
+                }
+            },
+            "decision_table": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["columns", "rows"],
+                "properties": {
+                    "columns": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+                    "rows": { "type": "array", "minItems": 1, "items": { "type": "array" } }
+                }
+            },
+            "postconditions": { "type": "array", "items": { "$ref": "#/$defs/assertion" } },
+            "verified_by": string_array(Some(CASE_ID_PATTERN)),
+            "ambiguities": string_array(Some(AMBIGUITY_ID_PATTERN)),
+            "data_sets": string_array(Some(CORPUS_KEY_PATTERN))
+        },
+        "allOf": [
+            { "if": { "properties": { "kind": { "const": "functional" } } },
+              "then": { "required": ["sm_operation", "flow"] } },
+            { "if": { "properties": { "kind": { "const": "content" } } },
+              "then": { "required": ["rm_class", "constraint_context", "decision_table"] } }
+        ],
+        "$defs": {
+            "requires": requires_def(),
+            "parameters": parameters_def(),
+            "flowStep": flow_step_def(),
+            "assertion": assertion_def()
+        }
+    })
+}
+
+/// `bindings/<its>/**` operation bindings (§ wire layer).
+#[must_use]
+pub fn operation_binding_schema() -> Value {
+    json!({
+        "$schema": DRAFT,
+        "$id": urn("operation-binding"),
+        "title": "CNF 2.0 operation binding",
+        "description": "Per-ITS wire realization of one SM operation: request construction, outcome kind → wire expectation, logical capture → wire source. Every mapping cites its OAS source.",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["sm_operation", "its", "request", "outcomes"],
+        "properties": {
+            "sm_operation": { "type": "string", "pattern": SM_OPERATION_PATTERN },
+            "its": { "enum": ["its-rest"] },
+            "applies": { "type": "object" },
+            "request": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["method", "path"],
+                "properties": {
+                    "method": { "enum": tokens(HttpMethod::ALL) },
+                    "path": { "type": "string", "pattern": "^/" },
+                    "body": { "oneOf": [ { "type": "string" }, { "type": "object" } ] },
+                    "headers": { "type": "object", "additionalProperties": { "type": "string" } }
+                }
+            },
+            "formats": { "type": "array", "items": { "enum": tokens(FormatName::ALL) } },
+            "format_headers": {
+                "type": "object",
+                "propertyNames": { "enum": tokens(FormatName::ALL) },
+                "additionalProperties": {
+                    "type": "object",
+                    "additionalProperties": { "type": "string" }
+                }
+            },
+            "outcomes": {
+                "type": "object",
+                "minProperties": 1,
+                "propertyNames": { "enum": tokens(OutcomeKind::ALL) },
+                "additionalProperties": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["status"],
+                    "properties": {
+                        "status": { "type": "integer", "minimum": 100, "maximum": 599 },
+                        "headers": { "type": "object", "additionalProperties": { "type": "string" } },
+                        "body": { "enum": BODY_SELECTOR_TOKENS }
+                    }
+                }
+            },
+            "captures": {
+                "type": "object",
+                "propertyNames": { "pattern": IDENT_PATTERN },
+                "additionalProperties": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["from"],
+                    "properties": {
+                        "from": { "type": "string" },
+                        "strip": { "enum": ["weak-quotes"] },
+                        "transform": { "enum": ["root-uid"] },
+                        "fallback": { "type": "string" }
+                    }
+                }
+            },
+            "server_assigned": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+        }
+    })
+}
+
+/// `vocab/outcomes.yaml` — all kinds required, none extra.
+#[must_use]
+pub fn outcomes_schema() -> Value {
+    let required: Vec<Value> = OutcomeKind::ALL
+        .iter()
+        .map(|k| Value::String(k.token().to_owned()))
+        .collect();
+    json!({
+        "$schema": DRAFT,
+        "$id": urn("outcomes"),
+        "title": "CNF 2.0 outcome-kind vocabulary",
+        "description": "The closed outcome taxonomy. Cases speak ONLY these kinds; bindings map each kind to wire per operation. Extension only by schedule release.",
+        "type": "object",
+        "propertyNames": { "enum": tokens(OutcomeKind::ALL) },
+        "required": required,
+        "additionalProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["class", "meaning"],
+            "properties": {
+                "class": { "enum": ["success", "error"] },
+                "meaning": { "type": "string", "minLength": 1 }
+            }
+        }
+    })
+}
+
+/// `vocab/selectors.yaml` — selector/matcher vocabularies + ignore-sets.
+#[must_use]
+pub fn selectors_schema() -> Value {
+    json!({
+        "$schema": DRAFT,
+        "$id": urn("selectors"),
+        "title": "CNF 2.0 selector vocabulary",
+        "description": "The closed body-selector and header-matcher vocabularies, plus the named ignore-set registry the `equivalent` assertion resolves (normative, never runner judgment).",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["body_selectors", "header_matchers", "ignore_sets"],
+        "properties": {
+            "body_selectors": { "const": BODY_SELECTOR_TOKENS },
+            "header_matchers": { "const": HEADER_MATCHER_FORMS },
+            "ignore_sets": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["server_assigned", "ctx_defaults"],
+                "properties": {
+                    "server_assigned": { "$ref": "#/$defs/ignoreSet" },
+                    "ctx_defaults": { "$ref": "#/$defs/ignoreSet" }
+                }
+            }
+        },
+        "$defs": {
+            "ignoreSet": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["source"],
+                "properties": {
+                    "paths": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+                    "per_binding": { "type": "boolean" },
+                    "source": { "type": "string", "minLength": 1 }
+                }
+            }
+        }
+    })
+}
+
+/// `vocab/capability_matrix.yaml` — capability → family/tier/required, with
+/// family-scoped tiers enforced in-schema.
+#[must_use]
+pub fn capability_matrix_schema() -> Value {
+    json!({
+        "$schema": DRAFT,
+        "$id": urn("capability-matrix"),
+        "title": "CNF 2.0 capability matrix",
+        "description": "The machine-readable capability→family→tier matrix — the Profiles book's capability×tier tables as data, the input the verdict machinery computes from.",
+        "type": "object",
+        "minProperties": 1,
+        "propertyNames": { "pattern": IDENT_PATTERN },
+        "additionalProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["family", "tier", "required"],
+            "properties": {
+                "family": { "enum": ["Platform", "Enterprise", "Security"] },
+                "tier": { "enum": tokens(Tier::ALL) },
+                "required": { "type": "boolean" },
+                "source": { "type": "string" }
+            },
+            "oneOf": [
+                { "properties": { "family": { "const": "Platform" },
+                                  "tier": { "enum": ["CORE", "STANDARD", "OPTIONS"] } } },
+                { "properties": { "family": { "const": "Security" },
+                                  "tier": { "enum": ["SEC-BASIC"] } } },
+                { "properties": { "family": { "const": "Enterprise" },
+                                  "tier": { "enum": ["D", "M", "X"] } } }
+            ]
+        }
+    })
+}
+
+/// `corpus/MANIFEST.yaml` — governed corpus entries.
+#[must_use]
+pub fn corpus_manifest_schema() -> Value {
+    json!({
+        "$schema": DRAFT,
+        "$id": urn("corpus-manifest"),
+        "title": "CNF 2.0 corpus manifest",
+        "description": "Every fixture and generated set is a manifest entry: adjudicated verdict + defect live here (never only in a filename); generated sets are committed seeded deterministic recipes.",
+        "type": "object",
+        "minProperties": 1,
+        "propertyNames": { "pattern": CORPUS_KEY_PATTERN },
+        "additionalProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["format", "validity", "provenance"],
+            "oneOf": [
+                { "required": ["source"], "not": { "required": ["generated_by"] } },
+                { "required": ["generated_by"], "not": { "required": ["source"] } }
+            ],
+            "properties": {
+                "source": { "type": "string", "minLength": 1 },
+                "generated_by": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["recipe", "digest"],
+                    "properties": {
+                        "recipe": { "type": "string", "pattern": IDENT_PATTERN },
+                        "digest": { "type": "string", "minLength": 1 }
+                    }
+                },
+                "format": { "enum": tokens(CorpusFormat::ALL) },
+                "rm_versions": { "type": "array", "items": { "type": "string" } },
+                "validity": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["verdict"],
+                    "properties": {
+                        "verdict": { "enum": ["valid", "invalid"] },
+                        "defect": { "type": "string", "minLength": 1 },
+                        "spec_ref": { "type": "string", "minLength": 1 }
+                    },
+                    "if": { "properties": { "verdict": { "const": "invalid" } } },
+                    "then": { "required": ["verdict", "defect", "spec_ref"] }
+                },
+                "placeholders": {
+                    "type": "object",
+                    "additionalProperties": { "enum": tokens(PlaceholderPolicy::ALL) }
+                },
+                "provenance": { "type": "string", "minLength": 1 },
+                "views": {
+                    "type": "object",
+                    "propertyNames": { "pattern": IDENT_PATTERN },
+                    "additionalProperties": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": ["select"],
+                        "properties": {
+                            "select": { "type": "string", "minLength": 1 },
+                            "where": { "type": "string" },
+                            "order_by": { "type": "string" }
+                        }
+                    }
+                },
+                "recipes": {
+                    "type": "object",
+                    "propertyNames": { "pattern": IDENT_PATTERN },
+                    "additionalProperties": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": ["digest"],
+                        "properties": { "digest": { "type": "string", "minLength": 1 } }
+                    }
+                }
+            }
+        }
+    })
+}
+
+/// `registers/ambiguities.yaml` — the ambiguity register.
+#[must_use]
+pub fn ambiguity_register_schema() -> Value {
+    json!({
+        "$schema": DRAFT,
+        "$id": urn("ambiguity-register"),
+        "title": "CNF 2.0 ambiguity register",
+        "description": "Every entry a real, verified spec divergence or silence with the normative handling a runner must apply. A runner that resolves an ambiguity privately is non-conformant to the schedule.",
+        "type": "object",
+        "minProperties": 1,
+        "propertyNames": { "pattern": AMBIGUITY_ID_PATTERN },
+        "additionalProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["ambiguity", "source", "handling", "disposition"],
+            "properties": {
+                "ambiguity": { "type": "string", "minLength": 1 },
+                "source": { "type": "string", "minLength": 1 },
+                "handling": { "type": "string", "minLength": 1 },
+                "disposition": { "enum": tokens(Disposition::ALL) },
+                "options": { "type": "array", "items": { "type": "string", "pattern": OPTION_TAG_PATTERN } }
+            },
+            "allOf": [
+                { "if": { "properties": { "disposition": { "const": "option_select" } } },
+                  "then": { "required": ["ambiguity", "source", "handling", "disposition", "options"],
+                            "properties": { "options": { "minItems": 2 } } },
+                  "else": { "properties": { "options": { "maxItems": 0 } } } }
+            ]
+        }
+    })
+}
+
+/// The full published set: (file name, schema document).
+#[must_use]
+pub fn emit_all() -> Vec<(&'static str, Value)> {
+    vec![
+        ("case-core.schema.json", case_core_schema()),
+        ("operation-binding.schema.json", operation_binding_schema()),
+        ("outcomes.schema.json", outcomes_schema()),
+        ("selectors.schema.json", selectors_schema()),
+        ("capability-matrix.schema.json", capability_matrix_schema()),
+        ("corpus-manifest.schema.json", corpus_manifest_schema()),
+        (
+            "ambiguity-register.schema.json",
+            ambiguity_register_schema(),
+        ),
+    ]
+}
+
+/// Render a schema document to its canonical published text
+/// (two-space pretty print + trailing newline).
+#[must_use]
+pub fn render(schema: &Value) -> String {
+    let mut text = serde_json::to_string_pretty(schema).unwrap_or_default();
+    text.push('\n');
+    text
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)] // test assertions
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_schema_compiles_under_2020_12() {
+        for (name, schema) in emit_all() {
+            jsonschema::validator_for(&schema)
+                .unwrap_or_else(|e| panic!("{name} does not compile: {e}"));
+        }
+    }
+
+    #[test]
+    fn rendering_is_deterministic() {
+        let a = render(&case_core_schema());
+        let b = render(&case_core_schema());
+        assert_eq!(a, b);
+        assert!(a.ends_with('\n'));
+    }
+
+    #[test]
+    fn no_null_tokens_leak() {
+        for (name, schema) in emit_all() {
+            let text = render(&schema);
+            assert!(
+                !text.contains(": null,"),
+                "{name} leaked a null vocabulary token"
+            );
+        }
+    }
+}

--- a/tools/cnf-runner/src/validate.rs
+++ b/tools/cnf-runner/src/validate.rs
@@ -1,0 +1,1065 @@
+//! Cross-artifact validation — the schedule's machine gates, generalized
+//! from ECC's coverage-guard discipline: id uniqueness, SM-operation
+//! resolution, spec-ref link checks, binding completeness, `verified_by`
+//! resolution, corpus integrity, ambiguity/option resolution,
+//! capability-vs-tier consistency, reference/sentinel grammar,
+//! decision-table literals, and vocabulary drift.
+//!
+//! Every check is pure over the loaded [`ArtifactSet`] (+ the vendored spec
+//! tree for the two resolution checks); every violation is one typed
+//! [`Finding`].
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use crate::artifacts::ArtifactSet;
+use crate::ids::{CaseId, CorpusKey, SmOperationRef, ViewName};
+use crate::literal::{Literal, ViolationRef};
+use crate::load::LoadError;
+use crate::model::assertion::{Assertion, EquivalentTarget, assertion_refs};
+use crate::model::case::{CaseCore, ExpectSpec, MatrixCell, Parameters};
+use crate::refgrammar::{CaptureField, TimeExpr, ValueRef};
+use crate::vocab::{CaseKind, Iteration, OutcomeKind};
+
+/// The check taxonomy (one id per machine gate).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum CheckId {
+    /// File-level load failure (YAML, schema, or typed parse).
+    Load,
+    /// Case-id uniqueness.
+    IdUniqueness,
+    /// Kind-conditional structure + assertion/parameter invariants.
+    KindShape,
+    /// `${…}` reference resolution + sentinel discipline.
+    ReferenceGrammar,
+    /// Decision-table literals + violation categories.
+    LiteralGrammar,
+    /// `sm_operation` (and flow `call:`) resolution against the vendored SM.
+    SmOperation,
+    /// `spec_refs` resolution against the vendored spec tree.
+    SpecRef,
+    /// Every used outcome kind mapped, every used capture wired, per binding.
+    BindingCompleteness,
+    /// `verified_by` targets exist.
+    VerifiedBy,
+    /// Corpus keys/views/sources exist; entry invariants hold.
+    CorpusIntegrity,
+    /// `ambiguities` ids resolve in the register.
+    AmbiguityLink,
+    /// `option:` tags resolve to an `option_select` register entry.
+    OptionTag,
+    /// Capabilities exist in the matrix; profile tiers consistent.
+    CapabilityTier,
+    /// Published vocabulary files drift from the compiled enums.
+    VocabDrift,
+}
+
+impl CheckId {
+    /// Stable token for reports/tests.
+    #[must_use]
+    pub fn token(self) -> &'static str {
+        match self {
+            Self::Load => "load",
+            Self::IdUniqueness => "id-uniqueness",
+            Self::KindShape => "kind-shape",
+            Self::ReferenceGrammar => "reference-grammar",
+            Self::LiteralGrammar => "literal-grammar",
+            Self::SmOperation => "sm-operation",
+            Self::SpecRef => "spec-ref",
+            Self::BindingCompleteness => "binding-completeness",
+            Self::VerifiedBy => "verified-by",
+            Self::CorpusIntegrity => "corpus-integrity",
+            Self::AmbiguityLink => "ambiguity-link",
+            Self::OptionTag => "option-tag",
+            Self::CapabilityTier => "capability-tier",
+            Self::VocabDrift => "vocab-drift",
+        }
+    }
+}
+
+/// One violation.
+#[derive(Debug, Clone)]
+pub struct Finding {
+    pub check: CheckId,
+    /// The offending artifact (file path or case id).
+    pub artifact: String,
+    pub message: String,
+}
+
+impl std::fmt::Display for Finding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "[{}] {}: {}",
+            self.check.token(),
+            self.artifact,
+            self.message
+        )
+    }
+}
+
+/// Validation context: the artifact set + optional vendored-spec root
+/// (`docs/specs/openehr`) enabling the two resolution checks.
+#[derive(Debug)]
+pub struct Context<'a> {
+    pub set: &'a ArtifactSet,
+    pub load_errors: &'a [LoadError],
+    pub spec_root: Option<&'a Path>,
+}
+
+/// Run every gate; findings in check order.
+#[must_use]
+pub fn validate(ctx: &Context<'_>) -> Vec<Finding> {
+    let mut findings = Vec::new();
+
+    for e in ctx.load_errors {
+        findings.push(Finding {
+            check: CheckId::Load,
+            artifact: e.path().display().to_string(),
+            message: e.detail(),
+        });
+    }
+
+    check_id_uniqueness(ctx.set, &mut findings);
+    for (_path, case) in &ctx.set.cases {
+        let who = case.id.to_string();
+        check_kind_shape(case, &who, &mut findings);
+        check_references(case, &who, ctx.set, &mut findings);
+        check_literals(case, &who, &mut findings);
+        check_capability_tier(case, &who, ctx.set, &mut findings);
+        check_links(case, &who, ctx.set, &mut findings);
+        if let Some(spec_root) = ctx.spec_root {
+            check_sm_operations(case, &who, spec_root, &mut findings);
+            check_spec_refs(case, &who, spec_root, &mut findings);
+        }
+    }
+    check_binding_completeness(ctx.set, &mut findings);
+    if let Some(spec_root) = ctx.spec_root {
+        for (path, binding) in &ctx.set.bindings {
+            let who = path.display().to_string();
+            resolve_sm_operation(&binding.sm_operation, &who, spec_root, &mut findings);
+        }
+    }
+    check_corpus_integrity(ctx.set, &mut findings);
+    check_vocab_drift(ctx.set, &mut findings);
+
+    findings
+}
+
+fn push(findings: &mut Vec<Finding>, check: CheckId, artifact: &str, message: String) {
+    findings.push(Finding {
+        check,
+        artifact: artifact.to_owned(),
+        message,
+    });
+}
+
+// ── id uniqueness ───────────────────────────────────────────────────────────
+
+fn check_id_uniqueness(set: &ArtifactSet, findings: &mut Vec<Finding>) {
+    let mut seen: BTreeSet<&str> = BTreeSet::new();
+    for (path, case) in &set.cases {
+        if !seen.insert(case.id.as_str()) {
+            push(
+                findings,
+                CheckId::IdUniqueness,
+                &path.display().to_string(),
+                format!("case id {} is declared more than once", case.id),
+            );
+        }
+    }
+}
+
+// ── kind shape + structural invariants ──────────────────────────────────────
+
+fn check_kind_shape(case: &CaseCore, who: &str, findings: &mut Vec<Finding>) {
+    check_kind_blocks(case, who, findings);
+    check_parameters_shape(case, who, findings);
+    check_assertion_shape(case, who, findings);
+    check_flow_shape(case, who, findings);
+    for guard in &case.guards {
+        if !guard.contains('—') && !guard.to_lowercase().contains("master") {
+            push(
+                findings,
+                CheckId::KindShape,
+                who,
+                format!("guard {guard:?} carries no spec citation"),
+            );
+        }
+    }
+}
+
+fn check_kind_blocks(case: &CaseCore, who: &str, findings: &mut Vec<Finding>) {
+    match case.kind {
+        CaseKind::Functional => {
+            if case.sm_operation.is_none() || case.flow.is_empty() {
+                push(
+                    findings,
+                    CheckId::KindShape,
+                    who,
+                    "functional case must carry sm_operation and a non-empty flow".to_owned(),
+                );
+            }
+            if case.decision_table.is_some() || case.constraint_context.is_some() {
+                push(
+                    findings,
+                    CheckId::KindShape,
+                    who,
+                    "functional case must not carry content blocks".to_owned(),
+                );
+            }
+        }
+        CaseKind::Content => {
+            if case.rm_class.is_none()
+                || case.constraint_context.is_none()
+                || case.decision_table.is_none()
+            {
+                push(
+                    findings,
+                    CheckId::KindShape,
+                    who,
+                    "content case must carry rm_class, constraint_context and decision_table"
+                        .to_owned(),
+                );
+            }
+        }
+    }
+}
+
+fn check_parameters_shape(case: &CaseCore, who: &str, findings: &mut Vec<Finding>) {
+    if let Some(parameters) = &case.parameters {
+        match (&parameters.matrix, &parameters.fixture_set) {
+            (Some(_), Some(_)) | (None, None) => push(
+                findings,
+                CheckId::KindShape,
+                who,
+                "parameters must carry exactly one of matrix | fixture_set".to_owned(),
+            ),
+            _ => {}
+        }
+        if let Some(matrix) = &parameters.matrix {
+            for (i, row) in matrix.rows.iter().enumerate() {
+                if row.len() != matrix.columns.len() {
+                    push(
+                        findings,
+                        CheckId::KindShape,
+                        who,
+                        format!(
+                            "matrix row {i} has {} cells for {} columns",
+                            row.len(),
+                            matrix.columns.len()
+                        ),
+                    );
+                }
+            }
+            let expected_col = matrix.columns.iter().position(|c| c == "expected");
+            if let Some(col) = expected_col {
+                for (i, row) in matrix.rows.iter().enumerate() {
+                    match row.get(col) {
+                        Some(MatrixCell::Literal(serde_json::Value::String(s)))
+                            if OutcomeKind::from_token(s).is_some() => {}
+                        _ => push(
+                            findings,
+                            CheckId::KindShape,
+                            who,
+                            format!("matrix row {i}: `expected` cell must be an outcome kind"),
+                        ),
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn check_assertion_shape(case: &CaseCore, who: &str, findings: &mut Vec<Finding>) {
+    let aggregate_needs_single_pass = case
+        .postconditions
+        .iter()
+        .chain(case.flow.iter().flat_map(|s| s.assertions.iter()))
+        .any(Assertion::is_aggregate);
+    if aggregate_needs_single_pass {
+        let single_pass = matches!(
+            case.parameters,
+            Some(Parameters {
+                iteration: Iteration::SinglePass,
+                ..
+            })
+        );
+        if !single_pass {
+            push(
+                findings,
+                CheckId::KindShape,
+                who,
+                "aggregate assertions require parameters.iteration: single_pass".to_owned(),
+            );
+        }
+    }
+
+    for assertion in case
+        .postconditions
+        .iter()
+        .chain(case.flow.iter().flat_map(|s| s.assertions.iter()))
+    {
+        if let Err(message) = assertion.check_invariants() {
+            push(findings, CheckId::KindShape, who, message);
+        }
+        if let Assertion::State { verified_by, .. } = assertion {
+            let verified = verified_by.is_some()
+                || !case.verified_by.is_empty()
+                || case.flow.iter().any(|s| !s.assertions.is_empty());
+            if !verified {
+                push(
+                    findings,
+                    CheckId::KindShape,
+                    who,
+                    "state assertion needs verified_by or an in-case verification step".to_owned(),
+                );
+            }
+        }
+    }
+}
+
+fn check_flow_shape(case: &CaseCore, who: &str, findings: &mut Vec<Finding>) {
+    let mut last_step = 0_u32;
+    for step in &case.flow {
+        if step.step <= last_step {
+            push(
+                findings,
+                CheckId::KindShape,
+                who,
+                format!(
+                    "flow step numbers must strictly increase (step {})",
+                    step.step
+                ),
+            );
+        }
+        last_step = step.step;
+        if matches!(step.expect, ExpectSpec::FixtureExpected)
+            && case
+                .parameters
+                .as_ref()
+                .is_none_or(|p| p.fixture_set.is_none())
+        {
+            push(
+                findings,
+                CheckId::KindShape,
+                who,
+                "expect: ${fixture.expected} requires parameters.fixture_set".to_owned(),
+            );
+        }
+        if let ExpectSpec::Kind(kind) = step.expect {
+            for (name, source) in step.captures() {
+                if source.outcome != kind {
+                    push(
+                        findings,
+                        CheckId::KindShape,
+                        who,
+                        format!(
+                            "capture {name} reads outcome `{}` but the step expects `{}`",
+                            source.outcome.token(),
+                            kind.token()
+                        ),
+                    );
+                }
+            }
+        }
+    }
+}
+
+// ── reference resolution ────────────────────────────────────────────────────
+
+fn matrix_columns(case: &CaseCore) -> Vec<&str> {
+    case.parameters
+        .as_ref()
+        .and_then(|p| p.matrix.as_ref())
+        .map(|m| m.columns.iter().map(String::as_str).collect())
+        .unwrap_or_default()
+}
+
+struct RefCtx<'a> {
+    columns: Vec<&'a str>,
+    has_fixtures: bool,
+    who: &'a str,
+    set: &'a ArtifactSet,
+}
+
+fn check_one_ref(
+    r: &ValueRef,
+    ctx: &RefCtx<'_>,
+    defined: &BTreeSet<String>,
+    findings: &mut Vec<Finding>,
+) {
+    let who = ctx.who;
+    match r {
+        ValueRef::Row(column) => {
+            if !ctx.columns.contains(&column.as_str()) {
+                push(
+                    findings,
+                    CheckId::ReferenceGrammar,
+                    who,
+                    format!("${{row.{column}}} names no matrix column"),
+                );
+            }
+        }
+        ValueRef::Fixture(_) | ValueRef::FixtureDataSet => {
+            if !ctx.has_fixtures {
+                push(
+                    findings,
+                    CheckId::ReferenceGrammar,
+                    who,
+                    "${fixture.*} reference without parameters.fixture_set".to_owned(),
+                );
+            }
+        }
+        ValueRef::Capture { name, optional } => {
+            if *optional {
+                push(
+                    findings,
+                    CheckId::ReferenceGrammar,
+                    who,
+                    format!("${{{name}?}} optional form is binding-template-only"),
+                );
+            } else if !defined.contains(name.as_str()) {
+                push(
+                    findings,
+                    CheckId::ReferenceGrammar,
+                    who,
+                    format!("${{{name}}} references no earlier capture or requires handle"),
+                );
+            }
+        }
+        ValueRef::DataSet { key, view } => {
+            check_ds_ref(key, view.as_ref(), who, ctx.set, findings);
+        }
+        ValueRef::Recipe(name) => {
+            let declared = ctx.set.corpus.as_ref().is_some_and(|(_, corpus)| {
+                corpus.entries().iter().any(|(_, e)| {
+                    e.recipes
+                        .as_deref()
+                        .unwrap_or_default()
+                        .iter()
+                        .any(|(n, _)| n == name)
+                        || e.generated_by.as_ref().is_some_and(|g| g.recipe == *name)
+                })
+            });
+            if !declared {
+                push(
+                    findings,
+                    CheckId::ReferenceGrammar,
+                    who,
+                    format!("${{recipe:{name}(row)}} is not declared in the corpus manifest"),
+                );
+            }
+        }
+        ValueRef::Time(expr) => {
+            let (a, b) = match expr {
+                TimeExpr::Before(t) | TimeExpr::After(t) => (t, None),
+                TimeExpr::Between(t1, t2) => (t1, Some(t2)),
+            };
+            for t in std::iter::once(a).chain(b) {
+                if !defined.contains(t.as_str()) {
+                    push(
+                        findings,
+                        CheckId::ReferenceGrammar,
+                        who,
+                        format!("${{time:…({t})}} references no earlier capture"),
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn check_references(case: &CaseCore, who: &str, set: &ArtifactSet, findings: &mut Vec<Finding>) {
+    let ctx = RefCtx {
+        columns: matrix_columns(case),
+        has_fixtures: case
+            .parameters
+            .as_ref()
+            .is_some_and(|p| p.fixture_set.is_some()),
+        who,
+        set,
+    };
+    let mut defined: BTreeSet<String> = case
+        .requires
+        .minted_handles()
+        .iter()
+        .map(ToString::to_string)
+        .collect();
+
+    for step in &case.flow {
+        // `with` executes before the step's captures exist ...
+        for (_, value) in step.with_entries() {
+            for r in value.refs() {
+                check_one_ref(r, &ctx, &defined, findings);
+            }
+        }
+        for (name, _source) in step.captures() {
+            defined.insert(name.to_string());
+        }
+        // ... while post-step assertions run after capture and may use them.
+        for assertion in &step.assertions {
+            for r in assertion_refs(assertion) {
+                check_one_ref(&r, &ctx, &defined, findings);
+            }
+        }
+    }
+    for assertion in &case.postconditions {
+        for r in assertion_refs(assertion) {
+            check_one_ref(&r, &ctx, &defined, findings);
+        }
+        if let Assertion::Equivalent {
+            to: EquivalentTarget::Committed,
+            ..
+        } = assertion
+        {
+            // `to: committed` needs something committed in-flow — a step that
+            // carried a payload.
+            if !case.flow.iter().any(|s| !s.with_entries().is_empty()) {
+                push(
+                    findings,
+                    CheckId::ReferenceGrammar,
+                    who,
+                    "equivalent to: committed, but no flow step commits a payload".to_owned(),
+                );
+            }
+        }
+    }
+
+    for key in case
+        .data_sets
+        .iter()
+        .chain(case.requires.templates.iter())
+        .chain(case.requires.commit.iter())
+        .chain(case.constraint_context.as_ref().map(|c| &c.template))
+    {
+        check_ds_ref(key, None, who, set, findings);
+    }
+}
+
+fn check_ds_ref(
+    key: &CorpusKey,
+    view: Option<&ViewName>,
+    who: &str,
+    set: &ArtifactSet,
+    findings: &mut Vec<Finding>,
+) {
+    let Some((_, corpus)) = &set.corpus else {
+        return;
+    };
+    match corpus.get(key) {
+        None => push(
+            findings,
+            CheckId::CorpusIntegrity,
+            who,
+            format!("corpus key {key} is not in the manifest"),
+        ),
+        Some(entry) => {
+            if let Some(view) = view
+                && entry.view(view).is_none()
+            {
+                push(
+                    findings,
+                    CheckId::CorpusIntegrity,
+                    who,
+                    format!("view {view} is not declared on corpus entry {key}"),
+                );
+            }
+        }
+    }
+}
+
+// ── literals ────────────────────────────────────────────────────────────────
+
+fn check_literals(case: &CaseCore, who: &str, findings: &mut Vec<Finding>) {
+    let Some(table) = &case.decision_table else {
+        return;
+    };
+    let violates_col = table.columns.iter().position(|c| c == "violates");
+    let expected_col = table.columns.iter().position(|c| c == "expected");
+    for (i, row) in table.rows.iter().enumerate() {
+        for (j, cell) in row.iter().enumerate() {
+            if Some(j) == violates_col {
+                match cell {
+                    serde_json::Value::Array(items) => {
+                        for item in items {
+                            match item.as_str().map(ViolationRef::parse) {
+                                Some(Ok(_)) => {}
+                                Some(Err(e)) => push(
+                                    findings,
+                                    CheckId::LiteralGrammar,
+                                    who,
+                                    format!("row {i}: {e}"),
+                                ),
+                                None => push(
+                                    findings,
+                                    CheckId::LiteralGrammar,
+                                    who,
+                                    format!("row {i}: violates entries must be strings"),
+                                ),
+                            }
+                        }
+                    }
+                    _ => push(
+                        findings,
+                        CheckId::LiteralGrammar,
+                        who,
+                        format!("row {i}: violates cell must be a list"),
+                    ),
+                }
+            } else if Some(j) == expected_col {
+                if !matches!(cell.as_str(), Some("accepted" | "rejected")) {
+                    push(
+                        findings,
+                        CheckId::LiteralGrammar,
+                        who,
+                        format!("row {i}: expected cell must be accepted | rejected"),
+                    );
+                }
+            } else if let Err(e) = Literal::from_cell(cell) {
+                push(
+                    findings,
+                    CheckId::LiteralGrammar,
+                    who,
+                    format!("row {i}: {e}"),
+                );
+            }
+        }
+    }
+}
+
+// ── capability / tier ───────────────────────────────────────────────────────
+
+fn check_capability_tier(
+    case: &CaseCore,
+    who: &str,
+    set: &ArtifactSet,
+    findings: &mut Vec<Finding>,
+) {
+    let Some((_, matrix)) = &set.matrix else {
+        return;
+    };
+    let mut tiers = BTreeSet::new();
+    for capability in case.capabilities.iter().chain(case.exercises.iter()) {
+        match matrix.get(capability) {
+            None => push(
+                findings,
+                CheckId::CapabilityTier,
+                who,
+                format!("capability {capability} is not in the capability matrix"),
+            ),
+            Some(entry) => {
+                if case.capabilities.contains(capability) {
+                    tiers.insert(entry.tier);
+                }
+            }
+        }
+    }
+    for tier in &case.profiles {
+        if !tiers.contains(tier) {
+            push(
+                findings,
+                CheckId::CapabilityTier,
+                who,
+                format!(
+                    "profiles lists {tier:?} but no verdict-bearing capability carries that tier"
+                ),
+            );
+        }
+    }
+    for tier in &tiers {
+        if !case.profiles.contains(tier) {
+            push(
+                findings,
+                CheckId::CapabilityTier,
+                who,
+                format!("capability tier {tier:?} is missing from profiles"),
+            );
+        }
+    }
+}
+
+// ── register links ──────────────────────────────────────────────────────────
+
+fn check_links(case: &CaseCore, who: &str, set: &ArtifactSet, findings: &mut Vec<Finding>) {
+    if let Some((_, register)) = &set.register {
+        for id in &case.ambiguities {
+            if register.get(id).is_none() {
+                push(
+                    findings,
+                    CheckId::AmbiguityLink,
+                    who,
+                    format!("{id} is not in the ambiguity register"),
+                );
+            }
+        }
+        if let Some(option) = &case.option
+            && !register.declares_option(option)
+        {
+            push(
+                findings,
+                CheckId::OptionTag,
+                who,
+                format!("option tag {option} is not declared by any option_select register entry"),
+            );
+        }
+    }
+    let ids: BTreeSet<&CaseId> = set.cases.iter().map(|(_, c)| &c.id).collect();
+    let assertion_targets = case
+        .postconditions
+        .iter()
+        .chain(case.flow.iter().flat_map(|s| s.assertions.iter()))
+        .filter_map(|a| match a {
+            Assertion::State {
+                verified_by: Some(target),
+                ..
+            } => Some(target),
+            _ => None,
+        });
+    for target in case.verified_by.iter().chain(assertion_targets) {
+        if !ids.contains(target) {
+            push(
+                findings,
+                CheckId::VerifiedBy,
+                who,
+                format!("verified_by target {target} does not exist"),
+            );
+        }
+    }
+}
+
+// ── SM + spec-ref resolution ────────────────────────────────────────────────
+
+fn sm_class_file(spec_root: &Path, interface: &str) -> PathBuf {
+    spec_root
+        .join("SM/docs/UML/classes")
+        .join(format!("{}.adoc", interface.to_lowercase()))
+}
+
+fn resolve_sm_operation(
+    op: &SmOperationRef,
+    who: &str,
+    spec_root: &Path,
+    findings: &mut Vec<Finding>,
+) {
+    let file = sm_class_file(spec_root, op.interface());
+    match std::fs::read_to_string(&file) {
+        Err(_) => push(
+            findings,
+            CheckId::SmOperation,
+            who,
+            format!(
+                "interface {} has no vendored SM class export ({})",
+                op.interface(),
+                file.display()
+            ),
+        ),
+        Ok(text) => {
+            if !text.contains(&format!("|*{}*", op.operation())) {
+                push(
+                    findings,
+                    CheckId::SmOperation,
+                    who,
+                    format!(
+                        "operation {op} is not defined by the vendored SM interface ({})",
+                        file.display()
+                    ),
+                );
+            }
+        }
+    }
+}
+
+fn check_sm_operations(case: &CaseCore, who: &str, spec_root: &Path, findings: &mut Vec<Finding>) {
+    let Some(anchor) = &case.sm_operation else {
+        return;
+    };
+    resolve_sm_operation(anchor, who, spec_root, findings);
+    for step in &case.flow {
+        let op = if step.call.contains('.') {
+            match SmOperationRef::parse(&step.call) {
+                Ok(op) => op,
+                Err(e) => {
+                    push(findings, CheckId::SmOperation, who, e.to_string());
+                    continue;
+                }
+            }
+        } else {
+            anchor.sibling(&step.call)
+        };
+        resolve_sm_operation(&op, who, spec_root, findings);
+    }
+}
+
+/// Component token → vendored directory.
+fn component_dir(token: &str) -> Option<&'static str> {
+    Some(match token {
+        "SM" => "SM",
+        "CNF" => "CNF",
+        "RM" => "RM",
+        "BASE" => "BASE",
+        "AM" => "AM",
+        "QUERY" => "QUERY",
+        "TERM" => "TERM",
+        "LANG" => "LANG",
+        "ITS-REST" => "ITS-REST",
+        "ITS-JSON" => "ITS-JSON",
+        "ITS-XML" => "ITS-XML",
+        _ => return None,
+    })
+}
+
+fn check_spec_refs(case: &CaseCore, who: &str, spec_root: &Path, findings: &mut Vec<Finding>) {
+    for citation in &case.spec_refs {
+        let mut tokens = citation.split_whitespace();
+        let Some(component) = tokens.next() else {
+            push(findings, CheckId::SpecRef, who, "empty spec_ref".to_owned());
+            continue;
+        };
+        let Some(dir) = component_dir(component) else {
+            push(
+                findings,
+                CheckId::SpecRef,
+                who,
+                format!("{citation:?}: unknown component {component:?}"),
+            );
+            continue;
+        };
+        let root = spec_root.join(dir);
+        if !root.is_dir() {
+            push(
+                findings,
+                CheckId::SpecRef,
+                who,
+                format!(
+                    "{citation:?}: vendored component dir {} missing",
+                    root.display()
+                ),
+            );
+            continue;
+        }
+        // The document token: the first token before the § section marker.
+        let doc_token = tokens.next().map(|t| t.trim_end_matches(',').to_owned());
+        let Some(doc_token) = doc_token.filter(|t| !t.starts_with('§')) else {
+            continue; // component-only citation: dir existence was the check
+        };
+        if !path_contains_token(&root, &doc_token.to_lowercase()) {
+            push(
+                findings,
+                CheckId::SpecRef,
+                who,
+                format!("{citation:?}: no vendored path under {dir} matches {doc_token:?}"),
+            );
+        }
+    }
+}
+
+/// Case-insensitive substring match of `token` against any path under `root`.
+fn path_contains_token(root: &Path, token: &str) -> bool {
+    let mut stack = vec![root.to_owned()];
+    while let Some(current) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&current) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let matches = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.to_lowercase().contains(token));
+            if matches {
+                return true;
+            }
+            if path.is_dir() {
+                stack.push(path);
+            }
+        }
+    }
+    false
+}
+
+// ── binding completeness ────────────────────────────────────────────────────
+
+fn check_binding_completeness(set: &ArtifactSet, findings: &mut Vec<Finding>) {
+    for (_, case) in &set.cases {
+        let Some(anchor) = &case.sm_operation else {
+            continue;
+        };
+        let who = case.id.to_string();
+        for step in &case.flow {
+            let op = if step.call.contains('.') {
+                match SmOperationRef::parse(&step.call) {
+                    Ok(op) => op,
+                    Err(_) => continue, // reported by the SM check
+                }
+            } else {
+                anchor.sibling(&step.call)
+            };
+            let bindings: Vec<_> = set
+                .bindings
+                .iter()
+                .filter(|(_, b)| b.sm_operation == op)
+                .collect();
+            if bindings.is_empty() {
+                push(
+                    findings,
+                    CheckId::BindingCompleteness,
+                    &who,
+                    format!("no binding declares operation {op}"),
+                );
+                continue;
+            }
+            // Kinds this step may observe: the fixed expectation, or every
+            // fixture-set `expected` kind when per-fixture.
+            let mut kinds: Vec<OutcomeKind> = Vec::new();
+            match step.expect {
+                ExpectSpec::Kind(kind) => kinds.push(kind),
+                ExpectSpec::FixtureExpected => {
+                    if let Some(fixtures) = case
+                        .parameters
+                        .as_ref()
+                        .and_then(|p| p.fixture_set.as_ref())
+                    {
+                        kinds.extend(fixtures.iter().map(|f| f.expected));
+                    }
+                }
+            }
+            let expected_column_kinds: Vec<OutcomeKind> = case
+                .parameters
+                .as_ref()
+                .and_then(|p| p.matrix.as_ref())
+                .map(|m| {
+                    let col = m.columns.iter().position(|c| c == "expected");
+                    col.map(|col| {
+                        m.rows
+                            .iter()
+                            .filter_map(|row| match row.get(col) {
+                                Some(MatrixCell::Literal(serde_json::Value::String(s))) => {
+                                    OutcomeKind::from_token(s)
+                                }
+                                _ => None,
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default()
+                })
+                .unwrap_or_default();
+            kinds.extend(expected_column_kinds);
+
+            for (path, binding) in bindings {
+                for kind in &kinds {
+                    if binding.outcome(*kind).is_none() {
+                        push(
+                            findings,
+                            CheckId::BindingCompleteness,
+                            &who,
+                            format!(
+                                "outcome kind `{}` on {op} is not mapped by {}",
+                                kind.token(),
+                                path.display()
+                            ),
+                        );
+                    }
+                }
+                for (name, source) in step.captures() {
+                    if let CaptureField::Field { name: field, .. } = &source.field
+                        && !binding.maps_capture(field)
+                    {
+                        push(
+                            findings,
+                            CheckId::BindingCompleteness,
+                            &who,
+                            format!(
+                                "capture {name} needs wire source `{field}` on {op}, not mapped by {}",
+                                path.display()
+                            ),
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ── corpus integrity ────────────────────────────────────────────────────────
+
+fn check_corpus_integrity(set: &ArtifactSet, findings: &mut Vec<Finding>) {
+    let Some((path, corpus)) = &set.corpus else {
+        return;
+    };
+    let who = path.display().to_string();
+    for (key, entry) in corpus.entries() {
+        if let Err(message) = entry.check_invariants() {
+            push(
+                findings,
+                CheckId::CorpusIntegrity,
+                &who,
+                format!("{key}: {message}"),
+            );
+        }
+        if let (Some(source), Some(dir)) = (&entry.source, &set.corpus_dir) {
+            let file = dir.join(source);
+            if !file.is_file() {
+                push(
+                    findings,
+                    CheckId::CorpusIntegrity,
+                    &who,
+                    format!("{key}: source {source} does not exist"),
+                );
+            }
+        }
+    }
+}
+
+// ── vocabulary drift ────────────────────────────────────────────────────────
+
+fn check_vocab_drift(set: &ArtifactSet, findings: &mut Vec<Finding>) {
+    if let Some((path, outcomes)) = &set.outcomes
+        && let Err(drift) = outcomes.check_against_enum()
+    {
+        for message in drift {
+            push(
+                findings,
+                CheckId::VocabDrift,
+                &path.display().to_string(),
+                message,
+            );
+        }
+    }
+    if let Some((path, selectors)) = &set.selectors
+        && let Err(drift) = selectors.check_against_enum()
+    {
+        for message in drift {
+            push(
+                findings,
+                CheckId::VocabDrift,
+                &path.display().to_string(),
+                message,
+            );
+        }
+    }
+    if let Some((path, matrix)) = &set.matrix
+        && let Err(drift) = matrix.check_tier_scoping()
+    {
+        for message in drift {
+            push(
+                findings,
+                CheckId::VocabDrift,
+                &path.display().to_string(),
+                message,
+            );
+        }
+    }
+    if let Some((path, register)) = &set.register {
+        for (id, entry) in register.entries() {
+            if let Err(message) = entry.check_invariants() {
+                push(
+                    findings,
+                    CheckId::VocabDrift,
+                    &path.display().to_string(),
+                    format!("{id}: {message}"),
+                );
+            }
+        }
+    }
+}

--- a/tools/cnf-runner/src/vocab.rs
+++ b/tools/cnf-runner/src/vocab.rs
@@ -1,0 +1,555 @@
+//! The closed vocabularies of the CNF 2.0 schedule.
+//!
+//! Every enum here is normative and extensible only by schedule release
+//! (CNF 2.0 artifact-set design; the outcome kinds carry the schedule
+//! language of `CNF platform_test_schedule master04/06/07`). A value outside
+//! these enums is unrepresentable in the typed model — the compile-time
+//! property the reference runner exists to demonstrate.
+
+use serde::{Deserialize, Serialize};
+
+/// Verdict class of an outcome kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutcomeClass {
+    /// The operation fulfilled its service contract.
+    Success,
+    /// The operation was refused for the reason the kind names.
+    Error,
+}
+
+macro_rules! outcome_kinds {
+    ($( $(#[$doc:meta])* ($variant:ident, $token:literal, $class:ident) ),+ $(,)?) => {
+        /// A protocol-neutral outcome kind — the only expectation language a
+        /// case core may speak (wire realization lives in the operation
+        /// bindings). Closed enum; extension only by schedule release.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+        pub enum OutcomeKind {
+            $( $(#[$doc])* #[serde(rename = $token)] $variant, )+
+        }
+
+        impl OutcomeKind {
+            /// All kinds, in schedule order (the `vocab/outcomes.yaml` order).
+            pub const ALL: &'static [OutcomeKind] = &[ $(OutcomeKind::$variant,)+ ];
+
+            /// The kind's wire-independent token (`created`, `not_found`, …).
+            #[must_use]
+            pub fn token(self) -> &'static str {
+                match self { $( OutcomeKind::$variant => $token, )+ }
+            }
+
+            /// Success or error class.
+            #[must_use]
+            pub fn class(self) -> OutcomeClass {
+                match self { $( OutcomeKind::$variant => OutcomeClass::$class, )+ }
+            }
+
+            /// Parse a token.
+            #[must_use]
+            pub fn from_token(token: &str) -> Option<Self> {
+                match token { $( $token => Some(OutcomeKind::$variant), )+ _ => None }
+            }
+        }
+    };
+}
+
+outcome_kinds! {
+    /// New resource exists ("positive response associated to the successful creation").
+    (Created, "created", Success),
+    /// Read/query succeeded with content.
+    (Ok, "ok", Success),
+    /// Fulfilled with no content (e.g. composition logically deleted at the requested time).
+    (OkEmpty, "ok_empty", Success),
+    /// New version of an existing resource created.
+    (Updated, "updated", Success),
+    /// Logical delete performed (a new VERSION, `lifecycle_state = openehr::523|deleted|`).
+    (Deleted, "deleted", Success),
+    /// Definition stored (stored-query PUT — wire 200, not 201).
+    (Stored, "stored", Success),
+    /// Duplicate identity ("an EHR with the provided `ehr_id` … should be unique"; duplicate `template_id`).
+    (AlreadyExists, "already_exists", Error),
+    /// Target does not exist ("EHR with `<ehr_id>` does not exist").
+    (NotFound, "not_found", Error),
+    /// `preceding_version_uid` does not exist.
+    (VersionNotFound, "version_not_found", Error),
+    /// Version precondition evaluated false (stale `preceding_version_uid`).
+    (PreconditionFailed, "precondition_failed", Error),
+    /// Required version precondition absent.
+    (PreconditionMissing, "precondition_missing", Error),
+    /// Semantically invalid content ("information about the errors in the provided COMPOSITION").
+    (ValidationFailed, "validation_failed", Error),
+    /// Referenced OPT not on the server ("information about the non-existent OPT").
+    (TemplateNotFound, "template_not_found", Error),
+    /// Content commits against a different `template_id` than the versioned object.
+    (TemplateMismatch, "template_mismatch", Error),
+    /// Simplified-format commit without template identification.
+    (MissingTemplateId, "missing_template_id", Error),
+    /// Delete of an already-deleted version.
+    (AlreadyDeleted, "already_deleted", Error),
+    /// Other uniqueness/state conflict.
+    (Conflict, "conflict", Error),
+    /// No representation satisfies `Accept`.
+    (NotAcceptable, "not_acceptable", Error),
+    /// Payload media type unsupported.
+    (UnsupportedMedia, "unsupported_media", Error),
+    /// Malformed/unprocessable AQL.
+    (InvalidQuery, "invalid_query", Error),
+    /// Server aborted at max execution time.
+    (Timeout, "timeout", Error),
+}
+
+/// Which optional case-core blocks are meaningful.
+///
+/// The schedule defines three kinds (`functional | content | performance`);
+/// the performance case-core schema is a separate artifact revision (this
+/// crate's W7 scope), so the assertion-machinery model closes over the two
+/// kinds it validates. // TODO: add `performance` with the §8.14 workload
+/// blocks when the performance schedule lands (W7, #202).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CaseKind {
+    /// SM-operation flow case.
+    Functional,
+    /// Template-parameterized decision-table case (one executor serves both:
+    /// a content row is a generate→commit→expect functional execution).
+    Content,
+}
+
+/// Case lifecycle status. Ids are never reused; a retired case keeps its id.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CaseStatus {
+    /// In force.
+    #[default]
+    Active,
+    /// Kept for id-permanence only; never selected.
+    Retired,
+    /// Not yet in force; validated but never verdict-bearing.
+    Draft,
+}
+
+/// The schedule component a case belongs to (the chapter taxonomy).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum Component {
+    Ehr,
+    EhrComposition,
+    EhrContribution,
+    EhrDirectory,
+    #[serde(rename = "DEFINITION_ADL14")]
+    DefinitionAdl14,
+    #[serde(rename = "DEFINITION_ADL2")]
+    DefinitionAdl2,
+    DefinitionQuery,
+    Query,
+    Demographic,
+    Admin,
+    Messaging,
+    Content,
+    SimplifiedFormats,
+    Performance,
+}
+
+/// A capability family (the certificate's rating dimensions).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Family {
+    /// The platform (CDR) profile family: CORE/STANDARD/OPTIONS.
+    Platform,
+    /// The proposed Enterprise extension: D/M/X.
+    Enterprise,
+    /// The Security & Privacy family: SEC-BASIC (higher rungs are future SEC work).
+    Security,
+}
+
+/// A family-scoped profile tier. Each tier knows its family so a
+/// capability-matrix row declaring a foreign tier is a typed error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum Tier {
+    #[serde(rename = "CORE")]
+    Core,
+    #[serde(rename = "STANDARD")]
+    Standard,
+    #[serde(rename = "OPTIONS")]
+    Options,
+    #[serde(rename = "SEC-BASIC")]
+    SecBasic,
+    #[serde(rename = "D")]
+    EnterpriseD,
+    #[serde(rename = "M")]
+    EnterpriseM,
+    #[serde(rename = "X")]
+    EnterpriseX,
+}
+
+impl Tier {
+    /// The family this tier is scoped to.
+    #[must_use]
+    pub fn family(self) -> Family {
+        match self {
+            Tier::Core | Tier::Standard | Tier::Options => Family::Platform,
+            Tier::SecBasic => Family::Security,
+            Tier::EnterpriseD | Tier::EnterpriseM | Tier::EnterpriseX => Family::Enterprise,
+        }
+    }
+}
+
+/// The machine-readable handling class of an ambiguity-register entry — the
+/// pipeline branches on this (closed enum).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Disposition {
+    /// Assert loosely (e.g. AMB-1: at most a `message` string).
+    LooseAssert,
+    /// Handling encoded directly in bindings/cases.
+    FixedHandling,
+    /// Sibling cases carry `option:` tags; the ICS `options` declaration selects.
+    OptionSelect,
+    /// Verdicts reported, never gating.
+    ReportOnly,
+    /// No normative cases; statement-declared behaviour only.
+    StatementDeclared,
+    /// Editorial defect in the schedule text itself.
+    Editorial,
+}
+
+/// A wire format role (the §8.7 format axes; media types per the ITS-REST
+/// `Accept_*`/`ContentType_*` parameter files).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum FormatName {
+    #[serde(rename = "canonical-json")]
+    CanonicalJson,
+    #[serde(rename = "canonical-xml")]
+    CanonicalXml,
+    #[serde(rename = "wt-flat")]
+    WtFlat,
+    #[serde(rename = "wt-structured")]
+    WtStructured,
+    /// The Web Template itself (`application/openehr.wt+json`, template GET only).
+    #[serde(rename = "wt")]
+    Wt,
+}
+
+/// A corpus payload format — the wire roles plus the template-source form.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CorpusFormat {
+    #[serde(rename = "canonical-json")]
+    CanonicalJson,
+    #[serde(rename = "canonical-xml")]
+    CanonicalXml,
+    #[serde(rename = "wt-flat")]
+    WtFlat,
+    #[serde(rename = "wt-structured")]
+    WtStructured,
+    /// An ADL 1.4 operational template (OPT XML).
+    #[serde(rename = "opt-xml")]
+    OptXml,
+}
+
+/// HTTP method of a binding request (the ITS-REST realization layer).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum HttpMethod {
+    Get,
+    Post,
+    Put,
+    Delete,
+    Head,
+}
+
+/// Parameter-iteration law (`CNF platform_test_schedule master04` iteration
+/// semantics: "the pre-conditions and post-conditions apply to the run for X").
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Iteration {
+    /// The master04 law: the whole `requires` block re-established per row.
+    ResetPerRow,
+    /// Rows execute against one shared server state — required when an
+    /// aggregate postcondition spans rows.
+    SinglePass,
+}
+
+/// The `requires.server` precondition ("The server should be empty (no EHRs,
+/// no commits, no OPTs)" — CNF master06).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ServerState {
+    Empty,
+    Any,
+}
+
+/// Adjudicated fixture verdict in the corpus manifest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FixtureVerdict {
+    Valid,
+    Invalid,
+}
+
+/// Runtime placeholder policy for a corpus fixture (the Robot corpus's
+/// `__AUTO-GENRATED-BY-TEST__` convention, formalized).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PlaceholderPolicy {
+    /// The runner substitutes a fresh random value per use.
+    #[serde(rename = "runtime-random")]
+    RuntimeRandom,
+}
+
+/// A named ignore-set the `equivalent` assertion may resolve
+/// (normative per operation/format overlay, never runner-chosen).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IgnoreSetName {
+    /// The operation's server-assigned paths — enumerated per binding.
+    ServerAssigned,
+    /// The simplified-formats ctx defaulting set — enumerated once in
+    /// `vocab/selectors.yaml` (ITS-REST `simplified_formats` master06 §ctx defaults).
+    CtxDefaults,
+}
+
+/// Spec-component keys of the `applies` version-applicability map.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SpecComponent {
+    Rm,
+    Base,
+    Am,
+    Aql,
+    ItsRest,
+    Term,
+}
+
+/// The RM `change_type` values the schedule asserts
+/// (`RM common §change_control` — `VERSION.commit_audit.change_type`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum ChangeType {
+    Create,
+    Modify,
+    Deleted,
+}
+
+/// AQL `RESULT_SET` comparison mode (`match:` of the `result_set` assertion).
+/// `Set` is bag (multiset) equality — duplicate rows significant, AQL being
+/// bag-semantics absent DISTINCT (QUERY `master03-syntax.adoc` §DISTINCT).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ResultSetMatch {
+    /// Legal only when the query totally orders the expected rows
+    /// (QUERY master03 §ORDER BY: absent ORDER BY, ordering is undefined).
+    Ordered,
+    /// Bag equality.
+    Set,
+    /// Row count only.
+    Count,
+    /// Every expected row appears (bag-wise); extra rows permitted.
+    Contains,
+}
+
+/// The ITS a binding realizes. Closed to the REST ITS until another ITS
+/// binding layer is registered by schedule release.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ItsName {
+    #[serde(rename = "its-rest")]
+    ItsRest,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn outcome_tokens_round_trip() {
+        for kind in OutcomeKind::ALL {
+            assert_eq!(OutcomeKind::from_token(kind.token()), Some(*kind));
+        }
+        assert_eq!(OutcomeKind::ALL.len(), 21);
+        assert_eq!(OutcomeKind::Created.class(), OutcomeClass::Success);
+        assert_eq!(OutcomeKind::Timeout.class(), OutcomeClass::Error);
+    }
+
+    #[test]
+    fn tier_families() {
+        assert_eq!(Tier::Core.family(), Family::Platform);
+        assert_eq!(Tier::SecBasic.family(), Family::Security);
+        assert_eq!(Tier::EnterpriseD.family(), Family::Enterprise);
+    }
+
+    #[test]
+    fn serde_tokens() {
+        let kind: OutcomeKind =
+            serde_json::from_value(serde_json::json!("already_exists")).unwrap();
+        assert_eq!(kind, OutcomeKind::AlreadyExists);
+        let tier: Tier = serde_json::from_value(serde_json::json!("SEC-BASIC")).unwrap();
+        assert_eq!(tier, Tier::SecBasic);
+        let comp: Component =
+            serde_json::from_value(serde_json::json!("DEFINITION_ADL14")).unwrap();
+        assert_eq!(comp, Component::DefinitionAdl14);
+        let fmt: FormatName = serde_json::from_value(serde_json::json!("wt-flat")).unwrap();
+        assert_eq!(fmt, FormatName::WtFlat);
+    }
+}
+
+impl CaseKind {
+    /// All variants, in vocabulary order (schema emission derives from this).
+    pub const ALL: &'static [CaseKind] = &[CaseKind::Functional, CaseKind::Content];
+}
+
+impl CaseStatus {
+    /// All variants, in vocabulary order (schema emission derives from this).
+    pub const ALL: &'static [CaseStatus] =
+        &[CaseStatus::Active, CaseStatus::Retired, CaseStatus::Draft];
+}
+
+impl Component {
+    /// All variants, in vocabulary order (schema emission derives from this).
+    pub const ALL: &'static [Component] = &[
+        Component::Ehr,
+        Component::EhrComposition,
+        Component::EhrContribution,
+        Component::EhrDirectory,
+        Component::DefinitionAdl14,
+        Component::DefinitionAdl2,
+        Component::DefinitionQuery,
+        Component::Query,
+        Component::Demographic,
+        Component::Admin,
+        Component::Messaging,
+        Component::Content,
+        Component::SimplifiedFormats,
+        Component::Performance,
+    ];
+}
+
+impl Family {
+    /// All variants, in vocabulary order (schema emission derives from this).
+    pub const ALL: &'static [Family] = &[Family::Platform, Family::Enterprise, Family::Security];
+}
+
+impl Tier {
+    /// All variants, in vocabulary order (schema emission derives from this).
+    pub const ALL: &'static [Tier] = &[
+        Tier::Core,
+        Tier::Standard,
+        Tier::Options,
+        Tier::SecBasic,
+        Tier::EnterpriseD,
+        Tier::EnterpriseM,
+        Tier::EnterpriseX,
+    ];
+}
+
+impl Disposition {
+    /// All variants, in vocabulary order (schema emission derives from this).
+    pub const ALL: &'static [Disposition] = &[
+        Disposition::LooseAssert,
+        Disposition::FixedHandling,
+        Disposition::OptionSelect,
+        Disposition::ReportOnly,
+        Disposition::StatementDeclared,
+        Disposition::Editorial,
+    ];
+}
+
+impl FormatName {
+    /// All variants, in vocabulary order (schema emission derives from this).
+    pub const ALL: &'static [FormatName] = &[
+        FormatName::CanonicalJson,
+        FormatName::CanonicalXml,
+        FormatName::WtFlat,
+        FormatName::WtStructured,
+        FormatName::Wt,
+    ];
+}
+
+impl CorpusFormat {
+    /// All variants, in vocabulary order (schema emission derives from this).
+    pub const ALL: &'static [CorpusFormat] = &[
+        CorpusFormat::CanonicalJson,
+        CorpusFormat::CanonicalXml,
+        CorpusFormat::WtFlat,
+        CorpusFormat::WtStructured,
+        CorpusFormat::OptXml,
+    ];
+}
+
+impl HttpMethod {
+    /// All variants, in vocabulary order (schema emission derives from this).
+    pub const ALL: &'static [HttpMethod] = &[
+        HttpMethod::Get,
+        HttpMethod::Post,
+        HttpMethod::Put,
+        HttpMethod::Delete,
+        HttpMethod::Head,
+    ];
+}
+
+impl Iteration {
+    /// All variants, in vocabulary order (schema emission derives from this).
+    pub const ALL: &'static [Iteration] = &[Iteration::ResetPerRow, Iteration::SinglePass];
+}
+
+impl ServerState {
+    /// All variants, in vocabulary order (schema emission derives from this).
+    pub const ALL: &'static [ServerState] = &[ServerState::Empty, ServerState::Any];
+}
+
+impl FixtureVerdict {
+    /// All variants, in vocabulary order (schema emission derives from this).
+    pub const ALL: &'static [FixtureVerdict] = &[FixtureVerdict::Valid, FixtureVerdict::Invalid];
+}
+
+impl PlaceholderPolicy {
+    /// All variants, in vocabulary order (schema emission derives from this).
+    pub const ALL: &'static [PlaceholderPolicy] = &[PlaceholderPolicy::RuntimeRandom];
+}
+
+impl SpecComponent {
+    /// All variants, in vocabulary order (schema emission derives from this).
+    pub const ALL: &'static [SpecComponent] = &[
+        SpecComponent::Rm,
+        SpecComponent::Base,
+        SpecComponent::Am,
+        SpecComponent::Aql,
+        SpecComponent::ItsRest,
+        SpecComponent::Term,
+    ];
+}
+
+impl ChangeType {
+    /// All variants, in vocabulary order (schema emission derives from this).
+    pub const ALL: &'static [ChangeType] =
+        &[ChangeType::Create, ChangeType::Modify, ChangeType::Deleted];
+}
+
+impl ResultSetMatch {
+    /// All variants, in vocabulary order (schema emission derives from this).
+    pub const ALL: &'static [ResultSetMatch] = &[
+        ResultSetMatch::Ordered,
+        ResultSetMatch::Set,
+        ResultSetMatch::Count,
+        ResultSetMatch::Contains,
+    ];
+}
+
+impl ItsName {
+    /// All variants, in vocabulary order (schema emission derives from this).
+    pub const ALL: &'static [ItsName] = &[ItsName::ItsRest];
+}
+
+#[cfg(test)]
+#[allow(clippy::panic)] // test assertions
+mod all_consts_tests {
+    use super::*;
+
+    /// Every `ALL` list is exhaustive: a match over the enum with no wildcard
+    /// would fail to compile on a new variant, and this test pins the counts
+    /// so schema emission can trust the lists.
+    #[test]
+    fn all_lists_are_exhaustive() {
+        assert_eq!(CaseKind::ALL.len(), 2);
+        assert_eq!(Component::ALL.len(), 14);
+        assert_eq!(Tier::ALL.len(), 7);
+        assert_eq!(Disposition::ALL.len(), 6);
+        assert_eq!(FormatName::ALL.len(), 5);
+        assert_eq!(CorpusFormat::ALL.len(), 5);
+    }
+}

--- a/tools/cnf-runner/tests/artifact_gates.rs
+++ b/tools/cnf-runner/tests/artifact_gates.rs
@@ -1,0 +1,67 @@
+//! The production artifact tree (`artifacts/`) passes every machine gate —
+//! the eight pilot encodings plus their `verified_by` targets, validated
+//! against the vendored spec tree.
+#![allow(clippy::panic, clippy::expect_used)] // test assertions/fixtures
+
+use cnf_runner::artifacts::load_root;
+use cnf_runner::validate::{Context, validate};
+
+fn repo_root() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("repo root")
+        .to_owned()
+}
+
+#[test]
+fn pilot_world_is_clean_under_all_gates() {
+    let crate_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let specs = repo_root().join("docs/specs/openehr");
+    assert!(
+        specs.is_dir(),
+        "vendored spec tree missing at {}",
+        specs.display()
+    );
+
+    let loaded = load_root(&crate_dir.join("artifacts")).expect("schema compilation");
+    let findings = validate(&Context {
+        set: &loaded.set,
+        load_errors: &loaded.errors,
+        spec_root: Some(&specs),
+    });
+    assert!(
+        findings.is_empty(),
+        "the artifact tree must be clean, found:\n{}",
+        findings
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+
+    let ids: Vec<&str> = loaded
+        .set
+        .cases
+        .iter()
+        .map(|(_, c)| c.id.as_str())
+        .collect();
+    for pilot in [
+        "I_EHR_SERVICE.create_ehr-main",
+        "I_EHR_SERVICE.create_ehr-same_ehr_twice",
+        "I_DEFINITION_ADL14.upload_opt-invalid_opt",
+        "I_EHR_COMPOSITION.update_composition-event",
+        "CONT-DV_QUANTITY-validate_property_units_mag",
+        "SF-FLAT-commit_roundtrip_ctx_defaults",
+        "I_QUERY_SERVICE.execute_ad_hoc_query-where_magnitude",
+        "I_EHR_CONTRIBUTION.commit_contribution-valid_invalid_compositions",
+        "I_EHR_STATUS.get_ehr_status-get_by_ehr_id",
+        "I_DEFINITION_ADL14.get_opts-retrieve_all_no_opts",
+    ] {
+        assert!(
+            ids.contains(&pilot),
+            "pilot {pilot} missing from the schedule"
+        );
+    }
+    assert!(loaded.set.bindings.len() >= 10, "binding set shrank");
+}

--- a/tools/cnf-runner/tests/defect_rejection.rs
+++ b/tools/cnf-runner/tests/defect_rejection.rs
@@ -1,0 +1,229 @@
+//! Every seeded-defect fixture is rejected with the expected gate — the
+//! validator's negative battery (one fixture per machine gate, schema-level
+//! through cross-artifact).
+#![allow(clippy::panic, clippy::expect_used)] // test assertions/fixtures
+
+use cnf_runner::artifacts::load_root;
+use cnf_runner::validate::{CheckId, Context, validate};
+
+/// (fixture file, overlay destination inside the copied world, expected gate)
+const DEFECTS: &[(&str, &str, &str)] = &[
+    // JSON-Schema-level rejections (the hard file-validation requirement)
+    ("case-unknown-field.yaml", "schedule/zz-defect.yaml", "load"),
+    (
+        "case-bad-outcome-kind.yaml",
+        "schedule/zz-defect.yaml",
+        "load",
+    ),
+    ("case-bad-kind.yaml", "schedule/zz-defect.yaml", "load"),
+    (
+        "binding-bad-status.yaml",
+        "bindings/its-rest/zz-defect.yaml",
+        "load",
+    ),
+    (
+        "binding-unknown-outcome-key.yaml",
+        "bindings/its-rest/zz-defect.yaml",
+        "load",
+    ),
+    (
+        "register-bad-disposition.yaml",
+        "registers/ambiguities.yaml",
+        "load",
+    ),
+    (
+        "register-option-select-without-options.yaml",
+        "registers/ambiguities.yaml",
+        "load",
+    ),
+    (
+        "corpus-missing-provenance.yaml",
+        "corpus/MANIFEST.yaml",
+        "load",
+    ),
+    (
+        "corpus-invalid-without-defect.yaml",
+        "corpus/MANIFEST.yaml",
+        "load",
+    ),
+    (
+        "matrix-bad-tier.yaml",
+        "vocab/capability_matrix.yaml",
+        "load",
+    ),
+    ("outcomes-missing-kind.yaml", "vocab/outcomes.yaml", "load"),
+    // typed-model rejections
+    ("case-bad-ref-form.yaml", "schedule/zz-defect.yaml", "load"),
+    (
+        "case-bad-capture-source.yaml",
+        "schedule/zz-defect.yaml",
+        "load",
+    ),
+    (
+        "case-duplicate-yaml-key.yaml",
+        "schedule/zz-defect.yaml",
+        "load",
+    ),
+    // cross-artifact rejections
+    (
+        "case-duplicate-id.yaml",
+        "schedule/zz-defect.yaml",
+        "id-uniqueness",
+    ),
+    (
+        "case-unresolved-sm-op.yaml",
+        "schedule/zz-defect.yaml",
+        "sm-operation",
+    ),
+    (
+        "case-bad-spec-ref.yaml",
+        "schedule/zz-defect.yaml",
+        "spec-ref",
+    ),
+    (
+        "case-unmapped-outcome.yaml",
+        "schedule/zz-defect.yaml",
+        "binding-completeness",
+    ),
+    (
+        "case-unmapped-capture.yaml",
+        "schedule/zz-defect.yaml",
+        "binding-completeness",
+    ),
+    (
+        "case-unresolved-verified-by.yaml",
+        "schedule/zz-defect.yaml",
+        "verified-by",
+    ),
+    (
+        "case-missing-corpus-key.yaml",
+        "schedule/zz-defect.yaml",
+        "corpus-integrity",
+    ),
+    (
+        "case-missing-view.yaml",
+        "schedule/zz-defect.yaml",
+        "corpus-integrity",
+    ),
+    (
+        "case-unresolved-ambiguity.yaml",
+        "schedule/zz-defect.yaml",
+        "ambiguity-link",
+    ),
+    (
+        "case-unresolved-option.yaml",
+        "schedule/zz-defect.yaml",
+        "option-tag",
+    ),
+    (
+        "case-unknown-capability.yaml",
+        "schedule/zz-defect.yaml",
+        "capability-tier",
+    ),
+    (
+        "case-profile-tier-mismatch.yaml",
+        "schedule/zz-defect.yaml",
+        "capability-tier",
+    ),
+    (
+        "case-aggregate-without-single-pass.yaml",
+        "schedule/zz-defect.yaml",
+        "kind-shape",
+    ),
+    (
+        "case-two-field-predicates.yaml",
+        "schedule/zz-defect.yaml",
+        "kind-shape",
+    ),
+    (
+        "case-undefined-capture-ref.yaml",
+        "schedule/zz-defect.yaml",
+        "reference-grammar",
+    ),
+    (
+        "case-bad-literal.yaml",
+        "schedule/zz-defect.yaml",
+        "literal-grammar",
+    ),
+    (
+        "corpus-missing-source.yaml",
+        "corpus/MANIFEST.yaml",
+        "corpus-integrity",
+    ),
+    (
+        "outcomes-wrong-class.yaml",
+        "vocab/outcomes.yaml",
+        "vocab-drift",
+    ),
+];
+
+fn copy_tree(from: &std::path::Path, to: &std::path::Path) {
+    std::fs::create_dir_all(to).expect("mkdir");
+    for entry in std::fs::read_dir(from).expect("read_dir") {
+        let entry = entry.expect("entry");
+        let target = to.join(entry.file_name());
+        if entry.path().is_dir() {
+            copy_tree(&entry.path(), &target);
+        } else {
+            std::fs::copy(entry.path(), &target).expect("copy");
+        }
+    }
+}
+
+#[test]
+fn every_seeded_defect_is_rejected_by_its_gate() {
+    let crate_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let specs = crate_dir
+        .ancestors()
+        .nth(2)
+        .expect("repo root")
+        .join("docs/specs/openehr");
+    let fixtures = crate_dir.join("tests/fixtures/defects");
+
+    // Every fixture on disk must be in the table — no silent dead fixtures.
+    let mut on_disk: Vec<String> = std::fs::read_dir(&fixtures)
+        .expect("defects dir")
+        .map(|e| e.expect("entry").file_name().to_string_lossy().into_owned())
+        .collect();
+    on_disk.sort();
+    let mut in_table: Vec<String> = DEFECTS.iter().map(|(f, _, _)| (*f).to_owned()).collect();
+    in_table.sort();
+    in_table.dedup();
+    assert_eq!(
+        on_disk, in_table,
+        "defect fixtures and the expectation table diverge"
+    );
+
+    for (fixture, dest, expected) in DEFECTS {
+        let temp = assert_fs::TempDir::new().expect("temp dir");
+        copy_tree(&crate_dir.join("artifacts"), temp.path());
+        let dest_path = temp.path().join(dest);
+        std::fs::create_dir_all(dest_path.parent().expect("parent")).expect("mkdir");
+        std::fs::copy(fixtures.join(fixture), &dest_path).expect("overlay");
+
+        let loaded = load_root(temp.path()).expect("schema compilation");
+        let findings = validate(&Context {
+            set: &loaded.set,
+            load_errors: &loaded.errors,
+            spec_root: Some(&specs),
+        });
+        let hit = findings.iter().any(|f| f.check.token() == *expected);
+        assert!(
+            hit,
+            "{fixture}: expected a `{expected}` finding, got:\n{}",
+            findings
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+        // The clean world produced zero findings, so any finding at all is
+        // attributable to the seeded defect; the specific-gate assertion
+        // above pins WHICH gate caught it.
+        assert!(
+            !findings.is_empty(),
+            "{fixture}: defect produced no findings at all"
+        );
+        let _ = CheckId::Load; // the enum is the vocabulary the tokens come from
+    }
+}

--- a/tools/cnf-runner/tests/fixtures/defects/binding-bad-status.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/binding-bad-status.yaml
@@ -1,0 +1,5 @@
+sm_operation: I_EHR_SERVICE.create_ehr
+its: its-rest
+request: { method: POST, path: /ehr }
+outcomes:
+  created: { status: 99 }

--- a/tools/cnf-runner/tests/fixtures/defects/binding-unknown-outcome-key.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/binding-unknown-outcome-key.yaml
@@ -1,0 +1,5 @@
+sm_operation: I_EHR_SERVICE.create_ehr
+its: its-rest
+request: { method: POST, path: /ehr }
+outcomes:
+  succeeded: { status: 200 }

--- a/tools/cnf-runner/tests/fixtures/defects/case-aggregate-without-single-pass.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/case-aggregate-without-single-pass.yaml
@@ -1,0 +1,20 @@
+id: DEFECT-aggregate-without-single-pass
+kind: functional
+component: EHR
+sm_operation: I_EHR_SERVICE.create_ehr
+capabilities: [EhrOperations]
+profiles: [CORE]
+test_purpose: "seeded defect: aggregate unique under reset_per_row"
+description: "seeded defect"
+spec_refs: ["CNF platform_test_schedule master06 §create_ehr data sets"]
+requires: { server: empty }
+parameters:
+  iteration: reset_per_row
+  matrix: { columns: [ehr_id], rows: [[absent]] }
+flow:
+  - step: 1
+    call: create_ehr
+    expect: created
+    capture: { new_ehr_id: created.ehr_id }
+postconditions:
+  - { assert: unique, over: "${new_ehr_id}", aggregate: true }

--- a/tools/cnf-runner/tests/fixtures/defects/case-bad-capture-source.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/case-bad-capture-source.yaml
@@ -1,0 +1,15 @@
+id: DEFECT-bad-capture-source
+kind: functional
+component: EHR
+sm_operation: I_EHR_SERVICE.create_ehr
+capabilities: [EhrOperations]
+profiles: [CORE]
+test_purpose: "seeded defect: capture source outcome outside the taxonomy"
+description: "seeded defect"
+spec_refs: ["CNF platform_test_schedule master06 §create_ehr data sets"]
+requires: { server: empty }
+flow:
+  - step: 1
+    call: create_ehr
+    expect: created
+    capture: { x: response.ehr_id }

--- a/tools/cnf-runner/tests/fixtures/defects/case-bad-kind.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/case-bad-kind.yaml
@@ -1,0 +1,7 @@
+id: DEFECT-bad-kind
+kind: performance
+component: PERFORMANCE
+capabilities: []
+test_purpose: "seeded defect: performance case-core schema is a later artifact revision"
+description: "seeded defect"
+spec_refs: ["CNF platform_test_schedule master03 §overview"]

--- a/tools/cnf-runner/tests/fixtures/defects/case-bad-literal.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/case-bad-literal.yaml
@@ -1,0 +1,16 @@
+id: CONT-DEFECT-bad_literal
+kind: content
+component: CONTENT
+rm_class: DV_QUANTITY
+capabilities: [ArchetypeValidation]
+profiles: [CORE]
+test_purpose: "seeded defect: violation entry outside the closed categories"
+description: "seeded defect"
+spec_refs: ["CNF platform_test_schedule master17.3 §CONT-DV_QUANTITY-validate_property_units_mag"]
+constraint_context:
+  template: cnf.tpl.quantity_property_units_mag
+  path: "/content/value"
+decision_table:
+  columns: [magnitude, units, expected, violates]
+  rows:
+    - [1.0, "cm", rejected, ["bogus: not a category"]]

--- a/tools/cnf-runner/tests/fixtures/defects/case-bad-outcome-kind.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/case-bad-outcome-kind.yaml
@@ -1,0 +1,14 @@
+id: DEFECT-bad-outcome-kind
+kind: functional
+component: EHR
+sm_operation: I_EHR_SERVICE.create_ehr
+capabilities: [EhrOperations]
+profiles: [CORE]
+test_purpose: "seeded defect: expect outside the outcome taxonomy"
+description: "seeded defect"
+spec_refs: ["CNF platform_test_schedule master06 §create_ehr data sets"]
+requires: { server: empty }
+flow:
+  - step: 1
+    call: create_ehr
+    expect: http_201

--- a/tools/cnf-runner/tests/fixtures/defects/case-bad-ref-form.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/case-bad-ref-form.yaml
@@ -1,0 +1,15 @@
+id: DEFECT-bad-ref-form
+kind: functional
+component: EHR
+sm_operation: I_EHR_SERVICE.create_ehr
+capabilities: [EhrOperations]
+profiles: [CORE]
+test_purpose: "seeded defect: the banned ${stepN} reference form"
+description: "seeded defect"
+spec_refs: ["CNF platform_test_schedule master06 §create_ehr data sets"]
+requires: { server: empty }
+flow:
+  - step: 1
+    call: create_ehr
+    with: { ehr_status: "${step2.body}" }
+    expect: created

--- a/tools/cnf-runner/tests/fixtures/defects/case-bad-spec-ref.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/case-bad-spec-ref.yaml
@@ -1,0 +1,14 @@
+id: DEFECT-bad-spec-ref
+kind: functional
+component: EHR
+sm_operation: I_EHR_SERVICE.create_ehr
+capabilities: [EhrOperations]
+profiles: [CORE]
+test_purpose: "seeded defect: citation to a nonexistent vendored document"
+description: "seeded defect"
+spec_refs: ["RM nonexistent_document §Nothing"]
+requires: { server: empty }
+flow:
+  - step: 1
+    call: create_ehr
+    expect: created

--- a/tools/cnf-runner/tests/fixtures/defects/case-duplicate-id.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/case-duplicate-id.yaml
@@ -1,0 +1,14 @@
+id: I_EHR_SERVICE.create_ehr-same_ehr_twice
+kind: functional
+component: EHR
+sm_operation: I_EHR_SERVICE.create_ehr
+capabilities: [EhrOperations]
+profiles: [CORE]
+test_purpose: "seeded defect: reuses an existing case id"
+description: "seeded defect"
+spec_refs: ["CNF platform_test_schedule master06 §create_ehr-same_ehr_twice"]
+requires: { server: empty }
+flow:
+  - step: 1
+    call: create_ehr
+    expect: created

--- a/tools/cnf-runner/tests/fixtures/defects/case-duplicate-yaml-key.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/case-duplicate-yaml-key.yaml
@@ -1,0 +1,15 @@
+id: DEFECT-duplicate-yaml-key
+kind: functional
+component: EHR
+sm_operation: I_EHR_SERVICE.create_ehr
+capabilities: [EhrOperations]
+profiles: [CORE]
+test_purpose: "seeded defect: duplicate mapping key"
+description: "seeded defect"
+spec_refs: ["CNF platform_test_schedule master06 §create_ehr data sets"]
+requires: { server: empty }
+flow:
+  - step: 1
+    call: create_ehr
+    expect: created
+    with: { ehr_id: "a", ehr_id: "b" }

--- a/tools/cnf-runner/tests/fixtures/defects/case-missing-corpus-key.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/case-missing-corpus-key.yaml
@@ -1,0 +1,15 @@
+id: DEFECT-missing-corpus-key
+kind: functional
+component: EHR
+sm_operation: I_EHR_SERVICE.create_ehr
+capabilities: [EhrOperations]
+profiles: [CORE]
+test_purpose: "seeded defect: data_sets key absent from the manifest"
+description: "seeded defect"
+spec_refs: ["CNF platform_test_schedule master06 §create_ehr data sets"]
+requires: { server: empty }
+flow:
+  - step: 1
+    call: create_ehr
+    expect: created
+data_sets: [cnf.does.not.exist]

--- a/tools/cnf-runner/tests/fixtures/defects/case-missing-view.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/case-missing-view.yaml
@@ -1,0 +1,15 @@
+id: DEFECT-missing-view
+kind: functional
+component: EHR
+sm_operation: I_EHR_SERVICE.create_ehr
+capabilities: [EhrOperations]
+profiles: [CORE]
+test_purpose: "seeded defect: named view absent from the corpus entry"
+description: "seeded defect"
+spec_refs: ["CNF platform_test_schedule master06 §create_ehr data sets"]
+requires: { server: empty }
+flow:
+  - step: 1
+    call: create_ehr
+    with: { ehr_status: "${ds:cnf.set.bp-10#nope}" }
+    expect: created

--- a/tools/cnf-runner/tests/fixtures/defects/case-profile-tier-mismatch.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/case-profile-tier-mismatch.yaml
@@ -1,0 +1,14 @@
+id: DEFECT-profile-tier-mismatch
+kind: functional
+component: EHR
+sm_operation: I_EHR_SERVICE.create_ehr
+capabilities: [EhrOperations]
+profiles: [STANDARD]
+test_purpose: "seeded defect: profile tier no listed capability carries"
+description: "seeded defect"
+spec_refs: ["CNF platform_test_schedule master06 §create_ehr data sets"]
+requires: { server: empty }
+flow:
+  - step: 1
+    call: create_ehr
+    expect: created

--- a/tools/cnf-runner/tests/fixtures/defects/case-two-field-predicates.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/case-two-field-predicates.yaml
@@ -1,0 +1,16 @@
+id: DEFECT-two-field-predicates
+kind: functional
+component: EHR
+sm_operation: I_EHR_SERVICE.create_ehr
+capabilities: [EhrOperations]
+profiles: [CORE]
+test_purpose: "seeded defect: field assertion with two predicates"
+description: "seeded defect"
+spec_refs: ["CNF platform_test_schedule master06 §create_ehr data sets"]
+requires: { server: empty }
+flow:
+  - step: 1
+    call: create_ehr
+    expect: created
+    assert:
+      - { assert: field, path: "ehr_id", exists: true, absent: true }

--- a/tools/cnf-runner/tests/fixtures/defects/case-undefined-capture-ref.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/case-undefined-capture-ref.yaml
@@ -1,0 +1,15 @@
+id: DEFECT-undefined-capture-ref
+kind: functional
+component: EHR
+sm_operation: I_EHR_SERVICE.create_ehr
+capabilities: [EhrOperations]
+profiles: [CORE]
+test_purpose: "seeded defect: reference to a capture never made"
+description: "seeded defect"
+spec_refs: ["CNF platform_test_schedule master06 §create_ehr data sets"]
+requires: { server: empty }
+flow:
+  - step: 1
+    call: create_ehr
+    with: { ehr_id: "${ghost}" }
+    expect: created

--- a/tools/cnf-runner/tests/fixtures/defects/case-unknown-capability.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/case-unknown-capability.yaml
@@ -1,0 +1,14 @@
+id: DEFECT-unknown-capability
+kind: functional
+component: EHR
+sm_operation: I_EHR_SERVICE.create_ehr
+capabilities: [TotallyNewCapability]
+profiles: [CORE]
+test_purpose: "seeded defect: capability absent from the matrix"
+description: "seeded defect"
+spec_refs: ["CNF platform_test_schedule master06 §create_ehr data sets"]
+requires: { server: empty }
+flow:
+  - step: 1
+    call: create_ehr
+    expect: created

--- a/tools/cnf-runner/tests/fixtures/defects/case-unknown-field.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/case-unknown-field.yaml
@@ -1,0 +1,15 @@
+id: DEFECT-unknown-field
+kind: functional
+component: EHR
+sm_operation: I_EHR_SERVICE.create_ehr
+capabilities: [EhrOperations]
+profiles: [CORE]
+test_purpose: "seeded defect: unknown top-level field"
+description: "seeded defect"
+spec_refs: ["CNF platform_test_schedule master06 §create_ehr data sets"]
+requires: { server: empty }
+severity: high
+flow:
+  - step: 1
+    call: create_ehr
+    expect: created

--- a/tools/cnf-runner/tests/fixtures/defects/case-unmapped-capture.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/case-unmapped-capture.yaml
@@ -1,0 +1,15 @@
+id: DEFECT-unmapped-capture
+kind: functional
+component: EHR
+sm_operation: I_EHR_SERVICE.create_ehr
+capabilities: [EhrOperations]
+profiles: [CORE]
+test_purpose: "seeded defect: capture with no wire source in the binding"
+description: "seeded defect"
+spec_refs: ["CNF platform_test_schedule master06 §create_ehr data sets"]
+requires: { server: empty }
+flow:
+  - step: 1
+    call: create_ehr
+    expect: created
+    capture: { subject: created.subject_id }

--- a/tools/cnf-runner/tests/fixtures/defects/case-unmapped-outcome.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/case-unmapped-outcome.yaml
@@ -1,0 +1,14 @@
+id: DEFECT-unmapped-outcome
+kind: functional
+component: EHR
+sm_operation: I_EHR_SERVICE.create_ehr
+capabilities: [EhrOperations]
+profiles: [CORE]
+test_purpose: "seeded defect: outcome kind the binding does not map"
+description: "seeded defect"
+spec_refs: ["CNF platform_test_schedule master06 §create_ehr data sets"]
+requires: { server: empty }
+flow:
+  - step: 1
+    call: create_ehr
+    expect: timeout

--- a/tools/cnf-runner/tests/fixtures/defects/case-unresolved-ambiguity.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/case-unresolved-ambiguity.yaml
@@ -1,0 +1,15 @@
+id: DEFECT-unresolved-ambiguity
+kind: functional
+component: EHR
+sm_operation: I_EHR_SERVICE.create_ehr
+capabilities: [EhrOperations]
+profiles: [CORE]
+test_purpose: "seeded defect: ambiguity id absent from the register"
+description: "seeded defect"
+spec_refs: ["CNF platform_test_schedule master06 §create_ehr data sets"]
+requires: { server: empty }
+flow:
+  - step: 1
+    call: create_ehr
+    expect: created
+ambiguities: [AMB-99]

--- a/tools/cnf-runner/tests/fixtures/defects/case-unresolved-option.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/case-unresolved-option.yaml
@@ -1,0 +1,15 @@
+id: DEFECT-unresolved-option
+kind: functional
+component: EHR
+sm_operation: I_EHR_SERVICE.create_ehr
+capabilities: [EhrOperations]
+profiles: [CORE]
+test_purpose: "seeded defect: option tag no register entry declares"
+description: "seeded defect"
+spec_refs: ["CNF platform_test_schedule master06 §create_ehr data sets"]
+requires: { server: empty }
+flow:
+  - step: 1
+    call: create_ehr
+    expect: created
+option: not-registered

--- a/tools/cnf-runner/tests/fixtures/defects/case-unresolved-sm-op.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/case-unresolved-sm-op.yaml
@@ -1,0 +1,14 @@
+id: DEFECT-unresolved-sm-op
+kind: functional
+component: EHR
+sm_operation: I_EHR_SERVICE.create_ehr_v2
+capabilities: [EhrOperations]
+profiles: [CORE]
+test_purpose: "seeded defect: operation absent from the vendored SM"
+description: "seeded defect"
+spec_refs: ["CNF platform_test_schedule master06 §create_ehr data sets"]
+requires: { server: empty }
+flow:
+  - step: 1
+    call: create_ehr_v2
+    expect: created

--- a/tools/cnf-runner/tests/fixtures/defects/case-unresolved-verified-by.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/case-unresolved-verified-by.yaml
@@ -1,0 +1,15 @@
+id: DEFECT-unresolved-verified-by
+kind: functional
+component: EHR
+sm_operation: I_EHR_SERVICE.create_ehr
+capabilities: [EhrOperations]
+profiles: [CORE]
+test_purpose: "seeded defect: verified_by ghost target"
+description: "seeded defect"
+spec_refs: ["CNF platform_test_schedule master06 §create_ehr data sets"]
+requires: { server: empty }
+flow:
+  - step: 1
+    call: create_ehr
+    expect: created
+verified_by: [I_EHR_SERVICE.ghost-case]

--- a/tools/cnf-runner/tests/fixtures/defects/corpus-invalid-without-defect.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/corpus-invalid-without-defect.yaml
@@ -1,0 +1,5 @@
+cnf.defect.invalid_without_defect:
+  source: fixtures/nope.json
+  format: canonical-json
+  validity: { verdict: invalid }
+  provenance: "seeded defect"

--- a/tools/cnf-runner/tests/fixtures/defects/corpus-missing-provenance.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/corpus-missing-provenance.yaml
@@ -1,0 +1,4 @@
+cnf.defect.no_provenance:
+  source: fixtures/nope.json
+  format: canonical-json
+  validity: { verdict: valid }

--- a/tools/cnf-runner/tests/fixtures/defects/corpus-missing-source.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/corpus-missing-source.yaml
@@ -1,0 +1,5 @@
+cnf.defect.source_missing:
+  source: fixtures/this/file/is/not/there.json
+  format: canonical-json
+  validity: { verdict: valid }
+  provenance: "seeded defect: source path resolves nowhere"

--- a/tools/cnf-runner/tests/fixtures/defects/matrix-bad-tier.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/matrix-bad-tier.yaml
@@ -1,0 +1,1 @@
+EhrOperations: { family: Platform, tier: SEC-BASIC, required: true }

--- a/tools/cnf-runner/tests/fixtures/defects/outcomes-missing-kind.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/outcomes-missing-kind.yaml
@@ -1,0 +1,1 @@
+created: { class: success, meaning: "seeded defect: the other twenty kinds are missing" }

--- a/tools/cnf-runner/tests/fixtures/defects/outcomes-wrong-class.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/outcomes-wrong-class.yaml
@@ -1,0 +1,25 @@
+# The closed outcome-kind taxonomy (CNF 2.0 artifact family 3).
+# Cases speak ONLY these kinds; bindings map each kind to wire per operation.
+# Extensible only by schedule release. Meanings carry the schedule language
+# (CNF platform_test_schedule master04/06/07).
+created: { class: error, meaning: "New resource exists (\"positive response associated to the successful creation\")" }
+ok: { class: success, meaning: "Read/query succeeded with content" }
+ok_empty: { class: success, meaning: "Fulfilled with no content (e.g. composition logically deleted at requested time)" }
+updated: { class: success, meaning: "New version of existing resource created" }
+deleted: { class: success, meaning: "Logical delete performed (a new version, lifecycle_state = openehr::523|deleted|)" }
+stored: { class: success, meaning: "Definition stored (stored query PUT — wire 200, not 201)" }
+already_exists: { class: error, meaning: "Duplicate identity (\"an EHR with the provided ehr_id ... should be unique\"; duplicate template_id)" }
+not_found: { class: error, meaning: "Target does not exist (\"EHR with <ehr_id> does not exist\")" }
+version_not_found: { class: error, meaning: "preceding_version_uid does not exist" }
+precondition_failed: { class: error, meaning: "Version precondition evaluated false (stale preceding_version_uid)" }
+precondition_missing: { class: error, meaning: "Required version precondition absent" }
+validation_failed: { class: error, meaning: "Semantically invalid content (\"information about the errors in the provided COMPOSITION\")" }
+template_not_found: { class: error, meaning: "Referenced OPT not on server (\"information about the non-existent OPT\")" }
+template_mismatch: { class: error, meaning: "Content commits against a different template_id than the versioned object" }
+missing_template_id: { class: error, meaning: "Simplified-format commit without template identification" }
+already_deleted: { class: error, meaning: "Delete of an already-deleted version" }
+conflict: { class: error, meaning: "Other uniqueness/state conflict" }
+not_acceptable: { class: error, meaning: "No representation satisfies Accept" }
+unsupported_media: { class: error, meaning: "Payload media type unsupported" }
+invalid_query: { class: error, meaning: "Malformed/unprocessable AQL" }
+timeout: { class: error, meaning: "Server aborted at max execution time" }

--- a/tools/cnf-runner/tests/fixtures/defects/register-bad-disposition.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/register-bad-disposition.yaml
@@ -1,0 +1,5 @@
+AMB-1:
+  ambiguity: "seeded defect"
+  source: "s"
+  handling: "h"
+  disposition: ad_hoc

--- a/tools/cnf-runner/tests/fixtures/defects/register-option-select-without-options.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/register-option-select-without-options.yaml
@@ -1,0 +1,5 @@
+AMB-4:
+  ambiguity: "seeded defect: option_select without option tags"
+  source: "CNF platform_test_schedule master04"
+  handling: "h"
+  disposition: option_select

--- a/tools/cnf-runner/tests/schema_drift.rs
+++ b/tools/cnf-runner/tests/schema_drift.rs
@@ -1,0 +1,34 @@
+//! The committed schema set (`schemas/*.schema.json`) is the published norm;
+//! it must stay byte-identical to what the code emits (regenerate with
+//! `cargo run -p cnf-runner -- emit-schemas --out tools/cnf-runner/schemas`).
+#![allow(clippy::panic)] // test assertions
+
+use cnf_runner::schema::{emit_all, render};
+
+#[test]
+fn committed_schemas_are_byte_identical_to_emission() {
+    let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("schemas");
+    for (name, schema) in emit_all() {
+        let committed = std::fs::read_to_string(dir.join(name))
+            .unwrap_or_else(|e| panic!("{name} is not committed: {e}"));
+        assert_eq!(
+            committed,
+            render(&schema),
+            "{name} drifted — regenerate with `cargo run -p cnf-runner -- emit-schemas`"
+        );
+    }
+}
+
+#[test]
+fn no_extra_schema_files_are_committed() {
+    let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("schemas");
+    let expected: Vec<&str> = emit_all().into_iter().map(|(n, _)| n).collect();
+    for entry in std::fs::read_dir(&dir).expect("schemas dir") {
+        let name = entry.expect("dir entry").file_name();
+        let name = name.to_string_lossy();
+        assert!(
+            expected.contains(&name.as_ref()),
+            "unexpected committed schema file {name}"
+        );
+    }
+}


### PR DESCRIPTION
First workstream of the CNF 2.0 reference runner ground-up rebuild (#202): the typed schedule-artifact model, the published JSON-Schema set, and the full cross-artifact validator, with the eight pilot encodings as the first schedule artifacts.

## What landed

**New crate `tools/cnf-runner`** (dev/verification tooling; ECC `tools/conformance` untouched — it remains the acceptance instrument until the comparison gate).

- **Typed artifact model** — one module per family: case cores (flow steps, typed `requires`/`parameters`, matrix sentinels `absent`/`provided`/`null`, bundled version-sets, per-step format roles), per-ITS operation bindings (closed capture-source / header-matcher / body-selector grammars, `server_assigned` ignore-sets), outcome + selector vocabularies, the capability→family→tier matrix (family-scoped tiers: CORE/STANDARD/OPTIONS · SEC-BASIC · D/M/X), corpus manifest (adjudicated verdicts, views, digest-pinned recipe contracts), ambiguity register (typed `disposition` enum). Every closed vocabulary is a Rust enum/newtype — illegal states unrepresentable. The closed `${…}` reference grammar and the decision-table literal grammar (ranges, unit-scoped lists, term codes, ordinal tuples, quantities, violation categories) are real parsers.
- **Published JSON Schemas** (draft 2020-12) for all seven artifact files, emitted deterministically from the compiled vocabularies and committed under `tools/cnf-runner/schemas/` — vendorable by any runner; a nextest drift guard keeps them byte-identical to emission. Every YAML artifact is schema-validated at load: a malformed file surfaces as a per-file `[load] … schema: …` finding (CLI exit 1).
- **Cross-artifact validator** (the schedule's machine-gate list as typed checks): id uniqueness, kind-shape + assertion/parameter invariants, reference/sentinel grammar resolution, decision-table literal parsing, `sm_operation` + flow-call resolution against the vendored SM UML class exports, `spec_refs` link-checking against `docs/specs/openehr/`, binding completeness (every used outcome kind mapped, every capture wired), `verified_by` resolution, corpus integrity (keys/views/sources), ambiguity/option-tag resolution, capability-vs-tier consistency, and vocabulary-drift (published files ≡ compiled enums, both directions).
- **CLI**: `cnf-runner emit-schemas --out DIR` · `cnf-runner validate --root DIR [--specs DIR]` (exit 0 clean / 1 findings / 2 runner error).
- **First schedule artifacts** (`tools/cnf-runner/artifacts/`): the eight pilot encodings + their two `verified_by` target cases (official master06/master04 cases), ten ITS-REST operation bindings (every status/header mapping cited to its OAS source file), the seeded corpus manifest, the outcome/selector vocabularies, the capability matrix, and the ambiguity register seeded AMB-1…AMB-13. The whole tree validates clean under every gate, spec-resolution included.
- **Seeded-defect battery**: 32 fixtures, each rejected by its designated gate (schema-level through cross-artifact), enforced by `tests/defect_rejection.rs`; the expectation table and the fixture directory are held equal so no fixture can go dead.

## Design-interpretation rulings (recorded on #202)

- Pilot read-back steps anchor to the SM's `get_composition_at_version` (no plain `get_composition` exists in the SM interface); the AQL pilot follows the official `execute_ad_hoc_query` family spelling.
- **AMB-13 (new register entry)**: CNF master04 anchors `I_DEFINITION_ADL14.get_opts()` while the vendored SM interface defines `list_opts` — official case ids keep the `get_opts` family, `sm_operation` carries the resolvable `list_opts` (`fixed_handling`).
- Capture sources outside the closed grammar (the design's `body-or-location` shorthand) are expressed via the grammar's `fallback:` modifier.
- Corpus payloads are structural placeholders with honest provenance; the spine-first corpus lands with the catalogue authoring (TODO in the manifest).
- The performance case-core (`kind: performance`) is deliberately not in this schema revision — it lands with the performance workstream per the issue's scoping.

## Gates

- `cargo clippy --workspace --all-targets --all-features` clean
- `cargo nextest run -p cnf-runner`: 37/37 (schema drift, pilot world clean under all gates, 32-defect rejection battery, grammar/model unit tests)
- `CHANGELOG.md` entry under [Unreleased]
- New workspace pins verified live at adoption: `serde-saphyr 1.0.0-rc.1` (pure-Rust YAML, anti-bomb Budget, duplicate-key + strict-boolean hardening), `semver 1.0.28`

Refs #202 (W1 exit criterion; the issue stays open for the remaining workstreams).