### PR TITLE
docs(book): enterprise identity providers — IdP-delegated ruling + AD FS/Entra walkthroughs (#316)

### DIFF
--- a/website/book/src/SUMMARY.md
+++ b/website/book/src/SUMMARY.md
@@ -25,6 +25,7 @@
   - [FHIR connectors](beyond-core/fhir.md)
   - [S3 multimedia](beyond-core/s3-multimedia.md)
 - [Security & multi-tenancy](security.md)
+  - [Enterprise identity providers](identity-providers.md)
   - [SMART App Launch](smart-app-launch.md)
   - [Audit trail (IHE ATNA)](audit.md)
 - [Admin console](admin-ui/index.md)

--- a/website/book/src/identity-providers.md
+++ b/website/book/src/identity-providers.md
@@ -1,0 +1,125 @@
+# Enterprise identity providers
+
+EHRbase-rs does not manage users. There is no user table, no user API, and no
+plan to add one: **identity administration is delegated to your identity
+provider (IdP)**, and the CDR consumes standard OIDC bearer tokens. This page
+records that posture and walks through connecting the two enterprise IdPs we
+are asked about most — **Microsoft Entra ID** (Azure AD) and **AD FS** — plus
+the answer for plain-LDAP directories.
+
+<!-- toc -->
+
+## The posture: users live in the IdP
+
+A clinical data repository is the wrong place to store credentials. A user
+store would make the CDR an authentication product — password lifecycle,
+lockout policy, MFA, recovery flows, and the largest new attack surface the
+product could grow — duplicating what a dedicated IdP already does under your
+existing governance. So the split is deliberate and permanent:
+
+- **The IdP owns identities**: accounts, passwords, MFA, group/role
+  membership, lifecycle (joiners/movers/leavers), and session policy.
+- **The CDR owns authorization**: it validates the token, mines roles from
+  its claims, and enforces [RBAC/ABAC and per-EHR access
+  control](security.md#authorization) on every request.
+
+The HTTP Basic user list in `ehrbase.toml` is a bootstrap/dev convenience,
+not a user store — production deployments authenticate with OIDC bearer
+tokens.
+
+> [!NOTE]
+> The admin console follows the same rule: it signs in against the same IdP
+> and has no user-management screens. To create, disable, or re-role a user,
+> use your IdP's own administration surface.
+
+## How the CDR consumes an IdP
+
+Two configuration groups do all the work:
+
+1. **Token validation** (`[auth.oidc]`): the server discovers the JWKS from
+   the issuer's `.well-known/openid-configuration` and validates each
+   bearer token's signature, `iss`, and (when configured) `aud` — see the
+   [OIDC settings table](security.md#authentication).
+2. **Role mining** (`[authz.rbac]`): `EHRBASE__AUTHZ__RBAC__ROLE_CLAIMS`
+   (default `["realm_access.roles","scope"]` — the Keycloak shape) names the
+   JWT claim paths whose values become the caller's roles for the
+   [role layer](security.md#authorization).
+
+Everything below is just those two groups pointed at a different issuer.
+
+## Microsoft Entra ID (Azure AD)
+
+Entra ID exposes a standards-compliant OIDC issuer per tenant.
+
+1. **Register an application** (Entra admin center → App registrations).
+   Note the *Directory (tenant) ID* and the *Application (client) ID*.
+2. **Define app roles** (App registration → App roles): create roles named
+   after the CDR roles you use (for example `USER`, `CLINICAL`, `ADMIN`) and
+   assign users/groups to them (Enterprise applications → your app → Users
+   and groups). Entra puts assigned app roles in the token's `roles` claim.
+3. **Expose an audience**: either use the client ID as the audience or add an
+   *Application ID URI* (for example `api://ehrbase`).
+4. **Point the CDR at the tenant issuer** and mine the `roles` claim:
+
+   ```bash
+   export EHRBASE__AUTH__OIDC__ISSUER=https://login.microsoftonline.com/<tenant-id>/v2.0
+   export EHRBASE__AUTH__OIDC__AUDIENCES=api://ehrbase
+   export EHRBASE__AUTHZ__RBAC__ROLE_CLAIMS='["roles"]'
+   ```
+
+5. **Verify**: request a token for the app (any OAuth2 client credential or
+   auth-code flow) and call the API. A valid token without a required role
+   must get `403`; no token, `401`.
+
+> [!TIP]
+> Group-based deployments can emit the `groups` claim instead and list it in
+> `ROLE_CLAIMS` — but group claims arrive as object IDs unless you configure
+> group names, so app roles usually read better in policy.
+
+## AD FS (on-premises Active Directory)
+
+AD FS 2016+ speaks OIDC. This is also the supported path for on-premises
+Active Directory in general: front AD with AD FS (or another OIDC-capable
+broker) rather than pointing anything at LDAP.
+
+1. **Create an Application Group** (AD FS Management → Application Groups →
+   *Web API* template, or *Server application + Web API* for interactive
+   clients). The Web API's *identifier* becomes the token audience.
+2. **Issue role claims**: on the Web API's *Issuance Transform Rules*, add a
+   rule mapping AD group membership to the `role` claim (template: *Send
+   Group Membership as a Claim*), one rule per CDR role.
+3. **Point the CDR at the AD FS issuer** and mine the `role` claim:
+
+   ```bash
+   export EHRBASE__AUTH__OIDC__ISSUER=https://adfs.example.com/adfs
+   export EHRBASE__AUTH__OIDC__AUDIENCES=ehrbase-api
+   export EHRBASE__AUTHZ__RBAC__ROLE_CLAIMS='["role"]'
+   ```
+
+   Discovery works out of the box (`https://adfs.example.com/adfs/.well-known/openid-configuration`).
+4. **Verify** exactly as above: `401` without a token, `403` with a token
+   that lacks the required role.
+
+> [!NOTE]
+> AD FS emits a single string for one role and an array for several; the
+> role-mining layer accepts both shapes on any configured claim path.
+
+## "We only have LDAP"
+
+The CDR does not speak LDAP, by design — LDAP bind would put password
+handling back inside the CDR. Front the directory with an OIDC-capable
+broker and connect that instead:
+
+- **Active Directory** → AD FS (above) or Entra ID (if synced).
+- **Generic LDAP** → Keycloak with LDAP user federation (the
+  [Keycloak example](security.md#authentication) then applies verbatim), or
+  any other OIDC provider that can federate LDAP.
+
+The broker owns the LDAP bind; the CDR sees only signed tokens.
+
+## Multi-tenant deployments
+
+Tenancy is also credential-derived: the tenant is read from a JWT claim per
+request (see [multi-tenancy](security.md#multi-tenancy)), so a multi-tenant
+IdP setup simply issues the tenant claim alongside the roles. No client —
+including the admin console — chooses a tenant; the credential does.

--- a/website/book/src/security.md
+++ b/website/book/src/security.md
@@ -69,8 +69,11 @@ a static `JWKS_JSON` (preferred when present) or an `HMAC_SECRET`.
 > ```
 >
 > The same pattern works for Active Directory or any standards-compliant
-> identity provider. Prefer JWKS/discovery over a shared HS256 secret in
-> production.
+> identity provider — walkthroughs for Entra ID and AD FS (and the answer for
+> plain-LDAP directories) are in
+> [Enterprise identity providers](identity-providers.md). Prefer
+> JWKS/discovery over a shared HS256 secret in production. User accounts,
+> roles, and lifecycle are administered in the IdP — the CDR has no user API.
 
 An unauthenticated request to a protected route is refused with `401`; an
 authenticated request that lacks the required role is refused with `403`.


### PR DESCRIPTION
Closes #316

Docs-only, per the rescoped contract:

- New book page **Enterprise identity providers** recording the ruling (the CDR has no user/role/identity API and is not getting one — identity administration is IdP-delegated; the Basic list is bootstrap/dev only, and the console has no user-management screens by the same rule).
- **Entra ID walkthrough**: app registration, app roles → `roles` claim, audience, `EHRBASE__AUTH__OIDC__ISSUER`/`AUDIENCES` + `EHRBASE__AUTHZ__RBAC__ROLE_CLAIMS='["roles"]'`, verify 401/403.
- **AD FS walkthrough**: application group, group-membership → `role` claim issuance rules, issuer/audience + `ROLE_CLAIMS='["role"]'`, discovery out of the box.
- **The LDAP answer**: the CDR never binds LDAP; front the directory with an OIDC-capable broker (AD FS, Entra, or Keycloak LDAP federation — the existing Keycloak example then applies verbatim).
- Credential-derived tenancy corollary noted; SUMMARY + security-chapter cross-links added.

Every environment variable, default, and behaviour claim verified against the config code and the existing security chapter (`ROLE_CLAIMS` default `["realm_access.roles","scope"]`, discovery-based JWKS, 401/403 split). No wire, config, or code change → `no-changelog`.