### PR TITLE
release: v3.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+## [3.10.0] - 2026-07-25
+
 ### Added
 
 - **CNF total wire-surface coverage gate (#271)**: a new `surface-coverage`
@@ -1685,7 +1687,8 @@ but has not yet run in production.
   seccomp, default-deny NetworkPolicy) and golden-render validation.
 
 
-[unreleased]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.9.0...HEAD
+[unreleased]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.10.0...HEAD
+[3.10.0]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.9.0...v3.10.0
 [3.9.0]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.8.0...v3.9.0
 [3.8.0]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.7.0...v3.8.0
 [3.7.0]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.6.0...v3.7.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,5 +33,5 @@ keywords:
   - ITS-REST
   - Rust
   - PostgreSQL
-version: 3.9.0
-date-released: "2026-07-24"
+version: 3.10.0
+date-released: "2026-07-25"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "cnf-runner"
-version = "3.9.0"
+version = "3.10.0"
 dependencies = [
  "assert_fs",
  "base64 0.22.1",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase"
-version = "3.9.0"
+version = "3.10.0"
 dependencies = [
  "assert_fs",
  "async-trait",
@@ -2366,7 +2366,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase-admin-ui"
-version = "3.9.0"
+version = "3.10.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2404,7 +2404,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase-rest"
-version = "3.9.0"
+version = "3.10.0"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -2456,7 +2456,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase-server"
-version = "3.9.0"
+version = "3.10.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -5225,7 +5225,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-codegen"
-version = "3.9.0"
+version = "3.10.0"
 dependencies = [
  "roxmltree",
  "serde_json",
@@ -8266,7 +8266,7 @@ dependencies = [
 
 [[package]]
 name = "testkit"
-version = "3.9.0"
+version = "3.10.0"
 dependencies = [
  "ehrbase",
  "sqlx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "3"                      # resolver v3 (edition 2024)
 members = ["crates/*", "app/*", "tools/*"]
 
 [workspace.package]
-version = "3.9.0"
+version = "3.10.0"
 edition = "2024"
 rust-version = "1.96"
 license = "Apache-2.0"

--- a/deploy/helm/ehrbase-rs/Chart.yaml
+++ b/deploy/helm/ehrbase-rs/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 # Chart versioning is independent of the application version.
 version: 3.2.0
 # The default container image tag (informational; overridable via image.tag).
-appVersion: "3.9.0"
+appVersion: "3.10.0"
 
 # PDB (policy/v1, GA 1.21), HPA (autoscaling/v2, GA 1.23), and the
 # seccompProfile pod field (GA 1.27) all resolve cleanly at 1.25+.

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.9.0"
+    app.kubernetes.io/version: "3.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -58,7 +58,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.9.0"
+    app.kubernetes.io/version: "3.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -77,7 +77,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.9.0"
+    app.kubernetes.io/version: "3.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
   annotations:
@@ -96,7 +96,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.9.0"
+    app.kubernetes.io/version: "3.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 type: Opaque
@@ -120,7 +120,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.9.0"
+    app.kubernetes.io/version: "3.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 type: Opaque
@@ -139,7 +139,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.9.0"
+    app.kubernetes.io/version: "3.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 data:
@@ -296,7 +296,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.9.0"
+    app.kubernetes.io/version: "3.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -323,7 +323,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.9.0"
+    app.kubernetes.io/version: "3.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -335,7 +335,7 @@ spec:
     metadata:
       annotations:
         # Roll pods when the rendered ehrbase.toml changes.
-        checksum/config: 239134ca2a49b35429b2db7d36413c4dc68e65b35fa2314fed7aaa16e5baea5c
+        checksum/config: a89e96a6b8f1d33506cc8bbbde22308273eaf4a9f5531b47562eed28fcd604f8
         prometheus.io/scrape: "true"
         prometheus.io/port: "9100"
         prometheus.io/path: "/management/prometheus"
@@ -356,7 +356,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ehrbase
-          image: "ghcr.io/rubentalstra/ehrbase-rs:3.9.0"
+          image: "ghcr.io/rubentalstra/ehrbase-rs:3.10.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -478,7 +478,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.9.0"
+    app.kubernetes.io/version: "3.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -511,7 +511,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.9.0"
+    app.kubernetes.io/version: "3.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.9.0"
+    app.kubernetes.io/version: "3.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -36,7 +36,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.9.0"
+    app.kubernetes.io/version: "3.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -55,7 +55,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.9.0"
+    app.kubernetes.io/version: "3.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 automountServiceAccountToken: false
@@ -69,7 +69,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.9.0"
+    app.kubernetes.io/version: "3.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 data:
@@ -168,7 +168,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.9.0"
+    app.kubernetes.io/version: "3.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -191,7 +191,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.9.0"
+    app.kubernetes.io/version: "3.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -204,7 +204,7 @@ spec:
     metadata:
       annotations:
         # Roll pods when the rendered ehrbase.toml changes.
-        checksum/config: 0f7059c4fc55fcf922bb0686f3f424852607ecb316cfc87992ada1e5cb7cceed
+        checksum/config: f7b6a8f6b0d3bdb527024f2a64f04f4dd1bfbcbfb03c1746f4c5efd243a77aee
       labels:
         app.kubernetes.io/name: ehrbase-rs
         app.kubernetes.io/instance: ehrbase-rs
@@ -222,7 +222,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ehrbase
-          image: "ghcr.io/rubentalstra/ehrbase-rs:3.9.0"
+          image: "ghcr.io/rubentalstra/ehrbase-rs:3.10.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## v3.10.0 release cut

Milestone **v3.10.0** reached zero open issues (13 closed). Per the release procedure (`.claude/rules/changelog.md`): the `[Unreleased]` section is cut to `## [3.10.0] - 2026-07-25` (link refs updated), the workspace version + `Cargo.lock`, Helm `appVersion` + golden renders, and `CITATION.cff` `version`/`date-released` (the new #279 rule, its first exercise) are all bumped in lockstep — `citation-guard` and the Helm validation are green locally.

### Release highlights (from the changelog section)

- **Simplified Formats folded into `openehr-its`** (crate graph mirrors the spec's component decomposition) + **ADL2/OPT2 templates as full FLAT/STRUCTURED peers** (archetype-conformance validation + commit-path resolution, with a filler-root naming fix).
- **CNF depth completed**: version-signature breadth (distinct-per-version + DIRECTORY N/A coverage, dual signing modes), the coded-text value dimension + deferred SF grounds + spec-authored corpus, and the **machine-enforced total-coverage gate** (SM-derived surface, never the OAS; the honest 85-gap ledger ratchets down on #288). Baseline: **445 records, 376 passed / 0 failed / 69 cited-N/A, zero drift** throughout.
- **AQL engine measured rungs**: dead-root-lateral elision + archetype case-fold at write (exec −11.3%, planning attributed per statement, knee 512/s held).
- **Docker/compose rework** (official-docs-grounded): cargo-chef cached builds, digest-pinned images, one runtime stage per image (zero compose↔release drift), lane isolation, envelope-aligned limits.
- **Citable repository**: `CITATION.cff` + ORCID + the `citation-guard` CI job.
- Upstream error-class adjudication recorded in the comparison narrative (all four classes attributed upstream; our record stands).

The release workflow publishes the GitHub Release from the changelog section after the tag; it stays `prerelease: true` pending production sign-off.