### PR TITLE
fix(test): reachable fixture deadline — subject_proxy json-pointer flake under parallel runs

### DIFF
--- a/app/ehrbase/tests/service_subject_proxy.rs
+++ b/app/ehrbase/tests/service_subject_proxy.rs
@@ -382,14 +382,26 @@ async fn subject_proxy_preconditions_and_reset() {
 // hermetic `wiremock` FHIR server stands in for the remote system (no network).
 
 /// A subject-proxy service wired to a single FHIR system `name` → `base_url`.
+///
+/// NOTE: the deadlines are deliberately far longer than any loopback exchange
+/// needs, because no test in this file asserts timeout *behaviour* and a missed
+/// deadline here is silent rather than loud: a retrieve that fails after being
+/// dispatched is an unavailable `SAMPLE`
+/// (`SM/docs/UML/classes/sample.adoc` — "Every retrieval attempt will generate
+/// a new Sample object, regardless of whether data was actually available or
+/// not"), which `extract_value` maps to the empty `VARIABLE_VALUE`. A deadline
+/// short enough to be reachable under parallel-run host contention therefore
+/// turns a scheduling hiccup into a wrong-value assertion failure that passes
+/// on rerun. Deadlines that must actually fire belong in a test that delays the
+/// response on purpose.
 fn service_with_fhir(pool: PgPool, name: &str, base_url: &str) -> EhrbaseService {
     let mut systems = std::collections::BTreeMap::new();
     systems.insert(
         name.to_owned(),
         SpFhirSystem {
             base_url: base_url.to_owned(),
-            connect_timeout_ms: 500,
-            request_timeout_ms: 1_500,
+            connect_timeout_ms: 30_000,
+            request_timeout_ms: 30_000,
         },
     );
     let fhir = SubjectProxyConfig { systems }


### PR DESCRIPTION
Root cause of #468: the hermetic wiremock fixture hard-coded a 500ms/1500ms deadline, and a missed deadline degrades SILENTLY — `sp_dispatch_fhir` correctly converts an executed-but-failed retrieve into `Sample::unavailable` (SM `sample.adoc`: every retrieval attempt generates a Sample "regardless of whether data was actually available or not"), so the assertion sees `Single { value: None }` instead of an error, while the mock's `.expect(1)` stays satisfied. Host jitter demonstrably reaches that envelope (a sibling test measured a >20s stall on an idle box).

Fix: 30s fixture deadlines + a NOTE — no test in this battery asserts timeout behaviour (that coverage lives where a delay is set on purpose); no assertion weakened, nothing ignored, no serial group. Reproduced deliberately (2500ms delay → the verbatim reported failure), then verified: 6 consecutive oversubscribed 16-thread runs green + the full `-p ehrbase` battery green.

#324 is NOT the same cause (no HTTP/deadline in its path — the environment attribution stands). Three same-class candidates noted on the issue for future hardening (aql_terminology, cedar/remote-pdp fixtures); `terminology_fhir` must keep its short deadlines (it asserts timeout behaviour deliberately).

Closes #468