### PR TITLE
fix(cnf): group-9 triage — numeric with-values promote to URL template vars; bound-but-unrenderable optional refs are loud

### DIFF
--- a/.claude/agent-memory/cnf-triage/MEMORY.md
+++ b/.claude/agent-memory/cnf-triage/MEMORY.md
@@ -11,4 +11,5 @@
 - [Two EHR_STATUS payload sites PR #431 missed](cnf-red-2026-07-27-ehr-status-payloads.md) — ehr_status recipe + contribution case core; catalogue bin; sweep command included
 - [Contained uid is a recommendation](contained-uid-is-a-recommendation.md) — data/uid presence is SHOULD in every released source; cannot gate CORE; AMB-65 fixes only the FORM
 - [AMB-54(b) contribution 412 ETag over-promise](amb54-contribution-412-etag-overpromise.md) — CATALOGUE bin: no If-Match on the contribution route ⇒ the ETag SHOULD's antecedent is false, and multi-member commits have no unique latest version_uid
+- [Non-string `with:` values dropped from URL/header templates](runner-nonstring-with-values-dropped.md) — RUNNER bin: merge_with_vars promotes only strings; `url_fetch: 4` never reaches `?fetch=`; body path is unaffected
 - [Upstream EHRbase Java non-conformance (#266)](upstream-ehrbase-java-nonconformance.md) — EHRbase 2.34.0 400s the spec-standard QUOTED If-Match (composition/ehr_status update classes) + 404s the STABLE item-tag surface; our driver/pack spec-valid, outcome (b), record stands

--- a/.claude/agent-memory/cnf-triage/runner-nonstring-with-values-dropped.md
+++ b/.claude/agent-memory/cnf-triage/runner-nonstring-with-values-dropped.md
@@ -1,0 +1,35 @@
+---
+name: runner-nonstring-with-values-dropped
+description: RUNNER defect pattern — numeric/bool `with:` values are never promoted into the VarStore, so ${var?} in a binding query/header template silently drops the parameter; only a with-key literally named like the parameter survives (build_url backfill)
+metadata:
+  type: project
+---
+
+`HttpDriver::merge_with_vars` (`tools/cnf-runner/src/exec/driver.rs`) promotes a
+step's `with:` entries into the template VarStore **only when the JSON value is a
+`Value::String`**. A numeric/bool `with:` value (e.g. `url_fetch: 4`) is therefore
+unbound when `build_url`/`build_headers` render `"${url_fetch?}"`; the ref is
+optional, so the parameter is **silently omitted** from the wire — no error, no
+inconclusive row. The structured-BODY path does not have this bug
+(`select_body` → `RequestBody::Structured` promotes non-strings as
+`Captured::Body`), so body forms of the same value work — the asymmetry is the
+tell.
+
+Why most numeric query params still work: `build_url` has a second loop that
+backfills `with.get(<query-param-name>)` (stringifying any JSON scalar). So a case
+binding `fetch: 100` reaches `?fetch=100` **by name coincidence**, while a case
+binding `url_fetch: 4` for a query slot named `fetch` sends nothing.
+
+**Why:** first confirmed 2026-07-27 triaging
+`I_QUERY_SERVICE.execute_ad_hoc_query-post_fetch_url_only` (row count 10 != 4) —
+attribution: runner machinery, not the app; the app's
+`merge_body_and_url_i64` (`app/ehrbase-rest/src/api/query/response.rs`) reads
+`?fetch=` on both POST arms correctly.
+
+**How to apply:** on any red row where the SUT "ignored" a URL/header parameter,
+first check whether the case's `with:` key name differs from the binding's
+parameter name AND the value is non-string — that combination means the parameter
+never left the runner. Same fault silently hollows
+`execute_stored_query-protocol_fetch_reserved` (its URL `fetch=5` is never sent;
+the case passes on the body half alone). Related:
+[[runner-driver-gaps]].

--- a/tools/cnf-runner/src/exec/driver.rs
+++ b/tools/cnf-runner/src/exec/driver.rs
@@ -215,8 +215,21 @@ impl<'a> HttpDriver<'a> {
             for (name, template) in query {
                 match assertions::render_template(template, vars) {
                     Ok(value) => params.push((name.clone(), value)),
-                    // optional refs that are unbound omit the parameter
-                    Err(_) if template_is_optional(template) => {}
+                    // An optional ref that is genuinely unbound omits the
+                    // parameter — but a name the step's `with:` DOES carry
+                    // (just not as a renderable scalar) is a case-authoring
+                    // or promotion defect and must be loud, never a silent
+                    // drop (the group-9 triage: a dropped bound parameter
+                    // masqueraded as a SUT failure).
+                    Err(e) if template_is_optional(template) => {
+                        if let Some(referenced) = template_ref_name(template)
+                            && with.contains_key(referenced)
+                        {
+                            return Err(format!(
+                                "query {name}: the optional ref ${{{referenced}?}} is bound in                                  the step's `with:` but did not render as a scalar: {e}"
+                            ));
+                        }
+                    }
                     Err(e) => return Err(format!("query {name}: {e}")),
                 }
             }
@@ -785,6 +798,15 @@ fn template_is_optional(template: &Template) -> bool {
     template
         .as_single_ref()
         .is_some_and(|r| matches!(r, ValueRef::Capture { optional: true, .. }))
+}
+
+/// The capture name an optional single-ref template references (`${name?}`
+/// → `name`), for the bound-but-unrendered diagnostic.
+fn template_ref_name(template: &Template) -> Option<&str> {
+    template.as_single_ref().and_then(|r| match r {
+        ValueRef::Capture { name, .. } => Some(name.as_str()),
+        _ => None,
+    })
 }
 
 /// Minimal base64 (standard alphabet, padding) — avoids a crypto dep for
@@ -1483,11 +1505,24 @@ impl HttpDriver<'_> {
     fn merge_with_vars(vars: &VarStore, with: &BTreeMap<String, Value>) -> VarStore {
         let mut merged = vars.clone();
         for (key, value) in with {
-            if let Value::String(s) = value
+            // Every SCALAR `with:` value is promoted into the template vars —
+            // numbers and booleans render as their wire text exactly like the
+            // structured-body path does (a number-typed `url_fetch: 4` must
+            // reach a `${url_fetch?}` URL slot; silently skipping non-strings
+            // turned a runner gap into a fake SUT failure — the group-9
+            // triage). Objects/arrays stay out: they have no scalar wire
+            // text.
+            let text = match value {
+                Value::String(s) => Some(s.clone()),
+                Value::Number(n) => Some(n.to_string()),
+                Value::Bool(b) => Some(b.to_string()),
+                _ => None,
+            };
+            if let Some(text) = text
                 && let Ok(name) = CaptureName::parse(key)
                 && merged.scalar(&name).is_none()
             {
-                merged.set(name, Captured::Scalar(s.clone()));
+                merged.set(name, Captured::Scalar(text));
             }
         }
         merged
@@ -1983,6 +2018,44 @@ mod tests {
             }
         }))
         .unwrap()
+    }
+
+    /// The group-9 triage regression: a NUMBER-typed `with:` value must
+    /// promote into the template vars and render on an optional URL slot —
+    /// `url_fetch: 4` reaching `${url_fetch?}` emits `?fetch=4`; silently
+    /// skipping non-string scalars dropped the parameter and masqueraded as
+    /// a SUT failure.
+    #[test]
+    fn numeric_with_values_render_on_optional_url_slots() {
+        let binding: OperationBinding = serde_json::from_value(serde_json::json!({
+            "sm_operation": "I_QUERY_SERVICE.execute_ad_hoc_query",
+            "its": "its-rest",
+            "request": {
+                "method": "POST",
+                "path": "/query/aql",
+                "query": { "fetch": "${url_fetch?}" }
+            },
+            "outcomes": { "ok": { "status": 200 } }
+        }))
+        .unwrap();
+        let mut with = BTreeMap::new();
+        with.insert("url_fetch".to_owned(), serde_json::json!(4));
+        let vars = HttpDriver::merge_with_vars(&VarStore::default(), &with);
+        let url = HttpDriver::build_url(&binding, "http://sut", &with, &vars).unwrap();
+        assert_eq!(url, "http://sut/query/aql?fetch=4");
+
+        // An unbound optional slot still omits the parameter.
+        let empty = BTreeMap::new();
+        let vars = HttpDriver::merge_with_vars(&VarStore::default(), &empty);
+        let url = HttpDriver::build_url(&binding, "http://sut", &empty, &vars).unwrap();
+        assert_eq!(url, "http://sut/query/aql");
+
+        // A bound-but-unrenderable (object) value is LOUD, never a drop.
+        let mut with = BTreeMap::new();
+        with.insert("url_fetch".to_owned(), serde_json::json!({"n": 4}));
+        let vars = HttpDriver::merge_with_vars(&VarStore::default(), &with);
+        let err = HttpDriver::build_url(&binding, "http://sut", &with, &vars).unwrap_err();
+        assert!(err.contains("did not render as a scalar"), "{err}");
     }
 
     #[test]


### PR DESCRIPTION
The group-9 closing run went 484/1/0. cnf-triage attributed the red row (`execute_ad_hoc_query-post_fetch_url_only`: row count 10 != expected 4) to RUNNER MACHINERY: `merge_with_vars` promoted only string `with:` values, so the numeric `url_fetch: 4` never bound and the optional `${url_fetch?}` URL slot silently dropped the parameter — the SUT correctly answered the request it actually received. The controlled contrast: the sibling `post_fetch_url_and_body` passed via the name-coincidence backfill loop, isolating the fault.

Fixes (runner only — no app or catalogue edit):
- Number/Bool `with:` scalars promote as their wire text (mirroring the structured-body path).
- Hardening: an optional URL template whose referenced name IS carried by the step's `with:` but did not render is now a loud error — a silently-dropped bound parameter is exactly what masqueraded as a SUT failure here.
- Regression test pins render / unbound-omit / bound-object-loud.

Triage also flagged `protocol_fetch_reserved` as vacuously passing (its URL fetch was never sent) — it genuinely gates its claim from this fix onward; the re-run verifies.

Gates: fmt, clippy 0, nextest `cnf-runner` 172 passed, validate 554/128/0. Red-run artifacts not committed; the pipeline re-runs next.