### PR TITLE
test(cnf): #543 + #545 — the minimal-Prefer escape generalized; TemplateExamples split to OPTIONS

### DIFF
--- a/tools/cnf-runner/artifacts/registers/ambiguities.yaml
+++ b/tools/cnf-runner/artifacts/registers/ambiguities.yaml
@@ -2858,9 +2858,16 @@ AMB-110:
     201 text is specific to these two operations and states the outcome
     directly, while the SHOULD-204 sentence is a general default in the
     overview and a SHOULD in any case; the specific released statement governs.
-    That RESOLVES AMB-62's unassigned minimal status FOR THESE TWO OPERATIONS
-    ONLY — AMB-62 continues to govern every write whose operation text assigns
-    nothing. Gated by I_DEFINITION_ADL14.upload_opt-prefer_minimal and
+    SCOPE ADJUDICATED 2026-07-28 (#543): the specific-over-general reading is
+    NOT Definition-scoped — the same shape holds wherever an operation family's
+    own released response text assigns the minimal outcome, which the AMB-62
+    re-adjudication confirmed is EVERY write family (the creates' 201 files end
+    "If the `Prefer` header is missing or set to `return=minimal`, the body is
+    empty"; 204_version_updated.yaml covers the updates). AMB-62 now carries
+    the per-family assignment as the governing entry; this branch's two upload
+    cases are simply the first instances of the general rule, and the remaining
+    families' minimal-arm cases are the AMB-62 NEW-CASE set (tracked, #584).
+    Gated by I_DEFINITION_ADL14.upload_opt-prefer_minimal and
     I_DEFINITION_ADL2.upload_artefact-prefer_minimal; the sibling identifier
     preference by -prefer_identifier on both. Reported upstream (UPR-74): add
     the semantic-rejection status to both uploads, and reconcile the 201-empty
@@ -3084,19 +3091,17 @@ AMB-115:
     I_DEFINITION_ADL14.get_opt-example_invalid_detail_level gates for every
     server: a value outside the enum has no "closest supported level" to fall
     back to, which makes the fall-back branch unreachable there.
-    THE ONE RESIDUAL, recorded rather than hidden: the two cases that exercise
-    the declared non-default enum members
+    RESIDUAL RESOLVED (#545, 2026-07-28): example generation is its own
+    OPTIONS-tier capability (TemplateExamples — the CNF profiles book has no
+    example row, the operation NOTE disclaims the output, and this entry's
+    latitude exists), so the enum-member cases
     (I_DEFINITION_ADL14.get_opt-example_type_output and
-    -example_detail_levels) expect the request to be FULFILLED. That holds for
-    a server implementing the member and for one taking the FALL-BACK branch
-    (which also answers 200 with the closest level); the only permitted
-    configuration it would fail is a server that neither implements the member
-    nor falls back. Those cases carry no option tag because their capability
-    (Adl14OptProvisioning) is a CORE-tier capability and the case model ties
-    profiles to capability tier, so an OPTIONS scoping is not expressible for
-    them; the residual is therefore carried here instead of being silently
-    asserted away. It closes when the released text assigns the branch (UPR-79)
-    or the two enum members are made mandatory.
+    -example_detail_levels) and the out-of-enum 400 case now ride that row
+    and can never gate CORE. The residual permitted configuration (a server
+    that neither implements a member nor falls back) simply does not claim
+    TemplateExamples and is not judged by these rows. The upstream ask
+    stands: it closes when the released text assigns the branch (UPR-79) or
+    the two enum members are made mandatory.
     Reported upstream (UPR-79): assign the unsupported-value branch, and give
     the ADL2 operation the same prose as its ADL 1.4 twin.
   disposition: fixed_handling

--- a/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.get_opt-example_detail_levels.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.get_opt-example_detail_levels.yaml
@@ -23,8 +23,8 @@ id: I_DEFINITION_ADL14.get_opt-example_detail_levels
 kind: functional
 component: DEFINITION_ADL14
 sm_operation: I_DEFINITION_ADL14.get_opt
-capabilities: [Adl14OptProvisioning]
-profiles: [CORE]           # the tier of Adl14OptProvisioning (vocab/capability_matrix.yaml)
+capabilities: [TemplateExamples]
+profiles: [OPTIONS]        # the tier of TemplateExamples (#545: example generation never gates CORE)
 test_purpose: >-
   Both non-default detail levels of the template example (medium, complete) are
   fulfilled and return a COMPOSITION instance in the negotiated format.

--- a/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.get_opt-example_invalid_detail_level.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.get_opt-example_invalid_detail_level.yaml
@@ -26,8 +26,8 @@ id: I_DEFINITION_ADL14.get_opt-example_invalid_detail_level
 kind: functional
 component: DEFINITION_ADL14
 sm_operation: I_DEFINITION_ADL14.get_opt
-capabilities: [Adl14OptProvisioning]
-profiles: [CORE]           # the tier of Adl14OptProvisioning (vocab/capability_matrix.yaml)
+capabilities: [TemplateExamples]
+profiles: [OPTIONS]        # the tier of TemplateExamples (#545: example generation never gates CORE)
 test_purpose: >-
   A template-example request naming a detail_level outside the declared enum is
   refused as a client error rather than answered with a substituted level.

--- a/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.get_opt-example_type_output.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.get_opt-example_type_output.yaml
@@ -20,8 +20,8 @@ id: I_DEFINITION_ADL14.get_opt-example_type_output
 kind: functional
 component: DEFINITION_ADL14
 sm_operation: I_DEFINITION_ADL14.get_opt
-capabilities: [Adl14OptProvisioning]
-profiles: [CORE]           # the tier of Adl14OptProvisioning (vocab/capability_matrix.yaml)
+capabilities: [TemplateExamples]
+profiles: [OPTIONS]        # the tier of TemplateExamples (#545: example generation never gates CORE)
 test_purpose: >-
   Requesting an output-type template example is fulfilled and returns a
   COMPOSITION instance in the negotiated format.

--- a/tools/cnf-runner/artifacts/vocab/capability_matrix.yaml
+++ b/tools/cnf-runner/artifacts/vocab/capability_matrix.yaml
@@ -7,6 +7,14 @@ Adl14ArchetypeProvisioning: { family: Platform, tier: CORE, required: true, sour
 Adl14OptProvisioning: { family: Platform, tier: CORE, required: true, source: "CNF profiles master03-profiles.adoc §Functional (Definitions: ADL 1.4 OPT provisioning)" }
 Adl2ArchetypeProvisioning: { family: Platform, tier: OPTIONS, required: false, source: "CNF profiles master03-profiles.adoc §Functional (Definitions: ADL 2 Archetype provisioning)" }
 Adl2OptProvisioning: { family: Platform, tier: OPTIONS, required: false, source: "CNF profiles master03-profiles.adoc §Functional (Definitions: ADL 2 OPT provisioning)" }
+# Example generation split from OPT provisioning (#545, 2026-07-28): the
+# /example sub-resource is SHOULD-level surface — the CNF profiles book has
+# no example row, the released operation NOTE disclaims the output
+# ("The implementation and completeness of these examples are not specified,
+# and vendors may produce different results"), and AMB-115 carries the
+# fall-back-or-400 latitude — so no CORE verdict may rest on it. Same
+# tier-by-analogy treatment as SimplifiedFormats/SystemApi.
+TemplateExamples: { family: Platform, tier: OPTIONS, required: false, source: "ITS-REST specifications/operations/definition_template_adl1.4_example_get.yaml NOTE + register AMB-115 (no CNF profiles row exists for example generation)" }
 QueryProvisioning: { family: Platform, tier: STANDARD, required: true, source: "CNF profiles master03-profiles.adoc §Functional (Definitions: Query provisioning)" }
 EhrOperations: { family: Platform, tier: CORE, required: true, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: EHR Operations)" }
 EhrStatus: { family: Platform, tier: CORE, required: true, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: EHR Status)" }

--- a/tools/cnf-runner/party/ehrbase-java/statement.json
+++ b/tools/cnf-runner/party/ehrbase-java/statement.json
@@ -17,6 +17,7 @@
     "capabilities": [
       "Adl14ArchetypeProvisioning",
       "Adl14OptProvisioning",
+      "TemplateExamples",
       "QueryProvisioning",
       "EhrOperations",
       "EhrStatus",
@@ -58,7 +59,7 @@
     "ehr-xml-supported"
   ],
   "non_functional": {
-    "note": "First-cut ICS for the CNF comparison re-base (#232), derived from the EHRbase 2.x documented surface: ADL 1.4 OPT provisioning only (no ADL 2 endpoints), no demographic/messaging/EHR-extract services, Basic auth with one clinical + one admin principal (no readonly role \u2014 the ixit declares no readonly instance), SimplifiedFormats UNCLAIMED: measured 2026-07-22, the /openehr/v1 composition endpoint answers 415 to the ITS-REST 1.1.0 media types (application/openehr.wt.flat+json / wt.structured+json) and accepts only the deprecated .schema+json names \u2014 the ITS-REST simplified wire is not implemented. Option selection (directory-empty-error) is configuration-pinned by docker/sut-ehrbase-java.yml, as is SYSTEM_ALLOWTEMPLATEOVERWRITE=false — no longer an option selection since the 2026-07-28 re-adjudication of AMB-4 made the duplicate-template 409 a gating expectation for every server, but still the setting this SUT needs in order to meet it. The canonical-XML family options (AMB-167) carry forward the posture this ICS already implied before those rows became option-gated \u2014 the EHR / EHR_STATUS / directory XML rows were judged as served and the CONTRIBUTION read rows as refused \u2014 with no new claim made; the party family is not declared because PartyOperations is not claimed. Every claim is refined by the measured run \u2014 the published verdicts, not this file, are the record."
+    "note": "First-cut ICS for the CNF comparison re-base (#232), derived from the EHRbase 2.x documented surface: ADL 1.4 OPT provisioning only (no ADL 2 endpoints), no demographic/messaging/EHR-extract services, Basic auth with one clinical + one admin principal (no readonly role \u2014 the ixit declares no readonly instance), SimplifiedFormats UNCLAIMED: measured 2026-07-22, the /openehr/v1 composition endpoint answers 415 to the ITS-REST 1.1.0 media types (application/openehr.wt.flat+json / wt.structured+json) and accepts only the deprecated .schema+json names \u2014 the ITS-REST simplified wire is not implemented. Option selection (directory-empty-error) is configuration-pinned by docker/sut-ehrbase-java.yml, as is SYSTEM_ALLOWTEMPLATEOVERWRITE=false \u2014 no longer an option selection since the 2026-07-28 re-adjudication of AMB-4 made the duplicate-template 409 a gating expectation for every server, but still the setting this SUT needs in order to meet it. The canonical-XML family options (AMB-167) carry forward the posture this ICS already implied before those rows became option-gated \u2014 the EHR / EHR_STATUS / directory XML rows were judged as served and the CONTRIBUTION read rows as refused \u2014 with no new claim made; the party family is not declared because PartyOperations is not claimed. Every claim is refined by the measured run \u2014 the published verdicts, not this file, are the record."
   },
   "evidence": []
 }

--- a/tools/cnf-runner/party/ehrbase-rs/statement.json
+++ b/tools/cnf-runner/party/ehrbase-rs/statement.json
@@ -19,6 +19,7 @@
       "Adl14OptProvisioning",
       "Adl2ArchetypeProvisioning",
       "Adl2OptProvisioning",
+      "TemplateExamples",
       "QueryProvisioning",
       "EhrOperations",
       "EhrStatus",


### PR DESCRIPTION
Closes #543. Closes #545.

- **#543**: AMB-110(b)'s escape (an operation family's own released response text assigns the minimal-`Prefer` status where the overview is general) is adjudicated **not Definition-scoped** — the #556 sweep's AMB-62 fill established the per-family assignment for every write family, so the escape *is* the general rule. Both register entries record the scope; the five-family minimal-arm case set is tracked (#584).
- **#545**: example generation splits to its own **OPTIONS-tier capability `TemplateExamples`** — no CNF profiles row exists for it, the released operation NOTE disclaims the output, and AMB-115's fall-back-or-400 latitude stands; a CORE verdict may not rest on the `/example` surface. The three tier-locked cases retag; AMB-115's residual resolves (a server taking neither branch simply doesn't claim the capability); both party statements claim it.

Gates: `validate` 709 cases / 0 findings, 186/186 nextest.