### PR TITLE
docs: CITATION.cff — citable repository (GitHub citation support + ORCID) with release-lifecycle guard

### DIFF
--- a/.claude/rules/changelog.md
+++ b/.claude/rules/changelog.md
@@ -22,7 +22,9 @@ optional:
   `[Unreleased]`, update the link references at the bottom, bump the
   workspace `version` in the root `Cargo.toml` (+ `Cargo.lock` via a
   `cargo check`, + Helm `appVersion`, golden renders via
-  `deploy/helm/validate.sh --update`), merge the release PR, then tag
+  `deploy/helm/validate.sh --update`, + `CITATION.cff` `version` and
+  `date-released` — the `citation-guard` CI job enforces the version
+  match), merge the release PR, then tag
   `vX.Y.Z` on the merge commit. The release workflow publishes the GitHub
   Release from the matching changelog section and **fails if the section or
   version match is missing**. Releases stay `prerelease: true` until the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,3 +409,30 @@ jobs:
           fi
           echo "::error::This PR changes user-visible surfaces (app/, crates/, deploy/, docker/, manifests) but does not add a CHANGELOG.md [Unreleased] entry (Keep a Changelog 1.1.0). Add one, or apply the 'no-changelog' label if truly invisible." >&2
           exit 1
+
+  # Citation guard: CITATION.cff must stay CFF-1.2.0-schema-valid and
+  # version-consistent with the workspace — a malformed file silently breaks
+  # GitHub's "Cite this repository" button, and a stale version misquotes the
+  # release in research citations. The release cut bumps version +
+  # date-released (.claude/rules/changelog.md §Cutting a release).
+  citation:
+    name: citation-guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Validate CITATION.cff (CFF 1.2.0 schema)
+        run: pipx run cffconvert --validate
+      - name: CITATION.cff version matches the workspace version
+        run: |
+          set -euo pipefail
+          cff_ver=$(sed -nE 's/^version:[[:space:]]*"?([^"]+)"?[[:space:]]*$/\1/p' CITATION.cff)
+          ws_ver=$(sed -nE 's/^version = "(.*)"$/\1/p' Cargo.toml | head -1)
+          if [ -z "$cff_ver" ] || [ -z "$ws_ver" ]; then
+            echo "::error::could not extract versions (CITATION.cff: '$cff_ver', Cargo.toml: '$ws_ver')." >&2
+            exit 1
+          fi
+          if [ "$cff_ver" != "$ws_ver" ]; then
+            echo "::error::CITATION.cff version ($cff_ver) != workspace version ($ws_ver) — the release cut bumps CITATION.cff version/date-released (.claude/rules/changelog.md)." >&2
+            exit 1
+          fi
+          echo "CITATION.cff version $cff_ver matches the workspace version."

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,11 +11,25 @@
 # Docs: https://docs.github.com/en/code-security/code-scanning
 name: CodeQL
 
+# Push/PR runs are path-filtered to Rust-relevant changes — a docs/CI/artifact
+# -only change has nothing for the rust analyzer to scan. The weekly scheduled
+# run has no filter, so full-tree coverage is never lost. (CodeQL is not a
+# required status check, so a skipped run cannot block a merge.)
 on:
   push:
     branches: [develop]
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/codeql.yml"
   pull_request:
     branches: [develop]
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/codeql.yml"
   schedule:
     - cron: "23 5 * * 1" # Mondays 05:23 UTC (off-the-hour to dodge load spikes)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Added
+
+- **Citation metadata (`CITATION.cff`)**: the repository is now citable in
+  research papers — GitHub renders a "Cite this repository" button (APA +
+  BibTeX) from the new CFF 1.2.0 file (author with ORCID, Apache-2.0,
+  abstract, keywords, release version/date). A `citation-guard` CI job
+  schema-validates the file and enforces that its `version` matches the
+  workspace version; the release procedure bumps `version`/`date-released`
+  on every cut.
+
 ## [3.9.0] - 2026-07-24
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,37 @@
+# Citation metadata (CFF 1.2.0) — renders GitHub's "Cite this repository"
+# button (APA + BibTeX). Kept release-accurate: every release cut bumps
+# `version` + `date-released` (.claude/rules/changelog.md §Cutting a release);
+# the citation-guard CI job schema-validates this file and enforces that
+# `version` matches the workspace version in the root Cargo.toml.
+cff-version: 1.2.0
+message: "If you use this software, please cite it using the metadata from this file."
+type: software
+title: "EHRbase-rs"
+abstract: >-
+  A pure-Rust, openEHR-specification-conformant clinical data repository
+  (CDR): ITS-REST 1.1.0 REST API, AQL 1.1 query language, and the openEHR
+  RM 1.2.0 reference model on PostgreSQL-18-native storage. The openEHR
+  specification layer is generated from the official machine-readable
+  specifications, and conformance is machine-verified per release by a
+  built-in CNF conformance runner.
+authors:
+  - family-names: Talstra
+    given-names: Ruben
+    orcid: "https://orcid.org/0009-0009-2758-0141"
+repository-code: "https://github.com/rubentalstra/ehrbase-rs"
+url: "https://rubentalstra.github.io/ehrbase-rs/"
+license: Apache-2.0
+keywords:
+  - openEHR
+  - clinical data repository
+  - CDR
+  - electronic health records
+  - EHR
+  - AQL
+  - health informatics
+  - healthcare interoperability
+  - ITS-REST
+  - Rust
+  - PostgreSQL
+version: 3.9.0
+date-released: "2026-07-24"


### PR DESCRIPTION
## Summary

Implements #279: the repository is now **fully citable for research use** — this is a clinical/medical data-repository project, and researchers building on it get a proper machine-readable citation.

- **`CITATION.cff`** (CFF 1.2.0, schema-validated with cffconvert): author Ruben Talstra with ORCID `0009-0009-2758-0141`, Apache-2.0, an abstract describing the openEHR CDR, research-relevant keywords, `version` 3.9.0 / `date-released` 2026-07-24 (the latest release). GitHub renders the **"Cite this repository"** button (APA + BibTeX) from this file per the official GitHub citation-files documentation.
- **Release lifecycle** ("100% fully set up" — a stale citation misquotes the release): `.claude/rules/changelog.md` §Cutting a release now bumps `CITATION.cff` `version`/`date-released` alongside the workspace version, Helm `appVersion` and goldens.
- **`citation-guard` CI job** (ci.yml): schema-validates the file (`pipx run cffconvert --validate`) and fails when `CITATION.cff` `version` ≠ the root `Cargo.toml` workspace version — the same drift-honesty pattern as the Helm `appVersion`. Uses no untrusted event inputs.

Verified locally: cffconvert reports the metadata valid against schema 1.2.0; the version-consistency extraction matches (3.9.0 = 3.9.0); `scripts/check-changelog-structure.sh` green.

Post-merge check (exit criterion): the "Cite this repository" button renders on the repo page with correct APA/BibTeX.

No openEHR spec governs this — repository metadata, our own concern.

Closes #279