### PR TITLE
feat(base-time): Iso8601_* computational functions — definite + nominal arithmetic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
+- **The ISO 8601 date/time/duration types implement their computational
+  functions** (BASE `foundation_types/master06-time_types.adoc`
+  §Computational Functions + the four `Iso8601_*` class definitions): the
+  DEFINITE `add`/`subtract`/`diff` on dates, times and date/times — a
+  duration reduced to exact seconds with the `Time_definitions`
+  `Average_days_in_year`/`Average_days_in_month` lengths — and the NOMINAL
+  `add_nominal`/`subtract_nominal`, which advance the calendar to the same
+  day-of-month and clamp it down where the target month is shorter (29 Feb
+  `++ P1Y` → 28 Feb, 31 Jan `++ P1M` → 28/29 Feb). Durations gain
+  `add`/`subtract`/`multiply`/`divide`/`negative`. Also added across the four
+  types: `as_string` (the value in extended format), `is_extended`,
+  `is_decimal_sign_comma` and `has_fractional_second`. Arithmetic on a
+  partial value, or a result outside the representable 0000–9999 year range,
+  is reported as no result rather than an invented one.
+
 - **openEHR path expressions support general comparison predicates** (BASE
   architecture overview §Paths and Locators, "Other Predicates"): path
   predicates of the form `[at0007 and time >= '2005-06-24T09:30:00']` or

--- a/crates/openehr-base/src/foundation_types/time/iso8601_date_impl.rs
+++ b/crates/openehr-base/src/foundation_types/time/iso8601_date_impl.rs
@@ -1,12 +1,31 @@
 //! Hand-written `Iso8601_date` spec behaviour: the accessor functions
-//! (`is_partial`, `month_unknown`, `day_unknown`, `year`/`month`/`day`) and a
+//! (`is_partial`, `is_extended`, `month_unknown`, `day_unknown`,
+//! `year`/`month`/`day`, `as_string`), the computational functions (definite
+//! `add`/`subtract`/`diff` and nominal `add_nominal`/`subtract_nominal`), and a
 //! `PartialOrd` implementing range semantics over partial dates.
 //!
 //! Spec sources (vendored):
 //! - `BASE/docs/UML/classes/org.openehr.base.foundation_types.iso8601_date.adoc`
-//!   (§Functions: the accessors; §Invariants).
+//!   (§Functions: the accessors, `as_string`, the definite `add`/`subtract`/
+//!   `diff` and the nominal `add_nominal`/`subtract_nominal` with their
+//!   day-clamping rules; §Invariants).
 //! - `BASE/docs/foundation_types/master06-time_types.adoc` (§Primitive Time
-//!   Types: the accepted date forms; week dates excluded).
+//!   Types: the accepted date forms; week dates excluded; §Computational
+//!   Functions: the definite/nominal split and the average-length constants the
+//!   definite forms use).
+//!
+//! NOTE: arithmetic needs every component of the value, and the openEHR spec
+//! says nothing about computing on a PARTIAL date (`2020`, `2020-06`) — the
+//! `add`/`diff` signatures simply take complete values. A partial (or
+//! unparseable) operand therefore yields `None`, the same undecidable answer
+//! this module's comparison gives, rather than an invented completion.
+//!
+//! NOTE: a definite result lands at an arbitrary instant (`P1M` is 30.42 days),
+//! but an `Iso8601_date` carries no time of day. We return the calendar date
+//! CONTAINING the resulting instant (truncation towards the start of the day, in
+//! both directions), which is the only reading that keeps `add` and `subtract`
+//! mutually consistent. No openEHR spec governs the rounding — our own
+//! design/extension.
 //!
 //! NOTE: the openEHR spec gives NO date comparison algorithm (`Ordered` is
 //! abstract, no `magnitude`), so the ordering here is our own design/extension:
@@ -21,7 +40,11 @@
 use std::cmp::Ordering;
 
 use super::iso8601_date::Iso8601Date;
-use super::iso8601_parse::{ParsedDate, parse_date};
+use super::iso8601_duration::Iso8601Duration;
+use super::iso8601_parse::{
+    EXACT_SECONDS_IN_DAY, ExactSeconds, ParsedDate, as_extended_date, civil_from_days,
+    days_from_civil, parse_date, render_date_extended, render_duration, shift_months,
+};
 
 impl Iso8601Date {
     /// Parsed components, or `None` when `value` is not a valid ISO 8601 date.
@@ -71,6 +94,125 @@ impl Iso8601Date {
     pub fn is_partial(&self) -> bool {
         self.parsed().is_none_or(|p| p.day.is_none())
     }
+
+    /// `Iso8601_date.is_extended`: true when the value uses `'-'` separators
+    /// (and, for the separator-less `YYYY` form, always — see the `is_extended`
+    /// NOTE in `iso8601_parse.rs`). A value that does not parse is not extended.
+    #[must_use]
+    pub fn is_extended(&self) -> bool {
+        self.parsed().is_some_and(|p| p.extended)
+    }
+
+    /// `Iso8601_date.as_string`: "Return string value in extended format" — a
+    /// compact value is re-spelled with `'-'` separators, an already-extended
+    /// one is returned unchanged.
+    ///
+    /// NOTE: the spec does not say what a value that is not a valid ISO 8601
+    /// date returns. It is returned verbatim, since `Iso8601_type.value` is the
+    /// only representation there is — our own design/extension.
+    #[must_use]
+    pub fn as_string(&self) -> String {
+        as_extended_date(&self.value).unwrap_or_else(|| self.value.clone())
+    }
+
+    /// `Iso8601_date.add` (alias `'+'`): DEFINITE addition of a duration —
+    /// `a_diff` is reduced to an exact number of seconds with the
+    /// `Time_definitions` average year/month lengths
+    /// (`master06` §Computational Functions) and the result is the calendar date
+    /// containing the shifted instant.
+    ///
+    /// `None` when either value does not parse, when this date is partial, or
+    /// when the result leaves the representable `0000`–`9999` year range.
+    #[must_use]
+    pub fn add(&self, a_diff: &Iso8601Duration) -> Option<Self> {
+        self.definite_shift(a_diff, false)
+    }
+
+    /// `Iso8601_date.subtract` (alias `'-'`): DEFINITE subtraction of a
+    /// duration. See [`Iso8601Date::add`].
+    ///
+    /// `None` under the same conditions as [`Iso8601Date::add`].
+    #[must_use]
+    pub fn subtract(&self, a_diff: &Iso8601Duration) -> Option<Self> {
+        self.definite_shift(a_diff, true)
+    }
+
+    /// `Iso8601_date.diff` (alias `'-'`): the difference `self - a_date` as an
+    /// `Iso8601_duration` of whole days — negative (the openEHR
+    /// negative-duration deviation, `master06` §Primitive Time Types) when
+    /// `a_date` is the later date.
+    ///
+    /// `None` when either value does not parse or is partial.
+    #[must_use]
+    pub fn diff(&self, a_date: &Self) -> Option<Iso8601Duration> {
+        let days = self.day_index()?.checked_sub(a_date.day_index()?)?;
+        let seconds = days.checked_mul(EXACT_SECONDS_IN_DAY)?;
+        Some(Iso8601Duration {
+            value: render_duration(ExactSeconds::new(seconds, 0.0)?)?,
+        })
+    }
+
+    /// `Iso8601_date.add_nominal` (alias `'++'`): NOMINAL addition — years and
+    /// months advance the calendar to the same day-of-month, clamped down when
+    /// the target month is shorter (29 Feb `++ P1Y` → 28 Feb next year; 31 Jan
+    /// `++ P1M` → 28 Feb, or 29 Feb in a leap year), and the remaining
+    /// components (weeks, days and any time part) apply as an exact calendar
+    /// shift.
+    ///
+    /// `None` when either value does not parse, when this date is partial, or
+    /// when the result leaves the representable `0000`–`9999` year range.
+    #[must_use]
+    pub fn add_nominal(&self, a_diff: &Iso8601Duration) -> Option<Self> {
+        self.nominal_shift(a_diff, false)
+    }
+
+    /// `Iso8601_date.subtract_nominal` (alias `'--'`): NOMINAL subtraction, with
+    /// the day-clamping semantics of [`Iso8601Date::add_nominal`].
+    ///
+    /// `None` under the same conditions as [`Iso8601Date::add_nominal`].
+    #[must_use]
+    pub fn subtract_nominal(&self, a_diff: &Iso8601Duration) -> Option<Self> {
+        self.nominal_shift(a_diff, true)
+    }
+
+    /// The date's day count since 1970-01-01, or `None` when the value does not
+    /// parse or is partial (arithmetic needs a complete value).
+    fn day_index(&self) -> Option<i64> {
+        let p = self.parsed()?;
+        Some(days_from_civil(p.year, p.month?, p.day?))
+    }
+
+    /// The date reached by shifting this one's midnight instant by `shift`
+    /// seconds, truncated to the containing calendar day. A fractional part is
+    /// irrelevant to that truncation: `shift.frac` is in `[0.0, 1.0)` and the
+    /// whole-second total is an integer, so adding it can never cross a day
+    /// boundary.
+    fn shifted(&self, shift: ExactSeconds) -> Option<Self> {
+        let base = self.day_index()?.checked_mul(EXACT_SECONDS_IN_DAY)?;
+        let total = base.checked_add(shift.whole)?;
+        let (year, month, day) = civil_from_days(total.div_euclid(EXACT_SECONDS_IN_DAY))?;
+        Some(Self {
+            value: render_date_extended(year, Some(month), Some(day)),
+        })
+    }
+
+    /// Shared body of the definite `add`/`subtract`.
+    fn definite_shift(&self, a_diff: &Iso8601Duration, subtract: bool) -> Option<Self> {
+        self.shifted(a_diff.parsed()?.to_definite_shift(subtract)?)
+    }
+
+    /// Shared body of the nominal `add_nominal`/`subtract_nominal`: the
+    /// year/month part shifts the calendar with day-clamping, then the
+    /// sub-month remainder applies as an exact shift.
+    fn nominal_shift(&self, a_diff: &Iso8601Duration, subtract: bool) -> Option<Self> {
+        let (months, remainder) = a_diff.parsed()?.to_nominal_parts(subtract)?;
+        let p = self.parsed()?;
+        let (year, month, day) = shift_months(p.year, p.month?, p.day?, months)?;
+        Self {
+            value: render_date_extended(year, Some(month), Some(day)),
+        }
+        .shifted(remainder)
+    }
 }
 
 /// Range-semantics comparison of two parsed dates on their shared prefix. Never
@@ -117,6 +259,23 @@ mod tests {
         Iso8601Date {
             value: v.to_owned(),
         }
+    }
+
+    fn dur(v: &str) -> Iso8601Duration {
+        Iso8601Duration {
+            value: v.to_owned(),
+        }
+    }
+
+    /// The value of a computed date, or `"None"` — keeps the arithmetic
+    /// assertions below readable as string comparisons.
+    fn value(d: Option<Iso8601Date>) -> String {
+        d.map_or_else(|| "None".to_owned(), |d| d.value)
+    }
+
+    /// The value of a computed duration, or `"None"`.
+    fn duration_value(d: Option<Iso8601Duration>) -> String {
+        d.map_or_else(|| "None".to_owned(), |d| d.value)
     }
 
     // ── full-vs-full ordering ────────────────────────────────────────────────
@@ -260,5 +419,200 @@ mod tests {
         assert!(!year_month.month_unknown());
         assert!(year_month.day_unknown());
         assert!(year_month.is_partial());
+    }
+
+    // ── is_extended / as_string ──────────────────────────────────────────────
+
+    #[test]
+    fn extended_and_compact_forms_are_distinguished() {
+        assert!(date("2020-06-15").is_extended());
+        assert!(date("2020-06").is_extended());
+        assert!(date("2020").is_extended()); // no separator position at all
+        assert!(!date("20200615").is_extended());
+        assert!(!date("202006").is_extended());
+        assert!(!date("not-a-date").is_extended());
+    }
+
+    #[test]
+    fn as_string_returns_the_extended_form() {
+        assert_eq!(date("20200615").as_string(), "2020-06-15");
+        assert_eq!(date("202006").as_string(), "2020-06");
+        assert_eq!(date("2020-06-15").as_string(), "2020-06-15");
+        assert_eq!(date("2020").as_string(), "2020");
+        // A value that is not a valid date has no extended form: verbatim.
+        assert_eq!(date("2020-13-01").as_string(), "2020-13-01");
+    }
+
+    // ── nominal arithmetic (the class doc's own examples) ─────────────────────
+
+    #[test]
+    fn nominal_year_on_leap_day_clamps_to_28_february() {
+        // iso8601_date.adoc §Functions add_nominal: "with the exception of the
+        // date 29 February in a leap year, to which the addition of a nominal
+        // year will result in 28 February of the following year".
+        assert_eq!(
+            value(date("2020-02-29").add_nominal(&dur("P1Y"))),
+            "2021-02-28"
+        );
+        // A non-leap-day date keeps its day-of-month.
+        assert_eq!(
+            value(date("2020-06-15").add_nominal(&dur("P1Y"))),
+            "2021-06-15"
+        );
+        // ... and the same clamp applies downwards.
+        assert_eq!(
+            value(date("2020-02-29").subtract_nominal(&dur("P1Y"))),
+            "2019-02-28"
+        );
+    }
+
+    #[test]
+    fn nominal_month_clamps_into_a_shorter_month() {
+        // add_nominal: "in the case of adding a month to the date 31 Jan, the
+        // result will be 28 Feb in a non-leap year (i.e. three less) and 29 Feb
+        // in a leap year (i.e. two less)".
+        assert_eq!(
+            value(date("2020-01-31").add_nominal(&dur("P1M"))),
+            "2020-02-29"
+        );
+        assert_eq!(
+            value(date("2021-01-31").add_nominal(&dur("P1M"))),
+            "2021-02-28"
+        );
+        // "one or two days less where the following month is shorter" — 31 May
+        // to 30 June.
+        assert_eq!(
+            value(date("2020-05-31").add_nominal(&dur("P1M"))),
+            "2020-06-30"
+        );
+        // "the same day in the following month, if it exists".
+        assert_eq!(
+            value(date("2020-01-15").add_nominal(&dur("P1M"))),
+            "2020-02-15"
+        );
+        assert_eq!(
+            value(date("2020-03-31").subtract_nominal(&dur("P1M"))),
+            "2020-02-29"
+        );
+    }
+
+    #[test]
+    fn nominal_year_and_month_combine_before_the_day_shift() {
+        // P1Y1M from 31 Dec: 13 months to 31 Jan (exists), then no day part.
+        assert_eq!(
+            value(date("2019-12-31").add_nominal(&dur("P1Y1M"))),
+            "2021-01-31"
+        );
+        // Weeks and days apply as exact calendar shifts after the clamp.
+        assert_eq!(
+            value(date("2020-01-31").add_nominal(&dur("P1M1D"))),
+            "2020-03-01"
+        );
+        assert_eq!(
+            value(date("2020-06-15").add_nominal(&dur("P2W"))),
+            "2020-06-29"
+        );
+    }
+
+    #[test]
+    fn nominal_arithmetic_honours_a_negative_duration() {
+        // The openEHR negative-duration deviation: '-P1M' added is a month back.
+        assert_eq!(
+            value(date("2020-03-31").add_nominal(&dur("-P1M"))),
+            "2020-02-29"
+        );
+        assert_eq!(
+            value(date("2020-02-29").subtract_nominal(&dur("-P1Y"))),
+            "2021-02-28"
+        );
+    }
+
+    // ── definite arithmetic (average year/month lengths) ─────────────────────
+
+    #[test]
+    fn definite_arithmetic_uses_the_average_lengths() {
+        // Average_days_in_month = 30.42, so P1M is 30 days and 10:04:48 — the
+        // resulting instant still falls on 14 February.
+        assert_eq!(value(date("2020-01-15").add(&dur("P1M"))), "2020-02-14");
+        // Average_days_in_year = 365.24.
+        assert_eq!(value(date("2019-03-01").add(&dur("P1Y"))), "2020-02-29");
+        // Definite day/week/time components are exact.
+        assert_eq!(value(date("2020-02-28").add(&dur("P1D"))), "2020-02-29");
+        assert_eq!(
+            value(date("2020-03-01").subtract(&dur("P1D"))),
+            "2020-02-29"
+        );
+        assert_eq!(value(date("2020-06-15").add(&dur("PT23H"))), "2020-06-15");
+        assert_eq!(value(date("2020-06-15").add(&dur("PT24H"))), "2020-06-16");
+        assert_eq!(
+            value(date("2020-06-15").subtract(&dur("PT1S"))),
+            "2020-06-14"
+        );
+    }
+
+    #[test]
+    fn definite_and_nominal_diverge_for_the_same_operands() {
+        // §Computational Functions: the definite form treats P1M/P1Y as the
+        // average length, the nominal form as the calendar step.
+        assert_eq!(value(date("2020-01-15").add(&dur("P1M"))), "2020-02-14");
+        assert_eq!(
+            value(date("2020-01-15").add_nominal(&dur("P1M"))),
+            "2020-02-15"
+        );
+        assert_eq!(value(date("2019-03-01").add(&dur("P1Y"))), "2020-02-29");
+        assert_eq!(
+            value(date("2019-03-01").add_nominal(&dur("P1Y"))),
+            "2020-03-01"
+        );
+    }
+
+    // ── diff ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn diff_reports_whole_days_in_both_directions() {
+        assert_eq!(
+            duration_value(date("2020-06-15").diff(&date("2020-06-01"))),
+            "P14D"
+        );
+        // The earlier operand first ⇒ the negative-duration deviation.
+        assert_eq!(
+            duration_value(date("2020-06-01").diff(&date("2020-06-15"))),
+            "-P14D"
+        );
+        assert_eq!(
+            duration_value(date("2020-06-15").diff(&date("2020-06-15"))),
+            "PT0S"
+        );
+        // Across a leap February.
+        assert_eq!(
+            duration_value(date("2020-03-01").diff(&date("2020-02-01"))),
+            "P29D"
+        );
+        assert_eq!(
+            duration_value(date("2021-03-01").diff(&date("2021-02-01"))),
+            "P28D"
+        );
+    }
+
+    // ── partial / unrepresentable operands ───────────────────────────────────
+
+    #[test]
+    fn partial_and_malformed_values_have_no_arithmetic() {
+        assert!(date("2020-06").add(&dur("P1D")).is_none());
+        assert!(date("2020").add_nominal(&dur("P1M")).is_none());
+        assert!(date("2020-06").subtract(&dur("P1D")).is_none());
+        assert!(date("2020-06").diff(&date("2020-06-15")).is_none());
+        assert!(date("2020-06-15").diff(&date("2020")).is_none());
+        assert!(date("not-a-date").add(&dur("P1D")).is_none());
+        // A malformed duration is equally uncomputable.
+        assert!(date("2020-06-15").add(&dur("1D")).is_none());
+    }
+
+    #[test]
+    fn results_outside_the_representable_years_are_none() {
+        // valid_year (y >= 0) + master06's 4-digit-year restriction.
+        assert!(date("9999-12-31").add(&dur("P1D")).is_none());
+        assert!(date("0000-01-01").subtract(&dur("P1D")).is_none());
+        assert!(date("9999-12-31").add_nominal(&dur("P1M")).is_none());
     }
 }

--- a/crates/openehr-base/src/foundation_types/time/iso8601_date_time_impl.rs
+++ b/crates/openehr-base/src/foundation_types/time/iso8601_date_time_impl.rs
@@ -1,13 +1,37 @@
-//! Hand-written `Iso8601_date_time` spec behaviour: the accessor functions and
-//! a `PartialOrd` implementing range semantics over partial date/times with
-//! timezone normalisation (which may roll the calendar date).
+//! Hand-written `Iso8601_date_time` spec behaviour: the accessor functions, the
+//! computational functions (definite `add`/`subtract`/`diff` and nominal
+//! `add_nominal`/`subtract_nominal`) and a `PartialOrd` implementing range
+//! semantics over partial date/times with timezone normalisation (which may roll
+//! the calendar date).
 //!
 //! Spec sources (vendored):
 //! - `BASE/docs/UML/classes/org.openehr.base.foundation_types.iso8601_date_time.adoc`
-//!   (§Functions: the accessors; §Invariants).
+//!   (§Functions: the accessors, `as_string`, `add`/`subtract`/`diff`,
+//!   `add_nominal`/`subtract_nominal`; §Invariants).
+//! - `BASE/docs/UML/classes/org.openehr.base.foundation_types.iso8601_date.adoc`
+//!   (§Functions `add_nominal`: the day-clamping rules this class refers to).
 //! - `BASE/docs/foundation_types/master06-time_types.adoc` (§Primitive Time
 //!   Types: partial date/times may omit any part down to the month;
-//!   `24:00:00` disallowed).
+//!   `24:00:00` disallowed; §Computational Functions: the definite/nominal
+//!   split).
+//!
+//! NOTE: arithmetic needs every component, and the openEHR spec says nothing
+//! about computing on a PARTIAL date/time — a partial (or unparseable) operand
+//! yields `None`, the same undecidable answer this module's comparison gives.
+//!
+//! NOTE: `Iso8601_date_time.add_nominal`/`subtract_nominal` are declared in the
+//! class table as returning `Iso8601_date`, while `add`/`subtract` on the same
+//! class return `Iso8601_date_time`. Taken literally, a nominal addition would
+//! silently discard the time of day it is documented to preserve
+//! (§Computational Functions: "the nominal addition results in the same time on
+//! the next or previous day"). We read the declaration as a copy-paste defect
+//! from `Iso8601_date` and return `Iso8601_date_time`.
+//!
+//! NOTE: definite and nominal arithmetic both operate on the LOCAL reading and
+//! carry the timezone offset through unchanged (its spelling canonicalised to
+//! the extended form, `Z` for UTC): a uniform offset is invariant under a shift
+//! of the instant, and openEHR has no zone-rule database with which to
+//! re-derive one. No openEHR spec governs this — our own design/extension.
 //!
 //! NOTE: the ordering algorithm is our own design/extension (the openEHR spec
 //! gives none — see `iso8601_parse.rs`). A partial date/time denotes the
@@ -21,8 +45,12 @@
 use std::cmp::Ordering;
 
 use super::iso8601_date_time::Iso8601DateTime;
+use super::iso8601_duration::Iso8601Duration;
 use super::iso8601_parse::{
-    ParsedDateTime, date_time_completion_range, parse_date_time, range_before,
+    EXACT_SECONDS_IN_DAY, EXACT_SECONDS_IN_HOUR, EXACT_SECONDS_IN_MINUTE, ExactSeconds,
+    ParsedDateTime, ParsedTime, as_extended_date_time, civil_from_days, date_time_completion_range,
+    days_from_civil, hms_from_seconds_of_day, parse_date_time, range_before, render_date_extended,
+    render_duration, render_time_extended, shift_months,
 };
 
 impl Iso8601DateTime {
@@ -122,6 +150,171 @@ impl Iso8601DateTime {
         self.parsed()
             .is_none_or(|p| p.time.and_then(|t| t.second).is_none())
     }
+
+    /// `Iso8601_date_time.is_extended`: true when the value uses `'-'` and `':'`
+    /// separators throughout (see the `is_extended` NOTE in
+    /// `iso8601_parse.rs` for the forms that have no separator position). A value
+    /// that does not parse is not extended.
+    #[must_use]
+    pub fn is_extended(&self) -> bool {
+        self.parsed()
+            .is_some_and(|p| p.date.extended && p.time.is_none_or(|t| t.extended))
+    }
+
+    /// `Iso8601_date_time.is_decimal_sign_comma`: true when the fractional second
+    /// is written with `','` rather than `'.'`. False when there is no
+    /// fractional part or the value does not parse.
+    #[must_use]
+    pub fn is_decimal_sign_comma(&self) -> bool {
+        self.parsed()
+            .is_some_and(|p| p.time.is_some_and(|t| t.decimal_sign_comma))
+    }
+
+    /// `Iso8601_date_time.has_fractional_second`: true when the
+    /// fractional-second part is significant, i.e. the value writes one — "even
+    /// if = 0.0". False when the value does not parse.
+    #[must_use]
+    pub fn has_fractional_second(&self) -> bool {
+        self.parsed()
+            .is_some_and(|p| p.time.is_some_and(|t| t.fractional_second.is_some()))
+    }
+
+    /// `Iso8601_date_time.as_string`: "Return the string value in extended
+    /// format" — a compact value is re-spelled with `'-'`/`':'` separators (its
+    /// fractional precision, decimal sign and partial precision all preserved),
+    /// an already-extended one is returned unchanged.
+    ///
+    /// NOTE: as for `Iso8601_date.as_string`, a value that is not a valid
+    /// ISO 8601 date/time is returned verbatim — our own design/extension.
+    #[must_use]
+    pub fn as_string(&self) -> String {
+        as_extended_date_time(&self.value).unwrap_or_else(|| self.value.clone())
+    }
+
+    /// `Iso8601_date_time.add` (alias `'+'`): DEFINITE addition of a duration —
+    /// `a_diff` is reduced to an exact number of seconds with the
+    /// `Time_definitions` average year/month lengths
+    /// (`master06` §Computational Functions) and added to the local reading.
+    ///
+    /// `None` when either value does not parse, when this date/time is partial,
+    /// or when the result leaves the representable `0000`–`9999` year range.
+    #[must_use]
+    pub fn add(&self, a_diff: &Iso8601Duration) -> Option<Self> {
+        self.shifted(a_diff.parsed()?.to_definite_shift(false)?)
+    }
+
+    /// `Iso8601_date_time.subtract` (alias `'-'`): DEFINITE subtraction of a
+    /// duration. See [`Iso8601DateTime::add`].
+    ///
+    /// `None` under the same conditions as [`Iso8601DateTime::add`].
+    #[must_use]
+    pub fn subtract(&self, a_diff: &Iso8601Duration) -> Option<Self> {
+        self.shifted(a_diff.parsed()?.to_definite_shift(true)?)
+    }
+
+    /// `Iso8601_date_time.diff` (alias `'-'`): the difference
+    /// `self - a_date_time` as an `Iso8601_duration` — negative (the openEHR
+    /// negative-duration deviation) when `a_date_time` is the later instant. Two
+    /// zoned values are compared on the UTC axis; a zoned and an unzoned value
+    /// are not comparable at all (`None`), matching this module's ordering rule.
+    ///
+    /// `None` when either value does not parse or is partial, when exactly one
+    /// side is zoned, or on arithmetic overflow.
+    #[must_use]
+    pub fn diff(&self, a_date_time: &Self) -> Option<Iso8601Duration> {
+        let (a, b) = (self.parsed()?, a_date_time.parsed()?);
+        if is_zoned(&a) != is_zoned(&b) {
+            return None;
+        }
+        let total = utc_seconds(&a)?.checked_sub(utc_seconds(&b)?)?;
+        Some(Iso8601Duration {
+            value: render_duration(total)?,
+        })
+    }
+
+    /// `Iso8601_date_time.add_nominal` (alias `'++'`): NOMINAL addition — years
+    /// and months advance the calendar to the same day-of-month at the same time
+    /// of day, clamped down when the target month is shorter (the rules of
+    /// `Iso8601_date.add_nominal`), and the remaining components (weeks, days,
+    /// hours, minutes, seconds) apply as an exact shift.
+    ///
+    /// `None` when either value does not parse, when this date/time is partial,
+    /// or when the result leaves the representable `0000`–`9999` year range.
+    #[must_use]
+    pub fn add_nominal(&self, a_diff: &Iso8601Duration) -> Option<Self> {
+        self.nominal_shift(a_diff, false)
+    }
+
+    /// `Iso8601_date_time.subtract_nominal` (alias `'--'`): NOMINAL subtraction,
+    /// with the day-clamping semantics of [`Iso8601DateTime::add_nominal`].
+    ///
+    /// `None` under the same conditions as [`Iso8601DateTime::add_nominal`].
+    #[must_use]
+    pub fn subtract_nominal(&self, a_diff: &Iso8601Duration) -> Option<Self> {
+        self.nominal_shift(a_diff, true)
+    }
+
+    /// The date/time reached by shifting this one's local instant by `shift`
+    /// seconds, re-rendered in extended form with the timezone carried through.
+    fn shifted(&self, shift: ExactSeconds) -> Option<Self> {
+        let p = self.parsed()?;
+        let total = local_seconds(&p)?.checked_add(shift)?;
+        render_absolute(total, p.time.and_then(|t| t.timezone)).map(|value| Self { value })
+    }
+
+    /// Shared body of the nominal `add_nominal`/`subtract_nominal`: the
+    /// year/month part shifts the calendar with day-clamping, then the
+    /// sub-month remainder applies as an exact shift of the local instant.
+    fn nominal_shift(&self, a_diff: &Iso8601Duration, subtract: bool) -> Option<Self> {
+        let (months, remainder) = a_diff.parsed()?.to_nominal_parts(subtract)?;
+        let p = self.parsed()?;
+        let time = p.time?;
+        let (year, month, day) = shift_months(p.date.year, p.date.month?, p.date.day?, months)?;
+        let clamped = local_seconds_at(year, month, day, &time)?;
+        render_absolute(clamped.checked_add(remainder)?, time.timezone).map(|value| Self { value })
+    }
+}
+
+/// A complete date/time's local instant on the absolute-seconds axis (days since
+/// 1970-01-01 × 86400 + time of day), or `None` when any component the
+/// arithmetic needs is missing.
+fn local_seconds(dt: &ParsedDateTime) -> Option<ExactSeconds> {
+    let time = dt.time?;
+    local_seconds_at(dt.date.year, dt.date.month?, dt.date.day?, &time)
+}
+
+/// The local instant of `(year, month, day)` at the time of day `time` (whose
+/// minute and second must be present).
+fn local_seconds_at(year: u32, month: u32, day: u32, time: &ParsedTime) -> Option<ExactSeconds> {
+    let whole = days_from_civil(year, month, day)
+        .checked_mul(EXACT_SECONDS_IN_DAY)?
+        .checked_add(i64::from(time.hour) * EXACT_SECONDS_IN_HOUR)?
+        .checked_add(i64::from(time.minute?) * EXACT_SECONDS_IN_MINUTE)?
+        .checked_add(i64::from(time.second?))?;
+    ExactSeconds::new(whole, time.fractional_second.unwrap_or(0.0))
+}
+
+/// A complete date/time's instant on the UTC axis when zoned (the same uniform
+/// shift the ordering uses), or its local instant when unzoned.
+fn utc_seconds(dt: &ParsedDateTime) -> Option<ExactSeconds> {
+    let offset = i64::from(dt.time.and_then(|t| t.timezone).unwrap_or(0))
+        .checked_mul(EXACT_SECONDS_IN_MINUTE)?;
+    local_seconds(dt)?.checked_sub(ExactSeconds::new(offset, 0.0)?)
+}
+
+/// Render an absolute-seconds instant as an extended-form date/time value with
+/// `timezone` carried through. `None` when the instant falls outside the
+/// representable year range.
+fn render_absolute(instant: ExactSeconds, timezone: Option<i32>) -> Option<String> {
+    let instant = instant.rounded_to_nanos()?;
+    let (year, month, day) = civil_from_days(instant.whole.div_euclid(EXACT_SECONDS_IN_DAY))?;
+    let (hour, minute, second) =
+        hms_from_seconds_of_day(instant.whole.rem_euclid(EXACT_SECONDS_IN_DAY))?;
+    Some(format!(
+        "{}T{}",
+        render_date_extended(year, Some(month), Some(day)),
+        render_time_extended(hour, minute, second, instant.frac, timezone)
+    ))
 }
 
 /// True when the value carries a timezone (a time part with an offset).
@@ -165,6 +358,22 @@ mod tests {
         Iso8601DateTime {
             value: v.to_owned(),
         }
+    }
+
+    fn dur(v: &str) -> Iso8601Duration {
+        Iso8601Duration {
+            value: v.to_owned(),
+        }
+    }
+
+    /// The value of a computed date/time, or `"None"`.
+    fn value(d: Option<Iso8601DateTime>) -> String {
+        d.map_or_else(|| "None".to_owned(), |d| d.value)
+    }
+
+    /// The value of a computed duration, or `"None"`.
+    fn duration_value(d: Option<Iso8601Duration>) -> String {
+        d.map_or_else(|| "None".to_owned(), |d| d.value)
     }
 
     // ── full-vs-full ordering ────────────────────────────────────────────────
@@ -309,5 +518,226 @@ mod tests {
         assert!(date_only.second_unknown());
         assert!(date_only.is_partial());
         assert_eq!(date_only.timezone(), None);
+    }
+
+    // ── lexical predicates / as_string ───────────────────────────────────────
+
+    #[test]
+    fn extended_and_compact_forms_are_distinguished() {
+        assert!(dt("2020-06-15T12:00:00").is_extended());
+        assert!(dt("2020-06-15T12:00:00Z").is_extended());
+        assert!(dt("2020-06-15").is_extended());
+        assert!(dt("2020-06").is_extended());
+        assert!(!dt("20200615T120000").is_extended());
+        assert!(!dt("2020-06-15T120000").is_extended()); // mixed spelling
+        assert!(!dt("20200615T12:00:00").is_extended());
+        assert!(!dt("2020-06-15T12:00:00+0200").is_extended()); // compact timezone
+        assert!(!dt("garbage").is_extended());
+    }
+
+    #[test]
+    fn decimal_sign_and_fractional_second_are_reported() {
+        assert!(dt("2020-06-15T12:00:00,5").is_decimal_sign_comma());
+        assert!(!dt("2020-06-15T12:00:00.5").is_decimal_sign_comma());
+        assert!(!dt("2020-06-15T12:00:00").is_decimal_sign_comma());
+        assert!(!dt("2020-06-15").is_decimal_sign_comma());
+
+        assert!(dt("2020-06-15T12:00:00.0").has_fractional_second());
+        assert!(dt("2020-06-15T12:00:00,25Z").has_fractional_second());
+        assert!(!dt("2020-06-15T12:00:00").has_fractional_second());
+        assert!(!dt("2020-06-15").has_fractional_second());
+        assert!(!dt("garbage").has_fractional_second());
+    }
+
+    #[test]
+    fn as_string_returns_the_extended_form() {
+        assert_eq!(dt("20200615T120000").as_string(), "2020-06-15T12:00:00");
+        assert_eq!(dt("20200615T1200").as_string(), "2020-06-15T12:00");
+        assert_eq!(dt("202006").as_string(), "2020-06");
+        assert_eq!(dt("2020-06-15T12:00:00").as_string(), "2020-06-15T12:00:00");
+        // Precision, decimal sign and timezone survive the re-spelling.
+        assert_eq!(
+            dt("20200615T120000,500+0200").as_string(),
+            "2020-06-15T12:00:00,500+02:00"
+        );
+        // An invalid date/time has no extended form: verbatim.
+        assert_eq!(dt("2020-06-15T24:00:00").as_string(), "2020-06-15T24:00:00");
+    }
+
+    // ── definite arithmetic ──────────────────────────────────────────────────
+
+    #[test]
+    fn definite_arithmetic_rolls_the_calendar() {
+        assert_eq!(
+            value(dt("2020-06-15T23:30:00").add(&dur("PT1H"))),
+            "2020-06-16T00:30:00"
+        );
+        assert_eq!(
+            value(dt("2020-06-15T00:30:00").subtract(&dur("PT1H"))),
+            "2020-06-14T23:30:00"
+        );
+        assert_eq!(
+            value(dt("2019-12-31T23:59:59").add(&dur("PT1S"))),
+            "2020-01-01T00:00:00"
+        );
+        assert_eq!(
+            value(dt("2020-02-28T12:00:00").add(&dur("P1D"))),
+            "2020-02-29T12:00:00"
+        );
+    }
+
+    #[test]
+    fn definite_month_and_year_use_the_average_lengths() {
+        // Average_days_in_month = 30.42 ⇒ 30 days and 10:04:48.
+        assert_eq!(
+            value(dt("2020-01-15T00:00:00").add(&dur("P1M"))),
+            "2020-02-14T10:04:48"
+        );
+        // Average_days_in_year = 365.24 ⇒ 365 days and 05:45:36.
+        assert_eq!(
+            value(dt("2019-03-01T00:00:00").add(&dur("P1Y"))),
+            "2020-02-29T05:45:36"
+        );
+    }
+
+    #[test]
+    fn definite_arithmetic_keeps_fractions_and_the_timezone() {
+        assert_eq!(
+            value(dt("2020-06-15T12:00:00.5").add(&dur("PT0.25S"))),
+            "2020-06-15T12:00:00.75"
+        );
+        assert_eq!(
+            value(dt("2020-06-15T12:00:00+02:00").add(&dur("PT30M"))),
+            "2020-06-15T12:30:00+02:00"
+        );
+        // A compact value's timezone is canonicalised to the extended spelling.
+        assert_eq!(
+            value(dt("20200615T120000+0200").add(&dur("PT30M"))),
+            "2020-06-15T12:30:00+02:00"
+        );
+        assert_eq!(
+            value(dt("2020-06-15T12:00:00Z").subtract(&dur("PT1H"))),
+            "2020-06-15T11:00:00Z"
+        );
+    }
+
+    // ── nominal arithmetic ───────────────────────────────────────────────────
+
+    #[test]
+    fn nominal_year_on_leap_day_clamps_and_keeps_the_time() {
+        // Iso8601_date.add_nominal's rule, with the time of day preserved
+        // (§Computational Functions: "the same time on the next or previous day").
+        assert_eq!(
+            value(dt("2020-02-29T12:00:00Z").add_nominal(&dur("P1Y"))),
+            "2021-02-28T12:00:00Z"
+        );
+        assert_eq!(
+            value(dt("2020-02-29T08:15:30.5").subtract_nominal(&dur("P1Y"))),
+            "2019-02-28T08:15:30.5"
+        );
+    }
+
+    #[test]
+    fn nominal_month_clamps_into_a_shorter_month() {
+        assert_eq!(
+            value(dt("2020-01-31T08:15:00").add_nominal(&dur("P1M"))),
+            "2020-02-29T08:15:00"
+        );
+        assert_eq!(
+            value(dt("2021-01-31T08:15:00").add_nominal(&dur("P1M"))),
+            "2021-02-28T08:15:00"
+        );
+        assert_eq!(
+            value(dt("2020-03-31T08:15:00").subtract_nominal(&dur("P1M"))),
+            "2020-02-29T08:15:00"
+        );
+    }
+
+    #[test]
+    fn nominal_time_components_shift_exactly() {
+        // P1DT2H nominally: the next day, two hours later.
+        assert_eq!(
+            value(dt("2020-06-15T22:00:00").add_nominal(&dur("P1DT2H"))),
+            "2020-06-17T00:00:00"
+        );
+        assert_eq!(
+            value(dt("2020-01-31T12:00:00").add_nominal(&dur("P1M1DT30M"))),
+            "2020-03-01T12:30:00"
+        );
+    }
+
+    #[test]
+    fn definite_and_nominal_diverge_for_the_same_operands() {
+        assert_eq!(
+            value(dt("2020-01-15T00:00:00").add(&dur("P1M"))),
+            "2020-02-14T10:04:48"
+        );
+        assert_eq!(
+            value(dt("2020-01-15T00:00:00").add_nominal(&dur("P1M"))),
+            "2020-02-15T00:00:00"
+        );
+    }
+
+    // ── diff ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn diff_reports_the_signed_interval() {
+        assert_eq!(
+            duration_value(dt("2020-06-15T12:00:00").diff(&dt("2020-06-14T12:00:00"))),
+            "P1D"
+        );
+        assert_eq!(
+            duration_value(dt("2020-06-14T12:00:00").diff(&dt("2020-06-15T12:00:00"))),
+            "-P1D"
+        );
+        assert_eq!(
+            duration_value(dt("2020-06-15T12:00:00").diff(&dt("2020-06-15T12:00:00"))),
+            "PT0S"
+        );
+        assert_eq!(
+            duration_value(dt("2020-06-15T12:00:01.5").diff(&dt("2020-06-15T12:00:00"))),
+            "PT1.5S"
+        );
+        assert_eq!(
+            duration_value(dt("2020-03-01T00:00:00").diff(&dt("2020-02-01T00:00:00"))),
+            "P29D"
+        );
+    }
+
+    #[test]
+    fn diff_normalises_two_zoned_values_and_refuses_a_mixed_pair() {
+        // 2020-06-15T12:00Z vs 2020-06-15T13:00+02:00 (= 11:00 UTC).
+        assert_eq!(
+            duration_value(dt("2020-06-15T12:00:00Z").diff(&dt("2020-06-15T13:00:00+02:00"))),
+            "PT1H"
+        );
+        assert!(
+            dt("2020-06-15T12:00:00Z")
+                .diff(&dt("2020-06-15T12:00:00"))
+                .is_none()
+        );
+    }
+
+    // ── partial / malformed operands ─────────────────────────────────────────
+
+    #[test]
+    fn partial_and_malformed_values_have_no_arithmetic() {
+        assert!(dt("2020-06-15").add(&dur("PT1H")).is_none()); // no time part
+        assert!(dt("2020-06-15T12:00").add(&dur("PT1H")).is_none()); // no second
+        assert!(dt("2020-06").add_nominal(&dur("P1M")).is_none());
+        assert!(
+            dt("2020-06-15T12:00")
+                .diff(&dt("2020-06-15T12:00:00"))
+                .is_none()
+        );
+        assert!(dt("garbage").add(&dur("PT1H")).is_none());
+        assert!(dt("2020-06-15T12:00:00").add(&dur("1H")).is_none());
+    }
+
+    #[test]
+    fn results_outside_the_representable_years_are_none() {
+        assert!(dt("9999-12-31T23:00:00").add(&dur("PT2H")).is_none());
+        assert!(dt("0000-01-01T00:00:00").subtract(&dur("PT1S")).is_none());
+        assert!(dt("9999-12-31T00:00:00").add_nominal(&dur("P1M")).is_none());
     }
 }

--- a/crates/openehr-base/src/foundation_types/time/iso8601_duration_impl.rs
+++ b/crates/openehr-base/src/foundation_types/time/iso8601_duration_impl.rs
@@ -1,14 +1,30 @@
 //! Hand-written `Iso8601_duration` spec behaviour: the accessor functions
-//! (component counts, `to_seconds`, `is_partial`) and a `PartialOrd` ordering
+//! (component counts, `to_seconds`, `is_partial`, `is_extended`,
+//! `is_decimal_sign_comma`, `as_string`), the arithmetic functions
+//! (`add`/`subtract`/`multiply`/`divide`/`negative`) and a `PartialOrd` ordering
 //! durations by their total-seconds reduction.
 //!
 //! Spec sources (vendored):
 //! - `BASE/docs/UML/classes/org.openehr.base.foundation_types.iso8601_duration.adoc`
-//!   (§Functions: the component accessors, `to_seconds`, `is_partial`; the
-//!   `add`/`subtract` semantics that reduce via `to_seconds`).
+//!   (§Functions: the component accessors, `to_seconds`, `is_partial`,
+//!   `is_extended`, `is_decimal_sign_comma`, `as_string`; the `add`/`subtract`
+//!   semantics that reduce via `to_seconds`, and `multiply`/`divide`/
+//!   `negative`).
 //! - `BASE/docs/UML/classes/org.openehr.base.foundation_types.time_definitions.adoc`
 //!   (§Constants `Average_days_in_year`/`Average_days_in_month` used by
 //!   `to_seconds`).
+//! - `BASE/docs/foundation_types/master06-time_types.adoc` (§Primitive Time
+//!   Types: the negative-duration and mixed-`W` deviations; §Computational
+//!   Functions).
+//!
+//! NOTE: the class doc gives an algorithm for `add`/`subtract` (reduce both
+//! operands via `to_seconds`) but none for `multiply`/`divide`. Component-wise
+//! scaling is not even expressible — `P1Y * 1.5` would need a fractional year,
+//! and the `Fractional_second_valid` invariant is the only place the spec admits
+//! a fraction — so `multiply`/`divide` use the same sanctioned `to_seconds`
+//! reduction, and every computed result renders in the canonical
+//! definite-designator form (`iso8601_parse::render_duration`). Our own
+//! design/extension on the spec's own reduction.
 //!
 //! NOTE: the openEHR spec gives no duration comparison, but it DOES sanction
 //! reducing a duration to a scalar via `to_seconds` (with the average-length
@@ -21,12 +37,13 @@
 use std::cmp::Ordering;
 
 use super::iso8601_duration::Iso8601Duration;
-use super::iso8601_parse::{ParsedDuration, parse_duration};
+use super::iso8601_parse::{ExactSeconds, ParsedDuration, parse_duration, render_duration};
 
 impl Iso8601Duration {
     /// Parsed components, or `None` when `value` is not a valid ISO 8601
-    /// duration.
-    fn parsed(&self) -> Option<ParsedDuration> {
+    /// duration. Crate-visible because a duration is the argument of every
+    /// other time type's computational functions.
+    pub(crate) fn parsed(&self) -> Option<ParsedDuration> {
         parse_duration(&self.value)
     }
 
@@ -95,12 +112,118 @@ impl Iso8601Duration {
         self.parsed().map(|_| false)
     }
 
+    /// `Iso8601_duration.is_extended`: always `True` for a duration (effected in
+    /// the spec — a duration has no compact form), or `None` when the value does
+    /// not parse.
+    #[must_use]
+    pub fn is_extended(&self) -> Option<bool> {
+        self.parsed().map(|_| true)
+    }
+
+    /// `Iso8601_duration.is_decimal_sign_comma`: true when the fractional
+    /// seconds are written with `','` rather than `'.'`. False when the value
+    /// carries no fraction or does not parse.
+    #[must_use]
+    pub fn is_decimal_sign_comma(&self) -> bool {
+        self.parsed().is_some_and(|p| p.decimal_sign_comma)
+    }
+
     /// `Iso8601_duration.to_seconds`: total seconds equivalent (sign applied),
     /// with years/months reduced via `Time_definitions.Average_days_in_year`
     /// / `Average_days_in_month`. `None` when the value does not parse.
     #[must_use]
     pub fn to_seconds(&self) -> Option<f64> {
         self.parsed().map(ParsedDuration::to_seconds)
+    }
+
+    /// `Iso8601_duration.as_string`: "Return the duration string value" — the
+    /// stored value verbatim (unlike the date/time types, the duration doc asks
+    /// for the value itself, and a duration has no compact form to re-spell).
+    /// A value that does not parse is likewise returned verbatim.
+    #[must_use]
+    pub fn as_string(&self) -> String {
+        self.value.clone()
+    }
+
+    /// `Iso8601_duration.add` (alias `'+'`): "Arithmetic addition of a duration
+    /// to a duration, via conversion to seconds, using
+    /// `Time_definitions.Average_days_in_year` and `Average_days_in_month`" —
+    /// the class doc's own algorithm.
+    ///
+    /// `None` when either value does not parse or the result overflows.
+    #[must_use]
+    pub fn add(&self, a_val: &Self) -> Option<Self> {
+        Self::rendered(self.exact_seconds()?.checked_add(a_val.exact_seconds()?)?)
+    }
+
+    /// `Iso8601_duration.subtract` (alias `'-'`): the same seconds reduction as
+    /// [`Iso8601Duration::add`], subtracted.
+    ///
+    /// `None` when either value does not parse or the result overflows.
+    #[must_use]
+    pub fn subtract(&self, a_val: &Self) -> Option<Self> {
+        Self::rendered(self.exact_seconds()?.checked_sub(a_val.exact_seconds()?)?)
+    }
+
+    /// `Iso8601_duration.multiply` (alias `'*'`): the duration scaled by a
+    /// `Real` factor.
+    ///
+    /// `None` when the value does not parse or the result is not representable.
+    #[must_use]
+    pub fn multiply(&self, a_val: f64) -> Option<Self> {
+        Self::rendered(ExactSeconds::from_f64(
+            self.exact_seconds()?.as_f64() * a_val,
+        )?)
+    }
+
+    /// `Iso8601_duration.divide` (alias `'/'`): the duration divided by a `Real`
+    /// factor.
+    ///
+    /// `None` when the value does not parse or the result is not representable —
+    /// which includes division by zero (an infinite result).
+    #[must_use]
+    pub fn divide(&self, a_val: f64) -> Option<Self> {
+        Self::rendered(ExactSeconds::from_f64(
+            self.exact_seconds()?.as_f64() / a_val,
+        )?)
+    }
+
+    /// `Iso8601_duration.negative` (alias `'-'`): "Generate negative of current
+    /// duration value" — the sign is flipped and the components are kept exactly
+    /// as written (the openEHR negative-duration deviation, `master06`
+    /// §Primitive Time Types).
+    ///
+    /// `None` when the value does not parse.
+    ///
+    /// NOTE: unlike `add`/`subtract`, this does NOT go through the seconds
+    /// reduction: the spec asks for the negative of *this* duration value, so
+    /// flipping the leading sign preserves the `Y`/`M`/`W` designators, the
+    /// fractional precision and the decimal sign — a reduction would destroy
+    /// all four. No openEHR spec prescribes the output spelling — our own
+    /// design/extension.
+    #[must_use]
+    pub fn negative(&self) -> Option<Self> {
+        let value = if self.parsed()?.negative {
+            self.value.strip_prefix('-')?.to_owned()
+        } else {
+            format!("-{}", self.value)
+        };
+        Some(Self { value })
+    }
+
+    /// The duration as an exact signed second quantity (the `to_seconds`
+    /// reduction, computed in whole seconds), or `None` when the value does not
+    /// parse or the reduction overflows.
+    fn exact_seconds(&self) -> Option<ExactSeconds> {
+        self.parsed()?.to_exact_seconds()
+    }
+
+    /// A computed second quantity as a duration value, in the canonical
+    /// definite-designator form (see [`render_duration`]).
+    fn rendered(total: ExactSeconds) -> Option<Self> {
+        Some(Self {
+            value: render_duration(total)?,
+        })
     }
 }
 
@@ -129,6 +252,11 @@ mod tests {
         Iso8601Duration {
             value: v.to_owned(),
         }
+    }
+
+    /// The value of a computed duration, or `"None"`.
+    fn value(d: Option<Iso8601Duration>) -> String {
+        d.map_or_else(|| "None".to_owned(), |d| d.value)
     }
 
     // ── ordering by total-seconds reduction ──────────────────────────────────
@@ -229,5 +357,110 @@ mod tests {
         assert_eq!(dur("PT1H").to_seconds(), Some(3600.0));
         // P1D = 86400 s.
         assert_eq!(dur("P1D").to_seconds(), Some(86_400.0));
+    }
+
+    // ── lexical predicates / as_string ───────────────────────────────────────
+
+    #[test]
+    fn a_duration_is_always_extended_and_never_partial() {
+        // iso8601_duration.adoc §Functions: is_extended "Returns True",
+        // is_partial "Returns False".
+        assert_eq!(dur("P1Y2M3W4DT5H6M7.5S").is_extended(), Some(true));
+        assert_eq!(dur("P1D").is_extended(), Some(true));
+        assert_eq!(dur("P1D").is_partial(), Some(false));
+        assert_eq!(dur("nonsense").is_extended(), None);
+    }
+
+    #[test]
+    fn decimal_sign_comma_is_reported() {
+        assert!(dur("PT0,5S").is_decimal_sign_comma());
+        assert!(dur("P1DT1M0,25S").is_decimal_sign_comma());
+        assert!(!dur("PT0.5S").is_decimal_sign_comma());
+        assert!(!dur("PT1S").is_decimal_sign_comma());
+        assert!(!dur("nonsense").is_decimal_sign_comma());
+    }
+
+    #[test]
+    fn as_string_returns_the_stored_value() {
+        // The duration doc asks for "the duration string value" (not, as for the
+        // date/time types, an extended re-spelling — a duration has no compact
+        // form), so every component spelling survives.
+        assert_eq!(dur("P1W3D").as_string(), "P1W3D");
+        assert_eq!(dur("-P3M").as_string(), "-P3M");
+        assert_eq!(dur("PT0,50S").as_string(), "PT0,50S");
+        assert_eq!(dur("nonsense").as_string(), "nonsense");
+    }
+
+    // ── add / subtract (via the to_seconds reduction) ─────────────────────────
+
+    #[test]
+    fn add_and_subtract_reduce_via_seconds() {
+        assert_eq!(value(dur("PT1H").add(&dur("PT30M"))), "PT1H30M");
+        assert_eq!(value(dur("P1D").add(&dur("PT12H"))), "P1DT12H");
+        assert_eq!(value(dur("PT1H").subtract(&dur("PT30M"))), "PT30M");
+        // A negative result carries the openEHR negative-duration sign.
+        assert_eq!(value(dur("PT1H").subtract(&dur("PT90M"))), "-PT30M");
+        assert_eq!(value(dur("PT1H").subtract(&dur("PT1H"))), "PT0S");
+        // A negative operand is honoured.
+        assert_eq!(value(dur("PT1H").add(&dur("-PT30M"))), "PT30M");
+    }
+
+    #[test]
+    fn add_uses_the_average_month_length() {
+        // The class doc mandates the Average_days_in_month reduction: P1M is
+        // 30 days and 10:04:48, which the canonical result form spells out.
+        assert_eq!(value(dur("P1M").add(&dur("PT0S"))), "P30DT10H4M48S");
+        // P1Y = 365 days and 05:45:36 (Average_days_in_year = 365.24).
+        assert_eq!(value(dur("P1Y").add(&dur("PT0S"))), "P365DT5H45M36S");
+    }
+
+    #[test]
+    fn add_and_subtract_keep_fractional_seconds() {
+        assert_eq!(value(dur("PT0.5S").add(&dur("PT0.25S"))), "PT0.75S");
+        assert_eq!(value(dur("PT0.5S").add(&dur("PT0.5S"))), "PT1S");
+        assert_eq!(value(dur("PT1S").subtract(&dur("PT0.25S"))), "PT0.75S");
+        assert_eq!(value(dur("PT0.25S").subtract(&dur("PT1S"))), "-PT0.75S");
+        // A comma decimal sign parses and renders back with a period.
+        assert_eq!(value(dur("PT0,5S").add(&dur("PT0,5S"))), "PT1S");
+    }
+
+    // ── multiply / divide / negative ─────────────────────────────────────────
+
+    #[test]
+    fn multiply_and_divide_scale_the_reduction() {
+        assert_eq!(value(dur("PT1H").multiply(2.0)), "PT2H");
+        assert_eq!(value(dur("P1D").multiply(0.5)), "PT12H");
+        assert_eq!(value(dur("PT1H").divide(2.0)), "PT30M");
+        assert_eq!(value(dur("PT1S").divide(4.0)), "PT0.25S");
+        // Scaling by a negative factor flips the sign.
+        assert_eq!(value(dur("PT1H").multiply(-1.0)), "-PT1H");
+        assert_eq!(value(dur("-P1D").multiply(2.0)), "-P2D");
+    }
+
+    #[test]
+    fn multiply_and_divide_round_trip() {
+        let original = dur("P1DT2H3M4S");
+        let doubled = original.multiply(2.0).unwrap();
+        assert_eq!(doubled.value, "P2DT4H6M8S");
+        assert_eq!(doubled.divide(2.0).unwrap().value, "P1DT2H3M4S");
+    }
+
+    #[test]
+    fn divide_by_zero_and_a_non_finite_factor_are_uncomputable() {
+        assert!(dur("PT1H").divide(0.0).is_none());
+        assert!(dur("PT1H").multiply(f64::NAN).is_none());
+        assert!(dur("PT1H").multiply(f64::INFINITY).is_none());
+    }
+
+    #[test]
+    fn negative_flips_the_sign_and_keeps_the_components() {
+        assert_eq!(value(dur("P1Y2M").negative()), "-P1Y2M");
+        assert_eq!(value(dur("-P3M").negative()), "P3M");
+        // Round-trip: the exact spelling comes back, designators and all.
+        let original = dur("P1Y2M3W4DT5H6M7,50S");
+        let flipped = original.negative().unwrap();
+        assert_eq!(flipped.value, "-P1Y2M3W4DT5H6M7,50S");
+        assert_eq!(flipped.negative().unwrap().value, original.value);
+        assert!(dur("nonsense").negative().is_none());
     }
 }

--- a/crates/openehr-base/src/foundation_types/time/iso8601_parse.rs
+++ b/crates/openehr-base/src/foundation_types/time/iso8601_parse.rs
@@ -1,23 +1,27 @@
-//! Hand-written ISO 8601 parsing + completion-range machinery shared by the
-//! four `Iso8601_*` `*_impl.rs` siblings.
+//! Hand-written ISO 8601 parsing, arithmetic and completion-range machinery
+//! shared by the four `Iso8601_*` `*_impl.rs` siblings.
 //!
 //! The generated `Iso8601_*` types hold their value as a single `String`
 //! (BMM: `Iso8601_type.value`). Ordering, the spec-declared accessor
-//! functions, and duration reduction all need the value decomposed into
-//! typed components, so this module parses the documented lexical forms into
-//! plain component structs. A malformed string parses to `None`, which every
-//! caller turns into an undecidable (`None`) comparison — the generated types
-//! admit any `String`, so parsing can always fail and must never panic.
+//! functions, duration reduction, and the computational functions
+//! (`add`/`subtract`/`diff`/`add_nominal`/`subtract_nominal`) all need the
+//! value decomposed into typed components, so this module parses the
+//! documented lexical forms into plain component structs, computes on them,
+//! and renders results back to a string. A malformed string parses to `None`,
+//! which every caller turns into an undecidable (`None`) comparison or an
+//! uncomputable (`None`) result — the generated types admit any `String`, so
+//! parsing can always fail and must never panic.
 //!
 //! Spec sources (vendored):
 //! - `BASE/docs/UML/classes/org.openehr.base.foundation_types.time_definitions.adoc`
 //!   (§Constants: the average-length constants used verbatim below; §Functions:
 //!   `valid_iso8601_date`/`_time`/`_date_time`/`_duration`, `valid_second`,
-//!   `valid_hour`).
+//!   `valid_hour`, `valid_year`).
 //! - `BASE/docs/foundation_types/master06-time_types.adoc` (§Overview,
 //!   §Primitive Time Types: the accepted forms and openEHR's deviations —
 //!   week dates `YYYY-Www` excluded, `24:00:00` disallowed anywhere, the `W`
-//!   duration designator mixable, negative durations, 4-digit years only).
+//!   duration designator mixable, negative durations, 4-digit years only;
+//!   §Computational Functions: the definite/nominal split).
 //!
 //! NOTE: the openEHR specs define THAT these types are `Ordered` (via the
 //! `Ordered` ancestry of `Iso8601_type`) but give NO comparison algorithm —
@@ -36,6 +40,9 @@
 //! are comparable when their completion intervals are order-separated.
 
 use std::cmp::Ordering;
+// `write!` into a `String` is infallible; the `let _ =` discards of its
+// `Result` below are the standard `std::fmt` idiom, not dropped guards.
+use std::fmt::Write;
 
 // ── Time_Definitions constants (verbatim; §Constants) ────────────────────────
 // The BMM `Time_Definitions` class is not emitted as a generated type (it
@@ -61,22 +68,58 @@ pub(crate) const SECONDS_IN_HOUR: f64 = MINUTES_IN_HOUR * SECONDS_IN_MINUTE;
 /// Seconds in one clock day (`Hours_in_day * Minutes_in_hour * Seconds_in_minute`).
 pub(crate) const SECONDS_IN_DAY: f64 = HOURS_IN_DAY * SECONDS_IN_HOUR;
 
+// ── Integer-second forms of the same constants ───────────────────────────────
+// NOTE: the definite computational functions (§Computational Functions) reduce a
+// duration to seconds and shift a date/time by it. Doing that on `f64` would
+// corrupt sub-second precision, because an absolute-seconds coordinate is
+// ~1e11 and an `f64` mantissa cannot carry a nanosecond fraction that far out.
+// The arithmetic therefore runs on `i64` whole seconds plus a separate
+// fractional part ([`ExactSeconds`]), which is exact — and it stays faithful to
+// the spec constants because both average lengths are a whole number of
+// seconds: `Average_days_in_year × 86400 = 365.24 × 86400 = 31_556_736` and
+// `Average_days_in_month × 86400 = 30.42 × 86400 = 2_628_288` (pinned by the
+// `average_constants_are_whole_seconds` test below). No openEHR spec governs
+// the arithmetic's internal representation — our own design/extension.
+
+/// `Time_Definitions.Seconds_in_minute` as exact seconds.
+pub(crate) const EXACT_SECONDS_IN_MINUTE: i64 = 60;
+/// Seconds in one clock hour, exact.
+pub(crate) const EXACT_SECONDS_IN_HOUR: i64 = 60 * EXACT_SECONDS_IN_MINUTE;
+/// Seconds in one clock day, exact.
+pub(crate) const EXACT_SECONDS_IN_DAY: i64 = 24 * EXACT_SECONDS_IN_HOUR;
+/// Seconds in `Time_Definitions.Days_in_week` days, exact.
+pub(crate) const EXACT_SECONDS_IN_WEEK: i64 = 7 * EXACT_SECONDS_IN_DAY;
+/// `Time_Definitions.Average_days_in_month` (30.42) in exact seconds.
+pub(crate) const EXACT_SECONDS_IN_AVERAGE_MONTH: i64 = 2_628_288;
+/// `Time_Definitions.Average_days_in_year` (365.24) in exact seconds.
+pub(crate) const EXACT_SECONDS_IN_AVERAGE_YEAR: i64 = 31_556_736;
+
+/// The inclusive year range the openEHR time types can represent: `valid_year`
+/// requires `y >= 0` (`time_definitions.adoc` §Functions) and `master06`
+/// §Primitive Time Types excludes 'expanded' (>4-digit) years, so an arithmetic
+/// result outside `0000`..=`9999` is not representable.
+const REPRESENTABLE_YEARS: std::ops::RangeInclusive<i64> = 0..=9999;
+
 // ── Parsed component structs ─────────────────────────────────────────────────
 
 /// A parsed ISO 8601 date. `year` is always present (the openEHR types have no
 /// sensible value without it); `month`/`day` are absent for the partial forms
-/// `YYYY` and `YYYY-MM`.
+/// `YYYY` and `YYYY-MM`. `extended` records the lexical form
+/// (`Iso8601_date.is_extended`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ParsedDate {
     pub(crate) year: u32,
     pub(crate) month: Option<u32>,
     pub(crate) day: Option<u32>,
+    pub(crate) extended: bool,
 }
 
 /// A parsed ISO 8601 time. `hour` is always present; `minute`/`second` are
 /// absent for the partial forms `hh` and `hh:mm`. `fractional_second` is only
 /// meaningful when `second` is present. `timezone` is the offset in signed
-/// minutes (`Z` → `Some(0)`, absent → `None`).
+/// minutes (`Z` → `Some(0)`, absent → `None`). `extended` and
+/// `decimal_sign_comma` record the lexical form (`Iso8601_time.is_extended`,
+/// `is_decimal_sign_comma`).
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) struct ParsedTime {
     pub(crate) hour: u32,
@@ -84,6 +127,8 @@ pub(crate) struct ParsedTime {
     pub(crate) second: Option<u32>,
     pub(crate) fractional_second: Option<f64>,
     pub(crate) timezone: Option<i32>,
+    pub(crate) extended: bool,
+    pub(crate) decimal_sign_comma: bool,
 }
 
 /// A parsed ISO 8601 date/time: a date (possibly partial) with an optional
@@ -95,11 +140,13 @@ pub(crate) struct ParsedDateTime {
 }
 
 /// A parsed ISO 8601 duration. Integer designator counts plus fractional
-/// seconds and a sign flag (openEHR allows a leading `-` and mixing `W` with
-/// other designators).
+/// seconds, a sign flag (openEHR allows a leading `-` and mixing `W` with
+/// other designators) and the decimal-sign lexeme
+/// (`Iso8601_duration.is_decimal_sign_comma`).
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) struct ParsedDuration {
     pub(crate) negative: bool,
+    pub(crate) decimal_sign_comma: bool,
     pub(crate) years: u64,
     pub(crate) months: u64,
     pub(crate) weeks: u64,
@@ -147,10 +194,11 @@ pub(crate) fn days_in_month(year: u32, month: u32) -> Option<u32> {
 
 /// Days since 1970-01-01 for a proleptic-Gregorian `(year, month, day)`
 /// (Howard Hinnant's `days_from_civil`, a standard branch-free algorithm). Used
-/// only to place date/times on a common absolute-seconds axis for timezone
-/// normalisation. Inputs are validated dates, so the result is well-defined.
+/// to place date/times on a common absolute-seconds axis, both for timezone
+/// normalisation and for the definite computational functions. Inputs are
+/// validated dates, so the result is well-defined.
 #[allow(clippy::cast_possible_wrap)] // year/month/day are small validated ranges
-fn days_from_civil(year: u32, month: u32, day: u32) -> i64 {
+pub(crate) fn days_from_civil(year: u32, month: u32, day: u32) -> i64 {
     let y = i64::from(year) - i64::from(month <= 2);
     let m = i64::from(month);
     let d = i64::from(day);
@@ -204,13 +252,25 @@ pub(crate) fn parse_date(s: &str) -> Option<ParsedDate> {
             _ => return None,
         }
     };
-    validate_date(year, month, day)
+    validate_date(year, month, day)?;
+    // `Iso8601_date.is_extended`: "True if this date uses '-' separators".
+    // NOTE: the spec does not say what a form with NO separator position
+    // (`YYYY`, identical in both forms) reports. We report it extended, which
+    // keeps the invariant `as_string() == value` exactly when `is_extended` —
+    // no openEHR spec governs this case — our own design/extension.
+    let extended = s.contains('-') || s.len() == 4;
+    Some(ParsedDate {
+        year,
+        month,
+        day,
+        extended,
+    })
 }
 
 /// Enforce the `Iso8601_date` validity invariants: a day requires a month
 /// (`Partial_validity`), and present components must be calendar-valid
 /// (`Month_valid`/`Day_valid`).
-fn validate_date(year: u32, month: Option<u32>, day: Option<u32>) -> Option<ParsedDate> {
+fn validate_date(year: u32, month: Option<u32>, day: Option<u32>) -> Option<()> {
     if let Some(m) = month {
         if !(1..=12).contains(&m) {
             return None;
@@ -224,7 +284,7 @@ fn validate_date(year: u32, month: Option<u32>, day: Option<u32>) -> Option<Pars
     } else if day.is_some() {
         return None; // day present but month unknown — invalid partial
     }
-    Some(ParsedDate { year, month, day })
+    Some(())
 }
 
 // ── Time parsing ──────────────────────────────────────────────────────────────
@@ -234,24 +294,51 @@ fn validate_date(year: u32, month: Option<u32>, day: Option<u32>) -> Option<Pars
 /// (`master06`; `Time_definitions.valid_second` Post `s < Seconds_in_minute`),
 /// see the leap-second NOTE in `iso8601_time_impl.rs`.
 pub(crate) fn parse_time(s: &str) -> Option<ParsedTime> {
-    // Split off the timezone: it starts at the first 'Z', '+' or '-'.
-    let tz_start = s.bytes().position(|b| b == b'Z' || b == b'+' || b == b'-');
-    let (main, timezone) = match tz_start {
-        Some(i) => {
-            let main = s.get(0..i)?;
-            let tz = s.get(i..)?;
-            (main, Some(parse_timezone(tz)?))
-        }
-        None => (s, None),
+    let (main, tz) = split_timezone_lexeme(s)?;
+    let timezone = if tz.is_empty() {
+        None
+    } else {
+        Some(parse_timezone(tz)?)
     };
     let (hour, minute, second, fractional_second) = parse_time_main(main)?;
+    // `Iso8601_time.is_extended`: "True if this time uses '-', ':' separators".
+    // A value counts as extended when every separator position it actually has
+    // is written with a separator (so `hh`, `Z` and `±hh`, which have none, do
+    // not disqualify it) — see the `parse_date` is_extended NOTE.
+    let extended = body_is_extended(split_fraction_lexeme(main).0) && timezone_is_extended(tz);
     Some(ParsedTime {
         hour,
         minute,
         second,
         fractional_second,
         timezone,
+        extended,
+        // After a successful parse the only comma the value can carry is the
+        // decimal sign (`Iso8601_time.is_decimal_sign_comma`).
+        decimal_sign_comma: s.contains(','),
     })
+}
+
+/// Split a time string into its time-of-day part and its timezone lexeme (`""`
+/// when unzoned): the timezone starts at the first `Z`, `+` or `-`.
+pub(crate) fn split_timezone_lexeme(s: &str) -> Option<(&str, &str)> {
+    match s.bytes().position(|b| b == b'Z' || b == b'+' || b == b'-') {
+        Some(i) => Some((s.get(0..i)?, s.get(i..)?)),
+        None => Some((s, "")),
+    }
+}
+
+/// True when a time-of-day body (fraction already split off) is in extended
+/// form: it either writes its `':'` separators or has no separator position
+/// (the `hh` partial).
+fn body_is_extended(body: &str) -> bool {
+    body.contains(':') || body.len() <= 2
+}
+
+/// True when a timezone lexeme is in extended form: `""` (unzoned), `Z` and
+/// `±hh` have no separator position; `±hh:mm` writes it, `±hhmm` does not.
+fn timezone_is_extended(tz: &str) -> bool {
+    tz.contains(':') || tz.len() <= 3
 }
 
 /// Parse the time-of-day part (no timezone) in extended or compact form.
@@ -315,6 +402,21 @@ fn split_fraction(main: &str) -> (&str, Option<f64>) {
         }
     } else {
         (main, None)
+    }
+}
+
+/// Split a trailing `(.|,)digits` fractional part off the time body, returning
+/// the body and the fractional lexeme VERBATIM (including its decimal sign, or
+/// `""` when absent). Used for re-rendering in extended form, which must never
+/// change a value's precision or decimal sign — unlike [`split_fraction`], this
+/// does not validate the lexeme (the caller has already parsed the value).
+fn split_fraction_lexeme(main: &str) -> (&str, &str) {
+    match main.bytes().position(|b| b == b'.' || b == b',') {
+        Some(i) => match (main.get(0..i), main.get(i..)) {
+            (Some(body), Some(frac)) => (body, frac),
+            _ => (main, ""),
+        },
+        None => (main, ""),
     }
 }
 
@@ -423,6 +525,9 @@ pub(crate) fn parse_duration(s: &str) -> Option<ParsedDuration> {
     }
     let mut d = ParsedDuration {
         negative,
+        // After a successful parse the only comma a duration can carry is the
+        // decimal sign (`Iso8601_duration.is_decimal_sign_comma`).
+        decimal_sign_comma: s.contains(','),
         years: 0,
         months: 0,
         weeks: 0,
@@ -662,5 +767,502 @@ fn intraday_range(day_start: f64, t: &ParsedTime) -> (f64, f64, bool) {
             (start, start + SECONDS_IN_MINUTE, true)
         }
         _ => (base, base + SECONDS_IN_HOUR, true),
+    }
+}
+
+// ── Exact second quantities (the arithmetic axis) ────────────────────────────
+
+/// An exact second quantity: an integer second count plus a fractional part in
+/// `[0.0, 1.0)`, denoting `whole + frac`. The representation is a *floor* one —
+/// a negative quantity has `whole` one below its truncation and a positive
+/// remainder (`-0.5` is `whole = -1, frac = 0.5`) — which is what makes
+/// `div_euclid`/`rem_euclid` decomposition into date + time-of-day correct in
+/// both directions without special-casing the sign.
+///
+/// NOTE: no openEHR spec governs the internal representation of the
+/// computational functions — our own design/extension, chosen because `f64`
+/// alone loses sub-second precision at absolute-time magnitudes (see the
+/// integer-constant NOTE above).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct ExactSeconds {
+    pub(crate) whole: i64,
+    pub(crate) frac: f64,
+}
+
+impl ExactSeconds {
+    /// Normalising constructor: rejects a non-finite or negative `frac` and
+    /// carries a `frac` of `1.0` or more (which is all that summing two
+    /// normalised fractions can produce) into `whole`. `None` on overflow.
+    pub(crate) fn new(whole: i64, frac: f64) -> Option<Self> {
+        if !frac.is_finite() || !(0.0..2.0).contains(&frac) {
+            return None;
+        }
+        let (whole, frac) = if frac >= 1.0 {
+            (whole.checked_add(1)?, frac - 1.0)
+        } else {
+            (whole, frac)
+        };
+        Some(Self { whole, frac })
+    }
+
+    /// Sum of two exact quantities, `None` on overflow.
+    pub(crate) fn checked_add(self, rhs: Self) -> Option<Self> {
+        Self::new(self.whole.checked_add(rhs.whole)?, self.frac + rhs.frac)
+    }
+
+    /// Difference of two exact quantities, `None` on overflow.
+    pub(crate) fn checked_sub(self, rhs: Self) -> Option<Self> {
+        self.checked_add(rhs.negated()?)
+    }
+
+    /// The additive inverse, `None` on overflow. Re-normalises the floor
+    /// representation: `-(w + f) = (-w - 1) + (1 - f)` for a non-zero fraction.
+    pub(crate) fn negated(self) -> Option<Self> {
+        if self.frac > 0.0 {
+            Some(Self {
+                whole: self.whole.checked_neg()?.checked_sub(1)?,
+                frac: 1.0 - self.frac,
+            })
+        } else {
+            Some(Self {
+                whole: self.whole.checked_neg()?,
+                frac: 0.0,
+            })
+        }
+    }
+
+    /// The quantity as an `f64` total (for `multiply`/`divide`, whose factor is
+    /// a spec `Real`).
+    #[allow(clippy::cast_precision_loss)] // second counts of interest are far inside 2^53
+    pub(crate) fn as_f64(self) -> f64 {
+        self.whole as f64 + self.frac
+    }
+
+    /// An exact quantity from an `f64` total, `None` when the value is
+    /// non-finite or so large that the `f64` no longer carries whole seconds
+    /// (beyond 2^53 s ≈ 285 million years, far outside the representable
+    /// 0000–9999 calendar).
+    pub(crate) fn from_f64(total: f64) -> Option<Self> {
+        const EXACT_INTEGER_LIMIT: f64 = 9_007_199_254_740_992.0; // 2^53
+        if !total.is_finite() || total.abs() >= EXACT_INTEGER_LIMIT {
+            return None;
+        }
+        let floor = total.floor();
+        #[allow(clippy::cast_possible_truncation)] // guarded above: |floor| < 2^53 < i64::MAX
+        let whole = floor as i64;
+        Self::new(whole, total - floor)
+    }
+
+    /// The quantity with its fraction rounded to nanosecond precision, carrying
+    /// a fraction that rounds up to a whole second into `whole`.
+    ///
+    /// NOTE: the openEHR specs bound a fractional second only by
+    /// `valid_fractional_second` (`0.0 <= fs < 1.0`) and say nothing about the
+    /// precision of a computed result, so the rendering precision is our own
+    /// design/extension: nanoseconds, which covers every precision ISO 8601
+    /// data carries in practice and keeps `f64` round-off out of the output.
+    pub(crate) fn rounded_to_nanos(self) -> Option<Self> {
+        let nanos = (self.frac * NANOS_PER_SECOND).round();
+        if nanos >= NANOS_PER_SECOND {
+            Some(Self {
+                whole: self.whole.checked_add(1)?,
+                frac: 0.0,
+            })
+        } else if nanos <= 0.0 {
+            Some(Self {
+                whole: self.whole,
+                frac: 0.0,
+            })
+        } else {
+            Some(Self {
+                whole: self.whole,
+                frac: nanos / NANOS_PER_SECOND,
+            })
+        }
+    }
+}
+
+/// Nanoseconds in a second — the precision computed fractional seconds render
+/// at (see [`ExactSeconds::rounded_to_nanos`]).
+const NANOS_PER_SECOND: f64 = 1_000_000_000.0;
+
+impl ParsedDuration {
+    /// The duration as an exact signed second quantity — the definite
+    /// (`§Computational Functions`) reduction `Iso8601_duration.to_seconds`
+    /// performs, with years/months at their `Time_definitions` average lengths,
+    /// computed in whole seconds so no precision is lost. `None` on overflow.
+    pub(crate) fn to_exact_seconds(self) -> Option<ExactSeconds> {
+        let mut whole: i64 = 0;
+        for (count, unit) in [
+            (self.years, EXACT_SECONDS_IN_AVERAGE_YEAR),
+            (self.months, EXACT_SECONDS_IN_AVERAGE_MONTH),
+            (self.weeks, EXACT_SECONDS_IN_WEEK),
+            (self.days, EXACT_SECONDS_IN_DAY),
+            (self.hours, EXACT_SECONDS_IN_HOUR),
+            (self.minutes, EXACT_SECONDS_IN_MINUTE),
+            (self.seconds, 1),
+        ] {
+            let part = i64::try_from(count).ok()?.checked_mul(unit)?;
+            whole = whole.checked_add(part)?;
+        }
+        let magnitude = ExactSeconds::new(whole, self.fractional_seconds)?;
+        if self.negative {
+            magnitude.negated()
+        } else {
+            Some(magnitude)
+        }
+    }
+
+    /// The NOMINAL split for calendrical arithmetic (`Iso8601_date.add_nominal`):
+    /// a signed month count (`years × Months_in_year + months`) applied with
+    /// day-clamping, plus the exact-second remainder (weeks, days and the time
+    /// components) applied as a plain calendar shift. Both carry the duration's
+    /// own sign, flipped when `subtract`. `None` on overflow.
+    pub(crate) fn to_nominal_parts(self, subtract: bool) -> Option<(i64, ExactSeconds)> {
+        let months = i64::try_from(self.years)
+            .ok()?
+            .checked_mul(12)?
+            .checked_add(i64::try_from(self.months).ok()?)?;
+        let mut remainder = Self {
+            years: 0,
+            months: 0,
+            ..self
+        }
+        .to_exact_seconds()?;
+        let mut months = if self.negative { -months } else { months };
+        if subtract {
+            months = months.checked_neg()?;
+            remainder = remainder.negated()?;
+        }
+        Some((months, remainder))
+    }
+
+    /// The DEFINITE shift this duration applies (`add`), or its inverse
+    /// (`subtract`). `None` on overflow.
+    pub(crate) fn to_definite_shift(self, subtract: bool) -> Option<ExactSeconds> {
+        let shift = self.to_exact_seconds()?;
+        if subtract {
+            shift.negated()
+        } else {
+            Some(shift)
+        }
+    }
+}
+
+// ── Calendar arithmetic (nominal rules) ──────────────────────────────────────
+
+/// The proleptic-Gregorian `(year, month, day)` for a day count since
+/// 1970-01-01 (Howard Hinnant's `civil_from_days`, the inverse of
+/// [`days_from_civil`]). `None` when the result falls outside the representable
+/// 0000–9999 year range.
+pub(crate) fn civil_from_days(days: i64) -> Option<(u32, u32, u32)> {
+    // Bound the input to the era arithmetic's safe domain before computing: the
+    // representable calendar spans roughly -719_468..=2_932_896 days.
+    if !(-4_000_000..=4_000_000).contains(&days) {
+        return None;
+    }
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097; // [0, 146096]
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365; // [0, 399]
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * doy + 2) / 153; // Mar=0 … Feb=11
+    let d = doy - (153 * mp + 2) / 5 + 1; // [1, 31]
+    let m = if mp < 10 { mp + 3 } else { mp - 9 }; // [1, 12]
+    let year = if m <= 2 { y + 1 } else { y };
+    if !REPRESENTABLE_YEARS.contains(&year) {
+        return None;
+    }
+    Some((
+        u32::try_from(year).ok()?,
+        u32::try_from(m).ok()?,
+        u32::try_from(d).ok()?,
+    ))
+}
+
+/// Shift a calendar date by a signed number of months under the NOMINAL rules
+/// of `Iso8601_date.add_nominal`: the same day in the target month, clamped
+/// down when that month is shorter (31 Jan `+ P1M` → 28/29 Feb, 29 Feb
+/// `+ P1Y` → 28 Feb). `None` when the result leaves the representable year
+/// range.
+pub(crate) fn shift_months(
+    year: u32,
+    month: u32,
+    day: u32,
+    months: i64,
+) -> Option<(u32, u32, u32)> {
+    let total = i64::from(year)
+        .checked_mul(12)?
+        .checked_add(i64::from(month) - 1)?
+        .checked_add(months)?;
+    let shifted_year = total.div_euclid(12);
+    if !REPRESENTABLE_YEARS.contains(&shifted_year) {
+        return None;
+    }
+    let shifted_year = u32::try_from(shifted_year).ok()?;
+    let shifted_month = u32::try_from(total.rem_euclid(12) + 1).ok()?;
+    let last = days_in_month(shifted_year, shifted_month)?;
+    Some((shifted_year, shifted_month, day.min(last)))
+}
+
+/// Decompose a seconds-of-day count into `(hour, minute, second)`. `None` when
+/// the count is outside `[0, 86400)`.
+pub(crate) fn hms_from_seconds_of_day(seconds: i64) -> Option<(u32, u32, u32)> {
+    if !(0..EXACT_SECONDS_IN_DAY).contains(&seconds) {
+        return None;
+    }
+    Some((
+        u32::try_from(seconds / EXACT_SECONDS_IN_HOUR).ok()?,
+        u32::try_from((seconds % EXACT_SECONDS_IN_HOUR) / EXACT_SECONDS_IN_MINUTE).ok()?,
+        u32::try_from(seconds % EXACT_SECONDS_IN_MINUTE).ok()?,
+    ))
+}
+
+// ── Rendering (extended form) ────────────────────────────────────────────────
+// NOTE: every computed result is rendered in the EXTENDED form, because
+// `master06` §Primitive Time Types states it is "strongly recommended that the
+// 'extended' form of date and time strings be used when writing and displaying
+// data". The spec does not otherwise prescribe the output spelling of a
+// computational function, so the remaining choices below (which designators a
+// computed duration uses, the timezone spelling) are our own design/extension.
+
+/// Render a date in extended form, omitting the components the value does not
+/// have (`YYYY-MM-DD`, `YYYY-MM`, `YYYY`).
+pub(crate) fn render_date_extended(year: u32, month: Option<u32>, day: Option<u32>) -> String {
+    match (month, day) {
+        (Some(m), Some(d)) => format!("{year:04}-{m:02}-{d:02}"),
+        (Some(m), None) => format!("{year:04}-{m:02}"),
+        _ => format!("{year:04}"),
+    }
+}
+
+/// Render a complete time of day in extended form
+/// (`hh:mm:ss[.fff][Z|±hh:mm]`). `frac` must already be rounded
+/// ([`ExactSeconds::rounded_to_nanos`]).
+pub(crate) fn render_time_extended(
+    hour: u32,
+    minute: u32,
+    second: u32,
+    frac: f64,
+    timezone: Option<i32>,
+) -> String {
+    format!(
+        "{hour:02}:{minute:02}:{second:02}{}{}",
+        fraction_lexeme_of(frac),
+        render_timezone_extended(timezone)
+    )
+}
+
+/// Render a timezone offset in signed minutes as an extended-form designator:
+/// `Z` for UTC, `±hh:mm` otherwise, `""` when unzoned.
+fn render_timezone_extended(timezone: Option<i32>) -> String {
+    match timezone {
+        None => String::new(),
+        Some(0) => "Z".to_owned(),
+        Some(offset) => {
+            let sign = if offset < 0 { '-' } else { '+' };
+            let magnitude = offset.abs();
+            let (hh, mm) = (magnitude / 60, magnitude % 60);
+            format!("{sign}{hh:02}:{mm:02}")
+        }
+    }
+}
+
+/// The fractional-second lexeme for an already-rounded fraction: `""` when
+/// zero, otherwise `'.'` followed by up to nine digits with trailing zeros
+/// trimmed. The decimal sign is the period, the form `master06` §Primitive
+/// Time Types recommends for written data.
+fn fraction_lexeme_of(frac: f64) -> String {
+    let nanos = (frac * NANOS_PER_SECOND).round();
+    if nanos <= 0.0 {
+        return String::new();
+    }
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)] // 0 < nanos < 1e9
+    let nanos = (nanos as u64).min(999_999_999);
+    format!(".{}", format!("{nanos:09}").trim_end_matches('0'))
+}
+
+/// Render a signed second quantity as an ISO 8601 duration in the canonical
+/// form `[-]P[nD][T[nH][nM][n[.f]S]]`, `PT0S` for zero. `None` on overflow.
+///
+/// NOTE: only the DEFINITE designators (days and below) are emitted. A computed
+/// result has passed through the `to_seconds` reduction the class doc mandates
+/// for `add`/`subtract`, which collapses years and months into their
+/// `Time_definitions` average lengths — re-deriving a `Y`/`M` component from
+/// that scalar would invent calendar structure the result no longer has. The
+/// leading `-` is the openEHR negative-duration deviation (`master06`
+/// §Primitive Time Types). No openEHR spec prescribes the output spelling —
+/// our own design/extension.
+pub(crate) fn render_duration(total: ExactSeconds) -> Option<String> {
+    let total = total.rounded_to_nanos()?;
+    // Split into sign and magnitude, undoing the floor representation.
+    let (negative, whole, frac) = if total.whole >= 0 {
+        (false, i128::from(total.whole), total.frac)
+    } else if total.frac > 0.0 {
+        (true, -(i128::from(total.whole) + 1), 1.0 - total.frac)
+    } else {
+        (true, -i128::from(total.whole), 0.0)
+    };
+    let seconds_in_day = i128::from(EXACT_SECONDS_IN_DAY);
+    let days = whole / seconds_in_day;
+    let rest = whole % seconds_in_day;
+    let hours = rest / i128::from(EXACT_SECONDS_IN_HOUR);
+    let minutes = (rest % i128::from(EXACT_SECONDS_IN_HOUR)) / i128::from(EXACT_SECONDS_IN_MINUTE);
+    let seconds = rest % i128::from(EXACT_SECONDS_IN_MINUTE);
+    let fraction = fraction_lexeme_of(frac);
+
+    let mut out = String::new();
+    if negative {
+        out.push('-');
+    }
+    out.push('P');
+    if days > 0 {
+        let _ = write!(out, "{days}D");
+    }
+    if hours > 0 || minutes > 0 || seconds > 0 || !fraction.is_empty() {
+        out.push('T');
+        if hours > 0 {
+            let _ = write!(out, "{hours}H");
+        }
+        if minutes > 0 {
+            let _ = write!(out, "{minutes}M");
+        }
+        if seconds > 0 || !fraction.is_empty() {
+            let _ = write!(out, "{seconds}{fraction}S");
+        }
+    }
+    if out.ends_with('P') {
+        out.push_str("T0S"); // the zero duration
+    }
+    Some(out)
+}
+
+// ── Extended-form re-spelling of a stored value (`as_string`) ────────────────
+
+/// The extended-form spelling of a stored date value (`Iso8601_date.as_string`:
+/// "Return string value in extended format"), or `None` when the value is not a
+/// valid date.
+pub(crate) fn as_extended_date(s: &str) -> Option<String> {
+    let d = parse_date(s)?;
+    Some(render_date_extended(d.year, d.month, d.day))
+}
+
+/// The extended-form spelling of a stored time value (`Iso8601_time.as_string`),
+/// or `None` when the value is not a valid time. Re-spelled LEXICALLY — only
+/// separators are inserted — so a partial time, the fractional-second precision
+/// and its decimal sign all survive verbatim.
+pub(crate) fn as_extended_time(s: &str) -> Option<String> {
+    parse_time(s)?; // validity gate
+    let (main, tz) = split_timezone_lexeme(s)?;
+    let (body, fraction) = split_fraction_lexeme(main);
+    let body = if body.contains(':') {
+        body.to_owned()
+    } else {
+        insert_separators(body, ':')?
+    };
+    let tz = if tz.len() == 5 {
+        insert_timezone_colon(tz)? // `±hhmm` → `±hh:mm`
+    } else {
+        tz.to_owned()
+    };
+    Some(format!("{body}{fraction}{tz}"))
+}
+
+/// The extended-form spelling of a stored date/time value
+/// (`Iso8601_date_time.as_string`), or `None` when the value is not a valid
+/// date/time.
+pub(crate) fn as_extended_date_time(s: &str) -> Option<String> {
+    parse_date_time(s)?; // validity gate
+    match s.split_once('T') {
+        Some((date, time)) => Some(format!(
+            "{}T{}",
+            as_extended_date(date)?,
+            as_extended_time(time)?
+        )),
+        None => as_extended_date(s),
+    }
+}
+
+/// Insert `separator` between every pair of characters of a compact
+/// fixed-width-pair lexeme (`hhmmss` → `hh:mm:ss`). `None` when the length is
+/// not a multiple of two.
+fn insert_separators(compact: &str, separator: char) -> Option<String> {
+    let mut out = String::new();
+    let mut at = 0;
+    while let Some(pair) = compact.get(at..at + 2) {
+        if at > 0 {
+            out.push(separator);
+        }
+        out.push_str(pair);
+        at += 2;
+    }
+    if at == compact.len() { Some(out) } else { None }
+}
+
+/// Re-spell a compact `±hhmm` timezone designator as extended `±hh:mm`.
+fn insert_timezone_colon(tz: &str) -> Option<String> {
+    Some(format!("{}:{}", tz.get(0..3)?, tz.get(3..5)?))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)] // test assertions
+mod tests {
+    use super::*;
+
+    #[test]
+    fn average_constants_are_whole_seconds() {
+        // The integer constants the arithmetic runs on ARE the spec's average
+        // lengths in seconds — pinned so a future edit cannot drift them.
+        let year = AVERAGE_DAYS_IN_YEAR * SECONDS_IN_DAY;
+        let month = AVERAGE_DAYS_IN_MONTH * SECONDS_IN_DAY;
+        assert!((year - 31_556_736.0).abs() < 1e-6);
+        assert!((month - 2_628_288.0).abs() < 1e-6);
+        assert_eq!(EXACT_SECONDS_IN_AVERAGE_YEAR, 31_556_736);
+        assert_eq!(EXACT_SECONDS_IN_AVERAGE_MONTH, 2_628_288);
+    }
+
+    #[test]
+    fn civil_day_conversion_round_trips() {
+        for (y, m, d) in [
+            (1970, 1, 1),
+            (2020, 2, 29),
+            (2021, 12, 31),
+            (0, 1, 1),
+            (9999, 12, 31),
+        ] {
+            assert_eq!(civil_from_days(days_from_civil(y, m, d)), Some((y, m, d)));
+        }
+    }
+
+    #[test]
+    fn out_of_range_days_are_unrepresentable() {
+        assert_eq!(civil_from_days(days_from_civil(9999, 12, 31) + 1), None);
+        assert_eq!(civil_from_days(days_from_civil(0, 1, 1) - 1), None);
+    }
+
+    #[test]
+    fn exact_seconds_negation_uses_floor_representation() {
+        let half = ExactSeconds::new(0, 0.5).unwrap();
+        let neg = half.negated().unwrap();
+        assert_eq!(neg.whole, -1);
+        assert!((neg.frac - 0.5).abs() < 1e-12);
+        assert_eq!(neg.negated(), Some(half));
+    }
+
+    #[test]
+    fn zero_and_signed_durations_render_canonically() {
+        assert_eq!(
+            render_duration(ExactSeconds::new(0, 0.0).unwrap()).as_deref(),
+            Some("PT0S")
+        );
+        assert_eq!(
+            render_duration(ExactSeconds::new(90_061, 0.5).unwrap()).as_deref(),
+            Some("P1DT1H1M1.5S")
+        );
+        assert_eq!(
+            render_duration(ExactSeconds::new(-1, 0.5).unwrap()).as_deref(),
+            Some("-PT0.5S")
+        );
     }
 }

--- a/crates/openehr-base/src/foundation_types/time/iso8601_time_impl.rs
+++ b/crates/openehr-base/src/foundation_types/time/iso8601_time_impl.rs
@@ -1,16 +1,32 @@
 //! Hand-written `Iso8601_time` spec behaviour: the accessor functions
-//! (`is_partial`, `minute_unknown`, `second_unknown`,
-//! `hour`/`minute`/`second`/`fractional_second`/`timezone`) and a `PartialOrd`
+//! (`is_partial`, `is_extended`, `is_decimal_sign_comma`,
+//! `has_fractional_second`, `minute_unknown`, `second_unknown`,
+//! `hour`/`minute`/`second`/`fractional_second`/`timezone`, `as_string`), the
+//! computational functions (`add`/`subtract`/`diff`) and a `PartialOrd`
 //! implementing range semantics over partial times with timezone
 //! normalisation.
 //!
 //! Spec sources (vendored):
 //! - `BASE/docs/UML/classes/org.openehr.base.foundation_types.iso8601_time.adoc`
-//!   (§Functions: the accessors; §Invariants).
+//!   (§Functions: the accessors, `as_string`, `add`/`subtract`/`diff`;
+//!   §Invariants).
 //! - `BASE/docs/UML/classes/org.openehr.base.foundation_types.time_definitions.adoc`
 //!   (§Functions `valid_second`, `valid_hour`).
 //! - `BASE/docs/foundation_types/master06-time_types.adoc` (§Primitive Time
-//!   Types: `24:00:00` disallowed anywhere).
+//!   Types: `24:00:00` disallowed anywhere; §Computational Functions: only the
+//!   definite forms exist for a time — 'year' and 'month' cannot land on a clock
+//!   face, so `Iso8601_time` declares no `add_nominal`).
+//!
+//! NOTE: arithmetic needs every component, and the openEHR spec says nothing
+//! about computing on a PARTIAL time (`hh`, `hh:mm`) — a partial (or
+//! unparseable) operand yields `None`, the same undecidable answer this
+//! module's comparison gives.
+//!
+//! NOTE: an `Iso8601_time` is a point on the clock face with no date behind it,
+//! so addition WRAPS modulo 24 h (`23:30:00 + PT1H` = `00:30:00`) and a
+//! difference is the signed distance between two clock readings, in
+//! `(-24 h, +24 h)`. No openEHR spec governs the overflow behaviour — our own
+//! design/extension, and the only one available without inventing a date.
 //!
 //! NOTE: `Time_definitions.valid_iso8601_time` prose allows a seconds field of
 //! `"00"`-`"60"` (a leap second), but the machine-checkable `valid_second`
@@ -29,7 +45,12 @@
 
 use std::cmp::Ordering;
 
-use super::iso8601_parse::{ParsedTime, parse_time, range_before, time_completion_range};
+use super::iso8601_duration::Iso8601Duration;
+use super::iso8601_parse::{
+    EXACT_SECONDS_IN_DAY, EXACT_SECONDS_IN_HOUR, EXACT_SECONDS_IN_MINUTE, ExactSeconds, ParsedTime,
+    as_extended_time, hms_from_seconds_of_day, parse_time, range_before, render_duration,
+    render_time_extended, time_completion_range,
+};
 use super::iso8601_time::Iso8601Time;
 
 impl Iso8601Time {
@@ -94,6 +115,116 @@ impl Iso8601Time {
     pub fn is_partial(&self) -> bool {
         self.parsed().is_none_or(|p| p.second.is_none())
     }
+
+    /// `Iso8601_time.is_extended`: true when the value uses `':'` separators
+    /// (and, for forms with no separator position — `hh`, and a `Z`/`±hh`
+    /// timezone — always; see the `is_extended` NOTE in `iso8601_parse.rs`). A
+    /// value that does not parse is not extended.
+    #[must_use]
+    pub fn is_extended(&self) -> bool {
+        self.parsed().is_some_and(|p| p.extended)
+    }
+
+    /// `Iso8601_time.is_decimal_sign_comma`: true when the fractional second is
+    /// written with `','` rather than `'.'`. False when the value has no
+    /// fractional part or does not parse.
+    #[must_use]
+    pub fn is_decimal_sign_comma(&self) -> bool {
+        self.parsed().is_some_and(|p| p.decimal_sign_comma)
+    }
+
+    /// `Iso8601_time.has_fractional_second`: true when the fractional-second
+    /// part is significant, i.e. the value writes one — "even if = 0.0", so
+    /// `12:00:00.0` qualifies. False when the value does not parse.
+    #[must_use]
+    pub fn has_fractional_second(&self) -> bool {
+        self.parsed().is_some_and(|p| p.fractional_second.is_some())
+    }
+
+    /// `Iso8601_time.as_string`: "Return string value in extended format" — a
+    /// compact value is re-spelled with `':'` separators (its fractional
+    /// precision, decimal sign and partial precision all preserved), an
+    /// already-extended one is returned unchanged.
+    ///
+    /// NOTE: as for `Iso8601_date.as_string`, a value that is not a valid
+    /// ISO 8601 time is returned verbatim — our own design/extension.
+    #[must_use]
+    pub fn as_string(&self) -> String {
+        as_extended_time(&self.value).unwrap_or_else(|| self.value.clone())
+    }
+
+    /// `Iso8601_time.add` (alias `'+'`): DEFINITE addition of a duration —
+    /// `a_diff` is reduced to an exact number of seconds
+    /// (`master06` §Computational Functions) and added to the clock reading,
+    /// wrapping modulo 24 h. The timezone offset is carried through unchanged.
+    ///
+    /// `None` when either value does not parse, when this time is partial, or on
+    /// arithmetic overflow.
+    #[must_use]
+    pub fn add(&self, a_diff: &Iso8601Duration) -> Option<Self> {
+        self.shifted(a_diff.parsed()?.to_definite_shift(false)?)
+    }
+
+    /// `Iso8601_time.subtract` (alias `'-'`): DEFINITE subtraction of a
+    /// duration. See [`Iso8601Time::add`].
+    ///
+    /// `None` under the same conditions as [`Iso8601Time::add`].
+    #[must_use]
+    pub fn subtract(&self, a_diff: &Iso8601Duration) -> Option<Self> {
+        self.shifted(a_diff.parsed()?.to_definite_shift(true)?)
+    }
+
+    /// `Iso8601_time.diff` (alias `'-'`): the difference `self - a_time` as an
+    /// `Iso8601_duration` — negative (the openEHR negative-duration deviation)
+    /// when `a_time` is the later clock reading. Two zoned times are compared on
+    /// the UTC axis; a zoned and an unzoned time are not comparable at all
+    /// (`None`), matching this module's ordering rule.
+    ///
+    /// `None` when either value does not parse or is partial, when exactly one
+    /// side is zoned, or on arithmetic overflow.
+    #[must_use]
+    pub fn diff(&self, a_time: &Self) -> Option<Iso8601Duration> {
+        let (a, b) = (self.parsed()?, a_time.parsed()?);
+        if a.timezone.is_some() != b.timezone.is_some() {
+            return None;
+        }
+        let total = utc_seconds_of_day(&a)?.checked_sub(utc_seconds_of_day(&b)?)?;
+        Some(Iso8601Duration {
+            value: render_duration(total)?,
+        })
+    }
+
+    /// The clock reading shifted by `shift` seconds, wrapped into a single day
+    /// and re-rendered in extended form with the original timezone.
+    fn shifted(&self, shift: ExactSeconds) -> Option<Self> {
+        let p = self.parsed()?;
+        let total = local_seconds_of_day(&p)?
+            .checked_add(shift)?
+            .rounded_to_nanos()?;
+        let (hour, minute, second) =
+            hms_from_seconds_of_day(total.whole.rem_euclid(EXACT_SECONDS_IN_DAY))?;
+        Some(Self {
+            value: render_time_extended(hour, minute, second, total.frac, p.timezone),
+        })
+    }
+}
+
+/// A complete time's seconds since local midnight, or `None` when the time is
+/// partial (arithmetic needs a complete value).
+fn local_seconds_of_day(t: &ParsedTime) -> Option<ExactSeconds> {
+    let whole = i64::from(t.hour) * EXACT_SECONDS_IN_HOUR
+        + i64::from(t.minute?) * EXACT_SECONDS_IN_MINUTE
+        + i64::from(t.second?);
+    ExactSeconds::new(whole, t.fractional_second.unwrap_or(0.0))
+}
+
+/// A complete time's seconds since midnight on the UTC axis when zoned (the same
+/// uniform shift the ordering uses), or since local midnight when unzoned. May
+/// fall outside `[0, 86400)`, which is correct for a difference.
+fn utc_seconds_of_day(t: &ParsedTime) -> Option<ExactSeconds> {
+    let local = local_seconds_of_day(t)?;
+    let offset = i64::from(t.timezone.unwrap_or(0)).checked_mul(EXACT_SECONDS_IN_MINUTE)?;
+    local.checked_sub(ExactSeconds::new(offset, 0.0)?)
 }
 
 /// Range-semantics comparison of two parsed times. `None` unless both are
@@ -133,6 +264,22 @@ mod tests {
         Iso8601Time {
             value: v.to_owned(),
         }
+    }
+
+    fn dur(v: &str) -> Iso8601Duration {
+        Iso8601Duration {
+            value: v.to_owned(),
+        }
+    }
+
+    /// The value of a computed time, or `"None"`.
+    fn value(t: Option<Iso8601Time>) -> String {
+        t.map_or_else(|| "None".to_owned(), |t| t.value)
+    }
+
+    /// The value of a computed duration, or `"None"`.
+    fn duration_value(d: Option<Iso8601Duration>) -> String {
+        d.map_or_else(|| "None".to_owned(), |d| d.value)
     }
 
     // ── full-vs-full ordering (incl. fractional seconds) ─────────────────────
@@ -277,5 +424,152 @@ mod tests {
 
         assert_eq!(time("09:30:00+02:30").timezone(), Some(150));
         assert_eq!(time("09:30:00-05:00").timezone(), Some(-300));
+    }
+
+    // ── lexical predicates / as_string ───────────────────────────────────────
+
+    #[test]
+    fn extended_and_compact_forms_are_distinguished() {
+        assert!(time("12:00:00").is_extended());
+        assert!(time("12:00").is_extended());
+        assert!(time("12").is_extended()); // no separator position at all
+        assert!(time("12:00:00Z").is_extended());
+        assert!(time("12:00:00+02").is_extended());
+        assert!(time("12:00:00+02:00").is_extended());
+        assert!(!time("120000").is_extended());
+        assert!(!time("1200").is_extended());
+        assert!(!time("12:00:00+0200").is_extended()); // compact timezone
+        assert!(!time("nonsense").is_extended());
+    }
+
+    #[test]
+    fn decimal_sign_and_fractional_second_are_reported() {
+        assert!(time("12:00:00,5").is_decimal_sign_comma());
+        assert!(!time("12:00:00.5").is_decimal_sign_comma());
+        assert!(!time("12:00:00").is_decimal_sign_comma());
+        assert!(!time("nonsense").is_decimal_sign_comma());
+
+        // "True if the fractional_second part is significant (i.e. even if = 0.0)".
+        assert!(time("12:00:00.0").has_fractional_second());
+        assert!(time("12:00:00,25").has_fractional_second());
+        assert!(!time("12:00:00").has_fractional_second());
+        assert!(!time("12:00").has_fractional_second());
+        assert!(!time("nonsense").has_fractional_second());
+    }
+
+    #[test]
+    fn as_string_returns_the_extended_form() {
+        assert_eq!(time("120000").as_string(), "12:00:00");
+        assert_eq!(time("1200").as_string(), "12:00");
+        assert_eq!(time("12").as_string(), "12");
+        assert_eq!(time("12:00:00").as_string(), "12:00:00");
+        // Precision, decimal sign and the timezone survive the re-spelling.
+        assert_eq!(time("120000,50").as_string(), "12:00:00,50");
+        assert_eq!(time("120000.500Z").as_string(), "12:00:00.500Z");
+        assert_eq!(time("120000+0200").as_string(), "12:00:00+02:00");
+        assert_eq!(time("120000+02").as_string(), "12:00:00+02");
+        // An invalid time has no extended form: verbatim.
+        assert_eq!(time("24:00:00").as_string(), "24:00:00");
+    }
+
+    // ── arithmetic (wraps on the clock face) ─────────────────────────────────
+
+    #[test]
+    fn add_wraps_past_midnight() {
+        assert_eq!(value(time("23:30:00").add(&dur("PT1H"))), "00:30:00");
+        assert_eq!(value(time("23:59:59").add(&dur("PT1S"))), "00:00:00");
+        // A whole day of duration returns the same clock reading.
+        assert_eq!(value(time("09:15:30").add(&dur("P1D"))), "09:15:30");
+        // Average_days_in_month = 30.42 ⇒ 30 days plus 10:04:48 of clock time.
+        assert_eq!(value(time("09:15:30").add(&dur("P1M"))), "19:20:18");
+    }
+
+    #[test]
+    fn subtract_wraps_before_midnight() {
+        assert_eq!(value(time("00:30:00").subtract(&dur("PT1H"))), "23:30:00");
+        assert_eq!(value(time("00:00:00").subtract(&dur("PT1S"))), "23:59:59");
+        // A negative duration added is the same as a positive one subtracted.
+        assert_eq!(value(time("00:30:00").add(&dur("-PT1H"))), "23:30:00");
+    }
+
+    #[test]
+    fn arithmetic_keeps_fractional_seconds_exact() {
+        assert_eq!(value(time("12:00:00.5").add(&dur("PT1S"))), "12:00:01.5");
+        assert_eq!(value(time("12:00:00.5").add(&dur("PT0.5S"))), "12:00:01");
+        assert_eq!(
+            value(time("12:00:01").subtract(&dur("PT0.25S"))),
+            "12:00:00.75"
+        );
+        assert_eq!(
+            value(time("00:00:00").subtract(&dur("PT0.5S"))),
+            "23:59:59.5"
+        );
+    }
+
+    #[test]
+    fn arithmetic_carries_the_timezone_through() {
+        assert_eq!(
+            value(time("12:00:00+02:00").add(&dur("PT30M"))),
+            "12:30:00+02:00"
+        );
+        assert_eq!(value(time("12:00:00Z").add(&dur("PT30M"))), "12:30:00Z");
+        // A compact timezone is canonicalised to the extended spelling.
+        assert_eq!(
+            value(time("120000+0200").add(&dur("PT30M"))),
+            "12:30:00+02:00"
+        );
+        assert_eq!(
+            value(time("12:00:00-05:30").add(&dur("PT1H"))),
+            "13:00:00-05:30"
+        );
+    }
+
+    // ── diff ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn diff_reports_the_signed_clock_distance() {
+        assert_eq!(
+            duration_value(time("12:00:00").diff(&time("09:30:00"))),
+            "PT2H30M"
+        );
+        assert_eq!(
+            duration_value(time("09:30:00").diff(&time("12:00:00"))),
+            "-PT2H30M"
+        );
+        assert_eq!(
+            duration_value(time("12:00:00").diff(&time("12:00:00"))),
+            "PT0S"
+        );
+        assert_eq!(
+            duration_value(time("12:00:01.25").diff(&time("12:00:00"))),
+            "PT1.25S"
+        );
+        assert_eq!(
+            duration_value(time("12:00:00").diff(&time("12:00:01.25"))),
+            "-PT1.25S"
+        );
+    }
+
+    #[test]
+    fn diff_normalises_two_zoned_times_and_refuses_a_mixed_pair() {
+        // 12:00Z vs 13:00+02:00 (= 11:00 UTC) ⇒ one hour later.
+        assert_eq!(
+            duration_value(time("12:00:00Z").diff(&time("13:00:00+02:00"))),
+            "PT1H"
+        );
+        assert!(time("12:00:00Z").diff(&time("12:00:00")).is_none());
+        assert!(time("12:00:00").diff(&time("12:00:00+02:00")).is_none());
+    }
+
+    // ── partial / malformed operands ─────────────────────────────────────────
+
+    #[test]
+    fn partial_and_malformed_values_have_no_arithmetic() {
+        assert!(time("12:00").add(&dur("PT1S")).is_none());
+        assert!(time("12").subtract(&dur("PT1S")).is_none());
+        assert!(time("12:00").diff(&time("12:00:00")).is_none());
+        assert!(time("12:00:00").diff(&time("12")).is_none());
+        assert!(time("24:00:00").add(&dur("PT1S")).is_none());
+        assert!(time("12:00:00").add(&dur("1H")).is_none());
     }
 }


### PR DESCRIPTION
Closes #744.

Found by the #706 audit (BASE 1.3.0 `foundation_types/master06-time_types.adoc` §Computational Functions + the four iso8601 class docs). Implements the full missing spec-function surface in the hand-written `*_impl.rs` siblings — definite arithmetic (average-length reduction per `Time_definitions`), nominal arithmetic (calendrical day-clamping per the class doc's own examples), duration algebra (multiply/divide/negative), and the remaining lexical accessors (`as_string` extended re-spelling per the class docs, `is_extended`, `is_decimal_sign_comma`, `has_fractional_second`).

Adjudications of note (all NOTE-flagged in code with citations):
- The `Iso8601_date_time.add_nominal/subtract_nominal` declared return type (`Iso8601_date`) is read as an upstream copy-paste defect — the §Computational Functions prose preserves time-of-day, so they return `Iso8601_date_time` (upstream-report candidate, recorded in the #706 audit).
- Partial-value arithmetic → `None` (spec-silent); results render extended (master06 recommendation); time arithmetic wraps mod 24 h; computed durations use definite designators only (the mandated `to_seconds` reduction).

Gates: `cargo clippy -p openehr-base --all-targets` + workspace clippy clean; `cargo nextest run -p openehr-base` 166/166 (+50 new tests incl. the 29 Feb clamp, definite-vs-nominal divergence, wrap-past-midnight, negative-diff direction). Changelog entry added.