### PR TITLE
fix(cnf-runner): the POC window's two 100%-error operations — Admin principal + RM-valid status body

### DIFF
--- a/tools/cnf-runner/src/perf.rs
+++ b/tools/cnf-runner/src/perf.rs
@@ -349,6 +349,12 @@ pub enum Principal {
     /// base (ITS-REST `docs/smart_app_launch/master04-service_discovery.adoc`
     /// §Service Discovery).
     SmartPlatform,
+    /// The ixit `admin` instance — the ADMIN-role principal every
+    /// admin-gated stage rides (the same instance the functional admin
+    /// cases address with `on: admin`). A party that declares no admin
+    /// instance drops the journeys that need it, exactly like the other
+    /// boundary principals.
+    Admin,
 }
 
 impl PerfOp {
@@ -463,6 +469,10 @@ impl PerfOp {
             PerfOp::UnauthenticatedProbe => Principal::Unauthenticated,
             PerfOp::ReadonlyWriteDenied => Principal::ReadOnly,
             PerfOp::SmartConfigurationRead => Principal::SmartPlatform,
+            // The activity report is admin-gated on the served extension
+            // route (the 2026-07-29 POC window drove it with the primary
+            // principal and 403'd on every arrival).
+            PerfOp::AdminContributionReport => Principal::Admin,
             _ => Principal::Primary,
         }
     }
@@ -1659,6 +1669,7 @@ mod tests {
                 PerfOp::UnauthenticatedProbe
                     | PerfOp::ReadonlyWriteDenied
                     | PerfOp::SmartConfigurationRead
+                    | PerfOp::AdminContributionReport
             );
             assert_eq!(
                 op.principal() == Principal::Primary,

--- a/tools/cnf-runner/src/perf_run/client.rs
+++ b/tools/cnf-runner/src/perf_run/client.rs
@@ -310,6 +310,7 @@ impl MintedGrant {
 /// address them.
 const UNAUTHENTICATED_INSTANCE: &str = "unauthenticated";
 const READONLY_INSTANCE: &str = "readonly";
+const ADMIN_INSTANCE: &str = "admin";
 
 /// Every principal a measured window drives: the party's default `sut`
 /// instance plus the optional boundary/platform principals.
@@ -318,6 +319,7 @@ pub struct PerfPrincipals {
     primary: PerfClient,
     unauthenticated: Option<PerfClient>,
     readonly: Option<PerfClient>,
+    admin: Option<PerfClient>,
     smart_platform: Option<PerfClient>,
 }
 
@@ -355,6 +357,7 @@ impl PerfPrincipals {
             primary,
             unauthenticated: named(UNAUTHENTICATED_INSTANCE)?,
             readonly: named(READONLY_INSTANCE)?,
+            admin: named(ADMIN_INSTANCE)?,
             smart_platform,
         })
     }
@@ -366,6 +369,7 @@ impl PerfPrincipals {
             primary,
             unauthenticated: None,
             readonly: None,
+            admin: None,
             smart_platform: None,
         }
     }
@@ -381,6 +385,13 @@ impl PerfPrincipals {
     #[must_use]
     pub fn with_readonly(mut self, client: PerfClient) -> Self {
         self.readonly = Some(client);
+        self
+    }
+
+    /// Add the ADMIN-role principal.
+    #[must_use]
+    pub fn with_admin(mut self, client: PerfClient) -> Self {
+        self.admin = Some(client);
         self
     }
 
@@ -407,6 +418,7 @@ impl PerfPrincipals {
             Principal::Unauthenticated => self.unauthenticated.as_ref(),
             Principal::ReadOnly => self.readonly.as_ref(),
             Principal::SmartPlatform => self.smart_platform.as_ref(),
+            Principal::Admin => self.admin.as_ref(),
         }
     }
 

--- a/tools/cnf-runner/src/perf_run/pack.rs
+++ b/tools/cnf-runner/src/perf_run/pack.rs
@@ -296,10 +296,21 @@ pub(crate) fn contribution_body(
 /// subject, an `other_details` note stamped with the simulated clock (the
 /// admission/discharge status touch).
 pub(crate) fn ehr_status_body(offset_s: u64) -> Vec<u8> {
+    // An EHR_STATUS is an archetype root, so the ARCHETYPED block is
+    // mandatory and the root archetype_node_id equals its archetype_id (RM
+    // common locatable.adoc §Invariants Archetyped_valid +
+    // §archetype_node_id) — the 2026-07-29 POC window sent a root-less body
+    // and the server rightly 422'd every update arrival.
     let body = serde_json::json!({
         "_type": "EHR_STATUS",
         "name": { "_type": "DV_TEXT", "value": "EHR Status" },
         "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
+        "archetype_details": {
+            "_type": "ARCHETYPED",
+            "archetype_id": { "_type": "ARCHETYPE_ID",
+                               "value": "openEHR-EHR-EHR_STATUS.generic.v1" },
+            "rm_version": "1.1.0"
+        },
         "subject": { "_type": "PARTY_SELF" },
         "is_queryable": true,
         "is_modifiable": true,

--- a/tools/cnf-runner/src/perf_run/schedule.rs
+++ b/tools/cnf-runner/src/perf_run/schedule.rs
@@ -512,6 +512,7 @@ mod tests {
             principals
                 .with_unauthenticated(client.clone())
                 .with_readonly(client.clone())
+                .with_admin(client.clone())
                 .with_smart_platform(client)
         } else {
             principals


### PR DESCRIPTION
The POC window (class NOT EARNED, error_rate 1.3% > 0) had exactly two error sources, both runner defects — the app was right both times:

1. **`admin_contribution_report` 68/68**: the stage drives the admin-gated activity-report extension route but `PerfOp::principal()` had no Admin arm — every arrival rode `Principal::Primary` into a 403 (the same defect class PR #661 fixed for the functional batteries, one layer over). `Principal::Admin` now resolves the ixit's `admin` instance like the other boundary principals; an undeclared party drops the journey and renormalizes.
2. **`ehr_status_update` 28/28**: `pack::ehr_status_body` carried a root `archetype_node_id` with no `archetype_details` — RM-invalid at an archetype root (`locatable.adoc` `Archetyped_valid`), rightly 422'd on every arrival. The body now carries the ARCHETYPED block.

Latency and throughput had already cleared the floors (worst p99 362 ms vs the class bound; 2.04/s vs 2/s), so the POC re-run after this merge should earn. Gates: nextest **248/248** (the vocabulary-pinning tests extend to the new principal), clippy unchanged, fmt clean.