### PR TITLE
chore(cnf): the residual java-triage adjudications — offsets, malformed ids, directory uid, 412 precedence (#652)

### DIFF
--- a/docs/conformance/upstream-reports.md
+++ b/docs/conformance/upstream-reports.md
@@ -741,15 +741,30 @@ CNF↔SM divergences, and benign released-documented behaviours carry no
 
 - **Components:** ITS-REST (overview + parameter files), BASE (base_types)
 - **Register:** AMB-76 (fixed_handling)
-- **Facts:** `ehr_id` / `versioned_object_uid` are HIER_OBJECT_IDs per the
-  glossary; BASE's UID subtypes have "mutually exclusive string patterns"
-  but no class-level lexical invariant beyond non-empty; the per-operation
-  response maps declare no 400 for a malformed segment, while the overview
-  400 row covers "syntactically invalid … parameter".
-- **Problem:** 400-vs-404 for a garbage identifier token is unassigned and
-  implementations diverge (the stalled Robot suite itself answers both
-  ways across sibling cases).
-- **Ask:** assign the malformed-identifier branch explicitly.
+- **Facts:** the release DOES fix the lexical form of every affected segment
+  — the docs text for `version_uid` (`Resources.md` §Identifier types: "in
+  the lexical form of `object_id :: creating_system_id ::
+  version_tree_id`"), the released OAS for the rest
+  (`parameters/path/ehr_id.yaml`, `path/versioned_object_uid_COMPOSITION.yaml`
+  and `path/contribution_uid.yaml` each declare `schema: {type: string,
+  format: uuid}`). What it does NOT do is declare the response to a
+  violation: `operations/ehr_get_by_id.yaml`,
+  `operations/versioned_composition_get.yaml` and
+  `operations/contribution_get.yaml` declare `{200, 404}` and no 400, while
+  each 404 file scopes its own trigger to an id that "does not exist"
+  (`404_unknown_ehr_id.yaml`: "`404 Not Found` is returned when an EHR with
+  `ehr_id` does not exist"), i.e. to a well-formed id. The only text left is
+  the overview's generic 400 row, "malformed request syntax".
+- **Problem:** the branch is derivable from two places at once but declared
+  in neither operation, and implementations diverge accordingly — upstream
+  EHRbase answers `404` with the body "EHR not found, in fact, only
+  UUID-type IDs are supported", i.e. it detects the type violation and
+  still reports a miss.
+- **Ask:** declare the 400 in the per-operation response maps of every
+  operation whose path parameters carry a `format`/lexical form, or state in
+  the overview that a path segment violating its declared parameter schema
+  is answered 404 as an ordinary miss. Either way, say it once and
+  per-operation rather than leaving it to the generic row.
 
 ### UPR-39 — editorial defects in SM I_EHR_COMPOSITION + three ITS-REST doc typos
 
@@ -2408,3 +2423,42 @@ CNF↔SM divergences, and benign released-documented behaviours carry no
   per-resource classification and the two-armed both-conformant handling are
   register AMB-167; our suite gates each undefined family's XML rows on a
   statement-declared option instead of asserting either branch.)
+
+### UPR-128 — BASE describes the ISO 8601 offset form two ways, so a mixed extended/basic date/time has no verdict
+
+- **Components:** BASE (`foundation_types` `time_definitions`,
+  `iso8601_date_time`, `iso8601_timezone`), RM (`data_types` `DV_DATE_TIME`)
+- **Register:** AMB-171 (editorial)
+- **Facts:** `DV_DATE_TIME`'s only lexical invariant is
+  `Value_valid: valid_iso8601_date_time (value)`. That function lists exactly
+  two complete forms and pairs each base with its own offset spelling —
+  `YYYY-MM-DDThh:mm:ss[(,|.)s+][Z|±hh[:mm]]` (extended) and
+  `YYYYMMDDThhmmss[(,|.)s+][Z|±hh[mm]]` (compact) — under which an extended
+  date/time carrying a basic `+0000` offset matches neither alternative. But
+  the sibling `valid_iso8601_time` states the offset as a SEPARATE trailing
+  clause ("with an additional optional timezone indicator of: `Z` or
+  `±hh[:mm]` (extended) `±hh[mm]` (compact)"), and `Iso8601_timezone` — the
+  type `Iso8601_date_time.timezone()` returns — gives its own format as
+  `Z | ±hh[mm]` while declaring `is_extended()`, "True if this time-zone uses
+  ':' separators", i.e. the offset's extendedness is a property of the offset
+  alone. Real openEHR data carries the mixed form: the vendored CNF Robot
+  corpus commits `2019-04-16T21:08:11,380+0000` as a `DV_DATE_TIME` value.
+  Nothing else disambiguates — the ITS-JSON schema types the member as a bare
+  string with no pattern, and ITS-REST `Resources.md` §Datetime format scopes
+  its extended-format MUST to "HTTP query parameters and path segments" while
+  passing a body value "as is".
+- **Problem:** implementations cannot agree on whether a mixed
+  extended-base/basic-offset `DV_DATE_TIME` satisfies `Value_valid`, and the
+  invariant's own cited function and the timezone class say different things.
+- **Ask:** give the offset form one voice — either state in
+  `valid_iso8601_date_time`/`valid_iso8601_time` that the timezone
+  designator's form is independent of the base representation, or drop
+  `Iso8601_timezone.is_extended()`'s implication that it is, and say
+  explicitly which side a mixed string falls on.
+- **Not part of this report — settled by the same text:** the COMMA decimal
+  sign is unambiguously legal (`Iso8601_date_time` states the value form as
+  `YYYY-MM-DDThh:mm:ss[(,|.)sss][Z | ±hh[:mm]]` and declares
+  `is_decimal_sign_comma()`; `valid_iso8601_time` spells the fraction as "an
+  optional string consisting of a comma or decimal point followed by numeric
+  string of 1 or more digits"). A server refusing a body `DV_DATE_TIME` for
+  its comma alone is non-conformant, not exercising a latitude.

--- a/tools/cnf-runner/CLAUDE.md
+++ b/tools/cnf-runner/CLAUDE.md
@@ -74,7 +74,11 @@ the dev-compose defaults are exported by `scripts/conformance.sh`.
 - **Every closed vocabulary is a Rust enum/newtype** (outcome kinds,
   selectors, header matchers, capture sources, the `${…}` reference grammar,
   dispositions, sentinels): illegal states unrepresentable. New vocabulary
-  values enter only by schedule release, never ad hoc.
+  values enter only by schedule release, never ad hoc. The one OPEN grammar
+  beside them is an `ignoring:`/`server_assigned` PATH, and it carries a
+  `**` segment matching zero or more attribute steps (`**/uid`): recursive
+  containment is an RM shape (`FOLDER.folders: List<FOLDER>`), so a
+  depth-anchored ignore path would silently under-cover a deeper tree.
 - **A deployment fact no released operation discloses is an IXIT
   declaration, never a runner guess**: the party's `ixit.json` declares it
   (e.g. `system_id`) and a case reads it as `${ixit:<field>}` — the field set

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_DIRECTORY.create_directory.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_DIRECTORY.create_directory.yaml
@@ -77,4 +77,11 @@ captures:
   versioned_object_uid:
     from: capture version_uid             # the VERSIONED_FOLDER container id — ITS-REST overview Resources.md §Identifier types: a version_uid's "`object_id` matches the VERSIONED_OBJECT identifier"
     transform: root-uid
-server_assigned: [uid]
+# The server-assigned uid, at EVERY FOLDER node: RM common locatable.adoc types
+# `uid` `0..1` ("Optional globally unique object identifier for root points of
+# archetyped structures") and RM common folder.adoc's NOTE recommends populating
+# it only "in _top-level_ (i.e. tree-root) `FOLDER` objects" — a uid at a nested
+# archetype-root FOLDER is permitted and unrequired, so it is a server
+# assignment, never a content difference. `**` matches every depth of the
+# recursive `folders: List<FOLDER>` shape.
+server_assigned: ["**/uid"]

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_DIRECTORY.delete_directory.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_DIRECTORY.delete_directory.yaml
@@ -47,7 +47,7 @@ outcomes:
     status: 412                           # 412_directory.yaml (stale If-Match)
     headers: { ETag: latest-version-uid }
   precondition_missing: { status: 400 }   # If-Match absent when required -> 400.yaml
-  not_found: { status: 404 }              # unknown ehr_id, or an EHR with no directory to delete (RM ehr §EHR.directory 0..1) — ITS-REST overview §HTTP status codes: 404 = target resource not found; If-Match precedence per RFC 9110 §13.2.2
+  not_found: { status: 404 }              # unknown ehr_id, or an EHR with no directory to delete (RM ehr §EHR.directory 0..1) — ITS-REST overview §HTTP status codes: 404 = target resource not found; If-Match precedence per RFC 9110 §13.2.1 ("A server MUST ignore all received preconditions if its response to the same request without those conditions … would have been a status code other than a 2xx … or 412")
 captures:
   version_uid:
     from: header ETag                     # the NEW 523|deleted| VERSION uid (register AMB-75)

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_DIRECTORY.get_directory-path.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_DIRECTORY.get_directory-path.yaml
@@ -43,4 +43,11 @@ outcomes:
       Content-Type: negotiated
       Location: { match: absent, applies: { its_rest: ">=1.1.0" } }  # read — overview §Location / §Deprecated headers
   not_found: { status: 404 }              # "when `path` does not exist within the directory"
-server_assigned: [uid]                    # the retrieved resource carries the server-assigned version uid the committed payload lacks
+# The server-assigned uid, at EVERY FOLDER node: RM common locatable.adoc types
+# `uid` `0..1` ("Optional globally unique object identifier for root points of
+# archetyped structures") and RM common folder.adoc's NOTE recommends populating
+# it only "in _top-level_ (i.e. tree-root) `FOLDER` objects" — a uid at a nested
+# archetype-root FOLDER is permitted and unrequired, so it is a server
+# assignment, never a content difference. `**` matches every depth of the
+# recursive `folders: List<FOLDER>` shape.
+server_assigned: ["**/uid"]

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_DIRECTORY.get_directory.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_DIRECTORY.get_directory.yaml
@@ -30,4 +30,15 @@ outcomes:
   ok_empty: { status: 204 }               # logically deleted directory (204_deleted_at_time.yaml)
   not_found: { status: 404 }
   not_acceptable: { status: 406 }         # unfulfillable Accept (overview Requests_and_responses negotiation rules; no simplified mapping exists for this resource)              # unknown ehr_id or no directory (404_directory_unknown_ehr_id_or_no_version_at_time_or_no_path.yaml)
-server_assigned: [uid]                    # the retrieved resource carries the server-assigned version uid the committed payload lacks
+# The retrieved resource carries the server-assigned version uid the committed
+# payload lacks — at EVERY FOLDER node, not only the tree root. RM common
+# locatable.adoc types `uid` `0..1`, "Optional globally unique object identifier
+# for root points of archetyped structures", and RM common folder.adoc's NOTE
+# scopes its population recommendation to the root alone ("It is strongly
+# recommended that the inherited attribute `uid` be populated in _top-level_
+# (i.e. tree-root) `FOLDER` objects"). A uid a server assigns at a nested
+# archetype-root FOLDER is therefore permitted and unrequired, and no released
+# text makes a directory read attribute-identical to the committed payload — so
+# its presence is a server assignment, never a content difference. `**` matches
+# at every depth of the recursive `folders: List<FOLDER>` shape.
+server_assigned: ["**/uid"]

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_DIRECTORY.get_directory_at_time.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_DIRECTORY.get_directory_at_time.yaml
@@ -32,4 +32,11 @@ outcomes:
       Location: { match: absent, applies: { its_rest: ">=1.1.0" } }  # read — overview §Location / §Deprecated headers
   ok_empty: { status: 204 }               # 204_deleted_at_time.yaml
   not_found: { status: 404 }              # unknown ehr_id or no version at the requested time
-server_assigned: [uid]                    # the retrieved resource carries the server-assigned version uid the committed payload lacks
+# The server-assigned uid, at EVERY FOLDER node: RM common locatable.adoc types
+# `uid` `0..1` ("Optional globally unique object identifier for root points of
+# archetyped structures") and RM common folder.adoc's NOTE recommends populating
+# it only "in _top-level_ (i.e. tree-root) `FOLDER` objects" — a uid at a nested
+# archetype-root FOLDER is permitted and unrequired, so it is a server
+# assignment, never a content difference. `**` matches every depth of the
+# recursive `folders: List<FOLDER>` shape.
+server_assigned: ["**/uid"]

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_DIRECTORY.get_directory_at_version-path.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_DIRECTORY.get_directory_at_version-path.yaml
@@ -41,4 +41,11 @@ outcomes:
       Content-Type: negotiated
       Location: { match: absent, applies: { its_rest: ">=1.1.0" } }  # read — overview §Location / §Deprecated headers
   not_found: { status: 404 }              # "when `path` does not exist within the directory"
-server_assigned: [uid]                    # the retrieved resource carries the server-assigned version uid the committed payload lacks
+# The server-assigned uid, at EVERY FOLDER node: RM common locatable.adoc types
+# `uid` `0..1` ("Optional globally unique object identifier for root points of
+# archetyped structures") and RM common folder.adoc's NOTE recommends populating
+# it only "in _top-level_ (i.e. tree-root) `FOLDER` objects" — a uid at a nested
+# archetype-root FOLDER is permitted and unrequired, so it is a server
+# assignment, never a content difference. `**` matches every depth of the
+# recursive `folders: List<FOLDER>` shape.
+server_assigned: ["**/uid"]

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_DIRECTORY.get_directory_at_version.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_DIRECTORY.get_directory_at_version.yaml
@@ -54,4 +54,11 @@ outcomes:
     # invalid branch"). One law, one kind: this is AMB-76's law.
     status: 400
     body: error_loose
-server_assigned: [uid]                    # the retrieved resource carries the server-assigned version uid the committed payload lacks
+# The server-assigned uid, at EVERY FOLDER node: RM common locatable.adoc types
+# `uid` `0..1` ("Optional globally unique object identifier for root points of
+# archetyped structures") and RM common folder.adoc's NOTE recommends populating
+# it only "in _top-level_ (i.e. tree-root) `FOLDER` objects" — a uid at a nested
+# archetype-root FOLDER is permitted and unrequired, so it is a server
+# assignment, never a content difference. `**` matches every depth of the
+# recursive `folders: List<FOLDER>` shape.
+server_assigned: ["**/uid"]

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_DIRECTORY.update_directory.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_DIRECTORY.update_directory.yaml
@@ -64,9 +64,16 @@ outcomes:
     status: 412                           # 412_directory.yaml (stale If-Match)
     headers: { ETag: latest-version-uid }
   precondition_missing: { status: 400 }   # If-Match absent when required -> 400.yaml (overview Requests_and_responses)
-  not_found: { status: 404 }              # unknown ehr_id, or an EHR with no directory to update (RM ehr §EHR.directory 0..1) — ITS-REST overview §HTTP status codes: 404 = target resource not found; If-Match precedence per RFC 9110 §13.2.2
+  not_found: { status: 404 }              # unknown ehr_id, or an EHR with no directory to update (RM ehr §EHR.directory 0..1) — ITS-REST overview §HTTP status codes: 404 = target resource not found; If-Match precedence per RFC 9110 §13.2.1 ("A server MUST ignore all received preconditions if its response to the same request without those conditions … would have been a status code other than a 2xx … or 412")
 captures:
   version_uid:
     from: header ETag
     strip: weak-quotes
-server_assigned: [uid]
+# The server-assigned uid, at EVERY FOLDER node: RM common locatable.adoc types
+# `uid` `0..1` ("Optional globally unique object identifier for root points of
+# archetyped structures") and RM common folder.adoc's NOTE recommends populating
+# it only "in _top-level_ (i.e. tree-root) `FOLDER` objects" — a uid at a nested
+# archetype-root FOLDER is permitted and unrequired, so it is a server
+# assignment, never a content difference. `**` matches every depth of the
+# recursive `folders: List<FOLDER>` shape.
+server_assigned: ["**/uid"]

--- a/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
+++ b/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
@@ -425,14 +425,14 @@ cnf.composition.minimal_persistent.v1:
   rm_versions: [">=1.0.2"]
   validity: { verdict: valid }
   template_id: "persistent_minimal.en.v1"
-  provenance: "openEHR CNF Robot corpus (vendored docs/specs/openehr/CNF/tests/platform/robot @ the CNF pin); re-adjudicated 2026-07-22; normalized to the literal RM ENTRY Is_archetype_root invariant (archetype_details added at archetype-id nodes; the upstream instance predates that strictness)"
+  provenance: "openEHR CNF Robot corpus (vendored docs/specs/openehr/CNF/tests/platform/robot @ the CNF pin); re-adjudicated 2026-07-22; normalized to the literal RM ENTRY Is_archetype_root invariant (archetype_details added at archetype-id nodes; the upstream instance predates that strictness); DV_DATE_TIME offsets normalized 2026-07-29 from the basic-format `+0000` to the extended `+00:00`: RM data_types dv_date_time.adoc's invariant `Value_valid: valid_iso8601_date_time (value)` admits only `YYYY-MM-DDThh:mm:ss[(,|.)s+][Z|±hh[:mm]]` (extended) or `YYYYMMDDThhmmss[(,|.)s+][Z|±hh[mm]]` (compact) (BASE foundation_types time_definitions.adoc §valid_iso8601_date_time), so an extended date/time carrying the compact offset matches neither alternative. The COMMA decimal sign is UNTOUCHED — BASE iso8601_date_time.adoc states the value form as `…ss[(,|.)sss]…` and declares `is_decimal_sign_comma()`, so a comma fraction is explicitly legal. Register AMB-171 carries the residual offset-form reading (upstream UPR-128)"
 cnf.composition.minimal_persistent.v2:
   source: fixtures/composition/minimal_persistent.v2.json
   format: canonical-json
   rm_versions: [">=1.0.2"]
   validity: { verdict: valid }
   template_id: "persistent_minimal.en.v1"
-  provenance: "openEHR CNF Robot corpus (vendored docs/specs/openehr/CNF/tests/platform/robot @ the CNF pin); re-adjudicated 2026-07-22; leaf value updated for the v2 content state; normalized to the literal RM ENTRY Is_archetype_root invariant (archetype_details added at archetype-id nodes; the upstream instance predates that strictness)"
+  provenance: "openEHR CNF Robot corpus (vendored docs/specs/openehr/CNF/tests/platform/robot @ the CNF pin); re-adjudicated 2026-07-22; leaf value updated for the v2 content state; normalized to the literal RM ENTRY Is_archetype_root invariant (archetype_details added at archetype-id nodes; the upstream instance predates that strictness); DV_DATE_TIME offsets normalized 2026-07-29 from the basic-format `+0000` to the extended `+00:00`: RM data_types dv_date_time.adoc's invariant `Value_valid: valid_iso8601_date_time (value)` admits only `YYYY-MM-DDThh:mm:ss[(,|.)s+][Z|±hh[:mm]]` (extended) or `YYYYMMDDThhmmss[(,|.)s+][Z|±hh[mm]]` (compact) (BASE foundation_types time_definitions.adoc §valid_iso8601_date_time), so an extended date/time carrying the compact offset matches neither alternative. The COMMA decimal sign is UNTOUCHED — BASE iso8601_date_time.adoc states the value form as `…ss[(,|.)sss]…` and declares `is_decimal_sign_comma()`, so a comma fraction is explicitly legal. Register AMB-171 carries the residual offset-form reading (upstream UPR-128)"
 cnf.composition.minimal_persistent.invalid_structure:
   source: fixtures/composition/minimal_persistent.invalid_structure.json
   format: canonical-json
@@ -467,14 +467,14 @@ cnf.composition.persistent.v1:
   rm_versions: [">=1.0.2"]
   validity: { verdict: valid }
   template_id: "persistent_minimal.en.v1"
-  provenance: "openEHR CNF Robot corpus (vendored docs/specs/openehr/CNF/tests/platform/robot @ the CNF pin); re-adjudicated 2026-07-22; normalized to the literal RM ENTRY Is_archetype_root invariant (archetype_details added at archetype-id nodes; the upstream instance predates that strictness)"
+  provenance: "openEHR CNF Robot corpus (vendored docs/specs/openehr/CNF/tests/platform/robot @ the CNF pin); re-adjudicated 2026-07-22; normalized to the literal RM ENTRY Is_archetype_root invariant (archetype_details added at archetype-id nodes; the upstream instance predates that strictness); DV_DATE_TIME offsets normalized 2026-07-29 from the basic-format `+0000` to the extended `+00:00`: RM data_types dv_date_time.adoc's invariant `Value_valid: valid_iso8601_date_time (value)` admits only `YYYY-MM-DDThh:mm:ss[(,|.)s+][Z|±hh[:mm]]` (extended) or `YYYYMMDDThhmmss[(,|.)s+][Z|±hh[mm]]` (compact) (BASE foundation_types time_definitions.adoc §valid_iso8601_date_time), so an extended date/time carrying the compact offset matches neither alternative. The COMMA decimal sign is UNTOUCHED — BASE iso8601_date_time.adoc states the value form as `…ss[(,|.)sss]…` and declares `is_decimal_sign_comma()`, so a comma fraction is explicitly legal. Register AMB-171 carries the residual offset-form reading (upstream UPR-128)"
 cnf.composition.persistent.v2:
   source: fixtures/contribution/composition.persistent.v2.json
   format: canonical-json
   rm_versions: [">=1.0.2"]
   validity: { verdict: valid }
   template_id: "persistent_minimal.en.v1"
-  provenance: "openEHR CNF Robot corpus (vendored docs/specs/openehr/CNF/tests/platform/robot @ the CNF pin); re-adjudicated 2026-07-22; leaf value updated for the v2 content state; normalized to the literal RM ENTRY Is_archetype_root invariant (archetype_details added at archetype-id nodes; the upstream instance predates that strictness)"
+  provenance: "openEHR CNF Robot corpus (vendored docs/specs/openehr/CNF/tests/platform/robot @ the CNF pin); re-adjudicated 2026-07-22; leaf value updated for the v2 content state; normalized to the literal RM ENTRY Is_archetype_root invariant (archetype_details added at archetype-id nodes; the upstream instance predates that strictness); DV_DATE_TIME offsets normalized 2026-07-29 from the basic-format `+0000` to the extended `+00:00`: RM data_types dv_date_time.adoc's invariant `Value_valid: valid_iso8601_date_time (value)` admits only `YYYY-MM-DDThh:mm:ss[(,|.)s+][Z|±hh[:mm]]` (extended) or `YYYYMMDDThhmmss[(,|.)s+][Z|±hh[mm]]` (compact) (BASE foundation_types time_definitions.adoc §valid_iso8601_date_time), so an extended date/time carrying the compact offset matches neither alternative. The COMMA decimal sign is UNTOUCHED — BASE iso8601_date_time.adoc states the value form as `…ss[(,|.)sss]…` and declares `is_decimal_sign_comma()`, so a comma fraction is explicitly legal. Register AMB-171 carries the residual offset-form reading (upstream UPR-128)"
 cnf.ehr_status.minimal:
   source: fixtures/contribution/ehr_status.minimal.json
   format: canonical-json
@@ -541,21 +541,21 @@ cnf.composition.coded_text_on_text:
   rm_versions: [">=1.0.2"]
   validity: { verdict: valid }
   template_id: "obs_admin.en.v2"
-  provenance: "openEHR CNF Robot corpus (vendored docs/specs/openehr/CNF/tests/platform/robot @ the CNF pin); extracted 2026-07-24 from the official obs_admin.contribution.altdvcodedtext.json (versions[0].data — a DV_CODED_TEXT instance on the OPT's DV_TEXT node at0004, the master08 B.2.f row) and normalized to the literal RM ENTRY Is_archetype_root invariant"
+  provenance: "openEHR CNF Robot corpus (vendored docs/specs/openehr/CNF/tests/platform/robot @ the CNF pin); extracted 2026-07-24 from the official obs_admin.contribution.altdvcodedtext.json (versions[0].data — a DV_CODED_TEXT instance on the OPT's DV_TEXT node at0004, the master08 B.2.f row) and normalized to the literal RM ENTRY Is_archetype_root invariant; DV_DATE_TIME offsets normalized 2026-07-29 from the basic-format `+0000` to the extended `+00:00`: RM data_types dv_date_time.adoc's invariant `Value_valid: valid_iso8601_date_time (value)` admits only `YYYY-MM-DDThh:mm:ss[(,|.)s+][Z|±hh[:mm]]` (extended) or `YYYYMMDDThhmmss[(,|.)s+][Z|±hh[mm]]` (compact) (BASE foundation_types time_definitions.adoc §valid_iso8601_date_time), so an extended date/time carrying the compact offset matches neither alternative. The COMMA decimal sign is UNTOUCHED — BASE iso8601_date_time.adoc states the value form as `…ss[(,|.)sss]…` and declares `is_decimal_sign_comma()`, so a comma fraction is explicitly legal. Register AMB-171 carries the residual offset-form reading (upstream UPR-128)"
 cnf.composition.null_flavour:
   source: fixtures/contribution/composition.obs_admin.null_flavour.json
   format: canonical-json
   rm_versions: [">=1.0.2"]
   validity: { verdict: valid }
   template_id: "obs_admin.en.v2"
-  provenance: "openEHR CNF Robot corpus (vendored docs/specs/openehr/CNF/tests/platform/robot @ the CNF pin); extracted 2026-07-24 from the official obs_admin.contribution.null_flavour.json (versions[0].data — empty ELEMENT.value with null_flavour |no information|, the master08 B.2.g row; RM data_structures ELEMENT Inv_null_flavour_indicated holds) and normalized to the literal RM ENTRY Is_archetype_root invariant"
+  provenance: "openEHR CNF Robot corpus (vendored docs/specs/openehr/CNF/tests/platform/robot @ the CNF pin); extracted 2026-07-24 from the official obs_admin.contribution.null_flavour.json (versions[0].data — empty ELEMENT.value with null_flavour |no information|, the master08 B.2.g row; RM data_structures ELEMENT Inv_null_flavour_indicated holds) and normalized to the literal RM ENTRY Is_archetype_root invariant; DV_DATE_TIME offsets normalized 2026-07-29 from the basic-format `+0000` to the extended `+00:00`: RM data_types dv_date_time.adoc's invariant `Value_valid: valid_iso8601_date_time (value)` admits only `YYYY-MM-DDThh:mm:ss[(,|.)s+][Z|±hh[:mm]]` (extended) or `YYYYMMDDThhmmss[(,|.)s+][Z|±hh[mm]]` (compact) (BASE foundation_types time_definitions.adoc §valid_iso8601_date_time), so an extended date/time carrying the compact offset matches neither alternative. The COMMA decimal sign is UNTOUCHED — BASE iso8601_date_time.adoc states the value form as `…ss[(,|.)sss]…` and declares `is_decimal_sign_comma()`, so a comma fraction is explicitly legal. Register AMB-171 carries the residual offset-form reading (upstream UPR-128)"
 cnf.composition.persistent_2.v1:
   source: fixtures/contribution/composition.persistent_2.v1.json
   format: canonical-json
   rm_versions: [">=1.0.2"]
   validity: { verdict: valid }
   template_id: "persistent_minimal_2.en.v1"
-  provenance: "derived 2026-07-24 from cnf.composition.persistent.v1 by re-pointing archetype_details.template_id to persistent_minimal_2.en.v1 (the official persistent_minimal_2.opt shares the identical archetype set, so the instance stays conformant) — the second-persistent-OPT member of the master08 multi-version combination B"
+  provenance: "derived 2026-07-24 from cnf.composition.persistent.v1 by re-pointing archetype_details.template_id to persistent_minimal_2.en.v1 (the official persistent_minimal_2.opt shares the identical archetype set, so the instance stays conformant) — the second-persistent-OPT member of the master08 multi-version combination B; DV_DATE_TIME offsets normalized 2026-07-29 from the basic-format `+0000` to the extended `+00:00`: RM data_types dv_date_time.adoc's invariant `Value_valid: valid_iso8601_date_time (value)` admits only `YYYY-MM-DDThh:mm:ss[(,|.)s+][Z|±hh[:mm]]` (extended) or `YYYYMMDDThhmmss[(,|.)s+][Z|±hh[mm]]` (compact) (BASE foundation_types time_definitions.adoc §valid_iso8601_date_time), so an extended date/time carrying the compact offset matches neither alternative. The COMMA decimal sign is UNTOUCHED — BASE iso8601_date_time.adoc states the value form as `…ss[(,|.)sss]…` and declares `is_decimal_sign_comma()`, so a comma fraction is explicitly legal. Register AMB-171 carries the residual offset-form reading (upstream UPR-128)"
 # Corpus additions for the CNF master09 (DIRECTORY) schedule cases.
 # NOTE: FOLDER payloads / provisioned directory trees — real canonical FOLDER
 # structures (openEHR CNF Robot corpus, re-adjudicated to spec-text-only

--- a/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_persistent.v1.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_persistent.v1.json
@@ -94,7 +94,7 @@
         "archetype_node_id": "at0001",
         "origin": {
           "_type": "DV_DATE_TIME",
-          "value": "2019-04-16T21:08:11,380+0000"
+          "value": "2019-04-16T21:08:11,380+00:00"
         },
         "events": [
           {
@@ -106,7 +106,7 @@
             "archetype_node_id": "at0002",
             "time": {
               "_type": "DV_DATE_TIME",
-              "value": "2019-04-16T21:08:11,384+0000"
+              "value": "2019-04-16T21:08:11,384+00:00"
             },
             "data": {
               "_type": "ITEM_TREE",

--- a/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_persistent.v2.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_persistent.v2.json
@@ -94,7 +94,7 @@
         "archetype_node_id": "at0001",
         "origin": {
           "_type": "DV_DATE_TIME",
-          "value": "2019-04-16T21:08:11,380+0000"
+          "value": "2019-04-16T21:08:11,380+00:00"
         },
         "events": [
           {
@@ -106,7 +106,7 @@
             "archetype_node_id": "at0002",
             "time": {
               "_type": "DV_DATE_TIME",
-              "value": "2019-04-16T21:08:11,384+0000"
+              "value": "2019-04-16T21:08:11,384+00:00"
             },
             "data": {
               "_type": "ITEM_TREE",

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.obs_admin.coded_text_on_text.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.obs_admin.coded_text_on_text.json
@@ -62,7 +62,7 @@
     "_type": "EVENT_CONTEXT",
     "start_time": {
       "_type": "DV_DATE_TIME",
-      "value": "2019-04-16T21:08:14,127+0000"
+      "value": "2019-04-16T21:08:14,127+00:00"
     },
     "setting": {
       "_type": "DV_CODED_TEXT",
@@ -121,7 +121,7 @@
         "archetype_node_id": "at0001",
         "origin": {
           "_type": "DV_DATE_TIME",
-          "value": "2019-04-16T21:08:14,129+0000"
+          "value": "2019-04-16T21:08:14,129+00:00"
         },
         "events": [
           {
@@ -133,7 +133,7 @@
             "archetype_node_id": "at0002",
             "time": {
               "_type": "DV_DATE_TIME",
-              "value": "2019-04-16T21:08:14,130+0000"
+              "value": "2019-04-16T21:08:14,130+00:00"
             },
             "data": {
               "_type": "ITEM_TREE",

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.obs_admin.null_flavour.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.obs_admin.null_flavour.json
@@ -62,7 +62,7 @@
     "_type": "EVENT_CONTEXT",
     "start_time": {
       "_type": "DV_DATE_TIME",
-      "value": "2019-04-16T21:08:14,127+0000"
+      "value": "2019-04-16T21:08:14,127+00:00"
     },
     "setting": {
       "_type": "DV_CODED_TEXT",
@@ -121,7 +121,7 @@
         "archetype_node_id": "at0001",
         "origin": {
           "_type": "DV_DATE_TIME",
-          "value": "2019-04-16T21:08:14,129+0000"
+          "value": "2019-04-16T21:08:14,129+00:00"
         },
         "events": [
           {
@@ -133,7 +133,7 @@
             "archetype_node_id": "at0002",
             "time": {
               "_type": "DV_DATE_TIME",
-              "value": "2019-04-16T21:08:14,130+0000"
+              "value": "2019-04-16T21:08:14,130+00:00"
             },
             "data": {
               "_type": "ITEM_TREE",

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.persistent.v1.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.persistent.v1.json
@@ -94,7 +94,7 @@
         "archetype_node_id": "at0001",
         "origin": {
           "_type": "DV_DATE_TIME",
-          "value": "2019-04-16T21:08:11,380+0000"
+          "value": "2019-04-16T21:08:11,380+00:00"
         },
         "events": [
           {
@@ -106,7 +106,7 @@
             "archetype_node_id": "at0002",
             "time": {
               "_type": "DV_DATE_TIME",
-              "value": "2019-04-16T21:08:11,384+0000"
+              "value": "2019-04-16T21:08:11,384+00:00"
             },
             "data": {
               "_type": "ITEM_TREE",

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.persistent.v2.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.persistent.v2.json
@@ -94,7 +94,7 @@
         "archetype_node_id": "at0001",
         "origin": {
           "_type": "DV_DATE_TIME",
-          "value": "2019-04-16T21:08:11,380+0000"
+          "value": "2019-04-16T21:08:11,380+00:00"
         },
         "events": [
           {
@@ -106,7 +106,7 @@
             "archetype_node_id": "at0002",
             "time": {
               "_type": "DV_DATE_TIME",
-              "value": "2019-04-16T21:08:11,384+0000"
+              "value": "2019-04-16T21:08:11,384+00:00"
             },
             "data": {
               "_type": "ITEM_TREE",

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.persistent_2.v1.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.persistent_2.v1.json
@@ -94,7 +94,7 @@
         "archetype_node_id": "at0001",
         "origin": {
           "_type": "DV_DATE_TIME",
-          "value": "2019-04-16T21:08:11,380+0000"
+          "value": "2019-04-16T21:08:11,380+00:00"
         },
         "events": [
           {
@@ -106,7 +106,7 @@
             "archetype_node_id": "at0002",
             "time": {
               "_type": "DV_DATE_TIME",
-              "value": "2019-04-16T21:08:11,384+0000"
+              "value": "2019-04-16T21:08:11,384+00:00"
             },
             "data": {
               "_type": "ITEM_TREE",

--- a/tools/cnf-runner/artifacts/registers/ambiguities.yaml
+++ b/tools/cnf-runner/artifacts/registers/ambiguities.yaml
@@ -1821,38 +1821,74 @@ AMB-75:
 
 AMB-76:
   ambiguity: >-
-    The rejection status for a lexically malformed identifier path segment
-    (ehr_id, versioned_object_uid; scope extended 2026-07-27 to
-    contribution_uid, which the glossary does not type at all — AMB-90 — and
-    which the path-parameter declaration types only as string/uuid) is
-    unassigned. The released glossary
-    types both as HIER_OBJECT_ID with no per-operation 400 branch; the
-    overview 400 row covers "syntactically invalid header, parameter or
-    content"; BASE gives UID three subtypes with "mutually exclusive
-    string patterns" but no rejecting regex on any class. A token
-    matching no UID subtype is syntactically invalid (400); a
-    lexically-valid non-UUID UID (an OID / INTERNET_ID) that names
-    nothing is arguably a plain miss (404).
+    RE-GROUNDED 2026-07-29, verdict unchanged. What is unassigned is narrower
+    than this entry used to claim, and the earlier ground was defective in
+    both directions: it mis-quoted the released 400 row, and it derived the
+    400 from a property of THIS SERVER ("every identifier this server MINTS
+    is a UUID") — a SUT-derived expectation, which the attribution law
+    forbids outright. Neither survives.
+    WHAT THE RELEASE DOES SETTLE: the lexical form of every affected path
+    segment. `version_uid` is fixed by the DOCS TEXT — Resources.md
+    §Identifier types: "The `version_uid` uniquely identifies a VERSION, in
+    the lexical form of `object_id :: creating_system_id ::
+    version_tree_id`". `ehr_id`, `versioned_object_uid` and
+    `contribution_uid` are fixed by the RELEASED OAS, where the docs text is
+    silent on their spelling: each path-parameter file declares
+    `schema: {type: string, format: uuid}`. A segment violating the declared
+    parameter schema is not the identifier the operation takes, so the
+    operation's only declared error branch does not reach it: the 404 files
+    state their trigger for a WELL-FORMED-but-absent id
+    ("`404 Not Found` is returned when an EHR with `ehr_id` does not
+    exist"), which presupposes an `ehr_id`. What is left is the overview's
+    400 row, whose first named case is exactly this: "malformed request
+    syntax".
+    WHAT REMAINS UNASSIGNED, and is why this entry survives: no operation
+    DECLARES a 400 response for a violation of its own path-parameter
+    schema. `ehr_get_by_id`, `versioned_composition_get` and
+    `contribution_get` all declare `{200, 404}` and nothing else, so the
+    branch is derivable from the overview but absent from every per-operation
+    response map — the gap UPR-38 asks openEHR to close. The release even
+    HAS the sentence, in the reusable `responses/400.yaml` ("`400 Bad
+    Request` is returned when the request could not be parsed or is invalid
+    (e.g. malformed request URL syntax, missing required header or
+    parameter, or syntactically invalid header, parameter or content)") —
+    it is simply not `$ref`ed by any of these three reads.
   source: >-
-    ITS-REST specifications/docs/overview/Glossary_and_conventions.md
-    (ehr_id / versioned_object_uid as HIER_OBJECT_ID; contribution_uid
-    absent from the table entirely) +
-    specifications/parameters/path/contribution_uid.yaml ("The CONTRIBUTION
-    uid", type string / format uuid — the only place the segment is typed);
-    Requests_and_responses.md §HTTP status codes (the 400 row); BASE
-    base_types master05-identification_package.adoc ("all three subtypes
-    have mutually exclusive string patterns") + the UID/HIER_OBJECT_ID
-    class tables (no lexical invariant beyond non-empty) — confirmed
+    ITS-REST specifications/docs/overview/Resources.md §Identifier types
+    (the `version_uid` lexical form, quoted above; `ehr_id` and
+    `versioned_object_uid` named without a spelling; `contribution_uid`
+    absent — AMB-90) + docs/overview/Requests_and_responses.md §HTTP status
+    codes, the 400 row VERBATIM: "The service cannot or will not process the
+    request due to something that is perceived to be a client error (e.g.,
+    malformed request syntax, syntactically invalid content)" — note this
+    Release-1.1.0 wording says "content", NOT the "header, parameter or
+    content" this entry previously quoted. TIER 2, THE RELEASED OAS, citable
+    because the docs text is silent on these three spellings (owner ruling
+    2026-07-28) and cited AS the OAS:
+    specifications/parameters/path/ehr_id.yaml,
+    path/versioned_object_uid_COMPOSITION.yaml and path/contribution_uid.yaml
+    (each `schema: {type: string, format: uuid}`);
+    specifications/operations/ehr_get_by_id.yaml, versioned_composition_get.yaml
+    and contribution_get.yaml (responses 200 + 404 only — no 400);
+    responses/404_unknown_ehr_id.yaml, 404_unknown_ehr_id_or_versioned_object_uid.yaml
+    and 404_CONTRIBUTION.yaml (each scoped to an id that "does not exist").
+    BASE base_types master05-identification_package.adoc ("all three subtypes
+    have mutually exclusive string patterns") + the UID/HIER_OBJECT_ID class
+    tables (no lexical invariant beyond non-empty) — all CONFIRMED
     first-hand.
   handling: >-
-    Fixed handling (repo-wide): identifier path segments that do not parse
-    as this repository's UUID identifier form are rejected 400 as
-    syntactically invalid parameters — every identifier this server MINTS
-    is a UUID, so a non-UUID token can never name a resource here and the
-    400 names the defect closest to its cause. Cases address unknown
-    resources with well-formed UUIDs, malformed-identifier cases expect
-    400. Reported upstream (UPR-38): assign the malformed-identifier
-    branch.
+    Fixed handling (repo-wide): an identifier path segment that violates the
+    lexical form the release fixes for it — the docs-text `::` composite for
+    `version_uid`, the OAS `format: uuid` for `ehr_id`,
+    `versioned_object_uid` and `contribution_uid` — is rejected 400 as
+    malformed request syntax, because the operation's 404 branch is scoped to
+    a well-formed id that names nothing. Cases address unknown resources with
+    well-formed identifiers and malformed-identifier cases expect 400, so the
+    400/404 split is exercised rather than assumed. The 400 is NOT an option
+    branch: it is derived from the released parameter typing plus the
+    overview row, not chosen. Reported upstream (UPR-38), re-scoped: declare
+    the 400 in the per-operation response maps that type their path
+    parameters.
   disposition: fixed_handling
   upstream_ref: "UPR-38"
 
@@ -6723,3 +6759,56 @@ AMB-170:
     these blocks is a `workload-coverage` finding, so the published
     certificate can never again carry an undecided row.
   disposition: statement_declared
+
+AMB-171:
+  ambiguity: >-
+    Whether the basic/extended FORM of an ISO 8601 timezone designator must
+    match the form of the date/time it is appended to is described two ways
+    in the released BASE text, so an extended date/time carrying a compact
+    offset (`2019-04-16T21:08:11,380+0000`) has no single reading. Reading
+    A, the one `DV_DATE_TIME.Value_valid` actually names: the function
+    `valid_iso8601_date_time` lists exactly two complete forms, extended
+    `YYYY-MM-DDThh:mm:ss[(,|.)s+][Z|±hh[:mm]]` and compact
+    `YYYYMMDDThhmmss[(,|.)s+][Z|±hh[mm]]`, pairing each base with its own
+    offset spelling — a mixed string matches neither. Reading B: the sibling
+    `valid_iso8601_time` states the offset as a SEPARATE trailing clause
+    ("with an additional optional timezone indicator of: `Z` or `±hh[:mm]`
+    (extended) `±hh[mm]` (compact)"), and `Iso8601_timezone` — the type
+    `Iso8601_date_time.timezone()` returns — gives its own format as
+    `Z | ±hh[mm]` while declaring `is_extended()` ("True if this time-zone
+    uses ':' separators"), i.e. extendedness is a property of the offset
+    alone. NOT AT ISSUE, and explicitly settled by the same text: the COMMA
+    decimal sign is legal. `Iso8601_date_time` states the value form as
+    `YYYY-MM-DDThh:mm:ss[(,|.)sss][Z | ±hh[:mm]]` and declares
+    `is_decimal_sign_comma()` ("True if this time has a decimal part
+    indicated by `','` (comma) rather than `'.'` (period)"), and
+    `valid_iso8601_time` spells the fraction out as "an optional string
+    consisting of a comma or decimal point followed by numeric string of 1
+    or more digits". A server refusing a body DV_DATE_TIME for its comma
+    alone therefore breaches released text, and no case may treat the comma
+    as optional behaviour.
+  source: >-
+    RM data_types dv_date_time.adoc §Invariants (`Value_valid:
+    valid_iso8601_date_time (value)`) + BASE foundation_types
+    time_definitions.adoc §valid_iso8601_date_time and §valid_iso8601_time +
+    BASE foundation_types iso8601_date_time.adoc §Description and
+    §is_decimal_sign_comma + BASE foundation_types iso8601_timezone.adoc
+    §Description and §is_extended + ITS-REST
+    specifications/docs/overview/Resources.md §Datetime format (the extended
+    format is a MUST only for "HTTP query parameters and path segments";
+    a body value "will be preserved as it was sent by the client, and passed
+    to the underlying backend engine as is") — all CONFIRMED first-hand.
+    The ITS-JSON schema adds nothing: `openehr_rm_1.1.0_all.json`
+    `definitions.DV_DATE_TIME.properties.value` is a bare
+    `{"type": "string"}` with no pattern.
+  handling: >-
+    The catalogue depends on NEITHER reading: every corpus DV_DATE_TIME uses
+    a form both admit — an extended base with `Z` or an extended `±hh:mm`
+    offset — so no case gates on the mixed representation. The seven
+    Robot-derived COMPOSITION fixtures that carried `+0000` on an extended
+    base were normalized to `+00:00` on 2026-07-29 (their MANIFEST
+    provenance records it); their comma fractions were kept, being legal
+    under the settled half above. Reported upstream (UPR-128): give the
+    offset form one voice.
+  disposition: editorial
+  upstream_ref: "UPR-128"

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_versioned_composition-malformed_uid.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_versioned_composition-malformed_uid.yaml
@@ -1,19 +1,27 @@
 # A versioned_object_uid path segment that is not an identifier at all: the
 # request is refused for its SHAPE, before any lookup.
 #
-# SPEC SILENCE, adjudicated as AMB-76 (fixed_handling): the released glossary
-# types `versioned_object_uid` as a HIER_OBJECT_ID (ITS-REST overview
-# Glossary_and_conventions.md), BASE base_types master05 gives UID "three
-# subtypes [with] mutually exclusive string patterns" but no rejecting lexical
-# invariant, and no per-operation branch is assigned to a malformed segment.
-# The register's repo-wide handling: an identifier segment that parses as none
-# of this repository's minted identifier forms is a syntactically invalid
-# parameter, which ITS-REST overview Requests_and_responses.md §HTTP status
-# codes places in the 400 row — "The service cannot or will not process the
-# request due to something that is perceived to be a client error (e.g.,
-# malformed request syntax, syntactically invalid content)" — while
-# well-formed-but-unknown identifiers keep the 404 the sibling
-# non_existent case pins.
+# The rejection is DERIVED, not chosen (register AMB-76, re-grounded
+# 2026-07-29). The docs text names `versioned_object_uid` (ITS-REST overview
+# Resources.md §Identifier types, "in a form of a HIER_OBJECT_ID") without
+# fixing its spelling, so the spelling comes from the RELEASED OAS, cited AS
+# the OAS: specifications/parameters/path/versioned_object_uid_COMPOSITION.yaml
+# declares `schema: {type: string, format: uuid}`. The token below violates
+# that declared parameter schema, so the operation's only declared error
+# branch does not reach it — responses/404_unknown_ehr_id_or_versioned_object_uid.yaml
+# scopes its trigger to a well-formed id ("`404 Not Found` is returned when an
+# EHR with `ehr_id` does not exist, or when the `versioned_object_uid` does not
+# exist"). What is left is ITS-REST overview Requests_and_responses.md §HTTP
+# status codes, whose 400 row names this case first: "The service cannot or
+# will not process the request due to something that is perceived to be a
+# client error (e.g., malformed request syntax, syntactically invalid
+# content)". Well-formed-but-unknown identifiers keep the 404 the sibling
+# non_existent case pins. BASE base_types master05 gives UID "three subtypes
+# [with] mutually exclusive string patterns" but no rejecting lexical
+# invariant, which is why the OAS typing is the operative ground. What AMB-76
+# still carries is narrower: this operation declares 200 + 404 and no 400 for
+# a path-parameter-schema violation — the editorial gap UPR-38 asks openEHR to
+# close.
 #
 # The two cases are deliberately adjacent: same route, same EHR, one garbage
 # token and one well-formed miss, so the boundary between 400 and 404 is
@@ -38,7 +46,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_COMPOSITION.get_versioned_composition"
 applies: { rm: ">=1.0.2" }
 guards:
-  - "The 400-vs-404 split for a malformed identifier segment rests on the AMB-76 adjudication — ITS-REST overview Requests_and_responses.md §HTTP status codes (the 400 row) covers 'syntactically invalid content' generally but assigns no branch to a malformed identifier segment, and BASE base_types master05 §Identification carries no rejecting lexical invariant; a server answering 404 for a garbage token breaches no quoted rule"
+  - "The 400 is derived, not optional (register AMB-76) — the released OAS parameters/path/versioned_object_uid_COMPOSITION.yaml types the segment `format: uuid`, responses/404_unknown_ehr_id_or_versioned_object_uid.yaml scopes the only declared error branch to an id that 'does not exist', and ITS-REST overview Requests_and_responses.md §HTTP status codes puts what is left in the 400 row ('malformed request syntax')"
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-non_existent.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-non_existent.yaml
@@ -1,9 +1,14 @@
 # Update with a random preceding_version_uid: negative. The REST binding
 # realizes preceding_version_uid as If-Match (ITS-REST overview §If-Match); the random uid also
 # names an unknown versioned-object PATH, so the unconditioned response is
-# the 404 (not_found) and RFC 9110 §13.2.2 precedence keeps it — 412
-# (precondition_failed/version_not_found) is reserved for a false If-Match
-# condition on an EXISTING resource.
+# the 404 (not_found) and RFC 9110 §13.2.1 keeps it: "A server MUST ignore all
+# received preconditions if its response to the same request without those
+# conditions, prior to processing the request content, would have been a
+# status code other than a 2xx (Successful) or 412 (Precondition Failed). In
+# other words, redirects and failures that can be detected before significant
+# processing occurs take precedence over the evaluation of preconditions."
+# 412 (precondition_failed/version_not_found) is therefore reserved for a
+# false If-Match condition on an EXISTING resource.
 id: I_EHR_COMPOSITION.update_composition-non_existent
 kind: functional
 component: EHR_COMPOSITION

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.get_contribution-malformed_contribution_uid.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.get_contribution-malformed_contribution_uid.yaml
@@ -1,18 +1,24 @@
 # A contribution_uid path segment that is not an identifier at all: the request
 # is refused for its SHAPE, before any lookup.
 #
-# SPEC SILENCE, adjudicated as AMB-76 (fixed_handling), whose scope was
-# extended to `contribution_uid`. The overview glossary types `ehr_id` and
-# `versioned_object_uid` but never mentions `contribution_uid` at all (a
-# released omission travelling in AMB-90); the only place the segment is typed
-# is its path-parameter declaration ("The CONTRIBUTION uid", string/uuid), and
-# no operation declares a branch for a malformed one. The register's repo-wide
-# handling puts a segment that parses as none of this repository's identifier
-# forms in the overview's 400 row (`Requests_and_responses.md` §HTTP status
-# codes, verbatim): "The service cannot or will not process the request due to
-# something that is perceived to be a client error (e.g., malformed request
-# syntax, syntactically invalid content)" — while a well-formed-but-unknown uid
-# keeps the 404 the -bad_contribution case pins.
+# The rejection is DERIVED, not chosen (register AMB-76, re-grounded
+# 2026-07-29). The docs text never mentions `contribution_uid` at all (a
+# released omission travelling in AMB-90), so the spelling comes from the
+# RELEASED OAS, cited AS the OAS:
+# specifications/parameters/path/contribution_uid.yaml declares
+# `schema: {type: string, format: uuid}`. The token below violates that
+# declared parameter schema, so the operation's only declared error branch does
+# not reach it — responses/404_CONTRIBUTION.yaml scopes its trigger to an id
+# that exists or does not ("`404 Not Found` is returned when an EHR with
+# `ehr_id` does not exist, or when a CONTRIBUTION with `contribution_uid` does
+# not exist"). What is left is the overview's 400 row
+# (`Requests_and_responses.md` §HTTP status codes, verbatim): "The service
+# cannot or will not process the request due to something that is perceived to
+# be a client error (e.g., malformed request syntax, syntactically invalid
+# content)" — while a well-formed-but-unknown uid keeps the 404 the
+# -bad_contribution case pins. What AMB-76 still carries is narrower: this
+# operation declares 200 + 404 and no 400 for a path-parameter-schema
+# violation — the editorial gap UPR-38 asks openEHR to close.
 #
 # The token fails on both counts: not a UUID, and not any composite identifier
 # form. The sibling -bad_contribution case supplies the other side of the
@@ -36,7 +42,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_CONTRIBUTION.get_contribution"
 applies: { rm: ">=1.0.2" }
 guards:
-  - "The 400-vs-404 split for a malformed identifier segment rests on the AMB-76 adjudication — ITS-REST overview Requests_and_responses.md §HTTP status codes offers both the 400 row ('syntactically invalid content') and the 404 row ('did not find the target resource') and assigns neither to a malformed segment; a server answering 404 for a garbage token breaches no quoted rule"
+  - "The 400 is derived, not optional (register AMB-76) — the released OAS parameters/path/contribution_uid.yaml types the segment `format: uuid`, responses/404_CONTRIBUTION.yaml scopes the only declared error branch to an id that 'does not exist', and ITS-REST overview Requests_and_responses.md §HTTP status codes puts what is left in the 400 row ('malformed request syntax')"
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.list_queries-prefix_all_versions.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.list_queries-prefix_all_versions.yaml
@@ -10,6 +10,14 @@
 # shape that discriminates all three claims (prefix, all versions, all
 # matches) at once.
 #
+# The BODY SHAPE the `[i]/name` assertions address is not chosen either. The
+# docs text does not describe the listing's representation, so the shape comes
+# from the RELEASED OAS, cited AS the OAS: definition_query_list.yaml's `'200'`
+# $refs responses/200_QueryList.yaml → schemas/definition/QueryList.yaml, which
+# is `type: array` of schemas/query/StoredQuery.yaml, and StoredQuery lists
+# `name` first among its `required` members. A 200 whose body is not an array
+# of objects carrying `name` is therefore outside the released shape.
+#
 # ORDER is spec-silent and adjudicated in register AMB-124: name, then version
 # SEMVER-ascending — the order the released QueryList example itself shows
 # (`1.0.1` before `1.1.7` under one name). The trailing absent-row assertion

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.delete_directory-empty_ehr.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.delete_directory-empty_ehr.yaml
@@ -18,9 +18,20 @@
 # fixed_handling, so the case GATES.
 #
 # The wire-required If-Match IS sent (a synthetic value), so the exchange is a
-# well-formed request rather than a missing-precondition one; RFC 9110 §13.2.2
-# precedence makes the missing-resource answer win over precondition
-# evaluation.
+# well-formed request rather than a missing-precondition one — and the
+# precondition is then NOT evaluated at all. RFC 9110 §13.2.1: "A server MUST
+# ignore all received preconditions if its response to the same request
+# without those conditions, prior to processing the request content, would
+# have been a status code other than a 2xx (Successful) or 412 (Precondition
+# Failed). In other words, redirects and failures that can be detected before
+# significant processing occurs take precedence over the evaluation of
+# preconditions." With no directory, the unconditional answer is the miss, so
+# the miss is the answer. (§13.2.2 orders MULTIPLE conditional fields against
+# each other; it is §13.2.1 that subordinates all of them to a failure.) The
+# ITS-REST overview §If-Match MUST — "If a service receives this header, and
+# the condition evaluates to `false` … it MUST respond with HTTP status code
+# `412 Precondition Failed`" — is not in conflict: it governs the case where
+# the condition IS evaluated.
 #
 # GROUNDING NOTE: this case previously cited the CNF platform test schedule as
 # the authority for its 404. The schedule never released stable and is a GUIDE

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory_at_version-malformed_version_uid.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.get_directory_at_version-malformed_version_uid.yaml
@@ -1,19 +1,22 @@
 # A version_uid path segment that is not an identifier at all: the request is
 # refused for its SHAPE, before any lookup.
 #
-# SPEC SILENCE, adjudicated as AMB-76 (fixed_handling): ITS-REST overview
-# Resources.md §Identifier types types `version_uid` as an OBJECT_VERSION_ID
-# "in the lexical form of `object_id :: creating_system_id ::
-# version_tree_id`", BASE base_types master05 gives UID "three subtypes [with]
-# mutually exclusive string patterns" but no rejecting lexical invariant, and
-# no per-operation branch is assigned to a malformed segment. The register's
-# repo-wide handling: an identifier segment that parses as none of this
-# repository's minted identifier forms is a syntactically invalid parameter,
-# which ITS-REST overview Requests_and_responses.md §HTTP status codes places
-# in the 400 row — "The service cannot or will not process the request due to
-# something that is perceived to be a client error (e.g., malformed request
-# syntax, syntactically invalid content)" — while well-formed-but-unknown
-# identifiers keep the 404 the existing empty_ehr / bad_ehr cases pin.
+# The rejection is DERIVED, not chosen (register AMB-76, re-grounded
+# 2026-07-29), and here the ground is the DOCS TEXT itself — the strongest
+# tier. ITS-REST overview Resources.md §Identifier types fixes the segment's
+# lexical form outright: "The `version_uid` uniquely identifies a VERSION, in
+# the lexical form of `object_id :: creating_system_id :: version_tree_id`".
+# A token carrying neither `::` separator is not a `version_uid`, so ITS-REST
+# overview Requests_and_responses.md §HTTP status codes places it in the 400
+# row — "The service cannot or will not process the request due to something
+# that is perceived to be a client error (e.g., malformed request syntax,
+# syntactically invalid content)" — while well-formed-but-unknown identifiers
+# keep the 404 the existing empty_ehr / bad_ehr cases pin. BASE base_types
+# master05 gives UID "three subtypes [with] mutually exclusive string
+# patterns" but no rejecting lexical invariant, which is why the ITS-REST
+# lexical-form sentence is the operative ground. What AMB-76 still carries is
+# narrower: no per-operation response map DECLARES the 400 — the editorial gap
+# UPR-38 asks openEHR to close.
 #
 # The token here fails the lexical form on both counts: it is not a UUID and it
 # carries none of the two `::` separators the composite form requires. The
@@ -39,7 +42,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_DIRECTORY.get_directory_at_version"
 applies: { rm: ">=1.0.2" }
 guards:
-  - "The 400-vs-404 split for a malformed identifier segment rests on the AMB-76 adjudication — ITS-REST overview Requests_and_responses.md §HTTP status codes (the 400 row) covers 'syntactically invalid content' generally but assigns no branch to a malformed identifier segment, and BASE base_types master05 §Identification carries no rejecting lexical invariant; a server answering 404 for a garbage token breaches no quoted rule"
+  - "The 400 is derived, not optional (register AMB-76) — ITS-REST overview Resources.md §Identifier types fixes the segment's lexical form ('in the lexical form of `object_id :: creating_system_id :: version_tree_id`'), so a token carrying neither separator is malformed request syntax under Requests_and_responses.md §HTTP status codes (the 400 row)"
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id}

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.update_directory-empty_ehr.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.update_directory-empty_ehr.yaml
@@ -17,9 +17,20 @@
 # that one exists"). fixed_handling, so the case GATES.
 #
 # The wire-required If-Match IS sent (a synthetic value), so the exchange is a
-# well-formed request rather than a missing-precondition one; RFC 9110 §13.2.2
-# precedence makes the missing-resource answer win over precondition
-# evaluation.
+# well-formed request rather than a missing-precondition one — and the
+# precondition is then NOT evaluated at all. RFC 9110 §13.2.1: "A server MUST
+# ignore all received preconditions if its response to the same request
+# without those conditions, prior to processing the request content, would
+# have been a status code other than a 2xx (Successful) or 412 (Precondition
+# Failed). In other words, redirects and failures that can be detected before
+# significant processing occurs take precedence over the evaluation of
+# preconditions." With no directory, the unconditional answer is the miss, so
+# the miss is the answer. (§13.2.2 orders MULTIPLE conditional fields against
+# each other; it is §13.2.1 that subordinates all of them to a failure.) The
+# ITS-REST overview §If-Match MUST — "If a service receives this header, and
+# the condition evaluates to `false` … it MUST respond with HTTP status code
+# `412 Precondition Failed`" — is not in conflict: it governs the case where
+# the condition IS evaluated.
 #
 # GROUNDING NOTE: this case previously cited the CNF platform test schedule as
 # the authority for its 404. The schedule never released stable and is a GUIDE

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.get_ehr-malformed_ehr_id.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.get_ehr-malformed_ehr_id.yaml
@@ -2,21 +2,27 @@
 # refused for its SHAPE, before any lookup, and never resolves to some other
 # EHR.
 #
-# SPEC SILENCE, adjudicated as AMB-76 (fixed_handling), whose scope names
-# `ehr_id` first. ITS-REST overview Glossary_and_conventions.md types `ehr_id`
-# as HIER_OBJECT_ID and no operation declares a branch for a malformed one;
-# overview Requests_and_responses.md §HTTP status codes offers two rows that
-# both fit and assigns neither — 400 ("The service cannot or will not process
-# the request due to something that is perceived to be a client error (e.g.,
-# malformed request syntax, syntactically invalid content)") and 404 ("The
-# origin service did not find the target resource or is not willing to
-# disclose that one exists"). The register's repo-wide handling puts a segment
-# that parses as none of this repository's identifier forms in the 400 row,
-# while a well-formed-but-unknown ehr_id keeps the 404 the sibling
-# -get_ehr_by_invalid_ehr_id case pins — so the 400/404 split is exercised
+# The rejection is DERIVED, not chosen (register AMB-76, re-grounded
+# 2026-07-29). The docs text names `ehr_id` (overview Resources.md §Identifier
+# types) without fixing its spelling, so the spelling comes from the RELEASED
+# OAS, cited AS the OAS: specifications/parameters/path/ehr_id.yaml declares
+# `schema: {type: string, format: uuid}`. `not-an-ehr-id` violates that
+# declared parameter schema, so it is not the `ehr_id` the operation takes —
+# and the operation's ONLY declared error branch does not reach it, because
+# responses/404_unknown_ehr_id.yaml scopes its own trigger to a well-formed
+# id: "`404 Not Found` is returned when an EHR with `ehr_id` does not exist".
+# What remains is overview Requests_and_responses.md §HTTP status codes, whose
+# 400 row names this case first: "The service cannot or will not process the
+# request due to something that is perceived to be a client error (e.g.,
+# malformed request syntax, syntactically invalid content)". A
+# well-formed-but-unknown ehr_id keeps the 404 the sibling
+# -get_ehr_by_invalid_ehr_id case pins, so the 400/404 split is exercised
 # rather than assumed. BASE base_types master05-identification_package.adoc
 # ("all three subtypes have mutually exclusive string patterns") is why the
 # token below is a UID of no kind: not a UUID, and not any composite form.
+# What AMB-76 still carries is narrower: no operation DECLARES the 400 for a
+# path-parameter-schema violation (this one declares 200 + 404 only), which is
+# the editorial gap UPR-38 asks openEHR to close.
 #
 # The outcome kind is `bad_request`, which the 2026-07-28 schedule release
 # (#544) added for exactly this family; before it the closed taxonomy had only
@@ -41,7 +47,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_SERVICE.get_ehr"
 applies: { rm: ">=1.0.2" }
 guards:
-  - "The 400-vs-404 split for a malformed identifier segment rests on the AMB-76 adjudication — ITS-REST overview Requests_and_responses.md §HTTP status codes offers both the 400 row ('syntactically invalid content') and the 404 row ('did not find the target resource') and assigns neither to a malformed segment; a server answering 404 for a garbage token breaches no quoted rule"
+  - "The 400 is derived, not optional (register AMB-76) — the released OAS parameters/path/ehr_id.yaml types the segment `format: uuid`, responses/404_unknown_ehr_id.yaml scopes the only declared error branch to a well-formed id ('when an EHR with `ehr_id` does not exist'), and ITS-REST overview Requests_and_responses.md §HTTP status codes puts what is left in the 400 row ('malformed request syntax')"
 requires:
   server: any
   ehr: { commits: none }                 # mints ${ehr_id} — so the server is not empty and the refusal is the token alone

--- a/tools/cnf-runner/src/exec/assertions.rs
+++ b/tools/cnf-runner/src/exec/assertions.rs
@@ -70,12 +70,38 @@ pub fn render_template(template: &Template, vars: &VarStore) -> Result<String, S
 
 /// Strip the named ignore-sets and explicit paths from a value (top-level
 /// path removal; nested server-assigned paths use `/`-separated forms).
+///
+/// A `**` segment matches zero or more intervening attribute steps, so
+/// `**/uid` names one attribute wherever it occurs in a recursive RM
+/// structure. Recursive containment is an RM shape, not a fixture depth:
+/// `FOLDER.folders` is `List<FOLDER>` (RM common `folder.adoc`), so an
+/// ignore-set that could only be written per depth would silently
+/// under-cover a deeper tree.
 #[must_use]
 pub fn strip_ignored(value: &Value, ignored_paths: &[String]) -> Value {
     fn remove(value: &mut Value, segments: &[&str]) {
         let Some((head, rest)) = segments.split_first() else {
             return;
         };
+        if *head == "**" {
+            // Zero intervening steps: apply the remainder here …
+            remove(value, rest);
+            // … or one-or-more: descend and retry the same pattern.
+            match value {
+                Value::Object(map) => {
+                    for child in map.values_mut() {
+                        remove(child, segments);
+                    }
+                }
+                Value::Array(items) => {
+                    for item in items {
+                        remove(item, segments);
+                    }
+                }
+                _ => {}
+            }
+            return;
+        }
         match value {
             Value::Object(map) => {
                 if rest.is_empty() {
@@ -648,6 +674,41 @@ mod tests {
             &json!("t0")
         );
         assert!(resolve_path(&body, "content[1]").is_none());
+    }
+
+    #[test]
+    fn recursive_ignore_segment_strips_every_depth() {
+        // A FOLDER tree (RM common `folder.adoc`: `folders: List<FOLDER>`),
+        // with a uid on the root and on each nested node.
+        let tree = json!({
+            "_type": "FOLDER",
+            "uid": { "_type": "OBJECT_VERSION_ID", "value": "r::s::1" },
+            "folders": [
+                {
+                    "_type": "FOLDER",
+                    "uid": { "_type": "HIER_OBJECT_ID", "value": "a" },
+                    "name": { "value": "emergency" },
+                    "folders": [
+                        { "_type": "FOLDER", "uid": { "value": "b" }, "name": { "value": "episode" } }
+                    ]
+                }
+            ]
+        });
+        // A depth-anchored path reaches only the root.
+        let shallow = strip_ignored(&tree, &["uid".to_owned()]);
+        assert!(shallow.get("uid").is_none());
+        assert!(shallow["folders"][0].get("uid").is_some());
+        // `**/uid` reaches the root and every nested node.
+        let deep = strip_ignored(&tree, &["**/uid".to_owned()]);
+        assert!(deep.get("uid").is_none());
+        assert!(deep["folders"][0].get("uid").is_none());
+        assert!(deep["folders"][0]["folders"][0].get("uid").is_none());
+        // Nothing else is touched.
+        assert_eq!(deep["folders"][0]["name"]["value"], json!("emergency"));
+        assert_eq!(
+            deep["folders"][0]["folders"][0]["name"]["value"],
+            json!("episode")
+        );
     }
 
     #[test]

--- a/website/book/src/comparison.md
+++ b/website/book/src/comparison.md
@@ -90,13 +90,46 @@ the committed `docs/conformance/ehrbase-java/results.json`.
 - **Unqualified stored-query names are rejected** although the specification
   makes the namespace optional and lists `my_compositions` as a valid
   example; a stale `If-Match` on a directory delete answers `404` where the
-  specification requires `412`; `405` responses omit the required `Allow`
-  header; and one contribution refusal surfaces as a raw `500`.
+  specification requires `412`; and `405` responses omit the required
+  `Allow` header.
+- **The stored-query listing does not match by prefix.** The specification's
+  own worked example lists "all versions of all queries with names starting
+  with `org.openehr`"; upstream returns the versions of an exactly-named
+  query but answers `200 []` for any shorter prefix, so a client cannot
+  discover what a namespace holds.
+- **A malformed identifier in the path answers `404`, not `400`.** Given a
+  path segment that is not a UUID at all, upstream detects the type
+  violation and still reports a miss — literally
+  `"EHR not found, in fact, only UUID-type IDs are supported"` — for the
+  EHR, versioned-COMPOSITION and CONTRIBUTION reads alike. (It does answer
+  `400` for a malformed *version* identifier, so the behaviour is not even
+  internally consistent.)
+- **Directory writes against an EHR that has no directory answer `412`.**
+  Both the update and the delete report `Precondition Failed` with the body
+  "does not contain a directory" — a missing resource dressed as a failed
+  precondition. HTTP requires the opposite order: a failure detectable
+  before the precondition is evaluated takes precedence over evaluating it.
+- **A contribution refusal surfaces as a raw `500`.** Committing a first
+  version whose change type is `deleted` returns `500 "An internal error has
+  occurred"`, where the specification assigns that family a `400`
+  ("the modification type does not match the operation"). The neighbouring
+  row is worse than an error: a *creation* whose lifecycle state is
+  `deleted` is **accepted** (`204`) instead of refused.
 - *(1.1.0-grounded)* The **template upload refuses `Accept:
   application/json`** (`406`), serving only XML — the released parameter
   enumeration lists JSON first. This single refusal is what makes most
   content-chapter rows inconclusive: the runner's provisioning uploads ask
   for JSON, upstream refuses, and the case's ground never exists.
+
+**Two red rows are not upstream's fault, and are called out rather than
+counted.** Storing a query with no version in the URL has to land at *some*
+version, and no released sentence says which. Our suite pins `1.0.0` because
+a suite must pin something; upstream continues the existing series instead
+(a stored `2.0.0` makes the next version-less store `3.0.0`). Both are
+defensible readings of a silence, so the two
+`store_query-{default_slot_with_higher_version,update_in_place}` rows record
+a difference of house convention, not a conformance defect — the open
+question is with openEHR, not with either implementation.
 
 ## Performance
 


### PR DESCRIPTION
Closes #652. Every row derived first-hand with a live wire reproduction (java stack composed and torn down within the task):

1. **The "comma decimal sign" was a misdiagnosis — catalogue (fixture) defect.** BASE settles the comma as LEGAL (`iso8601_date_time` value form `[(,|.)sss]`, `is_decimal_sign_comma()`), and the wire refutation is decisive: `,380+00:00` commits 201, `.380+0000` refuses 400 — the offender was the BASIC-form offset `+0000`, which `valid_iso8601_date_time` admits in neither of its two shapes. 16 offsets corrected across 7 Robot-provenance fixtures (comma KEPT); **AMB-171/UPR-128** record BASE's residual offset two-voicedness so no future case treats the comma as optional.
2. **Malformed path ids → 400 required (upstream diverges with 404).** The `version_uid` lexical form is tier-1 docs text; the other three spellings ground on the OAS `format: uuid` path schemas; the released 404 files scope themselves to well-formed ids. AMB-76 re-grounded in place — its SUT-derived reasoning ("every id this server mints is a UUID") deleted; UPR-38 rewritten with upstream's own "only UUID-type IDs are supported" 404 as evidence.
3. **The four singletons:** the contribution `500` (and an accepted `creation|deleted` commit) published as upstream findings against `400_CONTRIBUTION.yaml`'s explicit modification-mismatch row; the nested-FOLDER `uid` is PERMITTED at archetype roots (RM `locatable.adoc` 0..1 + `folder.adoc`'s top-level-only recommendation) — the comparator gains an any-depth `**/uid` ignore segment (+ unit test) and the seven directory bindings cite it; the stored-query prefix listing's body shape confirmed (upstream serves `[]`); the directory 412-before-404 grounds corrected to RFC 9110 **§13.2.1** (quoted) — upstream's 412 on a directory-less EHR stands as the finding.

The book comparison page's vague "one raw 500" line becomes five precise reproduced divergences, plus the standalone **AMB-117/UPR-81 house-convention caveat** on the two stored-query rows (per the #651 cross-reference — a difference of convention over released silence, not a conformance defect).

Gates: fmt clean, clippy zero new warnings, nextest **248/248**, validate **769 cases / 0 findings**, coverage report byte-identical. The fixture offset corrections are commit-safe against ehrbase-rs (already proven by the running baseline); the batch pipeline run verifies.