### PR TITLE
fix(cnf-runner): perf ixit path rebase; admin batteries ride the ADMIN principal

### DIFF
--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_ARCHIVE.archive_ehrs-archive_selected.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_ARCHIVE.archive_ehrs-archive_selected.yaml
@@ -27,6 +27,7 @@ requires: { ehr: { commits: any } }        # mints ${ehr_id}
 flow:
   - step: 1
     call: archive_ehrs
+    on: admin                              # ADMIN-role principal (ixit) — the route is admin-gated
     with: { ehr_ids: ["${ehr_id}"] }
     expect: ok
 ambiguities: [AMB-33]

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_ARCHIVE.archive_ehrs-archive_unknown.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_ARCHIVE.archive_ehrs-archive_unknown.yaml
@@ -27,6 +27,7 @@ requires: { server: empty }
 flow:
   - step: 1
     call: archive_ehrs
+    on: admin                              # ADMIN-role principal (ixit) — the route is admin-gated
     with: { ehr_ids: ["00000000-0000-0000-0000-000000000000"] }
     expect: not_found
 ambiguities: [AMB-33]

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_ARCHIVE.archive_parties-archive_selected.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_ARCHIVE.archive_parties-archive_selected.yaml
@@ -37,6 +37,7 @@ data_sets: [cnf.demographic.person.v1]
 flow:
   - step: 1
     call: archive_parties
+    on: admin                              # ADMIN-role principal (ixit) — the route is admin-gated
     with: { party_ids: ["${party_id}"] }
     expect: ok
 ambiguities: [AMB-33]

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_ARCHIVE.archive_parties-archive_unknown.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_ARCHIVE.archive_parties-archive_unknown.yaml
@@ -27,6 +27,7 @@ requires: { server: empty }
 flow:
   - step: 1
     call: archive_parties
+    on: admin                              # ADMIN-role principal (ixit) — the route is admin-gated
     with: { party_ids: ["00000000-0000-0000-0000-000000000000"] }
     expect: not_found
 ambiguities: [AMB-33]

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.composition_version_count-all.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.composition_version_count-all.yaml
@@ -27,6 +27,7 @@ requires: { ehr: { commits: any } }
 flow:
   - step: 1
     call: composition_version_count
+    on: admin                              # ADMIN-role principal (ixit) — the route is admin-gated
     with: { a_service: "ehr" }
     expect: ok
 ambiguities: [AMB-33]

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.composition_version_count-time_range.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.composition_version_count-time_range.yaml
@@ -27,6 +27,7 @@ requires: { ehr: { commits: any } }
 flow:
   - step: 1
     call: composition_version_count
+    on: admin                              # ADMIN-role principal (ixit) — the route is admin-gated
     with: { a_service: "ehr", time_interval: "2020-01-01T00:00:00Z/2026-12-31T00:00:00Z" }
     expect: ok
 ambiguities: [AMB-33]

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.contribution_count-all.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.contribution_count-all.yaml
@@ -27,6 +27,7 @@ requires: { ehr: { commits: any } }
 flow:
   - step: 1
     call: contribution_count
+    on: admin                              # ADMIN-role principal (ixit) — the route is admin-gated
     with: { a_service: "ehr" }
     expect: ok
 ambiguities: [AMB-33]

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.contribution_count-time_range.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.contribution_count-time_range.yaml
@@ -27,6 +27,7 @@ requires: { ehr: { commits: any } }
 flow:
   - step: 1
     call: contribution_count
+    on: admin                              # ADMIN-role principal (ixit) — the route is admin-gated
     with: { a_service: "ehr", time_interval: "2020-01-01T00:00:00Z/2026-12-31T00:00:00Z" }
     expect: ok
 ambiguities: [AMB-33]

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.list_contributions-all.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.list_contributions-all.yaml
@@ -29,6 +29,7 @@ requires: { ehr: { commits: any } }        # commits exist so there is something
 flow:
   - step: 1
     call: list_contributions
+    on: admin                              # ADMIN-role principal (ixit) — the route is admin-gated
     with: { a_service: "ehr" }
     expect: ok
 ambiguities: [AMB-33]

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.list_contributions-time_range.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.list_contributions-time_range.yaml
@@ -29,6 +29,7 @@ requires: { ehr: { commits: any } }
 flow:
   - step: 1
     call: list_contributions
+    on: admin                              # ADMIN-role principal (ixit) — the route is admin-gated
     with: { a_service: "ehr", time_interval: "2020-01-01T00:00:00Z/2026-12-31T00:00:00Z" }
     expect: ok
 ambiguities: [AMB-33]

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.versioned_composition_count-all.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.versioned_composition_count-all.yaml
@@ -27,6 +27,7 @@ requires: { ehr: { commits: any } }
 flow:
   - step: 1
     call: versioned_composition_count
+    on: admin                              # ADMIN-role principal (ixit) — the route is admin-gated
     with: { a_service: "ehr" }
     expect: ok
 ambiguities: [AMB-33]

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.versioned_composition_count-time_range.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.versioned_composition_count-time_range.yaml
@@ -27,6 +27,7 @@ requires: { ehr: { commits: any } }
 flow:
   - step: 1
     call: versioned_composition_count
+    on: admin                              # ADMIN-role principal (ixit) — the route is admin-gated
     with: { a_service: "ehr", time_interval: "2020-01-01T00:00:00Z/2026-12-31T00:00:00Z" }
     expect: ok
 ambiguities: [AMB-33]

--- a/tools/cnf-runner/src/bin/cnf-runner.rs
+++ b/tools/cnf-runner/src/bin/cnf-runner.rs
@@ -927,7 +927,7 @@ fn stress_command(
         }
         return ExitCode::from(2);
     }
-    let ixit: cnf_runner::ixit::Ixit = match std::fs::read_to_string(ixit_path)
+    let mut ixit: cnf_runner::ixit::Ixit = match std::fs::read_to_string(ixit_path)
         .map_err(|e| format!("cannot read {}: {e}", ixit_path.display()))
         .and_then(|text| serde_json::from_str(&text).map_err(|e| format!("ixit: {e}")))
     {
@@ -937,6 +937,11 @@ fn stress_command(
             return ExitCode::from(2);
         }
     };
+    // File references in the ixit (the SMART lane's signing key) are relative
+    // to the ixit document, not to the runner's working directory — the same
+    // rebase the `run` command applies (the measured client minted against an
+    // unresolved relative path and died at seeding, 2026-07-29 POC run).
+    ixit.rebase_paths(ixit_path.parent().unwrap_or(std::path::Path::new(".")));
     let (principals, environment) = match perf_run::window::measured_run_context(&ixit) {
         Ok(context) => context,
         Err(e) => {
@@ -1127,7 +1132,7 @@ fn probe_command(
         }
         return ExitCode::from(2);
     }
-    let ixit: cnf_runner::ixit::Ixit = match std::fs::read_to_string(ixit_path)
+    let mut ixit: cnf_runner::ixit::Ixit = match std::fs::read_to_string(ixit_path)
         .map_err(|e| format!("cannot read {}: {e}", ixit_path.display()))
         .and_then(|text| serde_json::from_str(&text).map_err(|e| format!("ixit: {e}")))
     {
@@ -1137,6 +1142,11 @@ fn probe_command(
             return ExitCode::from(2);
         }
     };
+    // File references in the ixit (the SMART lane's signing key) are relative
+    // to the ixit document, not to the runner's working directory — the same
+    // rebase the `run` command applies (the measured client minted against an
+    // unresolved relative path and died at seeding, 2026-07-29 POC run).
+    ixit.rebase_paths(ixit_path.parent().unwrap_or(std::path::Path::new(".")));
     let (principals, environment) = match perf_run::window::measured_run_context(&ixit) {
         Ok(context) => context,
         Err(e) => {
@@ -1264,7 +1274,7 @@ fn perf_command(
         }
         return ExitCode::from(2);
     }
-    let ixit: cnf_runner::ixit::Ixit = match std::fs::read_to_string(ixit_path)
+    let mut ixit: cnf_runner::ixit::Ixit = match std::fs::read_to_string(ixit_path)
         .map_err(|e| format!("cannot read {}: {e}", ixit_path.display()))
         .and_then(|text| serde_json::from_str(&text).map_err(|e| format!("ixit: {e}")))
     {
@@ -1274,6 +1284,11 @@ fn perf_command(
             return ExitCode::from(2);
         }
     };
+    // File references in the ixit (the SMART lane's signing key) are relative
+    // to the ixit document, not to the runner's working directory — the same
+    // rebase the `run` command applies (the measured client minted against an
+    // unresolved relative path and died at seeding, 2026-07-29 POC run).
+    ixit.rebase_paths(ixit_path.parent().unwrap_or(std::path::Path::new(".")));
     let (principals, environment) = match perf_run::window::measured_run_context(&ixit) {
         Ok(context) => context,
         Err(e) => {


### PR DESCRIPTION
Two defects from the first convergence+POC run over the #658/#660 batch, attributed per the triage law before fixing:

1. **Runner (the POC stage died at seeding):** only the `run` command called `Ixit::rebase_paths`, so the measured client resolved the SMART issuer's relative `key_file` against the CWD (`smart mint: cannot read ../smart/cnf-smart-test.key.pem`). `perf`/`stress`/`aql-probe` now apply the same rebase at load.
2. **Catalogue (all 12 functional reds):** the #658 admin-extension batteries drove with the standard principal against routes correctly gated on the `ADMIN` role — `expected ok, observed forbidden` across the board. The SUT behaved exactly as designed (the gating IS the extension's design); the cases now carry `on: admin` per driven step, matching every existing admin case. (The worker's real-router HTTP tests authenticated directly, which is why this only showed on the composed stack.)

Gates: validate 769 cases / 0 findings, nextest 247/247, fmt clean. The proof is the re-run pipeline+POC, launching after this merges.