### PR TITLE
fix: run-2 triage — demographic (key, target_path) tag identity + the stale-capture with: shadow

### DIFF
--- a/app/ehrbase-rest/tests/demographic_tags_http.rs
+++ b/app/ehrbase-rest/tests/demographic_tags_http.rs
@@ -372,3 +372,49 @@ async fn relationship_stale_delete_conflict_echoes_latest_etag() {
         .to_owned();
     assert_eq!(echoed, r2, "the latest version_uid rides the 409 ETag");
 }
+
+// ── the ITEM_TAG identity is the (key, target_path) PAIR ─────────────────────
+
+/// Two same-key tags on different target_paths coexist on one party target and
+/// the PUT round-trips both — ITS-REST overview Requests_and_responses.md
+/// §openehr-item-tag and openehr-version-item-tag ("uniquely identified by
+/// their `key` and `target_path` pair attributes"); RM common master07-tags.
+/// The run-2 triage regression (2026-07-28): the demographic PUT deduped by
+/// key alone and silently collapsed the pair (the EHR side had the identity
+/// fix since #369; this seam did not).
+#[tokio::test]
+async fn same_key_tags_on_different_target_paths_coexist() {
+    let (_pg, app) = app().await;
+    let ovid = create_person(&app).await;
+    let vo = vo_of(&ovid).to_owned();
+    let (status, body) = put_tags(
+        &app,
+        &vo,
+        serde_json::json!([
+            { "key": "flag", "value": "a" },
+            { "key": "flag", "value": "b", "target_path": "/details" }
+        ]),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let (status, body) = get_tags(&app, "person", &vo).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let tags: Vec<Value> = serde_json::from_str(&body).unwrap();
+    assert_eq!(
+        tags.len(),
+        2,
+        "both (key, target_path) identities persist: {body}"
+    );
+    assert!(
+        tags.iter().all(|t| t["key"] == "flag"),
+        "the shared key survives on both: {body}"
+    );
+    let paths: Vec<Option<&str>> = tags
+        .iter()
+        .map(|t| t.get("target_path").and_then(Value::as_str))
+        .collect();
+    assert!(
+        paths.contains(&None) && paths.contains(&Some("/details")),
+        "the two identities are distinguished by target_path: {body}"
+    );
+}

--- a/app/ehrbase/src/service/demographic/tags.rs
+++ b/app/ehrbase/src/service/demographic/tags.rs
@@ -96,10 +96,14 @@ impl EhrbaseService {
     }
 
     /// Replace the whole tag collection of a party with the posted set (PUT
-    /// full-collection semantics; an empty list clears all). Duplicate keys in
-    /// the body are last-wins. The RM `ITEM_TAG` invariants are enforced before
-    /// any write: `Inv_key_valid` (non-empty, no surrounding whitespace) and
-    /// `Inv_value_valid` (`value /= Void implies not value.is_empty`).
+    /// full-collection semantics; an empty list clears all). Duplicates in the
+    /// body are last-wins on the ITEM_TAG identity — the (key, target_path)
+    /// PAIR (ITS-REST overview Requests_and_responses.md §openehr-item-tag and
+    /// openehr-version-item-tag: "uniquely identified by their `key` and
+    /// `target_path` pair attributes"; RM common master07-tags). The RM
+    /// `ITEM_TAG` invariants are enforced before any write: `Inv_key_valid`
+    /// (non-empty, no surrounding whitespace) and `Inv_value_valid`
+    /// (`value /= Void implies not value.is_empty`).
     pub(super) async fn replace_party_tags(
         &self,
         kind: PartyKind,
@@ -109,9 +113,13 @@ impl EhrbaseService {
     ) -> Result<Vec<Value>, ServiceError> {
         self.ensure_party_tag_target(kind, vo_id, target_version)
             .await?;
-        // Validate + dedup (last wins) before touching the DB. A BTreeMap keys by
-        // tag key, matching the `ORDER BY key` read-back order.
-        let mut deduped: BTreeMap<String, (Option<String>, Option<String>)> = BTreeMap::new();
+        // Validate + dedup (last wins) before touching the DB, keyed on the
+        // ITEM_TAG identity — the (key, target_path) PAIR, never the key alone
+        // (two same-key tags on different target_paths coexist; keying by tag
+        // key collapsed them — the run-2 triage defect, 2026-07-28, mirroring
+        // the EHR-side #369 identity fix). BTreeMap ordering matches the
+        // `ORDER BY key` read-back order on the leading component.
+        let mut deduped: BTreeMap<(String, Option<String>), Option<String>> = BTreeMap::new();
         for tag in &tags {
             let key = tag
                 .get("key")
@@ -132,8 +140,8 @@ impl EhrbaseService {
             }
             let target_path = tag.get("target_path").and_then(Value::as_str);
             deduped.insert(
-                key.to_owned(),
-                (value.map(str::to_owned), target_path.map(str::to_owned)),
+                (key.to_owned(), target_path.map(str::to_owned)),
+                value.map(str::to_owned),
             );
         }
 
@@ -141,7 +149,7 @@ impl EhrbaseService {
         // are distinct), so the pre-dedup above is what enforces last-wins.
         let new_tags: Vec<tag_repo::NewTag<'_>> = deduped
             .iter()
-            .map(|(key, (value, target_path))| tag_repo::NewTag {
+            .map(|((key, target_path), value)| tag_repo::NewTag {
                 target_type: kind.rm_type(),
                 key: key.as_str(),
                 value: value.as_deref(),

--- a/tools/cnf-runner/src/exec/driver.rs
+++ b/tools/cnf-runner/src/exec/driver.rs
@@ -1566,7 +1566,15 @@ impl HttpDriver<'_> {
     }
 
     /// Captures plus the step's own scalar `with` values (the header/query
-    /// template resolution scope).
+    /// template resolution scope). A step's `with:` value SHADOWS a
+    /// same-named earlier capture in this step's scope — the step's explicit
+    /// input is the most specific binding, and the old keep-the-capture guard
+    /// silently rendered a STALE value into header templates (the run-2
+    /// triage, 2026-07-28: a case that captured `preceding_version_uid` at
+    /// step 1 and passed a newer uid under the same name at step 4 had its
+    /// If-Match rendered from step 1 — the SUT's 412 was correct and the red
+    /// row was this drop). The var store itself is not mutated; the shadow
+    /// lives only in the step-scoped merge.
     fn merge_with_vars(vars: &VarStore, with: &BTreeMap<String, Value>) -> VarStore {
         let mut merged = vars.clone();
         for (key, value) in with {
@@ -1585,7 +1593,6 @@ impl HttpDriver<'_> {
             };
             if let Some(text) = text
                 && let Ok(name) = CaptureName::parse(key)
-                && merged.scalar(&name).is_none()
             {
                 merged.set(name, Captured::Scalar(text));
             }
@@ -2083,6 +2090,40 @@ mod tests {
             }
         }))
         .unwrap()
+    }
+
+    /// The run-2 triage regression (2026-07-28): a step's explicit `with:`
+    /// value must SHADOW a same-named earlier capture in the step's template
+    /// scope. The old keep-the-capture guard rendered a STALE
+    /// `preceding_version_uid` into an If-Match header (step 1's capture
+    /// instead of the newer uid step 4 passed), and the SUT's correct 412
+    /// showed up as a red row.
+    #[test]
+    fn with_value_shadows_same_named_capture_in_step_scope() {
+        let mut vars = VarStore::default();
+        vars.set(
+            CaptureName::parse("preceding_version_uid").unwrap(),
+            Captured::Scalar("vo::sys::1".to_owned()),
+        );
+        let mut with = BTreeMap::new();
+        with.insert(
+            "preceding_version_uid".to_owned(),
+            serde_json::json!("vo::sys::2"),
+        );
+        let merged = HttpDriver::merge_with_vars(&vars, &with);
+        assert_eq!(
+            merged
+                .scalar(&CaptureName::parse("preceding_version_uid").unwrap())
+                .as_deref(),
+            Some("vo::sys::2"),
+            "the step's explicit with: value wins in its own scope"
+        );
+        // The underlying store is untouched — the shadow is step-scoped.
+        assert_eq!(
+            vars.scalar(&CaptureName::parse("preceding_version_uid").unwrap())
+                .as_deref(),
+            Some("vo::sys::1")
+        );
     }
 
     /// The group-9 triage regression: a NUMBER-typed `with:` value must


### PR DESCRIPTION
Three-way triage of the two red rows on the #288 closing run (631/703 passed, honest four-format profile, 0 review findings):

- **Application**: `replace_party_tags` deduped by tag key alone, collapsing same-key/different-path tags — the released identity is the **(key, target_path) pair** (§openehr-item-tag; RM master07). The EHR seam got this fix in #369; the demographic seam now matches, with the wire regression test.
- **Runner**: `merge_with_vars` kept an earlier same-named capture over a step's explicit `with:` value, rendering a **stale If-Match** (reproduced live: identical curl sequence passes; the filtered runner run fails deterministically, header or no header — the SUT's 412 was correct). The step's `with:` now shadows in step scope only.

`update_composition-audit_system_id`'s expectations were right on both arms — no catalogue change. Gates: clippy ×3 crates, 186/186 cnf-runner, 7/7 demographic_tags_http. The final zero-drift pipeline run follows.