### PR TITLE
fix(templates): ADL2 syntax failures answer 400; ADL1.4 AOM2 artefact violations answer 422

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **Template rejection statuses are coherent across both upload routes**
+  (#493). An ADL2 source with grammar-level syntax errors now answers
+  `400 Bad Request` (the released "syntactically invalid … content" branch)
+  instead of `422`; AOM2 validation-phase failures on a parsed source keep
+  answering `422` with the rule codes in `validationErrors`. On the ADL 1.4
+  side, an AOM2 artefact-validity violation on a successfully parsed OPT now
+  answers `422` with the rule code in `validationErrors` (previously `400`) —
+  syntax gates `400`, semantics gate `422`, on both routes.
+
 - **Template-upload rejection statuses follow the released split** (#489).
   An ADL 1.4 OPT upload whose body is not well-formed XML now answers
   `400 Bad Request` (the released "syntactically invalid … content" branch)

--- a/app/ehrbase-rest/tests/definition_adl2_http.rs
+++ b/app/ehrbase-rest/tests/definition_adl2_http.rs
@@ -611,3 +611,43 @@ async fn adl2_upload_with_charset_parameter_is_created() {
         "media-type parameters do not change the declared type: {body}"
     );
 }
+
+#[tokio::test]
+async fn upload_unparseable_source_is_400() {
+    let (_pg, app) = app().await;
+    // Content that fails the ADL2 grammar outright is *syntactically invalid
+    // content* — the released 400 branch declared on the upload
+    // (`responses/400.yaml`: "the request could not be parsed or is invalid
+    // (e.g. ... syntactically invalid ... content)") — never the semantic 422
+    // that AOM2 validation-phase failures (V-codes) carry.
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("{BASE}/definition/template/adl2"))
+        .header(header::CONTENT_TYPE, "text/plain")
+        .body(Body::from("this is not adl2 at all {{{"))
+        .unwrap();
+    let (status, _headers, body) = send(&app, req).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "an unparseable ADL2 source is the syntactic 400 branch: {body}"
+    );
+}
+
+#[tokio::test]
+async fn upload_empty_source_is_400() {
+    let (_pg, app) = app().await;
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("{BASE}/definition/template/adl2"))
+        .header(header::CONTENT_TYPE, "text/plain")
+        .body(Body::empty())
+        .unwrap();
+    let (status, _headers, body) = send(&app, req).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "an empty body matches no ADL2 production — syntactically invalid \
+         content (responses/400.yaml): {body}"
+    );
+}

--- a/app/ehrbase/src/service/definition/adl14.rs
+++ b/app/ehrbase/src/service/definition/adl14.rs
@@ -620,10 +620,12 @@ fn archetype_validate(adl: &str) -> Result<(), ServiceError> {
     }
 }
 
-/// Map an ADL 1.4 parse failure to a [`ServiceError::ValidationFailed`] carrying
-/// the S-code mnemonics — an unparseable source is an invalid archetype
-/// (`422`), not a distinct wire status (`AOM2/master04.6` §Syntax Validity
-/// Rules; SM `i_definition_adl14.adoc` `upload_archetype` `invalid_archetype`).
+/// Map an ADL 1.4 archetype parse failure to a [`ServiceError::ValidationFailed`]
+/// carrying the S-code mnemonics — the archetype-provisioning operations are
+/// SM-only (`i_definition_adl14.adoc` `upload_archetype` `invalid_archetype`;
+/// ITS-REST 1.1.0 surfaces no archetype route — the registered realization
+/// gap), so no released wire status attaches and the SM error is the whole
+/// contract.
 fn archetype_syntax_failure(errs: Vec<SyntaxError>) -> ServiceError {
     ServiceError::ValidationFailed(
         errs.into_iter()

--- a/app/ehrbase/src/service/definition/adl2.rs
+++ b/app/ehrbase/src/service/definition/adl2.rs
@@ -113,8 +113,9 @@ impl EhrbaseService {
     ///
     /// # Errors
     ///
-    /// - Source that fails to parse or fails an AOM2 validation phase →
-    ///   `invalid_artefact` (`422`, via [`ServiceError`]).
+    /// - Source that fails to parse → bad request (`400`, syntactically
+    ///   invalid content — `responses/400.yaml`); source that fails an AOM2
+    ///   validation phase → `invalid_artefact` (`422`, via [`ServiceError`]).
     /// - A database failure (`exception` → `500`).
     pub async fn upload_artefact(&self, adl2: String) -> Result<(), SmError> {
         let summary = self.adl2_validate(&adl2).await?;
@@ -278,18 +279,20 @@ impl EhrbaseService {
     /// Validate one uploaded ADL2 source with the `openehr-adl` engine and return
     /// its identity [`ArtefactSummary`].
     ///
-    /// Any invalidity — an unparseable source (S-code syntax errors) or an AOM2
-    /// validation-phase failure (V-codes) — is a `ValidationFailed`: the SM
-    /// `upload_artefact` maps it to `invalid_artefact` (`422`), and the wire
-    /// renders the ITS-REST `Error` object with the rule-code mnemonics as
-    /// `validationErrors[]` (`schemas/others/Error.yaml`). The openEHR
+    /// Invalidity splits on the syntax/semantics line: an unparseable source
+    /// (S-code syntax errors) is *syntactically invalid content* — the released
+    /// `400` branch (`responses/400.yaml`, via [`syntax_bad_request`]) — while
+    /// an AOM2 validation-phase failure (V-codes) on a parsed source is a
+    /// `ValidationFailed` (`422`), the wire rendering the ITS-REST `Error`
+    /// object with the rule-code mnemonics as `validationErrors[]`
+    /// (`schemas/others/Error.yaml`). The openEHR
     /// [`ProductionRmModel`] governs openEHR-published archetypes; a foreign/test
     /// model skips the RM pass (`AOM2/master04.3` §Reference Model Type Matching
     /// — a model this build does not carry would false-fire VCORM). External
     /// term bindings are verified through the terminology-service resolver
     /// (VETDF, `master03` §Validity Rules — see [`Self::adl2_terminology_resolver`]).
     async fn adl2_validate(&self, source: &str) -> Result<ArtefactSummary, ServiceError> {
-        let archetype = parse_artefact(source).map_err(syntax_validation_failure)?;
+        let archetype = parse_artefact(source).map_err(|errs| syntax_bad_request(&errs))?;
         let repo = self.adl2_repository().await?;
         let issues = if production_model_governs(&archetype) {
             // VETDF: external term bindings are verified against the terminology
@@ -300,7 +303,7 @@ impl EhrbaseService {
         } else {
             validate_source_phase1(source, Some(&repo))
         }
-        .map_err(syntax_validation_failure)?;
+        .map_err(|errs| syntax_bad_request(&errs))?;
 
         let errors: Vec<ValidationError> = issues
             .iter()
@@ -805,20 +808,18 @@ fn join_syntax_errors(errs: &[openehr_adl::error::SyntaxError]) -> String {
         .join("; ")
 }
 
-/// Map an ADL2 parse failure to a [`ServiceError::ValidationFailed`] carrying
-/// the S-code mnemonics as `validationErrors[]` — an unparseable source is an
-/// invalid artefact (`422`), not a distinct wire status (`AOM2/master04.6`
-/// §Syntax Validity Rules; SM `i_definition_adl2.adoc` `upload_artefact`
-/// `invalid_artefact`).
-fn syntax_validation_failure(errs: Vec<openehr_adl::error::SyntaxError>) -> ServiceError {
-    ServiceError::ValidationFailed(
-        errs.into_iter()
-            .map(|e| ValidationError {
-                path: e.code.mnemonic().to_owned(),
-                message: format!("{} (line {}, column {})", e.message, e.line, e.column),
-            })
-            .collect(),
-    )
+/// Map an ADL2 parse failure to a [`ServiceError::BadRequest`] carrying the
+/// joined S-code details — an unparseable source is *syntactically invalid
+/// content*, the released `400` branch declared on the upload
+/// (`docs/specs/openehr/ITS-REST/specifications/responses/400.yaml`: "the
+/// request could not be parsed or is invalid (e.g. … syntactically invalid …
+/// content)"). AOM2 validation-phase failures (V-codes) on a *parsed* source
+/// are the semantic `422` branch instead (see [`EhrbaseService::adl2_validate`]).
+fn syntax_bad_request(errs: &[openehr_adl::error::SyntaxError]) -> ServiceError {
+    ServiceError::BadRequest(format!(
+        "syntactically invalid ADL2 content: {}",
+        join_syntax_errors(errs)
+    ))
 }
 
 /// Map an artefact `kind` to the value the storage `kind` column accepts. The

--- a/app/ehrbase/src/templates/store.rs
+++ b/app/ehrbase/src/templates/store.rs
@@ -83,8 +83,8 @@ impl EhrbaseService {
         crate::validation::validate_opt_structure(xml)?;
 
         // The AOM2/08 standalone-artefact validity catalogue (VCOC/VACMCO,
-        // VATID/VTLC, VTTBK/VTCBK, VCORM/VCARM/VCAEX/VCACA/VCAM → `400` carrying
-        // the AOM2 rule code) is owned by the validation layer
+        // VATID/VTLC, VTTBK/VTCBK, VCORM/VCARM/VCAEX/VCACA/VCAM → `422` carrying
+        // the AOM2 rule code in `validationErrors[]`) is owned by the validation layer
         // (`crate::validation::opt`; spec `AM/docs/AOM2/master08-validation.adoc`).
         crate::validation::validate_opt_artefact(&opt)?;
 

--- a/app/ehrbase/src/validation/mod.rs
+++ b/app/ehrbase/src/validation/mod.rs
@@ -93,10 +93,11 @@ pub(crate) fn validate_opt_structure(xml: &str) -> Result<(), ServiceError> {
 ///
 /// # Errors
 ///
-/// The first violation found, as [`ServiceError::BadRequest`] (→ ITS-REST
-/// `400`, what the CNF `I_DEFINITION_ADL14` upload/validate suites assert for
-/// an invalid OPT) carrying the AOM2 rule code in the message
-/// (`"<CODE>: <detail>"`).
+/// The first violation found, as [`ServiceError::ValidationFailed`] (→
+/// ITS-REST `422` rendering the `Error` object with the AOM2 rule code in
+/// `validationErrors[]`): a rule violation on a successfully parsed artefact
+/// is a semantic error (the overview status table's `422` row), never the
+/// syntactic `400` branch of `responses/400.yaml`.
 pub fn validate_opt_artefact(opt: &OperationalTemplate) -> Result<(), ServiceError> {
     opt::validate_opt_artefact(opt)
 }

--- a/app/ehrbase/src/validation/opt/mod.rs
+++ b/app/ehrbase/src/validation/opt/mod.rs
@@ -26,10 +26,13 @@
 //!
 //! It does **not** run `valid_value` (that is instance-time — surface B in
 //! [`crate::validation`]). Every violation is reported through
-//! `ServiceError::sm` with `CallStatusType::PreconditionViolation` (→ ITS-REST
-//! `400 Bad Request`), carrying the AOM2 rule code in the message. `400` is
-//! what the CNF `I_DEFINITION_ADL14` upload/validate suites assert for an
-//! invalid OPT (`CNF/tests/platform/robot/I_DEFINITION_ADL14/validate_opt/…`).
+//! [`ServiceError::ValidationFailed`] (→ ITS-REST `422`, the `Error` object
+//! with the AOM2 rule code in `validationErrors[]`): an AOM2 rule violation is
+//! a semantic error on a successfully parsed artefact (the overview status
+//! table's `422` row, `docs/specs/openehr/ITS-REST/specifications/docs/
+//! overview/Requests_and_responses.md` §HTTP status codes), distinct from the
+//! syntactic `400` branch of `responses/400.yaml` that owns not-well-formed
+//! content.
 //!
 //! The check sequence (terminology sets first, then the walk; per node:
 //! VCORM → VATID → per-kind invariants → recurse) reports the **first**
@@ -46,7 +49,6 @@ use std::collections::HashSet;
 use openehr_its::opt14::{CAttribute, CObject, Intervalofinteger, OperationalTemplate};
 
 use crate::service::error::ServiceError;
-use crate::service::status::CallStatusType;
 
 /// One artefact-validity violation: the AOM2 rule code + a human detail.
 struct Violation {
@@ -140,19 +142,25 @@ fn attribute_children(attr: &CAttribute) -> &[CObject] {
 }
 
 /// Validate an uploaded OPT 1.4 artefact against the AOM2/08 standalone-artefact
-/// validity rules. The first violation found is returned as a `400` carrying the
-/// AOM2 rule code (`"<CODE>: <detail>"`); a fully valid artefact returns `Ok`.
+/// validity rules. The first violation found is returned as a `422` carrying the
+/// AOM2 rule code; a fully valid artefact returns `Ok`.
 ///
 /// # Errors
 ///
-/// `ServiceError::sm(PreconditionViolation, …)` — [`ServiceError::BadRequest`]
-/// on the wire (ITS-REST `400`) — for the first violation found.
+/// [`ServiceError::ValidationFailed`] (→ ITS-REST `422` rendering the `Error`
+/// object with the rule code in `validationErrors[]`) for the first violation
+/// found: an AOM2 rule violation is a semantic error on a successfully parsed
+/// artefact (the overview status table's `422` row,
+/// `docs/specs/openehr/ITS-REST/specifications/docs/overview/
+/// Requests_and_responses.md` §HTTP status codes; no template operation
+/// declares `422`, so the semantic branch is register-adjudicated), never the
+/// syntactic `400` branch of `responses/400.yaml`.
 pub(super) fn validate_opt_artefact(opt: &OperationalTemplate) -> Result<(), ServiceError> {
     check(opt).map_err(|v| {
-        ServiceError::sm(
-            CallStatusType::PreconditionViolation,
-            format!("{}: {}", v.code, v.detail),
-        )
+        ServiceError::ValidationFailed(vec![openehr_its::rest::runtime::ValidationError {
+            path: v.code.to_string(),
+            message: v.detail,
+        }])
     })
 }
 

--- a/app/ehrbase/tests/service_definition.rs
+++ b/app/ehrbase/tests/service_definition.rs
@@ -788,7 +788,11 @@ async fn adl2_errors() {
     let db = testkit::db().await.expect("testkit database");
     let svc = EhrbaseService::new(db.pool());
 
-    // Invalid ADL2 (unrecognised header) → 422 invalid_artefact.
+    // Unparseable ADL2 (unrecognised header) is *syntactically invalid
+    // content* — the released 400 branch (ITS-REST `responses/400.yaml`:
+    // "could not be parsed or is invalid (e.g. ... syntactically invalid ...
+    // content)"), not the semantic 422 that AOM2 validation-phase failures
+    // carry.
     let bad = svc
         .upload_artefact("concept\nopenEHR-EHR-OBSERVATION.bp.v1.0.0".to_owned())
         .await
@@ -797,14 +801,14 @@ async fn adl2_errors() {
         matches!(
             bad,
             SmError {
-                status: CallStatusType::ContentInvalid,
+                status: CallStatusType::PreconditionViolation,
                 ..
             }
         ),
         "got {bad:?}"
     );
 
-    // Recognised header but a malformed HRID → 422.
+    // Recognised header but a malformed HRID fails the grammar → 400 too.
     let bad_hrid = svc
         .upload_artefact("archetype\nnot-an-hrid".to_owned())
         .await
@@ -813,7 +817,7 @@ async fn adl2_errors() {
         matches!(
             bad_hrid,
             SmError {
-                status: CallStatusType::ContentInvalid,
+                status: CallStatusType::PreconditionViolation,
                 ..
             }
         ),
@@ -1089,9 +1093,10 @@ async fn adl2_template_upload_wire_conflicts_on_duplicate() {
     // The SM-native upload still replaces.
     svc.upload_artefact(tmpl).await.expect("native replace");
 
-    // Invalid source → a 422 validation failure carrying the rule codes (an
-    // unparseable source is an invalid artefact, AOM2 master04.6 §Syntax
-    // Validity Rules), not a distinct wire status.
+    // A source that fails the ADL2 grammar (missing mandatory sections →
+    // S-codes) is *syntactically invalid content* — the released 400 branch
+    // declared on the upload (ITS-REST `responses/400.yaml`), not the
+    // semantic 422 that AOM2 validation-phase failures (V-codes) carry.
     let bad = svc
         .template_adl2_upload(
             "template (adl_version=2.0.6)\nopenEHR-EHR-COMPOSITION.t_bad.v1\n".to_owned(),
@@ -1099,7 +1104,7 @@ async fn adl2_template_upload_wire_conflicts_on_duplicate() {
         .await
         .expect_err("invalid source rejected");
     assert!(
-        matches!(&bad, ServiceError::ValidationFailed(v) if !v.is_empty()),
+        matches!(&bad, ServiceError::BadRequest(m) if m.contains("syntactically invalid")),
         "got {bad:?}"
     );
 }

--- a/app/ehrbase/tests/validation_opt.rs
+++ b/app/ehrbase/tests/validation_opt.rs
@@ -42,11 +42,19 @@ fn parse(xml: &str) -> OperationalTemplate {
     opt14::from_xml(xml).expect("minimal OPT parses")
 }
 
-/// Assert the artefact is rejected with the given AOM2 rule code in the message.
+/// Assert the artefact is rejected with the given AOM2 rule code carried in the
+/// `ValidationFailed` payload (the ITS-REST 422 `validationErrors[]` rendering).
 fn expect_code(opt: &OperationalTemplate, code: &str) {
     let err = validate_opt_artefact(opt).expect_err("expected a violation");
-    let msg = err.to_string();
-    assert!(msg.contains(code), "expected `{code}` in error, got: {msg}");
+    let ServiceError::ValidationFailed(violations) = &err else {
+        panic!("expected ValidationFailed (422), got {err:?}");
+    };
+    assert!(
+        violations
+            .iter()
+            .any(|v| v.path == code || v.message.contains(code)),
+        "expected `{code}` in violations, got: {violations:?}"
+    );
 }
 
 /// Replace the first `from` occurring *after* `marker` with `to`.
@@ -131,9 +139,13 @@ fn corpus_all_valid_opts_pass() {
 }
 
 #[test]
-fn rejection_is_400_bad_request() {
-    // VCARM path — assert the wire status is 400 (CNF `validate_opt-invalid_opt`
-    // asserts "status code 400"; `ServiceError::BadRequest` → ITS-REST 400).
+fn rejection_is_422_validation_failed() {
+    // VCARM path — an AOM2 rule violation on a successfully PARSED artefact is
+    // a semantic error: the ITS-REST overview status table's 422 row
+    // (`Requests_and_responses.md` §HTTP status codes, "well-formed but …
+    // semantic errors"), rendered as the `Error` object with the rule code in
+    // `validationErrors[]`. The syntactic 400 branch (`responses/400.yaml`)
+    // owns only content that fails to parse.
     let xml = minimal_xml().replace(
         "<rm_attribute_name>category</rm_attribute_name>",
         "<rm_attribute_name>bogus_attr</rm_attribute_name>",
@@ -141,8 +153,8 @@ fn rejection_is_400_bad_request() {
     let opt = parse(&xml);
     let err = validate_opt_artefact(&opt).unwrap_err();
     assert!(
-        matches!(err, ServiceError::BadRequest(_)),
-        "expected BadRequest (400), got {err:?}"
+        matches!(err, ServiceError::ValidationFailed(_)),
+        "expected ValidationFailed (422), got {err:?}"
     );
 }
 


### PR DESCRIPTION
Closes #493.

Group-10 follow-up found while verifying the step-6 OpenAPI declarations (#490) against the shipped wire — the audit's "the ADL2 sibling already splits correctly" line was wrong, and both chains rested on invalid adjudications.

**ADL2 syntax → 400.** `adl2.rs::syntax_validation_failure` mapped S-code parse failures to 422 citing `AOM2/master04.6 §Syntax Validity Rules` — a file that does not exist (the vendored AM stops at master04.5). The released `responses/400.yaml` trigger is declared on the route and owns unparseable content. The mapper is now `syntax_bad_request` → `BadRequest(400)` with the joined S-code detail; AOM2 validation-phase failures (V-codes) on a parsed source keep the 422 `validationErrors` rendering (the existing VARD wire test still passes untouched).

**ADL1.4 AOM2 artefact violations → 422.** `validation::opt::validate_opt_artefact` mapped rule violations on a parsed OPT to 400, justified by the stalled CNF Robot suites (never a correctness authority). It now returns `ValidationFailed` carrying the AOM2 rule code in `validationErrors[]` (the overview status table's semantic 422 row).

**The law, both routes:** content failing its own syntax → the declared 400 branch; parsed content semantically invalid as a template artefact → 422 (register-adjudicated — no template operation declares 422). The SM-only archetype mapper keeps its SM contract (no wire route exists); stale citations scrubbed.

**Re-adjudicated tests** (each with the released citation replacing the invalid one): `validation_opt::rejection_is_400_bad_request` → `rejection_is_422_validation_failed` + `expect_code` reads the `validationErrors` payload; `service_definition::adl2_errors` unparseable arms → `PreconditionViolation`; `adl2_template_upload_wire_conflicts_on_duplicate`'s invalid-source arm → `BadRequest`. New wire tests: ADL2 unparseable/empty source → 400.

**Gates:** clippy (both crates, all targets) clean; nextest `-p ehrbase -p ehrbase-rest` 1167 passed / 0 failed. Catalogue rows re-adjudicate in #491.