### PR TITLE
chore: PORT-NOTE scrub, console disabled-admin doc fix, orphaned-UPR prune

### DIFF
--- a/app/ehrbase-admin-ui/src/admin.rs
+++ b/app/ehrbase-admin-ui/src/admin.rs
@@ -3,9 +3,12 @@
 //! (template delete, stored-query delete, physical EHR delete).
 //!
 //! The CDR's admin group is **off by default**, and while it is disabled every
-//! admin route answers `404` inside the dispatcher (never a `403`). The console
-//! therefore discovers the group before offering any of it, and renders no
-//! destructive affordance at all when it is not mounted.
+//! admin route answers `405 Method Not Allowed` with an empty `Allow` (the
+//! route exists but supports no method — ITS-REST overview
+//! Requests_and_responses.md §HTTP Methods: "If a method is recognized but not
+//! allowed for the target resource, the response SHOULD be 405 Method Not
+//! Allowed"). The console therefore discovers the group before offering any of
+//! it, and renders no destructive affordance at all when it is not mounted.
 //!
 //! NOTE: admin availability is discovered via the System API conformance
 //! manifest (ITS-REST 1.1.0 System API, `OPTIONS {base_path}` → `endpoints[]`) —
@@ -55,7 +58,8 @@ pub enum AdminAvailability {
     /// destructive affordances render (authorization is still per request).
     Available,
     /// The manifest does not list `/admin` — the CDR runs with the admin group
-    /// disabled and every admin route answers `404`.
+    /// disabled and every admin route answers `405` with an empty `Allow`
+    /// (overview Requests_and_responses.md §HTTP Methods).
     Disabled,
 }
 

--- a/app/ehrbase/src/service/admin/mod.rs
+++ b/app/ehrbase/src/service/admin/mod.rs
@@ -24,8 +24,8 @@
 //!   through the storage codec (`node_repo::read_version_canonical` /
 //!   `decompose` + `write_nodes`).
 //! - **[`archive`]** marks EHR/party versioned objects archived; the physical
-//!   cold-tier storage movement is a spec-silent TODO(perf) item (see the PORT
-//!   NOTE there).
+//!   cold-tier storage movement is a spec-silent `TODO(perf)` carried at the
+//!   top of that module.
 
 mod archive;
 mod delete;

--- a/docs/conformance/upstream-reports.md
+++ b/docs/conformance/upstream-reports.md
@@ -461,26 +461,11 @@ CNF↔SM divergences, and benign released-documented behaviours carry no
 - **Ask:** Correct the two cells to rejected (violation `rm_invariant(Events_valid)`)
   per RM history.adoc.
 
-### UPR-23 — commit_contribution mismatched-change_type rejection has no assigned status code
+### UPR-23 — superseded
 
-- **Register entry:** AMB-54
-- **Channel:** ITS-REST
-- **Status:** draft
-- **Spec citation:** RM common `master06-change_control_package.adoc` §Change
-  Control (addition = a first ORIGINAL_VERSION, `preceding_version_uid` Void,
-  `change_type 249|creation|`; modification = a new ORIGINAL_VERSION on an
-  existing VERSIONED_OBJECT, `change_type 251|modification|`) requires the
-  rejection; ITS-REST `overview/Requests_and_responses.md` §HTTP status codes
-  assigns no specific code (permits 400 generic or 422 semantic); the ITS-REST
-  docs text has no CONTRIBUTION status-code table.
-- **Problem:** Committing a CONTRIBUTION whose `change_type` mismatches the
-  version state (a `251|modification|` as the first version; a `249|creation|`
-  naming a `preceding_version_uid`) must be rejected per RM change-control, but
-  the released ITS-REST spec assigns no status code — servers may return 400 or
-  422, so conformance cannot gate a single code.
-- **Ask:** Assign a specific status code (400 or 422) to the
-  mismatched-`change_type` rejection on contribution commit in the ITS-REST
-  spec (docs text + OAS), so the behaviour is gateable.
+- Removed 2026-07-28 (#536): orphaned by the 2026-07-27 AMB-54 re-adjudication,
+  which re-grounded the mismatched-change_type rejection and reports under
+  UPR-47. See UPR-47 for the live ask.
 
 ### UPR-24 — DV_CODED_TEXT.value has no value==rubric invariant
 
@@ -519,22 +504,11 @@ CNF↔SM divergences, and benign released-documented behaviours carry no
 - **Ask:** Define (or explicitly delegate to RFC 7231) the q-value / weighted
   Accept semantics a conformant server must apply, so the behaviour is gateable.
 
-### UPR-26 — No simplified inner-data surface for commit_contribution
+### UPR-26 — superseded
 
-- **Register entry:** AMB-57
-- **Channel:** ITS-REST
-- **Status:** draft
-- **Spec citation:** ITS-REST `simplified_formats/master02-overview.adoc`
-  §Scope (covers "Mapping between the Simplified Formats and canonical openEHR
-  RM (e.g. COMPOSITION)"; CONTRIBUTION not in scope) + §MIME Types (only the
-  two wt COMPOSITION MIME types) vs the released ITS-REST contribution-create
-  operation (CONTRIBUTION envelope body, canonical JSON/XML only).
-- **Problem:** There is no ITS-REST 1.1.0 wire for committing a CONTRIBUTION
-  whose inner versions carry simplified-format COMPOSITIONs, so the behaviour
-  cannot be exercised as a normative case.
-- **Ask:** Define a simplified-format inner-data surface for
-  `commit_contribution` (or state explicitly that CONTRIBUTION commit is
-  canonical-only), so the boundary is authoritative rather than inferred.
+- Removed 2026-07-28 (#536): orphaned by the 2026-07-27 AMB-57 re-adjudication,
+  which re-grounded the simplified inner-data surface question and reports
+  under UPR-48. See UPR-48 for the live ask.
 
 ### UPR-27 — RM and ITS-REST disagree on the form of the uid copied into a top-level object
 


### PR DESCRIPTION
Closes #540. Closes #537. Closes #536.

Three tracked chores in one sweep: the dangling `PORT NOTE` reference in `service/admin/mod.rs` (the banned vocabulary — workspace grep now clean); the admin console's two doc comments claiming the disabled admin group 404s (the wire answers **405 + empty `Allow`**, §HTTP Methods — doc-only, zero visual effect, hence `no-ui-visual-change`); and the orphaned UPR-23/UPR-26 ledger rows replaced with superseded stubs pointing at their live successors UPR-47/UPR-48 (ledger↔register bijectivity restored).

Gates: clippy clean (`ehrbase`, `ehrbase-admin-ui` native + wasm32), leptosfmt clean.