### PR TITLE
fix(flat): the three master05 divergences — ENTRY /subject, null-flavoured ELEMENTs, context path spellings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -290,6 +290,30 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **Three FLAT/STRUCTURED mapping gaps: an entry's subject, null-flavoured
+  elements, and the event-context paths** (#532, #533, #534). An entry's
+  `subject` now travels over the wire in both directions: a composition whose
+  OBSERVATION, EVALUATION, INSTRUCTION, ACTION or ADMIN_ENTRY names someone
+  other than the record subject emits `…/subject|name`, `…|id`,
+  `…|id_scheme`, `…|id_namespace` plus the `/_identifier:i` and
+  `/relationship` sub-paths, and the same keys are accepted on input —
+  previously the subject was dropped on the way out and rejected as an
+  unknown suffix on the way in, so the information was lost in both
+  directions. A "self" subject carrying an external reference is marked
+  `|_type: PARTY_SELF` so it comes back as itself rather than as an
+  identified party. Second, an element that records *why* a value is missing
+  (a null flavour, which the reference model makes mutually exclusive with
+  the value) now keeps `/_null_flavour` and `/_null_reason` through a full
+  round trip; the flattener reached elements only through their value, so a
+  null-flavoured element vanished entirely. Third, the event-context fields
+  the specification also spells as paths — `…/context/start_time` and
+  `…/context/setting` — are honoured on input instead of being silently
+  discarded in favour of the `ctx/` defaults, as are an entry's
+  `…/language` and `…/encoding`; a bare `…/context/setting|code` resolves
+  against the openEHR *setting* value set exactly as `ctx/setting` does.
+  Paths the specification does not define are still rejected with a clear
+  error rather than ignored.
+
 - **The SMART discovery endpoint is fully described in the published API
   reference** (#535): the `application/json` requirement, the required
   `org.openehr.rest` service with its absolute `baseUrl`, the

--- a/crates/openehr-its/src/flat/build.rs
+++ b/crates/openehr-its/src/flat/build.rs
@@ -269,32 +269,7 @@ fn build(
     let mut history_origin: Option<String> = None;
 
     for child in &node.children {
-        // Standard EVENT_CONTEXT fields come from ctx/ (master06); only the
-        // archetyped other_context content is tree data.
-        if node.rm_type == "EVENT_CONTEXT" && !child.aql_path.contains("other_context") {
-            continue;
-        }
-        // Composition-level in-context attributes arrive via ctx resolution
-        // (`ctx::resolve` also reads their path spellings). The `context`
-        // child IS built when path keys address it — archetyped
-        // `other_context` content and the `_`-attribute families
-        // (`_health_care_facility`, `_participation:i`, `_end_time`,
-        // `_location` — master05 §EVENT_CONTEXT) are tree data; the standard
-        // leaf fields (start_time/setting) still come from ctx/ (the
-        // EVENT_CONTEXT rule above) via `apply_composition_ctx`.
-        // `category` is real tree data (master05 §COMPOSITION) and builds.
-        if node.rm_type == "COMPOSITION"
-            && matches!(child.id.as_str(), "language" | "territory" | "composer")
-        {
-            continue;
-        }
-        // ENTRY-level `language`/`encoding` default from the composition context
-        // (master06 §"Language and Territory"); they are filled by
-        // `apply_entry_defaults`, never rebuilt from a per-entry path key (the
-        // synthesized CODE_PHRASE in-context nodes carry no leaf inputs). `subject`
-        // is NOT skipped — a non-`PARTY_SELF` subject is real data
-        // (master05 §OBSERVATION `/subject`) and builds as a leaf.
-        if is_entry_family(&node.rm_type) && matches!(child.id.as_str(), "language" | "encoding") {
+        if !child_is_walked(node, child) {
             continue;
         }
         let Some(sim_child) = sim.children.get(&child.id).or_else(|| {
@@ -328,10 +303,14 @@ fn build(
             )?;
             continue;
         }
-        let known = node
-            .children
-            .iter()
-            .any(|c| c.id == *seg || c.alt_json_id.as_deref() == Some(seg));
+        // Only a template child the walk above ACTUALLY processes counts as
+        // handled. A child the in-context routing skipped
+        // ([`child_is_walked`]) must fall through to the direct-RM-path
+        // fallback below, or its datum would be neither honoured nor
+        // rejected — the one outcome master04 §Validation forbids.
+        let known = node.children.iter().any(|c| {
+            (c.id == *seg || c.alt_json_id.as_deref() == Some(seg)) && child_is_walked(node, c)
+        });
         let ctx_covered = node.rm_type == "COMPOSITION"
             && matches!(
                 seg.as_str(),
@@ -398,6 +377,47 @@ fn is_null_flavoured(sim: &SimNode) -> bool {
             .is_some_and(|c| c.occurrences.iter().any(|o| !o.is_empty()))
 }
 
+/// Whether the template-child walk builds `child` from its own sim sub-tree.
+///
+/// Three in-context families are routed elsewhere and are therefore NOT walked:
+///
+/// * **EVENT_CONTEXT** standard fields (everything but archetyped
+///   `other_context` content) — `start_time`/`setting` come from the `ctx/`
+///   vocabulary (master06 §§time, setting) via `apply_composition_ctx`, and
+///   their master05 §EVENT_CONTEXT PATH spellings are honoured by
+///   [`direct_rm_path`].
+/// * **COMPOSITION** `language`/`territory`/`composer` — resolved through
+///   `ctx::resolve`, which reads their path spellings too
+///   (`merge_root_ctx_spellings`). The `context` child itself IS walked: its
+///   archetyped `other_context` content and `_`-attribute families
+///   (`_health_care_facility`, `_participation:i`, `_end_time`, `_location` —
+///   master05 §EVENT_CONTEXT) are tree data, and `category` is real tree data
+///   (master05 §COMPOSITION).
+/// * **ENTRY** `language`/`encoding` — defaulted from the composition context
+///   (master06 §"Language and Territory") by `apply_entry_defaults`; the
+///   master05 ENTRY-table `/language` path spelling is honoured by
+///   [`direct_rm_path`]. `subject` is NOT in this set — a non-`PARTY_SELF`
+///   subject is real data (master05 §OBSERVATION `/subject`) and builds as a
+///   PARTY_PROXY leaf.
+///
+/// A skipped child's identifier must never be treated as "already handled" by
+/// the datum loop: every non-walked spelling either reaches [`direct_rm_path`]
+/// or is rejected as an unknown path (master04 §Validation).
+fn child_is_walked(node: &WebTemplateNode, child: &WebTemplateNode) -> bool {
+    if node.rm_type == "EVENT_CONTEXT" && !child.aql_path.contains("other_context") {
+        return false;
+    }
+    if node.rm_type == "COMPOSITION"
+        && matches!(child.id.as_str(), "language" | "territory" | "composer")
+    {
+        return false;
+    }
+    if is_entry_family(&node.rm_type) && matches!(child.id.as_str(), "language" | "encoding") {
+        return false;
+    }
+    true
+}
+
 /// An interval assembled from bound CHILDREN (a WT tree whose
 /// `lower`/`upper` are their own nodes — vs the leaf form
 /// `map::build_interval` covers) must still carry the four boundary flags:
@@ -435,6 +455,15 @@ enum DirectPath {
     /// `current_state`/`transition`/`careflow_step` + `_reason:i` sub-tree
     /// (master05 §ISM_TRANSITION).
     Ism,
+    /// A `DV_CODED_TEXT` attribute whose master05 row binds it to an openEHR
+    /// terminology group in its Note column, so a bare `|code` resolves its
+    /// rubric from the bundle instead of standing as a `local` code.
+    CodedGroup {
+        /// The RM attribute name the value is inserted under.
+        attr: &'static str,
+        /// The openEHR terminology group id the row's ValueSet names.
+        group: &'static str,
+    },
     /// `ACTIVITY.action_archetype_id` — a plain-String RM field
     /// (master05 §ACTIVITY).
     ActionArchetypeId,
@@ -446,8 +475,26 @@ enum DirectPath {
 /// The direct RM-attribute path (if any) named by `seg` on a node of base RM
 /// type `host`, per the master05 per-type mapping tables.
 fn direct_rm_path(host: &str, seg: &str) -> Option<DirectPath> {
-    use DirectPath::{ActionArchetypeId, HistoryOrigin, Ism, Leaf};
+    use DirectPath::{ActionArchetypeId, CodedGroup, HistoryOrigin, Ism, Leaf};
     Some(match (host, seg) {
+        // master05 §§ADMIN_ENTRY, INSTRUCTION, ACTION, EVALUATION, OBSERVATION
+        // `/language` (CODE_PHRASE → `language`). Output takes the master06
+        // §"Language and Territory" `ctx/language` route, so the template child
+        // is not walked ([`child_is_walked`]) — the table's PATH spelling is
+        // honoured here instead of being ignored.
+        (_, "language") if is_entry_family(host) => Leaf {
+            attr: "language",
+            rm_type: "CODE_PHRASE",
+        },
+        // `/encoding` has no row of its own in any ENTRY table (an editorial
+        // hole — RM ehr §ENTRY declares `encoding` 1..1), but the master05
+        // §COMPOSITION example block spells
+        // `…/conformance_observation/encoding|code`, so the same path form is
+        // accepted for it.
+        (_, "encoding") if is_entry_family(host) => Leaf {
+            attr: "encoding",
+            rm_type: "CODE_PHRASE",
+        },
         // master05 §§ACTION, POINT_EVENT, INTERVAL_EVENT: `/time` (DV_DATE_TIME)
         // is addressable on the ACTION and on every EVENT concrete type.
         ("ACTION" | "POINT_EVENT" | "INTERVAL_EVENT" | "EVENT", "time") => Leaf {
@@ -478,16 +525,18 @@ fn direct_rm_path(host: &str, seg: &str) -> Option<DirectPath> {
             attr: "math_function",
             rm_type: "DV_CODED_TEXT",
         },
-        // master05 §EVENT_CONTEXT: `/start_time` (DV_DATE_TIME), `/setting`
-        // (DV_CODED_TEXT). Normally supplied via the `ctx/` vocabulary
-        // (master06); accepted as path keys here for the master05 path form.
+        // master05 §EVENT_CONTEXT: `/start_time` (DV_DATE_TIME) and `/setting`
+        // (DV_CODED_TEXT, Note column "ValueSet (openEHR `setting` group)").
+        // Output takes the master06 §§time, setting `ctx/` route, so neither
+        // template child is walked ([`child_is_walked`]) — the table's PATH
+        // spellings are honoured here instead of being ignored.
         ("EVENT_CONTEXT", "start_time") => Leaf {
             attr: "start_time",
             rm_type: "DV_DATE_TIME",
         },
-        ("EVENT_CONTEXT", "setting") => Leaf {
+        ("EVENT_CONTEXT", "setting") => CodedGroup {
             attr: "setting",
-            rm_type: "DV_CODED_TEXT",
+            group: "setting",
         },
         _ => return None,
     })
@@ -567,6 +616,31 @@ fn place_direct_rm_path(
                 && !obj.contains_key(attr)
             {
                 let value = map::build_leaf(node, rm_type, None, &sub_path)?;
+                obj.insert(attr.to_owned(), value);
+            }
+        }
+        DirectPath::CodedGroup { attr, group } => {
+            if let Some(node) = occ
+                && !obj.contains_key(attr)
+            {
+                // A bare `|code` binds to the row's openEHR terminology group,
+                // resolving its rubric exactly as the equivalent `ctx/`
+                // shortcut does (master06 §setting: "either value or code is
+                // accepted"). Once the client spells out `|value` or
+                // `|terminology`, the datum parts stand as given
+                // (master05 §DV_CODED_TEXT).
+                let bound = node
+                    .attrs
+                    .get("code")
+                    .and_then(Value::as_str)
+                    .filter(|_| {
+                        !node.attrs.contains_key("value") && !node.attrs.contains_key("terminology")
+                    })
+                    .map(|code| map::coded_from_group(group, code));
+                let value = match bound {
+                    Some(v) => v,
+                    None => map::build_leaf(node, "DV_CODED_TEXT", None, &sub_path)?,
+                };
                 obj.insert(attr.to_owned(), value);
             }
         }

--- a/crates/openehr-its/src/flat/build.rs
+++ b/crates/openehr-its/src/flat/build.rs
@@ -93,7 +93,7 @@ pub fn build_composition(
     collect_slot_types(&wt.tree, &mut slot_types);
 
     let mut comp = match build(&wt.tree, data_root, root_id, &slot_types)? {
-        Value::Object(m) => m,
+        Some(Value::Object(m)) => m,
         _ => Map::new(),
     };
     finish_identity(&mut comp, &wt.tree, true, &wt.template_id);
@@ -230,13 +230,22 @@ fn wrapper_types(
 /// Build the RM value for `node` from the simplified occurrence `sim`.
 /// `path` is the printed simplified path (diagnostics); `slots` is the template's
 /// hoisted-wrapper type map (see [`build_composition`]).
+///
+/// `Ok(None)` means the occurrence builds **no value**: a leaf that carries no
+/// datum part, only the `/_null_flavour` (+ `/_null_reason`) rows of master05
+/// §ELEMENT. RM data_structures §ELEMENT (`Inv_null_flavour_indicated`) makes
+/// `value` and `null_flavour` mutually exclusive, so the wrapping ELEMENT is
+/// still materialised — carrying the null flavour and no `value`.
 fn build(
     node: &WebTemplateNode,
     sim: &SimNode,
     path: &str,
     slots: &[(Vec<PathSegment>, String)],
-) -> Result<Value, FlatError> {
+) -> Result<Option<Value>, FlatError> {
     if node.has_input() {
+        if is_null_flavoured(sim) {
+            return Ok(None);
+        }
         let mut dv = map::build_leaf(sim, base_type(&node.rm_type), Some(node), path)?;
         // Value-level `_` attributes (`_normal_range`, `_mapping`,
         // `_accuracy`, `_language`, …) attach to the DV value itself;
@@ -249,7 +258,7 @@ fn build(
                 }
             }
         }
-        return Ok(dv);
+        return Ok(Some(dv));
     }
 
     let mut obj = Map::new();
@@ -356,7 +365,7 @@ fn build(
     // master05 per-type tables place on a container; anything else is an
     // unknown suffix.
     if let Some(raw) = sim.attrs.get("raw") {
-        return build_raw(raw, path);
+        return build_raw(raw, path).map(Some);
     }
     apply_container_datum_attrs(node, sim, path, &mut obj)?;
 
@@ -373,7 +382,20 @@ fn build(
         }
         apply_interval_flags(m, &node.rm_type);
     }
-    Ok(value)
+    Ok(Some(value))
+}
+
+/// Whether a leaf occurrence expresses a **value-less** ELEMENT: no datum part
+/// of its own, and a `/_null_flavour` family (master05 §ELEMENT). RM
+/// data_structures §ELEMENT `Inv_null_flavour_indicated` makes `value` and
+/// `null_flavour` mutually exclusive, so this is the only shape in which a
+/// null flavour can legitimately reach the builder.
+fn is_null_flavoured(sim: &SimNode) -> bool {
+    sim.attrs.is_empty()
+        && sim
+            .children
+            .get("_null_flavour")
+            .is_some_and(|c| c.occurrences.iter().any(|o| !o.is_empty()))
 }
 
 /// An interval assembled from bound CHILDREN (a WT tree whose
@@ -643,10 +665,16 @@ fn apply_rm_attr(
 /// Insert `child_value` into `parent` at the relative RM path `rel`,
 /// re-materialising the collapsed structural nodes it passes through
 /// (`master04 §Level Removal`).
+///
+/// A `None` `child_value` is a value-less null-flavoured ELEMENT (see
+/// [`build`]): the collapsed wrapper chain is still re-materialised and the
+/// ELEMENT's own `_`-attribute family applied, but no `value` is inserted
+/// (master05 §ELEMENT; RM data_structures §ELEMENT
+/// `Inv_null_flavour_indicated`).
 fn place(
     parent: &mut Map<String, Value>,
     rel: &[PathSegment],
-    child_value: Value,
+    child_value: Option<Value>,
     child: &WebTemplateNode,
     occ: &SimNode,
     path: &str,
@@ -681,7 +709,7 @@ fn place_rec(
     rel: &[PathSegment],
     i: usize,
     id_idx: Option<usize>,
-    child_value: Value,
+    child_value: Option<Value>,
     child: &WebTemplateNode,
     occ: &SimNode,
     path: &str,
@@ -701,7 +729,9 @@ fn place_rec(
         let Some(arr) = arr else { return Ok(()) };
         if last {
             // The child value is itself the array element (a container child).
-            let mut el = child_value;
+            let Some(mut el) = child_value else {
+                return Ok(());
+            };
             set_node_id(&mut el, node_id);
             arr.push(el);
         } else {
@@ -768,7 +798,9 @@ fn place_rec(
     // A single-valued (object) attribute.
     if last {
         let wraps_element = seg.attribute == "value";
-        cur.insert(seg.attribute.clone(), child_value);
+        if let Some(child_value) = child_value {
+            cur.insert(seg.attribute.clone(), child_value);
+        }
         if wraps_element {
             // The map receiving `value` is the compacted-away ELEMENT
             // wrapper; apply its `_` attribute family (master05 §ELEMENT).

--- a/crates/openehr-its/src/flat/example.rs
+++ b/crates/openehr-its/src/flat/example.rs
@@ -42,8 +42,10 @@
 //! choices here (fixed instants, first coded value, range-clamped magnitudes) are
 //! ours; only the mandatory-skeleton-is-committable contract of the `required`
 //! level is load-bearing (verified by the composition validator in the crate tests).
-//! Reachable-in-content `PARTY_*` value leaves are skipped rather than fabricated
-//! (they carry no FLAT round-trip shape); they are almost always optional.
+//! Reachable-in-content `PARTY_*` value leaves are skipped rather than fabricated:
+//! they are almost always optional, an `ENTRY.subject` left unset defaults to
+//! PARTY_SELF (master05 §OBSERVATION `/subject` row Note), and a party invented
+//! here would put a fictitious identified person into an example document.
 
 use std::collections::HashSet;
 
@@ -422,9 +424,11 @@ fn emit_leaf(node: &WebTemplateNode, base: &str, out: &mut Map<String, Value>) -
             put(out, base, "", json!(value));
             put(out, base, "formalism", json!(formalism));
         }
-        // PARTY_PROXY / PARTY_IDENTIFIED value leaves carry no FLAT round-trip
-        // shape (they are rebuilt from `ctx/…`, not tree data); skip rather than
-        // fabricate an incomplete party. See the module NOTE.
+        // PARTY_PROXY / PARTY_IDENTIFIED value leaves are skipped rather than
+        // fabricated: an unset `ENTRY.subject` defaults to PARTY_SELF and a
+        // `COMPOSITION.composer` comes from `ctx/composer_*`, so inventing a
+        // named party here would put a fictitious person in the example.
+        // See the module NOTE.
         _ => return false,
     }
     true

--- a/crates/openehr-its/src/flat/flatten.rs
+++ b/crates/openehr-its/src/flat/flatten.rs
@@ -139,7 +139,6 @@ fn walk(node: &WebTemplateNode, rm: &Value, out: &mut SimNode) {
             continue;
         }
         let rel = rmpath::relative(&node.aql_path, &child.aql_path);
-        let matches = rmpath::resolve(rm, &rel);
         // Polymorphic choice alternatives share one aqlPath; emit only under
         // the alternative whose rm type matches this value's `_type`. The
         // filter must apply to EVERY member of a choice group — the first
@@ -150,39 +149,121 @@ fn walk(node: &WebTemplateNode, rm: &Value, out: &mut SimNode) {
                 .children
                 .iter()
                 .any(|c| c.id != child.id && c.aql_path == child.aql_path);
-        let matches: Vec<&Value> = if in_choice {
-            matches
-                .into_iter()
-                .filter(|m| type_matches(m, &child.rm_type))
-                .collect()
-        } else {
-            matches
-        };
-        if matches.is_empty() {
+        let occurrences = occurrences_of(child, rm, &rel, in_choice);
+        if occurrences.is_empty() {
             continue;
         }
         let repeating = child.max == -1 || child.max > 1;
         if repeating {
             out.children.entry(child.id.clone()).or_default().indexed = true;
         }
-        for (i, m) in matches.iter().enumerate() {
-            if is_default_entry_context(child, m) {
+        for (i, occurrence) in occurrences.iter().enumerate() {
+            if occurrence
+                .value
+                .is_some_and(|v| is_default_entry_context(child, v))
+            {
                 continue;
             }
             let slot = out.place_mut(&child.id, u32::try_from(i).unwrap_or(u32::MAX));
-            walk(child, m, slot);
+            if let Some(value) = occurrence.value {
+                walk(child, value, slot);
+            }
             // The leaf's wrapping ELEMENT carries its own `_` attribute
             // family (`master05 §ELEMENT`: `_uid`, `_null_flavour`,
             // `_null_reason`, `_link:i`, `_feeder_audit`); the leaf walk
             // above saw only the DV value, so surface the wrapper's here.
-            if child.has_input()
-                && let Some(element) = element_of(rm, &rel, i)
-            {
+            if let Some(element) = occurrence.element {
                 map::emit_rm_attrs(element, "ELEMENT", slot);
             }
         }
     }
     emit_direct_rm_paths(node, rm, out);
+}
+
+/// One emitted occurrence of a template child: the RM value its relative path
+/// reaches, plus the wrapping `ELEMENT` when the child is an ELEMENT-wrapped
+/// leaf (the wrapper owns the `master05 §ELEMENT` `_`-attribute rows, which
+/// belong on the same simplified node as the datum).
+struct Occurrence<'a> {
+    /// `None` for a **value-less** ELEMENT. RM data_structures §ELEMENT
+    /// (`Inv_null_flavour_indicated`: `is_null() xor null_flavour = Void`)
+    /// makes `value` and `null_flavour` mutually exclusive, so a
+    /// null-flavoured element carries no datum at all — only the
+    /// `/_null_flavour` and `/_null_reason` rows of master05 §ELEMENT.
+    value: Option<&'a Value>,
+    element: Option<&'a Value>,
+}
+
+/// The occurrences of template child `child` under RM value `rm`.
+///
+/// An ELEMENT-wrapped leaf (its relative RM path ends in the `value` step) is
+/// resolved through its **wrappers**, not through the values: the wrapper list
+/// is the authoritative occurrence list, so (a) a value-less null-flavoured
+/// ELEMENT is still reached (master05 §ELEMENT `/_null_flavour`,
+/// `/_null_reason`), and (b) wrapper↔value alignment holds even when only some
+/// wrappers carry a value. Every other child resolves straight to its values.
+fn occurrences_of<'a>(
+    child: &WebTemplateNode,
+    rm: &'a Value,
+    rel: &[openehr_rm::paths::PathSegment],
+    in_choice: bool,
+) -> Vec<Occurrence<'a>> {
+    let Some(wrappers) = value_step_owners(child, rm, rel) else {
+        return rmpath::resolve(rm, rel)
+            .into_iter()
+            .filter(|value| !in_choice || type_matches(value, &child.rm_type))
+            .map(|value| Occurrence {
+                value: Some(value),
+                element: None,
+            })
+            .collect();
+    };
+    wrappers
+        .into_iter()
+        .filter_map(|wrapper| {
+            let element = (wrapper.get("_type").and_then(Value::as_str) == Some("ELEMENT"))
+                .then_some(wrapper);
+            match wrapper.get("value").filter(|v| !v.is_null()) {
+                Some(value) if !in_choice || type_matches(value, &child.rm_type) => {
+                    Some(Occurrence {
+                        value: Some(value),
+                        element,
+                    })
+                }
+                Some(_) => None,
+                // A value-less null-flavoured ELEMENT belongs to no particular
+                // alternative of a choice group: the alternatives share one
+                // aqlPath and the datum that would select one is exactly what
+                // is absent. It is emitted once, under the group's first
+                // alternative. NOTE: no openEHR spec governs a null-flavoured
+                // choice — our own design/extension, chosen so the null flavour
+                // is neither duplicated across alternatives nor dropped.
+                None => (element
+                    .is_some_and(|e| e.get("null_flavour").is_some_and(|v| !v.is_null()))
+                    && (!in_choice || child.alt_json_id.is_none()))
+                .then_some(Occurrence {
+                    value: None,
+                    element,
+                }),
+            }
+        })
+        .collect()
+}
+
+/// The RM nodes that own the final `value` step of an ELEMENT-wrapped leaf —
+/// `Some` only when `child` is a datum leaf whose relative RM path ends in
+/// `value`. `None` selects the plain value-driven resolution (a leaf reached
+/// without a wrapper, e.g. `EVENT.time`, or a container child).
+fn value_step_owners<'a>(
+    child: &WebTemplateNode,
+    rm: &'a Value,
+    rel: &[openehr_rm::paths::PathSegment],
+) -> Option<Vec<&'a Value>> {
+    if !child.has_input() {
+        return None;
+    }
+    let (last, parents) = rel.split_last()?;
+    (last.attribute == "value").then(|| rmpath::resolve(rm, parents))
 }
 
 /// Whether the template-child walk already emitted a child that realizes RM
@@ -296,23 +377,6 @@ fn emit_ism_transition(ism: &Value, out: &mut SimNode) {
         }
     }
     map::emit_rm_attrs(ism, "ISM_TRANSITION", out);
-}
-
-/// The ELEMENT wrapper that owns the `i`-th leaf value reached by `rel`
-/// (`rel` ends in the `value` attribute step for ELEMENT-wrapped leaves;
-/// non-wrapped leaves — e.g. `EVENT.time` — have none).
-fn element_of<'a>(
-    rm: &'a Value,
-    rel: &[openehr_rm::paths::PathSegment],
-    i: usize,
-) -> Option<&'a Value> {
-    let (last, parents) = rel.split_last()?;
-    if last.attribute != "value" {
-        return None;
-    }
-    let wrappers = rmpath::resolve(rm, parents);
-    let element = *wrappers.get(i)?;
-    (element.get("_type").and_then(Value::as_str) == Some("ELEMENT")).then_some(element)
 }
 
 /// The base (generic-stripped) RM type name.

--- a/crates/openehr-its/src/flat/map/data_values.rs
+++ b/crates/openehr-its/src/flat/map/data_values.rs
@@ -178,6 +178,15 @@ pub(super) fn emit_leaf(rm: &Value, rm_type: &str, list_open: Option<bool>, out:
         }
         // master05 §DV_IDENTIFIER — delegated to the party/identifier module.
         "DV_IDENTIFIER" => parties::emit_identifier(rm, out),
+        // master05 §PARTY_PROXY → §§PARTY_SELF, PARTY_IDENTIFIED,
+        // PARTY_RELATED: a PARTY_PROXY-typed leaf (`ENTRY.subject` —
+        // master05 §§ADMIN_ENTRY/INSTRUCTION/ACTION/EVALUATION/OBSERVATION
+        // `/subject` row) decomposes into the inlined
+        // `|name`/`|id`/`|id_scheme`/`|id_namespace` suffixes plus the
+        // `/_identifier:i` and `/relationship` sub-paths.
+        "PARTY_PROXY" | "PARTY_SELF" | "PARTY_IDENTIFIED" | "PARTY_RELATED" => {
+            parties::emit_party(rm, out);
+        }
         // master05 §DV_MULTIMEDIA: bare = `uri.value`, plus the attribute set;
         // `/_thumbnail`, `/_charset`, `/_language` are `_`-attribute sub-paths.
         "DV_MULTIMEDIA" => emit_multimedia(rm, out),
@@ -494,6 +503,14 @@ fn build_core(
         "DV_DATE_TIME" | "DV_DATE" | "DV_TIME" => build_amount_temporal(node, base, false),
         "DV_URI" | "DV_EHR_URI" => bare_typed(node, base),
         "DV_IDENTIFIER" => Some(parties::build_identifier(node)),
+        // master05 §PARTY_PROXY → the three subtype tables. `PERSON` is the
+        // `PARTY_REF.type` used when the datum carries an `|id` but no
+        // explicit reference type: the carriers of a PARTY_PROXY leaf
+        // (`ENTRY.subject`, `COMPOSITION.composer`) reference a person, and
+        // the master05 tables define no flat row for `external_ref.type`.
+        "PARTY_PROXY" | "PARTY_SELF" | "PARTY_IDENTIFIED" | "PARTY_RELATED" => {
+            Some(parties::build_party(node, "PERSON"))
+        }
         "DV_MULTIMEDIA" => build_multimedia(node),
         "DV_PARSABLE" => build_parsable(node),
         "DV_INTERVAL" => Some(build_interval(

--- a/crates/openehr-its/src/flat/map/mod.rs
+++ b/crates/openehr-its/src/flat/map/mod.rs
@@ -312,6 +312,15 @@ fn is_known_suffix(base: &str, suffix: &str) -> bool {
         "DV_SCALE" => &["code", "value", "scale", "terminology"],
         "DV_DATE" | "DV_DATE_TIME" | "DV_TIME" => &["magnitude_status", "normal_status"],
         "DV_IDENTIFIER" => &["id", "issuer", "assigner", "type"],
+        // master05 §§PARTY_SELF, PARTY_IDENTIFIED, PARTY_RELATED — the three
+        // PARTY_PROXY subtype tables share `|id`/`|id_scheme`/`|id_namespace`
+        // and PARTY_IDENTIFIED/PARTY_RELATED add `|name`. `_type` is the
+        // PARTY_SELF discriminator (master05 §FEEDER_AUDIT_DETAILS `/subject`
+        // row Note: "add /subject|_type: PARTY_SELF"); the `/_identifier:i`
+        // and `/relationship` rows are sub-paths, not suffixes.
+        "PARTY_PROXY" | "PARTY_SELF" | "PARTY_IDENTIFIED" | "PARTY_RELATED" => {
+            &["name", "id", "id_scheme", "id_namespace", "_type"]
+        }
         "DV_PARSABLE" => &["value", "formalism"],
         "DV_MULTIMEDIA" => &[
             "mediatype",

--- a/crates/openehr-its/src/flat/map/parties.rs
+++ b/crates/openehr-its/src/flat/map/parties.rs
@@ -109,7 +109,18 @@ pub(super) fn build_object_ref(node: &SimNode) -> Option<Value> {
 /// PARTY_PROXY (`PARTY_SELF`/`PARTY_IDENTIFIED`/`PARTY_RELATED`) → inlined
 /// `|name`/`|id`/`|id_scheme`/`|id_namespace` attrs on `out`, plus `_identifier:i`
 /// (PARTY_IDENTIFIED) and a `/relationship` DV_CODED_TEXT child (PARTY_RELATED).
+///
+/// The three subtype tables (master05 §§PARTY_SELF, PARTY_IDENTIFIED,
+/// PARTY_RELATED) share the `|id`/`|id_scheme`/`|id_namespace` rows, so the
+/// concrete subtype is carried by two discriminators: a `/relationship` child
+/// means PARTY_RELATED (master05 §PARTY_RELATED), and `|_type` marks a
+/// PARTY_SELF (master05 §FEEDER_AUDIT_DETAILS, `/subject` row Note: "add
+/// /subject|_type: PARTY_SELF"). Without the marker a PARTY_SELF would rebuild
+/// as a PARTY_IDENTIFIED, so it is emitted whenever the value is one.
 pub(super) fn emit_party(p: &Value, out: &mut SimNode) {
+    if p.get("_type").and_then(Value::as_str) == Some("PARTY_SELF") {
+        out.attrs.insert("_type".to_owned(), json!("PARTY_SELF"));
+    }
     if let Some(name) = p.get("name").filter(|v| !v.is_null()) {
         out.attrs.insert("name".to_owned(), name.clone());
     }

--- a/crates/openehr-its/tests/master05_tables.rs
+++ b/crates/openehr-its/tests/master05_tables.rs
@@ -49,14 +49,6 @@
 //! Known implementation gaps this battery documents (recorded here so a
 //! `TODO` search finds them, and asserted as `Absent` so they cannot rot):
 //!
-//! TODO: emit + consume the ENTRY `/subject` row (master05 §§ADMIN_ENTRY,
-//! INSTRUCTION, ACTION, EVALUATION, OBSERVATION — `subject`: PARTY_PROXY).
-//! The leaf datum codec has no PARTY arm, so a non-`PARTY_SELF` ENTRY subject
-//! is dropped on RM→FLAT and `…/subject|name` is rejected on FLAT→RM. The
-//! PARTY_PROXY suffix set itself is exercised here through its other carriers
-//! (`_health_care_facility`, `_participation:i`, the FEEDER_AUDIT_DETAILS
-//! parties).
-//!
 //! TODO: emit + rebuild the master05 §ELEMENT `/_null_flavour` and
 //! `/_null_reason` rows for a *value-less* ELEMENT. The flattener reaches an
 //! ELEMENT only through its `value`, but RM data_structures §ELEMENT
@@ -534,16 +526,31 @@ fn flat_entry_with(
     entry: Value,
     comp_extra: Value,
 ) -> Map<String, Value> {
-    let archetype = entry_archetype(rm_type);
+    let wt = entry_web_template(rm_type, children);
+    composition_to_flat(&entry_composition(rm_type, entry, comp_extra), &wt)
+        .expect("composition_to_flat")
+}
+
+/// The web template an ENTRY-family fixture flattens against: the root
+/// COMPOSITION carrying a single `entry` child of `rm_type` with `children`.
+/// Exposed separately so a test can drive the build direction against the very
+/// same tree.
+fn entry_web_template(rm_type: &str, children: Vec<WebTemplateNode>) -> WebTemplate {
     let mut node = container(rm_type, &entry_aql(rm_type), "entry");
-    node.node_id = Some(archetype.clone());
+    node.node_id = Some(entry_archetype(rm_type));
     node.children = children;
+    web_template(root_node(vec![node]))
+}
+
+/// The composition [`flat_entry_with`] flattens: `entry` stamped with the
+/// fixture's archetype identity and hung under the root's `content`.
+fn entry_composition(rm_type: &str, entry: Value, comp_extra: Value) -> Value {
     let mut entry = entry;
     merge(
         &mut entry,
-        json!({"archetype_node_id": archetype, "name": dv_text("Entry")}),
+        json!({"archetype_node_id": entry_archetype(rm_type), "name": dv_text("Entry")}),
     );
-    flatten(root_node(vec![node]), &composition(entry, comp_extra))
+    composition(entry, comp_extra)
 }
 
 /// The in-context ENTRY children every ENTRY-family fixture carries
@@ -808,15 +815,10 @@ fn entry_shared_rows() -> Vec<Row> {
             "Yes",
             "unenforceable: the row names an RM attribute that does not exist",
         ),
-        row(
-            "/subject",
-            Absent(
-                "implementation gap — see the module-level TODO: the flat leaf codec has no \
-                 PARTY arm, so an ENTRY subject is not emitted",
-            ),
-            "no",
-            "",
-        ),
+        // The row's Note ("will be set to PARTY_SELF if not explicitly set")
+        // is what keeps the default out of the emission: only a subject that
+        // is NOT the bare PARTY_SELF default is real data and emits.
+        row("/subject", At(Sub("|name")), "no", ""),
         row("/_work_flow_id", At(Sub("|id")), "no", ""),
         row("/_link:0", At(Sub("|type")), "no", ""),
         row(
@@ -1019,17 +1021,103 @@ fn master05_observation() {
     assert_entry_encoding_hole(&flat);
 }
 
+/// The `(template, FLAT)` pair for an EVALUATION whose ENTRY-level `subject`
+/// is `party` — the fixture behind the master05 ENTRY `/subject` row (typed
+/// `PARTY_PROXY`, so each of the three subtype tables reaches it).
+fn entry_subject_case(party: Value) -> (WebTemplate, Map<String, Value>) {
+    let wt = entry_web_template("EVALUATION", entry_in_context("EVALUATION"));
+    let entry = json!({"_type": "EVALUATION", "subject": party});
+    let comp = entry_composition("EVALUATION", entry, json!({}));
+    let flat = composition_to_flat(&comp, &wt).expect("composition_to_flat");
+    (wt, flat)
+}
+
+/// The rebuilt `subject` of the single ENTRY in a document built from `flat`.
+fn built_subject(wt: &WebTemplate, flat: &Map<String, Value>) -> Value {
+    let built =
+        composition_from_flat(flat, wt, NOW).expect("the master05 ENTRY `/subject` row must build");
+    built["content"][0]["subject"].clone()
+}
+
+/// master05 ENTRY `/subject` (PARTY_PROXY) in both directions, once per
+/// concrete subtype the section dispatches to (master05 §PARTY_PROXY: "See
+/// PARTY_SELF, PARTY_IDENTIFIED and PARTY_RELATED"). Each subtype must survive
+/// RM → FLAT → RM unchanged; the row's Note ("will be set to PARTY_SELF if not
+/// explicitly set") governs the default, which stays off the wire.
+#[test]
+fn master05_entry_subject_round_trips_every_party_subtype() {
+    // PARTY_IDENTIFIED — the `|name`/`|id`/`|id_scheme`/`|id_namespace` rows.
+    let subject = party_identified("Susan Doe", "199");
+    let (wt, flat) = entry_subject_case(subject.clone());
+    assert_eq!(flat[&format!("{ENTRY}/subject|name")], json!("Susan Doe"));
+    assert_eq!(flat[&format!("{ENTRY}/subject|id")], json!("199"));
+    assert_eq!(
+        flat[&format!("{ENTRY}/subject|id_scheme")],
+        json!("HOSPITAL-NS")
+    );
+    assert_eq!(
+        flat[&format!("{ENTRY}/subject|id_namespace")],
+        json!("HOSPITAL-NS")
+    );
+    assert_eq!(built_subject(&wt, &flat), subject);
+
+    // PARTY_RELATED — adds the `/relationship` DV_CODED_TEXT sub-path and the
+    // `/_identifier:i` family (master05 §PARTY_RELATED).
+    let mut subject = party_identified("Susan Doe", "199");
+    merge(
+        &mut subject,
+        json!({
+            "_type": "PARTY_RELATED",
+            "relationship": dv_coded("mother", "openehr", "10"),
+            "identifiers": [{"_type": "DV_IDENTIFIER", "id": "122", "issuer": "issuer"}],
+        }),
+    );
+    let (wt, flat) = entry_subject_case(subject.clone());
+    assert_eq!(
+        flat[&format!("{ENTRY}/subject/relationship|code")],
+        json!("10")
+    );
+    assert_eq!(
+        flat[&format!("{ENTRY}/subject/_identifier:0|id")],
+        json!("122")
+    );
+    assert_eq!(built_subject(&wt, &flat), subject);
+
+    // PARTY_SELF with an external reference — `|_type` is the discriminator
+    // (master05 §FEEDER_AUDIT_DETAILS `/subject` row Note); without it the
+    // rebuild would produce a PARTY_IDENTIFIED.
+    let subject = json!({
+        "_type": "PARTY_SELF",
+        "external_ref": {
+            "_type": "PARTY_REF", "namespace": "DEMOGRAPHIC", "type": "PERSON",
+            "id": {"_type": "GENERIC_ID", "value": "42", "scheme": "HOSPITAL-NS"},
+        },
+    });
+    let (wt, flat) = entry_subject_case(subject.clone());
+    assert_eq!(flat[&format!("{ENTRY}/subject|_type")], json!("PARTY_SELF"));
+    assert_eq!(built_subject(&wt, &flat), subject);
+
+    // The bare PARTY_SELF default never reaches the wire and is restored by
+    // the builder (the row's Note).
+    let (wt, flat) = entry_subject_case(json!({"_type": "PARTY_SELF"}));
+    assert!(
+        !addressed(&flat, &format!("{ENTRY}/subject")),
+        "the PARTY_SELF default must not be emitted: {:?}",
+        sorted_keys(&flat)
+    );
+    assert_eq!(built_subject(&wt, &flat), json!({"_type": "PARTY_SELF"}));
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // master05 — structure classes
 // ═══════════════════════════════════════════════════════════════════════════
 
-/// master05 §ELEMENT — 5 rows.
-///
-/// The `_null_flavour`/`_null_reason` probe deliberately carries a `value`
-/// alongside them, which RM data_structures §ELEMENT forbids
-/// (`Inv_null_flavour_indicated`) — the flattener only reaches an ELEMENT
-/// through its `value`, so this isolates the mapping. See the module-level
-/// TODO for the reachability gap that isolation exposes.
+/// master05 §ELEMENT — 5 rows, over an element carrying every one of them at
+/// once. The `_null_flavour`/`_null_reason` rows sit here beside a `value`,
+/// which RM data_structures §ELEMENT forbids (`Inv_null_flavour_indicated`) —
+/// the combination isolates the five rows in one fixture; the shape the RM
+/// actually admits (null flavour, no value) is asserted in both directions by
+/// [`master05_element_null_flavoured_without_value`].
 #[test]
 fn master05_element() {
     let mut el = element(dv_text("value"));

--- a/crates/openehr-its/tests/master05_tables.rs
+++ b/crates/openehr-its/tests/master05_tables.rs
@@ -49,14 +49,6 @@
 //! Known implementation gaps this battery documents (recorded here so a
 //! `TODO` search finds them, and asserted as `Absent` so they cannot rot):
 //!
-//! TODO: emit + rebuild the master05 §ELEMENT `/_null_flavour` and
-//! `/_null_reason` rows for a *value-less* ELEMENT. The flattener reaches an
-//! ELEMENT only through its `value`, but RM data_structures §ELEMENT
-//! (`Inv_null_flavour_indicated`: `is_null() xor null_flavour = Void`) makes
-//! `value` and `null_flavour` mutually exclusive — so a real null-flavoured
-//! element loses its null flavour. The mapping itself is probed below with a
-//! deliberately invariant-relaxed fixture.
-//!
 //! TODO: consume the master05 §EVENT_CONTEXT `/start_time` and `/setting` PATH
 //! spellings on input (they are silently ignored today in favour of the
 //! `ctx/` defaults) — stated in full at the §EVENT_CONTEXT test.
@@ -200,6 +192,20 @@ fn sorted_keys(flat: &Map<String, Value>) -> Vec<&String> {
     let mut keys: Vec<&String> = flat.keys().collect();
     keys.sort();
     keys
+}
+
+/// The `(key, value)` pairs of `flat` addressing `path` — the key itself, a
+/// `|suffix` of it, or a `/child` under it — in key order. The comparison unit
+/// for a round-trip assertion scoped to one node.
+fn under(flat: &Map<String, Value>, path: &str) -> std::collections::BTreeMap<String, Value> {
+    flat.iter()
+        .filter(|(k, _)| {
+            k.as_str() == path
+                || k.starts_with(&format!("{path}|"))
+                || k.starts_with(&format!("{path}/"))
+        })
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect()
 }
 
 /// Assert every row of one master05 table against the FLAT document produced
@@ -587,26 +593,34 @@ fn entry_of(rm_type: &str, extra: Value) -> Value {
     entry
 }
 
+/// The template leaf node [`flat_element`] hangs its ELEMENT value under.
+fn element_leaf_node(rm_type: &str) -> WebTemplateNode {
+    leaf(
+        rm_type,
+        &format!(
+            "{}/data[at0001]/items[at0002]/value",
+            entry_aql("EVALUATION")
+        ),
+        "leaf",
+    )
+}
+
 /// Flatten an EVALUATION whose ITEM_TREE holds `element`, with the leaf value
 /// typed `rm_type` in the template. Leaf keys are based at [`LEAF`].
 fn flat_element(rm_type: &str, element: Value) -> Map<String, Value> {
-    flat_element_node(
-        leaf(
-            rm_type,
-            &format!(
-                "{}/data[at0001]/items[at0002]/value",
-                entry_aql("EVALUATION")
-            ),
-            "leaf",
-        ),
-        element,
-    )
+    flat_element_node(element_leaf_node(rm_type), element)
 }
 
 /// [`flat_element`] with a caller-supplied leaf template node (so a fixture can
 /// set `listOpen` or a generic slot type).
 fn flat_element_node(leaf_node: WebTemplateNode, element: Value) -> Map<String, Value> {
-    let entry = json!({
+    flat_entry("EVALUATION", vec![leaf_node], element_entry(element))
+}
+
+/// The EVALUATION an element fixture lives in: one ITEM_TREE (`at0001`)
+/// holding `element` at `at0002`.
+fn element_entry(element: Value) -> Value {
+    json!({
         "_type": "EVALUATION",
         "data": {
             "_type": "ITEM_TREE",
@@ -614,8 +628,7 @@ fn flat_element_node(leaf_node: WebTemplateNode, element: Value) -> Map<String, 
             "name": dv_text("Tree"),
             "items": [element],
         },
-    });
-    flat_entry("EVALUATION", vec![leaf_node], entry)
+    })
 }
 
 /// The common leaf fixture: a plain ELEMENT wrapping `value`.
@@ -1147,6 +1160,65 @@ fn master05_element() {
             ),
             row("/_uid", At(Str), "no", ""),
         ],
+    );
+}
+
+/// master05 §ELEMENT `/_null_flavour` + `/_null_reason` on the shape the RM
+/// admits: a **value-less** ELEMENT. RM data_structures §ELEMENT
+/// (`Inv_null_flavour_indicated`: `is_null() xor null_flavour = Void`) makes
+/// `value` and `null_flavour` mutually exclusive, so this — not the
+/// value-bearing probe above — is how a real null flavour reaches the wire.
+/// The section's third example block spells exactly this document.
+#[test]
+fn master05_element_null_flavoured_without_value() {
+    let el = json!({
+        "_type": "ELEMENT",
+        "archetype_node_id": "at0002",
+        "name": dv_text("Element"),
+        "null_flavour": dv_coded("unknown", "openehr", "253"),
+        "null_reason": dv_text("sample reason"),
+    });
+    let flat = flat_element("DV_TEXT", el);
+    check(
+        &flat,
+        LEAF,
+        &[
+            row("/_null_flavour", At(Sub("|code")), "no", ""),
+            row("/_null_reason", At(Str), "no", ""),
+        ],
+    );
+    // The element itself carries no datum: `value` is exactly what a null
+    // flavour replaces.
+    assert!(
+        !flat.contains_key(LEAF),
+        "a value-less ELEMENT emits no datum, got {:?}",
+        sorted_keys(&flat)
+    );
+
+    // …and the same document rebuilds the value-less ELEMENT (the master05
+    // §ELEMENT third example block, replayed as an input).
+    let wt = entry_web_template("EVALUATION", vec![element_leaf_node("DV_TEXT")]);
+    let built = composition_from_flat(&flat, &wt, NOW)
+        .expect("a null-flavoured ELEMENT must build from its master05 §ELEMENT rows");
+    let rebuilt = &built["content"][0]["data"]["items"][0];
+    assert_eq!(rebuilt["_type"], json!("ELEMENT"));
+    assert!(
+        rebuilt.get("value").is_none(),
+        "the rebuilt ELEMENT must carry no value: {rebuilt}"
+    );
+    assert_eq!(
+        rebuilt["null_flavour"]["defining_code"]["code_string"],
+        json!("253")
+    );
+    assert_eq!(rebuilt["null_reason"]["value"], json!("sample reason"));
+
+    // RM → FLAT → RM → FLAT is stable: the null flavour survives the round
+    // trip that used to drop it.
+    let reflattened = composition_to_flat(&built, &wt).expect("composition_to_flat");
+    assert_eq!(
+        under(&reflattened, LEAF),
+        under(&flat, LEAF),
+        "the null-flavoured ELEMENT must round-trip key-for-key"
     );
 }
 

--- a/crates/openehr-its/tests/master05_tables.rs
+++ b/crates/openehr-its/tests/master05_tables.rs
@@ -45,13 +45,6 @@
 //!   asserted structurally in [`check`] — a new required row cannot be added
 //!   without stating its enforcement. Where the flat build genuinely rejects,
 //!   the section test carries the negative assertion as well.
-//!
-//! Known implementation gaps this battery documents (recorded here so a
-//! `TODO` search finds them, and asserted as `Absent` so they cannot rot):
-//!
-//! TODO: consume the master05 §EVENT_CONTEXT `/start_time` and `/setting` PATH
-//! spellings on input (they are silently ignored today in favour of the
-//! `ctx/` defaults) — stated in full at the §EVENT_CONTEXT test.
 #![allow(
     clippy::panic,
     clippy::doc_markdown,
@@ -1583,14 +1576,15 @@ fn master05_event_context() {
                 "yes",
                 "RM ehr §EVENT_CONTEXT declares `start_time` 1..1; master06 §time makes it \
                  the `ctx/time` shortcut (defaulting to `now()`), so the path form is never \
-                 required on input and is not emitted",
+                 required on input and is not emitted — but IS accepted, asserted below",
             ),
             row(
                 "/setting",
                 Elsewhere("ctx/setting"),
                 "yes",
                 "RM ehr §EVENT_CONTEXT declares `setting` 1..1; master06 §setting makes it \
-                 the `ctx/setting` shortcut, which the builder defaults",
+                 the `ctx/setting` shortcut, which the builder defaults — the path form is \
+                 accepted too, asserted below",
             ),
             row("/_end_time", Elsewhere("ctx/end_time"), "no", ""),
             row("/_location", Elsewhere("ctx/location"), "no", ""),
@@ -1599,17 +1593,8 @@ fn master05_event_context() {
         ],
     );
 
-    // The route the two required rows actually travel, in both directions
+    // The route the two required rows actually travel on output
     // (master06 §§time, setting).
-    //
-    // TODO: consume the master05 §EVENT_CONTEXT `/start_time` and `/setting`
-    // PATH spellings on input as well. The Web-Template context node always
-    // carries synthesized `start_time`/`setting` children, so the builder's
-    // "this segment is already a template child" test skips them and its
-    // `EVENT_CONTEXT` direct-RM-path arm is unreachable: a client that spells
-    // the master05 path form has its datum silently ignored in favour of the
-    // `ctx/` default, rather than either honoured or rejected
-    // (master04 §Validation).
     let built = composition_from_flat(
         &flat_of(&[
             ("ctx/time", json!("2021-12-21T14:19:31+01:00")),
@@ -1626,6 +1611,66 @@ fn master05_event_context() {
     assert_eq!(
         built["context"]["setting"]["defining_code"]["code_string"],
         json!("238")
+    );
+
+    // …and the table's own PATH spellings are honoured on input, not ignored:
+    // the Web-Template context node always carries synthesized
+    // `start_time`/`setting` children, which used to make the builder treat
+    // the path keys as "already handled" and silently drop them in favour of
+    // the `ctx/` defaults — the one outcome master04 §Validation forbids.
+    let built = composition_from_flat(
+        &flat_of(&[
+            (
+                "test/context/start_time",
+                json!("2021-12-21T14:19:31+01:00"),
+            ),
+            ("test/context/setting|code", json!("238")),
+            ("test/context/setting|value", json!("other care")),
+            ("test/context/setting|terminology", json!("openehr")),
+        ]),
+        &web_template(root_node(vec![])),
+        NOW,
+    )
+    .expect("the master05 §EVENT_CONTEXT path spellings must build");
+    assert_eq!(
+        built["context"]["start_time"]["value"],
+        json!("2021-12-21T14:19:31+01:00")
+    );
+    assert_eq!(
+        built["context"]["setting"]["defining_code"]["code_string"],
+        json!("238")
+    );
+    assert_eq!(built["context"]["setting"]["value"], json!("other care"));
+
+    // The `/setting` row's Note binds it to a ValueSet ("openEHR `setting`
+    // group"), so a bare `|code` resolves its rubric from that group exactly
+    // as `ctx/setting` does (master06 §setting) rather than standing as a
+    // `local` code.
+    let built = composition_from_flat(
+        &flat_of(&[("test/context/setting|code", json!("238"))]),
+        &web_template(root_node(vec![])),
+        NOW,
+    )
+    .expect("a bare master05 §EVENT_CONTEXT `/setting|code` must build");
+    assert_eq!(
+        built["context"]["setting"]["defining_code"]["terminology_id"]["value"],
+        json!("openehr")
+    );
+    assert_eq!(built["context"]["setting"]["value"], json!("other care"));
+
+    // A spelling master05 does NOT define on EVENT_CONTEXT is still rejected
+    // loudly (master04 §Validation: field identifiers match WT metadata
+    // structure) — the fix widens what is honoured, never what is ignored.
+    assert!(
+        matches!(
+            composition_from_flat(
+                &flat_of(&[("test/context/frobnicate", json!("x"))]),
+                &web_template(root_node(vec![])),
+                NOW,
+            ),
+            Err(FlatError::UnknownPath(_))
+        ),
+        "an undefined EVENT_CONTEXT path must be rejected, never ignored"
     );
 }
 

--- a/crates/openehr-its/tests/master05_tables.rs
+++ b/crates/openehr-its/tests/master05_tables.rs
@@ -1031,8 +1031,23 @@ fn master05_observation() {
 /// is `party` — the fixture behind the master05 ENTRY `/subject` row (typed
 /// `PARTY_PROXY`, so each of the three subtype tables reaches it).
 fn entry_subject_case(party: Value) -> (WebTemplate, Map<String, Value>) {
-    let wt = entry_web_template("EVALUATION", entry_in_context("EVALUATION"));
-    let entry = json!({"_type": "EVALUATION", "subject": party});
+    // One leaf datum keeps the ENTRY representable on the wire: FLAT structure
+    // is rebuilt from datum paths (master04 §Building the RM composition), so
+    // an ENTRY whose only content is the OFF-WIRE PARTY_SELF default would
+    // have no keys at all and, correctly, never rebuild.
+    let mut children = entry_in_context("EVALUATION");
+    children.push(element_leaf_node("DV_TEXT"));
+    let wt = entry_web_template("EVALUATION", children);
+    let entry = json!({
+        "_type": "EVALUATION",
+        "subject": party,
+        "data": {
+            "_type": "ITEM_TREE",
+            "archetype_node_id": "at0001",
+            "name": dv_text("Tree"),
+            "items": [element(dv_text("anchor"))],
+        },
+    });
     let comp = entry_composition("EVALUATION", entry, json!({}));
     let flat = composition_to_flat(&comp, &wt).expect("composition_to_flat");
     (wt, flat)

--- a/website/book/src/templates-validation.md
+++ b/website/book/src/templates-validation.md
@@ -210,6 +210,54 @@ and the activity id:
 An interval event additionally carries `|sample_count` (the number of samples
 the interval summarises) alongside its `/width` and `/math_function` fields.
 
+An element that records *why* a value is missing carries `_null_flavour` (and
+optionally `_null_reason`) **instead of** a value — the reference model makes
+the two mutually exclusive — and both directions preserve it:
+
+```json
+{
+  "vital_signs/blood_pressure/any_event:0/systolic/_null_flavour|code": "253",
+  "vital_signs/blood_pressure/any_event:0/systolic/_null_flavour|value": "unknown",
+  "vital_signs/blood_pressure/any_event:0/systolic/_null_flavour|terminology": "openehr",
+  "vital_signs/blood_pressure/any_event:0/systolic/_null_reason": "not asked"
+}
+```
+
+### Who the entry is about: `subject`
+
+Every entry (observation, evaluation, instruction, action, admin entry)
+records a subject. It defaults to the owner of the EHR, and while it stays the
+default it does not appear on the wire at all. When an entry is about someone
+else — a relative, a donor, a fetus — spell it out with the party suffixes:
+
+```json
+{
+  "family_history/family_history/subject|name": "Susan Doe",
+  "family_history/family_history/subject|id": "199",
+  "family_history/family_history/subject|id_scheme": "HOSPITAL-NS",
+  "family_history/family_history/subject|id_namespace": "HOSPITAL-NS",
+  "family_history/family_history/subject/relationship|code": "10",
+  "family_history/family_history/subject/relationship|value": "mother",
+  "family_history/family_history/subject/relationship|terminology": "openehr"
+}
+```
+
+A `/relationship` sub-path makes the subject a *related party*; additional
+identifiers ride the `/_identifier:n` family; `|_type: "PARTY_SELF"` marks a
+subject that is the EHR owner yet still carries an external reference.
+
+### Context fields: `ctx/` shortcut or full path
+
+The composition's event context is normally set through the `ctx/` shortcuts
+(`ctx/time`, `ctx/setting`, `ctx/language`, …). The equivalent full paths are
+accepted on input too, and take precedence over the shortcut defaults:
+`…/context/start_time`, `…/context/setting`, and an entry's `…/language` and
+`…/encoding`. A bare `…/context/setting|code` is resolved against the openEHR
+*setting* value set, exactly as `ctx/setting` is. Output always uses the
+`ctx/` form for these, so a round trip through FLAT is stable. A path the
+Simplified Formats specification does not define is rejected with an error —
+never silently dropped.
+
 ### Embedding canonical JSON with `|raw`
 
 When one node needs full fidelity inside an otherwise-FLAT commit, write the


### PR DESCRIPTION
Closes #532. Closes #533. Closes #534.

The group-16 audit's three FLAT defects, fixed at the flatten/build seam with the master05 rows cited in place:

- **#532** — ENTRY `/subject` (PARTY_PROXY) now maps in BOTH directions across all five ENTRY tables, dispatching to the §PARTY_SELF/§PARTY_IDENTIFIED/§PARTY_RELATED suffix rows, with the `|_type: PARTY_SELF` discriminator per the §FEEDER_AUDIT_DETAILS note and the off-wire default restored by the builder.
- **#533** — value-less null-flavoured ELEMENTs are reachable: the flatten walk resolves ELEMENT wrappers through the wrappers (not through their values), which also repairs a latent wrapper↔value index misalignment; the build side re-materializes the collapsed ELEMENT with its `/_null_flavour`/`/_null_reason` rows. The §ELEMENT third example block replays as an input vector. One flagged spec-silent choice (a value-less element in a choice group emits under the first alternative) carries the our-own-design NOTE.
- **#534** — the EVENT_CONTEXT/ENTRY direct-RM-path spellings are honoured on input: the synthesized in-context children made the direct-path arm dead code, silently discarding the datum for the `ctx/` default; `child_is_walked` is now the one definition of walked children, `/language`+`/encoding` gained their CODE_PHRASE arms, and a bare `/setting|code` binds to the openEHR `setting` group per the row's ValueSet note. Undefined paths still reject loudly.

One gating correction at convergence: the subject fixture's default-restore arm used a data-less ENTRY, which is wire-unrepresentable (FLAT structure rebuilds from datum keys) — an anchor leaf added, assertion unchanged.

Gates: clippy all-features clean; **495/495 openehr-its** (incl. the new battery rows + round-trips, the corpus round-trip gate over the five affected vendored compositions, and both insta goldens untouched); 572/572 ehrbase-rest. Changelog + book updated. The pipeline run rides the wave batch.