### PR TITLE
fix(cnf-runner): selection honors case-level applies floors; provisioning refusals are inconclusive

### DIFF
--- a/.claude/agent-memory/cnf-triage/MEMORY.md
+++ b/.claude/agent-memory/cnf-triage/MEMORY.md
@@ -23,4 +23,8 @@
 - [ETag `W/` is 1.1.0-scoped](etag-weak-indicator-is-1-1-0-scoped.md) — form=MUST from 1.1.0, presence=SHOULD always; the catalogue applies the `its_rest` floor inconsistently (141 in-scope vs 108 out-of-scope rows, same matcher)
 - [Query ETag presence is a SHOULD](query-etag-presence-is-should.md) — no released source requires the header on a query 200; the `pattern:` matcher over-gates presence
 - [results.json records out-of-scope rows](results-json-records-out-of-scope-rows.md) — 542 red vs 227 in verdict scope on the java record; `binding.applies` is dead metadata
-- [Provisioning silently swallows failures](provisioning-silently-swallows-failures.md) — template upload result discarded, provisioning sends no Accept, `server: empty` is a no-op
+- [Provisioning silently swallows failures](provisioning-silently-swallows-failures.md) — template upload result discarded at driver.rs:2122 + :2325; ONE swallowed 406 made 197 in-scope red rows
+- [Runner ignores case-level `applies`](runner-ignores-case-level-applies.md) — run.rs gates on options/binding-floors/ixit but never `case.applies`; 127 floored rows driven at a 1.0.3 party
+- [ITS-REST 1.1.0-dated surfaces](its-rest-1-1-0-dated-surfaces.md) — the Amendment_record dating table (SF/item-tags/demographic/admin-delete/W-ETag…) = the ground for every version floor
+- [SHOULD headers over-gated](should-headers-over-gated.md) — Last-Modified presence + the 412 ETag are SHOULDs; bare `present` matchers must be `present?`
+- [AMB-167 documented-family root-name gap](amb167-documented-family-root-name-gap.md) — the handling carve-out contradicts the classification; DOCUMENTED XML root+namespace is a MUST with no case

--- a/.claude/agent-memory/cnf-triage/amb167-documented-family-root-name-gap.md
+++ b/.claude/agent-memory/cnf-triage/amb167-documented-family-root-name-gap.md
@@ -1,0 +1,40 @@
+---
+name: amb167-documented-family-root-name-gap
+description: AMB-167's handling forbids asserting an XML root name for EVERY family, contradicting its own finding that DOCUMENTED families' §XML Format MUSTs are enforceable
+metadata:
+  type: project
+---
+
+AMB-167 classifies canonical-XML per resource: **DOCUMENTED** (a published
+global `xs:element` exists — `composition`, `version`, `versioned_object`,
+`template`, `archetype`, `extract`, `extract_request`, `items`) vs **UNDEFINED**
+(EHR, EHR_STATUS, FOLDER, PARTY*, CONTRIBUTION, REVISION_HISTORY, ITEM_TAG).
+Its ambiguity text says: "For a resource WITH a document element, offering XML is
+fully released behaviour and the §XML Format MUSTs are enforceable as written."
+
+But its `handling` then says: "ROOT ELEMENT NAME where a family IS offered: no
+openEHR spec governs it — our own design/extension — so no case asserts one."
+That blanket carve-out is correct only for the UNDEFINED families and **wrong for
+the DOCUMENTED ones**, where `Composition.xsd` (`targetNamespace=
+http://schemas.openehr.org/v1`, `elementFormDefault="qualified"`) fixes both the
+root NAME and its NAMESPACE, and Resources.md §XML Format makes responses "MUST
+conform to the [published XSDs]".
+
+Consequence measured 2026-07-28: EHRbase 2.34.0 serves `<composition …>` with the
+root in NO namespace and **no case in the catalogue detects it** — a coverage
+gap on a MUST, not a latitude.
+
+Two further consequences of the same undefined/documented split:
+- The `<family>-xml-supported` arms are being used for **WRITE** rows
+  (`create_ehr-xml`, `create_directory-xml`, `set_ehr_*-xml_body`). A write
+  necessarily commits to a root element name, which for an UNDEFINED family is
+  exactly what AMB-167 says is spec-silent — so those rows assert an
+  unauthorable document. Same defect class as the AMB-165 read-side claim
+  ([[contribution-xml-read-not-a-released-document]]).
+- The released OAS declares `application/json` ONLY on the request bodies of
+  `ehr_create`, `ehr_status_update` and `directory_create`, so there is no
+  released ground for an XML request body on those routes at all.
+
+**How to apply:** CATALOGUE bin. Split AMB-167's handling by classification —
+assert root name + namespace on the DOCUMENTED families, keep the silence for
+UNDEFINED ones, and re-ground or retire the UNDEFINED-family write rows.

--- a/.claude/agent-memory/cnf-triage/its-rest-1-1-0-dated-surfaces.md
+++ b/.claude/agent-memory/cnf-triage/its-rest-1-1-0-dated-surfaces.md
@@ -1,0 +1,34 @@
+---
+name: its-rest-1-1-0-dated-surfaces
+description: The ITS-REST Amendment_record dating table — which surfaces arrived in Release-1.1.0 vs 1.0.3 and earlier; the ground for every case/header version floor
+metadata:
+  type: reference
+---
+
+`docs/specs/openehr/ITS-REST/specifications/docs/overview/Amendment_record.md`
+is the authoritative date line for every `applies: { its_rest: … }` floor. It is
+HTML-in-markdown; strip tags to read it.
+
+**Release-1.1.0 additions** (a party declaring 1.0.3 is out of scope for all of
+these): SPECITS-95 UPDATE_AUDIT typing (5.9) · SPECPR-472 `system_id` on
+`openehr-audit-details` (5.8) · SPECITS-92 RM sync + **SPECITS-84 Simplified
+Formats MIME types on CONTRIBUTION** (5.7) · SPECITS-86 `template_id`/`version`
+filters on listTemplates (5.6) · SPECITS-58 `/example` sub-resource,
+SPECITS-34 SM-derived resources, SPECITS-87 ADL2 deprecations, SPECITS-46 `aql`
+name fix (5.5) · **SPECITS-61 Simplified Formats consolidation + the Accept/
+Content-Type headers that support them** (5.4) · SPECITS-74 `Location`
+deprecation, **SPECITS-82 `W/` ETag**, SPECITS-50 minimal responses (5.3) ·
+**SPECITS-77 ITEM_TAGs**, **SPECITS-80 admin EHR delete**, SPECITS-75 header
+renames (`openEHR-AUDIT_DETAILS` → `openehr-audit-details`, etc.) (5.2) ·
+**SPECITS-70 Demographic API endpoint**, SPECITS-73 yaml restructure (5.1/5.0).
+
+**Release-1.0.3** contains exactly ONE item: SPECITS-66 "Migrate REST API specs
+to OpenAPI Specification" (4.1). **Release-1.0.2** carries SPECITS-41 **"Add
+double quotes to ETag and If-Match headers"** (3.3) — so the quoted entity-tag
+form is floor-proof at 1.0.2. **Release-1.0.1** carries SPECITS-38 "Fix response
+status code for semantic validation errors" (2.5) — 422-for-semantic is
+floor-proof at 1.0.1.
+
+**How to apply:** before attributing a comparison-party red row to upstream,
+date the surface here. A 404/406 on a 1.1.0-dated surface against a 1.0.3 party
+is a selection question, not an upstream finding.

--- a/.claude/agent-memory/cnf-triage/provisioning-silently-swallows-failures.md
+++ b/.claude/agent-memory/cnf-triage/provisioning-silently-swallows-failures.md
@@ -7,17 +7,27 @@ metadata:
 
 `exec/driver.rs::provision`, confirmed 2026-07-28:
 
-- **Template upload result discarded**: `let _uploaded = self.send(request_spec
-  .method, &url, &headers, Some(&payload), false)?;` (~L2241). Any non-2xx
+- **Template upload result discarded at TWO sites**: `let _uploaded =
+  self.send(request_spec.method, &url, &headers, Some(&payload), false)?;` —
+  `provision_synthesized_opt` **driver.rs:2122** (per-row synthesized OPT) and
+  `provision` **driver.rs:2325-2326** (`requires.templates`). Any non-2xx
   (406/415/422) on `POST /definition/template/adl1.4` is swallowed and the case
   proceeds as if the template exists — downstream commits then fail on
   "validation_failed"/"template_not_found" and read as SUT defects.
   The comment only sanctions tolerating **409 already-provisioned**.
-- **Provisioning sends no `Accept`** (headers are built from the binding's
-  `request.headers` + auth only), while the normal step path defaults
-  `Accept: application/json` (L1477/L1628). So the SAME upload can succeed in
-  provisioning and 406 when driven as a case — that is exactly the ehrbase-java
-  `I_DEFINITION_ADL14.upload_opt-*` 406 class.
+- **MEASURED BLAST RADIUS (ehrbase-java, 2026-07-28): 197 of 294 in-scope red
+  rows** — the whole 123-row CONT battery plus most of composition/contribution
+  — came from ONE swallowed 406. Reproduced: provisioning POSTs the OPT with
+  `Accept: application/json` (the binding's declared header, now shared with the
+  step path per #629), EHRbase answers `406 {"error":"Not Acceptable"}` and
+  serves the upload only for `Accept: application/xml`; every following commit
+  gets `422 "Template with template_id '…' does not exist"`, reported as
+  "expected `created`, observed `validation_failed`".
+- Provisioning now uses `compose_headers` (the one request-construction path),
+  so it DOES send the binding's `Accept` — the earlier "provisioning sends no
+  Accept" note is obsolete. The failure mode moved: the shared Accept means a
+  server that refuses that representation breaks provisioning for every
+  template-dependent case at once.
 - **`requires: { server: empty }` is a NO-OP** by design ("isolation is the
   runner's tenancy concern … never destructive", ~L2197). Emptiness is achieved
   only by the freshly composed SUT plus per-case scoping — the query cases mint

--- a/.claude/agent-memory/cnf-triage/runner-ignores-case-level-applies.md
+++ b/.claude/agent-memory/cnf-triage/runner-ignores-case-level-applies.md
@@ -1,0 +1,29 @@
+---
+name: runner-ignores-case-level-applies
+description: RUNNER selection defect — run.rs::execute never consults case.applies, so version-floored cases are driven against a party that declares a lower spec version
+metadata:
+  type: project
+---
+
+`run.rs::execute` applies FIVE drive-time selection arms — unrealized binding,
+extension-family × unclaimed capability, `case.option` vs `statement.options`,
+`OperationBinding.applies` (`unmet_binding_floors`, run.rs:384-406), SMART lane
+/ instance / ixit facts / exclusive-server — but **never `case.applies`**. Only
+`verdict.rs::select` (`applies_satisfied`, verdict.rs:509) filters on it.
+
+**Why it matters:** the #635 floor triage put the ITS-REST 1.1.0 floors on the
+CASE, not the binding. On the 2026-07-28 ehrbase-java record (party declares
+`its_rest: 1.0.3`) **127 red rows** sat on cases carrying
+`applies: { its_rest: ">=1.1.0" }` — 57 SF, 27 item tags, 16 demographic,
+8 composition, 7 admin, … They are excluded from the verdict, but they are
+published in `results.json` as failed/errored, i.e. as divergences on surfaces
+the release dated after the party's declared version. Only **4 binding-level**
+floors exist in the whole catalogue (3 × `I_EHR_SERVICE.create_ehr*`,
+`I_QUERY_SERVICE.execute_stored_query`), so the binding arm catches almost
+nothing.
+
+**How to apply:** the fix is one more arm in `run.rs::execute` mirroring the
+binding-floor arm (same not-applicable-with-citation shape). Until then, never
+read a red-row count off `results.json` for a party whose `spec_versions` are
+below the catalogue's realized ITS-REST — split by `case.applies` first.
+See [[results-json-records-out-of-scope-rows]], [[its-rest-1-1-0-dated-surfaces]].

--- a/.claude/agent-memory/cnf-triage/should-headers-over-gated.md
+++ b/.claude/agent-memory/cnf-triage/should-headers-over-gated.md
@@ -1,0 +1,30 @@
+---
+name: should-headers-over-gated
+description: Last-Modified presence and the 412 ETag are SHOULDs in the ITS-REST overview, but many bindings declare them as bare gating matchers
+metadata:
+  type: project
+---
+
+`ITS-REST/specifications/docs/overview/Requests_and_responses.md`:
+
+- §ETag and Last-Modified, closing sentence: "Both `ETag` and `Last-Modified`
+  **SHOULD** be included in responses for VERSION, VERSIONED_OBJECT, or other
+  resources that have versioning or unique state identifiers."
+- §If-Match: on a false precondition the service "MUST respond with HTTP status
+  code `412 Precondition Failed`, and **SHOULD** return also latest
+  `version_uid` in the `ETag` response headers."
+
+So on those two, PRESENCE is a SHOULD; only the FORM (`W/"…"`, 1.1.0-dated) is a
+MUST. The runner supports exactly this via `HeaderExpectation.optional` (authored
+`present?`). But ~20 bindings declare bare `Last-Modified: present` and the 412
+outcomes declare bare `ETag: latest-version-uid` — gating assertions. That cost
+8 in-scope red rows on the 2026-07-28 ehrbase-java record
+(`I_EHR_DIRECTORY.delete_directory-*`, `get_directory*-deleted*`,
+`I_EHR_STATUS.get_versioned_ehr_status-*`,
+`I_EHR_DIRECTORY.update_directory-stale_if_match`).
+
+**How to apply:** CATALOGUE bin. A header whose presence the released text makes
+a SHOULD is authored `present?`; the FORM matcher (and its `applies` floor) stays
+gating. Same family as [[query-etag-presence-is-should]] and
+[[etag-weak-indicator-is-1-1-0-scoped]] — the floor/optionality is applied
+inconsistently across bindings, so sweep, don't patch one file.

--- a/.claude/agent-memory/cnf-triage/upstream-ehrbase-java-nonconformance.md
+++ b/.claude/agent-memory/cnf-triage/upstream-ehrbase-java-nonconformance.md
@@ -1,39 +1,63 @@
 ---
 name: upstream-ehrbase-java-nonconformance
-description: EHRbase Java 2.34.0 upstream (comparison SUT) non-conformances found reproducing #266 measured-window error classes
+description: EHRbase Java 2.34.0 (comparison SUT) upstream divergences, all reproduced on the wire 2026-07-28 against the full catalogue
 metadata:
   type: project
 ---
 
-Reproducing #266's upstream measured error classes (EHRbase Java 2.34.0,
-`docker/sut-ehrbase-java.yml`) confirmed two UPSTREAM non-conformances vs the
-released ITS-REST 1.1.0 docs text — NOT our-side defects (our driver/pack are
-spec-valid; the identical exchanges pass 100% on ehrbase-rs).
+Reproduced first-hand against `docker/sut-ehrbase-java.yml` (2.34.0, declares
+ITS-REST 1.0.3). Each is a divergence from a RELEASED source at or below the
+party's own declared version unless marked otherwise. Never "fix" our
+pack/catalogue toward any of these.
 
-**1. Quoted If-Match → 400 "UUID string too large".** EHRbase rejects the
-RFC-9110 / spec-standard double-quoted entity-tag `If-Match: "uid::system::N"`
-(the form in `ITS-REST/specifications/docs/overview/Requests_and_responses.md`
-line 207) and only accepts the non-standard UNquoted value. It even 400s on its
-OWN returned ETag echoed back verbatim. This is the whole composition_update
-(77/77) + ehr_status_update (26/26) 400 class. Our driver
-(`perf_run/client.rs:120-122`) sends the quoted form = spec-correct.
+1. **Quoted `If-Match` → 400** "UUID string too large"; the unquoted value
+   works. The double-quoted entity-tag form dates to Release-**1.0.2**
+   (SPECITS-41) and is the overview §If-Match example, so this is floor-proof.
+   Whole `precondition_missing` class (27 in-scope rows).
+2. **`POST /definition/template/adl1.4` with `Accept: application/json` → 406**;
+   only `application/xml` is served. Released OAS `Accept_Template.yaml` enums
+   json/xml/`openehr.wt+json` and `201_Template_adl1_4_upload.yaml` declares an
+   `application/json` (TemplateIdentifier) entry. Ground is the 1.1.0 OAS — the
+   1.0.3 OAS is not vendored, so caveat the version.
+3. **Semantic RM violations answered 400, not 422** (`Missing attribute
+   EHR_STATUS/subject`). 422-for-semantic dates to Release-1.0.1 (SPECITS-38).
+4. **RM-invalid EHR_STATUS accepted (201)**: missing `archetype_details` on an
+   archetype root, and `other_details` with no `_type`. See
+   [[ehr-status-archetype-root-invariant]].
+5. **`openehr-audit-details` ignored on `POST /ehr`** (both the 1.1.0 spelling
+   and the deprecated `openEHR-AUDIT_DETAILS`): committer stays the auth user
+   and `description` comes back as `{"_type":"DV_TEXT"}` with NO `value` — an
+   RM-invalid DV_TEXT. Overview §openehr-version and openehr-audit-details:
+   "services MUST accept …" / "MUST be merged with the default VERSION and
+   VERSION.audit_details attributes on commit runtime".
+6. **Canonical XML is served UNNAMESPACED**: `<composition …
+   xmlns:ns2="http://schemas.openehr.org/v1">` — the root is in no namespace and
+   ns2 is unused, while `Composition.xsd` is `targetNamespace=…/v1`
+   `elementFormDefault="qualified"`. §XML Format: responses "MUST conform to the
+   [published XSDs]". NO catalogue case catches this (see
+   [[amb167-documented-family-root-name-gap]]).
+7. **`GET /definition/query` with `Accept: application/xml` → 200 `<List/>`**
+   (Content-Type application/xml) — an XML document conforming to no published
+   XSD, where the release offers JSON only on every query operation.
+8. **Unqualified/dotted stored-query name → 400** (`cnf.ward_dashboard-probe`).
+   Query `Qualified_query_name.md`: "The `namespace` is optional"; `query-name`
+   pattern `[a-zA-Z0-9_.-]`; `my_compositions` is a listed VALID example.
+9. **Stale `If-Match` on `DELETE /ehr/{id}/directory` → 404** (409 in the run),
+   where §If-Match makes 412 a MUST. 412 responses carry no `ETag` (that part is
+   only a SHOULD, so not gating).
+10. **405 responses carry no `Allow`** (RFC 9110 §15.5.6 MUST; the overview
+    status table incorporates RFC 9110).
+11. **Malformed path uuid → 404**, catalogue expects 400 — check the OAS before
+    calling this a divergence; not adjudicated.
+12. **`VERSIONED_EHR_STATUS.owner_id.type` = `"ehr"`**, not the RM class name
+    `EHR` (BASE `object_ref.adoc` §type: "class names are from the relevant
+    reference model").
+13. **500** on `commit_contribution` with invalid change types.
+14. **Admin EHR delete served at `/ehrbase/rest/admin/ehr/{id}`** (204), 404 at
+    the released `…/openehr/v1/admin/ehr/{id}` — but SPECITS-80 dates the
+    operation to 1.1.0, so it is OUT OF SCOPE for a 1.0.3 party, not a finding.
 
-**2. Item-tag surface unimplemented → 404 "No resource found at path".**
-`/ehr/{id}/tags`, `/ehr/{id}/composition/{uid}/tags` (GET+PUT) are part of the
-STABLE EHR API (`ehr.openapi.yaml` x-status: STABLE, L5; paths L95-113) but
-EHRbase 2.34.0 has no routes. The tags_put (34/34) + tags_read (34/34) 404 class.
-Released-STABLE, so upstream non-conformance, NOT N/A.
-
-**template_get 3/85 = transient** (endpoint returns 200 JSON+XML; load-window
-noise), not deterministic, no defect.
-
-Disposition for all: outcome (b) — measured record stands; note upstream
-non-conformances in the public comparison narrative. NEVER "fix" our pack/driver
-to match upstream (that would break the spec-correct ehrbase-rs path).
-
-**Why: `If-Match` echoing the server ETag verbatim (quoted) is the textbook
-RFC flow; deriving the expectation from the released docs text (not the SUT)
-made this an upstream verdict, not a pack fix.**
-**How to apply:** when a comparison SUT 400s a versioned PUT, check If-Match
-quoting before suspecting the payload; when it 404s item tags, it's a
-STABLE-surface gap.
+**CORRECTION to the earlier note:** the item-tag 404s are NOT an upstream
+non-conformance for this party — SPECITS-77 dates ITEM_TAGs to Release-**1.1.0**
+([[its-rest-1-1-0-dated-surfaces]]), and the party declares 1.0.3. Same for the
+Demographic API (SPECITS-70) and Simplified Formats (SPECITS-61).

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.physical_ehr_delete-delete_existing.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.physical_ehr_delete-delete_existing.yaml
@@ -18,7 +18,7 @@ spec_refs:
   - "SM openehr_platform §I_ADMIN_SERVICE.physical_ehr_delete"
   - "CNF platform_test_schedule master12 §physical_ehr_delete"
   - "ITS-REST admin §admin_ehr_delete (DELETE /admin/ehr/{ehr_id})"
-applies: { rm: ">=1.0.2" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # admin EHR delete arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-80); the floor its six siblings already carry
 guards:
   - "ITS-REST Admin API is DEVELOPMENT-stage — admin.openapi.yaml carries x-status: DEVELOPMENT (not STABLE); guarded until the Admin API stabilises"
 requires: { ehr: { commits: any } }        # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.physical_ehr_delete-delete_non_existing.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.physical_ehr_delete-delete_non_existing.yaml
@@ -14,7 +14,7 @@ spec_refs:
   - "SM openehr_platform §I_ADMIN_SERVICE.physical_ehr_delete"
   - "CNF platform_test_schedule master12 §physical_ehr_delete"
   - "ITS-REST admin §admin_ehr_delete (404_unknown_ehr_id)"
-applies: { rm: ">=1.0.2" }
+applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # admin EHR delete arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-80); the floor its six siblings already carry
 guards:
   - "ITS-REST Admin API is DEVELOPMENT-stage — admin.openapi.yaml carries x-status: DEVELOPMENT (not STABLE); guarded until the Admin API stabilises"
 requires: { server: empty }

--- a/tools/cnf-runner/party/ehrbase-java/statement.json
+++ b/tools/cnf-runner/party/ehrbase-java/statement.json
@@ -56,7 +56,9 @@
     "directory-empty-error",
     "directory-xml-supported",
     "ehr-status-xml-supported",
-    "ehr-xml-supported"
+    "ehr-xml-supported",
+    "adl14-partial-id-exact",
+    "xml-namespace-fixed"
   ],
   "non_functional": {
     "note": "First-cut ICS for the CNF comparison re-base (#232), derived from the EHRbase 2.x documented surface: ADL 1.4 OPT provisioning only (no ADL 2 endpoints), no demographic/messaging/EHR-extract services, Basic auth with one clinical + one admin principal (no readonly role \u2014 the ixit declares no readonly instance), SimplifiedFormats UNCLAIMED: measured 2026-07-22, the /openehr/v1 composition endpoint answers 415 to the ITS-REST 1.1.0 media types (application/openehr.wt.flat+json / wt.structured+json) and accepts only the deprecated .schema+json names \u2014 the ITS-REST simplified wire is not implemented. Option selection (directory-empty-error) is configuration-pinned by docker/sut-ehrbase-java.yml, as is SYSTEM_ALLOWTEMPLATEOVERWRITE=false \u2014 no longer an option selection since the 2026-07-28 re-adjudication of AMB-4 made the duplicate-template 409 a gating expectation for every server, but still the setting this SUT needs in order to meet it. The canonical-XML family options (AMB-167) carry forward the posture this ICS already implied before those rows became option-gated \u2014 the EHR / EHR_STATUS / directory XML rows were judged as served and the CONTRIBUTION read rows as refused \u2014 with no new claim made; the party family is not declared because PartyOperations is not claimed. Every claim is refined by the measured run \u2014 the published verdicts, not this file, are the record."

--- a/tools/cnf-runner/src/exec/driver.rs
+++ b/tools/cnf-runner/src/exec/driver.rs
@@ -2134,8 +2134,38 @@ impl HttpDriver<'_> {
         let base = instance.base_url.trim_end_matches('/');
         let url = format!("{base}{}", request_spec.path.raw());
         // 409 tolerated: a re-run row re-uploads the same deterministic OPT.
-        let _uploaded = self.send(request_spec.method, &url, &headers, Some(&payload), false)?;
+        let uploaded = self.send(request_spec.method, &url, &headers, Some(&payload), false)?;
+        if let Some(reason) = Self::provisioning_refusal("upload_opt", &uploaded) {
+            return Ok(Provisioned::RowErrored { reason });
+        }
         Ok(Provisioned::Ready)
+    }
+
+    /// Judge a PROVISIONING exchange: 2xx establishes the ground and 409
+    /// means it already exists (re-runs on a shared world) — anything else
+    /// is a REFUSAL, and the case's required ground does not exist. The
+    /// refusal is surfaced as an inconclusive row naming this exchange
+    /// (the triage law: an unestablished `requires` precondition is a
+    /// step-resolution failure, never a SUT failure of the behaviour under
+    /// test — the 2026-07-28 java run reported 197 swallowed template-upload
+    /// 406s as content-validation failures).
+    fn provisioning_refusal(what: &str, exchange: &Exchange) -> Option<String> {
+        if (200..300).contains(&exchange.status) || exchange.status == 409 {
+            return None;
+        }
+        let body_head: String = exchange
+            .body
+            .as_ref()
+            .map(ToString::to_string)
+            .unwrap_or_default()
+            .chars()
+            .take(200)
+            .collect();
+        Some(format!(
+            "provisioning {what} refused: status {} — the case's required ground was never \
+             established; the behaviour under test was not driven (body: {body_head})",
+            exchange.status
+        ))
     }
 }
 
@@ -2352,8 +2382,10 @@ impl StepDriver for HttpDriver<'_> {
             let base = instance.base_url.trim_end_matches('/');
             let url = format!("{base}{}", request_spec.path.raw());
             // 409 tolerated: already provisioned (the send records it).
-            let _uploaded =
-                self.send(request_spec.method, &url, &headers, Some(&payload), false)?;
+            let uploaded = self.send(request_spec.method, &url, &headers, Some(&payload), false)?;
+            if let Some(reason) = Self::provisioning_refusal("upload_opt", &uploaded) {
+                return Ok(Provisioned::RowErrored { reason });
+            }
         }
         if let Provisioned::RowNotApplicable { citation } =
             self.provision_synthesized_opt(case, row)?

--- a/tools/cnf-runner/src/exec/mod.rs
+++ b/tools/cnf-runner/src/exec/mod.rs
@@ -159,6 +159,16 @@ pub enum Provisioned {
         /// The excusing register citation (e.g. an `AMB-nn` entry).
         citation: String,
     },
+    /// The SUT REFUSED a provisioning exchange (e.g. a template upload
+    /// answered outside 2xx/409), so the case's required ground does not
+    /// exist — the row is inconclusive, never a SUT failure of the
+    /// behaviour under test (`.claude` triage law: an unestablished
+    /// `requires` precondition is a step-resolution failure). The reason
+    /// names the provisioning exchange so the red row localizes to it.
+    RowErrored {
+        /// The refused provisioning exchange (operation, status, body head).
+        reason: String,
+    },
 }
 
 /// Resolve the expected kind for a step in a given row (the per-fixture
@@ -223,13 +233,21 @@ pub fn run_case<D: StepDriver>(
     for row in 0..total {
         if reset_per_row || row == 0 {
             vars = VarStore::default();
-            // Law a; an unrealizable per-row ground records the row N/A.
-            if let Provisioned::RowNotApplicable { citation } =
-                driver.provision(case, row, &mut vars)?
-            {
-                row_states.push(vars.clone());
-                rows.push(RowOutcome::NotApplicable { citation });
-                continue;
+            // Law a; an unrealizable per-row ground records the row N/A,
+            // and a REFUSED provisioning exchange records it inconclusive
+            // (step 0 = the precondition, before any flow step drove).
+            match driver.provision(case, row, &mut vars)? {
+                Provisioned::Ready => {}
+                Provisioned::RowNotApplicable { citation } => {
+                    row_states.push(vars.clone());
+                    rows.push(RowOutcome::NotApplicable { citation });
+                    continue;
+                }
+                Provisioned::RowErrored { reason } => {
+                    row_states.push(vars.clone());
+                    rows.push(RowOutcome::Errored { step: 0, reason });
+                    continue;
+                }
             }
         }
 

--- a/tools/cnf-runner/src/run.rs
+++ b/tools/cnf-runner/src/run.rs
@@ -382,6 +382,42 @@ pub fn execute(
                 .push((case.id.clone(), Exception::Unrealized(citation)));
             continue;
         }
+        // Case-level spec-version floors (`CaseCore.applies`): a behaviour
+        // the spec dates to a release the party does not declare is out of
+        // scope for it — `Applies::satisfied_by`, the one polarity every
+        // consumer of the floor uses (`verdict` selection re-applies the
+        // same predicate). Driving such a case records a spurious failure
+        // against behaviour the party never claimed (the 2026-07-28 java
+        // run drove 127 red rows and 13 spuriously green ones this way) —
+        // excuse it at drive time with the declared ranges as the citation.
+        if let Some(stmt) = statement
+            && !case.applies.satisfied_by(&stmt.spec_versions)
+        {
+            let declared: Vec<String> = case
+                .applies
+                .entries()
+                .into_iter()
+                .map(|(component, range)| format!("{} {}", component.token(), range.raw()))
+                .collect();
+            let citation = format!(
+                "case version floor unmet ({}) — the party's declared spec versions do not \
+                 satisfy the case's applies ranges; ISO/IEC 9646 test selection",
+                declared.join(", ")
+            );
+            report.records.push(CaseRecord {
+                case: case.id.clone(),
+                format: None,
+                rows: vec![RowOutcome::NotApplicable {
+                    citation: citation.clone(),
+                }],
+                rows_driven: 0,
+                rows_total: crate::exec::row_count(case),
+            });
+            report
+                .exceptions
+                .push((case.id.clone(), Exception::Unrealized(citation)));
+            continue;
+        }
         // Operation-level spec-version floors (`OperationBinding.applies`):
         // a wire a later release introduced is not this party's behaviour to
         // answer for — the same ISO/IEC 9646 selection question the option


### PR DESCRIPTION
The two runner defects the fresh ehrbase-java triage attributed (both tainting that record — the honest comparison re-runs after this merges; #619):

1. **`run.rs::execute` never consulted the case core's own `applies` block** — only verdict selection applied it, so a 1.0.3-declaring party was DRIVEN through 1.1.0-dated cases: 127 red rows + 13 spuriously green ones in the record. Drive-time selection now applies `Applies::satisfied_by` (the same single-polarity predicate every other consumer uses) and records not-applicable with the declared ranges as the citation.
2. **Both template-upload provisioning sites discarded the HTTP result** (`let _uploaded = …`) — a 406/415/422 refusal was swallowed and the case ran on ground that did not exist: 197 in-scope rows reported as content-validation failures that were actually ONE upstream Accept defect. Provisioning exchanges are now judged (2xx / 409-already-provisioned tolerated); a refusal records the row **inconclusive** naming the provisioning exchange, per the triage law (an unestablished `requires` precondition is a step-resolution failure, never a SUT failure).

Plus the same triage's catalogue/party corrections: the two floor-less `physical_ehr_delete` admin cases gain the `its_rest: ">=1.1.0"` floor their six siblings carry (Amendment_record §Release-1.1.0, SPECITS-80), and the ehrbase-java ICS declares its two wire-proven options — `adl14-partial-id-exact` (partial template id → 404, exact ids serve) and `xml-namespace-fixed` (the `version` media-type parameter is not read) — resolving the run's two review findings.

Gates: validate 768 cases / 0 findings, nextest 245/245, clippy unchanged, fmt clean. The behavioural proof is the java re-run (the 127 wrongly-driven rows flip to cited N/A; the 197 swallowed-provisioning rows flip to inconclusive) and the ehrbase-rs zero-drift run at the batch convergence.