### PR TITLE
fix(smart): absolute baseUrls, capability honesty, template/AQL scope enforcement, discovery-path consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **SMART App Launch conformance** (#519). The discovery document's
+  `services.*.baseUrl` values are now absolute URLs built from the new
+  required `smart.public_base_url` origin (the specification requires
+  absolute URLs); the `openehr-permission-v1` capability is advertised only
+  in fail-closed mode (`require_smart_scopes = true`) so advisory
+  deployments no longer over-claim fine-grained enforcement; operators can
+  advertise the HL7 base capabilities via `smart.endpoints.capabilities`;
+  enabling SMART now boot-validates the origin plus the
+  authorization/token endpoints; the published OpenAPI's discovery path
+  follows a configured `platform_base_url`; and — the substantive gap —
+  the **template and AQL scope families now enforce**: in fail-closed mode
+  a token without a matching `template-…`/`aql-…` scope is denied `403` on
+  the template and query routes (previously only the composition family
+  was gated).
+
 - **Demographic ITEM_TAG collections honour the released dual-form
   addressing** (#509). A version-addressed `uid_based_id` on the demographic
   tag routes now reads, replaces, and deletes that VERSION's own distinct

--- a/app/ehrbase-rest/src/extensions/access/authn/jwt.rs
+++ b/app/ehrbase-rest/src/extensions/access/authn/jwt.rs
@@ -13,7 +13,7 @@
 //! (`docs/specs/openehr/ITS-REST/docs/smart_app_launch/master06-authentication.adoc`
 //! §Supported Authentication Flows; the deprecated Implicit and
 //! Resource-Owner-Password grants that a CDR must never advertise are rejected
-//! by `crate::smart::config::SmartConfig::validate`).
+//! by `ehrbase::config::smart::SmartConfig::validate`).
 
 use std::sync::Arc;
 use std::time::Duration;

--- a/app/ehrbase-rest/src/extensions/access/pep.rs
+++ b/app/ehrbase-rest/src/extensions/access/pep.rs
@@ -170,6 +170,13 @@ pub(crate) async fn pre_check(
     op: &'static str,
     parts: &RequestParts,
 ) -> Result<(), Response> {
+    // The SMART gate for the ABAC-`Skip` resource families (template + AQL,
+    // master08 §Resource Scopes) runs FIRST and independently of the ABAC
+    // wiring: those operations never reach the ABAC-integrated `smart_gate`
+    // below (query authz lives in the query path, template ops are RBAC-only),
+    // so their fine-grained scopes are enforced here, with the resource id
+    // resolved from the route's own path parameters.
+    smart_skip_family_gate(state, op, parts)?;
     let Some(handle) = state.authz() else {
         return Ok(());
     };
@@ -636,18 +643,54 @@ fn smart_decide(
         })
 }
 
-// NOTE (SMART coverage boundary, master08 §Resource Scopes): the SMART
-// gate above rides the ABAC pre/post checks, which cover the COMPOSITION family
-// (`mode_of` → `Pre`/`Post`). The AQL and template families are ABAC-`Skip`
-// (query is handled in the query path via `query_pre`/`query_post`; template
-// ops are RBAC-only, carrying no `ResourceKind`), so their SMART resource-scope
-// enforcement (`aql-<name>`, `template-<id>`) is applied at their own dispatch
-// call sites, not here: those dispatchers hold the resolved resource id (the
-// stored `qualified_query_name`, the `{template_id}` path param) and are the
-// point that would call the pure `smart_decide` for those families. That wiring
-// lives in `crate::api::query` / `crate::api::definition` (outside this module);
-// the COMPOSITION family — the one master08 example that flows through ABAC — is
-// fully gated here.
+/// The SMART resource-scope gate for the ABAC-`Skip` families — template and
+/// AQL (master08 §Resource Scopes: `template-…`, `aql-…`). The COMPOSITION
+/// family rides the ABAC-integrated [`smart_gate`] (it needs the ABAC-resolved
+/// template id + the launch-context subject binding); these two families carry
+/// their resource id in the route itself, so the gate runs directly off the
+/// path parameters, before and independently of any ABAC wiring:
+///
+/// - template ops → the `{template_id}` path parameter (uploads and lists have
+///   none — an unresolved id matches only a broad `*`/`**` scope, the
+///   documented fail-closed reading of [`enforce::evaluate`]);
+/// - AQL definition/stored-execution ops → `{qualified_query_name}` (ad-hoc
+///   execution has none — same broad-scope rule).
+///
+/// A `patient/` compartment permit needs no per-request EHR binding here:
+/// templates are unscoped and queries are cross-EHR — per-row patient scoping
+/// stays with the ABAC query subject-scope pre-filter (register-documented),
+/// exactly as the ABAC-integrated gate treats target-less operations.
+fn smart_skip_family_gate(
+    state: &AppState,
+    op: &str,
+    parts: &RequestParts,
+) -> Result<(), Response> {
+    let Some(cfg) = smart_config(state) else {
+        return Ok(());
+    };
+    let family = enforce::family_of_op(op);
+    if !matches!(
+        family,
+        Some(
+            openehr_its::rest::smart_scopes::ResourceFamily::Template
+                | openehr_its::rest::smart_scopes::ResourceFamily::Aql
+        )
+    ) {
+        return Ok(());
+    }
+    let principal = current_principal().unwrap_or_else(fallback_principal);
+    let resource_id = parts
+        .path
+        .get("template_id")
+        .or_else(|| parts.path.get("qualified_query_name"))
+        .map(String::as_str);
+    match smart_decide(cfg, &principal, op, resource_id) {
+        Err(reason) => Err(forbidden(&principal, &reason)),
+        // Permitted — including through a `patient/` compartment, whose EHR
+        // binding is vacuous for these target-less families (see the doc).
+        Ok(_) => Ok(()),
+    }
+}
 
 #[cfg(test)]
 #[allow(

--- a/app/ehrbase-rest/src/extensions/openapi.rs
+++ b/app/ehrbase-rest/src/extensions/openapi.rs
@@ -131,7 +131,12 @@ pub fn extensions_document(cfg: &AppConfig) -> utoipa::openapi::OpenApi {
     // discovery, the OAS meta-endpoints.
     doc.merge(health::openapi());
     doc.merge(status::openapi());
-    doc.merge(smart_discovery::openapi());
+    let rest_root = cfg
+        .server
+        .base_path
+        .strip_suffix("/openehr/v1")
+        .unwrap_or(&cfg.server.base_path);
+    doc.merge(smart_discovery::openapi(cfg, rest_root));
     // The System API's OPTIONS operation — a closure route mounted outside
     // OpenApiRouter (above CORS), documented via its twin (#418).
     doc.merge(crate::api::system::options::openapi());

--- a/app/ehrbase-rest/src/smart/discovery.rs
+++ b/app/ehrbase-rest/src/smart/discovery.rs
@@ -5,9 +5,10 @@
 //! *Platform* base URL, master04 §Service Discovery ¶3-4), advertising the
 //! external Authorization-Server endpoints, the `services` map (with the
 //! required `org.openehr.rest`), the SMART `capabilities`, and the enforced
-//! scope set. The document is **assembled from [`super::config::SmartConfig`]**
+//! scope set. The document is **assembled from [`SmartConfig`]**
 //! — the CDR advertises only what it (or its configured AS) actually offers; it
-//! implements none of the `OAuth2` endpoints (`smart.md` §1/§6 NOTEs).
+//! implements none of the `OAuth2` endpoints (those are Authorization-Server
+//! duties — master02 §Glossary, master06/master07).
 //!
 //! The response is `application/json` (master04 §Service Discovery, R-02) and is
 //! served **pre-auth**, on the same seam as the status router
@@ -105,11 +106,16 @@ pub struct Service {
 
 /// Build the discovery document from configuration.
 ///
-/// - `openehr_base_url` is the CDR's openEHR REST base (the one value the CDR
-///   authoritatively owns — `services.org.openehr.rest.baseUrl`, R-04).
+/// - `openehr_base_url` is the CDR's openEHR REST base path (the one value the
+///   CDR authoritatively owns — `services.org.openehr.rest.baseUrl`, R-04).
 /// - `fhir_base_url` populates `org.fhir.rest` when present (recommended).
 /// - `issuer_fallback` is used for `issuer` when `endpoints.issuer` is unset
 ///   (the configured OIDC bearer issuer, `auth.oidc.issuer`).
+///
+/// Every `services.*.baseUrl` is emitted ABSOLUTE (master04 §Services:
+/// "Absolute URL to the root of the API `*(required)*`"): a relative base path
+/// is prefixed with the configured external origin
+/// (`SmartConfig::public_base_url`, boot-required when SMART is enabled).
 #[must_use]
 pub fn build_document(
     cfg: &SmartConfig,
@@ -124,7 +130,7 @@ pub fn build_document(
     services.insert(
         "org.openehr.rest".to_owned(),
         Service {
-            base_url: openehr_base_url.to_owned(),
+            base_url: absolute_base(cfg, openehr_base_url),
             description: Some("The openEHR REST API baseUrl".to_owned()),
             version: None,
             documentation: None,
@@ -136,7 +142,7 @@ pub fn build_document(
         services.insert(
             "org.fhir.rest".to_owned(),
             Service {
-                base_url: fhir.to_owned(),
+                base_url: absolute_base(cfg, fhir),
                 description: Some("The FHIR APIs baseUrl".to_owned()),
                 version: None,
                 documentation: None,
@@ -168,22 +174,47 @@ pub fn build_document(
 }
 
 /// The advertised capabilities — **only** those the CDR actually enforces
-/// (master04 §Capabilities, R-05). `context-openehr-ehr` + `openehr-permission-v1`
-/// are always present (the CDR binds the `ehrId` launch context and enforces the
-/// fine-grained resource scopes); the two experimental capabilities are gated on
-/// their sub-flags.
+/// (master04 §Capabilities, R-05/R-07). `context-openehr-ehr` is always present
+/// (the CDR binds the `ehrId` launch context); `openehr-permission-v1` is
+/// advertised ONLY in fail-closed mode (`require_smart_scopes`) — the
+/// capability "Indicates support for fine-grained scopes and authorization
+/// scheme over openEHR resources", and advisory mode does not enforce against
+/// a scope-less caller, so advertising it there would over-claim. The two
+/// experimental capabilities are gated on their sub-flags, and the operator's
+/// `endpoints.capabilities` (the HL7-defined base capabilities the external
+/// framework owns — "In addition to those scopes defined in the original SMART
+/// App Launch framework") are appended, deduplicated.
 fn capabilities(cfg: &SmartConfig) -> Vec<String> {
-    let mut caps = vec![
-        "context-openehr-ehr".to_owned(),
-        "openehr-permission-v1".to_owned(),
-    ];
+    let mut caps = vec!["context-openehr-ehr".to_owned()];
+    if cfg.require_smart_scopes {
+        caps.push("openehr-permission-v1".to_owned());
+    }
     if cfg.episode.enabled {
         caps.push("context-openehr-episode".to_owned());
     }
     if cfg.launch_base64_json {
         caps.push("launch-base64-json".to_owned());
     }
+    for extra in &cfg.endpoints.capabilities {
+        if !caps.contains(extra) {
+            caps.push(extra.clone());
+        }
+    }
     caps
+}
+
+/// Make a base path absolute by prefixing the configured external origin
+/// (master04 §Services: `baseUrl` is an "Absolute URL"). An already-absolute
+/// value passes through; a missing origin (impossible on a validated enabled
+/// config) leaves the path as-is rather than fabricating one.
+fn absolute_base(cfg: &SmartConfig, base: &str) -> String {
+    if base.starts_with("http://") || base.starts_with("https://") {
+        return base.to_owned();
+    }
+    match cfg.public_base_url.as_deref() {
+        Some(origin) => format!("{}{base}", origin.trim_end_matches('/')),
+        None => base.to_owned(),
+    }
 }
 
 /// The advertised `scopes_supported` — the operator override when set, else a
@@ -304,13 +335,24 @@ async fn smart_configuration(State(state): State<AppState>) -> Json<SmartConfigu
     ))
 }
 
-/// The SMART discovery document's `OpenAPI` (path at the default REST root;
-/// config-gated: `EHRBASE_REST_SMART__ENABLED`). Served pre-auth. Spec:
-/// ITS-REST `smart_app_launch/master04`.
-pub(crate) fn openapi() -> utoipa::openapi::OpenApi {
-    OpenApiRouter::<AppState>::new()
+/// The SMART discovery document's `OpenAPI`, its path derived from the SAME
+/// [`discovery_path`] the live mount uses (a configured `platform_base_url`
+/// moves the served path, and the published document must follow — the
+/// `#[utoipa::path]` literal is only the default-root spelling). Config-gated:
+/// `EHRBASE_REST_SMART__ENABLED`. Served pre-auth. Spec: ITS-REST
+/// `smart_app_launch/master04`.
+pub(crate) fn openapi(cfg: &AppConfig, rest_root: &str) -> utoipa::openapi::OpenApi {
+    let mut doc = OpenApiRouter::<AppState>::new()
         .routes(routes!(smart_configuration))
-        .into_openapi()
+        .into_openapi();
+    let live = discovery_path(&cfg.smart, rest_root);
+    let declared = "/ehrbase/rest/.well-known/smart-configuration";
+    if live != declared
+        && let Some(item) = doc.paths.paths.remove(declared)
+    {
+        doc.paths.paths.insert(live, item);
+    }
+    doc
 }
 
 #[cfg(test)]
@@ -326,6 +368,7 @@ mod tests {
     fn enabled_cfg() -> SmartConfig {
         let mut c = SmartConfig {
             enabled: true,
+            public_base_url: Some("https://cdr.example.com".to_owned()),
             ..SmartConfig::default()
         };
         c.endpoints.authorization_endpoint = Some("https://as.example/authorize".to_owned());
@@ -351,15 +394,21 @@ mod tests {
             .services
             .get("org.openehr.rest")
             .expect("openehr service");
-        assert_eq!(openehr.base_url, "/ehrbase/rest/openehr/v1");
+        // master04 §Services: baseUrl is an ABSOLUTE URL.
+        assert_eq!(
+            openehr.base_url,
+            "https://cdr.example.com/ehrbase/rest/openehr/v1"
+        );
         // fhir.rest omitted when no FHIR base configured.
         assert!(!doc.services.contains_key("org.fhir.rest"));
         // issuer falls back to the OIDC issuer.
         assert_eq!(doc.issuer.as_deref(), Some("https://as.example"));
         // R-05 baseline capabilities.
         assert!(doc.capabilities.contains(&"context-openehr-ehr".to_owned()));
+        // Advisory mode (require_smart_scopes = false) must NOT claim the
+        // fine-grained enforcement capability (master04 §Capabilities).
         assert!(
-            doc.capabilities
+            !doc.capabilities
                 .contains(&"openehr-permission-v1".to_owned())
         );
         // experimental caps are off by default.
@@ -380,7 +429,7 @@ mod tests {
             None,
         );
         let fhir = doc.services.get("org.fhir.rest").expect("fhir service");
-        assert_eq!(fhir.base_url, "/fhir/r4");
+        assert_eq!(fhir.base_url, "https://cdr.example.com/fhir/r4");
     }
 
     #[test]
@@ -412,6 +461,37 @@ mod tests {
         c.endpoints.scopes_supported = vec!["openid".to_owned(), "patient/*.rs".to_owned()];
         let doc = build_document(&c, "/openehr", None, None);
         assert_eq!(doc.scopes_supported, vec!["openid", "patient/*.rs"]);
+    }
+
+    #[test]
+    fn permission_capability_rides_fail_closed_mode() {
+        let mut c = enabled_cfg();
+        c.require_smart_scopes = true;
+        let doc = build_document(&c, "/openehr", None, None);
+        assert!(
+            doc.capabilities
+                .contains(&"openehr-permission-v1".to_owned())
+        );
+    }
+
+    #[test]
+    fn operator_capabilities_append_deduplicated() {
+        let mut c = enabled_cfg();
+        c.endpoints.capabilities = vec![
+            "launch-ehr".to_owned(),
+            "sso-openid-connect".to_owned(),
+            "context-openehr-ehr".to_owned(), // duplicate of a derived one
+        ];
+        let doc = build_document(&c, "/openehr", None, None);
+        assert!(doc.capabilities.contains(&"launch-ehr".to_owned()));
+        assert!(doc.capabilities.contains(&"sso-openid-connect".to_owned()));
+        assert_eq!(
+            doc.capabilities
+                .iter()
+                .filter(|c| *c == "context-openehr-ehr")
+                .count(),
+            1
+        );
     }
 
     #[test]
@@ -448,7 +528,7 @@ mod tests {
         // master04 uses the camelCase `baseUrl` key.
         assert_eq!(
             json["services"]["org.openehr.rest"]["baseUrl"],
-            serde_json::json!("/openehr")
+            serde_json::json!("https://cdr.example.com/openehr")
         );
         // deprecated grant flows never appear (they're rejected at validate()).
         assert_eq!(

--- a/app/ehrbase-rest/src/smart/enforce.rs
+++ b/app/ehrbase-rest/src/smart/enforce.rs
@@ -27,7 +27,7 @@ use crate::extensions::access::authz::request::{AccessMode, ResourceKind};
 
 use openehr_its::rest::smart_scopes::{Compartment, Permission, ResourceFamily, SmartScope};
 
-/// Configuration the gate needs (a slice of [`super::config::SmartConfig`]).
+/// Configuration the gate needs (a slice of `ehrbase::config::smart::SmartConfig`).
 #[derive(Debug, Clone, Copy)]
 pub struct GateConfig {
     /// Fail-closed when the token carries no matching SMART resource scope for a
@@ -80,10 +80,11 @@ impl ScopeOutcome {
 /// §Resource Scopes: `template-…`, `composition-…`, `aql-…`).
 ///
 /// `None` for operation families the master08 grammar defines **no** resource
-/// scope for — EHR, `EHR_STATUS`, CONTRIBUTION, DIRECTORY. NOTE
-/// (`smart.md` §6): master08 lists only three resource types, so those
-/// operations are governed by the compartment binding + the existing RBAC/ABAC
-/// layers, not by a SMART resource scope; the SMART gate does not deny them.
+/// scope for — EHR, `EHR_STATUS`, CONTRIBUTION, DIRECTORY. NOTE: master08
+/// §Resource Scopes lists exactly three resource types, so those operations
+/// are governed by the compartment binding + the existing RBAC/ABAC layers,
+/// not by a SMART resource scope; the SMART gate does not deny them
+/// (register-documented — the out-of-noun silence).
 #[must_use]
 pub fn family_of_op(op: &str) -> Option<ResourceFamily> {
     if op.starts_with("composition_") || op.starts_with("versioned_composition_") {
@@ -243,7 +244,7 @@ pub fn launch_context_ehr_id(
 
 /// Whether the caller requested a `launch/patient` context (master07). Advisory:
 /// context *selection* is an Authorization-Server/Launcher duty (out of CDR
-/// scope, `smart.md` §1); the CDR only observes the marker.
+/// scope — master07 §SMART Authorization Flow); the CDR only observes the marker.
 #[must_use]
 pub fn requests_patient_context(scopes: &[SmartScope]) -> bool {
     use openehr_its::rest::smart_scopes::LaunchContext;

--- a/app/ehrbase-rest/src/smart/mod.rs
+++ b/app/ehrbase-rest/src/smart/mod.rs
@@ -9,17 +9,19 @@
 //!
 //! - [`discovery`] — the `/.well-known/smart-configuration` document
 //!   (master04 §Service Discovery), served pre-auth;
-//! - [`scope`] — the master08 resource-scope grammar
-//!   (`compartment/resource.permission`, `*`/`**`/`ns::*` patterns) parsed
-//!   from the validated token's `scope` claim;
+//! - the master08 resource-scope grammar
+//!   (`compartment/resource.permission`, `*`/`**`/`ns::*` patterns) —
+//!   `openehr_its::rest::smart_scopes`, parsed from the validated token's
+//!   `scope` claim;
 //! - [`enforce`] — scope enforcement riding the existing ABAC PEP
 //!   ([`crate::extensions::access::pep`]), AND-composed after RBAC/Cedar, plus the
 //!   `ehrId`/`patient` launch-context binding (master07/master09).
 //!
 //! Registration (master03), token issuance/grants/PKCE (master06), and
 //! launch-sequence UI (master07) are Authorization-Server/Launcher duties —
-//! out of scope for a CDR, recorded as NOTEs in the register.
-//! Config-gated ([`config`]): off by default, zero wire drift when disabled.
+//! out of scope for a CDR, recorded in the conformance register.
+//! Config-gated (`ehrbase::config::smart::SmartConfig`): off by default, zero
+//! wire drift when disabled.
 
 pub mod discovery;
 pub mod enforce;

--- a/app/ehrbase-rest/tests/smart_http.rs
+++ b/app/ehrbase-rest/tests/smart_http.rs
@@ -1,0 +1,191 @@
+#![allow(
+    clippy::panic,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    let_underscore_drop
+)] // test assertions/diagnostics/fixtures
+//! End-to-end HTTP tests for the SMART App Launch surface (group-15 audit,
+//! #391): the discovery document's absolute `baseUrl`s (master04 §Services:
+//! "Absolute URL to the root of the API `*(required)*`"), the honest
+//! `capabilities` (`openehr-permission-v1` only in fail-closed mode), and the
+//! fail-closed template/AQL scope enforcement (master08 §Resource Scopes —
+//! the previously-inert two of the three resource families).
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use axum::Router;
+use axum::body::Body;
+use http::{Request, StatusCode, header};
+use http_body_util::BodyExt;
+use serde_json::Value;
+use tower::ServiceExt;
+
+use ehrbase::config::auth::AuthConfig;
+use ehrbase::config::server::ServerConfig;
+use ehrbase_rest::config::AppConfig;
+
+mod common;
+
+const BASE: &str = "/ehrbase/rest/openehr/v1";
+
+fn config(smart_enabled: bool, fail_closed: bool) -> AppConfig {
+    let mut cfg = AppConfig {
+        server: ServerConfig {
+            bind: "127.0.0.1:0".to_owned(),
+            base_path: BASE.to_owned(),
+            max_in_flight: 1024,
+            swagger_ui: false,
+            cors_permissive: false,
+            ..Default::default()
+        },
+        auth: AuthConfig {
+            enabled: false,
+            basic: None,
+            oidc: None,
+            admin_scope: None,
+            ..AuthConfig::default()
+        },
+        ..Default::default()
+    };
+    cfg.smart.enabled = smart_enabled;
+    cfg.smart.require_smart_scopes = fail_closed;
+    cfg.smart.public_base_url = Some("https://cdr.example.com".to_owned());
+    cfg.smart.endpoints.authorization_endpoint = Some("https://as.example/authorize".to_owned());
+    cfg.smart.endpoints.token_endpoint = Some("https://as.example/token".to_owned());
+    cfg
+}
+
+async fn app(smart_enabled: bool, fail_closed: bool) -> (testkit::TestDb, Router) {
+    let (pg, service) = common::test_service().await;
+    (
+        pg,
+        common::router_with(config(smart_enabled, fail_closed), service),
+    )
+}
+
+async fn send(app: &Router, req: Request<Body>) -> (StatusCode, String) {
+    let resp = app.clone().oneshot(req).await.expect("response");
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.expect("body").to_bytes();
+    (status, String::from_utf8_lossy(&bytes).into_owned())
+}
+
+fn get(uri: &str) -> Request<Body> {
+    Request::builder()
+        .method("GET")
+        .uri(uri)
+        .header(header::ACCEPT, "application/json")
+        .body(Body::empty())
+        .unwrap()
+}
+
+// ── discovery ─────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn discovery_serves_absolute_base_urls() {
+    let (_pg, app) = app(true, false).await;
+    let (status, body) = send(&app, get("/ehrbase/rest/.well-known/smart-configuration")).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let doc: Value = serde_json::from_str(&body).unwrap();
+    let base = doc["services"]["org.openehr.rest"]["baseUrl"]
+        .as_str()
+        .expect("baseUrl");
+    assert!(
+        base.starts_with("https://cdr.example.com/"),
+        "master04 §Services: baseUrl is an Absolute URL — got {base}"
+    );
+}
+
+#[tokio::test]
+async fn discovery_absent_when_disabled() {
+    let (_pg, app) = app(false, false).await;
+    let (status, _b) = send(&app, get("/ehrbase/rest/.well-known/smart-configuration")).await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "zero wire drift when off");
+}
+
+#[tokio::test]
+async fn permission_capability_only_in_fail_closed_mode() {
+    let (_pg, advisory) = app(true, false).await;
+    let (_s, body) = send(
+        &advisory,
+        get("/ehrbase/rest/.well-known/smart-configuration"),
+    )
+    .await;
+    let doc: Value = serde_json::from_str(&body).unwrap();
+    let caps: Vec<&str> = doc["capabilities"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(Value::as_str)
+        .collect();
+    assert!(
+        !caps.contains(&"openehr-permission-v1"),
+        "advisory mode must not claim fine-grained enforcement: {caps:?}"
+    );
+
+    let (_pg2, strict) = app(true, true).await;
+    let (_s, body) = send(
+        &strict,
+        get("/ehrbase/rest/.well-known/smart-configuration"),
+    )
+    .await;
+    let doc: Value = serde_json::from_str(&body).unwrap();
+    let caps: Vec<&str> = doc["capabilities"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(Value::as_str)
+        .collect();
+    assert!(
+        caps.contains(&"openehr-permission-v1"),
+        "fail-closed mode advertises the enforcement it performs: {caps:?}"
+    );
+}
+
+// ── the template + AQL families enforce in fail-closed mode ─────────────────
+
+#[tokio::test]
+async fn fail_closed_denies_scopeless_template_access() {
+    let (_pg, app) = app(true, true).await;
+    // Auth is disabled, so the caller holds no SMART resource scopes at all —
+    // fail-closed mode (master08 §Scopes ¶2: "The Platform must validate
+    // requested scopes…") denies the template family.
+    let (status, body) = send(&app, get(&format!("{BASE}/definition/template/adl1.4"))).await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "a scope-less caller is denied the template family: {body}"
+    );
+}
+
+#[tokio::test]
+async fn fail_closed_denies_scopeless_query_access() {
+    let (_pg, app) = app(true, true).await;
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("{BASE}/query/aql"))
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(r#"{"q": "SELECT e/ehr_id/value FROM EHR e"}"#))
+        .unwrap();
+    let (status, body) = send(&app, req).await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "a scope-less caller is denied the AQL family: {body}"
+    );
+}
+
+#[tokio::test]
+async fn advisory_mode_defers_for_scopeless_callers() {
+    let (_pg, app) = app(true, false).await;
+    // Advisory mode: no SMART scope for the family → the gate defers to
+    // RBAC/ABAC; the list serves normally.
+    let (status, body) = send(&app, get(&format!("{BASE}/definition/template/adl1.4"))).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+}
+
+#[tokio::test]
+async fn smart_disabled_leaves_families_ungated() {
+    let (_pg, app) = app(false, false).await;
+    let (status, body) = send(&app, get(&format!("{BASE}/definition/template/adl1.4"))).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+}

--- a/app/ehrbase/assets/ehrbase.default.toml
+++ b/app/ehrbase/assets/ehrbase.default.toml
@@ -131,6 +131,7 @@ claim = "tenant"
 [smart]
 enabled = false
 #? platform_base_url = "/gateway/v1"
+#? public_base_url = "https://cdr.example.com"   # REQUIRED when enabled: the external origin the absolute services.*.baseUrl values are built from (master04 §Services)
 ehr_id_claim = "ehrId"
 patient_claim = "patient"
 require_smart_scopes = false
@@ -145,6 +146,7 @@ grant_types_supported = []
 response_types_supported = []
 code_challenge_methods_supported = []
 scopes_supported = []
+capabilities = []   # extra (HL7 base) capabilities to advertise, e.g. ["launch-ehr", "sso-openid-connect"]
 #? issuer = "https://as.example"
 #? jwks_uri = "https://as.example/jwks"
 #? authorization_endpoint = "https://as.example/authorize"

--- a/app/ehrbase/src/config/smart.rs
+++ b/app/ehrbase/src/config/smart.rs
@@ -38,6 +38,14 @@ pub struct SmartConfig {
     #[serde(default)]
     pub platform_base_url: Option<String>,
 
+    /// The server's externally-reachable origin (scheme + host [+ port]), e.g.
+    /// `https://cdr.example.com`. master04 §Services makes every `services.*`
+    /// entry's `baseUrl` an **"Absolute URL to the root of the API (required)"**,
+    /// so the discovery document prefixes this origin onto the served base
+    /// paths. REQUIRED when SMART is enabled ([`Self::validate`]).
+    #[serde(default)]
+    pub public_base_url: Option<String>,
+
     /// The token claim carrying the resolved openEHR `EHR` id for the launch
     /// context (master07 §Context Selection token-response table: `ehrId`).
     /// Default `ehrId`.
@@ -65,7 +73,7 @@ pub struct SmartConfig {
     /// `context-openehr-episode` and accepts the `launch/episode` scope +
     /// `episodeId` claim, but applies **no** episode-scoped filtering (openEHR
     /// has no first-class Episode resource yet; master09 states the semantics
-    /// are "currently implementation-defined"). NOTE, `smart.md` §6.
+    /// are "currently implementation-defined").
     #[serde(default)]
     pub episode: EpisodeConfig,
 
@@ -143,6 +151,14 @@ pub struct SmartEndpoints {
     /// list reflecting the scopes the CDR actually enforces.
     #[serde(default)]
     pub scopes_supported: Vec<String>,
+    /// `capabilities` the operator additionally advertises (the HL7-defined base
+    /// capabilities — `launch-ehr`, `sso-openid-connect`, `client-public`, … —
+    /// live in the external SMART App Launch framework; master04 §Capabilities:
+    /// the openEHR list is "In addition to those scopes defined in the original
+    /// SMART App Launch framework"). Appended to the openEHR capabilities the
+    /// CDR derives itself; duplicates are dropped.
+    #[serde(default)]
+    pub capabilities: Vec<String>,
 }
 
 impl Default for SmartConfig {
@@ -150,6 +166,7 @@ impl Default for SmartConfig {
         Self {
             enabled: false,
             platform_base_url: None,
+            public_base_url: None,
             ehr_id_claim: default_ehr_id_claim(),
             patient_claim: default_patient_claim(),
             require_smart_scopes: false,
@@ -161,13 +178,21 @@ impl Default for SmartConfig {
 }
 
 impl SmartConfig {
-    /// Boot validation (master06 §Deprecated Flows): the CDR must never advertise
-    /// the Implicit or Resource-Owner-Password grants. Returns the offending
-    /// grant name.
+    /// Boot validation.
+    ///
+    /// - master06 §Deprecated Flows: the CDR must never advertise the Implicit
+    ///   or Resource-Owner-Password grants.
+    /// - When SMART is enabled: `public_base_url` is required (master04
+    ///   §Services — `baseUrl` is an "Absolute URL … (required)", buildable
+    ///   only from a known external origin), and the three core
+    ///   Authorization-Server endpoints must be present — `issuer`,
+    ///   `authorization_endpoint`, `token_endpoint` (master04 §Authentication
+    ///   Endpoints delegates their requiredness to OIDC Discovery / the HL7
+    ///   SMART metadata, both of which require them; an enabled Platform
+    ///   without them serves an unusable document).
     ///
     /// # Errors
-    /// A message naming a deprecated grant type present in
-    /// `endpoints.grant_types_supported`.
+    /// A message naming the offending grant type or the missing required field.
     pub fn validate(&self) -> Result<(), String> {
         for grant in &self.endpoints.grant_types_supported {
             let g = grant.to_ascii_lowercase();
@@ -176,6 +201,27 @@ impl SmartConfig {
                     "grant type '{grant}' is deprecated and MUST NOT be advertised \
                      (master06 §Deprecated Flows)"
                 ));
+            }
+        }
+        if self.enabled {
+            let origin = self.public_base_url.as_deref().unwrap_or("");
+            if !(origin.starts_with("http://") || origin.starts_with("https://")) {
+                return Err("smart.public_base_url (an absolute http(s) origin, e.g. \
+                     'https://cdr.example.com') is required when SMART is \
+                     enabled — master04 §Services makes every services.*.baseUrl \
+                     an absolute URL"
+                    .to_owned());
+            }
+            if self.endpoints.authorization_endpoint.is_none()
+                || self.endpoints.token_endpoint.is_none()
+            {
+                return Err(
+                    "smart.endpoints.authorization_endpoint and .token_endpoint \
+                     are required when SMART is enabled (master04 \
+                     §Authentication Endpoints via OIDC Discovery / HL7 SMART \
+                     metadata requiredness)"
+                        .to_owned(),
+                );
             }
         }
         Ok(())
@@ -219,6 +265,8 @@ mod tests {
         let c = SmartConfig::default();
         assert!(!c.enabled);
         assert!(c.platform_base_url.is_none());
+        assert!(c.public_base_url.is_none());
+        assert!(c.endpoints.capabilities.is_empty());
         assert_eq!(c.ehr_id_claim, "ehrId");
         assert_eq!(c.patient_claim, "patient");
         assert!(!c.require_smart_scopes);
@@ -237,6 +285,25 @@ mod tests {
         assert!(c.validate().is_err());
 
         c.endpoints.grant_types_supported = vec!["PASSWORD".to_owned()];
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn enabled_requires_origin_and_core_endpoints() {
+        let mut c = SmartConfig {
+            enabled: true,
+            ..SmartConfig::default()
+        };
+        // Missing everything → the origin requirement fires first.
+        assert!(c.validate().is_err());
+        c.public_base_url = Some("https://cdr.example.com".to_owned());
+        // Origin present but no AS endpoints → still an error.
+        assert!(c.validate().is_err());
+        c.endpoints.authorization_endpoint = Some("https://as.example/authorize".to_owned());
+        c.endpoints.token_endpoint = Some("https://as.example/token".to_owned());
+        assert!(c.validate().is_ok());
+        // A relative origin is not an absolute URL.
+        c.public_base_url = Some("/ehrbase".to_owned());
         assert!(c.validate().is_err());
     }
 }

--- a/website/book/src/installation/configuration.md
+++ b/website/book/src/installation/configuration.md
@@ -338,16 +338,26 @@ SMART App Launch. Off by default; when off the discovery document is not served
 and the scope gate is inert. See [SMART App Launch](../smart-app-launch.md).
 
 `[smart]`: `enabled` (bool, `false`), `platform_base_url` (string, unset ⇒ REST
-root), `ehr_id_claim` (string, `ehrId`), `patient_claim` (string, `patient`),
-`require_smart_scopes` (bool, `false`), `launch_base64_json` (bool, `false`).
+root), `public_base_url` (string, **required when enabled** — the external
+origin, e.g. `https://cdr.example.com`, from which the discovery document's
+absolute `services.*.baseUrl` values are built), `ehr_id_claim` (string,
+`ehrId`), `patient_claim` (string, `patient`), `require_smart_scopes` (bool,
+`false` — when `true` the SMART resource-scope gate is fail-closed across the
+composition, template, and AQL families, and the `openehr-permission-v1`
+capability is advertised; when `false` the gate is advisory and the capability
+is not claimed), `launch_base64_json` (bool, `false`).
 `[smart.episode]`: `enabled` (bool, `false`).
 `[smart.endpoints]`: `issuer`, `jwks_uri`, `authorization_endpoint`,
 `token_endpoint`, `registration_endpoint`, `introspection_endpoint`,
 `revocation_endpoint`, `management_endpoint` (all string, unset ⇒ omitted from
 the discovery document); `token_endpoint_auth_methods_supported`,
 `grant_types_supported`, `response_types_supported`,
-`code_challenge_methods_supported`, `scopes_supported` (all list of string,
-`[]`). Deprecated grant types (`implicit`/password) are rejected at boot.
+`code_challenge_methods_supported`, `scopes_supported`, `capabilities` (all
+list of string, `[]` — `capabilities` appends operator-advertised HL7 base
+capabilities such as `launch-ehr`/`sso-openid-connect` to the derived openEHR
+set). Deprecated grant types (`implicit`/password) are rejected at boot;
+`enabled = true` additionally requires `public_base_url`,
+`authorization_endpoint`, and `token_endpoint` at boot.
 
 ## `[management]`
 


### PR DESCRIPTION
Closes #519.

Group-15 audit findings D-1…D-8 (#391 findings comment carries every file:line + released sentence). The grammar and gating were verified faithful; these are the divergences:

- **D-2**: `services.*.baseUrl` served origin-relative where master04 §Services requires "Absolute URL to the root of the API `*(required)*`" — the new `smart.public_base_url` origin (boot-required when enabled) builds the absolute values.
- **D-4/D-3**: `openehr-permission-v1` now advertised only in fail-closed mode (no over-claim in advisory mode); `smart.endpoints.capabilities` lets operators append the HL7 base capabilities the external framework owns.
- **D-1**: boot validation — `enabled ⇒ public_base_url + authorization_endpoint + token_endpoint` (the OIDC/HL7 requiredness boundary realized as config validation, per the register's B-2 scope statement).
- **D-5 (the substantive gap)**: the TEMPLATE and AQL scope families were parsed but never enforced — five of eight master08 maximal-table rows were inert; even fail-closed mode let a scope-less token upload templates and run queries. A new `smart_skip_family_gate` in the PEP pre-check enforces them off the route's own path parameters (uploads/ad-hoc have no path id — the documented broad-scope-only rule), before and independently of the ABAC wiring; the prose-deferral NOTE (D-6a, a TODO-rule violation) is replaced by the implementation.
- **D-7**: the served OpenAPI's discovery path derives from the same `discovery_path` as the live mount.
- **D-6/D-8**: the four dead `smart.md` citations re-grounded on the master chapters; broken intra-doc links fixed.

Config schema changes ship with the default-TOML template + the book page in the same PR (the config rule).

**Tests:** the new `smart_http.rs` battery (7) — absolute baseUrls, zero wire drift when off, per-mode capability honesty, **fail-closed 403 on scope-less template/query access** (the D-5 proof), advisory deferral; plus the extended discovery/config unit batteries.

**Gates:** clippy (both crates, all targets) — zero warnings; nextest `-p ehrbase -p ehrbase-rest` 1196 passed / 0 failed (one known-flaky multimedia_s3 retry).