### PR TITLE
fix(compose): observability overlay env keys use the strict EHRBASE__ grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,21 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **The observability Compose overlay boots again** (#321). Every server
+  variable in `docker-compose.observability.yml` was written in a
+  single-underscore form (`EHRBASE_MANAGEMENT_*`, `EHRBASE_OTEL_*`,
+  `EHRBASE_LOG_FORMAT`) that the strict boot-time sweep of the reserved
+  `EHRBASE_` namespace rejects, so `docker compose -f docker-compose.yml -f
+  docker-compose.observability.yml up` failed at startup with unknown-variable
+  errors instead of starting the server. The overlay now uses the documented
+  `EHRBASE__…` grammar (`EHRBASE__TELEMETRY__OTLP_ENDPOINT`,
+  `EHRBASE__LOG__FORMAT`, `EHRBASE__MANAGEMENT__ENABLED`,
+  `EHRBASE__MANAGEMENT__PORT`, `EHRBASE__MANAGEMENT__ENDPOINTS__{INFO,METRICS,PROMETHEUS}`),
+  with unchanged intent: OTLP traces to the bundled collector, JSON logs, and
+  the management surface public on internal port 9464 for the bundled Prometheus
+  to scrape. A test now runs the real sweep over every variable the shipped
+  Compose files set on the server service, so this class of drift fails in the
+  test suite rather than at `docker compose up`.
 - **Admin console: find-an-EHR-by-id works without JavaScript** (#301). The
   finder is now a plain `GET` form: submitting it before (or without) the
   browser app loading redirects to the EHR's detail screen server-side, and

--- a/app/ehrbase/src/config/strict.rs
+++ b/app/ehrbase/src/config/strict.rs
@@ -121,9 +121,12 @@ pub(super) fn damerau_levenshtein(a: &str, b: &str) -> usize {
     clippy::panic,
     clippy::print_stdout,
     clippy::print_stderr,
+    clippy::expect_used,
     let_underscore_drop
 )] // test assertions/diagnostics/fixtures
 mod tests {
+    use std::path::{Path, PathBuf};
+
     use super::*;
 
     #[test]
@@ -177,5 +180,170 @@ mod tests {
             .join("\n");
         assert_eq!(errs.len(), 1, "{joined}");
         assert!(joined.contains("EHRBASE__DB__URL"), "suggestion: {joined}");
+    }
+
+    // ── The shipped Compose artifacts must pass this very sweep ───────────────
+    //
+    // A Compose file that spells a reserved-namespace variable any other way
+    // produces a container that CANNOT BOOT, and the failure surfaces only at
+    // `docker compose up` — which is how a single-`_` env block once shipped in
+    // the observability overlay. This guard walks the committed YAML and runs
+    // the real sweep over every variable the CDR service sets, so the drift
+    // fails in the test suite instead. No openEHR spec governs configuration or
+    // Compose — our own design.
+
+    /// The compose service that runs the CDR binary this crate configures.
+    /// Every other service (the database, the admin console with its own
+    /// `EHRBASE_ADMIN__…` namespace, an upstream SUT) is unrelated.
+    const CDR_SERVICE: &str = "ehrbase";
+
+    /// The repository root — this crate lives at `app/ehrbase`.
+    fn repo_root() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+    }
+
+    fn is_yaml(path: &Path) -> bool {
+        matches!(
+            Path::extension(path).and_then(std::ffi::OsStr::to_str),
+            Some("yml" | "yaml")
+        )
+    }
+
+    /// Whether the file is a Compose file at all (as opposed to a Prometheus /
+    /// Grafana asset living beside one).
+    fn declares_services(path: &Path) -> bool {
+        std::fs::read_to_string(path)
+            .is_ok_and(|yaml| yaml.lines().any(|line| line.trim_end() == "services:"))
+    }
+
+    /// Every committed Compose artifact: the root `docker-compose*.yml` files
+    /// plus every `services:`-bearing YAML under `docker/`.
+    fn compose_files() -> Vec<PathBuf> {
+        let root = repo_root();
+        let mut files = Vec::new();
+        for entry in std::fs::read_dir(&root).expect("read repo root").flatten() {
+            let path = entry.path();
+            let is_root_compose = path
+                .file_name()
+                .and_then(std::ffi::OsStr::to_str)
+                .is_some_and(|name| name.starts_with("docker-compose"));
+            if is_root_compose && is_yaml(&path) {
+                files.push(path);
+            }
+        }
+        let mut dirs = vec![root.join("docker")];
+        while let Some(dir) = dirs.pop() {
+            let Ok(entries) = std::fs::read_dir(dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    dirs.push(path);
+                } else if is_yaml(&path) && declares_services(&path) {
+                    files.push(path);
+                }
+            }
+        }
+        files.sort();
+        files
+    }
+
+    /// `(service, 1-based line, variable name)` for every `environment:` entry
+    /// in a Compose file. Parsed by indentation, which is all this guard needs:
+    /// these files are uniformly two-space indented, so a service name sits at
+    /// indent 2, its `environment:` key at 4, and the entries below that — in
+    /// either the mapping (`NAME: value`) or the list (`- NAME=value`) form
+    /// (docs.docker.com/reference/compose-file/services/#environment).
+    fn env_entries(yaml: &str) -> Vec<(String, usize, String)> {
+        let mut out = Vec::new();
+        let mut in_services = false;
+        let mut service = String::new();
+        let mut in_env = false;
+        for (index, raw) in yaml.lines().enumerate() {
+            let line = raw.trim_end();
+            let body = line.trim_start();
+            if body.is_empty() || body.starts_with('#') {
+                continue;
+            }
+            match line.len() - body.len() {
+                0 => {
+                    in_services = body == "services:";
+                    service.clear();
+                    in_env = false;
+                }
+                2 => {
+                    service = body.trim_end_matches(':').to_owned();
+                    in_env = false;
+                }
+                4 => in_env = body == "environment:",
+                _ => {
+                    if in_services && in_env && !service.is_empty() {
+                        if let Some(name) = entry_name(body) {
+                            out.push((service.clone(), index + 1, name));
+                        }
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    /// The variable name of one `environment:` entry, in either form.
+    fn entry_name(entry: &str) -> Option<String> {
+        let name = match entry.strip_prefix("- ") {
+            // List form: `- NAME=value`, or a bare `- NAME` host pass-through.
+            Some(item) => item.trim().split_once('=').map_or(item.trim(), |(n, _)| n),
+            // Mapping form: `NAME: value`.
+            None => entry.split_once(':')?.0,
+        };
+        let name = name.trim();
+        if name.is_empty() {
+            None
+        } else {
+            Some(name.to_owned())
+        }
+    }
+
+    #[test]
+    fn shipped_compose_env_passes_the_strict_sweep() {
+        let files = compose_files();
+        assert!(
+            files.len() >= 2,
+            "no Compose artifacts discovered — the guard is blind: {files:?}"
+        );
+
+        let mut cdr_entries = Vec::new();
+        for path in &files {
+            let yaml = std::fs::read_to_string(path).expect("read compose file");
+            for (service, line, name) in env_entries(&yaml) {
+                if service == CDR_SERVICE {
+                    cdr_entries.push((path.clone(), line, name));
+                }
+            }
+        }
+
+        assert!(
+            cdr_entries
+                .iter()
+                .any(|(_, _, name)| name == "EHRBASE__DB__URL"),
+            "the CDR service's DSN variable was not extracted — the guard is \
+             blind (Compose layout or service name drift): {cdr_entries:?}"
+        );
+
+        let mut failures = Vec::new();
+        for (path, line, name) in &cdr_entries {
+            let mut one = HashMap::new();
+            one.insert(name.clone(), String::new());
+            for error in strict_env(&one) {
+                failures.push(format!("{}:{line}: {error}", path.display()));
+            }
+        }
+        assert!(
+            failures.is_empty(),
+            "Compose sets variables the boot-time sweep rejects, so the \
+             composed server cannot start:\n{}",
+            failures.join("\n")
+        );
     }
 }

--- a/app/ehrbase/src/config/strict.rs
+++ b/app/ehrbase/src/config/strict.rs
@@ -278,10 +278,12 @@ mod tests {
                 }
                 4 => in_env = body == "environment:",
                 _ => {
-                    if in_services && in_env && !service.is_empty() {
-                        if let Some(name) = entry_name(body) {
-                            out.push((service.clone(), index + 1, name));
-                        }
+                    if in_services
+                        && in_env
+                        && !service.is_empty()
+                        && let Some(name) = entry_name(body)
+                    {
+                        out.push((service.clone(), index + 1, name));
                     }
                 }
             }

--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -1,4 +1,4 @@
-# Observability overlay for the ehrbase-rs dev stack (binding doc §5).
+# Observability overlay for the ehrbase-rs dev stack.
 #
 #   docker compose -f docker-compose.yml -f docker-compose.observability.yml up --build
 #
@@ -6,29 +6,37 @@
 # Prometheus + Tempo + Loki + Grafana) and points the app at it:
 #   - traces  → OTLP/gRPC to otel-lgtm:4317 (→ Tempo)
 #   - metrics → pulled by the bundled Prometheus from ehrbase:9464/management/prometheus
-#   - logs    → stdout (12-factor; the platform collects them)
+#   - logs    → stdout as JSON lines (12-factor; the platform collects them)
 #
 # The management surface is enabled on an INTERNAL port (9464) exposed only on
 # the compose network — never published to the host. Grafana (3000) is the only
 # published port. This overlay is a manual dev convenience, not a CI job.
 services:
   ehrbase:
+    # Every server setting uses the ONE strict env grammar: `EHRBASE` + the TOML
+    # path, upper-cased, with `__` between EVERY segment (including after the
+    # prefix). The boot-time sweep of the reserved `EHRBASE_` namespace REJECTS
+    # any other spelling — a single-`_` variable is a startup error, not a
+    # silently ignored setting, so these names must stay in this form.
     environment:
-      # Traces to the LGTM collector (metrics stay a Prometheus pull; see below).
-      EHRBASE_OTEL_OTLP_ENDPOINT: http://otel-lgtm:4317
-      EHRBASE_OTEL_SERVICE_NAME: ehrbase
-      EHRBASE_OTEL_ENVIRONMENT: dev
-      EHRBASE_OTEL_TRACES_SAMPLE_RATIO: "1.0"
-      EHRBASE_LOG_FORMAT: json
+      # Traces to the LGTM collector ([telemetry]; metrics stay a Prometheus
+      # pull, see below). Unset otlp_endpoint would leave the OTel layer out.
+      EHRBASE__TELEMETRY__OTLP_ENDPOINT: http://otel-lgtm:4317
+      EHRBASE__TELEMETRY__SERVICE_NAME: ehrbase
+      EHRBASE__TELEMETRY__ENVIRONMENT: dev
+      EHRBASE__TELEMETRY__TRACES_SAMPLE_RATIO: "1.0"
+      # Structured stdout so the bundled log pipeline ingests fields, not text
+      # (overrides the root stack's dev-friendly `pretty`).
+      EHRBASE__LOG__FORMAT: json
       # Ops-introspection surface on an internal-only port; public within the
       # compose network so the bundled Prometheus can scrape without credentials.
       # (The health probes need none of this — /health, /health/liveness and
       # /health/readiness are always served on the main API port.)
-      EHRBASE_MANAGEMENT_ENABLED: "true"
-      EHRBASE_MANAGEMENT_PORT: "9464"
-      EHRBASE_MANAGEMENT_ENDPOINTS_INFO: "public"
-      EHRBASE_MANAGEMENT_ENDPOINTS_METRICS: "public"
-      EHRBASE_MANAGEMENT_ENDPOINTS_PROMETHEUS: "public"
+      EHRBASE__MANAGEMENT__ENABLED: "true"
+      EHRBASE__MANAGEMENT__PORT: "9464"
+      EHRBASE__MANAGEMENT__ENDPOINTS__INFO: "public"
+      EHRBASE__MANAGEMENT__ENDPOINTS__METRICS: "public"
+      EHRBASE__MANAGEMENT__ENDPOINTS__PROMETHEUS: "public"
     expose:
       - "9464"
     depends_on:

--- a/docker/observability/prometheus-scrape.yaml
+++ b/docker/observability/prometheus-scrape.yaml
@@ -1,6 +1,7 @@
 # Extra Prometheus scrape config merged into the bundled otel-lgtm Prometheus
-# (binding doc §5). Scrapes the app's management Prometheus endpoint over the
-# compose network. The management port (9464) is internal-only.
+# (docker-compose.observability.yml mounts it into the image's
+# scrape-configs directory). Scrapes the app's management Prometheus endpoint
+# over the compose network; the management port (9464) is internal-only.
 - job_name: ehrbase
   metrics_path: /management/prometheus
   scrape_interval: 15s

--- a/website/book/src/installation/compose.md
+++ b/website/book/src/installation/compose.md
@@ -129,6 +129,17 @@ docker compose -f docker-compose.yml -f docker-compose.observability.yml up --bu
 # Grafana → http://localhost:3000
 ```
 
+The overlay reconfigures the server for that stack: it exports traces over
+OTLP/gRPC (`EHRBASE__TELEMETRY__OTLP_ENDPOINT`), switches stdout to JSON lines
+(`EHRBASE__LOG__FORMAT=json`), and enables the management surface on its own
+internal port 9464 (`EHRBASE__MANAGEMENT__ENABLED`, `EHRBASE__MANAGEMENT__PORT`)
+with `info`, `metrics`, and `prometheus` set to `public` so the bundled
+Prometheus can scrape `/management/prometheus` without credentials. That port is
+only reachable on the Compose network — Grafana's 3000 is the sole published
+port. Every variable uses the same `EHRBASE__…` grammar as the rest of the
+[configuration reference](configuration.md); a single-underscore spelling is
+rejected at startup, not ignored.
+
 This is the easiest way to see the server's metrics and traces without wiring
 up a collector by hand. See [Operations](../operations.md) for what the server
 exports and how to consume it in production.


### PR DESCRIPTION
Closes #321

## What

The shipped `docker-compose.observability.yml` set every CDR env key in a single-underscore grammar (`EHRBASE_OTEL_*`, `EHRBASE_MANAGEMENT_*`, `EHRBASE_LOG_FORMAT`) that the strict boot sweep rejects — the overlay could not boot at all. Also, `EHRBASE_OTEL_*` was doubly wrong: there is no `otel` section; the real tree is `telemetry.*`.

- **Every key rewritten to its real config field path**, each verified against the struct definitions (mapping table on the issue/report): `EHRBASE__TELEMETRY__{OTLP_ENDPOINT,SERVICE_NAME,ENVIRONMENT,TRACES_SAMPLE_RATIO}`, `EHRBASE__LOG__FORMAT`, `EHRBASE__MANAGEMENT__{ENABLED,PORT}`, `EHRBASE__MANAGEMENT__ENDPOINTS__{INFO,METRICS,PROMETHEUS}`. Nothing removed-in-#320 reintroduced.
- **Drift guard**: `config::strict::tests::shipped_compose_env_passes_the_strict_sweep` — extracts every `EHRBASE_*` env key of the `ehrbase` service from all compose files and runs each through the *real* `strict_env` (no duplicated rule), with blindness guards (≥2 compose files discovered; `EHRBASE__DB__URL` must be seen). **Proven both ways on this machine**: PASS on this branch, FAIL against develop's committed overlay (10 findings, the exact 10 dead lines).
- Book compose page documents the overlay + the grammar rule; a stray internal-doc citation in `prometheus-scrape.yaml` scrubbed en route.

## Verification

- `cargo clippy -p ehrbase --all-targets` clean; strict/config tests 11/11
- **Live boot**: `docker compose -f docker-compose.yml -f docker-compose.observability.yml up -d --wait ehrbase` → all three containers Healthy (previously: boot failure on the first rejected key); clean `down -v`, zero survivors
- CHANGELOG `### Fixed` (a shipped overlay that could not boot now boots)