### PR TITLE
fix: derive every spec version from the openehr-* crate versions (stale ITS-REST 1.0.3 in banner and RESULT_SET)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,19 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- Spec version identity is now derived from the `openehr-*` crate versions
+  instead of hand-typed literals, fixing the stale values those literals had
+  drifted to: the startup banner advertised `ITS-REST 1.0.3` (now `1.1.0`),
+  and the AQL `RESULT_SET` `meta._schema_version` was still emitted as
+  `1.0.3` (now `1.1.0`, the implemented ITS-REST release). Every `openehr-*`
+  spec crate exposes a `SPEC_VERSION` constant (= its crate version; the AM
+  crate also exposes per-generation `am14`/`am24` constants from the BMM
+  schemas), and the shared provenance constants behind the banner,
+  `/status`, `OPTIONS /` (System Options), and `/management/info` read
+  those, so a future pin bump propagates everywhere at compile time. The
+  served `restapi_specs_version`/`openehr_rest_api_version` identity is now
+  the plain version string `1.1.0` (matching the System API OAS example)
+  instead of the tag-styled `Release-1.1.0`.
 - SM call-status fidelity: service-layer "does not exist" failures now carry
   their granular `CALL_STATUS_TYPE` (`ehr_id_does_not_exist`,
   `composition_does_not_exist`, `template_does_not_exist`,

--- a/app/ehrbase-rest/tests/http.rs
+++ b/app/ehrbase-rest/tests/http.rs
@@ -188,9 +188,12 @@ async fn status_endpoint_is_public() {
     assert_eq!(status, StatusCode::OK);
     let v: serde_json::Value = serde_json::from_str(&body).unwrap();
     assert_eq!(v["status"], "UP");
-    // The served identity is the released ITS-REST contract version, shared
-    // from the single provenance constant.
-    assert_eq!(v["openehr_rest_api_version"], "Release-1.1.0");
+    // The served identity is the released ITS-REST contract version — the
+    // `openehr-its` crate version, via the single provenance constant.
+    assert_eq!(
+        v["openehr_rest_api_version"],
+        ehrbase::telemetry::provenance::ITS_REST
+    );
 }
 
 #[tokio::test]

--- a/app/ehrbase-rest/tests/protocol_tail.rs
+++ b/app/ehrbase-rest/tests/protocol_tail.rs
@@ -170,9 +170,13 @@ async fn options_root_is_system_options_and_conformance() {
     );
     // The `Options` conformance manifest body.
     let v: Value = serde_json::from_str(&body).expect("options body");
-    // The served identity is the released ITS-REST contract version, shared
-    // from the single provenance constant.
-    assert_eq!(v["restapi_specs_version"], "Release-1.1.0");
+    // The served identity is the released ITS-REST contract version — the
+    // `openehr-its` crate version, via the single provenance constant (a
+    // plain version string, matching the System API OAS example).
+    assert_eq!(
+        v["restapi_specs_version"],
+        ehrbase::telemetry::provenance::ITS_REST
+    );
     assert_eq!(v["conformance_profile"], "STANDARD");
     assert!(v["endpoints"].as_array().is_some_and(|e| !e.is_empty()));
 }

--- a/app/ehrbase-server/tests/service_query.rs
+++ b/app/ehrbase-server/tests/service_query.rs
@@ -102,8 +102,8 @@ async fn adhoc_aql_over_http_returns_result_set() {
     let json: serde_json::Value = serde_json::from_str(&body).expect("result set json");
     assert_eq!(
         json["meta"]["_schema_version"],
-        serde_json::json!("1.0.3"),
-        "RESULT_SET carries the ITS-REST schema version"
+        serde_json::json!(ehrbase::telemetry::provenance::ITS_REST),
+        "RESULT_SET carries the implemented ITS-REST release as its schema version"
     );
     assert_eq!(
         json["rows"],

--- a/app/ehrbase/src/banner.rs
+++ b/app/ehrbase/src/banner.rs
@@ -6,7 +6,8 @@
 //! "standard" font and vendored here), so the boot path carries **zero** runtime
 //! dependency and no font-asset load for a fixed piece of art. The version is
 //! substituted from `CARGO_PKG_VERSION` at build time; the load-bearing spec
-//! pins are sourced from `docs/VERSIONS.md`.
+//! pins are read from [`crate::telemetry::provenance`] — the derived
+//! crate-version constants — never re-typed here.
 
 use std::fmt::Write as _;
 
@@ -23,14 +24,15 @@ const WORDMARK: &str = r"
 /// The project's public repository.
 const PROJECT_URL: &str = "https://github.com/rubentalstra/ehrbase-rs";
 
-/// The load-bearing spec/platform pins, one per line (wording per
-/// `docs/VERSIONS.md`: RM 1.2.0, ITS-REST 1.1.0, QUERY/AQL 1.1.0,
-/// `PostgreSQL` 18). `(label, version)` pairs, aligned when rendered.
+/// The load-bearing spec/platform pins, one per line — each version read
+/// from the shared [`crate::telemetry::provenance`] constants (themselves
+/// the `openehr-*` crate versions), so the banner can never drift from the
+/// actual pins. `(label, version)` pairs, aligned when rendered.
 const PINS: &[(&str, &str)] = &[
-    ("openEHR RM", "1.2.0"),
-    ("ITS-REST", "1.0.3"),
-    ("AQL", "1.1"),
-    ("PostgreSQL", "18"),
+    ("openEHR RM", crate::telemetry::provenance::RM),
+    ("ITS-REST", crate::telemetry::provenance::ITS_REST),
+    ("AQL", crate::telemetry::provenance::AQL),
+    ("PostgreSQL", crate::telemetry::provenance::PG_TARGET),
 ];
 
 /// Render the full banner for the given product `version`.

--- a/app/ehrbase/src/service/query/result_set.rs
+++ b/app/ehrbase/src/service/query/result_set.rs
@@ -13,8 +13,11 @@ use crate::aql::exec::QueryResult;
 use crate::aql::ir::{ParamValue, Params};
 use crate::service::query::request::AqlQueryRequest;
 
-/// The `RESULT_SET` schema version this server emits (ITS-REST 1.1.0).
-const RESULT_SET_SCHEMA_VERSION: &str = "1.0.3";
+/// The `RESULT_SET` `_schema_version` this server emits — "the version of the
+/// specification defining the serialized object" (ITS-REST
+/// `schemas/query/ResultSet`), i.e. the implemented ITS-REST release, read
+/// from the `openehr-its` crate version so it can never lag a pin bump.
+const RESULT_SET_SCHEMA_VERSION: &str = openehr_its::SPEC_VERSION;
 
 /// Build the typed [`Params`] from the request's `query_parameters` map
 /// (values arrive as JSON scalars; complex values degrade to their JSON

--- a/app/ehrbase/src/telemetry/build_info.rs
+++ b/app/ehrbase/src/telemetry/build_info.rs
@@ -10,8 +10,8 @@
 //! The spec-version fields are **not** local literals: they read the single
 //! [`provenance`](crate::telemetry::provenance) source shared with the System
 //! Options manifest (`OPTIONS /`) and `/status`, so all three identity surfaces
-//! quote one fact. In particular `its_rest` is the released ITS-REST contract
-//! version (`Release-1.1.0`). See that module for the derivation.
+//! quote one fact — and provenance itself derives every pin from the owning
+//! `openehr-*` crate's `SPEC_VERSION`. See that module for the derivation.
 
 use serde::Serialize;
 
@@ -47,8 +47,9 @@ pub struct SpecVersions {
     pub rm: &'static str,
     /// BASE version.
     pub base: &'static str,
-    /// Archetype Model versions.
-    pub am: &'static str,
+    /// Archetype Model versions — both extant generations, rendered as
+    /// `"<am14> + <am24>"`.
+    pub am: String,
     /// Terminology version.
     pub term: &'static str,
 }
@@ -68,7 +69,7 @@ impl BuildInfo {
                 aql: provenance::AQL,
                 rm: provenance::RM,
                 base: provenance::BASE,
-                am: provenance::AM,
+                am: format!("{} + {}", provenance::AM14, provenance::AM24),
                 term: provenance::TERM,
             },
             postgres_target: provenance::PG_TARGET,
@@ -105,11 +106,18 @@ mod tests {
     fn build_info_is_populated() {
         let info = BuildInfo::current();
         assert_eq!(info.name, "ehrbase");
-        assert_eq!(info.spec.rm, "1.2.0");
-        // The released ITS-REST contract version (matches the ECC report),
-        // sourced from the shared provenance constant.
-        assert_eq!(info.spec.its_rest, "Release-1.1.0");
-        assert_eq!(info.spec.its_rest, provenance::ITS_REST);
+        // The pins are the crate versions themselves — no re-typed literals
+        // anywhere in the chain, so a pin bump cannot silently diverge.
+        assert_eq!(info.spec.rm, openehr_rm::SPEC_VERSION);
+        assert_eq!(info.spec.its_rest, openehr_its::SPEC_VERSION);
+        assert_eq!(
+            info.spec.am,
+            format!(
+                "{} + {}",
+                openehr_am::am14::SPEC_VERSION,
+                openehr_am::SPEC_VERSION
+            )
+        );
         assert_eq!(info.postgres_target, "18.4+");
         // build_date parses to a real timestamp (not the "unknown" fallback) in
         // a normal build where build.rs ran.

--- a/app/ehrbase/src/telemetry/provenance.rs
+++ b/app/ehrbase/src/telemetry/provenance.rs
@@ -1,24 +1,34 @@
-//! Build/spec provenance constants (spec pins from `docs/VERSIONS.md`,
-//! emitted at build time by `build.rs`).
+//! Build/spec provenance constants — the spec pins **derived from the
+//! `openehr-*` crate versions** (each spec crate is versioned by the openEHR
+//! specification it implements, so its `SPEC_VERSION` constant is the pin),
+//! never hand-typed literals: a pin bump in a crate manifest propagates here
+//! at compile time, so the identity surfaces cannot drift.
 
-/// The openEHR ITS-REST contract version this server implements: the released
-/// `Release-1.1.0` (19-Jul-2026). The vendored `-codegen` OAS at
-/// `crates/openehr-its/vendor/rest-oas/PROVENANCE.md` pins that release
-/// (tag `24058992d`), byte-identical to the earlier pre-release snapshot.
-/// Reported by management `/info`, the System Options manifest, and `/status`.
-pub const ITS_REST: &str = "Release-1.1.0";
-/// The AQL (QUERY) specification version (`docs/VERSIONS.md`).
-pub const AQL: &str = "1.1.0";
-/// The openEHR Reference Model version (`docs/VERSIONS.md`).
-pub const RM: &str = "1.2.0";
-/// The openEHR BASE version (`docs/VERSIONS.md`).
-pub const BASE: &str = "1.3.0";
-/// The openEHR Archetype Model versions (`docs/VERSIONS.md`).
-pub const AM: &str = "1.4.0 + 2.4.0";
-/// The openEHR Terminology version (`docs/VERSIONS.md`).
-pub const TERM: &str = "3.1.0";
-/// The `PostgreSQL` version this server targets (`docs/VERSIONS.md`). No
-/// openEHR spec governs the datastore — our own design.
+/// The openEHR ITS-REST contract version this server implements (the released
+/// `Release-1.1.0`, 19-Jul-2026; the vendored `-codegen` OAS at
+/// `crates/openehr-its/vendor/rest-oas/PROVENANCE.md` pins that release).
+/// Reported by management `/info`, the System Options manifest
+/// (`restapi_specs_version` — a plain version string, per the System API OAS
+/// example `restapi_specs_version: 1.1.0`), and `/status`.
+pub const ITS_REST: &str = openehr_its::SPEC_VERSION;
+/// The AQL (QUERY) specification version.
+pub const AQL: &str = openehr_query::SPEC_VERSION;
+/// The openEHR Reference Model version.
+pub const RM: &str = openehr_rm::SPEC_VERSION;
+/// The openEHR BASE version.
+pub const BASE: &str = openehr_base::SPEC_VERSION;
+/// The ADL 1.4 generation of the Archetype Model (the `openehr-am` crate
+/// ships both extant generations side by side; this one is the `am14`
+/// module's own pin).
+pub const AM14: &str = openehr_am::am14::SPEC_VERSION;
+/// The ADL 2 generation of the Archetype Model (= the `openehr-am` crate
+/// version, its primary generation).
+pub const AM24: &str = openehr_am::SPEC_VERSION;
+/// The openEHR Terminology version.
+pub const TERM: &str = openehr_term::SPEC_VERSION;
+/// The `PostgreSQL` version this server targets. No openEHR spec governs the
+/// datastore — our own design; no crate carries this pin, so it stays
+/// hand-maintained here.
 pub const PG_TARGET: &str = "18.4+";
 /// The last machine-computed ECC conformance verdict — the highest profile
 /// obtained — advertised by the System Options manifest (`OPTIONS /`
@@ -28,3 +38,24 @@ pub const PG_TARGET: &str = "18.4+";
 /// in `docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md` §"Profile verdict"
 /// (Core PASS · Standard PASS). The manifest MUST NOT out-claim it.
 pub const CONFORMANCE_PROFILE: &str = "STANDARD";
+
+#[cfg(test)]
+#[allow(clippy::panic)] // test assertions
+mod tests {
+    use super::*;
+
+    /// The derivation chain holds end to end: every pin is the owning
+    /// crate's own `SPEC_VERSION`, and the AM crate version is its ADL 2
+    /// generation.
+    #[test]
+    fn pins_are_the_crate_versions() {
+        assert_eq!(ITS_REST, openehr_its::SPEC_VERSION);
+        assert_eq!(AQL, openehr_query::SPEC_VERSION);
+        assert_eq!(RM, openehr_rm::SPEC_VERSION);
+        assert_eq!(BASE, openehr_base::SPEC_VERSION);
+        assert_eq!(AM14, openehr_am::am14::SPEC_VERSION);
+        assert_eq!(AM24, openehr_am::am24::SPEC_VERSION);
+        assert_eq!(TERM, openehr_term::SPEC_VERSION);
+        assert_eq!(openehr_am::SPEC_VERSION, openehr_am::am24::SPEC_VERSION);
+    }
+}

--- a/crates/openehr-adl/src/lib.rs
+++ b/crates/openehr-adl/src/lib.rs
@@ -34,3 +34,9 @@ pub mod printer;
 pub mod rules;
 pub mod source;
 pub mod validate;
+
+/// The openEHR specification version this crate implements — the crate
+/// version itself: the spec crates are versioned by the specification they
+/// implement (`docs/VERSIONS.md` §Product and crate versioning), so
+/// consumers read the pin from the package, never from a hand-typed literal.
+pub const SPEC_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/openehr-am/src/am14/mod.rs
+++ b/crates/openehr-am/src/am14/mod.rs
@@ -2,3 +2,7 @@
 
 pub mod aom14;
 pub mod prelude;
+
+/// The openEHR specification version this generation implements —
+/// the vendored BMM schema's `rm_release`.
+pub const SPEC_VERSION: &str = "1.4.0";

--- a/crates/openehr-am/src/am24/mod.rs
+++ b/crates/openehr-am/src/am24/mod.rs
@@ -5,3 +5,7 @@ pub mod beom;
 pub mod bmm3;
 pub mod prelude;
 pub mod resource;
+
+/// The openEHR specification version this generation implements —
+/// the vendored BMM schema's `rm_release`.
+pub const SPEC_VERSION: &str = "2.4.0";

--- a/crates/openehr-am/src/lib.rs
+++ b/crates/openehr-am/src/lib.rs
@@ -15,3 +15,9 @@
 
 pub mod am14;
 pub mod am24;
+
+/// The openEHR specification version this crate implements — the crate
+/// version itself: the spec crates are versioned by the specification they
+/// implement (`docs/VERSIONS.md` §Product and crate versioning), so
+/// consumers read the pin from the package, never from a hand-typed literal.
+pub const SPEC_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/openehr-base/src/lib.rs
+++ b/crates/openehr-base/src/lib.rs
@@ -18,5 +18,11 @@ pub mod foundation_types;
 pub mod prelude;
 pub mod resource;
 
+/// The openEHR specification version this crate implements — the crate
+/// version itself: the spec crates are versioned by the specification they
+/// implement (`docs/VERSIONS.md` §Product and crate versioning), so
+/// consumers read the pin from the package, never from a hand-typed literal.
+pub const SPEC_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 // hand-written modules (spec behaviour), auto-declared:
 pub mod validate;

--- a/crates/openehr-its/src/lib.rs
+++ b/crates/openehr-its/src/lib.rs
@@ -36,3 +36,9 @@ pub mod rest;
 pub mod rm_terminology;
 pub mod rm_validate;
 pub mod xml;
+
+/// The openEHR specification version this crate implements — the crate
+/// version itself: the spec crates are versioned by the specification they
+/// implement (`docs/VERSIONS.md` §Product and crate versioning), so
+/// consumers read the pin from the package, never from a hand-typed literal.
+pub const SPEC_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/openehr-lang/src/lib.rs
+++ b/crates/openehr-lang/src/lib.rs
@@ -19,6 +19,12 @@ pub mod bmm3;
 pub mod bmm_persistence;
 pub mod prelude;
 
+/// The openEHR specification version this crate implements — the crate
+/// version itself: the spec crates are versioned by the specification they
+/// implement (`docs/VERSIONS.md` §Product and crate versioning), so
+/// consumers read the pin from the package, never from a hand-typed literal.
+pub const SPEC_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 // hand-written modules (spec behaviour), auto-declared:
 pub mod bel;
 pub mod odin;

--- a/crates/openehr-query/src/lib.rs
+++ b/crates/openehr-query/src/lib.rs
@@ -19,3 +19,9 @@ pub mod ast;
 pub mod lexer;
 pub mod parser;
 pub mod printer;
+
+/// The openEHR specification version this crate implements — the crate
+/// version itself: the spec crates are versioned by the specification they
+/// implement (`docs/VERSIONS.md` §Product and crate versioning), so
+/// consumers read the pin from the package, never from a hand-typed literal.
+pub const SPEC_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/openehr-rm/src/lib.rs
+++ b/crates/openehr-rm/src/lib.rs
@@ -21,9 +21,15 @@ pub mod demographic;
 pub mod ehr;
 pub mod ehr_extract;
 pub mod integration;
-pub mod model;
 pub mod prelude;
 pub mod support;
+
+/// The openEHR specification version this crate implements — the crate
+/// version itself: the spec crates are versioned by the specification they
+/// implement (`docs/VERSIONS.md` §Product and crate versioning), so
+/// consumers read the pin from the package, never from a hand-typed literal.
+pub const SPEC_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub mod model;
 
 // hand-written modules (spec behaviour), auto-declared:
 pub mod paths;

--- a/crates/openehr-term/src/lib.rs
+++ b/crates/openehr-term/src/lib.rs
@@ -16,6 +16,12 @@
 pub mod prelude;
 pub mod terminology;
 
+/// The openEHR specification version this crate implements — the crate
+/// version itself: the spec crates are versioned by the specification they
+/// implement (`docs/VERSIONS.md` §Product and crate versioning), so
+/// consumers read the pin from the package, never from a hand-typed literal.
+pub const SPEC_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 // hand-written modules (spec behaviour), auto-declared:
 pub mod bundle;
 pub mod measurement;

--- a/tools/openehr-codegen/src/render/emit.rs
+++ b/tools/openehr-codegen/src/render/emit.rs
@@ -147,6 +147,22 @@ fn emit_version(model: &Model, schema: &BmmSchema, prefix: &str, external: &Exte
         format!("{prefix}/prelude.rs")
     };
     files.extend(emit_module_tree(&tree_chains));
+    // A prefixed version module carries its own spec-version constant, sourced
+    // from the vendored BMM schema's `rm_release` (the crate-level constant in
+    // `lib.rs` covers only the crate's primary generation).
+    if !prefix.is_empty() {
+        let mod_path = format!("{prefix}/mod.rs");
+        for f in &mut files {
+            if f.path == mod_path {
+                f.body.push_str(&format!(
+                    "\n/// The openEHR specification version this generation implements —\n\
+                     /// the vendored BMM schema's `rm_release`.\n\
+                     pub const SPEC_VERSION: &str = \"{}\";\n",
+                    schema.rm_release
+                ));
+            }
+        }
+    }
     files.push(emit_prelude(&emitted, &prelude_path));
 
     // Top modules: the prefix itself if prefixed, else the type roots.
@@ -251,6 +267,13 @@ fn emit_lib(top: &BTreeSet<String>, include_prelude: bool, crate_doc: &str) -> G
     if include_prelude {
         b.push_str("pub mod prelude;\n");
     }
+    b.push_str(
+        "\n/// The openEHR specification version this crate implements — the crate\n\
+         /// version itself: the spec crates are versioned by the specification they\n\
+         /// implement (`docs/VERSIONS.md` §Product and crate versioning), so\n\
+         /// consumers read the pin from the package, never from a hand-typed literal.\n\
+         pub const SPEC_VERSION: &str = env!(\"CARGO_PKG_VERSION\");\n",
+    );
     GenFile {
         path: "lib.rs".to_string(),
         body: b,


### PR DESCRIPTION
Closes #225

## What

The startup banner advertised **ITS-REST 1.0.3** (the pin is Release-1.1.0), and the AQL `RESULT_SET` `meta._schema_version` still went out as `1.0.3` on every query response. Both were hand-typed literals that silently drifted when the ITS-REST pin bumped. This PR removes the drift mechanism itself: every spec version the server displays or serves is now derived, at compile time, from the owning `openehr-*` crate version (which is by policy the implemented spec version).

## How

- **Emitter** (`tools/openehr-codegen/src/render/emit.rs`): every generated crate's `lib.rs` now carries `pub const SPEC_VERSION: &str = env!("CARGO_PKG_VERSION");`; a prefixed version module (`am14`/`am24`) additionally gets its own `SPEC_VERSION` sourced from the vendored BMM schema's `rm_release` (`1.4.0`/`2.4.0`). Regenerated output committed; drift check green.
- **Hand-written spec crates** (`openehr-its`, `openehr-query`, `openehr-adl`): the same constant, added directly. `openehr-flat` is excluded — it carries the product version, not a spec version.
- **`ehrbase::telemetry::provenance`**: all spec pins are now derivations (`pub const RM: &str = openehr_rm::SPEC_VERSION;` …). The single `AM` combined literal is replaced by `AM14`/`AM24`; `/management/info` renders the combined `"1.4.0 + 2.4.0"` form from them (wire shape unchanged). `PG_TARGET` and `CONFORMANCE_PROFILE` stay hand-maintained — no crate carries those pins (no openEHR spec governs them).
- **Banner** renders its pins from `provenance` — now prints `ITS-REST 1.1.0`.
- **`RESULT_SET` `_schema_version`** = `openehr_its::SPEC_VERSION` ("the version of the specification defining the serialized object", ITS-REST `schemas/query/ResultSet`) → `1.1.0`.
- **Served identity value change**: `restapi_specs_version` (`OPTIONS /`) and `openehr_rest_api_version` (`/status`) are now the plain `1.1.0` instead of the tag-styled `Release-1.1.0` — matching the System API OAS example (`system-codegen.openapi.yaml`: `restapi_specs_version: 1.1.0`). The ECC runner derives its report identity from the vendored OAS provenance, not the served value, and no ECC case asserts these fields, so the conformance baseline is unaffected.
- Tests updated to assert through the constants (never re-typed literals); a new provenance unit test pins the whole derivation chain.

## Verification

- `cargo nextest run` on the spec layer (`openehr-codegen`/`-its`/`-query`/`-adl`/`-rm`/`-am`): 502/502 passed, including the emitter determinism invariant.
- `cargo clippy --all-targets` clean on all touched crates (spec layer + `ehrbase`, `ehrbase-rest`, `ehrbase-server`).
- The three touched DB-backed integration tests pass (`adhoc_aql_over_http_returns_result_set`, `options_root_is_system_options_and_conformance`, `status_endpoint_is_public`).
- `scripts/check-codegen-drift.sh` green (all emit targets byte-identical to the committed tree).
- Swept the workspace for residual spec-version literals: remaining `Release-1.1.0`/`1.0.3` occurrences are prose spec citations, the ECC edition taxonomy, and the watcher's tag parsing — all correct usages.