### PR TITLE
fix(definition): served OpenAPI completeness for the stored-query operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,18 @@ workflow refuses a tag that has no matching section here.
   `text/plain` body type with `415 Unsupported Media Type` (an absent
   `Content-Type` remains accepted).
 
+- **The published API reference now describes the stored-query endpoints in
+  full** (#499). The four stored-query operations in the served OpenAPI
+  document gained the `Location` response header both stores actually send,
+  the bodyless shape of their `200`, the status branches they actually
+  answer (`400` everywhere, `406` on the reads, `409` on the versioned
+  store, `404` on the version read), the qualified-name and `version`
+  grammars (including the reserved `aql` name and the read-side
+  prefix-resolution rule), request and response examples, and a spec
+  citation on every branch. The bare "list every stored query" route is now
+  labelled for what it is — an extension of this server, not a released
+  openEHR operation.
+
 - **Template rejection statuses are coherent across both upload routes**
   (#493). An ADL2 source with grammar-level syntax errors now answers
   `400 Bad Request` (the released "syntactically invalid … content" branch)

--- a/app/ehrbase-rest/src/api/definition/openapi_routes.rs
+++ b/app/ehrbase-rest/src/api/definition/openapi_routes.rs
@@ -46,9 +46,14 @@
 //!   is unreachable (only a path parameter); the reachable statuses are the
 //!   ones documented on each operation below.
 //! - **Stored-query list by name** (`definition_query_list.yaml`): the qualified
-//!   name is a prefix pattern (empty = wildcard), so an unmatched name yields an
-//!   empty `200` list, never `404` — matching the OAS, which declares only
-//!   `200`.
+//!   name is a prefix pattern, so an unmatched name yields an empty `200` list,
+//!   never `404` — the released operation declares only `200`
+//!   (`specifications/responses/200_QueryList.yaml`). Its "when is empty, it
+//!   will be treated as 'wildcard' in the search" clause is unreachable on the
+//!   released wire: `specifications/parameters/path/qualified_query_name.yaml`
+//!   is `required: true` and the release defines no bare `/definition/query`
+//!   operation — this build serves that empty-prefix case on an extension route
+//!   of its own (flagged as such on the declaration).
 
 use axum::extract::State;
 use axum::response::Response;
@@ -1352,14 +1357,75 @@ pub(crate) async fn definition_template_adl2_version_get(
 
 /// List every stored query (`GET /definition/query`).
 ///
-/// OUR OWN EXTENSION — no openEHR spec governs the bare form; the vendored OAS
-/// defines only the `{qualified_query_name}` route. This is the empty-prefix
-/// case of that route's documented prefix semantics ("List stored queries").
+/// OUR OWN EXTENSION — no openEHR spec governs this bare form. The release
+/// defines exactly one stored-query list operation,
+/// `GET /definition/query/{qualified_query_name}`
+/// (`specifications/operations/definition_query_list.yaml`), whose path
+/// parameter is `required: true`
+/// (`specifications/parameters/path/qualified_query_name.yaml`) — so that
+/// operation's "when is empty, it will be treated as 'wildcard' in the search"
+/// clause has no addressable form on the released wire. This route serves the
+/// empty-prefix case as a convenience extension; it answers exactly what the
+/// released list answers for the empty prefix.
 #[utoipa::path(
     get, path = "/definition/query", tag = "Query",
+    params(
+        ("Accept" = Option<String>, Header,
+         description = "`application/json` — the single representation of a \
+                        stored-query list (the released sibling operation \
+                        carries `parameters/header/Accept_JSON.yaml` and \
+                        `responses/200_QueryList.yaml` declares JSON content \
+                        only). Absent or `*/*` reads as JSON.",
+         example = "application/json")
+    ),
     responses(
-        (status = 200, description = "Every stored query, all versions (canonical \
-                                      JSON; empty when none are stored).",
+        (
+            status = 200, description = "Every stored query, all versions — the \
+                                        empty-prefix case of the released list, \
+                                        whose own trigger reads, verbatim: `200 \
+                                        OK` \"is returned when the query \
+                                        resources are successfully retrieved\" \
+                                        (ITS-REST \
+                                        `specifications/responses/200_QueryList.yaml`). \
+                                        A bare `QueryList` array \
+                                        (`schemas/definition/QueryList.yaml`), \
+                                        empty when nothing is stored — never a \
+                                        `404`. Rows are ordered by qualified \
+                                        name and then ascending SEMVER; no \
+                                        released text fixes an order for a \
+                                        stored-query list, so that ordering is \
+                                        OURS. This whole route is our own \
+                                        extension — no openEHR spec governs it.",
+            content((serde_json::Value = "application/json", example = json!([
+                {
+                    "name": "org.openehr::compositions",
+                    "type": "AQL",
+                    "version": "1.0.1",
+                    "saved": "2017-07-16T19:20:30Z",
+                    "q": "SELECT c FROM EHR e[ehr_id/value=$ehr_id] CONTAINS COMPOSITION c[$compositionid] WHERE c/name/value = 'Vitals'"
+                },
+                {
+                    "name": "org.openehr::compositions",
+                    "type": "AQL",
+                    "version": "1.1.7",
+                    "saved": "2018-06-13T09:37:20Z",
+                    "q": "SELECT c FROM EHR e[ehr_id/value=$ehr_id] CONTAINS COMPOSITION c[$uid] WHERE c/name/value = 'Vitals'"
+                }
+            ])))
+        ),
+        (status = 406, description = "The `Accept` header cannot be satisfied: a \
+                                      stored-query list has the single \
+                                      `application/json` representation the \
+                                      released sibling response declares \
+                                      (`200_QueryList.yaml`), so an \
+                                      exclusively-XML `Accept` is refused \
+                                      (`Resources.md` §\"JSON Format\": \"If the \
+                                      service cannot fulfill this aspect of the \
+                                      request, it MUST respond with HTTP status \
+                                      code `406 Not Acceptable`\"). Neither this \
+                                      extension nor its released sibling \
+                                      enumerates `406`; the MUST is \
+                                      cross-cutting.",
          body = serde_json::Value)
     )
 )]
@@ -1386,13 +1452,117 @@ pub(crate) async fn definition_query_list_all(
     get, path = "/definition/query/{qualified_query_name}", tag = "Query",
     params(
         ("qualified_query_name" = String, Path,
-         description = "The qualified stored-query name as a prefix pattern \
-                        (`[{namespace}::]{query-name}`); it matches every query \
-                        whose name starts with it (case-insensitive).")
+         description = "\"The (fully qualified) name of the query …, in a format \
+                        of `[{namespace}::]{query-name}`\" (ITS-REST \
+                        `specifications/parameters/path/qualified_query_name.yaml`), \
+                        whose grammar is fixed by \
+                        `specifications/docs/query/Qualified_query_name.md`: the \
+                        `namespace` is optional and \"should be in a form of a \
+                        reverse domain name\", and \"the `query-name` may include \
+                        any combination of characters, matched by the pattern \
+                        `[a-zA-Z0-9_.-]`\" — with the NOTE that \"the \
+                        `query-name` value must not be `aql` (case-insensitive), \
+                        as that is a reserved name\" (enforced at store time, \
+                        not here: a read simply matches nothing). On THIS \
+                        operation the value is a PREFIX — \"retrieves list of \
+                        all stored queries on the system matched by \
+                        `qualified_query_name` as pattern\" \
+                        (`operations/definition_query_list.yaml`, whose own \
+                        example lists \"all versions of all queries with names \
+                        starting with `org.openehr`\"). The prefix match is \
+                        case-insensitive, and a namespace-less prefix also \
+                        matches its `misc::`-namespaced form, because that is \
+                        the canonical key every surface stores under (SM \
+                        `docs/openehr_platform/master04-definition_package.adoc` \
+                        §Registered Queries: \"If no namespace is supplied, the \
+                        namespace `misc` is assumed\").",
+         example = "org.openehr::compositions"),
+        ("Accept" = Option<String>, Header,
+         description = "`application/json` — the single representation this \
+                        operation declares \
+                        (`specifications/parameters/header/Accept_JSON.yaml` on \
+                        the operation, `responses/200_QueryList.yaml` for the \
+                        body). Absent or `*/*` reads as JSON.",
+         example = "application/json")
     ),
     responses(
-        (status = 200, description = "The matching stored queries, all versions \
-                                      (canonical JSON; empty when none match).",
+        (
+            status = 200, description = "The released trigger, verbatim: `200 OK` \
+                                        \"is returned when the query resources \
+                                        are successfully retrieved\" (ITS-REST \
+                                        `specifications/responses/200_QueryList.yaml`) \
+                                        — retrieval, not matching: a prefix that \
+                                        matches nothing is this `200` with an \
+                                        empty array, never a `404`. The body is a \
+                                        bare `QueryList` array \
+                                        (`schemas/definition/QueryList.yaml`) of \
+                                        `StoredQuery` objects, EVERY stored \
+                                        version of every matching name, ordered \
+                                        by qualified name and then ascending \
+                                        SEMVER — no released text fixes an order, \
+                                        so the ordering is OURS. `type` echoes \
+                                        the stored formalism, which this build \
+                                        records as `AQL`, the `default`/`example` \
+                                        of `schemas/query/QueryType.yaml` (the \
+                                        released response examples spell the same \
+                                        value lowercase; casing is not fixed by \
+                                        any released rule). `saved` is the store \
+                                        timestamp, a `format: date-time` string \
+                                        (`schemas/query/StoredQuery.yaml`), \
+                                        rendered here as UTC extended ISO 8601 \
+                                        where the released examples show a \
+                                        `+01:00` offset form. `q` is returned \
+                                        exactly as stored.",
+            content((serde_json::Value = "application/json", example = json!([
+                {
+                    "name": "org.openehr::compositions",
+                    "type": "AQL",
+                    "version": "1.0.1",
+                    "saved": "2017-07-16T19:20:30Z",
+                    "q": "SELECT c FROM EHR e[ehr_id/value=$ehr_id] CONTAINS COMPOSITION c[$compositionid] WHERE c/name/value = 'Vitals'"
+                },
+                {
+                    "name": "org.openehr::compositions",
+                    "type": "AQL",
+                    "version": "1.1.7",
+                    "saved": "2018-06-13T09:37:20Z",
+                    "q": "SELECT c FROM EHR e[ehr_id/value=$ehr_id] CONTAINS COMPOSITION c[$uid] WHERE c/name/value = 'Vitals'"
+                }
+            ])))
+        ),
+        (status = 400, description = "The released trigger, verbatim: `400 Bad \
+                                      Request` \"is returned when the request \
+                                      could not be parsed or is invalid (e.g. \
+                                      malformed request URL syntax, missing \
+                                      required header or parameter, or \
+                                      syntactically invalid header, parameter or \
+                                      content)\" (ITS-REST \
+                                      `specifications/responses/400.yaml`). Here \
+                                      the only reachable trigger is malformed \
+                                      request URL syntax: a \
+                                      `qualified_query_name` segment whose \
+                                      percent-encoding does not decode to valid \
+                                      UTF-8, so no name can be read from the URL. \
+                                      A syntactically fine name that matches \
+                                      nothing is the empty `200` above. The \
+                                      released list operation does not enumerate \
+                                      `400`; the trigger is the cross-cutting \
+                                      one.",
+         body = serde_json::Value),
+        (status = 406, description = "The `Accept` header cannot be satisfied: \
+                                      the stored-query list has the single \
+                                      `application/json` representation the \
+                                      released response declares \
+                                      (`200_QueryList.yaml`, and \
+                                      `parameters/header/Accept_JSON.yaml` on the \
+                                      operation), so an exclusively-XML `Accept` \
+                                      is refused (`Resources.md` §\"JSON \
+                                      Format\": \"If the service cannot fulfill \
+                                      this aspect of the request, it MUST respond \
+                                      with HTTP status code `406 Not \
+                                      Acceptable`\"). The released operation does \
+                                      not enumerate `406`; the MUST is \
+                                      cross-cutting.",
          body = serde_json::Value)
     )
 )]
@@ -1418,22 +1588,122 @@ pub(crate) async fn definition_query_list(
     put, path = "/definition/query/{qualified_query_name}", tag = "Query",
     params(
         ("qualified_query_name" = String, Path,
-         description = "The qualified stored-query name \
-                        (`[{namespace}::]{query-name}`)."),
+         description = "\"The (fully qualified) name of the query …, in a format \
+                        of `[{namespace}::]{query-name}`\" (ITS-REST \
+                        `specifications/parameters/path/qualified_query_name.yaml`). \
+                        The grammar is \
+                        `specifications/docs/query/Qualified_query_name.md`: the \
+                        optional `namespace` \"should be in a form of a reverse \
+                        domain name\", and \"the `query-name` may include any \
+                        combination of characters, matched by the pattern \
+                        `[a-zA-Z0-9_.-]`\". Its NOTE is enforced here: \"The \
+                        `query-name` value must not be `aql` (case-insensitive), \
+                        as that is a reserved name\" — such a name is the `400` \
+                        below. An EXACT name on this operation (no prefix \
+                        matching); identity is case-insensitive but stored \
+                        case-preserving. A namespace-less name is keyed under \
+                        the assumed `misc` namespace — SM \
+                        `docs/openehr_platform/master04-definition_package.adoc` \
+                        §Registered Queries: \"If no namespace is supplied, the \
+                        namespace `misc` is assumed\" — the same canonical key \
+                        every other stored-query surface uses.",
+         example = "org.openehr::compositions"),
         ("query_type" = Option<String>, Query,
-         description = "The query formalism (default `AQL`); a non-AQL formalism \
-                        is an honest unsupported-formalism `400`.")
+         description = "\"Parameter indicating the query language/type\" \
+                        (ITS-REST \
+                        `specifications/parameters/query/query_type.yaml`, \
+                        `default: \"AQL\"`). Only AQL is supported: the store \
+                        validates and persists AQL, so an unsupported non-AQL \
+                        formalism is an honest unsupported-formalism `400` rather \
+                        than a blanket \"invalid AQL\". Matching is \
+                        case-insensitive and accepts the SM formalism-with-version \
+                        spelling (`aql`, `AQL::1.0.3`) — SM \
+                        `master04-definition_package.adoc` §Query Formalism.",
+         example = "AQL"),
+        ("Content-Type" = Option<String>, Header,
+         description = "`text/plain` — the operation's only declared payload \
+                        format \
+                        (`specifications/operations/definition_query_store.yaml` \
+                        carries `parameters/header/ContentType_text.yaml`, whose \
+                        enum is the single value `text/plain`). The body is read \
+                        as UTF-8 text; a body that is not UTF-8 is the `400` \
+                        below.",
+         example = "text/plain")
     ),
-    request_body(content((String = "text/plain")),
-                 description = "The AQL query text."),
+    request_body(content((String = "text/plain",
+                          example = "SELECT c FROM EHR e CONTAINS COMPOSITION c[openEHR-EHR-COMPOSITION.encounter.v1] CONTAINS OBSERVATION obs[openEHR-EHR-OBSERVATION.blood_pressure.v1] WHERE obs/data[at0001]/events[at0006]/data[at0003]/items[at0004]/value/magnitude >= $systolic_bp")),
+                 description = "\"The given AQL query\" \
+                                (`schemas/query/AQL.yaml`) as `text/plain`; \
+                                `required: true` on the released operation."),
     responses(
-        (status = 200, description = "Stored; `Location` addresses the stored \
-                                      query at its auto-assigned version.",
-         body = serde_json::Value),
-        (status = 400, description = "The AQL fails to parse, `query_type` is \
-                                      an unsupported non-AQL formalism, or the \
-                                      query-name is the reserved `aql` \
-                                      (case-insensitive).",
+        (
+            status = 200, description = "The released trigger, verbatim: `200 OK` \
+                                        \"is returned when the query was \
+                                        successfully stored\" (ITS-REST \
+                                        `specifications/responses/200_StoredQuery_stored.yaml`) \
+                                        — for the operation that \"stores a new \
+                                        query, or updates an existing query on \
+                                        the system\" \
+                                        (`operations/definition_query_store.yaml`). \
+                                        The response is BODYLESS: that released \
+                                        `200` declares a `Location` header and no \
+                                        `content` at all. The version this \
+                                        operation writes is the fixed `1.0.0` \
+                                        slot, re-written on each call — the \
+                                        released text names no version-minting \
+                                        rule for the version-less store, so the \
+                                        slot is OUR OWN design/extension, chosen \
+                                        so that \"or updates an existing query\" \
+                                        stays true while the VERSIONED store's \
+                                        `(name, version)` pairs remain immutable \
+                                        (`tags/StoredQuery_schema.md`).",
+            headers(
+                ("Location" = String,
+                 description = "\"The `Location` response header indicates the \
+                                URL of the Stored Query resource\" (ITS-REST \
+                                `specifications/headers/Location_Query.yaml`, \
+                                example \
+                                `https://openEHRSys.example.com/v1/definition/query/org.openehr::compositions/1.0.1`) \
+                                — set here to \
+                                `<base_path>/definition/query/<qualified_query_name>/<version>`, \
+                                naming the version THIS request stored, never \
+                                some other stored version of the same name. \
+                                Declaring `Location` on a `200` follows the \
+                                operation's own released response, which is the \
+                                specific text over the general rule that the \
+                                header \"MUST ONLY be used for resource creation \
+                                (e.g., `201 Created`) or redirect responses\" \
+                                (`Requests_and_responses.md` §Location) — a \
+                                released-vs-released conflict, reported \
+                                upstream.")
+            )
+        ),
+        (status = 400, description = "The released trigger, verbatim: `400 Bad \
+                                      Request` \"is returned when the request \
+                                      could not be parsed or is invalid (e.g. \
+                                      malformed request URL syntax, missing \
+                                      required header or parameter, or \
+                                      syntactically invalid header, parameter or \
+                                      content)\" (ITS-REST \
+                                      `specifications/responses/400.yaml`). The \
+                                      concrete triggers here: the query-name \
+                                      segment is the reserved `aql` \
+                                      (case-insensitive) — \"the `query-name` \
+                                      value must not be `aql` (case-insensitive), \
+                                      as that is a reserved name\" \
+                                      (`docs/query/Qualified_query_name.md` \
+                                      NOTE); the body is not syntactically valid \
+                                      AQL (a store-time parse, realizing the SM \
+                                      `Pre_valid_query` precondition of \
+                                      `store_query` — SM \
+                                      `docs/UML/classes/i_definition_query.adoc` \
+                                      — syntactically, which is the only branch \
+                                      the released status set grounds: this \
+                                      operation declares `200` and `400` only, \
+                                      and QUERY 1.1.0 states no store-time \
+                                      validity requirement); an unsupported \
+                                      non-AQL `query_type`; or a body that is not \
+                                      UTF-8 text.",
          body = serde_json::Value)
     )
 )]
@@ -1457,18 +1727,124 @@ pub(crate) async fn definition_query_store_yaml(
     get, path = "/definition/query/{qualified_query_name}/{version}", tag = "Query",
     params(
         ("qualified_query_name" = String, Path,
-         description = "The qualified stored-query name \
-                        (`[{namespace}::]{query-name}`)."),
+         description = "\"The (fully qualified) name of the query …, in a format \
+                        of `[{namespace}::]{query-name}`\" (ITS-REST \
+                        `specifications/parameters/path/qualified_query_name.yaml`; \
+                        grammar in \
+                        `specifications/docs/query/Qualified_query_name.md`, \
+                        including its NOTE that \"the `query-name` value must not \
+                        be `aql` (case-insensitive), as that is a reserved \
+                        name\"). Matched EXACTLY here — case-insensitively, and \
+                        with a namespace-less name resolving against the `misc` \
+                        namespace the store keys it under (SM \
+                        `docs/openehr_platform/master04-definition_package.adoc` \
+                        §Registered Queries) — never as a prefix; that is the \
+                        sibling list operation's semantic.",
+         example = "org.openehr::compositions"),
         ("version" = String, Path,
-         description = "A SEMVER version (exact, or a `{major}`/`{major}.{minor}` \
-                        prefix resolving to the highest matching version).")
+         description = "\"A SEMVER version number. This can be an exact version \
+                        (e.g. `1.7.1`), or a pattern as partial prefix, in a form \
+                        of `{major}` or `{major}.{minor}` (e.g. `1` or `1.0`), in \
+                        which case the highest (latest) version matching the \
+                        prefix will be considered\" (ITS-REST \
+                        `specifications/parameters/path/version.yaml`; the same \
+                        rule in `docs/query/Qualified_query_name.md`: \"the \
+                        system must use the latest `version` with the supplied \
+                        prefix\"). Prefixes match on a dot boundary (`1` matches \
+                        `1.x.y`, never `10.0.0`) and resolve over the numeric \
+                        `major.minor.patch` axis. A value that matches no stored \
+                        version — including a malformed one — is the `404` below; \
+                        the read side never rejects the selector itself, which is \
+                        where it differs from the versioned STORE (whose \
+                        `version` must be an exact three-part number).",
+         example = "1.0"),
+        ("Accept" = Option<String>, Header,
+         description = "`application/json` — the single representation this \
+                        operation declares \
+                        (`specifications/parameters/header/Accept_JSON.yaml` on \
+                        the operation, `responses/200_StoredQuery_get.yaml` for \
+                        the body). Absent or `*/*` reads as JSON.",
+         example = "application/json")
     ),
     responses(
-        (status = 200, description = "The stored query and its metadata \
-                                      (canonical JSON).",
+        (
+            status = 200, description = "The released trigger, verbatim: `200 OK` \
+                                        \"is returned when the stored AQL is \
+                                        successfully retrieved\" (ITS-REST \
+                                        `specifications/responses/200_StoredQuery_get.yaml`) \
+                                        — the operation \"retrieves the \
+                                        definition of a particular stored query \
+                                        (at specified version) and its associated \
+                                        metadata\" \
+                                        (`operations/definition_query_version_get.yaml`). \
+                                        The body is one `StoredQuery` object \
+                                        carrying all five members the schema \
+                                        REQUIRES — `name`, `type`, `version`, \
+                                        `saved`, `q` \
+                                        (`schemas/query/StoredQuery.yaml`). \
+                                        `version` is the CONCRETE stored version \
+                                        a prefix resolved to, never the prefix \
+                                        that addressed it; `type` echoes the \
+                                        stored formalism, recorded as `AQL` (the \
+                                        `default`/`example` of \
+                                        `schemas/query/QueryType.yaml`; the \
+                                        released response examples spell it \
+                                        lowercase and no released rule fixes the \
+                                        casing); `saved` is the store timestamp, \
+                                        a `format: date-time` string rendered as \
+                                        UTC extended ISO 8601; `q` is returned \
+                                        verbatim as stored. No `ETag` and no \
+                                        `Last-Modified`: the released response \
+                                        declares only `Content-Type`, and this \
+                                        build adds neither on a stored query.",
+            content((serde_json::Value = "application/json", example = json!({
+                "name": "org.openehr::compositions",
+                "type": "AQL",
+                "version": "1.0.1",
+                "saved": "2017-07-16T19:20:30Z",
+                "q": "SELECT c FROM EHR e[ehr_id/value=$ehr_id] CONTAINS COMPOSITION c[$compositionid] WHERE c/name/value = 'Vitals'"
+            })))
+        ),
+        (status = 400, description = "The released trigger, verbatim: `400 Bad \
+                                      Request` \"is returned when the request \
+                                      could not be parsed or is invalid (e.g. \
+                                      malformed request URL syntax, missing \
+                                      required header or parameter, or \
+                                      syntactically invalid header, parameter or \
+                                      content)\" (ITS-REST \
+                                      `specifications/responses/400.yaml`). Here \
+                                      the only reachable trigger is malformed \
+                                      request URL syntax: a path segment whose \
+                                      percent-encoding does not decode to valid \
+                                      UTF-8, so no name/version can be read from \
+                                      the URL. A well-formed selector that \
+                                      resolves to nothing is the `404` below. The \
+                                      released operation does not enumerate \
+                                      `400`; the trigger is the cross-cutting \
+                                      one.",
          body = serde_json::Value),
-        (status = 404, description = "No stored query matches that name and \
-                                      version.",
+        (status = 404, description = "The released trigger, verbatim: `404 Not \
+                                      Found` \"is returned when a stored query \
+                                      with `qualified_query_name` and `version` \
+                                      does not exist\" (ITS-REST \
+                                      `specifications/responses/404_Query_version.yaml`) \
+                                      — the name is unknown, or no stored version \
+                                      matches the exact value or the prefix.",
+         body = serde_json::Value),
+        (status = 406, description = "The `Accept` header cannot be satisfied: a \
+                                      stored query has the single \
+                                      `application/json` representation the \
+                                      released response declares \
+                                      (`200_StoredQuery_get.yaml`, and \
+                                      `parameters/header/Accept_JSON.yaml` on the \
+                                      operation), so an exclusively-XML `Accept` \
+                                      is refused (`Resources.md` §\"JSON \
+                                      Format\": \"If the service cannot fulfill \
+                                      this aspect of the request, it MUST respond \
+                                      with HTTP status code `406 Not \
+                                      Acceptable`\"). The released operation does \
+                                      not enumerate `406`; the MUST is \
+                                      cross-cutting.",
          body = serde_json::Value)
     )
 )]
@@ -1489,32 +1865,146 @@ pub(crate) async fn definition_query_version_get(
 /// Store a named AQL query at a specific version
 /// (`PUT /definition/query/{qualified_query_name}/{version}`).
 ///
-/// The AQL text is the `text/plain` request body; the version is stored verbatim.
+/// The AQL text is the `text/plain` request body; the `(name, version)` pair is
+/// immutable, so a second store at the same pair is a `409`.
 #[utoipa::path(
     put, path = "/definition/query/{qualified_query_name}/{version}", tag = "Query",
     params(
         ("qualified_query_name" = String, Path,
-         description = "The qualified stored-query name \
-                        (`[{namespace}::]{query-name}`)."),
+         description = "\"The (fully qualified) name of the query …, in a format \
+                        of `[{namespace}::]{query-name}`\" (ITS-REST \
+                        `specifications/parameters/path/qualified_query_name.yaml`; \
+                        grammar in \
+                        `specifications/docs/query/Qualified_query_name.md`). Its \
+                        NOTE is enforced: \"The `query-name` value must not be \
+                        `aql` (case-insensitive), as that is a reserved name\" — \
+                        such a name is the `400` below. Identity is \
+                        case-insensitive, stored case-preserving; a \
+                        namespace-less name is keyed under the assumed `misc` \
+                        namespace (SM \
+                        `docs/openehr_platform/master04-definition_package.adoc` \
+                        §Registered Queries).",
+         example = "org.openehr::compositions"),
         ("version" = String, Path,
-         description = "The exact SEMVER version to store the query under."),
+         description = "The SEMVER version to store the query under — \"in the \
+                        format specified by SEMVER style (i.e. \
+                        `major.minor.patch`)\" \
+                        (`docs/query/Qualified_query_name.md`). On the WRITE it \
+                        must be an EXACT three-part numeric version: the prefix \
+                        grammar of \
+                        `specifications/parameters/path/version.yaml` (\"a \
+                        pattern as partial prefix … the highest (latest) version \
+                        matching the prefix will be considered\") is a \
+                        READ-resolution semantic with nothing to resolve on a \
+                        store, and the released text assigns no meaning to a \
+                        prefix or malformed version here. Anything that is not \
+                        `major.minor.patch` — a prefix (`1`, `1.0`), a \
+                        pre-release/build suffix (`1.0.0-rc.1`), a non-numeric \
+                        segment — is a \"syntactically invalid … parameter\" \
+                        `400` (`responses/400.yaml`). That reading of the \
+                        released silence is OURS, and it keeps the whole \
+                        stored-query surface coherent: every list and get \
+                        resolves versions numerically, so a non-numeric stored \
+                        version would break reads of unrelated queries.",
+         example = "1.0.1"),
         ("query_type" = Option<String>, Query,
-         description = "The query formalism (default `AQL`); a non-AQL formalism \
-                        is an honest unsupported-formalism `400`.")
+         description = "\"Parameter indicating the query language/type\" \
+                        (ITS-REST \
+                        `specifications/parameters/query/query_type.yaml`, \
+                        `default: \"AQL\"`); only AQL is supported, so an \
+                        unsupported non-AQL formalism is an honest \
+                        unsupported-formalism `400`. Matching is case-insensitive \
+                        and accepts the SM formalism-with-version spelling (SM \
+                        `master04-definition_package.adoc` §Query Formalism).",
+         example = "AQL")
     ),
-    request_body(content((String = "text/plain")),
-                 description = "The AQL query text."),
+    request_body(content((String = "text/plain",
+                          example = "SELECT c FROM EHR e CONTAINS COMPOSITION c[openEHR-EHR-COMPOSITION.encounter.v1] CONTAINS OBSERVATION obs[openEHR-EHR-OBSERVATION.blood_pressure.v1] WHERE obs/data[at0001]/events[at0006]/data[at0003]/items[at0004]/value/magnitude >= $systolic_bp")),
+                 description = "\"The given AQL query\" \
+                                (`schemas/query/AQL.yaml`) as `text/plain` — the \
+                                only request content type the released operation \
+                                declares (`required: true`). Unlike the \
+                                version-less sibling this operation carries no \
+                                `Content-Type` header parameter of its own; the \
+                                body is read as UTF-8 text."),
     responses(
-        (status = 200, description = "Stored; `Location` addresses the stored \
-                                      query at this version.",
+        (
+            status = 200, description = "The released trigger, verbatim: `200 OK` \
+                                        \"is returned when the query was \
+                                        successfully stored\" (ITS-REST \
+                                        `specifications/responses/200_StoredQuery_stored.yaml`) \
+                                        — for the operation that \"stores a \
+                                        query, at a specified `version`, on the \
+                                        system\" \
+                                        (`operations/definition_query_version_store.yaml`). \
+                                        The response is BODYLESS: that released \
+                                        `200` declares a `Location` header and no \
+                                        `content` at all. The `(name, version)` \
+                                        pair is written once and never \
+                                        overwritten — a stored query is \
+                                        \"a reusable, immutable way to identify a \
+                                        specific AQL statement\" \
+                                        (`tags/StoredQuery_schema.md`) — so a \
+                                        repeat store at the same pair is the \
+                                        `409` below, not a second `200`.",
+            headers(
+                ("Location" = String,
+                 description = "\"The `Location` response header indicates the \
+                                URL of the Stored Query resource\" (ITS-REST \
+                                `specifications/headers/Location_Query.yaml`, \
+                                example \
+                                `https://openEHRSys.example.com/v1/definition/query/org.openehr::compositions/1.0.1`) \
+                                — set here to \
+                                `<base_path>/definition/query/<qualified_query_name>/<version>`, \
+                                the exact version this request stored. Declaring \
+                                `Location` on a `200` follows the operation's own \
+                                released response, which is the specific text \
+                                over the general rule that the header \"MUST ONLY \
+                                be used for resource creation (e.g., `201 \
+                                Created`) or redirect responses\" \
+                                (`Requests_and_responses.md` §Location) — a \
+                                released-vs-released conflict, reported \
+                                upstream.")
+            )
+        ),
+        (status = 400, description = "The released trigger, verbatim: `400 Bad \
+                                      Request` \"is returned when the request \
+                                      could not be parsed or is invalid (e.g. \
+                                      malformed request URL syntax, missing \
+                                      required header or parameter, or \
+                                      syntactically invalid header, parameter or \
+                                      content)\" (ITS-REST \
+                                      `specifications/responses/400.yaml`). The \
+                                      concrete triggers here: `version` is not an \
+                                      exact three-part numeric SEMVER (see that \
+                                      parameter); the query-name segment is the \
+                                      reserved `aql` (case-insensitive) — \"the \
+                                      `query-name` value must not be `aql` \
+                                      (case-insensitive), as that is a reserved \
+                                      name\" (`docs/query/Qualified_query_name.md` \
+                                      NOTE); the body is not syntactically valid \
+                                      AQL (the store-time parse realizing the SM \
+                                      `Pre_valid_query` precondition of \
+                                      `store_query`, SM \
+                                      `docs/UML/classes/i_definition_query.adoc`, \
+                                      syntactically — the only branch the \
+                                      released status set grounds); an \
+                                      unsupported non-AQL `query_type`; or a body \
+                                      that is not UTF-8 text.",
          body = serde_json::Value),
-        (status = 400, description = "The AQL fails to parse, `query_type` is \
-                                      an unsupported non-AQL formalism, or the \
-                                      query-name is the reserved `aql` \
-                                      (case-insensitive).",
-         body = serde_json::Value),
-        (status = 409, description = "A stored query already exists at this \
-                                      `(name, version)`.",
+        (status = 409, description = "The released trigger, verbatim: `409 \
+                                      Conflict` \"is returned when a query with \
+                                      the given `qualified_query_name` and \
+                                      `version` already exists on the server\" \
+                                      (ITS-REST \
+                                      `specifications/responses/409_StoredQuery_version.yaml`) \
+                                      — the pair is compared case-insensitively \
+                                      on the name (BASE \
+                                      `docs/base_types/master05-identification_package.adoc` \
+                                      §Composite Identifiers and Case) and the \
+                                      insert is race-safe, so two concurrent \
+                                      stores of the same pair yield one `200` and \
+                                      one `409`.",
          body = serde_json::Value)
     )
 )]

--- a/app/ehrbase-rest/src/api/definition/openapi_routes.rs
+++ b/app/ehrbase-rest/src/api/definition/openapi_routes.rs
@@ -1704,6 +1704,21 @@ pub(crate) async fn definition_query_list(
                                       validity requirement); an unsupported \
                                       non-AQL `query_type`; or a body that is not \
                                       UTF-8 text.",
+         body = serde_json::Value),
+        (status = 415, description = "The request DECLARES a payload media type \
+                                      the service cannot process as this \
+                                      operation's `text/plain` AQL body: a \
+                                      payload the service cannot process in the \
+                                      declared format \"MUST respond with HTTP \
+                                      status code `415 Unsupported Media Type`\" \
+                                      (`Resources.md` §format rules — the same \
+                                      cross-cutting MUST that grounds the \
+                                      template-upload guards). An absent \
+                                      `Content-Type` declares nothing to refuse \
+                                      and is accepted. The released operation \
+                                      does not enumerate `415`; the MUST is \
+                                      cross-cutting (`Requests_and_responses.md` \
+                                      §\"HTTP status codes\", the `415` row).",
          body = serde_json::Value)
     )
 )]
@@ -2005,6 +2020,21 @@ pub(crate) async fn definition_query_version_get(
                                       insert is race-safe, so two concurrent \
                                       stores of the same pair yield one `200` and \
                                       one `409`.",
+         body = serde_json::Value),
+        (status = 415, description = "The request DECLARES a payload media type \
+                                      the service cannot process as this \
+                                      operation's `text/plain` AQL body: a \
+                                      payload the service cannot process in the \
+                                      declared format \"MUST respond with HTTP \
+                                      status code `415 Unsupported Media Type`\" \
+                                      (`Resources.md` §format rules — the same \
+                                      cross-cutting MUST that grounds the \
+                                      template-upload guards). An absent \
+                                      `Content-Type` declares nothing to refuse \
+                                      and is accepted. The released operation \
+                                      does not enumerate `415`; the MUST is \
+                                      cross-cutting (`Requests_and_responses.md` \
+                                      §\"HTTP status codes\", the `415` row).",
          body = serde_json::Value)
     )
 )]

--- a/app/ehrbase-rest/tests/served_openapi.rs
+++ b/app/ehrbase-rest/tests/served_openapi.rs
@@ -178,11 +178,6 @@ async fn every_operation_documents_an_error_outcome() {
         "/health",
         "/health/liveness",
         "/ehrbase/rest/status",
-        // Stored-query list endpoints whose released contract is 200-only (an
-        // unmatched name prefix yields an empty list, never an error):
-        // definition_query_list.yaml.
-        "/ehrbase/rest/openehr/v1/definition/query",
-        "/ehrbase/rest/openehr/v1/definition/query/{qualified_query_name}",
     ];
     let doc = served_document().await;
     let mut findings = Vec::new();


### PR DESCRIPTION
Closes #499.

Step-6 of the group-11 audit (#387): the four released stored-query declarations plus our extension list-all route in `openapi_routes.rs`, brought to the same completeness bar as the template declarations (PR #495).

- **Both store 200s** declare the `Location` header (verbatim `headers/Location_Query.yaml` + the released example URL) and the bodyless-200 shape (`responses/200_StoredQuery_stored.yaml`); request bodies as `text/plain` with the released AQL example; the `1.0.0` default slot flagged as our own design; the `Location`-on-200 vs overview-§Location conflict noted (register-carried).
- **Every served branch with a verbatim released trigger**: 409 on the versioned store (case-insensitive pair identity, race-safety note), 400 on all four with the concrete triggers (reserved `aql` name, syntactic AQL parse realizing SM `Pre_valid_query`, unsupported `query_type`, the exact-three-part SEMVER rule on the versioned form — describing the post-#498 wire), 404 on the version get, 406 on the GETs (cross-cutting MUST), and — added post-#501 in the follow-up commit — 415 on both stores now that the wire guards exist.
- **Parameter prose**: the `[{namespace}::]{query-name}` grammar + `aql` reservation + SM `misc`-default blend on the name; read-side prefix resolution vs write-side exact SEMVER on `version`; `query_type` default.
- **Examples**: the released two-version `QueryList` array and the five-member `StoredQuery` object.
- **`GET /definition/query`** declared honestly as our extension (the release defines only the `{qualified_query_name}` operation; its "empty ⇒ wildcard" clause has no addressable released form).
- The two stored-query `EXEMPT` entries dropped from `served_openapi.rs` — the completeness rule now enforces them (ratchet up).

**Gates:** clippy `-p ehrbase-rest --all-targets` clean; nextest `-p ehrbase-rest` 537 passed / 0 failed.