### PR TITLE
chore(cnf): ratchet the conformance baseline — group-11 closing zero-drift run

### DIFF
--- a/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
@@ -7,12 +7,12 @@ Runner: cnf-runner 3.11.0 · verification pack: passed
 
 | Status | Count |
 | --- | --- |
-| passed | 499 |
+| passed | 517 |
 | failed | 0 |
 | errored | 0 |
 | skipped | 0 |
-| not_applicable | 67 |
-| total | 566 |
+| not_applicable | 70 |
+| total | 587 |
 
 ## By chapter
 
@@ -24,7 +24,7 @@ Runner: cnf-runner 3.11.0 · verification pack: passed
 | I_ADMIN_SERVICE | 2 | 0 | 0 | 0 | 10 |
 | I_DEFINITION_ADL14 | 19 | 0 | 0 | 0 | 6 |
 | I_DEFINITION_ADL2 | 21 | 0 | 0 | 0 | 8 |
-| I_DEFINITION_QUERY | 10 | 0 | 0 | 0 | 0 |
+| I_DEFINITION_QUERY | 28 | 0 | 0 | 0 | 3 |
 | I_DEMOGRAPHIC_SERVICE | 16 | 0 | 0 | 0 | 12 |
 | I_EHR_COMPOSITION | 65 | 0 | 0 | 0 | 0 |
 | I_EHR_CONTRIBUTION | 47 | 0 | 0 | 0 | 5 |
@@ -73,7 +73,7 @@ Percentiles re-derive from the embedded HDR V2 histograms; the class verdict is 
 
 ## Honesty
 
-Coverage: 499 of 566 selected cases driven.
+Coverage: 517 of 587 selected cases driven.
 
 Not-executed verdicts (each cited):
 
@@ -109,6 +109,9 @@ Not-executed verdicts (each cited):
 | I_DEFINITION_ADL2.list_artefacts-unrealized | I_DEFINITION_ADL2.list_artefacts: AMB-37 |
 | I_DEFINITION_ADL2.opts_count-unrealized | I_DEFINITION_ADL2.opts_count: AMB-37 |
 | I_DEFINITION_ADL2.templates_count-unrealized | I_DEFINITION_ADL2.templates_count: AMB-37 |
+| I_DEFINITION_QUERY.delete_query-delete_existing | I_DEFINITION_QUERY.delete_query: AMB-127 |
+| I_DEFINITION_QUERY.list_matching_queries-id_pattern | I_DEFINITION_QUERY.list_matching_queries: AMB-121 |
+| I_DEFINITION_QUERY.queries_count-count | I_DEFINITION_QUERY.queries_count: AMB-127 |
 | I_DEMOGRAPHIC_SERVICE.create_party_relationship-aaaa | I_DEMOGRAPHIC_SERVICE.create_party_relationship: AMB-32 |
 | I_DEMOGRAPHIC_SERVICE.create_party_relationship-bbbb | I_DEMOGRAPHIC_SERVICE.create_party_relationship: AMB-32 |
 | I_DEMOGRAPHIC_SERVICE.delete_party_relationship-aaaa | I_PARTY_RELATIONSHIP.delete_party_relationship: AMB-32 |

--- a/docs/conformance/ehrbase-rs/badge.json
+++ b/docs/conformance/ehrbase-rs/badge.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "openEHR conformance",
-  "message": "CORE+STANDARD PASS \u00b7 499/499 cases",
+  "message": "CORE+STANDARD PASS \u00b7 517/517 cases",
   "color": "brightgreen"
 }

--- a/docs/conformance/ehrbase-rs/results.json
+++ b/docs/conformance/ehrbase-rs/results.json
@@ -42,6 +42,13 @@
       "rows_total": 1
     },
     {
+      "case": "I_DEFINITION_QUERY.queries_count-count",
+      "status": "not_applicable",
+      "rows_driven": 0,
+      "rows_total": 1,
+      "citation": "I_DEFINITION_QUERY.queries_count: AMB-127"
+    },
+    {
       "case": "I_ADMIN_ARCHIVE.archive_ehrs-archive_selected",
       "status": "not_applicable",
       "rows_driven": 0,
@@ -1932,7 +1939,27 @@
       "rows_total": 2
     },
     {
+      "case": "I_DEFINITION_QUERY.delete_query-delete_existing",
+      "status": "not_applicable",
+      "rows_driven": 0,
+      "rows_total": 1,
+      "citation": "I_DEFINITION_QUERY.delete_query: AMB-127"
+    },
+    {
       "case": "I_DEFINITION_QUERY.has_query-xxx",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEFINITION_QUERY.list_matching_queries-id_pattern",
+      "status": "not_applicable",
+      "rows_driven": 0,
+      "rows_total": 1,
+      "citation": "I_DEFINITION_QUERY.list_matching_queries: AMB-121"
+    },
+    {
+      "case": "I_DEFINITION_QUERY.list_queries-no_match_empty_list",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -1944,7 +1971,61 @@
       "rows_total": 1
     },
     {
+      "case": "I_DEFINITION_QUERY.list_queries-prefix_all_versions",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_DEFINITION_QUERY.list_queries-select_items",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEFINITION_QUERY.list_queries-version_get_exact",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEFINITION_QUERY.list_queries-version_get_major_prefix",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEFINITION_QUERY.list_queries-version_get_minor_prefix",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEFINITION_QUERY.list_queries-version_get_unknown",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEFINITION_QUERY.list_queries-version_get_xml_not_acceptable",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEFINITION_QUERY.list_queries-xml_not_acceptable",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEFINITION_QUERY.store_query-default_slot_with_higher_version",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEFINITION_QUERY.store_query-default_version_slot",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -1963,6 +2044,54 @@
     },
     {
       "case": "I_DEFINITION_QUERY.store_query-unqualified_name",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEFINITION_QUERY.store_query-update_in_place",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEFINITION_QUERY.store_query-version_duplicate_case_variant_name",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEFINITION_QUERY.store_query-version_duplicate_conflict",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEFINITION_QUERY.store_query-version_malformed_rejected",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEFINITION_QUERY.store_query-version_prefix_rejected",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEFINITION_QUERY.store_query-version_prerelease_rejected",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEFINITION_QUERY.store_query-version_stored",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEFINITION_QUERY.store_query-wrong_media",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1

--- a/docs/conformance/ehrbase-rs/run-exceptions.json
+++ b/docs/conformance/ehrbase-rs/run-exceptions.json
@@ -1,5 +1,12 @@
 [
   {
+    "case": "I_DEFINITION_QUERY.queries_count-count",
+    "exception": {
+      "kind": "unrealized",
+      "detail": "I_DEFINITION_QUERY.queries_count: AMB-127"
+    }
+  },
+  {
     "case": "I_ADMIN_ARCHIVE.archive_ehrs-archive_selected",
     "exception": {
       "kind": "unrealized",
@@ -242,6 +249,27 @@
     "exception": {
       "kind": "unrealized",
       "detail": "I_DEFINITION_ADL2.templates_count: AMB-37"
+    }
+  },
+  {
+    "case": "I_DEFINITION_QUERY.delete_query-delete_existing",
+    "exception": {
+      "kind": "unrealized",
+      "detail": "I_DEFINITION_QUERY.delete_query: AMB-127"
+    }
+  },
+  {
+    "case": "I_DEFINITION_QUERY.list_matching_queries-id_pattern",
+    "exception": {
+      "kind": "unrealized",
+      "detail": "I_DEFINITION_QUERY.list_matching_queries: AMB-121"
+    }
+  },
+  {
+    "case": "I_DEFINITION_QUERY.store_query_set-register",
+    "exception": {
+      "kind": "status",
+      "detail": "Draft — never verdict-bearing"
     }
   },
   {

--- a/docs/conformance/ehrbase-rs/verdicts.json
+++ b/docs/conformance/ehrbase-rs/verdicts.json
@@ -183,7 +183,7 @@
     }
   ],
   "coverage": {
-    "selected": 566,
-    "driven": 499
+    "selected": 587,
+    "driven": 517
   }
 }


### PR DESCRIPTION
The group-11 (#387) closing pipeline run — clean on the first pass, no triage.

**587 case-records: 517 passed / 0 failed / 0 errored / 70 cited n-a; 39 capability verdicts, 0 review findings.** Baseline ratchets **499 → 517** with the group-11 stored-query catalogue (PRs #501/#502/#503): the Location-at-written-version probes (incl. the higher-version-present discriminator for the #498 fix), exact-SEMVER 400s, wrong-media 415, list/version-get prefix resolution + 404/406, and the `I_DEFINITION_QUERY` unrealized set with cited n-a verdicts.