### PR TITLE
fix(spec): adopt the 2-commit upstream RM delta — re-vendor at 66d3ac45

### DIFF
--- a/docs/VERSIONS.md
+++ b/docs/VERSIONS.md
@@ -73,7 +73,7 @@ pin accepts every valid older-minor instance.
 | Component | Our pin | Latest official release | Upstream WIP | Notes |
 |---|---|---|---|---|
 | BASE (Foundation + Base Types) | **1.3.0** (pre-release generation; text + BMM refreshed 2026-07-25 @ `e4879576` — SPECBASE-48 invariants, SPECAM-82 CODE_PHRASE move, SPECPR-426/386/460) | 1.2.0 (09-Apr-2021) | 1.3.0 | generated → `openehr-base` (foundation + base types; `openehr-foundation` folded in) |
-| RM (Reference Model) | **1.2.0** (development generation) | 1.1.0 (29-Sep-2020) | dev | generated → `openehr-rm` |
+| RM (Reference Model) | **1.2.0** (development generation; text + BMM refreshed 2026-07-26 @ `66d3ac45` — asterisk-entity normalization only, zero generated-output change) | 1.1.0 (29-Sep-2020) | dev | generated → `openehr-rm` |
 | AM (Archetype Model) | **1.4 + 2.4.0** (1.4 released; 2.4.0 WIP generation) | 2.3.0 (20-Mar-2024) | 2.4.0, **3.0.0** | generated → `openehr-am`, both majors side by side as `am14` (ADL 1.4) + `am24` (ADL 2) — the spec-mandated dual-generation case |
 | QUERY (AQL) | 1.1.0 (= the release) | 1.1.0 (14-May-2021) | 1.2.0 | `openehr-query`; grammar-driven (AqlLexer/Parser `.g4`), not BMM |
 | LANG (BMM / ODIN / EL) | master snapshot beyond 1.0.0 (development toward 1.1.0) | 1.0.0 (11-May-2020) | dev | `openehr-lang` — the ODIN + BMM reader that feeds codegen; the crate carries 1.0.0 as its spec version |

--- a/docs/specs/openehr/RM/PROVENANCE.md
+++ b/docs/specs/openehr/RM/PROVENANCE.md
@@ -2,7 +2,7 @@
 
 - Source: https://github.com/openEHR/specifications-RM
 - Ref: master (RM 1.2.0)
-- Commit: `c52de2b80503f3e8613dd4b7455b1b60336e9fac`
+- Commit: `66d3ac45587e4532a94d5fd27ca24bcf049f5bf3`
 - Vendored by: `scripts/vendor-spec-docs.sh` (text formats only: adoc md txt csv json yaml yml robot xml opt)
 - Images/UML/XSD/binaries excluded — fetch from the repo at the pinned commit.
 

--- a/docs/specs/openehr/RM/computable/BMM/openehr_rm_1.2.0.bmm.json
+++ b/docs/specs/openehr/RM/computable/BMM/openehr_rm_1.2.0.bmm.json
@@ -3528,7 +3528,7 @@
                 "multiply": {
                     "name": "multiply",
                     "aliases": [
-                        "&#42;"
+                        "*"
                     ],
                     "documentation": "Product of this Proportion and `_factor_`.",
                     "parameters": {
@@ -3737,7 +3737,7 @@
                 "multiply": {
                     "name": "multiply",
                     "aliases": [
-                        "&#42;"
+                        "*"
                     ],
                     "documentation": "Product of this Amount and `_factor_`.",
                     "parameters": {
@@ -3903,7 +3903,7 @@
                 "multiply": {
                     "name": "multiply",
                     "aliases": [
-                        "&#42;"
+                        "*"
                     ],
                     "documentation": "Product of this `DV_QUANTITY` and `_factor_`.",
                     "parameters": {
@@ -4051,7 +4051,7 @@
                 "multiply": {
                     "name": "multiply",
                     "aliases": [
-                        "&#42;"
+                        "*"
                     ],
                     "documentation": "Product of this `DV_COUNT` and `_factor_`.",
                     "parameters": {
@@ -4356,7 +4356,7 @@
                 "multiply": {
                     "name": "multiply",
                     "aliases": [
-                        "&#42;"
+                        "*"
                     ],
                     "documentation": "Product of this Duration and `_factor_`.",
                     "parameters": {

--- a/docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.composition.activity.adoc
+++ b/docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.composition.activity.adoc
@@ -28,7 +28,7 @@ h|*1..1*
 |*action_archetype_id*: `link:/releases/BASE/{base_release}/foundation_types.html#_string_class[String^]`
 a|Perl-compliant regular expression pattern, enclosed in  '//' delimiters, indicating the valid identifiers of archetypes for Actions corresponding to this Activity specification. 
 
-Defaults to  `/.&#42;/`, meaning any archetype.
+Defaults to  `/.*/`, meaning any archetype.
 
 h|*1..1*
 |*description*: `link:/releases/RM/{rm_release}/data_structures.html#_item_structure_class[ITEM_STRUCTURE^]`

--- a/docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.data_types.dv_amount.adoc
+++ b/docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.data_types.dv_amount.adoc
@@ -70,7 +70,7 @@ other: `<<_dv_amount_class,DV_AMOUNT>>[1]` +
 a|Return True if this `DV_AMOUNT` is considered equal to `_other_`.
 
 h|*1..1*
-|*multiply* __alias__ "&#42;" ( +
+|*multiply* __alias__ "*" ( +
 factor: `link:/releases/BASE/{base_release}/foundation_types.html#_real_class[Real^][1]` +
 ): `<<_dv_amount_class,DV_AMOUNT>>`
 a|Product of this Amount and `_factor_`.

--- a/docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.data_types.dv_count.adoc
+++ b/docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.data_types.dv_count.adoc
@@ -51,7 +51,7 @@ a|Difference of this `DV_COUNT` and `_other_`.
 
 h|*1..1 +
 (redefined)*
-|*multiply* __alias__ "&#42;" ( +
+|*multiply* __alias__ "*" ( +
 factor: `link:/releases/BASE/{base_release}/foundation_types.html#_real_class[Real^][1]` +
 ): `<<_dv_count_class,DV_COUNT>>`
 a|Product of this `DV_COUNT` and `_factor_`.

--- a/docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.data_types.dv_duration.adoc
+++ b/docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.data_types.dv_duration.adoc
@@ -46,7 +46,7 @@ a|Difference of this Duration and `_other_`.
 
 h|*1..1 +
 (redefined)*
-|*multiply* __alias__ "&#42;" ( +
+|*multiply* __alias__ "*" ( +
 factor: `link:/releases/BASE/{base_release}/foundation_types.html#_real_class[Real^][1]` +
 ): `<<_dv_duration_class,DV_DURATION>>`
 a|Product of this Duration and `_factor_`.

--- a/docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.data_types.dv_proportion.adoc
+++ b/docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.data_types.dv_proportion.adoc
@@ -81,7 +81,7 @@ a|Return True if this `DV_AMOUNT` is considered equal to `_other_`.
 
 h|*1..1 +
 (redefined)*
-|*multiply* __alias__ "&#42;" ( +
+|*multiply* __alias__ "*" ( +
 factor: `link:/releases/BASE/{base_release}/foundation_types.html#_real_class[Real^][1]` +
 ): `<<_dv_proportion_class,DV_PROPORTION>>`
 a|Product of this Proportion and `_factor_`.

--- a/docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.data_types.dv_quantity.adoc
+++ b/docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.data_types.dv_quantity.adoc
@@ -80,7 +80,7 @@ a|Difference of this `DV_QUANTITY` and `_other_`.
 
 h|*1..1 +
 (redefined)*
-|*multiply* __alias__ "&#42;" ( +
+|*multiply* __alias__ "*" ( +
 factor: `link:/releases/BASE/{base_release}/foundation_types.html#_real_class[Real^][1]` +
 ): `<<_dv_quantity_class,DV_QUANTITY>>`
 a|Product of this `DV_QUANTITY` and `_factor_`.

--- a/scripts/vendor-spec-docs.sh
+++ b/scripts/vendor-spec-docs.sh
@@ -24,7 +24,7 @@ INCLUDE_EXT=(adoc md txt csv json yaml yml robot xml opt)
 # already vendored for codegen.
 COMPONENTS=(
   "BASE|specifications-BASE|master (BASE 1.3.0)|e48795762a0648cbe5701be58d42ec5df0c701a7"
-  "RM|specifications-RM|master (RM 1.2.0)|c52de2b80503f3e8613dd4b7455b1b60336e9fac"
+  "RM|specifications-RM|master (RM 1.2.0)|66d3ac45587e4532a94d5fd27ca24bcf049f5bf3"
   "AM|specifications-AM|master (AM 2.4.0 + ADL/AOM/OPT 1.4)|da06d63297e8549a351c854d8b1c45cd9f1d577c"
   "TERM|specifications-TERM|master (TERM 3.1.0)|007d0dddcdd77648711681878b54ace021b2fbd5"
   "LANG|specifications-LANG|master (LANG 1.1.0)|201b647034f7b1ddfe207e4c3c6f52f6878869b8"

--- a/tools/openehr-codegen/vendor/bmm/components/RM/json/openehr_rm_1.2.0.bmm.json
+++ b/tools/openehr-codegen/vendor/bmm/components/RM/json/openehr_rm_1.2.0.bmm.json
@@ -3528,7 +3528,7 @@
                 "multiply": {
                     "name": "multiply",
                     "aliases": [
-                        "&#42;"
+                        "*"
                     ],
                     "documentation": "Product of this Proportion and `_factor_`.",
                     "parameters": {
@@ -3737,7 +3737,7 @@
                 "multiply": {
                     "name": "multiply",
                     "aliases": [
-                        "&#42;"
+                        "*"
                     ],
                     "documentation": "Product of this Amount and `_factor_`.",
                     "parameters": {
@@ -3903,7 +3903,7 @@
                 "multiply": {
                     "name": "multiply",
                     "aliases": [
-                        "&#42;"
+                        "*"
                     ],
                     "documentation": "Product of this `DV_QUANTITY` and `_factor_`.",
                     "parameters": {
@@ -4051,7 +4051,7 @@
                 "multiply": {
                     "name": "multiply",
                     "aliases": [
-                        "&#42;"
+                        "*"
                     ],
                     "documentation": "Product of this `DV_COUNT` and `_factor_`.",
                     "parameters": {
@@ -4356,7 +4356,7 @@
                 "multiply": {
                     "name": "multiply",
                     "aliases": [
-                        "&#42;"
+                        "*"
                     ],
                     "documentation": "Product of this Duration and `_factor_`.",
                     "parameters": {


### PR DESCRIPTION
Closes #346

The RM delta (`c52de2b8..66d3ac45`, found by the watcher's new commits-ahead signal from #340) is one content change: `&#42;` → `*` normalization in the RM BMM aliases + five class-table adocs (upstream PR #33) — the same normalization BASE received in #341/#343.

- Triaged first-hand: the emitter already decodes HTML entities, so the expected generated diff was zero.
- Verified: `scripts/check-codegen-drift.sh` is **green with the new BMM** — regeneration is byte-identical, no generated file changes.
- Adopted: `scripts/vendor-spec-docs.sh` RM pin → `66d3ac45`, spec text re-vendored (RM only), RM BMM json updated in the codegen vendor, `docs/VERSIONS.md` row annotated.
- Wire-invisible (nothing under `openehr-its`, no generated change at all) → no CNF run required, no changelog entry (outside the guard's path set and genuinely invisible).