### PR TITLE
fix(ehr): make the openEHR system_id deployment-configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,24 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Added
+
+- **`[server] system_id` — the deployment's own openEHR system identifier is
+  now configurable** (#424, `EHRBASE__SERVER__SYSTEM_ID`, default unchanged at
+  `ehrbase-rs.local`). The value is stamped into `EHR.system_id` at EHR
+  creation (RM *EHR Information Model* §EHR Identifier Allocation: the
+  identifier "that would normally be used for locally created EHRs"), into
+  `AUDIT_DETAILS.system_id` whenever the client supplies none through
+  `openehr-audit-details` (the REST API requires the server to "set it to its
+  own configured system identifier"), and into every minted
+  `OBJECT_VERSION_ID.creating_system_id`. Previously it was a hard-coded
+  constant that no configuration could change. Choose it before the first EHR
+  is created and keep it stable — the value is stored per EHR and per version,
+  so a later change affects only newly authored data and never rewrites
+  existing identifiers. It is distinct from `[server.identity]`, which is only
+  the `OPTIONS` manifest's display identity. An empty value, or one containing
+  the `OBJECT_VERSION_ID` separator `::`, is refused at boot.
+
 ### Fixed
 
 - **EHR creation mints RM-valid EHR_STATUS and EHR_ACCESS objects; the RM

--- a/app/ehrbase-server/src/main.rs
+++ b/app/ehrbase-server/src/main.rs
@@ -243,8 +243,14 @@ async fn serve(config_path: Option<&Path>, overrides: &[(String, String)]) -> an
         "version signing configured"
     );
 
+    // The data-authoring identity every commit stamps into `EHR.system_id`,
+    // `AUDIT_DETAILS.system_id`, and `OBJECT_VERSION_ID.creating_system_id`
+    // (`[server] system_id`) — logged so an operator can see the key took.
+    tracing::info!(system_id = %config.server.system_id, "openEHR system identifier");
+
     let audit_enabled = audit_sender.is_some();
     let mut service = EhrbaseService::new(pool.clone())
+        .with_system_id(config.server.system_id.clone())
         .with_signer(signer)
         .with_outbox_enabled(outbox_enabled)
         .with_query_config(&config.query);

--- a/app/ehrbase/assets/ehrbase.default.toml
+++ b/app/ehrbase/assets/ehrbase.default.toml
@@ -18,6 +18,13 @@ base_path = "/ehrbase/rest/openehr/v1"
 max_in_flight = 256          # concurrent-request admission cap; 0 disables shedding
 swagger_ui = true            # PROD: consider false
 cors_permissive = false      # PROD: keep false; configure explicit origins
+# This CDR's own openEHR system identifier: stamped into EHR.system_id, the
+# AUDIT_DETAILS.system_id server default, and every
+# OBJECT_VERSION_ID.creating_system_id. PROD: set a stable, deployment-unique
+# name (a DNS-style host name is the common convention). Changing it never
+# rewrites identifiers already committed. Distinct from [server.identity],
+# which is only the OPTIONS manifest's display identity.
+system_id = "ehrbase-rs.local"
 
 # [server.tls] — native TLS + client-certificate (mutual-TLS) authentication
 # on the main listener (the IHE ATNA ITI-19 node-authentication posture;

--- a/app/ehrbase/src/config/mod.rs
+++ b/app/ehrbase/src/config/mod.rs
@@ -91,6 +91,33 @@ impl EhrbaseConfig {
     pub fn validate(&self) -> Result<(), ConfigErrors> {
         let mut errors = Vec::new();
 
+        // server.system_id is stamped into every AUDIT_DETAILS, whose
+        // `system_id` carries the RM invariant `System_id_valid`:
+        // "not system_id.is_empty" (RM
+        // `docs/UML/classes/org.openehr.rm.common.audit_details.adoc`
+        // §Invariants). An empty value would author RM-invalid data, so it
+        // fails at boot.
+        if self.server.system_id.trim().is_empty() {
+            errors.push(ConfigError::semantic(
+                "server.system_id must not be empty (it is stamped into \
+                 EHR.system_id, AUDIT_DETAILS.system_id, and every \
+                 OBJECT_VERSION_ID)"
+                    .to_owned(),
+            ));
+        }
+        // `::` is the OBJECT_VERSION_ID field separator — "object_version_id =
+        // object_id, '::', creating_system_id, '::', version_tree_id" (BASE
+        // `base_types/master05-identification_package.adoc` §Syntaxes) — so a
+        // system id containing it would mint unparseable
+        // version identifiers.
+        if self.server.system_id.contains("::") {
+            errors.push(ConfigError::semantic(
+                "server.system_id must not contain \"::\" (the \
+                 OBJECT_VERSION_ID field separator)"
+                    .to_owned(),
+            ));
+        }
+
         // Authorization rules (moved verbatim from the old AuthzConfig::validate).
         if let Err(e) = self.authz.validate() {
             errors.push(ConfigError::semantic(format!("authz: {e}")));
@@ -389,6 +416,35 @@ mod tests {
         );
     }
 
+    /// `[server] system_id` — the CDR's own openEHR system identifier (stamped
+    /// into `EHR.system_id`, the `AUDIT_DETAILS.system_id` server default, and
+    /// every `OBJECT_VERSION_ID.creating_system_id`). Pins all three layers:
+    /// the compatibility default, the file value, and the `EHRBASE__` env form.
+    #[test]
+    fn server_system_id_default_file_and_env() {
+        // Default: unchanged from the service-layer constant, so an unset key
+        // boots byte-identically to previous behaviour.
+        let c = assemble_ok(None, &env(&[]), &[]);
+        assert_eq!(c.server.system_id, crate::service::DEFAULT_SYSTEM_ID);
+
+        // File.
+        let file = toml_file("[server]\nsystem_id = \"cdr.hospital.example\"\n");
+        let c = assemble_ok(Some(file.path()), &env(&[]), &[]);
+        assert_eq!(c.server.system_id, "cdr.hospital.example");
+
+        // Env wins over the file (the P-4 uniform grammar).
+        let c = assemble_ok(
+            Some(file.path()),
+            &env(&[("EHRBASE__SERVER__SYSTEM_ID", "cdr.env.example")]),
+            &[],
+        );
+        assert_eq!(c.server.system_id, "cdr.env.example");
+
+        // `system_id` and the `[server.identity]` display identity are
+        // independent knobs — setting one must not disturb the other.
+        assert_eq!(c.server.identity.solution, "EHRbase-RS");
+    }
+
     // ── 3. Strictness ─────────────────────────────────────────────────────────
 
     #[test]
@@ -604,6 +660,27 @@ mod tests {
         c.management.port = Some(8080);
         assert!(c.validate().is_err());
         c.management.port = Some(9100);
+        assert!(c.validate().is_ok());
+    }
+
+    /// An empty `system_id` would author `AUDIT_DETAILS` violating the RM
+    /// invariant `System_id_valid` ("not `system_id.is_empty`"), and a `::` in it
+    /// would mint unparseable `OBJECT_VERSION_ID`s — both are boot errors.
+    #[test]
+    fn validate_system_id_is_non_empty_and_separator_free() {
+        let mut c = EhrbaseConfig::default();
+        assert!(c.validate().is_ok());
+
+        c.server.system_id = "   ".to_owned();
+        assert!(c.validate().is_err(), "blank system_id must be rejected");
+
+        c.server.system_id = "cdr::hospital".to_owned();
+        assert!(
+            c.validate().is_err(),
+            "a system_id containing the OBJECT_VERSION_ID separator must be rejected"
+        );
+
+        c.server.system_id = "cdr.hospital.example".to_owned();
         assert!(c.validate().is_ok());
     }
 

--- a/app/ehrbase/src/config/server.rs
+++ b/app/ehrbase/src/config/server.rs
@@ -37,10 +37,42 @@ pub struct ServerConfig {
     pub swagger_ui: bool,
     /// Permissive CORS (dev only). Production configures explicit origins.
     pub cors_permissive: bool,
+    /// This CDR's own openEHR **system identifier** — the identity the
+    /// deployment stamps into the data it authors
+    /// (`EHRBASE__SERVER__SYSTEM_ID`). Three wire values carry it:
+    ///
+    /// - `EHR.system_id` at EHR creation — RM ehr
+    ///   `master04-ehr_package.adoc` §EHR Identifier Allocation: "the
+    ///   `EHR._system_id_` value should be set to the value that would normally
+    ///   be used for locally created EHRs";
+    /// - the `AUDIT_DETAILS.system_id` server default when the client supplies
+    ///   none through `openehr-audit-details` — ITS-REST
+    ///   `specifications/docs/overview/Requests_and_responses.md`
+    ///   §"openehr-version and openehr-audit-details": "when `system_id` is
+    ///   not provided by the client, the server MUST set it to its own
+    ///   configured system identifier";
+    /// - every `OBJECT_VERSION_ID.creating_system_id` a commit mints — RM
+    ///   common `master06-change_control_package.adoc` §Distributed
+    ///   Versioning. That value is stored per version, so changing this key
+    ///   never rewrites identifiers already committed.
+    ///
+    /// **Distinct from [`SystemOptionsConfig`] (`[server.identity]`)**: the
+    /// identity block is the *display* identity of the `OPTIONS` System-Options
+    /// manifest (who supplies the software and which profile it claims);
+    /// `system_id` names *which system authored the data*. They are set
+    /// independently. With multi-tenancy on, a resolved tenant's own
+    /// `system_id` takes precedence over this default for that request.
+    ///
+    /// Defaults to [`crate::service::DEFAULT_SYSTEM_ID`] — the pre-existing
+    /// value, so an unset key is byte-identical to previous behaviour. No
+    /// openEHR spec governs the configuration mechanism — our own design; the
+    /// specs govern only that a system HAS such an identifier.
+    pub system_id: String,
     /// The `OPTIONS /` System-Options manifest identity (`[server.identity]`,
     /// §3.1). Sourced from config so the public identity and advertised profile
     /// are not string literals in the handler; the live endpoint list is
-    /// supplied separately by [`crate::router`].
+    /// supplied separately by [`crate::router`]. This is the *display* identity
+    /// of the manifest — the data-authoring identity is [`Self::system_id`].
     pub identity: SystemOptionsConfig,
     /// `[server.tls]` — native TLS termination + client-certificate
     /// authentication (the IHE ATNA ITI-19 node-authentication posture).
@@ -94,6 +126,7 @@ impl Default for ServerConfig {
             max_in_flight: default_max_in_flight(),
             swagger_ui: true,
             cors_permissive: false,
+            system_id: default_system_id(),
             identity: SystemOptionsConfig::default(),
             tls: TlsConfig::default(),
         }
@@ -129,6 +162,13 @@ fn default_bind() -> String {
 
 fn default_base_path() -> String {
     "/ehrbase/rest/openehr/v1".to_owned()
+}
+
+/// The default openEHR system identifier — a single source of truth shared with
+/// the service layer's [`crate::service::DEFAULT_SYSTEM_ID`], so an unset
+/// `[server] system_id` boots exactly as the service's own default.
+fn default_system_id() -> String {
+    crate::service::DEFAULT_SYSTEM_ID.to_owned()
 }
 
 const fn default_max_in_flight() -> usize {
@@ -185,6 +225,16 @@ pub struct AdminConfig {
     pub enabled: bool,
 }
 
+/// `[server.identity]` — the `OPTIONS` System-Options manifest identity: the
+/// **display** identity this deployment advertises (product, vendor, the
+/// contract edition and conformance profile it claims).
+///
+/// Deliberately NOT the data-authoring identity: what a commit stamps into
+/// `EHR.system_id`, `AUDIT_DETAILS.system_id`, and
+/// `OBJECT_VERSION_ID.creating_system_id` is [`ServerConfig::system_id`]. A
+/// rebrand changes this block and nothing in the stored data; a change of
+/// `system_id` changes what newly authored data says about its origin and
+/// leaves the manifest alone.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct SystemOptionsConfig {

--- a/app/ehrbase/src/service/mod.rs
+++ b/app/ehrbase/src/service/mod.rs
@@ -82,8 +82,13 @@ pub(crate) fn tenant_cache() -> TenantCache {
         .build()
 }
 
-/// The default openEHR system identifier stamped into `OBJECT_VERSION_ID`s and
-/// audit rows. Configurable per deployment (the binary wires it from config).
+/// The default openEHR system identifier stamped into `EHR.system_id`,
+/// `AUDIT_DETAILS.system_id`, and every `OBJECT_VERSION_ID.creating_system_id`.
+///
+/// This is the fallback only: a deployment sets its own identifier with the
+/// `[server] system_id` config key (`EHRBASE__SERVER__SYSTEM_ID`), which the
+/// binary wires in via [`EhrbaseService::with_system_id`]. An unset key leaves
+/// this value in force.
 pub const DEFAULT_SYSTEM_ID: &str = "ehrbase-rs.local";
 
 /// The DB-backed application service — the concrete platform behind the SM
@@ -193,7 +198,9 @@ impl EhrbaseService {
 
     // ── Builders (the binary wires each configured subsystem) ────────────────
 
-    /// Override the openEHR system id (identifies this CDR in versions/audit).
+    /// Set the openEHR system id (identifies this CDR in `EHR.system_id`,
+    /// audit rows, and every minted `OBJECT_VERSION_ID`). The binary wires
+    /// `[server] system_id`; without a call, [`DEFAULT_SYSTEM_ID`] stands.
     #[must_use]
     pub fn with_system_id(mut self, system_id: impl Into<String>) -> Self {
         self.system_id = system_id.into();

--- a/app/ehrbase/tests/service_system_id.rs
+++ b/app/ehrbase/tests/service_system_id.rs
@@ -1,0 +1,169 @@
+#![allow(
+    clippy::panic,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    let_underscore_drop
+)] // test assertions/diagnostics/fixtures
+//! The configured openEHR **system identifier** reaches every wire value that
+//! carries it, against a real `PostgreSQL` 18 (shared testkit harness).
+//!
+//! `[server] system_id` (`EHRBASE__SERVER__SYSTEM_ID`) is wired into the
+//! service by the binary via `with_system_id`; these tests pin the three
+//! places the value surfaces:
+//!
+//! - `EHR.system_id` at creation — RM ehr `master04-ehr_package.adoc` §EHR
+//!   Identifier Allocation: "the `EHR._system_id_` value should be set to the
+//!   value that would normally be used for locally created EHRs";
+//! - `AUDIT_DETAILS.system_id` when the client supplies none — ITS-REST
+//!   `specifications/docs/overview/Requests_and_responses.md`
+//!   §"openehr-version and openehr-audit-details": "when `system_id` is not
+//!   provided by the client, the server MUST set it to its own configured
+//!   system identifier";
+//! - `OBJECT_VERSION_ID.creating_system_id` on every minted version — RM common
+//!   `master06-change_control_package.adoc` §Distributed Versioning.
+//!
+//! The default (no `with_system_id` call) is pinned too: it must stay
+//! `DEFAULT_SYSTEM_ID`, so an unset config key is byte-identical to previous
+//! behaviour.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use ehrbase::ids::EhrId;
+use ehrbase::service::version_update::{UpdateAudit, UpdateVersion};
+use ehrbase::service::{DEFAULT_SYSTEM_ID, EhrbaseService};
+use openehr_base::prelude::TerminologyCode;
+use openehr_rm::prelude::PartyProxy;
+use serde_json::{Value, json};
+
+/// An `openehr` terminology code (audit change type / lifecycle state).
+fn term(code: &str) -> TerminologyCode {
+    TerminologyCode {
+        terminology_id: "openehr".to_owned(),
+        terminology_version: None,
+        code_string: code.to_owned(),
+        uri: None,
+    }
+}
+
+fn committer(name: &str) -> PartyProxy {
+    openehr_its::json::from_canonical_value(&json!({ "_type": "PARTY_IDENTIFIED", "name": name }))
+        .expect("committer")
+}
+
+/// A minimal *valid* RM COMPOSITION: `language`, `territory`, `category`, and
+/// `composer` are all `1..1` (RM ehr, COMPOSITION class).
+fn composition(name: &str) -> Value {
+    json!({
+        "_type": "COMPOSITION",
+        "archetype_node_id": "openEHR-EHR-COMPOSITION.encounter.v1",
+        "archetype_details": {
+            "_type": "ARCHETYPED",
+            "archetype_id": {
+                "_type": "ARCHETYPE_ID",
+                "value": "openEHR-EHR-COMPOSITION.encounter.v1"
+            },
+            "rm_version": "1.2.0"
+        },
+        "name": { "_type": "DV_TEXT", "value": name },
+        "language": {
+            "_type": "CODE_PHRASE",
+            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_639-1" },
+            "code_string": "en"
+        },
+        "territory": {
+            "_type": "CODE_PHRASE",
+            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_3166-1" },
+            "code_string": "NL"
+        },
+        "category": {
+            "_type": "DV_CODED_TEXT",
+            "value": "event",
+            "defining_code": {
+                "_type": "CODE_PHRASE",
+                "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" },
+                "code_string": "433"
+            }
+        },
+        "composer": { "_type": "PARTY_IDENTIFIED", "name": "conformance tester" }
+    })
+}
+
+/// The SM `UPDATE_VERSION` commit envelope with **no** client-supplied
+/// `system_id` — the case in which the server MUST supply its own.
+fn uv(data: Value) -> UpdateVersion {
+    UpdateVersion {
+        preceding_version_uid: None,
+        lifecycle_state: term("532"),
+        attestations: None,
+        data,
+        audit: UpdateAudit {
+            change_type: term("249"),
+            description: None,
+            committer: committer("conformance tester"),
+            system_id: None,
+        },
+        signature: None,
+    }
+}
+
+/// Create an EHR + one composition on `svc` and return
+/// `(EHR.system_id, OBJECT_VERSION_ID, AUDIT_DETAILS.system_id)`.
+async fn stamped_identities(svc: &EhrbaseService) -> (String, String, String) {
+    let ehr_id: EhrId = svc.create_ehr(None).await.expect("create_ehr");
+    let summary = svc.get_ehr(ehr_id).await.expect("get_ehr");
+
+    let ovid = svc
+        .create_composition(ehr_id, uv(composition("system id")))
+        .await
+        .expect("create_composition")
+        .version_uid();
+    let original = svc
+        .composition_original_version(ehr_id, ovid.parse().expect("ovid"))
+        .await
+        .expect("composition_original_version");
+    let audit_system_id = original["commit_audit"]["system_id"]
+        .as_str()
+        .expect("commit_audit.system_id")
+        .to_owned();
+
+    (summary.system_id, ovid, audit_system_id)
+}
+
+#[tokio::test]
+async fn configured_system_id_stamps_ehr_audit_and_version_uid() {
+    let db = testkit::db().await.expect("testkit database");
+    let svc = EhrbaseService::new(db.pool()).with_system_id("custom.sys");
+
+    let (ehr_system_id, ovid, audit_system_id) = stamped_identities(&svc).await;
+
+    // RM ehr master04 §EHR Identifier Allocation.
+    assert_eq!(
+        ehr_system_id, "custom.sys",
+        "EHR.system_id must carry the configured identifier"
+    );
+    // RM common master06 §Distributed Versioning: the uid's middle segment is
+    // the creating system id.
+    assert_eq!(
+        ovid.split("::").nth(1),
+        Some("custom.sys"),
+        "OBJECT_VERSION_ID.creating_system_id must carry the configured identifier ({ovid})"
+    );
+    // ITS-REST Requests_and_responses.md: the server default for a commit that
+    // carried no client `system_id`.
+    assert_eq!(
+        audit_system_id, "custom.sys",
+        "AUDIT_DETAILS.system_id must default to the configured identifier"
+    );
+}
+
+#[tokio::test]
+async fn unset_system_id_keeps_the_compatibility_default() {
+    let db = testkit::db().await.expect("testkit database");
+    let svc = EhrbaseService::new(db.pool());
+
+    let (ehr_system_id, ovid, audit_system_id) = stamped_identities(&svc).await;
+
+    assert_eq!(ehr_system_id, DEFAULT_SYSTEM_ID);
+    assert_eq!(ovid.split("::").nth(1), Some(DEFAULT_SYSTEM_ID));
+    assert_eq!(audit_system_id, DEFAULT_SYSTEM_ID);
+}

--- a/website/book/src/installation/configuration.md
+++ b/website/book/src/installation/configuration.md
@@ -108,6 +108,7 @@ base_path = "/ehrbase/rest/openehr/v1"
 max_in_flight = 256
 swagger_ui = true
 cors_permissive = false
+system_id = "ehrbase-rs.local"
 ```
 
 | Key | Type | Default | Description |
@@ -117,6 +118,47 @@ cors_permissive = false
 | `max_in_flight` | int | `256` | Concurrent-request admission cap (not per second). Requests beyond it are shed immediately with `503` + `Retry-After` — never queued — so offered load beyond capacity cannot exhaust memory. Status/health/discovery routes are never limited. `0` disables shedding. |
 | `swagger_ui` | bool | `true` | Serve Swagger UI + the OpenAPI JSON at the REST root. Consider `false` in production. |
 | `cors_permissive` | bool | `false` | Permissive (development) CORS. Production configures explicit origins. |
+| `system_id` | string | `ehrbase-rs.local` | **This deployment's own openEHR system identifier** — see below. Set a stable, deployment-unique name in production (`EHRBASE__SERVER__SYSTEM_ID`). |
+
+### `system_id`: the data-authoring identity
+
+`system_id` is the identifier this CDR stamps into the data it authors. It
+appears on the wire in three places:
+
+- **`EHR.system_id`**, recorded when an EHR is created. The openEHR RM
+  (`EHR Information Model`, *EHR Identifier Allocation*) says the
+  `EHR.system_id` "should be set to the value that would normally be used for
+  locally created EHRs" — i.e. a value the deployment chooses, not a product
+  constant.
+- **`AUDIT_DETAILS.system_id`** on every commit for which the client did not
+  supply one through the `openehr-audit-details` header. The openEHR REST API
+  requires that "when `system_id` is not provided by the client, the server
+  MUST set it to its own configured system identifier".
+- **`OBJECT_VERSION_ID.creating_system_id`** — the middle segment of every
+  version identifier the server mints
+  (`<object_id>::<creating_system_id>::<version>`).
+
+Practical notes:
+
+- **Choose it before going live and keep it stable.** The value is stored with
+  each EHR and each version; changing it later affects only *newly* authored
+  data — existing EHR ids, audit rows, and version identifiers are never
+  rewritten, and previously issued `OBJECT_VERSION_ID`s stay valid.
+- **Make it unique per system**, so data exchanged between openEHR systems
+  keeps unambiguous provenance. A DNS-style host name (`cdr.hospital.example`)
+  is the common convention.
+- **With multi-tenancy on** (`[tenancy]`), a tenant's own `system_id` takes
+  precedence over this value for requests resolved to that tenant.
+- **Validated at boot.** An empty value is refused (the RM requires a
+  non-empty `AUDIT_DETAILS.system_id`), as is one containing `::` — that is
+  the `OBJECT_VERSION_ID` field separator, so it would make version
+  identifiers unparseable.
+- **`system_id` is not `[server.identity]`.** `system_id` says *which system
+  authored the data*; `[server.identity]` below is the *display* identity of
+  the `OPTIONS` System-Options manifest (product, version, vendor, advertised
+  profile). Rebranding changes the manifest and nothing in stored data;
+  changing `system_id` changes what new data says about its origin and leaves
+  the manifest alone. They are set independently.
 
 ### `[server.tls]` — native TLS + mutual-TLS client authentication
 
@@ -140,7 +182,9 @@ The separate-port management listener always stays plain HTTP.
 The System-Options manifest identity (`OPTIONS` on the API base path, e.g.
 `OPTIONS /ehrbase/rest/openehr/v1` — the System API's one location). Defaults
 are measured, not asserted — the manifest never out-claims the last
-conformance verdict.
+conformance verdict. This is the deployment's *display* identity only; the
+identifier stamped into authored data is
+[`server.system_id`](#system_id-the-data-authoring-identity).
 
 | Key | Type | Default | Description |
 |---|---|---|---|
@@ -547,6 +591,9 @@ For production, set at least:
 - **an auth mechanism** — a Basic user store and/or `[auth.oidc]`.
 - **`log.format = "json"`** for cluster log collectors.
 - **`server.cors_permissive`** stays `false`; **`server.swagger_ui`** per posture.
+- **`server.system_id`** — this deployment's own openEHR system identifier
+  (default `ehrbase-rs.local`). Choose it before the first EHR is created: it
+  is stored with every EHR, audit entry, and version identifier.
 - **`management.*`** per posture (a dedicated `port` is recommended so
   `/management` is never reachable on the clinical listener).
 - **TLS everywhere a transport supports it** — `audit.syslog.transport = "tls"`,


### PR DESCRIPTION
Closes #424 — fix 3 of the #379 (group-3) wave.

## What shipped

`[server] system_id` in the config tree (default `ehrbase-rs.local` — one source of truth via the service constant; env `EHRBASE__SERVER__SYSTEM_ID` per the uniform grammar — the issue's single-underscore spelling doesn't bind and gets a boot did-you-mean). Wired through the binary's service builder; the false "the binary wires it from config" doc comment is now true. The value stamps `EHR.system_id` (RM ehr master04 §EHR Identifier Allocation), the `AUDIT_DETAILS.system_id` server default (R&R §openehr-version…: "its own configured system identifier"), and every `OBJECT_VERSION_ID.creating_system_id`. Boot validation: non-empty (RM `System_id_valid`) and `::`-free (the OBJECT_VERSION_ID separator, BASE master05). The display-identity (`[server.identity]`, the OPTIONS manifest) vs data-authoring-identity distinction documented in both directions; config mechanism flagged own-design.

**Known interaction (documented, unchanged):** with tenancy ON, `tenant.system_id` wins; the default tenant's seeded row carries the literal default — the book documents the precedence.

## Tests
Config unit tests (default/TOML/env precedence; boot validation) + a new DB battery: a custom system_id reaches EHR.system_id, creating_system_id, and the audit default; the unconfigured service keeps the default. Helm deliberately untouched (curated subset; settable via config/extraEnv).

## Gates
fmt clean · clippy zero warnings (3 crates) · nextest 1137/1137. Changelog + book (new key + subsection + checklist bullet).