### PR TITLE
fix(changelog): resolve committed merge-conflict markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
-<<<<<<< HEAD
 - **The measured hospital-simulation workload now exercises every claimed
   capability** (#625). The performance run used to touch about a third of the
   capabilities the conformance statement claims, and the rest were listed as
@@ -41,7 +40,6 @@ workflow refuses a tag that has no matching section here.
   measurable at all. Boundary probes address the read-only and
   unauthenticated principals a deployment declares; a deployment that
   declares none simply runs the workload without those journeys.
-=======
 - **Conformance: the last two untested capabilities now carry real executed
   batteries** (#624). "Demographic archetype validation" and "Bulk EHR load"
   were the two capabilities the conformance report listed with *no cases* —
@@ -62,7 +60,6 @@ workflow refuses a tag that has no matching section here.
   returning exactly the loaded set). Both capabilities are now claimed in the
   published conformance statement, and their case-count floors are recorded so
   the coverage can only grow.
->>>>>>> develop
 
 - **Conformance: the PARTY_RELATIONSHIP capability is now tested rather than
   excused** (#623). openEHR's released REST API defines no PARTY_RELATIONSHIP


### PR DESCRIPTION
The #625 convergence merge (455a4e147) committed `CHANGELOG.md` with unresolved conflict markers — `git add -A && git commit --no-edit` took the marked file blind. Both sides were legitimate `[Unreleased]` entries (#625's workload coverage, #624's batteries): kept both, markers dropped. Found by the #637 worker.