### PR TITLE
chore(cnf): refresh the ehrbase-rs conformance baseline after #623

### DIFF
--- a/docs/conformance/ehrbase-rs/CONFORMANCE_CERTIFICATE.md
+++ b/docs/conformance/ehrbase-rs/CONFORMANCE_CERTIFICATE.md
@@ -40,7 +40,7 @@ The Realization column says what the row's cases were verified against: `release
 | Platform | Versioning | Y | released-wire | pass |
 | Platform | ArchetypeValidation | Y | released-wire | pass |
 | Platform | PartyOperations | OPT | released-wire | pass |
-| Platform | PartyRelationshipOperations | OPT | released-wire | excused (unrealized on this technology profile) |
+| Platform | PartyRelationshipOperations | OPT | extension | pass |
 | Platform | DemographicArchetypeValidation | OPT | released-wire | no cases |
 | Platform | AqlBasic | Y | released-wire | pass |
 | Platform | AqlAdvanced | OPT | released-wire | pass |

--- a/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
@@ -7,12 +7,12 @@ Runner: cnf-runner 3.11.0 · verification pack: passed
 
 | Status | Count |
 | --- | --- |
-| passed | 677 |
+| passed | 692 |
 | failed | 0 |
 | errored | 0 |
 | skipped | 0 |
-| not_applicable | 75 |
-| total | 752 |
+| not_applicable | 63 |
+| total | 755 |
 
 ## By chapter
 
@@ -25,7 +25,7 @@ Runner: cnf-runner 3.11.0 · verification pack: passed
 | I_DEFINITION_ADL14 | 20 | 0 | 0 | 0 | 6 |
 | I_DEFINITION_ADL2 | 21 | 0 | 0 | 0 | 8 |
 | I_DEFINITION_QUERY | 28 | 0 | 0 | 0 | 3 |
-| I_DEMOGRAPHIC_SERVICE | 42 | 0 | 0 | 0 | 13 |
+| I_DEMOGRAPHIC_SERVICE | 57 | 0 | 0 | 0 | 1 |
 | I_EHR_COMPOSITION | 88 | 0 | 0 | 0 | 0 |
 | I_EHR_CONTRIBUTION | 55 | 0 | 0 | 0 | 5 |
 | I_EHR_DIRECTORY | 63 | 0 | 0 | 0 | 4 |
@@ -63,7 +63,7 @@ Selected gating cases per claimed capability. `inconclusive` counts cases whose 
 | Versioning | pass | 59 | 0 | 0 | 0 |
 | ArchetypeValidation | pass | 121 | 0 | 0 | 0 |
 | PartyOperations | pass | 50 | 0 | 0 | 2 |
-| PartyRelationshipOperations | excused (unrealized on this technology profile) | 0 | 0 | 0 | 12 |
+| PartyRelationshipOperations | pass | 15 | 0 | 0 | 0 |
 | AqlBasic | pass | 19 | 0 | 0 | 0 |
 | AqlAdvanced | pass | 2 | 0 | 0 | 0 |
 | AqlTerminology | pass | 1 | 0 | 0 | 0 |
@@ -126,7 +126,7 @@ Percentiles re-derive from the embedded HDR V2 histograms; the class verdict is 
 
 ## Honesty
 
-Coverage: 677 of 752 selected cases driven.
+Coverage: 692 of 755 selected cases driven.
 
 Not-executed verdicts (each cited):
 
@@ -165,19 +165,7 @@ Not-executed verdicts (each cited):
 | I_DEFINITION_QUERY.delete_query-delete_existing | I_DEFINITION_QUERY.delete_query: AMB-127 |
 | I_DEFINITION_QUERY.list_matching_queries-id_pattern | I_DEFINITION_QUERY.list_matching_queries: AMB-121 |
 | I_DEFINITION_QUERY.queries_count-count | I_DEFINITION_QUERY.queries_count: AMB-127 |
-| I_DEMOGRAPHIC_SERVICE.create_party_relationship-aaaa | I_DEMOGRAPHIC_SERVICE.create_party_relationship: AMB-32 |
-| I_DEMOGRAPHIC_SERVICE.create_party_relationship-bbbb | I_DEMOGRAPHIC_SERVICE.create_party_relationship: AMB-32 |
-| I_DEMOGRAPHIC_SERVICE.delete_party_relationship-aaaa | I_PARTY_RELATIONSHIP.delete_party_relationship: AMB-32 |
-| I_DEMOGRAPHIC_SERVICE.delete_party_relationship-bbbb | I_PARTY_RELATIONSHIP.delete_party_relationship: AMB-32 |
 | I_DEMOGRAPHIC_SERVICE.get_party-xml_not_acceptable | option party-xml-unsupported: the ICS does not declare this register branch (statement.options) — ISO/IEC 9646 test selection |
-| I_DEMOGRAPHIC_SERVICE.get_party_relationship-aaaa | I_PARTY_RELATIONSHIP.get_party_relationship: AMB-32 |
-| I_DEMOGRAPHIC_SERVICE.get_party_relationship-bbbb | I_PARTY_RELATIONSHIP.get_party_relationship: AMB-32 |
-| I_DEMOGRAPHIC_SERVICE.get_party_relationship_at_time-aaaa | I_PARTY_RELATIONSHIP.get_party_relationship_at_time: AMB-32 |
-| I_DEMOGRAPHIC_SERVICE.get_party_relationship_at_time-bbbb | I_PARTY_RELATIONSHIP.get_party_relationship_at_time: AMB-32 |
-| I_DEMOGRAPHIC_SERVICE.get_party_relationship_at_version-aaaa | I_PARTY_RELATIONSHIP.get_party_relationship_at_version: AMB-32 |
-| I_DEMOGRAPHIC_SERVICE.get_party_relationship_at_version-bbbb | I_PARTY_RELATIONSHIP.get_party_relationship_at_version: AMB-32 |
-| I_DEMOGRAPHIC_SERVICE.update_party_relationship-aaaa | I_PARTY_RELATIONSHIP.update_party_relationship: AMB-32 |
-| I_DEMOGRAPHIC_SERVICE.update_party_relationship-bbbb | I_PARTY_RELATIONSHIP.update_party_relationship: AMB-32 |
 | I_EHR_CONTRIBUTION.list_contributions-ehr_containing_directory | I_EHR_CONTRIBUTION.list_contributions: AMB-22 |
 | I_EHR_CONTRIBUTION.list_contributions-ehr_containing_ehr_status | I_EHR_CONTRIBUTION.list_contributions: AMB-22 |
 | I_EHR_CONTRIBUTION.list_contributions-empty | I_EHR_CONTRIBUTION.list_contributions: AMB-22 |

--- a/docs/conformance/ehrbase-rs/CONFORMANCE_STATEMENT.md
+++ b/docs/conformance/ehrbase-rs/CONFORMANCE_STATEMENT.md
@@ -52,12 +52,12 @@ Capabilities claimed:
 - ItemTags
 - Signing
 - SimplifiedFormats
+- SmartAppLaunch
 - EhrDemographicSeparation
 - AuthenticatedAccess
 - AuthorizationSeparation
 - AuditAccountability
 - AnonymousEhrs
-- SmartAppLaunch
 
 Options declared: adl14-partial-id-exact, contribution-xml-unsupported, directory-empty-error, directory-xml-supported, ehr-status-xml-supported, ehr-xml-supported, legacy-alt-formats-unsupported, party-xml-supported, sf-deprecated-types-unsupported, versioned-party-xml-unsupported, xml-namespace-negotiated
 

--- a/docs/conformance/ehrbase-rs/badge.json
+++ b/docs/conformance/ehrbase-rs/badge.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "openEHR conformance",
-  "message": "CORE+STANDARD PASS \u00b7 677/677 cases",
+  "message": "CORE+STANDARD PASS \u00b7 692/692 cases",
   "color": "brightgreen"
 }

--- a/docs/conformance/ehrbase-rs/results.json
+++ b/docs/conformance/ehrbase-rs/results.json
@@ -2431,17 +2431,15 @@
     },
     {
       "case": "I_DEMOGRAPHIC_SERVICE.create_party_relationship-aaaa",
-      "status": "not_applicable",
-      "rows_driven": 0,
-      "rows_total": 1,
-      "citation": "I_DEMOGRAPHIC_SERVICE.create_party_relationship: AMB-32"
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
     },
     {
       "case": "I_DEMOGRAPHIC_SERVICE.create_party_relationship-bbbb",
-      "status": "not_applicable",
-      "rows_driven": 0,
-      "rows_total": 1,
-      "citation": "I_DEMOGRAPHIC_SERVICE.create_party_relationship: AMB-32"
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
     },
     {
       "case": "I_DEMOGRAPHIC_SERVICE.delete_party-aaaa",
@@ -2469,17 +2467,21 @@
     },
     {
       "case": "I_DEMOGRAPHIC_SERVICE.delete_party_relationship-aaaa",
-      "status": "not_applicable",
-      "rows_driven": 0,
-      "rows_total": 1,
-      "citation": "I_PARTY_RELATIONSHIP.delete_party_relationship: AMB-32"
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
     },
     {
       "case": "I_DEMOGRAPHIC_SERVICE.delete_party_relationship-bbbb",
-      "status": "not_applicable",
-      "rows_driven": 0,
-      "rows_total": 1,
-      "citation": "I_PARTY_RELATIONSHIP.delete_party_relationship: AMB-32"
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEMOGRAPHIC_SERVICE.delete_party_relationship-stale_version_conflict",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
     },
     {
       "case": "I_DEMOGRAPHIC_SERVICE.get_party-aaaa",
@@ -2559,45 +2561,39 @@
     },
     {
       "case": "I_DEMOGRAPHIC_SERVICE.get_party_relationship-aaaa",
-      "status": "not_applicable",
-      "rows_driven": 0,
-      "rows_total": 1,
-      "citation": "I_PARTY_RELATIONSHIP.get_party_relationship: AMB-32"
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
     },
     {
       "case": "I_DEMOGRAPHIC_SERVICE.get_party_relationship-bbbb",
-      "status": "not_applicable",
-      "rows_driven": 0,
-      "rows_total": 1,
-      "citation": "I_PARTY_RELATIONSHIP.get_party_relationship: AMB-32"
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
     },
     {
       "case": "I_DEMOGRAPHIC_SERVICE.get_party_relationship_at_time-aaaa",
-      "status": "not_applicable",
-      "rows_driven": 0,
-      "rows_total": 1,
-      "citation": "I_PARTY_RELATIONSHIP.get_party_relationship_at_time: AMB-32"
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
     },
     {
       "case": "I_DEMOGRAPHIC_SERVICE.get_party_relationship_at_time-bbbb",
-      "status": "not_applicable",
-      "rows_driven": 0,
-      "rows_total": 1,
-      "citation": "I_PARTY_RELATIONSHIP.get_party_relationship_at_time: AMB-32"
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
     },
     {
       "case": "I_DEMOGRAPHIC_SERVICE.get_party_relationship_at_version-aaaa",
-      "status": "not_applicable",
-      "rows_driven": 0,
-      "rows_total": 1,
-      "citation": "I_PARTY_RELATIONSHIP.get_party_relationship_at_version: AMB-32"
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
     },
     {
       "case": "I_DEMOGRAPHIC_SERVICE.get_party_relationship_at_version-bbbb",
-      "status": "not_applicable",
-      "rows_driven": 0,
-      "rows_total": 1,
-      "citation": "I_PARTY_RELATIONSHIP.get_party_relationship_at_version: AMB-32"
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
     },
     {
       "case": "I_DEMOGRAPHIC_SERVICE.update_party-aaaa",
@@ -2669,17 +2665,27 @@
     },
     {
       "case": "I_DEMOGRAPHIC_SERVICE.update_party_relationship-aaaa",
-      "status": "not_applicable",
-      "rows_driven": 0,
-      "rows_total": 1,
-      "citation": "I_PARTY_RELATIONSHIP.update_party_relationship: AMB-32"
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
     },
     {
       "case": "I_DEMOGRAPHIC_SERVICE.update_party_relationship-bbbb",
-      "status": "not_applicable",
-      "rows_driven": 0,
-      "rows_total": 1,
-      "citation": "I_PARTY_RELATIONSHIP.update_party_relationship: AMB-32"
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEMOGRAPHIC_SERVICE.update_party_relationship-invalid_body",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_DEMOGRAPHIC_SERVICE.update_party_relationship-missing_if_match",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
     },
     {
       "case": "I_DEMOGRAPHIC_SERVICE.versioned_party_version_at_time",

--- a/docs/conformance/ehrbase-rs/run-exceptions.json
+++ b/docs/conformance/ehrbase-rs/run-exceptions.json
@@ -273,94 +273,10 @@
     }
   },
   {
-    "case": "I_DEMOGRAPHIC_SERVICE.create_party_relationship-aaaa",
-    "exception": {
-      "kind": "unrealized",
-      "detail": "I_DEMOGRAPHIC_SERVICE.create_party_relationship: AMB-32"
-    }
-  },
-  {
-    "case": "I_DEMOGRAPHIC_SERVICE.create_party_relationship-bbbb",
-    "exception": {
-      "kind": "unrealized",
-      "detail": "I_DEMOGRAPHIC_SERVICE.create_party_relationship: AMB-32"
-    }
-  },
-  {
-    "case": "I_DEMOGRAPHIC_SERVICE.delete_party_relationship-aaaa",
-    "exception": {
-      "kind": "unrealized",
-      "detail": "I_PARTY_RELATIONSHIP.delete_party_relationship: AMB-32"
-    }
-  },
-  {
-    "case": "I_DEMOGRAPHIC_SERVICE.delete_party_relationship-bbbb",
-    "exception": {
-      "kind": "unrealized",
-      "detail": "I_PARTY_RELATIONSHIP.delete_party_relationship: AMB-32"
-    }
-  },
-  {
     "case": "I_DEMOGRAPHIC_SERVICE.get_party-xml_not_acceptable",
     "exception": {
       "kind": "unrealized",
       "detail": "option party-xml-unsupported: the ICS does not declare this register branch (statement.options) — ISO/IEC 9646 test selection"
-    }
-  },
-  {
-    "case": "I_DEMOGRAPHIC_SERVICE.get_party_relationship-aaaa",
-    "exception": {
-      "kind": "unrealized",
-      "detail": "I_PARTY_RELATIONSHIP.get_party_relationship: AMB-32"
-    }
-  },
-  {
-    "case": "I_DEMOGRAPHIC_SERVICE.get_party_relationship-bbbb",
-    "exception": {
-      "kind": "unrealized",
-      "detail": "I_PARTY_RELATIONSHIP.get_party_relationship: AMB-32"
-    }
-  },
-  {
-    "case": "I_DEMOGRAPHIC_SERVICE.get_party_relationship_at_time-aaaa",
-    "exception": {
-      "kind": "unrealized",
-      "detail": "I_PARTY_RELATIONSHIP.get_party_relationship_at_time: AMB-32"
-    }
-  },
-  {
-    "case": "I_DEMOGRAPHIC_SERVICE.get_party_relationship_at_time-bbbb",
-    "exception": {
-      "kind": "unrealized",
-      "detail": "I_PARTY_RELATIONSHIP.get_party_relationship_at_time: AMB-32"
-    }
-  },
-  {
-    "case": "I_DEMOGRAPHIC_SERVICE.get_party_relationship_at_version-aaaa",
-    "exception": {
-      "kind": "unrealized",
-      "detail": "I_PARTY_RELATIONSHIP.get_party_relationship_at_version: AMB-32"
-    }
-  },
-  {
-    "case": "I_DEMOGRAPHIC_SERVICE.get_party_relationship_at_version-bbbb",
-    "exception": {
-      "kind": "unrealized",
-      "detail": "I_PARTY_RELATIONSHIP.get_party_relationship_at_version: AMB-32"
-    }
-  },
-  {
-    "case": "I_DEMOGRAPHIC_SERVICE.update_party_relationship-aaaa",
-    "exception": {
-      "kind": "unrealized",
-      "detail": "I_PARTY_RELATIONSHIP.update_party_relationship: AMB-32"
-    }
-  },
-  {
-    "case": "I_DEMOGRAPHIC_SERVICE.update_party_relationship-bbbb",
-    "exception": {
-      "kind": "unrealized",
-      "detail": "I_PARTY_RELATIONSHIP.update_party_relationship: AMB-32"
     }
   },
   {

--- a/docs/conformance/ehrbase-rs/verdicts.json
+++ b/docs/conformance/ehrbase-rs/verdicts.json
@@ -59,7 +59,7 @@
     ],
     [
       "PartyRelationshipOperations",
-      "unrealized"
+      "passed"
     ],
     [
       "DemographicArchetypeValidation",
@@ -304,10 +304,10 @@
     [
       "PartyRelationshipOperations",
       {
-        "passed": 0,
+        "passed": 15,
         "failed": 0,
         "inconclusive": 0,
-        "unevidenced": 12
+        "unevidenced": 0
       }
     ],
     [
@@ -588,7 +588,7 @@
     }
   ],
   "coverage": {
-    "selected": 752,
-    "driven": 677
+    "selected": 755,
+    "driven": 692
   }
 }


### PR DESCRIPTION
Fresh `scripts/conformance.sh` run on the merged develop (PR #636): **755 case-records, 692 passed / 0 failed / 0 errored / 63 n-a**, 43 capability verdicts, 0 review findings, CORE/STANDARD/OPTIONS pass. The 15 new `PARTY_RELATIONSHIP` extension cases are driven in the one record; badges + visuals re-derived from the committed artifacts.