### PR TITLE
chore(cnf): ratchet the conformance baseline — group-9 closing zero-drift run

### DIFF
--- a/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
@@ -7,12 +7,12 @@ Runner: cnf-runner 3.11.0 · verification pack: passed
 
 | Status | Count |
 | --- | --- |
-| passed | 472 |
+| passed | 485 |
 | failed | 0 |
 | errored | 0 |
 | skipped | 0 |
 | not_applicable | 69 |
-| total | 541 |
+| total | 554 |
 
 ## By chapter
 
@@ -32,7 +32,7 @@ Runner: cnf-runner 3.11.0 · verification pack: passed
 | I_EHR_EXTRACT_SERVICE | 0 | 0 | 0 | 0 | 10 |
 | I_EHR_SERVICE | 16 | 0 | 0 | 0 | 0 |
 | I_EHR_STATUS | 29 | 0 | 0 | 0 | 0 |
-| I_QUERY_SERVICE | 18 | 0 | 0 | 0 | 0 |
+| I_QUERY_SERVICE | 31 | 0 | 0 | 0 | 0 |
 | I_TDD_SERVICE | 0 | 0 | 0 | 0 | 4 |
 | SEC | 6 | 0 | 0 | 0 | 0 |
 | SF | 57 | 0 | 0 | 0 | 1 |
@@ -73,7 +73,7 @@ Percentiles re-derive from the embedded HDR V2 histograms; the class verdict is 
 
 ## Honesty
 
-Coverage: 472 of 541 selected cases driven.
+Coverage: 485 of 554 selected cases driven.
 
 Not-executed verdicts (each cited):
 

--- a/docs/conformance/ehrbase-rs/badge.json
+++ b/docs/conformance/ehrbase-rs/badge.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "openEHR conformance",
-  "message": "CORE+STANDARD PASS \u00b7 472/472 cases",
+  "message": "CORE+STANDARD PASS \u00b7 485/485 cases",
   "color": "brightgreen"
 }

--- a/docs/conformance/ehrbase-rs/results.json
+++ b/docs/conformance/ehrbase-rs/results.json
@@ -2833,6 +2833,12 @@
       "rows_total": 2
     },
     {
+      "case": "I_QUERY_SERVICE.execute_ad_hoc_query-fetch_over_limit",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_QUERY_SERVICE.execute_ad_hoc_query-fetch_with_top",
       "status": "passed",
       "rows_driven": 1,
@@ -2857,6 +2863,24 @@
       "rows_total": 1
     },
     {
+      "case": "I_QUERY_SERVICE.execute_ad_hoc_query-post_fetch_url_and_body",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_QUERY_SERVICE.execute_ad_hoc_query-post_fetch_url_only",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_QUERY_SERVICE.execute_ad_hoc_query-result_set_etag",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_QUERY_SERVICE.execute_ad_hoc_query-terminology_expand_matches",
       "status": "passed",
       "rows_driven": 1,
@@ -2875,6 +2899,12 @@
       "rows_total": 1
     },
     {
+      "case": "I_QUERY_SERVICE.execute_ad_hoc_query-unknown_ehr_scope",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_QUERY_SERVICE.execute_ad_hoc_query-where_magnitude",
       "status": "passed",
       "rows_driven": 1,
@@ -2888,6 +2918,54 @@
     },
     {
       "case": "I_QUERY_SERVICE.execute_stored_query-empty_db",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_QUERY_SERVICE.execute_stored_query-post_empty_body",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_QUERY_SERVICE.execute_stored_query-protocol_fetch_reserved",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_QUERY_SERVICE.execute_stored_query-reserved_name",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_QUERY_SERVICE.execute_stored_query-version_exact",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_QUERY_SERVICE.execute_stored_query-version_major_prefix",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_QUERY_SERVICE.execute_stored_query-version_malformed_selector",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_QUERY_SERVICE.execute_stored_query-version_minor_prefix",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_QUERY_SERVICE.execute_stored_query-version_unknown_major",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1

--- a/docs/conformance/ehrbase-rs/verdicts.json
+++ b/docs/conformance/ehrbase-rs/verdicts.json
@@ -183,7 +183,7 @@
     }
   ],
   "coverage": {
-    "selected": 541,
-    "driven": 472
+    "selected": 554,
+    "driven": 485
   }
 }

--- a/website/book/src/conformance-assets/conformance-chapter-bars.svg
+++ b/website/book/src/conformance-assets/conformance-chapter-bars.svg
@@ -56,9 +56,9 @@ text { fill: #c3c2b7; }
 
 <text x="304.3703703703703" y="115" class="seg-label-dim" text-anchor="middle">16</text><text x="336.074074074074" y="115" class="muted">52</text>
 <text x="166" y="149" text-anchor="end">Query</text>
-<rect x="174" y="132" width="53.33333333333333" height="26" class="bar-passed"/>
+<rect x="174" y="132" width="91.85185185185185" height="26" class="bar-passed"/>
 
-<text x="200.66666666666666" y="149" class="seg-label" text-anchor="middle">18</text><text x="235.33333333333331" y="149" class="muted">18</text>
+<text x="219.92592592592592" y="149" class="seg-label" text-anchor="middle">31</text><text x="273.85185185185185" y="149" class="muted">31</text>
 <text x="166" y="183" text-anchor="end">Demographic</text>
 <rect x="174" y="166" width="47.407407407407405" height="26" class="bar-passed"/>
 


### PR DESCRIPTION
Group-9 (#385, Query API) close-out: the full CNF pipeline on a freshly composed SUT after the complete group-9 fix wave (PRs #484, #485, #486, #487).

## Run
- 554 case-records: **485 passed / 0 failed / 0 errored / 69 registered N/A**
- **CORE+STANDARD PASS**, 0 review findings
- The first closing run's single red row was triage-attributed to RUNNER MACHINERY (numeric `with:` values never promoted to URL template vars — the bound `fetch=4` silently dropped and the SUT correctly answered what it received) and fixed in PR #487 with a loudness hardening + regression test; this re-run is clean, and the previously-vacuous `protocol_fetch_reserved` now genuinely gates its claim
- Baseline ratchets upward only: +13 vs the 472-passed groups-7/8 baseline
- Conformance visuals regenerated from the committed artifacts

## Group-9 record
Audit findings + fixes on #385 (#481 the docs-text-wins codegen override + POST URL forms, #482 served-OpenAPI completeness, #483 13 coverage cases + AMB-98…103 + UPR-62…67); the register corrections adopted the shipped wire where the audit proposal disagreed (unknown ehr_id → 404 realizing SM's error; malformed selectors → 404).

Closes #385