### PR TITLE
refactor(aql): archetype_predicate pending AOM2 lineage work is a TODO

### DIFF
--- a/app/ehrbase/src/aql/sql/expr.rs
+++ b/app/ehrbase/src/aql/sql/expr.rs
@@ -202,12 +202,15 @@ pub(super) fn aql_like_to_sql(pattern: &str) -> String {
 // subsumption + interface-reference semantics instead, because a query naming a
 // parent archetype MUST retrieve data created with its specialisation children
 // (master10 §Design-time Relationships) — plain string equality never would.
-// AOM2-era identifiers carry no lineage semantics in the `-` separator (AM
-// master03 §"Legacy ADL 1.4 Semantics"), so full template-derived lineage
-// matching (specialisation parents obtainable only from the operational template
-// per master07 §Supporting Archetype-based Querying) is deferred to the ADL2
-// phase; the `-`-prefix rule here is exact for the ADL 1.4-form ids this store
-// holds (major-only `.vN`, lineage encoded directly in the concept).
+// The `-`-prefix rule here is exact for the ADL 1.4-form ids this store holds
+// (major-only `.vN`, lineage encoded directly in the concept).
+//
+// TODO: template-derived lineage matching for AOM2-era identifiers — those
+// carry no lineage semantics in the `-` separator (AM master03 §"Legacy ADL 1.4
+// Semantics"), so their specialisation parents are obtainable only from the
+// operational template (AM master07 §Supporting Archetype-based Querying);
+// completing this requires resolving the queried id's lineage through the
+// stored ADL2/OPT2 template family instead of the concept-prefix rule.
 pub(super) fn archetype_predicate(node: &str, value: &str) -> Expr {
     if let Ok(id) = value.parse::<ArchetypeId>()
         && let Ok(major) = id.major_version().parse::<i32>()


### PR DESCRIPTION
Closes #738.

Found by the #695 audit (BASE arch-overview ch.10). The `archetype_predicate` NOTE in `app/ehrbase/src/aql/sql/expr.rs` carried a prose deferral ("deferred to the ADL2 phase") — banned by the standing comment-form hard rule; pending work is `// TODO:` only. The settled QUERY-vs-BASE/AM adjudication stays a NOTE with its citations; the pending AOM2-era template-derived lineage matching is now a `// TODO:` stating what is missing and what completes it. Comment-only change.

Gates: `cargo fmt` + `cargo clippy -p ehrbase --all-targets` clean.