### PR TITLE
refactor(cnf-runner): converge the report's chapter grouping on conf_assets::TAXONOMY

### DIFF
--- a/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
@@ -16,32 +16,59 @@ Runner: cnf-runner 3.11.0 · verification pack: passed
 
 ## By chapter
 
-| Chapter | passed | failed | errored | skipped | not_applicable |
-| --- | --- | --- | --- | --- | --- |
-| CONT | 123 | 0 | 0 | 0 | 0 |
-| I_ADMIN_ARCHIVE | 0 | 0 | 0 | 0 | 4 |
-| I_ADMIN_DUMP_LOAD | 0 | 0 | 0 | 0 | 2 |
-| I_ADMIN_SERVICE | 9 | 0 | 0 | 0 | 10 |
-| I_DEFINITION_ADL14 | 22 | 0 | 0 | 0 | 6 |
-| I_DEFINITION_ADL2 | 21 | 0 | 0 | 0 | 8 |
-| I_DEFINITION_QUERY | 28 | 0 | 0 | 0 | 3 |
-| I_DEMOGRAPHIC_SERVICE | 57 | 0 | 0 | 0 | 1 |
-| I_EHR_COMPOSITION | 88 | 0 | 0 | 0 | 0 |
-| I_EHR_CONTRIBUTION | 55 | 0 | 0 | 0 | 5 |
-| I_EHR_DIRECTORY | 63 | 0 | 0 | 0 | 4 |
-| I_EHR_EXTRACT_SERVICE | 0 | 0 | 0 | 0 | 10 |
-| I_EHR_SERVICE | 24 | 0 | 0 | 0 | 1 |
-| I_EHR_STATUS | 46 | 0 | 0 | 0 | 1 |
-| I_ITS_REST_ITEM_TAGS | 30 | 0 | 0 | 0 | 0 |
-| I_ITS_REST_REVISION_HISTORY | 6 | 0 | 0 | 0 | 0 |
-| I_ITS_REST_SYSTEM | 1 | 0 | 0 | 0 | 0 |
-| I_ITS_REST_VERSIONED_PARTY | 3 | 0 | 0 | 0 | 1 |
-| I_QUERY_SERVICE | 36 | 0 | 0 | 0 | 0 |
-| I_TDD_SERVICE | 0 | 0 | 0 | 0 | 4 |
-| SEC | 6 | 0 | 0 | 0 | 0 |
-| SF | 63 | 0 | 0 | 0 | 1 |
-| SIG | 10 | 0 | 0 | 0 | 2 |
-| SMART | 3 | 0 | 0 | 0 | 0 |
+Grouping is the published per-chapter chart's taxonomy: chapters with their bands; `cited n/a` counts the not-executed outcomes that carry a citation (`not_applicable` + `skipped`).
+
+| Chapter / band | passed | failed | errored | cited n/a |
+| --- | --- | --- | --- | --- |
+| **EHR** | 312 | 0 | 0 | 11 |
+| — EHR resource | 24 | 0 | 0 | 1 |
+| — EHR_STATUS | 46 | 0 | 0 | 1 |
+| — COMPOSITION | 88 | 0 | 0 | 0 |
+| — DIRECTORY | 63 | 0 | 0 | 4 |
+| — CONTRIBUTION | 55 | 0 | 0 | 5 |
+| — Item tags | 30 | 0 | 0 | 0 |
+| — Revision history | 6 | 0 | 0 | 0 |
+| **Definitions** | 71 | 0 | 0 | 17 |
+| — ADL 1.4 templates | 22 | 0 | 0 | 6 |
+| — ADL 2 artefacts | 21 | 0 | 0 | 8 |
+| — Stored queries | 28 | 0 | 0 | 3 |
+| **Query** | 36 | 0 | 0 | 0 |
+| — Ad-hoc AQL | 25 | 0 | 0 | 0 |
+| — Stored query execution | 11 | 0 | 0 | 0 |
+| **Demographic** | 60 | 0 | 0 | 2 |
+| — Parties | 39 | 0 | 0 | 1 |
+| — Party relationships | 15 | 0 | 0 | 0 |
+| — Versioned party | 6 | 0 | 0 | 1 |
+| **Messaging** | 0 | 0 | 0 | 14 |
+| — EHR Extract | 0 | 0 | 0 | 10 |
+| — TDD | 0 | 0 | 0 | 4 |
+| **Admin** | 9 | 0 | 0 | 16 |
+| — Admin service | 9 | 0 | 0 | 10 |
+| — Archive | 0 | 0 | 0 | 4 |
+| — Dump & load | 0 | 0 | 0 | 2 |
+| **System** | 1 | 0 | 0 | 0 |
+| — Conformance manifest | 1 | 0 | 0 | 0 |
+| **Content validation** | 123 | 0 | 0 | 0 |
+| — Data types | 52 | 0 | 0 | 0 |
+| — Interval data types | 30 | 0 | 0 | 0 |
+| — Structure & cardinality | 41 | 0 | 0 | 0 |
+| **Simplified formats** | 63 | 0 | 0 | 1 |
+| — FLAT & STRUCTURED | 21 | 0 | 0 | 0 |
+| — Web Template | 5 | 0 | 0 | 0 |
+| — Path mapping | 30 | 0 | 0 | 0 |
+| — Scope & legacy media | 7 | 0 | 0 | 1 |
+| **Security & privacy** | 6 | 0 | 0 | 0 |
+| — Authenticated access | 2 | 0 | 0 | 0 |
+| — Authorization separation | 1 | 0 | 0 | 0 |
+| — Audit accountability | 1 | 0 | 0 | 0 |
+| — Anonymous EHRs | 1 | 0 | 0 | 0 |
+| — EHR/demographic separation | 1 | 0 | 0 | 0 |
+| **Signing** | 10 | 0 | 0 | 2 |
+| — Version signing | 10 | 0 | 0 | 2 |
+| **SMART App Launch** | 3 | 0 | 0 | 0 |
+| — Discovery | 1 | 0 | 0 | 0 |
+| — Resource scopes | 2 | 0 | 0 | 0 |
+| **Performance** | 0 | 0 | 0 | 0 |
 
 ## By capability
 

--- a/tools/cnf-runner/src/bin/cnf-runner.rs
+++ b/tools/cnf-runner/src/bin/cnf-runner.rs
@@ -550,7 +550,16 @@ fn run_verdicts(
                 }
             },
         ),
-        ("CONFORMANCE_REPORT.md", render_report(&results, &report)),
+        (
+            "CONFORMANCE_REPORT.md",
+            match render_report(&results, &report) {
+                Ok(markdown) => markdown,
+                Err(e) => {
+                    eprintln!("cannot render the report: {e}");
+                    return ExitCode::from(2);
+                }
+            },
+        ),
         (
             "CONFORMANCE_STATEMENT.md",
             render_statement(&statement, &report, served_extensions),

--- a/tools/cnf-runner/src/render.rs
+++ b/tools/cnf-runner/src/render.rs
@@ -20,9 +20,22 @@ use crate::vocab::{Family, FormatName, Tier};
 /// Render the conformance report (`CONFORMANCE_REPORT.md`): the outcome
 /// summary, a per-chapter table, and the honesty block (coverage bound +
 /// every not-executed verdict's citation).
-#[must_use]
+///
+/// The per-chapter table groups by the SAME two-level taxonomy the published
+/// chapter-bars chart renders ([`crate::conf_assets::TAXONOMY`], via
+/// [`crate::conf_assets::chapter_counts`]) — one taxonomy, one place, so the
+/// report and the chart can never disagree about what a chapter contains.
+///
+/// # Errors
+///
+/// [`crate::conf_assets::TaxonomyError`] when an outcome's case id maps to no
+/// taxonomy band — a taxonomy gap to close, never a silent bucket; the report
+/// refuses to publish rather than mis-group.
 #[allow(clippy::too_many_lines)] // one linear document renderer per published artifact
-pub fn render_report(results: &Results, verdicts: &VerdictReport) -> String {
+pub fn render_report(
+    results: &Results,
+    verdicts: &VerdictReport,
+) -> Result<String, crate::conf_assets::TaxonomyError> {
     let mut out = String::new();
     let _ = writeln!(out, "# Conformance Report\n");
     let _ = writeln!(
@@ -60,33 +73,43 @@ pub fn render_report(results: &Results, verdicts: &VerdictReport) -> String {
     let _ = writeln!(out, "| total | {} |\n", results.outcomes.len());
 
     // ── per-chapter table ───────────────────────────────────────────────────
-    let mut by_chapter: BTreeMap<String, BTreeMap<&'static str, usize>> = BTreeMap::new();
-    for outcome in &results.outcomes {
-        let chapter = chapter_of(outcome.case.as_str());
-        *by_chapter
-            .entry(chapter)
-            .or_default()
-            .entry(outcome.status.token())
-            .or_default() += 1;
-    }
+    // The published chart's two-level taxonomy, verbatim: chapter rows with
+    // their band sub-rows, in declaration order. `cited n/a` merges the two
+    // citation-bearing statuses (`not_applicable` + `skipped`) exactly as the
+    // chart's hatched segment does. All-empty bands are elided from the
+    // table (the chart draws them as zero-width segments; a table row of
+    // zeros carries no information), but an all-empty CHAPTER still prints
+    // its total row so the taxonomy stays visibly total.
+    let chapters = crate::conf_assets::chapter_counts(results)?;
     let _ = writeln!(out, "## By chapter\n");
     let _ = writeln!(
         out,
-        "| Chapter | passed | failed | errored | skipped | not_applicable |"
+        "Grouping is the published per-chapter chart's taxonomy: chapters \
+         with their bands; `cited n/a` counts the not-executed outcomes that \
+         carry a citation (`not_applicable` + `skipped`).\n"
     );
-    let _ = writeln!(out, "| --- | --- | --- | --- | --- | --- |");
-    for (chapter, c) in &by_chapter {
-        let g = |s: OutcomeStatus| c.get(s.token()).copied().unwrap_or(0);
+    let _ = writeln!(
+        out,
+        "| Chapter / band | passed | failed | errored | cited n/a |"
+    );
+    let _ = writeln!(out, "| --- | --- | --- | --- | --- |");
+    for chapter in &chapters {
+        let t = chapter.total;
         let _ = writeln!(
             out,
-            "| {} | {} | {} | {} | {} | {} |",
-            chapter,
-            g(OutcomeStatus::Passed),
-            g(OutcomeStatus::Failed),
-            g(OutcomeStatus::Errored),
-            g(OutcomeStatus::Skipped),
-            g(OutcomeStatus::NotApplicable),
+            "| **{}** | {} | {} | {} | {} |",
+            chapter.chapter, t.passed, t.failed, t.errored, t.cited_na,
         );
+        for (band, counts) in &chapter.bands {
+            if counts.is_empty() {
+                continue;
+            }
+            let _ = writeln!(
+                out,
+                "| — {} | {} | {} | {} | {} |",
+                band, counts.passed, counts.failed, counts.errored, counts.cited_na,
+            );
+        }
     }
     let _ = writeln!(out);
 
@@ -216,7 +239,7 @@ pub fn render_report(results: &Results, verdicts: &VerdictReport) -> String {
         }
     }
 
-    out
+    Ok(out)
 }
 
 /// Render the conformance statement (`CONFORMANCE_STATEMENT.md`): the `SDoC`
@@ -595,17 +618,6 @@ pub fn render_certificate(
 
 // ── shared formatting helpers ────────────────────────────────────────────────
 
-/// The chapter grouping for a case id: the SM interface prefix for a
-/// `I_X.op-variant` id, else the leading family token before the first `-`.
-fn chapter_of(case_id: &str) -> String {
-    if let Some((interface, _)) = case_id.split_once('.') {
-        return interface.to_owned();
-    }
-    case_id
-        .split_once('-')
-        .map_or_else(|| case_id.to_owned(), |(head, _)| head.to_owned())
-}
-
 fn declared_versions(statement: &Statement) -> Vec<(&'static str, &str)> {
     use crate::vocab::SpecComponent;
     let mut out = Vec::new();
@@ -818,12 +830,16 @@ mod tests {
     #[test]
     fn report_is_deterministic_and_lists_citations() {
         let v = verdicts();
-        let a = render_report(&results(), &v);
-        let b = render_report(&results(), &v);
+        let a = render_report(&results(), &v).unwrap();
+        let b = render_report(&results(), &v).unwrap();
         assert_eq!(a, b);
         assert!(a.ends_with('\n'));
         assert!(a.contains("Coverage: 1 of 1"));
         assert!(a.contains("AMB-33"));
+        // The by-chapter table groups by the published chart's taxonomy:
+        // the fixture's create_ehr case lands in the EHR chapter's
+        // "EHR lifecycle" band, exactly as conf_assets::TAXONOMY declares.
+        assert!(a.contains("| **EHR** |"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #618.

`render.rs` carried a second, coarser `chapter_of` (interface prefix / family token) driving the `CONFORMANCE_REPORT.md` grouping. The report's By-chapter table now consumes `conf_assets::chapter_counts` — the published chart's two-level taxonomy verbatim (chapter rows + band sub-rows in declaration order, `cited n/a` merging `not_applicable`+`skipped` exactly as the chart's hatched segment), so the report and the chart can never disagree. An unmapped case id now refuses to publish (`TaxonomyError`) instead of silently bucketing. The private `chapter_of` is deleted; the committed ehrbase-rs report is regenerated in this PR (verdicts.json byte-identical).

Gates: fmt clean, clippy unchanged, nextest 239/239, the regenerated report eyeballed against the chart taxonomy.