### PR TITLE
chore(cnf): ratchet the conformance baseline — group-5 closing zero-drift run

### DIFF
--- a/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
@@ -7,12 +7,12 @@ Runner: cnf-runner 3.11.0 · verification pack: passed
 
 | Status | Count |
 | --- | --- |
-| passed | 421 |
+| passed | 443 |
 | failed | 0 |
 | errored | 0 |
 | skipped | 0 |
 | not_applicable | 69 |
-| total | 490 |
+| total | 512 |
 
 ## By chapter
 
@@ -26,7 +26,7 @@ Runner: cnf-runner 3.11.0 · verification pack: passed
 | I_DEFINITION_ADL2 | 16 | 0 | 0 | 0 | 8 |
 | I_DEFINITION_QUERY | 10 | 0 | 0 | 0 | 0 |
 | I_DEMOGRAPHIC_SERVICE | 16 | 0 | 0 | 0 | 12 |
-| I_EHR_COMPOSITION | 42 | 0 | 0 | 0 | 0 |
+| I_EHR_COMPOSITION | 64 | 0 | 0 | 0 | 0 |
 | I_EHR_CONTRIBUTION | 36 | 0 | 0 | 0 | 5 |
 | I_EHR_DIRECTORY | 34 | 0 | 0 | 0 | 3 |
 | I_EHR_EXTRACT_SERVICE | 0 | 0 | 0 | 0 | 10 |
@@ -73,7 +73,7 @@ Percentiles re-derive from the embedded HDR V2 histograms; the class verdict is 
 
 ## Honesty
 
-Coverage: 421 of 490 selected cases driven.
+Coverage: 443 of 512 selected cases driven.
 
 Not-executed verdicts (each cited):
 

--- a/docs/conformance/ehrbase-rs/badge.json
+++ b/docs/conformance/ehrbase-rs/badge.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "openEHR conformance",
-  "message": "CORE+STANDARD PASS \u00b7 421/421 cases",
+  "message": "CORE+STANDARD PASS \u00b7 443/443 cases",
   "color": "brightgreen"
 }

--- a/docs/conformance/ehrbase-rs/results.json
+++ b/docs/conformance/ehrbase-rs/results.json
@@ -238,7 +238,19 @@
       "rows_total": 1
     },
     {
+      "case": "I_EHR_COMPOSITION.delete_composition-already_deleted",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_COMPOSITION.delete_composition-audit_headers",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.delete_composition-etag_names_new_version",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -251,6 +263,12 @@
     },
     {
       "case": "I_EHR_COMPOSITION.delete_composition-non_existent",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.delete_composition-not_latest_version",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -274,6 +292,30 @@
       "rows_total": 1
     },
     {
+      "case": "I_EHR_COMPOSITION.get_composition_at_time-before_first_version",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.get_composition_at_time-deleted_at_time",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.get_composition_at_time-future",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.get_composition_at_time-malformed",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_COMPOSITION.get_composition_at_time-no_time_arg",
       "status": "passed",
       "rows_driven": 1,
@@ -292,6 +334,12 @@
       "rows_total": 1
     },
     {
+      "case": "I_EHR_COMPOSITION.get_composition_at_version-deleted_version",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_COMPOSITION.get_composition_latest-bad_composition",
       "status": "passed",
       "rows_driven": 1,
@@ -299,6 +347,12 @@
     },
     {
       "case": "I_EHR_COMPOSITION.get_composition_latest-bad_ehr",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.get_composition_latest-deleted_head",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -334,13 +388,67 @@
       "rows_total": 1
     },
     {
+      "case": "I_EHR_COMPOSITION.get_versioned_composition-at_time_before_first_version",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.get_versioned_composition-at_time_future",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.get_versioned_composition-at_time_malformed",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.get_versioned_composition-at_time_omitted",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_COMPOSITION.get_versioned_composition-bad_ehr",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
     },
     {
+      "case": "I_EHR_COMPOSITION.get_versioned_composition-container_shape",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.get_versioned_composition-deleted_version_envelope",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.get_versioned_composition-malformed_uid",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_COMPOSITION.get_versioned_composition-non_existent",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.get_versioned_composition-version_of_other_container",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.get_versioned_composition-version_unknown",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -394,7 +502,19 @@
       "rows_total": 1
     },
     {
+      "case": "I_EHR_COMPOSITION.update_composition-body_uid_mismatch",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_COMPOSITION.update_composition-event",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.update_composition-missing_if_match",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -407,6 +527,18 @@
     },
     {
       "case": "I_EHR_COMPOSITION.update_composition-persistent",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.update_composition-return_identifier",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.update_composition-stale_if_match",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1

--- a/docs/conformance/ehrbase-rs/verdicts.json
+++ b/docs/conformance/ehrbase-rs/verdicts.json
@@ -183,7 +183,7 @@
     }
   ],
   "coverage": {
-    "selected": 490,
-    "driven": 421
+    "selected": 512,
+    "driven": 443
   }
 }

--- a/website/book/src/conformance-assets/conformance-chapter-bars.svg
+++ b/website/book/src/conformance-assets/conformance-chapter-bars.svg
@@ -44,55 +44,55 @@ text { fill: #c3c2b7; }
 <text x="24" y="28" class="title">Schedule outcomes by chapter — ehrbase-rs 3.11.0</text>
 
 <rect x="24" y="38" width="14" height="14" rx="3" class="bar-passed"/><text x="42" y="49" class="muted">passed</text><rect x="103.2" y="38" width="14" height="14" rx="3" class="bar-failed"/><text x="121.2" y="49" class="muted">failed</text><rect x="182.4" y="38" width="14" height="14" rx="3" class="bar-errored"/><text x="200.4" y="49" class="muted">errored</text><rect x="268.8" y="38" width="14" height="14" rx="3" class="bar-na"/><text x="286.8" y="49" class="muted">N/A (cited)</text><text x="166" y="81" text-anchor="end">EHR</text>
-<rect x="174" y="64" width="608.969696969697" height="26" class="bar-passed"/>
+<rect x="174" y="64" width="612.620320855615" height="26" class="bar-passed"/>
 
-<text x="478.4848484848485" y="81" class="seg-label" text-anchor="middle">157</text><rect x="782.969696969697" y="64" width="31.03030303030303" height="26" class="bar-na"/>
+<text x="480.3101604278075" y="81" class="seg-label" text-anchor="middle">179</text><rect x="786.620320855615" y="64" width="27.379679144385026" height="26" class="bar-na"/>
 
-<text x="798.4848484848485" y="81" class="seg-label-dim" text-anchor="middle">8</text><text x="822" y="81" class="muted">165</text>
+<text x="800.3101604278075" y="81" class="seg-label-dim" text-anchor="middle">8</text><text x="822" y="81" class="muted">187</text>
 <text x="166" y="115" text-anchor="end">Definitions</text>
-<rect x="174" y="98" width="139.63636363636363" height="26" class="bar-passed"/>
+<rect x="174" y="98" width="123.20855614973262" height="26" class="bar-passed"/>
 
-<text x="243.8181818181818" y="115" class="seg-label" text-anchor="middle">36</text><rect x="313.6363636363636" y="98" width="62.06060606060606" height="26" class="bar-na"/>
+<text x="235.6042780748663" y="115" class="seg-label" text-anchor="middle">36</text><rect x="297.2085561497326" y="98" width="54.75935828877005" height="26" class="bar-na"/>
 
-<text x="344.66666666666663" y="115" class="seg-label-dim" text-anchor="middle">16</text><text x="383.6969696969697" y="115" class="muted">52</text>
+<text x="324.5882352941176" y="115" class="seg-label-dim" text-anchor="middle">16</text><text x="359.96791443850265" y="115" class="muted">52</text>
 <text x="166" y="149" text-anchor="end">Query</text>
-<rect x="174" y="132" width="69.81818181818181" height="26" class="bar-passed"/>
+<rect x="174" y="132" width="61.60427807486631" height="26" class="bar-passed"/>
 
-<text x="208.9090909090909" y="149" class="seg-label" text-anchor="middle">18</text><text x="251.8181818181818" y="149" class="muted">18</text>
+<text x="204.80213903743316" y="149" class="seg-label" text-anchor="middle">18</text><text x="243.6042780748663" y="149" class="muted">18</text>
 <text x="166" y="183" text-anchor="end">Demographic</text>
-<rect x="174" y="166" width="62.06060606060606" height="26" class="bar-passed"/>
+<rect x="174" y="166" width="54.75935828877005" height="26" class="bar-passed"/>
 
-<text x="205.03030303030303" y="183" class="seg-label" text-anchor="middle">16</text><rect x="236.06060606060606" y="166" width="46.54545454545455" height="26" class="bar-na"/>
+<text x="201.37967914438502" y="183" class="seg-label" text-anchor="middle">16</text><rect x="228.75935828877004" y="166" width="41.06951871657754" height="26" class="bar-na"/>
 
-<text x="259.3333333333333" y="183" class="seg-label-dim" text-anchor="middle">12</text><text x="290.6060606060606" y="183" class="muted">28</text>
+<text x="249.2941176470588" y="183" class="seg-label-dim" text-anchor="middle">12</text><text x="277.8288770053476" y="183" class="muted">28</text>
 <text x="166" y="217" text-anchor="end">Admin</text>
-<rect x="174" y="200" width="7.757575757575758" height="26" class="bar-passed"/>
+<rect x="174" y="200" width="6.8449197860962565" height="26" class="bar-passed"/>
 
-<rect x="181.75757575757575" y="200" width="62.06060606060606" height="26" class="bar-na"/>
+<rect x="180.84491978609626" y="200" width="54.75935828877005" height="26" class="bar-na"/>
 
-<text x="212.78787878787878" y="217" class="seg-label-dim" text-anchor="middle">16</text><text x="251.8181818181818" y="217" class="muted">18</text>
+<text x="208.22459893048128" y="217" class="seg-label-dim" text-anchor="middle">16</text><text x="243.6042780748663" y="217" class="muted">18</text>
 <text x="166" y="251" text-anchor="end">Messaging</text>
-<rect x="174" y="234" width="54.303030303030305" height="26" class="bar-na"/>
+<rect x="174" y="234" width="47.9144385026738" height="26" class="bar-na"/>
 
-<text x="201.15151515151516" y="251" class="seg-label-dim" text-anchor="middle">14</text><text x="236.3030303030303" y="251" class="muted">14</text>
+<text x="197.9572192513369" y="251" class="seg-label-dim" text-anchor="middle">14</text><text x="229.9144385026738" y="251" class="muted">14</text>
 <text x="166" y="285" text-anchor="end">Content validation</text>
-<rect x="174" y="268" width="477.0909090909091" height="26" class="bar-passed"/>
+<rect x="174" y="268" width="420.96256684491976" height="26" class="bar-passed"/>
 
-<text x="412.54545454545456" y="285" class="seg-label" text-anchor="middle">123</text><text x="659.0909090909091" y="285" class="muted">123</text>
+<text x="384.4812834224599" y="285" class="seg-label" text-anchor="middle">123</text><text x="602.9625668449198" y="285" class="muted">123</text>
 <text x="166" y="319" text-anchor="end">Simplified formats</text>
-<rect x="174" y="302" width="221.0909090909091" height="26" class="bar-passed"/>
+<rect x="174" y="302" width="195.0802139037433" height="26" class="bar-passed"/>
 
-<text x="284.54545454545456" y="319" class="seg-label" text-anchor="middle">57</text><rect x="395.0909090909091" y="302" width="3.878787878787879" height="26" class="bar-na"/>
+<text x="271.5401069518716" y="319" class="seg-label" text-anchor="middle">57</text><rect x="369.0802139037433" y="302" width="3.4224598930481283" height="26" class="bar-na"/>
 
-<text x="406.969696969697" y="319" class="muted">58</text>
+<text x="380.50267379679144" y="319" class="muted">58</text>
 <text x="166" y="353" text-anchor="end">Security &amp; privacy</text>
-<rect x="174" y="336" width="23.272727272727273" height="26" class="bar-passed"/>
+<rect x="174" y="336" width="20.53475935828877" height="26" class="bar-passed"/>
 
-<text x="185.63636363636363" y="353" class="seg-label" text-anchor="middle">6</text><text x="205.27272727272728" y="353" class="muted">6</text>
+<text x="202.53475935828877" y="353" class="muted">6</text>
 <text x="166" y="387" text-anchor="end">Signing</text>
-<rect x="174" y="370" width="23.272727272727273" height="26" class="bar-passed"/>
+<rect x="174" y="370" width="20.53475935828877" height="26" class="bar-passed"/>
 
-<text x="185.63636363636363" y="387" class="seg-label" text-anchor="middle">6</text><rect x="197.27272727272728" y="370" width="7.757575757575758" height="26" class="bar-na"/>
+<rect x="194.53475935828877" y="370" width="6.8449197860962565" height="26" class="bar-na"/>
 
-<text x="213.03030303030303" y="387" class="muted">8</text>
+<text x="209.37967914438502" y="387" class="muted">8</text>
 </svg>


### PR DESCRIPTION
Group-5 (#381, COMPOSITION + VERSIONED_COMPOSITION) close-out: the full CNF pipeline on a freshly composed SUT after the complete group-5 fix wave (PRs #452, #453, #454).

## Run
- 512 case-records: **443 passed / 0 failed / 0 errored / 69 registered N/A**
- **CORE+STANDARD PASS**, 0 review findings; the 22 new group-5 cases pass first-run, including the newly-exercised `/versioned_composition/{uid}/version` at-time route and the container read's executed ETag+Last-Modified matchers
- Baseline ratchets upward only: +22 vs the 421-passed group-4 baseline
- Conformance visuals regenerated from the committed artifacts

## Group-5 record
Audit findings + fixes on #381 (#449 container-coherence wire fix, #450 served-OpenAPI completeness, #451 coverage + register incl. the body-uid-mismatch 400→422 alignment); register grew AMB-73…AMB-78 with upstream reports UPR-35…UPR-40.

Closes #381