### PR TITLE
fix(cnf-runner): declared corpus views cross-check their evaluators at validate time

### DIFF
--- a/tools/cnf-runner/src/exec/resolve.rs
+++ b/tools/cnf-runner/src/exec/resolve.rs
@@ -236,6 +236,20 @@ impl<'a> Resolver<'a> {
     /// # Errors
     /// [`ResolveError`] when the view is undeclared or its evaluator is
     /// not registered.
+    /// Every view name the evaluator match in [`Self::view`] can answer — the
+    /// single list the `corpus-integrity` validate gate cross-checks the
+    /// manifest's DECLARED views against, so a declared view without an
+    /// evaluator fails at validate time instead of at run time (#971).
+    pub const REGISTERED_VIEWS: &'static [&'static str] = &[
+        "current_state_code",
+        "signature",
+        "magnitude_ge_140_by_uid",
+        "magnitude_ge_140",
+        "systolic_ge_140_uids_asc",
+        "all_uids_asc",
+        "top3_systolic_desc_uids",
+    ];
+
     pub fn view(&mut self, key: &CorpusKey, view: &ViewName) -> Result<Value, ResolveError> {
         let entry = self
             .manifest
@@ -273,7 +287,7 @@ impl<'a> Resolver<'a> {
             // query time against committed uids — the driver substitutes the
             // captured uid list; here we return the SELECTION SPEC the
             // driver evaluates.
-            "magnitude_ge_140_by_uid" | "magnitude_ge_140" => {
+            "magnitude_ge_140_by_uid" | "magnitude_ge_140" | "systolic_ge_140_uids_asc" => {
                 Ok(serde_json::json!({ "systolic_min": 140, "order": "uid" }))
             }
             // the whole committed set, uid-ascending (bag/order anchors)

--- a/tools/cnf-runner/src/validate.rs
+++ b/tools/cnf-runner/src/validate.rs
@@ -1847,6 +1847,20 @@ fn check_corpus_integrity(set: &ArtifactSet, findings: &mut Vec<Finding>) {
                 );
             }
         }
+        // A DECLARED view must have a REGISTERED evaluator (#971): the
+        // resolver errors on an unregistered view only at RUN time, so the
+        // cross-check lives here where a dead declaration fails before any
+        // SUT is composed.
+        for (view, _) in entry.views.iter().flatten() {
+            if !crate::exec::resolve::Resolver::REGISTERED_VIEWS.contains(&view.as_str()) {
+                push(
+                    findings,
+                    CheckId::CorpusIntegrity,
+                    &who,
+                    format!("{key}: view {view} has no registered evaluator (exec::resolve)"),
+                );
+            }
+        }
     }
 }
 

--- a/tools/cnf-runner/tests/defect_rejection.rs
+++ b/tools/cnf-runner/tests/defect_rejection.rs
@@ -51,6 +51,13 @@ const DEFECTS: &[(&str, &str, &str)] = &[
         "corpus/MANIFEST.yaml",
         "load",
     ),
+    // A declared view with no registered evaluator fails corpus-integrity at
+    // validate time, never at run time (#971).
+    (
+        "corpus-view-without-evaluator.yaml",
+        "corpus/MANIFEST.yaml",
+        "corpus-integrity",
+    ),
     (
         "matrix-bad-tier.yaml",
         "vocab/capability_matrix.yaml",

--- a/tools/cnf-runner/tests/fixtures/defects/corpus-view-without-evaluator.yaml
+++ b/tools/cnf-runner/tests/fixtures/defects/corpus-view-without-evaluator.yaml
@@ -1,0 +1,8 @@
+cnf.defect.dead_view:
+  source: fixtures/nope.json
+  format: canonical-json
+  validity: { verdict: valid }
+  provenance: "seeded defect fixture — a declared view with no registered evaluator (#971)"
+  views:
+    no_such_evaluator:
+      select: "a view the resolver cannot answer"


### PR DESCRIPTION
Closes #971.

Found during the #967 batch. `systolic_ge_140_uids_asc` was declared in the corpus manifest with no registered evaluator — a run-time failure the validate gate could not see. Fixed both halves: the evaluator registered (identical selection spec to `magnitude_ge_140_by_uid`), and `Resolver::REGISTERED_VIEWS` is now the shared const the `corpus-integrity` gate cross-checks every declared view against, with a seeded defect fixture in the rejection battery proving the gate fires.

Gates: `cargo nextest run -p cnf-runner` 251/251; `cnf-runner validate` 860 cases / 0 findings. `no-changelog`: tooling-internal.