### PR TITLE
fix(ehr): bootstrap EHR_STATUS/EHR_ACCESS satisfy the RM archetype-root invariants; client bodies enforced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **EHR creation mints RM-valid EHR_STATUS and EHR_ACCESS objects; the RM
+  archetype-root invariants are enforced on client bodies** (#423). The
+  bootstrap defaults carried an archetype-HRID `archetype_node_id` with no
+  `archetype_details` — violating RM `Is_archetype_root` (unconditional on
+  both classes) with `Archetyped_valid` ("is_archetype_root xor
+  archetype_details = Void"). Both defaults now carry the `ARCHETYPED` block
+  (archetype_id = the node id, rm_version 1.2.0), and a client-supplied
+  EHR_STATUS/EHR_ACCESS violating `Archetyped_valid` (a root without
+  `archetype_details`, or a mismatching `archetype_id`) or `Links_valid`
+  (an explicit empty `links` list) is rejected with `422`. Clients that
+  previously committed root objects without `archetype_details` must now
+  supply it.
+
 ### Removed
 
 - **The bare-root `OPTIONS /` alias of the System API endpoint** (#420). The

--- a/app/ehrbase-rest/tests/ehr_access_gate.rs
+++ b/app/ehrbase-rest/tests/ehr_access_gate.rs
@@ -124,6 +124,13 @@ async fn seed_scheme(svc: &EhrbaseService, ehr_id: ehrbase::ids::EhrId, scheme: 
             "data": {
                 "_type": "EHR_ACCESS",
                 "archetype_node_id": "openEHR-EHR-EHR_ACCESS.generic.v1",
+                // Roots carry ARCHETYPED (LOCATABLE.Archetyped_valid).
+                "archetype_details": {
+                    "_type": "ARCHETYPED",
+                    "archetype_id": { "_type": "ARCHETYPE_ID",
+                                      "value": "openEHR-EHR-EHR_ACCESS.generic.v1" },
+                    "rm_version": "1.2.0"
+                },
                 "name": { "_type": "DV_TEXT", "value": "EHR Access" },
                 "settings": scheme
             }

--- a/app/ehrbase/src/service/ehr/access.rs
+++ b/app/ehrbase/src/service/ehr/access.rs
@@ -97,10 +97,17 @@ impl EhrbaseService {
 /// Creation). `EHR_ACCESS` is a LOCATABLE with only the
 /// optional `settings`; with no access-control scheme configured (Stage 1 has
 /// no RBAC), it is committed with none.
+///
+/// `archetype_details` is mandatory: `EHR_ACCESS` carries the same
+/// unconditional `Is_archetype_root` invariant as `EHR_STATUS`
+/// (RM ehr `ehr_access.adoc`), so `Archetyped_valid` (RM common
+/// `locatable.adoc`) requires the `ARCHETYPED` block on the root.
 pub(in crate::service) fn default_ehr_access() -> Value {
     json!({
         "_type": "EHR_ACCESS",
         "archetype_node_id": "openEHR-EHR-EHR_ACCESS.generic.v1",
+        "archetype_details":
+            crate::service::ehr::service::archetyped("openEHR-EHR-EHR_ACCESS.generic.v1"),
         "name": { "_type": "DV_TEXT", "value": "EHR Access" }
     })
 }

--- a/app/ehrbase/src/service/ehr/service.rs
+++ b/app/ehrbase/src/service/ehr/service.rs
@@ -404,14 +404,34 @@ impl EhrbaseService {
 
 /// The default `EHR_STATUS` for a new EHR (queryable, modifiable,
 /// `PARTY_SELF`) — RM ehr master04 §EHR Creation.
+///
+/// `archetype_details` is mandatory here: `EHR_STATUS` is unconditionally an
+/// archetype root (RM ehr `ehr_status.adoc` invariant `Is_archetype_root`),
+/// and RM common `locatable.adoc` `Archetyped_valid: is_archetype_root xor
+/// archetype_details = Void` makes a root without `archetype_details`
+/// RM-invalid; at a root, `archetype_node_id` "is always the stringified
+/// form of the `archetype_id` found in the `archetype_details` object"
+/// (`locatable.adoc` §`archetype_node_id`).
 pub(in crate::service) fn default_ehr_status() -> Value {
     json!({
         "_type": "EHR_STATUS",
         "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
+        "archetype_details": archetyped("openEHR-EHR-EHR_STATUS.generic.v1"),
         "name": { "_type": "DV_TEXT", "value": "EHR Status" },
         "subject": { "_type": "PARTY_SELF" },
         "is_queryable": true,
         "is_modifiable": true
+    })
+}
+
+/// A root `ARCHETYPED` block for a server-minted LOCATABLE (RM common
+/// `archetyped.adoc`: `archetype_id` 1..1, `rm_version` 1..1 — the RM
+/// release this server implements, `docs/VERSIONS.md`).
+pub(in crate::service) fn archetyped(archetype_id: &str) -> Value {
+    json!({
+        "_type": "ARCHETYPED",
+        "archetype_id": { "_type": "ARCHETYPE_ID", "value": archetype_id },
+        "rm_version": "1.2.0"
     })
 }
 

--- a/app/ehrbase/src/service/ehr/validation.rs
+++ b/app/ehrbase/src/service/ehr/validation.rs
@@ -290,6 +290,64 @@ fn is_persistent(composition: &Value) -> bool {
 ///
 /// # Errors
 /// [`ServiceError::Unprocessable`] naming the first violated rule (→ 422).
+/// The root-LOCATABLE invariants shared by the always-root EHR kinds
+/// (`EHR_STATUS`, `EHR_ACCESS` — RM ehr `ehr_status.adoc` /
+/// `ehr_access.adoc`, each with an unconditional `Is_archetype_root`):
+///
+/// - `Archetyped_valid` (RM common `locatable.adoc`: `is_archetype_root xor
+///   archetype_details = Void`) — a root MUST carry the `ARCHETYPED` block;
+/// - at a root, `archetype_node_id` "is always the stringified form of the
+///   `archetype_id` found in the `archetype_details` object"
+///   (`locatable.adoc` §`archetype_node_id`);
+/// - `Links_valid` (`links /= Void implies not links.is_empty`) — an
+///   explicit empty list is RM-invalid (absent is the way to say none).
+fn validate_root_locatable(
+    obj: &serde_json::Map<String, Value>,
+    kind: &str,
+) -> Result<(), ServiceError> {
+    let unproc = ServiceError::Unprocessable;
+    let details = obj
+        .get("archetype_details")
+        .filter(|v| v.is_object())
+        .ok_or_else(|| {
+            unproc(format!(
+                "{kind}.archetype_details is mandatory: {kind} is an archetype \
+                 root (Is_archetype_root) and a root without ARCHETYPED \
+                 violates LOCATABLE.Archetyped_valid"
+            ))
+        })?;
+    let declared_id = details
+        .get("archetype_id")
+        .and_then(|a| a.get("value"))
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            unproc(format!(
+                "{kind}.archetype_details.archetype_id.value is mandatory \
+                 (ARCHETYPED.archetype_id 1..1)"
+            ))
+        })?;
+    let node_id = obj
+        .get("archetype_node_id")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if declared_id != node_id {
+        return Err(unproc(format!(
+            "{kind}.archetype_node_id {node_id:?} must equal \
+             archetype_details.archetype_id.value {declared_id:?} at an \
+             archetype root (LOCATABLE archetype_node_id)"
+        )));
+    }
+    if let Some(links) = obj.get("links")
+        && links.as_array().is_some_and(Vec::is_empty)
+    {
+        return Err(unproc(format!(
+            "{kind}.links must be absent or non-empty (LOCATABLE.Links_valid)"
+        )));
+    }
+    Ok(())
+}
+
 pub(in crate::service) fn validate_ehr_status(status: &Value) -> Result<(), ServiceError> {
     let unproc = |m: String| ServiceError::Unprocessable(m);
     let obj = status
@@ -325,6 +383,7 @@ pub(in crate::service) fn validate_ehr_status(status: &Value) -> Result<(), Serv
             ));
         }
     }
+    validate_root_locatable(obj, "EHR_STATUS")?;
     if !obj.get("is_queryable").is_some_and(Value::is_boolean) {
         return Err(unproc(
             "EHR_STATUS.is_queryable is mandatory (1..1 Boolean)".to_owned(),
@@ -450,6 +509,10 @@ pub(in crate::service) fn validate_ehr_access(access: &Value) -> Result<(), Serv
                 .to_owned(),
         ));
     }
+    // EHR_ACCESS carries the same unconditional Is_archetype_root as
+    // EHR_STATUS (RM ehr `ehr_access.adoc`), so the root-LOCATABLE
+    // invariants apply identically.
+    validate_root_locatable(obj, "EHR_ACCESS")?;
     if let Some(settings) = obj.get("settings").filter(|v| !v.is_null())
         && settings
             .get("_type")
@@ -592,6 +655,12 @@ mod tests {
         let identified = json!({
             "_type": "EHR_STATUS",
             "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
+            "archetype_details": {
+                "_type": "ARCHETYPED",
+                "archetype_id": { "_type": "ARCHETYPE_ID",
+                                  "value": "openEHR-EHR-EHR_STATUS.generic.v1" },
+                "rm_version": "1.2.0"
+            },
             "name": { "_type": "DV_TEXT", "value": "EHR Status" },
             "subject": {
                 "_type": "PARTY_SELF",
@@ -616,6 +685,12 @@ mod tests {
         let bad = json!({
             "_type": "EHR_STATUS",
             "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
+            "archetype_details": {
+                "_type": "ARCHETYPED",
+                "archetype_id": { "_type": "ARCHETYPE_ID",
+                                  "value": "openEHR-EHR-EHR_STATUS.generic.v1" },
+                "rm_version": "1.2.0"
+            },
             "name": { "_type": "DV_TEXT", "value": "EHR Status" },
             "subject": {
                 "_type": "PARTY_IDENTIFIED",
@@ -646,6 +721,12 @@ mod tests {
             let status = json!({
                 "_type": "EHR_STATUS",
                 "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
+                "archetype_details": {
+                    "_type": "ARCHETYPED",
+                    "archetype_id": { "_type": "ARCHETYPE_ID",
+                                      "value": "openEHR-EHR-EHR_STATUS.generic.v1" },
+                    "rm_version": "1.2.0"
+                },
                 "name": { "_type": "DV_TEXT", "value": "EHR Status" },
                 "subject": subject,
                 "is_queryable": true,
@@ -656,13 +737,20 @@ mod tests {
     }
 
     /// Every vendored `EHR_STATUS` data set the CNF corpus labels invalid
-    /// (`master06 §Test Data Sets`, INVALID class 2) must be rejected — with
-    /// one spec-cited exception: `001_ehr_status_subject_empty.json`
-    /// (`subject: {}`) is spec-VALID (an empty `PARTY_SELF` is a completely
-    /// anonymous subject, master04), a documented corpus-vs-spec adjudication.
+    /// (`master06 §Test Data Sets`, INVALID class 2) must be rejected.
+    ///
+    /// Re-adjudicated with the `Archetyped_valid` enforcement: the former
+    /// exception `001_ehr_status_subject_empty.json` (its `subject: {}` IS
+    /// spec-valid — an empty `PARTY_SELF` is a completely anonymous subject,
+    /// RM ehr master04) is nonetheless rejected as a WHOLE, because like
+    /// every fixture in this corpus it carries a root `archetype_node_id`
+    /// with no `archetype_details` (RM common `locatable.adoc`
+    /// `Archetyped_valid`; RM ehr `ehr_status.adoc` `Is_archetype_root`) —
+    /// so its INVALID label holds, on different grounds than the corpus
+    /// intended. The subject-emptiness half of the old adjudication is
+    /// pinned by `anonymous_ehr_status_subject_is_accepted` above.
     #[test]
     fn every_invalid_ehr_status_fixture_is_rejected() {
-        const SPEC_VALID_ANONYMOUS: &str = "001_ehr_status_subject_empty.json";
         let dir = concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/../../docs/specs/openehr/CNF/tests/platform/robot/_resources/test_data_sets/ehr/invalid"
@@ -675,20 +763,11 @@ mod tests {
             }
             let text = std::fs::read_to_string(&path).expect("read fixture");
             let status: Value = serde_json::from_str(&text).expect("parse fixture");
-            let is_anon = path.file_name().and_then(|n| n.to_str()) == Some(SPEC_VALID_ANONYMOUS);
-            if is_anon {
-                validate_ehr_status(&status).unwrap_or_else(|e| {
-                    panic!(
-                        "spec-valid anonymous EHR_STATUS ({SPEC_VALID_ANONYMOUS}) was rejected: {e}"
-                    )
-                });
-            } else {
-                assert!(
-                    validate_ehr_status(&status).is_err(),
-                    "invalid EHR_STATUS fixture was accepted: {}",
-                    path.display()
-                );
-            }
+            assert!(
+                validate_ehr_status(&status).is_err(),
+                "invalid EHR_STATUS fixture was accepted: {}",
+                path.display()
+            );
             checked += 1;
         }
         assert_eq!(checked, 11, "expected 11 invalid EHR_STATUS fixtures");
@@ -705,14 +784,26 @@ mod tests {
             .expect_err("foreign _type rejected");
         assert!(err.to_string().contains("EHR_ACCESS"), "got {err}");
         let err = validate_ehr_access(&json!({
-            "_type": "EHR_ACCESS", "archetype_node_id": "openEHR-EHR-EHR_ACCESS.generic.v1"
-        }))
+                   "_type": "EHR_ACCESS", "archetype_node_id": "openEHR-EHR-EHR_ACCESS.generic.v1",
+        "archetype_details": {
+            "_type": "ARCHETYPED",
+            "archetype_id": { "_type": "ARCHETYPE_ID",
+                              "value": "openEHR-EHR-EHR_ACCESS.generic.v1" },
+            "rm_version": "1.2.0"
+        },
+               }))
         .expect_err("missing name rejected");
         assert!(err.to_string().contains("name"), "got {err}");
         let err = validate_ehr_access(&json!({
             "_type": "EHR_ACCESS",
             "name": { "_type": "DV_TEXT", "value": "EHR Access" },
             "archetype_node_id": "openEHR-EHR-EHR_ACCESS.generic.v1",
+            "archetype_details": {
+                "_type": "ARCHETYPED",
+                "archetype_id": { "_type": "ARCHETYPE_ID",
+                                  "value": "openEHR-EHR-EHR_ACCESS.generic.v1" },
+                "rm_version": "1.2.0"
+            },
             "settings": { "scheme": "acme" }
         }))
         .expect_err("settings without a concrete _type rejected (Scheme_valid)");

--- a/app/ehrbase/tests/multimedia_s3.rs
+++ b/app/ehrbase/tests/multimedia_s3.rs
@@ -143,6 +143,13 @@ fn status_with_media(media: Value) -> Value {
         "_type": "EHR_STATUS",
         "name": { "_type": "DV_TEXT", "value": "EHR Status" },
         "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
+        // Roots carry ARCHETYPED (LOCATABLE.Archetyped_valid).
+        "archetype_details": {
+            "_type": "ARCHETYPED",
+            "archetype_id": { "_type": "ARCHETYPE_ID",
+                              "value": "openEHR-EHR-EHR_STATUS.generic.v1" },
+            "rm_version": "1.2.0"
+        },
         "subject": { "_type": "PARTY_SELF" },
         "is_queryable": true,
         "is_modifiable": true,

--- a/app/ehrbase/tests/resources/config/ehr_status.json
+++ b/app/ehrbase/tests/resources/config/ehr_status.json
@@ -16,5 +16,13 @@
     }
   },
   "is_queryable": true,
-  "is_modifiable": true
+  "is_modifiable": true,
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-EHR_STATUS.generic.v1"
+    },
+    "rm_version": "1.2.0"
+  }
 }

--- a/app/ehrbase/tests/service_contribution.rs
+++ b/app/ehrbase/tests/service_contribution.rs
@@ -409,6 +409,12 @@ fn ehr_status(queryable: bool) -> Value {
     json!({
         "_type": "EHR_STATUS",
         "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
+        "archetype_details": {
+            "_type": "ARCHETYPED",
+            "archetype_id": { "_type": "ARCHETYPE_ID",
+                              "value": "openEHR-EHR-EHR_STATUS.generic.v1" },
+            "rm_version": "1.2.0"
+        },
         "name": { "_type": "DV_TEXT", "value": "EHR Status" },
         "subject": { "_type": "PARTY_SELF" },
         "is_queryable": queryable,
@@ -1046,6 +1052,12 @@ async fn create_composition_gate_error_surface_survives_the_writability_fold() {
     let deactivated = json!({
         "_type": "EHR_STATUS",
         "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
+        "archetype_details": {
+            "_type": "ARCHETYPED",
+            "archetype_id": { "_type": "ARCHETYPE_ID",
+                              "value": "openEHR-EHR-EHR_STATUS.generic.v1" },
+            "rm_version": "1.2.0"
+        },
         "name": { "_type": "DV_TEXT", "value": "EHR Status" },
         "subject": { "_type": "PARTY_SELF" },
         "is_queryable": true,

--- a/app/ehrbase/tests/service_ehr.rs
+++ b/app/ehrbase/tests/service_ehr.rs
@@ -719,6 +719,12 @@ async fn ehr_status_subject_type_is_enforced_end_to_end() {
     let wrong_subject = json!({
         "_type": "EHR_STATUS",
         "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
+        "archetype_details": {
+            "_type": "ARCHETYPED",
+            "archetype_id": { "_type": "ARCHETYPE_ID",
+                              "value": "openEHR-EHR-EHR_STATUS.generic.v1" },
+            "rm_version": "1.2.0"
+        },
         "name": { "_type": "DV_TEXT", "value": "EHR Status" },
         "subject": {
             "_type": "PARTY_IDENTIFIED",
@@ -774,6 +780,12 @@ async fn ehr_status_subject_type_is_enforced_end_to_end() {
     let anonymous = json!({
         "_type": "EHR_STATUS",
         "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
+        "archetype_details": {
+            "_type": "ARCHETYPED",
+            "archetype_id": { "_type": "ARCHETYPE_ID",
+                              "value": "openEHR-EHR-EHR_STATUS.generic.v1" },
+            "rm_version": "1.2.0"
+        },
         "name": { "_type": "DV_TEXT", "value": "EHR Status" },
         "subject": {},
         "is_queryable": true,
@@ -1053,6 +1065,12 @@ async fn ehr_get_by_subject_finds_the_ehr() {
     let status = json!({
         "_type": "EHR_STATUS",
         "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
+        "archetype_details": {
+            "_type": "ARCHETYPED",
+            "archetype_id": { "_type": "ARCHETYPE_ID",
+                              "value": "openEHR-EHR-EHR_STATUS.generic.v1" },
+            "rm_version": "1.2.0"
+        },
         "name": { "_type": "DV_TEXT", "value": "EHR Status" },
         // EHR_STATUS.subject is PARTY_SELF (RM ehr master04); the subject is
         // identified via its external_ref, not a PARTY_IDENTIFIED type.
@@ -1573,6 +1591,12 @@ async fn duplicate_subject_ehr_creation_conflicts() {
         json!({
             "_type": "EHR_STATUS",
             "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
+            "archetype_details": {
+                "_type": "ARCHETYPED",
+                "archetype_id": { "_type": "ARCHETYPE_ID",
+                                  "value": "openEHR-EHR-EHR_STATUS.generic.v1" },
+                "rm_version": "1.2.0"
+            },
             "name": { "_type": "DV_TEXT", "value": "EHR Status" },
             // EHR_STATUS.subject is PARTY_SELF (RM ehr master04); identified by
             // its external_ref.

--- a/app/ehrbase/tests/service_ehr_access.rs
+++ b/app/ehrbase/tests/service_ehr_access.rs
@@ -43,6 +43,13 @@ fn ehr_access_with_settings() -> Value {
     json!({
         "_type": "EHR_ACCESS",
         "archetype_node_id": "openEHR-EHR-EHR_ACCESS.generic.v1",
+        // Roots carry ARCHETYPED (LOCATABLE.Archetyped_valid).
+        "archetype_details": {
+            "_type": "ARCHETYPED",
+            "archetype_id": { "_type": "ARCHETYPE_ID",
+                              "value": "openEHR-EHR-EHR_ACCESS.generic.v1" },
+            "rm_version": "1.2.0"
+        },
         "name": { "_type": "DV_TEXT", "value": "EHR Access" },
         "settings": {
             "_type": "EHRBASE_ACCESS_CONTROL_V1",

--- a/app/ehrbase/tests/service_events.rs
+++ b/app/ehrbase/tests/service_events.rs
@@ -331,6 +331,12 @@ async fn rolled_back_commit_writes_no_outbox_row() {
     let status = json!({
         "_type": "EHR_STATUS",
         "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
+        "archetype_details": {
+            "_type": "ARCHETYPED",
+            "archetype_id": { "_type": "ARCHETYPE_ID",
+                              "value": "openEHR-EHR-EHR_STATUS.generic.v1" },
+            "rm_version": "1.2.0"
+        },
         "name": { "_type": "DV_TEXT", "value": "EHR Status" },
         "subject": {
             "_type": "PARTY_SELF",

--- a/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
+++ b/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
@@ -1175,6 +1175,15 @@ cnf.ehr_status.invalid.missing-subject:
     defect: "RM/Schema: subject is mandatory"
     spec_ref: "RM ehr §EHR_STATUS (subject 1..1)"
   provenance: "openEHR CNF Robot corpus (vendored docs/specs/openehr/CNF/tests/platform/robot @ the CNF pin); re-adjudicated 2026-07-21 to spec-text-only evidence"
+cnf.ehr_status.invalid.missing-archetype-details:
+  source: fixtures/ehr/invalid/ehr_status.missing_archetype_details.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "RM: an archetype root without archetype_details violates LOCATABLE.Archetyped_valid"
+    spec_ref: "RM common locatable.adoc (Archetyped_valid: is_archetype_root xor archetype_details = Void) + RM ehr ehr_status.adoc (Is_archetype_root)"
+  provenance: "authored 2026-07-26 for the #379 audit's Archetyped_valid enforcement (#423)"
 cnf.ehr_status.invalid.invalid-other-details:
   source: fixtures/ehr/invalid/ehr_status.invalid_other_details.json
   format: canonical-json

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/ehr_status.invalid.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/ehr_status.invalid.json
@@ -1,7 +1,18 @@
 {
   "_type": "EHR_STATUS",
-  "name": { "_type": "DV_TEXT", "value": "EHR Status" },
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "EHR Status"
+  },
   "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
   "is_queryable": true,
-  "is_modifiable": true
+  "is_modifiable": true,
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-EHR_STATUS.generic.v1"
+    },
+    "rm_version": "1.2.0"
+  }
 }

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/ehr_status.minimal.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/ehr_status.minimal.json
@@ -8,5 +8,13 @@
     "_type": "PARTY_SELF"
   },
   "is_modifiable": true,
-  "is_queryable": true
+  "is_queryable": true,
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-EHR_STATUS.generic.v1"
+    },
+    "rm_version": "1.2.0"
+  }
 }

--- a/tools/cnf-runner/artifacts/corpus/fixtures/ehr/ehr_status.with_subject.alt.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/ehr/ehr_status.with_subject.alt.json
@@ -16,5 +16,13 @@
     }
   },
   "is_modifiable": true,
-  "is_queryable": true
+  "is_queryable": true,
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-EHR_STATUS.generic.v1"
+    },
+    "rm_version": "1.2.0"
+  }
 }

--- a/tools/cnf-runner/artifacts/corpus/fixtures/ehr/ehr_status.with_subject.b.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/ehr/ehr_status.with_subject.b.json
@@ -16,5 +16,13 @@
     }
   },
   "is_modifiable": true,
-  "is_queryable": true
+  "is_queryable": true,
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-EHR_STATUS.generic.v1"
+    },
+    "rm_version": "1.2.0"
+  }
 }

--- a/tools/cnf-runner/artifacts/corpus/fixtures/ehr/ehr_status.with_subject.c.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/ehr/ehr_status.with_subject.c.json
@@ -16,5 +16,13 @@
     }
   },
   "is_modifiable": true,
-  "is_queryable": true
+  "is_queryable": true,
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-EHR_STATUS.generic.v1"
+    },
+    "rm_version": "1.2.0"
+  }
 }

--- a/tools/cnf-runner/artifacts/corpus/fixtures/ehr/ehr_status.with_subject.d.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/ehr/ehr_status.with_subject.d.json
@@ -16,5 +16,13 @@
     }
   },
   "is_modifiable": true,
-  "is_queryable": true
+  "is_queryable": true,
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-EHR_STATUS.generic.v1"
+    },
+    "rm_version": "1.2.0"
+  }
 }

--- a/tools/cnf-runner/artifacts/corpus/fixtures/ehr/ehr_status.with_subject.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/ehr/ehr_status.with_subject.json
@@ -16,5 +16,13 @@
     }
   },
   "is_modifiable": true,
-  "is_queryable": true
+  "is_queryable": true,
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-EHR_STATUS.generic.v1"
+    },
+    "rm_version": "1.2.0"
+  }
 }

--- a/tools/cnf-runner/artifacts/corpus/fixtures/ehr/invalid/ehr_status.missing_archetype_details.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/ehr/invalid/ehr_status.missing_archetype_details.json
@@ -1,0 +1,13 @@
+{
+  "_type": "EHR_STATUS",
+  "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "EHR Status"
+  },
+  "subject": {
+    "_type": "PARTY_SELF"
+  },
+  "is_queryable": true,
+  "is_modifiable": true
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/ehr/invalid/ehr_status.missing_is_modifiable.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/ehr/invalid/ehr_status.missing_is_modifiable.json
@@ -15,5 +15,13 @@
       "type": "PERSON"
     }
   },
-  "is_queryable": true
+  "is_queryable": true,
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-EHR_STATUS.generic.v1"
+    },
+    "rm_version": "1.2.0"
+  }
 }

--- a/tools/cnf-runner/artifacts/corpus/fixtures/ehr/invalid/ehr_status.missing_is_queryable.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/ehr/invalid/ehr_status.missing_is_queryable.json
@@ -15,5 +15,13 @@
       "type": "PERSON"
     }
   },
-  "is_modifiable": true
+  "is_modifiable": true,
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-EHR_STATUS.generic.v1"
+    },
+    "rm_version": "1.2.0"
+  }
 }

--- a/tools/cnf-runner/artifacts/corpus/fixtures/ehr/invalid/ehr_status.missing_subject.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/ehr/invalid/ehr_status.missing_subject.json
@@ -5,5 +5,13 @@
     "value": "EHR Status"
   },
   "is_modifiable": true,
-  "is_queryable": true
+  "is_queryable": true,
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-EHR_STATUS.generic.v1"
+    },
+    "rm_version": "1.2.0"
+  }
 }

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.create_ehr-invalid_status.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.create_ehr-invalid_status.yaml
@@ -26,6 +26,7 @@ parameters:
     - { data_set: cnf.ehr_status.invalid.missing-is-modifiable, expected: validation_failed, defect: "RM/Schema: is_modifiable is mandatory" }
     - { data_set: cnf.ehr_status.invalid.missing-subject, expected: validation_failed, defect: "RM/Schema: subject is mandatory" }
     - { data_set: cnf.ehr_status.invalid.invalid-other-details, expected: validation_failed, defect: "EHR_STATUS carries no _type discriminator" }
+    - { data_set: cnf.ehr_status.invalid.missing-archetype-details, expected: validation_failed, defect: "RM: archetype root without archetype_details (Archetyped_valid)" }
 flow:
   - step: 1
     call: create_ehr


### PR DESCRIPTION
Closes #423 — fix 2 of the #379 (group-3) wave; orchestrator-implemented (validation critical path).

## What shipped

**The server no longer mints RM-invalid objects on every EHR create.** `default_ehr_status()` and `default_ehr_access()` carried a root `archetype_node_id` with NO `archetype_details` — violating the unconditional `Is_archetype_root` (RM ehr `ehr_status.adoc`/`ehr_access.adoc`) with `Archetyped_valid` (RM common `locatable.adoc`: "is_archetype_root xor archetype_details = Void"). Both defaults now carry the `ARCHETYPED` block (archetype_id = the node id — `locatable.adoc`: at a root the node id "is always the stringified form of the archetype_id"; rm_version 1.2.0).

**Enforcement on client bodies** via a shared `validate_root_locatable` (EHR_STATUS + EHR_ACCESS): missing `ARCHETYPED`, a mismatching `archetype_id`, or an explicit empty `links` list (`Links_valid`) → 422.

**Blast radius handled honestly:** ~25 test/corpus fixtures were RM-invalid all along and are updated TOWARD the RM (never weakening the check); the CNF corpus adjudication for `001_ehr_status_subject_empty.json` is re-recorded — its `subject: {}` half remains spec-valid (pinned separately) but the fixture as a whole now rejects on `Archetyped_valid`, so its INVALID label holds on different grounds than the corpus intended. New invalid fixture `ehr_status.missing_archetype_details` + case row pin the new 422.

**Zero ambiguity-register entries** (owner ruling): the stalled OAS example sharing the defect is noise; the RM invariants stand alone.

## Gates
fmt clean · clippy zero warnings · nextest **1304/1304** (all three crates) · CNF validate 468/106/0. Changelog (behaviour change for clients committing root objects without `archetype_details`).

Wave: 2 of 8 (#422 ✅). Next: #424–#428.