### PR TITLE
fix(system): remove the bare-root OPTIONS / alias — one location, per the System API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Removed
+
+- **The bare-root `OPTIONS /` alias of the System API endpoint** (#420). The
+  System API defines exactly one location for the Options-and-Conformance
+  operation — the API base-path root (`OPTIONS {base_path}`, e.g.
+  `/ehrbase/rest/openehr/v1`); the extra bare-root mount was our own
+  duplication and answered identically. Clients probing `OPTIONS /` must use
+  the base path.
+
 ### Fixed
 
 - **Served OpenAPI: the System API's `OPTIONS` operation is now documented**

--- a/app/ehrbase-rest/src/api/system/options.rs
+++ b/app/ehrbase-rest/src/api/system/options.rs
@@ -177,12 +177,11 @@ impl SystemManifest {
 ///      `/demographic`, `/definition`, `/query`, and `/admin` when its group
 ///      is enabled), not [`SPEC_ENDPOINTS`] hardcoded;
 ///   2. it mounts this handler at the **API base-path root** (`cfg.base_path`,
-///      e.g. `OPTIONS /ehrbase/rest/openehr/v1`) — the root the OAS
-///      `servers`/`paths` describe;
-///   3. it keeps a bare-`/` mount as a compatibility alias for naive root
-///      probes (no openEHR spec mounts `OPTIONS /` outside the base path —
-///      our own compatibility choice);
-///   4. both mounts sit **above** the `CorsLayer` (that layer treats every
+///      e.g. `OPTIONS /ehrbase/rest/openehr/v1`) — the ONE location the
+///      System API defines (`system.openapi.yaml` `servers` `{baseUrl}/v1`,
+///      path `/`); the former bare-`/` alias was our own duplication,
+///      removed;
+///   3. the mount sits **above** the `CorsLayer` (that layer treats every
 ///      `OPTIONS` as a CORS preflight and short-circuits it), which is why the
 ///      handler is added after the middleware stack in `crate::router::router`.
 pub fn route<S>(manifest: Arc<SystemManifest>) -> MethodRouter<S>

--- a/app/ehrbase-rest/src/router.rs
+++ b/app/ehrbase-rest/src/router.rs
@@ -223,17 +223,16 @@ pub fn router(state: AppState, authenticator: Arc<Authenticator>) -> Router {
         endpoints,
     ));
 
-    // Mount at the API base-path root (System API) and keep a bare-`/` alias
-    // for naive root probes; every other request falls through to the
-    // CORS-wrapped application. Both sit above CORS so `OPTIONS` is not eaten as
-    // a preflight; real per-resource CORS preflights are on sub-paths and reach
-    // the CORS layer via the fallback.
+    // Mount at the API base-path root — the ONE location the System API
+    // defines (`system.openapi.yaml`: servers `{baseUrl}/v1`, path `/` — the
+    // operation lives at the API root, nowhere else; the former bare-`/`
+    // alias was our own duplication and is removed, #420). Every other
+    // request falls through to the CORS-wrapped application. The mount sits
+    // above CORS so `OPTIONS` is not eaten as a preflight; real per-resource
+    // CORS preflights are on sub-paths and reach the CORS layer via the
+    // fallback.
     let app: Router = Router::new()
-        .route(
-            &cfg.server.base_path,
-            system::options::route(manifest.clone()),
-        )
-        .route("/", system::options::route(manifest))
+        .route(&cfg.server.base_path, system::options::route(manifest))
         .fallback_service(inner);
 
     // Merge the management surface only when enabled AND not bound to a separate

--- a/app/ehrbase-rest/tests/protocol_tail.rs
+++ b/app/ehrbase-rest/tests/protocol_tail.rs
@@ -150,14 +150,17 @@ async fn commit_ips_composition(app: &Router) -> (String, String) {
     (ehr_id, etag_uid(&h))
 }
 
-// ── OPTIONS / (R32) ────────────────────────────────────────────────────────
+// ── OPTIONS on the API base path (the System API's one location) ──────────
 
 #[tokio::test]
 async fn options_root_is_system_options_and_conformance() {
     let (_pg, app) = app().await;
+    // The System API mounts at the API base-path root ONLY
+    // (`system.openapi.yaml` servers `{baseUrl}/v1`, path `/`); the former
+    // bare-`/` alias was our own duplication and is gone.
     let req = Request::builder()
         .method("OPTIONS")
-        .uri("/")
+        .uri(BASE)
         .body(Body::empty())
         .unwrap();
     let (status, h, body) = send(&app, req).await;

--- a/website/book/src/installation/configuration.md
+++ b/website/book/src/installation/configuration.md
@@ -137,8 +137,10 @@ The separate-port management listener always stays plain HTTP.
 
 ### `[server.identity]`
 
-The `OPTIONS /` System-Options manifest identity. Defaults are measured, not
-asserted — the manifest never out-claims the last conformance verdict.
+The System-Options manifest identity (`OPTIONS` on the API base path, e.g.
+`OPTIONS /ehrbase/rest/openehr/v1` — the System API's one location). Defaults
+are measured, not asserted — the manifest never out-claims the last
+conformance verdict.
 
 | Key | Type | Default | Description |
 |---|---|---|---|


### PR DESCRIPTION
Closes #420 (owner call during the #378 close-out: no duplications).

The Options-and-Conformance operation answered at two URLs — the spec-defined base-path root and a bare-root `OPTIONS /` alias that our own code flagged as spec-less. The System API defines exactly one location (`servers` `{baseUrl}/v1`, path `/`); the alias is removed. Test retargeted to the spec location (with the citation), book + changelog (`### Removed`) updated. The served OpenAPI already documented only the base-path location (#418), so document and wire now agree exactly.

## Gates
fmt clean · clippy zero warnings · nextest `ehrbase-rest` 503/503.