### PR TITLE
fix(admin): served OpenAPI completeness for the admin operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,26 @@ workflow refuses a tag that has no matching section here.
   the template and query routes (previously only the composition family
   was gated).
 
+- **The published API reference now describes the admin endpoints in full,
+  and the disabled-admin answer is documented correctly** (#513). The five
+  admin operations — the released `DELETE /admin/ehr/{ehr_id}` and
+  `DELETE /admin/ehr/all`, plus the template-delete, stored-query-version-
+  delete and effective-config extensions — gained the branches they actually
+  answer (`400` for a malformed EHR id, `401`/`403` from the admin role gate,
+  `404`, the template `409`), the mandatory empty `Allow` header on every
+  disabled-group `405`, and worked request/response examples. They now carry
+  the released operation text verbatim, including the permanent-physical-
+  delete cascade and its data-protection (GDPR) sentence, the
+  development/testing note on the bulk route, and the fact that this server
+  deletes synchronously (`204` only — the specification's optional
+  asynchronous `202` is never returned). The bulk route documents both
+  accepted query forms (`?ehr_id=a&ehr_id=b` and `?ehr_id=a,b`) and that an
+  absent or empty list deletes every EHR; the three extension routes are
+  flagged plainly as our own, governed by no openEHR operation. Reference
+  documentation and configuration docs that claimed a disabled admin API
+  answers `404` were corrected: it answers `405 Method Not Allowed` with an
+  empty `Allow` header.
+
 - **Demographic ITEM_TAG collections honour the released dual-form
   addressing** (#509). A version-addressed `uid_based_id` on the demographic
   tag routes now reads, replaces, and deletes that VERSION's own distinct

--- a/app/ehrbase-rest/src/api/admin/dispatch.rs
+++ b/app/ehrbase-rest/src/api/admin/dispatch.rs
@@ -1,14 +1,16 @@
-//! HTTP dispatch for the `admin` API group (physical EHR delete) over the
-//! [`AdminService`](ehrbase::service::AdminService) seam.
+//! HTTP dispatch for the `admin` API group, over the concrete
+//! `ehrbase::service::EhrbaseService` admin methods.
 //!
-//! Maturity: the ITS-REST Admin API is **`DEVELOPMENT`** (`admin.openapi.yaml`
-//! `info.version: development`, `x-status: DEVELOPMENT`). It mounts exactly two
-//! operations — both physical EHR delete — and both are dispatched here; there
-//! are **no extension routes** in this group (the other SM admin capabilities —
-//! party delete, statistics, archive, dump/load — have no ITS-REST binding and
-//! stay native-API-only on the `ehrbase-sm` seam).
+//! Maturity: the ITS-REST Admin API is **`DEVELOPMENT`**
+//! (`specifications/docs/admin/Description.md` §Status: "This specification is
+//! in the `DEVELOPMENT` state"). It mounts exactly two operations — both
+//! physical EHR delete — and both are dispatched here, alongside three of OUR
+//! OWN extension routes (template delete, stored-query-version delete, the
+//! redacted config read), which no ITS-REST operation governs. The remaining SM
+//! admin capabilities (party delete, statistics, archive, dump/load) have no
+//! ITS-REST binding and are not surfaced by this group at all.
 //!
-//! Spec grounding (both operations are vendored — `admin.openapi.yaml:24-30`,
+//! Spec grounding (both operations are vendored — `admin.openapi.yaml`,
 //! `security: []` so auth is out of band, SM master02):
 //! - `admin_ehr_delete` — `operations/admin_ehr_delete.yaml`: `DELETE
 //!   /admin/ehr/{ehr_id}`, physical cascade of every owned resource (COMPOSITION,
@@ -28,7 +30,14 @@
 //!   inconsistency.
 //!
 //! The group is config-gated (`AppConfig::admin.enabled`, default false): when
-//! disabled every admin route answers `404` without touching the backend.
+//! disabled every admin route answers **`405 Method Not Allowed`** with an
+//! empty `Allow`, without touching the backend. The ground differs per route —
+//! `admin_ehr_delete_all` has its own released NOTE + `responses/405.yaml`,
+//! while the single-EHR delete and the three extensions rest on the
+//! cross-cutting rule "If a method is recognized but not allowed for the target
+//! resource, the response SHOULD be `405 Method Not Allowed` status code"
+//! (`docs/overview/Requests_and_responses.md` §"HTTP Methods"). See the gate
+//! comment in `run` below and the declarations in [`super::openapi_routes`].
 
 use axum::Json;
 use axum::response::{IntoResponse, Response};
@@ -57,11 +66,19 @@ async fn run(
     parts: RequestParts,
 ) -> Result<Response, RestError> {
     // Config gate: the ADMIN API is opt-in. When disabled every admin route
-    // answers `405 Method Not Allowed` — the status the ITS-REST OAS itself
-    // declares for a disabled admin operation
-    // (`operations/admin_ehr_delete_all.yaml`: "may be disabled in production
-    // environments, in which case server may respond with 405", with
-    // `responses/405.yaml` enumerated), rendered with the openEHR error body.
+    // answers `405 Method Not Allowed`, rendered with the openEHR error body.
+    // Two grounds, one wire:
+    // - `admin_ehr_delete_all` has its OWN released provenance — its NOTE ("may
+    //   be disabled in production environments, in which case server may
+    //   respond with 405", `operations/admin_ehr_delete_all.yaml`) with
+    //   `responses/405.yaml` enumerated.
+    // - Every OTHER route here (the single-EHR delete, and the three
+    //   extensions, which have no released file at all) rests on the
+    //   cross-cutting rule instead: "If a method is recognized but not allowed
+    //   for the target resource, the response SHOULD be `405 Method Not
+    //   Allowed` status code" (`docs/overview/Requests_and_responses.md`
+    //   §"HTTP Methods"). The bulk route's NOTE governs only that operation and
+    //   is not their ground.
     //
     // This `405` comes from a MATCHED handler, so axum's allow-header machinery
     // (which only decorates a *method fallback*) never runs and the `Allow`

--- a/app/ehrbase-rest/src/api/admin/openapi_routes.rs
+++ b/app/ehrbase-rest/src/api/admin/openapi_routes.rs
@@ -245,7 +245,7 @@ pub(crate) async fn admin_config(
 /// > in which case server may respond with `405 Method Not Allowed`.
 ///
 /// "All resources associated with or owned by the targeted EHRs (such as
-/// COMPOSITION, EHR_STATUS, ITEM_TAG, CONTRIBUTION, and their historical
+/// `COMPOSITION`, `EHR_STATUS`, `ITEM_TAG`, `CONTRIBUTION`, and their historical
 /// versions) will also be **permanently** and physically deleted, in compliance
 /// with applicable data protection regulations (e.g., the GDPR in the European
 /// Union)."
@@ -375,7 +375,7 @@ pub(crate) async fn admin_ehr_delete_all(
 /// "Delete EHR by id"): "Deletes the EHR identified by `ehr_id`."
 ///
 /// "All resources associated with or owned by the specified EHR (such as
-/// COMPOSITION, EHR_STATUS, ITEM_TAG, CONTRIBUTION, and their historical
+/// `COMPOSITION`, `EHR_STATUS`, `ITEM_TAG`, `CONTRIBUTION`, and their historical
 /// versions) will also be **permanently** and physically deleted, in compliance
 /// with applicable data protection regulations (e.g., the GDPR in the European
 /// Union)."

--- a/app/ehrbase-rest/src/api/admin/openapi_routes.rs
+++ b/app/ehrbase-rest/src/api/admin/openapi_routes.rs
@@ -1,43 +1,128 @@
-//! Native `utoipa-axum` routing for the Admin API group.
+//! Native `utoipa-axum` routing for the **Admin API group** — the two released
+//! ITS-REST admin operations plus three of our own extension routes.
 //!
-//! The EHR-delete operations' semantics are the ITS-REST Admin API
-//! (`docs/specs/openehr/ITS-REST`, DEVELOPMENT status); no openEHR spec governs
-//! the OAS layout. Each handler forwards to the group dispatcher through
-//! [`guarded_dispatch`], so the wire behaviour is identical to the former
-//! table-driven `mount` adapter.
+//! Each `#[utoipa::path]` handler single-sources its route and its `OpenAPI`
+//! path, then forwards to the group dispatcher ([`super::dispatch::dispatch`])
+//! through [`guarded_dispatch`], so the wire behaviour is identical to the
+//! former table-driven `mount` adapter.
 //!
-//! The **template delete** and **stored-query-version delete** are OUR OWN
-//! EXTENSION — no openEHR spec governs them (the ITS-REST Admin API defines only
-//! EHR deletes). They mirror `admin_ehr_delete` end to end: same admin gate
-//! (`AppConfig::admin.enabled` → 404 when off; RBAC Admin class by the `/admin/`
-//! path), `204` on success, `404` for an unknown id, plus a `409` when a
-//! template delete would orphan committed clinical data.
+//! ## Release state
 //!
-//! ## Prose-vs-OAS reconciliations (documented real wire)
+//! The Admin API is `DEVELOPMENT`-state within ITS-REST Release-1.1.0 — "This
+//! specification is in the `DEVELOPMENT` state"
+//! (`docs/specs/openehr/ITS-REST/specifications/docs/admin/Description.md`
+//! §Status). That is a **reporting qualifier only**: the BCP-14 requirement
+//! force of the released text is not state-qualified, so every MUST/SHOULD
+//! below binds exactly as it does on a STABLE group, and nothing here is marked
+//! `deprecated` except where the released docs text itself deprecates it. The
+//! declarations are pinned to that release, not to the upstream development
+//! branch.
 //!
-//! - **Disabled admin API → `405 Method Not Allowed`**: the group is
-//!   config-gated (`AppConfig::admin.enabled`, default false); when off,
-//!   every admin route answers `405` with the openEHR error body — the
-//!   status the OAS itself declares for a disabled admin operation
-//!   (`admin_ehr_delete_all.yaml` + `responses/405.yaml`), applied
-//!   uniformly across the group (`admin/dispatch.rs`). Because that `405`
-//!   comes from a MATCHED handler it carries its own `Allow` header (RFC
-//!   9110 §15.5.6 makes it mandatory on every `405`), with the EMPTY field
-//!   value RFC 9110 §10.2.1 defines for a resource "temporarily disabled by
-//!   configuration".
-//! - **Synchronous deletes → `204`** (never `202`): the OAS permits an async
-//!   `202 Accepted`, but every delete here is synchronous, so success is always
-//!   `204 No Content` (bodyless); the `202` path is not produced.
-//! - **`admin_ehr_delete_all` `ehr_id`**: optional; an absent/empty list means
-//!   "delete ALL EHRs" (`admin_ehr_delete_all.yaml` + `ehr_id_Admin.yaml`). Both
-//!   the repeated (`?ehr_id=a&ehr_id=b`) and comma-separated (`?ehr_id=a,b`)
-//!   forms are accepted.
+//! ## The released surface is two operations
 //!
-//! NOTE (path): the generated `admin_ehr_delete_all` route carries an
-//! RFC 6570 query-expansion suffix (`/admin/ehr/all{?ehr_id*}`) that is not part
-//! of the resource path; the mounted/documented path is the plain
-//! `/admin/ehr/all` (the `ehr_id` list is read from the query string), matching
-//! the normalisation the former adapter applied.
+//! `specifications/admin.openapi.yaml` mounts exactly `DELETE
+//! /admin/ehr/{ehr_id}` (`operations/admin_ehr_delete.yaml`) and `DELETE
+//! /admin/ehr/all{?ehr_id*}` (`operations/admin_ehr_delete_all.yaml`), both
+//! tagged `EHR`. The other three routes below (`/admin/template/{template_id}`,
+//! `/admin/query/{qualified_query_name}/{version}`, `/admin/config`) are **OUR
+//! OWN EXTENSION** — no ITS-REST operation governs them — and are excluded from
+//! any conformance-profile claim.
+//!
+//! ## What the released responses do (and do not) declare
+//!
+//! - **No response header exists on any released admin response.** Every
+//!   response file the two operations `$ref` —
+//!   `responses/202.yaml`, `responses/204_deleted_hard.yaml`,
+//!   `responses/404.yaml`, `responses/404_unknown_ehr_id.yaml`,
+//!   `responses/405.yaml` — carries a `description:` and nothing else: no
+//!   `headers:` block anywhere. There is therefore no released response header
+//!   to declare on either operation, and none is declared. The ONE response
+//!   header this group emits at all is the `Allow` on the config-gate `405`
+//!   (below), which comes from RFC 9110, not from the openEHR text.
+//! - **`Location` is never declared, on any route of the group.**
+//!   `docs/overview/Requests_and_responses.md` §"Deprecated headers": the
+//!   `Location` response header on `GET` "was an incorrect use of the header,
+//!   and it is now deprecated", and "Similarly, the `Location` response header
+//!   was deprecated from responses of `DELETE` methods." Four routes here are
+//!   `DELETE` and the fifth is a `GET`, so no response of this group slots it.
+//! - **Success is always `204`, never `202`.** Both released operations say:
+//!   "The server may execute this operation asynchronously (e.g. in batches),
+//!   in which case returns status `202 Accepted`. If the deletion is processed
+//!   synchronously and completes successfully, the server returns status `204
+//!   No Content`." Every delete here is synchronous, so `204` is the only
+//!   success and the `202` branch (`responses/202.yaml`: "`202 Accepted` is
+//!   returned when the requested operation has been accepted for processing,
+//!   but processing has not been completed or may not have started (i.e. when
+//!   requests are processed asynchronously).") is NEVER produced. It is
+//!   documented in prose on both operations and deliberately NOT declared as a
+//!   served response — the served document describes only what this server
+//!   emits.
+//!
+//! ## `405` when the group is disabled — two different grounds
+//!
+//! The group is config-gated (`AppConfig::admin.enabled`, default false); when
+//! off EVERY route here answers `405 Method Not Allowed` with the openEHR error
+//! body, uniformly, before the backend is touched (`admin/dispatch.rs`). The
+//! spec ground for that status differs per route and each declaration cites its
+//! own:
+//!
+//! - `admin_ehr_delete_all` has its OWN released provenance — the NOTE in
+//!   `operations/admin_ehr_delete_all.yaml`: "This functionality is intended
+//!   primarily for **development** or **testing** purposes and may be disabled
+//!   in **production** environments, in which case server may respond with `405
+//!   Method Not Allowed`." — with `responses/405.yaml` enumerated ("`405 Method
+//!   Not Allowed` is returned when the service knows the request method, but
+//!   the target resource doesn't support this method (e.g. due to security
+//!   concerns).").
+//! - `admin_ehr_delete` does NOT enumerate `405`, and the three extension
+//!   routes have no released file at all, so the bulk route's NOTE is not their
+//!   ground. Theirs is the cross-cutting overview rule: "If a method is
+//!   recognized but not allowed for the target resource, the response SHOULD be
+//!   `405 Method Not Allowed` status code"
+//!   (`docs/overview/Requests_and_responses.md` §"HTTP Methods").
+//!
+//! Because that `405` comes from a MATCHED handler, axum's allow-header
+//! machinery (which only decorates a *method fallback*) never runs, so the
+//! `Allow` RFC 9110 §15.5.6 makes mandatory on every `405` is set explicitly —
+//! with the EMPTY field value RFC 9110 §10.2.1 defines for a resource
+//! "temporarily disabled by configuration".
+//!
+//! ## Authorization is our own design
+//!
+//! Every released admin operation carries `security: []`
+//! (`specifications/admin.openapi.yaml`) and declares no `401`/`403`, and the
+//! overview only says services "SHOULD implement and support an HTTP
+//! Authentication and Authorization framework, though this specification does
+//! not mandate a specific authentication scheme"
+//! (`docs/overview/Requests_and_responses.md` §"Authentication and
+//! authorization"). The `401`/`403` branches declared on all five routes are
+//! therefore OUR OWN design — no openEHR spec governs them: everything under
+//! `/admin/` is classified `OperationClass::Admin` by the RBAC gate
+//! ([`crate::extensions::access::authz`]), which runs before the config gate,
+//! so an unauthenticated caller sees `401` and a non-admin principal `403`
+//! whether or not the group is enabled.
+//!
+//! ## The `ehr_id` query form
+//!
+//! `parameters/query/ehr_id_Admin.yaml` is `in: query`, `style: form`,
+//! `explode: true`, and "An optional parameter to perform the operation on a
+//! subset of EHRs" — so an ABSENT or empty list means "delete ALL EHRs"
+//! (`admin_ehr_delete_all.yaml`: "Deletes all or multiple EHRs, or a specified
+//! subset of EHRs identified using the `ehr_id` query parameter."). Both the
+//! exploded/repeated form (`?ehr_id=a&ehr_id=b`, which is what `explode: true`
+//! means) and a comma-separated single value (`?ehr_id=a,b`) are accepted.
+//! Reading the list straight from the RAW query string is deliberate, not an
+//! oversight: the generated `AdminEhrDeleteAllParams.ehr_id` is an
+//! `Option<String>` that the type-directed params deserializer collapses a
+//! repeated parameter into — the reasoning is spelled out at the
+//! `admin_ehr_delete_all` arm of `admin/dispatch.rs`.
+//!
+//! NOTE (path): the generated `admin_ehr_delete_all` route carries an RFC 6570
+//! query-expansion suffix (`/admin/ehr/all{?ehr_id*}`) that is not part of the
+//! resource path; the mounted and documented path is the plain
+//! `/admin/ehr/all` (the `ehr_id` list is read from the query string), which is
+//! the normalization [`crate::api::normalize_path`] applies to every generated
+//! template.
 
 use axum::extract::State;
 use axum::response::Response;
@@ -57,38 +142,88 @@ pub(crate) fn routes() -> OpenApiRouter<AppState> {
         .routes(routes!(admin_config))
 }
 
-/// The redacted effective configuration as a JSON tree
-/// (`GET /admin/config`).
+/// The redacted effective configuration as a JSON tree (`GET /admin/config`).
 ///
-/// OUR OWN EXTENSION — no openEHR spec governs configuration (the ITS-REST
-/// Admin API defines only EHR deletes). Same admin gate as the sibling deletes
-/// (`AppConfig::admin.enabled` → `404` when off; RBAC Admin class by the
-/// `/admin/` path → `401` unauthenticated / `403` non-admin). Every
-/// secret-bearing leaf is redacted structurally by its `Secret`/`SecretUrl`
-/// type before it ever reaches this handler (see
-/// [`ehrbase::config::EhrbaseConfig::to_redacted_json`]).
+/// **Our own extension — no ITS-REST operation governs this.** The released
+/// Admin API (`specifications/admin.openapi.yaml`) defines exactly two
+/// operations, both EHR deletes, and no openEHR specification models server
+/// configuration at all; this route is excluded from any conformance-profile
+/// claim. Same admin gate as the sibling deletes (`AppConfig::admin.enabled` →
+/// `405` when off; RBAC Admin class by the `/admin/` path → `401`
+/// unauthenticated / `403` non-admin).
+///
+/// Every secret-bearing leaf is redacted STRUCTURALLY by its `Secret` /
+/// `SecretUrl` type before it ever reaches this handler — the binary builds the
+/// snapshot once at boot with
+/// [`ehrbase::config::EhrbaseConfig::to_redacted_json`], so no secret substring
+/// is present here to leak.
 #[utoipa::path(
     get, path = "/admin/config", tag = "ADMIN",
+    params(
+        ("Accept" = Option<String>, Header,
+         description = "The tree is served as `application/json`. No openEHR \
+                        format negotiation applies — this is not an RM \
+                        resource, so neither canonical XML nor a Simplified \
+                        format is meaningful for it.",
+         example = "application/json")
+    ),
     responses(
         (status = 200, description = "The redacted effective configuration \
-                                      (every secret leaf already `***` by its \
-                                      `Secret`/`SecretUrl` type).",
-         body = serde_json::Value),
+                                      (every secret leaf already `***`/\
+                                      `scheme://***@…` by its `Secret`/\
+                                      `SecretUrl` type). No response header \
+                                      accompanies it — the tree is not a \
+                                      versioned resource, so there is no `ETag` \
+                                      or `Last-Modified` to derive, and \
+                                      §\"Deprecated headers\" deprecates \
+                                      `Location` on `GET`.",
+         body = serde_json::Value,
+         example = json!({
+             "server": { "bind": "0.0.0.0:8080", "base_path": "/ehrbase/rest/openehr/v1" },
+             "db": { "url": "postgres://***@db:5432/ehrbase", "max_connections": 20 },
+             "admin": { "enabled": true }
+         })),
         (status = 401, description = "Unauthenticated (auth enabled, no valid \
-                                      principal).",
-         body = serde_json::Value),
-        (status = 403, description = "Authenticated but not in the Admin class.",
-         body = serde_json::Value),
-        (status = 405, description = "The admin API is disabled on this \
-                                      server (the status the OAS declares for \
-                                      a disabled admin operation: \
-                                      `admin_ehr_delete_all.yaml` + \
-                                      `responses/405.yaml`). Carries the \
-                                      mandatory `Allow` header (RFC 9110 \
-                                      §15.5.6) with the EMPTY field value \
-                                      RFC 9110 §10.2.1 defines for a resource \
-                                      disabled by configuration.",
-         body = serde_json::Value)
+                                      principal). Our own authorization design \
+                                      — the released admin operations carry \
+                                      `security: []` and declare no such branch \
+                                      (see the module docs).",
+         body = serde_json::Value,
+         example = json!({ "error": "Unauthorized", "message": "no credentials supplied" })),
+        (status = 403, description = "Authenticated but not in the Admin class \
+                                      (`OperationClass::Admin`, keyed off the \
+                                      `/admin/` path). Our own authorization \
+                                      design.",
+         body = serde_json::Value,
+         example = json!({ "error": "Forbidden", "message": "operation requires the 'ADMIN' role" })),
+        (status = 405, description = "The admin API is disabled on this server \
+                                      (`AppConfig::admin.enabled`, default \
+                                      false). This route has no released file, \
+                                      so its ground is the cross-cutting \
+                                      overview rule — \"If a method is \
+                                      recognized but not allowed for the target \
+                                      resource, the response SHOULD be `405 \
+                                      Method Not Allowed` status code\" \
+                                      (`Requests_and_responses.md` §\"HTTP \
+                                      Methods\") — not the bulk-delete NOTE, \
+                                      which governs only that one operation.",
+         body = serde_json::Value,
+         headers(
+             ("Allow" = String,
+              description = "EMPTY. RFC 9110 §15.5.6 makes `Allow` mandatory on \
+                             every `405`, and this one comes from a MATCHED \
+                             handler, so axum's method-fallback machinery never \
+                             supplies it. The empty field value is exactly what \
+                             RFC 9110 §10.2.1 defines for this case: \"An empty \
+                             Allow field value indicates that the resource \
+                             allows no methods, which might occur in a 405 \
+                             response if the resource has been temporarily \
+                             disabled by configuration.\"")
+         ),
+         example = json!({
+             "error": "Method Not Allowed",
+             "message": "the admin API is disabled on this server"
+         }))
     )
 )]
 pub(crate) async fn admin_config(
@@ -99,35 +234,125 @@ pub(crate) async fn admin_config(
     guarded_dispatch(state, "admin_config", parts, super::dispatch::dispatch).await
 }
 
-/// Physically delete multiple EHRs, or all of them
-/// (`DELETE /admin/ehr/all`).
+/// Delete multiple EHRs (`DELETE /admin/ehr/all`).
 ///
-/// Cascades every owned resource (`COMPOSITION`, `EHR_STATUS`, `ITEM_TAG`,
-/// CONTRIBUTION + historical versions) — a permanent physical delete (e.g. for
-/// GDPR erasure). Intended for development/testing.
+/// The released operation text (`operations/admin_ehr_delete_all.yaml`,
+/// summary "Delete multiple EHRs"): "Deletes all or multiple EHRs, or a
+/// specified subset of EHRs identified using the `ehr_id` query parameter."
+///
+/// > NOTE: This functionality is intended primarily for **development** or
+/// > **testing** purposes and may be disabled in **production** environments,
+/// > in which case server may respond with `405 Method Not Allowed`.
+///
+/// "All resources associated with or owned by the targeted EHRs (such as
+/// COMPOSITION, EHR_STATUS, ITEM_TAG, CONTRIBUTION, and their historical
+/// versions) will also be **permanently** and physically deleted, in compliance
+/// with applicable data protection regulations (e.g., the GDPR in the European
+/// Union)."
+///
+/// "The server may execute this operation asynchronously (e.g. in batches), in
+/// which case returns status `202 Accepted`. If the deletion is processed
+/// synchronously and completes successfully, the server returns status `204 No
+/// Content`." — this server is SYNCHRONOUS, so `204` is the only success and
+/// the `202` branch is never produced (hence not declared; see the module
+/// docs).
+///
+/// This operation realizes NO SM interface operation:
+/// `I_ADMIN_SERVICE.physical_ehr_delete` takes one `UUID[1]`
+/// (`docs/specs/openehr/SM/docs/UML/classes/i_admin_service.adoc`) and the
+/// archive operations archive rather than delete — a released wire behaviour
+/// with no service-model anchor to name it by.
+///
+/// The released generic `404` (`responses/404.yaml`: "`404 Not Found` is
+/// returned when, based on the request parameters, the server did not find a
+/// current representation of a target resource, or is not willing to disclose
+/// that one exists.") is UNREACHABLE on this server, and is therefore NOT
+/// declared: the released text defines no trigger for it on a mixed list, and
+/// the shipped semantics are delete-what-exists → `204` (an id that names no
+/// EHR deletes nothing and is not an error), with a malformed id rejected `400`
+/// before any deletion runs.
 #[utoipa::path(
     delete, path = "/admin/ehr/all", tag = "EHR",
     params(
         ("ehr_id" = Option<Vec<String>>, Query,
-         description = "The EHR ids (UUIDs) to delete, as repeated `ehr_id=…` or \
-                        a comma-separated `ehr_id=a,b`. OPTIONAL — an absent or \
-                        empty list deletes ALL EHRs.")
+         description = "The EHR ids (UUIDs) to delete — \"An optional parameter \
+                        to perform the operation on a subset of EHRs\" \
+                        (`parameters/query/ehr_id_Admin.yaml`). OPTIONAL: an \
+                        absent or empty list deletes ALL EHRs. Both the \
+                        exploded/repeated form (`?ehr_id=a&ehr_id=b`, which is \
+                        what the released `style: form` + `explode: true` \
+                        means) and a comma-separated single value \
+                        (`?ehr_id=a,b`) are accepted; blank entries are \
+                        dropped.",
+         example = json!([
+             "7d44b88c-4199-4bad-97dc-d78268e01398",
+             "297c3e91-7c17-4497-85dd-01e05aaae44e"
+         ]))
     ),
     responses(
-        (status = 204, description = "Deleted (synchronous; bodyless)."),
-        (status = 404, description = "An `ehr_id` in the list does not exist \
-                                      (nothing is deleted).",
-         body = serde_json::Value),
-        (status = 405, description = "The admin API is disabled on this \
-                                      server (the status the OAS declares for \
-                                      a disabled admin operation: \
-                                      `admin_ehr_delete_all.yaml` + \
-                                      `responses/405.yaml`). Carries the \
-                                      mandatory `Allow` header (RFC 9110 \
-                                      §15.5.6) with the EMPTY field value \
-                                      RFC 9110 §10.2.1 defines for a resource \
-                                      disabled by configuration.",
-         body = serde_json::Value)
+        (status = 204, description = "\"`204 No Content` is returned when the \
+                                      requested operation succeeded and the \
+                                      resource(s) identified by the request \
+                                      parameters has been physically deleted \
+                                      (i.e. hard-delete).\" \
+                                      (`responses/204_deleted_hard.yaml`) — \
+                                      synchronous and bodyless. No response \
+                                      header: the released response file \
+                                      declares none, the deleted EHRs have no \
+                                      surviving version to tag, and \
+                                      §\"Deprecated headers\" deprecates \
+                                      `Location` on `DELETE`."),
+        (status = 400, description = "An `ehr_id` in the list is not a \
+                                      well-formed UUID. The whole bulk request \
+                                      is rejected BEFORE any deletion runs \
+                                      (nothing is deleted). The released \
+                                      operation declares no `400`, so the \
+                                      ground is the overview status table's \
+                                      `400` row — \"malformed request syntax, \
+                                      syntactically invalid content\" \
+                                      (`Requests_and_responses.md` §\"HTTP \
+                                      status codes\").",
+         body = serde_json::Value,
+         example = json!({ "error": "Bad Request", "message": "invalid EHR id: not-a-uuid" })),
+        (status = 401, description = "Unauthenticated (auth enabled, no valid \
+                                      principal). Our own authorization design \
+                                      — the released operation carries \
+                                      `security: []` and declares no such \
+                                      branch (see the module docs).",
+         body = serde_json::Value,
+         example = json!({ "error": "Unauthorized", "message": "no credentials supplied" })),
+        (status = 403, description = "Authenticated but not in the Admin class. \
+                                      Our own authorization design.",
+         body = serde_json::Value,
+         example = json!({ "error": "Forbidden", "message": "operation requires the 'ADMIN' role" })),
+        (status = 405, description = "The admin API is disabled on this server \
+                                      (`AppConfig::admin.enabled`, default \
+                                      false). This is the ONE route in the \
+                                      group with its own released provenance: \
+                                      the operation's NOTE — \"may be disabled \
+                                      in **production** environments, in which \
+                                      case server may respond with `405 Method \
+                                      Not Allowed`\" — with \
+                                      `responses/405.yaml` enumerated: \"`405 \
+                                      Method Not Allowed` is returned when the \
+                                      service knows the request method, but the \
+                                      target resource doesn't support this \
+                                      method (e.g. due to security \
+                                      concerns).\"",
+         body = serde_json::Value,
+         headers(
+             ("Allow" = String,
+              description = "EMPTY — mandatory on every `405` (RFC 9110 \
+                             §15.5.6) and emitted here explicitly because the \
+                             status comes from a matched handler; the empty \
+                             field value is RFC 9110 §10.2.1's own case for a \
+                             resource \"temporarily disabled by \
+                             configuration\".")
+         ),
+         example = json!({
+             "error": "Method Not Allowed",
+             "message": "the admin API is disabled on this server"
+         }))
     )
 )]
 pub(crate) async fn admin_ehr_delete_all(
@@ -144,31 +369,117 @@ pub(crate) async fn admin_ehr_delete_all(
     .await
 }
 
-/// Physically delete one EHR by id (`DELETE /admin/ehr/{ehr_id}`).
+/// Delete EHR by id (`DELETE /admin/ehr/{ehr_id}`).
 ///
-/// Cascades every owned resource (`COMPOSITION`, `EHR_STATUS`, `ITEM_TAG`,
-/// CONTRIBUTION + historical versions) — a permanent physical delete (e.g. for
-/// GDPR erasure).
+/// The released operation text (`operations/admin_ehr_delete.yaml`, summary
+/// "Delete EHR by id"): "Deletes the EHR identified by `ehr_id`."
+///
+/// "All resources associated with or owned by the specified EHR (such as
+/// COMPOSITION, EHR_STATUS, ITEM_TAG, CONTRIBUTION, and their historical
+/// versions) will also be **permanently** and physically deleted, in compliance
+/// with applicable data protection regulations (e.g., the GDPR in the European
+/// Union)."
+///
+/// "The server may execute this operation asynchronously (e.g. in batches), in
+/// which case returns status `202 Accepted`. If the deletion is processed
+/// synchronously and completes successfully, the server returns status `204 No
+/// Content`." — this server is SYNCHRONOUS, so `204` is the only success and
+/// the `202` branch is never produced (hence not declared; see the module
+/// docs).
+///
+/// Realizes SM `I_ADMIN_SERVICE.physical_ehr_delete`
+/// (`docs/specs/openehr/SM/docs/UML/classes/i_admin_service.adoc` —
+/// precondition `has_ehr`, error `ehr_id_does_not_exist`). Note that the
+/// released operation does NOT carry the bulk route's development/testing NOTE
+/// and does NOT enumerate `405`: this single-EHR delete is not declared
+/// disable-in-production by the released text, so the group's config gate
+/// grounds its `405` on the overview §"HTTP Methods" rule instead.
 #[utoipa::path(
     delete, path = "/admin/ehr/{ehr_id}", tag = "EHR",
     params(
         ("ehr_id" = String, Path,
-         description = "The EHR id (a UUID), taken from EHR.ehr_id.value.")
+         description = "\"EHR identifier taken from EHR.ehr_id.value.\" \
+                        (`parameters/path/ehr_id.yaml`) — a UUID \
+                        (`format: uuid`).",
+         example = "7d44b88c-4199-4bad-97dc-d78268e01398")
     ),
     responses(
-        (status = 204, description = "Deleted (synchronous; bodyless)."),
-        (status = 404, description = "No EHR with `ehr_id`.",
-         body = serde_json::Value),
-        (status = 405, description = "The admin API is disabled on this \
-                                      server (the status the OAS declares for \
-                                      a disabled admin operation: \
-                                      `admin_ehr_delete_all.yaml` + \
-                                      `responses/405.yaml`). Carries the \
-                                      mandatory `Allow` header (RFC 9110 \
-                                      §15.5.6) with the EMPTY field value \
-                                      RFC 9110 §10.2.1 defines for a resource \
-                                      disabled by configuration.",
-         body = serde_json::Value)
+        (status = 204, description = "\"`204 No Content` is returned when the \
+                                      requested operation succeeded and the \
+                                      resource(s) identified by the request \
+                                      parameters has been physically deleted \
+                                      (i.e. hard-delete).\" \
+                                      (`responses/204_deleted_hard.yaml`) — \
+                                      synchronous and bodyless. No response \
+                                      header: the released response file \
+                                      declares none, a physically deleted EHR \
+                                      has no surviving version to tag, and \
+                                      §\"Deprecated headers\" deprecates \
+                                      `Location` on `DELETE`."),
+        (status = 400, description = "`ehr_id` is not a well-formed UUID \
+                                      (rejected before any deletion). The \
+                                      released operation declares no `400`, so \
+                                      the ground is the overview status table's \
+                                      `400` row — \"malformed request syntax, \
+                                      syntactically invalid content\" \
+                                      (`Requests_and_responses.md` §\"HTTP \
+                                      status codes\").",
+         body = serde_json::Value,
+         example = json!({ "error": "Bad Request", "message": "invalid EHR id: not-a-uuid" })),
+        (status = 401, description = "Unauthenticated (auth enabled, no valid \
+                                      principal). Our own authorization design \
+                                      — the released operation carries \
+                                      `security: []` and declares no such \
+                                      branch (see the module docs).",
+         body = serde_json::Value,
+         example = json!({ "error": "Unauthorized", "message": "no credentials supplied" })),
+        (status = 403, description = "Authenticated but not in the Admin class. \
+                                      Our own authorization design.",
+         body = serde_json::Value,
+         example = json!({ "error": "Forbidden", "message": "operation requires the 'ADMIN' role" })),
+        (status = 404, description = "\"`404 Not Found` is returned when an EHR \
+                                      with `ehr_id` does not exist.\" — this \
+                                      route's OWN released response file \
+                                      (`responses/404_unknown_ehr_id.yaml`), \
+                                      distinct from the generic \
+                                      `responses/404.yaml` the bulk route \
+                                      binds. It is the REST reading of the SM \
+                                      precondition `has_ehr` failing \
+                                      (`ehr_id_does_not_exist`, which \
+                                      `i_admin_service.adoc` defines only \
+                                      abstractly, with no HTTP binding).",
+         body = serde_json::Value,
+         example = json!({
+             "error": "Not Found",
+             "message": "EHR 7d44b88c-4199-4bad-97dc-d78268e01398"
+         })),
+        (status = 405, description = "The admin API is disabled on this server \
+                                      (`AppConfig::admin.enabled`, default \
+                                      false). The released operation enumerates \
+                                      no `405` and carries no \
+                                      disable-in-production NOTE — that NOTE \
+                                      belongs to `admin_ehr_delete_all` alone — \
+                                      so the ground here is the cross-cutting \
+                                      overview rule: \"If a method is \
+                                      recognized but not allowed for the target \
+                                      resource, the response SHOULD be `405 \
+                                      Method Not Allowed` status code\" \
+                                      (`Requests_and_responses.md` §\"HTTP \
+                                      Methods\").",
+         body = serde_json::Value,
+         headers(
+             ("Allow" = String,
+              description = "EMPTY — mandatory on every `405` (RFC 9110 \
+                             §15.5.6) and emitted here explicitly because the \
+                             status comes from a matched handler; the empty \
+                             field value is RFC 9110 §10.2.1's own case for a \
+                             resource \"temporarily disabled by \
+                             configuration\".")
+         ),
+         example = json!({
+             "error": "Method Not Allowed",
+             "message": "the admin API is disabled on this server"
+         }))
     )
 )]
 pub(crate) async fn admin_ehr_delete(
@@ -182,34 +493,101 @@ pub(crate) async fn admin_ehr_delete(
 /// Physically delete one operational template by its `template_id`
 /// (`DELETE /admin/template/{template_id}`).
 ///
-/// OUR OWN EXTENSION — no openEHR spec governs this operation (the ITS-REST
-/// Admin API defines only EHR deletes). Refuses with `409` while any committed
-/// version still references the template (physical deletes never orphan clinical
-/// data).
+/// **Our own extension — no ITS-REST operation governs this.** The released
+/// Admin API (`specifications/admin.openapi.yaml`) defines exactly two
+/// operations, both EHR deletes; there is no `DELETE` on any
+/// `/definition/template/adl1.4*` path either. This route is excluded from any
+/// conformance-profile claim.
+///
+/// SM relation: it is the wire ANALOGUE of `I_DEFINITION_ADL14.delete_opt`
+/// (`docs/specs/openehr/SM/docs/UML/classes/i_definition_adl14.adoc`), not a
+/// realization of it — that SM operation has no released wire at all (register
+/// AMB-17), and it is keyed by the OPT's internal id whereas this route is
+/// addressed by the wire `template_id` (matched case-insensitively, overview
+/// §"Composite Identifiers and Case").
+///
+/// The delete is guarded: it refuses with `409` while any committed version
+/// still references the template, so a physical delete can never orphan
+/// committed clinical data (the `vo_version.template_id` foreign key is the
+/// underlying integrity guard). No openEHR spec governs that guard — our own
+/// design.
 #[utoipa::path(
     delete, path = "/admin/template/{template_id}", tag = "ADMIN",
     params(
         ("template_id" = String, Path,
-         description = "The `template_id` (the wire address of the OPT).")
+         description = "The `template_id` — the wire address of the OPT, \
+                        matched case-insensitively (overview §\"Composite \
+                        Identifiers and Case\"), exactly as on the released \
+                        `/definition/template/adl1.4/{template_id}` reads.",
+         example = "openEHR-EHR-COMPOSITION.minimal.v1")
     ),
     responses(
-        (status = 204, description = "Deleted (bodyless)."),
-        (status = 404, description = "No template with `template_id`.",
-         body = serde_json::Value),
+        (status = 204, description = "Deleted (bodyless). Extension route — no \
+                                      released response file governs this; the \
+                                      status mirrors the released hard-delete \
+                                      `204` (`responses/204_deleted_hard.yaml`). \
+                                      No response header: a deleted template \
+                                      has nothing to tag, and §\"Deprecated \
+                                      headers\" deprecates `Location` on \
+                                      `DELETE`."),
+        (status = 401, description = "Unauthenticated (auth enabled, no valid \
+                                      principal). Our own authorization design.",
+         body = serde_json::Value,
+         example = json!({ "error": "Unauthorized", "message": "no credentials supplied" })),
+        (status = 403, description = "Authenticated but not in the Admin class. \
+                                      Our own authorization design.",
+         body = serde_json::Value,
+         example = json!({ "error": "Forbidden", "message": "operation requires the 'ADMIN' role" })),
+        (status = 404, description = "No template with `template_id`. Extension \
+                                      route — the status follows the overview \
+                                      table's `404` row \
+                                      (`Requests_and_responses.md` §\"HTTP \
+                                      status codes\"), by convention, not by \
+                                      obligation.",
+         body = serde_json::Value,
+         example = json!({
+             "error": "Not Found",
+             "message": "template openEHR-EHR-COMPOSITION.minimal.v1"
+         })),
         (status = 409, description = "A committed version still references the \
-                                      template (deletion would orphan clinical \
-                                      data).",
-         body = serde_json::Value),
-        (status = 405, description = "The admin API is disabled on this \
-                                      server (the status the OAS declares for \
-                                      a disabled admin operation: \
-                                      `admin_ehr_delete_all.yaml` + \
-                                      `responses/405.yaml`). Carries the \
-                                      mandatory `Allow` header (RFC 9110 \
-                                      §15.5.6) with the EMPTY field value \
-                                      RFC 9110 §10.2.1 defines for a resource \
-                                      disabled by configuration.",
-         body = serde_json::Value)
+                                      template, so deleting it would orphan \
+                                      clinical data. Our own guard — no openEHR \
+                                      spec governs it; the status follows the \
+                                      overview table's `409` row, a request \
+                                      that \"might generate a duplicate or a \
+                                      conflict\". The message names how many \
+                                      committed versions still hold the \
+                                      reference.",
+         body = serde_json::Value,
+         example = json!({
+             "error": "Conflict",
+             "message": "template 'openEHR-EHR-COMPOSITION.minimal.v1' is still referenced by 3 committed version(s); delete those compositions before deleting the template"
+         })),
+        (status = 405, description = "The admin API is disabled on this server \
+                                      (`AppConfig::admin.enabled`, default \
+                                      false). This route has no released file, \
+                                      so its ground is the cross-cutting \
+                                      overview rule — \"If a method is \
+                                      recognized but not allowed for the target \
+                                      resource, the response SHOULD be `405 \
+                                      Method Not Allowed` status code\" \
+                                      (`Requests_and_responses.md` §\"HTTP \
+                                      Methods\") — not the bulk-delete NOTE, \
+                                      which governs only that one operation.",
+         body = serde_json::Value,
+         headers(
+             ("Allow" = String,
+              description = "EMPTY — mandatory on every `405` (RFC 9110 \
+                             §15.5.6) and emitted here explicitly because the \
+                             status comes from a matched handler; the empty \
+                             field value is RFC 9110 §10.2.1's own case for a \
+                             resource \"temporarily disabled by \
+                             configuration\".")
+         ),
+         example = json!({
+             "error": "Method Not Allowed",
+             "message": "the admin API is disabled on this server"
+         }))
     )
 )]
 pub(crate) async fn admin_template_delete(
@@ -229,33 +607,90 @@ pub(crate) async fn admin_template_delete(
 /// Physically delete one stored-query version — a single `(name, version)` row
 /// (`DELETE /admin/query/{qualified_query_name}/{version}`).
 ///
-/// OUR OWN EXTENSION — no openEHR spec governs this operation (the ITS-REST
-/// Admin API defines only EHR deletes). The qualified name is matched
-/// case-insensitively (as on the stored-query PUT); the version is exact.
+/// **Our own extension — no ITS-REST operation governs this.** The released
+/// Admin API (`specifications/admin.openapi.yaml`) defines exactly two
+/// operations, both EHR deletes, and the released Definition API has no
+/// `DELETE` on `/definition/query/…` either. This route is excluded from any
+/// conformance-profile claim.
+///
+/// It does **NOT** realize SM `I_DEFINITION_QUERY.delete_query`
+/// (`docs/specs/openehr/SM/docs/UML/classes/i_definition_query.adoc`): that
+/// operation is keyed by NAME ALONE — `Pre_has_query: has_query(a_query_name)`,
+/// `Post_query_deleted: not has_query (a_query_name)` — so it removes every
+/// version of the query, whereas this route removes exactly one
+/// `(name, version)` row and leaves the query's other versions in place. The
+/// SM operation therefore stays unrealized on this server (register AMB-127);
+/// naming it here would be a false claim.
 #[utoipa::path(
     delete, path = "/admin/query/{qualified_query_name}/{version}", tag = "ADMIN",
     params(
         ("qualified_query_name" = String, Path,
          description = "The qualified query name \
-                        (`[{namespace}::]{query-name}`; matched \
-                        case-insensitively)."),
+                        (`[{namespace}::]{query-name}`), matched \
+                        case-insensitively — as on the released stored-query \
+                        `PUT` (overview §\"Composite Identifiers and Case\").",
+         example = "org.openehr::compositions"),
         ("version" = String, Path,
-         description = "The exact stored SEMVER version to delete.")
+         description = "The exact stored SEMVER version to delete. Only this \
+                        one row is removed; the query's other versions survive \
+                        (which is why this is not SM `delete_query`).",
+         example = "1.0.2")
     ),
     responses(
-        (status = 204, description = "Deleted (bodyless)."),
-        (status = 404, description = "No stored query at that `(name, version)`.",
-         body = serde_json::Value),
-        (status = 405, description = "The admin API is disabled on this \
-                                      server (the status the OAS declares for \
-                                      a disabled admin operation: \
-                                      `admin_ehr_delete_all.yaml` + \
-                                      `responses/405.yaml`). Carries the \
-                                      mandatory `Allow` header (RFC 9110 \
-                                      §15.5.6) with the EMPTY field value \
-                                      RFC 9110 §10.2.1 defines for a resource \
-                                      disabled by configuration.",
-         body = serde_json::Value)
+        (status = 204, description = "Deleted (bodyless). Extension route — no \
+                                      released response file governs this; the \
+                                      status mirrors the released hard-delete \
+                                      `204` (`responses/204_deleted_hard.yaml`). \
+                                      No response header: a deleted row has \
+                                      nothing to tag, and §\"Deprecated \
+                                      headers\" deprecates `Location` on \
+                                      `DELETE`."),
+        (status = 401, description = "Unauthenticated (auth enabled, no valid \
+                                      principal). Our own authorization design.",
+         body = serde_json::Value,
+         example = json!({ "error": "Unauthorized", "message": "no credentials supplied" })),
+        (status = 403, description = "Authenticated but not in the Admin class. \
+                                      Our own authorization design.",
+         body = serde_json::Value,
+         example = json!({ "error": "Forbidden", "message": "operation requires the 'ADMIN' role" })),
+        (status = 404, description = "No stored query at that \
+                                      `(name, version)` — an unknown name, or a \
+                                      known name with no such version. \
+                                      Extension route — the status follows the \
+                                      overview table's `404` row \
+                                      (`Requests_and_responses.md` §\"HTTP \
+                                      status codes\"), by convention, not by \
+                                      obligation.",
+         body = serde_json::Value,
+         example = json!({
+             "error": "Not Found",
+             "message": "stored query org.openehr::compositions at version 1.0.2"
+         })),
+        (status = 405, description = "The admin API is disabled on this server \
+                                      (`AppConfig::admin.enabled`, default \
+                                      false). This route has no released file, \
+                                      so its ground is the cross-cutting \
+                                      overview rule — \"If a method is \
+                                      recognized but not allowed for the target \
+                                      resource, the response SHOULD be `405 \
+                                      Method Not Allowed` status code\" \
+                                      (`Requests_and_responses.md` §\"HTTP \
+                                      Methods\") — not the bulk-delete NOTE, \
+                                      which governs only that one operation.",
+         body = serde_json::Value,
+         headers(
+             ("Allow" = String,
+              description = "EMPTY — mandatory on every `405` (RFC 9110 \
+                             §15.5.6) and emitted here explicitly because the \
+                             status comes from a matched handler; the empty \
+                             field value is RFC 9110 §10.2.1's own case for a \
+                             resource \"temporarily disabled by \
+                             configuration\".")
+         ),
+         example = json!({
+             "error": "Method Not Allowed",
+             "message": "the admin API is disabled on this server"
+         }))
     )
 )]
 pub(crate) async fn admin_query_delete(

--- a/app/ehrbase-rest/tests/served_openapi.rs
+++ b/app/ehrbase-rest/tests/served_openapi.rs
@@ -756,6 +756,8 @@ async fn demographic_item_tag_operations_are_fully_documented() {
             );
         }
     };
+    // Whitespace-normalized (doc comments hard-wrap, so a released sentence
+    // may span a line break in the served description).
     let text = |op: &Value| -> String {
         format!(
             "{} {}",
@@ -766,6 +768,9 @@ async fn demographic_item_tag_operations_are_fully_documented() {
                 .and_then(Value::as_str)
                 .unwrap_or_default()
         )
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
     };
     let param_doc = |op: &Value, name: &str| -> String {
         op.get("parameters")
@@ -1011,6 +1016,8 @@ async fn admin_operations_are_fully_documented() {
             );
         }
     };
+    // Whitespace-normalized (doc comments hard-wrap, so a released sentence
+    // may span a line break in the served description).
     let text = |op: &Value| -> String {
         format!(
             "{} {}",
@@ -1021,6 +1028,9 @@ async fn admin_operations_are_fully_documented() {
                 .and_then(Value::as_str)
                 .unwrap_or_default()
         )
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
     };
     let param_doc = |op: &Value, name: &str| -> String {
         op.get("parameters")

--- a/app/ehrbase-rest/tests/served_openapi.rs
+++ b/app/ehrbase-rest/tests/served_openapi.rs
@@ -969,6 +969,328 @@ async fn demographic_item_tag_operations_are_fully_documented() {
     );
 }
 
+/// The Admin API group's five served operations are documented to full step-6
+/// completeness: every branch this server actually emits, the `Allow` header on
+/// every config-gate `405`, worked examples, and NO `Location` anywhere.
+///
+/// The branches are the RELEASED ITS-REST text, not the stalled OAS. The two
+/// released operations (`operations/admin_ehr_delete.yaml`,
+/// `operations/admin_ehr_delete_all.yaml`) `$ref` only description-carrying
+/// response files (`responses/{202,204_deleted_hard,404,404_unknown_ehr_id,405}.yaml`
+/// declare no `headers:` at all), so the only response header this group may
+/// declare is the `Allow` RFC 9110 §15.5.6 makes mandatory on a `405`.
+/// `Requests_and_responses.md` §"Deprecated headers" deprecates `Location` on
+/// `GET` and `DELETE` responses — which is every route here — and §"HTTP
+/// Methods" is the ground for the `405` on every route EXCEPT
+/// `admin_ehr_delete_all`, whose own NOTE covers it.
+#[tokio::test]
+#[allow(clippy::too_many_lines)] // one regression test per audited group keeps the pins together
+async fn admin_operations_are_fully_documented() {
+    const BASE: &str = "/ehrbase/rest/openehr/v1/admin";
+
+    let doc = served_document().await;
+
+    let codes = |op: &Value| -> Vec<String> {
+        op["responses"]
+            .as_object()
+            .map(|r| r.keys().cloned().collect())
+            .unwrap_or_default()
+    };
+    let header_names = |op: &Value, status: &str| -> Vec<String> {
+        op["responses"][status]["headers"]
+            .as_object()
+            .map(|h| h.keys().cloned().collect())
+            .unwrap_or_default()
+    };
+    let require = |op: &Value, path: &str, method: &str, expected: &[&str]| {
+        let present = codes(op);
+        for want in expected {
+            assert!(
+                present.iter().any(|c| c == want),
+                "{method} {path} must document {want}; has {present:?}"
+            );
+        }
+    };
+    let text = |op: &Value| -> String {
+        format!(
+            "{} {}",
+            op.get("summary")
+                .and_then(Value::as_str)
+                .unwrap_or_default(),
+            op.get("description")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+        )
+    };
+    let param_doc = |op: &Value, name: &str| -> String {
+        op.get("parameters")
+            .and_then(Value::as_array)
+            .and_then(|params| {
+                params
+                    .iter()
+                    .find(|p| p.get("name").and_then(Value::as_str) == Some(name))
+            })
+            .and_then(|p| p.get("description").and_then(Value::as_str))
+            .unwrap_or_default()
+            .to_owned()
+    };
+
+    // ── every route: the RBAC pair, the gated 405 with its Allow, no Location ─
+    let all: [(String, &str); 5] = [
+        (format!("{BASE}/ehr/all"), "delete"),
+        (format!("{BASE}/ehr/{{ehr_id}}"), "delete"),
+        (format!("{BASE}/template/{{template_id}}"), "delete"),
+        (
+            format!("{BASE}/query/{{qualified_query_name}}/{{version}}"),
+            "delete",
+        ),
+        (format!("{BASE}/config"), "get"),
+    ];
+    for (path, method) in &all {
+        let op = doc["paths"][path][method].clone();
+        assert!(op.is_object(), "{method} {path} must be documented");
+        require(&op, path, method, &["401", "403", "405"]);
+        // The one response header this group emits: `Allow` on the config-gate
+        // 405 (RFC 9110 §15.5.6 makes it mandatory; the value is empty per
+        // §10.2.1 — a resource "temporarily disabled by configuration").
+        assert!(
+            header_names(&op, "405").iter().any(|h| h == "Allow"),
+            "{method} {path} 405 must document the mandatory Allow header; has {:?}",
+            header_names(&op, "405")
+        );
+        // No response of this group may declare Location: §"Deprecated headers"
+        // deprecates it on both GET and DELETE responses.
+        for status in codes(&op) {
+            assert!(
+                !header_names(&op, &status).iter().any(|h| h == "Location"),
+                "{method} {path} {status} must NOT declare Location \
+                 (§\"Deprecated headers\": deprecated on GET and DELETE)"
+            );
+        }
+    }
+
+    // ── the two RELEASED operations ──────────────────────────────────────────
+    // The single-EHR delete: its own 404 file, the UUID path parameter, the
+    // GDPR cascade sentence, and the §"HTTP Methods" ground for its 405.
+    let path = format!("{BASE}/ehr/{{ehr_id}}");
+    let op = doc["paths"][&path]["delete"].clone();
+    require(&op, &path, "DELETE", &["204", "400", "404"]);
+    assert!(
+        header_names(&op, "204").is_empty(),
+        "DELETE {path} 204 carries no header at all (no released response file \
+         declares one, and the EHR is gone); has {:?}",
+        header_names(&op, "204")
+    );
+    let body = text(&op);
+    assert!(
+        body.contains("GDPR in the European Union"),
+        "DELETE {path} must carry the released GDPR cascade sentence; has: {body}"
+    );
+    assert!(
+        body.contains("202 Accepted") && body.contains("SYNCHRONOUS"),
+        "DELETE {path} must document the released async 202 branch AND say this \
+         server is synchronous; has: {body}"
+    );
+    assert!(
+        !codes(&op).iter().any(|c| c == "202"),
+        "DELETE {path} must NOT declare a 202 it never emits"
+    );
+    let not_found = op["responses"]["404"]["description"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(
+        not_found.contains("`404 Not Found` is returned when an EHR with `ehr_id` does not exist."),
+        "DELETE {path} 404 must carry the verbatim 404_unknown_ehr_id.yaml trigger; has: {not_found}"
+    );
+    let gate = op["responses"]["405"]["description"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(
+        gate.contains("HTTP Methods"),
+        "DELETE {path} 405 must cite overview §\"HTTP Methods\" — the bulk \
+         route's NOTE does not govern it; has: {gate}"
+    );
+    let ehr_id = param_doc(&op, "ehr_id");
+    assert!(
+        ehr_id.contains("EHR.ehr_id.value") && ehr_id.contains("UUID"),
+        "DELETE {path} must carry the released ehr_id prose and its uuid format; has: {ehr_id}"
+    );
+
+    // The bulk delete: the generic-404 binding, both query forms, the
+    // dev/testing NOTE that is its own 405 provenance.
+    let path = format!("{BASE}/ehr/all");
+    let op = doc["paths"][&path]["delete"].clone();
+    require(&op, &path, "DELETE", &["204", "400"]);
+    assert!(
+        header_names(&op, "204").is_empty(),
+        "DELETE {path} 204 carries no header at all; has {:?}",
+        header_names(&op, "204")
+    );
+    let body = text(&op);
+    assert!(
+        body.contains("development") && body.contains("testing"),
+        "DELETE {path} must carry the released dev/testing NOTE; has: {body}"
+    );
+    assert!(
+        body.contains("GDPR in the European Union"),
+        "DELETE {path} must carry the released GDPR cascade sentence; has: {body}"
+    );
+    assert!(
+        body.contains("responses/404.yaml") && body.contains("UNREACHABLE"),
+        "DELETE {path} must record that it binds the GENERIC 404 and why that \
+         branch is unreachable here (delete-what-exists); has: {body}"
+    );
+    assert!(
+        !codes(&op).iter().any(|c| c == "404"),
+        "DELETE {path} must NOT declare a 404 it never emits"
+    );
+    assert!(
+        body.contains("202 Accepted") && body.contains("SYNCHRONOUS"),
+        "DELETE {path} must document the released async 202 branch AND say this \
+         server is synchronous; has: {body}"
+    );
+    assert!(
+        !codes(&op).iter().any(|c| c == "202"),
+        "DELETE {path} must NOT declare a 202 it never emits"
+    );
+    let gate = op["responses"]["405"]["description"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(
+        gate.contains("responses/405.yaml"),
+        "DELETE {path} 405 must cite its OWN released provenance (the NOTE + \
+         responses/405.yaml); has: {gate}"
+    );
+    let ehr_id = param_doc(&op, "ehr_id");
+    assert!(
+        ehr_id.contains("?ehr_id=a&ehr_id=b") && ehr_id.contains("?ehr_id=a,b"),
+        "DELETE {path} must document BOTH accepted query forms; has: {ehr_id}"
+    );
+    assert!(
+        ehr_id.contains("OPTIONAL") && ehr_id.contains("ALL EHRs"),
+        "DELETE {path} must state that an absent/empty list deletes ALL EHRs; has: {ehr_id}"
+    );
+    assert!(
+        documented_params(&op, "path").is_empty(),
+        "DELETE {path} takes no path parameter — the RFC 6570 `{{?ehr_id*}}` \
+         suffix is normalized away, it is not a path segment"
+    );
+
+    // ── the template-delete extension: the in-use 409 guard ──────────────────
+    let path = format!("{BASE}/template/{{template_id}}");
+    let op = doc["paths"][&path]["delete"].clone();
+    require(&op, &path, "DELETE", &["204", "404", "409"]);
+    let conflict = op["responses"]["409"]["description"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(
+        conflict.contains("orphan"),
+        "DELETE {path} 409 must state the never-orphan-committed-data guard; has: {conflict}"
+    );
+    assert!(
+        text(&op).contains("delete_opt"),
+        "DELETE {path} must name the SM I_DEFINITION_ADL14.delete_opt relation"
+    );
+
+    // ── the stored-query-version delete: NOT SM delete_query ─────────────────
+    let path = format!("{BASE}/query/{{qualified_query_name}}/{{version}}");
+    let op = doc["paths"][&path]["delete"].clone();
+    require(&op, &path, "DELETE", &["204", "404"]);
+    let body = text(&op);
+    assert!(
+        body.contains("delete_query") && body.contains("NOT"),
+        "DELETE {path} must state that it does NOT realize SM delete_query; has: {body}"
+    );
+    assert!(
+        body.contains("(name, version)"),
+        "DELETE {path} must state that it deletes exactly one (name, version) \
+         row while SM delete_query deletes by name alone; has: {body}"
+    );
+
+    // ── the config read: 200 with a redacted tree, no versioning headers ─────
+    let path = format!("{BASE}/config");
+    let op = doc["paths"][&path]["get"].clone();
+    require(&op, &path, "GET", &["200"]);
+    for banned in ["ETag", "Last-Modified"] {
+        assert!(
+            !header_names(&op, "200").iter().any(|h| h == banned),
+            "GET {path} 200 must NOT declare {banned}: the config tree is not a \
+             versioned resource"
+        );
+    }
+    assert!(
+        op["responses"]["200"]["content"]
+            .as_object()
+            .and_then(|c| c.values().next())
+            .map(|c| c["example"].clone())
+            .is_some_and(|e| e["admin"]["enabled"].is_boolean()),
+        "GET {path} 200 must carry a worked redacted-config example"
+    );
+}
+
+/// The three admin extension routes are OUR OWN EXTENSION: the released Admin
+/// API defines exactly two operations, both EHR deletes, so every other admin
+/// route must say so in its description and none may be counted towards a
+/// conformance-profile claim.
+#[tokio::test]
+async fn admin_extension_operations_are_flagged_as_an_extension() {
+    const BASE: &str = "/ehrbase/rest/openehr/v1/admin";
+
+    let doc = served_document().await;
+
+    // The three routes of the ADMIN group that no released operation governs
+    // (the other `/admin/*` surfaces — event subscriptions, tenants — belong to
+    // their own extension groups and carry their own flags).
+    let extensions: [(String, &str); 3] = [
+        (format!("{BASE}/template/{{template_id}}"), "delete"),
+        (
+            format!("{BASE}/query/{{qualified_query_name}}/{{version}}"),
+            "delete",
+        ),
+        (format!("{BASE}/config"), "get"),
+    ];
+    for (path, method) in &extensions {
+        let op = doc["paths"][path][method].clone();
+        assert!(op.is_object(), "{method} {path} must be documented");
+        let text = format!(
+            "{} {}",
+            op.get("summary")
+                .and_then(Value::as_str)
+                .unwrap_or_default(),
+            op.get("description")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+        );
+        assert!(
+            text.contains("no ITS-REST operation governs this"),
+            "{} {path} must carry the our-own-extension flag; has: {text}",
+            method.to_uppercase()
+        );
+    }
+
+    // …and the released half of the group is exactly two operations, both EHR
+    // deletes (`specifications/admin.openapi.yaml`), so nothing else may claim
+    // released status.
+    let released = [format!("{BASE}/ehr/all"), format!("{BASE}/ehr/{{ehr_id}}")];
+    for path in &released {
+        let op = doc["paths"][path]["delete"].clone();
+        assert!(op.is_object(), "DELETE {path} must be documented");
+        let text = format!(
+            "{} {}",
+            op.get("summary")
+                .and_then(Value::as_str)
+                .unwrap_or_default(),
+            op.get("description")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+        );
+        assert!(
+            !text.contains("no ITS-REST operation governs this"),
+            "DELETE {path} is a RELEASED operation and must not be flagged as an extension"
+        );
+    }
+}
+
 /// The eight `PARTY_RELATIONSHIP` operations are OUR OWN EXTENSION: the
 /// released Demographic API defines no `party_relationship` path, so every one
 /// of them must say so in its description and none may be counted towards a

--- a/app/ehrbase/src/config/server.rs
+++ b/app/ehrbase/src/config/server.rs
@@ -213,15 +213,19 @@ impl Default for TenancyConfig {
 
 /// Configuration of the ADMIN API group (`[admin]`, §3.7; SM `I_ADMIN_SERVICE`).
 ///
-/// NOTE: gating the admin surface behind an opt-in flag — when inactive
-/// the admin controllers are not registered, so the routes are absent (`404`),
-/// never a `403`. Physical, irreversible deletion is dangerous, so the group
-/// stays off by default. No openEHR spec governs this gate — our own design.
+/// NOTE: gating the admin surface behind an opt-in flag — when inactive every
+/// admin route answers `405 Method Not Allowed` with an empty `Allow`
+/// ("If a method is recognized but not allowed for the target resource, the
+/// response SHOULD be `405 Method Not Allowed` status code" —
+/// `docs/specs/openehr/ITS-REST/specifications/docs/overview/Requests_and_responses.md`
+/// §"HTTP Methods"), never a `403`. Physical, irreversible deletion is
+/// dangerous, so the group stays off by default. No openEHR spec governs the
+/// gate itself — our own design.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct AdminConfig {
     /// Whether the ADMIN API group is active. When `false`, every admin route
-    /// answers `404` without touching the backend.
+    /// answers `405 Method Not Allowed` without touching the backend.
     pub enabled: bool,
 }
 

--- a/website/book/src/installation/configuration.md
+++ b/website/book/src/installation/configuration.md
@@ -320,7 +320,7 @@ enum{organization,patient,template}).
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `enabled` | bool | `false` | Mount the ADMIN API (physical, irreversible delete). Off ⇒ routes are absent (404), never 403. |
+| `enabled` | bool | `false` | Mount the ADMIN API (physical, irreversible delete). Off ⇒ every admin route answers `405 Method Not Allowed` with an empty `Allow` header, never 403. |
 
 ## `[tenancy]`
 


### PR DESCRIPTION
Closes #513.

Step-6 of the group-14 audit (#390): the five admin declarations from zero `headers(...)`/examples to the completeness bar.

- **The two released ops**: verbatim operation descriptions (the GDPR cascade sentence, the bulk dev/testing NOTE, the async/sync sentence with the explicit "this server is SYNCHRONOUS" statement), the query-form documentation (repeated + comma forms with the raw-query rationale), the DEVELOPMENT reporting qualifier, the RFC 6570 normalization note, no `Location` anywhere, the `Allow`-empty 405 with its RFC 9110 §10.2.1 ground. Two honest non-declarations, each carried in prose with its verbatim released trigger: the 202 async branch (never produced — synchronous) and the bulk route's generic 404 (unreachable — delete-what-exists → 204, malformed → 400 pre-deletion; the shipped position, register-adjudicated in #514's AMB-140).
- **The three extension declarations**: the honest our-own-extension flag; the template delete names SM `delete_opt` as analogue-not-realization (AMB-17) + the never-orphan 409; the query delete states it does NOT realize SM `delete_query` (AMB-127).
- **The 404→405 doc scrub**: `dispatch.rs`'s module doc, the `AdminConfig` doc, and the configuration book page all claimed the disabled surface answers 404 — the wire answers 405 + empty `Allow`; corrected with the §HTTP Methods citation.
- Two new completeness batteries (ratchet); adoption polish normalizes the batteries' text probe for hard-wrapped doc comments.

**Gates:** clippy `-p ehrbase-rest --all-targets` — zero warnings; nextest `-p ehrbase-rest` 559 passed / 0 failed.

Known follow-up (worker-recorded): `app/ehrbase-admin-ui/src/admin.rs` carries the same stale-404 claim in two doc comments — admin-ui source is screenshot-guard-gated, lands separately.