### PR TITLE
test(cnf): the comma-fraction DV_DATE_TIME lexical case (#664)

### DIFF
--- a/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_event.comma_fraction.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_event.comma_fraction.json
@@ -1,0 +1,150 @@
+{
+    "_type": "COMPOSITION",
+    "name": {
+        "_type": "DV_TEXT",
+        "value": "Minimal"
+    },
+    "archetype_details": {
+        "archetype_id": {
+            "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+        },
+        "template_id": {
+            "value": "minimal_evaluation.en.v1"
+        },
+        "rm_version": "1.0.2"
+    },
+    "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+    "language": {
+        "terminology_id": {
+            "value": "ISO_639-1"
+        },
+        "code_string": "en"
+    },
+    "territory": {
+        "terminology_id": {
+            "value": "ISO_3166-1"
+        },
+        "code_string": "UY"
+    },
+    "category": {
+        "value": "event",
+        "defining_code": {
+            "terminology_id": {
+                "value": "openehr"
+            },
+            "code_string": "433"
+        }
+    },
+    "composer": {
+        "_type": "PARTY_IDENTIFIED",
+        "external_ref": {
+            "id": {
+                "_type": "HIER_OBJECT_ID",
+                "value": "fc376c46-29c1-4090-bc01-5cc046af7f26"
+            },
+            "namespace": "DEMOGRAPHIC",
+            "type": "PERSON"
+        },
+        "name": "Dr. House"
+    },
+    "context": {
+        "start_time": {
+            "value": "2021-09-21T21:52:31,927-03:00"
+        },
+        "setting": {
+            "value": "primary medical care",
+            "defining_code": {
+                "terminology_id": {
+                    "value": "openehr"
+                },
+                "code_string": "228"
+            }
+        },
+        "participations": [
+            {
+                "function": {
+                    "value": "legal guardian consent author"
+                },
+                "performer": {
+                    "_type": "PARTY_RELATED",
+                    "name": "Alexandra Alamo",
+                    "relationship": {
+                        "value": "mother",
+                        "defining_code": {
+                            "terminology_id": {
+                                "value": "openehr"
+                            },
+                            "code_string": "10"
+                        }
+                    }
+                },
+                "mode": {
+                    "value": "not specified",
+                    "defining_code": {
+                        "terminology_id": {
+                            "value": "openehr"
+                        },
+                        "code_string": "193"
+                    }
+                }
+            }
+        ]
+    },
+    "content": [
+        {
+            "_type": "EVALUATION",
+            "name": {
+                "_type": "DV_TEXT",
+                "value": "Minimal"
+            },
+            "archetype_details": {
+                "archetype_id": {
+                    "value": "openEHR-EHR-EVALUATION.minimal.v1"
+                },
+                "template_id": {
+                    "value": "minimal_evaluation.en.v1"
+                },
+                "rm_version": "1.0.2"
+            },
+            "archetype_node_id": "openEHR-EHR-EVALUATION.minimal.v1",
+            "language": {
+                "terminology_id": {
+                    "value": "ISO_639-1"
+                },
+                "code_string": "en"
+            },
+            "encoding": {
+                "terminology_id": {
+                    "value": "IANA_character-sets"
+                },
+                "code_string": "UTF-8"
+            },
+            "subject": {
+                "_type": "PARTY_SELF"
+            },
+            "data": {
+                "_type": "ITEM_TREE",
+                "name": {
+                    "_type": "DV_TEXT",
+                    "value": "Arbol"
+                },
+                "archetype_node_id": "at0001",
+                "items": [
+                    {
+                        "_type": "ELEMENT",
+                        "name": {
+                            "_type": "DV_TEXT",
+                            "value": "quantity"
+                        },
+                        "archetype_node_id": "at0002",
+                        "value": {
+                            "_type": "DV_QUANTITY",
+                            "magnitude": 78.5,
+                            "units": "kg"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-datetime_comma_fraction.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-datetime_comma_fraction.yaml
@@ -1,0 +1,55 @@
+# The COMMA-decimal-sign sibling of `-datetime_lexical`: the fractional
+# second rendered `,927` instead of `.927`. BASE settles the comma as LEGAL —
+# `foundation_types/UML/…iso8601_date_time.adoc` gives the value form
+# `YYYY-MM-DDThh:mm:ss[(,|.)sss][Z|±hh[:mm]]` and defines
+# `is_decimal_sign_comma()` ("True if this time has a decimal part indicated
+# by ',' (comma) rather than '.' (period)"); `time_definitions.adoc`
+# §valid_iso8601_time admits "a comma or decimal point". Register AMB-171
+# records the comma as SETTLED, so a server refusing it is a defect, never an
+# option. The preservation rule is the same decisive docs text as the
+# sibling (ITS-REST overview Resources.md §Datetime format): a body datetime
+# "will be preserved as it was sent by the client", and retrieval SHOULD
+# avoid "any format change" — normalizing the comma to a period IS such a
+# change. The offset stays extended (`-03:00`): the offset FORM is the
+# adjudicated fixture rule from the #652 derivation, and this case isolates
+# exactly one variable — the decimal sign.
+id: I_EHR_COMPOSITION.create_composition-datetime_comma_fraction
+kind: functional
+component: EHR_COMPOSITION
+sm_operation: I_EHR_COMPOSITION.create_composition
+rm_class: DV_DATE_TIME
+capabilities: [CompositionOps]
+exercises: [EhrApi]
+profiles: [CORE]
+test_purpose: >-
+  A DV_DATE_TIME whose fractional second uses the ISO 8601 COMMA decimal
+  sign commits and is read back byte-identical — the comma survives, never
+  normalized to a period.
+description: "Body datetime comma decimal sign preserved (canonical JSON)"
+spec_refs:
+  - "ITS-REST overview Resources.md §Datetime format"
+  - "BASE foundation_types §Iso8601_date_time (the (,|.)sss value form + is_decimal_sign_comma)"
+  - "SM openehr_platform §I_EHR_COMPOSITION.create_composition"
+applies: { rm: ">=1.0.2" }
+requires:
+  server: any
+  templates: [cnf.opt.minimal_event]
+  ehr: { commits: none }                 # mints ${ehr_id}
+data_sets: [cnf.composition.minimal_event.comma_fraction]
+ambiguities: [AMB-171]
+flow:
+  - step: 1
+    call: create_composition
+    format: canonical-json
+    with: { ehr_id: "${ehr_id}", composition: "${ds:cnf.composition.minimal_event.comma_fraction}" }
+    expect: created
+    capture: { version_uid: created.version_uid }
+  - step: 2
+    call: get_composition_at_version
+    format: canonical-json
+    with: { ehr_id: "${ehr_id}", version_uid: "${version_uid}" }
+    expect: ok
+    assert:
+      - { assert: instance_of, rm_type: COMPOSITION }
+      # The committed lexical form, verbatim — the comma intact.
+      - { assert: field, path: "context/start_time/value", equals: "2021-09-21T21:52:31,927-03:00" }


### PR DESCRIPTION
Closes #664. The comma sibling of `-datetime_lexical`: a COMPOSITION commit whose `DV_DATE_TIME` fraction uses the ISO 8601 COMMA decimal sign (BASE `iso8601_date_time` `[(,|.)sss]` + `is_decimal_sign_comma()`; AMB-171 records it settled-legal), read back byte-identical per the verbatim-preservation docs text (`Resources.md` §Datetime format). The extended offset is kept so exactly one variable is isolated. New provenance-stamped fixture + manifest entry. Gates: validate **770 cases / 0 findings**, the claim/gate suites 17/17. Drives at the batch pipeline run.