### PR TITLE
test(cnf): requires.party_relationship provisioning + the archive_parties relationship-id refusal case

### DIFF
--- a/app/ehrbase-rest/tests/admin_extension_http.rs
+++ b/app/ehrbase-rest/tests/admin_extension_http.rs
@@ -289,6 +289,159 @@ async fn the_archive_routes_refuse_unknown_malformed_and_shapeless_requests() {
     }
 }
 
+/// Create a demographic resource on `segment` and return its
+/// `VERSIONED_OBJECT` uid (the `ETag` carries the `OBJECT_VERSION_ID`; its root
+/// is the container).
+async fn create_demographic(app: &Router, segment: &str, body: &serde_json::Value) -> String {
+    let request = Request::builder()
+        .method("POST")
+        .uri(format!("{BASE}/demographic/{segment}"))
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body.to_string()))
+        .expect("request");
+    let response = app.clone().oneshot(request).await.expect("response");
+    assert_eq!(
+        response.status(),
+        StatusCode::CREATED,
+        "create {segment} must succeed"
+    );
+    let etag = response
+        .headers()
+        .get(header::ETAG)
+        .and_then(|v| v.to_str().ok())
+        .expect("ETag")
+        .trim_start_matches("W/")
+        .trim_matches('"')
+        .to_owned();
+    etag.split("::")
+        .next()
+        .expect("versioned object uid")
+        .to_owned()
+}
+
+/// A minimal demographic PARTY of `rm_type` (RM demographic `party.adoc`
+/// §Invariants, `Identities_valid`: at least one `PARTY_IDENTITY`).
+fn party_body(rm_type: &str, archetype: &str, name: &str) -> serde_json::Value {
+    serde_json::json!({
+        "_type": rm_type,
+        "archetype_node_id": archetype,
+        "archetype_details": { "_type": "ARCHETYPED",
+            "archetype_id": { "_type": "ARCHETYPE_ID", "value": archetype },
+            "rm_version": "1.1.0" },
+        "name": { "_type": "DV_TEXT", "value": name },
+        "identities": [{
+            "_type": "PARTY_IDENTITY",
+            "archetype_node_id": "at0001",
+            "name": { "_type": "DV_TEXT", "value": "legal name" },
+            "details": {
+                "_type": "ITEM_TREE",
+                "archetype_node_id": "at0002",
+                "name": { "_type": "DV_TEXT", "value": "structure" },
+                "items": [{
+                    "_type": "ELEMENT",
+                    "archetype_node_id": "at0003",
+                    "name": { "_type": "DV_TEXT", "value": "label" },
+                    "value": { "_type": "DV_TEXT", "value": name }
+                }]
+            }
+        }]
+    })
+}
+
+/// `archive_parties` selects PARTY version containers, so a
+/// `PARTY_RELATIONSHIP`'s container id is refused exactly like an id that names
+/// nothing: SM `i_admin_archive.adoc` §`archive_parties` takes `party_ids` and
+/// declares `party_id_does_not_exist` as its only error, and RM demographic
+/// `master02-demographic_package.adoc` puts every PARTY in "its own Version
+/// container" (§Versioning Semantics) while relationships are stored "as part
+/// of the data of the PARTY designated as the source" (§Party Relationships) —
+/// a relationship travels with the parties the call selects and is never itself
+/// a selectable party id. All-or-nothing: the party named alongside it stays
+/// unarchived, and the same party archives fine on its own.
+#[tokio::test]
+async fn archiving_a_party_relationship_id_is_refused_like_an_unknown_party() {
+    let (_pg, app) = app(true).await;
+
+    let source = create_demographic(
+        &app,
+        "person",
+        &party_body("PERSON", "openEHR-DEMOGRAPHIC-PERSON.person.v1", "Jane Doe"),
+    )
+    .await;
+    let target = create_demographic(
+        &app,
+        "organisation",
+        &party_body(
+            "ORGANISATION",
+            "openEHR-DEMOGRAPHIC-ORGANISATION.organisation.v1",
+            "General Hospital",
+        ),
+    )
+    .await;
+    // RM demographic master02 §Party Relationships: source/target are
+    // "OBJECT_REFs containing HIER_OBJECT_IDs to denote the Version container
+    // of a Party", so the refs name the two containers just created.
+    let relationship = create_demographic(
+        &app,
+        "party_relationship",
+        &serde_json::json!({
+            "_type": "PARTY_RELATIONSHIP",
+            "archetype_node_id": "openEHR-DEMOGRAPHIC-PARTY_RELATIONSHIP.relationship.v1",
+            "name": { "_type": "DV_TEXT", "value": "patient-of" },
+            "source": { "_type": "PARTY_REF", "namespace": "demographic", "type": "PERSON",
+                        "id": { "_type": "HIER_OBJECT_ID", "value": source } },
+            "target": { "_type": "PARTY_REF", "namespace": "demographic", "type": "ORGANISATION",
+                        "id": { "_type": "HIER_OBJECT_ID", "value": target } }
+        }),
+    )
+    .await;
+
+    let (status, body) = send(
+        &app,
+        post_json(
+            "/admin/archive/parties",
+            &format!(r#"{{"party_ids":["{relationship}"]}}"#),
+        ),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_FOUND,
+        "a PARTY_RELATIONSHIP id names no Party: {body}"
+    );
+
+    // Alongside a real party the refusal still covers the whole request, and
+    // that same party archives on its own — so the refusal is about the id's
+    // kind, not about the call.
+    let (status, body) = send(
+        &app,
+        post_json(
+            "/admin/archive/parties",
+            &format!(r#"{{"party_ids":["{source}","{relationship}"]}}"#),
+        ),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_FOUND,
+        "all-or-nothing: one relationship id refuses the whole set: {body}"
+    );
+
+    let (status, body) = send(
+        &app,
+        post_json(
+            "/admin/archive/parties",
+            &format!(r#"{{"party_ids":["{source}"]}}"#),
+        ),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::NO_CONTENT,
+        "the party itself archives: {body}"
+    );
+}
+
 // ── the dump/load pair (SM I_ADMIN_DUMP_LOAD) ────────────────────────────────
 
 /// A unique archive location for one test (the SM `file_sys_loc` parameter is

--- a/tools/cnf-runner/CLAUDE.md
+++ b/tools/cnf-runner/CLAUDE.md
@@ -69,8 +69,17 @@ the dev-compose defaults are exported by `scripts/conformance.sh`.
   must not drive a released one just to reach its precondition, or the
   realization it evidences stops being the one it is about. Provisioning
   therefore belongs in `requires` (`server`/`templates`/`ehr`/`directory`/
-  `party`/`commit` — `requires.party` mints `${party_id}`, the VERSIONED_OBJECT
-  uid the SM admin operations take), never as a flow step.
+  `party`/`party_relationship`/`commit` — `requires.party` mints `${party_id}`,
+  the VERSIONED_OBJECT uid the SM admin operations take, and
+  `requires.party_relationship` mints `${party_relationship_id}` the same way,
+  creating BOTH endpoint parties first and writing their container uids into the
+  relationship's `source`/`target` PARTY_REFs, as RM demographic
+  `master02-demographic_package.adoc` §Party Relationships requires:
+  "OBJECT_REFs containing HIER_OBJECT_IDs to denote the Version container of a
+  Party"), never as a flow step. Provisioning may itself drive an EXTENSION
+  route where the release surfaces no wire for the precondition (the
+  relationship create — register AMB-32), so such a requirement is usable only
+  on a party that serves that family.
 - **Every closed vocabulary is a Rust enum/newtype** (outcome kinds,
   selectors, header matchers, capture sources, the `${…}` reference grammar,
   dispositions, sentinels): illegal states unrepresentable. New vocabulary

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_ARCHIVE.archive_parties-relationship_id_refused.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_ARCHIVE.archive_parties-relationship_id_refused.yaml
@@ -1,0 +1,62 @@
+# Official master12 case (chapter TBD — AMB-33; NATURAL family ids).
+#
+# REALIZATION, re-derived first-hand 2026-07-29 (#680): ITS-REST 1.1.0 still
+# realizes only admin_ehr_delete / admin_ehr_delete_all of the SM Admin surface
+# and nothing in the release moves a resource to archival storage (register
+# AMB-33) — but this product SERVES the operation on a declared extension route
+# under /admin/archive/, so the case is EXECUTED against that route instead of
+# resolving excused. It gates the DemographicArchive capability only; no openEHR profile tier
+# and no ITS-REST wire-conformance claim rests on it.
+#
+# THE BEHAVIOUR: the SM signature takes `party_ids`, and its only declared error
+# is `party_id_does_not_exist` (i_admin_archive.adoc §archive_parties). A
+# PARTY_RELATIONSHIP's version container is not a Party's: RM demographic
+# master02-demographic_package.adoc §Versioning Semantics puts every PARTY in
+# "its own Version container" and §Party Relationships stores relationships "as
+# part of the data of the PARTY designated as the source" — so a relationship
+# travels with the parties the call selects and is never itself a selectable
+# party id. Naming one is therefore the same refusal as naming an id that
+# exists nowhere, and the all-or-nothing law leaves the repository untouched.
+id: I_ADMIN_ARCHIVE.archive_parties-relationship_id_refused
+kind: functional
+component: ADMIN
+sm_operation: I_ADMIN_ARCHIVE.archive_parties
+capabilities: [DemographicArchive]
+exercises: [AdminApi]
+profiles: [OPTIONS]
+test_purpose: "Archiving a set that names a PARTY_RELATIONSHIP instead of a Party is rejected as not found."
+description: "Archive a set naming an existing relationship's id"
+spec_refs:
+  - "SM openehr_platform §I_ADMIN_ARCHIVE.archive_parties"
+  - "RM demographic master02-demographic_package.adoc §Party Relationships + §Versioning Semantics"
+  - "CNF platform_test_schedule master12 §archive_parties"
+applies: { rm: ">=1.0.2" }
+guards:
+  - "EXTENSION ROUTE — no openEHR spec governs the /admin/archive/* routes; our own design/extension, declared in vocab/wire_surface.yaml served_extensions and adjudicated by register AMB-33. The row gates the DemographicArchive CAPABILITY verdict only, never ITS-REST wire conformance"
+  - "ITS-REST Admin API is DEVELOPMENT-stage — admin.openapi.yaml carries x-status: DEVELOPMENT (not STABLE); guarded until the Admin API stabilises"
+  - "The relationship this case names must EXIST, so that the refusal is about the id's KIND and not about it being unknown; minting it is precondition state (requires.party_relationship), which drives the /demographic/party_relationship extension route (register AMB-32) — a party serving neither extension family runs neither half"
+# The relationship is PROVISIONED STATE, not a flow step: a case whose subject
+# is `archive_parties` must drive nothing else, or the realization it evidences
+# stops being the one it is about. `requires.party_relationship` mints
+# `${party_relationship_id}` — the relationship's VERSIONED_OBJECT uid — after
+# creating both endpoint parties and writing their container uids into its
+# source/target PARTY_REFs (RM demographic master02 §Party Relationships: the
+# references are "OBJECT_REFs containing HIER_OBJECT_IDs to denote the Version
+# container of a Party").
+requires:
+  server: any
+  party_relationship:
+    source: cnf.demographic.person.v1
+    target: cnf.demographic.organisation.v1
+    relationship: cnf.demographic.party_relationship.v1
+data_sets:
+  - cnf.demographic.person.v1
+  - cnf.demographic.organisation.v1
+  - cnf.demographic.party_relationship.v1
+flow:
+  - step: 1
+    call: archive_parties
+    on: admin                              # ADMIN-role principal (ixit) — the route is admin-gated
+    with: { party_ids: ["${party_relationship_id}"] }
+    expect: not_found
+ambiguities: [AMB-33]

--- a/tools/cnf-runner/artifacts/vocab/capability_matrix.yaml
+++ b/tools/cnf-runner/artifacts/vocab/capability_matrix.yaml
@@ -268,7 +268,7 @@ EhrArchive: { family: Platform, tier: OPTIONS, required: false, realization: ext
 # `requires.party` precondition, so its FLOW stays extension-only). The
 # evidence_exception is GONE, the row is `realization: extension`, and the
 # workload_exclusion reason is re-derived to the destructive/one-shot family.
-DemographicArchive: { family: Platform, tier: OPTIONS, required: false, realization: extension, min_cases: 7, workload_exclusion: { register: AMB-170, reason: "destructive mid-measurement: archiving is a lifecycle transition applied to a named set of parties, so every arrival would move part of the demographic population the measured window is bound to into the archival tier - the same one-shot/destructive family as physical deletion and the EHR archive half" }, source: "CNF profiles master03-profiles.adoc §Functional (Admin: Demographic Archive)" }
+DemographicArchive: { family: Platform, tier: OPTIONS, required: false, realization: extension, min_cases: 8, workload_exclusion: { register: AMB-170, reason: "destructive mid-measurement: archiving is a lifecycle transition applied to a named set of parties, so every arrival would move part of the demographic population the measured window is bound to into the archival tier - the same one-shot/destructive family as physical deletion and the EHR archive half" }, source: "CNF profiles master03-profiles.adoc §Functional (Admin: Demographic Archive)" }
 # REALIZED ON THE EXTENSION SURFACE (#659, 2026-07-29). The released absence is
 # CONFIRMED unchanged first-hand: seven API groups (overview, system, ehr,
 # demographic, query, definition, admin) and no message/extract/tdd group in

--- a/tools/cnf-runner/schemas/case-core.schema.json
+++ b/tools/cnf-runner/schemas/case-core.schema.json
@@ -336,6 +336,37 @@
             }
           ]
         },
+        "party_relationship": {
+          "anyOf": [
+            {
+              "const": "none"
+            },
+            {
+              "type": "object",
+              "description": "A PARTY_RELATIONSHIP provisioned between two REAL parties (mints `${party_relationship_id}`, its VERSIONED_OBJECT uid). The two endpoint parties are created first and their container uids written into the relationship's source/target PARTY_REFs — RM demographic master02-demographic_package.adoc §Party Relationships: the references are \"OBJECT_REFs containing HIER_OBJECT_IDs to denote the Version container of a Party\". The relationship create has no released wire (register AMB-32, the `party-relationship` served_extensions family).",
+              "additionalProperties": false,
+              "required": [
+                "source",
+                "target",
+                "relationship"
+              ],
+              "properties": {
+                "source": {
+                  "type": "string",
+                  "pattern": "^[a-z0-9_-]+(\\.[a-z0-9_-]+)*$"
+                },
+                "target": {
+                  "type": "string",
+                  "pattern": "^[a-z0-9_-]+(\\.[a-z0-9_-]+)*$"
+                },
+                "relationship": {
+                  "type": "string",
+                  "pattern": "^[a-z0-9_-]+(\\.[a-z0-9_-]+)*$"
+                }
+              }
+            }
+          ]
+        },
         "commit": {
           "type": "array",
           "items": {

--- a/tools/cnf-runner/src/exec/driver.rs
+++ b/tools/cnf-runner/src/exec/driver.rs
@@ -1870,7 +1870,38 @@ impl HttpDriver<'_> {
             return Ok(());
         };
         let payload = self.resolver.data_set(&key).map_err(|e| e.to_string())?;
-        let binding = self.binding_for(case, "I_DEMOGRAPHIC_SERVICE.create_party")?;
+        if let Some(uid) = self.create_party(case, &payload, vars)? {
+            vars.set(
+                CaptureName::parse("party_id").map_err(|e| e.to_string())?,
+                Captured::Scalar(uid),
+            );
+        }
+        Ok(())
+    }
+
+    /// Create one demographic PARTY from a corpus payload and return its
+    /// `VERSIONED_OBJECT` uid.
+    ///
+    /// The route is the one the payload's own concrete RM type names: ITS-REST
+    /// 1.1.0 surfaces one create endpoint per concrete PARTY subtype (the
+    /// `create_party` binding realizes PERSON, its `agent`/`group`/
+    /// `organisation`/`role` variants the other four), so a payload's `_type`
+    /// selects the variant rather than the caller guessing one.
+    fn create_party(
+        &mut self,
+        case: &CaseCore,
+        payload: &Value,
+        vars: &VarStore,
+    ) -> Result<Option<String>, String> {
+        let variant = Self::party_create_variant(payload)?;
+        let binding =
+            self.binding_for_variant(case, "I_DEMOGRAPHIC_SERVICE.create_party", variant)?;
+        if binding.variant.as_deref() != variant {
+            return Err(format!(
+                "create_party declares no {} realization for the provisioned party payload",
+                variant.unwrap_or("person"),
+            ));
+        }
         let instance = self.provisioning_instance(case)?;
         let request_spec = binding
             .request
@@ -1889,7 +1920,117 @@ impl HttpDriver<'_> {
         )?;
         let base = instance.base_url.trim_end_matches('/');
         let url = format!("{base}{}", request_spec.path.raw());
-        let exchange = self.send(request_spec.method, &url, &headers, Some(&payload), true)?;
+        let exchange = self.send(request_spec.method, &url, &headers, Some(payload), true)?;
+        Ok(binding
+            .captures
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .find(|(n, _)| n.as_str() == "versioned_object_uid")
+            .and_then(|(_, spec)| Self::extract_capture(&exchange, binding, spec, vars)))
+    }
+
+    /// The `create_party` binding variant a party payload's concrete RM type
+    /// selects — `None` for PERSON, which the variant-less binding realizes.
+    fn party_create_variant(payload: &Value) -> Result<Option<&'static str>, String> {
+        match payload.get("_type").and_then(Value::as_str) {
+            Some("PERSON") => Ok(None),
+            Some("AGENT") => Ok(Some("agent")),
+            Some("GROUP") => Ok(Some("group")),
+            Some("ORGANISATION") => Ok(Some("organisation")),
+            Some("ROLE") => Ok(Some("role")),
+            other => Err(format!(
+                "a provisioned party payload must be a concrete PARTY subtype \
+                 (PERSON | AGENT | GROUP | ORGANISATION | ROLE), got {}",
+                other.unwrap_or("<no _type>")
+            )),
+        }
+    }
+
+    /// `party_relationship`: mint `${party_relationship_id}` — the relationship's
+    /// `VERSIONED_OBJECT` uid — by creating both endpoint parties over the
+    /// released demographic wire and then the relationship between them.
+    ///
+    /// The endpoint substitution is what RM demographic
+    /// `master02-demographic_package.adoc` §Party Relationships requires:
+    /// `source`/`target` are "`OBJECT_REFs` containing `HIER_OBJECT_IDs` to
+    /// denote the Version container of a Party, rather than
+    /// `OBJECT_VERSION_IDs`" — so each `PARTY_REF.id.value` becomes the
+    /// container uid the create just minted, and the corpus payload's declared
+    /// `PARTY_REF.type` must be the type of the party provisioned for that end
+    /// (a mismatch is a catalogue defect, refused here rather than sent).
+    ///
+    /// NOTE: the relationship create itself is driven over the SUT's own
+    /// `party-relationship` extension route — no openEHR spec governs it
+    /// (register AMB-32), the released ITS-REST surfaces no
+    /// `PARTY_RELATIONSHIP` resource — so this precondition is only available
+    /// on a party that serves that family.
+    fn provision_party_relationship(
+        &mut self,
+        case: &CaseCore,
+        vars: &mut VarStore,
+    ) -> Result<(), String> {
+        let Some(crate::model::case::PartyRelationshipRequirement::Exists {
+            source,
+            target,
+            relationship,
+        }) = case.requires.party_relationship.clone()
+        else {
+            return Ok(());
+        };
+        let mut body = self
+            .resolver
+            .data_set(&relationship)
+            .map_err(|e| e.to_string())?;
+        for (end, key) in [("source", &source), ("target", &target)] {
+            let payload = self.resolver.data_set(key).map_err(|e| e.to_string())?;
+            let party_type = payload
+                .get("_type")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_owned();
+            let declared = body
+                .get(end)
+                .and_then(|r| r.get("type"))
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            if declared != party_type {
+                return Err(format!(
+                    "requires.party_relationship: {relationship} declares {end} PARTY_REF.type \
+                     {declared:?}, but {key} provisions a {party_type:?}"
+                ));
+            }
+            let uid = self
+                .create_party(case, &payload, vars)?
+                .ok_or_else(|| format!("provisioning the {end} party minted no uid"))?;
+            *body
+                .get_mut(end)
+                .and_then(|r| r.get_mut("id"))
+                .and_then(|id| id.get_mut("value"))
+                .ok_or_else(|| {
+                    format!("requires.party_relationship: {relationship} has no {end}.id.value")
+                })? = Value::String(uid);
+        }
+        let binding = self.binding_for(case, "I_DEMOGRAPHIC_SERVICE.create_party_relationship")?;
+        let instance = self.provisioning_instance(case)?;
+        let request_spec = binding
+            .request
+            .as_ref()
+            .ok_or_else(|| "create_party_relationship unrealized".to_owned())?;
+        let headers = Self::compose_headers(
+            self.set,
+            self.ixit,
+            case,
+            None,
+            binding,
+            instance,
+            vars,
+            None,
+            self.spec_versions,
+        )?;
+        let base = instance.base_url.trim_end_matches('/');
+        let url = format!("{base}{}", request_spec.path.raw());
+        let exchange = self.send(request_spec.method, &url, &headers, Some(&body), true)?;
         if let Some((_, spec)) = binding
             .captures
             .as_deref()
@@ -1899,7 +2040,7 @@ impl HttpDriver<'_> {
             && let Some(value) = Self::extract_capture(&exchange, binding, spec, vars)
         {
             vars.set(
-                CaptureName::parse("party_id").map_err(|e| e.to_string())?,
+                CaptureName::parse("party_relationship_id").map_err(|e| e.to_string())?,
                 Captured::Scalar(value),
             );
         }
@@ -2493,6 +2634,7 @@ impl StepDriver for HttpDriver<'_> {
             }
         }
         self.provision_party(case, vars)?;
+        self.provision_party_relationship(case, vars)?;
         self.provision_commit_sets(case, vars)?;
         Ok(Provisioned::Ready)
     }

--- a/tools/cnf-runner/src/model/case.rs
+++ b/tools/cnf-runner/src/model/case.rs
@@ -193,6 +193,72 @@ impl<'de> Deserialize<'de> for PartyRequirement {
     }
 }
 
+/// The `requires.party_relationship` precondition.
+///
+/// A demographic `PARTY_RELATIONSHIP` is precondition STATE exactly as
+/// [`PartyRequirement`] is: the cases that operate ON an existing relationship
+/// — or, like the admin archive's party-only selection, on the boundary
+/// between a relationship and a party — must not drive its creation in the
+/// flow, or the realization they evidence stops being the one they are about.
+///
+/// The relationship is provisioned between two REAL parties. RM demographic
+/// `master02-demographic_package.adoc` §Party Relationships fixes what the
+/// endpoints are: "`PARTY_RELATIONSHIP._source_` and `_target_` are
+/// represented by references … `OBJECT_REFs` containing `HIER_OBJECT_IDs` to
+/// denote the Version container of a Party, rather than `OBJECT_VERSION_IDs`"
+/// — so provisioning creates each endpoint party first and writes its
+/// `VERSIONED_OBJECT` uid into the corresponding `PARTY_REF`, rather than
+/// committing a relationship whose endpoints name nothing on the server.
+///
+/// The relationship create itself has NO released wire (register AMB-32; the
+/// `party-relationship` `served_extensions` family) — no openEHR spec governs
+/// that route, so the requirement is only usable by a party that serves it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PartyRelationshipRequirement {
+    None,
+    /// A `PARTY_RELATIONSHIP` exists between two provisioned parties (mints
+    /// `${party_relationship_id}`, its `VERSIONED_OBJECT` uid).
+    Exists {
+        /// The corpus payload of the party at the relationship's `source` end.
+        source: CorpusKey,
+        /// The corpus payload of the party at the relationship's `target` end.
+        target: CorpusKey,
+        /// The corpus `PARTY_RELATIONSHIP` payload; its `source`/`target`
+        /// `PARTY_REF` ids are replaced by the two minted party uids.
+        relationship: CorpusKey,
+    },
+}
+
+impl<'de> Deserialize<'de> for PartyRelationshipRequirement {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Qualified {
+            source: CorpusKey,
+            target: CorpusKey,
+            relationship: CorpusKey,
+        }
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Raw {
+            Word(String),
+            Qualified(Qualified),
+        }
+        match Raw::deserialize(deserializer)? {
+            Raw::Word(w) if w == "none" => Ok(Self::None),
+            Raw::Word(w) => Err(D::Error::custom(format!(
+                "requires.party_relationship must be `none` or \
+                 {{ source, target, relationship }} corpus keys, got {w:?}"
+            ))),
+            Raw::Qualified(q) => Ok(Self::Exists {
+                source: q.source,
+                target: q.target,
+                relationship: q.relationship,
+            }),
+        }
+    }
+}
+
 /// Typed prerequisites — the schedule's precondition vocabulary. Every
 /// provisioned object mints a named handle usable as a flow variable.
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -214,6 +280,10 @@ pub struct Requires {
     /// `${party_id}`.
     #[serde(default)]
     pub party: Option<PartyRequirement>,
+    /// A demographic `PARTY_RELATIONSHIP` provisioned between two parties
+    /// before the flow; `Exists` mints `${party_relationship_id}`.
+    #[serde(default)]
+    pub party_relationship: Option<PartyRelationshipRequirement>,
     /// Corpus set keys pre-committed into the EHR by the runner (bulk setup
     /// is precondition state, never an un-anchored flow call).
     #[serde(default)]
@@ -243,6 +313,14 @@ impl Requires {
         // a provisioned PARTY publishes its VERSIONED_OBJECT uid
         if matches!(self.party, Some(PartyRequirement::Exists(_)))
             && let Ok(handle) = CaptureName::parse("party_id")
+        {
+            handles.push(handle);
+        }
+        // a provisioned PARTY_RELATIONSHIP publishes its VERSIONED_OBJECT uid
+        if matches!(
+            self.party_relationship,
+            Some(PartyRelationshipRequirement::Exists { .. })
+        ) && let Ok(handle) = CaptureName::parse("party_relationship_id")
         {
             handles.push(handle);
         }
@@ -553,6 +631,52 @@ mod tests {
 
         assert!(serde_json::from_value::<Requires>(serde_json::json!({ "ehr": "maybe" })).is_err());
         assert!(serde_json::from_value::<Requires>(serde_json::json!({ "srv": "empty" })).is_err());
+    }
+
+    #[test]
+    fn a_provisioned_party_relationship_mints_its_container_handle() {
+        let r: Requires = serde_json::from_value(serde_json::json!({
+            "party_relationship": {
+                "source": "cnf.demographic.person.v1",
+                "target": "cnf.demographic.organisation.v1",
+                "relationship": "cnf.demographic.party_relationship.v1"
+            }
+        }))
+        .unwrap();
+        assert!(matches!(
+            r.party_relationship,
+            Some(PartyRelationshipRequirement::Exists { .. })
+        ));
+        assert_eq!(
+            r.minted_handles()
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
+            vec!["party_relationship_id".to_owned()]
+        );
+
+        let r: Requires =
+            serde_json::from_value(serde_json::json!({ "party_relationship": "none" })).unwrap();
+        assert!(matches!(
+            r.party_relationship,
+            Some(PartyRelationshipRequirement::None)
+        ));
+        assert!(r.minted_handles().is_empty());
+
+        // Both ends and the relationship itself are mandatory: a partial block
+        // would provision a relationship with an unresolved endpoint.
+        assert!(
+            serde_json::from_value::<Requires>(serde_json::json!({
+                "party_relationship": { "relationship": "cnf.demographic.party_relationship.v1" }
+            }))
+            .is_err()
+        );
+        assert!(
+            serde_json::from_value::<Requires>(
+                serde_json::json!({ "party_relationship": "cnf.demographic.party_relationship.v1" })
+            )
+            .is_err()
+        );
     }
 
     #[test]

--- a/tools/cnf-runner/src/schema.rs
+++ b/tools/cnf-runner/src/schema.rs
@@ -131,6 +131,18 @@ fn requires_def() -> Value {
                 { "const": "none" },
                 { "type": "string", "pattern": CORPUS_KEY_PATTERN }
             ] },
+            "party_relationship": { "anyOf": [
+                { "const": "none" },
+                { "type": "object",
+                  "description": "A PARTY_RELATIONSHIP provisioned between two REAL parties (mints `${party_relationship_id}`, its VERSIONED_OBJECT uid). The two endpoint parties are created first and their container uids written into the relationship's source/target PARTY_REFs — RM demographic master02-demographic_package.adoc §Party Relationships: the references are \"OBJECT_REFs containing HIER_OBJECT_IDs to denote the Version container of a Party\". The relationship create has no released wire (register AMB-32, the `party-relationship` served_extensions family).",
+                  "additionalProperties": false,
+                  "required": ["source", "target", "relationship"],
+                  "properties": {
+                      "source": { "type": "string", "pattern": CORPUS_KEY_PATTERN },
+                      "target": { "type": "string", "pattern": CORPUS_KEY_PATTERN },
+                      "relationship": { "type": "string", "pattern": CORPUS_KEY_PATTERN }
+                  } }
+            ] },
             "commit": string_array(Some(CORPUS_KEY_PATTERN)),
             "instances": { "type": "object",
                 "propertyNames": { "pattern": IDENT_PATTERN },

--- a/tools/cnf-runner/src/validate.rs
+++ b/tools/cnf-runner/src/validate.rs
@@ -19,7 +19,9 @@ use crate::load::LoadError;
 use crate::model::assertion::{Assertion, EquivalentTarget, assertion_refs};
 use crate::model::binding::OperationBinding;
 use crate::model::capability::Realization;
-use crate::model::case::{CaseCore, ExpectSpec, FlowStep, MatrixCell, Parameters};
+use crate::model::case::{
+    CaseCore, ExpectSpec, FlowStep, MatrixCell, Parameters, PartyRelationshipRequirement,
+};
 use crate::model::wire_surface::{ServedExtension, WireSurface};
 use crate::refgrammar::{CaptureField, TimeExpr, ValueRef};
 use crate::vocab::{CaseKind, CaseStatus, Disposition, FormatName, Iteration, OutcomeKind};
@@ -1171,12 +1173,24 @@ fn check_references(case: &CaseCore, who: &str, set: &ArtifactSet, findings: &mu
         }
     }
 
+    // The three payloads a `requires.party_relationship` provisions (both
+    // endpoint parties + the relationship) resolve like any other corpus
+    // reference, so a typo is a catalogue finding here, not a drive-time error.
+    let relationship_keys: Vec<&CorpusKey> = match &case.requires.party_relationship {
+        Some(PartyRelationshipRequirement::Exists {
+            source,
+            target,
+            relationship,
+        }) => vec![source, target, relationship],
+        Some(PartyRelationshipRequirement::None) | None => Vec::new(),
+    };
     for key in case
         .data_sets
         .iter()
         .chain(case.requires.templates.iter())
         .chain(case.requires.commit.iter())
         .chain(case.constraint_context.as_ref().map(|c| &c.template))
+        .chain(relationship_keys)
     {
         check_ds_ref(key, None, who, set, findings);
     }


### PR DESCRIPTION
Closes #680 — the last #671-flagged gap: the `requires` vocabulary can now mint a PARTY_RELATIONSHIP, unlocking the refusal branch no case could reach.

## The vocabulary (closed, schema-published)

`requires.party_relationship { source, target, relationship }` (all three corpus refs mandatory, swept by `check_ds_ref` so a typo is a catalogue finding). Provisioning drives three requests through the ONE `compose_headers` path: create source party (route selected from the payload's own `_type` — a non-concrete subtype is a loud provisioning error), create target party, then `POST /demographic/party_relationship` with `source`/`target` `PARTY_REF`s rewritten to the minted VERSION-container uids per RM demographic `master02` §Party Relationships (HIER_OBJECT_IDs, never OBJECT_VERSION_IDs), with a declared-type-vs-provisioned-type consistency check before anything goes on the wire. Mints `${party_relationship_id}`.

## The case

`I_ADMIN_ARCHIVE.archive_parties-relationship_id_refused` (the `I_ADMIN_ARCHIVE.` prefix matching its `sm_operation` + the seven PR-#676 siblings — the issue text's `I_ADMIN_SERVICE.` was a slip): one call, `party_ids: [${party_relationship_id}]`, `expect: not_found`. Contract: SM `i_admin_archive.adoc` declares exactly one error (`party_id_does_not_exist`); RM demographic §Versioning Semantics + §Party Relationships make a relationship data OF its source party's container, never a selectable party id. DemographicArchive `min_cases` 7 → 8.

## App side

No leniency found — `mark_party_vos_archived` kind-checks ids against the five concrete PARTY kinds before any write, so a relationship id is the all-or-nothing 404 already. The branch is now PINNED by `archiving_a_party_relationship_id_is_refused_like_an_unknown_party` (HTTP: relationship-id alone 404, `[party, relationship]` 404 all-or-nothing, party alone 204).

## Gates (post-rebase onto PR #681's develop)

fmt clean · clippy zero new warnings (stash-compared, 25↔25 on tools) · `nextest -p cnf-runner` 249/249 (schema-drift green with the regenerated committed schema) · `nextest -p ehrbase -p ehrbase-rest` 1267/1267 · `validate --specs` **838 cases, 230 bindings, 0 findings**.

No changelog entry: runner + catalogue + tests only, no product behaviour change (`no-changelog`).

Known follow-up (not in this PR): `run.rs::extension_family` inspects flow steps only, so a party claiming DemographicArchive without a served `party-relationship` route would fail this case at provisioning instead of recording not-applicable-with-citation — pre-existing selection-law shape, surfaced one step further by provisioning-driven extension routes.