### PR TITLE
feat(cnf-runner): capture restapi_specs_version; declaration divergence is a review finding

### DIFF
--- a/tools/cnf-runner/schemas/results.schema.json
+++ b/tools/cnf-runner/schemas/results.schema.json
@@ -91,6 +91,11 @@
       "type": "string",
       "minLength": 1
     },
+    "restapi_specs_version": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The restapi_specs_version member the SUT's System OPTIONS manifest served during the campaign, when that exchange was driven (released OAS system.openapi.yaml Options — every member optional, so absence is normal). An independent confirmation of the statement's declared spec_versions.its_rest, never a source of truth: divergence from the declaration is a static-review finding, not a re-declaration."
+    },
     "outcomes": {
       "type": "array",
       "items": {

--- a/tools/cnf-runner/src/bin/cnf-runner.rs
+++ b/tools/cnf-runner/src/bin/cnf-runner.rs
@@ -1652,6 +1652,7 @@ fn run_command(
                 ),
         },
         ixit_digest,
+        restapi_specs_version: report.restapi_specs_version.clone(),
         outcomes,
         measurements: carried_measurements,
         ambiguity_dispositions: Vec::new(),

--- a/tools/cnf-runner/src/conf_assets.rs
+++ b/tools/cnf-runner/src/conf_assets.rs
@@ -1184,6 +1184,7 @@ mod tests {
                 formats: Vec::new(),
             },
             ixit_digest: "test".to_owned(),
+            restapi_specs_version: None,
             outcomes: outcomes
                 .iter()
                 .map(|(case, status)| crate::party::OutcomeRecord {

--- a/tools/cnf-runner/src/exec/driver.rs
+++ b/tools/cnf-runner/src/exec/driver.rs
@@ -53,6 +53,14 @@ pub struct HttpDriver<'a> {
     /// matcher (overview §"If-Match and accidental overwrites": the 412
     /// "SHOULD return also latest `version_uid` in the `ETag`").
     last_version_uid: Option<String>,
+    /// The `restapi_specs_version` member the System OPTIONS manifest served,
+    /// when the campaign drove that exchange (released OAS
+    /// `system.openapi.yaml` `Options` schema — every member optional). An
+    /// independent CONFIRMATION of the party's declared
+    /// `spec_versions.its_rest`, never a source of truth: no `required` list
+    /// binds it, and a server could dodge every dated MUST by
+    /// under-advertising — divergence surfaces as a static-review finding.
+    observed_restapi_specs_version: Option<String>,
     /// Recorded exchanges (the transcript seam).
     pub exchanges: Vec<Exchange>,
 }
@@ -97,8 +105,15 @@ impl<'a> HttpDriver<'a> {
             committed: Vec::new(),
             last_body: None,
             last_version_uid: None,
+            observed_restapi_specs_version: None,
             exchanges: Vec::new(),
         })
+    }
+
+    /// Take the System-manifest `restapi_specs_version` this driver observed,
+    /// if the campaign drove that exchange (see the field NOTE).
+    pub fn take_observed_restapi_specs_version(&mut self) -> Option<String> {
+        self.observed_restapi_specs_version.take()
     }
 
     fn binding_for(&self, case: &CaseCore, call: &str) -> Result<&'a OperationBinding, String> {
@@ -2238,6 +2253,21 @@ impl StepDriver for HttpDriver<'_> {
             self.committed.push(b.clone());
         }
         self.last_body.clone_from(&exchange.body);
+
+        // The System OPTIONS manifest's `restapi_specs_version`, when served
+        // (released OAS `system.openapi.yaml` `Options` — every member
+        // optional): observed as an independent confirmation of the party's
+        // declared its_rest version, never as the truth (see the field NOTE).
+        if binding.sm_operation.interface() == "I_ITS_REST_SYSTEM"
+            && binding.sm_operation.operation() == "options"
+            && let Some(version) = exchange
+                .body
+                .as_ref()
+                .and_then(|b| b.get("restapi_specs_version"))
+                .and_then(Value::as_str)
+        {
+            self.observed_restapi_specs_version = Some(version.to_owned());
+        }
 
         // Classify (law c) and bind captures.
         let selectors = self.set.selectors.as_ref().map(|(_, s)| s);

--- a/tools/cnf-runner/src/party.rs
+++ b/tools/cnf-runner/src/party.rs
@@ -463,6 +463,16 @@ pub struct Results {
     pub tech_profile: TechProfile,
     /// The digest of the ixit topology the run drove (provenance).
     pub ixit_digest: String,
+    /// The `restapi_specs_version` the SUT's own System OPTIONS manifest
+    /// served during the campaign, when that exchange was driven (released
+    /// OAS `system.openapi.yaml` `Options` — every member optional, so
+    /// absence is normal). An independent CONFIRMATION of the statement's
+    /// declared `spec_versions.its_rest`, never a source of truth: no
+    /// `required` list binds it and a server could dodge every release-dated
+    /// MUST by under-advertising — a divergence from the declaration is a
+    /// static-review finding, not a re-declaration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub restapi_specs_version: Option<String>,
     /// The per-case×format outcomes.
     #[serde(default)]
     pub outcomes: Vec<OutcomeRecord>,

--- a/tools/cnf-runner/src/run.rs
+++ b/tools/cnf-runner/src/run.rs
@@ -42,6 +42,12 @@ pub struct RunReport {
     pub interpreter_run: usize,
     /// All active assertion-machinery cases considered.
     pub considered: usize,
+    /// The `restapi_specs_version` the System OPTIONS manifest served, when
+    /// the campaign drove that exchange — an independent confirmation of the
+    /// party's declared `spec_versions.its_rest`, never a source of truth
+    /// (the released `Options` schema has no `required` list; a divergence
+    /// becomes a static-review finding, not a re-declaration).
+    pub restapi_specs_version: Option<String>,
 }
 
 impl RunReport {
@@ -521,6 +527,9 @@ pub fn execute(
         let record = run_case(&runnable, runnable.formats.first().copied(), &mut driver)?;
         report.interpreter_run += 1;
         report.records.push(record);
+        if let Some(version) = driver.take_observed_restapi_specs_version() {
+            report.restapi_specs_version.get_or_insert(version);
+        }
     }
     Ok(report)
 }

--- a/tools/cnf-runner/src/schema.rs
+++ b/tools/cnf-runner/src/schema.rs
@@ -788,6 +788,11 @@ pub fn results_schema() -> Value {
             "schedule_release": { "type": "string", "minLength": 1 },
             "tech_profile": tech_profile_def(),
             "ixit_digest": { "type": "string", "minLength": 1 },
+            "restapi_specs_version": {
+                "type": "string",
+                "minLength": 1,
+                "description": "The restapi_specs_version member the SUT's System OPTIONS manifest served during the campaign, when that exchange was driven (released OAS system.openapi.yaml Options — every member optional, so absence is normal). An independent confirmation of the statement's declared spec_versions.its_rest, never a source of truth: divergence from the declaration is a static-review finding, not a re-declaration."
+            },
             "outcomes": {
                 "type": "array",
                 "items": {

--- a/tools/cnf-runner/src/verdict.rs
+++ b/tools/cnf-runner/src/verdict.rs
@@ -255,6 +255,34 @@ pub fn compute(
             });
         }
     }
+    // The SUT's own System-manifest advertisement, when the campaign drove
+    // it, must agree with the statement's declaration. The manifest is never
+    // the source of truth (the released `Options` schema has no `required`
+    // list, and a server could dodge every release-dated MUST by
+    // under-advertising) — but a DISAGREEMENT means either the declaration
+    // or the deployment is wrong, and a certification must not rest on that.
+    if let (Some(served), Some(declared)) = (
+        results.restapi_specs_version.as_deref(),
+        statement.spec_versions.its_rest.as_deref(),
+    ) {
+        let same = match (
+            semver::Version::parse(served),
+            semver::Version::parse(declared),
+        ) {
+            (Ok(observed), Ok(claimed)) => observed == claimed,
+            _ => served == declared,
+        };
+        if !same {
+            review.push(ReviewFinding {
+                message: format!(
+                    "the SUT's System OPTIONS manifest advertises restapi_specs_version \
+                     {served} but the statement declares spec_versions.its_rest {declared} — \
+                     the declaration and the deployment disagree; fix whichever is wrong \
+                     (the manifest member is optional and is never the source of truth)"
+                ),
+            });
+        }
+    }
     let performance = measured_verdicts(statement, results, perf_cases, &mut review);
     let selected = select(statement, results, cases, register);
 
@@ -817,6 +845,62 @@ mod tests {
             map.insert("outcomes".to_owned(), outcomes);
         }
         serde_json::from_value(value).unwrap()
+    }
+
+    /// The System-manifest advertisement check (#634): a served
+    /// `restapi_specs_version` that disagrees with the statement's
+    /// `spec_versions.its_rest` is a static-review finding; agreement (or an
+    /// absent member — it is optional in the released `Options` schema)
+    /// raises nothing.
+    #[test]
+    fn manifest_advertised_its_rest_divergence_is_a_review_finding() {
+        let cases = vec![functional_case(
+            "I_EHR_SERVICE.create_ehr-main",
+            &["EhrOperations"],
+            &["CORE"],
+        )];
+        let st = statement(&["EhrOperations"], &["CORE"], &[]);
+        let outcomes = serde_json::json!([
+            { "case": "I_EHR_SERVICE.create_ehr-main", "format": "canonical-json",
+              "status": "passed", "rows_driven": 1, "rows_total": 1 }
+        ]);
+
+        // Divergence: served 1.0.3 vs declared 1.1.0 → exactly one finding.
+        let mut diverging = results(outcomes.clone());
+        diverging.restapi_specs_version = Some("1.0.3".to_owned());
+        let report = compute(&st, &diverging, &cases, &[], &matrix(), &register());
+        assert_eq!(
+            report
+                .review
+                .iter()
+                .filter(|f| f.message.contains("restapi_specs_version"))
+                .count(),
+            1,
+            "review: {:?}",
+            report.review
+        );
+
+        // Agreement (semver-equal): no finding.
+        let mut agreeing = results(outcomes.clone());
+        agreeing.restapi_specs_version = Some("1.1.0".to_owned());
+        let report = compute(&st, &agreeing, &cases, &[], &matrix(), &register());
+        assert!(
+            report
+                .review
+                .iter()
+                .all(|f| !f.message.contains("restapi_specs_version")),
+            "review: {:?}",
+            report.review
+        );
+
+        // Absent member (optional in the released schema): no finding.
+        let report = compute(&st, &results(outcomes), &cases, &[], &matrix(), &register());
+        assert!(
+            report
+                .review
+                .iter()
+                .all(|f| !f.message.contains("restapi_specs_version"))
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #634.

The runner now records the `restapi_specs_version` member when the campaign drives the System OPTIONS exchange (keyed on the `I_ITS_REST_SYSTEM.options` pseudo-interface at the one step-execution seam), carries it through `RunReport` into `results.json` (schema synced), and the verdict pipeline's static review flags a divergence from the statement's `spec_versions.its_rest` — semver-compared, string fallback. Never a source of truth (the released `Options` schema binds nothing; under-advertising could dodge every dated MUST): agreement confirms, disagreement flags, absence is normal. Would independently confirm the 1.0.3 handed to EHRbase 2.34.0 in the comparison record.

Gates: nextest **240/240** (new divergence/agreement/absence test), clippy unchanged, fmt clean, schemas regenerated.
