### PR TITLE
feat(terminology): mutual TLS to the terminology server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -896,8 +896,23 @@ workflow refuses a tag that has no matching section here.
   request to that server. The token is cached and renewed shortly before it
   expires, so a validation burst costs one token request per token lifetime. A
   refused grant fails the call with a clear error — a request is never sent
-  unauthenticated as a fallback. Mutual TLS to a terminology server is still
-  not supported.
+  unauthenticated as a fallback.
+- **Terminology servers can require a client certificate (mutual TLS).** A
+  provider takes three new keys — `client_cert_path`, `client_key_path` and
+  `ca_bundle_path` — so the CDR presents a client certificate to that
+  terminology server and verifies the server against that server's own trust
+  anchors. The identity is per provider because a client certificate is issued
+  by the peer's PKI: a deployment enrolled with a national SNOMED CT service, a
+  commercial value-set server and an in-house server holds three different
+  certificates, and repeating the same paths covers the case where one identity
+  really does serve them all. `ca_bundle_path` *replaces* the default trust
+  anchors for that provider, so a privately-issued terminology server is pinned
+  to its own CA instead of also accepting the whole public web PKI. There is no
+  option to skip verification — server-certificate and hostname verification
+  stay on for every provider; the bundle changes which anchors are trusted,
+  never whether the server is checked. Anything broken (one half of an
+  identity, an unreadable PEM, a key file holding no key, a CA bundle holding
+  no certificate) fails at startup, never at the first validated code.
 - **Composition commits can now check archetype value-set bindings against a
   live terminology server.** When a template binds an `ac` code to an external
   terminology query, and `[terminology.external]` is enabled, committing a

--- a/app/ehrbase/assets/ehrbase.default.toml
+++ b/app/ehrbase/assets/ehrbase.default.toml
@@ -237,6 +237,13 @@ fail_on_error = false        # TS unreachable/erroring: false = accept the
 #? cache_ttl_secs = 300
 #? cache_capacity = 10000
 #? oauth2_client = "ts-client"   # must name a [terminology.external.oauth2_clients.*]
+# Mutual TLS to THIS server (each TS issues its own client certificate, so the
+# identity is per provider). Set the cert and the key together. ca_bundle_path
+# REPLACES the default trust anchors for this provider — server-certificate and
+# hostname verification are always on; there is no way to disable them:
+#? client_cert_path = "/run/secrets/ts-client.crt.pem"
+#? client_key_path = "/run/secrets/ts-client.key.pem"
+#? ca_bundle_path = "/run/secrets/ts-ca.pem"
 #? [terminology.external.providers.snomed]
 #? type = "fhir"
 #? url = "https://snowstorm.example.org/fhir"

--- a/app/ehrbase/src/config/mod.rs
+++ b/app/ehrbase/src/config/mod.rs
@@ -235,10 +235,13 @@ fn server_bind_port(bind: &str) -> Option<u16> {
 /// Semantic checks on `[terminology.external]`: enabling it needs a provider,
 /// and every cross-reference must resolve. A dangling reference would degrade
 /// silently — a route to a missing provider quietly falls back to the default
-/// server, and an `oauth2_client` naming a missing client would send
-/// unauthenticated requests — so both are boot errors (§P-5: never make a bad
-/// value a silent default). No openEHR spec governs configuration — our own
-/// design.
+/// server, an `oauth2_client` naming a missing client would send
+/// unauthenticated requests, and half a mutual-TLS identity would connect
+/// without a client certificate — so all three are boot errors (§P-5: never
+/// make a bad value a silent default). The TLS material itself (readable PEM,
+/// a certificate where a certificate belongs, a key where a key belongs) is
+/// validated when the provider is built, which is also boot time. No openEHR
+/// spec governs configuration — our own design.
 fn validate_terminology(
     terminology: &crate::service::terminology::config::ExternalTerminologyConfig,
     errors: &mut Vec<ConfigError>,
@@ -259,6 +262,20 @@ fn validate_terminology(
         }
     }
     for (name, provider) in &terminology.providers {
+        // A mutual-TLS identity is a certificate AND its key; half of one
+        // would connect with no client certificate at all, which the server
+        // rejects at handshake time — a boot error, not a runtime surprise.
+        match (&provider.client_cert_path, &provider.client_key_path) {
+            (Some(_), None) => errors.push(ConfigError::semantic(format!(
+                "terminology.external.providers.{name}.client_cert_path is set without \
+                 client_key_path (a client certificate needs its private key)"
+            ))),
+            (None, Some(_)) => errors.push(ConfigError::semantic(format!(
+                "terminology.external.providers.{name}.client_key_path is set without \
+                 client_cert_path (a private key needs its certificate)"
+            ))),
+            _ => {}
+        }
         let Some(client) = provider.oauth2_client.as_deref() else {
             continue;
         };
@@ -760,6 +777,9 @@ mod tests {
                 connect_timeout_ms: 2_000,
                 request_timeout_ms: 10_000,
                 oauth2_client: None,
+                client_cert_path: None,
+                client_key_path: None,
+                ca_bundle_path: None,
                 cache_ttl_secs: 300,
                 cache_capacity: 10_000,
             },
@@ -798,6 +818,9 @@ mod tests {
                 connect_timeout_ms: 2_000,
                 request_timeout_ms: 10_000,
                 oauth2_client: Some("ts-client".to_owned()),
+                client_cert_path: None,
+                client_key_path: None,
+                ca_bundle_path: None,
                 cache_ttl_secs: 300,
                 cache_capacity: 10_000,
             },
@@ -887,6 +910,117 @@ mod tests {
         assert_eq!(
             client.client_secret.as_ref().map(Secret::expose),
             Some("s3cret")
+        );
+    }
+
+    /// A mutual-TLS client identity is a certificate AND its key: half of one
+    /// would connect presenting nothing, so it is a boot error. The trust
+    /// anchor (`ca_bundle_path`) stands alone — verification against a private
+    /// CA needs no client identity.
+    #[test]
+    fn validate_terminology_client_identity_needs_both_halves() {
+        let mut c = EhrbaseConfig::default();
+        let external = &mut c.terminology.external;
+        external.enabled = true;
+        external.providers.insert(
+            "default".to_owned(),
+            crate::service::terminology::config::FhirProviderConfig {
+                kind: crate::service::terminology::config::ProviderKind::Fhir,
+                url: "https://ts.example/fhir".to_owned(),
+                operation: crate::service::terminology::config::FhirOperation::ValidateCode,
+                connect_timeout_ms: 2_000,
+                request_timeout_ms: 10_000,
+                oauth2_client: None,
+                client_cert_path: Some(PathBuf::from("/run/secrets/ts-client.crt.pem")),
+                client_key_path: None,
+                ca_bundle_path: None,
+                cache_ttl_secs: 300,
+                cache_capacity: 10_000,
+            },
+        );
+        let err = c
+            .validate()
+            .expect_err("a certificate without its key must be rejected");
+        assert!(err.to_string().contains("client_key_path"), "got {err}");
+
+        let provider = c
+            .terminology
+            .external
+            .providers
+            .get_mut("default")
+            .expect("provider");
+        provider.client_cert_path = None;
+        provider.client_key_path = Some(PathBuf::from("/run/secrets/ts-client.key.pem"));
+        let err = c
+            .validate()
+            .expect_err("a key without its certificate must be rejected");
+        assert!(err.to_string().contains("client_cert_path"), "got {err}");
+
+        // Both halves together are valid; so is a bare trust anchor.
+        let provider = c
+            .terminology
+            .external
+            .providers
+            .get_mut("default")
+            .expect("provider");
+        provider.client_cert_path = Some(PathBuf::from("/run/secrets/ts-client.crt.pem"));
+        provider.ca_bundle_path = Some(PathBuf::from("/run/secrets/ts-ca.pem"));
+        assert!(c.validate().is_ok());
+
+        let provider = c
+            .terminology
+            .external
+            .providers
+            .get_mut("default")
+            .expect("provider");
+        provider.client_cert_path = None;
+        provider.client_key_path = None;
+        assert!(c.validate().is_ok(), "a CA bundle alone is valid");
+    }
+
+    /// The mutual-TLS keys are reachable through the one env grammar (§P-4).
+    #[test]
+    fn env_mapping_terminology_provider_mtls_paths() {
+        let c = assemble_ok(
+            None,
+            &env(&[
+                ("EHRBASE__TERMINOLOGY__EXTERNAL__ENABLED", "true"),
+                (
+                    "EHRBASE__TERMINOLOGY__EXTERNAL__PROVIDERS__SNOMED__URL",
+                    "https://snowstorm/fhir",
+                ),
+                (
+                    "EHRBASE__TERMINOLOGY__EXTERNAL__PROVIDERS__SNOMED__CLIENT_CERT_PATH",
+                    "/run/secrets/ts-client.crt.pem",
+                ),
+                (
+                    "EHRBASE__TERMINOLOGY__EXTERNAL__PROVIDERS__SNOMED__CLIENT_KEY_PATH",
+                    "/run/secrets/ts-client.key.pem",
+                ),
+                (
+                    "EHRBASE__TERMINOLOGY__EXTERNAL__PROVIDERS__SNOMED__CA_BUNDLE_PATH",
+                    "/run/secrets/ts-ca.pem",
+                ),
+            ]),
+            &[],
+        );
+        let provider = c
+            .terminology
+            .external
+            .providers
+            .get("snomed")
+            .expect("snomed");
+        assert_eq!(
+            provider.client_cert_path.as_deref(),
+            Some(Path::new("/run/secrets/ts-client.crt.pem"))
+        );
+        assert_eq!(
+            provider.client_key_path.as_deref(),
+            Some(Path::new("/run/secrets/ts-client.key.pem"))
+        );
+        assert_eq!(
+            provider.ca_bundle_path.as_deref(),
+            Some(Path::new("/run/secrets/ts-ca.pem"))
         );
     }
 }

--- a/app/ehrbase/src/service/terminology/binding.rs
+++ b/app/ehrbase/src/service/terminology/binding.rs
@@ -252,6 +252,9 @@ mod tests {
             connect_timeout_ms: 500,
             request_timeout_ms: 800,
             oauth2_client: None,
+            client_cert_path: None,
+            client_key_path: None,
+            ca_bundle_path: None,
             cache_ttl_secs: 0,
             cache_capacity: 0,
         }

--- a/app/ehrbase/src/service/terminology/config.rs
+++ b/app/ehrbase/src/service/terminology/config.rs
@@ -195,12 +195,27 @@ pub struct FhirProviderConfig {
     /// Name of the `OAuth2` client-credentials client
     /// ([`ExternalTerminologyConfig::oauth2_clients`]) whose bearer token is
     /// attached to every request to this provider. Unset = unauthenticated.
-    ///
-    /// TODO: mutual TLS to the terminology server is not implemented — a
-    /// provider that must present a client certificate has no way to say so;
-    /// the `[server.tls]` material is inbound-only.
     #[serde(default)]
     pub oauth2_client: Option<String>,
+    /// PEM file holding the client certificate (optionally a chain) this
+    /// provider presents to its terminology server for **mutual TLS**. Set
+    /// together with [`Self::client_key_path`]; unset = no client identity.
+    ///
+    /// The identity is per provider because a client certificate is issued by
+    /// the peer's PKI — see the [`super::tls`] module NOTE.
+    #[serde(default)]
+    pub client_cert_path: Option<PathBuf>,
+    /// PEM file holding the private key of [`Self::client_cert_path`]. Both
+    /// keys are set together; one without the other is a boot error.
+    #[serde(default)]
+    pub client_key_path: Option<PathBuf>,
+    /// PEM bundle of the trust anchors this provider's terminology-server
+    /// certificate is verified against. When set it **replaces** the default
+    /// anchors for this provider (a privately-issued server is pinned to its
+    /// own CA); unset = the platform's default trust. Server-certificate and
+    /// hostname verification are always on — there is no way to disable them.
+    #[serde(default)]
+    pub ca_bundle_path: Option<PathBuf>,
     /// Result-cache TTL in seconds for this provider's FHIR operations
     /// (`$validate-code`/`$expand`/`$subsumes`/`$lookup`). `0` disables the
     /// cache. Bounded staleness against the remote server is the trade for
@@ -283,6 +298,9 @@ pub(super) fn test_provider_config(url: &str) -> FhirProviderConfig {
         connect_timeout_ms: DEFAULT_CONNECT_TIMEOUT_MS,
         request_timeout_ms: DEFAULT_REQUEST_TIMEOUT_MS,
         oauth2_client: None,
+        client_cert_path: None,
+        client_key_path: None,
+        ca_bundle_path: None,
         cache_ttl_secs: 300,
         cache_capacity: 1024,
     }

--- a/app/ehrbase/src/service/terminology/fhir.rs
+++ b/app/ehrbase/src/service/terminology/fhir.rs
@@ -104,8 +104,10 @@ impl FhirTerminologyProvider {
     ///
     /// # Errors
     ///
-    /// [`SmError::exception`] if the URL is empty (after trimming) or the
-    /// `reqwest` client cannot be built (e.g. TLS backend init failure).
+    /// [`SmError::exception`] if the URL is empty (after trimming), the
+    /// configured TLS material is unusable ([`super::tls::TlsMaterialError`]),
+    /// or the `reqwest` client cannot be built (e.g. TLS backend init
+    /// failure).
     pub fn new(name: &str, cfg: &FhirProviderConfig) -> Result<Self, SmError> {
         let base = cfg.url.trim().trim_end_matches('/').to_owned();
         if base.is_empty() {
@@ -113,15 +115,19 @@ impl FhirTerminologyProvider {
                 "terminology provider '{name}' has an empty url"
             )));
         }
-        let client = reqwest::Client::builder()
+        let builder = reqwest::Client::builder()
             .connect_timeout(Duration::from_millis(cfg.connect_timeout_ms))
-            .timeout(Duration::from_millis(cfg.request_timeout_ms))
-            .build()
-            .map_err(|e| {
-                SmError::exception(format!(
-                    "building terminology client for provider '{name}': {e}"
-                ))
-            })?;
+            .timeout(Duration::from_millis(cfg.request_timeout_ms));
+        // Mutual TLS + the provider's trust anchors, when configured. Bad
+        // material is a boot failure here, never a first-request surprise
+        // ([`super::tls`]).
+        let builder = super::tls::apply(builder, cfg)
+            .map_err(|e| SmError::exception(format!("terminology provider '{name}': {e}")))?;
+        let client = builder.build().map_err(|e| {
+            SmError::exception(format!(
+                "building terminology client for provider '{name}': {e}"
+            ))
+        })?;
         let cache = (cfg.cache_ttl_secs > 0).then(|| {
             moka::future::Cache::builder()
                 .max_capacity(cfg.cache_capacity)
@@ -754,6 +760,9 @@ mod tests {
             connect_timeout_ms: 100,
             request_timeout_ms: 100,
             oauth2_client: None,
+            client_cert_path: None,
+            client_key_path: None,
+            ca_bundle_path: None,
             cache_ttl_secs: 0,
             cache_capacity: 1024,
         };

--- a/app/ehrbase/src/service/terminology/mod.rs
+++ b/app/ehrbase/src/service/terminology/mod.rs
@@ -23,6 +23,9 @@
 //!   [`ExternalTerminologyConfig`](config::ExternalTerminologyConfig)).
 //! - [`oauth2`] — [`TokenSource`](oauth2::TokenSource), the `OAuth2`
 //!   client-credentials authentication a provider may carry.
+//! - [`tls`] — the per-provider outbound TLS material: the client certificate
+//!   presented for mutual TLS and the trust anchors the server is verified
+//!   with (no openEHR spec governs transport security — our own design).
 //! - [`router`] — [`TerminologyRouter`](router::TerminologyRouter): every
 //!   configured server, materialised, with the terminology → provider routing.
 //! - [`routing`] — the 9 SM calls on `EhrbaseService`, routing between the
@@ -63,5 +66,6 @@ pub mod fhir;
 pub mod oauth2;
 pub mod router;
 mod routing;
+pub mod tls;
 
 pub mod types;

--- a/app/ehrbase/src/service/terminology/tls.rs
+++ b/app/ehrbase/src/service/terminology/tls.rs
@@ -1,0 +1,279 @@
+//! Outbound TLS material for one terminology-server provider: the client
+//! certificate the CDR presents (mutual TLS) and the trust anchors it verifies
+//! the server with.
+//!
+//! NOTE: no openEHR spec governs terminology-server transport security — our
+//! own design/extension. `BASE/docs/architecture_overview/master12-terminology.adoc`
+//! models the backend only as an external "terminology query server"; how the
+//! CDR authenticates the connection to it is entirely ours. The certificate
+//! formats themselves are PEM-encoded X.509 (RFC 7468) handled by the pinned
+//! `rustls` / `reqwest` stack — nothing here is hand-rolled crypto.
+//!
+//! # The identity is per provider, not per process
+//!
+//! NOTE (settled design): the client identity is configured on each
+//! `[terminology.external.providers.<name>]`, not once for the whole process.
+//! A client certificate is a credential **issued by the peer's PKI**, exactly
+//! like the `OAuth2` client credentials a provider already names with
+//! `oauth2_client`: a deployment federating to a national SNOMED CT service, a
+//! commercial `ValueSet` server and an in-house HAPI server is enrolled
+//! separately in three trust domains and holds three certificates with three
+//! subjects. A single shared outbound identity could not express that at all,
+//! whereas the per-provider shape degenerates to a shared one by repeating the
+//! same paths. The same argument applies to the trust anchors: the CA that
+//! signs each server's certificate is a property of that server, not of this
+//! process. The one outbound-TLS precedent in the tree is scoped the same way
+//! (`[audit.syslog] tls_identity_cert_file` / `tls_identity_key_file`, the IHE
+//! ITI-19 node-authenticated connection to one Audit Record Repository);
+//! `[server.tls]` is inbound-only and cannot be reused for an outbound
+//! identity.
+//!
+//! # Verification is never disabled
+//!
+//! There is no "insecure" / "skip verification" switch, by construction: this
+//! module only ever supplies *trust anchors* and a *client identity* to the
+//! `reqwest` builder. It never touches `danger_accept_invalid_certs` and never
+//! installs a custom certificate verifier, so server-certificate and hostname
+//! verification stay on for every provider. A configured
+//! [`FhirProviderConfig::ca_bundle_path`] **replaces** the default trust
+//! anchors for that provider (`reqwest::ClientBuilder::tls_certs_only`) rather
+//! than widening them — a terminology server issued by a private PKI is
+//! pinned to that PKI instead of also accepting the whole public web PKI.
+//!
+//! # Scope
+//!
+//! The material applies to the connection to the terminology server itself.
+//! The `OAuth2` token endpoint ([`super::oauth2::TokenSource`]) is a different
+//! host in a different trust domain and keeps the default TLS stack; presenting
+//! the terminology server's client certificate to an identity provider would be
+//! a credential leak, not a feature.
+
+use std::path::{Path, PathBuf};
+
+use super::config::FhirProviderConfig;
+
+/// A failure loading a provider's TLS material. Every variant is a boot
+/// failure: a route to a terminology server whose identity cannot be
+/// assembled must fail loudly at startup, never silently at the first
+/// validated code.
+#[derive(Debug, thiserror::Error)]
+pub enum TlsMaterialError {
+    /// `client_cert_path` was set without `client_key_path`, or the reverse.
+    #[error(
+        "client_cert_path and client_key_path must be set together (a client certificate is \
+         useless without its private key)"
+    )]
+    IncompleteIdentity,
+    /// A configured PEM file could not be read.
+    #[error("reading {role} '{}': {source}", path.display())]
+    Read {
+        /// Which configured key pointed at the unreadable file.
+        role: MaterialRole,
+        /// The configured path.
+        path: PathBuf,
+        /// The underlying I/O failure.
+        #[source]
+        source: std::io::Error,
+    },
+    /// A PEM file that must hold certificates holds none, or unparseable ones.
+    #[error("{role} '{}' holds no usable PEM certificate: {reason}", path.display())]
+    NoCertificate {
+        /// Which configured key pointed at the file.
+        role: MaterialRole,
+        /// The configured path.
+        path: PathBuf,
+        /// Why nothing usable came out of it.
+        reason: String,
+    },
+    /// The key file holds no parseable PEM private key.
+    #[error("client_key_path '{}' contains no PEM private key: {reason}", path.display())]
+    NoPrivateKey {
+        /// The configured path.
+        path: PathBuf,
+        /// The parser's rejection reason.
+        reason: String,
+    },
+    /// The HTTP client rejected the assembled material.
+    #[error("{role} was rejected by the TLS stack: {source}")]
+    Rejected {
+        /// Which configured key produced the rejected material.
+        role: MaterialRole,
+        /// The underlying `reqwest` failure.
+        #[source]
+        source: reqwest::Error,
+    },
+}
+
+/// Which configured key a piece of TLS material came from — the discriminant a
+/// boot error names, so an operator knows which line of the TOML to fix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MaterialRole {
+    /// `client_cert_path` — the client certificate (chain) presented to the TS.
+    ClientCertificate,
+    /// `client_key_path` — its private key.
+    ClientKey,
+    /// `ca_bundle_path` — the trust anchors the TS certificate is verified with.
+    CaBundle,
+}
+
+impl std::fmt::Display for MaterialRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::ClientCertificate => "client_cert_path",
+            Self::ClientKey => "client_key_path",
+            Self::CaBundle => "ca_bundle_path",
+        })
+    }
+}
+
+/// Apply a provider's configured TLS material to its HTTP-client builder.
+///
+/// A provider that configures neither an identity nor a CA bundle gets the
+/// builder back untouched — the default TLS stack, byte-identical to the
+/// behaviour before mutual TLS existed.
+///
+/// # Errors
+///
+/// [`TlsMaterialError`] when the identity is half-configured, a PEM file is
+/// unreadable, or its contents are not the certificates/key the key promises.
+pub(super) fn apply(
+    builder: reqwest::ClientBuilder,
+    cfg: &FhirProviderConfig,
+) -> Result<reqwest::ClientBuilder, TlsMaterialError> {
+    let builder = match (&cfg.client_cert_path, &cfg.client_key_path) {
+        (Some(cert), Some(key)) => builder.identity(load_identity(cert, key)?),
+        (None, None) => builder,
+        _ => return Err(TlsMaterialError::IncompleteIdentity),
+    };
+    let Some(ca) = &cfg.ca_bundle_path else {
+        return Ok(builder);
+    };
+    Ok(builder.tls_certs_only(load_trust_anchors(ca)?))
+}
+
+/// Load the client certificate chain + private key as one `reqwest` identity.
+///
+/// Both PEM files are parsed first with `rustls`' own reader so a mistake names
+/// the offending key (`client_cert_path` vs `client_key_path`) instead of
+/// surfacing as one opaque "invalid identity" from the concatenated buffer.
+fn load_identity(cert_path: &Path, key_path: &Path) -> Result<reqwest::Identity, TlsMaterialError> {
+    use rustls::pki_types::pem::PemObject;
+
+    let cert_pem = read(MaterialRole::ClientCertificate, cert_path)?;
+    let key_pem = read(MaterialRole::ClientKey, key_path)?;
+
+    let certs: Vec<_> = rustls::pki_types::CertificateDer::pem_slice_iter(&cert_pem)
+        .collect::<Result<_, _>>()
+        .map_err(|e| TlsMaterialError::NoCertificate {
+            role: MaterialRole::ClientCertificate,
+            path: cert_path.to_path_buf(),
+            reason: e.to_string(),
+        })?;
+    if certs.is_empty() {
+        return Err(TlsMaterialError::NoCertificate {
+            role: MaterialRole::ClientCertificate,
+            path: cert_path.to_path_buf(),
+            reason: "the file contains no PEM certificate section".to_owned(),
+        });
+    }
+    rustls::pki_types::PrivateKeyDer::from_pem_slice(&key_pem).map_err(|e| {
+        TlsMaterialError::NoPrivateKey {
+            path: key_path.to_path_buf(),
+            reason: e.to_string(),
+        }
+    })?;
+
+    // `reqwest::Identity::from_pem` takes the key and the chain in one buffer.
+    let mut combined = key_pem;
+    combined.extend_from_slice(b"\n");
+    combined.extend_from_slice(&cert_pem);
+    reqwest::Identity::from_pem(&combined).map_err(|e| TlsMaterialError::Rejected {
+        role: MaterialRole::ClientCertificate,
+        source: e,
+    })
+}
+
+/// Load the trust anchors a provider verifies its terminology server with.
+fn load_trust_anchors(path: &Path) -> Result<Vec<reqwest::Certificate>, TlsMaterialError> {
+    let pem = read(MaterialRole::CaBundle, path)?;
+    let anchors =
+        reqwest::Certificate::from_pem_bundle(&pem).map_err(|e| TlsMaterialError::Rejected {
+            role: MaterialRole::CaBundle,
+            source: e,
+        })?;
+    if anchors.is_empty() {
+        return Err(TlsMaterialError::NoCertificate {
+            role: MaterialRole::CaBundle,
+            path: path.to_path_buf(),
+            reason: "the file contains no PEM certificate section".to_owned(),
+        });
+    }
+    Ok(anchors)
+}
+
+/// Read a configured PEM file, naming the configuration key in the error.
+fn read(role: MaterialRole, path: &Path) -> Result<Vec<u8>, TlsMaterialError> {
+    std::fs::read(path).map_err(|source| TlsMaterialError::Read {
+        role,
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::panic,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    let_underscore_drop
+)] // test assertions/diagnostics/fixtures
+mod tests {
+    use super::*;
+    use crate::service::terminology::config::test_provider_config;
+
+    /// Neither key set: the builder is untouched — a deployment that never
+    /// mentions TLS material keeps the default stack.
+    #[test]
+    fn no_material_is_a_no_op() {
+        let cfg = test_provider_config("https://ts.example.org/fhir");
+        assert!(apply(reqwest::Client::builder(), &cfg).is_ok());
+    }
+
+    /// A certificate without its key (or the reverse) is a loud failure — never
+    /// a connection that silently presents no identity.
+    #[test]
+    fn a_half_configured_identity_is_rejected() {
+        let mut cfg = test_provider_config("https://ts.example.org/fhir");
+        cfg.client_cert_path = Some(PathBuf::from("/nonexistent/client.crt.pem"));
+        assert!(matches!(
+            apply(reqwest::Client::builder(), &cfg),
+            Err(TlsMaterialError::IncompleteIdentity)
+        ));
+
+        let mut cfg = test_provider_config("https://ts.example.org/fhir");
+        cfg.client_key_path = Some(PathBuf::from("/nonexistent/client.key.pem"));
+        assert!(matches!(
+            apply(reqwest::Client::builder(), &cfg),
+            Err(TlsMaterialError::IncompleteIdentity)
+        ));
+    }
+
+    /// An unreadable file names the configuration key that pointed at it.
+    #[test]
+    fn an_unreadable_file_names_its_config_key() {
+        let mut cfg = test_provider_config("https://ts.example.org/fhir");
+        cfg.ca_bundle_path = Some(PathBuf::from("/nonexistent/ca.pem"));
+        let err = apply(reqwest::Client::builder(), &cfg).expect_err("must fail");
+        assert!(
+            matches!(
+                &err,
+                TlsMaterialError::Read {
+                    role: MaterialRole::CaBundle,
+                    ..
+                }
+            ),
+            "got {err}"
+        );
+        assert!(err.to_string().contains("ca_bundle_path"), "got {err}");
+    }
+}

--- a/app/ehrbase/tests/adl2_vetdf.rs
+++ b/app/ehrbase/tests/adl2_vetdf.rs
@@ -76,6 +76,9 @@ fn provider(base: &str) -> FhirTerminologyProvider {
         connect_timeout_ms: 500,
         request_timeout_ms: 800,
         oauth2_client: None,
+        client_cert_path: None,
+        client_key_path: None,
+        ca_bundle_path: None,
         cache_ttl_secs: 0,
         cache_capacity: 0,
     };

--- a/app/ehrbase/tests/service_aql_terminology.rs
+++ b/app/ehrbase/tests/service_aql_terminology.rs
@@ -276,6 +276,9 @@ fn fhir_provider(base: &str) -> FhirTerminologyProvider {
         connect_timeout_ms: 800,
         request_timeout_ms: 1_500,
         oauth2_client: None,
+        client_cert_path: None,
+        client_key_path: None,
+        ca_bundle_path: None,
         cache_ttl_secs: 0,
         cache_capacity: 1024,
     };

--- a/app/ehrbase/tests/terminology_fhir.rs
+++ b/app/ehrbase/tests/terminology_fhir.rs
@@ -28,6 +28,9 @@ fn provider(base: &str, operation: FhirOperation) -> FhirTerminologyProvider {
         connect_timeout_ms: 500,
         request_timeout_ms: 800,
         oauth2_client: None,
+        client_cert_path: None,
+        client_key_path: None,
+        ca_bundle_path: None,
         // Cache off: these tests assert exact per-call server interactions.
         cache_ttl_secs: 0,
         cache_capacity: 0,
@@ -44,6 +47,9 @@ fn cached_provider(base: &str, operation: FhirOperation) -> FhirTerminologyProvi
         connect_timeout_ms: 500,
         request_timeout_ms: 800,
         oauth2_client: None,
+        client_cert_path: None,
+        client_key_path: None,
+        ca_bundle_path: None,
         cache_ttl_secs: 300,
         cache_capacity: 1024,
     };

--- a/app/ehrbase/tests/terminology_mtls.rs
+++ b/app/ehrbase/tests/terminology_mtls.rs
@@ -1,0 +1,496 @@
+#![allow(
+    clippy::panic,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    let_underscore_drop
+)] // test assertions/diagnostics/fixtures
+//! Mutual TLS from the CDR to a terminology server, proven against a real TLS
+//! listener that demands (and inspects) the client certificate.
+//!
+//! `wiremock` cannot terminate TLS, let alone require a client certificate, so
+//! these tests stand up a minimal `rustls` acceptor in-process and answer one
+//! canned FHIR `CodeSystem/$lookup` over it. What is asserted is the handshake
+//! outcome and the certificate the server actually saw — the only evidence
+//! that the client identity was presented rather than merely configured.
+//!
+//! No openEHR spec governs terminology-server transport security — our own
+//! design/extension (`BASE/docs/architecture_overview/master12-terminology.adoc`
+//! models the backend only as an external "terminology query server").
+//!
+//! # The test PKI
+//!
+//! Generated once, offline, with `openssl` — the same approach as the ATNA TLS
+//! round-trip test, and for the same reason: no certificate-minting crate is in
+//! the workspace dependency set, and the repository's `.gitignore` deliberately
+//! refuses committed `*.pem` / `*.key` files. The material is therefore inlined
+//! here and written to a temporary directory per test, because the
+//! configuration keys under test are *paths*.
+//!
+//! - CA `CN=ehrbase-terminology-test-ca` (`basicConstraints=CA:TRUE`);
+//! - server leaf `CN=localhost`, SAN `DNS:localhost` + `IP:127.0.0.1`,
+//!   `extendedKeyUsage=serverAuth`;
+//! - client leaf `CN=ehrbase-cdr`, `extendedKeyUsage=clientAuth`.
+//!
+//! Both leaves are signed by the CA and expire in 2126, so the suite does not
+//! rot. Every key here is a throwaway that never left this repository's tests.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use ehrbase::service::terminology::config::{
+    ExternalTerminologyConfig, FhirOperation, FhirProviderConfig, ProviderKind,
+};
+use ehrbase::service::terminology::router::TerminologyRouter;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio_rustls::TlsAcceptor;
+
+const CA_CERT_PEM: &[u8] = b"-----BEGIN CERTIFICATE-----
+MIIDPzCCAiegAwIBAgIUQdzLptxYSE4Z2KUtCRX4orOs5x4wDQYJKoZIhvcNAQEL
+BQAwJjEkMCIGA1UEAwwbZWhyYmFzZS10ZXJtaW5vbG9neS10ZXN0LWNhMCAXDTI2
+MDcyOTEzNDQ0MFoYDzIxMjYwNzA1MTM0NDQwWjAmMSQwIgYDVQQDDBtlaHJiYXNl
+LXRlcm1pbm9sb2d5LXRlc3QtY2EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
+AoIBAQCr5GwUx1SYbKWyobe/4gNljimQ2fMkF6NJ2UbqQo1YmchqjbDU3yqPhO+u
+2uA3tjPy7LJiyFai7JexYbrgBcQEcphDvfWfTUTkpb5XxSrWYBxQEW1auxWpq33m
+5oQKch+SkblKpdhGXnRwBwtmiQs/oECPexEq/AOWCYwjn0Y0ZwZryjH0L0SAlHXa
+0SWIihVz2pBGk1xKiQkV7OPM+sbbR1e9D+clQOzTHWz1cGtfep7b2vWn14nBc36C
+cbF336umG/2XiF9B+dFM6KQxNRA3RizCuSPIIH0fdQBaAVuCzjGc3/sLqvulsbxV
+cEFmZchu7kEcVGVdcrS1tCple8AFAgMBAAGjYzBhMB0GA1UdDgQWBBT4JtIe+Kky
+uKi1rzSo2Sc1sg+zhjAfBgNVHSMEGDAWgBT4JtIe+KkyuKi1rzSo2Sc1sg+zhjAP
+BgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBBjANBgkqhkiG9w0BAQsFAAOC
+AQEAhD4fgejqDAO0ypzfEgJLzaFqqvJpbt8pyiNZ+THR6KrjylW3pUNk1WZRxL9p
+4b9A1YKtQX1ABt2AEJ0pFgm1PiXy4EDszyRK8A33hls91c6761pHds0+SFYsq6jr
+zSJEanbJ5sQccTbsZ6nkzEjq3y/QBmw49TAqzbzMrYJjvHFPXpUr3Bpt9qTR/UmQ
+NQ/kWfCpLqmpWD8O71enKN1F7UId3nnpEus+/HMtnPtErMHBfGBOWsr95d37NB52
+CJTogkq19bUHC9nI4XBnNhR4F1BTZL9lQYghjettRzu0fvHj0JCR437GbkFmOZyA
+6O1x7xRNYxQG+wohHHPFnyDENg==
+-----END CERTIFICATE-----
+";
+
+const SERVER_CERT_PEM: &[u8] = b"-----BEGIN CERTIFICATE-----
+MIIDWjCCAkKgAwIBAgIUN6RUnq7anOZdiSdi9b6onYdW7PAwDQYJKoZIhvcNAQEL
+BQAwJjEkMCIGA1UEAwwbZWhyYmFzZS10ZXJtaW5vbG9neS10ZXN0LWNhMCAXDTI2
+MDcyOTEzNDQ0MFoYDzIxMjYwNzA1MTM0NDQwWjAUMRIwEAYDVQQDDAlsb2NhbGhv
+c3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCbjXXyGI544/qF09KL
+GXWCNXr4mN4DXDfuSGNGpMXV+maRhkK3rA5c+bphPmwaR6RQ4Bc7y0bPITqVU8AF
+m4VA0MZ2qe2TTKr8eaBCBZXETXLH3NjQuARVgO05hgrNSIgTFYhRrUW0nJo9SYZ9
+ryAYhpokhilrvquziyBMlhZzk+QoqUclnCDYdjJsTR8dSVxrKX0qmyN4kTjBCpKt
+y5Me7SbX0xy/AT2lPlUIkAkAxkwcrbZ0cB7BCvR7xdFE49GSc/3s5G8dFujsywNk
+hMCE0TbUMvgodTURJN9VD3Kw9bypJq7At6IFGrMX1oDepGGno48Ke7XlgRBTjyDA
+4xWdAgMBAAGjgY8wgYwwGgYDVR0RBBMwEYIJbG9jYWxob3N0hwR/AAABMA4GA1Ud
+DwEB/wQEAwIFoDATBgNVHSUEDDAKBggrBgEFBQcDATAJBgNVHRMEAjAAMB0GA1Ud
+DgQWBBTdRR/Wxur642w7IpXvYTI0OhMuxzAfBgNVHSMEGDAWgBT4JtIe+KkyuKi1
+rzSo2Sc1sg+zhjANBgkqhkiG9w0BAQsFAAOCAQEAFjeZyyNnvB3Hof0KFw/DMkV3
+xdk7ls7DPyfT0GUDiKtYP8wuMNpEjavvz4KmsE9Dri7xTgy6SiROLF5bQav7t4LN
+eeLZu47XX+8+BZNLmWv6OUU0Z9uzDZ4XR62jjac4Zoiu+isJGkZl9QMoeJJxln+d
+yBRARFGNmsDK/Db3Oi/PJE7FtiSda1mnxua8sRTBjujizcsF0jRoUCtc9hPFSEdY
+65qmTdb7rJUxTA6yFj1Hp1M6WzeuNGLZnoMV9c5QF50Cvkg29PVd+C57gRHYqAui
+T4eTPOd62IGoTZeAe+jQrFm5xdV6Q7wic93uLRJdYnJ7ZZKGuEzIDqWF2yDyrQ==
+-----END CERTIFICATE-----
+";
+
+const SERVER_KEY_PEM: &[u8] = b"-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCbjXXyGI544/qF
+09KLGXWCNXr4mN4DXDfuSGNGpMXV+maRhkK3rA5c+bphPmwaR6RQ4Bc7y0bPITqV
+U8AFm4VA0MZ2qe2TTKr8eaBCBZXETXLH3NjQuARVgO05hgrNSIgTFYhRrUW0nJo9
+SYZ9ryAYhpokhilrvquziyBMlhZzk+QoqUclnCDYdjJsTR8dSVxrKX0qmyN4kTjB
+CpKty5Me7SbX0xy/AT2lPlUIkAkAxkwcrbZ0cB7BCvR7xdFE49GSc/3s5G8dFujs
+ywNkhMCE0TbUMvgodTURJN9VD3Kw9bypJq7At6IFGrMX1oDepGGno48Ke7XlgRBT
+jyDA4xWdAgMBAAECggEAGN7s2UkI2pZk82nTU48+BRQk9cOHV9UyUiR7zwtAYH6Z
+ULI9T52wbDg3jx3Kbgc/Y/j4bgSJ7Us8USzjWmIr05mt6cIwrKkI+7Y8o+G9uPXD
+IOaUOgb6Fmu3QkfGyVzL+PUr5xdDumWBmcP8P3M1OAapdaaHz+TcEihwAR7MNy1R
+47BG24EtO7RWLOOdNsm3wYqMdCvoXJ8U9wPudigSKi7m+oO4+uTdmFslf1uDc2ie
+QUXRehjvof/3w/ltWJI/F+4DO1ze6deSIUz3G0c6dbENU9wmHGRgmMjBH1Ksiqqy
+xczsq4wt6/F/HcYBCeq/av/P2u7bGfeT9316E+kJxwKBgQDPx4kfm51k5HQi2nRe
+0c4ODVDu6P5R8P1h+q2VmPHyWoZGO9s+8b11FVSi1EyNPS5gzpltmeetQkSMiAs2
+unSlkpe4UG8cr2X2T2DIpEOgQL3WNWuKO61+W04AKXlnTacF2TJh+ecwp8xpQvVs
+Qhdxo1pP/5tCHwSbozXgF58n0wKBgQC/pw4irsApIDn2OrG+nIuZutXCKq/++HMy
+cyEiHd1Fx6+qX+AVPrz8XNWB6o4ZsBJHGEfKjCw5Fe1RcLmuAASveG/bAnei3L4a
+vvTUJaviM3M7XXnAdsdfOBKCkzDOSjkkngyY5Frel6YkB73X6iknPKes8HMS7E0J
+coomR0tWzwKBgQCh1xMIqqZLGuMW7r9rx9HPAjJDFPpbCvHiKmagunPiSP6DoEXi
+3lqq4wV8mw5RiREh2GqLgzCAtLg+Gg1aAJuxB+DjcMtLNZee5i9FuSTvot37BrsP
+/fHiFO5JlAR7IXHyTT5AMG4SaPEAIGaXf1dRbWKAI2FkfFKTg+oH9X5DfwKBgEoy
+Roqu1L4XN9lXx9BfkrwlVPQiypgPX6m8YKtwnGWTdTKkg4A2FbwtxIrTX8gaHjlf
+8Qs9UTGYh5Pr7Das0yOLoOJNBjwK8Z4xJ1+qZezgtk/ZVHVqhq0abDAZA+AZZB4F
+AiN+5J8gXrW8OYcJpH0IQnH1dNdynDB4I3vGRiiJAoGAJALnmQ2t263WmSt+pNRM
+jIrhr8CJwPiv648qLu+xkWNVjHqX5JqOT7LPYinSoNjEWfo5o6Bl52lgcwE/B2j4
++flFd9WfI18fXESLmKfzisARe+iftNsO75rwpFu/AZOaizFg/wqZlnaNCl3+No5n
+VZeOC1RrGYXZFXe6/XlN/Y4=
+-----END PRIVATE KEY-----
+";
+
+const CLIENT_CERT_PEM: &[u8] = b"-----BEGIN CERTIFICATE-----
+MIIDPjCCAiagAwIBAgIUN6RUnq7anOZdiSdi9b6onYdW7PEwDQYJKoZIhvcNAQEL
+BQAwJjEkMCIGA1UEAwwbZWhyYmFzZS10ZXJtaW5vbG9neS10ZXN0LWNhMCAXDTI2
+MDcyOTEzNDQ0MVoYDzIxMjYwNzA1MTM0NDQxWjAWMRQwEgYDVQQDDAtlaHJiYXNl
+LWNkcjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKYtID4ud0jEkUFr
+Dync/gEVvAeklhwA23JEdsLobmJkFJtbn68qJmmEMRyJx/0OYNwpoJ8MeY7NMNyx
+63J6lDfmhQFpxJVxHqLspBp9DmEu0ifO7Q5VmEeQrnqkd4cF/hp61M7X83TybG79
+O1605+X30/amgxHj6Y3NAFuO3+C9ayJl8oFjrX86if9m4ywPO2pps8fKRmy6V0P1
+O2PBIaf8lEvPYbzEj8pMiBiWj45ZuNopOq5OAUIndFtR55G7cL51KrocMuVo48i4
+AXRQQR14BDyhiyuCd8zhDtMoGuWsa0E+K9yove6Uhv7aKyaVlkVPSQ9vIQjXx9LJ
+b2n0QRkCAwEAAaNyMHAwDgYDVR0PAQH/BAQDAgeAMBMGA1UdJQQMMAoGCCsGAQUF
+BwMCMAkGA1UdEwQCMAAwHQYDVR0OBBYEFL65rmBZ4vWcx18igZhEiWnsGDp/MB8G
+A1UdIwQYMBaAFPgm0h74qTK4qLWvNKjZJzWyD7OGMA0GCSqGSIb3DQEBCwUAA4IB
+AQAHzzukoZnHp6zkcSwulSMUsECfdXQFjmPszTsgdoMRtozrIJBeTTn8TU4udt83
+lcqJO2aHxaEsXQAC6HiO68LLqudio4BymkpYY/jnBLZNOCiChY2NkMR+PNnWrrKh
+eXBNKgzE1OFcPs2eDzXDGi4u0C+5TAzTyk1iFJSjVPrm+WYBlSQ40+KkZjc3QPqM
+9mmbv/ywOeaLihcgIeIkTHQLb7dlhTazDyX5KpqegPqh/NMXVdVchN0pnRZ7l4V9
+xYMKapLu7dF65h/aXFYQaKSn7ztjDS5/sEKcwBjjSRcoXOqISuXyfONEjuInj/Lh
+WKGF8hUt9DgUqWPuDe33JrC8
+-----END CERTIFICATE-----
+";
+
+const CLIENT_KEY_PEM: &[u8] = b"-----BEGIN PRIVATE KEY-----
+MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQCmLSA+LndIxJFB
+aw8p3P4BFbwHpJYcANtyRHbC6G5iZBSbW5+vKiZphDEcicf9DmDcKaCfDHmOzTDc
+setyepQ35oUBacSVcR6i7KQafQ5hLtInzu0OVZhHkK56pHeHBf4aetTO1/N08mxu
+/TtetOfl99P2poMR4+mNzQBbjt/gvWsiZfKBY61/Oon/ZuMsDztqabPHykZsuldD
+9TtjwSGn/JRLz2G8xI/KTIgYlo+OWbjaKTquTgFCJ3RbUeeRu3C+dSq6HDLlaOPI
+uAF0UEEdeAQ8oYsrgnfM4Q7TKBrlrGtBPivcqL3ulIb+2ismlZZFT0kPbyEI18fS
+yW9p9EEZAgMBAAECggEACfes9m3dE81OlSjxyOYLik8ebyrtIhLfFtSKdxhv/pDY
+N5VgV6ZklXGrbHXLPB+PqcUJcGDULb+bDbHSWJSHrW6zTalldD1LxCQDl98mbKfd
+TSv5RiHWN3yzKoIQ9VVjr3zspNeJL9uWq3WfCQg63K1n1mSYegs8qBfCzLseLKG3
+LR2yhZSbMdH7NNWwoG1iwDXyJGx4SM4r7z2dPRobMxT5ErIKtCzDRLcUWMeW3FiU
+qEB5SXscrF5TitQaFtwRFPO0IpbPWoXbW99OZTPoi+ZHUxVRShWE3gtO3D6cvgHf
+iwLxdpy3tUHIAnm5SbDjtp30AAF1S/CUU3ZpcoiafQKBgQDc7/LI4FcG0xmKzGHe
+vzfDZDUFxjVkCY0zQ919l9TufJZbZXOp6iVnAEts46ykZ2oPZXAt9csLT94EF4iy
+1/VxQ67NQxAyfMMKCCTMMgAuL0VCWhzKdx0udcOvoqdnoRAt48jOW/9fKlhSitMW
+Ef6pg+n1T3ZbXUPE+zi4ezC+vwKBgQDAjGS6k11728mqKP9SThpGGdPiJVwM9c3y
+etCHwz0g7Dfo0dZBFrXbyDksaI+M/OchbJLq3Ar+UOlB0l08m60f6OmXVzSDFvgs
+m1ilCvAp3cxvFuasji5CqTlQ5DZlNbjbsADUHwel4geiCgYvn655IONuUqo2stCf
+qArTp9dOJwKBgQCo/ML3kFggOTDtL/yf0iRFyAyiOQO3W3LrxjnQiWRtcU/T4lpA
+mX44NUp7o/z11r+RvSW7kafXJCSNfq6pFHOASaOXDneCFllb//SdVpU6vh88bA5f
+chIY6ixd14wxwEjOwM5jwIwobwwVPmfMFsFxSRuW7Ut7AHAIZ5rvyBH1owKBgQCB
+yWBQPurhhPm+/9lyEgE1xU0D/2i3t6v1SQFssZZvranV/jMsNnGozqJzI5u3TfVB
+m1zAgEfMup8v5etA4jJk8usZPwe/YOkxsBilTuUpYz7clpQwNbpK5qQiuWFNAVQ0
+iMNWOABAuUWp3JXk3f6N2TRT9daT/h4PsAZ0OosvOwKBgQCt7E+/RlRNlcC+4o2S
+kT6qEL4sTV0Qc+RMtlakqDaLElcQx9ZIc4SPAeiIRq0Lm/w5l1GV1JvxawWR63P0
+16krB8b1EGloCd5p8XBWMQRdn7Pyo+kY+Xrpo+3SJroCVbKHojJKxnPgX2GE0XVx
+SxWyjGrM2xGr1RcYYQM5nopluQ==
+-----END PRIVATE KEY-----
+";
+
+/// The one canned FHIR `CodeSystem/$lookup` answer the test server gives to
+/// every request that reaches it — the payload is irrelevant here; that a
+/// request reached it at all is the assertion.
+const LOOKUP_BODY: &str = r#"{"resourceType":"Parameters","parameter":[{"name":"display","valueString":"Hypertension"}]}"#;
+
+/// The temporary directory holding this test's PEM files, plus their paths —
+/// the configuration keys under test are paths, so the material has to live on
+/// disk. Dropping this removes the directory.
+struct Pki {
+    _dir: assert_fs::TempDir,
+    ca: PathBuf,
+    client_cert: PathBuf,
+    client_key: PathBuf,
+}
+
+impl Pki {
+    fn write() -> Self {
+        let dir = assert_fs::TempDir::new().expect("temp dir");
+        let write = |name: &str, bytes: &[u8]| {
+            let path = dir.path().join(name);
+            std::fs::write(&path, bytes).expect("write pem");
+            path
+        };
+        let ca = write("ca.crt.pem", CA_CERT_PEM);
+        let client_cert = write("client.crt.pem", CLIENT_CERT_PEM);
+        let client_key = write("client.key.pem", CLIENT_KEY_PEM);
+        Self {
+            _dir: dir,
+            ca,
+            client_cert,
+            client_key,
+        }
+    }
+}
+
+/// A running TLS terminology-server stub: its port, and the peer certificates
+/// the first accepted connection presented (`None` when the handshake failed
+/// or the client sent none).
+struct TestTs {
+    port: u16,
+    peer: tokio::sync::mpsc::UnboundedReceiver<Option<usize>>,
+}
+
+impl TestTs {
+    /// Start a TLS listener serving the `localhost` leaf. With `require_client`
+    /// it also demands a certificate signed by the test CA, so a client
+    /// without an identity is rejected at the handshake.
+    async fn start(require_client: bool) -> Self {
+        use rustls::pki_types::pem::PemObject;
+
+        let mut roots = rustls::RootCertStore::empty();
+        for cert in certs(CA_CERT_PEM) {
+            roots.add(cert).expect("ca root");
+        }
+        let provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
+        let builder = rustls::ServerConfig::builder_with_provider(provider.clone())
+            .with_safe_default_protocol_versions()
+            .expect("protocol versions");
+        let builder = if require_client {
+            let verifier = rustls::server::WebPkiClientVerifier::builder_with_provider(
+                Arc::new(roots),
+                provider,
+            )
+            .build()
+            .expect("client verifier");
+            builder.with_client_cert_verifier(verifier)
+        } else {
+            builder.with_no_client_auth()
+        };
+        let mut config = builder
+            .with_single_cert(
+                certs(SERVER_CERT_PEM),
+                rustls::pki_types::PrivateKeyDer::from_pem_slice(SERVER_KEY_PEM).expect("key"),
+            )
+            .expect("server cert");
+        // The client is built with `default-features = false` (no `http2`), so
+        // it offers `http/1.1`; declare it rather than leaving ALPN empty.
+        config.alpn_protocols = vec![b"http/1.1".to_vec()];
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        let acceptor = TlsAcceptor::from(Arc::new(config));
+        let (tx, peer) = tokio::sync::mpsc::unbounded_channel();
+
+        tokio::spawn(async move {
+            loop {
+                let Ok((tcp, _)) = listener.accept().await else {
+                    return;
+                };
+                let acceptor = acceptor.clone();
+                let tx = tx.clone();
+                tokio::spawn(async move {
+                    let Ok(mut tls) = acceptor.accept(tcp).await else {
+                        // A rejected handshake is itself the observation.
+                        let _unused = tx.send(None);
+                        return;
+                    };
+                    let presented = tls
+                        .get_ref()
+                        .1
+                        .peer_certificates()
+                        .map(<[rustls::pki_types::CertificateDer<'_>]>::len);
+                    let _unused = tx.send(presented);
+                    // Read the request head, then answer it.
+                    let mut buf = [0_u8; 2048];
+                    let _read = tls.read(&mut buf).await;
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/fhir+json\r\n\
+                         content-length: {}\r\nconnection: close\r\n\r\n{LOOKUP_BODY}",
+                        LOOKUP_BODY.len()
+                    );
+                    let _written = tls.write_all(response.as_bytes()).await;
+                    let _flushed = tls.shutdown().await;
+                });
+            }
+        });
+
+        Self { port, peer }
+    }
+
+    fn url(&self) -> String {
+        format!("https://localhost:{}/fhir", self.port)
+    }
+}
+
+fn certs(pem: &[u8]) -> Vec<rustls::pki_types::CertificateDer<'static>> {
+    use rustls::pki_types::pem::PemObject;
+    rustls::pki_types::CertificateDer::pem_slice_iter(pem)
+        .collect::<Result<_, _>>()
+        .expect("certificates")
+}
+
+/// A provider config pointing at `url`, cache off so every call is a real
+/// connection.
+fn provider_cfg(url: &str) -> FhirProviderConfig {
+    FhirProviderConfig {
+        kind: ProviderKind::Fhir,
+        url: url.to_owned(),
+        operation: FhirOperation::ValidateCode,
+        connect_timeout_ms: 2_000,
+        request_timeout_ms: 4_000,
+        oauth2_client: None,
+        client_cert_path: None,
+        client_key_path: None,
+        ca_bundle_path: None,
+        cache_ttl_secs: 0,
+        cache_capacity: 0,
+    }
+}
+
+fn external(cfg: FhirProviderConfig) -> ExternalTerminologyConfig {
+    ExternalTerminologyConfig {
+        enabled: true,
+        providers: std::iter::once(("default".to_owned(), cfg)).collect(),
+        ..ExternalTerminologyConfig::default()
+    }
+}
+
+/// Build the router, take its sole provider, and run one `$lookup`.
+async fn lookup(cfg: FhirProviderConfig) -> Result<bool, ehrbase::service::status::SmError> {
+    let router = TerminologyRouter::build(&external(cfg))?.expect("router");
+    let provider = router.default_provider().expect("default provider");
+    provider
+        .has_term("http://snomed.info/sct", "38341003", None)
+        .await
+}
+
+/// (a) A provider carrying a client identity completes the handshake against a
+/// server that demands one, and its request is answered. The server-side
+/// assertion — a peer certificate was actually presented — is what
+/// distinguishes "mutual TLS works" from "the connection happened to succeed".
+#[tokio::test]
+async fn a_client_identity_completes_the_mutual_tls_handshake() {
+    let pki = Pki::write();
+    let mut ts = TestTs::start(true).await;
+
+    let mut cfg = provider_cfg(&ts.url());
+    cfg.client_cert_path = Some(pki.client_cert.clone());
+    cfg.client_key_path = Some(pki.client_key.clone());
+    cfg.ca_bundle_path = Some(pki.ca.clone());
+
+    assert!(
+        lookup(cfg).await.expect("the mTLS lookup must succeed"),
+        "the terminology server answered the lookup"
+    );
+    assert_eq!(
+        ts.peer.recv().await.expect("the server saw a connection"),
+        Some(1),
+        "the server must have received exactly the configured client certificate"
+    );
+}
+
+/// (b) The same server refuses a provider that configures no client identity:
+/// the handshake fails and the SM call surfaces a transport exception rather
+/// than a silent success.
+#[tokio::test]
+async fn the_same_server_refuses_a_provider_without_the_identity() {
+    let pki = Pki::write();
+    let mut ts = TestTs::start(true).await;
+
+    let mut cfg = provider_cfg(&ts.url());
+    // Trust anchors only — the server is verified, but nothing is presented.
+    cfg.ca_bundle_path = Some(pki.ca.clone());
+
+    let err = lookup(cfg)
+        .await
+        .expect_err("a client-authenticating server must refuse an anonymous client");
+    assert!(
+        err.message.contains("terminology provider 'default'"),
+        "got {}",
+        err.message
+    );
+    assert_eq!(
+        ts.peer.recv().await.expect("the server saw a connection"),
+        None,
+        "the server must have rejected the handshake, seeing no client certificate"
+    );
+}
+
+/// (c) A custom CA bundle is what makes a privately-issued terminology server
+/// trusted: with `ca_bundle_path` the call succeeds, and with the platform's
+/// default trust the very same server is refused. Verification is never
+/// disabled — only the anchors change.
+#[tokio::test]
+async fn a_custom_ca_bundle_trusts_a_private_server_that_default_trust_refuses() {
+    let pki = Pki::write();
+    let ts = TestTs::start(false).await;
+
+    let mut trusted = provider_cfg(&ts.url());
+    trusted.ca_bundle_path = Some(pki.ca.clone());
+    assert!(
+        lookup(trusted).await.expect("the pinned-CA lookup"),
+        "the private CA bundle makes the server trusted"
+    );
+
+    // Same server, same URL, no configured anchors: the default trust store
+    // does not know this CA, so the connection is refused.
+    //
+    // NOTE: this arm is the slow one on macOS. Default trust goes through the
+    // operating system's certificate evaluation, which hunts for the unknown
+    // issuer (network included) before giving up, and it does so synchronously
+    // inside the handshake — the provider's own connect/request timeouts
+    // cannot cut it short. Pinning the anchors with `ca_bundle_path`, the
+    // arm above, verifies against exactly the configured CA and returns
+    // immediately.
+    let untrusted = provider_cfg(&ts.url());
+    let err = lookup(untrusted)
+        .await
+        .expect_err("default trust must refuse a privately-issued certificate");
+    assert!(
+        err.message.contains("terminology provider 'default'"),
+        "got {}",
+        err.message
+    );
+}
+
+/// (d) Broken TLS material is a BOOT failure, not a first-request surprise: the
+/// router refuses to build. Both shapes are covered — a path that does not
+/// exist, and a file that exists but holds the wrong PEM object.
+#[tokio::test]
+async fn broken_tls_material_fails_at_boot() {
+    let pki = Pki::write();
+
+    // A certificate path that does not exist.
+    let mut missing = provider_cfg("https://ts.example.org/fhir");
+    missing.client_cert_path = Some(PathBuf::from("/nonexistent/ehrbase-ts-client.crt.pem"));
+    missing.client_key_path = Some(pki.client_key.clone());
+    let err = TerminologyRouter::build(&external(missing))
+        .expect_err("a missing certificate file must fail the build");
+    assert!(
+        err.message.contains("client_cert_path"),
+        "got {}",
+        err.message
+    );
+
+    // A key path pointing at a certificate — readable, but not a private key.
+    let mut wrong_key = provider_cfg("https://ts.example.org/fhir");
+    wrong_key.client_cert_path = Some(pki.client_cert.clone());
+    wrong_key.client_key_path = Some(pki.ca.clone());
+    let err = TerminologyRouter::build(&external(wrong_key))
+        .expect_err("a key file holding no private key must fail the build");
+    assert!(
+        err.message.contains("no PEM private key"),
+        "got {}",
+        err.message
+    );
+
+    // A CA bundle path pointing at a private key — no trust anchor in it.
+    let mut wrong_ca = provider_cfg("https://ts.example.org/fhir");
+    wrong_ca.ca_bundle_path = Some(pki.client_key.clone());
+    let err = TerminologyRouter::build(&external(wrong_ca))
+        .expect_err("a CA bundle holding no certificate must fail the build");
+    assert!(
+        err.message.contains("ca_bundle_path"),
+        "got {}",
+        err.message
+    );
+
+    // And half an identity never reaches the network either.
+    let mut half = provider_cfg("https://ts.example.org/fhir");
+    half.client_key_path = Some(pki.client_key.clone());
+    let err = TerminologyRouter::build(&external(half))
+        .expect_err("half a client identity must fail the build");
+    assert!(
+        err.message.contains("must be set together"),
+        "got {}",
+        err.message
+    );
+}
+
+/// The paths themselves are what the configuration carries — a sanity check
+/// that the fixture material really is what the tests above claim.
+#[test]
+fn the_test_pki_is_well_formed() {
+    assert_eq!(certs(CA_CERT_PEM).len(), 1);
+    assert_eq!(certs(SERVER_CERT_PEM).len(), 1);
+    assert_eq!(certs(CLIENT_CERT_PEM).len(), 1);
+    let pki = Pki::write();
+    for path in [&pki.ca, &pki.client_cert, &pki.client_key] {
+        assert!(Path::new(path).is_file(), "{} written", path.display());
+    }
+}

--- a/app/ehrbase/tests/terminology_multi_provider.rs
+++ b/app/ehrbase/tests/terminology_multi_provider.rs
@@ -46,6 +46,9 @@ fn provider_cfg(base: &str) -> FhirProviderConfig {
         connect_timeout_ms: 500,
         request_timeout_ms: 800,
         oauth2_client: None,
+        client_cert_path: None,
+        client_key_path: None,
+        ca_bundle_path: None,
         cache_ttl_secs: 0,
         cache_capacity: 0,
     }

--- a/deploy/helm/ehrbase-rs/values.yaml
+++ b/deploy/helm/ehrbase-rs/values.yaml
@@ -270,7 +270,9 @@ config:
   # Each key becomes /etc/ehrbase/<key> from a chart Secret (opaque, read-only),
   # alongside ehrbase.toml. Use for file-shaped material an in-TOML `*_path`/
   # `*_file` key points at: the PGP key (signing.key_path), Cedar policies
-  # (authz.abac.cedar.policy_dir), ATNA PEMs, a JWKS blob (auth.oidc.jwks_json_file).
+  # (authz.abac.cedar.policy_dir), ATNA PEMs, terminology-server mutual-TLS PEMs
+  # (terminology.external.providers.<name>.client_cert_path / client_key_path /
+  # ca_bundle_path), a JWKS blob (auth.oidc.jwks_json_file).
   files: {}
   # signing.asc: |
   #   -----BEGIN PGP PRIVATE KEY BLOCK-----

--- a/website/book/src/installation/configuration.md
+++ b/website/book/src/installation/configuration.md
@@ -484,6 +484,9 @@ extension API.
 (enum{validate_code,expand}, `validate_code`), `connect_timeout_ms` (int,
 `2000`), `request_timeout_ms` (int, `10000`), `oauth2_client` (string, unset —
 must name an entry under `[terminology.external.oauth2_clients]`),
+`client_cert_path` / `client_key_path` (paths, unset — the mutual-TLS client
+identity, see below), `ca_bundle_path` (path, unset — the trust anchors for
+this server, see below),
 `cache_ttl_secs` (int, `300` — TTL of the per-provider response cache; a
 repeated validate/expand/subsumes/lookup within the window is served locally
 instead of one HTTPS round trip per validated code; `0` disables),
@@ -546,9 +549,54 @@ client_secret_file = "/run/secrets/ts-client"
 scopes = ["system/*.read"]
 ```
 
-> [!NOTE]
-> Mutual TLS to a terminology server is not supported yet — a provider cannot
-> present a client certificate.
+### Mutual TLS to a terminology server
+
+A terminology server that authenticates its clients with certificates instead
+of (or in addition to) a bearer token is configured **per provider**, because a
+client certificate is issued by that server's PKI: a deployment enrolled with a
+national SNOMED CT service, a commercial value-set server and an in-house HAPI
+server holds three different certificates. Repeat the same paths in each
+provider table if one identity really does serve them all.
+
+Keys on `[terminology.external.providers.<name>]`:
+
+| Key | Meaning |
+|---|---|
+| `client_cert_path` | PEM file with the client certificate (optionally a chain) presented to this server. |
+| `client_key_path` | PEM file with that certificate's private key. |
+| `ca_bundle_path` | PEM bundle of the trust anchors this server's certificate is verified against. |
+
+```toml
+[terminology.external.providers.snomed]
+type = "fhir"
+url = "https://snowstorm.example.org/fhir"
+client_cert_path = "/run/secrets/ts-snomed-client.crt.pem"
+client_key_path = "/run/secrets/ts-snomed-client.key.pem"
+ca_bundle_path = "/run/secrets/ts-snomed-ca.pem"
+```
+
+`client_cert_path` and `client_key_path` are set together — one without the
+other is a startup error, never a connection that silently presents no
+certificate. Unreadable files, a certificate file with no certificate in it and
+a key file with no key in it are startup errors too, so a broken identity never
+waits until the first validated code to surface.
+
+`ca_bundle_path` **replaces** the default trust anchors for that provider, so a
+terminology server issued by a private PKI is pinned to that PKI instead of also
+accepting the whole public web PKI. Leave it unset to use the platform's default
+trust store.
+
+> [!IMPORTANT]
+> There is no option to disable certificate verification. Server-certificate and
+> hostname verification are always on for every provider; `ca_bundle_path`
+> changes *which* anchors are trusted, never *whether* the server is verified.
+
+The client identity applies to the connection to the terminology server itself.
+An OAuth2 token endpoint (`oauth2_client`) is a different host in a different
+trust domain and keeps the default TLS stack.
+
+Kubernetes deployments mount the PEM files with the chart's `config.files` map
+(see the Helm chart values), which materialises them under `/etc/ehrbase/`.
 
 ### Archetype value-set bindings at commit
 


### PR DESCRIPTION
Closes #683 — the last transport-security gap on the outbound terminology path (OAuth2 landed in PR #722).

## Shape: per-provider identity (the deferred design decision, decided + recorded)

Three optional keys on `[terminology.external.providers.<name>]` — `client_cert_path` / `client_key_path` / `ca_bundle_path` — NOT a shared outbound-TLS section:
1. A client certificate is a credential issued by the PEER's PKI, exactly like the per-provider OAuth2 credentials: three federated terminology services mean three trust domains with three subjects. Per-provider degenerates to shared by repeating paths; shared cannot express distinct identities at all.
2. Trust anchors are per peer for the same reason (`ca_bundle_path` REPLACES that provider's anchors — pinning a private-PKI server to its own CA).
3. Matches the tree's only outbound-TLS precedent (the ATNA ITI-19 syslog identity, scoped to one connection).

**No insecure escape hatch, structurally**: the `terminology::tls` module only ever supplies anchors + an identity to the reqwest builder — it never touches `danger_accept_invalid_certs` and never installs a custom verifier. Broken PEM / a missing half of the identity pair = BOOT error (`validate_terminology`), never a first-request surprise. No openEHR spec governs TS transport security — flagged our-own-design.

## Proof (real TLS acceptor requiring a client cert, in-test)

(a) `a_client_identity_completes_the_mutual_tls_handshake` — asserts the certificate the server ACTUALLY SAW (`peer_certificates()`), not just success · (b) `the_same_server_refuses_a_provider_without_the_identity` · (c) `a_custom_ca_bundle_trusts_a_private_server_that_default_trust_refuses` · (d) `broken_tls_material_fails_at_boot` — plus config validation + env-mapping tests. PEM fixtures are inline openssl-generated consts written to a per-test TempDir (the `system_log_tls_roundtrip` precedent; `.gitignore` blocks `*.pem`), provenance + 2126 expiry documented. Note: test (c) runs ~60–95 s on macOS (the OS trust evaluation hunts the unknown issuer synchronously — timeouts cannot cut it; documented, not weakened); Linux CI's webpki path rejects immediately.

## Gates (rebased onto current develop)

fmt clean · `clippy -p ehrbase -p ehrbase-server --all-targets` zero warnings in both crates · `nextest -p ehrbase` **700/700** · changelog-structure OK · Helm validate ALL CHECKS PASSED (goldens unchanged) · config template + book page updated in-PR.