### PR TITLE
feat(cnf): version-signature breadth — distinct-per-version + DIRECTORY N/A coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
+- **Version-signature conformance breadth (CNF)**: a distinct-signature-per-
+  version case (the signature is computed over the version's canonical form,
+  which includes `uid` — two versions can never share a signature; RM common
+  master06 §Digital Signature), backed by a new `distinct_from` fact on the
+  runner's signature assertion and a `signature` capture on the
+  version-envelope read binding. DIRECTORY (FOLDER) version-signature cases
+  land SM-anchored as N/A-with-citation on ITS-REST 1.1.0 (no
+  `versioned_directory` resource — AMB-24), activating automatically if a
+  later ITS release adds the endpoint. The runner's binding-completeness gate
+  now mirrors the interpreter's variant-based binding selection.
+
 - **ADL2/OPT2 templates are full FLAT/STRUCTURED peers of OPT 1.4 (#269)**: a
   FLAT (`application/openehr.wt.flat+json`) or STRUCTURED
   (`application/openehr.wt.structured+json`) composition **commit** keyed to an

--- a/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
@@ -7,12 +7,12 @@ Runner: cnf-runner 3.9.0 · verification pack: passed
 
 | Status | Count |
 | --- | --- |
-| passed | 373 |
+| passed | 374 |
 | failed | 0 |
 | errored | 0 |
 | skipped | 0 |
-| not_applicable | 67 |
-| total | 440 |
+| not_applicable | 69 |
+| total | 443 |
 
 ## By chapter
 
@@ -36,7 +36,7 @@ Runner: cnf-runner 3.9.0 · verification pack: passed
 | I_TDD_SERVICE | 0 | 0 | 0 | 0 | 4 |
 | SEC | 5 | 0 | 0 | 0 | 0 |
 | SF | 52 | 0 | 0 | 0 | 1 |
-| SIG | 5 | 0 | 0 | 0 | 0 |
+| SIG | 6 | 0 | 0 | 0 | 2 |
 
 ## Performance measurements
 
@@ -73,7 +73,7 @@ Percentiles re-derive from the embedded HDR V2 histograms; the class verdict is 
 
 ## Honesty
 
-Coverage: 373 of 440 selected cases driven.
+Coverage: 374 of 443 selected cases driven.
 
 Not-executed verdicts (each cited):
 
@@ -146,3 +146,5 @@ Not-executed verdicts (each cited):
 | I_TDD_SERVICE.import_tdds-bulk_invalid | I_TDD_SERVICE.import_tdds: AMB-34 |
 | I_TDD_SERVICE.import_tdds-bulk_valid | I_TDD_SERVICE.import_tdds: AMB-34 |
 | SF-DEPRECATED-media_supported | option sf-deprecated-types-supported: the ICS does not declare this register branch (statement.options) — ISO/IEC 9646 test selection |
+| SIG-VERSION-directory_signature_present | I_EHR_DIRECTORY.get_versioned_directory: AMB-24 |
+| SIG-VERSION-directory_verifiable | I_EHR_DIRECTORY.get_versioned_directory: AMB-24 |

--- a/docs/conformance/ehrbase-rs/badge.json
+++ b/docs/conformance/ehrbase-rs/badge.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "openEHR conformance",
-  "message": "CORE+STANDARD PASS \u00b7 373/373 cases",
+  "message": "CORE+STANDARD PASS \u00b7 374/374 cases",
   "color": "brightgreen"
 }

--- a/docs/conformance/ehrbase-rs/results.json
+++ b/docs/conformance/ehrbase-rs/results.json
@@ -2389,6 +2389,26 @@
       "rows_total": 1
     },
     {
+      "case": "SIG-VERSION-directory_signature_present",
+      "status": "not_applicable",
+      "rows_driven": 0,
+      "rows_total": 1,
+      "citation": "I_EHR_DIRECTORY.get_versioned_directory: AMB-24"
+    },
+    {
+      "case": "SIG-VERSION-directory_verifiable",
+      "status": "not_applicable",
+      "rows_driven": 0,
+      "rows_total": 1,
+      "citation": "I_EHR_DIRECTORY.get_versioned_directory: AMB-24"
+    },
+    {
+      "case": "SIG-VERSION-distinct_per_version",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "SIG-VERSION-ehr_status_signature",
       "status": "passed",
       "rows_driven": 1,

--- a/docs/conformance/ehrbase-rs/run-exceptions.json
+++ b/docs/conformance/ehrbase-rs/run-exceptions.json
@@ -462,6 +462,20 @@
     }
   },
   {
+    "case": "SIG-VERSION-directory_signature_present",
+    "exception": {
+      "kind": "unrealized",
+      "detail": "I_EHR_DIRECTORY.get_versioned_directory: AMB-24"
+    }
+  },
+  {
+    "case": "SIG-VERSION-directory_verifiable",
+    "exception": {
+      "kind": "unrealized",
+      "detail": "I_EHR_DIRECTORY.get_versioned_directory: AMB-24"
+    }
+  },
+  {
     "case": "SF-DEPRECATED-media_supported",
     "exception": {
       "kind": "unrealized",

--- a/docs/conformance/ehrbase-rs/verdicts.json
+++ b/docs/conformance/ehrbase-rs/verdicts.json
@@ -183,7 +183,7 @@
     }
   ],
   "coverage": {
-    "selected": 440,
-    "driven": 373
+    "selected": 443,
+    "driven": 374
   }
 }

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_COMPOSITION.get_versioned_composition-version.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_COMPOSITION.get_versioned_composition-version.yaml
@@ -31,3 +31,9 @@ outcomes:
     status: 200                           # overview §HTTP status codes (200 OK — payload = the ORIGINAL_VERSION)
     headers: { Content-Type: negotiated }
   not_found: { status: 404 }              # overview §HTTP status codes (404 — target resource not found)
+captures:
+  # The envelope's stored signature (RM common master06 §Digital Signature:
+  # ORIGINAL_VERSION.signature) — capturable so a later step can compare
+  # signatures across versions (the distinct-per-version fact).
+  signature:
+    from: body "signature"

--- a/tools/cnf-runner/artifacts/schedule/security/SIG-VERSION-directory_signature_present.yaml
+++ b/tools/cnf-runner/artifacts/schedule/security/SIG-VERSION-directory_signature_present.yaml
@@ -1,0 +1,47 @@
+# Signing capability (Platform, STANDARD, required: false) × EHR_DIRECTORY.
+# RM common master06 §Digital Signature signs "each Version of any logical
+# item" — EVERY versioned object, so a committed directory (FOLDER) version
+# carries a signature exactly as COMPOSITION/EHR_STATUS versions do. The
+# signature lives on the ORIGINAL_VERSION envelope, whose read seam is
+# I_EHR_DIRECTORY.get_versioned_directory — an operation ITS-REST 1.1.0 does
+# NOT realize (no /ehr/{ehr_id}/versioned_directory resource; the binding
+# declares `unrealized`, AMB-24), so on this ITS the case verdicts
+# not-applicable-WITH-CITATION and activates automatically when a later
+# ITS-REST release adds the resource. The SM-anchored requirement stays in
+# the catalogue rather than being silently omitted (testing.md §CNF coverage).
+id: SIG-VERSION-directory_signature_present
+kind: functional
+component: SECURITY
+sm_operation: I_EHR_DIRECTORY.create_directory
+capabilities: [Signing, DirectoryOps]
+exercises: [Versioning]
+profiles: [STANDARD]
+test_purpose: >-
+  A committed directory (FOLDER) version carries a signature — the Digital
+  Signature requirement covers every versioned object, not only COMPOSITION.
+description: "Committed directory versions carry a signature"
+spec_refs:
+  - "SM openehr_platform §I_EHR_DIRECTORY.create_directory"
+  - "SM openehr_platform §I_EHR_DIRECTORY.get_versioned_directory"
+  - "RM common §change_control (Digital Signature: each Version of any logical item)"
+  - "CNF profiles master03-profiles.adoc §Non-Functional (Security & Privacy: Signing)"
+applies: { rm: ">=1.0.2" }
+guards:
+  - "not-applicable when the SUT declares no Signing capability — CNF profiles master03-profiles.adoc §Non-Functional (Security & Privacy: Signing)"
+ambiguities: [AMB-24]
+requires:
+  server: any
+  ehr: { commits: none }                 # mints ${ehr_id}
+data_sets: [cnf.directory.root_only]
+flow:
+  - step: 1
+    call: create_directory
+    with: { ehr_id: "${ehr_id}", directory: "${ds:cnf.directory.root_only}" }
+    expect: created
+    capture: { dir_version_uid: created.version_uid }
+  - step: 2
+    call: get_versioned_directory          # unrealized on ITS-REST 1.1.0 (AMB-24) -> N/A-with-citation
+    with: { ehr_id: "${ehr_id}" }
+    expect: ok
+    assert:
+      - { assert: signature, of: "${dir_version_uid}", present: true }

--- a/tools/cnf-runner/artifacts/schedule/security/SIG-VERSION-directory_verifiable.yaml
+++ b/tools/cnf-runner/artifacts/schedule/security/SIG-VERSION-directory_verifiable.yaml
@@ -1,0 +1,47 @@
+# Signing capability (Platform, STANDARD, required: false) × EHR_DIRECTORY.
+# The verifiability half of the directory-version signature pair (see
+# SIG-VERSION-directory_signature_present for the breadth ground): the stored
+# signature verifies over the version's canonical form against the
+# ixit-declared key material (RM common master06 §Digital Signature — the
+# canonical serialisation minus the signature attribute, hashed and signed).
+# The version-read seam (I_EHR_DIRECTORY.get_versioned_directory) is
+# unrealized on ITS-REST 1.1.0 (AMB-24), so this case verdicts
+# not-applicable-WITH-CITATION on this ITS and activates when a later release
+# adds the resource.
+id: SIG-VERSION-directory_verifiable
+kind: functional
+component: SECURITY
+sm_operation: I_EHR_DIRECTORY.create_directory
+capabilities: [Signing, DirectoryOps]
+exercises: [Versioning]
+profiles: [STANDARD]
+test_purpose: >-
+  A committed directory (FOLDER) version's signature verifies against the
+  declared key material over the version's canonical serialisation.
+description: "Committed directory version signature is verifiable"
+spec_refs:
+  - "SM openehr_platform §I_EHR_DIRECTORY.create_directory"
+  - "SM openehr_platform §I_EHR_DIRECTORY.get_versioned_directory"
+  - "RM common §change_control (Digital Signature: signature generated per openPGP from the hash of the canonical Version serialisation)"
+  - "CNF profiles master03-profiles.adoc §Non-Functional (Security & Privacy: Signing)"
+applies: { rm: ">=1.0.2" }
+guards:
+  - "not-applicable when the SUT declares no Signing capability — CNF profiles master03-profiles.adoc §Non-Functional (Security & Privacy: Signing)"
+  - "requires ixit-declared signing key material — the verifying key is a statement/ixit input, not a wire value (RM common §change_control Digital Signature)"
+ambiguities: [AMB-24]
+requires:
+  server: any
+  ehr: { commits: none }                 # mints ${ehr_id}
+data_sets: [cnf.directory.root_only]
+flow:
+  - step: 1
+    call: create_directory
+    with: { ehr_id: "${ehr_id}", directory: "${ds:cnf.directory.root_only}" }
+    expect: created
+    capture: { dir_version_uid: created.version_uid }
+  - step: 2
+    call: get_versioned_directory          # unrealized on ITS-REST 1.1.0 (AMB-24) -> N/A-with-citation
+    with: { ehr_id: "${ehr_id}" }
+    expect: ok
+    assert:
+      - { assert: signature, of: "${dir_version_uid}", present: true, verifiable: true }

--- a/tools/cnf-runner/artifacts/schedule/security/SIG-VERSION-distinct_per_version.yaml
+++ b/tools/cnf-runner/artifacts/schedule/security/SIG-VERSION-distinct_per_version.yaml
@@ -1,0 +1,87 @@
+# Signing capability (Platform, STANDARD, required: false).
+# Distinct-signature-per-version: the signature is computed over the version's
+# canonical form — "serialising the entire Version object (note that the
+# signature attribute will be Void at this point)" (RM common master06
+# §Digital Signature), i.e. `canonical_form` = "all attributes except
+# signature" (RM UML version.adoc). That form includes `uid` and
+# `preceding_version_uid`, so two distinct versions of the same object
+# necessarily have distinct canonical forms and therefore distinct
+# digests/signatures — a SUT must never reuse or hardcode a signature across
+# versions ("the digest acts as a data integrity check", master06). The exact
+# serialisation is upstream-TBD (master06 §Digital Signature, the tbd note);
+# the DISTINCTNESS fact asserted here is serialisation-independent.
+# Wire-asserted: both ORIGINAL_VERSION envelopes are read back
+# (get_versioned_composition variant:version), the first signature is
+# captured, and the second is asserted present + verifiable + distinct from
+# the first.
+id: SIG-VERSION-distinct_per_version
+kind: functional
+component: SECURITY
+sm_operation: I_EHR_COMPOSITION.create_composition
+capabilities: [Signing]
+exercises: [CompositionOps, Versioning]
+profiles: [STANDARD]
+test_purpose: >-
+  Two distinct committed versions of the same versioned object carry distinct
+  signatures — the signature is a function of the version's canonical content,
+  never a reused or hardcoded value.
+description: "Distinct versions carry distinct signatures"
+spec_refs:
+  - "SM openehr_platform §I_EHR_COMPOSITION.create_composition"
+  - "RM common §change_control (Digital Signature: the entire Version object minus signature is serialised and hashed; VERSION.canonical_form)"
+  - "CNF profiles master03-profiles.adoc §Non-Functional (Security & Privacy: Signing)"
+applies: { rm: ">=1.0.2" }
+guards:
+  - "not-applicable when the SUT declares no Signing capability — CNF profiles master03-profiles.adoc §Non-Functional (Security & Privacy: Signing)"
+  - "requires ixit-declared signing key material — the verifying key is a statement/ixit input, not a wire value (RM common §change_control Digital Signature)"
+requires:
+  server: any
+  templates: [cnf.opt.minimal_event]
+  ehr: { commits: none }                 # mints ${ehr_id}
+data_sets: [cnf.composition.minimal_event.v1, cnf.composition.minimal_event.v2]
+flow:
+  - step: 1
+    call: create_composition
+    with:
+      ehr_id: "${ehr_id}"
+      composition: "${ds:cnf.composition.minimal_event.v1}"
+    expect: created
+    capture:
+      preceding_version_uid: created.version_uid
+      versioned_object_uid: created.versioned_object_uid
+    assert:
+      - { assert: version, of: "${preceding_version_uid}", change_type: CREATE }
+  - step: 2
+    call: get_versioned_composition          # read the creation VERSION envelope
+    variant: version
+    with:
+      ehr_id: "${ehr_id}"
+      versioned_object_uid: "${versioned_object_uid}"
+      version_uid: "${preceding_version_uid}"
+    expect: ok
+    capture:
+      sig_first: ok.signature
+    assert:
+      - { assert: signature, of: "${preceding_version_uid}", present: true }
+  - step: 3
+    call: update_composition
+    with:
+      ehr_id: "${ehr_id}"
+      composition: "${ds:cnf.composition.minimal_event.v2}"
+      versioned_object_uid: "${versioned_object_uid}"
+      preceding_version_uid: "${preceding_version_uid}"   # ITS-REST: If-Match (ITS-REST overview §If-Match)
+    expect: updated
+    capture: { v2_uid: updated.version_uid }
+    assert:
+      - { assert: version, of: "${v2_uid}", change_type: MODIFY }
+  - step: 4
+    call: get_versioned_composition          # read the modification VERSION envelope
+    variant: version
+    with:
+      ehr_id: "${ehr_id}"
+      versioned_object_uid: "${versioned_object_uid}"
+      version_uid: "${v2_uid}"
+    expect: ok
+    assert:
+      - { assert: signature, of: "${v2_uid}", present: true, verifiable: true }
+      - { assert: signature, of: "${v2_uid}", distinct_from: "${sig_first}" }

--- a/tools/cnf-runner/src/exec/driver.rs
+++ b/tools/cnf-runner/src/exec/driver.rs
@@ -434,12 +434,14 @@ impl<'a> HttpDriver<'a> {
     /// mode-agnostic; `verifiable` reconstructs the agreed canonical form and
     /// verifies per the ixit `signing` posture (RM common master06 §Digital
     /// Signature; [`crate::exec::signature`]).
+    #[allow(clippy::too_many_arguments)] // one parameter per declared signature fact — mirrors the assertion shape
     fn eval_signature_assertion(
         &mut self,
         body: &Value,
         present: Option<bool>,
         verifiable: Option<bool>,
         equals: Option<&crate::model::value::TemplatedValue>,
+        distinct_from: Option<&crate::model::value::TemplatedValue>,
         vars: &VarStore,
     ) -> Result<(), AssertionFailure> {
         let signature = body.get("signature").and_then(Value::as_str);
@@ -448,6 +450,39 @@ impl<'a> HttpDriver<'a> {
                 "signature: expected present, the ORIGINAL_VERSION envelope carries no signature"
                     .into(),
             ));
+        }
+        if let Some(other) = distinct_from {
+            // Distinct-signature-per-version: the canonical form the signature
+            // is computed over includes `uid`, so two distinct versions carry
+            // distinct signatures (RM common master06 §Digital Signature +
+            // version.adoc `canonical_form`: all attributes except signature).
+            // Both sides must be non-empty — an absent signature satisfies
+            // nothing, and an empty comparand means the earlier capture failed.
+            let want = self
+                .resolver
+                .resolve_value(other, vars)
+                .map_err(|e| AssertionFailure(e.to_string()))?;
+            let want = want
+                .as_str()
+                .map_or_else(|| want.to_string(), ToOwned::to_owned);
+            let Some(sig) = signature.filter(|s| !s.is_empty()) else {
+                return Err(AssertionFailure(
+                    "signature: distinct_from requested but the envelope carries no signature"
+                        .into(),
+                ));
+            };
+            if want.is_empty() {
+                return Err(AssertionFailure(
+                    "signature: distinct_from comparand is empty (the earlier signature capture failed)"
+                        .into(),
+                ));
+            }
+            if sig == want {
+                return Err(AssertionFailure(
+                    "signature: identical to the compared version's signature — the signature must be a function of the version's canonical content (RM common master06 §Digital Signature)"
+                        .into(),
+                ));
+            }
         }
         if let Some(expected) = equals {
             let want = self
@@ -618,12 +653,14 @@ impl<'a> HttpDriver<'a> {
                     present,
                     verifiable,
                     equals,
+                    distinct_from,
                     ..
                 } => self.eval_signature_assertion(
                     body,
                     *present,
                     *verifiable,
                     equals.as_ref(),
+                    distinct_from.as_ref(),
                     vars,
                 ),
                 // The version family still needs a versioned-object read the

--- a/tools/cnf-runner/src/model/assertion.rs
+++ b/tools/cnf-runner/src/model/assertion.rs
@@ -205,6 +205,16 @@ pub enum Assertion {
         /// storage rule for imported/committed signed versions).
         #[serde(default)]
         equals: Option<TemplatedValue>,
+        /// The stored signature differs from a known (non-empty) value — the
+        /// distinct-signature-per-version fact: the signature is computed over
+        /// the version's canonical form, which includes `uid`, so two distinct
+        /// versions necessarily carry distinct signatures (RM common
+        /// `master06-change_control_package.adoc` §Digital Signature — "the
+        /// entire Version object (… the signature attribute will be Void …)"
+        /// is serialised and hashed; `version.adoc` `canonical_form`: "all
+        /// attributes except signature").
+        #[serde(default)]
+        distinct_from: Option<TemplatedValue>,
     },
     /// RM versioning facts.
     Version {
@@ -338,15 +348,20 @@ impl Assertion {
                 present,
                 verifiable,
                 equals,
+                distinct_from,
             } => {
                 if of.is_some() == for_each.is_some() {
                     return Err(
                         "signature assertion needs exactly one of `of` | `for_each`".to_owned()
                     );
                 }
-                if present.is_none() && verifiable.is_none() && equals.is_none() {
+                if present.is_none()
+                    && verifiable.is_none()
+                    && equals.is_none()
+                    && distinct_from.is_none()
+                {
                     return Err(
-                        "signature assertion carries no fact (present | verifiable | equals)"
+                        "signature assertion carries no fact (present | verifiable | equals | distinct_from)"
                             .to_owned(),
                     );
                 }
@@ -453,6 +468,7 @@ pub fn assertion_refs(assertion: &Assertion) -> Vec<ValueRef> {
             of,
             for_each,
             equals,
+            distinct_from,
             ..
         } => {
             if let Some(SingleRef(r)) = of {
@@ -462,6 +478,9 @@ pub fn assertion_refs(assertion: &Assertion) -> Vec<ValueRef> {
                 out.push(r.clone());
             }
             if let Some(v) = equals {
+                out.extend(v.refs().into_iter().cloned());
+            }
+            if let Some(v) = distinct_from {
                 out.extend(v.refs().into_iter().cloned());
             }
         }
@@ -517,6 +536,26 @@ mod tests {
             "columns": [{ "name": "uid" }]
         }));
         assert!(a.check_invariants().is_ok());
+    }
+
+    #[test]
+    fn signature_distinct_from_is_a_fact() {
+        // `distinct_from` alone satisfies the carries-a-fact invariant, and its
+        // reference participates in reference collection (the capture feeding
+        // it is validated like any other).
+        let a = parse(serde_json::json!({
+            "assert": "signature", "of": "${v2_uid}", "distinct_from": "${sig_first}"
+        }));
+        assert!(a.check_invariants().is_ok());
+        assert!(
+            assertion_refs(&a).iter().any(
+                |r| matches!(r, ValueRef::Capture { name, .. } if name.as_str() == "sig_first")
+            )
+        );
+
+        // A signature assertion with no fact at all still bites.
+        let a = parse(serde_json::json!({ "assert": "signature", "of": "${v}" }));
+        assert!(a.check_invariants().is_err());
     }
 
     #[test]

--- a/tools/cnf-runner/src/validate.rs
+++ b/tools/cnf-runner/src/validate.rs
@@ -1006,7 +1006,7 @@ fn check_binding_completeness(set: &ArtifactSet, findings: &mut Vec<Finding>) {
             } else {
                 anchor.sibling(&step.call)
             };
-            let bindings: Vec<_> = set
+            let mut bindings: Vec<_> = set
                 .bindings
                 .iter()
                 .filter(|(_, b)| b.sm_operation == op)
@@ -1019,6 +1019,24 @@ fn check_binding_completeness(set: &ArtifactSet, findings: &mut Vec<Finding>) {
                     format!("no binding declares operation {op}"),
                 );
                 continue;
+            }
+            // Mirror the interpreter's binding selection (`binding_for_variant`):
+            // a step's `variant` selects the binding declaring that variant;
+            // a variant-less step (or a variant with no dedicated binding)
+            // falls back to the variant-less binding. Completeness is judged
+            // against the binding the interpreter would actually drive, not
+            // against every binding of the operation.
+            if let Some(v) = &step.variant
+                && bindings
+                    .iter()
+                    .any(|(_, b)| b.variant.as_deref() == Some(v.as_str()))
+            {
+                bindings.retain(|(_, b)| b.variant.as_deref() == Some(v.as_str()));
+            } else {
+                let has_variantless = bindings.iter().any(|(_, b)| b.variant.is_none());
+                if has_variantless {
+                    bindings.retain(|(_, b)| b.variant.is_none());
+                }
             }
             // An explicit `unrealized` declaration satisfies completeness:
             // the gap is machine-readable and the interpreter yields

--- a/website/book/src/conformance-assets/conformance-chapter-bars.svg
+++ b/website/book/src/conformance-assets/conformance-chapter-bars.svg
@@ -90,7 +90,9 @@ text { fill: #c3c2b7; }
 
 <text x="186.12121212121212" y="353" class="seg-label" text-anchor="middle">5</text><text x="206.24242424242425" y="353" class="muted">5</text>
 <text x="166" y="387" text-anchor="end">Signing</text>
-<rect x="174" y="370" width="24.242424242424242" height="26" class="bar-passed"/>
+<rect x="174" y="370" width="29.090909090909093" height="26" class="bar-passed"/>
 
-<text x="186.12121212121212" y="387" class="seg-label" text-anchor="middle">5</text><text x="206.24242424242425" y="387" class="muted">5</text>
+<text x="188.54545454545456" y="387" class="seg-label" text-anchor="middle">6</text><rect x="203.0909090909091" y="370" width="9.696969696969697" height="26" class="bar-na"/>
+
+<text x="220.78787878787878" y="387" class="muted">8</text>
 </svg>


### PR DESCRIPTION
## Summary

Completes #274 (the EHR_STATUS leg landed in PR #275; the DIRECTORY leg was re-adjudicated on the issue).

- **Distinct-signature-per-version** (`SIG-VERSION-distinct_per_version`): the signature is computed over the version's canonical form — *"the entire Version object (note that the signature attribute will be Void at this point)"* (RM common master06 §Digital Signature; `version.adoc` `canonical_form`: "all attributes except signature") — which includes `uid`, so two distinct versions can never share a signature. New runner fact `distinct_from` on the signature assertion (model invariants + reference collection + eval + re-emitted schemas + unit test), fed by a new `signature` body capture on the version-envelope read binding.
- **DIRECTORY (FOLDER) version signatures** (`present` + `verifiable`): SM-anchored cases riding the `unrealized` `get_versioned_directory` binding (AMB-24 — ITS-REST 1.1.0 surfaces no `versioned_directory` resource), verdicting **N/A-with-citation** on this ITS and activating automatically if a later release adds the endpoint — the master06 breadth requirement (*"each Version of any logical item"*) stays in the catalogue instead of being silently omitted.
- **Gate precision**: `check_binding_completeness` now mirrors the interpreter's `binding_for_variant` selection (exact variant wins, variant-less fallback) instead of judging a step against every binding of its operation.

## Verification

- Live-verified in **both signing modes** (digest + the openPGP compose overlay): 8 SIG-VERSION records each → **6 passed / 0 failed / 2 N/A** (the DIRECTORY pair, cited).
- Validator **443 cases / 90 bindings / 0 findings**; cnf-runner nextest **145/145**; schema drift test green; clippy clean.
- Full `scripts/conformance.sh`: **443 records → 374 passed / 0 failed / 0 errored / 69 N/A**, 0 review findings — baseline ratcheted, zero drift elsewhere. Artifacts + regenerated SVGs committed.

Closes #274