### PR TITLE
release: v3.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+## [3.12.0] - 2026-07-29
+
 ### Changed
 
 - **The conformance verdict model no longer has excused capability states.**
@@ -3470,7 +3472,8 @@ but has not yet run in production.
   seccomp, default-deny NetworkPolicy) and golden-render validation.
 
 
-[unreleased]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.11.0...HEAD
+[unreleased]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.12.0...HEAD
+[3.12.0]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.11.0...v3.12.0
 [3.11.0]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.10.0...v3.11.0
 [3.10.0]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.9.0...v3.10.0
 [3.9.0]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.8.0...v3.9.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,5 +33,5 @@ keywords:
   - ITS-REST
   - Rust
   - PostgreSQL
-version: 3.11.0
-date-released: "2026-07-26"
+version: 3.12.0
+date-released: "2026-07-29"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "cnf-runner"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "assert_fs",
  "base64 0.22.1",
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "assert_fs",
  "async-trait",
@@ -2371,7 +2371,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase-admin-ui"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2411,7 +2411,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase-rest"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -2463,7 +2463,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase-server"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -5238,7 +5238,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-codegen"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "roxmltree",
  "serde_json",
@@ -8291,7 +8291,7 @@ dependencies = [
 
 [[package]]
 name = "testkit"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "ehrbase",
  "sqlx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "3"                      # resolver v3 (edition 2024)
 members = ["crates/*", "app/*", "tools/*"]
 
 [workspace.package]
-version = "3.11.0"
+version = "3.12.0"
 edition = "2024"
 rust-version = "1.96"
 license = "Apache-2.0"

--- a/deploy/helm/ehrbase-rs/Chart.yaml
+++ b/deploy/helm/ehrbase-rs/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 # Chart versioning is independent of the application version.
 version: 3.2.0
 # The default container image tag (informational; overridable via image.tag).
-appVersion: "3.11.0"
+appVersion: "3.12.0"
 
 # PDB (policy/v1, GA 1.21), HPA (autoscaling/v2, GA 1.23), and the
 # seccompProfile pod field (GA 1.27) all resolve cleanly at 1.25+.

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.11.0"
+    app.kubernetes.io/version: "3.12.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -58,7 +58,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.11.0"
+    app.kubernetes.io/version: "3.12.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -77,7 +77,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.11.0"
+    app.kubernetes.io/version: "3.12.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
   annotations:
@@ -96,7 +96,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.11.0"
+    app.kubernetes.io/version: "3.12.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 type: Opaque
@@ -120,7 +120,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.11.0"
+    app.kubernetes.io/version: "3.12.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 type: Opaque
@@ -139,7 +139,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.11.0"
+    app.kubernetes.io/version: "3.12.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 data:
@@ -294,7 +294,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.11.0"
+    app.kubernetes.io/version: "3.12.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -321,7 +321,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.11.0"
+    app.kubernetes.io/version: "3.12.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -333,7 +333,7 @@ spec:
     metadata:
       annotations:
         # Roll pods when the rendered ehrbase.toml changes.
-        checksum/config: a1a1b9b4d09b00822f9d80d8d0ad97878d7b3cda0970e09ef01781d8fe292690
+        checksum/config: daf13aae4b46a583c18c8755094886a83c0ebc1e8b7d6e02d49c0130903c0cec
         prometheus.io/scrape: "true"
         prometheus.io/port: "9100"
         prometheus.io/path: "/management/prometheus"
@@ -354,7 +354,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ehrbase
-          image: "ghcr.io/rubentalstra/ehrbase-rs:3.11.0"
+          image: "ghcr.io/rubentalstra/ehrbase-rs:3.12.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -476,7 +476,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.11.0"
+    app.kubernetes.io/version: "3.12.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -509,7 +509,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.11.0"
+    app.kubernetes.io/version: "3.12.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.11.0"
+    app.kubernetes.io/version: "3.12.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -36,7 +36,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.11.0"
+    app.kubernetes.io/version: "3.12.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -55,7 +55,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.11.0"
+    app.kubernetes.io/version: "3.12.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 automountServiceAccountToken: false
@@ -69,7 +69,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.11.0"
+    app.kubernetes.io/version: "3.12.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 data:
@@ -166,7 +166,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.11.0"
+    app.kubernetes.io/version: "3.12.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -189,7 +189,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.11.0"
+    app.kubernetes.io/version: "3.12.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -202,7 +202,7 @@ spec:
     metadata:
       annotations:
         # Roll pods when the rendered ehrbase.toml changes.
-        checksum/config: ae75ce422a6fdb1c975e2906dcd16b56b1a46d0cc61bf776ecbae0faf9135528
+        checksum/config: b2c0e173c8e22aea52309f447a2080ec557b733832d7c815d80c291230f8fd15
       labels:
         app.kubernetes.io/name: ehrbase-rs
         app.kubernetes.io/instance: ehrbase-rs
@@ -220,7 +220,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ehrbase
-          image: "ghcr.io/rubentalstra/ehrbase-rs:3.11.0"
+          image: "ghcr.io/rubentalstra/ehrbase-rs:3.12.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
The v3.12.0 cut — the milestone reached zero open issues tonight (the cut trigger, `.claude/rules/changelog.md`).

The release's own record: the closed milestone (the whole CNF certification-completeness program #610 + children, the terminology stack #677/#683, the excuse-free verdict model #626, the negative-branch closure #671, ADL 1.4 #679, XML/7z archives #670, testkit/CI hardening #620/#335, mdbook math #672) and the committed conformance artifacts: **808/808 driven functional cases green, all 43 capabilities passed, CORE / STANDARD / OPTIONS + SEC-BASIC pass, class POC EARNED** (2.04/s × 3600 s, zero errors, worst p99 268.8 ms).

Mechanical contents: CHANGELOG section `[3.12.0] - 2026-07-29` + fresh `[Unreleased]` + link refs; workspace `version` 3.11.0 → 3.12.0 (+ `Cargo.lock`); Helm `appVersion` + regenerated goldens (`validate.sh --update`, ALL CHECKS PASSED); `CITATION.cff` version + date-released (the `citation-guard` match).

After merge: tag `v3.12.0` on the merge commit (the release workflow publishes from the matching changelog section, prerelease until production sign-off), close the milestone, next milestone (v3.13.0 — the BASE program) already exists.