### PR TITLE
docs: upstream stress evidence + cross-SUT overlay (rs 512/s vs java 0/s, both directions published)

### DIFF
--- a/docs/conformance/ehrbase-java/stress.json
+++ b/docs/conformance/ehrbase-java/stress.json
@@ -1,0 +1,1877 @@
+{
+  "corpus": "cnf.scale.10k",
+  "environment": {
+    "exclusive_server": true,
+    "hardware_class": "ci-runner",
+    "cores": 4,
+    "memory_gb": 16,
+    "storage_class": "ssd",
+    "topology": "single-node docker compose (docker/sut-ehrbase-java.yml, ehrbase/ehrbase:2.34.0 + ehrbase-v2-postgres:16.2; no readonly principal — EHRbase Basic auth carries one clinical user and one admin user)"
+  },
+  "step_warmup_s": 30,
+  "step_hold_s": 120,
+  "p99_budget_ms": 1000.0,
+  "error_budget": 0.001,
+  "steps": [
+    {
+      "rate": 2.0,
+      "offered_load_sustained": 2.0166666666666666,
+      "operations": [
+        {
+          "operation": "adhoc_query",
+          "requests": 32,
+          "errors": 0,
+          "latency_ms_p50": 84.287,
+          "latency_ms_p90": 151.039,
+          "latency_ms_p99": 232.319,
+          "hdr_v2_base64": "HISTEwAAAE4AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAALFjApsDAisCbwIZAm8CrQEC7wEC0wQCJQIrAicCSQKdAQI3AikC2QECyQECxQICiwICiwICqwECDwIfAhMCBwJRAmUCIQK7BwL3AQI7Ag=="
+        },
+        {
+          "operation": "composition_commit",
+          "requests": 10,
+          "errors": 10,
+          "latency_ms_p50": 91.455,
+          "latency_ms_p90": 343.039,
+          "latency_ms_p99": 384.511,
+          "hdr_v2_base64": "HISTEwAAABwAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAANtiAtcEAvcHAqkGAkkC+QgCewLZDAL1BwLBAgI="
+        },
+        {
+          "operation": "composition_read",
+          "requests": 64,
+          "errors": 0,
+          "latency_ms_p50": 31.663,
+          "latency_ms_p90": 76.223,
+          "latency_ms_p99": 125.823,
+          "hdr_v2_base64": "HISTEwAAAIwAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAM1CAm8CmwoChQYCewKlAQKJAQI5AhcCJQIfAgUCaQILAhcCKwIbAgsCIQKhAQIpBH8CDQIJAhkCAAILAjUCGwInAgMCFwIlAl0CSQIHAskBAnECGwK3AQICCwIXAhECPwJBAkcCRwJTAhMCPQJnAosBAlcCaQLjAgKdAwL9AgKjAwLFAQIZAm0CkQMC"
+        },
+        {
+          "operation": "composition_read_current",
+          "requests": 36,
+          "errors": 0,
+          "latency_ms_p50": 39.711,
+          "latency_ms_p90": 81.151,
+          "latency_ms_p99": 112.703,
+          "hdr_v2_base64": "HISTEwAAAFsAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAONNApkFAr8BAgcC4QECmwECiwICEQINAgMC2QMCKwJhApMBAn0CPwKZAQJFAjECyQICIwLZAQKnAQKJAgI7AoUBAqkBAgkCiwEC3QECPwJPAnsCXwKVAwLdAwI="
+        },
+        {
+          "operation": "composition_revision_history",
+          "requests": 34,
+          "errors": 0,
+          "latency_ms_p50": 42.175,
+          "latency_ms_p90": 84.287,
+          "latency_ms_p99": 118.591,
+          "hdr_v2_base64": "HISTEwAAAFYAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAMNHAs0IAtUCAqkBAvUBAvMCApUBAg0CaQIvAoUEAmUCBQLRAQIfAjMC1wECSQLZAQKNAQLvAQICawJLAoEBAjkCswICTwLzAQIfArMCAv8DAv8DAikC"
+        },
+        {
+          "operation": "composition_update",
+          "requests": 3,
+          "errors": 3,
+          "latency_ms_p50": 83.327,
+          "latency_ms_p90": 262.911,
+          "latency_ms_p99": 262.911,
+          "hdr_v2_base64": "HISTEwAAAAkAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAK1vAvkEAtcbAg=="
+        },
+        {
+          "operation": "contribution_commit",
+          "requests": 2,
+          "errors": 2,
+          "latency_ms_p50": 112.959,
+          "latency_ms_p90": 318.975,
+          "latency_ms_p99": 318.975,
+          "hdr_v2_base64": "HISTEwAAAAYAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAMd7Au8XAg=="
+        },
+        {
+          "operation": "contribution_read",
+          "requests": 4,
+          "errors": 0,
+          "latency_ms_p50": 96.575,
+          "latency_ms_p90": 351.231,
+          "latency_ms_p99": 351.231,
+          "hdr_v2_base64": "HISTEwAAAAwAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJlgAqsXAuECAocbAg=="
+        },
+        {
+          "operation": "directory_read",
+          "requests": 31,
+          "errors": 0,
+          "latency_ms_p50": 30.143,
+          "latency_ms_p90": 83.519,
+          "latency_ms_p99": 133.759,
+          "hdr_v2_base64": "HISTEwAAAEgAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJlKAokBAqMGAm0CXwJrAhsCGwSdAwI/Au0BAgMCLQLNAgITAmUC5QECXwIHAkkC+wECTQJrAgLnBQKrAwKZBgIxAvUDAskHAg=="
+        },
+        {
+          "operation": "directory_update",
+          "requests": 1,
+          "errors": 0,
+          "latency_ms_p50": 413.951,
+          "latency_ms_p90": 413.951,
+          "latency_ms_p99": 413.951,
+          "hdr_v2_base64": "HISTEwAAAAQAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJ+ZAQI="
+        },
+        {
+          "operation": "ehr_create",
+          "requests": 1,
+          "errors": 0,
+          "latency_ms_p50": 45.503,
+          "latency_ms_p90": 45.503,
+          "latency_ms_p99": 45.503,
+          "hdr_v2_base64": "HISTEwAAAAMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJlmAg=="
+        },
+        {
+          "operation": "ehr_read",
+          "requests": 3,
+          "errors": 0,
+          "latency_ms_p50": 31.439,
+          "latency_ms_p90": 49.855,
+          "latency_ms_p99": 49.855,
+          "hdr_v2_base64": "HISTEwAAAAkAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAK9WAqUIAs8JAg=="
+        },
+        {
+          "operation": "stored_query_execute",
+          "requests": 6,
+          "errors": 0,
+          "latency_ms_p50": 48.671,
+          "latency_ms_p90": 92.223,
+          "latency_ms_p99": 92.223,
+          "hdr_v2_base64": "HISTEwAAABIAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAO9cAvUHAvUCAssEAtkIArMBAg=="
+        },
+        {
+          "operation": "tags_put",
+          "requests": 1,
+          "errors": 1,
+          "latency_ms_p50": 49.631,
+          "latency_ms_p90": 49.631,
+          "latency_ms_p99": 49.631,
+          "hdr_v2_base64": "HISTEwAAAAMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJtoAg=="
+        },
+        {
+          "operation": "tags_read",
+          "requests": 1,
+          "errors": 1,
+          "latency_ms_p50": 61.503,
+          "latency_ms_p90": 61.503,
+          "latency_ms_p99": 61.503,
+          "hdr_v2_base64": "HISTEwAAAAMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAIFuAg=="
+        },
+        {
+          "operation": "template_get",
+          "requests": 3,
+          "errors": 0,
+          "latency_ms_p50": 158.335,
+          "latency_ms_p90": 169.983,
+          "latency_ms_p99": 169.983,
+          "hdr_v2_base64": "HISTEwAAAAkAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPFyArMQArMBAg=="
+        },
+        {
+          "operation": "template_list",
+          "requests": 3,
+          "errors": 0,
+          "latency_ms_p50": 20.431,
+          "latency_ms_p90": 129.855,
+          "latency_ms_p99": 129.855,
+          "hdr_v2_base64": "HISTEwAAAAkAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJlKAtsJAt0rAg=="
+        },
+        {
+          "operation": "ward_query",
+          "requests": 7,
+          "errors": 1,
+          "latency_ms_p50": 13230.079,
+          "latency_ms_p90": 20561.919,
+          "latency_ms_p99": 20561.919,
+          "hdr_v2_base64": "HISTEwAAABYAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAANvUAQLdEQKRAQLJAQKJAQKdAgKBBwI="
+        }
+      ],
+      "stable": false,
+      "breaches": [
+        "ward_query p99 20561.9ms > budget 1000ms",
+        "error rate 0.0744 > tolerance 0.0010"
+      ],
+      "generator_bound": false,
+      "resources": {
+        "sample_interval_s": 10,
+        "containers": [
+          {
+            "role": "sut",
+            "name": "cnf-ehrbase-java-ehrbase-java-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 23.757824433499806,
+                "rss_bytes": 1708343296,
+                "blk_read_bytes": 7602176,
+                "blk_write_bytes": 626688,
+                "net_rx_bytes": 4506905342,
+                "net_tx_bytes": 5184853350
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 15.939675131905581,
+                "rss_bytes": 1709867008,
+                "blk_read_bytes": 7790592,
+                "blk_write_bytes": 626688,
+                "net_rx_bytes": 4506992091,
+                "net_tx_bytes": 5185069935
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 31.71665910857369,
+                "rss_bytes": 1711394816,
+                "blk_read_bytes": 8036352,
+                "blk_write_bytes": 626688,
+                "net_rx_bytes": 4507114237,
+                "net_tx_bytes": 5185356686
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 38.581021662561,
+                "rss_bytes": 1714286592,
+                "blk_read_bytes": 8376320,
+                "blk_write_bytes": 643072,
+                "net_rx_bytes": 4507324456,
+                "net_tx_bytes": 5185777645
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 8.031653979287205,
+                "rss_bytes": 1714720768,
+                "blk_read_bytes": 8429568,
+                "blk_write_bytes": 643072,
+                "net_rx_bytes": 4507448858,
+                "net_tx_bytes": 5186058563
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 15.216782833940012,
+                "rss_bytes": 1715376128,
+                "blk_read_bytes": 8429568,
+                "blk_write_bytes": 643072,
+                "net_rx_bytes": 4507546507,
+                "net_tx_bytes": 5186290643
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 16.343553720632784,
+                "rss_bytes": 1716596736,
+                "blk_read_bytes": 8441856,
+                "blk_write_bytes": 659456,
+                "net_rx_bytes": 4507708062,
+                "net_tx_bytes": 5186712104
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 13.852557314970962,
+                "rss_bytes": 1716953088,
+                "blk_read_bytes": 8470528,
+                "blk_write_bytes": 659456,
+                "net_rx_bytes": 4507781988,
+                "net_tx_bytes": 5186894399
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 13.904335343992077,
+                "rss_bytes": 1717489664,
+                "blk_read_bytes": 8470528,
+                "blk_write_bytes": 659456,
+                "net_rx_bytes": 4507838080,
+                "net_tx_bytes": 5187040622
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 20.49010026392602,
+                "rss_bytes": 1722884096,
+                "blk_read_bytes": 12525568,
+                "blk_write_bytes": 675840,
+                "net_rx_bytes": 4507966394,
+                "net_tx_bytes": 5187330525
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 7.195767123643143,
+                "rss_bytes": 1722433536,
+                "blk_read_bytes": 12546048,
+                "blk_write_bytes": 675840,
+                "net_rx_bytes": 4508070888,
+                "net_tx_bytes": 5187567664
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 18.898890552141662,
+                "rss_bytes": 1723686912,
+                "blk_read_bytes": 12607488,
+                "blk_write_bytes": 675840,
+                "net_rx_bytes": 4508294438,
+                "net_tx_bytes": 5188486249
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 13.525712840034002,
+                "rss_bytes": 1723416576,
+                "blk_read_bytes": 12607488,
+                "blk_write_bytes": 688128,
+                "net_rx_bytes": 4508379511,
+                "net_tx_bytes": 5188654847
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 11.86789706875354,
+                "rss_bytes": 1723691008,
+                "blk_read_bytes": 12607488,
+                "blk_write_bytes": 688128,
+                "net_rx_bytes": 4508476380,
+                "net_tx_bytes": 5188879191
+              },
+              {
+                "offset_s": 150,
+                "phase": "drain",
+                "cpu_pct": 17.265126119898717,
+                "rss_bytes": 1724252160,
+                "blk_read_bytes": 12607488,
+                "blk_write_bytes": 688128,
+                "net_rx_bytes": 4508551123,
+                "net_tx_bytes": 5189527172
+              },
+              {
+                "offset_s": 160,
+                "phase": "drain",
+                "cpu_pct": 1.6862661012842148,
+                "rss_bytes": 1724366848,
+                "blk_read_bytes": 12607488,
+                "blk_write_bytes": 700416,
+                "net_rx_bytes": 4508551463,
+                "net_tx_bytes": 5189527759
+              }
+            ]
+          },
+          {
+            "role": "db",
+            "name": "cnf-ehrbase-java-ehrbase-java-db-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 3.639784987173125,
+                "rss_bytes": 2303221760,
+                "blk_read_bytes": 930926592,
+                "blk_write_bytes": 73523957760,
+                "net_rx_bytes": 4439753742,
+                "net_tx_bytes": 1260736718
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 170.46076177518557,
+                "rss_bytes": 2847633408,
+                "blk_read_bytes": 2143707136,
+                "blk_write_bytes": 73531527168,
+                "net_rx_bytes": 4439810363,
+                "net_tx_bytes": 1260812184
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 186.03235015594834,
+                "rss_bytes": 3210338304,
+                "blk_read_bytes": 3666292736,
+                "blk_write_bytes": 73984344064,
+                "net_rx_bytes": 4439949851,
+                "net_tx_bytes": 1260883167
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 238.78198023871326,
+                "rss_bytes": 3322564608,
+                "blk_read_bytes": 5206040576,
+                "blk_write_bytes": 73985466368,
+                "net_rx_bytes": 4440229182,
+                "net_tx_bytes": 1260956714
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 31.88879351922,
+                "rss_bytes": 3179933696,
+                "blk_read_bytes": 5480419328,
+                "blk_write_bytes": 74215804928,
+                "net_rx_bytes": 4440349110,
+                "net_tx_bytes": 1261032489
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 186.11184311633,
+                "rss_bytes": 3333373952,
+                "blk_read_bytes": 6338781184,
+                "blk_write_bytes": 74237300736,
+                "net_rx_bytes": 4440445386,
+                "net_tx_bytes": 1261097232
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 93.13870998929875,
+                "rss_bytes": 557432832,
+                "blk_read_bytes": 7294140416,
+                "blk_write_bytes": 74492665856,
+                "net_rx_bytes": 4440671419,
+                "net_tx_bytes": 1261151430
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 198.76688053143042,
+                "rss_bytes": 677953536,
+                "blk_read_bytes": 7738150912,
+                "blk_write_bytes": 74517831680,
+                "net_rx_bytes": 4440715969,
+                "net_tx_bytes": 1261213363
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 294.80886262172754,
+                "rss_bytes": 2129059840,
+                "blk_read_bytes": 9190891520,
+                "blk_write_bytes": 74518114304,
+                "net_rx_bytes": 4440759332,
+                "net_tx_bytes": 1261259522
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 51.39487954298879,
+                "rss_bytes": 1954103296,
+                "blk_read_bytes": 9510096896,
+                "blk_write_bytes": 74518417408,
+                "net_rx_bytes": 4440849000,
+                "net_tx_bytes": 1261349731
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 115.75727705260222,
+                "rss_bytes": 2083581952,
+                "blk_read_bytes": 10113245184,
+                "blk_write_bytes": 74519498752,
+                "net_rx_bytes": 4440959411,
+                "net_tx_bytes": 1261407226
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 217.5634579965553,
+                "rss_bytes": 2321874944,
+                "blk_read_bytes": 11669782528,
+                "blk_write_bytes": 74720653312,
+                "net_rx_bytes": 4441282634,
+                "net_tx_bytes": 1261473290
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 246.14213490141427,
+                "rss_bytes": 2447466496,
+                "blk_read_bytes": 12444831744,
+                "blk_write_bytes": 74721333248,
+                "net_rx_bytes": 4441318073,
+                "net_tx_bytes": 1261531111
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 245.05758143639662,
+                "rss_bytes": 2476941312,
+                "blk_read_bytes": 13784678400,
+                "blk_write_bytes": 74721439744,
+                "net_rx_bytes": 4441378690,
+                "net_tx_bytes": 1261605352
+              },
+              {
+                "offset_s": 150,
+                "phase": "drain",
+                "cpu_pct": 209.62113406372634,
+                "rss_bytes": 2444722176,
+                "blk_read_bytes": 15259111424,
+                "blk_write_bytes": 74722340864,
+                "net_rx_bytes": 4441408402,
+                "net_tx_bytes": 1261666231
+              },
+              {
+                "offset_s": 160,
+                "phase": "drain",
+                "cpu_pct": 257.4593658692325,
+                "rss_bytes": 2469994496,
+                "blk_read_bytes": 16603062272,
+                "blk_write_bytes": 74748215296,
+                "net_rx_bytes": 4441408947,
+                "net_tx_bytes": 1261666529
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "rate": 1.0,
+      "offered_load_sustained": 1.0166666666666666,
+      "operations": [
+        {
+          "operation": "adhoc_query",
+          "requests": 16,
+          "errors": 0,
+          "latency_ms_p50": 55.487,
+          "latency_ms_p90": 146.687,
+          "latency_ms_p99": 234.111,
+          "hdr_v2_base64": "HISTEwAAACkAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAOdbArUHAm8CHwInAjEClwUCWwJNAqECAoECAlMCtwcCvwICmwcC0woC"
+        },
+        {
+          "operation": "composition_commit",
+          "requests": 6,
+          "errors": 6,
+          "latency_ms_p50": 66.879,
+          "latency_ms_p90": 585.215,
+          "latency_ms_p99": 585.215,
+          "hdr_v2_base64": "HISTEwAAABIAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAM1oAv8CAtUEAosGAusZAsURAg=="
+        },
+        {
+          "operation": "composition_read",
+          "requests": 31,
+          "errors": 0,
+          "latency_ms_p50": 29.039,
+          "latency_ms_p90": 97.151,
+          "latency_ms_p99": 199.807,
+          "hdr_v2_base64": "HISTEwAAAE8AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAANFRAiUCMwJfArMBApUCAocBApEBAlUCNQIRAmcCKwIHAl0CBQLNAQJ1AiMCuQECRQL7AQL9BQKXAQLLBQKBAQKLAwLBAwLrAQK5AQKpDQI="
+        },
+        {
+          "operation": "composition_read_current",
+          "requests": 18,
+          "errors": 0,
+          "latency_ms_p50": 45.567,
+          "latency_ms_p90": 319.231,
+          "latency_ms_p99": 358.143,
+          "hdr_v2_base64": "HISTEwAAADIAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAOFSApsEAoMBAtsGAnECeQJlAqEDArsBAkkCyQMCnwcCxQEC8QECwwEC5RQC9wcCrQIC"
+        },
+        {
+          "operation": "composition_revision_history",
+          "requests": 17,
+          "errors": 0,
+          "latency_ms_p50": 47.199,
+          "latency_ms_p90": 106.687,
+          "latency_ms_p99": 157.439,
+          "hdr_v2_base64": "HISTEwAAACwAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAMdTAo8GAhMC4QICTQKPAQLBAgJ/AoUFAgACbwJ7AhMCuQQCuwIC+QkCkwkC"
+        },
+        {
+          "operation": "composition_update",
+          "requests": 1,
+          "errors": 1,
+          "latency_ms_p50": 51.263,
+          "latency_ms_p90": 51.263,
+          "latency_ms_p99": 51.263,
+          "hdr_v2_base64": "HISTEwAAAAMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAIFpAg=="
+        },
+        {
+          "operation": "contribution_commit",
+          "requests": 2,
+          "errors": 2,
+          "latency_ms_p50": 43.359,
+          "latency_ms_p90": 100.799,
+          "latency_ms_p99": 100.799,
+          "hdr_v2_base64": "HISTEwAAAAYAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJNlArUTAg=="
+        },
+        {
+          "operation": "contribution_read",
+          "requests": 2,
+          "errors": 0,
+          "latency_ms_p50": 42.143,
+          "latency_ms_p90": 77.311,
+          "latency_ms_p99": 77.311,
+          "hdr_v2_base64": "HISTEwAAAAYAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAMdkAqMOAg=="
+        },
+        {
+          "operation": "directory_read",
+          "requests": 16,
+          "errors": 0,
+          "latency_ms_p50": 29.391,
+          "latency_ms_p90": 96.063,
+          "latency_ms_p99": 106.239,
+          "hdr_v2_base64": "HISTEwAAACwAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAKNQAqkCAmcCMQLLAwJBAjUCnQQCrQIClwECkwICywMCoQkCqQIC3wUCuwIC"
+        },
+        {
+          "operation": "ehr_read",
+          "requests": 2,
+          "errors": 0,
+          "latency_ms_p50": 31.503,
+          "latency_ms_p90": 32.927,
+          "latency_ms_p99": 32.927,
+          "hdr_v2_base64": "HISTEwAAAAYAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAN9eAqUBAg=="
+        },
+        {
+          "operation": "stored_query_execute",
+          "requests": 3,
+          "errors": 0,
+          "latency_ms_p50": 36.159,
+          "latency_ms_p90": 43.583,
+          "latency_ms_p99": 43.583,
+          "hdr_v2_base64": "HISTEwAAAAgAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAANdgAncCzQMC"
+        },
+        {
+          "operation": "tags_put",
+          "requests": 1,
+          "errors": 1,
+          "latency_ms_p50": 51.839,
+          "latency_ms_p90": 51.839,
+          "latency_ms_p99": 51.839,
+          "hdr_v2_base64": "HISTEwAAAAMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAKVpAg=="
+        },
+        {
+          "operation": "tags_read",
+          "requests": 1,
+          "errors": 1,
+          "latency_ms_p50": 50.303,
+          "latency_ms_p90": 50.303,
+          "latency_ms_p99": 50.303,
+          "hdr_v2_base64": "HISTEwAAAAMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAMVoAg=="
+        },
+        {
+          "operation": "template_get",
+          "requests": 2,
+          "errors": 0,
+          "latency_ms_p50": 112.319,
+          "latency_ms_p90": 351.743,
+          "latency_ms_p99": 351.743,
+          "hdr_v2_base64": "HISTEwAAAAYAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAALN7AoMaAg=="
+        },
+        {
+          "operation": "template_list",
+          "requests": 1,
+          "errors": 0,
+          "latency_ms_p50": 21.647,
+          "latency_ms_p90": 21.647,
+          "latency_ms_p99": 21.647,
+          "hdr_v2_base64": "HISTEwAAAAMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAI9VAg=="
+        },
+        {
+          "operation": "ward_query",
+          "requests": 3,
+          "errors": 0,
+          "latency_ms_p50": 15351.807,
+          "latency_ms_p90": 15491.071,
+          "latency_ms_p99": 15491.071,
+          "hdr_v2_base64": "HISTEwAAAAkAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAANnmAQLFBgIfAg=="
+        }
+      ],
+      "stable": false,
+      "breaches": [
+        "ward_query p99 15491.1ms > budget 1000ms",
+        "error rate 0.0902 > tolerance 0.0010"
+      ],
+      "generator_bound": false,
+      "resources": {
+        "sample_interval_s": 10,
+        "containers": [
+          {
+            "role": "sut",
+            "name": "cnf-ehrbase-java-ehrbase-java-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 3.114105706192708,
+                "rss_bytes": 1724903424,
+                "blk_read_bytes": 12607488,
+                "blk_write_bytes": 700416,
+                "net_rx_bytes": 4508605468,
+                "net_tx_bytes": 5189642547
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 2.8694083406096005,
+                "rss_bytes": 1725014016,
+                "blk_read_bytes": 12615680,
+                "blk_write_bytes": 700416,
+                "net_rx_bytes": 4508634467,
+                "net_tx_bytes": 5189711852
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 3.883873483165651,
+                "rss_bytes": 1725104128,
+                "blk_read_bytes": 12615680,
+                "blk_write_bytes": 712704,
+                "net_rx_bytes": 4508661275,
+                "net_tx_bytes": 5189784694
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 7.941153998003347,
+                "rss_bytes": 1725218816,
+                "blk_read_bytes": 12668928,
+                "blk_write_bytes": 712704,
+                "net_rx_bytes": 4508706882,
+                "net_tx_bytes": 5189888856
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 5.02668750094929,
+                "rss_bytes": 1726881792,
+                "blk_read_bytes": 12668928,
+                "blk_write_bytes": 712704,
+                "net_rx_bytes": 4508767490,
+                "net_tx_bytes": 5190024780
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 9.095461364451065,
+                "rss_bytes": 1727156224,
+                "blk_read_bytes": 12668928,
+                "blk_write_bytes": 724992,
+                "net_rx_bytes": 4508801449,
+                "net_tx_bytes": 5190446768
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 2.712492299427658,
+                "rss_bytes": 1726918656,
+                "blk_read_bytes": 12668928,
+                "blk_write_bytes": 724992,
+                "net_rx_bytes": 4508845057,
+                "net_tx_bytes": 5190543005
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 4.158862320941922,
+                "rss_bytes": 1727307776,
+                "blk_read_bytes": 12668928,
+                "blk_write_bytes": 724992,
+                "net_rx_bytes": 4509031965,
+                "net_tx_bytes": 5190685803
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 5.542599017292115,
+                "rss_bytes": 1727250432,
+                "blk_read_bytes": 12668928,
+                "blk_write_bytes": 733184,
+                "net_rx_bytes": 4509067868,
+                "net_tx_bytes": 5190977681
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 13.334841275537954,
+                "rss_bytes": 1727270912,
+                "blk_read_bytes": 12668928,
+                "blk_write_bytes": 733184,
+                "net_rx_bytes": 4509093452,
+                "net_tx_bytes": 5191040987
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 9.002870730130084,
+                "rss_bytes": 1727959040,
+                "blk_read_bytes": 12668928,
+                "blk_write_bytes": 733184,
+                "net_rx_bytes": 4509137606,
+                "net_tx_bytes": 5191145084
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 4.7770013681198344,
+                "rss_bytes": 1727909888,
+                "blk_read_bytes": 12668928,
+                "blk_write_bytes": 745472,
+                "net_rx_bytes": 4509177313,
+                "net_tx_bytes": 5191233536
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 3.685493301566038,
+                "rss_bytes": 1728929792,
+                "blk_read_bytes": 12668928,
+                "blk_write_bytes": 745472,
+                "net_rx_bytes": 4509203889,
+                "net_tx_bytes": 5191298008
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 17.516822193688213,
+                "rss_bytes": 1729040384,
+                "blk_read_bytes": 12668928,
+                "blk_write_bytes": 745472,
+                "net_rx_bytes": 4509296082,
+                "net_tx_bytes": 5191891861
+              }
+            ]
+          },
+          {
+            "role": "db",
+            "name": "cnf-ehrbase-java-ehrbase-java-db-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 1.061172354262407,
+                "rss_bytes": 2375241728,
+                "blk_read_bytes": 17072513024,
+                "blk_write_bytes": 74748321792,
+                "net_rx_bytes": 4441440993,
+                "net_tx_bytes": 1261704377
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 1.163373512890563,
+                "rss_bytes": 2375016448,
+                "blk_read_bytes": 17072975872,
+                "blk_write_bytes": 74748329984,
+                "net_rx_bytes": 4441458431,
+                "net_tx_bytes": 1261728666
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 19.607004418208955,
+                "rss_bytes": 2444218368,
+                "blk_read_bytes": 17076137984,
+                "blk_write_bytes": 74748461056,
+                "net_rx_bytes": 4441480480,
+                "net_tx_bytes": 1261750627
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 257.6981274912259,
+                "rss_bytes": 2490818560,
+                "blk_read_bytes": 18433720320,
+                "blk_write_bytes": 74748534784,
+                "net_rx_bytes": 4441498918,
+                "net_tx_bytes": 1261786671
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 54.40428886234483,
+                "rss_bytes": 2367123456,
+                "blk_read_bytes": 18861412352,
+                "blk_write_bytes": 74877116416,
+                "net_rx_bytes": 4441548812,
+                "net_tx_bytes": 1261826628
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 243.56082478808983,
+                "rss_bytes": 2517422080,
+                "blk_read_bytes": 20208193536,
+                "blk_write_bytes": 74877165568,
+                "net_rx_bytes": 4441565959,
+                "net_tx_bytes": 1261849351
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 49.46942705344574,
+                "rss_bytes": 2396844032,
+                "blk_read_bytes": 20626264064,
+                "blk_write_bytes": 74877165568,
+                "net_rx_bytes": 4441576084,
+                "net_tx_bytes": 1261887590
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 1.5797340756583906,
+                "rss_bytes": 2396901376,
+                "blk_read_bytes": 20626739200,
+                "blk_write_bytes": 74877362176,
+                "net_rx_bytes": 4441611311,
+                "net_tx_bytes": 1261933711
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 43.42209654266258,
+                "rss_bytes": 2471723008,
+                "blk_read_bytes": 20720885760,
+                "blk_write_bytes": 74878722048,
+                "net_rx_bytes": 4441850359,
+                "net_tx_bytes": 1261959583
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 260.20134717934627,
+                "rss_bytes": 2518667264,
+                "blk_read_bytes": 21868441600,
+                "blk_write_bytes": 74879672320,
+                "net_rx_bytes": 4441864056,
+                "net_tx_bytes": 1261980914
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 85.03847563588778,
+                "rss_bytes": 2399285248,
+                "blk_read_bytes": 22385422336,
+                "blk_write_bytes": 74879852544,
+                "net_rx_bytes": 4441877527,
+                "net_tx_bytes": 1262019712
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 2.515104555266775,
+                "rss_bytes": 2364841984,
+                "blk_read_bytes": 22385840128,
+                "blk_write_bytes": 74879967232,
+                "net_rx_bytes": 4441915592,
+                "net_tx_bytes": 1262043168
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 86.51689588336565,
+                "rss_bytes": 2479439872,
+                "blk_read_bytes": 22574915584,
+                "blk_write_bytes": 74880647168,
+                "net_rx_bytes": 4441929074,
+                "net_tx_bytes": 1262064882
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 251.78284813870903,
+                "rss_bytes": 2519085056,
+                "blk_read_bytes": 23823446016,
+                "blk_write_bytes": 74881884160,
+                "net_rx_bytes": 4442070286,
+                "net_tx_bytes": 1262088155
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "rate": 0.5,
+      "offered_load_sustained": 0.55,
+      "operations": [
+        {
+          "operation": "adhoc_query",
+          "requests": 8,
+          "errors": 0,
+          "latency_ms_p50": 56.223,
+          "latency_ms_p90": 340.223,
+          "latency_ms_p99": 340.223,
+          "hdr_v2_base64": "HISTEwAAABcAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAANlfAoMBAhkCuQoCiQECuwMC7wQC6R8C"
+        },
+        {
+          "operation": "composition_commit",
+          "requests": 7,
+          "errors": 7,
+          "latency_ms_p50": 85.375,
+          "latency_ms_p90": 360.703,
+          "latency_ms_p99": 360.703,
+          "hdr_v2_base64": "HISTEwAAABQAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAALNqApUFApcFAgAClwQCgQgC9RQC"
+        },
+        {
+          "operation": "composition_read",
+          "requests": 15,
+          "errors": 0,
+          "latency_ms_p50": 26.143,
+          "latency_ms_p90": 132.479,
+          "latency_ms_p99": 170.111,
+          "hdr_v2_base64": "HISTEwAAACkAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAMNNAqcDAuECAhsCIQKdAwJBAscBAh0C4QEC+QIC7QEClRQCxwsCyQQC"
+        },
+        {
+          "operation": "composition_read_current",
+          "requests": 10,
+          "errors": 0,
+          "latency_ms_p50": 29.039,
+          "latency_ms_p90": 67.519,
+          "latency_ms_p99": 109.823,
+          "hdr_v2_base64": "HISTEwAAABwAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAANNUAosEAmUCAwLZAgKjBwLBAgKXAQKJCQKnCgI="
+        },
+        {
+          "operation": "composition_revision_history",
+          "requests": 7,
+          "errors": 0,
+          "latency_ms_p50": 29.567,
+          "latency_ms_p90": 78.783,
+          "latency_ms_p99": 78.783,
+          "hdr_v2_base64": "HISTEwAAABQAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAI9KAqEQAicCjQICrwMC0wECoxEC"
+        },
+        {
+          "operation": "composition_update",
+          "requests": 1,
+          "errors": 1,
+          "latency_ms_p50": 38.687,
+          "latency_ms_p90": 38.687,
+          "latency_ms_p99": 38.687,
+          "hdr_v2_base64": "HISTEwAAAAMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAO9iAg=="
+        },
+        {
+          "operation": "directory_create",
+          "requests": 1,
+          "errors": 1,
+          "latency_ms_p50": 32.607,
+          "latency_ms_p90": 32.607,
+          "latency_ms_p99": 32.607,
+          "hdr_v2_base64": "HISTEwAAAAMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAOlfAg=="
+        },
+        {
+          "operation": "directory_read",
+          "requests": 9,
+          "errors": 0,
+          "latency_ms_p50": 25.919,
+          "latency_ms_p90": 59.487,
+          "latency_ms_p99": 59.487,
+          "hdr_v2_base64": "HISTEwAAABoAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPNQAqECArkBAkUChwQC5QMCyQQC2QECywkC"
+        },
+        {
+          "operation": "directory_update",
+          "requests": 1,
+          "errors": 0,
+          "latency_ms_p50": 103.359,
+          "latency_ms_p90": 103.359,
+          "latency_ms_p99": 103.359,
+          "hdr_v2_base64": "HISTEwAAAAMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJt5Ag=="
+        },
+        {
+          "operation": "ehr_create",
+          "requests": 1,
+          "errors": 0,
+          "latency_ms_p50": 53.055,
+          "latency_ms_p90": 53.055,
+          "latency_ms_p99": 53.055,
+          "hdr_v2_base64": "HISTEwAAAAMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAPFpAg=="
+        },
+        {
+          "operation": "ehr_read",
+          "requests": 1,
+          "errors": 0,
+          "latency_ms_p50": 20.879,
+          "latency_ms_p90": 20.879,
+          "latency_ms_p99": 20.879,
+          "hdr_v2_base64": "HISTEwAAAAMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAK9UAg=="
+        },
+        {
+          "operation": "ehr_status_read",
+          "requests": 1,
+          "errors": 0,
+          "latency_ms_p50": 142.079,
+          "latency_ms_p90": 142.079,
+          "latency_ms_p99": 142.079,
+          "hdr_v2_base64": "HISTEwAAAAQAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAKmBAQI="
+        },
+        {
+          "operation": "ehr_status_update",
+          "requests": 1,
+          "errors": 1,
+          "latency_ms_p50": 47.327,
+          "latency_ms_p90": 47.327,
+          "latency_ms_p99": 47.327,
+          "hdr_v2_base64": "HISTEwAAAAMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAItnAg=="
+        },
+        {
+          "operation": "stored_query_execute",
+          "requests": 1,
+          "errors": 0,
+          "latency_ms_p50": 58.527,
+          "latency_ms_p90": 58.527,
+          "latency_ms_p99": 58.527,
+          "hdr_v2_base64": "HISTEwAAAAMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAMdsAg=="
+        },
+        {
+          "operation": "ward_query",
+          "requests": 2,
+          "errors": 0,
+          "latency_ms_p50": 12091.391,
+          "latency_ms_p90": 16793.599,
+          "latency_ms_p99": 16793.599,
+          "hdr_v2_base64": "HISTEwAAAAcAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAIXnAQL3CAI="
+        }
+      ],
+      "stable": false,
+      "breaches": [
+        "ward_query p99 16793.6ms > budget 1000ms",
+        "error rate 0.1515 > tolerance 0.0010"
+      ],
+      "generator_bound": false,
+      "resources": {
+        "sample_interval_s": 10,
+        "containers": [
+          {
+            "role": "sut",
+            "name": "cnf-ehrbase-java-ehrbase-java-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 3.0982740542501137,
+                "rss_bytes": 1729753088,
+                "blk_read_bytes": 12668928,
+                "blk_write_bytes": 757760,
+                "net_rx_bytes": 4509386473,
+                "net_tx_bytes": 5192235028
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 1.908226823202643,
+                "rss_bytes": 1729339392,
+                "blk_read_bytes": 12668928,
+                "blk_write_bytes": 757760,
+                "net_rx_bytes": 4509390481,
+                "net_tx_bytes": 5192242217
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 4.7532821850476745,
+                "rss_bytes": 1730404352,
+                "blk_read_bytes": 12824576,
+                "blk_write_bytes": 774144,
+                "net_rx_bytes": 4509422880,
+                "net_tx_bytes": 5192316416
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 2.9378467618209725,
+                "rss_bytes": 1730035712,
+                "blk_read_bytes": 12824576,
+                "blk_write_bytes": 774144,
+                "net_rx_bytes": 4509449638,
+                "net_tx_bytes": 5192369264
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 11.06605007703014,
+                "rss_bytes": 1732538368,
+                "blk_read_bytes": 12824576,
+                "blk_write_bytes": 774144,
+                "net_rx_bytes": 4509569620,
+                "net_tx_bytes": 5192609835
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 1.2402874820639287,
+                "rss_bytes": 1732096000,
+                "blk_read_bytes": 12824576,
+                "blk_write_bytes": 786432,
+                "net_rx_bytes": 4509573278,
+                "net_tx_bytes": 5192615649
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 3.3492678222674552,
+                "rss_bytes": 1735172096,
+                "blk_read_bytes": 12824576,
+                "blk_write_bytes": 786432,
+                "net_rx_bytes": 4509611187,
+                "net_tx_bytes": 5192704085
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 2.8575348486746623,
+                "rss_bytes": 1735192576,
+                "blk_read_bytes": 12824576,
+                "blk_write_bytes": 786432,
+                "net_rx_bytes": 4509617872,
+                "net_tx_bytes": 5192720633
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 12.169532409957686,
+                "rss_bytes": 1735651328,
+                "blk_read_bytes": 12824576,
+                "blk_write_bytes": 798720,
+                "net_rx_bytes": 4509680352,
+                "net_tx_bytes": 5192853743
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 1.5961694607798775,
+                "rss_bytes": 1735917568,
+                "blk_read_bytes": 12824576,
+                "blk_write_bytes": 798720,
+                "net_rx_bytes": 4509689379,
+                "net_tx_bytes": 5192870073
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 2.7132050413786146,
+                "rss_bytes": 1735512064,
+                "blk_read_bytes": 12824576,
+                "blk_write_bytes": 798720,
+                "net_rx_bytes": 4509712655,
+                "net_tx_bytes": 5192929789
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 3.1340119446028027,
+                "rss_bytes": 1735970816,
+                "blk_read_bytes": 12824576,
+                "blk_write_bytes": 811008,
+                "net_rx_bytes": 4509744918,
+                "net_tx_bytes": 5193000425
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 2.053945394452047,
+                "rss_bytes": 1736114176,
+                "blk_read_bytes": 12861440,
+                "blk_write_bytes": 811008,
+                "net_rx_bytes": 4509773252,
+                "net_tx_bytes": 5193060709
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 1.6076476859688882,
+                "rss_bytes": 1735892992,
+                "blk_read_bytes": 12861440,
+                "blk_write_bytes": 811008,
+                "net_rx_bytes": 4509829631,
+                "net_tx_bytes": 5193176637
+              },
+              {
+                "offset_s": 150,
+                "phase": "drain",
+                "cpu_pct": 2.262342201652799,
+                "rss_bytes": 1735933952,
+                "blk_read_bytes": 12861440,
+                "blk_write_bytes": 823296,
+                "net_rx_bytes": 4509853043,
+                "net_tx_bytes": 5193228933
+              }
+            ]
+          },
+          {
+            "role": "db",
+            "name": "cnf-ehrbase-java-ehrbase-java-db-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 1.414324916902246,
+                "rss_bytes": 2394963968,
+                "blk_read_bytes": 24138719232,
+                "blk_write_bytes": 74884132864,
+                "net_rx_bytes": 4442113517,
+                "net_tx_bytes": 1262156490
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 1.2479943492966095,
+                "rss_bytes": 2360020992,
+                "blk_read_bytes": 24138838016,
+                "blk_write_bytes": 74885140480,
+                "net_rx_bytes": 4442117953,
+                "net_tx_bytes": 1262159683
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 1.3979980263063687,
+                "rss_bytes": 2326253568,
+                "blk_read_bytes": 24139210752,
+                "blk_write_bytes": 74885148672,
+                "net_rx_bytes": 4442137125,
+                "net_tx_bytes": 1262186020
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 3.2705504418045566,
+                "rss_bytes": 2293506048,
+                "blk_read_bytes": 24139345920,
+                "blk_write_bytes": 74885390336,
+                "net_rx_bytes": 4442159837,
+                "net_tx_bytes": 1262200811
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 2.749652313045567,
+                "rss_bytes": 2227470336,
+                "blk_read_bytes": 24139681792,
+                "blk_write_bytes": 74885840896,
+                "net_rx_bytes": 4442347775,
+                "net_tx_bytes": 1262227078
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 1.4561155356290483,
+                "rss_bytes": 2195681280,
+                "blk_read_bytes": 24139935744,
+                "blk_write_bytes": 74886246400,
+                "net_rx_bytes": 4442351464,
+                "net_tx_bytes": 1262229968
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 0.7977276419925418,
+                "rss_bytes": 2195345408,
+                "blk_read_bytes": 24140140544,
+                "blk_write_bytes": 74886311936,
+                "net_rx_bytes": 4442363500,
+                "net_tx_bytes": 1262262777
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 218.74123726708783,
+                "rss_bytes": 2320838656,
+                "blk_read_bytes": 24527921152,
+                "blk_write_bytes": 74886451200,
+                "net_rx_bytes": 4442374472,
+                "net_tx_bytes": 1262267549
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 199.803710030795,
+                "rss_bytes": 2227777536,
+                "blk_read_bytes": 25879592960,
+                "blk_write_bytes": 74928914432,
+                "net_rx_bytes": 4442456378,
+                "net_tx_bytes": 1262296315
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 1.0187168457838316,
+                "rss_bytes": 2193039360,
+                "blk_read_bytes": 25879691264,
+                "blk_write_bytes": 74928914432,
+                "net_rx_bytes": 4442461306,
+                "net_tx_bytes": 1262302955
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 1.4882829092855174,
+                "rss_bytes": 2193211392,
+                "blk_read_bytes": 25880174592,
+                "blk_write_bytes": 74928922624,
+                "net_rx_bytes": 4442477378,
+                "net_tx_bytes": 1262322233
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 1.270555384782433,
+                "rss_bytes": 2189561856,
+                "blk_read_bytes": 25880305664,
+                "blk_write_bytes": 74929037312,
+                "net_rx_bytes": 4442483674,
+                "net_tx_bytes": 1262350977
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 0.9787908094936697,
+                "rss_bytes": 2189586432,
+                "blk_read_bytes": 25880788992,
+                "blk_write_bytes": 74929258496,
+                "net_rx_bytes": 4442526443,
+                "net_tx_bytes": 1262360926
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 0.6376118601891628,
+                "rss_bytes": 2189377536,
+                "blk_read_bytes": 25880944640,
+                "blk_write_bytes": 74929983488,
+                "net_rx_bytes": 4442605357,
+                "net_tx_bytes": 1262377543
+              },
+              {
+                "offset_s": 150,
+                "phase": "drain",
+                "cpu_pct": 59.62363513510609,
+                "rss_bytes": 2275098624,
+                "blk_read_bytes": 25999745024,
+                "blk_write_bytes": 74930622464,
+                "net_rx_bytes": 4442616856,
+                "net_tx_bytes": 1262395537
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "rate": 0.25,
+      "offered_load_sustained": 0.26666666666666666,
+      "operations": [
+        {
+          "operation": "adhoc_query",
+          "requests": 4,
+          "errors": 0,
+          "latency_ms_p50": 57.311,
+          "latency_ms_p90": 85.311,
+          "latency_ms_p99": 85.311,
+          "hdr_v2_base64": "HISTEwAAAAwAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAN1pApsCApMEAtMEAg=="
+        },
+        {
+          "operation": "composition_commit",
+          "requests": 1,
+          "errors": 1,
+          "latency_ms_p50": 269.567,
+          "latency_ms_p90": 269.567,
+          "latency_ms_p99": 269.567,
+          "hdr_v2_base64": "HISTEwAAAAQAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAALeQAQI="
+        },
+        {
+          "operation": "composition_read",
+          "requests": 8,
+          "errors": 0,
+          "latency_ms_p50": 24.799,
+          "latency_ms_p90": 94.143,
+          "latency_ms_p99": 94.143,
+          "hdr_v2_base64": "HISTEwAAABYAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAK9SAn8C7wMCcwKBAQLXAQL/DgL/DAI="
+        },
+        {
+          "operation": "composition_read_current",
+          "requests": 5,
+          "errors": 0,
+          "latency_ms_p50": 36.319,
+          "latency_ms_p90": 41.503,
+          "latency_ms_p99": 41.503,
+          "hdr_v2_base64": "HISTEwAAAA4AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJVaAuUFAtsBAlcC5wEC"
+        },
+        {
+          "operation": "composition_revision_history",
+          "requests": 5,
+          "errors": 0,
+          "latency_ms_p50": 35.551,
+          "latency_ms_p90": 259.455,
+          "latency_ms_p99": 259.455,
+          "hdr_v2_base64": "HISTEwAAAA8AAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAO9XAtMGAuMCAs8BAtMsAg=="
+        },
+        {
+          "operation": "composition_update",
+          "requests": 1,
+          "errors": 1,
+          "latency_ms_p50": 107.583,
+          "latency_ms_p90": 107.583,
+          "latency_ms_p99": 107.583,
+          "hdr_v2_base64": "HISTEwAAAAMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJ96Ag=="
+        },
+        {
+          "operation": "directory_read",
+          "requests": 4,
+          "errors": 0,
+          "latency_ms_p50": 21.855,
+          "latency_ms_p90": 55.135,
+          "latency_ms_p99": 55.135,
+          "hdr_v2_base64": "HISTEwAAAAwAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAItQApsFApcDAq0SAg=="
+        },
+        {
+          "operation": "ehr_status_read",
+          "requests": 1,
+          "errors": 0,
+          "latency_ms_p50": 63.839,
+          "latency_ms_p90": 63.839,
+          "latency_ms_p99": 63.839,
+          "hdr_v2_base64": "HISTEwAAAAMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJNvAg=="
+        },
+        {
+          "operation": "ehr_status_update",
+          "requests": 1,
+          "errors": 1,
+          "latency_ms_p50": 33.247,
+          "latency_ms_p90": 33.247,
+          "latency_ms_p99": 33.247,
+          "hdr_v2_base64": "HISTEwAAAAMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAJtgAg=="
+        },
+        {
+          "operation": "stored_query_execute",
+          "requests": 1,
+          "errors": 0,
+          "latency_ms_p50": 50.559,
+          "latency_ms_p90": 50.559,
+          "latency_ms_p99": 50.559,
+          "hdr_v2_base64": "HISTEwAAAAMAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAANVoAg=="
+        },
+        {
+          "operation": "ward_query",
+          "requests": 1,
+          "errors": 0,
+          "latency_ms_p50": 14065.663,
+          "latency_ms_p90": 14065.663,
+          "latency_ms_p99": 14065.663,
+          "hdr_v2_base64": "HISTEwAAAAQAAAAAAAAAAwAAAAAAAAABAAAAACPDRgA/8AAAAAAAAOfqAQI="
+        }
+      ],
+      "stable": false,
+      "breaches": [
+        "ward_query p99 14065.7ms > budget 1000ms",
+        "error rate 0.0938 > tolerance 0.0010"
+      ],
+      "generator_bound": false,
+      "resources": {
+        "sample_interval_s": 10,
+        "containers": [
+          {
+            "role": "sut",
+            "name": "cnf-ehrbase-java-ehrbase-java-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 1.4803958251822382,
+                "rss_bytes": 1736179712,
+                "blk_read_bytes": 12861440,
+                "blk_write_bytes": 823296,
+                "net_rx_bytes": 4509873556,
+                "net_tx_bytes": 5193271230
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 1.3895307799829841,
+                "rss_bytes": 1736437760,
+                "blk_read_bytes": 12861440,
+                "blk_write_bytes": 827392,
+                "net_rx_bytes": 4509877175,
+                "net_tx_bytes": 5193277637
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 4.076263321928144,
+                "rss_bytes": 1735884800,
+                "blk_read_bytes": 12861440,
+                "blk_write_bytes": 827392,
+                "net_rx_bytes": 4509882553,
+                "net_tx_bytes": 5193293822
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 1.2733635567192283,
+                "rss_bytes": 1735888896,
+                "blk_read_bytes": 12861440,
+                "blk_write_bytes": 827392,
+                "net_rx_bytes": 4509891815,
+                "net_tx_bytes": 5193312016
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 1.66444455316027,
+                "rss_bytes": 1736433664,
+                "blk_read_bytes": 12861440,
+                "blk_write_bytes": 839680,
+                "net_rx_bytes": 4509907753,
+                "net_tx_bytes": 5193349720
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 1.532676272739398,
+                "rss_bytes": 1735958528,
+                "blk_read_bytes": 12861440,
+                "blk_write_bytes": 839680,
+                "net_rx_bytes": 4509926884,
+                "net_tx_bytes": 5193396870
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 0.5992585695356533,
+                "rss_bytes": 1735958528,
+                "blk_read_bytes": 12861440,
+                "blk_write_bytes": 839680,
+                "net_rx_bytes": 4509929482,
+                "net_tx_bytes": 5193403838
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 0.7174408971208458,
+                "rss_bytes": 1735958528,
+                "blk_read_bytes": 12861440,
+                "blk_write_bytes": 839680,
+                "net_rx_bytes": 4509945216,
+                "net_tx_bytes": 5193440152
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 3.245871876216894,
+                "rss_bytes": 1736032256,
+                "blk_read_bytes": 12861440,
+                "blk_write_bytes": 847872,
+                "net_rx_bytes": 4509980273,
+                "net_tx_bytes": 5193484038
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 0.7837472023975948,
+                "rss_bytes": 1736032256,
+                "blk_read_bytes": 12861440,
+                "blk_write_bytes": 847872,
+                "net_rx_bytes": 4509984256,
+                "net_tx_bytes": 5193493901
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 1.36142767622196,
+                "rss_bytes": 1736032256,
+                "blk_read_bytes": 12861440,
+                "blk_write_bytes": 847872,
+                "net_rx_bytes": 4509990378,
+                "net_tx_bytes": 5193505962
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 1.4383051768260695,
+                "rss_bytes": 1736036352,
+                "blk_read_bytes": 12861440,
+                "blk_write_bytes": 856064,
+                "net_rx_bytes": 4510006919,
+                "net_tx_bytes": 5193547020
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 1.195591728488482,
+                "rss_bytes": 1736073216,
+                "blk_read_bytes": 12861440,
+                "blk_write_bytes": 856064,
+                "net_rx_bytes": 4510026340,
+                "net_tx_bytes": 5193588413
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 3.7140995017081226,
+                "rss_bytes": 1736232960,
+                "blk_read_bytes": 12861440,
+                "blk_write_bytes": 856064,
+                "net_rx_bytes": 4510120219,
+                "net_tx_bytes": 5193773115
+              },
+              {
+                "offset_s": 150,
+                "phase": "drain",
+                "cpu_pct": 2.9916731621524826,
+                "rss_bytes": 1737580544,
+                "blk_read_bytes": 12861440,
+                "blk_write_bytes": 868352,
+                "net_rx_bytes": 4510125369,
+                "net_tx_bytes": 5193786375
+              }
+            ]
+          },
+          {
+            "role": "db",
+            "name": "cnf-ehrbase-java-ehrbase-java-db-1",
+            "samples": [
+              {
+                "offset_s": 10,
+                "phase": "warmup",
+                "cpu_pct": 0.6950156644967354,
+                "rss_bytes": 2190389248,
+                "blk_read_bytes": 27586060288,
+                "blk_write_bytes": 74931503104,
+                "net_rx_bytes": 4442618571,
+                "net_tx_bytes": 1262414500
+              },
+              {
+                "offset_s": 20,
+                "phase": "warmup",
+                "cpu_pct": 1.3127595358620854,
+                "rss_bytes": 2157604864,
+                "blk_read_bytes": 27586109440,
+                "blk_write_bytes": 74931572736,
+                "net_rx_bytes": 4442621514,
+                "net_tx_bytes": 1262417197
+              },
+              {
+                "offset_s": 30,
+                "phase": "measured",
+                "cpu_pct": 228.71572387708684,
+                "rss_bytes": 2285305856,
+                "blk_read_bytes": 29213089792,
+                "blk_write_bytes": 74931572736,
+                "net_rx_bytes": 4442630790,
+                "net_tx_bytes": 1262421035
+              },
+              {
+                "offset_s": 40,
+                "phase": "measured",
+                "cpu_pct": 7.396512803685548,
+                "rss_bytes": 2158702592,
+                "blk_read_bytes": 29269495808,
+                "blk_write_bytes": 74931798016,
+                "net_rx_bytes": 4442635823,
+                "net_tx_bytes": 1262428991
+              },
+              {
+                "offset_s": 50,
+                "phase": "measured",
+                "cpu_pct": 1.323046051832597,
+                "rss_bytes": 2124234752,
+                "blk_read_bytes": 29269536768,
+                "blk_write_bytes": 74931798016,
+                "net_rx_bytes": 4442642024,
+                "net_tx_bytes": 1262443423
+              },
+              {
+                "offset_s": 60,
+                "phase": "measured",
+                "cpu_pct": 0.7024793606589083,
+                "rss_bytes": 2124484608,
+                "blk_read_bytes": 29269737472,
+                "blk_write_bytes": 74931855360,
+                "net_rx_bytes": 4442651718,
+                "net_tx_bytes": 1262460399
+              },
+              {
+                "offset_s": 70,
+                "phase": "measured",
+                "cpu_pct": 0.5501769606192384,
+                "rss_bytes": 2124214272,
+                "blk_read_bytes": 29269786624,
+                "blk_write_bytes": 74931863552,
+                "net_rx_bytes": 4442655288,
+                "net_tx_bytes": 1262462075
+              },
+              {
+                "offset_s": 80,
+                "phase": "measured",
+                "cpu_pct": 0.5588036766907046,
+                "rss_bytes": 2124537856,
+                "blk_read_bytes": 29269827584,
+                "blk_write_bytes": 74931863552,
+                "net_rx_bytes": 4442657527,
+                "net_tx_bytes": 1262476433
+              },
+              {
+                "offset_s": 90,
+                "phase": "measured",
+                "cpu_pct": 1.0645583575376811,
+                "rss_bytes": 2124283904,
+                "blk_read_bytes": 29269913600,
+                "blk_write_bytes": 74931863552,
+                "net_rx_bytes": 4442664233,
+                "net_tx_bytes": 1262492070
+              },
+              {
+                "offset_s": 100,
+                "phase": "measured",
+                "cpu_pct": 0.5916686715680387,
+                "rss_bytes": 2124845056,
+                "blk_read_bytes": 29269946368,
+                "blk_write_bytes": 74931863552,
+                "net_rx_bytes": 4442667458,
+                "net_tx_bytes": 1262495178
+              },
+              {
+                "offset_s": 110,
+                "phase": "measured",
+                "cpu_pct": 0.7183247852403004,
+                "rss_bytes": 2125025280,
+                "blk_read_bytes": 29270081536,
+                "blk_write_bytes": 74931867648,
+                "net_rx_bytes": 4442671990,
+                "net_tx_bytes": 1262500083
+              },
+              {
+                "offset_s": 120,
+                "phase": "measured",
+                "cpu_pct": 0.9503454410776265,
+                "rss_bytes": 2124627968,
+                "blk_read_bytes": 29270147072,
+                "blk_write_bytes": 74931994624,
+                "net_rx_bytes": 4442679507,
+                "net_tx_bytes": 1262514207
+              },
+              {
+                "offset_s": 130,
+                "phase": "measured",
+                "cpu_pct": 0.5527302415960285,
+                "rss_bytes": 2124701696,
+                "blk_read_bytes": 29270188032,
+                "blk_write_bytes": 74932051968,
+                "net_rx_bytes": 4442684505,
+                "net_tx_bytes": 1262530793
+              },
+              {
+                "offset_s": 140,
+                "phase": "measured",
+                "cpu_pct": 25.20233382673896,
+                "rss_bytes": 2222010368,
+                "blk_read_bytes": 29276696576,
+                "blk_write_bytes": 74932592640,
+                "net_rx_bytes": 4442864641,
+                "net_tx_bytes": 1262534623
+              },
+              {
+                "offset_s": 150,
+                "phase": "drain",
+                "cpu_pct": 257.0143890603226,
+                "rss_bytes": 2271784960,
+                "blk_read_bytes": 30644756480,
+                "blk_write_bytes": 74932592640,
+                "net_rx_bytes": 4442871058,
+                "net_tx_bytes": 1262538758
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "max_sustainable_throughput_per_s": 0.0,
+  "ladder_capped": false,
+  "generator_bound": false,
+  "remark": "Maximum sustainable throughput ≈ 0.0 arrivals/s on the cnf.scale.10k corpus (120s steps). Exploration only — never a conformance record; the first breached rung past this rate is where the system leaves the envelope."
+}

--- a/scripts/render-comparison.sh
+++ b/scripts/render-comparison.sh
@@ -197,7 +197,9 @@ JV_STRESS="$JV/stress.json"
 # step at the maximum sustainable rate; its worst per-operation p99 and its
 # sampled resource peaks summarize the knee honestly.
 mst() { jq -r '.max_sustainable_throughput_per_s | round' "$1"; }
-knee_p99() { jq -r '.max_sustainable_throughput_per_s as $m | [.steps[] | select(.rate == $m and .stable) | .operations[].latency_ms_p99] | max | round' "$1"; }
+# Every knee-step derivation tolerates a ZERO knee (no stable step — the
+# measured "cannot sustain the workload" case renders as an em dash).
+knee_p99() { jq -r '.max_sustainable_throughput_per_s as $m | [.steps[] | select(.rate == $m and .stable) | .operations[].latency_ms_p99] | if length == 0 then "—" else (max | round | tostring) end' "$1"; }
 knee_res() { # $1 file, $2 role, $3 field-expression over samples
   jq -r --arg role "$2" '.max_sustainable_throughput_per_s as $m
     | [.steps[] | select(.rate == $m and .stable) | .resources.containers[]? | select(.role == $role) | .samples[]'"$3"'] 

--- a/tools/cnf-runner/src/perf_run/corpus.rs
+++ b/tools/cnf-runner/src/perf_run/corpus.rs
@@ -18,7 +18,15 @@ use crate::perf_run::pack::JourneyPack;
 
 /// The stored query the ward dashboard executes continuously (registered
 /// once at seeding; `I_DEFINITION_QUERY.store_query` → wire 200).
-pub(crate) const STORED_QUERY_NAME: &str = "cnf.ward_dashboard";
+///
+/// NOTE: the namespaced form is the catalogue's own house convention —
+/// chosen as the workload constant so the workload runs on SUTs that
+/// (non-conformantly) reject the equally spec-valid namespace-less dotted
+/// form (ITS-REST `Qualified_query_name.md`: namespace optional, name
+/// charset `[a-zA-Z0-9_.-]`); that upstream non-conformance is recorded
+/// and catalogue-tested on its own tracker issue, never accommodated in
+/// any conformance expectation.
+pub(crate) const STORED_QUERY_NAME: &str = "org.openehr.cnf::ward_dashboard";
 
 /// The per-patient blood-pressure trend (the corpus contract's committed
 /// series), EHR-scoped via the `$ehr_id` binding — the ad-hoc read.

--- a/website/book/src/perf-assets/perf-stress-compare.svg
+++ b/website/book/src/perf-assets/perf-stress-compare.svg
@@ -1,0 +1,76 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 430" width="760" height="430" role="img">
+<style>
+text { fill: #52514e; font: 12px -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif; }
+.title { fill: #0b0b0b; font-weight: 600; }
+.muted { fill: #8a8880; font-size: 11px; }
+.grid { stroke: #e4e2dd; stroke-width: 1; }
+.p50 { fill: #7db4ea; } .p90 { fill: #3d7fd0; } .p99 { fill: #1b5cab; }
+.measured { fill: #2a78d6; }
+.floor { fill: none; stroke: #8a8880; stroke-width: 1.5; stroke-dasharray: 4 3; }
+.earned { fill: #1baf7a; font-weight: 600; }
+.notearned { fill: #b3261e; font-weight: 600; }
+.slo { stroke: #b3261e; stroke-width: 1.5; stroke-dasharray: 6 4; }
+.slotext { fill: #b3261e; font-size: 11px; }
+.sut { stroke: #2a78d6; fill: none; stroke-width: 1.8; }
+.db { stroke: #8a8880; fill: none; stroke-width: 1.6; stroke-dasharray: 5 3; }
+.warm { fill: #efede8; }
+.curve { stroke: #2a78d6; fill: none; stroke-width: 2; }
+.cmp { stroke: #8a8880; fill: none; stroke-width: 2; stroke-dasharray: 7 4; }
+.cmpfill { fill: #8a8880; }
+.knee { stroke: #1baf7a; stroke-width: 2; stroke-dasharray: 2 3; }
+@media (prefers-color-scheme: dark) {
+text { fill: #c3c2b7; }
+.title { fill: #ffffff; }
+.muted { fill: #8f8e85; }
+.grid { stroke: #3a3a38; }
+.p50 { fill: #3d5f82; } .p90 { fill: #3987e5; } .p99 { fill: #9ec7ef; }
+.measured { fill: #3987e5; }
+.floor { stroke: #8f8e85; }
+.earned { fill: #26c78d; }
+.notearned { fill: #e5484d; }
+.slo { stroke: #e5484d; }
+.slotext { fill: #e5484d; }
+.sut { stroke: #3987e5; }
+.db { stroke: #8f8e85; }
+.warm { fill: #2a2a28; }
+.curve { stroke: #3987e5; }
+.cmp { stroke: #8f8e85; }
+.cmpfill { fill: #8f8e85; }
+.knee { stroke: #26c78d; }
+}
+</style>
+<text x="24" y="28" class="title">Latency-throughput curves — both systems, the same step-load stress instrument</text>
+<text x="24" y="44" class="muted">Identical committed workload and ladder per side (120 s holds) · exploration only — never a conformance record</text>
+<line x1="24" y1="58" x2="52" y2="58" class="curve"/><circle cx="38" cy="58" r="4" class="measured"/><text x="58" y="62.0" class="muted">ehrbase-rs</text>
+<line x1="300" y1="58" x2="328" y2="58" class="cmp"/><rect x="310" y="54.0" width="8" height="8" class="cmpfill"/><text x="334" y="62.0" class="muted">upstream (Java)</text>
+<line x1="90.0" y1="96" x2="90.0" y2="360" class="grid"/><text x="90.0" y="376.0" class="muted" text-anchor="middle">1/s</text>
+<line x1="251.5" y1="96" x2="251.5" y2="360" class="grid"/><text x="251.5" y="376.0" class="muted" text-anchor="middle">10/s</text>
+<line x1="412.9" y1="96" x2="412.9" y2="360" class="grid"/><text x="412.9" y="376.0" class="muted" text-anchor="middle">100/s</text>
+<line x1="574.4" y1="96" x2="574.4" y2="360" class="grid"/><text x="574.4" y="376.0" class="muted" text-anchor="middle">1000/s</text>
+<line x1="90" y1="360.0" x2="700" y2="360.0" class="grid"/><text x="82.0" y="364.0" class="muted" text-anchor="end">1 ms</text>
+<line x1="90" y1="290.1" x2="700" y2="290.1" class="grid"/><text x="82.0" y="294.1" class="muted" text-anchor="end">10 ms</text>
+<line x1="90" y1="220.2" x2="700" y2="220.2" class="grid"/><text x="82.0" y="224.2" class="muted" text-anchor="end">100 ms</text>
+<line x1="90" y1="150.4" x2="700" y2="150.4" class="grid"/><text x="82.0" y="154.4" class="muted" text-anchor="end">1000 ms</text>
+<line x1="90" y1="150.4" x2="700" y2="150.4" class="slo"/><text x="696.0" y="144.4" class="slotext" text-anchor="end">p99 budget</text>
+<path d="M138.6,219.5 L187.2,220.0 L235.8,220.3 L284.4,226.2 L333.0,218.8 L381.6,231.0 L430.2,235.2 L478.8,239.8 L527.4,205.6 L535.7,151.5 L543.1,123.1 L555.9,161.5 L576.0,131.9" class="curve"/>
+<path d="M90.0,96.0 L90.0,96.0 L90.0,96.0 L138.6,96.0" class="cmp"/>
+<circle cx="138.6" cy="219.5" r="5" class="measured"/>
+<circle cx="187.2" cy="220.0" r="5" class="measured"/>
+<circle cx="235.8" cy="220.3" r="5" class="measured"/>
+<circle cx="284.4" cy="226.2" r="5" class="measured"/>
+<circle cx="333.0" cy="218.8" r="5" class="measured"/>
+<circle cx="381.6" cy="231.0" r="5" class="measured"/>
+<circle cx="430.2" cy="235.2" r="5" class="measured"/>
+<circle cx="478.8" cy="239.8" r="5" class="measured"/>
+<circle cx="527.4" cy="205.6" r="5" class="measured"/>
+<path d="M530.7,146.5 L540.7,156.5 M530.7,156.5 L540.7,146.5" class="slo" stroke-width="2"/>
+<path d="M538.1,118.1 L548.1,128.1 M538.1,128.1 L548.1,118.1" class="slo" stroke-width="2"/>
+<path d="M550.9,156.5 L560.9,166.5 M550.9,166.5 L560.9,156.5" class="slo" stroke-width="2"/>
+<path d="M571.0,126.9 L581.0,136.9 M571.0,136.9 L581.0,126.9" class="slo" stroke-width="2"/>
+<path d="M85.0,91.0 L95.0,101.0 M85.0,101.0 L95.0,91.0" class="slo" stroke-width="2"/>
+<path d="M85.0,91.0 L95.0,101.0 M85.0,101.0 L95.0,91.0" class="slo" stroke-width="2"/>
+<path d="M85.0,91.0 L95.0,101.0 M85.0,101.0 L95.0,91.0" class="slo" stroke-width="2"/>
+<path d="M133.6,91.0 L143.6,101.0 M133.6,101.0 L143.6,91.0" class="slo" stroke-width="2"/>
+<line x1="527.4" y1="96" x2="527.4" y2="360" class="knee"/><text x="90.0" y="394.0" class="earned">ehrbase-rs max sustainable 512/s</text>
+<line x1="90.0" y1="96" x2="90.0" y2="360" class="cmp"/><text x="90.0" y="412.0" class="muted">upstream (Java) max sustainable 0/s</text>
+</svg>


### PR DESCRIPTION
The workload's stored query moves to the catalogue's namespaced convention (owner call; both forms spec-valid — upstream's 400 on the dotted form stays recorded and catalogue-bound on #256), unblocking the upstream run. Its committed report: every rung breaches on the ward population query (14–20 s p99 at any rate on the 1M-composition corpus) — measured maximum sustainable 0 arrivals/s, published exactly as measured beside ehrbase-rs's 512/s. The overlay renders from both committed reports through the drift-guarded pipeline; the comparison knee table tolerates the zero-knee case. Fairness held: identical pack bytes (preflighted 204 on upstream), driver, ladder, host, settling.