### PR TITLE
test(cnf): #556 — the register-wide re-adjudication under the OAS-fallback oracle order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,6 +226,23 @@ workflow refuses a tag that has no matching section here.
 
 ### Changed
 
+- **Two behaviours the conformance suite used to treat as optional are now
+  required of every server** (#556). openEHR publishes its REST
+  specification as normative prose *and* as OpenAPI files, and the prose is
+  silent on more than it looks. Where the prose says nothing, those OpenAPI
+  files are now read as part of the specification rather than set aside — so
+  behaviours previously recorded as "the specification does not say" turn out
+  to be specified after all, and the suite stops excusing them. Two change
+  how a server is judged. Uploading an operational template under a
+  `template_id` that already exists must answer `409 Conflict`; it was
+  previously a declared choice between refusing and silently replacing the
+  stored template, and a server could opt out of the refusal. Updating a
+  COMPOSITION whose request body carries a `uid` naming a different version
+  container than the URL must be rejected; the mismatch was previously
+  reported without affecting the verdict. Both are now gating conformance
+  cases. The published conformance artifacts and the ambiguity register
+  record the specification sentence behind each.
+
 - **The published Conformance Statement now declares the non-openEHR surface
   this server serves** (#527). A new "Additional non-openEHR surface" section
   lists every extension route family — health, status, the OpenAPI/Swagger

--- a/docker/sut-ehrbase-java.yml
+++ b/docker/sut-ehrbase-java.yml
@@ -51,9 +51,12 @@ services:
       SECURITY_AUTHADMINPASSWORD: ehrbase
       # The catalogue's admin chapter (physical delete, template admin).
       ADMINAPI_ACTIVE: "true"
-      # Duplicate template upload must 409 (the AMB-4 adl14-duplicate-conflict
-      # option branch the party statement declares); the runner's provisioning
-      # is 409-tolerant, so re-runs stay idempotent.
+      # Duplicate template upload must 409 — a GATING expectation for every
+      # server since the 2026-07-28 re-adjudication of register AMB-4 (the
+      # released OAS responses/409_template_already_exists.yaml states the
+      # trigger where the ITS-REST docs text is silent), no longer an option
+      # branch the party statement selects; the runner's provisioning is
+      # 409-tolerant, so re-runs stay idempotent.
       SYSTEM_ALLOWTEMPLATEOVERWRITE: "false"
       LOGGING_LEVEL_ROOT: ${LOGGING_LEVEL_ROOT:-INFO}
     ports:

--- a/docs/conformance/upstream-reports.md
+++ b/docs/conformance/upstream-reports.md
@@ -8,12 +8,25 @@ rather than worked around forever.
 
 ## Grounding rules (non-negotiable)
 
-- **Docs text only.** Every report cites the openEHR **docs text**
-  (`docs/specs/openehr/…`) — the normative prose. The vendored **OAS is STALLED
-  and is NOT an oracle** (owner ruling 2026-07-24): it is never a citation here.
-  A "defect" that exists ONLY because the OAS is stale/incomplete is an
-  OAS-regeneration item, NOT an openEHR spec report, and does not belong in this
-  ledger.
+- **Docs text first; the released OAS only where the docs text is silent**
+  (owner rulings 2026-07-24 + 2026-07-28). Every report cites the openEHR
+  **docs text** (`docs/specs/openehr/…`) — the normative prose — wherever the
+  prose speaks, and the docs text WINS every conflict. Where the docs text is
+  SILENT, the **released OAS**
+  (`docs/specs/openehr/ITS-REST/specifications/{operations,responses,
+  parameters,schemas,headers}/**`, the same commit as the prose) is a
+  legitimate citation, because the release presents those files as its own
+  computable specification artifacts (overview `Specifications.md`) — but it
+  is always cited **AS the OAS** (file + element), never passed off as docs
+  text, and never read for more than it states.
+  **What that changes for this ledger** (2026-07-28): a behaviour the OAS
+  DEFINES is no longer a reportable silence — it is a released expectation the
+  suite gates, so the report is withdrawn or re-scoped to what genuinely
+  remains (typically: the rule is findable only in the computable artifact and
+  not in the normative prose, or its status branch is unassigned on both
+  tiers). Conversely a "defect" that exists ONLY because the OAS is
+  stale/incomplete against the prose remains an OAS-regeneration item, NOT an
+  openEHR spec report.
 - **Proven before listed.** A report appears here ONLY after its register entry
   is CONFIRMED first-hand against the docs text (the `cnf-triage` adjudication).
   An entry the docs text actually resolves is REFUTED — removed from the
@@ -36,7 +49,7 @@ entries realized internally by an existing released endpoint, name-only
 CNF↔SM divergences, and benign released-documented behaviours carry no
 `upstream_ref` and do NOT appear here.
 
-### UPR-01 — duplicate-`template_id` handling on the ADL 1.4 upload is unassigned
+### UPR-01 — SM `upload_opt` alone omits the duplicate rule its siblings state
 
 - **Register entry:** AMB-4
 - **Channel:** SPECPR
@@ -50,15 +63,30 @@ CNF↔SM divergences, and benign released-documented behaviours carry no
   `specifications/responses/409_template_already_exists.yaml` declares the
   conflict branch on the same operation; AM ADL 1.4 `master02-overview.adoc`
   §Templates defines no template versioning (all confirmed first-hand).
-- **Problem:** A second upload under an existing `template_id` has two
-  conformant answers — refuse it as a conflict, or replace the stored template
-  — and no released sentence picks one. Declaring the 409 branch is not
-  requiring it, and `upload_opt` is the only upload in the two Definition
-  interfaces that omits the replace rule its siblings state. With no formal
-  version for an ADL 1.4 template there is no third answer available either.
-- **Ask:** State the duplicate rule on `upload_opt` (replace, as its siblings
-  do, or conflict, as the ITS branch implies) so the suite can gate one
-  behaviour rather than carry sibling option cases.
+- **Problem:** `upload_opt` is the only upload in the two Definition
+  interfaces that omits the duplicate rule its siblings state, so SM and ITS
+  do not line up on the same operation: the ITS answers the question
+  (`409_template_already_exists.yaml` — "`409 Conflict` is returned when a
+  template with same `template_id` already exists") while the service model
+  says nothing, and the SM's own two siblings say the OPPOSITE of the ITS
+  ("replace it"). A reader of SM alone cannot tell which of the two families
+  `upload_opt` belongs to, and an implementer reading SM's siblings by analogy
+  would build the wrong wire behaviour. With no formal version for an ADL 1.4
+  template there is no third answer available either.
+- **Ask:** State the duplicate rule on `upload_opt` — align it with the ITS
+  409 branch, or, if replacement is intended, reconcile the two components
+  explicitly (the ADL2 side has the same clash as an outright contradiction,
+  UPR-69).
+- **Re-scoped (2026-07-28), under the OAS-fallback oracle order.** The WIRE
+  half of this report is answered and is withdrawn: the docs text is silent on
+  duplicate template upload, so the released OAS grounds the expectation, and
+  `409_template_already_exists.yaml` states its trigger in the indicative
+  rather than merely declaring a status. AMB-4 accordingly retyped from
+  `option_select` to `fixed_handling`, the `adl14-duplicate-conflict` /
+  `adl14-duplicate-replace` option pair is withdrawn, and
+  `I_DEFINITION_ADL14.upload_opt-valid_opt_twice_conflict` now gates for every
+  server — so the ask is no longer "so the suite can gate one behaviour". What
+  survives is the SM↔ITS misalignment above.
 - **Note (2026-07-27):** this report was re-grounded with AMB-4. Its earlier
   framing — conflict vs a version-parameter branch, taken from the CNF
   master04 NOTE — is false for Release-1.1.0: the ADL 1.4 upload declares no
@@ -775,22 +803,37 @@ CNF↔SM divergences, and benign released-documented behaviours carry no
 ### UPR-40 — the docs text never states the body-uid vs URL rule for a COMPOSITION update
 
 - **Component:** ITS-REST (overview Resources.md + Requests_and_responses.md)
-- **Register:** AMB-78 (report_only)
+- **Register:** AMB-78 (fixed_handling)
 - **Facts:** `Resources.md` §Identifier types derives the container from the
   served identifier ("which also implies that the VERSIONED_OBJECT identifier
   is `8849182c-…`") and calls populating a COMPOSITION's inherited `uid`
   "strongly recommended"/"should"; RM types `LOCATABLE.uid` 0..1. The
   normative prose never says what a service does when an update body's
-  `uid` names a DIFFERENT container than the addressed one — the requirement
-  exists only as an API-definition operation description.
+  `uid` names a DIFFERENT container than the addressed one. The requirement
+  exists only in the release's computable artifact —
+  `operations/composition_update.yaml`, description: "If the request body
+  already contains a COMPOSITION.uid.value, it must match the `uid_based_id`
+  in the URL", repeated verbatim over `PERSON.uid.value` in the five party
+  updates. Neither tier binds the violation to one of the statuses the same
+  operation declares (200/204/400/404/412/422).
 - **Problem:** the rule that clients are actually held to is invisible in the
-  normative text, and its branch is unassigned: 422 (well-formed but
-  unfollowable), 400 (client error), or silent acceptance with the
-  server's own uid are all defensible, so implementations diverge on a
+  normative text, and its branch is unassigned on BOTH tiers: 422 (well-formed
+  but unfollowable) and 400 (client error) are both declared by the operation
+  and neither is assigned to this trigger, so implementations diverge on a
   request that is trivially easy to send by accident (a read-modify-write
   client replaying a fetched COMPOSITION at the wrong URL).
-- **Ask:** state the rule in the docs text and assign its branch (suggested:
-  reject with 422 — the request is well-formed but cannot be followed).
+- **Ask:** promote the rule into the docs text, and assign its branch on
+  whichever tier states it (suggested: reject with 422 — the request is
+  well-formed but cannot be followed, which is what both the docs-text 422 row
+  and `responses/422.yaml` describe).
+- **Re-scoped (2026-07-28), under the OAS-fallback oracle order.** The RULE
+  half of this report is answered and is withdrawn: the docs text being silent
+  rather than in conflict, the operation description is a legitimate tier-2
+  ground, so the rejection is a released expectation. AMB-78 retyped from
+  `report_only` to `fixed_handling` and
+  `I_EHR_COMPOSITION.update_composition-body_uid_mismatch` now gates at CORE
+  instead of merely reporting. What survives is the two halves above — the
+  prose omission, and the unassigned status branch.
 
 ### UPR-41 — create-on-existing-directory has no wire branch
 
@@ -2279,7 +2322,7 @@ CNF↔SM divergences, and benign released-documented behaviours carry no
 - **Components:** ITS-REST (`docs/system/Description.md`;
   `docs/overview/Requests_and_responses.md` §"HTTP Methods", §"HTTP status
   codes")
-- **Register:** AMB-160 (report_only)
+- **Register:** AMB-160 (fixed_handling)
 - **Facts:** The System API is declared `STABLE` — `docs/system/Description.md`
   §Status, "This specification is in the `STABLE` state" — and the chapter that
   declares it is a stub: Purpose, Related Documents, Status, and nothing else.
@@ -2295,18 +2338,23 @@ CNF↔SM divergences, and benign released-documented behaviours carry no
   sentence of a STABLE specification while answering on different resources
   with different, or empty, bodies; no client can be written against the text
   as published, and no conformance test can assert more than "some 2xx".
-- **Ask:** give the System chapter the two sentences it is missing — the
-  resource the operation is served on (relative to the API base URL) and the
-  members of the response body, with which of them are mandatory — and state
-  the success status code and the response headers in the same chapter, so a
-  STABLE API is testable from its own normative text rather than from a
-  generated artifact. (Ours: the probe is answered at the API base-path root,
-  the one resource that IS the service, with `200` and an `Allow` header
-  listing the methods that resource supports; the body carries the product's
-  identity and the REST-API version it implements plus the conformance profile
-  it claims, and never out-claims the last machine-computed verdict. Our
-  conformance case asserts only the `200` and the `Allow` header — everything
-  else is recorded as this silence, not as an expectation.)
+- **Ask:** give the System chapter the sentences it is missing — the resource
+  the operation is served on (relative to the API base URL), the members of
+  the response body and which of them are mandatory, the success status code
+  and the response headers — so a STABLE API is testable from its own
+  normative text rather than only from the release's computable artifact.
+- **Re-scoped (2026-07-28), under the OAS-fallback oracle order.** The
+  testability half is answered and is withdrawn: the docs text being silent,
+  the released `system.openapi.yaml` grounds the resource (`paths: /`), the
+  `Content-Type: application/json` and the JSON manifest body, and AMB-160
+  retyped from `report_only` to `fixed_handling` — the binding and the case
+  now assert all three alongside the docs-text-grounded `200` + `Allow`. No
+  MANIFEST MEMBER is asserted, because the `Options` schema declares none
+  required and an optional member is not a presence requirement (which member
+  contents `endpoints` must carry stays open — AMB-158). What survives is
+  purely EDITORIAL and is the ask above: a STABLE specification's own chapter
+  should describe its one exchange instead of delegating it entirely to the
+  OAS artifact.
 
 ### UPR-125 — the CONTRIBUTION commit declares `application/xml` yet the release defines no XML form of the commit envelope
 

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL14.get_opt-example_legacy_tds2_accept.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL14.get_opt-example_legacy_tds2_accept.yaml
@@ -18,7 +18,9 @@
 # preserves it. Whether the legacy support exists is statement-declared
 # (register AMB-61, option_select).
 #
-# Sources (ITS-REST DOCS TEXT — the wire oracle, not the stalled OAS):
+# Sources (ITS-REST DOCS TEXT — tier 1, which wins every conflict; the
+# RELEASED OAS fills only what the docs text is silent on and is cited AS
+# the OAS where it does — owner ruling 2026-07-28):
 #   specifications/docs/overview/Resources.md §Alternative data formats,
 #   §Data representation, §XML Format, §Simplified Formats.
 sm_operation: I_DEFINITION_ADL14.get_opt

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL14.upload_opt.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL14.upload_opt.yaml
@@ -1,5 +1,7 @@
 # Wire realization of I_DEFINITION_ADL14.upload_opt for ITS-REST 1.1.0.
-# Sources: specifications/operations/definition_template_adl1.4_upload.yaml,
+# Sources, RELEASED OAS (tier 2 — the docs text describes no template-upload
+# exchange at all, so the OAS grounds it per the 2026-07-28 oracle order; cited
+# AS the OAS): specifications/operations/definition_template_adl1.4_upload.yaml,
 # responses/201_Template_adl1_4_upload.yaml, 409_template_already_exists.yaml.
 sm_operation: I_DEFINITION_ADL14.upload_opt
 its: its-rest
@@ -11,7 +13,7 @@ request:
     Content-Type: application/xml         # the ONLY accepted upload type (operation enum)
 outcomes:
   created: { status: 201 }                # 201_Template_adl1_4_upload.yaml
-  already_exists: { status: 409 }         # duplicate template_id — AMB-4
+  already_exists: { status: 409 }         # 409_template_already_exists.yaml: "`409 Conflict` is returned when a template with same `template_id` already exists" — AMB-4, gating for every server since 2026-07-28
   validation_failed:
     status: 422                           # ITS-REST overview §HTTP status codes — 422 = semantic errors
     body: error_loose                     # ITS-REST overview §HTTP status codes — for 4xx/5xx, services MAY return additional error details if Prefer: return=representation

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_COMPOSITION.create_composition-legacy_nc_flat_media.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_COMPOSITION.create_composition-legacy_nc_flat_media.yaml
@@ -16,7 +16,9 @@
 # distinguishes this exchange. Whether the legacy support exists is
 # statement-declared (register AMB-61, option_select).
 #
-# Sources (ITS-REST DOCS TEXT — the wire oracle, not the stalled OAS):
+# Sources (ITS-REST DOCS TEXT — tier 1, which wins every conflict; the
+# RELEASED OAS fills only what the docs text is silent on and is cited AS
+# the OAS where it does — owner ruling 2026-07-28):
 #   specifications/docs/overview/Resources.md §Alternative data formats,
 #   §Data representation, §Simplified Formats.
 sm_operation: I_EHR_COMPOSITION.create_composition

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_COMPOSITION.create_composition-wrong_media.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_COMPOSITION.create_composition-wrong_media.yaml
@@ -15,7 +15,9 @@
 # type distinguishes this exchange — the refusal is a media-type decision, not
 # a parse or validation outcome.
 #
-# Sources (ITS-REST DOCS TEXT — the wire oracle, not the stalled OAS):
+# Sources (ITS-REST DOCS TEXT — tier 1, which wins every conflict; the
+# RELEASED OAS fills only what the docs text is silent on and is cited AS
+# the OAS where it does — owner ruling 2026-07-28):
 #   specifications/docs/overview/Resources.md §JSON Format + §XML Format.
 sm_operation: I_EHR_COMPOSITION.create_composition
 its: its-rest

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_COMPOSITION.get_versioned_composition-at_time.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_COMPOSITION.get_versioned_composition-at_time.yaml
@@ -9,7 +9,9 @@
 # with the version container named in the path (a COMPOSITION is not a per-EHR
 # singleton).
 #
-# Sources (ITS-REST DOCS TEXT — the wire oracle, not the stalled OAS):
+# Sources (ITS-REST DOCS TEXT — tier 1, which wins every conflict; the
+# RELEASED OAS fills only what the docs text is silent on and is cited AS
+# the OAS where it does — owner ruling 2026-07-28):
 #   - Resource: overview Resources.md §Resources — "versioned entities:
 #     VERSIONED_COMPOSITION, VERSIONED_EHR_STATUS, etc. or their contained
 #     VERSION instances".

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_COMPOSITION.get_versioned_composition-version.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_COMPOSITION.get_versioned_composition-version.yaml
@@ -7,7 +7,9 @@
 # VERSION.signature (RM common master06 §Digital Signature) and the
 # commit_audit / lifecycle_state facts the signature (and version) assertion
 # families verify.
-# Sources (ITS-REST DOCS TEXT — the wire oracle, not the stalled OAS):
+# Sources (ITS-REST DOCS TEXT — tier 1, which wins every conflict; the
+# RELEASED OAS fills only what the docs text is silent on and is cited AS
+# the OAS where it does — owner ruling 2026-07-28):
 #   - Resource: overview Resources.md §Resource identification — a VERSION is
 #     retrievable by `version_uid` (OBJECT_VERSION_ID = object_id::system::tree),
 #     the "explicit version reference"; its uid is the ORIGINAL_VERSION.uid.

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_DIRECTORY.create_directory.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_DIRECTORY.create_directory.yaml
@@ -39,8 +39,17 @@ outcomes:
     # unable to be followed due to semantic errors" versus "400 | Bad Request |
     # … (e.g., malformed request syntax, syntactically invalid content)".
     # CORRECTED 2026-07-28: this branch read 400, sourced only from the OAS
-    # `400.yaml`, which is stalled and never a wire oracle (owner ruling
-    # 2026-07-24). The identical defect class already maps to 422 everywhere
+    # `400.yaml`. RE-GROUNDED the same day under the OAS-fallback oracle
+    # order; the correction stands, on the OAS's OWN wording rather than on
+    # its tier. `responses/400.yaml` scopes itself to input that does not
+    # parse ("the request could not be parsed or is invalid (e.g. malformed
+    # request URL syntax, missing required header or parameter, or
+    # syntactically invalid header, parameter or content)"), and an RM-invalid
+    # FOLDER parses fine — so the OAS never grounded this branch even as a
+    # tier-2 source, and `directory_create.yaml` declares no 422 to ground it
+    # either. The docs-text 422 row does describe it, and §HTTP status codes
+    # permits "Additional status codes … as long as they do not conflict with
+    # the predefined codes". The identical defect class already maps to 422 everywhere
     # else in the catalogue on this same row (I_EHR_SERVICE.create_ehr,
     # I_EHR_COMPOSITION.create_composition, I_EHR_STATUS.*-invalid_body); the
     # directory was the lone OAS-grounded outlier. The 400 that REMAINS

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_STATUS.get_ehr_status-at_time.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_STATUS.get_ehr_status-at_time.yaml
@@ -8,8 +8,10 @@
 # variant-less binding; the parameter is the only difference, so a red row
 # localizes to the at-time branch alone.
 #
-# Sources (ITS-REST DOCS TEXT — the wire oracle, not the stalled OAS; the OAS
-# path `ehr_status_get_at_time` is cited only for the route shape):
+# Sources (ITS-REST DOCS TEXT — tier 1, which wins every conflict; the
+# RELEASED OAS path `ehr_status_get_at_time` is the tier-2 ground for the
+# route shape the docs text does not state, cited AS the OAS — owner ruling
+# 2026-07-28):
 #   - the parameter's lexical form: overview Resources.md §Datetime format —
 #     "HTTP query parameters and path segments that are dates, datetimes, or
 #     times, MUST always use the _extended_ ISO 8601 format. The general form

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_STATUS.get_ehr_status_at_version.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_STATUS.get_ehr_status_at_version.yaml
@@ -9,7 +9,9 @@
 # versioned_ehr_status/version route serves the VERSION envelope instead
 # (the SM-vs-ITS return-type mismatch AMB-72 records as defect 4).
 #
-# Sources (ITS-REST DOCS TEXT — the wire oracle, not the stalled OAS):
+# Sources (ITS-REST DOCS TEXT — tier 1, which wins every conflict; the
+# RELEASED OAS fills only what the docs text is silent on and is cited AS
+# the OAS where it does — owner ruling 2026-07-28):
 #   - the addressing form: overview Resources.md §Identifier types — "a
 #     `version_uid` for identifying a VERSION from the version container,
 #     stored under VERSION.uid.value, in a form of an OBJECT_VERSION_ID", and

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_STATUS.get_versioned_ehr_status-at_time.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_STATUS.get_versioned_ehr_status-at_time.yaml
@@ -5,7 +5,9 @@
 # VERSIONED_OBJECT.version_at_time; the sibling `version` variant addresses a
 # VERSION by its uid instead.
 #
-# Sources (ITS-REST DOCS TEXT — the wire oracle, not the stalled OAS):
+# Sources (ITS-REST DOCS TEXT — tier 1, which wins every conflict; the
+# RELEASED OAS fills only what the docs text is silent on and is cited AS
+# the OAS where it does — owner ruling 2026-07-28):
 #   - Resource: overview Resources.md §Resources — "versioned entities:
 #     VERSIONED_COMPOSITION, VERSIONED_EHR_STATUS, etc. or their contained
 #     VERSION instances".

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_STATUS.get_versioned_ehr_status-version.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_STATUS.get_versioned_ehr_status-version.yaml
@@ -5,7 +5,9 @@
 # sub-resource. Surfaces VERSION.signature (RM common master06 §Digital
 # Signature) for the SIG-VERSION signature family on EHR_STATUS versions
 # (master06 signs "each Version of any logical item", not just COMPOSITION).
-# Sources (ITS-REST DOCS TEXT — the wire oracle, not the stalled OAS):
+# Sources (ITS-REST DOCS TEXT — tier 1, which wins every conflict; the
+# RELEASED OAS fills only what the docs text is silent on and is cited AS
+# the OAS where it does — owner ruling 2026-07-28):
 #   - Resource: overview Resources.md §Resource identification — a VERSION is
 #     retrievable by `version_uid`; "versioned entities: VERSIONED_COMPOSITION,
 #     VERSIONED_EHR_STATUS, etc. or their contained VERSION instances". The

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_STATUS.get_versioned_ehr_status.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_STATUS.get_versioned_ehr_status.yaml
@@ -4,7 +4,9 @@
 # singleton, so the container URI carries no {versioned_object_uid} segment
 # (unlike versioned_composition).
 #
-# Sources (ITS-REST DOCS TEXT — the wire oracle, not the stalled OAS):
+# Sources (ITS-REST DOCS TEXT — tier 1, which wins every conflict; the
+# RELEASED OAS fills only what the docs text is silent on and is cited AS
+# the OAS where it does — owner ruling 2026-07-28):
 #   - Resource: overview Resources.md §Resources — "versioned entities:
 #     VERSIONED_COMPOSITION, VERSIONED_EHR_STATUS, etc. or their contained
 #     VERSION instances" is the resource this route serves.

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_PARTY.update_party.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_PARTY.update_party.yaml
@@ -47,9 +47,17 @@ outcomes:
     # headers." 404 stays for an unresolvable PATH id, where there is no
     # resource to hold a current version at all (I_PARTY.update_party's
     # not_found, above).
-    # CORRECTED 2026-07-28: this branch read 404, sourced only from the OAS
-    # `person_update.yaml`, which is stalled and never a wire oracle (owner
-    # ruling 2026-07-24) — and CONTRADICTED by the released MUST above. The
+    # CORRECTED 2026-07-28: this branch read 404. RE-GROUNDED the same day
+    # under the OAS-fallback oracle order, and the correction stands on a
+    # firmer footing than the one first written for it. It is not that the OAS
+    # cannot ground anything (it can, where the docs text is silent) — it is
+    # that the docs text is NOT silent here and the two DISAGREE, which the
+    # docs text wins outright (owner ruling 2026-07-24, preserved by the
+    # 2026-07-28 order). The released OAS in fact declares BOTH branches on
+    # this operation (specifications/operations/person_update.yaml: '404' ->
+    # responses/404.yaml, '412' -> responses/412_PERSON.yaml), and the
+    # docs-text MUST above is what assigns an If-Match miss to the 412 of the
+    # two. The
     # sibling PUT with the identical If-Match realization,
     # I_EHR_COMPOSITION.update_composition, already carries exactly this
     # adjudication ("unknown preceding version = the If-Match condition

--- a/tools/cnf-runner/artifacts/registers/ambiguities.yaml
+++ b/tools/cnf-runner/artifacts/registers/ambiguities.yaml
@@ -2,26 +2,70 @@
 # silence with the normative handling a runner MUST apply. A runner that
 # resolves an ambiguity privately is non-conformant to the schedule.
 #
-# ORACLE (owner rulings 2026-07-24): only RELEASED openEHR components are
-# enforceable authority — RM, BASE, AM/ADL, QUERY, TERM, ITS-XML, SM, and the
-# ITS-REST docs text. The vendored OAS, the CNF Platform Conformance Test
-# Schedule, and the Robot suites are STALLED GUIDES (which behaviour to cover),
-# never authority. Every `source` cites a released component; a CNF/OAS/Robot
-# mention is a coverage guide, never the ground for a verdict.
+# ORACLE (owner rulings 2026-07-24 + 2026-07-28): only RELEASED openEHR
+# components are enforceable authority — RM, BASE, AM/ADL, QUERY, TERM,
+# ITS-XML, SM, and the ITS-REST docs text. For the ITS-REST wire the order is:
+#   (1) the ITS-REST DOCS TEXT (specifications/docs/**) WINS EVERY CONFLICT;
+#   (2) where the docs text is SILENT — not in conflict — the RELEASED OAS
+#       (specifications/{operations,responses,parameters,schemas,headers}/**
+#       and the assembled computable/OAS bundles, vendored for codegen at
+#       crates/openehr-its/vendor/rest-oas/) GROUNDS the expectation, because
+#       the release presents those files as its own computable specification
+#       artifacts (docs/overview/Specifications.md: "Specifications can be
+#       downloaded as YAML files in OpenAPI Specification 3.0 format"; every
+#       API Preface repeats it). An OAS ground is ALWAYS cited AS THE OAS
+#       (file + element) and is NEVER read for more than it states — an
+#       enumerated `Accept` value, an optional schema member, and an
+#       `example` are an offer or an illustration, never a presence
+#       requirement;
+#   (3) only a behaviour BOTH sources withhold is spec silence for this
+#       register.
+# The CNF Platform Conformance Test Schedule and the Robot suites remain
+# STALLED GUIDES (which behaviour to cover), never authority.
+#
+# REGISTER-WIDE RE-ADJUDICATION, 2026-07-28. Every entry was re-verified
+# first-hand against both ITS-REST sources under the order above. The AMB
+# numbering KEEPS ITS GAPS and is never renumbered. What moved:
+#  - RETYPED because the released OAS turned out to DEFINE the behaviour the
+#    entry called unassigned: AMB-4 (option_select -> fixed_handling: the
+#    duplicate ADL 1.4 upload is the OAS-declared 409, so the option pair is
+#    gone and its case gates), AMB-62 (the `Prefer: return=minimal` status is
+#    ASSIGNED per operation family by the released 201/204 response files),
+#    AMB-78 (report_only -> fixed_handling: the body-uid match rule is
+#    OAS-stated, so its case gates).
+#  - NARROWED: AMB-63(a) — the subject key is the OAS-named
+#    (subject id, namespace) pair, so only the folding question is ours.
+#  - RE-GROUNDED IN PLACE, verdict unchanged, because the entry's REASONING
+#    rested on the retired "the OAS is never an oracle" absolutism: AMB-58,
+#    AMB-132, AMB-134, AMB-152, AMB-158.
+# Every other entry stands verified with no edit.
 AMB-4:
   ambiguity: >-
-    A second ADL 1.4 OPT upload under an EXISTING template_id has two
-    conformant answers and no released sentence picks one: refuse it as a
-    conflict, or accept it and replace the stored template. The ITS-REST
-    upload declares the conflict branch, but declaring a status is not
-    requiring it — nothing says a service MUST reach that branch rather than
-    overwrite —, and the SM operation that anchors the upload is silent on
-    duplicates in a way its own siblings are not: `upload_archetype` ("If an
-    archetype with the same id already exists, replace it") and the ADL2
-    `upload_artefact` ("If an artefact with the same physical identifier and
-    namespace exists, replace it") both state the replace rule, while
-    `upload_opt` states nothing at all. Under AM ADL 1.4 an OPT has no formal
-    version either, so there is no third "new version" answer to reach for.
+    RE-ADJUDICATED 2026-07-28 under the OAS-fallback oracle order, and
+    RETYPED from `option_select` to `fixed_handling`: the wire answer is no
+    longer open. The entry's whole ground was that "declaring a status is not
+    requiring it" — that the ITS-REST upload's 409 branch could be read as an
+    offer rather than an obligation because the OAS was not an oracle. It is
+    one now wherever the docs text is silent, and here the docs text IS
+    silent (no ITS-REST prose chapter mentions duplicate template upload at
+    all) while the released OAS does not merely DECLARE the branch, it STATES
+    the trigger in the indicative: `409_template_already_exists.yaml`, which
+    `definition_template_adl1.4_upload.yaml` `$ref`s under its `'409'`
+    response, reads "`409 Conflict` is returned when a template with same
+    `template_id` already exists". So the conflict branch is a released
+    expectation, the replace branch has no released ground on this wire, and
+    the sibling option pair (`adl14-duplicate-conflict` /
+    `adl14-duplicate-replace`) is withdrawn.
+    WHAT REMAINS AN UPSTREAM DEFECT, and is why this entry survives at all:
+    the SM operation that anchors the upload is silent on duplicates in a way
+    its own siblings are not — `upload_archetype` ("If an archetype with the
+    same id already exists, replace it") and the ADL2 `upload_artefact` ("If
+    an artefact with the same physical identifier and namespace exists,
+    replace it") both state the replace rule, while `upload_opt` states
+    nothing at all. That is the SM↔ITS asymmetry AMB-105 records as an
+    outright contradiction on the ADL2 side, one interface over. Under AM
+    ADL 1.4 an OPT has no formal version, so there is no third "new version"
+    answer to reach for either.
     RE-ADJUDICATED 2026-07-27 (group-10 audit): the earlier framing —
     conflict vs a VERSION-PARAMETER branch, grounded in the CNF master04 NOTE
     ("the OPT upload service needs to handle a version parameter, for
@@ -49,24 +93,29 @@ AMB-4:
     docs/overview/Amendment_record.md SPECITS-87 ("Deprecate ADL2 'Get
     template at version' and the version query parameter from upload
     template") — all CONFIRMED first-hand.
+    Docs-text silence re-verified 2026-07-28: a grep of ITS-REST
+    specifications/docs/** for "duplicate", "already exists" and
+    "template_id" turns up no sentence governing a second upload under an
+    existing id, so the OAS response file above is the tier-2 ground and is
+    cited AS the OAS.
   handling: >-
-    Two sibling cases carry option tags; the ICS options declaration selects
-    which applies — at least the declared behaviour MUST pass; the undeclared
-    sibling is not-applicable. `adl14-duplicate-conflict` is gated by
-    I_DEFINITION_ADL14.upload_opt-valid_opt_twice_conflict (the declared 409
-    branch); `adl14-duplicate-replace` has no sibling case on this ITS yet —
-    a replace-on-duplicate server answers a success status the released 201
-    text describes and leaves exactly one template loaded, but no released
-    sentence assigns that status, so the option stands declared and
-    unexercised rather than pinned by an authored expectation (the AMB-8
-    pattern). The distinct-template_id upload pair is NOT part of this
-    latitude: two different template_id strings never collide under either
-    branch, so I_DEFINITION_ADL14.upload_opt-valid_opt_twice_no_conflict is
-    universally green and carries no option tag. Partial-template_id
-    RESOLUTION on retrieval — the other half the retired version-parameter
-    framing used to carry — is its own entry, AMB-104.
-  disposition: option_select
-  options: [adl14-duplicate-conflict, adl14-duplicate-replace]
+    Fixed handling: a second upload under an EXISTING `template_id` is
+    refused `409 Conflict` and the stored template is untouched — the
+    released OAS trigger verbatim, on the tier-2 ground the docs text's
+    silence opens (owner ruling 2026-07-28). Gated for every server by
+    I_DEFINITION_ADL14.upload_opt-valid_opt_twice_conflict, which no longer
+    carries an option tag. This is the same wire position AMB-105 reaches for
+    the ADL2 upload, and deliberately so: the two uploads are siblings whose
+    409 files say the same sentence, so a catalogue that gated one and
+    optioned the other would draw a line the release does not draw. The
+    distinct-template_id upload pair was never part of the withdrawn
+    latitude — two different template_id strings never collide — so
+    I_DEFINITION_ADL14.upload_opt-valid_opt_twice_no_conflict is unchanged.
+    Partial-template_id RESOLUTION on retrieval is its own entry, AMB-104,
+    whose option pair is unaffected. Reported upstream (UPR-01), re-scoped to
+    the SM half: give `upload_opt` the duplicate rule its two siblings state,
+    so SM and ITS agree rather than one of them being silent.
+  disposition: fixed_handling
   upstream_ref: "UPR-01"
 AMB-5:
   ambiguity: "Persistent-COMPOSITION uniqueness per EHR is under SEC debate."
@@ -795,10 +844,21 @@ AMB-58:
     only `application/openehr.wt+json` for the template-as-JSON case, and
     assigns the request neither a body nor a refusal. Both answers a service
     could give — serve some JSON document, or refuse 406 — are consistent with
-    every released sentence. The earlier framing of this entry as an internal
-    inconsistency has been dropped: the half that "offers" application/json
-    exists only in the OpenAPI source fragments, which are stalled and are not
-    an oracle, so it never had standing to contradict anything.
+    every released sentence.
+    RE-GROUNDED 2026-07-28 under the OAS-fallback oracle order; the VERDICT is
+    unchanged and the entry stands. The 2026-07-27 wording said the
+    application/json half "exists only in the OpenAPI source fragments, which
+    are stalled and are not an oracle, so it never had standing to contradict
+    anything" — that reasoning is retired. The OAS IS citable here, and it
+    still does not settle the question, for a reason the ruling itself states:
+    an enumerated `Accept` value is an OFFER, never a body contract.
+    `parameters/header/Accept_Template.yaml` lists `application/json` in its
+    enum, but `responses/200_Template_adl1_4_retrieved.yaml` declares content
+    for `application/xml` and `application/openehr.wt+json` ONLY — there is no
+    application/json response body anywhere in the operation — while the same
+    operation declares a `'406'` response. So tier 2 offers the request and
+    defines neither a body for it nor an obligation to fulfil it, leaving both
+    answers exactly as conformant as before.
   source: >-
     ITS-REST overview Resources.md §JSON Format ("The client SHOULD use the
     Accept: application/json request header to specify the expected JSON
@@ -810,7 +870,15 @@ AMB-58:
     Web Template JSON format") — the two rules that govern IF the request is
     fulfilled, neither of which says whether it is. No released sentence
     defines a canonical-JSON OPERATIONAL_TEMPLATE representation; silence
-    CONFIRMED first-hand across specifications/docs/**.
+    CONFIRMED first-hand across specifications/docs/**. TIER 2, cited AS the
+    OAS and re-read first-hand 2026-07-28: ITS-REST
+    specifications/parameters/header/Accept_Template.yaml (`enum:
+    application/json, application/xml, application/openehr.wt+json`) vs
+    specifications/responses/200_Template_adl1_4_retrieved.yaml (`content`:
+    application/xml + application/openehr.wt+json — no application/json entry)
+    and specifications/operations/definition_template_adl1.4_get.yaml
+    (responses 200/400/404/**406**) — the offer without a body, and the
+    declared refusal branch beside it.
   handling: >-
     Our own design/extension, documented rather than derived — no openEHR spec
     governs which of the two permitted answers a service gives. This CDR
@@ -974,17 +1042,38 @@ AMB-61:
   options: [legacy-alt-formats-supported, legacy-alt-formats-unsupported]
 AMB-62:
   ambiguity: >-
-    The `Prefer: return=minimal` branch — which is ALSO the assumed default
-    when no `Prefer` is sent — has no assigned response status. The released
-    text offers two sentences for the same exchange and neither assigns one:
-    "The HTTP status is typically `201 Created`" is descriptive ("typically",
-    not a MUST or a SHOULD), and "If no response body is returned, the service
-    SHOULD use `204 No Content`" is conditional on whether a body is returned,
-    a fact the same text never assigns either. So a conformant minimal write
-    may answer 201 or 204 and the text distinguishes neither, on any write
-    operation.
+    RE-ADJUDICATED 2026-07-28 under the OAS-fallback oracle order: the
+    DOCS-TEXT silence is real and unchanged, but the released OAS FILLS IT
+    per operation family, so the entry's former position — "the branch has no
+    assertable status at all" — is WITHDRAWN and replaced by the assignment
+    below.
+    THE DOCS-TEXT HALF (unchanged): the `Prefer: return=minimal` branch —
+    which is ALSO the assumed default when no `Prefer` is sent — is given two
+    sentences in one paragraph and neither assigns a status. "The HTTP status
+    is typically `201 Created`" is descriptive ("typically", not a MUST or a
+    SHOULD); "If no response body is returned, the service SHOULD use `204 No
+    Content`" is conditional on whether a body is returned, a fact the same
+    text never assigns either. The paragraph therefore does not speak with one
+    voice, which is a SILENCE about which status governs — not a determinate
+    rule the OAS could be in conflict with.
+    THE OAS HALF (the fill, cited AS the OAS and read for exactly what it
+    states): every released write operation declares its success statuses, and
+    the response files ASSIGN the minimal branch in the indicative on both
+    sides of the create/update split. CREATES declare exactly ONE success
+    status, 201, whose response file ends "If the `Prefer` header is missing
+    or set to `return=minimal`, the body is empty" — verified verbatim and
+    identically in `201_COMPOSITION.yaml`, `201_PERSON.yaml`,
+    `201_Template_adl1_4_upload.yaml` and `201_Template_adl2_upload.yaml`.
+    UPDATES declare 200 AND 204 and split them by preference: `200_*_updated`
+    is scoped to "when `Prefer` header is `return=representation` … or
+    `return=identifier`", while `204_version_updated.yaml` reads "`204 No
+    Content` is returned when the update operation was successful and the
+    `Prefer` header is missing or is set to `return=minimal`". So the minimal
+    status is 201-with-an-empty-body on a create and 204 on an update, and
+    nothing is left for a runner to guess.
   source: >-
-    ITS-REST specifications/docs/overview/Requests_and_responses.md §"Prefer
+    TIER 1, DOCS TEXT — ITS-REST
+    specifications/docs/overview/Requests_and_responses.md §"Prefer
     minimal, identifier or full representation response" ("`Prefer:
     return=minimal` Indicates the client prefers a minimal response. The
     response SHOULD include a `Location` header pointing to the newly created
@@ -992,36 +1081,78 @@ AMB-62:
     response body is returned, the service SHOULD use `204 No Content`.") +
     §Representation details negotiation ("If no `Prefer` header is provided,
     the default behavior is assumed to be `return=minimal`") — the absence of
-    a status assignment CONFIRMED first-hand. Contrast the SIBLING preference,
-    which IS assigned: §"Prefer only identifier" fixes "the status will be
-    `201 Created` or `200 OK`, never `204 No Content`".
+    a determinate status assignment CONFIRMED first-hand. Contrast the SIBLING
+    preference, which IS assigned in the docs text: §"Prefer only identifier"
+    fixes "the status will be `201 Created` or `200 OK`, never `204 No
+    Content`".
+    TIER 2, THE RELEASED OAS, citable because tier 1 states two answers and
+    settles on neither (owner ruling 2026-07-28) and cited AS the OAS — read
+    first-hand 2026-07-28. CREATES declare one success status:
+    specifications/operations/{composition_create,person_create,ehr_create,
+    ehr_create_with_id,directory_create,contribution_create,
+    definition_template_adl1.4_upload,definition_template_adl2_upload}.yaml
+    all map success to `'201'` and none declares a `'204'`; the response files
+    close with "If the `Prefer` header is missing or set to `return=minimal`,
+    the body is empty" (responses/201_COMPOSITION.yaml,
+    201_PERSON.yaml, 201_Template_adl1_4_upload.yaml,
+    201_Template_adl2_upload.yaml — verified verbatim). UPDATES declare both
+    and split them BY PREFERENCE: responses/200_COMPOSITION_updated.yaml (and
+    its 200_*_updated siblings) is scoped "with the full resource in the
+    response body when `Prefer` header is `return=representation`, or only its
+    identifiers when `Prefer` header is `return=identifier`", while
+    responses/204_version_updated.yaml states "`204 No Content` is returned
+    when the update operation was successful and the `Prefer` header is
+    missing or is set to `return=minimal`" — the one indicative sentence that
+    assigns the branch outright.
   handling: >-
-    No case pins the minimal status, and no binding declares a minimal
-    outcome — not even one carrying an alt_status pair. Accepting {201, 204}
-    would still be an authored expectation assembled from a descriptive
-    adverb plus a conditional SHOULD, which is the invention the attribution
-    law forbids; the honest position is that the branch has no assertable
-    status at all. What the branch DOES assign is asserted elsewhere: the
-    `Location` SHOULD is executed on the create outcomes
-    (wire_surface `header-location-on-create`), and the body selector
-    `prefer_conditional` deliberately never judges the minimal branch. The
-    default-when-absent half is exercised indirectly by the bindings that send
-    no `Prefer` (I_DEFINITION_ADL2.upload_artefact reads its identifier back
-    from `Location`). Carried as the cited wire_surface element
-    `header-prefer-return-minimal`. Activates as a gating case when a future
-    ITS-REST release fixes the minimal status, or when the case model gains an
-    either-status expectation grounded in the two sentences (extension only by
-    schedule release).
+    Fixed handling, per operation family, replacing the withdrawn
+    no-assertable-status position. A minimal write (explicit
+    `Prefer: return=minimal` or no `Prefer` at all) answers `201 Created` with
+    an EMPTY body on a create and `204 No Content` on an update; a delete is
+    the 204 family it already was. That is not an authored blend of a
+    descriptive adverb and a conditional SHOULD — it is what the release's own
+    computable artifacts state, per operation, in the indicative.
+    THE DOCS TEXT IS NOT OVERRIDDEN, because it never spoke with one voice
+    here: its "typically 201" and its "SHOULD use 204" are the two halves the
+    OAS then assigns to the two families, so the tier-2 fill is consistent
+    with both sentences rather than beating either. Where the docs text DOES
+    speak singly it still wins outright — §"Prefer only identifier" is
+    unaffected and stays docs-text-governed.
+    ALREADY GATED under this reading: the two template uploads, whose
+    operation-level 201 text AMB-110(b) had already read this way
+    (I_DEFINITION_ADL14.upload_opt-prefer_minimal,
+    I_DEFINITION_ADL2.upload_artefact-prefer_minimal) — that adjudication is
+    now the general rule rather than a two-operation exception.
+    STILL UNCOVERED, recorded as coverage to close rather than as silence: no
+    case yet pins the minimal branch on the COMPOSITION / EHR_STATUS /
+    DIRECTORY / PARTY / CONTRIBUTION writes, and the `Location` SHOULD is
+    asserted only on the create outcomes (wire_surface
+    `header-location-on-create`). The wire_surface element
+    `header-prefer-return-minimal` carries that gap with this entry's citation
+    and RETIRES when those cases land — it is a coverage gap now, not an
+    unassertable branch. The body selector `prefer_conditional` keeps its
+    current behaviour until it does.
   disposition: fixed_handling
 AMB-63:
   ambiguity: >-
-    One-EHR-per-subject is neither defined nor denied by the released sources,
-    and three sub-questions follow from that silence. (a) THE KEY: no released
-    sentence says which parts of the subject reference are compared, nor how —
-    whether `PARTY_REF.type` participates, and whether `id.value` /
-    `namespace` are matched byte-for-byte or folded (BASE gives a case rule for
-    composite IDENTIFIERS, not for a demographic id borne inside a
-    PARTY_SELF). (b) THE SCOPE: SM i_ehr_service.adoc declares the error
+    NARROWED 2026-07-28 under the OAS-fallback oracle order: sub-question (a)
+    is now mostly ANSWERED and only its folding half survives; (b) and (c)
+    stand unchanged.
+    One-EHR-per-subject is neither defined nor denied by the DOCS TEXT, which
+    never mentions a subject at all, and three sub-questions followed from
+    that silence. (a) THE KEY — PARTLY FILLED: the released OAS response the
+    id-less create declares for its conflict branch names the compared parts
+    outright, "a conflict with an already existing EHR with the same subject
+    id, namespace pair, whenever EHR_STATUS is supplied"
+    (responses/409_EHR.yaml, `$ref`d by operations/ehr_create.yaml under
+    `'409'`). That settles the two halves the entry used to call open — the
+    key IS the (id, namespace) pair, and `PARTY_REF.type` is NOT part of it —
+    and it also states the precondition under which the refusal bites (an
+    EHR_STATUS was supplied). What NO source states is HOW the pair is
+    compared: byte-for-byte or folded. BASE gives a case rule for composite
+    IDENTIFIERS, not for a demographic id borne inside a PARTY_SELF, so the
+    comparison discipline remains ours. (b) THE SCOPE: SM i_ehr_service.adoc
+    declares the error
     `ehr_for_subject_already_exists` on `create_ehr_for_subject` but NOT on
     `create_ehr_for_subject_with_id`, whose error list carries only
     `ehr_create_fail_duplicate_id` — so whether the refusal reaches the
@@ -1040,24 +1171,43 @@ AMB-63:
     + RM ehr EHR_STATUS class §Attributes (`subject`: 1..1 PARTY_SELF, "The
     subject of this EHR. The `_external_ref_` attribute can be used to contain
     a direct reference to the subject in a demographic or identity service" —
-    no uniqueness, no comparison rule) + the released ITS-REST docs text, which
-    never mentions a subject at all (grep of
+    no uniqueness, no comparison rule) + the released ITS-REST DOCS TEXT,
+    which never mentions a subject at all (grep of
     specifications/docs/**: zero hits) — silence CONFIRMED first-hand.
+    TIER 2, THE RELEASED OAS, citable because the docs text is silent (owner
+    ruling 2026-07-28) and cited AS the OAS — read first-hand 2026-07-28:
+    specifications/responses/409_EHR.yaml ("`409 Conflict` Unable to create a
+    new EHR due to a conflict with an already existing EHR with the same
+    subject id, namespace pair, whenever EHR_STATUS is supplied"), `$ref`d by
+    operations/ehr_create.yaml (responses 201/400/409) — the KEY and the
+    trigger condition. CONTRASTED with the with-id path, which is the reason
+    (b) survives: operations/ehr_create_with_id.yaml `$ref`s a DIFFERENT
+    conflict file, responses/409_EHR_with_id.yaml ("Unable to create a new EHR
+    due to a conflict with an already existing EHR. Can happen when the
+    supplied `ehr_id` is already used by an existing EHR"), whose only named
+    trigger is the id collision and whose "Can happen when" is illustrative
+    rather than exhaustive — so the OAS neither carries the subject refusal to
+    that path nor excludes it.
   handling: >-
     Fixed handling, and the parts of it that rest on nothing released are
     flagged as such rather than dressed up as spec. (a) THE KEY is the
-    EHR_STATUS.subject.external_ref pair (`id.value`, `namespace`), compared
-    EXACTLY — byte-for-byte, no case folding, `type` not part of the key. No
-    openEHR spec governs this — our own design/extension: a demographic
-    identifier is opaque to the CDR, so two spellings that a demographic
-    service might reconcile are two different subjects here, and folding them
-    would silently merge two patients' records, the wrong-clinical-answer
-    failure mode. Explicitly NOT the BASE composite-identifier case rule
-    (base_types master05 §Composite Identifiers and Case), which governs
-    OBJECT_VERSION_ID-shaped ids, not a demographic id. (b) THE SCOPE: the
-    refusal is carried to EVERY create path, the client-supplied-id form
-    included — the with-id operation's text does not lift it, and a rule that
-    a client could evade by choosing its own uuid would not be a rule.
+    EHR_STATUS.subject.external_ref pair (`id.value`, `namespace`), `type` NOT
+    part of it — and that much is now RELEASED-GROUNDED rather than ours, on
+    the OAS `409_EHR.yaml` sentence above ("the same subject id, namespace
+    pair"), as is the "whenever EHR_STATUS is supplied" precondition the
+    catalogue's cases already satisfy. What stays OURS is only the COMPARISON
+    DISCIPLINE: the pair is matched EXACTLY, byte-for-byte, with no case
+    folding and no normalization. No openEHR spec governs that — our own
+    design/extension: a demographic identifier is opaque to the CDR, so two
+    spellings a demographic service might reconcile are two different subjects
+    here, and folding them would silently merge two patients' records, the
+    wrong-clinical-answer failure mode. Explicitly NOT the BASE
+    composite-identifier case rule (base_types master05 §Composite Identifiers
+    and Case), which governs OBJECT_VERSION_ID-shaped ids, not a demographic
+    id. (b) THE SCOPE: the refusal is carried to EVERY create path, the
+    client-supplied-id form included — neither released source lifts it (the
+    with-id 409 names the id collision and stops), and a rule a client could
+    evade by choosing its own uuid would not be a rule.
     Because that carry is not stated, the case resting on it
     (I_EHR_SERVICE.create_ehr-with_ehr_id_subject_taken) is kept at OPTIONS,
     reported and never gating — the AMB-58 treatment. The id-less path's
@@ -1071,7 +1221,8 @@ AMB-63:
     could not be processed because it might generate a duplicate or a
     conflict") — so the two share the `already_exists` outcome kind and are
     told apart by CASE, never by expectation. Revisits if a future release
-    states the key, the scope, or admits several EHRs per subject.
+    states the comparison discipline, carries the refusal to the with-id path,
+    or admits several EHRs per subject.
   disposition: fixed_handling
 AMB-64:
   ambiguity: >-
@@ -1529,53 +1680,71 @@ AMB-77:
 
 AMB-78:
   ambiguity: >-
-    Whether a COMPOSITION update whose request body carries a `uid` naming a
-    DIFFERENT version container than the URL's `uid_based_id` must be
-    REJECTED — and with which status — is stated by NO released docs text.
-    The match requirement appears only in the API definition's operation
-    description ("If the request body already contains a COMPOSITION.uid.value,
-    it must match the `uid_based_id` in the URL"), which is the stalled OAS
-    layer and never an oracle. The docs text says only that a
-    COMPOSITION.uid.value "implies that the VERSIONED_OBJECT identifier is
-    …", and that copying the enclosing VERSION uid into the contained object
-    is "strongly recommended"/"should" — recommendation strength, so a server
-    that accepts the commit and stamps its own uid breaches nothing released.
-    Neither the 400 row nor the 422 row of the status table is assigned to
-    this case.
+    RE-ADJUDICATED 2026-07-28 under the OAS-fallback oracle order, and
+    RETYPED from `report_only` to `fixed_handling`: the RULE is released, so
+    the case gates. The entry's whole ground for never gating was that the
+    match requirement "appears only in the API definition's operation
+    description … which is the stalled OAS layer and never an oracle". That
+    layer is tier 2 now, and the docs text is SILENT rather than in conflict
+    with it, so the requirement holds: a COMPOSITION update whose request body
+    carries a `uid` naming a DIFFERENT version container than the URL's
+    `uid_based_id` MUST be refused.
+    WHAT IS STILL NOT ASSIGNED, and is why the entry survives: the STATUS. The
+    operation declares 200/204/400/404/412/422 and no released sentence — on
+    either tier — binds the body-vs-URL contradiction to one of them. The
+    docs text's own row descriptions decide it as far as anything can (see the
+    handling), but the assignment remains ours and the upstream ask stands.
+    The DOCS-TEXT half is unchanged: it says only that a COMPOSITION.uid.value
+    "implies that the VERSIONED_OBJECT identifier is …", and that copying the
+    enclosing VERSION uid into the contained object is "strongly
+    recommended"/"should" — which is why the rule had to come from tier 2.
   source: >-
-    ITS-REST specifications/docs/overview/Resources.md §Identifier types (the
-    "implies that the VERSIONED_OBJECT identifier is `8849182c-…`" derivation
-    + the "strongly recommended … should be copied" NOTE);
-    Requests_and_responses.md §HTTP status codes (rows 400 "malformed request
-    syntax, syntactically invalid content" and 422 "well-formed but … unable
-    to be followed due to semantic errors" — neither assigned to a
-    body-vs-URL identifier contradiction); RM common
-    UML/classes/org.openehr.rm.common.locatable.adoc §Attributes (uid 0..1) —
-    the silence confirmed first-hand across the whole ITS-REST docs tree (the
-    only "must match the `uid_based_id`" sentence lives in the OAS operation
-    file).
+    TIER 1, DOCS TEXT — ITS-REST specifications/docs/overview/Resources.md
+    §Identifier types (the "implies that the VERSIONED_OBJECT identifier is
+    `8849182c-…`" derivation + the "strongly recommended … should be copied"
+    NOTE); Requests_and_responses.md §HTTP status codes (rows 400 "malformed
+    request syntax, syntactically invalid content" and 422 "well-formed but …
+    unable to be followed due to semantic errors" — neither ASSIGNED to a
+    body-vs-URL identifier contradiction, though the 422 row is the only one
+    whose description fits it); RM common
+    UML/classes/org.openehr.rm.common.locatable.adoc §Attributes (uid 0..1).
+    Docs-text silence on the RULE re-confirmed first-hand 2026-07-28 across
+    the whole ITS-REST docs tree.
+    TIER 2, THE RELEASED OAS, citable because tier 1 is silent (owner ruling
+    2026-07-28) and cited AS the OAS — read first-hand 2026-07-28:
+    specifications/operations/composition_update.yaml, description, "If the
+    request body already contains a COMPOSITION.uid.value, it must match the
+    `uid_based_id` in the URL", with responses 200/204/400/404/412/422 and
+    responses/422.yaml ("returned when the content type and syntax is correct,
+    could be converted to a resource, but there are semantic validation
+    errors"). The same sentence, over the same attribute, appears in
+    operations/{person,agent,group,organisation,role}_update.yaml, each of
+    which likewise declares 422.
   handling: >-
-    Report-only: the update_composition-body_uid_mismatch case exercises the
-    branch and records the outcome without gating any tier. This server
-    REJECTS the self-contradictory request as its own design convention, and
-    the catalogue expects the SEMANTIC-error branch because the 422 row is
-    the only row that describes the exchange — the body is well-formed JSON
-    and a well-formed COMPOSITION; what cannot be followed is the
-    contradiction between body and URL — while the 400 row is scoped to
-    malformed syntax. A conformant server answering 400 instead, or accepting
-    the commit outright, breaches nothing released, so the case never gates.
-    Reported upstream (UPR-40): state the rule and its branch in the docs
-    text.
-    SCOPE EXTENDED 2026-07-27 (group-12 audit) to the five party updates, whose
-    operation descriptions carry the SAME sentence about the same body
-    attribute ("If the request body already contains a PERSON.uid.value, it
-    must match the `uid_based_id` in the URL") in the same OAS-only place, over
-    a class whose own uid rule is a released RM invariant rather than a
-    recommendation (AMB-129). The disposition is unchanged: report-only, the
-    semantic branch expected, no tier gated. The party CREATE is a different
-    question — it has no URL identifier for a body uid to contradict — and is
-    AMB-132.
-  disposition: report_only
+    Fixed handling. THE RULE GATES: a body uid naming another container is
+    REFUSED, on every update that carries the sentence — the COMPOSITION
+    update and all five party updates. `I_EHR_COMPOSITION.update_composition-body_uid_mismatch`
+    therefore drops its report-only shelter and gates at its declared CORE
+    tier, and the addressed container must keep its single version.
+    THE STATUS IS ADJUDICATED, not declared, and stays 422: the request parses
+    and carries a well-formed COMPOSITION, so the 400 row — scoped by its own
+    words to "malformed request syntax, syntactically invalid content" — does
+    not describe it, while both the docs-text 422 row ("well-formed but …
+    unable to be followed due to semantic errors") and the OAS `422.yaml`
+    ("the content type and syntax is correct, could be converted to a
+    resource, but there are semantic validation errors") describe it exactly,
+    and 422 is among the statuses the operation declares. A server answering
+    400 is answering outside that row's stated trigger; the catalogue holds
+    the 422 line and the residual risk is recorded here rather than hidden.
+    PARTY SCOPE (extended 2026-07-27, re-grounded 2026-07-28): the five party
+    updates carry the identical sentence over a class whose own uid rule is a
+    released RM invariant rather than a recommendation (AMB-129), so the rule
+    is if anything stronger there; the party CREATE is a different question —
+    it has no URL identifier for a body uid to contradict — and is AMB-132.
+    Reported upstream (UPR-40), re-scoped: the rule is now findable in the
+    release's computable artifacts but still absent from the normative prose,
+    and its branch is still unassigned on either tier.
+  disposition: fixed_handling
   upstream_ref: "UPR-40"
 
 AMB-79:
@@ -3781,7 +3950,9 @@ AMB-132:
     operations/contribution_create.yaml (the relaxed-envelope uid sentence,
     quoted above) and person_update.yaml ("If the request body already contains
     a PERSON.uid.value, it must match the `uid_based_id` in the URL" — the
-    OAS-only match rule AMB-78 carries, and in any case an UPDATE rule) + RM
+    OAS-stated match rule AMB-78 carries — tier-2 ground under the 2026-07-28
+    order, and in any case an UPDATE rule that a CREATE has no URL identifier
+    to be measured against) + RM
     demographic master02-demographic_package.adoc §Party Identification (the
     uid is the containing VERSION's OBJECT_VERSION_ID) + RM common
     master06-change_control_package.adoc §Version Identification (`object_id()`
@@ -3893,18 +4064,27 @@ AMB-134:
     on `POST /demographic/contribution` they are not accepted at all, because
     that route's own operation declares no Simplified arm and its inner
     payloads are PARTYs, which the Simplified Formats have no shape for
-    (AMB-128). No XML envelope is served on either route: §"Data
-    representation" requires "at least one of" the canonical formats and JSON
-    is that one, so serving JSON alone breaches nothing released, and the
-    `ContentType_canonical`/`ContentType_LOCATABLE` enums are OAS shape — the
-    stalled layer, never an oracle. The refusals are the negotiation section's
-    own: an XML or Simplified request payload the service cannot process is
-    `415`, an `Accept` it cannot satisfy is `406`. The divergence is worth
-    reporting even though the enum half lives in the OAS, because the OPERATION
-    DESCRIPTIONS — released prose — are where the asymmetry actually shows: one
-    route documents an inner-payload Simplified arm and the other documents
-    nothing, and neither says what an XML envelope is. Reported upstream
-    (UPR-98).
+    (AMB-128). No XML envelope is served on either route, and the reasoning
+    for that is RE-GROUNDED 2026-07-28 with the conclusion unchanged. The old
+    wording dismissed the `ContentType_canonical`/`ContentType_LOCATABLE`
+    enums as "OAS shape — the stalled layer, never an oracle"; under the
+    2026-07-28 order those enums ARE citable, and they still create no
+    obligation, for the reason the order itself states — an enumerated Accept
+    or Content-Type value is an OFFER, never a presence requirement. The
+    DOCS TEXT is not silent here either, so tier 2 could not override it in
+    any case: §"Data representation" requires "at least one of" the canonical
+    formats, JSON is that one, and serving JSON alone therefore breaches
+    nothing released. (What the release genuinely withholds about a
+    CONTRIBUTION in XML is adjudicated next door: the COMMIT envelope's shape
+    in AMB-165, the READ side's document root in AMB-167.) The refusals are
+    the negotiation section's own: an XML or Simplified request payload the
+    service cannot process is `415`, an `Accept` it cannot satisfy is `406`.
+    The upstream report stands on the OPERATION DESCRIPTIONS rather than the
+    enums — one route documents an inner-payload Simplified arm and the other
+    documents nothing, and neither says what an XML envelope is; those
+    descriptions are tier-2 text too, and citing them AS the OAS is what the
+    order requires (the 2026-07-27 wording called them "released prose", which
+    over-stated their tier). Reported upstream (UPR-98).
   disposition: fixed_handling
   upstream_ref: "UPR-98"
 
@@ -5016,10 +5196,20 @@ AMB-152:
     one of the openEHR **XML** or **JSON** canonical formats for resource
     representation. Additionally, the **Simplified Formats** format SHOULD be
     supported") + RM ehr §EHR_STATUS and RM common §FOLDER (neither is a
-    templated, OPT-derived structure) — all CONFIRMED first-hand. The
-    negotiation-enum half is OAS shape (stalled, never an oracle); the
-    load-bearing evidence is the released contribution_create prose plus the
-    Simplified Formats chapters' own scope.
+    templated, OPT-derived structure) — all CONFIRMED first-hand.
+    TIER NOTE, RE-GROUNDED 2026-07-28 with the verdict unchanged: the
+    2026-07-27 wording dismissed the negotiation enums as "OAS shape (stalled,
+    never an oracle)" and called `contribution_create`'s §Simplified Formats
+    paragraph "released text, not an OAS enum". Both tierings were wrong under
+    the current order and are corrected here — `operations/*.yaml` descriptions
+    and `parameters/header/*.yaml` enums are BOTH tier-2 OAS material, citable
+    where the docs text is silent and cited AS the OAS, which is how this entry
+    cites them now. Nothing about the adjudication moves, for two reasons that
+    survive the re-tiering intact: an enumerated MIME type is an OFFER and
+    never a presence requirement (the order says so explicitly), and the real
+    gap is not on either tier of ITS-REST at all — the Simplified Formats
+    sub-specification defines no EHR_STATUS and no FOLDER shape, and no OAS
+    element can supply a mapping table that was never written.
   handling: >-
     Fixed handling: EHR, EHR_STATUS and DIRECTORY (FOLDER) are CANONICAL-ONLY,
     and both refusals are the ones the negotiation section already mandates
@@ -5527,13 +5717,22 @@ AMB-158:
     occurrence. Plus docs/overview/Requests_and_responses.md §HTTP Methods
     (OPTIONS: "Describe the communication options for the target resource"),
     the only released sentence about the method's meaning. The `endpoints`
-    member itself appears ONLY in the stalled OAS
+    member itself appears ONLY in the RELEASED OAS
     (specifications/schemas/others/Options.yaml: `endpoints: {type: array,
     items: {type: string}}` with the five-entry example, no description; and
     specifications/operations/options.yaml, "exposing service capabilities for
-    a conformance manifest") — recorded as provenance for where the member
-    comes from, NOT as an oracle (owner ruling 2026-07-24: the OAS is stalled
-    and the docs text governs). Silence CONFIRMED first-hand.
+    a conformance manifest").
+    RE-GROUNDED 2026-07-28, verdict unchanged: the 2026-07-27 wording recorded
+    that OAS material as "provenance … NOT as an oracle (owner ruling
+    2026-07-24: the OAS is stalled and the docs text governs)". Under the
+    current order it IS the oracle for this member, the docs text being silent
+    — and AMB-160 duly grounds the resource, the Content-Type and the JSON
+    manifest body there. It still does not answer THIS question, for the
+    reason the order fixes: the OAS is never read for more than it states, and
+    what it states about `endpoints` is a TYPE (`array of string`, no
+    description, no `required`) plus an `example`. An example is an
+    illustration, not a rule, so which endpoints the member must list stays
+    undefined on both tiers. Silence CONFIRMED first-hand.
   handling: >-
     Fixed handling, and the shipped decision is stated rather than left
     implicit. The manifest lists the LIVE standardised ITS-REST group set —

--- a/tools/cnf-runner/artifacts/registers/ambiguities.yaml
+++ b/tools/cnf-runner/artifacts/registers/ambiguities.yaml
@@ -836,9 +836,7 @@ AMB-58:
   ambiguity: >-
     NOT an openEHR ambiguity — a documented extension of ours, kept in this
     register because a case rests on it and must never be mistaken for a
-    spec-derived expectation (re-framed 2026-07-27 under the owner ruling that
-    an "ambiguity" whose only conflict lives in the stalled OAS is not one).
-    The released docs text is simply SILENT on what an `Accept:
+    spec-derived expectation. The released docs text is simply SILENT on what an `Accept:
     application/json` read of an operational template returns: it defines no
     canonical-JSON representation of an OPERATIONAL_TEMPLATE anywhere, names
     only `application/openehr.wt+json` for the template-as-JSON case, and
@@ -6144,7 +6142,12 @@ AMB-167:
     `ehr-status`, `directory`, `party` (one seam for all five PARTY types —
     the demographic routes share one binding family and one document
     question), `contribution` (the READ side; the ok arm has no authored
-    case yet, the AMB-4 `adl14-duplicate-replace` pattern). The DOCUMENTED
+    case yet, the AMB-61 `legacy-alt-formats-supported` pattern — a declared
+    branch a party can select itself out of, with nothing spec-grounded to
+    assert about the positive exchange; AMB-4's `adl14-duplicate-replace`
+    used to be the reference instance of that pattern and was withdrawn on
+    2026-07-28 when the released OAS turned out to define its behaviour). The
+    DOCUMENTED
     rows stay ungated and unconditional: `-xml` cases on COMPOSITION, on the
     VERSIONED_* container reads and their `version` sub-resources, and on
     the OPT/archetype/example payloads assert behaviour the release fully

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-body_uid_mismatch.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-body_uid_mismatch.yaml
@@ -9,19 +9,29 @@
 # `11111111-…`, while the URL addresses the container this EHR's create
 # actually minted. The two cannot both be the target.
 #
-# SPEC SILENCE, registered as AMB-78 (report_only) — read the register entry
-# before changing anything here. No released sentence REQUIRES the rejection
-# (the match rule lives only in the API definition's operation description,
-# the stalled OAS layer; the docs text calls copying the enclosing VERSION uid
-# into the contained object "strongly recommended"/"should", and RM types
-# LOCATABLE.uid 0..1), and none assigns it a status. The catalogue expects the
-# SEMANTIC-error branch because the overview's 422 row is the only row that
-# describes this exchange — "The request was well-formed but was unable to be
-# followed due to semantic errors" — while the 400 row is scoped to "malformed
-# request syntax, syntactically invalid content" and the payload here is
-# neither. A conformant server answering 400, or accepting the commit and
-# stamping its own uid, breaches nothing released, so this case REPORTS and
-# never gates a tier.
+# GATING SINCE 2026-07-28, registered as AMB-78 (fixed_handling) — read the
+# register entry before changing anything here. The RULE is released: the
+# RELEASED OAS states it in the operation's own description (ITS-REST
+# specifications/operations/composition_update.yaml — "If the request body
+# already contains a COMPOSITION.uid.value, it must match the `uid_based_id`
+# in the URL"), and the docs text is SILENT rather than in conflict with it,
+# so under the 2026-07-28 oracle order that is a tier-2 ground and the
+# rejection is a released expectation. It is cited AS the OAS, never as docs
+# text. (The docs text reaches only as far as calling the copy of the
+# enclosing VERSION uid "strongly recommended"/"should", and RM types
+# LOCATABLE.uid 0..1 — which is why the rule had to come from tier 2. Before
+# the ruling this case carried report-only shelter on the reasoning that the
+# OAS was never an oracle; that shelter is withdrawn.)
+#
+# The STATUS is still ADJUDICATED, not declared, and stays 422: the operation
+# declares 200/204/400/404/412/422 and neither tier binds this trigger to one
+# of them, but the payload parses and is a well-formed COMPOSITION, so the
+# 400 row is out by its own scoping ("malformed request syntax, syntactically
+# invalid content") while both the docs-text 422 row ("The request was
+# well-formed but was unable to be followed due to semantic errors") and the
+# OAS responses/422.yaml ("the content type and syntax is correct, could be
+# converted to a resource, but there are semantic validation errors") describe
+# the exchange exactly. UPR-40 still asks upstream to assign the branch.
 #
 # The payload is otherwise the accepted v2 content (a valid COMPOSITION of the
 # same template), so the uid contradiction is the only rejectable defect.
@@ -31,7 +41,7 @@ component: EHR_COMPOSITION
 sm_operation: I_EHR_COMPOSITION.update_composition
 capabilities: [Versioning]
 exercises: [CompositionOps]
-profiles: [CORE]                         # Versioning is Core-tier; the case is NON-GATING via the report-only register entry AMB-78
+profiles: [CORE]                         # Versioning is Core-tier and the case GATES there: AMB-78 became fixed_handling on 2026-07-28
 ambiguities: [AMB-78]
 test_purpose: >-
   A COMPOSITION update whose body uid names a different version container than
@@ -45,7 +55,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_COMPOSITION.update_composition"
 applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
 guards:
-  - "The rejection itself rests on the AMB-78 adjudication — ITS-REST overview Resources.md §Identifier types only derives the container from the served identifier and calls copying the enclosing VERSION uid 'strongly recommended'/'should', and Requests_and_responses.md §HTTP status codes assigns neither its 400 nor its 422 row to a body-vs-URL identifier contradiction; the match rule itself appears only in the stalled API definition. A server that accepts the commit, or answers 400 instead of 422, is not in breach"
+  - "The REJECTION is released and gates: ITS-REST OAS operations/composition_update.yaml states the rule in its description ('If the request body already contains a COMPOSITION.uid.value, it must match the `uid_based_id` in the URL'), tier-2 ground where the docs text is silent (owner ruling 2026-07-28, register AMB-78). The 422 STATUS is adjudicated, not declared — neither tier binds this trigger to one of the operation's declared statuses; 422 is taken because the docs-text 422 row ('well-formed but was unable to be followed due to semantic errors') and the OAS responses/422.yaml both describe the exchange while the 400 row is scoped to malformed syntax. A server answering 400 answers outside that row's stated trigger"
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.upload_opt-valid_opt_twice_conflict.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.upload_opt-valid_opt_twice_conflict.yaml
@@ -1,17 +1,25 @@
-# The declared duplicate branch of the ADL 1.4 OPT upload: a second upload of
-# the SAME template_id is refused as a conflict and exactly one template remains
-# loaded. Decisive released sentence (ITS-REST
-# specifications/responses/409_template_already_exists.yaml, $ref'd by
-# specifications/operations/definition_template_adl1.4_upload.yaml): "`409
-# Conflict` is returned when a template with same `template_id` already exists".
+# The duplicate branch of the ADL 1.4 OPT upload: a second upload of the SAME
+# template_id is refused as a conflict and exactly one template remains loaded.
+# Decisive sentence, from the RELEASED OAS (tier 2 — the docs text is silent on
+# duplicate template upload, so the OAS grounds it per the 2026-07-28 oracle
+# order; cited AS the OAS): ITS-REST
+# specifications/responses/409_template_already_exists.yaml, $ref'd under the
+# '409' response of specifications/operations/definition_template_adl1.4_upload.yaml
+# — "`409 Conflict` is returned when a template with same `template_id` already
+# exists". It states the trigger in the indicative, not merely a status.
 #
-# This is the `adl14-duplicate-conflict` branch of AMB-4. The sibling branch,
-# `adl14-duplicate-replace`, is the SM-shaped reading — SM i_definition_adl14.adoc
+# GATING FOR EVERY SERVER since 2026-07-28. This case used to carry the
+# `adl14-duplicate-conflict` option tag of AMB-4, on the reading that a
+# DECLARED 409 branch was an offer rather than an obligation because the OAS
+# was not an oracle. Under the 2026-07-28 oracle order it is one wherever the
+# docs text is silent, and the docs text says nothing about a duplicate
+# template upload anywhere, so the sentence above is the released expectation
+# and the option pair (and its `adl14-duplicate-replace` sibling) is
+# withdrawn — see the re-adjudicated AMB-4. The same wire position the ADL2
+# upload already gated under AMB-105, whose 409 file says the same sentence.
+# The SM half stays an upstream defect (UPR-01): SM i_definition_adl14.adoc
 # §upload_opt is silent on duplicates where its own §upload_archetype ("If an
-# archetype with the same id already exists, replace it") is not — and has no
-# case on this ITS, because no released sentence assigns the replacing server's
-# status. The ICS options declaration selects which applies; a server declaring
-# neither runs neither.
+# archetype with the same id already exists, replace it") is not.
 id: I_DEFINITION_ADL14.upload_opt-valid_opt_twice_conflict
 kind: functional
 component: DEFINITION_ADL14
@@ -19,12 +27,11 @@ sm_operation: I_DEFINITION_ADL14.upload_opt
 capabilities: [Adl14OptProvisioning]
 exercises: [ArchetypeValidation]
 profiles: [CORE]
-option: adl14-duplicate-conflict
 test_purpose: "Uploading the same template_id twice is refused as a conflict; exactly one OPT remains loaded."
 description: "Upload valid OPT twice with conflict"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_ADL14.upload_opt"
-  - "ITS-REST definition_template_adl1.4_upload §409 Conflict"
+  - "ITS-REST OAS responses/409_template_already_exists.yaml (via operations/definition_template_adl1.4_upload.yaml '409')"
   - "CNF platform_test_schedule master04 §upload_opt-valid_opt_twice_conflict"
 applies: { rm: ">=1.0.2" }
 requires: { server: empty }              # "No OPTs should be loaded on the system"

--- a/tools/cnf-runner/artifacts/vocab/wire_surface.yaml
+++ b/tools/cnf-runner/artifacts/vocab/wire_surface.yaml
@@ -328,10 +328,16 @@ branches:
   # RETIRED coverage_gap: the create_directory validation_failed branch is now
   # exercised by I_EHR_DIRECTORY.create_directory-invalid_folder (a FOLDER with
   # the 1..1 LOCATABLE.name removed). Its declared status was corrected from
-  # 400 to 422 in the same change — the 400 rested only on the stalled OAS
-  # `400.yaml`, while the released §HTTP status codes 422 row describes a
-  # well-formed body with semantic errors and the whole rest of the catalogue
-  # already maps the identical defect class that way.
+  # 400 to 422 in the same change. Re-grounded 2026-07-28 under the
+  # OAS-fallback oracle order, verdict unchanged: the 400 rested on the OAS
+  # `400.yaml`, whose OWN wording scopes it to input that does not parse
+  # ("the request could not be parsed or is invalid (e.g. … syntactically
+  # invalid header, parameter or content)"), so it never grounded an
+  # RM-invalid but well-formed FOLDER even as a tier-2 source — and
+  # `directory_create.yaml` declares no 422 to ground either. The docs-text
+  # §HTTP status codes 422 row describes a well-formed body with semantic
+  # errors, and the whole rest of the catalogue already maps the identical
+  # defect class that way.
   # RETIRED coverage_gaps: the directory precondition family is now exercised.
   # delete_directory / update_directory `precondition_failed` are gated by
   # I_EHR_DIRECTORY.{delete,update}_directory-stale_if_match, and
@@ -425,8 +431,14 @@ branches:
   # The group-12 finding recorded here — that no released sentence assigns 404 to
   # an If-Match miss, while §"If-Match and accidental overwrites" assigns it 412 —
   # was RIGHT, and the entry was closed by ACTING on it rather than by inventing
-  # a case: the binding's declared status was corrected 404 -> 412 (its only
-  # ground was the stalled OAS person_update.yaml), matching the identical
+  # a case: the binding's declared status was corrected 404 -> 412. Re-grounded
+  # 2026-07-28 under the OAS-fallback oracle order, verdict unchanged and
+  # better founded: this is not a case of the OAS lacking standing, it is a
+  # docs-text-vs-OAS DISAGREEMENT, which the docs text wins outright — and the
+  # released OAS in fact declares BOTH branches on the operation
+  # (operations/person_update.yaml: '404' + '412'), so the docs-text §If-Match
+  # MUST simply picks which of the two an If-Match miss lands on. It matches
+  # the identical
   # adjudication I_EHR_COMPOSITION.update_composition already carried, and the
   # case now names the version_tree_id the ADDRESSED container never issued —
   # distinct from -weak_etag_stale, which offers a FOREIGN container's uid, and
@@ -802,7 +814,7 @@ elements:
       - I_ITS_REST_ITEM_TAGS.person_tags_delete-version_container_disjoint
   - id: item-tag-rm-target-shape
     description: "ITEM_TAG.target is emitted as the RM UID_BASED_ID (HIER_OBJECT_ID container / OBJECT_VERSION_ID version), never an OBJECT_REF wrapper — on the demographic party routes exactly as on the EHR-side ones, the RM class being shared."
-    source: "RM common master07-tags.adoc ITEM_TAG (target: UID_BASED_ID) — one class, one shape, for every route that serves an ITEM_TAG; the RELEASED RM wins over the stalled OAS ItemTag schema. The sibling attribute owner_id has no such single answer outside an EHR — see register AMB-137."
+    source: "RM common master07-tags.adoc ITEM_TAG (target: UID_BASED_ID) — one class, one shape, for every route that serves an ITEM_TAG. The RELEASED RM wins over the OAS ItemTag schema: the ITS-REST OAS is a tier-2 wire source that fills ITS-REST docs-text silence (owner ruling 2026-07-28), never a source of RM class shape, and the RM is a released component in its own right. The sibling attribute owner_id has no such single answer outside an EHR — see register AMB-137."
     covered_by:
       - I_ITS_REST_ITEM_TAGS.composition_tags_get-container_target_shape
       - I_ITS_REST_ITEM_TAGS.composition_tags_get-version_target_shape
@@ -1226,8 +1238,8 @@ elements:
       note: "server behaviour fixed + tested (#401): one shared decoder (app/ehrbase/src/service/datetime.rs, with its unit matrix) now backs every at-time read of the EHR and DEMOGRAPHIC groups, so an offset-less extended datetime resolves against the server's system timezone instead of 400-ing on jiff::Timestamp's offset-requiring grammar; HTTP-tested end to end in app/ehrbase-rest/tests/directory_http.rs and tests/demographic_http.rs (`version_at_time_without_offset_resolves_in_the_local_timezone`). Not authorable as a case today: a case can only name an instant through the CLOSED reference grammar's temporal vocabulary (${time:before|after|between}, tools/cnf-runner/src/refgrammar.rs), every member of which renders a UTC `…Z` string (format_instant_ms, tools/cnf-runner/src/exec/resolve.rs) — there is no offset-less rendering form, and the three members' ±1 ms / midpoint margins would not survive reinterpretation in an unknown SUT-local zone (the runner has no way to learn the SUT's system timezone, and ITS-REST exposes none). A literal offset-less string cannot stand in either: the instants a case must address are its own commit times, known only at run time. Closes when the temporal vocabulary gains an offset-less rendering member whose margin exceeds the ±14 h UTC-offset range (extension only by schedule release) — the same closed-vocabulary precedent as method-405-allow-header."
   # The System API (ITS-REST system, STABLE) — one operation, no SM anchor.
   - id: system-options-conformance-manifest
-    description: "OPTIONS on the API base path answers 200 and carries the Allow header, describing the communication options for that resource. That is the whole of the behaviour the released docs text assigns: the response BODY (the Options conformance manifest — solution/solution_version/vendor/restapi_specs_version/conformance_profile/endpoints) and the resource the operation is served on are described by no released sentence, so no expectation rests on them here."
-    source: "ITS-REST specifications/docs/system/Description.md §Status (\"This specification is in the `STABLE` state\") + docs/overview/Requests_and_responses.md §HTTP Methods (\"| OPTIONS | Describe the communication options for the target resource. |\", over RFC 9110, the authority that section names for method semantics) + §HTTP status codes (\"| 200 | OK | The request succeeded, payload sent in a 200 response depends on the request method |\" under \"an appropriate HTTP status code MUST be used as described above\"). The manifest members and the operation's path exist ONLY in the stalled OAS bundle, which is emit-rest codegen input and never a behavioural oracle (owner ruling 2026-07-24) — register AMB-160 carries that silence and its upstream report; the ITS-only anchor the case uses is register AMB-161."
+    description: "OPTIONS on the API base path answers 200 and carries the Allow header, describing the communication options for that resource — the docs-text half. The RESOURCE the operation is served on (`/`), the negotiated `Content-Type: application/json` and the JSON manifest body are grounded in the RELEASED OAS, which fills the docs text's silence here (owner ruling 2026-07-28). No MEMBER of the manifest is asserted: the Options schema declares none required, and an optional schema member is not a presence requirement."
+    source: "TIER 1, DOCS TEXT — ITS-REST specifications/docs/system/Description.md §Status (\"This specification is in the `STABLE` state\") + docs/overview/Requests_and_responses.md §HTTP Methods (\"| OPTIONS | Describe the communication options for the target resource. |\", over RFC 9110, the authority that section names for method semantics) + §HTTP status codes (\"| 200 | OK | The request succeeded, payload sent in a 200 response depends on the request method |\" under \"an appropriate HTTP status code MUST be used as described above\"). The System chapter is a stub and states no path, no field list and no media type. TIER 2, THE RELEASED OAS, citable because tier 1 is silent (owner ruling 2026-07-28) and cited AS the OAS: system.openapi.yaml `paths: /` (options) and its `200_options` response (headers Allow + ContentType_JSON; content application/json, schema `Options`, which declares NO required member — hence no member assertion). Register AMB-160 records the ruling's application and keeps the editorial upstream ask UPR-122; the ITS-only anchor the case uses is register AMB-161."
     covered_by: [I_ITS_REST_SYSTEM.options-conformance_manifest]
   # HTTP-method discipline (ITS-REST Requests_and_responses.md §HTTP Methods).
   - id: method-405-allow-header
@@ -1401,11 +1413,11 @@ elements:
   # §Prefer minimal, identifier or full representation response).
   - id: header-prefer-return-minimal
     description: "Prefer: return=minimal — and the assumed default when no Prefer is sent — answers a minimal response pointing at the affected resource through Location rather than returning its representation."
-    source: "ITS-REST Requests_and_responses.md §Prefer minimal, identifier or full representation response (\"`Prefer: return=minimal` Indicates the client prefers a minimal response. The response SHOULD include a `Location` header pointing to the newly created or updated resource. The HTTP status is typically `201 Created`. If no response body is returned, the service SHOULD use `204 No Content`\") + §Representation details negotiation (\"If no `Prefer` header is provided, the default behavior is assumed to be `return=minimal`\")"
+    source: "TIER 1, DOCS TEXT — ITS-REST Requests_and_responses.md §Prefer minimal, identifier or full representation response (\"`Prefer: return=minimal` Indicates the client prefers a minimal response. The response SHOULD include a `Location` header pointing to the newly created or updated resource. The HTTP status is typically `201 Created`. If no response body is returned, the service SHOULD use `204 No Content`\") + §Representation details negotiation (\"If no `Prefer` header is provided, the default behavior is assumed to be `return=minimal`\") — two sentences that between them settle no status. TIER 2, THE RELEASED OAS, citable because tier 1 states both and assigns neither (owner ruling 2026-07-28) and cited AS the OAS: the CREATE operations declare exactly one success status and their response files close \"If the `Prefer` header is missing or set to `return=minimal`, the body is empty\" (responses/201_COMPOSITION.yaml, 201_PERSON.yaml, 201_Template_adl1_4_upload.yaml, 201_Template_adl2_upload.yaml), while the UPDATE operations declare 200 and 204 and split them by preference — responses/204_version_updated.yaml, \"`204 No Content` is returned when the update operation was successful and the `Prefer` header is missing or is set to `return=minimal`\". Register AMB-62"
     exception:
       reason: coverage_gap
       register: AMB-62
-      note: "NEW-CASE candidate, but not authorable as a gating case today, and NOT authorable with an alt_status either: the released text leaves the minimal status OPEN — \"The HTTP status is typically `201 Created`\" is descriptive (an adverb, not a MUST or a SHOULD) and \"If no response body is returned, the service SHOULD use `204 No Content`\" is conditional on a body-presence fact the same text never assigns. A binding outcome would have to pick a status, or assemble a {201, 204} alt_status pair, that no docs-text sentence assigns — exactly the invention the attribution law forbids — so the branch carries no binding at all (re-affirmed under #428, which considered and rejected the alt_status route). Registered as AMB-62. What IS assertable is already executed: the `Location` header the minimal branch SHOULDs, on the create/update outcomes (header-location-on-create), and the body selector `prefer_conditional` deliberately never judges this branch. Closes when a future ITS-REST release fixes the minimal status, or when the case model gains an either-status expectation grounded in the two sentences (extension only by schedule release). The default-when-absent half is exercised indirectly: the I_DEFINITION_ADL2.upload_artefact binding sends no Prefer and reads its identifier back from Location. The SIBLING preference is fully covered — §\"Prefer only identifier\" DOES assign its status, and header-prefer-return-identifier carries a case on both a COMPOSITION and an EHR create."
+      note: "A GENUINE COVERAGE GAP since 2026-07-28, no longer an unassertable branch. AMB-62's former position — that no status could be asserted, and that even an alt_status pair would be invention (the reasoning #428 acted on) — rested on reading only the docs text; under the OAS-fallback order the released response files ASSIGN the branch per operation family, 201-with-an-empty-body on a create and 204 on an update. So a binding outcome and a gating case are now authorable and are simply MISSING on the COMPOSITION / EHR_STATUS / DIRECTORY / PARTY / CONTRIBUTION writes. NEW-CASE candidates, one behaviour each: a create sent with `Prefer: return=minimal` (201, empty body, Location present) and an update sent the same way (204). Already covered on the two template uploads, whose operation-level 201 text AMB-110(b) had read this way before the ruling generalized it: I_DEFINITION_ADL14.upload_opt-prefer_minimal and I_DEFINITION_ADL2.upload_artefact-prefer_minimal. What is separately executed: the `Location` header the minimal branch SHOULDs, on the create outcomes (header-location-on-create); the default-when-absent half indirectly, the I_DEFINITION_ADL2.upload_artefact binding sending no Prefer and reading its identifier back from Location; and the body selector `prefer_conditional` still deliberately does not judge this branch. The SIBLING preference is fully covered — §\"Prefer only identifier\" assigns its status in the docs text itself, and header-prefer-return-identifier carries a case on both a COMPOSITION and an EHR create. This exception RETIRES when the missing cases land."
   # Version-at-time semantics (RM common versioned_object.adoc; the wire form
   # in ITS-REST Resources.md §Datetime format).
   - id: version-at-time-extancy-branches

--- a/tools/cnf-runner/party/ehrbase-java/statement.json
+++ b/tools/cnf-runner/party/ehrbase-java/statement.json
@@ -51,7 +51,6 @@
     }
   ],
   "options": [
-    "adl14-duplicate-conflict",
     "contribution-xml-unsupported",
     "directory-empty-error",
     "directory-xml-supported",
@@ -59,7 +58,7 @@
     "ehr-xml-supported"
   ],
   "non_functional": {
-    "note": "First-cut ICS for the CNF comparison re-base (#232), derived from the EHRbase 2.x documented surface: ADL 1.4 OPT provisioning only (no ADL 2 endpoints), no demographic/messaging/EHR-extract services, Basic auth with one clinical + one admin principal (no readonly role \u2014 the ixit declares no readonly instance), SimplifiedFormats UNCLAIMED: measured 2026-07-22, the /openehr/v1 composition endpoint answers 415 to the ITS-REST 1.1.0 media types (application/openehr.wt.flat+json / wt.structured+json) and accepts only the deprecated .schema+json names \u2014 the ITS-REST simplified wire is not implemented. Option selections (duplicate-template 409 via SYSTEM_ALLOWTEMPLATEOVERWRITE=false; directory-empty-error) are configuration-pinned by docker/sut-ehrbase-java.yml. The canonical-XML family options (AMB-167) carry forward the posture this ICS already implied before those rows became option-gated \u2014 the EHR / EHR_STATUS / directory XML rows were judged as served and the CONTRIBUTION read rows as refused \u2014 with no new claim made; the party family is not declared because PartyOperations is not claimed. Every claim is refined by the measured run \u2014 the published verdicts, not this file, are the record."
+    "note": "First-cut ICS for the CNF comparison re-base (#232), derived from the EHRbase 2.x documented surface: ADL 1.4 OPT provisioning only (no ADL 2 endpoints), no demographic/messaging/EHR-extract services, Basic auth with one clinical + one admin principal (no readonly role \u2014 the ixit declares no readonly instance), SimplifiedFormats UNCLAIMED: measured 2026-07-22, the /openehr/v1 composition endpoint answers 415 to the ITS-REST 1.1.0 media types (application/openehr.wt.flat+json / wt.structured+json) and accepts only the deprecated .schema+json names \u2014 the ITS-REST simplified wire is not implemented. Option selection (directory-empty-error) is configuration-pinned by docker/sut-ehrbase-java.yml, as is SYSTEM_ALLOWTEMPLATEOVERWRITE=false — no longer an option selection since the 2026-07-28 re-adjudication of AMB-4 made the duplicate-template 409 a gating expectation for every server, but still the setting this SUT needs in order to meet it. The canonical-XML family options (AMB-167) carry forward the posture this ICS already implied before those rows became option-gated \u2014 the EHR / EHR_STATUS / directory XML rows were judged as served and the CONTRIBUTION read rows as refused \u2014 with no new claim made; the party family is not declared because PartyOperations is not claimed. Every claim is refined by the measured run \u2014 the published verdicts, not this file, are the record."
   },
   "evidence": []
 }

--- a/tools/cnf-runner/party/ehrbase-rs/statement.json
+++ b/tools/cnf-runner/party/ehrbase-rs/statement.json
@@ -74,7 +74,6 @@
     }
   ],
   "options": [
-    "adl14-duplicate-conflict",
     "adl14-partial-id-exact",
     "contribution-xml-unsupported",
     "directory-empty-error",


### PR DESCRIPTION
Closes #556.

All 136 register entries re-adjudicated first-hand under the 2026-07-28 oracle order. **9 changed, 127 stand verified** (the full verdict table is in the commit messages):

- **Two entries stop excusing behaviour the release actually defines**: AMB-4 (the OAS's 409 trigger is stated in the indicative — duplicate template upload now *gates*, the `adl14-duplicate-conflict`/`-replace` options withdrawn) and AMB-78 (the composition body-uid match rule is OAS-stated — the mismatch rejection now gates; only its 422 status stays adjudicated). Both behaviours already had executing cases; only the gating flag changed.
- **AMB-62 filled**: the minimal-`Prefer` status is per-family *released* (the 201/204 response files state the empty-body rule) — the old "no assertable status" position withdrawn, and `header-prefer-return-minimal` becomes a real coverage_gap naming the five-family NEW-CASE set (filed as a follow-up issue).
- **AMB-63 narrowed** (the subject-conflict key is released: "same subject id, namespace pair"), **five entries re-grounded** onto the correct oracle tier without verdict change.
- **UPR ledger reconciled**: the grounding-rules block rewritten for the order; UPR-01/40/122 re-scoped (their answered halves withdrawn, the surviving asks kept).

Cross-invariants verified: every `report_only`/`editorial` has its `upstream_ref`, every option/ambiguity link across 713 cases resolves, ledger↔register bijective. Gates: `validate` 709 cases / 202 bindings / 0 findings; 186/186 nextest. The zero-drift pipeline run lands with the wave batch.