### PR TITLE
test(cnf): the outward served-extensions axis + the extension-surface declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Changed
+
+- **The published Conformance Statement now declares the non-openEHR surface
+  this server serves** (#527). A new "Additional non-openEHR surface" section
+  lists every extension route family — health, status, the OpenAPI/Swagger
+  meta routes, management, terminology, event subscriptions, multi-tenancy,
+  the FHIR R4 connector and its mapping store, the ITI-81 audit read,
+  `PARTY_RELATIONSHIP`, the bare stored-query list, the admin
+  template/query/config routes and SMART discovery — with the routes it
+  serves and the configuration that enables it. The section states plainly
+  that none of it is part of any conformance claim: no openEHR specification
+  governs these routes, no conformance case exercises them, and no verdict
+  depends on them. A reader of the statement no longer has to discover the
+  extension surface on the wire.
+
 ### Fixed
 
 - **The SMART discovery endpoint is fully described in the published API

--- a/app/ehrbase-rest/src/router.rs
+++ b/app/ehrbase-rest/src/router.rs
@@ -209,6 +209,27 @@ pub fn router(state: AppState, authenticator: Arc<Authenticator>) -> Router {
     // the four always-on standardised groups plus `/admin` when its group is
     // enabled. Its identity/conformance fields come from `cfg.server.identity`
     //.
+    //
+    // NOTE (settled decision, registered as `AMB-158` in
+    // `tools/cnf-runner/artifacts/registers/ambiguities.yaml`): the list
+    // carries ONLY the standardised ITS-REST groups —
+    // the extension families this server also serves (terminology, tenancy,
+    // event subscriptions, the FHIR connector, management, …) are deliberately
+    // absent. No released sentence says what `endpoints` must contain: the
+    // System API chapter is a stub with no field semantics
+    // (`docs/specs/openehr/ITS-REST/specifications/docs/system/Description.md`
+    // — Purpose, Related Documents and Status only), and the member itself is
+    // defined only in the stalled OAS (`schemas/others/Options.yaml`:
+    // `array of string`, no description, one example listing exactly the
+    // released groups), which is codegen input and not an oracle. Two reasons
+    // for the omission: the operation's stated job is "exposing service
+    // capabilities for a conformance manifest", so a non-openEHR path listed
+    // there would sit inside a conformance claim; and the extension surface has
+    // its own honest declaration layers — the served OpenAPI document (every
+    // extension operation flagged our-own-extension) and the published
+    // Conformance Statement's "Additional non-openEHR surface" section. The
+    // list still tracks what is actually mounted, so it never advertises a
+    // group that answers 404.
     let mut endpoints = vec![
         "/ehr".to_owned(),
         "/definition".to_owned(),

--- a/tools/cnf-runner/artifacts/registers/ambiguities.yaml
+++ b/tools/cnf-runner/artifacts/registers/ambiguities.yaml
@@ -5447,3 +5447,114 @@ AMB-156:
     polymorphic choice alternatives a named, order-independent identifier rule.
   disposition: fixed_handling
   upstream_ref: "UPR-120"
+
+AMB-157:
+  ambiguity: >-
+    NOT an openEHR ambiguity — a DECLARATION, kept in this register so the
+    non-openEHR surface this server serves can never be mistaken for a
+    spec-derived one (the AMB-58 treatment, generalized from one operation to
+    the whole outward surface). The released ITS-REST text is SILENT on the URI
+    space beyond the openEHR resource set: it says what a resource IS and which
+    resources the API defines, and it never says whether a service may serve
+    anything ELSE at other paths. Both readings a reader could take — "the
+    listed resources are the whole permitted surface" and "the listed resources
+    are the openEHR part of a possibly larger surface" — are consistent with
+    every released sentence, and no released clause permits, forbids, or bounds
+    additional routes. This server takes the second reading and serves
+    FOURTEEN extension families beside the released groups.
+  source: >-
+    ITS-REST specifications/docs/overview/Resources.md §Resources ("For the
+    openEHR API, a **resource** is an instance object of a specific openEHR
+    class (type) that can be identified, addressed, handled or managed by the
+    service", followed by the resource-kind list and "For a complete list of
+    available types, refer to the class index") — a definition of the openEHR
+    resource set, never a constraint on the URI space around it. The overview's
+    only "Additional … MAY" sentence is about STATUS CODES, not routes
+    (Requests_and_responses.md §HTTP status codes: "Additional status codes MAY
+    be used as long as they do not conflict with the predefined codes"). Silence
+    CONFIRMED first-hand: a grep of specifications/docs/** for an
+    additional/vendor/proprietary/custom endpoint clause returns ZERO hits, and
+    the overview chapter set contains no "extension" sentence at all. The
+    System API chapter that might have bounded the surface is a STUB
+    (docs/system/Description.md — purpose, related documents and status only:
+    no endpoint list, no field semantics).
+  handling: >-
+    Statement-declared, and enumerated rather than described. THE FAMILIES ARE
+    NOT LISTED HERE: they live in the `served_extensions` axis of
+    vocab/wire_surface.yaml — one entry per family with its routes (the default
+    deployment spelling), its configuration gate, and its own verified
+    spec-silence line — and the Conformance Statement renders that axis as its
+    "Additional non-openEHR surface" section, so an SDoC reader learns the
+    surface exists instead of discovering it on the wire. Keeping the
+    enumeration in exactly one machine-readable place is the point: a prose copy
+    here would rot the first time a family is added, gated differently, or
+    removed. THE AXIS NEVER GATES: no coverage obligation is derived from it —
+    no case is required, no branch is expected, no verdict depends on it —
+    which every entry states as `never_gates: true` and the surface-coverage
+    gate's own tests pin. Every family is our own design/extension, no openEHR
+    spec governs any of them, and this party's statement claims conformance for
+    NONE of them. Consequence for the inward axes, stated so the two readings of
+    "off the wire" cannot be confused: an SM operation recorded `off_wire`
+    because released ITS-REST surfaces no resource for it stays exactly right
+    about the SPEC even when this server serves an extension in that space —
+    the nine I_TERMINOLOGY_SERVICE rows carry that cross-reference explicitly.
+    WHY THIS DISPOSITION: `report_only` is wrong because there is nothing to
+    report — the silence is not a defect in openEHR's text but the ordinary
+    condition of anything outside its scope, and the disposition would force an
+    `upstream_ref` that could only be invented. `fixed_handling` is wrong
+    because no case's expectation rests on this entry; nothing in the catalogue
+    changes because of it. `statement_declared` is exactly what it is: a
+    behaviour the party declares and no normative case covers. Revisits only if
+    a future ITS-REST release states a rule about the URI space beyond the
+    resource set.
+  disposition: statement_declared
+
+AMB-158:
+  ambiguity: >-
+    The System-API conformance manifest carries an `endpoints` member and no
+    released sentence says what it must contain. The docs text describes the
+    manifest's PURPOSE and never its content; the only place `endpoints` is
+    defined at all is the OAS schema, which types it `array of string`, gives
+    it no description, and shows one example listing the five standardised
+    groups. So "which endpoints" — every mounted route family, or the openEHR
+    API groups the release names — is undefined, and a service that lists only
+    the standardised groups and a service that also lists its extension
+    families are both consistent with every released sentence.
+  source: >-
+    ITS-REST specifications/docs/system/Description.md — the whole System API
+    chapter, a STUB carrying only Purpose, Related Documents and Status; it
+    contains no endpoint list, no manifest field list and no "endpoints"
+    occurrence. Plus docs/overview/Requests_and_responses.md §HTTP Methods
+    (OPTIONS: "Describe the communication options for the target resource"),
+    the only released sentence about the method's meaning. The `endpoints`
+    member itself appears ONLY in the stalled OAS
+    (specifications/schemas/others/Options.yaml: `endpoints: {type: array,
+    items: {type: string}}` with the five-entry example, no description; and
+    specifications/operations/options.yaml, "exposing service capabilities for
+    a conformance manifest") — recorded as provenance for where the member
+    comes from, NOT as an oracle (owner ruling 2026-07-24: the OAS is stalled
+    and the docs text governs). Silence CONFIRMED first-hand.
+  handling: >-
+    Fixed handling, and the shipped decision is stated rather than left
+    implicit. The manifest lists the LIVE standardised ITS-REST group set —
+    /ehr, /definition, /query, /demographic, plus /admin when that group is
+    enabled — and omits every extension family. Two reasons, neither of them
+    convenience. (a) THE MEMBER SPEAKS ITS-REST: the one example the release
+    offers is exactly the released group set, and the manifest's stated job is
+    "exposing service capabilities for a conformance manifest" — a
+    CONFORMANCE manifest, whose subject is the openEHR API a client can hold
+    the service to. Advertising our own routes in that field would put
+    non-openEHR paths inside a conformance claim. (b) THE EXTENSION SURFACE HAS
+    ITS OWN DECLARATION LAYERS, all three of them honest and all three richer
+    than a bare path list: the served OpenAPI document (every extension
+    operation flagged our-own-extension in its own description), the
+    `served_extensions` axis of vocab/wire_surface.yaml, and the Conformance
+    Statement's "Additional non-openEHR surface" section rendered from it
+    (register AMB-157). LIVE, NOT STATIC: the list still tracks what is actually
+    mounted — /admin appears only when the admin group is enabled — so the
+    manifest never advertises a group that answers 404. This entry gates
+    nothing: the manifest behaviour itself is exercised by the SUT's own tests
+    and recorded as the `system-options-conformance-manifest` wire-surface
+    element (no SM anchor exists for the System API operation). Revisits if a
+    future release defines the member's contents.
+  disposition: fixed_handling

--- a/tools/cnf-runner/artifacts/vocab/wire_surface.yaml
+++ b/tools/cnf-runner/artifacts/vocab/wire_surface.yaml
@@ -166,30 +166,39 @@ sm_operations:
   - operation: I_TERMINOLOGY_SERVICE.get_term
     reason: off_wire
     source: "SM i_terminology_service.adoc — released ITS-REST 1.1.0 surfaces no terminology REST resource (terminology access is the TERM component, not a wire API)"
+    note: "This SUT nevertheless SERVES a terminology API as a declared extension (GET /terminology and its five sub-routes) — enumerated in the served_extensions axis of this file and adjudicated by register AMB-157. The row above is about the SPEC and stays exactly right: released ITS-REST 1.1.0 surfaces no terminology resource. No released clause governs the URI space beyond the resource set, so serving one breaches nothing, and no conformance claim rests on those routes."
   - operation: I_TERMINOLOGY_SERVICE.get_terminology_description
     reason: off_wire
     source: "SM i_terminology_service.adoc — released ITS-REST 1.1.0 surfaces no terminology REST resource (terminology access is the TERM component, not a wire API)"
+    note: "This SUT nevertheless SERVES a terminology API as a declared extension (GET /terminology and its five sub-routes) — enumerated in the served_extensions axis of this file and adjudicated by register AMB-157. The row above is about the SPEC and stays exactly right: released ITS-REST 1.1.0 surfaces no terminology resource. No released clause governs the URI space beyond the resource set, so serving one breaches nothing, and no conformance claim rests on those routes."
   - operation: I_TERMINOLOGY_SERVICE.get_terminology_ids
     reason: off_wire
     source: "SM i_terminology_service.adoc — released ITS-REST 1.1.0 surfaces no terminology REST resource (terminology access is the TERM component, not a wire API)"
+    note: "This SUT nevertheless SERVES a terminology API as a declared extension (GET /terminology and its five sub-routes) — enumerated in the served_extensions axis of this file and adjudicated by register AMB-157. The row above is about the SPEC and stays exactly right: released ITS-REST 1.1.0 surfaces no terminology resource. No released clause governs the URI space beyond the resource set, so serving one breaches nothing, and no conformance claim rests on those routes."
   - operation: I_TERMINOLOGY_SERVICE.get_value_set
     reason: off_wire
     source: "SM i_terminology_service.adoc — released ITS-REST 1.1.0 surfaces no terminology REST resource (terminology access is the TERM component, not a wire API)"
+    note: "This SUT nevertheless SERVES a terminology API as a declared extension (GET /terminology and its five sub-routes) — enumerated in the served_extensions axis of this file and adjudicated by register AMB-157. The row above is about the SPEC and stays exactly right: released ITS-REST 1.1.0 surfaces no terminology resource. No released clause governs the URI space beyond the resource set, so serving one breaches nothing, and no conformance claim rests on those routes."
   - operation: I_TERMINOLOGY_SERVICE.has_term
     reason: off_wire
     source: "SM i_terminology_service.adoc — released ITS-REST 1.1.0 surfaces no terminology REST resource (terminology access is the TERM component, not a wire API)"
+    note: "This SUT nevertheless SERVES a terminology API as a declared extension (GET /terminology and its five sub-routes) — enumerated in the served_extensions axis of this file and adjudicated by register AMB-157. The row above is about the SPEC and stays exactly right: released ITS-REST 1.1.0 surfaces no terminology resource. No released clause governs the URI space beyond the resource set, so serving one breaches nothing, and no conformance claim rests on those routes."
   - operation: I_TERMINOLOGY_SERVICE.has_terminology
     reason: off_wire
     source: "SM i_terminology_service.adoc — released ITS-REST 1.1.0 surfaces no terminology REST resource (terminology access is the TERM component, not a wire API)"
+    note: "This SUT nevertheless SERVES a terminology API as a declared extension (GET /terminology and its five sub-routes) — enumerated in the served_extensions axis of this file and adjudicated by register AMB-157. The row above is about the SPEC and stays exactly right: released ITS-REST 1.1.0 surfaces no terminology resource. No released clause governs the URI space beyond the resource set, so serving one breaches nothing, and no conformance claim rests on those routes."
   - operation: I_TERMINOLOGY_SERVICE.has_value_set
     reason: off_wire
     source: "SM i_terminology_service.adoc — released ITS-REST 1.1.0 surfaces no terminology REST resource (terminology access is the TERM component, not a wire API)"
+    note: "This SUT nevertheless SERVES a terminology API as a declared extension (GET /terminology and its five sub-routes) — enumerated in the served_extensions axis of this file and adjudicated by register AMB-157. The row above is about the SPEC and stays exactly right: released ITS-REST 1.1.0 surfaces no terminology resource. No released clause governs the URI space beyond the resource set, so serving one breaches nothing, and no conformance claim rests on those routes."
   - operation: I_TERMINOLOGY_SERVICE.subsumes
     reason: off_wire
     source: "SM i_terminology_service.adoc — released ITS-REST 1.1.0 surfaces no terminology REST resource (terminology access is the TERM component, not a wire API)"
+    note: "This SUT nevertheless SERVES a terminology API as a declared extension (GET /terminology and its five sub-routes) — enumerated in the served_extensions axis of this file and adjudicated by register AMB-157. The row above is about the SPEC and stays exactly right: released ITS-REST 1.1.0 surfaces no terminology resource. No released clause governs the URI space beyond the resource set, so serving one breaches nothing, and no conformance claim rests on those routes."
   - operation: I_TERMINOLOGY_SERVICE.value_set_validate
     reason: off_wire
     source: "SM i_terminology_service.adoc — released ITS-REST 1.1.0 surfaces no terminology REST resource (terminology access is the TERM component, not a wire API)"
+    note: "This SUT nevertheless SERVES a terminology API as a declared extension (GET /terminology and its five sub-routes) — enumerated in the served_extensions axis of this file and adjudicated by register AMB-157. The row above is about the SPEC and stays exactly right: released ITS-REST 1.1.0 surfaces no terminology resource. No released clause governs the URI space beyond the resource set, so serving one breaches nothing, and no conformance claim rests on those routes."
   - operation: I_VALIDITY_CHECKER.content_valid
     reason: off_wire
     source: "SM i_validity_checker.adoc — validity checking is an internal service; released ITS-REST 1.1.0 exposes no validity-checker resource (validation happens at commit)"
@@ -1463,3 +1472,174 @@ elements:
       reason: statement_declared
       register: AMB-151
       note: "Same two blockers as smart-resource-scope-grammar (SMART off in the composed SUT; no per-case scoped Bearer token). Proven instead by app/ehrbase-rest/tests/smart_http.rs — `fail_closed_denies_scopeless_template_access` and `fail_closed_denies_scopeless_query_access` (the two families that were parsed-but-never-enforced before the group-15 wire fix), `advisory_mode_defers_for_scopeless_callers` and `smart_disabled_leaves_families_ungated` (the negative directions) — plus the PEP unit tests in app/ehrbase-rest/src/extensions/access/pep.rs. The generic 401/403 discipline itself is separately gated by the SEC-BASIC cases, which do not depend on SMART."
+
+# ── Axis 4 — the OUTWARD axis: the non-openEHR surface this SUT serves ──────
+#
+# The first three axes are spec-inward (what the released text defines, and
+# whether a case reaches it). This one runs the other way: it DECLARES the
+# route families the SUT serves BEYOND the openEHR resource set, so a reader
+# of the Conformance Statement learns the extension surface exists instead of
+# discovering it on the wire. Register AMB-157 is the adjudication.
+#
+# IT NEVER GATES. No coverage obligation is derived from this axis — no case
+# is required, no branch is expected, no verdict depends on it — and every
+# entry says so in its own `never_gates: true`.
+#
+# THE STANDING SILENCE every entry rests on, verified first-hand: no released
+# clause governs the URI space beyond the ITS-REST resource set.
+# docs/overview/Resources.md §Resources defines what a resource IS ("a
+# **resource** is an instance object of a specific openEHR class (type) that
+# can be identified, addressed, handled or managed by the service") and lists
+# the openEHR resource kinds; it never constrains what else a service may
+# serve. The overview's only "Additional … MAY" sentence is about status codes
+# (Requests_and_responses.md §HTTP status codes: "Additional status codes MAY
+# be used as long as they do not conflict with the predefined codes"). A grep
+# of ITS-REST specifications/docs/** for an additional/vendor/proprietary/
+# extension endpoint clause returns zero hits. So every family below is
+# spec-silent by construction — our own design/extension — and each entry
+# records the silence, never a permission the text does not grant.
+#
+# ROUTES are written as the server mounts them under the DEFAULT deployment
+# (absolute from the server root, `server.base_path` = /ehrbase/rest/openehr/v1
+# included) — the same convention the served OpenAPI document uses. A
+# non-default `server.base_path` moves the base-path-relative ones; the served
+# document follows it.
+served_extensions:
+  # ── (1) the ten families the group-17 audit found undeclared ──────────────
+  - family: health
+    routes:
+      - "GET /health"
+      - "GET /health/liveness"
+      - "GET /health/readiness"
+    config_gate: "always on — no toggle; mounted outside the API base path and outside authentication (app/ehrbase-rest/src/extensions/health.rs)"
+    spec_silence: "ITS-REST defines no health/liveness/readiness resource anywhere (grep of specifications/docs/**: zero hits) and no released clause governs the URI space beyond the resource set — Resources.md §Resources defines resources, never a route-space constraint. Our own design/extension: a container-orchestration probe surface."
+    never_gates: true
+  - family: server-status
+    routes:
+      - "GET /ehrbase/rest/status"
+    config_gate: "always on — no toggle; mounted at the REST root (the base path minus /openehr/v1), outside authentication (app/ehrbase-rest/src/overview/status.rs)"
+    spec_silence: "No released clause defines an operational status resource; the one released self-description operation is the System API's OPTIONS on the API root (docs/system/Description.md), which this endpoint neither replaces nor duplicates. No released clause governs the URI space beyond the resource set. Our own design/extension."
+    never_gates: true
+  - family: openapi-meta
+    routes:
+      - "GET /ehrbase/rest/api-docs/openapi.json"
+      - "GET /ehrbase/rest/api-docs/ehrbase-ehr.openapi.json"
+      - "GET /ehrbase/rest/api-docs/ehrbase-query.openapi.json"
+      - "GET /ehrbase/rest/api-docs/ehrbase-definition.openapi.json"
+      - "GET /ehrbase/rest/api-docs/ehrbase-demographic.openapi.json"
+      - "GET /ehrbase/rest/api-docs/ehrbase-admin.openapi.json"
+      - "GET /ehrbase/rest/api-docs/ehrbase-management.openapi.json"
+      - "GET /ehrbase/rest/api-docs/ehrbase-terminology.openapi.json"
+      - "GET /ehrbase/rest/api-docs/ehrbase-relationships.openapi.json"
+      - "GET /ehrbase/rest/api-docs/ehrbase-events.openapi.json"
+      - "GET /ehrbase/rest/api-docs/ehrbase-tenancy.openapi.json"
+      - "GET /ehrbase/rest/api-docs/ehrbase-fhir.openapi.json"
+      - "GET /ehrbase/rest/api-docs/ehrbase-smart.openapi.json"
+      - "GET /ehrbase/rest/swagger-ui"
+      - "GET /ehrbase/rest/swagger-ui/{*file}"
+    config_gate: "server.swagger_ui (default on) for the whole family; the document paths follow server.openapi_json_path()/swagger_ui_path(), which derive from server.base_path"
+    spec_silence: "No released clause defines an OAS-serving or API-console endpoint; the release publishes its own OpenAPI artifacts as downloads, not as a service obligation (docs/system/Description.md §Status links the bundles for validation/code generation). No released clause governs the URI space beyond the resource set. Our own design/extension: the twelve per-family documents plus the composed document are all generated from this server's own handlers — a vendored openEHR OAS is never served. The trailing `{*file}` is the embedded Swagger asset route (UI packaging, no API contract)."
+    never_gates: true
+  - family: management
+    routes:
+      - "GET /management/info"
+      - "GET /management/prometheus"
+      - "GET /management/metrics"
+      - "GET /management/metrics/{name}"
+      - "GET /management/env"
+      - "GET /management/loggers"
+      - "POST /management/loggers"
+      - "DELETE /management/loggers"
+    config_gate: "observability management.enabled (default off); with management.port set the family moves to its own listener instead of the API listener — when off, the routes are absent (a router 404), not gated in-handler"
+    spec_silence: "ITS-REST defines no operational/introspection surface at all (no metrics, no logger, no environment resource — grep of specifications/docs/**: zero hits) and no released clause governs the URI space beyond the resource set. Our own design/extension."
+    never_gates: true
+  - family: terminology
+    routes:
+      - "GET /ehrbase/rest/openehr/v1/terminology"
+      - "GET /ehrbase/rest/openehr/v1/terminology/{terminology_id}"
+      - "GET /ehrbase/rest/openehr/v1/terminology/{terminology_id}/term/{code}"
+      - "GET /ehrbase/rest/openehr/v1/terminology/{terminology_id}/subsumes"
+      - "GET /ehrbase/rest/openehr/v1/terminology/{terminology_id}/value_set/{value_set_id}"
+      - "GET /ehrbase/rest/openehr/v1/terminology/{terminology_id}/value_set/{value_set_id}/validate"
+    config_gate: "[terminology].api_enabled (default off); the gate sits in-handler behind authentication, so a disabled group answers 401 to an unauthenticated caller and 404 to an authenticated one"
+    spec_silence: "SM i_terminology_service.adoc declares the nine terminology operations and released ITS-REST 1.1.0 surfaces NO terminology resource for any of them (the Axis-1 I_TERMINOLOGY_SERVICE off_wire rows above record that boundary). The absence of a wire is not a prohibition on one: no released clause governs the URI space beyond the resource set. These routes are our own design/extension over the TERM component, and no conformance claim rests on them."
+    never_gates: true
+  - family: event-subscription
+    routes:
+      - "GET /ehrbase/rest/openehr/v1/admin/event_subscription"
+      - "POST /ehrbase/rest/openehr/v1/admin/event_subscription"
+      - "GET /ehrbase/rest/openehr/v1/admin/event_subscription/{subscription_id}"
+      - "PUT /ehrbase/rest/openehr/v1/admin/event_subscription/{subscription_id}"
+      - "DELETE /ehrbase/rest/openehr/v1/admin/event_subscription/{subscription_id}"
+    config_gate: "[events].admin_api (default off); the gate sits in-handler behind authentication (401 unauthenticated, 404 authenticated when off)"
+    spec_silence: "ITS-REST defines no subscription/notification resource and the released Admin API is exactly two operations (specifications/operations/admin_ehr_delete.yaml + admin_ehr_delete_all.yaml). No released clause governs the URI space beyond the resource set. Our own design/extension: change-event subscriptions administered under the /admin prefix."
+    never_gates: true
+  - family: tenancy
+    routes:
+      - "GET /ehrbase/rest/openehr/v1/admin/tenant"
+      - "POST /ehrbase/rest/openehr/v1/admin/tenant"
+      - "GET /ehrbase/rest/openehr/v1/admin/tenant/{tenant_id}"
+      - "PUT /ehrbase/rest/openehr/v1/admin/tenant/{tenant_id}"
+      - "DELETE /ehrbase/rest/openehr/v1/admin/tenant/{tenant_id}"
+    config_gate: "[tenancy].enabled (default off); the routes stay mounted and answer 404 in-handler when off (401 first for an unauthenticated caller)"
+    spec_silence: "openEHR has no multi-tenancy concept in any released component — ITS-REST names no tenant resource, header or parameter (grep of specifications/**: zero hits) — and no released clause governs the URI space beyond the resource set. Our own design/extension."
+    never_gates: true
+  - family: fhir-r4-connector
+    routes:
+      - "POST /ehrbase/rest/openehr/v1/fhir/r4/{resource_type}"
+      - "GET /ehrbase/rest/openehr/v1/fhir/r4/{resource_type}"
+    config_gate: "[fhir].api_enabled (default off); the gate sits in-handler behind authentication and refuses with a FHIR OperationOutcome"
+    spec_silence: "FHIR interoperability is outside every released openEHR component: ITS-REST defines no FHIR resource, media type or route, and no released clause governs the URI space beyond the resource set. Our own design/extension — the inbound HL7 FHIR R4 façade, whose contract is HL7's, not openEHR's."
+    never_gates: true
+  - family: fhir-mapping-store
+    routes:
+      - "GET /ehrbase/rest/openehr/v1/admin/fhir_mapping"
+      - "POST /ehrbase/rest/openehr/v1/admin/fhir_mapping"
+      - "GET /ehrbase/rest/openehr/v1/admin/fhir_mapping/{mapping_id}"
+      - "PUT /ehrbase/rest/openehr/v1/admin/fhir_mapping/{mapping_id}"
+      - "DELETE /ehrbase/rest/openehr/v1/admin/fhir_mapping/{mapping_id}"
+    config_gate: "[fhir].api_enabled (default off) — the same gate as the connector, same in-handler posture"
+    spec_silence: "The administration of FHIR↔openEHR mappings has no counterpart in any released component, and the released Admin API is exactly two EHR-deletion operations. No released clause governs the URI space beyond the resource set. Our own design/extension."
+    never_gates: true
+  - family: iti-81-audit-record-repository
+    routes:
+      - "GET /ehrbase/rest/openehr/v1/fhir/r4/AuditEvent"
+    config_gate: "the local Audit Record Repository (ehrbase::system_log, on by default); answers 404 when the repository is disabled"
+    spec_silence: "The SM platform overview's component table carries the row \"System Log | IHE ATNA-compliant system log.\" while UML/classes/i_system_log.adoc is an EMPTY interface table (no description, no functions) — so the service model names the obligation and defines no operation, and released ITS-REST surfaces no audit resource (the same gap register AMB-144 reports upstream). No released clause governs the URI space beyond the resource set. Our own design/extension: the IHE ITI-81 Retrieve ATNA Audit Event read side, whose contract is IHE's, not openEHR's."
+    never_gates: true
+  # ── (2) the extension families earlier audits already adjudicated ─────────
+  # Declared here too: the axis is the COMPLETE outward surface, and a family
+  # already carrying a register entry is no less served than a new one.
+  - family: party-relationship
+    routes:
+      - "POST /ehrbase/rest/openehr/v1/demographic/party_relationship"
+      - "GET /ehrbase/rest/openehr/v1/demographic/party_relationship/{uid_based_id}"
+      - "PUT /ehrbase/rest/openehr/v1/demographic/party_relationship/{uid_based_id}"
+      - "DELETE /ehrbase/rest/openehr/v1/demographic/party_relationship/{uid_based_id}"
+      - "GET /ehrbase/rest/openehr/v1/demographic/versioned_party_relationship/{versioned_object_uid}"
+      - "GET /ehrbase/rest/openehr/v1/demographic/versioned_party_relationship/{versioned_object_uid}/revision_history"
+      - "GET /ehrbase/rest/openehr/v1/demographic/versioned_party_relationship/{versioned_object_uid}/version"
+      - "GET /ehrbase/rest/openehr/v1/demographic/versioned_party_relationship/{versioned_object_uid}/version/{version_uid}"
+    config_gate: "always on with the DEMOGRAPHIC group (no separate toggle)"
+    spec_silence: "SM i_party_relationship.adoc declares the operations and released ITS-REST 1.1.0 surfaces no PARTY_RELATIONSHIP resource — register AMB-32, whose its-rest bindings are explicitly unrealized so the cases verdict not-applicable WITH CITATION. These routes are the honest boundary realization: no released clause governs the URI space beyond the resource set, so serving them breaches nothing, and no conformance claim rests on them."
+    never_gates: true
+  - family: stored-query-bare-list
+    routes:
+      - "GET /ehrbase/rest/openehr/v1/definition/query"
+    config_gate: "always on with the DEFINITION group (no separate toggle)"
+    spec_silence: "The release defines exactly one stored-query list operation, GET /definition/query/{qualified_query_name} (specifications/operations/definition_query_list.yaml), whose path parameter is required (parameters/path/qualified_query_name.yaml) — so its own \"when is empty, it will be treated as 'wildcard' in the search\" clause has no addressable released form. No released clause governs the URI space beyond the resource set. Our own design/extension: the bare form serves exactly what the released list serves for the empty prefix; the released route stays the gated one (register AMB-121 records the SM-vs-wire listing gap)."
+    never_gates: true
+  - family: admin-extension-routes
+    routes:
+      - "DELETE /ehrbase/rest/openehr/v1/admin/template/{template_id}"
+      - "DELETE /ehrbase/rest/openehr/v1/admin/query/{qualified_query_name}/{version}"
+      - "GET /ehrbase/rest/openehr/v1/admin/config"
+    config_gate: "[admin].enabled (default off) — the same gate as the released admin deletes; 405 when off, RBAC Admin class by the /admin/ path"
+    spec_silence: "The released Admin API is exactly two operations (specifications/operations/admin_ehr_delete.yaml + admin_ehr_delete_all.yaml); nothing released deletes a template, deletes one stored-query version, or exposes a configuration tree. The query delete deliberately does NOT claim SM I_DEFINITION_QUERY.delete_query, which is keyed by name alone and removes every version (register AMB-127 keeps that operation unrealized). No released clause governs the URI space beyond the resource set. Our own design/extension, excluded from every conformance-profile claim."
+    never_gates: true
+  - family: smart-discovery
+    routes:
+      - "GET /ehrbase/rest/.well-known/smart-configuration"
+    config_gate: "[smart] (default off) — absent entirely when disabled, so a non-SMART deployment's wire is byte-identical to one without the feature"
+    spec_silence: "The SMART on openEHR chapters are DEVELOPMENT-status and their subject is a Platform, not the CDR (register AMB-151). The discovery document itself is one of the three CDR-side behaviours those chapters do define (master04 §Service Discovery), but the endpoint definition is FHIR's, which master04 only \"extends\" — so the route exists in this server as a declared, statement-level capability, not as a released openEHR obligation, and this party's statement claims no SMART conformance."
+    never_gates: true

--- a/tools/cnf-runner/schemas/wire-surface.schema.json
+++ b/tools/cnf-runner/schemas/wire-surface.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "urn:openehr:cnf:schema:wire-surface:0.1.0",
   "title": "CNF 2.0 wire-surface coverage register",
-  "description": "The authored, spec-cited record of the wire surface the catalogue is measured against for TOTAL coverage (issue #271): Axis-1 SM operations with no its-rest binding, Axis-2 per-binding outcome/format branches no case exercises, and Axis-3 cross-cutting wire behaviours mapped to cases or an adjudicated exception. Every source is a released spec component / ITS-REST docs text, never the vendored OAS.",
+  "description": "The authored, spec-cited record of the wire surface the catalogue is measured against for TOTAL coverage (issue #271): Axis-1 SM operations with no its-rest binding, Axis-2 per-binding outcome/format branches no case exercises, Axis-3 cross-cutting wire behaviours mapped to cases or an adjudicated exception, and Axis-4 the outward declaration of the route families the SUT serves beyond the openEHR resource set (a declaration, never an obligation — no coverage requirement is derived from it). Every source is a released spec component / ITS-REST docs text, never the vendored OAS.",
   "type": "object",
   "additionalProperties": false,
   "properties": {
@@ -220,6 +220,45 @@
                 "minLength": 1
               }
             }
+          }
+        }
+      }
+    },
+    "served_extensions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "family",
+          "routes",
+          "config_gate",
+          "spec_silence",
+          "never_gates"
+        ],
+        "properties": {
+          "family": {
+            "type": "string",
+            "minLength": 1
+          },
+          "routes": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "pattern": "^(GET|POST|PUT|DELETE|HEAD) /\\S*$"
+            }
+          },
+          "config_gate": {
+            "type": "string",
+            "minLength": 1
+          },
+          "spec_silence": {
+            "type": "string",
+            "minLength": 1
+          },
+          "never_gates": {
+            "const": true
           }
         }
       }

--- a/tools/cnf-runner/src/bin/cnf-runner.rs
+++ b/tools/cnf-runner/src/bin/cnf-runner.rs
@@ -520,6 +520,14 @@ fn run_verdicts(
 
     let report = compute(&statement, &results, &cases, &perf_cases, matrix, register);
 
+    // The outward wire-surface axis (`vocab/wire_surface.yaml`
+    // `served_extensions`): rendered into the statement as a declaration of the
+    // non-openEHR surface, never an input to any verdict.
+    let served_extensions = match &loaded.set.wire_surface {
+        Some((_, wire_surface)) => wire_surface.served_extensions.as_slice(),
+        None => &[],
+    };
+
     if let Err(e) = std::fs::create_dir_all(out) {
         eprintln!("cannot create {}: {e}", out.display());
         return ExitCode::from(2);
@@ -541,7 +549,7 @@ fn run_verdicts(
         ("CONFORMANCE_REPORT.md", render_report(&results, &report)),
         (
             "CONFORMANCE_STATEMENT.md",
-            render_statement(&statement, &report),
+            render_statement(&statement, &report, served_extensions),
         ),
         (
             "CONFORMANCE_CERTIFICATE.md",

--- a/tools/cnf-runner/src/model/wire_surface.rs
+++ b/tools/cnf-runner/src/model/wire_surface.rs
@@ -15,6 +15,13 @@
 //! - `elements` — Axis 3: the cross-cutting wire behaviours (conditional
 //!   headers, content negotiation, the negotiation/error status families)
 //!   mapped to the cases that exercise them, or an adjudicated exception.
+//! - `served_extensions` — Axis 4, the OUTWARD axis: the route families a SUT
+//!   serves BEYOND the openEHR resource set. The first three axes are all
+//!   spec-inward (what the spec defines and whether a case reaches it); this
+//!   one runs the other way and is a **declaration, never an obligation** —
+//!   every entry carries `never_gates: true` and NO coverage requirement is
+//!   ever derived from it. It exists so an SDoC reader learns the extension
+//!   surface exists instead of discovering it on the wire.
 //!
 //! Every enumeration source is a RELEASED spec component or the ITS-REST docs
 //! text — NEVER the vendored OAS (owner ruling 2026-07-24,
@@ -25,7 +32,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::ids::{AmbiguityId, CaseId, SmOperationRef};
-use crate::vocab::{FormatName, OutcomeKind};
+use crate::vocab::{FormatName, HttpMethod, OutcomeKind};
 
 /// Why a spec-defined wire behaviour has no exercising case — the closed
 /// disposition vocabulary of the coverage register.
@@ -194,6 +201,101 @@ impl WireElement {
     }
 }
 
+/// Axis 4: one family of routes the SUT serves OUTSIDE the openEHR resource
+/// set — a **declaration**, never an obligation.
+///
+/// The released ITS-REST text defines a resource set
+/// (`docs/overview/Resources.md` §Resources: "a **resource** is an instance
+/// object of a specific openEHR class (type) that can be identified,
+/// addressed, handled or managed by the service") and never constrains the URI
+/// space around it: no released clause permits, forbids, or bounds additional
+/// routes. So every entry here is spec-silent by construction — our own
+/// design/extension — and `spec_silence` records the verified silence rather
+/// than a permission that does not exist.
+///
+/// The axis is inert by design: the `surface-coverage` gate derives NO
+/// obligation from it (no case is required, no branch is expected, no verdict
+/// depends on it), which [`ServedExtension::never_gates`] states in every
+/// entry and the gate's own tests pin.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ServedExtension {
+    /// A stable family name (the grouping an SDoC reader sees).
+    pub family: String,
+    /// The routes the family serves, each `"<METHOD> <path>"`, written as the
+    /// server mounts them under the DEFAULT deployment (absolute from the
+    /// server root, base path included — the same convention the served
+    /// OpenAPI document uses).
+    pub routes: Vec<String>,
+    /// The configuration that mounts (or answers on) the family, verbatim —
+    /// including the always-on case.
+    pub config_gate: String,
+    /// The verified released-text silence the family rests on: what the
+    /// released text does and does not say about this URI space.
+    pub spec_silence: String,
+    /// Always `true`, and stated per entry rather than assumed: this axis is a
+    /// declaration and MUST NOT be read as a coverage obligation.
+    pub never_gates: bool,
+}
+
+impl ServedExtension {
+    /// The path half of a declared route (`"GET /health"` → `"/health"`).
+    /// `None` when the route is outside the grammar — which
+    /// [`ServedExtension::check_invariants`] reports as its own finding.
+    #[must_use]
+    pub fn route_path(route: &str) -> Option<&str> {
+        let (method, path) = route.split_once(' ')?;
+        Self::method(method)?;
+        path.starts_with('/').then_some(path)
+    }
+
+    /// The closed method vocabulary, resolved through the same serde tokens the
+    /// binding layer uses (no second spelling of the method list).
+    fn method(token: &str) -> Option<HttpMethod> {
+        serde_json::from_value::<HttpMethod>(serde_json::Value::String(token.to_owned())).ok()
+    }
+
+    /// Shape invariants: a named family with at least one well-formed route, a
+    /// stated gate and silence, and `never_gates` actually set. Returns one
+    /// message per violated invariant (empty = sound).
+    #[must_use]
+    pub fn check_invariants(&self) -> Vec<String> {
+        let mut findings = Vec::new();
+        let label = if self.family.trim().is_empty() {
+            findings.push("served_extensions entry has an empty family name".to_owned());
+            "<unnamed>"
+        } else {
+            self.family.as_str()
+        };
+        if !self.never_gates {
+            findings.push(format!(
+                "served extension {label} sets never_gates: false — this axis is a declaration \
+                 and can never carry a coverage obligation"
+            ));
+        }
+        if self.routes.is_empty() {
+            findings.push(format!("served extension {label} declares no routes"));
+        }
+        for route in &self.routes {
+            if Self::route_path(route).is_none() {
+                findings.push(format!(
+                    "served extension {label} route {route:?} is outside the grammar \
+                     (\"<METHOD> /<path>\", method from the closed HTTP-method vocabulary)"
+                ));
+            }
+        }
+        if self.config_gate.trim().is_empty() {
+            findings.push(format!("served extension {label} states no config gate"));
+        }
+        if self.spec_silence.trim().is_empty() {
+            findings.push(format!(
+                "served extension {label} states no spec-silence citation"
+            ));
+        }
+        findings
+    }
+}
+
 /// `vocab/wire_surface.yaml` — the whole coverage register.
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -207,6 +309,10 @@ pub struct WireSurface {
     /// Axis 3 cross-cutting wire-surface elements.
     #[serde(default)]
     pub elements: Vec<WireElement>,
+    /// Axis 4 — the outward declaration of the non-openEHR surface this SUT
+    /// serves. Never a source of coverage obligations.
+    #[serde(default)]
+    pub served_extensions: Vec<ServedExtension>,
 }
 
 impl WireSurface {
@@ -267,6 +373,24 @@ impl WireSurface {
                 ));
             }
         }
+        let mut families = std::collections::BTreeSet::new();
+        let mut routes = std::collections::BTreeSet::new();
+        for extension in &self.served_extensions {
+            findings.extend(extension.check_invariants());
+            if !families.insert(extension.family.as_str()) {
+                findings.push(format!(
+                    "served_extensions family {} is declared twice",
+                    extension.family
+                ));
+            }
+            for route in &extension.routes {
+                if !routes.insert(route.as_str()) {
+                    findings.push(format!(
+                        "served_extensions route {route:?} is declared by more than one family"
+                    ));
+                }
+            }
+        }
         if findings.is_empty() {
             Ok(())
         } else {
@@ -309,6 +433,64 @@ mod tests {
         }))
         .unwrap();
         assert!(covered.check_invariants().is_ok());
+    }
+
+    fn served(never_gates: bool, routes: &[&str]) -> ServedExtension {
+        serde_json::from_value(serde_json::json!({
+            "family": "management",
+            "routes": routes,
+            "config_gate": "management.enabled",
+            "spec_silence": "no released clause governs the URI space beyond the resource set",
+            "never_gates": never_gates
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn served_extension_requires_never_gates_and_a_route_grammar() {
+        let ok = served(true, &["GET /management/info"]);
+        assert!(ok.check_invariants().is_empty());
+
+        // never_gates: false is the one value the axis cannot carry — a
+        // declaration may never become an obligation.
+        let gating = served(false, &["GET /management/info"]);
+        assert!(
+            gating
+                .check_invariants()
+                .iter()
+                .any(|m| m.contains("never_gates")),
+            "{:?}",
+            gating.check_invariants()
+        );
+
+        // Route grammar: "<METHOD> /<path>", method from the closed vocabulary.
+        for bad in ["/management/info", "FETCH /management/info", "GET info"] {
+            let e = served(true, &[bad]);
+            assert!(
+                e.check_invariants().iter().any(|m| m.contains("grammar")),
+                "{bad} should be rejected"
+            );
+        }
+        assert_eq!(
+            ServedExtension::route_path("DELETE /admin/tenant/{tenant_id}"),
+            Some("/admin/tenant/{tenant_id}")
+        );
+    }
+
+    #[test]
+    fn served_extension_families_and_routes_are_unique() {
+        let surface: WireSurface = serde_json::from_value(serde_json::json!({
+            "served_extensions": [
+                { "family": "health", "routes": ["GET /health"], "config_gate": "always on",
+                  "spec_silence": "s", "never_gates": true },
+                { "family": "health", "routes": ["GET /health"], "config_gate": "always on",
+                  "spec_silence": "s", "never_gates": true }
+            ]
+        }))
+        .unwrap();
+        let findings = surface.check_invariants().unwrap_err();
+        assert!(findings.iter().any(|m| m.contains("declared twice")));
+        assert!(findings.iter().any(|m| m.contains("more than one family")));
     }
 
     #[test]

--- a/tools/cnf-runner/src/model/wire_surface.rs
+++ b/tools/cnf-runner/src/model/wire_surface.rs
@@ -20,7 +20,7 @@
 //!   spec-inward (what the spec defines and whether a case reaches it); this
 //!   one runs the other way and is a **declaration, never an obligation** —
 //!   every entry carries `never_gates: true` and NO coverage requirement is
-//!   ever derived from it. It exists so an SDoC reader learns the extension
+//!   ever derived from it. It exists so an `SDoC` reader learns the extension
 //!   surface exists instead of discovering it on the wire.
 //!
 //! Every enumeration source is a RELEASED spec component or the ITS-REST docs
@@ -220,12 +220,12 @@ impl WireElement {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ServedExtension {
-    /// A stable family name (the grouping an SDoC reader sees).
+    /// A stable family name (the grouping an `SDoC` reader sees).
     pub family: String,
     /// The routes the family serves, each `"<METHOD> <path>"`, written as the
     /// server mounts them under the DEFAULT deployment (absolute from the
     /// server root, base path included — the same convention the served
-    /// OpenAPI document uses).
+    /// `OpenAPI` document uses).
     pub routes: Vec<String>,
     /// The configuration that mounts (or answers on) the family, verbatim —
     /// including the always-on case.

--- a/tools/cnf-runner/src/render.rs
+++ b/tools/cnf-runner/src/render.rs
@@ -12,6 +12,7 @@ use std::collections::BTreeMap;
 use std::fmt::Write;
 
 use crate::model::capability::CapabilityMatrix;
+use crate::model::wire_surface::ServedExtension;
 use crate::party::{OutcomeStatus, Results, Statement};
 use crate::verdict::{Evidence, ProfileVerdict, SecBasicVerdict, VerdictReport};
 use crate::vocab::{Family, FormatName, Tier};
@@ -177,9 +178,19 @@ pub fn render_report(results: &Results, verdicts: &VerdictReport) -> String {
 }
 
 /// Render the conformance statement (`CONFORMANCE_STATEMENT.md`): the `SDoC`
-/// text, the claims, the computed verdicts, and the attestation.
+/// text, the claims, the declared non-openEHR surface, the computed verdicts,
+/// and the attestation.
+///
+/// `served_extensions` is the catalogue's outward wire-surface axis
+/// (`vocab/wire_surface.yaml`); it is rendered verbatim as a declaration and
+/// never enters a verdict. An empty slice renders no section at all — a party
+/// that serves nothing beyond the openEHR resource set has nothing to declare.
 #[must_use]
-pub fn render_statement(statement: &Statement, verdicts: &VerdictReport) -> String {
+pub fn render_statement(
+    statement: &Statement,
+    verdicts: &VerdictReport,
+    served_extensions: &[ServedExtension],
+) -> String {
     let mut out = String::new();
     let _ = writeln!(out, "# Conformance Statement (SDoC)\n");
     let _ = writeln!(
@@ -213,6 +224,9 @@ pub fn render_statement(statement: &Statement, verdicts: &VerdictReport) -> Stri
     if !statement.options.is_empty() {
         let _ = writeln!(out, "Options declared: {}\n", join_options(statement));
     }
+
+    // ── the outward surface (a declaration, never a claim) ──────────────────
+    write_served_extensions(&mut out, statement, served_extensions);
 
     // ── the computed verdicts ───────────────────────────────────────────────
     let _ = writeln!(out, "## Verdicts\n");
@@ -260,6 +274,49 @@ pub fn render_statement(statement: &Statement, verdicts: &VerdictReport) -> Stri
     }
 
     out
+}
+
+/// The statement's "Additional non-openEHR surface" section: the outward
+/// wire-surface axis rendered as a declaration — family, routes, and the
+/// configuration that enables it — under release-pinned wording that puts the
+/// whole surface outside every conformance claim in the document. Nothing is
+/// written when the party declares no extension family.
+fn write_served_extensions(
+    out: &mut String,
+    statement: &Statement,
+    served_extensions: &[ServedExtension],
+) {
+    if served_extensions.is_empty() {
+        return;
+    }
+    let _ = writeln!(out, "## Additional non-openEHR surface\n");
+    let _ = writeln!(
+        out,
+        "Beside the openEHR resources of ITS-REST {}, this product serves the route \
+         families below. **None of them is part of any conformance claim in this \
+         statement**: no openEHR specification governs them, no conformance case \
+         exercises them, and no verdict below depends on them. They are declared here \
+         so a reader of this document learns the surface exists rather than \
+         discovering it on the wire. Paths are the default deployment spelling; a \
+         non-default API base path moves the base-path-relative ones.\n",
+        statement
+            .spec_versions
+            .get(crate::vocab::SpecComponent::ItsRest)
+            .unwrap_or("(unstated)"),
+    );
+    let _ = writeln!(out, "| Family | Routes | Enabled by |");
+    let _ = writeln!(out, "| --- | --- | --- |");
+    for extension in served_extensions {
+        let routes: Vec<String> = extension.routes.iter().map(|r| format!("`{r}`")).collect();
+        let _ = writeln!(
+            out,
+            "| {} | {} | {} |",
+            extension.family,
+            routes.join("<br>"),
+            extension.config_gate,
+        );
+    }
+    let _ = writeln!(out);
 }
 
 /// Render the certificate (`CONFORMANCE_CERTIFICATE.md`), modeled on the CNF
@@ -716,10 +773,32 @@ mod tests {
 
     #[test]
     fn statement_renders_verdicts_and_attestation() {
-        let text = render_statement(&statement(), &verdicts());
+        let text = render_statement(&statement(), &verdicts(), &[]);
         assert!(text.ends_with('\n'));
         assert!(text.contains("We declare conformance."));
         assert!(text.contains("CORE"));
+        // No extensions declared → no section at all.
+        assert!(!text.contains("Additional non-openEHR surface"));
+    }
+
+    /// The outward axis renders as a declaration: the family, its routes and
+    /// its gate, under wording that says it is in no conformance claim.
+    #[test]
+    fn statement_declares_the_non_openehr_surface() {
+        let served: Vec<ServedExtension> = serde_json::from_value(serde_json::json!([
+            { "family": "management", "routes": ["GET /management/info"],
+              "config_gate": "management.enabled (default off)",
+              "spec_silence": "no released clause governs the URI space beyond the resource set",
+              "never_gates": true }
+        ]))
+        .unwrap();
+        let text = render_statement(&statement(), &verdicts(), &served);
+        assert!(text.contains("## Additional non-openEHR surface"));
+        assert!(text.contains("ITS-REST 1.1.0"));
+        assert!(text.contains(
+            "| management | `GET /management/info` | management.enabled (default off) |"
+        ));
+        assert!(text.contains("None of them is part of any conformance claim"));
     }
 
     #[test]

--- a/tools/cnf-runner/src/schema.rs
+++ b/tools/cnf-runner/src/schema.rs
@@ -1221,7 +1221,7 @@ pub fn wire_surface_schema() -> Value {
         "$schema": DRAFT,
         "$id": urn("wire-surface"),
         "title": "CNF 2.0 wire-surface coverage register",
-        "description": "The authored, spec-cited record of the wire surface the catalogue is measured against for TOTAL coverage (issue #271): Axis-1 SM operations with no its-rest binding, Axis-2 per-binding outcome/format branches no case exercises, and Axis-3 cross-cutting wire behaviours mapped to cases or an adjudicated exception. Every source is a released spec component / ITS-REST docs text, never the vendored OAS.",
+        "description": "The authored, spec-cited record of the wire surface the catalogue is measured against for TOTAL coverage (issue #271): Axis-1 SM operations with no its-rest binding, Axis-2 per-binding outcome/format branches no case exercises, Axis-3 cross-cutting wire behaviours mapped to cases or an adjudicated exception, and Axis-4 the outward declaration of the route families the SUT serves beyond the openEHR resource set (a declaration, never an obligation — no coverage requirement is derived from it). Every source is a released spec component / ITS-REST docs text, never the vendored OAS.",
         "type": "object",
         "additionalProperties": false,
         "properties": {
@@ -1288,9 +1288,36 @@ pub fn wire_surface_schema() -> Value {
                         }
                     }
                 }
+            },
+            "served_extensions": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["family", "routes", "config_gate", "spec_silence", "never_gates"],
+                    "properties": {
+                        "family": { "type": "string", "minLength": 1 },
+                        "routes": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": { "type": "string", "pattern": route_pattern() }
+                        },
+                        "config_gate": { "type": "string", "minLength": 1 },
+                        "spec_silence": { "type": "string", "minLength": 1 },
+                        "never_gates": { "const": true }
+                    }
+                }
             }
         }
     })
+}
+
+/// The Axis-4 route grammar (`"<METHOD> /<path>"`), with the method alternation
+/// derived from the closed HTTP-method vocabulary so schema and reference
+/// implementation cannot drift.
+fn route_pattern() -> String {
+    let methods: Vec<String> = HttpMethod::ALL.iter().map(token_str).collect();
+    format!("^({}) /\\S*$", methods.join("|"))
 }
 
 /// The runner-verification transcript (pack part 1).

--- a/tools/cnf-runner/src/validate.rs
+++ b/tools/cnf-runner/src/validate.rs
@@ -19,7 +19,7 @@ use crate::load::LoadError;
 use crate::model::assertion::{Assertion, EquivalentTarget, assertion_refs};
 use crate::model::binding::OperationBinding;
 use crate::model::case::{CaseCore, ExpectSpec, FlowStep, MatrixCell, Parameters};
-use crate::model::wire_surface::WireSurface;
+use crate::model::wire_surface::{ServedExtension, WireSurface};
 use crate::refgrammar::{CaptureField, TimeExpr, ValueRef};
 use crate::vocab::{CaseKind, FormatName, Iteration, OutcomeKind};
 
@@ -1288,6 +1288,75 @@ fn check_surface_coverage(
     }
     check_binding_branch_coverage(set, wire_surface, findings);
     check_wire_surface_elements(set, wire_surface, findings);
+    check_served_extensions(set, wire_surface, findings);
+}
+
+/// Axis 4 — the outward declaration is well-formed and does not claim a route
+/// the RELEASED wire already defines.
+///
+/// This check reads the axis; it never derives an obligation FROM it. Nothing
+/// here can require a case, expect a branch, or move a verdict — the axis is a
+/// declaration, and `never_gates: true` on every entry (shape-checked by
+/// [`WireSurface::check_invariants`], which
+/// [`check_wire_surface_elements`] reports) states that in the artifact
+/// itself.
+///
+/// The one cross-artifact check that IS meaningful: a family must not declare
+/// a route whose path is a realized ITS-REST binding's path, which would
+/// mislabel a released operation as our own extension. The axis writes
+/// absolute default-deployment paths while a binding path is relative to the
+/// API base, so the comparison strips a leading MOUNT prefix — and a prefix
+/// only counts as a mount when its last segment is not itself a released
+/// first segment. That distinction is what separates
+/// `/…/v1` + `/ehr` (the same released operation, re-declared) from
+/// `/…/v1/admin` + `/query/{q}/{v}` (a different resource that merely ends in
+/// the same tail).
+fn check_served_extensions(
+    set: &ArtifactSet,
+    wire_surface: &WireSurface,
+    findings: &mut Vec<Finding>,
+) {
+    let released: Vec<&str> = set
+        .bindings
+        .iter()
+        .filter(|(_, b)| !b.is_unrealized())
+        .filter_map(|(_, b)| b.request.as_ref())
+        .map(|r| r.path.raw())
+        .collect();
+    let released_roots: BTreeSet<&str> = released
+        .iter()
+        .filter_map(|p| p.trim_start_matches('/').split('/').next())
+        .collect();
+    for extension in &wire_surface.served_extensions {
+        for route in &extension.routes {
+            let Some(path) = ServedExtension::route_path(route) else {
+                continue; // shape finding already raised by check_invariants
+            };
+            for binding_path in &released {
+                let claims = path == *binding_path
+                    || path.strip_suffix(*binding_path).is_some_and(|mount| {
+                        !mount.is_empty()
+                            && !mount.ends_with('/')
+                            && mount
+                                .rsplit('/')
+                                .next()
+                                .is_some_and(|last| !released_roots.contains(last))
+                    });
+                if claims {
+                    push(
+                        findings,
+                        CheckId::SurfaceCoverage,
+                        &extension.family,
+                        format!(
+                            "served_extensions route {route:?} claims the released ITS-REST path \
+                             {binding_path} — an extension family may not declare an operation \
+                             the release defines"
+                        ),
+                    );
+                }
+            }
+        }
+    }
 }
 
 /// Axis 1 — every SM operation of a pinned platform interface has an `its-rest`
@@ -1808,6 +1877,64 @@ h|*1..1*\n\
         assert!(
             findings.is_empty(),
             "the branch exception should suppress the gap, got: {findings:?}"
+        );
+    }
+
+    /// Axis 4 is a DECLARATION: adding served extensions changes no coverage
+    /// obligation on the other three axes, and a family may not claim a
+    /// released path.
+    #[test]
+    fn axis4_declares_without_gating() {
+        let set = build_set(true);
+        let wire = set.wire_surface.as_ref().map(|(_, w)| w).unwrap();
+        let mut baseline = Vec::new();
+        check_binding_branch_coverage(&set, wire, &mut baseline);
+        check_wire_surface_elements(&set, wire, &mut baseline);
+        assert!(baseline.is_empty(), "{baseline:?}");
+
+        let declared: WireSurface = serde_json::from_value(serde_json::json!({
+            "branches": [ {
+                "binding": "I_EHR_SERVICE.create_ehr", "outcome": "already_exists",
+                "reason": "coverage_gap",
+                "source": "ITS-REST Requests_and_responses.md §HTTP status codes"
+            } ],
+            "served_extensions": [ {
+                "family": "management",
+                "routes": ["GET /management/info"],
+                "config_gate": "management.enabled",
+                "spec_silence": "no released clause governs the URI space beyond the resource set",
+                "never_gates": true
+            } ]
+        }))
+        .unwrap();
+        let mut with_axis = Vec::new();
+        check_binding_branch_coverage(&set, &declared, &mut with_axis);
+        check_wire_surface_elements(&set, &declared, &mut with_axis);
+        check_served_extensions(&set, &declared, &mut with_axis);
+        assert!(
+            with_axis.is_empty(),
+            "the outward axis must never add an obligation, got: {with_axis:?}"
+        );
+
+        // Claiming a released path IS a finding (the binding fixture serves
+        // POST /ehr; the mount prefix is stripped at the segment boundary).
+        let claiming: WireSurface = serde_json::from_value(serde_json::json!({
+            "served_extensions": [ {
+                "family": "impostor",
+                "routes": ["POST /ehrbase/rest/openehr/v1/ehr"],
+                "config_gate": "always on",
+                "spec_silence": "s",
+                "never_gates": true
+            } ]
+        }))
+        .unwrap();
+        let mut findings = Vec::new();
+        check_served_extensions(&set, &claiming, &mut findings);
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.message.contains("claims the released")),
+            "expected a released-path claim finding, got: {findings:?}"
         );
     }
 


### PR DESCRIPTION
Closes #527.

The register half of the group-17 audit (#393, findings 2/3) — the structural gap: all three `wire_surface` axes were spec-inward; nothing declared what this server serves BEYOND the spec.

- **Axis 4 — `served_extensions`**: a new declaration-only section (`family`/`routes`/`config_gate`/`spec_silence`/`never_gates: true` — false is schema-unrepresentable) in the Rust model + emission + the committed JSON Schema (hand-written by the worker, confirmed byte-identical by `emit-schemas` on adoption). Populated with **14 families / 64 routes** (the ten unaudited families + the four already-audited extensions). The validator's overlap guard proves zero collisions with the 47 realized binding paths — with a subtle mount-prefix rule that avoids false-positives on `/admin/query/{name}/{version}` vs the released query route.
- **AMB-157** (`statement_declared`, deliberately no upstream ref — nothing to report upstream for a silence that is the ordinary condition of out-of-scope surface): the extension-surface declaration, pointing at the axis so the enumeration lives in one machine-readable place; cross-referenced from all nine `I_TERMINOLOGY_SERVICE` `off_wire` rows.
- **AMB-158** (`fixed_handling`): the System-Options manifest lists only the standardised groups — the shipped omission adjudicated (the manifest speaks ITS-REST group names; the extension surface is declared in the discovery/OpenAPI/statement layers), with the `// NOTE:` at the manifest builder.
- **The Conformance Statement** gains an "Additional non-openEHR surface" section rendered from the axis (pure-function-from-artifacts; the party statement contract untouched); the committed `CONFORMANCE_STATEMENT.md` picks it up on the closing pipeline run.
- Changelog: one `### Changed` entry (the statement section is user-visible in the published artifacts).

**Gates:** `emit-schemas` drift-free; `validate --specs` — 614 cases, 160 bindings, **0 findings**; nextest `-p cnf-runner` 176 passed (4 new); clippy zero.