### PR TITLE
release: v3.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+## [3.14.0] - 2026-07-30
+
 ### Fixed
 
 - **AQL VERSION coded-field predicates respect their sub-paths.** Predicates
@@ -3543,7 +3545,8 @@ but has not yet run in production.
   seccomp, default-deny NetworkPolicy) and golden-render validation.
 
 
-[unreleased]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.13.0...HEAD
+[unreleased]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.14.0...HEAD
+[3.14.0]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.13.0...v3.14.0
 [3.13.0]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.12.0...v3.13.0
 [3.12.0]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.11.0...v3.12.0
 [3.11.0]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.10.0...v3.11.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,5 +33,5 @@ keywords:
   - ITS-REST
   - Rust
   - PostgreSQL
-version: 3.13.0
+version: 3.14.0
 date-released: "2026-07-30"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "cnf-runner"
-version = "3.13.0"
+version = "3.14.0"
 dependencies = [
  "assert_fs",
  "base64 0.22.1",
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase"
-version = "3.13.0"
+version = "3.14.0"
 dependencies = [
  "assert_fs",
  "async-trait",
@@ -2371,7 +2371,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase-admin-ui"
-version = "3.13.0"
+version = "3.14.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2411,7 +2411,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase-rest"
-version = "3.13.0"
+version = "3.14.0"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -2463,7 +2463,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase-server"
-version = "3.13.0"
+version = "3.14.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -5238,7 +5238,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-codegen"
-version = "3.13.0"
+version = "3.14.0"
 dependencies = [
  "roxmltree",
  "serde_json",
@@ -8291,7 +8291,7 @@ dependencies = [
 
 [[package]]
 name = "testkit"
-version = "3.13.0"
+version = "3.14.0"
 dependencies = [
  "ehrbase",
  "sqlx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "3"                      # resolver v3 (edition 2024)
 members = ["crates/*", "app/*", "tools/*"]
 
 [workspace.package]
-version = "3.13.0"
+version = "3.14.0"
 edition = "2024"
 rust-version = "1.96"
 license = "Apache-2.0"

--- a/deploy/helm/ehrbase-rs/Chart.yaml
+++ b/deploy/helm/ehrbase-rs/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 # Chart versioning is independent of the application version.
 version: 3.2.0
 # The default container image tag (informational; overridable via image.tag).
-appVersion: "3.13.0"
+appVersion: "3.14.0"
 
 # PDB (policy/v1, GA 1.21), HPA (autoscaling/v2, GA 1.23), and the
 # seccompProfile pod field (GA 1.27) all resolve cleanly at 1.25+.

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.13.0"
+    app.kubernetes.io/version: "3.14.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -58,7 +58,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.13.0"
+    app.kubernetes.io/version: "3.14.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -77,7 +77,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.13.0"
+    app.kubernetes.io/version: "3.14.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
   annotations:
@@ -96,7 +96,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.13.0"
+    app.kubernetes.io/version: "3.14.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 type: Opaque
@@ -120,7 +120,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.13.0"
+    app.kubernetes.io/version: "3.14.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 type: Opaque
@@ -139,7 +139,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.13.0"
+    app.kubernetes.io/version: "3.14.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 data:
@@ -294,7 +294,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.13.0"
+    app.kubernetes.io/version: "3.14.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -321,7 +321,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.13.0"
+    app.kubernetes.io/version: "3.14.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -333,7 +333,7 @@ spec:
     metadata:
       annotations:
         # Roll pods when the rendered ehrbase.toml changes.
-        checksum/config: 159ea83982ec22534d000ff58df3dbd1a0bc7bac7689c4112217638d97599938
+        checksum/config: e83139481caee74f15100f4d341ad8bc9cec9cc7592c2f5a7beb2f51ce043fef
         prometheus.io/scrape: "true"
         prometheus.io/port: "9100"
         prometheus.io/path: "/management/prometheus"
@@ -354,7 +354,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ehrbase
-          image: "ghcr.io/rubentalstra/ehrbase-rs:3.13.0"
+          image: "ghcr.io/rubentalstra/ehrbase-rs:3.14.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -476,7 +476,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.13.0"
+    app.kubernetes.io/version: "3.14.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -509,7 +509,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.13.0"
+    app.kubernetes.io/version: "3.14.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.13.0"
+    app.kubernetes.io/version: "3.14.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -36,7 +36,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.13.0"
+    app.kubernetes.io/version: "3.14.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -55,7 +55,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.13.0"
+    app.kubernetes.io/version: "3.14.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 automountServiceAccountToken: false
@@ -69,7 +69,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.13.0"
+    app.kubernetes.io/version: "3.14.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 data:
@@ -166,7 +166,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.13.0"
+    app.kubernetes.io/version: "3.14.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -189,7 +189,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.13.0"
+    app.kubernetes.io/version: "3.14.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -202,7 +202,7 @@ spec:
     metadata:
       annotations:
         # Roll pods when the rendered ehrbase.toml changes.
-        checksum/config: 49acee1edffb7913c8a093a38c17f5f1f7f59b3c80ef44111336cf9958ca2d9a
+        checksum/config: 56de75d6888e4a5042fe21d3fac833c0992d7686661b3c7de1ccae21a36425e5
       labels:
         app.kubernetes.io/name: ehrbase-rs
         app.kubernetes.io/instance: ehrbase-rs
@@ -220,7 +220,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ehrbase
-          image: "ghcr.io/rubentalstra/ehrbase-rs:3.13.0"
+          image: "ghcr.io/rubentalstra/ehrbase-rs:3.14.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
Cuts v3.14.0 — the QUERY (AQL 1.1.0) spec-compliance milestone.

The milestone IS the #751 program (closed): all 5 AQL chapters + the examples-corpus sweep audited against the whole codebase under the fix-first cadence; 9 findings implemented and merged (#965 #966 #967 #971 #972 #974-triage #976 #969 #970); six wire-visible correctness defects fixed in the engine; the query catalogue grew 28 → 45 cases; close record 824/824 green.

Release mechanics per the changelog rule: `[Unreleased]` → `[3.14.0] - 2026-07-30` + link refs; workspace `version` 3.14.0 (+ lock); Helm `appVersion` + goldens (ALL CHECKS PASSED); `CITATION.cff` (date-released already 2026-07-30). Tag `v3.14.0` on the merge commit; milestone closes after the tag.