### PR TITLE
fix(demographic-tags): version-anchored tag collections, target gates, wrapper-header disciplines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **Demographic ITEM_TAG collections honour the released dual-form
+  addressing** (#509). A version-addressed `uid_based_id` on the demographic
+  tag routes now reads, replaces, and deletes that VERSION's own distinct
+  tag collection (previously every form reached the container's set); the
+  tags GET and DELETE now answer `404` for a nonexistent, wrong-kind, or
+  cross-space target (previously an empty `200` list); both
+  `openehr-item-tag` and `openehr-version-item-tag` request headers are
+  accepted on party create AND update, each landing on its own target's
+  collection with its own response-header echo; a tag's `target` is now the
+  bare RM `UID_BASED_ID` (an `OBJECT_VERSION_ID` for version targets) and
+  its `owner_id` follows the released examples' `local`/`SYSTEM` shape; and
+  the PARTY_RELATIONSHIP extension's stale-delete `409` now echoes the
+  latest `version_uid` in `ETag` like the party delete it mirrors.
+
 - **Demographic header echoes** (#388). The stale-version party DELETE's
   `409 Conflict` now returns the latest `version_uid` in `ETag` (the released
   response requires it); and the demographic CONTRIBUTION read now carries

--- a/app/ehrbase-rest/src/api/demographic/mod.rs
+++ b/app/ehrbase-rest/src/api/demographic/mod.rs
@@ -218,31 +218,36 @@ fn read_versioned(h: &HeaderMap, versioned_object_uid: &str, body: &serde_json::
 /// are rendered through [`crate::overview::params::emit_item_tag_header`]
 /// (`headers/openehr-item-tag.yaml`, `headers/openehr-version-item-tag.yaml`).
 ///
-/// Demographic `ITEM_TAGs` are stored against the `VERSIONED_OBJECT`
-/// (`item_tag.target_vo_id`, no version anchor), so the full set is emitted for
-/// both headers: `openehr-item-tag` (all tags on the `VERSIONED_OBJECT`) and
-/// `openehr-version-item-tag` (all tags on the current VERSION) coincide here.
+/// Each header carries its OWN target's collection (overview §"openehr-item-tag
+/// and openehr-version-item-tag": `openehr-item-tag` applies to the
+/// `VERSIONED_OBJECT`, `openehr-version-item-tag` to a specific VERSION within
+/// it) — the container's set from [`ResourceMeta::item_tags`], the served
+/// VERSION's own set from [`ResourceMeta::version_item_tags`]; the two are
+/// never merged.
 fn set_item_tag_headers(resp_out: &mut Response, resp: &ServiceResponse) {
     let Some(meta) = resp.meta.as_ref() else {
         return;
     };
-    let Some(serde_json::Value::Array(tags)) = meta.item_tags.as_ref() else {
-        return;
-    };
-    let entries: Vec<ItemTagHeaderEntry> = tags
-        .iter()
-        .filter_map(crate::overview::params::item_tag_to_header_entry)
-        .collect();
-    if entries.is_empty() {
-        return;
+    for (name, tags) in [
+        (crate::overview::params::H_ITEM_TAG, meta.item_tags.as_ref()),
+        (
+            crate::overview::params::H_VERSION_ITEM_TAG,
+            meta.version_item_tags.as_ref(),
+        ),
+    ] {
+        let Some(serde_json::Value::Array(tags)) = tags else {
+            continue;
+        };
+        let entries: Vec<ItemTagHeaderEntry> = tags
+            .iter()
+            .filter_map(crate::overview::params::item_tag_to_header_entry)
+            .collect();
+        if entries.is_empty() {
+            continue;
+        }
+        let value = crate::overview::params::emit_item_tag_header(&entries);
+        resp_out.headers_mut().insert(name, value);
     }
-    let value = crate::overview::params::emit_item_tag_header(&entries);
-    resp_out
-        .headers_mut()
-        .insert(crate::overview::params::H_ITEM_TAG, value.clone());
-    resp_out
-        .headers_mut()
-        .insert(crate::overview::params::H_VERSION_ITEM_TAG, value);
 }
 
 /// Render an error, additionally echoing the latest version in the `ETag` the

--- a/app/ehrbase-rest/src/api/demographic/openapi_routes.rs
+++ b/app/ehrbase-rest/src/api/demographic/openapi_routes.rs
@@ -5305,7 +5305,7 @@ pub(crate) async fn role_delete(
 /// Retrieve the `VERSIONED_PARTY` container
 /// (`GET /demographic/versioned_party/{versioned_object_uid}`).
 ///
-/// "Retrieves a VERSIONED_PARTY identified by `versioned_object_uid`."
+/// "Retrieves a `VERSIONED_PARTY` identified by `versioned_object_uid`."
 /// (ITS-REST `specifications/operations/versioned_party_get.yaml`). The four
 /// `versioned_party_*` reads are canonical-JSON-only on this server: the
 /// released operations reference `parameters/header/Accept_canonical.yaml`
@@ -5424,7 +5424,7 @@ pub(crate) async fn versioned_party_get(
 /// Retrieve the party's `REVISION_HISTORY`
 /// (`GET /demographic/versioned_party/{versioned_object_uid}/revision_history`).
 ///
-/// "Retrieves revision history of the VERSIONED_PARTY identified by
+/// "Retrieves revision history of the `VERSIONED_PARTY` identified by
 /// `versioned_object_uid`." (ITS-REST
 /// `specifications/operations/versioned_party_revision_history.yaml`).
 #[utoipa::path(
@@ -5521,7 +5521,7 @@ pub(crate) async fn versioned_party_revision_history(
 /// Retrieve the party VERSION at a point in time
 /// (`GET /demographic/versioned_party/{versioned_object_uid}/version`).
 ///
-/// "Retrieves a VERSION from the VERSIONED_PARTY identified by
+/// "Retrieves a VERSION from the `VERSIONED_PARTY` identified by
 /// `versioned_object_uid`." … "If `version_at_time` is supplied, retrieves the
 /// VERSION extant _at specified time_, otherwise retrieves the _latest_
 /// VERSION." (ITS-REST
@@ -5624,7 +5624,7 @@ pub(crate) async fn versioned_party_version_get_at_time(
 /// Retrieve a specific party VERSION by version uid
 /// (`GET /demographic/versioned_party/{versioned_object_uid}/version/{version_uid}`).
 ///
-/// "Retrieves a VERSION identified by `version_uid` of a VERSIONED_PARTY
+/// "Retrieves a VERSION identified by `version_uid` of a `VERSIONED_PARTY`
 /// identified by `versioned_object_uid`." (ITS-REST
 /// `specifications/operations/versioned_party_version_get_by_id.yaml`).
 #[utoipa::path(

--- a/app/ehrbase-rest/src/api/demographic/party.rs
+++ b/app/ehrbase-rest/src/api/demographic/party.rs
@@ -142,37 +142,60 @@ pub(super) async fn run(
     }
 }
 
-/// Persist any `openehr-item-tag` request-header `ITEM_TAGs` against the
-/// just-written party and reflect the stored set on the response metadata seam
-/// so the response headers echo them (`person_create.yaml` /
-/// `person_update.yaml`). The party must already exist (`item_tag.target_vo_id` FK), so this runs
-/// after the create/update write. A present-but-empty header clears all tags
-/// (the "remove all `ITEM_TAGs`" signal); an absent header is a no-op.
-// TODO: `person_update.yaml` (and the four sibling updates) declare
-// `openehr-version-item-tag` as the update's ITEM_TAG request header, but only
-// `openehr-item-tag` is read below — a client that sets tags on an update the
-// way the released operation documents gets nothing stored. Read both headers
-// here (they address the same VERSIONED_PARTY-anchored set on this surface) and
-// cover the update path with a CNF case.
+/// Apply the `openehr-item-tag` / `openehr-version-item-tag` write-wrapper
+/// request headers to the just-written party, mirroring the EHR side
+/// (`Requests_and_responses.md` §"openehr-item-tag and openehr-version-item-tag"
+/// §Usage in Requests): the two headers address DISTINCT collections —
+/// `openehr-item-tag` replaces the `VERSIONED_OBJECT` container's tags
+/// (addressed by the bare object id) and `openehr-version-item-tag` the
+/// just-committed VERSION's own tags (addressed by the full `version_uid`).
+/// A present-but-empty header clears its collection; an absent header leaves
+/// its collection untouched and echoes nothing. The stored sets ride the
+/// response metadata per header so the echo confirms exactly what each target
+/// now holds. Both headers are accepted on create AND update — the released
+/// update declares `openehr-version-item-tag` and its own prose says
+/// "`openehr-item-tag` or `openehr-version-item-tag`" (register-documented).
 async fn persist_request_tags(
     state: &AppState,
     kind: PartyKind,
     h: &HeaderMap,
     resp: &mut ServiceResponse,
 ) -> Result<(), RestError> {
-    let Some(entries) =
-        crate::overview::params::parse_item_tag_header(h, crate::overview::params::H_ITEM_TAG)
-    else {
+    let object_entries =
+        crate::overview::params::parse_item_tag_header(h, crate::overview::params::H_ITEM_TAG);
+    let version_entries = crate::overview::params::parse_item_tag_header(
+        h,
+        crate::overview::params::H_VERSION_ITEM_TAG,
+    );
+    if object_entries.is_none() && version_entries.is_none() {
+        return Ok(());
+    }
+    let Some(version_uid) = resp.meta.as_ref().map(|m| m.uid.clone()) else {
         return Ok(());
     };
-    let Some(uid) = resp.meta.as_ref().map(|m| m.uid.clone()) else {
-        return Ok(());
-    };
-    let tags = crate::overview::params::item_tags_from_header_entries(&entries);
-    // Full-collection PUT semantics via the same machinery as `party_tags_update`.
-    let stored = state.backend().party_tags_update(kind, uid, tags).await?;
-    if let Some(meta) = resp.meta.as_mut() {
-        meta.item_tags = Some(stored.body);
+    let container_uid = version_uid
+        .split_once("::")
+        .map_or(version_uid.as_str(), |(object_id, _)| object_id)
+        .to_owned();
+    if let Some(entries) = object_entries {
+        let tags = crate::overview::params::item_tags_from_header_entries(&entries);
+        let stored = state
+            .backend()
+            .party_tags_update(kind, container_uid, tags)
+            .await?;
+        if let Some(meta) = resp.meta.as_mut() {
+            meta.item_tags = Some(stored.body);
+        }
+    }
+    if let Some(entries) = version_entries {
+        let tags = crate::overview::params::item_tags_from_header_entries(&entries);
+        let stored = state
+            .backend()
+            .party_tags_update(kind, version_uid, tags)
+            .await?;
+        if let Some(meta) = resp.meta.as_mut() {
+            meta.version_item_tags = Some(stored.body);
+        }
     }
     Ok(())
 }

--- a/app/ehrbase-rest/src/api/demographic/relationship.rs
+++ b/app/ehrbase-rest/src/api/demographic/relationship.rs
@@ -1049,14 +1049,13 @@ pub(super) async fn run(
                 Err(e) => Err(RestError::from(e)),
             }
         }
-        // TODO: a stale `uid_based_id` here answers `409` without echoing the
-        // latest `version_uid` in `ETag`, unlike the party delete
-        // (`super::error_with_meta` + `party_current_meta`). Resolve the current
-        // relationship metadata on the conflict and echo it, so the extension
-        // matches the convention its declaration claims to follow.
+        // A stale `uid_based_id` answers `409` AND echoes the latest
+        // `version_uid` in `ETag`, matching the party delete this extension
+        // mirrors (`409_PERSON_with_uid_based_id.yaml`'s convention).
         "party_relationship_delete" => {
             let p = params::build::<AgentGetParams>(&parts.path, q, h)?;
-            let resp = state
+            let preceding = p.uid_based_id.clone();
+            match state
                 .backend()
                 .party_relationship_delete(
                     p.uid_based_id,
@@ -1066,10 +1065,27 @@ pub(super) async fn run(
                         crate::api::ehr::committer_proxy(),
                     ),
                 )
-                .await?;
-            let mut out = negotiate::empty(StatusCode::NO_CONTENT);
-            super::set_versioning_headers(&mut out, resp.meta.as_ref());
-            Ok(out)
+                .await
+            {
+                Ok(resp) => {
+                    let mut out = negotiate::empty(StatusCode::NO_CONTENT);
+                    super::set_versioning_headers(&mut out, resp.meta.as_ref());
+                    Ok(out)
+                }
+                Err(e) if super::is_precondition(&e) => {
+                    let meta = state
+                        .backend()
+                        .party_relationship_latest_meta(preceding)
+                        .await
+                        .ok()
+                        .flatten();
+                    Ok(super::error_with_meta(
+                        ApiError::Conflict(e.message),
+                        meta.as_ref(),
+                    ))
+                }
+                Err(e) => Err(RestError::from(e)),
+            }
         }
         // The versioned reads carry the weak `ETag` (+ `Last-Modified` where the
         // served body exposes a commit audit) the overview §"`ETag` and

--- a/app/ehrbase-rest/tests/demographic_http.rs
+++ b/app/ehrbase-rest/tests/demographic_http.rs
@@ -931,9 +931,9 @@ async fn stale_delete_conflict_echoes_latest_version_etag() {
 }
 
 /// The demographic CONTRIBUTION read carries the weak `ETag` (the contribution
-/// uid — the same identity the 201's ETag carries) and `Last-Modified` from
+/// uid — the same identity the 201's `ETag` carries) and `Last-Modified` from
 /// `audit.time_committed`, mirroring the EHR sibling's register-documented
-/// reading of the overview §"ETag and Last-Modified" SHOULD.
+/// reading of the overview §"`ETag` and Last-Modified" SHOULD.
 #[tokio::test]
 async fn demographic_contribution_get_carries_etag_and_last_modified() {
     let (_pg, app) = app().await;

--- a/app/ehrbase-rest/tests/demographic_tags_http.rs
+++ b/app/ehrbase-rest/tests/demographic_tags_http.rs
@@ -1,0 +1,374 @@
+#![allow(
+    clippy::panic,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    let_underscore_drop
+)] // test assertions/diagnostics/fixtures
+//! End-to-end HTTP tests for the demographic `ITEM_TAG` wire (group-13 audit,
+//! #389): the released dual-form `uid_based_id` addresses DISTINCT tag
+//! collections (the `VERSIONED_PARTY` container vs ONE of its VERSIONs — the
+//! disjointness law of RM `common.item_tag` `ITEM_TAG.target`), the tags
+//! GET/DELETE 404 on a nonexistent / wrong-kind target
+//! (`404_unknown_uid_based_id.yaml`; the kind-checked-routes law), both
+//! write-wrapper request headers land on their own collections, the RM target
+//! shape is the bare `UID_BASED_ID`, and the `owner_id` follows the released
+//! examples' `{namespace: local, type: SYSTEM}` shape.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use axum::Router;
+use axum::body::Body;
+use http::{Request, StatusCode, header};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use ehrbase::config::auth::AuthConfig;
+use ehrbase::config::server::ServerConfig;
+use ehrbase_rest::config::AppConfig;
+
+mod common;
+
+const BASE: &str = "/ehrbase/rest/openehr/v1";
+
+fn person_body() -> Value {
+    json!({
+        "_type": "PERSON",
+        "name": { "_type": "DV_TEXT", "value": "PERSON" },
+        "archetype_node_id": "openEHR-DEMOGRAPHIC-PERSON.person.v1",
+        "archetype_details": {
+            "_type": "ARCHETYPED",
+            "archetype_id": { "_type": "ARCHETYPE_ID",
+                              "value": "openEHR-DEMOGRAPHIC-PERSON.person.v1" },
+            "rm_version": "1.1.0"
+        },
+        "identities": [{
+            "_type": "PARTY_IDENTITY",
+            "name": { "_type": "DV_TEXT", "value": "legal identity" },
+            "archetype_node_id": "at0002",
+            "details": {
+                "_type": "ITEM_TREE",
+                "name": { "_type": "DV_TEXT", "value": "tree" },
+                "archetype_node_id": "at0003",
+                "items": [{
+                    "_type": "ELEMENT",
+                    "name": { "_type": "DV_TEXT", "value": "name" },
+                    "archetype_node_id": "at0004",
+                    "value": { "_type": "DV_TEXT", "value": "Jane Doe" }
+                }]
+            }
+        }]
+    })
+}
+
+fn config() -> AppConfig {
+    AppConfig {
+        server: ServerConfig {
+            bind: "127.0.0.1:0".to_owned(),
+            base_path: BASE.to_owned(),
+            max_in_flight: 1024,
+            swagger_ui: false,
+            cors_permissive: false,
+            ..Default::default()
+        },
+        auth: AuthConfig {
+            enabled: false,
+            basic: None,
+            oidc: None,
+            admin_scope: None,
+            ..AuthConfig::default()
+        },
+        ..Default::default()
+    }
+}
+
+async fn app() -> (testkit::TestDb, Router) {
+    let (pg, service) = common::test_service().await;
+    (pg, common::router_with(config(), service))
+}
+
+async fn send(app: &Router, req: Request<Body>) -> (StatusCode, header::HeaderMap, String) {
+    let resp = app.clone().oneshot(req).await.expect("response");
+    let status = resp.status();
+    let headers = resp.headers().clone();
+    let bytes = resp.into_body().collect().await.expect("body").to_bytes();
+    (
+        status,
+        headers,
+        String::from_utf8_lossy(&bytes).into_owned(),
+    )
+}
+
+/// Create a person, returning its full `version_uid` (from the create ETag).
+async fn create_person(app: &Router) -> String {
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("{BASE}/demographic/person"))
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(person_body().to_string()))
+        .unwrap();
+    let (status, h, body) = send(app, req).await;
+    assert_eq!(status, StatusCode::CREATED, "{body}");
+    h.get(header::ETAG)
+        .and_then(|v| v.to_str().ok())
+        .expect("ETag")
+        .trim_start_matches("W/")
+        .trim_matches('"')
+        .to_owned()
+}
+
+fn vo_of(ovid: &str) -> &str {
+    ovid.split("::").next().expect("vo uuid")
+}
+
+async fn put_tags(app: &Router, uid: &str, tags: Value) -> (StatusCode, String) {
+    let req = Request::builder()
+        .method("PUT")
+        .uri(format!("{BASE}/demographic/person/{uid}/tags"))
+        .header(header::CONTENT_TYPE, "application/json")
+        .header("Prefer", "return=representation")
+        .body(Body::from(tags.to_string()))
+        .unwrap();
+    let (status, _h, body) = send(app, req).await;
+    (status, body)
+}
+
+async fn get_tags(app: &Router, kind: &str, uid: &str) -> (StatusCode, String) {
+    let req = Request::builder()
+        .method("GET")
+        .uri(format!("{BASE}/demographic/{kind}/{uid}/tags"))
+        .header(header::ACCEPT, "application/json")
+        .body(Body::empty())
+        .unwrap();
+    let (status, _h, body) = send(app, req).await;
+    (status, body)
+}
+
+fn keys(body: &str) -> Vec<String> {
+    serde_json::from_str::<Vec<Value>>(body)
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|t| t.get("key").and_then(Value::as_str).map(str::to_owned))
+        .collect()
+}
+
+// ── the dual-form uid addresses DISTINCT collections ─────────────────────────
+
+#[tokio::test]
+async fn container_and_version_tag_collections_are_disjoint() {
+    let (_pg, app) = app().await;
+    let ovid = create_person(&app).await;
+    let vo = vo_of(&ovid).to_owned();
+
+    // Container-addressed PUT and version-addressed PUT write different sets.
+    let (status, body) = put_tags(&app, &vo, json!([{ "key": "container-tag" }])).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let (status, body) = put_tags(&app, &ovid, json!([{ "key": "version-tag" }])).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+
+    // Each addressing form reads back exactly its own collection (the released
+    // dual-form sentence: the container form addresses the VERSIONED_PARTY
+    // container, the version form that VERSION).
+    let (status, body) = get_tags(&app, "person", &vo).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(keys(&body), vec!["container-tag"], "container collection");
+    let (status, body) = get_tags(&app, "person", &ovid).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(keys(&body), vec!["version-tag"], "version collection");
+
+    // A version-addressed tag's target is the OBJECT_VERSION_ID; the
+    // container's is the HIER_OBJECT_ID (RM item_tag.adoc target shape).
+    let tags: Vec<Value> = serde_json::from_str(&body).unwrap();
+    assert_eq!(
+        tags[0]["target"]["_type"], "OBJECT_VERSION_ID",
+        "version-addressed target is an OBJECT_VERSION_ID: {tags:?}"
+    );
+    // owner_id follows the released examples' shape (register AMB-137).
+    assert_eq!(tags[0]["owner_id"]["namespace"], "local");
+    assert_eq!(tags[0]["owner_id"]["type"], "SYSTEM");
+
+    // Deleting by key on the VERSION leaves the container collection intact.
+    let req = Request::builder()
+        .method("DELETE")
+        .uri(format!("{BASE}/demographic/person/{ovid}/tags/version-tag"))
+        .body(Body::empty())
+        .unwrap();
+    let (status, _h, body) = send(&app, req).await;
+    assert_eq!(status, StatusCode::NO_CONTENT, "{body}");
+    let (_s, body) = get_tags(&app, "person", &vo).await;
+    assert_eq!(keys(&body), vec!["container-tag"], "container survives");
+    let (_s, body) = get_tags(&app, "person", &ovid).await;
+    assert!(keys(&body).is_empty(), "version collection cleared");
+}
+
+// ── the tags GET/DELETE gate the addressed target ────────────────────────────
+
+#[tokio::test]
+async fn tags_get_on_unknown_party_is_404() {
+    let (_pg, app) = app().await;
+    let (status, body) = get_tags(&app, "person", "00000000-0000-4000-8000-000000000000").await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_FOUND,
+        "404_unknown_uid_based_id: 'returned when the uid_based_id does not \
+         exist' — never an empty 200 list: {body}"
+    );
+}
+
+#[tokio::test]
+async fn tags_routes_are_kind_checked() {
+    let (_pg, app) = app().await;
+    let ovid = create_person(&app).await;
+    let vo = vo_of(&ovid).to_owned();
+    // A person's container addressed through the agent tag route → 404
+    // (the kind-checked-routes law; five kinds).
+    let (status, body) = get_tags(&app, "agent", &vo).await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "{body}");
+    // DELETE through the wrong kind must not reach the tags either.
+    let (status, body) = put_tags(&app, &vo, json!([{ "key": "t" }])).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let req = Request::builder()
+        .method("DELETE")
+        .uri(format!("{BASE}/demographic/agent/{vo}/tags/t"))
+        .body(Body::empty())
+        .unwrap();
+    let (status, _h, body) = send(&app, req).await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "{body}");
+    let (_s, body) = get_tags(&app, "person", &vo).await;
+    assert_eq!(keys(&body), vec!["t"], "the tag survived the foreign route");
+}
+
+#[tokio::test]
+async fn tags_get_on_unknown_version_is_404() {
+    let (_pg, app) = app().await;
+    let ovid = create_person(&app).await;
+    let vo = vo_of(&ovid);
+    let system = ovid.split("::").nth(1).expect("system id");
+    let (status, body) = get_tags(&app, "person", &format!("{vo}::{system}::99")).await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_FOUND,
+        "a version-addressed target must name an existing version: {body}"
+    );
+}
+
+// ── the write-wrapper headers land on their own collections ─────────────────
+
+#[tokio::test]
+async fn wrapper_headers_write_distinct_collections_on_update() {
+    let (_pg, app) = app().await;
+    let v1 = create_person(&app).await;
+    let vo = vo_of(&v1).to_owned();
+    // The released update declares `openehr-version-item-tag`; its prose says
+    // "`openehr-item-tag` or `openehr-version-item-tag`" — both are accepted,
+    // each addressing its own target.
+    let put = Request::builder()
+        .method("PUT")
+        .uri(format!("{BASE}/demographic/person/{vo}"))
+        .header(header::CONTENT_TYPE, "application/json")
+        .header("If-Match", format!("\"{v1}\""))
+        .header("openehr-item-tag", "key=\"container-side\"")
+        .header("openehr-version-item-tag", "key=\"version-side\"")
+        .body(Body::from(person_body().to_string()))
+        .unwrap();
+    let (status, h, body) = send(&app, put).await;
+    assert_eq!(status, StatusCode::NO_CONTENT, "{body}");
+    let v2 = h
+        .get(header::ETAG)
+        .and_then(|v| v.to_str().ok())
+        .expect("ETag")
+        .trim_start_matches("W/")
+        .trim_matches('"')
+        .to_owned();
+    // The response echoes each header with its own stored set.
+    let item = h
+        .get("openehr-item-tag")
+        .and_then(|v| v.to_str().ok())
+        .expect("openehr-item-tag echoed");
+    let version = h
+        .get("openehr-version-item-tag")
+        .and_then(|v| v.to_str().ok())
+        .expect("openehr-version-item-tag echoed");
+    assert!(item.contains("container-side"), "{item}");
+    assert!(version.contains("version-side"), "{version}");
+    // And the dedicated routes see the same split.
+    let (_s, body) = get_tags(&app, "person", &vo).await;
+    assert_eq!(keys(&body), vec!["container-side"]);
+    let (_s, body) = get_tags(&app, "person", &v2).await;
+    assert_eq!(keys(&body), vec!["version-side"]);
+}
+
+// ── the extension relationship delete echoes the latest version on 409 ──────
+
+#[tokio::test]
+async fn relationship_stale_delete_conflict_echoes_latest_etag() {
+    let (_pg, app) = app().await;
+    let source = create_person(&app).await;
+    let target = create_person(&app).await;
+    let rel = json!({
+        "_type": "PARTY_RELATIONSHIP",
+        "name": { "_type": "DV_TEXT", "value": "PARTY_RELATIONSHIP" },
+        "archetype_node_id": "openEHR-DEMOGRAPHIC-PARTY_RELATIONSHIP.relationship.v1",
+        "archetype_details": {
+            "_type": "ARCHETYPED",
+            "archetype_id": { "_type": "ARCHETYPE_ID",
+                "value": "openEHR-DEMOGRAPHIC-PARTY_RELATIONSHIP.relationship.v1" },
+            "rm_version": "1.1.0"
+        },
+        "source": { "_type": "PARTY_REF", "namespace": "demographic", "type": "PERSON",
+            "id": { "_type": "HIER_OBJECT_ID", "value": vo_of(&source) } },
+        "target": { "_type": "PARTY_REF", "namespace": "demographic", "type": "PERSON",
+            "id": { "_type": "HIER_OBJECT_ID", "value": vo_of(&target) } }
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("{BASE}/demographic/party_relationship"))
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(rel.to_string()))
+        .unwrap();
+    let (status, h, body) = send(&app, req).await;
+    assert_eq!(status, StatusCode::CREATED, "{body}");
+    let r1 = h
+        .get(header::ETAG)
+        .and_then(|v| v.to_str().ok())
+        .expect("ETag")
+        .trim_start_matches("W/")
+        .trim_matches('"')
+        .to_owned();
+    // Supersede r1.
+    let put = Request::builder()
+        .method("PUT")
+        .uri(format!(
+            "{BASE}/demographic/party_relationship/{}",
+            vo_of(&r1)
+        ))
+        .header(header::CONTENT_TYPE, "application/json")
+        .header("If-Match", format!("\"{r1}\""))
+        .body(Body::from(rel.to_string()))
+        .unwrap();
+    let (status, h, body) = send(&app, put).await;
+    assert_eq!(status, StatusCode::NO_CONTENT, "{body}");
+    let r2 = h
+        .get(header::ETAG)
+        .and_then(|v| v.to_str().ok())
+        .expect("ETag")
+        .trim_start_matches("W/")
+        .trim_matches('"')
+        .to_owned();
+    // Delete at the superseded uid → 409 + the latest version's ETag,
+    // matching the party delete this extension mirrors.
+    let del = Request::builder()
+        .method("DELETE")
+        .uri(format!("{BASE}/demographic/party_relationship/{r1}"))
+        .body(Body::empty())
+        .unwrap();
+    let (status, h, body) = send(&app, del).await;
+    assert_eq!(status, StatusCode::CONFLICT, "{body}");
+    let echoed = h
+        .get(header::ETAG)
+        .and_then(|v| v.to_str().ok())
+        .expect("409 echoes ETag")
+        .trim_start_matches("W/")
+        .trim_matches('"')
+        .to_owned();
+    assert_eq!(echoed, r2, "the latest version_uid rides the 409 ETag");
+}

--- a/app/ehrbase/src/service/demographic/api.rs
+++ b/app/ehrbase/src/service/demographic/api.rs
@@ -124,9 +124,23 @@ impl EhrbaseService {
         if resp.meta.is_none() {
             return Ok(());
         }
-        let tags = self.party_tags(vo_id).await?;
+        // The two response headers carry DISTINCT collections (overview
+        // §"openehr-item-tag and openehr-version-item-tag"): the container's
+        // set rides `openehr-item-tag`, the served VERSION's own set rides
+        // `openehr-version-item-tag`. The version tail comes from the response
+        // metadata's own OBJECT_VERSION_ID.
+        let container = self.party_tags(vo_id, None).await?;
+        let version_tail = resp
+            .meta
+            .as_ref()
+            .and_then(|m| m.uid.split_once("::").map(|(_, tail)| tail.to_owned()));
+        let version = match version_tail.as_deref() {
+            Some(tail) => Some(self.party_tags(vo_id, Some(tail)).await?),
+            None => None,
+        };
         if let Some(meta) = resp.meta.as_mut() {
-            meta.item_tags = Some(Value::Array(tags));
+            meta.item_tags = Some(Value::Array(container));
+            meta.version_item_tags = version.map(Value::Array);
         }
         Ok(())
     }
@@ -603,11 +617,15 @@ impl EhrbaseService {
     /// - [`SmError`] on a storage/database fault reading the tag store.
     pub async fn party_tags_get(
         &self,
-        _kind: PartyKind,
+        kind: PartyKind,
         uid_based_id: String,
     ) -> Result<ServiceResponse, SmError> {
-        let (vo_id, _) = parse_uid_based_id(&uid_based_id)?;
-        Ok(tags_response(self.party_tags(vo_id).await?))
+        let (vo_id, tail) = crate::service::ehr::tags::parse_tag_target(&uid_based_id)?;
+        // The released 404 trigger ("when the `uid_based_id` does not exist")
+        // plus the kind-checked-routes law: the guard runs on the GET too; an
+        // existing target with no tags stays an empty 200 list.
+        self.ensure_party_tag_target(kind, vo_id, tail).await?;
+        Ok(tags_response(self.party_tags(vo_id, tail).await?))
     }
 
     /// Replace the whole `ITEM_TAG` collection of a party (PUT full-collection
@@ -625,9 +643,9 @@ impl EhrbaseService {
         uid_based_id: String,
         body: Vec<Value>,
     ) -> Result<ServiceResponse, SmError> {
-        let (vo_id, _) = parse_uid_based_id(&uid_based_id)?;
+        let (vo_id, tail) = crate::service::ehr::tags::parse_tag_target(&uid_based_id)?;
         Ok(tags_response(
-            self.replace_party_tags(kind, vo_id, body).await?,
+            self.replace_party_tags(kind, vo_id, tail, body).await?,
         ))
     }
 
@@ -639,12 +657,12 @@ impl EhrbaseService {
     /// - [`SmError`] on a storage/database fault during the delete.
     pub async fn party_tags_delete(
         &self,
-        _kind: PartyKind,
+        kind: PartyKind,
         uid_based_id: String,
         key: String,
     ) -> Result<ServiceResponse, SmError> {
-        let (vo_id, _) = parse_uid_based_id(&uid_based_id)?;
-        self.delete_party_tag(vo_id, &key).await?;
+        let (vo_id, tail) = crate::service::ehr::tags::parse_tag_target(&uid_based_id)?;
+        self.delete_party_tag(kind, vo_id, tail, &key).await?;
         Ok(ServiceResponse::plain(Value::Null))
     }
 

--- a/app/ehrbase/src/service/demographic/party.rs
+++ b/app/ehrbase/src/service/demographic/party.rs
@@ -90,23 +90,6 @@ impl EhrbaseService {
             .ok_or_else(miss)
     }
 
-    /// Confirm a live party of the expected kind exists (not deleted) — the
-    /// SM `has_party` precondition (`i_party.adoc`).
-    pub(super) async fn ensure_party(
-        &self,
-        kind: PartyKind,
-        vo_id: VoId,
-    ) -> Result<(), ServiceError> {
-        let read = self.load_party_version(kind, vo_id, None, None).await?;
-        if read.deleted() {
-            return Err(ServiceError::sm(
-                CallStatusType::VersionedObjectDoesNotExist,
-                format!("{} {vo_id} is deleted", kind.rm_type()),
-            ));
-        }
-        Ok(())
-    }
-
     /// The stored [`PartyKind`] of a versioned object, for the kind-agnostic SM
     /// `I_PARTY` calls (which address parties by versioned-object id only). A
     /// non-party id (COMPOSITION, `PARTY_RELATIONSHIP`, …) or unknown id is `404`

--- a/app/ehrbase/src/service/demographic/relationship.rs
+++ b/app/ehrbase/src/service/demographic/relationship.rs
@@ -299,7 +299,11 @@ impl EhrbaseService {
         if let Some(expected) = expected
             && current.tree != expected
         {
-            return Err(ServiceError::Conflict(format!(
+            // A stale preceding version is a VERSION MISMATCH — the wire arm
+            // answers `409` and echoes the latest `version_uid` in `ETag`,
+            // mirroring the party delete's convention
+            // (`responses/409_PERSON_with_uid_based_id.yaml`).
+            return Err(ServiceError::VersionConflict(format!(
                 "preceding_version_uid names version {expected}, latest is {}",
                 current.tree
             )));

--- a/app/ehrbase/src/service/demographic/tags.rs
+++ b/app/ehrbase/src/service/demographic/tags.rs
@@ -26,14 +26,73 @@ impl EhrbaseService {
         target_path: Option<&str>,
     ) -> Result<Vec<Value>, ServiceError> {
         let rows = tag_repo::list_tags(&self.pool, None, None, key, value, target_path).await?;
-        Ok(rows.iter().map(party_tag_json).collect())
+        let sid = self.effective_system_id();
+        Ok(rows.iter().map(|r| party_tag_json(&sid, r)).collect())
     }
 
-    /// The tags on one party.
-    pub(super) async fn party_tags(&self, vo_id: VoId) -> Result<Vec<Value>, ServiceError> {
-        let rows =
-            tag_repo::list_tags(&self.pool, None, Some((vo_id, None)), None, None, None).await?;
-        Ok(rows.iter().map(party_tag_json).collect())
+    /// The tags on one party target — the `VERSIONED_PARTY` container
+    /// (`target_version: None`) or ONE of its VERSIONs (`Some(tail)`). The two
+    /// are DISJOINT collections of the same `target_vo_id` (RM
+    /// `common.item_tag` `ITEM_TAG.target`: "may be a `VERSIONED_OBJECT<T>` or
+    /// a `VERSION<T>`"; the released dual-form `uid_based_id` on every
+    /// demographic tag operation).
+    pub(super) async fn party_tags(
+        &self,
+        vo_id: VoId,
+        target_version: Option<&str>,
+    ) -> Result<Vec<Value>, ServiceError> {
+        let rows = tag_repo::list_tags(
+            &self.pool,
+            None,
+            Some((vo_id, target_version)),
+            None,
+            None,
+            None,
+        )
+        .await?;
+        let sid = self.effective_system_id();
+        Ok(rows.iter().map(|r| party_tag_json(&sid, r)).collect())
+    }
+
+    /// The demographic tag-target guard, mirroring the EHR side
+    /// (`service::ehr::tags::ensure_tag_target`): the addressed versioned
+    /// object must exist AND be a party of the routed kind (a person route
+    /// must not reach an agent's tags — the kind-checked-routes law), and a
+    /// VERSION-addressed target must name an existing version. The released
+    /// 404 trigger: `404_unknown_uid_based_id.yaml` — "returned when the
+    /// `uid_based_id` does not exist".
+    pub(super) async fn ensure_party_tag_target(
+        &self,
+        kind: PartyKind,
+        vo_id: VoId,
+        target_version: Option<&str>,
+    ) -> Result<(), ServiceError> {
+        let stored = crate::versioning::read::object_kind(&self.pool, vo_id).await?;
+        if stored != Some(crate::service::demographic::support::kind_of(kind)) {
+            return Err(ServiceError::sm(
+                CallStatusType::VersionedObjectDoesNotExist,
+                format!("tag target {} {vo_id}", kind.rm_type()),
+            ));
+        }
+        if let Some(tail) = target_version {
+            let tree = crate::versioning::object_version_id::parse_version_tail(tail)?;
+            let (branch_number, branch_version) = tree.branch.unwrap_or((0, 0));
+            if !crate::storage::version_repo::meta::version_exists(
+                &self.pool,
+                vo_id,
+                tree.trunk,
+                branch_number,
+                branch_version,
+            )
+            .await?
+            {
+                return Err(ServiceError::sm(
+                    CallStatusType::ObjectVersionDoesNotExist,
+                    format!("tag target version {vo_id}::{tail}"),
+                ));
+            }
+        }
+        Ok(())
     }
 
     /// Replace the whole tag collection of a party with the posted set (PUT
@@ -45,9 +104,11 @@ impl EhrbaseService {
         &self,
         kind: PartyKind,
         vo_id: VoId,
+        target_version: Option<&str>,
         tags: Vec<Value>,
     ) -> Result<Vec<Value>, ServiceError> {
-        self.ensure_party(kind, vo_id).await?;
+        self.ensure_party_tag_target(kind, vo_id, target_version)
+            .await?;
         // Validate + dedup (last wins) before touching the DB. A BTreeMap keys by
         // tag key, matching the `ORDER BY key` read-back order.
         let mut deduped: BTreeMap<String, (Option<String>, Option<String>)> = BTreeMap::new();
@@ -88,18 +149,27 @@ impl EhrbaseService {
             })
             .collect();
         let mut tx = self.pool.begin().await?;
-        tag_repo::replace_tags(&mut tx, None, vo_id, None, &new_tags).await?;
+        tag_repo::replace_tags(&mut tx, None, vo_id, target_version, &new_tags).await?;
         tx.commit().await?;
-        self.party_tags(vo_id).await
+        self.party_tags(vo_id, target_version).await
     }
 
-    /// Delete a tag by key from a party. An unknown key is `404`.
+    /// Delete a target's tags by key (a SET delete over the `(key,
+    /// target_path)` identities sharing the key, addressed to the container or
+    /// ONE VERSION per the parsed `uid_based_id`). The target itself is gated
+    /// first (`404_unknown_uid_based_id_or_key.yaml`: "the `uid_based_id` does
+    /// not exist, or … the `ITEM_TAG` identified by the `key` does not exist");
+    /// an unknown key on an existing target is the same `404`.
     pub(super) async fn delete_party_tag(
         &self,
+        kind: PartyKind,
         vo_id: VoId,
+        target_version: Option<&str>,
         key: &str,
     ) -> Result<(), ServiceError> {
-        if !tag_repo::delete_tag(&self.pool, None, vo_id, None, key).await? {
+        self.ensure_party_tag_target(kind, vo_id, target_version)
+            .await?;
+        if !tag_repo::delete_tag(&self.pool, None, vo_id, target_version, key).await? {
             return Err(ServiceError::sm(
                 CallStatusType::VersionedObjectDoesNotExist,
                 format!("item tag {key:?}"),
@@ -109,28 +179,40 @@ impl EhrbaseService {
     }
 }
 
-/// One demographic `ITEM_TAG` in its wire shape (RM `common.item_tag`).
+/// One demographic `ITEM_TAG` in its RM wire shape (`item_tag.adoc`): `key`,
+/// optional `value`/`target_path`, `target` as a bare `UID_BASED_ID` — a
+/// `HIER_OBJECT_ID` for a container target, an `OBJECT_VERSION_ID` for a
+/// VERSION target ("may be a `VERSIONED_OBJECT<T>` or a `VERSION<T>`") —
+/// exactly the EHR sibling's shape (the settled RM-target law; the stalled OAS
+/// `ItemTag` schema's `OBJECT_REF` wrapper loses to the released RM).
 ///
-/// NOTE: `owner_id` references the tagged party itself — there is no
-/// owning EHR for a demographic tag (no openEHR spec governs the owner of an
-/// ehr-less demographic tag — our own design).
-fn party_tag_json(row: &tag_repo::TagRow) -> Value {
+/// NOTE: `owner_id` follows the released examples' shape — an `OBJECT_REF`
+/// `{namespace: local, type: SYSTEM}` whose `id` carries the server's
+/// configured system identifier (every
+/// `schemas/demographic/ItemTagOf<T>.yaml` example; no demographic class
+/// declares a `tags` containment, so the EHR side's `EHR.tags` anchor has no
+/// analogue here — the register carries the fixed handling).
+fn party_tag_json(system_id: &str, row: &tag_repo::TagRow) -> Value {
     let target_vo_id = row.target_vo_id;
-    let target_type = row.target_type.as_str();
+    let target = match &row.target_version {
+        Some(tail) => json!({
+            "_type": "OBJECT_VERSION_ID",
+            "value": format!("{target_vo_id}::{tail}")
+        }),
+        None => json!({
+            "_type": "HIER_OBJECT_ID",
+            "value": target_vo_id.to_string()
+        }),
+    };
     let mut tag = json!({
         "_type": "ITEM_TAG",
         "key": row.key.as_str(),
-        "target": {
-            "_type": "OBJECT_REF",
-            "namespace": "demographic",
-            "type": target_type,
-            "id": { "_type": "HIER_OBJECT_ID", "value": target_vo_id.to_string() }
-        },
+        "target": target,
         "owner_id": {
             "_type": "OBJECT_REF",
-            "namespace": "demographic",
-            "type": target_type,
-            "id": { "_type": "HIER_OBJECT_ID", "value": target_vo_id.to_string() }
+            "namespace": "local",
+            "type": "SYSTEM",
+            "id": { "_type": "HIER_OBJECT_ID", "value": system_id }
         },
     });
     if let Some(value) = &row.value {

--- a/app/ehrbase/src/service/ehr/mod.rs
+++ b/app/ehrbase/src/service/ehr/mod.rs
@@ -49,7 +49,7 @@ mod directory;
 pub(in crate::service) mod meta;
 pub(in crate::service) mod service;
 mod status;
-mod tags;
+pub(in crate::service) mod tags;
 mod uri;
 pub(crate) mod validation;
 

--- a/app/ehrbase/src/service/ehr/tags.rs
+++ b/app/ehrbase/src/service/ehr/tags.rs
@@ -374,7 +374,9 @@ impl EhrbaseService {
 /// tail (RM `item_tag.adoc`: `target` "may be a `VERSIONED_OBJECT<T>` or a
 /// `VERSION<T>`"). The tail is validated as a well-formed `OBJECT_VERSION_ID`
 /// before it is kept verbatim.
-fn parse_tag_target(uid_based_id: &str) -> Result<(VoId, Option<&str>), SmError> {
+pub(in crate::service) fn parse_tag_target(
+    uid_based_id: &str,
+) -> Result<(VoId, Option<&str>), SmError> {
     let (vo_id, tree) = parse_uid_based_id(uid_based_id)?;
     if tree.is_none() {
         return Ok((vo_id, None));

--- a/app/ehrbase/src/service/response.rs
+++ b/app/ehrbase/src/service/response.rs
@@ -39,6 +39,11 @@ pub struct ResourceMeta {
     /// returns plain values, and this seam carries what the mandated headers
     /// need. The tag *content* is the RM `common.item_tag.ITEM_TAG` type.
     pub item_tags: Option<Value>,
+    /// The served/committed VERSION's own `ITEM_TAG` collection, when it is
+    /// distinct from the container's (`openehr-version-item-tag` — overview
+    /// §"openehr-item-tag and openehr-version-item-tag": the two headers
+    /// address a `VERSIONED_OBJECT` and a specific VERSION within it).
+    pub version_item_tags: Option<Value>,
 }
 
 impl ResourceMeta {
@@ -51,6 +56,7 @@ impl ResourceMeta {
             uid: uid.into(),
             last_modified: None,
             item_tags: None,
+            version_item_tags: None,
         }
     }
 


### PR DESCRIPTION
Closes #509.

Group-13 audit findings F-1/F-2/F-3 (#389 findings comment) plus the two shape divergences the #511 register worker surfaced.

**F-1 — the version anchor.** All 15 typed demographic tag routes discarded the `uid_based_id` version component and hard-coded `target_version: None` — a version-addressed uid reached the CONTAINER collection, against the released dual-form sentence carried verbatim in every operation (RM `item_tag.adoc`: target "may be a `VERSIONED_OBJECT<T>` or a `VERSION<T>`" — the settled disjointness law). The seam now threads the parsed tail (via the shared `ehr::tags::parse_tag_target`) through get/replace/delete; the version form's target is emitted as its `OBJECT_VERSION_ID`.

**F-2 — the target gate.** tags GET/DELETE gained `ensure_party_tag_target` (kind + existence + version-exists, mirroring the EHR side): nonexistent → 404 (`404_unknown_uid_based_id`), wrong-kind/cross-space → 404 (AMB-91's law across five kinds).

**Wrapper headers.** Both `openehr-item-tag` and `openehr-version-item-tag` are accepted on create AND update (the released update declares only the version one — a spec-following client's tags were silently dropped), each replacing its own target's collection with its own response-header echo (`ResourceMeta` gained `version_item_tags`; the GET's two headers now carry distinct collections too).

**Shape fixes (register-adjudicated in #511's entries):** `target` = the bare RM `UID_BASED_ID` (the OBJECT_REF wrapper was the stalled-OAS shape — the `item-tag-rm-target-shape` law); `owner_id` = the five released examples' `{namespace: local, type: SYSTEM}` shape carrying the server's system identifier (AMB-137's fixed handling).

**F-3.** The PARTY_RELATIONSHIP extension's stale delete now answers 409 echoing the latest `version_uid` ETag (the service raised the variant the handler never caught — the same defect class as PR #512's party fix).

Also heals six doc-markdown warnings that shipped with PR #507 (my adoption gate tailed only the last clippy line — corrected).

**Tests:** new `demographic_tags_http.rs` battery (6) — collection disjointness across PUT/GET/DELETE, unknown/wrong-kind/unknown-version 404s, the wrapper split on update with per-header echoes, the relationship 409 echo.

**Gates:** clippy (both crates, all targets) — zero warnings; nextest `-p ehrbase -p ehrbase-rest` 1185 passed / 0 failed.