### PR TITLE
fix(cnf): group-3 red-run triage — catalogue corrections + commit-time uid stamping

### DIFF
--- a/.claude/agent-memory/cnf-triage/MEMORY.md
+++ b/.claude/agent-memory/cnf-triage/MEMORY.md
@@ -7,4 +7,7 @@
 - [Runner driver gaps (confirmed)](runner-driver-gaps.md) — option-gating, header-mutation variants, ctx/ equivalence normalization
 - [content_synth HISTORY events existence](content-synth-history-events-existence.md) — RUNNER defect: builders hardcode events existence 1..1; zero-event+summary rows (any/opt cardinality) wrongly fail; SUT spec-correct
 - [ADL14 template_id collision](adl14-template-id-collision.md) — CATALOGUE defect: master08 contribution provisioning reuses master04 server:empty upload/validate template_ids (time_series/obs_admin); SUT already_exists is spec-correct
+- [EHR_STATUS archetype-root invariant](ehr-status-archetype-root-invariant.md) — archetype_details MANDATORY on EHR_STATUS/EHR_ACCESS (Is_archetype_root × Archetyped_valid); the app 422 is spec-correct
+- [Two EHR_STATUS payload sites PR #431 missed](cnf-red-2026-07-27-ehr-status-payloads.md) — ehr_status recipe + contribution case core; catalogue bin; sweep command included
+- [Contained uid is a recommendation](contained-uid-is-a-recommendation.md) — data/uid presence is SHOULD in every released source; cannot gate CORE; AMB-65 fixes only the FORM
 - [Upstream EHRbase Java non-conformance (#266)](upstream-ehrbase-java-nonconformance.md) — EHRbase 2.34.0 400s the spec-standard QUOTED If-Match (composition/ehr_status update classes) + 404s the STABLE item-tag surface; our driver/pack spec-valid, outcome (b), record stands

--- a/.claude/agent-memory/cnf-triage/cnf-red-2026-07-27-ehr-status-payloads.md
+++ b/.claude/agent-memory/cnf-triage/cnf-red-2026-07-27-ehr-status-payloads.md
@@ -1,0 +1,29 @@
+---
+name: cnf-red-2026-07-27-ehr-status-payloads
+description: The two EHR_STATUS payload sites PR #431 missed (recipe + contribution case core) — catalogue defects, not app
+metadata:
+  type: project
+---
+
+PR #431 (issue #423) swept the RM-invalid EHR_STATUS fixtures but reached only
+`source:`-backed JSON files. Two payload sites were missed and turned red in the
+2026-07-27 run (28 rows):
+
+1. `tools/cnf-runner/artifacts/corpus/recipes/ehr_status.md` (the digest-pinned
+   contract) + its implementation `tools/cnf-runner/src/exec/recipes.rs`
+   `fn ehr_status` + the two digests in
+   `artifacts/corpus/MANIFEST.yaml` (`cnf.ehr_status.provided`) — drives
+   `I_EHR_SERVICE.create_ehr-main` rows 2..17.
+2. The inline `versions[0].data` block in
+   `artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-ehr_status_valid_combinations.yaml`
+   — all 12 rows.
+
+Both emit `archetype_node_id: openEHR-EHR-EHR_STATUS.generic.v1` with no
+`archetype_details` → see [[ehr-status-archetype-root-invariant]].
+
+**How to apply:** a corpus **recipe** defect is a CATALOGUE bin defect even
+though the code lives in `tools/cnf-runner/src` — the authority is the
+digest-pinned `corpus/recipes/*.md` contract; the `.rs` is its implementation and
+moves in lockstep with a re-stamped digest. Sweep for further sites with:
+`for f in $(grep -rl '_type.*EHR_STATUS' tools/cnf-runner/artifacts/); do grep -q archetype_details "$f" || echo "$f"; done`
+(read-only cases and the deliberately-invalid fixture are the expected hits).

--- a/.claude/agent-memory/cnf-triage/contained-uid-is-a-recommendation.md
+++ b/.claude/agent-memory/cnf-triage/contained-uid-is-a-recommendation.md
@@ -1,0 +1,44 @@
+---
+name: contained-uid-is-a-recommendation
+description: The uid copied into a served top-level object (COMPOSITION/EHR_STATUS) is SHOULD-strength in every released source — it cannot gate CORE
+metadata:
+  type: project
+---
+
+The `uid` on a VERSION-contained top-level object is **never required** by any
+released component (confirmed first-hand 2026-07-27):
+
+- `RM/docs/UML/classes/org.openehr.rm.common.locatable.adoc` — `uid` is `0..1`.
+- `RM/docs/common/master03-archetyped_package.adoc` §Unique Node Identification —
+  "it is **recommended** to set the `_uid_` value to a copy of the
+  `_uid.object_id()_` value of the owning `VERSION` object … i.e. the leading
+  Uid"; same section: "The `_uid_` attribute will usually be empty in most EHR
+  data in most openEHR EHR systems."
+- `ITS-REST .../docs/overview/Resources.md` §Identifier types NOTE — "it is
+  **strongly recommended** that the inherited `uid` attribute **in COMPOSITION
+  objects** be populated … this value **should** be copied" (scoped to
+  COMPOSITION; no MUST/SHALL anywhere).
+- `RM/docs/UML/classes/org.openehr.rm.ehr.ehr_status.adoc` NOTE — "**strongly
+  recommended** … using the UID copied from the `_object_id()_` of the `_uid_`
+  field of the enclosing VERSION object", but its worked example copies the FULL
+  three-part `87284370-…::uk.nhs.ehr1::2`. That NOTE therefore contradicts
+  ITSELF (wording=object_id, example=full) and its example AGREES with ITS-REST
+  — the AMB-65 `source:` field misstates this as "the same object_id()-only rule
+  restated for EHR_STATUS".
+
+So AMB-65 legitimately fixes the FORM *given presence*; it does not and cannot
+make PRESENCE a requirement.
+
+SUT shape (2026-07-27): `service/ehr/meta.rs::with_uid` injects the full
+three-part OBJECT_VERSION_ID on **bare** reads only; the ORIGINAL_VERSION
+envelope serves `read.canonical` verbatim
+(`versioning/wire.rs::build_original_version`), which has no uid — the builder is
+shared with the commit-time signer, so a read-time injection would break the
+signature; the only sound app-side fix would stamp the uid into the STORED
+canonical before signing.
+
+**How to apply:** any assertion of `data/uid/...` presence must be non-gating
+(the runner's mechanism is `verdict.rs::is_report_only` — a case whose
+`ambiguities:` names a `report_only` register entry gets `gating = false`).
+A `capabilities: [EhrStatus]` tag makes a case CORE-gating regardless of its
+`profiles:` field (`vocab/capability_matrix.yaml`: EhrStatus tier CORE).

--- a/.claude/agent-memory/cnf-triage/ehr-status-archetype-root-invariant.md
+++ b/.claude/agent-memory/cnf-triage/ehr-status-archetype-root-invariant.md
@@ -1,0 +1,33 @@
+---
+name: ehr-status-archetype-root-invariant
+description: EHR_STATUS/EHR_ACCESS MUST carry archetype_details — app 422 is spec-correct; red rows are catalogue payload residue
+metadata:
+  type: project
+---
+
+CONFIRMED spec derivation (2026-07-27 triage, RM 1.2.0 vendored text):
+
+- `RM/docs/UML/classes/org.openehr.rm.common.locatable.adoc` §Invariants —
+  `__Archetyped_valid__: is_archetype_root xor archetype_details = Void`.
+- `RM/docs/UML/classes/org.openehr.rm.ehr.ehr_status.adoc` §Invariants —
+  `__Is_archetype_root__: is_archetype_root` (unconditional; same for
+  `org.openehr.rm.ehr.ehr_access.adoc`).
+
+Conjunction: `is_archetype_root = True` forces `archetype_details = Void` to be
+FALSE, i.e. **archetype_details is mandatory on every EHR_STATUS / EHR_ACCESS
+instance**. Plus `locatable.adoc` archetype_node_id Meaning: "At an archetype
+root point, the value of this attribute is always the stringified form of the
+`_archetype_id_` found in the `_archetype_details_` object" → node id must equal
+`archetype_details.archetype_id.value`.
+
+`app/ehrbase/src/service/ehr/validation.rs::validate_root_locatable` (PR #431 /
+issue #423) enforces exactly this and 422s — **spec-correct, not an app defect**.
+
+**How to apply:** any `expected: created` red row on an EHR_STATUS/EHR_ACCESS
+payload is a CATALOGUE defect (the payload is RM-invalid). PR #431 patched the
+JSON fixtures but missed two generator/inline sites — see
+[[cnf-red-2026-07-27-ehr-status-payloads]]. Self-check available inside the
+catalogue: `cnf.ehr_status.invalid.missing-archetype-details` +
+`I_EHR_SERVICE.create_ehr-invalid_status` already pin the 422 as the CORRECT
+outcome for the very same shape, so any other case expecting `created` for it is
+self-contradictory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ workflow refuses a tag that has no matching section here.
 
 ### Changed
 
+- **Stored top-level objects now carry their copied `uid` at commit time**
+  (#439). The full three-part `OBJECT_VERSION_ID` is stamped into the
+  canonical body before it is decomposed, signed, and stored, so the
+  contained object served inside an ORIGINAL_VERSION envelope, the bare
+  resource reads, AQL projections, and EHR Extract exports all carry the
+  identical uid value (ITS-REST overview *Resources* §Identifier types).
+  Previously the uid was injected only on some read paths; clients now see
+  one consistent shape everywhere. Imported (EHR Extract) content is
+  exempt — its bodies are preserved verbatim.
 - **`EHR.ehr_status` references the version container by its
   `HIER_OBJECT_ID`** (#426). The served EHR body's `ehr_status` OBJECT_REF
   (typed `VERSIONED_EHR_STATUS` per the RM invariant) previously carried an

--- a/app/ehrbase/src/versioning/change.rs
+++ b/app/ehrbase/src/versioning/change.rs
@@ -407,6 +407,26 @@ struct ResolvedWrite {
 /// modify/delete; [`ServiceError::Unprocessable`] for an out-of-group or
 /// illegal lifecycle transition; [`ServiceError::Internal`] on a multimedia
 /// offload failure; plus the storage/signing errors of [`commit_resolved`].
+/// Stamp the version's own `OBJECT_VERSION_ID` into the canonical's root
+/// `uid` BEFORE decompose/sign, so the stored, signed, and served bytes all
+/// carry it — the copied-uid recommendation for top-level types (RM common
+/// `master03-archetyped_package.adoc` §Unique Node Identification; ITS-REST
+/// `Resources.md` §Identifier types: the enclosing VERSION's uid "should be
+/// copied"; the full three-part form is this server's fixed handling,
+/// register AMB-65). A client-supplied `uid` is overwritten — the version
+/// identity is server-assigned, and the previous behaviour (store verbatim,
+/// overwrite at bare read) served two shapes for one object. The EHR Extract
+/// import path does NOT run through here (foreign versions keep their
+/// carried bytes verbatim).
+fn stamp_version_uid(canonical: &mut Value, version_uid: &str) {
+    if let Value::Object(map) = canonical {
+        map.insert(
+            "uid".to_owned(),
+            serde_json::json!({ "_type": "OBJECT_VERSION_ID", "value": version_uid }),
+        );
+    }
+}
+
 #[allow(clippy::too_many_lines)] // the three change arms building the resolved write
 #[allow(clippy::too_many_arguments)] // the commit scope; grouping is queued for the polish wave
 async fn apply_change(
@@ -439,6 +459,11 @@ async fn apply_change(
             let lifecycle = resolve_lifecycle(lifecycle_state)?;
             // a first version can only be `complete`/`incomplete`.
             validate_transition(None, &lifecycle)?;
+            let vo_id = VoId::new();
+            stamp_version_uid(
+                &mut canonical,
+                &object_version_id(vo_id, &ctx.system_id, TreeId::trunk(1)),
+            );
             let rows = decompose(canonical)?;
             let time_committed = match known_now {
                 Some(ts) => ts,
@@ -446,7 +471,7 @@ async fn apply_change(
             };
             ResolvedWrite {
                 kind,
-                vo_id: VoId::new(),
+                vo_id,
                 ehr_id,
                 ordinal: 1,
                 tree: TreeId::trunk(1),
@@ -480,11 +505,15 @@ async fn apply_change(
                     .map_err(|e| ServiceError::Internal(e.to_string()))?;
             }
             let lifecycle = resolve_lifecycle(lifecycle_state)?;
-            let rows = decompose(canonical)?;
             let next = next_version(tx, ehr_id, vo_id, kind, expected, &ctx.system_id).await?;
             // the transition from the preceding version's state must be
             // legal (master06 §Version Lifecycle state machine).
             validate_transition(Some(&next.preceding_lifecycle), &lifecycle)?;
+            stamp_version_uid(
+                &mut canonical,
+                &object_version_id(vo_id, &ctx.system_id, next.tree),
+            );
+            let rows = decompose(canonical)?;
             ResolvedWrite {
                 kind,
                 vo_id,

--- a/app/ehrbase/tests/service_aql.rs
+++ b/app/ehrbase/tests/service_aql.rs
@@ -437,10 +437,10 @@ async fn aql_acceptance_set() {
         )
         .await
         .expect("get_composition_latest");
-    // The query reassembles the stored canonical JSON (no injected uid); compare
-    // against the fetched body with its service-injected uid removed.
-    let mut expected = fetched.clone();
-    expected.as_object_mut().unwrap().remove("uid");
+    // The stored canonical carries the version uid since commit-time stamping
+    // (#439), so the AQL whole-object cell and the read surface serve ONE
+    // shape — compared verbatim.
+    let expected = fetched.clone();
     assert_eq!(
         queried, &expected,
         "whole-object reassembly equals composition_get"
@@ -473,16 +473,15 @@ async fn whole_object_projection_batches_over_a_multi_row_page() {
         let name = format!("comp-{i}");
         let ovid = create_comp(&svc, &ehr_id, &name, f64::from(i) + 10.0).await;
         let vo_id = ovid.split("::").next().unwrap();
-        let mut body = svc
+        let body = svc
             .get_composition_latest(
                 ehr_id.parse().expect("ehr uuid"),
                 vo_id.parse().expect("vo uuid"),
             )
             .await
             .expect("get_composition_latest");
-        // The AQL projection reassembles the stored canonical JSON (no injected
-        // uid); drop the service-injected uid for the comparison.
-        body.as_object_mut().unwrap().remove("uid");
+        // One shape since commit-time uid stamping (#439): the AQL cell and
+        // the read surface both carry the version uid — compared verbatim.
         expected.insert(name, body);
     }
 

--- a/app/ehrbase/tests/service_extract.rs
+++ b/app/ehrbase/tests/service_extract.rs
@@ -159,9 +159,9 @@ async fn export_ehrs_carries_every_versioned_object_latest_only() {
     assert_eq!(versions[0]["_type"], json!("ORIGINAL_VERSION"));
 
     // Canonical-JSON faithfulness: the exported version data is byte-equal to
-    // the read surface's current EHR_STATUS (modulo the read-decorated uid).
-    let mut current = svc.get_ehr_status_at_time(ehr, None).await.expect("read");
-    current.as_object_mut().unwrap().remove("uid");
+    // the read surface's current EHR_STATUS — one shape since commit-time uid
+    // stamping (#439).
+    let current = svc.get_ehr_status_at_time(ehr, None).await.expect("read");
     assert_eq!(
         versions[0]["data"], current,
         "exported EHR_STATUS data must match the stored canonical content"

--- a/docs/conformance/upstream-reports.md
+++ b/docs/conformance/upstream-reports.md
@@ -537,3 +537,20 @@ CNF↔SM divergences, and benign released-documented behaviours carry no
   not pre-populate the subject, the server defaulting it to an anonymous
   `PARTY_SELF` when absent) so it is satisfiable and consistent with the RM
   cardinality and the REST surface.
+
+### UPR-29 — no released text states whether a served top-level object carries a populated `uid` (non-COMPOSITION scope)
+
+- **Components:** RM common (locatable, master03), ITS-REST (Resources.md §Identifier types)
+- **Register:** AMB-67 (report_only)
+- **Facts:** `LOCATABLE.uid` is 0..1; master03 §Unique Node Identification
+  recommends the top-level copy yet states the field "will usually be empty
+  in most EHR data in most openEHR EHR systems"; the ITS-REST note is scoped
+  to "COMPOSITION objects" and is "strongly recommended"/"should". No
+  released sentence assigns presence (or absence) for the other top-level
+  types (EHR_STATUS, EHR_ACCESS, FOLDER, PARTY) on the wire.
+- **Problem:** clients cannot rely on the served `uid` of a contained
+  non-COMPOSITION object, and conformance instruments cannot test it — the
+  behaviour is untestable recommendation territory outside COMPOSITION.
+- **Ask:** extend the Resources.md §Identifier types note (or the RM
+  master03 section) to state the wire expectation for ALL top-level types,
+  with an RFC keyword.

--- a/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
+++ b/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
@@ -117,13 +117,13 @@ cnf.flat.vitals.minimal_ctx:
     current_state_code:
       select: "$['minimal/minimal:0/ism_transition/current_state|code']"
 cnf.ehr_status.provided:
-  generated_by: { recipe: ehr_status, digest: "sha256:530d2e5d5a311056417a4189bdc1418a00d58bcb43bfd280268dc31efed9bd60" }
+  generated_by: { recipe: ehr_status, digest: "sha256:d14aa17d5ce2d2694804be09218d45d9d84d3f939fca9e0024b7c463dc8ebb2f" }
   format: canonical-json
   rm_versions: [">=1.0.2"]
   validity: { verdict: valid }
   provenance: "generated set: EHR_STATUS instances synthesized per matrix row (recipe contract corpus/recipes/ehr_status.md)"
   recipes:
-    ehr_status: { digest: "sha256:530d2e5d5a311056417a4189bdc1418a00d58bcb43bfd280268dc31efed9bd60" }
+    ehr_status: { digest: "sha256:d14aa17d5ce2d2694804be09218d45d9d84d3f939fca9e0024b7c463dc8ebb2f" }
 cnf.set.bp-10:
   generated_by: { recipe: bp_series, digest: "sha256:344c64e658b287b6603f5575dd85d652c935a4fcb64d915413b683a87fb4f4e1" }
   format: canonical-json

--- a/tools/cnf-runner/artifacts/corpus/recipes/ehr_status.md
+++ b/tools/cnf-runner/artifacts/corpus/recipes/ehr_status.md
@@ -6,7 +6,12 @@ match this spec; its digest pins the recipe version).
 - Input: one `create_ehr-main` matrix row binding `ehr_status`,
   `is_queryable`, `is_modifiable`, `subject`, `other_details`, `ehr_id`.
 - `ehr_status = absent` => emit no EHR_STATUS at all (the class-1.a rows).
-- Otherwise emit a canonical-JSON `EHR_STATUS` (RM ehr, EHR_STATUS):
+- Otherwise emit a canonical-JSON `EHR_STATUS` (RM ehr, EHR_STATUS),
+  always carrying `archetype_details` (`ARCHETYPED` with
+  `archetype_id = openEHR-EHR-EHR_STATUS.generic.v1`, `rm_version`
+  `1.2.0`) — an EHR_STATUS is unconditionally an archetype root
+  (RM ehr `ehr_status.adoc` `Is_archetype_root`) and a root without
+  ARCHETYPED violates RM common `locatable.adoc` `Archetyped_valid`:
   `is_queryable`/`is_modifiable` verbatim from the row;
   `subject = provided` => a `PARTY_SELF` carrying an external ref with a
   deterministic namespace `cnf` and id `subject-<case id>-<row index>` —

--- a/tools/cnf-runner/artifacts/registers/ambiguities.yaml
+++ b/tools/cnf-runner/artifacts/registers/ambiguities.yaml
@@ -953,7 +953,7 @@ AMB-65:
     `ORIGINAL_VERSION`), i.e. the leading Uid, which is normally a Guid …
     the Guid `87284370-2D4B-4e3d-A3F3-F303D2F4F34B` would be copied to the
     contained `COMPOSITION.uid` field") and RM ehr EHR_STATUS class §Description
-    (the same object_id()-only rule restated for EHR_STATUS) vs ITS-REST
+    (restates the object_id()-only WORDING for EHR_STATUS while its own worked example copies the FULL three-part value — the sentence contradicts its example, siding with ITS-REST) vs ITS-REST
     specifications/docs/overview/Resources.md §Identifier types ("Since RM
     Release 1.0.4 it is strongly recommended that the inherited `uid` attribute
     in COMPOSITION objects be populated using the `uid` copied from the
@@ -980,6 +980,34 @@ AMB-65:
     future release aligns the two sentences the other way.
   disposition: fixed_handling
   upstream_ref: "UPR-27"
+AMB-67:
+  ambiguity: >-
+    Whether the CONTAINED top-level object served inside an ORIGINAL_VERSION
+    envelope must carry a populated `uid` at all is required by NO released
+    sentence: RM common locatable.adoc §Attributes types `uid` as
+    UID_BASED_ID 0..1; RM common master03-archetyped_package.adoc §Unique
+    Node Identification calls the copy "recommended" and adds "The `uid`
+    attribute will usually be empty in most EHR data in most openEHR EHR
+    systems"; the ITS-REST Resources.md §Identifier types note is
+    COMPOSITION-scoped and "strongly recommended"/"should". A server that
+    serves the contained object uid-less breaches nothing released.
+  source: >-
+    RM common locatable.adoc §Attributes (uid 0..1); RM common
+    master03-archetyped_package.adoc §Unique Node Identification
+    (recommended; "will usually be empty"); ITS-REST
+    specifications/docs/overview/Resources.md §Identifier types (COMPOSITION
+    scope, "strongly recommended … should be copied") — all
+    recommendation-strength, confirmed first-hand.
+  handling: >-
+    Report-only: the contained-uid-form case exercises the behaviour and
+    records the outcome without gating any tier — presence is a
+    recommendation this server ADOPTS (commit-time stamping, #439) but no
+    conformant server can be failed for omitting. The FORM when present
+    stays the gating AMB-65 fixed handling. Reported upstream (UPR-29): the
+    recommendation's scope and strength deserve an explicit wire-level
+    statement for the non-COMPOSITION top-level types.
+  disposition: report_only
+  upstream_ref: "UPR-29"
 AMB-66:
   ambiguity: >-
     The SM precondition `Pre_no_subject`: `an_ehr_status.subject = Void`, on

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-ehr_status_valid_combinations.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-ehr_status_valid_combinations.yaml
@@ -64,6 +64,15 @@ flow:
         - data:
             _type: EHR_STATUS
             archetype_node_id: "openEHR-EHR-EHR_STATUS.generic.v1"
+            # An EHR_STATUS is unconditionally an archetype root (RM ehr
+            # ehr_status.adoc Is_archetype_root), and a root without
+            # ARCHETYPED violates RM common locatable.adoc Archetyped_valid
+            # (is_archetype_root xor archetype_details = Void) — so the block
+            # is mandatory on every valid payload.
+            archetype_details:
+              _type: ARCHETYPED
+              archetype_id: { _type: ARCHETYPE_ID, value: "openEHR-EHR-EHR_STATUS.generic.v1" }
+              rm_version: "1.2.0"
             name: { value: "EHR Status" }
             subject:
               _type: PARTY_SELF

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_versioned_ehr_status-contained_uid_form.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_versioned_ehr_status-contained_uid_form.yaml
@@ -29,11 +29,17 @@
 # assertions then compare the served envelope and its contained object against
 # the same addressed value.
 #
-# Kept at OPTIONS: the adjudication picks one of two released recommendations,
-# so a server following the RM's object_id()-only wording is not in breach of
-# the RM. The ORIGINAL_VERSION's OWN uid is not part of that dispute — RM
-# common master06 §change_control fixes it as the three-part OBJECT_VERSION_ID
-# outright — but it shares the case so the contrast is visible in one row.
+# Tier + gating: the capability (EhrStatus) is Core-tier, so profiles is
+# CORE — but the case is NON-GATING via the report-only register entry
+# AMB-67 below: no released sentence REQUIRES the contained uid populated
+# at all (LOCATABLE.uid is 0..1; master03 calls the copy "recommended" and
+# says the field "will usually be empty"; the ITS-REST note is
+# "strongly recommended"/"should"), so a server omitting it breaches
+# nothing. The FORM when present is the AMB-65 fixed handling; this server
+# stamps the full value into the stored canonical at commit (#439). The
+# ORIGINAL_VERSION's OWN uid is not part of any dispute — RM common
+# master06 §change_control fixes it as the three-part OBJECT_VERSION_ID
+# outright — and it shares the case so the contrast is visible in one row.
 id: I_EHR_STATUS.get_versioned_ehr_status-contained_uid_form
 kind: functional
 component: EHR
@@ -41,7 +47,7 @@ sm_operation: I_EHR_STATUS.get_versioned_ehr_status
 capabilities: [EhrStatus]
 exercises: [Versioning]
 profiles: [CORE]                         # EhrStatus is Core-tier; the WIRE form is assigned by the ITS-REST docs text's own worked example (Resources.md §Resource identification: the full three-part value "should be copied") — AMB-65/UPR-27 carries the RM-side conflict upstream
-ambiguities: [AMB-65]
+ambiguities: [AMB-65, AMB-67]
 test_purpose: >-
   An EHR_STATUS ORIGINAL_VERSION read at an addressed version carries that
   version identity twice — as the VERSION's own uid, and copied into the

--- a/tools/cnf-runner/src/exec/recipes.rs
+++ b/tools/cnf-runner/src/exec/recipes.rs
@@ -89,6 +89,18 @@ pub fn ehr_status(
         "_type": "EHR_STATUS",
         "name": { "_type": "DV_TEXT", "value": "ehr status" },
         "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
+        // An EHR_STATUS is unconditionally an archetype root (RM ehr
+        // ehr_status.adoc Is_archetype_root); a root without ARCHETYPED
+        // violates RM common locatable.adoc Archetyped_valid, so every
+        // valid emitted payload carries the block.
+        "archetype_details": {
+            "_type": "ARCHETYPED",
+            "archetype_id": {
+                "_type": "ARCHETYPE_ID",
+                "value": "openEHR-EHR-EHR_STATUS.generic.v1"
+            },
+            "rm_version": "1.2.0"
+        },
         "subject": subject,
         "is_queryable": flag("is_queryable")?,
         "is_modifiable": flag("is_modifiable")?


### PR DESCRIPTION
Resolves the three red rows from the group-3 (#379) closing CNF run (400 passed / 3 failed), each triage-attributed per the attribution law before any change.

## Finding 1 — catalogue: contribution case payload violated Is_archetype_root
The inline EHR_STATUS payload in `I_EHR_CONTRIBUTION.commit_contribution-ehr_status_valid_combinations` omitted `archetype_details`. RM common locatable.adoc makes top-level objects archetype roots unconditionally, and Archetyped_valid ties `is_archetype_root` to `archetype_details /= Void` — the SUT's 422 was spec-correct. The case payload now carries the ARCHETYPED block.

## Finding 2 — catalogue: the `ehr_status` corpus recipe had the same defect
The recipe contract (`corpus/recipes/ehr_status.md`) and its implementation (`exec/recipes.rs`) now emit `archetype_details`; the MANIFEST digest is re-stamped (recipe tests 10/10 green).

## Finding 3 — app improvement + catalogue honesty (contained uid)
- **Closes #439**: `stamp_version_uid` in `app/ehrbase/src/versioning/change.rs` stamps the full three-part `OBJECT_VERSION_ID` into the canonical **before** decompose/sign, in both the Create and Modify arms — stored, signed, and served bytes now carry one uid shape across envelope reads, bare reads, AQL cells, and extracts (ITS-REST overview Resources.md §Identifier types; RM common master03 §Unique Node Identification). The EHR Extract import path stays verbatim-preserving. Test comparison strips in `service_aql.rs`/`service_extract.rs` removed — both sides now compare byte-equal (strips removed, nothing weakened).
- **Catalogue**: the `contained_uid_form` case header's stale OPTIONS-tier remark is gone (the capability is Core-tier); the presence of the contained uid is recommendation-only (LOCATABLE.uid is 0..1; master03: "will usually be empty"; the ITS-REST note is COMPOSITION-scoped, "strongly recommended"), so the case is carried **non-gating** via the new `report_only` register entry **AMB-67** with upstream report **UPR-29**. The FORM when present remains the gating AMB-65 fixed handling.
- **AMB-65 source corrected**: the RM EHR_STATUS restatement's own worked example copies the FULL three-part value — the sentence contradicts its example; the register no longer claims the RM restates the object_id()-only rule cleanly.

## Gates
- `cargo clippy -p ehrbase -p cnf-runner --all-targets --all-features` — 0 warnings
- `cargo nextest run -p ehrbase -p ehrbase-rest -p cnf-runner` — 1319 passed
- `cnf-runner validate --specs` — 0 findings
- Red-run conformance artifacts NOT committed (baseline ratchets only on a green run, which follows this merge)

Closes #439