### PR TITLE
docs: XML-escaped conformance SVGs, committed upstream comparison visuals, link gate green

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Conformance-assets drift gate (regenerated SVGs match the committed assets)
         # comparison-assets/ is gitignored build output (regenerated above);
         # the committed, drift-guarded copies are the product's own.
-        run: git diff --exit-code website/book/src/conformance-assets website/landing/assets/conformance-heat-grid.svg
+        run: git diff --exit-code website/book/src/conformance-assets website/landing/assets/conformance-heat-grid.svg website/book/src/comparison-assets/conformance-heat-grid-java.svg website/book/src/comparison-assets/conformance-chapter-bars-java.svg
       - name: Markdown lint gate
         run: mdbook-lint lint website/book/src
       - name: Assemble _site (landing + api + /docs/dev/)

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,10 @@ _check/
 # Stray local build artifacts
 *.rlib
 website/book/generated/
-website/book/src/comparison-assets/
+website/book/src/comparison-assets/*
+# The upstream conformance visuals are COMMITTED (README + book embeds),
+# drift-guarded in the docs workflow like the ehrbase-rs set.
+!website/book/src/comparison-assets/conformance-heat-grid-java.svg
+!website/book/src/comparison-assets/conformance-chapter-bars-java.svg
 __pycache__/
 docs/conformance/*/perf-corpus-*.json

--- a/README.md
+++ b/README.md
@@ -339,6 +339,20 @@ its curve is drawn exactly like one where it doesn't:
 
 ![Both systems' latency-throughput curves](website/book/src/perf-assets/perf-stress-compare.svg)
 
+Both systems' capability conformance, rendered from each party's own
+committed verdicts (one cell per claimed capability, evidence as color and
+glyph):
+
+![EHRbase-rs capability conformance](website/book/src/conformance-assets/conformance-heat-grid.svg)
+
+![Upstream EHRbase capability conformance](website/book/src/comparison-assets/conformance-heat-grid-java.svg)
+
+And the per-chapter outcomes side by side:
+
+![EHRbase-rs outcomes by chapter](website/book/src/conformance-assets/conformance-chapter-bars.svg)
+
+![Upstream EHRbase outcomes by chapter](website/book/src/comparison-assets/conformance-chapter-bars-java.svg)
+
 The full, generated comparison — profile verdicts, capability-by-capability
 evidence, failures in both directions, and the stress overlay once both
 committed reports exist — is the

--- a/tools/cnf-runner/src/conf_assets.rs
+++ b/tools/cnf-runner/src/conf_assets.rs
@@ -167,7 +167,8 @@ pub fn heat_grid_svg(
     svg_open(&mut out, width, height);
     let _ = writeln!(
         out,
-        "<text x=\"{MARGIN}\" y=\"28\" class=\"title\">Capability conformance — {sut_label}</text>"
+        "<text x=\"{MARGIN}\" y=\"28\" class=\"title\">Capability conformance — {}</text>",
+        xml_escape(sut_label)
     );
     // Legend (glyph + label per evidence kind; swatch + glyph = both channels).
     let mut lx = MARGIN;
@@ -244,6 +245,13 @@ pub struct ChapterCounts {
     pub failed: u64,
     pub errored: u64,
     pub not_applicable: u64,
+}
+
+/// Escape a string for SVG text content (XML character data): `&` and `<`
+/// break strict XML parsers when emitted raw — "Security & privacy" once
+/// shipped an invalid document.
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;")
 }
 
 /// The schedule chapter of a case id — the SM component of an
@@ -345,7 +353,8 @@ pub fn chapter_bars_svg(sut_label: &str, chapters: &[(&str, ChapterCounts)]) -> 
     svg_open(&mut out, width, height);
     let _ = writeln!(
         out,
-        "<text x=\"{MARGIN}\" y=\"28\" class=\"title\">Schedule outcomes by chapter — {sut_label}</text>\n"
+        "<text x=\"{MARGIN}\" y=\"28\" class=\"title\">Schedule outcomes by chapter — {}</text>\n",
+        xml_escape(sut_label)
     );
     // Legend.
     let mut lx = MARGIN;
@@ -369,7 +378,8 @@ pub fn chapter_bars_svg(sut_label: &str, chapters: &[(&str, ChapterCounts)]) -> 
         let total = counts.passed + counts.failed + counts.errored + counts.not_applicable;
         let _ = writeln!(
             out,
-            "<text x=\"{x}\" y=\"{ty}\" text-anchor=\"end\">{chapter}</text>",
+            "<text x=\"{x}\" y=\"{ty}\" text-anchor=\"end\">{}</text>",
+            xml_escape(chapter),
             x = MARGIN + LABEL_W - 8.0,
             ty = y + 17.0,
         );
@@ -507,5 +517,18 @@ mod tests {
         assert!(svg.contains(">15<"));
         assert!(svg.contains("bar-na"));
         assert!(svg.contains("prefers-color-scheme: dark"));
+    }
+
+    #[test]
+    fn svg_text_is_xml_escaped() {
+        // "Security & privacy" once shipped a raw ampersand — invalid XML
+        // strict renderers refuse. Both emitters escape text content.
+        let bars = chapter_bars_svg(
+            "sut & co",
+            &[("Security & privacy", ChapterCounts::default())],
+        );
+        assert!(!bars.contains("Security & privacy"), "raw ampersand: {bars}");
+        assert!(bars.contains("Security &amp; privacy"));
+        assert!(bars.contains("sut &amp; co"));
     }
 }

--- a/website/book/src/comparison-assets/conformance-chapter-bars-java.svg
+++ b/website/book/src/comparison-assets/conformance-chapter-bars-java.svg
@@ -1,0 +1,124 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 908 412" width="908" height="412" role="img">
+<style>
+text { fill: #52514e; font: 12px -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif; }
+.title { fill: #0b0b0b; font-weight: 600; }
+.muted { fill: #8a8880; font-size: 11px; }
+.grid { stroke: #e4e2dd; stroke-width: 1; }
+.cell-label { fill: #ffffff; font-size: 11px; }
+.cell-label-dim { fill: #0b0b0b; font-size: 11px; }
+.ev-passed { fill: #0072b2; }
+.ev-failed { fill: #d55e00; }
+.ev-not-evidenced { fill: #cbc9c2; }
+.ev-unrealized { fill: #e8e6e0; }
+.ev-no-cases { fill: #f4f2ec; }
+.cell-required { stroke: #52514e; stroke-width: 1.2; }
+.cell-optional { stroke: #cbc9c2; stroke-width: 1; stroke-dasharray: 3 2; }
+.bar-passed { fill: #0072b2; }
+.bar-failed { fill: #d55e00; }
+.bar-errored { fill: #e69f00; }
+.bar-na { fill: #cbc9c2; }
+.seg-label { fill: #ffffff; font-size: 10.5px; }
+.seg-label-dim { fill: #0b0b0b; font-size: 10.5px; }
+@media (prefers-color-scheme: dark) {
+text { fill: #c3c2b7; }
+.title { fill: #ffffff; }
+.muted { fill: #8f8e85; }
+.grid { stroke: #3a3a38; }
+.cell-label { fill: #ffffff; }
+.cell-label-dim { fill: #e8e6e0; }
+.ev-passed { fill: #3987e5; }
+.ev-failed { fill: #e5484d; }
+.ev-not-evidenced { fill: #4a4a47; }
+.ev-unrealized { fill: #3a3a38; }
+.ev-no-cases { fill: #2e2e2c; }
+.cell-required { stroke: #c3c2b7; }
+.cell-optional { stroke: #4a4a47; }
+.bar-passed { fill: #3987e5; }
+.bar-failed { fill: #e5484d; }
+.bar-errored { fill: #d9a514; }
+.bar-na { fill: #4a4a47; }
+.seg-label-dim { fill: #e8e6e0; }
+}
+</style>
+
+<text x="24" y="28" class="title">Schedule outcomes by chapter — ehrbase-java 2.34.0</text>
+
+<rect x="24" y="38" width="14" height="14" rx="3" class="bar-passed"/><text x="42" y="49" class="muted">passed</text><rect x="103.2" y="38" width="14" height="14" rx="3" class="bar-failed"/><text x="121.2" y="49" class="muted">failed</text><rect x="182.4" y="38" width="14" height="14" rx="3" class="bar-errored"/><text x="200.4" y="49" class="muted">errored</text><rect x="268.8" y="38" width="14" height="14" rx="3" class="bar-na"/><text x="286.8" y="49" class="muted">N/A (cited)</text><text x="166" y="81" text-anchor="end">EHR</text>
+<rect x="174" y="64" width="437.0731707317073" height="26" class="bar-passed"/>
+
+<text x="392.5365853658536" y="81" class="seg-label" text-anchor="middle">84</text><rect x="611.0731707317073" y="64" width="135.28455284552845" height="26" class="bar-failed"/>
+
+<text x="678.7154471544715" y="81" class="seg-label" text-anchor="middle">26</text><rect x="746.3577235772357" y="64" width="26.016260162601625" height="26" class="bar-errored"/>
+
+<text x="759.3658536585365" y="81" class="seg-label" text-anchor="middle">5</text><rect x="772.3739837398373" y="64" width="41.6260162601626" height="26" class="bar-na"/>
+
+<text x="793.1869918699185" y="81" class="seg-label-dim" text-anchor="middle">8</text><text x="821.9999999999999" y="81" class="muted">123</text>
+<text x="166" y="115" text-anchor="end">Definitions</text>
+<rect x="174" y="98" width="57.235772357723576" height="26" class="bar-passed"/>
+
+<text x="202.6178861788618" y="115" class="seg-label" text-anchor="middle">11</text><rect x="231.2357723577236" y="98" width="20.8130081300813" height="26" class="bar-failed"/>
+
+<rect x="252.0487804878049" y="98" width="88.45528455284553" height="26" class="bar-errored"/>
+
+<text x="296.2764227642277" y="115" class="seg-label" text-anchor="middle">17</text><rect x="340.5040650406504" y="98" width="83.2520325203252" height="26" class="bar-na"/>
+
+<text x="382.130081300813" y="115" class="seg-label-dim" text-anchor="middle">16</text><text x="431.7560975609756" y="115" class="muted">48</text>
+<text x="166" y="149" text-anchor="end">Query</text>
+<rect x="174" y="132" width="46.829268292682926" height="26" class="bar-passed"/>
+
+<text x="197.41463414634146" y="149" class="seg-label" text-anchor="middle">9</text><rect x="220.8292682926829" y="132" width="26.016260162601625" height="26" class="bar-failed"/>
+
+<text x="233.83739837398372" y="149" class="seg-label" text-anchor="middle">5</text><rect x="246.84552845528452" y="132" width="5.203252032520325" height="26" class="bar-errored"/>
+
+<text x="260.04878048780483" y="149" class="muted">15</text>
+<text x="166" y="183" text-anchor="end">Demographic</text>
+<rect x="174" y="166" width="20.8130081300813" height="26" class="bar-passed"/>
+
+<rect x="194.8130081300813" y="166" width="41.6260162601626" height="26" class="bar-errored"/>
+
+<text x="215.6260162601626" y="183" class="seg-label" text-anchor="middle">8</text><rect x="236.4390243902439" y="166" width="62.4390243902439" height="26" class="bar-na"/>
+
+<text x="267.6585365853658" y="183" class="seg-label-dim" text-anchor="middle">12</text><text x="306.8780487804878" y="183" class="muted">24</text>
+<text x="166" y="217" text-anchor="end">Admin</text>
+<rect x="174" y="200" width="5.203252032520325" height="26" class="bar-passed"/>
+
+<rect x="179.2032520325203" y="200" width="5.203252032520325" height="26" class="bar-failed"/>
+
+<rect x="184.40650406504062" y="200" width="83.2520325203252" height="26" class="bar-na"/>
+
+<text x="226.03252032520322" y="217" class="seg-label-dim" text-anchor="middle">16</text><text x="275.6585365853658" y="217" class="muted">18</text>
+<text x="166" y="251" text-anchor="end">Messaging</text>
+<rect x="174" y="234" width="72.84552845528455" height="26" class="bar-na"/>
+
+<text x="210.4227642276423" y="251" class="seg-label-dim" text-anchor="middle">14</text><text x="254.84552845528455" y="251" class="muted">14</text>
+<text x="166" y="285" text-anchor="end">Content validation</text>
+<rect x="174" y="268" width="192.520325203252" height="26" class="bar-passed"/>
+
+<text x="270.260162601626" y="285" class="seg-label" text-anchor="middle">37</text><rect x="366.520325203252" y="268" width="244.5528455284553" height="26" class="bar-failed"/>
+
+<text x="488.79674796747963" y="285" class="seg-label" text-anchor="middle">47</text><rect x="611.0731707317073" y="268" width="20.8130081300813" height="26" class="bar-errored"/>
+
+<text x="639.8861788617885" y="285" class="muted">88</text>
+<text x="166" y="319" text-anchor="end">Simplified formats</text>
+<rect x="174" y="302" width="26.016260162601625" height="26" class="bar-passed"/>
+
+<text x="187.0081300813008" y="319" class="seg-label" text-anchor="middle">5</text><rect x="200.0162601626016" y="302" width="218.53658536585365" height="26" class="bar-failed"/>
+
+<text x="309.2845528455284" y="319" class="seg-label" text-anchor="middle">42</text><rect x="418.55284552845524" y="302" width="10.40650406504065" height="26" class="bar-errored"/>
+
+<rect x="428.95934959349586" y="302" width="10.40650406504065" height="26" class="bar-na"/>
+
+<text x="447.3658536585365" y="319" class="muted">51</text>
+<text x="166" y="353" text-anchor="end">Security &amp; privacy</text>
+<rect x="174" y="336" width="20.8130081300813" height="26" class="bar-passed"/>
+
+<rect x="194.8130081300813" y="336" width="5.203252032520325" height="26" class="bar-errored"/>
+
+<text x="208.0162601626016" y="353" class="muted">5</text>
+<text x="166" y="387" text-anchor="end">Signing</text>
+<rect x="174" y="370" width="15.609756097560975" height="26" class="bar-passed"/>
+
+<rect x="189.609756097561" y="370" width="5.203252032520325" height="26" class="bar-failed"/>
+
+<text x="202.8130081300813" y="387" class="muted">4</text>
+</svg>

--- a/website/book/src/comparison-assets/conformance-heat-grid-java.svg
+++ b/website/book/src/comparison-assets/conformance-heat-grid-java.svg
@@ -1,0 +1,89 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1022 472" width="1022" height="472" role="img">
+<style>
+text { fill: #52514e; font: 12px -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif; }
+.title { fill: #0b0b0b; font-weight: 600; }
+.muted { fill: #8a8880; font-size: 11px; }
+.grid { stroke: #e4e2dd; stroke-width: 1; }
+.cell-label { fill: #ffffff; font-size: 11px; }
+.cell-label-dim { fill: #0b0b0b; font-size: 11px; }
+.ev-passed { fill: #0072b2; }
+.ev-failed { fill: #d55e00; }
+.ev-not-evidenced { fill: #cbc9c2; }
+.ev-unrealized { fill: #e8e6e0; }
+.ev-no-cases { fill: #f4f2ec; }
+.cell-required { stroke: #52514e; stroke-width: 1.2; }
+.cell-optional { stroke: #cbc9c2; stroke-width: 1; stroke-dasharray: 3 2; }
+.bar-passed { fill: #0072b2; }
+.bar-failed { fill: #d55e00; }
+.bar-errored { fill: #e69f00; }
+.bar-na { fill: #cbc9c2; }
+.seg-label { fill: #ffffff; font-size: 10.5px; }
+.seg-label-dim { fill: #0b0b0b; font-size: 10.5px; }
+@media (prefers-color-scheme: dark) {
+text { fill: #c3c2b7; }
+.title { fill: #ffffff; }
+.muted { fill: #8f8e85; }
+.grid { stroke: #3a3a38; }
+.cell-label { fill: #ffffff; }
+.cell-label-dim { fill: #e8e6e0; }
+.ev-passed { fill: #3987e5; }
+.ev-failed { fill: #e5484d; }
+.ev-not-evidenced { fill: #4a4a47; }
+.ev-unrealized { fill: #3a3a38; }
+.ev-no-cases { fill: #2e2e2c; }
+.cell-required { stroke: #c3c2b7; }
+.cell-optional { stroke: #4a4a47; }
+.bar-passed { fill: #3987e5; }
+.bar-failed { fill: #e5484d; }
+.bar-errored { fill: #d9a514; }
+.bar-na { fill: #4a4a47; }
+.seg-label-dim { fill: #e8e6e0; }
+}
+</style>
+
+<text x="24" y="28" class="title">Capability conformance — ehrbase-java 2.34.0</text>
+<rect x="24" y="38" width="14" height="14" rx="3" class="ev-passed"/><text x="31" y="49" class="cell-label" text-anchor="middle" font-size="10">✓</text><text x="42" y="49" class="muted">passed</text><rect x="103.2" y="38" width="14" height="14" rx="3" class="ev-failed"/><text x="110.2" y="49" class="cell-label" text-anchor="middle" font-size="10">✕</text><text x="121.2" y="49" class="muted">FAILED</text><rect x="182.4" y="38" width="14" height="14" rx="3" class="ev-not-evidenced"/><text x="189.4" y="49" class="cell-label-dim" text-anchor="middle" font-size="10">○</text><text x="200.4" y="49" class="muted">not evidenced</text><rect x="312" y="38" width="14" height="14" rx="3" class="ev-unrealized"/><text x="319" y="49" class="cell-label-dim" text-anchor="middle" font-size="10">◇</text><text x="330" y="49" class="muted">excused (unrealized)</text><rect x="492" y="38" width="14" height="14" rx="3" class="ev-no-cases"/><text x="499" y="49" class="cell-label-dim" text-anchor="middle" font-size="10">∅</text><text x="510" y="49" class="muted">no cases</text><text x="998" y="49" class="muted" text-anchor="end">solid border = required in tier · dashed = optional</text>
+<text x="24" y="82" class="title" font-size="12">CORE</text>
+<rect x="24" y="90" width="190" height="26" rx="5" class="ev-unrealized cell-required"/><text x="37" y="107" class="cell-label-dim" text-anchor="middle">◇</text><text x="50" y="107" class="cell-label-dim sm">Adl14ArchetypeProvisioning</text>
+<rect x="220" y="90" width="190" height="26" rx="5" class="ev-failed cell-required"/><text x="233" y="107" class="cell-label" text-anchor="middle">✕</text><text x="246" y="107" class="cell-label">Adl14OptProvisioning</text>
+<rect x="416" y="90" width="190" height="26" rx="5" class="ev-failed cell-required"/><text x="429" y="107" class="cell-label" text-anchor="middle">✕</text><text x="442" y="107" class="cell-label">EhrOperations</text>
+<rect x="612" y="90" width="190" height="26" rx="5" class="ev-failed cell-required"/><text x="625" y="107" class="cell-label" text-anchor="middle">✕</text><text x="638" y="107" class="cell-label">EhrStatus</text>
+<rect x="808" y="90" width="190" height="26" rx="5" class="ev-failed cell-required"/><text x="821" y="107" class="cell-label" text-anchor="middle">✕</text><text x="834" y="107" class="cell-label">CompositionOps</text>
+<rect x="24" y="122" width="190" height="26" rx="5" class="ev-failed cell-required"/><text x="37" y="139" class="cell-label" text-anchor="middle">✕</text><text x="50" y="139" class="cell-label">ChangeSets</text>
+<rect x="220" y="122" width="190" height="26" rx="5" class="ev-failed cell-required"/><text x="233" y="139" class="cell-label" text-anchor="middle">✕</text><text x="246" y="139" class="cell-label">Versioning</text>
+<rect x="416" y="122" width="190" height="26" rx="5" class="ev-failed cell-required"/><text x="429" y="139" class="cell-label" text-anchor="middle">✕</text><text x="442" y="139" class="cell-label">ArchetypeValidation</text>
+<rect x="612" y="122" width="190" height="26" rx="5" class="ev-not-evidenced cell-required"/><text x="625" y="139" class="cell-label-dim" text-anchor="middle">○</text><text x="638" y="139" class="cell-label-dim">DefinitionApi</text>
+<rect x="808" y="122" width="190" height="26" rx="5" class="ev-passed cell-required"/><text x="821" y="139" class="cell-label" text-anchor="middle">✓</text><text x="834" y="139" class="cell-label">EhrApi</text>
+<text x="24" y="182" class="title" font-size="12">STANDARD</text>
+<rect x="24" y="190" width="190" height="26" rx="5" class="ev-passed cell-required"/><text x="37" y="207" class="cell-label" text-anchor="middle">✓</text><text x="50" y="207" class="cell-label">QueryProvisioning</text>
+<rect x="220" y="190" width="190" height="26" rx="5" class="ev-failed cell-required"/><text x="233" y="207" class="cell-label" text-anchor="middle">✕</text><text x="246" y="207" class="cell-label">DirectoryOps</text>
+<rect x="416" y="190" width="190" height="26" rx="5" class="ev-failed cell-required"/><text x="429" y="207" class="cell-label" text-anchor="middle">✕</text><text x="442" y="207" class="cell-label">AqlBasic</text>
+<rect x="612" y="190" width="190" height="26" rx="5" class="ev-passed cell-required"/><text x="625" y="207" class="cell-label" text-anchor="middle">✓</text><text x="638" y="207" class="cell-label">QueryApi</text>
+<rect x="808" y="190" width="190" height="26" rx="5" class="ev-not-evidenced cell-optional"/><text x="821" y="207" class="cell-label-dim" text-anchor="middle">○</text><text x="834" y="207" class="cell-label-dim">Signing</text>
+<text x="24" y="250" class="title" font-size="12">OPTIONS</text>
+<rect x="24" y="258" width="190" height="26" rx="5" class="ev-not-evidenced cell-optional"/><text x="37" y="275" class="cell-label-dim" text-anchor="middle">○</text><text x="50" y="275" class="cell-label-dim sm">Adl2ArchetypeProvisioning</text>
+<rect x="220" y="258" width="190" height="26" rx="5" class="ev-not-evidenced cell-optional"/><text x="233" y="275" class="cell-label-dim" text-anchor="middle">○</text><text x="246" y="275" class="cell-label-dim">Adl2OptProvisioning</text>
+<rect x="416" y="258" width="190" height="26" rx="5" class="ev-not-evidenced cell-optional"/><text x="429" y="275" class="cell-label-dim" text-anchor="middle">○</text><text x="442" y="275" class="cell-label-dim">PartyOperations</text>
+<rect x="612" y="258" width="190" height="26" rx="5" class="ev-not-evidenced cell-optional"/><text x="625" y="275" class="cell-label-dim" text-anchor="middle">○</text><text x="638" y="275" class="cell-label-dim sm">PartyRelationshipOperations</text>
+<rect x="808" y="258" width="190" height="26" rx="5" class="ev-no-cases cell-optional"/><text x="821" y="275" class="cell-label-dim" text-anchor="middle">∅</text><text x="834" y="275" class="cell-label-dim sm">DemographicArchetypeValidation</text>
+<rect x="24" y="290" width="190" height="26" rx="5" class="ev-not-evidenced cell-optional"/><text x="37" y="307" class="cell-label-dim" text-anchor="middle">○</text><text x="50" y="307" class="cell-label-dim">AqlAdvanced</text>
+<rect x="220" y="290" width="190" height="26" rx="5" class="ev-not-evidenced cell-optional"/><text x="233" y="307" class="cell-label-dim" text-anchor="middle">○</text><text x="246" y="307" class="cell-label-dim">AqlTerminology</text>
+<rect x="416" y="290" width="190" height="26" rx="5" class="ev-not-evidenced cell-optional"/><text x="429" y="307" class="cell-label-dim" text-anchor="middle">○</text><text x="442" y="307" class="cell-label-dim">ActivityReport</text>
+<rect x="612" y="290" width="190" height="26" rx="5" class="ev-failed cell-optional"/><text x="625" y="307" class="cell-label" text-anchor="middle">✕</text><text x="638" y="307" class="cell-label">PhysicalDeletion</text>
+<rect x="808" y="290" width="190" height="26" rx="5" class="ev-not-evidenced cell-optional"/><text x="821" y="307" class="cell-label-dim" text-anchor="middle">○</text><text x="834" y="307" class="cell-label-dim">EhrDumpLoad</text>
+<rect x="24" y="322" width="190" height="26" rx="5" class="ev-no-cases cell-optional"/><text x="37" y="339" class="cell-label-dim" text-anchor="middle">∅</text><text x="50" y="339" class="cell-label-dim">BulkEhrLoad</text>
+<rect x="220" y="322" width="190" height="26" rx="5" class="ev-not-evidenced cell-optional"/><text x="233" y="339" class="cell-label-dim" text-anchor="middle">○</text><text x="246" y="339" class="cell-label-dim">EhrArchive</text>
+<rect x="416" y="322" width="190" height="26" rx="5" class="ev-not-evidenced cell-optional"/><text x="429" y="339" class="cell-label-dim" text-anchor="middle">○</text><text x="442" y="339" class="cell-label-dim">DemographicArchive</text>
+<rect x="612" y="322" width="190" height="26" rx="5" class="ev-not-evidenced cell-optional"/><text x="625" y="339" class="cell-label-dim" text-anchor="middle">○</text><text x="638" y="339" class="cell-label-dim">EhrExtract</text>
+<rect x="808" y="322" width="190" height="26" rx="5" class="ev-not-evidenced cell-optional"/><text x="821" y="339" class="cell-label-dim" text-anchor="middle">○</text><text x="834" y="339" class="cell-label-dim">Tds</text>
+<rect x="24" y="354" width="190" height="26" rx="5" class="ev-not-evidenced cell-optional"/><text x="37" y="371" class="cell-label-dim" text-anchor="middle">○</text><text x="50" y="371" class="cell-label-dim">DemographicApi</text>
+<rect x="220" y="354" width="190" height="26" rx="5" class="ev-failed cell-optional"/><text x="233" y="371" class="cell-label" text-anchor="middle">✕</text><text x="246" y="371" class="cell-label">AdminApi</text>
+<rect x="416" y="354" width="190" height="26" rx="5" class="ev-not-evidenced cell-optional"/><text x="429" y="371" class="cell-label-dim" text-anchor="middle">○</text><text x="442" y="371" class="cell-label-dim">MessageApi</text>
+<rect x="612" y="354" width="190" height="26" rx="5" class="ev-not-evidenced cell-optional"/><text x="625" y="371" class="cell-label-dim" text-anchor="middle">○</text><text x="638" y="371" class="cell-label-dim">SimplifiedFormats</text>
+<text x="24" y="414" class="title" font-size="12">SEC-BASIC</text>
+<rect x="24" y="422" width="190" height="26" rx="5" class="ev-passed cell-required"/><text x="37" y="439" class="cell-label" text-anchor="middle">✓</text><text x="50" y="439" class="cell-label">EhrDemographicSeparation</text>
+<rect x="220" y="422" width="190" height="26" rx="5" class="ev-passed cell-required"/><text x="233" y="439" class="cell-label" text-anchor="middle">✓</text><text x="246" y="439" class="cell-label">AuthenticatedAccess</text>
+<rect x="416" y="422" width="190" height="26" rx="5" class="ev-not-evidenced cell-required"/><text x="429" y="439" class="cell-label-dim" text-anchor="middle">○</text><text x="442" y="439" class="cell-label-dim">AuthorizationSeparation</text>
+<rect x="612" y="422" width="190" height="26" rx="5" class="ev-not-evidenced cell-required"/><text x="625" y="439" class="cell-label-dim" text-anchor="middle">○</text><text x="638" y="439" class="cell-label-dim">AuditAccountability</text>
+<rect x="808" y="422" width="190" height="26" rx="5" class="ev-not-evidenced cell-required"/><text x="821" y="439" class="cell-label-dim" text-anchor="middle">○</text><text x="834" y="439" class="cell-label-dim">AnonymousEhrs</text>
+</svg>

--- a/website/book/src/conformance-assets/conformance-chapter-bars.svg
+++ b/website/book/src/conformance-assets/conformance-chapter-bars.svg
@@ -85,7 +85,7 @@ text { fill: #c3c2b7; }
 <text x="304.0813008130081" y="319" class="seg-label" text-anchor="middle">50</text><rect x="434.1626016260162" y="302" width="5.203252032520325" height="26" class="bar-na"/>
 
 <text x="447.36585365853654" y="319" class="muted">51</text>
-<text x="166" y="353" text-anchor="end">Security & privacy</text>
+<text x="166" y="353" text-anchor="end">Security &amp; privacy</text>
 <rect x="174" y="336" width="26.016260162601625" height="26" class="bar-passed"/>
 
 <text x="187.0081300813008" y="353" class="seg-label" text-anchor="middle">5</text><text x="208.0162601626016" y="353" class="muted">5</text>

--- a/website/book/src/performance.md
+++ b/website/book/src/performance.md
@@ -264,15 +264,11 @@ window with the warmup shaded, and the database volume's on-disk size at
 four anchors — empty, after the scale seed, after the ward seed, and after
 the measured window — down to the storage cost per committed composition.
 These numbers are capacity-planning context — they never influence whether
-a class is earned.
-
-![Resource telemetry across the proof-of-concept measured run](perf-assets/perf-resources-class-POC.svg)
-
-The database volume's on-disk size is probed at four anchors — empty, after
-the scale seed, after the ward seed, and after the measured window — so the
-chart also answers the storage question directly: what one committed
-composition costs on disk, and how much the sustained hour wrote.
-
-![Disk growth across the measured run's four anchors](perf-assets/perf-disk-growth.svg)
+a class is earned. The database volume's on-disk size is probed at four
+anchors — empty, after the scale seed, after the ward seed, and after the
+measured window — down to the storage cost per committed composition. The
+rendered resource time-series and disk-growth charts join this page with
+the next committed measured class run (they render only from a committed
+record — nothing here is ever mocked).
 
 {{#include ../generated/perf-summary.md}}


### PR DESCRIPTION
The docs build failed its link gate on the two resource-chart embeds whose assets land with tonight's measured class run — the book now defers those embeds to the commit carrying their assets. En route: the chapter-bars renderer emitted raw ampersands ('Security & privacy') producing XML strict renderers refuse — text content is escaped and pinned; the upstream conformance visuals are committed + drift-guarded and the README comparison section embeds both SUTs' heat grids and chapter bars. All committed SVGs xmllint-clean; stale-numbers guard green.