### PR TITLE
Stored-query name grammar pinned + the interval/coded-text validation spec-overreach reverted

### DIFF
--- a/.claude/agent-memory/cnf-triage/MEMORY.md
+++ b/.claude/agent-memory/cnf-triage/MEMORY.md
@@ -2,5 +2,6 @@
 
 - [Results/wire evidence locations](results-evidence-locations.md) — where the observation, catalogue, and spec live
 - [SUT reproduction setup](sut-reproduction-setup.md) — composed SUT curl access + credentials
-- [cnf.opt.vitals is minimal_action, not a vitals OPT](cnf-opt-vitals-alias-mismatch.md) — a live catalogue defect: alias points at an ACTION template
+- [cnf.opt.vitals RESOLVED](cnf-opt-vitals-alias-mismatch.md) — was a catalogue defect; now a real body_temperature OBSERVATION (template_id cnf.vitals) — old attribution dead
+- [Interval + coded-text spec overreach](interval-and-coded-text-spec-overreach.md) — 2 confirmed app defects: DV_INTERVAL bound-presence + DV_CODED_TEXT value==rubric; both invent invariants the closed spec sets lack
 - [Runner driver gaps (confirmed)](runner-driver-gaps.md) — option-gating, header-mutation variants, ctx/ equivalence normalization

--- a/.claude/agent-memory/cnf-triage/cnf-opt-vitals-alias-mismatch.md
+++ b/.claude/agent-memory/cnf-triage/cnf-opt-vitals-alias-mismatch.md
@@ -1,30 +1,22 @@
 ---
 name: cnf-opt-vitals-alias-mismatch
-description: Live catalogue defect — cnf.opt.vitals resolves to minimal_action.en.v1, not a vitals OPT
+description: RESOLVED — cnf.opt.vitals is now a real body_temperature OBSERVATION (template_id cnf.vitals)
 metadata:
   type: project
 ---
 
-The corpus alias `cnf.opt.vitals` maps (MANIFEST.yaml) to
-`corpus/templates/vitals.opt`, whose actual `template_id` is
-`minimal_action.en.v1` — concept "Minimal action", a root ACTION archetype
-with web-template root `minimal` (NOT a vitals/body_temperature OBSERVATION).
+SUPERSEDED (verified on the wire 2026-07-23). The 2026-07-22 defect (the
+`cnf.opt.vitals` alias resolving to `minimal_action.en.v1`, an ACTION template)
+has been fixed. `tools/cnf-runner/artifacts/corpus/templates/vitals.opt` now
+carries `<template_id><value>cnf.vitals</value></template_id>` and IS a
+`openEHR-EHR-OBSERVATION.body_temperature.v1` carrier with a DV_QUANTITY
+temperature leaf (units Cel) and a `_normal_range` REFERENCE_RANGE. The SF flat
+fixtures `flat.normal_range.json` / `flat.all_types.json` commit against the
+`vitals/body_temperature:0/any_event:0/temperature...` paths and the SUT
+201-creates them (both interval bounds present).
 
-**Why:** it caused 8 red SF rows in the 2026-07-22 ehrbase-rs baseline. Every
-SF fixture/decision-table that references `vitals/body_temperature/.../temperature`
-(flat.multi_event, structured.vitals.minimal, structured.raw_quantity, and the
-SF-CTX/INDEX/MAP/NODEID content decision tables) commits against this alias and
-the SUT correctly 422s ("Simplified-Format conversion failed: unknown simplified
-path: vitals" — spec: ITS-REST simplified_formats master04 §Validation "Field
-identifiers match WT metadata structure"). Only `fixtures/flat/vitals.minimal_ctx.json`
-(root `minimal/minimal:0/...`) actually matches the template and commits (201).
-Each affected case core carries a TODO admitting "commits against the removed
-body_temperature carrier and 422s".
-
-**How to apply:** these are CATALOGUE artifact defects, not app/runner. The
-`created` expectation is wrong because the fixture is inconsistent with the bound
-template. Fix path: author/restore a real vitals OPT (with
-`openEHR-EHR-OBSERVATION.body_temperature.v1`, a repeating event, a DV_QUANTITY
-leaf) as `cnf.opt.vitals`, OR repoint the SF fixtures/tables to `cnf.opt.maximal`
-(`test_all_types.en.v1`) as the TODOs propose. Verify current state before
-re-attributing — an implementer may have fixed the corpus.
+**How to apply:** the old "SF vitals cases 422 on unknown simplified path"
+attribution is dead — do NOT reuse it. The corpus alias/template are consistent
+now. If an SF-MAP/vitals row is red today it is almost certainly the interval
+bound-presence app defect (a one-sided reference range with default
+`upper_unbounded=false`), see [[interval-and-coded-text-spec-overreach]].

--- a/.claude/agent-memory/cnf-triage/interval-and-coded-text-spec-overreach.md
+++ b/.claude/agent-memory/cnf-triage/interval-and-coded-text-spec-overreach.md
@@ -1,0 +1,43 @@
+---
+name: interval-and-coded-text-spec-overreach
+description: Two confirmed app-side validation overreaches — DV_INTERVAL bound-presence + DV_CODED_TEXT value==rubric
+metadata:
+  type: project
+---
+
+Two validation additions (build d09d9604c, 2026-07-23) enforce invariants the
+CLOSED openEHR invariant sets do not define — both are APPLICATION defects
+(spec overreach), both reproduced on the wire. The vendored spec is the oracle;
+"closing an acceptance hole" is not license to invent an invariant.
+
+1. **DV_INTERVAL bound-presence** (commit e9d2ec11f) —
+   `crates/openehr-rm/src/data_types/quantity/dv_interval_impl.rs`
+   `DvInterval::invariants` added `!lower_unbounded && lower.is_none()` (+ upper)
+   → 422 "lower/upper bound absent while *_unbounded is false on type
+   DV_INTERVAL". BASE `...foundation_types.interval.adoc`: `lower/upper` are
+   `0..1`; §Invariants is a closed 4-set (Lower/Upper_included_valid,
+   Limits_consistent, Limits_comparable) — NONE require a bound when the flag is
+   false. The repo's own register AMB-43 dispositions this ACCEPTED. The commit
+   also edited COUNT+QUANTITY validate_open case cores to expect `rejected`
+   (forbidden expectation-to-match-behaviour edit; masked green). Fix: revert
+   both blocks + both case-core edits.
+
+2. **DV_CODED_TEXT value==rubric** (commit e56245034, fed by WT-builder
+   43f9c5601) — `crates/openehr-flat/src/validation/leaf.rs`
+   `check_coded_text_rubric` → 422 "coded value 'X': value 'v' is not the bound
+   rubric". RM `...dv_text.adoc` §Invariants: the ONLY value invariant is
+   `Valid_value: not value.is_empty`; DV_CODED_TEXT adds only `defining_code
+   1..1`. "value must be the rubric" is prose and names the TERMINOLOGY SERVICE
+   (authoring language) as authority, NOT the template. CNF
+   CONT-DV_CODED_TEXT-validate_local_codes checks code_string+terminology_id vs
+   C_CODE_PHRASE, never value. When the OPT binds no term_definition rubric for
+   an external code, the WT fallback uses the code string as the label, so the
+   check degenerates to value==code. Fix: remove the check + its call site.
+
+**How to apply:** these caused all 8 red rows in the 2026-07-23 run
+(DV_CODED_TEXT-validate_local_codes + 6 DV_INTERVAL_*-validate_open +
+SF-MAP-interval_reference_range). ORDINAL/SCALE hit BOTH (row1 = bound-presence,
+rows4/5 = coded symbol value=code). Verify the two code paths still exist before
+re-attributing (an implementer may have reverted). Reproduction recipe in
+[[sut-reproduction-setup]]; the credential note there is correct
+(ehrbase-admin:ehrbase works — POST /ehr → 201).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,13 +146,6 @@ workflow refuses a tag that has no matching section here.
   terminology"). The qualified key now resolves; the covid19 example
   regenerates with rubrics; every pack example commits clean on strict
   validators.
-- **A `DV_INTERVAL` with an absent bound but a false `*_unbounded` flag is
-  now rejected at commit** (422 naming the rule): BASE `Interval`
-  semantics make a false unbounded flag assert a finite bound, and the
-  ITS-JSON schema requires all four boundary flags on the wire — the
-  previously-accepted flag-less half-open instance (whose missing flags
-  read as false) is a pinned rejection test at the wire boundary, and the
-  CNF interval decision tables gain the bound-presence rejection rows.
 - **Child-assembled `DV_INTERVAL` values now carry the mandatory boundary
   flags**: an interval built from `lower`/`upper` sub-path children (the
   FLAT builder's container path — template examples included) previously

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
+- **CNF catalogue: stored-query name-grammar cases** — three new
+  `definition_query` cases pin the ITS-REST `Qualified_query_name` grammar:
+  a plain unqualified name and a namespace-less dotted name (the dot is part
+  of the query-name character set, not a namespace separator) both store and
+  read back, and the reserved query-name `aql` is rejected case-insensitively.
 - **`cnf-runner stress-compare`** — the cross-SUT stress overlay: both
   systems' latency-throughput curves on one canvas, rendered
   deterministically from the two committed `stress.json` reports (driven
@@ -117,6 +122,11 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **Storing a query under the reserved name `aql` is now rejected** with
+  400, case-insensitively and whether or not a namespace is supplied
+  (ITS-REST `Qualified_query_name` §NOTE — the name would collide with the
+  ad-hoc `/query/aql` route). A three-part `ns::aql::name` name keeps
+  working: its middle segment is the formalism, not the query-name.
 - **A coded value whose text is not the template-bound rubric is now
   rejected at commit** (422 naming the path, the committed value, and
   the bound rubric): RM `DV_CODED_TEXT` — "value must be the rubric from

--- a/app/ehrbase-rest/src/api/definition/openapi_routes.rs
+++ b/app/ehrbase-rest/src/api/definition/openapi_routes.rs
@@ -575,8 +575,10 @@ pub(crate) async fn definition_query_list(
         (status = 200, description = "Stored; `Location` addresses the stored \
                                       query at its auto-assigned version.",
          body = serde_json::Value),
-        (status = 400, description = "The AQL fails to parse, or `query_type` is \
-                                      an unsupported non-AQL formalism.",
+        (status = 400, description = "The AQL fails to parse, `query_type` is \
+                                      an unsupported non-AQL formalism, or the \
+                                      query-name is the reserved `aql` \
+                                      (case-insensitive).",
          body = serde_json::Value)
     )
 )]
@@ -651,8 +653,10 @@ pub(crate) async fn definition_query_version_get(
         (status = 200, description = "Stored; `Location` addresses the stored \
                                       query at this version.",
          body = serde_json::Value),
-        (status = 400, description = "The AQL fails to parse, or `query_type` is \
-                                      an unsupported non-AQL formalism.",
+        (status = 400, description = "The AQL fails to parse, `query_type` is \
+                                      an unsupported non-AQL formalism, or the \
+                                      query-name is the reserved `aql` \
+                                      (case-insensitive).",
          body = serde_json::Value),
         (status = 409, description = "A stored query already exists at this \
                                       `(name, version)`.",

--- a/app/ehrbase/src/service/definition/query.rs
+++ b/app/ehrbase/src/service/definition/query.rs
@@ -389,6 +389,23 @@ impl EhrbaseService {
         version: Option<&str>,
         query_text: String,
     ) -> Result<String, ServiceError> {
+        // The bare query-name segment must not be the reserved name `aql`,
+        // case-insensitively (ITS-REST query Qualified_query_name §NOTE: "The
+        // `query-name` value must not be `aql` (case-insensitive), as that is
+        // a reserved name") — it would collide with the ad-hoc
+        // `GET /query/aql` route. Decomposed via the master04 schemes so a
+        // three-part name's *formalism* segment (`ns::aql::name`) is never
+        // mistaken for the query-name.
+        if parse_qualified_name(qualified_name)
+            .name
+            .eq_ignore_ascii_case("aql")
+        {
+            return Err(ServiceError::BadRequest(format!(
+                "`{qualified_name}`: the query-name `aql` is reserved \
+                 (ITS-REST Qualified_query_name)"
+            )));
+        }
+
         // Store-time AQL validation via the `openehr_query` parser: the
         // stored-query table only holds AQL (`query_type = 'AQL'`), so a non-AQL
         // or syntactically-invalid body is a `400 Bad Request`

--- a/app/ehrbase/tests/service_definition.rs
+++ b/app/ehrbase/tests/service_definition.rs
@@ -463,6 +463,66 @@ async fn query_store_rejects_non_aql_formalism() {
     .expect("AQL formalism stores");
 }
 
+/// The stored-query name grammar per ITS-REST query `Qualified_query_name`:
+/// the namespace is optional (`[{namespace}::]{query-name}`; `my_compositions`
+/// is a listed valid example), the query-name character set `[a-zA-Z0-9_.-]`
+/// admits dots and hyphens, and the query-name `aql` is reserved
+/// (case-insensitive, §NOTE).
+#[tokio::test]
+async fn query_store_name_grammar_and_reserved_name() {
+    let db = testkit::db().await.expect("testkit database");
+    let svc = EhrbaseService::new(db.pool());
+
+    let aql = "SELECT c FROM EHR e CONTAINS COMPOSITION c".to_owned();
+
+    // Namespace-less names — plain and dotted — store and read back.
+    for name in ["ward_dashboard_probe", "cnf.ward_dashboard-probe"] {
+        svc.query_store(name.to_owned(), None, "AQL".to_owned(), aql.clone())
+            .await
+            .unwrap_or_else(|e| panic!("namespace-less name `{name}` must store: {e:?}"));
+        let listed = svc
+            .query_list(name.to_owned())
+            .await
+            .unwrap_or_else(|e| panic!("`{name}` must be retrievable: {e:?}"));
+        assert!(
+            listed
+                .iter()
+                .any(|d| d.get("name").and_then(|v| v.as_str()) == Some(name)),
+            "the stored descriptor carries the namespace-less name verbatim: {listed:?}"
+        );
+    }
+
+    // The reserved query-name `aql` is rejected case-insensitively, with or
+    // without a namespace (Qualified_query_name §NOTE).
+    for name in ["aql", "AQL", "org.openehr::aql", "org.openehr::AQL"] {
+        let err = svc
+            .query_store(name.to_owned(), None, "AQL".to_owned(), aql.clone())
+            .await
+            .expect_err("the reserved query-name `aql` must be rejected");
+        assert!(
+            matches!(
+                err,
+                SmError {
+                    status: CallStatusType::PreconditionViolation,
+                    ..
+                }
+            ),
+            "`{name}` rejects as precondition_violation (wire 400), got {err:?}"
+        );
+    }
+
+    // A three-part name's MIDDLE `aql` is the formalism segment (SM master04
+    // §Registered Queries scheme 2), not the query-name — never reserved.
+    svc.query_store(
+        "task_planning::aql::chemotherapy_plans".to_owned(),
+        None,
+        "AQL".to_owned(),
+        aql,
+    )
+    .await
+    .expect("a three-part name with the `aql` formalism segment stores");
+}
+
 #[tokio::test]
 async fn opt_errors() {
     let db = testkit::db().await.expect("testkit database");

--- a/crates/openehr-flat/src/validation/leaf.rs
+++ b/crates/openehr-flat/src/validation/leaf.rs
@@ -136,66 +136,6 @@ fn check_coded_text(v: &mut Validator, instance: &Value, wt: &WebTemplateNode) {
         .and_then(|t| t.get("value"))
         .and_then(Value::as_str);
     check_code_membership(v, wt, code_input, code, terminology);
-    check_coded_text_rubric(v, instance, wt, code_input, code);
-}
-
-/// `DV_CODED_TEXT.value` must be the RUBRIC of the defining code (RM
-/// data_types `dv_coded_text.adoc`: "A text item whose value must be the
-/// rubric from a controlled terminology […] in the language in which the
-/// data were authored"). Checkable exactly when the template BINDS a
-/// rubric for the committed code (the coded-list entry's label /
-/// localized labels — local at-codes and qualified external
-/// `term_definitions` alike): the committed value must match one of the
-/// bound languages' rubrics. A code the template binds no rubric for
-/// stays accepted — the spec demand is only enforceable against a known
-/// rubric.
-fn check_coded_text_rubric(
-    v: &mut Validator,
-    instance: &Value,
-    wt: &WebTemplateNode,
-    code_input: &WebTemplateInput,
-    code: Option<&str>,
-) {
-    let Some(code) = code else { return };
-    // `openehr`-terminology rubrics belong to the TERMINOLOGY, not the
-    // template: TERM ships official translations (`433` is "event" in en,
-    // "evento" in es) beyond whatever single-language label the template
-    // carries, so a translated rubric is spec-valid data the template
-    // cannot enumerate — the check stays scoped to the rubrics the
-    // template itself is authoritative for (archetype-local at-codes and
-    // explicitly bound external term_definitions).
-    if code_input.terminology.as_deref() == Some("openehr") {
-        return;
-    }
-    let Some(value) = instance.get("value").and_then(Value::as_str) else {
-        return;
-    };
-    let Some(entry) = code_input.list.iter().find(|cv| cv.value == code) else {
-        return;
-    };
-    let mut bound = entry
-        .label
-        .iter()
-        .chain(entry.localized_labels.values())
-        .peekable();
-    if bound.peek().is_none() {
-        return; // no rubric bound — not checkable
-    }
-    if !bound.any(|rubric| rubric == value) {
-        let expected = entry
-            .label
-            .clone()
-            .or_else(|| entry.localized_labels.values().next().cloned())
-            .unwrap_or_default();
-        v.push(
-            &wt.aql_path,
-            format!(
-                "coded value '{code}': value '{value}' is not the bound rubric \
-                 (expected '{expected}')"
-            ),
-            ValidationKind::CodedValue,
-        );
-    }
 }
 
 fn check_code_phrase(v: &mut Validator, instance: &Value, wt: &WebTemplateNode) {

--- a/crates/openehr-flat/src/validation/mod.rs
+++ b/crates/openehr-flat/src/validation/mod.rs
@@ -1873,12 +1873,8 @@ mod tests {
             vec![ValidationKind::CodedValue]
         );
 
-        // The good instance carries the BOUND rubric as its value (RM
-        // dv_coded_text: value must be the rubric — enforced since the
-        // rubric check landed; this fixture's list binds the code string
-        // as its label).
         let good = json!({
-            "_type": "DV_CODED_TEXT", "value": "at0001",
+            "_type": "DV_CODED_TEXT", "value": "x",
             "defining_code": {"_type": "CODE_PHRASE",
                 "terminology_id": {"_type": "TERMINOLOGY_ID", "value": "local"},
                 "code_string": "at0001"}

--- a/crates/openehr-flat/tests/validation_checklist.rs
+++ b/crates/openehr-flat/tests/validation_checklist.rs
@@ -362,11 +362,8 @@ fn bullet7_terminology_bindings_valid() {
     )];
     leaf.inputs = vec![input];
     let coded_wt = wt_of(leaf);
-    // value = the bound rubric for the in-list code (RM dv_coded_text:
-    // value must be the rubric; the out-of-list code binds none, and the
-    // CodedValue kind under test fires on membership either way).
     let coded = |code: &str| {
-        json!({"_type": "DV_CODED_TEXT", "value": "at0001",
+        json!({"_type": "DV_CODED_TEXT", "value": "x",
                "defining_code": {"_type": "CODE_PHRASE",
                    "terminology_id": {"_type": "TERMINOLOGY_ID", "value": "local"},
                    "code_string": code}})

--- a/crates/openehr-flat/tests/validation_rules.rs
+++ b/crates/openehr-flat/tests/validation_rules.rs
@@ -331,11 +331,8 @@ fn coded_value_not_in_list() {
         vec![ValidationKind::CodedValue]
     );
 
-    // The good instance carries the BOUND rubric as its value (RM
-    // dv_coded_text: value must be the rubric; this fixture's list binds
-    // the code string as its label).
     let good = json!({
-        "_type": "DV_CODED_TEXT", "value": "at0001",
+        "_type": "DV_CODED_TEXT", "value": "x",
         "defining_code": {"_type": "CODE_PHRASE",
             "terminology_id": {"_type": "TERMINOLOGY_ID", "value": "local"},
             "code_string": "at0001"}
@@ -378,9 +375,9 @@ fn coded_value_explicit_local_rejects_foreign_terminology() {
         vec![ValidationKind::CodedValue],
         "an explicit-local closed C_CODE_PHRASE must reject a foreign-terminology code"
     );
-    // A local code in the list is clean (value = the bound rubric).
+    // A local code in the list is clean.
     let good = json!({
-        "_type": "DV_CODED_TEXT", "value": "ABC",
+        "_type": "DV_CODED_TEXT", "value": "abc",
         "defining_code": {"_type": "CODE_PHRASE",
             "terminology_id": {"_type": "TERMINOLOGY_ID", "value": "local"},
             "code_string": "ABC"}
@@ -1717,57 +1714,4 @@ fn non_locatable_context_matches_structurally_locatable_still_needs_node_id() {
         "a LOCATABLE node still requires its archetype_node_id: {:?}",
         walk_only(&bad, &root)
     );
-}
-
-/// RM `data_types` `dv_coded_text.adoc`: "A text item whose value must be
-/// the rubric from a controlled terminology". Enforceable exactly when
-/// the template binds a rubric for the committed code — the once-accepted
-/// code-as-value instance rejects; a code the template binds no rubric
-/// for stays accepted (the demand is uncheckable without a known rubric).
-#[test]
-fn coded_text_value_must_be_the_bound_rubric() {
-    let mut n = node("DV_CODED_TEXT", "/coded");
-    let mut input = WebTemplateInput::new(WebTemplateInputType::CodedText, Some("code"));
-    input.terminology = Some("SNOMED-CT".to_owned());
-    input.list = vec![WebTemplateCodedValue::new(
-        "1240741000000103",
-        Some("2019-nCoV (novel coronavirus) serology".to_owned()),
-    )];
-    n.inputs = vec![input];
-
-    // The defect instance: the raw code reused as the display value.
-    let code_as_value = json!({
-        "_type": "DV_CODED_TEXT", "value": "1240741000000103",
-        "defining_code": {"_type": "CODE_PHRASE",
-            "terminology_id": {"_type": "TERMINOLOGY_ID", "value": "SNOMED-CT"},
-            "code_string": "1240741000000103"}
-    });
-    assert_eq!(
-        kinds(&walk_only(&code_as_value, &n)),
-        vec![ValidationKind::CodedValue],
-        "code-as-value must reject against a bound rubric"
-    );
-
-    // The rubric as value is clean.
-    let with_rubric = json!({
-        "_type": "DV_CODED_TEXT", "value": "2019-nCoV (novel coronavirus) serology",
-        "defining_code": {"_type": "CODE_PHRASE",
-            "terminology_id": {"_type": "TERMINOLOGY_ID", "value": "SNOMED-CT"},
-            "code_string": "1240741000000103"}
-    });
-    assert!(walk_only(&with_rubric, &n).is_empty());
-
-    // A rubric-less bound code: any value stays accepted (not checkable).
-    let mut open_node = node("DV_CODED_TEXT", "/coded");
-    let mut open_input = WebTemplateInput::new(WebTemplateInputType::CodedText, Some("code"));
-    open_input.terminology = Some("SNOMED-CT".to_owned());
-    open_input.list = vec![WebTemplateCodedValue::new("999", None)];
-    open_node.inputs = vec![open_input];
-    let free_value = json!({
-        "_type": "DV_CODED_TEXT", "value": "whatever the authoring system rendered",
-        "defining_code": {"_type": "CODE_PHRASE",
-            "terminology_id": {"_type": "TERMINOLOGY_ID", "value": "SNOMED-CT"},
-            "code_string": "999"}
-    });
-    assert!(walk_only(&free_value, &open_node).is_empty());
 }

--- a/crates/openehr-its/tests/rm_validation.rs
+++ b/crates/openehr-its/tests/rm_validation.rs
@@ -717,27 +717,24 @@ fn terminology_uncoded_and_absent_slots_are_skipped() {
     assert!(terminology_of("ISM_TRANSITION", &no_transition).is_empty());
 }
 
-/// The pinned rejection of the once-accepted wire instance: a half-open
-/// `DV_INTERVAL` carrying NO boundary flags (the ITS-JSON schema requires
-/// all four — `INTERVAL`/`DV_INTERVAL` `required`). The tolerant read defaults
-/// the missing flags to `false`, and the bound-presence rule then rejects
-/// the absent lower bound (BASE `foundation_types` `Interval`:
-/// `lower_unbounded` false asserts a finite bound). A properly-flagged
-/// half-open interval stays clean.
+/// A half-open `DV_INTERVAL` is ACCEPTED whether or not its boundary flags
+/// are present on the wire. BASE
+/// `org.openehr.base.foundation_types.interval.adoc` declares `lower`/`upper`
+/// as 0..1 with a CLOSED four-invariant set (`Limits_consistent`,
+/// `Limits_comparable`, `Lower/Upper_included_valid`) — no invariant requires
+/// a bound value when its `*_unbounded` flag is false; the guarded
+/// implications are unevaluable then and skip (AMB-43 disposition, ACCEPTED).
+/// The tolerant read defaults missing flags to `false`, which violates
+/// nothing.
 #[test]
-fn flagless_half_open_interval_is_rejected() {
-    let stale_wire = json!({
+fn half_open_interval_is_accepted_with_or_without_flags() {
+    let flagless = json!({
         "_type": "DV_INTERVAL",
         "upper": {"_type": "DV_DURATION", "value": "PT1S"}
     });
-    let violations = full(&stale_wire);
-    assert!(
-        violations.iter().any(|iv| iv.message
-            == "lower bound absent while lower_unbounded is false on type DV_INTERVAL"),
-        "got {violations:?}"
-    );
+    assert!(full(&flagless).is_empty(), "got {:?}", full(&flagless));
 
-    let proper = json!({
+    let flagged = json!({
         "_type": "DV_INTERVAL",
         "upper": {"_type": "DV_DURATION", "value": "PT1S"},
         "lower_unbounded": true,
@@ -745,5 +742,5 @@ fn flagless_half_open_interval_is_rejected() {
         "lower_included": false,
         "upper_included": true
     });
-    assert!(full(&proper).is_empty(), "got {:?}", full(&proper));
+    assert!(full(&flagged).is_empty(), "got {:?}", full(&flagged));
 }

--- a/crates/openehr-rm/src/data_types/quantity/dv_interval_impl.rs
+++ b/crates/openehr-rm/src/data_types/quantity/dv_interval_impl.rs
@@ -72,25 +72,14 @@ impl<T: OrderedLimit> Validate for DvInterval<T> {
                 "Invariant Upper_included_valid failed on type DV_INTERVAL",
             ));
         }
-        // Bound presence: `lower_unbounded` is "True if lower boundary open
-        // (i.e. = -infinity)" (BASE foundation_types `Interval`), so false
-        // asserts a FINITE bound — an absent one leaves `Limits_consistent`
-        // and `has()` unevaluable, and the ITS-JSON schema makes all four
-        // boundary flags required on the wire (INTERVAL/DV_INTERVAL
-        // `required`), so a flag-less half-open instance whose missing
-        // flags read as false must reject here rather than pass unchecked.
-        // NOTE: no NAMED openEHR invariant states this — our enforcement of
-        // the class semantics above (spec-silent on the name, not the rule).
-        if !self.lower_unbounded && self.lower.is_none() {
-            out.push(InvariantViolation::here(
-                "lower bound absent while lower_unbounded is false on type DV_INTERVAL",
-            ));
-        }
-        if !self.upper_unbounded && self.upper.is_none() {
-            out.push(InvariantViolation::here(
-                "upper bound absent while upper_unbounded is false on type DV_INTERVAL",
-            ));
-        }
+        // NOTE: an absent bound with a false `*_unbounded` flag is ACCEPTED.
+        // BASE `org.openehr.base.foundation_types.interval.adoc` declares
+        // `lower`/`upper` as 0..1 and its §Invariants set is closed
+        // (Limits_consistent, Limits_comparable, Lower/Upper_included_valid) —
+        // no invariant requires a bound VALUE when its flag is false; the
+        // guarded `Limits_consistent`/`Limits_comparable` implications are
+        // simply unevaluable then and are skipped, never a rejection
+        // (AMB-43 disposition in the CNF ambiguity register).
         // Limits_consistent: bounded on both sides implies the limits are
         // strictly comparable and lower <= upper.
         if !self.lower_unbounded
@@ -170,10 +159,11 @@ mod tests {
     }
 
     #[test]
-    fn absent_bound_with_bounded_flag_rejects() {
-        // The acceptance hole this rule closes: a half-open interval whose missing wire
-        // flags read as false (lower None, lower_unbounded false) must
-        // violate — BASE Interval semantics + the ITS-JSON required flags.
+    fn absent_bound_with_bounded_flag_is_accepted() {
+        // BASE Interval: `lower`/`upper` are 0..1 and the closed invariant
+        // set has no bound-presence rule — an absent bound with a false
+        // `*_unbounded` flag violates nothing (the guarded Limits_consistent
+        // implication is unevaluable and skipped; AMB-43, ACCEPTED).
         let half_open = DvInterval::<DvQuantity> {
             lower: None,
             upper: Some(quantity(1.0, "s")),
@@ -182,13 +172,8 @@ mod tests {
             lower_included: false,
             upper_included: false,
         };
-        let v = half_open.invariants();
-        assert!(
-            v.iter().any(|m| m.message
-                == "lower bound absent while lower_unbounded is false on type DV_INTERVAL"),
-            "got {v:?}"
-        );
-        // The PROPER half-open form (lower_unbounded true) is clean.
+        assert!(half_open.invariants().is_empty());
+        // The flagged half-open form is equally clean.
         let proper = DvInterval::<DvQuantity> {
             lower: None,
             upper: Some(quantity(1.0, "s")),
@@ -207,12 +192,7 @@ mod tests {
             lower_included: true,
             upper_included: false,
         };
-        let v = no_upper.invariants();
-        assert!(
-            v.iter().any(|m| m.message
-                == "upper bound absent while upper_unbounded is false on type DV_INTERVAL"),
-            "got {v:?}"
-        );
+        assert!(no_upper.invariants().is_empty());
     }
 
     #[test]

--- a/docs/conformance/COMPARISON.md
+++ b/docs/conformance/COMPARISON.md
@@ -26,7 +26,7 @@
 
 ## Methodology
 
-Both systems execute the **same committed CNF 2.0 catalogue** (390 case-by-format
+Both systems execute the **same committed CNF 2.0 catalogue** (393 case-by-format
 executions) through the same reference runner (`tools/cnf-runner`), each on
 fresh volumes with its own committed party set: the ixit names the reachable
 instances (upstream declares no readonly principal), and the statement (the
@@ -52,8 +52,8 @@ runner, each with its own committed party statement.
 
 | | executed | passed | failed | errored | skipped | N/A |
 |---|---|---|---|---|---|---|
-| **ehrbase-rs** | 390 | 323 | 0 | 0 | 0 | 67 |
-| **upstream (Java)** | 390 | 158 | 126 | 38 | 0 | 68 |
+| **ehrbase-rs** | 393 | 326 | 0 | 0 | 0 | 67 |
+| **upstream (Java)** | 393 | 159 | 128 | 38 | 0 | 68 |
 
 An **errored** row is inconclusive (the wire answered outside the operation's
 bound outcome map), never counted as a failure. An **N/A** row carries a
@@ -131,6 +131,7 @@ case ran), **no_cases**, or **not claimed** (absent from that party's ICS).
 | I_EHR_CONTRIBUTION | 4 |
 | I_EHR_DIRECTORY | 4 |
 | I_DEFINITION_ADL2 | 3 |
+| I_DEFINITION_QUERY | 2 |
 | I_ADMIN_SERVICE | 1 |
 | I_DEFINITION_ADL14 | 1 |
 | I_EHR_SERVICE | 1 |
@@ -192,6 +193,8 @@ case ran), **no_cases**, or **not claimed** (absent from that party's ICS).
 | I_DEFINITION_ADL2.get_artefact-example | canonical-json | expected `ok`, observed `not_acceptable` | passed |
 | I_DEFINITION_ADL2.get_artefact-example_unknown | — | expected `not_found`, observed `not_acceptable` | passed |
 | I_DEFINITION_ADL2.get_artefact-retrieve | — | expected `ok`, observed `not_found` | passed |
+| I_DEFINITION_QUERY.store_query-dotted_name | — | expected `stored`, observed `validation_failed` | passed |
+| I_DEFINITION_QUERY.store_query-unqualified_name | — | expected `stored`, observed `validation_failed` | passed |
 | I_EHR_COMPOSITION.get_composition_at_time | — | equivalent: retrieved content differs from committed (modulo the normative ignore-set); go | passed |
 | I_EHR_COMPOSITION.get_composition_at_time-no_time_arg | — | expected `updated`, observed `precondition_missing` | passed |
 | I_EHR_COMPOSITION.get_composition_at_times | — | expected `updated`, observed `precondition_missing` | passed |

--- a/docs/conformance/ehrbase-java/CONFORMANCE_CERTIFICATE.md
+++ b/docs/conformance/ehrbase-java/CONFORMANCE_CERTIFICATE.md
@@ -6,7 +6,7 @@
 | --- | --- |
 | Solution | ehrbase-java 2.34.0 |
 | Vendor | EHRbase (vitagroup / upstream open-source project) |
-| Runner | cnf-runner 3.6.0 |
+| Runner | cnf-runner 3.7.0 |
 | Infrastructure | — |
 
 ## Scope of Test
@@ -15,6 +15,7 @@
 | --- | --- |
 | Functional | CORE, STANDARD |
 | Sec & Priv | — |
+| Performance | — |
 | Ext Data Fmt | canonical-json |
 
 ## Profile Report

--- a/docs/conformance/ehrbase-java/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ehrbase-java/CONFORMANCE_REPORT.md
@@ -1,18 +1,18 @@
 # Conformance Report
 
 SUT: ehrbase-java 2.34.0 · schedule cnf-2.0-w2 · ITS its-rest
-Runner: cnf-runner 3.6.0 · verification pack: passed
+Runner: cnf-runner 3.7.0 · verification pack: passed
 
 ## Summary
 
 | Status | Count |
 | --- | --- |
-| passed | 158 |
-| failed | 126 |
+| passed | 159 |
+| failed | 128 |
 | errored | 38 |
 | skipped | 0 |
 | not_applicable | 68 |
-| total | 390 |
+| total | 393 |
 
 ## By chapter
 
@@ -24,7 +24,7 @@ Runner: cnf-runner 3.6.0 · verification pack: passed
 | I_ADMIN_SERVICE | 1 | 1 | 0 | 0 | 10 |
 | I_DEFINITION_ADL14 | 3 | 1 | 5 | 0 | 8 |
 | I_DEFINITION_ADL2 | 1 | 3 | 12 | 0 | 8 |
-| I_DEFINITION_QUERY | 7 | 0 | 0 | 0 | 0 |
+| I_DEFINITION_QUERY | 8 | 2 | 0 | 0 | 0 |
 | I_DEMOGRAPHIC_SERVICE | 4 | 0 | 8 | 0 | 12 |
 | I_EHR_COMPOSITION | 19 | 9 | 4 | 0 | 0 |
 | I_EHR_CONTRIBUTION | 22 | 4 | 1 | 0 | 5 |

--- a/docs/conformance/ehrbase-java/badge-performance.json
+++ b/docs/conformance/ehrbase-java/badge-performance.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "openEHR CNF performance",
+  "message": "not measured",
+  "color": "lightgrey"
+}

--- a/docs/conformance/ehrbase-java/badge.json
+++ b/docs/conformance/ehrbase-java/badge.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "openEHR conformance",
-  "message": "NOT PASSING \u00b7 158/322 cases",
+  "message": "NOT PASSING \u00b7 159/325 cases",
   "color": "red"
 }

--- a/docs/conformance/ehrbase-java/results.json
+++ b/docs/conformance/ehrbase-java/results.json
@@ -5,7 +5,7 @@
   },
   "runner": {
     "name": "cnf-runner",
-    "version": "3.6.0",
+    "version": "3.7.0",
     "verification_pack_status": "passed"
   },
   "schedule_release": "cnf-2.0-w2",
@@ -15,7 +15,7 @@
       "canonical-json"
     ]
   },
-  "ixit_digest": "50fd94ddd3ef0d1e",
+  "ixit_digest": "bd88c8dadd68a7ce",
   "outcomes": [
     {
       "case": "I_DEFINITION_ADL14.get_opts-retrieve_all_no_opts",
@@ -4236,6 +4236,42 @@
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
+    },
+    {
+      "case": "I_DEFINITION_QUERY.store_query-dotted_name",
+      "status": "failed",
+      "rows_driven": 1,
+      "rows_total": 1,
+      "failing_step": 1,
+      "reason": "expected `stored`, observed `validation_failed`",
+      "failed_rows": [
+        {
+          "row": 0,
+          "step": 1,
+          "reason": "expected `stored`, observed `validation_failed`"
+        }
+      ]
+    },
+    {
+      "case": "I_DEFINITION_QUERY.store_query-reserved_name",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEFINITION_QUERY.store_query-unqualified_name",
+      "status": "failed",
+      "rows_driven": 1,
+      "rows_total": 1,
+      "failing_step": 1,
+      "reason": "expected `stored`, observed `validation_failed`",
+      "failed_rows": [
+        {
+          "row": 0,
+          "step": 1,
+          "reason": "expected `stored`, observed `validation_failed`"
+        }
+      ]
     },
     {
       "case": "I_DEFINITION_QUERY.valid_query-bad_formalism",

--- a/docs/conformance/ehrbase-java/verdicts.json
+++ b/docs/conformance/ehrbase-java/verdicts.json
@@ -173,6 +173,7 @@
     ]
   ],
   "security": null,
+  "performance": [],
   "coverage": {
     "selected": 255,
     "driven": 237

--- a/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
@@ -7,12 +7,12 @@ Runner: cnf-runner 3.7.0 · verification pack: passed
 
 | Status | Count |
 | --- | --- |
-| passed | 323 |
+| passed | 326 |
 | failed | 0 |
 | errored | 0 |
 | skipped | 0 |
 | not_applicable | 67 |
-| total | 390 |
+| total | 393 |
 
 ## By chapter
 
@@ -24,7 +24,7 @@ Runner: cnf-runner 3.7.0 · verification pack: passed
 | I_ADMIN_SERVICE | 2 | 0 | 0 | 0 | 10 |
 | I_DEFINITION_ADL14 | 9 | 0 | 0 | 0 | 8 |
 | I_DEFINITION_ADL2 | 16 | 0 | 0 | 0 | 8 |
-| I_DEFINITION_QUERY | 7 | 0 | 0 | 0 | 0 |
+| I_DEFINITION_QUERY | 10 | 0 | 0 | 0 | 0 |
 | I_DEMOGRAPHIC_SERVICE | 12 | 0 | 0 | 0 | 12 |
 | I_EHR_COMPOSITION | 32 | 0 | 0 | 0 | 0 |
 | I_EHR_CONTRIBUTION | 27 | 0 | 0 | 0 | 5 |
@@ -73,7 +73,7 @@ Percentiles re-derive from the embedded HDR V2 histograms; the class verdict is 
 
 ## Honesty
 
-Coverage: 323 of 390 selected cases driven.
+Coverage: 326 of 393 selected cases driven.
 
 Not-executed verdicts (each cited):
 

--- a/docs/conformance/ehrbase-rs/badge.json
+++ b/docs/conformance/ehrbase-rs/badge.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "openEHR conformance",
-  "message": "CORE+STANDARD PASS \u00b7 323/323 cases",
+  "message": "CORE+STANDARD PASS \u00b7 326/326 cases",
   "color": "brightgreen"
 }

--- a/docs/conformance/ehrbase-rs/results.json
+++ b/docs/conformance/ehrbase-rs/results.json
@@ -15,7 +15,7 @@
       "canonical-json"
     ]
   },
-  "ixit_digest": "4ef725fd7a51445e",
+  "ixit_digest": "f902513124f7e8de",
   "outcomes": [
     {
       "case": "I_DEFINITION_ADL14.get_opts-retrieve_all_no_opts",
@@ -1341,6 +1341,24 @@
     },
     {
       "case": "I_DEFINITION_QUERY.list_queries-select_items",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEFINITION_QUERY.store_query-dotted_name",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEFINITION_QUERY.store_query-reserved_name",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEFINITION_QUERY.store_query-unqualified_name",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1

--- a/docs/conformance/ehrbase-rs/verdicts.json
+++ b/docs/conformance/ehrbase-rs/verdicts.json
@@ -183,7 +183,7 @@
     }
   ],
   "coverage": {
-    "selected": 390,
-    "driven": 323
+    "selected": 393,
+    "driven": 326
   }
 }

--- a/tools/cnf-runner/artifacts/schedule/content/CONT-DV_INTERVAL_DV_COUNT-validate_open.yaml
+++ b/tools/cnf-runner/artifacts/schedule/content/CONT-DV_INTERVAL_DV_COUNT-validate_open.yaml
@@ -32,5 +32,3 @@ decision_table:
     - [null, null, true, true, true, false, rejected, ["rm_invariant(lower_included_valid): lower_included must be false when lower is unbounded"]]
     - [0, null, false, true, false, true, rejected, ["rm_invariant(upper_included_valid): upper_included must be false when upper is unbounded"]]
     - [200, 100, false, false, true, true, rejected, ["rm_invariant(limits_consistent): lower must not exceed upper"]]
-    - [null, 100, false, false, false, true, rejected, ["rm_schema: lower bound absent while lower_unbounded is false (BASE Interval: a false unbounded flag asserts a finite bound; ITS-JSON requires the boundary flags)"]]
-    - [0, null, false, false, true, false, rejected, ["rm_schema: upper bound absent while upper_unbounded is false (BASE Interval: a false unbounded flag asserts a finite bound; ITS-JSON requires the boundary flags)"]]

--- a/tools/cnf-runner/artifacts/schedule/content/CONT-DV_INTERVAL_DV_QUANTITY-validate_open.yaml
+++ b/tools/cnf-runner/artifacts/schedule/content/CONT-DV_INTERVAL_DV_QUANTITY-validate_open.yaml
@@ -30,5 +30,3 @@ decision_table:
     - [null, null, true, true, true, false, rejected, ["rm_invariant(lower_included_valid): lower_included must be false when lower is unbounded"]]
     - ["0 mg", null, false, true, false, true, rejected, ["rm_invariant(upper_included_valid): upper_included must be false when upper is unbounded"]]
     - ["200 mg", "100 mg", false, false, true, true, rejected, ["rm_invariant(limits_consistent): lower must not exceed upper"]]
-    - [null, "100 mg", false, false, false, true, rejected, ["rm_schema: lower bound absent while lower_unbounded is false (BASE Interval: a false unbounded flag asserts a finite bound; ITS-JSON requires the boundary flags)"]]
-    - ["0 mg", null, false, false, true, false, rejected, ["rm_schema: upper bound absent while upper_unbounded is false (BASE Interval: a false unbounded flag asserts a finite bound; ITS-JSON requires the boundary flags)"]]

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-dotted_name.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-dotted_name.yaml
@@ -1,0 +1,36 @@
+# Catalogue addition beyond the official master05 cells (which are TBD
+# placeholders): the stored-query NAME GRAMMAR, dotted variant. ITS-REST
+# query Qualified_query_name defines the query-name character set as
+# "[a-zA-Z0-9_.-]" — the DOT (and hyphen) are legal INSIDE a query-name and
+# are NOT a namespace separator (the separator is `::`, and the namespace is
+# optional). A namespace-less dotted name like `cnf.ward_dashboard-probe`
+# is therefore spec-valid and must store; a server that misreads the dot as
+# a namespace separator and rejects it is non-conformant.
+id: I_DEFINITION_QUERY.store_query-dotted_name
+kind: functional
+component: DEFINITION_QUERY
+sm_operation: I_DEFINITION_QUERY.store_query
+capabilities: [QueryProvisioning]
+profiles: [STANDARD]
+test_purpose: "A namespace-less DOTTED stored-query name (dot inside the query-name, no `::`) is accepted and the query is retrievable under it."
+description: "store_query under a namespace-less dotted name (query-name charset [a-zA-Z0-9_.-])"
+spec_refs:
+  - "ITS-REST Qualified_query_name §query-name character pattern"
+  - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
+guards:
+  - "master05 is TBD upstream: flows derived from the SM operation semantics and the stored-query Definitions API — CNF platform_test_schedule master05 (all cells xx/TBD); AMB-38"
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+requires: { server: empty }
+flow:
+  - step: 1
+    call: store_query
+    with:
+      qualified_query_name: "cnf.ward_dashboard-probe"
+      query: "SELECT c FROM EHR e CONTAINS COMPOSITION c"
+    expect: stored
+  - step: 2
+    call: has_query
+    with: { qualified_query_name: "cnf.ward_dashboard-probe" }
+    expect: ok
+    assert:
+      - { assert: returns, equals: true }   # registered under the dotted name

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-reserved_name.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-reserved_name.yaml
@@ -1,0 +1,34 @@
+# Catalogue addition beyond the official master05 cells (which are TBD
+# placeholders): the stored-query RESERVED NAME. ITS-REST query
+# Qualified_query_name §NOTE: "The `query-name` value must not be `aql`
+# (case-insensitive), as that is a reserved name" — it would collide with
+# the ad-hoc `GET /query/aql` route. A store under the reserved name must
+# be rejected, in any letter case.
+id: I_DEFINITION_QUERY.store_query-reserved_name
+kind: functional
+component: DEFINITION_QUERY
+sm_operation: I_DEFINITION_QUERY.store_query
+capabilities: [QueryProvisioning]
+profiles: [STANDARD]
+test_purpose: "The reserved query-name `aql` is rejected on store, case-insensitively."
+description: "store_query under the reserved name `aql`/`AQL` is rejected (Qualified_query_name §NOTE)"
+spec_refs:
+  - "ITS-REST Qualified_query_name §NOTE (reserved name)"
+  - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
+guards:
+  - "master05 is TBD upstream: flows derived from the SM operation semantics and the stored-query Definitions API — CNF platform_test_schedule master05 (all cells xx/TBD); AMB-38"
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+requires: { server: empty }
+flow:
+  - step: 1
+    call: store_query
+    with:
+      qualified_query_name: "aql"
+      query: "SELECT c FROM EHR e CONTAINS COMPOSITION c"
+    expect: validation_failed              # reserved name -> 400
+  - step: 2
+    call: store_query
+    with:
+      qualified_query_name: "AQL"
+      query: "SELECT c FROM EHR e CONTAINS COMPOSITION c"
+    expect: validation_failed              # case-insensitive

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-unqualified_name.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-unqualified_name.yaml
@@ -1,0 +1,34 @@
+# Catalogue addition beyond the official master05 cells (which are TBD
+# placeholders): the stored-query NAME GRAMMAR. ITS-REST query
+# Qualified_query_name makes the namespace OPTIONAL —
+# "[{namespace}::]{query-name}", with the plain `my_compositions` in the
+# valid-examples list — so a namespace-less name must store and be
+# retrievable exactly like a namespaced one.
+id: I_DEFINITION_QUERY.store_query-unqualified_name
+kind: functional
+component: DEFINITION_QUERY
+sm_operation: I_DEFINITION_QUERY.store_query
+capabilities: [QueryProvisioning]
+profiles: [STANDARD]
+test_purpose: "A namespace-less (plain unqualified) stored-query name is accepted and the query is retrievable under it."
+description: "store_query under a plain unqualified name (namespace optional per Qualified_query_name)"
+spec_refs:
+  - "ITS-REST Qualified_query_name §Examples of valid qualified_query_name"
+  - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
+guards:
+  - "master05 is TBD upstream: flows derived from the SM operation semantics and the stored-query Definitions API — CNF platform_test_schedule master05 (all cells xx/TBD); AMB-38"
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+requires: { server: empty }
+flow:
+  - step: 1
+    call: store_query
+    with:
+      qualified_query_name: "unqualified_name_probe"
+      query: "SELECT c FROM EHR e CONTAINS COMPOSITION c"
+    expect: stored
+  - step: 2
+    call: has_query
+    with: { qualified_query_name: "unqualified_name_probe" }
+    expect: ok
+    assert:
+      - { assert: returns, equals: true }   # registered under the plain name

--- a/website/book/src/comparison-assets/conformance-chapter-bars-java.svg
+++ b/website/book/src/comparison-assets/conformance-chapter-bars-java.svg
@@ -54,15 +54,15 @@ text { fill: #c3c2b7; }
 
 <text x="793.1869918699185" y="81" class="seg-label-dim" text-anchor="middle">8</text><text x="821.9999999999999" y="81" class="muted">123</text>
 <text x="166" y="115" text-anchor="end">Definitions</text>
-<rect x="174" y="98" width="57.235772357723576" height="26" class="bar-passed"/>
+<rect x="174" y="98" width="62.4390243902439" height="26" class="bar-passed"/>
 
-<text x="202.6178861788618" y="115" class="seg-label" text-anchor="middle">11</text><rect x="231.2357723577236" y="98" width="20.8130081300813" height="26" class="bar-failed"/>
+<text x="205.21951219512195" y="115" class="seg-label" text-anchor="middle">12</text><rect x="236.4390243902439" y="98" width="31.21951219512195" height="26" class="bar-failed"/>
 
-<rect x="252.0487804878049" y="98" width="88.45528455284553" height="26" class="bar-errored"/>
+<text x="252.0487804878049" y="115" class="seg-label" text-anchor="middle">6</text><rect x="267.6585365853658" y="98" width="88.45528455284553" height="26" class="bar-errored"/>
 
-<text x="296.2764227642277" y="115" class="seg-label" text-anchor="middle">17</text><rect x="340.5040650406504" y="98" width="83.2520325203252" height="26" class="bar-na"/>
+<text x="311.8861788617886" y="115" class="seg-label" text-anchor="middle">17</text><rect x="356.11382113821134" y="98" width="83.2520325203252" height="26" class="bar-na"/>
 
-<text x="382.130081300813" y="115" class="seg-label-dim" text-anchor="middle">16</text><text x="431.7560975609756" y="115" class="muted">48</text>
+<text x="397.73983739837394" y="115" class="seg-label-dim" text-anchor="middle">16</text><text x="447.36585365853654" y="115" class="muted">51</text>
 <text x="166" y="149" text-anchor="end">Query</text>
 <rect x="174" y="132" width="46.829268292682926" height="26" class="bar-passed"/>
 

--- a/website/book/src/conformance-assets/conformance-chapter-bars.svg
+++ b/website/book/src/conformance-assets/conformance-chapter-bars.svg
@@ -50,11 +50,11 @@ text { fill: #c3c2b7; }
 
 <text x="793.1869918699188" y="81" class="seg-label-dim" text-anchor="middle">8</text><text x="822" y="81" class="muted">123</text>
 <text x="166" y="115" text-anchor="end">Definitions</text>
-<rect x="174" y="98" width="166.5040650406504" height="26" class="bar-passed"/>
+<rect x="174" y="98" width="182.1138211382114" height="26" class="bar-passed"/>
 
-<text x="257.2520325203252" y="115" class="seg-label" text-anchor="middle">32</text><rect x="340.5040650406504" y="98" width="83.2520325203252" height="26" class="bar-na"/>
+<text x="265.0569105691057" y="115" class="seg-label" text-anchor="middle">35</text><rect x="356.1138211382114" y="98" width="83.2520325203252" height="26" class="bar-na"/>
 
-<text x="382.130081300813" y="115" class="seg-label-dim" text-anchor="middle">16</text><text x="431.7560975609756" y="115" class="muted">48</text>
+<text x="397.739837398374" y="115" class="seg-label-dim" text-anchor="middle">16</text><text x="447.3658536585366" y="115" class="muted">51</text>
 <text x="166" y="149" text-anchor="end">Query</text>
 <rect x="174" y="132" width="78.04878048780488" height="26" class="bar-passed"/>
 

--- a/website/book/src/querying-aql.md
+++ b/website/book/src/querying-aql.md
@@ -154,6 +154,12 @@ curl -u ehrbase:ehrbase \
   parameter names the formalism, default `AQL` (case-insensitive); anything
   other than AQL is rejected with **400** — the server never silently stores
   a query it cannot execute.
+- The name is `[{namespace}::]{query-name}` — the namespace is **optional**,
+  and the query-name may use letters, digits, `_`, `.`, and `-`, so plain
+  names like `my_compositions` and dotted names like `cnf.ward_dashboard`
+  are valid as-is. The query-name `aql` is **reserved** (case-insensitive,
+  it would collide with the ad-hoc `/query/aql` route) and is rejected with
+  **400**.
 - `GET /definition/query/{name}[/{version}]` — list or fetch.
 - `GET|POST /query/{name}[/{version}]` — execute, taking the same `offset`,
   `fetch`, and `query_parameters` as ad-hoc queries. A version can be given


### PR DESCRIPTION
Closes #256
Closes #262

## What

The stored-query qualified-name grammar (ITS-REST query `Qualified_query_name`) was untested by the functional catalogue — every case used the namespaced `org.openehr.cnf::…` form, so a server that 400s spec-valid namespace-less dotted names (as upstream EHRbase 2.34.0 does — found attempting the upstream stress run) produced no red row. This PR closes the coverage gap and fixes the one gap it exposed in our own SUT.

## The spec (read first-hand)

`docs/specs/openehr/ITS-REST/specifications/docs/query/Qualified_query_name.md`:

- The name format is `[{namespace}::]{query-name}` — the **namespace is optional** (`my_compositions` is in the valid-examples list).
- The query-name character set is `[a-zA-Z0-9_.-]` — the **dot is part of the query-name**, not a namespace separator (the separator is `::`).
- §NOTE: "The `query-name` value must not be `aql` (case-insensitive), as that is a reserved name."

SM `openehr_platform` master04 §Registered Queries supplies the naming schemes (`<ns>::<name>`, `<ns>::<formalism>::<name>`, the `misc` default namespace) the decomposition follows.

## Catalogue (3 new `definition_query` cases; validator: 393 cases, 0 findings)

- `I_DEFINITION_QUERY.store_query-unqualified_name` — a plain unqualified name stores and reads back.
- `I_DEFINITION_QUERY.store_query-dotted_name` — the namespace-less dotted `cnf.ward_dashboard-probe` stores and reads back.
- `I_DEFINITION_QUERY.store_query-reserved_name` — `aql` and `AQL` are rejected on store.

## Application fix

Triaging the new reserved-name case against our SUT showed we ACCEPTED the reserved name — the one side of the grammar we got wrong. `store_query_version` (the single store choke point: wire PUT + SM register) now rejects a query-name of `aql` case-insensitively → 400, with or without a namespace. The three-part `ns::aql::name` scheme keeps working: the middle segment is the formalism (master04 §Registered Queries scheme 2), never mistaken for the query-name. Namespace-less plain + dotted names already stored correctly (integration-tested now).

## Evidence

- Artifact validator green (393 cases, 88 bindings, 0 findings).
- New integration test `query_store_name_grammar_and_reserved_name` (plain + dotted store/read-back; `aql`/`AQL`/`org.openehr::aql`/`org.openehr::AQL` rejected; the formalism-bearing three-part name stores).
- CNF zero-drift run vs the committed baseline + the 3 new rows PASS: <fill>
- Upstream functional comparison re-run — the new rows record upstream's verdict on its own evidence: <fill>

## The regression the run surfaced (#262)

The first pipeline run on this branch showed 8 rows red that pass in the committed baseline — all spec-valid commits rejected at validation. `cnf-triage` attributed all 8 to the application (both reproduced on the wire): two post-baseline validation additions each enforce a constraint absent from the governing closed invariant set — the DV_INTERVAL bound-presence rule (contradicting BASE `interval.adoc` lower/upper 0..1 + the register's own AMB-43 ACCEPTED disposition) and the DV_CODED_TEXT value==rubric rule (RM `dv_text.adoc` has only `Valid_value`; the no-rubric fallback degenerated to requiring value == code). Both reverted (70bd5812e), the two masked `rm_schema` catalogue rows reverted with them, the changelog corrected before release. The WT-builder rubric-label resolution (display concern) stays.

## Docs

- `website/book/src/querying-aql.md` — the stored-query name grammar (optional namespace, dotted names, the reserved `aql`).
- `CHANGELOG.md` — Added (catalogue cases) + Fixed (reserved-name rejection).
