### PR TITLE
release: v3.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+## [3.11.0] - 2026-07-26
+
 ### Added
 
 - **Admin console: EHR_STATUS editing and a status version history** (#306). The
@@ -2079,7 +2081,8 @@ but has not yet run in production.
   seccomp, default-deny NetworkPolicy) and golden-render validation.
 
 
-[unreleased]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.10.0...HEAD
+[unreleased]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.11.0...HEAD
+[3.11.0]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.10.0...v3.11.0
 [3.10.0]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.9.0...v3.10.0
 [3.9.0]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.8.0...v3.9.0
 [3.8.0]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.7.0...v3.8.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,5 +33,5 @@ keywords:
   - ITS-REST
   - Rust
   - PostgreSQL
-version: 3.10.0
-date-released: "2026-07-25"
+version: 3.11.0
+date-released: "2026-07-26"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "cnf-runner"
-version = "3.10.0"
+version = "3.11.0"
 dependencies = [
  "assert_fs",
  "base64 0.22.1",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase"
-version = "3.10.0"
+version = "3.11.0"
 dependencies = [
  "assert_fs",
  "async-trait",
@@ -2366,7 +2366,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase-admin-ui"
-version = "3.10.0"
+version = "3.11.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2406,7 +2406,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase-rest"
-version = "3.10.0"
+version = "3.11.0"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -2458,7 +2458,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase-server"
-version = "3.10.0"
+version = "3.11.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -5227,7 +5227,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-codegen"
-version = "3.10.0"
+version = "3.11.0"
 dependencies = [
  "roxmltree",
  "serde_json",
@@ -8268,7 +8268,7 @@ dependencies = [
 
 [[package]]
 name = "testkit"
-version = "3.10.0"
+version = "3.11.0"
 dependencies = [
  "ehrbase",
  "sqlx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "3"                      # resolver v3 (edition 2024)
 members = ["crates/*", "app/*", "tools/*"]
 
 [workspace.package]
-version = "3.10.0"
+version = "3.11.0"
 edition = "2024"
 rust-version = "1.96"
 license = "Apache-2.0"

--- a/deploy/helm/ehrbase-rs/Chart.yaml
+++ b/deploy/helm/ehrbase-rs/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 # Chart versioning is independent of the application version.
 version: 3.2.0
 # The default container image tag (informational; overridable via image.tag).
-appVersion: "3.10.0"
+appVersion: "3.11.0"
 
 # PDB (policy/v1, GA 1.21), HPA (autoscaling/v2, GA 1.23), and the
 # seccompProfile pod field (GA 1.27) all resolve cleanly at 1.25+.

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.10.0"
+    app.kubernetes.io/version: "3.11.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -58,7 +58,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.10.0"
+    app.kubernetes.io/version: "3.11.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -77,7 +77,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.10.0"
+    app.kubernetes.io/version: "3.11.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
   annotations:
@@ -96,7 +96,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.10.0"
+    app.kubernetes.io/version: "3.11.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 type: Opaque
@@ -120,7 +120,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.10.0"
+    app.kubernetes.io/version: "3.11.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 type: Opaque
@@ -139,7 +139,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.10.0"
+    app.kubernetes.io/version: "3.11.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 data:
@@ -294,7 +294,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.10.0"
+    app.kubernetes.io/version: "3.11.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -321,7 +321,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.10.0"
+    app.kubernetes.io/version: "3.11.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -333,7 +333,7 @@ spec:
     metadata:
       annotations:
         # Roll pods when the rendered ehrbase.toml changes.
-        checksum/config: 42de50ea4906d9ea2f7833cc6ad5381c8be73deb84fa3a929012a6410904c7f4
+        checksum/config: a1a1b9b4d09b00822f9d80d8d0ad97878d7b3cda0970e09ef01781d8fe292690
         prometheus.io/scrape: "true"
         prometheus.io/port: "9100"
         prometheus.io/path: "/management/prometheus"
@@ -354,7 +354,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ehrbase
-          image: "ghcr.io/rubentalstra/ehrbase-rs:3.10.0"
+          image: "ghcr.io/rubentalstra/ehrbase-rs:3.11.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -476,7 +476,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.10.0"
+    app.kubernetes.io/version: "3.11.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -509,7 +509,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.10.0"
+    app.kubernetes.io/version: "3.11.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.10.0"
+    app.kubernetes.io/version: "3.11.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -36,7 +36,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.10.0"
+    app.kubernetes.io/version: "3.11.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -55,7 +55,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.10.0"
+    app.kubernetes.io/version: "3.11.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 automountServiceAccountToken: false
@@ -69,7 +69,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.10.0"
+    app.kubernetes.io/version: "3.11.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 data:
@@ -166,7 +166,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.10.0"
+    app.kubernetes.io/version: "3.11.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -189,7 +189,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.10.0"
+    app.kubernetes.io/version: "3.11.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -202,7 +202,7 @@ spec:
     metadata:
       annotations:
         # Roll pods when the rendered ehrbase.toml changes.
-        checksum/config: 73dd2ca8b366b0ef22f3be1a7ee655222e51ed643dfba1507a61958222d7e59c
+        checksum/config: ae75ce422a6fdb1c975e2906dcd16b56b1a46d0cc61bf776ecbae0faf9135528
       labels:
         app.kubernetes.io/name: ehrbase-rs
         app.kubernetes.io/instance: ehrbase-rs
@@ -220,7 +220,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ehrbase
-          image: "ghcr.io/rubentalstra/ehrbase-rs:3.10.0"
+          image: "ghcr.io/rubentalstra/ehrbase-rs:3.11.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
The v3.11.0 release cut (the milestone reached zero open issues; procedure per `.claude/rules/changelog.md`):

- `[Unreleased]` → `## [3.11.0] - 2026-07-26` + fresh empty Unreleased + link references
- Workspace `version` 3.10.0 → 3.11.0 (+ `Cargo.lock` via `cargo check`)
- Helm `appVersion` + regenerated goldens (`deploy/helm/validate.sh --update`, all checks passed)
- `CITATION.cff` version + date-released (citation-guard)

Highlights of the section: the whole console Wave-0/1 program (document viewer, pagination kit, multi-series charting, stored-query runner + reverse-lift, EHR_STATUS editing + history, endpoint completions, scope previewer, a11y batch), the five wire-conformance fixes from the console-wire spec review (named query parameters, ITEM_TAG identity/targets/shape, misc-namespace normalization, full version_uid identity + case rule, versioned-read headers), the BASE/RM spec re-pins, the watcher hardening (Rejected/Superseded skips + the commits-ahead signal), and the change_type rubric.

Tag `v3.11.0` goes on the merge commit; the milestone closes after (v3.12.0/v3.13.0 already exist). Release stays `prerelease: true` pending production sign-off.

`no-changelog` (the changelog change IS the release cut; the guard's path filter would otherwise demand an Unreleased entry for Cargo.toml).