### PR TITLE
fix(flat): the /_relationship input alias, one identifier emission site, Inv_null_flavour_indicated coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -320,6 +320,17 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **FLAT/STRUCTURED: the specification's other spelling of a related party's
+  relationship is accepted on input** (#589). The Simplified Formats mapping
+  table for a `PARTY_RELATED` writes the relationship sub-path
+  `…/_relationship`, while every example block in the same section — and the
+  participation-performer table — writes `…/relationship|code`. Only the
+  example form was accepted, so a producer that followed the table row had
+  its composition rejected with an unknown-path error. Both spellings are now
+  read, and either one makes the party a `PARTY_RELATED`. What the server
+  *emits* is unchanged: always the example spelling, so stored data and
+  round-trips look exactly as before.
+
 - **Three FLAT/STRUCTURED mapping gaps: an entry's subject, null-flavoured
   elements, and the event-context paths** (#532, #533, #534). An entry's
   `subject` now travels over the wire in both directions: a composition whose

--- a/app/ehrbase-rest/tests/composition_validation_http.rs
+++ b/app/ehrbase-rest/tests/composition_validation_http.rs
@@ -1,0 +1,171 @@
+#![allow(
+    clippy::panic,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    let_underscore_drop
+)] // test assertions/diagnostics/fixtures
+//! End-to-end HTTP tests for the COMPOSITION semantic-validation response —
+//! the `422` an RM class-invariant violation produces, driven through the
+//! assembled router over a **real** `EhrbaseService` on a real `PostgreSQL`.
+//!
+//! Wire oracle: ITS-REST 1.1.0
+//! `specifications/responses/422_COMPOSITION.yaml` ("content could be
+//! converted to a COMPOSITION, but there are semantic validation errors") and
+//! `schemas/others/Error.yaml` (the `Error` object's `validationErrors`
+//! list). The RM rule under test is `data_structures` §ELEMENT
+//! `Inv_null_flavour_indicated`.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::PathBuf;
+
+use axum::Router;
+use axum::body::Body;
+use http::{Request, StatusCode, header};
+use http_body_util::BodyExt;
+use serde_json::Value;
+use tower::ServiceExt;
+
+mod common;
+
+const BASE: &str = "/ehrbase/rest/openehr/v1";
+
+fn opt_xml() -> String {
+    std::fs::read_to_string(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../crates/openehr-its/tests/fixtures/sdk/ips.v0.opt"),
+    )
+    .expect("ips.v0.opt vendored in openehr-its")
+}
+
+fn canonical_composition() -> Value {
+    let text = std::fs::read_to_string(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(
+            "../../crates/openehr-its/tests/vendor/openehr_sdk/composition/canonical_json/ips_canonical.json",
+        ),
+    )
+    .expect("ips_canonical.json vendored in openehr-its");
+    serde_json::from_str(&text).expect("valid canonical composition")
+}
+
+async fn send(app: &Router, req: Request<Body>) -> (StatusCode, header::HeaderMap, String) {
+    let resp = app.clone().oneshot(req).await.expect("response");
+    let status = resp.status();
+    let headers = resp.headers().clone();
+    let bytes = resp.into_body().collect().await.expect("body").to_bytes();
+    (
+        status,
+        headers,
+        String::from_utf8_lossy(&bytes).into_owned(),
+    )
+}
+
+fn etag_uid(h: &header::HeaderMap) -> String {
+    h.get(header::ETAG)
+        .and_then(|v| v.to_str().ok())
+        .expect("ETag present")
+        .trim_start_matches("W/")
+        .trim_matches('"')
+        .to_owned()
+}
+
+/// A fresh EHR with the IPS operational template uploaded.
+async fn app_with_template() -> (testkit::TestDb, Router, String) {
+    let (pg, app) = common::test_router().await;
+    let (status, h, body) = send(
+        &app,
+        Request::builder()
+            .method("POST")
+            .uri(format!("{BASE}/ehr"))
+            .body(Body::empty())
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "ehr create: {body}");
+    let ehr_id = etag_uid(&h);
+
+    let (status, _h, body) = send(
+        &app,
+        Request::builder()
+            .method("POST")
+            .uri(format!("{BASE}/definition/template/adl1.4"))
+            .header(header::CONTENT_TYPE, "application/xml")
+            .body(Body::from(opt_xml()))
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "OPT upload: {body}");
+    (pg, app, ehr_id)
+}
+
+/// Strip the `value` of the first ELEMENT that has one, leaving no
+/// `null_flavour` behind — the shape RM data_structures §ELEMENT
+/// `Inv_null_flavour_indicated` forbids.
+fn strip_first_element_value(v: &mut Value) -> bool {
+    match v {
+        Value::Object(map) => {
+            if map.get("_type").and_then(Value::as_str) == Some("ELEMENT")
+                && map.get("null_flavour").is_none()
+                && map.remove("value").is_some()
+            {
+                return true;
+            }
+            let keys: Vec<String> = map.keys().cloned().collect();
+            keys.into_iter()
+                .any(|k| map.get_mut(&k).is_some_and(strip_first_element_value))
+        }
+        Value::Array(items) => items.iter_mut().any(strip_first_element_value),
+        _ => false,
+    }
+}
+
+/// A COMPOSITION holding an ELEMENT with neither `value` nor `null_flavour`
+/// violates RM data_structures §ELEMENT:
+///
+/// > `Inv_null_flavour_indicated`: `is_null() xor null_flavour = Void`
+/// > (`RM/docs/UML/classes/org.openehr.rm.data_structures.element.adoc`)
+///
+/// The commit is a `422` (ITS-REST `responses/422_COMPOSITION.yaml`: converts,
+/// but does not validate) whose `Error` body carries the violation in
+/// `validationErrors`, keyed by the offending RM path and naming the
+/// invariant — so the client learns which node is wrong and why, instead of
+/// the element being silently dropped.
+#[tokio::test]
+async fn composition_with_a_value_less_element_is_422_naming_the_invariant() {
+    let (_pg, app, ehr_id) = app_with_template().await;
+
+    let mut broken = canonical_composition();
+    assert!(
+        strip_first_element_value(&mut broken),
+        "the IPS composition carries a valued ELEMENT to empty"
+    );
+
+    let (status, _h, body) = send(
+        &app,
+        Request::builder()
+            .method("POST")
+            .uri(format!("{BASE}/ehr/{ehr_id}/composition"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(broken.to_string()))
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "an RM-invalid ELEMENT must not commit: {body}"
+    );
+
+    let error: Value = serde_json::from_str(&body).expect("the 422 carries an Error object");
+    let entries = error["validationErrors"]
+        .as_array()
+        .expect("the Error object lists validationErrors");
+    let named = entries
+        .iter()
+        .filter_map(Value::as_str)
+        .find(|e| e.contains("Inv_null_flavour_indicated"))
+        .unwrap_or_else(|| panic!("no entry names the invariant: {entries:?}"));
+    assert!(
+        named.contains(": "),
+        "each validationErrors entry is `<rm path>: <message>`, got {named:?}"
+    );
+}

--- a/app/ehrbase/tests/service_validation.rs
+++ b/app/ehrbase/tests/service_validation.rs
@@ -456,3 +456,81 @@ async fn deleting_a_template_invalidates_its_web_template_cache() {
         "nothing persisted against the deleted template"
     );
 }
+
+// ── RM data_structures §ELEMENT — Inv_null_flavour_indicated ─────────────────
+
+/// Strip the `value` of the first ELEMENT that has one, leaving no
+/// `null_flavour` behind — the RM-invalid shape
+/// `Inv_null_flavour_indicated` forbids. Returns the RM path of the ELEMENT
+/// that was emptied.
+fn strip_first_element_value(v: &mut Value, path: &str) -> Option<String> {
+    match v {
+        Value::Object(map) => {
+            if map.get("_type").and_then(Value::as_str) == Some("ELEMENT")
+                && map.get("null_flavour").is_none()
+                && map.remove("value").is_some()
+            {
+                return Some(path.to_owned());
+            }
+            let keys: Vec<String> = map.keys().cloned().collect();
+            for key in keys {
+                if let Some(child) = map.get_mut(&key)
+                    && let Some(found) = strip_first_element_value(child, &format!("{path}/{key}"))
+                {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        Value::Array(items) => items
+            .iter_mut()
+            .enumerate()
+            .find_map(|(i, item)| strip_first_element_value(item, &format!("{path}/{i}"))),
+        _ => None,
+    }
+}
+
+/// An ELEMENT carrying neither `value` nor `null_flavour` violates RM
+/// data_structures §ELEMENT:
+///
+/// > `Inv_null_flavour_indicated`: `is_null() xor null_flavour = Void`
+/// > (`RM/docs/UML/classes/org.openehr.rm.data_structures.element.adoc`)
+///
+/// The commit choke point runs the RM class-invariant pass unconditionally
+/// (template-independent), so such a COMPOSITION is a `422` naming the
+/// invariant — never a silent accept, and never a silent drop of the element
+/// at the simplified-format seam. Nothing is persisted.
+#[tokio::test]
+async fn element_without_value_or_null_flavour_is_rejected_at_commit() {
+    let db = testkit::db().await.expect("testkit database");
+    let pool = db.pool();
+    let svc = EhrbaseService::new(pool.clone());
+
+    svc.template_adl14_upload(fixture(IPS_OPT))
+        .await
+        .expect("upload IPS OPT");
+    let ehr_uuid = svc.create_ehr(None).await.expect("create_ehr");
+
+    let mut broken = composition("ips_canonical.json");
+    let emptied = strip_first_element_value(&mut broken, "")
+        .expect("the IPS composition carries a valued ELEMENT to empty");
+
+    let err = svc
+        .create_composition(ehr_uuid, uv(broken, "249", None))
+        .await
+        .expect_err("an ELEMENT with neither value nor null_flavour must be rejected");
+    let ServiceError::ValidationFailed(violations) = &err else {
+        panic!("expected content_invalid (422) with per-path violations, got {err:?}");
+    };
+    assert!(
+        violations
+            .iter()
+            .any(|v| v.message.contains("Inv_null_flavour_indicated")),
+        "the 422 must name the violated RM invariant (emptied {emptied}): {violations:?}"
+    );
+    assert_eq!(
+        composition_versions(&pool).await,
+        0,
+        "the RM-invalid composition was not persisted"
+    );
+}

--- a/crates/openehr-its/src/flat/build.rs
+++ b/crates/openehr-its/src/flat/build.rs
@@ -178,6 +178,27 @@ fn is_element_level(seg: &str) -> bool {
     )
 }
 
+/// Whether the leaf builder ([`map::build_leaf`]) already consumed the
+/// `_`-prefixed segment `seg` on a leaf of RM type `base`, so the generic
+/// `_`-family routing ([`apply_rm_attr`]) must not see it a second time.
+///
+/// One case: `/_relationship` on a PARTY_PROXY leaf. master05 §PARTY_RELATED
+/// spells the relationship sub-path `/_relationship` in its mapping table and
+/// `…/relationship|code` in both of the section's example blocks (and in the
+/// §"PARTY_RELATED performer" table); the flat builder accepts both, and
+/// `map::parties::build_party` reads whichever is present as the PARTY_PROXY
+/// **subtype discriminator**. Routing it on to [`map::build_rm_attr`] as well
+/// would either reject the spec's own table spelling as an unknown suffix, or
+/// — with a generic `relationship` arm there — attach the attribute to a party
+/// the leaf builder has already typed PARTY_IDENTIFIED.
+fn leaf_consumes_segment(base: &str, seg: &str) -> bool {
+    seg == map::parties::RELATIONSHIP_TABLE_SEGMENT
+        && matches!(
+            base,
+            "PARTY_PROXY" | "PARTY_SELF" | "PARTY_IDENTIFIED" | "PARTY_RELATED"
+        )
+}
+
 /// Collect the whole template's hoisted-wrapper type narrowings as
 /// `(parsed absolute archetype path, constrained RM type)` pairs, so the builder
 /// can look a re-materialised structural node's constrained type up by its
@@ -250,11 +271,16 @@ fn build(
         // Value-level `_` attributes (`_normal_range`, `_mapping`,
         // `_accuracy`, `_language`, …) attach to the DV value itself;
         // ELEMENT-level ones are routed onto the wrapping ELEMENT by
-        // `place` (master05 per-type tables vs §ELEMENT).
+        // `place` (master05 per-type tables vs §ELEMENT); the few the leaf
+        // builder itself consumed are skipped (`leaf_consumes_segment`).
         if let Value::Object(m) = &mut dv {
+            let base = base_type(&node.rm_type);
             for (seg, child) in &sim.children {
-                if seg.starts_with('_') && !is_element_level(seg) {
-                    apply_rm_attr(m, seg, &child.occurrences, base_type(&node.rm_type), path)?;
+                if seg.starts_with('_')
+                    && !is_element_level(seg)
+                    && !leaf_consumes_segment(base, seg)
+                {
+                    apply_rm_attr(m, seg, &child.occurrences, base, path)?;
                 }
             }
         }

--- a/crates/openehr-its/src/flat/flatten.rs
+++ b/crates/openehr-its/src/flat/flatten.rs
@@ -231,6 +231,21 @@ fn occurrences_of<'a>(
                     })
                 }
                 Some(_) => None,
+                // NOTE: the `false` arm below — a value-less ELEMENT with no
+                // null flavour either — emits nothing. That input is
+                // RM-INVALID and unreachable for data this platform accepted:
+                // RM data_structures §ELEMENT `Inv_null_flavour_indicated`
+                // (`is_null() xor null_flavour = Void`,
+                // `RM/docs/UML/classes/org.openehr.rm.data_structures.element.adoc`)
+                // makes exactly one of `value` / `null_flavour` present, and
+                // the commit choke point runs that invariant unconditionally
+                // (`crate::flat::validation::validate_rm_and_terminology`), so
+                // such a COMPOSITION is rejected 422 before it can be stored
+                // and re-flattened. The flattener therefore does not
+                // second-guess it: there is no datum and no null flavour to
+                // put on the wire, and inventing either would fabricate
+                // clinical meaning.
+                //
                 // A value-less null-flavoured ELEMENT belongs to no particular
                 // alternative of a choice group: the alternatives share one
                 // aqlPath and the datum that would select one is exactly what

--- a/crates/openehr-its/src/flat/map/parties.rs
+++ b/crates/openehr-its/src/flat/map/parties.rs
@@ -117,6 +117,15 @@ pub(super) fn build_object_ref(node: &SimNode) -> Option<Value> {
 /// PARTY_SELF (master05 §FEEDER_AUDIT_DETAILS, `/subject` row Note: "add
 /// /subject|_type: PARTY_SELF"). Without the marker a PARTY_SELF would rebuild
 /// as a PARTY_IDENTIFIED, so it is emitted whenever the value is one.
+///
+/// NOTE: master05 §PARTY_RELATED spells the relationship sub-path two ways —
+/// both example blocks of the section write
+/// `…/composer/relationship|code`/`|value`/`|terminology` (and the
+/// §"PARTY_RELATED performer" table row is likewise `/relationship`), while
+/// the §PARTY_RELATED mapping table's Flat Path column reads
+/// `/_relationship`. The example spelling is the emitted one (it is the form
+/// two tables and every example agree on); the underscore spelling is
+/// accepted on input as an alias by [`relationship_child`].
 pub(super) fn emit_party(p: &Value, out: &mut SimNode) {
     if p.get("_type").and_then(Value::as_str) == Some("PARTY_SELF") {
         out.attrs.insert("_type".to_owned(), json!("PARTY_SELF"));
@@ -157,13 +166,21 @@ pub(super) fn emit_party(p: &Value, out: &mut SimNode) {
 /// (master05 §PARTY_RELATED); otherwise `PARTY_IDENTIFIED` (master05
 /// §PARTY_IDENTIFIED). `default_party_type` is the `PARTY_REF.type` used when an
 /// `|id` is present but no explicit ref type (`PERSON`/`ORGANISATION`).
+///
+/// Both master05 spellings of the relationship sub-path are accepted here (see
+/// [`relationship_child`]); consuming it in this builder — rather than routing
+/// `_relationship` through [`super::build_rm_attr`] like the other
+/// `_`-prefixed families — is what makes the alias correct: the child is the
+/// PARTY_PROXY subtype discriminator, so it must be read *before* the concrete
+/// party type is decided, not attached afterwards to an already-typed
+/// PARTY_IDENTIFIED.
 pub(super) fn build_party(node: &SimNode, default_party_type: &str) -> Value {
     let explicit_self = node
         .attrs
         .get("_type")
         .and_then(Value::as_str)
         .is_some_and(|t| t == "PARTY_SELF");
-    let relationship = single(node, "relationship");
+    let relationship = relationship_child(node);
     let identifiers = build_party_identifiers(node);
 
     let mut p = Map::new();
@@ -377,6 +394,25 @@ fn single<'a>(node: &'a SimNode, name: &str) -> Option<&'a SimNode> {
     node.children.get(name).and_then(|c| c.occurrences.first())
 }
 
+/// The PARTY_RELATED `relationship` DV_CODED_TEXT child of a party node, under
+/// either spelling master05 §PARTY_RELATED gives it.
+///
+/// The section's two example blocks write
+/// `"…/composer/relationship|code": "10"` (and §"PARTY_RELATED performer"
+/// repeats `/relationship` in both its table and its example), while the
+/// §PARTY_RELATED mapping table's Flat Path column reads `/_relationship`.
+/// The spec contradicts itself, so both are read on input; only the example
+/// spelling is ever emitted ([`emit_party`]), keeping RM → FLAT → RM stable.
+fn relationship_child(node: &SimNode) -> Option<&SimNode> {
+    single(node, "relationship").or_else(|| single(node, RELATIONSHIP_TABLE_SEGMENT))
+}
+
+/// The master05 §PARTY_RELATED *table* spelling of the relationship sub-path,
+/// accepted on input as an alias of the example spelling `/relationship`.
+/// [`crate::flat::build`] excludes this segment from the generic `_`-family
+/// routing on a PARTY leaf, because [`build_party`] consumes it.
+pub(crate) const RELATIONSHIP_TABLE_SEGMENT: &str = "_relationship";
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -479,5 +515,75 @@ mod tests {
         assert_eq!(o["id"]["value"], json!("3445"));
         assert_eq!(o["id"]["scheme"], json!("HOSPITAL-NS"));
         assert_eq!(o["namespace"], json!("HOSPITAL-NS"));
+    }
+
+    /// A party node carrying the relationship sub-path under `name`.
+    fn party_with_relationship(segment: &str) -> SimNode {
+        let mut node = node_of(&[("name", json!("Susan Doe"))]);
+        let child = node.occurrence_mut(segment, None);
+        child.attrs.insert("code".to_owned(), json!("10"));
+        child.attrs.insert("value".to_owned(), json!("mother"));
+        child
+            .attrs
+            .insert("terminology".to_owned(), json!("openehr"));
+        node
+    }
+
+    // master05 §PARTY_RELATED gives the relationship sub-path TWO spellings:
+    // the mapping table's Flat Path column reads `/_relationship`, while both
+    // example blocks of the same section (and the §"PARTY_RELATED performer"
+    // table + example) write `…/relationship|code`. Both are accepted on
+    // input and both make the party a PARTY_RELATED — the child is the
+    // subtype discriminator, so `build_party` must consume it whichever way
+    // it is spelled.
+    #[test]
+    fn party_related_accepts_both_master05_relationship_spellings() {
+        let example = build_party(&party_with_relationship("relationship"), "PERSON");
+        let table = build_party(
+            &party_with_relationship(RELATIONSHIP_TABLE_SEGMENT),
+            "PERSON",
+        );
+        assert_eq!(example["_type"], json!("PARTY_RELATED"));
+        assert_eq!(
+            table, example,
+            "the `/_relationship` table spelling must build the same \
+             PARTY_RELATED as the `/relationship` example spelling"
+        );
+        assert_eq!(table["relationship"]["defining_code"]["code_string"], "10");
+    }
+
+    // The emitted spelling stays the example one — the alias is input-only, so
+    // an RM → FLAT → RM round-trip never starts producing `/_relationship`.
+    #[test]
+    fn party_related_emits_only_the_example_relationship_spelling() {
+        let rm = json!({
+            "_type": "PARTY_RELATED", "name": "Susan Doe",
+            "relationship": {
+                "_type": "DV_CODED_TEXT", "value": "mother",
+                "defining_code": {"_type": "CODE_PHRASE",
+                    "terminology_id": {"_type": "TERMINOLOGY_ID", "value": "openehr"},
+                    "code_string": "10"},
+            },
+        });
+        let mut out = SimNode::default();
+        emit_party(&rm, &mut out);
+        assert!(
+            out.children.contains_key("relationship"),
+            "master05 §PARTY_RELATED example blocks: `/relationship` is emitted"
+        );
+        assert!(
+            !out.children.contains_key(RELATIONSHIP_TABLE_SEGMENT),
+            "the `/_relationship` table spelling is an INPUT alias only; \
+             emitting it would change the wire: {:?}",
+            out.children.keys().collect::<Vec<_>>()
+        );
+        let rebuilt = build_party(&out, "PERSON");
+        assert_eq!(rebuilt["_type"], json!("PARTY_RELATED"));
+        assert_eq!(rebuilt["name"], json!("Susan Doe"));
+        assert_eq!(rebuilt["relationship"]["value"], json!("mother"));
+        assert_eq!(
+            rebuilt["relationship"]["defining_code"]["code_string"],
+            json!("10")
+        );
     }
 }

--- a/crates/openehr-its/src/flat/map/parties.rs
+++ b/crates/openehr-its/src/flat/map/parties.rs
@@ -126,6 +126,14 @@ pub(super) fn build_object_ref(node: &SimNode) -> Option<Value> {
 /// `/_relationship`. The example spelling is the emitted one (it is the form
 /// two tables and every example agree on); the underscore spelling is
 /// accepted on input as an alias by [`relationship_child`].
+///
+/// This is the **sole** emission site of the party `_identifier:i` family
+/// (master05 §§PARTY_IDENTIFIED, PARTY_RELATED `/_identifier:i`):
+/// [`super::structures::emit_rm_attrs`] deliberately carries no PARTY arm, so
+/// the family is emitted exactly once however a party node is reached — a
+/// PARTY_PROXY datum leaf through [`super::data_values::emit_leaf`], or a
+/// `_provider` / `_health_care_facility` / FEEDER_AUDIT_DETAILS party through
+/// [`super::structures`].
 pub(super) fn emit_party(p: &Value, out: &mut SimNode) {
     if p.get("_type").and_then(Value::as_str) == Some("PARTY_SELF") {
         out.attrs.insert("_type".to_owned(), json!("PARTY_SELF"));
@@ -584,6 +592,40 @@ mod tests {
         assert_eq!(
             rebuilt["relationship"]["defining_code"]["code_string"],
             json!("10")
+        );
+    }
+
+    // The party `_identifier:i` family (master05 §§PARTY_IDENTIFIED,
+    // PARTY_RELATED `/_identifier:i`) has exactly ONE emission site:
+    // `emit_party`. It used to be emitted a second time by
+    // `structures::emit_rm_attrs`'s PARTY arm — idempotent, so invisible on
+    // the wire, but a trap for the next change to either site. This pins the
+    // ownership split in both directions, so restoring either duplicate fails
+    // here rather than silently.
+    #[test]
+    fn party_identifiers_have_exactly_one_emission_site() {
+        let rm = json!({
+            "_type": "PARTY_IDENTIFIED", "name": "Silvia Blake",
+            "identifiers": [{"_type": "DV_IDENTIFIER", "id": "122", "issuer": "issuer"}],
+        });
+
+        let mut from_party = SimNode::default();
+        emit_party(&rm, &mut from_party);
+        assert_eq!(
+            from_party
+                .child("_identifier")
+                .and_then(|o| o.attrs.get("id")),
+            Some(&json!("122")),
+            "`emit_party` owns the `_identifier:i` family"
+        );
+
+        let mut from_rm_attrs = SimNode::default();
+        crate::flat::map::structures::emit_rm_attrs(&rm, "PARTY_IDENTIFIED", &mut from_rm_attrs);
+        assert!(
+            !from_rm_attrs.children.contains_key("_identifier"),
+            "the `_`-attribute dispatcher must NOT re-emit the party \
+             `_identifier:i` family — `emit_party` already did: {:?}",
+            from_rm_attrs.children.keys().collect::<Vec<_>>()
         );
     }
 }

--- a/crates/openehr-its/src/flat/map/structures.rs
+++ b/crates/openehr-its/src/flat/map/structures.rs
@@ -108,19 +108,16 @@ pub(super) fn emit_rm_attrs(rm: &Value, rm_type: &str, out: &mut SimNode) {
                 emit_instruction_details(det, out.occurrence_mut("_instruction_details", None));
             }
         }
-        "PARTY_IDENTIFIED" | "PARTY_RELATED" => {
-            if let Some(ids) = rm.get("identifiers").and_then(Value::as_array) {
-                for (i, id) in ids.iter().enumerate() {
-                    parties::emit_identifier(
-                        id,
-                        out.occurrence_mut(
-                            "_identifier",
-                            Some(u32::try_from(i).unwrap_or(u32::MAX)),
-                        ),
-                    );
-                }
-            }
-        }
+        // NOTE: no PARTY arm. The party `_identifier:i` family (master05
+        // §§PARTY_IDENTIFIED, PARTY_RELATED `/_identifier:i`) is emitted by
+        // [`parties::emit_party`], which every route to a party node already
+        // goes through — a PARTY_PROXY datum leaf via
+        // [`data_values::emit_leaf`], and the `_provider` /
+        // `_health_care_facility` / FEEDER_AUDIT_DETAILS parties from this
+        // module. A PARTY arm here would emit the family a second time onto
+        // the same node: idempotent, invisible on the wire, and a trap for
+        // the next change to either site. One family, one emission site
+        // (pinned by `parties::tests::party_identifiers_have_exactly_one_emission_site`).
         "ISM_TRANSITION" => {
             if let Some(reasons) = rm.get("reason").and_then(Value::as_array) {
                 for (i, r) in reasons.iter().enumerate() {

--- a/crates/openehr-its/tests/master05_tables.rs
+++ b/crates/openehr-its/tests/master05_tables.rs
@@ -1995,6 +1995,12 @@ fn master05_party_related() {
             row("|id_scheme", At(Str), "no", ""),
             row("|id_namespace", At(Str), "(yes)", ""),
             row("/_identifier:0", At(Sub("|id")), "no", ""),
+            // The table's Flat Path column reads `/_relationship`, but both
+            // example blocks of the SAME section (and the §"PARTY_RELATED
+            // performer" table + example) spell it `…/relationship|code` —
+            // the example form is the emitted one. The table spelling is
+            // accepted on INPUT as an alias; that direction is pinned by
+            // `master05_party_related_table_spelling_is_an_input_alias`.
             row(
                 "/_relationship",
                 Elsewhere(
@@ -2004,6 +2010,67 @@ fn master05_party_related() {
                 "",
             ),
         ],
+    );
+}
+
+/// master05 §PARTY_RELATED gives the relationship sub-path two spellings: the
+/// mapping table's Flat Path column reads `/_relationship`, while both example
+/// blocks of the same section write `"…/composer/relationship|code": "10"`
+/// (and the §"PARTY_RELATED performer" table + example agree with the
+/// examples). The emitted form is the example one — pinned by the
+/// `Elsewhere` row above and re-asserted here — and the table spelling is
+/// accepted on **input** as an alias, so a producer that followed the table
+/// row is not rejected with an unknown-path error.
+#[test]
+fn master05_party_related_table_spelling_is_an_input_alias() {
+    let mut subject = party_identified("Susan Doe", "199");
+    merge(
+        &mut subject,
+        json!({
+            "_type": "PARTY_RELATED",
+            "relationship": dv_coded("mother", "openehr", "10"),
+        }),
+    );
+    let (wt, flat) = entry_subject_case(subject.clone());
+
+    // Emission is unchanged: the example spelling, never the table spelling.
+    assert!(
+        flat.contains_key(&format!("{ENTRY}/subject/relationship|code")),
+        "the example spelling is the emitted one: {:?}",
+        sorted_keys(&flat)
+    );
+    assert!(
+        !addressed(&flat, &format!("{ENTRY}/subject/_relationship")),
+        "the `/_relationship` table spelling must never be emitted: {:?}",
+        sorted_keys(&flat)
+    );
+    assert_eq!(built_subject(&wt, &flat), subject, "round-trip unchanged");
+
+    // The same document re-keyed to the table spelling rebuilds the identical
+    // PARTY_RELATED: the alias is read as the PARTY_PROXY subtype
+    // discriminator, not attached to an already-decided PARTY_IDENTIFIED.
+    let aliased: Map<String, Value> = flat
+        .iter()
+        .map(|(k, v)| {
+            (
+                k.replace(
+                    &format!("{ENTRY}/subject/relationship"),
+                    &format!("{ENTRY}/subject/_relationship"),
+                ),
+                v.clone(),
+            )
+        })
+        .collect();
+    assert!(
+        aliased.contains_key(&format!("{ENTRY}/subject/_relationship|code")),
+        "the alias fixture carries the table spelling: {:?}",
+        sorted_keys(&aliased)
+    );
+    assert_eq!(
+        built_subject(&wt, &aliased),
+        subject,
+        "the `/_relationship` table spelling must build the same PARTY_RELATED \
+         as the `/relationship` example spelling"
     );
 }
 

--- a/crates/openehr-its/tests/rm_validation.rs
+++ b/crates/openehr-its/tests/rm_validation.rs
@@ -744,3 +744,145 @@ fn half_open_interval_is_accepted_with_or_without_flags() {
     });
     assert!(full(&flagged).is_empty(), "got {:?}", full(&flagged));
 }
+
+// ── ELEMENT Inv_null_flavour_indicated (RM data_structures §ELEMENT) ──────────
+
+/// The XOR arms of RM data_structures §ELEMENT `Inv_null_flavour_indicated`:
+///
+/// > `Inv_null_flavour_indicated`: `is_null() xor null_flavour = Void`
+/// > (`RM/docs/UML/classes/org.openehr.rm.data_structures.element.adoc`)
+///
+/// `is_null()` is "value is Void", so the invariant holds for exactly one of
+/// `value` / `null_flavour` being present. BOTH arms fail: an ELEMENT carrying
+/// both, and — the arm the vendored corpus actually contains — an ELEMENT
+/// carrying neither. Pinned on both dispatcher tiers, because the fast path
+/// may only skip the typed oracle when its result is identical.
+#[test]
+fn element_null_flavour_xor_fails_on_both_and_on_neither() {
+    let element = |extra: Value| {
+        let mut e = json!({
+            "_type": "ELEMENT",
+            "archetype_node_id": "at0002",
+            "name": {"_type": "DV_TEXT", "value": "an element"},
+        });
+        if let (Some(o), Some(x)) = (e.as_object_mut(), extra.as_object()) {
+            for (k, v) in x {
+                o.insert(k.clone(), v.clone());
+            }
+        }
+        e
+    };
+    let value = json!({"value": {"_type": "DV_TEXT", "value": "a datum"}});
+    let null_flavour = json!({"null_flavour": {
+        "_type": "DV_CODED_TEXT", "value": "no information",
+        "defining_code": {"_type": "CODE_PHRASE",
+            "terminology_id": {"_type": "TERMINOLOGY_ID", "value": "openehr"},
+            "code_string": "271"},
+    }});
+    let mut both = value.clone();
+    if let (Some(o), Some(x)) = (both.as_object_mut(), null_flavour.as_object()) {
+        for (k, v) in x {
+            o.insert(k.clone(), v.clone());
+        }
+    }
+
+    let violated = |v: &Value| {
+        two_tier(v)
+            .iter()
+            .any(|iv| iv.message == "Invariant Inv_null_flavour_indicated failed on type ELEMENT")
+    };
+
+    // The two valid shapes.
+    for ok in [element(value), element(null_flavour)] {
+        assert!(!violated(&ok), "must be accepted: {:?}", two_tier(&ok));
+    }
+    // Both present.
+    let both = element(both);
+    assert!(violated(&both), "got {:?}", two_tier(&both));
+    // Neither present — the corpus case.
+    let neither = element(json!({}));
+    assert!(violated(&neither), "got {:?}", two_tier(&neither));
+
+    // Same verdict from the authoritative typed oracle, on the tier the fast
+    // path claims to be equivalent to.
+    for case in [&both, &neither] {
+        assert!(fast_handled(case), "the fast path handles a plain ELEMENT");
+        assert_eq!(two_tier(case), typed(case));
+    }
+}
+
+/// The vendored openEHR-SDK corpus carries this violation for real: both
+/// `all_types_systematic_tests.json` and
+/// `all_types_systematic_tests_feeder_audit.json` hold one ELEMENT
+/// (`content[1]/data/items[0]`, `at0002`) with neither `value` nor
+/// `null_flavour` — RM-invalid per `Inv_null_flavour_indicated`.
+///
+/// Adjudication: the fixtures are NOT corrected. They exist to exercise the
+/// canonical-JSON codec, and the only gates that consume them (`fidelity.rs` —
+/// read, lossless re-serialize,
+/// ITS-JSON schema validation) are codec gates that do not run RM class
+/// invariants, so their verdicts are unaffected. The RM-invalid node is turned
+/// into a positive assertion instead: the dispatcher must reject it, naming
+/// the invariant. A fixture that stops carrying the violation fails here and
+/// must be re-adjudicated, never silently dropped.
+#[test]
+fn corpus_elements_without_value_or_null_flavour_are_rejected() {
+    let dir = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/vendor/openehr_sdk/composition/canonical_json"
+    );
+    for name in [
+        "all_types_systematic_tests.json",
+        "all_types_systematic_tests_feeder_audit.json",
+    ] {
+        let text = std::fs::read_to_string(format!("{dir}/{name}"))
+            .unwrap_or_else(|e| panic!("read {name}: {e}"));
+        let composition: Value =
+            serde_json::from_str(&text).unwrap_or_else(|e| panic!("parse {name}: {e}"));
+        let offenders = value_less_elements(&composition);
+        assert_eq!(
+            offenders.len(),
+            1,
+            "{name}: expected the one known RM-invalid ELEMENT, found {}",
+            offenders.len()
+        );
+        for element in offenders {
+            let violations = two_tier(element);
+            assert!(
+                violations.iter().any(|iv| iv.message
+                    == "Invariant Inv_null_flavour_indicated failed on type ELEMENT"),
+                "{name}: an ELEMENT with neither value nor null_flavour must be \
+                 rejected, got {violations:?}"
+            );
+        }
+    }
+}
+
+/// Every ELEMENT in `value` carrying neither `value` nor `null_flavour`.
+fn value_less_elements(value: &Value) -> Vec<&Value> {
+    let mut out = Vec::new();
+    fn walk<'a>(v: &'a Value, out: &mut Vec<&'a Value>) {
+        match v {
+            Value::Object(map) => {
+                let present = |k: &str| map.get(k).is_some_and(|x| !x.is_null());
+                if map.get("_type").and_then(Value::as_str) == Some("ELEMENT")
+                    && !present("value")
+                    && !present("null_flavour")
+                {
+                    out.push(v);
+                }
+                for child in map.values() {
+                    walk(child, out);
+                }
+            }
+            Value::Array(items) => {
+                for item in items {
+                    walk(item, out);
+                }
+            }
+            _ => {}
+        }
+    }
+    walk(value, &mut out);
+    out
+}


### PR DESCRIPTION
Closes #589. Closes #590. Closes #591.

- **#589** — master05 contradicts itself on PARTY_RELATED (`/_relationship` table row vs `/relationship` in every example block of the same section + the performer section): the example form stays the emitted one; the underscore form is accepted on input, consumed by `build_party` *before* the subtype is decided (the discriminator-routing trap the issue names). Battery + codec tests both directions.
- **#590** — `parties::emit_party` is the single `_identifier:i` emission site (the `structures::emit_rm_attrs` PARTY arm deleted with the reasoning NOTE); the regression test asserts both halves, so restoring either duplicate goes red — a wire-output check couldn't, the duplication being idempotent.
- **#591** — attribution: **already wired** (the hand-written ELEMENT invariant core, both dispatcher tiers, the unconditional commit choke point) — the gap was coverage + documentation, so no walker or emitter change. Landed: the four-shape two-tier test battery, the executable corpus adjudication (the two vendored files' violating ELEMENTs are asserted rejected; their only consumer is the codec fidelity gate, so nothing breaks and a silently-corrected fixture now fails loudly), the DB-backed commit test (422, zero versions persisted), the HTTP battery (the ITS-REST Error body naming the violation), and the flatten-seam NOTE (the drop is unreachable for accepted input). No changelog entry for #591 — behaviour unchanged.

Gates: fmt + clippy all-features clean ×3 crates; 501/501 openehr-its; service_validation + the new HTTP battery green. Two flagged findings filed as follow-ups (PARTY_RELATED web-template leaf; the build-side identifier twin).