### PR TITLE
fix(cnf-runner): the run record's tech profile is the statement's claim — the false-green deselection defect

### DIFF
--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.set_ehr_modifiable-xml_body.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.set_ehr_modifiable-xml_body.yaml
@@ -45,7 +45,7 @@ flow:
     format: canonical-json
     with: { ehr_id: "${ehr_id}" }
     expect: ok
-    capture: { status_version_uid: ok.status_version_uid }
+    capture: { status_version_uid: ok.status_version_uid, status_body: ok.body }   # the flip step is the variant-less read-modify-write realization: its binding builds the PUT body from this capture
   - step: 2                              # make the target transition observable: is_modifiable -> false first (JSON read-modify-write sibling)
     call: clear_ehr_modifiable
     format: canonical-json

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.set_ehr_queryable-xml_body.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.set_ehr_queryable-xml_body.yaml
@@ -45,7 +45,7 @@ flow:
     format: canonical-json
     with: { ehr_id: "${ehr_id}" }
     expect: ok
-    capture: { status_version_uid: ok.status_version_uid }
+    capture: { status_version_uid: ok.status_version_uid, status_body: ok.body }   # the flip step is the variant-less read-modify-write realization: its binding builds the PUT body from this capture
   - step: 2                              # make the target transition observable: is_queryable -> false first (JSON read-modify-write sibling)
     call: clear_ehr_queryable
     format: canonical-json

--- a/tools/cnf-runner/src/bin/cnf-runner.rs
+++ b/tools/cnf-runner/src/bin/cnf-runner.rs
@@ -1610,9 +1610,26 @@ fn run_command(
             verification_pack_status: cnf_runner::party::VerificationPackStatus::Passed,
         },
         schedule_release: "cnf-2.0-w2".to_owned(),
+        // The recorded technology profile IS the claim the verdict pipeline
+        // selects gating records with (`verdict::rollup_results`): a narrow
+        // hardcoded list here silently deselects every other format's failed
+        // rows — the false-green shape that hid four red canonical-xml rows
+        // behind a PASS badge (#288 convergence run, 2026-07-28). The profile
+        // therefore comes from the party statement's its-rest claim; with no
+        // statement, EVERY format is selected so nothing red can vanish.
         tech_profile: cnf_runner::party::TechProfile {
             its: cnf_runner::vocab::ItsName::ItsRest,
-            formats: vec![cnf_runner::vocab::FormatName::CanonicalJson],
+            formats: statement
+                .as_ref()
+                .and_then(|s| {
+                    s.tech_profiles
+                        .iter()
+                        .find(|p| p.its == cnf_runner::vocab::ItsName::ItsRest)
+                })
+                .map_or_else(
+                    || cnf_runner::vocab::FormatName::ALL.to_vec(),
+                    |p| p.formats.clone(),
+                ),
         },
         ixit_digest,
         outcomes,

--- a/tools/cnf-runner/src/verdict.rs
+++ b/tools/cnf-runner/src/verdict.rs
@@ -183,6 +183,33 @@ pub fn compute(
     register: &AmbiguityRegister,
 ) -> VerdictReport {
     let mut review = static_review(statement, cases, matrix, register);
+    // The results record's technology profile is the selection filter for
+    // every gating roll-up below, so a divergence from the statement's claim
+    // means records were (de)selected under a DIFFERENT profile than the one
+    // being certified — stale results, or a run driven without the statement.
+    // Surfaced as a review finding, never silently tolerated (a narrower
+    // recorded profile deselects failed rows: the false-green shape found on
+    // the #288 convergence run, 2026-07-28).
+    if let Some(claimed) = statement
+        .tech_profiles
+        .iter()
+        .find(|p| p.its == results.tech_profile.its)
+    {
+        let mut recorded = results.tech_profile.formats.clone();
+        let mut declared = claimed.formats.clone();
+        recorded.sort_unstable_by_key(|f| format!("{f:?}"));
+        declared.sort_unstable_by_key(|f| format!("{f:?}"));
+        if recorded != declared {
+            review.push(ReviewFinding {
+                message: format!(
+                    "results.tech_profile.formats {:?} diverges from the statement's {:?} \
+                     tech-profile claim {:?} — the run's gating selection does not match the \
+                     certified claim; re-run against the current statement",
+                    results.tech_profile.formats, results.tech_profile.its, claimed.formats
+                ),
+            });
+        }
+    }
     let performance = measured_verdicts(statement, results, perf_cases, &mut review);
     let selected = select(statement, results, cases, register);
 
@@ -786,6 +813,45 @@ mod tests {
                 .find(|(t, _)| *t == Tier::Core)
                 .map(|(_, v)| *v),
             Some(ProfileVerdict::Fail)
+        );
+    }
+
+    #[test]
+    fn diverging_recorded_tech_profile_is_a_review_finding() {
+        // A results record whose tech profile is NARROWER than the statement's
+        // claim deselects that format's rows from every gating roll-up — the
+        // false-green shape (a failed canonical-xml case invisible behind a
+        // PASS). The divergence itself must surface as a review finding.
+        let cases = vec![functional_case(
+            "I_EHR_SERVICE.create_ehr-main",
+            &["EhrOperations"],
+            &["CORE"],
+        )];
+        let mut st = statement(&["EhrOperations"], &["CORE"], &[]);
+        st.tech_profiles[0].formats = vec![FormatName::CanonicalJson, FormatName::CanonicalXml];
+        let rs = results(serde_json::json!([
+            { "case": "I_EHR_SERVICE.create_ehr-main", "format": "canonical-json",
+              "status": "passed", "rows_driven": 1, "rows_total": 1 }
+        ]));
+        let report = compute(&st, &rs, &cases, &[], &matrix(), &register());
+        assert!(
+            report
+                .review
+                .iter()
+                .any(|f| f.message.contains("diverges from the statement's")),
+            "expected the tech-profile divergence review finding, got {:?}",
+            report.review
+        );
+        // And the matching profile stays clean.
+        st.tech_profiles[0].formats = vec![FormatName::CanonicalJson];
+        let report = compute(&st, &rs, &cases, &[], &matrix(), &register());
+        assert!(
+            !report
+                .review
+                .iter()
+                .any(|f| f.message.contains("diverges from the statement's")),
+            "{:?}",
+            report.review
         );
     }
 


### PR DESCRIPTION
The owner spotted the smoking gun on the #288 convergence run: **CORE+STANDARD PASS on the badge with 4 failed / 2 errored rows in results.json**. Root cause: the `run` subcommand **hardcoded** `results.tech_profile.formats` to `[canonical-json]` — and that field is the selection filter for every gating roll-up (`verdict::rollup_results`), so every non-JSON record was silently deselected at verdict time. Harmless while the catalogue had one XML case; slice 3 made it load-bearing.

- The recorded profile now comes from the party statement's its-rest tech-profile claim (the statement was already correct: it declares all four formats); with no statement supplied, EVERY format is selected — nothing red can vanish by omission.
- The verdict pipeline raises a **review finding** whenever the results record's profile diverges from the statement's claim, so stale results or a statement-less run can never certify silently. Regression test included.
- Rides along: the two `set_*-xml_body` flip-step case fixes (attributed catalogue-side before fixing: the flip PUT's read-modify-write binding builds its body from the `status_body` capture the cases didn't take; the SUT's 422 was correct).

Gates: clippy clean, 183/183 nextest, `validate` 667 cases / 0 findings. The remaining four red rows (composition XML read-backs, contribution 406s) are in formal cnf-triage now; the re-run follows their attributed fixes.