### PR TITLE
chore(cnf): ratchet the conformance baseline — group-14 closing zero-drift run

### DIFF
--- a/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
@@ -7,12 +7,12 @@ Runner: cnf-runner 3.11.0 · verification pack: passed
 
 | Status | Count |
 | --- | --- |
-| passed | 538 |
+| passed | 543 |
 | failed | 0 |
 | errored | 0 |
 | skipped | 0 |
 | not_applicable | 70 |
-| total | 608 |
+| total | 613 |
 
 ## By chapter
 
@@ -21,7 +21,7 @@ Runner: cnf-runner 3.11.0 · verification pack: passed
 | CONT | 123 | 0 | 0 | 0 | 0 |
 | I_ADMIN_ARCHIVE | 0 | 0 | 0 | 0 | 4 |
 | I_ADMIN_DUMP_LOAD | 0 | 0 | 0 | 0 | 2 |
-| I_ADMIN_SERVICE | 2 | 0 | 0 | 0 | 10 |
+| I_ADMIN_SERVICE | 7 | 0 | 0 | 0 | 10 |
 | I_DEFINITION_ADL14 | 19 | 0 | 0 | 0 | 6 |
 | I_DEFINITION_ADL2 | 21 | 0 | 0 | 0 | 8 |
 | I_DEFINITION_QUERY | 28 | 0 | 0 | 0 | 3 |
@@ -73,7 +73,7 @@ Percentiles re-derive from the embedded HDR V2 histograms; the class verdict is 
 
 ## Honesty
 
-Coverage: 538 of 608 selected cases driven.
+Coverage: 543 of 613 selected cases driven.
 
 Not-executed verdicts (each cited):
 

--- a/docs/conformance/ehrbase-rs/badge.json
+++ b/docs/conformance/ehrbase-rs/badge.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "openEHR conformance",
-  "message": "CORE+STANDARD PASS \u00b7 538/538 cases",
+  "message": "CORE+STANDARD PASS \u00b7 543/543 cases",
   "color": "brightgreen"
 }

--- a/docs/conformance/ehrbase-rs/results.json
+++ b/docs/conformance/ehrbase-rs/results.json
@@ -18,6 +18,12 @@
   "ixit_digest": "911ec784dff4ca9b",
   "outcomes": [
     {
+      "case": "I_ADMIN_SERVICE.physical_ehr_delete-delete_all_unfiltered",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_DEFINITION_ADL14.get_opts-retrieve_all_no_opts",
       "status": "passed",
       "rows_driven": 1,
@@ -133,7 +139,31 @@
       "citation": "I_ADMIN_SERVICE.list_contributions: AMB-33"
     },
     {
+      "case": "I_ADMIN_SERVICE.physical_ehr_delete-delete_all_cascade",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ADMIN_SERVICE.physical_ehr_delete-delete_all_subset",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_ADMIN_SERVICE.physical_ehr_delete-delete_existing",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ADMIN_SERVICE.physical_ehr_delete-delete_existing_cascade",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ADMIN_SERVICE.physical_ehr_delete-delete_existing_recreate",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1

--- a/docs/conformance/ehrbase-rs/verdicts.json
+++ b/docs/conformance/ehrbase-rs/verdicts.json
@@ -183,7 +183,7 @@
     }
   ],
   "coverage": {
-    "selected": 608,
-    "driven": 538
+    "selected": 613,
+    "driven": 543
   }
 }


### PR DESCRIPTION
The group-14 (#390) closing pipeline run — clean on the first pass, no triage.

**613 case-records: 543 passed / 0 failed / 0 errored / 70 cited n-a; 39 capability verdicts, 0 review findings.** Baseline ratchets **538 → 543** with the group-14 admin catalogue (PRs #524/#525): the `delete_all` variant binding + the unfiltered/subset/cascade/re-creation cases.