### PR TITLE
fix(cnf): the comma-fraction fixture's missing manifest entry

### DIFF
--- a/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
+++ b/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
@@ -79,6 +79,13 @@ cnf.composition.minimal_event.v1:
   validity: { verdict: valid }
   template_id: "minimal_evaluation.en.v1"
   provenance: "openEHR CNF Robot corpus (vendored docs/specs/openehr/CNF/tests/platform/robot @ the CNF pin); re-adjudicated 2026-07-21 to spec-text-only evidence"
+cnf.composition.minimal_event.comma_fraction:
+  source: fixtures/composition/minimal_event.comma_fraction.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity: { verdict: valid }
+  template_id: "minimal_evaluation.en.v1"
+  provenance: "authored 2026-07-29 for the comma-decimal-sign lexical case: minimal_event.v1 with the EVENT_CONTEXT.start_time fraction rendered with the ISO 8601 COMMA decimal sign (BASE iso8601_date_time value form [(,|.)sss] + is_decimal_sign_comma(); AMB-171 records the comma as settled-legal), extended offset kept"
 cnf.composition.minimal_event.v2:
   source: fixtures/composition/minimal_event.v2.json
   format: canonical-json


### PR DESCRIPTION
PR #665 committed the case + fixture but the corpus manifest entry was staged against the wrong path case (`manifest.yaml` vs the tracked `MANIFEST.yaml`) and silently missed the commit — a clean checkout of develop fails validate (the case references `cnf.composition.minimal_event.comma_fraction`, which the committed manifest lacks). This adds the entry; validate on the complete tree: 770 cases / 0 findings.