### PR TITLE
fix(base-definitions): realize BASIC_DEFINITIONS/OPENEHR_DEFINITIONS constants + correct citations

### DIFF
--- a/crates/openehr-adl/src/assemble.rs
+++ b/crates/openehr-adl/src/assemble.rs
@@ -40,6 +40,7 @@ use openehr_am::am24::aom2::terminology::archetype_terminology::ArchetypeTermino
 use openehr_am::am24::aom2::terminology::value_set::ValueSet;
 use openehr_am::am24::beom::core::statement_set::StatementSet;
 use openehr_am::am24::resource::resource_description::ResourceDescription;
+use openehr_base::base_types::definitions::definitions_impl::LOCAL_TERMINOLOGY_ID;
 use openehr_base::prelude::{
     ResourceAnnotations, ResourceDescriptionItem, TerminologyCode, TranslationDetails, Uuid,
 };
@@ -888,9 +889,10 @@ fn strip_uri_delims(u: &str) -> String {
 fn term_code_of(v: &OdinValue) -> TerminologyCode {
     match v {
         OdinValue::TermCode(code) => parse_term_code(code),
-        other => {
-            string_of(Some(other)).map_or_else(|| term_code("local", ""), |s| parse_term_code(&s))
-        }
+        other => string_of(Some(other)).map_or_else(
+            || term_code(LOCAL_TERMINOLOGY_ID, ""),
+            |s| parse_term_code(&s),
+        ),
     }
 }
 
@@ -900,7 +902,7 @@ fn parse_term_code(raw: &str) -> TerminologyCode {
     let inner = raw.trim().trim_start_matches('[').trim_end_matches(']');
     let (terminology_part, code_string) = match inner.split_once("::") {
         Some((t, c)) => (t.to_owned(), c.to_owned()),
-        None => ("local".to_owned(), inner.to_owned()),
+        None => (LOCAL_TERMINOLOGY_ID.to_owned(), inner.to_owned()),
     };
     // Optional `(version)` suffix on the terminology id.
     let (terminology_id, terminology_version) = match terminology_part.split_once('(') {

--- a/crates/openehr-adl/src/cadl.rs
+++ b/crates/openehr-adl/src/cadl.rs
@@ -48,6 +48,7 @@ use openehr_am::am24::aom2::constraint_model::primitive::c_time::CTime;
 use openehr_am::am24::aom2::constraint_model::primitive::constraint_status::ConstraintStatus;
 use openehr_am::am24::aom2::constraint_model::sibling_order::SiblingOrder;
 use openehr_am::am24::beom::core::assertion::Assertion;
+use openehr_base::base_types::definitions::definitions_impl::LOCAL_TERMINOLOGY_ID;
 use openehr_base::prelude::{
     Cardinality, Interval, Iso8601Date, Iso8601DateTime, Iso8601Duration, Iso8601Time,
     MultiplicityInterval, PointInterval, ProperInterval, ProperIntervalData, TerminologyCode,
@@ -2730,7 +2731,7 @@ fn cstring_regex(regex: String, assumed: Option<String>) -> CString {
 /// A local (archetype-internal) at-code terminology value.
 fn local_term_code(code: &str) -> TerminologyCode {
     TerminologyCode {
-        terminology_id: "local".to_owned(),
+        terminology_id: LOCAL_TERMINOLOGY_ID.to_owned(),
         terminology_version: None,
         code_string: code.to_owned(),
         uri: None,

--- a/crates/openehr-base/src/base_types/definitions/definitions_impl.rs
+++ b/crates/openehr-base/src/base_types/definitions/definitions_impl.rs
@@ -1,0 +1,56 @@
+//! Hand-written realization of the BASE `definitions` constant-holder
+//! classes — `BASIC_DEFINITIONS` and `OPENEHR_DEFINITIONS` (which inherits
+//! it, adding `Local_terminology_id`). Both are adjudicated out of type
+//! emission (constant holders, no data — the codegen decision map), so their
+//! spec constants live here as plain module constants.
+//!
+//! Spec sources (vendored):
+//! - `BASE/docs/UML/classes/org.openehr.base.base_types.basic_definitions.adoc`
+//!   (§Constants: `CR`, `LF`, `Any_type_name`, `Regex_any_pattern`,
+//!   `Default_encoding`, `None_type_name`).
+//! - `BASE/docs/UML/classes/org.openehr.base.base_types.openehr_definitions.adoc`
+//!   (§Constants: `Local_terminology_id` = "local" — "Predefined terminology
+//!   identifier to indicate it is local to the knowledge resource in which it
+//!   occurs, e.g. an archetype").
+
+/// `BASIC_DEFINITIONS.CR` — carriage return character (`'\015'`).
+pub const CR: char = '\u{000D}';
+
+/// `BASIC_DEFINITIONS.LF` — line feed character (`'\012'`).
+pub const LF: char = '\u{000A}';
+
+/// `BASIC_DEFINITIONS.Any_type_name` — the name of the universal `Any` type.
+pub const ANY_TYPE_NAME: &str = "Any";
+
+/// `BASIC_DEFINITIONS.Regex_any_pattern` — the match-anything regex.
+pub const REGEX_ANY_PATTERN: &str = ".*";
+
+/// `BASIC_DEFINITIONS.Default_encoding` — the assumed string encoding
+/// (foundation_types master03 §Unicode: UTF-8 assumed).
+pub const DEFAULT_ENCODING: &str = "UTF-8";
+
+/// `BASIC_DEFINITIONS.None_type_name` — the name of the `None` type.
+pub const NONE_TYPE_NAME: &str = "None";
+
+/// `OPENEHR_DEFINITIONS.Local_terminology_id` — the predefined terminology
+/// identifier meaning "local to the knowledge resource in which it occurs,
+/// e.g. an archetype".
+pub const LOCAL_TERMINOLOGY_ID: &str = "local";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constants_carry_the_spec_values() {
+        // basic_definitions.adoc §Constants: octal '\015' / '\012'.
+        assert_eq!(CR as u32, 0o15);
+        assert_eq!(LF as u32, 0o12);
+        assert_eq!(ANY_TYPE_NAME, "Any");
+        assert_eq!(REGEX_ANY_PATTERN, ".*");
+        assert_eq!(DEFAULT_ENCODING, "UTF-8");
+        assert_eq!(NONE_TYPE_NAME, "None");
+        // openehr_definitions.adoc §Constants.
+        assert_eq!(LOCAL_TERMINOLOGY_ID, "local");
+    }
+}

--- a/crates/openehr-base/src/base_types/definitions/mod.rs
+++ b/crates/openehr-base/src/base_types/definitions/mod.rs
@@ -2,3 +2,6 @@
 
 pub mod validity_kind;
 pub mod version_status;
+
+// hand-written modules (spec behaviour), auto-declared:
+pub mod definitions_impl;

--- a/crates/openehr-its/src/flat/validation/leaf.rs
+++ b/crates/openehr-its/src/flat/validation/leaf.rs
@@ -10,6 +10,7 @@
 //! date/time/duration values is covered by the RM-invariant pass; precise
 //! temporal-range and precision semantics are deferred).
 
+use openehr_base::base_types::definitions::definitions_impl::LOCAL_TERMINOLOGY_ID;
 use serde_json::Value;
 
 use super::{ValidationKind, Validator};
@@ -115,7 +116,9 @@ fn check_code_lists(v: &mut Validator, instance: &Value, wt: &WebTemplateNode) {
 /// (`None` on the constraint side means the archetype-`local` terminology).
 fn terminology_matches(constraint: Option<&str>, instance: Option<&str>) -> bool {
     match constraint {
-        None | Some("local" | "") => matches!(instance, None | Some("local" | "")),
+        None | Some(LOCAL_TERMINOLOGY_ID | "") => {
+            matches!(instance, None | Some(LOCAL_TERMINOLOGY_ID | ""))
+        }
         Some(t) => instance == Some(t),
     }
 }

--- a/tools/openehr-codegen/src/plan/overrides.rs
+++ b/tools/openehr-codegen/src/plan/overrides.rs
@@ -246,13 +246,13 @@ pub(crate) const MAPPED_CLASSES: &[MappedClass] = &[
     },
     MappedClass {
         name: "BASIC_DEFINITIONS",
-        citation: "RM common (BASIC_DEFINITIONS)",
-        reason: "Constant holder; its constants become associated consts in *_impl.rs.",
+        citation: "BASE base_types.definitions (BASIC_DEFINITIONS; Base Types §Definitions Package)",
+        reason: "Constant holder; its constants live in base_types/definitions/definitions_impl.rs.",
     },
     MappedClass {
         name: "OPENEHR_DEFINITIONS",
-        citation: "RM common (OPENEHR_DEFINITIONS)",
-        reason: "Constant holder; its constants become associated consts in *_impl.rs.",
+        citation: "BASE base_types.definitions (OPENEHR_DEFINITIONS; Base Types §Definitions Package)",
+        reason: "Constant holder; its constants live in base_types/definitions/definitions_impl.rs.",
     },
 ];
 


### PR DESCRIPTION
Closes #746.

Found by the #711 audit (BASE 1.3.0 `base_types/master03-definitions_package.adoc`). Two defects in the definitions-package constant-holder adjudication:

1. Citations named `RM common`; the BASE BMM places both classes in `base_types.definitions` — corrected (same defect class as #736).
2. The adjudication's own stated realization was never written: the seven spec constants now live in the hand-written `definitions_impl.rs` (class-doc citations, values test-pinned: CR=\\015, LF=\\012, "Any", ".*", "UTF-8", "None", "local"); the generated `mod.rs` auto-declares it (regenerated, drift clean). The ADL term-code assemblers and the FLAT leaf terminology matcher now use `LOCAL_TERMINOLOGY_ID` instead of inlined `"local"` literals.

`no-changelog`: internal realization, zero wire change.

Gates: clippy (base/adl/its) clean; nextest 351/351 (base+adl) + 515/515 (its); codegen drift check exit 0.