### PR TITLE
feat: ADL2/OPT2 FLAT parity — am24 archetype-conformance validation + commit-path resolver fallback

### DIFF
--- a/.claude/agent-memory/cnf-triage/MEMORY.md
+++ b/.claude/agent-memory/cnf-triage/MEMORY.md
@@ -7,3 +7,4 @@
 - [Runner driver gaps (confirmed)](runner-driver-gaps.md) — option-gating, header-mutation variants, ctx/ equivalence normalization
 - [content_synth HISTORY events existence](content-synth-history-events-existence.md) — RUNNER defect: builders hardcode events existence 1..1; zero-event+summary rows (any/opt cardinality) wrongly fail; SUT spec-correct
 - [ADL14 template_id collision](adl14-template-id-collision.md) — CATALOGUE defect: master08 contribution provisioning reuses master04 server:empty upload/validate template_ids (time_series/obs_admin); SUT already_exists is spec-correct
+- [Upstream EHRbase Java non-conformance (#266)](upstream-ehrbase-java-nonconformance.md) — EHRbase 2.34.0 400s the spec-standard QUOTED If-Match (composition/ehr_status update classes) + 404s the STABLE item-tag surface; our driver/pack spec-valid, outcome (b), record stands

--- a/.claude/agent-memory/cnf-triage/upstream-ehrbase-java-nonconformance.md
+++ b/.claude/agent-memory/cnf-triage/upstream-ehrbase-java-nonconformance.md
@@ -1,0 +1,39 @@
+---
+name: upstream-ehrbase-java-nonconformance
+description: EHRbase Java 2.34.0 upstream (comparison SUT) non-conformances found reproducing #266 measured-window error classes
+metadata:
+  type: project
+---
+
+Reproducing #266's upstream measured error classes (EHRbase Java 2.34.0,
+`docker/sut-ehrbase-java.yml`) confirmed two UPSTREAM non-conformances vs the
+released ITS-REST 1.1.0 docs text — NOT our-side defects (our driver/pack are
+spec-valid; the identical exchanges pass 100% on ehrbase-rs).
+
+**1. Quoted If-Match → 400 "UUID string too large".** EHRbase rejects the
+RFC-9110 / spec-standard double-quoted entity-tag `If-Match: "uid::system::N"`
+(the form in `ITS-REST/specifications/docs/overview/Requests_and_responses.md`
+line 207) and only accepts the non-standard UNquoted value. It even 400s on its
+OWN returned ETag echoed back verbatim. This is the whole composition_update
+(77/77) + ehr_status_update (26/26) 400 class. Our driver
+(`perf_run/client.rs:120-122`) sends the quoted form = spec-correct.
+
+**2. Item-tag surface unimplemented → 404 "No resource found at path".**
+`/ehr/{id}/tags`, `/ehr/{id}/composition/{uid}/tags` (GET+PUT) are part of the
+STABLE EHR API (`ehr.openapi.yaml` x-status: STABLE, L5; paths L95-113) but
+EHRbase 2.34.0 has no routes. The tags_put (34/34) + tags_read (34/34) 404 class.
+Released-STABLE, so upstream non-conformance, NOT N/A.
+
+**template_get 3/85 = transient** (endpoint returns 200 JSON+XML; load-window
+noise), not deterministic, no defect.
+
+Disposition for all: outcome (b) — measured record stands; note upstream
+non-conformances in the public comparison narrative. NEVER "fix" our pack/driver
+to match upstream (that would break the spec-correct ehrbase-rs path).
+
+**Why: `If-Match` echoing the server ETag verbatim (quoted) is the textbook
+RFC flow; deriving the expectation from the released docs text (not the SUT)
+made this an upstream verdict, not a pack fix.**
+**How to apply:** when a comparison SUT 400s a versioned PUT, check If-Match
+quoting before suspecting the payload; when it 404s item tags, it's a
+STABLE-surface gap.

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Keep the docker build context small: both server images build with
+# `context: .` + `COPY . .` (docker/Dockerfile, docker/admin-ui/Dockerfile),
+# so without this file every image build ships the entire working tree —
+# observed 53 GB of context transfer once target/ grew (2026-07-24).
+# `.git` stays IN the context deliberately: app/ehrbase/build.rs derives the
+# /management/info git SHA from it (best-effort, no build arg wired).
+target/
+docs-dist/
+.claude/worktrees/
+**/node_modules/
+*.log
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,23 @@ workflow refuses a tag that has no matching section here.
   the REST contract this crate already houses). Pure packaging refactor — no
   change to the FLAT/STRUCTURED/Web-Template wire behaviour.
 
+### Fixed
+
+- **ADL2 filler-root naming in the projected WebTemplate**: a
+  `use_archetype`-filled archetype root resolved its display rubric in the
+  component (filled archetype) terminology first, so the template-side slot id
+  could false-positively match an unrelated internal id of the constituent
+  (e.g. a filled OBSERVATION surfacing as "history"). The slot rubric now
+  resolves in the introducing template's own terminology first (ADL2 obliges
+  the introducing artefact to define its node ids), with the component scope
+  as last resort — FLAT paths over filled ADL2 templates carry the
+  template-declared names.
+- **CNF runner: `openehr-template-id` for in-flow-provisioned templates**: the
+  simplified-format commit header now resolves from the committed data set's
+  own manifest-declared `template_id` (falling back to the case's provisioned
+  template list), so cases that upload their template inside the flow (the
+  ADL2 FLAT pair) drive the commit correctly instead of omitting the header.
+
 ## [3.9.0] - 2026-07-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
+- **ADL2/OPT2 templates are full FLAT/STRUCTURED peers of OPT 1.4 (#269)**: a
+  FLAT (`application/openehr.wt.flat+json`) or STRUCTURED
+  (`application/openehr.wt.structured+json`) composition **commit** keyed to an
+  ADL2-registered template now resolves and is validated against that template's
+  archetype constraints, exactly as an ADL 1.4 commit is. Two behaviours were
+  brought to parity: the am24 (OPT2) Web-Template builder now populates the
+  archetype-conformance constraints (existence, cardinality, closed-attribute
+  sibling sets, archetype slots, structural stubs) that composition validation
+  reads — so an ADL2-template instance is archetype-constraint-checked, not only
+  RM- and terminology-checked — and the runtime template resolver falls back to
+  the ADL2/OPT2 store when a template id is not an ADL 1.4 template (previously a
+  commit against an ADL2-registered template returned **422 "operational template
+  not known"**).
 - **Citation metadata (`CITATION.cff`)**: the repository is now citable in
   research papers — GitHub renders a "Cite this repository" button (APA +
   BibTeX) from the new CFF 1.2.0 file (author with ORCID, Apache-2.0,

--- a/app/ehrbase/src/service/definition/adl2.rs
+++ b/app/ehrbase/src/service/definition/adl2.rs
@@ -11,6 +11,7 @@
 //! `openehr-adl` phases degrade gracefully when a parent is unresolved).
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use openehr_adl::assemble::parse_artefact;
 use openehr_adl::meta::{ArtefactSummary, summarize};
@@ -35,6 +36,15 @@ use crate::service::list::Page;
 use crate::service::status::{CallStatusType, SmError};
 
 use super::{compile_pattern, page_bounds, paginate};
+
+/// The `WebTemplate`-cache key namespace for ADL2/OPT2 templates. The trailing
+/// ASCII Unit Separator (`U+001F`) cannot appear in a grammar-legal
+/// archetype/template id (printable ASCII —
+/// `docs/specs/openehr/BASE/docs/base_types/master05-identification_package.adoc`
+/// §Archetype Identifiers), so an ADL2 entry can never collide with an OPT 1.4
+/// entry keyed by the plain identity-canonical form. No openEHR spec governs the
+/// cache — our own design/extension.
+const ADL2_CACHE_NS: &str = "adl2\u{1f}";
 
 /// A memoised [`TerminologyResolver`] for ADL2 VETDF validation.
 ///
@@ -533,14 +543,93 @@ impl EhrbaseService {
     /// - [`ServiceError::Unprocessable`] (`422`) — the OPT cannot be compiled or
     ///   built into a `WebTemplate`.
     pub async fn web_template_adl2(&self, template_id: &str) -> Result<WebTemplate, ServiceError> {
-        let hrid = self.adl2_resolve(template_id, None).await?;
-        let source = self.adl2_get(&hrid).await?;
-        let opt = self.adl2_operational_template(&source).await?;
+        let opt = self.adl2_operational_template_for(template_id).await?;
         build_web_template_am24(&opt).map_err(|e| {
             ServiceError::Unprocessable(format!(
-                "ADL2 template {hrid} could not be built into a WebTemplate: {e}"
+                "ADL2 template {template_id} could not be built into a WebTemplate: {e}"
             ))
         })
+    }
+
+    /// The (cached) [`WebTemplate`] for a stored ADL2/OPT2 template on the
+    /// FLAT/STRUCTURED **commit** path — the ADL2 twin of
+    /// [`web_template_for`](crate::service::EhrbaseService::web_template_for)'s OPT
+    /// 1.4 resolution, reached as its fallback when a template id is not an ADL 1.4
+    /// template. The resulting Web Template carries the AOM2 archetype-conformance
+    /// constraints ([`build_web_template_am24`]), so a FLAT/STRUCTURED commit
+    /// against an ADL2 template is archetype-constraint-checked exactly as an OPT
+    /// 1.4 commit is.
+    ///
+    /// NOTE: the entry is cached under a dialect-namespaced key
+    /// ([`ADL2_CACHE_NS`]) in the shared `WebTemplate` cache, so an OPT 1.4 and an
+    /// ADL2 template that happen to share a `template_id` can never collide there —
+    /// the namespace prefix uses an ASCII control separator that no
+    /// grammar-legal archetype/template id can contain
+    /// (`docs/specs/openehr/BASE/docs/base_types/master05-identification_package.adoc`
+    /// §Archetype Identifiers — ids are printable ASCII). No openEHR spec governs
+    /// the internal resolver wiring or the derived-runtime cache — our own
+    /// design/extension.
+    ///
+    /// # Errors
+    ///
+    /// - [`ServiceError::Unprocessable`] (`422`) — no ADL2 template matches (an
+    ///   unknown referenced template on a commit is a *semantic* error, matching
+    ///   the OPT 1.4 side —
+    ///   `docs/specs/openehr/ITS-REST/specifications/responses/422.yaml`) or the
+    ///   stored OPT2 cannot be built into a `WebTemplate`.
+    /// - [`ServiceError::Internal`] (`500`) — the stored ADL2 source no longer
+    ///   parses (it was engine-valid at upload, so this is a server fault).
+    /// - [`ServiceError::Database`] — a store read failed.
+    pub(crate) async fn web_template_adl2_cached(
+        &self,
+        template_id: &str,
+    ) -> Result<Arc<WebTemplate>, ServiceError> {
+        let key = format!(
+            "{ADL2_CACHE_NS}{}",
+            crate::templates::identity::canonical_key(template_id)
+        );
+        if let Some(wt) = self.web_templates.get(&key).await {
+            return Ok(wt);
+        }
+        // Compile the stored ADL2 source to its OPT2 (async) before the sync WT
+        // build, mapping an unknown ADL2 template to the commit-path 422 the OPT
+        // 1.4 side uses (`web_template_for`).
+        let opt = match self.adl2_operational_template_for(template_id).await {
+            Ok(opt) => opt,
+            Err(ServiceError::NotFound(_)) => {
+                return Err(ServiceError::Unprocessable(format!(
+                    "operational template not known: {template_id}"
+                )));
+            }
+            Err(e) => return Err(e),
+        };
+        self.web_templates
+            .get_or_build(&key, || build_web_template_am24(&opt))
+            .await
+            .map_err(|e| {
+                ServiceError::Unprocessable(format!(
+                    "ADL2 template {template_id} could not be built into a WebTemplate: {e}"
+                ))
+            })
+    }
+
+    /// Resolve a `template_id` to its stored ADL2 source and compile it to its
+    /// operational template (OPT2). Shared by the example
+    /// ([`web_template_adl2`](Self::web_template_adl2)) and commit
+    /// ([`web_template_adl2_cached`](Self::web_template_adl2_cached)) paths.
+    ///
+    /// # Errors
+    ///
+    /// - [`ServiceError::NotFound`] (`404`) — no stored ADL2 template matches.
+    /// - [`ServiceError::Internal`] (`500`) — the stored source no longer parses.
+    /// - [`ServiceError::Unprocessable`] (`422`) — the OPT cannot be compiled.
+    async fn adl2_operational_template_for(
+        &self,
+        template_id: &str,
+    ) -> Result<OperationalTemplate, ServiceError> {
+        let hrid = self.adl2_resolve(template_id, None).await?;
+        let source = self.adl2_get(&hrid).await?;
+        self.adl2_operational_template(&source).await
     }
 
     /// Compile stored ADL2 `source` to its operational template: a stored

--- a/app/ehrbase/src/templates/runtime.rs
+++ b/app/ehrbase/src/templates/runtime.rs
@@ -75,17 +75,25 @@ impl EhrbaseService {
         note_cache_event("miss");
 
         // Miss: load the stored OPT XML (the one store read, amortised across
-        // every future commit for this template), mapping an unknown template to
-        // the commit-path 422. The XML load itself is not de-duplicated
-        // across a burst of concurrent *first* commits of a never-seen template —
-        // an accepted, bounded cost, since templates are provisioned before use
-        // and warm on the first hit.
+        // every future commit for this template). The XML load itself is not
+        // de-duplicated across a burst of concurrent *first* commits of a
+        // never-seen template — an accepted, bounded cost, since templates are
+        // provisioned before use and warm on the first hit.
+        //
+        // When the id is not an ADL 1.4 template, fall back to the ADL2/OPT2
+        // store (`web_template_adl2_cached`), so a FLAT/STRUCTURED commit keyed to
+        // an ADL2-registered template resolves and is archetype-constraint-checked
+        // (the am24 front end now carries the same conformance constraints — see
+        // `openehr_its::flat::webtemplate::build_web_template_am24`). Only after
+        // *both* stores miss is the id "operational template not known" (the
+        // commit-path 422). No openEHR spec governs the internal resolver wiring —
+        // our own design/extension (the FLAT-over-both-generations expectation is
+        // grounded in the AM side-by-side mandate,
+        // `docs/specs/openehr/BASE/docs/architecture_overview/master05-package_structure.adoc`).
         let xml = match self.get_template_xml(template_id).await {
             Ok(xml) => xml,
             Err(ServiceError::NotFound(_)) => {
-                return Err(ServiceError::Unprocessable(format!(
-                    "operational template not known: {template_id}"
-                )));
+                return self.web_template_adl2_cached(template_id).await;
             }
             Err(e) => return Err(e),
         };

--- a/app/ehrbase/tests/service_definition.rs
+++ b/app/ehrbase/tests/service_definition.rs
@@ -1074,3 +1074,62 @@ async fn adl2_template_resolves_on_the_commit_path_and_validates() {
         "an RM-invalid instance is rejected on the ADL2-resolved commit path"
     );
 }
+
+/// The full service seam for a template-with-filler: upload the archetype +
+/// the `template` that `use_archetype`-fills it, then assert the projected
+/// commit-path `WebTemplate` CONTAINS the filler's flattened subtree — under
+/// the SLOT-LEVEL name the template's own terminology defines (OPT2 master03:
+/// `create_opt` inlines every filler; RM `composition.entry.adoc` §Invariants
+/// `Is_archetype_root` makes the fill the only conformant way to put an ENTRY
+/// under content). Regression for the filler-root rubric resolving in the
+/// component terminology (mislabeling the node from the constituent's
+/// unrelated same-numbered id code).
+#[tokio::test]
+async fn adl2_template_with_filler_projects_the_filled_web_template() {
+    fn find<'a>(
+        n: &'a openehr_its::flat::webtemplate::WebTemplateNode,
+        id: &str,
+    ) -> Option<&'a openehr_its::flat::webtemplate::WebTemplateNode> {
+        if n.id == id {
+            return Some(n);
+        }
+        n.children.iter().find_map(|c| find(c, id))
+    }
+    fn dump(n: &openehr_its::flat::webtemplate::WebTemplateNode, d: usize, out: &mut String) {
+        use std::fmt::Write;
+        let _ = writeln!(out, "{}{} [{}]", "  ".repeat(d), n.id, n.rm_type);
+        for c in &n.children {
+            dump(c, d + 1, out);
+        }
+    }
+    const ARCH: &str = include_str!(
+        "../../../tools/cnf-runner/artifacts/corpus/fixtures/adl2/archetype/cnf_count_a.adls"
+    );
+    const TMPL: &str = include_str!(
+        "../../../tools/cnf-runner/artifacts/corpus/fixtures/adl2/opt/flat_parity_a.adls"
+    );
+    let db = testkit::db().await.expect("testkit database");
+    let svc = EhrbaseService::new(db.pool());
+
+    svc.upload_artefact(ARCH.to_owned())
+        .await
+        .expect("upload the filler archetype");
+    svc.upload_artefact(TMPL.to_owned())
+        .await
+        .expect("upload the template");
+
+    let wt = svc
+        .web_template("openEHR-EHR-COMPOSITION.cnf_adl2_flat_a.v1.0.0")
+        .await
+        .expect("the ADL2 template resolves on the commit path");
+    let mut tree = String::new();
+    dump(&wt.tree, 0, &mut tree);
+    assert!(
+        find(&wt.tree, "observation_one").is_some(),
+        "the filled OBSERVATION must appear in the projected WebTemplate; tree:\n{tree}"
+    );
+    assert!(
+        find(&wt.tree, "count_item").is_some(),
+        "the filler's constrained leaf must appear in the projected WebTemplate"
+    );
+}

--- a/app/ehrbase/tests/service_definition.rs
+++ b/app/ehrbase/tests/service_definition.rs
@@ -1001,3 +1001,76 @@ async fn adl2_template_upload_wire_conflicts_on_duplicate() {
         "got {bad:?}"
     );
 }
+
+// ── ADL2/OPT2 FLAT parity: commit-path resolver fallback (#269) ───────────────
+
+/// The runtime `WebTemplate` resolver (`web_template`/`web_template_for`) falls
+/// back to the ADL2/OPT2 store when a template id is not an ADL 1.4 template, so a
+/// FLAT/STRUCTURED composition **commit** keyed to an ADL2-registered template
+/// resolves and is validated — the ADL2 twin of the OPT 1.4 commit path. Before
+/// #269 this 422'd "operational template not known" (the resolver read only the
+/// OPT 1.4 `template_store`).
+///
+/// Validation runs through the same choke point every commit uses
+/// (`content_valid` → `validate_for_commit` → `web_template_for` →
+/// `validate_archetype_conformance`), so this also exercises the am24
+/// archetype-conformance capture end-to-end.
+#[tokio::test]
+async fn adl2_template_resolves_on_the_commit_path_and_validates() {
+    use serde_json::Value;
+
+    const HRID: &str = "openEHR-EHR-COMPOSITION.commit_resolver.v1.0.0";
+
+    let db = testkit::db().await.expect("testkit database");
+    let svc = EhrbaseService::new(db.pool());
+
+    let opt = adl2_source("operational_template", HRID, None);
+    svc.upload_artefact(opt).await.expect("upload ADL2 OPT");
+
+    // Gap 2: the runtime resolver used by the FLAT/STRUCTURED commit path now
+    // resolves the ADL2 template (before #269: `ServiceError::Unprocessable`).
+    let wt = svc
+        .web_template(HRID)
+        .await
+        .expect("the ADL2 template resolves on the commit path");
+    assert_eq!(wt.template_id, HRID);
+    assert_eq!(
+        wt.sem_ver.as_deref(),
+        Some("1.0.0"),
+        "resolved through the am24 (OPT2) front end, which carries semVer"
+    );
+
+    // A composition declaring that template validates end-to-end through the same
+    // per-commit choke point.
+    let mut comp = openehr_its::flat::example::example_composition(
+        &wt,
+        openehr_its::flat::example::DetailLevel::Complete,
+    );
+    assert_eq!(
+        comp.pointer("/archetype_details/template_id/value")
+            .and_then(Value::as_str),
+        Some(HRID),
+        "the example declares the ADL2 template id"
+    );
+    assert!(
+        svc.definitions_valid(&comp)
+            .await
+            .expect("definitions_valid"),
+        "the declared ADL2 template is now known to the definitions service"
+    );
+    assert!(
+        svc.content_valid(&comp).await.expect("content_valid"),
+        "a self-consistent instance validates clean against the ADL2 template"
+    );
+
+    // A structurally RM-broken instance is rejected — proving the validation
+    // passes actually run against the ADL2-resolved template
+    // (COMPOSITION.composer [1], RM common `composition.adoc`).
+    comp.as_object_mut()
+        .expect("composition object")
+        .remove("composer");
+    assert!(
+        !svc.content_valid(&comp).await.expect("content_valid"),
+        "an RM-invalid instance is rejected on the ADL2-resolved commit path"
+    );
+}

--- a/crates/openehr-its/src/flat/webtemplate/builder_am24.rs
+++ b/crates/openehr-its/src/flat/webtemplate/builder_am24.rs
@@ -246,16 +246,19 @@ fn build_node(
     parent_path: &str,
 ) -> WebTemplateNode {
     // A `C_ARCHETYPE_ROOT` switches the terminology scope to its constituent's
-    // (OPT2 master03 §Terminology); its own name is looked up in the new scope,
-    // falling back to the parent scope for the slot-level rubric.
-    let (child_term, is_root) = match co {
+    // for its CHILDREN (OPT2 master03 §Terminology). The root node's OWN rubric
+    // is the slot-level term the introducing artefact defines (ADL2 requires
+    // the artefact that introduces a node id to define it — AOM2 master03
+    // §Validity Rules), so it resolves in the OUTER scope first; the component
+    // scope is only a last resort. Resolving the slot id in the component scope
+    // first can false-positive on the constituent's own unrelated id codes.
+    let child_term = match co {
         CObject::CComplexObject(CComplexObject::CArchetypeRoot(r)) => {
-            (ctx.scope(&r.archetype_ref).unwrap_or(term), true)
+            ctx.scope(&r.archetype_ref).unwrap_or(term)
         }
-        _ => (term, false),
+        _ => term,
     };
-    let name_term = if is_root { child_term } else { term };
-    let mut node = create_node(ctx, name_term, term, attr_name, co, parent_path);
+    let mut node = create_node(ctx, term, child_term, attr_name, co, parent_path);
     build_children(ctx, child_term, co, &mut node);
     node
 }
@@ -284,8 +287,11 @@ fn create_node(
 
     let code = object_node_id(co);
     if !code.is_empty() {
-        // Resolve the rubric name in the node's own scope, falling back to the
-        // parent scope (a filler root's slot code lives in the parent).
+        // Resolve the rubric in the introducing artefact's scope first (for a
+        // filler root that is the OUTER template terminology, which ADL2
+        // obliges to define the slot code — AOM2 master03 §Validity Rules),
+        // falling back to the component scope only when the outer one is
+        // silent.
         node.name = rubric_text(name_term, code, &ctx.default_language)
             .or_else(|| rubric_text(parent_term, code, &ctx.default_language));
         node.localized_name.clone_from(&node.name);

--- a/crates/openehr-its/src/flat/webtemplate/builder_am24.rs
+++ b/crates/openehr-its/src/flat/webtemplate/builder_am24.rs
@@ -23,23 +23,26 @@
 //! am24-specific `build`/`inputs` half; the tree shaping is shared.
 //!
 //! NOTE: the am24 front end populates the node **shape** + `inputs` the example
-//! generator and FLAT/STRUCTURED codecs consume; it does **not** populate the
-//! validation-only constraint fields (`existence`/`card_all`/`slots`/
-//! `closed_attributes`/`structural_stubs`) the archetype-conformance walk
-//! ([`crate::flat::validation::validate_archetype_conformance`]) reads. No openEHR
-//! spec governs an example's completeness or an am24 instance-conformance walk
-//! against a Web Template — our own design/extension; a generated am24 example
-//! is validated by [`crate::flat::validation::validate_rm_and_terminology`] (RM class
-//! invariants + RM-mandated terminology, template-independent), which is
-//! self-consistent with the tree by construction. The am24 structural
-//! conformance walk is out of scope for this front end (master04 §"Web Template
-//! Metadata" is the seam it fills).
+//! generator and FLAT/STRUCTURED codecs consume **and** the validation-only
+//! constraint fields (`existence`/`card_all`/`closed_attributes`/
+//! `structural_stubs`; the hoisted-wrapper `slots` are added by the shared
+//! [`super::shape`] compaction) the archetype-conformance walk
+//! ([`crate::flat::validation::validate_archetype_conformance`]) reads — from the
+//! AOM2 constraint model (`C_ATTRIBUTE.existence`/`.cardinality`, node-identified
+//! `C_OBJECT` alternatives, `ARCHETYPE_SLOT`; AOM2
+//! `AM/docs/AOM2/master02-archetype_definition.adoc` §C_ATTRIBUTE, §ARCHETYPE_SLOT).
+//! So the archetype-conformance walk runs against an ADL2 template exactly as it
+//! does against an OPT 1.4 template (the shared dialect-neutral seam is the Web
+//! Template layer). No openEHR spec governs the Web Template model itself — our
+//! own design/extension; the walk *semantics* the captured fields serve cite AOM2
+//! / RM common.
 
 use std::collections::BTreeMap;
 
 use indexmap::IndexMap;
 use openehr_am::am24::aom2::archetype::archetype_hrid::ArchetypeHrid;
 use openehr_am::am24::aom2::archetype::operational_template::OperationalTemplate;
+use openehr_am::am24::aom2::constraint_model::archetype_slot::ArchetypeSlot;
 use openehr_am::am24::aom2::constraint_model::c_attribute::CAttribute;
 use openehr_am::am24::aom2::constraint_model::c_attribute_tuple::CAttributeTuple;
 use openehr_am::am24::aom2::constraint_model::c_complex_object::CComplexObject;
@@ -51,11 +54,13 @@ use openehr_am::am24::aom2::constraint_model::primitive::c_real::CReal;
 use openehr_am::am24::aom2::constraint_model::primitive::c_string::CString;
 use openehr_am::am24::aom2::constraint_model::primitive::c_terminology_code::CTerminologyCode;
 use openehr_am::am24::aom2::terminology::archetype_terminology::ArchetypeTerminology;
+use openehr_am::am24::beom::core::assertion::Assertion;
 use openehr_base::prelude::{Cardinality, Interval, MultiplicityInterval, ProperInterval};
 
 use super::model::{
-    WebTemplate, WebTemplateBindingCodedValue, WebTemplateCardinality, WebTemplateCodedValue,
-    WebTemplateInput, WebTemplateInputType, WebTemplateNode, WebTemplateRange,
+    WebTemplate, WebTemplateArchetypeSlot, WebTemplateBindingCodedValue, WebTemplateCardinality,
+    WebTemplateClosedAttribute, WebTemplateCodedValue, WebTemplateExistence, WebTemplateInput,
+    WebTemplateInputType, WebTemplateNode, WebTemplateRange, WebTemplateStructuralStub,
     WebTemplateValidation,
 };
 use super::shape;
@@ -335,6 +340,17 @@ fn build_children(
     }
 
     node.cardinalities = cardinalities(co, &node.aql_path);
+    node.card_all = all_cardinalities(co, &node.aql_path);
+    // Existence / closed-attribute / structural-stub capture is meaningful only
+    // for attribute-recursing (structural) nodes; a DV leaf's constraints are
+    // handled by `inputs` (mirrors the OPT-1.4 front end's `recurse_attrs` guard).
+    if recurse_attrs {
+        node.existence = existence_constraints(co, &node.aql_path);
+        node.closed_attributes = closed_attributes(co, &node.aql_path);
+        if shape::is_entry_family(&node.rm_type) {
+            node.structural_stubs = structural_stubs(ctx, term, co);
+        }
+    }
     node.children = children;
     shape::post_process(node);
 }
@@ -778,6 +794,225 @@ fn requires_cardinality(card: &Cardinality, children_count: usize) -> bool {
     } else {
         min > 1 || (max != -1 && max < count)
     }
+}
+
+// ── archetype-conformance constraint capture (validation-only fields) ─────────
+//
+// The am24 front end fills the same validation-only constraint fields the OPT-1.4
+// front end does ([`super::builder`]), so
+// [`crate::flat::validation::validate_archetype_conformance`] runs identically
+// for both dialects. AOM2 expresses these as `C_ATTRIBUTE.existence` /
+// `C_ATTRIBUTE.cardinality` / node-identified `C_OBJECT` alternatives /
+// `ARCHETYPE_SLOT` (AOM2 `AM/docs/AOM2/master02-archetype_definition.adoc`
+// §C_ATTRIBUTE, §ARCHETYPE_SLOT). Captured from the raw `co` (before the shared
+// [`super::shape`] compaction hoists wrappers and re-homes these — by absolute
+// archetype path — onto the surviving parent), so no constraint is lost.
+
+/// Capture EVERY constraining `C_ATTRIBUTE.cardinality` (AOM2 §C_ATTRIBUTE:
+/// "Cardinality constraint of attribute, if a container attribute") for the
+/// validation walk: any interval with a lower bound `>= 1` or a bounded upper
+/// bound constrains the container. A superset of the serialized [`cardinalities`]
+/// selection, so `0..1`/`1..1`/`1..*` container bounds are enforced from
+/// [`WebTemplateNode::card_all`] too (mirrors the OPT-1.4 front end).
+fn all_cardinalities(co: &CObject, node_path: &str) -> Vec<WebTemplateCardinality> {
+    let mut out = Vec::new();
+    for attr in co_attributes(co) {
+        let Some(card) = &attr.cardinality else {
+            continue;
+        };
+        let (min, max) = occ(&card.interval);
+        if min.unwrap_or(0) >= 1 || max != -1 {
+            out.push(WebTemplateCardinality {
+                min,
+                max,
+                ids: None,
+                path: format!("{node_path}/{}", attr.rm_attribute_name),
+            });
+        }
+    }
+    out
+}
+
+/// Capture the AOM2 `C_ATTRIBUTE.existence` constraints (AOM2 §C_ATTRIBUTE:
+/// existence "indicates whether its target object exists or not, i.e. is
+/// mandatory or not") with a lower bound `>= 1`, keyed by the attribute's
+/// absolute archetype path. `existence` is `Option` in AOM2 — "Only set if it
+/// overrides the underlying reference model or parent archetype" (AOM2
+/// §C_ATTRIBUTE) — so only an explicitly-mandated attribute is captured, biasing
+/// toward confident violations exactly as the OPT-1.4 front end does (where the
+/// RM-mandatory presence an AOM2 template leaves to the RM is still covered by the
+/// RM-invariant pass + occurrences). `name` is excluded — it names the node
+/// (master04 §"Field Identifiers").
+fn existence_constraints(co: &CObject, node_path: &str) -> Vec<WebTemplateExistence> {
+    let mut out = Vec::new();
+    for attr in co_attributes(co) {
+        if attr.rm_attribute_name == "name" {
+            continue;
+        }
+        let Some(ex) = &attr.existence else {
+            continue;
+        };
+        let (min, max) = occ(ex);
+        let min = min.unwrap_or(0);
+        if min < 1 {
+            continue;
+        }
+        // A container mandates the attribute's presence regardless of member
+        // cardinality (existence and cardinality are orthogonal, AOM2
+        // §C_ATTRIBUTE). A single-valued attribute counts when it is object-valued
+        // (a navigable RM instance attribute) or a bare mandatory attribute with no
+        // value constraint — a pure primitive-value constraint never appears as a
+        // navigable instance attribute.
+        let object_valued = attr.is_multiple
+            || attr.children.is_empty()
+            || attr.children.iter().any(is_object_valued);
+        if !object_valued {
+            continue;
+        }
+        out.push(WebTemplateExistence {
+            min,
+            max,
+            path: format!("{node_path}/{}", attr.rm_attribute_name),
+        });
+    }
+    out
+}
+
+/// Whether a child `C_OBJECT` is an object-valued (navigable) constraint — a
+/// complex object, an inlined archetype root, a proxy, or a slot — as opposed to
+/// a primitive value constraint (`C_STRING`/`C_INTEGER`/… never appears as a
+/// navigable RM instance attribute).
+fn is_object_valued(co: &CObject) -> bool {
+    matches!(
+        co,
+        CObject::CComplexObject(_) | CObject::CComplexObjectProxy(_) | CObject::ArchetypeSlot(_)
+    )
+}
+
+/// Capture the closed-archetype constraints (the AOM2 closed-world direction):
+/// per attribute carrying node-identified `C_OBJECT` alternatives and/or
+/// `ARCHETYPE_SLOT`s, the admissible child identities keyed by the attribute's
+/// absolute archetype path. An attribute carrying an unresolved
+/// `C_COMPLEX_OBJECT_PROXY` is left OPEN (its target is not resolved in this front
+/// end — matching the OPT-1.4 internal-ref handling), and a purely
+/// primitive/unconstrained attribute is never closed. `name` is matched by
+/// predicate, not closure (master04 §"Field Identifiers").
+fn closed_attributes(co: &CObject, node_path: &str) -> Vec<WebTemplateClosedAttribute> {
+    let mut out = Vec::new();
+    for attr in co_attributes(co) {
+        if attr.rm_attribute_name == "name" {
+            continue;
+        }
+        // An unresolved proxy makes the admissible set uncertain: leave OPEN
+        // rather than risk over-rejecting.
+        if attr
+            .children
+            .iter()
+            .any(|c| matches!(c, CObject::CComplexObjectProxy(_)))
+        {
+            continue;
+        }
+        let mut allowed_ids: Vec<String> = Vec::new();
+        let mut slots: Vec<WebTemplateArchetypeSlot> = Vec::new();
+        for child in &attr.children {
+            match child {
+                CObject::ArchetypeSlot(s) => slots.push(archetype_slot(s)),
+                // A node-identified LOCATABLE alternative (an at/id-coded
+                // C_COMPLEX_OBJECT, or an inlined C_ARCHETYPE_ROOT carrying its
+                // interface archetype id). Primitive value constraints never
+                // participate in sibling closure.
+                CObject::CComplexObject(_) => {
+                    let id = object_archetype_node_id(child);
+                    if !id.is_empty() {
+                        allowed_ids.push(id);
+                    }
+                }
+                _ => {}
+            }
+        }
+        if allowed_ids.is_empty() && slots.is_empty() {
+            continue; // Open attribute (no node-id alternatives, no slot).
+        }
+        out.push(WebTemplateClosedAttribute {
+            path: format!("{node_path}/{}", attr.rm_attribute_name),
+            allowed_ids,
+            slots,
+        });
+    }
+    out
+}
+
+/// The validation-only slot record from an AOM2 `ARCHETYPE_SLOT`: its constrained
+/// RM type, occurrences bounds, and the archetype-id regexes lifted from the
+/// include/exclude assertions (AOM2 §ARCHETYPE_SLOT: `includes`/`excludes` are
+/// ASSERTIONs of the form `EXPR_ARCHETYPE_REF matches EXPR_ARCHETYPE_ID_CONSTRAINT`).
+fn archetype_slot(s: &ArchetypeSlot) -> WebTemplateArchetypeSlot {
+    let (min, max) = occurrences(s.occurrences.as_ref());
+    WebTemplateArchetypeSlot {
+        rm_type: s.rm_type_name.clone(),
+        min: min.unwrap_or(0).max(0),
+        max,
+        includes: s.includes.iter().filter_map(slot_pattern).collect(),
+        excludes: s.excludes.iter().filter_map(slot_pattern).collect(),
+    }
+}
+
+/// The archetype-id regex of a slot `ASSERTION`, lifted from its
+/// `string_expression` (`… matches {/<regex>/}`; AOM2 §ARCHETYPE_SLOT — the
+/// serialised assertion form). Archetype ids contain no `/`, so the last `/}`
+/// delimits the regex.
+fn slot_pattern(a: &Assertion) -> Option<String> {
+    let s = a.string_expression.as_deref()?;
+    let start = s.find("matches {/")? + "matches {/".len();
+    let rest = &s[start..];
+    let end = rest.rfind("/}")?;
+    Some(rest[..end].to_owned())
+}
+
+/// The RM-mandatory structural attributes of an ENTRY whose value the FLAT/TDD
+/// composition builder synthesises when the simplified form carries no content
+/// under them (the ENTRY `data`/`state`/`protocol` plus `ACTION.description`;
+/// RM `composition`).
+const ENTRY_STRUCTURAL_ATTRS: [&str; 4] = ["data", "description", "protocol", "state"];
+
+/// Capture the structural stubs for an ENTRY node (mirrors the OPT-1.4 front
+/// end): for each RM-mandatory structural attribute the OPT constrains with a
+/// node-identified structural child, record its RM type, archetype node id, and
+/// rubric name. The compactor drops such a wrapper when it carries no leaf
+/// content, so this is the only surviving record of the *constrained* identity —
+/// the composition builder synthesises the empty attribute from it (AOM2
+/// §C_ATTRIBUTE: a constrained attribute must be filled by a conforming value)
+/// rather than a blind `at0001`/`id1` placeholder a closed-archetype walk rejects.
+fn structural_stubs(
+    ctx: &Ctx,
+    term: &ArchetypeTerminology,
+    co: &CObject,
+) -> Vec<WebTemplateStructuralStub> {
+    let mut out = Vec::new();
+    for attr in co_attributes(co) {
+        if !ENTRY_STRUCTURAL_ATTRS.contains(&attr.rm_attribute_name.as_str()) {
+            continue;
+        }
+        for child in &attr.children {
+            // Only a node-identified structural child gives a concrete identity to
+            // stamp; a slot / proxy leaves the attribute to its placeholder.
+            let CObject::CComplexObject(_) = child else {
+                continue;
+            };
+            let node_id = object_archetype_node_id(child);
+            if node_id.is_empty() {
+                continue;
+            }
+            out.push(WebTemplateStructuralStub {
+                attr: attr.rm_attribute_name.clone(),
+                rm_type: object_rm_type(child).to_owned(),
+                node_id,
+                name: rubric_text(term, object_node_id(child), &ctx.default_language),
+            });
+            break; // first node-identified structural child under this attribute
+        }
+    }
+    out
 }
 
 // ── am24 C_OBJECT navigation ─────────────────────────────────────────────────

--- a/crates/openehr-its/tests/webtemplate_am24.rs
+++ b/crates/openehr-its/tests/webtemplate_am24.rs
@@ -23,8 +23,12 @@ use openehr_adl::assemble::parse_artefact;
 use openehr_adl::opt::create_opt;
 use openehr_adl::validate::ArchetypeRepository;
 use openehr_its::flat::example::{DetailLevel, ExampleType, example_composition};
-use openehr_its::flat::validation::validate_rm_and_terminology;
-use openehr_its::flat::webtemplate::{WebTemplate, WebTemplateNode, build_web_template_am24};
+use openehr_its::flat::validation::{
+    ValidationKind, validate_archetype_conformance, validate_rm_and_terminology,
+};
+use openehr_its::flat::webtemplate::{
+    WebTemplate, WebTemplateCardinality, WebTemplateNode, build_web_template_am24,
+};
 
 const OBS_UPGRADE: &str =
     "upgrade/upgrade_from_14/openEHR-EHR-OBSERVATION.upgrade_add_use_nodes.v1.0.0.adls";
@@ -335,4 +339,96 @@ fn collect_ids(node: &WebTemplateNode, out: &mut Vec<String>) {
     for c in &node.children {
         collect_ids(c, out);
     }
+}
+
+// ── archetype-conformance validation (#269): the am24 builder now populates the
+//    validation-only constraint fields the walk reads, symmetric with OPT 1.4 ──
+
+/// Every `card_all` entry in the tree (depth-first).
+fn collect_card_all<'a>(node: &'a WebTemplateNode, out: &mut Vec<&'a WebTemplateCardinality>) {
+    out.extend(node.card_all.iter());
+    for c in &node.children {
+        collect_card_all(c, out);
+    }
+}
+
+/// Pad every `items` container currently holding 1..=6 members up to 8 by cloning
+/// its first member — exceeding an AOM2 `items cardinality {1..6}` upper bound.
+fn pad_items(v: &mut serde_json::Value) {
+    match v {
+        serde_json::Value::Array(a) => {
+            for item in a.iter_mut() {
+                pad_items(item);
+            }
+        }
+        serde_json::Value::Object(o) => {
+            let keys: Vec<String> = o.keys().cloned().collect();
+            for k in keys {
+                if let Some(val) = o.get_mut(&k) {
+                    pad_items(val);
+                }
+            }
+            if let Some(serde_json::Value::Array(items)) = o.get_mut("items")
+                && !items.is_empty()
+                && items.len() <= 6
+            {
+                let proto = items[0].clone();
+                while items.len() < 8 {
+                    items.push(proto.clone());
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+#[test]
+fn am24_populates_archetype_conformance_constraints() {
+    // The apgar OBSERVATION source carries `events cardinality {1..*}` and
+    // `items cardinality {1..6}` (AOM2 §C_ATTRIBUTE cardinality). The am24 front
+    // end now captures EVERY constraining cardinality into `card_all` for the
+    // validation walk, exactly as the OPT-1.4 front end does — so
+    // `validate_archetype_conformance` runs identically for both dialects.
+    let wt = web_template(OBS_APGAR);
+    let mut cards = Vec::new();
+    collect_card_all(&wt.tree, &mut cards);
+    assert!(
+        cards.iter().any(|c| c.max == 6),
+        "the `items {{1..6}}` bounded cardinality is captured, got {:?}",
+        cards.iter().map(|c| (c.min, c.max)).collect::<Vec<_>>()
+    );
+    assert!(
+        cards.iter().any(|c| c.min == Some(1) && c.max == -1),
+        "the `events {{1..*}}` cardinality is captured, got {:?}",
+        cards.iter().map(|c| (c.min, c.max)).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn am24_archetype_conformance_walk_enforces_cardinality() {
+    let wt = web_template(OBS_APGAR);
+    // A self-consistent example carries no cardinality violation against its own
+    // ADL2 template (symmetric with the OPT-1.4 front end, whose generated
+    // examples validate clean — `crates/openehr-its/tests/validation.rs`).
+    let comp = example_composition(&wt, DetailLevel::Complete);
+    let baseline = validate_archetype_conformance(&comp, &wt);
+    assert!(
+        !baseline
+            .iter()
+            .any(|m| m.kind == ValidationKind::Cardinality),
+        "baseline example must have no cardinality violation, got {baseline:?}"
+    );
+    // Padding a constrained `items` container beyond its `{1..6}` upper bound is
+    // rejected with the SAME typed outcome the OPT-1.4 path produces
+    // (`ValidationKind::Cardinality`).
+    let mut bad = comp;
+    pad_items(&mut bad);
+    let msgs = validate_archetype_conformance(&bad, &wt);
+    assert!(
+        msgs.iter().any(|m| m.kind == ValidationKind::Cardinality),
+        "expected a Cardinality violation after exceeding `items {{1..6}}`, got {:?}",
+        msgs.iter()
+            .map(|m| (m.kind, m.path.clone()))
+            .collect::<Vec<_>>()
+    );
 }

--- a/crates/openehr-its/tests/webtemplate_am24.rs
+++ b/crates/openehr-its/tests/webtemplate_am24.rs
@@ -432,3 +432,124 @@ fn am24_archetype_conformance_walk_enforces_cardinality() {
             .collect::<Vec<_>>()
     );
 }
+
+/// The template-with-filler seam: an ADL2 `template` whose content is a
+/// `use_archetype` C_ARCHETYPE_ROOT fill of a separately-held archetype must
+/// project a WebTemplate that CONTAINS the filler's flattened subtree — the
+/// normal ADL2 composition case (AOM2 master06 §Templates: slot fills;
+/// OPT2 master03: the created OPT inlines every filler). Regression for the
+/// live defect where the projected WT carried no content nodes and every FLAT
+/// path under the fill was "unknown simplified path".
+const FILLER_ARCHETYPE: &str = r#"archetype (adl_version=2.0.6; rm_release=1.0.2; generated)
+    openEHR-EHR-OBSERVATION.cnf_count_a.v1.0.0
+
+language
+    original_language = <[ISO_639-1::en]>
+
+description
+    lifecycle_state = <"unmanaged">
+    original_author = <
+        ["name"] = <"openEHR CNF">
+    >
+
+definition
+    OBSERVATION[id1] matches {    -- Observation one
+        data matches {
+            HISTORY[id2] matches {
+                events cardinality matches {1..*; unordered} matches {
+                    POINT_EVENT[id3] occurrences matches {0..*} matches {
+                        data matches {
+                            ITEM_TREE[id4] matches {
+                                items cardinality matches {1..1; unordered} matches {
+                                    ELEMENT[id5] occurrences matches {1..1} matches {
+                                        value matches {
+                                            DV_COUNT[id6]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+terminology
+    term_definitions = <
+        ["en"] = <
+            ["id1"] = <text = <"Observation one">; description = <"A constrained observation">>
+            ["id2"] = <text = <"History">; description = <"Event history">>
+            ["id3"] = <text = <"Any event">; description = <"A point event">>
+            ["id4"] = <text = <"Tree">; description = <"Item tree">>
+            ["id5"] = <text = <"Count item">; description = <"A count element">>
+            ["id6"] = <text = <"Count value">; description = <"The count value">>
+        >
+    >
+"#;
+
+const FILLER_TEMPLATE: &str = r#"template (adl_version=2.0.6; rm_release=1.0.2; generated)
+    openEHR-EHR-COMPOSITION.cnf_adl2_flat_a.v1.0.0
+
+language
+    original_language = <[ISO_639-1::en]>
+
+description
+    lifecycle_state = <"unmanaged">
+    original_author = <
+        ["name"] = <"openEHR CNF">
+    >
+
+definition
+    COMPOSITION[id1] matches {    -- Adl2 flat
+        content cardinality matches {1..*; unordered} matches {
+            use_archetype OBSERVATION[id2, openEHR-EHR-OBSERVATION.cnf_count_a.v1.0.0]
+        }
+    }
+
+terminology
+    term_definitions = <
+        ["en"] = <
+            ["id1"] = <text = <"Adl2 flat">; description = <"ADL2 FLAT-parity encounter">>
+            ["id2"] = <text = <"Observation one">; description = <"The filled observation">>
+        >
+    >
+"#;
+
+#[test]
+fn am24_template_filler_subtree_reaches_the_web_template() {
+    let mut repo = ArchetypeRepository::new();
+    repo.insert(parse_artefact(FILLER_ARCHETYPE).expect("parse filler archetype"));
+    let template = parse_artefact(FILLER_TEMPLATE).expect("parse template");
+    let opt = create_opt(&template, &repo).expect("create_opt inlines the filler");
+    let wt = build_web_template_am24(&opt).expect("build am24 web template");
+
+    let mut observations = Vec::new();
+    collect_typed(&wt.tree, "OBSERVATION", &mut observations);
+    assert!(
+        !observations.is_empty(),
+        "the filled OBSERVATION must appear in the projected WebTemplate; tree rm types: {:?}",
+        rm_types(&wt.tree)
+    );
+    let count = find(&wt.tree, "count_item").unwrap_or_else(|| {
+        panic!(
+            "count_item leaf missing; tree rm types: {:?}",
+            rm_types(&wt.tree)
+        )
+    });
+    // The shared shape pass compacts an ELEMENT to its value type (the Better
+    // WebTemplate convention, identical to the OPT 1.4 front end).
+    assert_eq!(count.rm_type, "DV_COUNT");
+    // The generated Complete example must realize the mandatory leaf, and it
+    // must satisfy its own template (the FLAT commit path depends on both).
+    let comp = example_composition(&wt, DetailLevel::Complete);
+    assert!(
+        comp.pointer("/content/0/archetype_details").is_some(),
+        "the filled ENTRY must be an archetype root (RM composition entry.adoc §Invariants Is_archetype_root)"
+    );
+    let msgs = validate_archetype_conformance(&comp, &wt);
+    assert!(
+        msgs.is_empty(),
+        "the Complete example must satisfy its own template, got {msgs:?}"
+    );
+}

--- a/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
@@ -7,12 +7,12 @@ Runner: cnf-runner 3.9.0 · verification pack: passed
 
 | Status | Count |
 | --- | --- |
-| passed | 371 |
+| passed | 373 |
 | failed | 0 |
 | errored | 0 |
 | skipped | 0 |
 | not_applicable | 67 |
-| total | 438 |
+| total | 440 |
 
 ## By chapter
 
@@ -35,7 +35,7 @@ Runner: cnf-runner 3.9.0 · verification pack: passed
 | I_QUERY_SERVICE | 15 | 0 | 0 | 0 | 0 |
 | I_TDD_SERVICE | 0 | 0 | 0 | 0 | 4 |
 | SEC | 5 | 0 | 0 | 0 | 0 |
-| SF | 50 | 0 | 0 | 0 | 1 |
+| SF | 52 | 0 | 0 | 0 | 1 |
 | SIG | 5 | 0 | 0 | 0 | 0 |
 
 ## Performance measurements
@@ -73,7 +73,7 @@ Percentiles re-derive from the embedded HDR V2 histograms; the class verdict is 
 
 ## Honesty
 
-Coverage: 371 of 438 selected cases driven.
+Coverage: 373 of 440 selected cases driven.
 
 Not-executed verdicts (each cited):
 

--- a/docs/conformance/ehrbase-rs/badge.json
+++ b/docs/conformance/ehrbase-rs/badge.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "openEHR conformance",
-  "message": "CORE+STANDARD PASS \u00b7 371/371 cases",
+  "message": "CORE+STANDARD PASS \u00b7 373/373 cases",
   "color": "brightgreen"
 }

--- a/docs/conformance/ehrbase-rs/results.json
+++ b/docs/conformance/ehrbase-rs/results.json
@@ -2468,6 +2468,18 @@
       "rows_total": 1
     },
     {
+      "case": "SF-FLAT-adl2_commit",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "SF-FLAT-adl2_reject_cardinality",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "SF-FLAT-commit_roundtrip_ctx_defaults",
       "status": "passed",
       "rows_driven": 1,

--- a/docs/conformance/ehrbase-rs/verdicts.json
+++ b/docs/conformance/ehrbase-rs/verdicts.json
@@ -183,7 +183,7 @@
     }
   ],
   "coverage": {
-    "selected": 438,
-    "driven": 371
+    "selected": 440,
+    "driven": 373
   }
 }

--- a/docs/endpoint-map.md
+++ b/docs/endpoint-map.md
@@ -1057,8 +1057,13 @@ chain: composition dispatcher → `composition_from_flat` / `composition_from_st
 `EhrbaseService::web_template` (the one shared moka WebTemplate cache) →
 `openehr_its::flat::validate_flat_other` + `from_flat`/`from_structured` → the normal
 composition commit
-sql: 0–1 round trips of its own — WebTemplate cache hit = 0, miss = 1 SELECT
-template_store (then the underlying composition operation's SQL)
+sql: 0–2 round trips of its own — WebTemplate cache hit = 0; miss = 1 SELECT
+template_store, and (when the id is not an ADL 1.4 template) a fall-back to the
+ADL2/OPT2 store (`web_template_adl2_cached` → `adl2_resolve`/`adl2_get`, cached
+under a dialect-namespaced key), so a commit keyed to an ADL2-registered template
+also resolves + archetype-conformance-validates (`build_web_template_am24` carries
+the same constraints); only after both stores miss is it the 422 "operational
+template not known" (then the underlying composition operation's SQL)
 notes: template id from `template_id`/`templateId` query param or the
 `openEHR-TEMPLATE_ID` header (a FLAT body carries none) — absent → 400; invalid JSON →
 400; well-formed-but-non-conformant simSDT/structSDT → **422** (ITS-REST

--- a/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
+++ b/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
@@ -1364,20 +1364,32 @@ cnf.adl2.opt.vitals:
   rm_versions: [">=1.0.2"]
   validity: { verdict: valid }
   provenance: "authored 2026-07-21 from the SM I_DEFINITION_ADL2 operation semantics; second valid OPT for list/count coverage; ADL2 source represented as opt-xml pending the adl2-text CorpusFormat addition; structural placeholder pending corpus authoring"
+cnf.adl2.archetype.count_a:
+  source: fixtures/adl2/archetype/cnf_count_a.adls
+  format: adl2-text
+  rm_versions: [">=1.0.2"]
+  validity: { verdict: valid }
+  provenance: "authored 2026-07-24 spine-first as the constrained OBSERVATION archetype behind the FLAT-over-ADL2 cases (AM AOM2 §C_ATTRIBUTE cardinality): items cardinality 1..1 + ELEMENT occurrences 1..1 give the FLAT reject row a real archetype constraint to violate"
+cnf.adl2.archetype.count_b:
+  source: fixtures/adl2/archetype/cnf_count_b.adls
+  format: adl2-text
+  rm_versions: [">=1.0.2"]
+  validity: { verdict: valid }
+  provenance: "derived 2026-07-24 from cnf.adl2.archetype.count_a by renaming the archetype HRID — each ADL2 upload-flow case owns a fresh logical artefact on a shared world"
 cnf.adl2.opt.flat_a:
   source: fixtures/adl2/opt/flat_parity_a.adls
   format: adl2-text
   rm_versions: [">=1.0.2"]
   validity: { verdict: valid }
   template_id: "openEHR-EHR-COMPOSITION.cnf_adl2_flat_a.v1.0.0"
-  provenance: "authored 2026-07-24 spine-first as the constrained ADL2 operational template for the FLAT-over-ADL2 commit cases (AM ADL2 §Templates; ITS-REST simplified_formats master04): items cardinality 1..1 + ELEMENT occurrences 1..1 give the FLAT reject row a real archetype constraint to violate"
+  provenance: "authored 2026-07-24 spine-first as the ADL2 template for the FLAT-over-ADL2 commit cases: its content is a use_archetype fill of cnf.adl2.archetype.count_a (AOM2 master06 §Templates — an ENTRY under content must be an archetype root, RM composition entry.adoc §Invariants Is_archetype_root; the constraint under test lives in the filled archetype)"
 cnf.adl2.opt.flat_b:
   source: fixtures/adl2/opt/flat_parity_b.adls
   format: adl2-text
   rm_versions: [">=1.0.2"]
   validity: { verdict: valid }
   template_id: "openEHR-EHR-COMPOSITION.cnf_adl2_flat_b.v1.0.0"
-  provenance: "derived 2026-07-24 from cnf.adl2.opt.flat_a by renaming the archetype HRID — each ADL2 upload-flow case owns a fresh logical artefact on a shared world"
+  provenance: "derived 2026-07-24 from cnf.adl2.opt.flat_a by renaming the template + filled-archetype HRIDs (fills cnf.adl2.archetype.count_b) — each ADL2 upload-flow case owns a fresh logical artefact on a shared world"
 cnf.adl2.opt.invalid.unparseable:
   source: fixtures/adl2/opt/invalid/unparseable.adls
   format: adl2-text

--- a/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
+++ b/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
@@ -1364,6 +1364,20 @@ cnf.adl2.opt.vitals:
   rm_versions: [">=1.0.2"]
   validity: { verdict: valid }
   provenance: "authored 2026-07-21 from the SM I_DEFINITION_ADL2 operation semantics; second valid OPT for list/count coverage; ADL2 source represented as opt-xml pending the adl2-text CorpusFormat addition; structural placeholder pending corpus authoring"
+cnf.adl2.opt.flat_a:
+  source: fixtures/adl2/opt/flat_parity_a.adls
+  format: adl2-text
+  rm_versions: [">=1.0.2"]
+  validity: { verdict: valid }
+  template_id: "openEHR-EHR-COMPOSITION.cnf_adl2_flat_a.v1.0.0"
+  provenance: "authored 2026-07-24 spine-first as the constrained ADL2 operational template for the FLAT-over-ADL2 commit cases (AM ADL2 §Templates; ITS-REST simplified_formats master04): items cardinality 1..1 + ELEMENT occurrences 1..1 give the FLAT reject row a real archetype constraint to violate"
+cnf.adl2.opt.flat_b:
+  source: fixtures/adl2/opt/flat_parity_b.adls
+  format: adl2-text
+  rm_versions: [">=1.0.2"]
+  validity: { verdict: valid }
+  template_id: "openEHR-EHR-COMPOSITION.cnf_adl2_flat_b.v1.0.0"
+  provenance: "derived 2026-07-24 from cnf.adl2.opt.flat_a by renaming the archetype HRID — each ADL2 upload-flow case owns a fresh logical artefact on a shared world"
 cnf.adl2.opt.invalid.unparseable:
   source: fixtures/adl2/opt/invalid/unparseable.adls
   format: adl2-text
@@ -1531,6 +1545,23 @@ cnf.sf.flat.datatype_mismatch:
     spec_ref: "ITS-REST simplified_formats master04 §Validation (data types match expected types from the OPT)"
   provenance: "authored 2026-07-21 by setting |magnitude to a string; structural placeholder pending corpus authoring"
 
+cnf.sf.flat.adl2_valid:
+  source: fixtures/sf/flat.adl2_valid.json
+  format: wt-flat
+  rm_versions: [">=1.0.2"]
+  validity: { verdict: valid }
+  template_id: "openEHR-EHR-COMPOSITION.cnf_adl2_flat_a.v1.0.0"
+  provenance: "authored 2026-07-24 against cnf.adl2.opt.flat_a — a single count_item instance satisfying the 1..1 items cardinality (ITS-REST simplified_formats master04 §Flat Format; DV_COUNT as a bare number per master05 per-type table)"
+cnf.sf.flat.adl2_cardinality_violation:
+  source: fixtures/sf/flat.adl2_cardinality_violation.json
+  format: wt-flat
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "second indexed instance (:1) supplied for a node whose ADL2 template pins items cardinality 1..1 and ELEMENT occurrences 1..1"
+    spec_ref: "ITS-REST simplified_formats master04 §Validation (cardinality constraints are satisfied); AM AOM2 §C_ATTRIBUTE (cardinality) via cnf.adl2.opt.flat_b"
+  template_id: "openEHR-EHR-COMPOSITION.cnf_adl2_flat_b.v1.0.0"
+  provenance: "authored 2026-07-24 against cnf.adl2.opt.flat_b by adding count_item:1 beyond the 1..1 cardinality — the ADL2 mirror of cnf.sf.flat.cardinality_violation"
 cnf.sf.flat.cardinality_violation:
   source: fixtures/sf/flat.cardinality_violation.json
   format: wt-flat

--- a/tools/cnf-runner/artifacts/corpus/fixtures/adl2/archetype/cnf_count_a.adls
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/adl2/archetype/cnf_count_a.adls
@@ -1,0 +1,47 @@
+archetype (adl_version=2.0.6; rm_release=1.0.2; generated)
+    openEHR-EHR-OBSERVATION.cnf_count_a.v1.0.0
+
+
+language
+    original_language = <[ISO_639-1::en]>
+
+description
+    lifecycle_state = <"unmanaged">
+    original_author = <
+        ["name"] = <"openEHR CNF">
+    >
+
+definition
+    OBSERVATION[id1] matches {    -- Observation one
+        data matches {
+            HISTORY[id2] matches {
+                events cardinality matches {1..*; unordered} matches {
+                    POINT_EVENT[id3] occurrences matches {0..*} matches {
+                        data matches {
+                            ITEM_TREE[id4] matches {
+                                items cardinality matches {1..1; unordered} matches {
+                                    ELEMENT[id5] occurrences matches {1..1} matches {
+                                        value matches {
+                                            DV_COUNT[id6]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+terminology
+    term_definitions = <
+        ["en"] = <
+            ["id1"] = <text = <"Observation one">; description = <"A constrained observation">>
+            ["id2"] = <text = <"History">; description = <"Event history">>
+            ["id3"] = <text = <"Any event">; description = <"A point event">>
+            ["id4"] = <text = <"Tree">; description = <"Item tree">>
+            ["id5"] = <text = <"Count item">; description = <"A count element — exactly one per event (items cardinality 1..1, occurrences 1..1)">>
+            ["id6"] = <text = <"Count value">; description = <"The count value">>
+        >
+    >

--- a/tools/cnf-runner/artifacts/corpus/fixtures/adl2/archetype/cnf_count_b.adls
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/adl2/archetype/cnf_count_b.adls
@@ -1,0 +1,47 @@
+archetype (adl_version=2.0.6; rm_release=1.0.2; generated)
+    openEHR-EHR-OBSERVATION.cnf_count_b.v1.0.0
+
+
+language
+    original_language = <[ISO_639-1::en]>
+
+description
+    lifecycle_state = <"unmanaged">
+    original_author = <
+        ["name"] = <"openEHR CNF">
+    >
+
+definition
+    OBSERVATION[id1] matches {    -- Observation one
+        data matches {
+            HISTORY[id2] matches {
+                events cardinality matches {1..*; unordered} matches {
+                    POINT_EVENT[id3] occurrences matches {0..*} matches {
+                        data matches {
+                            ITEM_TREE[id4] matches {
+                                items cardinality matches {1..1; unordered} matches {
+                                    ELEMENT[id5] occurrences matches {1..1} matches {
+                                        value matches {
+                                            DV_COUNT[id6]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+terminology
+    term_definitions = <
+        ["en"] = <
+            ["id1"] = <text = <"Observation one">; description = <"A constrained observation">>
+            ["id2"] = <text = <"History">; description = <"Event history">>
+            ["id3"] = <text = <"Any event">; description = <"A point event">>
+            ["id4"] = <text = <"Tree">; description = <"Item tree">>
+            ["id5"] = <text = <"Count item">; description = <"A count element — exactly one per event (items cardinality 1..1, occurrences 1..1)">>
+            ["id6"] = <text = <"Count value">; description = <"The count value">>
+        >
+    >

--- a/tools/cnf-runner/artifacts/corpus/fixtures/adl2/opt/flat_parity_a.adls
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/adl2/opt/flat_parity_a.adls
@@ -1,4 +1,4 @@
-operational_template (adl_version=2.0.6; rm_release=1.0.2; generated)
+template (adl_version=2.0.6; rm_release=1.0.2; generated)
     openEHR-EHR-COMPOSITION.cnf_adl2_flat_a.v1.0.0
 
 
@@ -14,27 +14,7 @@ description
 definition
     COMPOSITION[id1] matches {    -- Adl2 flat
         content cardinality matches {1..*; unordered} matches {
-            OBSERVATION[id2] occurrences matches {0..*} matches {
-                data matches {
-                    HISTORY[id3] matches {
-                        events cardinality matches {1..*; unordered} matches {
-                            POINT_EVENT[id4] occurrences matches {0..*} matches {
-                                data matches {
-                                    ITEM_TREE[id5] matches {
-                                        items cardinality matches {1..1; unordered} matches {
-                                            ELEMENT[id6] occurrences matches {1..1} matches {
-                                                value matches {
-                                                    DV_COUNT[id7]
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            use_archetype OBSERVATION[id2, openEHR-EHR-OBSERVATION.cnf_count_a.v1.0.0]
         }
     }
 
@@ -42,11 +22,6 @@ terminology
     term_definitions = <
         ["en"] = <
             ["id1"] = <text = <"Adl2 flat">; description = <"ADL2 FLAT-parity encounter">>
-            ["id2"] = <text = <"Observation one">; description = <"A constrained observation">>
-            ["id3"] = <text = <"History">; description = <"Event history">>
-            ["id4"] = <text = <"Any event">; description = <"A point event">>
-            ["id5"] = <text = <"Tree">; description = <"Item tree">>
-            ["id6"] = <text = <"Count item">; description = <"A count element — exactly one per event (items cardinality 1..1, occurrences 1..1)">>
-            ["id7"] = <text = <"Count value">; description = <"The count value">>
+            ["id2"] = <text = <"Observation one">; description = <"The constrained observation filling the content slot">>
         >
     >

--- a/tools/cnf-runner/artifacts/corpus/fixtures/adl2/opt/flat_parity_a.adls
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/adl2/opt/flat_parity_a.adls
@@ -1,0 +1,52 @@
+operational_template (adl_version=2.0.6; rm_release=1.0.2; generated)
+    openEHR-EHR-COMPOSITION.cnf_adl2_flat_a.v1.0.0
+
+
+language
+    original_language = <[ISO_639-1::en]>
+
+description
+    lifecycle_state = <"unmanaged">
+    original_author = <
+        ["name"] = <"openEHR CNF">
+    >
+
+definition
+    COMPOSITION[id1] matches {    -- Adl2 flat
+        content cardinality matches {1..*; unordered} matches {
+            OBSERVATION[id2] occurrences matches {0..*} matches {
+                data matches {
+                    HISTORY[id3] matches {
+                        events cardinality matches {1..*; unordered} matches {
+                            POINT_EVENT[id4] occurrences matches {0..*} matches {
+                                data matches {
+                                    ITEM_TREE[id5] matches {
+                                        items cardinality matches {1..1; unordered} matches {
+                                            ELEMENT[id6] occurrences matches {1..1} matches {
+                                                value matches {
+                                                    DV_COUNT[id7]
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+terminology
+    term_definitions = <
+        ["en"] = <
+            ["id1"] = <text = <"Adl2 flat">; description = <"ADL2 FLAT-parity encounter">>
+            ["id2"] = <text = <"Observation one">; description = <"A constrained observation">>
+            ["id3"] = <text = <"History">; description = <"Event history">>
+            ["id4"] = <text = <"Any event">; description = <"A point event">>
+            ["id5"] = <text = <"Tree">; description = <"Item tree">>
+            ["id6"] = <text = <"Count item">; description = <"A count element — exactly one per event (items cardinality 1..1, occurrences 1..1)">>
+            ["id7"] = <text = <"Count value">; description = <"The count value">>
+        >
+    >

--- a/tools/cnf-runner/artifacts/corpus/fixtures/adl2/opt/flat_parity_b.adls
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/adl2/opt/flat_parity_b.adls
@@ -1,4 +1,4 @@
-operational_template (adl_version=2.0.6; rm_release=1.0.2; generated)
+template (adl_version=2.0.6; rm_release=1.0.2; generated)
     openEHR-EHR-COMPOSITION.cnf_adl2_flat_b.v1.0.0
 
 
@@ -14,27 +14,7 @@ description
 definition
     COMPOSITION[id1] matches {    -- Adl2 flat
         content cardinality matches {1..*; unordered} matches {
-            OBSERVATION[id2] occurrences matches {0..*} matches {
-                data matches {
-                    HISTORY[id3] matches {
-                        events cardinality matches {1..*; unordered} matches {
-                            POINT_EVENT[id4] occurrences matches {0..*} matches {
-                                data matches {
-                                    ITEM_TREE[id5] matches {
-                                        items cardinality matches {1..1; unordered} matches {
-                                            ELEMENT[id6] occurrences matches {1..1} matches {
-                                                value matches {
-                                                    DV_COUNT[id7]
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            use_archetype OBSERVATION[id2, openEHR-EHR-OBSERVATION.cnf_count_b.v1.0.0]
         }
     }
 
@@ -42,11 +22,6 @@ terminology
     term_definitions = <
         ["en"] = <
             ["id1"] = <text = <"Adl2 flat">; description = <"ADL2 FLAT-parity encounter">>
-            ["id2"] = <text = <"Observation one">; description = <"A constrained observation">>
-            ["id3"] = <text = <"History">; description = <"Event history">>
-            ["id4"] = <text = <"Any event">; description = <"A point event">>
-            ["id5"] = <text = <"Tree">; description = <"Item tree">>
-            ["id6"] = <text = <"Count item">; description = <"A count element — exactly one per event (items cardinality 1..1, occurrences 1..1)">>
-            ["id7"] = <text = <"Count value">; description = <"The count value">>
+            ["id2"] = <text = <"Observation one">; description = <"The constrained observation filling the content slot">>
         >
     >

--- a/tools/cnf-runner/artifacts/corpus/fixtures/adl2/opt/flat_parity_b.adls
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/adl2/opt/flat_parity_b.adls
@@ -1,0 +1,52 @@
+operational_template (adl_version=2.0.6; rm_release=1.0.2; generated)
+    openEHR-EHR-COMPOSITION.cnf_adl2_flat_b.v1.0.0
+
+
+language
+    original_language = <[ISO_639-1::en]>
+
+description
+    lifecycle_state = <"unmanaged">
+    original_author = <
+        ["name"] = <"openEHR CNF">
+    >
+
+definition
+    COMPOSITION[id1] matches {    -- Adl2 flat
+        content cardinality matches {1..*; unordered} matches {
+            OBSERVATION[id2] occurrences matches {0..*} matches {
+                data matches {
+                    HISTORY[id3] matches {
+                        events cardinality matches {1..*; unordered} matches {
+                            POINT_EVENT[id4] occurrences matches {0..*} matches {
+                                data matches {
+                                    ITEM_TREE[id5] matches {
+                                        items cardinality matches {1..1; unordered} matches {
+                                            ELEMENT[id6] occurrences matches {1..1} matches {
+                                                value matches {
+                                                    DV_COUNT[id7]
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+terminology
+    term_definitions = <
+        ["en"] = <
+            ["id1"] = <text = <"Adl2 flat">; description = <"ADL2 FLAT-parity encounter">>
+            ["id2"] = <text = <"Observation one">; description = <"A constrained observation">>
+            ["id3"] = <text = <"History">; description = <"Event history">>
+            ["id4"] = <text = <"Any event">; description = <"A point event">>
+            ["id5"] = <text = <"Tree">; description = <"Item tree">>
+            ["id6"] = <text = <"Count item">; description = <"A count element — exactly one per event (items cardinality 1..1, occurrences 1..1)">>
+            ["id7"] = <text = <"Count value">; description = <"The count value">>
+        >
+    >

--- a/tools/cnf-runner/artifacts/corpus/fixtures/sf/flat.adl2_cardinality_violation.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/sf/flat.adl2_cardinality_violation.json
@@ -1,0 +1,7 @@
+{
+  "ctx/language": "en",
+  "ctx/territory": "NL",
+  "ctx/composer_self": true,
+  "adl2_flat/observation_one:0/any_event:0/count_item": 3,
+  "adl2_flat/observation_one:0/any_event:0/count_item:1": 4
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/sf/flat.adl2_valid.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/sf/flat.adl2_valid.json
@@ -1,0 +1,6 @@
+{
+  "ctx/language": "en",
+  "ctx/territory": "NL",
+  "ctx/composer_self": true,
+  "adl2_flat/observation_one:0/any_event:0/count_item": 3
+}

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-FLAT-adl2_commit.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-FLAT-adl2_commit.yaml
@@ -31,13 +31,17 @@ applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}
-data_sets: [cnf.adl2.opt.flat_a, cnf.sf.flat.adl2_valid]
+data_sets: [cnf.adl2.archetype.count_a, cnf.adl2.opt.flat_a, cnf.sf.flat.adl2_valid]
 flow:
   - step: 1
     call: I_DEFINITION_ADL2.upload_artefact
-    with: { opt_adl2: "${ds:cnf.adl2.opt.flat_a}" }
+    with: { opt_adl2: "${ds:cnf.adl2.archetype.count_a}" }
     expect: created
   - step: 2
+    call: I_DEFINITION_ADL2.upload_artefact
+    with: { opt_adl2: "${ds:cnf.adl2.opt.flat_a}" }
+    expect: created
+  - step: 3
     call: create_composition
     format: wt-flat                       # binding adds openehr-template-id (from the data set's declared template_id)
     with: { ehr_id: "${ehr_id}", composition: "${ds:cnf.sf.flat.adl2_valid}" }

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-FLAT-adl2_commit.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-FLAT-adl2_commit.yaml
@@ -1,0 +1,48 @@
+# FLAT over an ADL2-registered template — the positive half of the ADL2 FLAT
+# parity pair. Conditional on the SUT declaring BOTH SimplifiedFormats and
+# Adl2OptProvisioning (no docs-text sentence mandates the combination; a SUT
+# not claiming either is N/A here). For a SUT that claims both, the ground is
+# dialect-neutral by the spec's own definitions: the Web Template is "a
+# processed-representation of an openEHR Operational Template" — not of an
+# OPT 1.4 specifically — and "Specification of Web Template metadata is
+# separate from the data serialization format" (simplified_formats master04
+# §Web Template Metadata), while the AM component keeps ADL 1.4 and ADL 2
+# side by side (BASE architecture_overview master05 §Package Structure).
+# Provisioning happens in-flow (upload_artefact) because the ADL2 store is a
+# distinct SM surface from the OPT 1.4 provisioning the `requires.templates`
+# vocabulary drives.
+id: SF-FLAT-adl2_commit
+kind: functional
+component: SIMPLIFIED_FORMATS
+sm_operation: I_EHR_COMPOSITION.create_composition
+capabilities: [SimplifiedFormats, Adl2OptProvisioning]
+profiles: [OPTIONS]           # SHOULD-level per ITS-REST — never gates CORE/STANDARD
+test_purpose: >-
+  A FLAT composition commit keyed to an ADL2-registered operational template
+  resolves the template and is accepted when the instance satisfies its
+  archetype constraints.
+description: "FLAT commit against an ADL2-registered template is accepted"
+spec_refs:
+  - "ITS-REST simplified_formats master04 §Flat Format"
+  - "ITS-REST simplified_formats master04 §Web Template Metadata (dialect-neutral)"
+  - "SM openehr_platform §I_DEFINITION_ADL2.upload_artefact"
+  - "BASE architecture_overview master05 §Package Structure (ADL 1.4 and ADL 2 side by side)"
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+requires:
+  server: any
+  ehr: { commits: none }                 # mints ${ehr_id}
+data_sets: [cnf.adl2.opt.flat_a, cnf.sf.flat.adl2_valid]
+flow:
+  - step: 1
+    call: I_DEFINITION_ADL2.upload_artefact
+    with: { opt_adl2: "${ds:cnf.adl2.opt.flat_a}" }
+    expect: created
+  - step: 2
+    call: create_composition
+    format: wt-flat                       # binding adds openehr-template-id (from the data set's declared template_id)
+    with: { ehr_id: "${ehr_id}", composition: "${ds:cnf.sf.flat.adl2_valid}" }
+    expect: created
+    capture:
+      version_uid: created.version_uid
+    assert:
+      - { assert: version, of: "${version_uid}", change_type: CREATE }

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-FLAT-adl2_reject_cardinality.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-FLAT-adl2_reject_cardinality.yaml
@@ -1,0 +1,41 @@
+# FLAT over an ADL2-registered template — the reject half of the ADL2 FLAT
+# parity pair (simplified_formats master04 §Validation: "Cardinality
+# constraints are satisfied", dialect-neutral). The ADL2 template pins
+# items cardinality 1..1 + ELEMENT occurrences 1..1 (AM AOM2 §C_ATTRIBUTE),
+# so a FLAT commit supplying a second indexed instance (`count_item:1`) must
+# be rejected with the same validation outcome as the OPT 1.4 equivalent
+# (SF-FLAT-reject_cardinality). Own fresh ADL2 artefact (flat_b) per the
+# shared-world collision rule.
+id: SF-FLAT-adl2_reject_cardinality
+kind: functional
+component: SIMPLIFIED_FORMATS
+sm_operation: I_EHR_COMPOSITION.create_composition
+capabilities: [SimplifiedFormats, Adl2OptProvisioning]
+profiles: [OPTIONS]           # SHOULD-level per ITS-REST — never gates CORE/STANDARD
+test_purpose: >-
+  A FLAT commit against an ADL2-registered template that supplies a second
+  indexed instance of a cardinality-1..1 node violates the archetype
+  constraint and is rejected, symmetrically with the OPT 1.4 dialect.
+description: "FLAT commit violating an ADL2 archetype cardinality is rejected"
+spec_refs:
+  - "ITS-REST simplified_formats master04 §Validation"
+  - "ITS-REST simplified_formats master04 §Instance Indexing"
+  - "AM AOM2 §C_ATTRIBUTE (cardinality)"
+  - "ITS-REST overview Requests_and_responses §HTTP status codes"
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+requires:
+  server: any
+  ehr: { commits: none }                 # mints ${ehr_id}
+data_sets: [cnf.adl2.opt.flat_b, cnf.sf.flat.adl2_cardinality_violation]
+flow:
+  - step: 1
+    call: I_DEFINITION_ADL2.upload_artefact
+    with: { opt_adl2: "${ds:cnf.adl2.opt.flat_b}" }
+    expect: created
+  - step: 2
+    call: create_composition
+    format: wt-flat                       # binding adds openehr-template-id (from the data set's declared template_id)
+    with: { ehr_id: "${ehr_id}", composition: "${ds:cnf.sf.flat.adl2_cardinality_violation}" }
+    expect: validation_failed             # create_composition binding: 422
+    assert:
+      - { assert: message_exemplar, text: "instance count exceeds the template cardinality for the node" }

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-FLAT-adl2_reject_cardinality.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-FLAT-adl2_reject_cardinality.yaml
@@ -26,13 +26,17 @@ applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}
-data_sets: [cnf.adl2.opt.flat_b, cnf.sf.flat.adl2_cardinality_violation]
+data_sets: [cnf.adl2.archetype.count_b, cnf.adl2.opt.flat_b, cnf.sf.flat.adl2_cardinality_violation]
 flow:
   - step: 1
     call: I_DEFINITION_ADL2.upload_artefact
-    with: { opt_adl2: "${ds:cnf.adl2.opt.flat_b}" }
+    with: { opt_adl2: "${ds:cnf.adl2.archetype.count_b}" }
     expect: created
   - step: 2
+    call: I_DEFINITION_ADL2.upload_artefact
+    with: { opt_adl2: "${ds:cnf.adl2.opt.flat_b}" }
+    expect: created
+  - step: 3
     call: create_composition
     format: wt-flat                       # binding adds openehr-template-id (from the data set's declared template_id)
     with: { ehr_id: "${ehr_id}", composition: "${ds:cnf.sf.flat.adl2_cardinality_violation}" }

--- a/tools/cnf-runner/src/exec/driver.rs
+++ b/tools/cnf-runner/src/exec/driver.rs
@@ -1165,17 +1165,37 @@ impl HttpDriver<'_> {
                             }
                         }
                         crate::model::binding::FormatHeaderReq::Required => {
-                            // openehr-template-id: the manifest's declared
-                            // template identity for the case's template
-                            // (falling back to the corpus key for entries
-                            // that predate the metadata).
-                            if let Some(key) = case.requires.templates.first() {
-                                let template_id = set
-                                    .corpus
-                                    .as_ref()
-                                    .and_then(|(_, m)| m.get(key))
-                                    .and_then(|e| e.template_id.clone())
-                                    .unwrap_or_else(|| key.to_string());
+                            // openehr-template-id: the committed payload's own
+                            // manifest-declared template identity wins — the
+                            // step's `${ds:…}` body names the data set, and its
+                            // corpus entry carries the authoritative
+                            // `template_id` (this also serves cases that
+                            // provision their template IN-FLOW, e.g. via
+                            // I_DEFINITION_ADL2.upload_artefact, where
+                            // `requires.templates` is rightly empty). Fallback:
+                            // the case's provisioned template list (corpus key
+                            // itself for entries that predate the metadata).
+                            let body_ds_template_id =
+                                step.with_entries().iter().find_map(|(_, v)| {
+                                    v.refs().iter().find_map(|r| match r {
+                                        crate::refgrammar::ValueRef::DataSet { key, .. } => set
+                                            .corpus
+                                            .as_ref()
+                                            .and_then(|(_, m)| m.get(key))
+                                            .and_then(|e| e.template_id.clone()),
+                                        _ => None,
+                                    })
+                                });
+                            let template_id = body_ds_template_id.or_else(|| {
+                                case.requires.templates.first().map(|key| {
+                                    set.corpus
+                                        .as_ref()
+                                        .and_then(|(_, m)| m.get(key))
+                                        .and_then(|e| e.template_id.clone())
+                                        .unwrap_or_else(|| key.to_string())
+                                })
+                            });
+                            if let Some(template_id) = template_id {
                                 headers.insert(name.clone(), template_id);
                             }
                         }

--- a/website/book/src/conformance-assets/conformance-chapter-bars.svg
+++ b/website/book/src/conformance-assets/conformance-chapter-bars.svg
@@ -80,11 +80,11 @@ text { fill: #c3c2b7; }
 
 <text x="472.1818181818182" y="285" class="seg-label" text-anchor="middle">123</text><text x="778.3636363636364" y="285" class="muted">123</text>
 <text x="166" y="319" text-anchor="end">Simplified formats</text>
-<rect x="174" y="302" width="242.42424242424244" height="26" class="bar-passed"/>
+<rect x="174" y="302" width="252.12121212121212" height="26" class="bar-passed"/>
 
-<text x="295.21212121212125" y="319" class="seg-label" text-anchor="middle">50</text><rect x="416.42424242424244" y="302" width="4.848484848484849" height="26" class="bar-na"/>
+<text x="300.06060606060606" y="319" class="seg-label" text-anchor="middle">52</text><rect x="426.1212121212121" y="302" width="4.848484848484849" height="26" class="bar-na"/>
 
-<text x="429.2727272727273" y="319" class="muted">51</text>
+<text x="438.969696969697" y="319" class="muted">53</text>
 <text x="166" y="353" text-anchor="end">Security &amp; privacy</text>
 <rect x="174" y="336" width="24.242424242424242" height="26" class="bar-passed"/>
 

--- a/website/book/src/templates-validation.md
+++ b/website/book/src/templates-validation.md
@@ -150,6 +150,9 @@ Send the matching `Content-Type` when committing, or the matching `Accept` when
 retrieving, and the server converts between the flat/structured form and the
 canonical composition. These formats are a Better/EHRbase interoperability
 convenience; the canonical JSON and XML remain the openEHR-standard wire format.
+They work against both ADL 1.4 and ADL2 templates: a FLAT or STRUCTURED commit
+keyed to an ADL2-registered template resolves and is validated against that
+template's archetype constraints exactly as an ADL 1.4 commit is.
 
 > [!NOTE]
 > The FLAT and STRUCTURED formats are always relative to a template — the paths


### PR DESCRIPTION
## Summary

Implements #269: the ADL2 template surface becomes a **full FLAT/STRUCTURED peer of OPT 1.4** — commits keyed to ADL2-registered templates resolve and are archetype-constraint-checked, and the parity is wire-proven by a new CNF case pair over a spec-authored constrained ADL2 corpus.

### The two behaviour gaps (from the issue contract)

1. **am24 archetype-conformance validation populated**: `build_web_template_am24` now fills the validation-only constraint fields (`existence`, `card_all`, `slots`, `closed_attributes`, `structural_stubs`) from the AOM2 constraint model (AM AOM2 master02 §C_ATTRIBUTE / §ARCHETYPE_SLOT), so `validate_archetype_conformance` runs against ADL2 templates exactly as against OPT 1.4. Shared dialect-neutral downstream unchanged.
2. **Commit-path resolver fallback**: `web_template_for` falls back to the ADL2/OPT2 store on an OPT 1.4 miss (moka-cached under a dialect-namespaced key — collision-impossible per BASE §Archetype Identifiers); only a double miss 422s. No openEHR spec governs the resolver wiring — our own design; grounded in the AM side-by-side mandate (BASE architecture_overview master05).

### Red-run triage during live verification (attribution law — three fixes, none bending an expectation)

- **Corpus**: the first fixture inlined an OBSERVATION under content (violates RM `entry.adoc` §Invariants `Is_archetype_root`) and mislabeled a slot-filled `template` as `operational_template` (an OPT2 is self-contained by definition). Re-modeled spine-first: a constrained OBSERVATION archetype (items cardinality 1..1 + ELEMENT occurrences 1..1) + a `use_archetype` template, a/b variants.
- **Application**: `builder_am24` resolved a filler root's rubric in the component terminology first — the template-side slot id false-matched the constituent's unrelated same-numbered id (the filled OBSERVATION surfaced as "history"). Slot rubric now resolves in the introducing template's terminology first (AOM2 master03 §Validity Rules), component scope last. Regression tests at the engine seam + full service seam.
- **Runner**: the wt-flat `openehr-template-id` header only resolved from `requires.templates`, so in-flow-provisioned templates committed headerless and 422'd generically. Now resolves from the committed `${ds:…}` data set's manifest `template_id` first.

### CNF catalogue

`SF-FLAT-adl2_commit` + `SF-FLAT-adl2_reject_cardinality` — every expectation quoted from the released docs text (simplified_formats master04 §Validation / §Web Template Metadata / §Instance Indexing; master05 DV_COUNT; RM `entry.adoc`), capability-conditional on SimplifiedFormats + Adl2OptProvisioning. Live-verified 2/2 on a fresh composed SUT.

### Also in this PR

- `.dockerignore` (build contexts were shipping the whole tree — observed 53 GB once `target/` grew; precursor finding now programmed in **#282**).
- `cargo clean` hygiene (61 GiB reclaimed per the >30 GB rule).

## Gates

- `cargo build --workspace` · `clippy --workspace --all-targets --all-features` **0 warnings** · `nextest` **2314/2314** · `fmt --check` clean.
- Validator: **440 cases / 90 bindings / 0 findings**.
- Full `scripts/conformance.sh`: **440 case-records → 373 passed / 0 failed / 0 errored / 67 N/A**, 0 review findings — the pair enters the baseline green, zero drift elsewhere. Baseline + assets committed.

Closes #269
