### PR TITLE
feat(base-resource): implement AUTHORED_RESOURCE.languages_available

### DIFF
--- a/crates/openehr-base/src/resource/authored_resource_impl.rs
+++ b/crates/openehr-base/src/resource/authored_resource_impl.rs
@@ -1,0 +1,88 @@
+//! Hand-written spec functions of `AUTHORED_RESOURCE`.
+//!
+//! Spec: `BASE/docs/UML/classes/org.openehr.base.resource.authored_resource.adoc`
+//! §Functions, and `BASE/docs/resource/master02-resource_package.adoc`
+//! §Natural Languages and Translation ("The languages_available function
+//! provides a complete list of languages in the resource").
+
+use crate::resource::authored_resource::AuthoredResource;
+
+impl AuthoredResource {
+    /// `AUTHORED_RESOURCE.languages_available`: the total list of languages
+    /// available in this resource, derived from `original_language` and
+    /// `translations` (class doc §Functions). The original language is always
+    /// a member (invariant `Languages_available_valid`:
+    /// `languages_available.has (original_language)`), followed by the
+    /// translation language codes in their stored (key) order.
+    #[must_use]
+    pub fn languages_available(&self) -> Vec<&str> {
+        let mut out = vec![self.original_language.code_string.as_str()];
+        if let Some(translations) = &self.translations {
+            out.extend(translations.keys().map(String::as_str));
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::foundation_types::terminology::terminology_code::TerminologyCode;
+    use crate::resource::authored_resource::AuthoredResource;
+    use crate::resource::translation_details::TranslationDetails;
+
+    fn resource(translations: &[&str]) -> AuthoredResource {
+        AuthoredResource {
+            uid: None,
+            original_language: TerminologyCode {
+                terminology_id: "ISO_639-1".to_owned(),
+                terminology_version: None,
+                code_string: "en".to_owned(),
+                uri: None,
+            },
+            description: None,
+            is_controlled: None,
+            annotations: None,
+            translations: if translations.is_empty() {
+                None
+            } else {
+                Some(
+                    translations
+                        .iter()
+                        .map(|lang| {
+                            (
+                                (*lang).to_owned(),
+                                TranslationDetails {
+                                    language: TerminologyCode {
+                                        terminology_id: "ISO_639-1".to_owned(),
+                                        terminology_version: None,
+                                        code_string: (*lang).to_owned(),
+                                        uri: None,
+                                    },
+                                    author: std::collections::BTreeMap::new(),
+                                    accreditation: None,
+                                    other_details: None,
+                                    version_last_translated: None,
+                                    other_contributors: Vec::new(),
+                                },
+                            )
+                        })
+                        .collect(),
+                )
+            },
+        }
+    }
+
+    #[test]
+    fn original_language_only() {
+        // Languages_available_valid: the original language is always a member.
+        assert_eq!(resource(&[]).languages_available(), ["en"]);
+    }
+
+    #[test]
+    fn original_plus_translations() {
+        assert_eq!(
+            resource(&["de", "pt"]).languages_available(),
+            ["en", "de", "pt"]
+        );
+    }
+}

--- a/crates/openehr-base/src/resource/mod.rs
+++ b/crates/openehr-base/src/resource/mod.rs
@@ -5,3 +5,6 @@ pub mod resource_annotations;
 pub mod resource_description;
 pub mod resource_description_item;
 pub mod translation_details;
+
+// hand-written modules (spec behaviour), auto-declared:
+pub mod authored_resource_impl;


### PR DESCRIPTION
Closes #748.

Found by the #715 audit (BASE 1.3.0 `resource/master02-resource_package.adoc` §Natural Languages and Translation). The package's one declared spec function had no realization; now implemented in the hand-written `authored_resource_impl.rs` (class-doc-cited, `Languages_available_valid` shape honoured, tests for both branches). Generated `mod.rs` auto-declaration regenerated.

`no-changelog`: in-process spec function, no wire change.

Gates: clippy clean; `cargo nextest run -p openehr-base` 169/169.