### PR TITLE
chore(cnf): group-15 closing zero-drift run — the SmartAppLaunch capability verdict

### DIFF
--- a/docs/conformance/ehrbase-rs/CONFORMANCE_CERTIFICATE.md
+++ b/docs/conformance/ehrbase-rs/CONFORMANCE_CERTIFICATE.md
@@ -58,6 +58,7 @@ Result column: ITS its-rest (canonical-json)
 | Platform | MessageApi | OPT | excused (unrealized on this technology profile) |
 | Platform | Signing | OPT | pass |
 | Platform | SimplifiedFormats | OPT | pass |
+| Platform | SmartAppLaunch | OPT | no cases |
 | Security | EhrDemographicSeparation | Y | pass |
 | Security | AuthenticatedAccess | Y | pass |
 | Security | AuthorizationSeparation | Y | pass |

--- a/docs/conformance/ehrbase-rs/badge-options.json
+++ b/docs/conformance/ehrbase-rs/badge-options.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "openEHR CNF OPTIONS",
-  "message": "PASS 17/19 capabilities",
+  "message": "PASS 17/20 capabilities",
   "color": "brightgreen"
 }

--- a/docs/conformance/ehrbase-rs/verdicts.json
+++ b/docs/conformance/ehrbase-rs/verdicts.json
@@ -138,6 +138,10 @@
       "passed"
     ],
     [
+      "SmartAppLaunch",
+      "no_cases"
+    ],
+    [
       "EhrDemographicSeparation",
       "passed"
     ],


### PR DESCRIPTION
The group-15 (#391) closing pipeline run — clean, zero drift on pass counts.

**613 case-records: 543 passed / 0 failed / 0 errored / 70 cited n-a; 40 capability verdicts (the new `SmartAppLaunch` row renders as no-cases per AMB-151's statement-declared boundary — OPTIONS tier, unclaimed, cannot affect any verdict), 0 review findings.**