### PR TITLE
fix(demographic): served OpenAPI completeness for the ITEM_TAG operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,23 @@ workflow refuses a tag that has no matching section here.
   the PARTY_RELATIONSHIP extension's stale-delete `409` now echoes the
   latest `version_uid` in `ETag` like the party delete it mirrors.
 
+- **The published API reference now describes the demographic item-tag
+  endpoints in full** (#510). The sixteen `ITEM_TAG` operations — the
+  person / agent / group / organisation / role `tags` read, replace and
+  delete-by-key, plus the space-wide `GET /demographic/tags` — gained the
+  status branches they actually answer (`400`, `404`, `406`, `415`, `422`),
+  the `Prefer` / `Content-Type` / `Accept` request headers, the
+  `Preference-Applied` echo on both replace branches, and worked ITEM_TAG
+  examples. They now state plainly that a version-addressed `uid_based_id`
+  and a container-addressed one name two DISTINCT tag collections, that an
+  empty list on the replace clears every tag, that deleting by key alone
+  removes every tag under that key whatever its `target_path`, and that a
+  tag collection is never change-controlled — so no `ETag`, `Last-Modified`
+  or `Location` is offered anywhere on the family. The space-wide list is
+  documented for what it is: the one tag route with no scoping parameter at
+  all, no paging, and `200` (an empty array when nothing matches) or `400`
+  as its only outcomes.
+
 - **Demographic header echoes** (#388). The stale-version party DELETE's
   `409 Conflict` now returns the latest `version_uid` in `ETag` (the released
   response requires it); and the demographic CONTRIBUTION read now carries

--- a/app/ehrbase-rest/src/api/demographic/openapi_routes.rs
+++ b/app/ehrbase-rest/src/api/demographic/openapi_routes.rs
@@ -29,7 +29,11 @@
 //! responses/parameters/headers, differing only in the RM type and its own
 //! `headers/Location_{PERSON,AGENT,GROUP,ORGANISATION,ROLE}.yaml`. The
 //! `versioned_party_*` and `demographic_contribution_*` families are declared
-//! from their own operation files. Everything the released files leave open is
+//! from their own operation files, and the sixteen `ITEM_TAG` operations from
+//! theirs (five more byte-identical typed quintets plus the space-wide
+//! `demographic_tags_get.yaml` — see that section's own preamble, which carries
+//! the family-wide rules: canonical-JSON only, no change control, and the
+//! our-own-design `owner_id`). Everything the released files leave open is
 //! filled from the RELEASED overview chapters — never from the stalled OAS:
 //! `docs/overview/Requests_and_responses.md` (the weak `W/` `ETag` MUST, the
 //! `Prefer` triad + `Preference-Applied`, the committal-header
@@ -6116,24 +6120,225 @@ pub(crate) async fn contribution_get(
     let parts = crate::api::into_parts(request).await;
     guarded_dispatch(state, "contribution_get", parts, super::dispatch::dispatch).await
 }
-
 // ── ITEM_TAG sub-resources ───────────────────────────────────────────────────
+//
+// Sixteen released operations: five byte-identical typed quintets
+// (`{person,agent,group,organisation,role}_tags_{get,update,delete}.yaml`,
+// differing only in the RM type name and in their own
+// `responses/200_<RM>_ItemTagList_{retrieved,updated}.yaml` +
+// `schemas/demographic/ItemTagOf<Kind>.yaml`) plus the space-wide
+// `demographic_tags_get.yaml`. The fifteen typed ones mirror the EHR-side tag
+// family minus `ehr_id`; the space-wide one is a genuine delta (see it).
+//
+// Every tag route is canonical-JSON only. The canonical XML ITS defines no
+// ITEM_TAG type at all, so the released `Accept_canonical` enum's
+// `application/xml` member is stalled shape here: an XML `Accept` is `406`, and
+// an XML `Content-Type` on the five PUTs is `415` (`Resources.md` §"XML
+// Format"/§"JSON Format"). The five DELETEs declare no `Accept` and answer
+// `204` with no body, so they negotiate nothing and carry no `406`.
+//
+// Tags are not change-controlled: none of the sixteen commits a CONTRIBUTION,
+// mints a version, takes an `If-Match`, or serves an `ETag`, `Last-Modified` or
+// `Location`. The only response header on the whole family is
+// `Preference-Applied`, on the five PUTs.
+//
+// `owner_id` is our own design. RM `item_tag.adoc` types it `OBJECT_REF` —
+// "Identifier of owner object, such as EHR" — and a demographic party has no
+// EHR; no demographic RM class declares a `tags` containment either, so nothing
+// released fixes the owner of an EHR-less tag. This build names the owning
+// VERSIONED_PARTY; the position is register-documented in the conformance
+// catalogue. The released `ItemTagOf*` examples instead show
+// `{namespace: local, type: SYSTEM}`, which no released sentence requires.
+//
+// TODO: serve `target` as the bare `UID_BASED_ID` the RM declares
+// (`item_tag.adoc`: `target: UID_BASED_ID`, "which may be a
+// `VERSIONED_OBJECT<T>` or a `VERSION<T>`") instead of the `OBJECT_REF`
+// envelope this family currently emits. The EHR-side tag family already serves
+// the RM shape; the RM is the RELEASED component and wins over the stalled OAS
+// `ItemTag`/`UObjectRefOfUidBasedId` schema the envelope follows. Until that
+// lands, the declarations below describe the envelope actually served.
 
-/// List `ITEM_TAG`s across the demographic surface (`GET /demographic/tags`).
+/// List `ITEM_TAG`s across the whole Demographic space
+/// (`GET /demographic/tags`).
+///
+/// "Retrieves the list of ITEM_TAG resources associated with any target VERSION
+/// or VERSIONED_PARTY within the Demographic space." (ITS-REST
+/// `specifications/operations/demographic_tags_get.yaml`).
+///
+/// The ONLY tag route on the whole surface with NO scoping parameter: its
+/// EHR-side twin is bounded by one EHR, this one is a whole-space scan. The
+/// released operation declares no scoping parameter, no `offset`/`fetch`, no
+/// ordering and no limit, and no released sentence bounds who may read the
+/// space — it is served whole under the deployment's authorization layer, a
+/// position register-documented in the conformance catalogue (distinct from the
+/// filter semantics, which are their own entry).
 #[utoipa::path(
     get, path = "/demographic/tags", tag = "ITEM_TAG",
     params(
         ("tag_key" = Option<String>, Query,
-         description = "Filter by ITEM_TAG `key` (exact match)."),
+         description = "Filter by ITEM_TAG `key`. The released parameter file \
+                        (`specifications/parameters/query/tag_key.yaml`) \
+                        carries NO description at all — only `name`, `in: \
+                        query`, `style: form`, `explode: true` and `schema: \
+                        {type: string}` — so everything below is read off the \
+                        operation description or is OURS. The three filters \
+                        are AND-combined, each an EXACT, case-sensitive match \
+                        on the stored value; an omitted filter constrains \
+                        nothing — \"In case no such parameter is provided then \
+                        all ITEM_TAG resources will be retrieved\" \
+                        (`demographic_tags_get.yaml`). None of exactness, case \
+                        sensitivity or the combination rule is fixed by the \
+                        released text, so those semantics are OURS, \
+                        register-documented in the conformance catalogue. The \
+                        parameter is SCALAR: the released description says the \
+                        list \"can be filtered by the given one or more \
+                        `tag_key`, `tag_value`, `tag_target_path` query \
+                        parameters\" while each released parameter schema is a \
+                        plain `type: string` — the plural reads as one or more \
+                        OF THE THREE parameters (the mismatch is a \
+                        released-text defect, register-documented), and a \
+                        repeated parameter has no defined meaning.",
+         example = "flag"),
         ("tag_value" = Option<String>, Query,
-         description = "Filter by ITEM_TAG `value` (exact match)."),
+         description = "Filter by ITEM_TAG `value`. The released parameter \
+                        file \
+                        (`specifications/parameters/query/tag_value.yaml`) \
+                        carries NO description at all — only `name`, `in: \
+                        query`, `style: form`, `explode: true` and `schema: \
+                        {type: string}` — so everything below is read off the \
+                        operation description or is OURS. Same semantics as \
+                        `tag_key`: exact, case-sensitive, AND-combined, \
+                        scalar.",
+         example = "follow-up"),
         ("tag_target_path" = Option<String>, Query,
-         description = "Filter by ITEM_TAG `target_path` (exact match).")
+         description = "Filter by ITEM_TAG `target_path`. The released \
+                        parameter file \
+                        (`specifications/parameters/query/tag_target_path.yaml`) \
+                        carries NO description at all — only `name`, `in: \
+                        query`, `style: form`, `explode: true` and `schema: \
+                        {type: string}` — so everything below is read off the \
+                        operation description or is OURS. Same semantics as \
+                        `tag_key`: exact, case-sensitive, AND-combined, \
+                        scalar. Tags stored WITHOUT a `target_path` (the \
+                        absent 0..1 case, which is also where an empty string \
+                        normalizes to) match no value of this filter; they are \
+                        reached by omitting it.",
+         example = "/details/items[at0001]/value"),
+        ("Accept" = Option<String>, Header,
+         description = "The canonical response format (ITS-REST \
+                        `specifications/parameters/header/Accept_canonical.yaml`, \
+                        enum `application/json` | `application/xml`). An \
+                        ITEM_TAG list is served as `application/json` only — \
+                        the canonical XML ITS defines no ITEM_TAG type, so the \
+                        enum's `application/xml` member is stalled shape on \
+                        this operation and asking for it is `406`.",
+         example = "application/json")
     ),
     responses(
-        (status = 200, description = "The matching ITEM_TAGs (an empty array \
-                                      when none match).", body = serde_json::Value),
-        (status = 400, description = "A filter query parameter is invalid.",
+        (
+            status = 200, description = "The matching ITEM_TAG list, across \
+                                         every party kind and both target \
+                                         forms. An empty array when nothing \
+                                         matches — the released empty-list \
+                                         sentence for this operation still \
+                                         names an EHR, a copy-paste from the \
+                                         EHR-scoped twin onto a route that has \
+                                         no EHR at all; it is read as the \
+                                         Demographic space and the defect is \
+                                         register-documented in the \
+                                         conformance catalogue. A no-match \
+                                         result is `200 []`, never `404`. \
+                                         Every row carries the SERVER-ASSIGNED \
+                                         `target` and `owner_id`; neither is \
+                                         client input. `target` names the \
+                                         tagged target — `{namespace: \
+                                         \"demographic\", type: <PARTY kind>, \
+                                         id: <the addressed uid>}`, whose `id` \
+                                         is a `HIER_OBJECT_ID` for the \
+                                         container form and an \
+                                         `OBJECT_VERSION_ID` for the version \
+                                         form — and `owner_id` names the \
+                                         owning VERSIONED_PARTY. That \
+                                         `owner_id` is OUR OWN DESIGN: RM \
+                                         `item_tag.adoc` says only \
+                                         \"Identifier of owner object, such as \
+                                         EHR\" and a demographic party has no \
+                                         EHR, so no released sentence fixes \
+                                         it; the released `ItemTagOf*` \
+                                         examples show `{namespace: local, \
+                                         type: SYSTEM}` instead, which nothing \
+                                         requires. The position is \
+                                         register-documented in the \
+                                         conformance catalogue. `target_path` \
+                                         is present only on tags that carry \
+                                         one — it is 0..1 in the RM — and the \
+                                         empty string normalizes to ABSENT, so \
+                                         a stored tag never echoes the \
+                                         `target_path: \"\"` the released \
+                                         `ItemTagOf*` examples all show; that \
+                                         reconciliation is register-documented \
+                                         too. The released operation reuses \
+                                         `responses/200_PERSON_ItemTagList_retrieved.yaml` \
+                                         (items typed \
+                                         `schemas/demographic/ItemTagOfPerson.yaml`) \
+                                         for this CROSS-KIND list, another \
+                                         released-text defect — each row's own \
+                                         `target.type` names its kind, and the \
+                                         example below shows an AGENT tag \
+                                         beside a PERSON one. The (`key`, \
+                                         `target_path`) ordering the server \
+                                         applies is OURS: no openEHR spec \
+                                         governs tag ordering.",
+            content((serde_json::Value = "application/json", example = json!([
+                {
+                    "_type": "ITEM_TAG",
+                    "key": "flag",
+                    "value": "follow-up",
+                    "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "PERSON", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
+                    "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "PERSON", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                },
+                {
+                    "_type": "ITEM_TAG",
+                    "key": "reviewed",
+                    "value": "true",
+                    "target_path": "/details/items[at0001]/value",
+                    "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "AGENT", "id": { "_type": "HIER_OBJECT_ID", "value": "b1e6a0c4-6b2e-4f3a-9c1d-2f5a7e8b0c31" } },
+                    "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "AGENT", "id": { "_type": "HIER_OBJECT_ID", "value": "b1e6a0c4-6b2e-4f3a-9c1d-2f5a7e8b0c31" } }
+                }
+            ])))
+        ),
+        (status = 400, description = "The released cross-cutting trigger, \
+                                      verbatim: `400 Bad Request` \"is \
+                                      returned when the request could not be \
+                                      parsed or is invalid (e.g. malformed \
+                                      request URL syntax, missing required \
+                                      header or parameter, or syntactically \
+                                      invalid header, parameter or content)\" \
+                                      (ITS-REST \
+                                      `specifications/responses/400.yaml`). \
+                                      This route takes no path parameter and \
+                                      every filter is an unconstrained string, \
+                                      so the only reachable trigger is an \
+                                      unparseable query string. The released \
+                                      operation declares `200` and `400` ONLY \
+                                      — with no scoping parameter there is \
+                                      nothing to fail to find, so there is no \
+                                      `404` on this route.",
+         body = serde_json::Value),
+        (status = 406, description = "The `Accept` header cannot be satisfied: \
+                                      an ITEM_TAG list is served as canonical \
+                                      `application/json` only. The canonical \
+                                      XML ITS defines no ITEM_TAG type, so an \
+                                      `application/xml` Accept — a member of \
+                                      the released `Accept_canonical` enum, \
+                                      stalled shape on this operation — is \
+                                      refused (`Resources.md` §\"XML Format\": \
+                                      \"If the service cannot fulfill this \
+                                      aspect of the request, it MUST respond \
+                                      with HTTP status code `406 Not \
+                                      Acceptable`\"). The released operation \
+                                      does not enumerate `406`; the MUST is \
+                                      cross-cutting.",
          body = serde_json::Value)
     )
 )]
@@ -6153,18 +6358,184 @@ pub(crate) async fn demographic_tags_get(
 
 /// Retrieve an `AGENT`'s `ITEM_TAG`s
 /// (`GET /demographic/agent/{uid_based_id}/tags`).
+///
+/// "Retrieves the list of all ITEM_TAG resources associated with a given target
+/// AGENT version or VERSIONED_PARTY identified by `uid_based_id`" (ITS-REST
+/// `specifications/operations/agent_tags_get.yaml`).
+///
+/// The two `uid_based_id` forms address DISJOINT tag collections — see the
+/// parameter.
 #[utoipa::path(
     get, path = "/demographic/agent/{uid_based_id}/tags", tag = "ITEM_TAG",
     params(
         ("uid_based_id" = String, Path,
-         description = "The target AGENT VERSION (`version_uid`) or \
-                        VERSIONED_PARTY (`versioned_object_uid`).")
+         description = "The released parameter, verbatim: \"The `uid_based_id` \
+                        can take a form of an OBJECT_VERSION_ID identifier \
+                        taken from VERSION.uid.value (i.e. a `version_uid`), \
+                        or a form of a HIER_OBJECT_ID identifier taken from \
+                        VERSIONED_PARTY.uid.value (i.e. a \
+                        `versioned_object_uid`). The former is used to get the \
+                        tags of a particular (target) version of the AGENT \
+                        version (e.g. one identified by \
+                        `8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1`), \
+                        whereas the latter (e.g. an identifier like \
+                        `8849182c-82ad-4088-a07f-48ead4180515`) is be used to \
+                        get the tags of the target VERSIONED_PARTY \
+                        container.\" (ITS-REST \
+                        `specifications/operations/agent_tags_get.yaml`; the \
+                        released path parameter file \
+                        `parameters/path/uid_based_id.yaml` carries the same \
+                        dual-form sentence with VERSIONED_OBJECT in place of \
+                        VERSIONED_PARTY). The two forms address DISJOINT \
+                        collections: an ITEM_TAG carries exactly one `target` \
+                        (RM `item_tag.adoc`: `target: UID_BASED_ID`, \"which \
+                        may be a `VERSIONED_OBJECT<T>` or a `VERSION<T>`\"), \
+                        so a tag written against the container is invisible to \
+                        the version form and a tag written against \
+                        `8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1` \
+                        is invisible both to the container form and to every \
+                        other version. The container form names the \
+                        VERSIONED_PARTY's OWN tag collection, not the latest \
+                        version's — there is no implicit-latest reading here.",
+         example = "8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1"),
+        ("Accept" = Option<String>, Header,
+         description = "The canonical response format (ITS-REST \
+                        `specifications/parameters/header/Accept_canonical.yaml`, \
+                        enum `application/json` | `application/xml`). An \
+                        ITEM_TAG list is served as `application/json` only — \
+                        the canonical XML ITS defines no ITEM_TAG type, so the \
+                        enum's `application/xml` member is stalled shape on \
+                        this operation and asking for it is `406`.",
+         example = "application/json")
     ),
     responses(
-        (status = 200, description = "The ITEM_TAGs on the target (an empty \
-                                      array when none exist).",
+        (
+            status = 200, description = "The released trigger, verbatim: `200 \
+                                         OK` \"is returned when the requested \
+                                         ITEM_TAG list is successfully \
+                                         retrieved.\" (ITS-REST \
+                                         `specifications/responses/200_AGENT_ItemTagList_retrieved.yaml`; \
+                                         items typed \
+                                         `schemas/demographic/ItemTagOfAgent.yaml`). \
+                                         \"This will return an empty list when \
+                                         there is no ITEM_TAG associated with \
+                                         the given target\" \
+                                         (`agent_tags_get.yaml`) — an \
+                                         EXISTING, untagged target is `200 \
+                                         []`; a target that does not exist is \
+                                         `404`. \"More than one ITEM_TAG may \
+                                         be associated with a single target \
+                                         AGENT or VERSIONED_PARTY, in which \
+                                         case they are uniquely identified by \
+                                         their `key` and `target_path` pair \
+                                         attributes\". Every row carries the \
+                                         SERVER-ASSIGNED `target` and \
+                                         `owner_id`; neither is client input. \
+                                         `target` names the ADDRESSED \
+                                         collection — `{namespace: \
+                                         \"demographic\", type: <PARTY kind>, \
+                                         id: <the addressed uid>}`, whose `id` \
+                                         is a `HIER_OBJECT_ID` for the \
+                                         container form and an \
+                                         `OBJECT_VERSION_ID` for the version \
+                                         form — and `owner_id` names the \
+                                         owning VERSIONED_PARTY. That \
+                                         `owner_id` is OUR OWN DESIGN: RM \
+                                         `item_tag.adoc` says only \
+                                         \"Identifier of owner object, such as \
+                                         EHR\" and a demographic party has no \
+                                         EHR, so no released sentence fixes \
+                                         it; the released `ItemTagOf*` \
+                                         examples show `{namespace: local, \
+                                         type: SYSTEM}` instead, which nothing \
+                                         requires. The position is \
+                                         register-documented in the \
+                                         conformance catalogue. `target_path` \
+                                         is present only on tags that carry \
+                                         one — it is 0..1 in the RM — and the \
+                                         empty string normalizes to ABSENT, so \
+                                         a stored tag never echoes the \
+                                         `target_path: \"\"` the released \
+                                         `ItemTagOf*` examples all show; that \
+                                         reconciliation is register-documented \
+                                         too. No `ETag`, `Last-Modified` or \
+                                         `Location` accompanies the list: a \
+                                         tag collection is not \
+                                         change-controlled and has no version \
+                                         and no uid.",
+            content((serde_json::Value = "application/json", example =
+                json!([
+                    {
+                        "_type": "ITEM_TAG",
+                        "key": "flag",
+                        "value": "follow-up",
+                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "AGENT", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "AGENT", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                    },
+                    {
+                        "_type": "ITEM_TAG",
+                        "key": "reviewed",
+                        "value": "true",
+                        "target_path": "/details/items[at0001]/value",
+                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "AGENT", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "AGENT", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                    }
+                ])
+            ))
+        ),
+        (status = 400, description = "The released cross-cutting trigger, \
+                                      verbatim: `400 Bad Request` \"is \
+                                      returned when the request could not be \
+                                      parsed or is invalid (e.g. malformed \
+                                      request URL syntax, missing required \
+                                      header or parameter, or syntactically \
+                                      invalid header, parameter or content)\" \
+                                      (ITS-REST \
+                                      `specifications/responses/400.yaml`). \
+                                      Here: a `uid_based_id` that is neither a \
+                                      HIER_OBJECT_ID (a UUID) nor a \
+                                      well-formed three-part \
+                                      OBJECT_VERSION_ID. A well-formed \
+                                      identifier that names nothing is `404`, \
+                                      not `400`.",
          body = serde_json::Value),
-        (status = 404, description = "The `uid_based_id` does not exist.",
+        (status = 404, description = "The released trigger, verbatim: `404 Not \
+                                      Found` \"is returned when the \
+                                      `uid_based_id` does not exist.\" \
+                                      (ITS-REST \
+                                      `specifications/responses/404_unknown_uid_based_id.yaml`). \
+                                      All of these are that non-existence: an \
+                                      unknown `versioned_object_uid`; a \
+                                      version form whose version does not \
+                                      exist; and a well-formed uid whose \
+                                      stored container is NOT an AGENT — \
+                                      another PARTY kind, or a \
+                                      COMPOSITION/EHR_STATUS/FOLDER uid from \
+                                      the EHR space. The kind-checked reading \
+                                      is OURS (the released sentence does not \
+                                      spell it out) and follows from the route \
+                                      naming the target's class — a \
+                                      VERSIONED_OBJECT has one type (RM \
+                                      `common/master06` §Change Control); it \
+                                      is register-documented in the \
+                                      conformance catalogue. An EXISTING \
+                                      target with no tags is `200 []`, never \
+                                      `404`.",
+         body = serde_json::Value),
+        (status = 406, description = "The `Accept` header cannot be satisfied: \
+                                      an ITEM_TAG list is served as canonical \
+                                      `application/json` only. The canonical \
+                                      XML ITS defines no ITEM_TAG type, so an \
+                                      `application/xml` Accept — a member of \
+                                      the released `Accept_canonical` enum, \
+                                      stalled shape on this operation — is \
+                                      refused (`Resources.md` §\"XML Format\": \
+                                      \"If the service cannot fulfill this \
+                                      aspect of the request, it MUST respond \
+                                      with HTTP status code `406 Not \
+                                      Acceptable`\"). The released operation \
+                                      does not enumerate `406`; the MUST is \
+                                      cross-cutting.",
          body = serde_json::Value)
     )
 )]
@@ -6178,27 +6549,322 @@ pub(crate) async fn agent_tags_get(
 
 /// Replace an `AGENT`'s `ITEM_TAG`s
 /// (`PUT /demographic/agent/{uid_based_id}/tags`).
+///
+/// "Updates the list of all ITEM_TAG resources associated with a given target
+/// AGENT version or VERSIONED_PARTY identified by `uid_based_id`" (ITS-REST
+/// `specifications/operations/agent_tags_update.yaml`). It is a FULL COLLECTION
+/// REPLACE of the ADDRESSED collection — the container's or one version's,
+/// never both.
+///
+/// Tags are not change-controlled, so this write commits no CONTRIBUTION, mints
+/// no version, takes no `If-Match` and no committal headers, and serves neither
+/// `ETag` nor `Last-Modified`.
 #[utoipa::path(
     put, path = "/demographic/agent/{uid_based_id}/tags", tag = "ITEM_TAG",
     params(
         ("uid_based_id" = String, Path,
-         description = "The target AGENT VERSION (`version_uid`) or \
-                        VERSIONED_PARTY (`versioned_object_uid`)."),
+         description = "The released parameter, verbatim: \"The `uid_based_id` \
+                        can take a form of an OBJECT_VERSION_ID identifier \
+                        taken from VERSION.uid.value (i.e. a `version_uid`), \
+                        or a form of a HIER_OBJECT_ID identifier taken from \
+                        VERSIONED_OBJECT.uid.value (i.e. a \
+                        `versioned_object_uid`). The former is used to update \
+                        the tags of a particular AGENT version (e.g. one \
+                        identified by \
+                        `8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1`), \
+                        whereas the latter (e.g. an identifier like \
+                        `8849182c-82ad-4088-a07f-48ead4180515`) is be used to \
+                        update the tags of the target VERSIONED_PARTY \
+                        container.\" (ITS-REST \
+                        `specifications/operations/agent_tags_update.yaml`). \
+                        The update sentence sources the HIER_OBJECT_ID from \
+                        VERSIONED_OBJECT while the get and delete of the same \
+                        family source it from VERSIONED_PARTY, and all three \
+                        end on \"the target VERSIONED_PARTY container\" — an \
+                        editorial split inside one operation family, \
+                        register-documented in the conformance catalogue; both \
+                        name the same container. The two forms address \
+                        DISJOINT collections: an ITEM_TAG carries exactly one \
+                        `target` (RM `item_tag.adoc`: `target: UID_BASED_ID`, \
+                        \"which may be a `VERSIONED_OBJECT<T>` or a \
+                        `VERSION<T>`\"), so a tag written against the \
+                        container is invisible to the version form and a tag \
+                        written against \
+                        `8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1` \
+                        is invisible both to the container form and to every \
+                        other version. The container form names the \
+                        VERSIONED_PARTY's OWN tag collection, not the latest \
+                        version's — there is no implicit-latest reading here. \
+                        So replacing the container's list never touches any \
+                        version's list, and replacing one version's list never \
+                        touches the container's or a sibling version's.",
+         example = "8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1"),
         ("Prefer" = Option<String>, Header,
-         description = "`return=minimal` (default; empty body) or \
-                        `return=representation` (the stored ITEM_TAG list).")
+         description = "`return=minimal` — the default when the header is \
+                        absent (`Requests_and_responses.md` §\"Representation \
+                        details negotiation\": \"If no `Prefer` header is \
+                        provided, the default behavior is assumed to be \
+                        `return=minimal`\") — answers `204 No Content`; \
+                        `return=representation` answers `200` with the full \
+                        RESULTING tag list of the addressed collection. \
+                        `return=identifier` cannot be honoured: its released \
+                        contract is a body carrying \"only the identifier \
+                        (e.g., the `uid`) of the affected resource\" and an \
+                        ITEM_TAG has no uid, so the server applies — and \
+                        declares — the default `return=minimal`; that \
+                        resolution is OURS, register-documented in the \
+                        conformance catalogue. Whichever branch runs, the \
+                        response states it in `Preference-Applied` (ITS-REST \
+                        `specifications/parameters/header/Prefer.yaml`).",
+         example = "return=representation"),
+        ("Content-Type" = Option<String>, Header,
+         description = "The canonical payload format (ITS-REST \
+                        `specifications/parameters/header/ContentType_canonical.yaml`, \
+                        enum `application/json` | `application/xml`). The tag \
+                        list has no XML and no Simplified-Format shape, so \
+                        only `application/json` is processable and any other \
+                        declared type is `415`; an ABSENT `Content-Type` \
+                        declares nothing and is read as canonical JSON.",
+         example = "application/json"),
+        ("Accept" = Option<String>, Header,
+         description = "The canonical response format (ITS-REST \
+                        `specifications/parameters/header/Accept_canonical.yaml`, \
+                        enum `application/json` | `application/xml`). An \
+                        ITEM_TAG list is served as `application/json` only — \
+                        the canonical XML ITS defines no ITEM_TAG type, so the \
+                        enum's `application/xml` member is stalled shape on \
+                        this operation and asking for it is `406`.",
+         example = "application/json")
     ),
     request_body(content = serde_json::Value,
-                 description = "The full ITEM_TAG list to store; an empty array \
-                                removes all tags on the target."),
+                 description = "A BARE JSON ARRAY of UPDATE_ITEM_TAG objects — \
+                                the complete tag list to associate with the \
+                                ADDRESSED collection (`required: true`; there \
+                                is no envelope object). Per the released \
+                                `schemas/common/UpdateItemTag.yaml`: `key` is \
+                                REQUIRED (\"Tag key (identifier)\"), `value` \
+                                (\"Tag value\") and `target_path` (\"An AQL \
+                                path withing the `target` used to tag a \
+                                fine-grained element\") are optional, and \
+                                `additionalProperties: false` defines no other \
+                                member. `target` and `owner_id` are NOT client \
+                                input — the server assigns them from the route \
+                                — which is why the write schema omits them; a \
+                                body that nonetheless carries them is accepted \
+                                and those members ignored, per our canonical \
+                                tolerant-read posture (no released sentence \
+                                governs the extra-member case — our own \
+                                design). This is a FULL COLLECTION REPLACE: \
+                                tags omitted from the body are removed, and \
+                                \"Providing an empty list will effectively \
+                                remove all ITEM_TAG associated with the given \
+                                target\" (`agent_tags_update.yaml`), so `[]` \
+                                is the clear-all form and never an error. \
+                                Identity inside the list is the (`key`, \
+                                `target_path`) PAIR (\"More than one ITEM_TAG \
+                                may be associated with a single target, in \
+                                which case they are uniquely identified by \
+                                their `key` and `target_path` pair \
+                                attributes\"), so two entries may share a \
+                                `key` when their `target_path` differs; a \
+                                DUPLICATE pair inside one body is resolved \
+                                last-wins (no released rule and no \
+                                `uniqueItems` — ours, register-documented). A \
+                                `target_path` of `\"\"` normalizes to ABSENT, \
+                                the same identity as an entry with no \
+                                `target_path` at all: the RM models \
+                                `target_path` 0..1 with no non-empty invariant \
+                                while all five released `ItemTagOf*` examples \
+                                carry `target_path: \"\"` — reconciling the \
+                                two on one identity is ours, \
+                                register-documented. Canonical JSON only: an \
+                                XML (or Simplified-Format) `Content-Type` is \
+                                `415`.",
+                 example = json!([
+                     { "key": "flag", "value": "follow-up" },
+                     { "key": "reviewed", "value": "true", "target_path": "/details/items[at0001]/value" }
+                 ])),
     responses(
-        (status = 200, description = "Stored (`Prefer: return=representation`); \
-                                      body is the stored ITEM_TAG list.",
+        (
+            status = 200, description = "Applied, with `Prefer: \
+                                         return=representation`. The body is \
+                                         the full RESULTING ITEM_TAG list of \
+                                         the addressed collection — every tag \
+                                         now stored on it, server-assigned \
+                                         `target`/`owner_id` included — not \
+                                         merely the entries just sent. (The \
+                                         released \
+                                         `responses/200_AGENT_ItemTagList_updated.yaml` \
+                                         describes itself as \"returned when \
+                                         the requested ITEM_TAG list is \
+                                         successfully retrieved\", a \
+                                         copy-and-paste of its `_retrieved` \
+                                         sibling; the trigger is the update, \
+                                         as stated here. Items are typed \
+                                         `schemas/demographic/ItemTagOfAgent.yaml`.) \
+                                         Every row carries the SERVER-ASSIGNED \
+                                         `target` and `owner_id`; neither is \
+                                         client input. `target` names the \
+                                         ADDRESSED collection — `{namespace: \
+                                         \"demographic\", type: <PARTY kind>, \
+                                         id: <the addressed uid>}`, whose `id` \
+                                         is a `HIER_OBJECT_ID` for the \
+                                         container form and an \
+                                         `OBJECT_VERSION_ID` for the version \
+                                         form — and `owner_id` names the \
+                                         owning VERSIONED_PARTY. That \
+                                         `owner_id` is OUR OWN DESIGN: RM \
+                                         `item_tag.adoc` says only \
+                                         \"Identifier of owner object, such as \
+                                         EHR\" and a demographic party has no \
+                                         EHR, so no released sentence fixes \
+                                         it; the released `ItemTagOf*` \
+                                         examples show `{namespace: local, \
+                                         type: SYSTEM}` instead, which nothing \
+                                         requires. The position is \
+                                         register-documented in the \
+                                         conformance catalogue. `target_path` \
+                                         is present only on tags that carry \
+                                         one — it is 0..1 in the RM — and the \
+                                         empty string normalizes to ABSENT, so \
+                                         a stored tag never echoes the \
+                                         `target_path: \"\"` the released \
+                                         `ItemTagOf*` examples all show; that \
+                                         reconciliation is register-documented \
+                                         too. The only response header is \
+                                         `Preference-Applied`: a tag \
+                                         collection is not change-controlled, \
+                                         so there is no `ETag`, no \
+                                         `Last-Modified` and no `Location`.",
+            headers(
+                ("Preference-Applied" = String,
+                 description = "`return=representation` — the honoured \
+                                preference (`Requests_and_responses.md` \
+                                §\"Representation details negotiation\": the \
+                                service MAY include this header \"to indicate \
+                                that the client's preference has been \
+                                honored\").")
+            ),
+            content((serde_json::Value = "application/json", example =
+                json!([
+                    {
+                        "_type": "ITEM_TAG",
+                        "key": "flag",
+                        "value": "follow-up",
+                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "AGENT", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "AGENT", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                    },
+                    {
+                        "_type": "ITEM_TAG",
+                        "key": "reviewed",
+                        "value": "true",
+                        "target_path": "/details/items[at0001]/value",
+                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "AGENT", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "AGENT", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                    }
+                ])
+            ))
+        ),
+        (status = 204, description = "The released trigger, verbatim: `204 No \
+                                      Content` \"is returned when the update \
+                                      operation was successful and the \
+                                      `Prefer` header is missing or is set to \
+                                      `return=minimal`.\" (ITS-REST \
+                                      `specifications/responses/204_updated.yaml`) \
+                                      — the DEFAULT branch; a \
+                                      `return=identifier` request resolves \
+                                      here too. No body and no resource header \
+                                      of any kind — no `ETag`, no \
+                                      `Last-Modified`, no `Location` — only \
+                                      the `Preference-Applied` declaration.",
+         headers(
+             ("Preference-Applied" = String,
+              description = "`return=minimal` — the applied preference, \
+                             including when the request asked for \
+                             `return=identifier` (an ITEM_TAG has no uid to \
+                             return).")
+         )),
+        (status = 400, description = "The released trigger, verbatim: `400 Bad \
+                                      Request` \"is returned when the request \
+                                      could not be parsed or is invalid (e.g. \
+                                      malformed request URL syntax, missing \
+                                      required header or parameter, or \
+                                      syntactically invalid header, parameter \
+                                      or content)\" (ITS-REST \
+                                      `specifications/responses/400.yaml`). \
+                                      Here: a `uid_based_id` that is neither a \
+                                      UUID nor a well-formed three-part \
+                                      OBJECT_VERSION_ID, or a body that is not \
+                                      parseable JSON / not a JSON ARRAY. A \
+                                      well-formed array whose entries break an \
+                                      ITEM_TAG rule is `422`, not `400`.",
          body = serde_json::Value),
-        (status = 204, description = "Stored (`Prefer: return=minimal`)."),
-        (status = 400, description = "The ITEM_TAG list is invalid.",
+        (status = 404, description = "The released trigger, verbatim: `404 Not \
+                                      Found` \"is returned when the \
+                                      `uid_based_id` does not exist.\" \
+                                      (ITS-REST \
+                                      `specifications/responses/404_unknown_uid_based_id.yaml`). \
+                                      An unknown `versioned_object_uid`, a \
+                                      version form whose version does not \
+                                      exist, and a well-formed uid whose \
+                                      stored container is NOT an AGENT \
+                                      (another PARTY kind, or a uid from the \
+                                      EHR space) are all this `404` — the \
+                                      kind-checked reading being OURS, \
+                                      register-documented in the conformance \
+                                      catalogue.",
          body = serde_json::Value),
-        (status = 404, description = "The `uid_based_id` does not exist.",
+        (status = 406, description = "A `return=representation` request whose \
+                                      `Accept` cannot be satisfied: the \
+                                      ITEM_TAG list is served as canonical \
+                                      `application/json` only (the canonical \
+                                      XML ITS defines no ITEM_TAG type, so the \
+                                      released `Accept_canonical` enum's \
+                                      `application/xml` member is stalled \
+                                      shape here) — `Resources.md` §\"XML \
+                                      Format\": \"If the service cannot \
+                                      fulfill this aspect of the request, it \
+                                      MUST respond with HTTP status code `406 \
+                                      Not Acceptable`\". The default `204` \
+                                      branch returns no body and negotiates \
+                                      nothing. The released operation does not \
+                                      enumerate `406`; the MUST is \
+                                      cross-cutting.",
+         body = serde_json::Value),
+        (status = 415, description = "The request `Content-Type` is not \
+                                      canonical JSON. The tag list has no XML \
+                                      and no Simplified-Format shape, so any \
+                                      other declared media type is refused: \
+                                      \"If the service cannot process the \
+                                      request payload as JSON format, it MUST \
+                                      respond with HTTP status code `415 \
+                                      Unsupported Media Type`\" \
+                                      (`Resources.md` §\"JSON Format\"). An \
+                                      ABSENT `Content-Type` declares nothing \
+                                      and is accepted as JSON. The released \
+                                      operation does not enumerate `415`; the \
+                                      MUST is cross-cutting.",
+         body = serde_json::Value),
+        (status = 422, description = "The body is well-formed but an entry \
+                                      breaks an ITEM_TAG rule: a missing or \
+                                      empty `key`, a `key` with leading or \
+                                      trailing whitespace (RM `item_tag.adoc` \
+                                      __Inv_key_valid__: \"not key.is_empty \
+                                      and key.is_justified\"), or an EMPTY \
+                                      `value` (__Inv_value_valid__: \"value /= \
+                                      Void implies not value.is_empty\" — omit \
+                                      the member instead). The invariants are \
+                                      checked before any write, so a rejected \
+                                      list leaves the stored collection \
+                                      untouched. The released operation \
+                                      declares only `400`; answering `422` for \
+                                      these SEMANTIC failures follows \
+                                      `Requests_and_responses.md` §\"HTTP \
+                                      status codes\", the `422` row (\"The \
+                                      request was well-formed but was unable \
+                                      to be followed due to semantic errors\") \
+                                      and is OURS, register-documented in the \
+                                      conformance catalogue.",
          body = serde_json::Value)
     )
 )]
@@ -6210,20 +6876,132 @@ pub(crate) async fn agent_tags_update(
     guarded_dispatch(state, "agent_tags_update", parts, super::dispatch::dispatch).await
 }
 
-/// Delete one `ITEM_TAG` from an `AGENT` by key
+/// Delete an `AGENT`'s `ITEM_TAG`s under one key
 /// (`DELETE /demographic/agent/{uid_based_id}/tags/{key}`).
+///
+/// "Deletes the ITEM_TAG resource(s) identified by `tag_key`, associated with a
+/// given target AGENT version or VERSIONED_PARTY identified by `uid_based_id`"
+/// (ITS-REST `specifications/operations/agent_tags_delete.yaml`).
+///
+/// A SET delete, not a single-resource delete: ITEM_TAG identity is the (`key`,
+/// `target_path`) pair, the route carries no `target_path` selector, and the
+/// released text says "resource(s)" — so every tag under `key` on the addressed
+/// collection goes, however many paths they carry.
 #[utoipa::path(
-    delete, path = "/demographic/agent/{uid_based_id}/tags/{key}", tag = "ITEM_TAG",
+    delete, path = "/demographic/agent/{uid_based_id}/tags/{key}",
+    tag = "ITEM_TAG",
     params(
         ("uid_based_id" = String, Path,
-         description = "The target AGENT VERSION (`version_uid`) or \
-                        VERSIONED_PARTY (`versioned_object_uid`)."),
-        ("key" = String, Path, description = "The ITEM_TAG key to delete.")
+         description = "The released parameter, verbatim: \"The `uid_based_id` \
+                        can take a form of an OBJECT_VERSION_ID identifier \
+                        taken from VERSION.uid.value (i.e. a `version_uid`), \
+                        or a form of a HIER_OBJECT_ID identifier taken from \
+                        VERSIONED_PARTY.uid.value (i.e. a \
+                        `versioned_object_uid`). The former is used to delete \
+                        the tags a particular (target) version of the AGENT \
+                        version (e.g. one identified by \
+                        `8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1`), \
+                        whereas the latter (e.g. an identifier like \
+                        `8849182c-82ad-4088-a07f-48ead4180515`) is be used to \
+                        delete the tags of the target VERSIONED_PARTY \
+                        container.\" (ITS-REST \
+                        `specifications/operations/agent_tags_delete.yaml`). \
+                        The two forms address DISJOINT collections: an \
+                        ITEM_TAG carries exactly one `target` (RM \
+                        `item_tag.adoc`: `target: UID_BASED_ID`, \"which may \
+                        be a `VERSIONED_OBJECT<T>` or a `VERSION<T>`\"), so a \
+                        tag written against the container is invisible to the \
+                        version form and a tag written against \
+                        `8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1` \
+                        is invisible both to the container form and to every \
+                        other version. The container form names the \
+                        VERSIONED_PARTY's OWN tag collection, not the latest \
+                        version's — there is no implicit-latest reading here. \
+                        So deleting a key from the container leaves the same \
+                        key on every version untouched, and vice versa.",
+         example = "8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1"),
+        ("key" = String, Path,
+         description = "The ITEM_TAG `key` whose tags are deleted from the \
+                        addressed collection — \"The ITEM_TAG key\" (ITS-REST \
+                        `specifications/parameters/path/key.yaml`, `type: \
+                        string`), an UNCONSTRAINED string with no format, \
+                        pattern or length bound, taken percent-decoded from \
+                        the path segment (a key containing `/`, `?` or `#` \
+                        must be percent-encoded by the client). It selects a \
+                        SET, not one resource: identity is the (`key`, \
+                        `target_path`) pair and this route has no \
+                        `target_path` selector, so EVERY tag under the key \
+                        goes — which is why the released description says \
+                        \"Deletes the ITEM_TAG resource(s) identified by \
+                        `tag_key`\" (`agent_tags_delete.yaml`). (That \
+                        description calls the parameter `tag_key` in prose \
+                        while the path parameter is `key` — a released-text \
+                        inconsistency, register-documented in the conformance \
+                        catalogue; the wire name is `key`.)",
+         example = "flag")
     ),
     responses(
-        (status = 204, description = "The ITEM_TAG was deleted."),
-        (status = 404, description = "The `uid_based_id` does not exist, or no \
-                                      ITEM_TAG has that `key`.",
+        (status = 204, description = "The released trigger, verbatim: `204 No \
+                                      Content` \"is returned when the resource \
+                                      identified by the request parameters has \
+                                      been (logically) deleted.\" (ITS-REST \
+                                      `specifications/responses/204_deleted.yaml`). \
+                                      \"(logically) deleted\" is \
+                                      change-control vocabulary that cannot \
+                                      apply here — a tag is not \
+                                      change-controlled, so removal is plain: \
+                                      no deleted version is committed and the \
+                                      tags simply cease to exist. No body and \
+                                      no headers: an ITEM_TAG has no version \
+                                      and no uid, so there is nothing for an \
+                                      `ETag`/`Last-Modified` to carry, and \
+                                      \"the `Location` response header was \
+                                      deprecated from responses of `DELETE` \
+                                      methods\" (`Requests_and_responses.md` \
+                                      §\"Deprecated headers\"). The released \
+                                      operation declares no `Accept` either, \
+                                      and the empty body negotiates nothing — \
+                                      so this route has no `406`."),
+        (status = 400, description = "The released cross-cutting trigger, \
+                                      verbatim: `400 Bad Request` \"is \
+                                      returned when the request could not be \
+                                      parsed or is invalid (e.g. malformed \
+                                      request URL syntax, missing required \
+                                      header or parameter, or syntactically \
+                                      invalid header, parameter or content)\" \
+                                      (ITS-REST \
+                                      `specifications/responses/400.yaml`). \
+                                      Here: a `uid_based_id` that is neither a \
+                                      HIER_OBJECT_ID (a UUID) nor a \
+                                      well-formed three-part \
+                                      OBJECT_VERSION_ID. A well-formed \
+                                      identifier that names nothing is `404`, \
+                                      not `400`.",
+         body = serde_json::Value),
+        (status = 404, description = "The released trigger, verbatim: `404 Not \
+                                      Found` \"is returned when the \
+                                      `uid_based_id` does not exist, or when \
+                                      the ITEM_TAG identified by the `key` \
+                                      does not exist.\" (ITS-REST \
+                                      `specifications/responses/404_unknown_uid_based_id_or_key.yaml`). \
+                                      The SECOND trigger makes this operation \
+                                      deliberately NON-IDEMPOTENT on the wire: \
+                                      the second identical `DELETE` answers \
+                                      `404`, because after the first one no \
+                                      ITEM_TAG under that key exists on the \
+                                      addressed collection. A key that exists \
+                                      only on the OTHER collection of the same \
+                                      versioned object (container vs version) \
+                                      does not exist here either. Target \
+                                      non-existence covers an unknown \
+                                      `versioned_object_uid`, a version form \
+                                      whose version does not exist, and a \
+                                      well-formed uid whose stored container \
+                                      is NOT an AGENT (another PARTY kind, or \
+                                      a uid from the EHR space) — the \
+                                      kind-checked reading being OURS, \
+                                      register-documented in the conformance \
+                                      catalogue.",
          body = serde_json::Value)
     )
 )]
@@ -6237,18 +7015,184 @@ pub(crate) async fn agent_tags_delete(
 
 /// Retrieve a `GROUP`'s `ITEM_TAG`s
 /// (`GET /demographic/group/{uid_based_id}/tags`).
+///
+/// "Retrieves the list of all ITEM_TAG resources associated with a given target
+/// GROUP version or VERSIONED_PARTY identified by `uid_based_id`" (ITS-REST
+/// `specifications/operations/group_tags_get.yaml`).
+///
+/// The two `uid_based_id` forms address DISJOINT tag collections — see the
+/// parameter.
 #[utoipa::path(
     get, path = "/demographic/group/{uid_based_id}/tags", tag = "ITEM_TAG",
     params(
         ("uid_based_id" = String, Path,
-         description = "The target GROUP VERSION (`version_uid`) or \
-                        VERSIONED_PARTY (`versioned_object_uid`).")
+         description = "The released parameter, verbatim: \"The `uid_based_id` \
+                        can take a form of an OBJECT_VERSION_ID identifier \
+                        taken from VERSION.uid.value (i.e. a `version_uid`), \
+                        or a form of a HIER_OBJECT_ID identifier taken from \
+                        VERSIONED_PARTY.uid.value (i.e. a \
+                        `versioned_object_uid`). The former is used to get the \
+                        tags of a particular (target) version of the GROUP \
+                        version (e.g. one identified by \
+                        `8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1`), \
+                        whereas the latter (e.g. an identifier like \
+                        `8849182c-82ad-4088-a07f-48ead4180515`) is be used to \
+                        get the tags of the target VERSIONED_PARTY \
+                        container.\" (ITS-REST \
+                        `specifications/operations/group_tags_get.yaml`; the \
+                        released path parameter file \
+                        `parameters/path/uid_based_id.yaml` carries the same \
+                        dual-form sentence with VERSIONED_OBJECT in place of \
+                        VERSIONED_PARTY). The two forms address DISJOINT \
+                        collections: an ITEM_TAG carries exactly one `target` \
+                        (RM `item_tag.adoc`: `target: UID_BASED_ID`, \"which \
+                        may be a `VERSIONED_OBJECT<T>` or a `VERSION<T>`\"), \
+                        so a tag written against the container is invisible to \
+                        the version form and a tag written against \
+                        `8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1` \
+                        is invisible both to the container form and to every \
+                        other version. The container form names the \
+                        VERSIONED_PARTY's OWN tag collection, not the latest \
+                        version's — there is no implicit-latest reading here.",
+         example = "8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1"),
+        ("Accept" = Option<String>, Header,
+         description = "The canonical response format (ITS-REST \
+                        `specifications/parameters/header/Accept_canonical.yaml`, \
+                        enum `application/json` | `application/xml`). An \
+                        ITEM_TAG list is served as `application/json` only — \
+                        the canonical XML ITS defines no ITEM_TAG type, so the \
+                        enum's `application/xml` member is stalled shape on \
+                        this operation and asking for it is `406`.",
+         example = "application/json")
     ),
     responses(
-        (status = 200, description = "The ITEM_TAGs on the target (an empty \
-                                      array when none exist).",
+        (
+            status = 200, description = "The released trigger, verbatim: `200 \
+                                         OK` \"is returned when the requested \
+                                         ITEM_TAG list is successfully \
+                                         retrieved.\" (ITS-REST \
+                                         `specifications/responses/200_GROUP_ItemTagList_retrieved.yaml`; \
+                                         items typed \
+                                         `schemas/demographic/ItemTagOfGroup.yaml`). \
+                                         \"This will return an empty list when \
+                                         there is no ITEM_TAG associated with \
+                                         the given target\" \
+                                         (`group_tags_get.yaml`) — an \
+                                         EXISTING, untagged target is `200 \
+                                         []`; a target that does not exist is \
+                                         `404`. \"More than one ITEM_TAG may \
+                                         be associated with a single target \
+                                         GROUP or VERSIONED_PARTY, in which \
+                                         case they are uniquely identified by \
+                                         their `key` and `target_path` pair \
+                                         attributes\". Every row carries the \
+                                         SERVER-ASSIGNED `target` and \
+                                         `owner_id`; neither is client input. \
+                                         `target` names the ADDRESSED \
+                                         collection — `{namespace: \
+                                         \"demographic\", type: <PARTY kind>, \
+                                         id: <the addressed uid>}`, whose `id` \
+                                         is a `HIER_OBJECT_ID` for the \
+                                         container form and an \
+                                         `OBJECT_VERSION_ID` for the version \
+                                         form — and `owner_id` names the \
+                                         owning VERSIONED_PARTY. That \
+                                         `owner_id` is OUR OWN DESIGN: RM \
+                                         `item_tag.adoc` says only \
+                                         \"Identifier of owner object, such as \
+                                         EHR\" and a demographic party has no \
+                                         EHR, so no released sentence fixes \
+                                         it; the released `ItemTagOf*` \
+                                         examples show `{namespace: local, \
+                                         type: SYSTEM}` instead, which nothing \
+                                         requires. The position is \
+                                         register-documented in the \
+                                         conformance catalogue. `target_path` \
+                                         is present only on tags that carry \
+                                         one — it is 0..1 in the RM — and the \
+                                         empty string normalizes to ABSENT, so \
+                                         a stored tag never echoes the \
+                                         `target_path: \"\"` the released \
+                                         `ItemTagOf*` examples all show; that \
+                                         reconciliation is register-documented \
+                                         too. No `ETag`, `Last-Modified` or \
+                                         `Location` accompanies the list: a \
+                                         tag collection is not \
+                                         change-controlled and has no version \
+                                         and no uid.",
+            content((serde_json::Value = "application/json", example =
+                json!([
+                    {
+                        "_type": "ITEM_TAG",
+                        "key": "flag",
+                        "value": "follow-up",
+                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "GROUP", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "GROUP", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                    },
+                    {
+                        "_type": "ITEM_TAG",
+                        "key": "reviewed",
+                        "value": "true",
+                        "target_path": "/details/items[at0001]/value",
+                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "GROUP", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "GROUP", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                    }
+                ])
+            ))
+        ),
+        (status = 400, description = "The released cross-cutting trigger, \
+                                      verbatim: `400 Bad Request` \"is \
+                                      returned when the request could not be \
+                                      parsed or is invalid (e.g. malformed \
+                                      request URL syntax, missing required \
+                                      header or parameter, or syntactically \
+                                      invalid header, parameter or content)\" \
+                                      (ITS-REST \
+                                      `specifications/responses/400.yaml`). \
+                                      Here: a `uid_based_id` that is neither a \
+                                      HIER_OBJECT_ID (a UUID) nor a \
+                                      well-formed three-part \
+                                      OBJECT_VERSION_ID. A well-formed \
+                                      identifier that names nothing is `404`, \
+                                      not `400`.",
          body = serde_json::Value),
-        (status = 404, description = "The `uid_based_id` does not exist.",
+        (status = 404, description = "The released trigger, verbatim: `404 Not \
+                                      Found` \"is returned when the \
+                                      `uid_based_id` does not exist.\" \
+                                      (ITS-REST \
+                                      `specifications/responses/404_unknown_uid_based_id.yaml`). \
+                                      All of these are that non-existence: an \
+                                      unknown `versioned_object_uid`; a \
+                                      version form whose version does not \
+                                      exist; and a well-formed uid whose \
+                                      stored container is NOT a GROUP — \
+                                      another PARTY kind, or a \
+                                      COMPOSITION/EHR_STATUS/FOLDER uid from \
+                                      the EHR space. The kind-checked reading \
+                                      is OURS (the released sentence does not \
+                                      spell it out) and follows from the route \
+                                      naming the target's class — a \
+                                      VERSIONED_OBJECT has one type (RM \
+                                      `common/master06` §Change Control); it \
+                                      is register-documented in the \
+                                      conformance catalogue. An EXISTING \
+                                      target with no tags is `200 []`, never \
+                                      `404`.",
+         body = serde_json::Value),
+        (status = 406, description = "The `Accept` header cannot be satisfied: \
+                                      an ITEM_TAG list is served as canonical \
+                                      `application/json` only. The canonical \
+                                      XML ITS defines no ITEM_TAG type, so an \
+                                      `application/xml` Accept — a member of \
+                                      the released `Accept_canonical` enum, \
+                                      stalled shape on this operation — is \
+                                      refused (`Resources.md` §\"XML Format\": \
+                                      \"If the service cannot fulfill this \
+                                      aspect of the request, it MUST respond \
+                                      with HTTP status code `406 Not \
+                                      Acceptable`\"). The released operation \
+                                      does not enumerate `406`; the MUST is \
+                                      cross-cutting.",
          body = serde_json::Value)
     )
 )]
@@ -6262,27 +7206,321 @@ pub(crate) async fn group_tags_get(
 
 /// Replace a `GROUP`'s `ITEM_TAG`s
 /// (`PUT /demographic/group/{uid_based_id}/tags`).
+///
+/// "Updates the list of all ITEM_TAG resources associated with a given target
+/// GROUP version or VERSIONED_PARTY identified by `uid_based_id`" (ITS-REST
+/// `specifications/operations/group_tags_update.yaml`). It is a FULL COLLECTION
+/// REPLACE of the ADDRESSED collection — the container's or one version's,
+/// never both.
+///
+/// Tags are not change-controlled, so this write commits no CONTRIBUTION, mints
+/// no version, takes no `If-Match` and no committal headers, and serves neither
+/// `ETag` nor `Last-Modified`.
 #[utoipa::path(
     put, path = "/demographic/group/{uid_based_id}/tags", tag = "ITEM_TAG",
     params(
         ("uid_based_id" = String, Path,
-         description = "The target GROUP VERSION (`version_uid`) or \
-                        VERSIONED_PARTY (`versioned_object_uid`)."),
+         description = "The released parameter, verbatim: \"The `uid_based_id` \
+                        can take a form of an OBJECT_VERSION_ID identifier \
+                        taken from VERSION.uid.value (i.e. a `version_uid`), \
+                        or a form of a HIER_OBJECT_ID identifier taken from \
+                        VERSIONED_OBJECT.uid.value (i.e. a \
+                        `versioned_object_uid`). The former is used to update \
+                        the tags of a particular GROUP version (e.g. one \
+                        identified by \
+                        `8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1`), \
+                        whereas the latter (e.g. an identifier like \
+                        `8849182c-82ad-4088-a07f-48ead4180515`) is be used to \
+                        update the tags of the target VERSIONED_PARTY \
+                        container.\" (ITS-REST \
+                        `specifications/operations/group_tags_update.yaml`). \
+                        The update sentence sources the HIER_OBJECT_ID from \
+                        VERSIONED_OBJECT while the get and delete of the same \
+                        family source it from VERSIONED_PARTY, and all three \
+                        end on \"the target VERSIONED_PARTY container\" — an \
+                        editorial split inside one operation family, \
+                        register-documented in the conformance catalogue; both \
+                        name the same container. The two forms address \
+                        DISJOINT collections: an ITEM_TAG carries exactly one \
+                        `target` (RM `item_tag.adoc`: `target: UID_BASED_ID`, \
+                        \"which may be a `VERSIONED_OBJECT<T>` or a \
+                        `VERSION<T>`\"), so a tag written against the \
+                        container is invisible to the version form and a tag \
+                        written against \
+                        `8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1` \
+                        is invisible both to the container form and to every \
+                        other version. The container form names the \
+                        VERSIONED_PARTY's OWN tag collection, not the latest \
+                        version's — there is no implicit-latest reading here. \
+                        So replacing the container's list never touches any \
+                        version's list, and replacing one version's list never \
+                        touches the container's or a sibling version's.",
+         example = "8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1"),
         ("Prefer" = Option<String>, Header,
-         description = "`return=minimal` (default; empty body) or \
-                        `return=representation` (the stored ITEM_TAG list).")
+         description = "`return=minimal` — the default when the header is \
+                        absent (`Requests_and_responses.md` §\"Representation \
+                        details negotiation\": \"If no `Prefer` header is \
+                        provided, the default behavior is assumed to be \
+                        `return=minimal`\") — answers `204 No Content`; \
+                        `return=representation` answers `200` with the full \
+                        RESULTING tag list of the addressed collection. \
+                        `return=identifier` cannot be honoured: its released \
+                        contract is a body carrying \"only the identifier \
+                        (e.g., the `uid`) of the affected resource\" and an \
+                        ITEM_TAG has no uid, so the server applies — and \
+                        declares — the default `return=minimal`; that \
+                        resolution is OURS, register-documented in the \
+                        conformance catalogue. Whichever branch runs, the \
+                        response states it in `Preference-Applied` (ITS-REST \
+                        `specifications/parameters/header/Prefer.yaml`).",
+         example = "return=representation"),
+        ("Content-Type" = Option<String>, Header,
+         description = "The canonical payload format (ITS-REST \
+                        `specifications/parameters/header/ContentType_canonical.yaml`, \
+                        enum `application/json` | `application/xml`). The tag \
+                        list has no XML and no Simplified-Format shape, so \
+                        only `application/json` is processable and any other \
+                        declared type is `415`; an ABSENT `Content-Type` \
+                        declares nothing and is read as canonical JSON.",
+         example = "application/json"),
+        ("Accept" = Option<String>, Header,
+         description = "The canonical response format (ITS-REST \
+                        `specifications/parameters/header/Accept_canonical.yaml`, \
+                        enum `application/json` | `application/xml`). An \
+                        ITEM_TAG list is served as `application/json` only — \
+                        the canonical XML ITS defines no ITEM_TAG type, so the \
+                        enum's `application/xml` member is stalled shape on \
+                        this operation and asking for it is `406`.",
+         example = "application/json")
     ),
     request_body(content = serde_json::Value,
-                 description = "The full ITEM_TAG list to store; an empty array \
-                                removes all tags on the target."),
+                 description = "A BARE JSON ARRAY of UPDATE_ITEM_TAG objects — \
+                                the complete tag list to associate with the \
+                                ADDRESSED collection (`required: true`; there \
+                                is no envelope object). Per the released \
+                                `schemas/common/UpdateItemTag.yaml`: `key` is \
+                                REQUIRED (\"Tag key (identifier)\"), `value` \
+                                (\"Tag value\") and `target_path` (\"An AQL \
+                                path withing the `target` used to tag a \
+                                fine-grained element\") are optional, and \
+                                `additionalProperties: false` defines no other \
+                                member. `target` and `owner_id` are NOT client \
+                                input — the server assigns them from the route \
+                                — which is why the write schema omits them; a \
+                                body that nonetheless carries them is accepted \
+                                and those members ignored, per our canonical \
+                                tolerant-read posture (no released sentence \
+                                governs the extra-member case — our own \
+                                design). This is a FULL COLLECTION REPLACE: \
+                                tags omitted from the body are removed, and \
+                                \"Providing an empty list will effectively \
+                                remove all ITEM_TAG associated with the given \
+                                target\" (`group_tags_update.yaml`), so `[]` \
+                                is the clear-all form and never an error. \
+                                Identity inside the list is the (`key`, \
+                                `target_path`) PAIR (\"More than one ITEM_TAG \
+                                may be associated with a single target, in \
+                                which case they are uniquely identified by \
+                                their `key` and `target_path` pair \
+                                attributes\"), so two entries may share a \
+                                `key` when their `target_path` differs; a \
+                                DUPLICATE pair inside one body is resolved \
+                                last-wins (no released rule and no \
+                                `uniqueItems` — ours, register-documented). A \
+                                `target_path` of `\"\"` normalizes to ABSENT, \
+                                the same identity as an entry with no \
+                                `target_path` at all: the RM models \
+                                `target_path` 0..1 with no non-empty invariant \
+                                while all five released `ItemTagOf*` examples \
+                                carry `target_path: \"\"` — reconciling the \
+                                two on one identity is ours, \
+                                register-documented. Canonical JSON only: an \
+                                XML (or Simplified-Format) `Content-Type` is \
+                                `415`.",
+                 example = json!([
+                     { "key": "flag", "value": "follow-up" },
+                     { "key": "reviewed", "value": "true", "target_path": "/details/items[at0001]/value" }
+                 ])),
     responses(
-        (status = 200, description = "Stored (`Prefer: return=representation`); \
-                                      body is the stored ITEM_TAG list.",
+        (
+            status = 200, description = "Applied, with `Prefer: \
+                                         return=representation`. The body is \
+                                         the full RESULTING ITEM_TAG list of \
+                                         the addressed collection — every tag \
+                                         now stored on it, server-assigned \
+                                         `target`/`owner_id` included — not \
+                                         merely the entries just sent. (The \
+                                         released \
+                                         `responses/200_GROUP_ItemTagList_updated.yaml` \
+                                         describes itself as \"returned when \
+                                         the requested ITEM_TAG list is \
+                                         successfully retrieved\", a \
+                                         copy-and-paste of its `_retrieved` \
+                                         sibling; the trigger is the update, \
+                                         as stated here. Items are typed \
+                                         `schemas/demographic/ItemTagOfGroup.yaml`.) \
+                                         Every row carries the SERVER-ASSIGNED \
+                                         `target` and `owner_id`; neither is \
+                                         client input. `target` names the \
+                                         ADDRESSED collection — `{namespace: \
+                                         \"demographic\", type: <PARTY kind>, \
+                                         id: <the addressed uid>}`, whose `id` \
+                                         is a `HIER_OBJECT_ID` for the \
+                                         container form and an \
+                                         `OBJECT_VERSION_ID` for the version \
+                                         form — and `owner_id` names the \
+                                         owning VERSIONED_PARTY. That \
+                                         `owner_id` is OUR OWN DESIGN: RM \
+                                         `item_tag.adoc` says only \
+                                         \"Identifier of owner object, such as \
+                                         EHR\" and a demographic party has no \
+                                         EHR, so no released sentence fixes \
+                                         it; the released `ItemTagOf*` \
+                                         examples show `{namespace: local, \
+                                         type: SYSTEM}` instead, which nothing \
+                                         requires. The position is \
+                                         register-documented in the \
+                                         conformance catalogue. `target_path` \
+                                         is present only on tags that carry \
+                                         one — it is 0..1 in the RM — and the \
+                                         empty string normalizes to ABSENT, so \
+                                         a stored tag never echoes the \
+                                         `target_path: \"\"` the released \
+                                         `ItemTagOf*` examples all show; that \
+                                         reconciliation is register-documented \
+                                         too. The only response header is \
+                                         `Preference-Applied`: a tag \
+                                         collection is not change-controlled, \
+                                         so there is no `ETag`, no \
+                                         `Last-Modified` and no `Location`.",
+            headers(
+                ("Preference-Applied" = String,
+                 description = "`return=representation` — the honoured \
+                                preference (`Requests_and_responses.md` \
+                                §\"Representation details negotiation\": the \
+                                service MAY include this header \"to indicate \
+                                that the client's preference has been \
+                                honored\").")
+            ),
+            content((serde_json::Value = "application/json", example =
+                json!([
+                    {
+                        "_type": "ITEM_TAG",
+                        "key": "flag",
+                        "value": "follow-up",
+                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "GROUP", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "GROUP", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                    },
+                    {
+                        "_type": "ITEM_TAG",
+                        "key": "reviewed",
+                        "value": "true",
+                        "target_path": "/details/items[at0001]/value",
+                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "GROUP", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "GROUP", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                    }
+                ])
+            ))
+        ),
+        (status = 204, description = "The released trigger, verbatim: `204 No \
+                                      Content` \"is returned when the update \
+                                      operation was successful and the \
+                                      `Prefer` header is missing or is set to \
+                                      `return=minimal`.\" (ITS-REST \
+                                      `specifications/responses/204_updated.yaml`) \
+                                      — the DEFAULT branch; a \
+                                      `return=identifier` request resolves \
+                                      here too. No body and no resource header \
+                                      of any kind — no `ETag`, no \
+                                      `Last-Modified`, no `Location` — only \
+                                      the `Preference-Applied` declaration.",
+         headers(
+             ("Preference-Applied" = String,
+              description = "`return=minimal` — the applied preference, \
+                             including when the request asked for \
+                             `return=identifier` (an ITEM_TAG has no uid to \
+                             return).")
+         )),
+        (status = 400, description = "The released trigger, verbatim: `400 Bad \
+                                      Request` \"is returned when the request \
+                                      could not be parsed or is invalid (e.g. \
+                                      malformed request URL syntax, missing \
+                                      required header or parameter, or \
+                                      syntactically invalid header, parameter \
+                                      or content)\" (ITS-REST \
+                                      `specifications/responses/400.yaml`). \
+                                      Here: a `uid_based_id` that is neither a \
+                                      UUID nor a well-formed three-part \
+                                      OBJECT_VERSION_ID, or a body that is not \
+                                      parseable JSON / not a JSON ARRAY. A \
+                                      well-formed array whose entries break an \
+                                      ITEM_TAG rule is `422`, not `400`.",
          body = serde_json::Value),
-        (status = 204, description = "Stored (`Prefer: return=minimal`)."),
-        (status = 400, description = "The ITEM_TAG list is invalid.",
+        (status = 404, description = "The released trigger, verbatim: `404 Not \
+                                      Found` \"is returned when the \
+                                      `uid_based_id` does not exist.\" \
+                                      (ITS-REST \
+                                      `specifications/responses/404_unknown_uid_based_id.yaml`). \
+                                      An unknown `versioned_object_uid`, a \
+                                      version form whose version does not \
+                                      exist, and a well-formed uid whose \
+                                      stored container is NOT a GROUP (another \
+                                      PARTY kind, or a uid from the EHR space) \
+                                      are all this `404` — the kind-checked \
+                                      reading being OURS, register-documented \
+                                      in the conformance catalogue.",
          body = serde_json::Value),
-        (status = 404, description = "The `uid_based_id` does not exist.",
+        (status = 406, description = "A `return=representation` request whose \
+                                      `Accept` cannot be satisfied: the \
+                                      ITEM_TAG list is served as canonical \
+                                      `application/json` only (the canonical \
+                                      XML ITS defines no ITEM_TAG type, so the \
+                                      released `Accept_canonical` enum's \
+                                      `application/xml` member is stalled \
+                                      shape here) — `Resources.md` §\"XML \
+                                      Format\": \"If the service cannot \
+                                      fulfill this aspect of the request, it \
+                                      MUST respond with HTTP status code `406 \
+                                      Not Acceptable`\". The default `204` \
+                                      branch returns no body and negotiates \
+                                      nothing. The released operation does not \
+                                      enumerate `406`; the MUST is \
+                                      cross-cutting.",
+         body = serde_json::Value),
+        (status = 415, description = "The request `Content-Type` is not \
+                                      canonical JSON. The tag list has no XML \
+                                      and no Simplified-Format shape, so any \
+                                      other declared media type is refused: \
+                                      \"If the service cannot process the \
+                                      request payload as JSON format, it MUST \
+                                      respond with HTTP status code `415 \
+                                      Unsupported Media Type`\" \
+                                      (`Resources.md` §\"JSON Format\"). An \
+                                      ABSENT `Content-Type` declares nothing \
+                                      and is accepted as JSON. The released \
+                                      operation does not enumerate `415`; the \
+                                      MUST is cross-cutting.",
+         body = serde_json::Value),
+        (status = 422, description = "The body is well-formed but an entry \
+                                      breaks an ITEM_TAG rule: a missing or \
+                                      empty `key`, a `key` with leading or \
+                                      trailing whitespace (RM `item_tag.adoc` \
+                                      __Inv_key_valid__: \"not key.is_empty \
+                                      and key.is_justified\"), or an EMPTY \
+                                      `value` (__Inv_value_valid__: \"value /= \
+                                      Void implies not value.is_empty\" — omit \
+                                      the member instead). The invariants are \
+                                      checked before any write, so a rejected \
+                                      list leaves the stored collection \
+                                      untouched. The released operation \
+                                      declares only `400`; answering `422` for \
+                                      these SEMANTIC failures follows \
+                                      `Requests_and_responses.md` §\"HTTP \
+                                      status codes\", the `422` row (\"The \
+                                      request was well-formed but was unable \
+                                      to be followed due to semantic errors\") \
+                                      and is OURS, register-documented in the \
+                                      conformance catalogue.",
          body = serde_json::Value)
     )
 )]
@@ -6294,20 +7532,132 @@ pub(crate) async fn group_tags_update(
     guarded_dispatch(state, "group_tags_update", parts, super::dispatch::dispatch).await
 }
 
-/// Delete one `ITEM_TAG` from a `GROUP` by key
+/// Delete a `GROUP`'s `ITEM_TAG`s under one key
 /// (`DELETE /demographic/group/{uid_based_id}/tags/{key}`).
+///
+/// "Deletes the ITEM_TAG resource(s) identified by `tag_key`, associated with a
+/// given target GROUP version or VERSIONED_PARTY identified by `uid_based_id`"
+/// (ITS-REST `specifications/operations/group_tags_delete.yaml`).
+///
+/// A SET delete, not a single-resource delete: ITEM_TAG identity is the (`key`,
+/// `target_path`) pair, the route carries no `target_path` selector, and the
+/// released text says "resource(s)" — so every tag under `key` on the addressed
+/// collection goes, however many paths they carry.
 #[utoipa::path(
-    delete, path = "/demographic/group/{uid_based_id}/tags/{key}", tag = "ITEM_TAG",
+    delete, path = "/demographic/group/{uid_based_id}/tags/{key}",
+    tag = "ITEM_TAG",
     params(
         ("uid_based_id" = String, Path,
-         description = "The target GROUP VERSION (`version_uid`) or \
-                        VERSIONED_PARTY (`versioned_object_uid`)."),
-        ("key" = String, Path, description = "The ITEM_TAG key to delete.")
+         description = "The released parameter, verbatim: \"The `uid_based_id` \
+                        can take a form of an OBJECT_VERSION_ID identifier \
+                        taken from VERSION.uid.value (i.e. a `version_uid`), \
+                        or a form of a HIER_OBJECT_ID identifier taken from \
+                        VERSIONED_PARTY.uid.value (i.e. a \
+                        `versioned_object_uid`). The former is used to delete \
+                        the tags a particular (target) version of the GROUP \
+                        version (e.g. one identified by \
+                        `8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1`), \
+                        whereas the latter (e.g. an identifier like \
+                        `8849182c-82ad-4088-a07f-48ead4180515`) is be used to \
+                        delete the tags of the target VERSIONED_PARTY \
+                        container.\" (ITS-REST \
+                        `specifications/operations/group_tags_delete.yaml`). \
+                        The two forms address DISJOINT collections: an \
+                        ITEM_TAG carries exactly one `target` (RM \
+                        `item_tag.adoc`: `target: UID_BASED_ID`, \"which may \
+                        be a `VERSIONED_OBJECT<T>` or a `VERSION<T>`\"), so a \
+                        tag written against the container is invisible to the \
+                        version form and a tag written against \
+                        `8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1` \
+                        is invisible both to the container form and to every \
+                        other version. The container form names the \
+                        VERSIONED_PARTY's OWN tag collection, not the latest \
+                        version's — there is no implicit-latest reading here. \
+                        So deleting a key from the container leaves the same \
+                        key on every version untouched, and vice versa.",
+         example = "8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1"),
+        ("key" = String, Path,
+         description = "The ITEM_TAG `key` whose tags are deleted from the \
+                        addressed collection — \"The ITEM_TAG key\" (ITS-REST \
+                        `specifications/parameters/path/key.yaml`, `type: \
+                        string`), an UNCONSTRAINED string with no format, \
+                        pattern or length bound, taken percent-decoded from \
+                        the path segment (a key containing `/`, `?` or `#` \
+                        must be percent-encoded by the client). It selects a \
+                        SET, not one resource: identity is the (`key`, \
+                        `target_path`) pair and this route has no \
+                        `target_path` selector, so EVERY tag under the key \
+                        goes — which is why the released description says \
+                        \"Deletes the ITEM_TAG resource(s) identified by \
+                        `tag_key`\" (`group_tags_delete.yaml`). (That \
+                        description calls the parameter `tag_key` in prose \
+                        while the path parameter is `key` — a released-text \
+                        inconsistency, register-documented in the conformance \
+                        catalogue; the wire name is `key`.)",
+         example = "flag")
     ),
     responses(
-        (status = 204, description = "The ITEM_TAG was deleted."),
-        (status = 404, description = "The `uid_based_id` does not exist, or no \
-                                      ITEM_TAG has that `key`.",
+        (status = 204, description = "The released trigger, verbatim: `204 No \
+                                      Content` \"is returned when the resource \
+                                      identified by the request parameters has \
+                                      been (logically) deleted.\" (ITS-REST \
+                                      `specifications/responses/204_deleted.yaml`). \
+                                      \"(logically) deleted\" is \
+                                      change-control vocabulary that cannot \
+                                      apply here — a tag is not \
+                                      change-controlled, so removal is plain: \
+                                      no deleted version is committed and the \
+                                      tags simply cease to exist. No body and \
+                                      no headers: an ITEM_TAG has no version \
+                                      and no uid, so there is nothing for an \
+                                      `ETag`/`Last-Modified` to carry, and \
+                                      \"the `Location` response header was \
+                                      deprecated from responses of `DELETE` \
+                                      methods\" (`Requests_and_responses.md` \
+                                      §\"Deprecated headers\"). The released \
+                                      operation declares no `Accept` either, \
+                                      and the empty body negotiates nothing — \
+                                      so this route has no `406`."),
+        (status = 400, description = "The released cross-cutting trigger, \
+                                      verbatim: `400 Bad Request` \"is \
+                                      returned when the request could not be \
+                                      parsed or is invalid (e.g. malformed \
+                                      request URL syntax, missing required \
+                                      header or parameter, or syntactically \
+                                      invalid header, parameter or content)\" \
+                                      (ITS-REST \
+                                      `specifications/responses/400.yaml`). \
+                                      Here: a `uid_based_id` that is neither a \
+                                      HIER_OBJECT_ID (a UUID) nor a \
+                                      well-formed three-part \
+                                      OBJECT_VERSION_ID. A well-formed \
+                                      identifier that names nothing is `404`, \
+                                      not `400`.",
+         body = serde_json::Value),
+        (status = 404, description = "The released trigger, verbatim: `404 Not \
+                                      Found` \"is returned when the \
+                                      `uid_based_id` does not exist, or when \
+                                      the ITEM_TAG identified by the `key` \
+                                      does not exist.\" (ITS-REST \
+                                      `specifications/responses/404_unknown_uid_based_id_or_key.yaml`). \
+                                      The SECOND trigger makes this operation \
+                                      deliberately NON-IDEMPOTENT on the wire: \
+                                      the second identical `DELETE` answers \
+                                      `404`, because after the first one no \
+                                      ITEM_TAG under that key exists on the \
+                                      addressed collection. A key that exists \
+                                      only on the OTHER collection of the same \
+                                      versioned object (container vs version) \
+                                      does not exist here either. Target \
+                                      non-existence covers an unknown \
+                                      `versioned_object_uid`, a version form \
+                                      whose version does not exist, and a \
+                                      well-formed uid whose stored container \
+                                      is NOT a GROUP (another PARTY kind, or a \
+                                      uid from the EHR space) — the \
+                                      kind-checked reading being OURS, \
+                                      register-documented in the conformance \
+                                      catalogue.",
          body = serde_json::Value)
     )
 )]
@@ -6321,18 +7671,184 @@ pub(crate) async fn group_tags_delete(
 
 /// Retrieve an `ORGANISATION`'s `ITEM_TAG`s
 /// (`GET /demographic/organisation/{uid_based_id}/tags`).
+///
+/// "Retrieves the list of all ITEM_TAG resources associated with a given target
+/// ORGANISATION version or VERSIONED_PARTY identified by `uid_based_id`"
+/// (ITS-REST `specifications/operations/organisation_tags_get.yaml`).
+///
+/// The two `uid_based_id` forms address DISJOINT tag collections — see the
+/// parameter.
 #[utoipa::path(
     get, path = "/demographic/organisation/{uid_based_id}/tags", tag = "ITEM_TAG",
     params(
         ("uid_based_id" = String, Path,
-         description = "The target ORGANISATION VERSION (`version_uid`) or \
-                        VERSIONED_PARTY (`versioned_object_uid`).")
+         description = "The released parameter, verbatim: \"The `uid_based_id` \
+                        can take a form of an OBJECT_VERSION_ID identifier \
+                        taken from VERSION.uid.value (i.e. a `version_uid`), \
+                        or a form of a HIER_OBJECT_ID identifier taken from \
+                        VERSIONED_PARTY.uid.value (i.e. a \
+                        `versioned_object_uid`). The former is used to get the \
+                        tags of a particular (target) version of the \
+                        ORGANISATION version (e.g. one identified by \
+                        `8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1`), \
+                        whereas the latter (e.g. an identifier like \
+                        `8849182c-82ad-4088-a07f-48ead4180515`) is be used to \
+                        get the tags of the target VERSIONED_PARTY \
+                        container.\" (ITS-REST \
+                        `specifications/operations/organisation_tags_get.yaml`; \
+                        the released path parameter file \
+                        `parameters/path/uid_based_id.yaml` carries the same \
+                        dual-form sentence with VERSIONED_OBJECT in place of \
+                        VERSIONED_PARTY). The two forms address DISJOINT \
+                        collections: an ITEM_TAG carries exactly one `target` \
+                        (RM `item_tag.adoc`: `target: UID_BASED_ID`, \"which \
+                        may be a `VERSIONED_OBJECT<T>` or a `VERSION<T>`\"), \
+                        so a tag written against the container is invisible to \
+                        the version form and a tag written against \
+                        `8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1` \
+                        is invisible both to the container form and to every \
+                        other version. The container form names the \
+                        VERSIONED_PARTY's OWN tag collection, not the latest \
+                        version's — there is no implicit-latest reading here.",
+         example = "8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1"),
+        ("Accept" = Option<String>, Header,
+         description = "The canonical response format (ITS-REST \
+                        `specifications/parameters/header/Accept_canonical.yaml`, \
+                        enum `application/json` | `application/xml`). An \
+                        ITEM_TAG list is served as `application/json` only — \
+                        the canonical XML ITS defines no ITEM_TAG type, so the \
+                        enum's `application/xml` member is stalled shape on \
+                        this operation and asking for it is `406`.",
+         example = "application/json")
     ),
     responses(
-        (status = 200, description = "The ITEM_TAGs on the target (an empty \
-                                      array when none exist).",
+        (
+            status = 200, description = "The released trigger, verbatim: `200 \
+                                         OK` \"is returned when the requested \
+                                         ITEM_TAG list is successfully \
+                                         retrieved.\" (ITS-REST \
+                                         `specifications/responses/200_ORGANISATION_ItemTagList_retrieved.yaml`; \
+                                         items typed \
+                                         `schemas/demographic/ItemTagOfOrganisation.yaml`). \
+                                         \"This will return an empty list when \
+                                         there is no ITEM_TAG associated with \
+                                         the given target\" \
+                                         (`organisation_tags_get.yaml`) — an \
+                                         EXISTING, untagged target is `200 \
+                                         []`; a target that does not exist is \
+                                         `404`. \"More than one ITEM_TAG may \
+                                         be associated with a single target \
+                                         ORGANISATION or VERSIONED_PARTY, in \
+                                         which case they are uniquely \
+                                         identified by their `key` and \
+                                         `target_path` pair attributes\". \
+                                         Every row carries the SERVER-ASSIGNED \
+                                         `target` and `owner_id`; neither is \
+                                         client input. `target` names the \
+                                         ADDRESSED collection — `{namespace: \
+                                         \"demographic\", type: <PARTY kind>, \
+                                         id: <the addressed uid>}`, whose `id` \
+                                         is a `HIER_OBJECT_ID` for the \
+                                         container form and an \
+                                         `OBJECT_VERSION_ID` for the version \
+                                         form — and `owner_id` names the \
+                                         owning VERSIONED_PARTY. That \
+                                         `owner_id` is OUR OWN DESIGN: RM \
+                                         `item_tag.adoc` says only \
+                                         \"Identifier of owner object, such as \
+                                         EHR\" and a demographic party has no \
+                                         EHR, so no released sentence fixes \
+                                         it; the released `ItemTagOf*` \
+                                         examples show `{namespace: local, \
+                                         type: SYSTEM}` instead, which nothing \
+                                         requires. The position is \
+                                         register-documented in the \
+                                         conformance catalogue. `target_path` \
+                                         is present only on tags that carry \
+                                         one — it is 0..1 in the RM — and the \
+                                         empty string normalizes to ABSENT, so \
+                                         a stored tag never echoes the \
+                                         `target_path: \"\"` the released \
+                                         `ItemTagOf*` examples all show; that \
+                                         reconciliation is register-documented \
+                                         too. No `ETag`, `Last-Modified` or \
+                                         `Location` accompanies the list: a \
+                                         tag collection is not \
+                                         change-controlled and has no version \
+                                         and no uid.",
+            content((serde_json::Value = "application/json", example =
+                json!([
+                    {
+                        "_type": "ITEM_TAG",
+                        "key": "flag",
+                        "value": "follow-up",
+                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ORGANISATION", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ORGANISATION", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                    },
+                    {
+                        "_type": "ITEM_TAG",
+                        "key": "reviewed",
+                        "value": "true",
+                        "target_path": "/details/items[at0001]/value",
+                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ORGANISATION", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ORGANISATION", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                    }
+                ])
+            ))
+        ),
+        (status = 400, description = "The released cross-cutting trigger, \
+                                      verbatim: `400 Bad Request` \"is \
+                                      returned when the request could not be \
+                                      parsed or is invalid (e.g. malformed \
+                                      request URL syntax, missing required \
+                                      header or parameter, or syntactically \
+                                      invalid header, parameter or content)\" \
+                                      (ITS-REST \
+                                      `specifications/responses/400.yaml`). \
+                                      Here: a `uid_based_id` that is neither a \
+                                      HIER_OBJECT_ID (a UUID) nor a \
+                                      well-formed three-part \
+                                      OBJECT_VERSION_ID. A well-formed \
+                                      identifier that names nothing is `404`, \
+                                      not `400`.",
          body = serde_json::Value),
-        (status = 404, description = "The `uid_based_id` does not exist.",
+        (status = 404, description = "The released trigger, verbatim: `404 Not \
+                                      Found` \"is returned when the \
+                                      `uid_based_id` does not exist.\" \
+                                      (ITS-REST \
+                                      `specifications/responses/404_unknown_uid_based_id.yaml`). \
+                                      All of these are that non-existence: an \
+                                      unknown `versioned_object_uid`; a \
+                                      version form whose version does not \
+                                      exist; and a well-formed uid whose \
+                                      stored container is NOT an ORGANISATION \
+                                      — another PARTY kind, or a \
+                                      COMPOSITION/EHR_STATUS/FOLDER uid from \
+                                      the EHR space. The kind-checked reading \
+                                      is OURS (the released sentence does not \
+                                      spell it out) and follows from the route \
+                                      naming the target's class — a \
+                                      VERSIONED_OBJECT has one type (RM \
+                                      `common/master06` §Change Control); it \
+                                      is register-documented in the \
+                                      conformance catalogue. An EXISTING \
+                                      target with no tags is `200 []`, never \
+                                      `404`.",
+         body = serde_json::Value),
+        (status = 406, description = "The `Accept` header cannot be satisfied: \
+                                      an ITEM_TAG list is served as canonical \
+                                      `application/json` only. The canonical \
+                                      XML ITS defines no ITEM_TAG type, so an \
+                                      `application/xml` Accept — a member of \
+                                      the released `Accept_canonical` enum, \
+                                      stalled shape on this operation — is \
+                                      refused (`Resources.md` §\"XML Format\": \
+                                      \"If the service cannot fulfill this \
+                                      aspect of the request, it MUST respond \
+                                      with HTTP status code `406 Not \
+                                      Acceptable`\"). The released operation \
+                                      does not enumerate `406`; the MUST is \
+                                      cross-cutting.",
          body = serde_json::Value)
     )
 )]
@@ -6352,27 +7868,322 @@ pub(crate) async fn organisation_tags_get(
 
 /// Replace an `ORGANISATION`'s `ITEM_TAG`s
 /// (`PUT /demographic/organisation/{uid_based_id}/tags`).
+///
+/// "Updates the list of all ITEM_TAG resources associated with a given target
+/// ORGANISATION version or VERSIONED_PARTY identified by `uid_based_id`"
+/// (ITS-REST `specifications/operations/organisation_tags_update.yaml`). It is
+/// a FULL COLLECTION REPLACE of the ADDRESSED collection — the container's or
+/// one version's, never both.
+///
+/// Tags are not change-controlled, so this write commits no CONTRIBUTION, mints
+/// no version, takes no `If-Match` and no committal headers, and serves neither
+/// `ETag` nor `Last-Modified`.
 #[utoipa::path(
     put, path = "/demographic/organisation/{uid_based_id}/tags", tag = "ITEM_TAG",
     params(
         ("uid_based_id" = String, Path,
-         description = "The target ORGANISATION VERSION (`version_uid`) or \
-                        VERSIONED_PARTY (`versioned_object_uid`)."),
+         description = "The released parameter, verbatim: \"The `uid_based_id` \
+                        can take a form of an OBJECT_VERSION_ID identifier \
+                        taken from VERSION.uid.value (i.e. a `version_uid`), \
+                        or a form of a HIER_OBJECT_ID identifier taken from \
+                        VERSIONED_OBJECT.uid.value (i.e. a \
+                        `versioned_object_uid`). The former is used to update \
+                        the tags of a particular ORGANISATION version (e.g. \
+                        one identified by \
+                        `8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1`), \
+                        whereas the latter (e.g. an identifier like \
+                        `8849182c-82ad-4088-a07f-48ead4180515`) is be used to \
+                        update the tags of the target VERSIONED_PARTY \
+                        container.\" (ITS-REST \
+                        `specifications/operations/organisation_tags_update.yaml`). \
+                        The update sentence sources the HIER_OBJECT_ID from \
+                        VERSIONED_OBJECT while the get and delete of the same \
+                        family source it from VERSIONED_PARTY, and all three \
+                        end on \"the target VERSIONED_PARTY container\" — an \
+                        editorial split inside one operation family, \
+                        register-documented in the conformance catalogue; both \
+                        name the same container. The two forms address \
+                        DISJOINT collections: an ITEM_TAG carries exactly one \
+                        `target` (RM `item_tag.adoc`: `target: UID_BASED_ID`, \
+                        \"which may be a `VERSIONED_OBJECT<T>` or a \
+                        `VERSION<T>`\"), so a tag written against the \
+                        container is invisible to the version form and a tag \
+                        written against \
+                        `8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1` \
+                        is invisible both to the container form and to every \
+                        other version. The container form names the \
+                        VERSIONED_PARTY's OWN tag collection, not the latest \
+                        version's — there is no implicit-latest reading here. \
+                        So replacing the container's list never touches any \
+                        version's list, and replacing one version's list never \
+                        touches the container's or a sibling version's.",
+         example = "8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1"),
         ("Prefer" = Option<String>, Header,
-         description = "`return=minimal` (default; empty body) or \
-                        `return=representation` (the stored ITEM_TAG list).")
+         description = "`return=minimal` — the default when the header is \
+                        absent (`Requests_and_responses.md` §\"Representation \
+                        details negotiation\": \"If no `Prefer` header is \
+                        provided, the default behavior is assumed to be \
+                        `return=minimal`\") — answers `204 No Content`; \
+                        `return=representation` answers `200` with the full \
+                        RESULTING tag list of the addressed collection. \
+                        `return=identifier` cannot be honoured: its released \
+                        contract is a body carrying \"only the identifier \
+                        (e.g., the `uid`) of the affected resource\" and an \
+                        ITEM_TAG has no uid, so the server applies — and \
+                        declares — the default `return=minimal`; that \
+                        resolution is OURS, register-documented in the \
+                        conformance catalogue. Whichever branch runs, the \
+                        response states it in `Preference-Applied` (ITS-REST \
+                        `specifications/parameters/header/Prefer.yaml`).",
+         example = "return=representation"),
+        ("Content-Type" = Option<String>, Header,
+         description = "The canonical payload format (ITS-REST \
+                        `specifications/parameters/header/ContentType_canonical.yaml`, \
+                        enum `application/json` | `application/xml`). The tag \
+                        list has no XML and no Simplified-Format shape, so \
+                        only `application/json` is processable and any other \
+                        declared type is `415`; an ABSENT `Content-Type` \
+                        declares nothing and is read as canonical JSON.",
+         example = "application/json"),
+        ("Accept" = Option<String>, Header,
+         description = "The canonical response format (ITS-REST \
+                        `specifications/parameters/header/Accept_canonical.yaml`, \
+                        enum `application/json` | `application/xml`). An \
+                        ITEM_TAG list is served as `application/json` only — \
+                        the canonical XML ITS defines no ITEM_TAG type, so the \
+                        enum's `application/xml` member is stalled shape on \
+                        this operation and asking for it is `406`.",
+         example = "application/json")
     ),
     request_body(content = serde_json::Value,
-                 description = "The full ITEM_TAG list to store; an empty array \
-                                removes all tags on the target."),
+                 description = "A BARE JSON ARRAY of UPDATE_ITEM_TAG objects — \
+                                the complete tag list to associate with the \
+                                ADDRESSED collection (`required: true`; there \
+                                is no envelope object). Per the released \
+                                `schemas/common/UpdateItemTag.yaml`: `key` is \
+                                REQUIRED (\"Tag key (identifier)\"), `value` \
+                                (\"Tag value\") and `target_path` (\"An AQL \
+                                path withing the `target` used to tag a \
+                                fine-grained element\") are optional, and \
+                                `additionalProperties: false` defines no other \
+                                member. `target` and `owner_id` are NOT client \
+                                input — the server assigns them from the route \
+                                — which is why the write schema omits them; a \
+                                body that nonetheless carries them is accepted \
+                                and those members ignored, per our canonical \
+                                tolerant-read posture (no released sentence \
+                                governs the extra-member case — our own \
+                                design). This is a FULL COLLECTION REPLACE: \
+                                tags omitted from the body are removed, and \
+                                \"Providing an empty list will effectively \
+                                remove all ITEM_TAG associated with the given \
+                                target\" (`organisation_tags_update.yaml`), so \
+                                `[]` is the clear-all form and never an error. \
+                                Identity inside the list is the (`key`, \
+                                `target_path`) PAIR (\"More than one ITEM_TAG \
+                                may be associated with a single target, in \
+                                which case they are uniquely identified by \
+                                their `key` and `target_path` pair \
+                                attributes\"), so two entries may share a \
+                                `key` when their `target_path` differs; a \
+                                DUPLICATE pair inside one body is resolved \
+                                last-wins (no released rule and no \
+                                `uniqueItems` — ours, register-documented). A \
+                                `target_path` of `\"\"` normalizes to ABSENT, \
+                                the same identity as an entry with no \
+                                `target_path` at all: the RM models \
+                                `target_path` 0..1 with no non-empty invariant \
+                                while all five released `ItemTagOf*` examples \
+                                carry `target_path: \"\"` — reconciling the \
+                                two on one identity is ours, \
+                                register-documented. Canonical JSON only: an \
+                                XML (or Simplified-Format) `Content-Type` is \
+                                `415`.",
+                 example = json!([
+                     { "key": "flag", "value": "follow-up" },
+                     { "key": "reviewed", "value": "true", "target_path": "/details/items[at0001]/value" }
+                 ])),
     responses(
-        (status = 200, description = "Stored (`Prefer: return=representation`); \
-                                      body is the stored ITEM_TAG list.",
+        (
+            status = 200, description = "Applied, with `Prefer: \
+                                         return=representation`. The body is \
+                                         the full RESULTING ITEM_TAG list of \
+                                         the addressed collection — every tag \
+                                         now stored on it, server-assigned \
+                                         `target`/`owner_id` included — not \
+                                         merely the entries just sent. (The \
+                                         released \
+                                         `responses/200_ORGANISATION_ItemTagList_updated.yaml` \
+                                         describes itself as \"returned when \
+                                         the requested ITEM_TAG list is \
+                                         successfully retrieved\", a \
+                                         copy-and-paste of its `_retrieved` \
+                                         sibling; the trigger is the update, \
+                                         as stated here. Items are typed \
+                                         `schemas/demographic/ItemTagOfOrganisation.yaml`.) \
+                                         Every row carries the SERVER-ASSIGNED \
+                                         `target` and `owner_id`; neither is \
+                                         client input. `target` names the \
+                                         ADDRESSED collection — `{namespace: \
+                                         \"demographic\", type: <PARTY kind>, \
+                                         id: <the addressed uid>}`, whose `id` \
+                                         is a `HIER_OBJECT_ID` for the \
+                                         container form and an \
+                                         `OBJECT_VERSION_ID` for the version \
+                                         form — and `owner_id` names the \
+                                         owning VERSIONED_PARTY. That \
+                                         `owner_id` is OUR OWN DESIGN: RM \
+                                         `item_tag.adoc` says only \
+                                         \"Identifier of owner object, such as \
+                                         EHR\" and a demographic party has no \
+                                         EHR, so no released sentence fixes \
+                                         it; the released `ItemTagOf*` \
+                                         examples show `{namespace: local, \
+                                         type: SYSTEM}` instead, which nothing \
+                                         requires. The position is \
+                                         register-documented in the \
+                                         conformance catalogue. `target_path` \
+                                         is present only on tags that carry \
+                                         one — it is 0..1 in the RM — and the \
+                                         empty string normalizes to ABSENT, so \
+                                         a stored tag never echoes the \
+                                         `target_path: \"\"` the released \
+                                         `ItemTagOf*` examples all show; that \
+                                         reconciliation is register-documented \
+                                         too. The only response header is \
+                                         `Preference-Applied`: a tag \
+                                         collection is not change-controlled, \
+                                         so there is no `ETag`, no \
+                                         `Last-Modified` and no `Location`.",
+            headers(
+                ("Preference-Applied" = String,
+                 description = "`return=representation` — the honoured \
+                                preference (`Requests_and_responses.md` \
+                                §\"Representation details negotiation\": the \
+                                service MAY include this header \"to indicate \
+                                that the client's preference has been \
+                                honored\").")
+            ),
+            content((serde_json::Value = "application/json", example =
+                json!([
+                    {
+                        "_type": "ITEM_TAG",
+                        "key": "flag",
+                        "value": "follow-up",
+                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ORGANISATION", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ORGANISATION", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                    },
+                    {
+                        "_type": "ITEM_TAG",
+                        "key": "reviewed",
+                        "value": "true",
+                        "target_path": "/details/items[at0001]/value",
+                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ORGANISATION", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ORGANISATION", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                    }
+                ])
+            ))
+        ),
+        (status = 204, description = "The released trigger, verbatim: `204 No \
+                                      Content` \"is returned when the update \
+                                      operation was successful and the \
+                                      `Prefer` header is missing or is set to \
+                                      `return=minimal`.\" (ITS-REST \
+                                      `specifications/responses/204_updated.yaml`) \
+                                      — the DEFAULT branch; a \
+                                      `return=identifier` request resolves \
+                                      here too. No body and no resource header \
+                                      of any kind — no `ETag`, no \
+                                      `Last-Modified`, no `Location` — only \
+                                      the `Preference-Applied` declaration.",
+         headers(
+             ("Preference-Applied" = String,
+              description = "`return=minimal` — the applied preference, \
+                             including when the request asked for \
+                             `return=identifier` (an ITEM_TAG has no uid to \
+                             return).")
+         )),
+        (status = 400, description = "The released trigger, verbatim: `400 Bad \
+                                      Request` \"is returned when the request \
+                                      could not be parsed or is invalid (e.g. \
+                                      malformed request URL syntax, missing \
+                                      required header or parameter, or \
+                                      syntactically invalid header, parameter \
+                                      or content)\" (ITS-REST \
+                                      `specifications/responses/400.yaml`). \
+                                      Here: a `uid_based_id` that is neither a \
+                                      UUID nor a well-formed three-part \
+                                      OBJECT_VERSION_ID, or a body that is not \
+                                      parseable JSON / not a JSON ARRAY. A \
+                                      well-formed array whose entries break an \
+                                      ITEM_TAG rule is `422`, not `400`.",
          body = serde_json::Value),
-        (status = 204, description = "Stored (`Prefer: return=minimal`)."),
-        (status = 400, description = "The ITEM_TAG list is invalid.",
+        (status = 404, description = "The released trigger, verbatim: `404 Not \
+                                      Found` \"is returned when the \
+                                      `uid_based_id` does not exist.\" \
+                                      (ITS-REST \
+                                      `specifications/responses/404_unknown_uid_based_id.yaml`). \
+                                      An unknown `versioned_object_uid`, a \
+                                      version form whose version does not \
+                                      exist, and a well-formed uid whose \
+                                      stored container is NOT an ORGANISATION \
+                                      (another PARTY kind, or a uid from the \
+                                      EHR space) are all this `404` — the \
+                                      kind-checked reading being OURS, \
+                                      register-documented in the conformance \
+                                      catalogue.",
          body = serde_json::Value),
-        (status = 404, description = "The `uid_based_id` does not exist.",
+        (status = 406, description = "A `return=representation` request whose \
+                                      `Accept` cannot be satisfied: the \
+                                      ITEM_TAG list is served as canonical \
+                                      `application/json` only (the canonical \
+                                      XML ITS defines no ITEM_TAG type, so the \
+                                      released `Accept_canonical` enum's \
+                                      `application/xml` member is stalled \
+                                      shape here) — `Resources.md` §\"XML \
+                                      Format\": \"If the service cannot \
+                                      fulfill this aspect of the request, it \
+                                      MUST respond with HTTP status code `406 \
+                                      Not Acceptable`\". The default `204` \
+                                      branch returns no body and negotiates \
+                                      nothing. The released operation does not \
+                                      enumerate `406`; the MUST is \
+                                      cross-cutting.",
+         body = serde_json::Value),
+        (status = 415, description = "The request `Content-Type` is not \
+                                      canonical JSON. The tag list has no XML \
+                                      and no Simplified-Format shape, so any \
+                                      other declared media type is refused: \
+                                      \"If the service cannot process the \
+                                      request payload as JSON format, it MUST \
+                                      respond with HTTP status code `415 \
+                                      Unsupported Media Type`\" \
+                                      (`Resources.md` §\"JSON Format\"). An \
+                                      ABSENT `Content-Type` declares nothing \
+                                      and is accepted as JSON. The released \
+                                      operation does not enumerate `415`; the \
+                                      MUST is cross-cutting.",
+         body = serde_json::Value),
+        (status = 422, description = "The body is well-formed but an entry \
+                                      breaks an ITEM_TAG rule: a missing or \
+                                      empty `key`, a `key` with leading or \
+                                      trailing whitespace (RM `item_tag.adoc` \
+                                      __Inv_key_valid__: \"not key.is_empty \
+                                      and key.is_justified\"), or an EMPTY \
+                                      `value` (__Inv_value_valid__: \"value /= \
+                                      Void implies not value.is_empty\" — omit \
+                                      the member instead). The invariants are \
+                                      checked before any write, so a rejected \
+                                      list leaves the stored collection \
+                                      untouched. The released operation \
+                                      declares only `400`; answering `422` for \
+                                      these SEMANTIC failures follows \
+                                      `Requests_and_responses.md` §\"HTTP \
+                                      status codes\", the `422` row (\"The \
+                                      request was well-formed but was unable \
+                                      to be followed due to semantic errors\") \
+                                      and is OURS, register-documented in the \
+                                      conformance catalogue.",
          body = serde_json::Value)
     )
 )]
@@ -6390,20 +8201,133 @@ pub(crate) async fn organisation_tags_update(
     .await
 }
 
-/// Delete one `ITEM_TAG` from an `ORGANISATION` by key
+/// Delete an `ORGANISATION`'s `ITEM_TAG`s under one key
 /// (`DELETE /demographic/organisation/{uid_based_id}/tags/{key}`).
+///
+/// "Deletes the ITEM_TAG resource(s) identified by `tag_key`, associated with a
+/// given target ORGANISATION version or VERSIONED_PARTY identified by
+/// `uid_based_id`" (ITS-REST
+/// `specifications/operations/organisation_tags_delete.yaml`).
+///
+/// A SET delete, not a single-resource delete: ITEM_TAG identity is the (`key`,
+/// `target_path`) pair, the route carries no `target_path` selector, and the
+/// released text says "resource(s)" — so every tag under `key` on the addressed
+/// collection goes, however many paths they carry.
 #[utoipa::path(
-    delete, path = "/demographic/organisation/{uid_based_id}/tags/{key}", tag = "ITEM_TAG",
+    delete, path = "/demographic/organisation/{uid_based_id}/tags/{key}",
+    tag = "ITEM_TAG",
     params(
         ("uid_based_id" = String, Path,
-         description = "The target ORGANISATION VERSION (`version_uid`) or \
-                        VERSIONED_PARTY (`versioned_object_uid`)."),
-        ("key" = String, Path, description = "The ITEM_TAG key to delete.")
+         description = "The released parameter, verbatim: \"The `uid_based_id` \
+                        can take a form of an OBJECT_VERSION_ID identifier \
+                        taken from VERSION.uid.value (i.e. a `version_uid`), \
+                        or a form of a HIER_OBJECT_ID identifier taken from \
+                        VERSIONED_PARTY.uid.value (i.e. a \
+                        `versioned_object_uid`). The former is used to delete \
+                        the tags a particular (target) version of the \
+                        ORGANISATION version (e.g. one identified by \
+                        `8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1`), \
+                        whereas the latter (e.g. an identifier like \
+                        `8849182c-82ad-4088-a07f-48ead4180515`) is be used to \
+                        delete the tags of the target VERSIONED_PARTY \
+                        container.\" (ITS-REST \
+                        `specifications/operations/organisation_tags_delete.yaml`). \
+                        The two forms address DISJOINT collections: an \
+                        ITEM_TAG carries exactly one `target` (RM \
+                        `item_tag.adoc`: `target: UID_BASED_ID`, \"which may \
+                        be a `VERSIONED_OBJECT<T>` or a `VERSION<T>`\"), so a \
+                        tag written against the container is invisible to the \
+                        version form and a tag written against \
+                        `8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1` \
+                        is invisible both to the container form and to every \
+                        other version. The container form names the \
+                        VERSIONED_PARTY's OWN tag collection, not the latest \
+                        version's — there is no implicit-latest reading here. \
+                        So deleting a key from the container leaves the same \
+                        key on every version untouched, and vice versa.",
+         example = "8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1"),
+        ("key" = String, Path,
+         description = "The ITEM_TAG `key` whose tags are deleted from the \
+                        addressed collection — \"The ITEM_TAG key\" (ITS-REST \
+                        `specifications/parameters/path/key.yaml`, `type: \
+                        string`), an UNCONSTRAINED string with no format, \
+                        pattern or length bound, taken percent-decoded from \
+                        the path segment (a key containing `/`, `?` or `#` \
+                        must be percent-encoded by the client). It selects a \
+                        SET, not one resource: identity is the (`key`, \
+                        `target_path`) pair and this route has no \
+                        `target_path` selector, so EVERY tag under the key \
+                        goes — which is why the released description says \
+                        \"Deletes the ITEM_TAG resource(s) identified by \
+                        `tag_key`\" (`organisation_tags_delete.yaml`). (That \
+                        description calls the parameter `tag_key` in prose \
+                        while the path parameter is `key` — a released-text \
+                        inconsistency, register-documented in the conformance \
+                        catalogue; the wire name is `key`.)",
+         example = "flag")
     ),
     responses(
-        (status = 204, description = "The ITEM_TAG was deleted."),
-        (status = 404, description = "The `uid_based_id` does not exist, or no \
-                                      ITEM_TAG has that `key`.",
+        (status = 204, description = "The released trigger, verbatim: `204 No \
+                                      Content` \"is returned when the resource \
+                                      identified by the request parameters has \
+                                      been (logically) deleted.\" (ITS-REST \
+                                      `specifications/responses/204_deleted.yaml`). \
+                                      \"(logically) deleted\" is \
+                                      change-control vocabulary that cannot \
+                                      apply here — a tag is not \
+                                      change-controlled, so removal is plain: \
+                                      no deleted version is committed and the \
+                                      tags simply cease to exist. No body and \
+                                      no headers: an ITEM_TAG has no version \
+                                      and no uid, so there is nothing for an \
+                                      `ETag`/`Last-Modified` to carry, and \
+                                      \"the `Location` response header was \
+                                      deprecated from responses of `DELETE` \
+                                      methods\" (`Requests_and_responses.md` \
+                                      §\"Deprecated headers\"). The released \
+                                      operation declares no `Accept` either, \
+                                      and the empty body negotiates nothing — \
+                                      so this route has no `406`."),
+        (status = 400, description = "The released cross-cutting trigger, \
+                                      verbatim: `400 Bad Request` \"is \
+                                      returned when the request could not be \
+                                      parsed or is invalid (e.g. malformed \
+                                      request URL syntax, missing required \
+                                      header or parameter, or syntactically \
+                                      invalid header, parameter or content)\" \
+                                      (ITS-REST \
+                                      `specifications/responses/400.yaml`). \
+                                      Here: a `uid_based_id` that is neither a \
+                                      HIER_OBJECT_ID (a UUID) nor a \
+                                      well-formed three-part \
+                                      OBJECT_VERSION_ID. A well-formed \
+                                      identifier that names nothing is `404`, \
+                                      not `400`.",
+         body = serde_json::Value),
+        (status = 404, description = "The released trigger, verbatim: `404 Not \
+                                      Found` \"is returned when the \
+                                      `uid_based_id` does not exist, or when \
+                                      the ITEM_TAG identified by the `key` \
+                                      does not exist.\" (ITS-REST \
+                                      `specifications/responses/404_unknown_uid_based_id_or_key.yaml`). \
+                                      The SECOND trigger makes this operation \
+                                      deliberately NON-IDEMPOTENT on the wire: \
+                                      the second identical `DELETE` answers \
+                                      `404`, because after the first one no \
+                                      ITEM_TAG under that key exists on the \
+                                      addressed collection. A key that exists \
+                                      only on the OTHER collection of the same \
+                                      versioned object (container vs version) \
+                                      does not exist here either. Target \
+                                      non-existence covers an unknown \
+                                      `versioned_object_uid`, a version form \
+                                      whose version does not exist, and a \
+                                      well-formed uid whose stored container \
+                                      is NOT an ORGANISATION (another PARTY \
+                                      kind, or a uid from the EHR space) — the \
+                                      kind-checked reading being OURS, \
+                                      register-documented in the conformance \
+                                      catalogue.",
          body = serde_json::Value)
     )
 )]
@@ -6423,18 +8347,184 @@ pub(crate) async fn organisation_tags_delete(
 
 /// Retrieve a `PERSON`'s `ITEM_TAG`s
 /// (`GET /demographic/person/{uid_based_id}/tags`).
+///
+/// "Retrieves the list of all ITEM_TAG resources associated with a given target
+/// PERSON version or VERSIONED_PARTY identified by `uid_based_id`" (ITS-REST
+/// `specifications/operations/person_tags_get.yaml`).
+///
+/// The two `uid_based_id` forms address DISJOINT tag collections — see the
+/// parameter.
 #[utoipa::path(
     get, path = "/demographic/person/{uid_based_id}/tags", tag = "ITEM_TAG",
     params(
         ("uid_based_id" = String, Path,
-         description = "The target PERSON VERSION (`version_uid`) or \
-                        VERSIONED_PARTY (`versioned_object_uid`).")
+         description = "The released parameter, verbatim: \"The `uid_based_id` \
+                        can take a form of an OBJECT_VERSION_ID identifier \
+                        taken from VERSION.uid.value (i.e. a `version_uid`), \
+                        or a form of a HIER_OBJECT_ID identifier taken from \
+                        VERSIONED_PARTY.uid.value (i.e. a \
+                        `versioned_object_uid`). The former is used to get the \
+                        tags of a particular (target) version of the PERSON \
+                        version (e.g. one identified by \
+                        `8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1`), \
+                        whereas the latter (e.g. an identifier like \
+                        `8849182c-82ad-4088-a07f-48ead4180515`) is be used to \
+                        get the tags of the target VERSIONED_PARTY \
+                        container.\" (ITS-REST \
+                        `specifications/operations/person_tags_get.yaml`; the \
+                        released path parameter file \
+                        `parameters/path/uid_based_id.yaml` carries the same \
+                        dual-form sentence with VERSIONED_OBJECT in place of \
+                        VERSIONED_PARTY). The two forms address DISJOINT \
+                        collections: an ITEM_TAG carries exactly one `target` \
+                        (RM `item_tag.adoc`: `target: UID_BASED_ID`, \"which \
+                        may be a `VERSIONED_OBJECT<T>` or a `VERSION<T>`\"), \
+                        so a tag written against the container is invisible to \
+                        the version form and a tag written against \
+                        `8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1` \
+                        is invisible both to the container form and to every \
+                        other version. The container form names the \
+                        VERSIONED_PARTY's OWN tag collection, not the latest \
+                        version's — there is no implicit-latest reading here.",
+         example = "8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1"),
+        ("Accept" = Option<String>, Header,
+         description = "The canonical response format (ITS-REST \
+                        `specifications/parameters/header/Accept_canonical.yaml`, \
+                        enum `application/json` | `application/xml`). An \
+                        ITEM_TAG list is served as `application/json` only — \
+                        the canonical XML ITS defines no ITEM_TAG type, so the \
+                        enum's `application/xml` member is stalled shape on \
+                        this operation and asking for it is `406`.",
+         example = "application/json")
     ),
     responses(
-        (status = 200, description = "The ITEM_TAGs on the target (an empty \
-                                      array when none exist).",
+        (
+            status = 200, description = "The released trigger, verbatim: `200 \
+                                         OK` \"is returned when the requested \
+                                         ITEM_TAG list is successfully \
+                                         retrieved.\" (ITS-REST \
+                                         `specifications/responses/200_PERSON_ItemTagList_retrieved.yaml`; \
+                                         items typed \
+                                         `schemas/demographic/ItemTagOfPerson.yaml`). \
+                                         \"This will return an empty list when \
+                                         there is no ITEM_TAG associated with \
+                                         the given target\" \
+                                         (`person_tags_get.yaml`) — an \
+                                         EXISTING, untagged target is `200 \
+                                         []`; a target that does not exist is \
+                                         `404`. \"More than one ITEM_TAG may \
+                                         be associated with a single target \
+                                         PERSON or VERSIONED_PARTY, in which \
+                                         case they are uniquely identified by \
+                                         their `key` and `target_path` pair \
+                                         attributes\". Every row carries the \
+                                         SERVER-ASSIGNED `target` and \
+                                         `owner_id`; neither is client input. \
+                                         `target` names the ADDRESSED \
+                                         collection — `{namespace: \
+                                         \"demographic\", type: <PARTY kind>, \
+                                         id: <the addressed uid>}`, whose `id` \
+                                         is a `HIER_OBJECT_ID` for the \
+                                         container form and an \
+                                         `OBJECT_VERSION_ID` for the version \
+                                         form — and `owner_id` names the \
+                                         owning VERSIONED_PARTY. That \
+                                         `owner_id` is OUR OWN DESIGN: RM \
+                                         `item_tag.adoc` says only \
+                                         \"Identifier of owner object, such as \
+                                         EHR\" and a demographic party has no \
+                                         EHR, so no released sentence fixes \
+                                         it; the released `ItemTagOf*` \
+                                         examples show `{namespace: local, \
+                                         type: SYSTEM}` instead, which nothing \
+                                         requires. The position is \
+                                         register-documented in the \
+                                         conformance catalogue. `target_path` \
+                                         is present only on tags that carry \
+                                         one — it is 0..1 in the RM — and the \
+                                         empty string normalizes to ABSENT, so \
+                                         a stored tag never echoes the \
+                                         `target_path: \"\"` the released \
+                                         `ItemTagOf*` examples all show; that \
+                                         reconciliation is register-documented \
+                                         too. No `ETag`, `Last-Modified` or \
+                                         `Location` accompanies the list: a \
+                                         tag collection is not \
+                                         change-controlled and has no version \
+                                         and no uid.",
+            content((serde_json::Value = "application/json", example =
+                json!([
+                    {
+                        "_type": "ITEM_TAG",
+                        "key": "flag",
+                        "value": "follow-up",
+                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "PERSON", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "PERSON", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                    },
+                    {
+                        "_type": "ITEM_TAG",
+                        "key": "reviewed",
+                        "value": "true",
+                        "target_path": "/details/items[at0001]/value",
+                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "PERSON", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "PERSON", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                    }
+                ])
+            ))
+        ),
+        (status = 400, description = "The released cross-cutting trigger, \
+                                      verbatim: `400 Bad Request` \"is \
+                                      returned when the request could not be \
+                                      parsed or is invalid (e.g. malformed \
+                                      request URL syntax, missing required \
+                                      header or parameter, or syntactically \
+                                      invalid header, parameter or content)\" \
+                                      (ITS-REST \
+                                      `specifications/responses/400.yaml`). \
+                                      Here: a `uid_based_id` that is neither a \
+                                      HIER_OBJECT_ID (a UUID) nor a \
+                                      well-formed three-part \
+                                      OBJECT_VERSION_ID. A well-formed \
+                                      identifier that names nothing is `404`, \
+                                      not `400`.",
          body = serde_json::Value),
-        (status = 404, description = "The `uid_based_id` does not exist.",
+        (status = 404, description = "The released trigger, verbatim: `404 Not \
+                                      Found` \"is returned when the \
+                                      `uid_based_id` does not exist.\" \
+                                      (ITS-REST \
+                                      `specifications/responses/404_unknown_uid_based_id.yaml`). \
+                                      All of these are that non-existence: an \
+                                      unknown `versioned_object_uid`; a \
+                                      version form whose version does not \
+                                      exist; and a well-formed uid whose \
+                                      stored container is NOT a PERSON — \
+                                      another PARTY kind, or a \
+                                      COMPOSITION/EHR_STATUS/FOLDER uid from \
+                                      the EHR space. The kind-checked reading \
+                                      is OURS (the released sentence does not \
+                                      spell it out) and follows from the route \
+                                      naming the target's class — a \
+                                      VERSIONED_OBJECT has one type (RM \
+                                      `common/master06` §Change Control); it \
+                                      is register-documented in the \
+                                      conformance catalogue. An EXISTING \
+                                      target with no tags is `200 []`, never \
+                                      `404`.",
+         body = serde_json::Value),
+        (status = 406, description = "The `Accept` header cannot be satisfied: \
+                                      an ITEM_TAG list is served as canonical \
+                                      `application/json` only. The canonical \
+                                      XML ITS defines no ITEM_TAG type, so an \
+                                      `application/xml` Accept — a member of \
+                                      the released `Accept_canonical` enum, \
+                                      stalled shape on this operation — is \
+                                      refused (`Resources.md` §\"XML Format\": \
+                                      \"If the service cannot fulfill this \
+                                      aspect of the request, it MUST respond \
+                                      with HTTP status code `406 Not \
+                                      Acceptable`\"). The released operation \
+                                      does not enumerate `406`; the MUST is \
+                                      cross-cutting.",
          body = serde_json::Value)
     )
 )]
@@ -6448,27 +8538,322 @@ pub(crate) async fn person_tags_get(
 
 /// Replace a `PERSON`'s `ITEM_TAG`s
 /// (`PUT /demographic/person/{uid_based_id}/tags`).
+///
+/// "Updates the list of all ITEM_TAG resources associated with a given target
+/// PERSON version or VERSIONED_PARTY identified by `uid_based_id`" (ITS-REST
+/// `specifications/operations/person_tags_update.yaml`). It is a FULL
+/// COLLECTION REPLACE of the ADDRESSED collection — the container's or one
+/// version's, never both.
+///
+/// Tags are not change-controlled, so this write commits no CONTRIBUTION, mints
+/// no version, takes no `If-Match` and no committal headers, and serves neither
+/// `ETag` nor `Last-Modified`.
 #[utoipa::path(
     put, path = "/demographic/person/{uid_based_id}/tags", tag = "ITEM_TAG",
     params(
         ("uid_based_id" = String, Path,
-         description = "The target PERSON VERSION (`version_uid`) or \
-                        VERSIONED_PARTY (`versioned_object_uid`)."),
+         description = "The released parameter, verbatim: \"The `uid_based_id` \
+                        can take a form of an OBJECT_VERSION_ID identifier \
+                        taken from VERSION.uid.value (i.e. a `version_uid`), \
+                        or a form of a HIER_OBJECT_ID identifier taken from \
+                        VERSIONED_OBJECT.uid.value (i.e. a \
+                        `versioned_object_uid`). The former is used to update \
+                        the tags of a particular PERSON version (e.g. one \
+                        identified by \
+                        `8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1`), \
+                        whereas the latter (e.g. an identifier like \
+                        `8849182c-82ad-4088-a07f-48ead4180515`) is be used to \
+                        update the tags of the target VERSIONED_PARTY \
+                        container.\" (ITS-REST \
+                        `specifications/operations/person_tags_update.yaml`). \
+                        The update sentence sources the HIER_OBJECT_ID from \
+                        VERSIONED_OBJECT while the get and delete of the same \
+                        family source it from VERSIONED_PARTY, and all three \
+                        end on \"the target VERSIONED_PARTY container\" — an \
+                        editorial split inside one operation family, \
+                        register-documented in the conformance catalogue; both \
+                        name the same container. The two forms address \
+                        DISJOINT collections: an ITEM_TAG carries exactly one \
+                        `target` (RM `item_tag.adoc`: `target: UID_BASED_ID`, \
+                        \"which may be a `VERSIONED_OBJECT<T>` or a \
+                        `VERSION<T>`\"), so a tag written against the \
+                        container is invisible to the version form and a tag \
+                        written against \
+                        `8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1` \
+                        is invisible both to the container form and to every \
+                        other version. The container form names the \
+                        VERSIONED_PARTY's OWN tag collection, not the latest \
+                        version's — there is no implicit-latest reading here. \
+                        So replacing the container's list never touches any \
+                        version's list, and replacing one version's list never \
+                        touches the container's or a sibling version's.",
+         example = "8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1"),
         ("Prefer" = Option<String>, Header,
-         description = "`return=minimal` (default; empty body) or \
-                        `return=representation` (the stored ITEM_TAG list).")
+         description = "`return=minimal` — the default when the header is \
+                        absent (`Requests_and_responses.md` §\"Representation \
+                        details negotiation\": \"If no `Prefer` header is \
+                        provided, the default behavior is assumed to be \
+                        `return=minimal`\") — answers `204 No Content`; \
+                        `return=representation` answers `200` with the full \
+                        RESULTING tag list of the addressed collection. \
+                        `return=identifier` cannot be honoured: its released \
+                        contract is a body carrying \"only the identifier \
+                        (e.g., the `uid`) of the affected resource\" and an \
+                        ITEM_TAG has no uid, so the server applies — and \
+                        declares — the default `return=minimal`; that \
+                        resolution is OURS, register-documented in the \
+                        conformance catalogue. Whichever branch runs, the \
+                        response states it in `Preference-Applied` (ITS-REST \
+                        `specifications/parameters/header/Prefer.yaml`).",
+         example = "return=representation"),
+        ("Content-Type" = Option<String>, Header,
+         description = "The canonical payload format (ITS-REST \
+                        `specifications/parameters/header/ContentType_canonical.yaml`, \
+                        enum `application/json` | `application/xml`). The tag \
+                        list has no XML and no Simplified-Format shape, so \
+                        only `application/json` is processable and any other \
+                        declared type is `415`; an ABSENT `Content-Type` \
+                        declares nothing and is read as canonical JSON.",
+         example = "application/json"),
+        ("Accept" = Option<String>, Header,
+         description = "The canonical response format (ITS-REST \
+                        `specifications/parameters/header/Accept_canonical.yaml`, \
+                        enum `application/json` | `application/xml`). An \
+                        ITEM_TAG list is served as `application/json` only — \
+                        the canonical XML ITS defines no ITEM_TAG type, so the \
+                        enum's `application/xml` member is stalled shape on \
+                        this operation and asking for it is `406`.",
+         example = "application/json")
     ),
     request_body(content = serde_json::Value,
-                 description = "The full ITEM_TAG list to store; an empty array \
-                                removes all tags on the target."),
+                 description = "A BARE JSON ARRAY of UPDATE_ITEM_TAG objects — \
+                                the complete tag list to associate with the \
+                                ADDRESSED collection (`required: true`; there \
+                                is no envelope object). Per the released \
+                                `schemas/common/UpdateItemTag.yaml`: `key` is \
+                                REQUIRED (\"Tag key (identifier)\"), `value` \
+                                (\"Tag value\") and `target_path` (\"An AQL \
+                                path withing the `target` used to tag a \
+                                fine-grained element\") are optional, and \
+                                `additionalProperties: false` defines no other \
+                                member. `target` and `owner_id` are NOT client \
+                                input — the server assigns them from the route \
+                                — which is why the write schema omits them; a \
+                                body that nonetheless carries them is accepted \
+                                and those members ignored, per our canonical \
+                                tolerant-read posture (no released sentence \
+                                governs the extra-member case — our own \
+                                design). This is a FULL COLLECTION REPLACE: \
+                                tags omitted from the body are removed, and \
+                                \"Providing an empty list will effectively \
+                                remove all ITEM_TAG associated with the given \
+                                target\" (`person_tags_update.yaml`), so `[]` \
+                                is the clear-all form and never an error. \
+                                Identity inside the list is the (`key`, \
+                                `target_path`) PAIR (\"More than one ITEM_TAG \
+                                may be associated with a single target, in \
+                                which case they are uniquely identified by \
+                                their `key` and `target_path` pair \
+                                attributes\"), so two entries may share a \
+                                `key` when their `target_path` differs; a \
+                                DUPLICATE pair inside one body is resolved \
+                                last-wins (no released rule and no \
+                                `uniqueItems` — ours, register-documented). A \
+                                `target_path` of `\"\"` normalizes to ABSENT, \
+                                the same identity as an entry with no \
+                                `target_path` at all: the RM models \
+                                `target_path` 0..1 with no non-empty invariant \
+                                while all five released `ItemTagOf*` examples \
+                                carry `target_path: \"\"` — reconciling the \
+                                two on one identity is ours, \
+                                register-documented. Canonical JSON only: an \
+                                XML (or Simplified-Format) `Content-Type` is \
+                                `415`.",
+                 example = json!([
+                     { "key": "flag", "value": "follow-up" },
+                     { "key": "reviewed", "value": "true", "target_path": "/details/items[at0001]/value" }
+                 ])),
     responses(
-        (status = 200, description = "Stored (`Prefer: return=representation`); \
-                                      body is the stored ITEM_TAG list.",
+        (
+            status = 200, description = "Applied, with `Prefer: \
+                                         return=representation`. The body is \
+                                         the full RESULTING ITEM_TAG list of \
+                                         the addressed collection — every tag \
+                                         now stored on it, server-assigned \
+                                         `target`/`owner_id` included — not \
+                                         merely the entries just sent. (The \
+                                         released \
+                                         `responses/200_PERSON_ItemTagList_updated.yaml` \
+                                         describes itself as \"returned when \
+                                         the requested ITEM_TAG list is \
+                                         successfully retrieved\", a \
+                                         copy-and-paste of its `_retrieved` \
+                                         sibling; the trigger is the update, \
+                                         as stated here. Items are typed \
+                                         `schemas/demographic/ItemTagOfPerson.yaml`.) \
+                                         Every row carries the SERVER-ASSIGNED \
+                                         `target` and `owner_id`; neither is \
+                                         client input. `target` names the \
+                                         ADDRESSED collection — `{namespace: \
+                                         \"demographic\", type: <PARTY kind>, \
+                                         id: <the addressed uid>}`, whose `id` \
+                                         is a `HIER_OBJECT_ID` for the \
+                                         container form and an \
+                                         `OBJECT_VERSION_ID` for the version \
+                                         form — and `owner_id` names the \
+                                         owning VERSIONED_PARTY. That \
+                                         `owner_id` is OUR OWN DESIGN: RM \
+                                         `item_tag.adoc` says only \
+                                         \"Identifier of owner object, such as \
+                                         EHR\" and a demographic party has no \
+                                         EHR, so no released sentence fixes \
+                                         it; the released `ItemTagOf*` \
+                                         examples show `{namespace: local, \
+                                         type: SYSTEM}` instead, which nothing \
+                                         requires. The position is \
+                                         register-documented in the \
+                                         conformance catalogue. `target_path` \
+                                         is present only on tags that carry \
+                                         one — it is 0..1 in the RM — and the \
+                                         empty string normalizes to ABSENT, so \
+                                         a stored tag never echoes the \
+                                         `target_path: \"\"` the released \
+                                         `ItemTagOf*` examples all show; that \
+                                         reconciliation is register-documented \
+                                         too. The only response header is \
+                                         `Preference-Applied`: a tag \
+                                         collection is not change-controlled, \
+                                         so there is no `ETag`, no \
+                                         `Last-Modified` and no `Location`.",
+            headers(
+                ("Preference-Applied" = String,
+                 description = "`return=representation` — the honoured \
+                                preference (`Requests_and_responses.md` \
+                                §\"Representation details negotiation\": the \
+                                service MAY include this header \"to indicate \
+                                that the client's preference has been \
+                                honored\").")
+            ),
+            content((serde_json::Value = "application/json", example =
+                json!([
+                    {
+                        "_type": "ITEM_TAG",
+                        "key": "flag",
+                        "value": "follow-up",
+                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "PERSON", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "PERSON", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                    },
+                    {
+                        "_type": "ITEM_TAG",
+                        "key": "reviewed",
+                        "value": "true",
+                        "target_path": "/details/items[at0001]/value",
+                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "PERSON", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "PERSON", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                    }
+                ])
+            ))
+        ),
+        (status = 204, description = "The released trigger, verbatim: `204 No \
+                                      Content` \"is returned when the update \
+                                      operation was successful and the \
+                                      `Prefer` header is missing or is set to \
+                                      `return=minimal`.\" (ITS-REST \
+                                      `specifications/responses/204_updated.yaml`) \
+                                      — the DEFAULT branch; a \
+                                      `return=identifier` request resolves \
+                                      here too. No body and no resource header \
+                                      of any kind — no `ETag`, no \
+                                      `Last-Modified`, no `Location` — only \
+                                      the `Preference-Applied` declaration.",
+         headers(
+             ("Preference-Applied" = String,
+              description = "`return=minimal` — the applied preference, \
+                             including when the request asked for \
+                             `return=identifier` (an ITEM_TAG has no uid to \
+                             return).")
+         )),
+        (status = 400, description = "The released trigger, verbatim: `400 Bad \
+                                      Request` \"is returned when the request \
+                                      could not be parsed or is invalid (e.g. \
+                                      malformed request URL syntax, missing \
+                                      required header or parameter, or \
+                                      syntactically invalid header, parameter \
+                                      or content)\" (ITS-REST \
+                                      `specifications/responses/400.yaml`). \
+                                      Here: a `uid_based_id` that is neither a \
+                                      UUID nor a well-formed three-part \
+                                      OBJECT_VERSION_ID, or a body that is not \
+                                      parseable JSON / not a JSON ARRAY. A \
+                                      well-formed array whose entries break an \
+                                      ITEM_TAG rule is `422`, not `400`.",
          body = serde_json::Value),
-        (status = 204, description = "Stored (`Prefer: return=minimal`)."),
-        (status = 400, description = "The ITEM_TAG list is invalid.",
+        (status = 404, description = "The released trigger, verbatim: `404 Not \
+                                      Found` \"is returned when the \
+                                      `uid_based_id` does not exist.\" \
+                                      (ITS-REST \
+                                      `specifications/responses/404_unknown_uid_based_id.yaml`). \
+                                      An unknown `versioned_object_uid`, a \
+                                      version form whose version does not \
+                                      exist, and a well-formed uid whose \
+                                      stored container is NOT a PERSON \
+                                      (another PARTY kind, or a uid from the \
+                                      EHR space) are all this `404` — the \
+                                      kind-checked reading being OURS, \
+                                      register-documented in the conformance \
+                                      catalogue.",
          body = serde_json::Value),
-        (status = 404, description = "The `uid_based_id` does not exist.",
+        (status = 406, description = "A `return=representation` request whose \
+                                      `Accept` cannot be satisfied: the \
+                                      ITEM_TAG list is served as canonical \
+                                      `application/json` only (the canonical \
+                                      XML ITS defines no ITEM_TAG type, so the \
+                                      released `Accept_canonical` enum's \
+                                      `application/xml` member is stalled \
+                                      shape here) — `Resources.md` §\"XML \
+                                      Format\": \"If the service cannot \
+                                      fulfill this aspect of the request, it \
+                                      MUST respond with HTTP status code `406 \
+                                      Not Acceptable`\". The default `204` \
+                                      branch returns no body and negotiates \
+                                      nothing. The released operation does not \
+                                      enumerate `406`; the MUST is \
+                                      cross-cutting.",
+         body = serde_json::Value),
+        (status = 415, description = "The request `Content-Type` is not \
+                                      canonical JSON. The tag list has no XML \
+                                      and no Simplified-Format shape, so any \
+                                      other declared media type is refused: \
+                                      \"If the service cannot process the \
+                                      request payload as JSON format, it MUST \
+                                      respond with HTTP status code `415 \
+                                      Unsupported Media Type`\" \
+                                      (`Resources.md` §\"JSON Format\"). An \
+                                      ABSENT `Content-Type` declares nothing \
+                                      and is accepted as JSON. The released \
+                                      operation does not enumerate `415`; the \
+                                      MUST is cross-cutting.",
+         body = serde_json::Value),
+        (status = 422, description = "The body is well-formed but an entry \
+                                      breaks an ITEM_TAG rule: a missing or \
+                                      empty `key`, a `key` with leading or \
+                                      trailing whitespace (RM `item_tag.adoc` \
+                                      __Inv_key_valid__: \"not key.is_empty \
+                                      and key.is_justified\"), or an EMPTY \
+                                      `value` (__Inv_value_valid__: \"value /= \
+                                      Void implies not value.is_empty\" — omit \
+                                      the member instead). The invariants are \
+                                      checked before any write, so a rejected \
+                                      list leaves the stored collection \
+                                      untouched. The released operation \
+                                      declares only `400`; answering `422` for \
+                                      these SEMANTIC failures follows \
+                                      `Requests_and_responses.md` §\"HTTP \
+                                      status codes\", the `422` row (\"The \
+                                      request was well-formed but was unable \
+                                      to be followed due to semantic errors\") \
+                                      and is OURS, register-documented in the \
+                                      conformance catalogue.",
          body = serde_json::Value)
     )
 )]
@@ -6486,20 +8871,132 @@ pub(crate) async fn person_tags_update(
     .await
 }
 
-/// Delete one `ITEM_TAG` from a `PERSON` by key
+/// Delete a `PERSON`'s `ITEM_TAG`s under one key
 /// (`DELETE /demographic/person/{uid_based_id}/tags/{key}`).
+///
+/// "Deletes the ITEM_TAG resource(s) identified by `tag_key`, associated with a
+/// given target PERSON version or VERSIONED_PARTY identified by `uid_based_id`"
+/// (ITS-REST `specifications/operations/person_tags_delete.yaml`).
+///
+/// A SET delete, not a single-resource delete: ITEM_TAG identity is the (`key`,
+/// `target_path`) pair, the route carries no `target_path` selector, and the
+/// released text says "resource(s)" — so every tag under `key` on the addressed
+/// collection goes, however many paths they carry.
 #[utoipa::path(
-    delete, path = "/demographic/person/{uid_based_id}/tags/{key}", tag = "ITEM_TAG",
+    delete, path = "/demographic/person/{uid_based_id}/tags/{key}",
+    tag = "ITEM_TAG",
     params(
         ("uid_based_id" = String, Path,
-         description = "The target PERSON VERSION (`version_uid`) or \
-                        VERSIONED_PARTY (`versioned_object_uid`)."),
-        ("key" = String, Path, description = "The ITEM_TAG key to delete.")
+         description = "The released parameter, verbatim: \"The `uid_based_id` \
+                        can take a form of an OBJECT_VERSION_ID identifier \
+                        taken from VERSION.uid.value (i.e. a `version_uid`), \
+                        or a form of a HIER_OBJECT_ID identifier taken from \
+                        VERSIONED_PARTY.uid.value (i.e. a \
+                        `versioned_object_uid`). The former is used to delete \
+                        the tags a particular (target) version of the PERSON \
+                        version (e.g. one identified by \
+                        `8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1`), \
+                        whereas the latter (e.g. an identifier like \
+                        `8849182c-82ad-4088-a07f-48ead4180515`) is be used to \
+                        delete the tags of the target VERSIONED_PARTY \
+                        container.\" (ITS-REST \
+                        `specifications/operations/person_tags_delete.yaml`). \
+                        The two forms address DISJOINT collections: an \
+                        ITEM_TAG carries exactly one `target` (RM \
+                        `item_tag.adoc`: `target: UID_BASED_ID`, \"which may \
+                        be a `VERSIONED_OBJECT<T>` or a `VERSION<T>`\"), so a \
+                        tag written against the container is invisible to the \
+                        version form and a tag written against \
+                        `8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1` \
+                        is invisible both to the container form and to every \
+                        other version. The container form names the \
+                        VERSIONED_PARTY's OWN tag collection, not the latest \
+                        version's — there is no implicit-latest reading here. \
+                        So deleting a key from the container leaves the same \
+                        key on every version untouched, and vice versa.",
+         example = "8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1"),
+        ("key" = String, Path,
+         description = "The ITEM_TAG `key` whose tags are deleted from the \
+                        addressed collection — \"The ITEM_TAG key\" (ITS-REST \
+                        `specifications/parameters/path/key.yaml`, `type: \
+                        string`), an UNCONSTRAINED string with no format, \
+                        pattern or length bound, taken percent-decoded from \
+                        the path segment (a key containing `/`, `?` or `#` \
+                        must be percent-encoded by the client). It selects a \
+                        SET, not one resource: identity is the (`key`, \
+                        `target_path`) pair and this route has no \
+                        `target_path` selector, so EVERY tag under the key \
+                        goes — which is why the released description says \
+                        \"Deletes the ITEM_TAG resource(s) identified by \
+                        `tag_key`\" (`person_tags_delete.yaml`). (That \
+                        description calls the parameter `tag_key` in prose \
+                        while the path parameter is `key` — a released-text \
+                        inconsistency, register-documented in the conformance \
+                        catalogue; the wire name is `key`.)",
+         example = "flag")
     ),
     responses(
-        (status = 204, description = "The ITEM_TAG was deleted."),
-        (status = 404, description = "The `uid_based_id` does not exist, or no \
-                                      ITEM_TAG has that `key`.",
+        (status = 204, description = "The released trigger, verbatim: `204 No \
+                                      Content` \"is returned when the resource \
+                                      identified by the request parameters has \
+                                      been (logically) deleted.\" (ITS-REST \
+                                      `specifications/responses/204_deleted.yaml`). \
+                                      \"(logically) deleted\" is \
+                                      change-control vocabulary that cannot \
+                                      apply here — a tag is not \
+                                      change-controlled, so removal is plain: \
+                                      no deleted version is committed and the \
+                                      tags simply cease to exist. No body and \
+                                      no headers: an ITEM_TAG has no version \
+                                      and no uid, so there is nothing for an \
+                                      `ETag`/`Last-Modified` to carry, and \
+                                      \"the `Location` response header was \
+                                      deprecated from responses of `DELETE` \
+                                      methods\" (`Requests_and_responses.md` \
+                                      §\"Deprecated headers\"). The released \
+                                      operation declares no `Accept` either, \
+                                      and the empty body negotiates nothing — \
+                                      so this route has no `406`."),
+        (status = 400, description = "The released cross-cutting trigger, \
+                                      verbatim: `400 Bad Request` \"is \
+                                      returned when the request could not be \
+                                      parsed or is invalid (e.g. malformed \
+                                      request URL syntax, missing required \
+                                      header or parameter, or syntactically \
+                                      invalid header, parameter or content)\" \
+                                      (ITS-REST \
+                                      `specifications/responses/400.yaml`). \
+                                      Here: a `uid_based_id` that is neither a \
+                                      HIER_OBJECT_ID (a UUID) nor a \
+                                      well-formed three-part \
+                                      OBJECT_VERSION_ID. A well-formed \
+                                      identifier that names nothing is `404`, \
+                                      not `400`.",
+         body = serde_json::Value),
+        (status = 404, description = "The released trigger, verbatim: `404 Not \
+                                      Found` \"is returned when the \
+                                      `uid_based_id` does not exist, or when \
+                                      the ITEM_TAG identified by the `key` \
+                                      does not exist.\" (ITS-REST \
+                                      `specifications/responses/404_unknown_uid_based_id_or_key.yaml`). \
+                                      The SECOND trigger makes this operation \
+                                      deliberately NON-IDEMPOTENT on the wire: \
+                                      the second identical `DELETE` answers \
+                                      `404`, because after the first one no \
+                                      ITEM_TAG under that key exists on the \
+                                      addressed collection. A key that exists \
+                                      only on the OTHER collection of the same \
+                                      versioned object (container vs version) \
+                                      does not exist here either. Target \
+                                      non-existence covers an unknown \
+                                      `versioned_object_uid`, a version form \
+                                      whose version does not exist, and a \
+                                      well-formed uid whose stored container \
+                                      is NOT a PERSON (another PARTY kind, or \
+                                      a uid from the EHR space) — the \
+                                      kind-checked reading being OURS, \
+                                      register-documented in the conformance \
+                                      catalogue.",
          body = serde_json::Value)
     )
 )]
@@ -6519,18 +9016,184 @@ pub(crate) async fn person_tags_delete(
 
 /// Retrieve a `ROLE`'s `ITEM_TAG`s
 /// (`GET /demographic/role/{uid_based_id}/tags`).
+///
+/// "Retrieves the list of all ITEM_TAG resources associated with a given target
+/// ROLE version or VERSIONED_PARTY identified by `uid_based_id`" (ITS-REST
+/// `specifications/operations/role_tags_get.yaml`).
+///
+/// The two `uid_based_id` forms address DISJOINT tag collections — see the
+/// parameter.
 #[utoipa::path(
     get, path = "/demographic/role/{uid_based_id}/tags", tag = "ITEM_TAG",
     params(
         ("uid_based_id" = String, Path,
-         description = "The target ROLE VERSION (`version_uid`) or \
-                        VERSIONED_PARTY (`versioned_object_uid`).")
+         description = "The released parameter, verbatim: \"The `uid_based_id` \
+                        can take a form of an OBJECT_VERSION_ID identifier \
+                        taken from VERSION.uid.value (i.e. a `version_uid`), \
+                        or a form of a HIER_OBJECT_ID identifier taken from \
+                        VERSIONED_PARTY.uid.value (i.e. a \
+                        `versioned_object_uid`). The former is used to get the \
+                        tags of a particular (target) version of the ROLE \
+                        version (e.g. one identified by \
+                        `8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1`), \
+                        whereas the latter (e.g. an identifier like \
+                        `8849182c-82ad-4088-a07f-48ead4180515`) is be used to \
+                        get the tags of the target VERSIONED_PARTY \
+                        container.\" (ITS-REST \
+                        `specifications/operations/role_tags_get.yaml`; the \
+                        released path parameter file \
+                        `parameters/path/uid_based_id.yaml` carries the same \
+                        dual-form sentence with VERSIONED_OBJECT in place of \
+                        VERSIONED_PARTY). The two forms address DISJOINT \
+                        collections: an ITEM_TAG carries exactly one `target` \
+                        (RM `item_tag.adoc`: `target: UID_BASED_ID`, \"which \
+                        may be a `VERSIONED_OBJECT<T>` or a `VERSION<T>`\"), \
+                        so a tag written against the container is invisible to \
+                        the version form and a tag written against \
+                        `8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1` \
+                        is invisible both to the container form and to every \
+                        other version. The container form names the \
+                        VERSIONED_PARTY's OWN tag collection, not the latest \
+                        version's — there is no implicit-latest reading here.",
+         example = "8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1"),
+        ("Accept" = Option<String>, Header,
+         description = "The canonical response format (ITS-REST \
+                        `specifications/parameters/header/Accept_canonical.yaml`, \
+                        enum `application/json` | `application/xml`). An \
+                        ITEM_TAG list is served as `application/json` only — \
+                        the canonical XML ITS defines no ITEM_TAG type, so the \
+                        enum's `application/xml` member is stalled shape on \
+                        this operation and asking for it is `406`.",
+         example = "application/json")
     ),
     responses(
-        (status = 200, description = "The ITEM_TAGs on the target (an empty \
-                                      array when none exist).",
+        (
+            status = 200, description = "The released trigger, verbatim: `200 \
+                                         OK` \"is returned when the requested \
+                                         ITEM_TAG list is successfully \
+                                         retrieved.\" (ITS-REST \
+                                         `specifications/responses/200_ROLE_ItemTagList_retrieved.yaml`; \
+                                         items typed \
+                                         `schemas/demographic/ItemTagOfRole.yaml`). \
+                                         \"This will return an empty list when \
+                                         there is no ITEM_TAG associated with \
+                                         the given target\" \
+                                         (`role_tags_get.yaml`) — an EXISTING, \
+                                         untagged target is `200 []`; a target \
+                                         that does not exist is `404`. \"More \
+                                         than one ITEM_TAG may be associated \
+                                         with a single target ROLE or \
+                                         VERSIONED_PARTY, in which case they \
+                                         are uniquely identified by their \
+                                         `key` and `target_path` pair \
+                                         attributes\". Every row carries the \
+                                         SERVER-ASSIGNED `target` and \
+                                         `owner_id`; neither is client input. \
+                                         `target` names the ADDRESSED \
+                                         collection — `{namespace: \
+                                         \"demographic\", type: <PARTY kind>, \
+                                         id: <the addressed uid>}`, whose `id` \
+                                         is a `HIER_OBJECT_ID` for the \
+                                         container form and an \
+                                         `OBJECT_VERSION_ID` for the version \
+                                         form — and `owner_id` names the \
+                                         owning VERSIONED_PARTY. That \
+                                         `owner_id` is OUR OWN DESIGN: RM \
+                                         `item_tag.adoc` says only \
+                                         \"Identifier of owner object, such as \
+                                         EHR\" and a demographic party has no \
+                                         EHR, so no released sentence fixes \
+                                         it; the released `ItemTagOf*` \
+                                         examples show `{namespace: local, \
+                                         type: SYSTEM}` instead, which nothing \
+                                         requires. The position is \
+                                         register-documented in the \
+                                         conformance catalogue. `target_path` \
+                                         is present only on tags that carry \
+                                         one — it is 0..1 in the RM — and the \
+                                         empty string normalizes to ABSENT, so \
+                                         a stored tag never echoes the \
+                                         `target_path: \"\"` the released \
+                                         `ItemTagOf*` examples all show; that \
+                                         reconciliation is register-documented \
+                                         too. No `ETag`, `Last-Modified` or \
+                                         `Location` accompanies the list: a \
+                                         tag collection is not \
+                                         change-controlled and has no version \
+                                         and no uid.",
+            content((serde_json::Value = "application/json", example =
+                json!([
+                    {
+                        "_type": "ITEM_TAG",
+                        "key": "flag",
+                        "value": "follow-up",
+                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ROLE", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ROLE", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                    },
+                    {
+                        "_type": "ITEM_TAG",
+                        "key": "reviewed",
+                        "value": "true",
+                        "target_path": "/details/items[at0001]/value",
+                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ROLE", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ROLE", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                    }
+                ])
+            ))
+        ),
+        (status = 400, description = "The released cross-cutting trigger, \
+                                      verbatim: `400 Bad Request` \"is \
+                                      returned when the request could not be \
+                                      parsed or is invalid (e.g. malformed \
+                                      request URL syntax, missing required \
+                                      header or parameter, or syntactically \
+                                      invalid header, parameter or content)\" \
+                                      (ITS-REST \
+                                      `specifications/responses/400.yaml`). \
+                                      Here: a `uid_based_id` that is neither a \
+                                      HIER_OBJECT_ID (a UUID) nor a \
+                                      well-formed three-part \
+                                      OBJECT_VERSION_ID. A well-formed \
+                                      identifier that names nothing is `404`, \
+                                      not `400`.",
          body = serde_json::Value),
-        (status = 404, description = "The `uid_based_id` does not exist.",
+        (status = 404, description = "The released trigger, verbatim: `404 Not \
+                                      Found` \"is returned when the \
+                                      `uid_based_id` does not exist.\" \
+                                      (ITS-REST \
+                                      `specifications/responses/404_unknown_uid_based_id.yaml`). \
+                                      All of these are that non-existence: an \
+                                      unknown `versioned_object_uid`; a \
+                                      version form whose version does not \
+                                      exist; and a well-formed uid whose \
+                                      stored container is NOT a ROLE — another \
+                                      PARTY kind, or a \
+                                      COMPOSITION/EHR_STATUS/FOLDER uid from \
+                                      the EHR space. The kind-checked reading \
+                                      is OURS (the released sentence does not \
+                                      spell it out) and follows from the route \
+                                      naming the target's class — a \
+                                      VERSIONED_OBJECT has one type (RM \
+                                      `common/master06` §Change Control); it \
+                                      is register-documented in the \
+                                      conformance catalogue. An EXISTING \
+                                      target with no tags is `200 []`, never \
+                                      `404`.",
+         body = serde_json::Value),
+        (status = 406, description = "The `Accept` header cannot be satisfied: \
+                                      an ITEM_TAG list is served as canonical \
+                                      `application/json` only. The canonical \
+                                      XML ITS defines no ITEM_TAG type, so an \
+                                      `application/xml` Accept — a member of \
+                                      the released `Accept_canonical` enum, \
+                                      stalled shape on this operation — is \
+                                      refused (`Resources.md` §\"XML Format\": \
+                                      \"If the service cannot fulfill this \
+                                      aspect of the request, it MUST respond \
+                                      with HTTP status code `406 Not \
+                                      Acceptable`\"). The released operation \
+                                      does not enumerate `406`; the MUST is \
+                                      cross-cutting.",
          body = serde_json::Value)
     )
 )]
@@ -6544,27 +9207,321 @@ pub(crate) async fn role_tags_get(
 
 /// Replace a `ROLE`'s `ITEM_TAG`s
 /// (`PUT /demographic/role/{uid_based_id}/tags`).
+///
+/// "Updates the list of all ITEM_TAG resources associated with a given target
+/// ROLE version or VERSIONED_PARTY identified by `uid_based_id`" (ITS-REST
+/// `specifications/operations/role_tags_update.yaml`). It is a FULL COLLECTION
+/// REPLACE of the ADDRESSED collection — the container's or one version's,
+/// never both.
+///
+/// Tags are not change-controlled, so this write commits no CONTRIBUTION, mints
+/// no version, takes no `If-Match` and no committal headers, and serves neither
+/// `ETag` nor `Last-Modified`.
 #[utoipa::path(
     put, path = "/demographic/role/{uid_based_id}/tags", tag = "ITEM_TAG",
     params(
         ("uid_based_id" = String, Path,
-         description = "The target ROLE VERSION (`version_uid`) or \
-                        VERSIONED_PARTY (`versioned_object_uid`)."),
+         description = "The released parameter, verbatim: \"The `uid_based_id` \
+                        can take a form of an OBJECT_VERSION_ID identifier \
+                        taken from VERSION.uid.value (i.e. a `version_uid`), \
+                        or a form of a HIER_OBJECT_ID identifier taken from \
+                        VERSIONED_OBJECT.uid.value (i.e. a \
+                        `versioned_object_uid`). The former is used to update \
+                        the tags of a particular ROLE version (e.g. one \
+                        identified by \
+                        `8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1`), \
+                        whereas the latter (e.g. an identifier like \
+                        `8849182c-82ad-4088-a07f-48ead4180515`) is be used to \
+                        update the tags of the target VERSIONED_PARTY \
+                        container.\" (ITS-REST \
+                        `specifications/operations/role_tags_update.yaml`). \
+                        The update sentence sources the HIER_OBJECT_ID from \
+                        VERSIONED_OBJECT while the get and delete of the same \
+                        family source it from VERSIONED_PARTY, and all three \
+                        end on \"the target VERSIONED_PARTY container\" — an \
+                        editorial split inside one operation family, \
+                        register-documented in the conformance catalogue; both \
+                        name the same container. The two forms address \
+                        DISJOINT collections: an ITEM_TAG carries exactly one \
+                        `target` (RM `item_tag.adoc`: `target: UID_BASED_ID`, \
+                        \"which may be a `VERSIONED_OBJECT<T>` or a \
+                        `VERSION<T>`\"), so a tag written against the \
+                        container is invisible to the version form and a tag \
+                        written against \
+                        `8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1` \
+                        is invisible both to the container form and to every \
+                        other version. The container form names the \
+                        VERSIONED_PARTY's OWN tag collection, not the latest \
+                        version's — there is no implicit-latest reading here. \
+                        So replacing the container's list never touches any \
+                        version's list, and replacing one version's list never \
+                        touches the container's or a sibling version's.",
+         example = "8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1"),
         ("Prefer" = Option<String>, Header,
-         description = "`return=minimal` (default; empty body) or \
-                        `return=representation` (the stored ITEM_TAG list).")
+         description = "`return=minimal` — the default when the header is \
+                        absent (`Requests_and_responses.md` §\"Representation \
+                        details negotiation\": \"If no `Prefer` header is \
+                        provided, the default behavior is assumed to be \
+                        `return=minimal`\") — answers `204 No Content`; \
+                        `return=representation` answers `200` with the full \
+                        RESULTING tag list of the addressed collection. \
+                        `return=identifier` cannot be honoured: its released \
+                        contract is a body carrying \"only the identifier \
+                        (e.g., the `uid`) of the affected resource\" and an \
+                        ITEM_TAG has no uid, so the server applies — and \
+                        declares — the default `return=minimal`; that \
+                        resolution is OURS, register-documented in the \
+                        conformance catalogue. Whichever branch runs, the \
+                        response states it in `Preference-Applied` (ITS-REST \
+                        `specifications/parameters/header/Prefer.yaml`).",
+         example = "return=representation"),
+        ("Content-Type" = Option<String>, Header,
+         description = "The canonical payload format (ITS-REST \
+                        `specifications/parameters/header/ContentType_canonical.yaml`, \
+                        enum `application/json` | `application/xml`). The tag \
+                        list has no XML and no Simplified-Format shape, so \
+                        only `application/json` is processable and any other \
+                        declared type is `415`; an ABSENT `Content-Type` \
+                        declares nothing and is read as canonical JSON.",
+         example = "application/json"),
+        ("Accept" = Option<String>, Header,
+         description = "The canonical response format (ITS-REST \
+                        `specifications/parameters/header/Accept_canonical.yaml`, \
+                        enum `application/json` | `application/xml`). An \
+                        ITEM_TAG list is served as `application/json` only — \
+                        the canonical XML ITS defines no ITEM_TAG type, so the \
+                        enum's `application/xml` member is stalled shape on \
+                        this operation and asking for it is `406`.",
+         example = "application/json")
     ),
     request_body(content = serde_json::Value,
-                 description = "The full ITEM_TAG list to store; an empty array \
-                                removes all tags on the target."),
+                 description = "A BARE JSON ARRAY of UPDATE_ITEM_TAG objects — \
+                                the complete tag list to associate with the \
+                                ADDRESSED collection (`required: true`; there \
+                                is no envelope object). Per the released \
+                                `schemas/common/UpdateItemTag.yaml`: `key` is \
+                                REQUIRED (\"Tag key (identifier)\"), `value` \
+                                (\"Tag value\") and `target_path` (\"An AQL \
+                                path withing the `target` used to tag a \
+                                fine-grained element\") are optional, and \
+                                `additionalProperties: false` defines no other \
+                                member. `target` and `owner_id` are NOT client \
+                                input — the server assigns them from the route \
+                                — which is why the write schema omits them; a \
+                                body that nonetheless carries them is accepted \
+                                and those members ignored, per our canonical \
+                                tolerant-read posture (no released sentence \
+                                governs the extra-member case — our own \
+                                design). This is a FULL COLLECTION REPLACE: \
+                                tags omitted from the body are removed, and \
+                                \"Providing an empty list will effectively \
+                                remove all ITEM_TAG associated with the given \
+                                target\" (`role_tags_update.yaml`), so `[]` is \
+                                the clear-all form and never an error. \
+                                Identity inside the list is the (`key`, \
+                                `target_path`) PAIR (\"More than one ITEM_TAG \
+                                may be associated with a single target, in \
+                                which case they are uniquely identified by \
+                                their `key` and `target_path` pair \
+                                attributes\"), so two entries may share a \
+                                `key` when their `target_path` differs; a \
+                                DUPLICATE pair inside one body is resolved \
+                                last-wins (no released rule and no \
+                                `uniqueItems` — ours, register-documented). A \
+                                `target_path` of `\"\"` normalizes to ABSENT, \
+                                the same identity as an entry with no \
+                                `target_path` at all: the RM models \
+                                `target_path` 0..1 with no non-empty invariant \
+                                while all five released `ItemTagOf*` examples \
+                                carry `target_path: \"\"` — reconciling the \
+                                two on one identity is ours, \
+                                register-documented. Canonical JSON only: an \
+                                XML (or Simplified-Format) `Content-Type` is \
+                                `415`.",
+                 example = json!([
+                     { "key": "flag", "value": "follow-up" },
+                     { "key": "reviewed", "value": "true", "target_path": "/details/items[at0001]/value" }
+                 ])),
     responses(
-        (status = 200, description = "Stored (`Prefer: return=representation`); \
-                                      body is the stored ITEM_TAG list.",
+        (
+            status = 200, description = "Applied, with `Prefer: \
+                                         return=representation`. The body is \
+                                         the full RESULTING ITEM_TAG list of \
+                                         the addressed collection — every tag \
+                                         now stored on it, server-assigned \
+                                         `target`/`owner_id` included — not \
+                                         merely the entries just sent. (The \
+                                         released \
+                                         `responses/200_ROLE_ItemTagList_updated.yaml` \
+                                         describes itself as \"returned when \
+                                         the requested ITEM_TAG list is \
+                                         successfully retrieved\", a \
+                                         copy-and-paste of its `_retrieved` \
+                                         sibling; the trigger is the update, \
+                                         as stated here. Items are typed \
+                                         `schemas/demographic/ItemTagOfRole.yaml`.) \
+                                         Every row carries the SERVER-ASSIGNED \
+                                         `target` and `owner_id`; neither is \
+                                         client input. `target` names the \
+                                         ADDRESSED collection — `{namespace: \
+                                         \"demographic\", type: <PARTY kind>, \
+                                         id: <the addressed uid>}`, whose `id` \
+                                         is a `HIER_OBJECT_ID` for the \
+                                         container form and an \
+                                         `OBJECT_VERSION_ID` for the version \
+                                         form — and `owner_id` names the \
+                                         owning VERSIONED_PARTY. That \
+                                         `owner_id` is OUR OWN DESIGN: RM \
+                                         `item_tag.adoc` says only \
+                                         \"Identifier of owner object, such as \
+                                         EHR\" and a demographic party has no \
+                                         EHR, so no released sentence fixes \
+                                         it; the released `ItemTagOf*` \
+                                         examples show `{namespace: local, \
+                                         type: SYSTEM}` instead, which nothing \
+                                         requires. The position is \
+                                         register-documented in the \
+                                         conformance catalogue. `target_path` \
+                                         is present only on tags that carry \
+                                         one — it is 0..1 in the RM — and the \
+                                         empty string normalizes to ABSENT, so \
+                                         a stored tag never echoes the \
+                                         `target_path: \"\"` the released \
+                                         `ItemTagOf*` examples all show; that \
+                                         reconciliation is register-documented \
+                                         too. The only response header is \
+                                         `Preference-Applied`: a tag \
+                                         collection is not change-controlled, \
+                                         so there is no `ETag`, no \
+                                         `Last-Modified` and no `Location`.",
+            headers(
+                ("Preference-Applied" = String,
+                 description = "`return=representation` — the honoured \
+                                preference (`Requests_and_responses.md` \
+                                §\"Representation details negotiation\": the \
+                                service MAY include this header \"to indicate \
+                                that the client's preference has been \
+                                honored\").")
+            ),
+            content((serde_json::Value = "application/json", example =
+                json!([
+                    {
+                        "_type": "ITEM_TAG",
+                        "key": "flag",
+                        "value": "follow-up",
+                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ROLE", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ROLE", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                    },
+                    {
+                        "_type": "ITEM_TAG",
+                        "key": "reviewed",
+                        "value": "true",
+                        "target_path": "/details/items[at0001]/value",
+                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ROLE", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ROLE", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                    }
+                ])
+            ))
+        ),
+        (status = 204, description = "The released trigger, verbatim: `204 No \
+                                      Content` \"is returned when the update \
+                                      operation was successful and the \
+                                      `Prefer` header is missing or is set to \
+                                      `return=minimal`.\" (ITS-REST \
+                                      `specifications/responses/204_updated.yaml`) \
+                                      — the DEFAULT branch; a \
+                                      `return=identifier` request resolves \
+                                      here too. No body and no resource header \
+                                      of any kind — no `ETag`, no \
+                                      `Last-Modified`, no `Location` — only \
+                                      the `Preference-Applied` declaration.",
+         headers(
+             ("Preference-Applied" = String,
+              description = "`return=minimal` — the applied preference, \
+                             including when the request asked for \
+                             `return=identifier` (an ITEM_TAG has no uid to \
+                             return).")
+         )),
+        (status = 400, description = "The released trigger, verbatim: `400 Bad \
+                                      Request` \"is returned when the request \
+                                      could not be parsed or is invalid (e.g. \
+                                      malformed request URL syntax, missing \
+                                      required header or parameter, or \
+                                      syntactically invalid header, parameter \
+                                      or content)\" (ITS-REST \
+                                      `specifications/responses/400.yaml`). \
+                                      Here: a `uid_based_id` that is neither a \
+                                      UUID nor a well-formed three-part \
+                                      OBJECT_VERSION_ID, or a body that is not \
+                                      parseable JSON / not a JSON ARRAY. A \
+                                      well-formed array whose entries break an \
+                                      ITEM_TAG rule is `422`, not `400`.",
          body = serde_json::Value),
-        (status = 204, description = "Stored (`Prefer: return=minimal`)."),
-        (status = 400, description = "The ITEM_TAG list is invalid.",
+        (status = 404, description = "The released trigger, verbatim: `404 Not \
+                                      Found` \"is returned when the \
+                                      `uid_based_id` does not exist.\" \
+                                      (ITS-REST \
+                                      `specifications/responses/404_unknown_uid_based_id.yaml`). \
+                                      An unknown `versioned_object_uid`, a \
+                                      version form whose version does not \
+                                      exist, and a well-formed uid whose \
+                                      stored container is NOT a ROLE (another \
+                                      PARTY kind, or a uid from the EHR space) \
+                                      are all this `404` — the kind-checked \
+                                      reading being OURS, register-documented \
+                                      in the conformance catalogue.",
          body = serde_json::Value),
-        (status = 404, description = "The `uid_based_id` does not exist.",
+        (status = 406, description = "A `return=representation` request whose \
+                                      `Accept` cannot be satisfied: the \
+                                      ITEM_TAG list is served as canonical \
+                                      `application/json` only (the canonical \
+                                      XML ITS defines no ITEM_TAG type, so the \
+                                      released `Accept_canonical` enum's \
+                                      `application/xml` member is stalled \
+                                      shape here) — `Resources.md` §\"XML \
+                                      Format\": \"If the service cannot \
+                                      fulfill this aspect of the request, it \
+                                      MUST respond with HTTP status code `406 \
+                                      Not Acceptable`\". The default `204` \
+                                      branch returns no body and negotiates \
+                                      nothing. The released operation does not \
+                                      enumerate `406`; the MUST is \
+                                      cross-cutting.",
+         body = serde_json::Value),
+        (status = 415, description = "The request `Content-Type` is not \
+                                      canonical JSON. The tag list has no XML \
+                                      and no Simplified-Format shape, so any \
+                                      other declared media type is refused: \
+                                      \"If the service cannot process the \
+                                      request payload as JSON format, it MUST \
+                                      respond with HTTP status code `415 \
+                                      Unsupported Media Type`\" \
+                                      (`Resources.md` §\"JSON Format\"). An \
+                                      ABSENT `Content-Type` declares nothing \
+                                      and is accepted as JSON. The released \
+                                      operation does not enumerate `415`; the \
+                                      MUST is cross-cutting.",
+         body = serde_json::Value),
+        (status = 422, description = "The body is well-formed but an entry \
+                                      breaks an ITEM_TAG rule: a missing or \
+                                      empty `key`, a `key` with leading or \
+                                      trailing whitespace (RM `item_tag.adoc` \
+                                      __Inv_key_valid__: \"not key.is_empty \
+                                      and key.is_justified\"), or an EMPTY \
+                                      `value` (__Inv_value_valid__: \"value /= \
+                                      Void implies not value.is_empty\" — omit \
+                                      the member instead). The invariants are \
+                                      checked before any write, so a rejected \
+                                      list leaves the stored collection \
+                                      untouched. The released operation \
+                                      declares only `400`; answering `422` for \
+                                      these SEMANTIC failures follows \
+                                      `Requests_and_responses.md` §\"HTTP \
+                                      status codes\", the `422` row (\"The \
+                                      request was well-formed but was unable \
+                                      to be followed due to semantic errors\") \
+                                      and is OURS, register-documented in the \
+                                      conformance catalogue.",
          body = serde_json::Value)
     )
 )]
@@ -6576,20 +9533,132 @@ pub(crate) async fn role_tags_update(
     guarded_dispatch(state, "role_tags_update", parts, super::dispatch::dispatch).await
 }
 
-/// Delete one `ITEM_TAG` from a `ROLE` by key
+/// Delete a `ROLE`'s `ITEM_TAG`s under one key
 /// (`DELETE /demographic/role/{uid_based_id}/tags/{key}`).
+///
+/// "Deletes the ITEM_TAG resource(s) identified by `tag_key`, associated with a
+/// given target ROLE version or VERSIONED_PARTY identified by `uid_based_id`"
+/// (ITS-REST `specifications/operations/role_tags_delete.yaml`).
+///
+/// A SET delete, not a single-resource delete: ITEM_TAG identity is the (`key`,
+/// `target_path`) pair, the route carries no `target_path` selector, and the
+/// released text says "resource(s)" — so every tag under `key` on the addressed
+/// collection goes, however many paths they carry.
 #[utoipa::path(
-    delete, path = "/demographic/role/{uid_based_id}/tags/{key}", tag = "ITEM_TAG",
+    delete, path = "/demographic/role/{uid_based_id}/tags/{key}",
+    tag = "ITEM_TAG",
     params(
         ("uid_based_id" = String, Path,
-         description = "The target ROLE VERSION (`version_uid`) or \
-                        VERSIONED_PARTY (`versioned_object_uid`)."),
-        ("key" = String, Path, description = "The ITEM_TAG key to delete.")
+         description = "The released parameter, verbatim: \"The `uid_based_id` \
+                        can take a form of an OBJECT_VERSION_ID identifier \
+                        taken from VERSION.uid.value (i.e. a `version_uid`), \
+                        or a form of a HIER_OBJECT_ID identifier taken from \
+                        VERSIONED_PARTY.uid.value (i.e. a \
+                        `versioned_object_uid`). The former is used to delete \
+                        the tags a particular (target) version of the ROLE \
+                        version (e.g. one identified by \
+                        `8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1`), \
+                        whereas the latter (e.g. an identifier like \
+                        `8849182c-82ad-4088-a07f-48ead4180515`) is be used to \
+                        delete the tags of the target VERSIONED_PARTY \
+                        container.\" (ITS-REST \
+                        `specifications/operations/role_tags_delete.yaml`). \
+                        The two forms address DISJOINT collections: an \
+                        ITEM_TAG carries exactly one `target` (RM \
+                        `item_tag.adoc`: `target: UID_BASED_ID`, \"which may \
+                        be a `VERSIONED_OBJECT<T>` or a `VERSION<T>`\"), so a \
+                        tag written against the container is invisible to the \
+                        version form and a tag written against \
+                        `8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1` \
+                        is invisible both to the container form and to every \
+                        other version. The container form names the \
+                        VERSIONED_PARTY's OWN tag collection, not the latest \
+                        version's — there is no implicit-latest reading here. \
+                        So deleting a key from the container leaves the same \
+                        key on every version untouched, and vice versa.",
+         example = "8849182c-82ad-4088-a07f-48ead4180515::openEHRSys.example.com::1"),
+        ("key" = String, Path,
+         description = "The ITEM_TAG `key` whose tags are deleted from the \
+                        addressed collection — \"The ITEM_TAG key\" (ITS-REST \
+                        `specifications/parameters/path/key.yaml`, `type: \
+                        string`), an UNCONSTRAINED string with no format, \
+                        pattern or length bound, taken percent-decoded from \
+                        the path segment (a key containing `/`, `?` or `#` \
+                        must be percent-encoded by the client). It selects a \
+                        SET, not one resource: identity is the (`key`, \
+                        `target_path`) pair and this route has no \
+                        `target_path` selector, so EVERY tag under the key \
+                        goes — which is why the released description says \
+                        \"Deletes the ITEM_TAG resource(s) identified by \
+                        `tag_key`\" (`role_tags_delete.yaml`). (That \
+                        description calls the parameter `tag_key` in prose \
+                        while the path parameter is `key` — a released-text \
+                        inconsistency, register-documented in the conformance \
+                        catalogue; the wire name is `key`.)",
+         example = "flag")
     ),
     responses(
-        (status = 204, description = "The ITEM_TAG was deleted."),
-        (status = 404, description = "The `uid_based_id` does not exist, or no \
-                                      ITEM_TAG has that `key`.",
+        (status = 204, description = "The released trigger, verbatim: `204 No \
+                                      Content` \"is returned when the resource \
+                                      identified by the request parameters has \
+                                      been (logically) deleted.\" (ITS-REST \
+                                      `specifications/responses/204_deleted.yaml`). \
+                                      \"(logically) deleted\" is \
+                                      change-control vocabulary that cannot \
+                                      apply here — a tag is not \
+                                      change-controlled, so removal is plain: \
+                                      no deleted version is committed and the \
+                                      tags simply cease to exist. No body and \
+                                      no headers: an ITEM_TAG has no version \
+                                      and no uid, so there is nothing for an \
+                                      `ETag`/`Last-Modified` to carry, and \
+                                      \"the `Location` response header was \
+                                      deprecated from responses of `DELETE` \
+                                      methods\" (`Requests_and_responses.md` \
+                                      §\"Deprecated headers\"). The released \
+                                      operation declares no `Accept` either, \
+                                      and the empty body negotiates nothing — \
+                                      so this route has no `406`."),
+        (status = 400, description = "The released cross-cutting trigger, \
+                                      verbatim: `400 Bad Request` \"is \
+                                      returned when the request could not be \
+                                      parsed or is invalid (e.g. malformed \
+                                      request URL syntax, missing required \
+                                      header or parameter, or syntactically \
+                                      invalid header, parameter or content)\" \
+                                      (ITS-REST \
+                                      `specifications/responses/400.yaml`). \
+                                      Here: a `uid_based_id` that is neither a \
+                                      HIER_OBJECT_ID (a UUID) nor a \
+                                      well-formed three-part \
+                                      OBJECT_VERSION_ID. A well-formed \
+                                      identifier that names nothing is `404`, \
+                                      not `400`.",
+         body = serde_json::Value),
+        (status = 404, description = "The released trigger, verbatim: `404 Not \
+                                      Found` \"is returned when the \
+                                      `uid_based_id` does not exist, or when \
+                                      the ITEM_TAG identified by the `key` \
+                                      does not exist.\" (ITS-REST \
+                                      `specifications/responses/404_unknown_uid_based_id_or_key.yaml`). \
+                                      The SECOND trigger makes this operation \
+                                      deliberately NON-IDEMPOTENT on the wire: \
+                                      the second identical `DELETE` answers \
+                                      `404`, because after the first one no \
+                                      ITEM_TAG under that key exists on the \
+                                      addressed collection. A key that exists \
+                                      only on the OTHER collection of the same \
+                                      versioned object (container vs version) \
+                                      does not exist here either. Target \
+                                      non-existence covers an unknown \
+                                      `versioned_object_uid`, a version form \
+                                      whose version does not exist, and a \
+                                      well-formed uid whose stored container \
+                                      is NOT a ROLE (another PARTY kind, or a \
+                                      uid from the EHR space) — the \
+                                      kind-checked reading being OURS, \
+                                      register-documented in the conformance \
+                                      catalogue.",
          body = serde_json::Value)
     )
 )]

--- a/app/ehrbase-rest/src/api/demographic/openapi_routes.rs
+++ b/app/ehrbase-rest/src/api/demographic/openapi_routes.rs
@@ -125,9 +125,9 @@ pub(crate) fn routes() -> OpenApiRouter<AppState> {
 
 /// Create an `AGENT` (`POST /demographic/agent`).
 ///
-/// "Creates the first version of a new AGENT." (ITS-REST
+/// "Creates the first version of a new `AGENT`." (ITS-REST
 /// `specifications/operations/agent_create.yaml`). The `uid` is server-minted:
-/// a PARTY's `uid` is the containing VERSION's `OBJECT_VERSION_ID`, which the
+/// a PARTY's `uid` is the containing `VERSION`'s `OBJECT_VERSION_ID`, which the
 /// client cannot know at create time, so a `uid` in the submitted body does not
 /// survive the write and the invariant `Uid_mandatory` (RM
 /// `demographic/master02` §Party Identification, `PARTY.Uid_mandatory`) is
@@ -215,11 +215,12 @@ pub(crate) fn routes() -> OpenApiRouter<AppState> {
          description = "\"The list of all ITEM_TAG to be set and associated with \
                         the current VERSION\" (ITS-REST \
                         `specifications/parameters/header/openehr-version-item-tag.yaml`). \
-                        Demographic ITEM_TAGs are stored against the \
-                        VERSIONED_PARTY with no version anchor, so the two tag \
-                        sets coincide on this surface and this build takes the \
-                        list to store from `openehr-item-tag` only; both response \
-                        headers then carry that one set.",
+                        The two wrapper headers address DISTINCT collections \
+                        (overview §\"openehr-item-tag and \
+                        openehr-version-item-tag\"): this one replaces the \
+                        just-committed VERSION's own tag set, `openehr-item-tag` \
+                        the `VERSIONED_PARTY` container's; each response header \
+                        echoes its own stored set.",
          example = "key=\"reviewed\",value=\"true\"")
     ),
     request_body(content = serde_json::Value,
@@ -324,8 +325,10 @@ pub(crate) fn routes() -> OpenApiRouter<AppState> {
               description = "\"The list of all ITEM_TAG associated with the \
                              current VERSION\" (ITS-REST \
                              `specifications/headers/openehr-version-item-tag.yaml`); \
-                             demographic tags have no version anchor, so this \
-                             carries the same set as `openehr-item-tag`.")
+                             the served VERSION's own collection, distinct from \
+                             the container set `openehr-item-tag` carries \
+                             (overview §\"openehr-item-tag and \
+                             openehr-version-item-tag\").")
          ),
          examples(
              ("representation" = (summary = "Prefer: return=representation — the created AGENT",
@@ -439,7 +442,7 @@ pub(crate) async fn agent_create(
 /// Retrieve an `AGENT` by uid-based id
 /// (`GET /demographic/agent/{uid_based_id}`).
 ///
-/// "Retrieves a version of the AGENT identified by `uid_based_id`." (ITS-REST
+/// "Retrieves a version of the `AGENT` identified by `uid_based_id`." (ITS-REST
 /// `specifications/operations/agent_get.yaml`).
 #[utoipa::path(
     get, path = "/demographic/agent/{uid_based_id}", tag = "AGENT",
@@ -518,8 +521,10 @@ pub(crate) async fn agent_create(
               description = "\"The list of all ITEM_TAG associated with the \
                              current VERSION\" (ITS-REST \
                              `specifications/headers/openehr-version-item-tag.yaml`); \
-                             demographic tags have no version anchor, so this \
-                             carries the same set as `openehr-item-tag`.")
+                             the served VERSION's own collection, distinct from \
+                             the container set `openehr-item-tag` carries \
+                             (overview §\"openehr-item-tag and \
+                             openehr-version-item-tag\").")
          ),
          example = json!({
              "_type": "AGENT",
@@ -626,8 +631,8 @@ pub(crate) async fn agent_get(
 
 /// Update an `AGENT` (`PUT /demographic/agent/{uid_based_id}`).
 ///
-/// "Updates AGENT identified by `uid_based_id`." … "The existing latest
-/// `version_uid` of AGENT resource (i.e. the `preceding_version_uid`) must be
+/// "Updates `AGENT` identified by `uid_based_id`." … "The existing latest
+/// `version_uid` of `AGENT` resource (i.e. the `preceding_version_uid`) must be
 /// specified in the `If-Match` header." (ITS-REST
 /// `specifications/operations/agent_update.yaml`).
 #[utoipa::path(
@@ -1001,9 +1006,9 @@ pub(crate) async fn agent_update(
 
 /// Delete an `AGENT` (`DELETE /demographic/agent/{uid_based_id}`).
 ///
-/// "Deletes the AGENT identified by `uid_based_id`." (ITS-REST
+/// "Deletes the `AGENT` identified by `uid_based_id`." (ITS-REST
 /// `specifications/operations/agent_delete.yaml`). The delete is LOGICAL: it
-/// commits a new deletion VERSION rather than removing history — RM
+/// commits a new deletion `VERSION` rather than removing history — RM
 /// `common/master06` §Change Control keeps every committed version, and a
 /// subsequent read of the deleted current version answers `204`
 /// (`responses/204_deleted_at_time.yaml`).
@@ -1158,9 +1163,9 @@ pub(crate) async fn agent_delete(
 
 /// Create a `GROUP` (`POST /demographic/group`).
 ///
-/// "Creates the first version of a new GROUP." (ITS-REST
+/// "Creates the first version of a new `GROUP`." (ITS-REST
 /// `specifications/operations/group_create.yaml`). The `uid` is server-minted:
-/// a PARTY's `uid` is the containing VERSION's `OBJECT_VERSION_ID`, which the
+/// a PARTY's `uid` is the containing `VERSION`'s `OBJECT_VERSION_ID`, which the
 /// client cannot know at create time, so a `uid` in the submitted body does not
 /// survive the write and the invariant `Uid_mandatory` (RM
 /// `demographic/master02` §Party Identification, `PARTY.Uid_mandatory`) is
@@ -1248,11 +1253,12 @@ pub(crate) async fn agent_delete(
          description = "\"The list of all ITEM_TAG to be set and associated with \
                         the current VERSION\" (ITS-REST \
                         `specifications/parameters/header/openehr-version-item-tag.yaml`). \
-                        Demographic ITEM_TAGs are stored against the \
-                        VERSIONED_PARTY with no version anchor, so the two tag \
-                        sets coincide on this surface and this build takes the \
-                        list to store from `openehr-item-tag` only; both response \
-                        headers then carry that one set.",
+                        The two wrapper headers address DISTINCT collections \
+                        (overview §\"openehr-item-tag and \
+                        openehr-version-item-tag\"): this one replaces the \
+                        just-committed VERSION's own tag set, `openehr-item-tag` \
+                        the `VERSIONED_PARTY` container's; each response header \
+                        echoes its own stored set.",
          example = "key=\"reviewed\",value=\"true\"")
     ),
     request_body(content = serde_json::Value,
@@ -1357,8 +1363,10 @@ pub(crate) async fn agent_delete(
               description = "\"The list of all ITEM_TAG associated with the \
                              current VERSION\" (ITS-REST \
                              `specifications/headers/openehr-version-item-tag.yaml`); \
-                             demographic tags have no version anchor, so this \
-                             carries the same set as `openehr-item-tag`.")
+                             the served VERSION's own collection, distinct from \
+                             the container set `openehr-item-tag` carries \
+                             (overview §\"openehr-item-tag and \
+                             openehr-version-item-tag\").")
          ),
          examples(
              ("representation" = (summary = "Prefer: return=representation — the created GROUP",
@@ -1472,7 +1480,7 @@ pub(crate) async fn group_create(
 /// Retrieve a `GROUP` by uid-based id
 /// (`GET /demographic/group/{uid_based_id}`).
 ///
-/// "Retrieves a version of the GROUP identified by `uid_based_id`." (ITS-REST
+/// "Retrieves a version of the `GROUP` identified by `uid_based_id`." (ITS-REST
 /// `specifications/operations/group_get.yaml`).
 #[utoipa::path(
     get, path = "/demographic/group/{uid_based_id}", tag = "GROUP",
@@ -1551,8 +1559,10 @@ pub(crate) async fn group_create(
               description = "\"The list of all ITEM_TAG associated with the \
                              current VERSION\" (ITS-REST \
                              `specifications/headers/openehr-version-item-tag.yaml`); \
-                             demographic tags have no version anchor, so this \
-                             carries the same set as `openehr-item-tag`.")
+                             the served VERSION's own collection, distinct from \
+                             the container set `openehr-item-tag` carries \
+                             (overview §\"openehr-item-tag and \
+                             openehr-version-item-tag\").")
          ),
          example = json!({
              "_type": "GROUP",
@@ -1659,8 +1669,8 @@ pub(crate) async fn group_get(
 
 /// Update a `GROUP` (`PUT /demographic/group/{uid_based_id}`).
 ///
-/// "Updates GROUP identified by `uid_based_id`." … "The existing latest
-/// `version_uid` of GROUP resource (i.e. the `preceding_version_uid`) must be
+/// "Updates `GROUP` identified by `uid_based_id`." … "The existing latest
+/// `version_uid` of `GROUP` resource (i.e. the `preceding_version_uid`) must be
 /// specified in the `If-Match` header." (ITS-REST
 /// `specifications/operations/group_update.yaml`).
 #[utoipa::path(
@@ -2034,9 +2044,9 @@ pub(crate) async fn group_update(
 
 /// Delete a `GROUP` (`DELETE /demographic/group/{uid_based_id}`).
 ///
-/// "Deletes the GROUP identified by `uid_based_id`." (ITS-REST
+/// "Deletes the `GROUP` identified by `uid_based_id`." (ITS-REST
 /// `specifications/operations/group_delete.yaml`). The delete is LOGICAL: it
-/// commits a new deletion VERSION rather than removing history — RM
+/// commits a new deletion `VERSION` rather than removing history — RM
 /// `common/master06` §Change Control keeps every committed version, and a
 /// subsequent read of the deleted current version answers `204`
 /// (`responses/204_deleted_at_time.yaml`).
@@ -2191,9 +2201,9 @@ pub(crate) async fn group_delete(
 
 /// Create an `ORGANISATION` (`POST /demographic/organisation`).
 ///
-/// "Creates the first version of a new ORGANISATION." (ITS-REST
+/// "Creates the first version of a new `ORGANISATION`." (ITS-REST
 /// `specifications/operations/organisation_create.yaml`). The `uid` is server-minted:
-/// a PARTY's `uid` is the containing VERSION's `OBJECT_VERSION_ID`, which the
+/// a PARTY's `uid` is the containing `VERSION`'s `OBJECT_VERSION_ID`, which the
 /// client cannot know at create time, so a `uid` in the submitted body does not
 /// survive the write and the invariant `Uid_mandatory` (RM
 /// `demographic/master02` §Party Identification, `PARTY.Uid_mandatory`) is
@@ -2281,11 +2291,12 @@ pub(crate) async fn group_delete(
          description = "\"The list of all ITEM_TAG to be set and associated with \
                         the current VERSION\" (ITS-REST \
                         `specifications/parameters/header/openehr-version-item-tag.yaml`). \
-                        Demographic ITEM_TAGs are stored against the \
-                        VERSIONED_PARTY with no version anchor, so the two tag \
-                        sets coincide on this surface and this build takes the \
-                        list to store from `openehr-item-tag` only; both response \
-                        headers then carry that one set.",
+                        The two wrapper headers address DISTINCT collections \
+                        (overview §\"openehr-item-tag and \
+                        openehr-version-item-tag\"): this one replaces the \
+                        just-committed VERSION's own tag set, `openehr-item-tag` \
+                        the `VERSIONED_PARTY` container's; each response header \
+                        echoes its own stored set.",
          example = "key=\"reviewed\",value=\"true\"")
     ),
     request_body(content = serde_json::Value,
@@ -2390,8 +2401,10 @@ pub(crate) async fn group_delete(
               description = "\"The list of all ITEM_TAG associated with the \
                              current VERSION\" (ITS-REST \
                              `specifications/headers/openehr-version-item-tag.yaml`); \
-                             demographic tags have no version anchor, so this \
-                             carries the same set as `openehr-item-tag`.")
+                             the served VERSION's own collection, distinct from \
+                             the container set `openehr-item-tag` carries \
+                             (overview §\"openehr-item-tag and \
+                             openehr-version-item-tag\").")
          ),
          examples(
              ("representation" = (summary = "Prefer: return=representation — the created ORGANISATION",
@@ -2511,7 +2524,7 @@ pub(crate) async fn organisation_create(
 /// Retrieve an `ORGANISATION` by uid-based id
 /// (`GET /demographic/organisation/{uid_based_id}`).
 ///
-/// "Retrieves a version of the ORGANISATION identified by `uid_based_id`." (ITS-REST
+/// "Retrieves a version of the `ORGANISATION` identified by `uid_based_id`." (ITS-REST
 /// `specifications/operations/organisation_get.yaml`).
 #[utoipa::path(
     get, path = "/demographic/organisation/{uid_based_id}", tag = "ORGANISATION",
@@ -2590,8 +2603,10 @@ pub(crate) async fn organisation_create(
               description = "\"The list of all ITEM_TAG associated with the \
                              current VERSION\" (ITS-REST \
                              `specifications/headers/openehr-version-item-tag.yaml`); \
-                             demographic tags have no version anchor, so this \
-                             carries the same set as `openehr-item-tag`.")
+                             the served VERSION's own collection, distinct from \
+                             the container set `openehr-item-tag` carries \
+                             (overview §\"openehr-item-tag and \
+                             openehr-version-item-tag\").")
          ),
          example = json!({
              "_type": "ORGANISATION",
@@ -2698,8 +2713,8 @@ pub(crate) async fn organisation_get(
 
 /// Update an `ORGANISATION` (`PUT /demographic/organisation/{uid_based_id}`).
 ///
-/// "Updates ORGANISATION identified by `uid_based_id`." … "The existing latest
-/// `version_uid` of ORGANISATION resource (i.e. the `preceding_version_uid`) must be
+/// "Updates `ORGANISATION` identified by `uid_based_id`." … "The existing latest
+/// `version_uid` of `ORGANISATION` resource (i.e. the `preceding_version_uid`) must be
 /// specified in the `If-Match` header." (ITS-REST
 /// `specifications/operations/organisation_update.yaml`).
 #[utoipa::path(
@@ -3079,9 +3094,9 @@ pub(crate) async fn organisation_update(
 
 /// Delete an `ORGANISATION` (`DELETE /demographic/organisation/{uid_based_id}`).
 ///
-/// "Deletes the ORGANISATION identified by `uid_based_id`." (ITS-REST
+/// "Deletes the `ORGANISATION` identified by `uid_based_id`." (ITS-REST
 /// `specifications/operations/organisation_delete.yaml`). The delete is LOGICAL: it
-/// commits a new deletion VERSION rather than removing history — RM
+/// commits a new deletion `VERSION` rather than removing history — RM
 /// `common/master06` §Change Control keeps every committed version, and a
 /// subsequent read of the deleted current version answers `204`
 /// (`responses/204_deleted_at_time.yaml`).
@@ -3242,9 +3257,9 @@ pub(crate) async fn organisation_delete(
 
 /// Create a `PERSON` (`POST /demographic/person`).
 ///
-/// "Creates the first version of a new PERSON." (ITS-REST
+/// "Creates the first version of a new `PERSON`." (ITS-REST
 /// `specifications/operations/person_create.yaml`). The `uid` is server-minted:
-/// a PARTY's `uid` is the containing VERSION's `OBJECT_VERSION_ID`, which the
+/// a PARTY's `uid` is the containing `VERSION`'s `OBJECT_VERSION_ID`, which the
 /// client cannot know at create time, so a `uid` in the submitted body does not
 /// survive the write and the invariant `Uid_mandatory` (RM
 /// `demographic/master02` §Party Identification, `PARTY.Uid_mandatory`) is
@@ -3332,11 +3347,12 @@ pub(crate) async fn organisation_delete(
          description = "\"The list of all ITEM_TAG to be set and associated with \
                         the current VERSION\" (ITS-REST \
                         `specifications/parameters/header/openehr-version-item-tag.yaml`). \
-                        Demographic ITEM_TAGs are stored against the \
-                        VERSIONED_PARTY with no version anchor, so the two tag \
-                        sets coincide on this surface and this build takes the \
-                        list to store from `openehr-item-tag` only; both response \
-                        headers then carry that one set.",
+                        The two wrapper headers address DISTINCT collections \
+                        (overview §\"openehr-item-tag and \
+                        openehr-version-item-tag\"): this one replaces the \
+                        just-committed VERSION's own tag set, `openehr-item-tag` \
+                        the `VERSIONED_PARTY` container's; each response header \
+                        echoes its own stored set.",
          example = "key=\"reviewed\",value=\"true\"")
     ),
     request_body(content = serde_json::Value,
@@ -3441,8 +3457,10 @@ pub(crate) async fn organisation_delete(
               description = "\"The list of all ITEM_TAG associated with the \
                              current VERSION\" (ITS-REST \
                              `specifications/headers/openehr-version-item-tag.yaml`); \
-                             demographic tags have no version anchor, so this \
-                             carries the same set as `openehr-item-tag`.")
+                             the served VERSION's own collection, distinct from \
+                             the container set `openehr-item-tag` carries \
+                             (overview §\"openehr-item-tag and \
+                             openehr-version-item-tag\").")
          ),
          examples(
              ("representation" = (summary = "Prefer: return=representation — the created PERSON",
@@ -3556,7 +3574,7 @@ pub(crate) async fn person_create(
 /// Retrieve a `PERSON` by uid-based id
 /// (`GET /demographic/person/{uid_based_id}`).
 ///
-/// "Retrieves a version of the PERSON identified by `uid_based_id`." (ITS-REST
+/// "Retrieves a version of the `PERSON` identified by `uid_based_id`." (ITS-REST
 /// `specifications/operations/person_get.yaml`).
 #[utoipa::path(
     get, path = "/demographic/person/{uid_based_id}", tag = "PERSON",
@@ -3635,8 +3653,10 @@ pub(crate) async fn person_create(
               description = "\"The list of all ITEM_TAG associated with the \
                              current VERSION\" (ITS-REST \
                              `specifications/headers/openehr-version-item-tag.yaml`); \
-                             demographic tags have no version anchor, so this \
-                             carries the same set as `openehr-item-tag`.")
+                             the served VERSION's own collection, distinct from \
+                             the container set `openehr-item-tag` carries \
+                             (overview §\"openehr-item-tag and \
+                             openehr-version-item-tag\").")
          ),
          example = json!({
              "_type": "PERSON",
@@ -3743,8 +3763,8 @@ pub(crate) async fn person_get(
 
 /// Update a `PERSON` (`PUT /demographic/person/{uid_based_id}`).
 ///
-/// "Updates PERSON identified by `uid_based_id`." … "The existing latest
-/// `version_uid` of PERSON resource (i.e. the `preceding_version_uid`) must be
+/// "Updates `PERSON` identified by `uid_based_id`." … "The existing latest
+/// `version_uid` of `PERSON` resource (i.e. the `preceding_version_uid`) must be
 /// specified in the `If-Match` header." (ITS-REST
 /// `specifications/operations/person_update.yaml`).
 #[utoipa::path(
@@ -4118,9 +4138,9 @@ pub(crate) async fn person_update(
 
 /// Delete a `PERSON` (`DELETE /demographic/person/{uid_based_id}`).
 ///
-/// "Deletes the PERSON identified by `uid_based_id`." (ITS-REST
+/// "Deletes the `PERSON` identified by `uid_based_id`." (ITS-REST
 /// `specifications/operations/person_delete.yaml`). The delete is LOGICAL: it
-/// commits a new deletion VERSION rather than removing history — RM
+/// commits a new deletion `VERSION` rather than removing history — RM
 /// `common/master06` §Change Control keeps every committed version, and a
 /// subsequent read of the deleted current version answers `204`
 /// (`responses/204_deleted_at_time.yaml`).
@@ -4275,9 +4295,9 @@ pub(crate) async fn person_delete(
 
 /// Create a `ROLE` (`POST /demographic/role`).
 ///
-/// "Creates the first version of a new ROLE." (ITS-REST
+/// "Creates the first version of a new `ROLE`." (ITS-REST
 /// `specifications/operations/role_create.yaml`). The `uid` is server-minted:
-/// a PARTY's `uid` is the containing VERSION's `OBJECT_VERSION_ID`, which the
+/// a PARTY's `uid` is the containing `VERSION`'s `OBJECT_VERSION_ID`, which the
 /// client cannot know at create time, so a `uid` in the submitted body does not
 /// survive the write and the invariant `Uid_mandatory` (RM
 /// `demographic/master02` §Party Identification, `PARTY.Uid_mandatory`) is
@@ -4365,11 +4385,12 @@ pub(crate) async fn person_delete(
          description = "\"The list of all ITEM_TAG to be set and associated with \
                         the current VERSION\" (ITS-REST \
                         `specifications/parameters/header/openehr-version-item-tag.yaml`). \
-                        Demographic ITEM_TAGs are stored against the \
-                        VERSIONED_PARTY with no version anchor, so the two tag \
-                        sets coincide on this surface and this build takes the \
-                        list to store from `openehr-item-tag` only; both response \
-                        headers then carry that one set.",
+                        The two wrapper headers address DISTINCT collections \
+                        (overview §\"openehr-item-tag and \
+                        openehr-version-item-tag\"): this one replaces the \
+                        just-committed VERSION's own tag set, `openehr-item-tag` \
+                        the `VERSIONED_PARTY` container's; each response header \
+                        echoes its own stored set.",
          example = "key=\"reviewed\",value=\"true\"")
     ),
     request_body(content = serde_json::Value,
@@ -4474,8 +4495,10 @@ pub(crate) async fn person_delete(
               description = "\"The list of all ITEM_TAG associated with the \
                              current VERSION\" (ITS-REST \
                              `specifications/headers/openehr-version-item-tag.yaml`); \
-                             demographic tags have no version anchor, so this \
-                             carries the same set as `openehr-item-tag`.")
+                             the served VERSION's own collection, distinct from \
+                             the container set `openehr-item-tag` carries \
+                             (overview §\"openehr-item-tag and \
+                             openehr-version-item-tag\").")
          ),
          examples(
              ("representation" = (summary = "Prefer: return=representation — the created ROLE",
@@ -4589,7 +4612,7 @@ pub(crate) async fn role_create(
 /// Retrieve a `ROLE` by uid-based id
 /// (`GET /demographic/role/{uid_based_id}`).
 ///
-/// "Retrieves a version of the ROLE identified by `uid_based_id`." (ITS-REST
+/// "Retrieves a version of the `ROLE` identified by `uid_based_id`." (ITS-REST
 /// `specifications/operations/role_get.yaml`).
 #[utoipa::path(
     get, path = "/demographic/role/{uid_based_id}", tag = "ROLE",
@@ -4668,8 +4691,10 @@ pub(crate) async fn role_create(
               description = "\"The list of all ITEM_TAG associated with the \
                              current VERSION\" (ITS-REST \
                              `specifications/headers/openehr-version-item-tag.yaml`); \
-                             demographic tags have no version anchor, so this \
-                             carries the same set as `openehr-item-tag`.")
+                             the served VERSION's own collection, distinct from \
+                             the container set `openehr-item-tag` carries \
+                             (overview §\"openehr-item-tag and \
+                             openehr-version-item-tag\").")
          ),
          example = json!({
              "_type": "ROLE",
@@ -4776,8 +4801,8 @@ pub(crate) async fn role_get(
 
 /// Update a `ROLE` (`PUT /demographic/role/{uid_based_id}`).
 ///
-/// "Updates ROLE identified by `uid_based_id`." … "The existing latest
-/// `version_uid` of ROLE resource (i.e. the `preceding_version_uid`) must be
+/// "Updates `ROLE` identified by `uid_based_id`." … "The existing latest
+/// `version_uid` of `ROLE` resource (i.e. the `preceding_version_uid`) must be
 /// specified in the `If-Match` header." (ITS-REST
 /// `specifications/operations/role_update.yaml`).
 #[utoipa::path(
@@ -5151,9 +5176,9 @@ pub(crate) async fn role_update(
 
 /// Delete a `ROLE` (`DELETE /demographic/role/{uid_based_id}`).
 ///
-/// "Deletes the ROLE identified by `uid_based_id`." (ITS-REST
+/// "Deletes the `ROLE` identified by `uid_based_id`." (ITS-REST
 /// `specifications/operations/role_delete.yaml`). The delete is LOGICAL: it
-/// commits a new deletion VERSION rather than removing history — RM
+/// commits a new deletion `VERSION` rather than removing history — RM
 /// `common/master06` §Change Control keeps every committed version, and a
 /// subsequent read of the deleted current version answers `204`
 /// (`responses/204_deleted_at_time.yaml`).
@@ -5522,13 +5547,13 @@ pub(crate) async fn versioned_party_revision_history(
     .await
 }
 
-/// Retrieve the party VERSION at a point in time
+/// Retrieve the party `VERSION` at a point in time
 /// (`GET /demographic/versioned_party/{versioned_object_uid}/version`).
 ///
-/// "Retrieves a VERSION from the `VERSIONED_PARTY` identified by
+/// "Retrieves a `VERSION` from the `VERSIONED_PARTY` identified by
 /// `versioned_object_uid`." … "If `version_at_time` is supplied, retrieves the
-/// VERSION extant _at specified time_, otherwise retrieves the _latest_
-/// VERSION." (ITS-REST
+/// `VERSION` extant _at specified time_, otherwise retrieves the _latest_
+/// `VERSION`." (ITS-REST
 /// `specifications/operations/versioned_party_version_get_at_time.yaml`).
 #[utoipa::path(
     get, path = "/demographic/versioned_party/{versioned_object_uid}/version", tag = "VERSIONED_PARTY",
@@ -5625,10 +5650,10 @@ pub(crate) async fn versioned_party_version_get_at_time(
     .await
 }
 
-/// Retrieve a specific party VERSION by version uid
+/// Retrieve a specific party `VERSION` by version uid
 /// (`GET /demographic/versioned_party/{versioned_object_uid}/version/{version_uid}`).
 ///
-/// "Retrieves a VERSION identified by `version_uid` of a `VERSIONED_PARTY`
+/// "Retrieves a `VERSION` identified by `version_uid` of a `VERSIONED_PARTY`
 /// identified by `versioned_object_uid`." (ITS-REST
 /// `specifications/operations/versioned_party_version_get_by_id.yaml`).
 #[utoipa::path(
@@ -6142,27 +6167,21 @@ pub(crate) async fn contribution_get(
 // `Location`. The only response header on the whole family is
 // `Preference-Applied`, on the five PUTs.
 //
-// `owner_id` is our own design. RM `item_tag.adoc` types it `OBJECT_REF` —
-// "Identifier of owner object, such as EHR" — and a demographic party has no
-// EHR; no demographic RM class declares a `tags` containment either, so nothing
-// released fixes the owner of an EHR-less tag. This build names the owning
-// VERSIONED_PARTY; the position is register-documented in the conformance
-// catalogue. The released `ItemTagOf*` examples instead show
-// `{namespace: local, type: SYSTEM}`, which no released sentence requires.
-//
-// TODO: serve `target` as the bare `UID_BASED_ID` the RM declares
-// (`item_tag.adoc`: `target: UID_BASED_ID`, "which may be a
-// `VERSIONED_OBJECT<T>` or a `VERSION<T>`") instead of the `OBJECT_REF`
-// envelope this family currently emits. The EHR-side tag family already serves
-// the RM shape; the RM is the RELEASED component and wins over the stalled OAS
-// `ItemTag`/`UObjectRefOfUidBasedId` schema the envelope follows. Until that
-// lands, the declarations below describe the envelope actually served.
+// `target` is the bare RM `UID_BASED_ID` (`item_tag.adoc`: `target:
+// UID_BASED_ID`, "which may be a `VERSIONED_OBJECT<T>` or a `VERSION<T>`") — a
+// `HIER_OBJECT_ID` for a container target, an `OBJECT_VERSION_ID` for a
+// VERSION target; the RELEASED RM wins over the stalled OAS
+// `ItemTag`/`UObjectRefOfUidBasedId` envelope. `owner_id` follows the five
+// released `ItemTagOf*` examples' unanimous `{namespace: local, type: SYSTEM}`
+// shape carrying the server's system identifier — no demographic RM class
+// declares a `tags` containment, so nothing released fixes the owner of an
+// EHR-less tag; the position is register-documented (AMB-137).
 
 /// List `ITEM_TAG`s across the whole Demographic space
 /// (`GET /demographic/tags`).
 ///
-/// "Retrieves the list of ITEM_TAG resources associated with any target VERSION
-/// or VERSIONED_PARTY within the Demographic space." (ITS-REST
+/// "Retrieves the list of `ITEM_TAG` resources associated with any target `VERSION`
+/// or `VERSIONED_PARTY` within the Demographic space." (ITS-REST
 /// `specifications/operations/demographic_tags_get.yaml`).
 ///
 /// The ONLY tag route on the whole surface with NO scoping parameter: its
@@ -6294,16 +6313,16 @@ pub(crate) async fn contribution_get(
                     "_type": "ITEM_TAG",
                     "key": "flag",
                     "value": "follow-up",
-                    "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "PERSON", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
-                    "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "PERSON", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                    "target": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" },
+                    "owner_id": { "_type": "OBJECT_REF", "namespace": "local", "type": "SYSTEM", "id": { "_type": "HIER_OBJECT_ID", "value": "openEHRSys.example.com" } }
                 },
                 {
                     "_type": "ITEM_TAG",
                     "key": "reviewed",
                     "value": "true",
                     "target_path": "/details/items[at0001]/value",
-                    "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "AGENT", "id": { "_type": "HIER_OBJECT_ID", "value": "b1e6a0c4-6b2e-4f3a-9c1d-2f5a7e8b0c31" } },
-                    "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "AGENT", "id": { "_type": "HIER_OBJECT_ID", "value": "b1e6a0c4-6b2e-4f3a-9c1d-2f5a7e8b0c31" } }
+                    "target": { "_type": "HIER_OBJECT_ID", "value": "b1e6a0c4-6b2e-4f3a-9c1d-2f5a7e8b0c31" },
+                    "owner_id": { "_type": "OBJECT_REF", "namespace": "local", "type": "SYSTEM", "id": { "_type": "HIER_OBJECT_ID", "value": "openEHRSys.example.com" } }
                 }
             ])))
         ),
@@ -6359,8 +6378,8 @@ pub(crate) async fn demographic_tags_get(
 /// Retrieve an `AGENT`'s `ITEM_TAG`s
 /// (`GET /demographic/agent/{uid_based_id}/tags`).
 ///
-/// "Retrieves the list of all ITEM_TAG resources associated with a given target
-/// AGENT version or VERSIONED_PARTY identified by `uid_based_id`" (ITS-REST
+/// "Retrieves the list of all `ITEM_TAG` resources associated with a given target
+/// `AGENT` version or `VERSIONED_PARTY` identified by `uid_based_id`" (ITS-REST
 /// `specifications/operations/agent_tags_get.yaml`).
 ///
 /// The two `uid_based_id` forms address DISJOINT tag collections — see the
@@ -6469,16 +6488,16 @@ pub(crate) async fn demographic_tags_get(
                         "_type": "ITEM_TAG",
                         "key": "flag",
                         "value": "follow-up",
-                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "AGENT", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
-                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "AGENT", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                        "target": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "local", "type": "SYSTEM", "id": { "_type": "HIER_OBJECT_ID", "value": "openEHRSys.example.com" } }
                     },
                     {
                         "_type": "ITEM_TAG",
                         "key": "reviewed",
                         "value": "true",
                         "target_path": "/details/items[at0001]/value",
-                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "AGENT", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
-                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "AGENT", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                        "target": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "local", "type": "SYSTEM", "id": { "_type": "HIER_OBJECT_ID", "value": "openEHRSys.example.com" } }
                     }
                 ])
             ))
@@ -6550,8 +6569,8 @@ pub(crate) async fn agent_tags_get(
 /// Replace an `AGENT`'s `ITEM_TAG`s
 /// (`PUT /demographic/agent/{uid_based_id}/tags`).
 ///
-/// "Updates the list of all ITEM_TAG resources associated with a given target
-/// AGENT version or VERSIONED_PARTY identified by `uid_based_id`" (ITS-REST
+/// "Updates the list of all `ITEM_TAG` resources associated with a given target
+/// `AGENT` version or `VERSIONED_PARTY` identified by `uid_based_id`" (ITS-REST
 /// `specifications/operations/agent_tags_update.yaml`). It is a FULL COLLECTION
 /// REPLACE of the ADDRESSED collection — the container's or one version's,
 /// never both.
@@ -6751,16 +6770,16 @@ pub(crate) async fn agent_tags_get(
                         "_type": "ITEM_TAG",
                         "key": "flag",
                         "value": "follow-up",
-                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "AGENT", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
-                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "AGENT", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                        "target": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "local", "type": "SYSTEM", "id": { "_type": "HIER_OBJECT_ID", "value": "openEHRSys.example.com" } }
                     },
                     {
                         "_type": "ITEM_TAG",
                         "key": "reviewed",
                         "value": "true",
                         "target_path": "/details/items[at0001]/value",
-                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "AGENT", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
-                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "AGENT", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                        "target": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "local", "type": "SYSTEM", "id": { "_type": "HIER_OBJECT_ID", "value": "openEHRSys.example.com" } }
                     }
                 ])
             ))
@@ -6879,11 +6898,11 @@ pub(crate) async fn agent_tags_update(
 /// Delete an `AGENT`'s `ITEM_TAG`s under one key
 /// (`DELETE /demographic/agent/{uid_based_id}/tags/{key}`).
 ///
-/// "Deletes the ITEM_TAG resource(s) identified by `tag_key`, associated with a
-/// given target AGENT version or VERSIONED_PARTY identified by `uid_based_id`"
+/// "Deletes the `ITEM_TAG` resource(s) identified by `tag_key`, associated with a
+/// given target `AGENT` version or `VERSIONED_PARTY` identified by `uid_based_id`"
 /// (ITS-REST `specifications/operations/agent_tags_delete.yaml`).
 ///
-/// A SET delete, not a single-resource delete: ITEM_TAG identity is the (`key`,
+/// A SET delete, not a single-resource delete: `ITEM_TAG` identity is the (`key`,
 /// `target_path`) pair, the route carries no `target_path` selector, and the
 /// released text says "resource(s)" — so every tag under `key` on the addressed
 /// collection goes, however many paths they carry.
@@ -7016,8 +7035,8 @@ pub(crate) async fn agent_tags_delete(
 /// Retrieve a `GROUP`'s `ITEM_TAG`s
 /// (`GET /demographic/group/{uid_based_id}/tags`).
 ///
-/// "Retrieves the list of all ITEM_TAG resources associated with a given target
-/// GROUP version or VERSIONED_PARTY identified by `uid_based_id`" (ITS-REST
+/// "Retrieves the list of all `ITEM_TAG` resources associated with a given target
+/// `GROUP` version or `VERSIONED_PARTY` identified by `uid_based_id`" (ITS-REST
 /// `specifications/operations/group_tags_get.yaml`).
 ///
 /// The two `uid_based_id` forms address DISJOINT tag collections — see the
@@ -7126,16 +7145,16 @@ pub(crate) async fn agent_tags_delete(
                         "_type": "ITEM_TAG",
                         "key": "flag",
                         "value": "follow-up",
-                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "GROUP", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
-                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "GROUP", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                        "target": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "local", "type": "SYSTEM", "id": { "_type": "HIER_OBJECT_ID", "value": "openEHRSys.example.com" } }
                     },
                     {
                         "_type": "ITEM_TAG",
                         "key": "reviewed",
                         "value": "true",
                         "target_path": "/details/items[at0001]/value",
-                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "GROUP", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
-                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "GROUP", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                        "target": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "local", "type": "SYSTEM", "id": { "_type": "HIER_OBJECT_ID", "value": "openEHRSys.example.com" } }
                     }
                 ])
             ))
@@ -7207,8 +7226,8 @@ pub(crate) async fn group_tags_get(
 /// Replace a `GROUP`'s `ITEM_TAG`s
 /// (`PUT /demographic/group/{uid_based_id}/tags`).
 ///
-/// "Updates the list of all ITEM_TAG resources associated with a given target
-/// GROUP version or VERSIONED_PARTY identified by `uid_based_id`" (ITS-REST
+/// "Updates the list of all `ITEM_TAG` resources associated with a given target
+/// `GROUP` version or `VERSIONED_PARTY` identified by `uid_based_id`" (ITS-REST
 /// `specifications/operations/group_tags_update.yaml`). It is a FULL COLLECTION
 /// REPLACE of the ADDRESSED collection — the container's or one version's,
 /// never both.
@@ -7408,16 +7427,16 @@ pub(crate) async fn group_tags_get(
                         "_type": "ITEM_TAG",
                         "key": "flag",
                         "value": "follow-up",
-                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "GROUP", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
-                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "GROUP", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                        "target": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "local", "type": "SYSTEM", "id": { "_type": "HIER_OBJECT_ID", "value": "openEHRSys.example.com" } }
                     },
                     {
                         "_type": "ITEM_TAG",
                         "key": "reviewed",
                         "value": "true",
                         "target_path": "/details/items[at0001]/value",
-                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "GROUP", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
-                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "GROUP", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                        "target": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "local", "type": "SYSTEM", "id": { "_type": "HIER_OBJECT_ID", "value": "openEHRSys.example.com" } }
                     }
                 ])
             ))
@@ -7535,11 +7554,11 @@ pub(crate) async fn group_tags_update(
 /// Delete a `GROUP`'s `ITEM_TAG`s under one key
 /// (`DELETE /demographic/group/{uid_based_id}/tags/{key}`).
 ///
-/// "Deletes the ITEM_TAG resource(s) identified by `tag_key`, associated with a
-/// given target GROUP version or VERSIONED_PARTY identified by `uid_based_id`"
+/// "Deletes the `ITEM_TAG` resource(s) identified by `tag_key`, associated with a
+/// given target `GROUP` version or `VERSIONED_PARTY` identified by `uid_based_id`"
 /// (ITS-REST `specifications/operations/group_tags_delete.yaml`).
 ///
-/// A SET delete, not a single-resource delete: ITEM_TAG identity is the (`key`,
+/// A SET delete, not a single-resource delete: `ITEM_TAG` identity is the (`key`,
 /// `target_path`) pair, the route carries no `target_path` selector, and the
 /// released text says "resource(s)" — so every tag under `key` on the addressed
 /// collection goes, however many paths they carry.
@@ -7672,8 +7691,8 @@ pub(crate) async fn group_tags_delete(
 /// Retrieve an `ORGANISATION`'s `ITEM_TAG`s
 /// (`GET /demographic/organisation/{uid_based_id}/tags`).
 ///
-/// "Retrieves the list of all ITEM_TAG resources associated with a given target
-/// ORGANISATION version or VERSIONED_PARTY identified by `uid_based_id`"
+/// "Retrieves the list of all `ITEM_TAG` resources associated with a given target
+/// `ORGANISATION` version or `VERSIONED_PARTY` identified by `uid_based_id`"
 /// (ITS-REST `specifications/operations/organisation_tags_get.yaml`).
 ///
 /// The two `uid_based_id` forms address DISJOINT tag collections — see the
@@ -7782,16 +7801,16 @@ pub(crate) async fn group_tags_delete(
                         "_type": "ITEM_TAG",
                         "key": "flag",
                         "value": "follow-up",
-                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ORGANISATION", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
-                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ORGANISATION", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                        "target": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "local", "type": "SYSTEM", "id": { "_type": "HIER_OBJECT_ID", "value": "openEHRSys.example.com" } }
                     },
                     {
                         "_type": "ITEM_TAG",
                         "key": "reviewed",
                         "value": "true",
                         "target_path": "/details/items[at0001]/value",
-                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ORGANISATION", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
-                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ORGANISATION", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                        "target": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "local", "type": "SYSTEM", "id": { "_type": "HIER_OBJECT_ID", "value": "openEHRSys.example.com" } }
                     }
                 ])
             ))
@@ -7869,8 +7888,8 @@ pub(crate) async fn organisation_tags_get(
 /// Replace an `ORGANISATION`'s `ITEM_TAG`s
 /// (`PUT /demographic/organisation/{uid_based_id}/tags`).
 ///
-/// "Updates the list of all ITEM_TAG resources associated with a given target
-/// ORGANISATION version or VERSIONED_PARTY identified by `uid_based_id`"
+/// "Updates the list of all `ITEM_TAG` resources associated with a given target
+/// `ORGANISATION` version or `VERSIONED_PARTY` identified by `uid_based_id`"
 /// (ITS-REST `specifications/operations/organisation_tags_update.yaml`). It is
 /// a FULL COLLECTION REPLACE of the ADDRESSED collection — the container's or
 /// one version's, never both.
@@ -8070,16 +8089,16 @@ pub(crate) async fn organisation_tags_get(
                         "_type": "ITEM_TAG",
                         "key": "flag",
                         "value": "follow-up",
-                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ORGANISATION", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
-                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ORGANISATION", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                        "target": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "local", "type": "SYSTEM", "id": { "_type": "HIER_OBJECT_ID", "value": "openEHRSys.example.com" } }
                     },
                     {
                         "_type": "ITEM_TAG",
                         "key": "reviewed",
                         "value": "true",
                         "target_path": "/details/items[at0001]/value",
-                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ORGANISATION", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
-                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ORGANISATION", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                        "target": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "local", "type": "SYSTEM", "id": { "_type": "HIER_OBJECT_ID", "value": "openEHRSys.example.com" } }
                     }
                 ])
             ))
@@ -8204,12 +8223,12 @@ pub(crate) async fn organisation_tags_update(
 /// Delete an `ORGANISATION`'s `ITEM_TAG`s under one key
 /// (`DELETE /demographic/organisation/{uid_based_id}/tags/{key}`).
 ///
-/// "Deletes the ITEM_TAG resource(s) identified by `tag_key`, associated with a
-/// given target ORGANISATION version or VERSIONED_PARTY identified by
+/// "Deletes the `ITEM_TAG` resource(s) identified by `tag_key`, associated with a
+/// given target `ORGANISATION` version or `VERSIONED_PARTY` identified by
 /// `uid_based_id`" (ITS-REST
 /// `specifications/operations/organisation_tags_delete.yaml`).
 ///
-/// A SET delete, not a single-resource delete: ITEM_TAG identity is the (`key`,
+/// A SET delete, not a single-resource delete: `ITEM_TAG` identity is the (`key`,
 /// `target_path`) pair, the route carries no `target_path` selector, and the
 /// released text says "resource(s)" — so every tag under `key` on the addressed
 /// collection goes, however many paths they carry.
@@ -8348,8 +8367,8 @@ pub(crate) async fn organisation_tags_delete(
 /// Retrieve a `PERSON`'s `ITEM_TAG`s
 /// (`GET /demographic/person/{uid_based_id}/tags`).
 ///
-/// "Retrieves the list of all ITEM_TAG resources associated with a given target
-/// PERSON version or VERSIONED_PARTY identified by `uid_based_id`" (ITS-REST
+/// "Retrieves the list of all `ITEM_TAG` resources associated with a given target
+/// `PERSON` version or `VERSIONED_PARTY` identified by `uid_based_id`" (ITS-REST
 /// `specifications/operations/person_tags_get.yaml`).
 ///
 /// The two `uid_based_id` forms address DISJOINT tag collections — see the
@@ -8458,16 +8477,16 @@ pub(crate) async fn organisation_tags_delete(
                         "_type": "ITEM_TAG",
                         "key": "flag",
                         "value": "follow-up",
-                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "PERSON", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
-                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "PERSON", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                        "target": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "local", "type": "SYSTEM", "id": { "_type": "HIER_OBJECT_ID", "value": "openEHRSys.example.com" } }
                     },
                     {
                         "_type": "ITEM_TAG",
                         "key": "reviewed",
                         "value": "true",
                         "target_path": "/details/items[at0001]/value",
-                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "PERSON", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
-                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "PERSON", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                        "target": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "local", "type": "SYSTEM", "id": { "_type": "HIER_OBJECT_ID", "value": "openEHRSys.example.com" } }
                     }
                 ])
             ))
@@ -8539,8 +8558,8 @@ pub(crate) async fn person_tags_get(
 /// Replace a `PERSON`'s `ITEM_TAG`s
 /// (`PUT /demographic/person/{uid_based_id}/tags`).
 ///
-/// "Updates the list of all ITEM_TAG resources associated with a given target
-/// PERSON version or VERSIONED_PARTY identified by `uid_based_id`" (ITS-REST
+/// "Updates the list of all `ITEM_TAG` resources associated with a given target
+/// `PERSON` version or `VERSIONED_PARTY` identified by `uid_based_id`" (ITS-REST
 /// `specifications/operations/person_tags_update.yaml`). It is a FULL
 /// COLLECTION REPLACE of the ADDRESSED collection — the container's or one
 /// version's, never both.
@@ -8740,16 +8759,16 @@ pub(crate) async fn person_tags_get(
                         "_type": "ITEM_TAG",
                         "key": "flag",
                         "value": "follow-up",
-                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "PERSON", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
-                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "PERSON", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                        "target": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "local", "type": "SYSTEM", "id": { "_type": "HIER_OBJECT_ID", "value": "openEHRSys.example.com" } }
                     },
                     {
                         "_type": "ITEM_TAG",
                         "key": "reviewed",
                         "value": "true",
                         "target_path": "/details/items[at0001]/value",
-                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "PERSON", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
-                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "PERSON", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                        "target": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "local", "type": "SYSTEM", "id": { "_type": "HIER_OBJECT_ID", "value": "openEHRSys.example.com" } }
                     }
                 ])
             ))
@@ -8874,11 +8893,11 @@ pub(crate) async fn person_tags_update(
 /// Delete a `PERSON`'s `ITEM_TAG`s under one key
 /// (`DELETE /demographic/person/{uid_based_id}/tags/{key}`).
 ///
-/// "Deletes the ITEM_TAG resource(s) identified by `tag_key`, associated with a
-/// given target PERSON version or VERSIONED_PARTY identified by `uid_based_id`"
+/// "Deletes the `ITEM_TAG` resource(s) identified by `tag_key`, associated with a
+/// given target `PERSON` version or `VERSIONED_PARTY` identified by `uid_based_id`"
 /// (ITS-REST `specifications/operations/person_tags_delete.yaml`).
 ///
-/// A SET delete, not a single-resource delete: ITEM_TAG identity is the (`key`,
+/// A SET delete, not a single-resource delete: `ITEM_TAG` identity is the (`key`,
 /// `target_path`) pair, the route carries no `target_path` selector, and the
 /// released text says "resource(s)" — so every tag under `key` on the addressed
 /// collection goes, however many paths they carry.
@@ -9017,8 +9036,8 @@ pub(crate) async fn person_tags_delete(
 /// Retrieve a `ROLE`'s `ITEM_TAG`s
 /// (`GET /demographic/role/{uid_based_id}/tags`).
 ///
-/// "Retrieves the list of all ITEM_TAG resources associated with a given target
-/// ROLE version or VERSIONED_PARTY identified by `uid_based_id`" (ITS-REST
+/// "Retrieves the list of all `ITEM_TAG` resources associated with a given target
+/// `ROLE` version or `VERSIONED_PARTY` identified by `uid_based_id`" (ITS-REST
 /// `specifications/operations/role_tags_get.yaml`).
 ///
 /// The two `uid_based_id` forms address DISJOINT tag collections — see the
@@ -9127,16 +9146,16 @@ pub(crate) async fn person_tags_delete(
                         "_type": "ITEM_TAG",
                         "key": "flag",
                         "value": "follow-up",
-                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ROLE", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
-                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ROLE", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                        "target": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "local", "type": "SYSTEM", "id": { "_type": "HIER_OBJECT_ID", "value": "openEHRSys.example.com" } }
                     },
                     {
                         "_type": "ITEM_TAG",
                         "key": "reviewed",
                         "value": "true",
                         "target_path": "/details/items[at0001]/value",
-                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ROLE", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
-                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ROLE", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                        "target": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "local", "type": "SYSTEM", "id": { "_type": "HIER_OBJECT_ID", "value": "openEHRSys.example.com" } }
                     }
                 ])
             ))
@@ -9208,8 +9227,8 @@ pub(crate) async fn role_tags_get(
 /// Replace a `ROLE`'s `ITEM_TAG`s
 /// (`PUT /demographic/role/{uid_based_id}/tags`).
 ///
-/// "Updates the list of all ITEM_TAG resources associated with a given target
-/// ROLE version or VERSIONED_PARTY identified by `uid_based_id`" (ITS-REST
+/// "Updates the list of all `ITEM_TAG` resources associated with a given target
+/// `ROLE` version or `VERSIONED_PARTY` identified by `uid_based_id`" (ITS-REST
 /// `specifications/operations/role_tags_update.yaml`). It is a FULL COLLECTION
 /// REPLACE of the ADDRESSED collection — the container's or one version's,
 /// never both.
@@ -9409,16 +9428,16 @@ pub(crate) async fn role_tags_get(
                         "_type": "ITEM_TAG",
                         "key": "flag",
                         "value": "follow-up",
-                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ROLE", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
-                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ROLE", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                        "target": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "local", "type": "SYSTEM", "id": { "_type": "HIER_OBJECT_ID", "value": "openEHRSys.example.com" } }
                     },
                     {
                         "_type": "ITEM_TAG",
                         "key": "reviewed",
                         "value": "true",
                         "target_path": "/details/items[at0001]/value",
-                        "target": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ROLE", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } },
-                        "owner_id": { "_type": "OBJECT_REF", "namespace": "demographic", "type": "ROLE", "id": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" } }
+                        "target": { "_type": "HIER_OBJECT_ID", "value": "8849182c-82ad-4088-a07f-48ead4180515" },
+                        "owner_id": { "_type": "OBJECT_REF", "namespace": "local", "type": "SYSTEM", "id": { "_type": "HIER_OBJECT_ID", "value": "openEHRSys.example.com" } }
                     }
                 ])
             ))
@@ -9536,11 +9555,11 @@ pub(crate) async fn role_tags_update(
 /// Delete a `ROLE`'s `ITEM_TAG`s under one key
 /// (`DELETE /demographic/role/{uid_based_id}/tags/{key}`).
 ///
-/// "Deletes the ITEM_TAG resource(s) identified by `tag_key`, associated with a
-/// given target ROLE version or VERSIONED_PARTY identified by `uid_based_id`"
+/// "Deletes the `ITEM_TAG` resource(s) identified by `tag_key`, associated with a
+/// given target `ROLE` version or `VERSIONED_PARTY` identified by `uid_based_id`"
 /// (ITS-REST `specifications/operations/role_tags_delete.yaml`).
 ///
-/// A SET delete, not a single-resource delete: ITEM_TAG identity is the (`key`,
+/// A SET delete, not a single-resource delete: `ITEM_TAG` identity is the (`key`,
 /// `target_path`) pair, the route carries no `target_path` selector, and the
 /// released text says "resource(s)" — so every tag under `key` on the addressed
 /// collection goes, however many paths they carry.

--- a/app/ehrbase-rest/tests/demographic_tags_http.rs
+++ b/app/ehrbase-rest/tests/demographic_tags_http.rs
@@ -98,7 +98,7 @@ async fn send(app: &Router, req: Request<Body>) -> (StatusCode, header::HeaderMa
     )
 }
 
-/// Create a person, returning its full `version_uid` (from the create ETag).
+/// Create a person, returning its full `version_uid` (from the create `ETag`).
 async fn create_person(app: &Router) -> String {
     let req = Request::builder()
         .method("POST")

--- a/app/ehrbase-rest/tests/served_openapi.rs
+++ b/app/ehrbase-rest/tests/served_openapi.rs
@@ -801,7 +801,7 @@ async fn demographic_item_tag_operations_are_fully_documented() {
         }
     };
 
-    for (segment, rm_type) in KINDS {
+    for (segment, _rm_type) in KINDS {
         // ── get: 200/400/404/406, the dual-form prose, the served row shape ──
         let path = format!("{BASE}/{segment}/{{uid_based_id}}/tags");
         let op = doc["paths"][&path]["get"].clone();
@@ -834,12 +834,14 @@ async fn demographic_item_tag_operations_are_fully_documented() {
             "GET {path} 200 example must be an ITEM_TAG list"
         );
         assert_eq!(
-            first["target"]["type"], *rm_type,
-            "GET {path} 200 example must target {rm_type}"
+            first["target"]["_type"], "HIER_OBJECT_ID",
+            "GET {path} 200 example's container target is the bare RM \
+             UID_BASED_ID (item_tag.adoc), never an OBJECT_REF envelope"
         );
-        assert!(
-            first["owner_id"].is_object(),
-            "GET {path} 200 example must carry the server-assigned owner_id"
+        assert_eq!(
+            first["owner_id"]["type"], "SYSTEM",
+            "GET {path} 200 example's owner_id follows the released \
+             local/SYSTEM shape (register AMB-137)"
         );
         let retrieved = op["responses"]["200"]["description"]
             .as_str()

--- a/app/ehrbase-rest/tests/served_openapi.rs
+++ b/app/ehrbase-rest/tests/served_openapi.rs
@@ -697,6 +697,276 @@ async fn demographic_operations_are_fully_documented() {
     );
 }
 
+/// The Demographic API group's sixteen released `ITEM_TAG` operations are
+/// documented to full step-6 completeness: every served status branch, the
+/// dual-form `uid_based_id` prose with its disjointness reading, the
+/// `Prefer`/`Preference-Applied` pair on the five PUTs, the released-shaped
+/// examples, and — because a tag collection is not change-controlled — NO
+/// `ETag`, `Last-Modified` or `Location` anywhere on the family.
+///
+/// The five typed quintets are byte-identical on the released wire
+/// (`specifications/operations/{person,agent,group,organisation,role}_tags_{get,update,delete}.yaml`
+/// and their `$ref`d responses), so the loop asserts each kind individually — a
+/// quintet that drifts apart fails here. The space-wide
+/// `demographic_tags_get.yaml` is the delta: no scoping parameter at all, and
+/// `200`/`400` as its only released branches (there is nothing to fail to
+/// find, hence no `404`). `Resources.md` §"XML Format"/§"JSON Format" make the
+/// unfulfillable `Accept` a `406` and the unprocessable payload a `415`;
+/// `Requests_and_responses.md` §"Representation details negotiation" gives the
+/// `Prefer` split and its `Preference-Applied` echo.
+#[tokio::test]
+#[allow(clippy::too_many_lines)] // one regression test per audited group keeps the pins together
+async fn demographic_item_tag_operations_are_fully_documented() {
+    const BASE: &str = "/ehrbase/rest/openehr/v1/demographic";
+    const KINDS: &[(&str, &str)] = &[
+        ("person", "PERSON"),
+        ("agent", "AGENT"),
+        ("group", "GROUP"),
+        ("organisation", "ORGANISATION"),
+        ("role", "ROLE"),
+    ];
+
+    let doc = served_document().await;
+
+    let codes = |op: &Value| -> Vec<String> {
+        op["responses"]
+            .as_object()
+            .map(|r| r.keys().cloned().collect())
+            .unwrap_or_default()
+    };
+    let header_names = |op: &Value, status: &str| -> Vec<String> {
+        op["responses"][status]["headers"]
+            .as_object()
+            .map(|h| h.keys().cloned().collect())
+            .unwrap_or_default()
+    };
+    let first_content = |holder: &Value| -> Value {
+        holder["content"]
+            .as_object()
+            .and_then(|c| c.values().next())
+            .cloned()
+            .unwrap_or_default()
+    };
+    let require = |op: &Value, path: &str, method: &str, expected: &[&str]| {
+        let present = codes(op);
+        for want in expected {
+            assert!(
+                present.iter().any(|c| c == want),
+                "{method} {path} must document {want}; has {present:?}"
+            );
+        }
+    };
+    let text = |op: &Value| -> String {
+        format!(
+            "{} {}",
+            op.get("summary")
+                .and_then(Value::as_str)
+                .unwrap_or_default(),
+            op.get("description")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+        )
+    };
+    let param_doc = |op: &Value, name: &str| -> String {
+        op.get("parameters")
+            .and_then(Value::as_array)
+            .and_then(|params| {
+                params
+                    .iter()
+                    .find(|p| p.get("name").and_then(Value::as_str) == Some(name))
+            })
+            .and_then(|p| p.get("description").and_then(Value::as_str))
+            .unwrap_or_default()
+            .to_owned()
+    };
+    // The served example of a response, wherever the declaration put it (a
+    // media-typed `content(..)` block or the bare `example`).
+    let response_example = |resp: &Value| -> Value {
+        let via_content = first_content(resp)["example"].clone();
+        if via_content.is_null() {
+            resp["example"].clone()
+        } else {
+            via_content
+        }
+    };
+    // A tag collection has no version and no uid, so none of the
+    // change-control headers may be declared anywhere on this family.
+    let no_versioning_headers = |op: &Value, path: &str, method: &str, status: &str| {
+        for banned in ["ETag", "Last-Modified", "Location"] {
+            assert!(
+                !header_names(op, status).iter().any(|h| h == banned),
+                "{method} {path} {status} must NOT declare {banned}: an ITEM_TAG \
+                 collection is not change-controlled"
+            );
+        }
+    };
+
+    for (segment, rm_type) in KINDS {
+        // ── get: 200/400/404/406, the dual-form prose, the served row shape ──
+        let path = format!("{BASE}/{segment}/{{uid_based_id}}/tags");
+        let op = doc["paths"][&path]["get"].clone();
+        assert!(op.is_object(), "GET {path} must be documented");
+        require(&op, &path, "GET", &["200", "400", "404", "406"]);
+        no_versioning_headers(&op, &path, "GET", "200");
+        let uid = param_doc(&op, "uid_based_id");
+        assert!(
+            uid.contains("VERSIONED_PARTY") && uid.contains("version_uid"),
+            "GET {path} must carry the released dual-form uid_based_id prose; has: {uid}"
+        );
+        assert!(
+            uid.contains("DISJOINT"),
+            "GET {path} must state that the version and container collections are disjoint"
+        );
+        assert!(
+            documented_params(&op, "header")
+                .iter()
+                .any(|n| n == "Accept"),
+            "GET {path} must document the canonical Accept negotiation"
+        );
+        let rows = response_example(&op["responses"]["200"]);
+        assert!(
+            rows.is_array(),
+            "GET {path} 200 must carry a worked ITEM_TAG list example"
+        );
+        let first = rows[0].clone();
+        assert_eq!(
+            first["_type"], "ITEM_TAG",
+            "GET {path} 200 example must be an ITEM_TAG list"
+        );
+        assert_eq!(
+            first["target"]["type"], *rm_type,
+            "GET {path} 200 example must target {rm_type}"
+        );
+        assert!(
+            first["owner_id"].is_object(),
+            "GET {path} 200 example must carry the server-assigned owner_id"
+        );
+        let retrieved = op["responses"]["200"]["description"]
+            .as_str()
+            .unwrap_or_default();
+        assert!(
+            retrieved.contains("empty list"),
+            "GET {path} 200 must carry the released empty-collection sentence; has: {retrieved}"
+        );
+
+        // ── update: both Prefer branches with Preference-Applied, 415 + 422 ──
+        let op = doc["paths"][&path]["put"].clone();
+        assert!(op.is_object(), "PUT {path} must be documented");
+        require(
+            &op,
+            &path,
+            "PUT",
+            &["200", "204", "400", "404", "406", "415", "422"],
+        );
+        assert!(
+            documented_params(&op, "header")
+                .iter()
+                .any(|n| n == "Prefer"),
+            "PUT {path} must document the Prefer negotiation"
+        );
+        for status in ["200", "204"] {
+            assert!(
+                header_names(&op, status)
+                    .iter()
+                    .any(|h| h == "Preference-Applied"),
+                "PUT {path} {status} must echo the applied preference"
+            );
+            no_versioning_headers(&op, &path, "PUT", status);
+        }
+        assert!(
+            !documented_params(&op, "header")
+                .iter()
+                .any(|n| n.eq_ignore_ascii_case("if-match")),
+            "PUT {path} must NOT take If-Match: tags are not change-controlled"
+        );
+        let body = first_content(&op["requestBody"]).clone();
+        assert!(
+            body["example"][0]["key"].is_string(),
+            "PUT {path} request body must be a bare UPDATE_ITEM_TAG array example"
+        );
+        let body_doc = op["requestBody"]["description"]
+            .as_str()
+            .unwrap_or_default()
+            .to_owned();
+        assert!(
+            body_doc.contains("remove all ITEM_TAG"),
+            "PUT {path} must carry the released empty-list clear-all sentence; has: {body_doc}"
+        );
+        assert!(
+            body_doc.contains("REPLACE"),
+            "PUT {path} must state the full-collection replace semantics"
+        );
+
+        // ── delete: 204/400/404, no headers, the plural set semantics ────────
+        let path = format!("{BASE}/{segment}/{{uid_based_id}}/tags/{{key}}");
+        let op = doc["paths"][&path]["delete"].clone();
+        assert!(op.is_object(), "DELETE {path} must be documented");
+        require(&op, &path, "DELETE", &["204", "400", "404"]);
+        assert!(
+            header_names(&op, "204").is_empty(),
+            "DELETE {path} 204 carries no header at all; has {:?}",
+            header_names(&op, "204")
+        );
+        assert!(
+            text(&op).contains("resource(s)"),
+            "DELETE {path} must carry the released plural 'resource(s)' semantics"
+        );
+        let key = param_doc(&op, "key");
+        assert!(
+            key.contains("target_path"),
+            "DELETE {path} must explain that `key` alone selects every target_path"
+        );
+        let not_found = op["responses"]["404"]["description"]
+            .as_str()
+            .unwrap_or_default();
+        assert!(
+            not_found.contains("ITEM_TAG identified by the `key` does not exist"),
+            "DELETE {path} 404 must carry the released two-trigger text; has: {not_found}"
+        );
+    }
+
+    // ── the space-wide list: no scoping parameter, no 404 ────────────────────
+    let path = format!("{BASE}/tags");
+    let op = doc["paths"][&path]["get"].clone();
+    assert!(op.is_object(), "GET {path} must be documented");
+    require(&op, &path, "GET", &["200", "400", "406"]);
+    assert!(
+        !codes(&op).iter().any(|c| c == "404"),
+        "GET {path} has no scoping parameter, so nothing can be not-found"
+    );
+    assert!(
+        documented_params(&op, "path").is_empty(),
+        "GET {path} is the one tag route with no scoping path parameter"
+    );
+    for filter in ["tag_key", "tag_value", "tag_target_path"] {
+        assert!(
+            documented_params(&op, "query").iter().any(|n| n == filter),
+            "GET {path} must document the {filter} filter"
+        );
+        assert!(
+            param_doc(&op, filter).contains("carries NO description"),
+            "GET {path} must record that the released {filter} file is description-free"
+        );
+    }
+    no_versioning_headers(&op, &path, "GET", "200");
+    assert_eq!(
+        response_example(&op["responses"]["200"])[0]["_type"],
+        "ITEM_TAG",
+        "GET {path} 200 must carry a served ITEM_TAG list example"
+    );
+
+    // ── the family is complete: sixteen released ITEM_TAG operations ─────────
+    let tagged = operations(&doc)
+        .into_iter()
+        .filter(|(path, _, _)| path.starts_with(BASE) && path.contains("/tags"))
+        .count();
+    assert_eq!(
+        tagged, 16,
+        "the Demographic API serves sixteen released ITEM_TAG operations \
+         (five typed quintets + the space-wide list)"
+    );
+}
+
 /// The eight `PARTY_RELATIONSHIP` operations are OUR OWN EXTENSION: the
 /// released Demographic API defines no `party_relationship` path, so every one
 /// of them must say so in its description and none may be counted towards a


### PR DESCRIPTION
Closes #510.

Step-6 of the group-13 audit (#389): all **16** ITEM_TAG declarations (the issue title's 13 was the stale pre-extraction estimate) brought to the completeness bar.

- **Typed GET/PUT/DELETE ×5 each**: the verbatim dual-form `uid_based_id` prose (incl. the released `VERSIONED_PARTY`/`VERSIONED_OBJECT` wording split, register-carried); full-replace + the empty-list-clears sentence; `(key, target_path)` identity + last-wins + the `""`→absent normalization; Prefer 200/204 with `Preference-Applied` on both branches; delete-by-key-alone plural semantics + the `tag_key`/`{key}` released inconsistency + deliberate non-idempotence; verbatim 404 triggers widened to unknown/missing-version/wrong-kind; cross-cutting 406/415 rows (no 406 on the bodyless DELETE — nothing negotiates).
- **`demographic_tags_get`**: the unscoped whole-space delta honestly described (no scoping parameter — the only such tag route; filters whose released files carry no descriptions; `200 []`; no 404 — nothing to scope; the register-carried unbounded-scope position; the released "within given EHR" copy-paste named without being reproduced; the cross-kind list's single-kind released schema noted with a PERSON+AGENT example).
- **Adoption corrections** (the wire fix #509/PR #516 merged mid-flight): the version-item-tag header rows and the family preamble now describe the distinct-collections law; the examples' `target` is the bare RM `UID_BASED_ID` and `owner_id` the AMB-137 `local`/`SYSTEM` shape — the new `demographic_item_tag_operations_are_fully_documented` battery asserts both.
- Doc-markdown warnings healed; the battery is additive (no assertion dropped).

**Gates:** clippy `-p ehrbase-rest --all-targets` — zero warnings; nextest `-p ehrbase-rest` 548 passed / 0 failed.