### PR TITLE
fix(templates): ADL1.4 unparseable-upload 400 split + ADL2 upload text/plain 415 guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **Template-upload rejection statuses follow the released split** (#489).
+  An ADL 1.4 OPT upload whose body is not well-formed XML now answers
+  `400 Bad Request` (the released "syntactically invalid … content" branch)
+  instead of `422`; well-formed XML that is not a valid OPT stays `422`.
+  The ADL2 template upload now refuses a payload declaring a media type
+  other than its single `text/plain` body type with `415 Unsupported Media
+  Type` (an absent `Content-Type` remains accepted), mirroring the ADL 1.4
+  guard.
+
 - **Stored-query POST bodies accept `{}`; the query POSTs accept the URL
   parameter forms** (#481). The three body members of the stored-execute
   body are optional (the docs text gives `offset` a default and makes

--- a/app/ehrbase-rest/src/api/definition/template_adl2.rs
+++ b/app/ehrbase-rest/src/api/definition/template_adl2.rs
@@ -88,8 +88,13 @@ pub(super) async fn upload(state: &AppState, parts: &RequestParts) -> Result<Res
     // off the header map through the shared negotiation predicates, so every
     // write route resolves (and declares) it the same way.
     params::build::<DefinitionTemplateAdl2UploadParams>(&parts.path, parts.query.as_deref(), h)?;
-    // ADL2 arrives as text/plain source (dev-OAS: Content-Type text/plain, body
-    // `OperationalTemplateV2` | string).
+    // ADL2 arrives as text/plain source — the operation's single declared body
+    // type (`operations/definition_template_adl2_upload.yaml`). A payload
+    // DECLARING another media type cannot be processed as that type, so it is
+    // refused 415 before parsing (`Resources.md` §format rules), exactly as
+    // the ADL 1.4 sibling refuses non-XML; an absent `Content-Type` declares
+    // nothing to refuse (the header is a client MAY).
+    negotiate::require_text_plain(h)?;
     let source = negotiate::text_body(&parts.body)?;
     // The engine validates: an unparseable source is a `400` (BadRequest), an
     // AOM2-invalid one a `422` carrying the rule codes (ValidationFailed), a

--- a/app/ehrbase-rest/src/overview/negotiate.rs
+++ b/app/ehrbase-rest/src/overview/negotiate.rs
@@ -412,6 +412,31 @@ pub(crate) fn require_content_type(
     }
 }
 
+/// Refuse a request whose `Content-Type` DECLARES a media type other than
+/// `text/plain` — the single body type of the ADL2 template upload
+/// (`docs/specs/openehr/ITS-REST/specifications/operations/
+/// definition_template_adl2_upload.yaml` declares `text/plain` as the only
+/// request content type). The mirror of [`require_content_type`] for the one
+/// route whose body type is outside the [`WireFormat`] vocabulary; an ABSENT
+/// `Content-Type` is accepted for the same Resources.md client-MAY reason.
+///
+/// # Errors
+/// [`ApiError::UnsupportedMediaType`] when the declared media type is not
+/// `text/plain` (`Resources.md` §format rules: a payload the service cannot
+/// process as the operation's format "MUST respond with HTTP status code
+/// `415 Unsupported Media Type`").
+pub(crate) fn require_text_plain(headers: &HeaderMap) -> Result<(), ApiError> {
+    let Some(declared) = header_str(headers, header::CONTENT_TYPE) else {
+        return Ok(());
+    };
+    if media_token(&declared).eq_ignore_ascii_case("text/plain") {
+        return Ok(());
+    }
+    Err(ApiError::UnsupportedMediaType(format!(
+        "this operation accepts text/plain only, got {declared}"
+    )))
+}
+
 fn parse_json(body: &Bytes) -> Result<serde_json::Value, ApiError> {
     serde_json::from_slice(body)
         .map_err(|e| ApiError::BadRequest(format!("invalid JSON body: {e}")))
@@ -1157,6 +1182,32 @@ mod tests {
                 matches!(err, ApiError::UnsupportedMediaType(_)),
                 "Resources.md §XML Format: a payload the service cannot process as \
                  XML MUST be 415, got {err:?} for {refused}"
+            );
+        }
+    }
+
+    /// The `text/plain` mirror of [`require_content_type`] for the ADL2
+    /// upload: absent header accepted (client MAY), parameters ignored,
+    /// any other declared type → `415` (Resources.md §format rules).
+    #[test]
+    fn require_text_plain_refuses_only_a_declared_foreign_type() {
+        assert!(
+            require_text_plain(&HeaderMap::new()).is_ok(),
+            "an absent Content-Type declares nothing to refuse"
+        );
+        for accepted in ["text/plain", "text/plain; charset=utf-8", "Text/Plain"] {
+            assert!(
+                require_text_plain(&headers(&[("content-type", accepted)])).is_ok(),
+                "{accepted} declares the operation's single body type"
+            );
+        }
+        for refused in ["application/xml", "application/json", "text/html"] {
+            let err =
+                require_text_plain(&headers(&[("content-type", refused)])).expect_err("refused");
+            assert!(
+                matches!(err, ApiError::UnsupportedMediaType(_)),
+                "a payload the service cannot process as text/plain MUST be \
+                 415, got {err:?} for {refused}"
             );
         }
     }

--- a/app/ehrbase-rest/tests/definition_adl2_http.rs
+++ b/app/ehrbase-rest/tests/definition_adl2_http.rs
@@ -543,3 +543,71 @@ async fn etag_is_the_resolved_hrid_on_upload_and_every_get() {
          version changes (overview §\"ETag and Last-Modified\")"
     );
 }
+
+// ── POST: a non-text/plain payload type is 415, never a parse-time 400 ──────
+// The operation declares `text/plain` as its single request body type
+// (`operations/definition_template_adl2_upload.yaml`); a payload DECLARING
+// another media type cannot be processed as it — `Resources.md` §format rules:
+// "If the service cannot process the request payload as … format, it MUST
+// respond with HTTP status code 415 Unsupported Media Type". Mirrors the
+// ADL 1.4 sibling's guard.
+
+#[tokio::test]
+async fn adl2_upload_with_xml_content_type_is_415() {
+    let (_pg, app) = app().await;
+    let (status, _headers, body) = send(
+        &app,
+        Request::builder()
+            .method("POST")
+            .uri(format!("{BASE}/definition/template/adl2"))
+            .header(header::CONTENT_TYPE, "application/xml")
+            .body(Body::from(source()))
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::UNSUPPORTED_MEDIA_TYPE,
+        "a declared non-text/plain payload type is refused before parsing: {body}"
+    );
+}
+
+#[tokio::test]
+async fn adl2_upload_without_content_type_is_created() {
+    let (_pg, app) = app().await;
+    let (status, _headers, body) = send(
+        &app,
+        Request::builder()
+            .method("POST")
+            .uri(format!("{BASE}/definition/template/adl2"))
+            .body(Body::from(source()))
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "an absent Content-Type declares nothing to refuse (the header is a \
+         client MAY): {body}"
+    );
+}
+
+#[tokio::test]
+async fn adl2_upload_with_charset_parameter_is_created() {
+    let (_pg, app) = app().await;
+    let (status, _headers, body) = send(
+        &app,
+        Request::builder()
+            .method("POST")
+            .uri(format!("{BASE}/definition/template/adl2"))
+            .header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
+            .body(Body::from(source()))
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "media-type parameters do not change the declared type: {body}"
+    );
+}

--- a/app/ehrbase-rest/tests/template_adl14_http.rs
+++ b/app/ehrbase-rest/tests/template_adl14_http.rs
@@ -270,3 +270,67 @@ async fn opt_upload_without_content_type_is_created() {
     let (status, body) = upload(&app, None).await;
     assert_eq!(status, StatusCode::CREATED, "{body}");
 }
+
+// ── POST: the 400-vs-422 invalid-payload split ───────────────────────────────
+// `responses/400.yaml`: "400 Bad Request is returned when the request could
+// not be parsed or is invalid (e.g. … syntactically invalid … content)" — the
+// released branch for a payload that is not well-formed XML. A WELL-FORMED
+// document that is not a valid OPT is a semantic error (overview
+// `Requests_and_responses.md` §HTTP status codes, the 422 row; no template
+// operation declares 422, so the semantic branch is register-adjudicated).
+
+/// `POST /definition/template/adl1.4` with an arbitrary body under
+/// `Content-Type: application/xml`.
+async fn upload_body(app: &Router, body: &str) -> (StatusCode, String) {
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("{BASE}/definition/template/adl1.4"))
+                .header(header::CONTENT_TYPE, XML_MIME)
+                .body(Body::from(body.to_owned()))
+                .unwrap(),
+        )
+        .await
+        .expect("response");
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.expect("body").to_bytes();
+    (status, String::from_utf8_lossy(&bytes).into_owned())
+}
+
+#[tokio::test]
+async fn opt_upload_malformed_xml_is_400() {
+    let (_pg, app) = empty_app().await;
+    let (status, body) = upload_body(&app, "<template><language></template>").await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "mismatched tags are syntactically invalid content — the released 400 \
+         branch (responses/400.yaml), never 422: {body}"
+    );
+}
+
+#[tokio::test]
+async fn opt_upload_empty_body_is_400() {
+    let (_pg, app) = empty_app().await;
+    let (status, body) = upload_body(&app, "").await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "an empty document has no root element — not well-formed XML, the \
+         released 400 branch (responses/400.yaml): {body}"
+    );
+}
+
+#[tokio::test]
+async fn opt_upload_well_formed_non_opt_is_422() {
+    let (_pg, app) = empty_app().await;
+    let (status, body) = upload_body(&app, "<not_an_opt/>").await;
+    assert_eq!(
+        status,
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "well-formed XML that does not decode as an OPT is the semantic 422 \
+         branch (overview §HTTP status codes), not the syntactic 400: {body}"
+    );
+}

--- a/app/ehrbase/src/service/definition/adl14.rs
+++ b/app/ehrbase/src/service/definition/adl14.rs
@@ -248,8 +248,11 @@ impl EhrbaseService {
     ///
     /// # Errors
     ///
-    /// - Unparseable / structurally invalid OPT XML → `invalid_template`
-    ///   (`422`).
+    /// - Not well-formed XML → bad request (`400` — the released
+    ///   "syntactically invalid … content" branch,
+    ///   ITS-REST `responses/400.yaml`).
+    /// - Well-formed but undecodable / structurally invalid OPT XML →
+    ///   `invalid_template` (`422`).
     /// - A template with the same `template_id` already stored → conflict
     ///   (`409`).
     /// - A database failure (`exception` → `500`).

--- a/app/ehrbase/src/templates/ingest.rs
+++ b/app/ehrbase/src/templates/ingest.rs
@@ -35,16 +35,55 @@ use crate::service::error::ServiceError;
 
 /// Parse OPT 1.4 canonical XML into an [`OperationalTemplate`].
 ///
-/// A codec failure is a semantic error on the artefact, not a transport error:
-/// the XML negotiated fine at the REST edge but does not decode as a
-/// well-formed OPT — ITS-REST `responses/422.yaml` ("semantic validation
-/// errors" on a syntactically convertible payload).
+/// Failure classification follows the ITS-REST status split: a payload that is
+/// not well-formed XML at all is *syntactically invalid content* — the released
+/// `400` branch (`docs/specs/openehr/ITS-REST/specifications/responses/400.yaml`:
+/// "the request could not be parsed or is invalid (e.g. … syntactically
+/// invalid … content)") — while well-formed XML that does not decode as an OPT
+/// is a semantic error on the artefact (the overview status table's `422` row,
+/// `docs/specs/openehr/ITS-REST/specifications/docs/overview/
+/// Requests_and_responses.md` §HTTP status codes; no template operation
+/// declares `422`, so the semantic branch is register-adjudicated).
 ///
 /// # Errors
 ///
-/// [`ServiceError::Unprocessable`] (→ ITS-REST `422`) when the XML does not
-/// decode as an OPT 1.4 `OPERATIONAL_TEMPLATE` document.
+/// - [`ServiceError::BadRequest`] (→ ITS-REST `400`) when the payload is not
+///   well-formed XML (including an empty document).
+/// - [`ServiceError::Unprocessable`] (→ ITS-REST `422`) when well-formed XML
+///   does not decode as an OPT 1.4 `OPERATIONAL_TEMPLATE` document.
 pub(crate) fn parse_opt(xml: &str) -> Result<OperationalTemplate, ServiceError> {
+    require_well_formed_xml(xml)?;
     openehr_its::opt14::from_xml(xml)
         .map_err(|e| ServiceError::Unprocessable(format!("invalid OPT 1.4 XML: {e}")))
+}
+
+/// The well-formedness gate ahead of the OPT decode: scan the document with a
+/// bare `quick_xml::Reader` and reject anything that is not one well-formed
+/// XML document with a root element. This isolates the released `400` branch
+/// (syntactically invalid content) from the semantic `422` branch the tolerant
+/// codec reports past it.
+fn require_well_formed_xml(xml: &str) -> Result<(), ServiceError> {
+    let mut reader = quick_xml::Reader::from_str(xml);
+    let mut saw_root = false;
+    loop {
+        match reader.read_event() {
+            Ok(quick_xml::events::Event::Eof) => break,
+            Ok(quick_xml::events::Event::Start(_) | quick_xml::events::Event::Empty(_)) => {
+                saw_root = true;
+            }
+            Ok(_) => {}
+            Err(e) => {
+                return Err(ServiceError::BadRequest(format!(
+                    "syntactically invalid XML content: {e}"
+                )));
+            }
+        }
+    }
+    if saw_root {
+        Ok(())
+    } else {
+        Err(ServiceError::BadRequest(
+            "syntactically invalid XML content: the document has no root element".to_owned(),
+        ))
+    }
 }

--- a/app/ehrbase/src/templates/store.rs
+++ b/app/ehrbase/src/templates/store.rs
@@ -61,9 +61,12 @@ impl EhrbaseService {
     ///
     /// # Errors
     ///
-    /// - [`ServiceError::Unprocessable`] (→ `422`) — the XML does not decode as
-    ///   an OPT 1.4 document, or the decoded OPT has an empty `template_id` or
-    ///   `concept`.
+    /// - [`ServiceError::BadRequest`] (→ `400`) — the payload is not
+    ///   well-formed XML (ITS-REST `responses/400.yaml`: "syntactically
+    ///   invalid … content").
+    /// - [`ServiceError::Unprocessable`] (→ `422`) — well-formed XML that does
+    ///   not decode as an OPT 1.4 document, or a decoded OPT with an empty
+    ///   `template_id` or `concept`.
     /// - The structural gate
     ///   (`crate::validation::validate_opt_structure`) and the
     ///   AOM2/08 artefact-validity catalogue


### PR DESCRIPTION
Closes #489.

Group-10 audit findings F-1 + F-2 (adjudication + citations: the findings comment on #386).

**F-1 — ADL 1.4 upload, 400-vs-422 split.** A syntactically-unparseable XML body answered 422; the released `ITS-REST specifications/responses/400.yaml` trigger ("could not be parsed or is invalid (e.g. … syntactically invalid … content)") owns that branch. A well-formedness gate (`app/ehrbase/src/templates/ingest.rs::require_well_formed_xml`, a bare quick-xml scan requiring one well-formed document with a root element) now runs ahead of the OPT decode: not-well-formed (incl. empty document) → 400 `BadRequest`; well-formed-but-not-an-OPT stays 422 `Unprocessable` (the overview status table's semantic row — no template operation declares 422, so the semantic branch is register-adjudicated in #491). Mirrors the split the ADL2 chain already had.

**F-2 — ADL2 upload, declared-body-type guard.** The operation declares `text/plain` as its single request body type; a payload declaring another media type was previously fed to the ADL parser and died 400. New `negotiate::require_text_plain` (the `text/plain` mirror of `require_content_type`, outside the `WireFormat` vocabulary by design) refuses it 415 before parsing (`Resources.md` §format rules); absent `Content-Type` stays accepted (client MAY), media-type parameters ignored.

**Tests:** `template_adl14_http` — malformed-XML 400, empty-body 400, well-formed-non-OPT 422; `definition_adl2_http` — xml-content-type 415, absent-content-type 201, charset-parameter 201; unit battery for `require_text_plain`.

**Gates:** clippy (both crates, all targets) clean; nextest `-p ehrbase -p ehrbase-rest` 1165 passed / 0 failed. Catalogue re-adjudication of the `empty file` fixture row lands in #491.