### PR TITLE
test(cnf): #557 + #560 — the outcome-kind and System-chapter decisions recorded

### DIFF
--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_COMPOSITION.update_composition.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_COMPOSITION.update_composition.yaml
@@ -60,6 +60,13 @@ outcomes:
     headers: { ETag: latest-version-uid }
   precondition_missing: { status: 400 }   # If-Match absent -> SHOULD 400 (Requests_and_responses)
   not_found: { status: 404 }              # unknown ehr_id or uid
+  # DECISION (#557, 2026-07-28): version_not_found and precondition_failed
+  # STAY distinct kinds on this binding although both realize as the identical
+  # 412 + latest-version ETag (§"If-Match and accidental overwrites" folds
+  # them: a false-evaluating If-Match MUST 412 whether the named version is
+  # unknown or stale). The kinds carry the SM-level cause; the fold is this
+  # realization's fact; exec::outcome's tie-break (the expected member's
+  # status match satisfies the expectation) is the documented norm.
   version_not_found:
     status: 412                           # unknown preceding version = the If-Match condition
                                           # evaluates FALSE => MUST 412 (overview

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_PARTY.update_party.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_PARTY.update_party.yaml
@@ -36,6 +36,13 @@ outcomes:
       Location: absent
   precondition_missing: { status: 400 }   # If-Match absent -> SHOULD 400 (Requests_and_responses)
   not_found: { status: 404 }              # unknown party (versioned_object_does_not_exist)
+  # DECISION (#557, 2026-07-28): version_not_found and precondition_failed
+  # STAY distinct kinds on this binding although both realize as the identical
+  # 412 + latest-version ETag (§"If-Match and accidental overwrites" folds
+  # them: a false-evaluating If-Match MUST 412 whether the named version is
+  # unknown or stale). The kinds carry the SM-level cause; the fold is this
+  # realization's fact; exec::outcome's tie-break (the expected member's
+  # status match satisfies the expectation) is the documented norm.
   version_not_found:
     # An If-Match naming a version the ADDRESSED container never issued is a
     # condition that evaluates false, so the released If-Match rule decides it,

--- a/tools/cnf-runner/src/conf_assets.rs
+++ b/tools/cnf-runner/src/conf_assets.rs
@@ -274,6 +274,14 @@ pub fn chapter_of(case_id: &str) -> &'static str {
         i if i.starts_with("SEC-") => "Security & privacy",
         i if i.starts_with("SIG-") => "Signing",
         i if i.starts_with("PERF-") => "Performance",
+        // NOTE: the System API's cases (I_ITS_REST_SYSTEM.*) report under
+        // "Other" by decision (#560, 2026-07-28): the surface carries ONE
+        // case (the OPTIONS conformance manifest) and a dedicated chapter
+        // band would be visual noise for a single row. Revisit when the
+        // System surface grows past a handful of cases (a released docs-text
+        // System chapter, or the manifest body gaining member assertions).
+        // No openEHR spec governs the visuals' chapter taxonomy — our own
+        // presentation design over the CNF schedule chapters.
         _ => "Other",
     }
 }

--- a/tools/cnf-runner/src/vocab.rs
+++ b/tools/cnf-runner/src/vocab.rs
@@ -76,7 +76,18 @@ outcome_kinds! {
     (AlreadyExists, "already_exists", Error),
     /// Target does not exist ("EHR with `<ehr_id>` does not exist").
     (NotFound, "not_found", Error),
-    /// `preceding_version_uid` does not exist.
+    /// `preceding_version_uid` does not exist. DECISION (#557, 2026-07-28):
+    /// stays a distinct kind from `precondition_failed` even where ITS-REST
+    /// realizes both as one indistinguishable wire answer (the If-Match PUTs:
+    /// a false-evaluating If-Match "MUST respond with HTTP status code `412
+    /// Precondition Failed`" regardless of whether the named version ever
+    /// existed — overview Requests_and_responses.md §"If-Match and accidental
+    /// overwrites"). Case cores speak SM outcomes, and the SM distinguishes
+    /// the causes (an unknown version vs a stale one); the fold is a
+    /// REALIZATION fact recorded on each binding, and the tie-break in
+    /// `exec::outcome` is the documented norm: when the wire genuinely cannot
+    /// distinguish members, the expected member's status match satisfies the
+    /// expectation — the status/header assertions still gate.
     (VersionNotFound, "version_not_found", Error),
     /// Version precondition evaluated false (stale `preceding_version_uid`).
     (PreconditionFailed, "precondition_failed", Error),


### PR DESCRIPTION
Closes #557. Closes #560.

- **#557**: `version_not_found` and `precondition_failed` **stay distinct kinds** on the If-Match PUTs. The wire folds them (a false-evaluating If-Match MUST 412 regardless of cause — §If-Match and accidental overwrites), but case cores speak SM outcomes and the SM distinguishes the causes; the fold is a realization fact on each binding and the `exec::outcome` tie-break is the documented norm (the status/header assertions still gate — nothing can go false-green through the tie). Recorded in the vocab enum, both bindings, and the tie-break doc.
- **#560**: the System API keeps the "Other" visuals band — one case does not justify a chapter row; the revisit condition is recorded at `chapter_of` with the our-own-presentation-design flag.

Gates: clippy clean, targeted nextest green, `validate` 733 cases / 0 findings.