### PR TITLE
fix(testkit): bounded retry on the clone pool's first connect — the #620 flake root

### DIFF
--- a/tools/testkit/src/lib.rs
+++ b/tools/testkit/src/lib.rs
@@ -241,7 +241,28 @@ async fn provision(server: &str, template: Option<&str>) -> Result<TestDb, Testk
     let mut config = DbConfig::new(url.clone());
     config.max_connections = 10;
     config.min_connections = 0;
-    let pool = db::connect(&config).await?;
+    // The pool's validating first connect gets the same bounded-retry
+    // treatment `connect_ready` gives the admin connect, and for the same
+    // reason: under a full-parallel `nextest` run the shared server's accept
+    // path is briefly saturable, and a clone's first handshake can surface a
+    // transient protocol error (the #620 capture: "unexpected response from
+    // SSLRequest: 0x00" — the connection was accepted at TCP level and
+    // dropped before PostgreSQL answered the negotiation). That is server
+    // load, not a test defect: retry the ESTABLISHMENT briefly and loudly
+    // surface the last error at the deadline. Never a per-test retry.
+    const POOL_DEADLINE: Duration = Duration::from_secs(15);
+    let start = SystemTime::now();
+    let pool = loop {
+        match db::connect(&config).await {
+            Ok(pool) => break pool,
+            Err(error) => {
+                if start.elapsed().unwrap_or(POOL_DEADLINE) >= POOL_DEADLINE {
+                    return Err(TestkitError::from(error));
+                }
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    };
     Ok(TestDb {
         pool,
         url,


### PR DESCRIPTION
Closes #620, all four exit criteria:

1. **Reproduced with the full error text captured**: 12 planned full-parallel `cargo nextest run -p ehrbase` runs (662 tests each) with whole logs retained; run 5 failed exactly once — `the_bootstrap_ehr_status_version_has_no_preceding_version_uid`, 0.477 s, and this time the message survived:
   `testkit database: Db(Sqlx(Protocol("unexpected response from SSLRequest: 0x00 (sqlx_postgres::connection::tls:95)")))`
   at `service_ehr.rs:2551` — the `testkit::db()` call itself, before any service code ran. Runs 1–4 + 6 green (the search closed at reproduction).
2. **Attribution: the shared testkit server under resource pressure / the harness's connect path** — not `status_at`, not the commit path, not clone accumulation (fast failure, not a pool-acquire timeout; same signature seen once in `service_demographic` by a concurrent worker). The TCP connect is accepted and dropped before PostgreSQL answers the SSLRequest negotiation — classic accept-backlog saturation with 640 tests hammering one server.
3. **Fixed at the root**: the harness already retries ANY admin-connect failure for 60 s (`connect_ready`); the clone pool's validating first connect — the one establishment it did NOT guard — now gets the same bounded treatment (15 s deadline, 200 ms cadence, the last error surfaced loudly at deadline). No test touched, no per-test retry.
4. **Not clone accumulation** — the sweep cadence needs no revisit (criterion recorded as N/A with this evidence).

Gates: `cargo clippy -p testkit --all-targets` clean (the one visible warning is the pre-existing `openehr-its` site fixed separately on the clippy branch) · `cargo fmt -p testkit --check` clean. Test-infrastructure only → `no-changelog`.