### PR TITLE
chore(cnf): ratchet the conformance baseline — group-12 closing zero-drift run

### DIFF
--- a/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
@@ -7,12 +7,12 @@ Runner: cnf-runner 3.11.0 · verification pack: passed
 
 | Status | Count |
 | --- | --- |
-| passed | 517 |
+| passed | 538 |
 | failed | 0 |
 | errored | 0 |
 | skipped | 0 |
 | not_applicable | 70 |
-| total | 587 |
+| total | 608 |
 
 ## By chapter
 
@@ -25,9 +25,9 @@ Runner: cnf-runner 3.11.0 · verification pack: passed
 | I_DEFINITION_ADL14 | 19 | 0 | 0 | 0 | 6 |
 | I_DEFINITION_ADL2 | 21 | 0 | 0 | 0 | 8 |
 | I_DEFINITION_QUERY | 28 | 0 | 0 | 0 | 3 |
-| I_DEMOGRAPHIC_SERVICE | 16 | 0 | 0 | 0 | 12 |
+| I_DEMOGRAPHIC_SERVICE | 33 | 0 | 0 | 0 | 12 |
 | I_EHR_COMPOSITION | 65 | 0 | 0 | 0 | 0 |
-| I_EHR_CONTRIBUTION | 47 | 0 | 0 | 0 | 5 |
+| I_EHR_CONTRIBUTION | 51 | 0 | 0 | 0 | 5 |
 | I_EHR_DIRECTORY | 51 | 0 | 0 | 0 | 3 |
 | I_EHR_EXTRACT_SERVICE | 0 | 0 | 0 | 0 | 10 |
 | I_EHR_SERVICE | 16 | 0 | 0 | 0 | 0 |
@@ -73,7 +73,7 @@ Percentiles re-derive from the embedded HDR V2 histograms; the class verdict is 
 
 ## Honesty
 
-Coverage: 517 of 587 selected cases driven.
+Coverage: 538 of 608 selected cases driven.
 
 Not-executed verdicts (each cited):
 

--- a/docs/conformance/ehrbase-rs/badge.json
+++ b/docs/conformance/ehrbase-rs/badge.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "openEHR conformance",
-  "message": "CORE+STANDARD PASS \u00b7 517/517 cases",
+  "message": "CORE+STANDARD PASS \u00b7 538/538 cases",
   "color": "brightgreen"
 }

--- a/docs/conformance/ehrbase-rs/results.json
+++ b/docs/conformance/ehrbase-rs/results.json
@@ -2127,6 +2127,54 @@
       "rows_total": 1
     },
     {
+      "case": "I_DEMOGRAPHIC_SERVICE.create_party-client_supplied_uid",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEMOGRAPHIC_SERVICE.create_party-kind_parity_agent",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEMOGRAPHIC_SERVICE.create_party-kind_parity_group",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEMOGRAPHIC_SERVICE.create_party-kind_parity_organisation",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEMOGRAPHIC_SERVICE.create_party-kind_parity_role",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEMOGRAPHIC_SERVICE.create_party-return_identifier",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEMOGRAPHIC_SERVICE.create_party-simplified_content_type",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEMOGRAPHIC_SERVICE.create_party-wrong_subtype_body",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_DEMOGRAPHIC_SERVICE.create_party_relationship-aaaa",
       "status": "not_applicable",
       "rows_driven": 0,
@@ -2147,7 +2195,19 @@
       "rows_total": 1
     },
     {
+      "case": "I_DEMOGRAPHIC_SERVICE.delete_party-already_deleted",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_DEMOGRAPHIC_SERVICE.delete_party-bbbb",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEMOGRAPHIC_SERVICE.delete_party-stale_version_conflict",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -2179,6 +2239,12 @@
       "rows_total": 1
     },
     {
+      "case": "I_DEMOGRAPHIC_SERVICE.get_party-wrong_kind_container",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_DEMOGRAPHIC_SERVICE.get_party_at_time-aaaa",
       "status": "passed",
       "rows_driven": 1,
@@ -2186,6 +2252,12 @@
     },
     {
       "case": "I_DEMOGRAPHIC_SERVICE.get_party_at_time-bbbb",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEMOGRAPHIC_SERVICE.get_party_at_time-deleted_current",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -2263,6 +2335,24 @@
       "rows_total": 1
     },
     {
+      "case": "I_DEMOGRAPHIC_SERVICE.update_party-invalid_body",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEMOGRAPHIC_SERVICE.update_party-missing_if_match",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEMOGRAPHIC_SERVICE.update_party-unknown_container",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_DEMOGRAPHIC_SERVICE.update_party-weak_etag_accepted",
       "status": "passed",
       "rows_driven": 1,
@@ -2289,7 +2379,43 @@
       "citation": "I_PARTY_RELATIONSHIP.update_party_relationship: AMB-32"
     },
     {
+      "case": "I_DEMOGRAPHIC_SERVICE.versioned_party_version_at_time",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_DEMOGRAPHIC_SERVICE.versioned_party_version_read",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEMOGRAPHIC_SERVICE.versioned_party_version_unknown",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_CONTRIBUTION.commit_contribution-demographic",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_CONTRIBUTION.commit_contribution-demographic_client_uid",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_CONTRIBUTION.commit_contribution-demographic_invalid_change_types",
+      "status": "passed",
+      "rows_driven": 4,
+      "rows_total": 4
+    },
+    {
+      "case": "I_EHR_CONTRIBUTION.get_contribution-demographic_unknown",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1

--- a/docs/conformance/ehrbase-rs/verdicts.json
+++ b/docs/conformance/ehrbase-rs/verdicts.json
@@ -183,7 +183,7 @@
     }
   ],
   "coverage": {
-    "selected": 587,
-    "driven": 517
+    "selected": 608,
+    "driven": 538
   }
 }


### PR DESCRIPTION
The group-12 (#388) closing pipeline run.

**First pass:** 535 passed / **3 failed** — triaged to the APPLICATION (three-way, catalogue vindicated): the stale-version party DELETE's 409 carried no latest-`version_uid` ETag (`409_PERSON_with_uid_based_id.yaml` requires it; the service raised the wrong error variant for the handler's echoing arm), and the demographic CONTRIBUTION GET carried neither ETag nor Last-Modified (AMB-87's adjudication, implemented on the EHR sibling). Fixed in PR #512 with wire tests.

**Closing run:** 608 case-records — **538 passed / 0 failed / 0 errored / 70 cited n-a**; 39 capability verdicts, 0 review findings. Baseline ratchets **517 → 538** with the group-12 demographic catalogue (PRs #507/#508/#512).