### PR TITLE
chore(cnf): ratchet the conformance baseline — group-3 closing zero-drift run

### DIFF
--- a/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
@@ -7,12 +7,12 @@ Runner: cnf-runner 3.11.0 · verification pack: passed
 
 | Status | Count |
 | --- | --- |
-| passed | 398 |
+| passed | 403 |
 | failed | 0 |
 | errored | 0 |
 | skipped | 0 |
 | not_applicable | 69 |
-| total | 467 |
+| total | 472 |
 
 ## By chapter
 
@@ -30,8 +30,8 @@ Runner: cnf-runner 3.11.0 · verification pack: passed
 | I_EHR_CONTRIBUTION | 36 | 0 | 0 | 0 | 5 |
 | I_EHR_DIRECTORY | 34 | 0 | 0 | 0 | 3 |
 | I_EHR_EXTRACT_SERVICE | 0 | 0 | 0 | 0 | 10 |
-| I_EHR_SERVICE | 12 | 0 | 0 | 0 | 0 |
-| I_EHR_STATUS | 10 | 0 | 0 | 0 | 0 |
+| I_EHR_SERVICE | 16 | 0 | 0 | 0 | 0 |
+| I_EHR_STATUS | 11 | 0 | 0 | 0 | 0 |
 | I_QUERY_SERVICE | 18 | 0 | 0 | 0 | 0 |
 | I_TDD_SERVICE | 0 | 0 | 0 | 0 | 4 |
 | SEC | 6 | 0 | 0 | 0 | 0 |
@@ -73,7 +73,7 @@ Percentiles re-derive from the embedded HDR V2 histograms; the class verdict is 
 
 ## Honesty
 
-Coverage: 398 of 467 selected cases driven.
+Coverage: 403 of 472 selected cases driven.
 
 Not-executed verdicts (each cited):
 

--- a/docs/conformance/ehrbase-rs/badge.json
+++ b/docs/conformance/ehrbase-rs/badge.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "openEHR conformance",
-  "message": "CORE+STANDARD PASS \u00b7 398/398 cases",
+  "message": "CORE+STANDARD PASS \u00b7 403/403 cases",
   "color": "brightgreen"
 }

--- a/docs/conformance/ehrbase-rs/results.json
+++ b/docs/conformance/ehrbase-rs/results.json
@@ -2117,16 +2117,28 @@
       "rows_total": 1
     },
     {
+      "case": "I_EHR_SERVICE.create_ehr-committal_headers",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_SERVICE.create_ehr-invalid_status",
       "status": "passed",
-      "rows_driven": 4,
-      "rows_total": 4
+      "rows_driven": 5,
+      "rows_total": 5
     },
     {
       "case": "I_EHR_SERVICE.create_ehr-main",
       "status": "passed",
       "rows_driven": 18,
       "rows_total": 18
+    },
+    {
+      "case": "I_EHR_SERVICE.create_ehr-return_identifier",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
     },
     {
       "case": "I_EHR_SERVICE.create_ehr-same_ehr_twice",
@@ -2136,6 +2148,18 @@
     },
     {
       "case": "I_EHR_SERVICE.create_ehr-two_ehrs_same_patient",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_SERVICE.create_ehr-with_ehr_id",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_SERVICE.create_ehr-with_ehr_id_subject_taken",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -2220,6 +2244,12 @@
     },
     {
       "case": "I_EHR_STATUS.get_ehr_status-get_by_ehr_id",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_STATUS.get_versioned_ehr_status-contained_uid_form",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1

--- a/docs/conformance/ehrbase-rs/verdicts.json
+++ b/docs/conformance/ehrbase-rs/verdicts.json
@@ -183,7 +183,7 @@
     }
   ],
   "coverage": {
-    "selected": 467,
-    "driven": 398
+    "selected": 472,
+    "driven": 403
   }
 }

--- a/website/book/src/conformance-assets/conformance-chapter-bars.svg
+++ b/website/book/src/conformance-assets/conformance-chapter-bars.svg
@@ -44,55 +44,55 @@ text { fill: #c3c2b7; }
 <text x="24" y="28" class="title">Schedule outcomes by chapter — ehrbase-rs 3.11.0</text>
 
 <rect x="24" y="38" width="14" height="14" rx="3" class="bar-passed"/><text x="42" y="49" class="muted">passed</text><rect x="103.2" y="38" width="14" height="14" rx="3" class="bar-failed"/><text x="121.2" y="49" class="muted">failed</text><rect x="182.4" y="38" width="14" height="14" rx="3" class="bar-errored"/><text x="200.4" y="49" class="muted">errored</text><rect x="268.8" y="38" width="14" height="14" rx="3" class="bar-na"/><text x="286.8" y="49" class="muted">N/A (cited)</text><text x="166" y="81" text-anchor="end">EHR</text>
-<rect x="174" y="64" width="603.943661971831" height="26" class="bar-passed"/>
+<rect x="174" y="64" width="605.170068027211" height="26" class="bar-passed"/>
 
-<text x="475.9718309859155" y="81" class="seg-label" text-anchor="middle">134</text><rect x="777.943661971831" y="64" width="36.056338028169016" height="26" class="bar-na"/>
+<text x="476.5850340136055" y="81" class="seg-label" text-anchor="middle">139</text><rect x="779.170068027211" y="64" width="34.82993197278912" height="26" class="bar-na"/>
 
-<text x="795.9718309859155" y="81" class="seg-label-dim" text-anchor="middle">8</text><text x="822" y="81" class="muted">142</text>
+<text x="796.5850340136055" y="81" class="seg-label-dim" text-anchor="middle">8</text><text x="822.0000000000001" y="81" class="muted">147</text>
 <text x="166" y="115" text-anchor="end">Definitions</text>
-<rect x="174" y="98" width="162.25352112676057" height="26" class="bar-passed"/>
+<rect x="174" y="98" width="156.73469387755102" height="26" class="bar-passed"/>
 
-<text x="255.1267605633803" y="115" class="seg-label" text-anchor="middle">36</text><rect x="336.2535211267606" y="98" width="72.11267605633803" height="26" class="bar-na"/>
+<text x="252.3673469387755" y="115" class="seg-label" text-anchor="middle">36</text><rect x="330.734693877551" y="98" width="69.65986394557824" height="26" class="bar-na"/>
 
-<text x="372.3098591549296" y="115" class="seg-label-dim" text-anchor="middle">16</text><text x="416.3661971830986" y="115" class="muted">52</text>
+<text x="365.5646258503401" y="115" class="seg-label-dim" text-anchor="middle">16</text><text x="408.3945578231293" y="115" class="muted">52</text>
 <text x="166" y="149" text-anchor="end">Query</text>
-<rect x="174" y="132" width="81.12676056338029" height="26" class="bar-passed"/>
+<rect x="174" y="132" width="78.36734693877551" height="26" class="bar-passed"/>
 
-<text x="214.56338028169014" y="149" class="seg-label" text-anchor="middle">18</text><text x="263.1267605633803" y="149" class="muted">18</text>
+<text x="213.18367346938777" y="149" class="seg-label" text-anchor="middle">18</text><text x="260.36734693877554" y="149" class="muted">18</text>
 <text x="166" y="183" text-anchor="end">Demographic</text>
-<rect x="174" y="166" width="72.11267605633803" height="26" class="bar-passed"/>
+<rect x="174" y="166" width="69.65986394557824" height="26" class="bar-passed"/>
 
-<text x="210.05633802816902" y="183" class="seg-label" text-anchor="middle">16</text><rect x="246.11267605633805" y="166" width="54.08450704225352" height="26" class="bar-na"/>
+<text x="208.82993197278913" y="183" class="seg-label" text-anchor="middle">16</text><rect x="243.65986394557825" y="166" width="52.244897959183675" height="26" class="bar-na"/>
 
-<text x="273.1549295774648" y="183" class="seg-label-dim" text-anchor="middle">12</text><text x="308.19718309859155" y="183" class="muted">28</text>
+<text x="269.7823129251701" y="183" class="seg-label-dim" text-anchor="middle">12</text><text x="303.9047619047619" y="183" class="muted">28</text>
 <text x="166" y="217" text-anchor="end">Admin</text>
-<rect x="174" y="200" width="9.014084507042254" height="26" class="bar-passed"/>
+<rect x="174" y="200" width="8.70748299319728" height="26" class="bar-passed"/>
 
-<rect x="183.01408450704224" y="200" width="72.11267605633803" height="26" class="bar-na"/>
+<rect x="182.7074829931973" y="200" width="69.65986394557824" height="26" class="bar-na"/>
 
-<text x="219.07042253521126" y="217" class="seg-label-dim" text-anchor="middle">16</text><text x="263.1267605633803" y="217" class="muted">18</text>
+<text x="217.53741496598641" y="217" class="seg-label-dim" text-anchor="middle">16</text><text x="260.36734693877554" y="217" class="muted">18</text>
 <text x="166" y="251" text-anchor="end">Messaging</text>
-<rect x="174" y="234" width="63.098591549295776" height="26" class="bar-na"/>
+<rect x="174" y="234" width="60.952380952380956" height="26" class="bar-na"/>
 
-<text x="205.54929577464787" y="251" class="seg-label-dim" text-anchor="middle">14</text><text x="245.09859154929578" y="251" class="muted">14</text>
+<text x="204.47619047619048" y="251" class="seg-label-dim" text-anchor="middle">14</text><text x="242.95238095238096" y="251" class="muted">14</text>
 <text x="166" y="285" text-anchor="end">Content validation</text>
-<rect x="174" y="268" width="554.3661971830986" height="26" class="bar-passed"/>
+<rect x="174" y="268" width="535.5102040816327" height="26" class="bar-passed"/>
 
-<text x="451.1830985915493" y="285" class="seg-label" text-anchor="middle">123</text><text x="736.3661971830986" y="285" class="muted">123</text>
+<text x="441.7551020408163" y="285" class="seg-label" text-anchor="middle">123</text><text x="717.5102040816327" y="285" class="muted">123</text>
 <text x="166" y="319" text-anchor="end">Simplified formats</text>
-<rect x="174" y="302" width="256.90140845070425" height="26" class="bar-passed"/>
+<rect x="174" y="302" width="248.16326530612247" height="26" class="bar-passed"/>
 
-<text x="302.4507042253521" y="319" class="seg-label" text-anchor="middle">57</text><rect x="430.90140845070425" y="302" width="4.507042253521127" height="26" class="bar-na"/>
+<text x="298.0816326530612" y="319" class="seg-label" text-anchor="middle">57</text><rect x="422.16326530612247" y="302" width="4.35374149659864" height="26" class="bar-na"/>
 
-<text x="443.4084507042254" y="319" class="muted">58</text>
+<text x="434.5170068027211" y="319" class="muted">58</text>
 <text x="166" y="353" text-anchor="end">Security &amp; privacy</text>
-<rect x="174" y="336" width="27.04225352112676" height="26" class="bar-passed"/>
+<rect x="174" y="336" width="26.122448979591837" height="26" class="bar-passed"/>
 
-<text x="187.5211267605634" y="353" class="seg-label" text-anchor="middle">6</text><text x="209.04225352112675" y="353" class="muted">6</text>
+<text x="187.0612244897959" y="353" class="seg-label" text-anchor="middle">6</text><text x="208.12244897959184" y="353" class="muted">6</text>
 <text x="166" y="387" text-anchor="end">Signing</text>
-<rect x="174" y="370" width="27.04225352112676" height="26" class="bar-passed"/>
+<rect x="174" y="370" width="26.122448979591837" height="26" class="bar-passed"/>
 
-<text x="187.5211267605634" y="387" class="seg-label" text-anchor="middle">6</text><rect x="201.04225352112675" y="370" width="9.014084507042254" height="26" class="bar-na"/>
+<text x="187.0612244897959" y="387" class="seg-label" text-anchor="middle">6</text><rect x="200.12244897959184" y="370" width="8.70748299319728" height="26" class="bar-na"/>
 
-<text x="218.056338028169" y="387" class="muted">8</text>
+<text x="216.82993197278913" y="387" class="muted">8</text>
 </svg>


### PR DESCRIPTION
Group-3 (#379, EHR resource operations) close-out: the full CNF pipeline on a freshly composed SUT after the complete group-3 fix wave (PRs #429, #431–#437, #440).

## Run
- 472 case-records: **403 passed / 0 failed / 0 errored / 69 registered N/A**
- Verdicts: **CORE 10/10 + STANDARD 5/5 capabilities PASS**, 0 review findings
- Baseline ratchets upward only: +3 vs the previous 400-passed baseline (the three triage-resolved rows from PR #440), coverage unchanged-or-up everywhere.
- Conformance visuals (`conformance-chapter-bars.svg`, `conformance-heat-grid.svg`) regenerated from the committed artifacts via `scripts/render-conformance-assets.sh`.

## Group-3 record
Audit findings, fixes, and register entries are on #379 and its fix issues (#422–#428, #430, #439); the wave landed via PRs #429, #431–#437, #440. Ambiguity register grew AMB-65…AMB-67 with upstream reports UPR-27…UPR-29.

Closes #379