### PR TITLE
chore(cnf): the #288 closing zero-drift baseline (633/633 driven, honest four-format profile)

### DIFF
--- a/docs/conformance/ehrbase-rs/CONFORMANCE_CERTIFICATE.md
+++ b/docs/conformance/ehrbase-rs/CONFORMANCE_CERTIFICATE.md
@@ -16,11 +16,11 @@
 | Functional | CORE, STANDARD, OPTIONS, SEC-BASIC |
 | Sec & Priv | SEC-BASIC PASS |
 | Performance | class POC (earned) |
-| Ext Data Fmt | canonical-json |
+| Ext Data Fmt | canonical-json, canonical-xml, wt-flat, wt-structured |
 
 ## Profile Report
 
-Result column: ITS its-rest (canonical-json)
+Result column: ITS its-rest (canonical-json, canonical-xml, wt-flat, wt-structured)
 
 | Family | Capability | Required in profile | Result |
 | --- | --- | --- | --- |
@@ -56,6 +56,8 @@ Result column: ITS its-rest (canonical-json)
 | Platform | QueryApi | Y | pass |
 | Platform | AdminApi | OPT | pass |
 | Platform | MessageApi | OPT | excused (unrealized on this technology profile) |
+| Platform | SystemApi | OPT | pass |
+| Platform | ItemTags | OPT | pass |
 | Platform | Signing | OPT | pass |
 | Platform | SimplifiedFormats | OPT | pass |
 | Platform | SmartAppLaunch | OPT | no cases |
@@ -101,6 +103,8 @@ The exercised-capability set of the measured hospital-simulation workload agains
 | QueryApi | yes | yes |
 | AdminApi | yes | NO — catalogue gap |
 | MessageApi | yes | NO — catalogue gap |
+| SystemApi | yes | NO — catalogue gap |
+| ItemTags | yes | NO — catalogue gap |
 | Signing | yes | NO — catalogue gap |
 | SimplifiedFormats | yes | NO — catalogue gap |
 | EhrDemographicSeparation | yes | NO — catalogue gap |
@@ -109,7 +113,7 @@ The exercised-capability set of the measured hospital-simulation workload agains
 | AuditAccountability | yes | NO — catalogue gap |
 | AnonymousEhrs | yes | NO — catalogue gap |
 
-Claimed capabilities the simulation never touches (24): Adl14ArchetypeProvisioning, Adl2ArchetypeProvisioning, Adl2OptProvisioning, PartyOperations, PartyRelationshipOperations, AqlAdvanced, AqlTerminology, ActivityReport, PhysicalDeletion, EhrDumpLoad, EhrArchive, DemographicArchive, EhrExtract, Tds, DemographicApi, AdminApi, MessageApi, Signing, SimplifiedFormats, EhrDemographicSeparation, AuthenticatedAccess, AuthorizationSeparation, AuditAccountability, AnonymousEhrs. Each is either a journey-catalogue gap to close or a capability outside the measured-load surface (admin, demographics, messaging, security posture — exercised by the functional schedule, not the load instrument).
+Claimed capabilities the simulation never touches (26): Adl14ArchetypeProvisioning, Adl2ArchetypeProvisioning, Adl2OptProvisioning, PartyOperations, PartyRelationshipOperations, AqlAdvanced, AqlTerminology, ActivityReport, PhysicalDeletion, EhrDumpLoad, EhrArchive, DemographicArchive, EhrExtract, Tds, DemographicApi, AdminApi, MessageApi, SystemApi, ItemTags, Signing, SimplifiedFormats, EhrDemographicSeparation, AuthenticatedAccess, AuthorizationSeparation, AuditAccountability, AnonymousEhrs. Each is either a journey-catalogue gap to close or a capability outside the measured-load surface (admin, demographics, messaging, security posture — exercised by the functional schedule, not the load instrument).
 
 ## Performance Rating
 

--- a/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
@@ -7,12 +7,12 @@ Runner: cnf-runner 3.11.0 · verification pack: passed
 
 | Status | Count |
 | --- | --- |
-| passed | 543 |
+| passed | 633 |
 | failed | 0 |
 | errored | 0 |
 | skipped | 0 |
 | not_applicable | 70 |
-| total | 613 |
+| total | 703 |
 
 ## By chapter
 
@@ -22,17 +22,19 @@ Runner: cnf-runner 3.11.0 · verification pack: passed
 | I_ADMIN_ARCHIVE | 0 | 0 | 0 | 0 | 4 |
 | I_ADMIN_DUMP_LOAD | 0 | 0 | 0 | 0 | 2 |
 | I_ADMIN_SERVICE | 7 | 0 | 0 | 0 | 10 |
-| I_DEFINITION_ADL14 | 19 | 0 | 0 | 0 | 6 |
+| I_DEFINITION_ADL14 | 20 | 0 | 0 | 0 | 6 |
 | I_DEFINITION_ADL2 | 21 | 0 | 0 | 0 | 8 |
 | I_DEFINITION_QUERY | 28 | 0 | 0 | 0 | 3 |
-| I_DEMOGRAPHIC_SERVICE | 33 | 0 | 0 | 0 | 12 |
-| I_EHR_COMPOSITION | 65 | 0 | 0 | 0 | 0 |
-| I_EHR_CONTRIBUTION | 51 | 0 | 0 | 0 | 5 |
-| I_EHR_DIRECTORY | 51 | 0 | 0 | 0 | 3 |
+| I_DEMOGRAPHIC_SERVICE | 40 | 0 | 0 | 0 | 12 |
+| I_EHR_COMPOSITION | 82 | 0 | 0 | 0 | 0 |
+| I_EHR_CONTRIBUTION | 53 | 0 | 0 | 0 | 5 |
+| I_EHR_DIRECTORY | 60 | 0 | 0 | 0 | 3 |
 | I_EHR_EXTRACT_SERVICE | 0 | 0 | 0 | 0 | 10 |
-| I_EHR_SERVICE | 16 | 0 | 0 | 0 | 0 |
-| I_EHR_STATUS | 29 | 0 | 0 | 0 | 0 |
-| I_QUERY_SERVICE | 31 | 0 | 0 | 0 | 0 |
+| I_EHR_SERVICE | 21 | 0 | 0 | 0 | 0 |
+| I_EHR_STATUS | 45 | 0 | 0 | 0 | 0 |
+| I_ITS_REST_ITEM_TAGS | 30 | 0 | 0 | 0 | 0 |
+| I_ITS_REST_SYSTEM | 1 | 0 | 0 | 0 | 0 |
+| I_QUERY_SERVICE | 33 | 0 | 0 | 0 | 0 |
 | I_TDD_SERVICE | 0 | 0 | 0 | 0 | 4 |
 | SEC | 6 | 0 | 0 | 0 | 0 |
 | SF | 57 | 0 | 0 | 0 | 1 |
@@ -73,7 +75,7 @@ Percentiles re-derive from the embedded HDR V2 histograms; the class verdict is 
 
 ## Honesty
 
-Coverage: 543 of 613 selected cases driven.
+Coverage: 633 of 703 selected cases driven.
 
 Not-executed verdicts (each cited):
 

--- a/docs/conformance/ehrbase-rs/CONFORMANCE_STATEMENT.md
+++ b/docs/conformance/ehrbase-rs/CONFORMANCE_STATEMENT.md
@@ -47,6 +47,8 @@ Capabilities claimed:
 - QueryApi
 - AdminApi
 - MessageApi
+- SystemApi
+- ItemTags
 - Signing
 - SimplifiedFormats
 - EhrDemographicSeparation

--- a/docs/conformance/ehrbase-rs/badge-options.json
+++ b/docs/conformance/ehrbase-rs/badge-options.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "openEHR CNF OPTIONS",
-  "message": "PASS 17/20 capabilities",
+  "message": "PASS 19/22 capabilities",
   "color": "brightgreen"
 }

--- a/docs/conformance/ehrbase-rs/badge.json
+++ b/docs/conformance/ehrbase-rs/badge.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "openEHR conformance",
-  "message": "CORE+STANDARD PASS \u00b7 543/543 cases",
+  "message": "CORE+STANDARD PASS \u00b7 633/633 cases",
   "color": "brightgreen"
 }

--- a/docs/conformance/ehrbase-rs/results.json
+++ b/docs/conformance/ehrbase-rs/results.json
@@ -12,7 +12,10 @@
   "tech_profile": {
     "its": "its-rest",
     "formats": [
-      "canonical-json"
+      "canonical-json",
+      "canonical-xml",
+      "wt-flat",
+      "wt-structured"
     ]
   },
   "ixit_digest": "911ec784dff4ca9b",
@@ -275,7 +278,26 @@
       "rows_total": 1
     },
     {
+      "case": "I_EHR_COMPOSITION.create_composition-version_bare_deprecated",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.create_composition-version_lifecycle",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_COMPOSITION.create_composition-wrong_media",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.create_composition-xml",
+      "format": "canonical-xml",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -365,6 +387,19 @@
       "rows_total": 1
     },
     {
+      "case": "I_EHR_COMPOSITION.get_composition_at_time-simplified_forms",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.get_composition_at_time-xml",
+      "format": "canonical-xml",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_COMPOSITION.get_composition_at_time",
       "status": "passed",
       "rows_driven": 1,
@@ -383,6 +418,13 @@
       "rows_total": 1
     },
     {
+      "case": "I_EHR_COMPOSITION.get_composition_at_version-xml",
+      "format": "canonical-xml",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_COMPOSITION.get_composition_latest-bad_composition",
       "status": "passed",
       "rows_driven": 1,
@@ -396,6 +438,25 @@
     },
     {
       "case": "I_EHR_COMPOSITION.get_composition_latest-deleted_head",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.get_composition_latest-identifier_forms_agree",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.get_composition_latest-simplified_forms",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.get_composition_latest-xml",
+      "format": "canonical-xml",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -497,6 +558,13 @@
       "rows_total": 1
     },
     {
+      "case": "I_EHR_COMPOSITION.get_versioned_composition-xml",
+      "format": "canonical-xml",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_COMPOSITION.get_versioned_composition",
       "status": "passed",
       "rows_driven": 1,
@@ -510,6 +578,13 @@
     },
     {
       "case": "I_EHR_COMPOSITION.has_composition-bad_ehr",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.has_composition-xml",
+      "format": "canonical-xml",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -545,6 +620,12 @@
       "rows_total": 1
     },
     {
+      "case": "I_EHR_COMPOSITION.update_composition-audit_system_id",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_COMPOSITION.update_composition-body_uid_mismatch",
       "status": "passed",
       "rows_driven": 1,
@@ -552,6 +633,12 @@
     },
     {
       "case": "I_EHR_COMPOSITION.update_composition-event",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.update_composition-flat",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -587,7 +674,26 @@
       "rows_total": 1
     },
     {
+      "case": "I_EHR_COMPOSITION.update_composition-structured",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.update_composition-unknown_preceding_version",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_COMPOSITION.update_composition-wrong_template",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.update_composition-xml",
+      "format": "canonical-xml",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -1589,6 +1695,12 @@
       "rows_total": 1
     },
     {
+      "case": "I_EHR_CONTRIBUTION.get_contribution-xml_not_acceptable",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_CONTRIBUTION.has_contribution-bad_contribution",
       "status": "passed",
       "rows_driven": 1,
@@ -1608,6 +1720,12 @@
     },
     {
       "case": "I_EHR_CONTRIBUTION.has_contribution-existing",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_CONTRIBUTION.has_contribution-xml_not_acceptable",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -1689,6 +1807,12 @@
     },
     {
       "case": "I_DEFINITION_ADL14.get_opt-example_type_output",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEFINITION_ADL14.get_opt-flat_not_acceptable",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -2163,6 +2287,13 @@
       "rows_total": 1
     },
     {
+      "case": "I_DEMOGRAPHIC_SERVICE.create_party-item_tag_wrapper_headers",
+      "format": "canonical-json",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_DEMOGRAPHIC_SERVICE.create_party-kind_parity_agent",
       "status": "passed",
       "rows_driven": 1,
@@ -2200,6 +2331,13 @@
     },
     {
       "case": "I_DEMOGRAPHIC_SERVICE.create_party-wrong_subtype_body",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEMOGRAPHIC_SERVICE.create_party-xml",
+      "format": "canonical-xml",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -2275,6 +2413,13 @@
       "rows_total": 1
     },
     {
+      "case": "I_DEMOGRAPHIC_SERVICE.get_party-xml",
+      "format": "canonical-xml",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_DEMOGRAPHIC_SERVICE.get_party_at_time-aaaa",
       "status": "passed",
       "rows_driven": 1,
@@ -2293,6 +2438,13 @@
       "rows_total": 1
     },
     {
+      "case": "I_DEMOGRAPHIC_SERVICE.get_party_at_time-xml",
+      "format": "canonical-xml",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_DEMOGRAPHIC_SERVICE.get_party_at_version-aaaa",
       "status": "passed",
       "rows_driven": 1,
@@ -2300,6 +2452,13 @@
     },
     {
       "case": "I_DEMOGRAPHIC_SERVICE.get_party_at_version-bbbb",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEMOGRAPHIC_SERVICE.get_party_at_version-xml",
+      "format": "canonical-xml",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -2383,6 +2542,12 @@
       "rows_total": 1
     },
     {
+      "case": "I_DEMOGRAPHIC_SERVICE.update_party-unknown_preceding_version",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_DEMOGRAPHIC_SERVICE.update_party-weak_etag_accepted",
       "status": "passed",
       "rows_driven": 1,
@@ -2390,6 +2555,13 @@
     },
     {
       "case": "I_DEMOGRAPHIC_SERVICE.update_party-weak_etag_stale",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEMOGRAPHIC_SERVICE.update_party-xml",
+      "format": "canonical-xml",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -2451,6 +2623,104 @@
       "rows_total": 1
     },
     {
+      "case": "I_ITS_REST_ITEM_TAGS.demographic_tags_get-space_wide_listing",
+      "format": "canonical-json",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ITS_REST_ITEM_TAGS.organisation_tags_delete-wrong_kind_uid",
+      "format": "canonical-json",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ITS_REST_ITEM_TAGS.organisation_tags_get-wrong_kind_uid",
+      "format": "canonical-json",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ITS_REST_ITEM_TAGS.organisation_tags_update-wrong_kind_uid",
+      "format": "canonical-json",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ITS_REST_ITEM_TAGS.person_tags_delete-key_scoped",
+      "format": "canonical-json",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ITS_REST_ITEM_TAGS.person_tags_delete-unknown_key",
+      "format": "canonical-json",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ITS_REST_ITEM_TAGS.person_tags_delete-version_container_disjoint",
+      "format": "canonical-json",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ITS_REST_ITEM_TAGS.person_tags_get-container_target_shape",
+      "format": "canonical-json",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ITS_REST_ITEM_TAGS.person_tags_get-cross_space_composition_uid",
+      "format": "canonical-json",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ITS_REST_ITEM_TAGS.person_tags_get-version_target_shape",
+      "format": "canonical-json",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ITS_REST_ITEM_TAGS.person_tags_update-key_target_path_identity",
+      "format": "canonical-json",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ITS_REST_ITEM_TAGS.person_tags_update-non_array_body",
+      "format": "canonical-json",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ITS_REST_ITEM_TAGS.person_tags_update-unknown_container",
+      "format": "canonical-json",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ITS_REST_ITEM_TAGS.person_tags_update-version_container_disjoint",
+      "format": "canonical-json",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_DIRECTORY.create_directory-bad_ehr",
       "status": "passed",
       "rows_driven": 1,
@@ -2470,6 +2740,19 @@
     },
     {
       "case": "I_EHR_DIRECTORY.create_directory-empty_ehr",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_DIRECTORY.create_directory-invalid_folder",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_DIRECTORY.create_directory-xml",
+      "format": "canonical-xml",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -2553,6 +2836,13 @@
       "rows_total": 1
     },
     {
+      "case": "I_EHR_DIRECTORY.get_directory-xml",
+      "format": "canonical-xml",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_DIRECTORY.get_directory_at_time-bad_ehr",
       "status": "passed",
       "rows_driven": 1,
@@ -2619,6 +2909,13 @@
       "rows_total": 1
     },
     {
+      "case": "I_EHR_DIRECTORY.get_directory_at_time-xml",
+      "format": "canonical-xml",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_DIRECTORY.get_directory_at_version-bad_ehr",
       "status": "passed",
       "rows_driven": 1,
@@ -2667,6 +2964,13 @@
       "rows_total": 1
     },
     {
+      "case": "I_EHR_DIRECTORY.get_directory_at_version-xml",
+      "format": "canonical-xml",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_DIRECTORY.get_versioned_directory-bad_ehr",
       "status": "not_applicable",
       "rows_driven": 0,
@@ -2706,6 +3010,13 @@
       "rows_total": 1
     },
     {
+      "case": "I_EHR_DIRECTORY.has_directory-xml",
+      "format": "canonical-xml",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_DIRECTORY.has_directory_version-bad_ehr",
       "status": "passed",
       "rows_driven": 1,
@@ -2719,6 +3030,13 @@
     },
     {
       "case": "I_EHR_DIRECTORY.has_directory_version-empty_ehr",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_DIRECTORY.has_directory_version-xml",
+      "format": "canonical-xml",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -2743,6 +3061,13 @@
     },
     {
       "case": "I_EHR_DIRECTORY.has_path-folder_structure",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_DIRECTORY.has_path-xml",
+      "format": "canonical-xml",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -2773,6 +3098,20 @@
     },
     {
       "case": "I_EHR_DIRECTORY.update_directory-stale_if_match",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_DIRECTORY.update_directory-xml",
+      "format": "canonical-xml",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_COMPOSITION.create_composition-item_tag_wrapper_headers",
+      "format": "canonical-json",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -2826,6 +3165,13 @@
       "rows_total": 1
     },
     {
+      "case": "I_EHR_SERVICE.create_ehr-xml",
+      "format": "canonical-xml",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_SERVICE.get_ehr-existing_ehr_by_ehr_id",
       "status": "passed",
       "rows_driven": 1,
@@ -2845,6 +3191,20 @@
     },
     {
       "case": "I_EHR_SERVICE.get_ehr-get_ehr_by_invalid_subject_id",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_SERVICE.get_ehr-xml",
+      "format": "canonical-xml",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_SERVICE.get_ehrs_for_subject-xml",
+      "format": "canonical-xml",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -2874,6 +3234,20 @@
       "rows_total": 1
     },
     {
+      "case": "I_EHR_SERVICE.has_ehr-xml",
+      "format": "canonical-xml",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_SERVICE.has_ehr_for_subject-xml",
+      "format": "canonical-xml",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_STATUS.clear_ehr_modifiable-bad_ehr",
       "status": "passed",
       "rows_driven": 1,
@@ -2886,6 +3260,31 @@
       "rows_total": 1
     },
     {
+      "case": "I_EHR_STATUS.clear_ehr_modifiable-invalid_body",
+      "status": "passed",
+      "rows_driven": 5,
+      "rows_total": 5
+    },
+    {
+      "case": "I_EHR_STATUS.clear_ehr_modifiable-missing_if_match",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_STATUS.clear_ehr_modifiable-stale_if_match",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_STATUS.clear_ehr_modifiable-xml_body",
+      "format": "canonical-xml",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_STATUS.clear_ehr_queryable-bad_ehr",
       "status": "passed",
       "rows_driven": 1,
@@ -2893,6 +3292,31 @@
     },
     {
       "case": "I_EHR_STATUS.clear_ehr_queryable-existing_ehr",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_STATUS.clear_ehr_queryable-invalid_body",
+      "status": "passed",
+      "rows_driven": 5,
+      "rows_total": 5
+    },
+    {
+      "case": "I_EHR_STATUS.clear_ehr_queryable-missing_if_match",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_STATUS.clear_ehr_queryable-stale_if_match",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_STATUS.clear_ehr_queryable-xml_body",
+      "format": "canonical-xml",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -2929,6 +3353,13 @@
     },
     {
       "case": "I_EHR_STATUS.get_ehr_status-get_by_ehr_id",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_STATUS.get_ehr_status-xml",
+      "format": "canonical-xml",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -2994,6 +3425,13 @@
       "rows_total": 1
     },
     {
+      "case": "I_EHR_STATUS.get_versioned_ehr_status-xml",
+      "format": "canonical-xml",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_STATUS.set_ehr_modifiable-bad_ehr",
       "status": "passed",
       "rows_driven": 1,
@@ -3001,6 +3439,31 @@
     },
     {
       "case": "I_EHR_STATUS.set_ehr_modifiable-existing_ehr",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_STATUS.set_ehr_modifiable-invalid_body",
+      "status": "passed",
+      "rows_driven": 5,
+      "rows_total": 5
+    },
+    {
+      "case": "I_EHR_STATUS.set_ehr_modifiable-missing_if_match",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_STATUS.set_ehr_modifiable-stale_if_match",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_STATUS.set_ehr_modifiable-xml_body",
+      "format": "canonical-xml",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -3043,6 +3506,131 @@
     },
     {
       "case": "I_EHR_STATUS.set_ehr_queryable-stale_if_match",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_STATUS.set_ehr_queryable-xml_body",
+      "format": "canonical-xml",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_STATUS.update_other_details-round_trip",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ITS_REST_ITEM_TAGS.composition_tags_delete-key_scoped",
+      "format": "canonical-json",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ITS_REST_ITEM_TAGS.composition_tags_delete-unknown_key",
+      "format": "canonical-json",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ITS_REST_ITEM_TAGS.composition_tags_delete-version_container_disjoint",
+      "format": "canonical-json",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ITS_REST_ITEM_TAGS.composition_tags_get-container_target_shape",
+      "format": "canonical-json",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ITS_REST_ITEM_TAGS.composition_tags_get-cross_space_party_uid",
+      "format": "canonical-json",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ITS_REST_ITEM_TAGS.composition_tags_get-version_target_shape",
+      "format": "canonical-json",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ITS_REST_ITEM_TAGS.composition_tags_update-key_target_path_identity",
+      "format": "canonical-json",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ITS_REST_ITEM_TAGS.composition_tags_update-non_array_body",
+      "format": "canonical-json",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ITS_REST_ITEM_TAGS.composition_tags_update-unknown_container",
+      "format": "canonical-json",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ITS_REST_ITEM_TAGS.composition_tags_update-version_container_disjoint",
+      "format": "canonical-json",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ITS_REST_ITEM_TAGS.ehr_status_tags_delete-wrong_kind_uid",
+      "format": "canonical-json",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ITS_REST_ITEM_TAGS.ehr_status_tags_get-wrong_kind_uid",
+      "format": "canonical-json",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ITS_REST_ITEM_TAGS.ehr_status_tags_update-key_target_path_identity",
+      "format": "canonical-json",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ITS_REST_ITEM_TAGS.ehr_status_tags_update-wrong_kind_uid",
+      "format": "canonical-json",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ITS_REST_ITEM_TAGS.ehr_tags_get-ehr_wide_listing",
+      "format": "canonical-json",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ITS_REST_ITEM_TAGS.ehr_tags_get-unknown_ehr",
+      "format": "canonical-json",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -3153,6 +3741,12 @@
     },
     {
       "case": "I_QUERY_SERVICE.execute_ad_hoc_query-distinct",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_QUERY_SERVICE.execute_ad_hoc_query-ehr_id_header_deprecated_get",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -3273,6 +3867,12 @@
     },
     {
       "case": "I_QUERY_SERVICE.execute_stored_query-empty_db",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_QUERY_SERVICE.execute_stored_query-fetch_with_top",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
@@ -3762,6 +4362,13 @@
     },
     {
       "case": "SF-WT-web_template_json_accept",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_ITS_REST_SYSTEM.options-conformance_manifest",
+      "format": "canonical-json",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1

--- a/docs/conformance/ehrbase-rs/verdicts.json
+++ b/docs/conformance/ehrbase-rs/verdicts.json
@@ -130,6 +130,14 @@
       "unrealized"
     ],
     [
+      "SystemApi",
+      "passed"
+    ],
+    [
+      "ItemTags",
+      "passed"
+    ],
+    [
       "Signing",
       "passed"
     ],
@@ -187,7 +195,7 @@
     }
   ],
   "coverage": {
-    "selected": 613,
-    "driven": 543
+    "selected": 703,
+    "driven": 633
   }
 }

--- a/website/book/src/conformance-assets/conformance-chapter-bars.svg
+++ b/website/book/src/conformance-assets/conformance-chapter-bars.svg
@@ -44,63 +44,59 @@ text { fill: #c3c2b7; }
 <text x="24" y="28" class="title">Schedule outcomes by chapter — ehrbase-rs 3.11.0</text>
 
 <rect x="24" y="38" width="14" height="14" rx="3" class="bar-passed"/><text x="42" y="49" class="muted">passed</text><rect x="103.2" y="38" width="14" height="14" rx="3" class="bar-failed"/><text x="121.2" y="49" class="muted">failed</text><rect x="182.4" y="38" width="14" height="14" rx="3" class="bar-errored"/><text x="200.4" y="49" class="muted">errored</text><rect x="268.8" y="38" width="14" height="14" rx="3" class="bar-na"/><text x="286.8" y="49" class="muted">N/A (cited)</text><text x="166" y="81" text-anchor="end">EHR</text>
-<rect x="174" y="64" width="606.0606060606061" height="26" class="bar-passed"/>
+<rect x="174" y="64" width="620.9665427509294" height="26" class="bar-passed"/>
 
-<text x="477.03030303030306" y="81" class="seg-label" text-anchor="middle">250</text><rect x="780.0606060606061" y="64" width="9.696969696969697" height="26" class="bar-failed"/>
+<text x="484.4832713754647" y="81" class="seg-label" text-anchor="middle">261</text><rect x="794.9665427509294" y="64" width="19.033457249070633" height="26" class="bar-na"/>
 
-<rect x="789.7575757575759" y="64" width="4.848484848484849" height="26" class="bar-errored"/>
-
-<rect x="794.6060606060607" y="64" width="19.393939393939394" height="26" class="bar-na"/>
-
-<text x="822.0000000000001" y="81" class="muted">264</text>
+<text x="822" y="81" class="muted">269</text>
 <text x="166" y="115" text-anchor="end">Definitions</text>
-<rect x="174" y="98" width="167.27272727272728" height="26" class="bar-passed"/>
+<rect x="174" y="98" width="164.1635687732342" height="26" class="bar-passed"/>
 
-<text x="257.6363636363636" y="115" class="seg-label" text-anchor="middle">69</text><rect x="341.27272727272725" y="98" width="41.21212121212121" height="26" class="bar-na"/>
+<text x="256.0817843866171" y="115" class="seg-label" text-anchor="middle">69</text><rect x="338.1635687732342" y="98" width="40.446096654275095" height="26" class="bar-na"/>
 
-<text x="361.8787878787879" y="115" class="seg-label-dim" text-anchor="middle">17</text><text x="390.48484848484844" y="115" class="muted">86</text>
+<text x="358.3866171003717" y="115" class="seg-label-dim" text-anchor="middle">17</text><text x="386.6096654275093" y="115" class="muted">86</text>
 <text x="166" y="149" text-anchor="end">Query</text>
-<rect x="174" y="132" width="77.57575757575758" height="26" class="bar-passed"/>
+<rect x="174" y="132" width="78.51301115241635" height="26" class="bar-passed"/>
 
-<text x="212.78787878787878" y="149" class="seg-label" text-anchor="middle">32</text><text x="259.57575757575756" y="149" class="muted">32</text>
+<text x="213.25650557620818" y="149" class="seg-label" text-anchor="middle">33</text><text x="260.51301115241637" y="149" class="muted">33</text>
 <text x="166" y="183" text-anchor="end">Demographic</text>
-<rect x="174" y="166" width="94.54545454545455" height="26" class="bar-passed"/>
+<rect x="174" y="166" width="95.16728624535317" height="26" class="bar-passed"/>
 
-<text x="221.27272727272728" y="183" class="seg-label" text-anchor="middle">39</text><rect x="268.54545454545456" y="166" width="29.090909090909093" height="26" class="bar-na"/>
+<text x="221.5836431226766" y="183" class="seg-label" text-anchor="middle">40</text><rect x="269.1672862453532" y="166" width="28.550185873605948" height="26" class="bar-na"/>
 
-<text x="283.0909090909091" y="183" class="seg-label-dim" text-anchor="middle">12</text><text x="305.6363636363636" y="183" class="muted">51</text>
+<text x="283.4423791821562" y="183" class="seg-label-dim" text-anchor="middle">12</text><text x="305.7174721189591" y="183" class="muted">52</text>
 <text x="166" y="217" text-anchor="end">Admin</text>
-<rect x="174" y="200" width="16.96969696969697" height="26" class="bar-passed"/>
+<rect x="174" y="200" width="16.654275092936803" height="26" class="bar-passed"/>
 
-<rect x="190.96969696969697" y="200" width="38.78787878787879" height="26" class="bar-na"/>
+<rect x="190.6542750929368" y="200" width="38.066914498141266" height="26" class="bar-na"/>
 
-<text x="210.36363636363637" y="217" class="seg-label-dim" text-anchor="middle">16</text><text x="237.75757575757575" y="217" class="muted">23</text>
+<text x="209.68773234200745" y="217" class="seg-label-dim" text-anchor="middle">16</text><text x="236.7211895910781" y="217" class="muted">23</text>
 <text x="166" y="251" text-anchor="end">Messaging</text>
-<rect x="174" y="234" width="33.93939393939394" height="26" class="bar-na"/>
+<rect x="174" y="234" width="33.30855018587361" height="26" class="bar-na"/>
 
-<text x="190.96969696969697" y="251" class="seg-label-dim" text-anchor="middle">14</text><text x="215.93939393939394" y="251" class="muted">14</text>
+<text x="190.6542750929368" y="251" class="seg-label-dim" text-anchor="middle">14</text><text x="215.3085501858736" y="251" class="muted">14</text>
 <text x="166" y="285" text-anchor="end">Content validation</text>
-<rect x="174" y="268" width="298.1818181818182" height="26" class="bar-passed"/>
+<rect x="174" y="268" width="292.63940520446096" height="26" class="bar-passed"/>
 
-<text x="323.0909090909091" y="285" class="seg-label" text-anchor="middle">123</text><text x="480.1818181818182" y="285" class="muted">123</text>
+<text x="320.31970260223045" y="285" class="seg-label" text-anchor="middle">123</text><text x="474.63940520446096" y="285" class="muted">123</text>
 <text x="166" y="319" text-anchor="end">Simplified formats</text>
-<rect x="174" y="302" width="138.1818181818182" height="26" class="bar-passed"/>
+<rect x="174" y="302" width="135.61338289962825" height="26" class="bar-passed"/>
 
-<text x="243.0909090909091" y="319" class="seg-label" text-anchor="middle">57</text><rect x="312.1818181818182" y="302" width="2.4242424242424243" height="26" class="bar-na"/>
+<text x="241.80669144981414" y="319" class="seg-label" text-anchor="middle">57</text><rect x="309.6133828996283" y="302" width="2.379182156133829" height="26" class="bar-na"/>
 
-<text x="322.6060606060606" y="319" class="muted">58</text>
+<text x="319.9925650557621" y="319" class="muted">58</text>
 <text x="166" y="353" text-anchor="end">Security &amp; privacy</text>
-<rect x="174" y="336" width="14.545454545454547" height="26" class="bar-passed"/>
+<rect x="174" y="336" width="14.275092936802974" height="26" class="bar-passed"/>
 
-<text x="196.54545454545456" y="353" class="muted">6</text>
+<text x="196.27509293680296" y="353" class="muted">6</text>
 <text x="166" y="387" text-anchor="end">Signing</text>
-<rect x="174" y="370" width="14.545454545454547" height="26" class="bar-passed"/>
+<rect x="174" y="370" width="14.275092936802974" height="26" class="bar-passed"/>
 
-<rect x="188.54545454545456" y="370" width="4.848484848484849" height="26" class="bar-na"/>
+<rect x="188.27509293680296" y="370" width="4.758364312267658" height="26" class="bar-na"/>
 
-<text x="201.3939393939394" y="387" class="muted">8</text>
+<text x="201.0334572490706" y="387" class="muted">8</text>
 <text x="166" y="421" text-anchor="end">Other</text>
-<rect x="174" y="404" width="2.4242424242424243" height="26" class="bar-passed"/>
+<rect x="174" y="404" width="73.75464684014871" height="26" class="bar-passed"/>
 
-<text x="184.42424242424244" y="421" class="muted">1</text>
+<text x="210.87732342007436" y="421" class="seg-label" text-anchor="middle">31</text><text x="255.75464684014872" y="421" class="muted">31</text>
 </svg>

--- a/website/book/src/conformance-assets/conformance-heat-grid.svg
+++ b/website/book/src/conformance-assets/conformance-heat-grid.svg
@@ -80,7 +80,7 @@ text { fill: #c3c2b7; }
 <rect x="220" y="354" width="190" height="26" rx="5" class="ev-passed cell-optional"/><text x="233" y="371" class="cell-label" text-anchor="middle">✓</text><text x="246" y="371" class="cell-label">AdminApi</text>
 <rect x="416" y="354" width="190" height="26" rx="5" class="ev-unrealized cell-optional"/><text x="429" y="371" class="cell-label-dim" text-anchor="middle">◇</text><text x="442" y="371" class="cell-label-dim">MessageApi</text>
 <rect x="612" y="354" width="190" height="26" rx="5" class="ev-passed cell-optional"/><text x="625" y="371" class="cell-label" text-anchor="middle">✓</text><text x="638" y="371" class="cell-label">SystemApi</text>
-<rect x="808" y="354" width="190" height="26" rx="5" class="ev-no-cases cell-optional"/><text x="821" y="371" class="cell-label-dim" text-anchor="middle">∅</text><text x="834" y="371" class="cell-label-dim">ItemTags</text>
+<rect x="808" y="354" width="190" height="26" rx="5" class="ev-passed cell-optional"/><text x="821" y="371" class="cell-label" text-anchor="middle">✓</text><text x="834" y="371" class="cell-label">ItemTags</text>
 <rect x="24" y="386" width="190" height="26" rx="5" class="ev-passed cell-optional"/><text x="37" y="403" class="cell-label" text-anchor="middle">✓</text><text x="50" y="403" class="cell-label">SimplifiedFormats</text>
 <rect x="220" y="386" width="190" height="26" rx="5" class="ev-no-cases cell-optional"/><text x="233" y="403" class="cell-label-dim" text-anchor="middle">∅</text><text x="246" y="403" class="cell-label-dim">SmartAppLaunch</text>
 <text x="24" y="446" class="title" font-size="12">SEC-BASIC</text>

--- a/website/landing/assets/conformance-heat-grid.svg
+++ b/website/landing/assets/conformance-heat-grid.svg
@@ -80,7 +80,7 @@ text { fill: #c3c2b7; }
 <rect x="220" y="354" width="190" height="26" rx="5" class="ev-passed cell-optional"/><text x="233" y="371" class="cell-label" text-anchor="middle">✓</text><text x="246" y="371" class="cell-label">AdminApi</text>
 <rect x="416" y="354" width="190" height="26" rx="5" class="ev-unrealized cell-optional"/><text x="429" y="371" class="cell-label-dim" text-anchor="middle">◇</text><text x="442" y="371" class="cell-label-dim">MessageApi</text>
 <rect x="612" y="354" width="190" height="26" rx="5" class="ev-passed cell-optional"/><text x="625" y="371" class="cell-label" text-anchor="middle">✓</text><text x="638" y="371" class="cell-label">SystemApi</text>
-<rect x="808" y="354" width="190" height="26" rx="5" class="ev-no-cases cell-optional"/><text x="821" y="371" class="cell-label-dim" text-anchor="middle">∅</text><text x="834" y="371" class="cell-label-dim">ItemTags</text>
+<rect x="808" y="354" width="190" height="26" rx="5" class="ev-passed cell-optional"/><text x="821" y="371" class="cell-label" text-anchor="middle">✓</text><text x="834" y="371" class="cell-label">ItemTags</text>
 <rect x="24" y="386" width="190" height="26" rx="5" class="ev-passed cell-optional"/><text x="37" y="403" class="cell-label" text-anchor="middle">✓</text><text x="50" y="403" class="cell-label">SimplifiedFormats</text>
 <rect x="220" y="386" width="190" height="26" rx="5" class="ev-no-cases cell-optional"/><text x="233" y="403" class="cell-label-dim" text-anchor="middle">∅</text><text x="246" y="403" class="cell-label-dim">SmartAppLaunch</text>
 <text x="24" y="446" class="title" font-size="12">SEC-BASIC</text>


### PR DESCRIPTION
The #288 program's closing run: **703 case-records — 633 passed / 0 failed / 0 errored / 70 cited n-a; 42 capability verdicts, 0 review findings.** The first baseline recorded under the corrected run tech profile (all four formats — every driven record verdict-selected; the badge's case count and the PASS verdict now describe the same set). Baseline ratchet across the program: 543 → 633 passed; ledger `coverage_gap` reasons 90 → 55, each remaining one cited, register-anchored, or NEW-CASE-marked. Visuals regenerated from the committed artifacts.