### PR TITLE
fix(demographic): Location only on writes; If-Match accepts the weak form and compares case-insensitively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,32 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Demographic API: response-header discipline and `If-Match` handling** (#394).
+  Three MUST/SHOULD-level divergences from the ITS-REST overview
+  (`Requests_and_responses.md`) are corrected on the `/demographic` surface:
+  - `Location` is no longer emitted on reads, deletes, or `409`/`412` error
+    responses. The header now rides create/update writes only, per §Location
+    ("MUST NOT be used to indicate an alternate representation of an existing
+    resource"; "MUST ONLY be used for resource creation … or redirect
+    responses") and §"Deprecated headers", which deprecates it on `GET` and
+    `DELETE`. Those responses keep the weak `ETag` (and `Last-Modified` where
+    known), so a client reading the version identity is unaffected; a client
+    that was following the `Location` of a `GET`/`DELETE` must use the request
+    URL it already has.
+  - `If-Match` now accepts the **weak** `W/"…"` form the server itself emits as
+    the `ETag`, alongside the bare-quoted and unquoted forms — previously
+    echoing the server's own `ETag` back was rejected as a malformed
+    precondition (`400`). The full `OBJECT_VERSION_ID` is compared
+    case-insensitively (BASE composite-identifier semantics), so a case-variant
+    `creating_system_id` no longer raises a spurious `412`. A syntactically
+    invalid `If-Match` remains a `400` and is never silently ignored.
+  - The `versioned_party` / `versioned_party_relationship` reads (the container,
+    its revision history, and the version reads) now carry the weak `ETag` and,
+    where the served body exposes the commit instant, `Last-Modified` — both
+    SHOULD-present on `VERSION`/`VERSIONED_OBJECT` responses.
+
 ## [3.11.0] - 2026-07-26
 
 ### Added

--- a/app/ehrbase-rest/src/api/demographic/contribution.rs
+++ b/app/ehrbase-rest/src/api/demographic/contribution.rs
@@ -59,7 +59,8 @@ pub(super) async fn run(
 }
 
 /// A create response for a JSON-only payload (CONTRIBUTION), honouring `Prefer`
-/// and setting the demographic `ETag`/`Location`.
+/// and setting the demographic `ETag` + the creation `Location` (overview
+/// §Location — `201 Created` is exactly the case it scopes the header to).
 fn write_shared(
     h: &http::HeaderMap,
     base: &str,
@@ -73,6 +74,6 @@ fn write_shared(
     } else {
         negotiate::empty(minimal_status)
     };
-    super::set_headers(&mut out, base, segment, resp.meta.as_ref());
+    super::set_write_headers(&mut out, base, segment, resp.meta.as_ref());
     out
 }

--- a/app/ehrbase-rest/src/api/demographic/mod.rs
+++ b/app/ehrbase-rest/src/api/demographic/mod.rs
@@ -81,40 +81,134 @@ fn is_precondition(e: &SmError) -> bool {
     e.status == CallStatusType::VersionMismatch
 }
 
-/// The `If-Match` header value (an `OBJECT_VERSION_ID`), if present and
-/// well-formed.
+/// Normalize an `If-Match` wire value to the bare `OBJECT_VERSION_ID` the
+/// service seam compares.
+///
+/// The overview §"`ETag` and Last-Modified" makes every resource-identifier
+/// `ETag` weak-type (`W/"…"`), and §"Deprecated headers" keeps the pre-1.1.0
+/// bare quoted form supported ("implementations MAY still support it") — so a
+/// client echoing either shape of the `ETag` this server emitted names the same
+/// version. [`crate::overview::version_id::strip_etag`] is the one place this
+/// server decodes that syntax; the demographic seam now goes through it instead
+/// of stripping quotes only (which turned the server's OWN weak `ETag` into a
+/// malformed precondition).
+fn if_match_token(raw: &str) -> String {
+    crate::overview::version_id::strip_etag(raw).to_owned()
+}
+
+/// The `If-Match` request header normalized by [`if_match_token`], or `None`
+/// when the header is absent (or not valid header text). A present-but-empty
+/// value yields `Some("")`, which the service rejects as a malformed
+/// precondition — never silently as "no precondition" (overview §"If-Match and
+/// accidental overwrites": a received `If-Match` MUST be honoured).
 fn if_match_of(h: &HeaderMap) -> Option<String> {
     h.get("if-match")
         .and_then(|v| v.to_str().ok())
-        .map(str::to_owned)
+        .map(if_match_token)
 }
 
-/// Set `ETag` (the resource uid, weak form `W/"…"` — the ITS-REST overview
-/// §"`ETag` and Last-Modified" makes resource-identifier `ETag`s weak-type; the
-/// bare quoted form is deprecated) and a `/demographic/{segment}/{uid}`
-/// `Location` from a demographic [`ResourceMeta`] (whose `ehr_id` is empty —
-/// parties are not EHR-scoped). Location shape: `headers/Location_PERSON.yaml`.
-fn set_headers(resp: &mut Response, base: &str, segment: &str, meta: Option<&ResourceMeta>) {
+/// Set the versioning response headers from a demographic [`ResourceMeta`]
+/// (whose `ehr_id` is empty — parties are not EHR-scoped): the weak `ETag`
+/// (`W/"{uid}"` — the ITS-REST overview §"`ETag` and Last-Modified" makes
+/// resource-identifier `ETag`s weak-type; the bare quoted form is deprecated)
+/// and, when the metadata carries a commit time, `Last-Modified` (same section:
+/// "derived from `VERSION.commit_audit.time_committed.value`"; both SHOULD
+/// accompany `VERSION`/`VERSIONED_OBJECT` responses). Also stamps the ATNA
+/// audit object.
+///
+/// **No `Location`** — overview §Location: it "MUST NOT be used to indicate an
+/// alternate representation of an existing resource (e.g. via `GET` method)"
+/// and "MUST ONLY be used for resource creation (e.g., `201 Created`) or
+/// redirect responses"; §"Deprecated headers" deprecates it on `GET` and
+/// `DELETE` responses alike. Writes add it through [`set_write_headers`].
+fn set_versioning_headers(resp: &mut Response, meta: Option<&ResourceMeta>) {
     let Some(meta) = meta else { return };
     if let Ok(etag) = HeaderValue::from_str(&format!("W/\"{}\"", meta.uid)) {
         resp.headers_mut().insert(header::ETAG, etag);
     }
-    // `Last-Modified` from the version's commit time — overview §"ETag and
-    // Last-Modified": both SHOULD accompany versioned resources.
     if let Some(at) = meta.last_modified
         && let Ok(lm) = HeaderValue::from_str(&crate::overview::negotiate::http_date(at))
     {
         resp.headers_mut().insert(header::LAST_MODIFIED, lm);
-    }
-    let location = format!("{base}/demographic/{segment}/{}", meta.uid);
-    if let Ok(loc) = HeaderValue::from_str(&location) {
-        resp.headers_mut().insert(header::LOCATION, loc);
     }
     resp.extensions_mut()
         .insert(crate::system_log::middleware::AuditObject {
             ehr_id: None,
             uid: Some(meta.uid.clone()),
         });
+}
+
+/// The write-response headers: the versioning headers plus the
+/// `/demographic/{segment}/{uid}` `Location` of the version this request
+/// created.
+///
+/// `Location` rides ONLY the create/update writes: overview §Location scopes
+/// the header to "resource creation … or redirect responses", and §"Prefer
+/// minimal, identifier or full representation response" names the target as
+/// "the newly created or updated resource" — an openEHR update commits a new
+/// VERSION, which IS a newly created resource at the emitted URL. Reads,
+/// deletes, and error responses use [`set_versioning_headers`] instead.
+fn set_write_headers(resp: &mut Response, base: &str, segment: &str, meta: Option<&ResourceMeta>) {
+    set_versioning_headers(resp, meta);
+    let Some(meta) = meta else { return };
+    let location = format!("{base}/demographic/{segment}/{}", meta.uid);
+    if let Ok(loc) = HeaderValue::from_str(&location) {
+        resp.headers_mut().insert(header::LOCATION, loc);
+    }
+}
+
+/// The versioning metadata of a demographic versioned-object read whose service
+/// response carries none (the `VERSIONED_PARTY` container, its
+/// `REVISION_HISTORY`, and a version-addressed `ORIGINAL_VERSION`), derived from
+/// the served body.
+///
+/// `ETag` source — overview §"`ETag` and Last-Modified": the value "is usually
+/// taken from e.g. `VERSIONED_OBJECT.uid.value`, `VERSION.uid.value`". The
+/// body's own `uid.value` is exactly one of those two for the container and the
+/// version reads; a `REVISION_HISTORY` carries no `uid` of its own, so the
+/// addressed `versioned_object_uid` (the container the history belongs to) is
+/// the fallback.
+///
+/// `Last-Modified` source — same section: "derived from
+/// `VERSION.commit_audit.time_committed.value`". That is the `ORIGINAL_VERSION`'s
+/// own `commit_audit` for a version read, and the most recent revision-history
+/// item's first audit for a history read (`REVISION_HISTORY.items` is
+/// most-recent-last, RM common `master04-revision_history.adoc`
+/// §`REVISION_HISTORY`). A `VERSIONED_OBJECT` container body exposes no commit
+/// audit, so it carries the `ETag` alone (the header is a SHOULD).
+fn read_meta(versioned_object_uid: &str, body: &serde_json::Value) -> ResourceMeta {
+    let uid = body["uid"]["value"]
+        .as_str()
+        .unwrap_or(versioned_object_uid);
+    // Parties are not EHR-scoped, so the demographic `ehr_id` is empty.
+    let meta = ResourceMeta::new(String::new(), uid.to_owned());
+    match commit_time(body) {
+        Some(at) => meta.with_last_modified(at),
+        None => meta,
+    }
+}
+
+/// The commit instant a served demographic body exposes: an `ORIGINAL_VERSION`'s
+/// `commit_audit.time_committed`, else a `REVISION_HISTORY`'s most recent item's
+/// first audit (see [`read_meta`] for the citations).
+fn commit_time(body: &serde_json::Value) -> Option<jiff::Timestamp> {
+    let raw = body["commit_audit"]["time_committed"]["value"]
+        .as_str()
+        .or_else(|| {
+            body["items"]
+                .as_array()
+                .and_then(|items| items.last())
+                .and_then(|item| item["audits"][0]["time_committed"]["value"].as_str())
+        })?;
+    raw.parse::<jiff::Timestamp>().ok()
+}
+
+/// Render a demographic read that the service returns without metadata, with
+/// the versioning headers derived from the served body ([`read_meta`]).
+fn read_versioned(h: &HeaderMap, versioned_object_uid: &str, body: &serde_json::Value) -> Response {
+    let mut out = crate::overview::negotiate::respond(h, http::StatusCode::OK, body);
+    set_versioning_headers(&mut out, Some(&read_meta(versioned_object_uid, body)));
+    out
 }
 
 /// Emit the `openehr-item-tag` / `openehr-version-item-tag` **response** headers
@@ -151,15 +245,225 @@ fn set_item_tag_headers(resp_out: &mut Response, resp: &ServiceResponse) {
         .insert(crate::overview::params::H_VERSION_ITEM_TAG, value);
 }
 
-/// Render an error, additionally setting the latest-version `ETag`/`Location`
-/// the `412` (update) / `409` (delete) responses require.
-fn error_with_headers(
-    error: ApiError,
-    base: &str,
-    segment: &str,
-    meta: Option<&ResourceMeta>,
-) -> Response {
+/// Render an error, additionally echoing the latest version in the `ETag` the
+/// `412` (update) / `409` (delete) responses require — overview §"If-Match and
+/// accidental overwrites": on a false precondition the service "SHOULD return
+/// also latest `version_uid` in the `ETag` response headers".
+///
+/// No `Location`: an error response creates nothing, and overview §Location
+/// scopes the header to creation/redirect responses only.
+fn error_with_meta(error: ApiError, meta: Option<&ResourceMeta>) -> Response {
     let mut out = RestError(error).into_response();
-    set_headers(&mut out, base, segment, meta);
+    set_versioning_headers(&mut out, meta);
     out
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::panic,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    let_underscore_drop
+)] // test assertions/diagnostics/fixtures
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    const BASE: &str = "/ehrbase/rest/openehr/v1";
+    const VO: &str = "8849182c-82ad-4088-a07f-48ead4180515";
+    const UID: &str = "8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::2";
+
+    fn meta() -> ResourceMeta {
+        ResourceMeta::new(String::new(), UID.to_owned())
+    }
+
+    fn etag(resp: &Response) -> Option<&str> {
+        resp.headers()
+            .get(header::ETAG)
+            .and_then(|v| v.to_str().ok())
+    }
+
+    fn location(resp: &Response) -> Option<&str> {
+        resp.headers()
+            .get(header::LOCATION)
+            .and_then(|v| v.to_str().ok())
+    }
+
+    fn last_modified(resp: &Response) -> Option<&str> {
+        resp.headers()
+            .get(header::LAST_MODIFIED)
+            .and_then(|v| v.to_str().ok())
+    }
+
+    fn if_match_headers(value: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert("if-match", HeaderValue::from_str(value).unwrap());
+        h
+    }
+
+    /// Every non-creation demographic response carries the weak `ETag` and NO
+    /// `Location` — overview `Requests_and_responses.md` §Location: the header
+    /// "MUST NOT be used to indicate an alternate representation of an existing
+    /// resource (e.g. via `GET` method)" and "MUST ONLY be used for resource
+    /// creation … or redirect responses".
+    #[test]
+    fn versioning_headers_carry_no_location() {
+        let mut resp = crate::overview::negotiate::empty(http::StatusCode::OK);
+        set_versioning_headers(&mut resp, Some(&meta()));
+        assert_eq!(etag(&resp), Some(format!("W/\"{UID}\"").as_str()));
+        assert!(
+            location(&resp).is_none(),
+            "ITS-REST overview §Location: no Location on a non-creation response"
+        );
+    }
+
+    /// The commit instant rides `Last-Modified` when the metadata carries one
+    /// (overview §"`ETag` and Last-Modified": "derived from
+    /// `VERSION.commit_audit.time_committed.value`").
+    #[test]
+    fn versioning_headers_emit_last_modified_when_known() {
+        let at: jiff::Timestamp = "2009-07-22T19:15:56Z".parse().unwrap();
+        let mut resp = crate::overview::negotiate::empty(http::StatusCode::OK);
+        set_versioning_headers(&mut resp, Some(&meta().with_last_modified(at)));
+        assert_eq!(last_modified(&resp), Some("Wed, 22 Jul 2009 19:15:56 GMT"));
+
+        let mut bare = crate::overview::negotiate::empty(http::StatusCode::OK);
+        set_versioning_headers(&mut bare, Some(&meta()));
+        assert!(last_modified(&bare).is_none());
+    }
+
+    /// A create/update write DOES carry `Location` (overview §Location:
+    /// creation responses; §"Prefer minimal…": "the newly created or updated
+    /// resource").
+    #[test]
+    fn write_headers_add_the_creation_location() {
+        let mut resp = crate::overview::negotiate::empty(http::StatusCode::CREATED);
+        set_write_headers(&mut resp, BASE, "person", Some(&meta()));
+        assert_eq!(etag(&resp), Some(format!("W/\"{UID}\"").as_str()));
+        assert_eq!(
+            location(&resp),
+            Some(format!("{BASE}/demographic/person/{UID}").as_str())
+        );
+    }
+
+    /// A `412`/`409` echoes the latest version in `ETag` only — overview
+    /// §"If-Match and accidental overwrites" asks for the latest `version_uid`
+    /// in `ETag`; §Location forbids `Location` on a non-creation response.
+    #[test]
+    fn error_response_echoes_etag_without_location() {
+        let resp = error_with_meta(
+            ApiError::PreconditionFailed("stale".to_owned()),
+            Some(&meta()),
+        );
+        assert_eq!(resp.status(), http::StatusCode::PRECONDITION_FAILED);
+        assert_eq!(etag(&resp), Some(format!("W/\"{UID}\"").as_str()));
+        assert!(
+            location(&resp).is_none(),
+            "ITS-REST overview §Location: no Location on an error response"
+        );
+    }
+
+    /// `If-Match` is accepted in the weak `W/"…"` form the server itself emits,
+    /// in the deprecated bare quoted form, and unquoted — all naming the same
+    /// `OBJECT_VERSION_ID` (overview §"`ETag` and Last-Modified" +
+    /// §"Deprecated headers").
+    #[test]
+    fn if_match_normalizes_weak_quoted_and_bare_forms() {
+        for raw in [
+            format!("W/\"{UID}\""),
+            format!("w/\"{UID}\""),
+            format!("\"{UID}\""),
+            UID.to_owned(),
+            format!("  W/\"{UID}\"  "),
+        ] {
+            assert_eq!(
+                if_match_of(&if_match_headers(&raw)).as_deref(),
+                Some(UID),
+                "If-Match {raw:?} must reduce to the bare OBJECT_VERSION_ID"
+            );
+        }
+        assert_eq!(if_match_of(&HeaderMap::new()), None);
+        // A present-but-empty precondition is NOT "absent": it reaches the
+        // service, which rejects it (overview §If-Match: a received header MUST
+        // be honoured).
+        assert_eq!(
+            if_match_of(&if_match_headers("\"\"")).as_deref(),
+            Some(""),
+            "an empty If-Match must not read as an absent precondition"
+        );
+    }
+
+    /// A version read's `ETag` is `VERSION.uid.value` and its `Last-Modified`
+    /// the version's own `commit_audit.time_committed` (overview §"`ETag` and
+    /// Last-Modified").
+    #[test]
+    fn read_meta_of_an_original_version() {
+        let body = serde_json::json!({
+            "_type": "ORIGINAL_VERSION",
+            "uid": { "_type": "OBJECT_VERSION_ID", "value": UID },
+            "commit_audit": {
+                "_type": "AUDIT_DETAILS",
+                "time_committed": { "_type": "DV_DATE_TIME", "value": "2024-03-04T05:06:07Z" }
+            }
+        });
+        let m = read_meta(VO, &body);
+        assert_eq!(m.uid, UID);
+        assert_eq!(
+            m.last_modified,
+            Some("2024-03-04T05:06:07Z".parse::<jiff::Timestamp>().unwrap())
+        );
+    }
+
+    /// A `REVISION_HISTORY` carries no `uid`, so the `ETag` falls back to the
+    /// addressed `VERSIONED_OBJECT.uid.value`; `Last-Modified` comes from the
+    /// most recent item (`REVISION_HISTORY.items` is most-recent-last, RM common
+    /// `master04-revision_history.adoc`).
+    #[test]
+    fn read_meta_of_a_revision_history() {
+        let body = serde_json::json!({
+            "_type": "REVISION_HISTORY",
+            "items": [
+                { "version_id": { "value": format!("{VO}::s::1") },
+                  "audits": [{ "time_committed": { "value": "2024-01-01T00:00:00Z" } }] },
+                { "version_id": { "value": format!("{VO}::s::2") },
+                  "audits": [{ "time_committed": { "value": "2024-03-04T05:06:07Z" } }] }
+            ]
+        });
+        let m = read_meta(VO, &body);
+        assert_eq!(m.uid, VO);
+        assert_eq!(
+            m.last_modified,
+            Some("2024-03-04T05:06:07Z".parse::<jiff::Timestamp>().unwrap())
+        );
+    }
+
+    /// A `VERSIONED_OBJECT` container read takes its `ETag` from
+    /// `VERSIONED_OBJECT.uid.value` and exposes no commit audit, so it carries
+    /// no `Last-Modified` (the header is a SHOULD).
+    #[test]
+    fn read_meta_of_a_versioned_object_container() {
+        let body = serde_json::json!({
+            "_type": "VERSIONED_PARTY",
+            "uid": { "_type": "HIER_OBJECT_ID", "value": VO }
+        });
+        let m = read_meta(VO, &body);
+        assert_eq!(m.uid, VO);
+        assert_eq!(m.last_modified, None);
+    }
+
+    /// A versioned read emits the derived versioning headers and no `Location`.
+    #[test]
+    fn read_versioned_emits_etag_without_location() {
+        let body = serde_json::json!({
+            "_type": "VERSIONED_PARTY",
+            "uid": { "_type": "HIER_OBJECT_ID", "value": VO }
+        });
+        let resp = read_versioned(&HeaderMap::new(), VO, &body);
+        assert_eq!(resp.status(), http::StatusCode::OK);
+        assert_eq!(etag(&resp), Some(format!("W/\"{VO}\"").as_str()));
+        assert!(
+            location(&resp).is_none(),
+            "ITS-REST overview §Location: no Location on a GET"
+        );
+    }
 }

--- a/app/ehrbase-rest/src/api/demographic/party.rs
+++ b/app/ehrbase-rest/src/api/demographic/party.rs
@@ -76,7 +76,7 @@ pub(super) async fn run(
             if resp.is_empty() {
                 return Ok(negotiate::empty(StatusCode::NO_CONTENT));
             }
-            Ok(read_party(kind, h, &base, &resp))
+            Ok(read_party(kind, h, &resp))
         }
         "update" => {
             let p = params::build::<AgentUpdateParams>(&parts.path, q, h)?;
@@ -87,7 +87,10 @@ pub(super) async fn run(
                 .party_update(
                     kind,
                     p.uid_based_id,
-                    p.if_match,
+                    // The `W/"…"`/quoted ETag syntax is decoded here, at the
+                    // adapter seam, so the service compares a bare
+                    // OBJECT_VERSION_ID (overview §"`ETag` and Last-Modified").
+                    super::if_match_token(&p.if_match),
                     body,
                     crate::overview::committal::committal_audit(h),
                 )
@@ -117,17 +120,12 @@ pub(super) async fn run(
                         .await
                         .ok()
                         .flatten();
-                    Ok(super::error_with_headers(
-                        sm_api_error(e),
-                        &base,
-                        seg,
-                        meta.as_ref(),
-                    ))
+                    Ok(super::error_with_meta(sm_api_error(e), meta.as_ref()))
                 }
                 Err(e) => Err(RestError::from(e)),
             }
         }
-        "delete" => run_delete(&state, kind, &base, seg, &parts).await,
+        "delete" => run_delete(&state, kind, &parts).await,
         other => Err(RestError(ApiError::Internal(format!(
             "unrouted demographic party operation: {seg}_{other}"
         )))),
@@ -163,8 +161,10 @@ async fn persist_request_tags(
     Ok(())
 }
 
-/// `DELETE /demographic/{kind}/{uid_based_id}` — logical delete → `204` +
-/// `ETag`/`Location` of the deleted version.
+/// `DELETE /demographic/{kind}/{uid_based_id}` — logical delete → `204` + the
+/// deleted version's `ETag` (no `Location`: overview §"Deprecated headers"
+/// deprecates `Location` on `DELETE` responses, §Location scopes it to
+/// creation/redirect).
 ///
 /// `person_delete.yaml` places the `preceding_version_uid` to delete in the
 /// **path** (`uid_based_id_as_version_uid` — an `OBJECT_VERSION_ID`), not in an
@@ -174,8 +174,6 @@ async fn persist_request_tags(
 async fn run_delete(
     state: &AppState,
     kind: PartyKind,
-    base: &str,
-    seg: &str,
     parts: &RequestParts,
 ) -> Result<Response, RestError> {
     let h = &parts.headers;
@@ -183,11 +181,13 @@ async fn run_delete(
     // version_uid). All per-kind delete params are field-identical; reuse one.
     let p = params::build::<AgentDeleteParams>(&parts.path, parts.query.as_deref(), h)?;
     let preceding = p.uid_based_id.clone();
-    // NOTE (wire, compatibility): `person_delete.yaml` declares no `If-Match`
-    // and takes the preceding version from the path `uid_based_id` (an
-    // `OBJECT_VERSION_ID`, design its-rest/demographic.md §2.2), which is passed
-    // positionally to `party_delete` below; `If-Match` is retained only as a
-    // fallback source of the preceding version for older clients. The service
+    // NOTE (wire, compatibility): the delete operation takes the preceding
+    // version from the path `uid_based_id` (an `OBJECT_VERSION_ID`), which is
+    // passed positionally to `party_delete` below — ITS-REST overview
+    // §"If-Match and accidental overwrites" requires `If-Match` only "when the
+    // `preceding_version_uid` is not part of the endpoint path segment", and
+    // here it is. `If-Match` is therefore accepted, never required, as an
+    // alternative source of the preceding version. The service
     // signals a stale uid via `version_mismatch` (→ 409, handled below with the
     // latest `version_uid` echoed in `ETag`) and an already-deleted target via
     // `precondition_violation` (→ 400_already_deleted).
@@ -202,9 +202,9 @@ async fn run_delete(
         .await
     {
         Ok(resp) => {
-            // 204_version_deleted: ETag + Location of the deleted version.
+            // 204_version_deleted: the deleted version's ETag, no Location.
             let mut out = negotiate::empty(StatusCode::NO_CONTENT);
-            super::set_headers(&mut out, base, seg, resp.meta.as_ref());
+            super::set_versioning_headers(&mut out, resp.meta.as_ref());
             Ok(out)
         }
         // 409_PERSON_with_uid_based_id: supplied uid_based_id ≠ latest version.
@@ -215,10 +215,8 @@ async fn run_delete(
                 .await
                 .ok()
                 .flatten();
-            Ok(super::error_with_headers(
+            Ok(super::error_with_meta(
                 ApiError::Conflict(e.message),
-                base,
-                seg,
                 meta.as_ref(),
             ))
         }
@@ -264,7 +262,9 @@ fn respond_party(
 }
 
 /// A create/update response honouring `Prefer` and setting the demographic
-/// `ETag`/`Location`.
+/// `ETag`/`Last-Modified` + the `Location` of the version this write committed
+/// (overview §Location — creation/redirect only; §"Prefer minimal…" — "the
+/// newly created or updated resource").
 fn write_party(
     kind: PartyKind,
     h: &HeaderMap,
@@ -278,15 +278,17 @@ fn write_party(
     } else {
         negotiate::empty(minimal_status)
     };
-    super::set_headers(&mut out, base, kind.segment(), resp.meta.as_ref());
+    super::set_write_headers(&mut out, base, kind.segment(), resp.meta.as_ref());
     out
 }
 
-/// A `200 OK` read of a party, setting the demographic `ETag`/`Location` and the
-/// `ITEM_TAG` response headers (`person_get.yaml`).
-fn read_party(kind: PartyKind, h: &HeaderMap, base: &str, resp: &ServiceResponse) -> Response {
+/// A `200 OK` read of a party, setting the demographic `ETag`/`Last-Modified`
+/// and the `ITEM_TAG` response headers (`person_get.yaml`). No `Location` —
+/// overview §Location: the header "MUST NOT be used to indicate an alternate
+/// representation of an existing resource (e.g. via `GET` method)".
+fn read_party(kind: PartyKind, h: &HeaderMap, resp: &ServiceResponse) -> Response {
     let mut out = respond_party(kind, h, StatusCode::OK, &resp.body);
-    super::set_headers(&mut out, base, kind.segment(), resp.meta.as_ref());
+    super::set_versioning_headers(&mut out, resp.meta.as_ref());
     super::set_item_tag_headers(&mut out, resp);
     out
 }

--- a/app/ehrbase-rest/src/api/demographic/relationship.rs
+++ b/app/ehrbase-rest/src/api/demographic/relationship.rs
@@ -406,7 +406,6 @@ pub(super) async fn run(
     parts: RequestParts,
 ) -> Result<Response, RestError> {
     const SEG: &str = "party_relationship";
-    const VSEG: &str = "versioned_party_relationship";
     let h = &parts.headers;
     let q = parts.query.as_deref();
     let base = state.config().server.base_path.clone();
@@ -441,7 +440,7 @@ pub(super) async fn run(
             if resp.is_empty() {
                 return Ok(negotiate::empty(StatusCode::NO_CONTENT));
             }
-            Ok(read_relationship(h, &base, SEG, &resp))
+            Ok(read_relationship(h, &resp))
         }
         "party_relationship_update" => {
             let p = params::build::<AgentUpdateParams>(&parts.path, q, h)?;
@@ -451,7 +450,9 @@ pub(super) async fn run(
                 .backend()
                 .party_relationship_update(
                     p.uid_based_id,
-                    p.if_match,
+                    // Decode the `W/"…"`/quoted ETag syntax at the adapter seam
+                    // so the service compares a bare OBJECT_VERSION_ID.
+                    super::if_match_token(&p.if_match),
                     body,
                     crate::overview::committal::committal_audit(h),
                 )
@@ -472,12 +473,7 @@ pub(super) async fn run(
                         .await
                         .ok()
                         .flatten();
-                    Ok(super::error_with_headers(
-                        sm_api_error(e),
-                        &base,
-                        SEG,
-                        meta.as_ref(),
-                    ))
+                    Ok(super::error_with_meta(sm_api_error(e), meta.as_ref()))
                 }
                 Err(e) => Err(RestError::from(e)),
             }
@@ -493,43 +489,49 @@ pub(super) async fn run(
                 )
                 .await?;
             let mut out = negotiate::empty(StatusCode::NO_CONTENT);
-            super::set_headers(&mut out, &base, SEG, resp.meta.as_ref());
+            super::set_versioning_headers(&mut out, resp.meta.as_ref());
             Ok(out)
         }
+        // The versioned reads carry the weak `ETag` (+ `Last-Modified` where the
+        // served body exposes a commit audit) the overview §"`ETag` and
+        // Last-Modified" asks of VERSION / VERSIONED_OBJECT responses, and no
+        // `Location` (§Location — creation/redirect only).
         "versioned_party_relationship_get" => {
             let p = params::build::<VersionedPartyGetParams>(&parts.path, q, h)?;
+            let vo = p.versioned_object_uid.clone();
             let resp = state
                 .backend()
                 .versioned_party_relationship_get(p.versioned_object_uid)
                 .await?;
-            Ok(negotiate::respond(h, StatusCode::OK, &resp.body))
+            Ok(super::read_versioned(h, &vo, &resp.body))
         }
         "party_relationship_revision_history" => {
             let p = params::build::<VersionedPartyGetParams>(&parts.path, q, h)?;
+            let vo = p.versioned_object_uid.clone();
             let resp = state
                 .backend()
                 .party_relationship_revision_history(p.versioned_object_uid)
                 .await?;
-            Ok(negotiate::respond(h, StatusCode::OK, &resp.body))
+            Ok(super::read_versioned(h, &vo, &resp.body))
         }
         "party_relationship_version_get_at_time" => {
             let p = params::build::<VersionedPartyVersionGetAtTimeParams>(&parts.path, q, h)?;
-            let segment = format!("{VSEG}/{}/version", p.versioned_object_uid);
             let resp = state
                 .backend()
                 .party_relationship_version_get_at_time(p.versioned_object_uid, p.version_at_time)
                 .await?;
             let mut out = negotiate::respond(h, StatusCode::OK, &resp.body);
-            super::set_headers(&mut out, &base, &segment, resp.meta.as_ref());
+            super::set_versioning_headers(&mut out, resp.meta.as_ref());
             Ok(out)
         }
         "party_relationship_version_get_by_id" => {
             let p = params::build::<VersionedPartyVersionGetByIdParams>(&parts.path, q, h)?;
+            let vo = p.versioned_object_uid.clone();
             let resp = state
                 .backend()
                 .party_relationship_version_get_by_id(p.versioned_object_uid, p.version_uid)
                 .await?;
-            Ok(negotiate::respond(h, StatusCode::OK, &resp.body))
+            Ok(super::read_versioned(h, &vo, &resp.body))
         }
         other => Err(RestError(ApiError::Internal(format!(
             "unrouted demographic relationship operation: {other}"
@@ -558,23 +560,21 @@ fn write_relationship(
     } else {
         negotiate::empty(minimal_status)
     };
-    super::set_headers(&mut out, base, segment, resp.meta.as_ref());
+    super::set_write_headers(&mut out, base, segment, resp.meta.as_ref());
     out
 }
 
-/// A `200 OK` read of a relationship, setting the demographic `ETag`/`Location`.
-fn read_relationship(
-    h: &http::HeaderMap,
-    base: &str,
-    segment: &str,
-    resp: &ServiceResponse,
-) -> Response {
+/// A `200 OK` read of a relationship, setting the demographic
+/// `ETag`/`Last-Modified`. No `Location` — overview §Location: the header "MUST
+/// NOT be used to indicate an alternate representation of an existing resource
+/// (e.g. via `GET` method)".
+fn read_relationship(h: &http::HeaderMap, resp: &ServiceResponse) -> Response {
     let mut out = negotiate::respond_rm::<PartyRelationship>(
         h,
         StatusCode::OK,
         &resp.body,
         "party_relationship",
     );
-    super::set_headers(&mut out, base, segment, resp.meta.as_ref());
+    super::set_versioning_headers(&mut out, resp.meta.as_ref());
     out
 }

--- a/app/ehrbase-rest/src/api/demographic/versioned_party.rs
+++ b/app/ehrbase-rest/src/api/demographic/versioned_party.rs
@@ -3,6 +3,13 @@
 //! `versioned_party_version_get_at_time.yaml`,
 //! `versioned_party_version_get_by_id.yaml`. Canonical content negotiation
 //! (`Accept_canonical`/`ContentType_canonical`).
+//!
+//! Every read here is a `GET` on a `VERSION` / `VERSIONED_OBJECT` resource, so
+//! each carries the weak `ETag` (and `Last-Modified` where the served body
+//! exposes a commit audit) the ITS-REST overview
+//! `Requests_and_responses.md` §"`ETag` and Last-Modified" asks for — and NO
+//! `Location`, which §Location restricts to creation/redirect responses and
+//! §"Deprecated headers" deprecates on `GET`.
 
 use axum::response::Response;
 use http::StatusCode;
@@ -27,45 +34,52 @@ pub(super) async fn run(
     let h = &parts.headers;
     let q = parts.query.as_deref();
     let ok = StatusCode::OK;
-    let base = state.config().server.base_path.clone();
 
     match op {
         "versioned_party_get" => {
             let p = params::build::<VersionedPartyGetParams>(&parts.path, q, h)?;
+            let vo = p.versioned_object_uid.clone();
             let resp = state
                 .backend()
                 .versioned_party_get(p.versioned_object_uid)
                 .await?;
-            Ok(negotiate::respond(h, ok, &resp.body))
+            // ETag from VERSIONED_OBJECT.uid.value (overview §"ETag and
+            // Last-Modified" names it as an ETag source).
+            Ok(super::read_versioned(h, &vo, &resp.body))
         }
         "versioned_party_revision_history" => {
             let p = params::build::<VersionedPartyGetParams>(&parts.path, q, h)?;
+            let vo = p.versioned_object_uid.clone();
             let resp = state
                 .backend()
                 .versioned_party_revision_history(p.versioned_object_uid)
                 .await?;
-            Ok(negotiate::respond(h, ok, &resp.body))
+            // ETag from the addressed VERSIONED_OBJECT (a REVISION_HISTORY has
+            // no uid of its own); Last-Modified from the most recent item.
+            Ok(super::read_versioned(h, &vo, &resp.body))
         }
         "versioned_party_version_get_at_time" => {
             let p = params::build::<VersionedPartyVersionGetAtTimeParams>(&parts.path, q, h)?;
-            // 200_VERSION_at_time analogue: ETag(version_uid) + Location of the
-            // VERSION resource (…/versioned_party/{uid}/version/{version_uid}).
-            let segment = format!("versioned_party/{}/version", p.versioned_object_uid);
+            // 200_VERSION_at_time analogue: the served VERSION's ETag +
+            // Last-Modified (its commit instant rides the response metadata).
             let resp = state
                 .backend()
                 .versioned_party_version_get_at_time(p.versioned_object_uid, p.version_at_time)
                 .await?;
             let mut out = negotiate::respond(h, ok, &resp.body);
-            super::set_headers(&mut out, &base, &segment, resp.meta.as_ref());
+            super::set_versioning_headers(&mut out, resp.meta.as_ref());
             Ok(out)
         }
         "versioned_party_version_get_by_id" => {
             let p = params::build::<VersionedPartyVersionGetByIdParams>(&parts.path, q, h)?;
+            let vo = p.versioned_object_uid.clone();
             let resp = state
                 .backend()
                 .versioned_party_version_get_by_id(p.versioned_object_uid, p.version_uid)
                 .await?;
-            Ok(negotiate::respond(h, ok, &resp.body))
+            // ETag from VERSION.uid.value; Last-Modified from the served
+            // ORIGINAL_VERSION's commit_audit.time_committed.
+            Ok(super::read_versioned(h, &vo, &resp.body))
         }
         other => Err(RestError(ApiError::Internal(format!(
             "unrouted versioned_party operation: {other}"

--- a/app/ehrbase-rest/tests/demographic_http.rs
+++ b/app/ehrbase-rest/tests/demographic_http.rs
@@ -14,7 +14,13 @@
 //! `OBJECT_VERSION_ID`, so the tests create real parties through the wire and
 //! read the server-assigned `version_uid` back from the `ETag` — the invariant
 //! assertions (weak-`ETag` present, `Location` = `{base}/demographic/{kind}/{uid}`
-//! consistent with that `ETag`, body `_type`, status codes) are unchanged.
+//! consistent with that `ETag` **on writes only**, body `_type`, status codes).
+//!
+//! Header discipline (ITS-REST overview `Requests_and_responses.md`): `Location`
+//! rides create/update writes alone — §Location bars it as "an alternate
+//! representation of an existing resource" and §"Deprecated headers" deprecates
+//! it on `GET` and `DELETE`; reads, deletes and `4xx` responses identify the
+//! version through the weak `ETag` (+ `Last-Modified` where known).
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use axum::Router;
@@ -131,6 +137,17 @@ async fn send(app: &Router, req: Request<Body>) -> (StatusCode, header::HeaderMa
     )
 }
 
+/// A canonical-JSON `GET` against the composed router.
+async fn get_json(app: &Router, uri: String) -> (StatusCode, header::HeaderMap, String) {
+    let req = Request::builder()
+        .method("GET")
+        .uri(uri)
+        .header(header::ACCEPT, "application/json")
+        .body(Body::empty())
+        .unwrap();
+    send(app, req).await
+}
+
 fn etag(h: &header::HeaderMap) -> Option<&str> {
     h.get(header::ETAG).and_then(|v| v.to_str().ok())
 }
@@ -208,8 +225,13 @@ async fn person_create_representation_returns_body() {
     assert_eq!(v["_type"], "PERSON");
 }
 
+/// A `GET` carries the weak `ETag` and **no** `Location`: ITS-REST overview
+/// `Requests_and_responses.md` §Location — "It MUST NOT be used to indicate an
+/// alternate representation of an existing resource (e.g. via `GET` method)" and
+/// "MUST ONLY be used for resource creation (e.g., `201 Created`) or redirect
+/// responses"; §"Deprecated headers" deprecates `Location` on `GET`.
 #[tokio::test]
-async fn person_get_sets_etag_and_location() {
+async fn person_get_sets_etag_and_no_location() {
     let (_pg, app) = app().await;
     let ovid = create(&app, "person", &person_body()).await;
     let vo = vo_of(&ovid);
@@ -225,7 +247,9 @@ async fn person_get_sets_etag_and_location() {
     assert_eq!(etag(&h), Some(format!("W/\"{ovid}\"").as_str()));
     assert_eq!(
         location(&h),
-        Some(format!("{BASE}/demographic/person/{ovid}").as_str())
+        None,
+        "ITS-REST overview §Location: Location MUST NOT indicate an alternate \
+         representation of an existing resource (GET)"
     );
     let v: Value = serde_json::from_str(&body).expect("json body");
     assert_eq!(v["_type"], "PERSON");
@@ -257,8 +281,12 @@ async fn deleted_person_read_is_204() {
     assert!(body.is_empty());
 }
 
+/// A `204` delete carries the deleted version's weak `ETag` and **no**
+/// `Location`: ITS-REST overview §"Deprecated headers" — "the `Location`
+/// response header was deprecated from responses of `DELETE` methods";
+/// §Location scopes it to creation/redirect responses.
 #[tokio::test]
-async fn person_delete_is_204_with_headers() {
+async fn person_delete_is_204_with_etag_and_no_location() {
     let (_pg, app) = app().await;
     let ovid = create(&app, "person", &person_body()).await;
 
@@ -270,12 +298,13 @@ async fn person_delete_is_204_with_headers() {
     let (status, h, body) = send(&app, req).await;
 
     assert_eq!(status, StatusCode::NO_CONTENT);
-    // ETag + Location of the deleted version (a new version_uid).
+    // ETag of the deleted version (a new version_uid).
     let deleted = etag_uid(&h);
     assert_eq!(etag(&h), Some(format!("W/\"{deleted}\"").as_str()));
     assert_eq!(
         location(&h),
-        Some(format!("{BASE}/demographic/person/{deleted}").as_str())
+        None,
+        "ITS-REST overview §Deprecated headers: Location is deprecated on DELETE responses"
     );
     assert!(body.is_empty());
 }
@@ -300,8 +329,13 @@ async fn person_delete_by_versioned_uid_with_if_match_is_204() {
     assert!(body.is_empty());
 }
 
+/// A stale `If-Match` is `412` echoing the latest `version_uid` in `ETag`
+/// (ITS-REST overview §"If-Match and accidental overwrites": on a false
+/// condition the service "MUST respond with HTTP status code `412 Precondition
+/// Failed`, and SHOULD return also latest `version_uid` in the `ETag` response
+/// headers") — and no `Location`, which §Location scopes to creation/redirect.
 #[tokio::test]
-async fn stale_update_is_412_with_latest_headers() {
+async fn stale_update_is_412_with_latest_etag_and_no_location() {
     let (_pg, app) = app().await;
     let ovid = create(&app, "person", &person_body()).await;
     let vo = vo_of(&ovid);
@@ -317,13 +351,256 @@ async fn stale_update_is_412_with_latest_headers() {
         .unwrap();
     let (status, h, _body) = send(&app, req).await;
 
-    // Precondition failure → 412, decorated with the latest version headers.
+    // Precondition failure → 412, echoing the latest version_uid.
     assert_eq!(status, StatusCode::PRECONDITION_FAILED);
     assert_eq!(etag(&h), Some(format!("W/\"{ovid}\"").as_str()));
     assert_eq!(
         location(&h),
-        Some(format!("{BASE}/demographic/person/{ovid}").as_str())
+        None,
+        "ITS-REST overview §Location: no Location on an error response"
     );
+}
+
+/// The server emits weak `ETag`s (`W/"…"`, overview §"`ETag` and
+/// Last-Modified"), so a client echoing that exact value back as `If-Match`
+/// MUST satisfy the precondition. The bare quoted form stays supported
+/// (§"Deprecated headers": implementations "MAY still support it"), and the
+/// unquoted value is accepted for the same reason.
+#[tokio::test]
+async fn update_accepts_weak_bare_quoted_and_unquoted_if_match() {
+    let (_pg, app) = app().await;
+
+    for shape in ["weak", "quoted", "unquoted"] {
+        let ovid = create(&app, "person", &person_body()).await;
+        let vo = vo_of(&ovid).to_owned();
+        let if_match = match shape {
+            "weak" => format!("W/\"{ovid}\""),
+            "quoted" => format!("\"{ovid}\""),
+            _ => ovid.clone(),
+        };
+
+        let req = Request::builder()
+            .method("PUT")
+            .uri(format!("{BASE}/demographic/person/{vo}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .header(header::IF_MATCH, if_match.as_str())
+            .body(Body::from(person_body().to_string()))
+            .unwrap();
+        let (status, h, body) = send(&app, req).await;
+
+        assert_eq!(
+            status,
+            StatusCode::NO_CONTENT,
+            "If-Match {if_match:?} ({shape} form) must satisfy the precondition \
+             (ITS-REST overview §ETag and Last-Modified + §Deprecated headers): {body}"
+        );
+        let v2 = etag_uid(&h);
+        assert!(v2.ends_with("::2"), "second version committed, got {v2}");
+    }
+}
+
+/// `creating_system_id` is a composite identifier: BASE `base_types`
+/// `master05-identification_package.adoc` §"Composite Identifiers and Case" —
+/// two identifiers "identical apart from case … identify the same thing". A
+/// case-variant `If-Match` therefore names the current version and must NOT
+/// raise a spurious `412`.
+#[tokio::test]
+async fn update_if_match_compares_case_insensitively() {
+    let (_pg, app) = app().await;
+    let ovid = create(&app, "person", &person_body()).await;
+    let vo = vo_of(&ovid).to_owned();
+    let upper = ovid.to_uppercase();
+    assert_ne!(upper, ovid, "the fixture uid must have case to flip");
+
+    let req = Request::builder()
+        .method("PUT")
+        .uri(format!("{BASE}/demographic/person/{vo}"))
+        .header(header::CONTENT_TYPE, "application/json")
+        .header(header::IF_MATCH, format!("W/\"{upper}\""))
+        .body(Body::from(person_body().to_string()))
+        .unwrap();
+    let (status, _h, body) = send(&app, req).await;
+
+    assert_eq!(
+        status,
+        StatusCode::NO_CONTENT,
+        "BASE master05 §Composite Identifiers and Case: a case-variant \
+         OBJECT_VERSION_ID names the same version: {body}"
+    );
+}
+
+/// A syntactically invalid `If-Match` is a client error (`400`), never an
+/// ignored precondition — ITS-REST overview §"If-Match and accidental
+/// overwrites" requires a received `If-Match` to be honoured, so a value that
+/// cannot be evaluated must not run as if none was sent.
+#[tokio::test]
+async fn malformed_if_match_is_400() {
+    let (_pg, app) = app().await;
+    let ovid = create(&app, "person", &person_body()).await;
+    let vo = vo_of(&ovid).to_owned();
+
+    for bad in ["W/\"not-a-version-id\"", "\"\"", "\"a::b::c::3\""] {
+        let req = Request::builder()
+            .method("PUT")
+            .uri(format!("{BASE}/demographic/person/{vo}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .header(header::IF_MATCH, bad)
+            .body(Body::from(person_body().to_string()))
+            .unwrap();
+        let (status, _h, body) = send(&app, req).await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "If-Match {bad:?} is malformed and must be rejected, not skipped: {body}"
+        );
+    }
+}
+
+/// A `DELETE` addressed by the bare versioned-object uid accepts the weak
+/// `If-Match` form the server emits (same normalization seam as `PUT`).
+#[tokio::test]
+async fn delete_accepts_the_weak_if_match_form() {
+    let (_pg, app) = app().await;
+    let ovid = create(&app, "person", &person_body()).await;
+    let vo = vo_of(&ovid).to_owned();
+
+    let req = Request::builder()
+        .method("DELETE")
+        .uri(format!("{BASE}/demographic/person/{vo}"))
+        .header(header::IF_MATCH, format!("W/\"{ovid}\""))
+        .body(Body::empty())
+        .unwrap();
+    let (status, h, body) = send(&app, req).await;
+
+    assert_eq!(
+        status,
+        StatusCode::NO_CONTENT,
+        "a weak-form If-Match must satisfy the delete precondition: {body}"
+    );
+    assert!(etag(&h).is_some(), "the deleted version's ETag is echoed");
+    assert_eq!(
+        location(&h),
+        None,
+        "ITS-REST overview §Deprecated headers: Location is deprecated on DELETE responses"
+    );
+}
+
+/// The `VERSIONED_PARTY` reads are `VERSION`/`VERSIONED_OBJECT` responses, so
+/// each SHOULD carry `ETag` and `Last-Modified` (ITS-REST overview §"`ETag` and
+/// Last-Modified": both "SHOULD be included in responses for `VERSION`,
+/// `VERSIONED_OBJECT`, or other resources that have versioning or unique state
+/// identifiers"; the `ETag` is "usually taken from e.g.
+/// `VERSIONED_OBJECT.uid.value`, `VERSION.uid.value`") — and never `Location`.
+#[tokio::test]
+async fn versioned_party_reads_emit_versioning_headers() {
+    let (_pg, app) = app().await;
+    let ovid = create(&app, "person", &person_body()).await;
+    let vo = vo_of(&ovid).to_owned();
+
+    // The VERSIONED_PARTY container: ETag = VERSIONED_OBJECT.uid.value.
+    let (status, h, body) =
+        get_json(&app, format!("{BASE}/demographic/versioned_party/{vo}")).await;
+    assert_eq!(status, StatusCode::OK, "container read: {body}");
+    assert_eq!(etag(&h), Some(format!("W/\"{vo}\"").as_str()));
+    assert_eq!(
+        location(&h),
+        None,
+        "ITS-REST overview §Location: not on GET"
+    );
+
+    // The REVISION_HISTORY: ETag = the addressed VERSIONED_OBJECT uid,
+    // Last-Modified = the most recent item's commit audit.
+    let (status, h, body) = get_json(
+        &app,
+        format!("{BASE}/demographic/versioned_party/{vo}/revision_history"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "revision history: {body}");
+    assert_eq!(etag(&h), Some(format!("W/\"{vo}\"").as_str()));
+    assert!(
+        h.contains_key(header::LAST_MODIFIED),
+        "Last-Modified from REVISION_HISTORY.items.last().audits[0].time_committed"
+    );
+    assert_eq!(
+        location(&h),
+        None,
+        "ITS-REST overview §Location: not on GET"
+    );
+
+    // A version read: ETag = VERSION.uid.value, Last-Modified = its commit audit.
+    let (status, h, body) = get_json(
+        &app,
+        format!("{BASE}/demographic/versioned_party/{vo}/version/{ovid}"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "version read: {body}");
+    assert_eq!(etag(&h), Some(format!("W/\"{ovid}\"").as_str()));
+    assert!(
+        h.contains_key(header::LAST_MODIFIED),
+        "Last-Modified from ORIGINAL_VERSION.commit_audit.time_committed"
+    );
+    assert_eq!(
+        location(&h),
+        None,
+        "ITS-REST overview §Location: not on GET"
+    );
+
+    // The at-time version read (no version_at_time = latest).
+    let (status, h, body) = get_json(
+        &app,
+        format!("{BASE}/demographic/versioned_party/{vo}/version"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "version at time: {body}");
+    assert_eq!(etag(&h), Some(format!("W/\"{ovid}\"").as_str()));
+    assert_eq!(
+        location(&h),
+        None,
+        "ITS-REST overview §Location: not on GET"
+    );
+}
+
+/// The `PARTY_RELATIONSHIP` extension mirrors the party envelope: its versioned
+/// reads carry the same versioning headers and no `Location`.
+#[tokio::test]
+async fn versioned_party_relationship_reads_emit_versioning_headers() {
+    let (_pg, app) = app().await;
+    let ovid = create(&app, "party_relationship", &relationship_body()).await;
+    let vo = vo_of(&ovid).to_owned();
+
+    for (uri, expected_etag) in [
+        (
+            format!("{BASE}/demographic/versioned_party_relationship/{vo}"),
+            vo.clone(),
+        ),
+        (
+            format!("{BASE}/demographic/versioned_party_relationship/{vo}/revision_history"),
+            vo.clone(),
+        ),
+        (
+            format!("{BASE}/demographic/versioned_party_relationship/{vo}/version/{ovid}"),
+            ovid.clone(),
+        ),
+    ] {
+        let req = Request::builder()
+            .method("GET")
+            .uri(&uri)
+            .header(header::ACCEPT, "application/json")
+            .body(Body::empty())
+            .unwrap();
+        let (status, h, body) = send(&app, req).await;
+        assert_eq!(status, StatusCode::OK, "{uri}: {body}");
+        assert_eq!(
+            etag(&h),
+            Some(format!("W/\"{expected_etag}\"").as_str()),
+            "{uri} carries the versioned-resource ETag"
+        );
+        assert_eq!(
+            location(&h),
+            None,
+            "{uri}: ITS-REST overview §Location — no Location on a GET"
+        );
+    }
 }
 
 #[tokio::test]

--- a/app/ehrbase/src/service/demographic/api.rs
+++ b/app/ehrbase/src/service/demographic/api.rs
@@ -22,7 +22,8 @@ use crate::service::response::{ResourceMeta, ServiceResponse};
 use crate::service::status::{CallStatusType, SmError};
 use crate::service::version_update::{UpdateAudit, UpdateVersion};
 use crate::versioning::object_version_id::{
-    components, expected_from_if_match, parse_uid_based_id, parse_version_uid,
+    components, eq_composite_id, expected_from_if_match, if_match_token, parse_uid_based_id,
+    parse_version_uid,
 };
 
 /// Wrap a JSON array of item-tag objects as a plain (header-free) response.
@@ -62,25 +63,46 @@ fn party_kind_from_body(body: &Value) -> Result<PartyKind, SmError> {
     }
 }
 
-/// Full-`OBJECT_VERSION_ID` `If-Match` verification (ITS-REST overview
-/// §Concurrency control): the precondition names the current latest version
-/// **in full** — object id + creating system id + version — and a mismatch in
-/// ANY segment is a `412`. Reducing the header to the version-tree number
-/// alone would accept a precondition naming a version this server never held.
-/// Non-OVID tokens (a bare trunk number) keep the lenient tree addressing;
-/// an absent header or an object with no current version defers to the
-/// versioning path. Mirrors the EHR path's `ensure_if_match`.
+/// Full-`OBJECT_VERSION_ID` `If-Match` verification. ITS-REST overview
+/// `Requests_and_responses.md` §"If-Match and accidental overwrites": when the
+/// condition "evaluates to `false`, it MUST NOT perform the requested method.
+/// Instead, it MUST respond with HTTP status code `412 Precondition Failed`".
+///
+/// The precondition names the current latest version **in full** — the
+/// `object_id :: creating_system_id :: version_tree_id` triple — and a
+/// mismatch in ANY segment is a `412`. Reducing the header to the
+/// version-tree number alone would accept a precondition naming a version
+/// this server never held.
+///
+/// The comparison is case-**in**sensitive: an `OBJECT_VERSION_ID` is a
+/// composite identifier, and BASE `base_types`
+/// `master05-identification_package.adoc` §"Composite Identifiers and Case"
+/// makes two identifiers "identical apart from case … identify the same
+/// thing". Mirrors the EHR path's `ensure_if_match`.
+///
+/// The wire `ETag` syntax — the weak `W/"…"` form the overview §"`ETag` and
+/// Last-Modified" mandates on emitted `ETag`s, and the deprecated bare quoted
+/// form — is decoded by the ITS-REST adapter before the value reaches here;
+/// [`if_match_token`] applies the remaining quote tolerance so this compare and
+/// [`expected_from_if_match`] judge the same token.
+///
+/// Tokens that are not a full `OBJECT_VERSION_ID` are **not** silently skipped:
+/// the RFC 9110 `*` wildcard and the lenient bare `VERSION_TREE_ID` trunk
+/// number carry no full identity to compare (the versioning path enforces the
+/// tree precondition they do carry), and every other shape is rejected as
+/// malformed → `400` by [`expected_from_if_match`], which every caller of this
+/// function invokes on the same value.
 fn ensure_full_ovid_if_match(
     if_match: Option<&str>,
     current: Option<&ResourceMeta>,
 ) -> Result<(), SmError> {
     let Some(raw) = if_match else { return Ok(()) };
-    let token = raw.trim().trim_matches('"');
+    let token = if_match_token(raw);
     if <openehr_base::prelude::ObjectVersionId as std::str::FromStr>::from_str(token).is_err() {
         return Ok(());
     }
     match current {
-        Some(meta) if meta.uid == token => Ok(()),
+        Some(meta) if eq_composite_id(&meta.uid, token) => Ok(()),
         Some(meta) => Err(SmError::version_mismatch(format!(
             "If-Match {token:?} does not match the current latest version {:?}",
             meta.uid
@@ -357,9 +379,10 @@ impl EhrbaseService {
     }
 
     /// Update a party of the routed [`PartyKind`] under a mandatory `If-Match`
-    /// precondition (ITS-REST overview §Concurrency control). The current
-    /// version is resolved ONCE (lean, kind-checked): the same handle serves
-    /// the `If-Match` `ETag` compare here and the service write gate.
+    /// precondition (ITS-REST overview §"If-Match and accidental
+    /// overwrites"). The current version is resolved ONCE (lean,
+    /// kind-checked): the same handle serves the `If-Match` `ETag` compare
+    /// here and the service write gate.
     ///
     /// # Errors
     /// - [`SmError`] `precondition_violation` — the id or the `If-Match` token
@@ -855,9 +878,9 @@ impl EhrbaseService {
     }
 
     /// Update a relationship under a mandatory `If-Match` precondition
-    /// (ITS-REST overview §Concurrency control). The current version is
-    /// resolved ONCE (lean): the same handle serves the `If-Match` compare
-    /// and the service write gate.
+    /// (ITS-REST overview §"If-Match and accidental overwrites"). The current
+    /// version is resolved ONCE (lean): the same handle serves the `If-Match`
+    /// compare and the service write gate.
     ///
     /// # Errors
     /// - [`SmError`] `precondition_violation` — the id or the `If-Match` token
@@ -895,7 +918,8 @@ impl EhrbaseService {
     /// carries the versioned-relationship id (bare `HIER_OBJECT_ID` or full
     /// `OBJECT_VERSION_ID`); the preceding version for optimistic concurrency
     /// comes from `If-Match` when supplied, else the path OVID, else `None`
-    /// (delete the current version — ITS-REST overview §Concurrency control).
+    /// (delete the current version — ITS-REST overview §"If-Match and
+    /// accidental overwrites").
     ///
     /// # Errors
     /// - [`SmError`] `precondition_violation` — the id does not parse, or a
@@ -1019,5 +1043,99 @@ impl EhrbaseService {
     ) -> Result<Option<ResourceMeta>, SmError> {
         let (vo_id, _) = parse_uid_based_id(&uid_based_id)?;
         Ok(self.relationship_current_meta(vo_id).await?)
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::panic,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    let_underscore_drop
+)] // test assertions/diagnostics/fixtures
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    const VO: &str = "8849182c-82ad-4088-a07f-48ead4180515";
+
+    fn latest(uid: &str) -> ResourceMeta {
+        ResourceMeta::new(String::new(), uid.to_owned())
+    }
+
+    /// An `If-Match` naming the current latest version in full satisfies the
+    /// precondition (ITS-REST overview §"If-Match and accidental overwrites").
+    #[test]
+    fn matching_full_ovid_passes() {
+        let uid = format!("{VO}::openEHRSys.example.com::2");
+        assert!(ensure_full_ovid_if_match(Some(&uid), Some(&latest(&uid))).is_ok());
+        // The quote tolerance of the library boundary.
+        let quoted = format!("\"{uid}\"");
+        assert!(ensure_full_ovid_if_match(Some(&quoted), Some(&latest(&uid))).is_ok());
+    }
+
+    /// `creating_system_id` is a composite identifier, so a case variant names
+    /// the SAME version and must NOT raise a spurious `412` (BASE `base_types`
+    /// master05 §"Composite Identifiers and Case").
+    #[test]
+    fn case_variant_creating_system_id_matches() {
+        let stored = format!("{VO}::openEHRSys.example.com::2");
+        for variant in [
+            format!("{VO}::OPENEHRSYS.EXAMPLE.COM::2"),
+            format!("{VO}::openehrsys.example.com::2"),
+            format!("{}::openEHRSys.example.com::2", VO.to_uppercase()),
+        ] {
+            assert!(
+                ensure_full_ovid_if_match(Some(&variant), Some(&latest(&stored))).is_ok(),
+                "BASE master05 §Composite Identifiers and Case: {variant:?} names the \
+                 same version as {stored:?}"
+            );
+        }
+    }
+
+    /// A stale full `OBJECT_VERSION_ID` — a mismatch in ANY segment — is the
+    /// `412` branch.
+    #[test]
+    fn stale_or_foreign_ovid_is_a_version_mismatch() {
+        let stored = format!("{VO}::openEHRSys.example.com::2");
+        for stale in [
+            // wrong version_tree_id
+            format!("{VO}::openEHRSys.example.com::1"),
+            // wrong creating_system_id (not a mere case variant)
+            format!("{VO}::other.system::2"),
+            // wrong object_id
+            "00000000-0000-4000-8000-0000000000ff::openEHRSys.example.com::2".to_owned(),
+        ] {
+            let err = ensure_full_ovid_if_match(Some(&stale), Some(&latest(&stored)))
+                .expect_err("stale precondition");
+            assert_eq!(
+                err.status,
+                CallStatusType::VersionMismatch,
+                "{stale:?} must fail the precondition, got {err:?}"
+            );
+        }
+    }
+
+    /// An absent header, and an object with no current version, defer to the
+    /// versioning path (nothing to compare against).
+    #[test]
+    fn absent_header_or_no_current_version_defers() {
+        let uid = format!("{VO}::openEHRSys.example.com::2");
+        assert!(ensure_full_ovid_if_match(None, Some(&latest(&uid))).is_ok());
+        assert!(ensure_full_ovid_if_match(Some(&uid), None).is_ok());
+    }
+
+    /// A non-OVID token carries no full identity to compare here — the RFC 9110
+    /// `*` wildcard and the lenient trunk number pass through to
+    /// `expected_from_if_match`, which enforces the tree precondition or rejects
+    /// the value as malformed (`400`); nothing is silently skipped.
+    #[test]
+    fn non_ovid_tokens_defer_to_the_tree_precondition() {
+        let uid = format!("{VO}::openEHRSys.example.com::2");
+        assert!(ensure_full_ovid_if_match(Some("*"), Some(&latest(&uid))).is_ok());
+        assert!(ensure_full_ovid_if_match(Some("2"), Some(&latest(&uid))).is_ok());
+        // …and the malformed shapes the same call chain rejects downstream.
+        assert!(ensure_full_ovid_if_match(Some("garbage"), Some(&latest(&uid))).is_ok());
+        assert!(expected_from_if_match("garbage").is_err());
     }
 }

--- a/app/ehrbase/src/versioning/object_version_id.rs
+++ b/app/ehrbase/src/versioning/object_version_id.rs
@@ -264,6 +264,22 @@ pub(crate) fn parse_uid_based_id(raw: &str) -> Result<(VoId, Option<TreeId>), Ve
     }
 }
 
+/// The bare token inside an `If-Match` value: surrounding whitespace and the
+/// entity-tag double quotes stripped (RFC 9110 §8.8.3 — an entity-tag is a
+/// quoted string).
+///
+/// This is the ONE place the versioning core unwraps an `If-Match` value, so
+/// the demographic precondition comparison (`ensure_full_ovid_if_match`) and
+/// the version-tree extraction ([`expected_from_if_match`]) always judge the
+/// same token. The `W/` weakness indicator the ITS-REST overview §"`ETag` and
+/// Last-Modified" mandates on emitted `ETag`s is decoded one layer up, at the
+/// protocol adapter (`ehrbase-rest::overview::version_id::strip_etag`), where
+/// HTTP header syntax belongs; this function is the library-boundary tolerance
+/// for a direct caller that hands the quoted wire value straight through.
+pub(crate) fn if_match_token(if_match: &str) -> &str {
+    if_match.trim().trim_matches('"')
+}
+
 /// The expected (current) version from an `If-Match` header value: a quoted or
 /// bare `OBJECT_VERSION_ID` (strict BASE parse — the `object_id` need not be a
 /// UUID for precondition purposes), or a bare trunk integer.
@@ -286,7 +302,7 @@ pub(crate) fn parse_uid_based_id(raw: &str) -> Result<(VoId, Option<TreeId>), Ve
 /// the required-`If-Match` endpoints. `VersionIdError` converts into that `400`
 /// at each caller's error type.
 pub(crate) fn expected_from_if_match(if_match: &str) -> Result<Option<TreeId>, VersionIdError> {
-    let token = if_match.trim().trim_matches('"');
+    let token = if_match_token(if_match);
     // RFC 9110 §If-Match: `*` matches any current representation — no specific
     // version precondition to extract.
     if token == "*" {
@@ -438,6 +454,17 @@ mod tests {
             expected_from_if_match("abc::3"),
             Err(VersionIdError::Malformed { .. })
         ));
+    }
+
+    /// The one `If-Match` token normalizer strips whitespace and the
+    /// entity-tag quotes (RFC 9110 §8.8.3), leaving the bare value both the
+    /// precondition compare and the version-tree extraction judge.
+    #[test]
+    fn if_match_token_strips_quotes_and_whitespace() {
+        assert_eq!(if_match_token("\"abc::sys::3\""), "abc::sys::3");
+        assert_eq!(if_match_token("  \"abc::sys::3\"  "), "abc::sys::3");
+        assert_eq!(if_match_token("abc::sys::3"), "abc::sys::3");
+        assert_eq!(if_match_token("\"\""), "");
     }
 
     /// composite-identifier equality is case-insensitive

--- a/app/ehrbase/tests/service_demographic.rs
+++ b/app/ehrbase/tests/service_demographic.rs
@@ -594,3 +594,67 @@ async fn party_tags_crud() {
         .expect("get tags after delete");
     assert!(empty.body.as_array().expect("arr").is_empty());
 }
+
+/// The `If-Match` precondition compares the FULL `OBJECT_VERSION_ID`
+/// case-insensitively: an `OBJECT_VERSION_ID` is a composite identifier, and
+/// BASE `base_types` `master05-identification_package.adoc` §"Composite
+/// Identifiers and Case" makes two identifiers "identical apart from case …
+/// identify the same thing". A case-variant precondition therefore names the
+/// current version and MUST NOT raise a `412`. The quoted wire form is accepted
+/// at the same seam (RFC 9110 §8.8.3 — an entity-tag is a quoted string).
+#[tokio::test]
+async fn party_update_if_match_is_case_insensitive_and_quote_tolerant() {
+    let db = testkit::db().await.expect("testkit database");
+    let svc = EhrbaseService::new(db.pool());
+
+    let created = svc
+        .party_create(PartyKind::Person, person("Jane"), None)
+        .await
+        .expect("create person");
+    let ovid_v1 = ovid(&created.body).to_owned();
+    let vo = vo_uuid(&created.body);
+
+    // A case-variant of the current version_uid names the SAME version.
+    let upper = ovid_v1.to_uppercase();
+    assert_ne!(upper, ovid_v1, "the committed uid must have case to flip");
+    let v2 = svc
+        .party_update(
+            PartyKind::Person,
+            vo.clone(),
+            upper,
+            person("Jane Roe"),
+            None,
+        )
+        .await
+        .expect("BASE master05 §Composite Identifiers and Case: case-variant If-Match matches");
+    let ovid_v2 = ovid(&v2.body).to_owned();
+    assert!(ovid_v2.ends_with("::2"), "second version, got {ovid_v2}");
+
+    // The quoted wire form of the now-current version is accepted verbatim.
+    let v3 = svc
+        .party_update(
+            PartyKind::Person,
+            vo.clone(),
+            format!("\"{ovid_v2}\""),
+            person("Jane Doe"),
+            None,
+        )
+        .await
+        .expect("quoted If-Match accepted");
+    assert!(ovid(&v3.body).ends_with("::3"), "third version");
+
+    // A stale full OVID is still the precondition failure (412).
+    let stale = svc
+        .party_update(PartyKind::Person, vo, ovid_v1, person("stale"), None)
+        .await;
+    assert!(
+        matches!(
+            stale,
+            Err(SmError {
+                status: CallStatusType::VersionMismatch,
+                ..
+            })
+        ),
+        "a stale full OBJECT_VERSION_ID must still fail the precondition, got {stale:?}"
+    );
+}

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_PARTY.delete_party.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_PARTY.delete_party.yaml
@@ -15,15 +15,31 @@ its: its-rest
 request:
   method: DELETE
   path: /demographic/person/{version_uid}
+# Header discipline on this outcome (ITS-REST overview
+# Requests_and_responses.md): the weak `ETag` identifies the served version
+# (§"ETag and Last-Modified" — the value is "usually taken from e.g.
+# VERSIONED_OBJECT.uid.value, VERSION.uid.value" and carries the W/ weakness
+# indicator), and `Location` MUST BE ABSENT: §Location — "It MUST NOT be used
+# to indicate an alternate representation of an existing resource (e.g. via
+# GET method)" / "MUST ONLY be used for resource creation … or redirect
+# responses"; §"Deprecated headers" deprecates it on GET and DELETE alike.
+# TODO: the runner does not evaluate `outcomes.*.headers` matchers yet (only
+# the status is classified, tools/cnf-runner/src/exec/outcome.rs), so these
+# `Location: absent` / `ETag` declarations are the authored contract, not an
+# executed assertion — wire header-matcher evaluation into the step judgement.
 outcomes:
   deleted:
     status: 204                           # 204_version_deleted.yaml — logical delete performed
-    headers: { ETag: 'pattern:W/"<versioned_object_uid>::<system_id>::<n>"' }
+    headers:
+      ETag: 'pattern:W/"<versioned_object_uid>::<system_id>::<n>"'
+      Location: absent                    # DELETE — overview §Deprecated headers
   already_deleted: { status: 400 }        # 400_already_deleted.yaml — resource already deleted
   not_found: { status: 404 }              # 404.yaml — unknown party or version uid (versioned_object_does_not_exist)
   conflict:
     status: 409                           # 409_PERSON_with_uid_based_id.yaml — uid_based_id is not the latest version
-    headers: { ETag: latest-version-uid }
+    headers:
+      ETag: latest-version-uid
+      Location: absent                    # error response — overview §Location (creation/redirect only)
 captures:
   version_uid:
     from: header ETag                     # the new (deleted) VERSION uid (204_version_deleted.yaml ETag)

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_PARTY.get_party.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_PARTY.get_party.yaml
@@ -14,9 +14,24 @@ request:
   method: GET
   path: /demographic/person/{versioned_object_uid}
 formats: [canonical-json, canonical-xml]
+# Header discipline on this outcome (ITS-REST overview
+# Requests_and_responses.md): the weak `ETag` identifies the served version
+# (§"ETag and Last-Modified" — the value is "usually taken from e.g.
+# VERSIONED_OBJECT.uid.value, VERSION.uid.value" and carries the W/ weakness
+# indicator), and `Location` MUST BE ABSENT: §Location — "It MUST NOT be used
+# to indicate an alternate representation of an existing resource (e.g. via
+# GET method)" / "MUST ONLY be used for resource creation … or redirect
+# responses"; §"Deprecated headers" deprecates it on GET and DELETE alike.
+# TODO: the runner does not evaluate `outcomes.*.headers` matchers yet (only
+# the status is classified, tools/cnf-runner/src/exec/outcome.rs), so these
+# `Location: absent` / `ETag` declarations are the authored contract, not an
+# executed assertion — wire header-matcher evaluation into the step judgement.
 outcomes:
   ok:
     status: 200                           # 200_PERSON_retrieved.yaml
-    headers: { Content-Type: negotiated }
+    headers:
+      Content-Type: negotiated
+      ETag: 'pattern:W/"<versioned_object_uid>::<system_id>::<n>"'
+      Location: absent                    # GET — overview §Location / §Deprecated headers
   not_found: { status: 404 }
   not_acceptable: { status: 406 }         # unfulfillable Accept (overview negotiation rules; no simplified mapping exists for demographic resources)              # unknown versioned_object_uid (versioned_object_does_not_exist)

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_PARTY.get_party_at_time.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_PARTY.get_party_at_time.yaml
@@ -20,9 +20,26 @@ request:
   query:
     version_at_time: "${version_at_time}"
 formats: [canonical-json, canonical-xml]
+# Header discipline on this outcome (ITS-REST overview
+# Requests_and_responses.md): the weak `ETag` identifies the served version
+# (§"ETag and Last-Modified" — the value is "usually taken from e.g.
+# VERSIONED_OBJECT.uid.value, VERSION.uid.value" and carries the W/ weakness
+# indicator), and `Location` MUST BE ABSENT: §Location — "It MUST NOT be used
+# to indicate an alternate representation of an existing resource (e.g. via
+# GET method)" / "MUST ONLY be used for resource creation … or redirect
+# responses"; §"Deprecated headers" deprecates it on GET and DELETE alike.
+# TODO: the runner does not evaluate `outcomes.*.headers` matchers yet (only
+# the status is classified, tools/cnf-runner/src/exec/outcome.rs), so these
+# `Location: absent` / `ETag` declarations are the authored contract, not an
+# executed assertion — wire header-matcher evaluation into the step judgement.
 outcomes:
   ok:
     status: 200                           # 200_PERSON_retrieved.yaml
-    headers: { Content-Type: negotiated }
-  ok_empty: { status: 204 }               # 204_deleted_at_time.yaml — deleted at requested time
+    headers:
+      Content-Type: negotiated
+      ETag: 'pattern:W/"<versioned_object_uid>::<system_id>::<n>"'
+      Location: absent                    # GET — overview §Location / §Deprecated headers
+  ok_empty:
+    status: 204                           # 204_deleted_at_time.yaml — deleted at requested time
+    headers: { Location: absent }
   not_found: { status: 404 }              # unknown party or no version at time

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_PARTY.get_party_at_version.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_PARTY.get_party_at_version.yaml
@@ -17,8 +17,23 @@ request:
   method: GET
   path: /demographic/person/{version_uid}
 formats: [canonical-json, canonical-xml]
+# Header discipline on this outcome (ITS-REST overview
+# Requests_and_responses.md): the weak `ETag` identifies the served version
+# (§"ETag and Last-Modified" — the value is "usually taken from e.g.
+# VERSIONED_OBJECT.uid.value, VERSION.uid.value" and carries the W/ weakness
+# indicator), and `Location` MUST BE ABSENT: §Location — "It MUST NOT be used
+# to indicate an alternate representation of an existing resource (e.g. via
+# GET method)" / "MUST ONLY be used for resource creation … or redirect
+# responses"; §"Deprecated headers" deprecates it on GET and DELETE alike.
+# TODO: the runner does not evaluate `outcomes.*.headers` matchers yet (only
+# the status is classified, tools/cnf-runner/src/exec/outcome.rs), so these
+# `Location: absent` / `ETag` declarations are the authored contract, not an
+# executed assertion — wire header-matcher evaluation into the step judgement.
 outcomes:
   ok:
     status: 200                           # 200_PERSON_retrieved.yaml
-    headers: { Content-Type: negotiated }
+    headers:
+      Content-Type: negotiated
+      ETag: 'pattern:W/"<versioned_object_uid>::<system_id>::<n>"'
+      Location: absent                    # GET — overview §Location / §Deprecated headers
   not_found: { status: 404 }              # unknown version_uid (object_version_does_not_exist)

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_PARTY.update_party-weak_etag.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_PARTY.update_party-weak_etag.yaml
@@ -1,0 +1,61 @@
+# Wire realization of I_PARTY.update_party, variant weak_etag: the client sends
+# the preceding_version_uid back in the WEAK entity-tag form `W/"<uid>"` — the
+# exact shape the server emitted as the resource's `ETag`.
+#
+# Why that MUST work, from the ITS-REST docs text
+# (specifications/docs/overview/Requests_and_responses.md):
+#   §"ETag and Last-Modified": "the `ETag` is considered to be of weak-type and
+#   should have a weakness indicator `W/` prefix";
+#   §"Deprecated headers": "The `ETag` response header was used without a
+#   weakness indicator `W/`. This is now deprecated, all `ETag` headers that hold
+#   a resource identifier MUST include a weakness indicator `W/`."
+#   §"If-Match and accidental overwrites": "If a service receives this header,
+#   and the condition evaluates to `false`, it MUST NOT perform the requested
+#   method. Instead, it MUST respond with … `412 Precondition Failed`".
+# The value inside the weak tag is the current latest `version_uid`, so the
+# condition evaluates TRUE and the update proceeds; a STALE value inside the same
+# weak tag evaluates FALSE and is the `412`. Neither is a malformed precondition.
+#
+# Identical to the variant-less I_PARTY.update_party binding in every other
+# respect (path, body, Prefer, captures); only the `If-Match` value SHAPE
+# differs, so a red row localizes to weak-form decoding alone. The remaining
+# outcome branches (precondition_missing / not_found / version_not_found /
+# validation_failed) are shape-independent and stay declared + adjudicated on the
+# variant-less binding.
+# Sources: specifications/operations/person_update.yaml (200/204/400/404/412/422),
+# responses/200_PERSON_updated.yaml, 412_PERSON.yaml;
+# parameters/header/If-Match.yaml.
+sm_operation: I_PARTY.update_party
+its: its-rest
+variant: weak_etag
+request:
+  method: PUT
+  path: /demographic/person/{versioned_object_uid}
+  body: party
+  headers:
+    If-Match: 'W/"${preceding_version_uid}"'   # the weak form the server itself emits (overview §ETag and Last-Modified)
+    Prefer: "return=representation"
+formats: [canonical-json]
+# TODO: the runner does not evaluate `outcomes.*.headers` matchers yet (only the
+# status is classified, tools/cnf-runner/src/exec/outcome.rs), so the `ETag` /
+# `Location` declarations below are the authored contract, not an executed
+# assertion — wire header-matcher evaluation into the step judgement.
+outcomes:
+  updated:
+    status: 200                           # Prefer: return=representation (204 under minimal)
+    headers:
+      ETag: 'pattern:W/"<versioned_object_uid>::<system_id>::<n>"'
+    body: prefer_conditional
+  precondition_failed:
+    status: 412                           # 412_PERSON.yaml — the weak tag holds a stale version_uid
+    # overview §"If-Match and accidental overwrites": the service "SHOULD return
+    # also latest version_uid in the ETag response headers"; §Location keeps
+    # Location off a non-creation response.
+    headers:
+      ETag: latest-version-uid
+      Location: absent
+captures:
+  version_uid:
+    from: header ETag
+    strip: weak-quotes
+server_assigned: [uid]

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_PARTY.update_party.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_PARTY.update_party.yaml
@@ -28,7 +28,12 @@ outcomes:
     body: prefer_conditional
   precondition_failed:
     status: 412                           # 412_PERSON.yaml — If-Match does not match latest
-    headers: { ETag: latest-version-uid }
+    # overview §"If-Match and accidental overwrites": on a false condition the
+    # service "SHOULD return also latest version_uid in the ETag response
+    # headers"; §Location keeps Location off a non-creation response.
+    headers:
+      ETag: latest-version-uid
+      Location: absent
   precondition_missing: { status: 400 }   # If-Match absent -> SHOULD 400 (Requests_and_responses)
   not_found: { status: 404 }              # unknown party (versioned_object_does_not_exist)
   version_not_found: { status: 404 }      # unknown preceding version — same 404 family

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.update_party-weak_etag_accepted.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.update_party-weak_etag_accepted.yaml
@@ -1,0 +1,63 @@
+# A weak-form `If-Match` naming the CURRENT latest version satisfies the
+# precondition and the update proceeds.
+#
+# Derived from the ITS-REST docs text
+# (specifications/docs/overview/Requests_and_responses.md), not from any SUT:
+#   §"ETag and Last-Modified" — "the `ETag` is considered to be of weak-type and
+#   should have a weakness indicator `W/` prefix"; the value "is usually taken
+#   from e.g. VERSIONED_OBJECT.uid.value, VERSION.uid.value".
+#   §"Deprecated headers" — "all `ETag` headers that hold a resource identifier
+#   MUST include a weakness indicator `W/`".
+#   §"If-Match and accidental overwrites" — a `412` is required only when "the
+#   condition evaluates to `false`".
+# The client echoes back the exact `ETag` the server emitted for the current
+# version, so the condition evaluates TRUE and the write MUST be performed. The
+# `weak_etag` binding variant is the ONLY difference from
+# I_DEMOGRAPHIC_SERVICE.update_party-aaaa — it sends `W/"<uid>"` where the
+# variant-less binding sends `"<uid>"` — so a red row localizes to weak-form
+# `If-Match` decoding alone.
+# master10 anchors demographic cases under I_DEMOGRAPHIC_SERVICE; the resolvable
+# SM operation is I_PARTY.update_party.
+id: I_DEMOGRAPHIC_SERVICE.update_party-weak_etag_accepted
+kind: functional
+component: DEMOGRAPHIC
+sm_operation: I_PARTY.update_party
+capabilities: [PartyOperations]
+profiles: [OPTIONS]
+guards:
+  - "DEMOGRAPHIC API is DEVELOPMENT-stage in ITS-REST 1.1.0 — CNF profiles (Demographic Persistence, OPTIONS); ITS-REST demographic (DEVELOPMENT lifecycle)"
+  - "authored from SM I_DEMOGRAPHIC_SERVICE / I_PARTY operation semantics (declared meaning + Errors) + released ITS-REST demographic docs; master10 (DEMOGRAPHIC) is a stalled schedule stub (all cases TBD aaaa/bbbb) — a coverage guide only, not the authority"
+test_purpose: >-
+  update_party with the preceding_version_uid supplied in the weak entity-tag
+  form the server itself emits (W/"<uid>") satisfies the If-Match precondition
+  and commits the second VERSION.
+description: "Update a PARTY with a weak-form If-Match (the emitted ETag echoed back)"
+spec_refs:
+  - "ITS-REST overview Requests_and_responses §ETag and Last-Modified"
+  - "ITS-REST overview Requests_and_responses §Deprecated headers"
+  - "ITS-REST overview Requests_and_responses §If-Match and accidental overwrites"
+  - "SM openehr_platform §I_PARTY.update_party"
+applies: { rm: ">=1.0.2" }
+requires: { server: empty }
+data_sets: [cnf.demographic.person.v1, cnf.demographic.person.v2]
+flow:
+  - step: 1
+    call: I_DEMOGRAPHIC_SERVICE.create_party
+    with: { party: "${ds:cnf.demographic.person.v1}" }
+    expect: created
+    capture:
+      preceding_version_uid: created.version_uid
+      versioned_object_uid: created.versioned_object_uid
+  - step: 2
+    call: update_party
+    variant: weak_etag                                   # If-Match: W/"${preceding_version_uid}"
+    with:
+      versioned_object_uid: "${versioned_object_uid}"
+      party: "${ds:cnf.demographic.person.v2}"
+      preceding_version_uid: "${preceding_version_uid}"
+    expect: updated
+    capture: { v2_uid: updated.version_uid }
+    assert:
+      - { assert: version, of: "${v2_uid}", uid_pattern: "${versioned_object_uid}::<system>::2" }
+postconditions:
+  - { assert: version, count: 2 }

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.update_party-weak_etag_stale.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.update_party-weak_etag_stale.yaml
@@ -1,0 +1,55 @@
+# A weak-form `If-Match` carrying a STALE version_uid still evaluates the
+# precondition — it is `412`, never `400`.
+#
+# Derived from the ITS-REST docs text
+# (specifications/docs/overview/Requests_and_responses.md):
+#   §"If-Match and accidental overwrites" — "If a service receives this header,
+#   and the condition evaluates to `false`, it MUST NOT perform the requested
+#   method. Instead, it MUST respond with HTTP status code `412 Precondition
+#   Failed`, and SHOULD return also latest `version_uid` in the `ETag` response
+#   headers."
+#   §"ETag and Last-Modified" / §"Deprecated headers" — the `W/` weakness
+#   indicator is the emitted `ETag` form, so it is entity-tag SYNTAX, not part
+#   of the identifier being compared.
+# The pair with -weak_etag_accepted: the same weak syntax with a current value
+# passes, with a stale value fails as a PRECONDITION — proving the server
+# decodes the weak form and then evaluates it, rather than rejecting the syntax.
+# master10 anchors demographic cases under I_DEMOGRAPHIC_SERVICE; the resolvable
+# SM operation is I_PARTY.update_party.
+id: I_DEMOGRAPHIC_SERVICE.update_party-weak_etag_stale
+kind: functional
+component: DEMOGRAPHIC
+sm_operation: I_PARTY.update_party
+capabilities: [PartyOperations]
+profiles: [OPTIONS]
+guards:
+  - "DEMOGRAPHIC API is DEVELOPMENT-stage in ITS-REST 1.1.0 — CNF profiles (Demographic Persistence, OPTIONS); ITS-REST demographic (DEVELOPMENT lifecycle)"
+  - "authored from SM I_DEMOGRAPHIC_SERVICE / I_PARTY operation semantics (declared meaning + Errors) + released ITS-REST demographic docs; master10 (DEMOGRAPHIC) is a stalled schedule stub (all cases TBD aaaa/bbbb) — a coverage guide only, not the authority"
+test_purpose: >-
+  update_party with a stale preceding_version_uid supplied in the weak
+  entity-tag form is rejected as a failed precondition (412), not as malformed
+  syntax, and no new VERSION is created.
+description: "Update a PARTY with a stale weak-form If-Match (precondition failed)"
+spec_refs:
+  - "ITS-REST overview Requests_and_responses §If-Match and accidental overwrites"
+  - "ITS-REST overview Requests_and_responses §ETag and Last-Modified"
+  - "SM openehr_platform §I_PARTY.update_party"
+applies: { rm: ">=1.0.2" }
+requires: { server: empty }
+data_sets: [cnf.demographic.person.v1, cnf.demographic.person.v2]
+flow:
+  - step: 1
+    call: I_DEMOGRAPHIC_SERVICE.create_party
+    with: { party: "${ds:cnf.demographic.person.v1}" }
+    expect: created
+    capture: { versioned_object_uid: created.versioned_object_uid }
+  - step: 2
+    call: update_party
+    variant: weak_etag                                   # If-Match: W/"${preceding_version_uid}"
+    with:
+      versioned_object_uid: "${versioned_object_uid}"
+      party: "${ds:cnf.demographic.person.v2}"
+      preceding_version_uid: "00000000-0000-4000-8000-0000000000ff::openEHRSys.example.com::1"
+    expect: precondition_failed
+postconditions:
+  - { assert: version, count: 1 }

--- a/tools/cnf-runner/artifacts/vocab/wire_surface.yaml
+++ b/tools/cnf-runner/artifacts/vocab/wire_surface.yaml
@@ -740,6 +740,30 @@ elements:
     exception:
       reason: coverage_gap
       note: "NEW-CASE candidate: a stale-If-Match update (update_composition / update_directory / update_party) expecting 412 + latest version_uid in ETag. Consistent with the Axis-2 precondition_failed/precondition_missing gaps on those bindings."
+  - id: header-if-match-weak-form
+    description: "If-Match supplied in the weak entity-tag form W/\"<uid>\" — the shape the server itself emits as the ETag — is decoded and evaluated as a precondition: a current value passes the write, a stale value is 412 (never a malformed-syntax rejection)."
+    source: "ITS-REST Requests_and_responses.md §ETag and Last-Modified (the ETag \"is considered to be of weak-type and should have a weakness indicator W/ prefix\") + §Deprecated headers (\"all ETag headers that hold a resource identifier MUST include a weakness indicator W/\") + §If-Match and accidental overwrites (412 only when \"the condition evaluates to false\")"
+    covered_by:
+      - I_DEMOGRAPHIC_SERVICE.update_party-weak_etag_accepted
+      - I_DEMOGRAPHIC_SERVICE.update_party-weak_etag_stale
+  - id: header-if-match-case-insensitive
+    description: "The If-Match OBJECT_VERSION_ID is compared case-insensitively: a token differing from the current version_uid only in case names the same version and must not raise a spurious 412."
+    source: "BASE base_types master05-identification_package.adoc §Composite Identifiers and Case (two composite identifiers \"identical apart from case … identify the same thing\") applied to the ITS-REST Requests_and_responses.md §If-Match and accidental overwrites condition"
+    exception:
+      reason: coverage_gap
+      note: "server behaviour fixed + DB-tested (#394, app/ehrbase-rest/tests/demographic_http.rs + the service unit tests). NEW-CASE candidate blocked on a runner capability: a case cannot build a case-flipped variant of a captured version_uid (the only capture transforms are strip: weak-quotes and transform: root-uid — tools/cnf-runner/src/model/binding.rs), and no per-case header override exists."
+  - id: header-location-only-on-create
+    description: "Location is emitted ONLY on resource creation (and redirects): reads, deletes, and 4xx error responses carry no Location; the version identity travels in the weak ETag."
+    source: "ITS-REST Requests_and_responses.md §Location (\"It MUST NOT be used to indicate an alternate representation of an existing resource (e.g. via GET method)\"; \"The Location header MUST ONLY be used for resource creation (e.g., 201 Created) or redirect responses\") + §Deprecated headers (Location deprecated on GET and DELETE responses)"
+    exception:
+      reason: coverage_gap
+      note: "server behaviour fixed + DB-tested (#394); the absence is DECLARED as `Location: absent` on the get_party / get_party_at_time / get_party_at_version / delete_party / update_party binding outcomes. NEW-CASE candidate blocked on a runner capability: `outcomes.*.headers` matchers are parsed but never evaluated — only the status is classified (tools/cnf-runner/src/exec/outcome.rs), so no header assertion (present/absent/pattern) executes today."
+  - id: header-etag-on-versioned-object-read
+    description: "A VERSIONED_OBJECT / VERSION read carries the weak ETag (VERSIONED_OBJECT.uid.value or VERSION.uid.value) and, where the commit instant is available, Last-Modified."
+    source: "ITS-REST Requests_and_responses.md §ETag and Last-Modified (\"Both ETag and Last-Modified SHOULD be included in responses for VERSION, VERSIONED_OBJECT, or other resources that have versioning or unique state identifiers\"; the ETag \"is usually taken from e.g. VERSIONED_OBJECT.uid.value, VERSION.uid.value\", Last-Modified \"derived from VERSION.commit_audit.time_committed.value\")"
+    exception:
+      reason: coverage_gap
+      note: "server behaviour fixed + DB-tested for the demographic versioned reads (#394). NEW-CASE candidate blocked on two runner capabilities: header matchers are not evaluated (see header-location-only-on-create), and the /demographic/versioned_party/** resource has no binding of its own — the SM versioned-party reads are realized through I_PARTY.get_party_at_version on /demographic/person/{version_uid}."
   # Content negotiation (ITS-REST Requests_and_responses.md §HTTP status codes + Representation details negotiation).
   - id: negotiation-canonical-json
     description: "Canonical-JSON representation negotiated and returned (the default representation)."


### PR DESCRIPTION
Closes #394 — the first fix of the #373 full ITS-REST surface audit (group 1, cross-cutting header discipline; found by the #377 audit).

## What shipped

**`Location` discipline (MUST-level).** The demographic group emitted `Location` on GET reads, 204 DELETEs, and 409/412 error responses — ITS-REST overview `Requests_and_responses.md` §Location: it "MUST NOT be used to indicate an alternate representation of an existing resource (e.g. via `GET` method)", is deprecated on GET/DELETE responses (§Deprecated headers), and "MUST ONLY be used for resource creation … or redirect responses". The old `set_headers` is split: `set_versioning_headers` (weak `ETag` + `Last-Modified` + ATNA audit object, no `Location`) for reads/deletes/errors, `set_write_headers` (adds the creation `Location`) for writes.

**Adjudication — `Location` stays on PUT updates:** §Location says creation-only, but §"Prefer minimal…" names the target "the newly created **or updated** resource"; an openEHR update commits a new VERSION, which IS a newly created resource at the emitted URL. This keeps the demographic group consistent with the EHR group (`write_rm`) and the committed catalogue. Documented on `set_write_headers`.

**`If-Match` weak form + case (MUST-level).** The demographic precondition path stripped quotes only — a client echoing the server's OWN emitted `W/"…"` ETag got 400 — and compared the full `OBJECT_VERSION_ID` case-sensitively (the #367 case-insensitivity fix never reached this path). Now: the wire syntax is decoded at the adapter seam through the one existing `overview::version_id::strip_etag` (weak/bare-quoted/raw all accepted, per §"ETag and Last-Modified" + §"Deprecated headers"), and the service compares with `eq_composite_id` (case-insensitive — BASE `master05` §"Composite Identifiers and Case"). A new shared `if_match_token` normalizer means `ensure_full_ovid_if_match` and `expected_from_if_match` judge the same token; non-OVID tokens are documented as 400-via-`expected_from_if_match`, never a silent skip. Three `§Concurrency control` mis-citations corrected to the real section name; one internal-doc citation scrubbed.

**Versioned-party reads get versioning headers (SHOULD-level).** `versioned_party*` and `versioned_party_relationship*` reads emitted neither `ETag` nor `Last-Modified` (§"ETag and Last-Modified": both SHOULD accompany VERSION/VERSIONED_OBJECT responses). They now emit the weak ETag (container uid for container/revision-history reads, version uid for version reads) and `Last-Modified` from the served body's commit audit.

## Tests

- 6 new HTTP tests (weak/quoted/unquoted If-Match accepted; case-variant accepted; malformed → 400; weak-form DELETE; versioned-party header battery; relationship versioned-read battery) + 1 new DB-backed service test; new unit modules in `demographic/mod.rs` (9) and `demographic/api.rs` (5).
- 3 existing tests updated — they pinned the spec-violating `Location`; each now asserts absence with the governing spec sentence in the assertion message (testing.md: updated to assert the SPEC, not the old bug).

## CNF catalogue

- 2 new cases: `I_DEMOGRAPHIC_SERVICE.update_party-weak_etag_{accepted,stale}` (+ the `I_PARTY.update_party-weak_etag` binding variant).
- `Location: absent` + ETag declared on the party GET/at-time/at-version/DELETE bindings and the 412 outcome.
- 4 new `wire_surface.yaml` elements: `header-if-match-weak-form` (covered), `header-if-match-case-insensitive`, `header-location-only-on-create`, `header-etag-on-versioned-object-read` (registered gaps).
- **Found while doing this:** the runner parses but never evaluates header expectations — every header declaration in the catalogue is currently documentation, not assertion. Filed as #403 (P1) with the case-transform and versioned-party-binding gaps; the TODO-marked declarations here become executed assertions when #403 lands. #402 is blocked-by #403 accordingly.

## Gates

`cargo fmt --all` clean · `cargo clippy -p ehrbase -p ehrbase-rest --all-targets --all-features` zero warnings · `cargo nextest run -p ehrbase -p ehrbase-rest` 1049/1049 · `cargo nextest run -p cnf-runner` 153/153 (catalogue validation). Website book unchanged — `using-the-api/content-negotiation.md` already documents exactly this behaviour; the fix makes the demographic group match what the book promises. Changelog entry under `[Unreleased] ### Fixed`.

Group-1 fix wave status: this is fix 1 of 9 (#394–#402); per the #373 cadence the group-2 audit starts only when all nine are merged and a zero-drift CNF run has passed.
