### PR TITLE
chore(clippy): develop green again under the CI flag set

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -27,3 +27,4 @@
 - [Measurement environment discipline](measurement-environment-discipline.md) — idle box + envelope-matched limits for measured runs; ixit containers blocks track lane renames
 - [ITS audit fix-first cadence](its-audit-fix-first-cadence.md) — owner 2026-07-26: #373 audit runs group-by-group, ALL fix issues from a group implemented+merged before the next group's audit starts; never accumulate finding backlog
 - [Merge on local gates](merge-on-local-gates.md) — owner 2026-07-26: local gates green (fmt+clippy+nextest+cnf validate) → merge the PR immediately, no CI watchers between issues; CI is a post-merge backstop (release cuts keep normal discipline)
+- [Spec-chapter audit programs](spec-chapter-audit-programs.md) — owner method: milestone=component, issue=chapter, whole-codebase /spec-audit sweep, fix-first cadence; v3.13.0=CDS/GDL2 (#716), v3.14.0=BASE (#686), v4.0.0=admin-UI

--- a/.claude/memory/spec-chapter-audit-programs.md
+++ b/.claude/memory/spec-chapter-audit-programs.md
@@ -1,0 +1,29 @@
+---
+name: spec-chapter-audit-programs
+description: "Owner's preferred compliance method — one milestone per spec component, one issue per chapter, whole-codebase sweep, fix-first cadence"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 871531fb-1884-468e-9033-ae616ae2eb2b
+  modified: 2026-07-29T12:41:43.440Z
+---
+
+Owner directive 2026-07-29: systematic code compliance is driven as **one
+milestone = one spec component, one issue per spec CHAPTER**, each chapter
+issue sweeping the WHOLE codebase via `/spec-audit` — the same per-unit
+discipline as the ITS-REST per-endpoint audit (#373). First instance: v3.14.0 = the BASE 1.3.0 program (#686, 29 chapter
+children). Release sequence (owner 2026-07-29): v3.13.0 = the CDS 2.0.1 /
+GDL2 component program (#716 — a NET-NEW component, GDL2 only, retired
+GDL never implemented); v3.14.0 = BASE audit; v4.0.0 = the admin-UI
+program.
+
+**Why:** the owner considers this the best approach to reach real code
+compliance ("proper and systematically"), mirroring what worked for
+ITS-REST.
+
+**How to apply:** when a new compliance push starts (RM, AM, TERM, QUERY
+likely next), propose the same shape: parent program issue + per-chapter
+children (normative chapters only, front matter excluded by adjudication),
+findings as sub-issue fix issues with the [[its-audit-fix-first-cadence]]
+(all fixes from a chapter merged before the next chapter's audit starts),
+zero-drift pipeline at program close.

--- a/app/ehrbase-admin-ui/src/admin.rs
+++ b/app/ehrbase-admin-ui/src/admin.rs
@@ -5,7 +5,7 @@
 //! The CDR's admin group is **off by default**, and while it is disabled every
 //! admin route answers `405 Method Not Allowed` with an empty `Allow` (the
 //! route exists but supports no method — ITS-REST overview
-//! Requests_and_responses.md §HTTP Methods: "If a method is recognized but not
+//! `Requests_and_responses.md` §HTTP Methods: "If a method is recognized but not
 //! allowed for the target resource, the response SHOULD be 405 Method Not
 //! Allowed"). The console therefore discovers the group before offering any of
 //! it, and renders no destructive affordance at all when it is not mounted.
@@ -59,7 +59,7 @@ pub enum AdminAvailability {
     Available,
     /// The manifest does not list `/admin` — the CDR runs with the admin group
     /// disabled and every admin route answers `405` with an empty `Allow`
-    /// (overview Requests_and_responses.md §HTTP Methods).
+    /// (overview `Requests_and_responses.md` §HTTP Methods).
     Disabled,
 }
 

--- a/app/ehrbase-rest/src/api/demographic/mod.rs
+++ b/app/ehrbase-rest/src/api/demographic/mod.rs
@@ -177,7 +177,7 @@ fn set_write_headers(resp: &mut Response, base: &str, segment: &str, meta: Optio
 /// §`REVISION_HISTORY`). A `VERSIONED_OBJECT` container body exposes no
 /// commit audit — which is why the container READ does not use this seam:
 /// its `Last-Modified` rides the service metadata (the version spine's
-/// newest commit instant, overview §"ETag and Last-Modified").
+/// newest commit instant, overview §"`ETag` and Last-Modified").
 fn read_meta(versioned_object_uid: &str, body: &serde_json::Value) -> ResourceMeta {
     let uid = body["uid"]["value"]
         .as_str()

--- a/app/ehrbase-rest/tests/composition_validation_http.rs
+++ b/app/ehrbase-rest/tests/composition_validation_http.rs
@@ -98,7 +98,7 @@ async fn app_with_template() -> (testkit::TestDb, Router, String) {
 }
 
 /// Strip the `value` of the first ELEMENT that has one, leaving no
-/// `null_flavour` behind — the shape RM data_structures §ELEMENT
+/// `null_flavour` behind — the shape RM `data_structures` §ELEMENT
 /// `Inv_null_flavour_indicated` forbids.
 fn strip_first_element_value(v: &mut Value) -> bool {
     match v {
@@ -119,7 +119,7 @@ fn strip_first_element_value(v: &mut Value) -> bool {
 }
 
 /// A COMPOSITION holding an ELEMENT with neither `value` nor `null_flavour`
-/// violates RM data_structures §ELEMENT:
+/// violates RM `data_structures` §ELEMENT:
 ///
 /// > `Inv_null_flavour_indicated`: `is_null() xor null_flavour = Void`
 /// > (`RM/docs/UML/classes/org.openehr.rm.data_structures.element.adoc`)

--- a/app/ehrbase-rest/tests/demographic_tags_http.rs
+++ b/app/ehrbase-rest/tests/demographic_tags_http.rs
@@ -375,8 +375,8 @@ async fn relationship_stale_delete_conflict_echoes_latest_etag() {
 
 // ── the ITEM_TAG identity is the (key, target_path) PAIR ─────────────────────
 
-/// Two same-key tags on different target_paths coexist on one party target and
-/// the PUT round-trips both — ITS-REST overview Requests_and_responses.md
+/// Two same-key tags on different `target_paths` coexist on one party target and
+/// the PUT round-trips both — ITS-REST overview `Requests_and_responses.md`
 /// §openehr-item-tag and openehr-version-item-tag ("uniquely identified by
 /// their `key` and `target_path` pair attributes"); RM common master07-tags.
 /// The run-2 triage regression (2026-07-28): the demographic PUT deduped by

--- a/app/ehrbase-rest/tests/http.rs
+++ b/app/ehrbase-rest/tests/http.rs
@@ -361,6 +361,16 @@ async fn malformed_xml_composition_body_is_400() {
 /// the request, it MUST respond with HTTP status code `406 Not Acceptable`").
 #[tokio::test]
 async fn xml_response_lineage_is_negotiated_by_the_version_parameter() {
+    fn read(ehr_id: &str, accept: &str) -> Request<Body> {
+        Request::builder()
+            .method("GET")
+            .uri(format!("{BASE}/ehr/{ehr_id}"))
+            .header(header::AUTHORIZATION, basic("alice", "pw"))
+            .header(header::ACCEPT, accept)
+            .body(Body::empty())
+            .unwrap()
+    }
+
     let (_pg, app) = app(true).await;
 
     let create = Request::builder()
@@ -372,16 +382,6 @@ async fn xml_response_lineage_is_negotiated_by_the_version_parameter() {
     let (status, headers, _b) = send(app.clone(), create).await;
     assert_eq!(status, StatusCode::CREATED);
     let ehr_id = etag_uid(&headers).expect("ETag carries the new ehr_id");
-
-    fn read(ehr_id: &str, accept: &str) -> Request<Body> {
-        Request::builder()
-            .method("GET")
-            .uri(format!("{BASE}/ehr/{ehr_id}"))
-            .header(header::AUTHORIZATION, basic("alice", "pw"))
-            .header(header::ACCEPT, accept)
-            .body(Body::empty())
-            .unwrap()
-    }
 
     // Default (bare `application/xml`): the v1 lineage, bare Content-Type.
     let (status, headers, xml) = send(app.clone(), read(&ehr_id, "application/xml")).await;

--- a/crates/openehr-its/src/flat/validation/mod.rs
+++ b/crates/openehr-its/src/flat/validation/mod.rs
@@ -224,8 +224,10 @@ pub fn collect_constraint_binding_checks(
     composition: &Value,
     wt: &WebTemplate,
 ) -> Vec<ConstraintBindingCheck> {
-    let mut v = Validator::default();
-    v.collect_bindings = true;
+    let mut v = Validator {
+        collect_bindings: true,
+        ..Validator::default()
+    };
     v.walk(composition, &wt.tree);
     v.bindings
 }

--- a/crates/openehr-its/tests/constraint_binding_capture.rs
+++ b/crates/openehr-its/tests/constraint_binding_capture.rs
@@ -20,7 +20,7 @@
 //! (a `CONSTRAINT_REF` is "a proxy for a set of constraints … expressed in the
 //! binding of the constraint reference (e.g. 'ac0004') to a query"), and the
 //! ac-code → query map is the ontology's `constraint_bindings`
-//! (`AM/docs/ADL1.4/master08-adl.adoc` §Constraint_bindings).
+//! (`AM/docs/ADL1.4/master08-adl.adoc` §`Constraint_bindings`).
 
 use std::path::PathBuf;
 

--- a/crates/openehr-its/tests/rm_validation.rs
+++ b/crates/openehr-its/tests/rm_validation.rs
@@ -860,7 +860,6 @@ fn corpus_elements_without_value_or_null_flavour_are_rejected() {
 
 /// Every ELEMENT in `value` carrying neither `value` nor `null_flavour`.
 fn value_less_elements(value: &Value) -> Vec<&Value> {
-    let mut out = Vec::new();
     fn walk<'a>(v: &'a Value, out: &mut Vec<&'a Value>) {
         match v {
             Value::Object(map) => {
@@ -883,6 +882,7 @@ fn value_less_elements(value: &Value) -> Vec<&Value> {
             _ => {}
         }
     }
+    let mut out = Vec::new();
     walk(value, &mut out);
     out
 }

--- a/crates/openehr-its/tests/rm_validation.rs
+++ b/crates/openehr-its/tests/rm_validation.rs
@@ -747,7 +747,7 @@ fn half_open_interval_is_accepted_with_or_without_flags() {
 
 // ── ELEMENT Inv_null_flavour_indicated (RM data_structures §ELEMENT) ──────────
 
-/// The XOR arms of RM data_structures §ELEMENT `Inv_null_flavour_indicated`:
+/// The XOR arms of RM `data_structures` §ELEMENT `Inv_null_flavour_indicated`:
 ///
 /// > `Inv_null_flavour_indicated`: `is_null() xor null_flavour = Void`
 /// > (`RM/docs/UML/classes/org.openehr.rm.data_structures.element.adoc`)

--- a/crates/openehr-its/tests/webtemplate.rs
+++ b/crates/openehr-its/tests/webtemplate.rs
@@ -460,9 +460,9 @@ fn party_suffixes(node: &WebTemplateNode) -> Vec<&str> {
 /// A slot an OPT narrows to `PARTY_RELATED` is a party LEAF, exactly like one
 /// left at `PARTY_PROXY`/`PARTY_IDENTIFIED`: master05 gives all three subtypes
 /// their own mapping table and they share the party suffix rows. The subtype's
-/// extra `relationship` is a DV_CODED_TEXT SUB-PATH (master05 §"PARTY_RELATED
+/// extra `relationship` is a `DV_CODED_TEXT` SUB-PATH (master05 §"`PARTY_RELATED`
 /// performer": "the `relationship` attribute is emitted as a sub-path under the
-/// participation, with the standard DV_CODED_TEXT suffixes"), so it is a CHILD
+/// participation, with the standard `DV_CODED_TEXT` suffixes"), so it is a CHILD
 /// of the party node — never a reason to demote the party to an inputless
 /// container, which is the divergence this asserts against.
 #[test]

--- a/tools/cnf-runner/src/conf_assets.rs
+++ b/tools/cnf-runner/src/conf_assets.rs
@@ -1329,6 +1329,13 @@ mod tests {
 
     #[test]
     fn the_chart_keeps_its_embedded_width_and_grows_only_downwards() {
+        // Geometry invariants over constants — compile-time (const items,
+        // declared before any statement): the canvas width is pinned and
+        // nothing draws past the right margin.
+        const _: () = assert!(BARS_W.to_bits() == 908.0f64.to_bits());
+        const _: () = assert!(COUNTS_X + 4.0 * SLOT_W <= BARS_W - MARGIN);
+        const _: () = assert!(BAR_X + BAR_MAX_W < COUNTS_X);
+
         let rows = chapter_counts(&results_with(&[(
             "I_EHR_COMPOSITION.create_composition-a",
             OutcomeStatus::Passed,
@@ -1346,10 +1353,6 @@ mod tests {
             "unexpected canvas: {}",
             svg.lines().next().unwrap_or_default()
         );
-        assert!((BARS_W - 908.0).abs() < f64::EPSILON);
-        // Nothing is drawn past the right margin.
-        assert!(COUNTS_X + 4.0 * SLOT_W <= BARS_W - MARGIN);
-        assert!(BAR_X + BAR_MAX_W < COUNTS_X);
     }
 
     #[test]

--- a/tools/cnf-runner/src/conf_assets.rs
+++ b/tools/cnf-runner/src/conf_assets.rs
@@ -544,7 +544,7 @@ pub fn chapter_counts(results: &Results) -> Result<Vec<ChapterRow>, TaxonomyErro
     let mut rows: Vec<ChapterRow> = TAXONOMY
         .iter()
         .map(|(chapter, bands)| ChapterRow {
-            chapter: *chapter,
+            chapter,
             total: BandCounts::default(),
             bands: bands
                 .iter()

--- a/tools/cnf-runner/src/exec/driver.rs
+++ b/tools/cnf-runner/src/exec/driver.rs
@@ -2360,6 +2360,37 @@ impl HttpDriver<'_> {
             exchange.status
         ))
     }
+
+    /// Post-send bookkeeping shared state: the committed-payload trail for
+    /// the equivalent comparison, the last response body, and the System
+    /// OPTIONS manifest's `restapi_specs_version`, when served (released OAS
+    /// `system.openapi.yaml` `Options` — every member optional): observed as
+    /// an independent confirmation of the party's declared `its_rest`
+    /// version, never as the truth (see the field NOTE).
+    fn record_exchange_bookkeeping(
+        &mut self,
+        binding: &OperationBinding,
+        request_spec: &crate::model::binding::RequestSpec,
+        body: Option<&Value>,
+        exchange: &Exchange,
+    ) {
+        if matches!(request_spec.method, HttpMethod::Post | HttpMethod::Put)
+            && let Some(b) = body
+        {
+            self.committed.push(b.clone());
+        }
+        self.last_body.clone_from(&exchange.body);
+        if binding.sm_operation.interface() == "I_ITS_REST_SYSTEM"
+            && binding.sm_operation.operation() == "options"
+            && let Some(version) = exchange
+                .body
+                .as_ref()
+                .and_then(|b| b.get("restapi_specs_version"))
+                .and_then(Value::as_str)
+        {
+            self.observed_restapi_specs_version = Some(version.to_owned());
+        }
+    }
 }
 
 impl StepDriver for HttpDriver<'_> {
@@ -2469,28 +2500,7 @@ impl StepDriver for HttpDriver<'_> {
             Err(fault) => return Ok(StepObservation::transport(fault)),
         };
 
-        // Track committed payloads for the equivalent comparison.
-        if matches!(request_spec.method, HttpMethod::Post | HttpMethod::Put)
-            && let Some(b) = &body
-        {
-            self.committed.push(b.clone());
-        }
-        self.last_body.clone_from(&exchange.body);
-
-        // The System OPTIONS manifest's `restapi_specs_version`, when served
-        // (released OAS `system.openapi.yaml` `Options` — every member
-        // optional): observed as an independent confirmation of the party's
-        // declared its_rest version, never as the truth (see the field NOTE).
-        if binding.sm_operation.interface() == "I_ITS_REST_SYSTEM"
-            && binding.sm_operation.operation() == "options"
-            && let Some(version) = exchange
-                .body
-                .as_ref()
-                .and_then(|b| b.get("restapi_specs_version"))
-                .and_then(Value::as_str)
-        {
-            self.observed_restapi_specs_version = Some(version.to_owned());
-        }
+        self.record_exchange_bookkeeping(binding, request_spec, body.as_ref(), &exchange);
 
         // Classify (law c) and bind captures.
         let selectors = self.set.selectors.as_ref().map(|(_, s)| s);
@@ -2793,7 +2803,7 @@ mod tests {
 
     /// The committed CNF SMART test issuer (`tools/cnf-runner/party/smart/`) —
     /// public test material by design, never production key material.
-    fn test_mint(roles: Vec<String>) -> crate::ixit::BearerMint {
+    fn test_mint(roles: &[String]) -> crate::ixit::BearerMint {
         let key_file = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("party/smart/cnf-smart-test.key.pem");
         serde_json::from_value(serde_json::json!({
@@ -2837,7 +2847,7 @@ mod tests {
     /// space-delimited (RFC 6749 §3.3), and the RBAC role claim.
     #[test]
     fn mint_signs_a_scope_carrying_rs256_token() {
-        let mint = test_mint(vec!["USER".to_owned()]);
+        let mint = test_mint(&["USER".to_owned()]);
         let token = mint_access_token(
             &mint,
             None,
@@ -2858,8 +2868,7 @@ mod tests {
     /// (master08 §Scopes ¶2), so the claim is present and empty.
     #[test]
     fn mint_emits_an_empty_scope_claim_for_a_scopeless_token() {
-        let token =
-            mint_access_token(&test_mint(vec!["USER".to_owned()]), None, None, &[]).unwrap();
+        let token = mint_access_token(&test_mint(&["USER".to_owned()]), None, None, &[]).unwrap();
         let claims = decode_against_committed_jwks(&token);
         assert_eq!(claims["scope"], Value::from(""));
     }
@@ -2919,8 +2928,7 @@ mod tests {
         );
         let merged = HttpDriver::merge_with_vars(&vars, &with);
         assert_eq!(
-            merged
-                .scalar(&CaptureName::parse("preceding_version_uid").unwrap()),
+            merged.scalar(&CaptureName::parse("preceding_version_uid").unwrap()),
             Some("vo::sys::2"),
             "the step's explicit with: value wins in its own scope"
         );

--- a/tools/cnf-runner/src/exec/driver.rs
+++ b/tools/cnf-runner/src/exec/driver.rs
@@ -2920,15 +2920,13 @@ mod tests {
         let merged = HttpDriver::merge_with_vars(&vars, &with);
         assert_eq!(
             merged
-                .scalar(&CaptureName::parse("preceding_version_uid").unwrap())
-                .as_deref(),
+                .scalar(&CaptureName::parse("preceding_version_uid").unwrap()),
             Some("vo::sys::2"),
             "the step's explicit with: value wins in its own scope"
         );
         // The underlying store is untouched — the shadow is step-scoped.
         assert_eq!(
-            vars.scalar(&CaptureName::parse("preceding_version_uid").unwrap())
-                .as_deref(),
+            vars.scalar(&CaptureName::parse("preceding_version_uid").unwrap()),
             Some("vo::sys::1")
         );
     }

--- a/tools/cnf-runner/src/exec/headers.rs
+++ b/tools/cnf-runner/src/exec/headers.rs
@@ -377,7 +377,7 @@ mod tests {
 
     /// `optional: true` splits SHOULD-strength PRESENCE from MUST-strength
     /// FORM (issue #628): the query `ETag` is a SHOULD to emit (overview
-    /// §"ETag and Last-Modified") but a MUST to weaken when emitted
+    /// §"`ETag` and Last-Modified") but a MUST to weaken when emitted
     /// (§"Deprecated headers"). An omitted header passes; a malformed one
     /// still fails.
     #[test]

--- a/tools/cnf-runner/src/model/binding.rs
+++ b/tools/cnf-runner/src/model/binding.rs
@@ -106,7 +106,7 @@ pub enum StripRule {
 /// (issue #403).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 pub enum TransformRule {
-    /// The leading `object_id` — the VERSIONED_OBJECT identifier.
+    /// The leading `object_id` — the `VERSIONED_OBJECT` identifier.
     #[serde(rename = "root-uid")]
     RootUid,
     /// The MIDDLE segment — the identifier of the system that created the
@@ -241,9 +241,9 @@ impl<'de> Deserialize<'de> for HeaderMatcher {
 ///
 /// **`optional`** separates the strength of PRESENCE from the strength of
 /// FORM, because the released text assigns them differently. ITS-REST
-/// `specifications/docs/overview/Requests_and_responses.md` §"ETag and
+/// `specifications/docs/overview/Requests_and_responses.md` §"`ETag` and
 /// Last-Modified": "Both `ETag` and `Last-Modified` SHOULD be included in
-/// responses for VERSION, VERSIONED_OBJECT, or other resources that have
+/// responses for VERSION, `VERSIONED_OBJECT`, or other resources that have
 /// versioning or unique state identifiers" — presence is a SHOULD; while
 /// §"Deprecated headers" makes the form a MUST: "all `ETag` headers that hold
 /// a resource identifier MUST include a weakness indicator `W/`". An optional
@@ -257,7 +257,7 @@ impl<'de> Deserialize<'de> for HeaderMatcher {
 /// two of them to Release 1.1.0: §"Deprecated headers" ("The `ETag` response
 /// header was used without a weakness indicator `W/`. This is now deprecated,
 /// all `ETag` headers that hold a resource identifier MUST include a weakness
-/// indicator `W/`") with §"ETag and Last-Modified" naming the release
+/// indicator `W/`") with §"`ETag` and Last-Modified" naming the release
 /// ("DEPRECATION: Prior to Release 1.1.0, the `ETag` header was used without a
 /// weakness indicator `W/`"), and §Location ("DEPRECATION: Prior to Release
 /// 1.1.0, the `Location` header was used to indicate the canonical location of
@@ -1031,7 +1031,7 @@ mod tests {
         );
     }
 
-    /// The closed transform grammar decomposes an OBJECT_VERSION_ID by its
+    /// The closed transform grammar decomposes an `OBJECT_VERSION_ID` by its
     /// released lexical form `object_id :: creating_system_id ::
     /// version_tree_id` (ITS-REST Resources.md §Identifier types).
     #[test]

--- a/tools/cnf-runner/src/run.rs
+++ b/tools/cnf-runner/src/run.rs
@@ -271,6 +271,158 @@ fn needs_smart_lane(case: &CaseCore) -> bool {
             .is_some_and(|op| op.interface() == SMART_PSEUDO_INTERFACE)
 }
 
+fn not_applicable_record(case: &crate::model::case::CaseCore, citation: &str) -> CaseRecord {
+    CaseRecord {
+        case: case.id.clone(),
+        format: None,
+        rows: vec![RowOutcome::NotApplicable {
+            citation: citation.to_owned(),
+        }],
+        rows_driven: 0,
+        rows_total: crate::exec::row_count(case),
+    }
+}
+
+/// The drive-time selection law (ISO/IEC 9646 ICS-driven selection + the
+/// ixit declaration law): the FIRST ground that excuses `case` on this
+/// party/deployment, or `None` when the case drives. Each arm carries its
+/// citation inside the returned [`Exception`]; the caller records the same
+/// citation as the case's single not-applicable row.
+fn selection_exception(
+    set: &ArtifactSet,
+    ixit: &Ixit,
+    statement: Option<&crate::party::Statement>,
+    case: &crate::model::case::CaseCore,
+) -> Option<Exception> {
+    if let Some(citation) = fully_unrealized(set, case) {
+        return Some(Exception::Unrealized(citation));
+    }
+    // The EXTENSION arm: a case that drives a route no openEHR specification
+    // governs is our own design/extension, so it is behaviour only a party
+    // that CLAIMS the capability answers for. Driving it at another vendor's
+    // SUT would publish failures for routes that vendor never offered to
+    // serve — the published comparison must be honest in both directions,
+    // and a spurious red row is not honesty.
+    if let Some(stmt) = statement
+        && let Some(family) = extension_family(set, case)
+        && !case
+            .capabilities
+            .iter()
+            .any(|c| stmt.claims.capabilities.contains(c))
+    {
+        return Some(Exception::Unrealized(format!(
+            "extension realization ({family}): the ICS claims none of this case's \
+             capabilities, and no openEHR specification governs the route — ISO/IEC 9646 \
+             test selection"
+        )));
+    }
+    // An option branch the party statement does not declare is not this
+    // SUT's behaviour — driving it records a spurious failure the verdict
+    // pipeline would excuse anyway (`verdict::effective_outcome`); excuse it
+    // at drive time with the same citation.
+    if let Some(stmt) = statement
+        && let Some(tag) = &case.option
+        && !stmt.options.contains(tag)
+    {
+        return Some(Exception::Unrealized(format!(
+            "option {tag}: the ICS does not declare this register branch \
+             (statement.options) — ISO/IEC 9646 test selection"
+        )));
+    }
+    // Case-level spec-version floors (`CaseCore.applies`): a behaviour the
+    // spec dates to a release the party does not declare is out of scope for
+    // it — `Applies::satisfied_by`, the one polarity every consumer of the
+    // floor uses (`verdict` selection re-applies the same predicate).
+    // Driving such a case records a spurious failure against behaviour the
+    // party never claimed (the 2026-07-28 java run drove 127 red rows and 13
+    // spuriously green ones this way).
+    if let Some(stmt) = statement
+        && !case.applies.satisfied_by(&stmt.spec_versions)
+    {
+        let declared: Vec<String> = case
+            .applies
+            .entries()
+            .into_iter()
+            .map(|(component, range)| format!("{} {}", component.token(), range.raw()))
+            .collect();
+        return Some(Exception::Unrealized(format!(
+            "case version floor unmet ({}) — the party's declared spec versions do not \
+             satisfy the case's applies ranges; ISO/IEC 9646 test selection",
+            declared.join(", ")
+        )));
+    }
+    // Operation-level spec-version floors (`OperationBinding.applies`): a
+    // wire a later release introduced is not this party's behaviour to
+    // answer for — the same selection question the option branch is, with
+    // the binding's own declared range as the citation.
+    if let Some(stmt) = statement {
+        let unmet = unmet_binding_floors(set, case, &stmt.spec_versions);
+        if !unmet.is_empty() {
+            return Some(Exception::Unrealized(format!(
+                "operation version floor unmet ({}) — the party's declared spec versions \
+                 predate the release that introduced this wire; ISO/IEC 9646 test selection",
+                unmet.join("; ")
+            )));
+        }
+    }
+    // The SMART lane is a party declaration, exactly like the ixit facts
+    // below: the CDR is a SMART resource server that never issues tokens
+    // (ITS-REST docs/smart_app_launch/master06-authentication.adoc
+    // §Supported Authentication Flows), so a chosen `scope` claim exists
+    // only where the party declares a trusted test issuer to mint against.
+    // Undeclared => not-applicable with the citation, never a spurious
+    // failure against a deployment that legitimately does not run SMART.
+    if needs_smart_lane(case) && ixit.smart.is_none() {
+        return Some(Exception::Guarded(
+            "the ixit declares no `smart` lane — the case needs a SMART-enabled \
+             deployment and a minted, scope-carrying access token, neither of which any \
+             released operation discloses or provides; ISO/IEC 9646 test selection"
+                .to_owned(),
+        ));
+    }
+    // A flow step addressing an instance this party does not declare has no
+    // ground to run on (the deployment or principal simply does not exist
+    // here).
+    let missing_instances = undeclared_instances(case, ixit);
+    if !missing_instances.is_empty() {
+        return Some(Exception::Guarded(format!(
+            "the ixit declares no instance {} — the case's flow addresses it with `on:` and \
+             this party runs no such deployment/principal; ISO/IEC 9646 test selection",
+            missing_instances.join(", ")
+        )));
+    }
+    // A case reading a party-declared SUT fact this ixit does not carry
+    // cannot be driven: the fact is not on the wire, so the alternative to a
+    // declaration is a guess.
+    let missing = undeclared_ixit_facts(case, ixit);
+    if !missing.is_empty() {
+        return Some(Exception::Guarded(format!(
+            "the ixit declares no {} — the case reads it as ${{ixit:…}} and no released \
+             operation discloses the value; ISO/IEC 9646 test selection",
+            missing.join(", ")
+        )));
+    }
+    // Global-state grounds (an empty template list, a globally-absent
+    // artefact) hold only on an exclusively-owned SUT; on a shared instance
+    // the case is not-applicable, never a false verdict.
+    if matches!(
+        case.requires.server,
+        Some(crate::vocab::ServerState::Exclusive)
+    ) && !ixit
+        .environment
+        .as_ref()
+        .is_some_and(|env| env.exclusive_server)
+    {
+        return Some(Exception::Unrealized(
+            "requires.server: exclusive — the ixit declares a shared SUT instance \
+             (environment.exclusive_server: false); the global-state ground cannot \
+             be established"
+                .to_owned(),
+        ));
+    }
+    None
+}
+
 /// Execute every runnable case against the ixit's default topology.
 ///
 /// `statement` (the party ICS), when supplied, drives ISO/IEC 9646-style
@@ -282,6 +434,7 @@ fn needs_smart_lane(case: &CaseCore) -> bool {
 /// # Errors
 /// Interpreter defects only; per-case conformance outcomes land in the
 /// report.
+/// The one not-applicable record shape every drive-time exclusion produces.
 pub fn execute(
     set: &ArtifactSet,
     ixit: &Ixit,
@@ -308,249 +461,15 @@ pub fn execute(
             ));
             continue;
         }
-        if let Some(citation) = fully_unrealized(set, case) {
-            report.records.push(CaseRecord {
-                case: case.id.clone(),
-                format: None,
-                rows: vec![RowOutcome::NotApplicable {
-                    citation: citation.clone(),
-                }],
-                rows_driven: 0,
-                rows_total: crate::exec::row_count(case),
-            });
-            report
-                .exceptions
-                .push((case.id.clone(), Exception::Unrealized(citation)));
-            continue;
-        }
-        // ICS-driven selection (ISO/IEC 9646), the EXTENSION arm: a case that
-        // drives a route no openEHR specification governs is our own
-        // design/extension, so it is behaviour only a party that CLAIMS the
-        // capability answers for. Driving it at another vendor's SUT would
-        // publish failures for routes that vendor never offered to serve —
-        // the published comparison must be honest in both directions, and a
-        // spurious red row is not honesty.
-        if let Some(stmt) = statement
-            && let Some(family) = extension_family(set, case)
-            && !case
-                .capabilities
-                .iter()
-                .any(|c| stmt.claims.capabilities.contains(c))
-        {
-            let citation = format!(
-                "extension realization ({family}): the ICS claims none of this case's \
-                 capabilities, and no openEHR specification governs the route — ISO/IEC 9646 \
-                 test selection"
-            );
-            report.records.push(CaseRecord {
-                case: case.id.clone(),
-                format: None,
-                rows: vec![RowOutcome::NotApplicable {
-                    citation: citation.clone(),
-                }],
-                rows_driven: 0,
-                rows_total: crate::exec::row_count(case),
-            });
-            report
-                .exceptions
-                .push((case.id.clone(), Exception::Unrealized(citation)));
-            continue;
-        }
-        // ICS-driven selection (ISO/IEC 9646): an option branch the party
-        // statement does not declare is not this SUT's behaviour — driving
-        // it records a spurious failure the verdict pipeline would excuse
-        // anyway (`verdict::effective_outcome`); excuse it at drive time
-        // with the same citation.
-        if let Some(stmt) = statement
-            && let Some(tag) = &case.option
-            && !stmt.options.contains(tag)
-        {
-            let citation = format!(
-                "option {tag}: the ICS does not declare this register branch \
-                 (statement.options) — ISO/IEC 9646 test selection"
-            );
-            report.records.push(CaseRecord {
-                case: case.id.clone(),
-                format: None,
-                rows: vec![RowOutcome::NotApplicable {
-                    citation: citation.clone(),
-                }],
-                rows_driven: 0,
-                rows_total: crate::exec::row_count(case),
-            });
-            report
-                .exceptions
-                .push((case.id.clone(), Exception::Unrealized(citation)));
-            continue;
-        }
-        // Case-level spec-version floors (`CaseCore.applies`): a behaviour
-        // the spec dates to a release the party does not declare is out of
-        // scope for it — `Applies::satisfied_by`, the one polarity every
-        // consumer of the floor uses (`verdict` selection re-applies the
-        // same predicate). Driving such a case records a spurious failure
-        // against behaviour the party never claimed (the 2026-07-28 java
-        // run drove 127 red rows and 13 spuriously green ones this way) —
-        // excuse it at drive time with the declared ranges as the citation.
-        if let Some(stmt) = statement
-            && !case.applies.satisfied_by(&stmt.spec_versions)
-        {
-            let declared: Vec<String> = case
-                .applies
-                .entries()
-                .into_iter()
-                .map(|(component, range)| format!("{} {}", component.token(), range.raw()))
-                .collect();
-            let citation = format!(
-                "case version floor unmet ({}) — the party's declared spec versions do not \
-                 satisfy the case's applies ranges; ISO/IEC 9646 test selection",
-                declared.join(", ")
-            );
-            report.records.push(CaseRecord {
-                case: case.id.clone(),
-                format: None,
-                rows: vec![RowOutcome::NotApplicable {
-                    citation: citation.clone(),
-                }],
-                rows_driven: 0,
-                rows_total: crate::exec::row_count(case),
-            });
-            report
-                .exceptions
-                .push((case.id.clone(), Exception::Unrealized(citation)));
-            continue;
-        }
-        // Operation-level spec-version floors (`OperationBinding.applies`):
-        // a wire a later release introduced is not this party's behaviour to
-        // answer for — the same ISO/IEC 9646 selection question the option
-        // branch above is, with the binding's own declared range as the
-        // citation.
-        if let Some(stmt) = statement {
-            let unmet = unmet_binding_floors(set, case, &stmt.spec_versions);
-            if !unmet.is_empty() {
-                let citation = format!(
-                    "operation version floor unmet ({}) — the party's declared spec versions \
-                     predate the release that introduced this wire; ISO/IEC 9646 test selection",
-                    unmet.join("; ")
-                );
-                report.records.push(CaseRecord {
-                    case: case.id.clone(),
-                    format: None,
-                    rows: vec![RowOutcome::NotApplicable {
-                        citation: citation.clone(),
-                    }],
-                    rows_driven: 0,
-                    rows_total: crate::exec::row_count(case),
-                });
-                report
-                    .exceptions
-                    .push((case.id.clone(), Exception::Unrealized(citation)));
-                continue;
-            }
-        }
-        // The SMART lane is a party declaration, exactly like the ixit facts
-        // below: the CDR is a SMART resource server that never issues tokens
-        // (ITS-REST docs/smart_app_launch/master06-authentication.adoc
-        // §Supported Authentication Flows), so a chosen `scope` claim exists
-        // only where the party declares a trusted test issuer to mint
-        // against, and the discovery document exists only where the party
-        // runs the SMART role at all. Undeclared => not-applicable with the
-        // citation, never a spurious failure against a deployment that
-        // legitimately does not run SMART.
-        if needs_smart_lane(case) && ixit.smart.is_none() {
-            let citation = "the ixit declares no `smart` lane — the case needs a SMART-enabled \
-                 deployment and a minted, scope-carrying access token, neither of which any \
-                 released operation discloses or provides; ISO/IEC 9646 test selection"
-                .to_owned();
-            report.records.push(CaseRecord {
-                case: case.id.clone(),
-                format: None,
-                rows: vec![RowOutcome::NotApplicable {
-                    citation: citation.clone(),
-                }],
-                rows_driven: 0,
-                rows_total: crate::exec::row_count(case),
-            });
-            report
-                .exceptions
-                .push((case.id.clone(), Exception::Guarded(citation)));
-            continue;
-        }
-        // A flow step addressing an instance this party does not declare has
-        // no ground to run on (the deployment or principal simply does not
-        // exist here) — not-applicable with the citation, like every other
-        // undeclared topology fact.
-        let missing_instances = undeclared_instances(case, ixit);
-        if !missing_instances.is_empty() {
-            let citation = format!(
-                "the ixit declares no instance {} — the case's flow addresses it with `on:` and \
-                 this party runs no such deployment/principal; ISO/IEC 9646 test selection",
-                missing_instances.join(", ")
-            );
-            report.records.push(CaseRecord {
-                case: case.id.clone(),
-                format: None,
-                rows: vec![RowOutcome::NotApplicable {
-                    citation: citation.clone(),
-                }],
-                rows_driven: 0,
-                rows_total: crate::exec::row_count(case),
-            });
-            report
-                .exceptions
-                .push((case.id.clone(), Exception::Guarded(citation)));
-            continue;
-        }
-        // A case reading a party-declared SUT fact this ixit does not carry
-        // cannot be driven: the fact is not on the wire, so the alternative
-        // to a declaration is a guess.
-        let missing = undeclared_ixit_facts(case, ixit);
-        if !missing.is_empty() {
-            let citation = format!(
-                "the ixit declares no {} — the case reads it as ${{ixit:…}} and no released \
-                 operation discloses the value; ISO/IEC 9646 test selection",
-                missing.join(", ")
-            );
-            report.records.push(CaseRecord {
-                case: case.id.clone(),
-                format: None,
-                rows: vec![RowOutcome::NotApplicable {
-                    citation: citation.clone(),
-                }],
-                rows_driven: 0,
-                rows_total: crate::exec::row_count(case),
-            });
-            report
-                .exceptions
-                .push((case.id.clone(), Exception::Guarded(citation)));
-            continue;
-        }
-        // Global-state grounds (an empty template list, a globally-absent
-        // artefact) hold only on an exclusively-owned SUT; on a shared
-        // instance the case is not-applicable, never a false verdict.
-        if matches!(
-            case.requires.server,
-            Some(crate::vocab::ServerState::Exclusive)
-        ) && !ixit
-            .environment
-            .as_ref()
-            .is_some_and(|env| env.exclusive_server)
-        {
-            let citation = "requires.server: exclusive — the ixit declares a shared SUT instance \
-                 (environment.exclusive_server: false); the global-state ground cannot \
-                 be established"
-                .to_owned();
-            report.records.push(CaseRecord {
-                case: case.id.clone(),
-                format: None,
-                rows: vec![RowOutcome::NotApplicable {
-                    citation: citation.clone(),
-                }],
-                rows_driven: 0,
-                rows_total: crate::exec::row_count(case),
-            });
-            report
-                .exceptions
-                .push((case.id.clone(), Exception::Unrealized(citation)));
+        if let Some(exception) = selection_exception(set, ixit, statement, case) {
+            let citation = match &exception {
+                Exception::Unrealized(c)
+                | Exception::ContentGeneration(c)
+                | Exception::Guarded(c)
+                | Exception::Status(c) => c.clone(),
+            };
+            report.records.push(not_applicable_record(case, &citation));
+            report.exceptions.push((case.id.clone(), exception));
             continue;
         }
         let runnable = if matches!(case.kind, crate::vocab::CaseKind::Content) {

--- a/tools/cnf-runner/src/schema.rs
+++ b/tools/cnf-runner/src/schema.rs
@@ -346,35 +346,7 @@ pub fn operation_binding_schema() -> Value {
                     "ambiguity": { "type": "string", "pattern": AMBIGUITY_ID_PATTERN }
                 }
             },
-            "request": {
-                "type": "object",
-                "additionalProperties": false,
-                "required": ["method", "path"],
-                "properties": {
-                    "method": { "enum": tokens(HttpMethod::ALL) },
-                    "path": { "type": "string", "pattern": "^/" },
-                    "query": {
-                        "type": "object",
-                        "additionalProperties": { "oneOf": [
-                            { "type": "string" },
-                            { "type": "array", "minItems": 1, "items": { "type": "string" },
-                              "description": "The repeated (RFC 6570 exploded, {?p*}) form: one name=value pair per member, unbound optional members absent" }
-                        ] }
-                    },
-                    "body": { "oneOf": [
-                        { "type": "string" },
-                        { "type": "object",
-                          "additionalProperties": false,
-                          "required": ["from_capture", "set"],
-                          "properties": {
-                              "from_capture": { "type": "string", "pattern": IDENT_PATTERN },
-                              "set": { "type": "object", "minProperties": 1 }
-                          } },
-                        { "type": "object", "not": { "required": ["from_capture"] } }
-                    ] },
-                    "headers": { "type": "object", "additionalProperties": { "type": "string" } }
-                }
-            },
+            "request": binding_request_def(),
             "formats": { "type": "array", "items": { "enum": tokens(FormatName::ALL) } },
             "format_headers": {
                 "type": "object",
@@ -384,27 +356,7 @@ pub fn operation_binding_schema() -> Value {
                     "additionalProperties": { "type": "string" }
                 }
             },
-            "outcomes": {
-                "type": "object",
-                "minProperties": 1,
-                "propertyNames": { "enum": tokens(OutcomeKind::ALL) },
-                "additionalProperties": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "required": ["status"],
-                    "properties": {
-                        "status": { "type": "integer", "minimum": 100, "maximum": 599 },
-                        "alt_status": {
-                            "type": "array",
-                            "minItems": 1,
-                            "items": { "type": "integer", "minimum": 100, "maximum": 599 },
-                            "description": "Overview-permitted additional non-conflicting status codes beyond the OAS enumeration (ITS-REST Requests_and_responses §HTTP status codes)"
-                        },
-                        "headers": { "type": "object", "additionalProperties": header_expectation_def() },
-                        "body": { "enum": BODY_SELECTOR_TOKENS }
-                    }
-                }
-            },
+            "outcomes": binding_outcomes_def(),
             "captures": {
                 "type": "object",
                 "propertyNames": { "pattern": IDENT_PATTERN },
@@ -421,6 +373,68 @@ pub fn operation_binding_schema() -> Value {
                 }
             },
             "server_assigned": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+        }
+    })
+}
+
+/// The `request` member of an operation binding (§ wire layer) — request
+/// construction: method, templated path, RFC 6570 query, body source,
+/// header templates.
+fn binding_request_def() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["method", "path"],
+        "properties": {
+            "method": { "enum": tokens(HttpMethod::ALL) },
+            "path": { "type": "string", "pattern": "^/" },
+            "query": {
+                "type": "object",
+                "additionalProperties": { "oneOf": [
+                    { "type": "string" },
+                    { "type": "array", "minItems": 1, "items": { "type": "string" },
+                      "description": "The repeated (RFC 6570 exploded, {?p*}) form: one name=value pair per member, unbound optional members absent" }
+                ] }
+            },
+            "body": { "oneOf": [
+                { "type": "string" },
+                { "type": "object",
+                  "additionalProperties": false,
+                  "required": ["from_capture", "set"],
+                  "properties": {
+                      "from_capture": { "type": "string", "pattern": IDENT_PATTERN },
+                      "set": { "type": "object", "minProperties": 1 }
+                  } },
+                { "type": "object", "not": { "required": ["from_capture"] } }
+            ] },
+            "headers": { "type": "object", "additionalProperties": { "type": "string" } }
+        }
+    })
+}
+
+/// The `outcomes` member of an operation binding — outcome kind → wire
+/// expectation (status, permitted alternates, header matchers, body
+/// selector).
+fn binding_outcomes_def() -> Value {
+    json!({
+        "type": "object",
+        "minProperties": 1,
+        "propertyNames": { "enum": tokens(OutcomeKind::ALL) },
+        "additionalProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["status"],
+            "properties": {
+                "status": { "type": "integer", "minimum": 100, "maximum": 599 },
+                "alt_status": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": { "type": "integer", "minimum": 100, "maximum": 599 },
+                    "description": "Overview-permitted additional non-conflicting status codes beyond the OAS enumeration (ITS-REST Requests_and_responses §HTTP status codes)"
+                },
+                "headers": { "type": "object", "additionalProperties": header_expectation_def() },
+                "body": { "enum": BODY_SELECTOR_TOKENS }
+            }
         }
     })
 }

--- a/tools/cnf-runner/src/validate.rs
+++ b/tools/cnf-runner/src/validate.rs
@@ -1980,24 +1980,24 @@ const PSEUDO_INTERFACE_PREFIX: &str = "I_ITS_REST_";
 /// - `I_ITS_REST_SYSTEM` — the System API (ITS-REST
 ///   `docs/system/Description.md`, STABLE) defines `OPTIONS {base_path}`
 ///   (overview `Requests_and_responses.md` §HTTP Methods).
-/// - `I_ITS_REST_ITEM_TAGS` — the 23 released ITEM_TAG routes: the two
-///   space-wide lists, the EHR-side COMPOSITION/EHR_STATUS triples, and the
+/// - `I_ITS_REST_ITEM_TAGS` — the 23 released `ITEM_TAG` routes: the two
+///   space-wide lists, the EHR-side `COMPOSITION/EHR_STATUS` triples, and the
 ///   five demographic party triples. The SM models no tag concept at all —
 ///   `docs/specs/openehr/SM/docs/` contains zero occurrences of "tag"
 ///   (grep-verified) — while the released ITS-REST calls the
 ///   `openehr-item-tag` / `openehr-version-item-tag` headers "convenient
-///   wrappers around the dedicated ITEM_TAG operations" (overview
+///   wrappers around the dedicated `ITEM_TAG` operations" (overview
 ///   `Requests_and_responses.md` §openehr-item-tag and
 ///   openehr-version-item-tag), so the operations are unambiguously part of
 ///   the released wire with no service-model anchor to name them by.
 /// - `I_ITS_REST_REVISION_HISTORY` — the three released revision-history
-///   reads (COMPOSITION, EHR_STATUS, PARTY). The SM declares no
+///   reads (COMPOSITION, `EHR_STATUS`, PARTY). The SM declares no
 ///   revision-history operation on any interface —
 ///   `docs/specs/openehr/SM/docs/` contains zero occurrences of
-///   "revision_history" (grep-verified); the abstract counterpart lives in
+///   "`revision_history`" (grep-verified); the abstract counterpart lives in
 ///   the RM (`common` `versioned_object.adoc` §Functions
 ///   `revision_history`), which is a model, not a service interface.
-/// - `I_ITS_REST_VERSIONED_PARTY` — the VERSIONED_PARTY container read. Its
+/// - `I_ITS_REST_VERSIONED_PARTY` — the `VERSIONED_PARTY` container read. Its
 ///   two EHR-side twins DO have SM anchors
 ///   (`I_EHR_COMPOSITION.get_versioned_composition`,
 ///   `I_EHR_STATUS.get_versioned_ehr_status`); `I_PARTY` declares no
@@ -3309,7 +3309,7 @@ h|*1..1*\n\
     /// The pinned table is a MULTI-interface domain, not a single-row special
     /// case: every row parses, carries the reserved prefix and a non-empty
     /// citation, no reference is pinned twice, and more than one reserved
-    /// pseudo-interface is represented (System + ITEM_TAGS today).
+    /// pseudo-interface is represented (System + `ITEM_TAGS` today).
     #[test]
     fn pinned_non_sm_table_is_wellformed_across_several_pseudo_interfaces() {
         let mut seen: BTreeSet<&str> = BTreeSet::new();

--- a/tools/cnf-runner/src/verdict.rs
+++ b/tools/cnf-runner/src/verdict.rs
@@ -49,7 +49,7 @@ pub enum Evidence {
     /// failure) and none failed. Inconclusive is never a SUT failure
     /// (`cnf-triage` law) but it must not be absorbed into a green
     /// capability either: an errored row blocks `Passed` until the run is
-    /// clean (the 2026-07-28 posture run published CompositionOps `passed`
+    /// clean (the 2026-07-28 posture run published `CompositionOps` `passed`
     /// while both minimal-Prefer cases sat errored on a wire-visible
     /// defect — luck, not design).
     Inconclusive,

--- a/tools/cnf-runner/src/vocab.rs
+++ b/tools/cnf-runner/src/vocab.rs
@@ -81,7 +81,7 @@ outcome_kinds! {
     /// realizes both as one indistinguishable wire answer (the If-Match PUTs:
     /// a false-evaluating If-Match "MUST respond with HTTP status code `412
     /// Precondition Failed`" regardless of whether the named version ever
-    /// existed — overview Requests_and_responses.md §"If-Match and accidental
+    /// existed — overview `Requests_and_responses.md` §"If-Match and accidental
     /// overwrites"). Case cores speak SM outcomes, and the SM distinguishes
     /// the causes (an unknown version vs a stale one); the fold is a
     /// REALIZATION fact recorded on each binding, and the tie-break in

--- a/tools/cnf-runner/tests/artifact_gates.rs
+++ b/tools/cnf-runner/tests/artifact_gates.rs
@@ -77,7 +77,7 @@ fn pilot_world_is_clean_under_all_gates() {
 /// * §"Deprecated headers" — "The `ETag` response header was used without a
 ///   weakness indicator `W/`. This is now deprecated, all `ETag` headers that
 ///   hold a resource identifier MUST include a weakness indicator `W/`" —
-///   with §"ETag and Last-Modified" naming the release: "DEPRECATION: Prior to
+///   with §"`ETag` and Last-Modified" naming the release: "DEPRECATION: Prior to
 ///   Release 1.1.0, the `ETag` header was used without a weakness indicator
 ///   `W/`. This usage is now deprecated, but implementations MAY still support
 ///   it alongside the updated header format".


### PR DESCRIPTION
Develop's `clippy` job (`--workspace --all-targets --all-features -- -D warnings`) has been red since the PR-#678/#681 merges — the merge train accumulated pedantic-tier warnings that the narrower local per-crate flags miss (the owner-directed clean-CI pass before the terminology PRs land).

Two commits:
1. **Mechanical** (`cargo clippy --fix` under the CI flags): doc backticks, explicit auto-deref, needless pass-by-value, items-after-statements, `field_reassign_with_default`.
2. **Structural** (hand-written):
   - `run.rs::execute` (233 lines → under the limit): the eight drive-time exclusion gates extracted into `selection_exception` — the ISO/IEC 9646 selection law as ONE function returning the citation-carrying `Exception` — plus a shared `not_applicable_record` builder. Behaviour identical; every citation string byte-identical.
   - `driver.rs::perform`: post-send bookkeeping (committed-payload trail, last body, the observed `restapi_specs_version` confirmation) → `record_exchange_bookkeeping`.
   - `schema.rs::operation_binding_schema`: the `request`/`outcomes` member schemas split into named defs — **emission byte-identical, the schema-drift test pins it**.
   - `conf_assets`: the constant geometry assertions become compile-time `const` items (bits-equality for the pinned canvas width), hoisted above statements.

## Gates

- `cargo clippy --workspace --all-targets --all-features` — **zero warnings** (the exact CI invocation)
- `cargo fmt --all --check` clean
- `cargo nextest run -p cnf-runner -p ehrbase-rest -p openehr-its` — **1368/1368** (schema-drift green: the split changed no emitted byte)

Tooling/test hygiene only → `no-changelog`.