### PR TITLE
fix(cnf): group-7 red-row triage — the contribution 412 ETag expectation was catalogue over-specification

### DIFF
--- a/.claude/agent-memory/cnf-triage/MEMORY.md
+++ b/.claude/agent-memory/cnf-triage/MEMORY.md
@@ -10,4 +10,5 @@
 - [EHR_STATUS archetype-root invariant](ehr-status-archetype-root-invariant.md) — archetype_details MANDATORY on EHR_STATUS/EHR_ACCESS (Is_archetype_root × Archetyped_valid); the app 422 is spec-correct
 - [Two EHR_STATUS payload sites PR #431 missed](cnf-red-2026-07-27-ehr-status-payloads.md) — ehr_status recipe + contribution case core; catalogue bin; sweep command included
 - [Contained uid is a recommendation](contained-uid-is-a-recommendation.md) — data/uid presence is SHOULD in every released source; cannot gate CORE; AMB-65 fixes only the FORM
+- [AMB-54(b) contribution 412 ETag over-promise](amb54-contribution-412-etag-overpromise.md) — CATALOGUE bin: no If-Match on the contribution route ⇒ the ETag SHOULD's antecedent is false, and multi-member commits have no unique latest version_uid
 - [Upstream EHRbase Java non-conformance (#266)](upstream-ehrbase-java-nonconformance.md) — EHRbase 2.34.0 400s the spec-standard QUOTED If-Match (composition/ehr_status update classes) + 404s the STABLE item-tag surface; our driver/pack spec-valid, outcome (b), record stands

--- a/.claude/agent-memory/cnf-triage/amb54-contribution-412-etag-overpromise.md
+++ b/.claude/agent-memory/cnf-triage/amb54-contribution-412-etag-overpromise.md
@@ -1,0 +1,43 @@
+---
+name: amb54-contribution-412-etag-overpromise
+description: CATALOGUE defect — AMB-54(b) promised a latest-version ETag on the contribution-route 412; no released sentence grounds it and the route has no unique version referent
+metadata:
+  type: project
+---
+
+`I_EHR_CONTRIBUTION.commit_contribution-stale_preceding_version` step 3 went
+red on `header ETag: … got none` (status 412 matched). Attributed **catalogue**
+2026-07-27, confirmed first-hand:
+
+- `ITS-REST .../docs/overview/Requests_and_responses.md` §If-Match and
+  accidental overwrites — the ETag sentence is conditioned on the header:
+  "**If a service receives this header**, and the condition evaluates to
+  `false` … MUST respond with … `412` … and **SHOULD** return also latest
+  `version_uid` in the `ETag`". `POST /ehr/{ehr_id}/contribution` has no
+  `If-Match` parameter and the case sends none → antecedent false, and it is a
+  SHOULD even when true.
+- Same file §HTTP status codes, 412 row: "conditions given in the request
+  **header fields**" — the contribution precondition lives in the member body.
+- `.../docs/overview/Resources.md` — CONTRIBUTION is listed under
+  "**non-versioned** resources"; the route's own ETag identity is the
+  contribution uid (the binding captures `contribution_etag_uid` from it).
+- No unique referent: `SM .../UML/classes/i_ehr_contribution.adoc`
+  `commit_contribution(… versions: List<UPDATE_VERSION>[1] …)` +
+  `RM .../UML/classes/org.openehr.rm.common.contribution.adoc` "a list of
+  versions, which may include paths pointing to **any number** of versionable
+  items" — "the latest version_uid" is per-member, so one ETag cannot serve it
+  in general. The app is right to omit it.
+
+Contrast that proves the app is not at fault: every route where the antecedent
+DOES hold passes (`update_composition-stale_if_match`,
+`update_directory-/delete_directory-stale_if_match`,
+`set_ehr_queryable-stale_if_match`, `update_party-weak_etag_stale`) — the
+`error_with_meta` decoration in `app/ehrbase-rest` covers exactly those.
+
+**How to apply:** a register `handling:` text is a catalogue artifact and a
+suspect — an adjudicated status code does NOT license attaching further
+required headers to it "by analogy with a sibling route". Check the antecedent
+scope of a SHOULD sentence before a binding turns it into a gating matcher.
+Open consistency item (not a defect yet): the direct-route bindings gate the
+same SHOULD via the `latest-version-uid` matcher; there the antecedent holds and
+the referent is unique, so it is defensible, but its strength is SHOULD.

--- a/docs/conformance/upstream-reports.md
+++ b/docs/conformance/upstream-reports.md
@@ -801,7 +801,9 @@ CNF↔SM divergences, and benign released-documented behaviours carry no
 - **Facts:** `400_CONTRIBUTION` assigns first-version-of-a-MODIFICATION →
   400; creation-with-preceding, stale/unknown preceding (no If-Match/412 on
   this op), and out-of-group tokens remain unassigned.
-- **Ask:** assign the three residual branches.
+- **Ask:** assign the three residual branches, and assign (or decline) an
+  identifying header for the body-borne precondition failure (no single
+  latest `version_uid` exists on a multi-member contribution).
 
 ### UPR-48 — contribution GET's simplified promise contradicts its declared schema
 

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_CONTRIBUTION.commit_contribution.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_CONTRIBUTION.commit_contribution.yaml
@@ -54,18 +54,13 @@ outcomes:
     # §"If-Match and accidental overwrites" scopes its 412 to the `If-Match`
     # header, which this route does not carry at all: the precondition travels
     # inside the member body (`preceding_version_uid`). Register AMB-54(b)
-    # carries the adjudicated fixed handling — 412 with the current-latest weak
-    # ETag, the same shape the direct routes' precondition family answers, the
-    # ETag half mirroring the same section's "SHOULD return also latest
-    # `version_uid` in the `ETag` response headers".
+    # carries the adjudicated fixed handling — 412, with the response BEYOND
+    # the status unconstrained: the §If-Match ETag SHOULD is conditioned on
+    # the service RECEIVING If-Match ("If a service receives this header …"),
+    # which this operation has no parameter for, and CONTRIBUTION.versions is
+    # a list over "any number of versionable items" (RM contribution.adoc), so
+    # no single latest version_uid exists for an ETag to name.
     status: 412
-    headers:
-      # The entity tag names the CURRENT latest version of the addressed
-      # container. The `<name>` placeholder resolves from the case's own
-      # `latest_version_uid` capture; a case that captured none wildcards it and
-      # the matcher then asserts the weak-tag SHAPE alone (the
-      # §Deprecated-headers `W/` MUST).
-      ETag: 'pattern:W/"<latest_version_uid>"'
     body: error_loose
 captures:
   contribution_uid:

--- a/tools/cnf-runner/artifacts/registers/ambiguities.yaml
+++ b/tools/cnf-runner/artifacts/registers/ambiguities.yaml
@@ -513,10 +513,18 @@ AMB-54:
     Fixed handling: (a) creation-with-preceding and (c) out-of-group tokens
     are 422 (well-formed envelopes whose change-control semantics cannot be
     followed — the general 422 row); (b) a stale/unknown
-    preceding_version_uid is 412 with the current-latest weak ETag,
-    consistent with the direct routes' precondition family. The
-    first-version-modification case gates at the released 400. Reported
-    upstream (UPR-47): assign the three residual branches.
+    preceding_version_uid is 412; the response beyond the status is
+    UNCONSTRAINED on this branch — the §If-Match ETag SHOULD is conditioned
+    on the service RECEIVING If-Match ("If a service receives this header
+    …"), which this operation has no parameter for, and CONTRIBUTION.versions
+    is a list over "any number of versionable items" (RM contribution.adoc),
+    so no single latest version_uid exists to name. On the DIRECT routes the
+    antecedent holds and the referent is unique, and the catalogue
+    deliberately gates that SHOULD there (a strength choice, recorded here on
+    purpose). The first-version-modification case gates at the released 400.
+    Reported upstream (UPR-47): assign the three residual branches, and
+    assign (or decline) an identifying header for the body-borne
+    precondition failure.
   disposition: fixed_handling
   upstream_ref: "UPR-47"
 

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-stale_preceding_version.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-stale_preceding_version.yaml
@@ -10,16 +10,12 @@
 # on the server") and §"If-Match and accidental overwrites" scopes its 412 to
 # that header, while the contribution's precondition travels inside
 # `UpdateVersion.preceding_version_uid`. No released sentence assigns the
-# branch. The register's fixed handling is the 412 the direct routes answer for
-# the identical semantic failure, carrying the current-latest version uid in
-# the weak `ETag` — mirroring the same section's "SHOULD return also latest
-# `version_uid` in the `ETag` response headers".
-#
-# WHY the version identity in the tag is assertable here: step 2 commits the
-# second version and its uid is captured as `latest_version_uid`, which the
-# binding's ETag pattern resolves. Step 3 then names the SUPERSEDED first
-# version — so a server echoing the request's own stale uid, or omitting the
-# header, is a red row rather than a silent pass.
+# branch. The register's fixed handling is the 412 alone — the response
+# BEYOND the status is unconstrained: the §If-Match ETag SHOULD is
+# conditioned on the service RECEIVING If-Match, which this operation has no
+# parameter for, and CONTRIBUTION.versions spans "any number of versionable
+# items" (RM contribution.adoc), so no single latest version_uid exists for
+# an ETag to name on a multi-member commit.
 #
 # Contrast kept honest by the siblings: a CREATION member that names a
 # preceding version is 422, not 412 (-creation_with_preceding_version), and a
@@ -35,8 +31,7 @@ profiles: [CORE]
 ambiguities: [AMB-54]
 test_purpose: >-
   A CONTRIBUTION member whose preceding_version_uid names a superseded version
-  fails its precondition, the response names the container's current latest
-  version, and nothing is committed.
+  fails its precondition and nothing is committed.
 description: "Commit CONTRIBUTION with a stale preceding_version_uid"
 spec_refs:
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
@@ -76,7 +71,7 @@ flow:
         - data: "${ds:cnf.composition.minimal_event.v2}"
           change_type: modification
           preceding_version_uid: "${stale_version_uid}"
-    expect: precondition_failed          # ETag = W/"${latest_version_uid}" (asserted by the binding)
+    expect: precondition_failed          # 412 alone — the response beyond the status is unconstrained (AMB-54)
 postconditions:
   - assert: state
     text: >-


### PR DESCRIPTION
The group-7 closing run went 471/1/0. cnf-triage attributed the red row (`commit_contribution-stale_preceding_version`, step 3: expected `ETag: W/"<latest_version_uid>"`, got none) to the CATALOGUE:

- The §If-Match ETag SHOULD's antecedent ("If a service **receives this header**…") is false on the contribution route — it has no If-Match parameter; the precondition travels in the member body.
- `CONTRIBUTION.versions` spans "any number of versionable items" (RM contribution.adoc) — no single latest `version_uid` exists on a multi-member commit, so no conformant server could satisfy the assertion in general. The register over-promised, the runner evaluated the declared matcher correctly, the SUT's bare 412 is spec-permissible.
- Counter-evidence in the same run: every direct route where the antecedent DOES hold (composition/directory/status/party stale-If-Match cases) passes its gated ETag SHOULD.

Fixes (three co-located edits, one root cause): AMB-54's handling drops the ETag half and records the direct-route SHOULD-gating as a deliberate strength choice; UPR-47's ask extends to the body-borne precondition's identifying header; the binding's `precondition_failed` loses the ETag matcher (citations kept in place); the case's header/purpose trim to the grounded claims — it keeps its full value (412 + nothing-committed postconditions).

Gates: `cnf-runner validate --specs` 541/124/0; `nextest -p cnf-runner` 171 passed. Red-run artifacts not committed. The zero-drift pipeline re-runs next.