### PR TITLE
fix: cnf-runner CI red — clippy too_many_lines + unused tokio dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,7 +1353,6 @@ dependencies = [
  "serde-saphyr",
  "serde_json",
  "thiserror 2.0.18",
- "tokio",
  "urlencoding",
 ]
 

--- a/tools/cnf-runner/Cargo.toml
+++ b/tools/cnf-runner/Cargo.toml
@@ -16,8 +16,7 @@ path = "src/bin/cnf-runner.rs"
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
-# The executor: async HTTP driver realized from the operation bindings.
-tokio = { workspace = true }
+# The executor: blocking HTTP driver realized from the operation bindings.
 reqwest = { workspace = true }
 # YAML authoring front-end for the schedule artifacts: pure Rust, no RUSTSEC
 # advisories, alias-expansion Budget against untrusted case files.

--- a/tools/cnf-runner/src/bin/cnf-runner.rs
+++ b/tools/cnf-runner/src/bin/cnf-runner.rs
@@ -143,65 +143,13 @@ fn load_party_json<T: serde::de::DeserializeOwned>(
 
 fn main() -> ExitCode {
     match Cli::parse().command {
-        Command::EmitSchemas { out } => {
-            if let Err(e) = std::fs::create_dir_all(&out) {
-                eprintln!("cannot create {}: {e}", out.display());
-                return ExitCode::from(2);
-            }
-            for (name, schema) in emit_all() {
-                let path = out.join(name);
-                if let Err(e) = std::fs::write(&path, render(&schema)) {
-                    eprintln!("cannot write {}: {e}", path.display());
-                    return ExitCode::from(2);
-                }
-                println!("wrote {}", path.display());
-            }
-            ExitCode::SUCCESS
-        }
+        Command::EmitSchemas { out } => emit_schemas_command(&out),
         Command::CompareEcc {
             root,
             ecc_catalog,
             map,
             out,
-        } => {
-            let loaded = match load_root(&root) {
-                Ok(loaded) => loaded,
-                Err(e) => {
-                    eprintln!("runner defect: {e}");
-                    return ExitCode::from(2);
-                }
-            };
-            if !loaded.errors.is_empty() {
-                for e in &loaded.errors {
-                    eprintln!("{e}");
-                }
-                return ExitCode::from(2);
-            }
-            match compare::run(&ecc_catalog, &map, &loaded.set) {
-                Ok((cmp, report)) => {
-                    if let Err(e) = std::fs::write(&out, report) {
-                        eprintln!("cannot write {}: {e}", out.display());
-                        return ExitCode::from(2);
-                    }
-                    println!(
-                        "wrote {} — mapped {} · unmapped {} · gate {}",
-                        out.display(),
-                        cmp.mapped.len(),
-                        cmp.unmapped.len(),
-                        if cmp.gate_clean() { "clean" } else { "OPEN" }
-                    );
-                    if cmp.gate_clean() {
-                        ExitCode::SUCCESS
-                    } else {
-                        ExitCode::from(1)
-                    }
-                }
-                Err(e) => {
-                    eprintln!("comparison failed: {e}");
-                    ExitCode::from(2)
-                }
-            }
-        }
+        } => compare_ecc_command(&root, &ecc_catalog, &map, &out),
         Command::Run {
             root,
             ixit,
@@ -217,40 +165,103 @@ fn main() -> ExitCode {
             &sut_version,
             filter.as_deref(),
         ),
-        Command::Validate { root, specs } => {
-            let loaded = match load_root(&root) {
-                Ok(loaded) => loaded,
-                Err(e) => {
-                    eprintln!("runner defect: {e}");
-                    return ExitCode::from(2);
-                }
-            };
-            let findings = validate(&Context {
-                set: &loaded.set,
-                load_errors: &loaded.errors,
-                spec_root: specs.as_deref(),
-            });
-            for finding in &findings {
-                println!("{finding}");
-            }
-            println!(
-                "{} case(s), {} binding(s), {} finding(s)",
-                loaded.set.cases.len(),
-                loaded.set.bindings.len(),
-                findings.len()
-            );
-            if findings.is_empty() {
-                ExitCode::SUCCESS
-            } else {
-                ExitCode::from(1)
-            }
-        }
+        Command::Validate { root, specs } => validate_command(&root, specs.as_deref()),
         Command::Verdicts {
             statement,
             results,
             root,
             out,
         } => run_verdicts(&statement, &results, &root, &out),
+    }
+}
+
+fn emit_schemas_command(out: &std::path::Path) -> ExitCode {
+    if let Err(e) = std::fs::create_dir_all(out) {
+        eprintln!("cannot create {}: {e}", out.display());
+        return ExitCode::from(2);
+    }
+    for (name, schema) in emit_all() {
+        let path = out.join(name);
+        if let Err(e) = std::fs::write(&path, render(&schema)) {
+            eprintln!("cannot write {}: {e}", path.display());
+            return ExitCode::from(2);
+        }
+        println!("wrote {}", path.display());
+    }
+    ExitCode::SUCCESS
+}
+
+fn compare_ecc_command(
+    root: &std::path::Path,
+    ecc_catalog: &std::path::Path,
+    map: &std::path::Path,
+    out: &std::path::Path,
+) -> ExitCode {
+    let loaded = match load_root(root) {
+        Ok(loaded) => loaded,
+        Err(e) => {
+            eprintln!("runner defect: {e}");
+            return ExitCode::from(2);
+        }
+    };
+    if !loaded.errors.is_empty() {
+        for e in &loaded.errors {
+            eprintln!("{e}");
+        }
+        return ExitCode::from(2);
+    }
+    match compare::run(ecc_catalog, map, &loaded.set) {
+        Ok((cmp, report)) => {
+            if let Err(e) = std::fs::write(out, report) {
+                eprintln!("cannot write {}: {e}", out.display());
+                return ExitCode::from(2);
+            }
+            println!(
+                "wrote {} — mapped {} · unmapped {} · gate {}",
+                out.display(),
+                cmp.mapped.len(),
+                cmp.unmapped.len(),
+                if cmp.gate_clean() { "clean" } else { "OPEN" }
+            );
+            if cmp.gate_clean() {
+                ExitCode::SUCCESS
+            } else {
+                ExitCode::from(1)
+            }
+        }
+        Err(e) => {
+            eprintln!("comparison failed: {e}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+fn validate_command(root: &std::path::Path, specs: Option<&std::path::Path>) -> ExitCode {
+    let loaded = match load_root(root) {
+        Ok(loaded) => loaded,
+        Err(e) => {
+            eprintln!("runner defect: {e}");
+            return ExitCode::from(2);
+        }
+    };
+    let findings = validate(&Context {
+        set: &loaded.set,
+        load_errors: &loaded.errors,
+        spec_root: specs,
+    });
+    for finding in &findings {
+        println!("{finding}");
+    }
+    println!(
+        "{} case(s), {} binding(s), {} finding(s)",
+        loaded.set.cases.len(),
+        loaded.set.bindings.len(),
+        findings.len()
+    );
+    if findings.is_empty() {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::from(1)
     }
 }
 

--- a/tools/cnf-runner/src/exec/driver.rs
+++ b/tools/cnf-runner/src/exec/driver.rs
@@ -871,10 +871,9 @@ impl StepDriver for HttpDriver<'_> {
             // The interpreter surfaces this before perform() normally; the
             // driver answers with a transport-class observation so law (c)
             // holds even if reached.
-            return Ok(StepObservation {
-                observation: Observation::Transport("operation unrealized on this ITS".into()),
-                assertion_failures: Vec::new(),
-            });
+            return Ok(StepObservation::transport(
+                "operation unrealized on this ITS".into(),
+            ));
         }
         let instance = self.instance_for(step)?;
 
@@ -889,13 +888,10 @@ impl StepDriver for HttpDriver<'_> {
                     with.insert(key.clone(), v);
                 }
                 Err(e) => {
-                    return Ok(StepObservation {
-                        observation: Observation::Transport(format!(
-                            "step {}: with.{key}: {e}",
-                            step.step
-                        )),
-                        assertion_failures: Vec::new(),
-                    });
+                    return Ok(StepObservation::transport(format!(
+                        "step {}: with.{key}: {e}",
+                        step.step
+                    )));
                 }
             }
         }
@@ -918,33 +914,18 @@ impl StepDriver for HttpDriver<'_> {
         }
         let headers = match Self::build_headers(case, step, binding, instance, &header_vars) {
             Ok(headers) => headers,
-            Err(e) => {
-                return Ok(StepObservation {
-                    observation: Observation::Transport(e),
-                    assertion_failures: Vec::new(),
-                });
-            }
+            Err(e) => return Ok(StepObservation::transport(e)),
         };
 
         let body = match self.select_body(request_spec, &with, step, vars) {
             Ok(body) => body,
-            Err(e) => {
-                return Ok(StepObservation {
-                    observation: Observation::Transport(e),
-                    assertion_failures: Vec::new(),
-                });
-            }
+            Err(e) => return Ok(StepObservation::transport(e)),
         };
 
         let base = instance.base_url.trim_end_matches('/');
         let url = match Self::build_url(binding, base, &with, &header_vars) {
             Ok(url) => url,
-            Err(e) => {
-                return Ok(StepObservation {
-                    observation: Observation::Transport(e),
-                    assertion_failures: Vec::new(),
-                });
-            }
+            Err(e) => return Ok(StepObservation::transport(e)),
         };
         let body_is_json = !matches!(body, Some(Value::String(_)));
         let exchange = match self.send(
@@ -955,12 +936,7 @@ impl StepDriver for HttpDriver<'_> {
             body_is_json,
         ) {
             Ok(exchange) => exchange,
-            Err(fault) => {
-                return Ok(StepObservation {
-                    observation: Observation::Transport(fault),
-                    assertion_failures: Vec::new(),
-                });
-            }
+            Err(fault) => return Ok(StepObservation::transport(fault)),
         };
 
         // Track committed payloads for the equivalent comparison.

--- a/tools/cnf-runner/src/exec/mod.rs
+++ b/tools/cnf-runner/src/exec/mod.rs
@@ -75,6 +75,18 @@ pub struct StepObservation {
     pub assertion_failures: Vec<String>,
 }
 
+impl StepObservation {
+    /// A transport-class observation with no assertion results — the shape
+    /// every driver-internal failure takes (see `StepDriver::perform`).
+    #[must_use]
+    pub fn transport(message: String) -> Self {
+        Self {
+            observation: Observation::Transport(message),
+            assertion_failures: Vec::new(),
+        }
+    }
+}
+
 /// One step execution seam: the live HTTP driver and the transcript player
 /// both implement this. The driver resolves the step's operation against
 /// the bindings, performs the call on the selected instance, classifies the

--- a/tools/cnf-runner/src/exec/player.rs
+++ b/tools/cnf-runner/src/exec/player.rs
@@ -130,12 +130,9 @@ impl StepDriver for TranscriptPlayer<'_> {
         vars: &mut VarStore,
     ) -> Result<StepObservation, String> {
         let Some(recorded) = self.entry.steps.get(self.cursor) else {
-            return Ok(StepObservation {
-                observation: outcome::Observation::Transport(
-                    "transcript exhausted before the flow ended".to_owned(),
-                ),
-                assertion_failures: Vec::new(),
-            });
+            return Ok(StepObservation::transport(
+                "transcript exhausted before the flow ended".to_owned(),
+            ));
         };
         self.cursor += 1;
 


### PR DESCRIPTION
develop CI went red with commit db8072103 (the #202 live-triage push): the `clippy` and `cargo-machete` jobs fail on `cnf-runner`. PR #226 inherited the same red — neither failure was #226's change (both sites are cnf-runner code untouched by it).

Three defects, all in `tools/cnf-runner`:

1. **`HttpDriver::perform` at 106/100 lines** (`exec/driver.rs`, clippy `too_many_lines` at pedantic→deny). Six repeated `StepObservation { Observation::Transport(..), assertion_failures: Vec::new() }` literals collapse into a `StepObservation::transport(message)` constructor on the type (`exec/mod.rs`); `player.rs` adopts the same constructor for its identical literal.
2. **`main()` at 110/100 lines latent in the bin** (`src/bin/cnf-runner.rs`) — CI never reached it because the lib error aborted the compile first; it fails the same gate once 1 is fixed. The `emit-schemas`/`compare-ecc`/`validate` match arms extract into per-command functions, matching the existing `run_command`/`run_verdicts` shape.
3. **Unused `tokio` dependency** (`Cargo.toml`, cargo-machete) — the executor is `reqwest::blocking` throughout; the dep and its stale "async HTTP driver" comment go.

No behaviour change: pure extraction/constructor refactor + dead-dep removal. Gates: `cargo clippy -p cnf-runner --all-targets --all-features` 0 warnings · `cargo nextest run -p cnf-runner` 86/86 · `cargo machete` clean · `cargo fmt` applied.

Dev-tool internal only (no user-visible change) → `no-changelog`.