### PR TITLE
fix(aql): VERSION coded-field predicates respect their sub-paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **AQL VERSION coded-field predicates respect their sub-paths.** Predicates
+  on `commit_audit/change_type` and `lifecycle_state` compared every
+  sub-path against the stored numeric code, so the rubric form
+  (`…/value='creation'`) silently never matched. The three defined
+  sub-paths now compare correctly (`defining_code/code_string` against the
+  code, `value` against the terminology rubric, `terminology_id/value`
+  against `openehr`); other suffixes are clean invalid-query rejections.
 - **AQL `SELECT DISTINCT` with `ORDER BY` executes correctly.** Sorting a
   DISTINCT projection by one of its selected columns previously failed with
   a database error surfaced as HTTP 500; it now orders by the output column.

--- a/app/ehrbase/src/aql/analyze.rs
+++ b/app/ehrbase/src/aql/analyze.rs
@@ -379,17 +379,52 @@ fn resolve_version_field(object_path: Option<&ObjectPath>) -> Result<VersionFiel
 fn version_field_from_parts(parts: &[&str]) -> Result<VersionField, AqlError> {
     match parts {
         ["uid", ..] => Ok(VersionField::Uid),
-        ["lifecycle_state", ..] => Ok(VersionField::LifecycleState),
+        // The two CODED version fields are sub-path-sensitive: the stored
+        // representation is the numeric group code, the rubric renders from
+        // the openEHR terminology group, and the terminology id is the
+        // constant `openehr` — a flat mapping would compare the rubric form
+        // against the code and silently never match (#976).
+        ["lifecycle_state", rest @ ..] => coded_version_field(
+            rest,
+            parts,
+            VersionField::LifecycleState,
+            VersionField::LifecycleStateRubric,
+            VersionField::LifecycleStateTerminology,
+        ),
         ["contribution", ..] => Ok(VersionField::ContributionId),
-        ["commit_audit", rest @ ..] => match rest.first().copied() {
-            Some("time_committed") => Ok(VersionField::TimeCommitted),
-            Some("system_id") => Ok(VersionField::SystemId),
-            Some("change_type") => Ok(VersionField::ChangeType),
-            Some("committer") => Ok(VersionField::Committer),
-            Some("description") => Ok(VersionField::Description),
+        ["commit_audit", rest @ ..] => match rest {
+            ["time_committed", ..] => Ok(VersionField::TimeCommitted),
+            ["system_id", ..] => Ok(VersionField::SystemId),
+            ["change_type", rest2 @ ..] => coded_version_field(
+                rest2,
+                parts,
+                VersionField::ChangeType,
+                VersionField::ChangeTypeRubric,
+                VersionField::ChangeTypeTerminology,
+            ),
+            ["committer", ..] => Ok(VersionField::Committer),
+            ["description", ..] => Ok(VersionField::Description),
             _ => Err(AqlFeatureError::UnsupportedVersionPredicate(parts.join("/")).into()),
         },
         _ => Err(AqlFeatureError::UnsupportedVersionPredicate(parts.join("/")).into()),
+    }
+}
+
+/// Resolve the sub-path of a coded (DV_CODED_TEXT) version field to the
+/// representation it addresses; any other suffix — including the bare coded
+/// object, which has no defined scalar comparison form — is a typed reject.
+fn coded_version_field(
+    suffix: &[&str],
+    full: &[&str],
+    code: VersionField,
+    rubric: VersionField,
+    terminology: VersionField,
+) -> Result<VersionField, AqlError> {
+    match suffix {
+        ["defining_code", "code_string"] => Ok(code),
+        ["value"] => Ok(rubric),
+        ["defining_code", "terminology_id", "value"] => Ok(terminology),
+        _ => Err(AqlFeatureError::UnsupportedVersionPredicate(full.join("/")).into()),
     }
 }
 

--- a/app/ehrbase/src/aql/ir.rs
+++ b/app/ehrbase/src/aql/ir.rs
@@ -230,16 +230,30 @@ pub enum VersionField {
     TimeCommitted,
     /// `commit_audit/system_id`.
     SystemId,
-    /// `commit_audit/change_type[/value]`.
+    /// `commit_audit/change_type/defining_code/code_string` — the stored
+    /// numeric group code (e.g. `"249"`).
     ChangeType,
+    /// `commit_audit/change_type/value` — the rubric (e.g. `"creation"`),
+    /// rendered from the openEHR `audit_change_type` group.
+    ChangeTypeRubric,
+    /// `commit_audit/change_type/defining_code/terminology_id/value` — the
+    /// constant `openehr` terminology.
+    ChangeTypeTerminology,
     /// `commit_audit/committer[/...]`.
     Committer,
     /// `commit_audit/description[/value]`.
     Description,
     /// `contribution/id[/value]`.
     ContributionId,
-    /// `lifecycle_state[/value]`.
+    /// `lifecycle_state/defining_code/code_string` — the stored numeric
+    /// group code (e.g. `"532"`).
     LifecycleState,
+    /// `lifecycle_state/value` — the rubric (e.g. `"complete"`), rendered
+    /// from the openEHR `version_lifecycle_state` group.
+    LifecycleStateRubric,
+    /// `lifecycle_state/defining_code/terminology_id/value` — the constant
+    /// `openehr` terminology.
+    LifecycleStateTerminology,
 }
 
 /// The FROM containment tree: a boolean tree whose leaves are source operands,

--- a/app/ehrbase/src/aql/sql/value.rs
+++ b/app/ehrbase/src/aql/sql/value.rs
@@ -485,11 +485,38 @@ pub(super) fn version_field_expr(
         VersionField::TimeCommitted => col(&audit(), "time_committed"),
         VersionField::SystemId => col(&audit(), "system_id"),
         VersionField::ChangeType => col(&audit(), "change_type"),
+        // The rubric renders from the openEHR terminology group at SQL-build
+        // time (the bundle is the authority, never a hardcoded rubric — the
+        // same rule as the versioning render edge); the terminology id of
+        // both coded version fields is the constant `openehr` (#976).
+        VersionField::ChangeTypeRubric => {
+            coded_rubric_case(col(&audit(), "change_type"), "audit_change_type")
+        }
+        VersionField::ChangeTypeTerminology => Expr::val("openehr").into(),
         VersionField::Committer => col(&audit(), "committer"),
         VersionField::Description => col(&audit(), "description"),
         VersionField::ContributionId => cast(col(voa, "contribution_id"), "text"),
         VersionField::LifecycleState => col(voa, "lifecycle_state"),
+        VersionField::LifecycleStateRubric => {
+            coded_rubric_case(col(voa, "lifecycle_state"), "version_lifecycle_state")
+        }
+        VersionField::LifecycleStateTerminology => Expr::val("openehr").into(),
     }
+}
+
+/// `CASE <code_col> WHEN '<code>' THEN '<rubric>' … END` over an openEHR
+/// terminology group, generated from the vendored TERM bundle (TERM 3.1.0
+/// `openehr_terminology.xml`) — the coded version fields store the numeric
+/// group code; their `…/value` sub-path compares against the rubric.
+fn coded_rubric_case(code_col: Expr, group_id: &str) -> Expr {
+    let mut case = sea_query::CaseStatement::new();
+    for concept in openehr_term::bundle::openehr().concepts_in_group(group_id) {
+        case = case.case(
+            code_col.clone().eq(Expr::val(concept.id.clone())),
+            Expr::val(concept.rubric.clone()),
+        );
+    }
+    case.into()
 }
 
 /// The typed SQL for an EHR attribute (`ehr_id/value`, `time_created`,

--- a/app/ehrbase/tests/aql_planner.rs
+++ b/app/ehrbase/tests/aql_planner.rs
@@ -1336,3 +1336,63 @@ fn top_backward_rejected_with_guidance() {
     plan_ok("SELECT TOP 10 c/uid/value FROM COMPOSITION c");
     plan_ok("SELECT TOP 10 FORWARD c/uid/value FROM COMPOSITION c");
 }
+
+// ── coded version-field sub-paths (#976) ─────────────────────────────────────
+
+/// The coded version fields are sub-path-sensitive: `defining_code/code_string`
+/// reads the stored code column, `value` renders the rubric via a CASE over
+/// the openEHR terminology group, `defining_code/terminology_id/value` is the
+/// `openehr` constant — and any other suffix (incl. the bare coded object) is
+/// a typed reject.
+#[test]
+fn version_coded_field_subpaths() {
+    let code = build_sql(
+        "SELECT v/uid/value FROM VERSION v[commit_audit/change_type/defining_code/code_string='249'] \
+         CONTAINS COMPOSITION c",
+    );
+    assert!(
+        code.contains(r#""change_type" = CAST"#),
+        "the code form compares the stored column directly: {code}"
+    );
+
+    let rubric = build_sql(
+        "SELECT v/uid/value FROM VERSION v[commit_audit/change_type/value='creation'] \
+         CONTAINS COMPOSITION c",
+    );
+    assert!(
+        rubric.contains("CASE") && rubric.contains(r#""change_type""#),
+        "rubric renders as a CASE over the group: {rubric}"
+    );
+
+    let lifecycle_rubric = build_sql(
+        "SELECT v/uid/value FROM VERSION v[lifecycle_state/value='complete'] CONTAINS COMPOSITION c",
+    );
+    assert!(
+        lifecycle_rubric.contains("CASE") && lifecycle_rubric.contains(r#""lifecycle_state""#),
+        "lifecycle rubric CASE: {lifecycle_rubric}"
+    );
+
+    let term = build_sql(
+        "SELECT v/uid/value FROM VERSION \
+         v[commit_audit/change_type/defining_code/terminology_id/value='openehr'] \
+         CONTAINS COMPOSITION c",
+    );
+    // The terminology id is a bound constant on both sides — no column joins
+    // the comparison at all.
+    assert!(
+        !term.contains(r#""change_type""#) && term.contains("= CAST"),
+        "terminology form is a constant comparison: {term}"
+    );
+
+    // The bare coded object has no defined scalar comparison form.
+    let e = plan_err(
+        "SELECT v/uid/value FROM VERSION v[commit_audit/change_type='249'] CONTAINS COMPOSITION c",
+    );
+    assert!(
+        matches!(
+            e,
+            AqlError::Feature(AqlFeatureError::UnsupportedVersionPredicate(_))
+        ),
+        "bare coded object rejects: {e}"
+    );
+}


### PR DESCRIPTION
Closes #976.

Found while working #970 (#755 ch.3 program). `change_type/value='creation'` and every other sub-path of the two coded version fields compared against the stored numeric code — the rubric form could never match. Now sub-path-sensitive per the contract (code column / bundle-generated rubric CASE / `openehr` constant / typed reject), with planner tests pinning all four branches.

Gates: clippy clean; `cargo nextest run -p ehrbase` 706/706 (one known container-timing flake passed on retry). Changelog entry added.