### PR TITLE
fix(codegen): builtins MappedClass citations name base_types.builtins

### DIFF
--- a/tools/openehr-codegen/src/plan/overrides.rs
+++ b/tools/openehr-codegen/src/plan/overrides.rs
@@ -215,27 +215,27 @@ pub(crate) const MAPPED_CLASSES: &[MappedClass] = &[
     // ── service interfaces (no data) ──
     MappedClass {
         name: "Env",
-        citation: "BASE foundation_types (Env service interface)",
+        citation: "BASE base_types.builtins (Env service interface; Base Types §Built-in types)",
         reason: "Service interface, no data.",
     },
     MappedClass {
         name: "Locale",
-        citation: "BASE foundation_types (Locale service interface)",
+        citation: "BASE base_types.builtins (Locale service interface; Base Types §Built-in types)",
         reason: "Service interface, no data.",
     },
     MappedClass {
         name: "Math",
-        citation: "BASE foundation_types (Math service interface)",
+        citation: "BASE base_types.builtins (Math service interface; Base Types §Built-in types)",
         reason: "Service interface, no data.",
     },
     MappedClass {
         name: "Quantity_converter",
-        citation: "BASE foundation_types (Quantity_converter service interface)",
+        citation: "BASE base_types.builtins (Quantity_converter service interface; Base Types §Built-in types)",
         reason: "Service interface, no data.",
     },
     MappedClass {
         name: "Statistical_evaluator",
-        citation: "BASE foundation_types (Statistical_evaluator service interface)",
+        citation: "BASE base_types.builtins (Statistical_evaluator service interface; Base Types §Built-in types)",
         reason: "Service interface, no data.",
     },
     // ── constant-holder classes (no data; become assoc consts in *_impl.rs) ──


### PR DESCRIPTION
Closes #736.

Found by the #690 audit (BASE 1.3.0 `architecture_overview/master05-package_structure.adoc` §Base Component). The five builtins service-interface exclusions in `tools/openehr-codegen/src/plan/overrides.rs` cited `BASE foundation_types`; the vendored BASE BMM (1.2.0 and 1.3.0 alike) places `Env`, `Locale`, `Math`, `Quantity_converter`, `Statistical_evaluator` in `org.openehr.base.base_types.builtins`, documented in the BASE Base Types §Built-in types chapter. Citations corrected; the adjudication itself (service interface, no data — mapped out of emission) is unchanged.

Tooling-internal only: `is_mapped_class` matches by name, so no generated output changes (drift check unaffected). `no-changelog`: no user-visible behaviour.

Gates: `cargo fmt` + `cargo clippy -p openehr-codegen --all-targets` clean, `cargo nextest run -p openehr-codegen` 29/29 green.