### PR TITLE
fix(ci): spec-update watcher — skip the Superseded resolution

### DIFF
--- a/scripts/spec-update-watcher.sh
+++ b/scripts/spec-update-watcher.sh
@@ -207,10 +207,12 @@ while IFS= read -r issue; do
   # A rejected/duplicate resolution means NOTHING changed in the spec — no
   # triage material. Skip with a note (still deduped later if it ever flips).
   # "Rejected" was missing from this list, which is how SPECTERM-30
-  # (resolution: Rejected) got filed as tracker work (issue #175 / bug #340).
+  # (resolution: Rejected) got filed as tracker work (issue #175 / bug #340);
+  # "Superseded" likewise (SPECPR-124 → issue #347): the successor ticket is
+  # detected on its own resolution, the superseded one itself lands nothing.
   resolution=$(echo "$issue" | jq -r '.fields.resolution.name // "unresolved"')
   case "$resolution" in
-    "Rejected"|"Won't Do"|"Won't Fix"|"Duplicate"|"Cannot Reproduce"|"Declined"|"Abandoned"|"Not a Bug")
+    "Rejected"|"Superseded"|"Won't Do"|"Won't Fix"|"Duplicate"|"Cannot Reproduce"|"Declined"|"Abandoned"|"Not a Bug")
       echo "  $key: resolution '$resolution' — no spec change, skipped"
       continue ;;
   esac


### PR DESCRIPTION
Follow-up to #345 (same defect class as `Rejected`): the `Superseded` resolution was missing from the watcher's no-spec-change skip-list, which is how SPECPR-124 (Superseded 2026-07-25) got filed as #347. A superseded ticket itself lands nothing — its successor ticket is detected on its own resolution.

Verified in a live 7-day dry run: `SPECPR-124: resolution 'Superseded' — no spec change, skipped`, run exits 0. Script-only change (outside the changelog guard's path set).