### PR TITLE
fix(versioning): first-version-of-a-MODIFICATION answers the released 400; creation+preceding moves to 422

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **Contribution change-type mismatch statuses follow the released
+  assignment** (#467). A non-creation `change_type` committed as the FIRST
+  version of a versioned object (the released `400_CONTRIBUTION` trigger:
+  "the modification type does not match the operation - i.e. first version
+  of a MODIFICATION") now answers 400; a `249|creation|` member carrying a
+  `preceding_version_uid` — the unassigned mirror case — moves to 422.
+  Previously the two were inverted.
+
 - **The CONTRIBUTION GET serves `ETag` + `Last-Modified`** (#463).
   `GET …/contribution/{contribution_uid}` now carries the contribution-uid
   weak `ETag` (the same identity the 201 already carries) and a

--- a/app/ehrbase/src/versioning/contribution.rs
+++ b/app/ehrbase/src/versioning/contribution.rs
@@ -89,14 +89,17 @@ fn classify(
     match code.as_str() {
         change_type::CREATION => {
             if has_preceding {
-                // A change-control mismatch, not content validation: ITS-REST
-                // scopes `400_CONTRIBUTION` to "the modification type does not
-                // match the operation" — a 400, never a 422.
-                return Err(ServiceError::BadRequest(
+                // The released `400_CONTRIBUTION` trigger is DIRECTIONAL —
+                // "first version of a MODIFICATION" — and does not cover this
+                // mirror case; no released text assigns it, so it is the
+                // register-documented 422: a well-formed envelope whose
+                // change-control semantics cannot be followed (RM
+                // change_control §Contributions: creation commits a NEW
+                // VERSIONED_OBJECT).
+                return Err(ServiceError::Unprocessable(
                     "change_type 249|creation| is invalid for an existing object \
                      (preceding_version_uid present); creation commits a new \
-                     VERSIONED_OBJECT (RM change_control §Contributions; ITS-REST \
-                     contribution 400: modification type does not match)"
+                     VERSIONED_OBJECT (RM change_control §Contributions)"
                         .to_owned(),
                 ));
             }
@@ -109,8 +112,15 @@ fn classify(
         }
         change_type::DELETED => {
             if !has_preceding {
-                return Err(ServiceError::Unprocessable(
-                    "deleted (523) version requires preceding_version_uid".to_owned(),
+                // A non-creation change type as a FIRST version — the released
+                // `400_CONTRIBUTION` trigger family ("the modification type
+                // does not match the operation - i.e. first version of a
+                // MODIFICATION") → 400.
+                return Err(ServiceError::BadRequest(
+                    "deleted (523) version requires preceding_version_uid — a first \
+                     version's change type is 249|creation| (ITS-REST contribution \
+                     400: the modification type does not match the operation)"
+                        .to_owned(),
                 ));
             }
             if has_data {
@@ -150,10 +160,14 @@ fn classify(
         // version of an existing object; the code is preserved verbatim.
         _ => {
             if !has_preceding {
-                return Err(ServiceError::Unprocessable(format!(
+                // THE released assignment: `400_CONTRIBUTION` — "the
+                // modification type does not match the operation - i.e. first
+                // version of a MODIFICATION" → 400.
+                return Err(ServiceError::BadRequest(format!(
                     "change_type {code} requires preceding_version_uid — a first \
-                     version's change type is 249|creation| (RM change_control \
-                     §Contributions)"
+                     version's change type is 249|creation| (ITS-REST contribution \
+                     400: the modification type does not match the operation; RM \
+                     change_control §Contributions)"
                 )));
             }
             if !has_data {
@@ -1006,12 +1020,15 @@ mod tests {
 
     #[test]
     fn classify_rejects_spec_invalid_combinations() {
-        // creation with a preceding version is a change-control mismatch —
-        // the ITS-REST `400_CONTRIBUTION` scope, not content validation.
-        assert!(classify_bad_request(Some("249"), true, true).contains("249|creation|"));
-        assert!(classify_err(Some("250"), false, true).contains("preceding_version_uid"));
+        // A non-creation change type as the FIRST version is THE released
+        // `400_CONTRIBUTION` trigger ("the modification type does not match
+        // the operation - i.e. first version of a MODIFICATION") → 400;
+        // creation WITH a preceding is its unassigned mirror → the
+        // register-documented 422 (AMB-54, narrowed).
+        assert!(classify_err(Some("249"), true, true).contains("249|creation|"));
+        assert!(classify_bad_request(Some("250"), false, true).contains("preceding_version_uid"));
         assert!(classify_err(Some("523"), true, true).contains("must not carry data"));
-        assert!(classify_err(Some("523"), false, false).contains("preceding_version_uid"));
+        assert!(classify_bad_request(Some("523"), false, false).contains("preceding_version_uid"));
         assert!(classify_err(Some("999"), true, true).contains("audit_change_type"));
         assert!(classify_err(Some("251"), true, false).contains("needs data"));
     }

--- a/app/ehrbase/tests/service_ehr.rs
+++ b/app/ehrbase/tests/service_ehr.rs
@@ -855,8 +855,9 @@ async fn contribution_preserves_the_client_change_type_and_rejects_invalid_combo
     // (never narrowed to `modification` — RM change_control §"Contributions":
     // a correction is committed with change type 250|amendment|), and
     // spec-invalid combinations are rejected: creation on an existing object
-    // as 400 (ITS-REST 400_CONTRIBUTION — modification-type mismatch), an
-    // out-of-group code as 422 (content validation).
+    // as 422 (the register-documented mirror of the directional released
+    // 400_CONTRIBUTION trigger), an out-of-group code as 422 (content
+    // validation).
     let db = testkit::db().await.expect("testkit database");
     let svc = EhrbaseService::new(db.pool());
 
@@ -936,13 +937,14 @@ async fn contribution_preserves_the_client_change_type_and_rejects_invalid_combo
         matches!(
             bad_creation,
             Err(SmError {
-                status: CallStatusType::PreconditionViolation,
+                status: CallStatusType::ContentInvalid,
                 ..
             })
         ),
-        "creation on an existing object is a change-control mismatch — the \
-         ITS-REST 400_CONTRIBUTION scope (modification type does not match), \
-         not content validation; got {bad_creation:?}"
+        "creation on an existing object is the UNASSIGNED mirror of the \
+         released 400_CONTRIBUTION trigger (which is directional: 'first \
+         version of a MODIFICATION') — the register-documented 422 \
+         (AMB-54, narrowed); got {bad_creation:?}"
     );
 
     // Invalid code: not a member of the audit_change_type group


### PR DESCRIPTION
Found during the #464 step-6 pass (worker report): the served-document write-up exposed that `classify` inverted the one released status assignment for contribution change-control contradictions.

- `responses/400_CONTRIBUTION.yaml` (released, quoted in the code): 400 for "the modification type does not match the operation - i.e. first version of a MODIFICATION" — now answered 400 for every non-creation change_type without a `preceding_version_uid` (250/251/252/253/816/817, and 523/666 which additionally cannot name their target).
- The mirror case — `249|creation|` WITH a preceding — has NO released assignment; AMB-54 (narrowed, PR pending in the group-7 register wave) documents it as our 422. Moved accordingly.

Unit + service tests corrected toward the released/register-documented statuses with citations. One unrelated parallel-run flake observed and filed (#468); full battery green on rerun (1153 passed).

Gates: fmt, clippy 0 warnings, nextest `ehrbase` + `ehrbase-rest` 1153 passed. Changelog entry added.

Closes #467