### PR TITLE
fix(rest): emit Last-Modified on VERSION/COMPOSITION/EHR_STATUS reads and writes; ETag on EHR reads and ADL2 templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,35 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **`Last-Modified` and `ETag` completion on the EHR and DEFINITION surfaces**
+  (#396). ITS-REST overview `Requests_and_responses.md` §"`ETag` and
+  Last-Modified" requires both headers on "VERSION, VERSIONED_OBJECT, or other
+  resources that have versioning or unique state identifiers", with
+  `Last-Modified` "derived from `VERSION.commit_audit.time_committed.value`".
+  Only the `ETag` half shipped previously:
+  - `Last-Modified` (IMF-fixdate) is now emitted on every VERSION read
+    (`…/versioned_composition/{uid}/version[/{version_uid}]`,
+    `…/versioned_ehr_status/version[/{version_uid}]`), on all COMPOSITION and
+    `EHR_STATUS` reads and writes (including the delete `204` and the
+    FLAT/STRUCTURED representations, whose version identity is
+    serialization-independent), and on the EHR create `201`. The value is the
+    served version's commit instant — read off the VERSION envelope where the
+    body carries one, and off the version row / commit result for the bare
+    COMPOSITION and `EHR_STATUS` representations, which have no
+    `commit_audit` of their own.
+  - `GET /ehr/{ehr_id}` and `GET /ehr?subject_id=…` now carry the weak
+    `ETag` built from `EHR.ehr_id.value` — the source the spec section itself
+    names. (No `Last-Modified`: the RM `EHR` root is not a VERSION, and
+    `time_created` is not a last-modification instant.)
+  - The ADL2 template responses (`POST /definition/template/adl2`,
+    `GET …/adl2/{template_id}`, `GET …/adl2/{template_id}/{version}`) now
+    carry the weak `ETag` their ADL 1.4 siblings already emitted. The value is
+    the **resolved** `ARCHETYPE_HRID`, so addressing a template by a partial
+    id or major-version prefix still yields an `ETag` that changes when the
+    served artefact does.
+  `CONTRIBUTION` creation still omits `Last-Modified` (the commit instant is
+  not carried out of the version-set commit yet) and is marked `TODO` in the
+  service layer.
 - **Committal request headers: client `change_type` honoured, DELETE accepts
   the headers, deprecated `openEHR-AUDIT_DETAILS` spelling restored** (#395).
   Three divergences from ITS-REST overview `Requests_and_responses.md`

--- a/app/ehrbase-rest/src/api/definition/openapi_routes.rs
+++ b/app/ehrbase-rest/src/api/definition/openapi_routes.rs
@@ -315,10 +315,11 @@ pub(crate) async fn definition_template_adl2_list(
     request_body(content((String = "text/plain")),
                  description = "The ADL2 operational-template source."),
     responses(
-        (status = 201, description = "Stored; `Location` addresses the template. \
-                                      Body per `Prefer` (representation → ADL2 \
-                                      source; identifier → `{template_id}`; empty \
-                                      for minimal).",
+        (status = 201, description = "Stored; `Location` addresses the template \
+                                      and `ETag` (weak `W/` form) carries its \
+                                      `ARCHETYPE_HRID`. Body per `Prefer` \
+                                      (representation → ADL2 source; identifier \
+                                      → `{template_id}`; empty for minimal).",
          body = serde_json::Value),
         (status = 400, description = "The request body is not valid UTF-8 text.",
          body = serde_json::Value),
@@ -368,7 +369,9 @@ pub(crate) async fn definition_template_adl2_upload(
     responses(
         (status = 200, description = "The operational template — `text/plain` \
                                       ADL2 source or `application/json` \
-                                      `OperationalTemplateV2`.",
+                                      `OperationalTemplateV2`; `ETag` (weak `W/` \
+                                      form) carries the RESOLVED \
+                                      `ARCHETYPE_HRID` of the served artefact.",
          content((String = "text/plain"), (serde_json::Value = "application/json"))),
         (status = 404, description = "No template with `template_id`.",
          body = serde_json::Value),
@@ -470,7 +473,10 @@ pub(crate) async fn definition_template_adl2_example_get(
     responses(
         (status = 200, description = "The operational template at `version` — \
                                       `text/plain` ADL2 source or \
-                                      `application/json` `OperationalTemplateV2`.",
+                                      `application/json` `OperationalTemplateV2`; \
+                                      `ETag` (weak `W/` form) carries the \
+                                      RESOLVED `ARCHETYPE_HRID`, not the \
+                                      addressed prefix.",
          content((String = "text/plain"), (serde_json::Value = "application/json"))),
         (status = 404, description = "No template with `template_id` at `version`.",
          body = serde_json::Value),

--- a/app/ehrbase-rest/src/api/definition/template_adl14.rs
+++ b/app/ehrbase-rest/src/api/definition/template_adl14.rs
@@ -190,13 +190,11 @@ pub(super) async fn example_get(
 /// (`headers/ETag_Template_adl1_4.yaml`: `W/"<id>"`). Keyed on the
 /// `template_id` string, matching the upload path so a client's `If-None-Match`
 /// round-trips. The weak-form construction goes through the shared
-/// [`negotiate::resource_etag`] helper (overview §"Deprecated headers": a
+/// [`negotiate::set_etag`] helper (overview §"Deprecated headers": a
 /// resource-identifier `ETag` MUST carry the `W/` weakness indicator), so the
 /// upload and this GET share one implementation of the `W/"…"` format.
 fn set_template_etag(resp: &mut Response, template_id: &str) {
-    if let Some(v) = negotiate::resource_etag(template_id) {
-        resp.headers_mut().insert(header::ETAG, v);
-    }
+    negotiate::set_etag(resp, template_id);
 }
 
 /// Render the `201_Template_adl1_4_upload` response per `Prefer`:

--- a/app/ehrbase-rest/src/api/definition/template_adl2.rs
+++ b/app/ehrbase-rest/src/api/definition/template_adl2.rs
@@ -105,8 +105,10 @@ pub(super) async fn upload(state: &AppState, parts: &RequestParts) -> Result<Res
     );
     // 201_Template_adl2_upload: body per `Prefer` — representation → the OPT
     // source (text/plain); identifier → `{template_id}` (JSON); missing/minimal
-    // → empty. `Location` on every case.
-    Ok(upload_response(prefer.as_deref(), &location, hrid, source))
+    // → empty. `Location` + the weak `ETag` on every case.
+    let mut resp = upload_response(prefer.as_deref(), &location, hrid, source);
+    set_template_etag(&mut resp, hrid);
+    Ok(resp)
 }
 
 /// `GET …/definition/template/adl2/{template_id}` — the stored operational
@@ -200,6 +202,22 @@ pub(super) async fn example_get(
     }
 }
 
+/// Set the weak `ETag` of a served ADL2 template. The value is the artefact's
+/// **resolved** `ARCHETYPE_HRID` (AM `am24` — the HRID carries the artefact's
+/// SEMVER `release_version`, so it changes whenever the served artefact does),
+/// mirroring the ADL 1.4 sibling's `template_id` `ETag`.
+///
+/// ITS-REST `Requests_and_responses.md` §"`ETag` and Last-Modified": both
+/// headers "SHOULD be included in responses for VERSION, `VERSIONED_OBJECT`, or
+/// other resources that have versioning or unique state identifiers", and the
+/// `ETag` "is considered to be of weak-type and should have a weakness
+/// indicator `W/` prefix" — constructed by the shared
+/// [`negotiate::set_etag`] helper so upload and GET share one
+/// implementation.
+fn set_template_etag(resp: &mut Response, hrid: &str) {
+    negotiate::set_etag(resp, hrid);
+}
+
 /// Resolve + render one ADL2 template in the `Accept`-negotiated representation.
 async fn render(
     state: &AppState,
@@ -209,18 +227,22 @@ async fn render(
 ) -> Result<Response, RestError> {
     match negotiate_get(headers) {
         Some(Adl2Repr::Source) => {
-            let source = state
+            let template = state
                 .backend()
                 .template_adl2_source(template_id, version)
                 .await?;
-            Ok(text_response(StatusCode::OK, None, source))
+            let mut resp = text_response(StatusCode::OK, None, template.payload);
+            set_template_etag(&mut resp, &template.hrid);
+            Ok(resp)
         }
         Some(Adl2Repr::Json) => {
-            let json = state
+            let template = state
                 .backend()
                 .template_adl2_opt_json(template_id, version)
                 .await?;
-            Ok(json_response(StatusCode::OK, json))
+            let mut resp = json_response(StatusCode::OK, template.payload);
+            set_template_etag(&mut resp, &template.hrid);
+            Ok(resp)
         }
         None => Err(RestError(ApiError::NotAcceptable(
             "the ADL2 template is served as text/plain source or application/json \

--- a/app/ehrbase-rest/src/api/demographic/mod.rs
+++ b/app/ehrbase-rest/src/api/demographic/mod.rs
@@ -123,9 +123,9 @@ fn if_match_of(h: &HeaderMap) -> Option<String> {
 /// `DELETE` responses alike. Writes add it through [`set_write_headers`].
 fn set_versioning_headers(resp: &mut Response, meta: Option<&ResourceMeta>) {
     let Some(meta) = meta else { return };
-    if let Ok(etag) = HeaderValue::from_str(&format!("W/\"{}\"", meta.uid)) {
-        resp.headers_mut().insert(header::ETAG, etag);
-    }
+    // The weak-form construction is shared with the EHR/definition surfaces so
+    // there is one implementation of the `W/"…"` shape in the adapter.
+    crate::overview::negotiate::set_etag(resp, &meta.uid);
     if let Some(at) = meta.last_modified
         && let Ok(lm) = HeaderValue::from_str(&crate::overview::negotiate::http_date(at))
     {

--- a/app/ehrbase-rest/src/api/ehr/composition.rs
+++ b/app/ehrbase-rest/src/api/ehr/composition.rs
@@ -23,6 +23,7 @@ use openehr_rm::prelude::Composition;
 
 use ehrbase::ids::{EhrId, VoId};
 use ehrbase::service::response::{ResourceMeta, ServiceResponse};
+use ehrbase::versioning::change::Committed;
 
 use crate::api::RequestParts;
 use crate::negotiate::WireFormat;
@@ -100,19 +101,21 @@ pub(super) async fn run(
                 "COMPOSITION creation",
                 None,
             );
-            let uid = state
+            let committed = state
                 .backend()
                 .create_composition(ehr_id, uv)
                 .await
-                .map_err(|e| RestError::from(ApiError::from(e)))?
-                .version_uid();
+                .map_err(|e| RestError::from(ApiError::from(e)))?;
+            let uid = committed.version_uid();
             // apply the openehr-item-tag / openehr-version-item-tag
             // write-wrapper headers to the committed COMPOSITION
             // (Requests_and_responses.md §…§Usage in Requests).
             let stored_tags =
                 super::apply_item_tag_headers(&state, ehr_id, "COMPOSITION", &uid, h).await?;
+            let meta = commit_meta(ehr_id, uid, &committed);
             let mut resp =
-                composition_write_response(&state, h, &base, ehr_id, uid, created, created).await?;
+                composition_write_response(&state, h, &base, ehr_id, meta, created, created)
+                    .await?;
             if let Some((names, tags)) = stored_tags {
                 super::echo_item_tags(&mut resp, &names, &tags);
             }
@@ -122,22 +125,29 @@ pub(super) async fn run(
             let p = params::build::<CompositionGetParams>(&parts.path, q, h)?;
             let ehr_id = parse_ehr_id(&p.ehr_id)?;
             let uid = parse_uid_based_id(&p.uid_based_id)?;
-            let body = if let Some(ovid) = uid.version {
+            // The service returns the read PLUS its version metadata (uid +
+            // commit instant): the served body is a BARE COMPOSITION, which
+            // carries no `commit_audit`, so the `Last-Modified` instant the
+            // spec derives from `VERSION.commit_audit.time_committed.value`
+            // (Requests_and_responses.md §"ETag and Last-Modified") can only
+            // come from the version row the service already read.
+            let read = if let Some(ovid) = uid.version {
                 state
                     .backend()
-                    .get_composition_at_version(ehr_id, ovid)
+                    .composition_at_version_response(ehr_id, ovid)
                     .await?
             } else if p.version_at_time.is_some() {
                 state
                     .backend()
-                    .get_composition_at_time(ehr_id, uid.vo_id, p.version_at_time)
+                    .composition_at_time_response(ehr_id, uid.vo_id, p.version_at_time)
                     .await?
             } else {
                 state
                     .backend()
-                    .get_composition_latest(ehr_id, uid.vo_id)
+                    .composition_latest_response(ehr_id, uid.vo_id)
                     .await?
             };
+            let ServiceResponse { mut body, meta } = read;
             // A deleted version resolves to a null body → 204 No Content
             // (composition_get.yaml `204_because_deleted*`).
             if body.is_null() {
@@ -148,29 +158,42 @@ pub(super) async fn run(
             // when externalization is off or the body has no external media.
             // Not an openEHR spec parameter, so read off the raw query string
             // (the `template_id` precedent), never a generated params struct.
-            let body = if params::query_param(q, "expand_multimedia").as_deref() == Some("true") {
-                state.backend().expand_multimedia(body).await?
-            } else {
-                body
-            };
+            if params::query_param(q, "expand_multimedia").as_deref() == Some("true") {
+                body = state.backend().expand_multimedia(body).await?;
+            }
             // Negotiate the representation across `Accept_LOCATABLE`: FLAT /
             // STRUCTURED via the adapter, else canonical JSON/XML through
             // `read_rm` (which answers 406 for an unfulfillable Accept).
+            // The version-identity headers are representation-independent —
+            // "the `ETag` value is independent of its resource serialization
+            // format (JSON/XML)" (§"ETag and Last-Modified") — so the
+            // simplified representations carry them too.
             match negotiate::resolve_accept(h, COMPOSITION_FORMATS, WireFormat::CanonicalJson) {
                 Some(WireFormat::Flat) => {
-                    return crate::formats::dispatch::composition_flat_response(&state, ok, &body)
-                        .await;
+                    let mut out =
+                        crate::formats::dispatch::composition_flat_response(&state, ok, &body)
+                            .await?;
+                    if let Some(meta) = &meta {
+                        negotiate::set_versioning_headers(&mut out, meta);
+                    }
+                    return Ok(out);
                 }
                 Some(WireFormat::Structured) => {
-                    return crate::formats::dispatch::composition_structured_response(
+                    let mut out = crate::formats::dispatch::composition_structured_response(
                         &state, ok, &body,
                     )
-                    .await;
+                    .await?;
+                    if let Some(meta) = &meta {
+                        negotiate::set_versioning_headers(&mut out, meta);
+                    }
+                    return Ok(out);
                 }
                 _ => {}
             }
-            // 200_COMPOSITION_retrieved: ETag(version_uid) + Location.
-            let resp = super::read_resp(&p.ehr_id, body);
+            // 200_COMPOSITION_retrieved: ETag(version_uid) + Last-Modified
+            // (§"ETag and Last-Modified": both SHOULD accompany a resource
+            // with a unique state identifier).
+            let resp = ServiceResponse { body, meta };
             Ok(negotiate::read_rm::<Composition>(
                 h,
                 &base,
@@ -215,16 +238,16 @@ pub(super) async fn run(
                 .backend()
                 .update_composition(ehr_id, uid.vo_id, uv)
                 .await
-                .map(|c| c.version_uid())
             {
-                Ok(new_uid) => {
+                Ok(committed) => {
+                    let new_uid = committed.version_uid();
                     // apply item-tag write-wrapper headers to the new version.
                     let stored_tags =
                         super::apply_item_tag_headers(&state, ehr_id, "COMPOSITION", &new_uid, h)
                             .await?;
+                    let meta = commit_meta(ehr_id, new_uid, &committed);
                     let mut resp =
-                        composition_write_response(&state, h, &base, ehr_id, new_uid, ok, ok)
-                            .await?;
+                        composition_write_response(&state, h, &base, ehr_id, meta, ok, ok).await?;
                     if let Some((names, tags)) = stored_tags {
                         super::echo_item_tags(&mut resp, &names, &tags);
                     }
@@ -268,11 +291,15 @@ pub(super) async fn run(
                 .backend()
                 .delete_composition(ehr_id, &ovid, update_audit.as_ref())
                 .await
-                .map(|c| c.version_uid())
             {
-                Ok(uid) => {
-                    // 204_COMPOSITION_deleted: ETag + Location of the deleted version.
-                    let resp = ServiceResponse::deleted(ResourceMeta::new(p.ehr_id, uid));
+                Ok(committed) => {
+                    // 204_COMPOSITION_deleted: the deleted version's ETag +
+                    // Last-Modified — a logical delete commits a
+                    // `523|deleted|` VERSION, so its commit instant is the
+                    // resource's last modification (§"ETag and
+                    // Last-Modified"; RM common master06 §Logical Deletion).
+                    let uid = committed.version_uid();
+                    let resp = ServiceResponse::deleted(commit_meta(ehr_id, uid, &committed));
                     Ok(negotiate::deleted_with_headers(
                         &base,
                         Some("composition"),
@@ -340,26 +367,35 @@ pub(super) async fn run(
     }
 }
 
+/// The committed COMPOSITION version's [`ResourceMeta`]: the new
+/// `OBJECT_VERSION_ID` (the `ETag`/`Location` value) plus the server commit
+/// instant the commit result already carries — the `Last-Modified` value
+/// ITS-REST derives from `VERSION.commit_audit.time_committed.value`
+/// (`Requests_and_responses.md` §"`ETag` and Last-Modified"). Taken from the
+/// commit result, never re-read.
+fn commit_meta(ehr_id: EhrId, uid: String, committed: &Committed) -> ResourceMeta {
+    ResourceMeta::new(ehr_id.to_string(), uid).with_last_modified(committed.time_committed)
+}
+
 /// Render a COMPOSITION create/update response: FLAT/STRUCTURED interop bodies
 /// when requested (always the representation), else the canonical
-/// `ETag`/`Location` + `Prefer` write response.
+/// `ETag`/`Last-Modified`/`Location` + `Prefer` write response.
 async fn composition_write_response(
     state: &AppState,
     h: &http::HeaderMap,
     base: &str,
     ehr_id: EhrId,
-    uid: String,
+    meta: ResourceMeta,
     minimal: StatusCode,
     repr: StatusCode,
 ) -> Result<Response, RestError> {
-    let ehr_id_str = ehr_id.to_string();
     // A FLAT/STRUCTURED Accept returns the simplified representation (which
     // needs the stored body regardless of `Prefer`); canonical JSON/XML (or an
     // unfulfillable Accept) fall through to the `Prefer`-aware canonical write.
     if let Some(fmt @ (WireFormat::Flat | WireFormat::Structured)) =
         negotiate::resolve_accept(h, COMPOSITION_FORMATS, WireFormat::CanonicalJson)
     {
-        let ovid = parse_version_uid(&uid)?;
+        let ovid = parse_version_uid(&meta.uid)?;
         let body = state
             .backend()
             .get_composition_at_version(ehr_id, ovid)
@@ -380,12 +416,11 @@ async fn composition_write_response(
         // `specifications/docs/overview/Requests_and_responses.md` §Prefer).
         // Route through the same header helper the canonical write uses, as
         // the CONTRIBUTION simplified-commit path already does.
-        let meta = ResourceMeta::new(ehr_id_str, uid);
         negotiate::set_resource_headers(&mut out, base, Some("composition"), &meta);
         return Ok(out);
     }
     let body = if negotiate::prefers_representation(h) {
-        let ovid = parse_version_uid(&uid)?;
+        let ovid = parse_version_uid(&meta.uid)?;
         state
             .backend()
             .get_composition_at_version(ehr_id, ovid)
@@ -393,7 +428,7 @@ async fn composition_write_response(
     } else {
         Value::Null
     };
-    let resp = ServiceResponse::new(body, ResourceMeta::new(ehr_id_str, uid));
+    let resp = ServiceResponse::new(body, meta);
     Ok(negotiate::write_rm::<Composition>(
         h,
         base,

--- a/app/ehrbase-rest/src/api/ehr/ehr_resource.rs
+++ b/app/ehrbase-rest/src/api/ehr/ehr_resource.rs
@@ -46,27 +46,38 @@ pub(super) async fn run(
                 .backend()
                 .ehr_object_for_subject(&p.subject_id, &p.subject_namespace)
                 .await?;
-            // 200_EHR: no ETag/Location declared for EHR retrieval.
-            Ok(negotiate::respond_rm::<Ehr>(h, ok, &body, "ehr"))
+            // 200_EHR: the weak ETag off `EHR.ehr_id.value` — the ITS-REST
+            // overview's own example source for a resource with a unique
+            // state identifier (Requests_and_responses.md §"ETag and
+            // Last-Modified": the value "is usually taken from e.g.
+            // VERSIONED_OBJECT.uid.value, VERSION.uid.value,
+            // EHR.ehr_id.value"). No Location on a GET (§Location).
+            Ok(ehr_read_response(h, ok, &body))
         }
         "ehr_create" => {
             let _p = params::build::<EhrCreateParams>(&parts.path, q, h)?;
             let status = negotiate::optional_rm_value::<EhrStatus>(h, &parts.body)?;
-            let ehr_id = state.backend().create_ehr(status).await?;
-            ehr_write_response(&state, h, &base, ehr_id).await
+            // The service returns the created EHR's own resource metadata
+            // (ehr_id + creation instant) — the write path never rebuilds a
+            // metadata-less envelope, so `Last-Modified` survives to the wire.
+            let (ehr_id, meta) = state.backend().create_ehr_meta(status).await?;
+            ehr_write_response(&state, h, &base, ehr_id, meta).await
         }
         "ehr_create_with_id" => {
             let p = params::build::<EhrCreateWithIdParams>(&parts.path, q, h)?;
             let ehr_id = parse_ehr_id(&p.ehr_id)?;
             let status = negotiate::optional_rm_value::<EhrStatus>(h, &parts.body)?;
-            let ehr_id = state.backend().create_ehr_with_id(ehr_id, status).await?;
-            ehr_write_response(&state, h, &base, ehr_id).await
+            let meta = state
+                .backend()
+                .create_ehr_with_id_meta(ehr_id, status)
+                .await?;
+            ehr_write_response(&state, h, &base, ehr_id, meta).await
         }
         "ehr_get_by_id" => {
             let p = params::build::<EhrGetByIdParams>(&parts.path, q, h)?;
             let ehr_id = parse_ehr_id(&p.ehr_id)?;
             let body = state.backend().ehr_object(ehr_id).await?;
-            Ok(negotiate::respond_rm::<Ehr>(h, ok, &body, "ehr"))
+            Ok(ehr_read_response(h, ok, &body))
         }
         "ehr_tags_get" => {
             let p = params::build::<EhrTagsGetParams>(&parts.path, q, h)?;
@@ -83,15 +94,39 @@ pub(super) async fn run(
     }
 }
 
-/// Render an EHR create response (`201_EHR)`: `ETag(ehr_id)` + `Location`, with the
-/// RM `EHR` body only on `Prefer: return=representation`.
+/// Render an EHR read (`200_EHR`) with the weak `ETag` carrying
+/// `EHR.ehr_id.value` — the ITS-REST overview §"`ETag` and Last-Modified"
+/// example source, and a resource with a unique state identifier, for which
+/// the `ETag` SHOULD be present.
+///
+/// No `Last-Modified`: the RM `EHR` root is not a VERSION and has no
+/// `commit_audit`, and the spec derives the header from
+/// `VERSION.commit_audit.time_committed.value`. `EHR.time_created` is the
+/// creation instant, not the last modification (the served body changes with
+/// every `EHR_STATUS`/directory commit), so emitting it here would be wrong.
+fn ehr_read_response(h: &http::HeaderMap, status: StatusCode, body: &Value) -> Response {
+    let mut out = negotiate::respond_rm::<Ehr>(h, status, body, "ehr");
+    if let Some(id) = body["ehr_id"]["value"].as_str() {
+        negotiate::set_etag(&mut out, id);
+    }
+    out
+}
+
+/// Render an EHR create response (`201_EHR)`: `ETag(ehr_id)` +
+/// `Last-Modified` + `Location`, with the RM `EHR` body only on
+/// `Prefer: return=representation`.
+///
+/// `meta` comes straight from the service create (the `ehr_id` plus the
+/// creating CONTRIBUTION's commit instant), so the `Last-Modified` the
+/// ITS-REST overview §"`ETag` and Last-Modified" asks for is not lost between
+/// the commit and the wire.
 async fn ehr_write_response(
     state: &AppState,
     h: &http::HeaderMap,
     base: &str,
     ehr_id: EhrId,
+    meta: ResourceMeta,
 ) -> Result<Response, RestError> {
-    let ehr_id_str = ehr_id.to_string();
     let body = if negotiate::prefers_representation(h) {
         // `ehr_created_object` serves the just-committed EHR body from the
         // create-time stash (built from the commit results), avoiding the
@@ -100,7 +135,7 @@ async fn ehr_write_response(
     } else {
         Value::Null
     };
-    let resp = ServiceResponse::new(body, ResourceMeta::new(ehr_id_str.clone(), ehr_id_str));
+    let resp = ServiceResponse::new(body, meta);
     Ok(negotiate::write_rm::<Ehr>(
         h,
         base,

--- a/app/ehrbase-rest/src/api/ehr/ehr_status.rs
+++ b/app/ehrbase-rest/src/api/ehr/ehr_status.rs
@@ -16,7 +16,7 @@ use openehr_its::rest::generated::ehr::{
 use openehr_its::rest::runtime::ApiError;
 use openehr_rm::prelude::EhrStatus;
 
-use ehrbase::service::response::{ResourceMeta, ServiceResponse};
+use ehrbase::service::response::ServiceResponse;
 use ehrbase::service::status::CallStatusType;
 
 use crate::api::RequestParts;
@@ -47,18 +47,22 @@ pub(super) async fn run(
             let ehr_id = parse_ehr_id(&p.ehr_id)?;
             let (vo_id, version) = super::version_components(&parse_version_uid(&p.version_uid)?)?;
             // the bare EHR_STATUS at that version (not ORIGINAL_VERSION);
-            // 200_EHR_STATUS_retrieved: ETag(version_uid) + Location.
-            let body = state
+            // 200_EHR_STATUS_retrieved: ETag(version_uid) + Last-Modified.
+            // The bare EHR_STATUS carries no commit_audit, so the commit
+            // instant the spec derives Last-Modified from
+            // (`VERSION.commit_audit.time_committed.value`,
+            // Requests_and_responses.md §"ETag and Last-Modified") comes from
+            // the service's version metadata, not the served body.
+            let resp = state
                 .backend()
-                .get_ehr_status_at_version(ehr_id, ehrbase::ids::VoId(vo_id), &version)
+                .ehr_status_at_version_response(ehr_id, ehrbase::ids::VoId(vo_id), &version)
                 .await?;
             // The addressed version_uid must equal the served version's full
             // three-part identity, case-insensitively (ITS-REST overview
             // Resources.md §Identifier types; BASE master05 §Composite
             // Identifiers and Case) — a fabricated creating_system_id names
             // no VERSION here.
-            super::ensure_served_version(&p.version_uid, &body)?;
-            let resp = ServiceResponse::new(body, ResourceMeta::new(p.ehr_id, p.version_uid));
+            super::ensure_served_version(&p.version_uid, &resp.body)?;
             Ok(negotiate::read_rm::<EhrStatus>(
                 h,
                 &base,
@@ -70,11 +74,13 @@ pub(super) async fn run(
         "ehr_status_get_at_time" => {
             let p = params::build::<EhrStatusGetAtTimeParams>(&parts.path, q, h)?;
             let ehr_id = parse_ehr_id(&p.ehr_id)?;
-            let body = state
+            // Same derivation as the by-version read: the bare EHR_STATUS has
+            // no commit_audit, so the version metadata carries the
+            // Last-Modified instant (§"ETag and Last-Modified").
+            let resp = state
                 .backend()
-                .get_ehr_status_at_time(ehr_id, p.version_at_time)
+                .ehr_status_at_time_response(ehr_id, p.version_at_time)
                 .await?;
-            let resp = super::read_resp(&p.ehr_id, body);
             Ok(negotiate::read_rm::<EhrStatus>(
                 h,
                 &base,
@@ -95,21 +101,25 @@ pub(super) async fn run(
                 Some(require_if_match(&p.if_match)?),
             );
             // 204_EHR_STATUS (default minimal) / 200_EHR_STATUS_updated
-            // (representation); ETag + Location on both. 412 → latest version_uid.
-            match state.backend().replace_ehr_status(ehr_id, uv).await {
-                Ok(uid) => {
+            // (representation); ETag + Last-Modified + Location on all.
+            // The commit result's instant is the Last-Modified value
+            // (§"ETag and Last-Modified"), carried in the service metadata so
+            // the write path never re-reads the row it just wrote.
+            // 412 → latest version_uid.
+            match state.backend().replace_ehr_status_meta(ehr_id, uv).await {
+                Ok(meta) => {
                     // apply the openehr-item-tag / openehr-version-item-tag
                     // write-wrapper headers to the committed target
                     // (Requests_and_responses.md §…§Usage in Requests).
                     let stored_tags =
-                        super::apply_item_tag_headers(&state, ehr_id, "EHR_STATUS", &uid, h)
+                        super::apply_item_tag_headers(&state, ehr_id, "EHR_STATUS", &meta.uid, h)
                             .await?;
                     let repr = if negotiate::prefers_representation(h) {
                         state.backend().get_ehr_status(ehr_id).await?
                     } else {
                         Value::Null
                     };
-                    let resp = ServiceResponse::new(repr, ResourceMeta::new(p.ehr_id, uid));
+                    let resp = ServiceResponse::new(repr, meta);
                     let mut resp = negotiate::write_rm::<EhrStatus>(
                         h,
                         &base,

--- a/app/ehrbase-rest/src/api/ehr/mod.rs
+++ b/app/ehrbase-rest/src/api/ehr/mod.rs
@@ -69,16 +69,47 @@ pub(super) const CHANGE_MODIFICATION: &str = "251";
 pub(super) const LIFECYCLE_COMPLETE: &str = "532";
 
 /// The `uid`/`value` of a returned RM object → the resource metadata a read
-/// with an `ETag`/`Location` needs (the version id is the object's own `uid`).
+/// with an `ETag`/`Last-Modified` needs (the version id is the object's own
+/// `uid`).
+///
+/// When the served body is a VERSION envelope (an `ORIGINAL_VERSION`), its
+/// `commit_audit.time_committed` is also read as the `Last-Modified` instant:
+/// ITS-REST overview `Requests_and_responses.md` §"`ETag` and Last-Modified"
+/// — "For openEHR resources, this value should be derived from
+/// `VERSION.commit_audit.time_committed.value`" — and both headers "SHOULD be
+/// included in responses for VERSION, `VERSIONED_OBJECT`, or other resources
+/// that have versioning or unique state identifiers".
+///
+/// A bare RM body (a COMPOSITION / `EHR_STATUS`, or a `VERSIONED_OBJECT`
+/// container) carries no commit audit; those routes take their metadata from
+/// the service layer instead, which reads the commit instant off the version
+/// row.
 fn resource_meta_from(ehr_id: &str, body: &Value) -> Option<ResourceMeta> {
-    body.get("uid")
+    let uid = body
+        .get("uid")
         .and_then(|u| u.get("value"))
-        .and_then(Value::as_str)
-        .map(|uid| ResourceMeta::new(ehr_id.to_owned(), uid.to_owned()))
+        .and_then(Value::as_str)?;
+    let meta = ResourceMeta::new(ehr_id.to_owned(), uid.to_owned());
+    Some(match commit_instant(body) {
+        Some(at) => meta.with_last_modified(at),
+        None => meta,
+    })
+}
+
+/// The commit instant of a served VERSION envelope —
+/// `VERSION.commit_audit.time_committed.value` (RM common master04
+/// §Audit Details; the `Last-Modified` source named by ITS-REST overview
+/// §"`ETag` and Last-Modified"). `None` for a body that is not a VERSION.
+fn commit_instant(body: &Value) -> Option<jiff::Timestamp> {
+    body["commit_audit"]["time_committed"]["value"]
+        .as_str()?
+        .parse::<jiff::Timestamp>()
+        .ok()
 }
 
 /// Wrap a read body as a [`ServiceResponse`], attaching resource metadata drawn
-/// from the body's own `uid` when present.
+/// from the body's own `uid` (and, for a VERSION envelope, its commit instant)
+/// when present.
 pub(super) fn read_resp(ehr_id: &str, body: Value) -> ServiceResponse {
     match resource_meta_from(ehr_id, &body) {
         Some(m) => ServiceResponse::new(body, m),

--- a/app/ehrbase-rest/src/api/ehr/openapi_routes.rs
+++ b/app/ehrbase-rest/src/api/ehr/openapi_routes.rs
@@ -77,7 +77,9 @@ pub(crate) fn routes() -> OpenApiRouter<AppState> {
                         EHR_STATUS.subject.external_ref.namespace). Required.")
     ),
     responses(
-        (status = 200, description = "The EHR (canonical JSON/XML per `Accept`).",
+        (status = 200, description = "The EHR (canonical JSON/XML per `Accept`); \
+                                      `ETag` (weak `W/` form) carries \
+                                      `EHR.ehr_id.value`.",
          body = serde_json::Value),
         (status = 400, description = "A required subject query parameter is \
                                       missing or malformed.",
@@ -119,7 +121,8 @@ pub(crate) async fn ehr_get_by_subject(
                                 is_modifiable=true, PARTY_SELF subject) is used."),
     responses(
         (status = 201, description = "Created; `ETag` (weak `W/` form) carries \
-                                      the new `ehr_id`, `Location` the EHR URL. \
+                                      the new `ehr_id`, `Last-Modified` the \
+                                      creation instant, `Location` the EHR URL. \
                                       Body per `Prefer` (representation or \
                                       identifier; empty for minimal).",
          body = serde_json::Value),
@@ -151,7 +154,9 @@ pub(crate) async fn ehr_create(
     params(("ehr_id" = String, Path,
             description = "EHR identifier, taken from EHR.ehr_id.value (a UUID).")),
     responses(
-        (status = 200, description = "The EHR (canonical JSON/XML per `Accept`).",
+        (status = 200, description = "The EHR (canonical JSON/XML per `Accept`); \
+                                      `ETag` (weak `W/` form) carries \
+                                      `EHR.ehr_id.value`.",
          body = serde_json::Value),
         (status = 404, description = "No EHR exists with `ehr_id`.",
          body = serde_json::Value)
@@ -193,8 +198,9 @@ pub(crate) async fn ehr_get_by_id(
                                 is_modifiable=true, PARTY_SELF subject) is used."),
     responses(
         (status = 201, description = "Created; `ETag` (weak `W/` form) carries \
-                                      the `ehr_id`, `Location` the EHR URL. Body \
-                                      per `Prefer` (representation or identifier; \
+                                      the `ehr_id`, `Last-Modified` the creation \
+                                      instant, `Location` the EHR URL. Body per \
+                                      `Prefer` (representation or identifier; \
                                       empty for minimal).",
          body = serde_json::Value),
         (status = 400, description = "`ehr_id` is not a valid `HIER_OBJECT_ID` or \
@@ -330,11 +336,13 @@ pub(crate) async fn ehr_status_get_at_time(
         (status = 200, description = "Updated; body per `Prefer` \
                                       (representation or identifier). `ETag` \
                                       (weak `W/` form) + `Location` carry the \
-                                      new version.",
+                                      new version, `Last-Modified` its commit \
+                                      time.",
          body = serde_json::Value),
         (status = 204, description = "Updated (`Prefer: return=minimal`); `ETag` \
                                       (weak `W/` form) + `Location` carry the \
-                                      new version."),
+                                      new version, `Last-Modified` its commit \
+                                      time."),
         (status = 400, description = "Invalid EHR_STATUS, or `If-Match` expected \
                                       but missing/malformed.",
          body = serde_json::Value),
@@ -433,7 +441,9 @@ pub(crate) async fn versioned_ehr_status_revision_history(
     responses(
         (status = 200, description = "The ORIGINAL_VERSION of the EHR_STATUS \
                                       (canonical JSON/XML); `ETag` (weak `W/` \
-                                      form) carries the version uid.",
+                                      form) carries the version uid, \
+                                      `Last-Modified` its `commit_audit` \
+                                      `time_committed`.",
          body = serde_json::Value),
         (status = 400, description = "Malformed `version_at_time`.",
          body = serde_json::Value),
@@ -470,7 +480,9 @@ pub(crate) async fn versioned_ehr_status_version_get_at_time(
     responses(
         (status = 200, description = "The ORIGINAL_VERSION of the EHR_STATUS \
                                       identified by `version_uid` (canonical \
-                                      JSON/XML).",
+                                      JSON/XML); `ETag` (weak `W/` form) carries \
+                                      the version uid, `Last-Modified` its \
+                                      `commit_audit` `time_committed`.",
          body = serde_json::Value),
         (status = 404, description = "Unknown `ehr_id`, or no VERSION with \
                                       `version_uid`.",
@@ -529,8 +541,9 @@ pub(crate) async fn versioned_ehr_status_version_get_by_id(
     responses(
         (
             status = 201, description = "Created; `ETag` (weak `W/` form) carries \
-                                        the new version uid, `Location` the \
-                                        COMPOSITION version URL. Body per `Prefer` \
+                                        the new version uid, `Last-Modified` its \
+                                        commit time, `Location` the COMPOSITION \
+                                        version URL. Body per `Prefer` \
                                         (representation or identifier; empty for \
                                         minimal). Item tags MAY be echoed in the \
                                         `openehr-item-tag`/\
@@ -656,14 +669,15 @@ pub(crate) async fn composition_get(
             status = 200, description = "Updated; body per `Prefer` \
                                         (representation or identifier). `ETag` \
                                         (weak `W/` form) + `Location` carry the \
-                                        new version. Item tags MAY be echoed in \
+                                        new version, `Last-Modified` its commit \
+                                        time. Item tags MAY be echoed in \
                                         the `openehr-item-tag`/\
                                         `openehr-version-item-tag` response headers.",
             content((serde_json::Value = "application/json"), (serde_json::Value = "application/xml"), (serde_json::Value = "application/openehr.wt.flat+json"), (serde_json::Value = "application/openehr.wt.structured+json"))
         ),
         (status = 204, description = "Updated (`Prefer: return=minimal`); `ETag` \
                                       (weak `W/` form) + `Location` carry the new \
-                                      version."),
+                                      version, `Last-Modified` its commit time."),
         (status = 400, description = "The COMPOSITION could not be parsed, a body \
                                       uid mismatches the path, or `If-Match` is \
                                       missing/malformed.",
@@ -713,7 +727,8 @@ pub(crate) async fn composition_update(
     responses(
         (status = 204, description = "Logically deleted (a new deleted version \
                                       is committed); `ETag` carries the deleted \
-                                      version uid."),
+                                      version uid and `Last-Modified` its commit \
+                                      time."),
         (status = 400, description = "`uid_based_id` is not an OBJECT_VERSION_ID, \
                                       or the COMPOSITION is already deleted.",
          body = serde_json::Value),
@@ -829,7 +844,9 @@ pub(crate) async fn versioned_composition_revision_history(
     responses(
         (status = 200, description = "The ORIGINAL_VERSION of the COMPOSITION \
                                       (canonical JSON/XML); `ETag` (weak `W/` \
-                                      form) carries the version uid.",
+                                      form) carries the version uid, \
+                                      `Last-Modified` its `commit_audit` \
+                                      `time_committed`.",
          body = serde_json::Value),
         (status = 400, description = "Malformed `version_at_time`.",
          body = serde_json::Value),
@@ -871,7 +888,9 @@ pub(crate) async fn versioned_composition_version_get_at_time(
     responses(
         (status = 200, description = "The ORIGINAL_VERSION of the COMPOSITION \
                                       identified by `version_uid` (canonical \
-                                      JSON/XML).",
+                                      JSON/XML); `ETag` (weak `W/` form) carries \
+                                      the version uid, `Last-Modified` its \
+                                      `commit_audit` `time_committed`.",
          body = serde_json::Value),
         (status = 404, description = "Unknown `ehr_id` or `versioned_object_uid`, \
                                       or no VERSION with `version_uid`.",

--- a/app/ehrbase-rest/src/api/ehr/versioned_composition.rs
+++ b/app/ehrbase-rest/src/api/ehr/versioned_composition.rs
@@ -82,6 +82,10 @@ pub(super) async fn run(
                 .backend()
                 .composition_version_at_time(ehr_id, ehrbase::ids::VoId(vo_id), p.version_at_time)
                 .await?;
+            // Version-uid ETag + Last-Modified from the envelope's
+            // commit_audit.time_committed (§"ETag and Last-Modified": the
+            // value "should be derived from
+            // VERSION.commit_audit.time_committed.value").
             let resp = super::read_resp(&p.ehr_id, body);
             // ORIGINAL_VERSION<COMPOSITION> — JSON or canonical XML.
             Ok(negotiate::read_rm::<OriginalVersion<Composition>>(
@@ -101,8 +105,10 @@ pub(super) async fn run(
                 .composition_original_version(ehr_id, ovid)
                 .await?;
             // ORIGINAL_VERSION<COMPOSITION> — JSON or canonical XML, with the
-            // version-uid ETag + commit-time Last-Modified (§ETag and
-            // Last-Modified SHOULD on VERSION reads).
+            // version-uid ETag + Last-Modified from the envelope's
+            // commit_audit.time_committed (§"ETag and Last-Modified": both
+            // SHOULD accompany a VERSION response, and Last-Modified is
+            // "derived from VERSION.commit_audit.time_committed.value").
             let resp = super::read_resp(&p.ehr_id, body);
             Ok(negotiate::read_rm::<OriginalVersion<Composition>>(
                 h,

--- a/app/ehrbase-rest/src/api/ehr/versioned_ehr_status.rs
+++ b/app/ehrbase-rest/src/api/ehr/versioned_ehr_status.rs
@@ -81,8 +81,12 @@ pub(super) async fn run(
                 .backend()
                 .ehr_status_version_at_time(ehr_id, p.version_at_time)
                 .await?;
-            // 200_VERSION_at_time: ETag(version_uid) + Location of the VERSION;
-            // body is an ORIGINAL_VERSION<EHR_STATUS> (JSON or canonical XML).
+            // 200_VERSION_at_time: ETag(version_uid) + Location of the VERSION,
+            // plus Last-Modified from the envelope's
+            // commit_audit.time_committed (§"ETag and Last-Modified": the
+            // value "should be derived from
+            // VERSION.commit_audit.time_committed.value"); body is an
+            // ORIGINAL_VERSION<EHR_STATUS> (JSON or canonical XML).
             let resp = super::read_resp(&p.ehr_id, body);
             Ok(negotiate::read_rm::<OriginalVersion<EhrStatus>>(
                 h,
@@ -103,8 +107,10 @@ pub(super) async fn run(
             // Full-identity check as on the ehr_status by-version read
             // (Resources.md §Identifier types; BASE master05 case rule).
             super::ensure_served_version(&p.version_uid, &body)?;
-            // Version-uid ETag + commit-time Last-Modified (§ETag and
-            // Last-Modified SHOULD on VERSION reads).
+            // Version-uid ETag + Last-Modified from the envelope's
+            // commit_audit.time_committed (§"ETag and Last-Modified": both
+            // SHOULD accompany a VERSION response, and Last-Modified is
+            // "derived from VERSION.commit_audit.time_committed.value").
             let resp = super::read_resp(&p.ehr_id, body);
             Ok(negotiate::read_rm::<OriginalVersion<EhrStatus>>(
                 h,

--- a/app/ehrbase-rest/src/overview/negotiate.rs
+++ b/app/ehrbase-rest/src/overview/negotiate.rs
@@ -577,12 +577,20 @@ pub(crate) fn resource_etag(uid: &str) -> Option<HeaderValue> {
     HeaderValue::from_str(&format!("W/\"{uid}\"")).ok()
 }
 
+/// Set the weak `ETag` of a resource identifier on a response (overview
+/// §"`ETag` and Last-Modified" — the value "is usually taken from e.g.
+/// `VERSIONED_OBJECT.uid.value`, `VERSION.uid.value`, `EHR.ehr_id.value`").
+/// The single place the `W/"…"` header is written.
+pub(crate) fn set_etag(resp: &mut Response, uid: &str) {
+    if let Some(etag) = resource_etag(uid) {
+        resp.headers_mut().insert(header::ETAG, etag);
+    }
+}
+
 /// Set the versioning headers on a response: the weak `ETag` and — when the
 /// metadata carries a commit time — `Last-Modified`. No `Location`.
 pub(crate) fn set_versioning_headers(resp: &mut Response, meta: &ResourceMeta) {
-    if let Some(etag) = resource_etag(&meta.uid) {
-        resp.headers_mut().insert(header::ETAG, etag);
-    }
+    set_etag(resp, &meta.uid);
     if let Some(at) = meta.last_modified
         && let Ok(lm) = HeaderValue::from_str(&http_date(at))
     {

--- a/app/ehrbase-rest/tests/definition_adl2_http.rs
+++ b/app/ehrbase-rest/tests/definition_adl2_http.rs
@@ -452,3 +452,78 @@ async fn upload_invalid_source_is_422_with_rule_codes() {
         "the rule code VARD is reported in the 422 body: {errors:?}"
     );
 }
+
+/// ITS-REST overview `Requests_and_responses.md` §"`ETag` and Last-Modified":
+/// "Both `ETag` and `Last-Modified` SHOULD be included in responses for
+/// VERSION, `VERSIONED_OBJECT`, or other resources that have versioning or
+/// unique state identifiers", and the `ETag` "is considered to be of weak-type
+/// and should have a weakness indicator `W/` prefix". An ADL2 operational
+/// template's unique state identifier is its versioned `ARCHETYPE_HRID`, so
+/// the upload `201` and every retrieval carry `W/"<hrid>"` — the ADL 1.4
+/// sibling's behaviour, which the ADL2 routes previously omitted.
+///
+/// A partially addressed template (`…/{concept_family}/1`) resolves to a
+/// concrete artefact, so the `ETag` names the RESOLVED full HRID, not the
+/// addressed prefix — otherwise one `ETag` would span two different versions.
+#[tokio::test]
+async fn etag_is_the_resolved_hrid_on_upload_and_every_get() {
+    let (_pg, app) = app().await;
+    let expected = format!("W/\"{HRID}\"");
+
+    let (status, headers, _b) = send(&app, upload_req(None)).await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(
+        headers.get(header::ETAG).and_then(|v| v.to_str().ok()),
+        Some(expected.as_str()),
+        "overview §\"ETag and Last-Modified\": the weak ETag SHOULD accompany a \
+         resource with a unique state identifier (the template HRID)"
+    );
+
+    // text/plain source GET.
+    let req = Request::builder()
+        .method("GET")
+        .uri(format!("{BASE}/definition/template/adl2/{HRID}"))
+        .body(Body::empty())
+        .unwrap();
+    let (status, headers, _b) = send(&app, req).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        headers.get(header::ETAG).and_then(|v| v.to_str().ok()),
+        Some(expected.as_str()),
+        "overview §\"ETag and Last-Modified\": the source GET carries the weak ETag"
+    );
+
+    // application/json OperationalTemplateV2 GET — the ETag "is independent of
+    // its resource serialization format" (same section).
+    let req = Request::builder()
+        .method("GET")
+        .uri(format!("{BASE}/definition/template/adl2/{HRID}"))
+        .header(header::ACCEPT, "application/json")
+        .body(Body::empty())
+        .unwrap();
+    let (status, headers, _b) = send(&app, req).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        headers.get(header::ETAG).and_then(|v| v.to_str().ok()),
+        Some(expected.as_str()),
+        "overview §\"ETag and Last-Modified\": the ETag is serialization-independent"
+    );
+
+    // The partial-version GET resolves to the concrete artefact; the ETag is
+    // the resolved HRID, never the addressed `…/1` prefix.
+    let req = Request::builder()
+        .method("GET")
+        .uri(format!(
+            "{BASE}/definition/template/adl2/openEHR-EHR-COMPOSITION.t_clinical_info/1"
+        ))
+        .body(Body::empty())
+        .unwrap();
+    let (status, headers, _b) = send(&app, req).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        headers.get(header::ETAG).and_then(|v| v.to_str().ok()),
+        Some(expected.as_str()),
+        "the ETag names the resolved artefact — it must change when the served \
+         version changes (overview §\"ETag and Last-Modified\")"
+    );
+}

--- a/app/ehrbase-rest/tests/headers.rs
+++ b/app/ehrbase-rest/tests/headers.rs
@@ -104,6 +104,29 @@ fn location(h: &header::HeaderMap) -> Option<&str> {
     h.get(header::LOCATION).and_then(|v| v.to_str().ok())
 }
 
+fn last_modified(h: &header::HeaderMap) -> Option<&str> {
+    h.get(header::LAST_MODIFIED).and_then(|v| v.to_str().ok())
+}
+
+/// An openEHR `DV_DATE_TIME` value rendered as an HTTP-date (IMF-fixdate,
+/// RFC 9110 §5.6.7) — the form `Last-Modified` carries, and the exact value
+/// ITS-REST overview §"`ETag` and Last-Modified" derives from
+/// `VERSION.commit_audit.time_committed.value`.
+fn imf_fixdate(iso_instant: &str) -> String {
+    iso_instant
+        .parse::<jiff::Timestamp>()
+        .expect("commit_audit.time_committed.value is an ISO 8601 instant")
+        .strftime("%a, %d %b %Y %H:%M:%S GMT")
+        .to_string()
+}
+
+/// `VERSION.commit_audit.time_committed.value` of a served `ORIGINAL_VERSION`.
+fn commit_instant(version: &Value) -> &str {
+    version["commit_audit"]["time_committed"]["value"]
+        .as_str()
+        .expect("ORIGINAL_VERSION.commit_audit.time_committed.value")
+}
+
 /// The bare uid inside a weak `ETag` (`W/"{uid}"`).
 fn etag_uid(h: &header::HeaderMap) -> String {
     etag(h)
@@ -345,4 +368,315 @@ async fn composition_delete_is_204_with_headers() {
         "the OAS marks Location on this response Location_deprecated — not emitted"
     );
     assert!(body.is_empty());
+}
+
+// ── Last-Modified (overview §"ETag and Last-Modified") ───────────────────────
+//
+// "The `Last-Modified` response HTTP header, indicates the date and time when
+// the resource was last modified. … For openEHR resources, this value should
+// be derived from `VERSION.commit_audit.time_committed.value`." and "Both
+// `ETag` and `Last-Modified` SHOULD be included in responses for VERSION,
+// VERSIONED_OBJECT, or other resources that have versioning or unique state
+// identifiers."
+
+/// A VERSION read (`…/versioned_ehr_status/version/{version_uid}` and the
+/// at-time sibling) carries `Last-Modified` derived from the served
+/// envelope's own `commit_audit.time_committed` — not merely "present", but
+/// byte-equal to the IMF-fixdate rendering of that instant.
+#[tokio::test]
+async fn version_read_last_modified_is_the_commit_audit_instant() {
+    let (_pg, app) = app().await;
+    let ehr_id = create_ehr(&app).await;
+
+    // …/versioned_ehr_status/version — the ORIGINAL_VERSION at the latest time.
+    let req = Request::builder()
+        .method("GET")
+        .uri(format!("{BASE}/ehr/{ehr_id}/versioned_ehr_status/version"))
+        .body(Body::empty())
+        .unwrap();
+    let (status, h, body) = send(&app, req).await;
+    assert_eq!(status, StatusCode::OK);
+    let v: Value = serde_json::from_str(&body).expect("json ORIGINAL_VERSION");
+    assert_eq!(v["_type"], "ORIGINAL_VERSION");
+    assert_eq!(
+        last_modified(&h),
+        Some(imf_fixdate(commit_instant(&v)).as_str()),
+        "overview §\"ETag and Last-Modified\": the value \"should be derived from \
+         VERSION.commit_audit.time_committed.value\""
+    );
+
+    // …/versioned_ehr_status/version/{version_uid} — the by-id VERSION read.
+    let version_uid = v["uid"]["value"].as_str().expect("VERSION.uid").to_owned();
+    let req = Request::builder()
+        .method("GET")
+        .uri(format!(
+            "{BASE}/ehr/{ehr_id}/versioned_ehr_status/version/{version_uid}"
+        ))
+        .body(Body::empty())
+        .unwrap();
+    let (status, h, body) = send(&app, req).await;
+    assert_eq!(status, StatusCode::OK);
+    let v: Value = serde_json::from_str(&body).expect("json ORIGINAL_VERSION");
+    assert_eq!(
+        etag(&h),
+        Some(format!("W/\"{version_uid}\"").as_str()),
+        "overview §\"ETag and Last-Modified\": both headers SHOULD accompany a VERSION"
+    );
+    assert_eq!(
+        last_modified(&h),
+        Some(imf_fixdate(commit_instant(&v)).as_str()),
+        "overview §\"ETag and Last-Modified\": derived from \
+         VERSION.commit_audit.time_committed.value"
+    );
+}
+
+/// The COMPOSITION VERSION read (`…/versioned_composition/{vo}/version/{uid}`)
+/// and the bare COMPOSITION reads/writes all carry the same `Last-Modified`:
+/// the commit instant of the version served. The bare COMPOSITION body has no
+/// `commit_audit`, so this pins that the instant survives from the version row
+/// (read) / the commit result (write) to the wire.
+#[tokio::test]
+async fn composition_read_and_write_carry_the_commit_instant() {
+    let (_pg, app) = app().await;
+    let ehr_id = create_ehr(&app).await;
+    upload_opt(&app).await;
+
+    // POST /composition — the create 201.
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("{BASE}/ehr/{ehr_id}/composition"))
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(canonical_composition().to_string()))
+        .unwrap();
+    let (status, h, body) = send(&app, req).await;
+    assert_eq!(status, StatusCode::CREATED, "composition commit: {body}");
+    let ovid = etag_uid(&h);
+    let created_lm = last_modified(&h)
+        .expect(
+            "overview §\"ETag and Last-Modified\": Last-Modified SHOULD accompany the \
+             committed VERSION",
+        )
+        .to_owned();
+
+    // The VERSION envelope names the authoritative instant.
+    let vo = vo_of(&ovid).to_owned();
+    let req = Request::builder()
+        .method("GET")
+        .uri(format!(
+            "{BASE}/ehr/{ehr_id}/versioned_composition/{vo}/version/{ovid}"
+        ))
+        .body(Body::empty())
+        .unwrap();
+    let (status, h, body) = send(&app, req).await;
+    assert_eq!(status, StatusCode::OK);
+    let version: Value = serde_json::from_str(&body).expect("json ORIGINAL_VERSION");
+    let committed = imf_fixdate(commit_instant(&version));
+    assert_eq!(
+        last_modified(&h),
+        Some(committed.as_str()),
+        "overview §\"ETag and Last-Modified\": derived from \
+         VERSION.commit_audit.time_committed.value"
+    );
+    assert_eq!(
+        created_lm, committed,
+        "the create 201 reports the same commit instant the VERSION envelope carries"
+    );
+
+    // GET the bare COMPOSITION (latest) — same instant, though the served body
+    // carries no commit_audit of its own.
+    let req = Request::builder()
+        .method("GET")
+        .uri(format!("{BASE}/ehr/{ehr_id}/composition/{vo}"))
+        .body(Body::empty())
+        .unwrap();
+    let (status, h, _b) = send(&app, req).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        last_modified(&h),
+        Some(committed.as_str()),
+        "overview §\"ETag and Last-Modified\": both headers SHOULD accompany a resource \
+         with a unique state identifier — the bare COMPOSITION read included"
+    );
+
+    // GET the bare COMPOSITION addressed by its version uid — same instant.
+    let req = Request::builder()
+        .method("GET")
+        .uri(format!("{BASE}/ehr/{ehr_id}/composition/{ovid}"))
+        .body(Body::empty())
+        .unwrap();
+    let (status, h, _b) = send(&app, req).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(last_modified(&h), Some(committed.as_str()));
+
+    // PUT /composition — the update 200/204 carries the NEW version's instant.
+    let mut updated = canonical_composition();
+    updated.as_object_mut().unwrap().remove("uid");
+    let req = Request::builder()
+        .method("PUT")
+        .uri(format!("{BASE}/ehr/{ehr_id}/composition/{vo}"))
+        .header(header::CONTENT_TYPE, "application/json")
+        .header(header::IF_MATCH, format!("\"{ovid}\""))
+        .body(Body::from(updated.to_string()))
+        .unwrap();
+    let (status, h, body) = send(&app, req).await;
+    assert_eq!(status, StatusCode::OK, "composition update: {body}");
+    let new_ovid = etag_uid(&h);
+    assert_ne!(new_ovid, ovid, "a new version was created");
+    let updated_lm = last_modified(&h)
+        .expect("overview §\"ETag and Last-Modified\": Last-Modified on the update response")
+        .to_owned();
+
+    // The new VERSION envelope confirms the reported instant.
+    let req = Request::builder()
+        .method("GET")
+        .uri(format!(
+            "{BASE}/ehr/{ehr_id}/versioned_composition/{vo}/version/{new_ovid}"
+        ))
+        .body(Body::empty())
+        .unwrap();
+    let (status, _h, body) = send(&app, req).await;
+    assert_eq!(status, StatusCode::OK);
+    let version: Value = serde_json::from_str(&body).expect("json ORIGINAL_VERSION");
+    assert_eq!(updated_lm, imf_fixdate(commit_instant(&version)));
+}
+
+/// The `EHR_STATUS` resource reads and its `PUT` carry `Last-Modified` too —
+/// the bare `EHR_STATUS` body has no `commit_audit`, so the instant comes from
+/// the version row (read) and the commit result (write).
+#[tokio::test]
+async fn ehr_status_read_and_write_carry_the_commit_instant() {
+    let (_pg, app) = app().await;
+    let ehr_id = create_ehr(&app).await;
+
+    // GET /ehr_status.
+    let req = Request::builder()
+        .method("GET")
+        .uri(format!("{BASE}/ehr/{ehr_id}/ehr_status"))
+        .body(Body::empty())
+        .unwrap();
+    let (status, h, body) = send(&app, req).await;
+    assert_eq!(status, StatusCode::OK);
+    let current: Value = serde_json::from_str(&body).expect("json EHR_STATUS");
+    let ovid = current["uid"]["value"]
+        .as_str()
+        .expect("EHR_STATUS.uid")
+        .to_owned();
+    let read_lm = last_modified(&h)
+        .expect(
+            "overview §\"ETag and Last-Modified\": both headers SHOULD accompany a resource \
+             with a unique state identifier",
+        )
+        .to_owned();
+
+    // GET /ehr_status/{version_uid} — the same version, the same instant.
+    let req = Request::builder()
+        .method("GET")
+        .uri(format!("{BASE}/ehr/{ehr_id}/ehr_status/{ovid}"))
+        .body(Body::empty())
+        .unwrap();
+    let (status, h, _b) = send(&app, req).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(last_modified(&h), Some(read_lm.as_str()));
+
+    // PUT /ehr_status — the new version's commit instant, cross-checked
+    // against the VERSION envelope's commit_audit.
+    let mut next = current;
+    next.as_object_mut().unwrap().remove("uid");
+    let req = Request::builder()
+        .method("PUT")
+        .uri(format!("{BASE}/ehr/{ehr_id}/ehr_status"))
+        .header(header::CONTENT_TYPE, "application/json")
+        .header(header::IF_MATCH, format!("\"{ovid}\""))
+        .body(Body::from(next.to_string()))
+        .unwrap();
+    let (status, h, _b) = send(&app, req).await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+    let new_ovid = etag_uid(&h);
+    let write_lm = last_modified(&h)
+        .expect("overview §\"ETag and Last-Modified\": Last-Modified on the EHR_STATUS write")
+        .to_owned();
+
+    let req = Request::builder()
+        .method("GET")
+        .uri(format!(
+            "{BASE}/ehr/{ehr_id}/versioned_ehr_status/version/{new_ovid}"
+        ))
+        .body(Body::empty())
+        .unwrap();
+    let (status, _h, body) = send(&app, req).await;
+    assert_eq!(status, StatusCode::OK);
+    let version: Value = serde_json::from_str(&body).expect("json ORIGINAL_VERSION");
+    assert_eq!(write_lm, imf_fixdate(commit_instant(&version)));
+}
+
+/// The EHR create already carried the weak `ETag`; the EHR **reads** now do
+/// too. Overview §"`ETag` and Last-Modified": the value "is usually taken from
+/// e.g. `VERSIONED_OBJECT.uid.value`, `VERSION.uid.value`, `EHR.ehr_id.value`",
+/// and both headers SHOULD accompany "resources that have versioning or unique
+/// state identifiers". No `Location` on a GET (§Location).
+#[tokio::test]
+async fn ehr_get_carries_the_weak_ehr_id_etag() {
+    let (_pg, app) = app().await;
+    let ehr_id = create_ehr(&app).await;
+
+    let req = Request::builder()
+        .method("GET")
+        .uri(format!("{BASE}/ehr/{ehr_id}"))
+        .body(Body::empty())
+        .unwrap();
+    let (status, h, body) = send(&app, req).await;
+    assert_eq!(status, StatusCode::OK);
+    let v: Value = serde_json::from_str(&body).expect("json EHR");
+    assert_eq!(v["_type"], "EHR");
+    assert_eq!(
+        v["ehr_id"]["value"].as_str(),
+        Some(ehr_id.as_str()),
+        "the served EHR names the addressed ehr_id"
+    );
+    assert_eq!(
+        etag(&h),
+        Some(format!("W/\"{ehr_id}\"").as_str()),
+        "overview §\"ETag and Last-Modified\": EHR.ehr_id.value is the named ETag source"
+    );
+    assert_eq!(
+        location(&h),
+        None,
+        "overview §Location: Location MUST NOT indicate an alternate representation \
+         of an existing resource (e.g. via GET)"
+    );
+}
+
+/// The EHR create `201` carries `Last-Modified` (the creating CONTRIBUTION's
+/// commit instant) alongside the `ETag`/`Location` it already emitted.
+#[tokio::test]
+async fn ehr_create_carries_last_modified() {
+    let (_pg, app) = app().await;
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("{BASE}/ehr"))
+        .body(Body::empty())
+        .unwrap();
+    let (status, h, _b) = send(&app, req).await;
+    assert_eq!(status, StatusCode::CREATED);
+    let lm = last_modified(&h).expect(
+        "overview §\"ETag and Last-Modified\": both headers SHOULD accompany a resource \
+         with a unique state identifier",
+    );
+    assert!(
+        lm.ends_with("GMT"),
+        "Last-Modified is an HTTP-date (RFC 9110 §5.6.7): {lm:?}"
+    );
+
+    // The EHR's own EHR_STATUS VERSION was committed in the same CONTRIBUTION,
+    // so its commit_audit instant is the one reported.
+    let ehr_id = etag_uid(&h);
+    let req = Request::builder()
+        .method("GET")
+        .uri(format!("{BASE}/ehr/{ehr_id}/versioned_ehr_status/version"))
+        .body(Body::empty())
+        .unwrap();
+    let (status, _h, body) = send(&app, req).await;
+    assert_eq!(status, StatusCode::OK);
+    let version: Value = serde_json::from_str(&body).expect("json ORIGINAL_VERSION");
+    assert_eq!(lm, imf_fixdate(commit_instant(&version)));
 }

--- a/app/ehrbase/src/service/definition/types.rs
+++ b/app/ehrbase/src/service/definition/types.rs
@@ -24,6 +24,28 @@ pub struct TemplateListFilter {
     pub version: Option<String>,
 }
 
+/// One served ADL2 operational template: the artefact's **resolved**
+/// `ARCHETYPE_HRID` (the addressed `template_id` may be a partial that selects
+/// the latest matching version) paired with the rendered representation.
+///
+/// The wire needs the resolved id as well as the payload, because the `ETag` of
+/// a template response identifies the served artefact — ITS-REST
+/// `Requests_and_responses.md` §"`ETag` and Last-Modified": both headers
+/// "SHOULD be included in responses for VERSION, `VERSIONED_OBJECT`, or other
+/// resources that have versioning or unique state identifiers", and an ADL2
+/// artefact's unique state identifier is its versioned HRID (AM `am24`
+/// `ARCHETYPE_HRID`, whose `release_version` is the artefact's SEMVER).
+/// Returning the addressed string instead would keep one `ETag` across two
+/// different served versions.
+#[derive(Debug, Clone)]
+pub struct Adl2Template {
+    /// The resolved full `ARCHETYPE_HRID` of the served artefact.
+    pub hrid: String,
+    /// The rendered representation (ADL2 source, or the
+    /// `OperationalTemplateV2` canonical JSON).
+    pub payload: String,
+}
+
 /// The SM `QUERY_DESCRIPTOR` (`query_descriptor.adoc`) — the registration
 /// record `I_DEFINITION_QUERY.store_query` / `list_queries` return.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/app/ehrbase/src/service/definition/wire.rs
+++ b/app/ehrbase/src/service/definition/wire.rs
@@ -13,7 +13,7 @@ use serde_json::Value;
 use openehr_its::flat::example::{DetailLevel, ExampleType};
 
 use crate::service::EhrbaseService;
-use crate::service::definition::types::TemplateListFilter;
+use crate::service::definition::types::{Adl2Template, TemplateListFilter};
 use crate::service::error::ServiceError;
 use crate::service::list::Page;
 use crate::service::status::SmError;
@@ -157,7 +157,9 @@ impl EhrbaseService {
     /// full or partial `template_id` (`+` optional SEMVER `version`). Served as
     /// `text/plain` (`200_Template_adl2_retrieved.yaml` body `oneOf:
     /// [OperationalTemplateV2, string]`, example = ADL2 source): the stored
-    /// source is returned verbatim (lossless).
+    /// source is returned verbatim (lossless). The resolved `ARCHETYPE_HRID`
+    /// travels with the payload as the served artefact's identity (the wire
+    /// `ETag` source — see [`Adl2Template`]).
     ///
     /// # Errors
     ///
@@ -167,9 +169,10 @@ impl EhrbaseService {
         &self,
         template_id: String,
         version: Option<String>,
-    ) -> Result<String, ServiceError> {
+    ) -> Result<Adl2Template, ServiceError> {
         let hrid = self.adl2_resolve(&template_id, version.as_deref()).await?;
-        self.adl2_get(&hrid).await
+        let payload = self.adl2_get(&hrid).await?;
+        Ok(Adl2Template { hrid, payload })
     }
 
     /// `GET /definition/template/adl2/{template_id}` with `Accept:
@@ -186,10 +189,11 @@ impl EhrbaseService {
         &self,
         template_id: String,
         version: Option<String>,
-    ) -> Result<String, ServiceError> {
+    ) -> Result<Adl2Template, ServiceError> {
         let hrid = self.adl2_resolve(&template_id, version.as_deref()).await?;
         let source = self.adl2_get(&hrid).await?;
-        self.adl2_opt_json(&source).await
+        let payload = self.adl2_opt_json(&source).await?;
+        Ok(Adl2Template { hrid, payload })
     }
 
     /// `GET /definition/template/adl2` — the ADL2 twin of

--- a/app/ehrbase/src/service/ehr/composition.rs
+++ b/app/ehrbase/src/service/ehr/composition.rs
@@ -640,7 +640,7 @@ impl EhrbaseService {
         a_versioned_object_uid: VoId,
     ) -> Result<Value, SmError> {
         Ok(self
-            .read_composition(an_ehr_id, a_versioned_object_uid, None)
+            .composition_latest_response(an_ehr_id, a_versioned_object_uid)
             .await?
             .body)
     }
@@ -657,20 +657,10 @@ impl EhrbaseService {
         a_versioned_object_uid: VoId,
         a_time: Option<String>,
     ) -> Result<Value, SmError> {
-        match a_time.as_deref() {
-            None => Ok(self
-                .read_composition(an_ehr_id, a_versioned_object_uid, None)
-                .await?
-                .body),
-            Some(raw) => Ok(self
-                .composition_at_time(
-                    an_ehr_id,
-                    a_versioned_object_uid,
-                    super::parse_at_time(raw)?,
-                )
-                .await?
-                .body),
-        }
+        Ok(self
+            .composition_at_time_response(an_ehr_id, a_versioned_object_uid, a_time)
+            .await?
+            .body)
     }
 
     /// SM `I_EHR_COMPOSITION.get_composition_at_version` — the bare
@@ -684,14 +674,10 @@ impl EhrbaseService {
         an_ehr_id: EhrId,
         a_version_uid: ObjectVersionId,
     ) -> Result<Value, SmError> {
-        let (vo_id, version) = components(&a_version_uid)?;
-        let read = self
-            .read_composition(an_ehr_id, vo_id, Some(version))
-            .await?;
-        if let Some(meta) = read.meta.as_ref() {
-            super::ensure_addressed_version(&a_version_uid, &meta.uid)?;
-        }
-        Ok(read.body)
+        Ok(self
+            .composition_at_version_response(an_ehr_id, a_version_uid)
+            .await?
+            .body)
     }
 
     /// SM `I_EHR_COMPOSITION.get_versioned_composition` — the
@@ -767,6 +753,86 @@ impl EhrbaseService {
             super::ensure_addressed_version(&a_version_uid, served)?;
         }
         Ok(body)
+    }
+}
+
+// ── ITS-REST read-response adapter (adapter-support extension) ────────────────
+//
+// The SM `I_EHR_COMPOSITION` reads above return the bare COMPOSITION the
+// service model defines. A bare COMPOSITION carries no commit audit, so the
+// wire cannot derive `Last-Modified` from the served body — yet ITS-REST
+// requires it: `Requests_and_responses.md` §"`ETag` and Last-Modified" says
+// "this value should be derived from `VERSION.commit_audit.time_committed.value`"
+// and "Both `ETag` and `Last-Modified` SHOULD be included in responses for
+// VERSION, VERSIONED_OBJECT, or other resources that have versioning or unique
+// state identifiers". These siblings therefore hand the protocol adapter the
+// same read PLUS its [`ResourceMeta`] (version uid + commit instant), which the
+// version row already carries — no second read, and no re-derivation in the
+// adapter. No openEHR spec governs this envelope — our own design.
+
+impl EhrbaseService {
+    /// [`Self::get_composition_latest`] with the version metadata the wire's
+    /// `ETag`/`Last-Modified` need. A deleted latest version yields a null body
+    /// and no metadata (→ `204`).
+    ///
+    /// # Errors
+    /// [`SmError`] when the object does not exist in this EHR
+    /// (404-equivalent) or a read fails.
+    pub async fn composition_latest_response(
+        &self,
+        an_ehr_id: EhrId,
+        a_versioned_object_uid: VoId,
+    ) -> Result<ServiceResponse, SmError> {
+        Ok(self
+            .read_composition(an_ehr_id, a_versioned_object_uid, None)
+            .await?)
+    }
+
+    /// [`Self::get_composition_at_time`] with the version metadata the wire's
+    /// `ETag`/`Last-Modified` need.
+    ///
+    /// # Errors
+    /// [`SmError`] for a malformed `a_time` (400-equivalent), a missing
+    /// version at that instant (404-equivalent), or a read failure.
+    pub async fn composition_at_time_response(
+        &self,
+        an_ehr_id: EhrId,
+        a_versioned_object_uid: VoId,
+        a_time: Option<String>,
+    ) -> Result<ServiceResponse, SmError> {
+        match a_time.as_deref() {
+            None => Ok(self
+                .read_composition(an_ehr_id, a_versioned_object_uid, None)
+                .await?),
+            Some(raw) => Ok(self
+                .composition_at_time(
+                    an_ehr_id,
+                    a_versioned_object_uid,
+                    super::parse_at_time(raw)?,
+                )
+                .await?),
+        }
+    }
+
+    /// [`Self::get_composition_at_version`] with the version metadata the
+    /// wire's `ETag`/`Last-Modified` need.
+    ///
+    /// # Errors
+    /// [`SmError`] for a malformed `OBJECT_VERSION_ID`, an unknown version
+    /// (404-equivalent), or a read failure.
+    pub async fn composition_at_version_response(
+        &self,
+        an_ehr_id: EhrId,
+        a_version_uid: ObjectVersionId,
+    ) -> Result<ServiceResponse, SmError> {
+        let (vo_id, version) = components(&a_version_uid)?;
+        let read = self
+            .read_composition(an_ehr_id, vo_id, Some(version))
+            .await?;
+        if let Some(meta) = read.meta.as_ref() {
+            super::ensure_addressed_version(&a_version_uid, &meta.uid)?;
+        }
+        Ok(read)
     }
 }
 

--- a/app/ehrbase/src/service/ehr/contributions.rs
+++ b/app/ehrbase/src/service/ehr/contributions.rs
@@ -259,6 +259,11 @@ impl EhrbaseService {
     /// # Errors
     /// [`SmError`] if the CONTRIBUTION fails classification, content
     /// validation, the optimistic lock, or its storage commit.
+    // TODO: carry the commit instant out of `commit_version_set` so both
+    // branches below can attach `with_last_modified` — ITS-REST
+    // `Requests_and_responses.md` §"ETag and Last-Modified" asks for the
+    // header on any resource with a unique state identifier, and a
+    // CONTRIBUTION has one; today only the `ETag`/`Location` uid is emitted.
     pub async fn ehr_contribution_commit(
         &self,
         an_ehr_id: EhrId,

--- a/app/ehrbase/src/service/ehr/service.rs
+++ b/app/ehrbase/src/service/ehr/service.rs
@@ -416,10 +416,7 @@ impl EhrbaseService {
         // a 0..1 `PARTY_SELF` (RM ehr master04 §EHR Status), and the CDR treats
         // a supplied anonymous-or-identified subject as the EHR's subject
         // rather than rejecting it. Recorded, not silently guessed.
-        let ehr_id = EhrId::new();
-        let status = an_ehr_status.unwrap_or_else(default_ehr_status);
-        self.commit_new_ehr(ehr_id, status).await?;
-        Ok(ehr_id)
+        Ok(self.create_ehr_meta(an_ehr_status).await?.0)
     }
 
     /// SM `I_EHR_SERVICE.create_ehr_with_id` — create an EHR under the
@@ -433,9 +430,8 @@ impl EhrbaseService {
         an_ehr_id: EhrId,
         an_ehr_status: Option<Value>,
     ) -> Result<EhrId, SmError> {
-        // see `create_ehr` — `Pre_no_subject` deliberately not enforced.
-        let status = an_ehr_status.unwrap_or_else(default_ehr_status);
-        self.commit_new_ehr(an_ehr_id, status).await?;
+        self.create_ehr_with_id_meta(an_ehr_id, an_ehr_status)
+            .await?;
         Ok(an_ehr_id)
     }
 
@@ -561,6 +557,57 @@ impl EhrbaseService {
             .ehr_by_subject(subject_id, subject_namespace)
             .await?
             .body)
+    }
+}
+
+// ── ITS-REST create-response adapter (adapter-support extension) ──────────────
+//
+// The SM creates above return only the new `ehr_id`. The wire needs the
+// creation instant too: ITS-REST `Requests_and_responses.md` §"`ETag` and
+// Last-Modified" mandates both headers on "resources that have versioning or
+// unique state identifiers" — for an EHR the `ETag` source is
+// "`EHR.ehr_id.value`" (the section's own example list) and the `Last-Modified`
+// instant is the creating CONTRIBUTION's commit time, which
+// [`Self::commit_new_ehr`] already returns in its [`ResourceMeta`]. These
+// siblings surface it instead of the adapter rebuilding a metadata-less
+// envelope. No openEHR spec governs this envelope — our own design.
+
+impl EhrbaseService {
+    /// [`Self::create_ehr`] returning the new `ehr_id` together with the
+    /// created EHR's [`ResourceMeta`] (the `ETag`/`Location` id + the creation
+    /// instant).
+    ///
+    /// # Errors
+    /// [`SmError`] when the status is structurally invalid (422-equivalent),
+    /// the subject already owns an EHR (409-equivalent), or storage fails.
+    pub async fn create_ehr_meta(
+        &self,
+        an_ehr_status: Option<Value>,
+    ) -> Result<(EhrId, ResourceMeta), SmError> {
+        let ehr_id = EhrId::new();
+        let meta = self.create_ehr_with_id_meta(ehr_id, an_ehr_status).await?;
+        Ok((ehr_id, meta))
+    }
+
+    /// [`Self::create_ehr_with_id`] returning the created EHR's
+    /// [`ResourceMeta`].
+    ///
+    /// # Errors
+    /// [`SmError`] when the EHR already exists (409-equivalent), the status is
+    /// invalid, the subject already owns an EHR, or storage fails.
+    pub async fn create_ehr_with_id_meta(
+        &self,
+        an_ehr_id: EhrId,
+        an_ehr_status: Option<Value>,
+    ) -> Result<ResourceMeta, SmError> {
+        // see `create_ehr` — `Pre_no_subject` deliberately not enforced.
+        let status = an_ehr_status.unwrap_or_else(default_ehr_status);
+        let created = self.commit_new_ehr(an_ehr_id, status).await?;
+        created.meta.ok_or_else(|| {
+            SmError::exception(format!(
+                "EHR {an_ehr_id} was created without resource metadata"
+            ))
+        })
     }
 }
 

--- a/app/ehrbase/src/service/ehr/status.rs
+++ b/app/ehrbase/src/service/ehr/status.rs
@@ -541,8 +541,10 @@ impl EhrbaseService {
         an_ehr_id: EhrId,
         a_time: Option<String>,
     ) -> Result<Value, SmError> {
-        let at = a_time.as_deref().map(parse_at_time).transpose()?;
-        Ok(self.status_at(an_ehr_id, at).await?.body)
+        Ok(self
+            .ehr_status_at_time_response(an_ehr_id, a_time)
+            .await?
+            .body)
     }
 
     /// The bare `EHR_STATUS` at a specific version (not an
@@ -557,10 +559,8 @@ impl EhrbaseService {
         a_version_uid: VoId,
         a_version: &str,
     ) -> Result<Value, SmError> {
-        let tree = parse_tree_id(a_version)?;
-        // the bare EHR_STATUS at that version, not an ORIGINAL_VERSION.
         Ok(self
-            .status_by_version(an_ehr_id, a_version_uid, tree)
+            .ehr_status_at_version_response(an_ehr_id, a_version_uid, a_version)
             .await?
             .body)
     }
@@ -672,33 +672,7 @@ impl EhrbaseService {
         an_ehr_id: EhrId,
         a_status: UpdateVersion,
     ) -> Result<String, SmError> {
-        // NOTE: the ITS-REST wire replaces the whole EHR_STATUS in one PUT
-        // — the aggregate of the five discrete SM mutators above (formal
-        // equivalence, `master02-overview.adoc` §Interface Calls). The
-        // optimistic `preceding_version_uid` rides in UpdateVersion; a mismatch
-        // → 412.
-        //
-        // The `If-Match` meta pre-read also yields the `vo_id`, threaded into
-        // the write so the versioned object is resolved once (no second
-        // `current_vo`). No current EHR_STATUS ⇒ NotFound (404), the same
-        // outcome the prior `current_vo`-inside-the-write path produced.
-        let Some((vo_id, latest)) = self.ehr_status_meta_with_vo(an_ehr_id).await? else {
-            return Err(ServiceError::sm(
-                CallStatusType::EhrIdDoesNotExist,
-                format!("EHR_STATUS for EHR {an_ehr_id}"),
-            )
-            .into());
-        };
-        ensure_if_match(a_status.preceding_version_uid.as_ref(), Some(&latest))?;
-        let if_match = a_status
-            .preceding_version_uid
-            .as_ref()
-            .map(|o| o.value.clone())
-            .unwrap_or_default();
-        Ok(self
-            .commit_status(an_ehr_id, vo_id, a_status, &if_match)
-            .await?
-            .version_uid())
+        Ok(self.replace_ehr_status_meta(an_ehr_id, a_status).await?.uid)
     }
 
     /// SM `I_EHR_STATUS.get_revision_history` — the `REVISION_HISTORY` of the
@@ -741,5 +715,103 @@ impl EhrbaseService {
     ) -> Result<Value, SmError> {
         let tree = parse_tree_id(a_version)?;
         Ok(self.status_version(an_ehr_id, a_version_uid, tree).await?)
+    }
+}
+
+// ── ITS-REST read/write-response adapter (adapter-support extension) ──────────
+//
+// The SM `I_EHR_STATUS` calls above return the bare `EHR_STATUS` (or its new
+// version uid) the service model defines — neither carries the commit instant
+// ITS-REST wants on the wire: `Requests_and_responses.md` §"`ETag` and
+// Last-Modified" says the `Last-Modified` value "should be derived from
+// `VERSION.commit_audit.time_committed.value`" and that "Both `ETag` and
+// `Last-Modified` SHOULD be included in responses for VERSION,
+// VERSIONED_OBJECT, or other resources that have versioning or unique state
+// identifiers". These siblings hand the protocol adapter the same result PLUS
+// its [`ResourceMeta`] (version uid + commit instant), which the version row /
+// commit result already holds — no second read. No openEHR spec governs this
+// envelope — our own design.
+
+impl EhrbaseService {
+    /// [`Self::get_ehr_status_at_time`] with the version metadata the wire's
+    /// `ETag`/`Last-Modified` need.
+    ///
+    /// # Errors
+    /// [`SmError`] for a malformed `a_time` (400-equivalent), a missing status
+    /// at that instant (404-equivalent), or a read failure.
+    pub async fn ehr_status_at_time_response(
+        &self,
+        an_ehr_id: EhrId,
+        a_time: Option<String>,
+    ) -> Result<ServiceResponse, SmError> {
+        let at = a_time.as_deref().map(parse_at_time).transpose()?;
+        Ok(self.status_at(an_ehr_id, at).await?)
+    }
+
+    /// [`Self::get_ehr_status_at_version`] with the version metadata the
+    /// wire's `ETag`/`Last-Modified` need. The body is the **bare**
+    /// `EHR_STATUS`, not an `ORIGINAL_VERSION`.
+    ///
+    /// # Errors
+    /// [`SmError`] for a malformed version id, an unknown version
+    /// (404-equivalent), or a read failure.
+    pub async fn ehr_status_at_version_response(
+        &self,
+        an_ehr_id: EhrId,
+        a_version_uid: VoId,
+        a_version: &str,
+    ) -> Result<ServiceResponse, SmError> {
+        let tree = parse_tree_id(a_version)?;
+        Ok(self
+            .status_by_version(an_ehr_id, a_version_uid, tree)
+            .await?)
+    }
+
+    /// [`Self::replace_ehr_status`] returning the committed version's
+    /// [`ResourceMeta`] (uid + commit instant) instead of the bare uid.
+    ///
+    /// # Errors
+    /// [`SmError`] when the EHR has no current `EHR_STATUS` (404-equivalent),
+    /// the `preceding_version_uid` mismatches the current latest
+    /// (412-equivalent), the body fails structural validation
+    /// (422-equivalent), or the commit fails.
+    pub async fn replace_ehr_status_meta(
+        &self,
+        an_ehr_id: EhrId,
+        a_status: UpdateVersion,
+    ) -> Result<ResourceMeta, SmError> {
+        // NOTE: the ITS-REST wire replaces the whole EHR_STATUS in one PUT
+        // — the aggregate of the five discrete SM mutators (formal
+        // equivalence, `master02-overview.adoc` §Interface Calls). The
+        // optimistic `preceding_version_uid` rides in UpdateVersion; a mismatch
+        // → 412.
+        //
+        // The `If-Match` meta pre-read also yields the `vo_id`, threaded into
+        // the write so the versioned object is resolved once (no second
+        // `current_vo`). No current EHR_STATUS ⇒ NotFound (404), the same
+        // outcome the prior `current_vo`-inside-the-write path produced.
+        let Some((vo_id, latest)) = self.ehr_status_meta_with_vo(an_ehr_id).await? else {
+            return Err(ServiceError::sm(
+                CallStatusType::EhrIdDoesNotExist,
+                format!("EHR_STATUS for EHR {an_ehr_id}"),
+            )
+            .into());
+        };
+        ensure_if_match(a_status.preceding_version_uid.as_ref(), Some(&latest))?;
+        let if_match = a_status
+            .preceding_version_uid
+            .as_ref()
+            .map(|o| o.value.clone())
+            .unwrap_or_default();
+        let committed = self
+            .commit_status(an_ehr_id, vo_id, a_status, &if_match)
+            .await?;
+        Ok(self.version_meta(
+            an_ehr_id,
+            committed.vo_id,
+            &committed.creating_system_id,
+            committed.tree,
+            committed.time_committed,
+        ))
     }
 }

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL2.get_artefact-version.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL2.get_artefact-version.yaml
@@ -15,6 +15,23 @@ request:
   path: /definition/template/adl2/{template_id}/{version}  # definition_template_adl2_version_get.yaml (deprecated)
   headers:
     Accept: text/plain                            # Accept_Template_adl2.yaml
+# Header discipline on this outcome — ITS-REST overview
+# `Requests_and_responses.md` §"ETag and Last-Modified" (the DOCS TEXT, the wire
+# oracle): "Both `ETag` and `Last-Modified` SHOULD be included in responses for
+# VERSION, VERSIONED_OBJECT, or other resources that have versioning or unique
+# state identifiers", and the `ETag` "is considered to be of weak-type and
+# should have a weakness indicator `W/` prefix". An ADL2 operational template's
+# unique state identifier is its versioned ARCHETYPE_HRID (AM am24 —
+# `release_version` is the artefact's SEMVER), so the ETag names the RESOLVED
+# HRID, not the addressed (possibly partial) template_id.
+# TODO: the runner does not evaluate `outcomes.*.headers` matchers yet (only the
+# status is classified, tools/cnf-runner/src/exec/outcome.rs), so this
+# declaration is the authored contract, not an executed assertion — it becomes
+# executable when #403 wires header-matcher evaluation into the step judgement.
 outcomes:
-  ok: { status: 200, headers: { Content-Type: negotiated } }   # 200_Template_adl2_retrieved.yaml
+  ok:
+    status: 200                                    # 200_Template_adl2_retrieved.yaml
+    headers:
+      Content-Type: negotiated
+      ETag: 'pattern:W/"<template_id>"'            # the resolved ARCHETYPE_HRID, not the addressed prefix
   not_found: { status: 404 }                       # 404_unknown_template_id_or_version.yaml

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL2.get_artefact.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL2.get_artefact.yaml
@@ -16,6 +16,23 @@ request:
   path: /definition/template/adl2/{template_id}   # definition_template_adl2_get.yaml
   headers:
     Accept: text/plain                            # Accept_Template_adl2.yaml (canonical ADL2 OPT source)
+# Header discipline on this outcome — ITS-REST overview
+# `Requests_and_responses.md` §"ETag and Last-Modified" (the DOCS TEXT, the wire
+# oracle): "Both `ETag` and `Last-Modified` SHOULD be included in responses for
+# VERSION, VERSIONED_OBJECT, or other resources that have versioning or unique
+# state identifiers", and the `ETag` "is considered to be of weak-type and
+# should have a weakness indicator `W/` prefix". An ADL2 operational template's
+# unique state identifier is its versioned ARCHETYPE_HRID (AM am24 —
+# `release_version` is the artefact's SEMVER), so the ETag names the RESOLVED
+# HRID, not the addressed (possibly partial) template_id.
+# TODO: the runner does not evaluate `outcomes.*.headers` matchers yet (only the
+# status is classified, tools/cnf-runner/src/exec/outcome.rs), so this
+# declaration is the authored contract, not an executed assertion — it becomes
+# executable when #403 wires header-matcher evaluation into the step judgement.
 outcomes:
-  ok: { status: 200, headers: { Content-Type: negotiated } }   # 200_Template_adl2_retrieved.yaml
+  ok:
+    status: 200                                    # 200_Template_adl2_retrieved.yaml
+    headers:
+      Content-Type: negotiated
+      ETag: 'pattern:W/"<template_id>"'            # the resolved ARCHETYPE_HRID
   not_found: { status: 404 }                       # 404_unknown_template_id.yaml

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL2.upload_artefact.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL2.upload_artefact.yaml
@@ -16,8 +16,25 @@ request:
   body: opt_adl2
   headers:
     Content-Type: text/plain                     # the ONLY accepted upload type (operation Content-Type enum)
+# Header discipline on this outcome — ITS-REST overview
+# `Requests_and_responses.md` §"ETag and Last-Modified" (the DOCS TEXT, the wire
+# oracle): "Both `ETag` and `Last-Modified` SHOULD be included in responses for
+# VERSION, VERSIONED_OBJECT, or other resources that have versioning or unique
+# state identifiers", and the `ETag` "is considered to be of weak-type and
+# should have a weakness indicator `W/` prefix". An ADL2 operational template's
+# unique state identifier is its versioned ARCHETYPE_HRID (AM am24 —
+# `release_version` is the artefact's SEMVER), so the ETag names the RESOLVED
+# HRID, not the addressed (possibly partial) template_id.
+# TODO: the runner does not evaluate `outcomes.*.headers` matchers yet (only the
+# status is classified, tools/cnf-runner/src/exec/outcome.rs), so this
+# declaration is the authored contract, not an executed assertion — it becomes
+# executable when #403 wires header-matcher evaluation into the step judgement.
 outcomes:
-  created: { status: 201 }                        # 201_Template_adl2_upload.yaml
+  created:
+    status: 201                                   # 201_Template_adl2_upload.yaml
+    headers:
+      ETag: 'pattern:W/"<template_id>"'           # the stored ARCHETYPE_HRID
+      Location: present
   already_exists: { status: 409 }                 # 409_template_already_exists.yaml — duplicate template_id
   validation_failed:
     status: 422                           # ITS-REST overview §HTTP status codes — 422 = semantic errors

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_COMPOSITION.create_composition.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_COMPOSITION.create_composition.yaml
@@ -18,11 +18,22 @@ format_headers:
   wt-structured:
     Content-Type: application/openehr.wt.structured+json
     openehr-template-id: required
+# Header discipline on this outcome — ITS-REST overview
+# `Requests_and_responses.md` §"ETag and Last-Modified" (the DOCS TEXT, the wire
+# oracle): "Both `ETag` and `Last-Modified` SHOULD be included in responses for
+# VERSION, VERSIONED_OBJECT, or other resources that have versioning or unique
+# state identifiers", and "For openEHR resources, this value [Last-Modified]
+# should be derived from `VERSION.commit_audit.time_committed.value`".
+# TODO: the runner does not evaluate `outcomes.*.headers` matchers yet (only the
+# status is classified, tools/cnf-runner/src/exec/outcome.rs), so this
+# declaration is the authored contract, not an executed assertion — it becomes
+# executable when #403 wires header-matcher evaluation into the step judgement.
 outcomes:
   created:
     status: 201                           # 201_COMPOSITION.yaml
     headers:
       ETag: 'pattern:W/"<versioned_object_uid>::<system_id>::1"'
+      Last-Modified: present
       Location: present
       Content-Type: negotiated
     body: prefer_conditional

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_COMPOSITION.get_composition_at_time.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_COMPOSITION.get_composition_at_time.yaml
@@ -18,10 +18,23 @@ request:
   query:
     version_at_time: "${a_time?}"         # omitted -> latest (composition_get.yaml)
 formats: [canonical-json, canonical-xml, wt-flat, wt-structured]
+# Header discipline on this outcome — ITS-REST overview
+# `Requests_and_responses.md` §"ETag and Last-Modified" (the DOCS TEXT, the wire
+# oracle): "Both `ETag` and `Last-Modified` SHOULD be included in responses for
+# VERSION, VERSIONED_OBJECT, or other resources that have versioning or unique
+# state identifiers", and "For openEHR resources, this value [Last-Modified]
+# should be derived from `VERSION.commit_audit.time_committed.value`".
+# TODO: the runner does not evaluate `outcomes.*.headers` matchers yet (only the
+# status is classified, tools/cnf-runner/src/exec/outcome.rs), so this
+# declaration is the authored contract, not an executed assertion — it becomes
+# executable when #403 wires header-matcher evaluation into the step judgement.
 outcomes:
   ok:
     status: 200                           # 200_COMPOSITION_retrieved.yaml
-    headers: { Content-Type: negotiated }
+    headers:
+      Content-Type: negotiated
+      ETag: 'pattern:W/"<versioned_object_uid>::<system_id>::<n>"'
+      Last-Modified: present
   ok_empty: { status: 204 }               # version extant at the requested time is a logical delete (204_deleted_at_time.yaml)
   not_found: { status: 404 }              # unknown ehr_id, unknown versioned_object_uid, or no version at the requested time
 server_assigned: [uid]                    # the retrieved resource carries the server-assigned version uid the committed payload lacks

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_COMPOSITION.get_composition_at_version.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_COMPOSITION.get_composition_at_version.yaml
@@ -7,10 +7,23 @@ request:
   method: GET
   path: /ehr/{ehr_id}/composition/{version_uid}
 formats: [canonical-json, canonical-xml, wt-flat, wt-structured]
+# Header discipline on this outcome — ITS-REST overview
+# `Requests_and_responses.md` §"ETag and Last-Modified" (the DOCS TEXT, the wire
+# oracle): "Both `ETag` and `Last-Modified` SHOULD be included in responses for
+# VERSION, VERSIONED_OBJECT, or other resources that have versioning or unique
+# state identifiers", and "For openEHR resources, this value [Last-Modified]
+# should be derived from `VERSION.commit_audit.time_committed.value`".
+# TODO: the runner does not evaluate `outcomes.*.headers` matchers yet (only the
+# status is classified, tools/cnf-runner/src/exec/outcome.rs), so this
+# declaration is the authored contract, not an executed assertion — it becomes
+# executable when #403 wires header-matcher evaluation into the step judgement.
 outcomes:
   ok:
     status: 200                           # 200_COMPOSITION_retrieved.yaml
-    headers: { Content-Type: negotiated }
+    headers:
+      Content-Type: negotiated
+      ETag: 'pattern:W/"<versioned_object_uid>::<system_id>::<n>"'
+      Last-Modified: present
   ok_empty: { status: 204 }               # deleted at requested time (composition_get.yaml)
   not_found: { status: 404 }
 server_assigned: [uid]                    # the retrieved resource carries the server-assigned version uid the committed payload lacks

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_COMPOSITION.get_composition_latest.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_COMPOSITION.get_composition_latest.yaml
@@ -13,10 +13,23 @@ request:
   method: GET
   path: /ehr/{ehr_id}/composition/{versioned_object_uid}
 formats: [canonical-json, canonical-xml, wt-flat, wt-structured]
+# Header discipline on this outcome — ITS-REST overview
+# `Requests_and_responses.md` §"ETag and Last-Modified" (the DOCS TEXT, the wire
+# oracle): "Both `ETag` and `Last-Modified` SHOULD be included in responses for
+# VERSION, VERSIONED_OBJECT, or other resources that have versioning or unique
+# state identifiers", and "For openEHR resources, this value [Last-Modified]
+# should be derived from `VERSION.commit_audit.time_committed.value`".
+# TODO: the runner does not evaluate `outcomes.*.headers` matchers yet (only the
+# status is classified, tools/cnf-runner/src/exec/outcome.rs), so this
+# declaration is the authored contract, not an executed assertion — it becomes
+# executable when #403 wires header-matcher evaluation into the step judgement.
 outcomes:
   ok:
     status: 200                           # 200_COMPOSITION_retrieved.yaml
-    headers: { Content-Type: negotiated }
+    headers:
+      Content-Type: negotiated
+      ETag: 'pattern:W/"<versioned_object_uid>::<system_id>::<n>"'
+      Last-Modified: present
   ok_empty: { status: 204 }               # latest version is a logical delete (204_deleted_at_time.yaml)
   not_found: { status: 404 }              # unknown ehr_id or unknown versioned_object_uid
 server_assigned: [uid]                    # the retrieved resource carries the server-assigned version uid the committed payload lacks

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_COMPOSITION.get_versioned_composition-version.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_COMPOSITION.get_versioned_composition-version.yaml
@@ -26,10 +26,23 @@ request:
   method: GET
   path: /ehr/{ehr_id}/versioned_composition/{versioned_object_uid}/version/{version_uid}
 formats: [canonical-json, canonical-xml]
+# Header discipline on this outcome — ITS-REST overview
+# `Requests_and_responses.md` §"ETag and Last-Modified" (the DOCS TEXT, the wire
+# oracle): "Both `ETag` and `Last-Modified` SHOULD be included in responses for
+# VERSION, VERSIONED_OBJECT, or other resources that have versioning or unique
+# state identifiers", and "For openEHR resources, this value [Last-Modified]
+# should be derived from `VERSION.commit_audit.time_committed.value`".
+# TODO: the runner does not evaluate `outcomes.*.headers` matchers yet (only the
+# status is classified, tools/cnf-runner/src/exec/outcome.rs), so this
+# declaration is the authored contract, not an executed assertion — it becomes
+# executable when #403 wires header-matcher evaluation into the step judgement.
 outcomes:
   ok:
     status: 200                           # overview §HTTP status codes (200 OK — payload = the ORIGINAL_VERSION)
-    headers: { Content-Type: negotiated }
+    headers:
+      Content-Type: negotiated
+      ETag: 'pattern:W/"<versioned_object_uid>::<system_id>::<n>"'
+      Last-Modified: present
   not_found: { status: 404 }              # overview §HTTP status codes (404 — target resource not found)
 captures:
   # The envelope's stored signature (RM common master06 §Digital Signature:

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_COMPOSITION.update_composition.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_COMPOSITION.update_composition.yaml
@@ -12,11 +12,22 @@ request:
     If-Match: '"${preceding_version_uid}"'   # REQUIRED (If-Match.yaml); realizes SM preceding_version_uid (ITS-REST overview §If-Match)
     Prefer: "return=representation"
 formats: [canonical-json, canonical-xml, wt-flat, wt-structured]
+# Header discipline on this outcome — ITS-REST overview
+# `Requests_and_responses.md` §"ETag and Last-Modified" (the DOCS TEXT, the wire
+# oracle): "Both `ETag` and `Last-Modified` SHOULD be included in responses for
+# VERSION, VERSIONED_OBJECT, or other resources that have versioning or unique
+# state identifiers", and "For openEHR resources, this value [Last-Modified]
+# should be derived from `VERSION.commit_audit.time_committed.value`".
+# TODO: the runner does not evaluate `outcomes.*.headers` matchers yet (only the
+# status is classified, tools/cnf-runner/src/exec/outcome.rs), so this
+# declaration is the authored contract, not an executed assertion — it becomes
+# executable when #403 wires header-matcher evaluation into the step judgement.
 outcomes:
   updated:
     status: 200                           # 204 when Prefer minimal (204_version_updated.yaml)
     headers:
       ETag: 'pattern:W/"<versioned_object_uid>::<system_id>::<n>"'
+      Last-Modified: present
     body: prefer_conditional
   precondition_failed:
     status: 412                           # 412_COMPOSITION.yaml, MUST

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_SERVICE.create_ehr.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_SERVICE.create_ehr.yaml
@@ -11,10 +11,20 @@ request:
   headers:
     Prefer: "return=representation"       # default is return=minimal (Prefer.yaml); ask for the body
 formats: [canonical-json, canonical-xml]  # EHR resource is canonical-only (Accept_canonical)
+# Header discipline on this outcome — ITS-REST overview
+# `Requests_and_responses.md` §"ETag and Last-Modified" (the DOCS TEXT, the wire
+# oracle): "Both `ETag` and `Last-Modified` SHOULD be included in responses for
+# VERSION, VERSIONED_OBJECT, or other resources that have versioning or unique
+# state identifiers", and "For openEHR resources, this value [Last-Modified]
+# should be derived from `VERSION.commit_audit.time_committed.value`".
+# TODO: the runner does not evaluate `outcomes.*.headers` matchers yet (only the
+# status is classified, tools/cnf-runner/src/exec/outcome.rs), so this
+# declaration is the authored contract, not an executed assertion — it becomes
+# executable when #403 wires header-matcher evaluation into the step judgement.
 outcomes:
   created:
     status: 201                           # 201_EHR.yaml
-    headers: { ETag: present, Location: present }
+    headers: { ETag: present, Last-Modified: present, Location: present }
     body: prefer_conditional              # oneOf [Ehr | {uid} | empty] per Prefer
   already_exists:
     status: 409                           # 409_EHR.yaml (subject/ehr_id conflict)

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_SERVICE.get_ehr.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_SERVICE.get_ehr.yaml
@@ -6,6 +6,21 @@ request:
   method: GET
   path: /ehr/{ehr_id}
 formats: [canonical-json, canonical-xml]
+# Header discipline on this outcome — ITS-REST overview
+# `Requests_and_responses.md` §"ETag and Last-Modified" (the DOCS TEXT, the wire
+# oracle): "Both `ETag` and `Last-Modified` SHOULD be included in responses for
+# VERSION, VERSIONED_OBJECT, or other resources that have versioning or unique
+# state identifiers", and "For openEHR resources, this value [Last-Modified]
+# should be derived from `VERSION.commit_audit.time_committed.value`".
+# TODO: the runner does not evaluate `outcomes.*.headers` matchers yet (only the
+# status is classified, tools/cnf-runner/src/exec/outcome.rs), so this
+# declaration is the authored contract, not an executed assertion — it becomes
+# executable when #403 wires header-matcher evaluation into the step judgement.
 outcomes:
-  ok: { status: 200, headers: { Content-Type: negotiated } }
+  ok:
+    status: 200
+    headers:
+      Content-Type: negotiated
+      ETag: 'pattern:W/"<ehr_id>"'        # the section's own example source: "EHR.ehr_id.value"
+      Location: absent                    # GET — overview §Location
   not_found: { status: 404 }              # 404.yaml (unknown ehr_id)

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_STATUS.get_ehr_status.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_STATUS.get_ehr_status.yaml
@@ -6,10 +6,23 @@ request:
   method: GET
   path: /ehr/{ehr_id}/ehr_status
 formats: [canonical-json, canonical-xml]
+# Header discipline on this outcome — ITS-REST overview
+# `Requests_and_responses.md` §"ETag and Last-Modified" (the DOCS TEXT, the wire
+# oracle): "Both `ETag` and `Last-Modified` SHOULD be included in responses for
+# VERSION, VERSIONED_OBJECT, or other resources that have versioning or unique
+# state identifiers", and "For openEHR resources, this value [Last-Modified]
+# should be derived from `VERSION.commit_audit.time_committed.value`".
+# TODO: the runner does not evaluate `outcomes.*.headers` matchers yet (only the
+# status is classified, tools/cnf-runner/src/exec/outcome.rs), so this
+# declaration is the authored contract, not an executed assertion — it becomes
+# executable when #403 wires header-matcher evaluation into the step judgement.
 outcomes:
   ok:
     status: 200                           # 200_EHR_STATUS_retrieved.yaml
-    headers: { ETag: present, Content-Type: negotiated }
+    headers:
+      ETag: present
+      Last-Modified: present
+      Content-Type: negotiated
   not_found: { status: 404 }
   not_acceptable: { status: 406 }         # unfulfillable Accept (overview Requests_and_responses negotiation rules; no simplified mapping exists for this resource)
 captures:

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_STATUS.get_versioned_ehr_status-version.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_STATUS.get_versioned_ehr_status-version.yaml
@@ -23,8 +23,21 @@ request:
   method: GET
   path: /ehr/{ehr_id}/versioned_ehr_status/version/{version_uid}
 formats: [canonical-json, canonical-xml]
+# Header discipline on this outcome — ITS-REST overview
+# `Requests_and_responses.md` §"ETag and Last-Modified" (the DOCS TEXT, the wire
+# oracle): "Both `ETag` and `Last-Modified` SHOULD be included in responses for
+# VERSION, VERSIONED_OBJECT, or other resources that have versioning or unique
+# state identifiers", and "For openEHR resources, this value [Last-Modified]
+# should be derived from `VERSION.commit_audit.time_committed.value`".
+# TODO: the runner does not evaluate `outcomes.*.headers` matchers yet (only the
+# status is classified, tools/cnf-runner/src/exec/outcome.rs), so this
+# declaration is the authored contract, not an executed assertion — it becomes
+# executable when #403 wires header-matcher evaluation into the step judgement.
 outcomes:
   ok:
     status: 200                           # overview §HTTP status codes (200 OK — payload = the ORIGINAL_VERSION)
-    headers: { Content-Type: negotiated }
+    headers:
+      Content-Type: negotiated
+      ETag: present
+      Last-Modified: present
   not_found: { status: 404 }              # overview §HTTP status codes (404 — target resource not found)

--- a/tools/cnf-runner/artifacts/vocab/wire_surface.yaml
+++ b/tools/cnf-runner/artifacts/vocab/wire_surface.yaml
@@ -729,7 +729,7 @@ elements:
     source: "ITS-REST Requests_and_responses.md §ETag and Last-Modified (Last-Modified SHOULD be included for VERSION/VERSIONED_OBJECT responses)"
     exception:
       reason: coverage_gap
-      note: "NEW-CASE candidate: assert Last-Modified on a versioned GET (get_composition_at_version / get_ehr_status). SHOULD-level per the docs text; not yet exercised."
+      note: "server behaviour fixed + DB-tested (#396, app/ehrbase-rest/tests/headers.rs): Last-Modified is now emitted on every VERSION read, on the COMPOSITION / EHR_STATUS reads and writes, and on the EHR create, with the value pinned byte-equal to the IMF-fixdate rendering of the served VERSION.commit_audit.time_committed. The presence is DECLARED as `Last-Modified: present` on those binding outcomes. NEW-CASE candidate blocked on the runner capability tracked in #403: `outcomes.*.headers` matchers are parsed but never evaluated — only the status is classified (tools/cnf-runner/src/exec/outcome.rs) — so no executable header assertion exists yet; this gap closes when #403 lands header-matcher evaluation."
   - id: header-prefer-return-representation
     description: "Prefer: return=representation is honored — the created/updated resource body is returned (vs the default return=minimal)."
     source: "ITS-REST Requests_and_responses.md §Prefer + §Representation details negotiation (default return=minimal; return=representation returns the full resource)"
@@ -778,7 +778,7 @@ elements:
     source: "ITS-REST Requests_and_responses.md §ETag and Last-Modified (\"Both ETag and Last-Modified SHOULD be included in responses for VERSION, VERSIONED_OBJECT, or other resources that have versioning or unique state identifiers\"; the ETag \"is usually taken from e.g. VERSIONED_OBJECT.uid.value, VERSION.uid.value\", Last-Modified \"derived from VERSION.commit_audit.time_committed.value\")"
     exception:
       reason: coverage_gap
-      note: "server behaviour fixed + DB-tested for the demographic versioned reads (#394). NEW-CASE candidate blocked on two runner capabilities: header matchers are not evaluated (see header-location-only-on-create), and the /demographic/versioned_party/** resource has no binding of its own — the SM versioned-party reads are realized through I_PARTY.get_party_at_version on /demographic/person/{version_uid}."
+      note: "server behaviour fixed + DB-tested for the demographic versioned reads (#394) and for the EHR-group VERSION / COMPOSITION / EHR_STATUS reads (#396, app/ehrbase-rest/tests/headers.rs); the presence is DECLARED as `ETag` + `Last-Modified` on those binding outcomes. NEW-CASE candidate blocked on two runner capabilities: header matchers are not evaluated (see header-location-only-on-create; tracked as #403), and the /demographic/versioned_party/** resource has no binding of its own — the SM versioned-party reads are realized through I_PARTY.get_party_at_version on /demographic/person/{version_uid}."
   # Content negotiation (ITS-REST Requests_and_responses.md §HTTP status codes + Representation details negotiation).
   - id: negotiation-canonical-json
     description: "Canonical-JSON representation negotiated and returned (the default representation)."

--- a/website/book/src/using-the-api/content-negotiation.md
+++ b/website/book/src/using-the-api/content-negotiation.md
@@ -131,6 +131,32 @@ A **`Location`** header is emitted only when a resource is **created** —
 reads and deletes identify the version through `ETag` alone, so do not expect
 `Location` on them; the `ETag` is the authoritative identifier.
 
+## `Last-Modified` — when the version was committed
+
+Alongside the `ETag`, versioned responses carry a **`Last-Modified`** header
+in the standard HTTP-date form (`Wed, 22 Jul 2009 19:15:56 GMT`). Its value is
+the commit time of the version being served — the audit
+`time_committed` of that `VERSION` — so it changes exactly when the `ETag`
+does.
+
+You get it on:
+
+- every `VERSION` read (`…/versioned_composition/{uid}/version[/{version_uid}]`,
+  `…/versioned_ehr_status/version[/{version_uid}]`) and revision history read;
+- every COMPOSITION, `EHR_STATUS`, and DIRECTORY read — including the FLAT and
+  STRUCTURED representations, which describe the same version;
+- every write of those resources (create, update, and the delete `204`), and
+  the EHR create `201`.
+
+Resources that are not versioned do not carry it: `GET /ehr/{ehr_id}` returns
+the weak `ETag` (built from `EHR.ehr_id.value`) but no `Last-Modified`,
+because the `EHR` root object has no commit audit of its own.
+
+Template responses (ADL 1.4 and ADL2) carry a weak `ETag` keyed on the
+template identifier; for ADL2 it is the **resolved** `ARCHETYPE_HRID`, so
+requesting a template by a partial id or a major-version prefix still gives
+you an `ETag` that changes when the served artefact changes.
+
 > [!NOTE]
 > Version ids normally end in a plain trunk number (`…::2`), but openEHR
 > version trees can **branch**: when a version that was created on another


### PR DESCRIPTION
Closes #396 — fix 3 of the #373 audit's group-1 wave (found by #377; completes the #374 half-fix).

## What shipped

**Last-Modified everywhere the value exists** (ITS-REST overview `Requests_and_responses.md` §"ETag and Last-Modified": derived "from VERSION.commit_audit.time_committed.value"; both headers SHOULD accompany VERSION/VERSIONED_OBJECT/state-identified responses):
- VERSION-by-id and at-time reads (both composition and EHR_STATUS families) — derived at the adapter from the served ORIGINAL_VERSION's own `commit_audit.time_committed` (the body IS the authority there), mirroring the existing revision-history path.
- COMPOSITION and EHR_STATUS reads and writes, and EHR creates — enriched at the SERVICE layer via adapter-support siblings next to the existing `*_latest_meta` family (the bare wire bodies carry no commit audit; the service holds the instant on the version row / the write's `Committed`). SM methods delegate to the siblings — one implementation per read, ~60 SM test call sites untouched.

**Missing ETags** (same section; `EHR.ehr_id.value` is the spec's own example source): EHR GETs now carry the weak ehr_id ETag — the OAS-derived justification comment for its absence is deleted (the OAS is not the oracle). ADL2 template upload + all GET shapes now carry the template ETag (mirroring ADL1.4), with the ADL2 reads returning the resolved HRID so the partial-version GET tags the version it actually served.

**Consolidation:** new `negotiate::set_etag` is the single `W/\"…\"` writer (demographic + ADL1.4 hand-rolled copies routed through it). False comments corrected (`versioned_ehr_status.rs`/`versioned_composition.rs` claimed the header was emitted; now it is).

## Honest boundaries
- CONTRIBUTION create: no commit instant returned by `commit_version_set` yet — `// TODO:` recorded.
- EHR reads: no Last-Modified by design (`time_created` is not a modification instant; the EHR body changes on status/directory commits) — NOTE with citation.
- CNF: `header-last-modified` / `header-etag-on-versioned-object-read` stay registered gaps — the runner does not evaluate header matchers yet (#403); binding declarations + notes updated to record the server fix and name the blocker. No gap claimed closed that the runner cannot execute.

## Tests
+5 in `headers.rs`: Last-Modified asserted BYTE-EQUAL to the IMF-fixdate rendering of the served envelope's commit instant (VERSION reads), cross-checked on COMPOSITION/EHR_STATUS reads+writes; EHR weak ETag + Location absence; EHR-create Last-Modified. +1 in `definition_adl2_http.rs` (ETag across upload/source/JSON/partial-version GETs). No test weakened — none pinned the old absence.

## Gates
`cargo fmt` clean · clippy `-p ehrbase -p ehrbase-rest --all-targets --all-features` zero warnings · nextest 1065/1065 · `cnf-runner validate` 452 cases / 95 bindings / 0 findings. Changelog + website book (§Last-Modified) updated in-branch.

Wave: 3 of 9 (#394, #395 merged). Next: #397.