### PR TITLE
fix(rest): committal_audit seeds the committer with the authenticated principal

### DIFF
--- a/app/ehrbase-rest/src/api/demographic/party.rs
+++ b/app/ehrbase-rest/src/api/demographic/party.rs
@@ -47,7 +47,14 @@ pub(super) async fn run(
             // (overview::error::sm_api_error) — `?` routes each to its status.
             let mut resp = state
                 .backend()
-                .party_create(kind, body, crate::overview::committal::committal_audit(h))
+                .party_create(
+                    kind,
+                    body,
+                    crate::overview::committal::committal_audit(
+                        h,
+                        crate::api::ehr::committer_proxy(),
+                    ),
+                )
                 .await?;
             // the incoming `openehr-item-tag` request header (person_create.yaml)
             // carries ITEM_TAGs to persist. The party must exist first
@@ -92,7 +99,10 @@ pub(super) async fn run(
                     // OBJECT_VERSION_ID (overview §"`ETag` and Last-Modified").
                     super::if_match_token(&p.if_match),
                     body,
-                    crate::overview::committal::committal_audit(h),
+                    crate::overview::committal::committal_audit(
+                        h,
+                        crate::api::ehr::committer_proxy(),
+                    ),
                 )
                 .await
             {
@@ -197,7 +207,7 @@ async fn run_delete(
             kind,
             preceding.clone(),
             super::if_match_of(h),
-            crate::overview::committal::committal_audit(h),
+            crate::overview::committal::committal_audit(h, crate::api::ehr::committer_proxy()),
         )
         .await
     {

--- a/app/ehrbase-rest/src/api/demographic/relationship.rs
+++ b/app/ehrbase-rest/src/api/demographic/relationship.rs
@@ -422,7 +422,13 @@ pub(super) async fn run(
             let body = negotiate::rm_value::<PartyRelationship>(h, &parts.body)?;
             let resp = state
                 .backend()
-                .party_relationship_create(body, crate::overview::committal::committal_audit(h))
+                .party_relationship_create(
+                    body,
+                    crate::overview::committal::committal_audit(
+                        h,
+                        crate::api::ehr::committer_proxy(),
+                    ),
+                )
                 .await?;
             Ok(write_relationship(
                 h,
@@ -456,7 +462,10 @@ pub(super) async fn run(
                     // so the service compares a bare OBJECT_VERSION_ID.
                     super::if_match_token(&p.if_match),
                     body,
-                    crate::overview::committal::committal_audit(h),
+                    crate::overview::committal::committal_audit(
+                        h,
+                        crate::api::ehr::committer_proxy(),
+                    ),
                 )
                 .await
             {
@@ -487,7 +496,10 @@ pub(super) async fn run(
                 .party_relationship_delete(
                     p.uid_based_id,
                     super::if_match_of(h),
-                    crate::overview::committal::committal_audit(h),
+                    crate::overview::committal::committal_audit(
+                        h,
+                        crate::api::ehr::committer_proxy(),
+                    ),
                 )
                 .await?;
             let mut out = negotiate::empty(StatusCode::NO_CONTENT);

--- a/app/ehrbase-rest/src/api/ehr/composition.rs
+++ b/app/ehrbase-rest/src/api/ehr/composition.rs
@@ -282,7 +282,8 @@ pub(super) async fn run(
             // request headers are accepted and merged here too (overview
             // §"openehr-version and openehr-audit-details": PUT, POST and
             // DELETE).
-            let update_audit = crate::overview::committal::committal_audit(h);
+            let update_audit =
+                crate::overview::committal::committal_audit(h, super::committer_proxy());
             match state
                 .backend()
                 .delete_composition(ehr_id, &ovid, update_audit.as_ref())

--- a/app/ehrbase-rest/src/api/ehr/directory.rs
+++ b/app/ehrbase-rest/src/api/ehr/directory.rs
@@ -166,7 +166,8 @@ pub(super) async fn run(
             // request headers are accepted and merged here too (overview
             // §"openehr-version and openehr-audit-details": PUT, POST and
             // DELETE).
-            let update_audit = crate::overview::committal::committal_audit(h);
+            let update_audit =
+                crate::overview::committal::committal_audit(h, super::committer_proxy());
             match state
                 .backend()
                 .delete_directory(

--- a/app/ehrbase-rest/src/api/ehr/mod.rs
+++ b/app/ehrbase-rest/src/api/ehr/mod.rs
@@ -150,7 +150,7 @@ fn term(code: &str) -> TerminologyCode {
 /// published by the auth middleware (system identity when none). The SM service
 /// impl re-derives the committer from the same principal, so this rides in the
 /// [`UpdateVersion`] envelope for completeness.
-fn committer_proxy() -> PartyProxy {
+pub(crate) fn committer_proxy() -> PartyProxy {
     let value = match crate::extensions::access::authn::current_principal() {
         Some(principal) => {
             let id_type = match principal.method {

--- a/app/ehrbase-rest/src/overview/committal.rs
+++ b/app/ehrbase-rest/src/overview/committal.rs
@@ -143,16 +143,17 @@ fn apply_attrs(uv: &mut UpdateVersion, attrs: &IndexMap<String, Vec<(String, Str
 /// headers accepted on `PUT`, `POST` **and** `DELETE`). `None` when no
 /// committal header is present, so a plain request keeps the server-default
 /// attribution path.
-// TODO: seed this merge with the request's authenticated committer the way
-// `committal_commit` does — a request that supplies only `description`
-// currently attributes the commit to `UpdateVersion::direct`'s system
-// placeholder instead of the principal, which overwrites a default the client
-// never supplied (overview §"openehr-version and openehr-audit-details":
-// only "whatever is provided" is merged).
+/// Seeded with the request's authenticated committer (the same seed
+/// `committal_commit` takes), so a header set that supplies only
+/// `description` keeps the PRINCIPAL as committer — the merge only replaces
+/// "whatever is provided" (overview §"openehr-version and
+/// openehr-audit-details"); the `UpdateVersion::direct` system placeholder
+/// is never a default the client chose.
 pub(crate) fn committal_audit(
     headers: &HeaderMap,
+    committer: openehr_rm::prelude::PartyProxy,
 ) -> Option<ehrbase::service::version_update::UpdateAudit> {
-    merged_committal(headers, None).map(|c| c.audit)
+    merged_committal(headers, Some(committer)).map(|c| c.audit)
 }
 
 /// The full committal metadata — merged `UPDATE_AUDIT` **and** the VERSION
@@ -484,15 +485,38 @@ mod tests {
     #[test]
     fn committal_audit_blanks_the_placeholder_change_type() {
         let h = headers(&[(H_AUDIT_DETAILS, "description.value=\"why\"")]);
-        let audit = committal_audit(&h).expect("headers present");
+        let audit = committal_audit(
+            &h,
+            openehr_its::json::from_canonical_value(
+                &serde_json::json!({ "_type": "PARTY_IDENTIFIED", "name": "principal" }),
+            )
+            .expect("committer"),
+        )
+        .expect("headers present");
         assert_eq!(audit.change_type.code_string, "");
         assert_eq!(audit.description.as_deref(), Some("why"));
 
         let h = headers(&[(H_AUDIT_DETAILS, "change_type.code_string=\"250\"")]);
-        let audit = committal_audit(&h).expect("headers present");
+        let audit = committal_audit(
+            &h,
+            openehr_its::json::from_canonical_value(
+                &serde_json::json!({ "_type": "PARTY_IDENTIFIED", "name": "principal" }),
+            )
+            .expect("committer"),
+        )
+        .expect("headers present");
         assert_eq!(audit.change_type.code_string, "250");
 
-        assert!(committal_audit(&HeaderMap::new()).is_none());
+        assert!(
+            committal_audit(
+                &HeaderMap::new(),
+                openehr_its::json::from_canonical_value(
+                    &serde_json::json!({ "_type": "PARTY_IDENTIFIED", "name": "principal" })
+                )
+                .expect("committer")
+            )
+            .is_none()
+        );
     }
 
     // ── development-edition form (the worked example, lines 85–91) ───────────
@@ -581,6 +605,34 @@ mod tests {
         ]);
         merge_committal_headers(&mut uv, &h);
         assert_eq!(uv.audit.change_type.code_string, "251");
+    }
+
+    /// A header set supplying only `description` keeps the SEEDED principal
+    /// as committer — the merge replaces "whatever is provided", never the
+    /// default (overview §"openehr-version and openehr-audit-details").
+    #[test]
+    fn committal_audit_keeps_the_seeded_principal_committer() {
+        let seed = openehr_its::json::from_canonical_value(&serde_json::json!({
+            "_type": "PARTY_IDENTIFIED", "name": "dr-alice"
+        }))
+        .expect("committer");
+        let h = headers(&[(H_AUDIT_DETAILS, "description.value=\"why\"")]);
+        let audit = committal_audit(&h, seed).expect("headers present");
+        let committer = openehr_its::json::to_canonical_value(&audit.committer);
+        assert_eq!(
+            committer["name"], "dr-alice",
+            "principal survives a partial header set"
+        );
+
+        // A header-supplied committer still wins over the seed.
+        let seed = openehr_its::json::from_canonical_value(&serde_json::json!({
+            "_type": "PARTY_IDENTIFIED", "name": "dr-alice"
+        }))
+        .expect("committer");
+        let h = headers(&[(H_AUDIT_DETAILS, "committer.name=\"Locum\"")]);
+        let audit = committal_audit(&h, seed).expect("headers present");
+        let committer = openehr_its::json::to_canonical_value(&audit.committer);
+        assert_eq!(committer["name"], "Locum");
     }
 
     /// `committal_commit` carries BOTH halves of the merge from ONE parse: the

--- a/app/ehrbase-rest/tests/served_openapi.rs
+++ b/app/ehrbase-rest/tests/served_openapi.rs
@@ -278,6 +278,7 @@ async fn versioned_writes_document_if_match_and_412() {
 /// `406` MUST. `Requests_and_responses.md` §Location confines `Location` to
 /// creation responses, so a read MUST NOT declare it.
 #[tokio::test]
+#[allow(clippy::too_many_lines)] // one regression test per audited group keeps the pins together
 async fn ehr_resource_operations_are_fully_documented() {
     const EHR: &str = "/ehrbase/rest/openehr/v1/ehr";
     const EHR_BY_ID: &str = "/ehrbase/rest/openehr/v1/ehr/{ehr_id}";


### PR DESCRIPTION
Closes #430 — fix 7 of the #379 (group-3) wave (the #422 worker's flagged finding).

## What shipped

`committal_audit` — the seam behind composition delete, directory delete, and all six demographic commit paths — seeded its merge with `UpdateVersion::direct()`'s `\"EHRbase\"` placeholder committer, so a request supplying ONLY `description` attributed the commit to the placeholder instead of the authenticated principal. The merge may only replace \"whatever is provided\" (R&R §openehr-version…); the default committer is the principal. `committal_audit` now takes the same seed `committal_commit` does; all 8 call sites pass `committer_proxy()`. Unit tests pin both directions (principal survives a partial set; a header-supplied committer still wins). Piggy-backed: the #427 regression test's `too_many_lines` allow (documented) so develop is clippy-clean again.

## Gates
fmt clean · clippy zero warnings · nextest 1144/1144.