### PR TITLE
chore(cnf): ground or drop every case-level its_rest>=1.1.0 floor — 157 kept (cited), 186 dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,6 +309,25 @@ workflow refuses a tag that has no matching section here.
 
 ### Changed
 
+- **Conformance: a product is no longer excused from 186 test cases for
+  declaring an older REST release** (#635). Every conformance case may declare
+  the openEHR release its behaviour needs, and systems declaring an earlier
+  release are skipped for it. That declaration had been copied onto 343 cases
+  as authoring boilerplate, which quietly wrote off most of the EHR,
+  COMPOSITION, DIRECTORY, CONTRIBUTION, QUERY and template surface for any
+  product declaring ITS-REST 1.0.3 — behaviour those products do implement and
+  should be judged on. Each case was re-derived against the released
+  amendment record, and the requirement is kept only where the released text
+  actually dates it: ITEM_TAGs, the Demographic API, admin EHR deletion, the
+  Simplified Formats media types, `Prefer: return=identifier`, the
+  audit-details `system_id`, the reserved `aql` query name, the template
+  `/example` sub-resource, and SMART on openEHR. Everything else is now judged
+  for every product, with the two genuinely release-dated header rules (the
+  weak `W/` ETag form and the read/delete `Location` restriction) still
+  applied only to the release that introduced them. No test was removed or
+  weakened; the comparison against other openEHR products now covers what they
+  really implement.
+
 - **The conformance statement no longer claims nine capabilities it cannot
   demonstrate** (#623). ADL 1.4 and ADL 2 archetype provisioning, the admin
   Activity Report, EHR dump/load, EHR and demographic archiving, EHR Extract,

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.physical_ehr_delete-delete_all_cascade.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.physical_ehr_delete-delete_all_cascade.yaml
@@ -40,7 +40,7 @@ spec_refs:
   - "SM openehr_platform §I_ADMIN_SERVICE.physical_ehr_delete"
   - "ITS-REST admin §admin_ehr_delete_all (the owned-resource cascade sentence)"
   - "RM common §change_control (master06 §Contributions — every change is a CONTRIBUTION carrying its VERSIONs)"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # admin EHR deletion arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-80)
 guards:
   - "ITS-REST Admin API is DEVELOPMENT-stage — docs/admin/Description.md §Status: \"This specification is in the `DEVELOPMENT` state\", and docs/overview/Preface.md §Conformance is \"tbd.\"; guarded until the Admin API stabilises"
   - "admin_ehr_delete_all realizes NO SM operation — SM i_admin_service.adoc §physical_ehr_delete takes a single `an_ehr_id: UUID [1]` and the I_ADMIN_ARCHIVE list operations archive rather than delete (register AMB-33); the `delete_all` variant anchor is a catalogue naming convention, never an SM claim"

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.physical_ehr_delete-delete_all_malformed_id.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.physical_ehr_delete-delete_all_malformed_id.yaml
@@ -46,7 +46,7 @@ spec_refs:
   - "ITS-REST admin §admin_ehr_delete_all (DELETE /admin/ehr/all?ehr_id= — the subset selector)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "BASE base_types §identification (mutually exclusive UID string patterns)"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # admin EHR deletion arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-80)
 guards:
   - "ITS-REST Admin API is DEVELOPMENT-stage — docs/admin/Description.md §Status: \"This specification is in the `DEVELOPMENT` state\", and docs/overview/Preface.md §Conformance is \"tbd.\"; guarded until the Admin API stabilises"
   - "admin_ehr_delete_all realizes NO SM operation — SM i_admin_service.adoc §physical_ehr_delete takes a single `an_ehr_id: UUID [1]` and the I_ADMIN_ARCHIVE list operations archive rather than delete (register AMB-33); the `delete_all` variant anchor is a catalogue naming convention, never an SM claim"

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.physical_ehr_delete-delete_all_subset.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.physical_ehr_delete-delete_all_subset.yaml
@@ -30,7 +30,7 @@ spec_refs:
   - "SM openehr_platform §I_ADMIN_SERVICE.physical_ehr_delete"
   - "ITS-REST admin §admin_ehr_delete_all (DELETE /admin/ehr/all?ehr_id= — the subset selector)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # admin EHR deletion arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-80)
 guards:
   - "ITS-REST Admin API is DEVELOPMENT-stage — docs/admin/Description.md §Status: \"This specification is in the `DEVELOPMENT` state\", and docs/overview/Preface.md §Conformance is \"tbd.\"; guarded until the Admin API stabilises"
   - "admin_ehr_delete_all realizes NO SM operation — SM i_admin_service.adoc §physical_ehr_delete takes a single `an_ehr_id: UUID [1]` and the I_ADMIN_ARCHIVE list operations archive rather than delete (register AMB-33); the `delete_all` variant anchor is a catalogue naming convention, never an SM claim"

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.physical_ehr_delete-delete_all_subset_repeated.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.physical_ehr_delete-delete_all_subset_repeated.yaml
@@ -33,7 +33,7 @@ spec_refs:
   - "SM openehr_platform §I_ADMIN_SERVICE.physical_ehr_delete"
   - "ITS-REST admin §admin_ehr_delete_all (DELETE /admin/ehr/all?ehr_id= — the subset selector)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # admin EHR deletion arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-80)
 guards:
   - "ITS-REST Admin API is DEVELOPMENT-stage — docs/admin/Description.md §Status: \"This specification is in the `DEVELOPMENT` state\", and docs/overview/Preface.md §Conformance is \"tbd.\"; guarded until the Admin API stabilises"
   - "admin_ehr_delete_all realizes NO SM operation — SM i_admin_service.adoc §physical_ehr_delete takes a single `an_ehr_id: UUID [1]` and the I_ADMIN_ARCHIVE list operations archive rather than delete (register AMB-33); the `delete_all` variant anchor is a catalogue naming convention, never an SM claim"

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.physical_ehr_delete-delete_all_unfiltered.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.physical_ehr_delete-delete_all_unfiltered.yaml
@@ -37,7 +37,7 @@ spec_refs:
   - "SM openehr_platform §I_ADMIN_SERVICE.physical_ehr_delete"
   - "ITS-REST admin §admin_ehr_delete_all (DELETE /admin/ehr/all — absent ehr_id = all EHRs)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # admin EHR deletion arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-80)
 guards:
   - "ITS-REST Admin API is DEVELOPMENT-stage — docs/admin/Description.md §Status: \"This specification is in the `DEVELOPMENT` state\", and docs/overview/Preface.md §Conformance is \"tbd.\"; guarded until the Admin API stabilises"
   - "admin_ehr_delete_all realizes NO SM operation — I_ADMIN_SERVICE.physical_ehr_delete takes a single `an_ehr_id: UUID [1]` and the I_ADMIN_ARCHIVE list operations archive rather than delete (register AMB-33); the `delete_all` variant anchor is a catalogue naming convention, never an SM claim"

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.physical_ehr_delete-delete_existing_cascade.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.physical_ehr_delete-delete_existing_cascade.yaml
@@ -38,7 +38,7 @@ spec_refs:
   - "SM openehr_platform §I_ADMIN_SERVICE.physical_ehr_delete"
   - "ITS-REST admin §admin_ehr_delete (the owned-resource cascade sentence; 204_deleted_hard)"
   - "RM common §change_control (master06 §Contributions — every change is a CONTRIBUTION carrying its VERSIONs)"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # admin EHR deletion arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-80)
 guards:
   - "ITS-REST Admin API is DEVELOPMENT-stage — docs/admin/Description.md §Status: \"This specification is in the `DEVELOPMENT` state\", and docs/overview/Preface.md §Conformance is \"tbd.\"; guarded until the Admin API stabilises"
   - "the cascade list is exemplary (\"such as\") and the SM operation states a precondition but no postcondition — register AMB-143; what is asserted here is the released promise's observable form, unreachability, since no released read can see inside a destroyed EHR"

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.physical_ehr_delete-delete_existing_recreate.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.physical_ehr_delete-delete_existing_recreate.yaml
@@ -32,7 +32,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_SERVICE.create_ehr_with_id"
   - "ITS-REST admin §admin_ehr_delete (hard delete; 404_unknown_ehr_id)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # admin EHR deletion arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-80)
 guards:
   - "ITS-REST Admin API is DEVELOPMENT-stage — docs/admin/Description.md §Status: \"This specification is in the `DEVELOPMENT` state\", and docs/overview/Preface.md §Conformance is \"tbd.\"; guarded until the Admin API stabilises"
   - "no released sentence states the post-delete contract — SM i_admin_service.adoc §physical_ehr_delete declares `Pre_has_ehr` and NO postcondition, unlike SM i_definition_query.adoc §delete_query's `Post_query_deleted`; the position asserted here is the adjudicated one in register AMB-143"

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-audit_system_id_declared.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-audit_system_id_declared.yaml
@@ -39,7 +39,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §openehr-version and openehr-audit-details"
   - "RM common §change_control (AUDIT_DETAILS.system_id)"
   - "SM openehr_platform §I_EHR_COMPOSITION.create_composition"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the audit-details `system_id` attribute arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECPR-472)
 guards:
   - "the identity half is only checkable against a party declaration — no released ITS-REST operation discloses a server's configured system identifier, so a party whose ixit omits system_id records this case not-applicable (ITS-REST overview Requests_and_responses §openehr-version and openehr-audit-details states the MUST but no read surface for the value)"
 requires:

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-datetime_lexical.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-datetime_lexical.yaml
@@ -38,7 +38,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §Datetime format"
   - "SM openehr_platform §I_EHR_COMPOSITION.create_composition"
   - "RM data_types §DV_DATE_TIME"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-deprecated_template_id.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-deprecated_template_id.yaml
@@ -28,7 +28,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses (Deprecated headers)"
   - "ITS-REST overview Requests_and_responses (openehr-template-id)"
   - "SM openehr_platform §I_EHR_COMPOSITION.create_composition"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_action]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-ehr_not_modifiable.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-ehr_not_modifiable.yaml
@@ -38,7 +38,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_EHR_COMPOSITION.create_composition"
   - "SM openehr_platform §I_EHR_STATUS.clear_ehr_modifiable"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-null_empty_absent.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-null_empty_absent.yaml
@@ -30,7 +30,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §JSON Format"
   - "SM openehr_platform §I_EHR_COMPOSITION.create_composition"
   - "RM common §LOCATABLE (links, feeder_audit)"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-prefer_absent.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-prefer_absent.yaml
@@ -29,7 +29,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §Representation details negotiation"
   - "ITS-REST overview Requests_and_responses §Prefer minimal, identifier or full representation response"
   - "SM openehr_platform §I_EHR_COMPOSITION.create_composition"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 formats: [canonical-json]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-prefer_minimal.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-prefer_minimal.yaml
@@ -33,7 +33,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §Prefer minimal, identifier or full representation response"
   - "ITS-REST overview Requests_and_responses §Representation details negotiation"
   - "SM openehr_platform §I_EHR_COMPOSITION.create_composition"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 formats: [canonical-json]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-return_identifier.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-return_identifier.yaml
@@ -31,7 +31,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses (Prefer only identifier)"
   - "ITS-REST overview Requests_and_responses (Representation details negotiation)"
   - "SM openehr_platform §I_EHR_COMPOSITION.create_composition"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # `Prefer: return=identifier` arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-50) + Requests_and_responses.md §Prefer only identifier
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-version_bare_deprecated.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-version_bare_deprecated.yaml
@@ -40,7 +40,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §openehr-version and openehr-audit-details"
   - "TERM SupportTerminology §Version Lifecycle State"
   - "SM openehr_platform §I_EHR_COMPOSITION.create_composition"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-version_lifecycle.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-version_lifecycle.yaml
@@ -52,7 +52,7 @@ spec_refs:
   - "RM common §change_control (ORIGINAL_VERSION.lifecycle_state; Incomplete Content)"
   - "TERM SupportTerminology §Version Lifecycle State"
   - "SM openehr_platform §I_EHR_COMPOSITION.create_composition"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-wrong_media.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-wrong_media.yaml
@@ -32,7 +32,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Requests_and_responses (HTTP status codes: 415 Unsupported Media Type)"
   - "SM openehr_platform §I_EHR_COMPOSITION.create_composition"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-xml.yaml
@@ -36,7 +36,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-XML components §RM documents/Composition.xsd (the globally declared `composition` element)"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.delete_composition-already_deleted.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.delete_composition-already_deleted.yaml
@@ -36,7 +36,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "RM common §change_control (master06 §Logical Deletion)"
   - "SM openehr_platform §I_EHR_COMPOSITION.delete_composition"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.delete_composition-etag_names_new_version.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.delete_composition-etag_names_new_version.yaml
@@ -33,7 +33,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §ETag and Last-Modified"
   - "RM common §change_control (master06 §Logical Deletion)"
   - "SM openehr_platform §I_EHR_COMPOSITION.delete_composition"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.delete_composition-not_latest_version.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.delete_composition-not_latest_version.yaml
@@ -36,7 +36,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §ETag and Last-Modified"
   - "RM common §change_control (master06 — the version trunk and its head)"
   - "SM openehr_platform §I_EHR_COMPOSITION.delete_composition"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_at_time-before_first_version.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_at_time-before_first_version.yaml
@@ -31,7 +31,7 @@ spec_refs:
   - "ITS-REST overview Resources §Datetime format"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_EHR_COMPOSITION.get_composition_at_time"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_at_time-deleted_at_time.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_at_time-deleted_at_time.yaml
@@ -35,7 +35,7 @@ spec_refs:
   - "RM common §change_control (master06 §Logical Deletion)"
   - "RM common §versioned_object (version_at_time)"
   - "SM openehr_platform §I_EHR_COMPOSITION.get_composition_at_time"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_at_time-future.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_at_time-future.yaml
@@ -33,7 +33,7 @@ spec_refs:
   - "ITS-REST overview Resources §Datetime format"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_EHR_COMPOSITION.get_composition_at_time"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_at_time-malformed.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_at_time-malformed.yaml
@@ -30,7 +30,7 @@ spec_refs:
   - "ITS-REST overview Resources §Datetime format"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_EHR_COMPOSITION.get_composition_at_time"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_at_time-simplified_forms.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_at_time-simplified_forms.yaml
@@ -38,7 +38,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §Simplified Formats"
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-REST simplified_formats master04 §Conversion Between Formats"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_at_time-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_at_time-xml.yaml
@@ -36,7 +36,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-XML components §RM documents/Composition.xsd (the globally declared `composition` element)"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_at_version-deleted_version.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_at_version-deleted_version.yaml
@@ -32,7 +32,7 @@ spec_refs:
   - "ITS-REST overview Resources §Identifier types"
   - "RM common §change_control (master06 §Logical Deletion)"
   - "SM openehr_platform §I_EHR_COMPOSITION.get_composition_at_version"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_at_version-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_at_version-xml.yaml
@@ -35,7 +35,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-XML components §RM documents/Composition.xsd (the globally declared `composition` element)"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_latest-deleted_head.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_latest-deleted_head.yaml
@@ -35,7 +35,7 @@ spec_refs:
   - "RM common §change_control (master06 §Logical Deletion)"
   - "RM common §versioned_object (latest_version)"
   - "SM openehr_platform §I_EHR_COMPOSITION.get_composition_latest"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_latest-identifier_forms_agree.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_latest-identifier_forms_agree.yaml
@@ -49,7 +49,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §Identifier types"
   - "SM openehr_platform §I_EHR_COMPOSITION.get_composition_latest"
   - "SM openehr_platform §I_EHR_COMPOSITION.get_composition_at_version"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_latest-simplified_forms.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_latest-simplified_forms.yaml
@@ -39,7 +39,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §Simplified Formats"
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-REST simplified_formats master04 §Conversion Between Formats"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_latest-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_latest-xml.yaml
@@ -41,7 +41,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-XML components §RM documents/Composition.xsd (the globally declared `composition` element)"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_latest-xml_namespace_v2.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_latest-xml_namespace_v2.yaml
@@ -50,7 +50,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-XML README.adoc §Releases and IM Versions (the v1/v2 lineages)"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 guards:
   - "Canonical-XML lineage selection is statement-declared, not spec-mandated — the ICS options declaration selects this branch (AMB-169); released ITS-REST names no XML namespace and no selection mechanism"
 requires:

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_versioned_composition-at_time_before_first_version.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_versioned_composition-at_time_before_first_version.yaml
@@ -29,7 +29,7 @@ spec_refs:
   - "ITS-REST overview Resources §Datetime format"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_EHR_COMPOSITION.get_versioned_composition"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_versioned_composition-at_time_future.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_versioned_composition-at_time_future.yaml
@@ -30,7 +30,7 @@ spec_refs:
   - "RM common §change_control (master06 — VERSION.uid is an OBJECT_VERSION_ID)"
   - "ITS-REST overview Resources §Datetime format"
   - "SM openehr_platform §I_EHR_COMPOSITION.get_versioned_composition"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_versioned_composition-at_time_malformed.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_versioned_composition-at_time_malformed.yaml
@@ -25,7 +25,7 @@ spec_refs:
   - "ITS-REST overview Resources §Datetime format"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_EHR_COMPOSITION.get_versioned_composition"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_versioned_composition-at_time_omitted.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_versioned_composition-at_time_omitted.yaml
@@ -27,7 +27,7 @@ spec_refs:
   - "RM common §versioned_object (latest_version)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_EHR_COMPOSITION.get_versioned_composition"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_versioned_composition-container_shape.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_versioned_composition-container_shape.yaml
@@ -50,7 +50,7 @@ spec_refs:
   - "ITS-REST overview Resources §Resources"
   - "ITS-REST overview Requests_and_responses §ETag and Last-Modified"
   - "SM openehr_platform §I_EHR_COMPOSITION.get_versioned_composition"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_versioned_composition-deleted_version_envelope.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_versioned_composition-deleted_version_envelope.yaml
@@ -37,7 +37,7 @@ spec_refs:
   - "RM common §change_control (master06 §Logical Deletion)"
   - "RM common §version (Lifecycle_state_valid)"
   - "SM openehr_platform §I_EHR_COMPOSITION.get_versioned_composition"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_versioned_composition-malformed_uid.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_versioned_composition-malformed_uid.yaml
@@ -36,7 +36,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "BASE base_types §identification (mutually exclusive UID string patterns)"
   - "SM openehr_platform §I_EHR_COMPOSITION.get_versioned_composition"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 guards:
   - "The 400-vs-404 split for a malformed identifier segment rests on the AMB-76 adjudication — ITS-REST overview Requests_and_responses.md §HTTP status codes (the 400 row) covers 'syntactically invalid content' generally but assigns no branch to a malformed identifier segment, and BASE base_types master05 §Identification carries no rejecting lexical invariant; a server answering 404 for a garbage token breaches no quoted rule"
 requires:

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_versioned_composition-version_of_other_container.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_versioned_composition-version_of_other_container.yaml
@@ -41,7 +41,7 @@ spec_refs:
   - "RM common §change_control (master06 §Version Identification)"
   - "RM common §versioned_object (version_with_id / has_version_id)"
   - "SM openehr_platform §I_EHR_COMPOSITION.get_versioned_composition"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_versioned_composition-version_unknown.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_versioned_composition-version_unknown.yaml
@@ -28,7 +28,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "RM common §versioned_object (version_with_id / has_version_id)"
   - "SM openehr_platform §I_EHR_COMPOSITION.get_versioned_composition"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_versioned_composition-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_versioned_composition-xml.yaml
@@ -43,7 +43,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §Data representation"
   - "RM common §VERSIONED_OBJECT"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.has_composition-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.has_composition-xml.yaml
@@ -37,7 +37,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-XML components §RM documents/Composition.xsd (the globally declared `composition` element)"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-audit_system_id.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-audit_system_id.yaml
@@ -50,7 +50,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §openehr-version and openehr-audit-details"
   - "RM common §change_control (AUDIT_DETAILS.system_id)"
   - "SM openehr_platform §I_EHR_COMPOSITION.update_composition"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the audit-details `system_id` attribute arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECPR-472)
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-body_uid_mismatch.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-body_uid_mismatch.yaml
@@ -53,7 +53,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "RM common §locatable (uid 0..1)"
   - "SM openehr_platform §I_EHR_COMPOSITION.update_composition"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 guards:
   - "The REJECTION is released and gates: ITS-REST OAS operations/composition_update.yaml states the rule in its description ('If the request body already contains a COMPOSITION.uid.value, it must match the `uid_based_id` in the URL'), tier-2 ground where the docs text is silent (owner ruling 2026-07-28, register AMB-78). The 422 STATUS is adjudicated, not declared — neither tier binds this trigger to one of the operation's declared statuses; 422 is taken because the docs-text 422 row ('well-formed but was unable to be followed due to semantic errors') and the OAS responses/422.yaml both describe the exchange while the 400 row is scoped to malformed syntax. A server answering 400 answers outside that row's stated trigger"
 requires:

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-flat.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-flat.yaml
@@ -45,7 +45,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses.md §openehr-template-id"
   - "ITS-REST simplified_formats master02 §MIME Types"
   - "RM common §change_control (VERSION.commit_audit.change_type)"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.minimal_action]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-missing_if_match.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-missing_if_match.yaml
@@ -32,7 +32,7 @@ description: "Update a COMPOSITION without the If-Match precondition"
 spec_refs:
   - "ITS-REST overview Requests_and_responses §If-Match and accidental overwrites"
   - "SM openehr_platform §I_EHR_COMPOSITION.update_composition"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-prefer_absent.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-prefer_absent.yaml
@@ -30,7 +30,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §Representation details negotiation"
   - "ITS-REST overview Requests_and_responses §Prefer minimal, identifier or full representation response"
   - "SM openehr_platform §I_EHR_COMPOSITION.update_composition"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 formats: [canonical-json]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-prefer_minimal.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-prefer_minimal.yaml
@@ -31,7 +31,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §Prefer minimal, identifier or full representation response"
   - "ITS-REST overview Requests_and_responses §Representation details negotiation"
   - "SM openehr_platform §I_EHR_COMPOSITION.update_composition"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 formats: [canonical-json]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-return_identifier.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-return_identifier.yaml
@@ -46,7 +46,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §Representation details negotiation"
   - "ITS-REST overview Requests_and_responses §ETag and Last-Modified"
   - "SM openehr_platform §I_EHR_COMPOSITION.update_composition"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # `Prefer: return=identifier` arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-50) + Requests_and_responses.md §Prefer only identifier
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-stale_if_match.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-stale_if_match.yaml
@@ -36,7 +36,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §ETag and Last-Modified"
   - "RM common §change_control (master06 — VERSION.uid is an OBJECT_VERSION_ID)"
   - "SM openehr_platform §I_EHR_COMPOSITION.update_composition"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-structured.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-structured.yaml
@@ -44,7 +44,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses.md §openehr-template-id"
   - "ITS-REST simplified_formats master04 §Structured format"
   - "RM common §change_control (VERSION.commit_audit.change_type)"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.vitals]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-unknown_preceding_version.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-unknown_preceding_version.yaml
@@ -40,7 +40,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §If-Match and accidental overwrites"
   - "ITS-REST overview Resources.md §Identifier types"
   - "SM openehr_platform §I_EHR_COMPOSITION.update_composition"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-xml.yaml
@@ -32,7 +32,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-REST overview Requests_and_responses.md §If-Match and accidental overwrites"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/composition/I_ITS_REST_REVISION_HISTORY.versioned_composition_revision_history-two_versions.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_ITS_REST_REVISION_HISTORY.versioned_composition_revision_history-two_versions.yaml
@@ -45,7 +45,7 @@ spec_refs:
   - "RM common §revision_history (items 1..1; the items.last postconditions)"
   - "RM common §revision_history_item (version_id / audits; Audit_valid)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 formats: [canonical-json]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/composition/I_ITS_REST_REVISION_HISTORY.versioned_composition_revision_history-unknown_container.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_ITS_REST_REVISION_HISTORY.versioned_composition_revision_history-unknown_container.yaml
@@ -24,7 +24,7 @@ test_purpose: >-
 description: "COMPOSITION revision history for an unknown container (404)"
 spec_refs:
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 formats: [canonical-json]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-client_uid_in_use.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-client_uid_in_use.yaml
@@ -40,7 +40,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
   - "RM common §change_control (master06 §Contributions — a CONTRIBUTION is committed as a whole)"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-creation_with_preceding_version.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-creation_with_preceding_version.yaml
@@ -38,7 +38,7 @@ spec_refs:
   - "RM common §version (Preceding_version_uid_validity)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-deleted_member_with_data.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-deleted_member_with_data.yaml
@@ -43,7 +43,7 @@ spec_refs:
   - "RM common §original_version (data 0..1)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: any }                  # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-ehr_not_modifiable.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-ehr_not_modifiable.yaml
@@ -48,7 +48,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
   - "SM openehr_platform §I_EHR_STATUS.clear_ehr_modifiable"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-non_existing_ehr.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-non_existing_ehr.yaml
@@ -26,7 +26,7 @@ description: "Commit CONTRIBUTION to a non-existing EHR"
 spec_refs:
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]     # the template exists, so the miss is the EHR alone

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-prefer_minimal.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-prefer_minimal.yaml
@@ -30,7 +30,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §Prefer minimal, identifier or full representation response"
   - "ITS-REST overview Requests_and_responses §Representation details negotiation"
   - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 formats: [canonical-json]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-return_identifier.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-return_identifier.yaml
@@ -36,7 +36,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §Prefer only identifier"
   - "ITS-REST overview Requests_and_responses §Representation details negotiation"
   - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # `Prefer: return=identifier` arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-50) + Requests_and_responses.md §Prefer only identifier
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-stale_preceding_version.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-stale_preceding_version.yaml
@@ -38,7 +38,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §If-Match and accidental overwrites"
   - "RM common §change_control (master06 §Version tree — a new Version supersedes the one it names as preceding)"
   - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-wrong_media.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-wrong_media.yaml
@@ -33,7 +33,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §Simplified Formats"
   - "ITS-REST overview Requests_and_responses (HTTP status codes: 415 Unsupported Media Type)"
   - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.get_contribution-header_identity.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.get_contribution-header_identity.yaml
@@ -39,7 +39,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §Deprecated headers"
   - "ITS-REST overview Resources §Resources"
   - "SM openehr_platform §I_EHR_CONTRIBUTION.get_contribution"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.get_contribution-malformed_contribution_uid.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.get_contribution-malformed_contribution_uid.yaml
@@ -34,7 +34,7 @@ spec_refs:
   - "ITS-REST overview Glossary_and_conventions (the identifier table; contribution_uid absent from it)"
   - "BASE base_types §identification (mutually exclusive UID string patterns)"
   - "SM openehr_platform §I_EHR_CONTRIBUTION.get_contribution"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 guards:
   - "The 400-vs-404 split for a malformed identifier segment rests on the AMB-76 adjudication — ITS-REST overview Requests_and_responses.md §HTTP status codes offers both the 400 row ('syntactically invalid content') and the 404 row ('did not find the target resource') and assigns neither to a malformed segment; a server answering 404 for a garbage token breaches no quoted rule"
 requires:

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.get_contribution-resolve_refs.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.get_contribution-resolve_refs.yaml
@@ -44,7 +44,7 @@ spec_refs:
   - "ITS-REST specifications §operations/contribution_get (the Simplified Formats paragraph: only each versions[i].data payload is serialized in the requested form)"
   - "RM common §change_control (master06 — ORIGINAL_VERSION carries its own commit_audit)"
   - "SM openehr_platform §I_EHR_CONTRIBUTION.get_contribution"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.get_contribution-version_ref_shape.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.get_contribution-version_ref_shape.yaml
@@ -42,7 +42,7 @@ spec_refs:
   - "BASE base_types §object_ref (type — name of the class of object referred to)"
   - "RM common §change_control (master06 — VERSION objects are identified by a uid of type OBJECT_VERSION_ID)"
   - "SM openehr_platform §I_EHR_CONTRIBUTION.get_contribution"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.get_contribution-xml_not_acceptable.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.get_contribution-xml_not_acceptable.yaml
@@ -46,7 +46,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_CONTRIBUTION.get_contribution"
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.has_contribution-xml_not_acceptable.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.has_contribution-xml_not_acceptable.yaml
@@ -24,7 +24,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_CONTRIBUTION.has_contribution"
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.get_opt-example_detail_levels.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.get_opt-example_detail_levels.yaml
@@ -32,7 +32,7 @@ description: "get a template example at detail_level medium and complete"
 spec_refs:
   - "ITS-REST specifications §definition_template_adl1.4_example_get"
   - "SM openehr_platform §I_DEFINITION_ADL14.get_opt"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the template `/example` sub-resource arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-58)
 requires:
   server: any
   templates: [cnf.opt.minimal_action]    # provisioned as precondition (idempotent; 409 tolerated)

--- a/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.get_opt-example_invalid_detail_level.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.get_opt-example_invalid_detail_level.yaml
@@ -36,7 +36,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses.md §HTTP status codes"
   - "ITS-REST specifications §definition_template_adl1.4_example_get"
   - "SM openehr_platform §I_DEFINITION_ADL14.get_opt"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the template `/example` sub-resource arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-58)
 requires:
   server: any
   templates: [cnf.opt.minimal_action]    # provisioned as precondition (idempotent; 409 tolerated)

--- a/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.get_opt-example_type_output.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.get_opt-example_type_output.yaml
@@ -29,7 +29,7 @@ description: "get a template example with type=output"
 spec_refs:
   - "ITS-REST specifications §definition_template_adl1.4_example_get"
   - "SM openehr_platform §I_DEFINITION_ADL14.get_opt"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the template `/example` sub-resource arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-58)
 requires:
   server: any
   templates: [cnf.opt.minimal_action]    # provisioned as precondition (idempotent; 409 tolerated)

--- a/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.get_opt-flat_not_acceptable.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.get_opt-flat_not_acceptable.yaml
@@ -40,7 +40,7 @@ spec_refs:
   - "SM openehr_platform §I_DEFINITION_ADL14.get_opt"
   - "ITS-REST overview Resources.md §Simplified Formats"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.minimal_action]    # provisioned as precondition (idempotent; 409 tolerated)

--- a/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.get_opt-partial_template_id_no_match.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.get_opt-partial_template_id_no_match.yaml
@@ -43,7 +43,7 @@ spec_refs:
   - "SM openehr_platform §I_DEFINITION_ADL14.get_opt"
   - "ITS-REST specifications §definition_template_adl1.4_get"
   - "ITS-REST overview Requests_and_responses.md §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   templates: [cnf.opt.versioned.v1, cnf.opt.versioned.v2]   # the two-version family, provisioned (409-tolerant)

--- a/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.upload_opt-prefer_identifier.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.upload_opt-prefer_identifier.yaml
@@ -34,7 +34,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §Prefer only identifier"
   - "ITS-REST overview Requests_and_responses §Representation details negotiation"
   - "SM openehr_platform §I_DEFINITION_ADL14.upload_opt"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # `Prefer: return=identifier` arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-50) + Requests_and_responses.md §Prefer only identifier
 requires: { server: any }
 data_sets: [cnf.opt.time_series.v3]
 flow:

--- a/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.upload_opt-prefer_minimal.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.upload_opt-prefer_minimal.yaml
@@ -32,7 +32,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §Prefer minimal, identifier or full representation response"
   - "ITS-REST overview Requests_and_responses §Representation details negotiation"
   - "SM openehr_platform §I_DEFINITION_ADL14.upload_opt"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires: { server: any }
 data_sets: [cnf.opt.time_series.v4]
 flow:

--- a/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.upload_opt-unparseable_opt.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.upload_opt-unparseable_opt.yaml
@@ -30,7 +30,7 @@ spec_refs:
   - "SM openehr_platform §I_DEFINITION_ADL14.upload_opt"
   - "ITS-REST overview Requests_and_responses.md §HTTP status codes"
   - "CNF platform_test_schedule master04 §upload_opt data sets"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires: { server: empty }
 data_sets: [cnf.opt.invalid.empty_file]
 flow:

--- a/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.upload_opt-wrong_media.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.upload_opt-wrong_media.yaml
@@ -22,7 +22,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §JSON Format"
   - "SM openehr_platform §I_DEFINITION_ADL14.upload_opt"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
 data_sets: [cnf.opt.minimal_action]

--- a/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.get_artefact-version_prefix.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.get_artefact-version_prefix.yaml
@@ -42,7 +42,7 @@ spec_refs:
   - "SM openehr_platform §I_DEFINITION_ADL2.get_artefact"
   - "ITS-REST definition_template_adl2_version_get §200 OK"
   - "ITS-REST overview Requests_and_responses §ETag and Last-Modified"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires: { server: any }
 data_sets: [cnf.adl2.opt.versioned_v100, cnf.adl2.opt.versioned_v110]
 flow:

--- a/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.upload_artefact-prefer_identifier.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.upload_artefact-prefer_identifier.yaml
@@ -29,7 +29,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §Prefer only identifier"
   - "ITS-REST overview Requests_and_responses §Representation details negotiation"
   - "SM openehr_platform §I_DEFINITION_ADL2.upload_artefact"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # `Prefer: return=identifier` arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-50) + Requests_and_responses.md §Prefer only identifier
 requires: { server: any }
 data_sets: [cnf.adl2.opt.minimal_g]
 flow:

--- a/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.upload_artefact-prefer_minimal.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.upload_artefact-prefer_minimal.yaml
@@ -29,7 +29,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §Prefer minimal, identifier or full representation response"
   - "ITS-REST overview Requests_and_responses §Representation details negotiation"
   - "SM openehr_platform §I_DEFINITION_ADL2.upload_artefact"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires: { server: any }
 data_sets: [cnf.adl2.opt.minimal_h]
 flow:

--- a/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.upload_artefact-unparseable_artefact.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.upload_artefact-unparseable_artefact.yaml
@@ -33,7 +33,7 @@ spec_refs:
   - "SM openehr_platform §I_DEFINITION_ADL2.upload_artefact"
   - "AM ADL2 §Syntax (a well-formed artefact must parse)"
   - "ITS-REST overview Requests_and_responses.md §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires: { server: empty }
 parameters:
   iteration: reset_per_row

--- a/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.upload_artefact-wrong_media.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.upload_artefact-wrong_media.yaml
@@ -25,7 +25,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §JSON Format"
   - "SM openehr_platform §I_DEFINITION_ADL2.upload_artefact"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
 data_sets: [cnf.adl2.opt.vitals]

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.list_queries-no_match_empty_list.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.list_queries-no_match_empty_list.yaml
@@ -27,7 +27,7 @@ description: "list by a non-matching prefix on a populated registry (empty list)
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.list_queries"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires: { server: empty }
 flow:
   - step: 1

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.list_queries-prefix_all_versions.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.list_queries-prefix_all_versions.yaml
@@ -29,7 +29,7 @@ spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.list_queries"
   - "ITS-REST query Qualified_query_name.md §version identifier"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires: { server: empty }
 flow:
   - step: 1

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.list_queries-version_get_exact.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.list_queries-version_get_exact.yaml
@@ -32,7 +32,7 @@ spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.list_queries"
   - "ITS-REST query Qualified_query_name.md §version identifier"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires: { server: empty }
 flow:
   - step: 1

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.list_queries-version_get_major_prefix.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.list_queries-version_get_major_prefix.yaml
@@ -23,7 +23,7 @@ description: "get a stored query by a {major} version prefix"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.list_queries"
   - "ITS-REST query Qualified_query_name.md §version identifier"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires: { server: empty }
 flow:
   - step: 1

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.list_queries-version_get_minor_prefix.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.list_queries-version_get_minor_prefix.yaml
@@ -23,7 +23,7 @@ description: "get a stored query by a {major}.{minor} version prefix"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.list_queries"
   - "ITS-REST query Qualified_query_name.md §version identifier"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires: { server: empty }
 flow:
   - step: 1

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.list_queries-version_get_unknown.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.list_queries-version_get_unknown.yaml
@@ -28,7 +28,7 @@ spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.list_queries"
   - "ITS-REST query Qualified_query_name.md §version identifier"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires: { server: empty }
 flow:
   - step: 1

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.list_queries-version_get_xml_not_acceptable.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.list_queries-version_get_xml_not_acceptable.yaml
@@ -25,7 +25,7 @@ spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.list_queries"
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires: { server: empty }
 flow:
   - step: 1

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.list_queries-xml_not_acceptable.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.list_queries-xml_not_acceptable.yaml
@@ -24,7 +24,7 @@ spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.list_queries"
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires: { server: any }
 flow:
   - step: 1

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-default_slot_with_higher_version.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-default_slot_with_higher_version.yaml
@@ -30,7 +30,7 @@ spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
   - "ITS-REST overview Requests_and_responses §Representation details negotiation"
   - "ITS-REST query Qualified_query_name.md §version identifier"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires: { server: empty }
 flow:
   - step: 1

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-default_version_slot.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-default_version_slot.yaml
@@ -31,7 +31,7 @@ spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
   - "ITS-REST overview Requests_and_responses §Representation details negotiation"
   - "ITS-REST query Qualified_query_name.md §version identifier"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires: { server: empty }
 flow:
   - step: 1

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-dotted_name.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-dotted_name.yaml
@@ -19,7 +19,7 @@ spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
 guards:
   - "flows derived from SM I_DEFINITION_QUERY operation semantics + released ITS-REST definition docs; CNF platform_test_schedule master05 is a stalled schedule stub (all cells xx/TBD) — a coverage guide only, not the authority"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires: { server: empty }
 flow:
   - step: 1

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-reserved_name.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-reserved_name.yaml
@@ -17,7 +17,7 @@ spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
 guards:
   - "flows derived from SM I_DEFINITION_QUERY operation semantics + released ITS-REST definition docs; CNF platform_test_schedule master05 is a stalled schedule stub (all cells xx/TBD) — a coverage guide only, not the authority"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the reserved `aql` query-name resolution arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-46)
 requires: { server: empty }
 flow:
   - step: 1

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-unqualified_name.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-unqualified_name.yaml
@@ -17,7 +17,7 @@ spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
 guards:
   - "flows derived from SM I_DEFINITION_QUERY operation semantics + released ITS-REST definition docs; CNF platform_test_schedule master05 is a stalled schedule stub (all cells xx/TBD) — a coverage guide only, not the authority"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires: { server: empty }
 flow:
   - step: 1

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-update_in_place.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-update_in_place.yaml
@@ -27,7 +27,7 @@ spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
   - "ITS-REST query Qualified_query_name.md §version identifier"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires: { server: empty }
 flow:
   - step: 1

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-version_duplicate_case_variant_name.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-version_duplicate_case_variant_name.yaml
@@ -29,7 +29,7 @@ spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
   - "BASE base_types master05 §Composite Identifiers and Case"
   - "ITS-REST query Qualified_query_name.md"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires: { server: empty }
 flow:
   - step: 1

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-version_duplicate_conflict.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-version_duplicate_conflict.yaml
@@ -29,7 +29,7 @@ spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "ITS-REST query Qualified_query_name.md §version identifier"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires: { server: empty }
 flow:
   - step: 1

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-version_malformed_rejected.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-version_malformed_rejected.yaml
@@ -26,7 +26,7 @@ spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
   - "ITS-REST query Qualified_query_name.md §version identifier"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires: { server: any }
 flow:
   - step: 1

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-version_prefix_rejected.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-version_prefix_rejected.yaml
@@ -30,7 +30,7 @@ spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
   - "ITS-REST query Qualified_query_name.md §version identifier"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires: { server: any }
 flow:
   - step: 1

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-version_prerelease_rejected.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-version_prerelease_rejected.yaml
@@ -26,7 +26,7 @@ spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
   - "ITS-REST query Qualified_query_name.md §version identifier"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires: { server: any }
 flow:
   - step: 1

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-version_stored.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-version_stored.yaml
@@ -29,7 +29,7 @@ spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
   - "ITS-REST query Qualified_query_name.md §version identifier"
   - "ITS-REST overview Requests_and_responses §Representation details negotiation"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires: { server: empty }
 flow:
   - step: 1

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-wrong_media.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-wrong_media.yaml
@@ -28,7 +28,7 @@ spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
   - "ITS-REST overview Resources.md §JSON Format"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires: { server: any }
 flow:
   - step: 1

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.create_party-client_supplied_uid.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.create_party-client_supplied_uid.yaml
@@ -38,7 +38,7 @@ spec_refs:
   - "RM common §change_control (master06 §Version Identification)"
   - "ITS-REST overview Requests_and_responses §ETag and Last-Modified"
   - "SM openehr_platform §I_DEMOGRAPHIC_SERVICE.create_party"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 requires: { server: empty }
 data_sets: [cnf.demographic.person.client_uid]
 flow:

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.create_party-item_tag_wrapper_headers.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.create_party-item_tag_wrapper_headers.yaml
@@ -54,7 +54,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §openehr-item-tag and openehr-version-item-tag"
   - "ITS-REST person_create.yaml §description"
   - "RM item_tag.adoc §Attributes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 formats: [canonical-json]
 requires: { server: any }
 data_sets: [cnf.demographic.person.v1]

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.create_party-prefer_minimal.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.create_party-prefer_minimal.yaml
@@ -30,7 +30,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §Prefer minimal, identifier or full representation response"
   - "ITS-REST overview Requests_and_responses §Representation details negotiation"
   - "SM openehr_platform §I_DEMOGRAPHIC_SERVICE.create_party"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 formats: [canonical-json]
 requires: { server: empty }
 data_sets: [cnf.demographic.person.v1]

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.create_party-return_identifier.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.create_party-return_identifier.yaml
@@ -36,7 +36,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §Prefer only identifier"
   - "ITS-REST overview Requests_and_responses §Representation details negotiation"
   - "SM openehr_platform §I_DEMOGRAPHIC_SERVICE.create_party"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 requires: { server: empty }
 data_sets: [cnf.demographic.person.v1]
 flow:

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.create_party-simplified_content_type.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.create_party-simplified_content_type.yaml
@@ -43,7 +43,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §openehr-template-id"
   - "ITS-REST simplified_formats master02 §Overview"
   - "SM openehr_platform §I_DEMOGRAPHIC_SERVICE.create_party"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 requires: { server: empty }
 data_sets: [cnf.demographic.person.v1]
 flow:

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.create_party-wrong_subtype_body.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.create_party-wrong_subtype_body.yaml
@@ -33,7 +33,7 @@ spec_refs:
   - "RM demographic §PARTY"
   - "RM demographic §ROLE"
   - "SM openehr_platform §I_DEMOGRAPHIC_SERVICE.create_party"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 requires: { server: empty }
 data_sets: [cnf.demographic.role.v1]
 flow:

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.create_party-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.create_party-xml.yaml
@@ -63,7 +63,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §Data representation"
   - "RM demographic §PERSON"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 requires: { server: empty }
 data_sets: [cnf.demographic.person.v1.xml, cnf.demographic.person.v1]
 flow:

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.delete_party-already_deleted.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.delete_party-already_deleted.yaml
@@ -36,7 +36,7 @@ spec_refs:
   - "RM common §change_control (master06 §Logical Deletion)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_PARTY.delete_party"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 requires: { server: empty }
 data_sets: [cnf.demographic.person.v1]
 flow:

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.delete_party-stale_version_conflict.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.delete_party-stale_version_conflict.yaml
@@ -37,7 +37,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §If-Match and accidental overwrites"
   - "RM common §change_control (master06 §Version Identification)"
   - "SM openehr_platform §I_PARTY.delete_party"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 requires: { server: empty }
 data_sets: [cnf.demographic.person.v1, cnf.demographic.person.v2]
 flow:

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.get_party-wrong_kind_container.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.get_party-wrong_kind_container.yaml
@@ -38,7 +38,7 @@ spec_refs:
   - "RM demographic master02 §Versioning Semantics"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_PARTY.get_party"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 requires: { server: empty }
 data_sets: [cnf.demographic.person.v1]
 flow:

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.get_party-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.get_party-xml.yaml
@@ -64,7 +64,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §Data representation"
   - "RM demographic §PARTY"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 requires: { server: empty }
 data_sets: [cnf.demographic.person.v1]
 flow:

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.get_party-xml_not_acceptable.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.get_party-xml_not_acceptable.yaml
@@ -47,7 +47,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 requires: { server: empty }
 data_sets: [cnf.demographic.person.v1]
 flow:

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.get_party_at_time-deleted_current.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.get_party_at_time-deleted_current.yaml
@@ -31,7 +31,7 @@ spec_refs:
   - "RM common §change_control (master06 §Logical Deletion)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_PARTY.get_party_at_time"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 requires: { server: empty }
 data_sets: [cnf.demographic.person.v1]
 flow:

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.get_party_at_time-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.get_party_at_time-xml.yaml
@@ -57,7 +57,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §Data representation"
   - "RM demographic §PARTY"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 requires: { server: empty }
 data_sets: [cnf.demographic.person.v1]
 flow:

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.get_party_at_version-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.get_party_at_version-xml.yaml
@@ -57,7 +57,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §Data representation"
   - "RM demographic §PARTY"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 requires: { server: empty }
 data_sets: [cnf.demographic.person.v1]
 flow:

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.update_party-invalid_body.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.update_party-invalid_body.yaml
@@ -30,7 +30,7 @@ spec_refs:
   - "RM demographic §PARTY (Identities_valid)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_PARTY.update_party"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 requires: { server: empty }
 data_sets: [cnf.demographic.person.v1, cnf.demographic.person.invalid]
 flow:

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.update_party-missing_if_match.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.update_party-missing_if_match.yaml
@@ -30,7 +30,7 @@ description: "Update a PARTY without If-Match (missing precondition)"
 spec_refs:
   - "ITS-REST overview Requests_and_responses §If-Match and accidental overwrites"
   - "SM openehr_platform §I_PARTY.update_party"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 requires: { server: empty }
 data_sets: [cnf.demographic.person.v1, cnf.demographic.person.v2]
 flow:

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.update_party-prefer_minimal.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.update_party-prefer_minimal.yaml
@@ -29,7 +29,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §Prefer minimal, identifier or full representation response"
   - "ITS-REST overview Requests_and_responses §Representation details negotiation"
   - "SM openehr_platform §I_PARTY.update_party"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 formats: [canonical-json]
 requires: { server: empty }
 data_sets: [cnf.demographic.person.v1, cnf.demographic.person.v2]

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.update_party-unknown_container.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.update_party-unknown_container.yaml
@@ -32,7 +32,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "ITS-REST overview Requests_and_responses §If-Match and accidental overwrites"
   - "SM openehr_platform §I_PARTY.update_party"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 requires: { server: empty }
 data_sets: [cnf.demographic.person.v2]
 flow:

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.update_party-unknown_preceding_version.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.update_party-unknown_preceding_version.yaml
@@ -42,7 +42,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §If-Match and accidental overwrites"
   - "ITS-REST overview Resources.md §Identifier types"
   - "SM openehr_platform §I_PARTY.update_party"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 requires: { server: empty }
 data_sets: [cnf.demographic.person.v1, cnf.demographic.person.v2]
 flow:

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.update_party-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.update_party-xml.yaml
@@ -57,7 +57,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-REST overview Requests_and_responses.md §If-Match and accidental overwrites"
   - "RM demographic §PERSON"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 requires: { server: empty }
 data_sets: [cnf.demographic.person.v1, cnf.demographic.person.v2.xml, cnf.demographic.person.v2]
 flow:

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.versioned_party_version_at_time.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.versioned_party_version_at_time.yaml
@@ -42,7 +42,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §ETag and Last-Modified"
   - "RM common §versioned_object (version_at_time / has_version_at_time)"
   - "SM openehr_platform §I_PARTY.get_party_at_version"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 requires: { server: empty }
 data_sets: [cnf.demographic.person.v1, cnf.demographic.person.v2]
 flow:

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.versioned_party_version_unknown.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.versioned_party_version_unknown.yaml
@@ -34,7 +34,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "RM common §versioned_object (version_at_time / has_version_at_time)"
   - "SM openehr_platform §I_PARTY.get_party_at_version"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 requires: { server: empty }
 data_sets: [cnf.demographic.person.v1]
 flow:

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_EHR_CONTRIBUTION.commit_contribution-demographic.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_EHR_CONTRIBUTION.commit_contribution-demographic.yaml
@@ -36,7 +36,7 @@ spec_refs:
   - "RM demographic master02 §Party Identification"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 requires: { server: empty }
 data_sets: [cnf.demographic.person.v1]
 flow:

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_EHR_CONTRIBUTION.commit_contribution-demographic_client_uid.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_EHR_CONTRIBUTION.commit_contribution-demographic_client_uid.yaml
@@ -43,7 +43,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "RM common §change_control (master06 §Contributions)"
   - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 requires: { server: empty }
 data_sets: [cnf.demographic.person.v1]
 flow:

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_EHR_CONTRIBUTION.commit_contribution-demographic_invalid_change_types.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_EHR_CONTRIBUTION.commit_contribution-demographic_invalid_change_types.yaml
@@ -47,7 +47,7 @@ spec_refs:
   - "RM common §change_control (AUDIT_DETAILS Change_type_valid)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 requires: { server: empty }
 data_sets: [cnf.demographic.person.v1]
 parameters:

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_EHR_CONTRIBUTION.get_contribution-demographic_unknown.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_EHR_CONTRIBUTION.get_contribution-demographic_unknown.yaml
@@ -30,7 +30,7 @@ description: "Read an unknown demographic CONTRIBUTION (404)"
 spec_refs:
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_EHR_CONTRIBUTION.get_contribution"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 requires: { server: empty }
 flow:
   - step: 1

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_ITEM_TAGS.demographic_tags_get-space_wide_listing.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_ITEM_TAGS.demographic_tags_get-space_wide_listing.yaml
@@ -46,7 +46,7 @@ description: "Demographic space-wide tag listing reaches a PARTY tag"
 spec_refs:
   - "ITS-REST demographic_tags_get.yaml §description"
   - "RM common master07-tags.adoc §Semantics"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 formats: [canonical-json]
 requires: { server: any }
 data_sets: [cnf.demographic.person.v1]

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_ITEM_TAGS.organisation_tags_delete-wrong_kind_uid.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_ITEM_TAGS.organisation_tags_delete-wrong_kind_uid.yaml
@@ -54,7 +54,7 @@ spec_refs:
   - "RM demographic master02 §Versioning Semantics"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "ITS-REST organisation_tags_delete.yaml §description"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 formats: [canonical-json]
 requires: { server: any }
 data_sets: [cnf.demographic.person.v1]

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_ITEM_TAGS.organisation_tags_get-wrong_kind_uid.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_ITEM_TAGS.organisation_tags_get-wrong_kind_uid.yaml
@@ -54,7 +54,7 @@ spec_refs:
   - "RM demographic master02 §Versioning Semantics"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "ITS-REST organisation_tags_get.yaml §description"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 formats: [canonical-json]
 requires: { server: any }
 data_sets: [cnf.demographic.person.v1]

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_ITEM_TAGS.organisation_tags_update-wrong_kind_uid.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_ITEM_TAGS.organisation_tags_update-wrong_kind_uid.yaml
@@ -54,7 +54,7 @@ spec_refs:
   - "RM demographic master02 §Versioning Semantics"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "ITS-REST organisation_tags_update.yaml §description"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 formats: [canonical-json]
 requires: { server: any }
 data_sets: [cnf.demographic.person.v1]

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_ITEM_TAGS.person_tags_delete-key_scoped.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_ITEM_TAGS.person_tags_delete-key_scoped.yaml
@@ -39,7 +39,7 @@ description: "PERSON tag DELETE is key-scoped"
 spec_refs:
   - "ITS-REST person_tags_delete.yaml §description"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 formats: [canonical-json]
 requires: { server: any }
 data_sets: [cnf.demographic.person.v1]

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_ITEM_TAGS.person_tags_delete-unknown_key.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_ITEM_TAGS.person_tags_delete-unknown_key.yaml
@@ -37,7 +37,7 @@ description: "PERSON tag DELETE with an unknown key (404)"
 spec_refs:
   - "ITS-REST person_tags_delete.yaml §description"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 formats: [canonical-json]
 requires: { server: any }
 data_sets: [cnf.demographic.person.v1]

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_ITEM_TAGS.person_tags_delete-version_container_disjoint.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_ITEM_TAGS.person_tags_delete-version_container_disjoint.yaml
@@ -47,7 +47,7 @@ description: "PERSON tag DELETE reaches only the addressed collection"
 spec_refs:
   - "RM item_tag.adoc §Attributes"
   - "ITS-REST person_tags_delete.yaml §description"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 formats: [canonical-json]
 requires: { server: any }
 data_sets: [cnf.demographic.person.v1]

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_ITEM_TAGS.person_tags_get-container_target_shape.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_ITEM_TAGS.person_tags_get-container_target_shape.yaml
@@ -54,7 +54,7 @@ spec_refs:
   - "RM item_tag.adoc §Attributes"
   - "RM common master07-tags.adoc §Class Descriptions"
   - "ITS-REST person_tags_get.yaml §description"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 formats: [canonical-json]
 requires: { server: any }
 data_sets: [cnf.demographic.person.v1]

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_ITEM_TAGS.person_tags_get-cross_space_composition_uid.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_ITEM_TAGS.person_tags_get-cross_space_composition_uid.yaml
@@ -43,7 +43,7 @@ spec_refs:
   - "RM common §change_control (master06 §Typing)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "ITS-REST person_tags_get.yaml §description"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 formats: [canonical-json]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_ITEM_TAGS.person_tags_get-version_target_shape.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_ITEM_TAGS.person_tags_get-version_target_shape.yaml
@@ -42,7 +42,7 @@ spec_refs:
   - "RM item_tag.adoc §Attributes"
   - "RM common master07-tags.adoc §Class Descriptions"
   - "ITS-REST person_tags_get.yaml §description"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 formats: [canonical-json]
 requires: { server: any }
 data_sets: [cnf.demographic.person.v1]

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_ITEM_TAGS.person_tags_update-key_target_path_identity.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_ITEM_TAGS.person_tags_update-key_target_path_identity.yaml
@@ -56,7 +56,7 @@ spec_refs:
   - "ITS-REST person_tags_get.yaml §description"
   - "RM common master07-tags.adoc §Semantics"
   - "RM item_tag.adoc §Attributes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 formats: [canonical-json]
 requires: { server: any }
 data_sets: [cnf.demographic.person.v1]

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_ITEM_TAGS.person_tags_update-non_array_body.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_ITEM_TAGS.person_tags_update-non_array_body.yaml
@@ -42,7 +42,7 @@ description: "PERSON tag PUT with a non-array body (400)"
 spec_refs:
   - "ITS-REST person_tags_update.yaml §requestBody"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 formats: [canonical-json]
 requires: { server: any }
 data_sets: [cnf.demographic.person.v1]

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_ITEM_TAGS.person_tags_update-unknown_container.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_ITEM_TAGS.person_tags_update-unknown_container.yaml
@@ -37,7 +37,7 @@ spec_refs:
   - "ITS-REST person_tags_update.yaml §description"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "BASE base_types master05 §Identification"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 formats: [canonical-json]
 requires: { server: any }
 flow:

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_ITEM_TAGS.person_tags_update-version_container_disjoint.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_ITEM_TAGS.person_tags_update-version_container_disjoint.yaml
@@ -48,7 +48,7 @@ spec_refs:
   - "RM item_tag.adoc §Attributes"
   - "ITS-REST person_tags_get.yaml §description"
   - "ITS-REST person_tags_update.yaml §description"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 formats: [canonical-json]
 requires: { server: any }
 data_sets: [cnf.demographic.person.v1]

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_REVISION_HISTORY.versioned_party_revision_history-two_versions.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_REVISION_HISTORY.versioned_party_revision_history-two_versions.yaml
@@ -40,7 +40,7 @@ spec_refs:
   - "RM common §revision_history (items 1..1; the items.last postconditions)"
   - "RM common §revision_history_item (version_id / audits; Audit_valid)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 formats: [canonical-json]
 requires: { server: empty }
 data_sets: [cnf.demographic.person.v1, cnf.demographic.person.v2]

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_REVISION_HISTORY.versioned_party_revision_history-unknown_container.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_REVISION_HISTORY.versioned_party_revision_history-unknown_container.yaml
@@ -26,7 +26,7 @@ test_purpose: >-
 description: "PARTY revision history for an unknown container (404)"
 spec_refs:
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 formats: [canonical-json]
 requires: { server: empty }              # nothing committed, so the literal below cannot resolve
 flow:

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_VERSIONED_PARTY.versioned_party_get-container_shape.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_VERSIONED_PARTY.versioned_party_get-container_shape.yaml
@@ -58,7 +58,7 @@ spec_refs:
   - "RM common §change_control (master06 — the three-part VERSION uid the container uid is NOT)"
   - "ITS-REST overview Requests_and_responses §ETag and Last-Modified"
   - "ITS-REST overview Resources §Resources"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 formats: [canonical-json]
 requires: { server: empty }
 data_sets: [cnf.demographic.person.v1]

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_VERSIONED_PARTY.versioned_party_get-unknown_container.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_VERSIONED_PARTY.versioned_party_get-unknown_container.yaml
@@ -27,7 +27,7 @@ test_purpose: >-
 description: "Get VERSIONED_PARTY for an unknown container (404)"
 spec_refs:
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 formats: [canonical-json]
 requires: { server: empty }              # nothing committed, so the literal below cannot resolve
 flow:

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_VERSIONED_PARTY.versioned_party_get-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_VERSIONED_PARTY.versioned_party_get-xml.yaml
@@ -45,7 +45,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §Data representation"
   - "RM demographic §versioned_party"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 formats: [canonical-xml]
 option: versioned-party-xml-supported   # AMB-167 offering arm (finding 4, 2026-07-28): §Data representation makes offering XML a service choice even on a DOCUMENTED resource
 requires: { server: empty }

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_VERSIONED_PARTY.versioned_party_get-xml_not_acceptable.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_ITS_REST_VERSIONED_PARTY.versioned_party_get-xml_not_acceptable.yaml
@@ -25,7 +25,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # the Demographic API arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-70)
 requires:
   server: any
 flow:

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.create_directory-ehr_not_modifiable.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.create_directory-ehr_not_modifiable.yaml
@@ -46,7 +46,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_EHR_DIRECTORY.create_directory"
   - "SM openehr_platform §I_EHR_STATUS.clear_ehr_modifiable"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}; its EHR_STATUS v1 is is_modifiable = true

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.create_directory-ehr_with_directory.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.create_directory-ehr_with_directory.yaml
@@ -36,7 +36,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_DIRECTORY.create_directory (Pre_no_directory)"
   - "RM ehr §EHR (directory 0..1)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.create_directory-invalid_folder.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.create_directory-invalid_folder.yaml
@@ -37,7 +37,7 @@ spec_refs:
   - "SM openehr_platform §I_VALIDITY_CHECKER.content_valid"
   - "RM common §locatable (name: DV_TEXT, 1..1)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # EHR exists, no directory — mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.create_directory-prefer_minimal.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.create_directory-prefer_minimal.yaml
@@ -26,7 +26,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §Prefer minimal, identifier or full representation response"
   - "ITS-REST overview Requests_and_responses §Representation details negotiation"
   - "SM openehr_platform §I_EHR_DIRECTORY.create_directory"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 formats: [canonical-json]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.create_directory-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.create_directory-xml.yaml
@@ -55,7 +55,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_DIRECTORY.create_directory"
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-REST overview Resources.md §XML Format"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 guards:
   - "Canonical-XML support for this resource family is statement-declared, not spec-mandated — the published XSDs declare no document element for FOLDER and ITS-REST overview Resources.md §Data representation leaves the format to the service, so offering and refusing are both conformant (register AMB-167)"
 formats: [canonical-xml]

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.delete_directory-empty_ehr.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.delete_directory-empty_ehr.yaml
@@ -41,7 +41,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_DIRECTORY.delete_directory (Pre_has_directory)"
   - "RM ehr §EHR (directory 0..1)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # EHR exists, no directory — mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.delete_directory-etag_names_new_version.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.delete_directory-etag_names_new_version.yaml
@@ -46,7 +46,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "RM common §change_control (master06 §Logical Deletion)"
   - "SM openehr_platform §I_EHR_DIRECTORY.delete_directory"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.delete_directory-missing_if_match.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.delete_directory-missing_if_match.yaml
@@ -36,7 +36,7 @@ description: "Delete the directory without the If-Match precondition"
 spec_refs:
   - "ITS-REST overview Requests_and_responses §If-Match and accidental overwrites"
   - "SM openehr_platform §I_EHR_DIRECTORY.delete_directory"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.delete_directory-stale_if_match.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.delete_directory-stale_if_match.yaml
@@ -45,7 +45,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §ETag and Last-Modified"
   - "RM common §change_control (master06 — VERSION.uid is an OBJECT_VERSION_ID)"
   - "SM openehr_platform §I_EHR_DIRECTORY.delete_directory"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory-deleted_head.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory-deleted_head.yaml
@@ -40,7 +40,7 @@ spec_refs:
   - "RM common §change_control (master06 §Logical Deletion)"
   - "RM common §versioned_object (latest_version)"
   - "SM openehr_platform §I_EHR_DIRECTORY.get_directory"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory-path_sub_folder.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory-path_sub_folder.yaml
@@ -39,7 +39,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "RM ehr §FOLDER (name, folders)"
   - "SM openehr_platform §I_EHR_DIRECTORY.get_directory"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   ehr: { commits: any }                  # mints ${ehr_id}
   directory: cnf.directory.reference_structure   # the reference tree (provisioned; root -> emergency -> episode_x -> summary_compo_x)

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory-path_unresolved.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory-path_unresolved.yaml
@@ -34,7 +34,7 @@ description: "Get the directory narrowed by an unresolvable path"
 spec_refs:
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_EHR_DIRECTORY.get_directory"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   ehr: { commits: any }                  # mints ${ehr_id}
   directory: cnf.directory.reference_structure   # the reference tree; /emergency exists, /emergency/episode_z does not

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory-xml.yaml
@@ -51,7 +51,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_DIRECTORY.get_directory"
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-REST overview Resources.md §XML Format"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 guards:
   - "Canonical-XML support for this resource family is statement-declared, not spec-mandated — the published XSDs declare no document element for FOLDER and ITS-REST overview Resources.md §Data representation leaves the format to the service, so offering and refusing are both conformant (register AMB-167)"
 formats: [canonical-xml]

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory-xml_not_acceptable.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory-xml_not_acceptable.yaml
@@ -42,7 +42,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 guards:
   - "Whether the directory FOLDER is served in canonical XML is statement-declared, not spec-mandated — the published XSDs declare no document element for FOLDER and ITS-REST overview Resources.md §Data representation leaves the format to the service, so offering and refusing are both conformant (register AMB-167)"
 requires:

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory_at_time-before_first_version.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory_at_time-before_first_version.yaml
@@ -36,7 +36,7 @@ spec_refs:
   - "ITS-REST overview Resources §Datetime format"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_EHR_DIRECTORY.get_directory_at_time"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory_at_time-deleted_at_time.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory_at_time-deleted_at_time.yaml
@@ -35,7 +35,7 @@ spec_refs:
   - "RM common §change_control (master06 §Logical Deletion)"
   - "RM common §versioned_object (version_at_time)"
   - "SM openehr_platform §I_EHR_DIRECTORY.get_directory_at_time"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory_at_time-future.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory_at_time-future.yaml
@@ -39,7 +39,7 @@ spec_refs:
   - "ITS-REST overview Resources §Datetime format"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_EHR_DIRECTORY.get_directory_at_time"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory_at_time-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory_at_time-xml.yaml
@@ -55,7 +55,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_DIRECTORY.get_directory_at_time"
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-REST overview Resources.md §XML Format"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 guards:
   - "Canonical-XML support for this resource family is statement-declared, not spec-mandated — the published XSDs declare no document element for FOLDER and ITS-REST overview Resources.md §Data representation leaves the format to the service, so offering and refusing are both conformant (register AMB-167)"
 formats: [canonical-xml]

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory_at_version-deleted_version.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory_at_version-deleted_version.yaml
@@ -37,7 +37,7 @@ spec_refs:
   - "ITS-REST overview Resources §Identifier types"
   - "RM common §change_control (master06 §Logical Deletion)"
   - "SM openehr_platform §I_EHR_DIRECTORY.get_directory_at_version"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory_at_version-foreign_system_id.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory_at_version-foreign_system_id.yaml
@@ -41,7 +41,7 @@ spec_refs:
   - "RM common §change_control (master06 §Version Identification)"
   - "RM common §versioned_object (version_with_id / has_version_id)"
   - "SM openehr_platform §I_EHR_DIRECTORY.get_directory_at_version"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory_at_version-malformed_version_uid.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory_at_version-malformed_version_uid.yaml
@@ -37,7 +37,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "BASE base_types §identification (mutually exclusive UID string patterns)"
   - "SM openehr_platform §I_EHR_DIRECTORY.get_directory_at_version"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 guards:
   - "The 400-vs-404 split for a malformed identifier segment rests on the AMB-76 adjudication — ITS-REST overview Requests_and_responses.md §HTTP status codes (the 400 row) covers 'syntactically invalid content' generally but assigns no branch to a malformed identifier segment, and BASE base_types master05 §Identification carries no rejecting lexical invariant; a server answering 404 for a garbage token breaches no quoted rule"
 requires:

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory_at_version-path_sub_folder.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory_at_version-path_sub_folder.yaml
@@ -38,7 +38,7 @@ spec_refs:
   - "ITS-REST overview Resources §Identifier types"
   - "RM ehr §FOLDER (name, folders)"
   - "SM openehr_platform §I_EHR_DIRECTORY.get_directory_at_version"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   ehr: { commits: any }                  # mints ${ehr_id}
   directory: cnf.directory.reference_structure   # provisioned; publishes ${directory_version_uid}

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory_at_version-path_unresolved.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory_at_version-path_unresolved.yaml
@@ -32,7 +32,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "ITS-REST overview Resources §Identifier types"
   - "SM openehr_platform §I_EHR_DIRECTORY.get_directory_at_version"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   ehr: { commits: any }                  # mints ${ehr_id}
   directory: cnf.directory.reference_structure   # provisioned; publishes ${directory_version_uid}

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory_at_version-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory_at_version-xml.yaml
@@ -54,7 +54,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_DIRECTORY.get_directory_at_version"
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-REST overview Resources.md §XML Format"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 guards:
   - "Canonical-XML support for this resource family is statement-declared, not spec-mandated — the published XSDs declare no document element for FOLDER and ITS-REST overview Resources.md §Data representation leaves the format to the service, so offering and refusing are both conformant (register AMB-167)"
 formats: [canonical-xml]

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.has_directory-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.has_directory-xml.yaml
@@ -52,7 +52,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_DIRECTORY.has_directory"
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-REST overview Resources.md §XML Format"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 guards:
   - "Canonical-XML support for this resource family is statement-declared, not spec-mandated — the published XSDs declare no document element for FOLDER and ITS-REST overview Resources.md §Data representation leaves the format to the service, so offering and refusing are both conformant (register AMB-167)"
 formats: [canonical-xml]

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.has_directory_version-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.has_directory_version-xml.yaml
@@ -56,7 +56,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_DIRECTORY.has_directory_version"
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-REST overview Resources.md §XML Format"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 guards:
   - "Canonical-XML support for this resource family is statement-declared, not spec-mandated — the published XSDs declare no document element for FOLDER and ITS-REST overview Resources.md §Data representation leaves the format to the service, so offering and refusing are both conformant (register AMB-167)"
 formats: [canonical-xml]

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.has_path-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.has_path-xml.yaml
@@ -52,7 +52,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_DIRECTORY.has_path"
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-REST overview Resources.md §XML Format"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 guards:
   - "Canonical-XML support for this resource family is statement-declared, not spec-mandated — the published XSDs declare no document element for FOLDER and ITS-REST overview Resources.md §Data representation leaves the format to the service, so offering and refusing are both conformant (register AMB-167)"
 formats: [canonical-xml]

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.update_directory-empty_ehr.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.update_directory-empty_ehr.yaml
@@ -40,7 +40,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_DIRECTORY.update_directory (Pre_has_directory)"
   - "RM ehr §EHR (directory 0..1)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # EHR exists, no directory — mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.update_directory-invalid_folder.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.update_directory-invalid_folder.yaml
@@ -44,7 +44,7 @@ spec_refs:
   - "SM openehr_platform §I_VALIDITY_CHECKER.content_valid"
   - "RM common §locatable (name: DV_TEXT, 1..1)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # EHR exists, no directory — mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.update_directory-missing_if_match.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.update_directory-missing_if_match.yaml
@@ -30,7 +30,7 @@ description: "Update the directory without the If-Match precondition"
 spec_refs:
   - "ITS-REST overview Requests_and_responses §If-Match and accidental overwrites"
   - "SM openehr_platform §I_EHR_DIRECTORY.update_directory"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.update_directory-prefer_minimal.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.update_directory-prefer_minimal.yaml
@@ -25,7 +25,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §Prefer minimal, identifier or full representation response"
   - "ITS-REST overview Requests_and_responses §Representation details negotiation"
   - "SM openehr_platform §I_EHR_DIRECTORY.update_directory"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 formats: [canonical-json]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.update_directory-stale_if_match.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.update_directory-stale_if_match.yaml
@@ -36,7 +36,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §ETag and Last-Modified"
   - "RM common §change_control (master06 — VERSION.uid is an OBJECT_VERSION_ID)"
   - "SM openehr_platform §I_EHR_DIRECTORY.update_directory"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.update_directory-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.update_directory-xml.yaml
@@ -57,7 +57,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Requests_and_responses §If-Match and accidental overwrites"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 guards:
   - "Canonical-XML support for this resource family is statement-declared, not spec-mandated — the published XSDs declare no document element for FOLDER and ITS-REST overview Resources.md §Data representation leaves the format to the service, so offering and refusing are both conformant (register AMB-167)"
 formats: [canonical-xml]

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_COMPOSITION.create_composition-item_tag_wrapper_headers.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_COMPOSITION.create_composition-item_tag_wrapper_headers.yaml
@@ -55,7 +55,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §openehr-item-tag and openehr-version-item-tag"
   - "ITS-REST composition_create.yaml §description"
   - "RM item_tag.adoc §Attributes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # ITEM_TAGs are Release-1.1.0 behaviour — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-77)
 formats: [canonical-json]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.create_ehr-return_identifier.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.create_ehr-return_identifier.yaml
@@ -53,7 +53,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses (Prefer only identifier)"
   - "ITS-REST overview Resources (Identifier types — ehr_id identifies an EHR)"
   - "SM openehr_platform §I_EHR_SERVICE.create_ehr"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # `Prefer: return=identifier` arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-50) + Requests_and_responses.md §Prefer only identifier
 requires: { server: any }
 flow:
   - step: 1

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.create_ehr-subject_key_ignores_type.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.create_ehr-subject_key_ignores_type.yaml
@@ -39,7 +39,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "BASE base_types §party_ref (Type_validity)"
   - "SM openehr_platform §I_EHR_SERVICE.create_ehr"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 formats: [canonical-json]
 requires: { server: empty }
 data_sets: [cnf.ehr_status.with_subject.l, cnf.ehr_status.with_subject.m]

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.create_ehr-wrong_method.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.create_ehr-wrong_method.yaml
@@ -48,7 +48,6 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §HTTP Methods"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_EHR_SERVICE.create_ehr"
-applies: { its_rest: ">=1.1.0" }
 requires:
   server: any
 ambiguities: [AMB-60]

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.create_ehr-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.create_ehr-xml.yaml
@@ -75,7 +75,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 guards:
   - "Canonical-XML support for this resource family is statement-declared, not spec-mandated — the published XSDs declare no document element for EHR and ITS-REST overview Resources.md §Data representation leaves the format to the service, so offering and refusing are both conformant (register AMB-167)"
 formats: [canonical-xml]

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.get_ehr-malformed_ehr_id.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.get_ehr-malformed_ehr_id.yaml
@@ -39,7 +39,7 @@ spec_refs:
   - "ITS-REST overview Glossary_and_conventions (the identifier table: ehr_id as HIER_OBJECT_ID)"
   - "BASE base_types §identification (mutually exclusive UID string patterns)"
   - "SM openehr_platform §I_EHR_SERVICE.get_ehr"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 guards:
   - "The 400-vs-404 split for a malformed identifier segment rests on the AMB-76 adjudication — ITS-REST overview Requests_and_responses.md §HTTP status codes offers both the 400 row ('syntactically invalid content') and the 404 row ('did not find the target resource') and assigns neither to a malformed segment; a server answering 404 for a garbage token breaches no quoted rule"
 requires:

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.get_ehr-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.get_ehr-xml.yaml
@@ -52,7 +52,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_SERVICE.get_ehr"
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-REST overview Resources.md §XML Format"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 guards:
   - "Canonical-XML support for this resource family is statement-declared, not spec-mandated — the published XSDs declare no document element for EHR and ITS-REST overview Resources.md §Data representation leaves the format to the service, so offering and refusing are both conformant (register AMB-167)"
 formats: [canonical-xml]

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.get_ehr-xml_not_acceptable.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.get_ehr-xml_not_acceptable.yaml
@@ -41,7 +41,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 guards:
   - "Whether the EHR resource is served in canonical XML is statement-declared, not spec-mandated — the published XSDs declare no document element for EHR and ITS-REST overview Resources.md §Data representation leaves the format to the service, so offering and refusing are both conformant (register AMB-167)"
 requires:

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.get_ehrs_for_subject-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.get_ehrs_for_subject-xml.yaml
@@ -56,7 +56,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_SERVICE.get_ehrs_for_subject"
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-REST overview Resources.md §XML Format"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 guards:
   - "Canonical-XML support for this resource family is statement-declared, not spec-mandated — the published XSDs declare no document element for EHR and ITS-REST overview Resources.md §Data representation leaves the format to the service, so offering and refusing are both conformant (register AMB-167)"
 formats: [canonical-xml]

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.has_ehr-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.has_ehr-xml.yaml
@@ -50,7 +50,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_SERVICE.has_ehr"
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-REST overview Resources.md §XML Format"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 guards:
   - "Canonical-XML support for this resource family is statement-declared, not spec-mandated — the published XSDs declare no document element for EHR and ITS-REST overview Resources.md §Data representation leaves the format to the service, so offering and refusing are both conformant (register AMB-167)"
 formats: [canonical-xml]

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.has_ehr_for_subject-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.has_ehr_for_subject-xml.yaml
@@ -58,7 +58,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_SERVICE.has_ehr_for_subject"
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-REST overview Resources.md §XML Format"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 guards:
   - "Canonical-XML support for this resource family is statement-declared, not spec-mandated — the published XSDs declare no document element for EHR and ITS-REST overview Resources.md §Data representation leaves the format to the service, so offering and refusing are both conformant (register AMB-167)"
 formats: [canonical-xml]

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.clear_ehr_modifiable-invalid_body.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.clear_ehr_modifiable-invalid_body.yaml
@@ -41,7 +41,7 @@ spec_refs:
   - "RM ehr §EHR_STATUS"
   - "RM common §locatable (Archetyped_valid)"
   - "SM openehr_platform §I_EHR_STATUS.clear_ehr_modifiable"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.clear_ehr_modifiable-missing_if_match.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.clear_ehr_modifiable-missing_if_match.yaml
@@ -33,7 +33,7 @@ description: "Clear EHR modifiable without the If-Match precondition"
 spec_refs:
   - "ITS-REST overview Requests_and_responses §If-Match and accidental overwrites"
   - "SM openehr_platform §I_EHR_STATUS.clear_ehr_modifiable"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}; its EHR_STATUS v1 is is_modifiable = true

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.clear_ehr_modifiable-stale_if_match.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.clear_ehr_modifiable-stale_if_match.yaml
@@ -39,7 +39,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §ETag and Last-Modified"
   - "RM common §change_control (master06 — VERSION.uid is an OBJECT_VERSION_ID)"
   - "SM openehr_platform §I_EHR_STATUS.clear_ehr_modifiable"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}; its EHR_STATUS v1 is is_modifiable = true

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.clear_ehr_modifiable-xml_body.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.clear_ehr_modifiable-xml_body.yaml
@@ -51,7 +51,7 @@ spec_refs:
   - "ITS-REST overview Resources §XML Format"
   - "ITS-REST overview Resources §Data representation"
   - "SM openehr_platform §I_EHR_STATUS.clear_ehr_modifiable"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 guards:
   - "Canonical-XML support for this resource family is statement-declared, not spec-mandated — the published XSDs declare no document element for EHR_STATUS and ITS-REST overview Resources.md §Data representation leaves the format to the service, so offering and refusing are both conformant (register AMB-167)"
 formats: [canonical-xml]

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.clear_ehr_queryable-invalid_body.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.clear_ehr_queryable-invalid_body.yaml
@@ -41,7 +41,7 @@ spec_refs:
   - "RM ehr §EHR_STATUS"
   - "RM common §locatable (Archetyped_valid)"
   - "SM openehr_platform §I_EHR_STATUS.clear_ehr_queryable"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.clear_ehr_queryable-missing_if_match.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.clear_ehr_queryable-missing_if_match.yaml
@@ -33,7 +33,7 @@ description: "Clear EHR queryable without the If-Match precondition"
 spec_refs:
   - "ITS-REST overview Requests_and_responses §If-Match and accidental overwrites"
   - "SM openehr_platform §I_EHR_STATUS.clear_ehr_queryable"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}; its EHR_STATUS v1 is is_queryable = true

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.clear_ehr_queryable-stale_if_match.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.clear_ehr_queryable-stale_if_match.yaml
@@ -39,7 +39,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §ETag and Last-Modified"
   - "RM common §change_control (master06 — VERSION.uid is an OBJECT_VERSION_ID)"
   - "SM openehr_platform §I_EHR_STATUS.clear_ehr_queryable"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}; its EHR_STATUS v1 is is_queryable = true

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.clear_ehr_queryable-xml_body.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.clear_ehr_queryable-xml_body.yaml
@@ -51,7 +51,7 @@ spec_refs:
   - "ITS-REST overview Resources §XML Format"
   - "ITS-REST overview Resources §Data representation"
   - "SM openehr_platform §I_EHR_STATUS.clear_ehr_queryable"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 guards:
   - "Canonical-XML support for this resource family is statement-declared, not spec-mandated — the published XSDs declare no document element for EHR_STATUS and ITS-REST overview Resources.md §Data representation leaves the format to the service, so offering and refusing are both conformant (register AMB-167)"
 formats: [canonical-xml]

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_ehr_status-at_time_before_first_version.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_ehr_status-at_time_before_first_version.yaml
@@ -28,7 +28,7 @@ spec_refs:
   - "RM common §versioned_object (version_at_time / has_version_at_time)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_EHR_STATUS.get_ehr_status_at_time"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}; its EHR_STATUS v1 is committed during this run

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_ehr_status-at_time_future.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_ehr_status-at_time_future.yaml
@@ -28,7 +28,7 @@ spec_refs:
   - "RM common §versioned_object (version_at_time / has_version_at_time)"
   - "ITS-REST overview Resources §Datetime format"
   - "SM openehr_platform §I_EHR_STATUS.get_ehr_status_at_time"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_ehr_status-at_time_malformed.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_ehr_status-at_time_malformed.yaml
@@ -25,7 +25,7 @@ spec_refs:
   - "ITS-REST overview Resources §Datetime format"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_EHR_STATUS.get_ehr_status_at_time"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_ehr_status-at_time_omitted.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_ehr_status-at_time_omitted.yaml
@@ -31,7 +31,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_STATUS.get_ehr_status_at_time"
   - "ITS-REST overview Resources §Datetime format"
   - "RM common §versioned_object (VERSIONED_OBJECT.latest_version)"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}; its EHR_STATUS v1 is is_queryable = true

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_ehr_status-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_ehr_status-xml.yaml
@@ -51,7 +51,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_STATUS.get_ehr_status"
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-REST overview Resources.md §XML Format"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 guards:
   - "Canonical-XML support for this resource family is statement-declared, not spec-mandated — the published XSDs declare no document element for EHR_STATUS and ITS-REST overview Resources.md §Data representation leaves the format to the service, so offering and refusing are both conformant (register AMB-167)"
 formats: [canonical-xml]

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_ehr_status-xml_not_acceptable.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_ehr_status-xml_not_acceptable.yaml
@@ -43,7 +43,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 guards:
   - "Whether the EHR_STATUS resource is served in canonical XML is statement-declared, not spec-mandated — the published XSDs declare no document element for EHR_STATUS and ITS-REST overview Resources.md §Data representation leaves the format to the service, so offering and refusing are both conformant (register AMB-167)"
 requires:

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_ehr_status_at_version-addressed_version.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_ehr_status_at_version-addressed_version.yaml
@@ -32,7 +32,7 @@ spec_refs:
   - "ITS-REST overview Resources §Multiple identifiers for the same resource"
   - "RM common §versioned_object (version_with_id)"
   - "SM openehr_platform §I_EHR_STATUS.get_ehr_status_at_version"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}; its EHR_STATUS v1 is is_queryable = true

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_ehr_status_at_version-unknown_version.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_ehr_status_at_version-unknown_version.yaml
@@ -25,7 +25,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "RM common §versioned_object (has_version_id)"
   - "SM openehr_platform §I_EHR_STATUS.get_ehr_status_at_version"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_versioned_ehr_status-at_time_before_first_version.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_versioned_ehr_status-at_time_before_first_version.yaml
@@ -26,7 +26,7 @@ spec_refs:
   - "RM common §versioned_object (version_at_time / has_version_at_time)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_EHR_STATUS.get_versioned_ehr_status"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_versioned_ehr_status-at_time_future.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_versioned_ehr_status-at_time_future.yaml
@@ -29,7 +29,7 @@ spec_refs:
   - "RM common §change_control (master06 — VERSION.uid is an OBJECT_VERSION_ID)"
   - "ITS-REST overview Resources §Datetime format"
   - "SM openehr_platform §I_EHR_STATUS.get_versioned_ehr_status"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_versioned_ehr_status-at_time_malformed.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_versioned_ehr_status-at_time_malformed.yaml
@@ -23,7 +23,7 @@ spec_refs:
   - "ITS-REST overview Resources §Datetime format"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_EHR_STATUS.get_versioned_ehr_status"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_versioned_ehr_status-at_time_omitted.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_versioned_ehr_status-at_time_omitted.yaml
@@ -24,7 +24,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_STATUS.get_versioned_ehr_status"
   - "RM common §change_control (master06 — VERSION.uid is an OBJECT_VERSION_ID)"
   - "RM common §versioned_object (latest_version)"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_versioned_ehr_status-bad_ehr.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_versioned_ehr_status-bad_ehr.yaml
@@ -20,7 +20,7 @@ description: "Get VERSIONED_EHR_STATUS of a non-existing EHR"
 spec_refs:
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_EHR_STATUS.get_versioned_ehr_status"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires: { server: empty }              # no EHRs, so the literal below cannot resolve
 flow:
   - step: 1

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_versioned_ehr_status-container_shape.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_versioned_ehr_status-container_shape.yaml
@@ -39,7 +39,7 @@ spec_refs:
   - "ITS-REST overview Resources §Resources"
   - "ITS-REST overview Requests_and_responses §ETag and Last-Modified"
   - "SM openehr_platform §I_EHR_STATUS.get_versioned_ehr_status"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_versioned_ehr_status-version_of_other_ehr.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_versioned_ehr_status-version_of_other_ehr.yaml
@@ -31,7 +31,7 @@ spec_refs:
   - "RM common §versioned_object (version_with_id / has_version_id)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_EHR_STATUS.get_versioned_ehr_status"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id} — EHR A, the addressed EHR

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_versioned_ehr_status-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.get_versioned_ehr_status-xml.yaml
@@ -44,7 +44,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources §Resource identification"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 formats: [canonical-xml]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.set_ehr_modifiable-invalid_body.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.set_ehr_modifiable-invalid_body.yaml
@@ -41,7 +41,7 @@ spec_refs:
   - "RM ehr §EHR_STATUS"
   - "RM common §locatable (Archetyped_valid)"
   - "SM openehr_platform §I_EHR_STATUS.set_ehr_modifiable"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.set_ehr_modifiable-missing_if_match.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.set_ehr_modifiable-missing_if_match.yaml
@@ -33,7 +33,7 @@ description: "Set EHR modifiable without the If-Match precondition"
 spec_refs:
   - "ITS-REST overview Requests_and_responses §If-Match and accidental overwrites"
   - "SM openehr_platform §I_EHR_STATUS.set_ehr_modifiable"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}; its EHR_STATUS v1 is is_modifiable = true

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.set_ehr_modifiable-stale_if_match.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.set_ehr_modifiable-stale_if_match.yaml
@@ -40,7 +40,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §ETag and Last-Modified"
   - "RM common §change_control (master06 — VERSION.uid is an OBJECT_VERSION_ID)"
   - "SM openehr_platform §I_EHR_STATUS.set_ehr_modifiable"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}; its EHR_STATUS v1 is is_modifiable = true

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.set_ehr_modifiable-xml_body.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.set_ehr_modifiable-xml_body.yaml
@@ -51,7 +51,7 @@ spec_refs:
   - "ITS-REST overview Resources §XML Format"
   - "ITS-REST overview Resources §Data representation"
   - "SM openehr_platform §I_EHR_STATUS.set_ehr_modifiable"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 guards:
   - "Canonical-XML support for this resource family is statement-declared, not spec-mandated — the published XSDs declare no document element for EHR_STATUS and ITS-REST overview Resources.md §Data representation leaves the format to the service, so offering and refusing are both conformant (register AMB-167)"
 formats: [canonical-xml]

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.set_ehr_queryable-audit_change_type.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.set_ehr_queryable-audit_change_type.yaml
@@ -39,7 +39,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §openehr-version and openehr-audit-details"
   - "RM common §change_control (AUDIT_DETAILS.change_type; audit_change_type group)"
   - "SM openehr_platform §I_EHR_STATUS.set_ehr_queryable"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.set_ehr_queryable-invalid_body.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.set_ehr_queryable-invalid_body.yaml
@@ -40,7 +40,7 @@ spec_refs:
   - "RM ehr §EHR_STATUS"
   - "RM common §locatable (Archetyped_valid)"
   - "SM openehr_platform §I_EHR_STATUS.set_ehr_queryable"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.set_ehr_queryable-missing_if_match.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.set_ehr_queryable-missing_if_match.yaml
@@ -31,7 +31,7 @@ description: "Update EHR_STATUS without the If-Match precondition"
 spec_refs:
   - "ITS-REST overview Requests_and_responses §If-Match and accidental overwrites"
   - "SM openehr_platform §I_EHR_STATUS.set_ehr_queryable"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}; its EHR_STATUS v1 is is_queryable = true

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.set_ehr_queryable-prefer_minimal.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.set_ehr_queryable-prefer_minimal.yaml
@@ -29,7 +29,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §Prefer minimal, identifier or full representation response"
   - "ITS-REST overview Requests_and_responses §Representation details negotiation"
   - "SM openehr_platform §I_EHR_STATUS.set_ehr_queryable"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 formats: [canonical-json]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.set_ehr_queryable-return_identifier.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.set_ehr_queryable-return_identifier.yaml
@@ -33,7 +33,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses (Prefer only identifier)"
   - "ITS-REST overview Requests_and_responses (Representation details negotiation)"
   - "SM openehr_platform §I_EHR_STATUS.set_ehr_queryable"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # `Prefer: return=identifier` arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-50) + Requests_and_responses.md §Prefer only identifier
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.set_ehr_queryable-stale_if_match.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.set_ehr_queryable-stale_if_match.yaml
@@ -36,7 +36,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §ETag and Last-Modified"
   - "RM common §change_control (master06 — VERSION.uid is an OBJECT_VERSION_ID)"
   - "SM openehr_platform §I_EHR_STATUS.set_ehr_queryable"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}; its EHR_STATUS v1 is is_queryable = true

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.set_ehr_queryable-xml_body.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.set_ehr_queryable-xml_body.yaml
@@ -51,7 +51,7 @@ spec_refs:
   - "ITS-REST overview Resources §XML Format"
   - "ITS-REST overview Resources §Data representation"
   - "SM openehr_platform §I_EHR_STATUS.set_ehr_queryable"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 guards:
   - "Canonical-XML support for this resource family is statement-declared, not spec-mandated — the published XSDs declare no document element for EHR_STATUS and ITS-REST overview Resources.md §Data representation leaves the format to the service, so offering and refusing are both conformant (register AMB-167)"
 formats: [canonical-xml]

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.update_other_details-round_trip.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_STATUS.update_other_details-round_trip.yaml
@@ -37,7 +37,7 @@ spec_refs:
   - "RM ehr §EHR_STATUS (other_details: ITEM_STRUCTURE)"
   - "ITS-REST overview Requests_and_responses §If-Match and accidental overwrites"
   - "ITS-REST overview Resources.md §JSON Format"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}; its EHR_STATUS v1 carries no other_details

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.composition_tags_delete-key_scoped.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.composition_tags_delete-key_scoped.yaml
@@ -40,7 +40,7 @@ description: "COMPOSITION tag DELETE is key-scoped"
 spec_refs:
   - "ITS-REST composition_tags_delete.yaml §description"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # ITEM_TAGs are Release-1.1.0 behaviour — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-77)
 formats: [canonical-json]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.composition_tags_delete-unknown_key.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.composition_tags_delete-unknown_key.yaml
@@ -36,7 +36,7 @@ description: "COMPOSITION tag DELETE with an unknown key (404)"
 spec_refs:
   - "ITS-REST composition_tags_delete.yaml §description"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # ITEM_TAGs are Release-1.1.0 behaviour — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-77)
 formats: [canonical-json]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.composition_tags_delete-version_container_disjoint.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.composition_tags_delete-version_container_disjoint.yaml
@@ -44,7 +44,7 @@ description: "COMPOSITION tag DELETE reaches only the addressed collection"
 spec_refs:
   - "RM item_tag.adoc §Attributes"
   - "ITS-REST composition_tags_delete.yaml §description"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # ITEM_TAGs are Release-1.1.0 behaviour — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-77)
 formats: [canonical-json]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.composition_tags_get-container_target_shape.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.composition_tags_get-container_target_shape.yaml
@@ -53,7 +53,7 @@ spec_refs:
   - "RM common master07-tags.adoc §Class Descriptions"
   - "RM ehr.adoc §Attributes"
   - "ITS-REST composition_tags_get.yaml §description"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # ITEM_TAGs are Release-1.1.0 behaviour — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-77)
 formats: [canonical-json]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.composition_tags_get-cross_space_party_uid.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.composition_tags_get-cross_space_party_uid.yaml
@@ -49,7 +49,7 @@ spec_refs:
   - "RM ehr.adoc §Attributes"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "ITS-REST composition_tags_get.yaml §description"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # ITEM_TAGs are Release-1.1.0 behaviour — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-77)
 formats: [canonical-json]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.composition_tags_get-version_target_shape.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.composition_tags_get-version_target_shape.yaml
@@ -43,7 +43,7 @@ spec_refs:
   - "RM item_tag.adoc §Attributes"
   - "RM common master07-tags.adoc §Class Descriptions"
   - "ITS-REST composition_tags_get.yaml §description"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # ITEM_TAGs are Release-1.1.0 behaviour — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-77)
 formats: [canonical-json]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.composition_tags_update-key_target_path_identity.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.composition_tags_update-key_target_path_identity.yaml
@@ -59,7 +59,7 @@ spec_refs:
   - "ITS-REST composition_tags_get.yaml §description"
   - "RM common master07-tags.adoc §Semantics"
   - "RM item_tag.adoc §Attributes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # ITEM_TAGs are Release-1.1.0 behaviour — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-77)
 formats: [canonical-json]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.composition_tags_update-non_array_body.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.composition_tags_update-non_array_body.yaml
@@ -43,7 +43,7 @@ description: "COMPOSITION tag PUT with a non-array body (400)"
 spec_refs:
   - "ITS-REST composition_tags_update.yaml §requestBody"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # ITEM_TAGs are Release-1.1.0 behaviour — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-77)
 formats: [canonical-json]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.composition_tags_update-unknown_container.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.composition_tags_update-unknown_container.yaml
@@ -37,7 +37,7 @@ spec_refs:
   - "ITS-REST composition_tags_update.yaml §description"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "BASE base_types master05 §Identification"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # ITEM_TAGs are Release-1.1.0 behaviour — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-77)
 formats: [canonical-json]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.composition_tags_update-version_container_disjoint.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.composition_tags_update-version_container_disjoint.yaml
@@ -49,7 +49,7 @@ spec_refs:
   - "RM item_tag.adoc §Attributes"
   - "ITS-REST overview Requests_and_responses §openehr-item-tag and openehr-version-item-tag"
   - "ITS-REST composition_tags_update.yaml §description"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # ITEM_TAGs are Release-1.1.0 behaviour — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-77)
 formats: [canonical-json]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.ehr_status_tags_delete-wrong_kind_uid.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.ehr_status_tags_delete-wrong_kind_uid.yaml
@@ -47,7 +47,7 @@ spec_refs:
   - "RM common §change_control (master06 §Typing)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "ITS-REST ehr_status_tags_delete.yaml §description"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # ITEM_TAGs are Release-1.1.0 behaviour — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-77)
 formats: [canonical-json]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.ehr_status_tags_get-wrong_kind_uid.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.ehr_status_tags_get-wrong_kind_uid.yaml
@@ -47,7 +47,7 @@ spec_refs:
   - "RM common §change_control (master06 §Typing)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "ITS-REST ehr_status_tags_get.yaml §description"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # ITEM_TAGs are Release-1.1.0 behaviour — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-77)
 formats: [canonical-json]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.ehr_status_tags_update-key_target_path_identity.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.ehr_status_tags_update-key_target_path_identity.yaml
@@ -42,7 +42,7 @@ spec_refs:
   - "ITS-REST ehr_status_tags_update.yaml §description"
   - "ITS-REST ehr_status_tags_get.yaml §description"
   - "RM common master07-tags.adoc §Semantics"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # ITEM_TAGs are Release-1.1.0 behaviour — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-77)
 formats: [canonical-json]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.ehr_status_tags_update-wrong_kind_uid.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.ehr_status_tags_update-wrong_kind_uid.yaml
@@ -47,7 +47,7 @@ spec_refs:
   - "RM common §change_control (master06 §Typing)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "ITS-REST ehr_status_tags_update.yaml §description"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # ITEM_TAGs are Release-1.1.0 behaviour — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-77)
 formats: [canonical-json]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.ehr_tags_get-ehr_wide_listing.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.ehr_tags_get-ehr_wide_listing.yaml
@@ -41,7 +41,7 @@ description: "EHR-wide tag listing reaches a COMPOSITION tag"
 spec_refs:
   - "ITS-REST ehr_tags_get.yaml §description"
   - "RM ehr.adoc §Attributes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # ITEM_TAGs are Release-1.1.0 behaviour — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-77)
 formats: [canonical-json]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.ehr_tags_get-unknown_ehr.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_ITEM_TAGS.ehr_tags_get-unknown_ehr.yaml
@@ -35,7 +35,7 @@ description: "EHR-wide tag listing for an unknown EHR (404)"
 spec_refs:
   - "ITS-REST ehr_tags_get.yaml §responses"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # ITEM_TAGs are Release-1.1.0 behaviour — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-77)
 formats: [canonical-json]
 requires: { server: empty }
 flow:

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_REVISION_HISTORY.versioned_ehr_status_revision_history-bad_ehr.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_REVISION_HISTORY.versioned_ehr_status_revision_history-bad_ehr.yaml
@@ -25,7 +25,7 @@ test_purpose: >-
 description: "EHR_STATUS revision history of a non-existing EHR (404)"
 spec_refs:
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 formats: [canonical-json]
 requires: { server: empty }              # no EHRs, so the literal below cannot resolve
 flow:

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_REVISION_HISTORY.versioned_ehr_status_revision_history-two_versions.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_ITS_REST_REVISION_HISTORY.versioned_ehr_status_revision_history-two_versions.yaml
@@ -43,7 +43,7 @@ spec_refs:
   - "RM common §revision_history_item (version_id / audits; Audit_valid)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "ITS-REST overview Requests_and_responses §If-Match and accidental overwrites"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 formats: [canonical-json]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_ad_hoc_query-ehr_id_header_deprecated_get.yaml
+++ b/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_ad_hoc_query-ehr_id_header_deprecated_get.yaml
@@ -52,7 +52,7 @@ spec_refs:
   - "ITS-REST query Request.md §Common Headers and Query Parameters"
   - "ITS-REST query Query_types.md §Single EHR queries, §Population queries"
   - "SM openehr_platform §I_QUERY_SERVICE.execute_ad_hoc_query"
-applies: { rm: ">=1.0.2", aql: ">=1.1", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", aql: ">=1.1" }
 requires:
   server: any
   templates: [cnf.opt.blood_pressure, cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_ad_hoc_query-ehr_id_param_and_header_agree.yaml
+++ b/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_ad_hoc_query-ehr_id_param_and_header_agree.yaml
@@ -32,7 +32,7 @@ spec_refs:
   - "ITS-REST query Request.md §Common Headers and Query Parameters"
   - "ITS-REST query Query_types.md §Single EHR queries, §Population queries"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", aql: ">=1.1", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", aql: ">=1.1" }
 requires:
   server: any
   templates: [cnf.opt.blood_pressure]

--- a/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_ad_hoc_query-ehr_id_param_and_header_conflict.yaml
+++ b/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_ad_hoc_query-ehr_id_param_and_header_conflict.yaml
@@ -43,7 +43,7 @@ spec_refs:
   - "SM openehr_platform §I_QUERY_SERVICE.execute_ad_hoc_query"
   - "ITS-REST query Request.md §About the ehr_id parameter"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", aql: ">=1.1", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", aql: ">=1.1" }
 guards:
   - "No released sentence assigns precedence when the ehr_id parameter and the openehr-ehr-id header disagree — ITS-REST query Request.md §About the ehr_id parameter offers them as alternatives and stops there; the refusal rests on the AMB-59 adjudication, so a server that honoured one form over the other breaches no quoted rule"
 requires:

--- a/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_ad_hoc_query-fetch_over_limit.yaml
+++ b/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_ad_hoc_query-fetch_over_limit.yaml
@@ -36,7 +36,7 @@ spec_refs:
   - "ITS-REST query Request.md §Common Headers and Query Parameters"
   - "QUERY AQL §LIMIT"
   - "ITS-REST query Response.md §RESULT_SET response"
-applies: { rm: ">=1.0.2", aql: ">=1.1", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", aql: ">=1.1" }
 ambiguities: [AMB-98]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_ad_hoc_query-post_fetch_conflict.yaml
+++ b/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_ad_hoc_query-post_fetch_conflict.yaml
@@ -43,7 +43,7 @@ spec_refs:
   - "ITS-REST query Request.md §Common Headers and Query Parameters"
   - "ITS-REST query Request.md §GET vs POST"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", aql: ">=1.1", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", aql: ">=1.1" }
 guards:
   - "No released sentence assigns precedence when the same paging parameter is carried in the URL and in the body — ITS-REST query Request.md §Common Headers and Query Parameters offers the URL forms and §GET vs POST the body form, and neither legislates the collision; the refusal rests on the AMB-99 adjudication, so a server that honoured one place over the other breaches no quoted rule"
 requires:

--- a/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_ad_hoc_query-post_fetch_url_and_body.yaml
+++ b/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_ad_hoc_query-post_fetch_url_and_body.yaml
@@ -30,7 +30,7 @@ spec_refs:
   - "ITS-REST query Request.md §Common Headers and Query Parameters"
   - "ITS-REST query Request.md §GET vs POST"
   - "ITS-REST query Response.md §RESULT_SET response"
-applies: { rm: ">=1.0.2", aql: ">=1.1", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", aql: ">=1.1" }
 ambiguities: [AMB-99]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_ad_hoc_query-post_fetch_url_only.yaml
+++ b/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_ad_hoc_query-post_fetch_url_only.yaml
@@ -29,7 +29,7 @@ spec_refs:
   - "ITS-REST query Request.md §Common Headers and Query Parameters"
   - "ITS-REST query Request.md §GET vs POST"
   - "ITS-REST query Response.md §RESULT_SET response"
-applies: { rm: ">=1.0.2", aql: ">=1.1", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", aql: ">=1.1" }
 ambiguities: [AMB-99]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_ad_hoc_query-result_set_etag.yaml
+++ b/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_ad_hoc_query-result_set_etag.yaml
@@ -40,7 +40,7 @@ spec_refs:
   - "ITS-REST query Request.md §Common Headers and Query Parameters"
   - "ITS-REST overview Requests_and_responses.md §ETag and Last-Modified"
   - "ITS-REST overview Requests_and_responses.md §Deprecated headers"
-applies: { rm: ">=1.0.2", aql: ">=1.1", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", aql: ">=1.1" }
 requires:
   server: any
   ehr: { commits: none }                      # mints ${ehr_id} with zero commits

--- a/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_ad_hoc_query-unknown_ehr_scope.yaml
+++ b/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_ad_hoc_query-unknown_ehr_scope.yaml
@@ -35,7 +35,7 @@ spec_refs:
   - "ITS-REST query Request.md §About the ehr_id parameter"
   - "ITS-REST query Query_types.md §Single EHR queries"
   - "ITS-REST overview Requests_and_responses.md §HTTP status codes"
-applies: { rm: ">=1.0.2", aql: ">=1.1", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", aql: ">=1.1" }
 ambiguities: [AMB-101]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_stored_query-fetch_with_top.yaml
+++ b/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_stored_query-fetch_with_top.yaml
@@ -31,7 +31,7 @@ spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
   - "ITS-REST query Request.md §Common Headers and Query Parameters (fetch cannot be combined with TOP)"
   - "QUERY AQL §TOP"
-applies: { rm: ">=1.0.2", aql: ">=1.1", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", aql: ">=1.1" }
 requires:
   server: any
   ehr: { commits: none }                    # mints ${ehr_id} for the single-EHR execution context

--- a/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_stored_query-post_empty_body.yaml
+++ b/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_stored_query-post_empty_body.yaml
@@ -42,7 +42,7 @@ spec_refs:
   - "ITS-REST query Request.md §GET vs POST"
   - "ITS-REST query Request.md §Query parameters"
   - "ITS-REST query Response.md §RESULT_SET response"
-applies: { rm: ">=1.0.2", aql: ">=1.1", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", aql: ">=1.1" }
 ambiguities: [AMB-99]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_stored_query-protocol_fetch_reserved.yaml
+++ b/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_stored_query-protocol_fetch_reserved.yaml
@@ -46,7 +46,7 @@ spec_refs:
   - "ITS-REST query Request.md §Common Headers and Query Parameters"
   - "ITS-REST query Request.md §Query parameters"
   - "QUERY AQL §Parameters, §WHERE"
-applies: { rm: ">=1.0.2", aql: ">=1.1", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", aql: ">=1.1" }
 ambiguities: [AMB-100]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_stored_query-reserved_name.yaml
+++ b/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_stored_query-reserved_name.yaml
@@ -33,7 +33,7 @@ spec_refs:
   - "ITS-REST query Qualified_query_name.md §NOTE (reserved name)"
   - "ITS-REST query Query_types.md §Ad-hoc queries"
   - "ITS-REST overview Requests_and_responses.md §HTTP status codes"
-applies: { rm: ">=1.0.2", aql: ">=1.1", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", aql: ">=1.1", its_rest: ">=1.1.0" }   # the reserved `aql` query-name resolution arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-46)
 ambiguities: [AMB-102]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_stored_query-version_exact.yaml
+++ b/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_stored_query-version_exact.yaml
@@ -33,7 +33,7 @@ spec_refs:
   - "ITS-REST query Qualified_query_name.md §version identifier"
   - "ITS-REST query Response.md §RESULT_SET response"
   - "QUERY AQL §SELECT, §FROM, §CONTAINS"
-applies: { rm: ">=1.0.2", aql: ">=1.1", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", aql: ">=1.1" }
 requires:
   server: any
   templates: [cnf.opt.blood_pressure]

--- a/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_stored_query-version_major_prefix.yaml
+++ b/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_stored_query-version_major_prefix.yaml
@@ -29,7 +29,7 @@ spec_refs:
   - "ITS-REST query Qualified_query_name.md §version identifier"
   - "ITS-REST query Response.md §RESULT_SET response"
   - "QUERY AQL §SELECT, §FROM, §CONTAINS"
-applies: { rm: ">=1.0.2", aql: ">=1.1", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", aql: ">=1.1" }
 requires:
   server: any
   templates: [cnf.opt.blood_pressure]

--- a/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_stored_query-version_malformed_selector.yaml
+++ b/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_stored_query-version_malformed_selector.yaml
@@ -30,7 +30,7 @@ spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
   - "ITS-REST query Qualified_query_name.md §version identifier"
   - "ITS-REST overview Requests_and_responses.md §HTTP status codes"
-applies: { rm: ">=1.0.2", aql: ">=1.1", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", aql: ">=1.1" }
 ambiguities: [AMB-102]
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_stored_query-version_minor_prefix.yaml
+++ b/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_stored_query-version_minor_prefix.yaml
@@ -31,7 +31,7 @@ spec_refs:
   - "ITS-REST query Qualified_query_name.md §version identifier"
   - "ITS-REST query Response.md §RESULT_SET response"
   - "QUERY AQL §SELECT, §FROM, §CONTAINS"
-applies: { rm: ">=1.0.2", aql: ">=1.1", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", aql: ">=1.1" }
 requires:
   server: any
   templates: [cnf.opt.blood_pressure]

--- a/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_stored_query-version_unknown_major.yaml
+++ b/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_stored_query-version_unknown_major.yaml
@@ -27,7 +27,7 @@ spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
   - "ITS-REST query Qualified_query_name.md §version identifier"
   - "ITS-REST overview Requests_and_responses.md §HTTP status codes"
-applies: { rm: ">=1.0.2", aql: ">=1.1", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", aql: ">=1.1" }
 requires:
   server: any
 flow:

--- a/tools/cnf-runner/artifacts/schedule/security/SEC-AUTHENTICATED_ACCESS-www_authenticate_challenge.yaml
+++ b/tools/cnf-runner/artifacts/schedule/security/SEC-AUTHENTICATED_ACCESS-www_authenticate_challenge.yaml
@@ -39,7 +39,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses (HTTP status codes: 401 — lacks valid authentication credentials for the target resource)"
   - "SM openehr_platform §I_EHR_SERVICE.get_ehr"
   - "CNF 2.0 security schedule §SEC-BASIC Authenticated access (this proposal; 2017 schedule Security BASIC lineage)"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 guards:
   - "applies only when the SUT declares the SEC-BASIC security tier — CNF 2.0 security schedule (this proposal; 2017 schedule Security BASIC lineage)"
   - "the challenge is mandated only when the service requires authentication — ITS-REST overview Requests_and_responses §Authentication and authorization ('If authentication and authorization are required'); a service declaring no authentication framework is not in scope"

--- a/tools/cnf-runner/artifacts/schedule/security/SIG-VERSION-ehr_status_signature-pgp.yaml
+++ b/tools/cnf-runner/artifacts/schedule/security/SIG-VERSION-ehr_status_signature-pgp.yaml
@@ -30,7 +30,7 @@ spec_refs:
   - "RM common §change_control (Digital Signature: ORIGINAL_VERSION.signature over the canonical form, generated per openPGP RFC 4880 — each Version of any logical item)"
   - "ITS-REST overview Resources.md §Resource identification (VERSIONED_EHR_STATUS / its contained VERSION instances)"
   - "CNF profiles master03-profiles.adoc §Non-Functional (Security & Privacy: Signing)"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 guards:
   - "not-applicable when the SUT declares no Signing capability — CNF profiles master03-profiles.adoc §Non-Functional (Security & Privacy: Signing)"
   - "not-applicable when the party declares no openPGP-posture instance (`sut_pgp`) — the mode a deployment runs is an ixit declaration, not a wire value (RM common §change_control Digital Signature)"

--- a/tools/cnf-runner/artifacts/schedule/security/SIG-VERSION-ehr_status_signature.yaml
+++ b/tools/cnf-runner/artifacts/schedule/security/SIG-VERSION-ehr_status_signature.yaml
@@ -21,7 +21,7 @@ spec_refs:
   - "RM common §change_control (Digital Signature: ORIGINAL_VERSION.signature over the canonical form — each Version of any logical item)"
   - "ITS-REST overview Resources.md §Resource identification (VERSIONED_EHR_STATUS / its contained VERSION instances)"
   - "CNF profiles master03-profiles.adoc §Non-Functional (Security & Privacy: Signing)"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2" }
 guards:
   - "not-applicable when the SUT declares no Signing capability — CNF profiles master03-profiles.adoc §Non-Functional (Security & Privacy: Signing)"
 requires:

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-CONTRIB-flat_commit.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-CONTRIB-flat_commit.yaml
@@ -45,7 +45,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §openehr-template-id"
   - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
   - "RM common §change_control (CONTRIBUTION.versions)"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.minimal_action]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-CONTRIB-flat_read.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-CONTRIB-flat_read.yaml
@@ -38,7 +38,7 @@ spec_refs:
   - "ITS-REST simplified_formats master02 §MIME Types"
   - "SM openehr_platform §I_EHR_CONTRIBUTION.get_contribution"
   - "RM common §change_control (CONTRIBUTION.audit)"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-CONTRIB-structured_commit.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-CONTRIB-structured_commit.yaml
@@ -34,7 +34,7 @@ spec_refs:
   - "ITS-REST simplified_formats master04 §Structured format"
   - "ITS-REST overview Requests_and_responses §openehr-template-id"
   - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.vitals]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-CONTRIB-structured_read.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-CONTRIB-structured_read.yaml
@@ -26,7 +26,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §Simplified Formats"
   - "ITS-REST simplified_formats master04 §Structured format"
   - "SM openehr_platform §I_EHR_CONTRIBUTION.get_contribution"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-CTX-composer_name.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-CTX-composer_name.yaml
@@ -19,7 +19,7 @@ spec_refs:
   - "ITS-REST simplified_formats master05 §PARTY_IDENTIFIED"
   - "ITS-REST overview Requests_and_responses §openehr-template-id"
   - "RM common §PARTY_IDENTIFIED"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.minimal_action]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-CTX-composer_self.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-CTX-composer_self.yaml
@@ -18,7 +18,7 @@ spec_refs:
   - "ITS-REST simplified_formats master05 §PARTY_SELF"
   - "ITS-REST overview Requests_and_responses §openehr-template-id"
   - "RM common §PARTY_SELF"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.minimal_action]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-CTX-missing_mandatory.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-CTX-missing_mandatory.yaml
@@ -18,7 +18,7 @@ spec_refs:
   - "ITS-REST simplified_formats master04 §Context"
   - "ITS-REST simplified_formats master06 §Language and Territory"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.vitals]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-CTX-participations_forms.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-CTX-participations_forms.yaml
@@ -24,7 +24,7 @@ spec_refs:
   - "ITS-REST simplified_formats master05 §PARTICIPATION"
   - "ITS-REST simplified_formats master05 §DV_IDENTIFIER"
   - "RM ehr §EVENT_CONTEXT"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.vitals]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-CTX-vocabulary_mapping.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-CTX-vocabulary_mapping.yaml
@@ -23,7 +23,7 @@ spec_refs:
   - "ITS-REST simplified_formats master06 §Context Information"
   - "ITS-REST simplified_formats master04 §Context"
   - "RM ehr §EVENT_CONTEXT"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.minimal_action]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-DEPRECATED-accept_unsupported.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-DEPRECATED-accept_unsupported.yaml
@@ -30,7 +30,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §Alternative data formats (deprecated application/openehr.wt.flat.schema+json)"
   - "ITS-REST simplified_formats master02 §MIME Types"
   - "SM openehr_platform §I_DEFINITION_ADL14.get_opt"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 guards:
   - "Deprecated-media-type support is statement-declared, not spec-mandated — the ICS options declaration selects this branch (AMB-39); ITS-REST simplified_formats master02 §MIME Types defines only the current wt.flat/wt.structured MIME types"
 requires:

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-DEPRECATED-media_supported.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-DEPRECATED-media_supported.yaml
@@ -30,7 +30,7 @@ spec_refs:
   - "ITS-REST simplified_formats master02 §Overview"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "ITS-REST overview Resources.md §Simplified Formats (deprecated media types NOTE)"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 guards:
   - "Deprecated-media-type support is statement-declared, not spec-mandated — the ICS options declaration selects this branch (AMB-39); ITS-REST simplified_formats master02 defines only the current wt.flat/wt.structured MIME types"
 requires:

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-DEPRECATED-media_unsupported.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-DEPRECATED-media_unsupported.yaml
@@ -30,7 +30,7 @@ spec_refs:
   - "ITS-REST simplified_formats master02 §Overview"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "ITS-REST overview Resources.md §Simplified Formats (deprecated media types NOTE)"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 guards:
   - "Deprecated-media-type support is statement-declared, not spec-mandated — the ICS options declaration selects this branch (AMB-39); ITS-REST simplified_formats master02 defines only the current wt.flat/wt.structured MIME types"
 requires:

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-EXAMPLE-accept_forms.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-EXAMPLE-accept_forms.yaml
@@ -22,7 +22,7 @@ spec_refs:
   - "ITS-REST simplified_formats master05 §COMPOSITION"
   - "ITS-REST specifications §definition_template_adl1.4_example_get"
   - "SM openehr_platform §I_DEFINITION_ADL14.get_opt"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.minimal_action]    # provisioned as precondition (idempotent; 409 tolerated)

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-EXAMPLE-roundtrip.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-EXAMPLE-roundtrip.yaml
@@ -26,7 +26,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §Simplified Formats"
   - "SM openehr_platform §I_DEFINITION_ADL14.get_opt"
   - "SM openehr_platform §I_EHR_COMPOSITION.create_composition"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.minimal_action]    # provisioned as precondition (idempotent; 409 tolerated)

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-EXAMPLE-unsupported_accept.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-EXAMPLE-unsupported_accept.yaml
@@ -22,7 +22,7 @@ spec_refs:
   - "ITS-REST simplified_formats master04 §Web Template Metadata"
   - "ITS-REST specifications §definition_template_adl1.4_example_get"
   - "SM openehr_platform §I_DEFINITION_ADL14.get_opt"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.minimal_action]    # provisioned as precondition (idempotent; 409 tolerated)

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-FIELDID-structure.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-FIELDID-structure.yaml
@@ -22,7 +22,7 @@ description: "Field-identifier structure ingredients (master04)"
 spec_refs:
   - "ITS-REST simplified_formats master04 §Field Identifiers"
   - "ITS-REST simplified_formats master04 §Path Construction"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.maximal]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-FLAT-adl2_commit.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-FLAT-adl2_commit.yaml
@@ -27,7 +27,7 @@ spec_refs:
   - "ITS-REST simplified_formats master04 §Web Template Metadata (dialect-neutral)"
   - "SM openehr_platform §I_DEFINITION_ADL2.upload_artefact"
   - "BASE architecture_overview master05 §Package Structure (ADL 1.4 and ADL 2 side by side)"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-FLAT-adl2_reject_cardinality.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-FLAT-adl2_reject_cardinality.yaml
@@ -22,7 +22,7 @@ spec_refs:
   - "ITS-REST simplified_formats master04 §Instance Indexing"
   - "AM AOM2 §C_ATTRIBUTE (cardinality)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-FLAT-commit_roundtrip_ctx_defaults.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-FLAT-commit_roundtrip_ctx_defaults.yaml
@@ -17,7 +17,7 @@ spec_refs:
   - "ITS-REST simplified_formats master04 §Field Identifiers, §Validation"
   - "ITS-REST simplified_formats master06 §time + §setting"
   - "ITS-REST overview Requests_and_responses §openehr-template-id"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.minimal_action]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-FLAT-missing_template_id.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-FLAT-missing_template_id.yaml
@@ -19,7 +19,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §openehr-template-id"
   - "ITS-REST simplified_formats master02 §MIME Types"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.minimal_action]            # the OPT exists — the failure is the missing header, not a missing OPT

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-FLAT-reject_cardinality.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-FLAT-reject_cardinality.yaml
@@ -17,7 +17,7 @@ spec_refs:
   - "ITS-REST simplified_formats master04 §Validation"
   - "ITS-REST simplified_formats master04 §Instance Indexing"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.vitals]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-FLAT-reject_datatype_mismatch.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-FLAT-reject_datatype_mismatch.yaml
@@ -19,7 +19,7 @@ spec_refs:
   - "ITS-REST simplified_formats master05 §DV_QUANTITY"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "RM data_types §DV_QUANTITY"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.vitals]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-FLAT-reject_other_closed_list.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-FLAT-reject_other_closed_list.yaml
@@ -20,7 +20,7 @@ spec_refs:
   - "ITS-REST simplified_formats master05 §DV_CODED_TEXT"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "RM data_types §DV_CODED_TEXT"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.vitals]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-FLAT-reject_other_with_code.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-FLAT-reject_other_with_code.yaml
@@ -20,7 +20,7 @@ spec_refs:
   - "ITS-REST simplified_formats master05 §DV_CODED_TEXT"
   - "RM data_types §DV_CODED_TEXT"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.vitals]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-FLAT-reject_terminology_binding.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-FLAT-reject_terminology_binding.yaml
@@ -18,7 +18,7 @@ spec_refs:
   - "ITS-REST simplified_formats master05 §DV_CODED_TEXT"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "RM data_types §DV_CODED_TEXT"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.vitals]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-FLAT-reject_unknown_field.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-FLAT-reject_unknown_field.yaml
@@ -17,7 +17,7 @@ spec_refs:
   - "ITS-REST simplified_formats master04 §Validation"
   - "ITS-REST simplified_formats master04 §Field Identifiers"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.vitals]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-INDEX-multi_event_commit.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-INDEX-multi_event_commit.yaml
@@ -23,7 +23,7 @@ spec_refs:
   - "ITS-REST simplified_formats master04 §Flat format"
   - "ITS-REST overview Requests_and_responses §openehr-template-id"
   - "RM data_structures §HISTORY"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.vitals]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-INDEX-semantics.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-INDEX-semantics.yaml
@@ -26,7 +26,7 @@ spec_refs:
   - "ITS-REST simplified_formats master04 §Flat format"
   - "ITS-REST overview Requests_and_responses §openehr-template-id"
   - "RM data_structures §HISTORY"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.vitals]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-LEGACY-nc_flat_media_unsupported.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-LEGACY-nc_flat_media_unsupported.yaml
@@ -37,7 +37,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-REST overview Resources.md §Simplified Formats"
   - "ITS-REST overview Requests_and_responses (HTTP status codes: 415 Unsupported Media Type)"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 guards:
   - "Legacy alternative-format support is statement-declared, not spec-mandated — the ICS options declaration selects this branch (AMB-61); ITS-REST overview Resources.md §Data representation makes the alternative formats a MAY"
 requires:

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-LEGACY-tds2_accept_unsupported.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-LEGACY-tds2_accept_unsupported.yaml
@@ -35,7 +35,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §Data representation"
   - "ITS-REST overview Resources.md §XML Format"
   - "SM openehr_platform §I_DEFINITION_ADL14.get_opt"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 guards:
   - "Legacy alternative-format support is statement-declared, not spec-mandated — the ICS options declaration selects this branch (AMB-61); ITS-REST overview Resources.md §Data representation makes the alternative formats a MAY"
 requires:

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-LEVELS-collapsed_wrappers.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-LEVELS-collapsed_wrappers.yaml
@@ -23,7 +23,7 @@ spec_refs:
   - "ITS-REST simplified_formats master04 §Always Collapsed Wrapper Types"
   - "ITS-REST simplified_formats master04 §Conditionally Collapsed Wrapper Types"
   - "ITS-REST simplified_formats master04 §Level Removal"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.maximal]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-LEVELS-container_attribute_elision.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-LEVELS-container_attribute_elision.yaml
@@ -21,7 +21,7 @@ description: "Container-attribute names elided from simplified paths, present in
 spec_refs:
   - "ITS-REST simplified_formats master04 §Container Attributes Elided from Paths"
   - "ITS-REST simplified_formats master04 §Level Removal"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.maximal]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-LEVELS-lab_panel_example.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-LEVELS-lab_panel_example.yaml
@@ -25,7 +25,7 @@ spec_refs:
   - "ITS-REST simplified_formats master04 §Level Removal"
   - "ITS-REST simplified_formats master04 §Container Attributes Elided from Paths"
   - "ITS-REST simplified_formats master05 §CLUSTER"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.maximal]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-attribute_suffix_table.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-attribute_suffix_table.yaml
@@ -23,7 +23,7 @@ spec_refs:
   - "ITS-REST simplified_formats master05 §DV_QUANTITY"
   - "ITS-REST simplified_formats master05 §DV_CODED_TEXT"
   - "RM data_types §DATA_VALUE"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.maximal]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-context.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-context.yaml
@@ -24,7 +24,7 @@ spec_refs:
   - "ITS-REST simplified_formats master05 §ISM_TRANSITION"
   - "ITS-REST simplified_formats master06 §time + §setting"
   - "RM composition §EVENT_CONTEXT"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.minimal_action]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-dv_ordinal_proportion_count.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-dv_ordinal_proportion_count.yaml
@@ -25,7 +25,7 @@ spec_refs:
   - "ITS-REST simplified_formats master05 §DV_PROPORTION"
   - "ITS-REST simplified_formats master05 §DV_COUNT"
   - "RM data_types §DV_ORDINAL"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.maximal]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-dv_quantity.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-dv_quantity.yaml
@@ -22,7 +22,7 @@ spec_refs:
   - "ITS-REST simplified_formats master05 §DV_QUANTITY"
   - "ITS-REST simplified_formats master04 §Attribute Suffixes"
   - "RM data_types §DV_QUANTITY"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 guards:
   - "master05 DV_QUANTITY table swaps the flat-type cells (|magnitude shown String, |unit shown Real) — an upstream editorial defect; the RM types (magnitude:Real, units:String) are used here per RM data_types §DV_QUANTITY"
 requires:

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-dv_text_coded.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-dv_text_coded.yaml
@@ -23,7 +23,7 @@ spec_refs:
   - "ITS-REST simplified_formats master05 §DV_TEXT"
   - "ITS-REST simplified_formats master05 §CODE_PHRASE"
   - "RM data_types §DV_CODED_TEXT"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.maximal]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-entries.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-entries.yaml
@@ -22,7 +22,7 @@ spec_refs:
   - "ITS-REST simplified_formats master05 §OBSERVATION"
   - "ITS-REST simplified_formats master05 §EVALUATION"
   - "RM ehr §COMPOSITION"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.maximal]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-events_audit.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-events_audit.yaml
@@ -31,7 +31,7 @@ spec_refs:
   - "ITS-REST simplified_formats master05 §DV_IDENTIFIER"
   - "ITS-REST overview Requests_and_responses §openehr-template-id"
   - "RM common §FEEDER_AUDIT"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 guards:
   - "master05 FEEDER_AUDIT table types `/originating_system_audit` as `<<PARTY_IDENTIFIED,PARTY_IDENTIFIED>>` (required yes) — an upstream editorial defect; RM common §FEEDER_AUDIT declares originating_system_audit as FEEDER_AUDIT_DETAILS, and the read-back is asserted against that correct RM type here"
 requires:

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-instruction_details.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-instruction_details.yaml
@@ -42,7 +42,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §openehr-template-id"
   - "RM ehr §instruction_details"
   - "RM common §locatable_ref"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.minimal_action]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-interval_event.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-interval_event.yaml
@@ -56,7 +56,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §openehr-template-id"
   - "RM data_structures §INTERVAL_EVENT"
   - "AM AOM1.4 §C_OBJECT.rm_type_name (the events-slot narrowing the carrier declares)"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.tpl.sf_interval_event]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-interval_reference_range.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-interval_reference_range.yaml
@@ -20,7 +20,7 @@ spec_refs:
   - "ITS-REST simplified_formats master05 §DV_INTERVAL"
   - "ITS-REST simplified_formats master05 §REFERENCE_RANGE"
   - "RM data_types §DV_INTERVAL"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 constraint_context:
   template: cnf.opt.vitals
   path: "/content[openEHR-EHR-OBSERVATION.body_temperature.v1]/data/events/data/items/value"

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-multimedia_parsable.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-multimedia_parsable.yaml
@@ -21,7 +21,7 @@ spec_refs:
   - "ITS-REST simplified_formats master05 §DV_MULTIMEDIA"
   - "ITS-REST simplified_formats master05 §DV_PARSABLE"
   - "RM data_types §DV_MULTIMEDIA"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.maximal]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-party.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-party.yaml
@@ -22,7 +22,7 @@ spec_refs:
   - "ITS-REST simplified_formats master05 §PARTY_PROXY"
   - "ITS-REST simplified_formats master06 §Composer"
   - "RM common §PARTY_PROXY"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.minimal_action]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-simple_values.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-simple_values.yaml
@@ -22,7 +22,7 @@ spec_refs:
   - "ITS-REST simplified_formats master05 §DV_BOOLEAN"
   - "ITS-REST simplified_formats master05 §DV_URI"
   - "RM data_types §DV_IDENTIFIER"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.maximal]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-structure.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-structure.yaml
@@ -20,7 +20,7 @@ spec_refs:
   - "ITS-REST simplified_formats master05 §ELEMENT"
   - "ITS-REST simplified_formats master05 §CLUSTER"
   - "RM data_structures §ELEMENT"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.maximal]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-temporal.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-temporal.yaml
@@ -23,7 +23,7 @@ spec_refs:
   - "ITS-REST simplified_formats master05 §DV_TIME"
   - "ITS-REST simplified_formats master05 §DV_DURATION"
   - "RM data_types §DV_DATE_TIME"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.maximal]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-NODEID-generation_rules.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-NODEID-generation_rules.yaml
@@ -33,7 +33,7 @@ spec_refs:
   - "ITS-REST simplified_formats master04 §Web Template Metadata"
   - "ITS-REST overview Resources.md §Simplified Formats"
   - "SM openehr_platform §I_DEFINITION_ADL14.get_opt"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.vitals]            # provisioned as precondition (idempotent; 409 tolerated)

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-NODEID-web_template_ids.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-NODEID-web_template_ids.yaml
@@ -24,7 +24,7 @@ spec_refs:
   - "ITS-REST simplified_formats master04 §Node ID Generation Rules"
   - "ITS-REST overview Resources.md §Simplified Formats"
   - "SM openehr_platform §I_DEFINITION_ADL14.get_opt"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.minimal_action]    # provisioned as precondition (idempotent; 409 tolerated)

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-RAW-embedding.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-RAW-embedding.yaml
@@ -21,7 +21,7 @@ spec_refs:
   - "ITS-REST simplified_formats master05 §DV_QUANTITY"
   - "ITS-REST overview Requests_and_responses §openehr-template-id"
   - "RM data_types §DV_QUANTITY"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.maximal]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-RAW-missing_type.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-RAW-missing_type.yaml
@@ -18,7 +18,7 @@ spec_refs:
   - "ITS-REST simplified_formats master04 §Raw canonical JSON"
   - "ITS-REST simplified_formats master04 §Validation"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.vitals]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-RAW-structured_embedding.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-RAW-structured_embedding.yaml
@@ -32,7 +32,7 @@ spec_refs:
   - "ITS-REST simplified_formats master04 §Structured format"
   - "ITS-REST simplified_formats master05 §DV_QUANTITY"
   - "ITS-REST overview Requests_and_responses §openehr-template-id"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.vitals]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-RMATTR-normal_range_commit.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-RMATTR-normal_range_commit.yaml
@@ -21,7 +21,7 @@ spec_refs:
   - "ITS-REST simplified_formats master05 §DV_QUANTITY"
   - "ITS-REST overview Requests_and_responses §openehr-template-id"
   - "RM data_types §DV_QUANTITY"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.maximal]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-RMATTR-underscore_mapping.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-RMATTR-underscore_mapping.yaml
@@ -24,7 +24,7 @@ spec_refs:
   - "ITS-REST simplified_formats master04 §Field Identifiers"
   - "ITS-REST simplified_formats master05 §DV_QUANTITY"
   - "RM common §LOCATABLE"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.maximal]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-SCOPE-demographic_no_simplified.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-SCOPE-demographic_no_simplified.yaml
@@ -23,7 +23,7 @@ spec_refs:
   - "SM openehr_platform §I_PARTY.get_party"
   - "ITS-REST simplified_formats master02 §MIME Types (COMPOSITION scope)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes (unfulfillable Accept)"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 guards:
   - "DEMOGRAPHIC API is DEVELOPMENT-stage in ITS-REST 1.1.0 — CNF profiles (Demographic Persistence, OPTIONS); ITS-REST demographic (DEVELOPMENT lifecycle)"
 requires:

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-SCOPE-directory_no_simplified.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-SCOPE-directory_no_simplified.yaml
@@ -21,7 +21,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_DIRECTORY.get_directory"
   - "ITS-REST simplified_formats master02 §MIME Types (COMPOSITION scope)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes (unfulfillable Accept)"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-SCOPE-ehr_status_no_simplified.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-SCOPE-ehr_status_no_simplified.yaml
@@ -22,7 +22,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_STATUS.get_ehr_status"
   - "ITS-REST simplified_formats master02 §MIME Types (COMPOSITION scope)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes (unfulfillable Accept)"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-STRUCT-arrays_single_cardinality.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-STRUCT-arrays_single_cardinality.yaml
@@ -24,7 +24,7 @@ spec_refs:
   - "ITS-REST simplified_formats master04 §Conversion Between Formats"
   - "ITS-REST simplified_formats master05 §COMPOSITION"
   - "ITS-REST overview Requests_and_responses §openehr-template-id"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.vitals]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-STRUCT-empty_object_omission.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-STRUCT-empty_object_omission.yaml
@@ -23,7 +23,7 @@ description: "Structured empty-object omission and ctx grouping (master04)"
 spec_refs:
   - "ITS-REST simplified_formats master04 §Structured format"
   - "ITS-REST simplified_formats master06 §Context Information"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.vitals]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-STRUCT-style_rules.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-STRUCT-style_rules.yaml
@@ -27,7 +27,7 @@ description: "Structured-format syntax rules (master04)"
 spec_refs:
   - "ITS-REST simplified_formats master04 §Structured format"
   - "ITS-REST simplified_formats master04 §Conversion Between Formats"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.vitals]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-STRUCTURED-commit_roundtrip.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-STRUCTURED-commit_roundtrip.yaml
@@ -24,7 +24,7 @@ spec_refs:
   - "ITS-REST simplified_formats master05 §COMPOSITION"
   - "ITS-REST overview Resources.md §Simplified Formats"
   - "ITS-REST overview Requests_and_responses §openehr-template-id"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.vitals]

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-WT-web_template_get.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-WT-web_template_get.yaml
@@ -21,7 +21,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §Simplified Formats"
   - "ITS-REST simplified_formats master04 §Node ID Generation Rules"
   - "SM openehr_platform §I_DEFINITION_ADL14.get_opt"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any
   templates: [cnf.opt.minimal_action]    # provisioned as precondition (idempotent; 409 tolerated)

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-WT-web_template_json_accept.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-WT-web_template_json_accept.yaml
@@ -33,7 +33,7 @@ spec_refs:
   - "ITS-REST overview Resources.md §JSON Format"
   - "ITS-REST overview Resources.md §Simplified Formats"
   - "SM openehr_platform §I_DEFINITION_ADL14.get_opt"
-applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 guards:
   - "Fulfilling Accept: application/json on the OPT GET at all is OUR OWN documented extension (AMB-58), not a spec expectation: no released ITS-REST sentence defines a canonical-JSON OPERATIONAL_TEMPLATE representation or assigns this request an outcome, so a service that answers 406 instead is equally conformant. Only the shape of a returned body is spec-derived — ITS-REST overview Resources.md §JSON Format binds the response Content-Type to the negotiated type. The wt+json representation is the spec-named one and is exercised by SF-WT-web_template_get"
 requires:

--- a/tools/cnf-runner/artifacts/schedule/smart/SMART-DISCOVERY-document_shape.yaml
+++ b/tools/cnf-runner/artifacts/schedule/smart/SMART-DISCOVERY-document_shape.yaml
@@ -56,7 +56,7 @@ spec_refs:
   - "ITS-REST smart_app_launch master04-service_discovery.adoc §Capabilities"
   - "ITS-REST smart_app_launch master02-overview.adoc §Glossary"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-applies: { its_rest: ">=1.1.0" }
+applies: { its_rest: ">=1.1.0" }   # SMART on openEHR first ships in Release-1.1.0 — ITS-REST docs/smart_app_launch/master00-amendment_record.adoc §ITS_REST Release 1.1.0 (SPECITS-69)
 guards:
   - "applies only to a deployment running the CDR's SMART resource-server role — the specification is config-gated and DEVELOPMENT-state (ITS-REST docs/smart_app_launch/manifest_vars.adoc `:spec_status: DEVELOPMENT`); the party declares the role by declaring an ixit `smart` lane"
 formats: [canonical-json]

--- a/tools/cnf-runner/artifacts/schedule/smart/SMART-RESOURCE_SCOPES-granted_scope_permits.yaml
+++ b/tools/cnf-runner/artifacts/schedule/smart/SMART-RESOURCE_SCOPES-granted_scope_permits.yaml
@@ -60,7 +60,7 @@ spec_refs:
   - "ITS-REST smart_app_launch master06-authentication.adoc §Supported Authentication Flows"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_DEFINITION_ADL14.list_opts"
-applies: { its_rest: ">=1.1.0" }
+applies: { its_rest: ">=1.1.0" }   # SMART on openEHR first ships in Release-1.1.0 — ITS-REST docs/smart_app_launch/master00-amendment_record.adoc §ITS_REST Release 1.1.0 (SPECITS-69)
 guards:
   - "applies only to a deployment running the CDR's SMART resource-server role — the specification is config-gated and DEVELOPMENT-state (ITS-REST docs/smart_app_launch/manifest_vars.adoc `:spec_status: DEVELOPMENT`); the party declares the role by declaring an ixit `smart` lane"
 formats: [canonical-json]

--- a/tools/cnf-runner/artifacts/schedule/smart/SMART-RESOURCE_SCOPES-scope_deny_403.yaml
+++ b/tools/cnf-runner/artifacts/schedule/smart/SMART-RESOURCE_SCOPES-scope_deny_403.yaml
@@ -64,7 +64,7 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §Authentication and authorization"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_DEFINITION_ADL14.list_opts"
-applies: { its_rest: ">=1.1.0" }
+applies: { its_rest: ">=1.1.0" }   # SMART on openEHR first ships in Release-1.1.0 — ITS-REST docs/smart_app_launch/master00-amendment_record.adoc §ITS_REST Release 1.1.0 (SPECITS-69)
 guards:
   - "applies only to a deployment running the CDR's SMART resource-server role — the specification is config-gated and DEVELOPMENT-state (ITS-REST docs/smart_app_launch/manifest_vars.adoc `:spec_status: DEVELOPMENT`); the party declares the role by declaring an ixit `smart` lane"
   - "rows 2-4 apply only to a Platform advertising the `openehr-permission-v1` capability (ITS-REST docs/smart_app_launch/master04-service_discovery.adoc §Capabilities), the declaration that its scope layer decides an ungranted resource family"

--- a/tools/cnf-runner/artifacts/schedule/system/I_ITS_REST_SYSTEM.options-conformance_manifest.yaml
+++ b/tools/cnf-runner/artifacts/schedule/system/I_ITS_REST_SYSTEM.options-conformance_manifest.yaml
@@ -57,7 +57,6 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses §HTTP Methods"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "ITS-REST overview Specifications §Specifications"
-applies: { its_rest: ">=1.1.0" }
 formats: [canonical-json]
 requires:
   server: any


### PR DESCRIPTION
Closes #635 (unblocks #619).

Every one of the 343 case-core `its_rest: ">=1.1.0"` floors adjudicated against the release history in `docs/specs/openehr/ITS-REST/specifications/docs/overview/Amendment_record.md` (§Release-1.1.0 enumerates what 1.1.0 added over 1.0.3; the simplified-formats and SMART sub-specs carry their own amendment records):

- **157 kept**, each floor line now carrying its dating citation inline: ITEM_TAGs (SPECITS-77, 18), Demographic API (SPECITS-70, 47), Simplified Formats on the wire (SPECITS-61/84, 69), admin EHR delete (SPECITS-80, 7), `Prefer: return=identifier` (SPECITS-50, 8), SMART (SPECITS-69, 3), audit-details `system_id` (SPECPR-472, 2), reserved `aql` query name (SPECITS-46, 2), template `/example` (SPECITS-58, 3).
- **186 dropped** (behaviour already in 1.0.3 — the floor was boilerplate silently shrinking a 1.0.3 party's in-scope set): composition 44, ehr 46, directory 33, definition_query 20, query 17, contribution 14, definition ADL 8, security 3, system 1.
- **0 moved**: every genuinely release-dated header rule (weak `W/` ETag form, read/DELETE `Location` restriction) already sits on `HeaderExpectation.applies` from #627 — the case-level copies were exactly the "never raise a header rule's floor to the case" anti-pattern.

Notable adjudications: the ADL2 `{version}`-prefix endpoint stays in scope for 1.0.3 because SPECITS-87 *deprecated* it in 1.1.0 (deprecation proves it predates the release); the query result-set ETag case drops its case floor because only the `W/` FORM is dated (presence is `docs/query/Request.md` §Common Headers, undated, per the owner's presence-required ruling).

Residual defect found en route and filed as #640 (blocking #619): seven committal-metadata cases drive only the Release-1.1.0 header spellings (`openehr-audit-details`/`openehr-template-id`), which are underscore→hyphen renames — genuinely different fields under RFC 9110 §5.1 — so a 1.0.3 party would need the old spellings. Request-construction concern, out of this triage's scope.

Full per-group table: issue #635's triage comment. Gates: validate 756 cases / 0 findings (coverage report byte-identical), nextest 238/238, zero `.rs` changes.