### PR TITLE
chore(cnf): stored-query version-store semantics re-derived — catalogue correct, server conformant (#651)

### DIFF
--- a/app/ehrbase-rest/src/api/definition/openapi_routes.rs
+++ b/app/ehrbase-rest/src/api/definition/openapi_routes.rs
@@ -1909,13 +1909,20 @@ pub(crate) async fn definition_query_version_get(
                         pattern as partial prefix … the highest (latest) version \
                         matching the prefix will be considered\") is a \
                         READ-resolution semantic with nothing to resolve on a \
-                        store, and the released text assigns no meaning to a \
-                        prefix or malformed version here. Anything that is not \
+                        store — it would either name an already-stored pair, \
+                        which this operation answers `409`, or name nothing at \
+                        all — and the released text never completes a prefix \
+                        into a version to create. Anything that is not \
                         `major.minor.patch` — a prefix (`1`, `1.0`), a \
                         pre-release/build suffix (`1.0.0-rc.1`), a non-numeric \
-                        segment — is a \"syntactically invalid … parameter\" \
-                        `400` (`responses/400.yaml`). That reading of the \
-                        released silence is OURS, and it keeps the whole \
+                        segment — is therefore a `400`, the status the docs \
+                        text assigns to exactly this case \
+                        (`docs/overview/Requests_and_responses.md` §\"HTTP \
+                        status codes\": \"Status code `400` … a generic \
+                        client-side error, used when no other `4xx` error code \
+                        is appropriate. The client SHOULD NOT repeat the \
+                        request without modifications\"). Treating the released \
+                        silence this way is OURS, and it keeps the whole \
                         stored-query surface coherent: every list and get \
                         resolves versions numerically, so a non-numeric stored \
                         version would break reads of unrelated queries.",

--- a/app/ehrbase-rest/tests/stored_query_definition_http.rs
+++ b/app/ehrbase-rest/tests/stored_query_definition_http.rs
@@ -157,10 +157,15 @@ async fn versioned_store_accepts_exact_semver_and_conflicts_on_duplicate() {
 async fn versioned_store_rejects_non_exact_versions() {
     let (_pg, app) = app().await;
     // The prefix forms are read-side resolution patterns
-    // (parameters/path/version.yaml); on the write they are the released 400
-    // branch ("syntactically invalid … parameter", responses/400.yaml) —
-    // register-adjudicated. A pre-release tag would additionally poison the
-    // surface's SEMVER ordering.
+    // (parameters/path/version.yaml) that resolve to nothing writable on a
+    // store, and the released identifier format is three numeric parts
+    // ("SEMVER style (i.e. `major.minor.patch`)",
+    // docs/query/Qualified_query_name.md). Every other token is the 400 the
+    // docs text assigns to a client error no other 4xx fits
+    // (docs/overview/Requests_and_responses.md §"HTTP status codes": "a
+    // generic client-side error, used when no other `4xx` error code is
+    // appropriate. The client SHOULD NOT repeat the request without
+    // modifications") — register-adjudicated.
     for bad in ["1", "1.0", "1.0.0-rc.1", "latest", "1.0.x", "1..0"] {
         let (status, _h, body) = send(
             &app,

--- a/app/ehrbase/src/service/definition/query.rs
+++ b/app/ehrbase/src/service/definition/query.rs
@@ -24,10 +24,21 @@ use super::{compile_pattern, page_bounds, paginate};
 /// "stores a new query, or updates an existing query"
 /// (`definition_query_store.yaml`), so it upserts at this default version.
 ///
-/// NOTE (residue re-verified): a coherent auto-increment scheme for
-/// repeated no-version stores of *different* text (1.0.0 → 1.0.1 → …) is not
-/// attempted; the sanctioned "stores or updates" semantics is an upsert at this
-/// version, which is what a no-version store does.
+/// NOTE: **no openEHR spec governs the minted value — our own design.** No
+/// released ITS-REST sentence says which version a version-less store creates.
+/// The one candidate rule does not reach it: ITS-REST
+/// `specifications/docs/query/Qualified_query_name.md` says "when `version` is
+/// not supplied at all, the system must use the latest `version` with the
+/// supplied prefix", but reading that into the STORE would (a) overwrite the
+/// name's latest EXISTING version — silently replacing a version-addressed
+/// definition that the versioned sibling protects with a `409` — and (b)
+/// assign nothing on a first store, when no latest version exists. So it is a
+/// rule for USING a stored query, as its chapter states ("Stored queries are
+/// identified by their name … and an optional `version` number"), and the
+/// constant slot below is ours: it is the lowest SEMVER a first store can
+/// carry, it needs no minting rule, and it keeps the version-less form
+/// idempotent — a second no-version store updates the same slot rather than
+/// accumulating versions no client asked for and none can predict.
 const DEFAULT_QUERY_VERSION: &str = "1.0.0";
 
 // ── SM Definitions native API (I_DEFINITION_QUERY) — the catalog contract ────
@@ -456,17 +467,36 @@ impl EhrbaseService {
             return Ok(DEFAULT_QUERY_VERSION.to_owned());
         };
 
-        // The versioned store requires an EXACT numeric `major.minor.patch`.
-        // The prefix grammar of `parameters/path/version.yaml` is a READ-
-        // resolution semantic ("the highest (latest) version matching the
-        // prefix will be considered") and no released sentence assigns a
-        // status to a prefix or malformed version on the write, so the
-        // rejection is the released 400 branch (`responses/400.yaml`:
-        // "syntactically invalid … parameter") — register-adjudicated.
-        // Accepting the value verbatim is untenable: a non-numeric segment
-        // (`1.0.0-rc.1`) breaks the surface's SEMVER ordering
+        // The versioned store requires an EXACT numeric `major.minor.patch` —
+        // ITS-REST `specifications/docs/query/Qualified_query_name.md`: "The
+        // `version` identifier is in the format specified by SEMVER style
+        // (i.e. `major.minor.patch`)".
+        //
+        // The partial-prefix form is a READ-resolution semantic that cannot
+        // apply to a write. The same chapter states it over versions that
+        // ALREADY exist — "the system must use the latest `version` with the
+        // supplied prefix … then the latest query version matching supplied
+        // prefix will be used" — so on a store it either resolves to an
+        // existing `(name, version)` pair (which that operation assigns to
+        // `409`, making its declared `200` unreachable for every prefix) or
+        // resolves to nothing at all. No released sentence completes a prefix
+        // into a version to create, so the write outcome is a released
+        // silence, adjudicated in the conformance ambiguity register.
+        //
+        // The refusal STATUS is assigned by the docs text, not chosen:
+        // `specifications/docs/overview/Requests_and_responses.md` §"HTTP
+        // status codes", below the table — "Status code `400` indicates
+        // normally a bad request, as well as a generic client-side error,
+        // used when no other `4xx` error code is appropriate. The client
+        // SHOULD NOT repeat the request without modifications" (re-issuing
+        // with an exact version is exactly that modification). An outright
+        // malformed segment (`v1.x`) is the table's own `400` row.
+        //
+        // Accepting the value verbatim is untenable besides: a non-numeric
+        // segment (`1.0.0-rc.1`) breaks the surface's SEMVER ordering
         // (`string_to_array(semver, '.')::int[]`) and a stored prefix (`1`)
-        // collides with the read-side resolution algebra.
+        // collides with the read-side resolution algebra that must resolve
+        // `1` to a full version.
         if !is_exact_semver(v) {
             return Err(ServiceError::BadRequest(format!(
                 "`{v}` is not an exact SEMVER version: the versioned store requires \

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_QUERY.store_query-version.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_QUERY.store_query-version.yaml
@@ -30,12 +30,17 @@
 #   immutable, so re-storing an existing pair is exactly that duplicate
 #   (register AMB-117).
 # - `400` on a version segment that is not an exact `major.minor.patch` —
-#   §"HTTP status codes", row `400 Bad Request`: "The service cannot or will not
-#   process the request due to something that is perceived to be a client error
-#   (e.g., malformed request syntax, syntactically invalid content)". The
-#   `{version}` parameter's prefix semantics are RESOLUTION semantics over
-#   versions that already exist and cannot apply to a write; the write-side
-#   grammar is adjudicated in register AMB-122.
+#   §"HTTP status codes": an outright malformed segment is the row `400 Bad
+#   Request` ("The service cannot or will not process the request due to
+#   something that is perceived to be a client error (e.g., malformed request
+#   syntax, syntactically invalid content)"), and a segment that is WELL-FORMED
+#   but unwritable — a `{major}`/`{major}.{minor}` prefix, a pre-release form —
+#   is the sentence below that table: "Status code `400` indicates normally a
+#   bad request, as well as a generic client-side error, used when no other
+#   `4xx` error code is appropriate. The client SHOULD NOT repeat the request
+#   without modifications." The `{version}` parameter's prefix semantics are
+#   RESOLUTION semantics over versions that already exist and cannot apply to a
+#   write; the write-side grammar is adjudicated in register AMB-122.
 #
 # `query_type` — parameters/query/query_type.yaml, as on the variant-less
 # binding: optional, released default "AQL".
@@ -68,5 +73,5 @@ outcomes:
   # semantically invalid) and was only borrowed while the taxonomy had no
   # malformed-request kind. The wire status is unchanged (400 either way).
   bad_request:
-    status: 400                               # §HTTP status codes, row 400 (syntactically invalid content) — AMB-122
+    status: 400                               # §HTTP status codes — the row (malformed) + the generic-client-error sentence (well-formed but unwritable) — AMB-122
     body: error_loose

--- a/tools/cnf-runner/artifacts/registers/ambiguities.yaml
+++ b/tools/cnf-runner/artifacts/registers/ambiguities.yaml
@@ -3323,7 +3323,10 @@ AMB-117:
     which is a resolution rule over versions that already exist and says
     nothing about which one a write creates; the single illustration is the
     Location example's `…/org.openehr::compositions/1.0.1`, a minted version
-    shown without a rule for choosing it.
+    shown without a rule for choosing it. Re-adjudicated 2026-07-28 against
+    the one reading that would close the gap — taking that rule's "or when
+    `version` is not supplied at all" clause to govern the STORE — and it is
+    affirmatively wrong, not merely strained: see the handling.
   source: >-
     ITS-REST specifications/operations/definition_query_store.yaml
     (description "Stores a new query, or updates an existing query on the
@@ -3345,6 +3348,21 @@ AMB-117:
     VERSIONED store is the immutable form, where an existing
     `(name, version)` pair is refused 409 and never replaced. Immutability is
     therefore a property of a version-ADDRESSED definition, not of the name.
+    Reading `Qualified_query_name.md`'s "or when `version` is not supplied at
+    all … the system must use the latest `version`" into the STORE is the one
+    move that would make the minted version derivable, and it is refuted twice
+    over. First, it would have a version-less store target and OVERWRITE the
+    latest EXISTING version — silently replacing a version-ADDRESSED
+    definition that the sibling route protects as immutable with a 409, and
+    destroying a definition the client never named; a rule cannot both forbid
+    a write through one route and mandate it through another. Second, it
+    assigns nothing at all on a FIRST store, when no "latest query version"
+    exists — which is exactly the moment a creation rule would be needed. The
+    clause is therefore a rule for USING a stored query, as its chapter says
+    ("Stored queries are identified by their name … and an optional `version`
+    number"), and the minted version stays genuinely unassigned: the slot
+    below is OUR adjudication of a released silence, gated as such and
+    reported upstream, not a value the release states.
     The default slot is the constant `1.0.0`: it is the lowest SEMVER a first
     store can carry, it keeps the version-less form idempotent (a second
     store updates the same slot instead of accumulating versions no client
@@ -3575,39 +3593,74 @@ AMB-122:
     number. This can be an exact version (e.g. `1.7.1`), or a pattern as
     partial prefix, in a form of `{major}` or `{major}.{minor}` (e.g. `1` or
     `1.0`), in which case the highest (latest) version matching the prefix
-    will be considered." On the versioned STORE that sentence is incoherent —
-    a prefix selects among versions that already exist, and a store creates
-    one — and no released sentence assigns an outcome to a prefix, a SEMVER
-    pre-release/build form, or any other token on the write. The operation
-    declares 200/400/409, its 409 trigger is a duplicate
-    `(name, version)` pair, and its 400 is the general syntactic one.
+    will be considered." The DOCS TEXT states the same rule and no other:
+    "When only a partial `version` pattern is supplied, or when `version` is
+    not supplied at all, the system must use the latest `version` with the
+    supplied prefix - i.e. if only `major` or `major.minor` is used, then the
+    latest query version matching supplied prefix will be used." Applied to
+    the versioned STORE that rule is not merely odd but SELF-REFUTING, and
+    nothing released replaces it. The versions it resolves among are ones that
+    ALREADY EXIST ("the latest query version matching"), so on a name that has
+    them the target it yields is by construction an existing
+    `(name, version)` pair — exactly the trigger the same operation assigns to
+    409 — which would make the operation's own declared 200 unreachable for
+    every prefix; and on a name that has none it yields no version at all,
+    leaving the write with nothing to address. Nor does the release ever
+    COMPLETE a prefix into a version to create: this surface carries no
+    minting rule anywhere. The same silence covers a SEMVER
+    pre-release/build-metadata form and any other token — the operation
+    declares 200/400/409, its 409 trigger is a duplicate `(name, version)`
+    pair, and no released sentence names the branch these take.
   source: >-
-    ITS-REST specifications/parameters/path/version.yaml (the quoted
-    description, shared by definition_query_version_store.yaml,
+    ITS-REST docs/query/Qualified_query_name.md (the quoted partial/absent
+    version rule, and "The `version` identifier is in the format specified by
+    SEMVER style (i.e. `major.minor.patch`)") +
+    specifications/parameters/path/version.yaml (the quoted description,
+    shared by definition_query_version_store.yaml,
     definition_query_version_get.yaml and the query-execution routes) +
     operations/definition_query_version_store.yaml (responses 200/400/409) +
     responses/409_StoredQuery_version.yaml (the duplicate-pair trigger) +
     responses/400.yaml ("the request could not be parsed or is invalid (e.g.
     malformed request URL syntax, missing required header or parameter, or
-    syntactically invalid header, parameter or content)") + docs/query/
-    Qualified_query_name.md ("The `version` identifier is in the format
-    specified by SEMVER style (i.e. `major.minor.patch`)") — CONFIRMED
-    first-hand.
+    syntactically invalid header, parameter or content)") + docs/overview/
+    Requests_and_responses.md §"HTTP status codes" (the `400 Bad Request` row
+    and the generic-client-error sentence below the table) — CONFIRMED
+    first-hand; RE-ADJUDICATED 2026-07-28 (the earlier grounds are corrected
+    in the handling below).
   handling: >-
     Fixed handling: the versioned store requires an EXACT three-part numeric
-    `major.minor.patch`. A prefix (`1`, `1.0`), a pre-release or
-    build-metadata form (`1.0.0-rc.1`), and any other token are all
-    "syntactically invalid … parameter" and answer the operation's own
-    declared 400. Storing the segment verbatim is not a tenable alternative:
-    the whole surface ORDERS versions numerically — the read must resolve a
-    `{major}`/`{major}.{minor}` prefix to "the highest (latest) version
-    matching", and the list is SEMVER-ascending (AMB-124) — so a stored
-    non-numeric version has no place in that order, and a stored bare `1`
-    collides with the prefix algebra that must resolve `1` to a full version.
-    Coherent with AMB-102's read-side handling and deliberately distinct from
-    it: a READ addressing an unmatchable selector is 404 because it names no
-    existing resource, while a WRITE cannot address a non-existent resource
-    at all, so its unusable segment is a bad request and not a missing one.
+    `major.minor.patch`, and every other token — a prefix (`1`, `1.0`), a
+    pre-release or build-metadata form (`1.0.0-rc.1`), a non-numeric segment —
+    is refused with the operation's declared 400. The STATUS is ASSIGNED by
+    the docs text rather than chosen: docs/overview/Requests_and_responses.md
+    §"HTTP status codes", immediately below the table — "Status code `400`
+    indicates normally a bad request, as well as a generic client-side error,
+    used when no other `4xx` error code is appropriate. The client SHOULD NOT
+    repeat the request without modifications." A store the release gives no
+    version to write is precisely that generic client error, and re-issuing
+    with an exact version is precisely the modification the sentence demands.
+    No other 4xx fits: 409 needs a duplicate pair, which a fresh name does not
+    have, and 404 would claim the resource does not exist rather than that the
+    request may not create it (the read-side counterpart is AMB-102, kept
+    deliberately distinct — a READ addressing an unmatchable selector names no
+    existing resource, while a WRITE cannot address a non-existent resource at
+    all). "Syntactically invalid … parameter" is expressly NOT the ground and
+    the earlier entry was wrong to lean on it: the prefix form is a shape
+    `version.yaml` explicitly DECLARES legal, so the defect is that a legal
+    READ selector designates no version to WRITE, not that the token is
+    malformed. The three-part restriction is released text too, not a house
+    rule: the docs text glosses the identifier as "SEMVER style (i.e.
+    `major.minor.patch`)" and the parameter enumerates exactly three
+    admissible shapes — exact, `{major}`, `{major}.{minor}` — none of which
+    carries a suffix. (The earlier "an unorderable version" argument against a
+    pre-release form is WITHDRAWN: SEMVER 2.0.0 §11 does define pre-release
+    precedence, so orderability was never the problem; the released
+    three-part gloss is.) Storing the segment verbatim remains untenable on
+    its own terms: the read must resolve a `{major}`/`{major}.{minor}` prefix
+    to "the highest (latest) version matching", and the list is
+    SEMVER-ascending (AMB-124), so a stored bare `1` collides with the very
+    algebra that must resolve `1` to a full version and a stored non-numeric
+    version has no place in that order.
     Gated by I_DEFINITION_QUERY.store_query-version_prefix_rejected,
     -version_prerelease_rejected and -version_malformed_rejected. Reported
     upstream (UPR-86): state the write-side version grammar, since the

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-default_slot_with_higher_version.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-default_slot_with_higher_version.yaml
@@ -2,11 +2,18 @@
 # highest version of the name.
 #
 # The discriminating shape: a HIGHER version (2.0.0) is stored first, then a
-# version-less store writes the default slot. Under register AMB-117 the
-# version-less form writes `1.0.0` regardless of what else exists, so the
-# `Location` must end `/1.0.0` — a server that reports the name's latest
-# version instead answers `/2.0.0` and sends the client to a definition this
-# request did not store. The header's value is assigned by the released text:
+# version-less store writes the default slot. WHICH version a version-less
+# store mints is a released SILENCE — re-adjudicated 2026-07-28 and registered
+# in AMB-117, including the one reading that would close it: taking
+# docs/query/Qualified_query_name.md's "or when `version` is not supplied at
+# all … the system must use the latest `version`" to govern the STORE is
+# refuted twice, because it would have this request OVERWRITE the immutable,
+# version-ADDRESSED 2.0.0 that the sibling route protects with a 409, and
+# because it assigns nothing at all on a first store. So the constant `1.0.0`
+# slot is OUR adjudication of that silence, and the `Location` must end
+# `/1.0.0` — a server that reports the name's latest version instead answers
+# `/2.0.0` and sends the client to a definition this request did not store.
+# What IS assigned by the released text is the header itself:
 # ITS-REST docs/overview/Requests_and_responses.md §"Prefer minimal, identifier
 # or full representation response", `return=minimal` (the default per
 # §"Representation details negotiation", the store declaring no `Prefer`

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-default_version_slot.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-default_version_slot.yaml
@@ -3,7 +3,11 @@
 # Ground: the released store takes no `version`, and no released sentence says
 # which one it mints — `Qualified_query_name.md`'s absent/partial-version rule
 # is a rule for USING a stored query ("the system must use the latest `version`
-# with the supplied prefix"), not for creating one. Adjudicated in register
+# with the supplied prefix"), not for creating one. Re-adjudicated 2026-07-28:
+# reading it into the store is refuted twice, because it would overwrite the
+# name's latest EXISTING version — which the versioned sibling protects as
+# immutable with a 409 — and because it assigns nothing at all on a FIRST
+# store, exactly where a creation rule is needed. Adjudicated in register
 # AMB-117: the version-less form writes the constant `1.0.0` default slot.
 # What the released text DOES assign is the response header that names it —
 # ITS-REST docs/overview/Requests_and_responses.md §"Representation details

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-update_in_place.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-update_in_place.yaml
@@ -7,7 +7,11 @@
 # 400 only: no conflict branch exists for it to reach, in contrast with its
 # version-addressed sibling, which declares one. Register AMB-117 resolves the
 # apparent clash with the immutability prose BY FORM — the version-less store
-# is the overwriting form, writing the one default slot.
+# is the overwriting form, writing the one default slot; what it overwrites is
+# therefore its OWN slot, never a version the client addressed explicitly (the
+# reading that would have it overwrite the name's latest version is refuted in
+# AMB-117, because it would destroy the immutability the sibling's 409
+# declares).
 #
 # The observable consequences are both asserted: the second store succeeds
 # (no 409), and the listing afterwards holds exactly ONE row, at the same

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-version_malformed_rejected.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-version_malformed_rejected.yaml
@@ -4,14 +4,17 @@
 # docs/query/Qualified_query_name.md, "The `version` identifier is in the
 # format specified by SEMVER style (i.e. `major.minor.patch`)" — nor one of the
 # `{major}` / `{major}.{minor}` read prefixes the `{version}` parameter
-# defines. It is a syntactically invalid parameter, which
-# docs/overview/Requests_and_responses.md §"HTTP status codes", row `400 Bad
-# Request`, assigns directly: "The service cannot or will not process the
-# request due to something that is perceived to be a client error (e.g.,
-# malformed request syntax, syntactically invalid content)". Register AMB-122
-# carries the write-side grammar; the READ side of the same token family is
-# register AMB-102 (404, because a read addresses a resource that does not
-# exist, while a write cannot address one at all).
+# defines. Unlike the prefix and pre-release siblings it IS malformed outright,
+# so the `400 Bad Request` row of
+# docs/overview/Requests_and_responses.md §"HTTP status codes" assigns it
+# directly: "The service cannot or will not process the request due to
+# something that is perceived to be a client error (e.g., malformed request
+# syntax, syntactically invalid content)". Register AMB-122 carries the
+# write-side grammar for all three (and the generic-client-error sentence
+# below that same table, which assigns the two well-formed-but-unwritable
+# tokens); the READ side of the same token family is register AMB-102 (404,
+# because a read addresses a resource that does not exist, while a write
+# cannot address one at all).
 id: I_DEFINITION_QUERY.store_query-version_malformed_rejected
 kind: functional
 component: DEFINITION_QUERY

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-version_prefix_rejected.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-version_prefix_rejected.yaml
@@ -1,17 +1,30 @@
 # A PARTIAL version prefix is not a version a store can write.
 #
 # The `{version}` path parameter is described once, for the reads and the write
-# alike, and only in resolution terms — "a pattern as partial prefix, in a form
-# of `{major}` or `{major}.{minor}` …, in which case the highest (latest)
-# version matching the prefix will be considered". A prefix selects among
-# versions that already exist, so on a STORE it names nothing: the released
-# text assigns the write no outcome for it, and register AMB-122 adjudicates
-# the write-side grammar as an exact `major.minor.patch`, everything else
-# refused on the operation's own declared 400 —
-# docs/overview/Requests_and_responses.md §"HTTP status codes", row `400 Bad
-# Request`: "The service cannot or will not process the request due to
-# something that is perceived to be a client error (e.g., malformed request
-# syntax, syntactically invalid content)".
+# alike, and the DOCS TEXT states the same rule and no other — ITS-REST
+# docs/query/Qualified_query_name.md: "When only a partial `version` pattern is
+# supplied, or when `version` is not supplied at all, the system must use the
+# latest `version` with the supplied prefix - i.e. if only `major` or
+# `major.minor` is used, then the latest query version matching supplied prefix
+# will be used." That rule resolves among versions that ALREADY EXIST, so on a
+# STORE it is self-refuting rather than merely odd: on a name that has 1.x
+# versions the target it yields is by construction an existing
+# `(name, version)` pair — the operation's own 409 trigger — which would make
+# its declared 200 unreachable for every prefix; and on the FRESH name this
+# case uses it yields no version at all, leaving the write nothing to address.
+# The release completes a prefix into no version either — this surface carries
+# no minting rule — so the write outcome is a released silence, adjudicated in
+# register AMB-122 as an exact `major.minor.patch` write grammar.
+#
+# The refusal STATUS is assigned, not chosen —
+# docs/overview/Requests_and_responses.md §"HTTP status codes", the sentence
+# below the table: "Status code `400` indicates normally a bad request, as well
+# as a generic client-side error, used when no other `4xx` error code is
+# appropriate. The client SHOULD NOT repeat the request without
+# modifications." Re-issuing with an exact version is exactly that
+# modification. (NOT the "syntactically invalid … parameter" reading: the
+# prefix is a shape `parameters/path/version.yaml` explicitly declares legal —
+# the defect is that a legal READ selector designates no version to WRITE.)
 #
 # Step 2 discriminates a refusal from a silent store under the literal prefix:
 # nothing may be registered at `1` (which would also poison the read-side

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-version_prerelease_rejected.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-version_prerelease_rejected.yaml
@@ -2,16 +2,22 @@
 #
 # The released version grammar for a stored query is three numeric parts —
 # ITS-REST docs/query/Qualified_query_name.md: "The `version` identifier is in
-# the format specified by SEMVER style (i.e. `major.minor.patch`)" — and the
-# `{version}` parameter admits only that exact form plus the `{major}` /
-# `{major}.{minor}` READ prefixes. Nothing in the release admits a pre-release
-# suffix on this surface (the sibling question for the ADL2 read is register
-# AMB-113), and nothing assigns the write an outcome for one, so register
-# AMB-122 refuses it on the operation's own declared 400 —
-# docs/overview/Requests_and_responses.md §"HTTP status codes", row `400 Bad
-# Request`: "…(e.g., malformed request syntax, syntactically invalid content)".
-# Accepting it would also place an unorderable version inside a surface whose
-# reads must rank versions numerically.
+# the format specified by SEMVER style (i.e. `major.minor.patch`)". The
+# parenthetical gloss IS the released statement of the format, and the
+# `{version}` parameter enumerates exactly three admissible shapes to match it:
+# an exact version, `{major}`, and `{major}.{minor}` — none carrying a suffix.
+# Nothing in the release admits a pre-release form on this surface (the sibling
+# question for the ADL2 read is register AMB-113), and nothing assigns the
+# write an outcome for one, so register AMB-122 refuses it on the status the
+# docs text ASSIGNS to exactly this situation —
+# docs/overview/Requests_and_responses.md §"HTTP status codes", the sentence
+# below the table: "Status code `400` indicates normally a bad request, as well
+# as a generic client-side error, used when no other `4xx` error code is
+# appropriate. The client SHOULD NOT repeat the request without modifications."
+#
+# The ground is the three-part gloss, NOT orderability: SEMVER 2.0.0 §11 does
+# define pre-release precedence, so the earlier "unorderable version" argument
+# is withdrawn (register AMB-122 records the correction).
 id: I_DEFINITION_QUERY.store_query-version_prerelease_rejected
 kind: functional
 component: DEFINITION_QUERY

--- a/website/book/src/admin-ui/queries.md
+++ b/website/book/src/admin-ui/queries.md
@@ -167,7 +167,7 @@ which of the two openEHR store operations a click will perform:
 
 | Version field | What a save does |
 | --- | --- |
-| empty | `PUT /definition/query/{name}` — the server assigns the version and **replaces** the query stored at it |
+| empty | `PUT /definition/query/{name}` — the CDR files it at the default slot `1.0.0` and **replaces** whatever was stored there |
 | `1.2.0` | `PUT /definition/query/{name}/{version}` — stores a **new, immutable** version; if that exact `(name, version)` pair already exists the CDR refuses it (`409`) and the console says so |
 
 Because an explicit version is immutable, **Open in editor** and **Open in
@@ -181,7 +181,14 @@ A shorter pattern like `1` or `1.0` is a **read** form, not a store form: when
 the latest one matching that prefix, and omitting the version entirely means
 the latest of all. The console therefore refuses a partial version in the save
 field (with an explanation) rather than filing a definition under a string that
-later lookups would treat as a pattern.
+later lookups would treat as a pattern. The CDR refuses one too, with a `400`:
+a prefix names no version a store could create, and openEHR assigns the write
+no other outcome.
+
+The default slot `1.0.0` is the CDR's own choice — openEHR does not say which
+version a version-less store mints, so the version-less form always writes and
+reports that one slot, even when higher versions of the same name already
+exist. If you need a specific version, type it.
 
 ### Deleting a stored query
 


### PR DESCRIPTION
Closes #651.

The derivation (docs text → OAS → register), per question:

- **Partial-version store** (`PUT …/{name}/1`): `Qualified_query_name.md`'s prefix rule resolves among versions that already EXIST — self-refuting on a write (on a populated name it designates exactly the pair the operation's own `409_StoredQuery_version.yaml` refuses; on a fresh name it designates nothing; no released rule ever completes a prefix into a version to create). The 400 is ASSIGNED, not chosen: the overview's generic-client-error sentence ("used when no other 4xx error code is appropriate; the client SHOULD NOT repeat the request without modifications"). The old "syntactically invalid parameter" ground is withdrawn as wrong — the prefix is a shape `version.yaml` explicitly declares legal; the defect is that a legal READ selector designates no version to WRITE. **Java's 200 + minted 1.0.0 was an invention, evidence never reference.**
- **Version-less store landing version**: the candidate "use the latest with the prefix" reading is refuted twice (it would silently overwrite the immutable latest version the sibling route 409-protects, and assigns nothing on a first store) — genuine released silence, AMB-117 (`fixed_handling`, UPR-81) stands; the `1.0.0` slot is now explicitly labelled our house adjudication, incl. on the book page.
- **Pre-release rejection**: re-grounded on the docs-text SEMVER gloss (`major.minor.patch`) + the three admissible parameter shapes; the old "unorderable" argument withdrawn (SEMVER §11 defines pre-release precedence).

Every change is grounds/citations only — statuses, headers, and outcomes are byte-identical, no app behaviour change (hence `no-changelog`). AMB-122 + AMB-117 rewritten with the reductio arguments; six case headers + the store binding's split `bad_request` ground; citation-only comment updates in the service, the served-OpenAPI param description, and the book page.

**Flagged for the record:** AMB-117 is the one place the catalogue gates on a house position over released silence (java mints differently and reds those rows) — reported upstream as UPR-81; noted on #652 for the comparison narrative.

Gates: fmt clean, clippy zero warnings in touched files, nextest **1466/1466** (ehrbase + ehrbase-rest + cnf-runner), validate **768 cases / 0 findings**, coverage report no diff.