### PR TITLE
fix(testkit): explicit container shm-size + startup sweep of stale clone databases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8274,6 +8274,7 @@ dependencies = [
  "testcontainers-modules",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/tools/testkit/CLAUDE.md
+++ b/tools/testkit/CLAUDE.md
@@ -12,7 +12,19 @@ own container or running its own migrations.
   with `docker rm -f ehrbase-testkit-pg18`). The container runs the
   non-durable settings the PostgreSQL docs describe for throwaway data
   (`fsync=off` etc.) — never copy those flags anywhere near production
-  config.
+  config — and an **explicit `/dev/shm` size** (`with_shm_size`, 1 GiB;
+  the image default is 64 MB, see the failure mode below). The shm size is
+  applied at container CREATION: a container that already exists is adopted
+  as-is, so changing the value needs
+  `docker rm -f ehrbase-testkit-pg18`.
+- **Sweep:** every test process reclaims stale harness databases **once, at
+  server acquisition, before it hands out any clone** — clones past a short
+  grace window plus templates of other migration fingerprints. Drops are
+  **force-free on purpose**: a clone another process is still connected to is
+  refused with SQLSTATE `55006` and skipped as benign (never
+  `WITH (FORCE)` — that would tear a live test's database out from under it;
+  force is correct only in `TestDb::drop`, which drops the caller's *own*
+  clone). `testkit::sweep_stale()` is the manual entry point.
 - **Template discipline:** the template is migrated by the platform
   library's own `db::run_migrations` and keyed on
   `db::migration_fingerprint()`; completion is stamped as the database
@@ -21,7 +33,10 @@ own container or running its own migrations.
 - **Isolation is per-database, not per-server.** A test that needs
   server-global state (ALTER SYSTEM, cross-database assertions) does not
   belong on the shared server — flag it instead of hacking around the
-  harness.
+  harness. The single exception is testkit's OWN gate
+  (`tools/testkit/tests/harness.rs`), which must assert on cluster-wide state
+  (the sweep) — it does so under uniquely named databases in the
+  `ehrbase_tk_*` namespace so parallel processes cannot collide.
 - **Dependency shape:** `testkit → ehrbase` (normal dep); the app crates'
   tests consume testkit as a dev-dependency. The `ehrbase` ↔ `testkit`
   dev-dependency cycle is deliberate and cargo-legal — do not "fix" it.
@@ -29,3 +44,41 @@ own container or running its own migrations.
   infrastructure, never application behaviour — call sites `.expect()`.
 - Gates: `cargo clippy -p testkit --all-targets` +
   `cargo nextest run -p testkit`.
+
+## Failure mode: shared memory exhausted by leaked clones
+
+**Symptom.** Every DB-backed test in the workspace fails — even a single one
+run in isolation — with
+
+```
+could not resize shared memory segment "/PostgreSQL.<n>" to <n> bytes:
+No space left on device
+```
+
+and `docker exec ehrbase-testkit-pg18 df -h /dev/shm` shows `/dev/shm` nearly
+full at idle.
+
+**Cause.** Leaked clone databases accumulating on the reusable container
+(observed 2026-07-25: ~2957 `ehrbase_tk_*` clones). PostgreSQL keeps its
+cumulative statistics in shared memory, sized per database/relation, and
+allocates them from *dynamic* shared memory — POSIX shared memory under
+`/dev/shm` on Linux (`dynamic_shared_memory_type = posix`; PostgreSQL docs
+§ Resource Consumption). Thousands of databases fill the container's 64 MB
+default `/dev/shm`, after which *every* DSM allocation fails, including the
+ones ordinary queries need. The database count is the cause; the error is a
+symptom of the shm ceiling.
+
+**Recovery.** Nothing to do by hand in the normal case: the startup sweep
+reclaims unused stale clones on the next test process, and the container is
+created with a 1 GiB `/dev/shm`. To force it: `testkit::sweep_stale()`, or
+drop every `ehrbase_tk_*` database except the live `ehrbase_tk_tpl_*` template
+and restart the container (`docker restart ehrbase-testkit-pg18`) so the
+statistics area is rebuilt. A pre-existing container still carries the old
+64 MB — `docker rm -f ehrbase-testkit-pg18` to recreate it with the explicit
+size.
+
+**Prevention (in place).** Explicit `--shm-size` on the container (the
+official `postgres` image documents exactly this knob:
+<https://hub.docker.com/_/postgres>) plus the once-per-process startup sweep,
+so unused clones cannot accumulate across runs. Never "fix" a red DB-backed
+suite by weakening a test — check `/dev/shm` and the clone count first.

--- a/tools/testkit/Cargo.toml
+++ b/tools/testkit/Cargo.toml
@@ -22,6 +22,11 @@ ehrbase = { path = "../../app/ehrbase" }
 sqlx = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+# The startup sweep reports what it reclaimed and why a drop was skipped;
+# libraries speak `tracing`, never stdio (the workspace lints deny both print
+# macros). No subscriber is installed by the harness — a test binary that wants
+# the sweep's log installs one.
+tracing = { workspace = true }
 uuid = { workspace = true }
 # `reusable-containers` (experimental upstream) keeps ONE named PG container
 # alive across nextest's process-per-test model and across whole runs.

--- a/tools/testkit/src/lib.rs
+++ b/tools/testkit/src/lib.rs
@@ -15,9 +15,10 @@
 //!    previous run left it — via `testcontainers`' reusable-containers
 //!    support, tuned with the non-durable settings the `PostgreSQL` docs
 //!    describe for throwaway data (`fsync=off`, `synchronous_commit=off`,
-//!    `full_page_writes=off`; `PostgreSQL` docs § "Non-Durable Settings").
-//!    The container is deliberately left running across runs — reclaim it
-//!    with `docker rm -f ehrbase-testkit-pg18`.
+//!    `full_page_writes=off`; `PostgreSQL` docs § "Non-Durable Settings")
+//!    and an explicit shared-memory size (`SHM_SIZE_BYTES`). The container is
+//!    deliberately left running across runs — reclaim it with
+//!    `docker rm -f ehrbase-testkit-pg18`.
 //!
 //! The template database (`ehrbase_tk_tpl_<fingerprint>`) is created and
 //! migrated exactly once per migration fingerprint, guarded by a `PostgreSQL`
@@ -25,9 +26,14 @@
 //! test) converge on a single build. Completion is stamped as the database
 //! comment, readable via `shobj_description` without connecting to the
 //! template — connections to a template block cloning (`PostgreSQL` docs
-//! § CREATE DATABASE). Clones are named `ehrbase_tk_<secs>_<rand>`; stale
-//! clones and outdated templates are swept opportunistically under an
-//! advisory try-lock.
+//! § CREATE DATABASE). Clones are named `ehrbase_tk_<secs>_<rand>`.
+//!
+//! Every test process sweeps stale clones and outdated templates **once at
+//! initialization, before it hands out any database** — the drops are
+//! force-free, so a clone another process is still using is skipped as benign
+//! (see [`sweep_stale`]). Unused clones therefore cannot accumulate across
+//! runs, which matters: thousands of databases inflate the server's
+//! cumulative-statistics area until dynamic shared memory is exhausted.
 
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -47,17 +53,51 @@ const DB_PREFIX: &str = "ehrbase_tk_";
 /// The fixed name of the reusable local `PostgreSQL` container.
 const CONTAINER_NAME: &str = "ehrbase-testkit-pg18";
 
+/// Explicit shared-memory (`/dev/shm`) size for the reusable container, in
+/// bytes — one gibibyte.
+///
+/// The official `postgres` image documents setting this limit explicitly
+/// (<https://hub.docker.com/_/postgres>, "set shared memory limit when using
+/// docker compose": `shm_size`), because the container default is 64 MB while
+/// `PostgreSQL` allocates its cumulative-statistics area and every
+/// parallel-query segment from *dynamic* shared memory — POSIX shared memory
+/// under `/dev/shm` on Linux (`dynamic_shared_memory_type = posix`;
+/// `PostgreSQL` docs § Resource Consumption). Once that fills, EVERY dynamic
+/// allocation fails with
+/// `could not resize shared memory segment ...: No space left on device`
+/// and every database-backed test in the workspace goes red — observed at
+/// ~62 MB used by a server carrying ~3000 leaked clone databases.
+///
+/// The size is applied at container CREATION only: `ReuseDirective::Always`
+/// adopts an existing container as-is, so an already-running 64 MB container
+/// must be reclaimed (`docker rm -f ehrbase-testkit-pg18`) for a changed value
+/// to take effect.
+const SHM_SIZE_BYTES: u64 = 1024 * 1024 * 1024;
+
+/// `SQLSTATE` 55006 `object_in_use` — what `PostgreSQL` reports when
+/// `DROP DATABASE` is refused because sessions are still connected
+/// (`PostgreSQL` docs § DROP DATABASE; § Appendix A "`PostgreSQL` Error
+/// Codes", class 55 "Object Not In Prerequisite State").
+const SQLSTATE_OBJECT_IN_USE: &str = "55006";
+
 /// Environment variable naming an externally provided server (CI, local dev).
 const ENV_URL: &str = "EHRBASE_TEST_PG_URL";
 
 /// Advisory-lock key serializing template builds across test processes.
 const TEMPLATE_LOCK_KEY: i64 = 0x0EB2_7E57_0001;
 
-/// Advisory-lock key electing the (single, opportunistic) sweeper.
+/// Advisory-lock key electing the single startup sweeper.
 const SWEEP_LOCK_KEY: i64 = 0x0EB2_7E57_0002;
 
-/// Clones and outdated templates older than this are swept.
-const SWEEP_AGE: Duration = Duration::from_hours(2);
+/// Clones younger than this grace window are never swept.
+///
+/// A running test's clone can momentarily have NO session on it — the clone
+/// pools run `min_connections = 0` and `sqlx` closes idle connections — so
+/// connectedness alone cannot tell "live" from "leaked"; the name-embedded
+/// creation time can. The window is deliberately short: it is the bound on
+/// how long a leaked clone (a process killed before its `Drop` cleanup landed)
+/// can linger before the next process's startup sweep reclaims it.
+const SWEEP_GRACE: Duration = Duration::from_mins(30);
 
 /// Failures of the harness itself (server acquisition, template build,
 /// cloning). Test call sites `.expect()` on these — a testkit error always
@@ -121,6 +161,11 @@ impl Drop for TestDb {
         // Best-effort immediate cleanup on a detached thread — `Drop` cannot
         // await, and the test process may exit before this lands; the init
         // sweep is the durable backstop.
+        //
+        // NOTE: `WITH (FORCE)` is correct HERE and wrong in the sweep: this is
+        // our own clone, whose own pool may still hold connections, so the
+        // connections being terminated are ours. The sweep drops OTHER
+        // processes' leftovers and must never terminate a live test's sessions.
         let admin_url = self.admin_url.clone();
         let name = self.name.clone();
         drop(std::thread::Builder::new().spawn(move || {
@@ -220,21 +265,34 @@ static CONTAINER: OnceCell<ContainerAsync<Postgres>> = OnceCell::const_new();
 /// advisory lock inside, once per server across processes).
 static TEMPLATE: OnceCell<String> = OnceCell::const_new();
 
+/// The shared server's admin DSN, acquired once per test process. Acquisition
+/// includes the readiness wait and the startup sweep, so no caller can be
+/// handed a clone before stale ones have been reclaimed.
 async fn server() -> Result<&'static str, TestkitError> {
     SERVER
         .get_or_try_init(|| async {
-            if let Ok(url) = std::env::var(ENV_URL) {
-                return Ok(url);
-            }
-            let container = CONTAINER.get_or_try_init(start_container).await?;
-            let host = container.get_host().await?.to_string();
-            let port = container.get_host_port_ipv4(5432).await?;
-            Ok(format!(
-                "postgres://postgres:postgres@{host}:{port}/postgres"
-            ))
+            let url = resolve_server_url().await?;
+            let mut admin = connect_ready(&url).await?;
+            startup_sweep(&mut admin).await;
+            drop(admin.close().await);
+            Ok(url)
         })
         .await
         .map(String::as_str)
+}
+
+/// The admin DSN of the externally provided server, or of the reusable
+/// container (started or adopted).
+async fn resolve_server_url() -> Result<String, TestkitError> {
+    if let Ok(url) = std::env::var(ENV_URL) {
+        return Ok(url);
+    }
+    let container = CONTAINER.get_or_try_init(start_container).await?;
+    let host = container.get_host().await?.to_string();
+    let port = container.get_host_port_ipv4(5432).await?;
+    Ok(format!(
+        "postgres://postgres:postgres@{host}:{port}/postgres"
+    ))
 }
 
 /// Start — or adopt — the reusable named `PostgreSQL` 18 container. Concurrent
@@ -264,6 +322,11 @@ async fn start_container() -> Result<ContainerAsync<Postgres>, TestkitError> {
                 "-c",
                 "max_connections=200",
             ])
+            // Never leave /dev/shm at the image default (see SHM_SIZE_BYTES):
+            // 64 MB is exhausted by the cumulative-statistics area of a server
+            // carrying many databases, after which every dynamic-shared-memory
+            // allocation fails and the whole DB-backed suite goes red.
+            .with_shm_size(SHM_SIZE_BYTES)
             .with_container_name(CONTAINER_NAME)
             .with_reuse(ReuseDirective::Always);
         match request.start().await {
@@ -321,8 +384,9 @@ async fn ensure_template(admin_url: &str) -> Result<String, TestkitError> {
     // Fast path: a completed template is stamped as the database comment,
     // readable without connecting to it (connections to a template block
     // `CREATE DATABASE … TEMPLATE`; PostgreSQL docs § CREATE DATABASE).
+    // The sweep is NOT run here: it already ran once for this process while
+    // the server was acquired, before any clone could be handed out.
     if template_complete(&mut admin, &template, &stamp).await? {
-        sweep(&mut admin, &template).await;
         drop(admin.close().await);
         return Ok(template);
     }
@@ -410,10 +474,7 @@ async fn build_template(
 /// A unique clone name embedding its creation time (hex seconds) for the
 /// sweep: `ehrbase_tk_<secs-hex>_<rand>`.
 fn fresh_name() -> String {
-    let secs = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or(Duration::ZERO)
-        .as_secs();
+    let secs = now_secs();
     let rand = uuid::Uuid::new_v4().simple().to_string();
     let short = rand.get(..12).unwrap_or(rand.as_str());
     format!("{DB_PREFIX}{secs:x}_{short}")
@@ -463,15 +524,61 @@ fn redacted(url: &str) -> String {
     url.rsplit('@').next().unwrap_or("<unparseable>").to_owned()
 }
 
+/// Wall-clock seconds since the Unix epoch — the time base embedded in every
+/// clone name and read back by the sweep.
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_secs()
+}
+
 // ---------------------------------------------------------------------------
 // Sweep
 // ---------------------------------------------------------------------------
 
-/// Opportunistically drop stale harness databases: clones older than
-/// [`SWEEP_AGE`] and templates other than the current one. Elected by an
-/// advisory try-lock; every failure is ignored — the sweep is hygiene, not
+/// What one sweep pass did — the startup log line, and the seam the harness's
+/// own tests assert on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SweepReport {
+    /// Stale databases the pass selected for dropping.
+    pub candidates: usize,
+    /// Databases actually dropped.
+    pub dropped: usize,
+    /// Databases another test process was still connected to, so the
+    /// force-free drop was refused and the database left alone — the benign,
+    /// expected outcome under a parallel run.
+    pub in_use: usize,
+}
+
+/// Reclaim stale harness databases (and stale harness roles) now.
+///
+/// The harness sweeps once per test process at initialization, before it hands
+/// out any database; this is the explicit entry point for a manual reclaim and
+/// for the harness's own tests. It is safe to call at any time: the drops are
+/// force-free, so a database some other process is still connected to is
+/// skipped, never torn out from under it.
+///
+/// # Errors
+///
+/// Returns [`TestkitError`] when the shared server cannot be acquired or
+/// connected to. Individual drops never fail the call — a database another
+/// process is using is counted as [`SweepReport::in_use`], and any other drop
+/// failure is logged and ignored, because the sweep is hygiene, not
 /// correctness.
-async fn sweep(admin: &mut PgConnection, current_template: &str) {
+pub async fn sweep_stale() -> Result<SweepReport, TestkitError> {
+    let server = server().await?;
+    let mut admin = connect_ready(server).await?;
+    let report = sweep(&mut admin).await;
+    drop(admin.close().await);
+    Ok(report)
+}
+
+/// The once-per-process sweep run while the server is acquired, elected by an
+/// advisory try-lock: under a fully parallel nextest run exactly one process
+/// sweeps at a time and the losers skip it, since the winner is already
+/// reclaiming the very same set.
+async fn startup_sweep(admin: &mut PgConnection) {
     let elected: Result<Option<bool>, sqlx::Error> =
         sqlx::query_scalar("SELECT pg_try_advisory_lock($1)")
             .bind(SWEEP_LOCK_KEY)
@@ -481,50 +588,13 @@ async fn sweep(admin: &mut PgConnection, current_template: &str) {
         return;
     }
 
-    let names: Vec<String> = sqlx::query_scalar(
-        "SELECT datname FROM pg_database WHERE datname LIKE $1 AND NOT datistemplate",
-    )
-    .bind(format!("{DB_PREFIX}%"))
-    .fetch_all(&mut *admin)
-    .await
-    .unwrap_or_default();
-
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or(Duration::ZERO)
-        .as_secs();
-    for name in names {
-        if !stale(&name, current_template, now) {
-            continue;
-        }
-        let sql = format!("DROP DATABASE IF EXISTS {name} WITH (FORCE)");
-        drop(
-            sqlx::raw_sql(sqlx::AssertSqlSafe(sql))
-                .execute(&mut *admin)
-                .await,
-        );
-    }
-
-    // Roles are cluster-global: tests that must create login roles name them
-    // `<clone-db-name>_<suffix>` so the same staleness parse applies (their
-    // owned objects lived in the already-dropped clone).
-    let roles: Vec<String> =
-        sqlx::query_scalar("SELECT rolname FROM pg_roles WHERE rolname LIKE $1")
-            .bind(format!("{DB_PREFIX}%"))
-            .fetch_all(&mut *admin)
-            .await
-            .unwrap_or_default();
-    for role in roles {
-        if !stale(&role, current_template, now) {
-            continue;
-        }
-        let sql = format!("DROP ROLE IF EXISTS {role}");
-        drop(
-            sqlx::raw_sql(sqlx::AssertSqlSafe(sql))
-                .execute(&mut *admin)
-                .await,
-        );
-    }
+    let report = sweep(&mut *admin).await;
+    let candidates = report.candidates;
+    let dropped = report.dropped;
+    let in_use = report.in_use;
+    tracing::info!(
+        "testkit startup sweep: {candidates} stale database(s), {dropped} dropped, {in_use} in use"
+    );
 
     drop(
         sqlx::query("SELECT pg_advisory_unlock($1)")
@@ -534,9 +604,109 @@ async fn sweep(admin: &mut PgConnection, current_template: &str) {
     );
 }
 
+/// Drop every stale harness database — clones older than [`SWEEP_GRACE`], and
+/// templates other than the current migration fingerprint's — plus the stale
+/// harness roles.
+///
+/// The drops are deliberately **force-free**: `DROP DATABASE` fails while any
+/// session is connected unless `FORCE` is used (`PostgreSQL` docs
+/// § DROP DATABASE), reporting [`SQLSTATE_OBJECT_IN_USE`]. That refusal means
+/// exactly "another test process owns this clone", so it is skipped as benign.
+/// Together with the grace window — which spares a clone whose owner currently
+/// holds no pooled connection — this is what makes the sweep safe to run at the
+/// start of every test process against one shared server.
+///
+/// Every failure is swallowed (logged): the sweep is hygiene, not correctness.
+async fn sweep(admin: &mut PgConnection) -> SweepReport {
+    let mut report = SweepReport {
+        candidates: 0,
+        dropped: 0,
+        in_use: 0,
+    };
+    // The live template is derived, not passed in: the sweep runs before the
+    // template is ensured, and the fingerprint is a pure function of the
+    // migrations compiled into this binary.
+    let current_template = format!("{DB_PREFIX}tpl_{}", db::migration_fingerprint());
+    let now = now_secs();
+
+    let listed: Result<Vec<String>, sqlx::Error> = sqlx::query_scalar(
+        "SELECT datname FROM pg_database WHERE datname LIKE $1 AND NOT datistemplate",
+    )
+    .bind(format!("{DB_PREFIX}%"))
+    .fetch_all(&mut *admin)
+    .await;
+    let names = match listed {
+        Ok(names) => names,
+        Err(error) => {
+            tracing::warn!("testkit sweep: cannot list harness databases: {error}");
+            Vec::new()
+        }
+    };
+
+    for name in names {
+        if !stale(&name, &current_template, now) {
+            continue;
+        }
+        report.candidates += 1;
+        // No `WITH (FORCE)`: a clone with live sessions belongs to a test
+        // process that is still running and must survive this sweep.
+        let sql = format!("DROP DATABASE IF EXISTS {name}");
+        match sqlx::raw_sql(sqlx::AssertSqlSafe(sql))
+            .execute(&mut *admin)
+            .await
+        {
+            Ok(_) => report.dropped += 1,
+            Err(error) => {
+                if refusal_is_benign(sqlstate(&error).as_deref()) {
+                    report.in_use += 1;
+                    tracing::debug!("testkit sweep: {name} is in use, skipped");
+                } else {
+                    tracing::warn!("testkit sweep: dropping {name} failed: {error}");
+                }
+            }
+        }
+    }
+
+    // Roles are cluster-global: tests that must create login roles name them
+    // `<clone-db-name>_<suffix>` so the same staleness parse applies (their
+    // owned objects lived in the already-dropped clone).
+    let listed_roles: Result<Vec<String>, sqlx::Error> =
+        sqlx::query_scalar("SELECT rolname FROM pg_roles WHERE rolname LIKE $1")
+            .bind(format!("{DB_PREFIX}%"))
+            .fetch_all(&mut *admin)
+            .await;
+    for role in listed_roles.unwrap_or_default() {
+        if !stale(&role, &current_template, now) {
+            continue;
+        }
+        let sql = format!("DROP ROLE IF EXISTS {role}");
+        if let Err(error) = sqlx::raw_sql(sqlx::AssertSqlSafe(sql))
+            .execute(&mut *admin)
+            .await
+        {
+            tracing::debug!("testkit sweep: dropping role {role} failed: {error}");
+        }
+    }
+
+    report
+}
+
+/// The `SQLSTATE` a failure carries, when it was reported by the server at all
+/// (a transport or pool failure carries none).
+fn sqlstate(error: &sqlx::Error) -> Option<String> {
+    let code = sqlx::error::DatabaseError::code(error.as_database_error()?)?;
+    Some(code.into_owned())
+}
+
+/// Whether a refused sweep drop is the benign "another test process is still
+/// connected to this database" outcome rather than a broken-harness signal.
+fn refusal_is_benign(code: Option<&str>) -> bool {
+    code == Some(SQLSTATE_OBJECT_IN_USE)
+}
+
 /// Whether a harness database is stale: an outdated template (any
 /// `…tpl_…` other than the current one) or a clone whose name-embedded
-/// creation time is older than [`SWEEP_AGE`].
+/// creation time is older than [`SWEEP_GRACE`].
 fn stale(name: &str, current_template: &str, now_secs: u64) -> bool {
     let Some(rest) = name.strip_prefix(DB_PREFIX) else {
         return false;
@@ -550,12 +720,15 @@ fn stale(name: &str, current_template: &str, now_secs: u64) -> bool {
     let Ok(created) = u64::from_str_radix(secs_hex, 16) else {
         return false;
     };
-    now_secs.saturating_sub(created) >= SWEEP_AGE.as_secs()
+    now_secs.saturating_sub(created) >= SWEEP_GRACE.as_secs()
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{DB_PREFIX, SWEEP_AGE, clone_url, fresh_name, redacted, stale};
+    use super::{
+        DB_PREFIX, SQLSTATE_OBJECT_IN_USE, SWEEP_GRACE, clone_url, fresh_name, redacted,
+        refusal_is_benign, stale,
+    };
 
     #[test]
     fn clone_url_replaces_database_segment() {
@@ -586,8 +759,49 @@ mod tests {
         assert!(stale("ehrbase_tk_tpl_old0", current, now));
         let young = format!("{DB_PREFIX}{:x}_aaaa", now - 10);
         assert!(!stale(&young, current, now));
-        let old = format!("{DB_PREFIX}{:x}_aaaa", now - SWEEP_AGE.as_secs() - 1);
+        let old = format!("{DB_PREFIX}{:x}_aaaa", now - SWEEP_GRACE.as_secs() - 1);
         assert!(stale(&old, current, now));
         assert!(!stale("unrelated_db", current, now));
+    }
+
+    /// The live template is excluded from the sweep at every age: it carries no
+    /// creation time in its name and must survive arbitrarily long runs, since
+    /// every clone is made from it.
+    #[test]
+    fn stale_never_sweeps_the_live_template() {
+        let current = "ehrbase_tk_tpl_deadbeef";
+        for now in [0u64, 0x1000_0000, u64::MAX] {
+            assert!(
+                !stale(current, current, now),
+                "live template swept at {now}"
+            );
+        }
+        // A template built from any OTHER migration fingerprint is stale.
+        assert!(stale("ehrbase_tk_tpl_0", current, 0));
+        assert!(stale("ehrbase_tk_tpl_feedface", current, 0));
+    }
+
+    /// A clone name whose embedded creation time does not parse is never swept:
+    /// an unknown age is not evidence of staleness.
+    #[test]
+    fn stale_spares_unparseable_clone_names() {
+        let current = "ehrbase_tk_tpl_abcd";
+        let now = 0x1000_0000u64;
+        assert!(!stale("ehrbase_tk_notahexnumber_x", current, now));
+        assert!(!stale("ehrbase_tk_nounderscore", current, now));
+    }
+
+    /// `PostgreSQL` refuses a force-free `DROP DATABASE` on a database with
+    /// live sessions with SQLSTATE 55006 (`object_in_use`) — for the sweep that
+    /// is a benign "another test process owns this clone", not a harness
+    /// failure. Any other SQLSTATE, or none at all, is not benign.
+    #[test]
+    fn only_object_in_use_is_a_benign_sweep_refusal() {
+        assert_eq!(SQLSTATE_OBJECT_IN_USE, "55006");
+        assert!(refusal_is_benign(Some(SQLSTATE_OBJECT_IN_USE)));
+        assert!(!refusal_is_benign(Some("55000"))); // object_not_in_prerequisite_state
+        assert!(!refusal_is_benign(Some("42501"))); // insufficient_privilege
+        assert!(!refusal_is_benign(Some("3D000"))); // invalid_catalog_name
+        assert!(!refusal_is_benign(None)); // transport/pool failure
     }
 }

--- a/tools/testkit/tests/harness.rs
+++ b/tools/testkit/tests/harness.rs
@@ -43,6 +43,60 @@ async fn clones_are_unique_and_fully_migrated() {
     assert_eq!(counts, (1, 0), "clone state leaked between databases");
 }
 
+/// The sweep reclaims a leaked clone: a database in the harness's own clone
+/// namespace whose name-embedded creation time is ancient and which nothing is
+/// connected to. This is the regression gate for clone accumulation — thousands
+/// of leaked clones inflate the server's cumulative-statistics area until
+/// dynamic shared memory is exhausted and every DB-backed test fails with
+/// `could not resize shared memory segment ...: No space left on device`.
+///
+/// Deliberately cluster-global (unlike every other test on the shared server):
+/// the harness's own gate is the one place that may assert on server-wide
+/// state. The stand-in database carries a unique name inside the harness's
+/// prefix, so parallel test processes cannot collide on it.
+#[tokio::test]
+async fn sweep_reclaims_ancient_leaked_clones() {
+    let db = testkit::db().await.expect("clone");
+    let pool = db.pool();
+
+    // `ehrbase_tk_<secs-hex>_<rand>` with a 1970 creation stamp: exactly what a
+    // clone looks like after the owning process was killed before its cleanup
+    // landed. `CREATE DATABASE` is cluster-global, so the clone's own
+    // connection can create it.
+    let leaked = format!("ehrbase_tk_1_leaked{}", uuid::Uuid::new_v4().simple());
+    let create = format!("CREATE DATABASE {leaked}");
+    sqlx::raw_sql(sqlx::AssertSqlSafe(create))
+        .execute(&pool)
+        .await
+        .expect("create the leaked-clone stand-in");
+
+    testkit::sweep_stale().await.expect("sweep");
+
+    let after: Vec<String> =
+        sqlx::query_scalar("SELECT datname FROM pg_database WHERE datname = $1")
+            .bind(leaked.as_str())
+            .fetch_all(&pool)
+            .await
+            .expect("catalog probe after the sweep");
+    assert!(
+        after.is_empty(),
+        "sweep left the ancient clone {leaked} behind"
+    );
+
+    // The clone this test runs on is young and connected — the same sweep must
+    // never touch it.
+    let own: Vec<String> = sqlx::query_scalar("SELECT datname FROM pg_database WHERE datname = $1")
+        .bind(db.name())
+        .fetch_all(&pool)
+        .await
+        .expect("catalog probe for the running test's own clone");
+    assert_eq!(
+        own,
+        vec![db.name().to_owned()],
+        "sweep dropped the running test's own clone"
+    );
+}
+
 /// The migration fingerprint is stable within a build — the template cache
 /// key must not wobble between calls.
 #[test]


### PR DESCRIPTION
Closes #326

## What

The reusable `ehrbase-testkit-pg18` container accumulated ~3k stale `ehrbase_tk_*` clone databases; PostgreSQL's cumulative-statistics shared memory for them filled the default 64 MB `/dev/shm`, after which every DSM allocation failed and 156 DB-backed tests went red.

- **Explicit 1 GiB `/dev/shm`** on the reusable container via `ImageExt::with_shm_size` (verified against the pinned testcontainers 0.27.3 source; cited to the official postgres-image docs, which document exactly this failure mode). Note: `ReuseDirective::Always` adopts an existing container as-is — one `docker rm -f ehrbase-testkit-pg18` is needed once per machine for the new size to apply (documented in testkit's CLAUDE.md).
- **Startup sweep that keeps up**: runs once per process inside the server-resolution `OnceCell` (before any clone/template work), under the existing advisory-lock election. Plain `DROP DATABASE` **without** FORCE — Postgres refuses in-use databases, so a concurrent process's live clone survives by construction; SQLSTATE 55006 is a benign counted skip. The live template (current migration fingerprint) is always spared; other-fingerprint templates are stale; clones become stale past a 30-min grace. (The old sweep used `WITH (FORCE)` — which could have killed a concurrent template migration — and ran too rarely to keep up.)
- New `sweep_stale()` + `SweepReport` public seam for manual reclaim and testing.
- Failure mode documented in `tools/testkit/CLAUDE.md` (symptom → cause chain → recovery → prevention).

## Verification

- Authored in an isolated worktree without cargo (one-`target/` rule); gated on the main tree: compiles first try, fmt + clippy clean
- `cargo nextest run -p testkit`: 10/10 incl. the new live journey `sweep_reclaims_ancient_leaked_clones` (1970-stamped leaked clone reclaimed; the running test's own young clone survives)
- `cargo nextest run --workspace` through the new harness: **2357 passed, 6 skipped, 0 failed**
- Container recreated from this branch and inspected: `HostConfig.ShmSize = 1073741824` (1 GiB) — proven live
- Unit tests pin: live template never swept at any age, unparseable names spared, only 55006 classified benign

Internal test tooling only — `no-changelog`.