### PR TITLE
fix(telemetry): wire compositions_committed_total; register five uncataloged metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,19 @@ workflow refuses a tag that has no matching section here.
   to scrape. A test now runs the real sweep over every variable the shipped
   Compose files set on the server service, so this class of drift fails in the
   test suite rather than at `docker compose up`.
+- **The `compositions_committed_total` metric now counts** (#332). The counter
+  was declared and scraped but never incremented, so dashboards over it
+  rendered a permanently empty series. Every commit route that lands a
+  COMPOSITION version — create, update, delete, and a CONTRIBUTION commit —
+  now increments it once per committed version, labelled `change_type` with the
+  openEHR `audit_change_type` code recorded on that version's audit
+  (`249`/`251`/`523`/…). The increment happens after the transaction commits, so
+  a rolled-back write is never counted. In the same audit of the metric
+  registry, five metrics that were emitted but not registered
+  (`version_signature_invalid_total`, `authz_cedar_decisions_total`,
+  `authz_remote_pdp_calls_total`, `atna_audit_rejected_total`,
+  `atna_audit_reaped_total`) now carry their `# HELP`/`# TYPE` descriptions in
+  the `/management/prometheus` exposition.
 - **Admin console: find-an-EHR-by-id works without JavaScript** (#301). The
   finder is now a plain `GET` form: submitting it before (or without) the
   browser app loading redirects to the EHR's detail screen server-side, and

--- a/app/ehrbase-rest/src/extensions/access/authz/cedar.rs
+++ b/app/ehrbase-rest/src/extensions/access/authz/cedar.rs
@@ -41,9 +41,6 @@ use crate::extensions::access::authz::request::{
     AccessMode, AuthzRequest, Combination, Decision, ResourceKind,
 };
 
-/// `metrics` counter incremented once per Cedar decision (`result` = permit/deny).
-pub const METRIC_CEDAR_DECISIONS: &str = "authz_cedar_decisions_total";
-
 /// Every resource kind, for schema construction.
 const KINDS: [ResourceKind; 6] = [
     ResourceKind::Ehr,
@@ -184,9 +181,17 @@ impl PolicyEngine for CedarEngine {
     async fn decide(&self, req: &AuthzRequest<'_>) -> Result<Decision, AuthzError> {
         for combo in req.combinations() {
             if self.permits(req, &combo)? {
-                metrics::counter!(METRIC_CEDAR_DECISIONS, "result" => "permit").increment(1);
+                metrics::counter!(
+                    ehrbase::telemetry::prometheus::AUTHZ_CEDAR_DECISIONS,
+                    "result" => "permit"
+                )
+                .increment(1);
             } else {
-                metrics::counter!(METRIC_CEDAR_DECISIONS, "result" => "deny").increment(1);
+                metrics::counter!(
+                    ehrbase::telemetry::prometheus::AUTHZ_CEDAR_DECISIONS,
+                    "result" => "deny"
+                )
+                .increment(1);
                 return Ok(Decision::Deny);
             }
         }

--- a/app/ehrbase-rest/src/extensions/access/authz/remote.rs
+++ b/app/ehrbase-rest/src/extensions/access/authz/remote.rs
@@ -19,9 +19,6 @@ use crate::extensions::access::authz::engine::{AuthzError, PolicyEngine};
 use crate::extensions::access::authz::request::{AuthzRequest, Combination, Decision};
 use ehrbase::config::authz::{AbacConfig, AbacParam, PolicyRule};
 
-/// `metrics` counter incremented once per PDP HTTP call (`result` = permit/deny).
-pub const METRIC_REMOTE_CALLS: &str = "authz_remote_pdp_calls_total";
-
 /// The v1-compatible remote policy-decision-point client.
 #[derive(Debug)]
 pub struct RemotePdp {
@@ -105,10 +102,18 @@ impl PolicyEngine for RemotePdp {
         };
         for combo in req.combinations() {
             if !self.permits(rule, &combo).await? {
-                metrics::counter!(METRIC_REMOTE_CALLS, "result" => "deny").increment(1);
+                metrics::counter!(
+                    ehrbase::telemetry::prometheus::AUTHZ_REMOTE_PDP_CALLS,
+                    "result" => "deny"
+                )
+                .increment(1);
                 return Ok(Decision::Deny);
             }
-            metrics::counter!(METRIC_REMOTE_CALLS, "result" => "permit").increment(1);
+            metrics::counter!(
+                ehrbase::telemetry::prometheus::AUTHZ_REMOTE_PDP_CALLS,
+                "result" => "permit"
+            )
+            .increment(1);
         }
         Ok(Decision::Permit)
     }

--- a/app/ehrbase-server/tests/snapshots/telemetry__metric_catalog_snapshot.snap
+++ b/app/ehrbase-server/tests/snapshots/telemetry__metric_catalog_snapshot.snap
@@ -1,6 +1,5 @@
 ---
 source: app/ehrbase-server/tests/telemetry.rs
-assertion_line: 28
 expression: "lines.join(\"\\n\")"
 ---
 http_server_request_duration_seconds histogram buckets=[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]
@@ -8,6 +7,8 @@ http_server_active_requests gauge
 http_server_request_body_size_bytes histogram buckets=[64.0, 256.0, 1024.0, 4096.0, 16384.0, 65536.0, 262144.0, 1048576.0, 4194304.0, 16777216.0]
 http_server_response_body_size_bytes histogram buckets=[64.0, 256.0, 1024.0, 4096.0, 16384.0, 65536.0, 262144.0, 1048576.0, 4194304.0, 16777216.0]
 auth_failures_total counter
+authz_cedar_decisions_total counter
+authz_remote_pdp_calls_total counter
 db_pool_connections gauge
 db_pool_acquire_duration_seconds histogram buckets=[0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0]
 db_transactions_total counter
@@ -16,13 +17,16 @@ aql_query_duration_seconds histogram buckets=[0.001, 0.005, 0.01, 0.05, 0.1, 0.2
 aql_plan_cache_events_total counter
 compositions_committed_total counter
 validation_failures_total counter
+version_signature_invalid_total counter
 webtemplate_cache_events_total counter
 events_published_total counter
 atna_audit_emitted_total counter
 atna_audit_dropped_total counter
+atna_audit_rejected_total counter
 atna_audit_sent_total counter
 atna_audit_send_failed_total counter
 atna_audit_serialize_failed_total counter
+atna_audit_reaped_total counter
 process_start_time_seconds gauge
 ehrbase_build_info gauge
 tokio_workers gauge

--- a/app/ehrbase/src/service/ehr/composition.rs
+++ b/app/ehrbase/src/service/ehr/composition.rs
@@ -85,6 +85,7 @@ impl EhrbaseService {
         tx.commit().await?;
         metrics::counter!(crate::telemetry::prometheus::DB_TRANSACTIONS, "outcome" => "commit")
             .increment(1);
+        crate::versioning::change::meter_committed(&committed);
 
         // The write result is the committed version identity itself — a
         // representation response re-reads at the protocol layer.
@@ -368,6 +369,7 @@ impl EhrbaseService {
         tx.commit().await?;
         metrics::counter!(crate::telemetry::prometheus::DB_TRANSACTIONS, "outcome" => "commit")
             .increment(1);
+        crate::versioning::change::meter_committed(&committed);
 
         Ok(committed)
     }
@@ -509,6 +511,7 @@ impl EhrbaseService {
         tx.commit().await?;
         metrics::counter!(crate::telemetry::prometheus::DB_TRANSACTIONS, "outcome" => "commit")
             .increment(1);
+        crate::versioning::change::meter_committed(&committed);
         // 204_COMPOSITION_deleted: the (now deleted) version identity.
         Ok(committed)
     }

--- a/app/ehrbase/src/telemetry/prometheus.rs
+++ b/app/ehrbase/src/telemetry/prometheus.rs
@@ -1,22 +1,29 @@
 //! The Prometheus recorder: install, bucket ladders, metric catalog, and the
-//! `build_info` / `process_start_time` gauges (binding doc §1.2).
+//! `build_info` / `process_start_time` gauges.
 //!
 //! The [`catalog`] is the single source of truth for every application metric
 //! — its names, kinds, units, and (for histograms) explicit bucket ladders. It
 //! drives both the recorder's bucket configuration and the `describe_*`
 //! registrations, and a snapshot test pins it so a rename is always deliberate.
+//! That holds across crates: a metric the protocol adapter emits (the `http_*`,
+//! `auth_*`, `authz_*` families) declares its NAME here too, so an emitted
+//! series is never missing its `# HELP`/`# TYPE` registration — and, in the
+//! other direction, a catalog entry no code emits would render a permanently
+//! dead series, so every entry has at least one emitting call site.
 //!
 //! The `metrics` facade emits at the call sites; the recorder renders the
 //! exposition text served at `/management/prometheus`.
 
 use crate::system_log::sender::{
-    METRIC_DROPPED, METRIC_EMITTED, METRIC_SEND_FAILED, METRIC_SENT, METRIC_SERIALIZE_FAILED,
+    METRIC_DROPPED, METRIC_EMITTED, METRIC_REAPED, METRIC_REJECTED, METRIC_SEND_FAILED,
+    METRIC_SENT, METRIC_SERIALIZE_FAILED,
 };
 use crate::telemetry::build_info::BuildInfo;
 use metrics_exporter_prometheus::{BuildError, Matcher, PrometheusBuilder, PrometheusHandle};
 
-// HTTP-surface metric names (recorded by the protocol adapter's middleware,
-// registered here so the exporter and the recorder share one vocabulary).
+// Metric names the protocol adapter (`ehrbase-rest`) records — the HTTP
+// surface and the auth/authz decisions — declared here so the exporter and the
+// recorder share one vocabulary.
 /// HTTP request-duration histogram (`http_route`, `http_request_method`,
 /// `status_class`).
 pub const HTTP_REQUEST_DURATION: &str = "http_server_request_duration_seconds";
@@ -34,9 +41,17 @@ pub const HTTP_RESPONSE_BODY_SIZE: &str = "http_server_response_body_size_bytes"
 /// middleware.
 pub const AUTH_FAILURES: &str = "auth_failures_total";
 
-// ── Metric names emitted from this crate (§1.2). The http_* / auth_* names
-//    are emitted by `ehrbase-rest`; the atna_* names by
-//    `crate::system_log::sender`. ─────────────────────────────────────────────
+/// Cedar authorization-decision counter (`result` = permit/deny), emitted by
+/// the protocol adapter's `access::authz` Cedar engine.
+pub const AUTHZ_CEDAR_DECISIONS: &str = "authz_cedar_decisions_total";
+
+/// Remote-PDP authorization-call counter (`result` = permit/deny), emitted by
+/// the protocol adapter's `access::authz` remote decision point.
+pub const AUTHZ_REMOTE_PDP_CALLS: &str = "authz_remote_pdp_calls_total";
+
+// ── Metric names emitted from this crate (the http_* / auth_* / authz_* names
+//    above are emitted by `ehrbase-rest`; the atna_* names below by
+//    `crate::system_log::sender`). ────────────────────────────────────────────
 
 /// DB pool connection gauge (`state` = `idle/in_use`).
 pub const DB_POOL_CONNECTIONS: &str = "db_pool_connections";
@@ -52,7 +67,11 @@ pub const AQL_QUERY_DURATION: &str = "aql_query_duration_seconds";
 /// lowered query plans keyed on the query text (no openEHR spec governs
 /// this, our own performance design).
 pub const AQL_PLAN_CACHE_EVENTS: &str = "aql_plan_cache_events_total";
-/// Committed-composition counter (`change_type`).
+/// Committed-composition counter (`change_type` = the numeric openEHR
+/// `audit_change_type` group code — `249`/`251`/`523`/…), incremented by
+/// [`crate::versioning::change::meter_committed`] once per COMPOSITION version
+/// that a commit route actually committed (the direct create/update/delete
+/// routes and the CONTRIBUTION commit).
 pub const COMPOSITIONS_COMMITTED: &str = "compositions_committed_total";
 /// Validation-failure counter (`pass` = `rm_invariant/terminology/template`).
 pub const VALIDATION_FAILURES: &str = "validation_failures_total";
@@ -76,7 +95,7 @@ pub const TOKIO_GLOBAL_QUEUE_DEPTH: &str = "tokio_global_queue_depth";
 /// Tokio runtime alive-task count gauge.
 pub const TOKIO_ALIVE_TASKS: &str = "tokio_alive_tasks";
 
-// ── Histogram bucket ladders (§1.2), defined once. ──────────────────────────
+// ── Histogram bucket ladders, defined once. ─────────────────────────────────
 
 /// HTTP request duration: 5ms … 10s log ladder.
 pub const HTTP_DURATION_BUCKETS: &[f64] = &[
@@ -161,7 +180,7 @@ const fn histogram(
     }
 }
 
-/// The full application metric catalog (§1.2). Ordered for a stable snapshot.
+/// The full application metric catalog. Ordered for a stable snapshot.
 #[must_use]
 pub fn catalog() -> Vec<MetricSpec> {
     vec![
@@ -186,6 +205,14 @@ pub fn catalog() -> Vec<MetricSpec> {
             AUTH_FAILURES,
             "Authentication failures by mechanism and status",
         ),
+        counter(
+            AUTHZ_CEDAR_DECISIONS,
+            "Cedar authorization decisions by result",
+        ),
+        counter(
+            AUTHZ_REMOTE_PDP_CALLS,
+            "Remote-PDP authorization calls by result",
+        ),
         // Database.
         gauge(DB_POOL_CONNECTIONS, "Connection pool connections by state"),
         histogram(
@@ -208,6 +235,10 @@ pub fn catalog() -> Vec<MetricSpec> {
             "Committed compositions by change type",
         ),
         counter(VALIDATION_FAILURES, "Validation failures by pass"),
+        counter(
+            VERSION_SIGNATURE_INVALID,
+            "Version signature verification failures by verdict",
+        ),
         counter(WEBTEMPLATE_CACHE_EVENTS, "WebTemplate cache events"),
         // Contribution-outbox eventing.
         counter(
@@ -217,12 +248,17 @@ pub fn catalog() -> Vec<MetricSpec> {
         // ATNA audit (emitted by crate::system_log::sender).
         counter(METRIC_EMITTED, "ATNA audit records enqueued"),
         counter(METRIC_DROPPED, "ATNA audit records dropped"),
+        counter(
+            METRIC_REJECTED,
+            "Auditable operations rejected under fail_mode = closed",
+        ),
         counter(METRIC_SENT, "ATNA audit records sent to transport"),
         counter(METRIC_SEND_FAILED, "ATNA audit transport send failures"),
         counter(
             METRIC_SERIALIZE_FAILED,
             "ATNA audit record serialization failures (record dropped)",
         ),
+        counter(METRIC_REAPED, "ATNA audit rows reaped by the retention job"),
         // Process / build / runtime.
         gauge(PROCESS_START_TIME, "Process start time (unix seconds)"),
         gauge(
@@ -235,7 +271,7 @@ pub fn catalog() -> Vec<MetricSpec> {
     ]
 }
 
-/// Install the global Prometheus recorder with the §1.2 bucket ladders, then
+/// Install the global Prometheus recorder with the catalog bucket ladders, then
 /// register descriptions and emit the `build_info` / `process_start_time`
 /// gauges. Returns the render handle for `/management/prometheus`.
 ///
@@ -325,6 +361,8 @@ mod tests {
             HTTP_REQUEST_DURATION,
             HTTP_ACTIVE_REQUESTS,
             AUTH_FAILURES,
+            AUTHZ_CEDAR_DECISIONS,
+            AUTHZ_REMOTE_PDP_CALLS,
             DB_POOL_CONNECTIONS,
             DB_POOL_ACQUIRE_DURATION,
             DB_TRANSACTIONS,
@@ -333,8 +371,12 @@ mod tests {
             AQL_PLAN_CACHE_EVENTS,
             COMPOSITIONS_COMMITTED,
             VALIDATION_FAILURES,
+            VERSION_SIGNATURE_INVALID,
             WEBTEMPLATE_CACHE_EVENTS,
+            EVENTS_PUBLISHED,
             METRIC_SENT,
+            METRIC_REJECTED,
+            METRIC_REAPED,
             BUILD_INFO,
             PROCESS_START_TIME,
             TOKIO_WORKERS,

--- a/app/ehrbase/src/versioning/change.rs
+++ b/app/ehrbase/src/versioning/change.rs
@@ -76,6 +76,31 @@ impl Committed {
     }
 }
 
+/// Meter a just-committed version on the
+/// [`COMPOSITIONS_COMMITTED`](crate::telemetry::prometheus::COMPOSITIONS_COMMITTED)
+/// counter; kinds other than COMPOSITION are ignored.
+///
+/// Every commit route calls this **after** its transaction has committed, so a
+/// rolled-back write is never counted — which is why the increment cannot live
+/// in [`apply_change`] (it runs inside the commit transaction).
+///
+/// NOTE: no openEHR spec governs telemetry — our own design/extension. The
+/// `change_type` label carries the numeric openEHR `audit_change_type` group
+/// code recorded on the version's audit (`249`/`251`/`523`/…), never its English
+/// rubric: the code is the value the RM stores
+/// (`AUDIT_DETAILS.Change_type_valid`, RM common master04 §Audit Details) and
+/// the value the contribution-list surface already returns, so the series stays
+/// stable when terminology display text changes.
+pub(crate) fn meter_committed(committed: &Committed) {
+    if committed.kind == Kind::Composition {
+        metrics::counter!(
+            crate::telemetry::prometheus::COMPOSITIONS_COMMITTED,
+            "change_type" => committed.change_type.clone(),
+        )
+        .increment(1);
+    }
+}
+
 /// One change applied within a CONTRIBUTION — the openEHR change-set unit
 /// (RM common master06 §Contributions).
 ///
@@ -373,8 +398,9 @@ struct ResolvedWrite {
 ///   RM ehr `versioned_composition.adoc`), before a COMPOSITION modify;
 /// - `CommitEnv::post_status_commit` — the EHR promoted-subject-column sync,
 ///   after an `EHR_STATUS` version;
-/// - the `compositions_committed_total` metric — a cross-cutting service-layer
-///   concern, not a storage write.
+/// - [`meter_committed`] — the `compositions_committed_total` metric, a
+///   cross-cutting service-layer concern (and one that must only count work
+///   that actually committed), not a storage write.
 ///
 /// # Errors
 /// The [`next_version`] placement errors (`NotFound` / `VersionConflict`) on

--- a/app/ehrbase/src/versioning/contribution.rs
+++ b/app/ehrbase/src/versioning/contribution.rs
@@ -589,6 +589,12 @@ pub(crate) async fn commit_version_set(
     }
     tx.commit().await?;
 
+    // Meter the COMPOSITION versions this CONTRIBUTION landed, after the commit
+    // (a rolled-back contribution counts nothing).
+    for c in &committed {
+        change::meter_committed(c);
+    }
+
     // An EHR_ACCESS version changes the EHR's access-control policy (the
     // settings are change-controlled — RM ehr master04 §EHR Access), so drop the
     // cached settings the access gate consults per request.

--- a/app/ehrbase/tests/telemetry_metrics.rs
+++ b/app/ehrbase/tests/telemetry_metrics.rs
@@ -1,0 +1,251 @@
+#![allow(
+    clippy::panic,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    let_underscore_drop
+)] // test assertions/diagnostics/fixtures
+//! Service-layer metric emission against a real `PostgreSQL` 18 (shared testkit
+//! harness): the `compositions_committed_total` counter must move once per
+//! COMPOSITION version that a commit route actually committed — the direct
+//! create/update/delete routes and the CONTRIBUTION commit — and must NOT move
+//! for a write whose transaction rolled back.
+//!
+//! The `change_type` label is the numeric openEHR `audit_change_type` group code
+//! the version's audit records (`249|creation|` / `251|modification|` /
+//! `523|deleted|`; RM common `master06-change_control_package.adoc`
+//! §Contributions). No openEHR spec governs telemetry — the counter is our own
+//! operational surface.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::OnceLock;
+
+use ehrbase::service::EhrbaseService;
+use ehrbase::service::version_update::{UpdateAudit, UpdateVersion};
+use ehrbase::telemetry::build_info::BuildInfo;
+use ehrbase::telemetry::prometheus::install;
+use metrics_exporter_prometheus::PrometheusHandle;
+use openehr_base::prelude::{ObjectVersionId, TerminologyCode};
+use openehr_rm::prelude::PartyProxy;
+use serde_json::{Value, json};
+
+/// The process-wide recorder, installed through the real
+/// [`install`] entry point (so the catalog's `describe_*` registrations run too)
+/// and shared because only one global `metrics` recorder can exist per process.
+fn recorder() -> &'static PrometheusHandle {
+    static HANDLE: OnceLock<PrometheusHandle> = OnceLock::new();
+    HANDLE.get_or_init(|| install(&BuildInfo::current()).expect("install prometheus recorder"))
+}
+
+/// The rendered value of `compositions_committed_total{change_type="<code>"}`,
+/// or `0` when the series has not been emitted yet.
+fn committed(handle: &PrometheusHandle, change_type: &str) -> u64 {
+    let needle = format!("change_type=\"{change_type}\"");
+    handle
+        .render()
+        .lines()
+        .filter(|l| l.starts_with("compositions_committed_total{") && l.contains(&needle))
+        .find_map(|l| l.rsplit(' ').next().and_then(|v| v.parse::<u64>().ok()))
+        .unwrap_or(0)
+}
+
+/// An `openehr` terminology code (audit change type / lifecycle state).
+fn term(code: &str) -> TerminologyCode {
+    TerminologyCode {
+        terminology_id: "openehr".to_owned(),
+        terminology_version: None,
+        code_string: code.to_owned(),
+        uri: None,
+    }
+}
+
+fn committer(name: &str) -> Value {
+    json!({ "_type": "PARTY_IDENTIFIED", "name": name })
+}
+
+/// The wire `change_type` `DV_CODED_TEXT` of a CONTRIBUTION version item.
+fn change_type(code: &str, value: &str) -> Value {
+    json!({
+        "_type": "DV_CODED_TEXT", "value": value,
+        "defining_code": {
+            "_type": "CODE_PHRASE",
+            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" },
+            "code_string": code
+        }
+    })
+}
+
+/// The SM `UPDATE_VERSION` commit envelope for a bare-RM composition write.
+fn uv(data: Value, change_code: &str, preceding: Option<&str>) -> UpdateVersion {
+    UpdateVersion {
+        preceding_version_uid: preceding.map(|p| p.parse().expect("OBJECT_VERSION_ID")),
+        lifecycle_state: term("532"),
+        attestations: None,
+        data,
+        audit: UpdateAudit {
+            change_type: term(change_code),
+            description: None,
+            committer: openehr_its::json::from_canonical_value::<PartyProxy>(&committer(
+                "metrics tester",
+            ))
+            .expect("committer"),
+            system_id: None,
+        },
+        signature: None,
+    }
+}
+
+/// A minimal *valid* RM COMPOSITION.
+fn composition(name: &str) -> Value {
+    json!({
+        "_type": "COMPOSITION",
+        "archetype_node_id": "openEHR-EHR-COMPOSITION.encounter.v1",
+        "archetype_details": {
+            "_type": "ARCHETYPED",
+            "archetype_id": {
+                "_type": "ARCHETYPE_ID",
+                "value": "openEHR-EHR-COMPOSITION.encounter.v1"
+            },
+            "rm_version": "1.2.0"
+        },
+        "name": { "_type": "DV_TEXT", "value": name },
+        "language": {
+            "_type": "CODE_PHRASE",
+            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_639-1" },
+            "code_string": "en"
+        },
+        "territory": {
+            "_type": "CODE_PHRASE",
+            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_3166-1" },
+            "code_string": "NL"
+        },
+        "category": {
+            "_type": "DV_CODED_TEXT",
+            "value": "event",
+            "defining_code": {
+                "_type": "CODE_PHRASE",
+                "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" },
+                "code_string": "433"
+            }
+        },
+        "composer": { "_type": "PARTY_IDENTIFIED", "name": "metrics tester" }
+    })
+}
+
+fn vo_of(ovid: &str) -> &str {
+    ovid.split("::").next().expect("object id part")
+}
+
+/// One test drives every phase in a single process, so the counter deltas are
+/// never entangled with another test's commits.
+#[tokio::test]
+async fn compositions_committed_total_counts_every_committed_composition_version() {
+    let handle = recorder();
+    let db = testkit::db().await.expect("testkit database");
+    let svc = EhrbaseService::new(db.pool());
+    let ehr_id = svc.create_ehr(None).await.expect("create_ehr");
+
+    let (creations, modifications, deletions) = (
+        committed(handle, "249"),
+        committed(handle, "251"),
+        committed(handle, "523"),
+    );
+
+    // (1) The direct create route: one 249|creation| version.
+    let v1 = svc
+        .create_composition(ehr_id, uv(composition("v1"), "249", None))
+        .await
+        .expect("create_composition")
+        .version_uid();
+    assert_eq!(
+        committed(handle, "249"),
+        creations + 1,
+        "create_composition must count one 249|creation| commit"
+    );
+
+    // (2) The direct update route: one 251|modification| version.
+    let v2 = svc
+        .update_composition(
+            ehr_id,
+            vo_of(&v1).parse().expect("vo uuid"),
+            uv(composition("v2"), "251", Some(&v1)),
+        )
+        .await
+        .expect("update_composition")
+        .version_uid();
+    assert_eq!(
+        committed(handle, "251"),
+        modifications + 1,
+        "update_composition must count one 251|modification| commit"
+    );
+
+    // (3) A rolled-back write counts NOTHING: the stale `preceding_version_uid`
+    // fails the version placement inside the commit transaction, so the
+    // transaction never commits.
+    let stale: ObjectVersionId = v1.parse().expect("OBJECT_VERSION_ID");
+    let conflict = svc
+        .update_composition(
+            ehr_id,
+            vo_of(&v1).parse().expect("vo uuid"),
+            uv(composition("stale"), "251", Some(&v1)),
+        )
+        .await;
+    assert!(
+        conflict.is_err(),
+        "an update against a superseded version must fail: {conflict:?}"
+    );
+    assert_eq!(
+        committed(handle, "251"),
+        modifications + 1,
+        "a rolled-back update must not move the counter"
+    );
+
+    // (4) The direct delete route: one 523|deleted| version.
+    let latest: ObjectVersionId = v2.parse().expect("OBJECT_VERSION_ID");
+    svc.delete_composition(ehr_id, &latest)
+        .await
+        .expect("delete_composition");
+    assert_eq!(
+        committed(handle, "523"),
+        deletions + 1,
+        "delete_composition must count one 523|deleted| commit"
+    );
+    // The stale identity was only ever used for the negative case above.
+    assert_ne!(stale.value, latest.value);
+
+    // (5) The CONTRIBUTION route: its COMPOSITION versions are counted too, and
+    // its non-COMPOSITION versions (EHR_STATUS here) are not.
+    let contribution = json!({
+        "_type": "CONTRIBUTION",
+        "versions": [{
+            "_type": "ORIGINAL_VERSION",
+            "commit_audit": {
+                "change_type": change_type("249", "creation"),
+                "committer": committer("metrics tester")
+            },
+            "lifecycle_state": change_type("532", "complete"),
+            "data": composition("contributed")
+        }],
+        "audit": { "committer": committer("metrics tester") }
+    });
+    svc.create_ehr_contribution(ehr_id, contribution)
+        .await
+        .expect("create_ehr_contribution");
+    assert_eq!(
+        committed(handle, "249"),
+        creations + 2,
+        "a CONTRIBUTION-committed COMPOSITION must count one 249|creation| commit"
+    );
+
+    // The rendered exposition carries the counter with its catalog description,
+    // so the operational dashboards read a real series (not a dead metric).
+    let rendered = handle.render();
+    assert!(
+        rendered.contains("# TYPE compositions_committed_total counter"),
+        "the counter must render with its TYPE: {rendered}"
+    );
+    assert!(
+        rendered.contains("# HELP compositions_committed_total"),
+        "the counter must render with its catalog HELP text: {rendered}"
+    );
+}

--- a/website/book/src/operations.md
+++ b/website/book/src/operations.md
@@ -130,9 +130,10 @@ patient is possible only through the
   by route template, never by a path containing ids.
 - **Metrics** are exposed for Prometheus to scrape at `/management/prometheus`
   (OTLP metrics push is an option). The catalogue includes HTTP request
-  duration and active requests, authentication failures, database pool state,
-  AQL query counts and latency, compositions committed, validation failures,
-  and the audit pipeline's health.
+  duration and active requests, authentication failures and authorization
+  decisions, database pool state, AQL query counts and latency, compositions
+  committed (by openEHR audit change type), validation failures, and the audit
+  pipeline's health.
 
 The telemetry environment variables:
 


### PR DESCRIPTION
Closes #332

## What

Full metric-registry audit (table on the issue thread via the work report):

- **`compositions_committed_total`** — the only declared-but-never-incremented metric — is now wired via `versioning::change::meter_committed(&Committed)`, called at the four routes that land a COMPOSITION version, always **after** `tx.commit()` (success-only; a rolled-back commit can never count — pinned by a stale-`preceding_version_uid` test). Contribution commits count only their COMPOSITION versions. Label is the numeric openEHR `audit_change_type` code (`249`/`251`/`523`, per RM common master04 — codes are data, rubrics are display text), matching the existing Grafana panel expression. EHR-Extract import and dump restore are deliberately not metered (foreign-version replay would spike commit-rate panels) — recorded in the const doc.
- **The inverse defect, found by the same audit**: five metrics were emitted but never cataloged (no `# HELP`/`# TYPE`): `version_signature_invalid_total`, `atna_audit_rejected_total`, `atna_audit_reaped_total`, `authz_cedar_decisions_total`, `authz_remote_pdp_calls_total` — all registered; the two authz names moved into the shared vocabulary following the existing precedent.
- Stale internal-doc citations scrubbed from the touched file (the remainder is tracked on #330).

## Verification

- New integration test (`tests/telemetry_metrics.rs`, real PG18 via testkit, recorder installed through the real `prometheus::install`): create +1 on 249, update +1 on 251, stale-precondition update leaves 251 unchanged, delete +1 on 523, contribution-committed composition +1, HELP/TYPE present. Catalog snapshot updated deliberately (exactly the 5 additions).
- fmt clean; clippy 0 warnings (crate set + workspace `--all-features`); `cargo nextest run --workspace` 2362 passed / 6 skipped / 0 failed.
- The ops-panel commit tile (merged in #331) now reads a live series.

CHANGELOG: `### Fixed`.