### PR TITLE
chore(conformance): ratchet the baseline — group-1 close run, header assertions live

### DIFF
--- a/docs/conformance/ehrbase-rs/CONFORMANCE_CERTIFICATE.md
+++ b/docs/conformance/ehrbase-rs/CONFORMANCE_CERTIFICATE.md
@@ -4,9 +4,9 @@
 
 | Field | Value |
 | --- | --- |
-| Solution | ehrbase-rs 3.9.0 |
+| Solution | ehrbase-rs 3.11.0 |
 | Vendor | Ruben Talstra |
-| Runner | cnf-runner 3.9.0 |
+| Runner | cnf-runner 3.11.0 |
 | Infrastructure | ixit.json#/environment |
 
 ## Scope of Test

--- a/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
@@ -1,18 +1,18 @@
 # Conformance Report
 
-SUT: ehrbase-rs 3.9.0 · schedule cnf-2.0-w2 · ITS its-rest
-Runner: cnf-runner 3.9.0 · verification pack: passed
+SUT: ehrbase-rs 3.11.0 · schedule cnf-2.0-w2 · ITS its-rest
+Runner: cnf-runner 3.11.0 · verification pack: passed
 
 ## Summary
 
 | Status | Count |
 | --- | --- |
-| passed | 376 |
+| passed | 398 |
 | failed | 0 |
 | errored | 0 |
 | skipped | 0 |
 | not_applicable | 69 |
-| total | 445 |
+| total | 467 |
 
 ## By chapter
 
@@ -22,20 +22,20 @@ Runner: cnf-runner 3.9.0 · verification pack: passed
 | I_ADMIN_ARCHIVE | 0 | 0 | 0 | 0 | 4 |
 | I_ADMIN_DUMP_LOAD | 0 | 0 | 0 | 0 | 2 |
 | I_ADMIN_SERVICE | 2 | 0 | 0 | 0 | 10 |
-| I_DEFINITION_ADL14 | 9 | 0 | 0 | 0 | 8 |
+| I_DEFINITION_ADL14 | 10 | 0 | 0 | 0 | 8 |
 | I_DEFINITION_ADL2 | 16 | 0 | 0 | 0 | 8 |
 | I_DEFINITION_QUERY | 10 | 0 | 0 | 0 | 0 |
-| I_DEMOGRAPHIC_SERVICE | 12 | 0 | 0 | 0 | 12 |
-| I_EHR_COMPOSITION | 32 | 0 | 0 | 0 | 0 |
+| I_DEMOGRAPHIC_SERVICE | 16 | 0 | 0 | 0 | 12 |
+| I_EHR_COMPOSITION | 42 | 0 | 0 | 0 | 0 |
 | I_EHR_CONTRIBUTION | 36 | 0 | 0 | 0 | 5 |
 | I_EHR_DIRECTORY | 34 | 0 | 0 | 0 | 3 |
 | I_EHR_EXTRACT_SERVICE | 0 | 0 | 0 | 0 | 10 |
 | I_EHR_SERVICE | 12 | 0 | 0 | 0 | 0 |
 | I_EHR_STATUS | 10 | 0 | 0 | 0 | 0 |
-| I_QUERY_SERVICE | 15 | 0 | 0 | 0 | 0 |
+| I_QUERY_SERVICE | 18 | 0 | 0 | 0 | 0 |
 | I_TDD_SERVICE | 0 | 0 | 0 | 0 | 4 |
-| SEC | 5 | 0 | 0 | 0 | 0 |
-| SF | 54 | 0 | 0 | 0 | 1 |
+| SEC | 6 | 0 | 0 | 0 | 0 |
+| SF | 57 | 0 | 0 | 0 | 1 |
 | SIG | 6 | 0 | 0 | 0 | 2 |
 
 ## Performance measurements
@@ -73,7 +73,7 @@ Percentiles re-derive from the embedded HDR V2 histograms; the class verdict is 
 
 ## Honesty
 
-Coverage: 376 of 445 selected cases driven.
+Coverage: 398 of 467 selected cases driven.
 
 Not-executed verdicts (each cited):
 

--- a/docs/conformance/ehrbase-rs/CONFORMANCE_STATEMENT.md
+++ b/docs/conformance/ehrbase-rs/CONFORMANCE_STATEMENT.md
@@ -55,7 +55,7 @@ Capabilities claimed:
 - AuditAccountability
 - AnonymousEhrs
 
-Options declared: adl14-duplicate-conflict, directory-empty-error, sf-deprecated-types-unsupported
+Options declared: adl14-duplicate-conflict, directory-empty-error, legacy-alt-formats-unsupported, sf-deprecated-types-unsupported
 
 ## Verdicts
 

--- a/docs/conformance/ehrbase-rs/badge.json
+++ b/docs/conformance/ehrbase-rs/badge.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "openEHR conformance",
-  "message": "CORE+STANDARD PASS \u00b7 376/376 cases",
+  "message": "CORE+STANDARD PASS \u00b7 398/398 cases",
   "color": "brightgreen"
 }

--- a/docs/conformance/ehrbase-rs/results.json
+++ b/docs/conformance/ehrbase-rs/results.json
@@ -1,11 +1,11 @@
 {
   "sut": {
     "name": "ehrbase-rs",
-    "version": "3.9.0"
+    "version": "3.11.0"
   },
   "runner": {
     "name": "cnf-runner",
-    "version": "3.9.0",
+    "version": "3.11.0",
     "verification_pack_status": "passed"
   },
   "schedule_release": "cnf-2.0-w2",
@@ -166,6 +166,18 @@
       "citation": "I_ADMIN_SERVICE.versioned_composition_count: AMB-33"
     },
     {
+      "case": "I_EHR_COMPOSITION.create_composition-datetime_lexical",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.create_composition-deprecated_template_id",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_COMPOSITION.create_composition-event",
       "status": "passed",
       "rows_driven": 1,
@@ -196,13 +208,37 @@
       "rows_total": 1
     },
     {
+      "case": "I_EHR_COMPOSITION.create_composition-null_empty_absent",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_COMPOSITION.create_composition-persistent",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
     },
     {
+      "case": "I_EHR_COMPOSITION.create_composition-return_identifier",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_COMPOSITION.create_composition-same_opt_twice",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.create_composition-wrong_media",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.delete_composition-audit_headers",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -329,6 +365,30 @@
     },
     {
       "case": "I_EHR_COMPOSITION.has_composition",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.update_composition-audit_amendment",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.update_composition-audit_bare_deprecated",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.update_composition-audit_change_type_invalid",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.update_composition-audit_change_type_mismatch",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -1439,6 +1499,12 @@
       "citation": "option adl14-duplicate-versioned: the ICS does not declare this register branch (statement.options) — ISO/IEC 9646 test selection"
     },
     {
+      "case": "I_DEFINITION_ADL14.upload_opt-wrong_media",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_DEFINITION_ADL14.validate_opt-invalid_opt",
       "status": "passed",
       "rows_driven": 4,
@@ -1788,6 +1854,24 @@
       "rows_total": 1
     },
     {
+      "case": "I_DEMOGRAPHIC_SERVICE.update_party-case_variant_if_match",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEMOGRAPHIC_SERVICE.update_party-weak_etag_accepted",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEMOGRAPHIC_SERVICE.update_party-weak_etag_stale",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_DEMOGRAPHIC_SERVICE.update_party_relationship-aaaa",
       "status": "not_applicable",
       "rows_driven": 0,
@@ -1800,6 +1884,12 @@
       "rows_driven": 0,
       "rows_total": 1,
       "citation": "I_PARTY_RELATIONSHIP.update_party_relationship: AMB-32"
+    },
+    {
+      "case": "I_DEMOGRAPHIC_SERVICE.versioned_party_version_read",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
     },
     {
       "case": "I_EHR_DIRECTORY.create_directory-bad_ehr",
@@ -2269,6 +2359,18 @@
       "rows_total": 1
     },
     {
+      "case": "I_QUERY_SERVICE.execute_ad_hoc_query-ehr_id_header_get",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_QUERY_SERVICE.execute_ad_hoc_query-ehr_id_header_post",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_QUERY_SERVICE.execute_ad_hoc_query-empty_db",
       "status": "passed",
       "rows_driven": 1,
@@ -2335,6 +2437,12 @@
       "rows_total": 1
     },
     {
+      "case": "I_QUERY_SERVICE.execute_stored_query-ehr_id_header",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_QUERY_SERVICE.execute_stored_query-empty_db",
       "status": "passed",
       "rows_driven": 1,
@@ -2360,6 +2468,12 @@
     },
     {
       "case": "SEC-AUTHENTICATED_ACCESS-unauthenticated_sweep",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "SEC-AUTHENTICATED_ACCESS-www_authenticate_challenge",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -2572,6 +2686,18 @@
       "rows_total": 1
     },
     {
+      "case": "SF-LEGACY-nc_flat_media_unsupported",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "SF-LEGACY-tds2_accept_unsupported",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "SF-LEVELS-collapsed_wrappers",
       "status": "passed",
       "rows_driven": 1,
@@ -2753,6 +2879,12 @@
     },
     {
       "case": "SF-WT-web_template_get",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "SF-WT-web_template_json_accept",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1

--- a/docs/conformance/ehrbase-rs/verdicts.json
+++ b/docs/conformance/ehrbase-rs/verdicts.json
@@ -183,7 +183,7 @@
     }
   ],
   "coverage": {
-    "selected": 445,
-    "driven": 376
+    "selected": 467,
+    "driven": 398
   }
 }


### PR DESCRIPTION
The #373 group-1 closing run: fresh-composed SUT, the full 467-case catalogue, the first run with executed header matchers (#403). **398 passed / 0 failed / 0 errored / 69 registered N/A · 39 capability verdicts · 0 review findings.** Baseline only ratchets up: 450 → 467 cases.

Wire-verifies the whole #394–#401 wave: weak-ETag envelopes, Location-absence on 20 read/delete outcomes, Last-Modified, the 412 latest-version-uid echo, negotiated Content-Type, the committal merge family, legacy-media rejections, datetime lexical preservation.