### PR TITLE
fix(adl14/odin): dADL reading surface aligned with master04; revision_history parses

### DIFF
--- a/.claude/memory/spec-chapter-audit-programs.md
+++ b/.claude/memory/spec-chapter-audit-programs.md
@@ -14,7 +14,11 @@ issue sweeping the WHOLE codebase via `/spec-audit` — the same per-unit
 discipline as the ITS-REST per-endpoint audit (#373). First instance: the
 BASE 1.3.0 program (#686, 29 chapter children) = v3.13.0, **completed and
 released 2026-07-30** (8 findings, all fixed under the cadence; zero-drift
-close run 809/809; tag v3.13.0). Next: v4.0.0 = the admin-UI program.
+close run 809/809; tag v3.13.0). v3.14.0 = QUERY, **completed and released 2026-07-30** (9 findings incl. six
+wire-visible engine defects the green suite had never caught; catalogue
+28→45 query cases; AMB-174/175). Queue: v3.15.0 = AM (89 children),
+v3.16.0 = LANG (41), v3.17.0 = TERM (5), v3.18.0 = RM (47), v3.19.0 = SM
+(20), then v4.0.0 = the admin-UI program.
 (CDS/GDL2 was briefly v3.13.0 but adjudicated OUT after a first-hand spec
 read: CDS is a separate application layer consuming the CDR, not a CDR
 component — #716 closed with the citation.) Per-chapter mechanics that
@@ -33,3 +37,18 @@ children (normative chapters only, front matter excluded by adjudication),
 findings as sub-issue fix issues with the [[its-audit-fix-first-cadence]]
 (all fixes from a chapter merged before the next chapter's audit starts),
 zero-drift pipeline at program close.
+
+**Refinement (owner directive 2026-07-30, applied to RM/LANG/TERM/SM —
+AM excluded as the then-active program, kept at its owner-adjudicated
+pre-split granularity):** each chapter issue decomposes further into one
+sub-issue per spec §X.Y section (a chapter with 0–1 `== ` sections stays
+the audit unit itself) — auditing a whole chapter at once risks skipping
+sections like RM common §6.3 Versioning Semantics. And every audit body is
+behaviour-explicit: a requirement is the WHOLE normative content —
+structural (classes/invariants) AND behavioural (state machines,
+procedures, identifier rules, prose semantics — normative even when no
+invariant encodes them) AND wire-visible — and the audit question is
+whether the RUNTIME BEHAVIOUR matches the text, never merely "the types
+exist" (the owner rejected wording focused on "testable code" only).
+Section counts derive from `grep '^== ' <master file>` in the vendored
+spec tree; totals filed 2026-07-30: RM 122, LANG 136, TERM 5, SM 60.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,35 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **ADL 1.4 archetypes carrying a `revision_history` section now parse and
+  upload.** The section is defined by the ADL 1.4 specification (master08
+  §Revision History Section) but was not recognised, so an entire spec-valid
+  archetype was rejected with a "expected a section header" syntax error. It
+  is now read and preserved on the 1.4 source model. (ADL 2 removed the
+  section, so it has no ADL 2 counterpart; a 1.4 upload stores the source
+  verbatim, so nothing is lost.)
+- **The dADL/ODIN reader accepts the leaf and structure forms the ADL 1.4
+  specification defines** (master04 §dADL), which were previously rejected:
+  the `<...>` empty-section marker at any level; the whole partial date/time
+  family (`yyyy-MM-ddT??:??:??`, `yyyy-MM-??T??:??:??`,
+  `yyyy-??-??T??:??:??`); integers written with an exponent (`29e6`);
+  booleans in any case (`TRUE`, `fAlSe`); `infinity` / `-infinity` / `*` as
+  unbounded interval endpoints; and local term codes (`[at0200]`) as leaf
+  values.
+- **Values that were silently mis-read are now read correctly or rejected
+  loudly.** A `(TYPE)`-cast section value is read through instead of being
+  dropped; an `|N +/- M|` domain constraint becomes the interval
+  `[N-M, N+M]` instead of collapsing to the centre; a duplicate sibling
+  attribute is a typed error naming the attribute instead of the last one
+  silently winning (rule VDATU); duplicate keys in the `language` section are
+  now reported (VOKU); and an interval used as a `_default` value is rejected
+  instead of silently becoming a null default.
+- **Multi-line string values drop their continuation-line indentation**, as
+  the specification requires (master04 §String Data), instead of carrying the
+  source file's leading whitespace into the value.
+
 ## [3.14.0] - 2026-07-30
 
 ### Fixed

--- a/app/ehrbase/src/aql/analyze.rs
+++ b/app/ehrbase/src/aql/analyze.rs
@@ -410,7 +410,7 @@ fn version_field_from_parts(parts: &[&str]) -> Result<VersionField, AqlError> {
     }
 }
 
-/// Resolve the sub-path of a coded (DV_CODED_TEXT) version field to the
+/// Resolve the sub-path of a coded (`DV_CODED_TEXT`) version field to the
 /// representation it addresses; any other suffix — including the bare coded
 /// object, which has no defined scalar comparison form — is a typed reject.
 fn coded_version_field(

--- a/app/ehrbase/src/aql/sql/value.rs
+++ b/app/ehrbase/src/aql/sql/value.rs
@@ -490,17 +490,20 @@ pub(super) fn version_field_expr(
         // same rule as the versioning render edge); the terminology id of
         // both coded version fields is the constant `openehr` (#976).
         VersionField::ChangeTypeRubric => {
-            coded_rubric_case(col(&audit(), "change_type"), "audit_change_type")
+            coded_rubric_case(&col(&audit(), "change_type"), "audit_change_type")
         }
-        VersionField::ChangeTypeTerminology => Expr::val("openehr").into(),
         VersionField::Committer => col(&audit(), "committer"),
         VersionField::Description => col(&audit(), "description"),
         VersionField::ContributionId => cast(col(voa, "contribution_id"), "text"),
         VersionField::LifecycleState => col(voa, "lifecycle_state"),
         VersionField::LifecycleStateRubric => {
-            coded_rubric_case(col(voa, "lifecycle_state"), "version_lifecycle_state")
+            coded_rubric_case(&col(voa, "lifecycle_state"), "version_lifecycle_state")
         }
-        VersionField::LifecycleStateTerminology => Expr::val("openehr").into(),
+        // Both coded version fields belong to the constant `openehr`
+        // terminology (#976).
+        VersionField::ChangeTypeTerminology | VersionField::LifecycleStateTerminology => {
+            Expr::val("openehr")
+        }
     }
 }
 
@@ -508,7 +511,7 @@ pub(super) fn version_field_expr(
 /// terminology group, generated from the vendored TERM bundle (TERM 3.1.0
 /// `openehr_terminology.xml`) — the coded version fields store the numeric
 /// group code; their `…/value` sub-path compares against the rubric.
-fn coded_rubric_case(code_col: Expr, group_id: &str) -> Expr {
+fn coded_rubric_case(code_col: &Expr, group_id: &str) -> Expr {
     let mut case = sea_query::CaseStatement::new();
     for concept in openehr_term::bundle::openehr().concepts_in_group(group_id) {
         case = case.case(

--- a/app/ehrbase/tests/resources/service/knowledge/archetypes/openEHR-EHR-OBSERVATION.revision_history.v1.adl
+++ b/app/ehrbase/tests/resources/service/knowledge/archetypes/openEHR-EHR-OBSERVATION.revision_history.v1.adl
@@ -1,0 +1,67 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-OBSERVATION.revision_history.v1
+
+concept
+	[at0000]	-- Revision history section
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	details = <
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"A spec-valid ADL 1.4 archetype carrying the optional revision_history section of master08.">
+			keywords = <"revision_history", "regression">
+		>
+	>
+	lifecycle_state = <"AuthorDraft">
+	other_details = <
+		["regression"] = <"PASS">
+	>
+
+definition
+	OBSERVATION[at0000] matches {*}	-- Revision history section
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Revision history section">
+					description = <"Root of the revision-history regression fixture.">
+				>
+			>
+		>
+	>
+
+revision_history
+	revision_history = <
+		["1.57"] = <
+			committer = <"Miriam Hanoosh">
+			committer_organisation = <"AIHW.org.au">
+			time_committed = <2004-11-02 09:31:04+1000>
+			revision = <"1.2">
+			reason = <"Added social history section">
+			change_type = <"Modification">
+		>
+		["1.1"] = <
+			committer = <"Enrico Barrios">
+			committer_organisation = <"AIHW.org.au">
+			time_committed = <2004-09-24T11:57:00+1000>
+			revision = <"1.1">
+			reason = <"Updated HbA1C test result reference">
+			change_type = <"Modification">
+		>
+		["1.0"] = <
+			committer = <"Enrico Barrios">
+			committer_organisation = <"AIHW.org.au">
+			time_committed = <2004-09-14T16:05:00+1000>
+			revision = <"1.0">
+			reason = <"Initial Writing">
+			change_type = <"Creation">
+		>
+	>

--- a/app/ehrbase/tests/service_definition.rs
+++ b/app/ehrbase/tests/service_definition.rs
@@ -30,6 +30,10 @@ const ARCHETYPE_REL: &str =
     "tests/resources/service/knowledge/archetypes/openEHR-EHR-COMPOSITION.prescription.v1.adl";
 const ARCHETYPE_ID: &str = "openEHR-EHR-COMPOSITION.prescription.v1";
 
+const REVISION_HISTORY_ARCHETYPE_REL: &str =
+    "tests/resources/service/knowledge/archetypes/openEHR-EHR-OBSERVATION.revision_history.v1.adl";
+const REVISION_HISTORY_ARCHETYPE_ID: &str = "openEHR-EHR-OBSERVATION.revision_history.v1";
+
 const OPT_REL: &str = "tests/resources/service/knowledge/IDCR Allergies List.v0.opt";
 const OPT_TEMPLATE_ID: &str = "IDCR Allergies List.v0";
 
@@ -97,6 +101,41 @@ async fn archetype_upload_get_list_match_replace_delete() {
         .expect("delete");
     assert!(!svc.has_archetype(ARCHETYPE_ID.to_owned()).await.unwrap());
     assert_eq!(svc.archetypes_count_adl14().await.unwrap(), 0);
+}
+
+/// An ADL 1.4 archetype carrying the optional `revision_history` section
+/// (`docs/specs/openehr/AM/docs/ADL1.4/master08-adl.adoc` §Revision History
+/// Section — "It is optional, and is included at the end of the archetype")
+/// is a spec-valid 1.4 source: it must validate and upload like any other.
+///
+/// The section has no landing field on the assembled AOM2 artefact by upstream
+/// decision — `AM/docs/ADL2/master01-preface.adoc` §Changes from ADL 1.4
+/// removed it "since the AOM2 uses the openEHR Base Types version of the
+/// Resource package" (SPECAM-61) — but the upload stores the 1.4 *source*
+/// verbatim, so nothing is lost on the round trip.
+#[tokio::test]
+async fn archetype_with_revision_history_section_uploads() {
+    let db = testkit::db().await.expect("testkit database");
+    let svc = EhrbaseService::new(db.pool());
+    let adl = fixture(REVISION_HISTORY_ARCHETYPE_REL);
+
+    assert!(
+        svc.valid_archetype(&adl).unwrap(),
+        "a 1.4 archetype with a revision_history section is valid"
+    );
+    svc.upload_archetype(adl.clone()).await.expect("upload");
+    assert!(
+        svc.has_archetype(REVISION_HISTORY_ARCHETYPE_ID.to_owned())
+            .await
+            .unwrap()
+    );
+    assert_eq!(
+        svc.get_archetype(REVISION_HISTORY_ARCHETYPE_ID.to_owned())
+            .await
+            .expect("get"),
+        adl,
+        "the revision_history section survives storage verbatim"
+    );
 }
 
 #[tokio::test]

--- a/crates/openehr-adl/src/assemble.rs
+++ b/crates/openehr-adl/src/assemble.rs
@@ -244,7 +244,7 @@ fn assemble_original_language(
     art: &SourceArtefact,
     errors: &mut Vec<SyntaxError>,
 ) -> TerminologyCode {
-    let Some(OdinValue::Object(map)) = art.language.as_ref() else {
+    let Some(map) = art.language.as_ref().and_then(as_object) else {
         return term_code("ISO_639-1", "en");
     };
     match map.get("original_language") {
@@ -265,9 +265,7 @@ fn assemble_original_language(
 /// `translations = <["de"] = < language=<…> author=<…> … >>` →
 /// `lang → TRANSLATION_DETAILS` (`master07.07`).
 fn assemble_translations(language: &OdinValue) -> Option<BTreeMap<String, TranslationDetails>> {
-    let OdinValue::Object(map) = language else {
-        return None;
-    };
+    let map = as_object(language)?;
     let entries = as_keyed(map.get("translations")?)?;
     let mut out = BTreeMap::new();
     for (key, value) in entries {
@@ -373,9 +371,9 @@ fn assemble_terminology(
     original_language: String,
     errors: &mut Vec<SyntaxError>,
 ) -> Box<ArchetypeTerminology> {
-    let map = match art.terminology.as_ref() {
-        Some(OdinValue::Object(m)) => Some(m),
-        Some(other) => {
+    let map = match art.terminology.as_ref().map(|t| (as_object(t), t)) {
+        Some((Some(m), _)) => Some(m),
+        Some((None, other)) => {
             errors.push(SyntaxError::at(
                 SyntaxErrorCode::Saon,
                 format!("terminology section must be an ODIN object, found {other:?}"),
@@ -507,7 +505,7 @@ fn merge_value_sets(v: &OdinValue, out: &mut BTreeMap<String, ValueSet>) {
 fn assemble_annotations(annotations: &OdinValue) -> ResourceAnnotations {
     let mut documentation: BTreeMap<String, BTreeMap<String, BTreeMap<String, String>>> =
         BTreeMap::new();
-    if let OdinValue::Object(map) = annotations {
+    if let Some(map) = as_object(annotations) {
         let top = map
             .get("documentation")
             .or_else(|| map.get("items"))
@@ -532,7 +530,7 @@ fn assemble_annotations(annotations: &OdinValue) -> ResourceAnnotations {
 /// `master07.12`).
 fn assemble_rm_overlay(rm_overlay: &OdinValue) -> RmOverlay {
     let mut rm_visibility: BTreeMap<String, RmAttributeVisibility> = BTreeMap::new();
-    if let OdinValue::Object(map) = rm_overlay
+    if let Some(map) = as_object(rm_overlay)
         && let Some(entries) = map.get("rm_visibility").and_then(as_keyed)
     {
         for (path_key, path_val) in entries {
@@ -760,15 +758,33 @@ impl From<&ArtefactMeta> for Meta {
 
 // ── ODIN accessors ────────────────────────────────────────────────────────
 
+/// Peel any `(TYPE)` casts off an ODIN value.
+///
+/// `master07.08`/`master07.13` section data carries the optional ODIN type
+/// cast of `LANG/docs/odin/master05-content` §Adding Type Information — a
+/// *dynamic-binding hint for the parser* ("Where dynamic binding occurs in the
+/// data, it must be indicated in an ODIN document"), never part of the datum.
+/// Every accessor below therefore reads straight through it: a section written
+/// `details = (Hash<RESOURCE_DESCRIPTION_ITEM,String>) <…>` assembles exactly
+/// like the uncast form, instead of silently yielding nothing. The cast itself
+/// stays on the tree in [`OdinValue::Typed`] for any caller that wants it.
+fn untyped(v: &OdinValue) -> &OdinValue {
+    let mut cur = v;
+    while let OdinValue::Typed { value, .. } = cur {
+        cur = value;
+    }
+    cur
+}
+
 fn as_object(v: &OdinValue) -> Option<&indexmap::IndexMap<String, OdinValue>> {
-    match v {
+    match untyped(v) {
         OdinValue::Object(m) => Some(m),
         _ => None,
     }
 }
 
 fn as_keyed(v: &OdinValue) -> Option<&[(OdinKey, OdinValue)]> {
-    match v {
+    match untyped(v) {
         OdinValue::KeyedList(items) => Some(items),
         _ => None,
     }
@@ -785,7 +801,7 @@ fn key_str(k: &OdinKey) -> String {
 
 /// The scalar string an ODIN leaf carries (or a single-element list's leaf).
 fn string_of(v: Option<&OdinValue>) -> Option<String> {
-    match v? {
+    match untyped(v?) {
         OdinValue::String(s)
         | OdinValue::Date(s)
         | OdinValue::Time(s)
@@ -805,7 +821,7 @@ fn string_of(v: Option<&OdinValue>) -> Option<String> {
 /// A list of strings from an ODIN `List` (or a single scalar as a one-element
 /// list), dropping the trailing open-list marker.
 fn string_list(v: &OdinValue) -> Vec<String> {
-    match v {
+    match untyped(v) {
         OdinValue::List(items) => items
             .iter()
             .filter(|x| !matches!(x, OdinValue::ListContinue))
@@ -818,7 +834,7 @@ fn string_list(v: &OdinValue) -> Vec<String> {
 /// A `key → String` map from an ODIN keyed list or object of string leaves.
 fn string_map(v: &OdinValue) -> BTreeMap<String, String> {
     let mut out = BTreeMap::new();
-    match v {
+    match untyped(v) {
         OdinValue::KeyedList(items) => {
             for (k, val) in items {
                 if let Some(s) = string_of(Some(val)) {
@@ -862,18 +878,19 @@ fn term_other_items(obj: &indexmap::IndexMap<String, OdinValue>) -> BTreeMap<Str
 /// (`master07.13` §Deprecated Terminology Section Features); returns the inner
 /// value, or `v` unchanged if there is no wrapper.
 fn unwrap_items(v: &OdinValue) -> &OdinValue {
+    let v = untyped(v);
     if let OdinValue::Object(map) = v
         && map.len() == 1
         && let Some(inner) = map.get("items")
     {
-        return inner;
+        return untyped(inner);
     }
     v
 }
 
 /// The URI string a binding value carries, stripped of ODIN `<>` delimiters.
 fn uri_string(v: &OdinValue) -> String {
-    match v {
+    match untyped(v) {
         OdinValue::Uri(u) => strip_uri_delims(u),
         OdinValue::TermCode(t) => t.clone(),
         OdinValue::PathList(ps) => ps.first().cloned().unwrap_or_default(),
@@ -887,7 +904,7 @@ fn strip_uri_delims(u: &str) -> String {
 
 /// A `TerminologyCode` from an ODIN term-code leaf (`[ISO_639-1::en]`).
 fn term_code_of(v: &OdinValue) -> TerminologyCode {
-    match v {
+    match untyped(v) {
         OdinValue::TermCode(code) => parse_term_code(code),
         other => string_of(Some(other)).map_or_else(
             || term_code(LOCAL_TERMINOLOGY_ID, ""),

--- a/crates/openehr-adl/src/cadl.rs
+++ b/crates/openehr-adl/src/cadl.rs
@@ -815,6 +815,14 @@ impl Parser<'_> {
         let _ = start;
         match openehr_lang::odin::parse(text) {
             Ok(v) => {
+                if odin_contains_interval(&v) {
+                    self.push(
+                        SyntaxErrorCode::Sdinv,
+                        "interval values are not supported in a '_default' value",
+                        start_byte..end_byte,
+                    );
+                    return Err(());
+                }
                 let mut json = odin_to_json(&v);
                 if let Some(t) = cast
                     && let serde_json::Value::Object(m) = &mut json
@@ -2753,10 +2761,23 @@ fn is_adl14_domain_type(id: &str) -> bool {
     matches!(id, "C_DV_QUANTITY" | "C_DV_ORDINAL")
 }
 
+/// Peel any `(TYPE)` casts off an ODIN value: the cast of
+/// `LANG/docs/odin/master05-content` §Adding Type Information is a
+/// dynamic-binding hint for the parser, not part of the datum, so the domain
+/// lowering reads straight through it (the cast stays on the tree for a caller
+/// that wants it).
+fn untyped(v: &OdinValue) -> &OdinValue {
+    let mut cur = v;
+    while let OdinValue::Typed { value, .. } = cur {
+        cur = value;
+    }
+    cur
+}
+
 /// Lower a parsed 1.4 inline dADL domain block into a `DV_QUANTITY`/`DV_ORDINAL`
 /// complex object. Returns `None` for an empty/unusable block (→ `SDINV`).
 fn lower_adl14_domain(rm_type: &str, odin: &OdinValue) -> Option<CObject> {
-    let OdinValue::Object(map) = odin else {
+    let OdinValue::Object(map) = untyped(odin) else {
         return None; // empty `<>` or a bare scalar — nothing to constrain.
     };
     if map.is_empty() {
@@ -2773,7 +2794,7 @@ fn lower_adl14_domain(rm_type: &str, odin: &OdinValue) -> Option<CObject> {
     // `property = <[openehr::122]>` → a `property` at-code constraint (the
     // external code is rewritten to a synthesised at-code + binding by the
     // converter).
-    if let Some(OdinValue::TermCode(tc)) = map.get("property") {
+    if let Some(OdinValue::TermCode(tc)) = map.get("property").map(untyped) {
         let constraint = tc.trim_start_matches('[').trim_end_matches(']').to_owned();
         attributes.push(cattr_single(
             "property",
@@ -2857,10 +2878,10 @@ fn domain_list_rows(list: &OdinValue) -> Vec<Vec<(String, OdinValue)>> {
     let row_of = |m: &indexmap::IndexMap<String, OdinValue>| -> Vec<(String, OdinValue)> {
         m.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
     };
-    match list {
+    match untyped(list) {
         OdinValue::KeyedList(entries) => entries
             .iter()
-            .filter_map(|(_, v)| match v {
+            .filter_map(|(_, v)| match untyped(v) {
                 OdinValue::Object(m) => Some(row_of(m)),
                 _ => None,
             })
@@ -2874,7 +2895,7 @@ fn domain_list_rows(list: &OdinValue) -> Vec<Vec<(String, OdinValue)>> {
 /// attribute name disambiguates integer-vs-real intervals (`precision` is
 /// integral, `magnitude` real).
 fn domain_value_to_primitive(attr: &str, v: &OdinValue) -> Option<CPrimitiveObject> {
-    match v {
+    match untyped(v) {
         OdinValue::String(s) => Some(CPrimitiveObject::CString(cstring_values(
             std::slice::from_ref(s),
         ))),
@@ -3070,12 +3091,13 @@ fn point_int(v: i64) -> Interval<i32> {
 }
 
 fn odin_interval_to_real(iv: &openehr_lang::odin::OdinInterval) -> Interval<f64> {
-    let (lower, li, upper, ui) = odin_range_bounds(iv, odin_as_real);
+    let (lower, li, upper, ui) = odin_range_bounds(iv, odin_as_real, |r| r);
     proper_or_point_real(lower, li, upper, ui)
 }
 
 fn odin_interval_to_int(iv: &openehr_lang::odin::OdinInterval) -> Interval<i32> {
-    let (lower, li, upper, ui) = odin_range_bounds(iv, |v| odin_as_real(v).map(real_to_i32));
+    let (lower, li, upper, ui) =
+        odin_range_bounds(iv, |v| odin_as_real(v).map(real_to_i32), real_to_i32);
     if lower == upper && lower.is_some() {
         return point_int(i64::from(lower.unwrap_or_default()));
     }
@@ -3108,10 +3130,24 @@ fn proper_or_point_real(
     }))
 }
 
+/// The `(lower, lower_included, upper, upper_included)` of an ODIN interval,
+/// each endpoint converted with `conv` (a `None` endpoint stays unbounded).
+///
+/// The `|N +/- M|` form lowers to the closed interval `[N-M, N+M]`, per
+/// `AM/docs/ADL1.4/master04-dadl` §Intervals of Ordered Primitive Types —
+/// "`|N +/-M|` -- interval of N ± M", whose worked example glosses
+/// `|5.0 +/-0.5|` as "4.5 - 5.5" — and identically
+/// `LANG/docs/odin/master07-leaf_data` §Intervals of Ordered Primitive Types.
+/// The arithmetic is done in `f64` and mapped back with `from_real`, since the
+/// AOM2 targets of this lowering (`C_REAL` / `C_INTEGER`) are numeric; a
+/// non-numeric centre or half-width (a date ± duration, which cannot be
+/// reduced without type context) yields an unbounded interval rather than a
+/// fabricated endpoint.
 #[allow(clippy::type_complexity)]
 fn odin_range_bounds<T>(
     iv: &openehr_lang::odin::OdinInterval,
     conv: impl Fn(&OdinValue) -> Option<T>,
+    from_real: impl Fn(f64) -> T,
 ) -> (Option<T>, bool, Option<T>, bool) {
     match iv {
         openehr_lang::odin::OdinInterval::Range {
@@ -3125,8 +3161,11 @@ fn odin_range_bounds<T>(
             upper.as_deref().and_then(&conv),
             *upper_included,
         ),
-        openehr_lang::odin::OdinInterval::PlusMinus { centre, .. } => {
-            (conv(centre), true, None, true)
+        openehr_lang::odin::OdinInterval::PlusMinus { centre, delta } => {
+            match (odin_as_real(centre), odin_as_real(delta)) {
+                (Some(c), Some(d)) => (Some(from_real(c - d)), true, Some(from_real(c + d)), true),
+                _ => (None, true, None, true),
+            }
         }
     }
 }
@@ -3348,13 +3387,36 @@ fn decode_string_inner(inner: &str) -> String {
     out
 }
 
+/// Whether an ODIN value tree contains an interval anywhere.
+///
+/// An interval has no canonical-JSON encoding here (see [`odin_to_json`]), so
+/// a `_default` carrying one is refused outright rather than silently reduced
+/// to `null` — the loss would turn "this default is an interval" into "this
+/// node has a null default", which no reader can tell from a real absence.
+fn odin_contains_interval(v: &openehr_lang::odin::OdinValue) -> bool {
+    use openehr_lang::odin::OdinValue;
+    match v {
+        OdinValue::Interval(_) => true,
+        OdinValue::List(items) => items.iter().any(odin_contains_interval),
+        OdinValue::Object(map) => map.values().any(odin_contains_interval),
+        OdinValue::KeyedList(items) => items.iter().any(|(_, val)| odin_contains_interval(val)),
+        OdinValue::Typed { value, .. } => odin_contains_interval(value),
+        _ => false,
+    }
+}
+
 /// Convert an [`openehr_lang::odin::OdinValue`] to canonical JSON for a
 /// `C_DEFINED_OBJECT.default_value`.
 ///
-/// NOTE: interval ODIN values are represented as `null` here (rare in
-/// definition-section default values; a fuller typed encoding lands with the
-/// template/OPT phase — no openEHR spec mandates the intermediate JSON shape,
-/// our own design).
+/// NOTE: `AOM2/master04` types `C_DEFINED_OBJECT.default_value` as an instance
+/// of the constrained RM type, and no openEHR spec mandates an intermediate
+/// JSON shape for it — the canonical-JSON encoding used here is our own
+/// design/extension. An `<>` / `<...>` empty block is a genuine "no value" and
+/// maps to `null`.
+///
+// TODO: encode ODIN interval values (`|0..5|`) as a typed default instead of
+// `null` — [`odin_contains_interval`] refuses them at the parse for now, so a
+// `_default = <|0..5|>` is an error rather than a silent null.
 fn odin_to_json(v: &openehr_lang::odin::OdinValue) -> serde_json::Value {
     use openehr_lang::odin::OdinValue;
     match v {
@@ -3728,6 +3790,54 @@ mod tests {
             }
             _ => panic!("expected DV_ORDINAL complex object"),
         }
+    }
+
+    /// `AM/docs/ADL1.4/master04-dadl` §Intervals of Ordered Primitive Types
+    /// defines `|N +/-M|` as "interval of N ± M" and glosses its own example
+    /// `|5.0 +/-0.5|` as "4.5 - 5.5" — so an inline 1.4 domain block's
+    /// `magnitude` lowers to the CLOSED interval `[N-M, N+M]`, not to the
+    /// centre alone.
+    #[test]
+    fn adl14_plus_minus_domain_interval_lowers_to_both_bounds() {
+        let cco = parse_definition_body_adl14(
+            "OBSERVATION[at0000] matches {\n\
+             value matches {\n\
+             C_DV_QUANTITY <\n\
+             list = <\n\
+             [\"1\"] = <\n\
+             magnitude = <|5.0 +/-0.5|>\n\
+             >\n\
+             >\n\
+             >\n\
+             }\n\
+             }",
+        )
+        .expect("the 1.4 inline domain block must parse");
+        let CComplexObject::CComplexObject(d) = &cco else {
+            panic!("expected a plain complex object root");
+        };
+        let CObject::CComplexObject(CComplexObject::CComplexObject(quantity)) =
+            &d.attributes[0].children[0]
+        else {
+            panic!("expected the lowered DV_QUANTITY object");
+        };
+        let magnitude = quantity
+            .attributes
+            .iter()
+            .find(|a| a.rm_attribute_name == "magnitude")
+            .expect("magnitude attribute");
+        let CObject::CReal(real) = &magnitude.children[0] else {
+            panic!("expected a C_REAL magnitude constraint");
+        };
+        let [Interval::ProperInterval(ProperInterval::ProperInterval(range))] =
+            real.constraint.as_slice()
+        else {
+            panic!("expected one proper interval, got {:?}", real.constraint);
+        };
+        assert_eq!(range.lower, Some(4.5));
+        assert_eq!(range.upper, Some(5.5));
+        assert!(range.lower_included);
+        assert!(range.upper_included);
     }
 
     #[test]

--- a/crates/openehr-adl/src/lexer.rs
+++ b/crates/openehr-adl/src/lexer.rs
@@ -193,8 +193,18 @@ pub enum Token {
 
     // ── ISO8601 date/time/duration VALUES (base_lexer.g4) ──
     /// `ISO8601_DATE_TIME` (with optional partial `??` fields / timezone).
+    ///
+    /// The `??`-partial family covers the whole set of
+    /// `AM/docs/ADL1.4/master04-dadl` §Partial Date/Times, including the
+    /// `yyyy-MM-ddT??:??:??`, `yyyy-MM-??T??:??:??` and `yyyy-??-??T??:??:??`
+    /// forms — a whole-file lex failure here would reject an artefact whose
+    /// ODIN sections `openehr_lang::odin` accepts.
     #[regex(
-        r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}(:[0-9]{2}(:([0-9]{2}([.,][0-9]+)?|\?\?))?|:\?\?:\?\?)?(Z|[+\-][0-9]{4})?",
+        r"[0-9]{4}-[0-9]{2}-[0-9]{2}T([0-9]{2}(:[0-9]{2}(:([0-9]{2}([.,][0-9]+)?|\?\?))?|:\?\?:\?\?)?|\?\?:\?\?:\?\?)(Z|[+\-][0-9]{4})?",
+        |lex| lex.slice().to_owned()
+    )]
+    #[regex(
+        r"[0-9]{4}-([0-9]{2}-\?\?|\?\?-\?\?)T\?\?:\?\?:\?\?(Z|[+\-][0-9]{4})?",
         |lex| lex.slice().to_owned()
     )]
     Iso8601DateTime(String),

--- a/crates/openehr-adl/src/source.rs
+++ b/crates/openehr-adl/src/source.rs
@@ -91,6 +91,24 @@ pub struct SourceArtefact {
     pub rm_overlay: Option<openehr_lang::odin::OdinValue>,
     /// The `component_terminologies` section (ODIN; OPT only).
     pub component_terminologies: Option<openehr_lang::odin::OdinValue>,
+    /// The ADL **1.4** `revision_history` section (ODIN;
+    /// `AM/docs/ADL1.4/master08-adl` §Revision History Section: "The revision
+    /// history section of an archetype shows the audit history of changes to
+    /// the archetype, and is expressed in dADL syntax. It is optional, and is
+    /// included at the end of the archetype").
+    ///
+    /// NOTE: it has no landing site in the assembled AOM2 model, and that is
+    /// deliberate upstream, not a generated-model gap —
+    /// `AM/docs/ADL2/master01-preface` §Changes from ADL 1.4: "the
+    /// `revision_history` section is removed, since the AOM2 uses the openEHR
+    /// Base Types version of the Resource package" (SPECAM-61 in that
+    /// specification's amendment record, and the mirroring "Remove
+    /// `revision_history` property" entry in the BASE resource amendment
+    /// record). So the section is read and preserved *here*, at the 1.4 source
+    /// level, where a caller that wants the audit history can reach it, and it
+    /// is not carried into the ADL2 artefact that
+    /// [`crate::adl14::convert`] produces.
+    pub revision_history: Option<openehr_lang::odin::OdinValue>,
     /// The `definition` (cADL) body as a raw span.
     pub definition: Option<RawSpan>,
     /// The `rules`/`invariant` body as a raw span.
@@ -154,6 +172,9 @@ enum SectionKw {
     Annotations,
     ComponentTerminologies,
     RmOverlay,
+    /// The ADL 1.4-only `revision_history` clause
+    /// (`AM/docs/ADL1.4/master08-adl` §Revision History Section).
+    RevisionHistory,
     /// The obsolete `concept` clause (`master07.09`) — recognised as a section
     /// boundary and otherwise ignored in ADL2.
     Concept,
@@ -173,6 +194,11 @@ fn classify_section(s: &str) -> Option<SectionKw> {
         "terminology" | "ontology" => Some(SectionKw::Terminology),
         "annotations" => Some(SectionKw::Annotations),
         "component_terminologies" => Some(SectionKw::ComponentTerminologies),
+        // ADL 1.4-only (`master08` §Revision History Section); removed in ADL2
+        // (`ADL2/master01-preface` §Changes from ADL 1.4). Recognised so a
+        // spec-valid 1.4 archetype carrying one parses instead of sinking on
+        // "expected a section header".
+        "revision_history" => Some(SectionKw::RevisionHistory),
         // Obsolete in ADL2 (concept derives from the HRID); recognised as a
         // boundary and ignored (`master07.09`).
         "concept" => Some(SectionKw::Concept),
@@ -304,6 +330,7 @@ impl Outer<'_> {
             annotations: None,
             rm_overlay: None,
             component_terminologies: None,
+            revision_history: None,
             definition: None,
             rules: None,
             overlays: Vec::new(),
@@ -419,6 +446,9 @@ impl Outer<'_> {
             SectionKw::ComponentTerminologies => {
                 art.component_terminologies =
                     self.parse_odin(body, header_idx, "component_terminologies");
+            }
+            SectionKw::RevisionHistory => {
+                art.revision_history = self.parse_odin(body, header_idx, "revision_history");
             }
             // The obsolete `concept` clause is consumed and ignored in ADL2.
             SectionKw::Concept | SectionKw::ArtefactBoundary => {}

--- a/crates/openehr-adl/src/validate/phase1.rs
+++ b/crates/openehr-adl/src/validate/phase1.rs
@@ -1292,9 +1292,18 @@ fn check_rule_paths(
 /// model's `BTreeMap`s already dedupe keys).
 fn check_object_key_unique(src: &SourceArtefact, issues: &mut Vec<ValidationIssue>) {
     for section in [
+        // The `language` section is keyed too — `master07.07` types
+        // `translations` as `Hash<TRANSLATION_DETAILS, String>`, so a repeated
+        // `translations = <["de"] = <…> ["de"] = <…>>` key is the same VOKU
+        // violation as a repeated terminology code, and went unreported while
+        // this section was left out of the scanned set.
+        src.language.as_ref(),
         src.description.as_ref(),
         src.terminology.as_ref(),
         src.annotations.as_ref(),
+        src.rm_overlay.as_ref(),
+        src.component_terminologies.as_ref(),
+        src.revision_history.as_ref(),
     ]
     .into_iter()
     .flatten()
@@ -1328,6 +1337,10 @@ fn check_odin_key_unique(value: &OdinValue, issues: &mut Vec<ValidationIssue>) {
                 check_odin_key_unique(val, issues);
             }
         }
+        // A `(TYPE)` cast is a parser hint, not a level of the data
+        // (`LANG/docs/odin/master05-content` §Adding Type Information) — walk
+        // through it so a cast block's keys are checked like any other.
+        OdinValue::Typed { value, .. } => check_odin_key_unique(value, issues),
         _ => {}
     }
 }

--- a/crates/openehr-adl/tests/adl14_dadl_breadth.rs
+++ b/crates/openehr-adl/tests/adl14_dadl_breadth.rs
@@ -1,0 +1,273 @@
+//! The ADL 1.4 dADL breadth regression corpus (`tests/corpus/adl14-dadl/`).
+//!
+//! Unlike every other tree under `tests/corpus/`, this one is **hand-written,
+//! not vendored** (`tests/corpus/PROVENANCE.md` §`adl14-dadl/`): the vendored
+//! `adl2-reference` library exercises only a fraction of the dADL leaf
+//! grammar, so the forms `AM/docs/ADL1.4/master04-dadl` defines but no
+//! vendored artefact uses would otherwise have no regression net.
+//!
+//! Every fixture states its expectation in its file name, the corpus
+//! convention (`tests/corpus/INVENTORY.md`), and the accepting ones repeat it
+//! in the `regression` tag. Expectations here are derived from the spec text
+//! first-hand — the citation for each construct is in the fixture beside it,
+//! and in the reader that implements it (`openehr_lang::odin`).
+//!
+//! Both twins are kept for every refusal (`.claude/rules/testing.md`): a form
+//! the reader must ACCEPT lives in the breadth fixture, and a form it must
+//! REFUSE gets its own `SDINV_*` fixture, so a reader that turns lenient fails
+//! here rather than silently mis-reading an archetype.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::path::{Path, PathBuf};
+
+use openehr_adl::assemble::{parse_artefact_adl14, regression_tag};
+use openehr_adl::error::SyntaxErrorCode;
+use openehr_adl::source::parse_source;
+use openehr_adl::validate::{Severity, validate_source_phase1_adl14};
+use openehr_lang::odin::{OdinKey, OdinValue};
+
+/// What a fixture must do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Expect {
+    /// Parses in the 1.4 dialect and validates clean under the 1.4 phase-1
+    /// subset.
+    Pass,
+    /// Refused at parse with this code.
+    Refuse(SyntaxErrorCode),
+}
+
+/// Every fixture of the tree, with its expected outcome. The coverage gate
+/// (`corpus_coverage.rs`) cross-checks this list against the filesystem.
+const FIXTURES: &[(&str, Expect)] = &[
+    ("openEHR-EHR-OBSERVATION.dadl_breadth.v1.adl", Expect::Pass),
+    (
+        "openEHR-EHR-OBSERVATION.revision_history.v1.adl",
+        Expect::Pass,
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.SDINV_default_interval.v1.adl",
+        Expect::Refuse(SyntaxErrorCode::Sdinv),
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.SDINV_duplicate_sibling_attribute.v1.adl",
+        Expect::Refuse(SyntaxErrorCode::Sdinv),
+    ),
+];
+
+fn tree() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/corpus/adl14-dadl")
+}
+
+fn read(name: &str) -> String {
+    let path = tree().join(name);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+#[test]
+fn every_fixture_meets_its_declared_outcome() {
+    for (name, expect) in FIXTURES {
+        let src = read(name);
+        match expect {
+            Expect::Pass => {
+                let archetype = parse_artefact_adl14(&src)
+                    .unwrap_or_else(|e| panic!("{name} must parse, got {e:?}"));
+                assert_eq!(
+                    regression_tag(&archetype).as_deref(),
+                    Some("PASS"),
+                    "{name}: the in-file regression tag must agree with the table"
+                );
+                let issues = validate_source_phase1_adl14(&src)
+                    .unwrap_or_else(|e| panic!("{name} must parse for validation, got {e:?}"));
+                let errors: Vec<_> = issues
+                    .iter()
+                    .filter(|i| i.severity == Severity::Error)
+                    .collect();
+                assert!(errors.is_empty(), "{name} must validate clean: {errors:?}");
+            }
+            Expect::Refuse(code) => {
+                let errs =
+                    parse_artefact_adl14(&src).expect_err(&format!("{name} must be refused"));
+                assert!(
+                    errs.iter().any(|e| e.code == *code),
+                    "{name}: expected {code:?}, got {errs:?}"
+                );
+            }
+        }
+    }
+}
+
+/// The breadth fixture's newly-accepted leaf forms land as the right
+/// [`OdinValue`]s, not merely "parses without error".
+#[test]
+fn breadth_fixture_leaf_values() {
+    let src = read("openEHR-EHR-OBSERVATION.dadl_breadth.v1.adl");
+    let art = parse_source(&src).expect("breadth fixture parses");
+    let description = art.description.as_ref().expect("description section");
+    let OdinValue::Object(desc) = description else {
+        panic!("expected an object description section");
+    };
+    let OdinValue::KeyedList(entries) = desc.get("other_details").expect("other_details") else {
+        panic!("expected a keyed other_details list");
+    };
+    let get = |key: &str| -> &OdinValue {
+        entries
+            .iter()
+            .find(|(k, _)| matches!(k, OdinKey::String(s) if s == key))
+            .map_or_else(|| panic!("other_details[{key:?}] missing"), |(_, v)| v)
+    };
+
+    // `<...>` empty sections (master04 §Empty Sections).
+    assert_eq!(get("empty_leaf"), &OdinValue::Empty);
+    assert_eq!(get("empty_block"), &OdinValue::Empty);
+    assert_eq!(
+        get("empty_cast"),
+        &OdinValue::Typed {
+            rm_type: "PENSION".to_owned(),
+            value: Box::new(OdinValue::Empty),
+        }
+    );
+
+    // Partial date/times (master04 §Partial Date/Times).
+    assert_eq!(
+        get("date_time_unknown_time"),
+        &OdinValue::DateTime("2004-06-11T??:??:??".to_owned())
+    );
+    assert_eq!(
+        get("date_time_unknown_month_day_time"),
+        &OdinValue::DateTime("2004-??-??T??:??:??".to_owned())
+    );
+
+    // Integer exponent + case-insensitive booleans (master04 §Integer Data,
+    // §Boolean Data).
+    assert_eq!(get("integer_exponent"), &OdinValue::Integer(29_000_000));
+    assert_eq!(get("boolean_upper"), &OdinValue::Boolean(true));
+    assert_eq!(get("boolean_mixed"), &OdinValue::Boolean(false));
+
+    // Local term codes as leaf values (master04 §Lists of Built-in Types).
+    assert_eq!(
+        get("local_code"),
+        &OdinValue::TermCode("[at0200]".to_owned())
+    );
+    assert_eq!(
+        get("local_code_specialised"),
+        &OdinValue::TermCode("[at0010.2]".to_owned())
+    );
+
+    // Multi-line leader removal (master04 §String Data) and `&quot;` verbatim.
+    assert_eq!(
+        get("multi_line"),
+        &OdinValue::String(
+            "And now the STORM-BLAST came, and he\nWas tyrannous and strong :\nAnd chased us south along."
+                .to_owned()
+        )
+    );
+    assert_eq!(
+        get("quoted_phrase"),
+        &OdinValue::String("what one might call a &quot;phrase&quot;.".to_owned())
+    );
+}
+
+/// Unbounded interval endpoints land as `None` bounds (master04 §Intervals of
+/// Ordered Primitive Types: `infinity` / `-infinity` / `*`).
+#[test]
+fn breadth_fixture_unbounded_intervals() {
+    let src = read("openEHR-EHR-OBSERVATION.dadl_breadth.v1.adl");
+    let art = parse_source(&src).expect("breadth fixture parses");
+    let OdinValue::Object(desc) = art.description.as_ref().expect("description") else {
+        panic!("expected an object description section");
+    };
+    let OdinValue::KeyedList(entries) = desc.get("other_details").expect("other_details") else {
+        panic!("expected a keyed other_details list");
+    };
+    let bounds = |key: &str| -> (bool, bool) {
+        let value = entries
+            .iter()
+            .find(|(k, _)| matches!(k, OdinKey::String(s) if s == key))
+            .map_or_else(|| panic!("other_details[{key:?}] missing"), |(_, v)| v);
+        let OdinValue::Interval(openehr_lang::odin::OdinInterval::Range { lower, upper, .. }) =
+            value
+        else {
+            panic!("{key}: expected a range interval, got {value:?}");
+        };
+        (lower.is_some(), upper.is_some())
+    };
+    assert_eq!(bounds("interval_to_infinity"), (true, false));
+    assert_eq!(bounds("interval_to_star"), (true, false));
+    assert_eq!(bounds("interval_from_neg_infinity"), (false, true));
+    assert_eq!(bounds("interval_int"), (true, true));
+}
+
+/// A `(TYPE)`-cast section value assembles exactly like the uncast form.
+///
+/// The cast of `AM/docs/ADL1.4/master04-dadl` §Adding Type Information (and
+/// `LANG/docs/odin/master05-content` §Adding Type Information) is a
+/// dynamic-binding hint for the parser, not part of the datum — every
+/// assemble accessor reads through it. The breadth fixture writes its
+/// `translations` block cast twice over (on the container and on the entry),
+/// so a reader that stops at the cast produces NO translations at all.
+#[test]
+fn cast_section_values_assemble_transparently() {
+    let src = read("openEHR-EHR-OBSERVATION.dadl_breadth.v1.adl");
+    let archetype = parse_artefact_adl14(&src).expect("breadth fixture parses");
+    let openehr_am::am24::aom2::archetype::archetype::Archetype::AuthoredArchetype(authored) =
+        &archetype
+    else {
+        panic!("expected an authored archetype");
+    };
+    let openehr_am::am24::aom2::archetype::authored_archetype::AuthoredArchetype::AuthoredArchetype(
+        data,
+    ) = authored.as_ref()
+    else {
+        panic!("expected a plain authored archetype");
+    };
+    let translations = data
+        .translations
+        .as_ref()
+        .expect("the cast translations block must still assemble");
+    let de = translations.get("de").expect("the `de` translation");
+    assert_eq!(de.language.code_string, "de");
+    assert_eq!(de.author.get("name").map(String::as_str), Some("Ein Autor"));
+}
+
+/// The ADL 1.4 `revision_history` section parses and is preserved on the
+/// source artefact (`AM/docs/ADL1.4/master08-adl` §Revision History Section).
+/// It has no AOM2 landing field by upstream decision —
+/// `AM/docs/ADL2/master01-preface` §Changes from ADL 1.4 removed the section
+/// "since the AOM2 uses the openEHR Base Types version of the Resource
+/// package" (SPECAM-61) — so the assertion is that the 1.4 read model keeps
+/// it, not that the assembled artefact grows a field.
+#[test]
+fn revision_history_section_is_read_and_preserved() {
+    let src = read("openEHR-EHR-OBSERVATION.revision_history.v1.adl");
+    let art = parse_source(&src).expect("revision_history fixture parses");
+    let OdinValue::Object(section) = art
+        .revision_history
+        .as_ref()
+        .expect("revision_history section retained")
+    else {
+        panic!("expected an object revision_history section");
+    };
+    let OdinValue::KeyedList(revisions) = section
+        .get("revision_history")
+        .expect("revision_history attribute")
+    else {
+        panic!("expected a keyed revision list");
+    };
+    assert_eq!(revisions.len(), 3);
+    assert_eq!(revisions[0].0, OdinKey::String("1.57".to_owned()));
+    let OdinValue::Object(first) = &revisions[0].1 else {
+        panic!("expected an object revision entry");
+    };
+    assert_eq!(
+        first.get("committer"),
+        Some(&OdinValue::String("Miriam Hanoosh".to_owned()))
+    );
+    // The spec's own example writes the timestamp with a space instead of the
+    // ISO `T` designator its own §Complete Date/Times mandates; it is accepted
+    // and normalised (see the `openehr_lang::odin` lexer NOTE).
+    assert_eq!(
+        first.get("time_committed"),
+        Some(&OdinValue::DateTime("2004-11-02T09:31:04+1000".to_owned()))
+    );
+}

--- a/crates/openehr-adl/tests/corpus/INVENTORY.md
+++ b/crates/openehr-adl/tests/corpus/INVENTORY.md
@@ -14,6 +14,11 @@ it**.
   `tools/src/test/resources/com/nedap/archie/flattener/{specexamples,siblingorder}`,
   commit `e8d92f28aca33f92ea08a826ea19f9581d579720` (2026-07-08).
 
+**One tree here is NOT vendored:** `adl14-dadl/` is hand-written from
+`docs/specs/openehr/AM/docs/ADL1.4/master04-dadl.adoc` (+ `master08-adl.adoc`
+§Revision History Section) — see `PROVENANCE.md` §`adl14-dadl/` and §11 below.
+It is excluded from the vendored file-count ratchet in `corpus_coverage.rs`.
+
 **Maintenance:** regenerate/update this file whenever the corpus is re-vendored
 (the pins above change). File counts, the code frequency table, and the gap
 lists are all derived from the tree — re-derive them, do not hand-patch.
@@ -88,6 +93,7 @@ No `.adlf` files; expected flats are not vendored (§7).
 | `validity/terminology` | 12 | 0 |
 | `flattener/specexamples` | 25 | 0 |
 | `flattener/siblingorder` | 13 | 0 |
+| `adl14-dadl` *(hand-written)* | 0 | 4 |
 
 **Flags**
 
@@ -482,3 +488,22 @@ tag in `validity/**` should be a hard coverage-gate error (only the two
    claimable.
 6. Gate keys on full path (2 duplicate basenames) and the lexer strips the BOM
    (29 files).
+
+---
+
+## 11. `adl14-dadl/` — the hand-written ADL 1.4 dADL breadth tree
+
+Not vendored (PROVENANCE.md §`adl14-dadl/`): authored from
+`docs/specs/openehr/AM/docs/ADL1.4/master04-dadl.adoc` because the vendored
+`adl2-reference` library exercises only a fraction of the dADL leaf grammar.
+File names encode the expectation, corpus-convention style; the accepting
+fixtures repeat it in the `regression` tag. Harness:
+`tests/adl14_dadl_breadth.rs` (per-file expectation table + leaf-value
+assertions).
+
+| File | Expects | Exercises |
+|---|---|---|
+| `…dadl_breadth.v1.adl` | PASS | every leaf/structure form of master04: `<...>` empty sections (leaf, nested, behind a cast), the full partial date/time family incl. `T??:??:??`, integer exponents (`29e6`), case-insensitive booleans, intervals incl. `+/-` and the `infinity`/`-infinity`/`*` endpoints, qualified and local (`[at0200]`) term codes, lists + the open-list marker, URIs, characters, multi-line strings, `&quot;` |
+| `…revision_history.v1.adl` | PASS | the master08 §Revision History Section example, incl. its space-separated timestamp |
+| `…SDINV_default_interval.v1.adl` | SDINV | an interval inside a `_default` value — refused, not silently nulled |
+| `…SDINV_duplicate_sibling_attribute.v1.adl` | SDINV | a repeated sibling attribute name (rule VDATU / master04 §General Form) |

--- a/crates/openehr-adl/tests/corpus/PROVENANCE.md
+++ b/crates/openehr-adl/tests/corpus/PROVENANCE.md
@@ -37,4 +37,20 @@
   the spec text is corrected/adjudicated (recorded here), never followed
   blindly.
 
+## `adl14-dadl/`
+
+- **Hand-written in this repository — NOT vendored.** No upstream corpus
+  exercises the breadth of the ADL 1.4 dADL leaf/structure grammar
+  (`docs/specs/openehr/AM/docs/ADL1.4/master04-dadl.adoc`), so these fixtures
+  are authored directly from that chapter (plus `master08-adl.adoc` §Revision
+  History Section for the revision-history fixture).
+- Each file name encodes its expected outcome, corpus-convention style: an
+  `SDINV_*` prefix is a refusal fixture, everything else parses and validates
+  clean and repeats that in its in-file `regression` tag.
+- Owner: `crates/openehr-adl/tests/adl14_dadl_breadth.rs` (the per-file
+  expectation table lives there; `corpus_coverage.rs` cross-checks the tree).
+- Because it is not vendored, this tree may be edited — but a fixture is only
+  ever added or corrected against the spec text, never weakened to make a
+  build pass, and the accept/refuse twins stay paired.
+
 Never hand-edit vendored fixtures; re-vendor and update the pins here.

--- a/crates/openehr-adl/tests/corpus/adl14-dadl/openEHR-EHR-OBSERVATION.SDINV_default_interval.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-dadl/openEHR-EHR-OBSERVATION.SDINV_default_interval.v1.adl
@@ -1,0 +1,52 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-OBSERVATION.SDINV_default_interval.v1
+
+concept
+	[at0000]	-- Interval default value
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	lifecycle_state = <"AuthorDraft">
+
+definition
+	OBSERVATION[at0000] matches {	-- Interval default value
+		data matches {
+			HISTORY[at0001] matches {	-- Event Series
+				events cardinality matches {1..*; unordered} matches {
+					EVENT[at0002] occurrences matches {0..*} matches {	-- Any event
+						-- An interval has no canonical-JSON default encoding, so
+						-- it is refused rather than silently reduced to null.
+						_default = (DV_QUANTITY) <
+							units = <"mm[Hg]">
+							magnitude = <|0.0..5.0|>
+						>
+					}
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Interval default value">
+					description = <"Refusal fixture: an interval as a _default value.">
+				>
+				["at0001"] = <
+					text = <"Event Series">
+					description = <"@ internal @">
+				>
+				["at0002"] = <
+					text = <"Any event">
+					description = <"Any event.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-dadl/openEHR-EHR-OBSERVATION.SDINV_duplicate_sibling_attribute.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-dadl/openEHR-EHR-OBSERVATION.SDINV_duplicate_sibling_attribute.v1.adl
@@ -1,0 +1,32 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-OBSERVATION.SDINV_duplicate_sibling_attribute.v1
+
+concept
+	[at0000]	-- Duplicate sibling attribute
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	lifecycle_state = <"AuthorDraft">
+	-- master04 §General Form: "Sibling attribute names must be unique";
+	-- LANG odin master05 rule VDATU. `lifecycle_state` is declared twice.
+	lifecycle_state = <"published">
+
+definition
+	OBSERVATION[at0000] matches {*}	-- Duplicate sibling attribute
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Duplicate sibling attribute">
+					description = <"Refusal fixture: a repeated sibling attribute name.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-dadl/openEHR-EHR-OBSERVATION.dadl_breadth.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-dadl/openEHR-EHR-OBSERVATION.dadl_breadth.v1.adl
@@ -1,0 +1,196 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-OBSERVATION.dadl_breadth.v1
+
+concept
+	[at0000]	-- dADL leaf/structure breadth
+
+language
+	original_language = <[ISO_639-1::en]>
+	-- master04 §Adding Type Information: the '(TYPE)' cast is a parser hint on
+	-- the data, so a cast section value must read exactly like the uncast form.
+	translations = (Hash<TRANSLATION_DETAILS,String>) <
+		["de"] = (TRANSLATION_DETAILS) <
+			language = <[ISO_639-1::de]>
+			author = <["name"] = <"Ein Autor">>
+		>
+	>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	details = <
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"Exercise every leaf and structure form of ADL 1.4 dADL (master04) that the shared ODIN reader must accept.">
+			keywords = <"dadl", "odin", "regression">
+			use = <"Regression fixture only.">
+		>
+	>
+	lifecycle_state = <"AuthorDraft">
+	other_details = <
+		["regression"] = <"PASS">
+
+		-- master04 §Empty Sections: "Empty sections can appear anywhere",
+		-- at internal and leaf level, and nested.
+		["empty_leaf"] = <...>
+		["empty_block"] = <>
+		["empty_nested"] = <
+			inner = <...>
+			deeper = <
+				leaf = <...>
+			>
+		>
+		["empty_cast"] = (PENSION) <...>
+
+		-- master04 §Complete Date/Times + §Partial Date/Times.
+		["date_full"] = <1919-01-23>
+		["date_no_day"] = <2004-06>
+		["date_unknown_day"] = <2004-06-??>
+		["date_unknown_month_day"] = <2004-??-??>
+		["time_full"] = <16:35:04,5>
+		["time_no_seconds"] = <08:02>
+		["time_unknown_seconds"] = <16:35:??>
+		["time_unknown_min_sec"] = <16:??:??>
+		["date_time_full"] = <2001-05-12T07:35:20+1000>
+		["date_time_no_seconds"] = <2004-06-11T10:30>
+		["date_time_hour_only"] = <2004-06-11T10>
+		["date_time_unknown_seconds"] = <2004-06-11T10:30:??>
+		["date_time_unknown_min_sec"] = <2004-06-11T10:??:??>
+		["date_time_unknown_time"] = <2004-06-11T??:??:??>
+		["date_time_unknown_day_time"] = <2004-06-??T??:??:??>
+		["date_time_unknown_month_day_time"] = <2004-??-??T??:??:??>
+		["duration"] = <P22DT4H15M0S>
+
+		-- master04 §Integer Data / §Real Data / §Boolean Data (case-insensitive)
+		-- / §Character Data.
+		["integer"] = <300000>
+		["integer_signed"] = <-25>
+		["integer_exponent"] = <29e6>
+		["real"] = <3.1415926>
+		["real_exponent"] = <6.023e23>
+		["boolean_upper"] = <TRUE>
+		["boolean_mixed"] = <fAlSe>
+		["boolean_title"] = <True>
+		["boolean_lower"] = <false>
+		["character"] = <'a'>
+
+		-- master04 §Intervals of Ordered Primitive Types, including the
+		-- infinity / -infinity / '*' endpoint markers and the '+/-' form.
+		["interval_int"] = <|0..5|>
+		["interval_real_open_upper"] = <|0.0..<1000.0|>
+		["interval_open_lower"] = <|>0..10|>
+		["interval_time"] = <|08:02..09:10|>
+		["interval_ge_date"] = <|>=1939-02-01|>
+		["interval_le"] = <|<=100|>
+		["interval_point"] = <|42|>
+		["interval_plus_minus"] = <|5.0 +/-0.5|>
+		["interval_to_infinity"] = <|0..infinity|>
+		["interval_from_neg_infinity"] = <|-infinity..0|>
+		["interval_to_star"] = <|0..*|>
+
+		-- master04 §Coded Terms + §Lists of Built-in Types (the local
+		-- '[at0200]' leaf form).
+		["term_code"] = <[icd10AM::F60.1]>
+		["term_code_versioned"] = <[snomed-ct(3.1)::2004950]>
+		["local_code"] = <[at0200]>
+		["local_code_specialised"] = <[at0010.2]>
+		["local_code_open_list"] = <[at0200], ...>
+
+		-- master04 §Lists of Built-in Types.
+		["string_list"] = <"cyan", "magenta", "yellow">
+		["integer_list"] = <1, 1, 2, 3, 5>
+		["time_list"] = <08:02, 08:35, 09:10>
+		["open_list"] = <"en", ...>
+
+		-- master04 §URIs + §String Data (multi-line leader removal, and the
+		-- '&quot;' form carried through verbatim).
+		["uri"] = <http://archetypes.are.us/home.html>
+		["multi_line"] = <"And now the STORM-BLAST came, and he
+			Was tyrannous and strong :
+			And chased us south along.">
+		["quoted_phrase"] = <"what one might call a &quot;phrase&quot;.">
+	>
+
+definition
+	OBSERVATION[at0000] matches {	-- dADL leaf/structure breadth
+		data matches {
+			HISTORY[at0001] matches {	-- Event Series
+				events cardinality matches {1..*; unordered} matches {
+					EVENT[at0002] occurrences matches {0..*} matches {	-- Any event
+						data matches {
+							ITEM_TREE[at0003] matches {	-- Tree
+								items cardinality matches {0..*; unordered} matches {
+									ELEMENT[at0004] occurrences matches {0..1} matches {	-- Measured amount
+										value matches {
+											C_DV_QUANTITY <
+												property = <[openehr::122]>
+												list = <
+													["1"] = <
+														units = <"mm[Hg]">
+														magnitude = <|0.0..1000.0|>
+													>
+												>
+											>
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"dADL leaf/structure breadth">
+					description = <"Root of the dADL breadth regression fixture.">
+				>
+				["at0001"] = <
+					text = <"Event Series">
+					description = <"@ internal @">
+				>
+				["at0002"] = <
+					text = <"Any event">
+					description = <"Any event.">
+				>
+				["at0003"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0004"] = <
+					text = <"Measured amount">
+					description = <"A measured amount, constrained by an inline 1.4 dADL domain block.">
+				>
+			>
+		>
+		["de"] = <
+			items = <
+				["at0000"] = <
+					text = <"dADL-Blattwerte">
+					description = <"Wurzel der dADL-Breiten-Regressionsvorlage.">
+				>
+				["at0001"] = <
+					text = <"Ereignisserie">
+					description = <"@ internal @">
+				>
+				["at0002"] = <
+					text = <"Beliebiges Ereignis">
+					description = <"Beliebiges Ereignis.">
+				>
+				["at0003"] = <
+					text = <"Baum">
+					description = <"@ internal @">
+				>
+				["at0004"] = <
+					text = <"Gemessene Menge">
+					description = <"Eine gemessene Menge.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-dadl/openEHR-EHR-OBSERVATION.revision_history.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-dadl/openEHR-EHR-OBSERVATION.revision_history.v1.adl
@@ -1,0 +1,67 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-OBSERVATION.revision_history.v1
+
+concept
+	[at0000]	-- Revision history section
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	details = <
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"A spec-valid ADL 1.4 archetype carrying the optional revision_history section of master08.">
+			keywords = <"revision_history", "regression">
+		>
+	>
+	lifecycle_state = <"AuthorDraft">
+	other_details = <
+		["regression"] = <"PASS">
+	>
+
+definition
+	OBSERVATION[at0000] matches {*}	-- Revision history section
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Revision history section">
+					description = <"Root of the revision-history regression fixture.">
+				>
+			>
+		>
+	>
+
+revision_history
+	revision_history = <
+		["1.57"] = <
+			committer = <"Miriam Hanoosh">
+			committer_organisation = <"AIHW.org.au">
+			time_committed = <2004-11-02 09:31:04+1000>
+			revision = <"1.2">
+			reason = <"Added social history section">
+			change_type = <"Modification">
+		>
+		["1.1"] = <
+			committer = <"Enrico Barrios">
+			committer_organisation = <"AIHW.org.au">
+			time_committed = <2004-09-24T11:57:00+1000>
+			revision = <"1.1">
+			reason = <"Updated HbA1C test result reference">
+			change_type = <"Modification">
+		>
+		["1.0"] = <
+			committer = <"Enrico Barrios">
+			committer_organisation = <"AIHW.org.au">
+			time_committed = <2004-09-14T16:05:00+1000>
+			revision = <"1.0">
+			reason = <"Initial Writing">
+			change_type = <"Creation">
+		>
+	>

--- a/crates/openehr-adl/tests/corpus_coverage.rs
+++ b/crates/openehr-adl/tests/corpus_coverage.rs
@@ -27,6 +27,11 @@
 //! | `Upgrade15` | `upgrade/upgrade_from_15/*.adls` | `legacy14_corpus.rs` (parse+validate) |
 //! | `FeaturesAdls` | `features/**/*.adls` | `corpus_{outer_parse,definition_parse,roundtrip}.rs` |
 //! | `FeaturesAdl` | `features/**/*.adl` | `legacy14_corpus.rs` (1.4-tolerant parse) |
+//! | `Adl14Dadl` | `adl14-dadl/*.adl` | `adl14_dadl_breadth.rs` (accept/refuse per fixture) |
+//!
+//! `adl14-dadl/` is the one HAND-WRITTEN tree here (`tests/corpus/PROVENANCE.md`
+//! §`adl14-dadl/`); it is counted separately so the vendored-corpus size ratchet
+//! below stays a statement about the vendored trees alone.
 
 use std::path::{Path, PathBuf};
 
@@ -47,6 +52,7 @@ enum Category {
     Upgrade15,
     FeaturesAdls,
     FeaturesAdl,
+    Adl14Dadl,
 }
 
 /// Classify a corpus source file (relative to `tests/corpus/`) into exactly one
@@ -62,6 +68,10 @@ fn classify(rel: &str, is_adl: bool) -> Option<Category> {
             return Some(Category::FlattenerSiblingOrder);
         }
         return None;
+    }
+    // The hand-written ADL 1.4 dADL breadth tree.
+    if rel.starts_with("adl14-dadl/") {
+        return Some(Category::Adl14Dadl);
     }
     // adl2-reference fixtures.
     let r = rel.strip_prefix("adl2-reference/")?;
@@ -128,18 +138,28 @@ fn every_corpus_source_is_claimed_by_exactly_one_harness() {
     // The ADL fixture trees (the `rm/` subtree is the vendored BMM reference-model
     // corpus consumed wholesale by `corpus_validity_rm.rs`, not per-file ADL
     // fixtures, so it is not walked here).
-    let roots = [
+    let vendored_roots = [
         PathBuf::from(format!("{CORPUS}/adl2-reference")),
         PathBuf::from(format!("{CORPUS}/flattener")),
     ];
+    let hand_written_roots = [PathBuf::from(format!("{CORPUS}/adl14-dadl"))];
 
     let mut counts: std::collections::BTreeMap<String, usize> = std::collections::BTreeMap::new();
     let mut unclaimed: Vec<String> = Vec::new();
     let mut total = 0usize;
 
-    for root in &roots {
+    let mut hand_written = 0usize;
+    for (root, vendored) in vendored_roots
+        .iter()
+        .map(|r| (r, true))
+        .chain(hand_written_roots.iter().map(|r| (r, false)))
+    {
         for path in adl_sources(root) {
-            total += 1;
+            if vendored {
+                total += 1;
+            } else {
+                hand_written += 1;
+            }
             let rel = path
                 .strip_prefix(CORPUS)
                 .unwrap_or(&path)
@@ -155,7 +175,7 @@ fn every_corpus_source_is_claimed_by_exactly_one_harness() {
     }
 
     eprintln!(
-        "corpus coverage: {total} ADL sources across {} categories",
+        "corpus coverage: {total} vendored + {hand_written} hand-written ADL sources across {} categories",
         counts.len()
     );
     for (cat, n) in &counts {
@@ -174,6 +194,12 @@ fn every_corpus_source_is_claimed_by_exactly_one_harness() {
     // re-derive INVENTORY.md and update this expected total in the same change.
     assert_eq!(
         total, 340,
-        "expected 340 ADL source files (302 adl2-reference + 38 flattener); found {total}"
+        "expected 340 vendored ADL source files (302 adl2-reference + 38 flattener); found {total}"
+    );
+    // The hand-written tree only ratchets up: a fixture is added, never
+    // removed to go green (`.claude/rules/testing.md`).
+    assert!(
+        hand_written >= 4,
+        "expected at least the 4 hand-written adl14-dadl fixtures; found {hand_written}"
     );
 }

--- a/crates/openehr-adl/tests/legacy14_corpus.rs
+++ b/crates/openehr-adl/tests/legacy14_corpus.rs
@@ -17,6 +17,9 @@
 //!   which rejects at parse with `SDINV` (its `regression` tag) — an empty
 //!   `(C_DV_QUANTITY) <>` inline dADL block.
 //! - `features/**/*.adl` — parse (1.4 dialect) clean.
+//! - `adl14-dadl/*.adl` — the hand-written dADL breadth tree, claimed by
+//!   `adl14_dadl_breadth.rs` (accept/refuse per fixture, leaf values
+//!   asserted).
 #![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 
 use std::path::{Path, PathBuf};
@@ -112,6 +115,11 @@ fn every_adl_file_is_claimed_with_an_outcome() {
             // The lone 1.4 features source (intervention_decisions.v0).
             parse_artefact_adl14(&src)
                 .unwrap_or_else(|e| panic!("{r}: 1.4-tolerant parse failed: {e:?}"));
+            claimed += 1;
+        } else if r.starts_with("adl14-dadl/") {
+            // The hand-written dADL breadth tree, owned by
+            // `adl14_dadl_breadth.rs` (which asserts each fixture's declared
+            // accept/refuse outcome and its leaf values).
             claimed += 1;
         } else {
             panic!("unclaimed .adl file (no coverage category): {r}");

--- a/crates/openehr-lang/src/odin/lexer.rs
+++ b/crates/openehr-lang/src/odin/lexer.rs
@@ -25,19 +25,60 @@ pub(crate) struct Spanned {
 #[logos(skip r"[ \t\r\n]+")] // WS / LINE
 #[logos(skip(r"--[^\n]*", allow_greedy = true))] // CMT_LINE `-- … EOL`
 pub(crate) enum Token {
-    /// `True` / `true` (`SYM_TRUE`).
-    #[token("True")]
-    #[token("true")]
+    /// `SYM_TRUE` — fully case-insensitive (`base_lexer.g4`
+    /// `SYM_TRUE : [Tt][Rr][Uu][Ee]`; `LANG/docs/odin/master07-leaf_data`
+    /// §Boolean Data "Boolean values can be indicated by the following values
+    /// (case-insensitive)"; `AM/docs/ADL1.4/master04-dadl` §Symbols, the dADL
+    /// lex rule `[Tt][Rr][Uu][Ee]`).
+    #[regex("[Tt][Rr][Uu][Ee]")]
     True,
-    /// `False` / `false` (`SYM_FALSE`).
-    #[token("False")]
-    #[token("false")]
+    /// `SYM_FALSE` — fully case-insensitive (same citations as [`Token::True`]).
+    #[regex("[Ff][Aa][Ll][Ss][Ee]")]
     False,
 
+    /// `SYM_INFINITY` — an unbounded interval endpoint, case-insensitive
+    /// (`AM/docs/ADL1.4/master04-dadl` §Intervals of Ordered Primitive Types:
+    /// "The allowable values for `N` and `M` include any value in the range of
+    /// the relevant type, as well as: `infinity` / `-infinity` / `*`", and
+    /// §Symbols `[Ii][Nn][Ff][Ii][Nn][Ii][Tt][Yy]`).
+    ///
+    /// NOTE: `LANG/docs/odin/master07-leaf_data` §Intervals of Ordered
+    /// Primitive Types states only "any value in the range of the relevant
+    /// type", so accepting the marker in ODIN generally is a dADL-1.4-grounded
+    /// superset of the ODIN chapter — deliberate, since this reader serves the
+    /// 1.4 dADL front end as well.
+    #[regex("[Ii][Nn][Ff][Ii][Nn][Ii][Tt][Yy]")]
+    Infinity,
+
     /// `ISO8601_DATE_TIME` (with optional partial `??` fields / timezone).
+    ///
+    /// The `??`-partial family is the full set of
+    /// `AM/docs/ADL1.4/master04-dadl` §Partial Date/Times: `…Thh:mm:??`,
+    /// `…Thh:??:??`, `yyyy-MM-ddT??:??:??`, `yyyy-MM-??T??:??:??` and
+    /// `yyyy-??-??T??:??:??` (the last three are absent from
+    /// `LANG/docs/odin/master07-leaf_data`, which lists only the first two —
+    /// the dADL chapter's larger set is accepted here, a superset for the
+    /// ODIN-only callers).
     #[regex(
-        r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}(:[0-9]{2}(:([0-9]{2}([.,][0-9]+)?|\?\?))?|:\?\?:\?\?)?(Z|[+\-][0-9]{4})?",
+        r"[0-9]{4}-[0-9]{2}-[0-9]{2}T([0-9]{2}(:[0-9]{2}(:([0-9]{2}([.,][0-9]+)?|\?\?))?|:\?\?:\?\?)?|\?\?:\?\?:\?\?)(Z|[+\-][0-9]{4})?",
         |lex| lex.slice().to_owned()
+    )]
+    #[regex(
+        r"[0-9]{4}-([0-9]{2}-\?\?|\?\?-\?\?)T\?\?:\?\?:\?\?(Z|[+\-][0-9]{4})?",
+        |lex| lex.slice().to_owned()
+    )]
+    // The space-separated date/time form of the `AM/docs/ADL1.4/master08-adl`
+    // §Revision History Section example (`time_committed = <2004-11-02
+    // 09:31:04+1000>`). NOTE: that example contradicts its own chapter set —
+    // `master04-dadl` §Complete Date/Times mandates the ISO 8601 extended form
+    // with the `T` designator, and neither the dADL lex rules nor the vendored
+    // `base_lexer.g4` `ISO8601_DATE_TIME` admit a space. The form is accepted
+    // (an upstream spec-example defect, not an authoring error to punish) and
+    // normalised to the `T` form on read, so every consumer sees valid
+    // ISO 8601.
+    #[regex(
+        r"[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}(:[0-9]{2}([.,][0-9]+)?)?(Z|[+\-][0-9]{4})?",
+        |lex| lex.slice().replacen(' ', "T", 1)
     )]
     DateTime(String),
     /// `ISO8601_DATE` (with optional partial `??` fields).
@@ -59,6 +100,25 @@ pub(crate) enum Token {
     /// A term-code reference `[terminology(ver)?::code]` (`TERM_CODE_REF`).
     #[regex(r"\[[a-zA-Z0-9._\-]+(\([a-zA-Z0-9._\-]+\))?::[a-zA-Z0-9._\-]+\]", |lex| lex.slice().to_owned())]
     TermCodeRef(String),
+    /// A *local* term-code reference `[at0200]` — a bracketed code with no
+    /// `terminology::` qualifier (`AM/docs/ADL1.4/master04-dadl` §Symbols,
+    /// `V_LOCAL_TERM_CODE_REF : \[{ALPHANUM}{NAMECHAR}*\]`).
+    ///
+    /// NOTE (spec-internal conflict, resolved in favour of the lex rules + the
+    /// worked examples): the same chapter's yacc grammar admits only
+    /// `V_QUALIFIED_TERM_CODE_REF` under `primitive_object_value`, so by the
+    /// production rules alone `[at0200]` would not be a leaf value — yet the
+    /// chapter's own §Lists of Built-in Types example lists `[at0200], ...`
+    /// beside `"en", ...`, and `LANG/docs/odin/master07-leaf_data` §Lists of
+    /// Built-in Types repeats that example verbatim. Two normative passages
+    /// against one production rule: the local code is read as a leaf value.
+    ///
+    /// The pattern deliberately requires an ALPHA first character (narrower
+    /// than the 1.4 `ALPHANUM`) so that the container keys `[1]`, `[01234]`
+    /// and `[2004-06-11]` keep lexing as `'[' key ']'`, which the 1.4 lex rule
+    /// would otherwise swallow whole.
+    #[regex(r"\[[a-zA-Z][a-zA-Z0-9._\-]*\]", |lex| lex.slice().to_owned())]
+    LocalTermCodeRef(String),
     /// An embedded URI `<scheme:…>` (`EMBEDDED_URI`).
     #[regex(r"<[ \t\r\n]*[a-zA-Z][a-zA-Z0-9+.\-]*:[^>]*>", |lex| lex.slice().to_owned())]
     EmbeddedUri(String),
@@ -76,7 +136,10 @@ pub(crate) enum Token {
     #[regex(r"[0-9]+([eE][+\-]?[0-9]+)?", |lex| lex.slice().to_owned())]
     Integer(String),
     /// A double-quoted `STRING` (may span lines); escapes validated per
-    /// `master03` (`\r \n \t \\ \" \'` + `\uHHHH`/`\uHHHHHHHH`).
+    /// `master03` (`\r \n \t \\ \" \'` + `\uHHHH`/`\uHHHHHHHH`), and the
+    /// multi-line whitespace leaders removed per
+    /// `LANG/docs/odin/master07-leaf_data` §String Data (see
+    /// [`validate_string`]).
     #[regex(r#""([^"\\]|\\.)*""#, validate_string)]
     String(String),
     /// A single-quoted `CHARACTER`.
@@ -150,12 +213,29 @@ pub(crate) enum Token {
     /// `/` — a bare object-reference root path.
     #[token("/")]
     Slash,
+    /// `*` — "equivalent to infinity" as an interval endpoint
+    /// (`AM/docs/ADL1.4/master04-dadl` §Intervals of Ordered Primitive Types).
+    #[token("*")]
+    Star,
 }
 
-/// Validate `master03` string escapes and return the raw slice.
+/// Validate `master03` string escapes and return the raw (still-quoted) slice
+/// with multi-line whitespace leaders removed.
 ///
 /// Illegal escapes (anything other than `\r \n \t \\ \" \'` or a `\u` + 4/8
-/// hex-digit sequence) fail the lex (`LANG/docs/odin` + `ADL2/master03`).
+/// hex-digit sequence) fail the lex (`LANG/docs/odin/master03-basics`
+/// §Special Character Sequences + `AM/docs/ADL1.4/master03-file_encoding`
+/// §Special Character Sequences, which define `\"` as *the* encoding of a
+/// literal double quote).
+///
+/// NOTE (adjudicated as descriptive, not a decoding rule):
+/// `AM/docs/ADL1.4/master04-dadl` §String Data — and verbatim
+/// `LANG/docs/odin/master07-leaf_data` §String Data — illustrate quoting with
+/// `"… what one might call a &quot;phrase&quot;."`. No chapter defines a
+/// decoding step for that form, the two `master03` chapters make `\"` the
+/// normative literal-quote encoding, and decoding `&quot;` would be
+/// irreversible for text that legitimately contains it. The sequence is
+/// therefore carried through verbatim, as authored.
 fn validate_string(lex: &logos::Lexer<Token>) -> Result<String, ()> {
     let raw = lex.slice();
     let bytes = raw.as_bytes();
@@ -187,7 +267,55 @@ fn validate_string(lex: &logos::Lexer<Token>) -> Result<String, ()> {
             i += 1;
         }
     }
-    Ok(raw.to_owned())
+    Ok(strip_line_leaders(raw, leader_budget(lex)))
+}
+
+/// How many leading whitespace characters may be removed from each
+/// continuation line of a multi-line string: the column at which the string's
+/// first line of content starts.
+///
+/// `LANG/docs/odin/master07-leaf_data` §String Data (verbatim in
+/// `AM/docs/ADL1.4/master04-dadl` §String Data): "The exact contents of the
+/// string are computed as being the characters between the double quote
+/// characters, with the removal of white space leaders up to the left-most
+/// character of the first line of the string." The left-most character of the
+/// string's first line is the one immediately after the opening `"`, so its
+/// column is the budget.
+fn leader_budget(lex: &logos::Lexer<Token>) -> usize {
+    let start = lex.span().start;
+    let src = lex.source();
+    let Some(before) = src.get(..start) else {
+        return 0;
+    };
+    let line_start = before.rfind('\n').map_or(0, |i| i + 1);
+    // +1 for the opening quote itself.
+    before
+        .get(line_start..)
+        .map_or(0, |indent| indent.chars().count() + 1)
+}
+
+/// Remove up to `budget` leading whitespace characters from every line of
+/// `raw` after the first (see [`leader_budget`]). Single-line strings are
+/// returned untouched.
+fn strip_line_leaders(raw: &str, budget: usize) -> String {
+    if !raw.contains('\n') {
+        return raw.to_owned();
+    }
+    let mut out = String::with_capacity(raw.len());
+    for (idx, line) in raw.split_inclusive('\n').enumerate() {
+        if idx == 0 {
+            out.push_str(line);
+            continue;
+        }
+        let kept = line
+            .char_indices()
+            .take(budget)
+            .take_while(|(_, c)| *c == ' ' || *c == '\t')
+            .last()
+            .map_or(0, |(i, c)| i + c.len_utf8());
+        out.push_str(line.get(kept..).unwrap_or(line));
+    }
+    out
 }
 
 /// Lex `src` into a spanned ODIN token vector.

--- a/crates/openehr-lang/src/odin/mod.rs
+++ b/crates/openehr-lang/src/odin/mod.rs
@@ -24,7 +24,9 @@ use indexmap::IndexMap;
 #[derive(Debug, Clone, PartialEq)]
 pub enum OdinValue {
     /// `attr_vals` — an object with attribute → value members (insertion
-    /// order preserved). A later duplicate key overwrites the earlier value.
+    /// order preserved). Sibling names are unique by construction: a repeat
+    /// fails the parse with [`OdinErrorKind::DuplicateAttribute`] (rule
+    /// *VDATU*), it is never overwritten.
     Object(IndexMap<String, OdinValue>),
     /// `keyed_object*` — an insertion-ordered keyed list (`["k"] = <…>`).
     KeyedList(Vec<(OdinKey, OdinValue)>),
@@ -93,8 +95,11 @@ pub enum OdinKey {
 /// An ODIN interval value (`odin_values.g4` `*_interval_value`).
 #[derive(Debug, Clone, PartialEq)]
 pub enum OdinInterval {
-    /// A range `| >? lower .. <? upper |`, or a single-bounded `| relop v |`
-    /// (one endpoint `None` = unbounded on that side).
+    /// A range `| >? lower .. <? upper |`, or a single-bounded `| relop v |`.
+    /// A `None` endpoint is unbounded on that side — either because the form
+    /// is one-sided, or because the endpoint was written as one of the
+    /// `infinity` / `-infinity` / `*` markers of
+    /// `AM/docs/ADL1.4/master04-dadl` §Intervals of Ordered Primitive Types.
     Range {
         /// Lower bound (`None` = unbounded below).
         lower: Option<Box<OdinValue>>,
@@ -115,10 +120,29 @@ pub enum OdinInterval {
     },
 }
 
+/// What kind of ODIN failure occurred — the discriminant a caller branches on
+/// (the `message` is display text, never a decision input).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OdinErrorKind {
+    /// An unrecognised character or an illegal string escape.
+    UnrecognisedToken,
+    /// A syntactically unexpected token.
+    UnexpectedToken,
+    /// Two sibling attributes of one object node share a name — rule *VDATU*
+    /// of `LANG/docs/odin/master05-content` §General Structure ("sibling
+    /// attributes occurring within an object node must be uniquely named with
+    /// respect to each other"), the principle "Sibling attribute names must be
+    /// unique" of `AM/docs/ADL1.4/master04-dadl` §General Form. Carries the
+    /// repeated name.
+    DuplicateAttribute(String),
+}
+
 /// An ODIN parse or lex failure, with a 1-based line/column and a byte span.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[error("ODIN syntax error at line {line}, column {column}: {message}")]
 pub struct OdinError {
+    /// The failure kind.
+    pub kind: OdinErrorKind,
     /// A human-readable message.
     pub message: String,
     /// 1-based line number.
@@ -142,19 +166,31 @@ pub fn parse(src: &str) -> Result<OdinValue, OdinError> {
     let spanned = lexer::lex(src).map_err(|span| {
         let (line, column) = line_col(src, span.start);
         OdinError {
+            kind: OdinErrorKind::UnrecognisedToken,
             message: "unrecognised token".to_owned(),
             line,
             column,
             span,
         }
     })?;
-    parser::parse_tokens(&spanned).map_err(|offset| {
-        let (line, column) = line_col(src, offset);
+    parser::parse_tokens(&spanned).map_err(|located| {
+        let (line, column) = line_col(src, located.offset);
+        let (kind, message) = match located.failure {
+            parser::Failure::Syntax(_) => (
+                OdinErrorKind::UnexpectedToken,
+                "unexpected token".to_owned(),
+            ),
+            parser::Failure::DuplicateAttribute { name, .. } => (
+                OdinErrorKind::DuplicateAttribute(name.clone()),
+                format!("duplicate sibling attribute {name:?} (VDATU)"),
+            ),
+        };
         OdinError {
-            message: "unexpected token".to_owned(),
+            kind,
+            message,
             line,
             column,
-            span: offset..offset,
+            span: located.offset..located.offset,
         }
     })
 }
@@ -296,5 +332,176 @@ mod tests {
     #[test]
     fn illegal_escape_is_error() {
         assert!(parse(r#"a = <"bad \d">"#).is_err());
+    }
+
+    /// `AM/docs/ADL1.4/master04-dadl` §Empty Sections ("Empty sections can
+    /// appear anywhere"; "Nested empty sections can be used") +
+    /// `LANG/docs/odin/master05-content` §Void Objects.
+    #[test]
+    fn empty_sections_appear_anywhere() {
+        let m = obj("address = <...>");
+        assert_eq!(m.get("address"), Some(&OdinValue::Empty));
+
+        // nested: inside an object, inside a keyed list, and behind a cast.
+        let m = obj("a = <b = <...> c = <d = <...>>>\ne = <[1] = <...>>\nf = (PENSION) <...>");
+        let OdinValue::Object(inner) = m.get("a").expect("a") else {
+            panic!("expected object");
+        };
+        assert_eq!(inner.get("b"), Some(&OdinValue::Empty));
+        let OdinValue::KeyedList(entries) = m.get("e").expect("e") else {
+            panic!("expected keyed list");
+        };
+        assert_eq!(entries[0].1, OdinValue::Empty);
+        assert_eq!(
+            m.get("f"),
+            Some(&OdinValue::Typed {
+                rm_type: "PENSION".to_owned(),
+                value: Box::new(OdinValue::Empty),
+            })
+        );
+    }
+
+    /// `AM/docs/ADL1.4/master04-dadl` §Partial Date/Times, the `T??:??:??`
+    /// family the ODIN chapter omits.
+    #[test]
+    fn partial_date_time_family() {
+        for src in [
+            "2004-06-11T10:30:??",
+            "2004-06-11T10:??:??",
+            "2004-06-11T??:??:??",
+            "2004-06-??T??:??:??",
+            "2004-??-??T??:??:??",
+        ] {
+            let m = obj(&format!("d = <{src}>"));
+            assert_eq!(
+                m.get("d"),
+                Some(&OdinValue::DateTime(src.to_owned())),
+                "{src}"
+            );
+        }
+    }
+
+    /// `AM/docs/ADL1.4/master08-adl` §Revision History Section writes
+    /// `time_committed = <2004-11-02 09:31:04+1000>`; the space form is
+    /// accepted and normalised to the ISO `T` form (see the lexer NOTE).
+    #[test]
+    fn space_separated_date_time_normalises() {
+        let m = obj("time_committed = <2004-11-02 09:31:04+1000>");
+        assert_eq!(
+            m.get("time_committed"),
+            Some(&OdinValue::DateTime("2004-11-02T09:31:04+1000".to_owned()))
+        );
+    }
+
+    /// `AM/docs/ADL1.4/master04-dadl` §Integer Data lists `29e6` as integer
+    /// data; §Boolean Data + §Symbols make the boolean words case-insensitive.
+    #[test]
+    fn integer_exponents_and_case_insensitive_booleans() {
+        let m = obj("a = <29e6>\nb = <2900e-2>\nc = <TRUE>\nd = <fAlSe>");
+        assert_eq!(m.get("a"), Some(&OdinValue::Integer(29_000_000)));
+        assert_eq!(m.get("b"), Some(&OdinValue::Integer(29)));
+        assert_eq!(m.get("c"), Some(&OdinValue::Boolean(true)));
+        assert_eq!(m.get("d"), Some(&OdinValue::Boolean(false)));
+        // an inexact negative exponent has no integer value.
+        assert!(parse("a = <29e-2>").is_err());
+    }
+
+    /// `AM/docs/ADL1.4/master04-dadl` §Intervals of Ordered Primitive Types:
+    /// `infinity` / `-infinity` / `*` are allowable endpoint values, e.g.
+    /// `|0..infinity|`.
+    #[test]
+    fn unbounded_interval_endpoints() {
+        for src in ["|0..infinity|", "|0..*|", "|0..INFINITY|"] {
+            let m = obj(&format!("r = <{src}>"));
+            let Some(OdinValue::Interval(OdinInterval::Range {
+                lower,
+                lower_included,
+                upper,
+                upper_included,
+            })) = m.get("r")
+            else {
+                panic!("expected range interval for {src}");
+            };
+            assert_eq!(lower.as_deref(), Some(&OdinValue::Integer(0)), "{src}");
+            assert!(*lower_included, "{src}");
+            assert_eq!(upper.as_deref(), None, "{src}");
+            assert!(!*upper_included, "{src}");
+        }
+
+        let m = obj("r = <|-infinity..5.0|>");
+        let Some(OdinValue::Interval(OdinInterval::Range { lower, upper, .. })) = m.get("r") else {
+            panic!("expected range interval");
+        };
+        assert_eq!(lower.as_deref(), None);
+        assert_eq!(upper.as_deref(), Some(&OdinValue::Real(5.0)));
+    }
+
+    /// `AM/docs/ADL1.4/master04-dadl` §Lists of Built-in Types +
+    /// `LANG/docs/odin/master07-leaf_data` §Lists of Built-in Types both list
+    /// `[at0200], ...` as leaf data (see the lexer NOTE on the chapter's own
+    /// yacc disagreeing).
+    #[test]
+    fn local_term_codes_are_leaf_values() {
+        let m = obj("a = <[at0200]>\nb = <[at0200], ...>\nc = <[at0010.2]>");
+        assert_eq!(
+            m.get("a"),
+            Some(&OdinValue::TermCode("[at0200]".to_owned()))
+        );
+        assert_eq!(
+            m.get("b"),
+            Some(&OdinValue::List(vec![
+                OdinValue::TermCode("[at0200]".to_owned()),
+                OdinValue::ListContinue,
+            ]))
+        );
+        assert_eq!(
+            m.get("c"),
+            Some(&OdinValue::TermCode("[at0010.2]".to_owned()))
+        );
+        // integer / date container keys still lex as keys, not local codes.
+        let map = obj("k = <[1] = <\"x\">>");
+        let Some(OdinValue::KeyedList(entries)) = map.get("k") else {
+            panic!("expected keyed list");
+        };
+        assert_eq!(entries[0].0, OdinKey::Integer(1));
+    }
+
+    /// Rule *VDATU* (`LANG/docs/odin/master05-content` §General Structure) /
+    /// the "Sibling attribute names must be unique" principle of
+    /// `AM/docs/ADL1.4/master04-dadl` §General Form.
+    #[test]
+    fn duplicate_sibling_attributes_are_refused() {
+        let err = parse("a = <1>\nb = <2>\na = <3>").expect_err("duplicate `a`");
+        assert_eq!(err.kind, OdinErrorKind::DuplicateAttribute("a".to_owned()));
+
+        // …at any depth.
+        let err = parse("outer = <x = <1> x = <2>>").expect_err("duplicate nested `x`");
+        assert_eq!(err.kind, OdinErrorKind::DuplicateAttribute("x".to_owned()));
+
+        // the same name under DIFFERENT parents is not a duplicate.
+        assert!(parse("p = <x = <1>>\nq = <x = <2>>").is_ok());
+    }
+
+    /// `LANG/docs/odin/master07-leaf_data` §String Data (verbatim in
+    /// `AM/docs/ADL1.4/master04-dadl` §String Data): multi-line string
+    /// contents drop the white-space leaders of the continuation lines.
+    #[test]
+    fn multi_line_string_leaders_are_stripped() {
+        let m = obj(
+            "    text = <\"And now the STORM-BLAST came, and he\n        Was tyrannous and strong :\n        And chased us south along.\">",
+        );
+        assert_eq!(
+            m.get("text"),
+            Some(&OdinValue::String(
+                "And now the STORM-BLAST came, and he\nWas tyrannous and strong :\nAnd chased us south along."
+                    .to_owned()
+            ))
+        );
+        // `&quot;` is carried through verbatim (see the lexer NOTE).
+        let m = obj(r#"t = <"a &quot;phrase&quot;.">"#);
+        assert_eq!(
+            m.get("t"),
+            Some(&OdinValue::String("a &quot;phrase&quot;.".to_owned()))
+        );
     }
 }

--- a/crates/openehr-lang/src/odin/parser.rs
+++ b/crates/openehr-lang/src/odin/parser.rs
@@ -2,27 +2,118 @@
 //! transcribed from `odin.g4` / `odin_values.g4`. Produces an
 //! [`OdinValue`] tree.
 
+use chumsky::DefaultExpected;
+use chumsky::error::{Error, LabelError};
 use chumsky::prelude::*;
+use chumsky::util::MaybeRef;
 use indexmap::IndexMap;
 
 use super::lexer::{Spanned, Token};
 use super::{OdinInterval, OdinKey, OdinValue};
 
-type Err<'a> = chumsky::extra::Err<Simple<'a, Token>>;
+type Err<'a> = chumsky::extra::Err<Failure>;
+
+/// A parse failure: a plain syntactic conflict, or the typed
+/// duplicate-sibling-attribute violation.
+#[derive(Debug, Clone)]
+pub(super) enum Failure {
+    /// An unexpected token at the given token-index span.
+    Syntax(SimpleSpan),
+    /// VDATU: two sibling attributes share a name
+    /// (`LANG/docs/odin/master05-content` §General Structure).
+    DuplicateAttribute {
+        /// The repeated attribute name.
+        name: String,
+        /// Token-index span of the offending (second) occurrence.
+        span: SimpleSpan,
+    },
+}
+
+impl Failure {
+    /// The token-index span the failure points at.
+    fn span(&self) -> SimpleSpan {
+        match self {
+            Self::Syntax(s) | Self::DuplicateAttribute { span: s, .. } => *s,
+        }
+    }
+
+    /// Keep whichever failure carries the most information: a typed
+    /// duplicate-attribute violation always outranks a bare syntax conflict
+    /// (the enclosing `choice`s retry other alternatives after it, and each of
+    /// those contributes a syntax error at the same position).
+    fn preferred(self, other: Self) -> Self {
+        match (&self, &other) {
+            (Self::DuplicateAttribute { .. }, _) => self,
+            (_, Self::DuplicateAttribute { .. }) => other,
+            _ => self,
+        }
+    }
+}
+
+impl<'a> Error<'a, &'a [Token]> for Failure {
+    fn merge(self, other: Self) -> Self {
+        self.preferred(other)
+    }
+}
+
+impl<'a> LabelError<'a, &'a [Token], DefaultExpected<'a, Token>> for Failure {
+    fn expected_found<E: IntoIterator<Item = DefaultExpected<'a, Token>>>(
+        _expected: E,
+        _found: Option<MaybeRef<'a, Token>>,
+        span: SimpleSpan,
+    ) -> Self {
+        Self::Syntax(span)
+    }
+
+    fn merge_expected_found<E: IntoIterator<Item = DefaultExpected<'a, Token>>>(
+        self,
+        _expected: E,
+        _found: Option<MaybeRef<'a, Token>>,
+        span: SimpleSpan,
+    ) -> Self {
+        self.preferred(Self::Syntax(span))
+    }
+
+    fn replace_expected_found<E: IntoIterator<Item = DefaultExpected<'a, Token>>>(
+        self,
+        _expected: E,
+        _found: Option<MaybeRef<'a, Token>>,
+        span: SimpleSpan,
+    ) -> Self {
+        self.preferred(Self::Syntax(span))
+    }
+}
+
+/// A parse failure resolved to a byte offset in the original source.
+pub(super) struct Located {
+    /// The failure.
+    pub(super) failure: Failure,
+    /// Byte offset of the failure in the original source.
+    pub(super) offset: usize,
+}
 
 /// Parse a spanned ODIN token stream into an [`OdinValue`].
 ///
 /// # Errors
-/// Returns the byte offset (into the original source) of the first parse error.
-pub(super) fn parse_tokens(spanned: &[Spanned]) -> Result<OdinValue, usize> {
+/// Returns the first failure, resolved to a byte offset in the original
+/// source.
+pub(super) fn parse_tokens(spanned: &[Spanned]) -> Result<OdinValue, Located> {
     let tokens: Vec<Token> = spanned.iter().map(|s| s.token.clone()).collect();
     odin_text().parse(&tokens).into_result().map_err(|errs| {
-        let idx = errs.first().map_or(spanned.len(), |e| e.span().start);
-        spanned
+        let failure = errs
+            .into_iter()
+            .reduce(Failure::preferred)
+            .unwrap_or(Failure::Syntax(SimpleSpan::new(
+                (),
+                spanned.len()..spanned.len(),
+            )));
+        let idx = failure.span().start;
+        let offset = spanned
             .get(idx)
             .map(|s| s.span.start)
             .or_else(|| spanned.last().map(|s| s.span.end))
-            .unwrap_or(0)
+            .unwrap_or(0);
+        Located { failure, offset }
     })
 }
 
@@ -34,6 +125,15 @@ fn odin_text<'a>() -> impl Parser<'a, &'a [Token], OdinValue, Err<'a>> {
 }
 
 /// `attr_vals : ( attr_val ';'? )+` → [`OdinValue::Object`].
+///
+/// Sibling attribute names must be unique — `LANG/docs/odin/master05-content`
+/// §General Structure rule *VDATU*: "attribute name uniqueness: sibling
+/// attributes occurring within an object node must be uniquely named with
+/// respect to each other, in the same way as in class definitions in an
+/// information model", stated as the principle "Sibling attribute names must
+/// be unique" in `AM/docs/ADL1.4/master04-dadl` §General Form. A repeat is a
+/// typed [`Failure::DuplicateAttribute`], never a silent last-one-wins
+/// overwrite.
 fn attr_vals<'a>(
     block: impl Parser<'a, &'a [Token], OdinValue, Err<'a>> + Clone + 'a,
 ) -> impl Parser<'a, &'a [Token], OdinValue, Err<'a>> + Clone {
@@ -45,10 +145,19 @@ fn attr_vals<'a>(
     key.then_ignore(just(Token::Eq))
         .then(block)
         .then_ignore(just(Token::SemiColon).or_not())
+        .map_with(|pair, e| (pair, e.span()))
         .repeated()
         .at_least(1)
-        .collect::<Vec<(String, OdinValue)>>()
-        .map(|pairs| OdinValue::Object(pairs.into_iter().collect::<IndexMap<_, _>>()))
+        .collect::<Vec<((String, OdinValue), SimpleSpan)>>()
+        .try_map(|pairs, _| {
+            let mut map: IndexMap<String, OdinValue> = IndexMap::with_capacity(pairs.len());
+            for ((name, value), span) in pairs {
+                if map.insert(name.clone(), value).is_some() {
+                    return Err(Failure::DuplicateAttribute { name, span });
+                }
+            }
+            Ok(OdinValue::Object(map))
+        })
 }
 
 /// `object_block : object_value_block | object_reference_block` (+ the
@@ -96,7 +205,23 @@ fn object_block<'a>() -> impl Parser<'a, &'a [Token], OdinValue, Err<'a>> + Clon
                 OdinValue::PathList(v)
             });
 
+        // `<...>` — an empty section / void object, legal at any level.
+        // `AM/docs/ADL1.4/master04-dadl` §Empty Sections: "Empty sections are
+        // allowed at both internal and leaf node levels … Nested empty
+        // sections can be used", with the principle "Empty sections can appear
+        // anywhere"; `LANG/docs/odin/master05-content` §Void Objects: "A void
+        // object, i.e. an object attribute that has no value is allowed in an
+        // ODIN text, but ignored by parsers."
+        //
+        // NOTE: it maps to [`OdinValue::Empty`], the same value as `<>` —
+        // both spec passages define the construct as "this attribute exists
+        // and has no data", so no consumer can act on the distinction between
+        // the two spellings, and a separate variant would force every match
+        // arm in every consumer to handle a second no-data case.
+        let void = just(Token::ListContinue).to(OdinValue::Empty);
+
         let inner = choice((
+            void,
             ref_list,
             keyed_list,
             attr_vals(block.clone()),
@@ -130,6 +255,13 @@ fn object_block<'a>() -> impl Parser<'a, &'a [Token], OdinValue, Err<'a>> + Clon
 
 /// `rm_type_id : ALPHA_UC_ID ( '<' rm_type_id ( ',' rm_type_id )* '>' )?`,
 /// reconstructed as a flat string (e.g. `Interval<Quantity>`).
+///
+// TODO: accept the dot-separated namespace form of a type identifier
+// (`org.openehr.rm.ehr.content.ENTRY`, `Core.Abstractions.Relationships.
+// Relationship`) — `AM/docs/ADL1.4/master04-dadl` §Adding Type Information and
+// `LANG/docs/odin/master05-content` §Adding Type Information both allow it,
+// but the vendored `odin.g4` `rm_type_id` rule this parser transcribes does
+// not, so such a cast currently fails the parse.
 fn rm_type_id<'a>() -> impl Parser<'a, &'a [Token], String, Err<'a>> + Clone {
     recursive(|t| {
         select! { Token::AlphaUcId(s) => s }
@@ -197,18 +329,36 @@ fn primitive_object<'a>() -> impl Parser<'a, &'a [Token], OdinValue, Err<'a>> + 
 fn interval_value<'a>(
     leaf: impl Parser<'a, &'a [Token], OdinValue, Err<'a>> + Clone + 'a,
 ) -> impl Parser<'a, &'a [Token], OdinValue, Err<'a>> + Clone {
+    // An interval endpoint: a leaf value, or one of the unbounded markers
+    // `infinity` / `-infinity` / `*` (`AM/docs/ADL1.4/master04-dadl`
+    // §Intervals of Ordered Primitive Types — its own example `|0..infinity|`
+    // is glossed "0 - infinity (i.e. >= 0)"). An unbounded marker yields
+    // `None`, the representation this crate already uses for the open side of
+    // a one-sided interval; the sign carried by `-infinity` is not recorded
+    // separately because the side of the interval the endpoint sits on already
+    // determines the direction.
+    let unbounded = choice((
+        just(Token::Minus)
+            .or_not()
+            .ignore_then(just(Token::Infinity))
+            .ignored(),
+        just(Token::Star).ignored(),
+    ))
+    .to(None);
+    let bound = choice((unbounded, leaf.clone().map(Some)));
+
     // `| '>'? a '..' '<'? b |`
     let range = just(Token::Gt)
         .or_not()
-        .then(leaf.clone())
+        .then(bound.clone())
         .then_ignore(just(Token::IvlSep))
         .then(just(Token::Lt).or_not())
-        .then(leaf.clone())
+        .then(bound.clone())
         .map(|(((gt, lo), lt), hi)| OdinInterval::Range {
-            lower: Some(Box::new(lo)),
-            lower_included: gt.is_none(),
-            upper: Some(Box::new(hi)),
-            upper_included: lt.is_none(),
+            lower_included: gt.is_none() && lo.is_some(),
+            upper_included: lt.is_none() && hi.is_some(),
+            lower: lo.map(Box::new),
+            upper: hi.map(Box::new),
         });
 
     // `| a '+/-' b |`
@@ -228,24 +378,32 @@ fn interval_value<'a>(
         just(Token::Le).to(RelBound::Upper(true)),
         just(Token::Lt).to(RelBound::Upper(false)),
     ));
-    let single = relop.or_not().then(leaf).map(|(op, v)| match op {
-        None => OdinInterval::Range {
+    let single = relop.or_not().then(bound).map(|(op, v)| match (op, v) {
+        (None, Some(v)) => OdinInterval::Range {
             lower: Some(Box::new(v.clone())),
             lower_included: true,
             upper: Some(Box::new(v)),
             upper_included: true,
         },
-        Some(RelBound::Lower(incl)) => OdinInterval::Range {
+        (Some(RelBound::Lower(incl)), Some(v)) => OdinInterval::Range {
             lower: Some(Box::new(v)),
             lower_included: incl,
             upper: None,
             upper_included: false,
         },
-        Some(RelBound::Upper(incl)) => OdinInterval::Range {
+        (Some(RelBound::Upper(incl)), Some(v)) => OdinInterval::Range {
             lower: None,
             lower_included: false,
             upper: Some(Box::new(v)),
             upper_included: incl,
+        },
+        // A one-sided form whose single endpoint is itself an unbounded marker
+        // (`|>=-infinity|`, `|<*|`) constrains nothing at all.
+        (_, None) => OdinInterval::Range {
+            lower: None,
+            lower_included: false,
+            upper: None,
+            upper_included: false,
         },
     });
 
@@ -268,15 +426,18 @@ fn leaf_value<'a>() -> impl Parser<'a, &'a [Token], OdinValue, Err<'a>> + Clone 
     let integer = int_sign
         .then(select! { Token::Integer(s) => s })
         .try_map(|(sign, s), span| {
-            let mag = s.parse::<i64>().map_err(|_| Simple::new(None, span))?;
-            Ok(OdinValue::Integer(sign.unwrap_or(1) * mag))
+            let mag = integer_lexeme(&s).ok_or(Failure::Syntax(span))?;
+            sign.unwrap_or(1)
+                .checked_mul(mag)
+                .map(OdinValue::Integer)
+                .ok_or(Failure::Syntax(span))
         });
 
     let real_sign = choice((just(Token::Plus).to(1f64), just(Token::Minus).to(-1f64))).or_not();
     let real = real_sign
         .then(select! { Token::Real(s) => s })
         .try_map(|(sign, s), span| {
-            let mag = s.parse::<f64>().map_err(|_| Simple::new(None, span))?;
+            let mag = s.parse::<f64>().map_err(|_| Failure::Syntax(span))?;
             Ok(OdinValue::Real(sign.unwrap_or(1.0) * mag))
         });
 
@@ -287,7 +448,10 @@ fn leaf_value<'a>() -> impl Parser<'a, &'a [Token], OdinValue, Err<'a>> + Clone 
     };
     let character =
         select! { Token::Character(s) => s }.map(|s| OdinValue::Character(decode_char(&s)));
-    let term_code = select! { Token::TermCodeRef(s) => OdinValue::TermCode(s) };
+    let term_code = select! {
+        Token::TermCodeRef(s) => OdinValue::TermCode(s),
+        Token::LocalTermCodeRef(s) => OdinValue::TermCode(s),
+    };
     let date = select! { Token::Date(s) => OdinValue::Date(s) };
     let time = select! { Token::Time(s) => OdinValue::Time(s) };
     let date_time = select! { Token::DateTime(s) => OdinValue::DateTime(s) };
@@ -296,6 +460,35 @@ fn leaf_value<'a>() -> impl Parser<'a, &'a [Token], OdinValue, Err<'a>> + Clone 
     choice((
         real, integer, string, boolean, character, term_code, date_time, date, time, duration,
     ))
+}
+
+/// The value of an `INTEGER` lexeme, evaluating the optional exponent suffix.
+///
+/// `AM/docs/ADL1.4/master04-dadl` §Integer Data lists `29e6` beside `25` and
+/// `300000` as integer data, and both the chapter's lex rule
+/// (`[0-9]+[eE][+-]?[0-9]+`) and the vendored `base_lexer.g4`
+/// (`INTEGER : DIGIT+ E_SUFFIX?`) admit the suffix — so the lexeme is
+/// *evaluated*, not parsed as a bare decimal literal.
+///
+/// NOTE: neither chapter says what a negative exponent means for an integer
+/// (`29e-2` is not an integer). It is accepted only when the scaling is exact
+/// (`2900e-2` = 29); an inexact one has no integer value and is rejected as a
+/// malformed leaf rather than silently truncated. No openEHR spec governs that
+/// case — our own design/extension.
+fn integer_lexeme(s: &str) -> Option<i64> {
+    let Some(e) = s.find(['e', 'E']) else {
+        return s.parse::<i64>().ok();
+    };
+    let mantissa = s.get(..e)?.parse::<i64>().ok()?;
+    let exponent = s.get(e + 1..)?.parse::<i32>().ok()?;
+    let scale = 10i64.checked_pow(exponent.unsigned_abs())?;
+    if exponent >= 0 {
+        mantissa.checked_mul(scale)
+    } else if mantissa % scale == 0 {
+        Some(mantissa / scale)
+    } else {
+        None
+    }
 }
 
 /// Strip the surrounding double quotes and decode `master03` escapes.

--- a/crates/openehr-lang/tests/vendor_odin.rs
+++ b/crates/openehr-lang/tests/vendor_odin.rs
@@ -9,15 +9,16 @@
 //! and the normative spec text (`docs/specs/openehr/LANG/docs/odin/`) are the
 //! syntax authority.
 //!
-//! Three fixtures are adjudicated as expected-error (see the individual tests
-//! for the citation): `log4j2.xml` is a log4j configuration, not ODIN; and the
-//! two illustrative `master`-style example documents use bareword / meta-id
+//! Four fixtures are adjudicated as expected-error (see the individual tests
+//! for the citation): `log4j2.xml` is a log4j configuration, not ODIN; the two
+//! illustrative `master`-style example documents use bareword / meta-id
 //! placeholders and a top-level keyed-object list that the `odin_text` start
-//! rule does not accept.
+//! rule does not accept; and `odin_test.txt` declares one attribute name
+//! twice, which rule *VDATU* forbids.
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
-use openehr_lang::odin::{OdinInterval, OdinKey, OdinValue, parse};
+use openehr_lang::odin::{OdinErrorKind, OdinInterval, OdinKey, OdinValue, parse};
 use std::path::PathBuf;
 
 // ---------------------------------------------------------------------------
@@ -95,7 +96,9 @@ const ODIN_FIXTURES: &[(&str, bool)] = &[
     ("odin/odin/odin_primitive_lists.txt", true),
     ("odin/odin/odin_primitive_types.txt", true),
     ("odin/odin/odin_term_binding_test.txt", true),
-    ("odin/odin/odin_test.txt", true),
+    // Expected-error: the fixture declares the top-level attribute `people`
+    // twice — see `referencing_document_is_refused_for_duplicate_attribute`.
+    ("odin/odin/odin_test.txt", false),
     ("odin/odin/odin_types.txt", true),
 ];
 
@@ -405,16 +408,64 @@ fn typed_casts_and_generic_types() {
     assert_eq!(as_str(field(value, "bmmType")), "CODED_TEXT");
 }
 
+/// The INVALID twin of [`referencing_document_parses`]: the vendored fixture
+/// itself, which declares the top-level attribute `people` twice (once with
+/// integer keys, once with string keys — archie's fixture concatenates the two
+/// container examples of `AM/docs/ADL1.4/master04-dadl` §Container Objects
+/// under the same attribute name).
+///
+/// This assertion was MOVED TOWARD THE SPEC: it previously pinned a
+/// last-one-wins overwrite (6 surviving attributes). Sibling attribute names
+/// must be unique — `LANG/docs/odin/master05-content` §General Structure rule
+/// *VDATU*, and the principle "Sibling attribute names must be unique" of
+/// `AM/docs/ADL1.4/master04-dadl` §General Form — so the document is
+/// spec-invalid and the reader now refuses it with the typed error naming the
+/// repeated attribute. The vendored fixture is unchanged; only the expectation
+/// moved, from an implementation behaviour to the spec rule.
+#[test]
+fn referencing_document_is_refused_for_duplicate_attribute() {
+    let err = parse(&read("odin/odin/odin_test.txt")).expect_err("duplicate `people` must refuse");
+    assert_eq!(
+        err.kind,
+        OdinErrorKind::DuplicateAttribute("people".to_owned())
+    );
+}
+
+/// The spec-valid twin of the fixture above, with the duplicated attribute
+/// renamed and nothing else changed — so every construct archie's
+/// `OdinBaseVisitorReferencingTest` exercises stays asserted: `;`-separated
+/// attributes (`term = <text = <"plan">; …>`), object-reference paths
+/// (`</hotels["gran sevilla"]>`), and typed keyed values
+/// (`(HISTORIC_HOTEL) <…>`).
+const REFERENCING_DOCUMENT_VALID_TWIN: &str = r#"
+term = <text = <"plan">; description = <"The clinician's advice">>
+
+people_by_index = <
+    [1] = <name = <"akmal"> birth_date = <1975-02-21> interests = <"painting", "running"> >
+>
+
+people = <
+    ["akmal:1975-04-22"] = <name = <"akmal"> birth_date = <1975-04-22> >
+>
+
+destinations = <
+    ["seville"] = <
+        hotels = <
+            ["gran sevilla"] = </hotels["gran sevilla"]>
+        >
+    >
+>
+
+hotels = <
+    ["gran sevilla"] = (HISTORIC_HOTEL) <name=<"Gran Sevilla Hotel">>
+    ["sofitel"] = (LUXURY_HOTEL) <name=<"Sofitel">>
+>
+"#;
+
 #[test]
 fn referencing_document_parses() {
-    // archie OdinBaseVisitorReferencingTest: only asserts the document loads.
-    // It exercises `;`-separated attrs (`term = <text = <"plan">; ...>`),
-    // object-reference paths (`</hotels["gran sevilla"]>`), and typed keyed
-    // values (`(HISTORIC_HOTEL) <...>`).
-    let v = parse_ok("odin/odin/odin_test.txt");
-    // `people` appears twice at top level; a later duplicate overwrites the
-    // earlier (documented `OdinValue::Object` semantics), leaving 6 attrs.
-    assert_eq!(attr_count(&v), 6);
+    let v = parse(REFERENCING_DOCUMENT_VALID_TWIN).expect("valid twin parses");
+    assert_eq!(attr_count(&v), 5);
     assert_eq!(as_str(field(field(&v, "term"), "text")), "plan");
     // hotels holds typed keyed objects.
     let hotels = field(&v, "hotels");

--- a/tools/cnf-runner/src/exec/resolve.rs
+++ b/tools/cnf-runner/src/exec/resolve.rs
@@ -250,6 +250,11 @@ impl<'a> Resolver<'a> {
         "top3_systolic_desc_uids",
     ];
 
+    /// Resolve a declared corpus view to its selection-spec value.
+    ///
+    /// # Errors
+    /// [`ResolveError`] when the view is undeclared or its evaluator is
+    /// not registered.
     pub fn view(&mut self, key: &CorpusKey, view: &ViewName) -> Result<Value, ResolveError> {
         let entry = self
             .manifest


### PR DESCRIPTION
Closes #981. Closes #982.

The #766 construct-by-construct audit of ADL1.4 master04 (dADL). Eleven spec-defined behaviours fixed (rejected forms accepted, silent losses made correct or typed-loud), each spec-cited in code; three adjudications NOTE-recorded (integer negative exponents, &quot;, the ODIN-superset boundaries); the chapter-internal lex-vs-yacc conflict on local term codes recorded with the winning derivation; `revision_history` parses and is deliberately NOT forked onto AOM2 (SPECAM-61 — the correct landing adjudicated first-hand against the amendment records). New 1.4-shaped breadth corpus with accept+refusal twins.

Also: six clippy warnings from #971/#976 visible only under the full CI flag set — fixed (my earlier scoped clippy runs missed `--all-features`).

Gates: workspace clippy `--all-targets --all-features` ZERO warnings; nextest 494/494 (lang+adl+cnf-runner) + 707/707 (ehrbase); `openehr-codegen -- check` green (BMM loading unaffected). Changelog entry included.