### PR TITLE
fix(ehr): complete imported and archive-loaded EHRs (EHR_ACCESS + subject)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,23 @@ workflow refuses a tag that has no matching section here.
   previously committed root objects without `archetype_details` must now
   supply it.
 
+- **Imported and archive-loaded EHRs are now complete, first-class EHRs**
+  (#425). An EHR-Extract clone (`import_ehr`) created no EHR_ACCESS, so a
+  source extract that carried none produced an EHR permanently violating the
+  RM invariant `Ehr_access_valid` (`EHR.ehr_access` is 1..1) whose served
+  `GET /ehr/{ehr_id}` body simply omitted the mandatory reference; the clone
+  now commits the same default EHR_ACCESS the create path uses (RM ehr
+  master04 §EHR Creation — a root EHR object, an EHR Status object and an EHR
+  Access object), in the import's own transaction. Neither the import nor the
+  admin archive load promoted the EHR's subject, so imported/loaded EHRs were
+  invisible to `GET /ehr?subject_id=…&subject_namespace=…` and exempt from the
+  one-EHR-per-subject `409`; both paths now derive the subject from the landed
+  EHR_STATUS. Consequences: importing or loading an EHR whose subject this
+  repository already holds is now refused — `409` for an import (naming the
+  subject and the EHR that holds it), and, for the archive load, a per-record
+  `DUMP_LOAD_FAIL_REPORT` entry that skips just that EHR exactly like a
+  duplicate EHR id, leaving the rest of the archive to load.
+
 ### Removed
 
 - **The bare-root `OPTIONS /` alias of the System API endpoint** (#420). The

--- a/app/ehrbase/src/service/admin/dump_load.rs
+++ b/app/ehrbase/src/service/admin/dump_load.rs
@@ -34,6 +34,16 @@
 //! version-row re-persist is a storage seam
 //! ([`crate::storage::version_repo::import::insert_version_verbatim`]); this module
 //! keeps the archive format and orchestration.
+//!
+//! NOTE (load is a RESTORE, not an EHR creation): the load re-persists exactly
+//! what the archive holds and never synthesizes content. In particular it does
+//! NOT mint a missing `EHR_ACCESS` the way the EHR-Extract clone does (RM ehr
+//! master04 §EHR Creation governs *creating* an EHR — an archive record is a
+//! previously-created one), because inventing a versioned object with a fresh
+//! uid and an extra CONTRIBUTION would break the archive⇒repository identity
+//! this format guarantees. The one thing the load re-derives rather than
+//! copies is the promoted `ehr` column projection (the subject + status-flag
+//! cache of the loaded `EHR_STATUS`), which is not content.
 
 use std::path::Path;
 
@@ -308,9 +318,9 @@ impl EhrbaseService {
     }
 
     /// SM `load_ehrs`: populate the repository from a canonical-JSON archive
-    /// under `file_sys_loc`. Duplicate EHR ids are reported
-    /// (`dump_status = false`) and skipped; all other EHRs are re-persisted
-    /// verbatim.
+    /// under `file_sys_loc`. Duplicate EHR ids — and a subject this repository
+    /// already holds under another EHR — are reported (`dump_status = false`)
+    /// and skipped; all other EHRs are re-persisted verbatim.
     ///
     /// # Errors
     /// - `file_not_writable` — the manifest, a segment file, or a blob file
@@ -356,7 +366,22 @@ impl EhrbaseService {
                     });
                     continue;
                 }
-                self.load_one_ehr(&record).await?;
+                match self.load_one_ehr(&record).await {
+                    Ok(()) => {}
+                    // A per-EHR conflict — currently a subject this repository
+                    // already holds under another EHR (one EHR per subject, RM
+                    // ehr master04 §EHR Status), reachable only on a PARTIAL
+                    // load into a non-empty repository. Reported and skipped
+                    // (its transaction rolled back) exactly like a duplicate
+                    // EHR id, so the rest of the archive still loads.
+                    Err(ServiceError::Conflict(message)) => reports.push(DumpLoadFailReport {
+                        entity_type: "EHR".to_owned(),
+                        entity_id: ehr_id.to_string(),
+                        dump_status: false,
+                        error: Some(message),
+                    }),
+                    Err(e) => return Err(e.into()),
+                }
             }
         }
         Ok(reports)
@@ -617,17 +642,7 @@ impl EhrbaseService {
         let mut tx = self.pool.begin().await?;
         let ehr_id = record.ehr.id;
 
-        sqlx::query(
-            "INSERT INTO ehr (id, system_id, time_created, subject_id, subject_namespace) \
-             VALUES ($1, $2, $3::timestamptz, $4, $5)",
-        )
-        .bind(ehr_id)
-        .bind(&record.ehr.system_id)
-        .bind(&record.ehr.time_created)
-        .bind(&record.ehr.subject_id)
-        .bind(&record.ehr.subject_namespace)
-        .execute(&mut *tx)
-        .await?;
+        insert_ehr_row(&mut tx, &record.ehr).await?;
 
         for a in &record.audits {
             sqlx::query(
@@ -657,13 +672,18 @@ impl EhrbaseService {
             insert_version(&mut tx, ehr_id, v).await?;
         }
 
-        // The load re-decomposed the EHR_STATUS versions directly (the export
-        // record carries subject columns but not the status flags). Backfill the
-        // promoted `ehr.is_queryable` / `is_modifiable` from the stored current
-        // status so the AQL full-population gate and the content-write guard
-        // match the loaded state (RM ehr master04 §EHR Status / §EHR Active
-        // Status; SM I_QUERY_SERVICE — full population = queryable EHRs).
-        crate::storage::ehr_repo::sync_status_flags(&mut tx, ehr_id).await?;
+        // The load re-decomposed the EHR_STATUS versions directly, so the
+        // promoted `ehr` columns are re-derived from the loaded current status
+        // — the EHR_STATUS content is the truth, the exported columns only its
+        // cached projection (an archive written before a promotion fix, or by a
+        // path that never promoted, carries a stale/absent subject). This makes
+        // a loaded EHR visible to the subject lookup (SM
+        // `I_EHR_SERVICE.get_ehrs_for_subject`) and bound by the
+        // one-EHR-per-subject rule (RM ehr master04 §EHR Status), and keeps
+        // `is_queryable` / `is_modifiable` matching the loaded state for the AQL
+        // full-population gate (SM I_QUERY_SERVICE — full population =
+        // queryable EHRs) and the content-write guard (§EHR Active Status).
+        self.resync_promoted_columns(&mut tx, ehr_id).await?;
 
         // EHR.folders membership rows, verbatim (rank fidelity — RM ehr §EHR
         // Class Directory_in_folders: folders.item(1) = directory).
@@ -739,6 +759,48 @@ impl EhrbaseService {
         tx.commit().await?;
         Ok(())
     }
+}
+
+/// Re-persist the archived `ehr` root row verbatim (preserved id, immutable
+/// `system_id` and `time_created`, plus the archived promoted-column
+/// projection, which [`EhrbaseService::resync_promoted_columns`] then re-derives
+/// from the loaded `EHR_STATUS`).
+///
+/// # Errors
+/// [`ServiceError::Conflict`] when the record's subject is already held by
+/// another EHR in this repository — possible only on a PARTIAL load into a
+/// non-empty repository, since a self-consistent dump cannot clash with itself
+/// (one EHR per subject — RM ehr master04 §EHR Status). The caller reports that
+/// per record instead of aborting the load with an opaque constraint fault.
+/// [`ServiceError::Database`] on any other insert failure (a duplicate EHR id
+/// is pre-checked by the caller).
+async fn insert_ehr_row(tx: &mut PgConnection, ehr: &EhrRow) -> Result<(), ServiceError> {
+    sqlx::query(
+        "INSERT INTO ehr (id, system_id, time_created, subject_id, subject_namespace) \
+         VALUES ($1, $2, $3::timestamptz, $4, $5)",
+    )
+    .bind(ehr.id)
+    .bind(&ehr.system_id)
+    .bind(&ehr.time_created)
+    .bind(&ehr.subject_id)
+    .bind(&ehr.subject_namespace)
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| {
+        if let sqlx::Error::Database(db) = &e
+            && db.constraint() == Some("uq_ehr_subject")
+        {
+            return ServiceError::Conflict(format!(
+                "EHR {} names subject {}@{}, which another EHR in this repository already \
+                 holds (one EHR per subject)",
+                ehr.id,
+                ehr.subject_id.as_deref().unwrap_or("?"),
+                ehr.subject_namespace.as_deref().unwrap_or("?"),
+            ));
+        }
+        ServiceError::Database(e)
+    })?;
+    Ok(())
 }
 
 /// Insert one version row and its re-decomposed node rows (through the storage

--- a/app/ehrbase/src/service/ehr/access.rs
+++ b/app/ehrbase/src/service/ehr/access.rs
@@ -16,12 +16,16 @@ use std::sync::Arc;
 
 use crate::ids::EhrId;
 use crate::service::ehr::access_types::EhrAccessSettings;
+use crate::service::error::ServiceError;
 use crate::service::status::SmError;
 use moka::future::Cache;
 use serde_json::{Value, json};
+use sqlx::PgConnection;
 
 use crate::service::EhrbaseService;
 use crate::versioning::Kind;
+use crate::versioning::audit::change_type;
+use crate::versioning::change::{Change, commit_contribution};
 use crate::versioning::read::read_current;
 
 impl EhrbaseService {
@@ -43,6 +47,61 @@ impl EhrbaseService {
     /// [`Self::invalidate_ehr_access`].
     pub(in crate::service) async fn prewarm_ehr_access_open(&self, ehr_id: EhrId) {
         self.ehr_access.insert(ehr_id, None).await;
+    }
+
+    /// Commit the default [`default_ehr_access`] for an EHR that has none,
+    /// inside the caller's transaction — the EHR-Extract import bootstrap
+    /// ([`crate::service::message`]).
+    ///
+    /// `EHR.ehr_access` is 1..1 (RM ehr `ehr.adoc` invariant
+    /// `Ehr_access_valid`) and RM ehr master04 §EHR Creation requires that
+    /// creating an EHR yields "a root EHR object, an EHR Status object, and an
+    /// EHR Access object … created and committed in a Contribution". A clone
+    /// whose source extract carried no `EHR_ACCESS` would otherwise violate
+    /// that invariant permanently and serve an `EHR` body without the mandatory
+    /// reference, so the missing object is created locally.
+    ///
+    /// It is server-created content, NOT replayed extract content: it is
+    /// committed as a normal first `ORIGINAL_VERSION` (`249|creation|`,
+    /// server-signed when signing is enabled) under its OWN CONTRIBUTION rather
+    /// than folded into the import CONTRIBUTION — that one records the local
+    /// act of committal for the received originals, which "are never modified"
+    /// (RM common `master06-change_control_package.adoc` §Copying), and the
+    /// replay preserves each original's foreign identity/audit verbatim, which
+    /// a locally minted object has no business joining. Both CONTRIBUTIONs
+    /// commit in the caller's single transaction, so the created EHR is
+    /// complete atomically.
+    ///
+    /// # Errors
+    /// The [`crate::versioning::change::commit_contribution`] write errors.
+    pub(in crate::service) async fn commit_default_ehr_access(
+        &self,
+        tx: &mut PgConnection,
+        ehr_id: EhrId,
+        description: &str,
+    ) -> Result<(), ServiceError> {
+        let audit = self.audit(change_type::CREATION, description);
+        commit_contribution(
+            tx,
+            Some(ehr_id),
+            None,
+            &audit,
+            vec![(
+                audit.clone(),
+                Change::Create {
+                    kind: Kind::EhrAccess,
+                    canonical: default_ehr_access(),
+                    template_id: None,
+                    signature: None,
+                    lifecycle_state: None,
+                    attestations: Vec::new(),
+                },
+            )],
+            Vec::new(),
+            &self.signing_ctx(),
+        )
+        .await?;
+        Ok(())
     }
 
     /// Read + parse the EHR's current `EHR_ACCESS` scheme settings from

--- a/app/ehrbase/src/service/ehr/status.rs
+++ b/app/ehrbase/src/service/ehr/status.rs
@@ -346,8 +346,8 @@ impl EhrbaseService {
     /// Boolean, RM ehr master04 §EHR Active Status). Read from the promoted
     /// `ehr.is_modifiable` column, kept in lockstep with the current
     /// `EHR_STATUS` by [`Self::sync_ehr_subject`] and the import/archive-load
-    /// backfill; a missing EHR (`None`) is treated as modifiable so the guard
-    /// never spuriously blocks.
+    /// [`Self::resync_promoted_columns`]; a missing EHR (`None`) is treated as
+    /// modifiable so the guard never spuriously blocks.
     ///
     /// The column read is a storage seam
     /// ([`crate::storage::ehr_repo::ehr_is_modifiable`]; no openEHR spec
@@ -463,6 +463,54 @@ impl EhrbaseService {
             ServiceError::Database(e)
         })?;
         Ok(())
+    }
+
+    /// Re-promote the `ehr` columns from the **stored** current `EHR_STATUS` —
+    /// the seam for the paths that land `EHR_STATUS` versions WITHOUT the
+    /// service write hook: the EHR Extract import
+    /// ([`crate::service::message`]) and the admin archive load
+    /// ([`crate::service::admin`]). The current status root fragment is read on
+    /// the caller's transaction
+    /// ([`crate::storage::ehr_repo::current_status_root`]) and handed to
+    /// [`Self::sync_ehr_subject`], so those paths promote the subject columns
+    /// and the two status flags through exactly the extraction the create /
+    /// update paths use — an imported or loaded EHR is therefore visible to the
+    /// subject lookup (SM `I_EHR_SERVICE.get_ehrs_for_subject`;
+    /// `operations/ehr_get_by_subject.yaml`) and bound by the
+    /// one-EHR-per-subject rule (RM ehr master04 §EHR Status) like any other.
+    /// A no-op when the EHR has no current `EHR_STATUS` (the row keeps its
+    /// column defaults).
+    ///
+    /// A subject already owned by ANOTHER EHR is rejected BEFORE the UPDATE so
+    /// the caller can report which subject clashed and which EHR holds it. The
+    /// `uq_ehr_subject` index remains the backstop for a holder this
+    /// pre-check cannot see — a concurrent writer, or (under multi-tenancy) a
+    /// row RLS hides while the index stays service-wide — which surfaces as
+    /// [`Self::sync_ehr_subject`]'s own conflict.
+    ///
+    /// # Errors
+    /// [`ServiceError::Conflict`] when another EHR already owns the status's
+    /// subject; [`ServiceError::Database`] on a storage failure.
+    pub(in crate::service) async fn resync_promoted_columns(
+        &self,
+        tx: &mut PgConnection,
+        ehr_id: EhrId,
+    ) -> Result<(), ServiceError> {
+        let Some(status) = crate::storage::ehr_repo::current_status_root(tx, ehr_id).await? else {
+            return Ok(());
+        };
+        let (subject_id, namespace, _, _) = ehr_promoted_columns(&status);
+        if let (Some(subject_id), Some(namespace)) = (subject_id, namespace)
+            && let Some(owner) =
+                crate::storage::ehr_repo::ehr_id_by_subject(&mut *tx, subject_id, namespace).await?
+            && owner != ehr_id
+        {
+            return Err(ServiceError::Conflict(format!(
+                "EHR {ehr_id} names subject {subject_id}@{namespace}, which EHR {owner} \
+                 already holds (one EHR per subject)"
+            )));
+        }
+        self.sync_ehr_subject(tx, ehr_id, &status).await
     }
 }
 

--- a/app/ehrbase/src/service/message/import.rs
+++ b/app/ehrbase/src/service/message/import.rs
@@ -32,11 +32,19 @@
 //! — the OPT must already be provisioned in the target through the DEFINITION
 //! API. Re-validation on import is deferred (it would require the source's
 //! exact OPT); this matches the admin dump/load path, which master06 §Copying
-//! permits: "the `ORIGINAL_VERSION` instance is never modified". The promoted
-//! `ehr.subject_id` column is left unset for an imported EHR — a clone shares
-//! the source subject, which the one-EHR-per-subject index cannot represent, so
-//! the subject is preserved inside the `EHR_STATUS` content, not the promoted
-//! column (RM ehr, `EHR.ehr_status`).
+//! permits: "the `ORIGINAL_VERSION` instance is never modified".
+//!
+//! An imported EHR is a FULL local EHR, not a second-class one: the promoted
+//! `ehr` columns are re-derived from the landed `EHR_STATUS`
+//! ([`crate::service::EhrbaseService::resync_promoted_columns`]), so the clone
+//! is found by the subject lookup (SM `I_EHR_SERVICE.get_ehrs_for_subject`,
+//! `operations/ehr_get_by_subject.yaml`) and bound by the one-EHR-per-subject
+//! rule (RM ehr master04 §EHR Status) exactly like a created EHR — importing a
+//! clone of a subject the target already holds is therefore a conflict, not a
+//! silent duplicate. Where the extract carries no `EHR_ACCESS`, the whole-EHR
+//! clone completes the mandatory 1..1 `EHR.ehr_access` (RM ehr `ehr.adoc`
+//! `Ehr_access_valid`; master04 §EHR Creation) with the local default
+//! ([`crate::service::EhrbaseService::commit_default_ehr_access`]).
 
 use std::collections::BTreeMap;
 
@@ -74,6 +82,9 @@ impl EhrbaseService {
     ///   `ORIGINAL_VERSION` is malformed (see the parse errors in this module).
     /// - `ehr_create_fail_duplicate_id` — an EHR with the target id already
     ///   exists (`import_ehr` requires an empty target).
+    /// - `Conflict` (`409`) — the imported `EHR_STATUS` names a subject another
+    ///   EHR in this repository already holds (one EHR per subject — RM ehr
+    ///   master04 §EHR Status).
     /// - `exception` — a database/replay fault mid-transaction (rolled back).
     pub async fn import_ehr(
         &self,
@@ -124,18 +135,33 @@ impl EhrbaseService {
         let touches_ehr_access = containers.iter().any(|c| c.kind == Kind::EhrAccess);
         commit_import(&mut tx, ehr_id, &audit, containers, outbox_enabled).await?;
         commit_demographic_import(&mut tx, &audit, parties, outbox_enabled).await?;
+        // An EHR is created as "a root EHR object, an EHR Status object, and an
+        // EHR Access object" (RM ehr master04 §EHR Creation) and `EHR.ehr_access`
+        // is 1..1 (`ehr.adoc` invariant `Ehr_access_valid`). An extract that
+        // carried no EHR_ACCESS therefore leaves the clone incomplete — commit
+        // the local default in this same transaction.
+        if !touches_ehr_access {
+            self.commit_default_ehr_access(&mut tx, ehr_id, "EHR Extract import: default access")
+                .await?;
+        }
         // The clone landed the EHR_STATUS directly (not via the service's
-        // sync_ehr_subject hook), so backfill the promoted `ehr.is_queryable` /
-        // `is_modifiable` from the stored current status to keep the AQL
-        // full-population gate and the content-write guard consistent (RM ehr
-        // master04 §EHR Status / §EHR Active Status; SM I_QUERY_SERVICE).
-        crate::storage::ehr_repo::sync_status_flags(&mut tx, ehr_id).await?;
+        // sync_ehr_subject hook), so re-promote the `ehr` columns from the
+        // stored current status: the subject (`GET /ehr?subject_id` +
+        // one-EHR-per-subject, RM ehr master04 §EHR Status) and the
+        // `is_queryable` / `is_modifiable` flags the AQL full-population gate
+        // (SM I_QUERY_SERVICE) and the content-write guard (§EHR Active Status)
+        // read.
+        self.resync_promoted_columns(&mut tx, ehr_id).await?;
         tx.commit().await.map_err(ServiceError::from)?;
         // An imported EHR_ACCESS version changes the EHR's access policy — evict
         // the cached settings the access gate consults (RM ehr master04 §EHR
-        // Access; the settings are change-controlled).
+        // Access; the settings are change-controlled). A bootstrapped default
+        // carries no settings, so the clone is default-open: seed that entry
+        // instead, exactly as the create path does.
         if touches_ehr_access {
             self.invalidate_ehr_access(ehr_id).await;
+        } else {
+            self.prewarm_ehr_access_open(ehr_id).await;
         }
         self.emit_extract_audit(ehr_id, EventActionCode::Create);
         Ok(())
@@ -152,7 +178,8 @@ impl EhrbaseService {
     ///   in this module).
     /// - `Conflict` (`409`) — the EHR already holds an `EHR_STATUS`/`EHR_ACCESS`
     ///   under a different object id (an EHR holds at most one of each; RM ehr,
-    ///   EHR class 1..1).
+    ///   EHR class 1..1), or an imported `EHR_STATUS` names a subject another
+    ///   EHR already holds (one EHR per subject — RM ehr master04 §EHR Status).
     /// - `exception` — a database/replay fault mid-transaction (rolled back).
     pub async fn import_ehr_extract(
         &self,
@@ -195,11 +222,12 @@ impl EhrbaseService {
         commit_import(&mut tx, an_ehr_id, &audit, containers, outbox_enabled).await?;
         commit_demographic_import(&mut tx, &audit, parties, outbox_enabled).await?;
         // An imported EHR_STATUS version can change the current status
-        // (Copying Case 3 append); backfill the promoted `ehr.is_queryable` /
-        // `is_modifiable` from the stored current status so the AQL
-        // full-population gate and the content-write guard stay consistent (RM
-        // ehr master04 §EHR Status / §EHR Active Status; SM I_QUERY_SERVICE).
-        crate::storage::ehr_repo::sync_status_flags(&mut tx, an_ehr_id).await?;
+        // (Copying Case 3 append) — including its subject; re-promote the `ehr`
+        // columns from the stored current status so the subject lookup +
+        // one-EHR-per-subject rule (RM ehr master04 §EHR Status), the AQL
+        // full-population gate (SM I_QUERY_SERVICE) and the content-write guard
+        // (§EHR Active Status) all stay consistent with it.
+        self.resync_promoted_columns(&mut tx, an_ehr_id).await?;
         tx.commit().await.map_err(ServiceError::from)?;
         // An imported EHR_ACCESS version changes the EHR's access policy — evict
         // the cached settings the access gate consults (RM ehr master04 §EHR

--- a/app/ehrbase/src/storage/ehr_repo.rs
+++ b/app/ehrbase/src/storage/ehr_repo.rs
@@ -10,7 +10,8 @@
 //! policy, directory-slot resolution, the `is_modifiable` write guard) stay in
 //! the service layer, which calls these functions with plain inputs.
 
-use sqlx::{PgConnection, PgPool, Row};
+use serde_json::Value;
+use sqlx::{PgConnection, PgExecutor, PgPool, Row};
 use uuid::Uuid;
 
 use crate::ids::{EhrId, VoId};
@@ -85,51 +86,55 @@ pub async fn insert_ehr(
     }
 }
 
-/// Refresh the promoted `ehr` status-flag columns (`is_queryable` +
-/// `is_modifiable`) from the EHR's CURRENT `EHR_STATUS` root node (`num = 0`,
-/// latest trunk). Used by the paths that land `EHR_STATUS` versions WITHOUT the
-/// service's `sync_ehr_subject` hook — the EHR Extract import and the admin
-/// archive load — so both promoted flags match the stored status: the AQL
-/// full-population gate (SM `I_QUERY_SERVICE`, `i_query_service.adoc`: full
-/// population = EHRs whose status has `is_queryable = True`) and the
-/// content-write guard (RM ehr master04 §EHR Active Status:
-/// `EHR_STATUS.is_modifiable`) both read the column, not the node. Semantics: RM
-/// ehr master04 §EHR Status (`is_queryable`, 1..1 Boolean) / §EHR Active Status
-/// (`is_modifiable`, 1..1 Boolean). Each falls back to `true` (the column
-/// default / the default `EHR_STATUS`) when the EHR has no current `EHR_STATUS`.
-/// No openEHR spec governs the promoted columns — our own storage design.
+/// The CURRENT `EHR_STATUS` root node fragment (`num = 0` of the latest trunk
+/// version) of an EHR, read on the CALLER'S connection so a transaction sees
+/// the `EHR_STATUS` it has just written. `None` when the EHR has no current
+/// `EHR_STATUS`.
+///
+/// This is the read half of the promoted-column refresh the paths that land
+/// `EHR_STATUS` versions WITHOUT the service write hook use — the EHR Extract
+/// import and the admin archive load: they hand this fragment to the single
+/// service-layer extraction (`service::ehr::status::ehr_promoted_columns`), so
+/// every path promotes identical `(subject_id, subject_namespace,
+/// is_queryable, is_modifiable)` values. The fragment carries all four inputs
+/// verbatim — the decomposition splits only *structure* types into their own
+/// `node` rows, and a subject `PARTY_SELF`/`PARTY_IDENTIFIED` is not one, so
+/// `subject.external_ref` stays inline on the root. Semantics: RM ehr master04
+/// §EHR Status (`subject`, `is_queryable`) / §EHR Active Status
+/// (`is_modifiable`). No openEHR spec governs the promoted columns or the node
+/// decomposition — our own storage design.
 ///
 /// # Errors
 /// Returns [`StorageError::Database`] on a driver failure.
-pub async fn sync_status_flags(tx: &mut PgConnection, ehr_id: EhrId) -> Result<(), StorageError> {
-    sqlx::query(
-        "UPDATE ehr e SET \
-           is_queryable = COALESCE(s.is_queryable, true), \
-           is_modifiable = COALESCE(s.is_modifiable, true) \
-         FROM (SELECT $1::uuid AS id) k \
-         LEFT JOIN LATERAL (\
-           SELECT (n.data->>'is_queryable') = 'true' AS is_queryable, \
-                  (n.data->>'is_modifiable') = 'true' AS is_modifiable \
-           FROM vo_version v \
-           JOIN node n ON n.vo_id = v.vo_id AND n.sys_version = v.sys_version AND n.num = 0 \
-           WHERE v.ehr_id = k.id AND v.kind = 'EHR_STATUS' \
-             AND upper_inf(v.sys_period) AND v.branch_number = 0) s ON true \
-         WHERE e.id = k.id",
+pub async fn current_status_root(
+    tx: &mut PgConnection,
+    ehr_id: EhrId,
+) -> Result<Option<Value>, StorageError> {
+    Ok(sqlx::query_scalar(
+        "SELECT n.data FROM vo_version v \
+         JOIN node n ON n.vo_id = v.vo_id AND n.sys_version = v.sys_version AND n.num = 0 \
+         WHERE v.ehr_id = $1 AND v.kind = 'EHR_STATUS' \
+           AND upper_inf(v.sys_period) AND v.branch_number = 0",
     )
     .bind(ehr_id)
-    .execute(&mut *tx)
-    .await?;
-    Ok(())
+    .fetch_optional(&mut *tx)
+    .await?)
 }
 
 /// The id of the EHR whose promoted subject columns match `(subject_id,
 /// namespace)`, or `None`. Served from the unique `ehr.subject_*` columns (one
 /// EHR per subject — RM ehr master04 §EHR Status).
 ///
+/// Generic over the executor (the one such read in this module): the subject
+/// lookup serves both the pooled `GET /ehr?subject_id` path and the
+/// import/archive-load conflict pre-check, which must run on the caller's
+/// transaction connection rather than take a second pooled connection while a
+/// write transaction is open.
+///
 /// # Errors
 /// Returns [`StorageError::Database`] on a driver failure.
-pub async fn ehr_id_by_subject(
-    pool: &PgPool,
+pub async fn ehr_id_by_subject<'e>(
+    executor: impl PgExecutor<'e>,
     subject_id: &str,
     namespace: &str,
 ) -> Result<Option<EhrId>, StorageError> {
@@ -137,7 +142,7 @@ pub async fn ehr_id_by_subject(
         sqlx::query_scalar("SELECT id FROM ehr WHERE subject_id = $1 AND subject_namespace = $2")
             .bind(subject_id)
             .bind(namespace)
-            .fetch_optional(pool)
+            .fetch_optional(executor)
             .await?,
     )
 }
@@ -341,11 +346,12 @@ pub async fn directory_current_meta(
 }
 
 /// Whether the EHR is modifiable, read from the promoted `ehr.is_modifiable`
-/// column (kept in lockstep with the current `EHR_STATUS.is_modifiable` by
-/// [`sync_status_flags`] and the service's `sync_ehr_subject` hook; RM ehr
-/// master04 §EHR Active Status). `None` when the EHR does not exist (the caller
-/// treats that as modifiable so the guard never spuriously blocks). No openEHR
-/// spec governs the promoted column — our own storage design.
+/// column (kept in lockstep with the current `EHR_STATUS.is_modifiable` by the
+/// service's `sync_ehr_subject` hook and its import/archive-load re-promotion
+/// over [`current_status_root`]; RM ehr master04 §EHR Active Status). `None`
+/// when the EHR does not exist (the caller treats that as modifiable so the
+/// guard never spuriously blocks). No openEHR spec governs the promoted column
+/// — our own storage design.
 ///
 /// # Errors
 /// Returns [`StorageError::Database`] on a driver failure.
@@ -361,7 +367,8 @@ pub async fn ehr_is_modifiable(pool: &PgPool, ehr_id: EhrId) -> Result<Option<bo
 /// The two content-write pre-checks in ONE round trip: whether the EHR exists,
 /// and whether it is modifiable. Reads the `ehr` row directly — a present row is
 /// the existence signal and carries the promoted `is_modifiable` column (synced
-/// with the current `EHR_STATUS` by [`sync_status_flags`] / `sync_ehr_subject`).
+/// with the current `EHR_STATUS` by `sync_ehr_subject` and its
+/// import/archive-load re-promotion over [`current_status_root`]).
 /// Returns `(exists, is_modifiable)` where `is_modifiable` is `None` exactly when
 /// the EHR does not exist. The concepts guarded are RM ehr master04 §EHR
 /// Creation (existence) and §EHR Active Status (`EHR_STATUS.is_modifiable`); no

--- a/app/ehrbase/tests/service_dump_load.rs
+++ b/app/ehrbase/tests/service_dump_load.rs
@@ -10,7 +10,7 @@
 //! Spec: SM `I_ADMIN_DUMP_LOAD.export_ehrs`/`load_ehrs`
 //! (`docs/specs/openehr/SM/docs/UML/classes/i_admin_dump_load.adoc`), with
 //! `EXPORT_SPEC` (`export_spec.adoc`, `segment_split_size` kb) and
-//! `DUMP_LOAD_FAIL_REPORT` (`dump_load_fail_report.adoc`). The two acceptance
+//! `DUMP_LOAD_FAIL_REPORT` (`dump_load_fail_report.adoc`). The acceptance
 //! properties:
 //!
 //! 1. **Round-trip fidelity** — export N EHRs from a source repository, load the
@@ -20,6 +20,14 @@
 //! 2. **Duplicate-id failure path** — loading an EHR whose id already exists is
 //!    recorded in a `DUMP_LOAD_FAIL_REPORT` (`dump_status = false`) and skipped,
 //!    never a crash, and leaves the repository unchanged.
+//! 3. **Promoted-column re-derivation** — the `ehr.subject_*` columns are a
+//!    projection of `EHR_STATUS.subject` (RM ehr master04 §EHR Status), so the
+//!    load re-derives them from the loaded status: a loaded EHR is found by the
+//!    subject lookup (SM `I_EHR_SERVICE.get_ehrs_for_subject`,
+//!    `operations/ehr_get_by_subject.yaml`) even when the archive's projection
+//!    was stale, and a PARTIAL load carrying a subject this repository already
+//!    holds is reported like a duplicate id, never silently duplicated
+//!    (one EHR per subject).
 #![allow(clippy::expect_used, clippy::unwrap_used, clippy::too_many_lines)]
 
 use serde_json::{Value, json};
@@ -32,6 +40,7 @@ use openehr_rm::prelude::PartyProxy;
 use ehrbase::service::EhrbaseService;
 
 use ehrbase::service::admin::types::ExportSpec;
+use ehrbase::service::ehr_index::types::SubjectRef;
 use ehrbase::service::version_update::{UpdateAudit, UpdateVersion};
 
 /// A unique temporary directory path for one archive (best-effort cleaned up by
@@ -116,6 +125,33 @@ async fn seed_full_ehr(svc: &EhrbaseService) -> ehrbase::ids::EhrId {
         .expect("status update");
 
     ehr_uuid
+}
+
+/// An `EHR_STATUS` whose `PARTY_SELF` subject carries an `external_ref` — RM
+/// ehr master04 §EHR Status (the subject 0..1 identifies the EHR).
+fn status_for_subject(subject_id: &str) -> Value {
+    json!({
+        "_type": "EHR_STATUS",
+        "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
+        "archetype_details": {
+            "_type": "ARCHETYPED",
+            "archetype_id": { "_type": "ARCHETYPE_ID",
+                              "value": "openEHR-EHR-EHR_STATUS.generic.v1" },
+            "rm_version": "1.2.0"
+        },
+        "name": { "_type": "DV_TEXT", "value": "EHR Status" },
+        "subject": {
+            "_type": "PARTY_SELF",
+            "external_ref": {
+                "_type": "PARTY_REF",
+                "namespace": "patients",
+                "type": "PERSON",
+                "id": { "_type": "HIER_OBJECT_ID", "value": subject_id }
+            }
+        },
+        "is_queryable": true,
+        "is_modifiable": true
+    })
 }
 
 /// The per-EHR row counts across the versioned-object tables (used to prove the
@@ -263,6 +299,128 @@ async fn load_duplicate_ehr_ids_is_reported_not_fatal() {
         after_first,
         "a duplicate re-load must not add or remove rows"
     );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn load_promotes_the_subject_from_the_loaded_status() {
+    // The promoted `ehr.subject_*` columns are only a projection of
+    // `EHR_STATUS.subject` (RM ehr master04 §EHR Status), so the load re-derives
+    // them from the loaded status instead of trusting the archived projection:
+    // an archive whose projection is absent — the shape an EHR landed by a path
+    // that never promoted has — still yields an EHR the subject lookup finds
+    // (SM `I_EHR_SERVICE.get_ehrs_for_subject`).
+    let src_db = testkit::db().await.expect("testkit database");
+    let src_pool = src_db.pool();
+    let source = EhrbaseService::new(src_pool.clone());
+    let dst_db = testkit::db().await.expect("testkit database");
+    let target = EhrbaseService::new(dst_db.pool());
+
+    let ehr = source
+        .create_ehr(Some(status_for_subject("patient-dump-1")))
+        .await
+        .expect("source EHR for the subject");
+
+    // Fixture: clear the promoted projection, leaving the subject only in the
+    // EHR_STATUS content — what an EHR landed without promotion looks like.
+    sqlx::query("UPDATE ehr SET subject_id = NULL, subject_namespace = NULL WHERE id = $1")
+        .bind(Uuid::from(ehr))
+        .execute(&src_pool)
+        .await
+        .expect("clear the promoted subject columns");
+    assert!(
+        source
+            .get_ehrs_for_subject(SubjectRef::person("patient-dump-1", "patients"))
+            .await
+            .expect("source lookup")
+            .is_empty(),
+        "fixture: the source no longer finds the EHR by subject"
+    );
+
+    let dir = archive_dir();
+    source
+        .export_ehrs(dir.clone(), ExportSpec::canonical_json(1024))
+        .await
+        .expect("export");
+    let reports = target.load_ehrs(dir.clone()).await.expect("load");
+    assert!(reports.is_empty(), "clean load, got {reports:?}");
+
+    let found = target
+        .get_ehrs_for_subject(SubjectRef::person("patient-dump-1", "patients"))
+        .await
+        .expect("target lookup");
+    assert_eq!(
+        found.len(),
+        1,
+        "the loaded EHR must be found by the subject its EHR_STATUS names"
+    );
+    assert_eq!(found[0].ehr_id, ehr.to_string());
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn load_reports_an_ehr_whose_subject_the_repository_already_holds() {
+    // A dump of a self-consistent repository cannot clash with itself, but a
+    // PARTIAL load into a NON-EMPTY repository can: one EHR per subject (RM ehr
+    // master04 §EHR Status). The clash is reported per record
+    // (`DUMP_LOAD_FAIL_REPORT`, `dump_status = false`) and skipped exactly like
+    // a duplicate EHR id — never fatal, never a silent duplicate — and the rest
+    // of the archive still loads.
+    let src_db = testkit::db().await.expect("testkit database");
+    let source = EhrbaseService::new(src_db.pool());
+    let dst_db = testkit::db().await.expect("testkit database");
+    let target = EhrbaseService::new(dst_db.pool());
+
+    let clashing = source
+        .create_ehr(Some(status_for_subject("patient-dump-2")))
+        .await
+        .expect("source EHR for the subject");
+    let innocent = seed_full_ehr(&source).await;
+
+    // The target already holds that subject under a DIFFERENT EHR.
+    let owner = target
+        .create_ehr(Some(status_for_subject("patient-dump-2")))
+        .await
+        .expect("target EHR for the same subject");
+
+    let dir = archive_dir();
+    source
+        .export_ehrs(dir.clone(), ExportSpec::canonical_json(1024))
+        .await
+        .expect("export");
+    let reports = target.load_ehrs(dir.clone()).await.expect("load");
+
+    assert_eq!(
+        reports.len(),
+        1,
+        "only the subject clash fails, got {reports:?}"
+    );
+    assert_eq!(reports[0].entity_type, "EHR");
+    assert_eq!(reports[0].entity_id, clashing.to_string());
+    assert!(!reports[0].dump_status);
+    let error = reports[0].error.as_deref().expect("an explanatory error");
+    assert!(
+        error.contains("patient-dump-2"),
+        "the report must name the clashing subject, got: {error}"
+    );
+
+    // The clashing record was skipped whole; everything else loaded.
+    assert!(
+        !target.has_ehr(clashing).await.expect("has_ehr"),
+        "a reported record must not be partially loaded"
+    );
+    assert!(
+        target.has_ehr(innocent).await.expect("has_ehr"),
+        "the rest of the archive still loads"
+    );
+    let found = target
+        .get_ehrs_for_subject(SubjectRef::person("patient-dump-2", "patients"))
+        .await
+        .expect("target lookup");
+    assert_eq!(found.len(), 1, "the subject still resolves to its holder");
+    assert_eq!(found[0].ehr_id, owner.to_string());
 
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/app/ehrbase/tests/service_import.rs
+++ b/app/ehrbase/tests/service_import.rs
@@ -28,6 +28,15 @@
 //!    versioned object (master06 §Copying Case 2: first receipt of an item
 //!    clones its `VERSIONED_OBJECT` with the received `uid.object_id()`);
 //!    re-importing the same trunk version is a conflict.
+//! 4. **The clone is a complete, first-class local EHR**: `EHR.ehr_access` is
+//!    1..1 (RM ehr `ehr.adoc` invariant `Ehr_access_valid`; master04 §EHR
+//!    Creation — "a root EHR object, an EHR Status object, and an EHR Access
+//!    object … created and committed in a Contribution"), so an extract that
+//!    carries no `EHR_ACCESS` is completed with the local default; and the
+//!    imported `EHR_STATUS.subject` is promoted, so the clone is found by the
+//!    subject lookup (SM `I_EHR_SERVICE.get_ehrs_for_subject`,
+//!    `operations/ehr_get_by_subject.yaml`) and bound by the
+//!    one-EHR-per-subject rule (RM ehr master04 §EHR Status) like any other EHR.
 #![allow(clippy::expect_used, clippy::unwrap_used, clippy::too_many_lines)]
 
 use serde_json::{Value, json};
@@ -38,6 +47,7 @@ use openehr_rm::ehr_extract::common::extract_spec::ExtractSpec;
 use openehr_rm::prelude::PartyProxy;
 
 use ehrbase::service::EhrbaseService;
+use ehrbase::service::ehr_index::types::SubjectRef;
 use ehrbase::service::status::CallStatusType;
 
 use ehrbase::service::version_update::{UpdateAudit, UpdateVersion};
@@ -125,6 +135,68 @@ fn find_by_xtype<'a>(extract: &'a Value, xtype: &str) -> Option<&'a Value> {
         .find(|it| it["item"]["_type"] == json!(xtype))
 }
 
+/// How many content items of an extract wrap the given `X_VERSIONED_*` `_type`.
+fn count_by_xtype(extract: &Value, xtype: &str) -> usize {
+    extract["chapters"][0]["items"]
+        .as_array()
+        .expect("chapter items")
+        .iter()
+        .filter(|it| it["item"]["_type"] == json!(xtype))
+        .count()
+}
+
+/// The same extract with every `X_VERSIONED_EHR_ACCESS` content item removed —
+/// the export of a source that holds no `EHR_ACCESS`, or one filtered out en
+/// route.
+fn without_ehr_access(extract: &Value) -> Extract {
+    let mut raw = extract.clone();
+    let items: Vec<Value> = raw["chapters"][0]["items"]
+        .as_array()
+        .expect("chapter items")
+        .iter()
+        .filter(|it| it["item"]["_type"] != json!("X_VERSIONED_EHR_ACCESS"))
+        .cloned()
+        .collect();
+    raw["chapters"][0]["items"] = Value::Array(items);
+    openehr_its::json::from_canonical_value(&raw).expect("EXTRACT without EHR_ACCESS")
+}
+
+/// [`status_for_subject`] with an explicit namespace (the extract rewrite
+/// normalizes carried refs to `"local"` — EHR Extract master09 §Creation
+/// Semantics — so conflict fixtures must name it).
+fn status_for_subject_in(subject_id: &str, namespace: &str) -> Value {
+    let mut status = status_for_subject(subject_id);
+    status["subject"]["external_ref"]["namespace"] = json!(namespace);
+    status
+}
+
+/// An `EHR_STATUS` whose `PARTY_SELF` subject carries an `external_ref` —
+/// RM ehr master04 §EHR Status (the subject 0..1 identifies the EHR).
+fn status_for_subject(subject_id: &str) -> Value {
+    json!({
+        "_type": "EHR_STATUS",
+        "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
+        "archetype_details": {
+            "_type": "ARCHETYPED",
+            "archetype_id": { "_type": "ARCHETYPE_ID",
+                              "value": "openEHR-EHR-EHR_STATUS.generic.v1" },
+            "rm_version": "1.2.0"
+        },
+        "name": { "_type": "DV_TEXT", "value": "EHR Status" },
+        "subject": {
+            "_type": "PARTY_SELF",
+            "external_ref": {
+                "_type": "PARTY_REF",
+                "namespace": "patients",
+                "type": "PERSON",
+                "id": { "_type": "HIER_OBJECT_ID", "value": subject_id }
+            }
+        },
+        "is_queryable": true,
+        "is_modifiable": true
+    })
+}
+
 #[tokio::test]
 async fn import_ehr_clone_into_fresh_target_reuses_source_id() {
     let source_db = testkit::db().await.expect("testkit database");
@@ -173,6 +245,185 @@ async fn import_ehr_clone_into_fresh_target_reuses_source_id() {
             "clone must carry {xtype}"
         );
     }
+    // Exactly one: an extract that already carries an EHR_ACCESS is never given
+    // a second, locally bootstrapped one (EHR.ehr_access is 1..1 — RM ehr
+    // `ehr.adoc` invariant `Ehr_access_valid`).
+    assert_eq!(
+        count_by_xtype(&re_export[0], "X_VERSIONED_EHR_ACCESS"),
+        1,
+        "the carried EHR_ACCESS is the only one"
+    );
+}
+
+#[tokio::test]
+async fn import_ehr_without_ehr_access_bootstraps_the_mandatory_default() {
+    // RM ehr `ehr.adoc` invariant `Ehr_access_valid` makes `EHR.ehr_access`
+    // 1..1, and master04 §EHR Creation requires that creating an EHR yields "a
+    // root EHR object, an EHR Status object, and an EHR Access object …
+    // created and committed in a Contribution". An extract that carries no
+    // EHR_ACCESS must therefore be completed locally — otherwise the clone
+    // violates the invariant permanently and its served EHR body omits the
+    // mandatory reference.
+    let source_db = testkit::db().await.expect("testkit database");
+    let source = EhrbaseService::new(source_db.pool());
+    let target_db = testkit::db().await.expect("testkit database");
+    let target = EhrbaseService::new(target_db.pool());
+
+    let ehr = seed_ehr(&source).await;
+    let exported = source.extract_ehrs(ehr).await.expect("export");
+    assert_eq!(
+        count_by_xtype(&exported[0], "X_VERSIONED_EHR_ACCESS"),
+        1,
+        "fixture: the source export carries an EHR_ACCESS to strip"
+    );
+    target
+        .import_ehr(None, without_ehr_access(&exported[0]))
+        .await
+        .expect("import an extract with no EHR_ACCESS");
+
+    // The served EHR body carries the mandatory ehr_access reference.
+    let body = target.ehr_object(ehr).await.expect("EHR body");
+    assert_eq!(body["ehr_access"]["_type"], json!("OBJECT_REF"));
+    assert_eq!(body["ehr_access"]["type"], json!("VERSIONED_EHR_ACCESS"));
+    assert!(
+        body["ehr_access"]["id"]["value"]
+            .as_str()
+            .is_some_and(|v| !v.is_empty()),
+        "the ehr_access ref names the VERSIONED_EHR_ACCESS, got {body:#}"
+    );
+
+    // And the container really exists — one locally created first version.
+    let re_export = target.extract_ehrs(ehr).await.expect("re-export clone");
+    assert_eq!(
+        count_by_xtype(&re_export[0], "X_VERSIONED_EHR_ACCESS"),
+        1,
+        "exactly one bootstrapped EHR_ACCESS"
+    );
+    let access =
+        find_by_xtype(&re_export[0], "X_VERSIONED_EHR_ACCESS").expect("bootstrapped EHR_ACCESS");
+    let versions = access["item"]["versions"]
+        .as_array()
+        .expect("EHR_ACCESS versions");
+    assert_eq!(versions.len(), 1, "the bootstrap commits one version");
+    let version_uid = versions[0]["uid"]["value"]
+        .as_str()
+        .expect("version uid.value");
+    assert!(
+        version_uid.ends_with("::1"),
+        "the bootstrapped EHR_ACCESS is a first version, got {version_uid}"
+    );
+    assert_eq!(versions[0]["data"]["_type"], json!("EHR_ACCESS"));
+    // The default is an archetype root (RM ehr `ehr_access.adoc`
+    // `Is_archetype_root`; RM common `locatable.adoc` `Archetyped_valid`).
+    assert!(
+        versions[0]["data"]["archetype_details"].is_object(),
+        "the default EHR_ACCESS carries its ARCHETYPED block, got {:#}",
+        versions[0]["data"]
+    );
+}
+
+#[tokio::test]
+async fn import_ehr_promotes_the_subject_for_lookup_and_uniqueness() {
+    // An imported EHR is a full local EHR: its EHR_STATUS.subject is promoted,
+    // so the clone is found by the subject lookup (SM
+    // `I_EHR_SERVICE.get_ehrs_for_subject`;
+    // `operations/ehr_get_by_subject.yaml`) and holds the subject against a
+    // later create (one EHR per subject — RM ehr master04 §EHR Status).
+    let source_db = testkit::db().await.expect("testkit database");
+    let source = EhrbaseService::new(source_db.pool());
+    let target_db = testkit::db().await.expect("testkit database");
+    let target = EhrbaseService::new(target_db.pool());
+
+    let ehr = source
+        .create_ehr(Some(status_for_subject("patient-import-1")))
+        .await
+        .expect("source EHR for the subject");
+    let extract = export_one(&source, ehr).await;
+    target.import_ehr(None, extract).await.expect("import_ehr");
+
+    // The extract normalizes every OBJECT_REF-family namespace to "local"
+    // (EHR Extract master09 §Creation Semantics: "rewriting its
+    // OBJECT_REFs so that namespace = \"local\""), so the imported
+    // subject is patient-import-1@local — the promoted columns follow
+    // the STORED status, exactly as the fix requires.
+    let subject = SubjectRef::person("patient-import-1", "local");
+    assert!(
+        target
+            .has_ehr_for_subject(subject.clone())
+            .await
+            .expect("has_ehr_for_subject"),
+        "the imported clone must be visible to the subject lookup"
+    );
+    let found = target
+        .get_ehrs_for_subject(subject)
+        .await
+        .expect("get_ehrs_for_subject");
+    assert_eq!(found.len(), 1, "one EHR per subject");
+    assert_eq!(found[0].ehr_id, ehr.to_string());
+
+    // The subject is now taken in the target — under the "local" namespace
+    // the extract normalized it to — so a later create naming that same
+    // (id, namespace) pair is a 409.
+    let dup = target
+        .create_ehr(Some(status_for_subject_in("patient-import-1", "local")))
+        .await;
+    assert!(
+        matches!(
+            dup,
+            Err(ehrbase::service::status::SmError {
+                status: CallStatusType::CompositionAlreadyExists,
+                ..
+            })
+        ),
+        "an EHR for a subject an imported clone already holds must 409, got {dup:?}"
+    );
+}
+
+#[tokio::test]
+async fn import_ehr_conflicting_subject_is_rejected_and_rolled_back() {
+    // Importing a clone of a subject this repository already holds under
+    // another EHR is a conflict, not a silent duplicate (one EHR per subject —
+    // RM ehr master04 §EHR Status); the whole import transaction rolls back.
+    let source_db = testkit::db().await.expect("testkit database");
+    let source = EhrbaseService::new(source_db.pool());
+    let target_db = testkit::db().await.expect("testkit database");
+    let target = EhrbaseService::new(target_db.pool());
+
+    // The import will carry the subject under namespace "local" (the
+    // extract's master09 §Creation Semantics OBJECT_REF rewrite), so the
+    // pre-existing holder must own it under that namespace to collide.
+    let owner = target
+        .create_ehr(Some(status_for_subject_in("patient-import-2", "local")))
+        .await
+        .expect("the target already holds the subject");
+    let ehr = source
+        .create_ehr(Some(status_for_subject("patient-import-2")))
+        .await
+        .expect("source EHR for the same subject");
+    let extract = export_one(&source, ehr).await;
+
+    let err = target
+        .import_ehr(None, extract)
+        .await
+        .expect_err("importing a subject the target already holds must be rejected");
+    assert_eq!(err.status, CallStatusType::CompositionAlreadyExists);
+    assert!(
+        err.message.contains("patient-import-2") && err.message.contains(&owner.to_string()),
+        "the error must name the subject and the EHR that holds it, got: {}",
+        err.message
+    );
+
+    // Rolled back: the clone left nothing behind, and the owner is untouched.
+    assert!(
+        !target.has_ehr(ehr).await.expect("has_ehr"),
+        "a rejected import must not leave a partial EHR"
+    );
+    let found = target
+        .get_ehrs_for_subject(SubjectRef::person("patient-import-2", "local"))
+        .await
+        .expect("get_ehrs_for_subject");
+    assert_eq!(found.len(), 1);
+    assert_eq!(found[0].ehr_id, owner.to_string());
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #425 — fix 4 of the #379 (group-3) wave.

## What shipped

**Imported EHRs are complete.** `import_ehr` bootstraps the default EHR_ACCESS (post-#423: with its ARCHETYPED block) when the extract carries none — committed in its OWN contribution (`249|creation|`, server-signed) in the same transaction, so the clone never violates `Ehr_access_valid` (RM `ehr.adoc` 1..1) and the served EHR body is whole. The archive load deliberately does NOT synthesize (a restore is not a creation; archive⇒repository identity preserved — NOTE'd).

**Imported/loaded subjects participate.** A new `resync_promoted_columns` reads the STORED current EHR_STATUS and reuses the one existing promotion seam — imported and archive-loaded EHRs are now visible to `GET /ehr?subject_id` and hold the one-EHR-per-subject 409; a conflicting import/load rolls back with an error naming subject + owner (partial archive loads report per-record, rest still loads). The load re-derives from the loaded status (the archived columns are cache, not truth) — which retroactively fixes archives of pre-fix imports. Stale 'deliberately left unset' NOTE corrected.

**Gate finding (orchestrator, probe-verified):** the worker's tests asserted the source namespace after import — but the extract REWRITES every OBJECT_REF-family namespace to \"local\" (EHR Extract master09 §Creation Semantics, quoted in the export code), so an imported subject is `id@local` by spec. Tests corrected toward the spec (never the export weakened); the citation is now in the tests.

## Gates
fmt clean · clippy zero warnings · nextest **1142/1142**. Changelog updated. No wire/CNF change (import/load are not REST-exposed; the only visible effect — imported EHRs appearing in subject lookup — is changelogged).