### PR TITLE
release: v3.9.0 — CNF conformance release (catalogue audit + register remediation + version-signature + verify-on-read)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+## [3.9.0] - 2026-07-24
+
 ### Added
 
 - **Content structural conformance cases from the official schedule**: the
@@ -1544,7 +1546,8 @@ but has not yet run in production.
   seccomp, default-deny NetworkPolicy) and golden-render validation.
 
 
-[unreleased]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.8.0...HEAD
+[unreleased]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.9.0...HEAD
+[3.9.0]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.8.0...v3.9.0
 [3.8.0]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.7.0...v3.8.0
 [3.7.0]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.6.0...v3.7.0
 [3.6.0]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.5.0...v3.6.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "cnf-runner"
-version = "3.8.0"
+version = "3.9.0"
 dependencies = [
  "assert_fs",
  "base64 0.22.1",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase"
-version = "3.8.0"
+version = "3.9.0"
 dependencies = [
  "assert_fs",
  "async-trait",
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase-admin-ui"
-version = "3.8.0"
+version = "3.9.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2406,7 +2406,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase-rest"
-version = "3.8.0"
+version = "3.9.0"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -2459,7 +2459,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase-server"
-version = "3.8.0"
+version = "3.9.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -5228,7 +5228,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-codegen"
-version = "3.8.0"
+version = "3.9.0"
 dependencies = [
  "roxmltree",
  "serde_json",
@@ -5237,7 +5237,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-flat"
-version = "3.8.0"
+version = "3.9.0"
 dependencies = [
  "fancy-regex",
  "indexmap 2.14.0",
@@ -8286,7 +8286,7 @@ dependencies = [
 
 [[package]]
 name = "testkit"
-version = "3.8.0"
+version = "3.9.0"
 dependencies = [
  "ehrbase",
  "sqlx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "3"                      # resolver v3 (edition 2024)
 members = ["crates/*", "app/*", "tools/*"]
 
 [workspace.package]
-version = "3.8.0"
+version = "3.9.0"
 edition = "2024"
 rust-version = "1.96"
 license = "Apache-2.0"

--- a/deploy/helm/ehrbase-rs/Chart.yaml
+++ b/deploy/helm/ehrbase-rs/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 # Chart versioning is independent of the application version.
 version: 3.2.0
 # The default container image tag (informational; overridable via image.tag).
-appVersion: "3.8.0"
+appVersion: "3.9.0"
 
 # PDB (policy/v1, GA 1.21), HPA (autoscaling/v2, GA 1.23), and the
 # seccompProfile pod field (GA 1.27) all resolve cleanly at 1.25+.

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.8.0"
+    app.kubernetes.io/version: "3.9.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -58,7 +58,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.8.0"
+    app.kubernetes.io/version: "3.9.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -77,7 +77,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.8.0"
+    app.kubernetes.io/version: "3.9.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
   annotations:
@@ -96,7 +96,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.8.0"
+    app.kubernetes.io/version: "3.9.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 type: Opaque
@@ -120,7 +120,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.8.0"
+    app.kubernetes.io/version: "3.9.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 type: Opaque
@@ -139,7 +139,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.8.0"
+    app.kubernetes.io/version: "3.9.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 data:
@@ -296,7 +296,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.8.0"
+    app.kubernetes.io/version: "3.9.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -323,7 +323,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.8.0"
+    app.kubernetes.io/version: "3.9.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -335,7 +335,7 @@ spec:
     metadata:
       annotations:
         # Roll pods when the rendered ehrbase.toml changes.
-        checksum/config: 6df35b4d720cfb9b5b3c4c7f12ab29466bc493328b0d60abfa5b054d30c35f29
+        checksum/config: 239134ca2a49b35429b2db7d36413c4dc68e65b35fa2314fed7aaa16e5baea5c
         prometheus.io/scrape: "true"
         prometheus.io/port: "9100"
         prometheus.io/path: "/management/prometheus"
@@ -356,7 +356,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ehrbase
-          image: "ghcr.io/rubentalstra/ehrbase-rs:3.8.0"
+          image: "ghcr.io/rubentalstra/ehrbase-rs:3.9.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -478,7 +478,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.8.0"
+    app.kubernetes.io/version: "3.9.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -511,7 +511,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.8.0"
+    app.kubernetes.io/version: "3.9.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.8.0"
+    app.kubernetes.io/version: "3.9.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -36,7 +36,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.8.0"
+    app.kubernetes.io/version: "3.9.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -55,7 +55,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.8.0"
+    app.kubernetes.io/version: "3.9.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 automountServiceAccountToken: false
@@ -69,7 +69,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.8.0"
+    app.kubernetes.io/version: "3.9.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 data:
@@ -168,7 +168,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.8.0"
+    app.kubernetes.io/version: "3.9.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -191,7 +191,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.8.0"
+    app.kubernetes.io/version: "3.9.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -204,7 +204,7 @@ spec:
     metadata:
       annotations:
         # Roll pods when the rendered ehrbase.toml changes.
-        checksum/config: b270d34bf4f097f34d56ee48d4543e1403bdbc68778c9ace7ed5b1455ef3a2ba
+        checksum/config: 0f7059c4fc55fcf922bb0686f3f424852607ecb316cfc87992ada1e5cb7cceed
       labels:
         app.kubernetes.io/name: ehrbase-rs
         app.kubernetes.io/instance: ehrbase-rs
@@ -222,7 +222,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ehrbase
-          image: "ghcr.io/rubentalstra/ehrbase-rs:3.8.0"
+          image: "ghcr.io/rubentalstra/ehrbase-rs:3.9.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## v3.9.0 — the CNF conformance release

Cuts **v3.9.0** from the changelog. The milestone reached zero open issues; this
PR renames `[Unreleased]` → `[3.9.0]`, bumps the workspace + Helm app version,
and re-renders the Helm goldens. Tagging `v3.9.0` on the merge commit publishes
the GitHub Release (pre-release) from the matching changelog section.

### What shipped (since v3.8.0)

- **CNF catalogue audited case-by-case against the released spec text (#231)** —
  every case in every chapter re-verified across grounds, expectations,
  citations, fixtures, captures, and register linkage; spec-overreaching
  rejection rows removed, stale ids fixed, grounds realigned, eight new
  ambiguity-register entries pinning previously prose-only adjudications.
- **CNF register remediation (#272)** — docs-text + SM/ITS-REST adjudication
  applied; mis-bindings corrected; the ambiguity register and upstream ledger
  cleaned.
- **Version-signature conformance + verify-on-read strict-default (#273)** — a
  pure verify core (RFC 8785 JCS canonical form + digest and openPGP RFC-4880
  verification), wire-asserted `SIG-VERSION` cases across version kinds and both
  signing modes, and `signing.verify_on_read` now resolving to **strict** when
  signing is enabled (client-supplied / imported signatures stored verbatim and
  never re-verified).
- **Content structural conformance cases** from the official master15/master16
  schedule, encoded under their verbatim ids.
- **Dual POC measured records** (ehrbase-rs earns class POC; upstream does not on
  the identical instrument), and the perf-driver 204-minimal-return + shm-floor
  parity fixes.

### Release mechanics

- `CHANGELOG.md`: `[Unreleased]` → `## [3.9.0] - 2026-07-24`; fresh empty
  `[Unreleased]`; compare link references updated.
- Workspace `version` 3.8.0 → 3.9.0 (+ `Cargo.lock`); Helm `appVersion`
  3.8.0 → 3.9.0; goldens regenerated (`deploy/helm/validate.sh --update`).

### Post-merge

Tag `v3.9.0` on the merge commit → the Release workflow publishes the
pre-release; close the v3.9.0 milestone (#6); v3.10.0 already exists as the next
target.
