### PR TITLE
chore: re-ground the 'stalled OAS' vocabulary on the released oracle order (#615)

### DIFF
--- a/app/ehrbase-rest/src/api/definition/template_adl14.rs
+++ b/app/ehrbase-rest/src/api/definition/template_adl14.rs
@@ -175,7 +175,7 @@ pub(super) async fn example_get(
         .backend()
         .template_adl14_example(p.template_id, p.detail_level, p.r#type)
         .await?;
-    // Negotiate the four representations the dev-OAS `Accept_LOCATABLE`
+    // Negotiate the four representations the released OAS `Accept_LOCATABLE`
     // enumerates (json / xml / wt.flat+json / wt.structured+json). Any other
     // media type is a `406` (the endpoint's `406` response).
     match negotiate::resolve_accept(h, EXAMPLE_FORMATS, WireFormat::CanonicalJson) {

--- a/app/ehrbase-rest/src/api/definition/template_adl2.rs
+++ b/app/ehrbase-rest/src/api/definition/template_adl2.rs
@@ -171,7 +171,7 @@ pub(super) async fn example_get(
         .backend()
         .template_adl2_example(p.template_id.clone(), p.detail_level, p.r#type)
         .await?;
-    // Negotiate the four representations the dev-OAS `Accept_LOCATABLE`
+    // Negotiate the four representations the released OAS `Accept_LOCATABLE`
     // enumerates (json / xml / wt.flat+json / wt.structured+json). Any other
     // media type is a `406`.
     match negotiate::resolve_accept(h, EXAMPLE_FORMATS, WireFormat::CanonicalJson) {

--- a/app/ehrbase-rest/src/api/demographic/openapi_routes.rs
+++ b/app/ehrbase-rest/src/api/demographic/openapi_routes.rs
@@ -34,7 +34,8 @@
 //! `demographic_tags_get.yaml` — see that section's own preamble, which carries
 //! the family-wide rules: canonical-JSON only, no change control, and the
 //! our-own-design `owner_id`). Everything the released files leave open is
-//! filled from the RELEASED overview chapters — never from the stalled OAS:
+//! filled from the RELEASED overview chapters first (the docs text wins every
+//! conflict; the released OAS grounds only what the docs text leaves silent):
 //! `docs/overview/Requests_and_responses.md` (the weak `W/` `ETag` MUST, the
 //! `Prefer` triad + `Preference-Applied`, the committal-header
 //! `openehr-version`/`openehr-audit-details` MUST-accept rule, the `If-Match`
@@ -6170,7 +6171,7 @@ pub(crate) async fn contribution_get(
 // `target` is the bare RM `UID_BASED_ID` (`item_tag.adoc`: `target:
 // UID_BASED_ID`, "which may be a `VERSIONED_OBJECT<T>` or a `VERSION<T>`") — a
 // `HIER_OBJECT_ID` for a container target, an `OBJECT_VERSION_ID` for a
-// VERSION target; the RELEASED RM wins over the stalled OAS
+// VERSION target; the RELEASED RM wins the real conflict with the released OAS
 // `ItemTag`/`UObjectRefOfUidBasedId` envelope. `owner_id` follows the five
 // released `ItemTagOf*` examples' unanimous `{namespace: local, type: SYSTEM}`
 // shape carrying the server's system identifier — no demographic RM class

--- a/app/ehrbase-rest/src/api/ehr/composition.rs
+++ b/app/ehrbase-rest/src/api/ehr/composition.rs
@@ -207,9 +207,10 @@ pub(super) async fn run(
             let body = decode_composition_body(&state, h, &parts.body).await?;
             // A body-supplied COMPOSITION.uid must identify the same
             // versioned object as the path `uid_based_id` — never a silent
-            // write to the path's object. NOTE: no released ITS-REST sentence
-            // assigns this rejection (the "must match" rule appears only in
-            // the stalled OAS operation description); the body is well-formed,
+            // write to the path's object. NOTE: the "must match" rule is
+            // grounded by the released OAS operation description (the docs
+            // text is silent), but neither source assigns the rejection a
+            // status; the body is well-formed,
             // so the fitting released row is 422 ("well-formed but was unable
             // to be followed due to semantic errors",
             // Requests_and_responses.md §HTTP status codes) — our register-

--- a/app/ehrbase-rest/src/api/ehr/openapi_routes.rs
+++ b/app/ehrbase-rest/src/api/ehr/openapi_routes.rs
@@ -5387,9 +5387,9 @@ pub(crate) async fn contribution_get(
 /// every taggable kind (COMPOSITION, `EHR_STATUS`, FOLDER). Each row names its
 /// own `target` by identifier, but NOT by RM class: the RM types `target` as a
 /// bare `UID_BASED_ID` (`item_tag.adoc`), which carries no `type` member, so a
-/// client that needs the target's kind resolves the uid. (The stalled OAS
-/// models `target` as an `OBJECT_REF`, which would carry it; the released RM
-/// wins.)
+/// client that needs the target's kind resolves the uid. (The released OAS
+/// models `target` as an `OBJECT_REF`, which would carry it — a real
+/// conflict; the released RM wins.)
 ///
 /// The list is unbounded: the released operation declares no `offset`/`fetch`,
 /// ordering or limit parameter, so every matching tag is returned. The
@@ -5453,7 +5453,7 @@ pub(crate) async fn contribution_get(
                                         target — and `owner_id` is the RM \
                                         `OBJECT_REF` of the owning EHR \
                                         (`{namespace: local, type: EHR, id: \
-                                        <ehr_id>}`). The stalled OAS `ItemTag` \
+                                        <ehr_id>}`). The released OAS `ItemTag` \
                                         schema types `target` as an OBJECT_REF \
                                         instead; the RM is the RELEASED \
                                         component and wins. The example shows \
@@ -5587,7 +5587,7 @@ pub(crate) async fn ehr_tags_get(
                                         the container form, `OBJECT_VERSION_ID` \
                                         for the version form — and `owner_id` \
                                         the OBJECT_REF of the owning EHR. \
-                                        (The stalled OAS `ItemTag` schema \
+                                        (The released OAS `ItemTag` schema \
                                         types `target` as an OBJECT_REF; the \
                                         RM is the RELEASED component and \
                                         wins.) `target_path` is present only \
@@ -6115,7 +6115,7 @@ pub(crate) async fn composition_tags_delete(
                                         the container form, `OBJECT_VERSION_ID` \
                                         for the version form — and `owner_id` \
                                         the OBJECT_REF of the owning EHR. \
-                                        (The stalled OAS `ItemTag` schema \
+                                        (The released OAS `ItemTag` schema \
                                         types `target` as an OBJECT_REF; the \
                                         RM is the RELEASED component and \
                                         wins.) `target_path` is present only \

--- a/app/ehrbase-rest/src/api/query/openapi_routes.rs
+++ b/app/ehrbase-rest/src/api/query/openapi_routes.rs
@@ -8,8 +8,9 @@
 //! The Query API is one of the few groups with DEDICATED released prose
 //! (`docs/query/Request.md`, `Response.md`, `Query_types.md`,
 //! `Qualified_query_name.md` — all STABLE in Release 1.1.0), so the declarations
-//! below quote that text rather than the stalled OAS wherever the two could be
-//! read differently.
+//! below quote that text over the released OAS wherever the two conflict
+//! (the docs text wins every conflict; the OAS grounds only what the docs
+//! text leaves silent — the oracle order).
 //!
 //! ## Prose-vs-OAS reconciliations (documented real wire)
 //!
@@ -1024,7 +1025,7 @@ pub(crate) async fn query_execute_stored_query(
                        `fetch` and `query_parameters`, all OPTIONAL, and no \
                        `q` — the AQL is the stored definition. The released \
                        schema lists all three as `required`, but the docs text \
-                       wins (owner ruling: the stalled OAS is not the oracle): \
+                       wins this real conflict with the released OAS: \
                        `offset` has \"default is `0`\" and `fetch`'s \"default \
                        depends on the implementation\" (`Request.md` §Common \
                        Headers and Query Parameters), and a required member \

--- a/app/ehrbase-rest/src/api/query/stored.rs
+++ b/app/ehrbase-rest/src/api/query/stored.rs
@@ -122,8 +122,8 @@ fn stored_body_request(
     body: &bytes::Bytes,
 ) -> Result<AqlQueryRequest, RestError> {
     // All three body members are OPTIONAL (`Request.md` §Common Headers:
-    // offset defaults 0, fetch is implementation-default — the stalled OAS
-    // required-list loses to the docs text): `{}` executes a parameterless
+    // offset defaults 0, fetch is implementation-default — the released OAS
+    // required-list loses this real conflict to the docs text): `{}` executes a parameterless
     // stored query.
     let parsed: StoredQueryBody = response::decode_body(h, body)?;
     // The docs-text SHOULD-list draws no GET/POST distinction ("All query

--- a/app/ehrbase-rest/src/router.rs
+++ b/app/ehrbase-rest/src/router.rs
@@ -219,9 +219,10 @@ pub fn router(state: AppState, authenticator: Arc<Authenticator>) -> Router {
     // System API chapter is a stub with no field semantics
     // (`docs/specs/openehr/ITS-REST/specifications/docs/system/Description.md`
     // — Purpose, Related Documents and Status only), and the member itself is
-    // defined only in the stalled OAS (`schemas/others/Options.yaml`:
+    // grounded only by the released OAS (`schemas/others/Options.yaml`:
     // `array of string`, no description, one example listing exactly the
-    // released groups), which is codegen input and not an oracle. Two reasons
+    // released groups) — a docs-text-silent ground that prescribes no
+    // particular content. Two reasons
     // for the omission: the operation's stated job is "exposing service
     // capabilities for a conformance manifest", so a non-openEHR path listed
     // there would sit inside a conformance claim; and the extension surface has

--- a/app/ehrbase-rest/tests/example_http.rs
+++ b/app/ehrbase-rest/tests/example_http.rs
@@ -5,8 +5,8 @@
     let_underscore_drop
 )] // test assertions/diagnostics/fixtures
 //! End-to-end HTTP tests for the template-example endpoint
-//! (`GET /definition/template/adl1.4/{template_id}/example`, a post-1.0.3
-//! dev-OAS operation).
+//! (`GET /definition/template/adl1.4/{template_id}/example`, a Release-1.1.0
+//! operation — ITS-REST overview `Amendment_record` §Release-1.1.0, SPECITS-58).
 //!
 //! The Demo Vitals OPT is uploaded through the real wire
 //! (`POST /definition/template/adl1.4`, `application/xml`); the real service

--- a/app/ehrbase-rest/tests/http.rs
+++ b/app/ehrbase-rest/tests/http.rs
@@ -710,7 +710,7 @@ async fn authenticated_write_attributes_the_default_committer() {
 }
 
 /// The group-9 POST-body disciplines (#481): a stored-query POST accepts `{}`
-/// (all three body members are OPTIONAL — the stalled OAS required-list loses
+/// (all three body members are OPTIONAL — the released OAS required-list loses
 /// to the docs text: offset defaults 0, fetch is implementation-default), the
 /// POSTs accept the URL parameter forms (the docs-text SHOULD-list draws no
 /// GET/POST distinction), and a body-vs-URL conflict is a 400 (the AMB-59

--- a/app/ehrbase-rest/tests/served_openapi.rs
+++ b/app/ehrbase-rest/tests/served_openapi.rs
@@ -261,7 +261,8 @@ async fn versioned_writes_document_if_match_and_412() {
 /// success response, the `Prefer`-conditional 201 body as a named example
 /// pair, and a UUID-only `ehr_id`.
 ///
-/// The branches are the released ITS-REST text, not the stalled OAS:
+/// The branches are the released ITS-REST docs text (which wins every
+/// conflict with the released OAS):
 /// `Requests_and_responses.md` §"HTTP status codes" assigns `400` to
 /// "malformed request syntax, syntactically invalid content", `409` to a
 /// request that "might generate a duplicate or a conflict" and `422` to a
@@ -438,7 +439,8 @@ async fn system_options_operation_is_documented() {
 /// every success response that emits headers, released-shaped examples, and no
 /// `Location` on a read or a delete.
 ///
-/// The branches are the RELEASED ITS-REST text, not the stalled OAS. The five
+/// The branches are the RELEASED ITS-REST docs text (the OAS is the
+/// subordinate source). The five
 /// party CRUD quintets are byte-identical on the wire
 /// (`specifications/operations/{person,agent,group,organisation,role}_*.yaml`
 /// and their `$ref`d responses), so the loop below asserts each kind
@@ -978,7 +980,8 @@ async fn demographic_item_tag_operations_are_fully_documented() {
 /// completeness: every branch this server actually emits, the `Allow` header on
 /// every config-gate `405`, worked examples, and NO `Location` anywhere.
 ///
-/// The branches are the RELEASED ITS-REST text, not the stalled OAS. The two
+/// The branches are the RELEASED ITS-REST docs text (the OAS is the
+/// subordinate source). The two
 /// released operations (`operations/admin_ehr_delete.yaml`,
 /// `operations/admin_ehr_delete_all.yaml`) `$ref` only description-carrying
 /// response files (`responses/{202,204_deleted_hard,404,404_unknown_ehr_id,405}.yaml`

--- a/app/ehrbase/src/service/demographic/tags.rs
+++ b/app/ehrbase/src/service/demographic/tags.rs
@@ -191,8 +191,8 @@ impl EhrbaseService {
 /// optional `value`/`target_path`, `target` as a bare `UID_BASED_ID` — a
 /// `HIER_OBJECT_ID` for a container target, an `OBJECT_VERSION_ID` for a
 /// VERSION target ("may be a `VERSIONED_OBJECT<T>` or a `VERSION<T>`") —
-/// exactly the EHR sibling's shape (the settled RM-target law; the stalled OAS
-/// `ItemTag` schema's `OBJECT_REF` wrapper loses to the released RM).
+/// exactly the EHR sibling's shape (the settled RM-target law; the released
+/// OAS `ItemTag` schema's `OBJECT_REF` wrapper loses the conflict to the RM).
 ///
 /// NOTE: `owner_id` follows the released examples' shape — an `OBJECT_REF`
 /// `{namespace: local, type: SYSTEM}` whose `id` carries the server's

--- a/app/ehrbase/src/service/ehr/service.rs
+++ b/app/ehrbase/src/service/ehr/service.rs
@@ -314,7 +314,7 @@ impl EhrbaseService {
             // uid is a HIER_OBJECT_ID), consistent with the `ehr_access` ref
             // below. NOTE (spec defect): the non-normative ITS-REST example
             // shows `type: EHR_STATUS` with an OBJECT_VERSION_ID id — the
-            // stalled OAS reading; the RM wins on both counts.
+            // released-OAS reading; the RM wins this real conflict on both counts.
             "ehr_status": {
                 "_type": "OBJECT_REF",
                 "namespace": "local",

--- a/app/ehrbase/src/service/ehr/tags.rs
+++ b/app/ehrbase/src/service/ehr/tags.rs
@@ -249,7 +249,7 @@ impl EhrbaseService {
     ///
     /// NOTE: `_type` is emitted on the tag itself for canonical-JSON
     /// consistency (ITS-REST `Resources.md` §JSON Format neither requires nor
-    /// forbids it on a concrete standalone type); the stalled OAS `ItemTag`
+    /// forbids it on a concrete standalone type); the released OAS `ItemTag`
     /// schema disagrees with the RM on `target`'s shape — the RM is the
     /// RELEASED component and wins (owner ruling 2026-07-24).
     fn tag_json(ehr_id: EhrId, row: &crate::storage::tag_repo::TagRow) -> Value {

--- a/app/ehrbase/tests/service_ehr.rs
+++ b/app/ehrbase/tests/service_ehr.rs
@@ -1317,8 +1317,8 @@ async fn item_tag_wire_shape_is_the_rm_item_tag() {
     assert_eq!(tag["target_path"], "/context");
     // target: the RM shape — a bare UID_BASED_ID (`item_tag.adoc`:
     // `target: UID_BASED_ID`, "may be a VERSIONED_OBJECT<T> or a VERSION<T>");
-    // a container target is its HIER_OBJECT_ID. The stalled OAS's OBJECT_REF
-    // wrapper lost to the RELEASED RM (owner ruling 2026-07-24).
+    // a container target is its HIER_OBJECT_ID. The released OAS's OBJECT_REF
+    // wrapper lost the real conflict to the RELEASED RM (owner ruling 2026-07-24).
     assert_eq!(tag["target"]["_type"], "HIER_OBJECT_ID");
     assert_eq!(tag["target"]["value"], vo_id);
     // owner_id: OBJECT_REF naming the owning EHR.

--- a/tools/openehr-codegen/src/plan/overrides.rs
+++ b/tools/openehr-codegen/src/plan/overrides.rs
@@ -341,8 +341,9 @@ pub(crate) fn class_binding(class: &str) -> BTreeMap<String, String> {
 
 /// One REST-contract required-list correction: `(dto, field)` is emitted as
 /// OPTIONAL although the vendored OAS schema lists it under `required`. Used
-/// only where the ITS-REST **docs text** (the wire oracle — owner ruling
-/// 2026-07-24) contradicts the stalled OAS shape.
+/// only where the ITS-REST **docs text** (which wins every conflict with the
+/// released OAS — owner rulings 2026-07-24 + 2026-07-28) contradicts the OAS
+/// shape.
 pub(crate) struct RestOptionalOverride {
     pub dto: &'static str,
     pub field: &'static str,

--- a/tools/openehr-codegen/src/render/emit_rest.rs
+++ b/tools/openehr-codegen/src/render/emit_rest.rs
@@ -239,8 +239,8 @@ fn emit_dto(b: &mut String, name: &str, schema: &Value, ctx: &Ctx) {
         let ty_name = dto_type(name);
         // The vendored OAS `required` list, minus the docs-text-wins
         // corrections (`plan::overrides::REST_OPTIONAL_OVERRIDES` — the
-        // ITS-REST docs text is the wire oracle; where it contradicts the
-        // stalled OAS shape, the field is emitted optional).
+        // ITS-REST docs text wins every conflict with the released OAS; where
+        // it contradicts the OAS shape, the field is emitted optional).
         let required: BTreeSet<&str> = schema
             .get("required")
             .and_then(Value::as_array)


### PR DESCRIPTION
Closes #615.

Every `stalled OAS`/`dev-OAS` comment re-read against the oracle order (docs text wins conflicts; the released OAS grounds docs-text silence) and rewritten — 24 sites across `ehrbase-rest`, `ehrbase`, the test batteries, and `openehr-codegen`. **No behavioural conclusion flipped**: the ItemTag/EHR_STATUS RM-wins adjudications and the stored-query required-list docs-text-wins adjudications are real conflicts that survive; the System `endpoints` member and the composition body-uid must-match rule move from 'defined only in a non-oracle' to 'grounded by the released OAS (docs text silent)' with their content/status choices unchanged (independently grounded). The AMB-146 register entry quotes the retired framing inside its own re-adjudication narrative and already states the current order — kept as the historical record.

Gates: clippy no new warnings, fmt clean, the touched test binaries 42/42.