### PR TITLE
test(cnf): group-8 ITEM_TAG register entries AMB-91..97 + UPR-55..61; tag-discipline wire battery

### DIFF
--- a/app/ehrbase-rest/tests/headers.rs
+++ b/app/ehrbase-rest/tests/headers.rs
@@ -1283,3 +1283,89 @@ async fn ehr_wide_tag_listing_guards_the_ehr() {
         "unknown EHR is the released 404"
     );
 }
+
+/// The remaining group-8 tag disciplines in one battery: `[]` clear-all (the
+/// released sentence), `Prefer: return=identifier` resolving to the applied
+/// minimal default (an `ITEM_TAG` has no uid — AMB-92), delete-by-key as a
+/// SET delete (the released "resource(s)" plural — every `target_path` under
+/// the key goes, and the second delete is the released non-idempotent 404),
+/// and the `ehr_tags_get` filters (AND-combined, exact — AMB-94).
+#[tokio::test]
+async fn tag_collection_disciplines() {
+    let (_pg, app) = app().await;
+    let ehr_id = create_ehr(&app).await;
+    upload_opt(&app).await;
+    let version_uid = commit_composition(&app, &ehr_id).await;
+    let vo = vo_of(&version_uid).to_owned();
+    let put = |body: Value, prefer: Option<&'static str>| {
+        let mut b = Request::builder()
+            .method("PUT")
+            .uri(format!("{BASE}/ehr/{ehr_id}/composition/{vo}/tags"))
+            .header(header::CONTENT_TYPE, "application/json");
+        if let Some(p) = prefer {
+            b = b.header("Prefer", p);
+        }
+        b.body(Body::from(body.to_string())).unwrap()
+    };
+
+    // Seed: one key on two paths + a second key.
+    let seed = serde_json::json!([
+        { "key": "flag", "value": "a", "target_path": "/content[0]" },
+        { "key": "flag", "value": "b", "target_path": "/content[1]" },
+        { "key": "workflow", "value": "open" }
+    ]);
+    let (status, h, _b) = send(&app, put(seed, Some("return=identifier"))).await;
+    // return=identifier resolves to the APPLIED minimal default (AMB-92).
+    assert_eq!(status, StatusCode::NO_CONTENT);
+    assert_eq!(
+        h.get("preference-applied").and_then(|v| v.to_str().ok()),
+        Some("return=minimal"),
+        "identifier resolves to the applied minimal default"
+    );
+
+    // ehr_tags_get filters: AND-combined, exact.
+    let (status, _h, body) = send(
+        &app,
+        Request::builder()
+            .method("GET")
+            .uri(format!(
+                "{BASE}/ehr/{ehr_id}/tags?tag_key=flag&tag_target_path=/content%5B1%5D"
+            ))
+            .body(Body::empty())
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let filtered: Value = serde_json::from_str(&body).expect("filtered list");
+    assert_eq!(
+        filtered.as_array().map(Vec::len),
+        Some(1),
+        "AND + exact: {body}"
+    );
+    assert_eq!(filtered[0]["value"], "b");
+
+    // DELETE by key is a SET delete: both /content paths go; workflow stays.
+    let del = |key: &str| {
+        Request::builder()
+            .method("DELETE")
+            .uri(format!("{BASE}/ehr/{ehr_id}/composition/{vo}/tags/{key}"))
+            .body(Body::empty())
+            .unwrap()
+    };
+    let (status, _h, _b) = send(&app, del("flag")).await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+    let keys = stored_tag_keys(&app, &ehr_id, &vo).await;
+    assert_eq!(keys, vec!["workflow"], "both flag paths gone in one delete");
+    // The released third 404 trigger — deliberately non-idempotent.
+    let (status, _h, _b) = send(&app, del("flag")).await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "second delete is 404");
+
+    // [] clear-all (the released sentence) with the representation split.
+    let (status, _h, body) = send(
+        &app,
+        put(serde_json::json!([]), Some("return=representation")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body.trim(), "[]", "an empty list clears all: {body}");
+}

--- a/docs/conformance/upstream-reports.md
+++ b/docs/conformance/upstream-reports.md
@@ -876,3 +876,57 @@ CNF↔SM divergences, and benign released-documented behaviours carry no
   exemption vs the minimal 201, cross-EHR 404 by implication, atomicity as
   an unrestated "should", copy-down vs per-member committer. Normalize the
   interface and DTOs to the released ITS-REST 1.1.0 typing.
+
+### UPR-55 — wrong-kind uid on a typed tag route is unassigned
+
+- **Component:** ITS-REST (the typed tag routes' 404 file)
+- **Register:** AMB-91 (fixed_handling)
+- **Ask:** state whether a kind mismatch is the "does not exist" 404 (our
+  reading) or a 400.
+
+### UPR-56 — return=identifier on a tag PUT cannot satisfy the identifier contract
+
+- **Components:** ITS-REST (Prefer enum + §Prefer only identifier), RM (item_tag)
+- **Register:** AMB-92 (fixed_handling)
+- **Ask:** assign the branch or exclude the token for collection
+  resources without a uid.
+
+### UPR-57 — RM-invariant violations on the tag PUT have no status
+
+- **Components:** RM (item_tag invariants), ITS-REST (tag update responses)
+- **Register:** AMB-93 (fixed_handling)
+- **Ask:** assign 422 (our handling) or 400 explicitly.
+
+### UPR-58 — the ehr_tags_get filter grammar is undefined
+
+- **Component:** ITS-REST (ehr_tags_get + the three query params)
+- **Register:** AMB-94 (fixed_handling)
+- **Ask:** define repeatability, combination, match mode, and
+  absent-path matching; reconcile "one or more" with the scalar schemas.
+
+### UPR-59 — duplicate identity pairs in one tag PUT body
+
+- **Component:** ITS-REST (UpdateItemTag array)
+- **Register:** AMB-95 (fixed_handling)
+- **Ask:** uniqueItems or a merge rule (ours: last-wins).
+
+### UPR-60 — empty-string vs absent target_path splits the tag identity
+
+- **Components:** RM (item_tag target_path 0..1), ITS-REST (the "" example)
+- **Register:** AMB-96 (fixed_handling)
+- **Ask:** pick one representation (ours: "" normalizes to absent).
+
+### UPR-61 — the ITEM_TAG editorial defect bundle
+
+- **Components:** RM (item_tag, is_justified), BASE (String), ITS-REST, ITS-XML
+- **Register:** AMB-97 (editorial)
+- **Facts/Asks:** define `is_justified` (or restate the invariant on the
+  prose rule); fix the "(logically) deleted" wording; add an EHR-wide
+  ItemTagList schema; fix the copy-pasted _updated descriptions; either
+  add a canonical-XML ITEM_TAG type or drop XML from the tag enums; fix
+  the HIER_OBJECT_ID-with-type-COMPOSITION example and add a
+  VERSION-targeted example; align the DELETE descriptions' "tag_key" with
+  the {key} parameter; give FOLDER tags a route (or scope the overview);
+  define {key} encoding, list ordering/paging, and the
+  optional-feature refusal branch; state tag lifecycle vs target
+  lifecycle; note the development-RM provenance of the whole class.

--- a/tools/cnf-runner/artifacts/registers/ambiguities.yaml
+++ b/tools/cnf-runner/artifacts/registers/ambiguities.yaml
@@ -1691,6 +1691,174 @@ AMB-90:
   disposition: editorial
   upstream_ref: "UPR-54"
 
+AMB-91:
+  ambiguity: >-
+    A wrong-kind uid on a typed tag route (an EHR_STATUS container's uid
+    presented on /composition/{uid_based_id}/tags, or vice versa) has no
+    assigned outcome: the only released 404 text is "when the
+    `uid_based_id` does not exist", which never says whether a kind
+    mismatch is that miss or a 400.
+  source: >-
+    ITS-REST specifications/responses/404_unknown_ehr_id_or_uid_based_id.yaml
+    (the whole trigger set); the route-typed operation descriptions
+    (operations/{composition,ehr_status}_tags_*.yaml) — confirmed
+    first-hand.
+  handling: >-
+    Fixed handling: a wrong-kind uid is 404 — it is not "the
+    uid_based_id" of that route's resource family (the same route-kind
+    discipline the version routes carry). Enforced on GET, PUT and DELETE
+    alike. Reported upstream (UPR-55): assign the branch.
+  disposition: fixed_handling
+  upstream_ref: "UPR-55"
+
+AMB-92:
+  ambiguity: >-
+    "Prefer: return=identifier" is a legal enum value on the tag PUTs, but
+    the released identifier contract cannot apply: it requires a non-204
+    response whose body is "a single JSON object with a single `uid`
+    attribute" — an ITEM_TAG has NO uid (its identity is the (key,
+    target_path) pair) and the affected resource is a collection. No
+    released text assigns the branch.
+  source: >-
+    ITS-REST specifications/parameters/header/Prefer.yaml (the enum) +
+    docs/overview/Requests_and_responses.md §"Prefer only identifier" (the
+    uid-body contract) vs RM
+    UML/classes/org.openehr.rm.common.item_tag.adoc (no uid attribute) —
+    confirmed first-hand.
+  handling: >-
+    Fixed handling: return=identifier on a tag PUT resolves to the APPLIED
+    default return=minimal (204, Preference-Applied: return=minimal) —
+    there is no identifier to return, and claiming the identifier
+    preference was applied would be false. Reported upstream (UPR-56):
+    assign or exclude the token for collection resources.
+  disposition: fixed_handling
+  upstream_ref: "UPR-56"
+
+AMB-93:
+  ambiguity: >-
+    The rejection status for an ITEM_TAG violating its RM invariants
+    (Inv_key_valid: non-empty, no leading/trailing whitespace;
+    Inv_value_valid: a set value non-empty) is unassigned: the tag PUTs
+    declare only 400 ("syntactically invalid ... content") while such a
+    body is well-formed JSON satisfying the schema — the overview's own
+    422 row ("well-formed but was unable to be followed due to semantic
+    errors") describes it.
+  source: >-
+    RM UML/classes/org.openehr.rm.common.item_tag.adoc §Invariants;
+    ITS-REST operations/{composition,ehr_status}_tags_update.yaml
+    (responses 200/204/400/404 only) + Requests_and_responses.md §HTTP
+    status codes (the 422 row) — confirmed first-hand.
+  handling: >-
+    Fixed handling: RM-invariant violations answer 422; syntactic
+    failures (non-array body, non-string key, unparseable JSON) stay 400.
+    Reported upstream (UPR-57): assign the branch.
+  disposition: fixed_handling
+  upstream_ref: "UPR-57"
+
+AMB-94:
+  ambiguity: >-
+    The ehr_tags_get filter semantics are unstated in four ways: the
+    description says "filtered by the given one or more tag_key,
+    tag_value, tag_target_path" while all three params are scalar strings
+    (explode:true on a non-array schema is meaningless); how repeats of
+    one param combine and how different params combine is unsaid; the
+    match mode (exact/prefix/substring, case sensitivity) is unsaid; and
+    matching tag_target_path against a tag with no target_path is unsaid.
+  source: >-
+    ITS-REST operations/ehr_tags_get.yaml (the description) vs
+    parameters/query/tag_{key,value,target_path}.yaml (scalar schemas, no
+    description fields at all) — confirmed first-hand.
+  handling: >-
+    Fixed handling: the filters are scalar, AND-combined across
+    parameters, exact-match, case-sensitive; a tag_target_path filter
+    matches only tags carrying exactly that path (an absent path matches
+    no path filter). Reported upstream (UPR-58): define the filter
+    grammar.
+  disposition: fixed_handling
+  upstream_ref: "UPR-58"
+
+AMB-95:
+  ambiguity: >-
+    Duplicate (key, target_path) pairs inside ONE tag-PUT body have no
+    released rule: identity is the pair, but the array schema carries no
+    uniqueItems and no sentence assigns rejection or a merge order.
+  source: >-
+    ITS-REST operations/*_tags_update.yaml requestBody +
+    schemas/common/UpdateItemTag.yaml; Requests_and_responses.md §item-tag
+    headers (the identity sentence) — confirmed first-hand.
+  handling: >-
+    Fixed handling: last-wins — the posted set is deduped on the identity
+    pair with the final occurrence kept, mirroring a full-replace applied
+    left to right. Reported upstream (UPR-59): assign uniqueItems or a
+    merge rule.
+  disposition: fixed_handling
+  upstream_ref: "UPR-59"
+
+AMB-96:
+  ambiguity: >-
+    Empty-string vs absent target_path is identity-affecting and the two
+    released artifacts model it differently: RM types target_path 0..1
+    (absent = no path) with NO non-empty invariant, while the released
+    EHR_STATUS response example writes target_path: "" — under the (key,
+    target_path) identity those would be two distinct tags.
+  source: >-
+    RM UML/classes/org.openehr.rm.common.item_tag.adoc (target_path 0..1;
+    invariants cover key and value only) vs ITS-REST
+    specifications/schemas/ehr/ItemTagOfEhrStatus.yaml (the "" example);
+    the ...OfComposition example uses a real path — confirmed first-hand.
+  handling: >-
+    Fixed handling: "" normalizes to ABSENT at the service seam — one
+    identity, not two; served tags never carry an empty target_path.
+    Reported upstream (UPR-60): pick one representation.
+  disposition: fixed_handling
+  upstream_ref: "UPR-60"
+
+AMB-97:
+  ambiguity: >-
+    The ITEM_TAG released surface carries an editorial defect bundle: the
+    RM invariant Inv_key_valid calls key.is_justified, a function defined
+    NOWHERE (the BASE String class has no is_justified; the enforceable
+    rule must be read off the prose Meaning column, whose "whitespace" is
+    itself undefined); the DELETE 204 reuses "(logically) deleted" wording
+    from the change-control family though an ITEM_TAG has no
+    lifecycle_state; the EHR-wide aggregate declares the
+    COMPOSITION-specific list schema for a response spanning kinds (no
+    200_EHR_ItemTagList file exists); both _updated response files are
+    byte-copies of the _retrieved text ("successfully retrieved" on a
+    PUT); XML is enumerated on every tag Accept/Content-Type while no
+    ITEM_TAG canonical-XML type exists anywhere in ITS-XML and every
+    content block is application/json-only; the released examples pair a
+    HIER_OBJECT_ID target id with type COMPOSITION (a container id with
+    the data-class name) and NO released example anywhere shows a
+    VERSION-targeted tag — the form half the surface exists for; the
+    DELETE descriptions name the parameter "tag_key" while the path
+    declares {key}; the overview names FOLDER as a tag target but no
+    /directory tag route exists and the released directory operations
+    declare no item-tag headers (the wrapper prose is the only channel);
+    the {key} path segment is an unconstrained string with no encoding
+    rule; result ordering and paging are undefined on all three GETs (the
+    EHR-wide list is unbounded); the optional-feature sentence ("If the
+    server does not support ITEM_TAGs...") scopes only the headers and no
+    tag route declares a refusal branch; nothing states tag persistence
+    across new target versions, container-tag reach, or cascade on target
+    deletion; and the whole class is development-RM-only (SPECRM-87) —
+    the one surface in the released ITS-REST whose class link points at
+    RM/development.
+  source: >-
+    RM UML/classes/org.openehr.rm.common.item_tag.adoc + BASE
+    foundation_types string.adoc; ITS-REST specifications/
+    (operations/*tags*.yaml, responses/200_*_ItemTagList_*.yaml,
+    204_deleted.yaml, schemas/ehr/ItemTagOf*.yaml,
+    parameters/path/key.yaml, ehr.openapi.yaml L148-150) +
+    docs/overview/Requests_and_responses.md §item-tag headers; ITS-XML
+    (grep: no ITEM_TAG) — all confirmed first-hand.
+  handling: >-
+    Editorial: the wire follows the RM class + the operation descriptions
+    where they are the only released text; the served OpenAPI documents
+    each defect in place. Reported upstream (UPR-61).
+  disposition: editorial
+  upstream_ref: "UPR-61"
+
 AMB-66:
   ambiguity: >-
     The SM precondition `Pre_no_subject`: `an_ehr_status.subject = Void`, on

--- a/tools/cnf-runner/artifacts/vocab/wire_surface.yaml
+++ b/tools/cnf-runner/artifacts/vocab/wire_surface.yaml
@@ -641,7 +641,7 @@ elements:
     source: "RM common master07-tags.adoc ITEM_TAG.target (may be a VERSIONED_OBJECT<T> or a VERSION<T>); ITS-REST Requests_and_responses.md §item-tag headers"
     exception:
       reason: coverage_gap
-      note: "server behaviour fixed + DB-tested (#365); the disjointness now also holds through the wrapper-header write/echo path (#398, app/ehrbase-rest/tests/headers.rs reads both collections back through composition_tags_get after a two-header write); runner tag verbs land with the #288 derivation fix"
+      note: "server behaviour fixed + DB-tested (#365); the disjointness now also holds through the wrapper-header write/echo path (#398, app/ehrbase-rest/tests/headers.rs reads both collections back through composition_tags_get after a two-header write); the group-8 audit (#384) added the target-guard 404s (nonexistent/foreign/wrong-kind — AMB-91), the EHR-wide listing guard, the empty-target_path normalization (AMB-96), and the register set AMB-91..97 with wire tests (headers.rs tag_* batteries); runner tag verbs land with the #288 derivation fix"
   - id: item-tag-rm-target-shape
     description: "ITEM_TAG.target is emitted as the RM UID_BASED_ID (HIER_OBJECT_ID container / OBJECT_VERSION_ID version), never an OBJECT_REF wrapper."
     source: "RM common master07-tags.adoc ITEM_TAG (target: UID_BASED_ID); the RELEASED RM wins over the stalled OAS ItemTag schema"


### PR DESCRIPTION
From the #384 group-8 audit (findings F-3 + F-4).

## Register + upstream (authored in-session, confirmed first-hand)
AMB-91 wrong-kind-uid 404 (UPR-55) · AMB-92 return=identifier → applied minimal (UPR-56) · AMB-93 RM-invariant violations → 422 (UPR-57) · AMB-94 the filter grammar (UPR-58) · AMB-95 duplicate pairs last-wins (UPR-59) · AMB-96 ""→absent target_path (UPR-60) · AMB-97 the editorial defect bundle incl. the undefined `is_justified`, XML-with-no-XML-type, the never-shown VERSION-target example, FOLDER tags unreachable through the released op files, and the development-RM provenance of the whole class (UPR-61).

## Coverage
Tags remain honest wire_surface boundaries (no SM operation, no runner tag verbs — they land with #288); the boundary note now records the group-8 wave. The DB-backed wire coverage is the four headers.rs batteries: the #477 trio (target guards on GET/DELETE with all miss kinds, ""-normalization identity, the EHR-wide listing guard) plus the new tag-discipline battery (`[]` clear-all per the released sentence, identifier→minimal with Preference-Applied pinned, delete-by-key SET semantics + the released non-idempotent second-delete 404, AND/exact ehr_tags_get filters).

## Gates
`cnf-runner validate --specs` 541/124/0 (unchanged — no catalogue cases; boundaries only); fmt + clippy 0 warnings; the new battery green. The zero-drift pipeline runs next as the group-8 close.

Closes #476