### PR TITLE
fix(demographic): stale-delete 409 echoes the latest version ETag; contribution GET carries ETag + Last-Modified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **Demographic header echoes** (#388). The stale-version party DELETE's
+  `409 Conflict` now returns the latest `version_uid` in `ETag` (the released
+  response requires it); and the demographic CONTRIBUTION read now carries
+  the weak `ETag` (the contribution uid) and `Last-Modified` from the
+  committal instant, matching its EHR sibling.
+
 - **The published API reference now describes the demographic endpoints in
   full** (#505). The 26 person / agent / group / organisation / role,
   versioned-party and demographic-contribution operations in the served

--- a/app/ehrbase-rest/src/api/demographic/contribution.rs
+++ b/app/ehrbase-rest/src/api/demographic/contribution.rs
@@ -46,11 +46,27 @@ pub(super) async fn run(
         }
         "contribution_get" => {
             let p = params::build::<ContributionGetParams>(&parts.path, q, h)?;
+            let uid = p.contribution_uid.clone();
             let resp = state
                 .backend()
                 .demographic_contribution_get(p.contribution_uid)
                 .await?;
-            Ok(negotiate::respond(h, StatusCode::OK, &resp.body))
+            // Weak ETag (the contribution uid — the same identity the 201's
+            // ETag carries) + Last-Modified from `audit.time_committed`,
+            // mirroring the EHR sibling's register-documented reading of the
+            // overview §"ETag and Last-Modified" SHOULD (a CONTRIBUTION is
+            // immutable and uniquely identified; the released 200_CONTRIBUTION
+            // declares neither header).
+            let mut meta = ehrbase::service::response::ResourceMeta::new(String::new(), uid);
+            if let Some(at) = resp.body["audit"]["time_committed"]["value"]
+                .as_str()
+                .and_then(|raw| raw.parse::<jiff::Timestamp>().ok())
+            {
+                meta = meta.with_last_modified(at);
+            }
+            let mut out = negotiate::respond(h, StatusCode::OK, &resp.body);
+            super::set_versioning_headers(&mut out, Some(&meta));
+            Ok(out)
         }
         other => Err(RestError(ApiError::Internal(format!(
             "unrouted demographic contribution operation: {other}"

--- a/app/ehrbase-rest/tests/demographic_http.rs
+++ b/app/ehrbase-rest/tests/demographic_http.rs
@@ -893,3 +893,97 @@ async fn person_create_identifier_returns_the_uid_body() {
         "overview §\"Prefer only identifier\": a single JSON object with a single uid attribute"
     );
 }
+
+// ── group-12 close triage: the two header-echo defects ───────────────────────
+
+/// The stale-version DELETE answers `409` AND echoes the latest `version_uid`
+/// in `ETag` (`responses/409_PERSON_with_uid_based_id.yaml`: "Returns also
+/// latest `version_uid` in the `ETag` header").
+#[tokio::test]
+async fn stale_delete_conflict_echoes_latest_version_etag() {
+    let (_pg, app) = app().await;
+    let v1 = create(&app, "person", &person_body()).await;
+    // Supersede v1 with an update.
+    let put = Request::builder()
+        .method("PUT")
+        .uri(format!("{BASE}/demographic/person/{}", vo_of(&v1)))
+        .header(header::CONTENT_TYPE, "application/json")
+        .header("If-Match", format!("\"{v1}\""))
+        .body(Body::from(person_body().to_string()))
+        .unwrap();
+    let (status, h, body) = send(&app, put).await;
+    assert_eq!(status, StatusCode::NO_CONTENT, "{body}");
+    let v2 = etag_uid(&h);
+    // Delete at the superseded uid → 409 + the latest version's ETag.
+    let del = Request::builder()
+        .method("DELETE")
+        .uri(format!("{BASE}/demographic/person/{v1}"))
+        .body(Body::empty())
+        .unwrap();
+    let (status, h, body) = send(&app, del).await;
+    assert_eq!(status, StatusCode::CONFLICT, "{body}");
+    assert_eq!(
+        etag_uid(&h),
+        v2,
+        "the 409 returns the latest version_uid in ETag \
+         (409_PERSON_with_uid_based_id.yaml)"
+    );
+}
+
+/// The demographic CONTRIBUTION read carries the weak `ETag` (the contribution
+/// uid — the same identity the 201's ETag carries) and `Last-Modified` from
+/// `audit.time_committed`, mirroring the EHR sibling's register-documented
+/// reading of the overview §"ETag and Last-Modified" SHOULD.
+#[tokio::test]
+async fn demographic_contribution_get_carries_etag_and_last_modified() {
+    let (_pg, app) = app().await;
+    let commit = serde_json::json!({
+        "versions": [{
+            "data": person_body(),
+            "lifecycle_state": {
+                "_type": "DV_CODED_TEXT",
+                "value": "complete",
+                "defining_code": { "_type": "CODE_PHRASE",
+                    "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" },
+                    "code_string": "532" }
+            },
+            "commit_audit": {
+                "change_type": {
+                    "_type": "DV_CODED_TEXT",
+                    "value": "creation",
+                    "defining_code": { "_type": "CODE_PHRASE",
+                        "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" },
+                        "code_string": "249" }
+                },
+                "committer": { "_type": "PARTY_IDENTIFIED", "name": "committer" }
+            }
+        }],
+        "audit": {
+            "change_type": {
+                "_type": "DV_CODED_TEXT",
+                "value": "creation",
+                "defining_code": { "_type": "CODE_PHRASE",
+                    "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" },
+                    "code_string": "249" }
+            },
+            "committer": { "_type": "PARTY_IDENTIFIED", "name": "committer" }
+        }
+    });
+    let post = Request::builder()
+        .method("POST")
+        .uri(format!("{BASE}/demographic/contribution"))
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(commit.to_string()))
+        .unwrap();
+    let (status, h, body) = send(&app, post).await;
+    assert_eq!(status, StatusCode::CREATED, "{body}");
+    let cid = etag_uid(&h);
+    let (status, h, body) = get_json(&app, format!("{BASE}/demographic/contribution/{cid}")).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(etag_uid(&h), cid, "ETag = the contribution uid");
+    assert!(
+        h.get(header::LAST_MODIFIED).is_some(),
+        "Last-Modified from audit.time_committed"
+    );
+    assert!(location(&h).is_none(), "no Location on a GET");
+}

--- a/app/ehrbase/src/service/demographic/party.rs
+++ b/app/ehrbase/src/service/demographic/party.rs
@@ -359,7 +359,12 @@ impl EhrbaseService {
         if let Some(expected) = expected
             && current.tree != expected
         {
-            return Err(ServiceError::Conflict(format!(
+            // A stale preceding version is a VERSION MISMATCH: the wire arm
+            // answers `409` and echoes the latest `version_uid` in `ETag`
+            // (`responses/409_PERSON_with_uid_based_id.yaml`: "Returns also
+            // latest `version_uid` in the `ETag` header") — the handler's
+            // mismatch arm keys on this variant.
+            return Err(ServiceError::VersionConflict(format!(
                 "preceding_version_uid names version {expected}, latest is {}",
                 current.tree
             )));


### PR DESCRIPTION
Group-12 (#388) closing-run triage: three red rows, all attributed to the APPLICATION by three-way comparison (spec-required vs catalogue-expected vs SUT-observed).

**Row 1 — `delete_party-stale_version_conflict`.** Spec: `responses/409_PERSON_with_uid_based_id.yaml` — "Returns also latest `version_uid` in the `ETag` header." Observed: 409 with no ETag. Cause: the service's stale-version arm raised `ServiceError::Conflict` (→ `CompositionAlreadyExists`) while the handler's ETag-echoing arm guards on `VersionMismatch` — the very variant the handler's own wire comment documents as the contract. The stale arm now raises `VersionConflict`; the 409 lands in the echoing arm.

**Rows 2+3 — `commit_contribution-demographic` (+ `_client_uid`), both failing on their `get_contribution` step.** Spec: AMB-87's register adjudication (the immutable, uniquely-identified CONTRIBUTION carries its identity as the weak ETag and its committal instant as Last-Modified — the overview §"ETag and Last-Modified" SHOULD), implemented on the EHR sibling with the identical binding matcher passing. Observed: the demographic GET served a plain 200 with neither header. The handler now mirrors the EHR sibling (ETag = contribution uid; Last-Modified from `audit.time_committed`).

The catalogue and runner were correct on all three rows — no expectation changed.

**Tests:** two new wire batteries in `demographic_http.rs` (stale-delete 409 ETag echo incl. the superseding update; contribution GET ETag/Last-Modified/no-Location round-trip).

**Gates:** clippy (both crates, all targets) clean; nextest `-p ehrbase -p ehrbase-rest` 1179 passed / 0 failed. The pipeline re-run follows this merge as the group-12 close.