### PR TITLE
chore(clippy): hoist the testkit pool-deadline const — the last develop clippy red

### DIFF
--- a/tools/testkit/src/lib.rs
+++ b/tools/testkit/src/lib.rs
@@ -221,6 +221,8 @@ pub async fn empty_db() -> Result<TestDb, TestkitError> {
 /// Create a uniquely named database (a clone of `template`, or empty) and
 /// pool it.
 async fn provision(server: &str, template: Option<&str>) -> Result<TestDb, TestkitError> {
+    // The clone pool's establishment deadline (see the retry loop below).
+    const POOL_DEADLINE: Duration = Duration::from_secs(15);
     let name = fresh_name();
     let mut admin = connect_ready(server).await?;
     if let Some(template) = template {
@@ -250,7 +252,6 @@ async fn provision(server: &str, template: Option<&str>) -> Result<TestDb, Testk
     // dropped before PostgreSQL answered the negotiation). That is server
     // load, not a test defect: retry the ESTABLISHMENT briefly and loudly
     // surface the last error at the deadline. Never a per-test retry.
-    const POOL_DEADLINE: Duration = Duration::from_secs(15);
     let start = SystemTime::now();
     let pool = loop {
         match db::connect(&config).await {


### PR DESCRIPTION
PRs #723 (the #620 testkit fix) and #724 (the clippy sweep) crossed in flight: #723 introduced `const POOL_DEADLINE` after statements in `provision()`, and #724's sweep ran before it merged — so develop's `clippy` job (`--all-features -D warnings`) stayed red on exactly one `items_after_statements` hit. Hoisted to the function top; no behaviour change.

Gates: `cargo clippy -p testkit --all-targets` zero warnings (cold rebuild — the shared target was also cleaned this session per the >30 GB rule: 148 GB → fresh) · `cargo fmt -p testkit --check` clean.