### PR TITLE
ci: ui-e2e stops compiling inside Docker — host-built binary + runtime-prebuilt packaging (#335, part 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           # Dockerfile change, or a change to the job's own build recipe each
           # alter what is under test, and without them a build/caching-only PR
           # could not even run the job it changes.
-          if echo "$changed" | grep -qE '^(app/ehrbase-admin-ui/|scripts/ui-e2e\.sh$|docker-compose\.yml$|docker/Dockerfile$|docker/admin-ui/|docker/keycloak/|Cargo\.lock$|\.github/workflows/ci\.yml$)' ; then
+          if echo "$changed" | grep -qE '^(app/ehrbase-admin-ui/|scripts/ui-e2e\.sh$|docker-compose\.yml$|docker/Dockerfile$|docker/admin-ui/|docker/keycloak/|docker/postgres/|Cargo\.lock$|\.github/workflows/ci\.yml$)' ; then
             echo "admin_ui=true" >> "$GITHUB_OUTPUT"
           else
             echo "admin_ui=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
       admin_ui: ${{ steps.filter.outputs.admin_ui }}
+      server_dockerfile: ${{ steps.filter.outputs.server_dockerfile }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -74,12 +75,26 @@ jobs:
             echo "No build-relevant paths touched — cargo jobs will be skipped."
             echo "code=false" >> "$GITHUB_OUTPUT"
           fi
-          # Admin-console E2E trigger: the console crate, its harness, or the
-          # composed stack it drives.
-          if echo "$changed" | grep -qE '^(app/ehrbase-admin-ui/|scripts/ui-e2e\.sh$|docker-compose\.yml$|docker/admin-ui/|docker/keycloak/)' ; then
+          # Admin-console E2E trigger: the console crate, its harness, the
+          # composed stack it drives — AND the inputs to the CDR artifact the
+          # battery runs against. `Cargo.lock`, `docker/Dockerfile` and this
+          # workflow itself were missing (issue #335): a dependency bump, a
+          # Dockerfile change, or a change to the job's own build recipe each
+          # alter what is under test, and without them a build/caching-only PR
+          # could not even run the job it changes.
+          if echo "$changed" | grep -qE '^(app/ehrbase-admin-ui/|scripts/ui-e2e\.sh$|docker-compose\.yml$|docker/Dockerfile$|docker/admin-ui/|docker/keycloak/|Cargo\.lock$|\.github/workflows/ci\.yml$)' ; then
             echo "admin_ui=true" >> "$GITHUB_OUTPUT"
           else
             echo "admin_ui=false" >> "$GITHUB_OUTPUT"
+          fi
+          # The compose/local image target (docker/Dockerfile
+          # `runtime-from-source`) is no longer built by ui-e2e, which packages
+          # the shipped `runtime-prebuilt` target instead — so that target gets
+          # its own job, gated on the one file whose change can break it.
+          if echo "$changed" | grep -qE '^docker/Dockerfile$' ; then
+            echo "server_dockerfile=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "server_dockerfile=false" >> "$GITHUB_OUTPUT"
           fi
 
   # ── Required for code changes: formatting ───────────────────────────────────
@@ -300,6 +315,128 @@ jobs:
           tool: cargo-machete
       - run: cargo machete
 
+  # ── The CDR binary the ui-e2e battery runs against (issue #335) ─────────────
+  # It used to be compiled INSIDE the image: `docker/Dockerfile --target
+  # runtime-from-source` runs `cargo build --release` in the layer after
+  # `COPY . .`. No layer cache can serve that layer — every ui-e2e trigger path
+  # lives in the build context, so the COPY is invalidated by construction, and
+  # `cargo chef cook` caches THIRD-PARTY dependencies only. The ~190 kLoC
+  # first-party release build therefore ran cold on EVERY run (measured locally
+  # on an isolated buildx builder: 714 s cold; 6 s with nothing changed; 407 s
+  # after touching ONE admin-console source file, with the cook layer reported
+  # CACHED and the whole first-party graph recompiling behind it).
+  #
+  # So the binary is compiled here the way containers.yml compiles the
+  # PUBLISHED one — natively, in the pinned rust:*-slim-trixie image, never
+  # inside a Dockerfile — and ui-e2e then PACKAGES it with `runtime-prebuilt`,
+  # the very final target containers.yml ships. Both final targets inherit ONE
+  # shared runtime-base stage, so the battery drives the same distroless base,
+  # the same non-root user, EXPOSE, HEALTHCHECK and ENTRYPOINT as before.
+  #
+  # Two caches, strongest first:
+  #   1. the finished binary, keyed on the exact content of every input the
+  #      server build reads. An admin-console-only PR touches none of them, so
+  #      the key hits and no compile runs at all.
+  #   2. sccache (per compilation unit) for the miss case — a lockfile bump or
+  #      a server-side change then recompiles only what actually changed
+  #      instead of collapsing back to a cold build.
+  #
+  # SOURCE_DATE_EPOCH is pinned and REVISION is deliberately NOT passed in this
+  # lane: app/ehrbase/build.rs bakes both into the `ehrbase` crate through
+  # `cargo:rustc-env`, and sccache tracks `env!` values in its cache key
+  # ("Values from `env!` require Rust >= 1.46 to be tracked in caching" —
+  # github.com/mozilla/sccache docs/Rust.md), so a per-run value makes the three
+  # largest first-party crates uncacheable by construction. Without REVISION,
+  # build.rs degrades to SHA=unknown BY DESIGN, and the battery asserts
+  # behaviour, never provenance. The PUBLISHED images are untouched:
+  # containers.yml still stamps github.sha into them.
+  ui-e2e-binary:
+    name: ui-e2e server binary
+    needs: changes
+    if: needs.changes.outputs.admin_ui == 'true'
+    runs-on: ubuntu-latest
+    # Debian 13 (trixie) container so the binary targets glibc 2.41, matching
+    # gcr.io/distroless/cc-debian13 exactly — the same pin and the same reason
+    # as containers.yml's `binary` job. It must NOT be compiled on the bare
+    # runner: glibc compatibility runs forward only, so a runner image with a
+    # newer glibc than the runtime image ships yields a binary that image
+    # cannot load.
+    container: rust:1.96.1-slim-trixie
+    env:
+      # Fixed build timestamp — reproducible, and the precondition for the
+      # compile to be cacheable at all (see the block above; build.rs honours
+      # SOURCE_DATE_EPOCH per reproducible-builds.org/docs/source-date-epoch).
+      SOURCE_DATE_EPOCH: "1700000000"
+    steps:
+      - uses: actions/checkout@v7
+      - name: Verify toolchain pins (container == rust-toolchain.toml == Dockerfile)
+        shell: bash
+        run: |
+          set -euo pipefail
+          channel=$(grep -E '^channel' rust-toolchain.toml | sed -E 's/.*"(.*)".*/\1/')
+          have=$(rustc --version | awk '{print $2}')
+          arg=$(grep -E '^ARG RUST_VERSION=' docker/Dockerfile | head -1 | cut -d= -f2)
+          echo "rust-toolchain=$channel  container-rustc=$have  Dockerfile ARG=$arg"
+          if [ "$channel" != "$have" ]; then
+            echo "::error::Job container rustc ($have) != rust-toolchain.toml ($channel). Bump the container: tag."
+            exit 1
+          fi
+          if [ "$channel" != "$arg" ]; then
+            echo "::error::docker/Dockerfile RUST_VERSION ($arg) != rust-toolchain.toml ($channel)."
+            exit 1
+          fi
+      # Cache 1 — the binary itself. The key covers every path the server build
+      # reads and nothing else; app/ehrbase-admin-ui/ is deliberately absent
+      # because the console is not in ehrbase-server's dependency graph (that is
+      # ehrbase + ehrbase-rest), which is exactly why an admin-console PR can
+      # reuse the binary. Exact key, NO restore-keys: a near-match would package
+      # a binary that does not correspond to this tree
+      # (docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching).
+      - id: binary-cache
+        uses: actions/cache@v6
+        with:
+          path: bin/amd64/ehrbase
+          key: ui-e2e-server-bin-1.96.1-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', '.cargo/**', 'crates/**', 'app/ehrbase/**', 'app/ehrbase-rest/**', 'app/ehrbase-server/**', 'tools/**') }}
+      # Registry cache only, for the reason the ui-e2e job spells out below:
+      # rust-cache's key hashes every manifest, so a lockfile bump rotates a
+      # whole target archive and pays a cold build, while sccache degrades to
+      # partial hits (github.com/Swatinem/rust-cache — with `cache-targets:
+      # false`, "only the cargo registry will be cached").
+      - uses: Swatinem/rust-cache@v2
+        if: steps.binary-cache.outputs.cache-hit != 'true'
+        with:
+          shared-key: ui-e2e-server-binary
+          cache-targets: false
+      - uses: mozilla-actions/sccache-action@v0.0.10
+        if: steps.binary-cache.outputs.cache-hit != 'true'
+      - name: Build the server binary (release, native)
+        if: steps.binary-cache.outputs.cache-hit != 'true'
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+          RUSTC_WRAPPER: sccache
+          # "Incrementally compiled crates cannot be cached"
+          # (github.com/mozilla/sccache#known-caveats).
+          CARGO_INCREMENTAL: "0"
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build --release --locked -p ehrbase-server
+          strip target/release/ehrbase
+          mkdir -p bin/amd64
+          install -m0755 target/release/ehrbase bin/amd64/ehrbase
+      # Cache-hit visibility in the job log, the same as the battery job below.
+      - name: sccache statistics
+        if: always() && steps.binary-cache.outputs.cache-hit != 'true'
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+        run: ${SCCACHE_PATH} --show-stats
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ui-e2e-server-binary
+          path: bin/amd64/ehrbase
+          if-no-files-found: error
+          retention-days: 1
+
   # ── Admin-console E2E (merge gate for console-touching changes) ─────────────
   # Runs the full composed journey battery (scripts/ui-e2e.sh): postgres +
   # ehrbase + Keycloak via compose, the console built by cargo-leptos on the
@@ -307,22 +444,18 @@ jobs:
   # upload on success AND failure (human review — no pixel-diff assertions).
   ui-e2e:
     name: ui-e2e
-    needs: changes
+    needs: [changes, ui-e2e-binary]
     if: needs.changes.outputs.admin_ui == 'true'
     runs-on: ubuntu-latest
     # Least privilege, scoped to THIS job: the workflow declares no top-level
     # `permissions`, so every other job keeps the repository default and only
-    # ui-e2e gains the write scope it needs (job-level settings override
-    # workflow-level ones —
+    # ui-e2e states its own (job-level settings override workflow-level ones —
     # docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions).
-    # `contents: read` for the checkout, `packages: write` to export the buildx
-    # layer cache to GHCR below
-    # (docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions).
-    # A pull_request from a FORK is downgraded to a read-only token regardless
-    # of what is declared here — hence the cache-to guard further down.
+    # `contents: read` for the checkout is all it needs: nothing here writes to
+    # a registry any more (the GHCR buildx layer cache was removed, and the
+    # image is now packaged locally from a job artifact).
     permissions:
       contents: read
-      packages: write
     steps:
       - uses: actions/checkout@v7
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -362,36 +495,32 @@ jobs:
             https://github.com/tailwindlabs/tailwindcss/releases/download/v4.3.3/tailwindcss-linux-x64
           chmod +x /usr/local/bin/tailwindcss
           tailwindcss --help | head -1
-      # The compose stack's app image is the expensive (cargo-chef) build;
+      # The CDR image is PACKAGED here, never compiled here (issue #335 — the
+      # rationale is on the ui-e2e-binary job above). `runtime-prebuilt` is
+      # COPY-only, so this is a seconds-long step with no layer-cache backend
+      # involved at all — which is why GHCR stays product-images-only
+      # (ehrbase-rs, ehrbase-rs-postgres, ehrbase-rs-admin-ui) and no
+      # `build-cache` package is published beside them (owner call 2026-07-26).
       # `load: true` puts the result in the docker store so the compose
       # `--no-build` below finds it.
       #
-      # NO layer-cache backend, deliberately (owner call 2026-07-26): the
-      # registry exporter published a non-product `build-cache` package into
-      # GHCR beside the three product images, and its measured value was ~32 s
-      # per run (issue #335: the cacheable `cargo chef cook` layer is not the
-      # bottleneck — the first-party release build after `COPY . .` is, and
-      # every ui-e2e trigger invalidates that layer by construction, so no
-      # layer cache can serve it). GHCR stays product-images-only
-      # (ehrbase-rs, ehrbase-rs-postgres, ehrbase-rs-admin-ui); the real
-      # ui-e2e speed-up is #335's app-layer work.
-      #
-      # The in-image build (docker/Dockerfile `builder` stage) is deliberately
-      # NOT sccache-wrapped: sccache's Actions-cache backend "will need tokens
-      # like `ACTIONS_RESULTS_URL` and `ACTIONS_RUNTIME_TOKEN` to work"
-      # (github.com/mozilla/sccache docs/GHA.md), which exist only in the runner
-      # process and would have to be secret-mounted into every RUN.
+      # The artifact download loses the executable bit (GitHub artifacts do not
+      # preserve file permissions), which is exactly why the Dockerfile COPYs
+      # the binary with `--chmod=0755`
+      # (docs.docker.com/reference/dockerfile — COPY --chmod).
+      - uses: actions/download-artifact@v8
+        with:
+          name: ui-e2e-server-binary
+          path: bin/amd64
       - uses: docker/setup-buildx-action@v4
-      - name: Build the app image (from-source)
+      - name: Package the app image (COPY-only, seconds)
         uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile
-          target: runtime-from-source
+          target: runtime-prebuilt
           load: true
           tags: ehrbase-rs:ui-e2e
-          build-args: |
-            REVISION=${{ github.sha }}
       - name: Build the postgres image (COPY-only, seconds)
         run: docker buildx build --load -t ehrbase-rs-postgres:ui-e2e docker/postgres
       - name: Run the E2E journey battery
@@ -430,6 +559,30 @@ jobs:
           name: ui-e2e-screenshots
           path: target/ui-e2e/screenshots/
           if-no-files-found: ignore
+
+  # ── The compose/local image target (docker/Dockerfile runtime-from-source) ──
+  # ui-e2e packages the shipped `runtime-prebuilt` target now (issue #335), so
+  # the in-image cargo-chef build that `docker compose up --build` and
+  # scripts/conformance.sh rely on would otherwise have no CI exercise at all.
+  # It is built here instead — but ONLY when its own recipe changes, which is
+  # the one moment the full cold compile buys something. Nothing is exported:
+  # the build succeeding IS the assertion.
+  server-image-from-source:
+    name: server image (from source)
+    needs: changes
+    if: needs.changes.outputs.server_dockerfile == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/Dockerfile
+          target: runtime-from-source
+          push: false
 
   # Screenshot-freshness guard (the changelog-guard pattern): a PR that
   # changes the console UI must re-capture the published book screenshots in


### PR DESCRIPTION
Part 1 of #335 (the issue stays open for the battery-step pass — the ≤8 min criterion is not reachable by app-layer work alone).

**The mechanism, proven locally on an isolated buildx builder:** the in-Docker first-party release build was the binding constraint (cold 714 s; a one-file admin-console touch invalidated `COPY . .` and repaid 407 s — reproduced verbatim with `cargo chef cook … CACHED` followed by a 6m16s first-party rebuild). CI now compiles `ehrbase-server` in a `rust:1.96.1-slim-trixie` container job (glibc-safe against the distroless runtime) and ui-e2e packages the shipped **`runtime-prebuilt`** target — the same COPY-only packaging rule `containers.yml` already states for the published images. Packaging: **9 s cold / 3 s warm** vs 714/407. `docker inspect` proves the packaged image byte-equivalent in contract (same user/entrypoint/ports/healthcheck) — nothing about what the battery tests changes; `docker/Dockerfile` itself is untouched.

**The cache-key finding that unblocks everything:** `app/ehrbase/build.rs` emits `REVISION` + a `SystemTime::now()` build epoch via `cargo:rustc-env`, which sccache tracks in its keys — the three largest first-party crates were uncacheable BY CONSTRUCTION on every CI run. The new job pins `SOURCE_DATE_EPOCH` and omits `REVISION` (build.rs degrades to `SHA=unknown`; no journey asserts provenance; published images keep their stamp via `containers.yml`).

Two caches: the finished binary under an exact-key `actions/cache` (no `restore-keys`, so a near-match can never package a wrong binary; `app/ehrbase-admin-ui/**` deliberately outside the key — the console is not in the server's graph) + sccache for the miss case. The `runtime-from-source` target keeps coverage via a new job gated on `docker/Dockerfile` changes only. Path filters gain `docker/Dockerfile`, `Cargo.lock`, `ci.yml` itself, and `docker/postgres/` — the measurement gap that hid all of this.

**Expected steady state** (measure on the second admin-console PR after merge): binary job ~1–2 min on a hit + ui-e2e ~10 min ≈ **11–12 min** vs the 20m32s baseline. The remaining floor is the battery step itself (8m32s) — the follow-up scope recorded on #335.

Gates: actionlint exit 0, every `run:` block `bash -n` clean, path-filter regexes exercised against 11 change sets, local buildx timing table in the #335 thread.