### PR TITLE
CNF measured runs: resource telemetry + stress evidence + aql-probe instrument; --skip-seed retired

### DIFF
--- a/.claude/memory/session-workflow-gotchas.md
+++ b/.claude/memory/session-workflow-gotchas.md
@@ -28,7 +28,7 @@ Three recurring session-workflow traps (all hit 2026-07-13/14):
 4. **Killing scripts/conformance.sh destroys the seeded corpus** (hit
    2026-07-23): the script's `trap compose_down EXIT` fires on ANY exit —
    `pkill` of a mid-seed pipeline runs `docker compose down -v` and wipes
-   the hour-long 1M-composition seed + the perf-corpus sidecar's backing
+   the hour-long 1M-composition seed's backing
    data. If a run must be aborted but the corpus kept, kill with SIGKILL
    (`pkill -9 -f conformance.sh`) so the trap cannot run — or accept the
    re-seed. Corollary: smoke-test new measured-workload wire shapes against

--- a/.claude/skills/run-conformance/SKILL.md
+++ b/.claude/skills/run-conformance/SKILL.md
@@ -47,12 +47,12 @@ exclusive-server ground) → the committed catalogue → pure-function verdicts
    the `SUT_*` env variables the ixit references).
    Measured performance stage (hour-plus; exclusive SUT):
    `CONF_PERF_CLASS=POC|S|L|R` (+ `CONF_PERF_HOURS=1|2|4|6|8|12` for an
-   extended sustained hold, `CONF_PERF_SKIP_SEED=1` to reuse a prior
-   seeding's sidecar corpus index). The step-load STRESS ladder is a
+   extended sustained hold; every run seeds the freshly composed server
+   from empty — there is no seed reuse). The step-load STRESS ladder is a
    separate, non-conformance instrument:
    `cargo run -p cnf-runner -- stress --root tools/cnf-runner/artifacts
    --ixit <party>/ixit.json --out docs/conformance/<sut>/stress.json
-   [--corpus-class POC] [--skip-seed]` — it writes stress.json only, never
+   [--corpus-class POC]` — it writes stress.json only, never
    results.json. The full canonical CLI table lives in
    `tools/cnf-runner/CLAUDE.md`.
 3. **Compare against the committed baseline**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,23 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Added
+
+- **Measured runs record resource telemetry**: each measurement in
+  `results.json` now carries an optional, schema-published `resources`
+  block — per-container (server and database separately) CPU, resident
+  memory, block-device and network I/O sampled every 10 s across the
+  whole window (run-clock offsets, warmup/measured/drain phase stamps),
+  plus the database volume's on-disk size at four anchors (empty → scale
+  seed → ward seed → after the window) with the derived bytes per
+  committed composition. Sampling is enabled by the new optional
+  `containers` block in the ixit (compose container names); without it a
+  run records no resources and the report says so — telemetry never
+  influences a class verdict. Two new rendered assets (the resource
+  time-series and the disk-growth chart) join the perf-assets family and
+  the book's Performance chapter, drift-guarded in CI like every
+  published number.
+
 ### Fixed
 
 - **AQL cross-EHR queries with `LIMIT` no longer collapse under corpus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,54 +31,20 @@ workflow refuses a tag that has no matching section here.
   time-series and the disk-growth chart) join the perf-assets family and
   the book's Performance chapter, drift-guarded in CI like every
   published number.
-
-### Fixed
-
-- **AQL cross-EHR queries with `LIMIT` no longer collapse under corpus
-  scale**: predicates on multi-valued (anchored) paths now lower as
-  existential semi-joins (`EXISTS` — the predicate holds when ANY matched
-  node satisfies it; deterministic where the previous first-match pick was
-  plan-dependent), the archetype anchor index leads with the RM type so
-  the whole `CONTAINS`-class + archetype boundary is one index probe, and
-  queries that never touch audit fields no longer join the audit table.
-  The measured ward-dashboard profile (p99 5.8 s at class-POC scale) drops
-  to milliseconds-per-request territory.
-- The template **example generator no longer collapses `DV_INTERVAL`
-  wrappers** onto a single constrained bound: interval-valued elements keep
-  their interval identity (bounds as `/lower`/`/upper` sub-paths per the
-  Simplified Formats mapping), fixing generated examples the platform's own
-  validation rejected (the CKM CCTA report OPT); the CNF journey catalogue
-  re-commits the CCTA imaging report.
-
-### Removed
-
-- The completed ECC→CNF cutover comparison lane: the generated
-  `docs/conformance/cnf-comparison.md`, the `cnf-runner compare-ecc`
-  subcommand, the drift gate, and the preserved ECC catalogue/map (all in
-  git history; the five deferred grounds are re-registered on the
-  catalogue-deepening tracker). The `docs/conformance/CATALOG.md` pointer
-  stub is gone with it, and the CNF 2.0 design record moved to
-  `docs/conformance/cnf-design.md` as a permanent reference document.
-
-### Changed
-
-- The CNF measured-performance workload is now a full **hospital
-  simulation**: the class cases (`PERF-hospital_sim-*`, renamed from
-  `PERF-mixed_load-*`) schedule clinical journeys — ADT
-  admission/discharge, vitals rounds, the medication loop, medicines
-  reconciliation, asynchronous laboratory/imaging order-to-result
-  pipelines, specialist/registry reporting, public-health notifications,
-  chart review, ward dashboards with a registered stored query, versioned
-  corrections, contribution audit review, workflow tagging, logical
-  deletion, and template polling — expanding into 22 measured operation
-  kinds instead of 4, each with its own HDR-V2 record. The
-  population-anchored envelope is unchanged and now validator-enforced
-  (the expanded write share must reconcile to the derivation's 10:1..50:1
-  read:write band); journey payloads commit against 15 COMPOSITION-rooted
-  openEHR CKM templates vendored with provenance.
-
-### Added
-
+- **`cnf-runner aql-probe`** — the seeded-corpus AQL optimization probe:
+  fires the measurement machinery's own AQL vocabulary against a freshly
+  seeded server, records wire-latency percentiles per probe, and
+  attributes the database-side cost per statement (`pg_stat_statements`
+  through the ixit `containers` capability, degrading honestly without
+  it). Report schema published (`aql-probe.schema.json`); exploration
+  evidence only — never a conformance record.
+- **Stress steps carry resource telemetry** — every load-ladder rung
+  records the same per-container CPU/memory/I/O series as the measured
+  class runs over its own warmup+hold window, so a breached rung shows
+  where it saturated; the stress progress stream now logs each rung's
+  verdict live (stable/BREACHED with the sustained rate, resource peaks,
+  and named breaches) plus a ladder recap, and measured class runs log
+  their verdict evidence at window end.
 - A **diurnal day-curve** arrival option for the extended 8/12-hour
   measured holds (ITU-T E.500 busy-hour semantics: the class floor is the
   busy-hour rate).
@@ -98,6 +64,62 @@ workflow refuses a tag that has no matching section here.
   (`scripts/render-conformance-assets.sh`, CI regenerate-and-diff
   guarded) and embedded on the book's conformance and comparison pages
   (both SUTs) and the landing page.
+
+### Changed
+
+- **`--skip-seed` and the sidecar corpus index are retired** (CLI flags on
+  `perf`/`stress`, the `CONF_PERF_SKIP_SEED` pipeline variable): every
+  measurement instrument now always seeds a freshly composed, empty
+  server and the stack is torn down afterwards — seed reuse bred
+  stale-state confusion.
+- **Measurement instruments settle database maintenance
+  deterministically** (`vacuumdb --analyze` through the DB container)
+  after seeding and before every measured window and stress rung —
+  a stale-statistics plan after the million-row seed cost a measured ~9×
+  on the ward-worklist query; settling moves that debt outside every
+  measured window, identically for every SUT.
+- The CNF measured-performance workload is now a full **hospital
+  simulation**: the class cases (`PERF-hospital_sim-*`, renamed from
+  `PERF-mixed_load-*`) schedule clinical journeys — ADT
+  admission/discharge, vitals rounds, the medication loop, medicines
+  reconciliation, asynchronous laboratory/imaging order-to-result
+  pipelines, specialist/registry reporting, public-health notifications,
+  chart review, ward dashboards with a registered stored query, versioned
+  corrections, contribution audit review, workflow tagging, logical
+  deletion, and template polling — expanding into 22 measured operation
+  kinds instead of 4, each with its own HDR-V2 record. The
+  population-anchored envelope is unchanged and now validator-enforced
+  (the expanded write share must reconcile to the derivation's 10:1..50:1
+  read:write band); journey payloads commit against 15 COMPOSITION-rooted
+  openEHR CKM templates vendored with provenance.
+
+### Removed
+
+- The completed ECC→CNF cutover comparison lane: the generated
+  `docs/conformance/cnf-comparison.md`, the `cnf-runner compare-ecc`
+  subcommand, the drift gate, and the preserved ECC catalogue/map (all in
+  git history; the five deferred grounds are re-registered on the
+  catalogue-deepening tracker). The `docs/conformance/CATALOG.md` pointer
+  stub is gone with it, and the CNF 2.0 design record moved to
+  `docs/conformance/cnf-design.md` as a permanent reference document.
+
+### Fixed
+
+- **AQL cross-EHR queries with `LIMIT` no longer collapse under corpus
+  scale**: predicates on multi-valued (anchored) paths now lower as
+  existential semi-joins (`EXISTS` — the predicate holds when ANY matched
+  node satisfies it; deterministic where the previous first-match pick was
+  plan-dependent), the archetype anchor index leads with the RM type so
+  the whole `CONTAINS`-class + archetype boundary is one index probe, and
+  queries that never touch audit fields no longer join the audit table.
+  The measured ward-dashboard profile (p99 5.8 s at class-POC scale) drops
+  to milliseconds-per-request territory.
+- The template **example generator no longer collapses `DV_INTERVAL`
+  wrappers** onto a single constrained bound: interval-valued elements keep
+  their interval identity (bounds as `/lower`/`/upper` sub-paths per the
+  Simplified Formats mapping), fixing generated examples the platform's own
+  validation rejected (the CKM CCTA report OPT); the CNF journey catalogue
+  re-commits the CCTA imaging report.
 
 ## [3.7.0] - 2026-07-22
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,8 +126,8 @@ cargo fmt --all
 cargo audit && cargo deny check
 # conformance pipeline (the acceptance instrument) — the CNF 2.0 runner:
 bash scripts/conformance.sh   # compose up --build (fresh volumes) → the CNF catalogue → verdicts → docs/conformance/<sut>/ (results + verdicts + report/statement/certificate + badges); baseline numbers live ONLY in the committed artifacts
-# measured performance (hour-plus, exclusive SUT): CONF_PERF_CLASS=POC|S|L|R [CONF_PERF_HOURS=1|2|4|6|8|12] [CONF_PERF_SKIP_SEED=1] bash scripts/conformance.sh
-# step-load STRESS (exploration only, never a conformance record): cargo run -p cnf-runner -- stress --root tools/cnf-runner/artifacts --ixit <party>/ixit.json --out docs/conformance/<sut>/stress.json [--skip-seed]
+# measured performance (hour-plus, exclusive SUT): CONF_PERF_CLASS=POC|S|L|R [CONF_PERF_HOURS=1|2|4|6|8|12] bash scripts/conformance.sh
+# step-load STRESS (exploration only, never a conformance record): cargo run -p cnf-runner -- stress --root tools/cnf-runner/artifacts --ixit <party>/ixit.json --out docs/conformance/<sut>/stress.json
 # published perf/stress SVGs + summary regenerate FROM committed artifacts: bash scripts/render-perf-assets.sh (CI diff-guards) — full canonical CLI table: tools/cnf-runner/CLAUDE.md
 # admin-console gates: /ui-gates (both-target clippy, nextest, leptosfmt, cargo-leptos build)
 bash scripts/ui-e2e.sh        # the browser journey battery against the composed stack (merge gate in CI)

--- a/README.md
+++ b/README.md
@@ -289,12 +289,12 @@ committed results so the verdict re-derives from the artifact alone:
 CONF_PERF_CLASS=POC bash scripts/conformance.sh
 
 # an extended sustained hold (a stricter demonstration of the same class)
-CONF_PERF_CLASS=POC CONF_PERF_HOURS=8 CONF_PERF_SKIP_SEED=1 bash scripts/conformance.sh
+CONF_PERF_CLASS=POC CONF_PERF_HOURS=8 bash scripts/conformance.sh
 
 # the step-load stress instrument — exploration only, never a conformance record
 cargo run -p cnf-runner -- stress --root tools/cnf-runner/artifacts \
   --ixit tools/cnf-runner/party/ehrbase-rs/ixit.json \
-  --out docs/conformance/ehrbase-rs/stress.json --skip-seed
+  --out docs/conformance/ehrbase-rs/stress.json
 ```
 
 The published performance visuals — the class ladder, per-operation latency

--- a/README.md
+++ b/README.md
@@ -302,6 +302,21 @@ percentiles, and the latency-throughput stress curve — regenerate from the
 committed records (`bash scripts/render-perf-assets.sh`) and are diff-guarded
 in CI, exactly like the conformance numbers.
 
+The committed stress run's latency-throughput curve — the knee, the p99
+budget line, and the class floors as context — renders straight from
+[`docs/conformance/ehrbase-rs/stress.json`](docs/conformance/ehrbase-rs/stress.json)
+(exploration only; the chart carries the measured numbers so none are typed
+here):
+
+![The latency-throughput stress curve](website/book/src/perf-assets/perf-stress-curve.svg)
+
+Every measured class run and every stress step also records **resource
+telemetry**: per-container CPU, resident memory, and block/network I/O for
+the server and the database separately — plus, on class runs, the database
+volume's disk anchors down to the storage cost per committed composition.
+The committed record shows what a run cost the machine and where saturation
+lives; telemetry is measured context only and never influences a verdict.
+
 ## Measured against EHRbase (Java)
 
 One benchmark, two servers, byte-identical requests: a **simulated hospital

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -57,7 +57,7 @@ CONF_PERF_CLASS=POC CONF_PERF_HOURS=1 bash scripts/conformance.sh
 # the step-load stress ladder (exploration only)
 cargo run -p cnf-runner -- stress --root tools/cnf-runner/artifacts \
   --ixit tools/cnf-runner/party/<sut>/ixit.json \
-  --out docs/conformance/<sut>/stress.json --skip-seed
+  --out docs/conformance/<sut>/stress.json
 
 # regenerate every published perf/stress visual FROM committed artifacts
 bash scripts/render-perf-assets.sh

--- a/docs/conformance/ehrbase-rs/stress.json
+++ b/docs/conformance/ehrbase-rs/stress.json
@@ -1,0 +1,6231 @@
+{
+  "corpus": "cnf.scale.10k",
+  "environment": {
+    "exclusive_server": true,
+    "hardware_class": "consumer-laptop",
+    "cores": 8,
+    "memory_gb": 16,
+    "storage_class": "nvme",
+    "topology": "single-node docker compose (8-CPU/8GB Docker VM) on Apple M2"
+  },
+  "step_warmup_s": 30,
+  "step_hold_s": 120,
+  "p99_budget_ms": 1000.0,
+  "error_budget": 0.001,
+  "steps": [
+    {
+      "rate": 2.0,
+      "offered_load_sustained": 2.0166666666666666,
+      "operations": [
+        {
+          "operation": "adhoc_query",
+          "requests": 32,
+          "errors": 0,
+          "latency_ms_p50": 30.207,
+          "latency_ms_p90": 41.855,
+          "latency_ms_p99": 47.007,
+          "hdr_v2_base64": "HISTEwAAAEcAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAI9RAocCAhsCIwJxAgMCCQKHAQJ3AlUCCQIJAjcCNQKrBAJDAnECewKHAQIDAgUCAAINAk8CBwIvAhkCHwKLAgJLAmUCiQEC"
+        },
+        {
+          "operation": "composition_commit",
+          "requests": 10,
+          "errors": 0,
+          "latency_ms_p50": 41.887,
+          "latency_ms_p90": 93.887,
+          "latency_ms_p99": 96.639,
+          "hdr_v2_base64": "HISTEwAAABsAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJVbAokEAlsCLQKFBAKzAQKbAgLdAwKFCwJTAg=="
+        },
+        {
+          "operation": "composition_read",
+          "requests": 64,
+          "errors": 0,
+          "latency_ms_p50": 20.415,
+          "latency_ms_p90": 26.463,
+          "latency_ms_p99": 51.423,
+          "hdr_v2_base64": "HISTEwAAAIEAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAK85AqEHAqkDArMEAnMC5QECjwECzQECewKLAQItAgkCBwINAgMCTQIhAhcCBwIpBAIrAg8CAAQnAgkCJQIFAgMCHwIHBBECAAIRAhUCOQINAiUCGwIHAg0CHwJZAgUCBQIFAgkCBQIFAlkCPwJLAgACVQQRAikCFwJXArEBArcMAg=="
+        },
+        {
+          "operation": "composition_read_current",
+          "requests": 36,
+          "errors": 0,
+          "latency_ms_p50": 20.943,
+          "latency_ms_p90": 25.599,
+          "latency_ms_p99": 29.231,
+          "hdr_v2_base64": "HISTEwAAAEkAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAMVFAvEEAqMBAhMChwQCAkkCJwIXAhUCRwJhAgcCOQIpAgkCVwIFAp0BAkECJQIPAgIlBAIVAgkCVwINAkECJQICowECmQICAAI="
+        },
+        {
+          "operation": "composition_revision_history",
+          "requests": 34,
+          "errors": 0,
+          "latency_ms_p50": 15.087,
+          "latency_ms_p90": 22.127,
+          "latency_ms_p99": 29.759,
+          "hdr_v2_base64": "HISTEwAAAE0AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJM/ApkFAuEBAgkCewI7Ag0CIQKRAQIVAgMCNQIlAhkCAAK3AQK7AQIvAqsCAk0CBwJBAgcCOQJzAgACDwKZAQItAhsCVQIPAhMCjwcC"
+        },
+        {
+          "operation": "composition_update",
+          "requests": 3,
+          "errors": 0,
+          "latency_ms_p50": 43.935,
+          "latency_ms_p90": 54.111,
+          "latency_ms_p99": 54.111,
+          "hdr_v2_base64": "HISTEwAAAAkAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPlSArsSAvkEAg=="
+        },
+        {
+          "operation": "contribution_commit",
+          "requests": 2,
+          "errors": 0,
+          "latency_ms_p50": 24.191,
+          "latency_ms_p90": 90.879,
+          "latency_ms_p99": 90.879,
+          "hdr_v2_base64": "HISTEwAAAAYAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAM1XAsUeAg=="
+        },
+        {
+          "operation": "contribution_read",
+          "requests": 4,
+          "errors": 0,
+          "latency_ms_p50": 15.799,
+          "latency_ms_p90": 21.535,
+          "latency_ms_p99": 21.535,
+          "hdr_v2_base64": "HISTEwAAAAwAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAK9KArkEAs0DAsMCAg=="
+        },
+        {
+          "operation": "directory_read",
+          "requests": 31,
+          "errors": 0,
+          "latency_ms_p50": 16.783,
+          "latency_ms_p90": 21.423,
+          "latency_ms_p99": 27.695,
+          "hdr_v2_base64": "HISTEwAAAEQAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAALNGAlUClwEC3QECNQKBAgIjAgACUQIlAgcCLQI7AnMCSQILAkUC9QECBwILAhcCKQIjAgcCFwI3AhECCwIbApUFAlcC"
+        },
+        {
+          "operation": "directory_update",
+          "requests": 1,
+          "errors": 0,
+          "latency_ms_p50": 40.991,
+          "latency_ms_p90": 40.991,
+          "latency_ms_p99": 40.991,
+          "hdr_v2_base64": "HISTEwAAAAMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAP9jAg=="
+        },
+        {
+          "operation": "ehr_create",
+          "requests": 1,
+          "errors": 0,
+          "latency_ms_p50": 17.327,
+          "latency_ms_p90": 17.327,
+          "latency_ms_p99": 17.327,
+          "hdr_v2_base64": "HISTEwAAAAMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPNQAg=="
+        },
+        {
+          "operation": "ehr_read",
+          "requests": 3,
+          "errors": 0,
+          "latency_ms_p50": 18.559,
+          "latency_ms_p90": 18.623,
+          "latency_ms_p99": 18.623,
+          "hdr_v2_base64": "HISTEwAAAAgAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAN9QAqsBAgUC"
+        },
+        {
+          "operation": "stored_query_execute",
+          "requests": 6,
+          "errors": 0,
+          "latency_ms_p50": 28.031,
+          "latency_ms_p90": 33.215,
+          "latency_ms_p99": 33.215,
+          "hdr_v2_base64": "HISTEwAAABAAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJFUAgAClQcC4wECAwL9AgI="
+        },
+        {
+          "operation": "tags_put",
+          "requests": 1,
+          "errors": 0,
+          "latency_ms_p50": 26.271,
+          "latency_ms_p90": 26.271,
+          "latency_ms_p99": 26.271,
+          "hdr_v2_base64": "HISTEwAAAAMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAANFZAg=="
+        },
+        {
+          "operation": "tags_read",
+          "requests": 1,
+          "errors": 0,
+          "latency_ms_p50": 21.999,
+          "latency_ms_p90": 21.999,
+          "latency_ms_p99": 21.999,
+          "hdr_v2_base64": "HISTEwAAAAMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAALtVAg=="
+        },
+        {
+          "operation": "template_get",
+          "requests": 3,
+          "errors": 0,
+          "latency_ms_p50": 65.503,
+          "latency_ms_p90": 67.199,
+          "latency_ms_p99": 67.199,
+          "hdr_v2_base64": "HISTEwAAAAgAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPFcAocTAjMC"
+        },
+        {
+          "operation": "template_list",
+          "requests": 3,
+          "errors": 0,
+          "latency_ms_p50": 12.815,
+          "latency_ms_p90": 17.743,
+          "latency_ms_p99": 17.743,
+          "hdr_v2_base64": "HISTEwAAAAkAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPFHAo0BAqMIAg=="
+        },
+        {
+          "operation": "ward_query",
+          "requests": 7,
+          "errors": 0,
+          "latency_ms_p50": 187.391,
+          "latency_ms_p90": 285.439,
+          "latency_ms_p99": 285.439,
+          "hdr_v2_base64": "HISTEwAAABAAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJeDAQL3AgJZBJsGAgKjBAI="
+        }
+      ],
+      "stable": true,
+      "generator_bound": false,
+      "resources": {
+        "sample_interval_s": 10,
+        "containers": [
+          {
+            "role": "sut",
+            "name": "ehrbase-rs-ehrbase-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 1.7040302663062576,
+                "rss_bytes": 218107904,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4136202453,
+                "net_tx_bytes": 7842163460
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 1.1775974427311788,
+                "rss_bytes": 218087424,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4136361520,
+                "net_tx_bytes": 7842276738
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 1.3006915528723406,
+                "rss_bytes": 219578368,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4136622293,
+                "net_tx_bytes": 7842495505
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 2.4303460500050154,
+                "rss_bytes": 220446720,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4136903589,
+                "net_tx_bytes": 7842947137
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 1.2513643486172703,
+                "rss_bytes": 219930624,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4137097533,
+                "net_tx_bytes": 7843146280
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 1.155595237097454,
+                "rss_bytes": 219934720,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4137261750,
+                "net_tx_bytes": 7843315199
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 1.6103638231930544,
+                "rss_bytes": 220475392,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4137853461,
+                "net_tx_bytes": 7843670579
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 1.0410246951000917,
+                "rss_bytes": 220565504,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4137993360,
+                "net_tx_bytes": 7843772128
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 0.7564710446909763,
+                "rss_bytes": 220561408,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4138096846,
+                "net_tx_bytes": 7843859006
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 1.2807780694555704,
+                "rss_bytes": 220565504,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4138277861,
+                "net_tx_bytes": 7844021028
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 1.0612943141993796,
+                "rss_bytes": 220573696,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4138482682,
+                "net_tx_bytes": 7844227368
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 1.936430909377761,
+                "rss_bytes": 222257152,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4140722884,
+                "net_tx_bytes": 7844661168
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 1.127864951331429,
+                "rss_bytes": 221970432,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4140857629,
+                "net_tx_bytes": 7844786773
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 1.1617721130058263,
+                "rss_bytes": 221954048,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4141025622,
+                "net_tx_bytes": 7844918096
+              },
+              {
+                "offset_s": 150,
+                "phase": "drain",
+                "cpu_pct": 1.0746006274240134,
+                "rss_bytes": 225591296,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4143890293,
+                "net_tx_bytes": 7845033762
+              }
+            ]
+          },
+          {
+            "role": "db",
+            "name": "ehrbase-rs-ehrbase-postgres-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 28.132521914412795,
+                "rss_bytes": 1898385408,
+                "blk_read_bytes": 3133194240,
+                "blk_write_bytes": 44357648384,
+                "net_rx_bytes": 7178951967,
+                "net_tx_bytes": 979901417
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 37.55260095232029,
+                "rss_bytes": 1871634432,
+                "blk_read_bytes": 3326353408,
+                "blk_write_bytes": 45090521088,
+                "net_rx_bytes": 7179038913,
+                "net_tx_bytes": 980051571
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 5.1009700128053534,
+                "rss_bytes": 1873260544,
+                "blk_read_bytes": 3327467520,
+                "blk_write_bytes": 45094412288,
+                "net_rx_bytes": 7179230045,
+                "net_tx_bytes": 980262585
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 5.605206795940601,
+                "rss_bytes": 1880215552,
+                "blk_read_bytes": 3328909312,
+                "blk_write_bytes": 45098672128,
+                "net_rx_bytes": 7179656478,
+                "net_tx_bytes": 980409402
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 2.9951438594397635,
+                "rss_bytes": 1881821184,
+                "blk_read_bytes": 3329646592,
+                "blk_write_bytes": 45103767552,
+                "net_rx_bytes": 7179832729,
+                "net_tx_bytes": 980557825
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 5.602087588862786,
+                "rss_bytes": 1882177536,
+                "blk_read_bytes": 3330981888,
+                "blk_write_bytes": 45106880512,
+                "net_rx_bytes": 7179976052,
+                "net_tx_bytes": 980691903
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 2.783519300175806,
+                "rss_bytes": 1883254784,
+                "blk_read_bytes": 3332038656,
+                "blk_write_bytes": 45110091776,
+                "net_rx_bytes": 7180304887,
+                "net_tx_bytes": 981179364
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 5.132535727939425,
+                "rss_bytes": 1887952896,
+                "blk_read_bytes": 3332882432,
+                "blk_write_bytes": 45113352192,
+                "net_rx_bytes": 7180382058,
+                "net_tx_bytes": 981309447
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 4.082249035281174,
+                "rss_bytes": 1889181696,
+                "blk_read_bytes": 3334037504,
+                "blk_write_bytes": 45116358656,
+                "net_rx_bytes": 7180447338,
+                "net_tx_bytes": 981405072
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 3.1482972354133962,
+                "rss_bytes": 1889275904,
+                "blk_read_bytes": 3335110656,
+                "blk_write_bytes": 45118898176,
+                "net_rx_bytes": 7180583948,
+                "net_tx_bytes": 981551800
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 4.758494967127095,
+                "rss_bytes": 1891737600,
+                "blk_read_bytes": 3336093696,
+                "blk_write_bytes": 45122633728,
+                "net_rx_bytes": 7180764472,
+                "net_tx_bytes": 981710712
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 4.161928876381133,
+                "rss_bytes": 1910382592,
+                "blk_read_bytes": 3337404416,
+                "blk_write_bytes": 45126205440,
+                "net_rx_bytes": 7181144194,
+                "net_tx_bytes": 983799247
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 4.307578286541669,
+                "rss_bytes": 1898467328,
+                "blk_read_bytes": 3338059776,
+                "blk_write_bytes": 45128327168,
+                "net_rx_bytes": 7181247281,
+                "net_tx_bytes": 983907364
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 8.071913399094292,
+                "rss_bytes": 1898131456,
+                "blk_read_bytes": 3339239424,
+                "blk_write_bytes": 45154148352,
+                "net_rx_bytes": 7181352169,
+                "net_tx_bytes": 984055484
+              },
+              {
+                "offset_s": 150,
+                "phase": "drain",
+                "cpu_pct": 7.946185333419158,
+                "rss_bytes": 1899421696,
+                "blk_read_bytes": 3340447744,
+                "blk_write_bytes": 45195329536,
+                "net_rx_bytes": 7181425627,
+                "net_tx_bytes": 986911643
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "rate": 4.0,
+      "offered_load_sustained": 4.05,
+      "operations": [
+        {
+          "operation": "adhoc_query",
+          "requests": 63,
+          "errors": 0,
+          "latency_ms_p50": 28.431,
+          "latency_ms_p90": 37.791,
+          "latency_ms_p99": 46.719,
+          "hdr_v2_base64": "HISTEwAAAH4AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAOdLAvcGAm8CAj0CsQECLwJNAgcCHwILAjUCEQQLAgsCEQKHAQIrAhsCJQIPAgI5AgsCBwIJAg0CFQIlAgACFQRRAjkCPQI1Ah8CBwINAi8CIQInAikCBwIbAh0CHQIRAgACIwIrAgACWwIFAgACIwK3AQIXAn8CEQIAAr0BAg=="
+        },
+        {
+          "operation": "composition_commit",
+          "requests": 23,
+          "errors": 0,
+          "latency_ms_p50": 36.447,
+          "latency_ms_p90": 83.007,
+          "latency_ms_p99": 89.343,
+          "hdr_v2_base64": "HISTEwAAADcAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAALNSAgkC1QEC2wMCZwJ3AocCAt8CAtsBAq0BAgILAgUCIQICDQKRAwLHBQIzAsMFAqEDAk8CcQI="
+        },
+        {
+          "operation": "composition_read",
+          "requests": 128,
+          "errors": 0,
+          "latency_ms_p50": 17.615,
+          "latency_ms_p90": 22.975,
+          "latency_ms_p99": 27.759,
+          "hdr_v2_base64": "HISTEwAAAO8AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAI84AkUCxwUC5QMCPQI1AlUCAwKFAQIVAicCOQJhAmUCDQK/AQIRAl8CGQIAAhsCBQIRAkkCBwI1AgUCCwIRAjUCGwIDAisCHQIRAiUCCwIbAi0CDwIdAh8CFwIlAgsCCwINAgACCwQABBECBQIHAgMEAAICHwQDAgkCCQINAiUCCwIJAgILAgUCCwILAgUCCwIABAILAgIFAjcCBwQxAgACBwICDwIDAgMCHQICBwINAg8CAgACAwQVAg0CAgIAAgsCAgMCAAIPAhsCDQIpAg8CEQIFAiUCDwIJAhkCAwIDAlECLQItAi0CgQICkwUC"
+        },
+        {
+          "operation": "composition_read_current",
+          "requests": 73,
+          "errors": 0,
+          "latency_ms_p50": 20.287,
+          "latency_ms_p90": 24.895,
+          "latency_ms_p99": 32.799,
+          "hdr_v2_base64": "HISTEwAAAIkAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAALFBAoEFAksCtwECAo0BAi8CfwJjAnsCLwJbAksCDwQAAkkCDQIhAjMCHQIAAgIAAk0CJwIRAgkCFQILAiMCMwQPAg8CMwIxAiUCCwIAAhMCEwIVAgMCDwIVAhECAhUCGQI5Ag8CGQICMQIAAgMCAAYXAgICCQIpAkECAhMCHQJFAg8CvQIChQQC"
+        },
+        {
+          "operation": "composition_revision_history",
+          "requests": 68,
+          "errors": 0,
+          "latency_ms_p50": 14.631,
+          "latency_ms_p90": 18.591,
+          "latency_ms_p99": 23.823,
+          "hdr_v2_base64": "HISTEwAAAI0AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAANE1Ar0EAnUCJQIZApUBAkMCiwECPQKxAgJpAgcCiwECIwJdAiMCeQJTAj8CAAIFAikCYQIpAgsCJwIzAiMCBwILAiUC2QECLQIrAhkCSQKFAQILAg8CEwIJAkkCLwIPAhkCAgcCFQIAAgUCEQIlAgMCAgACEQIDAjECAgICHQIFAksCHwIvApcCAscBAg=="
+        },
+        {
+          "operation": "composition_update",
+          "requests": 5,
+          "errors": 0,
+          "latency_ms_p50": 26.927,
+          "latency_ms_p90": 31.775,
+          "latency_ms_p99": 31.775,
+          "hdr_v2_base64": "HISTEwAAAA4AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAALlXAvUBAm8CxwMCkQEC"
+        },
+        {
+          "operation": "contribution_commit",
+          "requests": 3,
+          "errors": 0,
+          "latency_ms_p50": 24.863,
+          "latency_ms_p90": 60.191,
+          "latency_ms_p99": 60.191,
+          "hdr_v2_base64": "HISTEwAAAAkAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAKlDAvUUAosVAg=="
+        },
+        {
+          "operation": "contribution_read",
+          "requests": 7,
+          "errors": 0,
+          "latency_ms_p50": 14.431,
+          "latency_ms_p90": 16.783,
+          "latency_ms_p99": 16.783,
+          "hdr_v2_base64": "HISTEwAAABQAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAK9AArMJAm8CuwECgQEC7QECowEC"
+        },
+        {
+          "operation": "directory_read",
+          "requests": 65,
+          "errors": 0,
+          "latency_ms_p50": 16.319,
+          "latency_ms_p90": 20.767,
+          "latency_ms_p99": 29.935,
+          "hdr_v2_base64": "HISTEwAAAIoAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAALUzArsIAvcCAhMCgQICXQKdAQIhAh0CcQJLAh0CIwIXAkUCMQIFApcBAk0CJwIxAlcCowECMwIzAjsCKwJvAhECKQKDAQIVAgkCDwIrAkkCBQIJAhMCAAITAgIDAiUCCwIHAgcEAwI7Ai0CAwIVAg8CAwIvAh0CBwIJAhcCXQIPAoUBAtcBAokFAg=="
+        },
+        {
+          "operation": "directory_update",
+          "requests": 1,
+          "errors": 0,
+          "latency_ms_p50": 16.847,
+          "latency_ms_p90": 16.847,
+          "latency_ms_p99": 16.847,
+          "hdr_v2_base64": "HISTEwAAAAMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAALdQAg=="
+        },
+        {
+          "operation": "ehr_create",
+          "requests": 1,
+          "errors": 0,
+          "latency_ms_p50": 21.183,
+          "latency_ms_p90": 21.183,
+          "latency_ms_p99": 21.183,
+          "hdr_v2_base64": "HISTEwAAAAMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAANVUAg=="
+        },
+        {
+          "operation": "ehr_read",
+          "requests": 6,
+          "errors": 0,
+          "latency_ms_p50": 10.551,
+          "latency_ms_p90": 16.143,
+          "latency_ms_p99": 16.143,
+          "hdr_v2_base64": "HISTEwAAABEAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAKU2AoEOAh8CjwQC3QQCgQIC"
+        },
+        {
+          "operation": "ehr_status_read",
+          "requests": 1,
+          "errors": 0,
+          "latency_ms_p50": 14.111,
+          "latency_ms_p90": 14.111,
+          "latency_ms_p99": 14.111,
+          "hdr_v2_base64": "HISTEwAAAAMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAMVLAg=="
+        },
+        {
+          "operation": "ehr_status_update",
+          "requests": 1,
+          "errors": 0,
+          "latency_ms_p50": 18.783,
+          "latency_ms_p90": 18.783,
+          "latency_ms_p99": 18.783,
+          "hdr_v2_base64": "HISTEwAAAAMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAKlSAg=="
+        },
+        {
+          "operation": "stored_query_execute",
+          "requests": 13,
+          "errors": 0,
+          "latency_ms_p50": 30.143,
+          "latency_ms_p90": 35.487,
+          "latency_ms_p99": 37.695,
+          "hdr_v2_base64": "HISTEwAAACMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAIdSAt8BArECAt0DApkBAvUBAiEC+QECgQECAAIvAjkChwEC"
+        },
+        {
+          "operation": "tags_put",
+          "requests": 2,
+          "errors": 0,
+          "latency_ms_p50": 7.919,
+          "latency_ms_p90": 19.279,
+          "latency_ms_p99": 19.279,
+          "hdr_v2_base64": "HISTEwAAAAYAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPU+Au8TAg=="
+        },
+        {
+          "operation": "tags_read",
+          "requests": 2,
+          "errors": 0,
+          "latency_ms_p50": 11.703,
+          "latency_ms_p90": 16.263,
+          "latency_ms_p99": 16.263,
+          "hdr_v2_base64": "HISTEwAAAAYAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAOtGAvEIAg=="
+        },
+        {
+          "operation": "template_get",
+          "requests": 6,
+          "errors": 0,
+          "latency_ms_p50": 34.175,
+          "latency_ms_p90": 47.231,
+          "latency_ms_p99": 47.231,
+          "hdr_v2_base64": "HISTEwAAABEAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJtVAsEEAvMGAlEC0wICgwMC"
+        },
+        {
+          "operation": "template_list",
+          "requests": 5,
+          "errors": 0,
+          "latency_ms_p50": 10.991,
+          "latency_ms_p90": 15.399,
+          "latency_ms_p99": 15.399,
+          "hdr_v2_base64": "HISTEwAAAA4AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPdCAssBAnECgQYCxwIC"
+        },
+        {
+          "operation": "ward_query",
+          "requests": 13,
+          "errors": 0,
+          "latency_ms_p50": 232.703,
+          "latency_ms_p90": 330.495,
+          "latency_ms_p99": 353.535,
+          "hdr_v2_base64": "HISTEwAAACIAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAM2CAQItAssBAuUGAgcCaQIFAoEBAgUC7wICRwKXAwKxAQI="
+        }
+      ],
+      "stable": true,
+      "generator_bound": false,
+      "resources": {
+        "sample_interval_s": 10,
+        "containers": [
+          {
+            "role": "sut",
+            "name": "ehrbase-rs-ehrbase-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 2.1548329812563667,
+                "rss_bytes": 225619968,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4144588097,
+                "net_tx_bytes": 7845351585
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 2.4901006001872807,
+                "rss_bytes": 225636352,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4145124141,
+                "net_tx_bytes": 7846150342
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 1.7158460104554,
+                "rss_bytes": 225628160,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4145365214,
+                "net_tx_bytes": 7846339926
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 1.9896380342224191,
+                "rss_bytes": 229220352,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4146478938,
+                "net_tx_bytes": 7846632573
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 1.7909558668430376,
+                "rss_bytes": 229199872,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4146727640,
+                "net_tx_bytes": 7846843689
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 2.1026646275074534,
+                "rss_bytes": 237600768,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4148970326,
+                "net_tx_bytes": 7847264448
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 2.277244451033607,
+                "rss_bytes": 237494272,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4149351787,
+                "net_tx_bytes": 7847736988
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 2.259747495410818,
+                "rss_bytes": 237494272,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4150050148,
+                "net_tx_bytes": 7848331778
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 1.8345408032819346,
+                "rss_bytes": 237498368,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4150438512,
+                "net_tx_bytes": 7848846632
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 2.1733903050426084,
+                "rss_bytes": 237658112,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4151294151,
+                "net_tx_bytes": 7849230844
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 1.5819734922291981,
+                "rss_bytes": 237637632,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4151531252,
+                "net_tx_bytes": 7849422120
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 1.6459876351507328,
+                "rss_bytes": 237641728,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4151792538,
+                "net_tx_bytes": 7849625622
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 1.9202133531351306,
+                "rss_bytes": 245968896,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4152798621,
+                "net_tx_bytes": 7849919661
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 1.8355310793332427,
+                "rss_bytes": 245968896,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4153075563,
+                "net_tx_bytes": 7850156111
+              }
+            ]
+          },
+          {
+            "role": "db",
+            "name": "ehrbase-rs-ehrbase-postgres-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 9.46976463890735,
+                "rss_bytes": 1901142016,
+                "blk_read_bytes": 3342766080,
+                "blk_write_bytes": 45239492608,
+                "net_rx_bytes": 7181689558,
+                "net_tx_bytes": 987540399
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 10.186026127755268,
+                "rss_bytes": 1909944320,
+                "blk_read_bytes": 3345620992,
+                "blk_write_bytes": 45272416256,
+                "net_rx_bytes": 7182439892,
+                "net_tx_bytes": 987831795
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 11.120127727758977,
+                "rss_bytes": 1916260352,
+                "blk_read_bytes": 3347996672,
+                "blk_write_bytes": 45307895808,
+                "net_rx_bytes": 7182582136,
+                "net_tx_bytes": 988056026
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 11.175567519411644,
+                "rss_bytes": 1909211136,
+                "blk_read_bytes": 3349995520,
+                "blk_write_bytes": 45346570240,
+                "net_rx_bytes": 7182817251,
+                "net_tx_bytes": 989102918
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 11.398104669020135,
+                "rss_bytes": 1910435840,
+                "blk_read_bytes": 3352850432,
+                "blk_write_bytes": 45386326016,
+                "net_rx_bytes": 7182982063,
+                "net_tx_bytes": 989323157
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 7.670265953379879,
+                "rss_bytes": 1913192448,
+                "blk_read_bytes": 3355877376,
+                "blk_write_bytes": 45403406336,
+                "net_rx_bytes": 7183335401,
+                "net_tx_bytes": 991476303
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 6.439658502865234,
+                "rss_bytes": 1913044992,
+                "blk_read_bytes": 3358162944,
+                "blk_write_bytes": 45408567296,
+                "net_rx_bytes": 7183759817,
+                "net_tx_bytes": 991700616
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 7.633979885199254,
+                "rss_bytes": 1915142144,
+                "blk_read_bytes": 3360722944,
+                "blk_write_bytes": 45426810880,
+                "net_rx_bytes": 7184300265,
+                "net_tx_bytes": 992206781
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 6.957967702885999,
+                "rss_bytes": 1917759488,
+                "blk_read_bytes": 3363151872,
+                "blk_write_bytes": 45440024576,
+                "net_rx_bytes": 7184770677,
+                "net_tx_bytes": 992445129
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 10.433624779468289,
+                "rss_bytes": 2028408832,
+                "blk_read_bytes": 3365675008,
+                "blk_write_bytes": 45482991616,
+                "net_rx_bytes": 7185097109,
+                "net_tx_bytes": 993178642
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 7.295007459830119,
+                "rss_bytes": 1921855488,
+                "blk_read_bytes": 3368095744,
+                "blk_write_bytes": 45501341696,
+                "net_rx_bytes": 7185243816,
+                "net_tx_bytes": 993387586
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 4.900798105683454,
+                "rss_bytes": 1922334720,
+                "blk_read_bytes": 3370840064,
+                "blk_write_bytes": 45503029248,
+                "net_rx_bytes": 7185399489,
+                "net_tx_bytes": 993621263
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 6.210014494151413,
+                "rss_bytes": 1923604480,
+                "blk_read_bytes": 3373989888,
+                "blk_write_bytes": 45504806912,
+                "net_rx_bytes": 7185635931,
+                "net_tx_bytes": 994555727
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 6.255679220443472,
+                "rss_bytes": 1923637248,
+                "blk_read_bytes": 3376898048,
+                "blk_write_bytes": 45510897664,
+                "net_rx_bytes": 7185824267,
+                "net_tx_bytes": 994790103
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "rate": 8.0,
+      "offered_load_sustained": 8.075,
+      "operations": [
+        {
+          "operation": "adhoc_query",
+          "requests": 127,
+          "errors": 0,
+          "latency_ms_p50": 25.503,
+          "latency_ms_p90": 34.751,
+          "latency_ms_p99": 65.599,
+          "hdr_v2_base64": "HISTEwAAAPUAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAMlAAtsBAhUCvQIC0wECjwECtwECJwJbAt0CAikCHQIlAusBAhECFQI1AgcCAwIzAg0CHwIRAgcCAiMCFwQHAkECAwIVAhsCGQQxAjMCNQIHAiECCwITAmECBQIAAgACAgsEIQI1AgIHAgsCAwICBwIXAgACQQIPAgUCAiMCCQILAg8CDQIdAgIVAgILAgACEQINAgACCwIbAgUCGQIJAjsCEQICEwICEQIAAksCAgcCAg0CKQITAgACGQITBA0CDQIpAiECBQJdAgsCDwIxAhcCAAIhAgUCCQINAhUCFwIAAisCWwLbAQJdAjUCFwIDAqsKAgcC"
+        },
+        {
+          "operation": "composition_commit",
+          "requests": 38,
+          "errors": 0,
+          "latency_ms_p50": 30.719,
+          "latency_ms_p90": 63.103,
+          "latency_ms_p99": 89.791,
+          "hdr_v2_base64": "HISTEwAAAFgAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAL9PAq0CAjECDwKbAQLTAgIhAqMBAhMCHwJjAiUCiwICEQJTAgkCVQIbAkcCTwIPAp8BAhcCUwJXAgIRAgMC2wECJwKnAQLbBQI9AgsCmwMC6wECNQLlBAI="
+        },
+        {
+          "operation": "composition_read",
+          "requests": 254,
+          "errors": 0,
+          "latency_ms_p50": 16.543,
+          "latency_ms_p90": 23.215,
+          "latency_ms_p99": 28.303,
+          "hdr_v2_base64": "HISTEwAAAb4AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAI82Ar0CAoMBAl8CUQKJAwIVAsUBAkcCEwKdAQIxAhUCQwI1AiUCHQIjAiMCGwIlAgACPwIFAgkCFwQCCwILAhMCFQIFAgUCPQITAgIRAgUCLwILAgUCCQIAAgUCBQIVAgMCAwIdAgACAAIdAgcCAgACBwICCwIhAgsCAAIJAgUCEQQRAgACAgACCQICAwIJAgMCCQICBQICBwIjAhMCCwQHAiUCKwIbAgMCBAcCAAIAAhMCAwIJAg0CAwQAAhcCDQQHAgkEAAILAhkCBQIFAgMCIQIdAgACAhsCEQIAAgkCAwIAAgsCBQIHAg8EBQINAg0CAgIDAgcCAwICAAICAAIVAgIZAgACBwIHAgkCFQQABAACCwIABgcCFwIDAgACBwIFAgIDAgIDAgACFQIEBwIFAgQFAgACBQIDAgQDAgACBAkCAgUCAgMCBwIDAgUCJQIDAgIHAgUCBwQCAAICAwINAgIDAgcCBQQFAhECDwICAwITAgkCBwIfAhcCAAICAhkCCwIAAgIFAhkCBwIAAjcCAAIxAgcCDQIAAgIPAgILAgACFQIHAgIJAhkCCQIXAjsCKwI5AqMBAt0BAksC"
+        },
+        {
+          "operation": "composition_read_current",
+          "requests": 142,
+          "errors": 0,
+          "latency_ms_p50": 19.087,
+          "latency_ms_p90": 24.863,
+          "latency_ms_p99": 29.343,
+          "hdr_v2_base64": "HISTEwAAARQAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJ02AtsEAs0BAi0CgQICtQMCQwI1AqEBAqUBAi8CAwKNAQI9Ak8COwIFAnUCfQI1AhUCHQIDAgkCGwILAjUCAAIVAg0COQILAikCAAIbAicCAwIjAg8CBQIFAgACBQIXAhkCHQIDAgMCCwINAgAEBwIZAgMCBwIFAg0CAAIvAgIPAgsCAAIAAhECDwIHAgcCBQIRAhECCwQjAgITAgUCAwQCAwINAgcCBwIFAg0CAAINAgMCEQICAAIPAgsCDwIDAgUCAwIRAhsCAAILAgUCAAIDAgsCCwIjBBMCGQIXAhkCCQIhAgcCCQIbAgICDQIDAgMCDwIFAgIDAgMCAwQLAgsCBQICAgACkQECHQJPAu8BAucCAg=="
+        },
+        {
+          "operation": "composition_revision_history",
+          "requests": 136,
+          "errors": 0,
+          "latency_ms_p50": 12.191,
+          "latency_ms_p90": 17.711,
+          "latency_ms_p99": 19.471,
+          "hdr_v2_base64": "HISTEwAAAREAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAM0mAv8CAq8DAr8BAgKtAQK9AgITAgcCLwI/AqcBAvsBAjkCEQIbAl0CvwECLQIFAssBAjsCBQIjAhsC/QICLQIHAhMCAAIRAgMCDwITAksCDQIAAgcCDQINAg0CGQINAiMCAhkCIQIPAjECBwIDAiUCMwIFAgUCEQIVAicCBQICBQI1AgACKQIpAhkCFQIXAgACEQIbAgACGQICJQIDAgsCDQI9AgIAAgUCAwINAg8CIQInAlsCSQIRAgACUwIAAiECFQIFAgIDAgcCDwIFAgcCEwIDAgcCLQIJAkcCXQIXAgACDQIPAgACAh0CAgMCAAIVAgIbAgcCBwINAg0CBQIZAhcCIQIfAh8EAwIDAqMCAg=="
+        },
+        {
+          "operation": "composition_update",
+          "requests": 11,
+          "errors": 0,
+          "latency_ms_p50": 33.503,
+          "latency_ms_p90": 40.991,
+          "latency_ms_p99": 47.007,
+          "hdr_v2_base64": "HISTEwAAAB4AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAN9LArMJAvUEAucDAtsBAlMChQECXQKNAQJZAvUCAg=="
+        },
+        {
+          "operation": "contribution_commit",
+          "requests": 5,
+          "errors": 0,
+          "latency_ms_p50": 60.991,
+          "latency_ms_p90": 85.759,
+          "latency_ms_p99": 85.759,
+          "hdr_v2_base64": "HISTEwAAAA8AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAK9GAssWAuEQAvUFApkBAg=="
+        },
+        {
+          "operation": "contribution_read",
+          "requests": 14,
+          "errors": 0,
+          "latency_ms_p50": 16.143,
+          "latency_ms_p90": 19.295,
+          "latency_ms_p99": 20.191,
+          "hdr_v2_base64": "HISTEwAAACEAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAALU1ApcQAr0DAiEC/QQCOwJNAj8CBQIjArEBAj0CQQJtAg=="
+        },
+        {
+          "operation": "directory_create",
+          "requests": 1,
+          "errors": 0,
+          "latency_ms_p50": 15.295,
+          "latency_ms_p90": 15.295,
+          "latency_ms_p99": 15.295,
+          "hdr_v2_base64": "HISTEwAAAAMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAO1NAg=="
+        },
+        {
+          "operation": "directory_read",
+          "requests": 128,
+          "errors": 0,
+          "latency_ms_p50": 13.103,
+          "latency_ms_p90": 18.303,
+          "latency_ms_p99": 22.287,
+          "hdr_v2_base64": "HISTEwAAAPMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAIkxArUCAnEC+wECCwLtAQIlAiUCRQI3AlMCEwINAo8BAkMCIQIjAk0CHQIrAhcCaQIJAjUCWwJnAjECCQICKQIPAjECTwIzAiUEDQIPAhkCHwICcwICGQICIQIAAi8CEQIAAgMCJQIJAgACBwInAgAEAwILBB0CAnsCKwIhAhkCBQKVAQIDAhECAgMCCwICEQIFAgUCDwIdAgcCNQIdAhECAAIJAhcCAhUCBwICBwJBAg0CAhkCBwICAwICBwIfAgMCAAIDAhUCAwIbAg0CDwIlAgUCCQIjBDkCAAIJAgsCHwIVAh0CDwJdAi0CAtMBAr0HAg=="
+        },
+        {
+          "operation": "directory_update",
+          "requests": 2,
+          "errors": 0,
+          "latency_ms_p50": 15.399,
+          "latency_ms_p90": 20.367,
+          "latency_ms_p99": 20.367,
+          "hdr_v2_base64": "HISTEwAAAAYAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAIdOAuUFAg=="
+        },
+        {
+          "operation": "ehr_create",
+          "requests": 2,
+          "errors": 0,
+          "latency_ms_p50": 20.447,
+          "latency_ms_p90": 23.583,
+          "latency_ms_p99": 23.583,
+          "hdr_v2_base64": "HISTEwAAAAYAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPlTAoUDAg=="
+        },
+        {
+          "operation": "ehr_read",
+          "requests": 13,
+          "errors": 0,
+          "latency_ms_p50": 15.063,
+          "latency_ms_p90": 18.015,
+          "latency_ms_p99": 20.111,
+          "hdr_v2_base64": "HISTEwAAACMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAANsyAqUKApcIAoUCAocBAo0BAvEDAr8BAm8CVQIrAlkCgwIC"
+        },
+        {
+          "operation": "ehr_status_read",
+          "requests": 4,
+          "errors": 0,
+          "latency_ms_p50": 11.831,
+          "latency_ms_p90": 19.615,
+          "latency_ms_p99": 19.615,
+          "hdr_v2_base64": "HISTEwAAAAwAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJdAAvEGAr8JAsECAg=="
+        },
+        {
+          "operation": "ehr_status_update",
+          "requests": 3,
+          "errors": 0,
+          "latency_ms_p50": 20.719,
+          "latency_ms_p90": 23.135,
+          "latency_ms_p99": 23.135,
+          "hdr_v2_base64": "HISTEwAAAAkAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAOtIAq0LAqsCAg=="
+        },
+        {
+          "operation": "stored_query_execute",
+          "requests": 28,
+          "errors": 0,
+          "latency_ms_p50": 32.959,
+          "latency_ms_p90": 37.343,
+          "latency_ms_p99": 43.903,
+          "hdr_v2_base64": "HISTEwAAADsAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAIFVApEBAnUCUwIlAg0CKwKpAgLxAgITAgcCNwLBAQICAwICJQIPAgACDQIDAgcCLwQhAlMChwECjQIC"
+        },
+        {
+          "operation": "tags_put",
+          "requests": 5,
+          "errors": 0,
+          "latency_ms_p50": 18.255,
+          "latency_ms_p90": 32.959,
+          "latency_ms_p99": 32.959,
+          "hdr_v2_base64": "HISTEwAAAA4AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAKlQAqUBAhMC/QYCnwcC"
+        },
+        {
+          "operation": "tags_read",
+          "requests": 5,
+          "errors": 0,
+          "latency_ms_p50": 12.087,
+          "latency_ms_p90": 20.287,
+          "latency_ms_p99": 20.287,
+          "hdr_v2_base64": "HISTEwAAAA8AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAO87AtcJAv8BAuMJArECAg=="
+        },
+        {
+          "operation": "template_get",
+          "requests": 11,
+          "errors": 0,
+          "latency_ms_p50": 55.999,
+          "latency_ms_p90": 67.327,
+          "latency_ms_p99": 82.751,
+          "hdr_v2_base64": "HISTEwAAAB4AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAKdAArMKAq0BAocTAvsLAhECTwILAsMBAuMCAt8DAg=="
+        },
+        {
+          "operation": "template_list",
+          "requests": 12,
+          "errors": 0,
+          "latency_ms_p50": 13.415,
+          "latency_ms_p90": 15.927,
+          "latency_ms_p99": 16.287,
+          "hdr_v2_base64": "HISTEwAAAB8AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAANU7Ar8CAo0DAq0CAr8DAvsCAvECAg8CRQI3AmkCVwI="
+        },
+        {
+          "operation": "ward_query",
+          "requests": 28,
+          "errors": 0,
+          "latency_ms_p50": 170.495,
+          "latency_ms_p90": 253.695,
+          "latency_ms_p99": 273.407,
+          "hdr_v2_base64": "HISTEwAAADsAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAALGAAQIAAgMC0QEEaQICFQInAg8CFwIAAjsCNQILAhcCSwIjAhkCUQIjAsMBAhEC0wECVQLXAwJ5Al0C"
+        }
+      ],
+      "stable": true,
+      "generator_bound": false,
+      "resources": {
+        "sample_interval_s": 10,
+        "containers": [
+          {
+            "role": "sut",
+            "name": "ehrbase-rs-ehrbase-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 3.5440266397554065,
+                "rss_bytes": 247996416,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4154819267,
+                "net_tx_bytes": 7851510271
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 3.44262096098613,
+                "rss_bytes": 247975936,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4156350350,
+                "net_tx_bytes": 7852357498
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 3.113994969849453,
+                "rss_bytes": 247971840,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4157027658,
+                "net_tx_bytes": 7853037244
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 3.839416069491217,
+                "rss_bytes": 247975936,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4159039809,
+                "net_tx_bytes": 7853672694
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 3.333402358924752,
+                "rss_bytes": 247980032,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4162025879,
+                "net_tx_bytes": 7854218154
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 3.080290096521525,
+                "rss_bytes": 247984128,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4162632799,
+                "net_tx_bytes": 7854820080
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 3.9044139642761837,
+                "rss_bytes": 253927424,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4166601882,
+                "net_tx_bytes": 7855623989
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 3.0223654339961663,
+                "rss_bytes": 253898752,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4167229569,
+                "net_tx_bytes": 7856280854
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 3.3065884343158713,
+                "rss_bytes": 253677568,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4167926158,
+                "net_tx_bytes": 7856857470
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 2.557742954927594,
+                "rss_bytes": 253657088,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4168820257,
+                "net_tx_bytes": 7857608158
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 3.475522392442138,
+                "rss_bytes": 256802816,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4173642673,
+                "net_tx_bytes": 7858038197
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 2.8197328309511263,
+                "rss_bytes": 257064960,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4174218142,
+                "net_tx_bytes": 7858512138
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 3.4779934473811114,
+                "rss_bytes": 256831488,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4175565665,
+                "net_tx_bytes": 7859025656
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 3.301142739067809,
+                "rss_bytes": 256823296,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4178701185,
+                "net_tx_bytes": 7859890300
+              }
+            ]
+          },
+          {
+            "role": "db",
+            "name": "ehrbase-rs-ehrbase-postgres-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 11.791588519466357,
+                "rss_bytes": 1925513216,
+                "blk_read_bytes": 3381174272,
+                "blk_write_bytes": 45533196288,
+                "net_rx_bytes": 7187024110,
+                "net_tx_bytes": 996171533
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 11.26346946784733,
+                "rss_bytes": 1923903488,
+                "blk_read_bytes": 3382996992,
+                "blk_write_bytes": 45546065920,
+                "net_rx_bytes": 7187756959,
+                "net_tx_bytes": 997490598
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 10.52903617179213,
+                "rss_bytes": 1925963776,
+                "blk_read_bytes": 3385589760,
+                "blk_write_bytes": 45556748288,
+                "net_rx_bytes": 7188340139,
+                "net_tx_bytes": 997975420
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 13.505893783289766,
+                "rss_bytes": 1929711616,
+                "blk_read_bytes": 3388473344,
+                "blk_write_bytes": 45567279104,
+                "net_rx_bytes": 7188856365,
+                "net_tx_bytes": 999821710
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 10.85062503917495,
+                "rss_bytes": 1965608960,
+                "blk_read_bytes": 3392888832,
+                "blk_write_bytes": 45578559488,
+                "net_rx_bytes": 7189289342,
+                "net_tx_bytes": 1002707558
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 9.775942378422986,
+                "rss_bytes": 1968910336,
+                "blk_read_bytes": 3397427200,
+                "blk_write_bytes": 45589225472,
+                "net_rx_bytes": 7189797645,
+                "net_tx_bytes": 1003165408
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 11.709701820205069,
+                "rss_bytes": 2057875456,
+                "blk_read_bytes": 3402694656,
+                "blk_write_bytes": 45599981568,
+                "net_rx_bytes": 7190472482,
+                "net_tx_bytes": 1006944024
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 10.580436161908612,
+                "rss_bytes": 2059210752,
+                "blk_read_bytes": 3407314944,
+                "blk_write_bytes": 45612187648,
+                "net_rx_bytes": 7191039342,
+                "net_tx_bytes": 1007413530
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 10.764739739030526,
+                "rss_bytes": 2057007104,
+                "blk_read_bytes": 3412086784,
+                "blk_write_bytes": 45622624256,
+                "net_rx_bytes": 7191513001,
+                "net_tx_bytes": 1007978820
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 10.34590523496282,
+                "rss_bytes": 2094632960,
+                "blk_read_bytes": 3417526272,
+                "blk_write_bytes": 45634289664,
+                "net_rx_bytes": 7192166179,
+                "net_tx_bytes": 1008666282
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 11.803835582456726,
+                "rss_bytes": 2065154048,
+                "blk_read_bytes": 3422466048,
+                "blk_write_bytes": 45644791808,
+                "net_rx_bytes": 7192458913,
+                "net_tx_bytes": 1013441023
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 9.647023917081892,
+                "rss_bytes": 2071175168,
+                "blk_read_bytes": 3427139584,
+                "blk_write_bytes": 45656850432,
+                "net_rx_bytes": 7192839316,
+                "net_tx_bytes": 1013926062
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 10.978127393906083,
+                "rss_bytes": 2072047616,
+                "blk_read_bytes": 3432013824,
+                "blk_write_bytes": 45668122624,
+                "net_rx_bytes": 7193249075,
+                "net_tx_bytes": 1015191058
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 10.679835095700193,
+                "rss_bytes": 2116444160,
+                "blk_read_bytes": 3438120960,
+                "blk_write_bytes": 45680017408,
+                "net_rx_bytes": 7193995622,
+                "net_tx_bytes": 1018050477
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "rate": 16.0,
+      "offered_load_sustained": 16.175,
+      "operations": [
+        {
+          "operation": "adhoc_query",
+          "requests": 254,
+          "errors": 0,
+          "latency_ms_p50": 24.655,
+          "latency_ms_p90": 32.479,
+          "latency_ms_p99": 45.183,
+          "hdr_v2_base64": "HISTEwAAAb0AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAOM+AqUCAm0CqwMCzwICUwKdAQJLAiECjwEChQECBwItAicCnQECMwIAAgJPAg0CBwIABAACGwIDAgACAgMCCwIfAgUCAwIlBA0CBQIDBAUCBQINAgACBwIHAhMCAwICBQQFAhECAwIbAgACGwIABAsCAAIPAgILAgcCCwIDBAkCAAICAgsCCQIFAhUCCQIJAgsCAAICAAILAgMEAAIAAg8CCwICAAQDAgsCAhcCCQIHAhcCBAIXAgIABAkCAwIJAhMCAAIAAgIRAgACCQIABA8CAAICFQIAAgUEDQIJAgcCAgcEAAIAAg0CAgIFAg8CBA8CCwIHAgACDwIDAgACAwILAgYHAgACAAIjAgICCwIHAgkCCwIAAgIDAgMCDwIVAg8CAwICAAIHAg0CKQYCAwIAAhECBwIAAgsCAgMCAAIHAgcCCwIHAiMEAAIFAgUCCQIhAgACBQICAwQFAgMCAgACCwIDAg0CAwIAAgsCGQIDAhcEBQIAAgUCCQILAgIbAgcCDQIHAhMCAwIRAg0CCQIPAgMCBwIPAgIHAgcCAhcCAwICSwJLAmcCAgkCEwKBAQIZAjMCnwECMwKXEQI="
+        },
+        {
+          "operation": "composition_commit",
+          "requests": 79,
+          "errors": 0,
+          "latency_ms_p50": 25.823,
+          "latency_ms_p90": 43.519,
+          "latency_ms_p99": 76.927,
+          "hdr_v2_base64": "HISTEwAAAJ8AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAO1EAk8CdwK5AwJpAkECzwICiwICPwICBwJJAgUCWQKRAQIXAmMCLwIHAgJHAiMCNQIXAhECCQIDAkcCKQIAAisCMQINAiMCEwIjBAcCAAQDBCUCgQIEAwJxAgcCYwIlAgkCEwKjAQIFAl0CDwITAgACBwIFAhUCMwJ/AgIRAnUCCQQLArsBAgkCDQLpAwKHAQLtAQKbAQL/AgJ9ArsBAg=="
+        },
+        {
+          "operation": "composition_read",
+          "requests": 508,
+          "errors": 0,
+          "latency_ms_p50": 12.199,
+          "latency_ms_p90": 19.119,
+          "latency_ms_p99": 24.351,
+          "hdr_v2_base64": "HISTEwAAAywAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAALErAhcCmQICGwJTAjkCAwIDAkkCiwECVwJPAlkCVQINAg8CGwIdAjsCNwIFAgcCBQIbAjUCBQIdAhcCGQIFAgUCTQIDAhECDQIRAgACAgIDAhsCAwI1AgIAAgkCAAICFQIhAg0CFwINAhkCBwICCwIVAh8CBwIHAgUCEwIRAgsCAAIxAgACiwECJwIABAIFAgACBwIEAwIfAgIlAgACKQQDAh0CAwIfAgIJAhMCBQIdBAMCCQIRAgkCAAICAgILAhECHQICAwIDAgkCAwIHBAAEAgkCCwIFAgMCBwQCEQICAAICBQIAAgACCwICAgMCBwIHBAsCDwICAgcCAAITAgkCDwIPBAUEAAIFAgACAgsCAAIFAgMCAgIAAgIJBAACAgQCAAQLAgIAAgIDAgQAAgACAgIAAgIHAgACAAIAAgICAAIAAgIDAgACAgMCAg8CAgkGAgIDBAUCAgACBwICAAILAgcEBQQDAgAEAwIHAgMCAAIDBAcCAwIAAgACCQIAAgACBQICAAIAAgcCBwIEAAIZAgILAgUCCQIDAhMCBQIAAgUCBwQAAgMCCQICAgIECwICAwIXAgIEBwQhAgcCAgACAwIAAhcCBQIPAgkCGQICAgsCFwIAAgkCDwQJAgAEBQIEBBECBAIAAgcEAgUEBwIDAhECAwICAAIHAgUCBQIAAhUCAwIJAgsCAgcCAgMCBQQRAgUCBwIAAgACAAIFAgIDAgUCBAACBQIDAgUCAhECAwIFAgIAAgIDBA8GAAIDAgMCAAIAAgMCBwIVAgUCAwICAgACBQYCBwICAAIFBAICAAIAAgUCAAIAAgAEBQIAAgsCAwIXAgsCAAI1AgMCAwICAgcEBwYNAgACAgcECQICAgIEAAQDAgACBQQABAICAAIHAgIGAAQCAAIDAgcCAgIPAhECCwIXAg0CBQIAAgACBwIDAgMCAwINAgICFQIHAgsCFQIEAgIPAhcCFwIDAgMCBwQxAgcCAAICDQICBwIDAgcCBwIFAgcEAwIAAgcCFQIAAgACIQIrAgcCAAITAh0CDwICBwIRAkcCBwIRAiECmwECJQK7BgI3AisC"
+        },
+        {
+          "operation": "composition_read_current",
+          "requests": 286,
+          "errors": 0,
+          "latency_ms_p50": 13.519,
+          "latency_ms_p90": 19.855,
+          "latency_ms_p99": 27.311,
+          "hdr_v2_base64": "HISTEwAAAgcAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJErArsDAusBAjsCNwJbAiMCFQITAq0BAgMCYQInAnsCSwI/AgITAhkCFQI5ApUBAgMCJQIfAjkCJwIPAhECNQICKwIrAhECRwIjAgsCFQICAl8CVQIfAi0CCQILAhUCBQJHAgUCBwInAgIPAgUCCwIRAhECDQIRAhECGwIAAgMCCQILAgsCBQIfAhcCFQICBQIAAgsCAAICCQIhAgIvAgMCBwIVAgACAgACBwICAAIAAgcCAAIDAicCDwIFAgsCBwYFAgACEQIbAgACBQIDAgkCGwIXAgMCAAIAAgACCQIJAg8CCwIrAgIDAgMCCwIAAgcCAwIDBAkCDQIFAgkCAAIAAgsCCQIPAgUEFwIXAhUCCwICAwITAgUCBQIDAg0CDQIFBAIAAg0CAwIHAhECAwIJAhECAgkCEwIDAkUCAAIAAgUCCQIpAgkECQIRAgACEQIFAgIDAgsCAgMCAwIHAgUCGwIJAgICBwIDAhMCCQIAAi0CNQICAgACAwIHBAUCBQQDAgUCAAIJAgUCAAINAgIAAgUCBwIAAg0CBQICBQIDAgIAAgIHAgAEBwIFAgACAhUCDQICBQINAgACAwQFAgsCAgUCBAQHAgcCFwIRAgACGwIAAgUCKQIfAiMCFwICAAIFBCcCDQICBAIRAmcCEwIHAgMCGwJDAicCHQKTAQLVAQJ/Ap8BAg=="
+        },
+        {
+          "operation": "composition_revision_history",
+          "requests": 275,
+          "errors": 0,
+          "latency_ms_p50": 13.399,
+          "latency_ms_p90": 18.543,
+          "latency_ms_p99": 24.687,
+          "hdr_v2_base64": "HISTEwAAAeIAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJMsAosFAgUCAAJzApUBAg0CAwJZAp8BAlUCLwKRAQKlAQIAAgMCCwINAjsCKQJtAicClQECMwIzAkMCDwIHAnsCBQIPAj8CCQIfAgMCDQIHAgIFAgIJBA0CKwItAhcCGQIRBCECCQIPAh8CCQITAgUCAg8CAgIJAg0CCwICFwIJAgUCDwIAAgMCEwIAAg8CGQIAAgACDQQFAg8CAwITAiUCAwICDQILAhMCFwITAhkCAgMCBwICAgIdAgACAwYdAgIFAjECBAMCAAIHAhUCAgICCwICAAIFBAkCCQICBQIHAgMCBwIVAgUCAwQTAgMCAAIRAgIAAgMCAgACEwIVAg0CDQIFAgACAAIDBBUCBQIJAgACAwIAAgkCAAIHAgINAgILAgACBwIFAgACAAIHAgUCAwICAgAEAgIFAgcCAwICCwIbAgACBwIJAgMCAwIAAgkCAgkCEQINAgIDAg0CCwIJAgcCDQICIwIFAgICAgUCBQIAAiECAwIlAhECAAICAiMECQQDAgMCCQILBAACFwICEwILBAACBQIAAgIABAACEQIJAgcCBQIHAgACCwIJAgIPAgMCAAICAgIAAgQAAiMECQINAgIABAACCQITAiUCLQIzAi0CjQICpwEC1wUCwQQC"
+        },
+        {
+          "operation": "composition_update",
+          "requests": 21,
+          "errors": 0,
+          "latency_ms_p50": 32.399,
+          "latency_ms_p90": 37.855,
+          "latency_ms_p99": 41.471,
+          "hdr_v2_base64": "HISTEwAAADAAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAKVBAq0SAvUBAi8CawIXAmMCLQLpBAKnAgIZAlMCDQI3AgcCXQIAAkUCEwKVAQJHAg=="
+        },
+        {
+          "operation": "contribution_commit",
+          "requests": 8,
+          "errors": 0,
+          "latency_ms_p50": 67.711,
+          "latency_ms_p90": 83.263,
+          "latency_ms_p99": 83.263,
+          "hdr_v2_base64": "HISTEwAAABYAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAOdAAvUnAsUHAhcClwECvwECgQECAwI="
+        },
+        {
+          "operation": "contribution_read",
+          "requests": 30,
+          "errors": 0,
+          "latency_ms_p50": 11.735,
+          "latency_ms_p90": 17.871,
+          "latency_ms_p99": 20.463,
+          "hdr_v2_base64": "HISTEwAAAEcAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAOM1AqcFAokEAmECfwKnAQIAAgsCGQIVApUBAmMCKQJHAo0BAqUBAgsCoQICTQIXAr0BAikCZQIXAokBAr8BAkECaQJ5AlkC"
+        },
+        {
+          "operation": "directory_create",
+          "requests": 2,
+          "errors": 0,
+          "latency_ms_p50": 5.867,
+          "latency_ms_p90": 13.367,
+          "latency_ms_p99": 13.367,
+          "hdr_v2_base64": "HISTEwAAAAYAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPM2ApUTAg=="
+        },
+        {
+          "operation": "directory_read",
+          "requests": 259,
+          "errors": 0,
+          "latency_ms_p50": 13.631,
+          "latency_ms_p90": 18.591,
+          "latency_ms_p99": 25.823,
+          "hdr_v2_base64": "HISTEwAAAb0AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJ8nAuMBArMCAskBAk8CWwJTAp8BAu0CAs0BAsEBAi8CQQIlAt8BAicEIwIAAg8CRQIvAgMCGQJDAgkCKQJ/AiECAwIvAlkCWwIrAg8CPQIAAgIDAgsCIQICBwIZAgIDBC0CAAIJAisCCwJbAg0CBAUCLQIbAj0CCwIAAgcCBQINAhECCQIfAhsCAwIVAgcCEQINAgACBQIHAgACFQQRAgUEEwQPAgACBQIDAhcCAwITAhUCEQIDAgQFAg8CBAUCAg8CAAITAgIAAgACEwICCwIZAgIFAhUCAAIfAgACBwIPAgIDAgQJAgMCAAIFAg8CAgMCAAIDAgUCAhUCAgMCBQIRAhUCFQILAg8CAwQTBBcCAgcCEQIAAgMCAwIAAhsCAAIAAhkCHwIAAgIFAgIAAg0ENwIvAgcEAgIAAgIVAgIHAgACHwQAAgACAgACPwICAAIDAgACEQIDAgQAAg0CAhEGAAIFAgACBQICEQIAAgACAAQDBAIAAgsCDwICCwIFAgYCAAIRAgkCAAIDBAQFAgACCwQAAg8CDwITAgICDQILAhcCGwQDAh0CCQIRAicCRwJzAqcBAoECAi0CeQI="
+        },
+        {
+          "operation": "directory_update",
+          "requests": 3,
+          "errors": 0,
+          "latency_ms_p50": 23.231,
+          "latency_ms_p90": 25.215,
+          "latency_ms_p99": 25.215,
+          "hdr_v2_base64": "HISTEwAAAAkAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAMs7AocbAvUBAg=="
+        },
+        {
+          "operation": "ehr_create",
+          "requests": 3,
+          "errors": 0,
+          "latency_ms_p50": 15.415,
+          "latency_ms_p90": 17.551,
+          "latency_ms_p99": 17.551,
+          "hdr_v2_base64": "HISTEwAAAAkAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAANU4ArMVAoEDAg=="
+        },
+        {
+          "operation": "ehr_read",
+          "requests": 26,
+          "errors": 0,
+          "latency_ms_p50": 11.879,
+          "latency_ms_p90": 16.799,
+          "latency_ms_p99": 28.095,
+          "hdr_v2_base64": "HISTEwAAAD8AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAOsyAo0BAj8CxwIC0wMCxQUCzQECaQI/AlcCiwEC3wECJwQjAlkCWQKNAQJVAkMCGQKbAgIpAqUCAu0BApEJAg=="
+        },
+        {
+          "operation": "ehr_status_read",
+          "requests": 6,
+          "errors": 0,
+          "latency_ms_p50": 12.847,
+          "latency_ms_p90": 23.375,
+          "latency_ms_p99": 23.375,
+          "hdr_v2_base64": "HISTEwAAABIAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAMUvAtUTAukFAskBAosHAoEFAg=="
+        },
+        {
+          "operation": "ehr_status_update",
+          "requests": 7,
+          "errors": 0,
+          "latency_ms_p50": 12.663,
+          "latency_ms_p90": 31.407,
+          "latency_ms_p99": 31.407,
+          "hdr_v2_base64": "HISTEwAAABQAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAKE8AuUCAosHAsECAq0HAg8Csw4C"
+        },
+        {
+          "operation": "stored_query_execute",
+          "requests": 55,
+          "errors": 0,
+          "latency_ms_p50": 26.863,
+          "latency_ms_p90": 34.239,
+          "latency_ms_p99": 35.551,
+          "hdr_v2_base64": "HISTEwAAAHAAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPdGAhcCqwkCCwJ9AkkCfwKrAQIJApEBBG0CDQIlAhECCQIlAgsCAwIRAiECHQJfAhMCBQJDAgILAh0CiQECDwIhAiECBwInAiUCEQINAhECSwIlAicCDQI1AgcCXQIHAhECDwIfAgkCDwIHAgsCGQI="
+        },
+        {
+          "operation": "tags_put",
+          "requests": 9,
+          "errors": 0,
+          "latency_ms_p50": 14.039,
+          "latency_ms_p90": 22.255,
+          "latency_ms_p99": 22.255,
+          "hdr_v2_base64": "HISTEwAAABgAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAOlFAqUCAqkBAnUCewKjAgJXAp8FAoMCAg=="
+        },
+        {
+          "operation": "tags_read",
+          "requests": 9,
+          "errors": 0,
+          "latency_ms_p50": 12.951,
+          "latency_ms_p90": 16.671,
+          "latency_ms_p99": 16.671,
+          "hdr_v2_base64": "HISTEwAAABcAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAOMrArUFApkRAtsGAgsCBQJNAi0C8wUC"
+        },
+        {
+          "operation": "template_get",
+          "requests": 23,
+          "errors": 0,
+          "latency_ms_p50": 35.231,
+          "latency_ms_p90": 57.311,
+          "latency_ms_p99": 66.367,
+          "hdr_v2_base64": "HISTEwAAAD8AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAL83AvcRAqsCAtUBAocDAo8EAtkDAtsBAk0C6wECnwQCHwIVAu8CArUCAqUBAhcCGwIXAr0BAuUBArcBAt8CAg=="
+        },
+        {
+          "operation": "template_list",
+          "requests": 23,
+          "errors": 0,
+          "latency_ms_p50": 8.463,
+          "latency_ms_p90": 13.751,
+          "latency_ms_p99": 15.471,
+          "hdr_v2_base64": "HISTEwAAADgAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAIUzAhkCjQICZwJVApMCAv8BAucCAucBAg0CFwI1Ap0DAi8CQwJVAqUBAhMCSwKDAwIlApcDAhEC"
+        },
+        {
+          "operation": "ward_query",
+          "requests": 55,
+          "errors": 0,
+          "latency_ms_p50": 154.751,
+          "latency_ms_p90": 194.815,
+          "latency_ms_p99": 311.807,
+          "hdr_v2_base64": "HISTEwAAAHAAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAKl4Au0BApcDAgcC7QECNQIZAhMCJwICDQIDAgACCQIdAgMCAjkCAgsCDwIRAhkCAAIAAiUCBwITAk0CAwIbAgACGwInAhcCBwIABC8CCwJNAgsCEwIAAhsCCwITAjsCDwI9Ag0CxwEC6QcCswECIQI="
+        }
+      ],
+      "stable": true,
+      "generator_bound": false,
+      "resources": {
+        "sample_interval_s": 10,
+        "containers": [
+          {
+            "role": "sut",
+            "name": "ehrbase-rs-ehrbase-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 5.699299078818471,
+                "rss_bytes": 262623232,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4184910692,
+                "net_tx_bytes": 7861977506
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 6.226517921908117,
+                "rss_bytes": 266305536,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4187258650,
+                "net_tx_bytes": 7863389716
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 4.993251417312594,
+                "rss_bytes": 266178560,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4188861319,
+                "net_tx_bytes": 7864851278
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 5.292199705041218,
+                "rss_bytes": 266915840,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4194407670,
+                "net_tx_bytes": 7866207985
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 5.101147633610763,
+                "rss_bytes": 266379264,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4197996740,
+                "net_tx_bytes": 7867355963
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 5.629323115726541,
+                "rss_bytes": 267186176,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4202523947,
+                "net_tx_bytes": 7868904873
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 5.485320595981152,
+                "rss_bytes": 268414976,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4204715250,
+                "net_tx_bytes": 7870074031
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 5.020978793373935,
+                "rss_bytes": 268410880,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4206663169,
+                "net_tx_bytes": 7871054425
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 5.848164003599832,
+                "rss_bytes": 268406784,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4210241330,
+                "net_tx_bytes": 7872603045
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 5.640059580130449,
+                "rss_bytes": 274276352,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4214736914,
+                "net_tx_bytes": 7873494958
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 5.294090542772707,
+                "rss_bytes": 273977344,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4216532304,
+                "net_tx_bytes": 7874979388
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 5.248373945409148,
+                "rss_bytes": 276742144,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4218808008,
+                "net_tx_bytes": 7876214392
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 5.105667187056981,
+                "rss_bytes": 276480000,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4223894162,
+                "net_tx_bytes": 7877418635
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 4.877975593299038,
+                "rss_bytes": 276631552,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4225190540,
+                "net_tx_bytes": 7878412908
+              },
+              {
+                "offset_s": 150,
+                "phase": "drain",
+                "cpu_pct": 5.0622336810527555,
+                "rss_bytes": 276557824,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4230350032,
+                "net_tx_bytes": 7879981198
+              }
+            ]
+          },
+          {
+            "role": "db",
+            "name": "ehrbase-rs-ehrbase-postgres-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 19.5654135200307,
+                "rss_bytes": 2164953088,
+                "blk_read_bytes": 3445866496,
+                "blk_write_bytes": 45705256960,
+                "net_rx_bytes": 7195765000,
+                "net_tx_bytes": 1023736544
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 22.197934070020533,
+                "rss_bytes": 2168455168,
+                "blk_read_bytes": 3453444096,
+                "blk_write_bytes": 45717995520,
+                "net_rx_bytes": 7197263307,
+                "net_tx_bytes": 1025636035
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 17.173525960093723,
+                "rss_bytes": 2301009920,
+                "blk_read_bytes": 3462045696,
+                "blk_write_bytes": 45733380096,
+                "net_rx_bytes": 7198238535,
+                "net_tx_bytes": 1026927320
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 18.66119920283735,
+                "rss_bytes": 2305482752,
+                "blk_read_bytes": 3469946880,
+                "blk_write_bytes": 45745823744,
+                "net_rx_bytes": 7199371304,
+                "net_tx_bytes": 1032126611
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 16.468571633420442,
+                "rss_bytes": 2307309568,
+                "blk_read_bytes": 3478355968,
+                "blk_write_bytes": 45758775296,
+                "net_rx_bytes": 7200307579,
+                "net_tx_bytes": 1035463065
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 17.66031816904148,
+                "rss_bytes": 2351460352,
+                "blk_read_bytes": 3481722880,
+                "blk_write_bytes": 45773357056,
+                "net_rx_bytes": 7201647804,
+                "net_tx_bytes": 1039620670
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 16.527632038443656,
+                "rss_bytes": 2398035968,
+                "blk_read_bytes": 3485097984,
+                "blk_write_bytes": 45788889088,
+                "net_rx_bytes": 7202603345,
+                "net_tx_bytes": 1041542779
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 15.821101626122932,
+                "rss_bytes": 2399064064,
+                "blk_read_bytes": 3493896192,
+                "blk_write_bytes": 45800448000,
+                "net_rx_bytes": 7203381094,
+                "net_tx_bytes": 1043300063
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 16.01023400220662,
+                "rss_bytes": 2403221504,
+                "blk_read_bytes": 3503235072,
+                "blk_write_bytes": 45815586816,
+                "net_rx_bytes": 7204705940,
+                "net_tx_bytes": 1046449575
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 18.94034623265451,
+                "rss_bytes": 2404925440,
+                "blk_read_bytes": 3511640064,
+                "blk_write_bytes": 45829857280,
+                "net_rx_bytes": 7205386152,
+                "net_tx_bytes": 1050809668
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 17.660362741051028,
+                "rss_bytes": 2406109184,
+                "blk_read_bytes": 3521806336,
+                "blk_write_bytes": 45841924096,
+                "net_rx_bytes": 7206672294,
+                "net_tx_bytes": 1052205126
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 13.74767366655331,
+                "rss_bytes": 2405859328,
+                "blk_read_bytes": 3531079680,
+                "blk_write_bytes": 45847519232,
+                "net_rx_bytes": 7207695089,
+                "net_tx_bytes": 1054176541
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 15.80712970891649,
+                "rss_bytes": 2406367232,
+                "blk_read_bytes": 3541147648,
+                "blk_write_bytes": 45852909568,
+                "net_rx_bytes": 7208658696,
+                "net_tx_bytes": 1058960550
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 17.201915558181426,
+                "rss_bytes": 2406404096,
+                "blk_read_bytes": 3550990336,
+                "blk_write_bytes": 45860106240,
+                "net_rx_bytes": 7209615514,
+                "net_tx_bytes": 1059961927
+              },
+              {
+                "offset_s": 150,
+                "phase": "drain",
+                "cpu_pct": 15.242457475818998,
+                "rss_bytes": 2406092800,
+                "blk_read_bytes": 3560525824,
+                "blk_write_bytes": 45872418816,
+                "net_rx_bytes": 7210791762,
+                "net_tx_bytes": 1064780418
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "rate": 32.0,
+      "offered_load_sustained": 32.325,
+      "operations": [
+        {
+          "operation": "adhoc_query",
+          "requests": 509,
+          "errors": 0,
+          "latency_ms_p50": 20.047,
+          "latency_ms_p90": 28.367,
+          "latency_ms_p99": 36.639,
+          "hdr_v2_base64": "HISTEwAAAvQAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAIE4ArMBAtcCAtMDAgcCHwKhAQIHAgITAlECRwIFAhMCBQJBAiECOQICLQIJAk8EFQIFAgACCQIbAhECIwIFAgACHwIPAicCDQIEBwILAgIDAgACAAICBQQfAg0CFQIAAgIDAgUCAgkCFwIPAg0CBwITAgcCBwIAAgACCwYHAg8CAwQEEwIjBGECBwICAgACAwIAAhcCBwIAAhECAwIAAgcEAgsCAAIRAgMCAgACBQI/Ag0CAgMCAgMEBQIFAgkCCQQLAgcEBAsCFwIHAgIAAg8CAgMCBAICEQQLBBsCAhkCEQIZAgIDAgACBQIGAgICAwQCAwINAgACAAIDAgAEBQIAAgUCBAIJBAACAgIAAgIHAgMCAgIDAgMCAgICAgYAAgIABAACAwIABAMCAgsCAgACAgIAAgACAgUCAAIABAACAwIEAwIFAgUCCQIDBAQFAgQABAICAwILAgcCAAIAAgIPBAcCAwICAAICAwIDAgQRAgICBQIJBAYAAgQCAwICBQICBAIABgACAAQAAgICAgIFAgIAAhkCAAQAAgIPAgACAwICCQIJBAMEAwIFAgACAAIAAgACAAICAAIEAgIDAgcCAwICAwIAAgIAAgYPAgICAAIDAgUEAAICAwIJAgMEAAICAgACAgACAgACDwIVBgMCBQIECQIAAgUCAgMCAgQAAgIPBAACAAICAgACAwYCAAIHAgUEAgMCBAcCAwIDAgQDAgUCBwICAwICAwQFBAMCCQINAgUCAwIDAgACDwIFAgICBQIAAgUCCQQAAgICCQIAAgQJBAMCAgIABAACAAICBAcCBAUCCwIDAgIAAgACCwQCBQIAAgACCQITAgcCCwQJAgMCAgACCQIAAgMECwIAAisEBQIAAgACAgICAAILAgILAgsCAAICDwICAAIFAgICAAICEQIDAg8CAAIDAgIJAgUCAjUCFwIFAgILAgkCAAJLAjMCOQQJAiECFQIFAgsCXwIDAgMCXwIxAm0CIQKZAQJ3Ag=="
+        },
+        {
+          "operation": "composition_commit",
+          "requests": 154,
+          "errors": 0,
+          "latency_ms_p50": 22.783,
+          "latency_ms_p90": 42.783,
+          "latency_ms_p99": 63.711,
+          "hdr_v2_base64": "HISTEwAAASsAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAANVAAjUCZwJJApUDAgsCQQIjAhcCHQItAgACLQItAs0BAoEBAgsCJQJRAh0CEwJfAhMCdwJDAicCEQIDAg8CCwIFAgUCDQIFAiECAgUCFQILAgIDAgACMQIbAgMCGQIPAgINAgACAwIJAgACIwICBQIDAgsCHQQAAjsCCwIHAhECKQIFAgACFwI7AkcCPwIHAgIFAgILAgI3AgIjAg8CEQIFAgMCBwIAAgkCBwIdAgIDAgUCBwIfAgsCOQIZAgcCCQIFAh8CBwJDAjMCDQJDAmMCcwILAgMEKQICAwI7AjECCwIbAmUCTwIlAh0CAgACBQIRAhsCCQIdAlkCDwIAAiUCLQIvAjMCTwIAAhEC7QECcQICSwItAusBAj0CFQJ5AnUCPwJZAkkCnQIC"
+        },
+        {
+          "operation": "composition_read",
+          "requests": 1017,
+          "errors": 0,
+          "latency_ms_p50": 10.039,
+          "latency_ms_p90": 16.751,
+          "latency_ms_p99": 22.431,
+          "hdr_v2_base64": "HISTEwAABTgAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAANknAo8CApsBAi0CCQJhAi0EEwInAisEDwKlAQIJAgMCAg8CBQIPAiUCCwIPAgcCBQIDAgkCCwINBA8CAAIHAgQLAgIJAgcCDQIEAAIFAgACAgIDAgcCJwIFBgMCBQIFAgACAgUCDQIPAgkCBQIJAgACAAICAwIAAgUCBwIJAgMCAgMCAAIAAgkCAgcCIQIDAgINAgMCAwIFAgIFBAUCAAICAAICAAINAgIAAgAEAgAECwIRAgUECwICAwICKQIPAgcCAgACBAAGAwIEAgACAgACAAIDAgACAgMCAgAGAAIDAgIAAh0CBwIHBAMCDwIHAgkECQICAwIABgICGwIEAAICCQIDAgsCCQQAAgIHBAMEAAIEAgINAgcCBwIAAg0CAwICCQIFAgUCBAACAAIDAgACAgQFBAAECQIFAgACAAIVAgUCBQIPBgACDwICDwILAgIABAUCBQIDAgIAAgIHAgICBAkCAgQHBAMCBQIHAgMCGwILBAIFAgACAgUCGQQLAgsCDQILAgQCAgcCAAICDQIFAgkCBwICAgMCAgMCAwIDAgkEBwICBwICAgICBQIAAhkCAwICBwIHAgUCAAIJAgYCAgcEBQQGAwILAgsCBQILAgcCCQYCAAIAAhECBQICBQIAAgIJAgMCAgACCQIAAgMEBQQJAgIDAgICAAICAgIDBAIEAgMCAAICAgQCAgIAAgIJAgIKAgACAgACCAUCAgIDAgICBQIEAgICCwIEBgICAgACBwIEAgQDAgQAAgMCAgMCAgIABAIAAgQCCQQDAgAGAgkCAgACAgUCAwYAAgQABAMCAAYAAgQAAgACBwIABAQFAgICBAIEAgMCBAQABAIAAgIDBAACAAQCAwIABAICAwICAAIAAgMCBAQCAAICBAIEAwIAAgIABgIFAgIAAgIDAgICAAIEAgkCAAIFBAACCQICAwQDAgMEAAIAAgMEBAICBAACBAQEAAgFCgACAAICAAQCBAAGAgQECQQCAgIEAgICCQQCAAICBAACAAICBwICAgMEAgACAgUCAgUCBgQCAAIFAgACBAIEAwQCBQQCAgMEAgICAgICAgMGAgIDAgUCAgAEAwIDAgIHBgAIAAIDAgACBQYCBAUCAgMCAwIGAwICCQQABgMCAwIACAICAgsCAgACAAgDAgIAAgQCAgACAAICAg8EBgACAg0EAAIHAgQFAgIABAIJAgAEAwIJAgICDQIFAgICAAICAgICBQIAAgMCAgkEAwIAAgMCAAIAAgACAwIABAMCAwIAAgICAgIFAgMCDwIDAgICAgACAgcCAgINAgMCAgUEAwICAAIAAgICCwIEDQITAgACAwIJAgMEAgMCAgACAAICBAcCAgICAAICAAQCAAICAwIAAgMCAwIAAhECAAQABAQCBAQDAgIHBAACBAACAAIHBAUCAwQTAgkCBwICBBkCBwICAAIAAgkCAAICAAIHAgACAAQPAgIAAgMCAAIFAgMCAhECAgACAAIABgkEBQICAgINAgIFAgACBQIAAgcCAAIAAgMCAAIABAYZAgMEBQINAgMCAAICAg8CBQIZAgACAAQAAgUECwYDBgIHAgACAgICBwIABAIJAgcCAgACBQIEAAINBAACBQIFAgsCAAICAAIEAgQHBAICGQIDAgQCEwIDAgACBQIDAgMCAAQFAhECEQIRAhUEAAIABAUCBQICBQQLAg0CAicCAgIHAhMEAwIXBAkEAAICAAIAAgcCAAIRAhcCXQIXAhsCBQIdAtsCArsBAgUCZwKBAwLpAwI="
+        },
+        {
+          "operation": "composition_read_current",
+          "requests": 573,
+          "errors": 0,
+          "latency_ms_p50": 11.287,
+          "latency_ms_p90": 17.903,
+          "latency_ms_p99": 24.063,
+          "hdr_v2_base64": "HISTEwAAA34AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAALsoApMBArECAgUCUwJdAr0BApsBAmUCDQIZAgMCAwQRBCECCQICBQIDAg8CBQIJAg8CDwINAgcCMwICBQIDAiUCAgcCCwILAhsCBQJLAg0CAhsCXQIJAgACFQIAAgACBQIAAgMCAAIAAgMCIQIHAh8CAgsCAAILAlcCAhMCEQIAAg0CGwIXAh8EAwQNAg0EAwINAgUCEwIAAgsCAgIZAgcCKwIFAgIVAh8CEwIAAhcCBQICAgMCFwIHAhECBwIAAhECGQQCAAIDAgkCAAQJAgACAgsCAAIJAgkCAAINAhcCCQICCQQCAAQPAgACCQITAgACAwQlAgsCKQICCwIAAg0CBAMCAwYFBAUGBwQLAgMEAAIDAgUCCQICAgUEAgsCBQQbAgAEAg8CAgIABAACCQIFAgcCBQIAAgACBwIABAICAgMCAAIJAgUCBAMCBwICBQIAAgMEAAQABAICDQQFAgIAAgkCAAQAAgACAAICAAIHAgACAwQCAgUCCQICAwICDwQEBwIHAgAEAAIEBwICBwICBQQCAgUCAAIJAgcCAgACDwIEAgMCAgACDQIABAsCEwIHAgUCAhMCAwQAAiMCBAQHAgIHAgIAAgACAgAEAhEEAgMCAwIEAgIABAQCAwIAAgMCBQIHAgMEAgICFwQFBAYLBAMCAgACFQIPAgACFwQCAAQAAg0CDQIAAgACAAIFBAILAgACAAIFAhUCBwICAwIJAgAEAwIFAgMCAAIXAgACCwQJAg8CAgUCBwICAh0CAgMCAgIFAgcEAAIEAgIDAgICAwILAgAEBwQXAgIEAgQLAgACAAIAAgkCAAICAgIJAg0CAgMCAgMCAwIPAgICDQIDAgIDAgcCAgsCBwIAAgkCAAINBAkCAwICAAIABAIAAgIDAhUCBAMCAAINAhECBQICAAIAAg8CBwIDBAIPAgcCAwIDAgUCAAIFAgMCAwIFAgsCAAILAgACAgMCAAIHAhUCAgMCAwIXAgMCAwQCAAIDAhkCAgMCAAQAAgICBAACAAIAAgMCBQIHAgACDQICBQICBQIjAgQCAgMCBQIDAgACAAICAwIFAgACBwIRBAMCAAIHAgcCAAIDAgMCAwINAgUCAgMCDwIjAhsCAikCAg0EAgMCAAIAAgIJAhcCAwIhAgcCBwIZAgInAhUCgwECNQIvAosBAi8CAAKNBgJ7Ag=="
+        },
+        {
+          "operation": "composition_revision_history",
+          "requests": 550,
+          "errors": 0,
+          "latency_ms_p50": 11.799,
+          "latency_ms_p90": 16.207,
+          "latency_ms_p99": 20.143,
+          "hdr_v2_base64": "HISTEwAAA1gAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAMElAh8CZQJtAmkCJQJHAg8CJwIPAjcCbQINAmcCAAJ/AjUCFQIFAiMCeQI1AgACBwIPAg0CQwIlAkkCCwIAAhkCDwICAicCAwIRAg8CBQIPAgsCAAIDBBsCBwIJAgACAwIHAgkCEQINAgUCAwItAgsCCQIZBAsCVQITAgcCBQIAAj0CBQIfAh8CCQIzAhECKQIDAgkCIwIDAgACJwIDAgINAjsCBQIXAgMECwQCFwITAhMCHQIrAh8CFQIhBBsCDQICKwQHAgACAwI3AgMEEQIPAgAECwINAgUCAgACCwIDAgACAAIHAi0CAAIPAhMCFwIFAhUCAwIFAgUCFwIJAg0CBwQCAwIDAgACCQICAg8EAAIEAgMCCwIFBAsCAwIAAgICDwIHAgACAwIHBAIDAgsCAAIDAgMCAAIZAgsCAgIPAgcCBwIABAcCBQICAwICAgIAAgIPAg0CAgACBQICBhECAgMCAwICAAINAgMCAgcCAAIDAgUCFQILAgMCAgICDwIDAgsCAwQHAgIAAgIAAgACAwIRAgMCBwQAAhECAAIFAgACAwIDAgMCAgACAhUCBQICAwIDAgACIQIAAgUGDQQECQICAAIFAgMCAwIHAgMCAAIAAgMCBwIFAgkCAgQABAAECwIDAgIGAgMCAwQLAgAEBAICAAIAAg8CAwICAwICAwIDAgMCAgUCAwIABgICAgUEBQIDAgcCDQQAAhkCAgIAAgICAAIHAgIAAgAEAgcCAgACBA8CAgACAAICAAQCBwQNAgACAAICBAIAAgQCAgIDAgkCAAIGAg0CAgcCAwIFAgAEDQQDAgICAwQEBwICBAUGAAIEBQIABAICAgACBwIAAg8ECQICAAICFQINAgILAgAEAAIAAgcCEQIHAgIAAgACAwICAAIFAgMCCQIDAgUCCwIAAgQFAgAEAgIDAgsCAAIHBAACAwIHAgUGAAICAgACAAQDBAACBAUCAwIFAgMCAAQCBwIHAgcCCwICAwIDAhECAgcCAhkCAgQPAgUCDwIJAgUCBwICAAICBQQCAAIEBQIECQQCBAICAgcCAAIPAgIAAgcCAAILAgIFAgkCCQIRAgUCDQIbAhsCGQIRAgIJAgMCMQIbAhkCGQIXAj0CXwLtAwLNAQI="
+        },
+        {
+          "operation": "composition_update",
+          "requests": 40,
+          "errors": 0,
+          "latency_ms_p50": 23.871,
+          "latency_ms_p90": 33.055,
+          "latency_ms_p99": 41.919,
+          "hdr_v2_base64": "HISTEwAAAF4AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAK8zAq8DAvsGAqkFAucFAsEBAr8BAnMCTwLzAQI3AqMCAlcChQEC3QECAwILAhECHwJ9AmMCzwECBQIJAg0CXwLFAgI1Al8CTwICJQIDAg0CIQIRAgMCMQKJAQLhAgI="
+        },
+        {
+          "operation": "contribution_commit",
+          "requests": 13,
+          "errors": 0,
+          "latency_ms_p50": 60.479,
+          "latency_ms_p90": 72.959,
+          "latency_ms_p99": 79.615,
+          "hdr_v2_base64": "HISTEwAAACEAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAANdeAokJApEBAoUCAmcCcwJfAmMCmQECkwECSQI9As0BAg=="
+        },
+        {
+          "operation": "contribution_read",
+          "requests": 59,
+          "errors": 0,
+          "latency_ms_p50": 7.847,
+          "latency_ms_p90": 13.031,
+          "latency_ms_p99": 19.727,
+          "hdr_v2_base64": "HISTEwAAAIMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAK0fArcBAt0BAlkCsQICvwICDwKDAQKLBAJJApsCAoUCAnECkwECIwKDAgJXAnMCEwKJAQJPAiUCWwJjAiECVQRDAgcCawINAosBAiUECQIZAlECvQECSwIlAiECMwICEwJJAmMCBQIbAtEBAhkEaQIdAiUCpQECjwECtwECjQQC4QEC"
+        },
+        {
+          "operation": "directory_create",
+          "requests": 4,
+          "errors": 0,
+          "latency_ms_p50": 13.647,
+          "latency_ms_p90": 17.695,
+          "latency_ms_p99": 17.695,
+          "hdr_v2_base64": "HISTEwAAAAsAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPFBAt0IArkGAhEC"
+        },
+        {
+          "operation": "directory_read",
+          "requests": 516,
+          "errors": 0,
+          "latency_ms_p50": 11.751,
+          "latency_ms_p90": 16.591,
+          "latency_ms_p99": 19.871,
+          "hdr_v2_base64": "HISTEwAAA0AAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAIUiAp0EAjsCUwIPAnkCtwECFQKVAQIbAi0CEwIVAgACEwIAAhECKwIdAgUCBQIxApEBAjkCDQIlAj8CAwIZAgIFAjUCBB8CBQIZAgMCEwINAlECKwILAlECCwICAhECAhcCCQIdAhECMwJJAgcCBQIvAgIDAgIbAgUCBQIvAiMCAAIFAhMCDQIJAgACFQICCwIzBAMCCQIVAg0CAAIZBAUCCwIDAgMCIQIAAgIJAgUCAAIEIQICAwIAAhcCBwIHAgkCBQIPAgMCAAICDQICEQIHAg8CUwIPBC0CAAIAAgkCJwICIwINAgcCCQIAAgsCLwIrAgcCIwIFAg8CBQIJAgICAwITAgIJAgIEBQILAgkCAAIbAiUCBQIHAgMCCwICBQIHAhUCAAILAgkCCQICAhECAAIAAgIRAgIDAgIPBAMEAgAEAAIFBAACAAICAAILAhECAAIHAgACCwIDAgIHAgACDQIJBAUCAAIAAgUCAgIAAgMCAAIVAgInAgUEEwIDAgMCCQIAAgsCBAIHAgMCAgMCAgACBQICAwITAgMCAwIAAgACAgIDAgUCAAILAgIABAcCBQICAAIDAgcCAAIAAgUCAwICCwIFAgMCCQIAAgACAAIHAgsCAgIFAgIFAgACAAIAAgICAwQEBQICAgAGAgUCAAICAgIFAgIDAgACAwICAgcCAAIAAgMCAwQNBAIDAgMGAAICAgMCAgMCAwIDAgIDAgMCAgcCEwIAAgICAgIHAgcCAgACBQIEAAQFAgIFBAACBQICAgQCBAACAgACAgIDAgIAAgcECwICAAQFAgMCAgMCBQICBQIDBAIAAgkCAAQCEwIJAgYCAgILAgcCAwIAAgAEAwIDAgACDwICAwIAAhkCBQICCQQAAgACDQIAAgkCBQQCEwIDBAINBAIEAhMCAgsEBAMCAwIJAgMCDwILAgsCDwITAgMCAAQDBA8CAgIDAg0CAg8CDQICAgsCAAIFAgcCNQIAAgIAAgMECQQFAgIAAgsCBwQCAhkCAgUCAAILAgUCAgACBQIHAgUCCwQCAwICAAITAgIFBAcCIQIHAgMCAwIFAgUCHwICCQIJAhkCEwJHAtUBAjkChQICFwI="
+        },
+        {
+          "operation": "directory_update",
+          "requests": 8,
+          "errors": 0,
+          "latency_ms_p50": 16.927,
+          "latency_ms_p90": 21.775,
+          "latency_ms_p99": 21.775,
+          "hdr_v2_base64": "HISTEwAAABcAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAKk/AqkDAvMIAvMEAksCkwEC4QECkwEC"
+        },
+        {
+          "operation": "ehr_create",
+          "requests": 8,
+          "errors": 0,
+          "latency_ms_p50": 10.007,
+          "latency_ms_p90": 15.087,
+          "latency_ms_p99": 15.087,
+          "hdr_v2_base64": "HISTEwAAABcAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAIEzAv8JApUEAqUCAgMCmwEC+QYC0wEC"
+        },
+        {
+          "operation": "ehr_read",
+          "requests": 54,
+          "errors": 0,
+          "latency_ms_p50": 7.567,
+          "latency_ms_p90": 14.807,
+          "latency_ms_p99": 15.727,
+          "hdr_v2_base64": "HISTEwAAAHwAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAKkfAocCAsEBApMBAoMEAnUCQwJrAiUCowECgwYCmwECHwKzAQK5AQIhAhUCAAI1Ai8CNQINAt8BApcBAkECHQKrAQJRAkECHwKFAQKXAQIVAgcChQECCwIlAn8CLQKzAgJXAmsCZQIPAl8COwJ9AhUCjQECTwI1AgMCUwQ="
+        },
+        {
+          "operation": "ehr_status_read",
+          "requests": 15,
+          "errors": 0,
+          "latency_ms_p50": 12.951,
+          "latency_ms_p90": 19.679,
+          "latency_ms_p99": 21.407,
+          "hdr_v2_base64": "HISTEwAAACgAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAME2AuUCAusBAvMEApcFAl0C2wECuwECAwITAp0DAlkClwUCQQLVAQI="
+        },
+        {
+          "operation": "ehr_status_update",
+          "requests": 14,
+          "errors": 0,
+          "latency_ms_p50": 13.663,
+          "latency_ms_p90": 19.519,
+          "latency_ms_p99": 27.743,
+          "hdr_v2_base64": "HISTEwAAACUAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAMsxApEJAuUKAh8CDQLxAQLlAgITAuEDAt8BAlcCgQECcwKBCAI="
+        },
+        {
+          "operation": "stored_query_execute",
+          "requests": 109,
+          "errors": 0,
+          "latency_ms_p50": 21.439,
+          "latency_ms_p90": 28.431,
+          "latency_ms_p99": 51.167,
+          "hdr_v2_base64": "HISTEwAAAM4AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPE+AscCAvMBAl8COwJvAgsCCQLHAQKPAQILAl8CTQI/AjkCJwI5AgMCHwKVAQJtApEBBFcCEwIRAgMCAgcCAwQNAhUCFQIDAgACBwICBQJlAg0CPQIZAgUCVQIRAgcCFwQdAgkCGwIAAgsCDwIhAgUCAwIRAhkECwQTAgMCAAIXAgIABAUCBwQFAhcCDwIAAgMCBwIjAgMCEQIDAiECAl0CBwIFAg8CVwQhAoEBAgUCNwIDBAcCGQJ3AgACKQJDAocCAlcCPwI3AskHAnMC"
+        },
+        {
+          "operation": "tags_put",
+          "requests": 18,
+          "errors": 0,
+          "latency_ms_p50": 10.943,
+          "latency_ms_p90": 19.631,
+          "latency_ms_p99": 21.871,
+          "hdr_v2_base64": "HISTEwAAADEAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAOUtAoUKAtkBAkMCzwUCeQJ/AsMCAoUBAn8CxwECVwL7AQKFAwKlAgKFAQKHAgKVAgI="
+        },
+        {
+          "operation": "tags_read",
+          "requests": 18,
+          "errors": 0,
+          "latency_ms_p50": 9.919,
+          "latency_ms_p90": 13.039,
+          "latency_ms_p99": 14.935,
+          "hdr_v2_base64": "HISTEwAAAC4AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAM0vAtUGAhEClQMCowMCzwICawKNAQLjAQIlAlMCcQKRAQIbAi8CtQECewLXAwI="
+        },
+        {
+          "operation": "template_get",
+          "requests": 46,
+          "errors": 0,
+          "latency_ms_p50": 22.143,
+          "latency_ms_p90": 50.303,
+          "latency_ms_p99": 63.295,
+          "hdr_v2_base64": "HISTEwAAAHMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAALcuAo0CApkFAgACrQECvwEC7wMChwQCzwECkQUCFwJ7AjcCAAJdAocCAg8C0wECmQICkQICKwIxAtUCApcDAp0DAksCOwKDAgI9Ao0BAhECGQKnAQJRAgUCrwECEwIXAgUCvQICKwJLAhkCNQK7AQKXBAI="
+        },
+        {
+          "operation": "template_list",
+          "requests": 45,
+          "errors": 0,
+          "latency_ms_p50": 7.583,
+          "latency_ms_p90": 12.975,
+          "latency_ms_p99": 18.127,
+          "hdr_v2_base64": "HISTEwAAAGwAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAP0kAtsDAoUDAvEBAnUChQECEwI5AjMCjQEC3wECAAKPAQIRAlMCywECuwECZwIvAoMBAmMCAwLfAQKJAgJbAgkCnQECYQJHAh0CDQKJAQJhAhcCIQJNApsBAicCNQIZAksCDwJxAusEArcCAg=="
+        },
+        {
+          "operation": "ward_query",
+          "requests": 109,
+          "errors": 0,
+          "latency_ms_p50": 138.111,
+          "latency_ms_p90": 188.543,
+          "latency_ms_p99": 247.551,
+          "hdr_v2_base64": "HISTEwAAALcAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAALt5AnECDwI1Ag8CNQIDAgKnAQIbAgIHAgMCSQIPAjUCFwQXAgcCCQIAAg0CDwICBAIZAgACAwIDAgsCBQICCwIAAhECBwIGAg0CAwIGBQIJAgIDAgkCBAsEDwIFAh8CAhMCHQIXAg8CEQIDAgMCVQILAgAEFwIDAgIJAgI/AhsCCQIFAhsEAgILAh0CCwIRAgJFAhECCwIzAgUCCQQHAgMCCwICCwIJAmECXwJ/Ao8CApMCAr8FAg=="
+        }
+      ],
+      "stable": true,
+      "generator_bound": false,
+      "resources": {
+        "sample_interval_s": 10,
+        "containers": [
+          {
+            "role": "sut",
+            "name": "ehrbase-rs-ehrbase-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 8.588382146278391,
+                "rss_bytes": 278085632,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4236126981,
+                "net_tx_bytes": 7882992227
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 7.740614571255254,
+                "rss_bytes": 280408064,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4243429343,
+                "net_tx_bytes": 7885407470
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 7.49263464247478,
+                "rss_bytes": 280428544,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4247984855,
+                "net_tx_bytes": 7887794205
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 7.893828983889489,
+                "rss_bytes": 284315648,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4258163760,
+                "net_tx_bytes": 7889887646
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 7.9714598273105,
+                "rss_bytes": 286269440,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4266300075,
+                "net_tx_bytes": 7892340357
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 7.74452056912662,
+                "rss_bytes": 287977472,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4272265133,
+                "net_tx_bytes": 7894862471
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 7.991013177314504,
+                "rss_bytes": 288034816,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4278721133,
+                "net_tx_bytes": 7897086066
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 7.673280510734587,
+                "rss_bytes": 287989760,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4282045661,
+                "net_tx_bytes": 7899344307
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 7.692060531244168,
+                "rss_bytes": 287989760,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4285461936,
+                "net_tx_bytes": 7901729212
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 7.943498936952648,
+                "rss_bytes": 288653312,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4294001857,
+                "net_tx_bytes": 7904426904
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 7.462854283447625,
+                "rss_bytes": 291151872,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4299898817,
+                "net_tx_bytes": 7906403935
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 7.0105290527031645,
+                "rss_bytes": 291328000,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4304763387,
+                "net_tx_bytes": 7908638554
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 8.025419745397286,
+                "rss_bytes": 277417984,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4313144427,
+                "net_tx_bytes": 7910921326
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 8.447901391656346,
+                "rss_bytes": 289689600,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4322098491,
+                "net_tx_bytes": 7913750812
+              },
+              {
+                "offset_s": 150,
+                "phase": "drain",
+                "cpu_pct": 7.891107690307568,
+                "rss_bytes": 289579008,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4330403574,
+                "net_tx_bytes": 7916067610
+              }
+            ]
+          },
+          {
+            "role": "db",
+            "name": "ehrbase-rs-ehrbase-postgres-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 26.62784797599236,
+                "rss_bytes": 2405720064,
+                "blk_read_bytes": 3574059008,
+                "blk_write_bytes": 45886009344,
+                "net_rx_bytes": 7213374058,
+                "net_tx_bytes": 1069691241
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 24.854444477918772,
+                "rss_bytes": 2408185856,
+                "blk_read_bytes": 3586932736,
+                "blk_write_bytes": 45898223616,
+                "net_rx_bytes": 7215370430,
+                "net_tx_bytes": 1076362328
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 24.311834480148953,
+                "rss_bytes": 2362413056,
+                "blk_read_bytes": 3602116608,
+                "blk_write_bytes": 45913272320,
+                "net_rx_bytes": 7217343934,
+                "net_tx_bytes": 1080282742
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 28.532804028417175,
+                "rss_bytes": 2363957248,
+                "blk_read_bytes": 3617112064,
+                "blk_write_bytes": 45926731776,
+                "net_rx_bytes": 7218986665,
+                "net_tx_bytes": 1090049771
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 28.447182803344955,
+                "rss_bytes": 2412724224,
+                "blk_read_bytes": 3633799168,
+                "blk_write_bytes": 45944442880,
+                "net_rx_bytes": 7221301167,
+                "net_tx_bytes": 1097475332
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 25.601315872317976,
+                "rss_bytes": 2415734784,
+                "blk_read_bytes": 3640176640,
+                "blk_write_bytes": 45959360512,
+                "net_rx_bytes": 7223093935,
+                "net_tx_bytes": 1102893166
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 24.116574845843726,
+                "rss_bytes": 2415689728,
+                "blk_read_bytes": 3645448192,
+                "blk_write_bytes": 45971288064,
+                "net_rx_bytes": 7224890416,
+                "net_tx_bytes": 1108798656
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 25.651136633824063,
+                "rss_bytes": 2417950720,
+                "blk_read_bytes": 3664072704,
+                "blk_write_bytes": 45985837056,
+                "net_rx_bytes": 7226755766,
+                "net_tx_bytes": 1111576547
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 24.251053914780446,
+                "rss_bytes": 2418241536,
+                "blk_read_bytes": 3686572032,
+                "blk_write_bytes": 46000705536,
+                "net_rx_bytes": 7228741741,
+                "net_tx_bytes": 1114314502
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 27.32370665403041,
+                "rss_bytes": 2416537600,
+                "blk_read_bytes": 3708203008,
+                "blk_write_bytes": 46014722048,
+                "net_rx_bytes": 7230986534,
+                "net_tx_bytes": 1122114412
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 25.366382930363336,
+                "rss_bytes": 2418102272,
+                "blk_read_bytes": 3735539712,
+                "blk_write_bytes": 46030696448,
+                "net_rx_bytes": 7232549685,
+                "net_tx_bytes": 1127628773
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 24.63127293837509,
+                "rss_bytes": 2418524160,
+                "blk_read_bytes": 3753877504,
+                "blk_write_bytes": 46045843456,
+                "net_rx_bytes": 7234378323,
+                "net_tx_bytes": 1131927162
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 26.294572826261188,
+                "rss_bytes": 2417098752,
+                "blk_read_bytes": 3760709632,
+                "blk_write_bytes": 46059876352,
+                "net_rx_bytes": 7236227996,
+                "net_tx_bytes": 1139756644
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 26.17540846246747,
+                "rss_bytes": 2419523584,
+                "blk_read_bytes": 3771387904,
+                "blk_write_bytes": 46078275584,
+                "net_rx_bytes": 7238635125,
+                "net_tx_bytes": 1147925555
+              },
+              {
+                "offset_s": 150,
+                "phase": "drain",
+                "cpu_pct": 25.488646551971577,
+                "rss_bytes": 2418110464,
+                "blk_read_bytes": 3782840320,
+                "blk_write_bytes": 46094528512,
+                "net_rx_bytes": 7240518130,
+                "net_tx_bytes": 1155659461
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "rate": 64.0,
+      "offered_load_sustained": 64.63333333333334,
+      "operations": [
+        {
+          "operation": "adhoc_query",
+          "requests": 1017,
+          "errors": 0,
+          "latency_ms_p50": 15.151,
+          "latency_ms_p90": 21.071,
+          "latency_ms_p99": 29.679,
+          "hdr_v2_base64": "HISTEwAABHsAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAL0yAqcCAsUDAk8CLQJxAiECDQIhAicCGwILAgACNwINAgIDAgACKwIfAm0CBQIJAgUEFQIbAg0CPwINAgIAAiUCCwIJAhsCFQIXAgACCQI1BAcCBAMCBgIAAgcCBQYCBwIFAhECBwIEAAIGAgUCBAQABgcCAgACAAIAAgIDAgkCAAIDBAIAAgMCAwQCBQIPAgMCEQIAAgkCAAIAAgIAAgkCAAIFAgICBwQAAgACBwICBQIFAgIAAg0CAgMCAgAGAAIGBwICAgACAgMCAgIDBAAEAAQJAgACAAIDAgICAgUEBwICCQICBwIAAgICBQIFBAICAgACBAQEAgIAAgkCDQIEBwYAAgICAAIEAAICAgQCAAINBgACAgICBAIEAAIFAgQEAAILAgICAwICAAYVAgICAgUCAwICBwYCAAQCBAIFAgIABAAGAgICAgQCAAICAgMCAgUEAgkCBAUGBwQAAgkCAgUCAgIDAgMCAwQDBAILAgACAAIFAgUCAgIAAgACAgAEAgQJBAIEBAIAAgAGAgIGAwIEAwIEAgIFAgACAAIAAgIACAICAAQFBAMCBQYFAgQGBAAEAAIEBQIEAgQEAwIEAwIGCQIAAgIEAAIDAgACBgMCAwIABAQEAAIEAgACAgMGCwICAAIAAgIAAgICBwQABAUCAgICAgAEAgIFBAICBQIEBwQCAgACBQIJAgUCBgAEAgIHAgkEAgUCAwICBQICBAMCAgQHBAACAgMCAgIEAAQCAAIFBAQCAgAEAgACCQQDAgACAgMCAgQJBAIABgQCAwICAgACBAIABAMCAAIFAgkCAgMCAgACBgICBAAEAwQAAgMEBAMCAgICBQYDAgQAAgIEBAIABgQCBQIAAgIAAgAGAgMEAAIAAgIEAAIEAgIHAgACAgcEAgMCAgICAAYCAAICAAICAAIAAgMCDQIAAgIDAgUCAwIEAAIABAICBgMCAgACAgQCAwIDBAQCAAgGAgQDCAIABgYCAggGAwICAgQEBgQEBQICAgQEAgAEAwQEAAIIBgQDAgIGBAQIBAQCBgIKAggEAgICBAQABAACAAIAAggEBAYEAAQEAAQEBAACBgQDAgIEAgQABgIDAgQCBAIEAAQEAAICAAIDBgIEBAICBAQDBAACAgIAAgMCAAQCAAICAgACAAICAwICAAYCBAIDAgUCAgACBQICAwIEAAIEAgICBAIEBAUEAAIABAYEAwIAAgQCAgAECQIABAAEAgICAAICAgICAAIJBAIAAgMCAAICAgACBQIEAgUEAAIDAgQDAgACAgACAgACAAIECwICCQICAAICAwIDBAICAAIDAgACAAIEBQIAAgIPAg0CCwIAAgMCAAICAAQCDQICBAIABAMCCQQCAwIDAgMCBwIJAgACBQICCwICEQIDAg0CAAQLAg0CCwIAAgACAAICFQICAAQFAhEEAwIJAgMCIQINBhcCDwIpAgUCAl0CEwIpAicCNwIJAgcCDQIrAg0CTwIxAh8C4QMCCQJPAt0BAkMCZwJtAlcCcQI="
+        },
+        {
+          "operation": "composition_commit",
+          "requests": 313,
+          "errors": 0,
+          "latency_ms_p50": 16.007,
+          "latency_ms_p90": 38.239,
+          "latency_ms_p99": 60.543,
+          "hdr_v2_base64": "HISTEwAAAi8AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPExArEBAr0GAh0C3QICeQJNAh8CbQIpAkcCQQIJAgkCFQIHAg8CFQIVAhkCMQITAgAEFwIJAhECBQIFAgIJAgcCAAIFAgACGQIPAgcCIQIvAj0CDwILAgACAgUCBQIFAgIHAgIHBAMCDwIZAgMCAwInAgMCAgcCAgsCBQQCBQICBAIFAgICDQICAg8CAwIAAgAEAhECFwILAgUCAwIJAgUCAwIHBAMCCwICFwIHAgIABA0CAh0CAAITAgkCAwINAgACGQILAgACAAITAgUCEQIPAg0CDwIRAh0CAAICCwINAgUCBQIVAgkEAAIJAgUCDQICAAICCwIDAg8CHQIJAicCGwICDQIxAgACOQIPAgMCBwIDAgICJQICCwICAhcCAgcCAgACAAICBwIHAgACCQITAgsCAgIDAgIFAgUCAgcCDwQHAgIHAgsCAwIVAgUCAAICAwQjAgMCBQQCBAIFAgkCAwIHAgkCAgsCAAQHAg0CAgkCCwI3AgsCDQQZAgUCDQIFAgcEAAQJAhECAwICDwIVAgMCAAITAhMCAhkCCwIHAhUCCwIHAksCAAIAAicCBQJZAgIRAiUCBwITAmMCBwIVAkMCCwJfAgMCQQIPAgsCCwIFAocBAmECiwICOQIZAhMCAAJLAh0CFQICMQIlAh0CAAIVAgMCEQIzAjMCNwIHAi8CFQIHAicCHQIdAlUCIwLrAQIVAhMCHQIpAjMCBwILAsMCAgkCsQECLwKrAgI="
+        },
+        {
+          "operation": "composition_read",
+          "requests": 2034,
+          "errors": 0,
+          "latency_ms_p50": 8.035,
+          "latency_ms_p90": 13.855,
+          "latency_ms_p99": 18.687,
+          "hdr_v2_base64": "HISTEwAAB/IAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAM8cAg8CrQUCIQIXAiMCAAITAiMCNwIbAgACFwIFAlECOQIDAg8CMwIRAg8CAAIDAgIVAgACGQIDAi0CDQIHAgMCAAINAgcCFwITAgkCBA0CAwQDAg8CEQITAgUEAgkCCQITBgACBAACFwICCwICBQIFAg0CCQIHAgkCAAIDAhUCAgcCBwIGAgkEBQIZAgUCAAQAAgACAgICAgUCAgUEBQIDBAACBwIFAhUCAwQEAwIPAgILAgMCAgMCBQYHAgIDAgUGCQICAgMEAgUEDQIEBQIDBAIEBQIDAgACBBUCCQIFAgUCAwIPAgIFAgIFAgsCBQQCBAACAAIHAgIAAgMCAgACAAQAAgACAgICAgACAgICAgIDAgIFBAACAgIEBwICCQILAgUCAgACAAQEAgAEAAIAAgMCAAIAAgACBAIAAgACAgICAAIAAgACAgICAwQABAMCAgAGBAACAgIAAgQEAAIABgMCBAACBAICAgIAAgICAAIAAgIABAQCCAIEBAIEBQQCAwQEAAYCBQQLCgMEBAQCAgYCAgMCAgMEAAICAAYFAgMCAgIGBAACAgICAgAEAgUEAAIAAgMEBQIAAgAEBAIAAgQCBAAGBQQDBAAEAgMCBAUCAgIDAgICAgQCAgMEBgIEAAICAAQABAQFBAAMAAIAAgIEAgACBgIEBgIGAgAIBAMCBAACAgQDAgAEBgACBAQCAAIDBAMCBgAEAAYABgUECgACAgYEAgYCAgQEAwQEBAIABAAEAgYDAgIGBAQFBAQCAAICBwQDAgQCAgACAwIDBgUCAgIABAMEAAIAAgQCBAQEAgQHAgIEAgAGAgMEAAICBAIFAgQCAAIHBAACBAQCAgIAAgACAgACAwYCAgIFAgIKAgQDBAICAgICBAICAgIDAgICAAQEAgICAgUCAAIAAgACAAIHBAYCAwIDBAQCAgIABAIDBAYCBAACAgMCAAICBwIABAICAgAEBAIABAYDBAACAAQPAgACAgACBQICAgQCAgQDAgICAAIEAgIABAICAAICAgACBAACBAACAAIHBgQAAgIAAgACAAIDAgACAgACAgQCAAIABAIJAgQDAgMCAAIEAAICBgMCBwYFAgIABAIEAgMCAgYEAAIAAgICAwIGAgIAAgIJAgACAAICAAIEAgIDAgICBQQDAgIEAwIEAAIAAgAEBAMGBAACAAICAAIDAgAEBgIHAgIEBwQCAwIAAgACAAIAAggCBAACCQQAAgIABAICAwIDAgAEBAACAgYAAgICAAICAAQAAgYCAgIFBAICBwQCBAACAgICAgUCAAIDBgIAAgUCAgICAAYCAwIDAgUCAwIDAgICAwQCAgACAgACDQoCAgMIAAQCBQICAAIFAgcCCQIAAgQCAwIECQIAAgACAAIFAgACAgIEBAIAAgIFAgACBAAEAgQAAgAGBwICBQICAgIEAgACAgIAAgIAAgACAwQAAgACAgMCAwQCAAICAgIEAwICAAYCBgICBAIHAgICAAYFBAIHAgMCAgICBAQCAgIEAgQEAgAEAgICBAYGAgQCBAIEBgQCAAIEAAYCBAACAAICAAQEAgAEAAYEAgICAgICBAIEBAICAgACAgIABgIEAggECAIEAAICCAUEAAICAAQAAgIAAgICBwQAAgACAwQCBAYEBAYEAAQCAgIEAAICBAIEBAQDBAICBAIAAggCBQoAAgICAAQEAgAEAgMCBgIAAgACAgICBAACAgYCAAICBgICAgACAgAIBwQEAgQABAMEBAIABAIEAgIABAAEBAMEBAYCAAIEAgACBgAEAgAGAAQCBAICBQIFBgAEBAAEAgAEAgQCBAMGAAQGAgACBQIGCAQCAgACBQYEAwICBQQCAgIEAAICBAACBgMCBgIAAgMCAAIIBAYCAgIABgIEBgIEAwIECAACAgICAAQABgQEAAIEBgQCAgAEBAACAAICBAACBwIHAgQEBAMGAwIFAgIEAgMCAgQABgMCAgAEAAIEBAMCAAIECAAEBgQCAgQAAgYGAgICAwICAAIEBAQCAAQCBAYCAAQCAAICAgACBAQAAgMCAAIFAgQEBAICBQICBAAEAgQABAICAgAEAgAEAAQAAgQEAAICAggAAgMCAgICAAQCAAICAgkCAgQGAAQGBAUCAgICBAIAAgIFBAMCAgMEBAAMBAgEAgMCAgQCBAIAAgICBAQABAICAgAIAgQGBAQCAAYEAAICBAAGAwQIAgQGBgMEBAMEAAQCAgIEAgIGAAQCAggAAgACAgYAAgAEBQQCAgACAwYAAgIEBgUCAAIABAIABgICAAYEBAIEAwICBgQCAgICAAIEAwQAAgAEBAIGAwICBwIDBAMCAgAEBQQGBAQEAAIEBgMCAwQEAAYAAgQCAgMEAAIABAQCAgYAAgMEAgACAgACAgIABAQCAAQGAgICAAICAgICAAgAAgACCAQCAgIDAgACAgQDAgYCAgACAAIDAgsCBBUEBAACAgQDBAICAAIDBgIGAAYFBAkCCQIFAgUCAwIAAgIABAcCAwIAAgICAgIRAgIHAgQABB8CCQIFAgMCAAIHBAUCCQIGDQIAAgIDBgIRAgMCAwICBwIABBsCAAIAAgcCAwIfBB8CAAIjAg8CCQILAgUCBQIDAgUCCQICGwIvAhkCBQItAjkCAgcCOQIJAi8CFwIHAl8CmwECHwJfAksCRwIjAoMGAucBAtMCAoMPAg=="
+        },
+        {
+          "operation": "composition_read_current",
+          "requests": 1144,
+          "errors": 0,
+          "latency_ms_p50": 7.931,
+          "latency_ms_p90": 13.599,
+          "latency_ms_p99": 18.191,
+          "hdr_v2_base64": "HISTEwAABaQAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAANckAg0CkQECiQECBwIAAisCHwIRAg0CAgUCAjECPwIfAhcCAgsCFwIhAhECEwIvAg0CAwIzAgcCAg0CAg8CIwIHAgMEAwI5AhUCOQILAgMCAwIVBA0CGQIJAgUCNQIABAMCCQI9AgcCAAIHAgACBwIPAg0CAAIRAgMEAAIAAgICBQQFAgACAAICAAQABAICAgUCBQYDBAICAgMCAAQAAg8GBwQAAgUCAgIAAgICCQIAAgUEBQQEAAICDQICAwIAAgQCBQIAAgUCAgQEDwIEAgIHAg0CBAQFAgIFAgICCQQHBgICBwQFAgIFAgACAAIFAgACAgICAwIHBAIABAACAAIEBAUCAAQCAwIDBAIAAgQAAgkEBwIFBAAEAgACAAYCAgIDAgUEBQIHAgACBQICAwICAAIAAgACCQQAAgICAwIDBAACAgQFBAAEAAIEAgACAAICAgIAAgQCAwICAgICAAIDBAUCAgMEAgIAAgQVAgMGAgQCAwICAgIABAMEBQICAAIDAgACAAILBAACAAQGBQQLAgIRAgMEAwIABgMCAAIAAgMCAwICBwIAAgACAAQAAgUCBAUEBAQCBgQCAAQCBQQCAgACBQICAwQFAgACAAIDBAQCBQQCAgQFAgACAwIDAgYAAgcCAgcEAgQCAgQAAgAEBAAEBgICBwICBQYJBAMCAgUCBAIAAgACBQIEBQIEAgAECAMCAgkCBwIFBAAEAAICAgMCAAIAAgQAAgACAAIDAgACBQIFBAIAAgUCCwIFAgIFAgYFAgIHAgICAgICAgIFAgIEBAIRAgMCBwQCBgIABAIAAgICCQIAAg0CAAICBQICAwQCBAIJAgIAAgICBQICBwgAAgACAAIAAg0CCwIFAgMCAAIDAgIEAg0EAwICAAIHAgIAAgIDAgACCwIABAMCAgcCBwQEAAICAwQDAgACAAICAAQAAgICAgACAgkEAwIZAgACBgIFAgkCCwIAAgQABAICBQINAgsCBwQCAAIAAgIABAMCAAIAAgMCBwIFAgAEAAQAAgQDAgAGAwQCAgICAgICAAQFAgIAAgUCAgIAAgACBgAEAAQCAAICAgQCAgMCAAIDBAAEBwIAAgMCAgMCAgIDAgACBAICAAQCAgMEAgACAAIFBgAGAAQCAAIDAgQABAAEAgAEAAICAgIECQIFAgUEAgIAAgICBAsCAAIABAYCAgACAgIDBAICBAQCAAQAAgMCAAIECQIAAgICAAQCAgMCAgcCAgkEAgACAwIAAgMCBAQEAgcCAwIDAgQABgUCBQQLBAAEAAIDBAACCwIFBAMEAAIEAgMEAAQCAwICAAIEDwIAAgYCAgAGBAIAAgMCAgUCAAQEBQICCQIABgACAgACBAIABAQCBAIHAg0CBQICCQICAgcCBgcCCwICBAIAAgIEBA0CAAQCAAIDBAAEAAIABAICAAICAgIFBgUCAwICAAICBwQEBAIDAgsEAwICAwQDBAIAAgICBQICAgkCAgIAAgcCAAgDAgQEAgACAAIAAgQCAgUCAgIAAgAEAgIFBAACAAQCBAMEAgMCAAQCAgYFAgIAAgACAgACAgAEBwICAgIFAgICAgACAAICAAICBBEEAwIEAgACBAIEBwIAAgACAgACAgAEBQYAAgQAAgMCAAIAAgACAAICBwICBgIFAgIABAUCBwIDAgMCAgACBAMCAgMCBAUECwQAAgACAgIAAgsCAwILAgUEAwQDAgUCBQQCAAQDBAMCAAIFAgIZAgMCAgACAwINAgcEAAIAAgMCAg0CAAIdAgACAAQLAgcCAAQNAhUCAAIAAgICBAMCCQQAAgIAAgACEQICDQINAgsCAAIXAgACUQICDQINAgACDQIbAh8CAwIZAgMCCQIhAgIjAgkCBwIbAgcCDwI1AgMCKQIZAh8C1wMCaQLdAQKtBgI="
+        },
+        {
+          "operation": "composition_revision_history",
+          "requests": 1097,
+          "errors": 0,
+          "latency_ms_p50": 7.983,
+          "latency_ms_p90": 12.383,
+          "latency_ms_p99": 18.287,
+          "hdr_v2_base64": "HISTEwAABZQAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAN8bAocBAg8CnQECdQJNAosBAgsCPQIdAgUCCQInAg0CFQIrAiECGQI9AgACFQIFBCECBQILAgUCAgACBQIPAgIHAmcCAiEEHQILAgACBQQCAwIHAjECIwICCQQJAgkCBQIHAh8CAgkGAwINAg0CFQIJAgIJAhcCAgIhAgIAAgUCAAILAgkCAAIAAgMCAg8CLQINBAACBQIAAgICDwICEwIAAgICDQINAhcCAg8CJQIHBAACAAQAAgcCBQIHAhcCBQIXAgIPAgkCAgACAwIbAgACAhMCAgIJAgACAAILAgcCIQIDAgITAgIDAgsEAgIAAgkEAAIJAgUCCQIAAgMCAwILAgcCAAIHAgUCDwIHAgkCBAUCAgUCBAMCFQICEQIJAgMEAAICAgACAgkCAAICBQIEAAICAgMCBwIFAgIDBAICAAIEAgIHAgACBAACAAICBQIHAgkEAAIDAgACAgsCCwIAAgMCBAYCAgUCAwIPAgACAwICCQQNAgIAAgAEAAIJAgUCDQIJAgIXAgAGBwIHAgACBQQCAAIDAgICAgkCCQQDBAILAgACBAAEAgACAAIDBAIFAgMEAAIEAAIDAgAEAgcCAgIHAgACBQQAAgICBAkCAwIJBAMCBCsCCQIFBAkCCQICBQIRAgIFBAICAAYJAgkCBQIAAgcCAAICAgACBQQFAgACCQQFAgUEAwYCCQIAAgcEAAYAAgMCAwIABgUCBwINAgkCBQIHAgUCCwIDAgICAg8CBQIJBAICAgICAwIFAgUCBAACAwIABAAEAwIFAgACAgkECQQAAgIJAgcEAAIAAgACAAIDAgACEQIPAgIDAgMEBQQCAAIDAg8CAwIRAgUCAwICAgMEAgMCAgAEEQIABAsCAgMCAgACBwIAAgACAwIAAgACAAQHAgAEAAQAAgICAgACAwIFBAIFBAQAAgICAwIJAgACAgUCBAACAgICAg8CAAIAAgMEAgMEAgMCAwIAAgMCAAIDAgIJBAUCAwIDAgACBAAEAwIAAgAEAwIRAgIAAgIFAgQHAgILAgIJAgMCAgIAAgIFAgUEAAQCAgIABgcEAAICAgICAgUCAAIRAgsCBQICAgACAgIFAgACAAIFAgIDAgACBAIDAgICAwQEAgIAAgACBgICAAQNBAUCAgUEAAIEAgICAgAEAgACBgMCAAQEAgIFAgACAwIAAgIGAAIAAgAGAwIEAgIDAgIAAgIAAgACAgMCAgIEAgQCAgMCAgQDAgQCAgQDAgMCAAQEAgQFAgICBAACAgkCAwIAAgICBQYAAgIDAgIDBgAEAAQEAgYAAg0CAgICAgIAAgQEBQICAAICAAQABgICAgQEBAQCAgQAAgAEAgACAAIDAgQCAgAEAgACBQQGBAQAAgAEBgMKBQQEAwIDAgICAgQDBAIEAAIABAQEAAICBAQLAgICBAICAwIGBAMCAgACBAACAgIIAAICAAQAAgUCAgAGAAIAAgACBQIAAgICAAIFAggCAgQCCAMEAgICBAUEBAIEAwQCAAIEAgICBQIABAMEAAICAgMCAgQAAgIFBAMCBAIGBAIABAYDAgAEAAQCCQIEBgYCAgYAAgAGBwICBQIAAgMCBAACAwIABAQDBAMCAAQCCQQCAgUCAAIEAAIAAgACAgIDAgIAAgICBQQDAgMCAAIDAgIAAgAEAwICAgACAwIEAAIDBAACAAQCAgACAAIJBgIAAgMCAgUCEQQLBAUCBwQHBAAEAgQDAgACAwIAAgMCAAIDAgACAgIAAgIEBQILAgACAgICAAICBAACAgMCDwIDAgsCCQICAgUCGQQCAAIHAg0CDQIFAgACBAcCFQIdAjUCAhcCRQIFAhMCWQI3Ao8BAgACXQJrAgsEPQIlAi8CAAIHAi0CIwJVApUCAosDAskHAg=="
+        },
+        {
+          "operation": "composition_update",
+          "requests": 82,
+          "errors": 0,
+          "latency_ms_p50": 13.447,
+          "latency_ms_p90": 22.607,
+          "latency_ms_p99": 25.311,
+          "hdr_v2_base64": "HISTEwAAAKIAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAMsxAvkBAr0DAjMCGQITAjcChwECAwINApUEAp0BAkECZwLnAQIvAicCcQIdAiUCNQIdAlECKwIAAiECHwJFBBcCaQIPBBsCAg0CBwKJAQIVAgcCAi0CCwIXAtkBAiMCHQJjAk0CoQECMwIVAg0CJwIRAgMCEwJNAgJXAgMCEwIDAj0CFQIPAlUCJQQCHwICJQJTAi0CBwJtAgJXAhsCDwIZAg=="
+        },
+        {
+          "operation": "contribution_commit",
+          "requests": 28,
+          "errors": 0,
+          "latency_ms_p50": 41.727,
+          "latency_ms_p90": 54.943,
+          "latency_ms_p99": 58.943,
+          "hdr_v2_base64": "HISTEwAAADwAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAANFCAuMbAocCAo8BAhMCHwIZAikEAAIzAisCXQIPAgIZAnECYwKlAQIdAjUChQECQwIFAkECJQKXAQJdAg=="
+        },
+        {
+          "operation": "contribution_read",
+          "requests": 118,
+          "errors": 0,
+          "latency_ms_p50": 5.531,
+          "latency_ms_p90": 10.959,
+          "latency_ms_p99": 16.799,
+          "hdr_v2_base64": "HISTEwAAAO4AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPkhAicCFQInAh8CMQKxAQIlAoEBAh0CBwKLAQIjAmECKQIPAg0CAg0CGwInAiUCCwIxAgMCFQILAhcCBwJZAgIDAkkCAwIDAi8CsQECCwIlApsBAgACBwIDAgMCGQJrAgcCAwI7AgINAiUCHQInAhECbQJXAgMCOQItAk0CAjsCGQJrAgUCQwJXAgcCUwIPAgACTQIJAlECCwINAgkCfwIdAi8CMQIAAisCEwJPAi8CWQQnAgcCLQIvAi0CKQI7Ag8CPwIHAhkCHQIAAg8CcQIABBkCTwJFAgcCyQECOQIrAgK5AgLNAQKVAwLjAQI="
+        },
+        {
+          "operation": "directory_create",
+          "requests": 9,
+          "errors": 0,
+          "latency_ms_p50": 13.407,
+          "latency_ms_p90": 21.743,
+          "latency_ms_p99": 21.743,
+          "hdr_v2_base64": "HISTEwAAABgAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJ00AukOAmsCnQEC+wQCLQI5AtcGAr0DAg=="
+        },
+        {
+          "operation": "directory_read",
+          "requests": 1032,
+          "errors": 0,
+          "latency_ms_p50": 6.335,
+          "latency_ms_p90": 9.783,
+          "latency_ms_p99": 15.447,
+          "hdr_v2_base64": "HISTEwAABUEAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAALMeAt0BAlkCQQIFAiUCAiUCBQIlAgkCIwIDAgACBQICAg8CCQQDAgUCGwIRAi0CBwIHAgcCBQIJAgIlAgcCOQIAAgsCCwIDAgcCAAIHAhUCCQIvAgIXAhcCAgIbAg0CDQIJBAIAAksCAgUCAgUCAgUCAAIHAgACAgkCBQICAwICAwIFBAMCBQILAiMCAgIFAgIJAgACBwIDAgcCAgkCAAIDAgIJAg8CAAICBQITAgUCAwIAAgIDAhUCBQIDBAICCQQAAgkCAAIRAhUEAAICAAIJCAIDAg0CAgIDBg8CAAQHAgIPAgcCAg0CBAQFBAMCBQIAAgMCEQICAAIFAgIRBAACAAIECQIPAgMCBQIDAgACAgICBwIAAgMEBwIJAgACBQIDAgIRBAMEDwIZAgQJAgIAAgIEAwIAAgMEAwIABAcCDwIDBAcCEwIDAgQCBgIAAgQGAAICAAQDBAkCBQICAwQAAgQCAgMCAgcCCwYCAAQAAgIEBwICAgQCAAIFAgcEAgMCAwQJAgACAgAEAgIAAgIFAgMCDQIFAgMCBQQFBAIDBgAEBgsEBwIDAgICAAICAgAEAwICAgICBQQLAgIFBAMCCwICAAIDAgYCBQQAAgMEBQICAgACAgMCAgMIBAMCBAAEAwQABAMCAwIABAIHAgACAgACAAIFAgsCAwQDAgIEBAQHAgIAAgACAwICAAIFAgUCAg0CAAYAAgQCBQICAAICAAICAAIDAgIEAAICBQIABAACAgIEAgACAgQCBwICAwIAAgAEBQIAAgcCBwICAgAEBQICAgICAwYCAAICAhUCAAICAAIFAgIDAgACAgICAAIABAUEAAIAAgMCBAICAAICAgUCBwIAAgACBQIAAgACBQIDAgQABAACBQIDAgIAAgACBwIEAAICBwICAAQCAAINAgMCAgIEAgACAgICBAIFAgIAAgIAAgACBAUCAAIDBAQFAgQCBQIAAgAEAAICAg0CAgAGAgICAwIDAgACAAICBwINAgAEBAMEAAIABAkEAAIAAgACAgIAAgMEBQICAAIHBAAEDQICAwQCBAcCAAICAgACAAIEAgIEAAIAAgACAgACAAQDAgAEAgMCAAIDAgIABAMCAgQABAQAAgAEAgUEAgUCBAMEDQQHAgAEBAcCAgMCAgcEBAACBwIHAgACAAIDAgQFAgACAgACAgIAAgQDAgACAAICAgACBQQAAgcGAAQFAgIFAgIAAgICAAQABAIDBAMEAAQDAgkCBwIDAgQDAgACAAIDAgQLAgIPBAIDAgACAgcCAAQFAgQDAgACAAIRAgIAAgQCBwIDAgQCAwIDAgIAAgsGAwICAAICBwICAgMCAAICBhECAgMCAgIGAgIFAgIAAgICAgACBgQEBQYDBAsCBAICAgIDAgIFAgQGAgIGBQIEAgIEAgIFBAcEAgIEAAYKAAICAAIAAgICAAIAAgACBAQABAACAgIEAgQCAgIHBAIAAgMEBAAEBgIAAgIAAgAGAAQAAgIAAgMEAwIDAgQCAgMCAAYAAgIDBAICAAIEAgQDAgACAgMEAAIFAgMCCAIAAgQDAgACAAQCBQIAAgMCAgQKAAIEAwICAgMCBwIEAgcCAgIFAgcCAgICAgQHBAIFAgMCDwIDAgAGCQIAAgIFAgsCAhUCAwICAAIDAgIHAgACCwIAAgICBwIFAgACAwIDAhUCBQIAAgMCHQIDAhMCAgUCAkECDwIfAiUCGQIFAkUCQwIbAhMCAAInAo0BAkECswICGwINApMBAnUCgwECNQILAh8CcwKfDQK1DQI="
+        },
+        {
+          "operation": "directory_update",
+          "requests": 14,
+          "errors": 0,
+          "latency_ms_p50": 9.455,
+          "latency_ms_p90": 14.527,
+          "latency_ms_p99": 15.695,
+          "hdr_v2_base64": "HISTEwAAACcAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPExAtEBApkFAqUFArMBAkUCrwIClwECTQL/AgInAqEBArcDAqECAg=="
+        },
+        {
+          "operation": "ehr_create",
+          "requests": 14,
+          "errors": 0,
+          "latency_ms_p50": 4.531,
+          "latency_ms_p90": 10.607,
+          "latency_ms_p99": 12.487,
+          "hdr_v2_base64": "HISTEwAAACcAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPEjAosFAv8CApkBAscDAmcCAwKtAQLNAgKPCQKdAQIdAq0EAtMDAg=="
+        },
+        {
+          "operation": "ehr_read",
+          "requests": 105,
+          "errors": 0,
+          "latency_ms_p50": 5.339,
+          "latency_ms_p90": 12.295,
+          "latency_ms_p99": 13.815,
+          "hdr_v2_base64": "HISTEwAAANYAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAKEfAmMCAAKBAQLJAQItAhcCCwILAksCgwICSwI/Ai8CJwJjAgMCBwIJAl0CqwECEwJBAl0CDQJPAicCHwJZAgkEBwItAjUCXQIAAkcCFwIXAgsCcwIjAgkCAwIZBAACCQIjAlkCHwIHAh0CKQJDAhsCCQI9AicCHwI5Ag0CCwITAjECEwJtAh8CNQJdAksCXwJXAikC2wECAAIXAg0CFQIrAikCBwJnAvMBAisCAAInAmECEwIlAqEBAiMCWwIDAjsCCQIXAgACBwI9Ah0CcQIPAl8CXwI="
+        },
+        {
+          "operation": "ehr_status_read",
+          "requests": 30,
+          "errors": 0,
+          "latency_ms_p50": 6.703,
+          "latency_ms_p90": 12.183,
+          "latency_ms_p99": 15.975,
+          "hdr_v2_base64": "HISTEwAAAEwAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAIsgAhcCZQKVAQLPBQLTAQL9AQIjAgAC8wQCmQICFQLrAQLDBAI9ArMBAg0ChwQCfwIVAl0C3wICPQLnAQIfAjsCFQLLAgKbAwLFAQI="
+        },
+        {
+          "operation": "ehr_status_update",
+          "requests": 27,
+          "errors": 0,
+          "latency_ms_p50": 8.887,
+          "latency_ms_p90": 17.231,
+          "latency_ms_p99": 21.407,
+          "hdr_v2_base64": "HISTEwAAAEcAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAKMsAvsFArMCAtkBAocBAh8CDwKNAQKPAQKVBAJLApMBApcBAgINApcCAmECvQECpQECrwECQwI3Av0BApMBAvsDAlMCsQMC"
+        },
+        {
+          "operation": "stored_query_execute",
+          "requests": 218,
+          "errors": 0,
+          "latency_ms_p50": 13.775,
+          "latency_ms_p90": 20.895,
+          "latency_ms_p99": 35.103,
+          "hdr_v2_base64": "HISTEwAAAYkAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAALc8AuEBAiMCBwJbAhECQQJRAhMCCwIAAhsCBwIDAiECLQINAgAEDQIDAg8CCwInAhsCCwILAgICAAQrAgcCGQIDAgACEQIDAgMCDQIdAgcCAwQFAg8CBQIDAgMCDwIHAg0CFwIFAgcCAAICCwIHAgACAg0CBAUCAgMCFwIDAhUCAAINAgIAAicEFwIJAgcCPQIHAhkCCwIAAgMCAAIVAgACAgIVAgUCCwIFAgACBQIFBDkCBQICDwIHAgsCAwILBAcCCQInAgMCDQIAAgIbAgMCGQITAicCCQInAgkCAwIHAiECBwIAAgACCQILAksCCwIAAgsCCQQXAgACBQQVBCECAwINAgcCCQQDAgACAAILAhkCAgkCAhEEBQICCQIJAikCBwIFBCUCBQIDAgACEQIDAgMCBQQjAgACBQIJAikCAAIAAg0CEwQXAgkCAgIbAgQHAgMCKQIRBCcCEQILAgIAAikCJwLLAQIhAosBAhcCjQECGQK5AQLFAgLnAQIdAiECOwI/At0DAg=="
+        },
+        {
+          "operation": "tags_put",
+          "requests": 37,
+          "errors": 0,
+          "latency_ms_p50": 5.043,
+          "latency_ms_p90": 12.567,
+          "latency_ms_p99": 23.023,
+          "hdr_v2_base64": "HISTEwAAAF4AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAIMkAtUBAo0BAs8BAiUCYwKXAQLPAQIJAk0C1QECKwJXAh0ClwECkwECTwIbAiECNQLBAQIRArMBAl0ClQICuQMCCwIDApMBAvEBAicCTwLLAQKHBQKDBAKrBALBBQI="
+        },
+        {
+          "operation": "tags_read",
+          "requests": 36,
+          "errors": 0,
+          "latency_ms_p50": 5.907,
+          "latency_ms_p90": 11.327,
+          "latency_ms_p99": 18.063,
+          "hdr_v2_base64": "HISTEwAAAFcAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAOUYAokGAtkBAj8EfwIJAkcCzwECvwECkQECnQQC2QMCkwICDQKhAwLfAQJNAnMCAqcCArUBAs8CApsCAl8CWwK/AQInAgK3AQIFAgMCQwIDAtUBAuEJAg=="
+        },
+        {
+          "operation": "template_get",
+          "requests": 92,
+          "errors": 0,
+          "latency_ms_p50": 18.911,
+          "latency_ms_p90": 39.391,
+          "latency_ms_p99": 74.495,
+          "hdr_v2_base64": "HISTEwAAAMkAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAK8jAgsCbwKfBwLzAQK7BQLNAwINApUCAs0BAhMC0wECFwJBAmcCEwJXAg0CNwJHArkCAjUCCQJfAgUCJQINAgcCXQJVAgsC7QECJwIbAl8C6wECKwJBAg0CGQKLAQJ1AoUBAicCvQICIQIPAhsCAwI3AgMCTQJtAikCVQJFAgkCWwINApEBBEsCGwIZAjsCAwIjAh8CBwIVAu8BAgIXAh8CEwKDAQJxAgcCPwK3AQJFAkUCQwInAhECFwJNAjECAp0BAtsBApsKAg=="
+        },
+        {
+          "operation": "template_list",
+          "requests": 91,
+          "errors": 0,
+          "latency_ms_p50": 4.123,
+          "latency_ms_p90": 8.999,
+          "latency_ms_p99": 15.407,
+          "hdr_v2_base64": "HISTEwAAALoAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPcWArEEAn8CnQICEwKrAQJbAgsCWQJ3AnkCPQIAAjMCBwICSQJFAk8CGwINAh8CkwECKwI9AgsCYwIfAh8CBQQDAicCEwIxAg0CQwIDBCkCJwInAgcCJwIhAosCAgsCTwKBAQIVApUBAgMCFQIjAgACAh0CQQI7Ah0CAwI/Ag0CAwIdAkcCMQKDAQI1AjkCFwIDAmcCOwIHAgcC2wMCNwJnAnkCNQIRAjEEVwKzAQJvBOMDAv0BAqMDAg=="
+        },
+        {
+          "operation": "ward_query",
+          "requests": 218,
+          "errors": 0,
+          "latency_ms_p50": 127.359,
+          "latency_ms_p90": 177.279,
+          "latency_ms_p99": 227.711,
+          "hdr_v2_base64": "HISTEwAAAVkAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAMF3AiECHQJjAksCLwQDAh0CAwIPAg0CBQICAAIZAgACAwIdAgQCAAIVBAILAgcCCwIDAgIAAgIABAQCAgACAgUCAwILAgIJBAIDAgUEAwICAgICAhUCAgUCBAUEAAQCAAIAAgMEAwICAgICAAIFAgMCCwILAgIFBAACAgcEBQIFAhcCEQICAwICDwIAAgMCBwQZAgMCAgsEAAIDBAkECQIFAgsCBwIAAgACAwIJAi0CAgkCBQIDAhECCwIHAgIPAgILAgcCAgIAAgAEBQIFAgUCCwICDQIXBAMCAAICGQIFAgACDwIAAgACAgMCBQIPAgcCCQIAAgkCAgMCAgICAgsCAAILAgMCAAICBBUCAwIbAiMCAgIDAgcCFQIAAgACFwIPBBEEAwILBAIXAh8CEwITAikCDQINAhMCAkcCqwECHwIXAgITAhkCiwECIQITAk8CAp0BAosIAg=="
+        }
+      ],
+      "stable": true,
+      "generator_bound": false,
+      "resources": {
+        "sample_interval_s": 10,
+        "containers": [
+          {
+            "role": "sut",
+            "name": "ehrbase-rs-ehrbase-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 10.125806544815173,
+                "rss_bytes": 289746944,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4346427765,
+                "net_tx_bytes": 7920560010
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 9.598352114316484,
+                "rss_bytes": 289869824,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4362337261,
+                "net_tx_bytes": 7925558755
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 8.043645802846102,
+                "rss_bytes": 289632256,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4371080007,
+                "net_tx_bytes": 7929719477
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 8.49162416246142,
+                "rss_bytes": 290570240,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4384225190,
+                "net_tx_bytes": 7934546628
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 8.79655482567252,
+                "rss_bytes": 290275328,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4396124343,
+                "net_tx_bytes": 7938863480
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 9.118657686779596,
+                "rss_bytes": 290713600,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4407165705,
+                "net_tx_bytes": 7943230253
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 9.408422871207097,
+                "rss_bytes": 292323328,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4424986986,
+                "net_tx_bytes": 7948176092
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 8.768167615764032,
+                "rss_bytes": 292696064,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4436340516,
+                "net_tx_bytes": 7952467896
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 8.350043539182494,
+                "rss_bytes": 292429824,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4449772398,
+                "net_tx_bytes": 7956968349
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 8.189951136790134,
+                "rss_bytes": 293302272,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4463499299,
+                "net_tx_bytes": 7961168610
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 8.873712614427694,
+                "rss_bytes": 278614016,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4472832404,
+                "net_tx_bytes": 7966029959
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 8.944869381723892,
+                "rss_bytes": 290181120,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4486215921,
+                "net_tx_bytes": 7970381385
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 11.833869168004519,
+                "rss_bytes": 290209792,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4497424922,
+                "net_tx_bytes": 7975115707
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 8.627961758333042,
+                "rss_bytes": 291659776,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4510116620,
+                "net_tx_bytes": 7979580578
+              },
+              {
+                "offset_s": 150,
+                "phase": "drain",
+                "cpu_pct": 8.373096682061147,
+                "rss_bytes": 291913728,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4516937273,
+                "net_tx_bytes": 7984350981
+              }
+            ]
+          },
+          {
+            "role": "db",
+            "name": "ehrbase-rs-ehrbase-postgres-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 45.32533556638608,
+                "rss_bytes": 2421559296,
+                "blk_read_bytes": 3805593600,
+                "blk_write_bytes": 46123757568,
+                "net_rx_bytes": 7244178081,
+                "net_tx_bytes": 1170530279
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 45.0238686146445,
+                "rss_bytes": 2423607296,
+                "blk_read_bytes": 3834732544,
+                "blk_write_bytes": 46151618560,
+                "net_rx_bytes": 7248291105,
+                "net_tx_bytes": 1185098390
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 38.63088572138424,
+                "rss_bytes": 2425233408,
+                "blk_read_bytes": 3863199744,
+                "blk_write_bytes": 46179258368,
+                "net_rx_bytes": 7251784841,
+                "net_tx_bytes": 1192726659
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 35.47796334172103,
+                "rss_bytes": 2429218816,
+                "blk_read_bytes": 3894525952,
+                "blk_write_bytes": 46203056128,
+                "net_rx_bytes": 7255599457,
+                "net_tx_bytes": 1204693848
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 38.57820987861978,
+                "rss_bytes": 2427031552,
+                "blk_read_bytes": 3927465984,
+                "blk_write_bytes": 46232006656,
+                "net_rx_bytes": 7259050079,
+                "net_tx_bytes": 1215527262
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 39.3839891977494,
+                "rss_bytes": 2429579264,
+                "blk_read_bytes": 3940257792,
+                "blk_write_bytes": 46256869376,
+                "net_rx_bytes": 7262572601,
+                "net_tx_bytes": 1225402370
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 38.54934883517328,
+                "rss_bytes": 2430058496,
+                "blk_read_bytes": 3953074176,
+                "blk_write_bytes": 46279741440,
+                "net_rx_bytes": 7266610774,
+                "net_tx_bytes": 1241888164
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 41.31656473041221,
+                "rss_bytes": 2430173184,
+                "blk_read_bytes": 3987603456,
+                "blk_write_bytes": 46306234368,
+                "net_rx_bytes": 7270056083,
+                "net_tx_bytes": 1252142626
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 37.114994026715046,
+                "rss_bytes": 2430779392,
+                "blk_read_bytes": 4025102336,
+                "blk_write_bytes": 46329761792,
+                "net_rx_bytes": 7273695166,
+                "net_tx_bytes": 1264423531
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 38.12330615962461,
+                "rss_bytes": 2434113536,
+                "blk_read_bytes": 4063211520,
+                "blk_write_bytes": 46355296256,
+                "net_rx_bytes": 7277071603,
+                "net_tx_bytes": 1277101811
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 39.639518679328916,
+                "rss_bytes": 2431832064,
+                "blk_read_bytes": 4102348800,
+                "blk_write_bytes": 46387974144,
+                "net_rx_bytes": 7281097736,
+                "net_tx_bytes": 1285071574
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 41.03153775347474,
+                "rss_bytes": 2434035712,
+                "blk_read_bytes": 4128460800,
+                "blk_write_bytes": 46407913472,
+                "net_rx_bytes": 7284579899,
+                "net_tx_bytes": 1297379063
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 54.22172063717675,
+                "rss_bytes": 2437230592,
+                "blk_read_bytes": 4156243968,
+                "blk_write_bytes": 46431981568,
+                "net_rx_bytes": 7288473740,
+                "net_tx_bytes": 1307266698
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 40.12286843863731,
+                "rss_bytes": 2436845568,
+                "blk_read_bytes": 4183265280,
+                "blk_write_bytes": 46468169728,
+                "net_rx_bytes": 7292100544,
+                "net_tx_bytes": 1318794112
+              },
+              {
+                "offset_s": 150,
+                "phase": "drain",
+                "cpu_pct": 38.409087707739324,
+                "rss_bytes": 2439368704,
+                "blk_read_bytes": 4212236288,
+                "blk_write_bytes": 46501658624,
+                "net_rx_bytes": 7296071657,
+                "net_tx_bytes": 1324277838
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "rate": 128.0,
+      "offered_load_sustained": 129.29166666666666,
+      "operations": [
+        {
+          "operation": "adhoc_query",
+          "requests": 2034,
+          "errors": 0,
+          "latency_ms_p50": 9.319,
+          "latency_ms_p90": 14.383,
+          "latency_ms_p99": 35.391,
+          "hdr_v2_base64": "HISTEwAABlUAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPkwAnECNQILAhcCEQIJAhcCBwINAgACBQIAAgMCBwQCBQIXAgUCBwITAhMCBQICBQIAAgUCCQJFAg0CAAIHBAIAAgINAgcCDQQAAgACBwIABAkCEwIDAgIHBAIAAgIFAgUCBQICBQICAAINAgcCAAQDAgUCAAIAAg8EAgMEAgUCAwIAAgQCBQIRAgUCAgcCAAIEAAICAwIABAUCAAQDAgIFAgMCAgYCEwIAAgACBAYFBAACBQQHAgMCAgMCAwIFAgICAgAEAAQAAgMEAwIDAgIAAgMCAAIDAgMCAgACBAICAAICAgIEAgICBAICAgIAAgcCCgICBAICAAYEAgAEBAQEAAICBwIABAAEAwIGAAICAgUGAgAEBwIGBAIGBAIABAAEAAQCAAIEAgAEBQIEAgIAAgQCAgACAAICAgQEAgICAAIDBAgAAgIGAwIABgICBgIEAgAEAwIIAgQCAgICBAAIBAACAgIAAgMGAAIEBAIABgQEAAIHBAIGAgMEAAYGBQQCAgMCAAICBgQDAgAIAgMCAAIGBgQCAgQABgICBAMCBAICBggCAAIEAgMGAgIEAgICAwQABAIGBAQCCAACAgAEAAIGCAQABAIGAAgEAgQAAgMEAgYGBAACAAQEAwgEBAICAgQCBAgDBAgCBgIDBAYIAAIEBAIDAgICBAQCBgIEBAACAAQJBgICAwYEBAQCBgYCBgACAAYKBAYIAAICBAIEAAQDAgQMAgACBAQCAAICBQQCAggGBAQCAAICAgICBgoCAAYCBAYEBgoIDgYEAgIEBgIGCAAGAgIIBAICCAIEFAgCABIECgQCAAQABAoADAYCAggCCgAEBggGAgQECAQICAIIBAgGDAoEDgQEBggOAgwEBAYGBgQMDAgCBAQGBgQEBAIEDAQGBggEBgYEAAIGBAQEAgQECgYCBAQGBAYECgYCAAQDBggCAwgEAAoIBgYGBAQIBgAEAgoEBAgAAgoKBgQEBgYGAgQGCggCBgQGBgQIBAgCDAgCBAIOBAIEAAYEBgYECgACBAIGBgAEBgYGBAYGCAYCBgICAAgGCAgGCAIEAAQMBAQEBggCAAQEBAYOAAQCBggGCAIDBAICBgQEBAQEBAIGCAQCBAgCAgQGAgQKAgQCAAIGBAQKBgIIBAUCBAICAgQCAgAEAgQEBAQAAgQIBAACAAICAAYDBgAEBAQEBAIABAQEBgQACAQEBAQEBgIABAwABAUCBgIGBAIAAgIAAgQGBAQCAwIACAYABAUCBAYKBAAEDgAEAgMCBQIGBAQCBgIAAgQCBwYEBgYCBAIDAgIAAgICAgQABgAEAAIEAgAEAgICAgQDBgQGAgMCAgQGAAIAAgIGBAMCBAUCBAIAAgICAgICAAIAAgYCAgIABAIAAgICBAACBAAEAAgEAgIDBAgABAAGAAQEAgIGAwgEAgIAAgMCAgAEAAQEAAIABAIABgYAAgMGAwIACAQAAgICAAQFAgACAwIEAAICAAIFBgIAAgIABAACAgIDAgICAAIDBAICAgUCAgICAgAEAgICAgICAgICCwIDAgMCAwQHAgACAwQEBgQAAgIAAgIEAgACAAIDAgYCAgIDBAQAAgICCQIABAICAgIAAgACBAMCAgICAwIDAgcEBAIAAgkCBgMCAAICAAICBAMEAAILAgIAAgIPAgAEAgQLAgICAwIDBAQAAgICBwIJBgIAAgcCDwIAAgcCBAMCAwIAAgICAgIHAgIFAgACAwIJBAMCAwQCBQIFAgIAAgIAAhECAwIABgIHAgcCAwIFAgIDAgACAgIAAgcCBwIDAgsCBQIFAgIJAgIDAhcCAwIFAgACAwINAgQHAgsEAAIJAh8CCQQDAgACBwIFAgACAgIAAgkCDQIDAgUCAgACAwIFAgcEAgMCBAIJAgIDAgIHAgcCAwICCQQAAg0EAgsCAgMCBQIFAgMCFQIDAgACBwQDAhECCQIAAgICAhMCBwIPAhkCBwIDAgIDAgIjAgMCHwIJAiUCBwITAhECAhECAwIFAicCAwIhAhkCNwIvAhcCNwIVAh0CLwIAAgsCVQIDAmMCVQKVAQJFAlkCpwICMQJVAhUCLwICkwECBQJ3AnsCMQLFAQLxAwJHArcBAgKFAgLHAQLjAQL7AQK9AgLLAwKjAQKjBAL9BgI="
+        },
+        {
+          "operation": "composition_commit",
+          "requests": 629,
+          "errors": 0,
+          "latency_ms_p50": 14.463,
+          "latency_ms_p90": 32.959,
+          "latency_ms_p99": 56.639,
+          "hdr_v2_base64": "HISTEwAAA/kAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAM0sApUCAuUBApcBAr8BAgACKQKlAgLjAQIpAgsCSwIRAgACFwIXAgIfAgINAgACAwIFAg8CAwIfAgsCFQILAgkCHQIbAgcCCwIbAiUCBwICDwIDAgUCAgcCBwIfAgMCFQIXAhUCEQINAgMCEQInBAkCAhUCBQI/AgMCAwICDQIRAgACGQQfAgIAAgACAwICBQQCGwYHAgQHAhUCBQILAgACAAIDAgMCAAIDAgIFAgICFQICCQIEBwQJAgsCAwIRAgACAAIFBgICBwIFBAUCAwQAAgQCCQICBwIVBAkCDQQDBAACCQIJAgMCGwIAAgICAgkCAAQAAgIDAgsCAAIDAgACFQICAAIDAgcCBwIFAgMCAgMEBQICBAIPAgQCAAQDBAIABAMEBQINAgIpAgACAgkCGQIJAgMEEQIHAgIRAgIDAgIDAg8EAAIAAgACCQIRAgACBAMCBwIJBAQEAwIEAwIFAgACFQIAAgIFAgQAAgcCAwQHBAsCAgACDQIDAgIAAgIDAgMECQILAgIABAIDAgMEAAQCCQIFAgACAhEEBQIAAhMCAAICAgAEEQIDAgIHAgACBAQCAwIAAgMCAgUCAgIPAgACAAIFAgIDAg8CEwICAAYVAgMCAgUCEQICAAIDAgACAwIFAgIHAgIHAgUEEwIZAgcCHQIFAg0CAgMEEQIVAgUCAhEECwIDAg8EAiUCAgMCAAICCQICAg0CAwIDAgITAgUCCQINAhcCAgcCDQIAAgQHAgACCwQABAICAwICAAIAAgICAgsECQIDAgACAgMCAg0CAwICAgIAAgIDAgICAAIAAgIAAgcEBwINAgACCQIAAgcCBAAEBwICAgUCAgICAAIFAgIAAgsCAwICAAICAgUCBwIHAgAEBQIDAgACAwIXAgACDwIXAgACAgIHAgACDQIFAgMEEQIFAgACAwICAwIIAAIDAgkCAAIbAg8CBwIAAgcCBwINAgACFQIDAgUEDQICAAIDAgIpAgIJAgIFAhUCCwIDAgIHAgACAwICAwIEAgUCAgIHAjkCBwIFAgACAh8CBwIbAgUCAAIRAgMCLQIAAgICEQIbAg8CCwICFQIDAgkCFwIHAgcCBQICAAIAAgMCBQQVAgcCSwILAgcCAgcCBQI3AgkCTQIFAgACDwIHAicCGwIJAg8CDwIRAlcCBwIAAgcCCwJHAgICCwIRAgACAwIDAgMCAAICBQILAgsCEwIPAg0CAgACBQIFAg0CHwICJQIRAgcCDwIAAh0CIwIFAgMCLQIHAgUCBQIDAgUCGwILAgIfAhMCBQItAgIDAj0CAAIJAg0CGQJnAiECQwIfAhcCpwMCcQIDAt0BAp0CApkCAsEGAg=="
+        },
+        {
+          "operation": "composition_read",
+          "requests": 4068,
+          "errors": 0,
+          "latency_ms_p50": 4.411,
+          "latency_ms_p90": 8.087,
+          "latency_ms_p99": 18.111,
+          "hdr_v2_base64": "HISTEwAACWAAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPcbArkBAh0CMwIFAgI5AgcCCwIjAhcCCwIpAgIFAg8CCQIAAg0CBQIAAg0CBQICCQIAAgINAgkCAwICAwIAAgcCDQIFAggABAMCCQIDAgACAgkCAAIAAgIFAgIHAhEEAAIDAgACAgIDAgACAwICAgIDAgYFBAICAAICBgICBwICAwICAgUEAgACAgcEAgICBAIDAgMGBAMCAAICAAICAAICBAINAggABAAEBgICAgACBAIDBAQEAwIDAgICAwICBAIAAgAEAgIABAICAAgABAUCAAQCBgAGBAMCAgIAAgACAgQCAAIEBgIABAIEAAIEBAAEAAICAwIEAwIABAYAAgICAwIDBAQIAAIGAAIEAAgEBAIEAAICBAACCAYCBAQAAgQAAgMEBgICAwICAgQCAgQAAgACBAAEBAQCAgIGBAIABAQAAgICAgAEBgACCAQDBgACAgICAgACAgACBAIABgIEBgAIAgQEAwIAAgIICAICBAICBAYCAgIEAgIGAAQEAgQABAAEAgIEAAYECAAEAAIEBAIEBgICAAICAgIGBAQCBAAMAggECAQABAQCAggABAICBAAEBAAECAIEAggEAgQCBgAEBQQCAAQEBAYGAgQGBgICBAIEBgQCBAMECgIABgYGBggGBAACBAIGBAIGCAQGAgICCAAGBAIACAIGBAICAAQIAgYCBAAEAgQCAAgGAAIGBgYEAgQKAAQAAgIGBAQCBAgEAgQCAgYGAgICCAYGBgYIAgQIAgoABgYGCAYIAAYEBgYEBgQEAgYECgIGCAYEAgQAAgIEBAYIBAQCAggECgoGCAwCCAYCDgACBgQGDgIEAAQIAAoGBAQCCAYCBAICBgIIBAIHCAQEBAIECgQCCAoMBAoEAAQGBAQEBgwODAQEAgYCBAICBAQCBAoEAgYECgQGAAYIAgQCBAQDBAYCBAAGCgIECAQGAAQCBAQABgYAAggCDAQGCgQODAgGBgQGBAQEAgQKBgQIAggGAgYCBAACBAYEBggCBAYGAgYEBAIMBAAEBAIEDgoCBgQEBAAGBgIGCAQCAggCBAIEBgQCBAICAgQCBgoGDAQECAACBgQIBgQKBAQIAAICBAIIAAYABgoECAYIBgYADAIGCAQCBAQABAoCAggEAgYEBgMEAAgCBgQEAgICCgYCBgYECgYKBAQABgoIBggKAg4GCAwCCAACAgQEAgQIAggIBAgECAIGBgQGBAICBggAAggGBggIBAQCAgICBggOAhAMBA4QBAgUBgwKBAIMCA4MDgYKBgwOCAYKDg4MCAwECAwKBggKCAYKBAoGBgwIDBIICA4ODA4ICAYGBg4MEggMDA4KDggMBg4SDgIKCAoGFAoEBhQGFAIMBAYEDAoODg4GBAYOCAoCCgoIDhIGCA4ECAgIBgYMCAoGBAoIDgIECA4IBgYGDAwGCAgIBgQIDAoGBAQKChQOBgICBg4EDAoGCAoGCAYGCAgMBAAGCAQGCggIBgYOCgIMAAQMCAwMBgQKCAYGCAoIBgwCDAYGBgIICggEBAQMAAgIBAgIDAYMCAoIDgQEBAACBgIEBg4GCAYCBgQKCgwEBgICBAgIBAQGBAgECAQIEAAEBggGCAYCBgICAgICCAgACgQECAQACAIMCAQEBAQGAAQKBAwGAgQICgYCDAYABgwGAggGBAwEBgIGBAAMAAgIAgAGAgIGAAYEBAYIAAIEAggAAgIEAAQCAgICBgQEAgQICAIGBgIEBAYCAgQGBAQCCAAEAgYEAgIEBAYKBAYEBAIGAgQCBAAMAAYGAAIEBAQCAAIEBAICBAQCCgIABAIEAgICBAQAAgIDBAQGBAQAAgAEBAACBgIEAAYCAgQGAwQCAgQDAgMCAgYDCAAIAgYGAgQCAggCBAgDBAQEAgQCBAQGAgQGAwQDCgACCAMCAgICAgMCAgQGAgQCAAIEAgIKAgICAgACAgIFAgQAAgMCBAQAAgMCAgQEBAUCAgMCAAQCAAQEBgACAAQEAgQCBgICBAYCCgICBAACBAYEAgIAAgQCCAIEAAQABAIIBAICBAIABAIAAgICAAICAgAEAwIFAgMCBQIGAAQCBAQCBgYCBAQEAgQCBQQCAwIIAgACBAQABAIABAUGAgIGAgQAAgAEBAYAAgIAAgAEAAYEBwQCAAIABAkCAAICAwIABAIAAgAGBAIAAgQAAgQABAQCAwIABAQIAgACBAQAAgAEAgICAwIDAgkCBwICAwICAgUCBAMCAwIDAgQAAgMCAAQEBAMCBgIGAAYCAgICAAICBggAAgIEAgICAgICAwIJAgIDBgMCAgAEBQIABAAEAAgGAAIDBAACAgMCBQQABAYCAAIABAIFBAQCAgYAAgICBQYABgIFAgACBQQDAgMGBAICAgQAAgQCAAQCAgQDBAICAwIEBQICAgACAgIDAgAGAgQEAAIFAgQCAhUCAwIAAgMCAAIAAgMCBAACAwICAgAEBAIABAIAAgUCAgQCAwIABgICAgQGBgQAAgICBgYCBQYHAgIAAgQCAgIEAgMEBAQEAgUEBwYCBwICBAICAgIDBAACAwIAAgACAgQEAwICAAIGBAICAwICBAQRAgACAwQABAACAwQCAgMEAAQEBAcCAAICAgIDAgICAgIABAYFBAIAAgIFBgsCBAMCAgQAAgACAAIEBQIDAgIHAgIEAAILAgACBwYAAgIABAMCAgICAgUCAAICCwIDAgcEAwIABAQAAgcCAgIDCgUCBQIAAgICBAACAgsCAgIDAgIEAAIAAgcCAgIFBAMCAAIECwIABgcCAgUCAwIFAgIAAgIABAMCAgICDwIPAgMCAwICAwIDAgICAgACDwIHAhMCBwIFAhcCAhUEFQIAAgMCDwIHAgACHQITAgsCAAIDAgUCBQIPBAACBQIHAg8CCQIRAgkCEQICCwIHAgIDAjMCDwIPAgMEAgIDAgACAwIAAhkCBwIHAgUCBQIVAhMCBwIFAgMCDQIFAg0CDQQZAg0CIwICHQINAgILAgUCCwITBAMCLQIDAgIJAgsCCQIAAicEIwIPAgkCCwJHAgIJAgsCBwIJAjUCbQIRAgIAAgkCBQILAgMCIQIFAgcCBwItAg0CfwIFAgIFAkECCwJHAoMBAoUBAjMCQwI7AjMC6QECAwJzAgcCgQEC+QECzwMCiQECwQICnwECXQKRAQKTAgJRAo0HArMDAg=="
+        },
+        {
+          "operation": "composition_read_current",
+          "requests": 2287,
+          "errors": 0,
+          "latency_ms_p50": 5.727,
+          "latency_ms_p90": 9.743,
+          "latency_ms_p99": 20.287,
+          "hdr_v2_base64": "HISTEwAABxoAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAANshAgAC1wICFwJfAhcCEwITAicCFQIFBA0CFQIAAg0CGwIbAhUCAhECAwIVAgACDQIDAg8CCQYPAhECBQIGEQIDAgUCFwQDAgICAgICCwINAgMCAAIDAgACAgcCFQIPAgcCAAINAgAEBQIEEQQDAgMCAgICAwICBQIDAgIJAgMCBwQAAgILAgMCBQIDAgUCAgILAgQCAgAEAAIEDQIFAgkCAgIAAgACAgMCAgMCBwIEAgcCAwIAAgACAgACAwIDAgUECQQEAAILAgQJAgACAwILAgICAgIEAAIDBA0EAwIDAgMCAwICAgIEBwIAAgACAgUEAwICAgUCAgACAAIHAgMCAgMCAAICCwIABgQEAgQDAgACAgAIAAIAAgICBAIABAACAAIAAgIAAgUCAgACAgACBAMCBAICAAICAgAEAwICAgcCAgAIAgACAAIEBAAEBgIACgQGAAICBAIACAYCAAQCAgQAAgAEAgAIBAIABAgCAgQCAAQACgIEAgQIAgIKBAQGBAIKBAgCAAQABAYDAgIAAgIKAggIAAQIBAQCAAQIAAQEAgQGBAQEBgQCAgoEBgAICgIKBAoCBAQGBAQAAgQCAAYGCAAEBgICCgACAgYKBgYCAgAKCAQGCAQCAAgCCAYACgACAAIGBgIKBgACAAQCBAYGAgIGBAQABgYGAAQEAggCBAICBAQEAgYCBAgCBgQCBgYGAggGBAIIBgQAAgQGBgIICAYOAAIKBAAICgAGCAMOBAQGBAoABAQEBgQABgIGBAYCCgAEBAYCBgIGCAYEBAQGBgoIBAYKCgIICgYGAgYEAAYICAYECAgIAgICBAAEDgQQCAAEAgQGCAQIAAwGAgoEBggCDgQKBggCDAICBgICAgIEAgQCBgQEBAgECAIGAg4GCAQICAYEAggGAgIKAA4ABAYGBAgCBggCAgYKBAwABAQCAgIAAgACAgQGBgQGAggKAgQDCgIGCAYEDAAEBAAGDAYECAAGAAgCBAIABAQEDAQCAAQEAgoCBgAEBgAIAgYGBAYEBgYABAYGBgYEAwQEAgQEAgACBgYIAgoKAAQIBAIEBAgEBgYGBgICBgIIAgQAAgYCAAIECAgEDgQABAAKAgYIBAYCAwgEAgYCAAYCBgICAgAEBAQGBAgABAYEAgIECAgCBgYCAgIEBAgCAAIACAQCAAgEAAYABgIEBgYABAQCAgACAAIEBAQCBQIABAAEBAQABgQCAgAGBAICBAACBAYCCAAEAgIEAgACAwIABAIABgMEAgQABAACBAIFAgAGBAIEAgYCAAYCCgQABAQCAgIGAgQDAgIGAgQEAgICAwIEAwYDAgACAgICBgACBAIABAICBAIIAgUCAgQCAAQEAgICBAICAAIEBAQCBgQEBAIABAMEBAICAgQCBAQAAgICAAIAAgIEAAQCAgACAwQCAAIEAwIAAgACBAACAwQEAgQEAAQCAgACBgIEAAICAAICAAICAgIEAAIAAgIABAYAAgICAgMCAgAEAgAEAAICCAYAAgQIAgICAgAEAgAEAgAEAgIDAgACAAIAAgACBQIGAwICAAQCAAIDBAIABAACAgQCBAkIAgACAgUCBwIABAACAgUEAgACAAIJAgcEBBECAAYHAgIABAYAAgILAgACAAIEBAIEBAMCAgMCAgIDAgACAAYDAgMCAwQAAgICAgMCBAIAAgAEBwIDBgACBQQABAQAAggCAwQGAgACAwICBAAEBAACBAIGAgACAgMCAggDBAAEBAMCAgYABgIAAgQDBAIFAgACBAAKAgICBAIDAgUCAwQCAAICAgAGAgMCAgIAAgIAAgIDAgQAAggFBgMCAAIAAgIABAIDAgICBQICBwICAgYHAgYCAAIABAICAgQDAgACAwIHBAQNAgIAAgICAAIAAgQCAAQAAgAGAgIJBAICBQIABAAEBAQLAgACAAILAgIAAgMCAAIFAgcCAAIAAgMCAAIAAgMCCQQDAgsCAgMEAgACAgACAAIJBAIHAgICAwINAgUCAwIAAgMCAAIAAgACAwIDBA0CBQICAwIRAgkCDwIEAgIABAkCAAIFAgIDBAQAAgIJAgMCAAIDAgIHAgIbAg0CAAIABgICGQIFAgIDAgACAwILAgIAAgIRAgUCBQIHAgACAwIFAgACFQQABAUCEwIHAg8CAgUCAgACBQICAgcEBQQNAgMCAAIAAgsCCQQnAgkCBQIPAgILAhsCAAICAwIPAgIFAhMCEwIRAgACAAINAgMCDwINAgkCEQIFAkcCAAIHAhkCAwIFAg0CAikCCQIFAjUEAwINAgMCCQIVAi8CBQI7Ai0CFwIdAhkCIwIHBCECbwI1AikCHwIXAgcCFQIZAgACQQJVAkECEQINAh8CNQJnAg0C3QQCIQLPAQKHBAIrAp0FAukDAq0BApkEArMGAg=="
+        },
+        {
+          "operation": "composition_revision_history",
+          "requests": 2196,
+          "errors": 0,
+          "latency_ms_p50": 5.919,
+          "latency_ms_p90": 10.495,
+          "latency_ms_p99": 15.615,
+          "hdr_v2_base64": "HISTEwAACH4AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAANcQAt0BAp0DAicCQQJBApsBAoUBAhECGQLFAQJlAgUCAAICCQIHAhECCwIbAgcCAwIdAjsEIwICFwINBAcCCwIAAgkCCQIfAg0CBQIPAgILAgUCCwInAgIDBgIEAgMCCQIRAgMCAwIJAgMCAgMCAgkEAgIjAgMCAAYJBAkCAAIFBAUCAgcEAgIAAgIDBAMCCQICAAQCBAcEBwICAgIFAgACAgYAAgILAgACEQILAgACAAQNAg0CAwINAgACHwINAgIEAgMCBAcCAwIRAgcCBQQLBgACBQIHAgICAwIFAgIDAgAEBwIABAACBAcEBwIAAgILAgACAgACAAICAgUCBQICBQQDBAMCAwIAAgIEAAICAAICCQICAwIAAgIAAgACBwIDAgIDAgIAAgIDAgMCCQICAAIEBgIEBQQAAgICCQIAAgACBwYHBAIAAgMCAgACAwIHAgQCAAIAAgICAAIABAIAAgIDAgQCDQIAAgMCBQIGAgACAAILAgIEAhECAg0CBAIDBAACDwIEBQICCQIEBQICBAACAgUCBAICAwICAAQCAgQABAAEAgIEBQIAAgACAAIFAgAEAAIFAgkCAwICAgMEBQQFAgQCAgUEBAQAAgYCAwIABAQHAgACAAQJAgUCAAIAAgIGAAIAAgICAAIDAgAEAAgCAwICAAIAAgACAgIEAgcCAgIAAgICAgICAgcCAAIDBAMCAAQAAgIDAgMCBQQCAgQCAAQEAAIAAgIAAgkECwYABAkCBQICAAIAAgACAgICAAIFAgMCAAIHAg8CAAICAgICAgIEAwYFAgIDAgIEAgQCAgICAwIDAgQAAgIABAIAAgIAAgAEAAIDBAACBQIAAgIACAMCAgICCQIABgMEAwIAAgIABAACAgACAgIJBAcEAAQDAgUEBwIABAACAAIABAQDBAIDBAIEAwICCQQAAgIHAgMEAwQCCQICAgICAAQCAAQACAQEAgICAgIEBAQEAAQEAAIEAgQAAgQCAgICAgACAwICBgQCBwQCAAIAAgQACAIEBgQAAgMEBAIDAgQCAAICAwICAgACAAQAAgMEBAYCAgQCAgIEAgIEBAQEAAICAAYGAAIABAQABAMEAgAEAAIDBAYEBAIABAACAAICBAICBAAGCgICBAIGAwYCAgIGAAIABAQCAgAEBgMGAwQHAgACBAUEAgYCAAQCBAACAAYEAgICBgICAgIABgAIAwIEAgQABAMEAAgEAgIAAgYEAAgJAgIAAgYCAAIAAgACAAQABAIAAgIABAQFAgYHBAAEBgYHBAAEAgACBgYEBQICAgIACAQCBgACAAIAAgIEBAICBAQAAgIIAAIEAgICAgIGBAUGBgQCAAQIAgYABAIHAgMCAgQHBAICAAYCAgQAAgQCCAQCBAIEBAYFCAICAgICBQIAAgYCCgYEAgIAAgYABAIEBAIEBgMEBAQCCAACAgIEAgQCBgQEAgQABgICAAQGAAQGAgAIAgACAAgCAgIEAAQEAAYGAwYGAwgABgYEAAQGBggGBAYCBAQCBAoCCAYEAgQABAACBAIKAgIIBgACDAQGBAQEBAYCAAQEAAQGBAgICAACAAYEBAIGBAICBAIABgAGAwICAgQGBAICAgIEBAICBgICCAACAggCCAgAAgAIBAoABgIIBQIGAAgIAgYABAIEAgAMAgIGBgQIBAICCAYCBgICAAQCAwIAAgMCCAgCAgACAgYAAgAEAgIEAgICBAQEAgIECAIAAgQEAgIDBAIGBAACAAICAwYAAgACAgwEBAAGAgQEBgACAgMCAgYGAAICAAIEBAMCBgIABAMCAwIGAAICBAAEBgAEAgQAAgIABAQCBAIAAgACAgIEBgACBAQCAggCBQQCAgIABgYAAggEAgMEAgQEAAIEAAIDBAUCAwIEAgYJAgICAgQAAgIEAAQAAgIAAgUCAwICAAQCAgMCAwQAAgcGBAIAAgACBgQAAggEAwIAAgIJAgIABAQCAgIEAgIEBAMCBAQEAgUGBAQCAwYAAgAGBAQCAAQEAAICAAICBQYCAgIDAgMEAgUCAAQABAMCAAQAAgIDAgICAAIABAACAwIFAgcCAgACAAQEAgkCAgIPAgQCAAICAgAEBAACAgACAgICAAIFAgICAAIHAgcCAAIHAgAEBAIDAgMCAAQAAgIAAgICBAACBAACAAQEAgQCDQIAAgQEAgQCBAYEBAQDAgQCCQIAAgICBAQEAgYCBAIGBwICAgQDAgUIAgIABAIABAIFAgIEBQQCBAICAAIEAgIDBAkCBAMEAAQEAAIGCgIAAgIAAgACBAIABAITAgQAAgIAAgACBQIABgICAwIABgIDAgMEAAQCAAIJBAICAAQDBAIAAgUCBAcGAg0CAwgCAAQAAgIAAgACAwICAAICAgUCAgICAgYAAgACAwIEAgACAAICAgACBQQCAgcEAgIEAgIAAgICAAIAAgACAgMCBAIDAgIAAgACAwIFAgUCAgMCAwQAAgMMBQIFAgACBQQAAgIAAgACAAIABAAGBQQDAgYCBQIAAgQDAgcCAwIDAgMCAgACAAIEAwQJAhMCAwIDCAACBQIDAgAEAAIABAIJAgUCAAICAgsCCQICAAIDAgACAgMCDQICAwIDBAIDAgACBAIAAgUCDwIABgIAAgMCAwICAgACCAMCAgIDAgIFAgACAAIEAgICAAIEBQICBQYFAgcCAgIEAAIDAhUCBQIAAgMCAwITAgIAAgIFAgIAAgMCAgUCCwQDAgUCAwIFAgMCDQILAgACBQIHBA8CAAIJAg0EEQIRAhECCQICAwILAiMCBwJRAj0CDwIAAg0CQQIFAgUCHwIbAgUCNQIdAiECDQI/AgkCgwECEQIlAoMBAlECswECJwKnAgIhAu0GAq8FAvcBAmsC"
+        },
+        {
+          "operation": "composition_update",
+          "requests": 163,
+          "errors": 0,
+          "latency_ms_p50": 11.327,
+          "latency_ms_p90": 16.799,
+          "latency_ms_p99": 29.023,
+          "hdr_v2_base64": "HISTEwAAATQAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJ8pAuMCAl8CiwICXQKNAQJNAmsCAwInAgACAwIRAgkEXQIDAgsCPwKlAQILAgcCEwJbAlECdwIAAh0CAwLbAQJdAhcCDwLJAQJ7AlMCewIVAjMCTwIjAiMCFQJrAgcCAgMCIwIFBAACBQIFAhkCMwIZAgMCAgIHAgcCBQITAgUCCQIRAhcCBwINAgIRAgMCAgICAgMCBAACGwIJAgACAwILAgUCAg0CBQIDAgACBwIbAgMCBwIHAgMCDQICBwICAgIDAiMCAwYHAhECCQI1AhkCAAINBAcCFwIrAhMCGwIvAhMCDwIfAgIXAlMCAwICJQIPAgACBwJhAgcCOQIVAhUCAwInAmUCFwIhAiECDwIFAgcCAwInAgMCAgUCAo8BAtUBAh0CKQIDAsMBAj8C5QUCkxYC"
+        },
+        {
+          "operation": "contribution_commit",
+          "requests": 61,
+          "errors": 0,
+          "latency_ms_p50": 40.287,
+          "latency_ms_p90": 50.495,
+          "latency_ms_p99": 108.479,
+          "hdr_v2_base64": "HISTEwAAAHkAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAM08AosDAocBAokCAusCAr0JAt8OApsBAocBAiECRwIPAg0CEQIXAgsEBQIFAhcCAwINAgsCAwIDAgACCwY5AjMCFQIjAgcCGwQVAgIHAhsCHQRVAgcCTQILAiECCwIDAjcCBwITAg8CAk0CAl8CkQECRwKfBwKDCAI="
+        },
+        {
+          "operation": "contribution_read",
+          "requests": 235,
+          "errors": 0,
+          "latency_ms_p50": 7.267,
+          "latency_ms_p90": 13.367,
+          "latency_ms_p99": 18.703,
+          "hdr_v2_base64": "HISTEwAAAcAAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPUaAvkDAk8CJwIHAlUCBQL3AQLFAQIvAiMCKwIhAh0CJwI7AiECFwIJAhMCCQIXAgACKwIpAgJHAgMCAwIFAhcCJwJPAgILAgcCEQIVAhkCCwIjAhUCDQJjAhECFQIHAhsCHwI7AgACUwI5Am0CDwQbAgUCQwILAgMCBQIfAg8CJQIDBB0CDwIAAgcCEwIEEwIFAgILAg8CDQIRAgACMwIvAkcCOQI/BB0COwI5AhUCKwIFAjkCAAINAhECFwIDAhECCwIAAiECKQIjAicCKQI7Ah8CDQITAgMCAwJBAgIDAgACOQJxAgcCgwECAAIfAhcCIQIZAgsCAwITAg8CFwIXAgkCCwITAhkCBQIAAgUCBQIDBAACIwIHAg0CAwQCAwIFAicCCwILAgkCAgACAg0CLwIDAhECBwICCQQNAjMCCQI9Ag8CKwIFAgIHAgUCFQIHAgcCEwIDAhsCAAIHAgMCCQIPAgkCAj8CDQIrAh0CFwIdAgUCBQIDAhcCGQICEQQLAgMCAgUCBwIPAgACBQILAgcCDwIPAhkCDwIJAgkCJQIHAg8CEwJlAgsCCwJRAgAC9wICEwJ5Ak0CRwK9BAI="
+        },
+        {
+          "operation": "directory_create",
+          "requests": 18,
+          "errors": 0,
+          "latency_ms_p50": 5.479,
+          "latency_ms_p90": 13.991,
+          "latency_ms_p99": 14.527,
+          "hdr_v2_base64": "HISTEwAAAC4AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAOcnArEHAmECiQEEiQECCwJnAp8CAsUBAkECuQEC1QICRwLlAQLBCwLdAQKDAQI="
+        },
+        {
+          "operation": "directory_read",
+          "requests": 2063,
+          "errors": 0,
+          "latency_ms_p50": 3.855,
+          "latency_ms_p90": 7.747,
+          "latency_ms_p99": 13.871,
+          "hdr_v2_base64": "HISTEwAAB9sAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAKETAgkCswIErwECKwIbAj0CEQQnAikCBwIFAiMEAwIAAjECAAITAh8CGQIRAhMCFQIRBAcCAAIzAg0CAwIDAgIHAjECAgMCDwIPAgICCwIRAgMCAwIDAgkCAwINBA0EDwIABBsCEQIJAgIJAgkCEwQCAwINAhECAgUCJQICAwQEAwICEQINAgACAgUCEwQCBQICCwICAwICAwIDBAACBwIDAgUCAAIDBAMCAgQHAgIFAgIDAgsCBQYLAgAGBwIAAgUCBwQCBwIAAgIDAgMIAgIDBAIEAAIAAgICBAICAgICAAIHAgIFAgIAAgACBQIAAgIABAIFAgIDAgMEAgIAAgACAAIHBgICBAIAAgQCAgUCAAICAgcCBAQDAgAEAggCAwgCBAACAgICBQQCAwYCAgIAAgACAAIGAgQCAgIAAgQDAgICAgYAAgkEBAIABgAIAgIAAgAGAwIAAggAAgYDBgACAAQAAgIABAICAAIACAAGAwICAAICAAICBAICAgQCAwQABAQCBAICAgIAAgIAAgQABgQAAgQCBAIDAgQCAgIEBAYCCAUCBgICBgMCAAIAAgACBgICBAQGAgUCBgACAgICBgACAgAIBAQCBAQIBQQCAgQAAgQCAgQCAwQAAgQAAgQABAIEAgICBgIEBAQCBAYAAgIDAgQCAAICAAQEAgIEAgQCBAAEAwIACAQGAAIAAgMCAAIGAgIAAgAGAgICAgQAAgICBAMGAgIABgYCBAIEBgICAAgIBAIEAgIEAggAAgQACAQAAgAEBQQCAgQCBAgCBAYDCgQEBAQEBAIACAYCAAQEBAACAgACAAICBgAEAgQFBAICAgAEAgIEAAQAAgAEBgACBAIEAAIGAAICBgMCBAQGBAYGAgQCAgQDAgQEAAICBAICAgQCCAMEBgICAwYEBAICAgYEBgAEAgICAgACBAQEAgMGAgACBgQCAgIDAgQAAgQEAgQEAgIGAAICAAYACAYABgACBAQEAgIDAgACAwICAwYCAgICAgICAgICAwgCAgQEAgIAAgICAAYCDAICBgIAAgAGAgQIAAICBAAIBAgDBAQCAgIEBAQCBAIABgMECAICBgAEAgYCAAQCBAQCAAIEAwICBAIGAgIGAgQCCgACCgIABgIHAgICBAQABAMEAgQABAMIAgICAgACBAQCBAMGAwYABAIEBAYEAAIEBgICBAAEAAIEBAIABAIAAgACAAIIAgQFBAQEAwICAgQCAgMGBwQEAwYAAgIABAAEAgIACAAEAwQDBgICBAIABAAEBAIEAgQGAgACAgAKAgIAAgACAAQGBgACAgQAAgIABAQHAgAGAgAEAgMCAwICBAIEAgAEAAoGAgQECAIGBgYCAgACBAIIAgQCAgIEBgQCAAQCBgQGAgQCAgIABAAEBgQGAAICAAQGBAICAAQABgIFAgIABAYCAgMCBgIEBAIABAwCAAQEBAYEAgICBAICBgIEAgQEAgACAgQCAgQAAggEAAQAAgAGAAICAgIEAgQEAAICAgQEBgYACgMEAAIABAICBgYAAgIGAAIAAgIICAUCAgACAAgCAAIDAgQCAgQAAgIABAICAAIABAIEBAQDBAICAAYEBAAEAAICCwICCAICAAICCAIEAAIEAgIAAgAEAgMCAgIAAgYFBAINBAQCAgICAgUCCAMCBAkEAAQAAgIEAgcCAgICAAIAAgACAwQCBgIABAACBgQFAgACAgUCAAICAAIAAgMCBwICBAICAAIFBAMCBAMCAgUEAgUCAAIFAgQCBwICBAIEAgICAAQAAgcCAAIDAgQCAgQAAgAEAAIAAgcEAgIABAICAgQDAgAEAgMCAAICAAIEBAACBQIABAcCAgUCAwQCBAIDBAACCQYDAgICAgICAAICAgICBwICAgQFAgIABAIAAgIJAgACAAICAgQAAgAEAAIDAgICAwICAgMCAAIEAAIFBAICAAICAgcCBgUGAgUCAAICBAIGAgICAAQAAgYIAAQDAgIAAgYCAwQDAgACAAIHBAcEAAQCAAIGAgIAAgIABAILAgAIAgIFBAIJBA8CAAICBwIAAgACAAIAAgQCBQIFBgcCAAICAgIJAgACAAIAAgICAAYAAgACAAICAwIAAgIAAgMEAAIVBgIEAAICAAIAAgMCAAICAwICAgAEBwICAAIDAgMEAwILAgIRAg8CAwICAwIAAgICAgIAAg0CFQIAAgMCBAACBQIDAgkECwIAAgMCAgIDBAkCAAIFBAMCBQICCQICAAIAAgICAgcCFQIPAg8EAgIAAgIfAgIHAgUCDQIFAgIHAgMCAgICCQIVAgcCBQICAAICAwICBgIABgQCAgcCAgMGAgIAAgIHAgQCAAIAAgkCAgMEAwIEAgILAgQAAgMCAAIGAwIAAgMEAAIFAgIAAgACAwIAAgcCAwIABgICAgQVAgACAAICCQQGCwICBQIAAgcCBAIFAgUEBAUCAgMCCwQCAwIABAICAAIDAgUCCwIHAgIZAg0CBQICAgACEQIAAgICAAQAAgACAwIDAhUCAgACAwIjAgcCBQQHAgACCQITAhECAhsCCQIfAjUCCwIFAhsCEQIXAmcCKQIdBAACkwECAiECBQIHAkkCCwLDAgKvAgICEQJjAg8CTQJHAksCJwLfAQIdAiMC/QICrQYCJwKLAQK1AQLBCwKbBQI="
+        },
+        {
+          "operation": "directory_update",
+          "requests": 30,
+          "errors": 0,
+          "latency_ms_p50": 9.927,
+          "latency_ms_p90": 13.983,
+          "latency_ms_p99": 46.815,
+          "hdr_v2_base64": "HISTEwAAAEcAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAMUrAo0BAr0GAgACAwIVAh8C7QkCYQIXArkBAkMClwECxQECAAIDAkcCHwIhAhsCXwJRAhMCKQIVAskDAmMCvwECzwMCrxYC"
+        },
+        {
+          "operation": "ehr_create",
+          "requests": 29,
+          "errors": 0,
+          "latency_ms_p50": 4.295,
+          "latency_ms_p90": 11.559,
+          "latency_ms_p99": 26.943,
+          "hdr_v2_base64": "HISTEwAAAEkAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJEjAqEDAisC9QECDwK1AgKdAQIPAmsCRwI1AlkCkwECAAIhAkcCkwEClQEClwEC1QECGQLvBQIC5QECmwYCMwKtAQLdCAL7CgI="
+        },
+        {
+          "operation": "ehr_read",
+          "requests": 210,
+          "errors": 0,
+          "latency_ms_p50": 4.143,
+          "latency_ms_p90": 7.291,
+          "latency_ms_p99": 13.167,
+          "hdr_v2_base64": "HISTEwAAAYUAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAO8eAgUCAwLlAQILAjMCHwITAhUCYwJZAhcCAgkCMQIPAg8CIwICQQI/Ai0CIwIZAgMCKQIZAiMCAwIAAgACAAIABA0CCwIJAiECIQIDAgMCEwICIQI5AiECCQIAAhcCAhMCAAILAgcCAAICAwICFQICBwIHBAInAgkCAgIJAgsCBwItAiMCBQIdAgMCAgAEAhkEAgMCBwIFAhkCEQICCQIbAgsCDwIRAgACEwI9AgICBwIXAgACEQIfAgsCEwIAAg8CBwIAAgACAAIJAgACAicCGQIAAg0CGwIHAgcCHQIFAgsCEQICBQITBBcCAgACKQIJAj0CCQICAhkCDwIJAhECKQIdAgUCBQIbAhMCeQIbAgUCDQILAgINAhECBQIvAgcCKQICAgUCBQIPAhMCGQIbAgMCIwINAgUCAhkCAwIJAgACFQITAgMCHQIdAkMCDwICFQIRAhUCPwJLApECAmsCQwItAncCCwICHQIHAt8CAgLlAQJjAgUCIQJvAg8CiwEC6QYC"
+        },
+        {
+          "operation": "ehr_status_read",
+          "requests": 58,
+          "errors": 0,
+          "latency_ms_p50": 5.799,
+          "latency_ms_p90": 11.663,
+          "latency_ms_p99": 22.191,
+          "hdr_v2_base64": "HISTEwAAAIAAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAOkcAskBAo0DAlUC8wECjQECLwIHAi0C2wECHQIRApMEAgLHAQJrAlUCTQJ7Ah8ECwIDAh8CcQJhAiUCOwKhAgI9AhECfQILAqcBAuUBAgcChQECKwIzAuECAjUCEQIZAicCKQIFAhECjwECzQECNQJNAh0CWwQDAl8CiwEC+QwC"
+        },
+        {
+          "operation": "ehr_status_update",
+          "requests": 54,
+          "errors": 0,
+          "latency_ms_p50": 6.671,
+          "latency_ms_p90": 13.775,
+          "latency_ms_p99": 18.911,
+          "hdr_v2_base64": "HISTEwAAAHUAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAMsqAk8C8QECMwK1AQKPAQICLQJZAnECAwJPAgcCGwIVAj8CRwJ3AgUCEQIrAikCIwICuwECgwECbwJZAlECHwJfAu8BAhECZQLPAQIABHcCAwIZAikCAwInAj0CdwJ3ApsCAh0ChwMCkwECZQInAvcCAqMCAg=="
+        },
+        {
+          "operation": "stored_query_execute",
+          "requests": 436,
+          "errors": 0,
+          "latency_ms_p50": 10.551,
+          "latency_ms_p90": 15.063,
+          "latency_ms_p99": 28.591,
+          "hdr_v2_base64": "HISTEwAAAlwAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAIM2AtMEAi8CGQJVAgMCGwIAAhMCKwIAAgcCDwQLAgkEBwRXAhcCCwIHAgcCBwIPAgMCAg8CAwIAAhcCBwQFAgcCEQIlAgUEBwILAgACBQICAwICAwQLAhUEAAQCBwIAAgACBAICBwIAAgICAgMCAgIAAgIIAgcCAg0CBwICAwICAAQDAgACAwIDAgACAAIEAgAGAgQFAgAEBQICAgACBAACAwQEBAIABgQHAgcCCwIEBgICBQICBBEGAwIDAgQAAgICAgIDBAICAwYAAgACAAICAAIAAgIEAgUEAgIAAgACAAIEAAICBAAEAAICAgMGAgQEBAIFBAMCBAACAgACAAYDBAIJAgAEAAICBwQCAAICCwYGAAICAwQFAgICBgMCBwICAgIAAgcCAAIAAgAEAgUCBQIGAgQAAgICBgICDQIAAgMCAAICBAIAAgMEAgICAAIEAAIDAgMCCQYAAgcCFwIDAgsCBwIGBQICAwIFAgMCAwIABAACAgACAgACEwIEAwINAgIDAgQAAhsCAgIDAgIJAg0CAwIJBAICCQILAgIAAgMCAwIAAgICAwIAAgcCCQIFAgUCBwQLBAACBQITAgUCEwILAgIPAgQFAgsCAwILAhECFQICCwIAAhMCEQINAhECCQITAgsCAgACAAIAAgUCAwICAwIbAgUCAgACAAIhBjUEGwIAAgIfAhUCDwITAgIrAk0CPwILAgUCAwIXAhcCCQIDAi0CAwIZAhMCCwILAh8CGQInAgcCAwQxAgsCDQKrBAIJAgACGQLxAQL3AQKrAQK9AwL5CwKZFAI="
+        },
+        {
+          "operation": "tags_put",
+          "requests": 73,
+          "errors": 0,
+          "latency_ms_p50": 5.291,
+          "latency_ms_p90": 11.071,
+          "latency_ms_p99": 17.999,
+          "hdr_v2_base64": "HISTEwAAAJoAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAMEiAiECTwJLAqUBAv8CAqMBAikCJwJvAhUCLwIRAh0CDQI7AmkCSwI7AhcCNwJRAkUCUQIPAgIRAgUCRQIAAgsCiwECJQIHBEMCGwJfAvkBAgcCGQIVAj0CuQECQwIhArcBAicCAh8CFQLHAQKTAQIAAl8CCQI7AgkCGQIfAicCJQIxAusBAmsCGQICCQLhBQIVAgMCnQUCRwI="
+        },
+        {
+          "operation": "tags_read",
+          "requests": 73,
+          "errors": 0,
+          "latency_ms_p50": 4.419,
+          "latency_ms_p90": 9.343,
+          "latency_ms_p99": 11.807,
+          "hdr_v2_base64": "HISTEwAAAJoAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAI0cAgACGwIpArECAnMC7wMCIQJVAgcCUwJRAlMCAwIjAiUCAh8CUwIpAg8CLwIRAm0CDQIHApMBAs0BAs8BAhkCLwIAAj8CNQICHQIdAgACUQJbAgUCOwJTAhkCCwIHAgsCAl0CGwILAicCkQECGQJlAnkCeQK9AgJXAgACkwECAAJVApMCAhcCXwIzAmkCKwJnAtEBAisCKQI="
+        },
+        {
+          "operation": "template_get",
+          "requests": 182,
+          "errors": 0,
+          "latency_ms_p50": 17.103,
+          "latency_ms_p90": 33.759,
+          "latency_ms_p99": 90.495,
+          "hdr_v2_base64": "HISTEwAAAW8AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAMUYAoMFAt8BAtUCAtkBAl0CHQInApUBAo8DAkkC9wECkwECVwILAlcCcQILAg0CCQIdAhsCfwIxAgILAp0BAh0CDQKhAQICSwKlAQJ1AgUC3QECjwECIQJjAjECRQI5AgkCDwKfAQILAk0CDQITAiUCEQIbAiMCTwJrAnkCBwIDAgkCHQKjAQIfAv0BBBkCZQJtAnkCGQIHAgIxAgACBwIvArMBAhECGQINAj0CMwItAocBBBMCKQQDAg0CFwIXAgkCFQIbAgMCLQIHAgICEwIbAg8CBQInAh8CBwIdAgUCDQICKwIfAgICAhMCEQIFAhMCAhkCAgUCAwINAgACKQInAiECAAIdAhsCVQIfAgUCBwIJAgcEBQIhAjsCIwIAAh8CAgIDAgITAp0BAgcCEwI3AhsCdwJBAiECFQJvAkcCJQJBAi0CHQIHAgMCGwIJAg8CAksCIwLBAQINAi0ClQEC1wECRQKnCgKBBAKPBgI="
+        },
+        {
+          "operation": "template_list",
+          "requests": 181,
+          "errors": 0,
+          "latency_ms_p50": 5.271,
+          "latency_ms_p90": 11.207,
+          "latency_ms_p99": 13.279,
+          "hdr_v2_base64": "HISTEwAAAVoAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAK0VAtUDAosBAhcCjwECdQJfAm8CgQICJQQ5AgUCBQIPAgQTAjsCMQIJAisCAwI3AhECIQIFAgIJAgACBwINAhUCKwIFAh0CGwICUQQJAgkCjwECGwI9AgcCHwIPAgkCBQIHAlUCAh8EBwIHAhMCLQI/AhkCRQIzAiUCDwIVAgkCFwIXAiMClQECnQECAikCTQIHAg0CMQIHAgkCGQQpAjUCAwIPAg8CSQICJwJVAgMCAwIVAg0CCQIVAhMCEwJxAg8CDwIVAisCNwIHAj0CNwIpAjkCFQITAssBAg8CBQIJAjUCMQIfAgACDQIbAkUCBQITAhcEAiMCAi8CFQIRAhUCIQIFAgsCBQIFAh0CHwIVAgkCFwIVAgcCNwITAgITAhMCgwECJQIJAmUCFQIXAgcCAwIRAgcCGwIPBAILAgkCEQIAAg8CCQIhAnkCDwIDAhsCAkUCGwJzAgI="
+        },
+        {
+          "operation": "ward_query",
+          "requests": 435,
+          "errors": 0,
+          "latency_ms_p50": 121.535,
+          "latency_ms_p90": 172.159,
+          "latency_ms_p99": 240.639,
+          "hdr_v2_base64": "HISTEwAAAiwAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAP93AicCDwIHAh0CAgIDAgMCEwIAAgUCAgcCCQITAhMCCwIJAgMEAgMCAwQCAAQABAMEAwIFAgIEBQICAAICAgACAgACAAIGAAIDBAACAgAEAwIGBAYIAgUIBAICAgUCBQIFAgACAgIAAgQEAAICBAQAAgACBAIEBgICBAIABgIEAgACBAACAgQCAAYAAgQGAgICAAYCAwICAAQCAgAEBAAGBQgDBAQCCQICAwQAAgIECQIECQQAAgIFAgIAAgAEAgIAAgIDAgUCAAICAgAEBAACAgAEAAIDAgMCBAIDBAIGAAQAAgACAgQFBAIDAgIABAQDBAMIAgQEAwICAwIHBAIJAgMCAgACAgIAAgUCAAIAAgACAwQHBAICBwICAAIDAgACBgMCAgACAwIABAMCBAACAAQDAgACAwIDAgIABAACDQIFAgMCAgAEBQIHAgUCAgICBQIDAgACAwQDAgMCAAICAwQFAgUCAAIDAgkCAwICAgICAAICDQQLAgACAAICCwIRAgUEJQIABAcCAwINAgIAAgACAgsCEwIHAgMCAgIPBAUCAgIHAgUCBwQAAgIDAgIDAgIFAgcCAwQCAAIDAgINAg8CCQINAgICAwILBAcCHwIHAgkCAAIAAg8CAAIJAgICAAIAAg8CDwIPBAMGBQIFAgUCBwIRAgILAgIFAgACAwIABAIlAhsCJwJZAgJRAqEBAgIDAsEBAjECLQKBAQKlAQLDAQKpBQL9CAI="
+        }
+      ],
+      "stable": true,
+      "generator_bound": false,
+      "resources": {
+        "sample_interval_s": 10,
+        "containers": [
+          {
+            "role": "sut",
+            "name": "ehrbase-rs-ehrbase-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 12.91517117999067,
+                "rss_bytes": 292569088,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4543172278,
+                "net_tx_bytes": 7993265817
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 13.044504225051323,
+                "rss_bytes": 292888576,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4571451717,
+                "net_tx_bytes": 8001862587
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 13.489938332763746,
+                "rss_bytes": 294993920,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4596185899,
+                "net_tx_bytes": 8010469178
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 17.40908194274979,
+                "rss_bytes": 296325120,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4621056314,
+                "net_tx_bytes": 8019215960
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 16.66784122896818,
+                "rss_bytes": 306991104,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4654384153,
+                "net_tx_bytes": 8027968207
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 14.720695723585234,
+                "rss_bytes": 307175424,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4682101552,
+                "net_tx_bytes": 8036906142
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 13.492981588646188,
+                "rss_bytes": 311382016,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4712190956,
+                "net_tx_bytes": 8045410898
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 13.463237004904219,
+                "rss_bytes": 299724800,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4746160378,
+                "net_tx_bytes": 8054389769
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 14.297316260138604,
+                "rss_bytes": 302256128,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4767542920,
+                "net_tx_bytes": 8062687296
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 13.966106194219702,
+                "rss_bytes": 293924864,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4790201439,
+                "net_tx_bytes": 8071604388
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 14.021152485937982,
+                "rss_bytes": 301133824,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4811856198,
+                "net_tx_bytes": 8080337251
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 13.548428474916777,
+                "rss_bytes": 302043136,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4842261431,
+                "net_tx_bytes": 8089375683
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 13.970237880157194,
+                "rss_bytes": 302714880,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4871719092,
+                "net_tx_bytes": 8098164994
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 13.622252733927297,
+                "rss_bytes": 304816128,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4900829865,
+                "net_tx_bytes": 8107058456
+              },
+              {
+                "offset_s": 150,
+                "phase": "drain",
+                "cpu_pct": 13.922149530722916,
+                "rss_bytes": 306950144,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4932301322,
+                "net_tx_bytes": 8116389489
+              }
+            ]
+          },
+          {
+            "role": "db",
+            "name": "ehrbase-rs-ehrbase-postgres-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 67.2643880019082,
+                "rss_bytes": 2445545472,
+                "blk_read_bytes": 4267655168,
+                "blk_write_bytes": 46564769792,
+                "net_rx_bytes": 7303359764,
+                "net_tx_bytes": 1348114361
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 65.04296371148548,
+                "rss_bytes": 2478477312,
+                "blk_read_bytes": 4327137280,
+                "blk_write_bytes": 46623703040,
+                "net_rx_bytes": 7310344719,
+                "net_tx_bytes": 1374137586
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 68.68441998813398,
+                "rss_bytes": 2444402688,
+                "blk_read_bytes": 4389765120,
+                "blk_write_bytes": 46668308480,
+                "net_rx_bytes": 7317076629,
+                "net_tx_bytes": 1396562317
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 84.20978504496934,
+                "rss_bytes": 2445426688,
+                "blk_read_bytes": 4458016768,
+                "blk_write_bytes": 46738472960,
+                "net_rx_bytes": 7324122912,
+                "net_tx_bytes": 1419008534
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 82.48656305268037,
+                "rss_bytes": 2495500288,
+                "blk_read_bytes": 4520435712,
+                "blk_write_bytes": 46806818816,
+                "net_rx_bytes": 7331146535,
+                "net_tx_bytes": 1450024504
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 71.02314011432833,
+                "rss_bytes": 2445221888,
+                "blk_read_bytes": 4557549568,
+                "blk_write_bytes": 46842314752,
+                "net_rx_bytes": 7338361391,
+                "net_tx_bytes": 1475349277
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 66.89459137630975,
+                "rss_bytes": 2495393792,
+                "blk_read_bytes": 4586749952,
+                "blk_write_bytes": 46891401216,
+                "net_rx_bytes": 7345109047,
+                "net_tx_bytes": 1505925366
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 65.22972570883584,
+                "rss_bytes": 2446020608,
+                "blk_read_bytes": 4651352064,
+                "blk_write_bytes": 46948163584,
+                "net_rx_bytes": 7352334328,
+                "net_tx_bytes": 1534745666
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 72.05800762227769,
+                "rss_bytes": 2445410304,
+                "blk_read_bytes": 4707647488,
+                "blk_write_bytes": 46993252352,
+                "net_rx_bytes": 7358955031,
+                "net_tx_bytes": 1553971245
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 69.17143883320533,
+                "rss_bytes": 2447249408,
+                "blk_read_bytes": 4772753408,
+                "blk_write_bytes": 47046279168,
+                "net_rx_bytes": 7366174572,
+                "net_tx_bytes": 1574148462
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 67.5651486692094,
+                "rss_bytes": 2449010688,
+                "blk_read_bytes": 4847865856,
+                "blk_write_bytes": 47102869504,
+                "net_rx_bytes": 7373233244,
+                "net_tx_bytes": 1593481122
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 64.30924454806322,
+                "rss_bytes": 2449874944,
+                "blk_read_bytes": 4910043136,
+                "blk_write_bytes": 47138734080,
+                "net_rx_bytes": 7380505291,
+                "net_tx_bytes": 1621447337
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 64.95871934279673,
+                "rss_bytes": 2450849792,
+                "blk_read_bytes": 4972621824,
+                "blk_write_bytes": 47191212032,
+                "net_rx_bytes": 7387584638,
+                "net_tx_bytes": 1648463894
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 69.92949703231841,
+                "rss_bytes": 2467119104,
+                "blk_read_bytes": 5033062400,
+                "blk_write_bytes": 47246098432,
+                "net_rx_bytes": 7394709578,
+                "net_tx_bytes": 1675158483
+              },
+              {
+                "offset_s": 150,
+                "phase": "drain",
+                "cpu_pct": 66.9287350558857,
+                "rss_bytes": 2502021120,
+                "blk_read_bytes": 5095256064,
+                "blk_write_bytes": 47285346304,
+                "net_rx_bytes": 7402271828,
+                "net_tx_bytes": 1703943825
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "rate": 256.0,
+      "offered_load_sustained": 258.5416666666667,
+      "operations": [
+        {
+          "operation": "adhoc_query",
+          "requests": 4068,
+          "errors": 0,
+          "latency_ms_p50": 8.607,
+          "latency_ms_p90": 15.471,
+          "latency_ms_p99": 49.151,
+          "hdr_v2_base64": "HISTEwAACSYAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAM0tAsUBAg8CiQECAAICAgcCAwINAhMGCwIDBAINAgUEAAIFAgACAwQHAgACAAIDAgICBQIFAgQEAAILAgAGAAQCBAAEBQIEAgICAgICAgACAgUCAgkCBAgFAgMEAgIGAAIEAgQFAgQCAAICCwQAAgUEAgMGAgIEAgIEAAQAAgIEAgQCBgAEBAACAgACAgIDBAAEAgcCAAYCBAQAAgIEAgIEAgQEAgICBgQCAAgEBAIGAgICAAICBAACAgIECgICAgICBAIGAAQEAAYAAgQCAwIAAgICAgICBAYAAgACAgIIBAQMBgUCAgYCCAQCAAYABAIEAggCAgIEAgYCBAQECAQCCAAMAggABggEAAIDBAACAgACBAMEAgIEBAICBgoGAAICCgQKBAQCAAIAAggGBAYEAgYIAAICBAAKCAIACgQCBAIGBgAGBAICBggEAAgAAgQCBgIGBggCAgIICAAGAggIBAQIBAYCAAIKCgIECAYGCgQEBAQCAgIICgYCAgQEAgAGBgoEAAQHBgQCAgICAgICBgQEBgQECgYGBgQABAIEBAAEBAAGBgIEBgQCAgICAwYCBAYEAgIGBAAEBgACBAIEBgQECgQIBAYGAAIIAAgGAAQABAIEAgIIBgQCCAgAAgIGAgAIBgQAAgIABgwEBgIGAgYGBAIABAQEAggCBAQGAAIGBgQEBAYAAgIABgQGAAgGBAwEAAYCAggCAAgIBgYEBggGCAICBAQIBgICAAQICAwECAYEBgIGAgIGCAAGBgYECAACBAgKCAYGBAYGBgICCAgEBgQCAAYEAggEBAYGDgAEBAQAAgIIAgYCBgIGBAYIDAgEBAQCBgIEAg4CAgQABAQCDgQABAIGAgAEBAQEAgQGCgYGBgAMBAgIBgYOBAYCAwIIAgYCAwgGBgIKBgYEAgIACgQEBAAGCgYMBgoEBgQCCAQCCAQEAgQEDAIABAIEAgQEAg4GCAQAAgQGCAIIBAIGAAICAgQEBAAIBAYABAoECAYCAgYEAAYEAggIBAYIAwQKBAYCCggEBgYGCAgEBgQGCAwIBgYICAIOBgYGAAgIBAQABAIECAIGBgQCCAYDBgQKAAoABgYCBggAAgQGCAgIBgAKCAQACAAGAgYABgYEAgAEBAIABgIOAgAIAAYGCgAGAgQIBgIABgIOBgYGDgAIDAYCAA4ABAgABAYCBgYICAYKBgICDAQCBgAGCgIGCggCAgQIBggGBAoIDAYOGAoEBgQMCAYICgQKDAYACAIODAoOBgQSDA4MDgwGCAoIBgoICAQECg4KCggECAwMChAGBgIEDgQKBgQCDhIECgYICgoIBgwKCAYGCAgCCAgGCAYGCg4EDAgGDAoMAgYKBhAIEAYMDAwMChAEDgwEAgIIDAQMDAYECAgMCAQKCAgGCgQECAwEBgQIBggGCggMEgQKDgoECAYQBgYCBg4GBgYMBAYMBAgMCgYMBAwKDAQEAgYMDAgCCAIEEgoGDAgOAgQIBgoKCAIIBAgICAAIBAYEAggEBAIKDgQDCgIKBhIAAggIFAYIAgoGBAQIAgoCBAYIBgIGAggGAgoGBAYGAgQIBAIICAoGCAYCAgQCBgICCAYCAAgGAgMMAgAIBgYGCgQEAgoGBgoMBAYIBg4IBgwIBAYCAg4IAggOCgYIBAwEAgAIAgQIBAQMBAIEAgQCDAQCAgQEAg4MBAYKAgQKAAYABAIIAgACAAIABAgEBAQEBAQGBAACBAYGAgIDBAACBAIAAgYGAAIGAAICAAQAAgYCAgQIAgYEBAQGAgQEBggEBAAGBgACAggEAgQGBgAEBAQAAgYGCAQCAwgIAgIEAgIHAgAGAgQGBAIEBAQCAwQDAgYGAgICAgICAgQEBAICBAAEAgYDBAICAgIFAgQEAgICAgIEAAQAAgICAAIEAwIGAgAIAgMCAwIGAgMCBQQCAAQCBAQEAAQCBgMIBAMEAgACAgQEBAACAgQCAAQEAgICBAQEAgYCBgAEAwICAwICBAQCAAQEAgACAgIAAgAGAAQCAgICAgMCBAAEAAIIAgYAAgUCAAIGBgYEAAICBAYAAgMEAgQEAgQAAgIAAgIFCAIABgICAwIDAgACAgACAgMCAgMCAAIHAgUCAAIGAAICAAIHBAACBQICAwIDAgQCAgACAAIFBAIDBAIDAgQABAIABgQGAAIAAgICCQIDBAAEAAICAAQCAAICAgIFAgMCAgIAAgMCAgAGBQYAAgMGAgMCAAIHAgIEBQICBAcCBAQCBwIABAACAAIDAgACEQICAwQAAgICAgYCAAIDAgQDAgIEBwIJAgICBQIAAgINBAkCAwICAgMCCQYDAgUCAgMCAg0CAwIHBAACAAQCAAIFAgACAgACCwYDBAcEAAIAAgAGCwICAgcCAgACAAIECQIABAQABAAEAwQECAQCBAACAAIAAgMCBAIEAgAGAwICAAIDBAQDAgQCAgMEAAIDAgACAgIAAgICAAIEAAIFBAICBwIDAgMCAwIDBAIABAAGAAICAgQAAgIDAgICAwIAAgICBQgCBwICAwIEAgMEDwICAgsCAgMCAAIEAAIAAgACAgACAAIAAgIABAACAwQCAgMCFQICBBECAgACAAQFAgIDAgICBQIDAgIFAg0CAgIAAgcEAgACBwIbBAkEAgAECQIFAgMCAAIHAgMCAwICBQQAAgMCAAIAAg0EAwIHBBECGQIAAgIDAg0CEwQJAh8CAAIEAgMCAgUCBwIAAgIHAgMCAgQCAAIFBAIAAgkECwIAAg8CAhUCDQICCwICGQICAgINAikCDwIDAgACDQIFAgkCBh0CAAINBAACAwILAgUCAAI1Ag8CKwILAi8EHwRBAh0CJQIPAg8CAAIXAk0CDwIHAhMCFQI1Ah8CBQICCwIRAkUCCQIDAgsCFwIDAgMCAwIJAgkCFwICIQIRAgMCCQIDAgACQQIHAjsCAwIDAhECAAITAhMCcQIDAjMCSwIFAi0CAwJxAi8CCQIDAgACBwI9AhUCAAI9Ak8CGQItAi8CNQI9Ag0CKQI/AhUCXwL5AgInAi8CDQIAAjMCaQKZAQIAAkECBQICYQIHAk8CJQIjArUBAgUCywUCGwIXAqECApUBAikCvwEC"
+        },
+        {
+          "operation": "composition_commit",
+          "requests": 1254,
+          "errors": 0,
+          "latency_ms_p50": 12.335,
+          "latency_ms_p90": 34.015,
+          "latency_ms_p99": 75.135,
+          "hdr_v2_base64": "HISTEwAABmEAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAANclAsMBAlcCSwJXAhsCAAIHAmkCJQIHAosCAjECKQJnAl8CCwLVAQIXAksCoQECWQI/AjcCCQIvAjECAgsCBwIfAgsCGQI9Ag8CAwIfAicCAwINAgIDAh0EAwIEGwIJAg8CAAIZAgACHwITBAMCBwIFAg8CAgIDBAACBwIFAgMCAgcCBwICAgcCBwIHAgIDAhUCAgMCAAIHAgkCAwIDAgsCBwIXAgMCBQIAAg0CAhMCAAIFBAACAwICBwICBwQFBAIAAgMCAgICJQIFAgIDBAIAAgACAAIFBAIJAgQAAgIDAgIDAgACCQIEAgkCCQIDAgIHAgMCAwIDAhUCJwIABAACAAICBQIPAgICCQYCBQICAwICCwIjAgcEAwICBQICAgsCAAICAAQCAAIDBAcEAgMEAgAEAAQCBwIDAgQCAgIEAAIAAgIAAgIAAgIAAgACBAACAgAGBAMCAwICBAYAAgACAgIDAgQEBgICAwgAAgAEAgIDAgQCAgYFAgMIAAQAAgAEAAQFAgIEAgIABAIEBgACAAYAAgMCBwICAgICAgQDBAQEAgIABAcCBAQEAgQCAgICAAIEAAQABAACAwIAAgAEAwICAgIABAACBAIHBAAEBQIABAICAgMEAgICAgUECQIABAACAgQABAQEAAIEBAAEAgQCBgIEBAIAAgICAAICBAICAgICAAICAgIFBgQDAgQABAgCAgMCBQYDAgQCAwYEAgACBQQEBAIEBgUEAAICAAQABAIAAgAGAgYCAgYAAgIEAgIDAgYEBAICAAIDBAAEAAIGAAIEAAICBQICBAQCAgQAAgQAAgICAgMEAAIABAcCAgIDBAMCBAACAgUCBAYCAgACAgIFAgIAAgIDBgACAgsEBAMCAAIABgACBAICAAICBAACAAIEBAICAAIACAACBAYEBwQEBQICAgIEAgACAgACBAACAAIEAAIDAgYDAgACAwIABAAEAwQCAAQCAAQEAAIDAgMCAgQDBAICAgQAAgIDBgICBgIAAgQCAwIDAgICAwIECQIAAgIJAgILAgcCCwYDAgIJAgACAAIDAgUCAwICCQQHAgICCwIHAgUCDwQDAgQDAgACAgICAgMEBAIAAgACBAMEAgACBAIDAgICAwIAAgUCAwICCQIAAgICBAMCBAMCAgIDAgcEBQICAAQCAgIFAgcEBQIHAgICAwICBAMCBwIRAgACAAIPAgACAAIAAgQRAgUCEQICCQIDAgUCAgIPBAMCAgMCBAMEBAMCBQIABAkCAAICAAQPAgUCFwIABAUCAAICAgUCAwIFAgUCAAIFAgACAAIHAgcCCwIAAgMCAhkCAgIFAgIAAgIDAgQAAgkEAAICBAAEAgIABAIAAgUEAAIFAgACAgACBAAGBAQAAgICAgAEAAIGAAICCwQCAAQEBQIEBAACAwQCAgMCCQQDAgACAAQCBAQHAgIAAgMCBAIAAgMCAAIEAwQCAgIEBAQHAgUCAgQAAgMCAwIABAIFAgQCAAYCAAILAgACAwIRAgcCAgUEAAIAAgIDAgACAwIDAgACAgsCAgACAAIABAIDAgUCAwIAAgMCFQIAAgQGBAIDBAITAgUCAAIDAgYHAhEEAg0EEQICBQILAgACAgIfAg0CDQIJAgACAAIFAgICDQICAwQPAhECBwILAgMCHwIAAgsEBQIHAhkCEwIDAgMCAwILAgMCCwQDAg8CBQIFAgMCCQIEKwIHBAACAwIAAgMCBwIDAg8CAAITAgJdBCUCFwIVAgUCCQIAAhcCHQJBAgcCAg0CAgsCBQIDAgIHAhUCCwILAgcCAhECDQItAhEEBwIlAgkCBQIHAgMCBQIRAgUCCQITAgUCHQIXAg8CDQIHAhECCQILAhUCBAIHBAMCCQQJAgIDAh8CEwIHAgsCDQIZAgUCBwIAAgMCAwIFAgsECQICAAINBAMCCQIdAgIHAgUCEQIDAgcCBAIFAgIHAgUCAgsCAgMCAAILAgUCAAINAgACBQIHAgQbAg8CEwIrAhsEAgICAwIRAgUCAAIZAgUCDQI/AgACIwQVAmkCDQICAwITAgMCAicCKwItAgUCDQILAjECIQJrAi8CEwIPAgkCYwJFAlsCCwINAg0CGQI/AksCVQIzAgIvAgMCTQK9AQIjAkMCDQJbAuMBAkMCjwECgwEClwUClwQCUQI="
+        },
+        {
+          "operation": "composition_read",
+          "requests": 8136,
+          "errors": 0,
+          "latency_ms_p50": 4.619,
+          "latency_ms_p90": 7.983,
+          "latency_ms_p99": 24.463,
+          "hdr_v2_base64": "HISTEwAAC3wAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAOMTArEDAlcCGQI7ArMCAlkCSQItAgACDQQAAjcCAhUCDwIFAhcCDQIDAgsCAgACBwQAAgcCAwIPAgACAgIfAgkCAAIJAgACBwQpAg8CAAICBwINBAACAgACBwQDAgIABAICBwICBAMCAgICAgMCAgACAgIEAgIDBAcCBAMCAgYCBAICAwIFAgACAgIEAgMCAgMCAgUEBAACAAICAwQABgMGBAICAgACAwICBAQEAAIEAAYAAgIABgQCAAICCAQCAAIEAAICAAIDBAoAAgMCAgICAAQAAgYCAwYCBAIEAgMGBAACBgQAAgYCBgMGAgAGBAIGAAQCAgICCAAEAAIAAgQGAgACAggAAgAEBAYDBAYCAAYEBAAECAYEBgQAAggCBQIEAAICBAAGCAQEBgYCAgYGCAACAgICAAQCAAIEBgIIBgIGAgQGAgQIAgYCAgICDAUGBAYGAgQEAgAEAgIEAAQCBgIGBAAKAgYAAgQCBggGBAAGAAIGBgoGBAIGCAQCAgYGAgoECgQGAgYEAgoCBgQCBgoCAAgGAgQOBgICBggIAAQECAYGCAIIBgQCBgIEBgACBAYIBAYMCAwDBAQGAAwGBAQKCAQICAYIAggIDAYEAgYCCgYEAgoGDAIGBgQECAgMAAQIDgAEBAQICAgMBhAIBAYECgYIBAoEAAQECgoIAAYGBAAEDAgCAggMDAYEAgIKCgIMBAQCAgQGCAgECAQGBgICBAoCBgwEDgYKDAIGBgYGBgQMAgYICgIIBhIGCgoMCAYGBgIICAAKCgACBgQGBgoEBgwKDAgABAIGCAoMAggKBAQKEgIICAIOCgAICAYGBgYCBgIECAQGCAgMDAwGCgoEDggICAYICAACAgwGBAYIAgYEBgoEEAwICAgEBggEBggKCgIGBAwEDgoGCgQIBgYGBAwGCAAIBgwMAggMBgYMBgYEBAQIBggCAgQGBA4IBAoMEgQEDAoGDA4ACAoGEgYCBgQOFAQCCgoIBgQOCAgGDAgEBggCAAoGBggKBA4EAggQDAwKBggGBAgIAg4KBAQIBAgKBAgCDAYIDgYICgoCCgoIBgwMCgQGAgYMBggKCAYIDAYOBAgEBgIEEgwIBggICAoGBAwGCAgEDA4KAgoMCAQIDAQGCAgEAgwMBhQMAA4MBgAIBggSCAYODAQACAoIAgYSCgwIBgQEBAIIAg4UCgYEBAoGBgoCBggIAgoMCAQECAgMDgIICggMBBAEBAoMBAgOCgYMCgQKDAgECAwIAgYQAgoIDgoQBg4MDhAKAAwICgoKCgAOBgoKCAgGCAYKAgoGDgYECggIBggEAgYGDAYEBAYSBggGCggICgQIAhQABAoYCAYGCgoKCBoOBgwIDAwGDAQOCAIKCAYGCAQOChAMCgQGEAoICBAEEAQMCgoKCggMBhAIAAwUFgwUDhoKFgwWDg4YDAYUFBQYDAoIGBAUCg4OFhIeEBIIEAIOFgoWEBYIEAgGGBQMFggOEBQSFBIWEhgQGBwWDhgaFA4KDBAWFAgQFBAMDg4MEAwSGBQUDgYWEBQWEggUChYIEhQODg4UChAQEAoYEhYOEAgUEBAUFhQMEBYICBYQChAKCgQMFhYUEAgKEBQcCgQSEg4UEAgOEg4UDBYUFBgMHBAUDg4WEhAMDgoKIBYSDggKDBASDBgKBgwSEgwMCgoMBhAQCggUFAYSGBYOGAgKEBoGChQMDggOGhIQChIMDBAIEhYKDg4MDhgIDhQODggOBgwMCgwQDBQWDA4MEAwWBhIIBgYOCgoCCBIOEgQQEhAKGg4UBgwMDgoOBgwSEBAMEgoUDA4MFBIOEAgMCA4OEhAMDggEBA4OEgQOBgYYCA4KCA4QChAIEA4MCgoIDBAICgwQGAoKDBAEDhAMEAwOCAwIBgoECgwWDAoGDgwMCgIYCA4KBg4MDggMDAwMBgoKCgYKDgoKDhIKDAYOBAgKCgYUDgYGDA4MCAgMCAgOBgYMCgwGEAwGBgoEBggGBgYMAAgEDAQECgIIAgwQBgIIBgQOCAAEBgwECAYGCAoIChAIEgwOBAgEBAYQAgoIBgwECAgMBgAGCAQGDhAGBAYKBAoECggGDggIBgIECggGChACCgIIBgYIBggICg4KBggGBgoGDgIIBgQICgoICAYGDA4GDAQIDAQMCAQIBAYGAgYCCAYCBgoKAgYCBAoICgwKABAGDAQCCAYOBAgGCgYIBAgKAgYIBAoGAgQGBAgECAgGAAoKBgYABAoGCAAGCAoEBgYCCAYEAgoIBgIEBAQEBgYIAgQGAggIBgYEAgYGAgYCCAQAAgQEBgAICAIKAggEBAQGAgIGCAQIBgQGBAoGBAQGBgoECAQEBAYEBAQAAgoGCAYCBgoGAgoABgYEAAQCAAgEBAAEBAIIAgoGBgICBgICAgQEBAAIAAgAAgIEAgQAAgQEBAgABgQEAgYABgYEAgYCBAICBAIABAYGAgIABgIAAgICBgQIBAQCBgQEAgIGAAIGAgAIAgIECAQEAAQGBAIFBAACAgYEAgQABAYCCAYCAgQCAgACBAAGAgoCAgACBAMCAAYCBgAEAgICAgICAgUEAAQCAAQCAwQEBAIABAQCAgQIBAICBAAIAAQAAgIDAgAEAggCBAQIAAIDBAMEBAICBAIAAgIGAwQCAAIGBAAEAgQDAgIGAgQEBAIDAgICAgACAAIIAgIEAggABAYAAgQCBAIGBgICAgIAAgIGAgYCAwQDAgMGBwICCAICAAIEBAUEAgQCAggEAgQABAQACgIDAgYCAAoGBgQCBgQGAgQEAhAGBgYCAgAEBgACBgAEAAICAAIGBAgCAgYABgAGBAIAAgICAgoCBgYGBAIDAgICAAQGAgQCAgcEAAIEBAQCAgoCAAICAgACAgAIAAQCBAACBgQABAICBAIEAAICBgMEAAIAAgIDBAACAwICBAACBgIGCgQFAgICBgQDAggDAgQGAAQEAAICAgAEAgQGBAQCAAICAgQEAAIEBQIDBAIEBAQICAYCAAgAAgACBQQCBAIEAgIAAgkCAgYGAgICAgICAAIAAgAEAwIEAgQEBAAEAgIEAgcEAAICAwIAAgMEBAIAAgACAgACAgACAwQDAgICBAICAgAEAAQCAAIDAgIEAgMCBwQCAgICAgQDAgIABAAEBAIFBAACAwILAgcCAAQDBAACBgICAwICAAICBAICAgACAgMEAAQEAwIFAgICBQQJAgUCAAIIAwIAAgUCAgACDwIFAgkCAgUCBAUCBwIAAgIABAUCAgcCAgACAAIAAgICAwIAAgcCBQQAAgMGBQIDAgAEBAACAwIAAgUCBQIJAgIABgMCDwQCAwIEAAQDBAIDBAMCAgcCIwIDAgcCAwIDAgkCAiECAgUCBQIHAgACAAIAAgAEAgACCwICAgcEBwQLAgkCBAMCAgIFAgINBAkCBQIhAgsCAAINAg0CDwIDAgMCAgMCBAsCAiUCAAICAwQDBAICDQICBwYTAgIjAgMCKQINAgMCBQQFAgICAgACDQI1AgMCEwICGwIdAgIDAgkCBQIFAgkCDwICBQINBAUCCQIJAg0CAgACFQIPAhMCCwQDAgMCBQIFAh8CBwQRAgINAhECFwIZAgIZBA8CTQICDwIhAgACGQIfAhcCFwInAhMCCQIRAgUCAgMCAgkCBQIHAkkCAhMCMwIHAgsCDwINAgMCawICHQIHAg0CAwITAgkCNwIdAgMCiwECdQIXAgMCNwILAgsCDQIlAiECEQITAgcCAAIFAg0CRQJLAncCAAJ3AgMCJQI5AgUCBwIVAhECJwJdAgcCAwIRAncCdwIVAiMCBQIXAgMCNwIjAgMCnwICNwIJAgUCxQECUQKvAQJFAlkCAAI9AlcCBQICVQJ7BAACJQJJAgcCAwKRAQLbAQIfAokGAs8DAg=="
+        },
+        {
+          "operation": "composition_read_current",
+          "requests": 4575,
+          "errors": 0,
+          "latency_ms_p50": 4.563,
+          "latency_ms_p90": 8.319,
+          "latency_ms_p99": 24.079,
+          "hdr_v2_base64": "HISTEwAACP4AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAIceAscCAh8CYQJ1Ag8CBQIjAhMCAAIFAgIFAjECCwIHBAIJBAMEAgkEAgcCEQIAAgUCBwQDAgIDAgUEFQINAgMCBwIEAAQDBAACBQQCBQIAAgACBAUCAgUCAwIAAgMEAAQABAACAgAEAwIAAgIFAgACAwQDAgACAgMCAAQCAgIEAwYCAwICAgMCAgACAAIEBQICAgAEAgAGBAICAgMCAwIEAAIABgYCAgQGAgACAgIFCAIGAwIEBgkEBAAGAgMGAAgCAgIEAgAEAgACAgQEBAYCAAQCBAACBAgGBAACAAIAAgQECggAAgYEBAQGBAICBAIDBAYGBgMGAAIGBAYGBAIEAgIACAQIBgIACAoEBAIEBgQEAgIEAAQIBAYACAQCAgIACAICAAgCAgQIAAgCAAICAgQEAwYAAgQCAgAEBAYEBgAEBAQIBAYCCAQIAgACBgAEBgIEAAQGCgoGCgoGAggCAAgABgICBgIKBgQABgQGAgQGDAgIAwQIBAYGAgIGBAgIBgYABAQIAggIBggKCAYKBgQGBAQABAwKBAYGAAgGBAgCBgQCAgIECAIOBgQGBAYEBAQEAgQGBgQECggIAgwACAQMDAQEAgQEBAACCAwCBAYGBAYGBggCBgIIBgICDAYKBAoKCggIBgAEAAQGCAwIBAYIBgIMCAgECggMBAYABgQGCAgGDAYIBgYGBggEBA4ICAoICAIGDAQEBAoCCAQCBAYIDhAIDggABgwGCgYABAIGCAoIBAIGCAgCAgQEAAYCBAIICggGCgQMDAAIBAAMBgYGAgAECAYGCAIEBggACgoMBAAOBAgKAAwIBgwCBAgMCAIEBggICgQCDgQGBgQOCAoIBggKDAIGCgwEBA4EDAQGCAgKCAgEBggKBAgCBAgKBgYEAAQIAAgMCggECAIMCAgMAgYIBg4IBAgKBAQIBAgGBgwMBA4KBBAMDg4OEA4UDAoMEhQWBhIICgYOEBYMEgQKCgoQBA4MBBISEAoKDBAKBhAMDAoOCAoIEgwCDAwKFAQMDBoQCA4ODAwSFBAMEgoKDAgSDhIICAgODAQICggQFAgIDAwIFggSDAoQCgwOCAgKFBIICgwGDAgOBgoMEAYIEgoGAhQMDAgOCgoGCgQGFgYIEgYIEAoIBAgKBhYUCAYECgoQDgwKCgYIDAIQCgoQCggGDAwYBgYIBAwMCgoKCgwKBggECg4KDAQGCggSAggEBggECAoEBgYICAwEBgYEEAwIBgIGCgQIBgoMBAgQDA4KDgYGBgwIBgYIDAYIAggOAggEDAgGCAoGDgwGEAQCCAQGCAIECAoEBgIMCAgGBAgCAgIGDAYGChIIBAIECggIBAIKAggEAggKCgIGBgQKCAQGBgIEBAIIBggMBgIKCAQGAgwIBAAGCAgCAgYGAgQIBAwKCAQCBAQGCAwCAggGAgwGAgYEDAAKBgYIAgIGAgQIAgYIAAYIAgwCBgAICgIGBAIIBAYEAAIEBgIGBAIDAgQGCAAIBgoGBgICBgQAAgQGBAAEBgICAAQEBAgEBAICBAIEAAIDAgQGBAgAAgYICAgACAQMAAICBgQEAAQEBAQABgAGAAYGAgYCAgQCAgQECAgGBAIABAIGAAIIAAIEAgQIBQYIBAQEAAQAAgQEBAQCDAMCAgQEBgIEBAICBAIABAQGAgQCAgACBAACBAMECgICAAgGBAQCAAICAgQEAgQDBAAEAgIEBAQCAgQABAYAAgIEBAIEBQIIBAAEAAIEBAgGBAICAgYCAgYCAgYCBwIGBAYCAwQCAgICAgAEAggCAAQACAMCAgUCAAICAwIAAgwCBAQEBAICBgAEBAQCBAAGAgACAwYCAAIFAgQEAgMCAgAGBAQABAICAAIAAgICAgQAAgIIAAgCAAQAAggCAwIEAgQCAAIEAgMKAgQCAgMGCAMEAwICAgACAgMGAAIAAgIABAICAAICAgAEBgICAAICBAcCAwQABAAEAgACAgIGAgIAAgACAAQIAgMGBAIFAgACBgcEAgQFAgMCBAAIEwQFAgQAAgIGAgAEAgYEAwQHBAMCBAICAAYEAgIAAgICAgIEAgACAAQABgQABgICAwICAAICAgcEBQQCAAIABAYFAgACBAICBwIABAIEAAQABgACAwQHAgUCBAIEBQIDAgIDBAIAAgIFAgICBQYCBQIECQICAAIDAgACAAICAgIABAAEBAICAgQDAgQEBAIFBAIIBAgAAgACAgQFBAACAgIABAQDAgMCAgIGBwIDBgIAAgYCBAMEAAQEAwIABAIEBAIHAgACAgMGAwQIAgIAAgMCBQQEAgACBQYCAAIEBAACAgMCAgICAAIDAgAEBAACAAQIAgMCAgIEBAIEAgIAAgACEQQAAgQCAAIABAQCAAYDAgMCAgQDAgICAAQCAAIDBAsEBAQEAAIGAwQCBAIAAgAEAwICBQIAAgICAwICAgUCBQQAAgACAAIDAgACAAQCAgILAgIAAgQLAgAEBwIAAgACAgMCAgQAAgUEGQIDAgUCCQQCCQIHAgICBAQCEQYAAgUCAgIFAgMCDwIFAgQDAgICDQIFAg8ECQIDAhkCAgcCAAIDAg0EAgQJAgMCAAIAAhUCAgIfAgIAAgUCAgACHQIAAgIFAgsCAgMCCQICCwIAAhUCCwIDAhUCAwICAgMCDwIAAiUCAwIRAicCCwIAAg8EAAIABAcCCwIDBAMCAwIFAgsCAwIAAgcCDwIvAgUCGwIrAgACAwILAgcCBwIbAhsCJwICMQQVAgACDQIJAgIFAgkCDwIRAgACAAICBwIHAg8CAwI7AgcCAg0CCQQDAgILAgMCAwILAhcCBQIHAgUCAg8CAgMCCQIDAg8CAwIlAgIHAk8CUwITAgkCAwIAAgIFAgMCIwIAAg0CBwIXAh0CBQInAh8CIwIZAlcCGQILAgsCBwIdArMBAiUCEQIhAh0CyQECmQECCwKRAQQrAkkCKQIjAh8CDwIZAp8BAhcCbwICTwJzAjsCAwInAksClQECHQIpAjkC6QECkwEC2QQCEQITAhMCgwECHwLRAQJdAlcCmQYChwICOwI="
+        },
+        {
+          "operation": "composition_revision_history",
+          "requests": 4395,
+          "errors": 0,
+          "latency_ms_p50": 3.283,
+          "latency_ms_p90": 7.443,
+          "latency_ms_p99": 18.271,
+          "hdr_v2_base64": "HISTEwAAC5QAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAN0OAiECBQLvAQJVAjMCEwIHAhcCDQJNAgUCAAICAh8CNwIDAhECAwIAAgACAwIFAgMECQIPAgcCAAIDBAUCBwIAAgMCBQIHAgACAwICAgMCAAIHAgMCBQQFAgcCDwQAAgACAwIABAICAwIPBAAEAwICAgIHAgACAAIDAgIAAgMCAAIAAgMEAAIDAgQDAgIEBQQAAgcCBAACAgAEAwIAAgACAgQJBAMCAAIEAgIAAgIAAgACAgMCAAQCBgcEAgACAgIABAMCBAIDAgICAgICAAQLAgICAAQDBAQAAgAEAwICAAICAgMCAgMEBQICBgICAAIABAAEAAIDAgMGAAIHAgIAAgMCBgILAgIEAAIEAAQCAgAEAgMCAwQEAAQCAgYCAAIFBAIDBAIABAQCAgQAAgQAAgICAgIAAgIGAAQAAgQABAgGAAYCCAYABAACAAQEBQIEAgACAgICAAQABAQABAICAggFBAYCBwQEAwIABAIEAgQEAAIEBgIABAICAgQDBAoCAgYDAgAEAgMEAwYEAAQEBAgEBQQAAgICAgAEAAYCAgICAgAEBgICAgQGAgAEBAQEAAICAAICAgMCBAICAAQEBAgCAgIIAAQCBAIKAAICAwIEBgIEAgIABAQEBAIGBAICAgAMAAYFAgICAAYCAwIKAAgABAAEBAQCBgQCBAACBAAEAAQABgUIBAQEAgACBAIAAgIEBAYCAggGAgYCAgIEAwQIBAUCBAAEAggEBAYEAAgAAgIEBAICAgYDAgQCAwQGBAYCBAQCAgIDAgACAAYEBgICBAQAAgICAAQGAAIEBgACAgIAAgAIBgICAgYEAgQCBgIFAgACAAgCAgACAAYEAgIKCgQKAAoCBgQGCAICBgYQBgYDCAQEAggCCAQIBAIEAgAIBAgKAgYCBAQIAgAEAgYICAgGBAYGAgQGAgAMCggGCAwEAAgKBAwGCAQABAQKCggEChAGAgIKBgYIAgQEAgQCCggEAwgIBggKEAgIBgQECAIMCAQKBAwGAAgKBAQGBAYECAQGDAYKCAIQCggCAgYICAYIBgQCBgYEDA4ECgACBggEBAoGAAwEBgQICAYIBAYIBgAGAgwGCAICAgQGCgYECgQEBAQGCgQABggICAYAAgQGBg4CBAgIDgYCBgAICAQCBAQGBgoIDAQKBAoGDggMAAQKAgQKBAoEBAgECggEAAIEAAYCBgIAAgwMCgQCBAgAAgYEBgQEBAYEBAQEAggECAQEBgYABgICBAQGBAAEBAgICggCBAACDAIGCAoCBgoEBAACBgYKBgYEBgQCBAMEAgYKBAIEBgYCCAwGBgACBgYCBAgEBAIKAAgCAgIDBgAGBgIIBgIEBAAEBAgGBgICAgIGBAwGAgIEBBAMCAgGAAQICAQABAQGBAICAAIEAgYCAgIEAggEBAQEBAgKAAIEAgQEBgICAAQAAgIECgIABAYGBgYAAgICBAICBAICBAYECAQGAgIKAggGBgYAAgYEBgIKCAYGBAYABAYEAgAECAQGAgoCAgICBgAEBAQEBgICCggGAgQCAggEAAgCBgQCAgQGAgICAgYCBgoICAQEBgQABAAIAgIEAAIGBgQCBgACAgACAgIABAoAAgIABgQAAgQCAgIGAAIGAgQEAAIGAAICAAIAAgIABAAGBgIDAgYCAggAAgQIAg4GAAICAAIAAgYGAgIIAAQCAgAGBAQDAgIACAQEAgQABgQAAgICAgQABAICAgICCAIABAMCAgIIAwQGBAIGCAIGBAYEAgYCAgQDBAIAAgYGAgACCgQACAMEAgIIBgIDBgQABgIDAgQGAgIEBgICAAYCAgAEAAQCAgQIAgIGBAIIAgYAAgQAAgYCBAICBgUEAgQAAgACBAIEBAIEBAAEBgACAgIEAgIGAgIEBAQCBgICBAIEBAQCAgQCBAIDAgIEAgQABAIGBAICCAMCBAQABAICBggCBAICBQICAAIEAAIEAwICBgACCAACBAgCAgACAAIABgQCAgQCBAMEBAIDBAICBAQCAgQEBAAEAAQEBAIEAAICBAAGAAoEAAQEAAICAAIGBAACBgIEBAQEBgYEAAICBgQAAgICAgQEBAQDAgQGAgAGBAIEAwQCAgICBAMCCgQAAgQCAAYCAgQDBAAEBAYAAgICAgQEBAIABAQDAgIAAgIABAAEBAIDAgQEBgQCBgQCBAQGCgQCCAgECAAEDgYGBgIECgIGAgIGBgQCBgQCAgQCBggACgACBAIDAgAGCAIECgQCDAIECAYECgIEBAAEAgQEBAYCAgIGAgIGBggCBAQCBgIEBAIICAQCDAMGAAQGBgQEAAgABggABAQDBggKCAgCAgYEDAQCBAoIBgQCBgYEBgQGAgQEBgQGBAgGBgYABAYICAQGBgAEBAQEAgQEBAoCBAIIAAQGDAgCBAgCAgAEAAQGBQYGAgYEBgAICAACAgIEBAYCBAQCBAYEBgICAgQGCAAEAggCBAQABAYCBAQEBgICBAAIAgYDAgQGAggCBgQEBgIEAAQCAgICBAIIAAYEBAQCBgICBgQEBgQAAgQGBAIABgIGAAICBgQIAgAMAwIGAAICCAYACAIEBgQGAgIEBgACAgIEAAICBAgDBAAGBQIEBAMGBgIACAUEBQICAgQEAAIEAgQGBAAEAgQEAgYABAQAAgQEBgYABAQEAwIGAAIEBgIGAgIEAAIABAIDAgIDBAgACAIEBgIGAgQCAgAEBAIEBgIEAgACAgQCAgACAgAGAgACAgIDAgQDBAMCAgIEBAYCAAYDBAoCAAIIBAACAgIHBAAICQICAAQABAIDAgQEBAIABgYCAAQAAgMEBAAEAAQGBAIKAgQAAgICAgIDBAMGAwIJBAQGAwIAAgQAAgICBQIGAgYCAAIABAQCBAQABAQAAgIIAgACAAYCAgICAAICAAICAgQFAgACBAICAAIHAgIEAAIFAgUCAgIGBAICAAIEAwIABAAGBQIEAgACBAAIAAIHAgUCAAQCBQICCAkEAgYACAQCBgICAAQCBAIDBAIGBAcEAAIAAgIEAgIEAAQEAwICAgIABgICAgIFBAMEAgIDBAcGAgcCBAICAgAEAgACBQIEAgUCAwICAgAEBAQABAIGAgAEAgQDBAAIBAIIBAIEBAAEAgQAAgUGAAQCBAQEBAIABgACAgIDAgQCBAIAAgICAAICBAUGAwICAgIEAgICAgIAAgQABggFAgQCAgUCAgIGAgAEAwQCBwICBAMCAAIABAYCBQIAAgIEAgYCAgACAgIFBgICAwIEAAQAAgIABAIAAgIAAgACAgACAgACAgAGAwICBAMEAwIFBAACAAQCCwICBQQDAgICAgIABAcEAAIDBgACAAICAAIDAgACBQQEAAIFBgIDBgQKAgQDAgICBAMCCAACAgICCAIAAgIACAUEAAIEAgIABAQABAQABAAEBgACAAICAgQCAgIDBAACAgIEAAQDAgcCBAMCAgACBAIDAgIFAgACAgMCAhMCAgIEAAIABAICAAIAAgUCAAIFAgACAgIFAgQCBAUCBAACAwIDBAINBAICAgcCAgIABAQJAgIDAgAEAAIAAhECGwIJAgIFAg0CIQIDBAsCDwQAAgACEQIDBAACFwIdAgACCQIAAgMCCwICAwIPBgMCEQIZAgIHAgIPAgcCBQILAhMCMQIbBAIRAgIHAgACCwIRAgkECQIZAgIZBAMCBQIjBB0CDwIVAgIFAgINAgILAg8CRwITAgkCAAIbAk8CBwIHAgACDQI3AgkCFQJRAgMCRQI/BIcBAhUCGwI7AgACFwIAAgcCAAIAAg0CIQIDAhkCDwIvAkUCNQIbAgMCJwInAg8CCQICAwIRAi0CHQIlAhsCMQIvAlcCvwECSwL1AgLfBAJ7Ah0CqwECJwKPAQLLAgJ5AisEuQECmwECAAJVAusBAnECoQECMQKFAgLlCQJ7Ag=="
+        },
+        {
+          "operation": "composition_update",
+          "requests": 326,
+          "errors": 0,
+          "latency_ms_p50": 11.703,
+          "latency_ms_p90": 20.495,
+          "latency_ms_p99": 38.239,
+          "hdr_v2_base64": "HISTEwAAAkYAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAKcqAhcCEQJfAi8CHwJpAj8CBwI/AgcCEQKfAQIXAhMCDQIdBBsCAwIfAg8CAAIHAhECCwIjAgcCHQIdAgACIwILAhUCDwJDAgUCCQIFAhECDwIZAgUCLwInAgACEQIFAgACFwIVAiMCFwIJAnkCAgMCBQIAAgACAwIAAhMCCwI3AhcCGQIhAgcECQINAgMCAAJBAi8CDwIdAhkCEQJJAksCewI1AhECJwJlAnkCJQI7BAkCAgkEMwIFAjsEBQQCEwIJAiECHwIAAhECAwIPAgACAAIfAg0CAAIDAgkCDQILAhsCBwIEAgcCKQIFBgkCBQIAAgACBAMCAgMCAAINAgUCDQQFAgIDAhcCAAQFAgACBwIDAg8CBQILAgMCCQIHAgMCBwIDBBUCAAICAgACBQICAwIDAgACBwICBQIhAhUCCwIAAg0CAAQHAgAEAgIDAgQHAgACAAIAAgMCAAIFAhcCAwITBAcCAAQLAhMCAwIDAgUCBQICFQQFAgIFAgsCBQILAgIbAgcCGQJLAgsCEwIDAhMCDQIDAgsCCQIAAgIdAj8EDwQRAgsCVQIVAhcCIQINAgACAgcECQInAgACAAIZAgILAgMCBQQAAgACAAQDAgQHAgMCAg0CAAITBAMCAwIJAgIjAgUCHwIfAjcCEQIAAgMCDQIXAgIJAj8CCQInAgkCDwIJAqUBAiUCAAInAicCCQJrAjsCDQINAgkCpwECOwItAgMCHQJ3AhcCCQITAlMCCwINAtEDAjECqwECWQKrBwIdAg=="
+        },
+        {
+          "operation": "contribution_commit",
+          "requests": 115,
+          "errors": 0,
+          "latency_ms_p50": 38.719,
+          "latency_ms_p90": 47.359,
+          "latency_ms_p99": 67.775,
+          "hdr_v2_base64": "HISTEwAAANMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAANM6AmUCzwEC1wMCpQUCuQECmRMCJwKLAwIfAnUCDwI7AgUCHwIDAg8CAwINAgMCBQIAAgUCBQIDAgICAwILAgMCBwQCAAIHAgIAAgIFAgACEwIAAikCAgUCAgAEAAIDAhUCAAIAAgkCAgICBwINAgQJAgACBwIAAgMCCQQABAkCGwIFAgkCDQINAg8CAAIAAgMCAAQAAgACEwI3AgkCEQIZAgIXAgUCEQIEAgICAAIvAgsCBQIdAhECfQITAmECCwLBAgIbAk0CcQKNAQL1AQL3AQI="
+        },
+        {
+          "operation": "contribution_read",
+          "requests": 472,
+          "errors": 0,
+          "latency_ms_p50": 3.999,
+          "latency_ms_p90": 8.615,
+          "latency_ms_p99": 40.415,
+          "hdr_v2_base64": "HISTEwAAAyYAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAMsaAhMCQQL9AQI9AhECgwECOwINAgACQQITAj0CBQIZAgcCFwILAgMCAgACAAINAgUCDwInAgcCCQIDAgMGGQICCwIrBgsCFwIABAMCBQIHAgMCAwIHAgAEBwIAAgQDAgcCAAQCAAIDAgACBwQCAwIHAgACAgcCAgMGAgcCAAIDAgACAAICAAINAgUCAgUCAAQRAgMCAwIHAgIHAgYFBAkEAhcCBQIPAgACAAIHAgIPBAINAgACAAQHAg8CBwICBQINAgICCwIPAgACCQIJAgkCAAIAAgACBwICAAICBQIFAhcCBQIHAgIDAgIDBAICBwIbAgUCAgMCAwIDAhECBQQXAgkCAAINBAsCBwITBAACAgkCDwIFAgsCDQQCDwIDBAkCBAACAwICAAINAgICAwILAg0CBwICAAIHAgkCBwIAAgACEQIAAkMCEQIAAgQCAgcEAgITAgcECwITAgIDAgsCAAILAhEEBwIDAgMCIwIABAcCEwICBwIdAgcCCwIVAgACBQIJAgACBQIAAhMCEwIFAgMCBAIJAgIDAgUCBQIHAgACAgIAAgMCBwQAAgICAAICAAIJAgIAAgIFAgACCwIAAgUCAwIDAgMCCQIDAgINAgkCBAcCAgUCDwIDAgACCQICDQQlAgIHAhECAwILBDkCBwIDAgsCFwQPAgUCAgACAAIXAgQHAgkCAgUCFwIJAgcCBwIHAhUCAAIFAgILAhcCFQIFAgACBQYNAgcCFQIRAg0CFwIDAgUCDwITAgMCAAILAgcCDQIHAgUCBQIFAgcCEwQAAgcCBAUCAAIJAhcEGQIXAhkCCQIDAhMCDQIPAgIpAisCAAIFAhkCUwILAhECDwYbAgIRAkcCIwIDAhUCBQILAgsCBQITAgIRAhMCAAIXAgkCCwIPAhcCAgACCwILAgUCAAIHAgUCAAIdAh0CAgMCFwIJAgkCDwIDAgcCAgACFQIPAgkCOQIHAhcCEwIVAl0CmQECBwJXAgkCJQItAoEBAtUBAs8DAhUCGwLHAQIDAosBAiMCIwIvAk0CBQJDAvECAokMAokCArEHAp0CAuMCAgcC"
+        },
+        {
+          "operation": "directory_create",
+          "requests": 36,
+          "errors": 0,
+          "latency_ms_p50": 6.231,
+          "latency_ms_p90": 10.391,
+          "latency_ms_p99": 21.359,
+          "hdr_v2_base64": "HISTEwAAAFUAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAOclApkCAr8BAr0DAkcCvwECVwIhAhECJwJlAh0CQQIVAiUCuwECwQICywECUwQ3AoMBAnUCIwKFAQJhAi8CMwKRAwKHAQIdAm8CPwLDAgKFBQL3CAI="
+        },
+        {
+          "operation": "directory_read",
+          "requests": 4126,
+          "errors": 0,
+          "latency_ms_p50": 3.355,
+          "latency_ms_p90": 8.231,
+          "latency_ms_p99": 19.631,
+          "hdr_v2_base64": "HISTEwAACs4AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAIkQAo8DAncCHQITAhMCMQIDBgcCEQITAgMCAAIAAhMCBQIRAgMCJQJNAgkCBwIDAgUCAh8CBwINAgIDAgACBwICFwILAhkCBwICAgkCAgMCGwILAgsEAAQVAgIJAgMCAwINAgQCHQIlAgACAAIEBAACBQIDBgMCAAIAAgcCDwICAwQLBAQHAgMCBQIFAgcCAgQAAgACBwICAwICAAIAAgIDAgIEAgAEAAICAgQCAAICAAIFAgIPAgMCAgIGAAIDBAIDBAMCBwIHAgQDBAIEAAIFAgMCAwQEAAQCAAICAAIAAgIAAgAEAAIDAgcCBQIAAgQDAgIEAwICAgAEAAQCAAIABgICAgIAAgAEAgkCAAICBAICAgACBQIEAgQAAgICBAMCAAIAAgIABAIDAgIAAgAGAgMCBAIACAIABAAEBQICBAACAAgEBQQABAIEAgAEBgIEAgIEAAQHAgoABgIGAAIJBAQHBAIAAgAGBwYEBAICBAQCCAQCAgQEAgQCAAIABgQCAggICAQICgQGBAAECAAGAgQEBAIEBgoEBAYABgYDBAQCBgAECAoIAgYEBgYECAICBgQIBAYIBgIIBAYIBAIEAgYIAggEBAYEBgYEBAYMAgIKDAQOAgIGBgYCBgYCCg4CAgYGCAQIBAQEBAIIBgQICgYEDgQIAggIBAoGBA4QBAoCCAIKEAYKCgIGAgYGCAIKBgQIAggEBggGEAQKBAwKAAwGCAIKCgoEAgICChAGCAYCBAQKBAwCCAYICgoKCAQIAgYOAgYCEgQACggECAIEAAYICAAGCggEBAgECAgKBAgABAoABAQGCAwSBgIEDgIKCAQEDAYEBAYGCAQIBAYQBgQMBAwEEgYGDggGBggMBgQGAgIIAgQGEAYMAAQICgwCChAKDAYABAYICAQQBgQGBAYCBAQEBAYGCAYGBgwIAggIAgIEDA4EBAoGCAgCCgwEFAYKCAACAgIEBAoQBgICAgYEBgIEBAYGAAoEBAYOCAQEBgIIDAYGAgIOAgwEBgQEAggKBgQEBAgCAAIEBggEAgYIBAYIAgoIBAgEBgIGBgYEAgQCAgYGDAgEAgMCBAQIBAIICAYABgIIAAoEBgQIAgIGBAYAAgYDBgIECAIABAYEAgYEAAIGBggGBAQECAwIAAICBAQGBgQEAgACAgICBgQIAAQEAggCBgIIBAQCAAYEBAYGAgYEAggGAAYCBgQECgACBAIECAIECgQEBAQEBAYCCAACBAgABAYAAgYGBg4CAAgCBAIGAgwIAgYEBAoGCgoGAAgAAgACCAQGBAYEAAICBgIGDgMEAgIICAIGBAgEBAQCBgQEAAIEBAQIAAIACAICBAQABAIEBAQGBAQGBAACBgAIAAIABAICBAYEAwQGCgQIAgICAgAEBAgEAgIAAggEAAQIBAQIBAAGAgACAAQECAIABgYEAAYCAgACBgQAAgQABAYECAQCAgIIAAIGBAACCAICBAgCAgQAAgYGBAIAAgICAAICAAQEBgQGAgQDAgICBAIHAgQFAgIFBAAEDAMCAAYCBgICBAAIAwQEAAICBgAEAgAEAgcCAgIDAgQABAMCAgQEAwQABAYAAgAEBAcEAgIABAYCAgAEBAYCCAQEAAICAAYCAgACAgQCBAMGAgQEAgQEAgUCAgIEBAQAAgQCBggCBQIKBAMEAgIABAAGAAICAgACBgQABAIEAAQAAgQFBAYIBAMCAAQEAgMGBgIGAAICAgICAAIEBgIECAACAAICBAIABAMIAgICBgQEAAIAAgMCBgIAAgQEAAICCgICBgIGAgIACAIEBgYABAAKBgYEDgIGCAgCBgYGAgIGAgIECAYIAAYDBAYCBAIKCAgGBAQIAgQEAgQGBgIGCAICAgAEAgQICAQAAgYEAgQCBAAEAgIDAgQGBgIEAgIAAgQCAAQAAgYCAgICAgYCAAIEBAQACAQECgQCAgYABgIKBgQGBgIABAgEAgQABAAGAggCAgIEAgACAgIAAgAGAgAEBAQCBgQEBgQIAAIAAggABAACBAIECgQECgIIBAAEAAYEAgICAAQEAwIEAAYEBAgCAAIAAgQCAAQGBgACBAgFBAYEAgIAAgIFBAIABAYGBAwCAgQEAgYKAgICAgYCAgIEAgIEBAUECAQCAgMCAAICBAIEAAQCBAICBAIEAAIGAwICBAIKBAQGBgYKBgMGAgIGAAIDBAQABAYAAgMEDAYCBgYABAICBQIEBAYABgIAAgIEBAQEAwQAAgIEAAICAgICAAQAAgYCBAAEAAYAAgAEAAQDBgMCAAQEAAQCBgACAgIGBAIEAAQDAgIGAgICAgACAgAGAgIEAggAAgIAAgUGAgQDAgYCBAACAgQCBAACAgQEBAACAgIGAgQAAgACBAAEAgQEAAIABAQGAgYCBAQAAgACBAIAAgAGAgQCBAIAAgAGBgMCAgIEAgYGAAIABAYCBAICBAQCAAwABAIEAgYAAgICBAICBAACAggDCAYAAgQGAwYCBAACAAICAAQFAgQDAgACAgQAAgMEAAYDAgQABAQEAgIDAgMCAgMCBwICAAICAgACAAIAAgkCAAQAAgMCAgACAgAGAAQCAgACAgQABgUCAAQEBwIGAgQCAwQCAwIABAICAgIAAgQLAgACAgICAAQGAAQAAgACBAIHBAIDAgIABAACAAQCBwICBQIECQQCAgQCBwICAAIDAgcCAwICAgMCAwIAAgMCAAQCBQIAAgQAAgIDAgQAAgAEBgACAAQCAAIAAgAGAAIDAgUEAgsCAwQCAwIEBAACAgIHAgIDBAIAAgACAgQCAAIFAgYHBAICAgMCBQIEAgMCAgUCBAACAwIAAgIEAgAEAwIDAgACAAIDAgUCAAQEAAICBgACBhEGBAcCAAgAAgQAAgICAgIAAgQFAgIEBAUEBAQNBAICBAIABAACAAIGBQQCBwQAAgQEAwQDAgQAAgICAgQAAgACBAICBAIDAgACAAYAAgMEAgICAgUEAgIAAgQEBAIIAgQAAgQCAwQCAgAEAAQGAgICBAAEBAAGAgAGBAQCBgIABAACAwYACAIEBgIAAgICAAICBAIGBAMCBAICAAQAAgACAgQCBgQCAAIGAwQCAAYCAAIEAAIGBAMEBwQAAgYCBAACAgQCAAIEAAYAAgACAAQAAgMCAwICAAIHAgMCAAICAAQEBgIDAgACAgMCAAQJAgUCAAIABAMEAgICAAQDBgUEAgICAwQFAgAGCwIAAgICBwQAAgAEAgUGAAIAAgICBAIEBwQCBAMCAAIAAgACAwIDAgACAgIAAgIHCAIFAgACAAYDBAMCAAIPBAQCBQQAAgACBwIDBBUCAgMCDQIFAgQJAgMEAgMCFwIAAg0CAAIAAgIDAgACAAQDAg8CDQICAwICBQQCBQILAgACBQIRAgUCAAITAgcCCQILAgUCIQICAgsCAgkCDwIAAg8ECQIRAhkCEwIfAgsCAg8CBQIZAhMCDQIFAlMCDwI3AhMCLwJ5Ai8CJQIDAikEGQI7AkkCKwIrAhcCGQIlAh8CEwIfAgIHAgkCRQIRAgACAwICCwIJAl8CGQIHAisCLwIrAv0BAh0CNQIPAmkCAwLLAQI3Ah8CPQI/AqUCAlcCAg0CHwIzAhsCGQJtAmECFwL9AQLTAgICiQEClQECxwMCSQLBAwITAhUCXQIJAqsIAg=="
+        },
+        {
+          "operation": "directory_update",
+          "requests": 58,
+          "errors": 0,
+          "latency_ms_p50": 5.475,
+          "latency_ms_p90": 9.159,
+          "latency_ms_p99": 27.743,
+          "hdr_v2_base64": "HISTEwAAAH0AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAOcjAqUCAnsCGwIVAk8CEQIjAgACmwECLwJLAiMCFQJzAlkCQQJtAk8CXQIRAh0CEwKxAQIpAj8CFQLNAQJxAi0CqwECBQICfQIlAh0CswECOQKNAQJxAmcCEwIhAikCfwIXAjUCAhMCNQIDAgKbAQIbAgAC9wQC1wwCoQcC"
+        },
+        {
+          "operation": "ehr_create",
+          "requests": 58,
+          "errors": 0,
+          "latency_ms_p50": 4.771,
+          "latency_ms_p90": 8.375,
+          "latency_ms_p99": 86.911,
+          "hdr_v2_base64": "HISTEwAAAIAAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAP8jAgkCHQKHAQI/AiUCBQJHAnkCwwECMwIrAkcCNwITAikCowICIwJTAicCIQJTAjkCAAKTAQITAgcCMwRTAm8CEwIPAg0CEwIHAiECOwLnAQIXAg0CLwIpAkUCiwECRwIjAosBAhUCLQIAAgcCuwMC3wUCuQgCtQQC8QECoSAC"
+        },
+        {
+          "operation": "ehr_read",
+          "requests": 421,
+          "errors": 0,
+          "latency_ms_p50": 4.395,
+          "latency_ms_p90": 7.307,
+          "latency_ms_p99": 20.623,
+          "hdr_v2_base64": "HISTEwAAAsIAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPkXAh0CWwL/AQKZAQJLAgsCMwINAhsCMwInAgACOwJBAkkEAAIDAjUCJQIXAgACJQIHAgITAgsCJwIdAgACAAINAhMCAwIbAgUCKwQhAiMCCwIJAiUCBwIHAg8CGwINAgMCBwICAAIDAg0CDwICBAUCAhECAgMCAwICCQIFAg0CDQIRBAsCJwITAgACBwINAgcCEwIDAgUCCQILAgACDQI1AgMCAwIVAgINAgUCAh8CBQIAAgIDAgcCAwIFAgUCBwITAhMCCwINAgACAwIAAgACAgkCCQIDAhMCCQICEwIGCwICBwILBAkCAAIFAgIHAgcCAAICCwICAgsCDQIFAgIbAicCAAQHAg8EAAQNBAIEDwILAgMCAAIRAgMEAhMCAAIABAkCCQICEwQLAg0CBQICCwIpAgsCCwIRAgMCCwIJAgIDAg8CAAQDBAIFAg8CAgMCBQIAAgAGBQIAAgkCDQICAgMCAAIDAgIDAgMCAwIAAgcCBAICCwQCBwIFAgcCDQIFAg8CAAIjAgkCJQICCQIZAgACAwIJAgIAAgICBAACAwILAgcCAwIHAgcCBQIbAgACDQQHAg0CAgMCDQIHBA0CAAQFAgcCAwIEAAQAAgkCAwICAwICBwICDQICBQQCAwIAAgACAAQLAgUCAgACAAIAAgMCAgcCDQIDAg8CFQIAAgICBAMEAgkCDwICBQYCAwICBQQCAgUCCwICAhECCQIJAgACDwYTAgACCwIJAgsCDQILAiUCBAAGIQQDAgMCAAIRAhcCBQICEQIDAiECAwICAAIAAgIhAgcCDwIDAgkGJQJTAgUCCwIjAgsCKQInAisCHwICMQIbAgACTQIbAgsCBwIRAiECHwIJAgACBwJXAm8CcQIxAhkCyQECVwKBAgJjAicC6wMCNwJ5AgKFAQKxAgLjAQLFBwL5CgLnAgLNDgI="
+        },
+        {
+          "operation": "ehr_status_read",
+          "requests": 116,
+          "errors": 0,
+          "latency_ms_p50": 3.263,
+          "latency_ms_p90": 5.811,
+          "latency_ms_p99": 28.383,
+          "hdr_v2_base64": "HISTEwAAAOUAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAMMcAgkCKwIPAmUCAhsCiQECIQI7AisCIQIZAhkCGwIfAgJhAgJFAgUCJwIHAhECGQIXAhECCwICAwIDAhECJwILAhMCDwIdAk0CIQILAhkCAAIRAh8CFwICCwIdAhMCBQIAAhMCAAIDAgITAiECUQILAh8CBwIZAgMCBwJLAlUCAwI3AhsCEwIRAgcCLQJ/Ah8CUwIHBA8CAhsCeQIDAgMCDQIdAg0CEQIXAh0CMQIVAjkCRwIhAh0CXQIXAgkCQQJhAhcCEwIAAgUC1QECbwJdAmMCCQKVBQJ1AgLdAwLxFgK1GgI="
+        },
+        {
+          "operation": "ehr_status_update",
+          "requests": 108,
+          "errors": 0,
+          "latency_ms_p50": 5.543,
+          "latency_ms_p90": 9.791,
+          "latency_ms_p99": 27.583,
+          "hdr_v2_base64": "HISTEwAAANIAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJ8mAm8CIQIZAiMCPQIZAoUBAjMCPwIbAgACCwIlAgACWwILAgACEQLxAQJHBEsCAi8CRQIJAgsCAAICAgcCGQIDAgIjAhECNwI1Aj0CAAIXAgUCIwIHAjcCAk8CCwItBAkCHwIHAgIrAgkCBwIDAgITAhMCBQIdAjcCGwItAiMCMQJVAi8CHQIDAgIAAh8CUQJFAgcCPQJDAjsCLwJxAoEBAnkCQQIJAjECHQIRAgIhAgICKQICPQJbArsBAhsCIwKPAQLVAgJPAt0LAukEAtsLAg=="
+        },
+        {
+          "operation": "stored_query_execute",
+          "requests": 872,
+          "errors": 0,
+          "latency_ms_p50": 11.431,
+          "latency_ms_p90": 21.119,
+          "latency_ms_p99": 62.143,
+          "hdr_v2_base64": "HISTEwAABKUAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAM01AsUBAgACUQINAhUCKwIFAgACAgcCEwIFAiMCAAIHAgkCKwIJAgsCAgMCDwIVBAMCAAQCAgkCBwITAgACBwICDwIFAgcCAAIFAgIAAg0CAAQFAgIFAgsCAhMCAAIFAgIFAgACAAIHAgACCwIFAgcCAwIABAACAAQHAjMCAgACAAILAgsCAAIDAiEEBQIEAgMCAgIRAgIAAh0CAAIAAgACCQICCQQHAgUEAAICBQIDAgMCAwIPAgIFAgQFAgMCAAIJAgIDAgIEBAMCDQIABAAEAgACAAQABAIAAgACBQICAgICAAIGAwQCAAIAAgICAgIABAACBAQCAgACBgQDBAcEBgICAAIDAgcCAAICAAIDAgIEAgIAAgMCBAQABAACAgICAAIDAgICBAMGAgQEAAIEBQQCAwIGAAICAAQAAgIABAICBAACAAQCAgMGAgQCBgUCBAQEAgYCBAIABAIEAgQGAwIAAgIAAgICAgAEAAIDAgACBQIDAgACAgACBQIEBAIGAgMCAgMCAAQAAgIFBAICAgIDAgAEAgIDAgUCBgIAAgIEAgACAgICBAIAAgACBAMCAAQAAgIDAgQDAgMCAAQCAAIFBAACAwICAwIAAgkEBAAEBwIDAgIGAwICAAQCAgICAgMEAgIJAgcEBQIAAgUCAgMCAgMCAgACAgQCBQICAAICAAIDAgMEAAYCAAICAgQABgIEAgMCBQICAgIFAgICAwQAAgMGAgIJBAICBAIHAgQFAg8EAAIHAgACAgIDAgQAAgACAwIDBAICAgMCAAICAwIEAAIAAgACBQIFAgIEBQICAgIDAgICAAICBAAEAgICCwIAAgMCBQIAAgMCAwICAwICCQICAAQFBAIFBAcCAAICAwQCAgIJAgICBAMCAgICAAICAAICAAQJAgsCAgACHwIDAgIFBgACBAMCAwQDAgICAgAEAgQDAgACAgUCAgkCAgIAAgICCQIEGQIHAgkEEQIAAgQEAwIFBAACAgsCBQQJAgACAgMECQIAAgAEAgICCwIHAgICBQQFAgMCAwIDAgICAgACAwICAgUCAAICBQIAAgkCCQIJAgMCAAIDAgcEAgICAgIAAgQHAgMCBQIFAgMCAgkCAgIXAgACBQITAgIFAg8CAAIEAAQDAgUCAwICCQIJAgIABAMCGQICIwICCQICBAACBAUCBwICAhUCAgIAAgMEAAIABgkCAAIHBAcCAgIDAgMCAgIAAgACAAIAAgIFAgIJBAAEBwQCAwICBQIDAgACCQIEAg8CCQICAwILAhECAAIJAgQJAgMCBQIAAgIJAhECCwQCAgsCDQIABAkCBQICAwILAgIZBBUCAAIfAgsEAgIRAgkCCQIFAgMCDwITAgcCIQILAg8CEQICGwQNAhcCAAIRAgUCFwIJAi0CBwIJAgMCEwILAgUCAAIvAgsCDwQPAh0CGwICCwIXAg0CEQIHAjsCEQIfAncCIwJ7AkUCCQINAiMCAAIfAhMCTQJFAgIVAhUCBQIpAhkCOQInAksCTQIDAtsBAr0BApcCAuEBAqUBAm0C2wECuQEC1QMCqQECpQECDwLXAQLHAgLjAwI="
+        },
+        {
+          "operation": "tags_put",
+          "requests": 145,
+          "errors": 0,
+          "latency_ms_p50": 4.103,
+          "latency_ms_p90": 10.063,
+          "latency_ms_p99": 42.623,
+          "hdr_v2_base64": "HISTEwAAASIAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAOcgAkECFwJVAmkCBQIDAjsCKwIbAgACHQJTAjkCEQILAk8CCwIDAgMCIQIFAgcCAwIfAiECEwINAiUCKQICBQIHBB8CEwIfAg0EAiECCQIdAh0CAAIDAhsCAAIdAhsCDQQFAgUCAAIHAhkCCQIbAg8CCwIDAisCSQITAiUCEwJHAgACBQIVAmkCAAIJAgACAwILAgACBQIAAgMCDQQAAh0CFQINAg8CUwIbAgMCBQITAgMCAgsCDwIDAg0CBwI7AiECnQECCQI3AnsCAoEBAgcCZwKLAQIbAgcCJQIJBJUBAjkCNQIbAkECdwJ7AlsCMQIfAg8CpQEChQECIQIbAnUECQKlBgLJAgI7AjcCkwECgQEC1QECxQECmQICyw4CvwoC"
+        },
+        {
+          "operation": "tags_read",
+          "requests": 146,
+          "errors": 0,
+          "latency_ms_p50": 3.083,
+          "latency_ms_p90": 7.347,
+          "latency_ms_p99": 10.679,
+          "hdr_v2_base64": "HISTEwAAARMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPEWAgkCGwKRAgJDAlECmQECCQIrAhsCGwIbAicCGwSVAQJHAg0CBwJbAiECJwICBQIHAgIDAh8CAgcCAgsCGQIjBAACAg8CEwIFAhUCBwIXAgUCAAITAhcCAgMCBQI1Ag8CCwITAg0CAgIdAgQCEwICSwI1AgUCUwIFAg8CDQIZAg8CSQIpAjMCJQIRAgACCQIDBAICDwIxAicCAAIXAisENQJnAisCFQIPAg0CAwIjAikCLwITAgcCfQIDAnsCbwJLAh0CAAIDAgINAjECKQIAAmsCBwJFAj8CFQIHAjMCTQKJAQJ9Ai8C2wECSwJ9AgsCBwITAkMCPQIdAj0CgQMCJwJBAgI9Al0CJQIDAmkCnQ8C"
+        },
+        {
+          "operation": "template_get",
+          "requests": 363,
+          "errors": 0,
+          "latency_ms_p50": 13.383,
+          "latency_ms_p90": 31.359,
+          "latency_ms_p99": 52.159,
+          "hdr_v2_base64": "HISTEwAAAqoAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPUWAs8CArkCArMBArcBAo8BAm8COQIlAiMCHQIHAhUCDwJlAhMCKQIXAisCMQIzAgkCFQIdAgI9AkcCEwIDAiUCAlcCBwJPAlsCFQJDAj8CJQIPAj8CGwIbAgkCJQIRAjsCMQIbAiMCQQIzAiUCEQIDAhcCTwINAgMCFwIEHQIXAjsCFwJDAiUCUQIDAhcCKQJxAh8CCwIXAgACDwINAgUCUwIVAgkCBQIVAjMCHQIbAgkCAgACMwIHAhEEHwIvAh0CCQINAgACRQIdAgMCAg0CFQITAgcCBwI1Ag0CDwIHAh0COwIFAh8CRwIfAg0CHwIFAg8CKQIZAiMCAAILAj8CBQIAAgkEDQIjAhMCCwIXAisCCQIJAgIRAhUCNwICEQIFBAACAgcCDwIxAnMECwIHAgcCAAIfAhMCFQIRAm8CAAINAhsCHwIRAhsCBQIhAjMCGQIHAgUCRQILAi8CBwIhAjECLwJPAh8CFwIJAg0CBwJNAhkCSQIAAgUCHQIrBAACFwIvAh8COwIRAhkCFQIJAgcCDQICFwIHAgcCBQIFBBUCJwIHAg0CAgsCCwIABAkECQIAAg0CCQICGwIJAhMCAgACAAIAAgUCEQIZAhMCAAICAAQFAhMCDQIHAgACEwIRAgIPAgMCAAICAwIFAgcCCQICCwICGQIJBAACJQIHAgUCAgMCGwIXAhcCJQIECQILAgcCAAYRAgkCCwIJAgACAwInAgUCDQIRAhsCBQJdAgACJQIVAgUCAgsCAAIJAhECDwICCwIlAgMCHQIxAikCEQI3AkECAAITAhECDwILAhECLwI7Ag8CDQIdBAIHBAMCDQITAikCBQIvAg0CFQIjAhMCJQIAAgIFAmkCBwIfAhUCNwIhAgsClwIC3QECaQLBBAKnAgKJBQI="
+        },
+        {
+          "operation": "template_list",
+          "requests": 364,
+          "errors": 0,
+          "latency_ms_p50": 2.653,
+          "latency_ms_p90": 5.919,
+          "latency_ms_p99": 14.111,
+          "hdr_v2_base64": "HISTEwAAAmUAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPcSAtUBAh0CAtkBAisCKQIvAgACCQJdAq0BAgsCMQINAhcCBQIAAh0CAwIXAhkCNwQDAgcCAhEEDwITAgMCBQIdAgkCBwIAAhUCAAINAgICAwILAhcEGwINAgAEBwIXAgkCDQILAgACAwIFAgsCAAICBwIbAgsCAwIfAgcCAgACAAQLAgsCAAQAAgQFAgACHQIECQIAAgACAAIJAgIAAgIAAgcEAgcCAgUCAAQAAgIEBQICAwIGAgACAwIAAgACBQICAAQAAgICAAIFAg0CBwIFAgACBAACAAQDAhUCAAIPAgcGBwQLAgMEAgQCIwIJAgACAwIABgACAwIAAgACAgMCAgACAgMCAwIHAgINAgMCBgkCCQYDBAMCBQIFAgkCBAsCAg0CAAIHBg0CBQQAAgQDBAACCwIPAgACAgMCEQIHAgAEAwIAAgACDwIFAgUCBQIFAhsCAwIJAgMCAAIZAgACGwIVAgIPAgUECQQTAhcCBQQEBwQPAgkCDQIAAgcEBQITAgACAwI7AgMCAAICBwIhAhkCCQICAgACDQIFAgkCCwIFAgACEwIAAgMCAAITAgcENQJlAh8CPQILAgIdAhECDQJPAj8CAAItAhcCEwIZAiUCAwIdAgUEAhcCIwIDAhUCAAQDAhMCAAIvAh8CCwIJAgACFwIZAgUCOwInAgcCAwIDAiUCBQIVAicCgwECBwI1AgIVAjUCIwJtAgACCwIAAgMCQwIjAj0CQQKXAQIvAnMCiwECnwICAAIrAhcCKwI9AjsCDwI3AkECaQJLAr0BApcBAl8CawLlAQKFBAKhDwK5CwI="
+        },
+        {
+          "operation": "ward_query",
+          "requests": 871,
+          "errors": 0,
+          "latency_ms_p50": 123.711,
+          "latency_ms_p90": 184.447,
+          "latency_ms_p99": 306.175,
+          "hdr_v2_base64": "HISTEwAAA2QAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJ14Ag8CCQICAgACDQIAAgcEAwQDAgMCCwIDBAICAAIABgYCAAYCAgsCAgIDAgQFAgYCAgAEBAgDBgAEAgMCAgIGAgICAgAEBgQEAgICAgACAgICAAIGAAQEBgACBAQCAggGBAMGAAQAAgQCBAIEAwIABgIDAgYCAgYEAAIEAgQEBAQDAgACBAQEAgYGBAACAgMCAgYEBAACBAQABAICBAACAAQDAgIABgYCAgMCBgQEBAIKAAIIAAoEBAIECgIEBAICAgYIAgQEAgQAAggCBAIGBAAGAgYCAgIEBwgCBgIGAgICAgQCAgACAggCBAMCAggEAwYDAgIEAgQACAIDBgIEBAAGAgIDAgICAgAEBwQDAgYCAAIGBgICBAgDBAQIAwICBAICBAIEBAAIBAIEBAQCAAICAwIEAwIEBQQEAAQCBAUCAAIFAgMEAgQAAgIABAICAAIEAAIAAgIEBAQCAwICAgQAAgAEAAICAgYFAgACAgQCAgICBAQCBQQDAgACAgUCAAQFAgACAAIABgIAAgQCAgUEAgIEBQIAAgUCAgICAAIEAgQDAgAEAAICBAQAAgIEAAQGBAYABAIEBgICAwIEAAoDAgICAwQEAgIEAAYFAgQEAgACBAACAAQCAgYCBQYDAgIEBgACAwICAAQCAwIGAAICAAIACAYCAgACAAQDAgAEBAIFAgUCBAIGAgICAAICCwIJAgACAgAGCQIFAgMCAgMCAgsCAgYCAgACAgACAAICAwIABAUCAgMCAgIFAgICAgMCAAIDAgIFAgACAwIFBAUCCQQAAgUEAwICAgIDAgIFAgUCBwQDBgUCAgACBQQAAgACAwIAAgAEAgcCBQIAAgQAAgIDBAIDAgMCAAQEAgMCAAIABAUCCwIDAgACBgkCAAIFAgIJAgACAgACCwINAgUCAwICAAIAAgACAg0CAgUCAgAEAwINAgsCBQIFBAUCCwITAgAEEwICAgkCCwIFBAMCAAIDAgACAwITAgMCDwICAjcCAAIfAkkCAwIVAgUEEwIRAgMCBQIAAhUCAAICAAIAAgkCCwIAAgACBQIpAgMCFwITAhkCIQJBAgkCAAJbAhkCKwJZAgkCNQITBDUCHQIXAhECEwJrAhsCEwIzAncCJwJbAgACKwKDAgKxBAL5AQI="
+        }
+      ],
+      "stable": true,
+      "generator_bound": false,
+      "resources": {
+        "sample_interval_s": 10,
+        "containers": [
+          {
+            "role": "sut",
+            "name": "ehrbase-rs-ehrbase-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 65.5587315488117,
+                "rss_bytes": 334045184,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 4986167600,
+                "net_tx_bytes": 8133318410
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 45.703380658815206,
+                "rss_bytes": 340422656,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 5036366733,
+                "net_tx_bytes": 8150559558
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 28.69908742853791,
+                "rss_bytes": 346955776,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 5078631381,
+                "net_tx_bytes": 8167720423
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 30.172329051825987,
+                "rss_bytes": 350957568,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 5128921802,
+                "net_tx_bytes": 8184920210
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 27.404183415708427,
+                "rss_bytes": 354443264,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 5186813135,
+                "net_tx_bytes": 8201941557
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 26.760739951541346,
+                "rss_bytes": 348520448,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 5235432211,
+                "net_tx_bytes": 8218979955
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 33.18463703565248,
+                "rss_bytes": 352550912,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 5289570357,
+                "net_tx_bytes": 8236296479
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 30.220505258720177,
+                "rss_bytes": 342024192,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 5339498059,
+                "net_tx_bytes": 8253594479
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 30.189886698263603,
+                "rss_bytes": 352460800,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 5390957783,
+                "net_tx_bytes": 8270873107
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 37.002243112684866,
+                "rss_bytes": 352817152,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 5441670995,
+                "net_tx_bytes": 8288247508
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 25.634497693465295,
+                "rss_bytes": 352686080,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 5476843650,
+                "net_tx_bytes": 8305186782
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 30.350370308173417,
+                "rss_bytes": 354058240,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 5528330843,
+                "net_tx_bytes": 8322574255
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 33.66390907590576,
+                "rss_bytes": 354652160,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 5574007922,
+                "net_tx_bytes": 8340226766
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 34.60567815451941,
+                "rss_bytes": 356745216,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 5625386573,
+                "net_tx_bytes": 8358733536
+              },
+              {
+                "offset_s": 150,
+                "phase": "drain",
+                "cpu_pct": 34.9888531864867,
+                "rss_bytes": 355434496,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 5672577362,
+                "net_tx_bytes": 8376816726
+              }
+            ]
+          },
+          {
+            "role": "db",
+            "name": "ehrbase-rs-ehrbase-postgres-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 322.60310917239485,
+                "rss_bytes": 2452017152,
+                "blk_read_bytes": 5194637312,
+                "blk_write_bytes": 47352643584,
+                "net_rx_bytes": 7415840419,
+                "net_tx_bytes": 1752922719
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 223.18615335501875,
+                "rss_bytes": 2452410368,
+                "blk_read_bytes": 5252689920,
+                "blk_write_bytes": 47422513152,
+                "net_rx_bytes": 7429702650,
+                "net_tx_bytes": 1798406937
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 139.33836350028153,
+                "rss_bytes": 2504097792,
+                "blk_read_bytes": 5304668160,
+                "blk_write_bytes": 47530893312,
+                "net_rx_bytes": 7443499982,
+                "net_tx_bytes": 1835926334
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 144.60427918021944,
+                "rss_bytes": 2455945216,
+                "blk_read_bytes": 5379706880,
+                "blk_write_bytes": 47627034624,
+                "net_rx_bytes": 7457296561,
+                "net_tx_bytes": 1881590014
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 133.47241646190378,
+                "rss_bytes": 2465951744,
+                "blk_read_bytes": 5449457664,
+                "blk_write_bytes": 47696297984,
+                "net_rx_bytes": 7470841689,
+                "net_tx_bytes": 1934891774
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 131.19831329758793,
+                "rss_bytes": 2468737024,
+                "blk_read_bytes": 5496492032,
+                "blk_write_bytes": 47790989312,
+                "net_rx_bytes": 7484478831,
+                "net_tx_bytes": 1978874554
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 160.88573638156947,
+                "rss_bytes": 2468175872,
+                "blk_read_bytes": 5555220480,
+                "blk_write_bytes": 47882772480,
+                "net_rx_bytes": 7498341199,
+                "net_tx_bytes": 2028269384
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 149.11104503567705,
+                "rss_bytes": 2476494848,
+                "blk_read_bytes": 5606735872,
+                "blk_write_bytes": 47946883072,
+                "net_rx_bytes": 7512226998,
+                "net_tx_bytes": 2073472868
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 143.9870293700586,
+                "rss_bytes": 2528288768,
+                "blk_read_bytes": 5700571136,
+                "blk_write_bytes": 48036167680,
+                "net_rx_bytes": 7526094746,
+                "net_tx_bytes": 2120279769
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 169.9426091150511,
+                "rss_bytes": 2479550464,
+                "blk_read_bytes": 5827801088,
+                "blk_write_bytes": 48128057344,
+                "net_rx_bytes": 7540037937,
+                "net_tx_bytes": 2166218455
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 131.67858440948126,
+                "rss_bytes": 2477723648,
+                "blk_read_bytes": 5963337728,
+                "blk_write_bytes": 48223272960,
+                "net_rx_bytes": 7553678970,
+                "net_tx_bytes": 2196805110
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 139.787928430149,
+                "rss_bytes": 2528256000,
+                "blk_read_bytes": 6089351168,
+                "blk_write_bytes": 48294051840,
+                "net_rx_bytes": 7567641935,
+                "net_tx_bytes": 2243576528
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 154.801897680588,
+                "rss_bytes": 2531090432,
+                "blk_read_bytes": 6241763328,
+                "blk_write_bytes": 48391880704,
+                "net_rx_bytes": 7582009256,
+                "net_tx_bytes": 2284285741
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 170.124566054437,
+                "rss_bytes": 2418331648,
+                "blk_read_bytes": 6369062912,
+                "blk_write_bytes": 48493441024,
+                "net_rx_bytes": 7597116522,
+                "net_tx_bytes": 2330551556
+              },
+              {
+                "offset_s": 150,
+                "phase": "drain",
+                "cpu_pct": 167.98122454764274,
+                "rss_bytes": 2412081152,
+                "blk_read_bytes": 6522552320,
+                "blk_write_bytes": 48629665792,
+                "net_rx_bytes": 7611969080,
+                "net_tx_bytes": 2372694118
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "rate": 512.0,
+      "offered_load_sustained": 517.1416666666667,
+      "operations": [
+        {
+          "operation": "adhoc_query",
+          "requests": 8135,
+          "errors": 3004,
+          "latency_ms_p50": 3299.327,
+          "latency_ms_p90": 7335.935,
+          "latency_ms_p99": 12009.471,
+          "hdr_v2_base64": "HISTEwAAF68AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPcKAu8CAjkCNwIrAosBAj0CNwICIwI/Ah8CFwIjAgsCBQIjAhkCBQJfAhECCwJLAicCAwJfAgUCBwQpAg8CIwIHAhkCEQI/AgkCDQI7AkECEQILBBUCAwIJAgcCCQItAikCAwIpAiMCDwIPAgIAAh8CEwIpAgkCOQIJAgcCMwIDAhECAAIlAg0CAg0CDQINAgsCHwQFAgACBwIRAhECEwIAAgMCAgMCAAIEDQIJBAIDAgIPAgACAAYFAgICHQIFAhECCwIJBAINBAUCDwICAgIHAgIDAgcCBwQPBAUCBQINAgMCAgACAwICBQINAgACAgUEAwIFBBECAwIAAgACAhkCBAsCBAIFBAsCBQICCwICAAIAAgMCBAACAgMCAwIAAgACAgMCBwILAgACCwIAAhMCBQIABAAEDQIDAgIFAgIDBAsCBwIGBQICAgICAgACAwQCBwINAgQHAgACAgAEAAIHBAcCCwIDAgAEBwIDAgACBQQJAgACAgQNAgMEAgUEAAQAAgQAAgIHBAUCJQIAAgAEAAIAAgcCAgACAgUCAwIDAgMEBQIAAgIAAgACAwYHAgIHAgcCAgMCAwILAgMECwICCwIDAhsCAgIDAgIHBAACBAUCAwIFAgQHBAIFBAMCAg8CCQICEQIAAgIHAgkCAAIDAgMCBQICAgcCAAIDAgUCCQQRAgIDAgQCAgIFAgICAgAEAgMCAAICAAIDAgIFAg8CAwIDAgcCBwILAgACBQIAAgACBwIAAgAEAAIFAgkEBAIAAgQAAgcCBwICAAICAwIDAgACEQIFAhsCAgIFAgcCBwIRAgUEAwICAAICAgIFAgMCAAIAAgUCAgIAAgACAAIDAgcCAgsCEwQAAgQECQICBQICBwICCQQAAgMCBwICAAIAAgIEAwIABAICAgkCBgIFAgICAhsCAAIDAgIAAgIFAgcCBQICAgACAAIVAgMEAgIABAIFBgIFAgIAAgMCAgQCAgUCAAIAAgQAAgMCBwIEAgMEAgMCCQICAgACAgIHAgACAgACAAQAAgICAgACAgIAAgMEAgIAAgAEAAIAAgQCAAQCAAQFAhMCAgMCAAIEAgMCAwICAwQFAgACCQIAAgUCHQIEAAQEAwQCBAMCBQIGAgIHAgQAAgUCBAIAAgUCAwQCAwIDAgMEAgQHAgUCAgcCAgICAgAEAAIAAgIAAgMEAAIDBAMCAAYCAwIEBAIHAgIEBwIFAgICBwIABgIAAgMCCQICAwIAAgIDBAICAgICAAIJAgIAAgMCBwIABAMCAg0CBQICAgQHAgIDAgUCAAIAAgMCBAACAAYDAgMGAgACAgUCCwICBQIABgACCwQCAAIAAgMEAAICAAICBQIDAgQABgcEAAIJAgIDAgQCAggCBwIHBAACBAACAgIAAgIDBAUEBAAEBAACAgUCBwIVAgACAAICAgACBQQAAgMEBQIJAgUCAgACEwIDAgAGCQQFAgIHAgICBQQAAgQCAgcEAgMEBQIGCwIFAgIDAgACAwIDAgMCAAIAAgIAAgICAAIAAgIFAgUCAAYAAgACAwQHAgcCAgACBwICBgQCBgIDAgkEAgIEBQICAwYAAgMCBAAEAgMGAgACAwQABAIFBAIAAgMCAAQCAAIHBAICAgMCAgsCAAICBwILAgICBAICBQIAAgACAgMEBAIHAgIAAgMCAgMCAAQGAwICAwIHBAMCAwIAAgQEAAICAAICAwIEAgUCHQQJAgACAwIHAgIAAgIJAgACDQQCAgACBwICAAICAgICAwQFAgICAgYCBAIABAQFBAAEAgUEAAQDCgICAgAEAAICAgIDAgIFAgIDAgQAAgICAgIFBAICAwIDBAICBAICAgQCAgACAAQEAAQEAAICBAIAAgIECQIDAgICCAAEBAgABAAGCAMCAAICBAIEAgICAAIEAgIABAUEBAMCAwICAgACBAQCAgIEBwQCAgIAAgUCAAQAAgYABAkCAAoCBAUCBAYAAgMCBAAEBQIEAgACBQIEAwYKAwIABgIGBwIFAgIAAgQEAAIABAkCAgACAgICAgICBQQCAAICBQIABAYEBAMCAgQAAgQCBAAEAAICAwQAAgUCAAICAgACAgMEAwQAAgACBAACAgIAAgQAAgcEBAACAgUCAgIEAgILAgMCAgMEAgACBwIAAgMEAAQCAwICAwQLAgMCAgMEBQICAAgABAACAgIABAICAAICAAYCAAIJAgMEBQIGAAIAAgIAAgACBAIABAIABAcCAAQHAgICAgYEAAIRAgMEAgUCAAQFAgYFAgIEBAcCAAIAAggJBAIFBAcGAAIPAgUEAAQLAgICAwYFBAUCBAIFAgACAwIDBAMCAgIABAIDAgIHAgIHAgMCAAIDCAIFBAACAwICAwIABAAEBAMCBQQCAAQEBwICBwIFAgIFAgUCBAsCAwIDBAACBAMCAgUCAAICAgUCAgMCCQIEAgACBAIDAgMCAgUCBgUCAAIFAgACAwIDBAICAgUCBQIAAgIAAgACAAIHBAUCAwIEAAICAAIDAgIAAgIAAgIABAIFAgYCAgACAgIAAgICAgIEAgACAgACAAIDAgcCCQIEAgQCAgUEAgACAwQAAgICAgcCAwIEFQICDQYHAgQCAAIEAwIDAgUCAgIPAgUCAAQHAgIAAgICAgcCBwIAAgMEBAUCAwICBAMCBwICAAICAgAEFQIHAgUCAwIEAgIAAgUCAwIABAMCAAQDAgMCAgIGAgICAggAAgQCAAIEAAICAAICAAQAAgICBAIAAgkCAgQCAgICAwQCAgACAwQAAgACBAIABAIAAgACAgICAAQCAgACBAQEAgcCBgAEBgQEBAQGAgIEBwICAgICAAICAgIAAgACAAIEAAIDAgIFAgICAgAEAgMCBAACAgICCQICAAICAgICAgAEAgUEAgICAgUEAAICBAICAAQGAgICBQYHAgcCAAIFBgICAgMCBAQCAgIABAICBAsEAAICAgMCAgACAgQAAgYIBgACBAIABAACAgICBAACBQYABgQFBAACAgIJAgICBQIAAgQHAgMCAwQCBAIAAgACAAICAAICAwIABAIRAgACAwIAAgICAgIFAgACAgACCQIFAgMCBwICAAIDAgICAgACAAgRAgICAgsCAwIEAAIEBQQCAAIAAgQHAgkCBgcCDQICAwIAAgAGBAIHAgMCAwIDAgIDAgACBwIFAgACAAIDAgACBwQDAgACBAACBQIFAgQCAAIAAgcEBgMCAgAEAwIDAgACAgACFwYCAgMGAgACAAIDBAIHAgAEAgACAAIDAgMCAgICBAACAAIJBgACAAQTAgACAwIAAgACAgICAgACAAIAAgMCBQICBAACBQICDwQLAgACAgUCAAIDAgsCAwIAAgILAgUGAAIJAg0CAwQAAgMCCQICAwQAAgMCDwICAwIAAgICAgUCAAICAAICAAICAAYJAg0CDwIDAgcEBQICBwIRAgsCBAkCAwIAAgMCAAIHAgQFAgMEEQIRAgACBAACAAIJAgIABgIAAgMCBwQCAgIJAgAEAwIDBAsEAwITAgACAwIDAg8CBQIDBAIDAgIHAhMCBQIAAgACCwIPAgQEAgYEAAIABAMCAgUEAgIHAgIFAgQEAgUCAgIEBwQCBwQAAgMCBgACAgACAwICAgIEAgICAAICAgACAgsCBAAECQIAAgcEBQIAAgIFAgAGAgMCBAQCAAQCAAQCAAQAAgACAgIDBAACBwIEAgACAgACAgMEAAQCAAIDBAICAgAEAgACAgUCAwIDAgACAAIEBAIAAgMEAwIDAgACAAIAAgIDAg0CBwICAwIEAAIDAgACAAQEBQIABAMCAAIGAwQCAgsCAAQCAwILBgIDAgUGCQIAAgIAAgICAAIEAwIEAAQAAgIHAgAEAAIAAgIFAgUEAAQCAhMCBwIAAgACAAICAgINAgIAAgAEAgIAAgACBwIAAgsCBwYCAgILAgIFAgMCAwIDBA0CBAILAgIDAgIHAgIPAgUCAgACAAIAAgIRAgIAAgIJAgcCAAIDAgQJAg8CAgACDwIJAgIPAgUCAAIDAgcCBQIFAgkCBQICAwIAAgAEBBECAwIEBAUCBQICAgICAhUCAgcCCQIDAgACAwIFAgUCCQIDAgILAgACAAIAAgACAgsCAhkCBwICAAIFAgUGBwIFAhMCBQIHAgUCAgACAgcCAgACBQIIAgkEAAIFAgACAwQNAgMCBQIABAUCEQQAAgACAgIAAgIFAgIHAgIHAgILAgsCFQINAgsCAAICBQICAg8CLQICAwIdAgIAAgkCAgMCAAICAgIPAg8CGQIPAg0CEQIPBA0CAgsCAwICAgICAAIAAgIFAgICAgMCBwIDAgUCBwIFAg8EBAACFwIAAgICAwIdAgIAAgQJAgQCBQQAAgIAAgQCAwIABAMCBQILAgUCAwIAAgQCAgkCAgACBQIDAgMCAAQCAAIfAgMCAwQHAgACDQIAAgcCBQIFAgkCAAICBAIDAhcCAwIhAgMCAgMCAAILAgIPAg0CAgACAAIRAgIbAgkCEQICAwIhAhcCCwICAwIHAgcCAg0CAgkCAgIFBAIDAgMEAgUCAgUCEQIjAgMCAgsCEwIPAgIPAgsCAAIDAgUCEwIVAgkCAgMCCwJTAgMCDQILAgcCAgUCBwItAgkCAg0ECwINAgMCAwIJAgMCCwIHAgUCAg8CAg8CAgINAgIFAiMCBwIvAgcCAAICAwJDAgACAwI1AgcCCQIAAg8CAAIDAgIvAg0CHwIFAgACRwIAAgkCCwIHAiMCBwIHAgsCDwIdAgsCDwICBwIAAgkCAwIDAgUCDwIJBAUCAAIAAgMCFQITAgIVAgkCDwIHAgIXAgkCEQIJAisCLQILBAMCAgcCAgkCAiUCFQI5AgkCAwIVAkMCAAQ/AgACAiUCDwIPAgMCIwI1Ag0CCQICEQIFAhUCEwIVAgIVAgUCJwIDAg0CAwIDAk0CAwIdBD8CAgMCBwIAAjECJwIpAisCEQIAAh0CHQIhAgkCAkcCCwIXAhcCBwIAAhECCwINAhUCBwIPBBECAgIVAh0CCQIRAgkCBwIAAhMCBQICBQICEwIZAikCEwIXAgIdAgILAgACCQIfAgYCIwIVAgI1AgMCAwIJAisCAAIVAgcCBwIHAksCBQIAAjkCIQIDAhcCAAIVAhECKwICDQIPAhkCAwIJAmECAhMCHwICZwJFAgIpAikCdQIxAgUCJQIVAj8CAAKnAQIjAgMCAAITAh0CGwItAhcCEwIpAgIJAgMCBwITAgMCFwIdAj0CiwECYQIXAiUCBwIxAhMCAAI5AgMCDwICIwIHAgACDwJlAjsCJwIvAlECrQECrwICVQLFAQJRAgMCCQICAggCBgICCAQGBgICBAQEBgQGAgAIBgQCBAACAAIABAACBAQDAgQEBAAEAAYAAggAAgQKAwIEAgIDAgQCBAMCAAICAAIAAgUCAgUCBQIDAhMCBwIHBAcCDQQFAg8CSQJPAiUCGwIJAgACSwILAhcCBQIvAjMEHwI5AkECvQECBQIdAj0CGQJXAmMCGwIDAh0CAhsCmwECCwIJAkECEQJ3AgUCAwQPBALXBAIHAgICAi8CAAIDAgICAwICBAACAgkCAAICAgACBAgIAgIABAYCBgYACgQCAgACAgQECAYADgQCAgQGBAQMBgAEBAYEBggECgYGAAQKAgYIBgACBgACBAACBAQGBgQKDAQKBAYKBgwICAgMCgIIBAoKBgwEDgYGDAgICggOEAgIDgYICAIEDg4IBggGFgwMFAoMEAwKDhoSDBYQEAwMBB4MEBoOFBIWChgODBIYDBYMHgwMFBoMFA4KFhwKEg4ODAgOBgoQCgYMEhASFgYOBhIIEA4WCgYICg4WEBAKEA4SDCAQCA4eDBwSFCQMCAYUEhAMEAoODggOChQaFgwSDBIKGBgMDBIMDBYGCgYMEgYWCgoOFBIMDhQQDgYMChIICggKFggMDg4QDAwYCggQHAoOCgoMEA4UCgoMGAgQAgwCAggMAAQIAggEDAQEBgQGAwYSBgIICAwCBAIEBQQCAAYEAAQCCAQGAgIEBAgEBggECAQCBAIEFAwKDAQSCggODggOCAYIBgQIAg4GCAoQBBAKCgIIEggKFAoMDA4MAg4ECggKCg4GCggKFgoMCAwIBgQMAgQSCggMDggEBggMBgYOCgYCDBAKDgQKBg4OCAgEBgoMCgwEBAQKBhAIBBAGCgYIAgoOBAoGAggIBgwKCAoKCgoMBAgGDAwODAwICgoIEAYICAwIBAgKCgQSAgAEBAQIBgYKBAIEBAYQCAQKAAQEAAYCBAQUAgoECAoOBgYKCAQIAgYACAwCBggOAAgMCAIEBgQDCAwAAgQKBggGCAQKCggECAoGCAYEEAoEBggIBgICCAQCDAYMBAQIBggIBAIGCAAIAgAEAAYEBAIDAggIAgYMCg4QGA4IEhgUBhgKBgoSBAwMDAoYChoIEBoWGA4QCBAaDBAMGBYSEhAOEhQIGA4MDA4KBgICCgoEBAIDCAYGBAQIAgoABggKAAoIBgoKBAQCBAQAAgIEBAYGBAwEBg4EDgQCCgYGCAQGBAQDAgIEAwgFBgQEAAgEBAQDBgQCAgAEAgICBgIEAgIAAgACAwIAAgIDBgQDAgMCAgICAgAEAAIABAMCAg0CCQIDAg0CAgACAwIABAIAAgQDAgMEAgQGAwICAAQCAAICAAIFAgIHAhcCAgQEAAIEAwIZAgACCQICCwILAgQABAAEAAQAAgIEAggIAgIABAoCBAIGAggEAAQGAgIAAgoEBAIICAIGBgAIAgIGBgAKAgACBwIHBAACBAACAgIGAwIEAgAIAgIEBAQEAgQGAgcEBAQCAAIDBAICAgIADAAEBAgCCAQKBAAEBAIACAAMBgAEAgIAAggCBgAGBgQGAgQABgoGBAYGBAQCAgAGAwIEBAYGAgIEBAIAAgACBgACBAYEBAYCBAgCAgIEAwQHBAICAgMCAgACAgIAAgQEBQIACAACAgYIAgICAwQCAgICAAQEBgIEBAICBgACBAICAgACBAYCBgQDAgIAAgACCAQEBAACBAIAAgAEAgIDAgYABAgCAggCBAMEBAIAAgAEAgICBAACAgAGAwIEBAIGAgQAAgQACAICAAQCBQYCBQIAAgIAAgIJAgsCAwIACAIEAA4CBAQGAgYNAgICAAQAAgACAgACAAIDBAcCAgACAAIAAgQCBAICAAIABAMEAAQCBAICAAIIAAYIAwIDAgACAgYEBAAEBAMGBgAGBAYIBAAGCAQGCgQEDAoICAICBAYCBgIEAAICBAICAgYNAgYHAgUCAg0EBQIEAgAEBwIAAgICAgAEAgQDAgAEAgIGBAQGAgICAAIABgICAgQCAgIGBAYGBAgCAAQEAgQGAgIAAgAEAgICAgYECAICBAICAAQICAQGAAQEAgIGAAIEAAQEAAYGAwYCCAICAAQFAgICBAMCCwQCAgQAAgMEAgQHAgACAg8CAgIEAAIJBC0EAgsCAAIDAgIFAgQFBgACBQQEBAIGAgICAgACAAIAAgAEAgQAAgQEBAIEAgIKAAQGAgIGBAMCAwICBAIABAIEAgIEAgAECAICAAYDBAQEAgAGBAACAAICBAQAAgICAAIAAgUCAAIGAAICAgQABgICCQQABAQCBAICAAIDAgIDBAMCBQIFAgkECAQEBQIEAAICBQQCAgIEAgACAAIFAgYCCAACBggICg4CCAIKCAQECggGDAAGAAYCBAQHAgICAgIAAggAAgAGAgYGAgQCAgcCAgQCAwIABAMEAAIEAgICBAIAAgICAAQGAgIEAAQCBAMEAgIEBAQEAgQEBgYEAgIAAgACAgQCAAQAAgUEAgIABgIADAICAgMCAgYCBAIGAAgMAgAIBgQGBAgCBgQEAgYCBAAKAgAEBAQEAgIABAACAgcGAAIEBAQMCAQACgAEAgQDAgICAAICAgINAg8CCQIHAikCAgACBAwEBAMEBQIEAAIKAAIGAAICAAQCAwYGAgYABgQEAgQIBAQEAgAEAAIABgYEAgACAAIGAgQAAgICAgYEAggAAgAEAAgAAg=="
+        },
+        {
+          "operation": "composition_commit",
+          "requests": 2513,
+          "errors": 907,
+          "latency_ms_p50": 10829.823,
+          "latency_ms_p90": 28917.759,
+          "latency_ms_p99": 30081.023,
+          "hdr_v2_base64": "HISTEwAACo4AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAALsbApEDAjUCIwKlAgKpAQKDAQIVAi0COwKPAgJtApkBAiUCEQIrAqUBAmsCBQIFAhECQQIfAjECHwINAhMCOQILAiUCBwIbAiECDwJPAg8CIwI7AgIAAhcCDQITAg8CCQIVAgsCBwI5Ag8CKQIDAgMCHQQDAgMCKwIFAgUCEwILAhECCwITAgMCKQIxAhMCAwIPAhsCCwICFQIjAgIPAlsCEwIFAgIFAgUCAAICAAIFAgcCEQIFAh8CEwIHAgUCAwIAAgACGwIdAj8CBQIRAhECDwIXAgACAAIjAhECCQIFAgInAgACAAICAgAEBQICCQIPAg0CQwINAgkCAhMCAwQJAhECAisCAwICEQJbAgIJAgcEJQIJAgsCBQIDAgMEAwICBwIPBAUCAAIDAgkCAhECAg0CBQICHQICCQIPAgACBQIJAgIHAiMCDQIJAhkCDQICAAICAAICAgMCAgkCEwICAwIAAgcCAwINAgcCHQIDAgACAgACAgIEAwIAAg8CAAILBAMCDQINAgkCGQITAgkCAAIDAhUCAwINAgkCCwIFAgACEQICBQICJQITAgUCAAIDAgkCGwIJAg8CAwIXAgIPAgcCAwIJAhMCAAIEBwQAAgAEBQIAAgkCAAINAgcCDwILAgACBQICDwIFBAAEFwIJAgACDQQCAwIHBA8EAAICAAIRAgACHQIJAgACDQIDAgMCAAIAAg0CGwITAgkCCQIPAiUCAwI5Ai0CAAIAAgACCQInAjUCAgcCBwIxAhECBQIZAh0CAAICAgUCAAIJAhUCDQIFBg8CAgcCAAIfAgsCIwIFBAkCDQQVAgUCBwIJBAMCDwIDAg8CCQINAgcCEQICFQICFwINBAUCAwIEAgsEAAIHAh8CHwQPAg0CBBECAwICDQICAwQJAgACAgcCAhcCAwIJAgICAwIZAgI7AgMCAwIEAwILAgsCBQI3AgACBwICDQIEHwILAgUCBQICAAICAhUCAAIJAgIfAgIJAi0CAhUCBQIdAgJBAgkCAhsCAwQJAgUCCwJLAgACCQIJAjMCCQQJAhUCCwIFAgUCAAITAgINAgUCIQIDAhECDwIjAgMCBwIlAgACAAJlAgUCFwIFAgcCFQIFAg8CJQIAAiMCAgITAgICBQIJAgACFQIAAhECBQIFAikCCQJPAgcEAgcCFQICAwI3AgcCFwIAAhMCQQICFwQDAgcECQIXAg8CMQILAi0CHQITAgMCBQQpAgsCAiECAwIAAg8CGwIDAgACGwIJAh8CCQQ7AiMCHQIAAg0CTQICAhkCCwIFAg0CEQITAhMCBwIZAhMCCQIDAhECYQIHAkMCAAIlAmcCCQIlAg0CAwIVAj0CBwIAAgIhAgACBwICAwICLwINAgMCBwILAhMEDwIAAjUCCQIZAiUCIwI1AgInAgUCAgMCAAIJAgsCHQITAikCAAIDAgcCCwJXAgsCJQIdAgcCZQIxBF8CEQIDAjkCLwIjAg8CFwIlAgJJAtMBAg8CMwJFAg0CFQICpQECywECQQKLAgJ5Am8CTQIlAjUCFwIAAncCKwK/AgJHArkCAhECLwJhAj0CbwI7AgACFQILAhEECQJjAiMCNwKDAgIzAm0C9QECywECPwIbAlcCEwKVAgKpAQJLAhsCywECpQEC1wICLQIFAhECGQK3AgJtAiUCrRYCEQIHAgMCPQJFAokBAksCjQICHwILAvkBAikC9wMCYQJZAkcCgwEClwECQQIPAjsCVwKLAgJlAlsCDQIdAgMCAwIAAgIDAgACCQICAgIFBAkEAgIJBAACAgsEAAILAgMEAAIDBAICAgMCBAICAwQCAAICAgIFBAcCAgIABAACAgMCAwQABAIAAgIABAACAwQCAgACBAQCBA0EBAACAAIABAQEBAQCAgIDAgAGBAMEAgMCBAUEBgICBgQABAACAAQDAgMCAAIGAgAEBAcCAwQCBAQAAgIEBAUCAgMCBgICAgIEAAIABAIEBAsCBAMEBAACAgcCBgICAgcCAgQDAgAGBgIIBgYCAAQAAgAEAgIAAggCAAYCAgIECAQABAMEAgAGBAICAgQCAwQCBAIFBAACAAQGAgACAAIEAgMCCwQJBAAEAgACBAIAAgcCFwIPBAMGAgACAgACAAQCAgQCAwIAAgMEBQIFAgIEAgICAgIEBQQCAgACAAICBgIAAgICBAIDAgQCAgMCAgACAgMCAAQCAAQDAgQEAAIAAggCAAIAAgUEAAQACAIEAgAEBAIABAICBgAEAgQCAAIDBAACBAAEAAIDBgMCAgIGAgYCBQIEAgAEAwIFAgACCQIFAgYJAgUCCQIVAhkCDQIDAgItAgkCBQIAAgIhAgsCAgUCAgsCAgMCAgcCAgUEAwQFAhECCQICCQIFAgMCAwIFAgIDAgQDAgQEBAQEAAICAgICBwgAAgIEAgIEAAIEAAQAAgACAAIHAgQCBwICAgACBwIDAgAEAgUGAwICGQIJAhECAgcCBQICBgAEBAUCAgQDAgIDAgIDAgMCAAIJAgMCAwICBwQCAgACBwIFAgMCBAAEBAcGAgACAgACAgAEAgIEBAAGBwILAgUCAwIFBAAEAwICBQIDAgkCBQIJAgUCBwIDAgcEBQIDAg8CAAICBwIAAgcCAAIPAgACBwQPBAIDAhEEBAcCAAIVAgcCAAIFBgAGAgMCAgcCAgMCGwIFAgkCAAIABgAEBgIFAgACBQIABA8CDQICAAIAAgIFAgkCAAIFAgUCAAQCCQIAAgAEGwIFAgkCCQQCBwIEBwIAAgkEBAACAgICAAICAAICAAIPBAkCBQIJAhMCAwICAgMCAgICBgIAAgsCFQIDBAACAAICAAQJAgIDAgIABAIABAMCCwIDAgACAAIFAgACAg0EEQwABBUCAgMEAwINAgkCCwIVAgICAAIAAgUCAgIAAgkECwQFAgkCBwIJAgMCAgQAAgICCQQAAgACAAQAAgICAwIDBAACAAIEAAYGAgACBAQCBggABAoEBAQEAgAGDAIECgYGCAgMAgQEBggMCgIQDgwKCBYKCAoOEAoGCAwGCg4UCgQGBgYEBAwKChAGDAIOBAYCDgQMBgIIBgwGBAAEBgYECAYCAgIIDgAKBgoGBgYIBgYDAgIABgACBAMEBgYABAYIAgACBQICAwIABAACCgQICgIECAQCCgICBgICCAQIBAQGAgAGAAQGCAoECgQIBAgQBgQCBAYADgYEBgIEEAgKCAYEBgACAAQEBgICAAQCAgIHAgIAAg0CAwIFBAACBAMCAAICCwICAwIDAgkCAAILAgAEBQILAgICEQIfAgACAgMCAAQABgMCAAIFAgICAgACAAIPAgkCAwIHBBsCAAIAAgQCAAIJBgQAAgICAgICAgICCQIZAgIzAg8GAgMCAAIAAgICAAIFAgcCAwQVAgkCAgcCDwIDAgIFAiECGQIjBjsCAAILAiUCAAICAwIAAhkCEQICAAQDAgACAgACAAICAgIfAgMCAgcCBAkEAAQZBAMCAgICAAIAAgACAgMEBwICAgYNAgAGAAYEBggEAgQDBgACBAIAAgAGAgACAAIbAh+UAYYBNiQMBAgCAAQEAAIAAgACAwICBikC"
+        },
+        {
+          "operation": "composition_read",
+          "requests": 16270,
+          "errors": 15104,
+          "latency_ms_p50": 8.439,
+          "latency_ms_p90": 341.503,
+          "latency_ms_p99": 30015.487,
+          "hdr_v2_base64": "HISTEwAAIZ8AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAL8KAgsCWwI/BBUCJwIRAhsCEQInAgUCDwI/AgACAg8CAwIdAgUCBwIAAgUCAg0CAwIDAhUCGQIFBAACAgIDAgUCBAACBAMCAAINAg8CAwICAhECCwQAAg0CBQICAgMCAgMCAgIJAgACAAIAAgUIBwIAAhECAAYAAgIABBMCCQIABAICAwITAgACBQIHAgcCCQQDBgUCAAICAAIDBAACBwICAAICAgMCAAICCwIHBAQEAAIAAgACAg0CAgICAwQGAgAEBAMCCQIHAgAGAgIAAgUCBQQHAgkCAAICAwICBgAGBQICBwIAAggAAgACAgACAgIDAgACAgACAAICAgMCAAIECAUEAwYAAgAIAgICAwQAAgQDAgQGAgACAgIDBAMCBAAEAgMCAgMCBAIAAgUEBgACAAYCBAIAAgMCCQIAAgMCAgMCAwIAAgYAAgIAAggAAgMIAAIAAgIDAgICAgAEAAQCAwQEAgIAAgIABAkCAgICAgIAAgAGAwICBAYEAwICAAIEAgICAAIAAgACAgIFAgQDAgAGAAYGAAQCAgACAgIABgQCBQIDAgICAgACAAQAAgIAAgQHBAIEBAMEAAgHBAMCAwIFAgAGAAIDAgAEAgQCBAQCAAYAAgUCAgMCCQICAgACBwgCBgQCBQIGAAIAAgQEAgQEAgIDAgQEAgAEAgMCAgICAAQAAgQCAAQAAgQCAgMEBAACAwIABgICAgACBAAEAAICAgACAAIABAQCAgMEAAINBgAEAgMEBgQCAAQDBgQEBAAEAgQCAAQEAAIEAgQCAgICCAICAAICAAIGBgYCAgIFAgACAgMCBAMGAgMCBgICBgAGAgYCAAIDAggCBAICBAICAAQABAIECAICBAMCAgMCAgICBgQHAgQABgICAAgCAgMECgQDBAICBgQCAAoABAQCAgAGAgQCAgQCAAQCBAAEBAIDAgYCAgQEAgACAgYIAgICAgIGAAQAAgIABAQDAgQACAICBAICAAQEBAcCBgQCBAYDBAMEBAIAAgIAAgAGBAACCgAGBgIABAIEAgIGAAICAgACAgIEAgACAAIABgYCBAMEBgQEAgAEAgAEBAIEBAMCBAIHAgAEBQQCAAICAAICAAQCAgIAAgYABggEBAAGAAYEAgAGBgIEAgIEAgIAAgQIAAICBgYDCAQCBAYMAgYIAgIABAAGCgQGBAQEBgIKCgYGAAQEAgYOAAQEBgYACAYEBhAIBAYKDgQECAgEBAgGBgIGAgYGCgwGBAAMDgYIAgACBgIICA4IBggOBgQGBAgGCAgEBAYGDAQMBgQCBggIDhAABgYEAgQGAgYCBAQMBgQCBAYGAAoGCgQCAgQICgoQBgYMAggEAgYGCAQCBAYKAgYCCgAMCAQGBAgCBggCBAoGBgQKCAoCDAQEBgoKDAQKCgQEBggEBgYMBgYEBAIOCgYGBAoICAoKBgwMCgoGCAgIBggKBhACCggMCAQCAAYGBAAIAgYICgYMCgQGCAYICgoIBgQGDgIECBIIBgYKBAoIBAIKBAoGBAQCAAQEBAYCAgYIBAYGAgIKBgYGAgYCAgoGAgIGBAAGBgwIBAIEBgQIBgQCBgwCCAIGAgoCCgAKCAIGBAYOAgYGCAgGBhAEBAoIEAYMAgIGCAQQDAIMCAYEBAwGBgoIBAgECAoKBgwKBgYIAAQIBggGCAQIBA4CAgQKAgYKAgAODgIGBgwCAggKDgYGBgQEAgQIDAoGBAgACA4KBgYIBAgEAggOAgQOCgoGAAQGBAIGCgIEBAgAAgYEAAQECgYCAg4EBAoGAgQGAAYKAg4ECAIEBAQIBAQGBgYEAAgADAYGCAAGAggICAgCBgoKCAIIBgYIBgAKCAgKCgYIAgQIAg4EBAoKBAQABgQMDAIIAggMBAAEAgAIBgIGBAwICAQEDAIOAgICCAQMAAgGBAgCBAYECAYCDAQEDAoEBAYGCgYGBAQIBgwCBgwCBAQIBAwMBAgMEAYIDAYGBAQKCA4GCAIKBgIEBgoCBgQECAgKCAgKBAIGBAQABgoIBggKDggECggCAAQCBAYKCg4ECAYACAQCBAYEBAQICAoEBgYGBgYGCAYKAgQCBgwKAA4KCgIMBAgIEggKBgYGCgwGAgQCBgYMCAoMBAYIBgIGBAIGAAIICgQGAgQKBgwEBAgEDAgIAgQGAgwEAggGBgwCCAQECgQCCgYGBAQGBAYABgQGBgIEBAIGBAQABAoECAgQAgQGCgQECgIEBgQCCAQCCAYGBAYICgoEAgoCBAwECAgCEggMBgYIDAIKBgYKCAoEAgYKBAoCBAwICgYCBAYKBgQIBAgCAgYGAgYIAgQCBgACBAICDgwCDA4GBgYEBgoICAQKBggIBgQGBAIGBAIIAgoEAgQGAggGAgQCBAYGBAQKBAgECAQIBggKBgMGBgQGCAYEAgIKBgYECgYIBAQEBgIMBAoKCggKDAYIBAYEBg4EBAICAgYECgQECgYGBAQCCAQCCgIQBAoEAAgGBgQCBgQMBgYMCgoKBgYEBgYADgACAgQKCAQIEhIEChgMCgwIEAwQDgoQDBQQDgAOCAQMCAoMCgYOCAwGAggECAQKCgoGDAoKCAYIAhYSBAgQBgwGCgoMCAgMEAQCBAoKDAoKDAYUCAwIDA4GCBIQCAQQEgwOBAgMDgoGBhAMCgoIGg4IDAwEEAgOCgQOCggQEgwKAgwIBAYMCgQCCBIGEBAMBAoIDgQGCAgSCg4GEgoICAgEEAYQEggGAggMCgQODAgKDgYKAgoCCAgKDAAMCgYGBhwCEBIECAYIDAoQCAwKFg4ICAYKDgYIEA4MBgoICgYKBgYEBgYGBggIEBIECgwEBgwCChIICAoMDAYMBgIICAYMCggIBAQMAgQIBAgGBgIKDAAMCgIGDgQKDAwMDAgIEggODAoIDAoABAYEAgQKCg4MBA4ICAYCCAoKCgoMCAoGBAYGAggKBAgKCgwCCgwIBAYIDgwKCAgOBAYGDAgEBgAKCAwKBgoICAYMCAIKBhAECggECAIOBAQEBAQCBAoGCAoGCAwIDBIKBAwKDAAKCggQDAYGBAoQCgIKBAQICgYSDA4GBhIWAgwIDggGCgYIDgQMBAgGCgoEBggGAgQABgIECAoGAAoQAgwECgYMBgwCCgoEDgwICggECgQKDAIGBA4IDAIECgoQBgoKBgQOAhIICAYIBAoIBggEBAQKCAoECgYMAgIGDAgCCgIKCggGBAQIBgYEBAoIDggECggECgYEAgIKBggGDgIGCAQEBggECA4ECgQGBggICggIBggGBAwMBAgGAgQKCgQADA4GBggKBAgEBgQGBAQGCgQICAACBAYIEAgGCA4GBggICAwKBgYIBgoGCAQSAA4EBgIQBgAKCAAOAAIGCgQKCgIMCgQIBgwICgYAAg4KAgYKCAQEBgoABgYCBgwMBAYKAAQMCggMCAYGCAgCCAAIAAoIBggEBBIIBgQCBAwQBAQECAQICAQECAAGCAgEBAgGCAQKDgICCAYGBAoMCggMDAIEDAQEBgQGBgIIAgICAAQIAggEBAgEBAwICAwIAAgCCAwGBggGCAgGBAYGBAICCAoEDAIGCAAGBAQEAg4GAAIKCAYGCggCCAgCBAoGBggGBgwOAgwGAgoCBgYKDAQCAAoMCAIGDAgCBQQIBAYGCAIIBAQKBAoICAQGBAgABAYEDgQCAAQEBBICCAIKBggMBAQCCAIEDAgICAQGCAQIBAoGAggECAICCggGDggIAgwAAgQIDgwEBgYMAgQEAgISBgAGBAQECgYMAgIIDgwCCgQGCggEBAgCAAQICAIEAggCBAYKCAQAAgYGAAQCCggIAggEBggECAQCAgYKCgYEBgACDAQIAggGBgAICg4IBAYIBAQGAg4GAgwEDAYMDggGBgoKCgQGBgwKDAwODggIDAwIBggQEAgKBAwGAhIEDgoQBgYKBAoMDAgKCgoOCA4QCBIKDAoOCAIEDAwKBgQECAwOFBIECgYQDggGDggMDgQKCAIEBgQQEAYCCgYEBAQKCgQEDAwMBAYIDAQMBggIBAwCDgIMBgoCDAgGDBAIBggCCgoIBgoGBhIGDggKCgoKCAoIDgIOBgYIDAYKDAQIEgwGBgYIEAYOCgQIDAQKDg4CAgQIBAgADhIGDgQACAYEBgQEDAoIDAgCBAoECgIGAgoKAAoGAgYGEAQKCgoADAYIAgwICAIGDg4GDAgMBgIEBAQGBgwGCggGBAgOCAQEAgYCBAQGDAoGDAgCCAIGDAQICAgIAgoIBgoKBggIAgYEDgQICgoGBAICBgAGBgYICAQKCAQAAgoQEAYGCgAGBgYKCAAGAggICggEBAQIBAYEAgoICAYCBgYGCgQKDgQKBgQGCAIECAYCBgYEBggCDgIIDAAEBgQGCAoGCAYGBAYOBgoIBAQIAAYACgICAwQICggKBAQGBgQECAYEBAYEBgQEBAIGAgQICgICAAQEBAAIBgYECAYICAYIBAYMBggKBAQEBAIGCAYDCAgECgwGAAYOFAAIAgQQBAgABgAECA4KBAQGBAgGBAIEAgoABA4GBAgIAggEBAYMAgQKCAICBgQICgACCAIGBAYICggCCgYIAhICBggGAgIKCgQECgYABgQKBAgGAgoABAQCAgYGAgYMCAQGBgoABAYIBAIGAAIGBgYCCgQKCAYEAAIGBAICCgYGAgIKAgIGBAIGBAQCCAIKBAgGBAIICAgIBgQEAAoCCAgEAgAEAgYECgIEBgYCBAYABgAIBAIEBgYGBgQCCAoEEAQIAgIIBgYEAAYCAggECgAGBAgABAQECAQIBgYIBAYCAAQEAgoICAgAAgQABAYCAgYEAgACAgIACAYCCgoICAQEEAgEBAQDBgQGBgQGBAIIBAYKBAIEBgAGBAYECAYCCggEBQICBAQIBAIGCAICBAIEBAQEAAQCCgQGAgIIBgYECgQGCAICBgIGBgYGAgAEAAwGAAYCBgACBBAEAgoEBgICBgYEAAIIAgAEAgIKBgAEAAQGCAIGAgQEBAIIBAQIAgYGBAIABgIEAgACCAYABAICAgIKBAYEAAQGBgQCAgIABgYEBAQCCAQEBAICBgQCBggGAAYGAAYGCBQEDAoAAggGBgIEBAIABAIEAggEAgQGBgYCBgQECAIEAAQCAAQCAgQEAgACBgYECAYEAgAGAgYEAgQCBgYGAAYECAgIAAQCAgIAAgQIBAQECAMCBAQABgIECAYCBAQFBgQGBgQGCgwEBAQGAgQKAggKCAYKAgYMDAoCCgYKAAoIEAIECgAEBAwEDAoCBgAICgIEBAYECAYEBggKCAQCCAgACgIGBgIGBAYGBgIKBggEBAQIDgIKAgQCCAIECAAEBggIAgIECgIEAgQGCAYACAQAAgMCCAQIDgYGBggKBAQABAYIAgQGAgYEAgQGAgoMCAgCAAYGAgIEAggGCAQEBAgCAAoECAIIAgQEAAQGBAgDBgYECgQMBgQGAAYEBAgEAgQIBAQEAgQCBgIIAgoEBAAEBAYIBAoGBAIKBgoCAgQKCgYEBAAGCgQEBgIEBAQGCgAEAAIIAggGAAQABgQECgYECAYGBgQEAgYEAAgEAgYGAAQGBgQADAYIBgYGBgQGCAoCAgYABgoEBgYGBgIEBAYGAgMGAgICBAYKBAYECAIEBAIIAggEBgYECgICAAYCBAACBgQEBAgEBgYCAgICDAoGAgQEBgYCAgQEBAQEAAYIBgYECgAEBgIKBggCAAIABAACBgQCDAAICAQEAwICAgQCBAQCBAAEAgYCAgICBAAEBgQCAgICAgYABAYGAgAEBAICBAgCBAIDAgMECAAEBAQEAwIGBQYGBgICCAAKCgYCBAQEAAICCAIGAgIFAgQEAgAEBAoCBggFBAQGBgQCBgYABAYFBAIGBAQCBAYGAgAGAgIGAgICAgQGAwIEBgMIAgAKAgIAAgAEAgICBgQGAgAEAgIACgQCAgQABAAIBAYCBgQEBAYCBgAGAgACAgIEAwIGBAYABgICAgIAAgACAAIGAwYEAgYEAAIEAgYGAgAEAggAAgIGAAQGAgIDAgYCAgYAAgIEAgIEBAQGAAQGBAIAAgQCAgQCAgIDBgoAAgIIAgIEAgICAgICAgUCBgACAAICCAAEAgQCAgQCBAYCBgQCAgQCBgICCAMEAgIGAgACBgQGAAICAAICCAICAAIEAAIEAgMEAgACBgICAgAGBAQABAIEAAYCBAYEAAQAAgMCBgACAgACBAYGAgQEAAQCCAIGAgIEBAACAgQAAgIIAgICAwICAgAEAAICBAICAgQHBgACAgACBgIEAgQGBgACAgQABgQEAAQABAIEBAAEAwQAAgIAAgQCBAQEBgIEBAAGBgIABAQCAwIEBAUEAgIAAgAEBgQCAgIAAgAEAgIABAACBAMCCAIAAgwCAwIGAAYEBAQCAwIDCAYIBgIEAgQCAgIEAgQCAAQCBAIEAgIAAgACAAIEBQIFAgIAAgQCAAIEAwQDAgAEAgICAAIAAgYEBgIAAgMEAgICAgACAAIDAgUEBAQCBAIEAgACAgQCAgACBgICBAACAgAKAgICAAgABAIGBgIIBgYEAgIKCAIAAgACAgYAAgQCAAIIAAIEBgMKCAIECAIGBgIEAgIAAgQCAggGBgQABgYEAAIAAgYABAQABgAGAgQECgAEDAACBQQAAgIEAgAEBgQCAAQCBAIAAgICBAQAAgIABAIEBAQAAggEBAAEBgUCBAgEAggCAgIDAgQEAwIFAgICBAACAAYCAgQIBAICCAICAgYEAgQFBAYCAgACCAAIAAIFBAIIBAcGAAIABAACBAMEAAQEAwQCAwQGBAAGAgIAAgQCBQICAgQEAgQHAgICAgQCAgQCAAIAAgQGBQICAgQCAwICAwYCAAIEBAIDAgQABAACAgAGAgMCAAQAAgIDAgIAAgICBAUEAgAEAgMCAwICAgIABAICCAcCBAYGAAgAAgIABAQAAgIGAAICBAAEAwgCBAIAAgICAgICAgAEAgICAwYCAAIEBgMCBAQGBAIIAgMIAAQABAICAwQCAgICAgQDAgQCAgIAAgIFAgAEBAIEBAIABgIDBAIAAgACAwIEBgIEAgYEBgIAAgIEAgACAwQCAgICBAIEAAYEAgICBAQAAgUGAgAEAgICBwQAAgAEAgQIAAQCAgIAAgMEAwQEBAkCAwIEAAQFBAQCAgIABAACBAIDAgkCBAIGAAIDAgQEAAgCBQILAgACAgAEAAIAAgMCAAICBgIAAgIFBAYCAgUEAAICAAIABAACAgICBAkEBAgGBQICBQQAAgIAAgIDAgAEAAICCAACAgIEBAACAAIDAgICBAACCQIEAAQCAAIEAAIABAIAAgACAwIDAgACAAICAgcEAgACAgIEAgIABgACBgICAAITBgACAwIDBgcCAgICAAIDAgMCBAQCAgUCAgACAAIAAgUCAAIAAgACBAICAAIABAICBQICAgIAAgACAgACAgAEAgIDAgIFAgMEAwIDBAUCAAYCAgACAgMEAgIDAgMCBAACAgIGAAIDAgACBAACBAAEAgUCAAIAAgIEDQQCBAICEwICAwICAwICDQICBAQCAgIFAgACBAIAAgACAwIFAgIDAgACAgMCAgIEBQICAAIAAgQDAgACAwQLAgQPAgcCAwgEAwIAAgIAAgMCCQICAgQCBAIEAAQFAgACAAIEAwIGBAACAgAEAAIACAICBgMCAwQABAIEBwYCAgQCBAQCAAIABAQEBAYCBwIDAgQCBAIDAgQAAgAEAgUCAgACBgACBAIDBgQCAgACAAQCAAIABAsCAgAEAAICAgUEAgICAgkCAwICAgMCAgIAAgUEAgUCAAICBQYEBAMCAgIGAgMCAgAEAAICDQIEBAcCAgIAAgcEAgYPAgACAAIAAgQDAgAECQIDAgMCAAIAAgIAAgMEAwICAwICBAMEAgUCAAIFAgACAgIDAgIABAMCBwICAAIAAgAEAgACAgIFAgICAgAGAAIEAAIDAgACBQIGBAICAgYJBAIAAgMCAAIAAgACAg0EAAIAAgQXBAACDwIJAgICCQIHAgMGAAICAAIDAgICAwIDAgUCAwIAAgUEBwIHAgIEBQIDAgIFAgkCAwQCAAYLBAIDAgACAwIEAgQNBAcEAgcCCwIRAgcCAAIPAgkCAAIEAgcCBwIAAgAIAwITAgMCBwQRAgUECQIDAgMCAAIFBAACAgMCAwIAAgIDAgIAAgIFAgMCDQICAwIEAAIEAAQCAgACFwIAAgcEDQQJAg0CDQIHBAIAAgUEBAcCAgICAAIFAgAEAgICAAICAgACFwICAgICAwIAAhECAAICBBsEAgsCAwICDQIAAgUCAgICAgIDBAACAAICBwIAAh8CAAIXAg0CDQIAAgcCBwIDAicCAAIFAgkCAg8CAwIEDQICEQIAAgINAgMCAgcCBQICAgACAwICBQIAAgACAwICAgQCAwQDAgIJAgMCBQIAAgMCAAIPAhUCBQIDAgUCAAQFBAIPAgACAgACBAcCAgACAgQDAgMCBwIDBAQJAgQDBAACAgUCAAIFBAMEAgUEAAIAAgcCAgUCAgUCBwICAAICAwIAAgUCAwIAAgUEBQQCAgkEAgMCAAICAgACDQICAwIXAhcCAgMCAAICEwIAAgICAAILAgIPAgkCAgUCAAIHAgsGAAIDAgILAgACBQQCBQIFBAICAgcCAgcEAgIfAhECAwIFAgIDBAACAAINAgcCAwIAAgkCAhkCAwQDAhECAgACAwIXAgACAwIXAgUCAhECAwIAAhECBQICDwIAAgcCAhECAgcCDwIFAhECLQIPAgkEAAIVAgMCCQIdAgUCBwICDwIFAgkCBQIRBAAEDQIFAgUCFQIAAgUCBwICFwIFBAcCEQYZAgUCGQIJBAACBQIDBAACCQIDAhMCBB8CBwILAgUCHwIHAhsCBQIVBAQABAUEAwICAwIAAgMCAwIAAgcCAgIDAgMCAgIFAiECAwICAgMCFQQCAAICDwIABAUCBAQCAgIAAgUCCwINAgACAgIAAgcCAAIAAgINAgkCAgACAgkCAgMCBQIFAgACBQQAAgcCBwICAwICAAIEAAIFAgIVBAACBAUEAAIFAhUCCwQJAgICCwICAgACAgICGQICAgACGQIJAgACAAIAAgAEIwILAg0CBwQJAgcEAgMCBQIHAgkCAwIPAgcCBQIAAgQFAgIAAgMCAwIDAgIDAgMCFwICAAINAgUCAwIJAgACAAICAgUCAAIAAgICAAILAgsCBQIJAiECAgMCAgcCEQQdAgACAwIbAgMCBQIFAg8CAAIDAiUEAwIXAhMCEwIHAhkCAgIDAgMCCQQLAgACAAIPAhUCAwICEQICAwIJAgACAAIDAgMCHwIVBAUCAhcCAAIFAgIZBA8CEQIZAgACCQICAAICAg8CJwQVAhkCCwICAh0EEwICBQJVAiECDQJBAgUCBQIHAgILAgIDBAQLAgkEAAIAAgIDAgICBQIDBAUCAwICAwICGQIVAgACCwQFAhMCAAQVBAUCBQINAgACGQIAAgAECQIJAgMCAgcEBQIXAhECAgACDQIDAgACFwINAgUCAAICAAIHBAUCBwIHAgkCCwIDBAsCAAIAAgUENwIDAiUEBwICBwICAAQECwICDQIAAgkCAwIAAgMCAAIFAhUCEQIFAgIAAhECCQIZAgMCAAIAAgUCAwIDAgsCFQILAgUEEQIJAhsCCQIHAg0CGQILAgUCDQILAgcCAwIPAicCAAIpAhcCHwIjAgACDQIvAg0C0wECIQIAAhECEQIdAgMCAwIRAo0BAmMCCwIvAu8PAgACAwIAAgUCBQITAgMCuwECaQIbAkECcQIFApUBAgcCCQJFAh8C5wUEhQECAgJFAgACHQILAhEECQIJAk0CAwIVAiECDQQdAgKrAQJPAq0BAhsCxQECBwIAAgACNQICAwICBwICAgACAwIFAgsCBA0CCQILAgQGBwIAAgIABgAEAgACDQIABgIHBgIEAgcCAAICAwIFAgQCAgMEAgQCAAgCAgIEAwIEAgMCBAAEAwIFAgMCAAICBQIFBAIAAgIDAgQKAAQCAwIAAgICBQIPBAMCBQICAgACAwICAgICAgACAgIEBAQGAAQGAwIFAgQDAgIHAgQFAgUCBQIAAgAEAgQCAwIDBAIABAIGAAIECAIHAgIEBgICAAIABAIACAQEDQQCAAICAgIRAgACAAIFAhkCAAIAAgIXAhUCAgUCDwICAAIABAACAAICAwIDAgIEBQICBAIAAgICAgQHAgIAAgcCAAICAgICBAICAAICAwIAAgIDAgACDQICAAQJAgUEAgQGAgIFAgILAgACBwIHAgIABAQGAAQCBAACBAIDBAQJAgQAAgUCAAIPAgIZAhkCFwInAgsCEwIFAhcCOwIFAhcCBQIPAgsCDwICAAIPAgAGAwYFAgACCQQDAgMCAAIDAgAEAwYAAgQEAgMCAAIAAgICBQICAwIAAgsCAwIPAgsCBQICGQQHAgkCAwQEAAICAwQAAgUCAAQCAwIFAgACAAICDQICBQICIwQTAgICCwIDAgACAgMEAgICCAMCAg0CAwICAgQNAgQCBQIAAgQABAMCAAQCCwIDAgIAAg0CAgIvAgcCBQIAAgINAgMCAAICKQINAgACAgUCDQIFAgcCAwIHAgICAAIEAgcCBQgHAgcEAg0CAwIDBAQCAAIKBQQAAgUCAgcCBQIHAhECBwICAhECBwIPAgMEDQILAgUECQICAgIEBB8EBQICBQQbAg8CDwICBQIAAg0CAAIDBAIAAgUCAhsCBQICBQIHAgUCAAIAAgICAAIbAgkCCwINAgsCFQIAAgICAwIDAgACJQIFAgACBQIHAgcCHQIFAgIfAgIDBAcCAhUECQICAgQABAIHAgAEBQQCBgIGAgIFAgICBAAKBggEBAAGBAAEAgYEBAQEBgYCDBIICg4EEAwICAgIBgYECAIEBAYGBAQACAwEBgYCCAQICAIEBgYCAgAEBgYABAICAgQCBAgGBAAECAIKAgICAAIGBQIEAwIAAgACAwYGAgYDAgMCBwIJAgoICAQEBAACBQQABAACAgQCAAIGAAIABAIABAoGAwYQCAYCAgIACggCCAQCDAQCAAIABAYVAg0CEQIAAgACBAMGAgMCBwICAgUCCQICAAIJBAACAAIdAgsCHQIFAgIDAgQAAgICAhECAgIRAgUCAAIDAg0EBwIDAgMCBgIEAAIDAgsCAAIEBgIABAACFwIJAhsCFwIDAgACHQIDBBcCEwIDAgACDQIDAgAEAgIDAgMEAAIHAi0CFQIjAgIDBA8CAwIAAgMCDwIjAhEEBQIDAg0EBwI7AgkEJwITBAkCAgAIAgIEAAICAgIDBAICBAQAAgAEAwIAAgQABAACBAYMBAQGAgACAwIDBAIFAgICBQIhAgUCD8QBTiAMCAoIAwIPAgIRAg=="
+        },
+        {
+          "operation": "composition_read_current",
+          "requests": 9151,
+          "errors": 8491,
+          "latency_ms_p50": 8.039,
+          "latency_ms_p90": 257.023,
+          "latency_ms_p99": 20660.223,
+          "hdr_v2_base64": "HISTEwAAG9EAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAOkJAokBAkkCFQI/Ag8CTQIAAgMCAAIZAgUCAgACAAIdAgMCAgkCAgcCDQIXAi0CAwITAhcCCwICAwIAAgMCAwICCwIHBAsCGwIFAgACBQICAwIAAgMCBwIPAhECBwIDAgUCAgUCBQINAgUCAAITAgIAAgMCAgcCAgkCAAIFAgACBQQDAgUCEQIAAgACAgQDAgIHAgAEBwIDBAACAAIAAgIAAiUCBQIZAgcCAwIDAgMCBAAEAgcCCwIABAMCAAQCAwIFAgIABAMGBwIHAgkCBQQFAgACAgIDAgMCAgIFAhUCCQIFAgQCCQICAAQDAgQFAgACBQICBQQDBAICAwIEAwIAAgIAAgACAgIAAgACAgICAAICAgACAg0CCQIAAgkCAwIDAgYGAgcCDwQDAgYDAgUCAAIEAAICAAIDAgICBAIAAgIEAAICBAIEBQQHAgAEBQICBAICAgAEAwIDBAMCAgACAgUCBgMCAAICBQIAAgIDAgQCAgQDAgACAAIEAgAGAwQEAAICBQICAgICAAYFAgQAAgACAgAGAgQCAAIFBAMCAwYABAAEBAICBQQAAgICAAIDAgACAAQCAgMCAAIABAMCAgQCAgIDBAICAAQEAAIAAgMCAgIABAoCAgQFAgUEBAACAAQCBAACAAIDAgQEAAQEAwICBAACCQIEAAIABAICAwQEAgAEAwQEBAIAAgsIBQICBQQCAwQCBAcCAAIAAgIFAgMEAAIAAgIGAwIEBAICAgMEAgMCBQIAAgUCAgQAAgIEAAIDCAICAgAEAgYABAACBQICBAICAgACAAICAAQDAgQCBQQCAgACBAQCBAACAgIABAACAgoABAMIAAICAgACAgQCAgAEAwIAAgICBAIHAgQDAgQECQICBAQAAgIAAgICAgQCAgQCBgIDAgIFBAQABAICBAIEAgYABAACBQIABAACAgAEAgACAAYEBwICAwQGAwQAAgYDBA0EBAIHBAMEAAICAgcCAgIAAgACAgMCBAACAgIDBAICBAQEAAQIAgAEAAQCAgMGBAQKBAQCBAIEAgIIAAQEAgIEAgYIAgICCAQEBAIABgQAAgMCAAQEAAIEAAYAAgIIBAIAAgIMBAQGAAQGBAQGBAYCAgYABAYEBAYEBAYCBgIEAAQACAQCAgAGCAAGBAgIBgIGAAQCDgICCggIBAICAgQABggGAggAAgQGAAIQAgQEAgQGBgIGAAIIAAYACAQGAgQCAAoACAgACgQECAYGAggICAYCAgQCCgQGAAgGBAQEBgMCBgIEBgQEBgYGBggEBAICAgYGAAQAAggABAgCBAMCCgAGBgQCAAgGCgQIBAAEAgQAAgwIBAgEAgYGCAQCBAgKBAwCBAQCBgQCAg4EBAICAgQEBAQCAgQIAgAEBAQEBgICAgAEAggGAAICBAAEBAgGBgYEBgIGDAIIBAYIBAgCBAICAgQGAAQGBgICBAYEAwYEAgAEBgACCgQEAgYEAgAIAAYGBgQABAIGDgQCBgoIAwYKAwIGBAYEAgIEAgICAgYGAAYECAoCAgQAAgICAgQEBAIAAgIIBgIEAgAIAgICAgIABAQIBAIGAgIABgYEBAQAAgAGBAYAAgIEAAIEAgAGBAQEAgIEAgIECAYCAggCBAIABAYECAQCBgYIAgQAAgQEBAIABAMCAwICBAQEBAIEBgAEAAIFCAICAAQGCAYEAAQEBAICAgIAAgYAAgYCAgYEBAQCCgYCBAAGAgYGBgIGBgICAgICBAQCAAQCAAIEBgIIBAQABgIGBAIGAAIIAgACAgMEBgICAgoAAgIEAAQABAQCBgACBgICBgACCAYCAAgCBAIIBgAEBAQGAgICBgQCAgQGAAYIBAIEAwgCAgAEBgQEBAYGBgQCAgQEBAYABAoGAAQGBAIABgQKBQQGAAYGAgYCBAICAgYEAgMGBAQCBAYGBgQIBgQGAwYCBAACAAgEAAIECAQCAgoCCgIABAQAAgQCCgQCAgYABAICBAIOAgIABgQCAAoEBAoAAgIIAAIABgICBAICAgQCBgICAAYCAgAGAgYCAgYCAgQCAggEBAQCBAQCCgICBgQEAgQCAgYCBgIIBgQDBAICBAYGBAoCAgMGBAAIAgIDAgMGAAIEAwIEAwQCAgICBAYGAgAGAgQCBAYCBQIAEAICBAIEBAQAAgQGDgYEBgAGBQQABAQGBgYCAgYCBAACAgAIAwQDBAQGBggEAAgCAAICAgQCAgQCAAYIBAACAAIIBAIEBgICBAYCBAQCBAMIBgACBAACCAICAwIEBAIGAgYCBgQAAgIDBAIECAQCAgQEAAQAAgQEAgYEAAICAgYABgQACAICBAICBAACBAICBAgCBgAEAwgCBggCDgQEBQIGAggGCAIEBAQIAgQAAgAKDAYGBgQCBgIIAgwGCAgCCgACAgYCCgIQBAIIAggGAgAGBgIIBggEAg4IBAgGBAgEBgoEAhAIBAQIBAIEBAQEBg4EBgIGBgQKAgYECgQKCAYCBgYIAgIMBAgIBgQGCAQMCAICDgYGBgIDCAIGAAgGAAgEBgYCAgwKAgYGAAgCAgoACgQIAgAECAIEAgYCCggACAYEBAIEDAQEAAYMBAYECAIGCAIGCAYEBAwMBggCBgYCBgQIBgoCCgQGBgYEBAQEAgQIDgIOBAIDBAIGAgICBgwGBAgICgQICggECAgEBAgCCAAICgwCBAQEAgAEBggEAgQGCAgGCAoABgYGBAACBAQICggMCgQECAQEBgQECAoACAYEAAQEBAQGCAgIBAICBAgMBAIGCggEAgYIBgYEBgoCBgQEAgIGAAYCAAYGBggKAgICBAYAAgQIAhAADAQCBgQGBAIEBAQCBAYEBgIIBAIGBAgKCAgCBgYKBgoCBAQEBggEDAgGAggIAAgOCgoGAAQGBgQCBAYGAgYGBAQICAgKAAQGDAgEDAQCBAYCAAYCAgYIAgAEBAQABAgCAgICAgQAAgYGBgYGCgYGAAYIAAYMAAQEAAQGBgQGAgIAAgICBAQEBAQKBAoECAMEBAIIBAAEAAIIBAIGBgIGBgAEBAYEBgQEBgQCAAQGAgICAAIICAgCAggIBAYEBAIKBggEBA4CAgAICgIEAgQCBAgEAAQKBAMEDAQGCAYABAICBAIAAggCCAICAgIGBAQABAQGAgAGAgACBggCAwQEBAACBAIEBAMCDAAEBAQCBAAECAIGAAICAAYCAgYEBAQEAAYGCAIGAwIEAwIAAgYCBAgEAAYCBAICAgACBgQGAAYCBAMCAgYCBgIEBgACBAIDAggEAgAEBAgABAIGBAYAAgIABAICBAAGCAICBAgAAgYABAgGBgYABAAGAgICDAQEBAACAwYGAgIEBgICAgICBAQAAgICAgQABAMCCAQCBAQEAgICAgIDCAYAAgIEAAIEBAIEAAYCBAQCAAYIAgYEAAIGAAICBQIKAAQCBAACCAQEAwIFBgACCAQEAgIDBgIEBAYABgICBAIAAgIEAgQEAgACAAIEBAgGAgICCAAEAgQDAggCBgICBgIGBAAEAAQCAgQABAAGAAICBAYEAgICAAQEAgICCAYABAQCBAQEAgAEAgICBAAEAAIECAAECgICAAIIBggAAgQAAgQDBgQCAgIDAgQCAgICAgQEAAIABgQEAAICCAQCAgYCAgAEAgQCAAQGAgMGCAYIAgIAAgIGBgIGCAIEBgYGAgQKBgQIBAoICAIICAQCAgQEBggCBAwCBAYEBAoEAggIAgQEAggIDAIEBAQCCggEAgYIBgYKAgAEAgYECgQCBAwABgIGAggKBgQEAgIEAAYFBgIABAgCBgIEBggIAAQCBAYCBggIBAwCBAYEAgYKBAYKAgQECAYEBAQEBgYCDgQEAAgKDAYCBAIGCgIABggCBggECAgEAgAIAgQEAggIAgQMBAQCAgQGAAQGBgAIBAYABAQECAgKBgAEBAACBAIEBAAECgQEAAQEAAQEBAAEBggACAMIAAQCAgQGCAIACAIEAgQGBAICBAgIAAQGBgYGCAQABAYEBAYCAAICAgYABAQEBAoGBgYAAgAGBAICAgQECAQEAgACCAICBgQDBAQEBAIEAggABAwEAgIEBgYABAoCAgICAAYCBgQCBgIGAAYCBgYCAAIABgICBAoGAgYABgIICAQEAwIEBAACBAYCAAQAAgACBAIABAICBAIAAgQEAAQCAAICCAgAAgAEBAQGBgIECAAEBAYIAAQGDAQGAgIEAwQEAAQAAgQGAAIEBgIGAgAEBAQCBAQEAgQEAgIEAgQEBAIGBgQCBAYABAYGAgQDAgIAAgAGAAQGAgIEBAICBAIACgICBAAEAgMCBAwGBAQEBAgGAgAGBgQGBAICBgIABAMCAgAEAAICBAIGAgIABgAEBAIAAgQEAwIKAAQGAAQCAAQDAgQCAgIEBAIEAAYGAgICAgAEAgQEAAYABAYGBgAEBgMEBAIGAgQEBAQCBgQEAgUCAgIEBAQDAgAECAICAgACAgQGAgIDAgwEAgIABAQABAYCAAQGBgICAgAEBAQCAgACAgQCAAICAgICCAAEBAQABAQDAgIIAgACCAIEAAIEAAYCAgYCAAYMAgYEAAoCAgIIBAIDBAYEAgYABAICAgQIAgYEBAQGAAQABAQFCgMCAgAGBAICAAQABAIABAQABAMKAgACAgAEBAACAgICAwIAAgIGAAICBAIABAAEAAQEAgIICAIEAAICAgYDAgMCAAICBgIEBAIGAgICAAICAgIAAgICBAACAwICBgQCBAAEBgIAAgYAAgYCAwQCAgIEAwIGAAIGAgMCBAYEAgIEAgIEAAIGAgQFAgYCAgYCBAYCAAIAAgQEAgICAgQEAAICBAACAgIGBAACAgMEAwQCAAIEAgIAAgMCAgICAgACAAYDAgUCAgUCAgAEAgQAAgACAgcEAgIEAAQGBgIEAgQAAgAGBAIEBAMEBgAGAgAEBAACBgICBQIAAgUCBAACBAICCQQABgYEBAAEAAIGAgICCAIABgYEAggECAYKAgAEBgYEAgQEAgIEBAQDAgACBgICBAACAAYCBQIAAgQCCAIGAgACAgYAAgACAgICCAAIAAQEAgICAgICBAQCBAIGBgAGBgQEBAICBgAGAgQGAgAEAAQCAgIEAAYCAAIABAgIAgQGBAIECAICBgAGAAIABAIEAAQEAwICAAQEBAICAAoCAgIAAgIEBAYEBAQABAIGAgIEBAQEBgQEAgIGBgIIBAYEBAICBAYAAgYCBgIIBgoEAgIGCgMCBwYGAwQCAgQIBAACAAQIAAIEAgIGAAQEBAQCBAIDCgYCBAQEBAACAAIEBAQABAQABAQCBAIFBAICBAIIBgACAwIEAAQCAgIDBAMCBgQEAgACAwICAgAEAgICAwICAgICAAICAwIGBgQEAwQACAACAwQEAgMIAgAEBAYCBAACAgIFBgICAgIEBAIABAYAAgIAAgQAAgICAAICAAIAAgUCBAICBAAEAgIAAgICAAQEAwIDBAAGAgUCAwQIAAICAgIEAgICBAACBAYAAgICAAIFBAQABAIGBAgDAgQDBAMCBAQDAgIJBAMCAgMCBAQGAwIABAIDAgACAAIEAgAEAgIGAwQCAAICAgQNAgACAgACAAIEAgACAgIFBAICAgICAgAEAgAIAgcCBAIDAgIEAwIABAIAAgQEAwIAAgIAAgACBQIFCAMCAgIEAgUCAAIDBgIABgQAAgUEBAACAwIAAgQHBAUCAgACAgIHAgsCAAIEBAcCAgICAgICAwQCAwgAAgQDAgACAAIAAgIAAgACAgQAAgAGAAIAAgICAgAEBAMCAgACAgQCAgIAAgQFAgMCBAYCBAQEAgQDAgYHAgAEBwQGAgACBAACBAAEAgACAAQCAAICAgIFBAQHAgACAgACAgAEAgcCAAgCAAQAAgUCBQIAAgMCAgICAgIABAIDAgIAAgIEAAQCAwICAAIFAgcCAAQEAwICAgYEAwQAAgICAgACAgAECQIABAMCAwIAAgMCBAMCAgQCAAIAAgUEAwICAAICAwICAwIFBAICAwIEAwICCQIGAgICBAcCAgMCAAIJAgAEAgICBgUCAwICAwIABgQEAgACAgkCBQICBAIAAg8CBgMCAwIAAgICAAIAAgIAAgAEAgIAAgMCAgAEAAIAAgAEAgMEBwIAAgICAAIEAgUGAgACAgQCAgIEAgIAAgMCBwIHAgIDAgQDBAIEBAMEAAIDAgACAwICAgIEAAIEAwQCBwIAAgICBAcEAgQAAgACBAICAwQDAgIAAgACAgIABAACAwQCAAIABAIDAggEBAUCAAIFBAIEAwICAgICAAICAAICAAICBQYACAACAAICAwILAgQCCQIAAgUEAgICCAQAAgkCAAIEAwQDAgMCAgMCAAIABgIDAgACBQIAAgINAgIDAgIFBAYHAgcGAggCAwQDBgACAwICAgAEAgAEAgMCAAQEAwIDBAACBwQCAgQDAgIGBwIABAIAAgIFAgIAAgYDBAYAAgIABAIDAgsEAgICBAQAAgACBAACAgQJAgUEAAIDAgMCAAQEAgMCBwQCAgACBAIDAgIEAgcCAgMCAwICAAQEBAMCAwIDAgMCAAIDBAACAwQCAAQDAgkCCQICAAQCAgsCAAICAgcCAwYFAgACBQQEAwILAgACAgIEBgACBwYAAgIAAgUCAgUCAwIPAhECAgACAgACAwQDAgICBAACAwQCAwQCAAQFAgIAAgsCAwIpAgIFAgIDAgkECwIABAkCAgcCBQIDBAACBQIFBAUCAAIHAgIAAgICAgMEAwILAgQJAhUCCwIAAgAEAAICDwIJAgACAwICAgINAgIAAgACAAICBQICDwIHAgcEAAICAAQFAgACAgsCAgACAAIFBAACBAUCAgACEwIECQIDAgAEAAQHAgsCAAICBQICAwICEQQHAgsEAAQDAgMCAAIXAgUCAwIEAAIJAgACAAIAAgkCAAIDAikEBwICAAICCwIGAgMCAAQDCAUCCQIDAgcCBQIFAgIIAAIAAgUEAgICAgICBgIAAgIFAgICBQQHAgIAAgkEAAQEHQICAgACAAICAAQDAgQCAAIAAgICAgMCAAIAAgACAgIHAgUCAwIDBAUCAAICCQIJAgACAAIHAgMCAwINAg8CAAIDAgUEAwITBCUCAgACAwIAAg0CAgACAAITAgcCFQIAAgMEAAICAgUCAgsEAgACAAINAgMCBQIAAgICBAACAgILAgUCEwIEBwIDAgcCCQINAgICAAQdAgACCwICAgUEBQIRAgkCAAQAAgACAAIVAgcCDQQAAhsCBwIDAgMCAgQJAgIDAgIPAhcCAhcCBwYDAgACCQIDAgUCBwITAg0CDQIAAgcCAgACCQICDQIDAgcCGwIHAgUCCwICDQIHAgAEBwIFAgIHBA0CBQIDAjcCEwIbAgUCCQIFAgsCEwICEwIAAgACCQIFAgMCAAIFAgMCAicCBQIhAgsCAAIAAgACAAILAg0CBQIXAkECBwQFAiUCEQIAAgMCAAICCQQHAgMCBwIDAgMCAAIFAgcCAgIFAisCAgQJAgcCBQIDAgkCAisCAAQPAg0CEQIAAgsCDQIDAgMCAwIPAgMCDwIHAgACAAIAAhECAAIDAgACGwIFAg8CCQIVBBsCEQINAgMCEQIJAhUCAAIDAg8CAAIhAhsCBwIFAgIPAgUCGwIpAgUCAwIHAgUCBQIAAiUCBQIDAicCDQIAAhECAwICBwICAgsEQwIXAgACAwICHQICBwINAjUCBQIDAg0CFQJBAgUCBQILAhECEwIAAgsCEwIJAgJFAgMCCwInAh0CBwIAAg0CAhUCAwIHAg0CCwILAgkCEQIFAgACDQIDAgkCBwIJAgICBwIFAgUCCQITAg0CCQIDAgUCAhECBQQLBAMCCQIdAgcCAhcCBQIDAgIDBA8CAhkEBQIFAgkCGQIfAgACDwIAAh8CFwIRAgAECQIFAg8CAAICAwIPAgINAhECHQILAgIVAgcCCwICEQIFAgcCBwIDAgACAwIdAiUCAwIFAgkGCwQ9AgMCAgMCBQIFAhkCGwIfAgACAhsCHwIRAg0CDQILAgkCDwIbAgkCBwQzAhsCFQIPAgcCFwIPAgUCAgMCJQIAAgUCAAILAhMCDQIXAhUCPQIDBAIJAh0CAwIFAisCEQJdAhUCBQQDAjsCTQJDAgACAAIFAiUCAgACEwIFAgUCFwINAgkCAwIrAgcCHQIRAikCAg8CCwJFAgMCBQIPAh0CAwIJAgcCEwIPBB0CAgUCJQIHAgcCBwICCQIPAhMCFwICDQICAAIHAhcCAAIPAhkCJwIDAgIHBA8CDwICFwIPAgcCBQICaQItAjMCZQL5AQJrAjUCDwILAjECCQJ7AhMCnxECEQJHAgAEcQIFAn0CIwILAl8CNwIPApEBAhECUwLxBQJrAicCSQIPAhkCBwICfQKfAQJ1AjUCuQECAAIRAg0CFQKJAQIZAgUCFwIlAgMCAiECAAIFBAMCEwIDBgsEAgAEAAYEAAIABgACAgACDwIABAAEBQIFAgIABAIEBwQCAwQCAAIIAAQGAgICBgIDAgQCBQQNBAAGBAMCAgAEAgMCBAAICQIAAgMCAwIDAhkEAAQCAAQCAAIDBAkEAgMGAwYAAgQAAgQNAgMCDQILAgIAAgACBAQABAIDAgYCAgIAAgYHBgAGAAYAAgAEAgAECwIDAg8GAgMEAgkEAgsCEQIABAQCAwITBg0CBwIPAg0CAAICAgACAgIFAgkEAgMCAAIDAgUEAgICBA0CAgAGAAICAAQFAgMCCwQDAgYCAgIAAgIABAIAAg0CBwQCAgIEBAIDBAAICwIDAgcCBQIDAgACAwIJBAIEBQIHAh8CAlcCAAIfAn8CAAICAgkCAgIRAgI3AgIDAgIPAhsCAgIDAgIjBBUCEQITAiECDQICAwICAAIJAgICBwIJAgQFAhkCAgIAAgICAAQJAgUCDwICAwIRBAQCAgQCAgMGAwIFAgMCCQIAAgICCQICDQIFAgY3AgkCEwJDBDUCjwEEBwYAAgIDAisCBQIJAhUCBgACCQIAAi8CAAIFAg8CEQICBQYpAgUCNQIJAhkCBwINAgMCBBsCCwIRAgcCAAIFAhcCAwIDAgIAAgIHAgACAgACDQIDAkUCIwIAAgUCFQICBQQNAgMCCwQDAgsCAgMEAgcEAgMCBAQFAgUEBQIEAAIDAgIEAAICBQYCAggKAAYAAgICAAICBAYCAgAEAAYEBgkCBAIEAgIADAYABAIDAgACAgICAAIDAgIFAgIAAgsECQILAgIABAACAAQCBQQTAgQCAgICAgMCAAIPAgcCBQYEBAIABAICDQIGBAMCBwICAgcCGQIVAikCBwICHwICOQIRAgICEwIDAicCBwIPAgUCBQYAAgILAgIAAgACBgMEBHkCDQIZAikCAAILAgACCQYCAwICbQINAo0CAhECAjkCAwIABgACZS4MBgMCAgITAgcC"
+        },
+        {
+          "operation": "composition_revision_history",
+          "requests": 8789,
+          "errors": 6322,
+          "latency_ms_p50": 16.799,
+          "latency_ms_p90": 14991.359,
+          "latency_ms_p99": 29458.431,
+          "hdr_v2_base64": "HISTEwAAHRUAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAK8KAlcCBwIFAi0CLQIbAgUCPQIAAk0CAhMCEQJXAgkEAwIzAiMCFwILAkEEAAIHAhECAwIRAgACAAIPAhMCCQIFAg8CIwINAjMEAgACAgMCCQIAAgcCBwQLAgIAAgcCAgUCAwQhAgIAAgcCAAQDBAcCAAIFAgcCBwQFAgICAAIdBgsCAgICAAINBAMCAAINAgIVBAIJBBkCHQIDAgMCAwQDAgACAAQLAgACBAAEAg0CBQIDBAQCCwIAAgkCCwICDQIDAgACBwIDBAMCAgUCBQIDBAcCAAQLBAIAAgcCAgICAAIDAgUEAgIAAgIABAUEAwIJBAAEBQIJAgICAwQCAAIAAgIFAgkEAgIAAhUCBwIDAgUCBQICAAICAAIHAgUCAAICAwICAAIDAgACAAYEFwINAgkCAAICAgIEAwIAAgMEAwIDAgACCwIDAgUCBAkCBQIDAgcCAg8CAAQCBwQFAgICAwICAAICAgIHAgACBwILAgMCBwIAAgIEAgACBQIFAgQDAgUGAgICAgQCAgICAAQAAgUCBwICAwYCAAQCCQICAwIAAgIAAgICBQIAAgsCBgMCAwYDAgACAAIEAAIAAgACCQIAAgIDAgkCAAILBgACAgAEAwQABAICAgIABAIDAgMECQIABAACBwQFBAIEAgIAAgACBAICBAICAAICAAIHAgQFAgACBQICAAIAAgIABAQHAgICBwQAAgIHAgUCAAIAAgIABAAEAAQAAgMCAgICCQIAAgICAgACAAICAgUEBAYCAgICAgQEBwIEAgQEAAIABgACBAAEAgIEBAQCBgACAAYAAgQECAIEAAICAggAAgQABgIEAgICAAQGAAQABgAEAAYCAAICAwQCAwQABgIGAgACCQQEBgQCBAQAAgAEAAICAgQCBAICAAYDBAIEAAQEAgIEAgQCBAACBAIEAgICAAQABAAGBgQCAAIACAQACAYAAgICCAACBgQCAgYGAwgCCAIEAAgAAgQDBgICAgQGAgQEAgIEBQYCAAQEBggAAgAGBQQCAgACAgYEAwIGAgAEBgACAgIACAIEAgIABAQAAgACAgICBAMCBAICAgIGAgQCBAICAAYACAACAgICAgIDBAYAAgICAAwAAgIIBAACCgQCAwIGBgYGBAQCAgQDAgMCAgQABAIDBAIAAgYCBAACAgICAgACBAICAAIDAgQABAIEBAICAAICCgYCBAgECgYAAgACAgQCAwIDAgoCAAQCBgIEAgIDBAICCAACAgAEBAAEAAIIBAIEAgMGAgYCAwQCAAQCBgQAAgYEAgQGAAIDBgACAgICAwICAAIDBgICBAQDBAYCAgIEBwQAAgAEAgIEBgICAAQCAAQCAAQCAgQAAgICAwIFAgACAAYCAAIAAgQCAwQCAgQCAgICCgACAgAIBgICCAAGBgACAAIGAAQDBAICAgACAgACAgQEBgICBAQCAgICAgUCAAIAAgQCBgIEBwIAAgICBAgEAgACBAACCAMCAgICAAIGBQIEAgIABAIACAIGAwYCAAIGAgACBAQDAggCAAoDAgICAgMCBAIGAAQCCAIAAgYEAAYCAAQAAgQGAgYEBAIEAgIDBAACAAICAAIABAMCBgYCBAIEAgACAggKAwIEAgAEAwQGAgMEAgACAAQAAgAGAAQABAYIBgIGBAQAAgICAgIEAAgCAgACAwICAgIAAgQCAAIAAgICAwQCBAQCAwICAgQCAwICBAcCBQIEAAQAAgICAAIGAAQCAgYCAgAEAAICAgQEAAICAgMCAgQCAgYEAgQABAYCBAgAAgYGAAICAwIAAgIEBQIFAgQAAgQABgACBQQCAgQFBgIAAgQLAgIEAgQEAAQDBgYAAgIABAQCBgIEAAICAgAGDAICAgQCBAACAAICBQICAAQCBgQEBgIAAgICCgICAAQEAgACAgACBAIEAwICBgAEAgAEBAQGAgQAAgIABgICAAgEAgACAggCBAIEAAIEBAAEBgYACAQCAAQEAAIDBgAGCgAEBAACBgQCAgQCBggEAgQCAgYCAAYCBgQEBgYCAgQMAgIADAIEBggEAgAGBgIABAICAAQEBAIGDAgACAgGBAQQAAoGAgoIBAYCBgICAgYABgQECgYEAgYCAgAIBgIIAAYCBgACBAICBgQCDAQEAgIGAgICAgQGAgQGAggCCggGBgYEAgIGCAgEBgQABgQEBAIABAoCAAgCAAIGBAQMCAIEBAIEAgQEAgQGAgQCBgYCBgIABgIEBAACBAYGBAIEAgAEAgQCBgQIBgQECAwKBgIEBAAEAgYEBAIECgIGBAoGBggEBgICAgAEAgIECAYGAgQAAgAECgIEAgAEAggGBAIQAAICCAIGAgQIBgYCBgYIBAMCAgoAAgACBgAIBAICAggEBgQCAgQDBAICAgMEBAIEAggCBAIGAgQADAQEBggEAgACAgQABAQEAwIABAgEAAQEAgACBAgCAAYEAgQAAgQABAMEBAYEAgIGAgYCAwICAgQAAgYDAgQAAgQCAAICAAYCAgQAAgICBAgCAgIEAAICBAIIAAICAgIGAAQABAIEBAICCAgCBAIEAgQDBgIEAAYCBAACBAQGCAYCBAAEAgQEBAIGAgUCBAQAAgQCBQICAgACAgACAwIABgQCBAgABAMCAgQIAgQKBQICBgkEBgQCAwQCBgIEBAQCAAYDAgMCAgACAwQCBAMCBAQCAgAEBAQCAAICAAICBggEAwQCAAQABAMIAgQCBgYCAgACAgACAAICAgQCAgYEBAICAAICBgIFBgACBgICBAAEAgIEBAIFAgUIAgMEBAACBAQCAgIDBAIGBAIEAAQCAAQCBAIABAgAAgICAgACAgQAAgcEBAACAAIPBAICBgACAgMEAAICAgICBAQABgQCAgAIBAICAAQCAAICBAIAAgMCAgQAAgICBAYCAgYEAgQCBAICCAACAAQAAgIEAgIEAwQAAgICBQQAAgQABAQFAgICBgIEAgIAAgICBgcEAgAEAgQCAgACAgIABgQDAgIEAgQIBQICAAICAAQAAgMCBAICAgACBAQEAwIFBAIEBgIABAQCAgMCAAICAgMCAwQAAgICBAUCBAUCAgAEBQICAAIFAgYCAgIABAIFAgQAAgAGCAMEAAQCAgMEAgQFAgIABAIABAIABgQFAgIDBAMCAgACAgQCAgAEAAICAgACBgICAAIIAgQCAAQAAgMCAAIAAgACAgAEBAIAAgMCAwQABgACAgAGAgIEAgACAAIEAgICBgIEAgIKAgYEAgQGBAoKBAgGCgQGBAQGBgQGBAQGBAQCBgYGAgQCAAYABgQGCgYCAgQGBAQCBgQEDAgECAQCBAQCBgICBAoIBAQGAgYCAgIEBAICCAIEBAICBAYCBAICAAIKAAICBAIGBAQDAgQCBAQIBAQEAgAEAggEBAACBAYABAACBAIEAAQCBgICBAACAgAECgYCBAAECAQGAgQABAAGBAgCAAYCBAQAAgIGAggIBAQGBgICAgQCAwIGAgQKBAQCAgYKBggKAAoCAAoEBAQIAgAGAgIEBgICAgICAAIEDgAGCgIAAgAEBggEBAYGBAAEBgACCAIAAgYEBAQEBAICBAIEBAQCCAoECAIGAAgEAgICBgIKBgAEAAQEAAIEAgICAAQABgIGBgQCBgYCAAYABAAIBAIEAgQGCAQDBAQIAgIABAQCAgIAAgACAAQCAAgAAgQICggABgACAgQEAgACAAQEAgQEBAYAAgIIAgcEAgAEAAQKBgQAAgICAAYDBAYCBgMCBgACBAYCAgQEAgIABgAKBAIEBAICAgMEAgYCAgIGBAYCBAICAAIECAYCAwYCAgICAgIAAgIDAgMCAgQEBAAEAgICBAYABgMCAwQEAwICAgYCAgAEAgICAgUCAAIGBAACAgIAAgUCCAIIBAIEAgQGAAIABAQDBAQCAgIDBgIABAICAwIEBgIGBgQCAgAIAAQEBAAIAgIEAAIEAgICAgICAgMEBAAEBgICAgICBAICAAQCAgICAgAGAgICAgACCAIAAgkCBgIDBAIEAAQAAgQCBAICAgQABAIABgYEBAIEAgACBwICAgAEAAYDBgICAAQDAgIAAgICAgAEAgIAAgAGAAYEAgIABAACAwIABAAEBgMCBAIAAgMEBAIAAgIAAgACAgACAAIABAAGAAIFAgcCAAIDAgICAwIABAICAgACBQIAAgICAAICAgIAAgIABAMEAAICAgACBAMCBAYCBAMCAAIDAgkCAAIDAgIEBwQAAgICAwICAgIFAgAEBwICBAkCAwIGAwIAAgAGCAACAgACAAQABAgLBAAGAAYEBAACBAIAAgAEAgIAAgICAgAEAAIECAMCAgUCAgACAgIEAAIAAgAGBAQFBAIAAgIABAACAwgEBQICAAQCAgAEAwIAAgkCBwgCAAQCAAIFBAIEAgIEAAIFAgACAAIAAgIGAgACAgACAwICAAQEAgIFAgQAAgACDwICAgICAAIEBgQIAgYIAgACBAIEAAICAgQEBAQEBgIMAwIDAgIEBAQCBgIABgIEAAQCBAQICAIDAgAKAAQGAAQAAgQHBAAGBAACAAQDBAIAAgAEAgACAAIEAgIIBAICAAICCAQCAgIABAUCBAACAAICBAIABgYGAAICAAIAAgYDAgMEAgQCBAYEBAQCBAIABAIGBgIEAAQGAAIIAgIEAgQAAgAEAAIEBAgIAgYDBAUEBgICBAQEBAYEAggFAgAGAgQEAAQACAIABAIABAICBgQCAAQCAAQGBAQABAIAAgMGBAIDBAAEAAQIAgIEAAQCAgYFCAIGAgACAgIABAACAgAEAAgCAgYDBAACAgICAgUEAAQAAgMCBgQCAwQCAgQCBAQCAgAGAAICAAQEAgICAgMEAgAEAgYDAgUEAAICBAAEBAIEAgIEBgQDAggCAgIEBgICAAQAAgoDAgACAAIHBAACAAYAAggAAgIFAgICAgQEBAIDAggEBwIAAgICAAIEAgICAAIAAgAEAAICAAIAAgACAAYAAgAEBQIDAgMCBAAEBAIAAgUCAAQDAgAEBQIEAwIDAgcCAAIDAgIHAgYCBAAEAwIHAgYDBAQDBAIEAAQAAgMGAAQDBAIFAgAGAAgDAgICAwQCAwIKAAICBgACAgACAAQABAACAgACAAIABAIAAgIDAgICAgACAAIAAgIAAgIAAgACAAICAAICBQQFAgMEAgMEAggCAgAEAgUEBAICAgMCBQIAAgICAwICAAICAgIGAhMCBAMEBgAGBQIEAAQCAAICBgYDAgIEAgUCAgIDAggEAgQCBQIABAIDBAMCAAQDBAIDBAIABAIEAwICAwIFAgQHAgICDwQAAgACAwIDAgYCAwIEAAIAAgIAAgIAAgsEAAICBQQFAgUCBQIHAgMCAgACAwIAAgACAAIAAgMCBwIAAgACAgACAgUCHwIEAAICAwQCAgMCAhECAAIAAgQCBwICAgUCAgYABAIAAgcEAgAEBAIABAACAwQAAgMCAAICAgAGCQICAgIAAgcGAAICAAIAAgIDAgYDBAkCAAQABAIPAgACBwIFBAILBAICBAMCAgACAgIDBAMCAwQDAgICAwICBgAEAgIEBAAEDwIABAICBAIGAgICBQICAAIFAgAEAgQCAAIEBAYDAgQCAgQDAgAGAAICAgICAgICAgsCAgYCAwIAAgACAAgCAgACAwIEAAIAAgMCAgYCBAIEAgACAAIAAgIABgACAgUCAAQCAgIAAgMCAwQAAgACBQQAAgACAAIFAgMIAAICBAACAgIAAgAEAAICAgACAgIHAgcEBQIEAAYHAgIEDQQJAgMCAgIEAAICAgIHAgUCAwICEwICAgAEBAAEAAQDBgIFAgIHAgICCQIAAgICAAQCAAIIBQIFBAAEAgQEAgICBQICCQICAgMEAgcCCQICAgMEAAIEAAICAgsCAwIAAgAEBAkCAAICAgUCBwICBwIAAgMCAgIDAgACEwILBAIDAgACAAQAAgILAgUCAAQCAwIFAgIHAgIJAgIAAgIAAgcCAgUEBQIDBAMCAwIABAIAAgQFBAMCAgACAAIAAgkCAgAGAAQHAgMCBgcCBQIDAgIFAgIEBAIAAgACBwIDBgICAg0CDwIRAgACBwYEAgIEBQIDAgACAAIAAgcCAgMCAAIABAACBQIFAgUCAwILAgACBwIABgkCAwQAAgACAAIXBAsEAwITAhUEAAIDAgACBAUCAgUCAAICGQILAgUCAgIAAgICDQIHAgACEQQRAgMEAAIEAwICAAQLAgMGBwIDAgMCAwIDAgUCAwIAAgUCBAACBQIAAgACBwICBwIVAgMCAwITAgACAwIJAgACBwICBAACCwIEAgkCAgQAAgsCAgIABAIAAgIAAgUCAg0CCwICAAIEBQICAAIDBAkEBQIABgACAgACAgMCAgIAAgQCAgsCAwQCAgsCBQICAhECCwIAAgsCAgACAAICDwIFAgMCCQICBQYLAgkCAAIAAgICAgACAwIJAgkCAAIAAgcCAgMCAgACAgACCwQCBQICAwICCQQDAgAEAgMCBQICAgIDAhkCAAIFAgIAAgACAwIECQIEAwIHBA0CAg0CAAQNAgUCBQIbAgAEDQILBAICCQIAAgACBQIpBAUCCwICAwQLAgUEAgACAAIJAgMCAAIJAg0CFwIRAgACCQIDAgIFAgACAAIAAgACAAIbAhUCGQIFAgMCAAIPAgsCLwQHAgIFAgIRAgcCBQIDAgkCCwICDwICDQIHAgACAhsCAhECAgMCAgACAgIZAgMCGQIDAgICNwIAAgkCAAIXAgUCAgkCGQIVAgIFAgkCCwInAgUCAAIDAgACBwINAhUCAAIJAhUEFwIPAgMCGwIJAgUCAwIfAgACAkECAgkCGQIDAgsCBAACBQILAgMCCwILAgkCEwIfBAUCEQIDAgIfAg0CAAIDAgUEAAIDAgkCDwIFAgUCAAIAAhsCAwIHAgsCAAIHAgcCBQIAAgQCDQIZBAUCAg8CEQQfAi0CEQICCwINAgkCEwIRAhUCBwIHAh8CBwQAAg8CEQIDAgsCEQILAgACEwILAhECHwQDAgsCAhMCCwITAgkCAgkCAwIhAgACJwIFAhcCDwILAikCAwICEwIhAgsCLwInAhcCMQIRAgUCFQJBAgcCBwJRAhcCAgMCAwIHAgcCQwIPAgACCwINAhMCMwINAg0CBwYCAwIHBAMCBwINAgkCBwIFAgACBwIDAgkCDQIDAgkCEwIDAg8CDQIDAgcCAwIHAg0CCQIDAgIFAg8CEQITAhkCCwICHwIDAgcCAwIZBAUCHwICBwIXAhECAwIzAgUCKwILAg0ECwIAAhkCBwILAi0CGwIDAgMCFQIHAhUCDQIvAgUCBwIAAicCDwItAj8CSwIVAgkCEQIfAhMCIQIrAhkCKwI9AjcCDQIzAhkCPQIfAh8CmQECNwIAAgkCDQIXAgIHAhECBQIHAhsCAwILAg8CFQIVAg8CEwIFAgMEBQIdAj0CEQINAiUCQQIfArMBAh8CGwIHAgcCAgMCGwIDAhUCCQIAAhsCFQICJQKDBAKzBAKhEAINAgMGAgACAAIDBAsCAAIAAgUCBQIXAgACAAIPBAUCAAJjAg0CAwQNAgcCCwI5AgACCQIDAgMCAAIPAgACBwIfAgUCNQI9AgILAjUCBwIDBBsCJwIAAgIFAj8CHwJvAgUCCQINAgUCBJMBAsECAnMEAAIAAgUCXQIAAgMCAAIFAgACCQINAicCAAILAgsCCAUCAgYAAgACAgIJBAAEAwQFBAcCSwIDAg8CAwIAAiMCAgsCAAITBB0CHQIVAg8CKwIxAjMCAAJ5BgQ3AgIVBAAEBQIRAjECHQIAAikEAAIFAgAEBA0CAAIABAYABAICFQIJAgACAAIAAgIIAgYEBAQGCAIGBgAMCgIAAgACBAACAgMGBAQIAggCAAICBwIEAAIAAgQAAgYEAAQCCAgDBgYEBAgKBgoGAgQEAggCAgIEBAYEBAQABAIEAAIGBgICCAoGBgoACAoMAAwICAoMBggEBAoIAgoIBAoIBAYGDAQECAQCDAIEBAIABAMCAgYGAggEAgIEAgYGBAIGBgQEAAQECAQABAAGBAgIBggCBAYEAgICCAIGBAACAgQICAYGBAIEBgQEBggGAA4KBggGDgYIChIEBhAQBg4EAgQGBAICAgIEAgIEBgICAAIDBgQGCAQEAgYEBAQOBAgGBAYECAoIDAQCBgYGBgwGDAwEBA4EDhIGDAIODAwIEBAGDAgACAgGBAQAAgIGBggGAAQCBAgCAwgDAgQCAwIDAgQDAgUCAgACAgwEBgIEBAgCBQIHBAICBAQJAgQAAgkCAgUEAgIAAgIEAgQCAgYGAAQIBAYCBAICAgIAAgQEAA4CBgYABAgIAgoEBAQCAAICAgACBAQCAgIEAgYAAgQCAAIEAgACAAQAAgMEAgQEAgUCBgQGBgIABAQCCAQGBAQKBgYECgYGBgIEAwQIAgIEBAQIAgoGBAIEBAIMBAIEAgQEAgYDBAIGAgUEAgIAAgQIAgACAAIvAgMCBwIfAgMCAAIAAgUCAAJRAg8CCwIFAgACMQQEAgACAAIAAgACAgQFAgICCwIFAgAEAhcEAgIAAgMCAgAEAgQGCAYCCgQDAgAGAgIGBAICBAgGBg4EBAICBAgAAgICBAIEBgYEAgICBgIFAgQCAgQABAIDAgUCAAIFAgUCAAQNAgACAgcEBwICAgIAAgkCAgIEAggGBgICAAQABAIGAwYDAgACHQQABAILAgIEAgcEEQYCBgYABAYCAAICAAQCAgYEBgAEBAYECAoGAgIABgIAAgACAAIEAAIEAggDBgMEAAICAwICDQIJAgAEAAIAAgIABAIDBBMCAgIEAwIDAgILAgACAAIHAgkCAAIjAgICJQIAAhcCBQQFAgACBwIFBAMCAgIFAgcCBQIFAiUCBwQDCgIEAgILAgMCBwQFAgIHAgcCCQILAgIHAgUCAwIAAgMCAgMCAAIHBAkCBQIFAgAEBAQIBgICAgACAAQAAgMCAwQAAgACAgAEBQICAwQCBwIHAgMCAAILAgACGQQCBAIAAgIAAgAGAgUCAwIDAgMCAwICBQIGAgMEAgIACAoEAgIAAgMCAAIFAgIEDQIAAgACAAIJAgkCBAACAwQHAgQCBwICAgACCQIAAgUCDwIHAhcCAAQDAgUCCQIHAgACAwIAAgsCAwIABA0CAgsCAwIGBAACCQICAgYCCwYAAgUGAgIACgIEAgAEBAQKBAQAAgIEBgICBAACAgYCAAIIBgICBgQGBAQCBAIEBAwCAgIIBgIGAgAGCAQACAgECAQIDAQGCgwMDAQGBAwGBAgGEhIECgwMAggKCgYGAggIAgYEBggCAgIGBggKEBAKDgoOCAACBgYGAgQEAAICAgQCAgQGAgACAgQABAIAAgMCCwQEAgACBgQKCggCCwQCBAICAgIAAgQEAgICCAYIBAIIEAgIBgYDBggICAgGAgMGBAQCAgMCAwIABAACAgMGAgAEAgIJAgACBQICAwIDBAIJAgIAAggABgAECwQJAgcCCwIJBAAEAgUCAAIHAgcCAgIAAgACAgMCBQIAAgoHBAIEAAICAgIEAwIEAgICDwIHAgMCAAINBAUCAgUCAgQABgIFBAICBQIGAwgGCgIAAgQnAjsCAg8CAg0CJQIPAgUCAgILBAcEAAQCAAICAg8CAAIJAgMCAhMCAAIAAgACKwICCwIbAgMCDQIDAgkCAwICCQIFAgACEQICAwIVAiUCDQIJBAIDAhECAAIDAhMCAgACAgIEAAQEAAIAAgACBgIABgIDAgACAwQAAgAGAgACCAICCAIAAgMCAwICAgIABAIEAgIAAgMCFQICBwIAAgsCAEoqCAQEBgIAAgMEAgMCAgMCBwIAAgAC"
+        },
+        {
+          "operation": "composition_update",
+          "requests": 654,
+          "errors": 177,
+          "latency_ms_p50": 19251.199,
+          "latency_ms_p90": 30048.255,
+          "latency_ms_p99": 30261.247,
+          "hdr_v2_base64": "HISTEwAAApsAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAKXBAQIdAk0C4QUC+wYCqQYCjQICBQQdAhUGAwITAicCGQICAAQJAgsCNQIAAgIFAhMCAwIHAgICDwQAAgITAgUCAwIABAkCDQILBAIJBAIAAhECDQILBAkCAgcCAAIVAgAEAwQAAgMCBwIAAgAEAwIbAgUCAkkCGQIfAgACEwJZBBsCDwQHAgICAgACBQIHAgMCCQIFAgMCAwIJAgUCDwICVQIDAmMCWQIXAgcCKwI/AgkECQInAhcCKwIFAjkCCwQXAh8CLQIHAhkCAwIHAgkCHQIRAgkCOQIpAgJHAgsCGwICHQIrAgIrAgUCCwIXAg0CAwILAg8CKQIDAhMCCwIdAhUCGQIHAi8CFQIPAhkEKQICEQIVAisCDwICBwIHAiECIwIJAgMCLwIdAh0CCQIRAgMCAAIJAgMCCwQFAgIDAgAEAAQCBQQFBAIABgMEBAYIAgQEBgQCAgIGAAIEAgQEAgIIBAYAAgIAAgIAAgAKBgYEAwICAgIEAAIECQIAAgYABAICAgQEAAIABAIAAgMCAwICBwIDAgMCAAQGBwIHAgMCAAIEBAYAAgQDAgQCAgICAwIGAwIHBgIEBAQCBgICBgQGBAMCAgUEAAQCAAIEAAQFAgIJAgIbAgMCAgcCAg8CDwIPAhMCAh8CJQIAAgACCwIVBAcCFQIZAgcCAAIDAg8CAgsCAAITAhUCDQITAjMCBQICBQIVAhcCCQQCFQIFAgIVAgMCEwIjAgACDQIHAgcCGwITAgcCEQINAhMCBwIRAg0CAg0CAhsCBwIVAgUCDQINAgACAwIABAACAgQCBwQDAgIAAgMCAgIDAgUIAAIEAAQFAgIABAACBAAEAwIrAgcCDVxiPhoMBgQQCAIEAAYAAgYFAgACAwY="
+        },
+        {
+          "operation": "contribution_commit",
+          "requests": 234,
+          "errors": 89,
+          "latency_ms_p50": 23379.967,
+          "latency_ms_p90": 30081.023,
+          "latency_ms_p99": 30474.239,
+          "hdr_v2_base64": "HISTEwAAAQEAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAM+bAQLXQALdBAILAmsCOwI1AiECFwJTAh0CHQILAgIAAgcCGQIFAkkCgQECjwEChwECSwLfAQJVAlECmQICCwRxAjcCaQIJAgkCTwICNwIAAj8CMwIDAgACBQICAgICCQIFAg0CAAIDAgMEBQYCAAICDQYCAgIAAgIGAgQFAgACBAIPAgACAAYABBECAwIDAgMCDwIJAgIDBAkCBwICAgACBQICAAQABgUCAwIGDQIPAgMEAgQHAgMCAAQjAhcCAAI/Ak8CIQILAi0CAwITAgsCBQIjAjkCAwIZAgUCFwInAgkCUQI7AicCDQQoKCoQDgACAgACAwIHAgcCBwQFAgkC"
+        },
+        {
+          "operation": "contribution_read",
+          "requests": 944,
+          "errors": 276,
+          "latency_ms_p50": 19628.031,
+          "latency_ms_p90": 30031.871,
+          "latency_ms_p99": 30261.247,
+          "hdr_v2_base64": "HISTEwAAAt4AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPFmAtdwAj8E7QECPwIVAmkCCQQAAiECJwK9AQIDAmkCDQJpAj0CdQIDAiMCKQQdAg0CHQIfAhcCAg8CGQIDAgUCCwICEwIVAgIXAgUCBQIfAhMCBwQbAgsCFwIFAiECCwIJAg8CAwILAgACBwIRAg0CGQIlAgACCwQDAhMCHwIbAg0CAAIXAgACAiUCEQICAgcCAwICAAIZAg8CAgcEDwIfAgUCFQILAgMCGwIDAhcCEQICDwILAgcCCQILAiECAhcCAwIHAh0CAhECCwILAhUCAAQbAgMEIwIFAhsCBQIAAgcCCQIFAisCCQIXAhEECQIdAgACAwIXAgIAAgMCBQIAAgcEAAIDAgMGAgIEBQQEAgQIAAIECAAEAgAEAgACCgYEBgQCBAQIBggOCgQGBggGAAYKBAoIBAYCBAYEBAIDBgQECggCBgYEAAgEAgMEBAAIAgICBgACAgQCCgYEAggGCAIABAAEBgQHAgIAAgACAgIABgIGAAIEAAICAAICAwICBQICBAgCCAICCAIABAIGAgQACAIGAAIAAgICAAgGCAAGBgYGBgQIAgYCCAYACgYCAAYEBgIABgICAgYCAgUECwIDAhUGDQYLAgMCAAINAhECCQIDAgcCBwQAAgMCCwIPAgILAgsEAwICDQIFAgcCCQIFAgACEQINAgMCAwIFAg8CDwINAgIAAgIFAgUCEQIRAgMCDQIDAgkCAgIDAgUEAhECCwIFAgsCAgUCAgMCAAIPBgUCAAIHAg8CCwQHAg8CDQIDAg0CCwIAAgIRAg0CAAITAgILAhECAAICBwIAAg8CAgACCwICAgMCAgUEAAICDQITAgkCBBMCCwICCwIAAgUEAAQABAAEAgACAAIABAQCAgIDAgACAwIGAgMCBAQIAggCAgACAAQCAwIEAAQCAwIAAg8CBwIDAgUCAwIRhAKMATYUDgYOBgYEBAMCAgIFBAIAAgUCAAIDBAcC"
+        },
+        {
+          "operation": "directory_create",
+          "requests": 72,
+          "errors": 46,
+          "latency_ms_p50": 30015.487,
+          "latency_ms_p90": 30031.871,
+          "latency_ms_p99": 30146.559,
+          "hdr_v2_base64": "HISTEwAAAEYAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAM3iAQL3AQLvAQLDAgLlAQKlAQKXAgLnAQJtApsBAj8CfQJXAnMCyQECMQIlAk8CBQJbAgAC3QEEVwIDAjUCOzAeAgYEBQI="
+        },
+        {
+          "operation": "directory_read",
+          "requests": 8251,
+          "errors": 6512,
+          "latency_ms_p50": 12.983,
+          "latency_ms_p90": 16875.519,
+          "latency_ms_p99": 30031.871,
+          "hdr_v2_base64": "HISTEwAAGsYAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAN0IAoMCAp8BAoUBAgACGQIJAmcCEQItAjsEAgIAAhECCQIlAgcCRQITAhUCBwQDAgUCBwIAAgkCBQIVAgIDAgACBQIPAgACCwICHwQJBAACFQIFAgACDQICAgIDAhMCDwIRAh8CAgMGBQIAAgMGAwIAAgcCCwQAAgACCwINAgACCwIRAgkCAAIJAgACAAICBAACAgQAAgIABAIAAgMCAAIHBAIABAAECwIAAgAEAgUCAAICAAQFAgIRAgUCCQQPAgcCBAICAwICGQICAwQABAsCAAIFAgsCAwICAAIFAgQHAgkCAgUEEwICAgcCAAIDAgUEBAMCAgACAwIAAgIAAgMCAAQABAQFAgcCBBECBAcCAwIAAgICAAQHAgUCAAIDAgUCDwIAAgUCAgIJAgMCBQIAAhcCAwQJAg0EAgIABA8CAgcCAAIAAgMEBwIABAIDAgACAgACAgUEAgUEAAIPBAQAAgICAAIJAgkCAAICAwQCAgICAAICAgICAAQAAgMCBwIAAgIFAgACBQIHAgIAAgIHAgICAgMCAwYFAgIAAgIEBQIAAgcCBwIAAgICBQICBQQJAgACBAACAAYHBAAECQIJAgICAAICCQQAAgAGBwIJAgIDAgUCAAICAgIDBAQAAgAEBgMCAAICAwICAgIABAAEAAQCAwIABAUCCQQAAgICAgkEAAQCBwYAAgcEAgMCAgAEAwQGAAIABAIFAgICAgQAAgMCBwIFAgIEAgICBwICAgMCAAQCAAIEAAIDAgAEBAAIAAQCAgAEAgQCAAQABAIFAgMCAgcCAgICAggCAggCAAICAwIEAAYAAggDAgICCAoACgACBwIDBAAEAAICCAIEBAYCBgICBQIEBAACAAQABAICBAQAAgACAAIEAAIABAIEBAICDAICBgYCAgIAAgIEAgIAAgACBAQCBAgCBAIEBgQDCAIAAgoEAAYCBAIDAgQCCAYABAIGBgIEBAQEAgYCBAICAgAEBAACBAIEAgACBQQEAgIEAgICAgIEAAgCAAYAAgYEBAACBAQEBggACAIGBAACCgQIBgICBgQDAgIGBgIGAgIGAAIDAgMEAgAEAgQEBAIEAwIEAwIEAgIEAgQFAgIEAgQEAgIEAAICCAIACAQEAgQABAQGBAYEAgAEAgIGAgQEBAQHBgQEBAQEBgIEAAQABggEBAMEAgMCAwgEAgIEAgQDAgIHAgAGAAQCAgYCAgIAAgIAAgYCAgIEAgIDBAYEBgIEAAQEAgIGAgIGCAoCBAMCBQIEAgQGAgIABAUCBAUCAgYCBgAGAgQAAgACAAIGBAICBAIDAgAGBgMCBggEAgACAgIGAwQCBgMGBQQCBAQCBAICAgMEAgIAAgAGBAACAgIABAICBAACAgIAAgICBAgKAAIAAgAEAAYDAgQEAgIDBgQCAgIAAgIEAgQAAgQCBAIABgICBAQEAgQAAgIGAgACBAACBAACAgICAgYCAAQGAwIGCAAEBAMCBAQCAAQCBgAEAAIEBgICAgQCAgICAAQGAAQEAgQAAgYCAAICAgIGAgUMAgQEBAACAgICAgQEAgYDAgQCAAQEAAICAgIEAAoEBAICBAICAgICAgAEBAIAAgMCBAIEAgYEAgUEAgICAgIEAAICAgIGAAIDAgICAgQCAAIIAgQCAgYEBQYCAgACAgACAgUEAAQCBgQCBAQCAAQCAAIGAAIGBwIEAgIAAgACAgACAwoABAAGBwQKAgIFAgACBAQCAgIEAgQAAgIEBAUEAgMEAAYCBAMCAgICAAQDBAIEAgYCBAIAAgICAwQCBggEBwIAAgIABgACBgIABAIEAAQEAgICAwYCAgICAAIEAgICBwIFAgQCAgQCAwQABAQEAgACAgACAwgEBAACBAYCAAILBAQCAAICBAQIAgIEBAACAgYABgMCAgICBAICBgQDAgACAAIFAgAEAAICAAQEAAIABgYCAgQCAgICAwIABAICAgIDCAIGBAQGBAYCBAQGBgICBgYCBAIGBAIEBAQIAgYDCgQGBAQCAgQCAAIEAggEAgYMBAQEBAQJAgIGBAQCAgAGBgIAAgAKAAQEAAQAAgAGAAQIBgICDgICAgQABAYCBAQEBAQDCAAGAgQGAAIIBAIGBgQCAAQGBAQEAggIBgQCAAQCAAQGAggIAggAAgACBAYIAgQGBAYGBAIGBgQAAgQEAAYDBAIIBAIEBAgMAgQCBAYGAgACBAICBgoEAgYEBAQGAgYEAgIEBAgCAgAIBAQKCAYGAgwABAICBAgCAgIAAgoGBgIGBAIEAgICAAYCBAYEBgQEBgAEBAQGAgYGAAIIAgACBAgCBgQGBAIAAgAEBgICBAYAAgQCBgAGBgIKBAQAAgIEBAIEBAQGAgQCBgYEAAQCCAICBgQCBAgACAIAAgYGAAQEAgoEBgQABgQAAggCBAQCBAICAAICBAQEAAIGAAQCAgIGCAAEAAIGBgAEBAQCAgMCBgYABgQEAgQCAgQECAQGAgICBAQCAgAEBAQCBAAGAgACAAYEBgQABAAGAAQCBgYCAAICAwICBgACBgMEAgIIAgQCBAIGBAIEBgYAAgYGAwQEAAIEBAICAAICBAICAAIGAAQABAYDAgAEBAQEAgIGBAQEAgACAwIIAgAEAAQEAAIEBAYCBgYEBAAEAgIEBgQEBAIEBAUCAgUGBgICAAIECQICBAMGBAYCAgIABgACBgAGAgQEAgICAgQEBAQAAgYEBAYEAggCAgIGAgIEBAYEBwQEAgIABAICAAIGBgAEBAICAAYAAgICAwYCBAACAgYEAgICCQICBgQDAgICAgMECgIEAAICAgAEAgIEAAICAAIGAgICAAICAgQCAgACAgQEAAICAgQABAACAAICAwICBAQCBgMEBgIEAgAGAgAEAAYCAAIEAgICBAQGAgIEAgYCAgICAgQCBAACBgAEAwIEBAIDAgICBAMCBAQGBAIEBAIDBAIDBgQCAgIAAgYEBAIDBAICAgAEBAIACggCAAICBQIDBgAGBgACAAgEBAMCAgQEAgIEAAQGBAIAAgIEBAACBgQACAMECAIAAgACBgACAgIGAgIGAAIDBAQEBAICBAQDBAACBAUEBAIEAgICAgQIAAQGAAgCBAMCAgAGAgIDAgICAAQDBAACAgAEAgACAAYAAgIEAAQAAgIEAgAEBgIADAIDBAACBAIEBAYCAggAAgYEBgQGAgYCBAIABAQCAgQAAgIGAgMCBAQGAgAEAggABAACBAMEAgIABgICAgAECAIEBAQCAgACBAQEBAgAAgIIBAIIAAICBgQEAAIIAgQEAgYCBAYABAIEAgYEDAQABAYICAIEBAQEBAgCBAoGBAYEAgoIBAQCBgYGBgQGAgoEAgQKBAYCAgAKBggEAgYICAQCAgQCAgYEBgYGAgIKCAoCBAQCCAAGBAYGAgQGBgAGBAIEAgYCAAIGAgYIBAACBAQIAAQEAgQEBAIGAAgEAgYCBAYGAgQEAgMKAwQEBgQCAAoGBgYABAgEBgIKBAQGCAIGCAAIDgIEBAQEAgICAAQECAQCBgoCAgYCAgQEBAQCAgYGBgAEAgIEBAQGAAgEBgIGBAIEBgIEBAQABAQCBAACBAYAAgAGBAQGDAQCAgQADAQCBgQCAgIGBAQEAgQEAgYGAgIGCAwGBAIGBgQAAgAEBAMCAAQABAICAgQABAgFBAQGCAQCDAYCAAIEAgAECAAEAwQCAAQGBAIACAYAAgQAAggCBAIABAIEAgACAgIEAAIEBAIAAgQGAAICBgACAgACBgICBAICAAIACAQCAwQABgACAAQCAAoCAgACAgQFBAQAAgQEAgMEBAICAgICBAACAAIDAgIEAgQEAAIABgYCAgICBQYEAAIEAgQABgICBAIGAgYCBwICBAAGBAICAAIAAgAEBQICAgAIAwIABAACAgACAgAEAgQFBAMEAAICAgIDBAUCAgQAAgIEAggCBAQEAgACAAIEBAIFBgICAAQCBgIEAAICBAQAAgQCBAICAgIAAgICCAACBgQDBgQGAgIEBgICAgQJAgACBAIEBAICAAQAAgICBgICAAIABgMGAgACAwYEBgUCAAYEAgACBgAEAgIIBAACAAIABgICAAIABAAEAgIAAgACAgIGCwQCBAMCAgACAAIFBgACAAICAgQDAgICAgACAAIECAACAgMGAAQCBAIEBAQCAAIABAUCAAQCAgYCAAIDAgIAAgICAgQDBAMEAAIGBgACCAIEBAMCAgYCAgQCAgQAAgIEAgICBgIABAYABAACAAQCAAIEAAIAAgIFBAIFAgACAAICAgACBAAEAAQAAgQEAgACAAYAAgMCAgIEAgQAAgMCBAAEAgICBAIAAgICAgICAAIDBAACAgYCAwQDBgAEAgMCAgIDBAMCAgIAAgMGAAICAAIGAAICAgIAAgMEAgIEAgAEAAIAAgICBQIGAgMCBAACAwICAgACAwQEAAYDBAIFBAMCAwgHBAACBAQGAgICAgACAgICBAICBQIEAg0CBQQCCAICAAIIBgQCAAQIBAIABAQEBAQAAggGAgIEBAQGBAMEAAIIAAIEAgACBAIABAICAAQAAgAEAAYCBAMCBAQGBgQACAQEAgMCAgACAAQCAAYCAgQEAgQAAgAGAAQIAgQACAAEAgkCAgYCBAACAgYABAwEAAIEAAICBAQCAAIEBAMCAAQEBAMCBAQCAgIABAIEAgYCAgQDAgICBAIGBgIABAICAgACBgYIBAQAAgMCAAIECQIDBgACAAIEBAIAAgAEAAQHAgQDAgIEAgACBAAICQQCAgYCCAIEAgIDAgACBAQDBAQFAgUCCAMCBAUCAgQAAgACAAYAAgICBgIDBAICAgAGAgICAAYDBAQABAACAwQHAgMCAgMEBgcCAAIEAgIDAgIDBgQCAgACAAQCAAICBAACAAIAAgQIAgACAAICAgACAgQDAgMCBwICAAIFAgIGBgIEAgMCAwIGBQQACAQGBAAEAgMCBAcGAgICAAQABAACBAMCAgACAgIEAAICAgIAAgYDBAYFBgQFAgACBgYDBAICBQIAAgICAgQCBQIDBAMCDQQDAgICAAQAAgICAAIHAgIEAwQEAwIAAgMCAgIABgMCAgACBQIEAAQCBwQDAgMGBAICAgIEAAICAAIDBgIFAgMCAAIJAgMCAw4CAgAGAAQEAwIJBAACAgICAgMCAAIABAIABAICBgMCEQIAAgICBwYCAAILAgQAAgQAAgYABAYDAgMCAgQEAAICBgICAgICAAICAgICAgACBQIEAgQJAgYCAgUCAgACAAIAAgACAgICAgIAAgMCAgcCBAMCAgMCAgACAAICBQgCAAICAgIDAgMCAwIAAgMEBAQAAgQbAgICAgACAgIAAgIDAgACAgIHAgUEAgUCAwICAg0EBAICDQIAAgIAAgQFAgIDAgIHAgIAAgAEAAIAAgICCwICAAICAgQCAgACAwQDBgICAAIAAgICAwICAAICBQICAAICAwQAAgAEAAQEAAIDAg8EBAsCBAIEAAIABAQAAgsCCwICAAIAAgICAwIAAgILBAUCAwQAAgMEAwIEAgIEAgQCAAICAAIAAgIEAgIAAgIIAgICBwIEAgIAAgQFBAAEAwICAwIAAgQEAAQDAgIAAgQJAgAEBAIEAAIFAgIIAgACBgUCAAIDAgACBAICAgACAgIAAgIEAAQCAgIDBAIDAgIAAgICAwICBwQABAICBAACAgQNBAACAwIAAgMCAgkCAgACAwQCBQIABgUCBAMCCQICBwICAAIAAgILAgIABAACBQIEAwICBAcCAgAEAgQDBAICAgACAgACAgsCAAIAAgACAAQCBAIGAAICAwICBQQCAgYFAgICAgMCBwIDAgIDAgMEAAICAgACBwQAAgIFAgAGAwICAgICAAQJAgUCBAMCAAIDAgcCCwIABAACDwQDAgICAwQHBAIFAgACAgQAAgMCAAILAg8CAgIPBgMEAAICAAIABAAGAAIEAAQNAgMEBQQFAgMCAwICAAICAAgDAgAEAAINBAcCAhMCAgIDBAIEAwQDAhECAAICAwQCAgMCDQIDAgACAgMCAAICCQIAAgINAgcCAwQJAgIFAgMCAAQAAgMCAgIAAgMCAwIAAgACBQIEAwIHAgUCAgkCAgMGAwIPAgQDAgACAAICCQIJAgACAAIFAgcCAAIAAgUCAgMCAAICBAcCBQIDAgkCAAIFBAACAwIJBgACCwIAAgIAAgkGAgUCBQQCBwIFAgUEAgUCAgUCEwIfAg0CAgsCAgICBQQHAgcCBQIHAgsCAgsCCQILAhUCAwIDAg0CAAIHAhkCAwIDAgACBAsEAgcCBQILAgUCAgMCAwIDAhMCBQIFAgICCQQIAAIABAACCQICAgACCQIEAwIEAAICAwIDAgIDBAAEAgACCwIAAgcCDwQFAgIPAgUCAAICAAIAAhsEAgIAAgACCQICBwIFAgACAAIVAgcCAAIHAgUCBQIAAgMCDQQFAhECAwIHAgIAAgUCAAICAgACAwQJAgIAAgcCAAIAAhkEEwQFAgMCBwIFAgIEEQIAAgACAAIJAgICAgUCAgILAgIFAgUEFQQFBAsEEQIDAgIFAgsCBwIbAgUCDwIVAgUCAwIbAgIZAgMCCwQbBBkCAgMCAgkCCwIABBsCDwIFAhkEDwITBAsCAAIxBBkCEQIDAhcEDwIDBAUCBwICCwQhAh8CAgUCCQIrAhUCCQIDAhUCDQIDAhsCIwIHAgIHAhsCDQILAgACAg0CFwIJAgMCGwICEwICAAIFAgsCCQIRAi0CLQILAgkCAwICDQIHAh0CAgMCAgUCBQIAAgIFBAACAgUCCQIAAgACAgJjAgQFAgIJAg8CAAIHAgkCBwIFBAACAwIDAgIJAgILAgMCGwIzAkcCNQIXAgUCAAIHAgMCFwIFAgMEGQIHAhkCCwITAgAEGQIjAhMCAgkCBQI1AgMCAwIHAgACAgcCFQITAgUEDQIPAhcCMwIHAhsCBQIAAg0CAwIDAgMCJwICAhUCAAIHAikCDwILAgkCGQJNAkkCBQICBwIbAgMCEQIxAmkCCQICAwIJAiECEQIAAhECAAIFAgUCDwICBQIAAhUCAwIPAg0CAgIXAhMEFQIDAisCAiMCBA8CCQIAAhMCAAIJAg8COQIAAgACAAIRAisCDwIJAg0CCQIJAhMCBQI/AhcCBQIJAgACBwIjAgkCJwIFAgUCCQQHAhECBQQXAhUCBQInAhECDwIFAgQAAg0CIQIXAgMCdQQHAgcCBQJVAgMEDwITAhECLQICFwIVBAMCCwIFAgkCAAIVAkcCDwIAAgUCBwJFAlUCBwIFAgIRAkkCLwIJAjcCFQIFAhMCBwI3AgIZAgsCKQIAAgMCEQIFAgUCDQQNBBMCGQILAg8CDQIAAgcCDwQ7Ag0CVQIFAgIDAjcCCQIFAg8CCwIFAg0CBwIpAiMCAAIFAg0CDwIJAh8CBQIRAikCAwIAAgIJAh0CAg0CEQICBwIRAgMCBQIPAiUCAwIlAgkCFQIZAicCSQILAicCWQI7Ar0BAh0CKwIDAg0CwwECArsjAg8CDwIAAgIRAr8BAh0CrwECAAIpAicCSwICAAICCwJBAhcCDwIzAgI3AgACAAIHAgACAgQJBAcCAgkCLQIxAgJzAhMCewJvAgJJAhkCBQIDBAIFAgICGwIHAgMCBQIEAAICCwIAAgACEwYCAwILAgACGwIPAgAEAgQGAgQGAgICAgIGAwIDAgcCBwICBwIFBgMCAAQCBAIDBgQGAAIKAAoMCAYGAAIABAQEAAYECgQCBgQGBggICAIIBggGCg4UDBgiGA4EDAIKBAoIBAwIDhQOAgQEBgIAAgoECAYGBAYCCAgGAAYCAwICBAQICgwAAgAKBAIEBgoEBgYIEAACAAIEAgACAgQEAgIFBggDBAIEBAACAAIEBAoEBAICDgYKCAIKDggEAgQABggIBggKAgoMBgQIAAIOBgQGCgIAAgAIBAQCBgIECAwIBAQEDggEBgYOFAoKBAICAgYGBgQABAACAgAEAgwABAICBAgAAgYDAgQEAwYAEAgECgYECAIEAAgGBgQIAgAGBgwMAgYKDAgGBAACBgACBgYEAAIIBAgECAQCBAsEBgkCAg8CCQIDAgAEAgIAAgACAAICBAACAgQCAgYEAAQCBAYCBQQCBAgCCQIAAgQFBEkCBQIJAgQFAgINAgIEAgACAgUCDwIDAgkCEwINAiECDQIDBAACFQICDwYRAgILAgIAAg8CNwILAgkCDQIABgACBwIHAgkCAgcCBQIDAgIEAAIHBAcCFQIAAgICAwIDAgIABAcCAAIAAgMCAwIDAgACBAITAgsCAgACCwICBAYAAgACAAICBwIEAAIEDQYNAgQIAgICAgYCAwICBQIGAAYCAgYKAAIDAgACAgIABgYCAwIDAgcCAgkGAg8CAgMCIwIFAgQJAgkEGQIAAgQCCwQABAQABAQCAAIABgIEBgICBgQAAgYCCAYIBAgADAIGBgYEBAQEBAIECAYEBgQCAgIEAgkCBAMCAAQKAgQABAACAwIFBAICAgIDAgIGAgQEAgQEAgQEBwIAAgICCQYFBAAEAggDAgAEAgIDAgUEBgIAAgUCAgYEAAQCAAYHAgACBwIAAgIABAMGAAICBwIAAgICAgcEBAIDBAICCwQDAgIDAgACAwIDBAIDBAMCAgIAAgACAgQIAgACAAICAgMEAAQCAgIEAAICAgQCAAIABAIDBAIHAgQGBAgGBAAGBgIMBAoMAgoMDAwMBAIGBgAEAgIEAggKChAODhIKBA4ODAACBAQEAAYCAAYABAIGAAIFBAMEBwIFAgACAgMCAAIEAgACAgIEAgQIAAYECAIGCAYCBAAGBQIAAgQCAgMGAgICAAICAgIIBgIKBgICCAUCBQIIEwIZBAACCwIAAgIDAgUCCwIJAikCDwILAgsCIQIAAh0CDwIJAgUCBQILBAACAgUCBQQCAAYAAgIDAgUCJQILAgMCDQICDwIEAgkCBAMCAAICAAIAAggRAgQDBAUEBAIABgQCAgcCAAQABAYDBgQGAgYEAgIABAACAAICCAACAgQDAgACAkcCNwIJrAFUHBYGBAIDAgYCAgIDAg0CCwIC"
+        },
+        {
+          "operation": "directory_update",
+          "requests": 117,
+          "errors": 5,
+          "latency_ms_p50": 11427.839,
+          "latency_ms_p90": 22085.631,
+          "latency_ms_p99": 30048.255,
+          "hdr_v2_base64": "HISTEwAAAOUAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAI/CAQLpBAKLCQLBBwIJAiUCNQIlAi0CEQIEBQIFAgsCFwIAAiUCFwIAAgIhAgIAAksCCQIVBAsCAgUCIQIJAh8CEwIhAikCGwIJAmMCJwILAgkCAh0CRQKXAgIFAicCTwILAg8CSQItAhcCPwJbAgMCEQIrAgUCJQIbAhMCfQJlAkkCbQITAkECXwIHAiECQwJpAuEBAjUCDQIFAgkCEQIFAhkCCwIVAgMCBQITAgcEAwIHAg0CLwIrAgsCJwIAAgUCGQIAAg0CWQIRAj8CWwIXAkUCAwKZAQJfAtEDAosBAgQCBQI="
+        },
+        {
+          "operation": "ehr_create",
+          "requests": 116,
+          "errors": 0,
+          "latency_ms_p50": 4333.567,
+          "latency_ms_p90": 10280.959,
+          "latency_ms_p99": 12173.311,
+          "hdr_v2_base64": "HISTEwAAAOYAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAANWxAQJVAokUAgcCMwIfAgACMQIRAgcCFQIZAgsCIQIbAg8CCwIDAgsCAwIbAgkCBQIDAi8CEwIdAgsCGwJRAhEEDQIhAgUCGQItAgIDAgcCBQICBwIFAh0CMwJBAgMCEwJxAg8CCQIZAgMCAh0CAwITAgsCTQILAgJhAoECAjECRwICDQJNAjMCFwINAlMCQwIXAlcCCwIfApcBAiUCKQIPAl0CDwIxAhUCHwItAi8CUwJFAokBAicCIQIjAgkCDQJBAkcCEwINAgITAksCGwJTAhECDwIZAisCAAJTAlsCGQIxAh0C"
+        },
+        {
+          "operation": "ehr_read",
+          "requests": 842,
+          "errors": 75,
+          "latency_ms_p50": 14958.591,
+          "latency_ms_p90": 28508.159,
+          "latency_ms_p99": 30048.255,
+          "hdr_v2_base64": "HISTEwAAA7kAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAOUmAo2eAQKHAQJRAgsCNwITAhECIwILAjMCJQIAAikCCQIJAg8CDQINAgUCHwIAAlECewIlAisCBQLFAQSHAQLBAgLNAQIAAgUCgwECYwIAAgUCCwIDAgUCAAILAgIXAjcEJwIRAgkCAwIjAgsCHwIAAgcCCQIVAgUCBwJVAgcCHwITAgUCQQINAgcCBwIvAgMCBQIDAgMCCQI1AjcCTQI5AhkCAwJFAiECEQIVAkECQQIFAgMCEQIJAg0ECwIPBBMCBwIJAhUCFQIRAhMCBQIlAg8CAAIXAh0CAwILBAILAhcCAAIHBA0CDQILAg0CAAIZAg8CDwIFBAcCAhUCFwINAgsCFwIhAgIFAgMCCwITAg0CDwICAgACEQIABAkCEwINAg8CCwIDAgMCAAIFAgUCBQIjBB0CBwIEDwIHAhUCAAITAgIhAgACFQIHAgIFBAcCBwIDBgAGBAIEAAICAAIAAgACAAIEAAIHAgoDBAQEAgQAAgQCBgIKAgQABgICCgYEAAICAgIDBgQCCAYCAwgEAAIAAgIFAgUCAgMCAgACAgACAgICAwICBAIABgQDBAICAAIFBgAEBgICAgQAAgICBAIEBgICBAAEBgACAgIEAgQECAIECAIEAAIECAIEAgACBAAGBgIECgACAgIEAwICBwIAAgIDAgIDAgIDAgIABgIEBQIDAgQNBAIEAgACBQIHAgQCAgsCBAsCAgACBAcCAAQAAgACAAQIAwIABgMCAAIDBAIEAwIEAgICBgIFAgUCAAICAAIAAgICAgUCAwIEFQIFAgICAgICAwICAAIAAgACBQIHBgkCAwIAAgIIAgMEBQICAggEBAQGAAIDAgIAAncCLwICBQIRAgcCAkMCMwILBBkCGQIhAgIZAgUCEQIVAhsCGQIRAgITBAINAg0CCQIAAgITAgIDAgACGQIJAk8CBQIAAgACAgAEAwICAgIIAgMCCQICAwIECwICBQIDAgkCAgMCAgkCBQICDwQDAgIABAIEAg0CAgACAwIDAgMCAgIFAgACAgQECgMCBAAEAgIEAgICAAIDAgQCBgACBAQEBAQCAgMEAwIIDwICBwIHAgQCBgACAAIABAQCBwIDAhEEAgQDBAUCAAIEAgkCBg8CAgIDAgIHBAUCBQIDBAkCAgAGAAQDAgcCIwIEAwICAgcCBQICAgACAgICAAIEBQQAAgACAgAEAwIFAgMCAwIABAIEAwIABAUCAAICAhMEEQINAjcCEwIPAgILAgdcGhACBgACAgMC"
+        },
+        {
+          "operation": "ehr_status_read",
+          "requests": 232,
+          "errors": 34,
+          "latency_ms_p50": 21413.887,
+          "latency_ms_p90": 30015.487,
+          "latency_ms_p99": 30064.639,
+          "hdr_v2_base64": "HISTEwAAAVYAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAN/WAQKJCAIxAosCAh0CWwINAgUCDwIDAhMCAAIEAgACCQIHAgsCCQICHQITAi8CHQQLAh0EAgQTAgcCAgcCAi0CBwInAhMCHwIHAhMCAwJhAg0CgQECEwIAAsMBAkMCtQECAwIbAqcBAhUCPQIHAgMCoQECAg8CCwIDAgkCAAIDAgcCCQQbAgACEQItAiECBQIPAgACCQI7AgMCBwIAAgITAisCCQIFAgACBwICAgUCCQICAgACBwIJAgACAgMEBAUCAgMCBAIAAgIFAgIFBAAEAgUCBQIDAgMGAgACAAIHAhMCCQILAgMCAhUCCwICAgICBAIJBAIFAg0CAgUCAAIFAgMEAhMCCQIZAicCIQIAAj8CCQJFAhsCAmcCMQIbAgINAgcCEwIHAg0CAgINAgIDAgACAgUCEQIFAgcCDQQfAgcCAg0CCwICDQINAg8eFAoEDQIFAg=="
+        },
+        {
+          "operation": "ehr_status_update",
+          "requests": 217,
+          "errors": 162,
+          "latency_ms_p50": 0.543,
+          "latency_ms_p90": 8146.943,
+          "latency_ms_p99": 18202.623,
+          "hdr_v2_base64": "HISTEwAAAY4AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAIEBAhkCCwICAwIZAgsCFwICCQIJAgUCFwIHAgIEAgkCAgIAAicCAAICAhMCEQILAgAEAgUCAgACAgMCAwIFAgINAgAEDwIDAgIRAgIDAgIHAgMCBQIABAIHAgIHAgsEAgIEBQIHAgUCBAIAAg0EAgMCFwILAgcCDwIRAgkCDQIAAgcCAAIJAgsCAAIAAg8CAwIfAg8CAgQJAgMCAAICAwIXAgsCDwILAgIXAgUCAgcCDwIfAgMCRQIDAgUCBQITAgMCAwIAAgkCGwICSQIPAgcCDwIAAiUCIQIAAgIXAmECAwIXAj8C2QECEQIAAvkBAk8CRQJJAkECyQECEQIFAskBAmECTQIzAqUBAu8BAp0FApEBAucCAo0DAvsEAsEyAoFhArsJAv0LAocBAk0CHQIFAgACNQIRAgMCPwIbAjcECwRNAgIFAgsCHQQpAisCJQI5AicCAgkCTQINAgsCMQItAg0ChQICOQKPAwKzBAKpAQIfAnsCZQJzAlsCZwIvAgUCEQIrAgACYwIhAgAC"
+        },
+        {
+          "operation": "stored_query_execute",
+          "requests": 1743,
+          "errors": 227,
+          "latency_ms_p50": 11550.719,
+          "latency_ms_p90": 26263.551,
+          "latency_ms_p99": 28786.687,
+          "hdr_v2_base64": "HISTEwAABiQAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJUdAq8CAokCAisCCwLvAQIzAkcCHQI/Ao0BAgIVApEBAnMCdwK9BAJzAoUBAj0CApsBApEBAjUCIQQTAgcCCwIrApUBAmcCbQIVAjcCiwECNQJDAgIPAnUCQQLrAQIlAjUCEQIHAg0COQIDAhECCwIAAhcCAj0CFQIdAgcCtwECGQIDAhsCBQIFAgMCPwIvAi8CAAIVBD8CAwI1AhECCwIjAlcCLQIRAokBAgsCJQJXAicCLwIVAjsCWwKLAQIPAksCGQICbwQ7AkcCHQIZAmECFQIJAhMCAAIbAgACFwIDAk8CRwJJAj0CCwIhAlECDQIZAgACGQIRAhECAgUCGwIJAiMCAjUCPwITAgkCAAKNAQINAgIFAlECEQITAgsCWwIvAgLJAQIXAgcCAAIZAgsCJQIHAmkCIQINAlsCYQIJAgMCQQKZAQIJAlkCmwICEwIrAh0CBQKbAQLTAQIZAksCHwK5AgKVAQJDAlsCEQIrAicCOwKFAQIZAlECAj8CCwQCzQECNQIJAgsC/wMCBwIFAikCRQIAAiEC6wECrwICKQJ5ArsBAiUCCwI/Aj8CPQIhAtEBAg8C0wQCpQUChwECAl0C5QMCHwJ7Ah8C0QEC7QEC5QICgQICyzMCAwILAgsCBwIDBAIZAl8CSQJlAmsCcQJrAhsCqQECCwINAgcCCwJrAgUCbwKJAQIrAiMCBQIpAhkCJQQVAgMCBwICAwIDAhsCAgIZAgIHAgMCBQINAgIfAgkCBQIFAgIFAgACBQQVAhMCAAIABAcGBgQIBAIIAgQIBgQGBgAEAgQIAAICAgQABAUIAgQCBAAIAgoMBAgICAwKCBQKCgQECAoOCgYCCgoKDgwIBgYEEAgGBgYKDgYECgQCAgQEAggEAgYEBAYGBAYGCAgGAAYMBgYCBgYCDAICAAICAAICAAIEAgQCAAIEAgYABgYEAgICBgAGAAIGBAoEAgQGBAICCAYACAgEBgoGAgQECAgEBgYMBgoECAACBgICCAQECgQEAAYEAgYMAgoEBgYCCgwEBAYGAAIABgQCAgAGAA4CAAICBAIABAQABAIGAgQKAAQCAAQIBgIGBgIIBgAEBAQOAgQFBAICCgoIBAYABggCCAYEBAQCDAIEAgAGBgIEAAgCBQICBgAEAgYABAACAwQDAgACBQILAgAEBAMCAgQAAgACBAIEAgAGAAICBAIABAMIAgIDBgQECgIGAwgCBAIEAggCAk0CFQIbBB0CCQITAgcCBwIjAgMCAAQHAhECHQINAgMCCQIDAg0EDQIpAiECLwIPAhMCFwIJAjECAAIdAiMCAAICCQICAAIJAgACAwICAwQHAgUEBQIFAgIEAwQDAgIJAgACAgACAgcEAwIFAgACAAIAAgIDAgUEAgACDQIAAg0CDwINAgcCAAIAAgUCAwICCQIAAgAEAAYCAgQGBAYCBgQGAgQCBggACAQEBg4QCAgKAgQIBAwGCgYGBAgABAQKBgICCAgACAQEAgICAAICBAAEAAICAgMEAgIFAgMCAgACAwIABgMCBAUCAgACBwQDBAIAAgMCAgICBAQCBAICAgMEBwIABAYCAgAEAgICAAICAgICBAIDAgIFBAUCBAcEAgICAgQDAgACAgAEAAQAAgACAAYAAgAEAgUCAgUCAgMCAgQDBAACAAQDAgIDBAcCAgACAwIABAIAAgQDAgIDAgACAAQCBQICAwYDBAUCAwICBAACAAQCAgUGAgAGBAwGCAAEBgICBAQAAgICAgIEBgQEBgAGAgIEAgQCAgIAAgQCAAQCAwQLAhsCEwIAAgkCAgkCAwIPAgACAgIFAgMCAwQFAgACAAICAAQCAwIFAgUCBQICBAkCEwICBwIDAh8CAgcCBQIjAgILAgIHAgMCBQICAwIJAgMEAgcCAAIDAgMCAwIHAgUCBQIAAgACBQQCAwIABAcCAwIFBAUCAAICBwIDAgkCAwIDAgcCBQIFAgUCAgMCBQIDAgIDAgMCBQIDBgcCAAQCBQYHAgMCAgQEAwQEBgIGAgICBAgEAgICAAIEAAQGBgYICA4ODAoKCggOBgQEAgIGBgICBAQGBAQCBgICBQICAg=="
+        },
+        {
+          "operation": "tags_put",
+          "requests": 291,
+          "errors": 89,
+          "latency_ms_p50": 24690.687,
+          "latency_ms_p90": 30031.871,
+          "latency_ms_p99": 30179.327,
+          "hdr_v2_base64": "HISTEwAAAWsAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAP/fAQJ1AlcCwQECLwKZAQIpAnsCVQIZAtkBAgUCAAITAgACAgIPAhECAAIDAgICAgAEBQICAwIHAgkCCQIAAgIDAgsCBwITAg0CAgcCAgcCAgcCDQIHAgQPAgcCBQIEFwICEwIDAgACAh8EAwIFAgIFAgACAwIJAgILAgICBQIpAgIPAgcCAAICAgIAAgACBQIfAhUCEQIFAhcCBQIVAgUCAAILAgkCAwIEAwQzAg8CSQIjAhMCHwIdAgUCPwIZAgACAkECCwI5Ag0CAwIDAgACHQIDAgMCDwINAgUCKwIdAgkCKwIdAgMCHQINAhMCDwJJAiUCAwIZAhMCCwIAAgICAAYPAgUCCQIAAgMEBQIEBwIAAgACAAIDAgACAAIAAgQFAgUCAwIZBAACAAIPAgcCBgUEAhUCCQIAAgICBwITAgACAAIAAgcCKQIJAhsCAgACCwInAgACHQKnAVouCAgEBgQABgACAAIxAg=="
+        },
+        {
+          "operation": "tags_read",
+          "requests": 290,
+          "errors": 14,
+          "latency_ms_p50": 10264.575,
+          "latency_ms_p90": 24477.695,
+          "latency_ms_p99": 30031.871,
+          "hdr_v2_base64": "HISTEwAAAggAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJWxAQITAncC+RMCNwQJAikCEwIDAgkCJQIPAgcCCQIdBAcEBwInAg0CBQIHAgUCDwIDAgACAwICDwIDAg0CBwICEQQNAgcCDQQhAhECDwJpAhcCIwIlAgsCIwJZAgITAiMCFwIAAi8CIwITAgcCSQIFBB0CAwINAgMCAAIJAgACPwI5AgACkQECLQLJAQICJwIFAhUCBwIHAjcCHwI9AhECAAICawIhAjkCdwIFAlUCAwIJAmECEQICLwICEwIFAg0CBQIRAh0CHwIAAhUCAAIDAgMCAAIRAgcCBwIdAgACIQIXAh8CEwIFAgcCYQINAgkCHQILAhMCEQJPAgINAi0CCwJRAhECAAQAAjECGQIbAkcCEQIVAgUCIQIpAgkCAAILAhsCEQJHAhkCFwInAhkCDQIHAhECKQJZAgsCBwIdAgACAgsCAAINAgUEBQQCAwIAAgsCAAIFAgACAgIFAg8CBwIjAgMEDQIDAgIbAgcCCwIDAgcCGQILAgcCCQILAgILAg0EBwIhAgUCAAITAhECCwIFAgUCCQIJBAMCEQIRAgcCPwILAgsCAwIXAgICAgMCCQKPAQItAoUBAjECFwIzAicCFwIPAikCCQICKwIfAhcCDQIFAgMCPwIHAjECLwIdAjMCNQItAh8COwItAi0CBQIbAhkCSQIPAj0CDQIdAhECYwInDg4="
+        },
+        {
+          "operation": "template_get",
+          "requests": 727,
+          "errors": 1,
+          "latency_ms_p50": 4378.623,
+          "latency_ms_p90": 10264.575,
+          "latency_ms_p99": 12222.463,
+          "hdr_v2_base64": "HISTEwAABAIAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJ02AuN6AicCBQINAh0CFQIDAgkCAiMCNQLfAgI/Au8GAp8JBAACDwIHAgMCAAIHAgACAhECAAILBAAEBQILBAACCQIEAwIABA0EAgIAAgUCBAACCQIEAAILAgMEBQICAgIEAAIGAgIAAgICBAACAgIFBAICAgICAAICBAUCBQICAAYCAAQCAAICAgIHAgcEAgAEBAQCAgAEAAQEAwIABAICAwQAAgICAAQAAgACAgICAgIABgMEAAIAAgACAAIGAAYFAgYFAgUEBAICAgIAAgIFBAIFAgAEAAQCAAICAAIDAgUEAwIDBAMCBQIAAgACAAIAAg8CBQIPAgIPAgACAwQCAgkCAAQDAgMEAgACBwQJAgAEAgACAAQCAAYEBAACBQIABAIHAgICAgUCCwIAAgkCAwICAAIABAIAAgIDAgIABAICBAMEBQIJAgMCAgACBQQDAgMCAgACAwQAAgcEAAQCAwIFAgsCAwIJAgMCDwICAAIDBAAEBAMCAAIAAgkCAgICBA0CAwIJAgMCAAIRBAkCBAkCAAIAAgIAAgINAg0EAgcCAAICAAQAAgACCAcEBAIEAgICAwICBQQCBAIDAgAIAAIABAICAAIAAgIEAgAEAgcCAAIAAgIFAgIDAgIPAgICCQIDAgACAAIAAgcEAwILAgMCCQILAgACGwIfAhsCBwIbAjECBQI/AjECAwIJAhcCDwICAAQJAgsEAgMCAgcCFQIFBAIAAgMCEQINAgsCBAcCDwICAAIFAgACAAIAAgICAAIAAgACAAIDBAICCQIPAgITAgMCDQIAAgICAwIDAgICCwIAAhkCDQIDAgMCBwQAAhMCCwIDBAACCQIFAgUCDwQNAgUCAwIAAgUCAwIVAgACAgkCAAInAhcCBAkCCwIDAg8CCwITAgcCAAIAAgMCAAQHBAsEBQIFAg0EAAILAgkCAgsCBQIAAgMCAAICAhcCAgMCLwICCwICAgUEAwIAAgUCAAYAAgQCAAINAgQLAgMCAAINAgACAAIDBAUCCwIDAgIjAg0CAAIhAgUCAwIHAgINAh8CIwICCQILAg8CAgMCAgUCAwQPAgACAAIFAgMCAgILAgMCAgAEAgIHAgUCAgUCBQQCEQIDAgACDQQHAgsCAwICFQICAAIDAgsCAwQDAgkCAhcCBAAEAwQLBAUEAAICAAICBQICAgUCAgAEAwIHAgUCAwQEAAIHAgcCAAIFAgAEDwIDAgMCCQIFAgUCBAACAwIJAgkCAgMCCwICBQQDAgMCBQIHBAQAAgMEAgkCBQIDAgIDAgUCBQIAAgUGBQINAgcCFwIpAgsCFQIFAgMCAAIDAhMEBwQAAgMCAgACAgAEEwIDAgsCAAQHAgMCAg=="
+        },
+        {
+          "operation": "template_list",
+          "requests": 726,
+          "errors": 1,
+          "latency_ms_p50": 4345.855,
+          "latency_ms_p90": 10174.463,
+          "latency_ms_p99": 12197.887,
+          "hdr_v2_base64": "HISTEwAABAIAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAP1eApdSAgINBAILAhECCwIvAgMCQwKZAwK/BQLLAQLBBAKjBAIdAhECBwIHAgcCCQICAgAEAhMCAAYLAgMCDQIFAgUCAgIEAAQCAgIFAgMCBQIFAgACCQIEAAICAwICAAQEAAIABAICAwIFAgICAgIGBAMEAgQFBAICAAQDAgACAgMEAgACAgIDAgAEAwICAgICBwICAAIAAgUIAgAGAgQAAgQEAwIHAgIGAgIEAwIDAgAEAgUCAgACAwIEBQQCAgIABAACBQQCAAIEAgICAgIIBAILAgACAgMCAgACAAICAgACAgIFAgMCAgsCAAIFAgUCAAILAgAEAAQJAhsCAwYJAgIAAgICAgACAgACBAQABAIAAgIAAgMCAgAEAwQAAgIDAg8EAAQCAhECAgIDAgMCAAIABAIAAgACAwIDBAIAAgACAgkCBAAECwIFAgIJAgACAgIEAwICAgIAAgICCwIDBgACBwICAgMCEQIFAgQDAgMCAAIAAgIJBAACDQIABAUCBQIDAgACAAIDBAAEAgUCBwIFBBECAAIHAgIAAgMCAgkCAAIJAgACBQQDAgICBwQCBAIAAgACBAACAAIEAAQCBAICAgIEAgIABAMCAwQABAQAAgIDBAsCAAIAAgUCAAICAAIAAgMCEwQNBgIAAgMCBwIFAgMCDwICBQIhAhMCAwITAi8CAwIfAgsCQwIlAkEEAAIJAgQFAgACAwILAgkCAAIAAgAEBQIAAgcCAwIHAgcCBwIHAgMCAwIDAhECAAIDBAcCAAICAwIAAgcCBQQAAgMCAAIDBAIJAg0CBwICCQIAAgkCAAICBQIFAgILAhUCAwQbAgACAg8CAgAECwIRAgMCFQIAAgYFAgACAwIDAhUEBQIXAgUCBQILAhUCGwIHAgMCAgkECwIRAgUCFwIDAgMCAwIHAgACAAQFBBUCCwILBAUCBAMCAwQAAgACBQIVAgACHQIAAg0CAwQABAMCCwIDAgUCAwQAAgUCAAQJAgIDAgUCBwIAAgMCAAIEBwIJAgkCBQICCQIABAcCIwICJQIFAgACBwINAhEEGwIVAg8CAAIHAgIbAgMCAgMCAAINAgMCAAQNAgIEAwICBQIECQIDAgcEAAQPAgkCAAIAAg0CAwIDAgIDAgkCBQICDQICAAIVAgMCAAIAAgcCAAIJAgIEAwIFBAACAwQAAgAEBQIEAAIDAgUIDwIHAgUGBQQDAg8EBAIVAgACAgMCDwIABBECAwQNAgUCBwQCAAICBQILAgsCAAICAgQCAgIDAgICEwIAAgACAgIJAgAEAg0CAAQAAikCDQIJAiUCGwICAgkCBwQDAgsCAgACAwIAAgICCwIDAgACAwQFAgACBQIAAg=="
+        },
+        {
+          "operation": "ward_query",
+          "requests": 1743,
+          "errors": 720,
+          "latency_ms_p50": 3557.375,
+          "latency_ms_p90": 7434.239,
+          "latency_ms_p99": 12533.759,
+          "hdr_v2_base64": "HISTEwAACW8AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAM8NAr8BApUDAsUBAp0BAh0ChQIC2wEClQECMQJnAgMCTQItAgUCDQKJAQIlAlsCCQJVAisCDwJHAgUECwIvAgACCQIRAmcCCQIHAg8CDQIDAgUCaQIJAhUCAwIdAhUCFQRnBAICAAITAgIbAgUCCQIDAgMCBQIFBAMCIQIVAgcCCwIVAgMCIQIHAgkCBQINAjcCMQIJAgIRAg8CAwIfAgILAi8CXwIJAgUCFwIlAgcCBQIAAgMCGwIAAkcCHQJJAikCEQITAhUCEwIzBAMCOwIRAgkCIQIRAg8CAAIHAgcCAwIHAhsCBwIVAgUCDwIAAgIFAgILAg8CCwINAgsCAwIDAgMCAwIJAg8CEQIJAg0CCwIDAgILAgMCBwIPAiMCAAIHBAkCAwIbAgICAAIDAgIDAgcEBwIDAgINAhECAwIPAgcCBwIFAg0CDQIHAgACAAIVAi0CFQIFAhUGEQIAAgUCBQINAgMCBwIXAgkCEQICAwIAAgkCCwIHAgcEDwIRAgcCEwQLAiUCAAIjAlkCFwIVAg8CBQITAgIpAgcCAwQdAgcCGwICAwIDAgMCBQIbAi0EDwIAAgIFAhsCEQIRAgACTwIhAhsCFQIfAgkCAhcCAgACHQIHAgMGAwIAAgACAwIVAgsEAAILBA0CAg0CAikCAgkCAwYABAsCBwITAg8CAAQNAgMCAgkCLQIDBAQXAgUEDQIAAgsCDwICCQIFAgsCGwIECwICCwIdAgMCCQICAgsCDwIRAgUCAwIdAg0CBAIHAgUCOQICAhMCDQQCHwIDAgIFAhcCAAICFQIEBQIAAgsCCwIbAgIAAiMCBQIVAhMCAAIRAgUCBwIbAgACBQQCBQIAAhsCAwIJAiECBQIDAgACEwIDAiUCAwIJAhMCAwIJAg8CBwILAhUCCwIpAgIHAgMCBwINAgACGwIDAgkCIQIdAgIlAgIFAikCGwIFAgIAAgUCAhMCDwIJAhsCCwIlAgQAAgMCBwQbAgACBAkCAgcCBQQLAgcCIwIDAgITAgMCBwIJAhUCCwIAAlUCAAIAAhECEQINBAcCAwIHAhsCDwQHAhECAAQFAgIHAhMCIQIDAgkCAwIFAhMCCQIlAhECCwITBAMCDwICDwIRAisCAwIDAgcCBwJPBA0CAAIFAgkCHQILAgQpAgkCEwIAAg0CAgIpAgACKQIjAg0CEwIJBCkCLwIAAj0CCQICDQINAgIAAhcCEQILAkECCwIPAhsCcwINAicEAkUCFQIDAiMCCQILAgcCCwIFAgIJAhUCCwI5AgsCAAIbAgsCAmMCBQIDAgACAwIAAgUCBAACBwIAAhkCGQIjAicCAgMCAAIHAi8CBwIxAgUCAgMCIwILAh0CCQJHAgkCBwItAgsCAwILAikCAhMCHQIDAiECCwIbAhkCWQQJAgcCBQIFAiUCAAICIQIDAhcCAkUCQwIXAocBAgUCCwI1AgkCDQIhAgITAgUCYQJTAgcCBwICAAIvAhkCGwIpBgUCFQIjAg0CRwIFBAACAgMCFwItAg8CLQJfAi8CawI9AiUCGwIXAvUBAgkCcwIdAtMBAmECgQECCQJ5Ak8CgwECHwIjAhcCIQLZAQQPAgcCVwIPAiUCeQIpAjsCHwKfAQICEwLvAgIpAqEBAgsCVwJnAikCLwKDAQKHAQK1AQIFAkECcwK7AQIFAgcCLQIFAoEBAsUBAlEC1QICHwIPApEBApcDAskBAnECkwECnwECIQJ7AmsCuQEC2QsCMQILAgACBwIVAiUCAwIAAgcCDQIHAg0EAwIDAiUCGwITAh0CDwLDAQIFAk8CLwJNAq8CAoEBAq0BAoMCAvUEAmkCRQIHAgIHAgcCBQICDQQJAgQCEwICAgMCAwITAhECCQIFAgIAAgACAgAGAAICAwIEAwICAAYDAgAIAgIEBgMCAgIEAgYCCAAEAAQAAgACCgICAgQABAgCAwICAAYGAgQDAgACBAICBAIGBgQGAwQIAgIEAgQABAYCAgYABAoIBAICAgACAwIEAAQCBAAGBAAGAgQCAAYGDAMGAgQEBgAIAwQCAgQCAAYEAwYKAgYEAAQABgMEBgAEAgYGBAQCAgQAAgIDAgMGAgUCBgAGBgICBAYEBAQAAgoDAgIEAgMCAAIAAgAGAgICAwICAAIDAgAEBAICBAACBQIAAgQCAgAEAwIEAwYAAgICAgQCAgACBAYCBQIEAgACAgICBgQDBAIDAgMECQICBgACAgQEBQIDAgICBAICBQICBAIDBAAEBQIAAgMCAgIGBgICBQQCAgACAAIHAgMEAgICAgUCAAIDBAACAwYEBAQDBgICCwIFAgYEAwYCAAYEAgQKBAQABgQEBAIGBAAEAggCBAICAgQAAgIEAgIGAgIEAgQCAgICAgACAgYAAgQAAgICAgIEAAQEAgACCAAECAQCBgYGBgIIBgACAAgDAgYAAgMEAgIGAgAGBAgGAAICBAIEAAIEAgIEBAIABAQABgIABAIABAIIAwYCBAICAwgCBQIFBAQCBAICBAIECQIABAQFAgICCwIEAAIDBAIHAgMEAAIDAgMCAAIFAgIDAgMCAgkCAAIAAgIAAhMCGwIAAhECAAIVBAIZAgACGwIAAjMCLQICAhECAgsCCQIFAh0CGwIDAgILAgQAAgIFBAITAiMCCQITAgkCCwIDBAMCAgAEAwIAAgQECQIEBAIDAgUCFwIAAgkCAwQCAAIAAh8CAAICAwYCBQIAAhcEAAICAgkCBQIHAgUCDQICAwIXAgMEAwIDAg0CBQILAgIDAgMCAAQDAgMCAwIFAgACDQILAgIHAhMCFwIRAhkCDwIAAgMCPQITBAIAAgACBwIDBAMCAAIDAgIFAgUCBAMCAAIDAg8CAgMCAAIFAgMCLQINAgMCFwILAhsCDwIJAgMCAAIDAhUCFwIEBQIFAgcCBQICAwIAAgUCBwIFAgUCCQIDAgMCEQIfAgcCAgACGwIDAgcELQIDAhkCCQIFAgMCCQICFwINAg8EBQIJBAITAgkCEQQHAhUCBwIAAgUCBQIDAgICAAIbAgMCAAQRAgICBQIDAgUCBwICAwIJBAMCAAIFAgICBQITAgcCAAIJAgIAAgQDAgMCAAIAAgACAAIHAgkCAAICAwIAAgMCAAIXAgIXAg0CAAICBQInAgMCBAIJAgIAAgcCDwIFAgICAAINAgkEBwIFAgIFAgkCAgcCCQIDAgMCIQIPAg=="
+        }
+      ],
+      "stable": false,
+      "breaches": [
+        "adhoc_query p99 12009.5ms > budget 1000ms",
+        "composition_commit p99 30081.0ms > budget 1000ms",
+        "composition_read p99 30015.5ms > budget 1000ms",
+        "composition_read_current p99 20660.2ms > budget 1000ms",
+        "composition_revision_history p99 29458.4ms > budget 1000ms",
+        "composition_update p99 30261.2ms > budget 1000ms",
+        "contribution_commit p99 30474.2ms > budget 1000ms",
+        "contribution_read p99 30261.2ms > budget 1000ms",
+        "directory_create p99 30146.6ms > budget 1000ms",
+        "directory_read p99 30031.9ms > budget 1000ms",
+        "directory_update p99 30048.3ms > budget 1000ms",
+        "ehr_create p99 12173.3ms > budget 1000ms",
+        "ehr_read p99 30048.3ms > budget 1000ms",
+        "ehr_status_read p99 30064.6ms > budget 1000ms",
+        "ehr_status_update p99 18202.6ms > budget 1000ms",
+        "stored_query_execute p99 28786.7ms > budget 1000ms",
+        "tags_put p99 30179.3ms > budget 1000ms",
+        "tags_read p99 30031.9ms > budget 1000ms",
+        "template_get p99 12222.5ms > budget 1000ms",
+        "template_list p99 12197.9ms > budget 1000ms",
+        "ward_query p99 12533.8ms > budget 1000ms",
+        "error rate 0.6809 > tolerance 0.0010"
+      ],
+      "generator_bound": false,
+      "resources": {
+        "sample_interval_s": 10,
+        "containers": [
+          {
+            "role": "sut",
+            "name": "ehrbase-rs-ehrbase-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 99.41246110819674,
+                "rss_bytes": 355360768,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 5771352110,
+                "net_tx_bytes": 8409138407
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 94.79377064806444,
+                "rss_bytes": 380030976,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 5868883970,
+                "net_tx_bytes": 8433626000
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 95.32076932920594,
+                "rss_bytes": 443105280,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 5941895822,
+                "net_tx_bytes": 8452113140
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 100.74963294436634,
+                "rss_bytes": 491614208,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 6005022778,
+                "net_tx_bytes": 8469078093
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 96.56961818590906,
+                "rss_bytes": 539160576,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 6086743329,
+                "net_tx_bytes": 8483405300
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 101.52964056632518,
+                "rss_bytes": 574611456,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 6154798805,
+                "net_tx_bytes": 8501265555
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 107.4775029258775,
+                "rss_bytes": 604307456,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 6227067786,
+                "net_tx_bytes": 8517831224
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 108.67137355534817,
+                "rss_bytes": 624816128,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 6312736479,
+                "net_tx_bytes": 8538998826
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 114.89577412565693,
+                "rss_bytes": 631898112,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 6384926003,
+                "net_tx_bytes": 8557749935
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 118.63938636734149,
+                "rss_bytes": 640335872,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 6440859587,
+                "net_tx_bytes": 8572039505
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 136.01870335949394,
+                "rss_bytes": 644128768,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 6514123406,
+                "net_tx_bytes": 8582022868
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 117.42236383395048,
+                "rss_bytes": 650452992,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 6599228967,
+                "net_tx_bytes": 8595289557
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 130.7924340675023,
+                "rss_bytes": 680824832,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 6670034260,
+                "net_tx_bytes": 8604146230
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 142.83125707332073,
+                "rss_bytes": 688386048,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 6701583468,
+                "net_tx_bytes": 8610141881
+              },
+              {
+                "offset_s": 150,
+                "phase": "drain",
+                "cpu_pct": 141.02992662503053,
+                "rss_bytes": 695808000,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 6787571445,
+                "net_tx_bytes": 8617539869
+              }
+            ]
+          },
+          {
+            "role": "db",
+            "name": "ehrbase-rs-ehrbase-postgres-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 482.7902189492134,
+                "rss_bytes": 2391638016,
+                "blk_read_bytes": 6618558464,
+                "blk_write_bytes": 48740601856,
+                "net_rx_bytes": 7637791179,
+                "net_tx_bytes": 2462478915
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 552.7217747840743,
+                "rss_bytes": 2509770752,
+                "blk_read_bytes": 6862385152,
+                "blk_write_bytes": 48832671744,
+                "net_rx_bytes": 7656155188,
+                "net_tx_bytes": 2550449351
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 592.6961097200739,
+                "rss_bytes": 2685296640,
+                "blk_read_bytes": 7053807616,
+                "blk_write_bytes": 48955633664,
+                "net_rx_bytes": 7669688791,
+                "net_tx_bytes": 2614341774
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 560.5471994405042,
+                "rss_bytes": 2652880896,
+                "blk_read_bytes": 7239557120,
+                "blk_write_bytes": 49043263488,
+                "net_rx_bytes": 7682138731,
+                "net_tx_bytes": 2668139650
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 566.1056280672416,
+                "rss_bytes": 2695360512,
+                "blk_read_bytes": 7439384576,
+                "blk_write_bytes": 49094397952,
+                "net_rx_bytes": 7691985638,
+                "net_tx_bytes": 2741985332
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 566.2978856074049,
+                "rss_bytes": 2791026688,
+                "blk_read_bytes": 7621533696,
+                "blk_write_bytes": 49186820096,
+                "net_rx_bytes": 7705667096,
+                "net_tx_bytes": 2799004259
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 545.2235091367444,
+                "rss_bytes": 2733793280,
+                "blk_read_bytes": 7831916544,
+                "blk_write_bytes": 49286434816,
+                "net_rx_bytes": 7717886368,
+                "net_tx_bytes": 2863903850
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 546.7419231769776,
+                "rss_bytes": 2782633984,
+                "blk_read_bytes": 8081256448,
+                "blk_write_bytes": 49373138944,
+                "net_rx_bytes": 7734139886,
+                "net_tx_bytes": 2938447415
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 540.5938042533398,
+                "rss_bytes": 2692235264,
+                "blk_read_bytes": 8269496320,
+                "blk_write_bytes": 49489694720,
+                "net_rx_bytes": 7748644072,
+                "net_tx_bytes": 3001668617
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 509.3506576292632,
+                "rss_bytes": 2807549952,
+                "blk_read_bytes": 8408223744,
+                "blk_write_bytes": 49549127680,
+                "net_rx_bytes": 7758768067,
+                "net_tx_bytes": 3048047678
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 444.97800881345916,
+                "rss_bytes": 2752131072,
+                "blk_read_bytes": 8502222848,
+                "blk_write_bytes": 49583149056,
+                "net_rx_bytes": 7764887545,
+                "net_tx_bytes": 3112797403
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 517.718731530658,
+                "rss_bytes": 2805534720,
+                "blk_read_bytes": 8675811328,
+                "blk_write_bytes": 49667403776,
+                "net_rx_bytes": 7773592489,
+                "net_tx_bytes": 3188447388
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 519.4428368353574,
+                "rss_bytes": 2941370368,
+                "blk_read_bytes": 8777871360,
+                "blk_write_bytes": 49694470144,
+                "net_rx_bytes": 7778609451,
+                "net_tx_bytes": 3249676146
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 421.7287442439617,
+                "rss_bytes": 2812870656,
+                "blk_read_bytes": 8824352768,
+                "blk_write_bytes": 49708888064,
+                "net_rx_bytes": 7781173575,
+                "net_tx_bytes": 3271463543
+              },
+              {
+                "offset_s": 150,
+                "phase": "drain",
+                "cpu_pct": 416.7322712922366,
+                "rss_bytes": 2785521664,
+                "blk_read_bytes": 8893116416,
+                "blk_write_bytes": 49739198464,
+                "net_rx_bytes": 7784758981,
+                "net_tx_bytes": 3347835564
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "rate": 384.0,
+      "offered_load_sustained": 387.89166666666665,
+      "operations": [
+        {
+          "operation": "adhoc_query",
+          "requests": 6102,
+          "errors": 1240,
+          "latency_ms_p50": 4231.167,
+          "latency_ms_p90": 6930.431,
+          "latency_ms_p99": 8912.895,
+          "hdr_v2_base64": "HISTEwAADRIAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAANUOAqcCAuMCAgITAosBAj8CLwIfAgMCMQIZAkUCZwI7Ah0CLQItAh8CDQJ3Ai0CMwIfAh0CDQILAokBAh8CIwIlAgACMwIfAh8CKwIVAhkCBwIdAgcCDwIfAgsCCQICBwIFAgsCCwIPAgcCAAIFBBkEDwITAgACDwIDAgACDwIHAgACAg8CAAIAAg8CLwICNwICHwIJAgIAAhECCQIZAgACBwIAAgACEwILAiMECwIJAhsCAhECIQIFAg0CDQIPAgACAwIAAgMCAAIbAiUEEQITAjECCwIJAhcCBwINAg0CAwIFAi8CAwIJAg0CAhECAAICAgsEIQIbAgUCFQIXAg0CEwIhAgcEAwIPBAsCAAICAh8CAgsCAAITAiMCAgILAgICEQICDwIHBAInBB0CAgIDAiUCAwJDAgkCBQIHAgUECwIDAgUGBQIRAhECAgMCAAQCCwIHAgkCAwIAAgICBwQXAgMCCwIEFwIJBBMCBQIAAhUEAwIRAgUCAAIPAgIjAgACHwIRAgICCQIPAgkCAAIDAgIJAgACBA0CCQICAwICCQQAAgACCQIVAhUEDQIAAgACCQIlAgACBwIbAgMCAAICBwICCQIAAisCGwIJAgcCAAIAAgcECwIFAgIDAgIAAgIAAhUCCwIPAgkCAwIHAgkCCwILAg8CCQIHAgcCAwICAAIDAgICAAIDAgILAg0CAgAEAAICAAIJAgcCEwIDAgAECQQDAgcCBwIDAgACCQILAg0CGQICAh0CAAIFAgICDwIPAgITAgcCCwI1AhUCCQIDAg8CCQIAAgQDAg8CDwICBwIABAUCAg8CCwIAAgsCFQICJwIlAgMCAAIEAgIDAgMCAwIAAgACDwILAg8CIQIFAgMCBQQAAhECBAMCDwQAAgIFAgACAgACAAICAgAEAAIAAgUCBwQCAAIDAgACAgYLAgACAAICFQQCAgIAAgACAgICAwIDAgkCBAcCAgkEAwIDAgkCCQYCCAACAgAEAgACAAIFAgMCAgcCAgcCCQIFAgACAgACAgsEAgcCBAQABAcCAAIFBAIFBAYAAgIDAgUCAgAEAwITAgQCAgkEBwIRAhcCDQIAAg0CBQINBAcCBwIAAgACAwIDAgsCBwICAAIPAgACBQIFAgsCAwIFBAcCBQIHAgMEAwIEBAICAwIVAgICAAILBAUCAAIABAACAgACAgAEAAIRAgACAgcCCwIAAgkEBQIXBAMCAgACAgUCBQIFAgAEAAIJAgUCAwIHAgUCAgACAwIFAgILAgACAAILAgUCAAIDAhECBwICBwIAAgIABAAEBwIFAgACAAICCwIfAgACBAUCAwIABBMCAAIDAhsCAgICCwIAAgMCAwIABBECAAICAgkCAAIPAhUEBQIFAgcCAwICCwIDAgIABAQCBQIAAgkCAAIFAgMCDQQDBAIAAg8CCQIFAg0CAg0CEQICAwIDAgMCAwIJAgICAAIjAg0CAAIRAgIAAgACAAILAgIDAhMEBgICAgkCAwIAAgkCAwIlAhkEBwIAAgcEAgcEBAIAAgUCAAICAgMGBAcCAwIAAgQAAgICAwIAAgIAAgkCAgIDAgUCAgkEBQICAAIFAgILBAQDAgUCAwIAAgICAgUCAwICAgkCDwIHAgkCAAIRAgMCAAIFAgACIQIAAgIDAgIAAgICCwIHAgMCBQIAAhECAgUCAAICAAIZAgMCCQICAAICDQICAwIFAgIRAgIDAgACDQICAAQDCAIDAg8CAAIDAgIDAgACAgkCAgICBQIAAgIEAgcCAhECAgINAgsCAAIHAgUEAgACBQIFAgMCAgIRAgIFAgACBQIDAgACAgkCAgACBwICBQIJAgACCwIAAgACCwIHAgIHAgIRBgACAgAEAgICAAQFAgUCDQIAAgMEBwICFwICAwIHAgkCAAINAg8CCQICAwILAgMCFwIHAgsCBwQDAgACAAIZAgMCHwIHBAIAAgUCBQIRAgUCEQITAhMCAAICAwICAAIVBAUCAg0CBQIrAgUCDwIpAgIlAhsCFQQDBCcCAgMCBwIJAiMCAAIFAhsCGwIHAg0EIwIFAgMCAAILAgIAAgACAAIDAgcCBA0CAwIPAgACAwIDAhkCAwIFAg8CHwIFBAkCAgsCBQIDAgUCJQIJAgcCBQYCAhUCCQILAhMGAwIJBBcCLQILAgMCAwIFBAkCDQIVAgkCAwQXAgUCFwIdBG8CAAIJAgkCDwINAhUCAwIFAg8EAwICAg0CAAIHAgcCAgUCAhMCAwIFBAACAwIHAgMCAhMCDQIVAisCCwIjAgMCMQILAgkCCwICHwIHAgkCCwILAg8CAAIbAjsCDwIHAisCCwIlBAMCBwIJAhMCAwYtAg8COwIfAg0CAAIFAgcCAgUCGwIPAhsCAAICNQICIwIAAisCCwIHAgMCBwICEwIDAgcCAwIJAgMCCQIlAgIAAgACAAICCQIAAgQJAg8CEwICQwIlAgMEBQICDQICDQI9AgACBwQAAkECDwIAAh0CGwICAwIHAgAEKwICIwIJAgUCBwICAAILAhMCAhECLQIlAhMCAwI3AgIdAgACAgKNAQIAAhkCIwIHAhECJQIxAgACTwIvAgUCDQQpAg0CAo0BAj8CFQK1AQIXAgUCAiUCSwI/AgMCMwINAkUCxQECFQJFAi0COwKPAQITAicCIQLFBAKpAwK9OgIFAgkCAgcCEQQdAgMCAgIDAgkCBwIABAACAAQGAgIEAgIAAgICBAQCAAICAAIDAgACCgIEAgYCCgIIAA4EAg4IAgQABggCAgYIDAgQBgQGBAgKDAYKEBAIAAIMDAQOCgQODAoMFg4MDhgMCBgUCBAICAoODhAKDBAWDBoOEgQOCggMFAoOChwMDhISFhQIGhASFhQSEhoaGhIQEBQSEBIgFBoWGBAKHA4UChgWGAoOBBIYCgwMChASCAQMGggMCgwWEBQSBgoOBgoQGAYSDBAQDAoIEhYOCBAECBgODAwQEAoSEg4KEBgECg4ODg4KCBIMCBIKEBAQChYOEBYOBAgQDgIWCgoOEgwGDA4UCgoKFBYWEBgQFAgYDhoQFAwMEBoODgoSEhQeGh4kGCQWDhwODiAUEg4IEhgaCh4OGBAaHAwQGBogHAoMFBAaKhwiEBogGhYYGhoqGAgWDCAiKh4QGi4iJCgcHBYOHBYWDhYiFAYKEAoMEAoUCgoOEg4ICAoKEAgUFggOEhIMFhwIDBAaHBoYDhQMEAwSDAYCEAgMDgoOCgwMEgoGCAgMCAQGDAoICAIGAAIEBAYABAYGCAgEBgMGCAoGBgACBgQEAggIBAIFAgAGAgQEAgICAAgECAQEBgQEAAQEAgQEAgIKDAgCBAQGAgQEAggCBAIMCggMCgYEDgIQDgYOCgoUCgwODgoMBgYMBgwKBAgABgYGCgwQCgQOCAoIBAAKBAYABAIGCAQIBAgMBAQGDAoOCAwADgwGAgYEBAIEAgIGAgAEAgIAAgIABAIABAICCAIABAgADgQGAwIIBgYEAAQEAAYGAgYIBAQEBgQEBgYEBgIKCAQGBgQECAoIDAYIBAoICAYGDAgOBgYIDAgKBAQEAgYCAgoEAAIDAgAEAgQCAgUCAwICBAQABAQCBgYIBAQMBAAGBggGBgICCAMCBAIAAgIKBgIMBAwEBgoODhAGDAwOBgwOCAYKDAQGCggGFAoECgoKCgIGBgYOBggKBAgKBAIGCgYIAgQIAgYGCggABAgCCAYAAgYKAgQEAgICBAQGAgMGCgQGAgYECAQGBgQCAgACBAgGAgQDAgQCAAIEBAICAAQKAAIEBgQABgAEAggABgICBQQDBAIHAgQAAgMCAgMEAAIAAgYFAgAGAgACAwQAAgACAAICAgACAgMCBAMCBAQCAAIEAwgDBAICAAIEAgACBAIABAICAAICAAQCAgcCAAQDAgAEAgIDAgQCAgIEAAIACAAGBAYEAAQCAgACBwICAgACAAICAAQCCQIGAwQCBAACAgIEAgIEAgQAAgQEAgIEBgQGAAIGBAQGBgAEBgQGBgYECAoIDAoICgYGAggGCgYGBgoECAYEBgYCAAgCAgQCAAYGCAICAgAECgIEAgICAAICAwQHBAUEAgQEAgQCBAQCAAQGBAYABAQKBgACAgIABgQEAAIGAgIABAYAAgACBQQTAgIFAgINAgUCBQILAgQCAAIAAgIFAgACAggCBAACBAYIAgICAgYEBgYCAgAOAwIEBwIEAgMCBAsCAwICAgAEAgMCBwIEAAYAAgIEAwQPAgILBAIAAgACAAIFAgIEAgACAwICBwIAAgMCAAYAAgAGAgYCAgIEBgYEBAIADAQECAIGDgQCAgICAwIEAAIEAgYCBAYECAgGBAgIBAwEDAYKEAYIBggCCgQJAgACAwICAwYCBAICAgQGBgMCAgMCAwICAgIDAgIFBAMEBAICAgQAAgQCAAICAAQDAgMCBwICDQI="
+        },
+        {
+          "operation": "composition_commit",
+          "requests": 1883,
+          "errors": 269,
+          "latency_ms_p50": 12984.319,
+          "latency_ms_p90": 27721.727,
+          "latency_ms_p99": 30048.255,
+          "hdr_v2_base64": "HISTEwAAB3wAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPsiAi8CwwQCjwICFQLRAQL3AQKRAQKVAwIfAjsCVQJFAqcBAgcCLQI1AkkCEwIxAh8CPwJVAgMCIwIZAjsCBwIZAiUEUQICCwIRAm0CQwIAAksCLQILAhMCIwIDAisCYwIfAgMCEwIJAkMCJQIAAg0CDwIHAg0CDQILAgMCNwIDAg8GEwIJAiECBwITAg0CCwIJAgMCUwIRAgUCIwJNAhcCdwIjAgkCLwIAAgACAAIPAjsCPQIpAgcCHQIJAiECHQIfAjsCEQIbAgcCAAJTAgUCHQICHQIzAgkCVQIAAh8CJwIZAjMCSQIJAhUCDwIFAhMCAwINAgACAgcCAh0CAwIJAgACEQINAgkCawIHAicCCQIfAhMCFQINAg8CCwIJAgkCCQJlBAACCwIvAoEBAgJTAnkCAAJFAhcCIwJBAjsCLwIPAlkCkQEC3wECIQI5AhMCRQIAAgMCAwICLQITAgsCXQIFAgMCAhkCzQECJQIfAjcCFwICCQLpAgLjAQKvAQITAk8C8QECIwKZAgITAjUCxwECUwLlAQKdAQItApEBAhkCqwECIQI7AgcCcwLzAwLbAgLPAQKHBQLlAwK/RwIhAkkCFwIVAgsCSwJFAjkCAwIZAgI1AlMCAgUCFwIFBAJHAgUCVQIDAhMCFQICDQIJAhsCFQIlAh8CAAQNAgsCAAItAhMCDQILAgMCAAIHBAcCAwIDAgACAwQCBAIRBgYJAgAEAgIAAgACAAICBAIAAgACAgACAAgCAgIEBAIGAgIDBgACAAQCBgAEBAMCAgIEBAICBAACAAQEAgIABAICAgICBAQABgIABgMCAwIABAMCBgACAgICAgQCBAICAgICAgMGBAIAAgUEAgYEBAIEBAICAgIECQIAAgIAAgcCAAgAAgACAgQAAgACAgACAgACAwQCAAQCAgACAAIDBgACBAIAAgICAAIDBAgCAAoHAgQFAgQEBAIAAgIEAgYKBgIEBAIEAgICBAICBgACAgIAAgoCAgQCAgYEAwQAAgACAgICAgICAgAGBAQCAgQCBQQGCAAEBAAECAICAgYEAgUCAgQGAwQAAgICAwICAgAEBQIEAAIEAAIEBAQNAgACBAACBAACAgcEAwICAAYAAgICBAICBQQNAgMEBAACAgMGAAIABgMGAAYCBgACAgICAgICAgIEBQYAAgIFAgICAgACAAQEAgQGBQICBQIABgAEBgAGAgQCAgQEAAIABgICAgIHAgUCBgMCAgYEAwQDAgACBQICBQIAAgcCAgcCBQICAgcCBQICAAIABAIGBQIAAgACBgICBwIABAcCCwICBAAEAAQDAgACAgIDAgACCQICAAICAwQAAgAEAgMEAgIAAgIAAgQCBAQCAgAEAgUCAgQCAAIDAgIAAgICAwQCAAIIAgIEAwICAAIKBAMCAgICAggDAgIEAgUCBAIGBAACBgQABAcEBAACAgIFAgACAAIAAgUEAgQCBAMEAgkCAgIDAgQABAACAgUCBAICAgUCAAIABgAEAgMEAgQCAgMEBAQCAgMCAAIGAgAEAAICBQIAAgIDAgIEBgIDBAYADAQCAAIAAgIEAgAEBAYCAAICBAACAgAECAICAAQJAgQEAwQDAgQEAAICAAICBgUCAgUEAg8CBAILAgACEQICAgMCAwIAAgQLAgACDQIEAgUCAgcCBwICCwQDAgACAAIAAgkCAgMEEQIABAILBAICAgIAAgICAwIEAAIEBQIAAgACAwIJAgICAgACCwICAgIFBAACAgIFAgAEBwIPAgIHAgACCwIZAikCIQIbAgMCCQICKQIdAhECDwICAgsCAgMCIQIPAgUCBQIHAgACBwIABBcCFwIFAgMEAwINBAsCBQQCAAICAAgJAhMCDQQEAAICAwIVAgIAAgIPAgIHBgICAgACAAIDAgIGAgkCBAMEAgQEBAQCBAgEAAQEAgACCgQCAgIEAggCBAIGBAgECgAGCgAEAgICAAIDBAQGAggICgIEBggFAgIGAgIAAgIDAgAEAgIEBAIAAgIEBgQAAgQCBgcGBgYACgoEAgIABgICAgAKBAYADgICBAICAAgLAgICAgACAwIEAAIAAgACAAICAAICAgQAAgAEAgACBAACAwIABgACBQIDBAIHAgACDQIAAgICAgUCAwIFBgUEGwICAgACAwIHAgQCAwQABAMCAgIPAgILAgAEAAQFAhEEAAIRAgIFBAkCAwIEAgICAgQABAUCCQIFBggEAAIEBAYEAgICAgIGAgQCAgQECAQGAgIECAoCBgIABAICAgYAAgIGBAYAAggACAgEAgACAAYDBgIGAgIABgIKAAIABgQCBAYEBgICAgIHBAMCAAQEAgQCAAYEBgQEBAQFAgACAAQCAAYLAgQDAgACAwYABAYFBAIGAwIDAgACAgwAAgYGAgQABAICBAgAAgAEAAYHBAQGAgIDBAYFAh0CAAIHAgMCBAIGAAIGBgQKAAYGBgIACgoABgAGBggGDggGAwIDCAoFAgQIAgIECwICAAIAAiMCAgcCAgICBAACAxweHAwAAgACAgAC"
+        },
+        {
+          "operation": "composition_read",
+          "requests": 12202,
+          "errors": 11217,
+          "latency_ms_p50": 7.371,
+          "latency_ms_p90": 86.143,
+          "latency_ms_p99": 28098.559,
+          "hdr_v2_base64": "HISTEwAAG20AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAANkKAlMCAAJLAg8CBQIVAgkCCQIFAiUCGwINBDcCFwIPAg0CAg0CGwQCCQIJAgIPAg0CAAICEQIAAgMCCwIAAgMCCwIPAgUCBQIJAhUCCQIhAgsCAwQJBAUCBAkEBQIAAgIDAgIAAgMCAgQABAACAgIAAgMCAAIDAgcCDwIDAgkCAgsCBAUCBQILAgsCAgkCBQIDAgMCAAIHAgMCAAQCBgICAwIDAgMEBAIHAhECDwIJAgINAgIAAgICBQIFAgIAAgAGAAIFAgICBwYCCQICAAICBQIEAgACBAQCAAICAgMEBAICAgIAAgMEAgAGAwIAAgACAgIAAgMEAgQAAgIEAAICBAIDBAACBAsCAwICAwICAwICBgIEAwYCAgIPBAMCAAICAgIJBAACAgACAgIDBAMEAgACBgICAAIFAgACAAQFAgMEAgIDAgQCBQIEAAICAgIDAgACAgAGBQQCAAIEBAIABAIFAgICAAIEBgIEAAQCAgIAAgQCAAIABAACAgICAgMCAgIAAgYCAAQCAAIABAIEAAQEAAQAAgQABgACBAIGAgMCBgQIAAICBAYCBgIGAAgAAgIEBAICAAIAAgMGAAIAAgYAAgICAwICAAQAAgIDAgIAAgIAAgICAgQEAAQAAgIAAgQCBAIABAYCAAYCAAICAwQAAgQAAgQCAAIABgMCAgICAAgAAgIAAgQABAMEAAIDAgACAgQCAgAGBQIEAgICAgQEAwICAgMCAAYGBAQAAgYCAgMCAAQCAAYAAgYCBwQCAAIAAgACAgACAgQEAgACAAQCBAICAgUEAAICBQQAAgAEAgQABAAGAAQCAgAGBgAGAAQABAQCBgAEAAQEBgYEAgIEBgAIBAIEAAIEBQIECAAEBAICAAIDAgACAgAGAAIFAgsEAgIDAgQCAgYAAgICAAICAAYDBAQAAgQCAAQEAAIDAgICBAAGBAACAgQDAgICAgUECAIEAAIEBAIABAgAAgIEAAICAgQCBgQCBAACAAICAgQABAIAAgIGAgACBAYCBgACBAACAgACBgACBgQAAgICBQQCAAQCAgAEAggECAACBAQAAgQEBgAEAAQABAACAgAEBAIDAgIEAAgDAgQGAgACAgIEBAQEAAQCAgICAAICCAQAAgMGAAgAAgYEBAgGBgICBAYCBAQECAYKBAICBgwEBAICBAQCBgAECgYIBgQKCAIEBgIGBAwGAAQGAgQCAgQABgoEAgYCCAQGCAQGAgYACAAIBgIGBgYEBAQEDgYEDAQECgQCBgMCBgQEBAQGBgACBgIEBAACCAIMBAYOBAIGAAIEBAIGBAYGAAYKBgIICAYCAgYEBAgGBgICAgoCBAwCCAIECAYEAgQEBAgECgYACgQIBAQICAYABAgEBAICAggGAAQGAgwCAgQACgIICAgEAggCBAIGAAgMAgQCCgQGBgoCCAgIBgYIAgYGCAQACgQGBgACBgIGAgYCBAIGCgAEBgAEBAIIBAQCCAACBgQMCgICAAIECgICAAQGBgIGBAgEAgoKAAIABggOAgIEAgIEBgIGBAACBAQGAggGCAQIBAgGAAYCBgYIBgoGCgYIAAgEBAYSDAYECgwECAIIAgAICgQIAgYABAQMAgoEBAYGAgAMBgYKBAoGCAYEAAQGCgwEBgQGBgYCAgIGBggGAgIICAQCBAIIAgoCBgAIAAIGBgYEBAICBAAEBggACgQEAgYABAQCBggOBggCBggCBAwKCAYECAYGAgYGCgQGBAgEBgYKAgIGAgAEBgYIBAgGBgYEBgoGBAIGCAQGBggCCAYCAAQGCAIOBgQABgQGAgoEAAoKBAIMBgoCCAIIBAgICAIEBAYGCAYAAgYOBAYODgQAAgoEAAgIBAwMBAYABAIACBAOAgIGCAgCCggKAgACBAQCAggOBAIKBAYGBAgECAgABAQEAggEAgQCAgIKAAYEBgQIBgYCAgYGBAAEBAgEAgAEBAICCAgCBAQGAhIEBAYGBAACAAwEAAgCAgQGAgIECgIMBgYECAoCDgIEBAQIAAYGBAYGBgICBAQKAgQEBAYCAAQCAgoICAYCBAgGDAgEAgQICAAEBAIIBAYEAggEDAIGCgoCBgQKBAYMBggEBAQIBgACAgQGAAIGBAYCBAICBAgICAACDAgGBAQECAAEAAQEBgQIAAQEBgQCAgIEAAYCAAIGBAIGBAIKAgQABAYCAgIGBAgABAIAAggCBgQEBAwEAg4CAgQAAgIGBgIECAQABAoEBgQCCAYGAgYEAAIKDAgEAgIGBgICAgIGBAAGBAIEAgACBAgGBAgEAggECAQGDAYGAgAECAIABAQKBgwGAAwEBAAECAYGCAgABgYEBgMIBAIABgYEBAYABAIAAgYEAAYEBAYCAAoEDAIEBAIECgAKBAIKBAgCBggAAgACBgQEAgoECgQEBgICCA4CAgwEAgQIAgIEBAAGAAIIAgQEBgQGDAoEAgIECAIIBAYCBAYDCgQGCA4EBAAGBAQABAACBAYEAgQCBAICCAYEDgoKCAwKBgoKBAQIBAoUDggIBgoMEAgEBAoEDggOCgwKCAoCCgYIBg4KBAYIBgwCBgwIDAQIBgYKDgwCCAwGCAoEBgQGBAwGDgYQCAgGAAgECgoKABAOCgQKDgIGCgoMCAoGCAwEDggSBgwKDAQICAgCAgYMBgoMBgYEDg4KCg4MEBQICBISCgYIBAwGAhIIBAQCAggEBgwICAYQBg4KBAYIDA4GCBIGBgoODggECgIGBgwKDA4MBggODBAGBAIKAgQKAAQGBggGCAwADAgGBhAOBgYGBgYIBAICBAIIBAgCBgQMCgYICAQABgYIBgYEBgYMAgQIBAgGBgQIBAgIBAQGCgYIBA4IDAQCBAAECAQIEAQEDAQEBAgOBgQCBAICCgIGAgQCDAYKCgIKCAoIEAgIBggMDgoMAggEABIIABAEBAYCAgYECAgEBg4EAggCBgYEBAQGBAgGCAwGAgAIBgIGCgwGBAQIBAgMCgoEBAYCAAYCBBAIBAYGCgwMBgYICAYEAgwOCgoIAgIEBAQECggECAAIBgoIBAYGBgoEBAoEBgYIBAgIDAAQBgoGBgYECA4EAAQGCgoCBAgCCggGDAoIBgAGCAQEAgYICAQKEggEEAIICAgCAggMAgYEAg4KAgoEBgIIBAYCDgQEBAQIBAQGCAoGCAIACAQKFAUGCAgIBAYCBgoEAgQODAQIBgYKBgwMCA4GBAgCAgQEBgwGAgQGBAICBAIMCAoEBAYICAoIBAwECAYIAgIEBgIIAggIAgIKBAIIAgACBgoEBgIABAQOBA4CBAYKDAIGCAYGAAgICAgEAAwCAAwCAgIECgYGBAYOCAYECAQEAgQABAIIAgYGEAYCDAoEBgIKCgQEDgQEBAQGBgYGBAAKBAQCBgoIBAwIAAIEBAYIBgYGBggEBgwEBgQGDAYQAgIGAgIECAYGBAYACAIGAggKBggEAAoKCgQEAgIIBggECAoGBgYEBgYCAgYEBAQCBAQEAgIGCgICBgYGAgIEBAAGAgAGCAoIBggEAgQGBAgMAgIMAgoGBgIIBAoIAAYKAgYIBAgEBAgCCggCBAAEBgQEBAYCBAQGCAgIAAgEAgoGBAQCCAYIAgoGDgQGAAIEBAQCAgIEBAYKDAIKCgYCCAIEBgIECgIEAgYIAgQCAAgEBgoIBAIEBgYGDAQCCAoCCgYABAQGCAIGCAQIBAQIBgYCBgQMAAgCBgIGCAQGBAYGBgIGAgQECAQEAggCBgIAAgYEAgAEAAYGAAIEAggABgQEBgACAgYGCgYEBAIGAggGAgQCAAICBAYGDAQCEAIGCAACAggCAgAIBgQCBggIBgIEAgIIAgIEAgICBAIKAAYGAgYEBAYECBIIAgoECgoKCAoEBgwCCAYOCAQKDAIOCAgECAgKBAIOCg4CCgoKBAgGBAQIBAoQCggGEggEBAYCBAQECggGDgYMBgwCCAoKCAIOBgoABAAGCAQICAgGDgoOCAIKBgICCgQEDAYCAgYEBgoGBAIMBggIBggGBAYGCAYQBAYECAgGDAYOBgQCCAYKEAoGCgoEEgYGEhIECggIBAQEDAIEEAQKBAQEBAQEDgYICgIKBAgMAAwCBAoICgoOBAoOCAAECAYICAgICgACAgoEDAYKAgwGAgQEDAIEBgYIAggGBgoECggGBgwICAIEAgIGCAwGBAIKDAIGAgoCAggCBgICCgYGDAIOBAQCBgYCCAYEBgoIEAIGBAwGCAgCCAoICgoICgoIBhAMBgQGBAYECAYIBAoKAggIAggGDAgGBAgKBAgGBAYCBgQCDgQMCAoGAgYEBgIGAAIGBgQCAgQCAgQGBAQGBAIABgIKBggKBAQGCgoCCgYGCgIEBAYCCAYCAAIGCAgCAAoECgIABAYGCAQEBgQMAgQGBgYGBAYCAAIEBA4GAgQCAgYEBAQCBAICBggIAgIGBgQIBAIEBgoEAgICCAIGCggGBgYABAQCBAICAAQEBgYEAwQGAgIKAgQEBAAGBgIMAAQIBAwCAgYCBgQCBAYABgIICAMMCAQGCggEAgQGBAgCAgQFBAQKBgQCBAYMBgQIBgYGBAQKBgYACAICAgQKCgMIAgQGAAQICgIICggDBgoAAgAGCAIEAgICAgYEBgQDAgMGAgAKBgQCAAQEAAQEAAQECAIKBgQKAAgEAgICBAACBAYEBgYEAgQECAIEBAQGCgQEBAQIAgYKBgoCBggGAgIEBgYCBgIGDAQCCAMEAgoAAgIEAgQEBgQIAAYABAIKBgACAgAECAYCCAQEBAQCBAIIAgYCAgIABgQCBgACAgYGAgYKBAQEBAQEBAYGAAYCAAIEAAYCBAIEAAQOAgYGAAYCAgIEBQICBAAEBAIEBAQACgIEAgMIAgQABAwKAgIGBAACAAQEBAACBgYEAgIEBgMGAgAECAICAggACgIDBAQCDAQGCggCCAgEBAQGBAACAAYCBAAEAgQEAAIABAIEAwQEAgIAAgIABgICBAIEAwgCAgMEAgACBgYCAAQEBAICAgYEBgIEBAQCAgMEAgIDBAAEAwIGBAQABgMCBgQCCgYCBAQABAoGBAICAAIEBAIABAQAAgMICgQCAwICCAQEBAIGAgYABAQAAgYCCAYEAgIEAgIDBgIEAAQEAAoCBAIAAgMCCgACAAYGAAgACAACBgIACgACBAIEAgQCBAIAAgICAgYKBAYEAgICAAYEAwIGBAAEBAQMBgYABgQCBAIEBgoAAgACCAIABAoKBgQGBggGBAQCCAQECAIKBAgCAgICAgYCAgoEAgIIAAIABgYEAgIIAAQEBAAGBgoGBAgMBAIIAAYGCgACAAYEBgQCAwYABgYCBAMEAwgACgQCBgQGAAYGBgAEBgQGAgQACAoCCAoEBAAIAgQCBgYKBAICBgYCAgQGBAQIAgYEBAQCBAYEAgACBAQIAgoCAwYEBAICBAACBgYICgIMBAICAwIGBAIEBgMCAAQGAAICBAYCBgIEAgQCAAIGAAIKBAQCAAIEAAoAAgQCBAQGAAwEBQgCAgQGAgIEAgIIAgMIAAQAAgIGBgIAAgUECAMGAgICAAYGBAICAgYIAgQEAgACAgQCAAIEAggCCAQDBAQABAMEAAIEAgQCBAICAgIAAgIKAAQDAgIABAICBgQEAwICAgICAgACBAQCAgAIBAIACAICAAQEAAICAgQAAgACAgIEAgQCCAIAAgAEAgICAgQEBgIEBgIACAIGBAIGAgIDBAgCBAICAAQABAICBgQEAAIEAwYCCAICAgUGAwIABAIABAAEAAIEBgQGAAIABAIAAgYCBgIFAgACAAQCBQIABAQCAgMCAAYCAgQGAgcCAgICAAICAwICBAIDAgICAgIEBAACAgIIAgACAgIEAgIDAgIEAAICBAQCBAYEBAAGAgACBAICBgMCAwQEAggCAgQABAQCAAYCCQQEBwQCAgIEAAIABAQCAgUCAggAAgICAAQDBgMCBAACBAMEAgQAAgQDAgIDAgIIAAICAwQCAwICAgQCAgICBAQCAgAGBAACAgMCAAQEAAIAAgIAAgUCAAIFAgICAgMCAAYFAgUCAAICAgIIAgYCAAQDAgACAwgFAgMCAgIDAgICAgMCAAQCAgIAAgICAAIEAgICAgACAAIDAgACAAIGAgQEAwQLAgICAgQCBQIGAAICAAQCBAICBQIXBAMCAgIFBgACBQIEAAIAAgIABAIAAgMCAwIACAQDAgACAAICAgQABAICAAQCAgMEAgICAwIAAgICAAICAwIDAgAEAAICBQICAAIAAgAEAAQFBAACAwICAgICBgUCAAIFBAMCBhMCAAIDBAIJBgIDAgMCAgACAgACBQIAAgIDAgAEAgIABAkEBQIEAgIAAgcGAAICAAIABAICAgQEAgYGAgICAgAEAgAEAgMEAwQCAgACAgMGAgIGAgYDAgICBAICAAICAgACAAQCBAACAAYCAgIEBAQCCwICAgQABAICAgIIAgMCAgIABAQCAgICAgQABgACAAICBQIDAgACAgIEAgICBAACAAIEAgUCAwQECAICAgICAgsCAAIABAYAAgIGBwIDAg0CBQQDAgQCCAIAAgIDBAsCAgIHAgIDBAAEAAIABAIAAgMCAAICAAYABAQDAgAEAgICAAIABAQEAAIABAACBAIGBwQCBAIDAgcCAgICDQQCAgIEBAACBwIEAAICCQQEAgACAgACAAIJCAQEAgACAAICBAMCBQIGAgICAgQGBwIFBAACAAYCAwQCBAIAAgICBQQDBAACBAACBQQFBAICBAACAAIFBAACBgUCAgACAAIJAhECAAIDAgIAAgUCAwIJAgIAAgcCBwQCAwIHAgACBwIFAgACAgIDAgYEAwICAAIJAgACBQIDAgkCAAQAAg8CAwIJBAACAgMCAAIEAgACAwIFAg0CAwIAAgACAgQDBgUCBwICBQIFAgMEAAYAAgACAwICAAIABAACAgMCAwIAAgsCAgICCwIAAgcCBwIJAgACAwIJBAUCAwIFAgICAAICAgcEAAQEAAQCAAIEAg8CAgIHBAICAAICAAYJAgUCBwQAAgcCAwIAAgAGAAICAgUEBQIHAgkCBQIABAMCAAIlAg0CBQIFAgACAwIXAgACBwICEQICEwIRBAACAAQNAgACCwIDAgACAAQCBwIDAgIFAgIAAgIDAgIZBgsEAwIABAIVAgUCAgICBQIEAgUCCwILBCMCAwICAgMCAAICAwIAAgACAAICBAICAAICAgcCCwIDAgMCAwIHBAIGAhECAgIDAgkCAAILAgACAgcCAgACAwICCwIDAgIHAgACAwINAgIEAAICBwQCAAIFAgACCwIAAgILAgMEAwIDAgACBQQDBAMCAwIDAgACBAcEAgUCAAQPAgACAgMEAAIDBAIFAgACAAIEAgMCFQIDAg0CAwIFAgIDAgACAgQFCAACBwIAAgkCAg8CAAICAgsCBgIFAgIJAgkCBQIRAgMCAAILAgINAg0CAwIHAgMCBQIDAgcCBAcCBQIJAgkCFQIFAgIHAgUCBQICBQIDAgMCBQIPAgIDAgIAAhECCwIDAgUCCwIAAgMCAg8CEwQEAgICBQIHAgMCAgkEBwIHAgILAg0CBwIFAgMCBwICFQIFAhECBQICAAICAwINAgACEwITAhECGQIPAhsCBAACAgcCIwIABg8CBwIDAhsCBQIHAgkCIwINAgQXBAsCNwIlAiMCFQJFAgMCAwIVAisCDwIDAgkCFwQAAgACAikCGQIAAh0CAg8CBQIHAg0CAg8EEQINAhUCAAIRAgUCJwIZAgsEFwIVAgACNQIFAgsCCQI9AhUCCQIJAhUCIQI7AgIXAgMCewINAhUEPwIlAikCFQLRAQJBAqcBAq8DAqVDAgIFAisEaQJNAg0CXQIJAhkEEQIdAjcCNwK7AQIxAgUCQQKVAQIFAmUCCQINAgcCBQQEAwICAgAEAgAEBgACBQICCQILBAMCAAQEAwICAgMCBAACAgMCCAICAgcCAgUEBAUCBwQEAgcCBwIHBAIFAgMEAAQABAIAAgIEAgQAAgICAAQCCQIDAgUCAAIJBAAEAAIEAgIGCQQAAgIEAgMCBAACAAINAgIAAgsEBQQAAgACAwIEAwICAgQFAgIHAgACBQIABAQHBgACAgcEAgMEAg4MAAYDAgQABAIJAgIHBAQCAgQCAgACAgIFBgIAAgYDBAIABAIAAgACAAIABAMEAwIDAgICBwIEAAIAAgIFAgQCAAQAAgIAAgICBAUCAAIJAgACAgICBQIVBAIHAgUCBQIFAgACDwIFAgACBQIEAg0CCQIAAgkCAgIFBAICBAMCAAIABgMEAAICAgIEBAQAAgICAwIGBQIJAgkCAgMCAgIDAgUCAgkCAgMCAgINBgsGBQQTAh0EBwIDAgkCBwICAgUCBgICBwIHBAcCCQINAgIDAgIDAgMEAAIAAgAEGwICBQQFAgACBAUCAgMCAAIAAgIEAwIFBAACAgcCAiUCAgACGwIJBAICAgcCBQIRAgACBwICAAIJAgcCAAICAgcCEQIAAgACAgMIBQQCAgICCAcEAwIEAwIDAgcEBQIAAgACAwIKAgACBAIDAgAGAAIAAgIAAgUCGQQNAgcCBwIHAg0CAhUCBQQAAhkCAAIGOwQCEwQACAIDAgACBwICCwIxAhUCDwQABCkCCwIFAgUCGQIAAgACPQIdAj0CBwICAmMCAgcEDwIRAgkCAAIDAgcCAgIPAhECFwIPAgIFAhcCBwQCAwQDBAIFAgsEEwIDAgMCAwIFBAIJBAICAgQCBQIFBAIEBAIACgYAAgAECAQCAgICAgQEAgIAAgMCAgACBAACAgQEAgICAgICAwIFAgACBAMCAAIEAgIDAgUCAwICAAQCCQIABAYHAggCAAIAAgQCBAgEAwIDAgIDBAACAggEBAIAAgUCCQICAgACBAUCCQQCDQIABAsCAAIGBAsGBgIGBwIAAgACAAILBgMCCQIECQIAAgUCBQIDAgkEAAQDAgMCAgQCBgICAgICAgMCEwICBwIDAgkCAAIAAgMCAhECCQQAAgAEAAIFBAACAAIDAg0CAgAECQICAAIAAgcEAAIEAgACAAYEBgAEAAQAAgACAwICAAQEAAIDAgAEBgYGBAAGAAYFAgUEAAQAAgIAAgIAAgUCAAICBAACBAMCBwICBAQDAgYCBAAEBgMCDwIAAg0GAgAEAAQCBAACAgIJAgMCCQQAAggEBAYCAAYGAgQCBAQCCwIABAICBAACAgIABAQABDMCBgIEAAIGCAgQAgYGAgYGBAACAgAGBAIEAgcCBQQDAg0CAgICAgACOwICAAIAAjoaBgIGBAI="
+        },
+        {
+          "operation": "composition_read_current",
+          "requests": 6866,
+          "errors": 6023,
+          "latency_ms_p50": 8.439,
+          "latency_ms_p90": 8036.351,
+          "latency_ms_p99": 26935.295,
+          "hdr_v2_base64": "HISTEwAAFo0AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAIULAtcBAi0CGwKTAQIRAlMCFQIXAgUCAgkCIQIAAi0CIwIdAgACGQIhAhcCBwIfAgIHAgcCDwIDAg0CBQIPAhMCAAIAAhECDwIbAgkCDQIDAgkCAg8CAwINAgsCAgMCAAIEAwIAAgIAAgUCBwILBA8CAgIAAgkCAAINAgACFwIDAgAEAgAEAhkCAAIFAgIAAgcCAgACCwIFAgMCBBkCAAQDAgACAAIAAgACAgMCAwQFAgcCAgMCAwICAAICBgMCDQQAAgACBAQnAgQEAgQCAwICAgICAAIDAgACCQQAAgIAAgMCAgMCAwIAAgAEAAICAgkCAgMCBwYFBgcCBwIEDwIVAgIAAgIAAgMCFQIDAgkCAgcCAwICAwIEAgMCAAIEAAICAAQAAgIEAgACBAQJAgIAAgQDAgACAgACAgIEAgIFAgACAwQAAgQCBAMCCQQDAgMCCQIFBAQZAgcEBQQAAgMGAgQAAgQCAgACBAcCBQIDAgICAwIFAgMCAwIEAwIHAgQEAgICAgUCAgICAAINBAUCAAIEBQQDAgACAgIEBAICAAQCAAIDAgQDBAQCAAICBwQDAgICDwICBAUCAwIEBQIAAgUEAAIEAAICBQIEAgICAgUEBAICBAICBQICBAQDAgQCAwIAAgACBwIJAgMGBAIACAIGDQIEAgQDBAIHBAMEBQQAAgMCBAQCAAICBQICAgAEAgICAgAEAgAEBgMIAAgCAgIDBAQABgYGAwQABgACAAQAAgUCAgQEAgQCAAIGCgIEAAICAgQABAIEAAICAAIEAgICAgACAgUEAgIAAgIEAggABAACAgICAAIEAwIAAgQDAgQEBgIEAgQACAICAAYCBAQCAwQCBAQCAAgFAgMGBAQCBwIEBgIABAICBgIEBQIGAAIFBAAEBAIABgICAgAKAAYDAgIGAgAEAgUEAgQEAgQAAgYMAAICAAIEAgICAAQCBQYCAAQDAgICBAIAAgYCAgMEBgAEAwQCBgIABAIEAgoCAgICAAIIBAIDAgAKAgIAAgQAAgICAgUEBgACAgAEAgICBAICBAQCAgYABAIDAgcGBgIEBAIEAgICBgcEAAICAgYEAgAKAAIJAgYIAgQEAgYEAgACBAICBAICAgICBgIABAkGBAgCAgAGBgQEBAoAAgQGAgIABgIABAYCAgMGAgACBAQEAwICAgIAAgICAgUCAwIAAgIEAgYCAAQCBgACAwQGBAQACAIAAgYEAAQEBgUCAgICAgAIAAQECgYEAgAGAgQGBAICAAIEAgIEAAIAAgQGAggABAYEAAgEBgYGAAICAgQEBAACAgIAAgQABgQAAgAEAwQCAgACBQQABAAEAAQEBAQIBAICBgICBAQECAIIAgIAAgIABgMGCAAEAgICAgAIAAQAAgIABAAIAgAEAgMEBQQCBgMIBgIEBgIACAACBAUGAgYCBAYCAgYABAIEAgACAgIABAYEAwQABAACAgQCAgAEAwYDAgICAgAGAgQEAgQACAQCBAICAwgCAAYCAAIABgYAAgAEBAQABgAEAgICBAIAAgICCAACAAYABAICAgYEAgQGAgQECAICAgACAAQAAgICCAIGAgQEAwIEAAIEAAIDBAUEAAICAgQAAgQCAgACBAIABAIDAgICBAICBAQFAgAEBAQIBAAEAgQIBQIECwQFAgICAAICAAYEAgQAAgUCAgICBAACAAQDAgQAAgIEBAQCAwIPAgAEAwYEAgIFAgMGAgIEAAICBwYCAgAEAgUGAgAEAgIIAAYCAAQCCQQEBgMGAAICAAQEAgQEAAQABAACAgIABAQCAgQCAAIAAgIGAgACAgcCBQIEAAYABAYAAgICBAACAAQEAgACBgICAAQCAgMGAgIEAAQCAAIABAAEAgIABAQABAACAgIEAAICAAYEAAQAAgACBAQABAYGBAAEAgIEBgIEAgoGAgQIBAIIBQQGAgQIBAIAAgYCBgYEAgQGAAQABgIIBAoCBAIGAgACAgQEBgQIBAIIAwgGCAIIAAIIBgQCBAoCBAIGBAAGAgYGBAIABAQGBAIIBAgEBAQGBgQGAgYEBgACBAIABAIABAIIAgIEAggEAgQCAgoGCAAEBAQEAgYIBgQGAgYCAhIGAAYCAAQGBAQEBAIIAgIGBgIGBgYCBAAGBAoADAQDBggICAQAAgYABgAEBAQAAgQCCgYGBAIEDAQEDAICBAIAAgYKBAQEBAoEBgQABAQEAgQAAgYCCAAEAgIICAAGBAYEAgACAgICAgYEBgMGBAIGAgAEAAQEBgYCAAIECAIEAAgEBAIEAgICAgYKCggCBAgGBAYCBAQEBgYIAAgGAgIGAgQKBAICAgIGBAIACAYAAgIEAgQCAgQEBgICAgYAAgAICAgCAggABAIEBgIICAQGBAIDBAIACAQAAgYEAAQCBAQABAgCCAgCBAgABAYGAgQCAAICAAgEAAQCAgQABAQGAAQCAgAGBgQGBAYEAgwGBgYCBgQGBggEBgIIBAQEBAYCCAgEAgQCAggCBAAGBgIGCAYCAgwECAQGBgQGAAQGBAgGAAYCAgYCAggECAQCBAUEBAAGBgYIAAICAgAEAAQGBAACAAIGBgYGBgIGBAQCBgYCCAIDBAAEAgIEBAQCBgIGAAIEAgIEBAAGAgQIBAQCAgQGBgIKAgQKBAQEAAIECgQEBAAEAAQIAAIIBAQCBgYCBAgCBAACBAQEBAAGAAYCAAYKAgIAAgIECAIEBgYEAggCBAIECAYGBAQEAgICBAMEAgQEBAQABgICAgQIBAIGAAICBgAIAgQCBAAIAgICAAQEBAgGAAICBAIABAIIAAYCBAYCAgICAgAGAAQEAwYEAgQGAgICAgICCAICAAIABAIEAgIABAMEAAIEBAAIBAQCBgIIBgQGBAMEBgICBgIAAgIFBAQEAgQCAgQCAggEAgQCBAICBAQCBAYGAgYCAgcCAAIABAIAAgYEBAUCAgMGBgIAAgQGAgYCAAQEAgIEAAICAAYEBgICAAQAAgIAAgQAAgICBAICAgMCAgQEBgIIBAICBAAEBgIACAYABAAEBgQEAAYCBgICAAIABAYCAgACAgQDBgIABAIFAgQCAgIEAgQEAwICBAQGBgUEAAICAgICBAICBAgEAAIABAQCAAIFBAYCAgIAAgACAAQEBAACAgIDBAYEAgICBAICAAIGAgIEAAIAAgYCAgQCBAMEAwQCBAIGAAQCAgACBAAEBgICBAQACAIAAgIEAggIBggEAAgIBggMBgoCBAgCBAgGBgIACAQCAgIECAACBgIGAAoEDgQABAQMAAYEBAYIAgIGAgIKCAIIDAIEBggKBAYIAAQEBAQGBgwEAgIAAgACBggIBAAICAQGBAIGBAQEAgIGBAQCAAQCBAACAgYEBAIACAYECgIGAgIGBAYCAwYEBggCBAYIBgQCCAYECAIAAgYCCgIEBggKBAQEBgIACAQIAggGBAwEBAYACgQGBAMCBAAGBgUEBAQEAgIGBAQEBAIAAgQEAAQCBAICCAIEBAIEBAIAAgYCAAYOCgYCAAQCBwIEAAICCAQGAAQKBAQABAICBAICBAAEAAICBAACBAIIAgYCAAQIAgAEAgwCBAoDBgIGAwQEBAAEBAAGBAICAAYABAIEAgQCBAMCAAQEAgIIAgQEAAgEBgIGAAgABAIGBgAICAQEAgIGBAAGBAIAAgIEBgACAAIECgAEBAIKAAQGBgAEAgUEBAYAAggEAgIMAAIKCAQDCAQCAgIGBAgGBgIGAgACCAICAgQIAgQCBAIDAgAEAwgCAgIEAgMEAgICBgQGAAICAgQCAgICAAIEAgICAAYAAgQEAwIGBgAMBAYCAgIEBAIEBAQABAACBgYEAgYEAgICBAQEAgYEBAQCBgIEAwgCAgYEBAIICAICCAYCAgMEAgcCAgIDAgIAAgICBAIEBgIAAgACAgIABgQCAgICBgQCAAQCAAYDAgACAggAAgQAAgMEAgAIBgQACAQIAAQACAACAAIHBgACCgACBgQCBgAGAwIABAIGAgIABAQCBAQEAwIABAIAAgICBAQCAgQAAgQAAgICAAICBgAEAAIAAgQCAgQEBAQABAAIAAIEAwQIAwIGAgQEAAIDAgACAAoEBAQABAQFAgUCAgQCAgIAAgIAAgUCAAQEAAIEAgIDCAIDAgICAwICBAIDBAACBwQEAgIEBgMCAAQCBgACAAIFAgQCAwICBAACAgIIAgICAAYEBgICAgQCAAICBgMEBAQAAgQCAgACBAYDAggCAAIEAAICCwIEAAIHAgAKAAQGAgAEBAIDAgAIAAICAgQAAgUGAAQDAgMCAAIGBAMCBAACAAICAgIAAgIEBwQAAgQDBgICAAICAgAEAAQDAgYFAgQEBAMEAAICAgIAAgIEAAIDAgUGAAIDAgAEAAIEAgMEAwIEAgACBAIEBwIGAwgCBgQCBAACAwICBQYDBgMCAgIABAYCBAICBgMCAwQDBgIEBgIEBgIABAICBAQCBAYCAAYGAAIIBAIEAAIAAgIAAgACAgIABAIEBAACAwIABgIGBAQDCAMEAgQCAAIABgIEBAIIBAIIAgYCAgQABAAGAwQEEgACAAQABAQCAgQEBgQCBggCAgIEAgIDAgYAAgACAgIAAgUCAAYABAQCAgYCAwQGAgICBgQCAAIEAgIAAggABgYCBAQDBAAEAgIDBAQDAgIGAgIEAgQCAgACBQYEAgICAAIAAgIAAgYCAwQGBwoABAIABAMCBAQCAgQAAgIEAgMCAwIAAgIABAIAAgACBAQABAAGAAICBwIEBQICAAYIBAICAgAEAgMEBgIAAgMCAAQEAAQCAAIABAACAgMCAAIEBQQCAAIEBQYCAwIEAgIAAgACAgMCBwIGAgACBQICAwQEBAICAgMCAgIFBAMCAgIFAgIDAgMCAgQFAgIFAgUCBQgAAgAEBAcCAwQCAgACAwQHAgQAAgIAAgACAAICAgYCAwIFAgMEAgICBQICBQQFAgICAAYEAwQEAwIEBAACAgUCAgQCAgUCAgACAwQCCQIFAgQCAgICAgAGBwIAAgUCAAIEAgMCAgMEAgUEBgIEBQICBQQABAMEAAIABAICBwQFAgMCAwQFAgACCQIDAgIAAgIAAgIAAgIFAgIABAUCAAICAwQCAAQLAgIEAwICAwICBAACBQIABAACAgICCwIDAgMCAgIAAgcCAAIDAgQDAgUCAAIFAgIDAgMCAgACAwIDAgAEAAIEAAQDAgQNBAIAAgAEAAIECQICAAIAAgUEAwICAwIDAgsCAAIEAAIFAgIJAgMCAAIFBAUCCQICBhMCBwICBwQAAgMCBQIDAgMGAAICAAIDAhECAgUCCwICAwIJBA0GAgAEAAICDwIGBQIAAgICAgIXAgkCCQIHAgAEBQILAgIDBAMCAAIPAgIAAgsEAAQAAgICAgMCBwIAAgIDAgIAAgACCQIAAgIDBAACAAIAAgMCAwQNAgQCAgAEAAICAwYFAgUCAgACAAIAAgIAAgAEEQIEAgAEBAIAAgAEBwIEBQIABAMEAAIAAgUCAwIDCAACAAIJAgUCAgICBAkCAwICAgIDAgIFAgICAAYAAgcCAwICAAICAgACAgMEAgACBQQTAgUCDQIAAgUCAgIAAgMCBwIAAgICBAMCAAIJAg0EAgACAgQDAgUCCwICAAIABAACCwICFQITAgUCAAIAAgACAAICAAIEBAACBQICAgMCCwIJAgsCAAIDAgMCAgMCAwIdAgACBQIFAg0CAAICAAIHAgACAwQAAgMECwICBQIDAgcCAwILAgQAAgMCAgsCDQIRAg0CAAIECQIDAgICDQINAgACHQIDBAMCBQIFAgUCAgsCBwIAAgACNQILAgMCAgMECQIDAgMCBAcCCQIHAgMEAgkCCwICAgMCBQICAAICCQICFQIAAgUECwILAgIDAgMCBQICAgcCAgUCCwIABAkCAhMCFQIAAgIfAgMCBQICCwILBAcCAAICAAIjAgACCQIxAgILAgACDwIHAhsCFwIAAhECAhcCDwICDwIHAgUCAAIAAhMECQIDAgQDAgIFAgICAwIPAgIRAhUCAgACAwIEAgMEAwQJAgIAAg0CAgUCCQIHAgsCGQIFAgMCAwIXBAcCBwIJAg8CHwIFAgUCAgMCHQIFAhkCBQQhAg0CEwIJAhsCEQQFAhECAgUCEwYABBMCBAUCBwICCwIVAg0CBAcCIQITAgkCAAIHAgsCFQIPAgcCIwIhAgMCAgkCAAQABFECBwI9AgMCAwIJAgMCEwIAAgMCEQIHAgcCOwICBwICAAJDAkcCEQIXAg8CBQIABBcCAhMCGQIDAhECAiECOwIRAgkCBQIpAkcCLwIdAl0CEQIHAgkCDQIZAh0CQwICEQIAAhsCDQIxAnECNQIPAmUCSwIjAiUCJQIAAqUBAgUCZwLPAQKDAQLfBAKFQwIFAgcCMQIAAgMCFQILAgcCHQIHAgJzAmcCIwJpAiUC9QECMwILAhMCCwIHAlUCBwIFAgUCUwIDAhMCDQIAAgMGAgQCAgYABAQIAAQDAgACAAICDwIGAgIEAAICAgQABAAGBAUCCAIDAgAEAgICAwIEAwQCCAQAAgIEBAAGAgACAwIAAgACAgIFAgIABgICAgIECgYGBAICAgAEBAICAgUCBAIDBAIEBAACAgICAgAEAwIEAgMCAgQCAgACAAICBAICAAIHAgYCAAICAAIDAgAEAwICDwIDAgAGBAQFBAYECAAEBwIHAgICAAYCAgMCBwYFAgICAAICAgIEBAAICgQECgYGBAwFBgYDAgQCBgYCAgAGBAQCBAACBgQHAgAEAAICAAICAAQIAgICAAQCAgYDBAACBAIEBAUCAgcEAAIABAUCBwIFAhcCAAIDAgAEAwIDAgIAAgIHAgACAgACAgcCAAQFAgkECwINBAIEAgMEAAIDAgACAAIAAgACAAIDAgUCAwICAgICAgIAAgICAgQCBAIIAAIEBAILBAMEBAAECQICCQIJAgACBQITAgIDAgsEBA0CAAYCCQQHAgMEEQQCAgQNAgACAwIGAwIABAACAgUCAgIEBAQHBAACAAQPBAIFBAACBQIAAgQHAhMCAgIAAgMCAwIFBAQABgICAAIEAgICEQYGAAIEAgQCCAACAAIjAgIzAgMEAAICIQIFAgQFAgMCAgMCAwICAAIHAgUCBQIHBAICAwYCBAAEBAYCBAACAgQAAgICAAYCAAICAgQCAAIEAgACAAICDQIDAgACAAIHAgMCAAIAAhcCEwIlAgkCAwIAAhMCHwQCBwIHAiEGBQIHAgsEAgUCAgUCAAYEJwItAhECKQIvAh0CVwIDAjUCxQECQwJJAgMCBwQHAjcCBwIAAgkCCQIFAgcCAwIDAgIEAgkCAwICAwIAAgsCAAICCQYCAAIPAhMCFQIDAgQEBgAEBQIAAgACAAQCAAIEBgQAAgACFwIRAgUCAAYAAgIFAgUCAggRAgkCAgcCCwICBwIVAgIAAgIDAgsCAAICEQIDAhECFQIdAgIZAgILAhEEAgIFAg8CAikEBQIJBAIFAgcCAgAEBwQEBgACBAIFAgMCBgMCEwICAg8CFQIRAgkCGwICAgICDQIDAhECAAQDAgMCAgICAg0EAwIFAgMCGwIbAgQCBwIKCgICAAICAgICBQIABAIAAgMCAwIZAgACPQICAwIFEgY="
+        },
+        {
+          "operation": "composition_revision_history",
+          "requests": 6591,
+          "errors": 4332,
+          "latency_ms_p50": 15.511,
+          "latency_ms_p90": 13230.079,
+          "latency_ms_p99": 28852.223,
+          "hdr_v2_base64": "HISTEwAAFpoAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJUOAkcCnwECKQI/AjECAAJLAhECDwIDAhUCOQIHAiMCAwIHAgMCGwITAgACEQIHAhcCDQIRBAUCBQICBQILAhUCCQIRAhkCAwIHAg8CIQIAAgcCAwILAhMCAAIDAgACEwIABAICCwIFAg8CEQIHAg8CAwIRAgUCBQIAAgUEAwIAAg8CBQIHAgUCEwIJAgACAAIFBAACDQICBwIJAgMCAgQHAgUEAgACAgQFAg0CBQICDQIFAgACCwIJBAITAg0CCQIFAgQECwICFQIAAgcEBQICAwIDAgcCAgMCAwIDBAsGAwQFAgACAAIAAgACAAICAwIJAgUCAAIDAgkCBQICCQIFAg0CAAQJAgIDAgINAhMCBQIDAgIEAAIFAgUCCQICAgcCAAICAwICAAQABAIDAgUCEQIAAgIDAgQAAgMCAgACCwICBQICEwIDAgACAwIFCAICAgACAgACAAIDBAACAwICCQICAwIAAgsCAwIFAgkEDwIAAgIFAgcCAgACAgAEAgACBgQCAgIFAgQEBAACAgIDAgACDwIAAgACAAIEBgUCAgMEAgYCAAIEAAIEAgMCAgIABgMIBQIFAgAGAAIAAgIHAgACAgMEBAQGAAQCAAICBAQABAIEBAACBAUCAAQEAAIAAgICAgACAgMCAAIJBAYCAgIDBAIEAAICAAQCAgIEAAYCAgMCAgAEAAIAAgIABgMEAgACAAIAAgAEAgQDAgICAgACAgUEAgACAgUCAAQEBAIAAgIEBQQEBgAEAgIABgQCAAICAAICAAQCAAIEAAICAwICAwIDAgQJBgAEBgICAgIEBgICAAIEBAAEAgMEBAICBAMEAwQAAgUCAAQCAAIAAgICAgIABAMCAgIAAgUCBAYEAAIGAAQGAAgABAIGAgACBAICBAQCAAIABAQCBAIABAAEBQIDAgIEAwYEBQQDAgQAAgkCAgcCAgUCAwIEAgQCBAIEBAMEAgICAgIEBQQCAgIDAgICAgICAgQEAgQEAgMCAgYAAgICAgYEAgcEAgACAgACBAICAgICAgMEAgAIAgIAAgACBAMEBgICBAQDAgICAAYEAAIAAgACBgIEAAICBAICBQIAAggAAgQDAgACAgICAgACAgkCAAIEAggCBAIEAgAEAgIEAAYABAQAAgIAAgAEBAIGAAQAAgMCAwQJAgQDAgQABggDBgACAgAEBAQAAgIAAgACAgAGAAQGAAICAgkEAgUCAAIDBAACBAAEAAQEAgMGAwIAAgYCAgQAAgACAAIAAgAEAwIAAgUCAgIHBAIEAgQEAgICBAMIAwICCAAEBAIHCAIEBgICBgIAAgIGAgMCBgcCAgIDBAMGBwIAAgUCAAQDAgAEAwIABAIEAgAEAgACBQQCAAIDAgICCwIEAAQCCAQCBAIAAgAGBAIEAgICBQIAAgAGAAQAAgAEAAIDAgQEBgICAgMCAgIDBAICAgcCAAIAAgAEAwICAAIEAgMCAAICAAQAAgICAgIFAgIDAgMEAgIDAgUCAgACCQYCAAQCCAQCBwICAgMCBAACAwIAAgICCQIABAIABAACAgICAgAEAAIDAgACAAIJAgAGAgAEAgICAgUCAAQAAgACAgMCAAQFAgICAAICAAICBgACAAYIAgQEAgIIBAQGBgQCAgAGBgACBgQABAMCAgQFBAICAAICBAAEAgQEAgAEAwQFAgQABAIEAgYCAgQCAgICBAQGAwQCAgACBgICAgICAAIDAgYGAAICBgICAAICAAoEAAQABAAEAwQEBAIABAICBAYCAgICBAIEBgUEBgICBgAGAgIEAgUCAAICAAQGBgoCBgQAAgUECAYCBAMEBAYAAgYCAgICBAIGBAICAgICCgIEAgMCBAACAgICAgoCAgICAwICAAgFBgIGBAICBAIABgIKAgACAgYCAgICBgIDCgAGAAIECAIEAgAEAgACAAICBgQDAgACAAYEAAQCAAQGAwQIAAIEBAUEAwIAAgIAAgACAAQEBAoABAYCCAQCAAIEAgQIAAIEBAIDBgIAAgICAgIDBAACBAICAgACAggIAAYCBQIAAgAEAgACAgQAAgIAAgACAgUCBAMCBgACAgQCAAIIAAIEAgACBAUEAgIDBAIAAgQCBAIAAgIEAAICBAIAAgYAAgICBAICAgAEAwICAgMCAgMCAgYABAIAAgIAAgICAgACAwICCAIABAACAgACAgIEAAIEAgAEAgoEBAYEAgICAAIAAgQAAgYABAMCBAIDBAIAAgQEAgQCAgQCAgQEAgQGAAgCBAMCAAQABAsCAAICBAACBAICAgICBgIAAgICBgIEAgMCBAACAgQAAgACBAQCBgACAAQCAgkCAwIMAgQABAIFBAUEBAICAgICAgIDAgICAwIABAICAgYGAgYCBAAGBgQCAgQEBQQGAgICAAICBAIEAAIABAICAggCAgICAwQCAgYCBAICBAIGAgIABgQCAgQCAgQHBAAEAgICBgQGAgIDBgICAwICBgIGAgYCAgMIAAQCAAYCBAIEAAIEBAICBAACBAAGAgIIAgACCAIGAgACBgACBQIABAgAAgYCAgMCBAYABAMCBAACBgACAAQEAwQGAgAEAgIAAgQEAAIAAgAEAAQCAgQCAAIAAgICAAIABAgCAAIAAgACAgQDAgMGAgQABgICBAYAAgACBAIEAAIEAAIABgAEBAMEBAICAgIAAgYCAgQCAgQABgQIAAICAwYGAg4CBAICAgQFBAYCAgQEBAQCBAICBAAEBQQCAgICBAIEAgIDAgcCAgACBAQCAgQAAgICBAQCBAMEAAICBwIAAgIDAgQEBAACAgQDAgICAgQEAgQCBwQCAAQEBgUCAAYCAAIDAgACAgMIAAIGAAgABAYCBAYEBgIECAQDBggCBAIEBgAGBAQABAAIAgQEAAICAgQGBAIECAYCAwICAggGCAgGBggABAIAAgAEBAYDCAACAgIEBwQECAICBAIACgIEAgMCBgIGAgIABAUGBAQCAAIGBAICBgIEAgIAAgYCAAICBgIAAgACAgIECAIEAggCCAAEAAIEAgIABAYCAgACBgAIAAIEBAYABAIABAICAgICBAQIAgIABAIEAgIMAgIGAgYCAgMEBAQCBAoCAgQAAgACAgAGAgACAAgDCAIGBAYCAwQCCgQCAAQABAgKAgQCAgQAAgQCAgAGBAYABgQCCAACAgQAAgQDAgIAAgYCBQgEBAIEAgQCBAAEAgMEAgICBgACAAICBAACBAIEBAACAAICBgYEBAQCBAMCBAIIBAMEAgACAAYAAgICAgICAAIGCAACAgYCAggGAAICBAACAgACAgACBAICAwoCBAAEBAMGAAgCCAIEAAICBAACAgAEBAICBQoCCAIABAIAAgMEBAQCAgIEAgACAgQABAQCAgIDBAIGAgICAAYCBQQEAgQAAgYEBAQAAgUCBAQCAAYAAgIFCAACAgAEAAQABAQEAgQCCAACAAIEBQIFAgIAAgcCAgQAAgAGAwYCAgAEAAQEBAYCAAIDAgIHAgIABAIAAgICAwIHBAAEBAICBAQFBAIEAAIAAgICAwQGAgQCBQYFAgMCBAQCAAQHAgACBAAEBAQABAQAAgUEAgACAAICBAACAAQDBAQAAgIGBgICAAIAAgQAAgIDAgsEAAQDAggFBAQGAgAEAgICBAYDBgIAAgMCBQICAgAEBQQCBAICAwIEBAQEAAIDBgUCAgMGBAACAAIABgUCAgQEBAIDAgACAwIDAgMCAgUEAAIEBAQABAIEAwQCAwIAAgIAAgcEAAIEAgACAgUCBAUEBAQCBQQEBAIDAgcCAgQDAgIEAAICAgICAgACBAACAgMCAgIEBAIAAgICAgICAAIFAgAEAAIIAgIAAgIEAgACAwQFAgMCAgMEAgIABAcGBQIAAgQABAAGAgACAwIAAgcCAAIAAgQFAgIAAgMEAAIAAgUCAwICAwIAAgACAgQDAgQCAgACBQICAAIAAgsCBAIDAg8CAwIDAgIAAgIDAgQDAgIAAgUCBAACAgQFBgQEAgICAgYGBAICAgUEBAQLAgMGAgAEAgQAAgcGAgICAgQCAAIEBAMCBAMCAgICBAIAAgYEBwIEAAQEAwQAAgICBAIFAgICBAACAgICAgACAgQABAQCAgICAAICBQQABAMEBQIDAgAEAwQCBAICAAIABgICAgAEAgIABAQCAAYCAwQDAgQCAAYEAwQCAgACAAYCAAIABAACAgIDBAACAAIAAgICAgIDAgIAAgICAgIAAgACAAICBAAEAAIEAgICAAQAAgQAAgUEAwIDAgACAgICBwQCAAYCAgQDAgICAAIDBAICAwIAAgsEAwYCAwIFAgMCAwIABAMCAAIDAgIDAgAEAAIAAgICAgIFAgIEBwQHBAIAAgACAwICAgACAAIEAAQHBAACAgMCAgAGAgIFAgICAgQAAgIAAgAEAwIAAgIDAgICAgUEBwIFBAACEwIDAgMCAwICAAIDCAACDQICBQIAAgQAAgACAAICCAkCAAIHAgIDAgMCAAIDBAUCAgQJAgMCBAACAwIEAg8CAgkCAAICAwICAgACBAICAAIFAgACBQICAAIFAgMEBwICAAQDAgAEAAQFBA8CAAILAgIEAAILAgIDAgcCEwIABgcCBQICAgACBQIAAgACAgACAwINAgIAAgMCAAICAgUCAAQJAhsCAgUGGwQJAgAEAAIAAgICDQYCBgAECQIDAgAEAwICAgICAwICBQIDAgACAgACAwIFAgACCQIHAgMCCwIAAgIAAgcCAwINAgUCAwQCAwICAAIEHwQCBQIDAgcCAgIlAgkCAAIFBAACAwQLAgUCCQQCAAICAAQCBwQFBA0CEQIFAgMCFQIAAgUCAAICFQIXAgIHAgACAgMEAgMCAgICAgACAgACBAACAwICCwICBAAEBQICAAIAAgICAwIAAgsCAAQDAgUEBQIDAgIABAACBgMCAgMEBAILAgAEAAIAAgYCAgIAAgMCAgUCAwIGAgIAAgMCBwIDBAAEAAIABAIDBgIAAgACFwIDAgkCAgILAgMCFQQAAgUCAAIAAgUCAgQGAgAEAgQCAwIAAg0CFQIAAgsCCQIAAgACAwIHAgUCAAIAAg0CAgIABAACAAIDAgACAAICKQIFAgQAAgACAgMCAwIDAgACBQICAgACAgACCQICDwIAAgIDBAIZAgcCBA0CFQIPAhMCCQIJAgMCBQIDAgACBwIJAhcEAAIHAgACAAIFAhECFQILAgMCBQICCwIJAgcCAgILAgcCAAIDAgIHBAIfAg0CFwIdAgUCAwICGQIAAgUCCwIABAkCAAICBwIJAgUCAAQCAhkCCQILAgIHAhkCAwICBB0CDQIFAh0CBQIABA0CJwICBQIDAgkCGQIbAgUCBwIFAgMCEwIPAhECEQIDAgACDQIbAgsCAwI5AgACBwIDAgACAAIAAgUCBBMCAgUCCwIJAgMCAgsCAAIDAgMCCQQFAhECAAICAgQHAgICDwIAAhkCAAIVAhECEQIdAgsECQIjAicCAAIFAgIHAg8CBQIDAgACFwILAgMCAgUCAwIHAiEEBQIAAh0CCQICBwIdAgMEAgkCAAIFAgMCAwIXAgMCAgILAgMCAAINAhsCBAIAAgACCwIAAgMCBQIzAh0CLQICGwITAhECBwJHAgkCCwI9AgACJwIpAgcCBQIXAjcCVwIbAgINAhkEBwILAmkEBwIHAhkCaQIHAhsCQQIfAgACBQILAjUCEQIVAjMCMwINAjUCKwIhAksCYwIpBDsCLwIdAikCTQJBAgMCqwECxwECRwKXAQL/AwLJQwIzAhEEBQIFAgUCAAIHAjkCFQIHAjUCBQIhAg0CHQIPAgcCCwIFAgcCFwInAgUCCwICAAIFAi0CBQIPAgUCAAIhAjcCAwIDAgACAAIDAgIAAg0CAwIABAUCBQIFAgcCDwIbAgcCAAIHAgMCAwIAAgkCIwIXBFMCBwQAAgACAAICBQITBAACCQIABAIABAICAAICAAQADAcCAgICAAICAgIIBAgCBAQCCAYEBgQCBAIGAggIBAYEDAwICAQQFAYGCAoKCAYEBAgGBgAIAgoMAgIEAgYKAAQMBgwEAgQEDAIGBAQCCgQGAgQMCgwKBAwCBAgKBAYGAgQEAgoKAggACAYCAgIKAgQGAAQEAgIEAgQCAwQIBAYEAAQCAgICAgIIBgYCBAgCAwQIAgAEAgACBgACBgAEBgQABAQGAAYABAYCBgIIBAoMBgYGAgIGBAYCBAgCBgAGBgACAgIABAcGAgYCAAICAgQGAgICAgYEAhIEFBgEDA4OCgwCBAAIAAICDAIEAwgCBhAKEAgQBAYIBgQEAgQGCgYGAggOBggSDhASChAICAYKAAYCBA4GCAoGCAYGBAgEAAYCDAYKCAYGBQQCAAIABgIDBgQAAgYEBgIAAgIEBAcEAwIGCAAGAgQAAgQCAgAGAgIGAggDAgIABAQDAgACAgIAAgACCAQCBgYGAgQCBAIGAgQEAAIABgQCBgIHBAAGBgIGBgQGAgICBgQCBAQEBgYKBgYGDAQCCAIGBgICAgAIAwYEBgICAgQGBAYGBhQADAIKAAIAAgQGAAIABgICAAIEAgQCAAYCBAICAAIGBAICAAICAAICAwIABAQABgICBQICBQQAAgIGBAACAgIDBAIEBgoMAgICBAACAgACAAICBAQCAgACAwIFAgIAAgMGBAACAwIAAgQABAQCAgMGAgYCAgMCAgACCAIEAgICBAIEBAIEAgQCAAQCAgQABgQCBwIACAIAAgIAAgACAgIABAoEBggKBAoICAQECAICAAQFBAgCBAgCAgwEAAYDAgQEAgYCAgACAAQJAgAEAgUCBgQEBgICAgIEAgICAAIFBgUCAAQAAgAGBQIIBAIEAAICAgIEAwICBQYCBAYGAAIKBgQDBgUGBggEAgIECA4ECggAAgYCAAIDAgcCAgYIBAQGBgICDAQSDBAIBggIBAQGBAQCAwQEAAICAwIGAgMCAgICAgMCBQIDBAIIAAICAgICAAIHBAMCAhECAgkCCwIHAgICAAIAAhkCDQIJAgACGQIAAgACNQIAAgACAAICAwYCAAQGCgIIBAIIAAoGBgoCBAQEBAICCQQJAgACAgQCAgACAgIEAwIEBAACAAIABAQAAgACDQQAAgICAAInAgIxAgsCLQIJAjECQQJPAgIDBAIAAhkCAgACJwIDAgACDQIHAgIDAgcCAgcCAgICAAQDAgUCAAInAgMCAwIPAgMCNwILAgsCBwICCwQLAgkCAgUEAgIFAgMCAgACBQICAAIAAgIDBAAEAwICBAAEAgIFAgkCAwQAAgwABgAIBAQGAwQABgYCBAgEBAUCBgYEAAIEBgMCBQICEQICBAACBAIAAgACAwIABgcEBAYIDAQMCgICAgIHAhMEAwINBAcCBQIVAiMEAwJVAgMCBQICAgACAhUCBQIABAIFAgACAAICEQYGBwYAAgICAggEAAIJBAoGCAIEBg4ECAIEBAQCBgYRAgkEBgQAAgAEAgYCBgYCCAQIAgQEAAQABAMEAgUEAgwGAgYCBwIFAgIEBQICAAICAAIJAgcCBwIDAgcECgYIBgAMBAACAAIAAgAEBQIDAgIIBgICAgMECwQAAgMCAAQHAkcCBwQMCAwEBAYCAAQECAQEBgwQCAwGBAIGBgQEAgUCAgMCAwIFAgJHAgMU"
+        },
+        {
+          "operation": "composition_update",
+          "requests": 490,
+          "errors": 91,
+          "latency_ms_p50": 23478.271,
+          "latency_ms_p90": 29114.367,
+          "latency_ms_p99": 30048.255,
+          "hdr_v2_base64": "HISTEwAAApIAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAANnWAQJNAikCIwJHAlUCjwECmQICEQINAgI5Ag8CGwICCQIJAh0EAgcCBQIFAhECHwIvAi8CAg8CCwINAgcCDwITAgACAAIDAiUCBwIAAgACEwIJAgMCBwInAgACAwIJAgsCBQIlAgsCCQIvAh8CFQIFBAMCGwIHAgMCLQJDAjsCLwIhAgsCBwIDAg0CGQIAAg8CCwJNAg0CAwICFQINAkECAwIPAgACJwILAg8CKwIXAhUCAAIpAmMCNwILAjUCBQJdAhECAh0CIQJJAgACVwIxAicCBwIfAiECGQIHAisCFwIdAg0CDwITAjECAwIFAgIDAgMCAg0EAg8EAgIDAgICAAIAAgIFAgAEAgACAgACAgIEBAAEBAAEAAIAAgACAwIAAgICAAIAAgQAAgACBAkCAwIDAgQAAgAEAwICAgMCAgUCAAIABgACAwQDAgIAAgIDAgICAgAEBAACAgIJAgIAAgkCAwICAAIFBAkCBQICBQIHBAILAgACEQIDAgQAAgMCAAICAgINAgMCCQIAAgACEwICBwQJBAUEAAIFAgMCEQINAgILAgcCCQICAwICAwIFBAcCAAQDBAICAgIDAgsCAgACBgIFAgACAgQFBAMEAgICAgYDAgIDAgACAAIABAIAAgUEAgMGAAQCAAQDBAAEBQIDAgIDAgIDAgIAAgIEBQYCBwQCBwIAAgICBAACBQICAgsCAAIAAgACBQQCAgACBAUCBQICAwIFAgUCAAIFBAIGAAIABAUEAwQCAwIABAAEAgACAgkCAwIXAgsCBQIDBgIEAgIIBAQEBAQABAICAwQCBAQCAAQAAgQEBAAEAgACAgUEAAIDAgIDAgQAAhECFwQHAgACAAQCAA4iBAICDQI="
+        },
+        {
+          "operation": "contribution_commit",
+          "requests": 181,
+          "errors": 79,
+          "latency_ms_p50": 29720.575,
+          "latency_ms_p90": 30064.639,
+          "latency_ms_p99": 30179.327,
+          "hdr_v2_base64": "HISTEwAAAM0AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAIHYAQL9AQJhAq8CAvsCArMBAr8BApcBAqUBApsBAkcCfwKRAQIVAikCYwK5AQKNAQLNAQR/AlECPwJHAgsCSwIJAjECFwJFAkMCRQJJAjcCMQIhAhUCAAICAAIfAgUCAgMCAgUCAAIJAgACCQIHAgUCAg0CBQINAgcCFwIZAhMCFQICAg0CDQIFAg0CHwIVAhECIQIRAgUCMQIHAh0CEQIAAgkCAwIfAgACBBsEBAACAgIAAgIAAgQAAgIFBAICAwYeNiIMCgQAAgICAAI="
+        },
+        {
+          "operation": "contribution_read",
+          "requests": 708,
+          "errors": 55,
+          "latency_ms_p50": 24477.695,
+          "latency_ms_p90": 29327.359,
+          "latency_ms_p99": 30031.871,
+          "hdr_v2_base64": "HISTEwAAAssAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAOXWAQJfAmkCDwJnAlECZwICbwJNAmUCJQIlAgIfAgIAAgUCPQIPAg0CAwI9Al8CCQILAhkEKQIFAhcCAAIPBDsCKQInAgMCJwINAgIJAgsCBQIDAgUCBQIfAg8CDwIVAgACMQIfAgMCMwIhBAsCDwIZAi0CEwIRAgcCKQIJAikCAjMCAi8CGQQLAgsCHQIAAjcCIwIpAiMCAwIFAjUCJwI1AiMCJQI1Ah0CDQIvAgkCIQIdAhECJQIpAi0CBwIjAg8CEwIEFQINAg0CAwIVAgIJAg0CFQIAAg0CBwINBAUCHwIJBAACBQICAwIAAgIAAgUECwQHAgACAgwFBgQCAgMGAAICCAAEAgIABgQAAgQABAIACAYCAgMCAgMEAwQCAgQAAgQGAgMCAAQEAgAEAwIABgAEAwQCBAICBAACBAACAAICAAICAAQCAAIEAAQCBAUGBgIABAACBgQEAgQCBAMCBQICBwQEAgACAAILAgQDAgIEBgICAgACAgMCAgIEBwIDBAIAAgMCAgMCAgMCAwQAAgIAAgIEAAILAgMCAgUCAAICAgUCBQQNAgICAgIHBAQAAgACAgsCAg8CAgIDAgUEAgcCAwICAAQJAgAEAwICAAIGAwICAAICAAIEBAACBAQAAgIHBAIAAgACBAACAgACBgIEAgMEAggAAgACAgYACgIDAgAEBAICBwgFAgICAgACBAwCBgAEAgMCBgICBAACAgAEAAQCBwIECgMEAAQCAgICAgACAAICAAQDBgIAAgAEAgAEAgICBQINAgACAgICAAQEAgQABAACAwIAAgcEAgIDBAACBwgMAAQEBAUEAgICAAICBQICBgQDBAsCAAIFAg8CEQICAgMCAgYCCggECgYIBgIGBAAEBgQCAgAGBgYAAgQCCAIGAwIABAgCAwIAAgAEBgQHAgcCDwQNBAACAwQAAgUCA0ImAAY="
+        },
+        {
+          "operation": "directory_create",
+          "requests": 54,
+          "errors": 18,
+          "latency_ms_p50": 21807.103,
+          "latency_ms_p90": 30015.487,
+          "latency_ms_p99": 30130.175,
+          "hdr_v2_base64": "HISTEwAAAFoAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAIXcAQK9BAK/AgKnAwKzAgLbAQLnAgLdAQJhArMBAlUCDQIlAgICDQIAAgIAAgUCBQI7AjECSwIbAgUCEwIAAhUCBQJnAo8BAqMBAoUCAmMCTQJjGgQAAgIDAg=="
+        },
+        {
+          "operation": "directory_read",
+          "requests": 6188,
+          "errors": 4724,
+          "latency_ms_p50": 11.791,
+          "latency_ms_p90": 17596.415,
+          "latency_ms_p99": 30015.487,
+          "hdr_v2_base64": "HISTEwAAFT0AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAALUOArsBAgsCaQJbAhMCIQIDAjcCBQQRAgMCAgcCHQIRAh8CAAIDAhsCHQIHAhMCTwICBwIFAgMCLwILAgsCBAACJwICEQICCQINBA0CGQITAgsCCwIAAgUEEwIAAgMCGQINBAMCCwIJAhkCAwIABAMCAwIHAhECBQICAwIDAgACBwICAgIJAgIAAgMCBQILAgICEQICBQIAAgsCAgsEAgcCBQICAgkCAgcEBwICGwIHAgICAAQJAgMCBAUCBwIHBAACAAYABAUCBQINAgICAgcCAgsCCQIEAgMCAAQFAgACAgACCwICAwIAAgACBQIABAACAwIAAgACAAQCAgIFAgIAAgQCCQICBwICAgIFAgUCAAQCAwICAAIAAgICBQIHAgkCDQQJAgUEAwQVAgkCAgACBwICAgcCAAICAwIjAgACDwIABAIHAgMCAgMCBAMEBQIFAhMCAAICBwIAAgcCAwQCBAAEAAIFAgAEBAUCBAAGAAIHAgICBAQEAAICAgMCAgQACAIGAAQEAgACAgIAAgACAgACBQQCAAQNAgICAgUCBAACAAICAwICAgMCBAICBgYCCAMGBQQCAgMIAAQCAggEAgILBAMCAgYAAgACBAICBwQABAAEAAICCAYDAgIFAggAAgIAAgIEAAIAAgAEBAYCAgIEAgIAAgICBgIGAwQGBwIEAAYCAgAEBgYCAAQCBQICAgICBAICAAIGBAQCBAkCBAQCAgMCCAQCAgYGBAIEBgAEAgIFAgICCAIDBgIDAgQABAMEAgACAgQGBwIEBAUCAgICBAAEAwQAAgYCBAACAgMKAgQCAwYCAAQAAgICAAQEAgACAAQDAgAEAAIEAgIAAgIAAggAAgQABAIABAQCBQICAwICAgICAggCCAAEAgQCAwICBwQEAAIAAgIGAgIFBAIEAgMEBAMEAgACAgIICgACAgQEBAAEBAICBgIAAgIEAAQCAgQABgIDAgIAAgAEAgQGAwIABAICAAQCBgQEBgYEAAIEBAAEAwQAAgMCBgYAAgICAAIFAgMCBAAGBAUCAAQCAwICBAAIAAIGAgQEBgQEAwIABAICAgIABAACAAQDBgMCAwQEBAIAAgoCAAIABAYEBAACAwIFAgQAAgQABAgKBgIGAgMCAAICAAIEBAMCBgACAAYABAACAgMCAgACBgIEAwIGAgQFBAACAgQCAgYDAgICAgMCAgICBgACAgACBggABAkCAAICAgYCBAICAAICAgIEAgICAgICAgMCAAQEAwQDBAACBAMEAAIEBgACBggABAIAAgACBAACAgYCDAYAAgMCBAQCAAYCAgMCAAIFAgACAAIAAgIGBgQEAgICAgIEBAMGAgQEBAUEAwIAAgQCAgUCAgMGBAAEAgICBQICAgACAgAEAgICBgUCAAICAgAEAgICAAICBAAEBAAEAgYCAAQDAgQFAgMCBAACBAMCBAQCAgILBAIDAgIDAgQEBAACAwgABgIAAgICAgACAgQDAgACBAMCAwICAwIEAgICBgICAAQECQIABAMKBAIDAgICAAIAAgACAwQDAgQAAgQAAgIDAgIJBAUCCwIABAICBwIDAgICAAICAAYAAgIGAgQCAgIFBAUEBgIDBAAEAgICBAgEAAIEAgIECgQCBgIGAAQCAAQEBAAEAgACBAQDBgQCAgIEAgYCBAICAgYGBgIAAggABAQGAgIGAgIABgYFBgACBAQABgYEAAYEBAQGCAYCAgICBAICBAQEBAAGCAYCBAIEBgIEAAYCCAICBAACAAQIAgQABAIEAgIABgIAAgICAgQCBAQEAgYACAQCAgQIAgAGBgYGAAIEBgAECAIAAgYCAgIEBAACAgACBAQCBgICBAICBAICBAAGAgIIBAQEBAQGAgQEBgACAAIABAYGBAIGAAQAAgQEBAICAgAEAAoABAACBAQAAgAKAgICCAQCAgAIAwIABAgCBgAEAAIAAgMCAgQCBgMCBAIEBAICAgICAgIEBgAGBgQABAICBAIAAgQCAgAEBAACBAICBAgEBgMEAgQCAgICBAQAAgICAAICAgYCAwIEBAAMBAQEAgIEAgIEAgQEBAMCAgQGAgICAAIGAgIAAgACAgIGAgACAwIECAYEAAICAAQCBAIGAgQEBAMCBAAEAgIEBgICAgICBAYEAgIGBAICAgYGBAIAAgICAgQCAgMEAwICAgIEAAQAAgQEBgAEAwICBAAEBQIEBAIGAAgEAgYDBAICBAIEAgACAAQECAQEAgIEBAACBAQEAAIEAgQABAICAgICAAQCBAYABgAEBAAGAAgCBAACBAIEBAYCBAQDAgMCAgQCAwYCBwgAAgQFBAQCBQQABgYABAIEBAMCAgQEAgAEBAICAwIEBAIDBAIDAgIAAgMEBAIEAgQCAAQEAgQEAgACBAICAAYEAgIJAggCAAQGAgQEAgIABAACAAIAAgIEAgQDAgIGCAAKAgIJAgYEAAIGAAYGBAYCAAIEAgMCAAQEAgIAAgIAAgACAAQEAgICBgIEBAACAgQEBAQAAgQCAwQIBAQDAgYAAgQEAgAIAAICAgQGBgACBAIGAAICAwQCAAIEAAIABgAGAgICAAIEAgIAAgACAgICBgIDAgAEAAIAAgMCCwIDAgQCBggGAAIDBAICBAYDAgIABgQABgUCBQQAAgIEAAQFAgACAgIDBAIAAgAEBQQDAgIGAgACAgIEAAgHAgIDAgcEAgIABAIEBAIEBgICBAACAAIAAgAKAgQAAgACAAYAAgYCBQICAwgDAgQAAgACAgICAgAECgQEBQIEAgIAAgACCAAEBAACAwIDAgIAAgICAgIGAgIAAgIEBAACAgACAgQAAgICBgIFBAIAAgICAAQEBgYGAgIABgQCBAQAAgQCAgQCAgQABAICCAYEBAYABgQCBAIEAgMEBgACAgIEAAICAAICAgAEAgQDBAIEBAIAAgYEAAQCBAYDAgAEAgQAAgICAAIABAAEAgIEBAIGBAQAAgAEAgICAAYCBAIEAgQEAgUCAgIEBAYEAgAIAwQGAwIEAAIGBAQCAgQABAAEAgQAAgQEBg4GBAAIAgICAgQEAgIEAgQGAAICBAQACAIEBgIECAQCAgIDBgIEAgIDAgIEAwQGBgIECAQEBAQEBQIABAQEAgUIAgQCAgAIAwQEBAICAgICCAgCAgQIAgACAAIABgIEAwICAAYGAgUEAgYCAAYCDAYCAgYABAQIBAIABAIABAAEAgUCBgYGAgAMAgICBAIAAgIABgIGAgIEAAIEAgQDBAYCAAYCAgACAgIAAgIEAgIABAICCAICAggCAgICBAAGBgQCBAQCBAMCBgACAwQCAAIABAYAAgYAAgYEAAIEAgQCAgIABgAEAAIEAAQCAAICBAUEBAIGAAICAAQCAgACBgQEBAIEBAACAAQEBQYABAIEAgIGCgICAwICAgIJBgICAAICBAUCBAIEAAgCBQIABAIFAgACAwQDAgQCBQYGBAQDBgIEBAMCAgICBAQHAgIABgMEAAIABAICAgICAAgEBAMEAgYCBAIABAIEBgACBAQCAgAEAgACCQIIAAQCAgAGAAIECgcEBAIABAQCBgIABAAEAgIEAAIGAwIIAgIDBAIDAgIAAgACAAIAAgQCBwIJBAICBAIEBAIAAgUCAAICAAICBAIABAQAAgICAAQCAgMCBwIEAAQAAgACAAICAgAEAAICAAICAAQABAMEAgAECAcCBQQDAgMEAggAAgACBgAIAAIABgQCAgIEAgAEAAIEAAIGAgAEAgMEAAIABAMEAgACAAYDBAICAgICAgMEAgQDAgcCAAIDAgACBAQCAgACAgUCAAIEAgIEAAQGBAACAAIAAgICAAIAAgIEAAICAAIFAgACAwICAgYEAgICAwIAAgAEAwICBgICAAICAgIDAgAEAAIEAAIFAgIAAgACAwIDAgQCAgICAgIGBwICAgcCBgICAgQCAwICBgQCAgACAgACBQIAAgMEAwQCAwIEAAIEAAICAwQCAgIDAgIABAIAAhEEAAICAAQCAwYCAgUCAgMEAgQCAgICAwIGAAIICAIEAgICAAQCAAQDAgIGAgQCAgACAgIABgMCAgACAgIGAgQCBgYCAwYCAAIABAIDBAQCAAgEAgIDAgAGAwIEAAYCAgUGBgMCAgAEAgACBAIAAgAEAgYCAAIECAIDAgIEAAICAAICAgACBAQAAgAEBAICAAIEAgACAAIAAgACAAQABgICAAICAwIIAAIAAgIABAAEAgQGAgAEAAQCAgAEAgQDAgQCAwIAAgQEBwQEAAIAAgAEBQIEAgYDBAICAAIEAAICBwQCAwIAAgIABAICAgICAwIAAgICAgICBAICAAIDBgQABAACAAQAAgIABAIJBAcCAAIDAgICAgACAgINAgMGAAIDAgMCAgACAwICAAQDAgsCBQIABAIDBgQCAgUEAgMGAAQGBQQCCAUCAAIFBAQAAgIEAgIAAgACAAQCAgAEAAIHAgIEBQIDAgACAgMCAgMCAgACAgcEDQIFAgMCBwIABAICDQICAwICAgIDAgINAgACAAIFAgACBAACAAIDAgIDAg0CAgACAgUCAAIHAgIAAgMCBwIAAgUCAAQAAgILAgIHAgIDBAYLAgQCAAIEAwILAgICAAIHAgACAwIAAgQAAg0CAgAEAAIFAg8EAAQDAgACCQQABAAEAwQAAgIDAgICAgICAwQCFwIDBAIFAgINAgQCAgIAAgIAAgkEAAIJAgUEBQIPAgIDBAcCAgIHAgACAwIFAgINAgMCAgUCAwIFAgQHAgcCAwINAgAEFwIEAhECBQILAgIRAggABAICAgICAgMCDwQPAgIFAgINAgIAAg0CEQIFAhsCAwIPAgACCQICAwIAAgACCQIJAg8EAwICCQINAgMCFQICCQIDAgIJBAUCBwIDAgILAgUCAAICBQIFAgMEAAIHAgMEBQICBAsCAwIFAgICAgACAwICCwIFAgACAgAEAgQAAgUEAAIABAIFBA8CAAICAgIABAIDAgUCBQIDAgIFAgACAAIAAgACAAIHBAMCAgAECQICAwIDAgACAgIDAgIABAMEAwIEAAQJAgACBQIAAgACAAIFAhECBQIAAgACBQICAAITAg8CAAIAAgICFQICAwIDAgMCAgACAwICBQQCAgUCBQIAAgUCCQIFAhMCAgMCBQIAAgMCBwIAAgICAAICAhUCAAIfAgsCAwIAAgIAAhsEGwIAAgACAwIVAgAEAg8CBQIDAgsCDwICBAMCCQIpAgACAgMCEQIJAgsCAgcCEwICAgACAwIDAgUEDQINAg8CKQIHAgMEAAIJAgUCGQIDAhMCAwIAAgcCCwIJAgsCCwIfAgACGQIHAgICDQICBQIPAg8CBwIrAhcCCQIDBgIHBBkCBQIHAg0CAgACBQIFAgIXAgsCDwICAAQAAikCDQITAgACAgsCPwILAgIJAgcCAwICAgQJAgUEAwICBwIXAgIVAhcEBwIDAgUCBQILAgIEAAIXAh0CAwICDQIFAgMEJQIJBAcCFQIjAgMCDwIRAgACAAIDAgICBQITAgkCAgUCDQILAgACAi8CHQIXAi0CFwILAgIZAgIAAgACAgIHAhkCFQIDAg0CAAQCFQINAhsCCQINAgIPAgUCAwIJAhMCBQItAgUCEwIJAiMCUwInAhcCCwIDAgcCAicCAjMCAAIhAgILAgMCGwIHAi8CAwJXAmcCHwSTAQIrAgsCHQIdAgUCAAIVBFkCWQINAg8CCQIvAtEBAg8CPwITAq0BAg8CIwJpAi8CvwECowECjQECMQKrAwLHRAKTAQINAgsCBwIAAsMCAukCAlECAjECAlMCEQILAgkCIQItAicCbwIXAgACEQItAgUCBQIJAgcCDQIVAgACAgACAAICDQQAAgACAgACAAIDAgICAAIAAgACAwICAwIAAgICAgACAgkCAAICAAIABAMCAAIHAgIAAgMCAAQJAhMCAAINAgMCAhUCAgACJQIRAg0CDQI7AhUCAAIHBAICAgsCAwIAAgACAgIAAgUEAAQDAgUCAAIHAgIAAhMCBgQGBAAEBggEBgYMAgQCAAICBAAGBAQABgYEBQIGCAIEAgIIAgMEAwICCAICAAQAAgYMAA4IBgQEDAYGBAgIDAQEAgwIAggEBgQIBAQCAgQEBAwEBAQACAQCDAQEAgIGBAIAAgQEAgIGAgYEAAYHCAAEAAYGDAQMBgQABAQGAwIEAwIFAgUEAgICAwIDAgMGAgQDAgIFBgQAAgYCBAMEAgYCCgYKBgQAAgQEAAQCBAACAwIFBAQAAgMCAgACAAICCAACAgMEAgIEAgIEBAACAgIAAgAEBAgIBAgKCAIKAgQECgQIAwYCAAQCAgQGCAwICggIBAQCBgQIBQICAwIDAgIbAgMCAwQCBAYAAgICAAICAAQDBAIAAgMCBAcCAAIAAgACAwQIBgYCBgICBAkEAwIDAgAGAgMCAAIXBAkCAgMCAwIEAgQFAgIHAgMCAAYGAAQbAgQABgMCBwIDBAQCCgIDBAUCBAICBAQCAAYFBAACBAICCwIDAgMCAwQCFQIXAgIRAgUCAAICBAQAAgsEAAICDwQDAgACAAILAgMCAgIGAgIFAgcEBQIEBgIEAgQCAgQCBAgGBgIAAgACAAIDAgACAgYGAAwEBAIEAAQDAgQEAAYCAgACAAQDAgcEAAQEBggKBgYABgIEAggAEgoGCBQICAIKBA4UGgQKDAoKDAoEBAQGAggKDAQGBAACAAYEBgIEAAYGBAoMCAgQBgoIBBEEAgMCBQICAgIABAIEAAIEBAIGAgwEAgoEBg4IAAICBgICAgIEBgQEAgICBQICAAoGBgICBgACDwIEAAQCAgICBwQCAgACAgQCAgQCChIKBAIDAgICBAAEBAQCBhIEAgACAwgABgQECgQCBAICAAIHAgQDAgIDAgIJAgMCSwIHAgcCAgIVAgMCAh0CAgUCBQIZAhkCCQIAAgMCAgICAgACAAICGQJZAgcCBAQGBAIGBQIGAgIGBAgFAgQACAICAgIHAgIAAgACAgACAgQCAwQCCQYFAgMEAgMCAgQCBwICAgQCBgYAAgAEAAYCBAAEAh0CEwQCAgACBQQEAgICBAQDAhUCBQIAAgUCAwIJAgACBQIAAhcCAg8CAwICGQJLAgIAAisCMQIbBAMCCQIAAgIEBBMCAwIDBgACBAQEAgQEAgIAAgQCAAQAAgAGAwQAAgIC8AFKEAAGAgI="
+        },
+        {
+          "operation": "directory_update",
+          "requests": 86,
+          "errors": 0,
+          "latency_ms_p50": 9674.751,
+          "latency_ms_p90": 13197.311,
+          "latency_ms_p99": 15130.623,
+          "hdr_v2_base64": "HISTEwAAAJ4AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAK3WAQLPBAKNAQIfAk8CEwITBAACBwIDAg0CHQIvAgIrAgcCBwIHAgUCRwIzAicCAAICAwQNAgsCAAIJAgUCBQIRAgIPBAMCJQIHAhcCCQI/AgILAhcCJwICEQInAgsCAAIXAgUCCwIxAksCIQIFAjECDQInBB8CGwIbAgIJAhECTwIxAgIFBB0CLwICAwIJAgACWQIvAnECWwIFAl0C"
+        },
+        {
+          "operation": "ehr_create",
+          "requests": 87,
+          "errors": 0,
+          "latency_ms_p50": 4583.423,
+          "latency_ms_p90": 7544.831,
+          "latency_ms_p99": 9289.727,
+          "hdr_v2_base64": "HISTEwAAAKAAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJnMAQIxAgMCCwIRAgsCFQIHAhMCCQIVAgACGQIHAjsCBA8CHwIAAgIXAhcCBQIAAgMCKwIDAh0CAgIdBAAEEQIRBAUCBQQFAjECAgACAi8CHQIFAiUCQwIHAiMCDQIAAlcCMQJHAh0CAhUCEwIjAjcCHwIXAg8CEQICJQJ1AkECZQKHAQIFAgkCJwJbAjMCVwJVAqkBAmMCFQIRAncCCwI="
+        },
+        {
+          "operation": "ehr_read",
+          "requests": 631,
+          "errors": 0,
+          "latency_ms_p50": 18726.911,
+          "latency_ms_p90": 23724.031,
+          "latency_ms_p99": 25673.727,
+          "hdr_v2_base64": "HISTEwAAAtIAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAOfLAQLbAQJvAh8CdwJBAg0CEQIAAgACAjkCAwIPAgUCRQINAgMCEwIbAgMCOQICEwJHAj0CJQIFAhkCJQIbAicCOQIbAhkCLQIZAgMCDwIRAhsCKQInAiMCRwIFAhkCBwIDAl0CEQJRAgACPwIdAgIAAgsCYwICTQQfAjcCdwJbAicCLwI1AgIfAiUCBQI5AgsCFQIlAjsCEQIbAikCMQI1AiMCIwI7AgMCHwIrAjsCKQInAjECJwIAAikCJwIrAi0CLQINAhUCKwIPAiUCMwIRAhECFQIVAhECAgUCAwQHBAACAwIRAgAEAAYHAgIABAIFAgkCAwQFAgACAAYCDwIAAgkCBwIDAgQABAIHAgIAAgUEBAIAAgIKAgIDAgAEAgQEBwIABAIFBgYEAgIAAgIABAIABAICBAMCAAICAAICBwIGAgICBwIAAgMCBQICBwICAwINAgMCAAIEBwIDAgMCAgIABAQAAgACAgMEAAIDAgYAAgIEAAQABAAEAggGAgIEBAICBAsEAgIFAgYDAgQCAwQJAgACBAMCBQQFBAIAAgMEBAICAgACAwICAgAEBAICAgIAAgIHAgACAgUCCQIPAgMCAgIEAwICCQICAgACBwICAAQABAsCAAINAgACEQICCQIAAgIABAsEAwICAAICAgMEAAQGAAIIBAMGAgIGAwQEAAQCAwQABAIAAgIDAgQDBgQCAgACAwQGAgcCAgcEBAQCBgMGBAQCCgYAAgACBgIKAAgCAgQGBAYABAIABgUEAgkEAgUCAgACBAIDAg8CAgUGAgUCAAIEAAQAAgICAwIABAACAAYEAgICCAMGAgICBAYOBggCBAQCBgYAAgIEAAICAgYFAggCAAQCAwILAgMCAgACAwQHAgACAAQABAUCFwQAAgACBgMECAACAgACBAYEBgICBAUCEQICDQITAg0CAAIDAgUCBQIDAgUCBQIC"
+        },
+        {
+          "operation": "ehr_status_read",
+          "requests": 174,
+          "errors": 19,
+          "latency_ms_p50": 17170.431,
+          "latency_ms_p90": 30015.487,
+          "latency_ms_p99": 30064.639,
+          "hdr_v2_base64": "HISTEwAAAR0AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJHXAQLZAgLzAQLjAwKrAQKfAQIvAisCkQECmQECNQIRAiUCCQIXAgACAAIJAgUCBwITAiECAwQNAhcCAgUCBAACLwIvAj0CBQINAgsCFwIFAikCBQQJAhkCGwQnAi8CHQQ3BAcCGwIJAhUCIwIDAgIjAgsCIQIFAhECAAITAhMCEwILAhUCAwIfAgcCAgMCEQIDAisCJQIDBAACAwIJAgIHAgIDAgcEBQIEFQIDAgUCBAAEBQIAAgkCAAILAg8CCwIHAgsEAwICCwIPAgIHAiMCAwIAAg8CAAIVAhsCAAIRAgkCUQIHAgIHBA8CAgkCJQIvAgsELQJJAjkCEQIAAjsCJQIzAo8BAnsCXQKFAQIXAgMCEQICFRoKAAIHAg=="
+        },
+        {
+          "operation": "ehr_status_update",
+          "requests": 163,
+          "errors": 113,
+          "latency_ms_p50": 1.367,
+          "latency_ms_p90": 12615.679,
+          "latency_ms_p99": 26689.535,
+          "hdr_v2_base64": "HISTEwAAAUUAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAK0BAgUCDQIFBAUCJwQCDQIjBAsCBQIZAhMCAiEEAgkCBQIAAhkCAgcCAgcCBwIDAgMCIwIDAgkCCwIFAlkCDwIhAgIrAhcCAlMCGQIZAgACHwIxAgUCIQKBAQIvAgcCAwQDAhUCAAILAgMCJwJvAi8CFwIpAnECRwIdAm8CXQICIQI/Ai8CWwIDAo0CAicCNwIfAg0CrQECBQJNAlcC3QECRQKHAQIRAhcCAh0CAAJLAg0CswECmwECbQIHArUBAj8CAAIpAgcCIwKrAQKnAgLjBQLTCAL3BwKnJALBBAL1bgKfBAKlAwIDAjkCHQIPAjMECwIJAhMCAikCEQIdAgACTwInAgACdQLhAQIHAnUCTQINAikCiwECAgJtAgUCPQI1AkECDwIjAg8CAg0CHwLLAgK1AgLZAQLBAgJPAsUFAgIrAgI="
+        },
+        {
+          "operation": "stored_query_execute",
+          "requests": 1307,
+          "errors": 0,
+          "latency_ms_p50": 14843.903,
+          "latency_ms_p90": 18726.911,
+          "latency_ms_p99": 20168.703,
+          "hdr_v2_base64": "HISTEwAAA60AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJPVAQIvAg0CIQIlAjECIQIhAi0CKwInAiMCHwItAhsCNwIVAi8CIQIfAicCKwIzAh0CGwI1Ah8CKQIlAikCJwIpAisCIQIjAhMCEQILAhcCHQILAg0CDQILAhUCDwITAg8CDQIRAgACFQITAgkCDwITAhECEQINAg0CEwIPAhUCDwIFAgACCwIRAhECCQIZBAkCAAIDAgUEAwICBAIJAgACAAIJAgIAAgsCAAIEAgIAAgQEBgIKBAIEBAoIBggCAgQCAgQCBAQABgACAgQCBgAGBgAGAgIAAgIABAICAgQCBgQEBAQEAgQKBgYKBgQIDAYEBAgABAoEAgAECgYEBgIEAgoABAgCAgQCAggEBAgEAgAEAAgACAAEBAYCAAYCBAACCgQCAggGBAoADAIEBgQCBAIEAAQACgAEAgAEBgICAgIFBAIEAgIAAgIJBAICAAYDCAIGAgIABgQCAAQGCgQAAgQCAgACAgQCCQICAgYABAIEAAIDBgACBAICAAYEAgACBAQCAgMCBAQCAAQIAAIDBgYEBAwEBgICBAIGBgQCAgIDBAQIAgACCgICCAQACAACBAAEBgQGAwgCAgAEAwICAgAECwIEAAICAAYFAgIDBAACBAIAAgMCAAYCBAMEAAIAAgIAAgQGBAIGAAIEBgACBAUCAgIAAgICAAIAAgUGBQIDBAILAgMCAAIHAgMCBAIAAgICAAICAAICAgACAgICAgICBwIDAgsEAgIEAAIHAgIABAUCAAICAAQCBwQABgICAgoEAgIAAgACAAICAAQFAgAEAwICAwIDAgcCAgACBQICAwIDAgcCAgAEAgMCAwIAAgIHBAkCBAACAgQDBAICAgACAwIAAgACAAYCAwICAgYCAwYACAICAgMCBAIEBAIEAwICAAIEAgQEBAQIAAgEAAYCAgQCBAMCAAQEBAICBgYCBAQABAACAwgCBAIAAgACAAIAAgQAAgIEBAgCCgYEAgQEBAYCCg4GCAoKBggECAgQBgoMBhAQCAYEBggICgQICAoGBAQECgQGBgQIBAgKDgQMCAgMCgoGBhIEBgMCAgICAgIEAgIAAgAEAgICAAQCAgYGAgQEAgQEBAQCAAYEBgQABAQCBAYABgQEBgYCBgACAgQAAgYIBgACBgQEAgICAgAEAgIEAgIFBgAEBQIEAAgEBAYMBAYMAAQGBgYEAgAEAAICAgMCAAIABgQAAgIACAACAwgCAgACBQIAAgACAgACBgIJAgQABAUC"
+        },
+        {
+          "operation": "tags_put",
+          "requests": 218,
+          "errors": 33,
+          "latency_ms_p50": 21708.799,
+          "latency_ms_p90": 30015.487,
+          "latency_ms_p99": 30048.255,
+          "hdr_v2_base64": "HISTEwAAAUkAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAKXXAQKLAgKxAQKZAQK3AwJVApUBAlECewKHAQJ1AlcClQECbwKJAQJDAoUBAlECqQECLwIdAh0CAwIHAh8CAAIJAgsCAwIRAgIHAg0CDQIFAgMCAgUCAwIbAgkCCQICAAIRAgUCJwIdAgQPAg8CCQIHBAICDwIAAgIFAhkCGQIHAgITAgIAAgUEBQIDAgACDQQHAi0CCwIbAgILAhkCBQIjAgkCAgACCwIEAwIAAgACAwIHAgACAgUCAAIHAhEEAAIJAhECAgcCAgACDQIDAgIDAgUEAAIAAgMCFQIDAg0EGQITAhEEDQICAwQDAgIGAwIDAgACAwIHAgACAwICAwICAAINAgIRAgcCAgIRAgMCCQQHAgIDAgACDQQCAAIHAhkEGwIAAhECAhUCDQQxAg8CmwECHQITAiMCGQIHAk8CAAINAhkoEgYC"
+        },
+        {
+          "operation": "tags_read",
+          "requests": 218,
+          "errors": 0,
+          "latency_ms_p50": 4939.775,
+          "latency_ms_p90": 20512.767,
+          "latency_ms_p99": 25591.807,
+          "hdr_v2_base64": "HISTEwAAAYgAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAM3LAQINAhcCAAJBAhMCCwIAAgIXAgMCBQICBQINAgIHAgMCAgACBAACAAIAAgACAAIFBBECBwITAgACCQIAAgcCAwIDAgITAgUEBwILAgkCAgMCBQIHAg0CBwICBQQTAgMCAAQDAgsCCQIAAgcCAwICAAIDAgsCAgsCAgACAgIHAgIHAgkCAAICAAIFBAIDAgcEAwICAgIHAgACBwIAAgcEAAINAgUCCQICDwIDAhUCDQIlAgsCBQIDAhECGwIlAhkCAgIjBBUCAgACGQIhAjsCAwIRAgACAgMCAAITAisCFwQdAgcCBQIpAhECCwIVAgMCCwIlAhsCGwI5AgkCWwIfAmECCwIlAhcCGwIDAiMCWwITAm8CIwICHwKjAQICAwIfAhkCEQITAhMCAAIfAgsCNwICiQECRwKXAwLJAwLtAQJ7AhsCGwJhAjkCuwEEfQInAgcCAwIvAjcCIQIVAkcCJwIXAjMEBQILAgUCLwI5AhkCLQIFAgkCNwI5AisCAAJDAhUCAikC"
+        },
+        {
+          "operation": "template_get",
+          "requests": 545,
+          "errors": 0,
+          "latency_ms_p50": 4607.999,
+          "latency_ms_p90": 7516.159,
+          "latency_ms_p99": 9125.887,
+          "hdr_v2_base64": "HISTEwAAAp4AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAMXKAQJtAiUCCwIXAgcCBQICCQICBwQAAgUCAgACDQICBwIABAIDAgMEAwIEAgQFBgQGBwICAg0CBAMCBAACAAIAAgACBAAEAgACAwIDBAACBgMCAAYCAAIDBAICBAIDAgUCBAMCAAIAAgIEAgQDBAYEAwQDAgIABgkCAwIABAUEBAMCAAIGDwIAAgQCAgICAgIEBwQCAgICBwQLBAICAgYCAwgAAggDAgcCAgYEAwYAAgACBwQCAAQABgMCBAICAgYDBgACAgQABAIDAgUCBAACBgACAgIACAgCBgIEAgMEBAYDBAQCAgMCAAIGAgIABAIAAgAEAgIFAgMCAwIABgACAAQABAIABAICBgQCAgQEBQICBAACAgQAAgAEBQIDAgMCBwYAAgQAAgUCAwIFBAIDAgACBQIPAgMCGQICAAIAAgkCAwIRAgMCAgQHAgIHAgYABAIAAgIFAgMCAgACCwIAAgICAwIDAgILAgIHBAMCCwIHAgYAAgMCCQIDAgMCCwQCEQQRAgUEBwYDAgACAAICAAQPAgACBAQJAgcCAgsCDQINAgUCBwQLAgUCBAcCCQQABAACAAQFBAIDAgAEAgACAgcEAAIAAgUCBA0CAwQHAgICCQIAAgACAwICCQICAwIPAgsCAgcCAgACEQIAAgcCBQICBA8CDwIJAhUCAAQvAgsCDQIAAgMCIwINBAUCAhECCQQCFwIdBAIHAiECAwICDQIAAgUEBwIAAgMCAAICAAIDAgcEBQIDAgsCAwIFAgsCEQQAAgIpAg8EEQI5AgUEAAIVAgMCAgITAgACHQIXAgMCPQIdAgACGwIAAgACBwILAgMCAwIFAgUCAgkCAgIAAg0CAgIJAgIDAhECAAINAgUCAicCCQIJAgUCBwI="
+        },
+        {
+          "operation": "template_list",
+          "requests": 545,
+          "errors": 0,
+          "latency_ms_p50": 4571.135,
+          "latency_ms_p90": 7462.911,
+          "latency_ms_p99": 9150.463,
+          "hdr_v2_base64": "HISTEwAAAqwAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAKnKAQJxAikCEQIDAgkCEwINAgMCBwIEBwIAAgICAgACCwICBQIJAgcGAgoCBAICAwICBQQACAICAwIAAgACAwIAAgICBAAEAAICBAQCAAICAwQAAgAEAgIGBAQHAgcCBAIABAACAgACAgMCBwQCAAIHAgMCBAIABAIGBQIDBAICAgQFAgUCAgAEAwYAAgICAAQCAgAEBAkCBAICAgQAAgIFAgMCAgUCAgIAAgIEAAICAgICBgIAAgAEAgICAAICAAIHAgMCAAICAAIDAgIABgICAgAGAgQABAACAgICAgIAAgICBAMEAwIECAYCCAICBAQAAgUIAgYCBAACBAIEAgACAgIDBgQCAwICBAMCAgQEAAQDAgMCAgMGAwICBgIGBAACAwICAgMCAwIFAgAGAgIHBAkCBwIDAgIFAgkCAwIFAgsCCQIDAgACBwICAhUCBQQAAgIHAgICAgMCAgIDAgACBQICAAYAAgMCAwIEBQIAAgcCBQIABAkCAgACBQIFAgMCAAIAAgMCHwIEBwIGCwQAAhcCCQIDAgMCBQQAAgACBQIDAgIDAgAEAgACBgACCwINAhkEBwICBQIAAgMEAAILBAMCAwIAAgACAgAEAgMCBQICAgYFBAACBwIDAgIDAgIFAgIFAgsCBQICAwQAAgACAgUCCwIJAgACAwIHAgACAhMECwIDAgsCAh8CAAICAAIrAgkCAwIXAgsCAwYhAhsCAAIFAgIHAgMCBwILAhUCDQIAAhECAgUCAwICAAIZAgIABAUEAAQFAgICHwICAAQNAgcCCwITAgIDBAACAwIfAgUCLQIPAiMCAhUCBwICIwICAAIhAhUCAwIFAjECCQIFAi0CBwIAAg8CAgQHBA0CAgMCAAIHAgMCAAQEAwINAhUCAwIZAgMCEwQJBA=="
+        },
+        {
+          "operation": "ward_query",
+          "requests": 1308,
+          "errors": 282,
+          "latency_ms_p50": 4607.999,
+          "latency_ms_p90": 7323.647,
+          "latency_ms_p99": 9601.023,
+          "hdr_v2_base64": "HISTEwAABW4AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAMEUAnMCNQLTCgIPAoEBAkECYwKFAgIFAgUCbQKvAQIbAosBAkMCWwITAikCJQIXAqEBAmMCAhECCQIDAgMCCwIzAp8BApUBAikCFwIHAgACTQICBwIzAgMCAAILAgUCGwIPBC8CDQIjAgUCPQIFAqsBAg8CLwIVAi0CDwIJAjECCQIbAh0CCQIPAhUCFQJFAjMCQQIZBBUEeQIVAicCIwITAgUCBQIDAicCGwIrAkUCAAQ1BC8CLQJDAg0CAwIXAgMCDQICCwIdAiUCBQIPAgkCDQICAwIDAhMCZQIdAgMCAhcEEQIFAjsCZQJdAkECQQIDAjECJQICFwI1Ai8CUwIDAgMCIQIfAjECDQICHwIJAhcCFwIrAhMCFwIRAk0CFQIHAgUCEwIHAgsCQQIDAgUCDwI7ArsBAgIFAhMCPQIfAgINAgACBwICFwICTQIPAiUCBQQCKQIPAg0CNQICDwIbAgACBQJzAhMCBwIzAgcCIwIDAgJ7Ag8CDQIxAhsCDwIRAkMCGQIVBFECCwIpAg8CDwI3AkUCDwJdAhMCPwI5Am8CNQIjAlkCEQJpAg0CAAIAAh8CEQIfAhkCAAIJAj0CMQIxAjMCMwIlAgUCjwECAh0CXwLFAQI7AjkCCwInAhsC1QECGQJJAokBBBMCpwECUQIJAi0CHQIRAgkCCwJLAgkCTwIbAr8BAhECiQICWwIfAqcBAvsDAm8COwLjAQKpAQJ7AjcCuQkC7UECGQILAgkCAAIbAhMCCQICAAIAAgICBQICAgMCAwIEAgMCBAQCBAAEBwICAgICBgQEAgAIAwQGAAgEAgMGBgIDBAYGBgIKBAIACAQAAgQCBgoKDAQKBAQGAgwMBAoKDgQIBgYGAgQCAggKAggEAggGAgQGAgQICgIIAggGCgwICggKBAQIDgYCAAYECAYKBgYGBgYGBgYGBgQKBgIMAAYICgoCAgQCCgQECAQEAggEAgQGBAwIBAQEBgQGCgACBAoGAggEAgwABAQECAgCBgAEEAYEBgIIBAYAAgQGAgYEAgIABgQCBAACBAQCAgIABgQEBAICCAQEAAIEBAYIAwICBAgGAgACBAIIAgICAAYEAAIGAgQCAgIAAgYGBgUKAgUEAgQEBgACAgAGBQQABAYABAIEAAIEBQIAAgIABAIHAgIAAgACAg0EBQICAgUECQQCBQICAgIAAgICAgcCAAIFAgIFAgMCAgIDAgICAAIDAgQAAgACAAICAgUCAwICAgACAwIEBAAGCQIGBgAEAwICAgICBAAEAgIEBAACAwIHAgIAAgACAAIABBMCAgUCAwIDAgACAgMGAwQNAgMCAgMCCwIDAgQEAAQAAgUCAgIEAAIDBAACAgMCBgcCAAQAAgACBAUCAAICAwIABAkEAgACAwIDAgUCAAQFAgUCAwQCAgACAAQFAgACAwQCAAIFAgUCBQYFBgMEAAIAAgYFAgACAAIABAMCAgcCAgQDAgIABgMCAAIAAgcCBwQAAgMCAgACAgACAgICAAIABAQEBQICCQICEwIFAgcCBwIDAgACAgkCAwILAgIHAgUCIwICCwIDAgkCBQIAAgMCBQINAhcCAgACAgIFAgILAiMCAgACCQIFAgMCAAIDAgUCAwICAAIAAgIFAgkEAgIAAgMCAwIFAhcCDwIFAgACAgACCQICBwQABAIAAgACBwICBwIDAgsCCwIDBAUCAhECCQIDAgIFAhECKQIAAgMCAAIAAgcCAAIVAgIDAgACBAMCAAILAgICBQIDAgIFAgACAgICAgsCAAICDQIDAgIAAgACAAIEBQQCAwQEAwICBwIbBA0CCwIHAhUCAAIAAhsCAwIJBg8GIQI="
+        }
+      ],
+      "stable": false,
+      "breaches": [
+        "adhoc_query p99 8912.9ms > budget 1000ms",
+        "composition_commit p99 30048.3ms > budget 1000ms",
+        "composition_read p99 28098.6ms > budget 1000ms",
+        "composition_read_current p99 26935.3ms > budget 1000ms",
+        "composition_revision_history p99 28852.2ms > budget 1000ms",
+        "composition_update p99 30048.3ms > budget 1000ms",
+        "contribution_commit p99 30179.3ms > budget 1000ms",
+        "contribution_read p99 30031.9ms > budget 1000ms",
+        "directory_create p99 30130.2ms > budget 1000ms",
+        "directory_read p99 30015.5ms > budget 1000ms",
+        "directory_update p99 15130.6ms > budget 1000ms",
+        "ehr_create p99 9289.7ms > budget 1000ms",
+        "ehr_read p99 25673.7ms > budget 1000ms",
+        "ehr_status_read p99 30064.6ms > budget 1000ms",
+        "ehr_status_update p99 26689.5ms > budget 1000ms",
+        "stored_query_execute p99 20168.7ms > budget 1000ms",
+        "tags_put p99 30048.3ms > budget 1000ms",
+        "tags_read p99 25591.8ms > budget 1000ms",
+        "template_get p99 9125.9ms > budget 1000ms",
+        "template_list p99 9150.5ms > budget 1000ms",
+        "ward_query p99 9601.0ms > budget 1000ms",
+        "error rate 0.6122 > tolerance 0.0010"
+      ],
+      "generator_bound": false,
+      "resources": {
+        "sample_interval_s": 10,
+        "containers": [
+          {
+            "role": "sut",
+            "name": "ehrbase-rs-ehrbase-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 87.2704210122454,
+                "rss_bytes": 674672640,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 6908355339,
+                "net_tx_bytes": 8665064720
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 88.1115883782852,
+                "rss_bytes": 678572032,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 6961562994,
+                "net_tx_bytes": 8676056011
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 95.91100332451448,
+                "rss_bytes": 679444480,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 7020428239,
+                "net_tx_bytes": 8686775142
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 97.38622179605333,
+                "rss_bytes": 680419328,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 7071913283,
+                "net_tx_bytes": 8699476909
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 99.09299057733732,
+                "rss_bytes": 680996864,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 7107232084,
+                "net_tx_bytes": 8710717176
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 111.54379486736137,
+                "rss_bytes": 681168896,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 7158963081,
+                "net_tx_bytes": 8719730488
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 108.35072553932552,
+                "rss_bytes": 685916160,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 7230323077,
+                "net_tx_bytes": 8732111357
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 125.46369106463966,
+                "rss_bytes": 685993984,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 7274825148,
+                "net_tx_bytes": 8739308508
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 106.49439673819184,
+                "rss_bytes": 687996928,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 7346224521,
+                "net_tx_bytes": 8750790765
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 100.9086284674548,
+                "rss_bytes": 687984640,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 7409264047,
+                "net_tx_bytes": 8765065624
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 104.41302382536009,
+                "rss_bytes": 687632384,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 7452033258,
+                "net_tx_bytes": 8778175859
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 121.34326567366136,
+                "rss_bytes": 688586752,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 7526592312,
+                "net_tx_bytes": 8790084303
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 111.4687776060317,
+                "rss_bytes": 689397760,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 7587829310,
+                "net_tx_bytes": 8804298605
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 104.79801133613445,
+                "rss_bytes": 689344512,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 7651820814,
+                "net_tx_bytes": 8820060126
+              },
+              {
+                "offset_s": 150,
+                "phase": "drain",
+                "cpu_pct": 114.61753375221278,
+                "rss_bytes": 689778688,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 7694573578,
+                "net_tx_bytes": 8836964299
+              }
+            ]
+          },
+          {
+            "role": "db",
+            "name": "ehrbase-rs-ehrbase-postgres-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 498.1985430420072,
+                "rss_bytes": 2840911872,
+                "blk_read_bytes": 9192480768,
+                "blk_write_bytes": 49899974656,
+                "net_rx_bytes": 7826061218,
+                "net_tx_bytes": 3460482835
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 536.6928005514292,
+                "rss_bytes": 2786320384,
+                "blk_read_bytes": 9313263616,
+                "blk_write_bytes": 49964429312,
+                "net_rx_bytes": 7833619358,
+                "net_tx_bytes": 3507113662
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 541.6467197625433,
+                "rss_bytes": 2852384768,
+                "blk_read_bytes": 9418776576,
+                "blk_write_bytes": 50005028864,
+                "net_rx_bytes": 7840810072,
+                "net_tx_bytes": 3558643403
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 547.6325180910401,
+                "rss_bytes": 2928898048,
+                "blk_read_bytes": 9595711488,
+                "blk_write_bytes": 50086879232,
+                "net_rx_bytes": 7850072625,
+                "net_tx_bytes": 3603045810
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 528.9900446005506,
+                "rss_bytes": 2902507520,
+                "blk_read_bytes": 9817006080,
+                "blk_write_bytes": 50154733568,
+                "net_rx_bytes": 7858452986,
+                "net_tx_bytes": 3631227046
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 555.7105825949071,
+                "rss_bytes": 2836701184,
+                "blk_read_bytes": 10006376448,
+                "blk_write_bytes": 50193301504,
+                "net_rx_bytes": 7864361083,
+                "net_tx_bytes": 3677445166
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 541.7832037788535,
+                "rss_bytes": 2906824704,
+                "blk_read_bytes": 10153664512,
+                "blk_write_bytes": 50238267392,
+                "net_rx_bytes": 7873222958,
+                "net_tx_bytes": 3740546762
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 509.1506530255314,
+                "rss_bytes": 2846572544,
+                "blk_read_bytes": 10274201600,
+                "blk_write_bytes": 50294054912,
+                "net_rx_bytes": 7877446079,
+                "net_tx_bytes": 3778047888
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 571.3221181588697,
+                "rss_bytes": 2954063872,
+                "blk_read_bytes": 10440151040,
+                "blk_write_bytes": 50344034304,
+                "net_rx_bytes": 7885484277,
+                "net_tx_bytes": 3842672725
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 558.0724289016596,
+                "rss_bytes": 2879201280,
+                "blk_read_bytes": 10673057792,
+                "blk_write_bytes": 50422054912,
+                "net_rx_bytes": 7896080444,
+                "net_tx_bytes": 3898574195
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 511.3687156237537,
+                "rss_bytes": 2869760000,
+                "blk_read_bytes": 10858196992,
+                "blk_write_bytes": 50512232448,
+                "net_rx_bytes": 7905917169,
+                "net_tx_bytes": 3934358396
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 534.962948493805,
+                "rss_bytes": 2899652608,
+                "blk_read_bytes": 10990100480,
+                "blk_write_bytes": 50558541824,
+                "net_rx_bytes": 7914353875,
+                "net_tx_bytes": 4001999130
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 541.7980922234674,
+                "rss_bytes": 2807308288,
+                "blk_read_bytes": 11141603328,
+                "blk_write_bytes": 50638368768,
+                "net_rx_bytes": 7925184560,
+                "net_tx_bytes": 4055978635
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 558.1851455584365,
+                "rss_bytes": 2921938944,
+                "blk_read_bytes": 11320393728,
+                "blk_write_bytes": 50764304384,
+                "net_rx_bytes": 7937112388,
+                "net_tx_bytes": 4112296704
+              },
+              {
+                "offset_s": 150,
+                "phase": "drain",
+                "cpu_pct": 547.6377880541298,
+                "rss_bytes": 2910351360,
+                "blk_read_bytes": 11504267264,
+                "blk_write_bytes": 50851336192,
+                "net_rx_bytes": 7950595067,
+                "net_tx_bytes": 4147316884
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "rate": 320.0,
+      "offered_load_sustained": 323.21666666666664,
+      "operations": [
+        {
+          "operation": "adhoc_query",
+          "requests": 5085,
+          "errors": 200,
+          "latency_ms_p50": 19.199,
+          "latency_ms_p90": 2936.831,
+          "latency_ms_p99": 9289.727,
+          "hdr_v2_base64": "HISTEwAAE68AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAKkXAqkNAtsFAtUBAnUClwQCFQQXAoMBAgACJwJ5AhECLQIFAgACAg0EEwIZAksCAAIrAhMCRwIdAgkCAgUCLQQCAgIJAgcCBwICCwInAgcCAgAEAwICAhMCBwQEAwICAAICCwIPAgcCBwIDAgICAwIJAgIDAgMCAgACAgMCCwICBwIDBAUCBQIABAACAwIDAgMCAAQFAgcCAgAEDwIVAgUCAwIAAgQAAgIAAgACBQIAAgACDwIHAgUCAAIFAgACAgkEAgMCBAYAAgICBwIEAgICBQIHAgICAgACAgYAAgACAgIFAgYCAAYAAgYCAgIEAAQCBwIAAgIDAgACAAILBAICBAMCAAIAAgQDBAQAAgQCAAQCAwICAgQCAgACAgIEAgIAAgIEAgIAAgcCAAICBAACBQQAAgIABgIGAwIDAgMCAgQCAwQEAgACAgIAAgIAAgACAAIDAgICBAQCAAYCAAQCBAAEAgAEAgYEAgIAAgAEBAIFAgACAgYAAgICBAIABAIAAgQEAgIAAgIAAgQKAgICBQIEBAIABAIABgMCAgICBAQEBgQCBAgEBgYEAgYGDAIGAggOCgwCAgoICAIKAgYGBAYGAAgCBgQCBgQEAggGCAgABAwEAAoCAgICBgIACAgCAAgIBgYCBAwABAgICgQIAggECgYKAgwCBAAMAgQGBgYEBAYCBAQKCgoICAQIBAgEAggGBgQQAgQGCAgOBAIIAgYCBAIIBAYICgACAgoCAgYCBgICBAIICAQCBgICCAIEBggEBggCBAQEAgIGDAQKBAYECAgEBAIKAgYIDAQABgYCBAgABAYEAgIIAggMBAIEBAoIAgoIBgQIBgIEBgQIBAgKCgwKBgQEBgoECgAGAgIKBgwIAAYCBAgEBgAEAgoCCgQIBgIEBgYKAgYEAgQECAIDAggEBgwCCgIICAgQBAgIAgYIBAYEBAQGAgIABgQCAgYGBAICBgQAAgYGBgYEAgQEBAYKCgQABAQEAAYEDAICBAYGAgYCAgAGCAYCBgICAgQCCAIABAAEBAQKBAYGBAAIBgAGCAQEAgQKAgQCBAAECAoIBAQEBgYACgICBAIGBAoCBA4EBgICBAQEAgYCBAgABgACCAQCBAIEBAACAAIABggIAgIEBAQABAgEBAQABgYEAggGBgAGBAQEBgIDAggCBAQIBAICAgQEBAgEBgYCBgAIBAIIAgQGBAwIBAYGBAQKAAQGBAIEBAQGBgoGBAIIBAQEBgIABgYABAACAgQCAgYEAgAGCAIIBgoCAAQAAgMGBAIGAgICAgQIAgICAAIEBAAEAAYKAggGAgIEAgYEBgICCgoEBAAGBAQABAQGCgACBAQEAgUGAwYEAggCBgQEBAIEAgICBAQKBAAGBAQCCAICAgYEBgQEAAIABgIEAgQCAAQAAgQABAgIAgAMAgAIBgQACAQCCAoCAAgECAACAAYCBAIEAAIEBAIABAIAAgAEAwICBgYCAAIGAwIABAICBAMCBgQEBgoABgoEAgAEAAICBAwCAgYCCAICAAIEBgYCBgACAgACAgQAAgMCAgAEBgICAgICAAgEAAIEBgIAAgYEAAIEAAICAgQCAgIDCAYCAAYEAwIDAgYCBggEAgICAAICBAACAAQEAgIEAgICAgMCAggGBAgGCAICAgICBAYAAgYAAggAAgQEAgYFAgIEAgACBgIEBQIEAgIAAgMCAgICAAQAAgQCBAACAggCAgACBAoEAAQEBAgCAAQGBgICBAIEAAQAAgIFAgAGAwIFAgMGAgcGBQIFCAICAAIEAgQDBAQCAwIABAQCBgICAwQCAgQAAgMCAgIGAgICAAIAAgICAgMEAgQCAAIABAICAgACAwICAgQCBgACAAYCAgYCBggEBAgCAAICBAYECAIABgICAAQGBgQAAgAEAgQEAgIEAgYEAAICAwIEAgMEBAACAgICBgYAAgIEBAQCBAYCAgMCAgQCCgUGAgMCAAIFAgIGAgYCAgQEAAQEBAYCAAIAAgQDAggCBAAEBgACBgQEAgACBAMCAgQCBQQEAAIGAAQDBgIAAgIGBQQEAAIAAgACBAACAgAGAgYEAwQEAAICAAQDAgIGBAUEAgYCBAYABAQEAAQABAICAgIDAgIAAgIFAgIDBAUCAAIAAgIIBAIDAgIEAwICCQICAgIAAgYCAwIGAgAECwICAgIAAgICBQIDAgQDBAMCAAICAgIEAgQCBAIAAgIEAgMCAgIJAgACAwICAAYAAgICCAMCBwICAgYCAgAGAgMCAAQHBAMCAgUCAwIEAAIDBAkGAgIDAgIGAgIECQIFAgICCQIEAgQEAgACBQIDBAcCAAQAAgIDAgACAgUCAAICAgIJAgMCAAICAgUCAwICAgQCAgQHBAMCBwIDAgICAgAEAAQAAgACBAUECQQHBAIAAgUEBwQCAAQAAgACAAIHAgICAgMCAgACAgIDAgIDAgIDAgICAgACAgkCAgIAAhMCGwIGAgAEDwICAAIAAgICAAICBQIDAgACBQQCDQQCAwIFAgIAAgUEAAICAAQCBAACAwICAgQAAgACAAIJAgUCAgACAAIFAgMEAgIPAgICAAIHAgICAgACAgACFQICAAIJBgcCAgMCCwIAAgIEBQICAgACAAIAAgUCAgMCAAIJBAMCBwIAAgUCAgQHAg8CAgIDAgkCAAQAAgInAgACAwICBQIJAgACAwICCQQDAgMCCQIDAgUCBQIDAgIHAgUCBQIRAgACCQILBAIJAgMEAgMCGQIAAh0CBwIFAgIJAgUCAgACAgcCAgIAAgcCCQIABAICAAIDAgACAgcCAAIAAgACAAICAAQDAgACAgcCAwIDAgUCAhECAAIJAgUCBAQDAgACAAIPAgUCBQIAAgsEBAICAgQFBAUCAgcCAgIfAgAEBQINAgIEAgUCAgMCBwIPAgMCCQIHAgACAgQAAgMCBwIDAgIFBAIAAgACAgcCAAIJAgIDAg8EBQICDQYFBAsCBwICAAQCAAINAgACAwQCAAIDAgMCEQICAwICAgIAAgkCAhsCAAILAgUCAgMECQICAgMCAwQLAgACAAICCwIFAgACAAIHAgACAhECAgIECwIAAgACAgICAgICAAICCwIABAMCAAIAAhUCAAITAgcCAwIEAAIABgICAwIFAgIJAgsCAgMCAgUCBwQCAgITAgMCBQIHAgcCAgUCAgACBQILAgUCAAIAAg0CBwIHAgICDwICCQQDAgkCBQITAgcCAgACAwQNAhECAgACBwILAgkCAicCAg0CDwINAgMCDwIABAACBAUCAwIJAgMCAhkCBwIFAgIjAgACAAICAAICFQIAAg0CAAIDAhECBwITAjMCBwICAAIAAgcCAgQbAh0ECQITAgkCAAYHAgsCBAMGBAUCAAIDAgICAAIAAg8CAAICAgACAAQDBAMCEQICAAQFAgAEAgsCGQYPBAACAgMCFQIJAgsCCQIPAgACBwICAAIFBgILAgQJAhECAgkCFwILAgkCBQQXAgACBwIRAgACAhMCQwIFAgIAAgcCAhECAwQCBQQAAg8CAAIDAg8CAhsCBwIAAgUCDwIFAg0CDwICCwIAAhMCAgACAgkCDQIFAg8CDwIAAgACBwICAAILAh8CNwICBQIVAhsCFwICAgUCDQIDAiMCKQIjAgMEIQIjAjsCAhsCAwINAhMCIwICFwINAh0CAgMCDQIJAg0CAAJTAgItAisCAAQDAgkCCQITAgUEBQIJAg8CIwIJAgUCCwIXAgcCAAQDAgsCAAINAgIJAgIFAgACAAICBQICEwIAAgACAh8CAAICIQIJAgMCAg0CHQIZAgACMQIDAgMCNQQhAgMCEwIAAiECGQIHAgIXAiECCwIPAgACAhkCCQIDAgMCAAInAiUCBwIFAk0CCQIDAg0EAAIdAgMCBQIXAg8CCwICAAIXAh0CAAIFAg0CRQIFAicCAwIABAMCBwICAwIZAgsCBQIDAhECAhMCBwIEAAIJAgIRAgUCDQIHAgkCCwIDAgsCCQIJAgUCDQIAAikCJQIfAhcCBwILAgcEBAkCCwIAAgIHAgMCCwIAAh0CAwILAgACEwIAAgACAgACAiUCBwIFBAkCAwICAAICAg8CCwICAAIFAgICAgUCAgICAAIJBA0CBAcCAhMGBwQCBQQHAgcCAAILAgsCDQICBAsCBQIAAgIDAgsCAgQDAgACBBkCBQIPAiECAgACAAIPBAACDwICBQIJAg8CDQILAgJBAgIHAgcEEQIJAgMCEwQJAiMCEQIRAgITBAUCCQIFAg0CCQIAAgUCDQIVAg0EFwIDAgACGQICEwQFAgACDQIXAg0CCwIDBAACBwIVAgMEBwQNAgUCBwQJAgIJAgMCKwIDAg8CBQQCAAIAAgMCBwIEAwIFAgUCFQQHAjkCAwICAwQHAgIAAgACAAIECwIDAgMCAAIAAgMCAgICBAMCCwITAgIDAgMCDwIEBwIAAgACAwIFBAMCAhECAgMCCwICDwIHAgIFAgACAwIfAhUCBwITAgUCDQIRAgIHBAMCBQITAiMCAAIFAhsCDwINAhcCAAIAAgQRBAIPAhUCAgIHAgMCBQIFAgACBQQCBQIJAgcCAAQCAwQAAhcCAwIAAhECDwINAgACCQIjAg0CBQIAAicCDwIfAjcCAwIlAgACHwIFAgMCTwILAgMEAgkCBQQAAgICCwIFAgMCDwIAAgIDAhECCQQDAgIDAgMCAAICDQICAAIFAgIDAgACAwYAAgQDAgACAAQEAAQFBAQCAgMEBgICAAIAAgACAAILAgQDBAICBAIABgUCBAMCBQYCEwIFAg0EAhECBwIHBAMCEQIHAgIXAgcCAAIHAgIDAhECAhUCBAMCAAQAAgACAgACAAILAgACBwICAAIZAgUCAgkCEwIPAhECBQIJAgMCCwQTAgACAAQDAg8CFQIDAgkEBQQDAgsCBAACAgACAAICCQICDwIRAhsCBQQVAgACBwIJAgACAAIHAhECBQIAAg0CEwIDAgACCQICAgMCAAIFAgAEAgIXAgICCwIJAgMCHQIdAgMCNQIbAgUCAAICDQIDAgACAAIDAgQCAwINAg0CBQIbAhkCEQICHwIhAjMCFQILAiECJQIAAi8CAAIRBAcCAAJFAgIAAhsCAwIJAgcCBQIHAg8CAAIJAgsCAAQAAh0CBQITAgcCIQIHBBcCFQIzAg8CDwILAgUCCQIJBCkEDQIFAgIHAhUCBQIJAgAECQIFAgUCAgUCBQICAgIDAgIAAgcCAgQDAgkCAgQHBAUCEQIHBhECAwQEBgICAwYCCQICAwIIAgICAgMCAwICAAICAgkCAgUCDQIEAgUIBwQCAgIEBgQAAgIDAgIFBAIEBAcEBwQGBgIAAgQCBAIEAAIDAgACBgcCBAIABAcCAwIJBgIAAgIEAAQCAwIABAICBAIECwQDBgYCAgIEAgACBA8CAAIAAgACAgACAgACBQILAgQCAAIHAgUCFQIVAiMCAgUCAAITAgUEAgACFQIFAiECBwIJAgACBwIHAgUCCwICAgICAgIDBAAEAAIGAwQCAAICAgUEBQQCAgYCAAIAAgMCAgIAAgIFAgQAAgACAgICAwICAAQCAgcCAgMCAgQCAAIEAAICAgMCAAIHAgQCAAYEAgMCAgIEAgQABgQDAgIHAgIGAgACAwIAAgACBAACAgQCAgkEAAQDBAACAAIDAgMCCQICAAIAAgILAg8ECwQCAgACAwIABAIEBAIEAAICAAIFAgAGBQYFAgYEAgMEBAICAgIEBAICAAQABAQEAAIEAgsEAgQFAgMCAAYAAgMEAgIFAgACBQICBAMEAgICAgQAAgMCBQINAgkCBQIAAgMCBQIHAgsCDQQCAwIVAgUCAwIHAgUCBhMCBQIAAgMCAAIFAgACAAIAAgUCAAIHAgUCAwILAhUCAwITAg0CBQINAgcCEwIAAgQAAhMCAgIEAgICAgICAgIEAAQECAIGBAACAgQCAAYCCAQGCgICAgUEBAIEAgUEAAQEAAIDAgQCAAICAAQCBAICAgACBQQAAgIDAgIEAwQCAAQCCQIAAgIFBAUCAgMCAgACAgIDAgIAAhECKQIAAgQCAhMCAgACCQIAAgUCAAIAAgMCBQIDAgACCQIDAgIAAgIDAgMCCwIFAgUCAwICAg0EBQJtAgsCAgMCAAIJAgkCBQIABAACAwICBAIAAgMCAgACBAMEAgMEDwIJAgIPAgICDQJFAg8CEQJXAgACCQIAAgcCAwICAAIAAgQAAgIDBAACCQQZAgUCCQIHAg8CAwIDAgMCBwINAgcCIwICFwIJAgIAAgMEHwINAgUCHwICAwIAAgcCAgMCTwICBwIAAh8CAAICAwICBwIbAgACEQIxAiECDQIvAgsCAAICEwITAgkCBwITAgACAAIFAgMCUQIlAhkCDQIAAhUCEQIAAgsCFQIhAh0CEQIdAg8CIQJDAgkCAgACAgMCAwIDAgUCAwIFAgACBQIHAhUCIQIFAiECOQIFAhECeQIVBAUEAAQHAgACCQIbAhcCFwYFAgItAgMCAgMCAgICAwICBQITAgcCAAQHBAIDAgIDBAACAgAEBgQCBAYEAgAECgIEBAAEAgICAgAGAAIIAgIEBAACBgICBAQCAAwGAAIGAgAGBAYCAgMCBAIEAgYEBgQDAgQABgQAAgIABgUEAAICBgACCAICAAYEAgACBwYCBQIDAhMC"
+        },
+        {
+          "operation": "composition_commit",
+          "requests": 1570,
+          "errors": 0,
+          "latency_ms_p50": 30.079,
+          "latency_ms_p90": 11091.967,
+          "latency_ms_p99": 21315.583,
+          "hdr_v2_base64": "HISTEwAACcwAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPElAosDAqUBAhkCrQECIQKhAwIHAhsCMQJ1AkMC6wEClwECHQIDAg0CmwECOQILAjcCNQINAgkETQICAg8CBQILAg8CCwIZAikCCwIDAhcCFwQjAi0CCQIAAgUCFwICBwILAgACCwIbAg0CGwICEwITAiUCAwIFAgkEHQIFAhECJwICAAILAgIXBAIJAgUCAwIDAgICAgYDAgIAAgUCAwIHBBMCAwIDAgMCBQIAAhsCAAIXAgACAwQAAgACBAUEAgIABAMCAAIEBwIDAgAEAwICBAICCwIABgACAAQCAAIECQIAAgMEAAQGAgkCAAIAAgMCAgACAgMCBwIDBAMEAAIABAACAAIAAgkEAgcCAgIAAgACAwICAgMCAAIHAgACAwIDAgAEAgIAAgUCBgACAAIDBAQAAgUCAwICBAICBAIHBAMCBAIAAgACAgACDQIDAgQHAgMCBwICCQICAAICAgIFAgICAgINAgACBAUEAgQCAgQABAIHAgACAwIECQQAAgIAAgICAgQHAgMCAAITAgMCAgMCAAIDAgYFAgcCBwIEAwIDAgIEAgIGAgAKAAIHAgIABAQDAgILAgMCAAIHAgACBAIFAgIEAgIEAgIFAg0CAgcCAAIAAgQFAgIFAgIDAgACBwIEAgsEAwQCBAACAgkCBAIAAgsCAwICAAIABAIABAIAAgUCAAIFAgACAAIDAgACBAIAAgIFAgACAAIHAgIDBAIdAgACAgIAAgACAgQCBQILAgMCAgACAAIFBAICAgIABAYFAgACAwQCAgMCAAIDAgACCwQNBAAECQIAAgACAwICAAICCQICCQIDBAUCAgAGAgACAAILBAMCAAILAgcCAAIAAgMCAAQCAgICAwIEAAIFAhMCAAITAgIAAgIDAgMCBQIDAhECCwIDAgsCAhECAAIPAgMCAwIJAgACAgsCAAIRBA0CAAICCQIHAgACBQIfAhcCAgkCLwICCwQDAgICAwQJAhUCAAIFAgcCCQIXAgsCBQIHAgQCAAIFAgsCCwQCAgQCEQIEAAIDAgsEBwIFAgcCAwICBgcCAAIFAgcCAwIHAgMCAAICAgACAgIAAgACAgMCCQgEAAICAwQCCQQAAgACAgQCAwQCBAACAwIDBAICBAICAgIHAgMCBwIDAgIEAwIAAgMCAwICAwIDAgIJAgIPAgUCAgACAgIABAkCAgMCBwIDAg8CAgACAwIAAgMCAgkCEwYAAgMCAAIAAgUCAwIJAgkCBQICBwICAAIDBAIAAgkEAAICBgkCAAIEBAkGAwIAAgACAgcCBwICAwIFAgACBQICAwINAgUCAg0CAwIHAgMCAwIlAgUCDQIAAhUCAgsCAgUCAwQLBAkCBQIJAgAEBQICAgkCBQIAAh8CBQIHAgIAAhsCCQIZAgAEAhsCBQIPAgUCAAILAgICFQIHAhsCAh0CAwIAAgACBwINAgUCEwIRAiECAAIJAhMCAAIJAgIHAgACCwIDAgMCBwQHAgACGQINAgsCFwIJAhcCBQIFAgACAwI9Ag0CAAILBBkCEQITAgkCAAITAhECCQILAhECDQIXAgcCAwIPAg8CAAQHAgMCBQIHAgMCAgMCBQIFBAMCBQICAAQAAgsECQIAAgACBwILAgIFAgMEBwIAAgACAAIDAgIXBBMCAAICBwICFQICGwIHAgkCAwILAgUCAwQHBAIXAgkCAgITAgMCAAICAgkCBwILAg8CCQIABAcCBQQCBwIZAg0CBQILAhkCAhMECQIDAgQAAgMCCwIFAgMCJwIPAh8CAAIPAg0EAAITAg8CHwICCQIjAhkCDQIRAgsCAgUCCQITAh0CAAIAAiMCiwECAwIvAi0CBwIZAkECDwILAhUCHwQjAgACCQINAisCDQJLAgIFAhUCDwIXAg0CGQICAgcEAAQJAk8CBQIFAgACCQI1Ag8CKwIpAhsCUwIRAgMCWQIXAgkCDwIvBA0CCwI1Ag0CAh8CNwIdAgMCKQIdAoUBAi0CCwJLAiECBQIHAg0CIQIFAn0COQJlAgsCOwIZAg0CnQECvQEELwKPAQIPAl0CdwIbAkcCKQIxAgsCZQIHAnUCoQECIQKFAwKZAgKnAgK7AQIJAnECLwL5AgIJAjkCNQIAAhcCKwJFAokBAikCfwIXAi0CRwJHAgIJAhcCAiMCSQI7AqEBAiECCwIAAgMCvQECTQIPBIsBAkUCUQIxAkMC2QECEQIhAgI7AhECDQJfAkcCAAIHAjsCBwIHAgUCCQIjAncCEwIfApkBAisCArEBAhcCOQIDAh0CLQIHAgIbAgcCBQILAh0CQwIRAkECdwIDAnMCAgIVAhMCFQIHAgsCAjMCCQIXAgMCCQIxAhkCBwIRAhMEJQItAgkCDQIbAhUCBQI9AkcCCwIDAhMCGwIRAgMCiQECAwJHAjsCLwI9AjECAgUCAwIZAhUCmwECFwICAAIhAg0CCQIVAmMCIwJVAgAEWQITAqUBAlMCIwIABBcCBwIfAg8CCQIHAgMCHwICFwJPAlECGwIDAgUCFQQCIQIAAkECAlMCAwITAg8CQQIAAikCAgIAAgUCAAIPAiMCKQIDBCkCAjECGQIHAgMCAAICEQIFAgILBAACAAIRAgACDQIDAi0CJQIhAgcCAAIRAgcCAwICKwIAAgMCCQIfAgkCDwIAAgACCwIhAgUEGQIfBBkCAwIABA8CFwIEEwIRAhkCDwIDAgcCGQIFAgMCBwIAAhsCAg8CEwIAAgQrAicCOwIDAgMCAwIDAhcCNQQFAgUCDQIDBBECDwIXAg0CCwIhAgUCAiUCAgcCCwQFAgIAAgICKwIZBAsCVQICCQIDAgMCDQILAgICAgIFAkMCAAI1AgsCTQIFAgILBAkCOwIAAjECNQIhAgIHAjMCAgMCEQJJAi8CAgACDQIHBAMCBwILAiECEQIJAhMCAAIDBAUCDwIDAgcCAiMCHQIPAgACAgUCDQIHAgsCEwIDAgkCGQIFAgkCAwQCDQIHAgACCQIHAgUCAwIfAgITAgACAAIAAgsCDwIAAg8EEQIRAgACIwIRAgAEAwIABAICAAIABAICBC0CAAIjAgMCCQQVAgIAAgIAAgACCQINAi8CBwIFAgMCBQILAg8CBQQAAgACBQIFAgsCAwINAgIEAAIDAgcCAAQAAgkCCwIRAgMCAAIFAgMChQECFwILAgUCAwI9AkECBQILAgIVAlECAiUCGwIAAgUCGQIbAgkCJQIRAgAEKQIRAjkCEQIFAgICAAQ7AgIGOwILBAkCAwICQQQdAgcCCwIVBgUCAAQPAgIbBA0CAAINBAkCAisCBAMCBwQCAgACAwIDBAICBwIEAAIDBgIJBA=="
+        },
+        {
+          "operation": "composition_read",
+          "requests": 10168,
+          "errors": 2124,
+          "latency_ms_p50": 6.011,
+          "latency_ms_p90": 1111.039,
+          "latency_ms_p99": 19529.727,
+          "hdr_v2_base64": "HISTEwAAHFwAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAALsMArMCAk0C6QECQwJPAlECEwI5AlUCCwIJAiMCBQIJAgITAjsCBQIfAgIlAjMCBwIFAgQdAgACEwIFAhECBEcCJwIRAgMCCwIFAhcCLwQLAgACFQIZAiUCMwIFAgACHwIFAg0CFwINAgIXAgACBwIDAgMCAwIAAgICEQIRAi8CEwINAgMCEQIJAgMCHQIHAhkCBQQDBAQECQIDAgIAAgACCQIFAgIDAgACCwIDAgAEDwICAAILAgkCAgICCQIEAgsCAgIDAgINAgACBAACBAAGBwIEBAMGBgACAwIABAYAAgMGBAACAgIAAgQFAgQGBAAEAgACAAYDBgICBgACAgYEAgACAAQCBAAEBAICBAIFAgAECgAEAAQCAwQEAgYGBAACAAQAAgYEAgIEAAIEBgIAAgACAwgEAgACAgAEAgIGBAIEAAICBAACAggIBAIIAAQGAwIABAICAgIEAgUEBAACAAICAAoEBgwEAAQEBgAECAIEAgIGBAIGAAIKAAYABAYGAgICAgQABAICDgQCAAIEAAQGAgYGBAIGCAICBAQIAgQAAgICAAICCAIABAAIAAICAAQCCgIEDAICBgQCAgYCBgQAAgACAAQIBgQAAgQCBAYECAgEBgAEAgQABAgIBgYGBgYEAgQGAAQEBAYCAgoCAgYGAgQMCgYCAgIGBAIIBAIECgAIBAIGCAQEBAIGBAYGBAQGBgYICAgCAgQEAAgGAAwCDAYEBAYMCAgCAggGCgQMBgYGBAIIBgQEBAQCAgYCCAgGBgYIDAQEBAIEBAYMBAoGBgQEAAYGBgIABAoGBgQEBAYGAg4EBAYGCAAIBAoGBggECAgKCggACAQEAgYCBAAGBggGBgQMBAgADgYIBAACDBQEBgwEBAgKBg4IBgYAAggKBAYECAoOBgIIBAYGBAoEDAoEAAoICgIGDgYECAQGBA4GDAgGCAgCDAwIBggADgQCCAYGCggKAgoICAoGBgQGAggECAYEAgQMCgwMBgYGBAQKDg4EDAQGCAgICAIGCgAKCgYMCAIGCAwECgoGDAoICAgGEAIEAgYIBgQEBgYICAwECAoGBAQGCgwIBAgKDAYIBgQACAwKAggMBgQKCgYIBggMAAYKBgQICgIIBgYABA4ICAQECAYCBAYKAgYIBgIGBAgIAgQGCgQCBgYICggCCAYMAgQGEggGAg4KAgQICgICCAoIBAQGBgYGDgYKBggGDAgOBggKCAQIBggOAAYIBgQGBgoGDgYKBAQGCAIICAoMBgQEDAYCBAIEDggGBA4KBgYKBAgEBAYGBAYICgYKCAYGDAYGBgQEDgYCDggCCAoECAYMBAgCCAYIBggGCAoGBgQICAYIBhIIBgYIDAYIDggMDgoOCgoCBgYGBAYMBgQACAgKBggGCgICAggICAYCBgoEBAYGAgYGBAQQAgACCAwIBgoGBAQDDAQKCgQGBAQECAQGBgQGBgoEBAYMBgQMBgQCBgoGBAIECAgIDAoCCAQCBg4GAgYCBAYICgQCAggGDgICBgwECAgGCAgCCgICBgIGAAoEBAgGCgICBgQIBAwEBAYIBAgMBAgKBAgGCAYODAQEABAABAYIAggIAggGCgYEBAwIBBoGDhAaEhIUEAQMChAMDgwKBhYMAhISBBIQDhAOBhAMDhIOIBIMCgYSCA4QEAwGBg4GCBQQCggKCAoSDgwKDAgOEAYQCgoOBgwGCgwKCg4GEAYICgoIDg4GCBAQCg4IDAIKDAwSCgoMDggIDBIMEg4GBgIQEAwQBAgMAgQKBggGDAgECAgEDAYMCAwKDgoIBgwQDgoMCgYSCAoQDgQGCAQMDggKCggKBgoMCgYKChAIChAEDBQIDAwGBAoMBgoEDBIQChYGCA4GDAYUCAoKAggGDAgMCAwKBAoGAgoIDAQGBBIKCAYGBAgIBAgKDAwGCAAOChIQCAgGBAwMCAQQCggOBgQOBgYSEAgEDgYOCAQMBgQMCgwICAYMDAYICgYEAgQICAoKBAgGDAYQCggICAgGBgYMEAgEBAYIBg4GAwoEAgQCBAQGCgYOCAYMBggKCAYKCg4MCgIKBgYIDAgECAYOAggOCgYOBgwIBAoGBggIBAgICAYGEAoKDAgGBgYGBAoCAgICCAgMEgYCCgQECAYEEgYEBgYKAgQMBgYGAgIEAgQCBgYEBAAKBAoIBgwGBgwCAggOAgIGBBQMBgIGAgYIAgYIBggIAgQGCAgIAgoKCAgCEggCBAgECAgGCAoCBgYGDAYKCgQEBAYICgYIBAQECAYGAgQIBAIABgICAgIIBAgIAAIGAAgGBAACAgAKAggGBgQCBAgCBAYEAgoCCAgICgoCBAoCBgACAAICBAQEDAYGBAQIBAIIBAIMBgIGAgIEBgQEBgAGCAIIAgIAAgAIBAAEAgoEBAQEBgIECgMGBAIEBAICCAYGAAgEBggCAgQACAoIAgYGAgACBgYEAAYCAggICAIDAgYEBgQEAAQCAgQEBAYEAAgABAQCCAYIBAQGBgYEBAIECAgCAAgECgICBggCAgYKAgICBAICCAACBAQAAgIIBgYEBgACBAIEAgIIAgQCDAACAAYEAgQMAgQABAAEAgYCAgYCAAoCAAICCAAEDAIECAUEAgYACgYCAgQIAgIIBgoEBgACAAQEBAQCAgQABAIGAAYIBgQEBAYGAgICCAQEBAMCAgAIAAQEBAQCBAIEAgIEBAIGBAgGAwoDBgQKAAICAAgABAICAgIEBAQIAgIGAwICBAYKAgICBQQCAgQEAAIGAAQGBgcEAggCAAQEAwQEDQoAAgMEBAQCAgAECAIAAgQCAAQGAggCAgQEBAIGBAQGAgoCAgQGBAQEAgQABAYEAgIGAAIABgQCAgIAAgQIAAQCAgACAAIFAgYGBAACAgIDCgIDBAACAwIGAAIEAgMEBgACAgIEAAICBAQGBAAGDgYCBgIECgQGBgIGBAoIBAIEBggEBgIECAQCCAYCBgAEAgwEBAQCAggEBAYMBAACCAYMAgACBAICAgQIBgAKBgYCBAQMAgAKCAQEBAYMBAQEAgQCCgYGAgICCAACBgQEAggDAgIGBAIEAgAEAgwCAgIECAIGBAYIAAIKAAYCAgACAAgGAgIEBAQEBAQKBgIABAoGAgQCBgYEBAYCBAQABAYEAgICBAIIAAQCAgACBAICBAIEAgoCAgAGAgYCBgYABAAEAAIABAICAAYEAgYDBAQCAgYCCgICAgIIAgAEBgYCAAQEAgYCAwQGBgACAAIAAgUEBgIIBgICBgIAAgAEBAMEBgIEBAMECAQCBgMECAYDBAUCAgICAgQEAwgCBAACBwQCBgQDAgAGAgIICAAEAAICAgQEAgIGAgIAAgAGBAACAgMCCgIHBgIGAAICCAYEBgIAAgACAgICAgACAgQAAgIGAAIAAgIEAgACAgQGAAIAAgMCBgIABAQGAgQABgQFBAICAwICBQICAwYCAAIABAACAAIFBAACAAICAgIECQICAAIEAgQEAgAEAgkCAgMCAAICBQQABgQCAAQGAgQCAAIEAwIABAkCAAICAgcCAAIABAIABgAEBAACAgYCAwIAAgQFBAAEAgQCAAIDAgICAgICAgQAAgIDAgIFAgIABAICAwYCBgILBgIGAAQNBAQDAgMGAAIFAgAEAgIABgIHAgUGAwIAAgQEAgACAgQCAgQCBQILBAICAgAEBwQCAgQJAgACAgACAgACAwIAAgIEBQICAAICAAIFAgIAAgACAAIAAgAEAwYDAgMCAwIGAAIFAgIDBAYGAwICAgQCBQIAAgMCBQIEAwIAAiMCAgACAAIAAgMCAAICBQIEAgIEAwYCAgcCAAIDAgMCBQICAgACAgAEAgILBAUCAwIGAgQCAgACAwICAgIFAgIABgcCAwYHBAIEAwICAAIDBAIEAgACAAQCAgICAAQAAgACAAIDAgICAAICBwICAAQDAgMCAAICAAIDAgMCAgQNAgkCEQICAgACAwICAAQDAgcCBBECAwICAAIFAgICAAIHAgIAAgACAgMEAgACAgQFBgICAAQCBAMEBgQEAgAGAwICAAICAgICAgMEAgcCBAICAAICBAQCAwIAAgACAgIDCAICAAgFBAIFAgACBQIAAgIABAICAAIJAgQCBAACAAQAAgAGBAACAwICAgACBAMCAwICAwICAwIEAgICAgMEAAIAAgACAAIEAAIAAgICAgQAAgICAgILBgMEAgAEAgQHAgACAgAGAwICAwIGAAIDBAMCAwIAAgIFBgIAAgIAAgYABAAEBAIJBAACAwICBQIAAgMCAgACAAICAgQAAgACBAUIBQQEAgcCAgQFAgAEAAQCAgIAAgICBwQAAgIAAgMCAgQFBgIDAgICAAIDBAACAgQAAgICAAQHBgMCAAICAAIAAgMGAgIAAgIPAgIDAgQJAgACBQIAAgIAAgMCCQINAgMCAgACCQYABAACAwIDAgACBQIDAgQAAgIDAgMECQIAAg0EAAIEAgIXAgICBwIABAQDAgACAAIDAgsCAAIHAgACAgMEAgICAAQNAgICAAYAAgUECQICAg0CAwIHAgIDAgkCAgsEAwICAgUCBQINAgIAAgMCBQIEAAQDAgcCBQIDBAMCBwYAAgIHBAICBQIABAMCBQIZAgICBQQAAgACAAICBAACAgACBQILAgAEAg8CAgIEAwICAAIFAgICBQIJAgMCBQICAgYDAgUCAAIJAgQCBwIFAgICAAQFAgkCAwIDAgUEBQIDBAMCAgkEFwIHAgUCAAICAgsCBQIDAgACAgIDBAIAAh0CAAIJAgkCAAILAgQCEwICBQIABAMEAgMCAgACCQIRAhECAAICAgMCAgUCAwIVAgcEBwIFAgIJAgIHAgIEAAICAwQEAAICAAQAAgACAgkEBQIAAgQGAgIAAgMCAwIFAgUCAAQCBwIAAgMCAwIABAMCBwICBAACAwICAAIAAgMEAgACAgMCAgsCAAICAgICAgIABAcCAAIDAgICAAITAgICAwIDCAIEAAIEBQIFBAIFAhcCAAIFAgYAAgICAgIFAgcCAgIEAwIAAgICAAIHAgAEBQIEBwIXBAIHAgACAAIFAgYAAgIFAgsEEQIVAgACBAIAAgMCKwQCAgACAwQLBAACAAIJAgUCAAIAAgMCAAIDBAUCBwIAAgMCBwICAgMCCQIDBAMECQICAAICAgcCAwYFBAMCAgUCBQIJBAACBQICCwYDAgAEAAQDAgACBAIDAgACAwIhAgUCBQICFQIAAg0CBQIDAgACBwICDQQNAgcCAAIDAgACAAQJAgMCAAIDAgIAAgACAgMCAAICCwICAgUCBQICAAICAgACAwQAAgkCAgACAwIAAgcCAAIJAgACCwIFAgAEAwICDQQEAAIFAgUCBQIJAgIAAgACAgACAgsGAwILAgkCAgAEAgICBQIEAAITAgUEBAQCBQICAAIJAgkEBwIDAiUCAAITAgACAwIAAgIHAgUCAgUCAgcCAAIDAgUCDQIXAgUCBwIFAgIPAgcCAgMCCwIAAgIHAhECCwICAAQGAwICDQIFAg0CAAICAAIFAhEECwIAAgsEAAIJAgQDAgIJAgINAgACAwIDAgACAAICAwQEBwIDAgACDwICBwQXAhECBwQDAgMCBAkCAAIDAgMECQIFAgICAwIABAUEAwIAAgIAAgACAg0CAgcCCwIAAgMCAwYNAgIABAcCAgMCAAIEBwIAAgMCAgYCAg0CAAIPAgMCCQQABAUCAAIAAgUCBAQHAgINAgUCDwICBQIAAgMCAgkCAAIDAgACAAIDAgcCGQQABBcCAgMCAAILBAACCwIDAgMCBAIPAg8CEwIFAgACCQIAAgICJQIDAgcCAgcCAgsCAgcCCQQCDQIAAgMCAwILBgsCCQICAAQCAwIJAgUCAAILAgcCCQICAwIpAgYRAgACAgcCDwIACA8CBwIFAgkEAwIDAgIAAgcCDwIAAgMCEQICAAICAgMCFQILAgICBQIFBCkCAikCAAIAAhMCAgsCDwIVAgMCFQIHAgUCBwQAAgACHQICAhMCAwITAgACBQQLAhECBQIHAg0CAgMCBwIAAgUCBQICAgUEAwQAAgQCBQIAAgcCAg0CFQINAgMCAgMCBQIABA0CAiMCAAICCQIAAgIDAgIEBwICAgIDAgMCGQIHAgACBwICAgcCBQIHAgMEAgACAwQDAgYCAgIFAgQCAAIDAgICCQIDAgACBAQCBQIDAgkCDQQCAAIJBAcCAgACAgACAAICAgcEAgIFAgACBQIJAgcCAAIDAgACAAIAAgACAAIAAgIAAg8CBQINAgUCAAIEAAIFAgcCAgIAAgICAgACAwIJAgMCAhUCAAILAgcCAg0CAwIHBAMCFwIDAgACAg8CCwQFBAIFBAUEAwIHAgUCAAQFAgUCAgMCAAINAgkCBwIAAgACAwICBQQCCQQCAgIDAgMCAgMCAwQHAgMCCwQVAgIFAgAEAgICAwIXAgACVwIDAgIHAgsCAgIHBAUCAAIDBgUCAAIDAg8CAgMCBQIJAgkCBwITAh0CAgQDAgACCQINAgUCBQIRAgcCAwICAAIDAg0CKQINAiECAwIAAhsCAgsCDQICAwIPAgkCJQINAhECAgUCAhcCAgINAgkCAisCEQIfAh0EAgUCFQIZAg0CAgsCGwIDAgACAhUCAgUCAwIFBAUCAAQAAgACBQIDAgAEBwIRAgACAAIAAhECAAITAgIJAgUCAAIHAgMCAwINAgkCAgUCCwQAAgkCAAICEwIABAkCBQICGwIfAgICAwQCEwIAAhUEDQIFAgACCQIPAgACAAIJAgcCCQILAgMCFQIDAh8CAAICDQITBAAEEwIABCUEAwICAhUCFwIJBAMCAAICHwIHAgcCCQICAgcCAAICAg0CEwICAgACCwIAAgACBwQCAgYXAgcCAgsCAAIDBBcCAwQHAgQAAg8CAgsCCwIJAhUCAhECAAIAAgcCBQIHAhMGBwINAgMCCQYFAgICCQICFwIHBA8CEwQDAgICBwQCAgIAAgAECQQDAgACAAIDAg8CAgIAAgIHBAcCAwQAAgICBwQFAg0CAAIAAg8ECQIFAgICBQQAAgMCAAICBQIAAhMCAAICAAIPAgMCAgINBAMCAwIJAhMCGQQCAwIEAwICBwIPAgUCAgUCDQICBQIPAgMCCQIAAgACAgACHwQCHwQAAgACAwINAgMCBwINAgkCAAICAwICBAUCAg8EBwIJAgUCAAQFAgQLAgcCAAIFAgIDAgQABAICAgACAgUCDwQFBAUCCwIAAgkCBAMCAgMCAgACCwICAwIVAgACGQINAgkCBAcCAg0CBQIAAgACBQIAAhUCAAIGBQICAgACBQIVAgUEEQIPAgMEAAIJAg0CBQIPAhcEBwIXAgcCAwQJAgICAAIJAgcEAAIAAgMCAAIXAgUCBQINBBECAAICBwICDQIJAgIDBgIHAgINAgMCBQIDBAICCQIDAgYCAgQAAgACAgIDAgQCBAACAAIAAgACAAIVBAMCAwINAgsCCQICDQIFAgACAAIFAg8CBQIHAgAEAwICAgUCAgcCBAICCQICAwICAAIDAgACBQIDAgkCAwIRAgYNAg8CAwQHBAcCEQICCQIHAgkCDwQPBAIbAgkCBQIAAgcCAhMCBwITCBkCBQIVBAkCCQIRAg0COwICAgUCBwINAgMCAAIJAg0CCQIJAgACAAIAAgICAgkCIQIFAgICCwIXBA0CAAIEBQINAgsCAAIAAgYEAAICAgMGBAICBwYGAgMCAAICAgQABAIEBwIAAgQABgACAAIABAYCAAIGAgICAwQCAAIHBAAGAAIAAgIEAgMGAAQFAhkCBQIFAgcEAAICAAIDAgINAgUCGwIFAgACAgACAg8CBQICDwQDAgcCDwILAgUEAwIAAgkCDwIAAgUCBQQABAMCAAIAAgICBAkCAAQCBwIAAgkEAwICBQICCwIEBgICBQICAgQDBAUCFQQDAgcCBAIAAgIABAMEAgQFAgIAAgUCBAACBAQEAAIABAIDAgACAAIDBAUEAwILAhsEEQIAAgICAAIEAAQEAgMCAAICAgUCAAIDAgMCBAcCAwYAAgQCAgYGAgIDAgACBwIHAgIDAgQCAgIABAIFAgMCBQQAAgMCCwICFQINAgICAgkCDwIFAgAEEQINAgACBQIAAgUCCwICAgMCAAIRAg0CGQICFQINAhMCEQQXAicCHQICBQIAAgkCAwILAgILAgcCBQIAAgMCAAICDQIFAhECEQIbAgkCFQICEwILAgcCBwIEAgQDAgUEAAICAAIDAgkCBAIECwYNBBMCAwIFAgACAwICAAICAwIHAgIDAgMCCQIAAhECAwIDAgACAAQCAAIDBAQCBQICAgcCBwIAAgIFAgIFAgMCAwQCAAIDBAACBAACAgQDAgIAAgACBAICAAICAgUCBAMCEQICDQIDAgIABAACDwIDAhMCBQITAgsCAAIHAhECIQIPAhECAgcEAAICAwIJAgsCCQQCAg8CBwICBwICAAIEAAICBwIFAiECAwQFAgcCVQIFAgsCBwIHAhUCCwIDBAIFAgICBwIFAgkCDwIDAgACBQIPAhcCAAIAAgMCBQIHAgIAAgICAwIDAgICEwIDAgkEDwILAgcCBwQCAgACAgcGBBECNwIAAgIAAgcCBwIFBAIEBAACCwQAAgQCAAIHAgYDAgMCAwIZAgMCAwIAAgMCAAICAgIAAgACAwYVAgcCAgMCAwIAAhECHwICAwICDQICDQIAAgIAAgIJAgMCAAIJAgACAwIFAgkCAgMCCQIJAgkCBAcCBQICBwIDAg0CAgcEAAIAAgIAAgIAAgMCAAIABBECHwIDAgINAgAGCQQCAgMEHwIPAgICAAILAgQFAgIFAgIJAgAEBQIJAgIDBAIEBQIEAgYCAAQCAwIDCAMEDQIJAgQCAwIEFQIAAgQDAgQDAgICAgUCAAILAgMCBwICAAILAgcCAwIXAg8CBQILAgACAAIFAgsCAAI/AgACCwQLAgMCAAIAAgAEAgUCAgsCAAILAgcGAgMEAAQCAgIAAgUEHwIRAgsCAwICBAcCAwIAAiECFwICFwIHAgsCBQQCBQIFAgICBQIFAgICAlECAgkCDQInAh0CBQICAwIDAgIDBAILAgIVAgUEDwIAAhcCDQIPAgQtAgIFAhcCAgACBQICCQIHAgkCCwInAgACAAIABAMCFwIDAgkCGwIRAgUCEQIdAgUCOwIjAhsCCQIRAgsCPQIRAgIDAl8CAnMCFQICBQIJBAUEAgcCAgICAgkCAAItAgUCCwIpAgMEAwIHAgI5AgICAhECAwICFwIPBAQCCwIrAi0CBwI9AgIAAgMCAgIRAgMCNwIAAh0CCQIHBAIAAhECAwICBQIAAhMCCwIHAgIFAgsCVwIfAjcEAAIJAgACAgcCBAACAm0CMwJhAg8COwICAgIFAg0GBQQAAg0ETQJPAtkBBAcCBQIAAksCTQIVAg0CZQIABAkCbwICAgIAAgACAAQHAgcCCwIHAi0CBQQpAisCBQIHAhMCEwIFBA0CAgQEAwIdBAcCAAIAAgIEBgMCBAQRBAUCBAMCBQIFBgILBAIABAsCDQQCBAACAgkEAgQDBAMCCQINBgIEAwgCAAQEAAYGCAIIAAIEAAIGBA4CAwQAAgICAg=="
+        },
+        {
+          "operation": "composition_read_current",
+          "requests": 5720,
+          "errors": 1188,
+          "latency_ms_p50": 6.631,
+          "latency_ms_p90": 790.527,
+          "latency_ms_p99": 19316.735,
+          "hdr_v2_base64": "HISTEwAAFJsAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAALEQAhkCvwMCTwIAAgsCBQJFAhkCCwJVAgsCTwIzAlECBQITAi0CBwIFAgUCEwQZAkMCBwIAAgcCCQJFAg0CIQIRAgcCGwIHAgMCCQIVAgIxAhcCFwIAAgcCIwIPAhECBQI7AiMCAgACGQIRAgcCDQIXAgsCBwIlAgMCBQICAwILAgQCAwIHAgACBwIAAgITAg0CCwQFAgcCCwIJAgcCFQICGwIDAgACAhECBQIAAgUEAgsCCQILAg0ECQICCQIDAgkCAg8CAAIEAAIAAgACAAIDAgACAAIDAgACAAIAAgIFAgMCBwQNAgMCAg0CAAIPAgsCDQIHAgACAAICAgACAgsGAAIFAgQEAAQDAgUCAAQABgUCCwIFAgICAAICAgsECQIAAgsEAAIFAgACAgACAgIJAgIDAgsCAAICAwICAgUCAgMCAgICBwIDBAQCAwIHAgICAAIDBAACAAICBQICBwYEAgICAAQEAwIEAwIAAgACBQIAAgACAgICAAYAAgQHAgACAgACCQQABgUGCAAEAgIIBAQDAgICBAkCBAIDAgIEBAIABAAKBAACAgIAAgQCAgICAgUCAAQCBgUCBgACAgACBAIECAYEAgACBAIAAgQABAQCBAAGAgYCBgIEAAIABAwEBgQABAIDAgcCAggAAgIGBAAECAIEBAIGBAIEBQIDBAYGAAICAgIAAgQEAAQEAAIEAgIGAgIEAgIAAgICAAIEBAIEAAQKBAAEAgQIAgAEAggGCAYEBAIABAQGBAYGBgICBAQDBAICAwQABgICAAICAAQKBAIGBgQCBAgCBAYEBgACBAoCAAIFAgIACAAEAgMCBAQCBAQCAwIACAAGAgACAAYABAYCCAYEAwICAgQEBgYEBgQECAQEAAYCAAIEAAICAgYCBgIMAAIGBgAGDAYEAAQGAAgEAgoCBAYGBAQGCAIEAggIAAICBAQCBgYAAggGBAQABAgCAAYEBgICAgACBAIGAgACBAAEAgQEAgQCAgcCCAIEBAIEBAgAAgQKAgYIBAIGBgYEBAYGAggCBAIGAgICAAYKCAYCCgYCBAACAAQGBAQCAwIIBAgKAgYGBAIEAAgKBgQGAgAEAAgICAQEAgQCAgYEAgIAAgACBAICAgYABAAEBAgGBgQIAAIEBAIGAgYGDAYMCAQGAgQEDAoECAgGAAIIAAgICAYECAgEAAoKBhIKDg4ABgQQDAoICgYCCggKBAgKBBAGCgQEDAoKBgYGBAgGCAgIEgQCBgIECAYOBAoKBggGAgoKCgoICAwGAgwOCgoGCggKBgYQAgYGBgYGBgIOCggEDgIEChICCgAGBggKBgoMDgoCBggIFAwIBAQKAgQMBAQMCggIBAYKBAgMBAgABhQIBgwECggKCggGBAYIFAQKBgQGCgwMAgQAEAoMBgIGCAQMBAgCBAgICAYGBgYEBgYGBAoGBAQGCAgGBAYICAQGBA4ICgoGAgQKCgoEBgIKBAoKBAIIBggECAgEAgYGAgQEBAIKCAYICAoMBgQGCgYGBAgMBAgCCAIAAgYCDAYGBgYEEAAECAICBgYGCgwECAQIAgQABggECAwICAQKBggGAAoECAYGCgYECAQABAYGCgQCBAQCAgYICAgCCgQKBgoGAgYGAgIIBgQCCAIMEAIEBAIGAgAIAgYGAgQGBgIDAgYCAgMEAgQGBAIGBAQGBAICAgYCAggGCgICBAYECAIIAgAEAAYECAQABAIEBgYIBAYCAgIKBAQKBggGBgwIAgYKAAQEAAgGAg4KBAgEAgoCAAgEBgIGAgYKBgoEDAIGAgYGBAIEBAYGAgQEAggEBAIEBAYGAgQEBAYEAgIEAgIEBgIKAgAEBgQIAAQABgACAAQECgICAgAECgYQAgIDAgQEAwIEBAQCAgAEBAAIAgQIBAIABAgCAgQECAAGAgYEAgQCAgIEBgIEAAICAgQEAgYEAAYGBgACAgUGBAAEAAgCAgAGAgIAAgQABAAEBAQCAAIIAAYGBAACBAQEAgAEBAICAgIGAgACBAQAAgACAwIEAAIACAIEAgYGBAACAgICBAQKBAACBAAGBAIDCgYAAgQGBAIEBAQGCgMGAgQEAAIDCAQDAgIEBAQABAAIAwIEAgIAAgICAAIIAgAGAgIEAAICAgAIAgAIAAIEAAIIBAQEAAYDAgICAgICBgMCBgIEAgQCAgYEAgYABAQCAgACBAACAAQAAgACAgIEBAUCBAQCAwYGAgICBAIAAgQABAICAAIIAgICAgYCBAQAAgQGBgICAgIDAgYGAgICAAQEAAYCBAICAgMCAAICBgIEBAQGAgYCBAIEAwICAgYCCAUCBgIAAgIEAwYCAgIABAMGAgIEBAICAAICBAIEAAQCAgICBQICCAACAgACAAQDCAIEAAQCAwQABgIEAAICAAIDBgkCBAMGAwICAwIJBAQCAAQCAgMCBAACAAIDAgQCBAQGAAIEAAIAAgQAAgYGAgIDBAQIAgQIAgYGBgYGCAMEBAgECAgEBAQGAAQCBAYCBAIEAAQCAgYEBAQABgQABAACBgQGCgMCBAIGBgYCAgQKAgQCAgACBAAEAgQDAgIDBAAEAgIEAgICAgAEAAICBwIEAgkCAAIABAQCBAAKBgQCAAQIAAYEBQQFAgYCAAQCBQIAAgQCAAQCAAIECgICBAkCAAICBAQGAwIAAgQCAgMIAgQCAAIEAgICAAICAgAEAgICAAQCAgACAgYCAgACCAMCAAICAgQCAgAGAwICAwIEAgQDBAAEAAgAAgYEAgICBgACBgIABgYCAgIABgACAgIABAIHAgMEAAIFBAIAAgACAAYCAgQECAACAwIEBAICAgQCBgAEAgMEAgICAAQCAgYCAAIDBAACAgMCAAIEAgIHAgACAwIDBAMCBAAEAgMCCQQCBAAEBQIAAgICAAQAAgMCAg0CBAIDAgIAAgIFAgQCAwQCAwICBAIDAgICAwIDBAsCAAIPAgUCAAICBAICAgICAAIDAgcCAwIDAgMCAAICAgQCBQIFBAMEAAIFBAkCAAQHBAYCAwIDBAUCAgILAgkCAgcCAgMEAgUEAAICAgMCAAQAAgcCAgMEAAIPBAIABAkEDQIEBwIHBAkCAwQABAICBQQLAhMCAgUCCwQCAwIAAgIEDQIAAgQCBQIDAgkEAAQFAgUCBQINAgAEBgACBQIHAgACBQICBQIDAgICAAIFAgIJAgkCAgIAAgcCAgkEAhMCAwIFAgACAAIJBAUCAAIEAhMCBAMCAgIDAgUCAhECAwIAAgMEAwIAAgUCBwIHAhECAAICBwIJAg8CBwICCwIlAgICAAIAAgILAgUCAg0CBAkCEwIAAgICBwIEDQIAAgIAAgACBAICAhECAAQNAgICBQICAgMCAgAEAAIJAgMEAwICAgMCAAIEAAICBAcCAwIAAhECAgcCAAQDAgAEAAINAgMCAAICBAIAAgACAwIAAgUCAwILAgMCAAQDAgIAAgAEAwIDAgACAAICAgACCwIAAgMCAgkCAgACBAICAgIHAgMCCwIPBAMCAgcCAg0EAgICAgACAgACCwIDAgIDAgACAgIDAgUCAgYTAgICAgIECwIAAgUCAg8CDQIDAgsCAAIAAgACAgACAgIDAgMCAwICBAcCAAIHBAACBwIAAgMCAwICDwIJAgUCBQICAAIdAgACAgIAAgUCAAIRAhECAAIHAgIDAgACAAIPAhMCAgcECwIJAgcCAgACAgICHQITBA8CAwICCQIDAgIhAg0CFQI9AgMCAgMCBwICCwICBQICAAIDAgcCCQIDAgcCBQITAgACAwIDAgACBAACAgMCGQQJAgQDAg8EBQICGQQAAgcCAAIJAg0CJQIJAgMCEQIEAwIRAjUCBhMCAgsCAgMCCwINBAMCBQIJAgIAAgUCCwITAgMCFQIRAgACBQIAAgITAgMCAwIAAgACBwINAgMEAgkCAwIAAgcCAwIDAgACEQIDAgcCAAIAAgIFAgIXAgACAgUCEQIHAgICFQQNAg8CAAIACA0CAwYHAgcCAAIDAgICAgkCDQQCAgQCAwIDAgAEDwIDBAUCBAACAAIAAgACAAILBCcCAgIDAg0EBQIDAi0CFQIABAIEBgcCEQIJAgUEEwIAAgIDAgUCBwIHAgkECQIFAg8CBwIAAgIHAgkCGQINAgAGBwQJAgIFAh8CDQICAwIHAgkCBQIAAgMCBQIVBAIHAgMCAwIHAgMCCwIAAgIAAgcEAgcCBwIHAgQDAgICAgMCBwIJAgMCAgILAgMEDQIPAg0CCwICBQIJAgMCAAIPAhECDQIXAg0CDQILBAACBwIFAgIDAgUCJQIfAgICFQIAAhMCDQIECQIAAgMCEQILAgIPAgUCCQIHAgcCBwIFAhUCAwIJBAUCDQQDAhsCCQIDAgACAgACBQIFAg0EHQIPAgIJAhMCBwIHAgsCAAIDAgUCAwIhAgIAAgkCAAIJAgIFAg8CEwIDAgkCAgAEEQINAgUCBwIHBAIDAgICFwICAAICDQIAAgkCEwIABAIFAisEAwINAg8CAwIFAgICJQIJAhEEBQIFAhUCBwIAAgACAwIHAg0CKQIDAhECCQIPAg0CHQQLAgkCFwIDAjUCHQILAgcCBwIJAhECAAITAg0CJwINAh0CCQIDAgUCCQIFAgUCHwIHAgACDwIFAhMCHwQAAgUCIwIDAgIRAg0CFQIJAgcELQIFAgMCGQIVAgACDQIfAgICCQICFQINAi0CEQIJAgUCBwICHQITAgACCwIJAhkCDwIAAhMCMQIAAisEAAILAhECBwICEQIDAgIDAgUCAgcCCQYRAg8CBQIFAgIXAgICAAIHAgIAAgACHQIHAgUCAAIAAgIZBBUCBwIEBwIZAiUCBQIHBBECBwIDAg8CAgMCDwIAAgQPAgUCAAIAAgACBwQDAgIJAgUCBAQPAiECAAIXAgMCCQQDAhUCBQIFAgIVAgIDAgcCAgsCAgACAAInAhUCFwINAgMCBQICFQICEwIRAhsCGwIHAgACCwIDAhkCDwIRAgACAAI7AhsCEQIAAhECBQIrAgIFAhkCAwIDAgcCGQJjAgsCEQIFAlECEQICCwIAAgsCGQIJAh8CMQIRAhMCAjUCSwIDAgkEBwIHAi8CBQILAgsEAwIHAh0CDQIbAgACIQICGwILAgUCCwJJAgsCBwIpAgUCAAIDAhUCEwInAgcCHwIDAgJFAgACAAIVAg0CBwIAAgIHAhECGwIDBCsCCQIFAg8CEQIFAgIVAgACKwQHAgcCJwIVAgkEAgMCGwIAAgIdBBEEFQICDwILAhcCBQICGwICBAICAgUCAAIbAgACDQI5AgIFAgMCAAIDAgAEDQIAAgACAAICAgACAwICCwICAAQEAwIDAgICAgAEAAICBQIHAgkCAwQFBgAEAgACBAcCAgIJAgIAAgIFAgMCAwINAgMCBAMCAgsCAgIFAgICCwJNAgsEBQIdAgcCCwIHAgsCAAQDAgMCBQYCAgMCDQICEwIAAgcCAgQCIwIZAgACDQILAgcCAgkCBQIFAgIABAIAAg8CBwICCQILAgUCCQIHBAILAgIHAgIAAgIDAgMCGQILAgACCwICAwIHAgACAicCCQICCwIJAg0EBQILAgACDQYNAhEEBwICDQIXAhECAwICAAINAhkCBQIDAgcCAwICBQIHAgACAAIDAgUCDwIDAgITAhECAAIDAgsCAgUCAAIRAgACAwIAAg0EGwIHAgsCAwICAwIDAgIAAgUCBBkCAwIAAhMCCQIDAgICAwQEBgUCAAIDAgICAgIFAhcCBwICAAICAgIJAg8EBwQZAgMEAAILAhECAAIAAgACAwIFAgMCAAIAAgMCAgACCQYAAgIFBAACAAIDAgcCJQIJAg0CDQIdAgcCAwICIQIVAgITBAQCDQILAgIJAgkCFQIAAhUCBwINBAsEAh8CAwInAgsCFwICKwIrBCECAwILAhsCJwITAgsCIQIAAgMGAAIHBAUCBQIHAgACHwIDAgACGQIFAhUCFQIFAgICBQIPAgkCEQJJAgkEEQIAAgUCLwIHAgACBQQdAgMCEQIFAgIAAgMCAgUCAgACBwIJAicCCwIFAhkCHQITAgIDAgMCBAACDwICEQIDAgcCBwIAAgACAwICAgAGAwgCAAQAAgQCAwICBQIEAAIAAgICBAACBQICBAMCAgILAg0CAAIFAgQJAgUCAAIJAgACLQQZAgkCMQIVAg8CEwIRAhkCGwIpAksCNwIhAkMCCwIVAiUCNwIDBAkCCQICEwIlAgACCwILAg8CWQQEEwIHAiUCHQICCwILAgsCAkECBQIbAhECIQJLAh0CCwIFAh0CAwIDAgMCAwIAAgkCAAIFAj8CEwItAksCKQIlAgkCPwIAAgIDAgcCAwIJAgIAAgkCAAIDAg8CLwIHAgACAgIRAh0CKQIJAicCBQICAAIEAgMCAAIEBQICCwIJAgACDQIXAgMCDQINAg0CIQIJAg8CAAIAAikCAwIJAgcCCQIFAgkCCwIDAgACAAIDAgACHwIEAwIFAgcCAwIRAhsCMQIHAgAEAwIVAgIAAiMCEwICAAIHAgICAgkCCQICAwINAgIAAgMCAwICAAICBQICAgILAgACEQIDAgACHQICCQIHAg8CEQICAAIFAiUCBwI3AgsCJQItAgUCFwIAAgcCGQQLAgIFAgI9AgkCCQIvAgsCNQIFApEBAjkCJQQAAgkEBAIAAmkCGQJjAksCAwIFAgACBQIVAk0CBQIDAmsCPQIlAlUCIwIFAj8CJQJ9AhMCOwIfAg0CHQJJAhMCBQITAicCBQIZAjMCAAICTQQFAg0CIQIHAgMCEQIJAiUEAwIJAgcCDQIABB0CywECFQICAAICBQILAgJLAgsCZwI7AgUCHQIpAhkCDQL1BAITAgJ7AkUCAgACAAIfAkcCAhECRwI5Ag8CCwIDAhkCAwIAAgICAwIFAhECAAIAAgACBQICAwIVBAMCEQIFAgACCwICAgUEAgACFwIABAMCAAQCAgQDBAQEAgQCAgMKBAI="
+        },
+        {
+          "operation": "composition_revision_history",
+          "requests": 5492,
+          "errors": 590,
+          "latency_ms_p50": 4.771,
+          "latency_ms_p90": 4714.495,
+          "latency_ms_p99": 21233.663,
+          "hdr_v2_base64": "HISTEwAAFdMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPURAgkCUwIfAhkCMwJBAn0CDwIVAgACCQIFBAMCBwIHAgYJAgkCCwIDAgMCAAIAAgMCAwIFAgACCwIPAgMCCQQJAhMCAwICBwILAgILBAMCCwITBA8CAAIDAgcCAwIAAgACBAUCAAICAgcCAwQCAwIDAgICAwIDAgQAAgAEAgIDAgACCQYDAgACAAIAAgIAAgIAAg8CCwIDAgIABAIAAgMEAAICAwQHBAcCAwICAgICAgUGCwIABAIEAgMEAwQFAgIECwQCAAICAAICAgIABgIABgAEAAIDAgYFAgQJAgIAAgACBAMCAwQEBAIABgIEBwICAgACAgYCAgACAwIAAgACAAIDAgICAwQDAgMCAgQCBgMCBgIAAgQGAgQEBAACAAIABAAGAgMCBQQEAAgAAgQDAgQCAgUEAgAGBgIEBAIABAICAwICAgMCBAIAAgACAAIDAgACBgIAAgMEBwQGAAIGBggABgYEAAICAwIDBgUEAgMCAgMCAwIDBAAGAgICAgICAwoCBgUCAAIAAgcCAgQEAgMCAgMEAgICBwIFBAAGAwYAAgMCAgQGBwIAAgAEBAMCAAQEBAMCBAACBAYAAgAIAgACAwIGAgAEAAICAAQGAAIDBgICAwICBAIABAYEAggGBgICBAICAggGAgIABAYEBgQCAgIGAgYABAQCBAQEBAYIBAYGAAYCCAAEAgIGAgACCAQEBAAEAAgEAggCBAgICAQKBAYCCAICAgICAgQDBAQEBAICBgQCCgIEBAoCAgIGCAIAAgQCBgQCBAACAAIECgACCgIGAgYEBAIEAggIBAIEAAwKBAAGAgQEAggEAgQIAgIICgIEBAgGAAYEAAQCBAYEAggCAgQEBgAKAgICCAYEAgACCAgCBAwABAIACggICgIIAAYCBgYCBAIGAwQEBgICCgMCCAIGBgICBgYEBAgICAQEAgIICgIABAQCBAQCAgQCBAIGAAIKCAUIAAIGBgQCBgICAAgGBgAIAgQIDAIEBgMIBAICCggEAAYCAgQCAgoEAgYEBAAGAgYKCggDBAYGAgAIBgIKBAYEBAQCBAgEBgQEAgYABAYCBggEAwgEAgQCBgIABAYKBgYGBAYCAAwAAgIEBQYGAgIGAgYCCAQCEgACAgQCBgYICAIGAgICBgQACAYAAgICBgAEBAUGBgICCAQCBAQEBgQIBAQEDAQCAAIABAICAgICBgQCBAAGBgQCAgQIAgIEBggCBAYEBAYGAAYICAQDBAgCBgAEAgMCCAoQAgQIBgQACAQCBggCAgICBAgABAQEBAIACAQGBgIGBAAKBgYGBgIEBAICBgACAgIIAAYEAAQCAgQIBgQEBggABAIGCAgCBgIECgICDAIEBAIEAgQGBAgGAAIEAAQCBgQABAICBgYGCAIGBAAEAgQCAgYEAAICAgQEBgAGBgAEAggGDAYCBgYECA4EBgQCAAIACAAGBAICCAQIBAQEBAYEBgAEBgIKBgQCAgYGBAwGBAgECAIABAQGAAQCBgYCBAgIAgQGAAQEAAQKBAIACgIECAIEBgQEAggGBAIGBAIGBgQAAggEBgIKAggDCAgABAAGAgACBgIIAggGBgAGAgIGAgIABgwABgQCAgAEAAYEBAgEAgQGCAYADAYGBgICCAgGAgAKCAQCAgACBAYCAgQGCAQKBAIEBAQGBgAEAgAEAgYCCAAMAAQGBgAEBAIGAgIEAgICBAMCBAIABAYGAggEBAIKAggCBAIDAgQIBgIGAgQEAgIAAgAKAgACBAIIAAQCBAQEAgYIAgACBAIECAoCAggGBgYCBAQCBAIEAAIABAoKAgQABAIEBAAGAgYCAwQCBAQCAgQICAUKAgIAAggEBAICAgQEAAICAgIKAgQCAgIECgYCAgACBAQABgAEAAICAwQEAAICAAQEBAYCAAQEBQQCBggIBgICBAICBAQAAgIGAgIABAQFAgAGAAQABAQEBgQGBAYABgQKBAQGDAQABggECAYCAAgIBgoCBgIGAgIKBAIGAgQCBAoCAgQICAIABgQHCAYAAgQGAAQEBAIGAAIEBAACAgQEBAAGAgYEBAYCAgICAgYOAgQCAgAKBgQEAgYAAgACBAgCBAAKBAICAgICBgMCCgQEBAQCAgIKBAYCAAYCBAQIAgYAAgACBQIEBAYCAgICBggAAgQGAAQABAQABgICAgQAAgAGBAAEBgACAgUGBAICAgIGCAIAAgAEBgYEAgICAAIEBAICBAQCBAICAggCBwICBAIGAwIEBgQAAgAEAgUGAAQEBAUCBAYCBAICAAQEAAYCAwYEAgMCAgIAAgYCAAICAgAGAAICAAQCAgACAgIDAgAEAAIFAgQCBAQEAwIEAgAGAAIAAgACBAIAAgMCAAICAwQGAgYCAAQFBAIAAgICBAICAwYCAAICAwICAAIECQQCBAICAAIECAAEBAACAAIGAwICAgUCAgQCAAQCBgUEAAQFAgACBAACAAQFAgUGAwICAgQDAgUCAgcEDwIFAgUCBQIAAgQCAwIABAMCBAIAAgIECQIECwQEBAACAgICAwIHBAUCAAIAAgkCBQQAAgUCAgMCAgMEAgACAAICAAIFAgIEAwIAAgIAAgUCCQYCBAACAgIDBAICAgMCAgIABAIHAgACAgICAgcCAAICBQICAgIHAgIFAgMCAwICBgUEAwIAAgIAAgAEBgUCAAIAAgIDAgMCAwQFBgQLBAACAwQCBQIDBAIAAgICAwIFAgMCAgAEAgACBQQFAgUCGwIHBAQDAgICAAIAAgQCBwIDAgMCAAIAAgMCAgACCQIDAgACAAIDBAUCCwIFAgcCBAINAgACBQIFBAMEAgcCAAIEAwIFBAIEBwQCAAICBwIPBAIAAgIDAgUCCwICGwICAgUCAAIhAgQJAgUEAAICAgUEAhECCQIFAgkCAwICDQIZBgIEAAICAwIHAgICAgIEBQQCAAIEAgIAAgACBQIAAgQCAwIDBAMCAAIRBAACAgYPAgACAgACAAICAAQCAAIAAgcCBwIDAgICAgUCCwQFAgUCBQQCAgMCBwICAgMCBAILAgACFQIFAgkCBQQAAgACAgcCFwQFBAMEFQIAAgIHAgMCBQICAwICBAINAgMGAAIHAhECAgIAAgsCAAIABAMCBQIVAhcCAAICAgkCAAQAAgcCAgUCAgIEAwIRBAkCAAIEBAIDAgMCAwIXBAACBQIAAgUCAgICBQIFAgIPAgAEAgIFAgACGQIDAgMCAgMCAwIAAgICCwIAAgQNAgUCAwIPAgICBQIAAgILAgACAwICAwQDAgICAwQFAgACAAIAAgkCDwIPAgIHBgACFQIRAgACBA8CBQIJAgIPAgICBQQDAhkCAwIAAgAECwIHAikCAAIABBECEQILAgILAgsCFwIJAgcCBQIAAgMCBwINAgUCAAIDAhcCAAITAgMCAwIFAgkCDwIAAgkCBwJhAgUCBQIAAgMCDQQRBAACEQICDwITAgACBQIFAgcCCwITAg0CCQIDAgIAAgcCAAIDAgICEQQAAgMCAwINAgcCCwIHAgsCAgACBwIRAgIAAgIHAgMCDQQVAgsCAwQTAgcCBQYCAwICAgACBQIDAhECAgMCCwICAAIDAgIDAhMCGwIHAgMCBQIHBAkCAAIJAg8CFQIHAgMCAgMCBQIPAgUCAwIAAgkCAAIpAgUCAwICBQIpAgACAAIHAgUCCwIDAg0CDwINAi8CBwIAAgUCMQIHAgkCDwIABAsCEQIVAgkGCQIAAgsEBwIFAgcECwIHAgACAAIPAgIAAg8CBwIDAiMCGQICAAIVAgIAAhUCAAInAgACFwIDAhUCAAILAgIAAg0EDwIXAgcCAAIAAgUEBwITAiUCFwIdAgIJAj0CDQIDAgAEBwIjAgACBQInAgAEAAIpAg8CGwILAisCAwQDBAIDAg0ECQIPAikEDQIHAgcCAgUCDQIDAgQCAwIAAg8CBwIhAgMCBQIEAAINAgkCEQICAhMCAiUCAwINAgIHBAMCAgsCFQIDAiMCFQIAAgIDAhsCAAQDAhMCAwINAgkCBQICBQIAAgIFAicCAwIdAgUCBQIbAgcCHwICAwIAAhcCBQQAAg8CAgUEAAICBQICAgUCAgcCBQIPAgUCAwIvBAQTAgUCBQIfAg8CCQIfAg0CKQILAgACGQIjAkMCFwIJAgMCCQIpAgcCEQIAAgsCBQIJAgUCCQIJAg8CEQIHBAMCBQIDAgcCFQITAgIbAgkCEwIEBQIAAgsCCQIbAgUCVQITAhMCJwIxAgMCAAIVAgsCAgkCDQIDAgcCAAIDAgIPAgILAhECAgcEDQIRAh0CBwIfAhECAAIFAgACAAIZAgkCCQIAAgIhAhMCDQITAgUEDwI3Ag0CDQIJAgMCBwQCCQITAgUCAAITAkMCFQIJAgIfAgIZAgsCAwIDAgsCCQIpAhcCLQQAAl8CBwIZAkMCOwINAhcCIwIHAgkCBwIfAgUCAgkCBwILAicCLQIPAgACBQICAhMCAwIJAhUCBwILAiECDwIRAgcCCwIbAgACJwILAhkCMQIPAg0CAgUCAgcCDwIZAgUCAAIVAhMCBQQRAgI1AgMCBwIAAgMCCwILAgcCFQIHAhECDwIJBAACAg0CAwINAhMEEQIFAhUCBwIAAikCCQIHAgMCAh0CBQICAgcCAgkCAhECAAICAwQLAisCEQIHAgACGwIHAgINAgACEQQbAhsCCQIPAhMECwIHAgsCAhcCAAIAAh8CEQIXAg8CJQIRAgIFAg8CIQIdAj8CHwIPAg0CBwIAAg0CewIHAg0CLQJVAiUCKwIJAgUCIQITAicCBwINAgACHQIZAkMCAg0CAwINAgACHQIlAgsCLwIxAgMCBwIVAgACPQIFAiUCOQIDAgIRAlECIQIPAgIAAlUCFwIbAgACCQINAgcCFwIJAgsCIQJRAgkCBQIVAh0CAAItAgMCEQQFBAsCDQIFAgsCBQINAgsCDwIHAg8EAgMCAwICIQIAAgACBwIFAhECAgUCAwIDAgACBQICBwIAAgkCAAICEwICDQIHAgsCAAIABBcCBwIPAgUCDwIFAjkCCwIVAi0CCQIAAhECEwIPAgIrAhECIwIAAhcCFQIEAi0CAwIFAgMEBwIAAgIDAgIFAhsCAhMCFwILAgkCBwITAgUCBAACFQIDAgIdAgMCHQIHAhkCBwIHAgMCDwIDAgUCAAIdAiUCJQIhAg0CAAIhAhUCBwIDBAIXAhUCBQIJAg0CBwIFAgACAAIAAgACCQINAgILAhECAgIFAgACAAIDBAUCIwIDAgIDAgcCAgUCCwIPAhMCDwIVAg8CQwQLAisCHQILAgkCAisCIwIZAhcCAwINAisCAwICBQICDwJVAiMCCQIhAjECIwILAisCAgcCFwIHAhkCAgMCAAICLQIDAg0CCQIPAgACAgIDBAkCBwIABAAECQICAwIAAgACCQIFAgIAAgACAgAEAAIAAgQABAsCAgMCAAICAwIRAiMCCwIAAgUCDwIPAgkCEwIHAgUCJwINAhUCHwIRAg8CBAIAAiECBQIHAgkCBQIPAgUCAgkCEQIFBAACAAIDAgACBQQCAwIAAgICBwIDAgACAwIAAgkCAAIAAgUCAgkCAgIAAgICBwIHAgUCEQQAAgACAwIAAgMEAgACBQIDBAAGAgIDAgMGAwIFAgUCAgIDAgAGAgMCBAAGCwIFAgIDBAACAgIEAAIDAgMCAgUECQQAAhMCAAILAgIRAgkCDwIPAg8CDQIFAgACAwIVAgUCEQIXAgsCAwIDAgsCAAILAh0CLQIbAhcCCQIXAgUEAhcEBQIRBBkCGQIPBBcCGQICJwIJAg0CBQIJAgQRAgkCDQIDAgsCBwILAgIDAg8CBQIAAgIRAhMCAgMCAwIEAwICAwIDAgcCAAIAAg8CAwIAAgkCAgUCAgICAAIEAAILAgIFAgIAAgIJAgICBQIRAgIZAgIRAgUCAhMCBQIDAgUCAAIZAgACFQILAg8CAAIHAgkCCQICAAIDBAcCCwIDAgkCAgUCAgsCBwIDBAACAgUEBAITAgMCCQIAAgACCQIFAgUCBQIDAgMCKwIDAg8CGwIbAgIPAgIFAgsEFwIFAgACAAIDAgkCBQIHAgACDQIAAgIDAgACBAACBQIDAgIHAgMCDQIPAjECBwILAgIAAhMCAwJzAgkCAwIHAj0CCQQAAgIRAgACBQINAgIAAgIFAgIAAgUCBwQABAAEAAICAwQEBwIEAgMEBwIFAgACBQQKAgIFAgIFBgQHAgAGAAQCAgUEBQICBQICAAIHBAIAAgICBAUCAgQAAgMGAwIEAAIDBAIAAgACAAIEAgkEAgIAAgIDAgAEAwQCBAACAAQFAgUCAAICCwICFQIAAgAEBwIHAgIFAgUCBiECAAIHAgMCAwQNBBUCAwQCAwILAgACAgICBAACBgQAAgUCAgQDAgIAAgACAgIHAgMCBQIPAgILAgMEAAIAAgkCAgAECQIZBA0CBwIJAgIHAgkCFwIdAgIABAMCCwIFAgMCGQIECQIRAgcCCwICAAIDAgMCBQIABAUEAgIAAgUCBQICBQQDAgQFAgIFAhECAwQNAgMCAwIDAgUCAAIEAAIFAgMCBQIJAgIHAgkCAgIDAgQLAgACAgsCAgIEAgIABAUCAAIVAgcCAwIAAgUCCQIJBAcCBQIAAgMCAgUCCQIFBgIAAgIDAgUCBwIJAgkCAwIHAgUCAAICBQIAAgQDBAIEAAIGBAIGBgIABAICAgACAgIAAgMEJwIDBBECUQIxAikCAwIPAg8CBwQXAhsCHwIAAhECEQIDAg8CHwIjAgUCDQIDAgMCFwIAAg8CBwIVAgIHBA8CGQIAAhUCBwINAgUCBwINBAACCQIDAgILAg0CBQIJAgIAAgMCAwIAAgcCIQIJAgUCHQIFAhECCwIEAgQAAg8CGQITAgMCCQIAAgIFAg0CAwIJAgIFAgIFAgUCFQIFAgMCDwIFAg8CHQINAgACAAINAgcCBwICAAJdAgACAwICAgIAAgkCFQIEBwIFAhECCQIFAhMCPQIlAgAEBAMEBQIJAgACDwIJAgUCAhUCAiUCAwItAgcCGQIJAgsEAgIEBgQGAg0CAgICBAMCIQIFAg8EBQIAAgcEMQICAAQDAgACCwIZAgMCBAACAgcCAwIDAgITAgICAAQFAgIAAgMCBAQEBAQEBAAIBgIABAgEBgoCAwIAAgICAgQABAgEAgYKBAIEAgIEAgACBAMGAwQCAgQCBAICBgIAAgMCGQIAAgUCAhkCEwKfAQIhAjUCCQIAAg8CdwI9An0CKwJfAgACAwINAgkCNwINAjcCbQIECQITAgkEAAIABAMEAgQCBAIEEQIDAgICAgAEAAIJAgINAgUCAgkCDwIDAgICAwIPBAkGAAQJAgYGBgIGBgQGBAoABAYEBAACAggABgYEAgIEAAYCAwI="
+        },
+        {
+          "operation": "composition_update",
+          "requests": 409,
+          "errors": 398,
+          "latency_ms_p50": 9.287,
+          "latency_ms_p90": 13123.583,
+          "latency_ms_p99": 21315.583,
+          "hdr_v2_base64": "HISTEwAAAzAAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAIMaAtsEArEBApEBAmMCLwItAhsCCwIXAhECAg0CAwIJAhkCAAIpAkECYwJNAgsCCQIbAo0BAgUCCQIZAhUCgwECAg0CoQECFQI1AikCHQQxAhcCAwIZAgkCPwIDAh0CTQJJAmECDQILAg8CbwIlAhcCAg8CJQIbAgIZAiMCDQICAwIHAhkCCQIPAgcCAm0CCQIAAgMCEQIFAgILAgMCBQIdAgMCCQIVAgcCLwIFAg8CHQIrBBMCOwIFBBsEEQILAhsCIwIAAgACAwIAAgIAAgIFAgACAwIAAgkCAAILAgACCwIDAhUCDwIPAhECFQQHAgILAhsCBQITBAUCAgIDAgACAAIJAgUCDwIPBAACAgIdAgIHAg8EBAUCDQICFwIFAgMCCQIAAjkCAAIPBA0CFwINAgcCKQIVAhECAwIhAgACCQIZAhkCGwIJAgkCAwIDAgkCAwIJAgUCAgkCAgMCAgACAAILAhcCEwICGwIHAg0CAwICFwIAAhECEwICBQIPAiECJwICFQICBQIbAgMEEQIJAgACAAICFQI7AkUCEwJNAh0CqQECdwIlAiMCLQJjAkMCUQLDAwIjAt8DAnUCFQLLCQJVAvUBAgsCqwECrwMCZwK9AgL7AQKBAQICJQL1AQKlBAKHAQLLBAKNAQLfAwJXAqsCAv8CAokBAtEBAucKAp8KAoMDAo0DAo0DAi0C0QMCdQJhAtsCAqkBAgKTAQIfAlsCJwINAo8BAqsCAgkCeQIjAnECcQIdAnEC8QECdwJZAucBAoUBAjsC9QEC7QECZQKpAgILAr8BAncClwECzQECPQK1AQKHAQJFAncCSQKFAQIAAiECKwINAjMCTQI3AjMCjwECKwI7AksCRwICSwITAlkC2QECAAJZAkkCFwI5AiECUQIhAm8CWwIJAlUCIQIFAkMCHwIjAg0CEwJLAlsCAjUCYQInAiUCGQIbAgACBQIZAhUCFwJBAi0CVQI1Al8CZwJrAi0CDQJpAjUCEwJnAicCAAJlAkUCBQIRAhkCHQIrAgIhAhkCFwIfAiECAAIHAiUCKQICAwIVAikCHwIfAgcCAwIAAg8CDQIFAg=="
+        },
+        {
+          "operation": "contribution_commit",
+          "requests": 143,
+          "errors": 0,
+          "latency_ms_p50": 61.343,
+          "latency_ms_p90": 16621.567,
+          "latency_ms_p99": 23560.191,
+          "hdr_v2_base64": "HISTEwAAAUIAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPc1AvsEAqcBAssKArsDAq8KAqMLAjkCEwJVBGUCBQINAjcCCQIEBQIDAgMCAwICAhcCAAIJAgcCHQJLAgMCFwIHAhsEEQIdAgACKQIRAhsCDQInAhcCAgcCEwIHApcBAgcCAgsCAhkCAwIFAgUCAgcCGQIFAhcCSwIRAskBAgkCBwI5Ah0CHQJNAh8CAwIjAq0BAg8CIwIAAsMBAkcChQECDwICEwJ7AnkCJQLtBgLzBAJfAj8CqwcCqwMC3QICcwKRGAKZBALRBwKZAQKfAgL1BALHAwLdAgLrAQLTAgLxAwL1AgLfAQL9AQKdAgKBAgKbAgLNAQKNAgLdAQLFAQKhAQKXAQKNAQKFAQKnAQK3AQJbApkBApEBAgMCzwECvwECgwECBQJzAjUCbwJTAo8BAgsCYwJDAlMCDwILAh8CBwI="
+        },
+        {
+          "operation": "contribution_read",
+          "requests": 590,
+          "errors": 0,
+          "latency_ms_p50": 7.027,
+          "latency_ms_p90": 15376.383,
+          "latency_ms_p99": 21479.423,
+          "hdr_v2_base64": "HISTEwAABFIAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAI0ZArsCAk0CEwLTAQI1AicCRQJLAn8CDwIHAg8CGwIAAgsCBwQCAAIJAhcCAwIJAg0CDQICDQITAh0CBwICAAQDAgACAwICCwIAAgMCIQIDAgkCBQIJAgsCCwIAAgkCDwIJAgIAAgcCBwQPAhMEAwILAh8CAwILAhMCDwIFAgMCGwIDAgACAwINAgUCAAIJAgIAAgACAwIDAgcCHQICBwIPAgcCAwIDAgACFQQAAgIFAgILBAIRAgMCEwIDAgIFAgkCEQIHAgMCAAIDAgcCBQQFAg8CAAIAAgACAgcCAAIHAhECAgMCBwQLBAUCCwQFAg0CCQIRAgQCBwQPAg8CFwINAgMEAgkCAwIFAgACIQIDAgcCCQQLAgQ3AhcEBQIAAhMCAAIbAgACKwIDAgACBwIDAh8CAwIRAhcCDQIHAhMEAgcCAgACDwIJAgIFAgAECwIFBAsCFwICGwIFBAMCBwYDAg0CAgsCEwICBQIPAhcCAgICGQINAgQJAgsCAwICBAIHAg0CJwIAAgUCCwIZAgUCAAIAAg8CBQQAAgsCAAIHAhkCAwIDAhkCAgcCAAINAgUCBwQDAgMCDQIAAi8CBwICEQIDAgsCEQQHAh0CEQIDAh8CEwIvAg8CFQIfAgACDwIRAhcCBwIvAgcCCwITAhkCJQINAlMCVQIHAhECCwI7AgIbAhsCAAI9AiUCIQIPAgsCNwIhAjMCAi8CAAILAhMCGwINAgUCBwJFAgsCBwJ9Ag8CAAI3AiUCUwItAgkCEQITAiMCGQIvAgJDAgJPAnsClQECFQKZAQJjAvEDAicCPQIxAlMCuwECGwLxAwIXAokBAokBAr8CApMEAtcBAkEC2QECgQEC3QMCnwQCawICXQI9Ah0ChwICWQKbBAJzAl0CtwMCFQLxBAI3AjUCZQIfAtkCAuEEArEFAuUCAsMKAjMC/QUCUQJhAp8CAskBAi8C2QUCIwITAtUBAlECAAICEQJTAisCpQECLQIpAgMCdQIZAnkCWwKvAQLRAgJvAhUChwECcwInAq0BAgMCHQIVAl0CYwIfAoUBAh8CZQJBAtEBAmkCYQIvAhcCMQJbAgcCcQJbAkcCAjcCOQJ1AiMCDwJ1AhcCEwJNAl8CTwItAg8CZQIvAhcCGwJLAmcCKwIHAk0CXQI3AkkCJwJHAlUCDwJvAkUCUQJVAlcCXQIHAhMCawIxAhUCEQItAicCHwIVAiECLwIfAgkCAwIfAiECGwINAjsCGwInAgUCJwJBAicCAhUCAwIHAgACDQICLQIbAgcCKwIfAh0CFQILAjMCNQINAh8CLwI9Ai0CBQIpAkMCJwIXAhkCOwI7AjUCBQIzAh0CJQIRAjMCBwIJAiMCEQIAAgMCEQIdAg8CCwIJAg0CMwIJAg8CCwINAg0CEQITAg0CGQINAgICGwQVAhECAhECEwICEQQHAgkCDQIFAgQCAgMCAAICBwIJAgMCAwIE"
+        },
+        {
+          "operation": "directory_create",
+          "requests": 46,
+          "errors": 0,
+          "latency_ms_p50": 5.727,
+          "latency_ms_p90": 98.879,
+          "latency_ms_p99": 1323.007,
+          "hdr_v2_base64": "HISTEwAAAHAAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAANspAk0ClQMCIwLLAgI5AgUCAAIRAg8CHwJlAlkCBwIlAgUCCQKfAQJnAhcCFwIVAgACSwIZAkMC2wQCgwICxQECBwItAtkCAh0CnwQChQIC9QYCQQLZAwKRBQKlBQLXBgL1EQLnDwK7BQKnHAKxCgI="
+        },
+        {
+          "operation": "directory_read",
+          "requests": 5158,
+          "errors": 574,
+          "latency_ms_p50": 5.011,
+          "latency_ms_p90": 5668.863,
+          "latency_ms_p99": 22085.631,
+          "hdr_v2_base64": "HISTEwAAFVwAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPsQAnsCjwECCwIbAh8CAAIAAg8CLwICAAIHAkkCBwIjAgMCKwItAhsCFwIJAgUCAgUCBQIXAgIGEQIAAgMCCQYAAgICAwICBAIAAgICEwIDAgkCAgcEAwIDAgQDAgUCCQICBwIDAgACAgsCAAIDAgACBwIAAgIEDQIAAgIAAgICAAQCAAIFAgMEBwICAAICAAIAAgIDAgACAAIAAgIACAcCBQICAAICAAIDBgcCAAQABgQCAgICAAIAAgACAAIFAgQDAgMCAgcCCQYABgQDBAMCAwgABAIAAgUEBAUCAAQAAgICAgQEAgIAAgQCBQQCBgICAwIDAgIDAgcEAwIEAgMEBAACBAACAAIEAgQDAgAEBQICAgMCBAACAAQEAgICAAYEBgAEAgIABAMEAAIACAIEAgIDAgIDBAIDAgIDAgsGBgICAAIGAgIAAgICAgACAgIDBgQAAgIEAgYCAgICAgAEBwQCAgICAgACAAICAAQIBAgCAgIEAgQDBAUCAgQCAAICAAICBQQCAgAEAgIEAgMCAgACAgYIAgAEBAICAgQAAgMCAwIABAAGAAIDBAIABgQAAgQCCwYFAgICBAIDBAICAAQCAwIDAgIABAQCBAICAAIEBgIABgQABAYDBAYCBAICBAYGBAQIAgYEBAIIBggEBgQCBgYIBAgCAgAGBAQEAgIECgQAAgQICgYEBAIABAgAAgIECAQCAgQGBAQEAAQIBgQCAgYEBAoEBAIGBAQEBAYMBAQICgQEAgIGBAQCBgYGDAIGAgIEAgwEBAQDBAIGAAQCBgQEBAYDBgIICgYEBAQIAggKAgAIBAAEBAAEBAQGAgICBAAGAgYIAgYABgACAgQABAMGDAgEBgQICggGCgQAAgIEBAIEBAQEBAYEBggEBAICCAQGBAQCBgIECAYCBAYEBgIEBgAGAgYGAgQABgYEAgYEBgoGBAYEBgoEBAAECAQIAgQCBAAEBAQEAAQECAgGAggGBgQECAACCAYGAAIEBAQEBAIKBAgGAAQICAIEBAIIAgIKBgQKAAYAAggCAgAGBAAKCgQCAAYEBgQCAgoEBgoCAgAEBgYACgIGAgIGCAQCCAQABAAGAgQGAgYCAgQEBgIIBAAGCAUGAgACCAYABAgGAgYEAAICDAICAAIEBAYEBAYGBgIEBAYKAgIIBgICAgYEAggCBAAICAQCBgQEAAQCAggCAgYICAQCBAYCAAQCAgQGAgICAAYEAAgEAAYECgAGAwYABAoCBAICAgIGAgQIBAAEAggGAAIAAggCBAQABAYIAgIEBAYCBgYCBAgGAgICAggEAgAEBAICBgIGBgIABgICAgQECAQEAgYGAwQGAAICBgYEBAIAAgAEBgIAAgMEAAYKDAQAAgQEAAYCAAYCBgQEBgMIBAgEBgIAAgMCCAQIBgICBgIEBAAGDAACBAQDAgIEAgYEBgICAAICAggABgICAAQAAgYKAAICAgIDBAIIAgACAgIEBgQCAgQCBgIGAgAGBAYDAgQCAgYMBAwCAggAAgYCAgYEAgICAgIEAgIGBAQEAAYEAgQCAAIDDAIEAgAIBQICAgACAAQCBgICAgICBAQCBgACAgICAAQABgIEAAQEAgIMAgIEBgYCBAACBAIABgQCAgoGBgIGAAQACAQECAQGAggABgICAgIGAgICBAQCAgYABAIABAIIAAoDBAYCBAACBQIDAgAEAAICBAAGCAICAAQEAgMEAAYCBgAIAgQABAICBgIABAYEAAQCAgAEAgQIAgQCBAMCAgAIBAUEAAQGBAACBAQCAgIAAgAIAgIABAAGAAIEBgIGAgQEBAICBwIDAgIEBAYHBAgEAwICAgACAAgCBAIEAAICAgQEAgMCAgAEBAACAggABgAEAAQEAgQIAAQABAICAgQEAgACBAIEAgACAgMCBgAEAwICAgIEAgYAAgIAAgsCBAIEAgQCBAYGAgYIBAgGAgICAgIKBAIIAggCDAIMAgICBAICAAIEAwYKBAIEBAYGBAQEAgQCBAQABAICBAICBggGBgACAgAIAgAGAAICBgQEAAYCAAIIAgYGCgIHAgIIAAIFAgwEAAIGAgQCAgAEBAAEAgQGAgICAwQCAAICBAICBAICAAICAAQGAgAEAgQABgIIAgMEAAICBgACBAQAAgAEBgIEAwICBAICAgQCAgMEAgICBAwCAgQEAgQCAgAGAgIGBQQCAgMCAgIFAgoCAAICCAICAAIDBAQCAAIJAgQGBgQCAAICAAQGAgUIAAIFAgICAAoAAgACAgIFAgAEAAQIBAIEAgIABAACAgACCAYCAAIDAg0CAgMGBAIABgQCAAIGAgIEBAMCAgMEBAsEAAICAgICBAAEBwICAAIAAgICAAQCAgIABgAEAAQCBAYCAgACAwIDAgACBgIFAgMCAgIEAgIAAgACAgACCQICAAIGAAQCAgcCAgMEBQQGAAIGAAYCAgYCAAIEBAICAwICAgQCAAIAAgACAwICBAMEAgACAAIABAQABg8EAgACAwICAAIEAwICBAIABAQHAgUECQICAAIFBAACAwIJAgACBAACAAQGAAIAAgQAAgAEAgACBAACAAICAgAEBAICAAQCBAACAgAEBQIEAAYJBAkEBwQCAwIDAgIABAMCAAQDAgUCAAIAAgACAgMCAgsCAgAEAgUCCQQCAgILAgMEBwQDBAMIAwIFAgIHAgUCDwIAAgIDAgUCBQICAAIABAsEAgIHAgIHAgQCAgUCAAICCwIAAg0EBAACAAILBAACAgMCAgIAAgUCAgIDAgACBAACBAACAwIJAgMCAgACAAIJBAICBAIAAgUCAgIJAgQAAgQFAhECAwIABgIDBAIDBAMCCQIAAgcEAgIAAgYFAgIHAgAECwIABAcCCwIDAgICAAICAAYHAgIJBAIDAgcCAAIDAgMCAgQFAg8CDQIFAgACAwILAgcCAgMCBAICAgACAwICAgAEAgACAwIDAgACDwQCBAIHAgINAgMCAAIFAgMCCQICAgIFAgkCCwIECwIAAgMCBQIFAgQJAgACAg0GAgIAAgUCAwICBQIJAgACEQIAAgAEAgICAwQCAgIEBQQDAgAEBwICDQIAAgMCAAIJAgACAgUCAAICAgMCAwIAAgkEAgACAgACAgMCAAINAhECAAIEEQICCwICBQIJAgACCAUCAwIJAgACAAIFAgMCFQIDAgUEBAcCEwIDAhMCAAIABAMCBAMCEQIEBwIHAgIPAgICAAICAgACBQICBQIDAgINBAsCCQQHAgUCAAIVAgcCAgMCBwIFAgIAAgMCAAIDAgIDBAkIAAICCwIZBAkCAwITAgIDAgAEAg0CBQICBQIJAhMCBwIbAgMCHQILAgIJAg0CAAIRAg0GAiUCAgACAAIbAgACFwILAhcCAwIAAhECDwIJAgICAgACBwQHAgACDQIVAgsCPQIFAgkCEQIFAgACAiMCAAILAgUEFQIAAg0CGwIHAgsCKwICEQICAgACAwICAhECCwIDAgMEAgcCBQIFAhcCAAIAAhMCAg0CCQICAg0CAAIDAgsCDwINAhcCAwICKQIRAgACCwIAAhMCCQQCBQIHAgACAwIAAgAEBQIAAgACDQIHAg0CDQIHAhUCGwINAgIDAgcCBQICBQQJAgsCAwICBwIJAgACHQQCBQICAwICAAIPAgIFAgACDwIJAgsCCQIhAhMCAgIRAgsCCQIFAgkCCQIRAgACFQIAAgMCBBsCBgACAgICBwIDAgkCBwIVAgsCBwILAhECMwIDAgACBQIRAicCBQICEQIJAg0CBQIAAi8CAgcCAAQDAgUCAgMCBQIJAgACAgUCMQICDwINAh8CEwIAAgMCMwIjAhMCIQILAjUCAAIAAgsCIwIdAgACDwIXAgcCCwIAAgUCBAACEwICAgkCBwIFAgACKwIFBA0CBwICBwIAAgUCLQIZAhsCCwICAgICAg0CKwIJAh0CBQIJAgIHAgIFAgACIwQhAgkCDQIXAhECAwICAl0CDQILAgMCPQIFAhcCEQJHAgMCCQIJAi8CFQIAAgItAgMCHwIAAgMEBwQFAgMEAwIDAgIXAgcCAwIZAgkCAAITAhcCBwQTAgICAAIFAh8CHQIHBAUCEQInAiUCDQIPAgUCEwIAAl8CGQINBAICNwINAgkCIQIDAg8CAwIAAgUCHQIHAgInAgIFAgcCAwIHAgUCBwILAgIAAg8CBwIJAicCAAIFAgACBwIDAgMCAhECBQIDAhECAhMCBQIDAhcCBwIFAgMCCwIAAh0CBQIDAgMEGQIAAhECCQIHAhcCAgUCAAIHAg8CAAIRAiMCAgIABAMCAwICAwIHAgUCBQIJAgMCDwIDAgMCBQITAgcEBwQPAgkCAhECAgICAAIHAh8CBwIPAgkCBwIFAg0CAAIDAgMEAg8CDQIAAgMCNwJPAhkCAk0CAhECCQILAgcCCwILAgIAAhECAwIXAkMCRQINAgUCCwILAgACHQINAhECCQI5AgMCCwIAAgIJAgkCAAILAhECBwITAgcCGwIrAgUCCQIVAgcCOQIDAhUCBwICBwIFAh0EKwIPAhECEwIlAgACCwInAgIhAg8CAwIZBAACCQIHAhECBwILAg8CFQIAAgUCIwIXAgMCJQICBQIVAiECBQIFAgUCBCECDwIDAgUCEwILAgkCDwQPAg0CDwIHAh8CFwJTBBsCEQILAhMCDQIdAgACBQINBAkCDQI3Ai0CAhMCAAIbAgUCLwIFAkECLwITAlcCEQIzAgICOwIbAgcCBQIFAi8CEQJvAgQdAgJBAhMCBwILBBUCJQITAi8CQwIDAhUCPwIlBCUCFwQ9AikCJwIJAgACCQInAhMCAwIHAiMCAAIJAmsCCwITAiUCFQIrAgkCPQIRAjMCFQIbAjMCRwIJAgJDAhkCOQINAlkCMQIPAgIdAicCGwILAh8CPwI5AgcCBQIFAgMCAAITAgACCQICAwIFAgkCAAIFAgACAAIDAgQAAikCAgACEwIpAgsCAAIHAg8CAwIAAgsEAgkCAhcCDQICAwIDAgACAgMCAgICBwIJAgUCAAIDAgMCAwICBQQAAgUCAgACBQIFAgUEAAIEEQIAAgICDQIEBwIDAgsCAgIAAgkCFwICBQIPBAACBQIDAgcEBwIhAgACAAINAhECAAIHAhUCBQIjAhUCAwIbAgcCOwIAAgMCCwIXAkMCDwIJAgkCLQICAwIdAgcCEwIAAh0CBQIFAh0CAAIFAgACIQITAgcCDwIAAhUCCQIPAhcCIQIHAgIZAgILAhMCEwICEwIDAgkCBQIFAikCDwIXAgKzAQIHAhkCBQIbAgACAgsCBQIFAgIDAhUCAgMCBwICAwIPAgUCAwICAgQLAgkCCQIDAgMEAAQAAgQAAgMCAAIAAgMCAgIFAgACAgICAgMCAAIHAgICAgMCAAIAAgMCAwYHAgQCAgMEAAQCBQIABgkCAwQHBB8CBwICBQILBAMCGQQHAhMCAwIPAgACEwIHAisEDQIHAg8CBwIAAgUCBQIdAgUCDwITAgIdAgIdAgcCDQIAAhkCFwIAAgUCAgMCAhMCAgACAiECBwINAgsCBQItAgUCCwICCwIDAgkCCwIABAsCDwIHAgMCCwIDAgIAAgIDAgQCAAICAgACAgkECwIJAgkCDQIDAg0EAhECAAIVAgUCCwICGwIFAgMCDwILAgcCBQIAAgIVAg8CBQINAgACAAIPAgsCDwIbAiUCEQIZAicCBwIFAgACEwIHAg0CBQIhBAcEAAICCQICDwICBQICAAIDAgIABAACBAICAAQEAAIEAgQGBAICAgMEAgICBAMCBwQFAgUCBQQCAwICAwIDAgIABgACAgAEBwIAAgAGAwICBAQDAgACBwIAAgACAgMCBAIEAAQDAgICAgACAAICCQITAgkCAwQLAgcCAgIAAgIFAgQHAgACAwIABgMCAgMCAgMCAgIJAgILAgIJAgsCAgsCBwIJAgkCBQIAAgUCDQIFAgkCBQIDBAcCAgIABgsCAAIFAgkCDwITAhcCCQINAgcCDQIDAhUCCQILAhkCMwITAgIRAhMCAwILAg0CCwInAhsCFwIRAhUCIwIAAgACCQIDAgUCDQIFAhsCHQIXAgsCAwIHBAACCwIFAgIZAgcCFQIFAhECFwICBwIJAgQJAg8CDwIAAg0CDwIDAj0CDQILAgkEFQILAgMCAgcCEwIXAgcCDwIDAhsCCQICEQIPAgMCEwITAgMCAwIAAg8CBQICBwIHAgUCBwICAAINAgMCAAIJAgMCAwIDAgACCQICAgIEAgcCBQIFAgUCCwIRAgACAAIABAMEAAQNAgMCBQIHAgkCAgkCAAIAAgAEBQIEAgACAgMCAwIAAgICEwIDAgsCFwIbAgkCCwIxAgIFBAsCAAICBQIHAhcCCwIAAgkCDwIAAgUCEwIAAgACAwICAAICCQIABAMCCwICAgAEBAACBQIEAwQFAgIAAgACBgIHAgACAAIDAgUCBQIDAgIHAgMCAAIABAIFAgIDAgUCAgIDAgQAAgQAAgILAgcCAAIDAgMCAAIAAgMCAAIFAgcCAAIFAgMCBwIHAgkCAwIHAgUEBQIDAgUCBwIAAgUCAgICAAQCAgQGBAICAgIHAgMEAgIFAgIEAAIABAQGAgQAAgICAwYABAIABAACAgMCAgMCAg0CDwIJAgIXAgUCAgIDAgMCAwIHAg8CBQIJAgcCAwICAwICBQIDAgIABAMCIQIDAmsCIwIRAjMCAAIDAgIHAgcCAgcCBQIHAgcCAgACEwICAgIEAgIEAgACAgACAgACBAMCFwIJAgACAwICAmkCJQIhAgIJAgACAgACAAIAAgILAgUCBwIvAjUCAhECBwIFAgIPAgAGAwIHAgIAAgkCAAIHAgMCAg8CAwIAAgACJwIDAmsCAwItAhsCAwICBwI7AgsCNQIDAgkCBwI3AhsCLQI/Ah0CFQIPAi0COwILAhECCwIhAhsCEwJjAksCAAJZAhMCAAIHAgUCRQIJAgACAgAEBAQCAgACAgIDAgQCAgQEAAICCQYJBAQDBAACAwQCCQIFAgACAAICAwIABAACAAIDAgYABgAGBgIEBgQIBAICAgQDBAIEAAQCBAQCAAIDAgACAwICBgYEBAQGBgICAgoIAAgEBgQEBgACBgICAAQCAgICBAYXAgICAAINAgACAAKRAQJrAnsCCwKhAQIXAgAGCQIXAgIDAgAEBAIEBwIJAgMCCwICAAQAAgACCQIABBcIBAIFAgMGBAACBAMCAgUCAwgEAAICAgcCAAIC"
+        },
+        {
+          "operation": "directory_update",
+          "requests": 73,
+          "errors": 0,
+          "latency_ms_p50": 13.207,
+          "latency_ms_p90": 8351.743,
+          "latency_ms_p99": 20381.695,
+          "hdr_v2_base64": "HISTEwAAALwAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAMUmAhsCsQEClQECOwJXAgkChwECGQIHAq8CAlcCeQIxAgMCGwKnAgIpAjcCBwIlAtsBAisCCwSvAQIDApMBAkkCNwKDAgKbAgLRAQKLBwJDAm0CkQEC2QECvQICKwKlAgKPAQLlCwKxBQLnBALFBAK/AwLbAQLJKQIPAnUCwQ0CjwUC9QcC8QECnwgC2wUC2wMCgwQClQMC+QECtQIC5wEC5wICgwEC8QMC/wEC2QICvQICaQJ5AikClQoC"
+        },
+        {
+          "operation": "ehr_create",
+          "requests": 73,
+          "errors": 0,
+          "latency_ms_p50": 9.191,
+          "latency_ms_p90": 3590.143,
+          "latency_ms_p99": 9175.039,
+          "hdr_v2_base64": "HISTEwAAALgAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAMkjAq8BAh8CTQInAj8CgwECxQECrQECHQITAgAClwECvwECiwECNQIJAiUCZwLFAgICXQI/AnsCTwKFAQJbAjUCpQIC5wECAAK/AgIXAmUCbwJZAiECowICNQLHCwKPAQJxAusCAocBAh8CmQoC4QUCAv0mAv8JAl0C4QIC0wsCLQKfBQK7AQL9BwKBBQKdAQKRBAKfAQL7AQKRBAJVAjsCvQICgQQCtQEC0wMCzQUCzwQCswICIQI="
+        },
+        {
+          "operation": "ehr_read",
+          "requests": 526,
+          "errors": 0,
+          "latency_ms_p50": 6.199,
+          "latency_ms_p90": 13033.471,
+          "latency_ms_p99": 19103.743,
+          "hdr_v2_base64": "HISTEwAAA+0AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAALkVAoUBAsUBApEBAkMCEwJfAk0CXQJnAhECMwI1AgACIwInAhkCOwITAgsCAgMCAhkCCQINBA8CAwIXAgIJAgQAAgMEFQIDAgkCCQQAAgIAAgUCBQICBAkCBQIDBAkCCwIHAhMCAgIDAgIRAhECAgIFAgACAwIFAh0EBQIDAgUCAgkCBwIJAhECAgIDAgQXAgcCCQIAAgcCBQITAhECDQIAAgACBwIHAhMCDwICFQIPAg8CAwINAgIFAgMCFQITAgkCZwQDAhECAAILAgITAgkEIwIJAg0CBQIDAgsCAwIhAhUCAgACBQIJAgcCBQIAAgIFAgIxAh0CJwQFAgACAwIRAhMCIwIPAiECAAIHAgIDAhkCAwJrAhECDQITAgACIwIHBAICDwIdAgMCAwIAAgMCFwILAhkCIwIFBA8CJQIJAgMCAgMCBwIAAgACAwQPAgsCAAQJAgMCAgIAAgcEBQICDwICAwIXAgcCAAICBQIfAgMECQIXAgcCDQIJAgACBQICAAIVAgIbAgMCHwIJAgsCDQIHAgACAAIrAhsEAwITAh0CCQINAhMCBwIVAgInAjMCAwIDAicCBwICAwIVAjECGQIbAgMCAisCKwIAAh0CHQIHAh0CAk0CAk0CEQIRAicCPwICIQIbAh8CDQKxAQIZAjkCBwIZAg8CAo0BAgcCIQIRAgMCqQECFwI9AjUCFwIHAgMCAj8CaQItAsUBAgkCrQECWwL5AQIpAvMBApEBAq0BAk0CqQICXQKDAQL/AQK7AgIAAqMCAtkBAqcDAqkBAiEC+QcCEwKxAQL3BAIZAv8BAg8CDwKhAwKRAwIlAoEBAm8CnwcC+QQC7wMC9QcCzwICuwIC/QIC4QYCdQL1AQKvAgJhAoEBAhECKQJHAkUCvQECBwKhAgKbAQJ/Ag0CAAIjAq8CAoUBAoEBAgUCUwJNAhUCCQKFAQI7Ag0C2QECyQECowICbQIJArcBAlECRQItAhcCdwJJAnUCTwITAhMCFQIhAnsCZQILAmsCqwEChQIEYwJrAlcCWwI1Ag0CPQJDAk0CSwJzAjMCSQItAgsCNQJBAkcCTwI/AksCJwI/AjsCCwJbAk0CVwICCwJVAmkCYQIJAg8CCQIHBAcCDwIVAicCCwICKQIhAgkCBQIlAicCJwIDAgMCCwIAAgIVAh0CMQIrAgIhAiUCOQI9Ah0CIwItAhcCLwIfAj8CMwIxAj0CEwIrAi0CJwRDAisCOwI9BC8CMQI5AjECKQIAAgcCKwINAiMCQwIDAhsCFwINAhUCCQIJAiECCQINAgUCBQICCwIRAgcCAwQHBAACAwICAgcCBQIEBwINAg=="
+        },
+        {
+          "operation": "ehr_status_read",
+          "requests": 146,
+          "errors": 0,
+          "latency_ms_p50": 6.535,
+          "latency_ms_p90": 14147.583,
+          "latency_ms_p99": 23019.519,
+          "hdr_v2_base64": "HISTEwAAAUwAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAKEfAjcCIwIZAhECGQJJAmsCMQIDAhUCFwILAgMCTwIPAgcCTQJdAg0EHwJHAg8COQJPAjECJQIlAgsCMwIJAgsCHQIVAgMCAmkCJQICHwJJAgACUQIJAiMCkQECCQIvAjMCIQJvAhkCKwIxAusBAgUCAAIVAi8CJwITAoMBAgMCaQJnAhMCUwIAAjUCCQIfAnUCGwKPAQIRAssCAjMCWwIZAgUC5wECrwECcQLlAgLHAwLjCALBAQLfAwLtBQKNAwL1BAKVBQKVBQLfAgLLDgKFIQLLCQKNAQKnAwK3AgJvArkCAqcKAsEBAicC3wMCAp8BArMCAqsGAo8EAr0CAmcCQQIZAikCkwICiwECDwKzAgKdAQINAhECEQKBBQIvAt0BAl8CrwICBQIPAukBAnMCHQInAj0CQQJhAo0BAtMBAp8BAmUCFwJbAjcC"
+        },
+        {
+          "operation": "ehr_status_update",
+          "requests": 137,
+          "errors": 14,
+          "latency_ms_p50": 9.087,
+          "latency_ms_p90": 4009.983,
+          "latency_ms_p99": 17809.407,
+          "hdr_v2_base64": "HISTEwAAAToAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAFcCfQJbAiECPQI1AjkCvQECxwICjQIC5QICnwEC7QICuwcCuw0CKQIbAu8CAgMCCQLlBAI7AoUBAg8CHwQABAsCCQIAAgkCDQIFAoUBAj0CCwIrAgsCKwIrAgJZAmkCSQITAgMCLwInAgsCEQKzAQIDAiMCLwIHApcBAiECSwIRAjkC7QICaQIfAhECQwINAkMCAAIFAiMCJQIDBBsCTwIPAgsCPwIZAgIzAiUCAj8CCwIPAtEDAiECswECmwEC7QEC7wMCDwKFAgSBAQLpBQLfAgL5BQIXAucFAuMBAvEDAikChxYCgR4CJQLbAgLrBALXAwIHApEEAuUBAqsGAr8EAv8GAgUCUQJbAsMBAoECAkECnwECiQoC9wICoQcCzQICwwICVQIvAoMBArMCAkkCmwICvwECrwMC"
+        },
+        {
+          "operation": "stored_query_execute",
+          "requests": 1090,
+          "errors": 0,
+          "latency_ms_p50": 21.679,
+          "latency_ms_p90": 10641.407,
+          "latency_ms_p99": 16506.879,
+          "hdr_v2_base64": "HISTEwAABv0AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAL04AmkCGQJJAgcCwwECSwIJAk8CAwItAhcCEwICAAIbAgMCDQInAgIDAgMCEQINBEkCAhECFQICAAQFAisEAAICAwIFBAkCEQYFAhsEBQIRBBUCAwIJBAIHAhMCBwIFAgQAAgMCAwICAwIFBAIABAIDAgcCAAQHBAACBwICAAIFBAICBwIDAgACCQICAgMCAgIJAgkCBAAEAhcCAgUCAwIFBAkCAwIEAgAEBwIAAgIAAgICAgACAgUEAAIAAgACAgICBwICAgQDAgsCAwQABAcCAAIEAgsCBQIFAgcCAwYLAgMEBgMCAwIAAgMCAwIDAgIAAhMCAgACEwILAhECAAICBwIFBAcCBQICBQILAgACAwICAwIDBAAGCwQDAgIEBQICAwYAAgUCAwICBwQNAgUCAAIHAgACBQQAAgACAAIAAgUCAgcEAwYEAwIDAgACAgAEAAICCQgFAgUECwQDAgMCAgcCAgMCAgQFAgIABAQEBQIDBAIGAAIAAgICAwQCAgIABAMCBwICAgMCAAIEAwQCDwIAAgICAAQCAgACAAIAAgIDAgkCAwYDAgQAAgACAwIDAgUCAAIDAgkCAgUGAAQCBAACAgIAAgQCBwIEAAIHAgAECwIABBECAgMCBwICAgAEAgIDAgMCBwQCAwICAg0CAAQEBQIJAgMCAgICAwIAAgAEDQIEAgAEBwIDAgACCQQDAgMEAwIEDQQHAgACAwIFAgIDAgsCBQIAAgcCEQIEAwIAAgQCAwICAAIDAgILAgACDQICBwIAAgACAgkEBwILBAACAAIAAgkCAgICAAICBQIbAgUCCQIDAgcCAgICAgACAwIHAgQAAgACDQICBAICAwIEBwIFAgIDAgAEBgIHAgACBQIAAgcCBwIEEwIABAICAgMCCwIDAgICEwICCQIABAIAAgQLAgkEBAcCBAUCPQICDQIHBgILAhECAgUCJwICCwICAAIAAgsCAAIFAg8EAAIVAgILAgIRAh0CCwIhAhUCAwIXAgACAAICFQIDAgkCAwITBAIHAhcCAwIJAgIFAgACDwKHAQIFAgQvAicCBQIjAgMCOwIxAkUCAwILAhECAl8CDwIJAhkCCQILAi0CLQJHAh0CNwIVAhkEAAIXBBcCBwIFAgcCHQIJAgACAwIAAhUCJwIHBBUCAAINAm0CSwIAAgsCDwIZAgkCFQI1AgMCJwITAicCCQIDAgJbAgcCDwIZAgMCAn8CRwIpAiUCKQIjAjMCJQJvAj0CFQJ7AkkCJQIVAmEClwECDQInAgACEQIJAi8CTQIFAisCCQINAh0CBQILAlECRwIdAgMCTQI7AgsCRQICYQIjAncCAALVAQIfAgMC3wECNwICVQIAAgUCNQKTAQI7Am0ClQICAwJFAg8CAoMBAicChQYCuwICkwMCnwECOwJNAvECAsUBAm0CyQMCCwKZAwJtAp0BAmECNQIzAicCbQIZAlECBQILAjMCBQITAh0CAgkCIwIhAg0CGQIPAkUCWwI/AhcCFQIJAvcBAgcCLwJ9Ap0BAgACGwIZAjsCMQIrAosBAn8CMQILAhECDQIDAgIzAh0CFwIHAhcCDQIJAh8CAwIJAgINAlMCJQJRAiEC5QECPwJ7AkkCeQIpAgUCDQITAokBAjsCaQKnAQIRAj8CNwIFAgUCCwQTBAUCEwIXBB8EMQICBwIFAg0CIQINAjkCAAIdAhMCMwINAhcCKwJTAhkCIQIrAm0CTQI7AjsCQQJVAl0CDwIVAmECBwInAhMCJQJHAjUCBwIRAhkCcQIjAjMCHwIdAjsCCwIRAgsCJQIbAgACCwIXAikCAAITAgIHAh8CHwI1AicCDwIAAgACDwIlAikCIQIEFQIFAg0CDQIDAgcCBwIFAgMCBQIHAgkCEQIdAgACAwIRAgACEQIZAiECNwIVAiMCAgMCAwIFAgUCDQIRAgACAwIFAgsCEQINAgMCFwITAgsCHwICGwIlAiUCJwIfAgACNwItAiECIwIAAh0CMQIAAgcCEQICAwIHAgkCBQITBAACGwIZAh8CEwIVAhMCEwILAgsCCwIFAgACAg8CFQINAhECBwIRAg8CDwILAhECCwIXAhECAwILAhUCFQITAg0CGwQjAgACEwIXAhUCAwIVAhECFQINAhMCCwIXAhcCGQIRAhMCCwIbAhkCFQIZAhUCBwIFAhMCEwIRAh0CEwIXAgITAgIRAhsCCQIJAgsCBQIZAg0CAAIbAhECCQIVAhECHwILAgcCEQIRAhECFQIFAgkCEQIJAhsCHQQDAhMCBwIGBwICBQIHAgUCBwIDAgMCCwICIQIAAgACAAIDAgkCAgUEBwICAwICAAILAgUCAgcCAAIDAgQFAgIFAgICAwICAAIAAiMCAwI="
+        },
+        {
+          "operation": "tags_put",
+          "requests": 182,
+          "errors": 0,
+          "latency_ms_p50": 10.095,
+          "latency_ms_p90": 12795.903,
+          "latency_ms_p99": 25034.751,
+          "hdr_v2_base64": "HISTEwAAAYwAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAKciAsMBAoEBAlsCkwECBQI9AnMCEwKbAQJjAicCGQIAAisCDwIPAgcCTQIAAi8CGwJDAhcCLQItAl0CIwIFAgUCLQQbAgUCBwITBA0CCwJFAocBAgIjAjECUQIZAgcCDwICEQIJAj8CBQIHBAsCMwRRAgkCIQRFAj0CJQITAmUCCQIdAi8CDwIJAisCMQI9AikCmwECZwIjAkUCBQLDAQJZAgUCFwI5AgsCKwJVAmECAikCMQIlAgKrAQKVAQJNAvkBAnECLwLnAQLtAgIzAgKBAQIXAoUBAusFAp0BAm8C3QICKQLxCwLtDAJRAt0MAtcBAqUPAo8OAiUC8QYC0wUCjwICvQICHQLFAwLbAQIdAjcC4QEC7wQC7QECnQICtQECawKJAgKnAgLhBAKNAQJ/AvkBAuUBAoMBAuUEAscCAlECAAJPAj0CLQI3AhMCQwQRAmcCBwIvAmMCRQJrApcBAksCrwECfQKVAQJ3ApsBAk0CTwJLAiUCUQI7AjMCIwIFAu0EAjECJQIDAg=="
+        },
+        {
+          "operation": "tags_read",
+          "requests": 182,
+          "errors": 0,
+          "latency_ms_p50": 5.179,
+          "latency_ms_p90": 4231.167,
+          "latency_ms_p99": 17645.567,
+          "hdr_v2_base64": "HISTEwAAAZoAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAMkVAsMBAm0C7QEClwMCWQKtAgITAl8CfwITAg0CBwIJAhMCEQIAAikCAgUCQQIVAgACAh0CAAI7AgsCCwICCQIAAgQCBwITAikCDwIJAgACEQIjAgACKQI5Ag8CBwIJAgUCIQIJAhUCFwIFAiMCFQIRAk8CMwICAwIDAjMCkwEChwECFQI7AhECAgUCEwI1Ai0CAAIXAhkCXwIAAikCAAIrAgACIwIhAg0COQICdQITAm0CUwIjAisCYwK7AQIpAokBAnkCCQI5AgInAqMBAt8CAscBAosBAikC0QECzQICcwILAq8BAo0JAokEAvcJArUCAoEOAs8FAvEHAskJAoUBAqUFAq0BAqkGArkDAucGAm0CmQUCfQKzAgLTAQL1AQKfAwK3AQLZAgLPAQKJAgKNAQJDAlcCXQIVAm8CdQLJAgJHAjkCYQIJAg8CkQECMQICqQECpQECBQL1AQIAAgcChQMCyQECEQLfAgLDAQJFAl8C0wQCqQQCRQLzAQIrAo8BAmcCZwIlAsMDAqkBApkCAskDAo8EAlsC"
+        },
+        {
+          "operation": "template_get",
+          "requests": 453,
+          "errors": 0,
+          "latency_ms_p50": 31.215,
+          "latency_ms_p90": 3848.191,
+          "latency_ms_p99": 9355.263,
+          "hdr_v2_base64": "HISTEwAAA40AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAANEVAqUEAoEDAqEDApMBAhkCOwI9BAsCLQJvAj8ELwInAh8COwITAhkCdQRLAjcCXwIhAjMCMwI7Am0CGwITAjECUwIfAq0BApcBAgIhAlcCDwILAjMCGwIHAgUCGQIAAksChQECzQECDwIvAlUCHQIfAsMBAgUCGwJHAgMCKwIpAlECGwINAgIABAUCEQInAkcCCwIfAmECBQIPAgcCIQIPAh0CFQJBAhMCCwIPAhUCAAIAAgQPAgACAwIVAgItAikCBQI1AhcCAh8CAAITAi8CHwIPAhUCFQIjAgIlAg0CAwIFAgIpAkkCAAIXAicCMwJNAhECGwIDAh0CDQIZAt8BAk8CDwIAAqMBAhMCBwJbAkECDQIRAiECSwIdAgACEQIFAoEBAgI3AjsCFwICBwIAAj0CAwITAgACBwIhAgIZBBsCHQIAAgUCAAIRAgkCJwQfAgUCCQICCQITAgcCOQIHAgIrAiMCAwJLAhMCAAILAhsCLQITAl8EBwIAAkkEAgsEEQIjAgcCKQIFAh0CBwIVAgACIQIDAnkCIwIDAhUCCQIPAk8CAgMCDwICEwI/Ah8ECQITAgMCKQIFAg8CPQIDAgMCEwIFAgcCQwIAAlECAwIrAgsCEwIJAisCGQIRAgUCFQIHAgIlAhcCLQIpAiECBQICFQIdAgMCAlkCFwJdAi8CIQJlAgcCxQECHQJPAk8COQIDArMBAk0ChwIESQIRAikCkwECGwILAm8C8wICOwL7BAIrAtMFAtMBAqcCAgsChwECiwICxQECVQKBAQKBAgIJAnkCzQECTQLbAQJ1An8C3QECcwK5AQIpAhsCQwJTAg0CrQECAALTAQKZAQIdAvcDAo8BAgkCJQIRAlUCAj8CbQIFAjsCuwECKwIJAmECRQJvApUCAgcCnQECMQLTAgLdAQK/AQLRAgICRwI5AgkCHQIAAgJFAgcCHwIdAh0CHwIXAhcCEwIhAm0ChwECPQIZAhcCJQI5Ah0CAwQ7AiECCQJpAiMCDQIJAgACHwITAiMCoQECPQI7Am0CLQIfAgUCCwInAgACFwIFAh0CHwJdAlUChwECGwJXAgkCMwJNAqMBAl8CKwIZAh0CXQI7Ao8BAg8CYQJFAhMCVwJdAjkCZQJJAkMCaQIDAk8CnQECDQJNAoMBAkkCPQJdAkUCPQIRAgMCEwIAAg0CFwIDAhUCFQIAAgMCBQIPAg=="
+        },
+        {
+          "operation": "template_list",
+          "requests": 454,
+          "errors": 0,
+          "latency_ms_p50": 4.255,
+          "latency_ms_p90": 3817.471,
+          "latency_ms_p99": 9265.151,
+          "hdr_v2_base64": "HISTEwAAA3YAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAALUUAkECzwECHwQTAlUCAAIPAqcBAgsEFwIfAhECHQIZAg0CJwICBQInAhUCAwIABAACBQIFAhUCBwIEBQIDAhUCNwIHAgcCBQIHAgcCCQINAgcEAAIAAgIHBAIPBA8CBQIAAiMCBwIABAACDwINAgACAgICCwIDAgcCAgcCHQIHAgsCAAIFAgsCAAIDAg0CCwIAAgIRAgMCAAYCFQILAgMCAgIDAgQDAgcCCQQLAgUCBwIJAgkCCQIAAhkCBwIVAgQFAgUCAg8CAAICAAIDBAcCBQQHBAIRAgACBgMCKQIbBAUCCwIhAgMECQIPAi8CBwIJBA0CBwINAgACCwIAAgcCCwIRAiECAAICAAIVAhUCDQINAgILAg8CAgUCAAIJAgsCDQICBQIFAgIFAgcCAAIJAgMCBAIDAgMCAgMCIwIDAgUCAAIjAgcCCQIHAiMCCQI9AgMCKQIXAiMCDQIXAiMCKwIjAjUCEQIjAgMCAAIpAi8CBwJfAjcCCwIxAjsCJQIfAgUCCwILAgUCRwIdAiMCLQIHAqMBAh8CqQECCQIJAhMCIwIHAgJfAgACBwIFAiUCJQIzAgUCGwKBAQILArEBAvUBAnMCNwIXAqEBAkcCPwJhAgsCuQECQQLdAQILAgMCPQJnAmkCIQJhAl8C2QICCwIXAuMBAj8C3QECWwKdAgJlAvcCAhMChwEC4QEC7wgC+wIC4wwCDQLpAgKrAwKvBgIPApUBAsMEAkcCkwECVQL/AQIfAmECUQKLAQIHAqkDAs0BAskBAgMCxQECYQLfAQKXAQKvAQIJAlUCKwKBAQINAosBAtcBAjEC9QECqQICRQJjAhMCAicCTQIrAgUCaQJlApsBAlsCRwKbAQI5AmcCowICMQLzAQLBAQJjAq8BAt8BAm8CFQRPAk0CJwInAjMCAwIVAg0CKQITAgIjAgACVQKLAQJ7AksCJQIDAjUCEQILAhECLQINAhUCFQKFAQIPAj0CCQIDAgIlAgsCUQJZAlECfQIxAjMCBQIFAgUCBQIHAhECMQInAjcCSwJnAgsCpwECGwIXAhcCqQEChQECGwIdAiECawJTAl0CNQI1AhcCUwJVAn8CSwJRAn8CVwIPAn0CTQIbApEBAlUCWQJDAlcCMQIlAjkCJwIAAgkCEQIAAgUCBQIfAhkCCwIVAgcCDwI="
+        },
+        {
+          "operation": "ward_query",
+          "requests": 1089,
+          "errors": 42,
+          "latency_ms_p50": 199.167,
+          "latency_ms_p90": 3497.983,
+          "latency_ms_p99": 9814.015,
+          "hdr_v2_base64": "HISTEwAABmsAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAMMuAvcNAoEHAq0DAoEIAnEClQMCvwICmQECVQJZAqkDArMEAosBAmkCOQKzAgJ5As8BAp0DApUBAl8ChwQCAAIvArEBAmEC/QIC+QECgwICAhECAwIHAg0CAAQCAAQHAgUCAAICAgACAwIEAgICBQICAgMCAwINCAIFAgkGCQIDAgUCAwQCAwIGAAICBQIHAgIGAwIFAgAECQICAwQCAgIFAgAEAgQAAhUCAgIFBAICBwIDAgICAAIEAgACBQICBQQCAgICBQIAAgACAgMEAgcCDQIJBAACAgAECQICAAIECQIDAgMCAwIAAgICAgICBwQFAgACAgACAgACAgcCAwICBwIFAgIAAgIABAACAwQCBwQAAgUCAAIFAgICAwIAAgIAAgIAAgIDAgICBgQAAgILBAICAgIEAAQCAgACBAICAgICAAICAgQEAwQCAgAGAwICAAIABAQDBAsCAAICAAICAgMCAAIFAgIAAgMCBQQEAAIEAAIFAgIABAMCBAACBAIEBAQCAgYCAgIEAgMCAgIAAgMEAAICAgAGAgIFAgcCCQICBAACAAICBwIIAgICBgIAAgACAgIDBAACAgMCBAICAgACAgcCBQQGAgACAgACBQQCBAQHAgICAAQCAwICAAIAAgACAAIEAgYAAgQCAAYAAgIAAgICBQQABAMCAgACAgQCAwICCwIIAAQFAggCAgUCBQICAgUGAwIEBgAEBwYCBAACBQICBwIAAgIJAgACAwQAAgQCBgICAAIAAgACAgICAwIJCAMCBQQCAwICAAILBgIJAgMCBQICBwIAAgQFAgICAAIABAYCAgcEAgACAwICAgUCAwIFBAUEBAMCBQICBAIABBUCAwIAAgcEBQICAgUEDQIABAcCCwIRBAIAAgkCBQQHAgMCDQIDAg8CAAICAAICDQIJAgIFAgIDBgQDAgMEEQQDAgMEBwIAAgMCBwIDAgIHAgACCwIAAgACBwILAgICAwIDAg0CAAQDAgMCCQIAAgMCAAIAAgQCGwIAAhcCBwICAgUCAgACIwIRAhcCBwQNAgIDAgUCBQIAAgsCFQIDAgUCBA0CEwILAgkCBQIHAgACAAITAgIDAg0CAgkCJwJXAgUCAhkCDQIDAh8CFwQRAgIDAgACGwICCQIFAgUCAAYHAgIRAhUCCwIPAg8CBwIJAgcCBQIXAgUCAAIXAgMCFQIDAgcCAgcCCQIAAg8CGwINBgACDQILAg8CAgMCPQIjAgcCEQIdAiMCFwIAAgMCBwILAhMCDQJLAg0CCQJPAgkCAAIJAocBAhUCCQIRAgkCDQITAgUCPQIDAiUCDQIXAgUCGwIPAiMCAr8BAhMCCQICPQJbAhMCUwINAgkCAg0CDwIFAgACewILAhcCLQIXAgMCDwIlAg0CFQIHAhsCSQQDAgINAgIfAgACHQIpAgACAiUCQwIRAhMCCwIJAiMCAwIJAgkCBQJbAgUCFwItAgkCAwRBAgUCAgsCNQIDBAUCCwILAhUCAAI3AoUBAicCDQIJAksCDwInAgITAjcCNQI7Ah8CBwIJAiECDQIAAgsCBwIdAgkCAhMCAgsCDQIFAiEEBBUEEQINAg8CDQINAiUCAwINAlMCCQIhAjUCFQIPAhMCBwIXAjECFwIJAisCAAIpAgsCbQI1AjsCDwIzAkcCOwJ9AlcCIQIrAo8BAhEEIQJjAgACqwECEwINAgINAgMCAgAEAwIbAgACAgUCAAIJAg0CAgICAwQAAgACAgACAgICBwQCCwILAhECAAIFBAUCAwIbAgMCHwIVAhUCEwIzAhsCAwILAgcCDwIJAg8EBwIVAgACDQItAgACHwIDAgcCGwICAwIDAhEEBQIZAgINAhkEBQIfAgkCAAIHAgcCCwIPAgcCAAIAAhUCAAJDAgUCDwITAhsCJwI3AgACEQIrAhcCDQIRAgUCDQICIwINAgcCAwIFAgAEBQIDAgACBQICAhkCIwILAhcCAwIpAiECAAIVAgUCRQKzAQJBAhUCAhsCEQIJAgACGwJFAgcCAAIAAg8CAh8CnwECXQITAmsCDQIvAoEBAlMCFwITAgsC2QECPQJtAgsCLQLRAQILAu0BAhcCAgMCUQIHAg8COQIFAgMCBQICBwIFBAACCwIDAgcCEwI1AgACBAUEAgICAAIAAgMCAgACDQIJAgACAgAGEwIXAh0C"
+        }
+      ],
+      "stable": false,
+      "breaches": [
+        "adhoc_query p99 9289.7ms > budget 1000ms",
+        "composition_commit p99 21315.6ms > budget 1000ms",
+        "composition_read p99 19529.7ms > budget 1000ms",
+        "composition_read_current p99 19316.7ms > budget 1000ms",
+        "composition_revision_history p99 21233.7ms > budget 1000ms",
+        "composition_update p99 21315.6ms > budget 1000ms",
+        "contribution_commit p99 23560.2ms > budget 1000ms",
+        "contribution_read p99 21479.4ms > budget 1000ms",
+        "directory_create p99 1323.0ms > budget 1000ms",
+        "directory_read p99 22085.6ms > budget 1000ms",
+        "directory_update p99 20381.7ms > budget 1000ms",
+        "ehr_create p99 9175.0ms > budget 1000ms",
+        "ehr_read p99 19103.7ms > budget 1000ms",
+        "ehr_status_read p99 23019.5ms > budget 1000ms",
+        "ehr_status_update p99 17809.4ms > budget 1000ms",
+        "stored_query_execute p99 16506.9ms > budget 1000ms",
+        "tags_put p99 25034.8ms > budget 1000ms",
+        "tags_read p99 17645.6ms > budget 1000ms",
+        "template_get p99 9355.3ms > budget 1000ms",
+        "template_list p99 9265.2ms > budget 1000ms",
+        "ward_query p99 9814.0ms > budget 1000ms",
+        "error rate 0.1323 > tolerance 0.0010"
+      ],
+      "generator_bound": false,
+      "resources": {
+        "sample_interval_s": 10,
+        "containers": [
+          {
+            "role": "sut",
+            "name": "ehrbase-rs-ehrbase-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 89.92350167837255,
+                "rss_bytes": 670044160,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 7775469694,
+                "net_tx_bytes": 8888692014
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 99.71588060302042,
+                "rss_bytes": 670339072,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 7828010158,
+                "net_tx_bytes": 8904039669
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 100.12559901439026,
+                "rss_bytes": 668839936,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 7893264228,
+                "net_tx_bytes": 8928066318
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 79.94917141166718,
+                "rss_bytes": 664653824,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 7956231358,
+                "net_tx_bytes": 8943251012
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 120.59312546519834,
+                "rss_bytes": 680734720,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 7975465148,
+                "net_tx_bytes": 8946182723
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 88.59380791390514,
+                "rss_bytes": 681996288,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 8047761955,
+                "net_tx_bytes": 8956049997
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 106.26195323363568,
+                "rss_bytes": 679182336,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 8109189544,
+                "net_tx_bytes": 8979829405
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 103.17286664930079,
+                "rss_bytes": 676696064,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 8190462060,
+                "net_tx_bytes": 9011497340
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 64.58053979737494,
+                "rss_bytes": 676958208,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 8249254312,
+                "net_tx_bytes": 9031594626
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 60.945261393047055,
+                "rss_bytes": 677457920,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 8302221422,
+                "net_tx_bytes": 9052878110
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 53.1560825914176,
+                "rss_bytes": 676782080,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 8367366327,
+                "net_tx_bytes": 9073443595
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 58.1677470629405,
+                "rss_bytes": 677208064,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 8424350780,
+                "net_tx_bytes": 9093622096
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 55.37195814432992,
+                "rss_bytes": 676708352,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 8488355189,
+                "net_tx_bytes": 9115366238
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 52.48745663175467,
+                "rss_bytes": 676937728,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 8544114199,
+                "net_tx_bytes": 9137268915
+              },
+              {
+                "offset_s": 150,
+                "phase": "drain",
+                "cpu_pct": 55.668263757865645,
+                "rss_bytes": 676945920,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 8602146877,
+                "net_tx_bytes": 9158658834
+              }
+            ]
+          },
+          {
+            "role": "db",
+            "name": "ehrbase-rs-ehrbase-postgres-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 441.97407475740044,
+                "rss_bytes": 2933608448,
+                "blk_read_bytes": 12026097664,
+                "blk_write_bytes": 51066458112,
+                "net_rx_bytes": 7996680003,
+                "net_tx_bytes": 4221550196
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 561.4713395896131,
+                "rss_bytes": 2915643392,
+                "blk_read_bytes": 12239142912,
+                "blk_write_bytes": 51163648000,
+                "net_rx_bytes": 8008204108,
+                "net_tx_bytes": 4268185057
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 521.048078885921,
+                "rss_bytes": 2870267904,
+                "blk_read_bytes": 12516655104,
+                "blk_write_bytes": 51314274304,
+                "net_rx_bytes": 8027336823,
+                "net_tx_bytes": 4327493384
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 375.4996281600886,
+                "rss_bytes": 2919206912,
+                "blk_read_bytes": 12712529920,
+                "blk_write_bytes": 51367407616,
+                "net_rx_bytes": 8038977128,
+                "net_tx_bytes": 4384726845
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 498.8511915261375,
+                "rss_bytes": 2815131648,
+                "blk_read_bytes": 12753100800,
+                "blk_write_bytes": 51410595840,
+                "net_rx_bytes": 8040069753,
+                "net_tx_bytes": 4397876545
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 573.959634082071,
+                "rss_bytes": 2969440256,
+                "blk_read_bytes": 12927467520,
+                "blk_write_bytes": 51452391424,
+                "net_rx_bytes": 8046654904,
+                "net_tx_bytes": 4464400440
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 562.2993543916158,
+                "rss_bytes": 2819534848,
+                "blk_read_bytes": 13172899840,
+                "blk_write_bytes": 51520352256,
+                "net_rx_bytes": 8066660286,
+                "net_tx_bytes": 4521647237
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 460.7679411927089,
+                "rss_bytes": 2871107584,
+                "blk_read_bytes": 13402038272,
+                "blk_write_bytes": 51609972736,
+                "net_rx_bytes": 8092446399,
+                "net_tx_bytes": 4595176221
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 294.32739719672674,
+                "rss_bytes": 2928553984,
+                "blk_read_bytes": 13578547200,
+                "blk_write_bytes": 51676229632,
+                "net_rx_bytes": 8108343808,
+                "net_tx_bytes": 4647872762
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 299.0865694907372,
+                "rss_bytes": 2873061376,
+                "blk_read_bytes": 13758926848,
+                "blk_write_bytes": 51842199552,
+                "net_rx_bytes": 8125263393,
+                "net_tx_bytes": 4695071522
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 231.27116866107306,
+                "rss_bytes": 2822422528,
+                "blk_read_bytes": 13966159872,
+                "blk_write_bytes": 51929059328,
+                "net_rx_bytes": 8141540663,
+                "net_tx_bytes": 4754446845
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 287.4334276736273,
+                "rss_bytes": 2870980608,
+                "blk_read_bytes": 14183182336,
+                "blk_write_bytes": 51997593600,
+                "net_rx_bytes": 8157534665,
+                "net_tx_bytes": 4808402375
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 234.54526677466458,
+                "rss_bytes": 2871418880,
+                "blk_read_bytes": 14367813632,
+                "blk_write_bytes": 52119998464,
+                "net_rx_bytes": 8175000799,
+                "net_tx_bytes": 4863279577
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 225.6436623156129,
+                "rss_bytes": 2872377344,
+                "blk_read_bytes": 14561247232,
+                "blk_write_bytes": 52199346176,
+                "net_rx_bytes": 8192638834,
+                "net_tx_bytes": 4912550923
+              },
+              {
+                "offset_s": 150,
+                "phase": "drain",
+                "cpu_pct": 250.14080072887128,
+                "rss_bytes": 2871717888,
+                "blk_read_bytes": 14800982016,
+                "blk_write_bytes": 52289056768,
+                "net_rx_bytes": 8209769274,
+                "net_tx_bytes": 4964310830
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "rate": 288.0,
+      "offered_load_sustained": 290.9,
+      "operations": [
+        {
+          "operation": "adhoc_query",
+          "requests": 4576,
+          "errors": 180,
+          "latency_ms_p50": 3162.111,
+          "latency_ms_p90": 5967.871,
+          "latency_ms_p99": 8110.079,
+          "hdr_v2_base64": "HISTEwAAETkAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAALkUAu0EArsIApEBAq8DAoUCArUBAo8BAlsCvwECZQL9AQIbAicCJQIZAqkBAmUCnwECDwJXAjcCOQIFAjECdQINAmcCIwIxAgUCEwIDAgIDAgACAAIXAgMCLQITAgACHwICBwIVAgkCGQIHAgMCIQIJAgIDAgUCAhMCAgUCAgsCBA8CEwIAAgsCBQICDwICAgMCAwICGwINAgcCFQItAgACAgcEFwIAAg0CAAIVAgIDAgcCAgACBQIAAgILAgMCBQIDBAACDwIDAgIEDwQDAgIAAgIAAgMEAgICAwIECQIEAgMCAAQAAgIAAgACAgsGAgcCAgACAgACAgMCAwICAgACAgMCBwIDAgICBwIEAgMCAAIEBQIACAICAgMCBwIABAACBAACAAYABAUEAgIEAAICAAINBgkCAAILAg0EAgQAAgUCBAACAAIEAwQCBwIDBAQDBAACAAQDBAIEAgACAgcCAgICBgICAwIAAgIAAgMCAAIHBAICBAcCBAIDAgUCAAICAAQDAgAGAgACAwIECwIFBAACAgcCAgACAgIFBAICAgACAgAEBAIAAgMIAAICAwIAAgACAAIABAYDBAIAAgMEAgQAAgIEAgIAAgIGAwIEAgAEAwIEBAQDAgIAAgACBAQIAgACBwQEAAIABAAEBQIEAgUCAwICAgMCAgIHAgIAAgACAgACAAIAAgACAgIAAgICCAACAAQAAgACAwIEAwQCAgIFAgMCBAACAgIAAgIEBQIGBAIGAAIFAgQCAAICAAICAgIDAg8CAgACAgMGAwQEAAIAAgICAwICBAQAAgACAgMCBwIJBAMCBAACAgMEAAIAAgcCAAIAAgMEAwICAgIAAgMCAgICBwICCQIEAgIEAgMCDwIFAg0CAwIABAACAwIHAgQDAgUCAAICAAIEAwIGAAQDAgAGAgIAAgACBQIHAgIHAgACAAIHAgMCAgMCBAcCBAIAAgMCAAIDAhMCBQICBwIFBAICAgUCAAIDBAACBAMCBAIAAgACDwIAAgkEAwICAgACAAICAwIFAgUCBQICAAIHAgQFAgIEBwIEBAkCAgkCAAIFAgMCAwICAgICAgACBQIHBAACFwICAgACBQIAAgIDAgMCCQIJAgkCBAICBQIJAgIHAgACBBcCAAIDAhUCAgACAgIJAgkCDQQCBAICAAIDAgkCAAQCAgACDQQEAwIFAgMEAwIIAwIFAgACAgQCAAQCAgIDAgICAwICAAIDAgMCAwIDBAILAgACBQIFAgICAgACAAICBgMCAgIFAgIFAgIHBgIDAgACAwIDAgkCBwIEBQIDAgMCBQIAAgQDBAUCAAICAwICAwICBQITAg0EDQIHBAACCQILAgUCAAICBQICAwIEAgACCQICAwQHBBUCAwQAAhUCAAINAgIEDQILBAkCDQQVAhMCAAQPAh0CAwICAgIDAgkCBQIAAgQDAgIAAhMCAgMCAhUCAAIPAgcCAgACGwIAAgUCEQICEwQCCQIDAgICDQIjAgUCAgMCFQQNAgACAjMCCwINAgIPAgcCAgACCwICAAIJBBECAwINAgUCAiUCHwIAAjMCEQIAAhUCAAICAAIFAg0CDQIZAhsECwQHAikCCQIAAgIAAgIvAgMCCwIPAhkCIQIJAgsCAAICDQIPAgUCCQIJAjECAAITAhECBQIDAgcCEwIJAgILAgcCTQICJwIPAhcCBQIZAhMCCQIbBAcCHQILAgACEQIHAgsCJwICAAIAAgACDwIhAhECHwIAAhUCAg0CCQITAkUEAAIlAgcCCQIAAgMCNwITAhECBwIpAgkCDQIFAg8CBQIPAhMCOQIFAgMCFwJDAhECAg8CBwJZAgsCAwIxAhMCGQIDAlMCCQINAq8BAgUCWwICLQJJAh8CAwIFAgACBwIVAiMCEwIPAhECCQIJAgcCCQIfAhcCcQIRAhkCDQIAAkECJwINAikCIQIlAiECCQICEwITAgMCMQJHAhUCBwIPAjUCBQIlAkMCGwIfAjUCcwKXAQI7Ah0CJQJTAh8CNQKnAQIpAgMCAwINAl0CBQILAgUCPQINAkUCFQIDAg8CFwIJAhECFwIAAicCGQQhAgcCAgJDAiUCFQIpAhMCEwINAiUCEQIpAgsCFQINAhMCJQIJAgUCAwIDAgACAAIDAjsCGQICDQIvAgkCHQIZAgMCDwICEwITAgcCOQJHAgcCGQIpAjECGQIhAkcCAAJ7AiMCFwIbAi0CDQIRAgIHAhECJwIFAg0CAAIAAgcCEQITAhUCAAIZAgAEAwIPAgMCBQIJAgACAgACEwIFAhkCHwIFAg0CEQICBwICAAIDAgkCAgcCCwIAAgMCAAIbAhECAwIjAgACAwIPAhkCawIpAgMCAAIAAgsCAAILAh0CBwQFAiUCDQIAAhcEBwINAgkCCQIpAhUCIwIHAiECKQIHBAIRBAIFAgcCAwICAgUCAAIAAhECFQILAh8CAgsCAAINAhECAwIVAgcEBwIDAhcCBQIZAgMCCwQLAg0CAg0CCQIJAg0CHwIPAhcCAhsCCwIHAgcCBQIAAgMCDQICFQICEQIPAg0CBQIDAhMGBAMCAg8CAwIDAgsCAgAEBAIFAgIFAgACEQICAAQFBAIFAgUCAAICBQINAg8CBwIHBAsCAgsEAAICAwQPAgIJAhUCBwQDAgMCBQIAAgIVAgUCAwICAgIHAgkCAgYHAgACDQYTAh0CAAICCwIpAgIJAgMECQILAg8CAwIFAgcEKwIHAgACAAILAgkCBwIJBAICDQIDAgIEGQIRAg0CFQQCAwIEAgMCAAIDAgACAwQDAgACAwIAAgIAAgACAgMCAgMCAgMCBQINAhECAAIFAgIABgcEAgMCBwIDBAIHBgIAAgACAAICAwIAAgAGAgQJBAACCAICAAIDBAMCCwICAgACAwIAAgAEBQQFAgQFAgUCAAQLBAkEBQIJAgICBAUCBQQCAwICAg0CAAIAAgUCAgACAAQDAgcCAgcCBwIHAgMCBQIJAgcCAAIDAgIPAgMCAAIDAgUCBwIHAgMCAwICAAIDAgsEAAIFBAsCAAIDAgACAAIAAgIPAgAECQIAAhUCAwILAg0EBwIAAgMCBwIABgMCAgUCCQIJAgMCBQICBAACAAQDAgMCAgkCAwIDAgIABAAEBQIDAgUCBAACAgcEAgcCAwICEwQDAgkCFQICBQICAAIJAgIAAgIHAgUEAgAEAAYCAAQCAgIFAgcEBQICBwIAAgIAAgAIAwYGAAIAAgACBAIAAgMCAwIAAgQCAgMEAwIEAgIEBAICBQICAAQCBwIABAQEAgACAgMCAgICAgMCBAQFAgQCAgUEAgACBAcEAgACAgACAwIABBECBwQEAgIFAgQCBwQAAgMCAAIAAgICCwIAAgQGDQIEAgMCAAQCAwQFAgICBAMCAgIDBAACBwQlAgACAgIJAg8CCQQFAgACCQIJAgcEAwQPAgcCKQQVAgI3AhUCBgMGAAIAAgkCAAIAAgIJBBMCGQIJAhUCBwIPAjcCMwI5AgIDAjsCDQIfAhkCFQIJAhECCwIDAgkCAgUCAgAEAgkCAgMCAgIDAg0EAgcCCwIAAgMCAAIDAgYCBAIABAICAgIDAgICAgMCAAIEAAIABAcCAgMCAgICAgILAgUCAAIDAgACCQIhAgIlBCsCAAIDAg8CAAIPAgACIQICBQICAgIDAgACAgMEAgAECwIFBAMCAgAIAgAEAgACBwIEBAICAwQCAgACAgcCBgIGAAIEAAYGAgICAAQAAgYAAgAGAgIAAgICAgACAgMCAAYFAgACAAIEAAYFAgUCBAUCBgICAgIDAgICAgICBAACAg8EAgIAAgAGAgIEBgIEBAYIBQQEAwQEBAICAAICAgAEAAICCwIAAgACEQICBQICBAACAgIAAgsEAAIHAg0CBBcCCQIPAhMEAAIEAwICBwQABAMCCwIJAhMCCQIVBAMCBQIDAg0CAAQNAhECDwITAhECAAICBQQXBAcCEQIDAhUCAAIHAgACBQQDAgICAwIJAgMCAggAAgIDAgYAAgIEBQIEBQIABAkCBwIHAgQDBAIABAIDAgIACAACAgIEAAQEAAQCAAICBgQCBAAEAgQCAAICBQIAAgIEAgIEAAQFAgYCAgIIAgYDAgYGBAIAAgQACAQAAgIEBgQKAgQEBAIGAAYEBAYGAgQOAgIABAQCBAQCBgAGBAQAAgICBgwEAAIIAgoCBAYCAAYAAgQIBQIMBAQCBAYECAQCAgQEAggGAAYFBAYEAgYAAgYCAgYCBAUCBAYEAAYIBgIABAoCAgIGAgQGBAMEAgYAAgAEAgQEBAQEBgAEBgICCAgCAAQCBgIGCAoGCgQCAgQEBgIIBgQSCAgABAwGAggKBAYKBAoKCAYKBgoGBAIGBggEBhIIAgYEAgQICgYOAAgIDAgGBAYACAYGBAgCBggIAhAABAQKBgIIDAYIAgQICgwCBAQIBgYIBAgGBgIKCAYEAgAEBAYECggEAgICCAQEBAYEBgIIAgQIAAQEBAYCBAQCAgUGAgQIAgQEAgAGBgAEAgICBAQEAgACBgIIAAQIAgACAgIEBAYEAwICBAQCAgAEBAIECAIEAAIEAggGBAYGBggAAgAEAgQEBAIGBAIIBgYGBgAIBAIGBggEBAIEAAYECAIEAgIIAgYEAgIABgYEBgICAggCBAQEBAYGBgIIAAQGAgQEBAQECAIABgIICAIEAggGAAIIBAIEBAwECAoICAIEAgYIBAICAwwCCAoCBgYGCAYCCAQEAgoEBAQKBgYCAAQEBAQEBgoEAggKBAQCAgYCCAQEAgQIDAQCBggGBAIEAwIDAgICBgQCAgQGBgICAwIGBgACAAgCDAIEDAQGBggEBgoIBggEDAoKCAoEEggSEAYKDAoEBAYKCggKDgwIFAYIFAwOCgoOBAgICgoIDAQOFg4KDgoKAgoGCAoQCAwAEAgEDAQGCgYKCAgKCAYOCggOCggMCgoGCggECgwCCAYCBggAAgICAgQDBAICAAICBwIABAACAgAEAAQCAgICAwIDAgIAAgMCCQIHAgQCAAIFBAACAwIECAQCAgQAAgICBgICAwQEAwIEBQQCCQIHAgIPAgACAgQABAIDAgIGAAIDAgAEBAIABAIDAgMCAgAEBAQEBgICBAcCBAIGBAACAgIEBAQCAAYABgIECAACBgMCAAIJAgQFAgMCAgIAAgUEAAIDAgIHAgIAAgcCAwIFBgACAAIHAgUCAgACBwILAgUCAgUCAgMCAgAEAAIAAgIEAwICAgACAAYGAgACAgIAAgIFAgICAgACAgICAAIEAAIAAgIGBAIEBgIECAQGBAgAAgYFCAgCAgIGAgAGCgIGAgQEAgQIBAYAAgQEBAQICgQFBAIGAgAEAAIEAwIEAgIDBAYCBggAAgIJBgICBQICAAICBwIAAgACAwICBQIDAgACCQQNAgMCAAIEBQYCBwQCAgACAgACAgACAAICAAICAgcCAwIAAgUCCQIDAgIAAgICBQIDBA8CBQQABgICBQICBQICAAQAAgQCAgACBQIABAMCAAICBAUCAgIEAgICBAQCAgICAgQEAAQCAAQCBAAEAgQCBAYEAgMIBAICBAYCBgAEAgACAAICAgQFBAACAgIFAgMCCQICBQIDAgMCBAkCBwIAAg8CAwIFBAIAAgILBAIABAIEAgIEBAQHAgIGAAIFAgMCAg0CBQQDAgsCCwIEBwICAgICAgACAgAEAgACAgIAAgYEAgMCAgACBQQACAAEAgAEBAQEAgQEAgICAAQGAAICBQIABgIEAAIABAkCCQIFAgACAAIGAgQCAgIABgACBwICAgIDAgACAAICAAQFCAIEBgACBAIEAwIDAgkCBwIJAgAC"
+        },
+        {
+          "operation": "composition_commit",
+          "requests": 1413,
+          "errors": 1,
+          "latency_ms_p50": 7622.655,
+          "latency_ms_p90": 20905.983,
+          "latency_ms_p99": 23969.791,
+          "hdr_v2_base64": "HISTEwAAB+kAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAANM1ApsCAlkCMwIpAikCCQIFAg0CBwJTAisCAwIdAhkCVQIhAgsCGQICAiMCDQILAi8CIwIbAg0CCQKXAQITAgUCDwILBAIVAgsCBwIRAgIVAg8CBwIAAgACEwIPAhECFQQpAgcCYwICAgMCHwIDAisCDQIAAg8CCQJTAh0CAwILAi8CAAILAgIZAiUCHwIAAhUCFQIAAgUCAAIRAhUCDwINAgcCCwIDAhsCDwIAAgINAgUCHQIVAjECAAIVAgUCBQI5AgMCKwIJAh0EDwIlAhsCAwIfAgACAwICFQIJBBcCPQIZAgACDwICBQIHAhcCMQIJAjcCHwIDAh8CCQJbAgMCCQIFAhECAhECAwINAgMCBQICCwIPAiMCAgUCFwIDAg0CCQIFAgsCEwIFAgsEAAIFAg8CEwIFAgINAgsCAAICDwIAAjECBQICIwICAwICAAIFAiMCEQIXAhMCAwIFBBECCQJjAgkCGQINAhECAAINAgIXAgcCBQIAAhkCJwInAmECAAIFAgcCKwInAhUCEQJBAkECAwIJAgACYwJtAjMCGwJVAkMCYQKnAQI5AgMCRQIvAoEBAksCCQJjAn0CEQINAoUBAikCLQI9Aj0CFQIXAgACBwIlAmMCFQJfAmsCGwJvAoMBAgkCMQIFAhsCHQIpAn0C1wICsQMCDQJHAtcBAu8CAmsCdQKTAQIlAgkCmQICeQKFAQIDAu8CAqkBAsECAi0CfQKZAgKPAQI9Ai8CVQLDAQIvAikCLwIvAicC7wECdQIRArsBAi8CLQKNAgI1AoMCAl0CbwKFAQLXAQJ3Ap8CBCcCeQLbAgIxAkUCCwIZAhUCPQITAkEEOwIAAl0CCwI1AgMEBwIXAhECLQICAhsCAAI5Ag0CIQIDAj0CBQJ1Ah8CJwJzAiMCUQIDAhECGwIRAhsCKQQjAgUCdwJvBCkCJwIAAgJPAmMCCQI9AhECYQIHAisCFwIAAhUCGQIdAisCQwIZAgICBwIAAhUCGwIAAg0CAAICCQI/AgACAwIHAh0CDQICBQItBAMCAgsEDwICCQIJAhUCAAQCAwICCwIAAgkCCQIjAgACAAIzAhcCQQInAjcCAiUCOQJhAhUCAhcCBQIDAhECFQItAhcCCwIVBhkCAi8CHQIJAg8CWwI7AgsCDQJNArEBAgUCAgACAjECEwIDAgACDwIHAgMCAAIFAhcCAg8CCQIJAgcCCQITBAMCBwIFAgIAAhMCFQIVAg8CCQI3AgkCAwINBAMCEQIRAg0CDwIDBAUCAwIRAgIFAgIJAgACCQINAgACAgcCBD0CAwIPAhECAwICAiECAwIFAg0CAAIJAgINAgIFAgUCDwITAgIFAgQAAgcCAwIAAgkCAgIlAgkCBQI1AiECAwIAAicCAwIEQQIdAgcCHQIDAhsCGQItAjECDQIlBAICAAICAwIHAgcEAgcCBQICBwIFAhECBBECCQIAAgMCBAMCAgIDAgACBwQACAACBwQAAgQDAgMCAgQDAgUCAAIAAgICAgUCAAQHAgACAgMEAgMCAwICAgcEAgMCAgACAAIAAgACAgQAAgICAgkCAAICAAIFAgIEBAkCAgIAAgUCCwQDAgACAgcCBgAEDwQCAwIFAgUEAAQAAgICAAIAAgMGAwQAAgIDBAMCBAIGAAIAAgICAAIAAgcCBwQAAgACBQIEAAIAAgICBAILAgIAAgACAggCAAICBgACAgACBwICEwIDAhUCAAICAgcCAAQCFQIJAgUCAAIHAgACBQIAAgACCQIHAhECAgsCBQIAAgUCAgUCAhkEAgACAAICBAQGAAIECAACAgYCBAIAAgMCAAIEBQIFBgcEBQIDBgICAAQEAAQEAAQABgMCAgQEAAIAAgICCwYDAgIGAwICAAIABgUEDwICAAICDwICAgACAwIEAgACFQICBAACAgACAAgPAgcCAAIABAACAgUCAAIDAgIDAgAEAwICBQICBwITBA0EFQICAwICDwICBQIDAgsCAgIEBAMCBA0CAwICAAIAAgICAgUCBwICDwIVAgUEDwIAAgkCAAQCCwIGAggFAgIAAgIEAAIFAgQAAgUCAgkCBQIAAgACCQIFAgUCAAIDAgACAgACAAIAAgMCAgACAwIDAgAEAgIEAwQABAkGBAIAAgICAgAEBAACAAgAAgICBAICAwIAAgACAgQCAgIEAwIDAgACDwQCAwIDAgMCAgUCFwICGQICTQIPAjECBQIJBAMCGQICCQILAlsCCQIDAgIDAiECBwIJAgMCAjkCFwIFAgIRAjEERQIAAgUCAAIvAhsEDwQPAgsCEQIjAgcCAAIAAjsCCQICCQIXAgMCAhkCAwILAgMCBwQFAgACBwILBBkCAwYAAgICAgIGAgMEAgIFAgIABgMCBAUCAgMECwIFBAMGAwICAAICAAICAgICAggGBgIIBggCAAYCBAIEAAwABAQIAgYCAgMCBgQAAgYJAgUGBAICCQIACAQDBAIGAgIJBAMGAwYEAgMEBAACAAQCAgQAAgIEAAIACgICLQQHAgIAAgIEAg8CAgACAgIJAgIPAgILAgMCAwQEAgACAwIAAgMCAwIAAgIDBAQABgQKAgQCAgMEBAACAgQKAAQCBAAGBAYDAgMCAgAEAgQCBwICAgMEAwIGAgICAgMGAgUCAwIHBAICAgUGAgQCAgYEAAYCBAIhAgkCAgQAAg=="
+        },
+        {
+          "operation": "composition_read",
+          "requests": 9154,
+          "errors": 5221,
+          "latency_ms_p50": 10.527,
+          "latency_ms_p90": 5279.743,
+          "latency_ms_p99": 22626.303,
+          "hdr_v2_base64": "HISTEwAAHugAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAOsNAgIlAiUCvwICTQIXAj8CGwIPAgsCKQINAgUCFQIDBBMCBQQDAgACAiMEBQITAgIAAhECAhkCGwIJAgACAikCAAIHBAACDwQAAgIbAhECBwIHAgUCBQIXAg8CEQIFAg8CDwIFAh0CDQICLQINAgMEDwINBAcCBwIJAgcCAAIAAgsCBQIAAhECAgsEAwIGCQICEQQLAgQCAgcCAhMCCQIRAgACAAIPAgINAgsCAAIDAgACBwICCQIDAhUCAAIEBQILAgICBAMEAAIFAgACFQQCCwIVAgIDAhcCAAIDAgMCCwINBAACAgMEAwIFAg0CAAgRAgIAAgIAAgICAgACAAICAAIAAgACBQIABAUEBQICBQIAAgcCAgUCAgcCAgACAAQAAgMEBwIDBAAEBQIDAgkCAAIFAgMCCwQLAgIAAgACAgICAAICDQIFAgQFAgkCAwQCAgIHAgYCBgUCAAQDBAACBQICAAIAAgACAAIFAgAEAgACBgICAAIEBgICBgIDAgICAAYEAgIGBAQCAgQACAIABgIAAggCAgACAgMCAgIAAgQCAgAGAgACBAAEAAIEAgYCAwIAAgACAgYABgQAAgACBAAEAgAGBgYCAgIEAgIAAgIGAgYEAgQABAIEAgQCAAYCBgQAAgACBgQEBgAEAgQIAggCAAYCBAUCAAICCAICAAIEBAIFBAQCAgAEAgAEAgICAgICBAQCAgMIBAICAAICBAQEAgIEBggCBQIDBAQAAgICAgAGAAIAAgACBAYDAggCBgICAAQABgIGBAQCAgQABgQCCgQCBgYEAgIAAgYCBQQEAAIEAgIABAIEAgQCBAIEBAIGBgQDAgQCAgQABgAEBgACAgQEBgICAgQEBAIACAYCAgIEAgMEAgMEAgIGAgQEAgACBAQAAgIEBQIEAgoGAAoEAAQKBAICAAICBAAGAAQEAgQKDgQEBgIEBgYEAAgEAgQEAgIABAICAgYCBAIEBAIEAAIEBAQAAgYCBgQCBAICBAMEAgAGBAIABgICAgQDBAIEBAYEBAQCAgIEAAQCBgQCCAICAgQGAgIEBAACCgYCBgACAgQCAgYCAAQABgQCAgQEBgQABgoCAgQCAAYKAAgEAgYCBAIAAgIGAgIACAYIBgIEAgIECAICAgIABgQCBgYEAgQAAgIGAgAEAAYECQIABgAEBgYGAAgGAgAEAAQGAgIGAAIEBAQCCAIEAAQCAgYEBgICAgIAAgQGBgICAgYGAAIABAQAAggABAQCBgAGAgAKAgIAAgYEAAYGAgAIAgoCAgAIBAICAAYEAAIABAQGAAYEBgQGAgICAAgCBgIIAgwABAQCAgYCAgQKAAQCAgoIAgICAAIEBgIABgQCBgAEAgQCBgYMAgYEBAIEAgIAAgIABAACAgQGAwgGBAMCAgQAAggEBgYCBAgGBgACAAIEBAoGAgYEAgICAAIABAQCAgIIBAgCBAIEAggEBAQOBAQEAAICAgYECAQCBAICBAQCCAAIAgAGBggCBAICBAYCBAgICAQABAIEBAQEAgAGAgQEAAYCAgQGAAYEAgACBAIECAQEAgYACAYGBAQABAYEBAQCAAQCBgAGAAQGAgQCAgICCAQEBAYGBAIEAgMEAgAGAgQCAgQEBAACCgAEBAQEAAICAAYAAgIEAgICBAICCAgEAgAEAgAGBgYGAgQEBgQABgQCBAAEBAIDBAIEAAICAgIGAgYACgMGBAIDBgIIAgIAAgQEBgIDBgQECgIACAIEAAoGBgYGAAYICggKCgQABggGDAgGBAICAgYEAgwKCAYGDAQIBggCCAQEBBIKAgIGBAYMCAQKBgoCBgIEAgAECAIIBgoCAAwEAA4CDAYKBAYEBAIGAAIGBggICAoGBgoECAgEAAwIBgICDgYGCgYICAAECAYKAAoCBAgCDAgCBAQCBgYEAgYIBAAEBAQGAgIEBAwABAQGBAQGBgYEBAoAAgwEAgIGBgYIBAoCAAYIBAQABAIEDAoIBAYIBAgGAggCBgQGBAQIBAgEBAoMBAIEDAgGBgICBAQCCgICBgQCCgAGBAQMBgIOBAIEBgIIBggGCAQIBggGBAIGBgIABAQIBgYGBAIACAgIAgIICAQIAggDCgIIBAICCgAIAgYGBgYECAIAAgYGBgQGDgYIAgIGAgIEBgwCAggGBgoGAg4EBAoIBgQGAggECgICBAYABAICBAIEAggCAgIEBggGBgYCBAoGBAYKAgQIAgIGBAIEAgIGBgQCBAAKAgwIAgQKBgYEBgQIAgIEAwoACgYABAgIBgoEAgwCBgYEBAIEAAQKAgIACgoEBg4CBAIIAggEBgYEAgIICAYIEAICAgICCAYGAAgEBgwSAAwAAgQEBAMGBAQEAwIGAAYCBAYECgoABgIIAgQEBgYCBAQAAgYEAwIIBAQCBgQGBAQGCAYEAgIECAgAAgQCBAYCCAYGCAAEAgYAAgIEAgICAggEBAQDCAQCAgIEAgYAAgQIBAgABgQACAQGBAQGBA4EAAYCAgQGBAYEAgoCAAIIBAAEBAYGBggEBAACCgIIBAIGBAICAgYEAhACBAYABAoCBAoGBAIECgYECgYEDAQACAICBAIEAgACCAIECgQCAgACAgAEBggGAgIDAgQCBAYOAgIAAgYABAAEAgYACAICAgQGBAYCAwoGBAYKBgIEBgQIBgAGBgYEBAQGAgICBAYEAgYCBAoCCgACBgQEAgAEAAQKBgQCBAIEBgICBAYCBAMCAgQCAgICAAICAgIEBAIGBgAGBgYEBgIABgAKBgUGCAIGAAQEAAICAgQABAYCBAQGBAoIAgQCBAQKAgICAgYABAIEAgUCAgIAAgQCCAYEBAAIBAICCAIGAgYCAAYABAQEAAIGBgICBAAEAAQCAgACAAYEBAIEAAIAAgYACgQEBgYGBAICBgQGAggCAgAEBAQGBAIDAgICBAUCAgAEBAACAgIAAgICAgQCBAACAgQAAgQDAgQCAgAEAAQCBAQEBAIABAIDAgIGAwoIAggCBAIEAgIGAgQGAgQAAgICDAAGAgQCBAQABAIEBgIEBAICAgoCAAYEBAAGAgYCAAQEAAIDBgAEBgIDAgwIBgQEBgoACAYEDAIEAgIGBAIGBgIKBgQGBAYIAgIGAggCBgYEAgYICgQGCAYEAAICBAgEBAICAAIKCAIEBgIGBgQGBAIIAwYEAAQCCAMEAggEAggEBAoGCAQEBAQMCgQGBAAEDAICBggEBgoGCAIEAAQCBAIIBAQCBgIGBAIGBAICCAACAgAGCAYIBAgIBAQGAAgABgQACAAKCggCBAQEAgYABAAGBAACAgYCCAQEBgQEBgQECAAEAgQCBAoCAAICCAQIAgACAAQCAgICAgYEAgQOAgQCBgACBAIEBgIGAgQEAgQEAgMCBAQCAAIIBAYAAgIEBgMEBAIGBAIABgIAAgQCAgQCAAIIBgYEBAACBgIEAgICAgAGBAYCBgYCAAICCAICAgICAAICBAICBAYCCgAEAgIAAgAEBgQAAgIEAAICBgIABAACAgMCBgMGAgQABgACAAICAgIGBAQAAgQCAgIEBgcEBAIABAQAAgICBAYKBAICAgICBAgABAQEAAQCBAIGCAMCAAICBAQCBAgCCAAGAgACAgIGAAQCAAIGAgMCBAYFBgAEAgMIAAQCAwQCAgQEBAQCAAIEAAIABAYAAgAGBAIAAgYEAgACAAQECAICAgICBAICAgMEAgQCAgQCBAIAAgAEAgIAAgIEAgQEAgIGAgIDAgQCAAYCBAIABAIABgQAAgICAgQCAgIAAgIEAAICAgYEAgQCAAYCBQIEAAIFAgAGAgYDAgYAAgYCAwIGAAIEAAQEBAIGAAIEAAIDAgIDAgIEBAQCAgIDBAIGBAQCAgQCAgAKAwIEBQQEBAYAAgIIBAACCAQCAwICBAMEAgQDAgQCAAIHBAAGAwIFBgACAgQGCQQEAAIAAgQABAQCAwQCAgMEAAICAgIDBgQJAgcCAgICAAICAgQEAgAEBAMEAgQJBgAEBAcCAAICBAACAAICBAMECAIFBAICAgMCBgMEAgQEAAgCBgQDBAQCBAIEAgAIBwICBAACAgQEAgIAAgIEAAYAAgIDAgYAAgUEAgAEAgIAAgACBAQCAgIDAgIEAAICBQIEAgAEBAMCAAICAAICAgYCAgIDAgYIAgACAgACAwQCBAACAwQCCQIAAgIFAgAGAAICAgIEAAQFAgIEAAICBAMCBAIDBAIABAIAAgQDAgACAgIAAgMCBAIAAgIFAgIABAICAAIFAgcCAgICAgACAgIFAgICAAIEBAMCAAILBgQEAwIAAgICAgICBAgEAgIDAgAIAgICAgICAgkGBgIABgQCAgIIBAICAgIEAgQCAAICAgAEAgAECgQCAgQGCAQAAgQCBgQMAgIDAgUCAgYEAAQGBAIEAAYEAgYCAgIEAAICBAUCAgQCAAIGAAIABAQCAgQDAgICAAgABAQGAgIEAAICAgACAgQAAgMCAgICBAQCAAYGBQQAAgACBAQECAkEAwYABAIGAwYABAQCBgIDAgIEAAICAgYGAAICBAACAAYCCgIGAgACAgACAgAEAAYCAAICBgACAwQAAgAEAAQCBgIGAgYCBAACAAQCAAQAAgMCAgYFBAoCBAMCAwYDBAICBgIEAAYCBgACBgACBQQCCgMCAgIAAgACAgMCAgICAgAEAAQABgACAAIABAACAgIABAICBAYAAgIABAACAAICAAICAgQCAAQEAAIEAAIGAgQCAgICBgMGBQICBwICAAIEBAQEAgcCBAkGAgUCAgICAgIDAgQCAgIEBAACAAIEAgMEAwIEAgIHAgUCAAQCAwQDBAQEAgIFBgcCBwIDBgACBAMEAgAEAgIAAgcCAgUEAgIABAMGAAICBQQHBAMEAgMCAgIAAgAEBAcEAAIEAgMEAg8EAgACBQQAAgQHBAkEAwICAwICAAICAAICAAICAAILBAUCAAICBQIZAgUGAgAEAAIFAgUCAAYCAgQFAgUEAAICAAQJAgIAAgkCAwICBQIDAgACBQQCAAQEBQICAgIAAgIHAgACDwICCwILAgIDAgACBAACAAIEBwICBAIAAg0CAgICDwQCBwICAwIDAgMCAwQCAgACAgACAAQAAg8CBwQCAwIAAgQJAgACAgUCAgICAgIEBAACBAIEBAQAAgICBQIFAgcCAgcCAwIAAgMCAwQEAwICAgIAAgAEAAICAwICCQIHAgkEBQIDAgcCAgACAAIAAgUCAg8CCQIDBAIFAgICBQILAgIAAgkCAwILBAICBQIEAwIDAgcGAgQCAgMCAAIDBAICAAIABAYCAgcCAgICAgACAgICBAICAgAEAwQCAAQABAICBAIAAgIAAgACBAIEBgIDAgIFBAICAwIFAgACAgACAAIAAgIAAgACBQIDAgIAAgMCAAIEAgAEFQQAAgICAAICAgUCAgACAgIABAICAwQABAIAAgIAAgMCAAQCAAICCQQDAgACAgACBwQCAAIDAgIHAgIHAgACBQIHAgACBgACAAICEQIEBAsCAgILAgkCAgcEAgIJAgAIAg0CAAIAAgACBAACBQIHBg0EAwICBAMCAAQCBQIAAgACAwICAwIAAgIEAAIEBAACAAIEAg0EAAQHAgcCAhUCAwIAAgIFAgAEAgMCAAIAAgIHAgkCAAQZBAICAAIFAgcEAwIHBAMEAwICAAIGAAIfAgACDwQDAgcCDQIDAgcCDwIHAgQCCQICAAIDAgcCAwICBQIDAgIDAgICAgMEAgAEAwIRAgACAAQDAgACAgkCBQQHAhMCAgILAgIJAgACAAIFAgcCAwINAgUEBwICAAICAAIJAgACAAICAAIDAgICBQIFAgAEAgACBwIPAgIFBAIHAgMCAwIDAgACCQIJAgQFAgkCCQIDAgIFAgUCAAIDAgACBwIFAgIVAgIAAjsCAwIhAgkCAgIAAhUCAAIEGwIEBAMCDQIPAgkCAgUCBQICDwICAg0EAAIAAgIDAgsCAwIFAgQNAgACBQICAgcCEQYCAAICBwIAAgMEBwIABAIDAgkCDQIHAgQNAgACAgACAgIAAgMCAwIAAgACAAIAAgMCBQIDAgMEDQIFAgACAAIJAgMCAAIDAgAEAgMCAwIFAhsCDwIDAgMCAAIAAhUCAwIAAgsCAgIAAhcCAgACAwQFAgACAgIDAgACBQIDAgMCAwICCwIFAgIFAgUEAAIAAgIHAgIDBBcCDQICEQIDAgICAwIFAg8CAAICEwIHAgICEQIECQILAgUCEwIAAgQCCQQFAgIAAgcEAAIDAgUCAwIHAgACAwILAhUCAAQCBQQJAgUCDQQCAgcCKQIFAgICAwIAAgMCCwIRBAcEAwIDAgsEAwILAgIAAhMCAgIHAg8CBQIJBg0CCQIZAg8CDQIAAgUCBQICBwIjAgIDAgUCBQIHAgkCDQITAgIJAg0CAAICFQIAAgMCCQICBwILAhECEQJZAgsCBwIAAgsEAwIDAgILAhsCCQI3AgACAAIVAgMCAhUCRwIrAgACCwILBAMCAAIDAgMCEwIAAgMCCwICBwIEAAQAAgMCAgcCCQInAgACDQQLBAUCBwIPAhECEQIFAgUCDQIXAicCAwIAAgQNAgkCAg8CAwICBwIFAgcCEQIDAgcCAAICBwIDAgACBwIDAhMCAAIAAgIFAhMCCQIDAgMCFQIAAgkCHwICDwIDAg8CBwICAAIAAgACAAIHAgAEDwINAgUCFwIFAgMCBQIJAgACBQIDAgACBwIDAgcCMQQDAgACBQIFAg8CAwIHAgcCBQIHAgcCBwIFAg0CCQIJAg8CFQILAgcCAgMCAwICCQIAAgIDAgMCAAIbAgUCAwIVAgIFBA0CBQIAAg0EAAIFAgcCGQIAAgsCAwIFAg8CBQIDAgMCAwIbAg0CDwIrAhECAgACAwQZBAUCCQIHAgUCAwIAAgkCCwINAgACAwIAAgMCAAQDAgcCEwITAhECGQIRAgMCBwICDQIVAhkCEQICAgMCBQIAAgIAAgkCAgkCAAIHAgMCAAIFAgMCDQIJAgcCAgACCQICCwIABAACBwQnAgkCAgINAgUCAAIPAgkCAhEECQITAgQCAwICBQIFAhECBwIAAgICEQQFBBECAAInAgIHAgMCAAICAgkECwIHAgICGQIJAhMCAAICLwIRAgACFwICAwICBwILAhkCAwIVAg8CEQIHAgkCCQIbAgIDAhMCCQIJBAkCAAQAAgACDQIZAgMCCQIFAg0CBwILAgYHAgACBwIJAhECDwITAgUCBQIAAg8CAgkCBwIVAgkCCQIDBAsCCwILAgIDAgcCBQINAgsEAAICAAIVAgUCAgsCAwIJAgMCCQIFAhMEGwIAAgsEAgUCAgkCBQIVAhMCAwIABAsECwIABA8EAg0CCwINAgcCCQITAg8ECwIJAhUCAwIAAhMCJQIJAgACDwIAAgIPBAMCBQIFAgUCBwIAAgsCBwICEQIPBAIRBAUCAAIlAg0CGwICCQIbAg0CBQIdAg0CAwIJAhkCAgMCAAIFAgsCAAQHAgsCAwILAiMEAAIDAgMCAwIbAhUCDQIfAhECAhcCAAITAg0CEQIrAgICLwIHAgcCAwIFAg0CEwIHAgMCCQIDAgACAgkCAhcCCQIDAgACGQICAgcCBwIEAwILAhMCAhUCAhkCAAQLAhsCAgIAAgUCBQIHAgMCCQIAAgICAg0CCwIAAgACAwIAAgICAgMEBQIDAgMCBQICAwIDAg8CAgkCAgIDAgICCQQRAgACBQIDAg8EAwIDAgICBwQXAgMEAgQAAgQFAgMCAwIAAgUCAAIEBwIHBAICAAIDAgAECwIFAgACAAQAAgAEAAIAAgICAAICAgACBAMEDwQDBAACAgAEGQIPAhECDwICAwIAAgICAgIPAhMCAwICAgMCBwIABAQCAwIHAgACBwIHAgQFAgMCAAICAwICBAICCwINAgMCAwICAgcCAgYJAg0CAAICAwINAgICCwIHAg0CAgMCCQIEBQICCQQCAg8CAgUCBQIPAgsCAAIFAgcCBwICAwIDBAACEwIdAhMCAwIRAgcCAgkCBwIFAg8CAAILAgMCCwINAgACAgcCAwIAAgUCAgUEAAIFAgIDAgIAAgAEAwIFAgAEAgAEAgMCAwIDAg0EAAITAgQAAgICBQICBQIAAgIVAgMCBQIZAgACEwIFAg0CDQIDAgkCAAIVAgMCCwIAAhECEwIAAgUCBwINAgACAwIVAhECAgQNAhEEAgMCAwIAAgACBwIAAg0CAgACAAIDAgMCBQICAwIAAgACAgMCAAICBQIPAgQDAgACAgUCAgUCBQIFAgcCCQIFAgACFwIAAhECDwIAAgsCDQICAgACAAQCBwIXBAUCFQIJAgkCBQIAAgIJAgIAAgUCAAIAAgIABgIAAgIFAgICAAQCBAICAgcEAwIAAgQAAgQGBAACAAYCAgIFAgIAAgACAgUCAAIHAgMELwINAgINAgUCAAIFAgUCAAIlAgUCAAICAhECAgcCFQIAAgAEAwINAgMCAgMCAAIHAg0CHwIAAgUCDQIAAgIFAgcEAAIDAgICDwICAgACAAICAAIGAAQABgIAAgICAwIDAgACAwICAAIEAgIEAwIEAAIECQQABgIEBAYCBQIEAAQGBAACAAIAAgACAggABAQAAgICAwQCAAICBQIAAgMCAwIEBQYNAgAEAgACAgIPAgACEQINAgsCBwIAAgMCAAIFAgUCAgMCAgIPAgIDAgIDAgIABAQCCQIAAgMCAwICBQIAAgIAAgMCBQIJAgIAAgACBQIAAgUCDwIHAgkCBQICBA8CBQICIQIFAgcCDQIpAgcCAwICBwQDAgAEAwIHBAsCAwICAwIHAgcCAAICBQICAwIlAgAEBwIAAhcECwIDAgIAAgIVAgIFAg8CAgMCAAIAAgsCBwQFAgcCAAQDAgQFBA8CAgACHQQDAhEEAAIAAgACAwIDAgQAAgIDAgkEDwIAAgcCEQIDAgIFAhECBwICCQIdAhMCBQIAAgMCAhkCEwILBAcCAwIFBAACEQIAAgACAgIPAgkCCQIFAgICAwIFAgICAAICAgIAAgACAAQLAgACBAsCAAQCAgACBgMCAwILAgACAwIHAgIPAgkCAAIFBAUCAAQCAgIFAgIEAgAEBQIFBAMCAAICBgIDBAUCAgICAAIAAgsCAgACAgIABA8CIwIPBAkCEwIEAgICAAIFBgACAwIHAhMCFwICAgIDAgACFQIEAwICBAMCAgICCQIHBAACCQIAAgMCAgMCAgACAgIGAAQEAgACAgkCBwYCBAAEAAQEAgICAgQGAgACAwIJAgIDBAIDBAAEAgQJBAMCBQIDAgsECQQEAwIAAgACAgAIAgICAgQCBQoCBAIEAAIGBAIEAAgCAgICAgICAgAEAgYABAAEAggIBgIGBAoEAgACBAYKBAoCAgACAgMCAgIEAgIFAgkCEQIFAjMCkQEC1QECWQIfAgMEAgACCQIAAgUCAwIFAgACCQIAAgsCCQICFwQDAgIAAgkCAAIFAgUCBAMCBQIABAIHAgsCBQQFAgQAAgIAAgIAAgIDAg0CAAIABAACAAIHBAAEBAYAAgACAgIAAgIAAgIDBAICAwICBAcEBgICAAICBAMCAwIAAgACAAIDAgsCFQIVBgMCAgAEDgYABgAGAgAGBAICAgIAAgMEAwIJAgUCBwIFBAQCCQILBgQDBAQAAgICBAIAAgQCAAYEAgUCBAMEAgACCwIpAiMCDQQDBAIDBAIECQI1AhECBQIRAgUCAgICBAILBgICAgMCCQIEBAICAgwGDgYGBAIEBAQDAgACAgACAgQCAgsCCQQABAACBAIDBAMEAgAECAYhAhECDQIzAg0CFwICAwICAwIRAgICBwIFAgMCAgACCQINAgQEAj0EDwICBAMEBAMCAwIJAgIAAgIABAIGAgQEAAIAAgIEAAQEAgMCAAICAgICBAIEAAIABAUEAgAEAwICAgACUwIDAgUGAgACAgICBAILAgUCAAIHAgMCGQIJAgQxAgACBAIHBAMCDQIJAgcCAgsEAgAEBQQDBgICBAkCAwQAAgIPAgUCAg0CGQIAAokBAt8BAgMCAwITAgcCAwIAAgAEAAIECQIAAgsCBQICAwICGwICIwIAAjECAgICJQIJAiMCZwIVAi0CKQICJQICUwIELwYAAgIDAgIIBggGDAQCBgcCAgkEAAIEDAAEAgAEAgICCAYKBgoCAAICAwIEAgIFAgkCAgQDBAIGAgIAAgYMAgQGAAIAAgICAgACBQICCgQYBgICAAQEAgAEBAQMCA4EAgIRAgACAAILAgIEBAYCAgICAgcCAAIEAAYIBgYIBgYUDgIEBggABAIABAYAGAoEAgICAAICCQIHBAkGEwICBgICAgIEBwICAAIGAwIEAAIPAgcCFQICAAIJAgQAAgUCCggGBggKCgoQDgICAgICAgIDAgICAgYAAg8CAAILAj8CCAIEAAgCBgQEBgQCBgACBgQICAQLAhcCCAQCAAICAgIAAgI="
+        },
+        {
+          "operation": "composition_read_current",
+          "requests": 5148,
+          "errors": 2901,
+          "latency_ms_p50": 11.111,
+          "latency_ms_p90": 4710.399,
+          "latency_ms_p99": 20873.215,
+          "hdr_v2_base64": "HISTEwAAFoIAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAIESAkUCHwIfAhsCJQIHAlsCGwIpBAACIwI1AgkCGwJFAgIPAmkCAAIdAhUCIQIFAg0CAgsEAwIHAhMCJQIDAgICLQQDAgIAAgkCCwI/AgUCGwICEQIAAh8CFQICAhcCEwIJAhkCBwIFAgkCCQINAhkCBQIHAgMCEwYDAgACAgkCAAIPAgIDAjUCMwIJBAIAAg8CAwIEBQILAgUCDwIHBA0CAAIJAgIPAgUCEQICBwICAAQGAAQHAgACAhMEAAIHAgACAwICAAQAAgQZAgsEDwIAAgACBwIPBAACAgQAAgUCAgUEAAICAgQEAgMCAAICAgYHAgMCAAICAAIAAgACAAIGFQIFAgIAAgcCAgMEAAIABgICAAIDBgIABAIFAgAEAgcCAgMGBwIDAgIAAgsCCQYDAgQCAgACAgQCAgMCAgQHAgcCCQIABAICAAICBAIAAgQDAgIGAgUCAwIDBAYEAgIEBQIDAgICAgMCAAIJAgACBAQCBAACAAICBAACAgIFAgIHBAACBwIFAgACAAQFAgAEAgIGAAIAAgMCAwIDAgACBgMEBAIEAwIDBgICAgQDAg8GAAIEAAQEAAYABAUCBAICBgQDCAQDAgMEAgMEAAICAgIACAYCAgQABAMCBAQABAACAgICBQQFAgIFBAIDBgICCAACAgIABAIDAgIDBgUCAwQHAgAGAgQCAgACAgUCBAINAgACAgACAgICAAYEAAIEBgIEAgICAAIABgYCAAICBAcCAgQCAgQCAgUCAwIIBQIEAgYFAgMEAgICBAUECQQCAAICAAIDBAACBAQDBAIEAgAEBgIDAgIFBAIABAICBQQEAAIDBAAGAAIABAMCAgUCAgQGAgIAAgAGAgIABgIAAgMIAgUEBAACAAICAAIABAACAgIDAgIDAgQCCQIEAgIGAgIEAgQDBAMEAAQEAAQEAwQCBAQGAgYAAgIAAgMEBAAIAgYEAAIAAgAEAgMEAgIEAAQGAgQCAgAEAAICAAQAAgQEAgUCAgIGAgMCAAYCAwICBAYCAgUCAgICAgACAwIEAAQCBgAGAAQAAgIEBAIAAgAEAgIDAgIFAgACAwQECA8CBQIJBAIEAAQCAwIEAgMCAAICAgYEAAYFAgIAAgICAgICBAACBAIABAQCAAIAAgIGAAIDAgACAgACAgIABgAEAgAEAAICBAQCAAICAgAEBAIDBAMCAgcCAAIFAgACAwIDAgICBAYCAgQEAAIABAACAgUEAgACBAAEBgIEAgIKAAIGBAIEBAIEAgACBAQIBAIIAggGBAIKCAQEAAYGAAQIAAYEBgQCBAQAAgYCCgQAAgQEBAMGBAIABgAEAgYEBAIGAgQCBggACgQCBgYECAIABAIGAAoEBgQAAgYCAAoEAgQCBgQEAAYEBAwABAQABAACAgAECAQACAoEAAQIBAIGEAgCCgQEBgQCAAQABAICAAQEBAQACAACAgIABAIEAgICBgACAgAIBAACAgQGAAICBAQGBAIICAACCgICBgIABgQCAwQIAAICAAQEAgYAAgMEAgIGCAMEBAIAAgQACAICBAICAwQEBgQEAgQCAAgIAgoAAgACAgMCBAIGBgAGAgICBAIABAIDAgAIAgQCAgIIAgACAgYIAgQCAgQCBAgAAggDBAQABAAGAgQEAAQEAgIEBgYCBAQEBAIABAIDAgAGBAICAgICAgICAgIEAgQIAgAEAAQABAQDAgICAgACAAQEAgQABAIEAgQCAAgCAgAEBAQEBgQAAgAGAAYEAAYEAgQGAggCAAIACAAECAIGBAYCBAICAgQCAgIAAgICBAICAgICBAYEAgIABAYABAIGAgAGAgQEAggGAAQMBAQEAwICAAQCAAYCAgQCAAQCBAMGAAQEBgIAAgQCAgQCAgUGAgQCAgICAAIGBAMCAwQCAAYHAgIDAgAGAgIAAgIDBAIABAgCBgYCBgYCBAACAgYCAgYCAwYEAAICAAICBwIEBgICAAICAgICAAIDBAIAAgICBgIDAggDAgYCBAACAgQAAgAEBgMCBgIEBAIABgQAAgQCAgIDAgUCAAQICAkECwICBAQJAgYABAQABAICAgIDAgMCAAQEAAIDBgIAAgQDAgAEBAIAAgAGAgMCBAMGAgQCAAYHAgACAAICAgQCAgACAgAEBAICBAACBAIDAgACAAIAAgcCBAMCAgYCBwQDBAYFBAIAAgUEBgQIBgIABAQEAAICBAACAwYCAgACAAQGBAIRBAYABAYCAgAEAAIJAgIAAgICBQIEAgACAgIEAAQCAAIEAgICAgYCAgIACAICAwQCAgIEAwICAwgABAIABAYAAgUCAwICAgIAAgQCAwgCAwICAgACAgUEAgMCBAACBAQEAAIDAgMGAAgEAAYAAgICBAUCAgIDAgQCBQIGAwIAAgIDBAQCBAIAAgACBwICAAIDBgIAAgACAgICBgQDAgAEAgQAAgACAAQCAgUEAAYDAgIIAwQCBAQCCAIEBAQGAgQKAAQGBAQEBAAGAgYEBgIEAAYABAQGBAIDBAICAggCAAQAAgMGBAACBAACBAAEAAIABAACAAgABAQCBAQGAgIEAgIEAgQGAgAEAwIABgQABAIECAACAAQEAwQEBgICAAICBAIEAgYCBAAEAwQFBgACBAAEAAQEAAQCBAIEAwYABAYABgQCAgYCBAACAgIDAgACAgACAAQCBAACAgICBAACAgICAgQCAgYGAgIAAggEBgAEBgMEBwICAAICBgACAgAEBAQCAAIEBgMCBAACBAUCAgICAAQGBAACCAQACAMCAAQABgMCAwIAAgMCAgoCAgMEBAMCAgQGBAIABAYCAAIGAgIAAgQIAgIEAgMCBQILAgAEAAICAgACBAQCCAMCAgQCAgICAgIEBQQGAAQCAgQFAgQGAwICAgICAgICAAICAAIAAgIDAgcCAAICAAIHAgMCBAAGAAQAAgUEBAIHAgACBAACAgACAAQABA8EAAQGAgACAgMEBAQABAACAgQCAAQAAgICAgQCBAIFAgQDAgACAAICAgsCAwIAAgACBQIAAgACAwICBQIPAgcMBAACBAACAgACAgICAgACAwIABAACAwIEBAQAAgACAAQGCQICAwIDAgMEAwIAAgQAAgIDAgMCAgsCAAIJAgUECwICAgQAAgMCAAQEAAICAAICBAIJAgIAAgUCAgAEAgACAwQCAgIAAgMCAgICBQIACAUEAgIFAgACAgMCAgACAAQCBQQCAgACAgIAAgMCAgUCCQIABAMCAgIDAgUEBAUCAwICBAMCCwIAAgACAg0CAgMCAAICAgMCAgIFBAITAgMCAgQEAAIFAgICAgUCAgACCQIDBgICBQQFAgACBgIEAAYABAMCAAIAAgUCAgQNAgUGBQIAAgMCBAMEAg0CAgIEBwIHAgAEAgACCwIAAgICAAIEAAQCBQILAgMCBgICAAIAAgACBwICAwICAwICAwICAwIAAgkEAgQEAgMCBQQDAgIEAgQCAAICAwIHAgMIAAIDAgACAAQABAAEAAIEAgQDAgICAgQEAgACAAIFBAYAAggCAgQAAg0GBgACAgIDBAACAAQCAgIAAgMCAgMIBQQACAIEAgMCBQIDAgACCAMEAgICBAIAAgACAgIEAAICAgQCAgQCBQYEAAIHBAQHAgQFAgQAAgICAgMCAgIAAgIFAgACAgQAAgACBQIEBAMCAgIAAgMCAwQFCAACAAIFAgMCAAIEAAICAgkCAgcCAwIEAwYEEQQCAAIAAgAGAwYHAgICAgICBQIJAgACAAQEAgICAAQCBQoCBQICAAIAAgQAAhEEAgACBAUCAwIDAgICAhMCAAIECwIHBAQDAgkGAgIEBAQJAgACAwICAAQAAgACAAIAAgACAwIPAgMCAhECAAIEBwICAgACAAQDAgUEAAQAAgACAwIAAgMCAwIAAgIDBAIAAgkCAgACBAICEwIAAgIFAgUEAgACBAMCAgcCAgICAgIFAgAEAwIDAgcEAgIDAgUCDQICBwIAAgQDAgMCAgACAAILAgIDBAACEwQAAgQCEwIEAgACCwQCDQICEwIFAg8EBwICAgQAAgMCCwICAAQFAgUCAgMCAgACAgICBwIDAgACCwIAAgMCFwQNAgIHAgcCAgcCAgACAgkCAwIDAhMCCQIFAgcCDwIHAhMCAgkCCQIAAgMCBAIRAgAEAgMCAAIDAgUCAAIDAg0CIwIXAgMCAAIFAgkCFQIDAgUEAwIFAgMCAgIFBAsCBwIFAgAEAgACIwIJAhUCCwICDQINAg8CAAILAgMCAwIABAkCBwIAAgMCAgACAgACCwIHAgICBQIRAgUEAAQHAgQNAgMCAAQCAgMCDwQCAwQABAkCEQITAgACBwIAAgACAwICBQIDAgYDAgUCEQIJBgICCQICIQIAAgUCAAIFAgACBQICAgACAwICBQICAwILAgIAAhsCAg0CGQIEDwICEwICBQINAgIHAgcCBwINAgMCAwIFAgIHAgAGAAIAAgUCBwILAgcCHQICBwIHAgMCFwIAAgUCFwIDAiMCEQIRAgMCEwIvAgIJAgACCQIbAgkCDQQCBQIJAgACAgMCCQIFAhMCAwIPAhECLQICBQQAAhcCGwICFQI1AgsCAgICBwRFAg0CBQQFAg0CUwITAgIPBCUCEQIbAgMCEwQLAgsCCwIbAgUGAwILAhMCAwILAgsCBwIFAgkCCQIDAgcCCQIAAgUCAAIEBQIAAgIAAgACAwICDQITAg0CAgUCAAIDAgMCDQIVAiUEAwIJAgMEAwILAgMCAgIHAgkCBQIFAhECBQIPAgITAgIFBAIAAhUEAwICAAIDAgACAAIHAgACAwIXAh0EAwIAAg8CAgcCIwINAhsCHQIDAgkCBQIDAgsCDwIAAg8CAwIHAgkCAAINAgIDAgkCAAIRAh8CFQIbAhMCGQIAAg8CMwIHAgUCAAIFAgIJAgkCCQInAgMCBwIDAgkCKwIFAgMCGwITAgkCAgMCFQIrAgUCGQILBAsCPQIjAoEBAhkCFQIVAgkCAAI5Ag8CHwIXAgcCHQICHQIJAgcCEQIRAgsCHQIJAgUCAwINAgACJQINAg8CIQIFAhsCAwQCAAIFAgkEEwIJAg8EHQINAhsCAwIFAj0CFwITAgcCHQIhAgUCGwINAgkCIQIFAikCcwIEAAINAg0CAgMCCwICGwIbAgMCAgUCBQIDAgACEQIAAgMCAwICEwIrAgIpAhUCAwIdAgIlAgUCBQIAAhkCUwJbAgsCAAIbAgkCCwINAjMCEQIbAgIVBAkCRwIZAgIDAgUCGQQCAAIRAiUCBwIHAikESQJJAgIVAi0CAAIFAhMCBQIVAgkCAgMCAgIAAhMCDQIZAgsCCQINAgACJQITAgUCWQIRAgMCEQQfAgINAksCIQItAhUCJwICAhUCAAIzAg0CBwIpAhECAwI5AgUCBAIFAh0CAhUCEwIHAg8CQwIDAgUCFQICIQIVBAIRAgcCJQInBAUCAAYFAgMCBwQCBwIJAikEBwI5AgUCBQIRAgACIwIFAicCFQIVAhcCBwICDwIZAgICHwIAAgUCAAIJAgMEHQIRAgcCHQIPAgUCGQQnAg8CBwILAisCAwICEQIJAhcCAwIfAgsCAAIHAisCIQICOwIAAh0CHwIRAgACDQIVAhMCAwINAhkCAwICJwQJAgMCBwIbAg0CAicECQIFAgcCAgsCEwIJAh0CDQIFAgIAAgACDQIEFQICBwIbAgcCAgUCCwICAwQCBwICAgsCCQICAAIAAgACBwIAAgsCCwILAgICCQIPAgACAAICEwQCAwQJBAACAgACBwICAAIDAgUCAwIHAhECAAILAgQJAgILAgIAAgACAgIFAg0EBgYEBQICAgUCBwICBwQCCwQCGwIAAgIABAUCBwIAAgACAAIDBAACAwIABAIDAgACAAICDwIAAgUEFQICCQIVAgUEGwIAAgkEAAICAgMCAAIFAgACCQILBAQPAgIRAgMCDQIXAg0CAhMCCQIJAg8CAAIAAhUCBBECCwIAAgMCDwIJAhUCMwIHAgITBBUCAwIDAgkCBQQJAgMCCQIHAgQHAhsCBwIABAACBwILAgACAg8CAgMCAwIFAgIFAgICAwINAgcCAAIbAg0EFwIbAgACAgIHAh0CFQIHAgUCFQIFAhcEGwQDAhsCBwQtAg0ECQIAAg8CAgACFQIDAgINBAIjAgMCCwINAgUCEQIEEwIAAjMCBQIXAgkCAwIJAgkCBwIvAgQCAwQEAgIAAgUCAgQAAgQEAgAEAAYCAAQCBQIDAgQAAgIFAgUEAAIABAAEEwgDAg0CAAIjAgACEQIRAhMCGQIDAgkCAAICCQQHAg8CEQICAwIHAgUCCwIJAgQAAgIPAgsCAhkCBwIPAgIFAgACAgUCAhUCAAIAAgICAgIEAAICAgICAgMEAAYCAAIABgAEAgICBQIABAUCAwQEBAACAAICBQIAAgQCAwICAAICAwQCAAIEBgIIAgICBgUCAgMCAAQEBwIDAgMCAg0CAgIDAgMCCQICDQICEwIjAgACDwICCQIJAhMCBQINAgcEAwILAm0CAAIdAjcCEwIRAgIzAgIAAgIHAg8CGQQFAgACGwIdAiUCAAICFQIjAgUCAwICDQILBAMCBQICAgACAAQCAwIFAh8CAgsCAAIJAg0CBCsCGQI9Al8CBQILAhkCGQIhAhUCFwIbAgACBAMCAwIHAgsCEQILAgkCBwQTAgkCDQIFAgQAAgIFAgICBwIPAgMEAgIbAgIAAgMEAgMCCwITAksCBQIDAgMCAgcCAAQVAgACAwIDAgMCAgUCCwQABAMCAgMCAAIFAgcCCQIFAgkEAwICAAICRQIDAg0CCQILAgMCDQInAgACDwIdBAACAgACEwINAgIJBAMEAAoEAwQCBAIEBAMCBAMCAAIAAgUCAgUCKQILAmMCKQLXAgQNBAkCAAIHAgkCAgMCAAICBwICAwIEBAIABAMCGQITAgMCDQIlAgAECwIJAjUCAwILBAACAAICAgIDAgIFAgACAgICAAIEBAACBAACAgIAAgICBAUCBAMCBAACBQIVAgIbAgIHAgICAAIAAgQABgICDAAEBAQIAAICAAICAwQCBQILAgUCAAIAAgACAgICAgIJAgMCAwICBwQEAgACAwIAAgACAwICBAIDAgUCFQIVAiECAgUCCwICAAIEAwICAgUCAicCQQIHAgcCDwINAgMCBAYICAwIAgICBAQAAgMCBAACAAIAAgQCAgMCDQIDBAYEAgIEAgAIAAQACAYAAgIEBQILAgcCBwIFBAkCMQIRAgMCFQICBwQAAgQAAgkCAAICAAIDAgMEBAIAAgMCAgACAhEEAwJHAgkCLwITAgUCCQIDAhcCEQI3AgsCAwICAAIABAYAAgACBAIHAgcCEwIHAgITBAACBQIzAgACAgACAwYRAgUCDQICBQIDBAICAgcGAgAEAAIHAgMCBQLHAwIJAg0CBQIVAtsCAgcC3QECTwICBQQEAgICAgQEJwIHAjkCAwICAAILAg0CBQQCBQICAAQAAgMKBggAAh0CFQIAAhECAAQABAQCAgICAgIDAgkCABAGBAIAAiECAgACEQIABAUCBwICAAICBAICAicCKQIfAg0EDQIXAjsCAAIGAgIAAgAEAgAEAAQDAgMEAAIJAhkCBAUC"
+        },
+        {
+          "operation": "composition_revision_history",
+          "requests": 4943,
+          "errors": 1486,
+          "latency_ms_p50": 302.335,
+          "latency_ms_p90": 12369.919,
+          "latency_ms_p99": 23855.103,
+          "hdr_v2_base64": "HISTEwAAFr8AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAIkPApcBAn0CjwICPQIrAl0CVwIXAhUCBQJHAhkCSwIVAgMCAgMCCwIFAiUCAAIJBAsCCQIbAhECAhECDQIdAhUCBwIAAg8CDQIEAwIDAgIAAg8CBwIFAgcEAAICCwIJBAACCwIABAILAgACAgUCBwIAAgUCAAIHBAcCIQQABAUEAAIAAgcEAgACAAIFBAACAgsCBwICAAQFAgsCAAIAAgACAgIRBAMCDwICAgsCAAIFAg0CAg0EAAIAAgsCAAIFAgIHAgINBAcCAwQCAwICAwIAAgIFAgQAAgIDAgACAwIDAgUCAgIAAgIAAgUCAwIABAUCAgACBQIDAgICAgINAgACAgIPBAIEAgACAwIDAgACAgMEDQQGAgMCAgACAgACBwQCAgcCAgAEAAIHCAIAAgICAAICAAICBQQCAgACAgACAgIDAgAEBAUCBAIFBgICAAIAAgACAgQJBAIDAgUCAAQCBAMGAgAEBgIAAgACAgIGBAQGAgICBwICAgAEBAICBAIAAgIDAgICBAQCAgMEAgIGAgIJAgACAgICBAACBAIAAgICAAQDAgICAgMCBAIABgMCBgICAAgCBQICAAIEBgIGAgkCAAQJAgUEBgIDAgIABgIFBAMEAgYDAgQCBAMCBgYABAACAwQCAgAGAgMEAgIAAgUCAgMEAwQEAgIEAAICAAQEAAIEAgMGAgUEAgMCAgICBQICBAMCBAACAgICBwIAAgQDAgICAgUCAAIGAgMCAgILAgAGAAICAwIFBAMCAAIGAgMCBwIABAICAAYCBQIAAgMEAgMEAgACBQIAAgcCBAQFAgACAgICAAIABAIFAgQDAgYCAgAEBQICBgICBgICBAICBAIDBAQDAgQCBAAEAgoEAgcEAAQJBAACAgMCAgAEBwQEAwYAAgQCAwQCAgACAAYAAgIDAgICAAIFBAIDAgIAAgQABAACAAICAgMCAAIFAgACAgICBwIAAgACBwQABAACAgIFBAICAwIABAUCAAIHBAIDAgACAwICAgACAwIEAgMCAgICAwIFAgUCAAIEAAICAAICCAICAgIDAgQCBAICBAkCAAILAgQEAgACAAICAgcCBQIAAgQHAgACAAQJCAsCAgcCBAkCAgIGAAICAAIDAgIFAgMCAgACBwIDAgkCAgMEAAQCAwQJAgMCAgAGBQQHAgYABAACBAIDAgIEAAICAgIDBAQDAgAGAgIHBAcCAAICBAACBAAEAgMEAgMCBAAEAAIDAgACBAUEAwICAAICEQICAgACAwICCQIHBAMEBAMGBAIDAgILAgACCwIABAcCAAIEBwQFAgICDQIEAgIAAgICAAIAAgACBQICAgACBQIDAgUGAAQCAwIDAgIEAgICBAcGAAIGAAIABAUEBAIAAgUGAgIABAIEAgICAAIEAgAEAgYCAwIGAgMGAgACAgACAAICAAYABAICAwIAAgACAgACBAoDBgACAAICBQYFAgUIAgICAgICBAICAAIAAgIFAgAEAgICCAMCAgICAggFBgICBwIEAgICAgICAgAGAwIAAgACAwICAgIDBAgEAAIEBwICAgMCBQYEAAQAAggGAwQCAgICAAQABAMGAAIABAICDwQABAIAAgACBwIPBAQCBAIEBAIAAgYHBAICAwICAgICAwQCAAICAAIAAgACAgIAAgMCAwIDAgIAAgICAgICAgcEAgICAwICAgACAAQFAgACCQQDAgACAAICAwILAgACBAIDAgUCAAIAAgIGAAIAAgACCQIACAcCAAITAgsEAgcCAgAECwIEBwQAAgAEAAITAgUCAAIAAgQAAgUCAgICAAIDAgcCAAIJAgIAAgAGAwQJAgIHBgcEAwICAAICAgAEAgMCBAYCBQICAgMEAwYAAgIEAgMCAgMECQQFAgMCBwICAAIHBAAEAwIAAgACCwIFAgMCAgQLAgACAwIABgUCAgACAAQJAgIABAUCAAIDAgMCBQICAgACBwICCQIDBAICAg8CAgUCAAIDAgUCAwIHBAICAwIDBAMEBg8CAwICCwIABAACAwIEBwIDAgICAAIFAgAGAwICAwIABAMCAAIFAgACAgIHAgMCBQICAAIAAgIAAgAGAwQGCAIAAgUCAAQCAwIABAACAgMCAgcCCQIFBgICAgACAwICAgkCBwIAAgACFQIFAgMEAgAIAwIABAMCAgACAwICBQICAgICBAUCAAICAAICAAIHAg0CAAICBwIEAAICGQQHAgYCAAIDAgUGAgICAAILAgAECQIEAgQHAgMCAwQIAgACAgUIBQIDBAACAwIJAgICAgICBAIDCAACBAICBAQEAAICAgAECQICAgIJBAIDBAACAwIABAcGBQIEAAIFAgICAgIFAgICAAQHAgACAgMCAAICAAIDBAACCQICBwQCAgIABgAEAgMGBAcCAgIFAgIAAgUCAAQDAgIABgQCBAMCAgILAgMCAgIABAMEAwIDBAACDwIABAICAgQAAgACBwIEAgsCAAIDBAACBwIDBAcCCQIAAgICBQICAgMCAAICAwIEAgcCAAIDAgIEAgMGCQIGBAsCAgIDBAACAgICAAICAAIEAgkEAAQABAMEAAICBQICCQIAAgICBAACAwINAgcCAgIAAgIABAACAgIJAgIPAgACAwICAgAEBQIAAgUEBwIABAACBQQCAAIDAgMCAwQEAwIABgIEBQICDQICBQQCCQIAAgsCAgMCBwIAAgACAgMEAwIFAgIJAgAEAAIEAgMCBQIAAgACBwIAAgUCAAIFAgACAgACAwIAAgACBAACAAIAAgsCCwICAwIAAgIAAgACAAQHAgIPBA8EAgUCBQIFBAcCAAIHAgMCEQQABAQCAAIDAgACAgUCAgUCBAIAAhECDQIVAg8CAhEEBQIHAgIFAikCAgIAAhUCAAINAgkCBQICDQINAgIJAgACCwIAAgMCAwIAAgIVAhsEAhkCBwIDAgMCAwIHAhECJQIAAhMCAwILAhECBQQHAgUCBwIJAgUEAwIDAgACAAQCAwIXAgIHAgMCBwQHBAICBQIAAgACBAUEAhECAAQCBgMCBwIAAgIABgcCCQIHAgUCAgkCBwIFAgACAwIDAgINAgAEAAIAAgICAwIjAgACAgIJAgQABAUEAAQCAhcCAgACAgIDAgMCAgACGQIPAg8CAAILAhUCAAIDAgMCBQIDAg8EBQIAAhMCCQICAAIJAgkCEQICAwIEAwIHAgACAhMCAwICBwILBAUEBwICBQQDBBsGEQILAgIFAgUCDQYFAgMCAgsEBwIDAgcCDQICAAIDAgkEAg8CAgIDAgACCQIDAgIbAgcCAAIAAgUEDQICAAILAgACCQIDAgMCAgMCFQYLAgMCAwIZAgcCCQICCwINAgACAwQECwIAAgICBwIFAgsCEwIJAgACDQIAAgACAAIXAgkCAgACAgACAgMCAgMCBQIHAgQNBAMEDwIRAgIFAiECIQIAAjcCJQIDAgUCDwI/AhcCHwICAwIHAgMCEQIHAgMCAwIRAgMCAAIdAgcGAgINAgACAAICDQICAgACAgACDwIRAgkCAAIJAgkCDQILBAUCGwIDAgUEAg0EBAUCCwIPAgACDQICBQIJAhsCCQIDAgIJAgUCFwIAAhcCEQICCQICBQQDAgUCFQICDQICCwIfAgACAAIXAiMCCQIDAgACGQIHAgINAgUCBQIdAhcCMwQhAgsCAgJXAgUCAAIjAhcCLwI3AhkEQQIFAhECBwQrAg8CEwIFAgUCAwIFAgACAgMCHQIHBBcCDwICAg8CAhkCAgIJAjECFwIjAg0CAwIRAg0CEQIRAg8CEwIJAgsCIwIXAhsCFQITAg8CCwILBBUCCQIDAhMCCwICDQIHAg0CDQICAwICAAICBQIPAg8CAwIAAgMCCQJnAgcCCwIENwIRBAUCBQIJAgsCCQIPAhcCAwICAwQhAhsCJwIENQJLAksCHwQTAg0CKwJHAg8EAAJBAkECBQIdAhUCCwIdAgkCCQIVAg0CCQIAAgACDQKXAQKFAgKpAQIpAgIrAgIPAgUCHQILAiUCOQIXAgkCDQIZAg0CHQQCBwITAhkGFQIpBAItAjECFwIPAhECEwIDAgUCAwINAgACCQIxAgILAhUEMwIPAg0CBwIJAgUCOwIJAgACHQIDAh0CIwQFAkMEGQIHAgUCCQItAgJxAgMCHQIPAgMCGwIhAgUCAAIbAg8CMwIPAgcCAwIDAh0CCQIZAhUCCwIvAg8CFQItAgUCYQIFAjMCAgIhAgIRAgACAwITAgUCIwILAgUCAgACDQInAgkCAwICPQIAAhECIwIdAgILAgsCHQIZAh8CIwI3Ag8CFwI/Ag0CCwIDAiMCFQINAjUCMQILAgsEEwIFAhUCCQIPAgsCAgMCDQITAgMCGwIRAksCHQIPAhsCBwINAiMCAgIDAgsCFwIHAjcCBQIJAgUCAwILAgkCDQIbAgIVAgIHAgIHAjkCFQIlAgcCEQIAAisCDwIJAhECEwINAjECBwIRAhECVQICHQIDAhMCAwINBD8CAwITBBkCAwINAhkELQICRwIJAgcCDwIbAicCAAIRAhkCGwIdAisCFwIHAgIdAhUCBwICAAINAgMCBwIHAhMCEQIHAgACAg8CCwIAAhMCAAIFAgILAgsCCwIFAgIDAgcCAgMCAwIfBAACAgcCBwIJAgMCAwIAAgITAgACBwIDAgcCCwIJAg0CAAIXBAMEBQIFAgMCBwIDAgsCAwIAAgAEDQIFAgACAgkCAwILAgMCAwIAAgACAgUCAgICAAQAAgcCBQICAAIJAgAEAgUCDwICBwIFAgMEBgICAwICAAIJAgQEAwIAAhUCDQIAAgMCAAIDAgIFAgcCAgUEBQILAhUECQIXAgkEBQICCQIJAgcCAgACAgAGAgMCAwQfAgACAAQJAgUCAwIFAgIbAgkCBwIDAgUCEwIXBBECDQIzAgMCAhUCAAIHAh8CAwIRAgACAwIhBAINAgUCCwIHAgkCCQQCEwQCAg0ECQQDAgUCBQIPAgIDAgIAAgIEAwIAAgQCAwICAAICAwICAAICBQICAAINAgMCDwIRAgkCCwINAhECAwILAgMCAhUCGQIEDwICDwIHAhUCBQIDAgACEwIFAgILBAUCAhcCAgkCBQQDAgsCEwILAgMCDQIZAgIFAgcCCQIAAgACDwIFAgMCAgACDQICFwIHAgIHAiECAAIAAgMCAgMCAgACBwIDAgIAAgIFAgcCBQIHAgMEAwIEBQICAAIDAgMCAgICAgACAAICBAYCBgACBAIHAgQGBgIAAgACAgMIAgICBgIAAgMEAAQEAAIABAMCAgMEDwIFBAcCAgkCAAQAAhMCAwIHAgMCAAIFAgIVAgMCAAIDAgsCBwICCQIDAgIAAgACAwIFAgIDAhMCAwIEAg0CAwINBAMCAAICAgUCAgUCEQIDAgIABAIAAgUEAwIAAgACBgACAgACBwIJAgIGBwQCAgcEAgkEBwICAggCAAICBwQCAgACAAQCAgMEBAQCBAMCAAIEAgACAwIGAgQAAgIEAAQCAAIIBAIDBgIEBAIAAgIGAAQGAAQEAAQABAACAAQDBAICBAIDAgUCAwQJAgMCBwQDBAkCBwIABAACAwIRAhUCAAILAhcCAAIHAg0CAgkCAAIFAgMCAgcCAhMCDwQRAgsCDQIJAgACBwIJAgIFAgACAgQDAgMCFQIDBgcCAAIECQIJAhUCAAIDAgICAgIPAgACBwIAAgQCAAIFBAcEAgIHAgQCDwICBAICAgUCAwICAAITAgUCBwIPAg8CDQIJAgkCAgIJAg8CCwILAgINAgACBQIDAgIEAgIDAgMCAgACAgUCBwIFAhMCBQIPAg8CBwICAAINAgUCBwIVAhMCGQIHAhMCDwILAgACFQILAg8CEQIXAhkCCwIABAIABAsCAAIAAgIEAgYEBgIEAAICAgICAgIFAgIEAAIJBAACBAQAAgICAgIHAhUCBwIFAgMCBwIJAhMCAwIHAgACAwIDAgACAgICBAAEAgMGAAIAAgICBAACAgICBAACAgMEAgwGBAUGBAAECQQCBAQCBAACAhECCQIFAgACBwIAAhcCCQIPAgQCAgMCBAICAgAEAwIDAgACAAILAgUCBQIFAgIHAgMCBQIDAgMCAgICAgACBAIDAgICAwQAAgMCAgACBAIACAICAgUCAwIABAUCBwIAAgIDAgMCAwIJAgkCAgACAAIABgIFAgIABAAGAwIEAgIEBQIAAgkCFwIHAgMCAwIEDQIEBwQCAAIACAkCAwQCBAUCBwICAAIDAgICAwYDAgACAgACAgYAAgIAAgQCBggCAgICAgMEBAICAAIEBAMCCQIFAgACAwIJAgUCAAIAAgACBQIFAg0CAAIHAgkCJwIJAg8CNQINAhsCBwIAAh0CAAIdAgcCEQIbAgACBwIFAgkCAwIJAhsCBQIHAgMCAAIFAgICBAAEAwIGBAICBgIACAgCAgMCCAICAgACAgIEAAIGAwQAAgACBwICAgIDAgIDAgIAAgACAgIABAIFAgIFAgQABAQAAggCBAQGAgYECgACAAQCAAQAAgIKAAQCBAIGAAICAgQGAAYCAAQCAgQCAAYEAgICAgYCAgICAgIGBwICBgAEBAACAgACAAICBgIEAAQCAAIDBgIEBAgABAACBgICAgICBAIFBAICAwIAAgIFBAMCAgMCAgQAAgACAwIABAcCGQICAwICBAMCAgAIAgICAgQEBAQEAggCBAQIAgAKCgIABAQCBAYHBAIABAAGCQICAgACAgIABAIFAgMCBAIEAAwCCgQCBggCBAYKAgAEBgAGAgIEBQQFAgkCAAQAAgUCBQIAAgACAwIFAgIFAgACHQIFAgYCAgICAgYFAgACAAIDBBkCFwIAAgUCFwINAgACAAICAg0EBgIAAgQCAAQEAgYCAgQCCAIIDBAMDgoEBgQGAgQEAgIEAAQAAgICAgMCAAIFAgQCCAQEBAYCDAIICAgICgQECAoMCAYEBAQCBgICAAICAAIEAgIABAsCAgICAAIABgAEHQIDAgILAgICCQIABBkCCQIDAgcCAgICAAQFAgcCBgICAgMCAwIEBQIHAgAEAjECAwICEwIRAgUCAgUCAAIDAgACAgACAgICAwIABA8EAgQCAgQGDwIFAg8CAAITAgcCCQIAAgICAAQDAgUCAAICAAICAwIGAwQCBQICAgIDAhUEBwICCQIHBAICBAIGAgQCCAACAgACBAACAwICAAICAgQGBAIGAAQGBAQGAAQCCAICDAQIBAIGBAQABAIAAgIABgICAgIEAgQIBgYCBAgMAAQIBAIAAgQCAgQABAICBAQEAgAEAwIEAgICAAIABAQjAocDAhECxQECNwLJAQINAicCJwJNBBkEKQIAAgIfAgIAAgQABA4IBgYCBAAEAAICBAQGAgcCAwgAAgwKAgIABAIAAgUCAgACAwICAgACAgAEAgACCgQCAgIAAgQABAYGCAoKAgYEAgQCBAYCAgIGAAYCAAITBAICCAICBwYIBAQABAIKAgYEAgAEAwQECgQODAIABAIEAgQEBAIEBAIFBgIAAgMCAwQdBhsCAwIAAgUCAwIAAgIRAhUCDQQCBAQAAgIEAAIABAAEBgAIBgICBAoIBAYICgYIBwYEBAIIBgIEBgQCAgACAAQCAAIAAggCAgACAgIHAgACAgcEAgYGBgQEAgIEBAACAAQCBgQIAgIAAgQCBAgKBAYEDBAGCAYEAAQIDQQVBAUCAAQABA=="
+        },
+        {
+          "operation": "composition_update",
+          "requests": 368,
+          "errors": 246,
+          "latency_ms_p50": 7630.847,
+          "latency_ms_p90": 22478.847,
+          "latency_ms_p99": 24035.327,
+          "hdr_v2_base64": "HISTEwAAArsAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAM8pApsEAssBAkECCwLNAgIDAmkCBwIPAgMCBQIfAgsCDwInAhcCFQIJAhcCSwIvAhECWwIhAi0CAhcCAgkCIwJjAiUCdwIDAhkCFwIPAisCLwIRAgUCgQECKwLbAQI3AiMCKwJPAgMCCQJVAgJPAi0CYwIvAgsCHQJpAqsBAkECNQKNAQJXAvMBAlMCyQUC1wMC+QUC1woCIwL9CwJ3AjsC0wUCmQkCtQwCcwKHBAKpAQKfAwKzBALZBwK1BAKvAwKJAQKBAgILAt0BAjEC+wECOwIrAkMChQEE1QECNQKHAgI/AmUCHwJLAgcCNwSXAwIxAjcCBQJDAk8CgwECVwKNAQIfAkkCeQKdAQKHAQK3AgIbAhkCDQJpAlMCVwJNAiMCIQIhAmsCGQIrAgUCBQIJAmcCOQITAgMCKQIAAgMCnwICVwKbAQI3AgACAAIVAgUCUQIJAgIDAgsCBQIAAg0CDwIJAgsCJQINAg0EEQIJAgACBwITAhsCGwI9AgMCCQQDAgACAAIFAgMCNQINAiEEAAIAAgACNwKRAQIDAhkCIwIDAgACAAICAwIfAgIlAgQCDwQCCQIlAgsCAAItAgUCCwIAAiECUQIAAhkCBQInAhUCFQIbAh8CFQIJAhECMQIDAiECAhMCHQIJAgkCCwIDAhMCDwICAAIPAgkCEQQDAgMCEQIDAjcCbwJDAnMCUQJfAkECwQECIQI3AgcCNQKJAQInAk0CDwIJAgsCAAILAgkEDQIFAgsCAwQFAgMCAgIABAICEQQCAgYCAgICAgUCBQICAAIRAgILAgUCAAQAAgkEDQIFAgUCAgIFAgUCBQICEQIHAhkCDwIjAikCDwIHAgMCAAQCAwICAAIABAACAAICBAIJAgACAwINAgILAgIDAgUCDwIXBAcCAgIJAgACAgIHAgUCIwIFAg=="
+        },
+        {
+          "operation": "contribution_commit",
+          "requests": 131,
+          "errors": 0,
+          "latency_ms_p50": 19529.727,
+          "latency_ms_p90": 27099.135,
+          "latency_ms_p99": 28934.143,
+          "hdr_v2_base64": "HISTEwAAASYAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAKVaAvcDAuMBAr8DAkkCOwI1AlUCCwLLAgI9AqEBAhsCEQKPAQJPAtkBAp0BAjMCvwEC7wECPQKDAQLZAQK1BwKxHgKlBwKhEgKdAQLPBALJAQLlAwKlAwLLAQKZAgIZAp0EAusBAs0BApEBAlUCpwICqQECSwIrApcCArUDAuECAhUCgQIC1QECqwECtQECAAKhAQKrAQIDAt8BAtUBArkBAs0BAoEBAoMBAlcCFwIzAgACQwJXAlcCUQIdAgcCIQQAAgMCBQIDBAMCDwIHAgUCGQIDAgcCCQITAgkCAgIAAhcCBQINAgsCBBcCDQIrAgcCFQIFAgcEDQILAhECAgcCAAIAAhkCCQITAgMCGwIDAgILAgUCEwIAAh8CGQIHAhECKwIXAg=="
+        },
+        {
+          "operation": "contribution_read",
+          "requests": 531,
+          "errors": 0,
+          "latency_ms_p50": 16777.215,
+          "latency_ms_p90": 22757.375,
+          "latency_ms_p99": 24100.863,
+          "hdr_v2_base64": "HISTEwAAAzYAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAOcYApMFAmUCtQECTQIVAi8CIQIAAjMCOQIFAjcCAwIjAgsCFwIAAgUCHQQRAicCAhUCEwI9AgkCDQJBAhkCBQIbAl0CkQECAwIpAjECHwJhAksEPQIdAicCDwIJArMBAhsCcwIjAnUCAAIHAgUEBQIFAiMCXQJZAgACDQIAAi8CUQIHAgsCFQIdAn8CBwIDAgkCAh0CFQI1Ao8BAgACAwIFAjUCDQI3AgMCKQLPAQJdAg0CsQECgQECqwECcwK/AgJlAoEBAhcClQQCAwLHAQIbAnkCtwECoQoCAwLHAwKBFgLtBgLLEAKpBALJAgKzAgK3AgKZCQKjAQL5BQKPBAKPBQKLAQIdAlsC6QICSwLtAgJXAscBAhEC9wEC7wECOQIdAisC6wICJwKzAQIVAgsCFwJTAh0CJwIzAhECfQIhAmsCoQECKwJJAgsCBQKrAQInAgACpQECKQJPAiUCGQJDAg0CLQJNAi8CRwQbAisCIQILAg8CAAIDAgACYQILAkcCAAQFAg8CAgMCFQICgwECjwECWwIJAhMCXQKZAQJTAgkCEQIbAjsCgwECSQIZAiUCBwJFAokBAlkCFwIzAgUCNQI3AhMCBwI9AjkCDwIRAiUCQwIrAgcCJQIlAgcCFQQJAgcCAicCMwIzAjkCAAJZAhcCEwIPAg8CKwI5AgACMQI7AksCJQQJAiMCAj0CKwIFAjECPwInAikEBwItAiMCLQIHAjkCNwIxAgMCFQIhAhUCAwILAh0CAhECBAQAAg8EBQICAgAEBAUCAAQCCQQCAAIABAACBwQCAgMCBwILBAMEBAICAAIABAQEAgYCAAIIAgoAAgQGBAYKAAIAAgIAAgYCAAIEAgIFAgQDAgYAAgACAgIFBAIAAgIEAAIAAgICBgUCCQQCAgQCBAgCAAQCAAICAwQCBQQCAAIDAgIRAgUCAAIJAg0CAgcCAgMCBQIHBAUCAgUCDQIHBAACBwQPBgQCBAICAgQCAAYCBgIGBAIDCAIEBAICAAQCAwICAgACAwIEAAICAgAEBQIZAgACAgQCAAIABAICCQIEAwYFAgMCAgYHBAACAAQCAAIVAg0EAAIFAg=="
+        },
+        {
+          "operation": "directory_create",
+          "requests": 41,
+          "errors": 8,
+          "latency_ms_p50": 24575.999,
+          "latency_ms_p90": 30048.255,
+          "latency_ms_p99": 30162.943,
+          "hdr_v2_base64": "HISTEwAAAFgAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAALu7AQK7EQLhCAL3BQKrBQI1AmkC4wEChQICzwgCLQJXAj0CBQJHAhECbwKnAQLLAQK/AQJtAmMClwECLwJBAhECTQILAgsCIwITAj8CIQQEAgACAAIAAgI="
+        },
+        {
+          "operation": "directory_read",
+          "requests": 4641,
+          "errors": 1608,
+          "latency_ms_p50": 60.799,
+          "latency_ms_p90": 15319.039,
+          "latency_ms_p99": 26329.087,
+          "hdr_v2_base64": "HISTEwAAFWMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAIETAsUDAmECIwIbAokBAhsCEwIRAiECAwIhAgUEAAJBAhcCFwIZAgsCJwIFAg0CTwIDAgMCSwIPAg0CAgMCDwIpAgACAh0CBwICBQIvAgsCAwICAwIpAgIDAikCCQIDAhMCBwIAAgMCBwIAAgMCAAIAAgQDAgACAAIAAgkCAg8CCwQDAgMEAhEEBQICAAIDAgICAwIFAgQCAAIDAgIFAgUCAg0CBwICBQICCwIHBgINAgMCAwIAAgUCBwILAgIHAgUCBQIFAgIDAgAEAgIHBAYDBgICAwIFBAIFAgIHAgICAgACAgUCAgAEBAcCBQIDAgACAwIDAhEEAAIEAwQAAgIDAgYFAgIEBA8CBwQCAgUCBAQGAwIEAgACAgQHAgMCBAMCBAQCBgMEAAQABAACAwQABgkEAgICAwICAgIEBAACAgICAgIEAwIABAQCAwIHAgIABAIFBggFAgMCBAMCAgIAAgIFAgMCAAQEAAQCAwICAwIEAgIDAgQCAAICAAQCAgAEBwIDAgcCAgQABAQHAgICAgMCAAQABAMCAgAIBQICAAQCBAIAAgIABAACAgICAwIEAAQAAgQCAwICAgILAgMEAAIHAgACAgICAwIEBQIGBAICAgIEBQICAgMCAAICAgIEAgIDAgQAAgYIAgIABAACBgYCAgQEAgQAAgQCBgIDBgUCAwIEBAICBQIAAgQCAAIAAgMEAAoEBQICBAICAgIAAgQACAIDBAgCAwICAgQGBAIEAAIABAACBAACAAIEAgIHBgAGBAIGAgAEAgUCCAQCAggAAgIABAIEBgICBgAGAgQCBwQCAAICAgAGCAUCAgICBwQIAwYABAAGAgQCCAIEAgQCAgICBAQAAgICBgMCAgYCAgcEAAQABgIAAgICAgQCAgIAAgIEAggAAgQEAAQCBAIAAgACAgYAAgACCAAEBQIJAgYCAgQIBAMEAgQFAgAGAgoFAgQCAwQCAgIACAIDAgQAAgICBAYEAwICAgACAgQCAAQAAhEECQIDAgACCwQDAgMCAwICAgACAAQCAAIEBgIAAgYDBgACAAQCBAICAwIHBAIEAgACAgQCBwYDAgIDAgIDBgQDAgQCAgIEAAIIAAYCBAICBAQCAgcCAAIEBAACAgACAgICBAACAgQCAAoAAgQDBAYEBAACAgIAAgIGBAACBAIFBAMCAAQEBAAECAIAAgMCAgQEAgIACgIAAgICAgIDAgIEAAQCAgQGCwQAAgMGBAAGAAYEAgQABAIAAgIJBAIEAAgEAAIABAYABAIEAgMCBAQHBAIKAgQEAgQEBwIEAAQEAAYCAAQGAgIABAIEBQICAAQABAIAAgICAgYCBAUCAAQCBwIEAAQAAgIAAgYCAgIAAgIAAgAEBwIABAIDAgAEAgMEAgACAwICAwICAgMCAgYCAAIDAgIABgMCAAIFBgIDAgACAgQCAAIHAgQCAgQABgUCBAIEAAICAwICAgACCwIDAgICAgIABAICAgIAAgINAgQABAICAwIEAgYDAgQCAAICAAQFAgMEAgAGAAIABAkCAgQCAwICBwQAAgQHAgMEAAICBAMCCQIEAgILAgIDAgIEAwIFAgIAAgIJAgMCBQIDAgMEAAICCQICAAICAgMCBQIAAgAEAAICBAIABAIDAgMCAgACAgQCAgIFAgICAAIDBAQEAAIDBAMEAAINAgACAAICAgACAAQCAAIABAAEAgACBAICBAAEAAYEAgACCQICBwIIAgACBAIAAgICBAIABAACAgUCAAICAwICAwIFBAAECwICAgICAgIAAgMCAAQABAACAAICAAQCDQICCQIAAgUGAgQCAgACAAIDAgQHAgQCAgACAAIFAgACCwICAAIFAgUCAgkCBAMEAg8CAgIAAgkCAwIFAgUCAgIABAUCBQQCAgQEAAIJBAIDAgMCAAIAAgACBQQHAgACAgUCCwINAgQABgcCBwICBQICAwIHAgIDAgACAAIGAgINAg0CBQILAgIAAhkEAgMCAwQAAgACAwoAAgICAwICAwQHAgIRAgIDAg0CDwQHAgIAAgACAwIAAgQCAAIHAgIEAgQJAgAEAAIDAgMEAgQHAgQAAgYCBAMCAgIJBAQABAAEBQIAAgAIBAMCAAITAgACAwICAAIEBwICBAMEDQICAgsCAgMEBQQCAAQDBAAEAgUCBAMCCwQCBgACAAIDAgMCAAQAAgQCAAQCBgMCAAIFAgQDAgcCAAIAAgACAgAEAAICAgMEAwICAAIEAAICAAIAAgAECQIFAgAEAgkCAAICAAIHBAcEBQIAAgMCAgACAgkCAAIAAgICBwICAgAEBwYHBAMCAAICBAIDAgIGAwQCAAIDAgACCQQDBAACAgAEAwICAgACAwIECQIFAgUEAwIABAIABAIHAgIAAgACAAIHAgICBQQEBQYCBgACBAIHAgcCBQICBwIHAgQHAgYCAwICAgQAAgcCAAIFAgIEFwICBA8CAgQDAgAEAAICAgQCAgICAAINAgcCBQQDAgkCAgMEAgIAAgILAgUCBwQCAgMCAAIFAgcCAgIJBgQEBQIJAgcCAgUCBgkCDQIABAIFBAMCDwQEAAIAAgIDAgcEAAIDAg0EAgQAAgACAAIAAgkCAAIDBAIFAgACAgACCQIHAgACDQQDAgACAhkECwICBAACAwQFAgACAgACBQQAAgkCAAIDAg0CAgkEAwILAgACEQIDAgIAAgIAAgcCBA0CAAIHAgUEAgICBAACAAIHBAQEAAYAAgICAwIEBwQXAgMCAwINAgsCFwIEAgIDAgUEBBMCAAITAgUCBQIJAgMCBwIPBAICCQIRAgUCAAIHAgUCAwQDAgACAwQAAgQCBQICAgACAAQCCQIHBAICAgIAAgIHAgMCAgMCBwIAAgsCBQQCAwIABAcECwIHAgAEEwIAAgcCAgQDBAAEAgMCAgcCAgICBAIDAg8CAwIFBAIHAg0CAgUCCQIJBgcCAgUEBwIEAAQFAgACAgIAAgQXAgMCAgMCAwIDAg0CAwIJAgUCAgIHBAACAgsCBQQCBgMCAgIAAgMCAgAEHwIFAgsEAAICAwYHAgcCAgUCBwIABAACCQIAAgMCBQICAgIDAgMCAAIFAgACBQICAgUCAAIDAgkCBQIFAgIXAgICAgUCBwYLAgkCAwICEQIHAgIFAgMCDQICAhUCCwIJAgkCEQINAgUCCQIHAgMCCQICDQITAgACAAIDAgACBwICCQIAAg0CAgUCAiUCHwICAwIPAgsCMQILAgUCBQICCQICAh8CBwIDAgACBQIAAgI1AgkCCwIJAgMCBwILAgUCBQICBQILAgACAAIAAhMCAgkCAgMCPQIJAgIFAgMCFQICAgsCEwICKwICHQINAhcCEwILAgMCDwICBQIhAgINAgcCBQIJAgILAgUCBwIbAhMCCQINAgcCAAIPBAUCBQIFAgUCCQITAgsCBwINAgUCDQIFAgINAhUCDwIPAgIDAgUCAwIFAi0CLwITAgUCAwIFAgMCAgUCCwIHAg8CEwIAAgIPAh8CCwINAgUCCwQCAwIDAisCVwIJAgUCAgkCAwIdAgACAgMEDQIHAgACBwICEwINAg8CCwIFAg0CCwIFAh0CAAIvAj8CDQIPAhECMwILAoEBAgkCBQJLAgMCAAICBQIfAgsCEQIlAgkCBwIDAjUCRQINAgkCDwIFAkECCQIJBBECBQIPAgcCDQIDAgsCAAIDAgMCAwIFAhMCAwICAiMCFwIJAgkCDwI7AhUCBwIHAhMEAgUCAAINAgkCAAIRAh0CCwIZAgMCDQILAgkCBwINAgACEQIPAjkEAgMCGwITAikCDwI1Ai0CIwIPAgUCDwIAAgACBwIJAiUCFwIFAh8CBQJTAgcCMwInAmUCHwICGwJdAgsERwQjAgcCGQIPAgsCBQICQQQvAiMCAjMCOQIJAjkCFwICIQIDAhsCJwIPAhMCTQItAhMCBQIHAiMCGwICNQIbAgkCAwICFQINAgACFQIAAikCaQINBAACAwIrAhkCIQIFAgUCDQItAhMCVwI5BAUCGwINBDMCKwIRAisCKQIDAlECEQItAhUCawIdAg0CBQICOQIJAi0CCwIRAg0CGQIHAkcCRwIZAhMCBQIrAicCCQITAi8CCQIHAg8CIQIDAgACJwI3AhMCCQIHAiECCwICAg8CAgcCAAIXAi0EEQILAg0CCwIdAg8CAAQCLwJNBBECFQIXAhkCDQIHAgMCLQJDAgsCAAIXAg0CDwIhAgACHwIlAgACFQIVAgACAiUCMQIAAgkEBQICZwI3AiUCJQIXAgIpAgMCGQIdAgUCMwIDAgJLAgsCMQIpAg8CAwIjAgsCCwQHAgMCAAIDAgcCAh0CBwIDAgIAAgACAwIAAgUEBQINAhcCAgcCFwIdAg8CAlsEAwIDAgICOQIRAhUEBwIJAi8CGwQ/AhMCAg8CAAIDAgcCHQIPAgIFAh0CHwIAAgILAhsCDQILAgkCCwIHAiMCCQJNAiECAgACAAICPwINAgUCDwITAhsCRQIPAhkCDQIJAjUCFQILAgUCBQIzAgcCEQICAAIFAgsCBwIDAgUCEQIAAiMCAAIdAgkCAAQLAgACCQINAgACCQIDAgACAwIZAgcCFQILAgUEBwIRAgcCJQIHAhsEBwIPAgAECQIAAhcCCQITAhECHQYFAgIJAgILAg0CDwQDAgUCBwIAAgICAwICAAIFAgIZBAUCBQIAAgQNAgMCEQIAAgsCAAIJAgAEEwQCBQIEAgUCAwICBwIVAgIDAgMCAwILAgUEAAIHBAMCAAICBwIFBB0CBQIDAgACCQIDAgMCBAACBAICAwIPAgACIQIFAgACCwIDAgIrAgcCHwIAAgUCDwITAgUCAgUCAgMCAAICAgMEBAMCBQICAgcCAgACBwIJAgkCAAIDAgcCBwILAgIPAgMCCwIRAgcCEwIRAgAEAAICGQQNAgACCQIPAgUCBQIJAgMCDwIPAisCJwIJAgcCCwIPAhUCBwIHAg0CCQIPAgsCBwIDAgcCAAIDAhMCAwIHAgICFwIXAgIAAgIDAgACAgQCAgIFAgAGAwIDBAACAAICAAIAAgIDAgQHAgIDAgUCAAIAAgACBQIHAgILBAICBwYCAgQCAwIECQQDAgACAgACCwIJAgcCAwICAAIHAgUCBQIHAgILAgAEAhEEAwILAg8CAAQPAgkEGQICCwIFAgIDAg0CDwILAgACAwIFAg0CAwIFAgsEBwIHAgIDAgUCAAYCAgMCAAIAAgICAgACAAICAgICAgAEAwQDAgIEAAIDAgIFAgUCAgMCAAYCCwIHCAIAAgACAgQCAgIFBgAEAgcEAwIEBwQNAgcCAgUCAgICCwIAAgkCCQQLBAICFQICAgcCAAIEAwIDAgICAwIDBAsCAAICAgACBQIAAgIEAgIAAgkEAAIGAgIAAgAEBAICAAIDBgICAgUEAAQDBAIEAgMEAAIDAgQCBgACAgACAAIAAi8CKQIAAhMCGQIHAgACAgcCAAYFAgACAg8CEwILAgcEAwIEAwIDAgUCBAUCAgsCBBUEBQIPAgUCCQICGQIZAhkCGQIrAhcCGQINAhkCFwIFAiUCBQINAg8CCwINAgkCAwIZAgMCBQIDAgsCCwINAgkCBQIJAgACBQIAAg0CAwIHAgsCAAIFAgQHAgILAgUCAAIFAgMCBQILAgkCAgIABAsCAgIHAgsCCwQLAgMCCQITAgkCBwIhAgUCCwIDAgMCAAIHAgUCAwICBwICAhsCBQIHAgACXQIJAhcCAAILAgMCCwIDAgACAgUCBAACAgMCAgQAAgUCAAICAgQAAgMCCQILAgQCAAQCAgIFAgMCAgQABgMCAgcCAgUCCwIDAgIJAgkCAhcCAgUIAAIFAgIDAgMEDQIJAgcCAwICAAQRAg8CBwIFAgsCBwICAAIAAgACDQIEBwIHBAUCCwQCAAICAwSVAQQFAg0CAwIHAhMCAAIVAhcCDwITAgIxAjkCCwIHAgItAhcCAwICFQIAAgcCJQINAgsCCQQAAgIFAgIHAg0CCwIAAgkCAgcCAwIAAgMCBQICAAIEAAIHAgICAgIFAgIDAgMCBwIFAgIHAgMCAgMCAAIFAgkCAgACAgIDBAMCAwICAAIDAgICAgIAAgQEAgQLAgkCAAIDAgkCBQIAAg8CDwIVAj8CFQQAAhMCBQQCAg4GEAoIDAoEBgICAgIEAgAEAgQABAICAgICAAIEBgQAAgACAggABgYEAgYABAICBAICBAICBAIEBAgEBgACBAcEDQICCQICAwQCBQQCAAQCAwYGAAIFAgYCBgIEBAgCAgIMAAgCBAACBAIGAAQDAgACAgUCBwIGAgICAAQCAAQEBAIAAgIAAgQCAgUEAAQCAgQIAAICAgYAAgQCAAIAAgQCCAIEAAQEAAoGCAgKBggCBAQGCgQCBAgIAggGBgYKCAoaBAgWDA4IBgoEAAIDAgAEAgAEAgYKAAQAAgIEBgYGBAIAAgACAAQCAAIAAgQCBAAEBQICAwICBAACAgIPAgUCAAIABAIDAgcGAgACBAICAAoECAQECAYGBgoCDAoGDAYCBgACBAIIBAIEAAQCCAICAAIDAhkCBwIPAhMCAgACAgINAgUCAgkCBAACAAQAAgMCAAIAAgACAwIAAgIFBAUEDwIJAgYCCAICAgACBCcCAgkCAAIDAgIHAgMCAAIDAgAGAgsCAhcCDQIFBAUEAwICDwIFBAUECwICAgIEBgIFAgAEAAIEAwIAAgIEBAwCBAAEBgQAAggEAgQIAgIEAggKCAAEBgIDAgMCAAIABAUEBgQCCAIEAAIEAwIACAoCBAgEAAQCAgQAAgIAAgICAgICAAYEBAACAAIFAgACBgAGAgQGAAYGAgQAAgACDAYCBAIIAgIEAgAEBQICBgIFBAYCBAQEBAIEBgQACAYABAYCBgIAAgcCAwIDAgILAgACAAIAAgACAAICAgUCAgYJAgMGAAICAgUCVQIlAkUCIQQJAjECYwIAAgIrAi0CEwIjAgACBQIAAgACCwQDAgcCHQIAAgACBAMCAgACAgUCAgQDAgACAgIDAgICBAgEAgQEBAwICAIEBgYGAAQCAgIEAgIAAgQGBQQABAIAAgIAAjsCBwQCCwQJAgkCLwIAAgQFAgcCOwIDBAIAAgcCAAQCBAQCBgYEBgYFBAICAwgIBAYCAAICAwQGAgIEBgIEAgYCBgYIBAICAggCAAQDAjkCBwIRAgACAwIFBgACBQILAgACGQIABAcCBQICAgsCAgACAgICBQIACAAEBAQAAj8CAAIDAg=="
+        },
+        {
+          "operation": "directory_update",
+          "requests": 66,
+          "errors": 0,
+          "latency_ms_p50": 6701.055,
+          "latency_ms_p90": 11673.599,
+          "latency_ms_p99": 12640.255,
+          "hdr_v2_base64": "HISTEwAAAJwAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPUnAq8GAoECAkECOQKXAQJdAlkC7QQCuwQC/wICqwICvQ0CYQLLNQKRFAKzEALbAwLHCALnBAIHAtMDArUBArsCAuUGAscDAtUCAmsC5QECKwLBBAJLAh8CKwIXAl8CIQI/AmcCCQIbAhsCVwIDAjkCDwKDAQKTAQIdAgINAiMCDwIAAnECSwLNAQTBAQIHAiECCwI7AgkCIwJHAg=="
+        },
+        {
+          "operation": "ehr_create",
+          "requests": 65,
+          "errors": 0,
+          "latency_ms_p50": 3424.255,
+          "latency_ms_p90": 6074.367,
+          "latency_ms_p99": 8142.847,
+          "hdr_v2_base64": "HISTEwAAAJ8AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAKMiAjEC+wICEwLRBAK1AwLzBAK/AQKzAQLZBAKhBgKjHQKRAQKLAwLfKALVDgL/CgKFAQKpAgLJBgJTAocFAsEBApkFAqsEAgcCAtEEAscCAhUCowECsQECFwIFAgkCFwJZAhMCEQIhAlkCBQJrAm0CCQJ3AoMBAgIPAgILAhECMQLLAQJ1AmECGQLnAQJBAiMCWwLpAgILAs8CAp8BAg=="
+        },
+        {
+          "operation": "ehr_read",
+          "requests": 474,
+          "errors": 0,
+          "latency_ms_p50": 13262.847,
+          "latency_ms_p90": 19398.655,
+          "latency_ms_p99": 20643.839,
+          "hdr_v2_base64": "HISTEwAAAxEAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAL8ZAlcCswICqQECGwKDAQIXAkECEwIjAmcCGwJvAhUCEQQDAicCMQJNAg8CCQIpAgACSwINAg8COQIDAkECIQIFBC0CBQIZAgsCQwIdAg0CCwIAAlkCAwInAk8CAwIzAn0CCQIXAq8CAgACBQIDAnECFwJfAgYNAjMCIwIZAhMCMQICGQLBAQIDAi8CHQKBAgIDAhkCCwJBAgcCEwINAoMBAiUC3QECbQKJBQJDAkMCxwMCMQIPAtUBArcGAs0GAokMAq0BAocHAq0DAvkcAi8CjwECow8CvwICywMCxQMCywECeQIDArcEAucBAosDAqUBArMBAhECqwIClwICOQLzAgIHAn8CNwIFAkMCIQI5AmkCAkUCBwIAAnUChwECBwKnAQIPAkcCEwJtAgcCBD0CgQICLwJ1Aj8CCQI5AgkCKQJJAlMCMQKPAQITApMBAhUCBQIrAgUCAwRFAgMCDQIXAgkCGwIRAhECLwI1Am0CmwECAwJnAh8CYwITAisCaQJvAlUCLQJLAgUCFQICAwInArcBAlUCQQJpAmcCQQI7Ag0CFwIbAg8CIQIzAg8CEwIfAiECFQIVAhECCwIZAgcCCwIRAg0CNQIbAjECGQIVAhkCAk8CPQIdAg0CQQIlAisCAAI1BAACPwIpAgIZAkECHwIFBgUCBwQFAg0CAgIDAgUCAwIDAh0CBQIHAgIZAgUCAwIDAgsCDQIDAgcGLwICBwITAgACAAIRAgIFBAACAhECAAINAgQEAwICBAILAgIJBA0CFwIHAgMCAAIGAgUEBQQDAgUCAgcCBAAIAwIAAgACBQICCQIAAgIAAgUEBAAEBAQCBAYEAgACAgQCAgcEAgIAAhECAAIHAgkCAgUCDQILBAQDAg0CBAMCAwITAgINAgcCAgsCAAIAAhUCAAITAgACAgMCAgICAwICBAUCBAACAgcGAAICBAACAAQABAACAgcEAAINAgACAAIAAgIJAgMEAgIGBAQDBgQCAgACAgQAAgQLAgAEAgUCBAMCBAIABAICAgIjAgsCBQIDAgQE"
+        },
+        {
+          "operation": "ehr_status_read",
+          "requests": 130,
+          "errors": 0,
+          "latency_ms_p50": 10928.127,
+          "latency_ms_p90": 25591.807,
+          "latency_ms_p99": 28639.231,
+          "hdr_v2_base64": "HISTEwAAASQAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAL0ZArEHAjUCiQECGQK9AgKhAgIHAq8CAokBAtsEArcBAj8CsQECbQIhApkCAgcCPQLFAwKnBgLtAQLTAQLzCALPAwK7DQKHAwLPMgLnDQKFBAKJFQLBAwL9BQKJAQIlAjkC7wECSQKtAgKfAQL9AgIAAvMBAtkBAjMCmwICBwLFAgIjAm0CuQICEQLPAQIPAgUCFwL1AgIbAssBAi0CHQIDAgUCIQI3AiMCKQI9AhcCUwIEBQICPQIxAg8CDwITAisCFQJ5AgIHAg0CMQJnAmsCewIdAg0CSQIhAh0CAwIvAh8CIQJVArcBAmsCHwJbAnMCcQIPAhUCAwIZAgkCAwInAjECLQINAhECaQIhAikCAgsCAh8CBwJRAgcCKwIvAiUCLQI="
+        },
+        {
+          "operation": "ehr_status_update",
+          "requests": 122,
+          "errors": 42,
+          "latency_ms_p50": 313.855,
+          "latency_ms_p90": 18579.455,
+          "latency_ms_p99": 24051.711,
+          "hdr_v2_base64": "HISTEwAAAR4AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAH8CgQECRwIbAqsBAkECVQIvAhsCAAI7AtcCAgkCAALNAQIPAh8CUwIXAlUCDQIPAgACAAIAAh8CPwIHAj8CGQIDAkUCMQJFArMCAiUCiwICjwECRQLbCwLBDAL3DAKlAgLdAQIzAi0CuQICBQKDAQJPAjcCbQJZAhEC7wYCtwwCxQIC8xIChxsCIwKtBwKtBQLrAgLLAQLTBgKjCgL5BAKnBgKHBAKbAQKbAQKXBwKNAQKPAQLbAwIAAq0BAv0CAgsCgwICjwUClQECFQIvAgsCLwJtAkkCDQJhAskCAgI5Ag8CLwIDAiECpQECQwIzAjUCtwECOQKZAQIAAh0CAi8CswkCNwIJAhECOQIZAksCzQICCQIzAgIvAg0CMQI="
+        },
+        {
+          "operation": "stored_query_execute",
+          "requests": 981,
+          "errors": 0,
+          "latency_ms_p50": 10469.375,
+          "latency_ms_p90": 15687.679,
+          "latency_ms_p99": 16678.911,
+          "hdr_v2_base64": "HISTEwAABbMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAME8Am8CzQECGwI3AjkCBQI9AgUCDwICAwQ5AgACDwIAAgAEAgIAAi0CAwIDAgACLQQCBQQTAgcCDQIAAhECAwIJAgMCFwINAgMCAwIDAgMCMwICBQIAAgACGwIJAgMCRwIFAh8CGQInAh0CAwIAAhcCEQICAAICAgUCAgIDBAInAgACBQICBQIHAhUCBwIFAlECAAIPAgkCGwIJAhkGCQICAkUCCQICBQIVAgK3AQIJAhcCAwJFAh0CEQIAAgJBAh0CAAIAAgAEQQQlAiECAgsCRwIDAgcCBQIAAg8CAjcCAAIAAgkCCwIJAgkCaQIRAgUCAwIvAh8CAicCCwKTAQIzAiMCFwIjAjMCJQIVAhMCCwIVAi0CDwIAAgUCFQJvAg0CPQIPAhUCEwKlAQILAiUCvwECQQKTAQIvAgMCQQJ7ApMCAi0C1QECKwIFAgACiQICCwIHAmcEqwECEQKdAgLbAwK/AQIVAi0C+wECvQQCJwL7AwLbAQKpAQKNAQIjAtsBAv8JAu0CAh0CKQKtAwKJAQJpAtEBAqkBAjUCsQMCZQK1AgIvApsDAjUCFwIxAgcCBQI/ArcCApkBAg8ClQMCtQECvwECRQIAAi8CBwKhAQI5AjEClwECBQKVAQILAgsCNQIPAl0CBwIpAi0CAwITAgACKQITAkUCIQI7AhMCCQIXAgkCAh0CKQI9AhcCEQICVwINAmUCBQKZAQI9AjUCKwIxAikCBQIVAhkCGQIDAgcCEQIZAgUCEwIlAhMCCwIJAjcCDQJHAhkCBQJLAg0CFQI9AgkCFwIZAgACBQIPAhkCAAICGQICBwIAAh8CAwI1AgkCLwIVAgACBQJJAh8CAgkCEQIABA0CEQIDBAMCAwIZAksCKQIFAj8CCwJDAg8CGQIDAgMCAgJlAjECYQI3AiMCFwIfAjMCHwIdAisCKwIXAhcCIwIPAgMCHwIvAhUCJQIhAhUCCQIPAicCEwIdAh8CAgUCCwICAwQjAhUCCQICEQIAAh8EBwIXAgMCAgsCBQIZAh8CDQINAgkCAwIXAiUCDwItAhUCAiMCAhUCAAITAisCJwInAgUCEQIdAh8CIwIdAg0CGQIAAhECAAIHAgsCDwIHAiUCMwIhAjECKQIjAhsCBQIbAg8CAwIJAhUCAhMCEQIHAhECAgACBwILAgUCEQIjAgUCEwIdAhcCHQIPAhkCBwQCAAICAgQCAAgCAgIGBAQCAAIFAgAEAgQAAgACBAQAAgYHBgIABgAEBAICBgICBAIAAgIFBgACBQINAgIHAgACAgIAAgACAgICAgMEAAIEBAACAwICAgAEAgQCAgQCAgACBAAEAgICAAYCAgUCAgACBQIEBQIAAgQDBAACBAcCAgAEAAICAwICAgIAAgIEAAQDBAACBAIAAgMEAgAEAwIEAwICAAYCBgMCAwQDBAQABAIGAgIEAAgEAgQCBgwGAAQECAQCAgcCAgQFAgQABAACAgAEBAIABAQEAgIAAgICAAIGAAYDAgMEAgACBQIEBQIFAgkCAwIAAgsCAAQABAQCBwIEAgQAAgACBAYAAgICAwQEAwIAAgQCAAIABgMCAgACAwIPAgMCAAIJAgACHQIDAgsCAwIAAgIAAgIAAgMCAwICAgkCCQIDAg0EAwINAgACAwICAwIDBAIDAgACCwIJAgUCBAACBwIPAgMCBQIHAgMCAwQCDwIHAgUECQICBQIHAgACBwIJAgkCAAIPAgICBQICBQICAAIDBgACAgIEAwQAAgICBAUCBAYEBwICBAcEAgMCAwIGBAsCBgQCAgICAAICAAICAgICAAgABAACAwYAAgICAgACAgIAAgICBgQABgQCAwICAAQFDAIDAgMCAAIEBQIFAgACAwICAAIABAIAAgICAgIHAgICAgACAwIHAgUCAAIAAgcEAwQJAgMCAwIEAwIAAgUCAAI="
+        },
+        {
+          "operation": "tags_put",
+          "requests": 163,
+          "errors": 4,
+          "latency_ms_p50": 14032.895,
+          "latency_ms_p90": 19529.727,
+          "latency_ms_p99": 30064.639,
+          "hdr_v2_base64": "HISTEwAAAWAAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAMkkAt8BAkUCPQK3AwJDArsBAqsBAqcCAkMCZQI9Am8CxwICxwIChQECUQIlAhEC9QEC+wMCTwJlAo0BAsECAhsChQEChwEC9QEChwICxQECoQsCZwKVDgKPHQLpFAKbEgKtBwLVCAKhAwLfAQKBAQJLApMEAqEDAk8CHQJnAqcBAtEBArEBAgsCaQKPAQJtAoMCAncCdQKBAQJHAgUCewI3AtsBAscBAsECAlUCaQJRAiMCNwIDAnECDQKlAgJdApUBAnMCcQIJAgACFQItAl0CAgkCQwIHAgICCwIAAhUCMQIJAgkCBQIJAiUCAhcCBQIDAh0CBQIVAgACBAMCDwQFAgUCAAICAiECBwIJAi0CDQIJAgcCUwIbAgkCCQIDAgQRBAACAAIAAg0CCwIDAhECBwIJAgACBwIAAgACAgUCAwINAgMCCwIHAh8CHwITAjMCgwICqQMC/wICAgACKwI="
+        },
+        {
+          "operation": "tags_read",
+          "requests": 163,
+          "errors": 0,
+          "latency_ms_p50": 3405.823,
+          "latency_ms_p90": 15237.119,
+          "latency_ms_p99": 20037.631,
+          "hdr_v2_base64": "HISTEwAAAWMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAANUYAokCAhMCpwICAwIrAjECJQKvAQIdAj8CrwICCQIZAlECNQIhAmECWwJJApcBAqMCArsBAp8GArkBAjsCcQKfAgJ/AvMEAokBArcgAoMBAtUCAo0VAvcIApMEAsMOAp8FAp0HAukCAskBAocBAtsCAnUCdQKxAQL7AgLDAgI3AhUCVwIZAo0DAkMCxwIC3wECGQLPAgLTAQIjAokBAg0CRwKzAQKpAQLzAQJlAkUCNQIAAgI7AlUCCQI3AgMCRQIHAgAEBwIZAhcCMQIFAh0CEwIJAhkCTwIVAgUCDwICBwJBAhMCDwIrAjsCCQITAlsCGQJTAgINAgACAhUECwICAwIvAgACBQJjAj8CAAK5AQQ/Ai0CqwECPQIdAgACCQJPAo0BAnkERQInAm8CewJpAhsCdwKTBAKfCAJNAlMCCwIxAi0CTwKFAQIAAlsCTQInAjMCCQIhAn0CCQICAicCBwI="
+        },
+        {
+          "operation": "template_get",
+          "requests": 409,
+          "errors": 0,
+          "latency_ms_p50": 3330.047,
+          "latency_ms_p90": 6103.039,
+          "latency_ms_p99": 7970.815,
+          "hdr_v2_base64": "HISTEwAAAxMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAALEfAtsBAqkCAgAC/wECRQL/AgJBAnMC5QECvQYCCwLzAgJ1ApcBAlUCLwK7AQLFAgJ1AgsCCwIFApEBApkCAiECdQJNAhECbwJtAiUCMwITAr8CAkkCVQIjAjcCsQECawILAj8CJwKtAQJjAusBAjECBwIjAgsCGQInAh8CUQJRAhsCVQIAAgACbQJpAkECxQECQQKJAQJnAg0CQwJJAt8BAmECTwI5AjECYQKhAwKpAQLTBQKpAwJnAo0CAqUBAtkDAucBAlECqQYCHQKDBQJLAqUBAtcBApMJApEBAqkBAk8CrwMCxwECYQIAApcCAmEC0QECAwITAmECCwJBApEBAmUC7wECAAIZAlUCDQLXAQJlAhECMQILAjsCWQIrApUBAhMCFwJHAnsCFwItAhMCMQI3AhcCCQIAAq8BAgACAwIVAhkCAAK1AQLhAQIVAoUCAusCAhkEBQILAnsCWwI/BBMCHQI3AkcCLwIhAgcCDwILAgcCGQR/AhUCXwJRAmsCZQJjAicCBQIfBAcCAwIFAk0CAwIJAgACBQIPAgcCCQIAAgIJAg0CFwIHAgsCBQIPAg8EAAITAg0CEQILAgACFwQHAgACCwILAgIHBAsCCwIAAgIDAgICAwICBQICCQQPAgcCEQIHAgMCAgMCAg0CAwIJAg8EAwIAAhsCBQIFAgkCDwIPAgkCCwITAgMCAwQDAgACFwIRAgcCCQITAgACAgIHAg8CBwIHAgACEQICCwIPAgIZAgMCAgcCBwIJAgMCCQIJAgcCAAILAgUCAgMCJQILAgQHAgUCAgsCAAICAgkCAgUCBAIDAgACCAIAAgUCAgUEAwIHAgMCAAQAAgMCAgACBwQEFQIAAgsCBQILAgMCDQIjAgUCCwIFAi8CEwInAi0CCQIXAg8CBQIRAgcCMwIVAgMCSQIXAg8CAwIfAiUCBwIEDwQJAhECBQIPAgsCAwIdAgIbAi8CEwIAAjcCEQIVAg0EQwIJAg8CBDcCBQIAAh8CBwJFAiMCJwIhAiECUwQ1AgIDAg8COwIZAg0CCQI="
+        },
+        {
+          "operation": "template_list",
+          "requests": 409,
+          "errors": 0,
+          "latency_ms_p50": 3305.471,
+          "latency_ms_p90": 6029.311,
+          "latency_ms_p99": 7897.087,
+          "hdr_v2_base64": "HISTEwAAAvMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAOUSAoUBApECAssBAsUBAkECIwIfAg0CnQICNQI9AkkCEwKBAQIFAicCBQITBAcCDwIJAgMCDwgEFQQPBCUCAjkCjQECSwJvAhsCBwIlAhMCEwIPAgKNAQICqQECGwIjAjsCBQIAAmECJQJHAhUCQwIDAgcC4wECPwIpAt8BAhkCEQIHAiECYwLJAQIdAsEBAgcCSwItAgMChQUCiQECpwQCjQUC0QsC2w0C0QkCnwgC5wIC/wMC2QcCzQQCHQIVAk0C7QcCTQKPBwLnAQIXAp8BAkUCUQLLBAI5ArsBAg0CTwI7AjUCMQJNAtMBAkkCEwJRAhMCZwIDAjcCBwLDAQJjAlUCFQIpAsECAg0CEQJTAgkCAisCqwECTQIdAgACHwIZAgUCBwJHAgMCqQECHwKFAgIxApMDApMBBAcCKQICGwKzAQKXAQIRAhsCKQQVAhsCGwINAkcCDQIJAh8CCQIhAlMCcwJhAkcCaQINAlkCAAJdAgACAwIAAhMCPwICGQICBBECCQIJBDUCAgUCCQIHAgICAgcCCQITAhcCAg0CCwIHAhcCBQICBwIDAgACAwIAAgsCBAUCBwIDAgUCAgICAwIDAgINAgMCAwIVAgcCAgIDAgkCAAIDAgcCAAIlBg8CAwIVAhUCAwIFAgcCAhMCAAICAAItAhsCCwQRAgkCBBECAgsCAwIDAgIJAgMCBQIHAhMCAgMCAAILBAIDAg0CAhkCDQIbAgkCAAIHAgUCGQIPAgAEAAIAAgQDAgMCAAINBAIAAgIAAgcCBAACAAIAAgICAAIAAg0EAAIAAgUCAAIAAgIABAMCAwIAAgUCAgUCAgUCBwIFAikCAAJNAgsCFwILAgIjAhkCGQINAhUGGwIAAiECFQIrAnkCAgITAgACKQQAAgcCBQIFBBECBQInAgAEFQIFAk8CKQIJAgICTwICGQIFAg8CJwILAgIlAgIJAgkCGwINAjUCVQIPAjUCPwIlAgkCAAIHAgMCVwQ5AgMC"
+        },
+        {
+          "operation": "ward_query",
+          "requests": 980,
+          "errors": 35,
+          "latency_ms_p50": 3719.167,
+          "latency_ms_p90": 6561.791,
+          "latency_ms_p99": 8511.487,
+          "hdr_v2_base64": "HISTEwAABfYAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAALEhAu0FAjMCLwLDAwLZCAKZBQK5AgLDCgK/BQKhBwKvAQKbBAK5EgKpBgL5BALXAgKHAQIDBA8CJQIJAgACHQICAg0CBwIHAgsCHQIAAiMCGwIDAiMCBwIJAgACKwIAAgMCGQIEFwIJBAUCIQICEQIPAgMCDwIFAgkCDQIjAh0CAgsCAAIVAgcCCQQLAgACGwICBwYAAgUCFwQAAhECAwIfAgUCBQINAiECBQIFAhUCAwIFAgACBwQDAhECBQQRAiECGwICIwQNAgMCAwIPAgACAgsCAhUCCwIAAgACBwICBQIFAhkCBwILAgIAAg8CAwIPAgMCBQIFAg0CKQINAgIFAhECHwIPAgUCFQQjAgcCAwIPAgMCAwIPAgkCBwIAAgACEwJZAgMCCQIfAi8CBwIFAhECCwJ7AgsCDQItAiECHQIHBAIjAhUCBwIbAgcCHQIpAgMCaQICIwINAkcCAwIAAgACCQIpAicCAg0CHwJXAiUCEQIJAgkCJQIXAikCFwIJAhECGQIRAlMCBQI9AgUCDwIXBAINAiMCEwJFAmkECQITAhUCVQIPAicCEwIJAtkDAp8BAjcCowECFwIHAgcCLQIDAmECSwIzAjMCfQIvBF8CKQINAgUCNQIXAgMCBQITAhkCFQIRAhsCPwQCxwECNQJJAgsCJwKJAQIbAi8CDwINAjcEGwQ/AhkCTwJFAgMCJQIAAgcCBQIJAhkCAgsCAh0CEQIlAiMCAg8CBwIDAg0CBwICJQICHwIXAgcCDwIFAg8CAgACCwInAgcEEQIPAgIAAhsCAhsCEQIVAg8CAk0CAhUCAgkCAwIPAgACAAIVAgsCAiMCAAITBAcCGwIDAhECAwICHwIDAgMCFwIbAh0EBwIJAgACBwILAgINAg8CAAIJAgUCCwIVAkUCBwIABDUCAAJXAiMCLQIZAkECZQIlAhUCQwIlAhUCBQIEDQIAAhECAAIRAhMCCQIJAg0CEQIXAgcCCQIAAkUCAwILAgkCBQIDAgMEBwIDAgACDwICBwIDAgUCAwIFAgMCAgUCEQICAAIEAgIlAgUCEwIFAgkCOwQTAjECFwI1AiECVwIRAgUCNQIbAisCAAIRAgACXQInAhECCQQZAgkCAAIDBBECAAILBAIHAgUCAAIAAg0CAAIAAgcCAAIAAgUCFQINAgIbAgMCBAIAAgACAwIFAgMCAgUCAAIABAMCAgACAwIAAgICAgICBQICAwIGAgUCAAIABAACAgcCBQQAAgkEAgIGAwIJAgMCAwICBAACAgIAAgMCAAIAAgIFAgACAwYCBQQCBAACAAIABAUCBAMCAAIDAgIFAgQLBgQCAAIAAgQEBwICAAICAwQDAgACAAQABAkCBwICAwINAgACEwICAwICBQIFAgIAAgACAgIDBAIAAgQCAwICAgMEAAQCAgICCAMCAgACBQICAAQDAgACAAIEAAQCBgIEAgICAgMCAgYAAgQCAgACAgAEAgACBAIGAgICAAQCAgMCAAICAgQCAgAGBAICAAICAgAEAgAEAgICAgACAgACAAQCAgIAAgACAgMCAwYAAgACAgMEBAACBAYEBAACAgICAAIEAgQEBAgEAgUCAgAEAAQCAgYCBgIDAgICBAYJBAQCCQICAgYDAgYAAgIJAgIFAgMCAgACAgIAAgMCAgIFAgcCBQICAgIJAgACAgUCBQINAg8EAAIPAgACAwICCQQDAgUCCQIJAg8CCwIDAg0CBwIxAgIFAgACAwIDAgMCAwINAgkCAwIbAgUCJwIJAgITAh0CDQINAgIrAgUCBwIAAg0CBwIAAgIJAgcEDwQABA0EBwIAAgACBQIHAgIDBAkCBQIFAgACAgIAAgMCCQINAhMCAgUCTQIHAkkCAAIDAgUCCwIXAhECAAITAgICBQICBQICAAQDBAIFAgIFAgMCAwQDAgsCAAICFwIFAgcCAwIJAhsCDwIJAhsCAhcCAAInAgMCDwIJAgsCCwIAAgICBwIfAgACBwIDAgACEQIEAhECDwIAAgAEAAINBD8C"
+        }
+      ],
+      "stable": false,
+      "breaches": [
+        "adhoc_query p99 8110.1ms > budget 1000ms",
+        "composition_commit p99 23969.8ms > budget 1000ms",
+        "composition_read p99 22626.3ms > budget 1000ms",
+        "composition_read_current p99 20873.2ms > budget 1000ms",
+        "composition_revision_history p99 23855.1ms > budget 1000ms",
+        "composition_update p99 24035.3ms > budget 1000ms",
+        "contribution_commit p99 28934.1ms > budget 1000ms",
+        "contribution_read p99 24100.9ms > budget 1000ms",
+        "directory_create p99 30162.9ms > budget 1000ms",
+        "directory_read p99 26329.1ms > budget 1000ms",
+        "directory_update p99 12640.3ms > budget 1000ms",
+        "ehr_create p99 8142.8ms > budget 1000ms",
+        "ehr_read p99 20643.8ms > budget 1000ms",
+        "ehr_status_read p99 28639.2ms > budget 1000ms",
+        "ehr_status_update p99 24051.7ms > budget 1000ms",
+        "stored_query_execute p99 16678.9ms > budget 1000ms",
+        "tags_put p99 30064.6ms > budget 1000ms",
+        "tags_read p99 20037.6ms > budget 1000ms",
+        "template_get p99 7970.8ms > budget 1000ms",
+        "template_list p99 7897.1ms > budget 1000ms",
+        "ward_query p99 8511.5ms > budget 1000ms",
+        "error rate 0.3361 > tolerance 0.0010"
+      ],
+      "generator_bound": false,
+      "resources": {
+        "sample_interval_s": 10,
+        "containers": [
+          {
+            "role": "sut",
+            "name": "ehrbase-rs-ehrbase-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 40.60838451439249,
+                "rss_bytes": 677191680,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 8662576855,
+                "net_tx_bytes": 9178081379
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 47.63337549490345,
+                "rss_bytes": 676859904,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 8717283162,
+                "net_tx_bytes": 9196528568
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 38.23382120004949,
+                "rss_bytes": 677187584,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 8780256481,
+                "net_tx_bytes": 9215394632
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 47.268811010601766,
+                "rss_bytes": 676913152,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 8837357695,
+                "net_tx_bytes": 9233544954
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 56.777425910722975,
+                "rss_bytes": 678010880,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 8893296623,
+                "net_tx_bytes": 9248596831
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 90.50698294558272,
+                "rss_bytes": 677761024,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 8950519547,
+                "net_tx_bytes": 9268590555
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 76.1924891774062,
+                "rss_bytes": 678354944,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 9007495455,
+                "net_tx_bytes": 9283605971
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 108.47134662661651,
+                "rss_bytes": 682287104,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 9033799598,
+                "net_tx_bytes": 9288490736
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 107.10240288536347,
+                "rss_bytes": 684036096,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 9058940705,
+                "net_tx_bytes": 9293600076
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 81.5602134710032,
+                "rss_bytes": 684675072,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 9123433563,
+                "net_tx_bytes": 9303711800
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 100.12399639209117,
+                "rss_bytes": 684113920,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 9158802105,
+                "net_tx_bytes": 9315781616
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 94.13716868326074,
+                "rss_bytes": 683794432,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 9205942657,
+                "net_tx_bytes": 9328751064
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 105.28619216391904,
+                "rss_bytes": 683778048,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 9241458540,
+                "net_tx_bytes": 9339794313
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 100.30519769315455,
+                "rss_bytes": 684589056,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 9289059202,
+                "net_tx_bytes": 9348025191
+              },
+              {
+                "offset_s": 150,
+                "phase": "drain",
+                "cpu_pct": 110.20114857123262,
+                "rss_bytes": 683995136,
+                "blk_read_bytes": 217088,
+                "blk_write_bytes": 0,
+                "net_rx_bytes": 9353023274,
+                "net_tx_bytes": 9369418053
+              }
+            ]
+          },
+          {
+            "role": "db",
+            "name": "ehrbase-rs-ehrbase-postgres-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 184.78504935884942,
+                "rss_bytes": 2873671680,
+                "blk_read_bytes": 14974128128,
+                "blk_write_bytes": 52419588096,
+                "net_rx_bytes": 8225276876,
+                "net_tx_bytes": 5020511802
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 197.79807367247633,
+                "rss_bytes": 2824019968,
+                "blk_read_bytes": 15140405248,
+                "blk_write_bytes": 52485836800,
+                "net_rx_bytes": 8239910016,
+                "net_tx_bytes": 5068610896
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 170.19357458194858,
+                "rss_bytes": 2874523648,
+                "blk_read_bytes": 15340924928,
+                "blk_write_bytes": 52556255232,
+                "net_rx_bytes": 8254862608,
+                "net_tx_bytes": 5126243105
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 241.8360728358091,
+                "rss_bytes": 2898325504,
+                "blk_read_bytes": 15602683904,
+                "blk_write_bytes": 52915785728,
+                "net_rx_bytes": 8269228209,
+                "net_tx_bytes": 5178247310
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 298.44068228950306,
+                "rss_bytes": 2993201152,
+                "blk_read_bytes": 15878508544,
+                "blk_write_bytes": 53535019008,
+                "net_rx_bytes": 8280730128,
+                "net_tx_bytes": 5228946445
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 501.8982181582716,
+                "rss_bytes": 2856849408,
+                "blk_read_bytes": 16178999296,
+                "blk_write_bytes": 53766983680,
+                "net_rx_bytes": 8296587479,
+                "net_tx_bytes": 5280664176
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 407.5401870375752,
+                "rss_bytes": 2875179008,
+                "blk_read_bytes": 16521736192,
+                "blk_write_bytes": 53979262976,
+                "net_rx_bytes": 8308081706,
+                "net_tx_bytes": 5332446093
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 544.3448386855366,
+                "rss_bytes": 3180154880,
+                "blk_read_bytes": 16653422592,
+                "blk_write_bytes": 54080999424,
+                "net_rx_bytes": 8310938760,
+                "net_tx_bytes": 5353309014
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 513.24713405427,
+                "rss_bytes": 3020800000,
+                "blk_read_bytes": 16744779776,
+                "blk_write_bytes": 54493786112,
+                "net_rx_bytes": 8313852462,
+                "net_tx_bytes": 5375433151
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 561.6223197384519,
+                "rss_bytes": 2987888640,
+                "blk_read_bytes": 16958377984,
+                "blk_write_bytes": 54543831040,
+                "net_rx_bytes": 8320875490,
+                "net_tx_bytes": 5432223953
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 532.8523942700125,
+                "rss_bytes": 2941530112,
+                "blk_read_bytes": 17111511040,
+                "blk_write_bytes": 54593884160,
+                "net_rx_bytes": 8330308716,
+                "net_tx_bytes": 5462294385
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 555.4031398806878,
+                "rss_bytes": 2933682176,
+                "blk_read_bytes": 17302319104,
+                "blk_write_bytes": 54688448512,
+                "net_rx_bytes": 8340324716,
+                "net_tx_bytes": 5504169698
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 506.3754727113713,
+                "rss_bytes": 2934788096,
+                "blk_read_bytes": 17443782656,
+                "blk_write_bytes": 54729293824,
+                "net_rx_bytes": 8349031467,
+                "net_tx_bytes": 5534007146
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 542.938856117359,
+                "rss_bytes": 3007598592,
+                "blk_read_bytes": 17560584192,
+                "blk_write_bytes": 54766297088,
+                "net_rx_bytes": 8354606162,
+                "net_tx_bytes": 5576102301
+              },
+              {
+                "offset_s": 150,
+                "phase": "drain",
+                "cpu_pct": 551.6407266438681,
+                "rss_bytes": 2887106560,
+                "blk_read_bytes": 17776992256,
+                "blk_write_bytes": 54859390976,
+                "net_rx_bytes": 8372288237,
+                "net_tx_bytes": 5634132365
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "max_sustainable_throughput_per_s": 256.0,
+  "ladder_capped": false,
+  "generator_bound": false,
+  "floors_context": [
+    {
+      "class": "POC",
+      "floor_per_s": 2.0,
+      "cleared": true
+    },
+    {
+      "class": "S",
+      "floor_per_s": 15.0,
+      "cleared": true
+    },
+    {
+      "class": "L",
+      "floor_per_s": 150.0,
+      "cleared": true
+    },
+    {
+      "class": "R",
+      "floor_per_s": 1500.0,
+      "cleared": false
+    }
+  ],
+  "remark": "Maximum sustainable throughput ≈ 256.0 arrivals/s on the cnf.scale.10k corpus (120s steps). Class-floor context: POC, S, L cleared. Classes are earned EXCLUSIVELY by the hour-long class runs on their own corpus scales — this stress report claims none."
+}

--- a/scripts/conformance.sh
+++ b/scripts/conformance.sh
@@ -46,9 +46,6 @@
 #   CONF_PERF_HOURS sustained-window ladder for the perf stage:
 #                   1 (default) | 2 | 4 | 6 | 8 | 12 — longer holds are
 #                   stricter demonstrations; nothing shorter exists.
-#   CONF_PERF_SKIP_SEED
-#                   if set, reuse the sidecar corpus index a prior seeding
-#                   wrote beside results.json instead of re-seeding.
 #   SKIP_BUILD      if set, compose up without --build (published image).
 #   SUT_USER/SUT_PASS, SUT_ADMIN_USER/SUT_ADMIN_PASS,
 #   SUT_RO_USER/SUT_RO_PASS
@@ -164,10 +161,10 @@ if [ "$run_rc" -ge 2 ]; then
 fi
 
 # Optional measured performance run (§8.14, conformance-by-measurement):
-# CONF_PERF_CLASS=POC|S|L|R seeds the scale corpus (unless
-# CONF_PERF_SKIP_SEED is set — reuse a prior seeding's sidecar index) and
-# drives the class's open-loop sustained case, merging the measurement
-# records into results.json BEFORE the verdict pipeline runs. This is an
+# CONF_PERF_CLASS=POC|S|L|R seeds the scale corpus into the freshly
+# composed SUT (the workflow always seeds an empty database) and drives
+# the class's open-loop sustained case, merging the measurement records
+# into results.json BEFORE the verdict pipeline runs. This is an
 # hour-plus act (5 min warmup + the sustained window, after corpus seeding)
 # and needs the exclusive composed SUT — never on by default.
 # CONF_PERF_HOURS=1|2|4|6|8|12 extends the sustained window (default 1 —
@@ -176,7 +173,6 @@ if [ -n "${CONF_PERF_CLASS:-}" ]; then
   echo "==> Measured performance run (class $CONF_PERF_CLASS, ${CONF_PERF_HOURS:-1} h window)"
   perf_args=(perf --root "$ROOT" --ixit "$IXIT" --results "$OUT/results.json"
              --class "$CONF_PERF_CLASS" --hours "${CONF_PERF_HOURS:-1}")
-  [ -n "${CONF_PERF_SKIP_SEED:-}" ] && perf_args+=(--skip-seed)
   perf_rc=0
   "$REPO_ROOT/target/debug/cnf-runner" "${perf_args[@]}" || perf_rc=$?
   if [ "$perf_rc" -ge 2 ]; then

--- a/tools/cnf-runner/CLAUDE.md
+++ b/tools/cnf-runner/CLAUDE.md
@@ -9,17 +9,21 @@ language, ever.
 
 | Command | Purpose |
 |---|---|
-| `bash scripts/conformance.sh` | THE pipeline (compose fresh → run → verdicts → badges). Env: `CONF_SUT=ehrbase-rs\|ehrbase-java\|byo`, `CONF_PERF_CLASS=POC\|S\|L\|R` (adds the measured stage), `CONF_PERF_HOURS=1\|2\|4\|6\|8\|12`, `CONF_PERF_SKIP_SEED=1`, `CONF_NO_COMPOSE=1`, `SKIP_BUILD=1` |
+| `bash scripts/conformance.sh` | THE pipeline (compose fresh → run → verdicts → badges). Env: `CONF_SUT=ehrbase-rs\|ehrbase-java\|byo`, `CONF_PERF_CLASS=POC\|S\|L\|R` (adds the measured stage), `CONF_PERF_HOURS=1\|2\|4\|6\|8\|12`, `CONF_NO_COMPOSE=1`, `SKIP_BUILD=1` |
 | `cargo run -p cnf-runner -- validate --root tools/cnf-runner/artifacts --specs docs/specs/openehr` | every machine gate over the artifact tree (zero findings = green) |
 | `cargo run -p cnf-runner -- run --root tools/cnf-runner/artifacts --ixit <party>/ixit.json --out <dir> --sut-name N --sut-version V --statement <party>/statement.json [--filter SUBSTR]` | execute the functional catalogue against a live SUT |
 | `cargo run -p cnf-runner -- verdicts --statement F --results F --root tools/cnf-runner/artifacts --out <dir>` | the pure verdict pipeline + report/statement/certificate |
-| `cargo run -p cnf-runner -- perf --root tools/cnf-runner/artifacts --ixit F --results F --class POC\|S\|L\|R [--hours 1\|2\|4\|6\|8\|12] [--skip-seed]` | the measured class run (conformance-by-measurement; merges into results.json) |
-| `cargo run -p cnf-runner -- stress --root tools/cnf-runner/artifacts --ixit F --out stress.json [--corpus-class POC] [--skip-seed] [--step-secs 120] [--bisections 3] [--max-rate 4096]` | the step-load stress ladder → maximum sustainable throughput (exploration only; NEVER touches results.json) |
+| `cargo run -p cnf-runner -- perf --root tools/cnf-runner/artifacts --ixit F --results F --class POC\|S\|L\|R [--hours 1\|2\|4\|6\|8\|12]` | the measured class run (conformance-by-measurement; merges into results.json) |
+| `cargo run -p cnf-runner -- stress --root tools/cnf-runner/artifacts --ixit F --out stress.json [--corpus-class POC] [--step-secs 120] [--bisections 3] [--max-rate 4096]` | the step-load stress ladder → maximum sustainable throughput (exploration only; NEVER touches results.json) |
+| `cargo run -p cnf-runner -- aql-probe --root tools/cnf-runner/artifacts --ixit F --out aql-probe.json [--corpus-class POC] [--requests 20]` | the seeded-corpus AQL optimization probe: wire percentiles + pg_stat_statements attribution (exploration only; NEVER touches results.json) |
 | `bash scripts/render-perf-assets.sh` (env `CONF_SUT`) | regenerate the published SVGs + summary FROM committed artifacts (CI diffs them) |
 | `bash scripts/render-conformance-assets.sh` (env `CONF_SUT`) | regenerate the conformance visuals (capability heat grid + per-chapter outcome bars) FROM committed verdicts/results (CI diffs them) |
 | `cargo run -p cnf-runner -- emit-schemas --out tools/cnf-runner/schemas` | regenerate the published JSON Schemas after a schema.rs change (drift-tested) |
 
-Credentials for direct `run`/`perf`/`stress` invocations come from the env
+Every instrument seeds a freshly composed, empty SUT and the stack is torn
+down afterwards — there is no seed reuse (the `--skip-seed`/sidecar scheme
+is retired). Credentials for direct `run`/`perf`/`stress`/`aql-probe`
+invocations come from the env
 the ixit references: `SUT_USER/SUT_PASS` (+ `SUT_ADMIN_*`, `SUT_RO_*`) —
 the dev-compose defaults are exported by `scripts/conformance.sh`.
 

--- a/tools/cnf-runner/party/ehrbase-java/ixit.json
+++ b/tools/cnf-runner/party/ehrbase-java/ixit.json
@@ -23,6 +23,10 @@
       }
     }
   },
+  "containers": {
+    "sut": "cnf-ehrbase-java-ehrbase-java-1",
+    "db": "cnf-ehrbase-java-ehrbase-java-db-1"
+  },
   "environment": {
     "exclusive_server": true,
     "hardware_class": "ci-runner",

--- a/tools/cnf-runner/party/ehrbase-rs/ixit.json
+++ b/tools/cnf-runner/party/ehrbase-rs/ixit.json
@@ -31,6 +31,10 @@
       }
     }
   },
+  "containers": {
+    "sut": "ehrbase-rs-ehrbase-1",
+    "db": "ehrbase-rs-ehrbase-postgres-1"
+  },
   "environment": {
     "exclusive_server": true,
     "hardware_class": "consumer-laptop",

--- a/tools/cnf-runner/schemas/aql-probe.schema.json
+++ b/tools/cnf-runner/schemas/aql-probe.schema.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:openehr:cnf:schema:aql-probe:0.1.0",
+  "title": "CNF 2.0 AQL probe report",
+  "description": "The seeded-corpus AQL optimization probe: per-probe wire-latency percentiles and pg_stat_statements attribution through the container runtime, environment-bound. Exploration evidence for the optimization loop — never a conformance record; results.json is never touched.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "corpus",
+    "environment",
+    "requests_per_probe",
+    "maintenance_settled",
+    "attribution",
+    "probes",
+    "remark"
+  ],
+  "properties": {
+    "corpus": {
+      "type": "string",
+      "pattern": "^[a-z0-9_-]+(\\.[a-z0-9_-]+)*$"
+    },
+    "environment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "hardware_class",
+        "cores",
+        "memory_gb",
+        "storage_class",
+        "topology"
+      ],
+      "properties": {
+        "exclusive_server": {
+          "type": "boolean"
+        },
+        "hardware_class": {
+          "type": "string",
+          "minLength": 1
+        },
+        "cores": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "memory_gb": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "storage_class": {
+          "type": "string",
+          "minLength": 1
+        },
+        "topology": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "requests_per_probe": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "maintenance_settled": {
+      "type": "boolean"
+    },
+    "attribution": {
+      "type": "string",
+      "minLength": 1
+    },
+    "probes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "aql",
+          "failures",
+          "wire_ms"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "aql": {
+            "type": "string",
+            "minLength": 1
+          },
+          "failures": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "wire_ms": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "min_ms",
+              "p50_ms",
+              "p95_ms",
+              "max_ms"
+            ],
+            "properties": {
+              "min_ms": {
+                "type": "number",
+                "minimum": 0.0
+              },
+              "p50_ms": {
+                "type": "number",
+                "minimum": 0.0
+              },
+              "p95_ms": {
+                "type": "number",
+                "minimum": 0.0
+              },
+              "max_ms": {
+                "type": "number",
+                "minimum": 0.0
+              }
+            }
+          },
+          "statements": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "sql",
+                "calls",
+                "mean_ms",
+                "total_ms",
+                "shared_blks_hit",
+                "shared_blks_read"
+              ],
+              "properties": {
+                "sql": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "calls": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "mean_ms": {
+                  "type": "number",
+                  "minimum": 0.0
+                },
+                "total_ms": {
+                  "type": "number",
+                  "minimum": 0.0
+                },
+                "shared_blks_hit": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "shared_blks_read": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "remark": {
+      "type": "string",
+      "minLength": 1
+    }
+  }
+}

--- a/tools/cnf-runner/schemas/ixit.schema.json
+++ b/tools/cnf-runner/schemas/ixit.schema.json
@@ -127,6 +127,24 @@
           "minLength": 1
         }
       }
+    },
+    "containers": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sut",
+        "db"
+      ],
+      "properties": {
+        "sut": {
+          "type": "string",
+          "minLength": 1
+        },
+        "db": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
     }
   }
 }

--- a/tools/cnf-runner/schemas/results.schema.json
+++ b/tools/cnf-runner/schemas/results.schema.json
@@ -339,6 +339,125 @@
               "type": "string",
               "minLength": 1
             }
+          },
+          "resources": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "sample_interval_s",
+              "containers",
+              "disk"
+            ],
+            "properties": {
+              "sample_interval_s": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "containers": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "role",
+                    "name",
+                    "samples"
+                  ],
+                  "properties": {
+                    "role": {
+                      "enum": [
+                        "sut",
+                        "db"
+                      ]
+                    },
+                    "name": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "samples": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                          "offset_s",
+                          "phase",
+                          "cpu_pct",
+                          "rss_bytes",
+                          "blk_read_bytes",
+                          "blk_write_bytes",
+                          "net_rx_bytes",
+                          "net_tx_bytes"
+                        ],
+                        "properties": {
+                          "offset_s": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "phase": {
+                            "enum": [
+                              "warmup",
+                              "measured",
+                              "drain"
+                            ]
+                          },
+                          "cpu_pct": {
+                            "type": "number",
+                            "minimum": 0.0
+                          },
+                          "rss_bytes": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "blk_read_bytes": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "blk_write_bytes": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "net_rx_bytes": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "net_tx_bytes": {
+                            "type": "integer",
+                            "minimum": 0
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "disk": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "before_scale_seed_bytes": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "after_scale_seed_bytes": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "after_ward_seed_bytes": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "after_window_bytes": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "seed_compositions": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/tools/cnf-runner/schemas/results.schema.json
+++ b/tools/cnf-runner/schemas/results.schema.json
@@ -345,8 +345,7 @@
             "additionalProperties": false,
             "required": [
               "sample_interval_s",
-              "containers",
-              "disk"
+              "containers"
             ],
             "properties": {
               "sample_interval_s": {

--- a/tools/cnf-runner/schemas/stress.schema.json
+++ b/tools/cnf-runner/schemas/stress.schema.json
@@ -157,6 +157,124 @@
           },
           "generator_bound": {
             "type": "boolean"
+          },
+          "resources": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "sample_interval_s",
+              "containers"
+            ],
+            "properties": {
+              "sample_interval_s": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "containers": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "role",
+                    "name",
+                    "samples"
+                  ],
+                  "properties": {
+                    "role": {
+                      "enum": [
+                        "sut",
+                        "db"
+                      ]
+                    },
+                    "name": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "samples": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                          "offset_s",
+                          "phase",
+                          "cpu_pct",
+                          "rss_bytes",
+                          "blk_read_bytes",
+                          "blk_write_bytes",
+                          "net_rx_bytes",
+                          "net_tx_bytes"
+                        ],
+                        "properties": {
+                          "offset_s": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "phase": {
+                            "enum": [
+                              "warmup",
+                              "measured",
+                              "drain"
+                            ]
+                          },
+                          "cpu_pct": {
+                            "type": "number",
+                            "minimum": 0.0
+                          },
+                          "rss_bytes": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "blk_read_bytes": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "blk_write_bytes": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "net_rx_bytes": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "net_tx_bytes": {
+                            "type": "integer",
+                            "minimum": 0
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "disk": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "before_scale_seed_bytes": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "after_scale_seed_bytes": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "after_ward_seed_bytes": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "after_window_bytes": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "seed_compositions": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/tools/cnf-runner/src/bin/cnf-runner.rs
+++ b/tools/cnf-runner/src/bin/cnf-runner.rs
@@ -13,19 +13,25 @@
 //!                                       and write the report/statement/
 //!                                       certificate + verdicts.json
 //! cnf-runner perf --root DIR --ixit FILE --results FILE --class POC|S|L|R
-//!                 [--hours 1|2|4|6|8|12] [--skip-seed] [--seed-workers N]
+//!                 [--hours 1|2|4|6|8|12] [--seed-workers N]
 //!                                       the measured class run (conformance-
 //!                                       by-measurement): seed the scale
 //!                                       corpus, hold the class's offered
 //!                                       load for the sustained window, merge
 //!                                       the record into results.json
 //! cnf-runner stress --root DIR --ixit FILE --out FILE
-//!                   [--corpus-class POC|S|L|R] [--skip-seed]
+//!                   [--corpus-class POC|S|L|R]
 //!                   [--step-secs N] [--bisections N] [--max-rate R]
 //!                                       the step-load stress ladder to the
 //!                                       maximum sustainable throughput
 //!                                       (exploration only — writes
 //!                                       stress.json, never results.json)
+//! cnf-runner aql-probe --root DIR --ixit FILE --out FILE
+//!                      [--corpus-class POC|S|L|R] [--requests N]
+//!                                       the seeded-corpus AQL optimization
+//!                                       probe: wire percentiles + DB
+//!                                       statement attribution (exploration
+//!                                       only — never a conformance record)
 //! cnf-runner perf-assets --root DIR --results FILE --out DIR
 //!                        [--summary FILE] [--stress FILE]
 //!                                       render the published SVGs + summary
@@ -126,10 +132,6 @@ enum Command {
         /// Select the performance case(s) of this class (POC | S | L | R).
         #[arg(long)]
         class: String,
-        /// Skip corpus seeding and load the sidecar corpus index written by
-        /// a prior seeding pass.
-        #[arg(long)]
-        skip_seed: bool,
         /// Parallel seeding workers.
         #[arg(long, default_value_t = 16)]
         seed_workers: usize,
@@ -159,10 +161,6 @@ enum Command {
         /// (POC | S | L | R) — data volume context only, no class claim.
         #[arg(long, default_value = "POC")]
         corpus_class: String,
-        /// Skip corpus seeding and load the sidecar corpus index written by
-        /// a prior seeding pass (shared with `perf`).
-        #[arg(long)]
-        skip_seed: bool,
         /// Parallel seeding workers.
         #[arg(long, default_value_t = 16)]
         seed_workers: usize,
@@ -176,6 +174,33 @@ enum Command {
         /// The climb cap (arrivals/s).
         #[arg(long, default_value_t = 4096.0)]
         max_rate: f64,
+    },
+    /// Run the AQL optimization probe: fire the measurement machinery's
+    /// AQL vocabulary against a live, freshly seeded SUT, record wire
+    /// percentiles, and attribute the DB-side cost per probe via
+    /// `pg_stat_statements` (exploration evidence for the optimization
+    /// loop — never a conformance record).
+    AqlProbe {
+        /// The artifact root.
+        #[arg(long)]
+        root: PathBuf,
+        /// The ixit topology file (JSON) — the `containers` block enables
+        /// DB-side attribution and maintenance settling.
+        #[arg(long)]
+        ixit: PathBuf,
+        /// Where to write the probe report (aql-probe.json).
+        #[arg(long)]
+        out: PathBuf,
+        /// The class whose corpus the probes run against (data-volume
+        /// context only).
+        #[arg(long, default_value = "POC")]
+        corpus_class: String,
+        /// Parallel seeding workers.
+        #[arg(long, default_value_t = 16)]
+        seed_workers: usize,
+        /// Requests fired per probe.
+        #[arg(long, default_value_t = 20)]
+        requests: u32,
     },
     /// Render the published performance SVG assets FROM a committed
     /// results.json (deterministic; CI regenerates and diffs — hand-drawn
@@ -289,24 +314,14 @@ fn main() -> ExitCode {
             ixit,
             results,
             class,
-            skip_seed,
             seed_workers,
             hours,
-        } => perf_command(
-            &root,
-            &ixit,
-            &results,
-            &class,
-            skip_seed,
-            seed_workers,
-            hours,
-        ),
+        } => perf_command(&root, &ixit, &results, &class, seed_workers, hours),
         Command::Stress {
             root,
             ixit,
             out,
             corpus_class,
-            skip_seed,
             seed_workers,
             step_secs,
             bisections,
@@ -316,12 +331,19 @@ fn main() -> ExitCode {
             &ixit,
             &out,
             &corpus_class,
-            skip_seed,
             seed_workers,
             step_secs,
             bisections,
             max_rate,
         ),
+        Command::AqlProbe {
+            root,
+            ixit,
+            out,
+            corpus_class,
+            seed_workers,
+            requests,
+        } => probe_command(&root, &ixit, &out, &corpus_class, seed_workers, requests),
         Command::PerfAssets {
             root,
             results,
@@ -763,35 +785,21 @@ enum SeedStage {
     AfterWard,
 }
 
-/// Seed the scale corpus + the standing ward (or load the sidecar index a
-/// prior seeding wrote — the index lives beside `artifact_path` so `perf`
-/// and `stress` share it). Ward seeding is idempotent, so a pre-journey
-/// sidecar upgrades in place on the next non-skip run. `stage` observes
-/// the seeding milestones (never called on a `--skip-seed` load — those
-/// anchors would be dishonest).
-#[allow(clippy::too_many_arguments)] // the one-shot seeding seam both handlers share
-fn seed_or_load_corpus(
+/// Seed the scale corpus + the standing ward. The workflow ALWAYS seeds a
+/// freshly composed, empty SUT and the stack is torn down afterwards —
+/// there is no seed reuse (the retired `--skip-seed`/sidecar-index scheme
+/// bred stale-state confusion). `stage` observes the seeding milestones
+/// (the disk anchors).
+fn seed_corpus(
     client: &cnf_runner::perf_run::client::PerfClient,
     corpus_key: &str,
     opt_xml: &str,
     journey_pack: &cnf_runner::perf_run::pack::JourneyPack,
-    artifact_path: &std::path::Path,
-    skip_seed: bool,
     seed_workers: usize,
     progress: &(dyn Fn(String) + Sync),
     stage: &mut dyn FnMut(SeedStage),
 ) -> Result<cnf_runner::perf_run::corpus::SeededCorpus, String> {
     use cnf_runner::perf_run::corpus;
-    let index_path =
-        artifact_path.with_file_name(format!("perf-corpus-{}.json", corpus_key.replace('.', "-")));
-    if skip_seed {
-        return std::fs::read_to_string(&index_path)
-            .map_err(|e| format!("cannot read corpus index {}: {e}", index_path.display()))
-            .and_then(|text| {
-                serde_json::from_str::<corpus::SeededCorpus>(&text)
-                    .map_err(|e| format!("corpus index: {e}"))
-            });
-    }
     let (ehrs, versions) = corpus::scale_shape(corpus_key)?;
     stage(SeedStage::BeforeScale);
     let mut seeded = corpus::seed_scale_ladder(
@@ -808,10 +816,6 @@ fn seed_or_load_corpus(
     corpus::seed_ward(client, &mut seeded, journey_pack, seed_workers, progress)
         .map_err(|e| format!("ward seeding failed: {e}"))?;
     stage(SeedStage::AfterWard);
-    let text =
-        serde_json::to_string(&seeded).map_err(|e| format!("serialize corpus index: {e}"))?;
-    std::fs::write(&index_path, text)
-        .map_err(|e| format!("cannot write corpus index {}: {e}", index_path.display()))?;
     Ok(seeded)
 }
 
@@ -823,7 +827,6 @@ fn stress_command(
     ixit_path: &std::path::Path,
     out: &std::path::Path,
     corpus_class: &str,
-    skip_seed: bool,
     seed_workers: usize,
     step_secs: u64,
     bisections: u32,
@@ -901,13 +904,11 @@ fn stress_command(
         }
     };
     let progress = |message: String| eprintln!("[stress] {message}");
-    let corpus = match seed_or_load_corpus(
+    let corpus = match seed_corpus(
         &client,
         case.corpus.as_str(),
         &opt_xml,
         &journey_pack,
-        out,
-        skip_seed,
         seed_workers,
         &progress,
         // The stress instrument records no disk anchors (exploration only).
@@ -976,6 +977,143 @@ fn stress_command(
     ExitCode::SUCCESS
 }
 
+/// The AQL-probe handler (`aql-probe`): seed the class corpus fresh, run
+/// the probe set, write the report (exploration only — never touches
+/// results.json).
+#[allow(clippy::too_many_lines)] // one-shot orchestration seam
+fn probe_command(
+    root: &std::path::Path,
+    ixit_path: &std::path::Path,
+    out: &std::path::Path,
+    corpus_class: &str,
+    seed_workers: usize,
+    requests: u32,
+) -> ExitCode {
+    use cnf_runner::perf::PerfClass;
+    use cnf_runner::perf_run;
+
+    let class = match PerfClass::parse(corpus_class) {
+        Ok(class) => class,
+        Err(e) => {
+            eprintln!("{e}");
+            return ExitCode::from(2);
+        }
+    };
+    let loaded = match load_root(root) {
+        Ok(loaded) => loaded,
+        Err(e) => {
+            eprintln!("runner defect: {e}");
+            return ExitCode::from(2);
+        }
+    };
+    if !loaded.errors.is_empty() {
+        for e in &loaded.errors {
+            eprintln!("{e}");
+        }
+        return ExitCode::from(2);
+    }
+    let ixit: cnf_runner::ixit::Ixit = match std::fs::read_to_string(ixit_path)
+        .map_err(|e| format!("cannot read {}: {e}", ixit_path.display()))
+        .and_then(|text| serde_json::from_str(&text).map_err(|e| format!("ixit: {e}")))
+    {
+        Ok(ixit) => ixit,
+        Err(e) => {
+            eprintln!("{e}");
+            return ExitCode::from(2);
+        }
+    };
+    let (instance, environment) = match perf_run::window::measured_run_context(&ixit) {
+        Ok(context) => context,
+        Err(e) => {
+            eprintln!("{e}");
+            return ExitCode::from(2);
+        }
+    };
+    let client = match perf_run::client::PerfClient::from_instance(instance) {
+        Ok(client) => client,
+        Err(e) => {
+            eprintln!("{e}");
+            return ExitCode::from(2);
+        }
+    };
+    let Some((_, case)) = loaded
+        .set
+        .performance
+        .iter()
+        .find(|(_, c)| c.class == class)
+    else {
+        eprintln!("no performance case of class {corpus_class} in the catalogue");
+        return ExitCode::from(2);
+    };
+    let opt_xml = match scale_opt_xml(&loaded) {
+        Ok(xml) => xml,
+        Err(e) => {
+            eprintln!("{e}");
+            return ExitCode::from(2);
+        }
+    };
+    let (_, journey_pack) = match journey_context(&loaded) {
+        Ok(context) => context,
+        Err(e) => {
+            eprintln!("{e}");
+            return ExitCode::from(2);
+        }
+    };
+    let progress = |message: String| eprintln!("[probe] {message}");
+    let corpus = match seed_corpus(
+        &client,
+        case.corpus.as_str(),
+        &opt_xml,
+        &journey_pack,
+        seed_workers,
+        &progress,
+        // The probe records no disk anchors (exploration only).
+        &mut |_| {},
+    ) {
+        Ok(corpus) => corpus,
+        Err(e) => {
+            eprintln!("{e}");
+            return ExitCode::from(2);
+        }
+    };
+    let options = cnf_runner::probe::ProbeOptions { requests };
+    let report = match cnf_runner::probe::run_probe(
+        &client,
+        &corpus,
+        environment,
+        ixit.containers.as_ref(),
+        &options,
+        &progress,
+    ) {
+        Ok(report) => report,
+        Err(e) => {
+            eprintln!("probe run failed: {e}");
+            return ExitCode::from(2);
+        }
+    };
+    match serde_json::to_string_pretty(&report) {
+        Ok(mut text) => {
+            text.push('\n');
+            if let Some(parent) = out.parent()
+                && let Err(e) = std::fs::create_dir_all(parent)
+            {
+                eprintln!("cannot create {}: {e}", parent.display());
+                return ExitCode::from(2);
+            }
+            if let Err(e) = std::fs::write(out, text) {
+                eprintln!("cannot write {}: {e}", out.display());
+                return ExitCode::from(2);
+            }
+        }
+        Err(e) => {
+            eprintln!("serialize: {e}");
+            return ExitCode::from(2);
+        }
+    }
+    println!("wrote {} ({} probes)", out.display(), report.probes.len());
+    ExitCode::SUCCESS
+}
+
 /// The measured-run handler (`perf`): seed the scale corpus, drive the
 /// open-loop workload, merge the measurement record into results.json.
 #[allow(clippy::too_many_lines)] // one-shot orchestration seam
@@ -984,7 +1122,6 @@ fn perf_command(
     ixit_path: &std::path::Path,
     results_path: &std::path::Path,
     class_token: &str,
-    skip_seed: bool,
     seed_workers: usize,
     hours: u64,
 ) -> ExitCode {
@@ -1106,13 +1243,11 @@ fn perf_command(
                 }
             }
         };
-        let corpus = match seed_or_load_corpus(
+        let corpus = match seed_corpus(
             &client,
             case.corpus.as_str(),
             &opt_xml,
             &journey_pack,
-            results_path,
-            skip_seed,
             seed_workers,
             &progress,
             &mut |milestone| match milestone {
@@ -1133,6 +1268,17 @@ fn perf_command(
                 return ExitCode::from(2);
             }
         };
+        // Settle the seeding's maintenance debt before the window: a
+        // mid-window autovacuum/analyze of the freshly seeded tables would
+        // saturate the engine inside the measurement.
+        if let Some(c) = &containers {
+            progress(
+                "settling maintenance before the measured window (vacuumdb --analyze)".to_owned(),
+            );
+            if let Err(e) = perf_run::resources::settle_maintenance(&c.db) {
+                progress(format!("maintenance not settled: {e}"));
+            }
+        }
         // The case's normative warmup; the sustained window extends by the
         // hours ladder (a longer hold of the same offered load is a stricter
         // demonstration of the same class).
@@ -1196,16 +1342,7 @@ fn perf_command(
                 op.latency_ms_p99
             );
         }
-        println!(
-            "  offered load sustained {:.2}/s — verdict {:?}{}",
-            measurement.offered_load_sustained,
-            measurement.verdict,
-            if measurement.violations.is_empty() {
-                String::new()
-            } else {
-                format!(" ({})", measurement.violations.join("; "))
-            }
-        );
+        println!("  {}", cnf_runner::perf::verdict_evidence(&measurement));
         if measurement.verdict != cnf_runner::perf::ClassVerdict::Earned {
             earned_all = false;
         }

--- a/tools/cnf-runner/src/bin/cnf-runner.rs
+++ b/tools/cnf-runner/src/bin/cnf-runner.rs
@@ -584,6 +584,7 @@ fn conformance_assets_command(
 
 /// The asset renderer (`perf-assets`): deterministic SVGs FROM the committed
 /// measurement records (regenerate-and-diff guarded in CI).
+#[allow(clippy::too_many_lines)] // one-shot orchestration seam
 fn perf_assets_command(
     root: &std::path::Path,
     results_path: &std::path::Path,
@@ -657,6 +658,17 @@ fn perf_assets_command(
                 return ExitCode::from(2);
             }
         }
+        // The resource time-series renders only from a record that carries
+        // one (sampling is optional by capability; nothing is fabricated).
+        if let Some(svg) = cnf_runner::perf_assets::resources_timeseries_svg(measurement) {
+            files.push((
+                format!("perf-resources-class-{}.svg", measurement.class.token()),
+                svg,
+            ));
+        }
+    }
+    if let Some(svg) = cnf_runner::perf_assets::disk_growth_svg(&results.measurements) {
+        files.push(("perf-disk-growth.svg".to_owned(), svg));
     }
     for (name, body) in &files {
         let path = out.join(name);

--- a/tools/cnf-runner/src/bin/cnf-runner.rs
+++ b/tools/cnf-runner/src/bin/cnf-runner.rs
@@ -937,6 +937,7 @@ fn stress_command(
         &corpus,
         &workload,
         environment,
+        ixit.containers.as_ref(),
         &options,
         &progress,
     ) {
@@ -1175,7 +1176,7 @@ fn perf_command(
                 measurement.resources = Some(cnf_runner::perf::ResourcesRecord {
                     sample_interval_s: perf_run::resources::SAMPLE_INTERVAL.as_secs(),
                     containers: series,
-                    disk,
+                    disk: Some(disk),
                 });
             } else {
                 progress(

--- a/tools/cnf-runner/src/bin/cnf-runner.rs
+++ b/tools/cnf-runner/src/bin/cnf-runner.rs
@@ -742,10 +742,21 @@ fn journey_context(
     Ok((catalogue, pack))
 }
 
+/// The seeding milestones the disk anchors probe at (`perf` passes a
+/// probing observer; `stress` observes nothing).
+#[derive(Debug, Clone, Copy)]
+enum SeedStage {
+    BeforeScale,
+    AfterScale,
+    AfterWard,
+}
+
 /// Seed the scale corpus + the standing ward (or load the sidecar index a
 /// prior seeding wrote — the index lives beside `artifact_path` so `perf`
 /// and `stress` share it). Ward seeding is idempotent, so a pre-journey
-/// sidecar upgrades in place on the next non-skip run.
+/// sidecar upgrades in place on the next non-skip run. `stage` observes
+/// the seeding milestones (never called on a `--skip-seed` load — those
+/// anchors would be dishonest).
 #[allow(clippy::too_many_arguments)] // the one-shot seeding seam both handlers share
 fn seed_or_load_corpus(
     client: &cnf_runner::perf_run::client::PerfClient,
@@ -756,6 +767,7 @@ fn seed_or_load_corpus(
     skip_seed: bool,
     seed_workers: usize,
     progress: &(dyn Fn(String) + Sync),
+    stage: &mut dyn FnMut(SeedStage),
 ) -> Result<cnf_runner::perf_run::corpus::SeededCorpus, String> {
     use cnf_runner::perf_run::corpus;
     let index_path =
@@ -769,6 +781,7 @@ fn seed_or_load_corpus(
             });
     }
     let (ehrs, versions) = corpus::scale_shape(corpus_key)?;
+    stage(SeedStage::BeforeScale);
     let mut seeded = corpus::seed_scale_ladder(
         client,
         corpus_key,
@@ -779,8 +792,10 @@ fn seed_or_load_corpus(
         progress,
     )
     .map_err(|e| format!("seeding failed: {e}"))?;
+    stage(SeedStage::AfterScale);
     corpus::seed_ward(client, &mut seeded, journey_pack, seed_workers, progress)
         .map_err(|e| format!("ward seeding failed: {e}"))?;
+    stage(SeedStage::AfterWard);
     let text =
         serde_json::to_string(&seeded).map_err(|e| format!("serialize corpus index: {e}"))?;
     std::fs::write(&index_path, text)
@@ -883,6 +898,8 @@ fn stress_command(
         skip_seed,
         seed_workers,
         &progress,
+        // The stress instrument records no disk anchors (exploration only).
+        &mut |_| {},
     ) {
         Ok(corpus) => corpus,
         Err(e) => {
@@ -1038,6 +1055,12 @@ fn perf_command(
         }
     };
     let progress = |message: String| eprintln!("[perf] {message}");
+    // Resource sampling is optional by capability: no ixit `containers`
+    // block → no `resources` record, never a failed run.
+    let containers = ixit.containers.clone();
+    if containers.is_none() {
+        progress("resources: not sampled (ixit declares no `containers` block)".to_owned());
+    }
 
     let mut earned_all = true;
     for (path, case) in selected {
@@ -1046,6 +1069,30 @@ fn perf_command(
             case.id,
             path.display()
         );
+        // The disk anchors bracket the seeding milestones; every probe
+        // failure degrades to an absent anchor with the reason logged.
+        let mut disk = cnf_runner::perf::DiskAnchors {
+            before_scale_seed_bytes: None,
+            after_scale_seed_bytes: None,
+            after_ward_seed_bytes: None,
+            after_window_bytes: None,
+            seed_compositions: perf_run::corpus::scale_shape(case.corpus.as_str())
+                .ok()
+                .and_then(|(ehrs, versions)| u64::try_from(ehrs.saturating_mul(versions)).ok()),
+        };
+        let probe_volume = |label: &str| -> Option<u64> {
+            let db = &containers.as_ref()?.db;
+            match perf_run::resources::db_volume_bytes(db) {
+                Ok(bytes) => {
+                    progress(format!("disk anchor {label}: {bytes} bytes"));
+                    Some(bytes)
+                }
+                Err(e) => {
+                    progress(format!("disk anchor {label} unavailable: {e}"));
+                    None
+                }
+            }
+        };
         let corpus = match seed_or_load_corpus(
             &client,
             case.corpus.as_str(),
@@ -1055,6 +1102,17 @@ fn perf_command(
             skip_seed,
             seed_workers,
             &progress,
+            &mut |milestone| match milestone {
+                SeedStage::BeforeScale => {
+                    disk.before_scale_seed_bytes = probe_volume("before scale seed");
+                }
+                SeedStage::AfterScale => {
+                    disk.after_scale_seed_bytes = probe_volume("after scale seed");
+                }
+                SeedStage::AfterWard => {
+                    disk.after_ward_seed_bytes = probe_volume("after preflight + ward seed");
+                }
+            },
         ) {
             Ok(corpus) => corpus,
             Err(e) => {
@@ -1067,7 +1125,13 @@ fn perf_command(
         // demonstration of the same class).
         let warmup_s = case.workload.warmup.0;
         let duration_s = case.workload.duration.0.max(hours.saturating_mul(3600));
-        let measurement = match perf_run::window::drive_case(
+        // The sampler brackets the whole window (warmup + sustained + the
+        // completion drain) and stops after the dispatcher's last
+        // completion lands — drive_case returns only then.
+        let sampler = containers
+            .as_ref()
+            .map(|c| perf_run::resources::ResourceSampler::start(c, warmup_s, duration_s));
+        let mut measurement = match perf_run::window::drive_case(
             case,
             &client,
             &corpus,
@@ -1084,6 +1148,30 @@ fn perf_command(
                 return ExitCode::from(2);
             }
         };
+        if let Some(sampler) = sampler {
+            let (series, notes) = sampler.stop();
+            for note in notes {
+                progress(note);
+            }
+            disk.after_window_bytes = probe_volume("after measured window");
+            let sampled_any = series.iter().any(|s| !s.samples.is_empty());
+            let anchored_any = disk.before_scale_seed_bytes.is_some()
+                || disk.after_scale_seed_bytes.is_some()
+                || disk.after_ward_seed_bytes.is_some()
+                || disk.after_window_bytes.is_some();
+            if sampled_any || anchored_any {
+                measurement.resources = Some(cnf_runner::perf::ResourcesRecord {
+                    sample_interval_s: perf_run::resources::SAMPLE_INTERVAL.as_secs(),
+                    containers: series,
+                    disk,
+                });
+            } else {
+                progress(
+                    "resources: not sampled (container runtime unreachable for the whole run)"
+                        .to_owned(),
+                );
+            }
+        }
         for op in &measurement.operations {
             println!(
                 "  {}: {} requests, {} errors, p50 {:.1}ms p90 {:.1}ms p99 {:.1}ms",

--- a/tools/cnf-runner/src/ixit.rs
+++ b/tools/cnf-runner/src/ixit.rs
@@ -62,6 +62,19 @@ pub struct Environment {
     pub topology: String,
 }
 
+/// The container-runtime identities of the composed SUT — topology facts,
+/// exactly what the ixit is for. Presence enables resource sampling on
+/// measured runs; absence records no `resources` block and never fails a
+/// run (a BYO SUT has no reachable containers).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Containers {
+    /// The SUT process container name.
+    pub sut: String,
+    /// The database container name (also the disk-anchor probe target).
+    pub db: String,
+}
+
 /// The whole IXIT document.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -72,6 +85,10 @@ pub struct Ixit {
     pub instances: Vec<(InstanceName, Instance)>,
     #[serde(default)]
     pub environment: Option<Environment>,
+    /// The composed SUT's container identities (optional by capability —
+    /// see [`Containers`]).
+    #[serde(default)]
+    pub containers: Option<Containers>,
 }
 
 impl Ixit {
@@ -126,6 +143,24 @@ mod tests {
                 .auth,
             AuthMode::None
         ));
+    }
+
+    #[test]
+    fn containers_block_is_optional_and_parses() {
+        let bare: Ixit = serde_json::from_value(serde_json::json!({
+            "instances": { "sut": { "base_url": "http://x", "auth": { "mode": "none" } } }
+        }))
+        .unwrap();
+        assert!(bare.containers.is_none());
+
+        let with: Ixit = serde_json::from_value(serde_json::json!({
+            "instances": { "sut": { "base_url": "http://x", "auth": { "mode": "none" } } },
+            "containers": { "sut": "ehrbase-rs-ehrbase-1", "db": "ehrbase-rs-ehrbase-postgres-1" }
+        }))
+        .unwrap();
+        let containers = with.containers.unwrap();
+        assert_eq!(containers.sut, "ehrbase-rs-ehrbase-1");
+        assert_eq!(containers.db, "ehrbase-rs-ehrbase-postgres-1");
     }
 
     #[test]

--- a/tools/cnf-runner/src/lib.rs
+++ b/tools/cnf-runner/src/lib.rs
@@ -21,6 +21,7 @@ pub mod party;
 pub mod perf;
 pub mod perf_assets;
 pub mod perf_run;
+pub mod probe;
 pub mod refgrammar;
 pub mod render;
 pub mod run;

--- a/tools/cnf-runner/src/perf.rs
+++ b/tools/cnf-runner/src/perf.rs
@@ -995,7 +995,11 @@ pub struct ResourcesRecord {
     pub sample_interval_s: u64,
     /// Per-container series (SUT and database separately).
     pub containers: Vec<ContainerResourceSeries>,
-    pub disk: DiskAnchors,
+    /// The disk anchors — present on measured class runs (whose seeding
+    /// milestones bracket them); absent on stress steps (exploration
+    /// stays light).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disk: Option<DiskAnchors>,
 }
 
 /// The whole measured run for one performance case.
@@ -1248,13 +1252,13 @@ mod tests {
                     net_tx_bytes: 4_000,
                 }],
             }],
-            disk: DiskAnchors {
+            disk: Some(DiskAnchors {
                 before_scale_seed_bytes: Some(10),
                 after_scale_seed_bytes: Some(20),
                 after_ward_seed_bytes: None,
                 after_window_bytes: Some(30),
                 seed_compositions: Some(1_000_000),
-            },
+            }),
         });
         let full = serde_json::to_value(&m).unwrap();
         // Run-clock offsets + phase stamps on the wire, absent anchors omitted.
@@ -1270,7 +1274,7 @@ mod tests {
         let parsed: Measurement = serde_json::from_value(full).unwrap();
         let resources = parsed.resources.unwrap();
         assert_eq!(resources.sample_interval_s, 10);
-        assert_eq!(resources.disk.seed_compositions, Some(1_000_000));
+        assert_eq!(resources.disk.unwrap().seed_compositions, Some(1_000_000));
     }
 
     #[test]

--- a/tools/cnf-runner/src/perf.rs
+++ b/tools/cnf-runner/src/perf.rs
@@ -898,6 +898,16 @@ pub enum ContainerRole {
 impl ContainerRole {
     /// All roles, fixed order (schema emission derives from this).
     pub const ALL: &'static [ContainerRole] = &[ContainerRole::Sut, ContainerRole::Db];
+
+    /// The display label (progress lines, summary tables) — the same token
+    /// the wire serialization carries.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            ContainerRole::Sut => "sut",
+            ContainerRole::Db => "db",
+        }
+    }
 }
 
 /// The run phase a resource sample was taken in (closed vocabulary): the
@@ -957,11 +967,44 @@ pub struct ContainerResourceSeries {
     pub samples: Vec<ResourceSample>,
 }
 
+impl ContainerResourceSeries {
+    /// Peak CPU% over the whole series (`0` when empty) — the one shared
+    /// derivation the progress logs and the generated summaries both use
+    /// (aggregates DERIVE from the series, never stored beside it).
+    #[must_use]
+    pub fn cpu_peak(&self) -> f64 {
+        self.samples.iter().map(|s| s.cpu_pct).fold(0.0, f64::max)
+    }
+
+    /// Peak RSS bytes over the whole series (`0` when empty).
+    #[must_use]
+    pub fn rss_peak(&self) -> u64 {
+        self.samples.iter().map(|s| s.rss_bytes).max().unwrap_or(0)
+    }
+
+    /// The measured-phase samples — falling back to the whole series when
+    /// the window never reached the measured phase (an aborted run still
+    /// reports what it saw).
+    #[must_use]
+    pub fn measured_samples(&self) -> Vec<&ResourceSample> {
+        let measured: Vec<&ResourceSample> = self
+            .samples
+            .iter()
+            .filter(|s| s.phase == ResourcePhase::Measured)
+            .collect();
+        if measured.is_empty() {
+            self.samples.iter().collect()
+        } else {
+            measured
+        }
+    }
+}
+
 /// The database volume's on-disk size at the run's four anchors (bytes).
 /// The first two yield bytes per committed composition (the
 /// storage-efficiency headline); the last two yield the sustained load's
 /// write amplification. Each anchor is honestly absent when it could not
-/// be probed (e.g. a `--skip-seed` run never sees the seeding anchors).
+/// be probed (a failed probe degrades to absence, never a run failure).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiskAnchors {
@@ -1031,6 +1074,44 @@ pub struct Measurement {
     /// `containers` block or the container runtime was unreachable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resources: Option<ResourcesRecord>,
+}
+
+/// The one-line evidence behind a measured-run verdict, for progress
+/// streams and console summaries — the committed record (encoded
+/// histograms + environment) stays the re-checkable evidence; this is the
+/// operator-facing digest of it.
+#[must_use]
+pub fn verdict_evidence(measurement: &Measurement) -> String {
+    let floor = measurement.class.arrival_floor_per_s();
+    let (requests, errors) = measurement
+        .operations
+        .iter()
+        .fold((0_u64, 0_u64), |(r, e), op| {
+            (r.saturating_add(op.requests), e.saturating_add(op.errors))
+        });
+    let worst = measurement
+        .operations
+        .iter()
+        .max_by(|a, b| a.latency_ms_p99.total_cmp(&b.latency_ms_p99));
+    let worst_text = worst.map_or_else(
+        || "no operations measured".to_owned(),
+        |op| format!("worst p99 {:.0} ms ({})", op.latency_ms_p99, op.operation),
+    );
+    let verdict_text = match measurement.verdict {
+        ClassVerdict::Earned => "EARNED",
+        ClassVerdict::NotEarned => "NOT EARNED",
+    };
+    let violation_text = if measurement.violations.is_empty() {
+        String::new()
+    } else {
+        format!(" — {}", measurement.violations.join("; "))
+    };
+    format!(
+        "window verdict: class {} {verdict_text} — offered {:.2}/s vs floor {floor}/s; \
+         {worst_text}; {errors} errors / {requests} requests{violation_text}",
+        measurement.class.token(),
+        measurement.offered_load_sustained,
+    )
 }
 
 /// Class verdicts (the second machinery's output).

--- a/tools/cnf-runner/src/perf.rs
+++ b/tools/cnf-runner/src/perf.rs
@@ -885,6 +885,119 @@ impl OperationMeasurement {
     }
 }
 
+/// The container roles the resource sampler distinguishes (closed
+/// vocabulary): the SUT process and its database — the split shows where a
+/// class's headroom actually burns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContainerRole {
+    Sut,
+    Db,
+}
+
+impl ContainerRole {
+    /// All roles, fixed order (schema emission derives from this).
+    pub const ALL: &'static [ContainerRole] = &[ContainerRole::Sut, ContainerRole::Db];
+}
+
+/// The run phase a resource sample was taken in (closed vocabulary): the
+/// charts shade warmup, and trailing samples taken while in-flight
+/// completions drain past the planned window stamp as `drain`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResourcePhase {
+    Warmup,
+    Measured,
+    Drain,
+}
+
+impl ResourcePhase {
+    /// All phases, run order (schema emission derives from this).
+    pub const ALL: &'static [ResourcePhase] = &[
+        ResourcePhase::Warmup,
+        ResourcePhase::Measured,
+        ResourcePhase::Drain,
+    ];
+}
+
+/// One resource observation of one container at a run-clock offset
+/// (offsets from the measured window's start — never wall-clock, the same
+/// determinism rule as every other record field). Peak and mean aggregates
+/// are DERIVED from the series at render time, never stored beside it.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ResourceSample {
+    /// Seconds since the measured window started (warmup included).
+    pub offset_s: u64,
+    pub phase: ResourcePhase,
+    /// CPU utilisation percent over the preceding sample interval
+    /// (100 = one full core).
+    pub cpu_pct: f64,
+    /// Resident-set memory, bytes.
+    pub rss_bytes: u64,
+    /// Cumulative block-device bytes read since container start (deltas →
+    /// rates at render time).
+    pub blk_read_bytes: u64,
+    /// Cumulative block-device bytes written since container start.
+    pub blk_write_bytes: u64,
+    /// Cumulative network bytes received since container start.
+    pub net_rx_bytes: u64,
+    /// Cumulative network bytes transmitted since container start.
+    pub net_tx_bytes: u64,
+}
+
+/// One container's sampled resource time-series.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ContainerResourceSeries {
+    pub role: ContainerRole,
+    /// The container-runtime identity sampled (the ixit `containers` block).
+    pub name: String,
+    /// The observations, in offset order.
+    pub samples: Vec<ResourceSample>,
+}
+
+/// The database volume's on-disk size at the run's four anchors (bytes).
+/// The first two yield bytes per committed composition (the
+/// storage-efficiency headline); the last two yield the sustained load's
+/// write amplification. Each anchor is honestly absent when it could not
+/// be probed (e.g. a `--skip-seed` run never sees the seeding anchors).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiskAnchors {
+    /// Before the scale seed (the empty-volume baseline).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub before_scale_seed_bytes: Option<u64>,
+    /// After the scale seed committed its compositions.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub after_scale_seed_bytes: Option<u64>,
+    /// After the pack preflight + standing-ward seed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub after_ward_seed_bytes: Option<u64>,
+    /// After the measured window drained.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub after_window_bytes: Option<u64>,
+    /// Compositions the scale seed committed (the bytes-per-composition
+    /// denominator — a run fact, not derivable from the series).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seed_compositions: Option<u64>,
+}
+
+/// The resource telemetry of one measured run — measured CONTEXT, never
+/// verdict-bearing: classes stay earned on latency/error/throughput only,
+/// and an absent record never fails a run (sampling is optional by
+/// capability — it requires the ixit `containers` block and a reachable
+/// container runtime).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ResourcesRecord {
+    /// The fixed sampling cadence, seconds.
+    pub sample_interval_s: u64,
+    /// Per-container series (SUT and database separately).
+    pub containers: Vec<ContainerResourceSeries>,
+    pub disk: DiskAnchors,
+}
+
 /// The whole measured run for one performance case.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -909,6 +1022,11 @@ pub struct Measurement {
     /// when earned).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub violations: Vec<String>,
+    /// The resource telemetry sampled during the run — measured CONTEXT,
+    /// never a verdict input; absent when the ixit declares no
+    /// `containers` block or the container runtime was unreachable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resources: Option<ResourcesRecord>,
 }
 
 /// Class verdicts (the second machinery's output).
@@ -1085,6 +1203,74 @@ mod tests {
         let (verdict, violations) = class_verdict(&c, 15.0, &[m]).unwrap();
         assert_eq!(verdict, ClassVerdict::NotEarned);
         assert!(!violations.is_empty());
+    }
+
+    #[test]
+    fn the_resources_block_is_optional_and_round_trips() {
+        // A pre-telemetry record (no `resources`) still parses — the
+        // committed baseline stays valid.
+        let h = histogram(&[10_000]);
+        let op = OperationMeasurement::from_histogram("ehr_read", &h, 0).unwrap();
+        let mut m = Measurement {
+            case: crate::ids::CaseId::parse("PERF-hospital_sim-class_POC").unwrap(),
+            class: PerfClass::Poc,
+            environment: serde_json::from_value(serde_json::json!({
+                "hardware_class": "test", "cores": 1, "memory_gb": 1,
+                "storage_class": "ram", "topology": "stub"
+            }))
+            .unwrap(),
+            offered_load_sustained: 2.0,
+            warmup_s: 300,
+            duration_s: 3600,
+            operations: vec![op],
+            verdict: ClassVerdict::Earned,
+            violations: Vec::new(),
+            resources: None,
+        };
+        let bare = serde_json::to_value(&m).unwrap();
+        assert!(bare.get("resources").is_none()); // absent, never null
+        let parsed: Measurement = serde_json::from_value(bare).unwrap();
+        assert!(parsed.resources.is_none());
+
+        m.resources = Some(ResourcesRecord {
+            sample_interval_s: 10,
+            containers: vec![ContainerResourceSeries {
+                role: ContainerRole::Sut,
+                name: "ehrbase-rs-ehrbase-1".to_owned(),
+                samples: vec![ResourceSample {
+                    offset_s: 10,
+                    phase: ResourcePhase::Warmup,
+                    cpu_pct: 42.5,
+                    rss_bytes: 123_456_789,
+                    blk_read_bytes: 1_000,
+                    blk_write_bytes: 2_000,
+                    net_rx_bytes: 3_000,
+                    net_tx_bytes: 4_000,
+                }],
+            }],
+            disk: DiskAnchors {
+                before_scale_seed_bytes: Some(10),
+                after_scale_seed_bytes: Some(20),
+                after_ward_seed_bytes: None,
+                after_window_bytes: Some(30),
+                seed_compositions: Some(1_000_000),
+            },
+        });
+        let full = serde_json::to_value(&m).unwrap();
+        // Run-clock offsets + phase stamps on the wire, absent anchors omitted.
+        let sample = &full["resources"]["containers"][0]["samples"][0];
+        assert_eq!(sample["offset_s"], 10);
+        assert_eq!(sample["phase"], "warmup");
+        assert_eq!(full["resources"]["containers"][0]["role"], "sut");
+        assert!(
+            full["resources"]["disk"]
+                .get("after_ward_seed_bytes")
+                .is_none()
+        );
+        let parsed: Measurement = serde_json::from_value(full).unwrap();
+        let resources = parsed.resources.unwrap();
+        assert_eq!(resources.sample_interval_s, 10);
+        assert_eq!(resources.disk.seed_compositions, Some(1_000_000));
     }
 
     #[test]

--- a/tools/cnf-runner/src/perf_assets.rs
+++ b/tools/cnf-runner/src/perf_assets.rs
@@ -558,6 +558,7 @@ mod tests {
             operations: vec![op],
             verdict: ClassVerdict::Earned,
             violations: Vec::new(),
+            resources: None,
         }
     }
 

--- a/tools/cnf-runner/src/perf_assets.rs
+++ b/tools/cnf-runner/src/perf_assets.rs
@@ -29,6 +29,9 @@ const STYLE: &str = "<style>\n\
   .notearned { fill: #b3261e; font-weight: 600; }\n\
   .slo { stroke: #b3261e; stroke-width: 1.5; stroke-dasharray: 6 4; }\n\
   .slotext { fill: #b3261e; font-size: 11px; }\n\
+  .sut { stroke: #2a78d6; fill: none; stroke-width: 1.8; }\n\
+  .db { stroke: #8a8880; fill: none; stroke-width: 1.6; stroke-dasharray: 5 3; }\n\
+  .warm { fill: #efede8; }\n\
   @media (prefers-color-scheme: dark) {\n\
     text { fill: #c3c2b7; }\n\
     .title { fill: #ffffff; }\n\
@@ -41,6 +44,9 @@ const STYLE: &str = "<style>\n\
     .notearned { fill: #e5484d; }\n\
     .slo { stroke: #e5484d; }\n\
     .slotext { fill: #e5484d; }\n\
+    .sut { stroke: #3987e5; }\n\
+    .db { stroke: #8f8e85; }\n\
+    .warm { fill: #2a2a28; }\n\
   }\n\
 </style>\n";
 
@@ -414,6 +420,462 @@ pub fn stress_curve_svg(report: &crate::stress::StressReport) -> Result<String, 
     Ok(out)
 }
 
+/// Fixed-precision byte label (decimal units — KB/MB/GB, the vocabulary
+/// every reader knows; the exact byte counts stay in the record):
+/// sub-10 values keep one decimal, larger values round whole.
+fn format_bytes(bytes: f64) -> String {
+    const UNITS: [&str; 5] = ["B", "KB", "MB", "GB", "TB"];
+    let mut value = bytes.max(0.0);
+    let mut unit = 0;
+    while value >= 1000.0 && unit < UNITS.len() - 1 {
+        value /= 1000.0;
+        unit += 1;
+    }
+    let text = if unit == 0 {
+        format!("{value:.0}")
+    } else if value < 10.0 {
+        format!("{value:.1}")
+    } else {
+        format!("{value:.0}")
+    };
+    format!("{text} {}", UNITS.get(unit).copied().unwrap_or("B"))
+}
+
+/// A count with thousands separators (`1,000,000`) — fixed formatting,
+/// locale-independent.
+fn format_count(n: u64) -> String {
+    let digits = n.to_string();
+    let mut out = String::new();
+    for (i, c) in digits.chars().enumerate() {
+        if i > 0 && (digits.len() - i).is_multiple_of(3) {
+            out.push(',');
+        }
+        out.push(c);
+    }
+    out
+}
+
+/// The smallest 1/2/2.5/5 × 10^k value at or above `v` — a nice axis
+/// ceiling (`v <= 0` yields 1).
+fn nice_ceil(v: f64) -> f64 {
+    if v <= 0.0 {
+        return 1.0;
+    }
+    let magnitude = 10.0_f64.powf(v.log10().floor());
+    for step in [1.0, 2.0, 2.5, 5.0, 10.0] {
+        if step * magnitude >= v {
+            return step * magnitude;
+        }
+    }
+    10.0 * magnitude
+}
+
+/// One derived series of a resource time-series chart: run-clock offset
+/// (seconds) → value.
+type ResourcePoints = Vec<(f64, f64)>;
+
+/// A cumulative-counter selector on a resource sample (the I/O strips).
+type CounterOf = &'static dyn Fn(&crate::perf::ResourceSample) -> u64;
+
+/// Extract one per-container value series from the sampled record.
+fn value_series(
+    series: &crate::perf::ContainerResourceSeries,
+    value: &dyn Fn(&crate::perf::ResourceSample) -> f64,
+) -> ResourcePoints {
+    series
+        .samples
+        .iter()
+        .map(|s| {
+            #[allow(clippy::cast_precision_loss)] // offsets << 2^52
+            (s.offset_s as f64, value(s))
+        })
+        .collect()
+}
+
+/// Derive a rate series (units/s) from a cumulative byte counter: deltas
+/// between consecutive samples over their spacing. A counter reset (a
+/// restarted container) clamps to zero rather than plunging negative.
+fn rate_series(
+    series: &crate::perf::ContainerResourceSeries,
+    counter: &dyn Fn(&crate::perf::ResourceSample) -> u64,
+) -> ResourcePoints {
+    series
+        .samples
+        .windows(2)
+        .filter_map(|pair| {
+            let (a, b) = (pair.first()?, pair.get(1)?);
+            let span = b.offset_s.saturating_sub(a.offset_s);
+            if span == 0 {
+                return None;
+            }
+            #[allow(clippy::cast_precision_loss)] // counters/offsets << 2^52
+            Some((
+                b.offset_s as f64,
+                counter(b).saturating_sub(counter(a)) as f64 / span as f64,
+            ))
+        })
+        .collect()
+}
+
+/// Append one polyline path for a value series.
+fn polyline(
+    out: &mut String,
+    points: &[(f64, f64)],
+    x_of: &dyn Fn(f64) -> f64,
+    y_of: &dyn Fn(f64) -> f64,
+    class: &str,
+) {
+    if points.len() < 2 {
+        return;
+    }
+    let d: Vec<String> = points
+        .iter()
+        .enumerate()
+        .map(|(i, (t, v))| {
+            format!(
+                "{}{:.1},{:.1}",
+                if i == 0 { "M" } else { "L" },
+                x_of(*t),
+                y_of(*v)
+            )
+        })
+        .collect();
+    let _ = writeln!(out, "<path d=\"{}\" class=\"{class}\"/>", d.join(" "));
+}
+
+/// The resource time-series for one measured run: CPU and RSS panels over
+/// the run clock (SUT and DB as two series, distinguishable by color AND
+/// dash), warmup shaded, with small-multiple I/O rate strips (block
+/// read/write, network receive/transmit) under them on the shared x-axis.
+/// Fixed canvas — the series are lines, so width never grows with
+/// duration. `None` when the record carries no drawable series (a chart
+/// of nothing would be a fabrication).
+#[must_use]
+#[allow(clippy::too_many_lines)] // one linear chart emitter
+pub fn resources_timeseries_svg(measurement: &Measurement) -> Option<String> {
+    let resources = measurement.resources.as_ref()?;
+    if !resources.containers.iter().any(|c| c.samples.len() >= 2) {
+        return None;
+    }
+    let width = 760.0;
+    let (x0, x1) = (86.0, 724.0);
+    let sut = resources
+        .containers
+        .iter()
+        .find(|c| c.role == crate::perf::ContainerRole::Sut);
+    let db = resources
+        .containers
+        .iter()
+        .find(|c| c.role == crate::perf::ContainerRole::Db);
+    let both = [sut, db];
+
+    // The x-domain: the planned window (warmup + sustained), extended by
+    // any trailing drain samples.
+    let last_offset = resources
+        .containers
+        .iter()
+        .flat_map(|c| c.samples.iter().map(|s| s.offset_s))
+        .max()
+        .unwrap_or(0);
+    #[allow(clippy::cast_precision_loss)] // spans << 2^52
+    let span_s = (measurement.warmup_s + measurement.duration_s).max(last_offset) as f64;
+    let x_of = move |t: f64| x0 + (t / span_s).clamp(0.0, 1.0) * (x1 - x0);
+
+    let mut out = String::new();
+    // Header (title + caption + legend) 84, two panels of 110 with 26-px
+    // titles, four 40-px strips with 22-px titles, 38 for the time axis.
+    let cpu_top = 110.0;
+    let panel_h = 110.0;
+    let rss_top = cpu_top + panel_h + 26.0;
+    let strips_top = rss_top + panel_h + 26.0;
+    let strip_h = 40.0;
+    let strip_step = strip_h + 22.0;
+    // The last strip's bottom edge; the time axis sits in a fixed band
+    // below it, inside the canvas by construction.
+    let bottom = strips_top + 3.0 * strip_step + strip_h;
+    let height = bottom + 34.0;
+    svg_open(&mut out, width, height);
+    let _ = writeln!(
+        out,
+        "<text x=\"24\" y=\"28\" class=\"title\">Resource telemetry — class {} measured run ({})</text>",
+        measurement.class.token(),
+        measurement.case,
+    );
+    let _ = writeln!(
+        out,
+        "<text x=\"24\" y=\"44\" class=\"muted\">Sampled every {} s across the whole window · measured context, never a verdict input — the class is earned on latency, errors and offered load alone</text>",
+        resources.sample_interval_s,
+    );
+    // Legend at fixed columns (the container identities live in the
+    // generated summary table — the legend never grows with a name).
+    let legend_y = 58.0;
+    for (class, label, lx) in [
+        ("sut", "SUT container", 24.0),
+        ("db", "database container", 170.0),
+    ] {
+        let _ = writeln!(
+            out,
+            "<line x1=\"{lx}\" y1=\"{:.1}\" x2=\"{:.1}\" y2=\"{:.1}\" class=\"{class}\"/>\
+             <text x=\"{:.1}\" y=\"{:.1}\" class=\"muted\">{label}</text>",
+            legend_y + 4.0,
+            lx + 22.0,
+            legend_y + 4.0,
+            lx + 28.0,
+            legend_y + 8.0,
+        );
+    }
+    let _ = writeln!(
+        out,
+        "<rect x=\"344\" y=\"{legend_y}\" width=\"14\" height=\"10\" class=\"warm\"/>\
+         <text x=\"364\" y=\"{:.1}\" class=\"muted\">warmup</text>",
+        legend_y + 8.0,
+    );
+
+    // Time ticks: a minute step giving <= 8 ticks.
+    let minutes = span_s / 60.0;
+    let tick_step_min = [1.0, 2.0, 5.0, 10.0, 15.0, 30.0, 60.0, 120.0, 240.0]
+        .into_iter()
+        .find(|step| minutes / step <= 8.0)
+        .unwrap_or(240.0);
+
+    #[allow(clippy::cast_precision_loss)] // window seconds << 2^52
+    let warm_w = x_of(measurement.warmup_s as f64) - x0;
+
+    // One panel or strip: warmup shade, gridlines, y-labels, series.
+    let panel = |out: &mut String,
+                 top: f64,
+                 h: f64,
+                 title: &str,
+                 points: &[(&str, ResourcePoints)],
+                 label_of: &dyn Fn(f64) -> String| {
+        let y_max = nice_ceil(
+            points
+                .iter()
+                .flat_map(|(_, p)| p.iter().map(|(_, v)| *v))
+                .fold(0.0, f64::max),
+        );
+        let y_of = move |v: f64| top + h - (v / y_max).clamp(0.0, 1.0) * h;
+        let _ = writeln!(
+            out,
+            "<text x=\"{x0}\" y=\"{:.1}\" class=\"muted\">{title}</text>",
+            top - 7.0,
+        );
+        let _ = writeln!(
+            out,
+            "<rect x=\"{x0}\" y=\"{top:.1}\" width=\"{warm_w:.1}\" height=\"{h}\" class=\"warm\"/>",
+        );
+        // Gridlines at 0 / half / full scale, labeled on the left.
+        for frac in [0.0, 0.5, 1.0] {
+            let y = y_of(y_max * frac);
+            let _ = writeln!(
+                out,
+                "<line x1=\"{x0}\" y1=\"{y:.1}\" x2=\"{x1}\" y2=\"{y:.1}\" class=\"grid\"/>\
+                 <text x=\"{:.1}\" y=\"{:.1}\" class=\"muted\" text-anchor=\"end\">{}</text>",
+                x0 - 8.0,
+                y + 4.0,
+                label_of(y_max * frac),
+            );
+        }
+        for (class, series_points) in points {
+            polyline(out, series_points, &x_of, &y_of, class);
+        }
+    };
+
+    let pair = |value: &dyn Fn(&crate::perf::ResourceSample) -> f64| -> Vec<(&'static str, ResourcePoints)> {
+        let mut set = Vec::new();
+        if let Some(c) = sut {
+            set.push(("sut", value_series(c, value)));
+        }
+        if let Some(c) = db {
+            set.push(("db", value_series(c, value)));
+        }
+        set
+    };
+    let rate_pair = |counter: &dyn Fn(&crate::perf::ResourceSample) -> u64| -> Vec<(&'static str, ResourcePoints)> {
+        both.iter()
+            .flatten()
+            .map(|c| {
+                (
+                    if c.role == crate::perf::ContainerRole::Sut {
+                        "sut"
+                    } else {
+                        "db"
+                    },
+                    rate_series(c, counter),
+                )
+            })
+            .collect()
+    };
+
+    panel(
+        &mut out,
+        cpu_top,
+        panel_h,
+        "CPU (% of one core)",
+        &pair(&|s| s.cpu_pct),
+        &|v| format!("{v:.0}%"),
+    );
+    panel(
+        &mut out,
+        rss_top,
+        panel_h,
+        "Resident memory",
+        &pair(&|s| {
+            #[allow(clippy::cast_precision_loss)] // bytes << 2^52
+            {
+                s.rss_bytes as f64
+            }
+        }),
+        &format_bytes,
+    );
+    let strips: [(&str, CounterOf); 4] = [
+        ("Block read", &|s| s.blk_read_bytes),
+        ("Block write", &|s| s.blk_write_bytes),
+        ("Network receive", &|s| s.net_rx_bytes),
+        ("Network transmit", &|s| s.net_tx_bytes),
+    ];
+    for (i, (title, counter)) in strips.iter().enumerate() {
+        #[allow(clippy::cast_precision_loss)] // four strips
+        let top = strips_top + i as f64 * strip_step;
+        panel(&mut out, top, strip_h, title, &rate_pair(counter), &|v| {
+            format!("{}/s", format_bytes(v))
+        });
+    }
+
+    // The shared time axis under the last strip.
+    let axis_y = bottom + 6.0;
+    let mut t_min = 0.0;
+    while t_min * 60.0 <= span_s {
+        let x = x_of(t_min * 60.0);
+        let _ = writeln!(
+            out,
+            "<text x=\"{x:.1}\" y=\"{:.1}\" class=\"muted\" text-anchor=\"middle\">{t_min:.0} min</text>",
+            axis_y + 12.0,
+        );
+        t_min += tick_step_min;
+    }
+    out.push_str("</svg>\n");
+    Some(out)
+}
+
+/// The disk-growth waterfall: the database volume's on-disk size at the
+/// run's four anchors (empty → scale seed → ward seed → after the
+/// window), each present anchor a bar labeled with its absolute size, the
+/// scale-seed step annotated with the derived bytes per committed
+/// composition. Rendered from the highest measured class carrying
+/// anchors; `None` when no record carries any. Fixed columns — nothing
+/// can overflow by construction.
+#[must_use]
+#[allow(clippy::too_many_lines)] // one linear chart emitter
+pub fn disk_growth_svg(measurements: &[Measurement]) -> Option<String> {
+    let measurement = measurements
+        .iter()
+        .filter(|m| {
+            m.resources.as_ref().is_some_and(|r| {
+                r.disk.before_scale_seed_bytes.is_some()
+                    || r.disk.after_scale_seed_bytes.is_some()
+                    || r.disk.after_ward_seed_bytes.is_some()
+                    || r.disk.after_window_bytes.is_some()
+            })
+        })
+        .max_by(|a, b| {
+            a.class
+                .arrival_floor_per_s()
+                .total_cmp(&b.class.arrival_floor_per_s())
+        })?;
+    let disk = &measurement.resources.as_ref()?.disk;
+
+    let (width, height) = (640.0, 312.0);
+    let (y_top, y_bottom) = (100.0, 244.0);
+    let anchors: [(&str, Option<u64>); 4] = [
+        ("empty", disk.before_scale_seed_bytes),
+        ("after scale seed", disk.after_scale_seed_bytes),
+        ("after ward seed", disk.after_ward_seed_bytes),
+        ("after window", disk.after_window_bytes),
+    ];
+    #[allow(clippy::cast_precision_loss)] // volume sizes << 2^52
+    let max_bytes = anchors
+        .iter()
+        .filter_map(|(_, v)| *v)
+        .max()
+        .unwrap_or(1)
+        .max(1) as f64;
+
+    let mut out = String::new();
+    svg_open(&mut out, width, height);
+    let _ = writeln!(
+        out,
+        "<text x=\"24\" y=\"28\" class=\"title\">Disk growth — database volume across the class {} measured run</text>",
+        measurement.class.token(),
+    );
+    let _ = writeln!(
+        out,
+        "<text x=\"24\" y=\"48\" class=\"muted\">The volume's on-disk size at the run's four anchors, probed read-only inside the DB container.</text>"
+    );
+    let _ = writeln!(
+        out,
+        "<text x=\"24\" y=\"63\" class=\"muted\">The scale-seed step yields the storage cost per committed composition · measured context, never a verdict input.</text>"
+    );
+    let _ = writeln!(
+        out,
+        "<line x1=\"60\" y1=\"{y_bottom}\" x2=\"580\" y2=\"{y_bottom}\" class=\"grid\"/>"
+    );
+
+    let bar_w = 84.0;
+    for (i, (label, value)) in anchors.iter().enumerate() {
+        #[allow(clippy::cast_precision_loss)] // four columns
+        let cx = 120.0 + i as f64 * 140.0;
+        let _ = writeln!(
+            out,
+            "<text x=\"{cx:.1}\" y=\"{:.1}\" class=\"muted\" text-anchor=\"middle\">{label}</text>",
+            y_bottom + 18.0,
+        );
+        match value {
+            Some(bytes) => {
+                #[allow(clippy::cast_precision_loss)] // volume sizes << 2^52
+                let bytes_f = *bytes as f64;
+                let h = (bytes_f / max_bytes) * (y_bottom - y_top);
+                let y = y_bottom - h.max(2.0);
+                let _ = writeln!(
+                    out,
+                    "<rect x=\"{:.1}\" y=\"{y:.1}\" width=\"{bar_w}\" height=\"{:.1}\" rx=\"4\" class=\"measured\"/>\
+                     <text x=\"{cx:.1}\" y=\"{:.1}\" text-anchor=\"middle\">{}</text>",
+                    cx - bar_w / 2.0,
+                    h.max(2.0),
+                    y - 8.0,
+                    format_bytes(bytes_f),
+                );
+            }
+            None => {
+                let _ = writeln!(
+                    out,
+                    "<text x=\"{cx:.1}\" y=\"{:.1}\" class=\"muted\" text-anchor=\"middle\">not probed</text>",
+                    f64::midpoint(y_top, y_bottom),
+                );
+            }
+        }
+    }
+    // The storage-efficiency headline under the scale-seed column.
+    if let (Some(before), Some(after), Some(n)) = (
+        disk.before_scale_seed_bytes,
+        disk.after_scale_seed_bytes,
+        disk.seed_compositions,
+    ) && n > 0
+    {
+        #[allow(clippy::cast_precision_loss)] // sizes/counts << 2^52
+        let per = after.saturating_sub(before) as f64 / n as f64;
+        let _ = writeln!(
+            out,
+            "<text x=\"260\" y=\"{:.1}\" class=\"muted\" text-anchor=\"middle\">&#8776; {} / composition ({} committed)</text>",
+            y_bottom + 34.0,
+            format_bytes(per),
+            format_count(n),
+        );
+    }
+    out.push_str("</svg>\n");
+    Some(out)
+}
+
 /// Fixed-precision label: sub-10 ms values keep one decimal, larger values
 /// round to whole milliseconds.
 fn format_ms(ms: f64) -> String {
@@ -519,8 +981,87 @@ pub fn summary_markdown(
                 format_ms(ms(0.99)),
             );
         }
+        resources_markdown(&mut out, m.resources.as_ref());
     }
     Ok(out)
+}
+
+/// The derived resources table of one measured run (peak/mean CPU, peak
+/// RSS, the disk anchors — every number derived from the committed series,
+/// never stored beside it), or the honest absence line.
+fn resources_markdown(out: &mut String, resources: Option<&crate::perf::ResourcesRecord>) {
+    let Some(r) = resources else {
+        let _ = writeln!(out, "\nResources: not sampled.");
+        return;
+    };
+    let _ = writeln!(
+        out,
+        "\nResources (measured context, never a verdict input) — sampled every {} s; \
+         CPU/RSS derived over the measured phase:\n",
+        r.sample_interval_s,
+    );
+    let _ = writeln!(out, "| Container | CPU mean | CPU peak | RSS peak |");
+    let _ = writeln!(out, "| --- | --- | --- | --- |");
+    for c in &r.containers {
+        let role = match c.role {
+            crate::perf::ContainerRole::Sut => "sut",
+            crate::perf::ContainerRole::Db => "db",
+        };
+        let measured: Vec<&crate::perf::ResourceSample> = c
+            .samples
+            .iter()
+            .filter(|s| s.phase == crate::perf::ResourcePhase::Measured)
+            .collect();
+        // A run whose window never reached the measured phase still
+        // reports what it saw.
+        let set = if measured.is_empty() {
+            c.samples.iter().collect()
+        } else {
+            measured
+        };
+        if set.is_empty() {
+            let _ = writeln!(out, "| {role} `{}` | — | — | — |", c.name);
+            continue;
+        }
+        #[allow(clippy::cast_precision_loss)] // sample counts << 2^52
+        let cpu_mean = set.iter().map(|s| s.cpu_pct).sum::<f64>() / set.len() as f64;
+        let cpu_peak = set.iter().map(|s| s.cpu_pct).fold(0.0, f64::max);
+        let rss_peak = set.iter().map(|s| s.rss_bytes).max().unwrap_or(0);
+        #[allow(clippy::cast_precision_loss)] // bytes << 2^52
+        let _ = writeln!(
+            out,
+            "| {role} `{}` | {cpu_mean:.1}% | {cpu_peak:.1}% | {} |",
+            c.name,
+            format_bytes(rss_peak as f64),
+        );
+    }
+    #[allow(clippy::cast_precision_loss)] // volume sizes << 2^52
+    let anchor =
+        |v: Option<u64>| v.map_or_else(|| "not probed".to_owned(), |b| format_bytes(b as f64));
+    let per_composition = match (
+        r.disk.before_scale_seed_bytes,
+        r.disk.after_scale_seed_bytes,
+        r.disk.seed_compositions,
+    ) {
+        (Some(before), Some(after), Some(n)) if n > 0 => {
+            #[allow(clippy::cast_precision_loss)] // sizes/counts << 2^52
+            let per = after.saturating_sub(before) as f64 / n as f64;
+            format!(
+                " (≈ {} / composition over {} committed)",
+                format_bytes(per),
+                format_count(n)
+            )
+        }
+        _ => String::new(),
+    };
+    let _ = writeln!(
+        out,
+        "\nDisk anchors: empty {} → after scale seed {}{per_composition} → after ward seed {} → after window {}.",
+        anchor(r.disk.before_scale_seed_bytes),
+        anchor(r.disk.after_scale_seed_bytes),
+        anchor(r.disk.after_ward_seed_bytes),
+        anchor(r.disk.after_window_bytes),
+    );
 }
 
 #[cfg(test)]
@@ -587,5 +1128,120 @@ mod tests {
         // p99 of the fixture histogram is 40ms — the label re-derives from
         // the decoded histogram.
         assert!(latency.contains(">40<"));
+    }
+
+    fn sample(
+        offset_s: u64,
+        phase: crate::perf::ResourcePhase,
+        cpu_pct: f64,
+        rss_bytes: u64,
+    ) -> crate::perf::ResourceSample {
+        crate::perf::ResourceSample {
+            offset_s,
+            phase,
+            cpu_pct,
+            rss_bytes,
+            blk_read_bytes: offset_s * 1_000,
+            blk_write_bytes: offset_s * 5_000,
+            net_rx_bytes: offset_s * 200,
+            net_tx_bytes: offset_s * 300,
+        }
+    }
+
+    fn measurement_with_resources() -> Measurement {
+        use crate::perf::ResourcePhase;
+        let mut m = measurement();
+        m.resources = Some(crate::perf::ResourcesRecord {
+            sample_interval_s: 10,
+            containers: vec![
+                crate::perf::ContainerResourceSeries {
+                    role: crate::perf::ContainerRole::Sut,
+                    name: "ehrbase-rs-ehrbase-1".to_owned(),
+                    samples: vec![
+                        sample(10, ResourcePhase::Warmup, 12.0, 400_000_000),
+                        sample(310, ResourcePhase::Measured, 55.0, 600_000_000),
+                        sample(3910, ResourcePhase::Drain, 5.0, 500_000_000),
+                    ],
+                },
+                crate::perf::ContainerResourceSeries {
+                    role: crate::perf::ContainerRole::Db,
+                    name: "ehrbase-rs-ehrbase-postgres-1".to_owned(),
+                    samples: vec![
+                        sample(10, ResourcePhase::Warmup, 30.0, 900_000_000),
+                        sample(310, ResourcePhase::Measured, 140.0, 1_400_000_000),
+                    ],
+                },
+            ],
+            disk: crate::perf::DiskAnchors {
+                before_scale_seed_bytes: Some(64_000_000),
+                after_scale_seed_bytes: Some(10_000_000_000),
+                after_ward_seed_bytes: None,
+                after_window_bytes: Some(11_000_000_000),
+                seed_compositions: Some(1_000_000),
+            },
+        });
+        m
+    }
+
+    #[test]
+    fn the_resource_charts_are_deterministic_and_honest() {
+        // A record without resources renders nothing — never a fabricated
+        // chart.
+        assert!(resources_timeseries_svg(&measurement()).is_none());
+        assert!(disk_growth_svg(&[measurement()]).is_none());
+
+        let m = measurement_with_resources();
+        let series = resources_timeseries_svg(&m).unwrap();
+        assert_eq!(series, resources_timeseries_svg(&m).unwrap());
+        assert!(series.contains("Resource telemetry — class POC measured run"));
+        assert!(series.contains("never a verdict input"));
+        assert!(series.contains("CPU (% of one core)"));
+        assert!(series.contains("Resident memory"));
+        assert!(series.contains("Block write"));
+        assert!(series.contains("Network transmit"));
+        assert!(series.contains("class=\"warm\"")); // the warmup shade
+        assert!(series.contains("class=\"sut\""));
+        assert!(series.contains("class=\"db\""));
+        assert!(series.contains("prefers-color-scheme: dark"));
+
+        let disk = disk_growth_svg(std::slice::from_ref(&m)).unwrap();
+        assert_eq!(disk, disk_growth_svg(std::slice::from_ref(&m)).unwrap());
+        assert!(disk.contains("Disk growth"));
+        assert!(disk.contains("64 MB")); // the empty anchor
+        assert!(disk.contains("10 GB"));
+        assert!(disk.contains("not probed")); // the absent ward anchor stays honest
+        // (10 GB - 64 MB) / 1M compositions ≈ 9.9 KB/composition.
+        assert!(disk.contains("/ composition"));
+        assert!(disk.contains("9.9 KB"));
+    }
+
+    #[test]
+    fn the_summary_carries_the_derived_resources_table() {
+        let cases = [case("POC", "2/s")];
+        // Without a record the summary says so.
+        let bare = summary_markdown(&cases, &[measurement()]).unwrap();
+        assert!(bare.contains("Resources: not sampled."));
+
+        let with = summary_markdown(&cases, &[measurement_with_resources()]).unwrap();
+        assert!(with.contains("| Container | CPU mean | CPU peak | RSS peak |"));
+        // The SUT row derives over the measured phase only (one sample:
+        // 55% / 600 MB).
+        assert!(with.contains("| sut `ehrbase-rs-ehrbase-1` | 55.0% | 55.0% | 600 MB |"));
+        assert!(with.contains("Disk anchors: empty 64 MB"));
+        assert!(with.contains("not probed"));
+        assert!(with.contains("/ composition over 1,000,000 committed"));
+    }
+
+    #[test]
+    fn byte_and_ceiling_helpers_are_fixed_precision() {
+        assert_eq!(format_bytes(0.0), "0 B");
+        assert_eq!(format_bytes(999.0), "999 B");
+        assert_eq!(format_bytes(1536.0), "1.5 KB");
+        assert_eq!(format_bytes(64_000_000.0), "64 MB");
+        assert_eq!(format_bytes(10_000_000_000.0), "10 GB");
+        assert!((nice_ceil(0.0) - 1.0).abs() < f64::EPSILON);
+        assert!((nice_ceil(3.0) - 5.0).abs() < f64::EPSILON);
+        assert!((nice_ceil(140.0) - 200.0).abs() < f64::EPSILON);
+        assert!((nice_ceil(730.0) - 1000.0).abs() < f64::EPSILON);
     }
 }

--- a/tools/cnf-runner/src/perf_assets.rs
+++ b/tools/cnf-runner/src/perf_assets.rs
@@ -32,6 +32,8 @@ const STYLE: &str = "<style>\n\
   .sut { stroke: #2a78d6; fill: none; stroke-width: 1.8; }\n\
   .db { stroke: #8a8880; fill: none; stroke-width: 1.6; stroke-dasharray: 5 3; }\n\
   .warm { fill: #efede8; }\n\
+  .curve { stroke: #2a78d6; fill: none; stroke-width: 2; }\n\
+  .knee { stroke: #1baf7a; stroke-width: 2; stroke-dasharray: 2 3; }\n\
   @media (prefers-color-scheme: dark) {\n\
     text { fill: #c3c2b7; }\n\
     .title { fill: #ffffff; }\n\
@@ -47,6 +49,8 @@ const STYLE: &str = "<style>\n\
     .sut { stroke: #3987e5; }\n\
     .db { stroke: #8f8e85; }\n\
     .warm { fill: #2a2a28; }\n\
+    .curve { stroke: #3987e5; }\n\
+    .knee { stroke: #26c78d; }\n\
   }\n\
 </style>\n";
 
@@ -378,11 +382,7 @@ pub fn stress_curve_svg(report: &crate::stress::StressReport) -> Result<String, 
             )
         })
         .collect();
-    let _ = writeln!(
-        out,
-        "<path d=\"{}\" fill=\"none\" class=\"s1s\" stroke-width=\"2\"/>",
-        path.join(" ")
-    );
+    let _ = writeln!(out, "<path d=\"{}\" class=\"curve\"/>", path.join(" "));
     for (rate, ms, stable) in &points {
         let (x, y) = (x_of(*rate), y_of(*ms));
         if *stable {
@@ -410,7 +410,7 @@ pub fn stress_curve_svg(report: &crate::stress::StressReport) -> Result<String, 
     let mst_x = x_of(report.max_sustainable_throughput_per_s.max(min_rate));
     let _ = writeln!(
         out,
-        "<line x1=\"{mst_x:.1}\" y1=\"{y_top}\" x2=\"{mst_x:.1}\" y2=\"{y_bottom}\" class=\"s2s\" stroke-width=\"2\" stroke-dasharray=\"2 3\"/>\
+        "<line x1=\"{mst_x:.1}\" y1=\"{y_top}\" x2=\"{mst_x:.1}\" y2=\"{y_bottom}\" class=\"knee\"/>\
          <text x=\"{:.1}\" y=\"{:.1}\" class=\"earned\">max sustainable {:.0}/s</text>",
         mst_x + 6.0,
         y_top + 14.0,
@@ -771,19 +771,22 @@ pub fn disk_growth_svg(measurements: &[Measurement]) -> Option<String> {
     let measurement = measurements
         .iter()
         .filter(|m| {
-            m.resources.as_ref().is_some_and(|r| {
-                r.disk.before_scale_seed_bytes.is_some()
-                    || r.disk.after_scale_seed_bytes.is_some()
-                    || r.disk.after_ward_seed_bytes.is_some()
-                    || r.disk.after_window_bytes.is_some()
-            })
+            m.resources
+                .as_ref()
+                .and_then(|r| r.disk)
+                .is_some_and(|disk| {
+                    disk.before_scale_seed_bytes.is_some()
+                        || disk.after_scale_seed_bytes.is_some()
+                        || disk.after_ward_seed_bytes.is_some()
+                        || disk.after_window_bytes.is_some()
+                })
         })
         .max_by(|a, b| {
             a.class
                 .arrival_floor_per_s()
                 .total_cmp(&b.class.arrival_floor_per_s())
         })?;
-    let disk = &measurement.resources.as_ref()?.disk;
+    let disk = measurement.resources.as_ref()?.disk?;
 
     let (width, height) = (640.0, 312.0);
     let (y_top, y_bottom) = (100.0, 244.0);
@@ -1035,13 +1038,18 @@ fn resources_markdown(out: &mut String, resources: Option<&crate::perf::Resource
             format_bytes(rss_peak as f64),
         );
     }
+    // The disk anchors exist only on measured class runs (stress-style
+    // records sample containers without them).
+    let Some(disk) = r.disk else {
+        return;
+    };
     #[allow(clippy::cast_precision_loss)] // volume sizes << 2^52
     let anchor =
         |v: Option<u64>| v.map_or_else(|| "not probed".to_owned(), |b| format_bytes(b as f64));
     let per_composition = match (
-        r.disk.before_scale_seed_bytes,
-        r.disk.after_scale_seed_bytes,
-        r.disk.seed_compositions,
+        disk.before_scale_seed_bytes,
+        disk.after_scale_seed_bytes,
+        disk.seed_compositions,
     ) {
         (Some(before), Some(after), Some(n)) if n > 0 => {
             #[allow(clippy::cast_precision_loss)] // sizes/counts << 2^52
@@ -1057,10 +1065,10 @@ fn resources_markdown(out: &mut String, resources: Option<&crate::perf::Resource
     let _ = writeln!(
         out,
         "\nDisk anchors: empty {} → after scale seed {}{per_composition} → after ward seed {} → after window {}.",
-        anchor(r.disk.before_scale_seed_bytes),
-        anchor(r.disk.after_scale_seed_bytes),
-        anchor(r.disk.after_ward_seed_bytes),
-        anchor(r.disk.after_window_bytes),
+        anchor(disk.before_scale_seed_bytes),
+        anchor(disk.after_scale_seed_bytes),
+        anchor(disk.after_ward_seed_bytes),
+        anchor(disk.after_window_bytes),
     );
 }
 
@@ -1172,13 +1180,13 @@ mod tests {
                     ],
                 },
             ],
-            disk: crate::perf::DiskAnchors {
+            disk: Some(crate::perf::DiskAnchors {
                 before_scale_seed_bytes: Some(64_000_000),
                 after_scale_seed_bytes: Some(10_000_000_000),
                 after_ward_seed_bytes: None,
                 after_window_bytes: Some(11_000_000_000),
                 seed_compositions: Some(1_000_000),
-            },
+            }),
         });
         m
     }

--- a/tools/cnf-runner/src/perf_assets.rs
+++ b/tools/cnf-runner/src/perf_assets.rs
@@ -1006,22 +1006,8 @@ fn resources_markdown(out: &mut String, resources: Option<&crate::perf::Resource
     let _ = writeln!(out, "| Container | CPU mean | CPU peak | RSS peak |");
     let _ = writeln!(out, "| --- | --- | --- | --- |");
     for c in &r.containers {
-        let role = match c.role {
-            crate::perf::ContainerRole::Sut => "sut",
-            crate::perf::ContainerRole::Db => "db",
-        };
-        let measured: Vec<&crate::perf::ResourceSample> = c
-            .samples
-            .iter()
-            .filter(|s| s.phase == crate::perf::ResourcePhase::Measured)
-            .collect();
-        // A run whose window never reached the measured phase still
-        // reports what it saw.
-        let set = if measured.is_empty() {
-            c.samples.iter().collect()
-        } else {
-            measured
-        };
+        let role = c.role.label();
+        let set = c.measured_samples();
         if set.is_empty() {
             let _ = writeln!(out, "| {role} `{}` | — | — | — |", c.name);
             continue;

--- a/tools/cnf-runner/src/perf_run/corpus.rs
+++ b/tools/cnf-runner/src/perf_run/corpus.rs
@@ -3,8 +3,9 @@
 //! STANDING WARD — the per-patient state the journey stages address
 //! mid-flight (an episode directory, the GP-data-set chart document, the
 //! medicines list, one committed CONTRIBUTION), seeded strictly through
-//! the public API (never a database backdoor) and persisted as a sidecar
-//! index so re-runs can skip re-seeding.
+//! the public API (never a database backdoor). The workflow always seeds
+//! a freshly composed, empty SUT and tears the stack down afterwards —
+//! there is no seed reuse.
 
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -55,8 +56,8 @@ pub struct WardPatient {
     pub contribution_uid: String,
 }
 
-/// The seeded corpus index: what the measurement operations address.
-/// Persisted as a sidecar JSON so a re-run can skip re-seeding.
+/// The seeded corpus index: what the measurement operations address
+/// (in-memory for the run; the workflow always seeds fresh).
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SeededCorpus {
     /// The corpus key this index realizes (e.g. `cnf.scale.10k`).
@@ -65,8 +66,7 @@ pub struct SeededCorpus {
     pub ehr_ids: Vec<String>,
     /// Seeded compositions as `(ehr index, version_uid)`.
     pub compositions: Vec<(usize, String)>,
-    /// The standing ward (empty in a pre-journey sidecar; `seed_ward`
-    /// fills it).
+    /// The standing ward (`seed_ward` fills it after the scale seed).
     #[serde(default)]
     pub ward: Vec<WardPatient>,
 }
@@ -288,8 +288,8 @@ pub fn seed_scale_ladder(
 /// (409 on re-run is fine), register the dashboard stored query, then per
 /// ward patient commit the GP chart document, the medicines list, the
 /// episode directory, and one CONTRIBUTION — capturing every uid the
-/// journey stages address. Idempotent per sidecar: a corpus whose `ward`
-/// already covers the target size is left untouched.
+/// journey stages address. Idempotent: a corpus whose `ward` already
+/// covers the target size is left untouched.
 ///
 /// # Errors
 /// A message on any unexpected wire outcome or a transport fault.
@@ -558,10 +558,9 @@ mod tests {
     }
 
     #[test]
-    fn a_pre_journey_sidecar_still_parses_without_a_ward() {
-        let sidecar =
-            r#"{"corpus":"cnf.scale.10k","ehr_ids":["a"],"compositions":[[0,"u::s::1"]]}"#;
-        let corpus: SeededCorpus = serde_json::from_str(sidecar).unwrap();
+    fn a_pre_ward_index_parses_with_an_empty_ward() {
+        let index = r#"{"corpus":"cnf.scale.10k","ehr_ids":["a"],"compositions":[[0,"u::s::1"]]}"#;
+        let corpus: SeededCorpus = serde_json::from_str(index).unwrap();
         assert!(corpus.ward.is_empty());
     }
 }

--- a/tools/cnf-runner/src/perf_run/mod.rs
+++ b/tools/cnf-runner/src/perf_run/mod.rs
@@ -21,11 +21,13 @@
 //! arrivals (uniform + diurnal curves) · [`execute`] the per-stage wire
 //! realization + captured-id state · [`window`] the measured window core
 //! shared by the class runs (conformance) and the stress ladder
-//! (exploration).
+//! (exploration) · [`resources`] the per-container resource sampler + disk
+//! anchors (measured context, never verdict-bearing).
 
 pub mod client;
 pub mod corpus;
 pub mod execute;
 pub mod pack;
+pub mod resources;
 pub mod schedule;
 pub mod window;

--- a/tools/cnf-runner/src/perf_run/resources.rs
+++ b/tools/cnf-runner/src/perf_run/resources.rs
@@ -314,6 +314,43 @@ fn parse_stats(v: &serde_json::Value) -> Option<RawCounters> {
     })
 }
 
+/// Pay the database's maintenance debt outside the measured windows:
+/// seeding outruns autovacuum/autoanalyze (a stale-statistics plan cost a
+/// measured ~9x on the ward-worklist query, 2026-07-23), and an
+/// autovacuum firing INSIDE a window saturates the engine
+/// mid-measurement. `vacuumdb --all --analyze` through the DB container
+/// settles both, deterministically, identically for every SUT.
+/// NOTE: no openEHR spec governs measured performance — instrument-side
+/// fairness, our own design/extension (the retired benchmark lab's
+/// documented prior art).
+///
+/// # Errors
+/// A message when the runtime/exec/`vacuumdb` is unavailable or fails
+/// (logged and skipped by callers — never a run failure).
+pub fn settle_maintenance(db_container: &str) -> Result<(), String> {
+    let output = Command::new("docker")
+        .args([
+            "exec",
+            db_container,
+            "vacuumdb",
+            "-U",
+            "postgres",
+            "--all",
+            "--analyze",
+        ])
+        .output()
+        .map_err(|e| format!("docker exec: {e}"))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "vacuumdb failed (exit {:?}): {}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        ))
+    }
+}
+
 /// Probe the database volume's on-disk size (bytes): a read-only `du`
 /// over the volume mount inside the DB container — instrument telemetry
 /// through the container runtime, never a clinical-data path.

--- a/tools/cnf-runner/src/perf_run/resources.rs
+++ b/tools/cnf-runner/src/perf_run/resources.rs
@@ -1,0 +1,417 @@
+//! The resource-telemetry sampler for measured runs: per-container
+//! CPU/RSS/block-IO/network series on a fixed cadence via the Docker
+//! Engine API stats endpoint (one-shot stats per container per tick), plus
+//! the database volume's disk-anchor probe. Measured CONTEXT only — never
+//! verdict-bearing, and every failure degrades to an absent/truncated
+//! series with the reason in the progress log, never a run failure.
+//!
+//! NOTE: no openEHR spec governs measured performance or its telemetry —
+//! our own design/extension (the CNF guide excludes non-functional
+//! conformance; see `crate::perf`).
+
+use std::process::Command;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use crate::ixit::Containers;
+use crate::perf::{ContainerResourceSeries, ContainerRole, ResourcePhase, ResourceSample};
+
+/// The fixed sampling cadence of a measured run (the schedule the record's
+/// `sample_interval_s` publishes).
+pub const SAMPLE_INTERVAL: Duration = Duration::from_secs(10);
+
+/// The DB container path the disk anchors probe — the compose volume mount
+/// (`docker-compose.yml` mounts `ehrbase-pgdata` at `/var/lib/postgresql`;
+/// the stock postgres images keep PGDATA under the same prefix).
+const DB_VOLUME_DIR: &str = "/var/lib/postgresql";
+
+/// How long one stats/probe subprocess may take before it counts as a
+/// failed tick (well under the cadence, so a hung runtime cannot skew the
+/// schedule).
+const PROBE_TIMEOUT: Duration = Duration::from_secs(8);
+
+/// The cumulative counters one Engine-API stats reply carries (the raw
+/// material a sample derives from; CPU% needs two consecutive readings).
+#[derive(Debug, Clone, Copy)]
+struct RawCounters {
+    /// Total CPU consumed since container start, nanoseconds.
+    cpu_total_ns: u64,
+    /// Resident-set memory, bytes (usage minus the page cache the kernel
+    /// can reclaim — the same subtraction the docker CLI shows).
+    rss_bytes: u64,
+    blk_read_bytes: u64,
+    blk_write_bytes: u64,
+    net_rx_bytes: u64,
+    net_tx_bytes: u64,
+}
+
+/// A running resource sampler over the ixit-declared SUT + DB containers.
+#[derive(Debug)]
+pub struct ResourceSampler {
+    stop: Arc<AtomicBool>,
+    handle: JoinHandle<(Vec<ContainerResourceSeries>, Vec<String>)>,
+}
+
+impl ResourceSampler {
+    /// Start sampling at [`SAMPLE_INTERVAL`]. `warmup_s`/`duration_s` are
+    /// the planned window bounds the samples' phase stamps derive from
+    /// (offsets past `warmup_s + duration_s` stamp as `drain` — the
+    /// trailing completions still draining).
+    #[must_use]
+    pub fn start(containers: &Containers, warmup_s: u64, duration_s: u64) -> Self {
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_flag = Arc::clone(&stop);
+        let targets = vec![
+            (ContainerRole::Sut, containers.sut.clone()),
+            (ContainerRole::Db, containers.db.clone()),
+        ];
+        let handle =
+            std::thread::spawn(move || sample_loop(&targets, warmup_s, duration_s, &stop_flag));
+        Self { stop, handle }
+    }
+
+    /// Stop sampling and collect the per-container series plus the
+    /// degradation notes (failed ticks and their reasons — logged by the
+    /// caller, never a run failure).
+    #[must_use]
+    pub fn stop(self) -> (Vec<ContainerResourceSeries>, Vec<String>) {
+        self.stop.store(true, Ordering::Relaxed);
+        self.handle.join().unwrap_or_else(|_| {
+            (
+                Vec::new(),
+                vec!["resource sampler thread panicked — series lost".to_owned()],
+            )
+        })
+    }
+}
+
+/// The phase a run-clock offset falls in against the planned window.
+fn phase_of(offset_s: u64, warmup_s: u64, duration_s: u64) -> ResourcePhase {
+    if offset_s < warmup_s {
+        ResourcePhase::Warmup
+    } else if offset_s < warmup_s.saturating_add(duration_s) {
+        ResourcePhase::Measured
+    } else {
+        ResourcePhase::Drain
+    }
+}
+
+fn sample_loop(
+    targets: &[(ContainerRole, String)],
+    warmup_s: u64,
+    duration_s: u64,
+    stop: &AtomicBool,
+) -> (Vec<ContainerResourceSeries>, Vec<String>) {
+    let started = Instant::now();
+    let mut notes: Vec<String> = Vec::new();
+    let mut series: Vec<ContainerResourceSeries> = targets
+        .iter()
+        .map(|(role, name)| ContainerResourceSeries {
+            role: *role,
+            name: name.clone(),
+            samples: Vec::new(),
+        })
+        .collect();
+    // Baseline counters at t0 (CPU% needs a delta, so the first emitted
+    // sample lands one interval in).
+    let mut prev: Vec<Option<(Instant, RawCounters)>> = targets
+        .iter()
+        .map(|(_, name)| {
+            container_counters(name).map_or_else(
+                |e| {
+                    notes.push(format!("resource baseline for {name}: {e}"));
+                    None
+                },
+                |c| Some((started, c)),
+            )
+        })
+        .collect();
+
+    let mut tick: u32 = 1;
+    loop {
+        let next = started + SAMPLE_INTERVAL * tick;
+        while Instant::now() < next {
+            if stop.load(Ordering::Relaxed) {
+                return (series, dedup_notes(notes));
+            }
+            std::thread::sleep(Duration::from_millis(250));
+        }
+        for (i, (_, name)) in targets.iter().enumerate() {
+            let now = Instant::now();
+            match container_counters(name) {
+                Ok(counters) => {
+                    if let (Some(slot), Some(target)) = (prev.get_mut(i), series.get_mut(i)) {
+                        if let Some((prev_at, prev_counters)) = *slot {
+                            let wall_ns = now.duration_since(prev_at).as_nanos().max(1);
+                            let cpu_ns = counters
+                                .cpu_total_ns
+                                .saturating_sub(prev_counters.cpu_total_ns);
+                            // % of one core over the interval (100 = one
+                            // full core) — both deltas are far below 2^52.
+                            #[allow(clippy::cast_precision_loss)]
+                            let cpu_pct = cpu_ns as f64 / wall_ns as f64 * 100.0;
+                            let offset_s = started.elapsed().as_secs();
+                            target.samples.push(ResourceSample {
+                                offset_s,
+                                phase: phase_of(offset_s, warmup_s, duration_s),
+                                cpu_pct,
+                                rss_bytes: counters.rss_bytes,
+                                blk_read_bytes: counters.blk_read_bytes,
+                                blk_write_bytes: counters.blk_write_bytes,
+                                net_rx_bytes: counters.net_rx_bytes,
+                                net_tx_bytes: counters.net_tx_bytes,
+                            });
+                        }
+                        *slot = Some((now, counters));
+                    }
+                }
+                Err(e) => {
+                    notes.push(format!("resource sample for {name}: {e}"));
+                    // A failed tick breaks the CPU delta chain honestly.
+                    if let Some(slot) = prev.get_mut(i) {
+                        *slot = None;
+                    }
+                }
+            }
+        }
+        tick = tick.saturating_add(1);
+        if stop.load(Ordering::Relaxed) {
+            return (series, dedup_notes(notes));
+        }
+    }
+}
+
+/// Collapse repeated failure reasons so a long outage logs once with a
+/// count instead of once per tick.
+fn dedup_notes(notes: Vec<String>) -> Vec<String> {
+    let mut out: Vec<(String, u32)> = Vec::new();
+    for note in notes {
+        if let Some((_, n)) = out.iter_mut().find(|(text, _)| *text == note) {
+            *n += 1;
+        } else {
+            out.push((note, 1));
+        }
+    }
+    out.into_iter()
+        .map(|(text, n)| {
+            if n > 1 {
+                format!("{text} (x{n})")
+            } else {
+                text
+            }
+        })
+        .collect()
+}
+
+/// One one-shot Engine-API stats reading for `container`.
+fn container_counters(container: &str) -> Result<RawCounters, String> {
+    let body = engine_api_get(&format!(
+        "/containers/{}/stats?stream=false&one-shot=true",
+        urlencoding::encode(container)
+    ))?;
+    let value: serde_json::Value =
+        serde_json::from_str(&body).map_err(|e| format!("stats JSON: {e}"))?;
+    parse_stats(&value).ok_or_else(|| "stats reply carries no cpu/memory counters".to_owned())
+}
+
+/// GET `path` on the Docker Engine API over the local socket (`curl
+/// --unix-socket`; honours a `unix://` `DOCKER_HOST`). One short-lived
+/// subprocess per tick — the sampling cost is negligible against the 10 s
+/// cadence.
+fn engine_api_get(path: &str) -> Result<String, String> {
+    let socket = std::env::var("DOCKER_HOST")
+        .ok()
+        .and_then(|host| host.strip_prefix("unix://").map(str::to_owned))
+        .unwrap_or_else(|| "/var/run/docker.sock".to_owned());
+    let output = Command::new("curl")
+        .args([
+            "-sf",
+            "--max-time",
+            &PROBE_TIMEOUT.as_secs().to_string(),
+            "--unix-socket",
+            &socket,
+            &format!("http://localhost{path}"),
+        ])
+        .output()
+        .map_err(|e| format!("curl: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "engine API GET {path} failed (curl exit {:?})",
+            output.status.code()
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Extract the cumulative counters from one Engine-API stats reply
+/// (cgroup v2 field shapes, with the v1 fallbacks the API still serves).
+fn parse_stats(v: &serde_json::Value) -> Option<RawCounters> {
+    let cpu_total_ns = v
+        .pointer("/cpu_stats/cpu_usage/total_usage")
+        .and_then(serde_json::Value::as_u64)?;
+    let usage = v
+        .pointer("/memory_stats/usage")
+        .and_then(serde_json::Value::as_u64)?;
+    // The docker CLI's "used" subtracts the reclaimable page cache:
+    // inactive_file on cgroup v2, cache on v1; absent both, raw usage.
+    let reclaimable = v
+        .pointer("/memory_stats/stats/inactive_file")
+        .or_else(|| v.pointer("/memory_stats/stats/cache"))
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    let rss_bytes = usage.saturating_sub(reclaimable);
+    // Block IO: sum the per-device read/write entries (op is lowercase on
+    // cgroup v2, capitalized on v1). A runtime that reports none (e.g. a
+    // VM-backed engine without blkio accounting) yields honest zeros.
+    let (mut blk_read_bytes, mut blk_write_bytes) = (0_u64, 0_u64);
+    if let Some(entries) = v
+        .pointer("/blkio_stats/io_service_bytes_recursive")
+        .and_then(serde_json::Value::as_array)
+    {
+        for entry in entries {
+            let op = entry
+                .get("op")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("");
+            let bytes = entry
+                .get("value")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0);
+            if op.eq_ignore_ascii_case("read") {
+                blk_read_bytes = blk_read_bytes.saturating_add(bytes);
+            } else if op.eq_ignore_ascii_case("write") {
+                blk_write_bytes = blk_write_bytes.saturating_add(bytes);
+            }
+        }
+    }
+    // Network: sum across interfaces.
+    let (mut received, mut transmitted) = (0_u64, 0_u64);
+    if let Some(networks) = v.get("networks").and_then(serde_json::Value::as_object) {
+        for iface in networks.values() {
+            received = received.saturating_add(
+                iface
+                    .get("rx_bytes")
+                    .and_then(serde_json::Value::as_u64)
+                    .unwrap_or(0),
+            );
+            transmitted = transmitted.saturating_add(
+                iface
+                    .get("tx_bytes")
+                    .and_then(serde_json::Value::as_u64)
+                    .unwrap_or(0),
+            );
+        }
+    }
+    Some(RawCounters {
+        cpu_total_ns,
+        rss_bytes,
+        blk_read_bytes,
+        blk_write_bytes,
+        net_rx_bytes: received,
+        net_tx_bytes: transmitted,
+    })
+}
+
+/// Probe the database volume's on-disk size (bytes): a read-only `du`
+/// over the volume mount inside the DB container — instrument telemetry
+/// through the container runtime, never a clinical-data path.
+///
+/// # Errors
+/// A message when the runtime/exec/`du` is unavailable or unparseable
+/// (recorded as an absent anchor, never a run failure).
+pub fn db_volume_bytes(db_container: &str) -> Result<u64, String> {
+    let output = Command::new("docker")
+        .args(["exec", db_container, "du", "-sb", DB_VOLUME_DIR])
+        .output()
+        .map_err(|e| format!("docker exec: {e}"))?;
+    // `du` exits non-zero when files vanish mid-walk (a live database) but
+    // still prints the total — parse stdout regardless, fail only when no
+    // total is present.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout
+        .split_whitespace()
+        .next()
+        .and_then(|token| token.parse::<u64>().ok())
+        .ok_or_else(|| {
+            format!(
+                "du on {db_container}:{DB_VOLUME_DIR} yielded no byte total (exit {:?})",
+                output.status.code()
+            )
+        })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)] // test assertions/fixtures
+mod tests {
+    use super::*;
+
+    /// A cgroup-v2-shaped Engine API stats reply (the fields the sampler
+    /// reads, per the Docker Engine API `ContainerStats` reference).
+    fn stats_fixture() -> serde_json::Value {
+        serde_json::json!({
+            "cpu_stats": { "cpu_usage": { "total_usage": 5_000_000_000_u64 },
+                            "system_cpu_usage": 100_000_000_000_u64, "online_cpus": 8 },
+            "memory_stats": { "usage": 300_000_000_u64,
+                               "stats": { "inactive_file": 50_000_000_u64 } },
+            "blkio_stats": { "io_service_bytes_recursive": [
+                { "major": 254, "minor": 0, "op": "read", "value": 1_000_u64 },
+                { "major": 254, "minor": 0, "op": "write", "value": 2_000_u64 },
+                { "major": 254, "minor": 16, "op": "Read", "value": 10_u64 }
+            ] },
+            "networks": {
+                "eth0": { "rx_bytes": 111_u64, "tx_bytes": 222_u64 },
+                "eth1": { "rx_bytes": 9_u64, "tx_bytes": 1_u64 }
+            }
+        })
+    }
+
+    #[test]
+    fn parses_a_cgroup_v2_stats_reply() {
+        let c = parse_stats(&stats_fixture()).unwrap();
+        assert_eq!(c.cpu_total_ns, 5_000_000_000);
+        assert_eq!(c.rss_bytes, 250_000_000); // usage - inactive_file
+        assert_eq!(c.blk_read_bytes, 1_010); // v2 + v1 op casings summed
+        assert_eq!(c.blk_write_bytes, 2_000);
+        assert_eq!(c.net_rx_bytes, 120);
+        assert_eq!(c.net_tx_bytes, 223);
+    }
+
+    #[test]
+    fn a_reply_without_counters_is_rejected() {
+        assert!(parse_stats(&serde_json::json!({})).is_none());
+        // Missing blkio/networks degrade to zeros, not a rejection.
+        let minimal = serde_json::json!({
+            "cpu_stats": { "cpu_usage": { "total_usage": 1_u64 } },
+            "memory_stats": { "usage": 2_u64 }
+        });
+        let c = parse_stats(&minimal).unwrap();
+        assert_eq!(c.rss_bytes, 2);
+        assert_eq!(c.blk_read_bytes, 0);
+        assert_eq!(c.net_tx_bytes, 0);
+    }
+
+    #[test]
+    fn phases_stamp_against_the_planned_window() {
+        assert_eq!(phase_of(0, 300, 3600), ResourcePhase::Warmup);
+        assert_eq!(phase_of(299, 300, 3600), ResourcePhase::Warmup);
+        assert_eq!(phase_of(300, 300, 3600), ResourcePhase::Measured);
+        assert_eq!(phase_of(3899, 300, 3600), ResourcePhase::Measured);
+        assert_eq!(phase_of(3900, 300, 3600), ResourcePhase::Drain);
+    }
+
+    #[test]
+    fn repeated_failure_notes_collapse() {
+        let notes = vec![
+            "a".to_owned(),
+            "b".to_owned(),
+            "a".to_owned(),
+            "a".to_owned(),
+        ];
+        assert_eq!(
+            dedup_notes(notes),
+            vec!["a (x3)".to_owned(), "b".to_owned()]
+        );
+    }
+}

--- a/tools/cnf-runner/src/perf_run/schedule.rs
+++ b/tools/cnf-runner/src/perf_run/schedule.rs
@@ -299,8 +299,7 @@ pub(crate) fn build_schedule(
     let needs_ward = resolved.iter().any(|j| !j.fresh_ehr);
     if needs_ward && ward_len == 0 {
         return Err(
-            "the workload addresses standing ward patients but the corpus has no seeded ward \
-             (re-seed without --skip-seed)"
+            "the workload addresses standing ward patients but the corpus has no seeded ward"
                 .to_owned(),
         );
     }

--- a/tools/cnf-runner/src/perf_run/window.rs
+++ b/tools/cnf-runner/src/perf_run/window.rs
@@ -306,6 +306,9 @@ pub fn drive_case(
         operations: window.operations,
         verdict,
         violations,
+        // The perf handler attaches the sampled telemetry after the window
+        // (the sampler brackets this call); stress windows never carry one.
+        resources: None,
     })
 }
 

--- a/tools/cnf-runner/src/probe.rs
+++ b/tools/cnf-runner/src/probe.rs
@@ -1,0 +1,402 @@
+//! The AQL optimization probe — the seeded-corpus troubleshooting loop as
+//! an instrument: fire the measurement machinery's own AQL vocabulary
+//! against a live SUT N times each, record wire-latency percentiles, and
+//! attribute the DB-side cost per probe via `pg_stat_statements` through
+//! the container runtime (the ixit `containers` capability). A seeded
+//! database is the only place real bottlenecks show — an empty database
+//! hides every planner failure — so the probe always runs against the
+//! scale corpus + standing ward the class runs use.
+//!
+//! Exploration evidence for the optimization ladder (rungs cite probe
+//! reports as their before/after) — never a conformance record, and
+//! results.json is never touched.
+//!
+//! NOTE: no openEHR spec governs measured performance — our own
+//! design/extension (the CNF guide excludes non-functional conformance;
+//! see [`crate::perf`]).
+
+use std::process::Command;
+use std::time::Instant;
+
+use serde::{Deserialize, Serialize};
+
+use crate::ixit::{Containers, Environment};
+use crate::perf_run::client::PerfClient;
+use crate::perf_run::corpus::{ADHOC_AQL, STORED_QUERY_NAME, SeededCorpus, WARD_AQL};
+use crate::perf_run::resources::settle_maintenance;
+
+/// The probe shape (flag-tunable).
+#[derive(Debug, Clone)]
+pub struct ProbeOptions {
+    /// Requests fired per probe (wire percentiles derive from these).
+    pub requests: u32,
+}
+
+impl Default for ProbeOptions {
+    fn default() -> Self {
+        Self { requests: 20 }
+    }
+}
+
+/// Wire-latency percentiles of one probe (milliseconds, client-observed).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WireStats {
+    pub min_ms: f64,
+    pub p50_ms: f64,
+    pub p95_ms: f64,
+    pub max_ms: f64,
+}
+
+/// One DB statement's attributed cost over a probe's request burst
+/// (`pg_stat_statements`, normalized SQL text).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StatementCost {
+    pub sql: String,
+    pub calls: u64,
+    pub mean_ms: f64,
+    pub total_ms: f64,
+    pub shared_blks_hit: u64,
+    pub shared_blks_read: u64,
+}
+
+/// One executed probe: the AQL fired, its wire percentiles, and the
+/// attributed DB statements (empty when attribution is unavailable).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProbeResult {
+    pub name: String,
+    pub aql: String,
+    /// Requests that did not return 200 (a failing probe is a finding,
+    /// never an instrument error).
+    pub failures: u32,
+    pub wire_ms: WireStats,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub statements: Vec<StatementCost>,
+}
+
+/// The probe report — committed-able exploration evidence, environment-
+/// bound like every other measurement artifact.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AqlProbeReport {
+    /// The corpus the probes ran against (a class corpus key).
+    pub corpus: String,
+    pub environment: Environment,
+    pub requests_per_probe: u32,
+    /// Whether the maintenance debt was settled before probing
+    /// (`vacuumdb --analyze` through the DB container).
+    pub maintenance_settled: bool,
+    /// `pg_stat_statements` when DB-side attribution ran, else the honest
+    /// reason it could not.
+    pub attribution: String,
+    pub probes: Vec<ProbeResult>,
+    /// The human summary, incl. the explicit exploration disclaimer.
+    pub remark: String,
+}
+
+/// One wire probe: name, the AQL it exercises, method, path, JSON body.
+type ProbeSpec = (
+    &'static str,
+    String,
+    reqwest::Method,
+    String,
+    Option<Vec<u8>>,
+);
+
+/// The percentile of a sorted sample set (nearest-rank; `0` when empty).
+fn percentile(sorted: &[f64], q: f64) -> f64 {
+    if sorted.is_empty() {
+        return 0.0;
+    }
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss
+    )]
+    // sample counts are tiny; nearest-rank index is non-negative by construction
+    let index = ((q * sorted.len() as f64).ceil() as usize).saturating_sub(1);
+    sorted
+        .get(index.min(sorted.len() - 1))
+        .copied()
+        .unwrap_or(0.0)
+}
+
+/// Run one SQL statement on the `postgres` maintenance database inside the
+/// DB container, returning stdout (the probe's attribution channel —
+/// instrument telemetry, never a clinical-data path).
+fn db_sql(db_container: &str, sql: &str) -> Result<String, String> {
+    let output = Command::new("docker")
+        .args([
+            "exec",
+            db_container,
+            "psql",
+            "-U",
+            "postgres",
+            "-d",
+            "postgres",
+            "-Atc",
+            sql,
+        ])
+        .output()
+        .map_err(|e| format!("docker exec: {e}"))?;
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    } else {
+        Err(format!(
+            "psql failed (exit {:?}): {}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        ))
+    }
+}
+
+/// Read the top statements since the last reset, ordered by total time.
+fn read_statements(db_container: &str) -> Result<Vec<StatementCost>, String> {
+    let json = db_sql(
+        db_container,
+        "SELECT COALESCE(json_agg(t),'[]'::json) FROM (SELECT calls, mean_exec_time, \
+         total_exec_time, shared_blks_hit, shared_blks_read, query FROM pg_stat_statements \
+         WHERE query NOT ILIKE '%pg_stat_statements%' AND query NOT ILIKE 'VACUUM%' \
+         ORDER BY total_exec_time DESC LIMIT 8) t;",
+    )?;
+    let rows: Vec<serde_json::Value> =
+        serde_json::from_str(json.trim()).map_err(|e| format!("statement JSON: {e}"))?;
+    Ok(rows
+        .iter()
+        .filter_map(|row| {
+            Some(StatementCost {
+                sql: row.get("query")?.as_str()?.to_owned(),
+                calls: row.get("calls")?.as_u64()?,
+                mean_ms: row.get("mean_exec_time")?.as_f64()?,
+                total_ms: row.get("total_exec_time")?.as_f64()?,
+                shared_blks_hit: row
+                    .get("shared_blks_hit")
+                    .and_then(serde_json::Value::as_u64)
+                    .unwrap_or(0),
+                shared_blks_read: row
+                    .get("shared_blks_read")
+                    .and_then(serde_json::Value::as_u64)
+                    .unwrap_or(0),
+            })
+        })
+        .collect())
+}
+
+/// Execute the probe set against a live, seeded SUT.
+///
+/// # Errors
+/// A message on a probe-construction failure (an empty corpus); a failing
+/// REQUEST is a recorded finding, and absent attribution/settling degrade
+/// to honest report fields — never errors.
+#[allow(clippy::too_many_lines)] // one linear probe procedure
+pub fn run_probe(
+    client: &PerfClient,
+    corpus: &SeededCorpus,
+    environment: &Environment,
+    containers: Option<&Containers>,
+    options: &ProbeOptions,
+    progress: &(dyn Fn(String) + Sync),
+) -> Result<AqlProbeReport, String> {
+    let ehr_id = corpus
+        .ehr_ids
+        .first()
+        .ok_or_else(|| "corpus index has no EHRs".to_owned())?
+        .clone();
+    let requests = options.requests.max(1);
+
+    // Settle first — probing an unsettled database measures the maintenance
+    // debt, not the schema (a stale-statistics plan cost a measured ~9x).
+    let maintenance_settled = if let Some(c) = containers {
+        match settle_maintenance(&c.db) {
+            Ok(()) => {
+                progress("maintenance settled (vacuumdb --analyze)".to_owned());
+                true
+            }
+            Err(e) => {
+                progress(format!("maintenance not settled: {e}"));
+                false
+            }
+        }
+    } else {
+        progress("maintenance not settled (no ixit `containers` block)".to_owned());
+        false
+    };
+
+    // Attribution capability: pg_stat_statements through the DB container.
+    let attribution_db = containers.and_then(|c| {
+        match db_sql(&c.db, "CREATE EXTENSION IF NOT EXISTS pg_stat_statements;") {
+            Ok(_) => Some(c.db.clone()),
+            Err(e) => {
+                progress(format!("statement attribution unavailable: {e}"));
+                None
+            }
+        }
+    });
+    let attribution = attribution_db.as_ref().map_or_else(
+        || "unavailable (no containers block or pg_stat_statements not loadable)".to_owned(),
+        |_| "pg_stat_statements".to_owned(),
+    );
+
+    // The closed probe set: the measurement machinery's own AQL vocabulary.
+    let adhoc_body =
+        serde_json::json!({ "q": ADHOC_AQL, "query_parameters": { "ehr_id": ehr_id } });
+    let ward_body = serde_json::json!({ "q": WARD_AQL });
+    let stored_path = format!("/query/{STORED_QUERY_NAME}?ehr_id={ehr_id}");
+    let probe_set: Vec<ProbeSpec> = vec![
+        (
+            "ward_worklist",
+            WARD_AQL.to_owned(),
+            reqwest::Method::POST,
+            "/query/aql".to_owned(),
+            Some(serde_json::to_vec(&ward_body).map_err(|e| e.to_string())?),
+        ),
+        (
+            "adhoc_trend",
+            ADHOC_AQL.to_owned(),
+            reqwest::Method::POST,
+            "/query/aql".to_owned(),
+            Some(serde_json::to_vec(&adhoc_body).map_err(|e| e.to_string())?),
+        ),
+        (
+            "stored_dashboard",
+            format!("GET /query/{STORED_QUERY_NAME} (registered: {ADHOC_AQL})"),
+            reqwest::Method::GET,
+            stored_path,
+            None,
+        ),
+    ];
+
+    let mut probes = Vec::new();
+    for (name, aql, method, path, body) in probe_set {
+        if let Some(db) = &attribution_db {
+            let _reset = db_sql(db, "SELECT pg_stat_statements_reset();");
+        }
+        let mut samples_ms: Vec<f64> = Vec::new();
+        let mut failures: u32 = 0;
+        for _ in 0..requests {
+            let started = Instant::now();
+            let reply = client.request(
+                method.clone(),
+                &path,
+                body.as_ref()
+                    .map(|bytes| ("application/json", bytes.clone())),
+                false,
+                None,
+            );
+            let elapsed_ms = started.elapsed().as_secs_f64() * 1_000.0;
+            match reply {
+                Ok(reply) if reply.status == 200 => samples_ms.push(elapsed_ms),
+                Ok(_) | Err(_) => {
+                    failures = failures.saturating_add(1);
+                    samples_ms.push(elapsed_ms);
+                }
+            }
+        }
+        samples_ms.sort_by(f64::total_cmp);
+        let wire_ms = WireStats {
+            min_ms: samples_ms.first().copied().unwrap_or(0.0),
+            p50_ms: percentile(&samples_ms, 0.50),
+            p95_ms: percentile(&samples_ms, 0.95),
+            max_ms: samples_ms.last().copied().unwrap_or(0.0),
+        };
+        let statements = attribution_db
+            .as_ref()
+            .and_then(|db| match read_statements(db) {
+                Ok(rows) => Some(rows),
+                Err(e) => {
+                    progress(format!("probe {name}: attribution read failed: {e}"));
+                    None
+                }
+            })
+            .unwrap_or_default();
+        progress(format!(
+            "probe {name}: p50 {:.1} ms · p95 {:.1} ms · max {:.1} ms ({requests} requests, {failures} failures{})",
+            wire_ms.p50_ms,
+            wire_ms.p95_ms,
+            wire_ms.max_ms,
+            statements.first().map_or(String::new(), |top| {
+                format!(
+                    "; top statement {:.1} ms mean × {} calls",
+                    top.mean_ms, top.calls
+                )
+            }),
+        ));
+        probes.push(ProbeResult {
+            name: name.to_owned(),
+            aql,
+            failures,
+            wire_ms,
+            statements,
+        });
+    }
+
+    let remark = format!(
+        "AQL probe over the seeded {} corpus — exploration evidence for the optimization \
+         loop; never a conformance record (results.json untouched). Wire percentiles from \
+         {requests} requests per probe; DB attribution: {attribution}.",
+        corpus.corpus,
+    );
+    progress(remark.clone());
+    Ok(AqlProbeReport {
+        corpus: corpus.corpus.clone(),
+        environment: environment.clone(),
+        requests_per_probe: requests,
+        maintenance_settled,
+        attribution,
+        probes,
+        remark,
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)] // test assertions/fixtures
+mod tests {
+    use super::*;
+
+    #[test]
+    fn percentiles_are_nearest_rank() {
+        let sorted: Vec<f64> = (1..=100).map(f64::from).collect();
+        assert!((percentile(&sorted, 0.50) - 50.0).abs() < f64::EPSILON);
+        assert!((percentile(&sorted, 0.95) - 95.0).abs() < f64::EPSILON);
+        assert!((percentile(&[42.0], 0.95) - 42.0).abs() < f64::EPSILON);
+        assert!(percentile(&[], 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn the_report_round_trips_and_degrades_honestly() {
+        let report = AqlProbeReport {
+            corpus: "cnf.scale.10k".to_owned(),
+            environment: serde_json::from_value(serde_json::json!({
+                "hardware_class": "test", "cores": 1, "memory_gb": 1,
+                "storage_class": "ram", "topology": "stub"
+            }))
+            .unwrap(),
+            requests_per_probe: 20,
+            maintenance_settled: false,
+            attribution: "unavailable (no containers block or pg_stat_statements not loadable)"
+                .to_owned(),
+            probes: vec![ProbeResult {
+                name: "ward_worklist".to_owned(),
+                aql: "SELECT ...".to_owned(),
+                failures: 0,
+                wire_ms: WireStats {
+                    min_ms: 1.0,
+                    p50_ms: 2.0,
+                    p95_ms: 3.0,
+                    max_ms: 4.0,
+                },
+                statements: Vec::new(),
+            }],
+            remark: "r".to_owned(),
+        };
+        let value = serde_json::to_value(&report).unwrap();
+        // Absent attribution serializes as an empty-free record (statements
+        // omitted), never fabricated rows.
+        assert!(value["probes"][0].get("statements").is_none());
+        let parsed: AqlProbeReport = serde_json::from_value(value).unwrap();
+        assert_eq!(parsed.probes.len(), 1);
+        assert!(!parsed.maintenance_settled);
+    }
+}

--- a/tools/cnf-runner/src/schema.rs
+++ b/tools/cnf-runner/src/schema.rs
@@ -765,7 +765,8 @@ pub fn results_schema() -> Value {
                             "items": operation_measurement_def()
                         },
                         "verdict": { "enum": ["earned", "not-earned"] },
-                        "violations": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+                        "violations": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+                        "resources": resources_def()
                     }
                 }
             },
@@ -828,7 +829,76 @@ pub fn ixit_schema() -> Value {
                     }
                 }
             },
-            "environment": environment_def()
+            "environment": environment_def(),
+            "containers": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["sut", "db"],
+                "properties": {
+                    "sut": { "type": "string", "minLength": 1 },
+                    "db": { "type": "string", "minLength": 1 }
+                }
+            }
+        }
+    })
+}
+
+/// The resource-telemetry block of one measurement record — measured
+/// CONTEXT, never verdict-bearing: per-container CPU/RSS/I/O series on a
+/// fixed cadence (run-clock offsets, phase-stamped) plus the database
+/// volume's four disk anchors. Optional: absent when the ixit declares no
+/// `containers` block or the container runtime was unreachable.
+fn resources_def() -> Value {
+    let byte_counter = json!({ "type": "integer", "minimum": 0 });
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["sample_interval_s", "containers", "disk"],
+        "properties": {
+            "sample_interval_s": { "type": "integer", "minimum": 1 },
+            "containers": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["role", "name", "samples"],
+                    "properties": {
+                        "role": { "enum": tokens(crate::perf::ContainerRole::ALL) },
+                        "name": { "type": "string", "minLength": 1 },
+                        "samples": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "required": ["offset_s", "phase", "cpu_pct", "rss_bytes",
+                                              "blk_read_bytes", "blk_write_bytes",
+                                              "net_rx_bytes", "net_tx_bytes"],
+                                "properties": {
+                                    "offset_s": { "type": "integer", "minimum": 0 },
+                                    "phase": { "enum": tokens(crate::perf::ResourcePhase::ALL) },
+                                    "cpu_pct": { "type": "number", "minimum": 0.0 },
+                                    "rss_bytes": byte_counter.clone(),
+                                    "blk_read_bytes": byte_counter.clone(),
+                                    "blk_write_bytes": byte_counter.clone(),
+                                    "net_rx_bytes": byte_counter.clone(),
+                                    "net_tx_bytes": byte_counter.clone()
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "disk": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "before_scale_seed_bytes": byte_counter.clone(),
+                    "after_scale_seed_bytes": byte_counter.clone(),
+                    "after_ward_seed_bytes": byte_counter.clone(),
+                    "after_window_bytes": byte_counter.clone(),
+                    "seed_compositions": { "type": "integer", "minimum": 1 }
+                }
+            }
         }
     })
 }

--- a/tools/cnf-runner/src/schema.rs
+++ b/tools/cnf-runner/src/schema.rs
@@ -843,17 +843,19 @@ pub fn ixit_schema() -> Value {
     })
 }
 
-/// The resource-telemetry block of one measurement record — measured
-/// CONTEXT, never verdict-bearing: per-container CPU/RSS/I/O series on a
-/// fixed cadence (run-clock offsets, phase-stamped) plus the database
-/// volume's four disk anchors. Optional: absent when the ixit declares no
-/// `containers` block or the container runtime was unreachable.
+/// The resource-telemetry block of one measurement record or stress step
+/// — measured CONTEXT, never verdict-bearing: per-container CPU/RSS/I/O
+/// series on a fixed cadence (run-clock offsets, phase-stamped) plus, on
+/// measured class runs only, the database volume's four disk anchors
+/// (stress steps stay anchor-free — exploration stays light). Optional:
+/// absent when the ixit declares no `containers` block or the container
+/// runtime was unreachable.
 fn resources_def() -> Value {
     let byte_counter = json!({ "type": "integer", "minimum": 0 });
     json!({
         "type": "object",
         "additionalProperties": false,
-        "required": ["sample_interval_s", "containers", "disk"],
+        "required": ["sample_interval_s", "containers"],
         "properties": {
             "sample_interval_s": { "type": "integer", "minimum": 1 },
             "containers": {
@@ -983,7 +985,8 @@ pub fn stress_schema() -> Value {
                         },
                         "stable": { "type": "boolean" },
                         "breaches": { "type": "array", "items": { "type": "string", "minLength": 1 } },
-                        "generator_bound": { "type": "boolean" }
+                        "generator_bound": { "type": "boolean" },
+                        "resources": resources_def()
                     }
                 }
             },

--- a/tools/cnf-runner/src/schema.rs
+++ b/tools/cnf-runner/src/schema.rs
@@ -1011,6 +1011,73 @@ pub fn stress_schema() -> Value {
     })
 }
 
+/// `aql-probe.json` — the AQL optimization probe report (exploration
+/// evidence: wire percentiles + per-statement DB attribution over the
+/// seeded corpus; never a conformance record).
+#[must_use]
+pub fn aql_probe_schema() -> Value {
+    json!({
+        "$schema": DRAFT,
+        "$id": urn("aql-probe"),
+        "title": "CNF 2.0 AQL probe report",
+        "description": "The seeded-corpus AQL optimization probe: per-probe wire-latency percentiles and pg_stat_statements attribution through the container runtime, environment-bound. Exploration evidence for the optimization loop — never a conformance record; results.json is never touched.",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["corpus", "environment", "requests_per_probe", "maintenance_settled",
+                      "attribution", "probes", "remark"],
+        "properties": {
+            "corpus": { "type": "string", "pattern": CORPUS_KEY_PATTERN },
+            "environment": environment_def(),
+            "requests_per_probe": { "type": "integer", "minimum": 1 },
+            "maintenance_settled": { "type": "boolean" },
+            "attribution": { "type": "string", "minLength": 1 },
+            "probes": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["name", "aql", "failures", "wire_ms"],
+                    "properties": {
+                        "name": { "type": "string", "minLength": 1 },
+                        "aql": { "type": "string", "minLength": 1 },
+                        "failures": { "type": "integer", "minimum": 0 },
+                        "wire_ms": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": ["min_ms", "p50_ms", "p95_ms", "max_ms"],
+                            "properties": {
+                                "min_ms": { "type": "number", "minimum": 0.0 },
+                                "p50_ms": { "type": "number", "minimum": 0.0 },
+                                "p95_ms": { "type": "number", "minimum": 0.0 },
+                                "max_ms": { "type": "number", "minimum": 0.0 }
+                            }
+                        },
+                        "statements": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "required": ["sql", "calls", "mean_ms", "total_ms",
+                                              "shared_blks_hit", "shared_blks_read"],
+                                "properties": {
+                                    "sql": { "type": "string", "minLength": 1 },
+                                    "calls": { "type": "integer", "minimum": 0 },
+                                    "mean_ms": { "type": "number", "minimum": 0.0 },
+                                    "total_ms": { "type": "number", "minimum": 0.0 },
+                                    "shared_blks_hit": { "type": "integer", "minimum": 0 },
+                                    "shared_blks_read": { "type": "integer", "minimum": 0 }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "remark": { "type": "string", "minLength": 1 }
+        }
+    })
+}
+
 /// The published performance-class tokens, ladder order.
 fn perf_class_tokens() -> Vec<&'static str> {
     crate::perf::PerfClass::ALL
@@ -1222,6 +1289,7 @@ pub fn emit_all() -> Vec<(&'static str, Value)> {
         ("performance-case.schema.json", performance_case_schema()),
         ("journey-catalogue.schema.json", journey_catalogue_schema()),
         ("stress.schema.json", stress_schema()),
+        ("aql-probe.schema.json", aql_probe_schema()),
         ("transcript.schema.json", transcript_schema()),
     ]
 }

--- a/tools/cnf-runner/src/stress.rs
+++ b/tools/cnf-runner/src/stress.rs
@@ -198,6 +198,16 @@ pub fn run_stress(
                     steps: &mut Vec<LoadStep>,
                     generator_bound: &mut bool|
      -> Result<bool, String> {
+        // Settle the maintenance debt the previous rungs' writes built up
+        // BEFORE the rung, so autovacuum/analyze never fires inside a hold
+        // and every rung starts from the same settled state.
+        if let Some(c) = containers {
+            if let Err(e) = crate::perf_run::resources::settle_maintenance(&c.db) {
+                progress(format!("maintenance not settled: {e}"));
+            }
+        } else {
+            progress("maintenance not settled (no ixit `containers` block)".to_owned());
+        }
         progress(format!(
             "load step at {rate}/s ({}s hold)",
             options.step_hold_s
@@ -249,16 +259,7 @@ pub fn run_stress(
             let peaks: Vec<String> = r
                 .containers
                 .iter()
-                .map(|c| {
-                    let cpu = c.samples.iter().map(|s| s.cpu_pct).fold(0.0, f64::max);
-                    format!(
-                        "{} peak {cpu:.0}% cpu",
-                        match c.role {
-                            crate::perf::ContainerRole::Sut => "sut",
-                            crate::perf::ContainerRole::Db => "db",
-                        }
-                    )
-                })
+                .map(|c| format!("{} peak {:.0}% cpu", c.role.label(), c.cpu_peak()))
                 .collect();
             format!(", {}", peaks.join(", "))
         });

--- a/tools/cnf-runner/src/stress.rs
+++ b/tools/cnf-runner/src/stress.rs
@@ -243,6 +243,37 @@ pub fn run_stress(
                 "generator bound at {rate}/s — the instrument, not the SUT, is the bottleneck"
             ));
         }
+        // The verdict, live: what the instrument DECIDED about this rung —
+        // never leave the console reading as a pass while the SUT sheds.
+        let resource_note = resources.as_ref().map_or(String::new(), |r| {
+            let peaks: Vec<String> = r
+                .containers
+                .iter()
+                .map(|c| {
+                    let cpu = c.samples.iter().map(|s| s.cpu_pct).fold(0.0, f64::max);
+                    format!(
+                        "{} peak {cpu:.0}% cpu",
+                        match c.role {
+                            crate::perf::ContainerRole::Sut => "sut",
+                            crate::perf::ContainerRole::Db => "db",
+                        }
+                    )
+                })
+                .collect();
+            format!(", {}", peaks.join(", "))
+        });
+        progress(if stable {
+            format!(
+                "step {rate}/s: stable (sustained {:.1}/s{resource_note})",
+                window.offered_load_sustained
+            )
+        } else {
+            format!(
+                "step {rate}/s: BREACHED (sustained {:.1}/s{resource_note}) — {}",
+                window.offered_load_sustained,
+                breaches.join("; ")
+            )
+        });
         steps.push(LoadStep {
             rate,
             offered_load_sustained: window.offered_load_sustained,
@@ -282,6 +313,9 @@ pub fn run_stress(
             if !(mid.is_finite() && mid > good && mid < bad) {
                 break;
             }
+            progress(format!(
+                "bisecting between {good}/s (stable) and {bad}/s (breached)"
+            ));
             if run_step(mid, &mut steps, &mut generator_bound)? {
                 good = mid;
             } else {
@@ -289,6 +323,17 @@ pub fn run_stress(
             }
         }
         last_good = good;
+    }
+
+    // The rung recap — one line per executed step, so an operator reading
+    // only the tail still sees the whole ladder's verdicts.
+    for step in &steps {
+        progress(format!(
+            "recap: {:>7}/s {} {}",
+            step.rate,
+            if step.stable { "stable  " } else { "BREACHED" },
+            step.breaches.first().map_or("", String::as_str),
+        ));
     }
 
     let floors_context: Vec<FloorContext> = PerfClass::ALL

--- a/tools/cnf-runner/src/stress.rs
+++ b/tools/cnf-runner/src/stress.rs
@@ -79,6 +79,13 @@ pub struct LoadStep {
     pub breaches: Vec<String>,
     /// The generator, not the SUT, was the bottleneck at this rate.
     pub generator_bound: bool,
+    /// The step's resource telemetry (the shared measured-run sampler over
+    /// this step's own warmup+hold window; no disk anchors — exploration
+    /// stays light). Joins resource burn to offered rate: a breached rung
+    /// shows WHERE it saturated. Optional by the ixit `containers`
+    /// capability; absence never fails a step.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resources: Option<crate::perf::ResourcesRecord>,
 }
 
 /// A class floor, as CONTEXT beside the measured maximum (never a claim).
@@ -174,6 +181,7 @@ pub fn run_stress(
     corpus: &SeededCorpus,
     workload: &JourneyWorkload<'_>,
     environment: &Environment,
+    containers: Option<&crate::ixit::Containers>,
     options: &StressOptions,
     progress: &(dyn Fn(String) + Sync),
 ) -> Result<StressReport, String> {
@@ -182,6 +190,9 @@ pub fn run_stress(
     let mut first_bad: Option<f64> = None;
     let mut generator_bound = false;
     let mut ladder_capped = false;
+    if containers.is_none() {
+        progress("resources: not sampled (ixit declares no `containers` block)".to_owned());
+    }
 
     let run_step = |rate: f64,
                     steps: &mut Vec<LoadStep>,
@@ -191,6 +202,15 @@ pub fn run_stress(
             "load step at {rate}/s ({}s hold)",
             options.step_hold_s
         ));
+        // The sampler brackets this step's own warmup+hold window (phase
+        // stamps derive from the step bounds).
+        let sampler = containers.map(|c| {
+            crate::perf_run::resources::ResourceSampler::start(
+                c,
+                options.step_warmup_s,
+                options.step_hold_s,
+            )
+        });
         let window = run_window(
             client,
             corpus,
@@ -199,7 +219,22 @@ pub fn run_stress(
             options.step_warmup_s,
             options.step_hold_s,
             progress,
-        )?;
+        );
+        let resources = sampler.and_then(|sampler| {
+            let (series, notes) = sampler.stop();
+            for note in notes {
+                progress(note);
+            }
+            series
+                .iter()
+                .any(|s| !s.samples.is_empty())
+                .then_some(crate::perf::ResourcesRecord {
+                    sample_interval_s: crate::perf_run::resources::SAMPLE_INTERVAL.as_secs(),
+                    containers: series,
+                    disk: None,
+                })
+        });
+        let window = window?;
         let breaches = step_breaches(&window.operations, options)?;
         let stable = breaches.is_empty() && !window.generator_bound;
         if window.generator_bound {
@@ -215,6 +250,7 @@ pub fn run_stress(
             stable,
             breaches,
             generator_bound: window.generator_bound,
+            resources,
         });
         Ok(stable)
     };

--- a/website/book/src/perf-assets/perf-class-ladder.svg
+++ b/website/book/src/perf-assets/perf-class-ladder.svg
@@ -11,6 +11,11 @@ text { fill: #52514e; font: 12px -apple-system, 'Segoe UI', Helvetica, Arial, sa
 .notearned { fill: #b3261e; font-weight: 600; }
 .slo { stroke: #b3261e; stroke-width: 1.5; stroke-dasharray: 6 4; }
 .slotext { fill: #b3261e; font-size: 11px; }
+.sut { stroke: #2a78d6; fill: none; stroke-width: 1.8; }
+.db { stroke: #8a8880; fill: none; stroke-width: 1.6; stroke-dasharray: 5 3; }
+.warm { fill: #efede8; }
+.curve { stroke: #2a78d6; fill: none; stroke-width: 2; }
+.knee { stroke: #1baf7a; stroke-width: 2; stroke-dasharray: 2 3; }
 @media (prefers-color-scheme: dark) {
 text { fill: #c3c2b7; }
 .title { fill: #ffffff; }
@@ -23,6 +28,11 @@ text { fill: #c3c2b7; }
 .notearned { fill: #e5484d; }
 .slo { stroke: #e5484d; }
 .slotext { fill: #e5484d; }
+.sut { stroke: #3987e5; }
+.db { stroke: #8f8e85; }
+.warm { fill: #2a2a28; }
+.curve { stroke: #3987e5; }
+.knee { stroke: #26c78d; }
 }
 </style>
 <text x="24" y="28" class="title">Performance class ladder — offered-load floors vs measured sustained load</text>

--- a/website/book/src/perf-assets/perf-latency-class-POC.svg
+++ b/website/book/src/perf-assets/perf-latency-class-POC.svg
@@ -11,6 +11,11 @@ text { fill: #52514e; font: 12px -apple-system, 'Segoe UI', Helvetica, Arial, sa
 .notearned { fill: #b3261e; font-weight: 600; }
 .slo { stroke: #b3261e; stroke-width: 1.5; stroke-dasharray: 6 4; }
 .slotext { fill: #b3261e; font-size: 11px; }
+.sut { stroke: #2a78d6; fill: none; stroke-width: 1.8; }
+.db { stroke: #8a8880; fill: none; stroke-width: 1.6; stroke-dasharray: 5 3; }
+.warm { fill: #efede8; }
+.curve { stroke: #2a78d6; fill: none; stroke-width: 2; }
+.knee { stroke: #1baf7a; stroke-width: 2; stroke-dasharray: 2 3; }
 @media (prefers-color-scheme: dark) {
 text { fill: #c3c2b7; }
 .title { fill: #ffffff; }
@@ -23,6 +28,11 @@ text { fill: #c3c2b7; }
 .notearned { fill: #e5484d; }
 .slo { stroke: #e5484d; }
 .slotext { fill: #e5484d; }
+.sut { stroke: #3987e5; }
+.db { stroke: #8f8e85; }
+.warm { fill: #2a2a28; }
+.curve { stroke: #3987e5; }
+.knee { stroke: #26c78d; }
 }
 </style>
 <text x="24" y="28" class="title">Latency percentiles — class POC measured run (PERF-hospital_sim-class_POC)</text>

--- a/website/book/src/perf-assets/perf-stress-curve.svg
+++ b/website/book/src/perf-assets/perf-stress-curve.svg
@@ -1,0 +1,67 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 400" width="760" height="400" role="img">
+<style>
+text { fill: #52514e; font: 12px -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif; }
+.title { fill: #0b0b0b; font-weight: 600; }
+.muted { fill: #8a8880; font-size: 11px; }
+.grid { stroke: #e4e2dd; stroke-width: 1; }
+.p50 { fill: #7db4ea; } .p90 { fill: #3d7fd0; } .p99 { fill: #1b5cab; }
+.measured { fill: #2a78d6; }
+.floor { fill: none; stroke: #8a8880; stroke-width: 1.5; stroke-dasharray: 4 3; }
+.earned { fill: #1baf7a; font-weight: 600; }
+.notearned { fill: #b3261e; font-weight: 600; }
+.slo { stroke: #b3261e; stroke-width: 1.5; stroke-dasharray: 6 4; }
+.slotext { fill: #b3261e; font-size: 11px; }
+.sut { stroke: #2a78d6; fill: none; stroke-width: 1.8; }
+.db { stroke: #8a8880; fill: none; stroke-width: 1.6; stroke-dasharray: 5 3; }
+.warm { fill: #efede8; }
+.curve { stroke: #2a78d6; fill: none; stroke-width: 2; }
+.knee { stroke: #1baf7a; stroke-width: 2; stroke-dasharray: 2 3; }
+@media (prefers-color-scheme: dark) {
+text { fill: #c3c2b7; }
+.title { fill: #ffffff; }
+.muted { fill: #8f8e85; }
+.grid { stroke: #3a3a38; }
+.p50 { fill: #3d5f82; } .p90 { fill: #3987e5; } .p99 { fill: #9ec7ef; }
+.measured { fill: #3987e5; }
+.floor { stroke: #8f8e85; }
+.earned { fill: #26c78d; }
+.notearned { fill: #e5484d; }
+.slo { stroke: #e5484d; }
+.slotext { fill: #e5484d; }
+.sut { stroke: #3987e5; }
+.db { stroke: #8f8e85; }
+.warm { fill: #2a2a28; }
+.curve { stroke: #3987e5; }
+.knee { stroke: #26c78d; }
+}
+</style>
+<text x="24" y="28" class="title">Latency-throughput curve — step-load stress to the maximum sustainable throughput</text>
+<text x="24" y="44" class="muted">Short intense load steps (120 s hold) on the cnf.scale.10k corpus · exploration only — classes are earned exclusively by the hour-long class runs</text>
+<line x1="90.0" y1="64" x2="90.0" y2="330" class="grid"/><text x="90.0" y="346.0" class="muted" text-anchor="middle">1/s</text>
+<line x1="251.5" y1="64" x2="251.5" y2="330" class="grid"/><text x="251.5" y="346.0" class="muted" text-anchor="middle">10/s</text>
+<line x1="412.9" y1="64" x2="412.9" y2="330" class="grid"/><text x="412.9" y="346.0" class="muted" text-anchor="middle">100/s</text>
+<line x1="574.4" y1="64" x2="574.4" y2="330" class="grid"/><text x="574.4" y="346.0" class="muted" text-anchor="middle">1000/s</text>
+<line x1="90" y1="330.0" x2="700" y2="330.0" class="grid"/><text x="82.0" y="334.0" class="muted" text-anchor="end">1 ms</text>
+<line x1="90" y1="259.6" x2="700" y2="259.6" class="grid"/><text x="82.0" y="263.6" class="muted" text-anchor="end">10 ms</text>
+<line x1="90" y1="189.2" x2="700" y2="189.2" class="grid"/><text x="82.0" y="193.2" class="muted" text-anchor="end">100 ms</text>
+<line x1="90" y1="118.8" x2="700" y2="118.8" class="grid"/><text x="82.0" y="122.8" class="muted" text-anchor="end">1000 ms</text>
+<line x1="90" y1="118.8" x2="700" y2="118.8" class="slo"/><text x="696.0" y="112.8" class="slotext" text-anchor="end">p99 budget</text>
+<line x1="138.6" y1="64" x2="138.6" y2="330" class="floor"/><text x="138.6" y="58.0" class="muted" text-anchor="middle">POC</text>
+<line x1="279.9" y1="64" x2="279.9" y2="330" class="floor"/><text x="279.9" y="58.0" class="muted" text-anchor="middle">S</text>
+<line x1="441.3" y1="64" x2="441.3" y2="330" class="floor"/><text x="441.3" y="58.0" class="muted" text-anchor="middle">L</text>
+<line x1="602.8" y1="64" x2="602.8" y2="330" class="floor"/><text x="602.8" y="58.0" class="muted" text-anchor="middle">R</text>
+<path d="M138.6,157.1 L187.2,150.6 L235.8,158.4 L284.4,154.4 L333.0,161.5 L381.6,164.0 L430.2,162.3 L478.8,155.0 L487.1,64.0 L494.5,64.0 L507.3,64.0 L527.4,64.0" class="curve"/>
+<circle cx="138.6" cy="157.1" r="5" class="measured"/>
+<circle cx="187.2" cy="150.6" r="5" class="measured"/>
+<circle cx="235.8" cy="158.4" r="5" class="measured"/>
+<circle cx="284.4" cy="154.4" r="5" class="measured"/>
+<circle cx="333.0" cy="161.5" r="5" class="measured"/>
+<circle cx="381.6" cy="164.0" r="5" class="measured"/>
+<circle cx="430.2" cy="162.3" r="5" class="measured"/>
+<circle cx="478.8" cy="155.0" r="5" class="measured"/>
+<path d="M482.1,59.0 L492.1,69.0 M482.1,69.0 L492.1,59.0" class="slo" stroke-width="2"/>
+<path d="M489.5,59.0 L499.5,69.0 M489.5,69.0 L499.5,59.0" class="slo" stroke-width="2"/>
+<path d="M502.3,59.0 L512.3,69.0 M502.3,69.0 L512.3,59.0" class="slo" stroke-width="2"/>
+<path d="M522.4,59.0 L532.4,69.0 M522.4,69.0 L532.4,59.0" class="slo" stroke-width="2"/>
+<line x1="478.8" y1="64" x2="478.8" y2="330" class="knee"/><text x="484.8" y="78.0" class="earned">max sustainable 256/s</text>
+</svg>

--- a/website/book/src/performance.md
+++ b/website/book/src/performance.md
@@ -181,10 +181,10 @@ cnf-runner perf --root tools/cnf-runner/artifacts \
 # the case's normative window and the default; two, four, six, eight, or
 # twelve hours hold the same offered load for longer — a stricter
 # demonstration of the same class). The seeded corpus is reusable across
-# runs via the sidecar index written by the first seeding.
+# every run seeds the freshly composed server from empty.
 cnf-runner perf --root tools/cnf-runner/artifacts \
                 --ixit <ixit.json> --results <results.json> \
-                --class POC --skip-seed --hours 8
+                --class POC --hours 8
 ```
 
 There is deliberately no shortened run: the measurement record always covers
@@ -209,7 +209,7 @@ throughput**: the highest offered rate held inside the latency budget
 # the step-load stress ladder over the seeded corpus (exploration only)
 cnf-runner stress --root tools/cnf-runner/artifacts \
                   --ixit <ixit.json> --out <stress.json> \
-                  --corpus-class POC --skip-seed
+                  --corpus-class POC
 ```
 
 The two instruments never blur: a stress report earns no class, never

--- a/website/book/src/performance.md
+++ b/website/book/src/performance.md
@@ -231,4 +231,21 @@ committed HDR V2 histograms for the proof-of-concept class:
 
 ![Proof-of-concept class latency, re-derived from the committed histograms](perf-assets/perf-latency-class-POC.svg)
 
+### What the run cost the machine
+
+Alongside the latencies, every measured run records its resource telemetry:
+CPU and resident memory for the server and database containers separately,
+plus block-device and network I/O, sampled every 10 seconds across the whole
+window with the warmup shaded. These numbers are capacity-planning context —
+they never influence whether a class is earned.
+
+![Resource telemetry across the proof-of-concept measured run](perf-assets/perf-resources-class-POC.svg)
+
+The database volume's on-disk size is probed at four anchors — empty, after
+the scale seed, after the ward seed, and after the measured window — so the
+chart also answers the storage question directly: what one committed
+composition costs on disk, and how much the sustained hour wrote.
+
+![Disk growth across the measured run's four anchors](perf-assets/perf-disk-growth.svg)
+
 {{#include ../generated/perf-summary.md}}

--- a/website/book/src/performance.md
+++ b/website/book/src/performance.md
@@ -241,16 +241,11 @@ committed HDR V2 histograms for the proof-of-concept class:
 Alongside the latencies, every measured run records its resource telemetry:
 CPU and resident memory for the server and database containers separately,
 plus block-device and network I/O, sampled every 10 seconds across the whole
-window with the warmup shaded. These numbers are capacity-planning context —
-they never influence whether a class is earned.
-
-![Resource telemetry across the proof-of-concept measured run](perf-assets/perf-resources-class-POC.svg)
-
-The database volume's on-disk size is probed at four anchors — empty, after
-the scale seed, after the ward seed, and after the measured window — so the
-chart also answers the storage question directly: what one committed
-composition costs on disk, and how much the sustained hour wrote.
-
-![Disk growth across the measured run's four anchors](perf-assets/perf-disk-growth.svg)
+window with the warmup shaded, and the database volume's on-disk size at
+four anchors — empty, after the scale seed, after the ward seed, and after
+the measured window — down to the storage cost per committed composition.
+These numbers are capacity-planning context — they never influence whether
+a class is earned. The rendered resource time-series and disk-growth charts
+join this page with the next committed measured run.
 
 {{#include ../generated/perf-summary.md}}

--- a/website/book/src/performance.md
+++ b/website/book/src/performance.md
@@ -215,9 +215,14 @@ cnf-runner stress --root tools/cnf-runner/artifacts \
 The two instruments never blur: a stress report earns no class, never
 touches `results.json`, and names the class floors only as context so you
 can see the headroom at a glance. Every load step embeds its own
-re-checkable histograms, a breached step is reported with the exact
-envelope violation, and a run where the load *generator* tops out before
-the server is flagged as such rather than counted against the system.
+re-checkable histograms and its own resource telemetry (the same
+per-container CPU/memory/I/O series the measured runs record, so a
+breached step shows *where* it saturated), a breached step is reported
+with the exact envelope violation, and a run where the load *generator*
+tops out before the server is flagged as such rather than counted against
+the system.
+
+![The latency-throughput curve from the committed stress run](perf-assets/perf-stress-curve.svg)
 
 The published assets are rendered from the committed `results.json` by
 `cnf-runner perf-assets` (wrapped by `scripts/render-perf-assets.sh`); the


### PR DESCRIPTION
## CNF measured runs: resource telemetry, the stress evidence, the aql-probe instrument, always-fresh seeding

The measured-run record now SHOWS what a run costs the machine, the stress instrument carries its first committed evidence, and the optimization loop that produced today's findings is an instrument instead of an artisanal session.

### Resource telemetry (#244 — the instrument half; the committed class-POC run follows)

- Every measurement record gains an optional, schema-published `resources` block: per-container (SUT and database separately) CPU / RSS / block-IO / network series on a 10 s cadence, run-clock offsets, `warmup|measured|drain` phase stamps, plus the database volume's four disk anchors (empty → scale seed → ward seed → post-window) and the bytes-per-committed-composition denominator. Sampling is optional by capability — the ixit gains a `containers` block (compose container names; both party ixits carry theirs); absence records no block and never fails a run. **Never verdict-bearing**: classes stay earned on latency/error/throughput alone.
- `perf_run::resources`: the shared sampler (Docker Engine API one-shot stats per tick; CPU% from consecutive cumulative deltas; RSS as usage minus reclaimable cache; honest degradation with deduped reasons) + the read-only `du` disk probe, smoke-verified live.
- Two renderers join the drift-guarded perf-assets family in the house style: the resource time-series (CPU/RSS panels + four I/O rate strips, warmup shaded, fixed geometry, light+dark) and the disk-growth waterfall (fixed columns, per-composition annotation). `perf-summary.md` gains the derived resources table; byte labels use decimal KB/MB/GB.

### The first committed stress run + live verdicts (#237 progress, #249 closed)

- `docs/conformance/ehrbase-rs/stress.json`: knee ≈ 256 arrivals/s on the POC corpus (12 steps, geometric + 3 bisections), per-step resource telemetry showing saturation living in the DB container; the latency-throughput curve is committed and embedded (book + README) — including a fix for the invisible-curve defect (the renderer referenced CSS classes the shared style block never defined).
- Stress steps consume the shared sampler (no disk anchors — exploration stays light), schema-published.
- The progress stream now narrates what the instrument DECIDES: per-rung `stable`/`BREACHED` verdicts with sustained rate, resource peaks and named breaches, bisection-bound narration, a ladder recap, and the measured-window verdict-evidence line — closes #249 (the first live run read as a clean climb on the console while the SUT shed 503s).

### The optimization loop as an instrument (#251 groundwork, #250 rung 1)

- **`cnf-runner aql-probe`** (new subcommand + published `aql-probe.schema.json`): seeds the class corpus fresh, fires the measurement machinery's own AQL vocabulary N times, records wire percentiles, and attributes DB-side cost per statement via `pg_stat_statements` through the containers capability — the loop that found today's ~9× stale-statistics regression, re-runnable per change and per SUT. Exploration only; never touches results.json.
- **Maintenance settling** (#250 rung 1, measured ~9× on the ward-worklist query): every instrument settles the database's maintenance debt (`vacuumdb --analyze` through the DB container) after seeding and before every measured window and stress rung — deterministic, identical for every SUT. The full attribution session (plan autopsy, the three disproved plan-shape rewrites) is recorded on #250.

### Always-fresh seeding (owner ruling)

`--skip-seed` and the sidecar corpus index are retired everywhere (CLI, `CONF_PERF_SKIP_SEED`, docs, book, skills): every instrument seeds a freshly composed, empty SUT and the stack is torn down afterwards.

Remaining on the open trackers: the committed class-POC run carrying the resources block + rendered charts (#244), the Java stress run + comparison switch + benchmark-lab deletion (#237), the probe's first committed report (#251), and the knee-lifting rungs (#250).

Closes #249
