### PR TITLE
fix(ehr): directory by-version identity check; DELETE 204 carries the deleted version's identity

### DIFF
--- a/.claude/agent-memory/spec-researcher/MEMORY.md
+++ b/.claude/agent-memory/spec-researcher/MEMORY.md
@@ -6,7 +6,7 @@
 - [VERSION.signature location](version-signature-location.md) — signature 0..1/optional, canonical_form, server-vs-client signing; RM common master06 + UML version.adoc; SM/ITS-REST/CNF silent
 - [Persistent COMPOSITION uniqueness](persistent-composition-uniqueness.md) — one-persistent-per-template is NOT spec-mandated (SILENT/under-debate); RM ehr master04 + CNF master07 same_opt_twice (tagged future)
 - [FLAT/STRUCTURED format location](flat-structured-format-location.md) — ITS-REST simplified_formats (STABLE) = authoritative wire; SM SIM-B/SDF (DEVELOPMENT) = abstract model+rules; SDT retired; CNF only legacy Robot suite
-- [DIRECTORY API location](directory-api-location.md) — EHR FOLDER/directory REST (OAS-split YAML) + FOLDER RM + CNF master09 + the status-code spec gaps (409/404-no-directory undefined; no versioned_directory route)
+- [DIRECTORY API location](directory-api-location.md) — the 5 directory ops/responses/params + FOLDER RM + SM I_EHR_DIRECTORY + CNF master09/Robot; `path` param defined ONLY in parameters/query/path.yaml; enumerated released-text gaps
 - [TemplateMetadata.version location](template-metadata-version-location.md) — ITS-REST definition/template list version field (deprecated, not required); source = template_id suffix OR OPT other_details (CNF master04 L161); ADL1.4 has no formal versioning
 - [FOLDER / directory model location](folder-directory-model-location.md) — RM FOLDER/VERSIONED_FOLDER/EHR.directory-vs-folders model, invariants, deletion, + generated Rust bindings
 - [AOM2 validation catalogue location](aom2-validation-catalogue-location.md) — where every V-code full text lives (master03/04.5/07/06), master08=phase orchestration only, the 14 spec-silent codes (external adl_syntax_errors.txt), am24 gen tree map

--- a/.claude/agent-memory/spec-researcher/directory-api-location.md
+++ b/.claude/agent-memory/spec-researcher/directory-api-location.md
@@ -1,30 +1,60 @@
 ---
 name: directory-api-location
-description: Where the DIRECTORY (EHR FOLDER) API + FOLDER RM + CNF tests live, and the spec gaps for status codes
+description: Where the DIRECTORY (EHR FOLDER) 5-operation API + FOLDER RM + SM I_EHR_DIRECTORY + CNF live, and the enumerated released-text gaps
 metadata:
   type: reference
 ---
 
-DIRECTORY / EHR FOLDER API spec locations (ITS-REST is OAS-split YAML, NOT prose .adoc):
+DIRECTORY / EHR FOLDER API spec locations (ITS-REST is OAS-split YAML; the EHR-API
+docs prose is a STUB — see [[ehr-status-ops-location]]).
 
-- Routes: `docs/specs/openehr/ITS-REST/specifications/ehr.openapi.yaml` lines 77-88 — `/ehr/{ehr_id}/directory` (post/put/delete/get) + `/ehr/{ehr_id}/directory/{version_uid}` (get).
-- Operations: `.../specifications/operations/directory_{create,update,delete,get_at_time,get_by_version_id}.yaml`.
-- Responses: `.../specifications/responses/` — `201_directory`, `200_directory_updated`, `204_version_updated`, `204_deleted`, `204_deleted_at_time`, `200_FOLDER_retrieved`, `412_directory`, `404_directory_*`, `404_unknown_ehr_id`, `400`.
-- Params: `.../parameters/query/{version_at_time,path}.yaml`, `.../parameters/path/{ehr_id,version_uid}.yaml`, `.../parameters/header/{If-Match,Prefer,Accept_LOCATABLE,ContentType_LOCATABLE}.yaml`.
-- Headers: `.../headers/{ETag_FOLDER,Location_directory,Location_deprecated,ContentType_LOCATABLE}.yaml`.
-- Schema: `.../schemas/ehr/Folder.yaml` (FOLDER: items[OBJECT_REF] / folders[FOLDER] / details[ITEM_STRUCTURE], all 0..1; allOf Versionable->Locatable).
-- General header/status semantics (Location deprecation, ETag W/, If-Match->412/400, Prefer, version_at_time, openehr-version/audit-details/item-tag): `.../specifications/docs/overview/Requests_and_responses.md`.
-- Vendored codegen OAS (same content, bundled): `crates/openehr-its/vendor/rest-oas/ehr-*.openapi.yaml`.
+- Routes: `ITS-REST/specifications/ehr.openapi.yaml` L77-88 — `/ehr/{ehr_id}/directory`
+  (post/put/delete/get) + `/ehr/{ehr_id}/directory/{version_uid}` (get). No `folders`
+  route, no `versioned_directory` route, no FOLDER `tags` route (only composition +
+  ehr_status have `/tags`).
+- Operations: `operations/directory_{create,update,delete,get_at_time,get_by_version_id}.yaml`.
+- Responses: `201_directory`, `200_directory_updated`, `204_version_updated` (SHARED with
+  ehr_status/composition/demographic updates — it, not the 200, declares
+  `Location_version` + the two item-tag headers), `204_deleted`, `204_deleted_at_time`,
+  `200_FOLDER_retrieved`, `412_directory`, `404_unknown_ehr_id`, `400`,
+  `404_directory_unknown_ehr_id_or_no_version_{at_time,uid}_or_no_path`.
+- Params: `parameters/query/{path,version_at_time}.yaml`, `path/{ehr_id,version_uid}.yaml`,
+  `header/{If-Match,Prefer,Accept_LOCATABLE,ContentType_LOCATABLE}.yaml`.
+- Headers: `headers/{ETag_FOLDER,ETag,Location_directory,Location_version,Location_deprecated,ContentType_LOCATABLE}.yaml`.
+- Schema: `schemas/ehr/Folder.yaml` (+ `UMFolder.yaml`); items ->
+  `schemas/base_types/UObjectRefOfUidBasedId.yaml` -> `ObjectRef.yaml` (namespace/type/id
+  ALL required). `schemas/ehr/Ehr.yaml` carries **NO** directory/folders/compositions/
+  contributions properties at all.
 
-RM grounding:
-- FOLDER class: `docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.common.folder.adoc` (no uniqueness invariant at class level; only LOCATABLE.name). Prose: `RM/docs/common/master05-directory_package.adoc` (VERSIONED_FOLDER = VERSIONED_OBJECT<FOLDER>; path = slash-separated name values + uniqueness modifier).
-- EHR.directory: `RM/docs/UML/classes/org.openehr.rm.ehr.ehr.adoc` L42 (directory: OBJECT_REF 0..1), invariants Directory_valid (type=VERSIONED_FOLDER) L70, Directory_in_folders L76.
+**THE `path` QUERY PARAM: its ONLY released definition is `parameters/query/path.yaml`**
+("slash-separated values of the name attribute of FOLDERs in the directory",
+example `episodes/a/b/c`) + SM `has_path` Meaning (same words). The overview docs
+(`docs/overview/*.md`) mention directory/folder only 3 times and NEVER the path param —
+grep-verified. RM's own directory paths are a DIFFERENT syntax
+(`/folders[hospital episodes]/items[1]`, `RM/docs/common/master05-directory_package.adoc §Paths`).
 
-CNF tests: `docs/specs/openehr/CNF/docs/platform_test_schedule/master09-func_tc_ehr_directory.adoc` — SM I_EHR_DIRECTORY ops (has_directory, has_path, create/update/delete_directory, get_directory[_at_time/_at_version], has_directory_version, get_versioned_directory). Robot suites under CNF/tests/platform/robot/I_EHR_DIRECTORY/.
+RM grounding: `RM/docs/common/master05-directory_package.adoc` (VERSIONED_FOLDER =
+VERSIONED_OBJECT<FOLDER>) + `RM/docs/UML/classes/org.openehr.rm.common.{folder,versioned_folder}.adoc`
+(FOLDER declares NO invariants) + `RM/docs/ehr/master04-ehr_package.adoc §Folders` (L102-131)
+and L237 (`is_modifiable` covers Folders) + `master06-change_control_package.adoc §Contributions`
+(change_type 249/250/251/523) + `§Logical Deletion`. See [[folder-directory-model-location]].
 
-KNOWN SPEC GAPS (flag as "spec-silent / our own design"):
-- No REST endpoint for get_versioned_directory (VERSIONED_OBJECT of directory) — CNF L.1-L.3 have no ITS-REST route.
-- create on EHR-that-already-has-directory: CNF E.2 requires an error, REST create defines only 400/404 (no 409). Status undefined.
-- update/delete when EHR exists but has NO directory: CNF H.2/I.1 require error, REST defines only 404_unknown_ehr_id/412/400 (404 is "unknown ehr_id" only). Status undefined.
-- GET at_time with malformed version_at_time: operation omits 400 (only 200/204/404); overview general 400 would apply.
-- Last-Modified: overview says SHOULD for VERSION resources, but directory responses list only ETag/Location/Content-Type.
+SM: `SM/docs/UML/classes/i_ehr_directory.adoc` — 9 ops (has_directory, has_path,
+create/update/delete_directory, get_directory, get_directory_at_time,
+has_directory_version, get_directory_at_version, get_versioned_directory);
+`uv_folder.adoc` (UV_FOLDER = UPDATE_VERSION<FOLDER>) + `update_version.adoc` +
+`openehr_platform/master03-common_package.adoc §Version Update Semantics`.
+
+CNF (stalled guide): `CNF/docs/platform_test_schedule/master09-func_tc_ehr_directory.adoc`
+(cases C.1–L.3). Robot: `CNF/tests/platform/robot/I_EHR_DIRECTORY/**` +
+`_resources/keywords/directory_keywords.robot` (the validate-* keywords carry the concrete
+status codes; L730 literally says the 409-already-exists case "is not (yet) in the SPEC").
+Fixtures: `_resources/test_data_sets/directory/*.json`.
+
+RELEASED-TEXT GAPS for directory (all confirmed first-hand):
+create-on-existing-directory status; update/delete when EHR has no directory;
+`path` leading-slash + root-name-included + escaping + items-addressable; the
+`path`-miss branch on a 204-deleted version; `EHR.directory`/`folders` never on the wire;
+committal + item-tag request headers absent from all 5 op files (docs text mandates them);
+is_modifiable rejection status; body-`uid`-vs-If-Match mismatch; DELETE 204 declares no
+headers at all.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **Directory by-version reads verify the full addressed identity; the
+  directory DELETE 204 carries the deleted version's identity** (#456).
+  `GET …/directory/{version_uid}` now answers 404 when the addressed
+  `creating_system_id` does not match the stored identity (ITS-REST
+  overview *Resources* §Identifier types), and
+  `DELETE …/directory` answers 204 with the NEW `523|deleted|` version's
+  weak `ETag` + `Last-Modified` (previously header-less), matching the
+  composition DELETE.
+
 - **COMPOSITION update body-uid mismatch is 422, not 400** (#451). A PUT
   whose body `COMPOSITION.uid` names a different versioned object than the
   request path is now rejected 422 Unprocessable Entity — the body is

--- a/app/ehrbase-rest/src/api/ehr/directory.rs
+++ b/app/ehrbase-rest/src/api/ehr/directory.rs
@@ -177,7 +177,15 @@ pub(super) async fn run(
                 )
                 .await
             {
-                Ok(()) => Ok(negotiate::empty(no_content)),
+                // 204 with the NEW deleted version's weak ETag + Last-Modified
+                // (overview §"ETag and Last-Modified": both SHOULD accompany
+                // versioned resources; the delete commits a 523|deleted|
+                // version — RM common master06 §Logical Deletion).
+                Ok(resp) => Ok(negotiate::deleted_with_headers(
+                    &base,
+                    Some("directory"),
+                    &resp,
+                )),
                 Err(e) if e.status == CallStatusType::VersionMismatch => {
                     let meta = state
                         .backend()

--- a/app/ehrbase-rest/tests/directory_http.rs
+++ b/app/ehrbase-rest/tests/directory_http.rs
@@ -1122,3 +1122,61 @@ async fn update_with_a_fetched_body_round_trips() {
     let v2 = etag_uid(&h);
     assert!(v2.ends_with("::2"), "trunk v2, got {v2}");
 }
+
+/// The directory DELETE 204 carries the NEW `523|deleted|` version's weak
+/// `ETag` + `Last-Modified` (overview §"`ETag` and Last-Modified": both
+/// SHOULD accompany versioned resources; RM common master06 §Logical
+/// Deletion: the delete commits a new version).
+#[tokio::test]
+async fn delete_204_carries_the_deleted_versions_identity() {
+    let (_pg, app) = common::test_router().await;
+    let ehr = create_ehr(&app).await;
+    let (status, h, _b) = create_directory(&app, &ehr, &folder_json("root", vec![]), None).await;
+    assert_eq!(status, StatusCode::CREATED);
+    let v1 = etag_uid(&h);
+
+    let (status, h, _b) = delete_directory(&app, &ehr, Some(&quoted(&v1))).await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+    let deleted_uid = etag_uid(&h);
+    assert_ne!(deleted_uid, v1, "the 204 names the NEW deleted version");
+    assert!(
+        deleted_uid.ends_with("::2"),
+        "the delete committed the next trunk version: {deleted_uid}"
+    );
+    assert!(
+        header_str(&h, http::header::LAST_MODIFIED).is_some(),
+        "Last-Modified accompanies the deleted version's identity"
+    );
+}
+
+/// The by-version read verifies the FULL addressed identity: a fabricated
+/// `creating_system_id` names no VERSION in this repository → 404
+/// (Resources.md §Identifier types; BASE master05 case rule) — while the
+/// stored identity still serves 200.
+#[tokio::test]
+async fn by_version_read_rejects_fabricated_creating_system_id() {
+    let (_pg, app) = common::test_router().await;
+    let ehr = create_ehr(&app).await;
+    let (status, h, _b) = create_directory(&app, &ehr, &folder_json("root", vec![]), None).await;
+    assert_eq!(status, StatusCode::CREATED);
+    let v1 = etag_uid(&h);
+
+    let (status, _h, _b) = send(&app, get(format!("{BASE}/ehr/{ehr}/directory/{v1}"), None)).await;
+    assert_eq!(status, StatusCode::OK, "the stored identity serves");
+
+    let (vo, tree) = (
+        v1.split("::").next().unwrap(),
+        v1.rsplit("::").next().unwrap(),
+    );
+    let fabricated = format!("{vo}::not.this.system::{tree}");
+    let (status, _h, _b) = send(
+        &app,
+        get(format!("{BASE}/ehr/{ehr}/directory/{fabricated}"), None),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_FOUND,
+        "a fabricated creating_system_id names no VERSION"
+    );
+}

--- a/app/ehrbase/src/service/ehr/directory.rs
+++ b/app/ehrbase/src/service/ehr/directory.rs
@@ -325,7 +325,7 @@ impl EhrbaseService {
             )?,
             None => self.audit(change_type::DELETED, "DIRECTORY delete"),
         };
-        delete(
+        let committed = delete(
             &mut tx,
             Some(ehr_id),
             vo_id,
@@ -337,7 +337,12 @@ impl EhrbaseService {
         )
         .await?;
         tx.commit().await?;
-        Ok(ServiceResponse::plain(Value::Null))
+        // The 204's identity: the NEW 523|deleted| version the delete
+        // committed (RM common master06 §Logical Deletion) — the resource's
+        // current state, carried so the wire serves the weak ETag +
+        // Last-Modified the overview §"ETag and Last-Modified" SHOULDs on
+        // versioned resources.
+        Ok(self.committed_response(ehr_id, &committed))
     }
 
     /// The current directory FOLDER version metadata (for a `412`
@@ -543,7 +548,10 @@ impl EhrbaseService {
 
     /// SM `I_EHR_DIRECTORY.delete_directory` — logically delete the EHR's
     /// directory (a new `523|deleted|` version, RM common master06 §Logical
-    /// Deletion).
+    /// Deletion). Returns the committed deleted version's metadata (uid +
+    /// commit instant) so the wire 204 carries the weak `ETag`/`Last-Modified`
+    /// the overview §"`ETag` and Last-Modified" SHOULDs on versioned
+    /// resources.
     ///
     /// # Errors
     /// [`SmError`] when the EHR has no directory (404-equivalent), the
@@ -554,7 +562,7 @@ impl EhrbaseService {
         an_ehr_id: EhrId,
         preceding_version_uid: Option<ObjectVersionId>,
         update_audit: Option<&crate::service::version_update::UpdateAudit>,
-    ) -> Result<(), SmError> {
+    ) -> Result<ServiceResponse, SmError> {
         let Some((vo_id, is_modifiable, latest)) = self.directory_meta_with_vo(an_ehr_id).await?
         else {
             return Err(ServiceError::sm(
@@ -568,9 +576,10 @@ impl EhrbaseService {
             .as_ref()
             .map(|o| components(o).map(|(_, v)| v))
             .transpose()?;
-        self.delete_directory_at(an_ehr_id, vo_id, expected, is_modifiable, update_audit)
+        let resp = self
+            .delete_directory_at(an_ehr_id, vo_id, expected, is_modifiable, update_audit)
             .await?;
-        Ok(())
+        Ok(resp)
     }
 
     /// The directory FOLDER at the named version
@@ -588,9 +597,18 @@ impl EhrbaseService {
         a_path: Option<&str>,
     ) -> Result<ServiceResponse, SmError> {
         let (vo_id, version) = components(&a_version_uid)?;
-        Ok(self
+        let resp = self
             .directory_version(an_ehr_id, vo_id, version, a_path)
-            .await?)
+            .await?;
+        // The addressed version_uid must equal the stored full three-part
+        // identity (ITS-REST overview Resources.md §Identifier types; BASE
+        // master05 case rule) — a fabricated creating_system_id names no
+        // VERSION here. A deleted read carries no metadata (204 body-less),
+        // so there is nothing to verify against.
+        if let Some(meta) = resp.meta.as_ref() {
+            super::ensure_addressed_version(&a_version_uid, &meta.uid)?;
+        }
+        Ok(resp)
     }
 
     /// SM `I_EHR_DIRECTORY.has_directory_version` — whether the named


### PR DESCRIPTION
From the #382 group-6 audit, findings F-1 + F-2.

1. **By-version identity**: the directory by-version read resolved by (object_id, version_tree_id) only — a fabricated `creating_system_id` still served the version. Now the addressed uid must equal the stored full three-part identity, case-insensitively (Resources.md §Identifier types; BASE master05 case rule) → 404 on mismatch, via the same `ensure_addressed_version` seam the EHR_STATUS/COMPOSITION routes use. Deleted reads (204, body-less) carry no metadata and are exempt.
2. **DELETE 204 identity**: `delete_directory` returned `()` and the wire answered a bare 204. The delete commits a NEW `523|deleted|` version (RM master06 §Logical Deletion); the 204 now carries its weak ETag + Last-Modified per the §"ETag and Last-Modified" SHOULD and AMB-75's uniform handling — matching the composition DELETE. (The `204_deleted.yaml` declaring no headers is stalled shape; the docs-text SHOULD governs.)

Two new `directory_http` wire tests pin both. CNF pins land with #458.

Gates: fmt, clippy 0 warnings, nextest `ehrbase` + `ehrbase-rest` 1152 passed. Changelog entry added.

Closes #456