### PR TITLE
fix(ehr): EHR.ehr_status and EHR.ehr_access refs both carry the container HIER_OBJECT_ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Changed
+
+- **`EHR.ehr_status` references the version container by its
+  `HIER_OBJECT_ID`** (#426). The served EHR body's `ehr_status` OBJECT_REF
+  (typed `VERSIONED_EHR_STATUS` per the RM invariant) previously carried an
+  `OBJECT_VERSION_ID` naming one version — inconsistent with the sibling
+  `ehr_access` ref and with the RM's container semantics (`OBJECT_REF.id` is
+  the id of the referenced object; the referenced object is the
+  VERSIONED_EHR_STATUS, whose uid is a `HIER_OBJECT_ID`). Both refs now
+  carry the container id. Clients that read the current EHR_STATUS version
+  uid from the EHR body must fetch `GET /ehr/{ehr_id}/ehr_status` and use
+  its own `uid` instead.
+
 ### Added
 
 - **`[server] system_id` — the deployment's own openEHR system identifier is

--- a/app/ehrbase-rest/tests/protocol_tail.rs
+++ b/app/ehrbase-rest/tests/protocol_tail.rs
@@ -425,7 +425,22 @@ async fn ehr_create_accepts_and_merges_committal_headers() {
     assert_eq!(status, StatusCode::CREATED, "ehr create: {body}");
     let ehr_id = etag_uid(&h);
     let ehr: Value = serde_json::from_str(&body).expect("ehr json");
-    let status_uid = ehr["ehr_status"]["id"]["value"]
+    // The EHR body's ehr_status ref names the CONTAINER (HIER_OBJECT_ID —
+    // RM ehr Ehr_status_valid + BASE master05 OBJECT_REF.id); the VERSION
+    // uid comes from the served EHR_STATUS itself.
+    assert_eq!(ehr["ehr_status"]["id"]["_type"], "HIER_OBJECT_ID");
+    let (status, _h, body) = send(
+        &app,
+        Request::builder()
+            .method("GET")
+            .uri(format!("{BASE}/ehr/{ehr_id}/ehr_status"))
+            .body(Body::empty())
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "status read: {body}");
+    let st: Value = serde_json::from_str(&body).expect("ehr_status json");
+    let status_uid = st["uid"]["value"]
         .as_str()
         .expect("ehr_status version id")
         .to_owned();
@@ -486,7 +501,22 @@ async fn ehr_create_with_id_accepts_and_merges_committal_headers() {
     let (status, _h, body) = send(&app, req).await;
     assert_eq!(status, StatusCode::CREATED, "ehr create with id: {body}");
     let ehr: Value = serde_json::from_str(&body).expect("ehr json");
-    let status_uid = ehr["ehr_status"]["id"]["value"]
+    // The EHR body's ehr_status ref names the CONTAINER (HIER_OBJECT_ID —
+    // RM ehr Ehr_status_valid + BASE master05 OBJECT_REF.id); the VERSION
+    // uid comes from the served EHR_STATUS itself.
+    assert_eq!(ehr["ehr_status"]["id"]["_type"], "HIER_OBJECT_ID");
+    let (status, _h, body) = send(
+        &app,
+        Request::builder()
+            .method("GET")
+            .uri(format!("{BASE}/ehr/{CREATED_EHR_ID}/ehr_status"))
+            .body(Body::empty())
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "status read: {body}");
+    let st: Value = serde_json::from_str(&body).expect("ehr_status json");
+    let status_uid = st["uid"]["value"]
         .as_str()
         .expect("ehr_status version id")
         .to_owned();

--- a/app/ehrbase/src/service/ehr/service.rs
+++ b/app/ehrbase/src/service/ehr/service.rs
@@ -21,7 +21,6 @@ use crate::service::error::ServiceError;
 use crate::versioning::Kind;
 use crate::versioning::audit::change_type;
 use crate::versioning::change::{Change, commit_contribution};
-use crate::versioning::object_version_id::{TreeId, object_version_id};
 
 use super::status_for_subject;
 
@@ -214,14 +213,15 @@ impl EhrbaseService {
             .iter()
             .find(|c| c.kind == Kind::EhrStatus)
             .map(|c| {
+                // The container ref: HIER_OBJECT_ID of the VERSIONED_EHR_STATUS
+                // (RM ehr `Ehr_status_valid` + BASE master05 OBJECT_REF.id —
+                // the referenced object IS the container), matching the read
+                // path and the ehr_access ref.
                 json!({
                     "_type": "OBJECT_REF",
                     "namespace": "local",
                     "type": "VERSIONED_EHR_STATUS",
-                    "id": {
-                        "_type": "OBJECT_VERSION_ID",
-                        "value": object_version_id(c.vo_id, &c.creating_system_id, c.tree)
-                    }
+                    "id": { "_type": "HIER_OBJECT_ID", "value": c.vo_id.to_string() }
                 })
             });
         let mut body = json!({
@@ -302,28 +302,24 @@ impl EhrbaseService {
                 format!("EHR_STATUS for EHR {ehr_id}"),
             )
         })?;
-        let status_version = TreeId::from_columns(
-            status.trunk_version,
-            status.branch_number,
-            status.branch_version,
-        );
-        let status_ovid =
-            object_version_id(status.vo_id, &status.creating_system_id, status_version);
-
         let mut body = json!({
             "_type": "EHR",
             "system_id": { "_type": "HIER_OBJECT_ID", "value": stored_system_id },
             "ehr_id": { "_type": "HIER_OBJECT_ID", "value": ehr_id.to_string() },
             // Ehr_status_valid: ehr_status.type.is_equal("VERSIONED_EHR_STATUS")
-            // (RM ehr `ehr.adoc` invariants — normative). NOTE (spec
-            // defect): the non-normative ITS-REST example shows `type:
-            // EHR_STATUS`; the RM invariant wins for `type`, the id keeps the
-            // OBJECT_VERSION_ID form clients use to address the current version.
+            // (RM ehr `ehr.adoc` invariants — normative): the ref names the
+            // version CONTAINER, so its `id` is the container's
+            // HIER_OBJECT_ID (BASE master05: OBJECT_REF.id is the "Globally
+            // unique id of an object" — here the VERSIONED_EHR_STATUS, whose
+            // uid is a HIER_OBJECT_ID), consistent with the `ehr_access` ref
+            // below. NOTE (spec defect): the non-normative ITS-REST example
+            // shows `type: EHR_STATUS` with an OBJECT_VERSION_ID id — the
+            // stalled OAS reading; the RM wins on both counts.
             "ehr_status": {
                 "_type": "OBJECT_REF",
                 "namespace": "local",
                 "type": "VERSIONED_EHR_STATUS",
-                "id": { "_type": "OBJECT_VERSION_ID", "value": status_ovid }
+                "id": { "_type": "HIER_OBJECT_ID", "value": status.vo_id.to_string() }
             },
             "time_created": { "_type": "DV_DATE_TIME", "value": time_created.to_string() }
         });

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_SERVICE.create_ehr-committal.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_SERVICE.create_ehr-committal.yaml
@@ -22,11 +22,11 @@
 # the persisted EHR_STATUS ORIGINAL_VERSION.commit_audit.
 #
 # Identical to the variant-less I_EHR_SERVICE.create_ehr binding except the
-# added committal header and the EHR_STATUS version capture, so a red row
-# localizes to the create-time merge alone. `Prefer: return=representation`
-# (already the base binding's request) yields the RM EHR body whose
-# `ehr_status` OBJECT_REF carries the committed version's OBJECT_VERSION_ID —
-# the read-back handle for step 2.
+# added committal header, so a red row localizes to the create-time merge
+# alone. The EHR body's `ehr_status` OBJECT_REF names the version CONTAINER
+# (a HIER_OBJECT_ID — RM ehr `Ehr_status_valid` + BASE master05
+# `OBJECT_REF.id`), so the case fetches the committed VERSION uid from the
+# served EHR_STATUS itself (`I_EHR_STATUS.get_ehr_status` step 2).
 sm_operation: I_EHR_SERVICE.create_ehr
 its: its-rest
 variant: committal
@@ -52,8 +52,4 @@ captures:
   ehr_id:
     from: body "ehr_id.value"
     fallback: header Location last-segment
-  # The OBJECT_VERSION_ID of the EHR_STATUS version the creation committed
-  # (RM ehr master04 §EHR Creation) — the EHR body's ehr_status OBJECT_REF.
-  status_version_uid:
-    from: body "ehr_status.id.value"
 server_assigned: [ehr_id, system_id, time_created, ehr_status/uid, ehr_access]

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.create_ehr-committal_headers.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.create_ehr-committal_headers.yaml
@@ -46,8 +46,17 @@ flow:
     expect: created
     capture:
       new_ehr_id: created.ehr_id
-      status_version_uid: created.status_version_uid
+  # The EHR body's ehr_status ref names the CONTAINER (RM ehr
+  # `Ehr_status_valid`; BASE master05 OBJECT_REF.id), so the committed
+  # VERSION uid is read from the served EHR_STATUS.
   - step: 2
+    call: I_EHR_STATUS.get_ehr_status
+    with:
+      ehr_id: "${new_ehr_id}"
+    expect: ok
+    capture:
+      status_version_uid: ok.status_version_uid
+  - step: 3
     call: I_EHR_STATUS.get_versioned_ehr_status
     variant: version
     with:


### PR DESCRIPTION
Closes #426 — fix 5 of the #379 (group-3) wave; orchestrator-implemented.

## What shipped

The served `EHR.ehr_status` OBJECT_REF — correctly typed `VERSIONED_EHR_STATUS` (RM `Ehr_status_valid`) — carried an `OBJECT_VERSION_ID` naming ONE version, mutually inconsistent with the sibling `ehr_access` ref (container `HIER_OBJECT_ID`). RM grounding: BASE master05 `OBJECT_REF.id` is the id of the referenced OBJECT, and the referenced object is the CONTAINER, whose uid is a `HIER_OBJECT_ID`. Both the create-response and read paths now emit the container id; the in-code NOTE keeps the stalled-OAS divergence as provenance only (owner ruling: never an ambiguity, zero register entries).

**Ripple handled:** the #422 CNF committal case + wire tests captured the version uid from the body ref — both now read it from the served EHR_STATUS's own `uid` (the honest source), with the citation.

## Gates
fmt clean · clippy zero warnings · nextest 1142/1142 + cnf-runner 171/171 · validate 468/106/0. Changelog (`### Changed` — wire change with the client migration note).