### PR TITLE
refactor(rest): SMART scope grammar moves to openehr-its (one parser, #299 phase 1)

### DIFF
--- a/app/ehrbase-rest/src/extensions/access/pep.rs
+++ b/app/ehrbase-rest/src/extensions/access/pep.rs
@@ -63,10 +63,10 @@ use crate::extensions::access::authz::AbacGate;
 use crate::overview::error::RestError;
 
 use crate::smart::enforce::{self, GateConfig, ScopeDecision};
-use crate::smart::scope::SmartScope;
 use crate::state::AppState;
 use crate::{negotiate, params};
 use ehrbase::config::smart::SmartConfig;
+use openehr_its::rest::smart_scopes::SmartScope;
 
 /// Whether an operation is ABAC-checked, and when.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/app/ehrbase-rest/src/smart/enforce.rs
+++ b/app/ehrbase-rest/src/smart/enforce.rs
@@ -25,7 +25,7 @@
 
 use crate::extensions::access::authz::request::{AccessMode, ResourceKind};
 
-use super::scope::{Compartment, Permission, ResourceFamily, SmartScope};
+use openehr_its::rest::smart_scopes::{Compartment, Permission, ResourceFamily, SmartScope};
 
 /// Configuration the gate needs (a slice of [`super::config::SmartConfig`]).
 #[derive(Debug, Clone, Copy)]
@@ -246,7 +246,7 @@ pub fn launch_context_ehr_id(
 /// scope, `smart.md` §1); the CDR only observes the marker.
 #[must_use]
 pub fn requests_patient_context(scopes: &[SmartScope]) -> bool {
-    use super::scope::LaunchContext;
+    use openehr_its::rest::smart_scopes::LaunchContext;
     scopes
         .iter()
         .any(|s| matches!(s, SmartScope::LaunchContext(LaunchContext::Patient)))

--- a/app/ehrbase-rest/src/smart/mod.rs
+++ b/app/ehrbase-rest/src/smart/mod.rs
@@ -23,4 +23,5 @@
 
 pub mod discovery;
 pub mod enforce;
-pub mod scope;
+// The scope grammar itself lives in `openehr_its::rest::smart_scopes` (one
+// grammar for the gate here and for REST clients previewing grants).

--- a/crates/openehr-its/CLAUDE.md
+++ b/crates/openehr-its/CLAUDE.md
@@ -10,6 +10,7 @@ Know which half you are touching before editing anything:
 | `src/rest/generated/` (ITS-REST DTOs, server traits, routes) | **GENERATED** (`emit-rest`, from the vendored OAS) | edit the emitter, regenerate |
 | `xml/runtime.rs`, `json_codec/runtime.rs`, `rest/runtime.rs`, `json` + `rm_validate` entry points, validation, fidelity gates | hand-written | edit normally, with spec citations |
 | `src/flat/` — Simplified Formats (FLAT / STRUCTURED / Web Template / TDD) | hand-written (BMM has no simplified-format model) | edit normally, with spec citations |
+| `src/rest/smart_scopes.rs` — the SMART on openEHR scope grammar (master08 resource scopes + master07/09 launch contexts) | hand-written (an ITS-REST sub-spec with no machine-readable model) | edit normally, with spec citations — the ONE grammar the CDR's scope gate AND scope-previewing REST clients (the admin console) parse with |
 
 The native canonical-JSON codec (`json_codec`) is THE canonical-JSON
 (de)serialization for every spec type (all five crates) — the emitted

--- a/crates/openehr-its/src/rest/mod.rs
+++ b/crates/openehr-its/src/rest/mod.rs
@@ -12,5 +12,6 @@
 
 pub mod generated;
 pub mod runtime;
+pub mod smart_scopes;
 
 pub use runtime::ApiError;

--- a/crates/openehr-its/src/rest/smart_scopes.rs
+++ b/crates/openehr-its/src/rest/smart_scopes.rs
@@ -3,6 +3,12 @@
 //! plus the launch-context scopes of master07 §Context Selection and master09
 //! §Experimental: Episode Context.
 //!
+//! Hand-written (like [`crate::flat`], SMART App Launch is an ITS-REST
+//! sub-specification with no machine-readable model): ONE grammar, consumed by
+//! the CDR's scope gate (`ehrbase-rest::smart`) and by any REST client that
+//! previews what a scope string grants (the admin console) — the two can never
+//! drift because they parse with the same code.
+//!
 //! A **total** parser: [`SmartScope::parse`] maps every scope string the token's
 //! `scope` claim carries onto a typed value; anything the grammar does not
 //! recognise becomes [`SmartScope::Other`] and is retained but inert


### PR DESCRIPTION
Part of #299 (the design-ruling half; the console previewer + session-drawer UI follows separately).

## What

The master08 resource-scope + master07/09 launch-context grammar moves **verbatim** (98% rename similarity) from `ehrbase-rest::smart::scope` to `openehr_its::rest::smart_scopes`, tests included.

**Why there:** SMART App Launch is an ITS-REST sub-specification with no machine-readable model — the same reason the Simplified Formats live as the hand-written `flat` module of `openehr-its`. The dependency arrows (`app/* → crates/openehr-*`, console → `crates/openehr-*` only) then let the CDR's scope gate and any REST client that previews what a scope string grants (the admin console) parse with the **same code** — the ruling recorded on #299: one shared grammar module, no new CDR endpoint, no drifting copies.

No behaviour change: consumers (`smart::enforce`, `access::pep`) import from the defining module (zero re-exports); the grammar's 17 unit tests pass in their new home; both crates' full suites green (`ehrbase-rest` 420, `openehr-its` 444). Crate CLAUDE.md updated. Wire-invisible → `no-changelog`.