### PR TITLE
feat(terminology): simultaneous multi-provider routing, OAuth2 to the TS, binding-resolved validation at commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -866,6 +866,41 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
+- **Several terminology servers can now serve one instance at the same time.**
+  Every entry under `[terminology.external.providers]` is started up, not just
+  `default`, and a new `[terminology.external.routes]` map sends each
+  terminology to the server that serves it — the key is a terminology id
+  (`SNOMED-CT`) or a system URI (`http://snomed.info/sct`), matched
+  case-insensitively, and the value names a provider. A terminology with no
+  route goes to the provider named `default` (or to the sole configured one).
+  Routing applies to the whole terminology surface: the `/terminology/*`
+  extension API, AQL `TERMINOLOGY(…)`, and composition validation. So SNOMED CT
+  can live on one server while LOINC or ICD live on others — the deployment
+  reality openEHR's terminology chapter describes. Configuring a route to a
+  provider that does not exist is now a startup error instead of a silent
+  fallback.
+- **Terminology servers can require OAuth2.** A provider's `oauth2_client` key
+  now does something: it names an entry under
+  `[terminology.external.oauth2_clients]` (token endpoint, client id, client
+  secret or `client_secret_file`, optional scopes, `refresh_leeway_secs`, and
+  `client_secret_basic` / `client_secret_post`), and the CDR obtains a
+  client-credentials access token and sends it as a bearer credential on every
+  request to that server. The token is cached and renewed shortly before it
+  expires, so a validation burst costs one token request per token lifetime. A
+  refused grant fails the call with a clear error — a request is never sent
+  unauthenticated as a fallback. Mutual TLS to a terminology server is still
+  not supported.
+- **Composition commits can now check archetype value-set bindings against a
+  live terminology server.** When a template binds an `ac` code to an external
+  terminology query, and `[terminology.external]` is enabled, committing a
+  COMPOSITION resolves that query and requires the coded value to be a member
+  of the value set it returns. A non-member is a `422` naming the path, the
+  code and the bound query. If the value set cannot be resolved at all (server
+  down, error response, no server configured for that terminology), the
+  existing `fail_on_error` switch decides: `false` (the default) accepts the
+  commit and logs a warning, `true` rejects it. With `[terminology.external]`
+  disabled — the shipped default — nothing is resolved, no request is made, and
+  commit behaviour is exactly as before.
 - **`POST /admin/dump` now serves the `openehr_canonical_xml` logical format,
   which used to answer `501`.** Both openEHR export formats are available:
   the default `openehr_canonical_json` keeps each version's content inline in

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2324,6 +2324,7 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "moka",
+ "oauth2",
  "object_store",
  "openehr-adl",
  "openehr-am",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ pin-project-lite = "0.2"
 
 # ── Authentication & authorization (do NOT hand-roll) ────────────────────────
 jsonwebtoken = { version = "10.4.0", features = ["aws_lc_rs"] }   # JWT encode/decode/validate; aws-lc-rs crypto provider (matches the rustls stack)
-oauth2 = "5"                        # OAuth2 client            (verify latest 5.x)
+oauth2 = { version = "5", default-features = false } # OAuth2 client (HTTP-client agnostic: we supply the pinned reqwest)
 openidconnect = "4"                 # OIDC / Keycloak          (verify latest 4.x)
 argon2 = "0.5"                      # password hashing (Argon2id)
 password-hash = "0.6.1"              # PHC string traits

--- a/app/ehrbase-server/src/main.rs
+++ b/app/ehrbase-server/src/main.rs
@@ -264,14 +264,21 @@ async fn serve(config_path: Option<&Path>, overrides: &[(String, String)]) -> an
             service.with_audit_store(ehrbase::system_log::store::AuditStore::new(pool.clone()));
     }
 
-    // Opt-in external FHIR terminology provider.
-    match config.terminology.external.default_provider() {
-        Some(Ok(provider)) => {
-            tracing::info!("external FHIR terminology provider configured");
-            service = service.with_external_terminology(Arc::new(provider));
-        }
-        Some(Err(e)) => return Err(e).context("initialising the external terminology provider"),
-        None => {}
+    // Opt-in external FHIR terminology servers — ALL configured providers,
+    // with the terminology→provider routing (a deployment binds several
+    // terminologies at once; BASE `architecture_overview/
+    // master12-terminology.adoc` §Overview).
+    if let Some(router) = ehrbase::service::terminology::router::TerminologyRouter::build(
+        &config.terminology.external,
+    )
+    .context("initialising the external terminology providers")?
+    {
+        tracing::info!(
+            providers = %router.provider_names().collect::<Vec<_>>().join(", "),
+            fail_on_error = router.fail_on_error(),
+            "external FHIR terminology providers configured"
+        );
+        service = service.with_terminology_router(Arc::new(router));
     }
 
     // Opt-in Subject Proxy FHIR-frame executor (fail-closed).

--- a/app/ehrbase/Cargo.toml
+++ b/app/ehrbase/Cargo.toml
@@ -42,6 +42,10 @@ sea-query.workspace = true
 sea-query-sqlx.workspace = true
 # `EHR_ACCESS` scheme-settings cache (per-ehr, invalidated on EHR_ACCESS commit).
 moka.workspace = true
+# Terminology-server authentication (`service::terminology::oauth2`): the
+# OAuth2 client-credentials grant (RFC 6749 §4.4) to a terminology server's
+# token endpoint. HTTP-client agnostic — the request rides the pinned reqwest.
+oauth2.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 # OPT 1.4 upload structure validation (`service::template`): a depth-aware scan

--- a/app/ehrbase/assets/ehrbase.default.toml
+++ b/app/ehrbase/assets/ehrbase.default.toml
@@ -222,16 +222,41 @@ publish_max_retries = 3
 api_enabled = false
 
 [terminology.external]
-enabled = false
-fail_on_error = false
-# Named FHIR R4 terminology-server providers (map; `default` or the sole one wins):
+enabled = false              # on: SM lookups, AQL TERMINOLOGY(), and
+                             # composition ac-code binding resolution route here
+fail_on_error = false        # TS unreachable/erroring: false = accept the
+                             # composition (fail-open), true = reject it (422)
+# Named FHIR R4 terminology-server providers (map). EVERY entry is materialised
+# — a deployment binds SNOMED CT, LOINC, ICD… to different servers at once:
 #? [terminology.external.providers.default]
 #? type = "fhir"
 #? url = "https://r4.ontoserver.csiro.au/fhir"
 #? operation = "validate_code"   # validate_code | expand
 #? connect_timeout_ms = 2000
 #? request_timeout_ms = 10000
-#? oauth2_client = "ts-client"
+#? cache_ttl_secs = 300
+#? cache_capacity = 10000
+#? oauth2_client = "ts-client"   # must name a [terminology.external.oauth2_clients.*]
+#? [terminology.external.providers.snomed]
+#? type = "fhir"
+#? url = "https://snowstorm.example.org/fhir"
+
+# Terminology → provider routing. Keys are terminology ids or system URIs
+# (matched case-insensitively, whole string); values name a provider above.
+# An unmatched terminology goes to `default` (or the sole provider):
+#? [terminology.external.routes]
+#? "SNOMED-CT" = "snomed"
+#? "http://snomed.info/sct" = "snomed"
+#? "http://loinc.org" = "default"
+
+# OAuth2 client-credentials clients the providers authenticate with:
+#? [terminology.external.oauth2_clients.ts-client]
+#? token_url = "https://idp.example.org/realms/ts/protocol/openid-connect/token"
+#? client_id = "ehrbase-cdr"
+#? client_secret = "..."        # or client_secret_file = "/run/secrets/ts-client"
+#? scopes = ["system/*.read"]
+#? refresh_leeway_secs = 30
+#? auth_method = "client_secret_basic"   # client_secret_basic | client_secret_post
 
 # ── [multimedia] — DV_MULTIMEDIA externalization to S3-compatible storage ─────
 [multimedia]

--- a/app/ehrbase/src/config/loader.rs
+++ b/app/ehrbase/src/config/loader.rs
@@ -303,6 +303,15 @@ fn resolve_secret_files(config: &mut EhrbaseConfig, errors: &mut Vec<ConfigError
         config.multimedia.secret_access_key_file.take(),
         errors,
     );
+    for (name, client) in &mut config.terminology.external.oauth2_clients {
+        let file = client.client_secret_file.take();
+        resolve_secret(
+            &format!("terminology.external.oauth2_clients.{name}.client_secret"),
+            &mut client.client_secret,
+            file,
+            errors,
+        );
+    }
 }
 
 /// Read `path`'s contents (trailing newline trimmed) into `target` as a

--- a/app/ehrbase/src/config/mod.rs
+++ b/app/ehrbase/src/config/mod.rs
@@ -19,6 +19,7 @@ mod alias;
 pub mod loader;
 
 use crate::config::loader::{ConfigError, ConfigErrors};
+use crate::config::secret::Secret;
 mod strict;
 
 pub mod auth;
@@ -171,14 +172,7 @@ impl EhrbaseConfig {
                 "management.port ({port}) must differ from the server.bind port"
             )));
         }
-        // External terminology enabled ⇒ at least one provider.
-        if self.terminology.external.enabled && self.terminology.external.providers.is_empty() {
-            errors.push(ConfigError::semantic(
-                "terminology.external.enabled = true requires at least one \
-                 [terminology.external.providers.<name>]"
-                    .to_owned(),
-            ));
-        }
+        validate_terminology(&self.terminology.external, &mut errors);
 
         if errors.is_empty() {
             Ok(())
@@ -236,6 +230,65 @@ impl EhrbaseConfig {
 /// The port component of a `host:port` bind string, if parseable.
 fn server_bind_port(bind: &str) -> Option<u16> {
     bind.rsplit_once(':').and_then(|(_, p)| p.parse().ok())
+}
+
+/// Semantic checks on `[terminology.external]`: enabling it needs a provider,
+/// and every cross-reference must resolve. A dangling reference would degrade
+/// silently — a route to a missing provider quietly falls back to the default
+/// server, and an `oauth2_client` naming a missing client would send
+/// unauthenticated requests — so both are boot errors (§P-5: never make a bad
+/// value a silent default). No openEHR spec governs configuration — our own
+/// design.
+fn validate_terminology(
+    terminology: &crate::service::terminology::config::ExternalTerminologyConfig,
+    errors: &mut Vec<ConfigError>,
+) {
+    if terminology.enabled && terminology.providers.is_empty() {
+        errors.push(ConfigError::semantic(
+            "terminology.external.enabled = true requires at least one \
+             [terminology.external.providers.<name>]"
+                .to_owned(),
+        ));
+    }
+    for (key, provider) in &terminology.routes {
+        if !terminology.providers.contains_key(provider) {
+            errors.push(ConfigError::semantic(format!(
+                "terminology.external.routes.\"{key}\" names provider '{provider}', which has no \
+                 [terminology.external.providers.{provider}]"
+            )));
+        }
+    }
+    for (name, provider) in &terminology.providers {
+        let Some(client) = provider.oauth2_client.as_deref() else {
+            continue;
+        };
+        if !terminology.oauth2_clients.contains_key(client) {
+            errors.push(ConfigError::semantic(format!(
+                "terminology.external.providers.{name}.oauth2_client names '{client}', which has \
+                 no [terminology.external.oauth2_clients.{client}]"
+            )));
+        }
+    }
+    for (name, client) in &terminology.oauth2_clients {
+        if client.token_url.trim().is_empty() {
+            errors.push(ConfigError::semantic(format!(
+                "terminology.external.oauth2_clients.{name}.token_url must not be empty"
+            )));
+        }
+        if client.client_id.trim().is_empty() {
+            errors.push(ConfigError::semantic(format!(
+                "terminology.external.oauth2_clients.{name}.client_id must not be empty"
+            )));
+        }
+        if client.client_secret.as_ref().is_none_or(Secret::is_empty)
+            && client.client_secret_file.is_none()
+        {
+            errors.push(ConfigError::semantic(format!(
+                "terminology.external.oauth2_clients.{name} requires client_secret or \
+                 client_secret_file (the client-credentials grant authenticates the client)"
+            )));
+        }
+    }
 }
 
 /// Assemble the configuration from explicit inputs — the pure seam every test
@@ -689,5 +742,151 @@ mod tests {
         let mut c = EhrbaseConfig::default();
         c.terminology.external.enabled = true;
         assert!(c.validate().is_err());
+    }
+
+    /// A terminology route naming a provider that is not configured is a boot
+    /// error — never a silent fall-back to the default server.
+    #[test]
+    fn validate_terminology_route_must_name_a_configured_provider() {
+        let mut c = EhrbaseConfig::default();
+        let external = &mut c.terminology.external;
+        external.enabled = true;
+        external.providers.insert(
+            "default".to_owned(),
+            crate::service::terminology::config::FhirProviderConfig {
+                kind: crate::service::terminology::config::ProviderKind::Fhir,
+                url: "https://ts.example/fhir".to_owned(),
+                operation: crate::service::terminology::config::FhirOperation::ValidateCode,
+                connect_timeout_ms: 2_000,
+                request_timeout_ms: 10_000,
+                oauth2_client: None,
+                cache_ttl_secs: 300,
+                cache_capacity: 10_000,
+            },
+        );
+        assert!(c.validate().is_ok(), "a routeless provider set is valid");
+
+        c.terminology
+            .external
+            .routes
+            .insert("SNOMED-CT".to_owned(), "snomed".to_owned());
+        let err = c.validate().expect_err("a dangling route must be rejected");
+        assert!(err.to_string().contains("snomed"), "got {err}");
+
+        // Pointing the route at the configured provider resolves it.
+        c.terminology
+            .external
+            .routes
+            .insert("SNOMED-CT".to_owned(), "default".to_owned());
+        assert!(c.validate().is_ok());
+    }
+
+    /// A provider naming an `oauth2_client` with no matching client table is a
+    /// boot error — never a silently unauthenticated terminology request. The
+    /// client itself must carry a token endpoint, a client id, and a secret.
+    #[test]
+    fn validate_terminology_oauth2_client_reference_and_shape() {
+        let mut c = EhrbaseConfig::default();
+        let external = &mut c.terminology.external;
+        external.enabled = true;
+        external.providers.insert(
+            "default".to_owned(),
+            crate::service::terminology::config::FhirProviderConfig {
+                kind: crate::service::terminology::config::ProviderKind::Fhir,
+                url: "https://ts.example/fhir".to_owned(),
+                operation: crate::service::terminology::config::FhirOperation::ValidateCode,
+                connect_timeout_ms: 2_000,
+                request_timeout_ms: 10_000,
+                oauth2_client: Some("ts-client".to_owned()),
+                cache_ttl_secs: 300,
+                cache_capacity: 10_000,
+            },
+        );
+        let err = c
+            .validate()
+            .expect_err("an unconfigured oauth2_client must be rejected");
+        assert!(err.to_string().contains("ts-client"), "got {err}");
+
+        // A client with no secret cannot run the client-credentials grant.
+        c.terminology.external.oauth2_clients.insert(
+            "ts-client".to_owned(),
+            crate::service::terminology::config::TerminologyOauth2Config {
+                token_url: "https://idp.example/token".to_owned(),
+                client_id: "cdr".to_owned(),
+                client_secret: None,
+                client_secret_file: None,
+                scopes: Vec::new(),
+                refresh_leeway_secs: 30,
+                auth_method:
+                    crate::service::terminology::config::Oauth2AuthMethod::ClientSecretBasic,
+            },
+        );
+        let err = c.validate().expect_err("a secretless client is rejected");
+        assert!(err.to_string().contains("client_secret"), "got {err}");
+
+        c.terminology
+            .external
+            .oauth2_clients
+            .get_mut("ts-client")
+            .expect("client")
+            .client_secret = Some(secret::Secret::new("s3cret"));
+        assert!(c.validate().is_ok());
+    }
+
+    /// The new terminology keys are reachable through the one env grammar
+    /// (§P-4), map keys included.
+    #[test]
+    fn env_mapping_terminology_routes_and_oauth2_clients() {
+        let c = assemble_ok(
+            None,
+            &env(&[
+                ("EHRBASE__TERMINOLOGY__EXTERNAL__ENABLED", "true"),
+                (
+                    "EHRBASE__TERMINOLOGY__EXTERNAL__PROVIDERS__SNOMED__URL",
+                    "https://snowstorm/fhir",
+                ),
+                (
+                    "EHRBASE__TERMINOLOGY__EXTERNAL__PROVIDERS__SNOMED__OAUTH2_CLIENT",
+                    "ts-client",
+                ),
+                (
+                    "EHRBASE__TERMINOLOGY__EXTERNAL__ROUTES__SNOMED-CT",
+                    "snomed",
+                ),
+                (
+                    "EHRBASE__TERMINOLOGY__EXTERNAL__OAUTH2_CLIENTS__TS-CLIENT__TOKEN_URL",
+                    "https://idp/token",
+                ),
+                (
+                    "EHRBASE__TERMINOLOGY__EXTERNAL__OAUTH2_CLIENTS__TS-CLIENT__CLIENT_ID",
+                    "cdr",
+                ),
+                (
+                    "EHRBASE__TERMINOLOGY__EXTERNAL__OAUTH2_CLIENTS__TS-CLIENT__CLIENT_SECRET",
+                    "s3cret",
+                ),
+            ]),
+            &[],
+        );
+        let external = &c.terminology.external;
+        assert!(external.enabled);
+        assert_eq!(
+            external.providers.get("snomed").expect("snomed").url,
+            "https://snowstorm/fhir"
+        );
+        assert_eq!(
+            external.routes.get("snomed-ct").map(String::as_str),
+            Some("snomed"),
+            "map keys arrive lower-cased from the env grammar"
+        );
+        let client = external
+            .oauth2_clients
+            .get("ts-client")
+            .expect("oauth2 client");
+        assert_eq!(client.token_url, "https://idp/token");
+        assert_eq!(
+            client.client_secret.as_ref().map(Secret::expose),
+            Some("s3cret")
+        );
     }
 }

--- a/app/ehrbase/src/service/ehr/validation.rs
+++ b/app/ehrbase/src/service/ehr/validation.rs
@@ -101,6 +101,8 @@ impl EhrbaseService {
     ) -> Result<(), ServiceError> {
         let mut messages = openehr_its::flat::validation::validate_rm_and_terminology(composition);
         let rm_terminology_failures = messages.len();
+        let mut template_failures = 0;
+        let mut binding_failures = 0;
         if let Some(template_id) = composition
             .pointer("/archetype_details/template_id/value")
             .and_then(Value::as_str)
@@ -114,8 +116,21 @@ impl EhrbaseService {
             } else {
                 openehr_its::flat::validation::validate_archetype_conformance(composition, &wt)
             });
+            template_failures = messages.len() - rm_terminology_failures;
+            // Archetype constraint bindings (ac-code → external value set)
+            // resolve against the routed terminology servers. A no-op — and
+            // free of any remote call — unless `[terminology.external]` is
+            // configured (BASE `architecture_overview/master12-terminology.adoc`
+            // §"Binding Terminology Value-sets to Archetypes"). The relaxation
+            // for a `553|incomplete|` commit does not reach it: a code that IS
+            // present may not be wrong (RM common master06 §Incomplete
+            // Content). Counted as its own pass — a bound value set the
+            // terminology server rejects is a different operational signal
+            // from an archetype-shape violation.
+            let bindings = self.constraint_binding_violations(composition, &wt).await;
+            binding_failures = bindings.len();
+            messages.extend(bindings);
         }
-        let template_failures = messages.len() - rm_terminology_failures;
         if rm_terminology_failures > 0 {
             metrics::counter!(
                 crate::telemetry::prometheus::VALIDATION_FAILURES,
@@ -129,6 +144,13 @@ impl EhrbaseService {
                 "pass" => "template",
             )
             .increment(template_failures as u64);
+        }
+        if binding_failures > 0 {
+            metrics::counter!(
+                crate::telemetry::prometheus::VALIDATION_FAILURES,
+                "pass" => "constraint_binding",
+            )
+            .increment(binding_failures as u64);
         }
         if messages.is_empty() {
             return Ok(());

--- a/app/ehrbase/src/service/mod.rs
+++ b/app/ehrbase/src/service/mod.rs
@@ -43,6 +43,7 @@ use crate::service::query::config::QueryConfig;
 use crate::service::query::plan_cache::PlanCache;
 use crate::service::subject_proxy::config::SubjectProxyFhir;
 use crate::service::terminology::fhir::FhirTerminologyProvider;
+use crate::service::terminology::router::TerminologyRouter;
 
 mod commit_env;
 
@@ -117,11 +118,16 @@ pub struct EhrbaseService {
     /// retrieval; `crate::system_log::store`). `None` = the local store is
     /// off; the binary wires it via [`Self::with_audit_store`].
     pub(crate) audit_store: Option<crate::system_log::store::AuditStore>,
-    /// The optional external terminology provider (FHIR R4), selected when a
-    /// deployment opts in ([`ExternalTerminologyConfig`]). Used by AQL
-    /// `TERMINOLOGY(…)` resolution; `None` keeps terminology on the
-    /// in-process `openehr-term` bundle only.
-    pub(crate) external_terminology: Option<Arc<FhirTerminologyProvider>>,
+    /// The optional external terminology servers (FHIR R4) — **all** of the
+    /// configured providers plus the terminology → provider routing, built
+    /// when a deployment opts in
+    /// ([`ExternalTerminologyConfig`](crate::service::terminology::config::ExternalTerminologyConfig)).
+    /// Consulted by the SM `I_TERMINOLOGY_SERVICE` calls, composition
+    /// constraint-binding validation, and AQL `TERMINOLOGY(…)` resolution;
+    /// `None` keeps terminology on the in-process `openehr-term` bundle only.
+    /// Several servers serve different terminologies at once — BASE
+    /// `docs/architecture_overview/master12-terminology.adoc` §Overview.
+    pub(crate) terminology: Option<Arc<TerminologyRouter>>,
     /// The optional `DV_MULTIMEDIA` externalization engine (no openEHR spec
     /// governs media externalization — our own extension,
     /// [`crate::extensions::multimedia`]). `None` (default) = inline
@@ -181,7 +187,7 @@ impl EhrbaseService {
             signer: Arc::new(Signer::digest_default()),
             audit: None,
             audit_store: None,
-            external_terminology: None,
+            terminology: None,
             multimedia: None,
             subject_proxy_fhir: None,
             tenant_cache: tenant_cache(),
@@ -232,13 +238,48 @@ impl EhrbaseService {
         self
     }
 
-    /// Install an external FHIR R4 terminology provider (opt-in), used by AQL
-    /// `TERMINOLOGY(…)` resolution. Without it, terminology routes only to
-    /// the in-process `openehr-term` bundle.
+    /// Install the materialised terminology servers + their routing (opt-in).
+    /// Without it, terminology routes only to the in-process `openehr-term`
+    /// bundle.
     #[must_use]
-    pub fn with_external_terminology(mut self, provider: Arc<FhirTerminologyProvider>) -> Self {
-        self.external_terminology = Some(provider);
+    pub fn with_terminology_router(mut self, router: Arc<TerminologyRouter>) -> Self {
+        self.terminology = Some(router);
         self
+    }
+
+    /// Install a single external FHIR R4 terminology provider as the default
+    /// route — the one-server shorthand for
+    /// [`Self::with_terminology_router`].
+    #[must_use]
+    pub fn with_external_terminology(self, provider: Arc<FhirTerminologyProvider>) -> Self {
+        self.with_terminology_router(Arc::new(TerminologyRouter::single(provider)))
+    }
+
+    /// The terminology server `key` is explicitly routed to, or `None` (no
+    /// default fallback — [`TerminologyRouter::route`]). A caller with several
+    /// candidate keys chains this and ends with
+    /// [`Self::terminology_default_provider`].
+    pub(crate) fn terminology_route(&self, key: &str) -> Option<Arc<FhirTerminologyProvider>> {
+        self.terminology.as_deref().and_then(|r| r.route(key))
+    }
+
+    /// The terminology server answering an unrouted call, or `None` when no
+    /// external terminology is configured
+    /// ([`TerminologyRouter::default_provider`]).
+    pub(crate) fn terminology_default_provider(&self) -> Option<Arc<FhirTerminologyProvider>> {
+        self.terminology
+            .as_deref()
+            .and_then(TerminologyRouter::default_provider)
+    }
+
+    /// The terminology server serving `terminology` — its explicit route, else
+    /// the default provider.
+    pub(crate) fn terminology_provider(
+        &self,
+        terminology: &str,
+    ) -> Option<Arc<FhirTerminologyProvider>> {
+        self.terminology_route(terminology)
+            .or_else(|| self.terminology_default_provider())
     }
 
     /// Install the `DV_MULTIMEDIA` externalization engine (opt-in extension).

--- a/app/ehrbase/src/service/terminology/binding.rs
+++ b/app/ehrbase/src/service/terminology/binding.rs
@@ -1,0 +1,397 @@
+//! Commit-time resolution of archetype **constraint bindings** — the ac-code
+//! value sets a template binds to an external terminology query.
+//!
+//! # What the spec requires
+//!
+//! BASE `docs/architecture_overview/master12-terminology.adoc` §"Binding
+//! Terminology Value-sets to Archetypes": where a terminology is the
+//! appropriate source of values, "an internal code is defined, in this case an
+//! 'ac' code ('ac' = archetype constraint), and this is bound to queries to one
+//! or more external terminologies, whose result would be a (possibly
+//! structured) value set from that terminology". The query is not part of the
+//! archetype — the archetype "simply hold[s] an identifier for a query; the
+//! query itself is defined within a 'terminology query server'". AOM 1.4
+//! `AM/docs/AOM1.4/master04-constraint_model_package.adoc` §Reference Objects
+//! says the same from the constraint-model side: a `CONSTRAINT_REF` is "a proxy
+//! for a set of constraints … expressed in the binding of the constraint
+//! reference (e.g. 'ac0004') to a query … into an external service (e.g. a
+//! terminology service)". AOM2 `AM/docs/AOM2/master08-validation.adoc`
+//! §Terminology places binding validity in the archetype-validation phase;
+//! the *data*-side consequence — an instance code must be in the bound value
+//! set — is what this module enforces at ingestion.
+//!
+//! # What this module does
+//!
+//! `openehr_its::flat::validation::collect_constraint_binding_checks` walks the
+//! COMPOSITION against its `WebTemplate` and returns one
+//! [`ConstraintBindingCheck`] per bound coded value present in the instance.
+//! Each check is resolved against the terminology server the binding routes to
+//! ([`super::router::TerminologyRouter`]) with the SM `value_set_validate`
+//! call, i.e. FHIR `ValueSet/$validate-code` (or `$expand` + membership, per
+//! the provider's configured operation).
+//!
+//! # Outcomes
+//!
+//! - **No external terminology configured** (the default): nothing runs and no
+//!   check is even collected — behaviour is byte-identical to a deployment
+//!   without this module.
+//! - **Resolved, code is a member**: accepted.
+//! - **Resolved, code is NOT a member**: a
+//!   [`ValidationKind::Terminology`] violation → `422`. This is a real
+//!   constraint violation, not a service failure, so `fail_on_error` does not
+//!   apply to it.
+//! - **Unresolvable** (terminology server down, `5xx`, unknown value set, no
+//!   provider routes to the binding's terminology): governed by
+//!   `[terminology.external] fail_on_error` — fail-closed rejects the
+//!   composition, fail-open (the default) accepts it and logs a warning.
+//!
+//! NOTE: the openEHR `CODE_PHRASE.terminology_id` is forwarded verbatim as the
+//! FHIR `system` parameter. No openEHR spec defines a mapping between
+//! `terminology_id` values (`SNOMED-CT`) and FHIR system URIs
+//! (`http://snomed.info/sct`) — our own design/extension: the value travels as
+//! written, and a deployment whose archetypes and terminology server disagree
+//! aligns them with the terminology-server configuration, not with a hidden
+//! alias table here.
+
+use openehr_its::flat::validation::{ConstraintBindingCheck, ValidationKind, ValidationMessage};
+use openehr_its::flat::webtemplate::WebTemplate;
+use serde_json::Value;
+
+use crate::service::EhrbaseService;
+use crate::service::status::SmError;
+
+impl EhrbaseService {
+    /// Resolve every archetype constraint binding this COMPOSITION triggers
+    /// against the routed terminology servers, returning the violations found.
+    ///
+    /// Empty (and free of any remote call) when external terminology is not
+    /// configured or the template carries no constraint binding.
+    pub(in crate::service) async fn constraint_binding_violations(
+        &self,
+        composition: &Value,
+        wt: &WebTemplate,
+    ) -> Vec<ValidationMessage> {
+        let Some(router) = self.terminology.as_deref() else {
+            return Vec::new();
+        };
+        let checks =
+            openehr_its::flat::validation::collect_constraint_binding_checks(composition, wt);
+        if checks.is_empty() {
+            return Vec::new();
+        }
+        let mut out = Vec::new();
+        for check in checks {
+            match self.resolve_binding(&check).await {
+                Ok(true) => {}
+                Ok(false) => out.push(ValidationMessage {
+                    path: check.path.clone(),
+                    message: format!(
+                        "code '{}' (terminology '{}') is not in the value set bound to \
+                         constraint code '{}' ({}) — BASE master12 §Binding Terminology \
+                         Value-sets to Archetypes",
+                        check.instance_code,
+                        check.instance_terminology,
+                        check.ac_code,
+                        check.query_uri,
+                    ),
+                    kind: ValidationKind::Terminology,
+                }),
+                Err(e) => {
+                    if router.fail_on_error() {
+                        out.push(ValidationMessage {
+                            path: check.path.clone(),
+                            message: format!(
+                                "the value set bound to constraint code '{}' ({}) could not be \
+                                 resolved and terminology.external.fail_on_error is set: {}",
+                                check.ac_code, check.query_uri, e.message,
+                            ),
+                            kind: ValidationKind::Terminology,
+                        });
+                    } else {
+                        tracing::warn!(
+                            ac_code = %check.ac_code,
+                            query_uri = %check.query_uri,
+                            terminology = %check.binding_terminology,
+                            error = %e.message,
+                            "constraint-binding value set unresolved; accepting the composition \
+                             (terminology.external.fail_on_error is not set)"
+                        );
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    /// Ask the terminology server that serves this binding whether the
+    /// instance code is a member of the bound value set.
+    ///
+    /// Routed by the binding's terminology first (the archetype's own
+    /// statement of which terminology it binds to), then the instance code's
+    /// terminology, then the query URI itself.
+    async fn resolve_binding(&self, check: &ConstraintBindingCheck) -> Result<bool, SmError> {
+        let provider = self
+            .terminology_route(&check.binding_terminology)
+            .or_else(|| self.terminology_route(&check.instance_terminology))
+            .or_else(|| self.terminology_route(&check.query_uri))
+            .or_else(|| self.terminology_default_provider())
+            .ok_or_else(|| {
+                SmError::exception(format!(
+                    "no terminology server is configured for '{}'",
+                    check.binding_terminology
+                ))
+            })?;
+        provider
+            .value_set_validate(
+                &check.instance_terminology,
+                &check.query_uri,
+                &check.instance_code,
+                None,
+            )
+            .await
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::panic,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    let_underscore_drop
+)] // test assertions/diagnostics/fixtures
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+
+    use openehr_its::flat::webtemplate::{
+        WebTemplate, WebTemplateConstraintBinding, WebTemplateNode,
+    };
+    use serde_json::json;
+    use wiremock::matchers::{method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+    use crate::service::terminology::config::{
+        ExternalTerminologyConfig, FhirOperation, FhirProviderConfig, ProviderKind,
+    };
+    use crate::service::terminology::router::TerminologyRouter;
+
+    const BOUND_VS: &str = "http://vs.example/blood-group";
+    const SNOMED: &str = "http://snomed.info/sct";
+
+    /// A one-node template whose `DV_CODED_TEXT` leaf carries the ac-code
+    /// constraint binding, and the matching instance value. The walk-matching
+    /// machinery itself is covered in `openehr-its`; here the node IS the root
+    /// so the test isolates the resolution semantics.
+    fn bound_template() -> WebTemplate {
+        let mut node = WebTemplateNode::new(
+            "DV_CODED_TEXT".to_owned(),
+            "/content[at0001]/value".to_owned(),
+        );
+        node.id = "blood_group".to_owned();
+        node.constraint_bindings = vec![WebTemplateConstraintBinding {
+            attr: "defining_code".to_owned(),
+            ac_code: "ac0001".to_owned(),
+            terminology: "SNOMED-CT".to_owned(),
+            query_uri: BOUND_VS.to_owned(),
+        }];
+        WebTemplate {
+            template_id: "binding.test.v1".to_owned(),
+            sem_ver: None,
+            version: "2.3".to_owned(),
+            default_language: "en".to_owned(),
+            languages: vec!["en".to_owned()],
+            tree: node,
+            other_details: indexmap::IndexMap::new(),
+        }
+    }
+
+    fn coded_instance(code: &str) -> serde_json::Value {
+        json!({
+            "_type": "DV_CODED_TEXT",
+            "value": "A positive",
+            "defining_code": {
+                "_type": "CODE_PHRASE",
+                "terminology_id": { "_type": "TERMINOLOGY_ID", "value": SNOMED },
+                "code_string": code
+            }
+        })
+    }
+
+    /// A `$validate-code` server answering `result` for `member_code` and
+    /// `false` for anything else.
+    async fn validate_code_server(member_code: &str) -> MockServer {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/ValueSet/$validate-code"))
+            .and(query_param("url", BOUND_VS))
+            .and(query_param("code", member_code))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "resourceType": "Parameters",
+                "parameter": [{"name": "result", "valueBoolean": true}]
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/ValueSet/$validate-code"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "resourceType": "Parameters",
+                "parameter": [{"name": "result", "valueBoolean": false}]
+            })))
+            .mount(&server)
+            .await;
+        server
+    }
+
+    fn provider_cfg(base: &str) -> FhirProviderConfig {
+        FhirProviderConfig {
+            kind: ProviderKind::Fhir,
+            url: base.to_owned(),
+            operation: FhirOperation::ValidateCode,
+            connect_timeout_ms: 500,
+            request_timeout_ms: 800,
+            oauth2_client: None,
+            cache_ttl_secs: 0,
+            cache_capacity: 0,
+        }
+    }
+
+    /// A service routing `SNOMED-CT` at `base`, with the given fail-open /
+    /// fail-closed posture.
+    async fn service(base: &str, fail_on_error: bool) -> EhrbaseService {
+        let cfg = ExternalTerminologyConfig {
+            enabled: true,
+            fail_on_error,
+            providers: BTreeMap::from([("default".to_owned(), provider_cfg(base))]),
+            routes: BTreeMap::from([("SNOMED-CT".to_owned(), "default".to_owned())]),
+            ..ExternalTerminologyConfig::default()
+        };
+        let router = TerminologyRouter::build(&cfg)
+            .expect("build router")
+            .expect("router");
+        let db = testkit::db().await.expect("testkit database");
+        EhrbaseService::new(db.pool()).with_terminology_router(Arc::new(router))
+    }
+
+    /// A code the bound value set contains is accepted (BASE master12
+    /// §"Binding Terminology Value-sets to Archetypes").
+    #[tokio::test]
+    async fn a_member_code_is_accepted() {
+        let ts = validate_code_server("278149003").await;
+        let service = service(&ts.uri(), false).await;
+        let violations = service
+            .constraint_binding_violations(&coded_instance("278149003"), &bound_template())
+            .await;
+        assert!(
+            violations.is_empty(),
+            "unexpected violations: {violations:?}"
+        );
+        assert_eq!(
+            ts.received_requests().await.unwrap().len(),
+            1,
+            "the binding was resolved against the terminology server"
+        );
+    }
+
+    /// A code the bound value set does NOT contain is a violation → 422. This
+    /// is a resolved constraint violation, not a service failure, so
+    /// `fail_on_error` must not change it.
+    #[tokio::test]
+    async fn a_non_member_code_is_refused_under_either_posture() {
+        for fail_on_error in [false, true] {
+            let ts = validate_code_server("278149003").await;
+            let service = service(&ts.uri(), fail_on_error).await;
+            let violations = service
+                .constraint_binding_violations(&coded_instance("999999"), &bound_template())
+                .await;
+            assert_eq!(
+                violations.len(),
+                1,
+                "a non-member code must be refused (fail_on_error = {fail_on_error})"
+            );
+            let v = &violations[0];
+            assert_eq!(v.kind, ValidationKind::Terminology);
+            assert_eq!(v.path, "/content[at0001]/value");
+            assert!(v.message.contains("999999"), "got {}", v.message);
+            assert!(v.message.contains("ac0001"), "got {}", v.message);
+        }
+    }
+
+    /// Terminology server unreachable: fail-open (the default) accepts the
+    /// composition, fail-closed rejects it. The observable difference is the
+    /// whole point of `[terminology.external] fail_on_error`.
+    #[tokio::test]
+    async fn an_unresolvable_binding_follows_fail_on_error() {
+        // A started-then-dropped server yields an address nothing listens on,
+        // so the provider's connect fails the way a TS outage does.
+        let dead_uri = {
+            let ts = MockServer::start().await;
+            ts.uri()
+        };
+
+        let open = service(&dead_uri, false).await;
+        let violations = open
+            .constraint_binding_violations(&coded_instance("278149003"), &bound_template())
+            .await;
+        assert!(
+            violations.is_empty(),
+            "fail-open must accept an unresolvable binding, got {violations:?}"
+        );
+
+        let closed = service(&dead_uri, true).await;
+        let violations = closed
+            .constraint_binding_violations(&coded_instance("278149003"), &bound_template())
+            .await;
+        assert_eq!(
+            violations.len(),
+            1,
+            "fail-closed must reject an unresolvable binding"
+        );
+        assert!(
+            violations[0].message.contains("fail_on_error"),
+            "the refusal names the posture that caused it, got {}",
+            violations[0].message
+        );
+    }
+
+    /// With no external terminology configured — the shipped default — the
+    /// binding pass does nothing at all: no check is collected, no request is
+    /// made, and commit behaviour is byte-identical to a deployment without
+    /// this module.
+    #[tokio::test]
+    async fn the_disabled_default_resolves_nothing() {
+        let ts = validate_code_server("278149003").await;
+        let db = testkit::db().await.expect("testkit database");
+        let service = EhrbaseService::new(db.pool());
+        let violations = service
+            // A code that WOULD be refused if the binding were resolved.
+            .constraint_binding_violations(&coded_instance("999999"), &bound_template())
+            .await;
+        assert!(
+            violations.is_empty(),
+            "no binding is resolved without [terminology.external]"
+        );
+        assert_eq!(
+            ts.received_requests().await.unwrap().len(),
+            0,
+            "no terminology request is made"
+        );
+    }
+
+    /// A template with no constraint binding raises no question even with
+    /// terminology configured — the pass is free for the overwhelmingly common
+    /// unbound template.
+    #[tokio::test]
+    async fn an_unbound_template_makes_no_request() {
+        let ts = validate_code_server("278149003").await;
+        let service = service(&ts.uri(), true).await;
+        let mut wt = bound_template();
+        wt.tree.constraint_bindings.clear();
+        let violations = service
+            .constraint_binding_violations(&coded_instance("999999"), &wt)
+            .await;
+        assert!(violations.is_empty());
+        assert_eq!(ts.received_requests().await.unwrap().len(), 0);
+    }
+}

--- a/app/ehrbase/src/service/terminology/config.rs
+++ b/app/ehrbase/src/service/terminology/config.rs
@@ -16,25 +16,42 @@
 //! Provider selection is **openEHR-bundle-by-default, FHIR opt-in**: with
 //! [`ExternalTerminologyConfig::enabled`] `false` (the default) no remote
 //! provider is built and composition validation stays on the in-process
-//! `openehr-term` bundle ([`super::bundle`]); a FHIR provider is materialised
+//! `openehr-term` bundle ([`super::bundle`]); FHIR providers are materialised
 //! only when a deployment opts in.
+//!
+//! **Several servers at once.** `BASE/docs/architecture_overview/
+//! master12-terminology.adoc` §Overview names the target ecosystem — LOINC,
+//! `ICDx`, ICPC, SNOMED CT "and the many other terminologies and vocabularies
+//! used in healthcare" — so a deployment binds to several at the same time and
+//! the CDR must operate against several terminology servers simultaneously.
+//! Every entry of [`ExternalTerminologyConfig::providers`] is therefore
+//! materialised, and [`ExternalTerminologyConfig::routes`] maps a terminology
+//! id / system URI to the provider that serves it
+//! ([`super::router::TerminologyRouter`]).
+//!
+//! NOTE: no openEHR spec governs the routing-config mechanics (the named
+//! provider map, the route keys, the `default` fallback) — our own
+//! design/extension. Only the *requirement* to serve several terminologies
+//! simultaneously is the spec's (BASE master12 §Overview).
 
 use std::collections::BTreeMap;
+use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+use crate::config::secret::Secret;
 use crate::service::status::SmError;
 
 use super::fhir::FhirTerminologyProvider;
+use super::oauth2::TokenSource;
 
 /// Default per-provider connect timeout (ms).
 const DEFAULT_CONNECT_TIMEOUT_MS: u64 = 2_000;
 /// Default per-provider request timeout (ms).
 const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 10_000;
-/// The provider name selected by
-/// [`ExternalTerminologyConfig::default_provider`] when several are
-/// configured.
-const DEFAULT_PROVIDER_NAME: &str = "default";
+/// The provider name the router falls back to when no route matches
+/// (or the sole configured provider when there is exactly one).
+pub(super) const DEFAULT_PROVIDER_NAME: &str = "default";
 
 /// The `[terminology]` section: the extension-API toggle + external-server
 /// validation config.
@@ -66,9 +83,72 @@ pub struct ExternalTerminologyConfig {
     /// treats it.
     #[serde(default)]
     pub fail_on_error: bool,
-    /// The configured terminology-server providers, keyed by name.
+    /// The configured terminology-server providers, keyed by name. **All** of
+    /// them are materialised at boot (BASE master12 §Overview — a deployment
+    /// binds to several terminologies at the same time).
     #[serde(default)]
     pub providers: BTreeMap<String, FhirProviderConfig>,
+    /// Terminology → provider routing: a terminology id (`SNOMED-CT`) or
+    /// system URI (`http://snomed.info/sct`) mapped to a provider name from
+    /// [`Self::providers`]. Lookups are case-insensitive and exact; an
+    /// unmatched key falls back to the `default` provider (or the sole
+    /// configured one). No openEHR spec governs the routing map — our own
+    /// design/extension.
+    #[serde(default)]
+    pub routes: BTreeMap<String, String>,
+    /// `OAuth2` client-credentials clients a provider authenticates with,
+    /// keyed by the name its [`FhirProviderConfig::oauth2_client`] references.
+    #[serde(default)]
+    pub oauth2_clients: BTreeMap<String, TerminologyOauth2Config>,
+}
+
+/// How the `OAuth2` client authenticates at the token endpoint (RFC 6749
+/// §2.3.1: `client_secret_basic` — the HTTP Basic form servers MUST support —
+/// or the `client_secret_post` form body).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Oauth2AuthMethod {
+    /// Credentials in the `Authorization: Basic` header (the RFC 6749 default).
+    #[default]
+    ClientSecretBasic,
+    /// Credentials in the token-request form body.
+    ClientSecretPost,
+}
+
+/// An `OAuth2` client-credentials client used to authenticate to a terminology
+/// server (`[terminology.external.oauth2_clients.<name>]`).
+///
+/// No openEHR spec governs terminology-server authentication — our own
+/// design/extension; `BASE/docs/architecture_overview/master12-terminology.adoc`
+/// only models the backend as an external "terminology query server".
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TerminologyOauth2Config {
+    /// The `OAuth2` token endpoint (RFC 6749 §3.2).
+    pub token_url: String,
+    /// The registered client identifier.
+    pub client_id: String,
+    /// The client secret (redacted in every rendering); or set
+    /// [`Self::client_secret_file`].
+    #[serde(default)]
+    pub client_secret: Option<Secret>,
+    /// A file whose contents are the client secret, resolved by the config
+    /// loader into [`Self::client_secret`].
+    #[serde(default)]
+    pub client_secret_file: Option<PathBuf>,
+    /// Scopes requested with the client-credentials grant (RFC 6749 §4.4.2).
+    #[serde(default)]
+    pub scopes: Vec<String>,
+    /// How long before a token's stated expiry it is refreshed, in seconds.
+    #[serde(default = "default_refresh_leeway_secs")]
+    pub refresh_leeway_secs: u64,
+    /// Client authentication method at the token endpoint.
+    #[serde(default)]
+    pub auth_method: Oauth2AuthMethod,
+}
+
+const fn default_refresh_leeway_secs() -> u64 {
+    30
 }
 
 /// The kind of terminology server. Only FHIR R4 is supported.
@@ -112,16 +192,13 @@ pub struct FhirProviderConfig {
     /// Overall request timeout (ms).
     #[serde(default = "default_request_timeout_ms")]
     pub request_timeout_ms: u64,
-    /// Optional name of an `OAuth2` client-credentials client to authenticate
-    /// to the TS with.
+    /// Name of the `OAuth2` client-credentials client
+    /// ([`ExternalTerminologyConfig::oauth2_clients`]) whose bearer token is
+    /// attached to every request to this provider. Unset = unauthenticated.
     ///
-    /// NOTE: `OAuth2` client-credentials + mutual-TLS to the TS
-    /// are a follow-up on top of this
-    /// core `$validate-code`/`$expand`/`$subsumes`/`$lookup` provider; the
-    /// field is accepted so config written for the full design parses, but no
-    /// bearer token is attached yet. A configured value that would silently
-    /// send unauthenticated requests is surfaced at build time
-    /// ([`FhirTerminologyProvider::new`]).
+    /// TODO: mutual TLS to the terminology server is not implemented — a
+    /// provider that must present a client certificate has no way to say so;
+    /// the `[server.tls]` material is inbound-only.
     #[serde(default)]
     pub oauth2_client: Option<String>,
     /// Result-cache TTL in seconds for this provider's FHIR operations
@@ -153,42 +230,61 @@ const fn default_request_timeout_ms() -> u64 {
 }
 
 impl ExternalTerminologyConfig {
-    /// Build the named provider, or `None` when external terminology is
-    /// disabled or no provider carries that name. The inner `Result` is
-    /// `Err` ([`SmError`]) when the named provider's configuration is invalid
-    /// (empty URL or an un-buildable HTTP client).
+    /// Build the named provider, with its `OAuth2` token source attached when
+    /// one is configured. `None` when external terminology is disabled or no
+    /// provider carries that name.
+    ///
+    /// # Errors
+    ///
+    /// [`SmError`] when the provider's configuration is invalid (empty URL, an
+    /// un-buildable HTTP client) or its `oauth2_client` names a client that is
+    /// missing or itself invalid.
     #[must_use]
     pub fn provider(&self, name: &str) -> Option<Result<FhirTerminologyProvider, SmError>> {
         if !self.enabled {
             return None;
         }
-        self.providers
-            .get(name)
-            .map(|cfg| FhirTerminologyProvider::new(name, cfg))
+        let cfg = self.providers.get(name)?;
+        Some(self.build_provider(name, cfg))
     }
 
-    /// Build the default provider: the one named `default`, or the single
-    /// configured provider when exactly one exists. `None` when external
-    /// terminology is disabled or the selection is ambiguous/empty. The
-    /// inner `Result` is `Err` ([`SmError`]) when the selected provider's
-    /// configuration is invalid.
-    #[must_use]
-    pub fn default_provider(&self) -> Option<Result<FhirTerminologyProvider, SmError>> {
-        if !self.enabled {
-            return None;
-        }
-        let (name, cfg) = self
-            .providers
-            .get_key_value(DEFAULT_PROVIDER_NAME)
-            .or_else(|| {
-                // Exactly one configured provider → use it unambiguously.
-                let mut it = self.providers.iter();
-                match (it.next(), it.next()) {
-                    (Some(only), None) => Some(only),
-                    _ => None,
-                }
-            })?;
-        Some(FhirTerminologyProvider::new(name, cfg))
+    /// Build one provider from its config: the FHIR client plus, when
+    /// `oauth2_client` is set, the client-credentials [`TokenSource`] whose
+    /// bearer token every request carries.
+    pub(super) fn build_provider(
+        &self,
+        name: &str,
+        cfg: &FhirProviderConfig,
+    ) -> Result<FhirTerminologyProvider, SmError> {
+        let provider = FhirTerminologyProvider::new(name, cfg)?;
+        let Some(client_name) = cfg.oauth2_client.as_deref() else {
+            return Ok(provider);
+        };
+        let client_cfg = self.oauth2_clients.get(client_name).ok_or_else(|| {
+            SmError::exception(format!(
+                "terminology provider '{name}' names oauth2_client '{client_name}', which is not \
+                 configured under [terminology.external.oauth2_clients]"
+            ))
+        })?;
+        let token = TokenSource::new(client_name, client_cfg)?;
+        Ok(provider.with_token(std::sync::Arc::new(token)))
+    }
+}
+
+/// A provider config pointing at `url`, with defaults everywhere else and no
+/// authentication — the shared fixture for this module's and
+/// [`super::router`]'s tests.
+#[cfg(test)]
+pub(super) fn test_provider_config(url: &str) -> FhirProviderConfig {
+    FhirProviderConfig {
+        kind: ProviderKind::Fhir,
+        url: url.to_owned(),
+        operation: FhirOperation::ValidateCode,
+        connect_timeout_ms: DEFAULT_CONNECT_TIMEOUT_MS,
+        request_timeout_ms: DEFAULT_REQUEST_TIMEOUT_MS,
+        oauth2_client: None,
+        cache_ttl_secs: 300,
+        cache_capacity: 1024,
     }
 }
 
@@ -208,62 +304,58 @@ mod tests {
         assert!(!c.enabled);
         assert!(!c.fail_on_error);
         assert!(c.providers.is_empty());
-        assert!(c.default_provider().is_none());
+        assert!(c.routes.is_empty());
+        assert!(c.oauth2_clients.is_empty());
+        assert!(c.provider(DEFAULT_PROVIDER_NAME).is_none());
     }
 
     #[test]
     fn a_configured_provider_materialises() {
-        let mut providers = BTreeMap::new();
-        providers.insert(
+        let providers = BTreeMap::from([(
             "default".to_owned(),
-            FhirProviderConfig {
-                kind: ProviderKind::Fhir,
-                url: "http://terminology:8090/fhir".to_owned(),
-                operation: FhirOperation::ValidateCode,
-                connect_timeout_ms: DEFAULT_CONNECT_TIMEOUT_MS,
-                request_timeout_ms: DEFAULT_REQUEST_TIMEOUT_MS,
-                oauth2_client: None,
-                cache_ttl_secs: 300,
-                cache_capacity: 1024,
-            },
-        );
+            test_provider_config("http://terminology:8090/fhir"),
+        )]);
         let enabled = ExternalTerminologyConfig {
             enabled: true,
-            fail_on_error: false,
             providers: providers.clone(),
+            ..ExternalTerminologyConfig::default()
         };
-        assert!(enabled.default_provider().expect("selected").is_ok());
+        assert!(enabled.provider("default").expect("selected").is_ok());
         // Disabled selects nothing even with a provider present.
         let disabled = ExternalTerminologyConfig {
             enabled: false,
-            fail_on_error: false,
             providers,
+            ..ExternalTerminologyConfig::default()
         };
         assert!(disabled.provider("default").is_none());
-        assert!(disabled.default_provider().is_none());
     }
 
     #[test]
     fn empty_url_is_rejected_at_build() {
-        let mut providers = BTreeMap::new();
-        providers.insert(
-            "default".to_owned(),
-            FhirProviderConfig {
-                kind: ProviderKind::Fhir,
-                url: "   ".to_owned(),
-                operation: FhirOperation::ValidateCode,
-                connect_timeout_ms: DEFAULT_CONNECT_TIMEOUT_MS,
-                request_timeout_ms: DEFAULT_REQUEST_TIMEOUT_MS,
-                oauth2_client: None,
-                cache_ttl_secs: 300,
-                cache_capacity: 1024,
-            },
-        );
         let c = ExternalTerminologyConfig {
             enabled: true,
-            fail_on_error: false,
-            providers,
+            providers: BTreeMap::from([("default".to_owned(), test_provider_config("   "))]),
+            ..ExternalTerminologyConfig::default()
         };
         assert!(c.provider("default").expect("present").is_err());
+    }
+
+    /// A provider naming an `oauth2_client` that is not configured is a build
+    /// error — never a silent unauthenticated request to the terminology
+    /// server.
+    #[test]
+    fn unknown_oauth2_client_is_rejected_at_build() {
+        let mut provider = test_provider_config("http://terminology:8090/fhir");
+        provider.oauth2_client = Some("ts-client".to_owned());
+        let c = ExternalTerminologyConfig {
+            enabled: true,
+            providers: BTreeMap::from([("default".to_owned(), provider)]),
+            ..ExternalTerminologyConfig::default()
+        };
+        let err = c
+            .provider("default")
+            .expect("present")
+            .expect_err("unknown oauth2_client must fail the build");
+        assert!(err.message.contains("ts-client"), "got {}", err.message);
     }
 }

--- a/app/ehrbase/src/service/terminology/expander.rs
+++ b/app/ehrbase/src/service/terminology/expander.rs
@@ -4,6 +4,12 @@
 //! `TERMINOLOGY('expand', …)` operands, the Boolean operations, and
 //! `matches { terminology-uri }` through this service's providers
 //! (QUERY master03 §TERMINOLOGY, §matches).
+//!
+//! A FHIR operand is answered by the terminology server its routing keys
+//! select ([`crate::service::terminology::router::TerminologyRouter`]) — the
+//! value set / `system` argument first, then the `service_api` flavour, then
+//! the default provider — so several servers resolve different value sets in
+//! one instance.
 
 use std::collections::BTreeMap;
 
@@ -38,9 +44,10 @@ fn is_fhir_service_api(service_api: &str) -> bool {
 #[async_trait]
 impl TerminologyExpander for EhrbaseService {
     /// Resolve `TERMINOLOGY('expand', service_api, params_uri)` to the value
-    /// set's codes: route by `service_api` (FHIR → the configured remote
-    /// provider; `"openehr"` → the in-process bundle), fetch the expansion
-    /// via the SM `get_value_set`, and return its code keys.
+    /// set's codes: route by `service_api` (FHIR → the terminology server the
+    /// value-set URL or the `service_api` routes to; `"openehr"` → the
+    /// in-process bundle), fetch the expansion via the SM `get_value_set`, and
+    /// return its code keys.
     ///
     /// # Errors
     ///
@@ -50,11 +57,18 @@ impl TerminologyExpander for EhrbaseService {
     /// (server/transport) failure is a 500 ([`ExecError::Terminology`]).
     async fn expand(&self, service_api: &str, params_uri: &str) -> Result<Vec<String>, AqlError> {
         let extract = if is_fhir_service_api(service_api) {
-            let provider = self.external_terminology.as_ref().ok_or_else(|| {
-                AqlFeatureError::UnknownTerminologyService(format!(
-                    "{service_api} (no FHIR terminology server configured)"
-                ))
-            })?;
+            // Routed by the value set first (a deployment may point a specific
+            // value-set URL at a specific server), then by the `service_api`
+            // flavour, else the default provider.
+            let provider = self
+                .terminology_route(params_uri)
+                .or_else(|| self.terminology_route(service_api))
+                .or_else(|| self.terminology_default_provider())
+                .ok_or_else(|| {
+                    AqlFeatureError::UnknownTerminologyService(format!(
+                        "{service_api} (no FHIR terminology server configured)"
+                    ))
+                })?;
             // The FHIR provider ignores `terminology_id` for `$expand`; the
             // value set is identified by `params_uri` (its URL).
             provider.get_value_set(service_api, params_uri).await
@@ -100,18 +114,25 @@ impl TerminologyExpander for EhrbaseService {
         if !fhir && service_api != BUNDLE_SERVICE_API {
             return Err(AqlFeatureError::UnknownTerminologyService(service_api.to_owned()).into());
         }
-        let fhir_provider = || {
-            self.external_terminology.as_ref().ok_or_else(|| {
-                AqlFeatureError::UnknownTerminologyService(format!(
-                    "{service_api} (no FHIR terminology server configured)"
-                ))
-            })
+        // The FHIR operations name their terminology in the `system` argument,
+        // which is the routing key; the `service_api` flavour and the value-set
+        // URL are the fallbacks.
+        let fhir_provider = |primary: &str, secondary: &str| {
+            self.terminology_route(primary)
+                .or_else(|| self.terminology_route(secondary))
+                .or_else(|| self.terminology_route(service_api))
+                .or_else(|| self.terminology_default_provider())
+                .ok_or_else(|| {
+                    AqlFeatureError::UnknownTerminologyService(format!(
+                        "{service_api} (no FHIR terminology server configured)"
+                    ))
+                })
         };
         let result = match operation.to_ascii_lowercase().as_str() {
             "validate" => {
                 let (system, url, code) = (arg("system")?, arg("url")?, arg("code")?);
                 if fhir {
-                    fhir_provider()?
+                    fhir_provider(system, url)?
                         .value_set_validate(system, url, code, None)
                         .await
                 } else {
@@ -121,7 +142,9 @@ impl TerminologyExpander for EhrbaseService {
             "subsumes" => {
                 let (system, code_a, code_b) = (arg("system")?, arg("codeA")?, arg("codeB")?);
                 if fhir {
-                    fhir_provider()?.subsumes(system, code_a, code_b).await
+                    fhir_provider(system, system)?
+                        .subsumes(system, code_a, code_b)
+                        .await
                 } else {
                     bundle::subsumes(system, code_a, code_b)
                 }
@@ -138,8 +161,9 @@ impl TerminologyExpander for EhrbaseService {
     /// Expand a terminology URI operand (`matches { terminology://… }` —
     /// QUERY master03 §matches/URI): the URI identifies a value set; matching
     /// is membership of its expansion. Routed to the in-process bundle for a
-    /// `terminology://openehr/<set>` URI, else to the configured FHIR
-    /// provider (the URI is the value-set identifier).
+    /// `terminology://openehr/<set>` URI, else to the FHIR server the URI
+    /// routes to (the URI is both the value-set identifier and the routing
+    /// key).
     ///
     /// # Errors
     ///
@@ -156,7 +180,7 @@ impl TerminologyExpander for EhrbaseService {
                 .map_err(|e| map_expand_error(e, "openehr", uri))?;
             return Ok(codes_of(extract));
         }
-        let provider = self.external_terminology.as_ref().ok_or_else(|| {
+        let provider = self.terminology_provider(uri).ok_or_else(|| {
             AqlFeatureError::UnknownTerminologyService(format!(
                 "{uri} (no FHIR terminology server configured for URI operands)"
             ))

--- a/app/ehrbase/src/service/terminology/fhir.rs
+++ b/app/ehrbase/src/service/terminology/fhir.rs
@@ -55,6 +55,7 @@
 //! provider.
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 use serde::Deserialize;
@@ -66,6 +67,7 @@ use crate::service::terminology::types::{
 };
 
 use super::config::{FhirOperation, FhirProviderConfig};
+use super::oauth2::TokenSource;
 
 /// The `Term_relationship.relation_name` under which a FHIR `$expand`
 /// parent→child `contains` nesting is preserved (`terminology_extract.adoc`).
@@ -91,6 +93,10 @@ pub struct FhirTerminologyProvider {
     /// including the 404 "unknown resource" outcome — so a validation burst
     /// over the same codes costs one remote round trip per TTL window.
     cache: Option<moka::future::Cache<String, Option<serde_json::Value>>>,
+    /// The `OAuth2` client-credentials token source whose bearer credential
+    /// authenticates every request, when the provider configures one. `None` =
+    /// unauthenticated requests.
+    token: Option<Arc<TokenSource>>,
 }
 
 impl FhirTerminologyProvider {
@@ -128,7 +134,23 @@ impl FhirTerminologyProvider {
             operation: cfg.operation,
             name: name.to_owned(),
             cache,
+            token: None,
         })
+    }
+
+    /// Attach the `OAuth2` client-credentials token source whose bearer
+    /// credential every request to this provider carries
+    /// (`[terminology.external.providers.<name>] oauth2_client`).
+    #[must_use]
+    pub fn with_token(mut self, token: Arc<TokenSource>) -> Self {
+        self.token = Some(token);
+        self
+    }
+
+    /// The configured provider name (routing, logging, error context).
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
     }
 
     /// GET a FHIR operation with query params, returning the parsed body.
@@ -172,10 +194,17 @@ impl FhirTerminologyProvider {
             };
         }
         let cache_key = url.as_str().to_owned();
-        let response = self
+        let mut request = self
             .client
             .get(url)
-            .header(reqwest::header::ACCEPT, "application/fhir+json")
+            .header(reqwest::header::ACCEPT, "application/fhir+json");
+        // The bearer is resolved per request (the token source serves it from
+        // its cache and re-grants only around expiry), so a rotated credential
+        // takes effect without a restart.
+        if let Some(token) = &self.token {
+            request = request.bearer_auth(token.bearer().await?);
+        }
+        let response = request
             .send()
             .await
             .map_err(|e| self.transport_error(op_path, &e))?;

--- a/app/ehrbase/src/service/terminology/mod.rs
+++ b/app/ehrbase/src/service/terminology/mod.rs
@@ -18,10 +18,17 @@
 //!   `Terminology_extract`, `Term_code`/`Defined_term`, relationships).
 //! - [`bundle`] — the in-process `openehr-term` bundle provider (TERM 3.1.0):
 //!   the enumerable local default.
-//! - [`fhir`] — [`FhirTerminologyProvider`], a remote FHIR R4 TS client
-//!   (opt-in via [`ExternalTerminologyConfig`]).
+//! - [`fhir`] — [`FhirTerminologyProvider`](fhir::FhirTerminologyProvider), a
+//!   remote FHIR R4 TS client (opt-in via
+//!   [`ExternalTerminologyConfig`](config::ExternalTerminologyConfig)).
+//! - [`oauth2`] — [`TokenSource`](oauth2::TokenSource), the `OAuth2`
+//!   client-credentials authentication a provider may carry.
+//! - [`router`] — [`TerminologyRouter`](router::TerminologyRouter): every
+//!   configured server, materialised, with the terminology → provider routing.
 //! - [`routing`] — the 9 SM calls on `EhrbaseService`, routing between the
-//!   two providers (the routing rule below).
+//!   bundle and the routed remote provider (the routing rule below).
+//! - [`binding`] — commit-time resolution of archetype **constraint bindings**
+//!   (ac-code value sets) against the routed terminology service.
 //! - [`expander`] — the AQL `TERMINOLOGY()` seam
 //!   ([`crate::aql::terminology::TerminologyExpander`] on `EhrbaseService`).
 //! - [`config`] — the `[terminology]` config section (no openEHR spec governs
@@ -36,15 +43,25 @@
 //!   these.
 //! - **Lookup / validation** (`has_term`, `get_term`, `subsumes`,
 //!   `value_set_validate`, `has_value_set`, `get_value_set`) is answered by
-//!   the bundle when it knows the terminology, else routed to the configured
-//!   FHIR provider, else falls through to the bundle's `Pre_has_terminology`
-//!   → `NotFound`. With no FHIR provider configured (the default) this is
-//!   byte-identical to a bundle-only service.
+//!   the bundle when it knows the terminology, else routed **by terminology**
+//!   to one of the configured FHIR providers
+//!   ([`router::TerminologyRouter`]), else falls through to the bundle's
+//!   `Pre_has_terminology` → `NotFound`. With no FHIR provider configured (the
+//!   default) this is byte-identical to a bundle-only service.
+//! - Several servers answer **simultaneously**: SNOMED CT may live on one
+//!   server and LOINC on another in the same running instance, which is the
+//!   deployment reality BASE
+//!   `docs/architecture_overview/master12-terminology.adoc` §Overview
+//!   describes ("LOINC, `ICDx`, ICPC, SNOMED CT and the many other terminologies
+//!   and vocabularies used in healthcare").
 
+mod binding;
 mod bundle;
 pub mod config;
 mod expander;
 pub mod fhir;
+pub mod oauth2;
+pub mod router;
 mod routing;
 
 pub mod types;

--- a/app/ehrbase/src/service/terminology/oauth2.rs
+++ b/app/ehrbase/src/service/terminology/oauth2.rs
@@ -1,0 +1,302 @@
+//! [`TokenSource`] — `OAuth2` client-credentials authentication to a
+//! terminology server, over the pinned `oauth2` crate.
+//!
+//! A [`super::fhir::FhirTerminologyProvider`] whose
+//! [`FhirProviderConfig::oauth2_client`](super::config::FhirProviderConfig::oauth2_client)
+//! names a configured client attaches this source's bearer token to every FHIR
+//! operation it issues. The token is cached and refreshed shortly before its
+//! stated expiry, so a validation burst costs one token round trip per token
+//! lifetime rather than one per request.
+//!
+//! NOTE: no openEHR spec governs terminology-server authentication — our own
+//! design/extension. `BASE/docs/architecture_overview/master12-terminology.adoc`
+//! models the backend only as an external "terminology query server"; the
+//! grant itself is RFC 6749 §4.4 (client credentials), implemented by the
+//! `oauth2` crate rather than hand-rolled.
+//!
+//! The `oauth2` crate is HTTP-client agnostic: it builds an
+//! `http::Request<Vec<u8>>` and parses the `http::Response<Vec<u8>>` through
+//! its `AsyncHttpClient` trait (docs.rs `oauth2::AsyncHttpClient`). Its own
+//! `reqwest` impl targets a different major version of that crate than the
+//! workspace pins, so [`Oauth2HttpClient`] supplies the pinned one — the token
+//! endpoint is then reached with the same TLS stack as the terminology
+//! operations themselves.
+//!
+//! NOTE: the transport trait is implemented on a concrete type rather than
+//! through the crate's blanket closure impl. The blanket impl leaves the
+//! future's `Send`-ness higher-ranked, which the compiler cannot discharge
+//! through the `#[async_trait]` call chain that reaches it (the AQL
+//! terminology seam); a named impl declares `Send` outright.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use oauth2::TokenResponse;
+
+use crate::service::status::SmError;
+
+use super::config::{Oauth2AuthMethod, TerminologyOauth2Config};
+
+/// A token-endpoint client for one configured `OAuth2` client-credentials
+/// client, with a cached access token.
+#[derive(Debug)]
+pub struct TokenSource {
+    /// The configured client name (for error/log context).
+    name: String,
+    /// The `oauth2` client, already carrying the token endpoint.
+    client: oauth2::basic::BasicClient<
+        oauth2::EndpointNotSet,
+        oauth2::EndpointNotSet,
+        oauth2::EndpointNotSet,
+        oauth2::EndpointNotSet,
+        oauth2::EndpointSet,
+    >,
+    /// Scopes requested with every grant (RFC 6749 §4.4.2).
+    scopes: Vec<oauth2::Scope>,
+    /// The HTTP client the token request rides on (the workspace `reqwest`).
+    http: Oauth2HttpClient,
+    /// How long before the stated expiry a cached token is refreshed.
+    refresh_leeway: Duration,
+    /// The cached token, if one has been obtained and is still fresh.
+    cached: tokio::sync::RwLock<Option<CachedToken>>,
+}
+
+/// A cached access token with the instant it stops being usable.
+#[derive(Debug, Clone)]
+struct CachedToken {
+    /// The `access_token` value, sent verbatim as the bearer credential.
+    bearer: Arc<str>,
+    /// When the token must be replaced; `None` when the server stated no
+    /// `expires_in` (RFC 6749 §5.1 makes it OPTIONAL), in which case the token
+    /// is reused until a request fails.
+    refresh_after: Option<Instant>,
+}
+
+impl CachedToken {
+    /// Whether the token may still be used at `now`.
+    fn is_fresh(&self, now: Instant) -> bool {
+        self.refresh_after.is_none_or(|deadline| now < deadline)
+    }
+}
+
+impl TokenSource {
+    /// Build a token source from its configuration.
+    ///
+    /// # Errors
+    ///
+    /// [`SmError::exception`] when `token_url` is empty or unparseable,
+    /// `client_id` is empty, no client secret is configured, or the HTTP
+    /// client cannot be built.
+    pub fn new(name: &str, cfg: &TerminologyOauth2Config) -> Result<Self, SmError> {
+        let fail =
+            |what: &str| SmError::exception(format!("terminology oauth2 client '{name}': {what}"));
+        let client_id = cfg.client_id.trim();
+        if client_id.is_empty() {
+            return Err(fail("client_id must not be empty"));
+        }
+        let token_url = oauth2::TokenUrl::new(cfg.token_url.trim().to_owned())
+            .map_err(|e| fail(&format!("invalid token_url: {e}")))?;
+        let secret = cfg
+            .client_secret
+            .as_ref()
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                fail("client_secret (or client_secret_file) is required for the client-credentials grant")
+            })?;
+        let auth_type = match cfg.auth_method {
+            Oauth2AuthMethod::ClientSecretBasic => oauth2::AuthType::BasicAuth,
+            Oauth2AuthMethod::ClientSecretPost => oauth2::AuthType::RequestBody,
+        };
+        let client = oauth2::basic::BasicClient::new(oauth2::ClientId::new(client_id.to_owned()))
+            .set_client_secret(oauth2::ClientSecret::new(secret.expose().to_owned()))
+            .set_token_uri(token_url)
+            .set_auth_type(auth_type);
+        let http = Oauth2HttpClient(
+            reqwest::Client::builder()
+                .build()
+                .map_err(|e| fail(&format!("building the token-endpoint HTTP client: {e}")))?,
+        );
+        Ok(Self {
+            name: name.to_owned(),
+            client,
+            scopes: cfg
+                .scopes
+                .iter()
+                .filter(|s| !s.trim().is_empty())
+                .map(|s| oauth2::Scope::new(s.clone()))
+                .collect(),
+            http,
+            refresh_leeway: Duration::from_secs(cfg.refresh_leeway_secs),
+            cached: tokio::sync::RwLock::new(None),
+        })
+    }
+
+    /// The bearer credential to send on the next terminology request: the
+    /// cached token when it is still fresh, else a newly granted one.
+    ///
+    /// # Errors
+    ///
+    /// [`SmError::exception`] when the token endpoint cannot be reached or
+    /// answers an `OAuth2` error / unparseable body.
+    pub async fn bearer(&self) -> Result<Arc<str>, SmError> {
+        if let Some(token) = self.cached.read().await.as_ref()
+            && token.is_fresh(Instant::now())
+        {
+            return Ok(Arc::clone(&token.bearer));
+        }
+        // Re-check under the write lock: a burst of concurrent validations
+        // must cost one grant, not one per caller.
+        let mut slot = self.cached.write().await;
+        if let Some(token) = slot.as_ref()
+            && token.is_fresh(Instant::now())
+        {
+            return Ok(Arc::clone(&token.bearer));
+        }
+        let granted = self.grant().await?;
+        let bearer = Arc::clone(&granted.bearer);
+        *slot = Some(granted);
+        Ok(bearer)
+    }
+
+    /// Run one client-credentials grant (RFC 6749 §4.4) against the token
+    /// endpoint.
+    async fn grant(&self) -> Result<CachedToken, SmError> {
+        let response = self
+            .client
+            .exchange_client_credentials()
+            .add_scopes(self.scopes.iter().cloned())
+            .request_async(&self.http)
+            .await
+            .map_err(|e| {
+                SmError::exception(format!(
+                    "terminology oauth2 client '{}': client-credentials grant failed: {e}",
+                    self.name
+                ))
+            })?;
+        // Refresh a leeway before the stated expiry so an in-flight request
+        // never carries a token that expires mid-call. A leeway at or beyond
+        // the lifetime would refresh on every call, so it is clamped to leave
+        // at least a moment of usable life.
+        let refresh_after = response.expires_in().map(|lifetime| {
+            let usable = lifetime
+                .checked_sub(self.refresh_leeway)
+                .unwrap_or_else(|| lifetime / 2);
+            Instant::now() + usable
+        });
+        Ok(CachedToken {
+            bearer: Arc::from(response.access_token().secret().as_str()),
+            refresh_after,
+        })
+    }
+}
+
+/// The workspace-pinned `reqwest` client as an `oauth2` transport
+/// (`oauth2::AsyncHttpClient`): send the request the crate built and reassemble
+/// the reply as the `http::Response<Vec<u8>>` it parses.
+#[derive(Debug)]
+struct Oauth2HttpClient(reqwest::Client);
+
+impl<'c> oauth2::AsyncHttpClient<'c> for Oauth2HttpClient {
+    type Error = TokenTransportError;
+    /// `Send` is *declared* here, not inferred — it is what keeps every
+    /// service future that can reach a token grant `Send` (see the module
+    /// NOTE).
+    type Future =
+        Pin<Box<dyn Future<Output = Result<oauth2::HttpResponse, Self::Error>> + Send + 'c>>;
+
+    fn call(&'c self, request: oauth2::HttpRequest) -> Self::Future {
+        Box::pin(async move {
+            let response = self.0.execute(reqwest::Request::try_from(request)?).await?;
+            let mut builder = http::Response::builder().status(response.status());
+            for (name, value) in response.headers() {
+                builder = builder.header(name, value);
+            }
+            builder
+                .body(response.bytes().await?.to_vec())
+                .map_err(TokenTransportError::Http)
+        })
+    }
+}
+
+/// A transport failure while calling the token endpoint. The `oauth2` crate
+/// requires the HTTP client's error type to be `std::error::Error`, so the two
+/// failure shapes (`reqwest` and `http` response assembly) are one enum.
+#[derive(Debug, thiserror::Error)]
+enum TokenTransportError {
+    /// The request could not be sent or its body could not be read.
+    #[error("token endpoint request failed: {0}")]
+    Reqwest(#[from] reqwest::Error),
+    /// The response could not be reassembled as an `http::Response`.
+    #[error("token endpoint response was malformed: {0}")]
+    Http(#[from] http::Error),
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::panic,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    let_underscore_drop
+)] // test assertions/diagnostics/fixtures
+mod tests {
+    use super::*;
+
+    fn client_config(token_url: &str) -> TerminologyOauth2Config {
+        TerminologyOauth2Config {
+            token_url: token_url.to_owned(),
+            client_id: "cdr".to_owned(),
+            client_secret: Some(crate::config::secret::Secret::new("s3cret")),
+            client_secret_file: None,
+            scopes: vec!["system/*.read".to_owned()],
+            refresh_leeway_secs: 30,
+            auth_method: Oauth2AuthMethod::ClientSecretBasic,
+        }
+    }
+
+    #[test]
+    fn a_missing_secret_is_rejected() {
+        let mut cfg = client_config("https://idp.example/token");
+        cfg.client_secret = None;
+        let err = TokenSource::new("ts", &cfg).expect_err("no secret must be rejected");
+        assert!(err.message.contains("client_secret"), "got {}", err.message);
+    }
+
+    #[test]
+    fn an_invalid_token_url_is_rejected() {
+        let err = TokenSource::new("ts", &client_config("not a url"))
+            .expect_err("an unparseable token_url must be rejected");
+        assert!(err.message.contains("token_url"), "got {}", err.message);
+    }
+
+    #[test]
+    fn an_empty_client_id_is_rejected() {
+        let mut cfg = client_config("https://idp.example/token");
+        cfg.client_id = "  ".to_owned();
+        let err = TokenSource::new("ts", &cfg).expect_err("a blank client_id must be rejected");
+        assert!(err.message.contains("client_id"), "got {}", err.message);
+    }
+
+    /// A token whose stated lifetime is shorter than the refresh leeway must
+    /// still be usable for part of that lifetime — never refreshed on every
+    /// single call.
+    #[test]
+    fn a_short_lived_token_keeps_some_usable_life() {
+        let lifetime = Duration::from_secs(10);
+        let leeway = Duration::from_secs(30);
+        let usable = lifetime.checked_sub(leeway).unwrap_or(lifetime / 2);
+        assert_eq!(usable, Duration::from_secs(5));
+    }
+
+    /// A token with no stated `expires_in` (RFC 6749 §5.1 makes it OPTIONAL)
+    /// stays fresh indefinitely.
+    #[test]
+    fn a_token_without_expiry_is_always_fresh() {
+        let token = CachedToken {
+            bearer: Arc::from("t"),
+            refresh_after: None,
+        };
+        assert!(token.is_fresh(Instant::now()));
+    }
+}

--- a/app/ehrbase/src/service/terminology/router.rs
+++ b/app/ehrbase/src/service/terminology/router.rs
@@ -1,0 +1,353 @@
+//! [`TerminologyRouter`] — every configured terminology server, materialised,
+//! with the terminology → provider routing that picks one per call.
+//!
+//! # Why several servers
+//!
+//! `BASE/docs/architecture_overview/master12-terminology.adoc` §Overview names
+//! the ecosystem archetypes bind to — LOINC, `ICDx`, ICPC, SNOMED CT "and the
+//! many other terminologies and vocabularies used in healthcare" — and
+//! §"Binding Terminology Value-sets to Archetypes" binds an ac-code "to queries
+//! to **one or more** external terminologies". A real deployment therefore
+//! serves several terminologies at once, from several terminology query
+//! servers, and the CDR must hold them all open simultaneously rather than
+//! picking one at boot.
+//!
+//! # The routing rule
+//!
+//! NOTE: no openEHR spec governs how a terminology is mapped to a server — our
+//! own design/extension. The rule is deliberately mechanical, so a deployment
+//! can predict which server answers a given call:
+//!
+//! 1. the caller offers one or more **candidate keys** in priority order (a
+//!    terminology id, a system URI, a value-set URL, the AQL `service_api`);
+//! 2. the first candidate with an entry in
+//!    [`ExternalTerminologyConfig::routes`] (matched case-insensitively, whole
+//!    string — never a prefix) selects that provider;
+//! 3. otherwise the **default** provider answers: the one named `default`, or
+//!    the sole configured provider when exactly one exists;
+//! 4. with no default and no matching route, the call has no remote provider
+//!    and falls through to the caller's local behaviour.
+//!
+//! A route naming an unconfigured provider is a boot error
+//! ([`crate::config::EhrbaseConfig::validate`]), so step 2 never silently
+//! degrades to step 3.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use crate::service::status::SmError;
+
+use super::config::{DEFAULT_PROVIDER_NAME, ExternalTerminologyConfig};
+use super::fhir::FhirTerminologyProvider;
+
+/// Every materialised terminology-server provider plus the routing that
+/// selects among them.
+#[derive(Debug)]
+pub struct TerminologyRouter {
+    /// Materialised providers, keyed by their configured name.
+    providers: BTreeMap<String, Arc<FhirTerminologyProvider>>,
+    /// Routing keys (lower-cased terminology id / system URI) → provider name.
+    routes: BTreeMap<String, String>,
+    /// The provider answering an unrouted call, when one can be chosen.
+    default: Option<Arc<FhirTerminologyProvider>>,
+    /// Whether a terminology-server error rejects the composition
+    /// (fail-closed) or is tolerated (fail-open) —
+    /// [`ExternalTerminologyConfig::fail_on_error`].
+    fail_on_error: bool,
+}
+
+impl TerminologyRouter {
+    /// Materialise every configured provider and its routing.
+    ///
+    /// `Ok(None)` when external terminology is disabled or no provider is
+    /// configured — the byte-identical bundle-only default.
+    ///
+    /// # Errors
+    ///
+    /// [`SmError`] from the first provider whose configuration is invalid (an
+    /// empty URL, an un-buildable HTTP client, a missing or invalid
+    /// `oauth2_client`). A provider that cannot be built is a boot failure,
+    /// never a silently-absent route.
+    pub fn build(cfg: &ExternalTerminologyConfig) -> Result<Option<Self>, SmError> {
+        if !cfg.enabled || cfg.providers.is_empty() {
+            return Ok(None);
+        }
+        let mut providers = BTreeMap::new();
+        for (name, provider_cfg) in &cfg.providers {
+            let provider = cfg.build_provider(name, provider_cfg)?;
+            providers.insert(name.clone(), Arc::new(provider));
+        }
+        let default = providers
+            .get(DEFAULT_PROVIDER_NAME)
+            .or_else(|| {
+                // Exactly one configured provider → it is unambiguously the
+                // default; two or more without a `default` entry means every
+                // call must be routed explicitly.
+                let mut it = providers.values();
+                match (it.next(), it.next()) {
+                    (Some(only), None) => Some(only),
+                    _ => None,
+                }
+            })
+            .map(Arc::clone);
+        let routes = cfg
+            .routes
+            .iter()
+            .map(|(key, provider)| (key.trim().to_ascii_lowercase(), provider.clone()))
+            .collect();
+        Ok(Some(Self {
+            providers,
+            routes,
+            default,
+            fail_on_error: cfg.fail_on_error,
+        }))
+    }
+
+    /// A router over one already-built provider, registered under the
+    /// `default` name so every unrouted call reaches it.
+    #[must_use]
+    pub fn single(provider: Arc<FhirTerminologyProvider>) -> Self {
+        Self {
+            providers: BTreeMap::from([(DEFAULT_PROVIDER_NAME.to_owned(), Arc::clone(&provider))]),
+            routes: BTreeMap::new(),
+            default: Some(provider),
+            fail_on_error: false,
+        }
+    }
+
+    /// Whether a terminology-server error rejects the composition
+    /// (`[terminology.external] fail_on_error`).
+    #[must_use]
+    pub fn fail_on_error(&self) -> bool {
+        self.fail_on_error
+    }
+
+    /// The provider `key` is **explicitly routed** to, or `None` when the
+    /// routing map does not name it (routing rule step 2 alone — no default
+    /// fallback). A caller with several candidate keys chains this and ends
+    /// with [`Self::default_provider`].
+    ///
+    /// Every handle is an owned [`Arc`] clone rather than a borrow: callers
+    /// await a remote call on it, and a borrow of the router held across that
+    /// await would make the resulting future non-`Send`. For the same reason
+    /// the candidate keys are passed one at a time rather than as a slice — a
+    /// `&[&str]` in an async body carries two extra lifetimes that defeat the
+    /// compiler's auto-trait inference.
+    #[must_use]
+    pub fn route(&self, key: &str) -> Option<Arc<FhirTerminologyProvider>> {
+        let key = key.trim();
+        if key.is_empty() {
+            return None;
+        }
+        self.routes
+            .get(&key.to_ascii_lowercase())
+            .and_then(|name| self.providers.get(name))
+            .map(Arc::clone)
+    }
+
+    /// The provider answering an unrouted call (routing rule step 3): the one
+    /// named `default`, or the sole configured provider.
+    #[must_use]
+    pub fn default_provider(&self) -> Option<Arc<FhirTerminologyProvider>> {
+        self.default.clone()
+    }
+
+    /// The provider serving `terminology` — its explicit route, else the
+    /// default (routing rule steps 2–3).
+    #[must_use]
+    pub fn provider_for(&self, terminology: &str) -> Option<Arc<FhirTerminologyProvider>> {
+        self.route(terminology).or_else(|| self.default_provider())
+    }
+
+    /// The provider configured under `name`, if any.
+    #[must_use]
+    pub fn named(&self, name: &str) -> Option<Arc<FhirTerminologyProvider>> {
+        self.providers.get(name).map(Arc::clone)
+    }
+
+    /// The configured provider names, in stable (sorted) order — boot logging
+    /// and operational introspection.
+    pub fn provider_names(&self) -> impl Iterator<Item = &str> {
+        self.providers.keys().map(String::as_str)
+    }
+
+    /// How many providers are materialised.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.providers.len()
+    }
+
+    /// Whether no provider is materialised (never true for a built router —
+    /// [`Self::build`] answers `None` instead).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.providers.is_empty()
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::panic,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    let_underscore_drop
+)] // test assertions/diagnostics/fixtures
+mod tests {
+    use super::*;
+    use crate::service::terminology::config::test_provider_config;
+
+    fn config(providers: &[(&str, &str)], routes: &[(&str, &str)]) -> ExternalTerminologyConfig {
+        ExternalTerminologyConfig {
+            enabled: true,
+            providers: providers
+                .iter()
+                .map(|(name, url)| ((*name).to_owned(), test_provider_config(url)))
+                .collect(),
+            routes: routes
+                .iter()
+                .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+                .collect(),
+            ..ExternalTerminologyConfig::default()
+        }
+    }
+
+    #[test]
+    fn disabled_or_empty_builds_no_router() {
+        let disabled = ExternalTerminologyConfig::default();
+        assert!(
+            TerminologyRouter::build(&disabled)
+                .expect("build")
+                .is_none()
+        );
+        let enabled_but_empty = ExternalTerminologyConfig {
+            enabled: true,
+            ..ExternalTerminologyConfig::default()
+        };
+        assert!(
+            TerminologyRouter::build(&enabled_but_empty)
+                .expect("build")
+                .is_none()
+        );
+    }
+
+    /// Every configured provider is materialised — not just `default`
+    /// (BASE master12 §Overview: several terminologies at the same time).
+    #[test]
+    fn every_provider_is_materialised_and_routed() {
+        let cfg = config(
+            &[
+                ("default", "http://default.example/fhir"),
+                ("snomed", "http://snomed.example/fhir"),
+                ("loinc", "http://loinc.example/fhir"),
+            ],
+            &[
+                ("SNOMED-CT", "snomed"),
+                ("http://snomed.info/sct", "snomed"),
+                ("http://loinc.org", "loinc"),
+            ],
+        );
+        let router = TerminologyRouter::build(&cfg)
+            .expect("build")
+            .expect("router");
+        assert_eq!(router.len(), 3);
+        assert_eq!(
+            router.provider_names().collect::<Vec<_>>(),
+            ["default", "loinc", "snomed"]
+        );
+        let named = |key: &str| router.provider_for(key).map(|p| p.name().to_owned());
+        assert_eq!(named("SNOMED-CT").as_deref(), Some("snomed"));
+        // Route keys match case-insensitively.
+        assert_eq!(named("snomed-ct").as_deref(), Some("snomed"));
+        assert_eq!(named("http://snomed.info/sct").as_deref(), Some("snomed"));
+        assert_eq!(named("http://loinc.org").as_deref(), Some("loinc"));
+        // Unrouted terminologies fall back to `default`.
+        assert_eq!(named("ICD-10").as_deref(), Some("default"));
+        assert_eq!(named("").as_deref(), Some("default"));
+    }
+
+    /// Candidate keys are tried in order; the first explicitly routed one
+    /// wins, and a fully unrouted candidate list falls back to the default.
+    #[test]
+    fn candidate_keys_are_tried_in_order() {
+        let cfg = config(
+            &[
+                ("default", "http://default.example/fhir"),
+                ("snomed", "http://snomed.example/fhir"),
+            ],
+            &[("http://snomed.info/sct", "snomed")],
+        );
+        let router = TerminologyRouter::build(&cfg)
+            .expect("build")
+            .expect("router");
+        let named = |keys: [&str; 2]| {
+            keys.iter()
+                .find_map(|k| router.route(k))
+                .or_else(|| router.default_provider())
+                .map(|p| p.name().to_owned())
+        };
+        assert_eq!(
+            named(["hl7.org/fhir/4.0", "http://snomed.info/sct"]).as_deref(),
+            Some("snomed")
+        );
+        assert_eq!(
+            named(["hl7.org/fhir/4.0", "unknown"]).as_deref(),
+            Some("default")
+        );
+    }
+
+    /// With exactly one provider and no `default` entry, that provider IS the
+    /// default; with two and no `default`, an unrouted call has no provider.
+    #[test]
+    fn default_selection() {
+        let sole = config(&[("snomed", "http://snomed.example/fhir")], &[]);
+        let router = TerminologyRouter::build(&sole)
+            .expect("build")
+            .expect("router");
+        assert_eq!(
+            router.provider_for("anything").map(|p| p.name().to_owned()),
+            Some("snomed".to_owned())
+        );
+
+        let ambiguous = config(
+            &[
+                ("snomed", "http://snomed.example/fhir"),
+                ("loinc", "http://loinc.example/fhir"),
+            ],
+            &[("http://loinc.org", "loinc")],
+        );
+        let router = TerminologyRouter::build(&ambiguous)
+            .expect("build")
+            .expect("router");
+        assert!(router.provider_for("unrouted").is_none());
+        assert_eq!(
+            router
+                .provider_for("http://loinc.org")
+                .map(|p| p.name().to_owned()),
+            Some("loinc".to_owned())
+        );
+    }
+
+    /// A provider whose configuration is invalid fails the whole build — an
+    /// unbuildable terminology server never becomes a silently absent route.
+    #[test]
+    fn an_invalid_provider_fails_the_build() {
+        let cfg = config(
+            &[
+                ("default", "http://default.example/fhir"),
+                ("broken", "   "),
+            ],
+            &[],
+        );
+        assert!(TerminologyRouter::build(&cfg).is_err());
+    }
+
+    #[test]
+    fn fail_on_error_is_carried() {
+        let mut cfg = config(&[("default", "http://default.example/fhir")], &[]);
+        cfg.fail_on_error = true;
+        let router = TerminologyRouter::build(&cfg)
+            .expect("build")
+            .expect("router");
+        assert!(router.fail_on_error());
+    }
+}

--- a/app/ehrbase/src/service/terminology/routing.rs
+++ b/app/ehrbase/src/service/terminology/routing.rs
@@ -4,7 +4,10 @@
 //! [`super`]).
 //!
 //! Enumeration is always the bundle's; lookup/validation goes to the bundle
-//! when it knows the terminology, else to the configured FHIR provider, else
+//! when it knows the terminology, else to the FHIR provider **the
+//! `terminology_id` routes to** ([`super::router::TerminologyRouter`] — several
+//! servers may be configured at once, BASE
+//! `docs/architecture_overview/master12-terminology.adoc` §Overview), else
 //! falls through to the bundle's `Pre_has_terminology` → `NotFound`.
 
 use std::collections::BTreeMap;
@@ -71,7 +74,7 @@ impl EhrbaseService {
     ) -> Result<bool, SmError> {
         if bundle::has_terminology(terminology_id) {
             bundle::has_term(terminology_id, code)
-        } else if let Some(p) = &self.external_terminology {
+        } else if let Some(p) = self.terminology_provider(terminology_id) {
             p.has_term(terminology_id, code, at_date).await
         } else {
             bundle::has_term(terminology_id, code)
@@ -98,7 +101,7 @@ impl EhrbaseService {
     ) -> Result<TerminologyExtract, SmError> {
         if bundle::has_terminology(terminology_id) {
             bundle::get_term(terminology_id, code)
-        } else if let Some(p) = &self.external_terminology {
+        } else if let Some(p) = self.terminology_provider(terminology_id) {
             p.get_term(terminology_id, code, attributes, at_date).await
         } else {
             bundle::get_term(terminology_id, code)
@@ -125,7 +128,7 @@ impl EhrbaseService {
     ) -> Result<bool, SmError> {
         if bundle::has_terminology(terminology_id) {
             bundle::subsumes(terminology_id, ref_code, candidate_child_code)
-        } else if let Some(p) = &self.external_terminology {
+        } else if let Some(p) = self.terminology_provider(terminology_id) {
             p.subsumes(terminology_id, ref_code, candidate_child_code)
                 .await
         } else {
@@ -155,7 +158,7 @@ impl EhrbaseService {
     ) -> Result<bool, SmError> {
         if bundle::has_terminology(terminology_id) {
             bundle::value_set_validate(terminology_id, value_set_id, candidate_code)
-        } else if let Some(p) = &self.external_terminology {
+        } else if let Some(p) = self.terminology_provider(terminology_id) {
             p.value_set_validate(terminology_id, value_set_id, candidate_code, at_date)
                 .await
         } else {
@@ -178,7 +181,7 @@ impl EhrbaseService {
     ) -> Result<bool, SmError> {
         if bundle::has_terminology(terminology_id) {
             Ok(bundle::has_value_set(terminology_id, value_set_code))
-        } else if let Some(p) = &self.external_terminology {
+        } else if let Some(p) = self.terminology_provider(terminology_id) {
             p.has_value_set(terminology_id, value_set_code).await
         } else {
             Ok(bundle::has_value_set(terminology_id, value_set_code))
@@ -203,7 +206,7 @@ impl EhrbaseService {
     ) -> Result<TerminologyExtract, SmError> {
         if bundle::has_terminology(terminology_id) {
             bundle::get_value_set(terminology_id, value_set_code)
-        } else if let Some(p) = &self.external_terminology {
+        } else if let Some(p) = self.terminology_provider(terminology_id) {
             p.get_value_set(terminology_id, value_set_code).await
         } else {
             bundle::get_value_set(terminology_id, value_set_code)

--- a/app/ehrbase/src/telemetry/prometheus.rs
+++ b/app/ehrbase/src/telemetry/prometheus.rs
@@ -73,7 +73,10 @@ pub const AQL_PLAN_CACHE_EVENTS: &str = "aql_plan_cache_events_total";
 /// that a commit route actually committed (the direct create/update/delete
 /// routes and the CONTRIBUTION commit).
 pub const COMPOSITIONS_COMMITTED: &str = "compositions_committed_total";
-/// Validation-failure counter (`pass` = `rm_invariant/terminology/template`).
+/// Validation-failure counter (`pass` =
+/// `rm_terminology`/`template`/`constraint_binding` — the last being an
+/// archetype ac-code value-set binding the routed terminology server refused
+/// or could not resolve under `fail_on_error`).
 pub const VALIDATION_FAILURES: &str = "validation_failures_total";
 /// Version-signature verification-failure counter (`verdict` =
 /// `digest_mismatch/pgp_invalid`), incremented under `verify_on_read`

--- a/app/ehrbase/src/validation/mod.rs
+++ b/app/ehrbase/src/validation/mod.rs
@@ -59,11 +59,17 @@
 //!   unlisted archetype-rooted fillers under slotless attributes — follows the
 //!   AOM2 `c_conforms_to` / VSONCT/VSONCO formalization
 //!   (`AM/docs/AOM2/master08-validation.adoc` §Phase 2, lines 96–101).
-//! - **NOTE — terminology binding resolution.** VTTBK/VTCBK
-//!   here check binding *keys* only; resolving ac-code value sets against the
-//!   live terminology service (`TerminologyService`) at ingestion is unwired,
-//!   to land with the `CONSTRAINT_REF` policy
-//!   (`AM/docs/AOM2/master08-validation.adoc` §Terminology).
+//! - **Terminology binding resolution (wired, elsewhere).** VTTBK/VTCBK here
+//!   are *artefact*-side rules: they check that a binding's key is a defined
+//!   at-/ac-code (`AM/docs/AOM2/master08-validation.adoc` §Terminology). The
+//!   *data*-side consequence — an instance code must belong to the value set
+//!   the ac-code's `CONSTRAINT_REF` is bound to (BASE
+//!   `architecture_overview/master12-terminology.adoc` §"Binding Terminology
+//!   Value-sets to Archetypes") — cannot be decided from the artefact alone: it
+//!   needs the external terminology query server. It is resolved at commit by
+//!   `service::terminology::binding`, off the checks
+//!   `openehr_its::flat::validation::collect_constraint_binding_checks`
+//!   collects from the same walk as surface B.
 
 mod opt;
 mod structure;

--- a/app/ehrbase/tests/terminology_multi_provider.rs
+++ b/app/ehrbase/tests/terminology_multi_provider.rs
@@ -1,0 +1,524 @@
+#![allow(
+    clippy::panic,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    let_underscore_drop
+)] // test assertions/diagnostics/fixtures
+//! Simultaneous multi-terminology-server operation + terminology-server
+//! authentication, driven by `wiremock` — several hermetic FHIR R4 servers in
+//! one process, no network.
+//!
+//! BASE `docs/architecture_overview/master12-terminology.adoc` §Overview names
+//! the ecosystem archetypes bind to — "LOINC, `ICDx`, ICPC, SNOMED CT and the
+//! many other terminologies and vocabularies used in healthcare" — so a
+//! deployment binds several at the same time and the CDR must operate against
+//! several terminology servers simultaneously. These tests are the N ≥ 2
+//! proof: two servers serving different terminologies inside one
+//! `EhrbaseService`, selected per call by the configured routing.
+//!
+//! The routing-map mechanics themselves are spec-silent — our own
+//! design/extension.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use ehrbase::service::EhrbaseService;
+use ehrbase::service::terminology::config::{
+    ExternalTerminologyConfig, FhirOperation, FhirProviderConfig, Oauth2AuthMethod, ProviderKind,
+    TerminologyOauth2Config,
+};
+use ehrbase::service::terminology::router::TerminologyRouter;
+use serde_json::json;
+use wiremock::matchers::{body_string_contains, header, header_exists, method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const SNOMED: &str = "http://snomed.info/sct";
+const LOINC: &str = "http://loinc.org";
+
+/// A provider config pointing at `base`, cache off so every test assertion
+/// counts real server interactions.
+fn provider_cfg(base: &str) -> FhirProviderConfig {
+    FhirProviderConfig {
+        kind: ProviderKind::Fhir,
+        url: base.to_owned(),
+        operation: FhirOperation::ValidateCode,
+        connect_timeout_ms: 500,
+        request_timeout_ms: 800,
+        oauth2_client: None,
+        cache_ttl_secs: 0,
+        cache_capacity: 0,
+    }
+}
+
+fn external(
+    providers: &[(&str, &FhirProviderConfig)],
+    routes: &[(&str, &str)],
+) -> ExternalTerminologyConfig {
+    ExternalTerminologyConfig {
+        enabled: true,
+        providers: providers
+            .iter()
+            .map(|(name, cfg)| ((*name).to_owned(), (*cfg).clone()))
+            .collect(),
+        routes: routes
+            .iter()
+            .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+            .collect(),
+        ..ExternalTerminologyConfig::default()
+    }
+}
+
+/// A `CodeSystem/$lookup` server that answers only for `system`, with
+/// `display` — so a call landing on the wrong server is an unmistakable miss.
+async fn lookup_server(system: &str, code: &str, display: &str) -> MockServer {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/CodeSystem/$lookup"))
+        .and(query_param("system", system))
+        .and(query_param("code", code))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "resourceType": "Parameters",
+            "parameter": [{"name": "display", "valueString": display}]
+        })))
+        .mount(&server)
+        .await;
+    // Anything else this server is asked is a routing defect, reported as a
+    // distinguishable 404 rather than wiremock's "no match" panic.
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+    server
+}
+
+/// Two servers, two terminologies, one running service: a SNOMED CT lookup and
+/// a LOINC lookup each reach their own server (BASE master12 §Overview — the
+/// N ≥ 2 requirement).
+#[tokio::test]
+async fn two_servers_serve_two_terminologies_at_once() {
+    let snomed = lookup_server(SNOMED, "38341003", "Hypertensive disorder").await;
+    let loinc = lookup_server(LOINC, "8480-6", "Systolic blood pressure").await;
+
+    let snomed_cfg = provider_cfg(&snomed.uri());
+    let loinc_cfg = provider_cfg(&loinc.uri());
+    let cfg = external(
+        &[("snomed", &snomed_cfg), ("loinc", &loinc_cfg)],
+        &[(SNOMED, "snomed"), (LOINC, "loinc")],
+    );
+    let router = TerminologyRouter::build(&cfg)
+        .expect("build router")
+        .expect("router materialised");
+    assert_eq!(
+        router.provider_names().collect::<Vec<_>>(),
+        ["loinc", "snomed"],
+        "every configured provider is materialised, not just `default`"
+    );
+
+    let service = service_with(router).await;
+    let snomed_term = service
+        .get_term(SNOMED, "38341003", None, None)
+        .await
+        .expect("SNOMED lookup routes to the SNOMED server");
+    assert_eq!(snomed_term.terminology_id, SNOMED);
+    let loinc_term = service
+        .get_term(LOINC, "8480-6", None, None)
+        .await
+        .expect("LOINC lookup routes to the LOINC server");
+    assert_eq!(loinc_term.terminology_id, LOINC);
+
+    // Each server saw exactly its own terminology's lookup — proof the calls
+    // did not both land on one provider.
+    assert_eq!(
+        snomed.received_requests().await.unwrap().len(),
+        1,
+        "the SNOMED server answered exactly the SNOMED lookup"
+    );
+    assert_eq!(
+        loinc.received_requests().await.unwrap().len(),
+        1,
+        "the LOINC server answered exactly the LOINC lookup"
+    );
+}
+
+/// A terminology with no explicit route falls back to the `default` provider;
+/// with a route it does not. Both servers stay live throughout, so the
+/// assertion is about selection, not availability.
+#[tokio::test]
+async fn unrouted_terminologies_fall_back_to_the_default_provider() {
+    const OTHER: &str = "http://example.org/icd";
+    let fallback = lookup_server(OTHER, "I10", "Essential hypertension").await;
+    let snomed = lookup_server(SNOMED, "38341003", "Hypertensive disorder").await;
+
+    let fallback_cfg = provider_cfg(&fallback.uri());
+    let snomed_cfg = provider_cfg(&snomed.uri());
+    let cfg = external(
+        &[("default", &fallback_cfg), ("snomed", &snomed_cfg)],
+        &[(SNOMED, "snomed")],
+    );
+    let service = service_with(
+        TerminologyRouter::build(&cfg)
+            .expect("build router")
+            .expect("router"),
+    )
+    .await;
+
+    service
+        .get_term(OTHER, "I10", None, None)
+        .await
+        .expect("an unrouted terminology reaches the default provider");
+    assert_eq!(fallback.received_requests().await.unwrap().len(), 1);
+    assert_eq!(
+        snomed.received_requests().await.unwrap().len(),
+        0,
+        "the routed provider must not see an unrouted terminology"
+    );
+}
+
+/// Route keys match case-insensitively (`SNOMED-CT` ≡ `snomed-ct`), so an
+/// archetype's terminology id spelling does not silently change the server.
+#[tokio::test]
+async fn route_keys_are_case_insensitive() {
+    let snomed = lookup_server("SNOMED-CT", "38341003", "Hypertensive disorder").await;
+    let snomed_cfg = provider_cfg(&snomed.uri());
+    let cfg = external(
+        &[
+            ("default", &provider_cfg("http://unused.invalid/fhir")),
+            ("snomed", &snomed_cfg),
+        ],
+        &[("snomed-ct", "snomed")],
+    );
+    let service = service_with(
+        TerminologyRouter::build(&cfg)
+            .expect("build router")
+            .expect("router"),
+    )
+    .await;
+    service
+        .get_term("SNOMED-CT", "38341003", None, None)
+        .await
+        .expect("an upper-case terminology id matches a lower-case route key");
+    assert_eq!(snomed.received_requests().await.unwrap().len(), 1);
+}
+
+/// The AQL `TERMINOLOGY('expand', …)` seam routes by the value-set URL, so two
+/// value sets on two servers resolve in one instance (QUERY master03
+/// §TERMINOLOGY).
+#[tokio::test]
+async fn the_aql_terminology_seam_routes_per_value_set() {
+    let snomed = expand_server("http://vs.example/snomed-set", &["38341003"]).await;
+    let loinc = expand_server("http://vs.example/loinc-set", &["8480-6"]).await;
+
+    let snomed_cfg = provider_cfg(&snomed.uri());
+    let loinc_cfg = provider_cfg(&loinc.uri());
+    let cfg = external(
+        &[("snomed", &snomed_cfg), ("loinc", &loinc_cfg)],
+        &[
+            ("http://vs.example/snomed-set", "snomed"),
+            ("http://vs.example/loinc-set", "loinc"),
+        ],
+    );
+    let service = service_with(
+        TerminologyRouter::build(&cfg)
+            .expect("build router")
+            .expect("router"),
+    )
+    .await;
+
+    let codes = ehrbase::aql::terminology::TerminologyExpander::expand(
+        &service,
+        "hl7.org/fhir/4.0",
+        "http://vs.example/snomed-set",
+    )
+    .await
+    .expect("expand the SNOMED value set");
+    assert_eq!(codes, ["38341003"]);
+
+    let codes = ehrbase::aql::terminology::TerminologyExpander::expand(
+        &service,
+        "hl7.org/fhir/4.0",
+        "http://vs.example/loinc-set",
+    )
+    .await
+    .expect("expand the LOINC value set");
+    assert_eq!(codes, ["8480-6"]);
+
+    assert_eq!(snomed.received_requests().await.unwrap().len(), 1);
+    assert_eq!(loinc.received_requests().await.unwrap().len(), 1);
+}
+
+/// With no external terminology configured — the shipped default — no router
+/// is built at all, so terminology stays on the in-process `openehr-term`
+/// bundle and no remote call can happen.
+#[tokio::test]
+async fn the_disabled_default_builds_no_router_and_calls_nothing() {
+    let unreachable = MockServer::start().await;
+    let cfg = ExternalTerminologyConfig {
+        // A provider IS configured — only `enabled` is off, which is the
+        // switch that must decide.
+        providers: BTreeMap::from([("default".to_owned(), provider_cfg(&unreachable.uri()))]),
+        ..ExternalTerminologyConfig::default()
+    };
+    assert!(!cfg.enabled, "external terminology is off by default");
+    assert!(
+        TerminologyRouter::build(&cfg).expect("build").is_none(),
+        "the disabled default materialises no terminology server"
+    );
+
+    // A bare service answers the bundle terminologies exactly as before and
+    // never reaches out.
+    let db = testkit::db().await.expect("testkit database");
+    let service = EhrbaseService::new(db.pool());
+    assert!(
+        service
+            .has_term("ISO_3166-1", "NL", None)
+            .await
+            .expect("bundle lookup"),
+        "the openEHR bundle still answers with no external provider"
+    );
+    let unknown = service
+        .get_term("http://snomed.info/sct", "38341003", None, None)
+        .await;
+    assert!(
+        unknown.is_err(),
+        "an unknown terminology stays a bundle precondition failure, not a remote call"
+    );
+    assert_eq!(
+        unreachable.received_requests().await.unwrap().len(),
+        0,
+        "nothing was sent to the configured-but-disabled server"
+    );
+}
+
+/// A provider with an `oauth2_client` obtains a client-credentials token
+/// (RFC 6749 §4.4) and sends it as a bearer credential on every FHIR
+/// operation; the token is cached, so a second operation costs no second
+/// grant.
+#[tokio::test]
+async fn oauth2_client_credentials_token_is_obtained_and_reused() {
+    let idp = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        // client_secret_basic (RFC 6749 §2.3.1) — credentials in the header,
+        // never the body.
+        .and(header_exists("authorization"))
+        .and(body_string_contains("grant_type=client_credentials"))
+        // The configured scope reaches the token request (RFC 6749 §4.4.2);
+        // the matcher stops at the scope name because the form encoder's
+        // treatment of `/` and `*` is its own business, not this test's.
+        .and(body_string_contains("scope=system"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "access_token": "tok-abc",
+            "token_type": "bearer",
+            "expires_in": 3600
+        })))
+        .mount(&idp)
+        .await;
+
+    let ts = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/CodeSystem/$lookup"))
+        .and(header("authorization", "Bearer tok-abc"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "resourceType": "Parameters",
+            "parameter": [{"name": "display", "valueString": "Hypertensive disorder"}]
+        })))
+        .mount(&ts)
+        .await;
+
+    let mut ts_cfg = provider_cfg(&ts.uri());
+    ts_cfg.oauth2_client = Some("ts-client".to_owned());
+    let cfg = ExternalTerminologyConfig {
+        enabled: true,
+        providers: BTreeMap::from([("default".to_owned(), ts_cfg)]),
+        oauth2_clients: BTreeMap::from([(
+            "ts-client".to_owned(),
+            TerminologyOauth2Config {
+                token_url: format!("{}/token", idp.uri()),
+                client_id: "ehrbase-cdr".to_owned(),
+                client_secret: Some(ehrbase::config::secret::Secret::new("s3cret")),
+                client_secret_file: None,
+                scopes: vec!["system/*.read".to_owned()],
+                refresh_leeway_secs: 30,
+                auth_method: Oauth2AuthMethod::ClientSecretBasic,
+            },
+        )]),
+        ..ExternalTerminologyConfig::default()
+    };
+    let service = service_with(
+        TerminologyRouter::build(&cfg)
+            .expect("build router")
+            .expect("router"),
+    )
+    .await;
+
+    for _ in 0..2 {
+        service
+            .get_term(SNOMED, "38341003", None, None)
+            .await
+            .expect("an authenticated lookup succeeds");
+    }
+    assert_eq!(
+        ts.received_requests().await.unwrap().len(),
+        2,
+        "both lookups carried the bearer credential (an unauthenticated one would not match)"
+    );
+    assert_eq!(
+        idp.received_requests().await.unwrap().len(),
+        1,
+        "the token is cached — a second operation must not re-run the grant"
+    );
+}
+
+/// A token endpoint that refuses the grant surfaces as a typed provider error
+/// — never a silent unauthenticated request.
+#[tokio::test]
+async fn a_refused_grant_is_a_typed_error_not_an_anonymous_request() {
+    let idp = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+            "error": "invalid_client"
+        })))
+        .mount(&idp)
+        .await;
+
+    let ts = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "resourceType": "Parameters",
+            "parameter": [{"name": "display", "valueString": "should never be reached"}]
+        })))
+        .mount(&ts)
+        .await;
+
+    let mut ts_cfg = provider_cfg(&ts.uri());
+    ts_cfg.oauth2_client = Some("ts-client".to_owned());
+    let cfg = ExternalTerminologyConfig {
+        enabled: true,
+        providers: BTreeMap::from([("default".to_owned(), ts_cfg)]),
+        oauth2_clients: BTreeMap::from([(
+            "ts-client".to_owned(),
+            TerminologyOauth2Config {
+                token_url: format!("{}/token", idp.uri()),
+                client_id: "ehrbase-cdr".to_owned(),
+                client_secret: Some(ehrbase::config::secret::Secret::new("wrong")),
+                client_secret_file: None,
+                scopes: Vec::new(),
+                refresh_leeway_secs: 30,
+                auth_method: Oauth2AuthMethod::ClientSecretBasic,
+            },
+        )]),
+        ..ExternalTerminologyConfig::default()
+    };
+    let service = service_with(
+        TerminologyRouter::build(&cfg)
+            .expect("build router")
+            .expect("router"),
+    )
+    .await;
+
+    let err = service
+        .get_term(SNOMED, "38341003", None, None)
+        .await
+        .expect_err("a refused grant must fail the call");
+    assert!(
+        err.message.contains("client-credentials grant failed"),
+        "the error names the failing grant, got: {}",
+        err.message
+    );
+    assert_eq!(
+        ts.received_requests().await.unwrap().len(),
+        0,
+        "no request reaches the terminology server without a token"
+    );
+}
+
+/// `client_secret_post` puts the credentials in the token-request body
+/// instead of the `Authorization` header (RFC 6749 §2.3.1).
+#[tokio::test]
+async fn client_secret_post_sends_credentials_in_the_body() {
+    let idp = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .and(body_string_contains("client_id=ehrbase-cdr"))
+        .and(body_string_contains("client_secret=s3cret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "access_token": "tok-post",
+            "token_type": "bearer",
+            "expires_in": 3600
+        })))
+        .mount(&idp)
+        .await;
+
+    let ts = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(header("authorization", "Bearer tok-post"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "resourceType": "Parameters",
+            "parameter": [{"name": "display", "valueString": "ok"}]
+        })))
+        .mount(&ts)
+        .await;
+
+    let mut ts_cfg = provider_cfg(&ts.uri());
+    ts_cfg.oauth2_client = Some("ts-client".to_owned());
+    let cfg = ExternalTerminologyConfig {
+        enabled: true,
+        providers: BTreeMap::from([("default".to_owned(), ts_cfg)]),
+        oauth2_clients: BTreeMap::from([(
+            "ts-client".to_owned(),
+            TerminologyOauth2Config {
+                token_url: format!("{}/token", idp.uri()),
+                client_id: "ehrbase-cdr".to_owned(),
+                client_secret: Some(ehrbase::config::secret::Secret::new("s3cret")),
+                client_secret_file: None,
+                scopes: Vec::new(),
+                refresh_leeway_secs: 30,
+                auth_method: Oauth2AuthMethod::ClientSecretPost,
+            },
+        )]),
+        ..ExternalTerminologyConfig::default()
+    };
+    let service = service_with(
+        TerminologyRouter::build(&cfg)
+            .expect("build router")
+            .expect("router"),
+    )
+    .await;
+    service
+        .get_term(SNOMED, "38341003", None, None)
+        .await
+        .expect("the post-form grant authenticates the lookup");
+    assert_eq!(idp.received_requests().await.unwrap().len(), 1);
+}
+
+/// A `ValueSet/$expand` server answering only for `value_set_url`.
+async fn expand_server(value_set_url: &str, codes: &[&str]) -> MockServer {
+    let server = MockServer::start().await;
+    let contains: Vec<_> = codes
+        .iter()
+        .map(|c| json!({ "system": "s", "code": c, "display": c }))
+        .collect();
+    Mock::given(method("GET"))
+        .and(path("/ValueSet/$expand"))
+        .and(query_param("url", value_set_url))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "resourceType": "ValueSet",
+            "expansion": { "contains": contains }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+    server
+}
+
+/// A service over a throwaway database with `router` installed. The database
+/// comes from the shared harness — never a per-test container.
+async fn service_with(router: TerminologyRouter) -> EhrbaseService {
+    let db = testkit::db().await.expect("testkit database");
+    EhrbaseService::new(db.pool()).with_terminology_router(Arc::new(router))
+}

--- a/crates/openehr-its/src/flat/validation/mod.rs
+++ b/crates/openehr-its/src/flat/validation/mod.rs
@@ -184,6 +184,52 @@ pub fn validate_archetype_conformance_incomplete(
     v.out
 }
 
+/// One terminology-server question the template's archetype **constraint
+/// bindings** raise about a coded value in this instance.
+///
+/// A `CONSTRAINT_REF` bound to an external terminology query names a value set
+/// the instance's code must belong to (BASE
+/// `architecture_overview/master12-terminology.adoc` §"Binding Terminology
+/// Value-sets to Archetypes": the ac-code "is bound to queries to one or more
+/// external terminologies, whose result would be a … value set from that
+/// terminology"). The query lives in a "terminology query server", which this
+/// crate has no access to — so the walk collects the questions and a caller
+/// that owns a terminology service answers them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConstraintBindingCheck {
+    /// The archetype `aqlPath` of the constrained node (the path a resulting
+    /// violation is keyed by).
+    pub path: String,
+    /// The archetype constraint code (`ac0004`) the binding is keyed by.
+    pub ac_code: String,
+    /// The terminology the binding names (`SNOMED-CT`, `LOINC`, …) — the
+    /// routing key for choosing a terminology server.
+    pub binding_terminology: String,
+    /// The bound terminology-query URI identifying the admissible value set.
+    pub query_uri: String,
+    /// The instance code's own terminology id (`CODE_PHRASE.terminology_id`).
+    pub instance_terminology: String,
+    /// The instance code (`CODE_PHRASE.code_string`) whose membership is in
+    /// question.
+    pub instance_code: String,
+}
+
+/// Collect every [`ConstraintBindingCheck`] the template's constraint bindings
+/// raise for this instance, by the same archetype-conformance walk
+/// [`validate_archetype_conformance`] performs (so a check is raised only for a
+/// node the template actually matched). Pure: no violation is decided here —
+/// the caller resolves each query against its terminology service.
+#[must_use]
+pub fn collect_constraint_binding_checks(
+    composition: &Value,
+    wt: &WebTemplate,
+) -> Vec<ConstraintBindingCheck> {
+    let mut v = Validator::default();
+    v.collect_bindings = true;
+    v.walk(composition, &wt.tree);
+    v.bindings
+}
+
 /// Validate the `|other` open-value-set rules on a **FLAT input** map, before
 /// conversion to RM (ITS-REST `simplified_formats/master04-basic_concepts.adoc`
 /// §"Open Value-Sets and the `|other` Suffix"):
@@ -546,6 +592,14 @@ struct Validator {
     /// `PatternError`, `CodedValue`, `WrongType`) are still enforced — only the
     /// "not enough / absent" violations are suppressed.
     relax_lower_bounds: bool,
+    /// When set, the archetype-conformance walk records the terminology
+    /// questions the matched nodes' constraint bindings raise into
+    /// [`Self::bindings`] (see [`collect_constraint_binding_checks`]). Off for
+    /// the ordinary validation passes, which decide nothing about bindings.
+    collect_bindings: bool,
+    /// The collected constraint-binding checks (empty unless
+    /// [`Self::collect_bindings`]).
+    bindings: Vec<ConstraintBindingCheck>,
 }
 
 impl Validator {
@@ -838,6 +892,42 @@ impl Validator {
     /// Visit an instance node matched to a `WebTemplate` node: check type
     /// conformance, leaf domain constraints, then descend into the `WebTemplate`
     /// children and container cardinalities.
+    /// Record the terminology questions this matched node's constraint
+    /// bindings raise about the instance's coded value. The `CODE_PHRASE` is
+    /// read from the binding's `attr` (`defining_code` for a `DV_CODED_TEXT`);
+    /// an empty `attr` means the node itself IS the `CODE_PHRASE`. A node the
+    /// instance leaves uncoded raises no question — the binding constrains a
+    /// value that is not there.
+    fn collect_node_bindings(&mut self, instance: &Value, wt: &WebTemplateNode) {
+        for binding in &wt.constraint_bindings {
+            let code_phrase = if binding.attr.is_empty() {
+                Some(instance)
+            } else {
+                instance.get(&binding.attr)
+            };
+            let Some(cp) = code_phrase else { continue };
+            let Some(code) = cp.get("code_string").and_then(Value::as_str) else {
+                continue;
+            };
+            if code.is_empty() {
+                continue;
+            }
+            let instance_terminology = cp
+                .get("terminology_id")
+                .and_then(|t| t.get("value"))
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            self.bindings.push(ConstraintBindingCheck {
+                path: wt.aql_path.clone(),
+                ac_code: binding.ac_code.clone(),
+                binding_terminology: binding.terminology.clone(),
+                query_uri: binding.query_uri.clone(),
+                instance_terminology: instance_terminology.to_owned(),
+                instance_code: code.to_owned(),
+            });
+        }
+    }
+
     fn walk(&mut self, instance: &Value, wt: &WebTemplateNode) {
         if let Some(inst_type) = instance.get("_type").and_then(Value::as_str)
             && !subtype::conforms(inst_type, &wt.rm_type)
@@ -856,6 +946,10 @@ impl Validator {
 
         if !wt.inputs.is_empty() {
             leaf::check_inputs(self, instance, wt);
+        }
+
+        if self.collect_bindings && !wt.constraint_bindings.is_empty() {
+            self.collect_node_bindings(instance, wt);
         }
 
         // The archetype-conformance walk is driven by the node's pre-parsed

--- a/crates/openehr-its/src/flat/webtemplate/builder.rs
+++ b/crates/openehr-its/src/flat/webtemplate/builder.rs
@@ -44,16 +44,16 @@
 use std::collections::HashMap;
 
 use crate::opt14::{
-    ArchetypeTerm, Assertion, CArchetypeRoot, CObject, CPrimitive, Cardinality, Intervalofinteger,
-    OperationalTemplate, TermBindingItem, Termbindingset,
+    ArchetypeTerm, Assertion, CArchetypeRoot, CObject, CPrimitive, Cardinality,
+    Constraintbindingset, Intervalofinteger, OperationalTemplate, TermBindingItem, Termbindingset,
 };
 use indexmap::IndexMap;
 
 use super::inputs::{self, Labels};
 use super::model::{
     CodedName, WebTemplate, WebTemplateArchetypeSlot, WebTemplateBindingCodedValue,
-    WebTemplateCardinality, WebTemplateClosedAttribute, WebTemplateCodeList, WebTemplateExistence,
-    WebTemplateNode, WebTemplateStructuralStub,
+    WebTemplateCardinality, WebTemplateClosedAttribute, WebTemplateCodeList,
+    WebTemplateConstraintBinding, WebTemplateExistence, WebTemplateNode, WebTemplateStructuralStub,
 };
 use super::shape;
 
@@ -71,12 +71,18 @@ type Ontology = HashMap<String, HashMap<String, HashMap<String, Rubric>>>;
 /// root's `term_bindings`. A node inherits its owning archetype root's bindings.
 type TermBindings = HashMap<String, Vec<Termbindingset>>;
 
+/// External **constraint** bindings per archetype, keyed by `archetype_id`: the
+/// flat ontology's `constraint_bindings` (ac-code → terminology-query URI,
+/// `AM/docs/ADL1.4/master08-adl.adoc` §Constraint_bindings).
+type ConstraintBindings = HashMap<String, Vec<Constraintbindingset>>;
+
 /// Build context shared across the walk.
 struct Ctx {
     default_language: String,
     languages: Vec<String>,
     ontology: Ontology,
     term_bindings: TermBindings,
+    constraint_bindings: ConstraintBindings,
 }
 
 impl Ctx {
@@ -118,6 +124,67 @@ impl Ctx {
         }
         out
     }
+
+    /// The external constraint bindings of `ac_code` within `arch_id`'s
+    /// archetype: one entry per terminology whose `ConstraintBindingSet` binds
+    /// the ac-code to a query URI (`AM/docs/ADL1.4/master08-adl.adoc`
+    /// §Constraint_bindings). `attr` is the RM attribute of the leaf carrying
+    /// the constrained code. An empty query URI is dropped — an unbound
+    /// ac-code constrains nothing resolvable.
+    fn constraint_bindings_for(
+        &self,
+        arch_id: &str,
+        ac_code: &str,
+        attr: &str,
+    ) -> Vec<WebTemplateConstraintBinding> {
+        let mut out = Vec::new();
+        if ac_code.is_empty() {
+            return out;
+        }
+        let Some(sets) = self.constraint_bindings.get(arch_id) else {
+            return out;
+        };
+        for set in sets {
+            for item in set.items.iter().filter(|it| it.code == ac_code) {
+                let query_uri = item.value.trim();
+                if query_uri.is_empty() {
+                    continue;
+                }
+                out.push(WebTemplateConstraintBinding {
+                    attr: attr.to_owned(),
+                    ac_code: ac_code.to_owned(),
+                    terminology: set.terminology.clone(),
+                    query_uri: query_uri.to_owned(),
+                });
+            }
+        }
+        out
+    }
+}
+
+/// Every `CONSTRAINT_REF` (`ac`-code proxy) in force on `co`, resolved against
+/// the archetype ontology's `constraint_bindings`: the node itself when it IS a
+/// `CONSTRAINT_REF` (a bare `CODE_PHRASE` proxy), plus one per coded attribute
+/// (`defining_code`, …) whose child is a `CONSTRAINT_REF`. AOM 1.4
+/// `master04-constraint_model_package.adoc` §Reference Objects.
+fn constraint_bindings_of(
+    ctx: &Ctx,
+    co: &CObject,
+    arch_id: &str,
+) -> Vec<WebTemplateConstraintBinding> {
+    let mut out = Vec::new();
+    if let CObject::ConstraintRef(cr) = co {
+        out.extend(ctx.constraint_bindings_for(arch_id, &cr.reference, ""));
+    }
+    for attr in inputs::attributes(co) {
+        let attr_name = inputs::attribute_name(attr);
+        for child in inputs::attribute_children(attr) {
+            if let CObject::ConstraintRef(cr) = child {
+                out.extend(ctx.constraint_bindings_for(arch_id, &cr.reference, attr_name));
+            }
+        }
+    }
+    out
 }
 
 /// The bound code phrase's code string with its terminology id (falling back to
@@ -206,6 +273,7 @@ pub fn build_web_template(
         languages: collect_languages(opt, &default_language),
         ontology: collect_ontology(opt, &default_language),
         term_bindings: collect_term_bindings(opt),
+        constraint_bindings: collect_constraint_bindings(opt),
         default_language,
     };
 
@@ -322,6 +390,12 @@ fn create_node(
     // whose item code matches this node's constraint node id (master04
     // §"Web Template Metadata": the node-level `termBindings` map).
     node.term_bindings = ctx.term_bindings_for(arch_id, name_code);
+    // Archetype constraint bindings (ac-code → external terminology query) in
+    // force on this node's coded value — resolvable only by a terminology
+    // service, so recorded rather than checked here (BASE
+    // `architecture_overview/master12-terminology.adoc` §"Binding Terminology
+    // Value-sets to Archetypes").
+    node.constraint_bindings = constraint_bindings_of(ctx, co, arch_id);
     node
 }
 
@@ -1036,6 +1110,24 @@ fn collect_root_bindings(root: &CArchetypeRoot, out: &mut TermBindings) {
     for r in nested {
         collect_root_bindings(r, out);
     }
+}
+
+/// Collect the flat ontologies' `constraint_bindings`, keyed by archetype id —
+/// the ac-code → terminology-query URI map a `CONSTRAINT_REF` resolves through
+/// (`AM/docs/ADL1.4/master08-adl.adoc` §Constraint_bindings). The root
+/// `ontology` and every `component_ontologies` entry carries its own
+/// `archetype_id`.
+fn collect_constraint_bindings(opt: &OperationalTemplate) -> ConstraintBindings {
+    let mut out: ConstraintBindings = HashMap::new();
+    for onto in opt.ontology.iter().chain(opt.component_ontologies.iter()) {
+        if onto.constraint_bindings.is_empty() {
+            continue;
+        }
+        out.entry(onto.archetype_id.clone())
+            .or_default()
+            .extend(onto.constraint_bindings.iter().cloned());
+    }
+    out
 }
 
 fn rubric_of(term: &ArchetypeTerm) -> Rubric {

--- a/crates/openehr-its/src/flat/webtemplate/mod.rs
+++ b/crates/openehr-its/src/flat/webtemplate/mod.rs
@@ -23,6 +23,7 @@ pub(crate) use inputs::PROPORTION_KINDS;
 pub use model::{
     CodedName, WebTemplate, WebTemplateArchetypeSlot, WebTemplateBindingCodedValue,
     WebTemplateCardinality, WebTemplateClosedAttribute, WebTemplateCodeList, WebTemplateCodedValue,
-    WebTemplateExistence, WebTemplateInput, WebTemplateInputType, WebTemplateNode,
-    WebTemplateRange, WebTemplateSlot, WebTemplateStructuralStub, WebTemplateValidation,
+    WebTemplateConstraintBinding, WebTemplateExistence, WebTemplateInput, WebTemplateInputType,
+    WebTemplateNode, WebTemplateRange, WebTemplateSlot, WebTemplateStructuralStub,
+    WebTemplateValidation,
 };

--- a/crates/openehr-its/src/flat/webtemplate/model.rs
+++ b/crates/openehr-its/src/flat/webtemplate/model.rs
@@ -246,6 +246,22 @@ pub struct WebTemplateNode {
     #[serde(skip)]
     pub code_lists: Vec<WebTemplateCodeList>,
 
+    /// Archetype **constraint bindings** in force on this node: an `ac`-code
+    /// `CONSTRAINT_REF` under a coded attribute whose ac-code the OPT ontology
+    /// binds to an external terminology query
+    /// (`AM/docs/ADL1.4/master08-adl.adoc` §Constraint_bindings). BASE
+    /// `architecture_overview/master12-terminology.adoc` §"Binding Terminology
+    /// Value-sets to Archetypes": "an internal code is defined, in this case an
+    /// 'ac' code … and this is bound to queries to one or more external
+    /// terminologies, whose result would be a (possibly structured) value set
+    /// from that terminology"; the query itself "is defined within a
+    /// 'terminology query server'". The binding is therefore NOT resolvable
+    /// inside this crate — the checks it implies are surfaced by
+    /// [`crate::flat::validation::collect_constraint_binding_checks`] for a
+    /// caller that owns a terminology service. Validation-only; `#[serde(skip)]`.
+    #[serde(skip)]
+    pub constraint_bindings: Vec<WebTemplateConstraintBinding>,
+
     /// Closed-archetype constraints: per
     /// constrained attribute that carries archetype-node-identified alternatives
     /// and/or open `ARCHETYPE_SLOT`s, the admissible child identities. The walk
@@ -336,6 +352,7 @@ impl WebTemplateNode {
             quantity_property: None,
             coded_terminology_local: false,
             code_lists: Vec::new(),
+            constraint_bindings: Vec::new(),
             closed_attributes: Vec::new(),
             structural_stubs: Vec::new(),
             full_id: String::new(),
@@ -538,6 +555,35 @@ pub struct WebTemplateCodeList {
     pub attr: String,
     pub terminology: Option<String>,
     pub codes: Vec<String>,
+}
+
+/// An archetype **constraint binding** in force on a coded leaf
+/// (validation-only, never serialized).
+///
+/// A `CONSTRAINT_REF` under a coded attribute is "a proxy for a set of
+/// constraints … expressed in the binding of the constraint reference (e.g.
+/// 'ac0004') to a query … into an external service (e.g. a terminology
+/// service)" (`AM/docs/AOM1.4/master04-constraint_model_package.adoc`
+/// §Reference Objects); the ac-code → query mapping is the archetype ontology's
+/// `constraint_bindings` (`AM/docs/ADL1.4/master08-adl.adoc`
+/// §Constraint_bindings). Resolving the query is a terminology-server duty
+/// (BASE `architecture_overview/master12-terminology.adoc` §"Binding
+/// Terminology Value-sets to Archetypes"), so the web template only records
+/// what must be asked.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WebTemplateConstraintBinding {
+    /// The RM attribute of this leaf holding the coded value the binding
+    /// constrains (`defining_code` for a `DV_CODED_TEXT`; empty when the node
+    /// itself IS the `CODE_PHRASE` proxy).
+    pub attr: String,
+    /// The archetype constraint code (`ac0004`) the binding is keyed by.
+    pub ac_code: String,
+    /// The terminology the binding names (the `ConstraintBindingSet`
+    /// `terminology`, e.g. `SNOMED-CT`, `LOINC`).
+    pub terminology: String,
+    /// The bound terminology-query URI whose result is the admissible value
+    /// set.
+    pub query_uri: String,
 }
 
 /// A structural stub for an RM-mandatory structural attribute of an ENTRY-family

--- a/crates/openehr-its/src/flat/webtemplate/shape.rs
+++ b/crates/openehr-its/src/flat/webtemplate/shape.rs
@@ -666,4 +666,14 @@ fn copy_values(from: &WebTemplateNode, to: &mut WebTemplateNode) {
     to.slots.extend(from.slots.iter().cloned());
     to.closed_attributes
         .extend(from.closed_attributes.iter().cloned());
+    // A collapsed wrapper may itself have carried the `CONSTRAINT_REF` proxy
+    // (an ELEMENT whose `value` IS the ac-code reference), so its constraint
+    // bindings move to the survivor rather than being dropped. Deduplicated —
+    // both nodes can name the same ac-code binding, and one check per binding
+    // is enough.
+    for binding in &from.constraint_bindings {
+        if !to.constraint_bindings.contains(binding) {
+            to.constraint_bindings.push(binding.clone());
+        }
+    }
 }

--- a/crates/openehr-its/tests/constraint_binding_capture.rs
+++ b/crates/openehr-its/tests/constraint_binding_capture.rs
@@ -1,0 +1,212 @@
+#![allow(clippy::panic, clippy::print_stdout, let_underscore_drop)] // test assertions/diagnostics
+//! Archetype **constraint bindings** — the OPT → `WebTemplate` capture and the
+//! instance-side check collection.
+//!
+//! BASE `docs/architecture_overview/master12-terminology.adoc` §"Binding
+//! Terminology Value-sets to Archetypes": where a terminology is the
+//! appropriate source of values, "an internal code is defined, in this case an
+//! 'ac' code ('ac' = archetype constraint), and this is bound to queries to one
+//! or more external terminologies, whose result would be a (possibly
+//! structured) value set from that terminology". The query "is defined within a
+//! 'terminology query server'", so this crate cannot resolve it — it captures
+//! the binding
+//! ([`WebTemplateConstraintBinding`](openehr_its::flat::webtemplate::WebTemplateConstraintBinding))
+//! and surfaces the questions
+//! ([`collect_constraint_binding_checks`](openehr_its::flat::validation::collect_constraint_binding_checks))
+//! for a caller that owns one.
+//!
+//! The constraint-model side is AOM 1.4
+//! `AM/docs/AOM1.4/master04-constraint_model_package.adoc` §Reference Objects
+//! (a `CONSTRAINT_REF` is "a proxy for a set of constraints … expressed in the
+//! binding of the constraint reference (e.g. 'ac0004') to a query"), and the
+//! ac-code → query map is the ontology's `constraint_bindings`
+//! (`AM/docs/ADL1.4/master08-adl.adoc` §Constraint_bindings).
+
+use std::path::PathBuf;
+
+use openehr_its::flat::validation::collect_constraint_binding_checks;
+use openehr_its::flat::webtemplate::{WebTemplate, WebTemplateNode, build_web_template};
+use openehr_its::opt14;
+use serde_json::json;
+
+const BOUND_VS: &str = "http://terminology.example/ValueSet/blood-group";
+const SNOMED: &str = "http://snomed.info/sct";
+
+/// The vendored corpus template whose `DV_CODED_TEXT.defining_code` is a
+/// `CONSTRAINT_REF` to `ac0001`. It deliberately carries NO binding (its
+/// purpose is the *unbound* case), so the bound case is produced by adding the
+/// ontology `constraint_bindings` element the bound case is defined by — the
+/// only difference between the two.
+fn corpus_opt() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tools/cnf-runner/artifacts/corpus/templates/dt_coded_text_constraint_ref.opt");
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+/// The corpus template with an `ontology` binding `ac0001` to a
+/// terminology-query URI (`ARCHETYPE_ONTOLOGY.constraint_bindings`, an
+/// `archetype_id`-scoped `ConstraintBindingSet`).
+fn bound_opt() -> String {
+    let ontology = format!(
+        r#"<ontology archetype_id="openEHR-EHR-OBSERVATION.minimal.v1">
+             <constraint_bindings terminology="SNOMED-CT">
+               <items code="ac0001"><value>{BOUND_VS}</value></items>
+             </constraint_bindings>
+           </ontology>"#
+    );
+    let xml = corpus_opt();
+    assert!(
+        xml.contains("</definition>"),
+        "the corpus template shape changed; the ontology injection point is gone"
+    );
+    xml.replace("</definition>", &format!("</definition>\n  {ontology}"))
+}
+
+fn build(xml: &str) -> WebTemplate {
+    let opt = opt14::from_xml(xml).unwrap_or_else(|e| panic!("opt14 parse: {e}"));
+    build_web_template(&opt).unwrap_or_else(|e| panic!("build_web_template: {e}"))
+}
+
+/// Depth-first search for the first node carrying a constraint binding.
+fn find_bound(n: &WebTemplateNode) -> Option<&WebTemplateNode> {
+    if !n.constraint_bindings.is_empty() {
+        return Some(n);
+    }
+    n.children.iter().find_map(find_bound)
+}
+
+/// A bound `CONSTRAINT_REF` is captured onto the coded leaf, naming the RM
+/// attribute it constrains, the ac-code, the binding terminology, and the
+/// query URI.
+#[test]
+fn a_bound_constraint_ref_is_captured_on_the_coded_leaf() {
+    let wt = build(&bound_opt());
+    let node = find_bound(&wt.tree).expect("the bound coded leaf carries its constraint binding");
+    assert_eq!(node.constraint_bindings.len(), 1);
+    let binding = &node.constraint_bindings[0];
+    assert_eq!(binding.ac_code, "ac0001");
+    assert_eq!(binding.terminology, "SNOMED-CT");
+    assert_eq!(binding.query_uri, BOUND_VS);
+    assert_eq!(
+        binding.attr, "defining_code",
+        "the binding names the coded RM attribute it constrains"
+    );
+}
+
+/// An `ac`-code with no binding captures nothing: AOM 1.4 leaves the
+/// no-binding case undefined and no local fallback exists, so it constrains
+/// nothing enforceable at commit time.
+#[test]
+fn an_unbound_constraint_ref_captures_nothing() {
+    let wt = build(&corpus_opt());
+    assert!(
+        find_bound(&wt.tree).is_none(),
+        "an unbound CONSTRAINT_REF must not raise a terminology question"
+    );
+}
+
+/// The instance walk raises exactly one question per bound coded value
+/// present, carrying both the binding's terminology (the routing key) and the
+/// instance's own code + terminology (the membership question).
+#[test]
+fn a_bound_coded_value_raises_one_check() {
+    let wt = build(&bound_opt());
+    let leaf = find_bound(&wt.tree).expect("bound leaf");
+    let composition = composition_with_code(&leaf.aql_path, "278149003");
+
+    let checks = collect_constraint_binding_checks(&composition, &wt);
+    assert_eq!(checks.len(), 1, "got {checks:?}");
+    let check = &checks[0];
+    assert_eq!(check.ac_code, "ac0001");
+    assert_eq!(check.binding_terminology, "SNOMED-CT");
+    assert_eq!(check.query_uri, BOUND_VS);
+    assert_eq!(check.instance_terminology, SNOMED);
+    assert_eq!(check.instance_code, "278149003");
+    assert_eq!(check.path, leaf.aql_path);
+}
+
+/// An unbound template raises no question at all, so a deployment with no
+/// bindings pays nothing.
+#[test]
+fn an_unbound_template_raises_no_check() {
+    // The two templates share one definition and differ only in the ontology
+    // binding, so the bound build supplies the leaf path and the unbound build
+    // is the subject: the SAME composition raises a check against one and none
+    // against the other.
+    let bound = build(&bound_opt());
+    let leaf = find_bound(&bound.tree).expect("bound leaf");
+    let composition = composition_with_code(&leaf.aql_path, "278149003");
+    assert_eq!(
+        collect_constraint_binding_checks(&composition, &bound).len(),
+        1,
+        "control: the bound template does raise a check for this composition"
+    );
+
+    let unbound = build(&corpus_opt());
+    assert!(collect_constraint_binding_checks(&composition, &unbound).is_empty());
+}
+
+/// A composition that leaves the bound node uncoded raises no question — the
+/// binding constrains a value that is not there.
+#[test]
+fn an_absent_coded_value_raises_no_check() {
+    let wt = build(&bound_opt());
+    let composition = json!({
+        "_type": "COMPOSITION",
+        "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+        "name": { "_type": "DV_TEXT", "value": "minimal" }
+    });
+    assert!(collect_constraint_binding_checks(&composition, &wt).is_empty());
+}
+
+/// A minimal COMPOSITION whose single coded leaf sits at `aql_path` carrying
+/// `code`. The path is the template's own `aqlPath`, so the walk matches it.
+fn composition_with_code(aql_path: &str, code: &str) -> serde_json::Value {
+    // The corpus template's shape:
+    // COMPOSITION[at0000] / content[at0000 OBSERVATION] / data[at0001 HISTORY]
+    //   / events[at0002 EVENT] / data[at0003 ITEM_TREE] / items[at0004 ELEMENT]
+    //   / value (DV_CODED_TEXT).
+    assert!(
+        aql_path.ends_with("/value"),
+        "the coded leaf is the ELEMENT value; got {aql_path}"
+    );
+    json!({
+        "_type": "COMPOSITION",
+        "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+        "name": { "_type": "DV_TEXT", "value": "minimal" },
+        "content": [{
+            "_type": "OBSERVATION",
+            "archetype_node_id": "openEHR-EHR-OBSERVATION.minimal.v1",
+            "name": { "_type": "DV_TEXT", "value": "Minimal" },
+            "data": {
+                "_type": "HISTORY",
+                "archetype_node_id": "at0001",
+                "name": { "_type": "DV_TEXT", "value": "Event Series" },
+                "events": [{
+                    "_type": "POINT_EVENT",
+                    "archetype_node_id": "at0002",
+                    "name": { "_type": "DV_TEXT", "value": "Any event" },
+                    "data": {
+                        "_type": "ITEM_TREE",
+                        "archetype_node_id": "at0003",
+                        "name": { "_type": "DV_TEXT", "value": "Tree" },
+                        "items": [{
+                            "_type": "ELEMENT",
+                            "archetype_node_id": "at0004",
+                            "name": { "_type": "DV_TEXT", "value": "value" },
+                            "value": {
+                                "_type": "DV_CODED_TEXT",
+                                "value": "A positive",
+                                "defining_code": {
+                                    "_type": "CODE_PHRASE",
+                                    "terminology_id": { "_type": "TERMINOLOGY_ID", "value": SNOMED },
+                                    "code_string": code
+                                }
+                            }
+                        }]
+                    }
+                }]
+            }
+        }]
+    })
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -205,7 +205,7 @@ The service layer realizes the openEHR **SM Platform Service Model**
 | System Log | `I_SYSTEM_LOG` (stub; "IHE ATNA-compliant") | `ehrbase::system_log` (dual DICOM PS3.15 + FHIR `AuditEvent`/BALP rendering; local Audit Record Repository in the `audit` schema, on by default; syslog + ITI-20 ATX:FHIR Feed forwarding sinks; the ITI-81 retrieval as the read side; ITI-19 mTLS via `[server.tls]`) | implemented |
 | Admin | `I_ADMIN_SERVICE` (+archive/dump-load) | `service::admin` | implemented |
 | EHR Index | `I_EHR_INDEX` | `service::ehr_index` | implemented |
-| Terminology | `I_TERMINOLOGY_SERVICE` | `service::terminology` | implemented |
+| Terminology | `I_TERMINOLOGY_SERVICE` | `service::terminology` (in-process `openehr-term` bundle + N simultaneously-materialised FHIR R4 servers, selected per call by an explicit terminology→provider route map with a `default` fallback; optional OAuth2 client-credentials per server; commit-time ac-code constraint-binding resolution) | implemented |
 | Message | `I_MESSAGE_SERVICE`, `I_EHR_EXTRACT_SERVICE`, `I_TDD_SERVICE` | `service::message` | implemented |
 | Subject Proxy | `I_SUBJECT_PROXY_SERVICE`, `I_DATA_BINDING` | `service::subject_proxy` | implemented |
 

--- a/website/book/src/installation/configuration.md
+++ b/website/book/src/installation/configuration.md
@@ -473,7 +473,7 @@ events exchange for PHI isolation), `tls` (bool, `false`), `batch_size` (int,
 
 ## `[terminology]`
 
-Terminology extension API and external FHIR-terminology validation.
+Terminology extension API and external FHIR-terminology servers.
 
 `[terminology]`: `api_enabled` (bool, `false`) — mount the terminology
 extension API.
@@ -482,11 +482,99 @@ extension API.
 `[terminology.external.providers.<name>]` (conventionally `default`): `type`
 (enum{fhir}, `fhir`), `url` (string, required), `operation`
 (enum{validate_code,expand}, `validate_code`), `connect_timeout_ms` (int,
-`2000`), `request_timeout_ms` (int, `10000`), `oauth2_client` (string, unset),
+`2000`), `request_timeout_ms` (int, `10000`), `oauth2_client` (string, unset —
+must name an entry under `[terminology.external.oauth2_clients]`),
 `cache_ttl_secs` (int, `300` — TTL of the per-provider response cache; a
 repeated validate/expand/subsumes/lookup within the window is served locally
 instead of one HTTPS round trip per validated code; `0` disables),
 `cache_capacity` (int, `10000` — maximum cached responses per provider).
+
+### Several terminology servers at once
+
+**Every** entry under `[terminology.external.providers]` is materialised at
+startup, so one instance can serve SNOMED CT from one server and LOINC or ICD
+from others. `[terminology.external.routes]` maps a terminology to the provider
+that answers for it — the key is a terminology id (`SNOMED-CT`) or a system URI
+(`http://snomed.info/sct`), matched case-insensitively as a whole string, and
+the value names a provider. A terminology with no route goes to the provider
+named `default`, or to the sole configured provider when there is exactly one.
+A route naming a provider that does not exist is a startup error.
+
+```toml
+[terminology.external]
+enabled = true
+fail_on_error = false
+
+[terminology.external.providers.default]
+type = "fhir"
+url = "https://r4.ontoserver.csiro.au/fhir"
+
+[terminology.external.providers.snomed]
+type = "fhir"
+url = "https://snowstorm.example.org/fhir"
+oauth2_client = "ts-client"
+
+[terminology.external.routes]
+"SNOMED-CT" = "snomed"
+"http://snomed.info/sct" = "snomed"
+"http://loinc.org" = "default"
+```
+
+Routing applies everywhere terminology is consulted: the
+`/terminology/*` extension API, AQL `TERMINOLOGY(…)` resolution, and the
+composition-commit binding checks below.
+
+### Authenticating to a terminology server
+
+`[terminology.external.oauth2_clients.<name>]` configures an OAuth2
+client-credentials client; a provider references it by name with
+`oauth2_client`. The access token is cached and re-requested shortly before it
+expires, so a validation burst costs one token request per token lifetime.
+
+Keys: `token_url` (string, required), `client_id` (string, required),
+`client_secret` (secret — or `client_secret_file` pointing at a file holding
+it; exactly one of the two), `scopes` (list of strings, empty),
+`refresh_leeway_secs` (int, `30` — how long before expiry the token is
+renewed), `auth_method`
+(enum{client_secret_basic,client_secret_post}, `client_secret_basic`).
+
+```toml
+[terminology.external.oauth2_clients.ts-client]
+token_url = "https://idp.example.org/realms/ts/protocol/openid-connect/token"
+client_id = "ehrbase-cdr"
+client_secret_file = "/run/secrets/ts-client"
+scopes = ["system/*.read"]
+```
+
+> [!NOTE]
+> Mutual TLS to a terminology server is not supported yet — a provider cannot
+> present a client certificate.
+
+### Archetype value-set bindings at commit
+
+With `[terminology.external]` enabled, committing a COMPOSITION also resolves
+the archetype **constraint bindings** its template declares: where a template
+binds an `ac` code to an external terminology query, the coded value in the
+composition must be a member of the value set that query returns. The query is
+sent to the server the binding's terminology routes to.
+
+- The code is in the value set → the commit proceeds.
+- The code is **not** in the value set → `422` naming the path, the code, and
+  the bound query. This is a real constraint violation, so `fail_on_error` does
+  not change it.
+- The value set could **not be resolved** (server down, error response, no
+  provider routes to that terminology) → `fail_on_error` decides:
+  `false` (default) accepts the commit and logs a warning; `true` rejects it
+  with `422`.
+
+With `[terminology.external] enabled = false` (the default) no binding is
+resolved and no request is made, so commit behaviour is exactly as before.
+
+> [!NOTE]
+> The composition's `terminology_id` is sent verbatim as the FHIR `system`
+> parameter. If your archetypes use `SNOMED-CT` where your terminology server
+> expects `http://snomed.info/sct`, configure the server to accept the id your
+> archetypes carry — the CDR does not rewrite it.
 
 ## `[multimedia]`
 


### PR DESCRIPTION
The app-core half of #677 (points 1–3; the Docker compose profile + CNF instrument axis follow as the second half). BASE `architecture_overview/master12-terminology.adoc` §Overview names the deployment reality — several external terminologies bound at the same time — and this PR makes the CDR actually operate that way.

## 1. Every configured provider materialised + routed per terminology

`[terminology.external.routes]` maps terminology ids / system URIs (case-insensitive, whole-string) to named providers, `default` as fallback. All providers build at boot (`TerminologyRouter::build`); a route to an unconfigured provider is a BOOT error, never a silent fallback. Selection applied at every seam: the six SM `I_TERMINOLOGY_SERVICE` calls, AQL `TERMINOLOGY()` expand/validate/subsumes + the URI operand, and commit-time binding resolution. Proven with two wiremock servers serving different terminologies in one instance (`two_servers_serve_two_terminologies_at_once` + the fallback/case-insensitivity/AQL-seam siblings). The routing-config mechanics are flagged our-own-design; the simultaneity requirement cites BASE master12 §Overview.

## 2. ac-code binding resolution at composition ingestion

`CONSTRAINT_REF` bindings captured into the WebTemplate (`constraint_bindings`, surviving compaction), one check per bound coded value at commit, resolved through the ROUTED provider (`value_set_validate`): non-member → 422 under either posture; unresolvable → the existing `fail_on_error` fail-open/fail-closed split; external disabled → zero checks, zero requests (proven byte-identical). BASE master12 §Binding Terminology Value-sets to Archetypes + AOM2 master08 §Terminology. The `validation/mod.rs` unwired-NOTE is deleted with the wiring. New metric label `pass="constraint_binding"`.

## 3. TS OAuth2 is live

`oauth2_client` now attaches a client-credentials bearer (pinned `oauth2` crate): token cached, re-minted inside a configurable leeway, `client_secret_basic`/`client_secret_post`, secret inline or file. A refused grant is a typed error and NO anonymous request reaches the TS (tested). mTLS deliberately split: #683 (blocked-by this), carrying the per-provider-vs-shared-outbound-identity design question.

## Gates

fmt clean · clippy zero warnings in touched files (`ehrbase`/`ehrbase-rest`/`ehrbase-server`/`openehr-its`) · `nextest -p ehrbase -p ehrbase-rest` **1294/1294** · `-p openehr-its` **514/514** · changelog-structure OK · Helm validate ALL CHECKS PASSED (goldens unchanged) · config template + book configuration page updated in-PR.

Part of #677.