### PR TITLE
fix(aql): DISTINCT+ORDER BY, date/time-function comparisons, comma-fraction timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **AQL `SELECT DISTINCT` with `ORDER BY` executes correctly.** Sorting a
+  DISTINCT projection by one of its selected columns previously failed with
+  a database error surfaced as HTTP 500; it now orders by the output column.
+  Sorting a DISTINCT projection by an expression that is not selected is a
+  clean invalid-query rejection (the AQL specification defines no semantics
+  for it) instead of a 500.
+- **AQL date/time functions work in temporal comparisons.** Comparing a
+  temporal path against `NOW()`/`CURRENT_DATE_TIME` etc. previously failed
+  with a database type error surfaced as HTTP 500; function operands now
+  join the comparison in the same coercion space as literals.
+- **Comma-fraction ISO 8601 timestamps compare correctly in AQL.** Canonical
+  `DV_DATE_TIME` values using the ISO-permitted comma decimal sign
+  (`21:22:19,501+00:00`) were silently excluded from temporal comparisons
+  (and their promoted index column stored NULL). Both the write-time
+  promotion and the query-time casts now normalize the comma form.
 - **AQL coded-name node predicates match correctly.** The name term-code
   shortcut (`[at0002, snomed_ct(3.1)::313267000]`, and the
   `terminology::code|informational text|` form) was compared as one raw

--- a/app/ehrbase/migrations/ext/0001_openehr_functions.sql
+++ b/app/ehrbase/migrations/ext/0001_openehr_functions.sql
@@ -263,10 +263,15 @@ END $$;
 -- used in DML (the write INSERT and the backfill), where STABLE is correct.
 -- Canonical DV_DATE_TIME values carrying an explicit offset/Z are
 -- TimeZone-independent.
+-- ISO 8601 permits a COMMA decimal sign on the fractional second (canonical
+-- DV_DATE_TIME values may carry it; BASE foundation_types master06), which
+-- PostgreSQL's timestamptz input rejects. A comma cannot occur elsewhere in a
+-- valid ISO timestamp, so it normalizes to the dot before the cast — matching
+-- the AQL engine's query-time normalization (app/ehrbase/src/aql/sql/value.rs).
 CREATE FUNCTION openehr_timestamp(v text) RETURNS timestamptz
 LANGUAGE plpgsql STABLE STRICT PARALLEL SAFE AS $$
 BEGIN
-    RETURN v::timestamptz;
+    RETURN replace(v, ',', '.')::timestamptz;
 EXCEPTION WHEN others THEN
     RETURN NULL;
 END;

--- a/app/ehrbase/src/aql/error.rs
+++ b/app/ehrbase/src/aql/error.rs
@@ -202,6 +202,16 @@ pub enum AnalysisError {
         minimum: i64,
     },
 
+    /// `SELECT DISTINCT` ordered by an expression that is not one of the
+    /// selected columns. QUERY master03 §DISTINCT defines no semantics for
+    /// sorting a de-duplicated projection by an unselected expression (and
+    /// the DBMS requires ORDER BY expressions to appear in the select list).
+    #[error(
+        "ORDER BY with SELECT DISTINCT must sort by a selected column \
+         (QUERY §SELECT/DISTINCT)"
+    )]
+    DistinctOrderByUnselected,
+
     /// An aggregate applied to a non-conforming input type (`SUM`/`AVG`
     /// accept Integer/Real input only — QUERY master03 §Functions/SUM, AVG).
     #[error("{func} requires a numeric (Integer/Real) input; the path selects {got}")]

--- a/app/ehrbase/src/aql/sql/predicate.rs
+++ b/app/ehrbase/src/aql/sql/predicate.rs
@@ -319,7 +319,20 @@ impl Builder<'_> {
             Operand::Path(t) => self.value_expr(t, ValueMode::Value(coercion)),
             Operand::Literal(lit) => Ok(coerce_rhs(super::expr::literal_value(lit), coercion)),
             Operand::Param(p) => Ok(coerce_rhs(self.param_value(p)?, coercion)),
-            Operand::Function { func, args } => self.scalar_fn_expr(*func, args),
+            Operand::Function { func, args } => {
+                let expr = self.scalar_fn_expr(*func, args)?;
+                // A function operand joins the comparison in the requested
+                // coercion space like any literal: the date/time functions
+                // render ISO-8601 text (QUERY master03 §Date and time
+                // functions), so a temporal comparison casts them to
+                // timestamptz exactly as it casts a temporal literal —
+                // otherwise a promoted timestamptz column has no operator
+                // against text.
+                Ok(match coercion {
+                    Coercion::Temporal => cast(expr, "timestamptz"),
+                    _ => expr,
+                })
+            }
         }
     }
 

--- a/app/ehrbase/src/aql/sql/value.rs
+++ b/app/ehrbase/src/aql/sql/value.rs
@@ -14,7 +14,7 @@ use std::fmt::Write as _;
 
 use sea_query::{Alias, Expr, ExprTrait as _, Order, Query};
 
-use crate::aql::error::{AqlError, SqlError};
+use crate::aql::error::{AnalysisError, AqlError, SqlError};
 use crate::aql::ir::{Coercion, EhrField, LeafPath, OrderKey, PathTarget, Source, VersionField};
 use crate::db::iden::Node;
 use crate::storage::promoted::{PROMOTED_LEAVES, PromotedKind};
@@ -313,6 +313,27 @@ impl Builder<'_> {
         for key in self.ir.order_by.clone() {
             let OrderKey { path, ascending } = key;
             let order = if ascending { Order::Asc } else { Order::Desc };
+            // SELECT DISTINCT: PostgreSQL requires every ORDER BY expression
+            // to appear in the select list, so a sort key that IS a selected
+            // column orders by that output column (jsonb ordering of the
+            // projected cell — numbers numeric, strings lexical), and an
+            // unselected sort key is a typed reject: QUERY master03 §DISTINCT
+            // defines no semantics for sorting a de-duplicated projection by
+            // an expression outside it.
+            if self.ir.distinct {
+                let selected = self.ir.select.iter().position(
+                    |c| matches!(&c.value, crate::aql::ir::SelectValue::Path(p) if *p == path),
+                );
+                match selected {
+                    Some(i) => {
+                        self.q.order_by(Alias::new(format!("col{i}")), order);
+                        continue;
+                    }
+                    None => {
+                        return Err(AnalysisError::DistinctOrderByUnselected.into());
+                    }
+                }
+            }
             // ORDER BY `e/ehr_id[/value]` sorts by the raw `ehr.id` uuid column,
             // not the `CAST(id AS text)` the projection reads: a UUID's canonical
             // text form is fixed-length lowercase hex (BASE base_types master05
@@ -371,8 +392,15 @@ pub(super) fn coerce_value(base: Expr, mode: ValueMode, leaf: &LeafPath) -> Expr
         // NOTE: temporal comparison casts the ISO-8601 leaf text to
         // timestamptz — precise for full timestamps; partial-precision temporals
         // (`2019`, `12:00`) are a documented gap (QUERY master03 §Built-in
-        // Types/Dates and Times).
-        ValueMode::Value(Coercion::Temporal) => cast(as_text(base), "timestamptz"),
+        // Types/Dates and Times). ISO 8601 permits a COMMA decimal sign on the
+        // fractional second (BASE foundation_types master06 — canonical
+        // DV_DATE_TIME values may carry it); PostgreSQL's timestamptz input
+        // does not, and a comma cannot occur elsewhere in a valid ISO
+        // timestamp, so it normalizes to the dot before the cast.
+        ValueMode::Value(Coercion::Temporal) => cast(
+            Expr::cust_with_exprs("replace($1, ',', '.')", [as_text(base)]),
+            "timestamptz",
+        ),
         ValueMode::Value(Coercion::Text | Coercion::Raw) => as_text(base),
         // a mixed-type (`Raw`) leaf being compared/matched against a
         // numeric literal — extract numerically, but guard on the stored jsonb
@@ -389,7 +417,12 @@ pub(super) fn coerce_rhs(value: sea_query::Value, coercion: Coercion) -> Expr {
     match coercion {
         Coercion::Magnitude => cast(Expr::val(value), "numeric"),
         Coercion::Boolean => cast(Expr::val(value), "boolean"),
-        Coercion::Temporal => cast(Expr::val(value), "timestamptz"),
+        // Comma-fraction normalization as on the leaf side (ISO 8601 permits
+        // the comma decimal sign; PostgreSQL's timestamptz input does not).
+        Coercion::Temporal => cast(
+            Expr::cust_with_exprs("replace($1, ',', '.')", [cast(Expr::val(value), "text")]),
+            "timestamptz",
+        ),
         Coercion::Text | Coercion::Raw => cast(Expr::val(value), "text"),
     }
 }

--- a/app/ehrbase/tests/service_aql.rs
+++ b/app/ehrbase/tests/service_aql.rs
@@ -1435,3 +1435,58 @@ async fn ehr_scope_binds_the_bare_ehr_source() {
         "and it is the scoped EHR"
     );
 }
+
+/// The two first-execution 500s from the #967 wire batch, reproduced at the
+/// service seam and pinned green (QUERY master03 §DISTINCT/§LIMIT and
+/// §Date/time functions): SELECT DISTINCT with ORDER BY + LIMIT, and a
+/// temporal comparison against NOW().
+#[tokio::test]
+async fn distinct_order_by_limit_and_now_comparison() {
+    let db = testkit::db().await.expect("testkit database");
+    let pool = db.pool();
+    let svc = EhrbaseService::new(pool);
+
+    let ehr_id = create_ehr(&svc).await;
+    create_comp(&svc, &ehr_id, "BP", 80.0).await;
+    create_comp(&svc, &ehr_id, "BP", 120.0).await;
+    create_comp(&svc, &ehr_id, "HR", 100.0).await;
+
+    // DISTINCT + ORDER BY + LIMIT: duplicates filter BEFORE the limit
+    // (master03 §LIMIT: "applies to remaining rows, after duplicates were
+    // filtered out"), and PG's DISTINCT/ORDER BY compatibility rule must be
+    // honoured by the generated SQL.
+    let aql = "SELECT DISTINCT c/name/value AS name \
+               FROM EHR e CONTAINS COMPOSITION c \
+               ORDER BY c/name/value ASC LIMIT 3";
+    let r = run_aql(&svc, aql, ehr_scope(&ehr_id)).await;
+    let names: Vec<&str> = rows(&r)
+        .iter()
+        .map(|row| row[0].as_str().expect("name"))
+        .collect();
+    assert_eq!(names, vec!["BP", "HR"], "2 distinct names, ordered");
+
+    // DISTINCT ordered by an UNSELECTED expression is a typed reject (no
+    // spec semantics; the DBMS forbids it) — never a 500.
+    let err = svc
+        .execute_ad_hoc_query(
+            format!(
+                "SELECT DISTINCT c/name/value FROM EHR e CONTAINS COMPOSITION c \
+                 CONTAINS OBSERVATION o[{OBS_ARCHETYPE}] ORDER BY o/{MAG_PATH}"
+            ),
+            ehr_scope(&ehr_id),
+        )
+        .await
+        .expect_err("DISTINCT + unselected sort key must be a typed reject");
+    assert!(
+        err.to_string().contains("must sort by a selected column"),
+        "typed reject, not a DB error: {err}"
+    );
+
+    // Temporal comparison against NOW(): every committed context start_time
+    // precedes the query instant (master03 §CURRENT_DATE_TIME or NOW).
+    let aql = "SELECT c/uid/value AS uid \
+               FROM EHR e CONTAINS COMPOSITION c \
+               WHERE c/context/start_time/value < NOW()";
+    let r = run_aql(&svc, aql, ehr_scope(&ehr_id)).await;
+    assert_eq!(rows(&r).len(), 3, "all compositions precede NOW()");
+}


### PR DESCRIPTION
Triage of the two `errored` rows from PR #973's first pipeline run — both 500s, both attributed to the application (spec-valid queries; a conformant server never 500s on them), plus the deeper defect the second one exposed:

1. **DISTINCT + ORDER BY** → PG's select-list rule violated by the generated SQL. Fixed: matched sort keys order by the output column; unmatched keys under DISTINCT are a typed reject (no spec semantics — QUERY master03 §DISTINCT).
2. **Temporal comparison vs NOW()** → `timestamptz < text`. Fixed: function operands take the comparison coercion like literals.
3. **Comma-fraction ISO 8601** (found underneath #2): spec-valid `21:22:19,501+00:00` values were silently un-comparable — `ext.openehr_timestamp` NULLed the promoted column and the query-time cast errored. Both paths normalize the comma (baseline edited per the pre-production rule).

Gates: clippy clean; `cargo nextest run -p ehrbase` 705/705 (new service-seam regression test over real PG). Changelog entries added. The green conformance record lands on PR #973 after this merges (combined-tree re-run).