### PR TITLE
fix(aql): coded-name node predicates decompose; TOP BACKWARD rejects with guidance

### DIFF
--- a/.claude/memory/spec-chapter-audit-programs.md
+++ b/.claude/memory/spec-chapter-audit-programs.md
@@ -5,18 +5,23 @@ metadata:
   node_type: memory
   type: feedback
   originSessionId: 871531fb-1884-468e-9033-ae616ae2eb2b
-  modified: 2026-07-29T12:41:43.440Z
+  modified: 2026-07-29T23:18:28.454Z
 ---
 
 Owner directive 2026-07-29: systematic code compliance is driven as **one
 milestone = one spec component, one issue per spec CHAPTER**, each chapter
 issue sweeping the WHOLE codebase via `/spec-audit` — the same per-unit
-discipline as the ITS-REST per-endpoint audit (#373). First instance: v3.14.0 = the BASE 1.3.0 program (#686, 29 chapter
-children). Release sequence (owner 2026-07-29, revised same day): v3.13.0 = the BASE
-audit; v4.0.0 = the admin-UI program. (CDS/GDL2 was briefly v3.13.0 but
-adjudicated OUT after a first-hand spec read: CDS is a separate
-application layer consuming the CDR, not a CDR component — #716 closed
-with the citation.)
+discipline as the ITS-REST per-endpoint audit (#373). First instance: the
+BASE 1.3.0 program (#686, 29 chapter children) = v3.13.0, **completed and
+released 2026-07-30** (8 findings, all fixed under the cadence; zero-drift
+close run 809/809; tag v3.13.0). Next: v4.0.0 = the admin-UI program.
+(CDS/GDL2 was briefly v3.13.0 but adjudicated OUT after a first-hand spec
+read: CDS is a separate application layer consuming the CDR, not a CDR
+component — #716 closed with the citation.) Per-chapter mechanics that
+worked: post the walked checklist as an issue comment (the record), tick
+body checkboxes via `gh issue edit`, close finding-free chapters by hand
+with the record; findings merge on green local gates before the next
+chapter's audit starts.
 
 **Why:** the owner considers this the best approach to reach real code
 compliance ("proper and systematically"), mirroring what worked for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,25 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **AQL coded-name node predicates match correctly.** The name term-code
+  shortcut (`[at0002, snomed_ct(3.1)::313267000]`, and the
+  `terminology::code|informational text|` form) was compared as one raw
+  token against `code_string` and could never match. It now decomposes per
+  the AQL specification's canonical expansion: `code_string` and
+  `terminology_id/value` are compared separately, the informational `|…|`
+  tail is ignored, and a bare at-code name operand asserts the archetype's
+  `local` terminology.
+
+### Changed
+
+- **`TOP n BACKWARD` is now rejected with rewrite guidance.** The deprecated
+  direction variant previously returned the *first* n rows silently. The
+  server now refuses it as an invalid query whose message shows the
+  recommended rewrite (`ORDER BY <path> DESC LIMIT n`). Plain `TOP n` and
+  `TOP n FORWARD` are unchanged.
+
 ## [3.13.0] - 2026-07-30
 
 ### Added

--- a/app/ehrbase/src/aql/analyze.rs
+++ b/app/ehrbase/src/aql/analyze.rs
@@ -537,9 +537,35 @@ fn resolve_node_name(n: &NodeNameConstraint) -> NameConstraint {
     match n {
         NodeNameConstraint::String(s) => NameConstraint::Value(s.clone()),
         NodeNameConstraint::Parameter(p) => NameConstraint::Param(param_name(p)),
-        NodeNameConstraint::TermCode(c) | NodeNameConstraint::Code(c) => {
-            NameConstraint::TermCode(c.clone())
-        }
+        NodeNameConstraint::TermCode(c) => parse_name_term_code(c),
+        // A bare at/id-code as the name operand is a term from the archetype's
+        // own terminology — the canonical expansion asserts
+        // `terminology_id/value = 'local'` (QUERY master03 §Node predicate).
+        NodeNameConstraint::Code(c) => NameConstraint::TermCode {
+            terminology: "local".to_owned(),
+            code: c.clone(),
+        },
+    }
+}
+
+/// Decompose a `terminology::code|value|` name term-code lexeme into its
+/// matching parts (QUERY master03 §Node predicate): the part before `::` is
+/// the terminology id (an optional `(version)` suffix stays part of it), the
+/// part after is the code string, and a trailing `|value|` is informational
+/// only — it takes no part in matching and is dropped.
+fn parse_name_term_code(raw: &str) -> NameConstraint {
+    let (terminology, rest) = match raw.split_once("::") {
+        Some((t, r)) => (t, r),
+        // The lexer guarantees `::` is present; keep a lossless fallback.
+        None => ("local", raw),
+    };
+    let code = match rest.split_once('|') {
+        Some((c, _informational)) => c,
+        None => rest,
+    };
+    NameConstraint::TermCode {
+        terminology: terminology.to_owned(),
+        code: code.to_owned(),
     }
 }
 

--- a/app/ehrbase/src/aql/error.rs
+++ b/app/ehrbase/src/aql/error.rs
@@ -143,6 +143,16 @@ pub enum AqlFeatureError {
     #[error("TOP and LIMIT cannot be combined in one query (QUERY §Query structure/LIMIT)")]
     TopWithLimit,
 
+    /// `TOP n BACKWARD` — the deprecated direction variant is not supported;
+    /// the reject carries the spec's own rewrite guidance
+    /// (QUERY §SELECT/TOP deprecation note).
+    #[error(
+        "TOP {0} BACKWARD is not supported: TOP is deprecated as of AQL 1.1.0 \
+         (QUERY §SELECT/TOP) — rewrite the query with the recommended form, \
+         e.g. `ORDER BY <path> DESC LIMIT {0}`"
+    )]
+    TopBackward(i64),
+
     /// A named scalar function that is not on the supported whitelist.
     /// QUERY §Functions.
     #[error("function `{0}` is not supported (QUERY §Functions)")]

--- a/app/ehrbase/src/aql/ir.rs
+++ b/app/ehrbase/src/aql/ir.rs
@@ -369,8 +369,17 @@ pub enum NameConstraint {
     Value(String),
     /// `name/value = $param`.
     Param(String),
-    /// `name/defining_code/code_string = '<code>'` (coded-name shortcut).
-    TermCode(String),
+    /// The coded-name shortcut, decomposed per its canonical expansion
+    /// (QUERY master03 §Node predicate: `[at0002, terminology::code|value|]`
+    /// ≡ `name/defining_code/code_string = '<code>' AND
+    /// name/defining_code/terminology_id/value = '<terminology>'`; the
+    /// `|value|` tail is informational and takes no part in matching).
+    TermCode {
+        /// `name/defining_code/terminology_id/value`.
+        terminology: String,
+        /// `name/defining_code/code_string`.
+        code: String,
+    },
 }
 
 /// A resolved standard predicate (`[objectPath op operand]`) on a node — the

--- a/app/ehrbase/src/aql/lower.rs
+++ b/app/ehrbase/src/aql/lower.rs
@@ -10,7 +10,7 @@
 use openehr_query::ast::{
     AggregateCall, ClassExprOperand, ColumnExpr, CompareOperand, ContainsExpr, FunctionCall,
     IdentifiedExpr, LikeOperand, MatchesOperand, OrderByExpr, SelectQuery, SortOrder, StatFunc,
-    Terminal, ValueListItem, VersionPredicate, WhereExpr,
+    Terminal, TopDirection, ValueListItem, VersionPredicate, WhereExpr,
 };
 use openehr_rm::model;
 
@@ -436,7 +436,16 @@ impl Planner {
 fn lower_limit(query: &SelectQuery) -> Result<(Option<i64>, Option<i64>, bool), AqlError> {
     let (limit, offset, limit_is_top) = match (&query.select.top, &query.limit) {
         (Some(_), Some(_)) => return Err(AqlFeatureError::TopWithLimit.into()),
-        (Some(top), None) => (Some(top.count), None, true),
+        (Some(top), None) => {
+            // `TOP n [FORWARD]` maps to `LIMIT n`; the deprecated BACKWARD
+            // direction is a typed reject carrying the spec's own rewrite
+            // guidance (QUERY §SELECT/TOP deprecation note) — never a silent
+            // first-n answer.
+            if top.direction == Some(TopDirection::Backward) {
+                return Err(AqlFeatureError::TopBackward(top.count).into());
+            }
+            (Some(top.count), None, true)
+        }
         (None, Some(limit)) => (Some(limit.limit), limit.offset, false),
         (None, None) => (None, None, false),
     };

--- a/app/ehrbase/src/aql/sql/predicate.rs
+++ b/app/ehrbase/src/aql/sql/predicate.rs
@@ -355,12 +355,22 @@ impl Builder<'_> {
         match n {
             NameConstraint::Value(s) => Ok(col(node, "name").eq(Expr::val(s.clone()))),
             NameConstraint::Param(p) => Ok(col(node, "name").eq(Expr::val(self.param_str(p)?))),
-            NameConstraint::TermCode(c) => {
-                let extract = as_text(jsonb_path(
+            // The canonical expansion of the coded-name shortcut (QUERY
+            // master03 §Node predicate): code_string AND terminology_id/value
+            // compared separately; the informational `|value|` tail was
+            // already dropped at analysis.
+            NameConstraint::TermCode { terminology, code } => {
+                let code_extract = as_text(jsonb_path(
                     col(node, "data"),
                     "$.name.defining_code.code_string",
                 ));
-                Ok(extract.eq(Expr::val(c.clone())))
+                let term_extract = as_text(jsonb_path(
+                    col(node, "data"),
+                    "$.name.defining_code.terminology_id.value",
+                ));
+                Ok(code_extract
+                    .eq(Expr::val(code.clone()))
+                    .and(term_extract.eq(Expr::val(terminology.clone()))))
             }
         }
     }

--- a/app/ehrbase/tests/aql_planner.rs
+++ b/app/ehrbase/tests/aql_planner.rs
@@ -1251,3 +1251,88 @@ fn streaming_shape_keeps_the_population_gate() {
         "the bare root keeps its queryable gate: {bare}"
     );
 }
+
+// ── coded-name node predicates (QUERY master03 §Node predicate) ──────────────
+
+/// The name term-code shortcut decomposes into its canonical expansion:
+/// `name/defining_code/code_string` AND `name/defining_code/terminology_id/value`
+/// compared separately (the spec's own example pair, master03 §Node predicate).
+#[test]
+fn name_term_code_predicate_decomposes() {
+    let ir = plan_ok(
+        "SELECT o/name/value FROM COMPOSITION c CONTAINS \
+         OBSERVATION o CONTAINS ELEMENT e[at0002, snomed_ct(3.1)::313267000]",
+    );
+    let dumped = format!("{ir:?}");
+    assert!(
+        dumped.contains("terminology: \"snomed_ct(3.1)\"")
+            && dumped.contains("code: \"313267000\""),
+        "parts decomposed (version suffix stays with the terminology): {dumped}"
+    );
+    // SQL shape: TWO fragment extractions ANDed on the constrained node (the
+    // jsonpath text itself binds as a parameter).
+    let sql = build_sql(
+        "SELECT o/name/value FROM COMPOSITION c CONTAINS \
+         OBSERVATION o CONTAINS ELEMENT e[at0002, snomed_ct(3.1)::313267000]",
+    );
+    let extracts = sql.matches(r#"jsonb_path_query_first("n2"."data""#).count();
+    assert!(
+        extracts >= 2,
+        "code_string AND terminology_id both extracted on the node: {sql}"
+    );
+}
+
+/// The informational `|value|` tail takes no part in matching — only the
+/// terminology and code land in the IR (master03: `icd10AM::F60.1|Schizoid
+/// personality disorder|`).
+#[test]
+fn name_term_code_informational_tail_dropped() {
+    let ir = plan_ok(
+        "SELECT e FROM COMPOSITION c CONTAINS \
+         ELEMENT e[at0003, icd10AM::F60.1|Schizoid personality disorder|]",
+    );
+    let dumped = format!("{ir:?}");
+    assert!(
+        dumped.contains("terminology: \"icd10AM\"") && dumped.contains("code: \"F60.1\""),
+        "parts decomposed: {dumped}"
+    );
+    assert!(
+        !dumped.contains("Schizoid"),
+        "informational tail dropped: {dumped}"
+    );
+}
+
+/// A bare at-code name operand is a term from the archetype's own terminology:
+/// the canonical expansion asserts `terminology_id/value = 'local'`
+/// (master03 §Node predicate: `[at0002 and name/defining_code/code_string='at0003'
+/// and name/defining_code/terminology_id/value='local']`).
+#[test]
+fn name_at_code_asserts_local_terminology() {
+    let ir = plan_ok("SELECT e FROM COMPOSITION c CONTAINS ELEMENT e[at0002, at0003]");
+    let dumped = format!("{ir:?}");
+    assert!(
+        dumped.contains("terminology: \"local\"") && dumped.contains("code: \"at0003\""),
+        "local terminology asserted: {dumped}"
+    );
+}
+
+/// `TOP n BACKWARD` is a typed reject carrying the spec's rewrite guidance
+/// (owner disposition on #966: the deprecated direction variant is refused
+/// loudly, never a silent first-n answer); plain `TOP n` and the default
+/// FORWARD direction keep working (QUERY §SELECT/TOP — deprecated but defined).
+#[test]
+fn top_backward_rejected_with_guidance() {
+    let e = plan_err("SELECT TOP 10 BACKWARD c/uid/value FROM COMPOSITION c");
+    let msg = e.to_string();
+    assert!(
+        matches!(e, AqlError::Feature(AqlFeatureError::TopBackward(10))),
+        "typed reject: {msg}"
+    );
+    assert!(
+        msg.contains("deprecated") && msg.contains("ORDER BY") && msg.contains("LIMIT 10"),
+        "the reject carries the rewrite guidance: {msg}"
+    );
+    // Plain TOP and the explicit default direction stay accepted.
+    plan_ok("SELECT TOP 10 c/uid/value FROM COMPOSITION c");
+    plan_ok("SELECT TOP 10 FORWARD c/uid/value FROM COMPOSITION c");
+}


### PR DESCRIPTION
Closes #965. Closes #966.

Both findings from the #755 audit (QUERY 1.1.0 `AQL/master03-syntax.adoc`):

**#965 — coded-name node predicates** (§Node predicate, canonical expansion): `NameConstraint::TermCode` is now `{terminology, code}` — analysis decomposes the lexeme (informational `|…|` tail dropped; version suffix stays with the terminology id), SQL compares `$.name.defining_code.code_string` AND `$.name.defining_code.terminology_id.value` separately, and bare at-code names assert `local`. Previously the raw token was compared to code_string alone — a predicate that could never match (silent wrong answer).

**#966 — TOP BACKWARD** (§SELECT/TOP, owner-directed disposition): the deprecated direction variant is a typed reject whose message carries the spec's recommended rewrite (`ORDER BY <path> DESC LIMIT n`); plain `TOP n`/`FORWARD` unchanged (deprecated-but-defined stays accepted; the committed conformance record's TOP cases are unaffected).

Gates: `cargo clippy -p ehrbase --all-targets` clean; `cargo nextest run -p ehrbase` 704/704 (4 new planner tests pinning the spec's own examples + both TOP branches). Changelog entries added.