### PR TITLE
test(cnf): #288 slice 3a — canonical-XML format breadth on the EHR / EHR_STATUS / DIRECTORY bindings

### DIFF
--- a/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
+++ b/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
@@ -174,12 +174,36 @@ cnf.ehr_status.with_subject.e:
   rm_versions: [">=1.0.2"]
   validity: { verdict: valid }
   provenance: "derived 2026-07-27 from the official Robot EHR_STATUS with a known per-case subject ref (cnf-subject-04@cnf) — subject-keyed cases must own their subject on a single-EHR-per-subject SUT"
+cnf.ehr_status.with_subject.f:
+  source: fixtures/ehr/ehr_status.with_subject.f.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity: { verdict: valid }
+  provenance: "derived 2026-07-28 from the official Robot EHR_STATUS with a known per-case subject ref (cnf-subject-05@cnf) — subject-keyed cases must own their subject on a single-EHR-per-subject SUT"
+cnf.ehr_status.with_subject.g:
+  source: fixtures/ehr/ehr_status.with_subject.g.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity: { verdict: valid }
+  provenance: "derived 2026-07-28 from the official Robot EHR_STATUS with a known per-case subject ref (cnf-subject-06@cnf) — subject-keyed cases must own their subject on a single-EHR-per-subject SUT"
 cnf.ehr_status.with_subject.alt:
   source: fixtures/ehr/ehr_status.with_subject.alt.json
   format: canonical-json
   rm_versions: [">=1.0.2"]
   validity: { verdict: valid }
   provenance: "derived 2026-07-22 from the official Robot EHR_STATUS by renaming the subject external ref (single-EHR-per-subject SUTs reject a reused subject; no openEHR spec governs subject uniqueness — SUT-policy accommodation)"
+# The canonical-XML sibling of cnf.ehr_status.with_subject: the SAME payload in
+# the other canonical representation, so a canonical-xml write case can be read
+# back and compared against the JSON twin. ITS-REST overview Resources.md §XML
+# Format governs the representation ("both request payloads and responses MUST
+# conform to the published XSDs"); the derivation is mechanical, never
+# hand-written XML.
+cnf.ehr_status.with_subject.xml:
+  source: fixtures/ehr/ehr_status.with_subject.xml
+  format: canonical-xml
+  rm_versions: [">=1.0.2"]
+  validity: { verdict: valid }
+  provenance: "codec-derived 2026-07-28 from fixtures/ehr/ehr_status.with_subject.json via crates/openehr-its/examples/canonical_convert.rs (the gate-proven FromJson + ToXml codec pair); the JSON twin is the openEHR CNF Robot corpus payload re-adjudicated 2026-07-21 to spec-text-only evidence"
 # Corpus additions for the master04 (DEFINITION_ADL14) cases. Same entry
 # schema as MANIFEST.yaml; the orchestrator concatenates this into
 # MANIFEST.yaml at integration (never edit MANIFEST.yaml directly here).
@@ -486,6 +510,24 @@ cnf.directory.v2:
   rm_versions: [">=1.0.2"]
   validity: { verdict: valid }
   provenance: "openEHR CNF Robot corpus (vendored docs/specs/openehr/CNF/tests/platform/robot @ the CNF pin); re-adjudicated 2026-07-21 to spec-text-only evidence"
+# The canonical-XML siblings of the two FOLDER payloads: the SAME structures in
+# the other canonical representation, so a canonical-xml create/update can be
+# read back and compared against the JSON twin. ITS-REST overview Resources.md
+# §XML Format governs the representation ("both request payloads and responses
+# MUST conform to the published XSDs"); the derivation is mechanical, never
+# hand-written XML.
+cnf.directory.root_only.xml:
+  source: fixtures/directory/root_only.xml
+  format: canonical-xml
+  rm_versions: [">=1.0.2"]
+  validity: { verdict: valid }
+  provenance: "codec-derived 2026-07-28 from fixtures/directory/root_only.json via crates/openehr-its/examples/canonical_convert.rs (the gate-proven FromJson + ToXml codec pair); the JSON twin is the openEHR CNF Robot corpus payload re-adjudicated 2026-07-21 to spec-text-only evidence"
+cnf.directory.v2.xml:
+  source: fixtures/directory/v2.xml
+  format: canonical-xml
+  rm_versions: [">=1.0.2"]
+  validity: { verdict: valid }
+  provenance: "codec-derived 2026-07-28 from fixtures/directory/v2.json via crates/openehr-its/examples/canonical_convert.rs (the gate-proven FromJson + ToXml codec pair); the JSON twin is the openEHR CNF Robot corpus payload re-adjudicated 2026-07-21 to spec-text-only evidence"
 cnf.directory.invalid.missing_name:
   source: fixtures/directory/missing_name.json
   format: canonical-json

--- a/tools/cnf-runner/artifacts/corpus/fixtures/ehr/ehr_status.with_subject.f.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/ehr/ehr_status.with_subject.f.json
@@ -1,0 +1,28 @@
+{
+  "_type": "EHR_STATUS",
+  "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
+  "name": {
+    "value": "EHR Status"
+  },
+  "subject": {
+    "external_ref": {
+      "id": {
+        "_type": "GENERIC_ID",
+        "value": "cnf-subject-05",
+        "scheme": "id_scheme"
+      },
+      "namespace": "cnf",
+      "type": "PERSON"
+    }
+  },
+  "is_modifiable": true,
+  "is_queryable": true,
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-EHR_STATUS.generic.v1"
+    },
+    "rm_version": "1.2.0"
+  }
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/ehr/ehr_status.with_subject.g.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/ehr/ehr_status.with_subject.g.json
@@ -1,0 +1,28 @@
+{
+  "_type": "EHR_STATUS",
+  "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
+  "name": {
+    "value": "EHR Status"
+  },
+  "subject": {
+    "external_ref": {
+      "id": {
+        "_type": "GENERIC_ID",
+        "value": "cnf-subject-06",
+        "scheme": "id_scheme"
+      },
+      "namespace": "cnf",
+      "type": "PERSON"
+    }
+  },
+  "is_modifiable": true,
+  "is_queryable": true,
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-EHR_STATUS.generic.v1"
+    },
+    "rm_version": "1.2.0"
+  }
+}

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.create_directory-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.create_directory-xml.yaml
@@ -1,0 +1,64 @@
+# The canonical-XML REQUEST-payload branch of directory creation: POST
+# /ehr/{ehr_id}/directory carrying the FOLDER as canonical XML.
+#
+# Decisive released sentence (ITS-REST overview Resources.md §XML Format): "A
+# client MAY use the header `Content-Type: application/xml` in the requests to
+# specify the XML payload format. If the service cannot process the request
+# payload as XML format, it MUST respond with HTTP status code `415
+# Unsupported Media Type`." A service inside the XML technology profile
+# therefore processes the payload, and the same section fixes its shape: "both
+# request payloads and responses MUST conform to the published XSDs".
+#
+# Only the REQUEST representation is XML: the runner's format role on a
+# body-carrying request names the request payload and the response is
+# negotiated canonical JSON. That is what makes step 2 the real assertion —
+# the FOLDER read back from the XML create must equal the canonical-JSON twin
+# of the very fixture that was posted (cnf.directory.root_only.xml is
+# codec-derived from cnf.directory.root_only), so the XML payload is proven to
+# have been understood as the same resource, not merely accepted.
+#
+# Technology-profile scope: canonical XML is OPTIONAL support — Resources.md
+# §Data representation, "Services MUST support at least one of the openEHR
+# **XML** or **JSON** canonical formats for resource representation" — so the
+# case declares the canonical-xml format axis and is counted only against a
+# statement whose technology profile declares that format.
+id: I_EHR_DIRECTORY.create_directory-xml
+kind: functional
+component: EHR_DIRECTORY
+sm_operation: I_EHR_DIRECTORY.create_directory
+capabilities: [DirectoryOps]
+exercises: [Versioning]
+profiles: [STANDARD]
+test_purpose: >-
+  create_directory with a canonical-XML FOLDER payload creates the directory,
+  and the created structure is the one the payload described.
+description: "Test create_directory with a canonical-XML FOLDER payload"
+spec_refs:
+  - "SM openehr_platform §I_EHR_DIRECTORY.create_directory"
+  - "ITS-REST overview Resources.md §Data representation"
+  - "ITS-REST overview Resources.md §XML Format"
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+formats: [canonical-xml]
+requires:
+  server: any
+  ehr: { commits: none }                 # EHR exists, no directory — mints ${ehr_id}
+data_sets: [cnf.directory.root_only.xml, cnf.directory.root_only]
+flow:
+  - step: 1
+    call: create_directory
+    format: canonical-xml                # Content-Type: application/xml
+    with: { ehr_id: "${ehr_id}", directory: "${ds:cnf.directory.root_only.xml}" }
+    expect: created
+  - step: 2                              # the XML payload landed as that FOLDER
+    call: get_directory
+    format: canonical-json
+    with: { ehr_id: "${ehr_id}" }
+    expect: ok
+    assert:
+      - { assert: instance_of, rm_type: FOLDER }
+      - { assert: equivalent, to: "${ds:cnf.directory.root_only}", ignoring: server_assigned }
+postconditions:
+  - assert: state
+    text: >-
+      The EHR ehr_id has a directory whose structure is the XML payload's
+      FOLDER (verified by step 2)

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory-xml.yaml
@@ -1,0 +1,46 @@
+# The canonical-XML representation branch of the directory read:
+# GET /ehr/{ehr_id}/directory under `Accept: application/xml`.
+#
+# Decisive released sentences (ITS-REST overview Resources.md §XML Format):
+# "The client SHOULD use the `Accept: application/xml` request header to
+# specify the expected XML response format. If the service cannot fulfill this
+# aspect of the request, it MUST respond with HTTP status code `406 Not
+# Acceptable`." and "Proper header `Content-Type: application/xml` MUST be
+# present in the response of the service unless the response has no content
+# body (HTTP status code `204`)." A 200 answer therefore has exactly one
+# conformant Content-Type, and the binding's `Content-Type: negotiated`
+# matcher is what asserts it — an XML body is not JSON, so the RM-level
+# assertions the canonical-JSON sibling carries
+# (I_EHR_DIRECTORY.get_directory-ehr_root_directory) cannot apply here and are
+# deliberately absent.
+#
+# Technology-profile scope: canonical XML is OPTIONAL support — Resources.md
+# §Data representation, "Services MUST support at least one of the openEHR
+# **XML** or **JSON** canonical formats for resource representation" — so the
+# case declares the canonical-xml format axis and is counted only against a
+# statement whose technology profile declares that format.
+id: I_EHR_DIRECTORY.get_directory-xml
+kind: functional
+component: EHR_DIRECTORY
+sm_operation: I_EHR_DIRECTORY.get_directory
+capabilities: [DirectoryOps]
+profiles: [STANDARD]
+test_purpose: >-
+  get_directory requested as canonical XML answers the directory FOLDER in the
+  negotiated XML representation.
+description: "Test get_directory with Accept: application/xml"
+spec_refs:
+  - "SM openehr_platform §I_EHR_DIRECTORY.get_directory"
+  - "ITS-REST overview Resources.md §Data representation"
+  - "ITS-REST overview Resources.md §XML Format"
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+formats: [canonical-xml]
+requires:
+  ehr: { commits: any }                  # mints ${ehr_id}
+  directory: cnf.directory.root_only     # a single empty root FOLDER (provisioned)
+flow:
+  - step: 1
+    call: get_directory
+    format: canonical-xml                # Accept: application/xml
+    with: { ehr_id: "${ehr_id}" }
+    expect: ok

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory_at_time-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory_at_time-xml.yaml
@@ -1,0 +1,57 @@
+# The canonical-XML representation branch of the at-time directory read:
+# GET /ehr/{ehr_id}/directory?version_at_time under `Accept: application/xml`.
+#
+# Decisive released sentences (ITS-REST overview Resources.md §XML Format):
+# "The client SHOULD use the `Accept: application/xml` request header to
+# specify the expected XML response format. If the service cannot fulfill this
+# aspect of the request, it MUST respond with HTTP status code `406 Not
+# Acceptable`." and "Proper header `Content-Type: application/xml` MUST be
+# present in the response of the service unless the response has no content
+# body (HTTP status code `204`)." The binding's `Content-Type: negotiated`
+# matcher is what asserts the representation; an XML body is not JSON, so the
+# RM-level assertions the canonical-JSON sibling carries
+# (I_EHR_DIRECTORY.get_directory_at_time-ehr_with_directory) cannot apply here
+# and are deliberately absent.
+#
+# The directory is created in-flow (canonical JSON) so its commit instant t0
+# anchors the "current time" query — the provisioning representation is not
+# the behaviour under test.
+#
+# Technology-profile scope: canonical XML is OPTIONAL support — Resources.md
+# §Data representation, "Services MUST support at least one of the openEHR
+# **XML** or **JSON** canonical formats for resource representation" — so the
+# case declares the canonical-xml format axis and is counted only against a
+# statement whose technology profile declares that format.
+id: I_EHR_DIRECTORY.get_directory_at_time-xml
+kind: functional
+component: EHR_DIRECTORY
+sm_operation: I_EHR_DIRECTORY.get_directory_at_time
+capabilities: [DirectoryOps]
+exercises: [Versioning]
+profiles: [STANDARD]
+test_purpose: >-
+  get_directory_at_time requested as canonical XML answers the directory
+  FOLDER extant at that time in the negotiated XML representation.
+description: "Test get_directory_at_time with Accept: application/xml"
+spec_refs:
+  - "SM openehr_platform §I_EHR_DIRECTORY.get_directory_at_time"
+  - "ITS-REST overview Resources.md §Data representation"
+  - "ITS-REST overview Resources.md §XML Format"
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+formats: [canonical-xml]
+requires:
+  server: any
+  ehr: { commits: none }                 # mints ${ehr_id}
+data_sets: [cnf.directory.root_only]
+flow:
+  - step: 1
+    call: create_directory
+    format: canonical-json
+    with: { ehr_id: "${ehr_id}", directory: "${ds:cnf.directory.root_only}" }
+    expect: created
+    capture: { t0: created.commit_time }
+  - step: 2
+    call: get_directory_at_time
+    format: canonical-xml                # Accept: application/xml
+    with: { ehr_id: "${ehr_id}", a_time: "${time:after(t0)}" }
+    expect: ok

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory_at_version-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory_at_version-xml.yaml
@@ -1,0 +1,56 @@
+# The canonical-XML representation branch of the by-version directory read:
+# GET /ehr/{ehr_id}/directory/{version_uid} under `Accept: application/xml`.
+#
+# Decisive released sentences (ITS-REST overview Resources.md §XML Format):
+# "The client SHOULD use the `Accept: application/xml` request header to
+# specify the expected XML response format. If the service cannot fulfill this
+# aspect of the request, it MUST respond with HTTP status code `406 Not
+# Acceptable`." and "Proper header `Content-Type: application/xml` MUST be
+# present in the response of the service unless the response has no content
+# body (HTTP status code `204`)." The binding's `Content-Type: negotiated`
+# matcher is what asserts the representation; an XML body is not JSON, so the
+# RM-level assertions the canonical-JSON sibling carries
+# (I_EHR_DIRECTORY.get_directory_at_version-directory_with_two_versions) cannot
+# apply here and are deliberately absent.
+#
+# The directory is created in-flow (canonical JSON) so its version uid is known
+# — the provisioning representation is not the behaviour under test.
+#
+# Technology-profile scope: canonical XML is OPTIONAL support — Resources.md
+# §Data representation, "Services MUST support at least one of the openEHR
+# **XML** or **JSON** canonical formats for resource representation" — so the
+# case declares the canonical-xml format axis and is counted only against a
+# statement whose technology profile declares that format.
+id: I_EHR_DIRECTORY.get_directory_at_version-xml
+kind: functional
+component: EHR_DIRECTORY
+sm_operation: I_EHR_DIRECTORY.get_directory_at_version
+capabilities: [DirectoryOps]
+exercises: [Versioning]
+profiles: [STANDARD]
+test_purpose: >-
+  get_directory_at_version requested as canonical XML answers the addressed
+  directory version in the negotiated XML representation.
+description: "Test get_directory_at_version with Accept: application/xml"
+spec_refs:
+  - "SM openehr_platform §I_EHR_DIRECTORY.get_directory_at_version"
+  - "ITS-REST overview Resources.md §Data representation"
+  - "ITS-REST overview Resources.md §XML Format"
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+formats: [canonical-xml]
+requires:
+  server: any
+  ehr: { commits: none }                 # mints ${ehr_id}
+data_sets: [cnf.directory.root_only]
+flow:
+  - step: 1
+    call: create_directory
+    format: canonical-json
+    with: { ehr_id: "${ehr_id}", directory: "${ds:cnf.directory.root_only}" }
+    expect: created
+    capture: { v1_uid: created.version_uid }
+  - step: 2
+    call: get_directory_at_version
+    format: canonical-xml                # Accept: application/xml
+    with: { ehr_id: "${ehr_id}", version_uid: "${v1_uid}" }
+    expect: ok

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.has_directory-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.has_directory-xml.yaml
@@ -1,0 +1,49 @@
+# The canonical-XML representation branch of the directory existence probe.
+# ITS-REST 1.1.0 has no dedicated probe, so has_directory is realized as
+# GET /ehr/{ehr_id}/directory (200 = a directory exists); asking for that
+# answer as XML must still produce the boolean AND the negotiated
+# representation.
+#
+# Decisive released sentences (ITS-REST overview Resources.md §XML Format):
+# "The client SHOULD use the `Accept: application/xml` request header to
+# specify the expected XML response format. If the service cannot fulfill this
+# aspect of the request, it MUST respond with HTTP status code `406 Not
+# Acceptable`." and "Proper header `Content-Type: application/xml` MUST be
+# present in the response of the service unless the response has no content
+# body (HTTP status code `204`)." The binding's `Content-Type: negotiated`
+# matcher asserts the representation; the `returns` assertion is wire-presence
+# (the 2xx/non-2xx split the boolean is carried by), so it is representation-
+# independent and stays.
+#
+# Technology-profile scope: canonical XML is OPTIONAL support — Resources.md
+# §Data representation, "Services MUST support at least one of the openEHR
+# **XML** or **JSON** canonical formats for resource representation" — so the
+# case declares the canonical-xml format axis and is counted only against a
+# statement whose technology profile declares that format.
+id: I_EHR_DIRECTORY.has_directory-xml
+kind: functional
+component: EHR_DIRECTORY
+sm_operation: I_EHR_DIRECTORY.has_directory
+capabilities: [DirectoryOps]
+profiles: [STANDARD]
+test_purpose: >-
+  has_directory requested as canonical XML reports the directory exists and
+  answers in the negotiated XML representation.
+description: "Test has_directory with Accept: application/xml"
+spec_refs:
+  - "SM openehr_platform §I_EHR_DIRECTORY.has_directory"
+  - "ITS-REST overview Resources.md §Data representation"
+  - "ITS-REST overview Resources.md §XML Format"
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+formats: [canonical-xml]
+requires:
+  ehr: { commits: any }                  # mints ${ehr_id}
+  directory: cnf.directory.root_only     # the EHR has a directory (provisioned tree)
+flow:
+  - step: 1
+    call: has_directory
+    format: canonical-xml                # Accept: application/xml
+    with: { ehr_id: "${ehr_id}" }
+    expect: ok                            # a directory exists -> true
+    assert:
+      - { assert: returns, equals: true }

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.has_directory_version-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.has_directory_version-xml.yaml
@@ -1,0 +1,60 @@
+# The canonical-XML representation branch of the directory-version existence
+# probe. ITS-REST 1.1.0 has no dedicated probe, so has_directory_version is
+# realized as GET /ehr/{ehr_id}/directory/{version_uid} (200 = the version
+# exists); asking for that answer as XML must still produce the boolean AND
+# the negotiated representation.
+#
+# Decisive released sentences (ITS-REST overview Resources.md §XML Format):
+# "The client SHOULD use the `Accept: application/xml` request header to
+# specify the expected XML response format. If the service cannot fulfill this
+# aspect of the request, it MUST respond with HTTP status code `406 Not
+# Acceptable`." and "Proper header `Content-Type: application/xml` MUST be
+# present in the response of the service unless the response has no content
+# body (HTTP status code `204`)." The binding's `Content-Type: negotiated`
+# matcher asserts the representation; the `returns` assertion is wire-presence
+# (the 2xx/non-2xx split the boolean is carried by), so it is representation-
+# independent and stays.
+#
+# The directory is created in-flow (canonical JSON) so its version uid is known
+# — the provisioning representation is not the behaviour under test.
+#
+# Technology-profile scope: canonical XML is OPTIONAL support — Resources.md
+# §Data representation, "Services MUST support at least one of the openEHR
+# **XML** or **JSON** canonical formats for resource representation" — so the
+# case declares the canonical-xml format axis and is counted only against a
+# statement whose technology profile declares that format.
+id: I_EHR_DIRECTORY.has_directory_version-xml
+kind: functional
+component: EHR_DIRECTORY
+sm_operation: I_EHR_DIRECTORY.has_directory_version
+capabilities: [DirectoryOps]
+exercises: [Versioning]
+profiles: [STANDARD]
+test_purpose: >-
+  has_directory_version requested as canonical XML reports the addressed
+  directory version exists and answers in the negotiated XML representation.
+description: "Test has_directory_version with Accept: application/xml"
+spec_refs:
+  - "SM openehr_platform §I_EHR_DIRECTORY.has_directory_version"
+  - "ITS-REST overview Resources.md §Data representation"
+  - "ITS-REST overview Resources.md §XML Format"
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+formats: [canonical-xml]
+requires:
+  server: any
+  ehr: { commits: none }                 # mints ${ehr_id}
+data_sets: [cnf.directory.root_only]
+flow:
+  - step: 1
+    call: create_directory
+    format: canonical-json
+    with: { ehr_id: "${ehr_id}", directory: "${ds:cnf.directory.root_only}" }
+    expect: created
+    capture: { v1_uid: created.version_uid }
+  - step: 2
+    call: has_directory_version
+    format: canonical-xml                # Accept: application/xml
+    with: { ehr_id: "${ehr_id}", version_uid: "${v1_uid}" }
+    expect: ok                            # the version exists -> true
+    assert:
+      - { assert: returns, equals: true }

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.has_path-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.has_path-xml.yaml
@@ -1,0 +1,49 @@
+# The canonical-XML representation branch of the directory-path existence
+# probe. ITS-REST 1.1.0 has no dedicated probe, so has_path is realized as
+# GET /ehr/{ehr_id}/directory?path (200 = the path exists); asking for that
+# answer as XML must still produce the boolean AND the negotiated
+# representation.
+#
+# Decisive released sentences (ITS-REST overview Resources.md §XML Format):
+# "The client SHOULD use the `Accept: application/xml` request header to
+# specify the expected XML response format. If the service cannot fulfill this
+# aspect of the request, it MUST respond with HTTP status code `406 Not
+# Acceptable`." and "Proper header `Content-Type: application/xml` MUST be
+# present in the response of the service unless the response has no content
+# body (HTTP status code `204`)." The binding's `Content-Type: negotiated`
+# matcher asserts the representation; the `returns` assertion is wire-presence
+# (the 2xx/non-2xx split the boolean is carried by), so it is representation-
+# independent and stays.
+#
+# Technology-profile scope: canonical XML is OPTIONAL support — Resources.md
+# §Data representation, "Services MUST support at least one of the openEHR
+# **XML** or **JSON** canonical formats for resource representation" — so the
+# case declares the canonical-xml format axis and is counted only against a
+# statement whose technology profile declares that format.
+id: I_EHR_DIRECTORY.has_path-xml
+kind: functional
+component: EHR_DIRECTORY
+sm_operation: I_EHR_DIRECTORY.has_path
+capabilities: [DirectoryOps]
+profiles: [STANDARD]
+test_purpose: >-
+  has_path requested as canonical XML reports the root path exists and answers
+  in the negotiated XML representation.
+description: "Test has_path with Accept: application/xml"
+spec_refs:
+  - "SM openehr_platform §I_EHR_DIRECTORY.has_path"
+  - "ITS-REST overview Resources.md §Data representation"
+  - "ITS-REST overview Resources.md §XML Format"
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+formats: [canonical-xml]
+requires:
+  ehr: { commits: any }                  # mints ${ehr_id}
+  directory: cnf.directory.root_only     # a single empty root FOLDER (provisioned)
+flow:
+  - step: 1
+    call: has_path
+    format: canonical-xml                # Accept: application/xml
+    with: { ehr_id: "${ehr_id}", a_path: "/" }
+    expect: ok                            # the root path exists -> true
+    assert:
+      - { assert: returns, equals: true }

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.update_directory-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.update_directory-xml.yaml
@@ -1,0 +1,74 @@
+# The canonical-XML REQUEST-payload branch of the directory update: PUT
+# /ehr/{ehr_id}/directory carrying the replacement FOLDER as canonical XML.
+#
+# Decisive released sentence (ITS-REST overview Resources.md §XML Format): "A
+# client MAY use the header `Content-Type: application/xml` in the requests to
+# specify the XML payload format. If the service cannot process the request
+# payload as XML format, it MUST respond with HTTP status code `415
+# Unsupported Media Type`." A service inside the XML technology profile
+# therefore processes the payload, and the same section fixes its shape: "both
+# request payloads and responses MUST conform to the published XSDs".
+#
+# The directory is created in-flow (canonical JSON) so its version uid is known
+# — the required If-Match / preceding_version_uid (ITS-REST overview
+# Requests_and_responses.md §If-Match and accidental overwrites). Only the
+# UPDATE payload is XML; the response is negotiated canonical JSON, which is
+# what makes step 3 the real assertion: the FOLDER read back must equal the
+# canonical-JSON twin of the XML fixture that replaced it (cnf.directory.v2.xml
+# is codec-derived from cnf.directory.v2), so the XML payload is proven to have
+# been understood as the same resource, not merely accepted.
+#
+# Technology-profile scope: canonical XML is OPTIONAL support — Resources.md
+# §Data representation, "Services MUST support at least one of the openEHR
+# **XML** or **JSON** canonical formats for resource representation" — so the
+# case declares the canonical-xml format axis and is counted only against a
+# statement whose technology profile declares that format.
+id: I_EHR_DIRECTORY.update_directory-xml
+kind: functional
+component: EHR_DIRECTORY
+sm_operation: I_EHR_DIRECTORY.update_directory
+capabilities: [DirectoryOps]
+exercises: [Versioning]
+profiles: [STANDARD]
+test_purpose: >-
+  update_directory with a canonical-XML FOLDER payload replaces the directory,
+  and the new structure is the one the payload described.
+description: "Test update_directory with a canonical-XML FOLDER payload"
+spec_refs:
+  - "SM openehr_platform §I_EHR_DIRECTORY.update_directory"
+  - "ITS-REST overview Resources.md §Data representation"
+  - "ITS-REST overview Resources.md §XML Format"
+  - "ITS-REST overview Requests_and_responses §If-Match and accidental overwrites"
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+formats: [canonical-xml]
+requires:
+  server: any
+  ehr: { commits: none }                 # mints ${ehr_id}
+data_sets: [cnf.directory.root_only, cnf.directory.v2.xml, cnf.directory.v2]
+flow:
+  - step: 1
+    call: create_directory               # the version to update from
+    format: canonical-json
+    with: { ehr_id: "${ehr_id}", directory: "${ds:cnf.directory.root_only}" }
+    expect: created
+    capture: { preceding_version_uid: created.version_uid }
+  - step: 2
+    call: update_directory
+    format: canonical-xml                # Content-Type: application/xml
+    with:
+      ehr_id: "${ehr_id}"
+      directory: "${ds:cnf.directory.v2.xml}"
+      preceding_version_uid: "${preceding_version_uid}"
+    expect: updated
+  - step: 3                              # the XML payload landed as that FOLDER
+    call: get_directory
+    format: canonical-json
+    with: { ehr_id: "${ehr_id}" }
+    expect: ok
+    assert:
+      - { assert: equivalent, to: "${ds:cnf.directory.v2}", ignoring: server_assigned }
+postconditions:
+  - assert: state
+    text: >-
+      The EHR ehr_id has the updated directory structure the XML payload
+      described (verified by step 3)

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.create_ehr-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.create_ehr-xml.yaml
@@ -1,0 +1,94 @@
+# The canonical-XML REQUEST-payload branch of EHR creation, on both wire forms
+# of the operation: the client-supplied-id PUT /ehr/{ehr_id} and the id-less
+# POST /ehr. One case, one step per wire form — the accept-forms shape
+# (SF-EXAMPLE-accept_forms), because both steps drive the SAME SM operation and
+# the behaviour under test is a single one: an EHR_STATUS sent as canonical XML
+# is processed as the resource it represents.
+#
+# Decisive released sentence for the payload branch (ITS-REST overview
+# Resources.md §XML Format): "A client MAY use the header `Content-Type:
+# application/xml` in the requests to specify the XML payload format. If the
+# service cannot process the request payload as XML format, it MUST respond
+# with HTTP status code `415 Unsupported Media Type`." A service inside the
+# XML technology profile therefore processes the payload, and the same section
+# fixes the payload's shape: "both request payloads and responses MUST conform
+# to the published XSDs". Only the REQUEST representation is XML here: the
+# runner's format role on a body-carrying request names the request payload
+# and the response is negotiated canonical JSON, which is what lets step 3 read
+# the created EHR back and compare identifiers.
+#
+# Why step 2 is the refusal rather than a second creation. The XML EHR_STATUS
+# carries a subject, and a subject owns at most one EHR — SM
+# i_ehr_service.adoc §create_ehr_for_subject, error
+# `ehr_for_subject_already_exists`, the same ground the canonical-JSON sibling
+# I_EHR_SERVICE.create_ehr-two_ehrs_same_patient gates on. So the id-less POST
+# of the same XML payload is a duplicate, answered per ITS-REST overview
+# Requests_and_responses.md §HTTP status codes, row 409 ("Indicates that the
+# request could not be processed because it might generate a duplicate or a
+# conflict"). That refusal is itself evidence the XML body was parsed: the
+# service can only see the duplicate subject by reading the payload. Committing
+# a second XML EHR would need a second XML EHR_STATUS fixture with its own
+# subject, which buys no additional wire behaviour.
+#
+# Technology-profile scope: canonical XML is OPTIONAL support — Resources.md
+# §Data representation, "Services MUST support at least one of the openEHR
+# **XML** or **JSON** canonical formats for resource representation" — so the
+# case declares the canonical-xml format axis and is counted only against a
+# statement whose technology profile declares that format, rather than gating
+# CORE on a representation the release leaves open.
+#
+# The ehr_id is the deterministic per-case/per-row value the `provided` matrix
+# sentinel mints (a pure function of case id + row index), so two runners
+# choose the same id and no other case can collide with it.
+id: I_EHR_SERVICE.create_ehr-xml
+kind: functional
+component: EHR
+sm_operation: I_EHR_SERVICE.create_ehr
+capabilities: [EhrOperations]
+exercises: [EhrApi]
+profiles: [CORE]
+test_purpose: >-
+  An EHR_STATUS sent as a canonical-XML request payload creates the EHR under
+  the client-supplied ehr_id, and a second XML create for the same subject is
+  refused as a duplicate.
+description: "Create EHR from a canonical-XML EHR_STATUS payload"
+spec_refs:
+  - "SM openehr_platform §I_EHR_SERVICE.create_ehr_for_subject_with_id"
+  - "SM openehr_platform §I_EHR_SERVICE.create_ehr_for_subject"
+  - "ITS-REST overview Resources.md §Data representation"
+  - "ITS-REST overview Resources.md §XML Format"
+  - "ITS-REST overview Requests_and_responses §HTTP status codes"
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+formats: [canonical-xml]
+requires: { server: any }
+data_sets: [cnf.ehr_status.with_subject.xml]
+parameters:
+  iteration: reset_per_row
+  matrix: { columns: [ehr_id], rows: [[provided]] }
+flow:
+  - step: 1
+    call: create_ehr
+    variant: with_ehr_id                 # PUT /ehr/{ehr_id}
+    format: canonical-xml                # Content-Type: application/xml
+    with:
+      ehr_id: "${row.ehr_id}"
+      ehr_status: "${ds:cnf.ehr_status.with_subject.xml}"
+    expect: created
+  - step: 2
+    call: create_ehr                     # POST /ehr — same subject, same XML payload
+    format: canonical-xml                # Content-Type: application/xml
+    with: { ehr_status: "${ds:cnf.ehr_status.with_subject.xml}" }
+    expect: already_exists
+  - step: 3                              # the XML payload really created THAT EHR
+    call: get_ehr
+    format: canonical-json
+    with: { ehr_id: "${row.ehr_id}" }
+    expect: ok
+    assert:
+      - { assert: instance_of, rm_type: EHR }
+      - { assert: field, path: "ehr_id/value", equals: "${row.ehr_id}" }
+postconditions:
+  - assert: state
+    text: >-
+      Exactly one EHR exists for the XML payload's subject — the one created
+      under the client-supplied ehr_id in step 1 (verified by step 3)

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.get_ehr-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.get_ehr-xml.yaml
@@ -1,0 +1,48 @@
+# The canonical-XML representation branch of the EHR read: GET /ehr/{ehr_id}
+# under `Accept: application/xml` is answered in XML, not silently in the
+# service's preferred representation.
+#
+# Decisive released sentences (ITS-REST overview Resources.md §XML Format):
+# "The client SHOULD use the `Accept: application/xml` request header to
+# specify the expected XML response format. If the service cannot fulfill this
+# aspect of the request, it MUST respond with HTTP status code `406 Not
+# Acceptable`." and "Proper header `Content-Type: application/xml` MUST be
+# present in the response of the service unless the response has no content
+# body (HTTP status code `204`)." A 200 answer therefore has exactly one
+# conformant Content-Type, and the binding's `Content-Type: negotiated`
+# matcher is what asserts it — an XML body is not JSON, so the RM-level
+# `instance_of`/`field` assertions the canonical-JSON sibling case carries
+# cannot apply here and are deliberately absent (the JSON read is asserted by
+# I_EHR_SERVICE.get_ehr-existing_ehr_by_ehr_id).
+#
+# Technology-profile scope: canonical XML is OPTIONAL support — Resources.md
+# §Data representation, "Services MUST support at least one of the openEHR
+# **XML** or **JSON** canonical formats for resource representation" — so the
+# case declares the canonical-xml format axis and is counted only against a
+# statement whose technology profile declares that format, rather than
+# gating CORE on a representation the release leaves open.
+id: I_EHR_SERVICE.get_ehr-xml
+kind: functional
+component: EHR
+sm_operation: I_EHR_SERVICE.get_ehr
+capabilities: [EhrOperations]
+profiles: [CORE]
+test_purpose: >-
+  get_ehr requested as canonical XML answers the EHR in the negotiated XML
+  representation.
+description: "Get existing EHR with Accept: application/xml"
+spec_refs:
+  - "SM openehr_platform §I_EHR_SERVICE.get_ehr"
+  - "ITS-REST overview Resources.md §Data representation"
+  - "ITS-REST overview Resources.md §XML Format"
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+formats: [canonical-xml]
+requires:
+  server: any
+  ehr: { commits: any }                  # mints ${ehr_id}
+flow:
+  - step: 1
+    call: get_ehr
+    format: canonical-xml                # Accept: application/xml
+    with: { ehr_id: "${ehr_id}" }
+    expect: ok

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.get_ehrs_for_subject-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.get_ehrs_for_subject-xml.yaml
@@ -1,0 +1,56 @@
+# The canonical-XML representation branch of the by-subject EHR read:
+# GET /ehr?subject_id&subject_namespace under `Accept: application/xml`.
+#
+# Decisive released sentences (ITS-REST overview Resources.md §XML Format):
+# "The client SHOULD use the `Accept: application/xml` request header to
+# specify the expected XML response format. If the service cannot fulfill this
+# aspect of the request, it MUST respond with HTTP status code `406 Not
+# Acceptable`." and "Proper header `Content-Type: application/xml` MUST be
+# present in the response of the service unless the response has no content
+# body (HTTP status code `204`)." The binding's `Content-Type: negotiated`
+# matcher is what asserts the representation; an XML body is not JSON, so the
+# RM-level assertions the canonical-JSON sibling carries
+# (I_EHR_SERVICE.get_ehr-existing_ehr_by_subject_id) cannot apply here and are
+# deliberately absent.
+#
+# The subject is this case's own (cnf-subject-05@cnf): the SUT is shared across
+# the catalogue and a subject owns at most one EHR
+# (I_EHR_SERVICE.create_ehr-two_ehrs_same_patient), so a subject-keyed case
+# that borrowed another case's fixture would fail on ordering rather than on
+# the behaviour under test. The provisioning create stays canonical-json — the
+# behaviour under test is the READ representation.
+#
+# Technology-profile scope: canonical XML is OPTIONAL support — Resources.md
+# §Data representation, "Services MUST support at least one of the openEHR
+# **XML** or **JSON** canonical formats for resource representation" — so the
+# case declares the canonical-xml format axis and is counted only against a
+# statement whose technology profile declares that format.
+id: I_EHR_SERVICE.get_ehrs_for_subject-xml
+kind: functional
+component: EHR
+sm_operation: I_EHR_SERVICE.get_ehrs_for_subject
+capabilities: [EhrOperations]
+profiles: [CORE]
+test_purpose: >-
+  get_ehrs_for_subject requested as canonical XML answers the subject's EHR in
+  the negotiated XML representation.
+description: "Get existing EHR by subject_id with Accept: application/xml"
+spec_refs:
+  - "SM openehr_platform §I_EHR_SERVICE.get_ehrs_for_subject"
+  - "ITS-REST overview Resources.md §Data representation"
+  - "ITS-REST overview Resources.md §XML Format"
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+formats: [canonical-xml]
+requires: { server: any }
+data_sets: [cnf.ehr_status.with_subject.f]
+flow:
+  - step: 1
+    call: create_ehr                     # provision the known-subject precondition
+    format: canonical-json
+    with: { ehr_status: "${ds:cnf.ehr_status.with_subject.f}" }
+    expect: created
+  - step: 2
+    call: get_ehrs_for_subject
+    format: canonical-xml                # Accept: application/xml
+    with: { subject_id: "cnf-subject-05", subject_namespace: "cnf" }
+    expect: ok

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.has_ehr-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.has_ehr-xml.yaml
@@ -1,0 +1,48 @@
+# The canonical-XML representation branch of the EHR existence probe. ITS-REST
+# has no dedicated probe, so has_ehr is realized as GET /ehr/{ehr_id} (200 =
+# exists); asking for that answer as XML must still produce the boolean AND the
+# negotiated representation.
+#
+# Decisive released sentences (ITS-REST overview Resources.md §XML Format):
+# "The client SHOULD use the `Accept: application/xml` request header to
+# specify the expected XML response format. If the service cannot fulfill this
+# aspect of the request, it MUST respond with HTTP status code `406 Not
+# Acceptable`." and "Proper header `Content-Type: application/xml` MUST be
+# present in the response of the service unless the response has no content
+# body (HTTP status code `204`)." The binding's `Content-Type: negotiated`
+# matcher asserts the representation; the `returns` assertion is wire-presence
+# (the 2xx/non-2xx split the boolean is carried by), so it is representation-
+# independent and stays.
+#
+# Technology-profile scope: canonical XML is OPTIONAL support — Resources.md
+# §Data representation, "Services MUST support at least one of the openEHR
+# **XML** or **JSON** canonical formats for resource representation" — so the
+# case declares the canonical-xml format axis and is counted only against a
+# statement whose technology profile declares that format.
+id: I_EHR_SERVICE.has_ehr-xml
+kind: functional
+component: EHR
+sm_operation: I_EHR_SERVICE.has_ehr
+capabilities: [EhrOperations]
+profiles: [CORE]
+test_purpose: >-
+  has_ehr requested as canonical XML reports the EHR exists and answers in the
+  negotiated XML representation.
+description: "Check has EHR with Accept: application/xml"
+spec_refs:
+  - "SM openehr_platform §I_EHR_SERVICE.has_ehr"
+  - "ITS-REST overview Resources.md §Data representation"
+  - "ITS-REST overview Resources.md §XML Format"
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+formats: [canonical-xml]
+requires:
+  server: any
+  ehr: { commits: any }                  # mints ${ehr_id}
+flow:
+  - step: 1
+    call: has_ehr
+    format: canonical-xml                # Accept: application/xml
+    with: { ehr_id: "${ehr_id}" }
+    expect: ok                           # positive: the EHR exists
+    assert:
+      - { assert: returns, equals: true }

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.has_ehr_for_subject-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.has_ehr_for_subject-xml.yaml
@@ -1,0 +1,60 @@
+# The canonical-XML representation branch of the by-subject existence probe.
+# ITS-REST has no dedicated probe, so has_ehr_for_subject is realized as
+# GET /ehr?subject_id&subject_namespace (200 = an EHR exists for the subject);
+# asking for that answer as XML must still produce the boolean AND the
+# negotiated representation.
+#
+# Decisive released sentences (ITS-REST overview Resources.md §XML Format):
+# "The client SHOULD use the `Accept: application/xml` request header to
+# specify the expected XML response format. If the service cannot fulfill this
+# aspect of the request, it MUST respond with HTTP status code `406 Not
+# Acceptable`." and "Proper header `Content-Type: application/xml` MUST be
+# present in the response of the service unless the response has no content
+# body (HTTP status code `204`)." The binding's `Content-Type: negotiated`
+# matcher asserts the representation; the `returns` assertion is wire-presence
+# (the 2xx/non-2xx split the boolean is carried by), so it is representation-
+# independent and stays.
+#
+# The subject is this case's own (cnf-subject-06@cnf): the SUT is shared across
+# the catalogue and a subject owns at most one EHR
+# (I_EHR_SERVICE.create_ehr-two_ehrs_same_patient), so a subject-keyed case
+# that borrowed another case's fixture would fail on ordering rather than on
+# the behaviour under test. The provisioning create stays canonical-json — the
+# behaviour under test is the READ representation.
+#
+# Technology-profile scope: canonical XML is OPTIONAL support — Resources.md
+# §Data representation, "Services MUST support at least one of the openEHR
+# **XML** or **JSON** canonical formats for resource representation" — so the
+# case declares the canonical-xml format axis and is counted only against a
+# statement whose technology profile declares that format.
+id: I_EHR_SERVICE.has_ehr_for_subject-xml
+kind: functional
+component: EHR
+sm_operation: I_EHR_SERVICE.has_ehr_for_subject
+capabilities: [EhrOperations]
+profiles: [CORE]
+test_purpose: >-
+  has_ehr_for_subject requested as canonical XML reports the subject's EHR
+  exists and answers in the negotiated XML representation.
+description: "Check has EHR by subject_id with Accept: application/xml"
+spec_refs:
+  - "SM openehr_platform §I_EHR_SERVICE.has_ehr_for_subject"
+  - "ITS-REST overview Resources.md §Data representation"
+  - "ITS-REST overview Resources.md §XML Format"
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+formats: [canonical-xml]
+requires: { server: any }
+data_sets: [cnf.ehr_status.with_subject.g]
+flow:
+  - step: 1
+    call: create_ehr                     # provision the known-subject precondition
+    format: canonical-json
+    with: { ehr_status: "${ds:cnf.ehr_status.with_subject.g}" }
+    expect: created
+  - step: 2
+    call: has_ehr_for_subject
+    format: canonical-xml                # Accept: application/xml
+    with: { subject_id: "cnf-subject-06", subject_namespace: "cnf" }
+    expect: ok                           # positive: an EHR exists for the subject
+    assert:
+      - { assert: returns, equals: true }

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_ehr_status-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_ehr_status-xml.yaml
@@ -1,0 +1,46 @@
+# The canonical-XML representation branch of the EHR_STATUS read:
+# GET /ehr/{ehr_id}/ehr_status under `Accept: application/xml`.
+#
+# Decisive released sentences (ITS-REST overview Resources.md §XML Format):
+# "The client SHOULD use the `Accept: application/xml` request header to
+# specify the expected XML response format. If the service cannot fulfill this
+# aspect of the request, it MUST respond with HTTP status code `406 Not
+# Acceptable`." and "Proper header `Content-Type: application/xml` MUST be
+# present in the response of the service unless the response has no content
+# body (HTTP status code `204`)." A 200 answer therefore has exactly one
+# conformant Content-Type, and the binding's `Content-Type: negotiated`
+# matcher is what asserts it — an XML body is not JSON, so the RM-level
+# assertions the canonical-JSON sibling carries
+# (I_EHR_STATUS.get_ehr_status-get_by_ehr_id) cannot apply here and are
+# deliberately absent.
+#
+# Technology-profile scope: canonical XML is OPTIONAL support — Resources.md
+# §Data representation, "Services MUST support at least one of the openEHR
+# **XML** or **JSON** canonical formats for resource representation" — so the
+# case declares the canonical-xml format axis and is counted only against a
+# statement whose technology profile declares that format.
+id: I_EHR_STATUS.get_ehr_status-xml
+kind: functional
+component: EHR
+sm_operation: I_EHR_STATUS.get_ehr_status
+capabilities: [EhrStatus]
+profiles: [CORE]
+test_purpose: >-
+  get_ehr_status requested as canonical XML answers the EHR_STATUS in the
+  negotiated XML representation.
+description: "Get EHR_STATUS with Accept: application/xml"
+spec_refs:
+  - "SM openehr_platform §I_EHR_STATUS.get_ehr_status"
+  - "ITS-REST overview Resources.md §Data representation"
+  - "ITS-REST overview Resources.md §XML Format"
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+formats: [canonical-xml]
+requires:
+  server: any
+  ehr: { commits: any }                  # mints ${ehr_id}
+flow:
+  - step: 1
+    call: get_ehr_status
+    format: canonical-xml                # Accept: application/xml
+    with: { ehr_id: "${ehr_id}" }
+    expect: ok

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_versioned_ehr_status-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_versioned_ehr_status-xml.yaml
@@ -1,0 +1,71 @@
+# The canonical-XML representation branch of the versioned EHR_STATUS, on BOTH
+# realizations of the operation: the VERSIONED_EHR_STATUS container read
+# (GET /ehr/{ehr_id}/versioned_ehr_status) and its VERSION sub-resource
+# (.../version/{version_uid}). One case, one step per realization — the
+# accept-forms shape (SF-EXAMPLE-accept_forms) — because both drive the same SM
+# operation and the behaviour under test is one: the versioned resource is
+# served in the representation the client negotiated.
+#
+# Decisive released sentences (ITS-REST overview Resources.md §XML Format):
+# "The client SHOULD use the `Accept: application/xml` request header to
+# specify the expected XML response format. If the service cannot fulfill this
+# aspect of the request, it MUST respond with HTTP status code `406 Not
+# Acceptable`." and "Proper header `Content-Type: application/xml` MUST be
+# present in the response of the service unless the response has no content
+# body (HTTP status code `204`)." Both bindings declare `Content-Type:
+# negotiated`, which is what asserts the representation; an XML body is not
+# JSON, so the RM-level assertions the canonical-JSON siblings carry
+# (-container_shape, -contained_uid_form) cannot apply here and are
+# deliberately absent.
+#
+# Step 1 stays canonical-json: it exists only to learn the version identity the
+# sub-resource is addressed by (the ETag of the EHR_STATUS read), which is
+# representation-independent.
+#
+# Technology-profile scope: canonical XML is OPTIONAL support — Resources.md
+# §Data representation, "Services MUST support at least one of the openEHR
+# **XML** or **JSON** canonical formats for resource representation" — so the
+# case declares the canonical-xml format axis and is counted only against a
+# statement whose technology profile declares that format.
+id: I_EHR_STATUS.get_versioned_ehr_status-xml
+kind: functional
+component: EHR
+sm_operation: I_EHR_STATUS.get_versioned_ehr_status
+capabilities: [EhrStatus]
+exercises: [Versioning]
+profiles: [CORE]
+test_purpose: >-
+  The VERSIONED_EHR_STATUS container and an addressed EHR_STATUS version,
+  requested as canonical XML, are answered in the negotiated XML
+  representation.
+description: "Get VERSIONED_EHR_STATUS and one of its versions with Accept: application/xml"
+spec_refs:
+  - "SM openehr_platform §I_EHR_STATUS.get_versioned_ehr_status"
+  - "ITS-REST overview Resources.md §Data representation"
+  - "ITS-REST overview Resources.md §XML Format"
+  - "ITS-REST overview Resources §Resource identification"
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+formats: [canonical-xml]
+requires:
+  server: any
+  ehr: { commits: none }                 # mints ${ehr_id}
+flow:
+  - step: 1
+    call: I_EHR_STATUS.get_ehr_status    # learn the version identity to address
+    format: canonical-json
+    with: { ehr_id: "${ehr_id}" }
+    expect: ok
+    capture: { status_version_uid: ok.status_version_uid }
+  - step: 2
+    call: get_versioned_ehr_status       # the version CONTAINER
+    format: canonical-xml                # Accept: application/xml
+    with: { ehr_id: "${ehr_id}" }
+    expect: ok
+  - step: 3
+    call: get_versioned_ehr_status       # the VERSION sub-resource
+    variant: version
+    format: canonical-xml                # Accept: application/xml
+    with:
+      ehr_id: "${ehr_id}"
+      version_uid: "${status_version_uid}"
+    expect: ok

--- a/tools/cnf-runner/artifacts/vocab/wire_surface.yaml
+++ b/tools/cnf-runner/artifacts/vocab/wire_surface.yaml
@@ -549,65 +549,21 @@ branches:
     format: canonical-xml
     reason: coverage_gap
     source: "ITS-REST §content negotiation — the canonical-xml representation of I_EHR_CONTRIBUTION.has_contribution is declared but the catalogue exercises canonical-json; the canonical-xml variant is a NEW-CASE candidate"
-  - binding: I_EHR_DIRECTORY.create_directory
-    format: canonical-xml
-    reason: coverage_gap
-    source: "ITS-REST §content negotiation — the canonical-xml representation of I_EHR_DIRECTORY.create_directory is declared but the catalogue exercises canonical-json; the canonical-xml variant is a NEW-CASE candidate"
-  - binding: I_EHR_DIRECTORY.get_directory
-    format: canonical-xml
-    reason: coverage_gap
-    source: "ITS-REST §content negotiation — the canonical-xml representation of I_EHR_DIRECTORY.get_directory is declared but the catalogue exercises canonical-json; the canonical-xml variant is a NEW-CASE candidate"
-  - binding: I_EHR_DIRECTORY.get_directory_at_time
-    format: canonical-xml
-    reason: coverage_gap
-    source: "ITS-REST §content negotiation — the canonical-xml representation of I_EHR_DIRECTORY.get_directory_at_time is declared but the catalogue exercises canonical-json; the canonical-xml variant is a NEW-CASE candidate"
-  - binding: I_EHR_DIRECTORY.get_directory_at_version
-    format: canonical-xml
-    reason: coverage_gap
-    source: "ITS-REST §content negotiation — the canonical-xml representation of I_EHR_DIRECTORY.get_directory_at_version is declared but the catalogue exercises canonical-json; the canonical-xml variant is a NEW-CASE candidate"
-  - binding: I_EHR_DIRECTORY.has_directory
-    format: canonical-xml
-    reason: coverage_gap
-    source: "ITS-REST §content negotiation — the canonical-xml representation of I_EHR_DIRECTORY.has_directory is declared but the catalogue exercises canonical-json; the canonical-xml variant is a NEW-CASE candidate"
-  - binding: I_EHR_DIRECTORY.has_directory_version
-    format: canonical-xml
-    reason: coverage_gap
-    source: "ITS-REST §content negotiation — the canonical-xml representation of I_EHR_DIRECTORY.has_directory_version is declared but the catalogue exercises canonical-json; the canonical-xml variant is a NEW-CASE candidate"
-  - binding: I_EHR_DIRECTORY.has_path
-    format: canonical-xml
-    reason: coverage_gap
-    source: "ITS-REST §content negotiation — the canonical-xml representation of I_EHR_DIRECTORY.has_path is declared but the catalogue exercises canonical-json; the canonical-xml variant is a NEW-CASE candidate"
-  - binding: I_EHR_DIRECTORY.update_directory
-    format: canonical-xml
-    reason: coverage_gap
-    source: "ITS-REST §content negotiation — the canonical-xml representation of I_EHR_DIRECTORY.update_directory is declared but the catalogue exercises canonical-json; the canonical-xml variant is a NEW-CASE candidate"
-  # canonical-json on the with_ehr_id variant is EXERCISED by
-  # I_EHR_SERVICE.create_ehr-with_ehr_id — the exception is retired.
-  - binding: I_EHR_SERVICE.create_ehr
-    variant: with_ehr_id
-    format: canonical-xml
-    reason: coverage_gap
-    source: "released ITS-REST 1.1.0 — the create-EHR-with-id path (PUT /ehr/{ehr_id}) is unexercised in canonical-xml; a create-EHR-with-id case is a NEW-CASE candidate"
-  - binding: I_EHR_SERVICE.create_ehr
-    format: canonical-xml
-    reason: coverage_gap
-    source: "ITS-REST §content negotiation — the canonical-xml representation of I_EHR_SERVICE.create_ehr is declared but the catalogue exercises canonical-json; the canonical-xml variant is a NEW-CASE candidate"
-  - binding: I_EHR_SERVICE.get_ehr
-    format: canonical-xml
-    reason: coverage_gap
-    source: "ITS-REST §content negotiation — the canonical-xml representation of I_EHR_SERVICE.get_ehr is declared but the catalogue exercises canonical-json; the canonical-xml variant is a NEW-CASE candidate"
-  - binding: I_EHR_SERVICE.get_ehrs_for_subject
-    format: canonical-xml
-    reason: coverage_gap
-    source: "ITS-REST §content negotiation — the canonical-xml representation of I_EHR_SERVICE.get_ehrs_for_subject is declared but the catalogue exercises canonical-json; the canonical-xml variant is a NEW-CASE candidate"
-  - binding: I_EHR_SERVICE.has_ehr
-    format: canonical-xml
-    reason: coverage_gap
-    source: "ITS-REST §content negotiation — the canonical-xml representation of I_EHR_SERVICE.has_ehr is declared but the catalogue exercises canonical-json; the canonical-xml variant is a NEW-CASE candidate"
-  - binding: I_EHR_SERVICE.has_ehr_for_subject
-    format: canonical-xml
-    reason: coverage_gap
-    source: "ITS-REST §content negotiation — the canonical-xml representation of I_EHR_SERVICE.has_ehr_for_subject is declared but the catalogue exercises canonical-json; the canonical-xml variant is a NEW-CASE candidate"
+  # RETIRED coverage_gaps (2026-07-28) — the canonical-xml branch of the whole
+  # EHR_DIRECTORY surface and of the EHR-service surface is now exercised, so
+  # the fourteen exceptions are gone rather than reworded (coverage only
+  # ratchets up). One `-xml` case per operation: the writes
+  # (I_EHR_DIRECTORY.{create,update}_directory-xml,
+  # I_EHR_SERVICE.create_ehr-xml — the last driving BOTH create wire forms,
+  # the with_ehr_id PUT and the id-less POST) send a codec-derived canonical-
+  # XML request payload and read the resource back to prove it was understood,
+  # and the reads (I_EHR_DIRECTORY.{get_directory, get_directory_at_time,
+  # get_directory_at_version, has_directory, has_directory_version,
+  # has_path}-xml, I_EHR_SERVICE.{get_ehr, get_ehrs_for_subject, has_ehr,
+  # has_ehr_for_subject}-xml) negotiate `Accept: application/xml` and are
+  # judged by each binding's `Content-Type: negotiated` matcher. The
+  # canonical-json exception on the create_ehr with_ehr_id variant had already
+  # retired with I_EHR_SERVICE.create_ehr-with_ehr_id.
   - binding: I_EHR_STATUS.clear_ehr_modifiable
     format: canonical-xml
     reason: coverage_gap
@@ -616,16 +572,16 @@ branches:
     format: canonical-xml
     reason: coverage_gap
     source: "ITS-REST §content negotiation — the canonical-xml representation of I_EHR_STATUS.clear_ehr_queryable is declared but the catalogue exercises canonical-json; the canonical-xml variant is a NEW-CASE candidate"
-  - binding: I_EHR_STATUS.get_ehr_status
-    format: canonical-xml
-    reason: coverage_gap
-    source: "ITS-REST §content negotiation — the canonical-xml representation of I_EHR_STATUS.get_ehr_status is declared but the catalogue exercises canonical-json; the canonical-xml variant is a NEW-CASE candidate"
-  # Scoped to every realization of the operation (container read + version
-  # sub-resource): neither declares a canonical-xml case yet.
-  - binding: I_EHR_STATUS.get_versioned_ehr_status
-    format: canonical-xml
-    reason: coverage_gap
-    source: "ITS-REST §content negotiation — the canonical-xml representation of the VERSIONED_EHR_STATUS container read and of its version sub-resource is declared but the catalogue exercises canonical-json; the canonical-xml variant is a NEW-CASE candidate"
+  # RETIRED coverage_gaps (2026-07-28) — the two EHR_STATUS READS are now
+  # exercised in canonical-xml: I_EHR_STATUS.get_ehr_status-xml, and
+  # I_EHR_STATUS.get_versioned_ehr_status-xml, which covers BOTH realizations
+  # the retired exception scoped (the VERSIONED_EHR_STATUS container read and
+  # its version sub-resource) with one step each. The four SETTER rows stay
+  # (clear_ehr_modifiable / clear_ehr_queryable above,
+  # set_ehr_modifiable / set_ehr_queryable below): their variant-less
+  # realization is a read-modify-write whose request body the runner BUILDS
+  # from the EHR_STATUS it just read, so there is no seam through which a
+  # canonical-XML request payload can enter that wire form.
   - binding: I_EHR_STATUS.set_ehr_modifiable
     format: canonical-xml
     reason: coverage_gap


### PR DESCRIPTION
#288 slice 3, part A: 16 canonical-xml format branch gaps burned down into 15 cases (EHR ×5, EHR_STATUS reads ×2, DIRECTORY ×8). `cnf-runner validate` on this tree: 645 cases, 168 bindings, **0 findings**; ledger `coverage_gap` count 74 → 58.

Design (stated in every header): READ cases assert through the binding's strict `Content-Type: negotiated` matcher (an XML body is a string to the runner — no RM assertions pretend otherwise); WRITE cases post the codec-derived XML fixtures (PR #552) and prove the payload was *understood* by reading back negotiated JSON and `equivalent`-comparing it to the fixture's canonical-JSON twin; every case scopes the `canonical-xml` format axis so a CORE-tier statement without the XML technology profile is never gated on optional support (Resources.md §Data representation: "at least one of" the two canonical formats).

Honestly left open (rows kept, reason recorded): the four EHR_STATUS setters' canonical-xml rows — their variant-less bindings build the PUT body by JSON read-modify-write (`from_capture` + `set:`), so no XML request seam exists today; closing them needs per-setter `xml_body` variant bindings + four new XML fixtures (follow-up in this program) and exposed a real runner defect (silent no-op `set:` on a non-object captured body — filed separately).

Corpus: three canonical-xml manifest keys (provenance-stamped codec-derived) + two subject-keyed JSON fixtures following the existing `.b`–`.e` precedent.