### PR TITLE
fix(query-store): Location names the stored version; versioned PUT requires exact SEMVER; text/plain 415 guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **Stored-query stores answer honest `Location`s and validate the version
+  segment** (#498). The version-less `PUT /definition/query/{name}` now
+  always names the version it actually wrote (`…/1.0.0`) in `Location` —
+  previously, when a higher version already existed, the header pointed at
+  that untouched neighbour. The versioned
+  `PUT /definition/query/{name}/{version}` now requires an exact numeric
+  `major.minor.patch` and rejects prefix, pre-release, or malformed version
+  segments with `400 Bad Request` — previously any string was stored
+  verbatim, and a single non-numeric version (e.g. `1.0.0-rc.1`) broke every
+  later stored-query list and retrieval on the server. Both store forms also
+  now refuse a payload declaring a media type other than their single
+  `text/plain` body type with `415 Unsupported Media Type` (an absent
+  `Content-Type` remains accepted).
+
 - **Template rejection statuses are coherent across both upload routes**
   (#493). An ADL2 source with grammar-level syntax errors now answers
   `400 Bad Request` (the released "syntactically invalid … content" branch)

--- a/app/ehrbase-rest/src/api/definition/stored_query.rs
+++ b/app/ehrbase-rest/src/api/definition/stored_query.rs
@@ -14,7 +14,7 @@
 //! (`responses/200_StoredQuery_stored.yaml` + `headers/Location_Query.yaml`).
 
 use axum::response::Response;
-use http::{HeaderMap, StatusCode};
+use http::StatusCode;
 
 use openehr_its::rest::generated::definition::{
     DefinitionQueryListParams, DefinitionQueryStoreYamlParams, DefinitionQueryVersionGetParams,
@@ -75,30 +75,32 @@ pub(super) async fn store(state: &AppState, parts: &RequestParts) -> Result<Resp
     let query_type = p
         .query_type
         .unwrap_or_else(|| DEFAULT_QUERY_TYPE.to_owned());
+    // The store's single declared body type is `text/plain`
+    // (`operations/definition_query_store.yaml`); a payload DECLARING another
+    // media type is refused 415 before parsing (`Resources.md` §format rules
+    // MUST), an absent `Content-Type` declares nothing to refuse.
+    negotiate::require_text_plain(h)?;
     let body = negotiate::text_body(&parts.body)?;
     // The `DefinitionAdapter::query_store` impl honours `query_type`: an
     // AQL formalism runs the syntactic check, while an unsupported non-AQL
     // formalism is rejected as a distinct unsupported-formalism `400`
     // (not a blanket "invalid AQL"). See `QUERY_DESCRIPTOR.formalism`,
     // `parameters/query/query_type.yaml`.
-    state
+    //
+    // The store returns the SEMVER it actually wrote at, and the `Location`
+    // names exactly that resource (`headers/Location_Query.yaml`: the header
+    // "indicates the URL of the Stored Query resource") — never a
+    // neighbouring version recovered by a post-hoc lookup, which could name
+    // a higher version this PUT did not touch.
+    let version = state
         .backend()
         .query_store(name.clone(), None, query_type, body)
         .await?;
-    // The no-version store auto-assigns the SEMVER but the generated trait
-    // method is bodyless (`()`), so the assigned version is recovered through
-    // the list seam: exact-name rows come back ordered by version ascending, so
-    // the last one is the version this store just wrote (or upserted).
-    match stored_version_of(state, &name, h).await {
-        Some(version) => {
-            let location = format!(
-                "{}/definition/query/{name}/{version}",
-                state.config().server.base_path
-            );
-            Ok(negotiate::empty_with_location(StatusCode::OK, &location))
-        }
-        None => Ok(negotiate::empty(StatusCode::OK)),
-    }
+    let location = format!(
+        "{}/definition/query/{name}/{version}",
+        state.config().server.base_path
+    );
+    Ok(negotiate::empty_with_location(StatusCode::OK, &location))
 }
 
 /// `GET …/definition/query/{qualified_query_name}/{version}` — the registered
@@ -121,7 +123,8 @@ pub(super) async fn version_get(
 }
 
 /// `PUT …/definition/query/{qualified_query_name}/{version}` — store a query at
-/// a specified SEMVER (stored verbatim); `409` on an existing `(name, version)`.
+/// a specified SEMVER (an exact `major.minor.patch`; a prefix or malformed
+/// segment is the released `400` branch); `409` on an existing `(name, version)`.
 ///
 /// as [`store`], the `query_type` parameter is read and threaded through.
 pub(super) async fn version_store(
@@ -139,31 +142,24 @@ pub(super) async fn version_store(
     let query_type = p
         .query_type
         .unwrap_or_else(|| DEFAULT_QUERY_TYPE.to_owned());
+    // Same `text/plain`-only body type as the version-less store (the released
+    // operation omits the Content-Type parameter but carries the identical
+    // text/plain body) — a declared foreign media type is 415 (`Resources.md`
+    // §format rules MUST).
+    negotiate::require_text_plain(h)?;
     let body = negotiate::text_body(&parts.body)?;
     // As in `store`, the `query_store` impl honours `query_type`: the AQL
     // syntactic check runs only for the AQL formalism, and an unsupported
-    // non-AQL formalism is an honest unsupported-formalism reject.
-    state
+    // non-AQL formalism is an honest unsupported-formalism reject. The
+    // returned SEMVER is the exact path version (the store requires an exact
+    // `major.minor.patch`; a prefix or malformed value is its `400`).
+    let stored = state
         .backend()
-        .query_store(name.clone(), Some(version.clone()), query_type, body)
+        .query_store(name.clone(), Some(version), query_type, body)
         .await?;
     let location = format!(
-        "{}/definition/query/{name}/{version}",
+        "{}/definition/query/{name}/{stored}",
         state.config().server.base_path
     );
     Ok(negotiate::empty_with_location(StatusCode::OK, &location))
-}
-
-/// The stored SEMVER of the stored query `name` after a no-version store: the
-/// exact-name entries from the list seam (ordered by version ascending), taking
-/// the highest. `None` when the lookup fails or finds nothing — the store itself
-/// already succeeded, so the response degrades to Location-less rather than
-/// failing the request.
-async fn stored_version_of(state: &AppState, name: &str, _headers: &HeaderMap) -> Option<String> {
-    let list = state.backend().query_list(name.to_owned()).await.ok()?;
-    list.iter()
-        .filter(|entry| entry.get("name").and_then(|n| n.as_str()) == Some(name))
-        .filter_map(|entry| entry.get("version").and_then(|v| v.as_str()))
-        .next_back()
-        .map(str::to_owned)
 }

--- a/app/ehrbase-rest/tests/stored_query_definition_http.rs
+++ b/app/ehrbase-rest/tests/stored_query_definition_http.rs
@@ -1,0 +1,245 @@
+#![allow(
+    clippy::panic,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    let_underscore_drop
+)] // test assertions/diagnostics/fixtures
+//! End-to-end HTTP tests for the stored-query DEFINITION wire (group-11 audit,
+//! `I_DEFINITION_QUERY`): the version-less `PUT /definition/query/{name}`
+//! (whose `Location` names exactly the version the store wrote — never a
+//! neighbouring one, `headers/Location_Query.yaml`) and the versioned
+//! `PUT …/{name}/{version}` (exact `major.minor.patch` required — the
+//! `{major}`/`{major}.{minor}` prefix forms of `parameters/path/version.yaml`
+//! are READ-side resolution patterns, and a non-numeric segment would poison
+//! the surface's SEMVER ordering; register-adjudicated `400`).
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use axum::Router;
+use axum::body::Body;
+use http::{Request, StatusCode, header};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+use ehrbase::config::auth::AuthConfig;
+use ehrbase::config::server::ServerConfig;
+use ehrbase_rest::config::AppConfig;
+
+mod common;
+
+const BASE: &str = "/ehrbase/rest/openehr/v1";
+const AQL: &str = "SELECT e/ehr_id/value FROM EHR e";
+
+fn config() -> AppConfig {
+    AppConfig {
+        server: ServerConfig {
+            bind: "127.0.0.1:0".to_owned(),
+            base_path: BASE.to_owned(),
+            max_in_flight: 1024,
+            swagger_ui: false,
+            cors_permissive: false,
+            ..Default::default()
+        },
+        auth: AuthConfig {
+            enabled: false,
+            basic: None,
+            oidc: None,
+            admin_scope: None,
+            ..AuthConfig::default()
+        },
+        ..Default::default()
+    }
+}
+
+async fn app() -> (testkit::TestDb, Router) {
+    let (pg, service) = common::test_service().await;
+    (pg, common::router_with(config(), service))
+}
+
+async fn send(app: &Router, req: Request<Body>) -> (StatusCode, header::HeaderMap, String) {
+    let resp = app.clone().oneshot(req).await.expect("response");
+    let status = resp.status();
+    let headers = resp.headers().clone();
+    let bytes = resp.into_body().collect().await.expect("body").to_bytes();
+    (
+        status,
+        headers,
+        String::from_utf8_lossy(&bytes).into_owned(),
+    )
+}
+
+fn put(uri: String) -> Request<Body> {
+    Request::builder()
+        .method("PUT")
+        .uri(uri)
+        .header(header::CONTENT_TYPE, "text/plain")
+        .body(Body::from(AQL))
+        .unwrap()
+}
+
+fn location(h: &header::HeaderMap) -> &str {
+    h.get(header::LOCATION)
+        .and_then(|v| v.to_str().ok())
+        .expect("Location header")
+}
+
+// ── the version-less store's Location names the WRITTEN version ─────────────
+
+#[tokio::test]
+async fn versionless_store_location_names_the_default_slot() {
+    let (_pg, app) = app().await;
+    let (status, headers, body) =
+        send(&app, put(format!("{BASE}/definition/query/org.test::a"))).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(
+        location(&headers),
+        format!("{BASE}/definition/query/org.test::a/1.0.0"),
+        "the version-less store writes the 1.0.0 default slot and Location \
+         names exactly that resource (headers/Location_Query.yaml)"
+    );
+}
+
+#[tokio::test]
+async fn versionless_store_location_ignores_higher_stored_versions() {
+    let (_pg, app) = app().await;
+    // A higher version exists first…
+    let (status, _h, body) = send(
+        &app,
+        put(format!("{BASE}/definition/query/org.test::b/2.0.0")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    // …then the version-less store writes 1.0.0: Location must name 1.0.0,
+    // never the neighbouring 2.0.0 this PUT did not touch.
+    let (status, headers, body) =
+        send(&app, put(format!("{BASE}/definition/query/org.test::b"))).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(
+        location(&headers),
+        format!("{BASE}/definition/query/org.test::b/1.0.0"),
+        "Location indicates the URL of the Stored Query resource this PUT \
+         stored (headers/Location_Query.yaml), not the highest version"
+    );
+}
+
+#[tokio::test]
+async fn versionless_store_updates_in_place() {
+    let (_pg, app) = app().await;
+    let uri = format!("{BASE}/definition/query/org.test::c");
+    let (status, _h, body) = send(&app, put(uri.clone())).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    // "Stores a new query, or updates an existing query on the system"
+    // (definition_query_store.yaml) — the second PUT is an update, not a 409.
+    let (status, headers, body) = send(&app, put(uri)).await;
+    assert_eq!(status, StatusCode::OK, "update-in-place: {body}");
+    assert!(location(&headers).ends_with("/1.0.0"));
+}
+
+// ── the versioned store requires an exact numeric SEMVER triple ─────────────
+
+#[tokio::test]
+async fn versioned_store_accepts_exact_semver_and_conflicts_on_duplicate() {
+    let (_pg, app) = app().await;
+    let uri = format!("{BASE}/definition/query/org.test::d/1.2.3");
+    let (status, headers, body) = send(&app, put(uri.clone())).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(
+        location(&headers),
+        format!("{BASE}/definition/query/org.test::d/1.2.3")
+    );
+    // "409 Conflict is returned when a query with the given
+    // qualified_query_name and version already exists on the server"
+    // (responses/409_StoredQuery_version.yaml).
+    let (status, _h, body) = send(&app, put(uri)).await;
+    assert_eq!(status, StatusCode::CONFLICT, "{body}");
+}
+
+#[tokio::test]
+async fn versioned_store_rejects_non_exact_versions() {
+    let (_pg, app) = app().await;
+    // The prefix forms are read-side resolution patterns
+    // (parameters/path/version.yaml); on the write they are the released 400
+    // branch ("syntactically invalid … parameter", responses/400.yaml) —
+    // register-adjudicated. A pre-release tag would additionally poison the
+    // surface's SEMVER ordering.
+    for bad in ["1", "1.0", "1.0.0-rc.1", "latest", "1.0.x", "1..0"] {
+        let (status, _h, body) = send(
+            &app,
+            put(format!("{BASE}/definition/query/org.test::e/{bad}")),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "`{bad}` is not an exact major.minor.patch: {body}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn version_get_resolves_prefixes_to_highest() {
+    let (_pg, app) = app().await;
+    for v in ["1.0.0", "1.0.9", "1.2.0"] {
+        let (status, _h, body) = send(
+            &app,
+            put(format!("{BASE}/definition/query/org.test::f/{v}")),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+    }
+    // "a pattern as partial prefix … the highest (latest) version matching
+    // the prefix will be considered" (parameters/path/version.yaml).
+    for (sel, expect) in [("1", "1.2.0"), ("1.0", "1.0.9"), ("1.0.0", "1.0.0")] {
+        let get = Request::builder()
+            .method("GET")
+            .uri(format!("{BASE}/definition/query/org.test::f/{sel}"))
+            .header(header::ACCEPT, "application/json")
+            .body(Body::empty())
+            .unwrap();
+        let (status, _h, body) = send(&app, get).await;
+        assert_eq!(status, StatusCode::OK, "{sel}: {body}");
+        let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(
+            v.get("version").and_then(|x| x.as_str()),
+            Some(expect),
+            "selector `{sel}` resolves to `{expect}`: {body}"
+        );
+    }
+}
+
+// ── a non-text/plain declared body type is 415, never a parse-time 400 ──────
+
+#[tokio::test]
+async fn stores_refuse_a_declared_foreign_body_type_with_415() {
+    let (_pg, app) = app().await;
+    // Both store forms declare text/plain as the single body type; a payload
+    // declaring another media type cannot be processed as it (`Resources.md`
+    // §format rules: the service "MUST respond with HTTP status code 415
+    // Unsupported Media Type").
+    for uri in [
+        format!("{BASE}/definition/query/org.test::g"),
+        format!("{BASE}/definition/query/org.test::g/1.0.0"),
+    ] {
+        let req = Request::builder()
+            .method("PUT")
+            .uri(uri.clone())
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(AQL))
+            .unwrap();
+        let (status, _h, body) = send(&app, req).await;
+        assert_eq!(status, StatusCode::UNSUPPORTED_MEDIA_TYPE, "{uri}: {body}");
+    }
+}
+
+#[tokio::test]
+async fn stores_accept_an_absent_content_type() {
+    let (_pg, app) = app().await;
+    // An absent Content-Type declares nothing to refuse (the header is a
+    // client MAY) — the operation's own body type applies.
+    let req = Request::builder()
+        .method("PUT")
+        .uri(format!("{BASE}/definition/query/org.test::h/1.0.0"))
+        .body(Body::from(AQL))
+        .unwrap();
+    let (status, _h, body) = send(&app, req).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+}

--- a/app/ehrbase/src/service/definition/query.rs
+++ b/app/ehrbase/src/service/definition/query.rs
@@ -456,6 +456,25 @@ impl EhrbaseService {
             return Ok(DEFAULT_QUERY_VERSION.to_owned());
         };
 
+        // The versioned store requires an EXACT numeric `major.minor.patch`.
+        // The prefix grammar of `parameters/path/version.yaml` is a READ-
+        // resolution semantic ("the highest (latest) version matching the
+        // prefix will be considered") and no released sentence assigns a
+        // status to a prefix or malformed version on the write, so the
+        // rejection is the released 400 branch (`responses/400.yaml`:
+        // "syntactically invalid … parameter") — register-adjudicated.
+        // Accepting the value verbatim is untenable: a non-numeric segment
+        // (`1.0.0-rc.1`) breaks the surface's SEMVER ordering
+        // (`string_to_array(semver, '.')::int[]`) and a stored prefix (`1`)
+        // collides with the read-side resolution algebra.
+        if !is_exact_semver(v) {
+            return Err(ServiceError::BadRequest(format!(
+                "`{v}` is not an exact SEMVER version: the versioned store requires \
+                 `major.minor.patch` (the {{major}}/{{major}}.{{minor}} prefix forms are \
+                 read-side resolution patterns, parameters/path/version.yaml)"
+            )));
+        }
+
         // Versioned store: insert-only, immutable pair. A case-insensitive match
         // at this version is a 409 (BASE master05 §Composite Identifiers and
         // Case). The exact-case insert stays race-safe via `ON CONFLICT (rdn,
@@ -757,6 +776,18 @@ pub(super) fn is_aql_v1(a_type: &str) -> bool {
 fn is_partial_semver(version: &str) -> bool {
     let segments: Vec<&str> = version.split('.').collect();
     segments.len() < 3
+        && segments
+            .iter()
+            .all(|s| !s.is_empty() && s.chars().all(|c| c.is_ascii_digit()))
+}
+
+/// Whether a `version` value is an EXACT numeric `major.minor.patch` triple —
+/// the only form the versioned store accepts (the prefix forms of
+/// `parameters/path/version.yaml` are read-side resolution patterns; see
+/// [`EhrbaseService::store_query_version`]).
+fn is_exact_semver(version: &str) -> bool {
+    let segments: Vec<&str> = version.split('.').collect();
+    segments.len() == 3
         && segments
             .iter()
             .all(|s| !s.is_empty() && s.chars().all(|c| c.is_ascii_digit()))

--- a/app/ehrbase/src/service/definition/wire.rs
+++ b/app/ehrbase/src/service/definition/wire.rs
@@ -257,16 +257,19 @@ impl EhrbaseService {
     /// build can only validate + store AQL, so a non-AQL formalism is an
     /// honest *unsupported-formalism* reject (a distinct `400`, not a blanket
     /// "invalid AQL"). AQL bodies fall through to the store-time AQL
-    /// syntactic check. The effective version is recovered by the dispatcher
-    /// through the list seam for the `Location` header; the store itself is
-    /// bodyless.
+    /// syntactic check. Returns the **effective SEMVER the store wrote at**,
+    /// so the dispatcher's `Location` names exactly the stored resource
+    /// (`headers/Location_Query.yaml`: the header "indicates the URL of the
+    /// Stored Query resource") — never a neighbouring version recovered by a
+    /// lookup. The store response itself is bodyless.
     ///
     /// # Errors
     ///
     /// - A non-AQL `query_type` → `precondition_violation` (`400`).
     /// - A body that fails the AQL parse → `precondition_violation` (`400`).
-    /// - With an explicit `version`, an already-existing `(name, version)`
-    ///   pair → conflict (`409`, `409_StoredQuery_version.yaml`).
+    /// - With an explicit `version`, a non-exact SEMVER → `precondition_violation`
+    ///   (`400`), and an already-existing `(name, version)` pair → conflict
+    ///   (`409`, `409_StoredQuery_version.yaml`).
     /// - A database failure (`exception` → `500`).
     pub async fn query_store(
         &self,
@@ -274,16 +277,16 @@ impl EhrbaseService {
         version: Option<String>,
         query_type: String,
         body: String,
-    ) -> Result<(), SmError> {
+    ) -> Result<String, SmError> {
         if !is_aql_v1(&query_type) {
             return Err(SmError::precondition(format!(
                 "unsupported query formalism `{query_type}`: only AQL is supported for \
                  stored queries (parameters/query/query_type.yaml)"
             )));
         }
-        self.store_query_version(&qualified_query_name, version.as_deref(), body)
-            .await?;
-        Ok(())
+        Ok(self
+            .store_query_version(&qualified_query_name, version.as_deref(), body)
+            .await?)
     }
 }
 


### PR DESCRIPTION
Closes #498.

Group-11 audit findings F-1 + F-2 (adjudications + citations: the findings comment on #387), plus the 415 gap the #499 step-6 verification surfaced.

**F-1 — honest `Location` on the version-less store.** The handler recovered the `Location` version by taking the *highest* stored version of the name, while the write lands at the fixed `1.0.0` slot — with a `2.0.0` already stored, `Location` named a resource the PUT did not write (`headers/Location_Query.yaml`: the header "indicates the URL of the Stored Query resource"). `wire.rs::query_store` now returns the effective SEMVER the store wrote at; the handler builds `Location` from it; the post-hoc list recovery (`stored_version_of`) is deleted.

**F-2 — exact SEMVER on the versioned store.** The path version was stored verbatim: one non-numeric segment (`1.0.0-rc.1`) poisoned every later stored-query list/get (the surface orders by `string_to_array(semver,'.')::int[]` — SQL cast errors → 500s), and a stored prefix (`1`) collided with the read-side resolution algebra. The prefix grammar of `parameters/path/version.yaml` is a read semantic and the released text assigns nothing to the write, so the versioned store now requires an exact numeric `major.minor.patch` — anything else is the released 400 branch (`responses/400.yaml` "syntactically invalid … parameter"), register-adjudicated in #500.

**415 guards.** Neither store enforced its single declared `text/plain` body type; a declared foreign media type is now refused 415 before parsing (`Resources.md` §format-rules MUST), matching the template-upload guards; absent `Content-Type` stays accepted.

**Tests:** new `stored_query_definition_http.rs` battery — Location at the written version (incl. the higher-version-present probe), update-in-place, exact-semver + duplicate 409, six non-exact rejects, GET prefix resolution to highest, 415 on both forms, absent-Content-Type acceptance.

**Gates:** clippy (both crates, all targets) clean; nextest `-p ehrbase -p ehrbase-rest` 1175 passed / 0 failed.