### PR TITLE
fix(adl14): cADL correctness — typed domain lowering, qualified-constraint validation, VCOC, dialect gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,45 @@ workflow refuses a tag that has no matching section here.
 - **Multi-line string values drop their continuation-line indentation**, as
   the specification requires (master04 §String Data), instead of carrying the
   source file's leading whitespace into the value.
+- **An inline ADL 1.4 domain constraint is no longer lowered to the wrong data
+  type.** `(TYPE) <…>` domain blocks (ADL 1.4 master09 §Customising ADL) other
+  than `C_DV_ORDINAL` were all turned into a `DV_QUANTITY`, so e.g. a
+  `C_CODE_PHRASE` coded-term constraint silently became a quantity constraint.
+  `C_DV_QUANTITY` and `C_DV_ORDINAL` are lowered as before; any other domain
+  type is now a syntax error naming the type instead of a wrong answer.
+- **An inline ADL 1.4 domain constraint's `assumed_value` is no longer
+  dropped.** It is now carried onto the constrained leaves (and an assumed
+  value that satisfies none of the block's own `list` rows is rejected instead
+  of silently ignored).
+- **ADL 1.4 coded-term constraints are checked for definedness.** The
+  dominant ADL 1.4 spelling of a value set (`[local:: at0004, at0005; at0004]`,
+  master09 §Custom Syntax) bypassed the term-definedness rules entirely, so an
+  archetype referring to codes its own ontology never defines uploaded
+  cleanly. Every listed code — and the assumed-value code — is now checked
+  (VATDF/VACDF, ADL 1.4 master08 §Validity Rules); codes of an external
+  terminology are correctly exempt.
+- **The ADL 1.4 cardinality/occurrences rule VCOC is enforced** (master05
+  §Occurrences): a container whose children's occurrences cannot fit inside
+  its cardinality is now rejected. The ADL 1.4 default `occurrences {1..1}`
+  and `existence {1..1}` (master05 §Occurrences / §Existence) are applied when
+  evaluating it, and the default occurrences is now written out explicitly by
+  the ADL 1.4 → 2 conversion, where an unstated occurrences means something
+  different.
+- **`use_node` type conformance is enforced (VUNT).** An internal reference
+  whose declared type is neither the referenced node's type nor an ancestor of
+  it is now a validation error instead of passing silently.
+
+### Changed
+
+- **An ADL 1.4 upload is now validated as ADL 1.4, not as a permissive
+  superset of ADL 2.** ADL 1.4's cADL keyword set is closed (master05
+  §Keywords), so constructs that only ADL 2 defines are refused in a 1.4 text
+  with a syntax error naming the construct: `use_archetype`, the archetype-slot
+  `closed` marker, the `_default` pseudo-attribute, second-order attribute
+  tuples, term-constraint strengths (`required`/`extensible`/`preferred`/
+  `example`), and `@terminology` operational bindings. `before`/`after` sibling
+  order stays accepted — master05 lists both as ADL 1.4 cADL keywords. ADL 2
+  uploads are unaffected.
 
 ## [3.14.0] - 2026-07-30
 

--- a/crates/openehr-adl/CLAUDE.md
+++ b/crates/openehr-adl/CLAUDE.md
@@ -15,6 +15,20 @@ into the generated `openehr_am::am24::aom2` model — never re-model AOM2.
 - **No ANTLR runtime, ever.** The normative `.g4` grammars from
   `openEHR/adl-antlr` are vendored under `vendor/grammar/` (with PROVENANCE.md)
   as reference input only.
+- **A 1.4 upload is judged AS 1.4, never as an ADL2 superset.**
+  `cadl::Dialect::Adl14` both ADDS the 1.4-only forms (qualified/listed term
+  constraints, inline dADL domain blocks) and REMOVES the constructs ADL 2
+  introduced — the cADL 1.4 keyword set is closed (`ADL1.4/master05-cadl.adoc`
+  §Keywords). The 1.4-only validity rules (VCOC; VATDF/VACDF over the
+  qualified/listed spelling) run on the `Dialect::Adl14` phase-1 path only.
+  The `S*` error space is a verbatim 1:1 mirror of the openEHR catalogue
+  (`ADL2/master04.6`): never invent a code — reuse the catalogue code for the
+  parse position and name the construct in the message.
+- **1.4 defaults are EFFECTIVE-value accessors, never mutations** —
+  `validate::conformance::effective_{existence,occurrences}_adl14` apply
+  master05's `{1..1}` defaults (and the `use_node` inheritance rule) on read;
+  an absent value stays absent in the parsed AOM. Only the 1.4→2 CONVERTER
+  writes a default out, because ADL 2 infers a different one.
 - **ADL 1.4→2 conversion (`adl14/`) has NO spec basis** — the whole module is
   our own design (archie is prior art only), flagged as such; every heuristic is
   pinned by the paired `upgrade_from_14` corpus fixtures, not a spec clause.
@@ -24,9 +38,12 @@ into the generated `openehr_am::am24::aom2` model — never re-model AOM2.
   re-minted archetype-wide-unique (VCOSU) with their terminology bindings cloned,
   and all remaps are recorded in `RESOURCE_DESCRIPTION.conversion_details`.
 - **Conformance corpus:** `tests/corpus/` (the openEHR ADL2 regression library;
-  file names encode the expected rule code). Corpus cases are the regression net
-  — never delete/weaken one to get green; a defect goes through adjudication, not
-  case edits.
+  file names encode the expected rule code) plus two HAND-WRITTEN ADL 1.4 trees
+  the vendored ADL2 library cannot cover — `adl14-dadl/` (master04 dADL breadth)
+  and `adl14-cadl/` (master05 cADL: dialect gates, domain lowering,
+  VATDF/VACDF, VCOC). Corpus cases are the regression net — never delete/weaken
+  one to get green; a defect goes through adjudication, not case edits, and
+  every refusal keeps its accepting twin.
 - Dependencies point downward only: `openehr-am`, `openehr-base`, `openehr-lang`
   (ODIN/BEL), `openehr-term`. No app-crate knowledge, no SQL, no REST.
 - Versioned by the spec (ADL/AOM 2.4.0) — bumps only on a spec-pin bump.

--- a/crates/openehr-adl/src/adl14/convert.rs
+++ b/crates/openehr-adl/src/adl14/convert.rs
@@ -203,7 +203,11 @@ impl<'a> Converter<'a> {
         self.renumber_nodes(&mut data.definition);
         // 3. Convert every terminology-code constraint (local/external/list).
         self.convert_constraints(&mut data.definition);
-        // 4. Elide RM-default cardinality/occurrences.
+        // 4. Write out the ADL 1.4 default occurrences where ADL 2 would infer a
+        //    different one, then elide the RM-default cardinality/occurrences.
+        //    Order matters: the materialisation reads the 1.4 cardinality, which
+        //    the elision may drop.
+        materialise_adl14_occurrences(&mut data.definition);
         elide_multiplicity(&mut data.definition);
         // 5. Rebuild the terminology (renumber keys, drop @internal, add synth).
         data.terminology = Box::new(self.rebuild_terminology(&data.terminology));
@@ -967,6 +971,84 @@ fn rewrite_path(path: &str, cx: &Converter<'_>) -> String {
 
 fn elide_multiplicity(def: &mut CComplexObject) {
     elide_cco(def);
+}
+
+/// Materialise the ADL 1.4 default `occurrences` on container children before the
+/// definition is emitted as ADL 2.
+///
+/// The two formalisms give an ABSENT `occurrences` different meanings, so the
+/// default cannot be carried across implicitly:
+///
+/// - ADL 1.4 — `ADL1.4/master05-cadl.adoc` §Occurrences L316: "The default
+///   occurrences, if none is mentioned, is `{1..1}`".
+/// - ADL 2 — `AOM2/master04.5-constraint_model-class_definitions.adoc`
+///   §Occurrences inferencing rules: an absent `occurrences` is inferred from the
+///   owning attribute's cardinality upper (lower forced to 0), i.e.
+///   `0..cardinality.upper`.
+///
+/// So an unstated 1.4 occurrences on a container child means "exactly once", and
+/// leaving it unstated in the ADL 2 output would silently widen it to "none to
+/// many". It is written out explicitly here.
+///
+/// Restricted to CONTAINER attributes because master05 L308 restricts the rule's
+/// significance to them ("It only has significance for objects which are children
+/// of a container attribute, since by definition, the occurrences of an object
+/// which is the value of a single valued attribute can only be `0..1` or `1..1`,
+/// and this is already defined by the attribute `existence`"). A `use_node`
+/// internal reference is exempt: master05 L515 gives it the REFERENCED node's
+/// occurrences, which is exactly what leaving it unstated means in ADL 2 once the
+/// proxy is expanded.
+///
+/// NOTE: no openEHR spec governs 1.4→2 conversion — our own design (see the
+/// module flag on [`crate::adl14`]); the two default rules it reconciles are the
+/// spec-cited ones above.
+fn materialise_adl14_occurrences(def: &mut CComplexObject) {
+    let Some(d) = cco_data_mut(def) else { return };
+    for attr in &mut d.attributes {
+        let is_container = attr.cardinality.is_some();
+        for child in &mut attr.children {
+            if is_container
+                && child_occurrences(child).is_none()
+                && !matches!(child, CObject::CComplexObjectProxy(_))
+            {
+                set_occurrences(child, one_to_one());
+            }
+            if let CObject::CComplexObject(c) = child {
+                materialise_adl14_occurrences(c);
+            }
+        }
+    }
+}
+
+/// The ADL 1.4 default multiplicity `{1..1}` (`ADL1.4/master05-cadl.adoc`
+/// §Occurrences L316).
+fn one_to_one() -> openehr_base::prelude::MultiplicityInterval {
+    openehr_base::prelude::MultiplicityInterval {
+        lower: Some(1),
+        upper: Some(1),
+        lower_unbounded: false,
+        upper_unbounded: false,
+        lower_included: true,
+        upper_included: true,
+    }
+}
+
+fn set_occurrences(obj: &mut CObject, occ: openehr_base::prelude::MultiplicityInterval) {
+    match obj {
+        CObject::CComplexObject(CComplexObject::CComplexObject(d)) => d.occurrences = Some(occ),
+        CObject::CComplexObject(CComplexObject::CArchetypeRoot(r)) => r.occurrences = Some(occ),
+        CObject::CComplexObjectProxy(p) => p.occurrences = Some(occ),
+        CObject::ArchetypeSlot(s) => s.occurrences = Some(occ),
+        CObject::CBoolean(o) => o.occurrences = Some(occ),
+        CObject::CInteger(o) => o.occurrences = Some(occ),
+        CObject::CReal(o) => o.occurrences = Some(occ),
+        CObject::CString(o) => o.occurrences = Some(occ),
+        CObject::CTerminologyCode(o) => o.occurrences = Some(occ),
+        CObject::CDate(o) => o.occurrences = Some(occ),
+        CObject::CTime(o) => o.occurrences = Some(occ),
+        CObject::CDateTime(o) => o.occurrences = Some(occ),
+        CObject::CDuration(o) => o.occurrences = Some(occ),
+    }
 }
 
 fn elide_cco(cco: &mut CComplexObject) {

--- a/crates/openehr-adl/src/cadl.rs
+++ b/crates/openehr-adl/src/cadl.rs
@@ -119,16 +119,24 @@ pub fn parse_definition(src: &str) -> Result<CComplexObject, Vec<SyntaxError>> {
 
 /// Which ADL dialect the cADL parser accepts.
 ///
-/// `Adl2` is the spec-conformant grammar (`cadl2.g4`); `Adl14` additionally
-/// tolerates the ADL 1.4-only definition forms the `adl14` 1.4→2 converter
-/// front end feeds it — qualified/listed terminology constraints
-/// (`[local::at0001]`, `[local:: a, b, c ; assumed]`, `[openehr::524]`) and the
-/// inline dADL domain constraints (`C_DV_QUANTITY <…>`, `(C_DV_ORDINAL) <…>`).
+/// `Adl2` is the spec-conformant grammar (`cadl2.g4`). `Adl14` accepts the ADL
+/// 1.4 cADL language: it ADDS the 1.4-only definition forms — qualified/listed
+/// terminology constraints (`[local::at0001]`, `[local:: a, b, c ; assumed]`,
+/// `[openehr::524]`) and the inline dADL domain constraints
+/// (`C_DV_QUANTITY <…>`, `(C_DV_ORDINAL) <…>`) — and REMOVES the constructs ADL
+/// 2 introduced, because a 1.4 source is judged as 1.4 rather than as a
+/// permissive superset. The removed set (each refused with a typed
+/// [`SyntaxError`] naming the construct, see [`Parser::adl2_only`]):
+/// `use_archetype`, the slot `closed` marker, the `_default` pseudo-attribute,
+/// second-order attribute tuples, term-constraint strengths, and `@terminology`
+/// operational bindings. `before`/`after` sibling order stays accepted —
+/// `ADL1.4/master05-cadl.adoc` §Keywords L53 lists both as cADL 1.4 keywords.
 ///
-/// NOTE: no openEHR spec governs 1.4→2 conversion — the `Adl14` acceptance here
-/// exists only to feed `crate::adl14`; it is our own design (see the module
-/// flag on `crate::adl14`). It is purely additive (the tolerated forms are not
-/// valid `cadl2.g4`), so `Adl2` parsing is byte-identical.
+/// NOTE: no openEHR spec governs 1.4→2 conversion — the additive half exists
+/// only to feed `crate::adl14` and is our own design (see the module flag on
+/// `crate::adl14`). The subtractive half IS spec-grounded: the closed cADL 1.4
+/// keyword set of `ADL1.4/master05-cadl.adoc` §Keywords (L48-53). `Adl2` parsing
+/// is unchanged either way.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Dialect {
     /// The spec-conformant ADL2 grammar.
@@ -248,6 +256,31 @@ impl Parser<'_> {
         let span = self.cur_span();
         self.push(code, msg, span);
         Err(())
+    }
+
+    /// Refuse an ADL 2-only cADL construct met while parsing in the
+    /// [`Dialect::Adl14`] dialect.
+    ///
+    /// A 1.4 source is judged AS 1.4. The cADL 1.4 keyword set is CLOSED —
+    /// `ADL1.4/master05-cadl.adoc` §Keywords (L48-53) lists exactly
+    /// `matches`/`~matches`/`is_in`/`~is_in`, `occurrences`/`existence`/
+    /// `cardinality`, `ordered`/`unordered`/`unique`, `infinity`,
+    /// `use_node`/`allow_archetype`, `include`/`exclude`, `before`/`after` — so a
+    /// construct that ADL 2 added is a syntax error in a 1.4 text, not a
+    /// silently-accepted superset.
+    ///
+    /// NOTE: the `S*` code space is a verbatim 1:1 mirror of the openEHR
+    /// catalogue (`ADL2/master04.6-cadl_validity_rules.adoc` §Syntax Validity
+    /// Rules) and carries no "wrong ADL generation" code, so each gate reuses the
+    /// catalogue code for its parse POSITION (`SCOAT` in an object body, `SCCOG`
+    /// in object position, `STCCP` inside a term-code constraint) and names the
+    /// construct plus the generation in the message. Inventing a code would break
+    /// the 1:1 mirror [`SyntaxErrorCode`] documents.
+    fn adl2_only<T>(&mut self, code: SyntaxErrorCode, construct: &str) -> PResult<T> {
+        self.err(
+            code,
+            format!("{construct} is an ADL 2 construct and is not valid in ADL 1.4"),
+        )
     }
 
     /// Consume a token matching `pred` or record `code`/`msg` and bail.
@@ -552,10 +585,33 @@ impl Parser<'_> {
         while !matches!(self.peek(), Some(Token::RCurly) | None) {
             match self.peek() {
                 Some(Token::AlphaUnderscoreId(s)) if s == "_default" => {
+                    // ADL2-only: the `_default` pseudo-attribute is introduced by
+                    // `ADL2/master06-default_values.adoc` §Default Values; the 1.4
+                    // cADL keyword set (master05 §Keywords L48-53) has no such
+                    // construct and no 1.4 chapter defines default values.
+                    if self.dialect == Dialect::Adl14 {
+                        return self
+                            .adl2_only(SyntaxErrorCode::Scoat, "the '_default' pseudo-attribute");
+                    }
                     default = Some(self.parse_default_value()?);
                     break; // default_value is last in the body (`cadl2.g4`).
                 }
-                Some(Token::LBracket) => tuples.push(self.parse_c_attribute_tuple()?),
+                Some(Token::LBracket) => {
+                    // ADL2-only: second-order attribute tuples
+                    // (`ADL2/master04.4-cadl_second_order.adoc` §Second Order
+                    // Constraints). ADL 1.4 expresses the same co-constraint with
+                    // an inline dADL domain type — `AOM2/master04.3` §Tuple
+                    // Constraints: "The tuple constraint type replaces all
+                    // domain-specific constraint types defined in ADL/AOM 1.4,
+                    // including `C_DV_QUANTITY` and `C_DV_ORDINAL`."
+                    if self.dialect == Dialect::Adl14 {
+                        return self.adl2_only(
+                            SyntaxErrorCode::Scoat,
+                            "a second-order attribute tuple '[attr, …] matches {…}'",
+                        );
+                    }
+                    tuples.push(self.parse_c_attribute_tuple()?);
+                }
                 _ => attrs.push(self.parse_c_attribute()?),
             }
         }
@@ -967,6 +1023,13 @@ impl Parser<'_> {
     }
 
     /// `c_regular_object_ordered : sibling_order? c_regular_object`.
+    ///
+    /// NOTE: the `before`/`after` sibling-order markers are NOT dialect-gated.
+    /// `ADL1.4/master05-cadl.adoc` §Keywords L53 lists `before` and `after` among
+    /// "the keywords … recognised in cADL" for the 1.4 formalism itself, so a
+    /// sibling order in a 1.4 text is legal 1.4 cADL — even though no 1.4 chapter
+    /// elaborates its semantics beyond that list. Refusing it here would
+    /// contradict the 1.4 keyword set.
     fn parse_c_regular_object_ordered(&mut self) -> PResult<CObject> {
         let sibling = if matches!(self.peek(), Some(Token::SymAfter | Token::SymBefore)) {
             Some(self.parse_sibling_order()?)
@@ -1013,13 +1076,18 @@ impl Parser<'_> {
                     return self.parse_adl14_term_object();
                 }
                 Some(Token::LParen) => return self.parse_adl14_domain_object(true),
-                // Bare `C_DV_QUANTITY <…>` / `C_DV_ORDINAL <…>` (no parens): a
+                // ADL2-only: `use_archetype` (`C_ARCHETYPE_ROOT`). The 1.4 cADL
+                // keyword set (master05 §Keywords L51) has `use_node` and
+                // `allow_archetype` only — an external archetype reference is
+                // expressed in 1.4 by an `allow_archetype` slot whose assertions
+                // name the archetype id (master05 §Archetype Slots).
+                Some(Token::SymUseArchetype) => {
+                    return self.adl2_only(SyntaxErrorCode::Sccog, "'use_archetype'");
+                }
+                // Bare `C_DV_QUANTITY <…>` / `(C_CODE_PHRASE) <…>` (no parens): a
                 // domain type immediately followed by an ODIN block would
                 // otherwise be misread as a generic type by `parse_rm_type_id`.
-                Some(Token::AlphaUcId(id))
-                    if is_adl14_domain_type(id)
-                        && matches!(self.peek_at(1), Some(Token::SymLt)) =>
-                {
+                Some(Token::AlphaUcId(_)) if self.is_adl14_domain_block_start() => {
                     return self.parse_adl14_domain_object(false);
                 }
                 _ => {}
@@ -1035,6 +1103,25 @@ impl Parser<'_> {
                 "expecting a new node definition, primitive node, 'use' path, or archetype reference",
             ),
         }
+    }
+
+    /// True if the cursor is at a BARE (unparenthesised) 1.4 inline dADL domain
+    /// block: a type name immediately followed by `<` whose first inner token is
+    /// an attribute name.
+    ///
+    /// `ADL1.4/master09-customising_adl.adoc` §Introduction fixes the shape —
+    /// "the dADL section must be 'typed', i.e. it must start with a type name"
+    /// followed by the ODIN object — so the discriminator against a generic cADL
+    /// type (`HISTORY<ITEM_LIST>`, whose `<` is followed by a TYPE name) is the
+    /// case of the token after `<`. Matching on the shape rather than on a
+    /// known-type list is what lets an unsupported domain type
+    /// (`C_CODE_PHRASE <…>`) reach the typed refusal in
+    /// [`Parser::parse_adl14_domain_object`] instead of being mis-parsed as a
+    /// generic type.
+    fn is_adl14_domain_block_start(&self) -> bool {
+        matches!(self.peek(), Some(Token::AlphaUcId(_)))
+            && matches!(self.peek_at(1), Some(Token::SymLt))
+            && matches!(self.peek_at(2), Some(Token::AlphaLcId(_)))
     }
 
     /// True if the cursor is at a 1.4 qualified/listed terminology constraint
@@ -1150,10 +1237,25 @@ impl Parser<'_> {
     /// `C_DV_ORDINAL <…>`. The ODIN block is parsed via `openehr_lang::odin`
     /// and lowered to a `DV_QUANTITY`/`DV_ORDINAL` `C_COMPLEX_OBJECT` (the RM
     /// type the domain constrainer targets), carrying the `property` external
-    /// code as a `C_TERMINOLOGY_CODE` and the `list` rows as an attribute tuple
-    /// (multi-member) or plain attributes (single member). No openEHR spec
-    /// governs this — our own design (1.4→2 converter front end;
-    /// `AOM2/master04.4` §Second-Order Constraints is the ADL2 tuple target).
+    /// code as a `C_TERMINOLOGY_CODE`, the `list` rows as an attribute tuple
+    /// (multi-member) or plain attributes (single member), and the
+    /// `assumed_value` object as the per-leaf `C_PRIMITIVE_OBJECT.assumed_value`s
+    /// it decomposes into. No openEHR spec governs the 1.4→2 lowering — our own
+    /// design (converter front end); `AOM2/master04.3` §Tuple Constraints is the
+    /// ADL2 target ("The tuple constraint type replaces all domain-specific
+    /// constraint types defined in ADL/AOM 1.4, including `C_DV_QUANTITY` and
+    /// `C_DV_ORDINAL`").
+    ///
+    /// A domain type this lowering does not model is refused with a typed
+    /// [`SyntaxErrorCode::Sdinv`] naming the type, never lowered to some other
+    /// type: `ADL1.4/master09-customising_adl.adoc` §Introduction admits any
+    /// `C_DOMAIN_TYPE` descendant here ("This approach can be used for any custom
+    /// type which represents a constraint on a reference model type"), and each
+    /// one targets a DIFFERENT RM type, so guessing is a silent wrong answer.
+    // TODO: lower the remaining openEHR Archetype Profile domain constrainers
+    // (`C_CODE_PHRASE` → `CODE_PHRASE`, `C_DV_STATE` → `DV_STATE`;
+    // `ADL1.4/master09-customising_adl.adoc` §Custom Syntax) so they stop being
+    // refused — tracked as the ADL1.4 master09 chapter audit.
     fn parse_adl14_domain_object(&mut self, parenthesised: bool) -> PResult<CObject> {
         let start = self.cur_span().start;
         if parenthesised {
@@ -1200,22 +1302,44 @@ impl Parser<'_> {
         let Some(close) = close else {
             return self.err(SyntaxErrorCode::Sdinv, "unterminated domain block '<…>'");
         };
+        let span = start..self.span_at(close).end;
+        if !is_adl14_domain_type(&rm_type) {
+            self.push(
+                SyntaxErrorCode::Sdinv,
+                format!(
+                    "inline dADL domain constrainer {rm_type:?} is not supported; only \
+                     'C_DV_QUANTITY' and 'C_DV_ORDINAL' are lowered"
+                ),
+                span,
+            );
+            return Err(());
+        }
         let block = &self.src[self.span_at(open).start..self.span_at(close).end];
         let Ok(odin) = openehr_lang::odin::parse(block) else {
-            let span = start..self.span_at(close).end;
             self.push(SyntaxErrorCode::Sdinv, "invalid dADL in domain block", span);
             return Err(());
         };
-        if let Some(obj) = lower_adl14_domain(&rm_type, &odin) {
-            Ok(obj)
-        } else {
-            let span = start..self.span_at(close).end;
-            self.push(
-                SyntaxErrorCode::Sdinv,
-                "empty or unsupported inline dADL domain block",
-                span,
-            );
-            Err(())
+        match lower_adl14_domain(&rm_type, &odin) {
+            Ok(obj) => Ok(obj),
+            Err(DomainLoweringError::Empty) => {
+                self.push(
+                    SyntaxErrorCode::Sdinv,
+                    "empty or unsupported inline dADL domain block",
+                    span,
+                );
+                Err(())
+            }
+            Err(DomainLoweringError::AssumedValueUnmatched(attrs)) => {
+                self.push(
+                    SyntaxErrorCode::Sdinv,
+                    format!(
+                        "the domain block's 'assumed_value' ({attrs}) satisfies none of its \
+                         'list' rows"
+                    ),
+                    span,
+                );
+                Err(())
+            }
         }
     }
 
@@ -1377,7 +1501,16 @@ impl Parser<'_> {
         let mut includes = Vec::new();
         let mut excludes = Vec::new();
 
-        if self.eat(|t| matches!(t, Token::SymClosed)) {
+        if matches!(self.peek(), Some(Token::SymClosed)) {
+            // ADL2-only: the `closed` slot marker (`ADL2/master04.3` §Archetype
+            // Slots; `ARCHETYPE_SLOT.is_closed`, redefinition rule VDSSC). The 1.4
+            // cADL keyword set (master05 §Keywords L51-52) has `allow_archetype`
+            // with `include`/`exclude` only.
+            if self.dialect == Dialect::Adl14 {
+                return self
+                    .adl2_only(SyntaxErrorCode::Sccog, "the archetype-slot 'closed' marker");
+            }
+            self.pos += 1;
             is_closed = true;
         } else {
             if matches!(self.peek(), Some(Token::SymOccurrences)) {
@@ -1526,6 +1659,18 @@ impl Parser<'_> {
             Some(Token::String(_)) => self.parse_c_string(node_id),
             Some(Token::LBracket) => self.parse_c_terminology_code(node_id, None),
             Some(Token::AlphaLcId(s)) if is_strength_keyword(&s) => {
+                // ADL2-only: constraint strengths (`required`/`extensible`/
+                // `preferred`/`example`) are `C_TERMINOLOGY_CODE.constraint_status`,
+                // introduced by `AOM2/master04.2` §Constraint Strengths ("Uniquely
+                // in the AOM, a Terminology code constraint may not be required").
+                // The 1.4 cADL keyword set (master05 §Keywords L48-53) has no
+                // strength vocabulary and AOM 1.4 has no such attribute.
+                if self.dialect == Dialect::Adl14 {
+                    return self.adl2_only(
+                        SyntaxErrorCode::Stccp,
+                        format!("the term-constraint strength {s:?}").as_str(),
+                    );
+                }
                 self.pos += 1;
                 self.parse_c_terminology_code(node_id, Some(strength_status(&s)))
             }
@@ -1711,6 +1856,19 @@ impl Parser<'_> {
             _ => return self.err(SyntaxErrorCode::Stccp, "expecting an ac-code or at-code"),
         };
         // Optional OPT operational binding `@terminology`.
+        //
+        // ADL2-only: the `[acN@terminology]` operational binding belongs to the
+        // ADL2 terminology-integration surface (`ADL2/master08-terminology_integration.adoc`
+        // §Terminology Bindings / OPT2 operational form). The 1.4 cADL keyword set
+        // (master05 §Keywords L48-53) has no `@` operator, and 1.4 expresses
+        // external terminology through the qualified `[terminology::code, …]` form
+        // of `ADL1.4/master09-customising_adl.adoc` §Custom Syntax.
+        if matches!(self.peek(), Some(Token::SymAt)) && self.dialect == Dialect::Adl14 {
+            return self.adl2_only(
+                SyntaxErrorCode::Stccp,
+                "an '@terminology' operational binding on a term-code constraint",
+            );
+        }
         if self.eat(|t| matches!(t, Token::SymAt)) {
             match self.peek().cloned() {
                 Some(Token::AlphaLcId(t) | Token::AlphaUcId(t)) => {
@@ -2774,19 +2932,36 @@ fn untyped(v: &OdinValue) -> &OdinValue {
     cur
 }
 
+/// Why an inline dADL domain block could not be lowered (each maps to `SDINV`).
+enum DomainLoweringError {
+    /// An empty `<>` block, a bare scalar, or a type this lowering does not model.
+    Empty,
+    /// The block's `assumed_value` satisfies none of its `list` rows (the
+    /// attribute names carried for the message).
+    AssumedValueUnmatched(String),
+}
+
 /// Lower a parsed 1.4 inline dADL domain block into a `DV_QUANTITY`/`DV_ORDINAL`
-/// complex object. Returns `None` for an empty/unusable block (→ `SDINV`).
-fn lower_adl14_domain(rm_type: &str, odin: &OdinValue) -> Option<CObject> {
+/// complex object.
+///
+/// # Errors
+/// [`DomainLoweringError`] for an empty/unusable block or an `assumed_value` that
+/// matches no `list` row; the caller turns both into `SDINV`.
+fn lower_adl14_domain(rm_type: &str, odin: &OdinValue) -> Result<CObject, DomainLoweringError> {
     let OdinValue::Object(map) = untyped(odin) else {
-        return None; // empty `<>` or a bare scalar — nothing to constrain.
+        // Empty `<>` or a bare scalar — nothing to constrain.
+        return Err(DomainLoweringError::Empty);
     };
     if map.is_empty() {
-        return None;
+        return Err(DomainLoweringError::Empty);
     }
-    let target_rm = if rm_type == "C_DV_ORDINAL" {
-        "DV_ORDINAL"
-    } else {
-        "DV_QUANTITY"
+    let target_rm = match rm_type {
+        "C_DV_ORDINAL" => "DV_ORDINAL",
+        "C_DV_QUANTITY" => "DV_QUANTITY",
+        // Unreachable: the parse site gates the type before calling in. Kept as a
+        // typed refusal rather than a fallback so no other domain constrainer can
+        // ever be silently lowered to the wrong RM type.
+        _ => return Err(DomainLoweringError::Empty),
     };
     let mut attributes: Vec<CAttribute> = Vec::new();
     let mut attribute_tuples: Vec<CAttributeTuple> = Vec::new();
@@ -2862,13 +3037,295 @@ fn lower_adl14_domain(rm_type: &str, odin: &OdinValue) -> Option<CObject> {
         }
     }
 
-    Some(complex_object(
+    // `assumed_value = <units=<"C"> magnitude=<8.0> …>` — the 1.4 domain
+    // constrainer's assumed value is an INSTANCE of the constrained RM type
+    // (AOM 1.4 `C_DV_QUANTITY.assumed_value: DV_QUANTITY`). AOM2 has no
+    // `assumed_value` on `C_COMPLEX_OBJECT` — `AOM2/master04.2` §Assumed_value
+    // puts it on `C_PRIMITIVE_OBJECT`/`C_TERMINOLOGY_CODE`, and §Assumed_value
+    // L175 expressly separates it from `default_value` ("default values do appear
+    // in data, while assumed values don't"), so `default_value` is NOT a legal
+    // carrier. The instance is therefore decomposed into its per-attribute leaves
+    // and each leaf lands on the `C_PRIMITIVE_OBJECT.assumed_value` of the
+    // constraint this lowering already produced for that attribute.
+    if let Some(OdinValue::Object(assumed)) = map.get("assumed_value").map(untyped) {
+        apply_domain_assumed_values(assumed, &mut attributes, &mut attribute_tuples)?;
+    }
+
+    Ok(complex_object(
         target_rm.to_owned(),
         String::new(),
         attributes,
         attribute_tuples,
         None,
     ))
+}
+
+/// Land the leaves of a domain block's `assumed_value` object on the constraints
+/// `attributes`/`attribute_tuples` already carry.
+///
+/// A leaf whose attribute is a plain constraint sets that constraint's
+/// `assumed_value` directly. A leaf whose attribute is a tuple member sets the
+/// member of the ONE tuple row the whole assumed combination satisfies — a tuple
+/// row is a co-constrained alternative (`AOM2/master04.3` §Tuple Constraints), so
+/// the assumed instance belongs to exactly one row, never to all of them.
+///
+/// NOTE: a leaf for an attribute the block does not constrain at all (e.g.
+/// `precision` in an `assumed_value` whose `list` rows carry only
+/// `units`/`magnitude`) has no AOM2 carrier — `assumed_value` is a field OF a
+/// `C_PRIMITIVE_OBJECT` (`AOM2/master04.2` §`Assumed_value`), and an unconstrained
+/// attribute has no constraint object to hold it. Such a leaf is dropped rather
+/// than carried on a fabricated "any" constraint, which has no ADL2 rendering.
+/// No openEHR spec governs 1.4→2 conversion — our own design.
+///
+/// # Errors
+/// [`DomainLoweringError::AssumedValueUnmatched`] when tuple members are present
+/// and no row admits the assumed combination — the 1.4 source states an assumed
+/// value outside its own `list`, which the parse refuses loudly rather than
+/// binding to an arbitrary row.
+fn apply_domain_assumed_values(
+    assumed: &indexmap::IndexMap<String, OdinValue>,
+    attributes: &mut [CAttribute],
+    attribute_tuples: &mut [CAttributeTuple],
+) -> Result<(), DomainLoweringError> {
+    // The assumed leaves, as the primitive shape the constraint side uses.
+    let leaves: Vec<(String, CPrimitiveObject)> = assumed
+        .iter()
+        .filter_map(|(name, value)| {
+            domain_value_to_primitive(name, value).map(|p| (name.clone(), p))
+        })
+        .collect();
+    if leaves.is_empty() {
+        return Ok(());
+    }
+
+    // Plain attributes first.
+    for (name, leaf) in &leaves {
+        if let Some(attr) = attributes.iter_mut().find(|a| &a.rm_attribute_name == name)
+            && let Some(child) = attr.children.first_mut()
+        {
+            set_assumed_on_cobject(child, leaf);
+        }
+    }
+
+    // Tuple members: pick the single row the whole combination satisfies.
+    for tuple in attribute_tuples.iter_mut() {
+        let positions: Vec<(usize, &CPrimitiveObject)> = tuple
+            .members
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, m)| {
+                leaves
+                    .iter()
+                    .find(|(name, _)| name == &m.rm_attribute_name)
+                    .map(|(_, leaf)| (idx, leaf))
+            })
+            .collect();
+        if positions.is_empty() {
+            continue;
+        }
+        let row = tuple.tuples.iter().position(|row| {
+            positions.iter().all(|(idx, leaf)| {
+                row.members
+                    .get(*idx)
+                    .is_some_and(|constraint| primitive_admits(constraint, leaf))
+            })
+        });
+        let Some(row) = row else {
+            let named = positions
+                .iter()
+                .filter_map(|(idx, _)| tuple.members.get(*idx))
+                .map(|m| m.rm_attribute_name.clone())
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(DomainLoweringError::AssumedValueUnmatched(named));
+        };
+        for (idx, leaf) in positions {
+            if let Some(row) = tuple.tuples.get_mut(row)
+                && let Some(member) = row.members.get_mut(idx)
+            {
+                set_assumed_on_primitive(member, leaf);
+            }
+        }
+    }
+    Ok(())
+}
+
+/// True if `constraint` admits the single value `value` carries.
+///
+/// Deliberately CONSERVATIVE: it answers `false` only where non-membership is
+/// positively decidable (a string not in a value list, a number outside every
+/// interval). A mismatched kind or an unconstrained (`{*}`) constraint answers
+/// `true`, so the refusal it feeds can never fire on a case this lowering does
+/// not fully understand.
+fn primitive_admits(constraint: &CPrimitiveObject, value: &CPrimitiveObject) -> bool {
+    match (constraint, value) {
+        (CPrimitiveObject::CString(c), CPrimitiveObject::CString(v)) => {
+            c.constraint.is_empty()
+                || v.constraint
+                    .iter()
+                    .all(|want| c.constraint.iter().any(|have| have == want))
+        }
+        (CPrimitiveObject::CReal(c), CPrimitiveObject::CReal(v)) => {
+            c.constraint.is_empty()
+                || v.constraint
+                    .iter()
+                    .filter_map(interval_point_f64)
+                    .all(|p| c.constraint.iter().any(|iv| real_interval_contains(iv, p)))
+        }
+        (CPrimitiveObject::CInteger(c), CPrimitiveObject::CInteger(v)) => {
+            c.constraint.is_empty()
+                || v.constraint
+                    .iter()
+                    .filter_map(interval_point_i32)
+                    .all(|p| c.constraint.iter().any(|iv| int_interval_contains(iv, p)))
+        }
+        _ => true,
+    }
+}
+
+/// Set `leaf`'s single value as the `assumed_value` of the primitive `target`.
+fn set_assumed_on_primitive(target: &mut CPrimitiveObject, leaf: &CPrimitiveObject) {
+    match (target, leaf) {
+        (CPrimitiveObject::CString(t), CPrimitiveObject::CString(l)) => {
+            t.assumed_value = l.constraint.first().cloned();
+        }
+        (CPrimitiveObject::CReal(t), CPrimitiveObject::CReal(l)) => {
+            t.assumed_value = l.constraint.first().and_then(interval_point_f64);
+        }
+        (CPrimitiveObject::CInteger(t), CPrimitiveObject::CInteger(l)) => {
+            t.assumed_value = l
+                .constraint
+                .first()
+                .and_then(interval_point_i32)
+                .map(f64::from);
+        }
+        (CPrimitiveObject::CBoolean(t), CPrimitiveObject::CBoolean(l)) => {
+            t.assumed_value = l.constraint.first().copied();
+        }
+        // Kind mismatch (or a leaf kind the domain lowering never produces):
+        // leave the constraint untouched rather than coerce across types.
+        _ => {}
+    }
+}
+
+/// Set `leaf`'s single value as the `assumed_value` of the primitive object
+/// `target` wraps, if it is one.
+fn set_assumed_on_cobject(target: &mut CObject, leaf: &CPrimitiveObject) {
+    match target {
+        CObject::CString(t) => {
+            if let CPrimitiveObject::CString(l) = leaf {
+                t.assumed_value = l.constraint.first().cloned();
+            }
+        }
+        CObject::CReal(t) => {
+            if let CPrimitiveObject::CReal(l) = leaf {
+                t.assumed_value = l.constraint.first().and_then(interval_point_f64);
+            }
+        }
+        CObject::CInteger(t) => {
+            if let CPrimitiveObject::CInteger(l) = leaf {
+                t.assumed_value = l
+                    .constraint
+                    .first()
+                    .and_then(interval_point_i32)
+                    .map(f64::from);
+            }
+        }
+        CObject::CBoolean(t) => {
+            if let CPrimitiveObject::CBoolean(l) = leaf {
+                t.assumed_value = l.constraint.first().copied();
+            }
+        }
+        _ => {}
+    }
+}
+
+/// The single point value of a real interval (`{v}` / `{v..v}`), else `None`.
+fn interval_point_f64(iv: &Interval<f64>) -> Option<f64> {
+    match iv {
+        Interval::PointInterval(p) => p.lower,
+        Interval::ProperInterval(_) => None,
+    }
+}
+
+/// The single point value of an integer interval (`{v}` / `{v..v}`), else `None`.
+fn interval_point_i32(iv: &Interval<i32>) -> Option<i32> {
+    match iv {
+        Interval::PointInterval(p) => p.lower,
+        Interval::ProperInterval(_) => None,
+    }
+}
+
+/// The `(lower, upper)` bounds of an interval as `f64`, each `None` when open or
+/// unbounded, plus the two inclusivity flags. A `MultiplicityInterval` variant
+/// (structurally possible on the generic enum but never produced for a domain
+/// leaf constraint) yields fully-open bounds, so membership is undecided and the
+/// conservative `true` answer stands.
+fn interval_bounds_f64<T: Copy + Into<f64>>(
+    iv: &Interval<T>,
+) -> (Option<f64>, Option<f64>, bool, bool) {
+    let (lower, upper, lower_unbounded, upper_unbounded, lower_included, upper_included) = match iv
+    {
+        Interval::PointInterval(p) => (
+            p.lower,
+            p.upper,
+            p.lower_unbounded,
+            p.upper_unbounded,
+            p.lower_included,
+            p.upper_included,
+        ),
+        Interval::ProperInterval(ProperInterval::ProperInterval(p)) => (
+            p.lower,
+            p.upper,
+            p.lower_unbounded,
+            p.upper_unbounded,
+            p.lower_included,
+            p.upper_included,
+        ),
+        Interval::ProperInterval(ProperInterval::MultiplicityInterval(_)) => {
+            return (None, None, true, true);
+        }
+    };
+    (
+        if lower_unbounded {
+            None
+        } else {
+            lower.map(Into::into)
+        },
+        if upper_unbounded {
+            None
+        } else {
+            upper.map(Into::into)
+        },
+        lower_included,
+        upper_included,
+    )
+}
+
+/// True if the real interval `iv` contains `v` (honouring open/closed bounds).
+fn real_interval_contains(iv: &Interval<f64>, v: f64) -> bool {
+    bounds_admit(v, interval_bounds_f64(iv))
+}
+
+/// True if the integer interval `iv` contains `v` (honouring open/closed bounds).
+fn int_interval_contains(iv: &Interval<i32>, v: i32) -> bool {
+    bounds_admit(f64::from(v), interval_bounds_f64(iv))
+}
+
+/// Interval membership over `f64` bounds, shared by the real/integer tests.
+fn bounds_admit(v: f64, bounds: (Option<f64>, Option<f64>, bool, bool)) -> bool {
+    let (lower, upper, lower_included, upper_included) = bounds;
+    if let Some(lo) = lower
+        && (v < lo || (!lower_included && (v - lo).abs() < f64::EPSILON))
+    {
+        return false;
+    }
+    if let Some(hi) = upper
+        && (v > hi || (!upper_included && (v - hi).abs() < f64::EPSILON))
+    {
+        return false;
+    }
+    true
 }
 
 /// The `["1"] = <…> …` rows of a domain `list`, each an ordered
@@ -3838,6 +4295,302 @@ mod tests {
         assert_eq!(range.upper, Some(5.5));
         assert!(range.lower_included);
         assert!(range.upper_included);
+    }
+
+    /// An interval has no ODIN/JSON default-value encoding
+    /// (`ADL2/master06-default_values.adoc` §Default Values: a `_default` is an
+    /// object INSTANCE, and an interval is a constraint), so a `_default`
+    /// carrying one is refused rather than silently reduced to null. This is the
+    /// ADL2 dialect's own behaviour — a 1.4 text has no `_default` at all
+    /// (`ADL1.4/master05-cadl.adoc` §Keywords L48-53), and the 1.4 refusal of the
+    /// construct is `tests/corpus/adl14-cadl/…SCOAT_adl2_default_value.v1.adl`.
+    #[test]
+    fn adl2_default_value_rejects_an_interval() {
+        let errs = parse_definition_body(
+            "OBSERVATION[id1] matches {\n\
+             data matches {\n\
+             HISTORY[id2] matches {\n\
+             _default = (DV_QUANTITY) <\n\
+             units = <\"mm[Hg]\">\n\
+             magnitude = <|0.0..5.0|>\n\
+             >\n\
+             }\n\
+             }\n\
+             }",
+        )
+        .expect_err("an interval in a `_default` must be refused");
+        assert!(
+            errs.iter().any(|e| e.code == SyntaxErrorCode::Sdinv),
+            "expected SDINV, got {:?}",
+            errs.iter().map(|e| e.code).collect::<Vec<_>>()
+        );
+    }
+
+    /// Every ADL2-only cADL construct is refused in the 1.4 dialect with the
+    /// typed code for its parse position, and is still accepted in ADL 2 — the
+    /// gate must narrow the 1.4 dialect only (`ADL1.4/master05-cadl.adoc`
+    /// §Keywords L48-53 is the closed 1.4 keyword set).
+    #[test]
+    fn adl2_only_constructs_are_refused_in_the_14_dialect_only() {
+        let cases: &[(&str, SyntaxErrorCode)] = &[
+            // `_default` (ADL2/master06-default_values.adoc).
+            (
+                "OBSERVATION[at0000] matches {\n\
+                 data matches {\n\
+                 HISTORY[at0001] matches {\n\
+                 _default = (DV_QUANTITY) <units = <\"mm[Hg]\"> magnitude = <5.0>>\n\
+                 }\n\
+                 }\n\
+                 }",
+                SyntaxErrorCode::Scoat,
+            ),
+            // Second-order attribute tuple (ADL2/master04.4).
+            (
+                "OBSERVATION[at0000] matches {\n\
+                 value matches {\n\
+                 DV_QUANTITY matches {\n\
+                 [magnitude, units] matches {\n\
+                 [{|>=0.0|}, {\"mm[Hg]\"}]\n\
+                 }\n\
+                 }\n\
+                 }\n\
+                 }",
+                SyntaxErrorCode::Scoat,
+            ),
+            // `use_archetype` (ADL2/master04.3 §Archetype Slots).
+            (
+                "SECTION[at0000] matches {\n\
+                 items cardinality matches {0..*} matches {\n\
+                 use_archetype CLUSTER[at0001, openEHR-EHR-CLUSTER.dimensions.v1]\n\
+                 }\n\
+                 }",
+                SyntaxErrorCode::Sccog,
+            ),
+            // The slot `closed` marker (ADL2/master04.3 §Archetype Slots).
+            (
+                "SECTION[at0000] matches {\n\
+                 items cardinality matches {0..*} matches {\n\
+                 allow_archetype CLUSTER[at0001] closed\n\
+                 }\n\
+                 }",
+                SyntaxErrorCode::Sccog,
+            ),
+            // Constraint strength (AOM2/master04.2 §Constraint Strengths).
+            (
+                "ELEMENT[at0000] matches {\n\
+                 value matches {\n\
+                 DV_CODED_TEXT matches {\n\
+                 defining_code matches {preferred [ac0001]}\n\
+                 }\n\
+                 }\n\
+                 }",
+                SyntaxErrorCode::Stccp,
+            ),
+            // `@terminology` operational binding (ADL2/master08).
+            (
+                "ELEMENT[at0000] matches {\n\
+                 value matches {\n\
+                 DV_CODED_TEXT matches {\n\
+                 defining_code matches {[ac0001@snomed]}\n\
+                 }\n\
+                 }\n\
+                 }",
+                SyntaxErrorCode::Stccp,
+            ),
+        ];
+        for (src, code) in cases {
+            let errs = parse_definition_body_adl14(src)
+                .err()
+                .unwrap_or_else(|| panic!("the 1.4 dialect must refuse:\n{src}"));
+            assert!(
+                errs.iter().any(|e| &e.code == code),
+                "expected {code} for:\n{src}\ngot {:?}",
+                errs.iter().map(|e| e.code).collect::<Vec<_>>()
+            );
+            assert!(
+                parse_definition_body(src).is_ok(),
+                "the ADL2 dialect must still accept:\n{src}"
+            );
+        }
+    }
+
+    /// `before`/`after` are cADL 1.4 keywords (`ADL1.4/master05-cadl.adoc`
+    /// §Keywords L53), so a sibling order is legal in a 1.4 text and must not be
+    /// gated with the ADL2-only constructs.
+    #[test]
+    fn adl14_accepts_sibling_order() {
+        let cco = parse_definition_body_adl14(
+            "CLUSTER[at0000] matches {\n\
+             items cardinality matches {0..*} matches {\n\
+             ELEMENT[at0001] matches {*}\n\
+             before [at0001] ELEMENT[at0002] matches {*}\n\
+             }\n\
+             }",
+        )
+        .expect("sibling order is legal ADL 1.4 cADL");
+        let CComplexObject::CComplexObject(d) = &cco else {
+            panic!("expected a plain complex object root");
+        };
+        let CObject::CComplexObject(CComplexObject::CComplexObject(second)) =
+            &d.attributes[0].children[1]
+        else {
+            panic!("expected the re-ordered ELEMENT");
+        };
+        let order = second.sibling_order.as_ref().expect("a sibling order");
+        assert!(order.is_before);
+        assert_eq!(order.sibling_node_id, "at0001");
+    }
+
+    /// A domain block's `assumed_value` decomposes onto the leaf constraints the
+    /// lowering produced: `AOM2/master04.2` §`Assumed_value` puts `assumed_value` on
+    /// `C_PRIMITIVE_OBJECT` (never on a `C_COMPLEX_OBJECT`, and never on
+    /// `default_value` — L175 separates the two notions), and
+    /// `AOM2/master04.3` §Tuple Constraints makes a tuple ROW one co-constrained
+    /// alternative, so the assumed instance binds to exactly the row it satisfies.
+    #[test]
+    fn adl14_domain_assumed_value_lands_on_the_matching_tuple_row() {
+        let cco = parse_definition_body_adl14(
+            "ELEMENT[at0000] matches {\n\
+             value matches {\n\
+             C_DV_QUANTITY <\n\
+             assumed_value = <units = <\"C\"> precision = <0> magnitude = <8.0>>\n\
+             list = <\n\
+             [\"1\"] = <units = <\"C\"> magnitude = <|>=4.0|>>\n\
+             [\"2\"] = <units = <\"F\"> magnitude = <|>=40.0|>>\n\
+             >\n\
+             >\n\
+             }\n\
+             }",
+        )
+        .expect("the 1.4 inline domain block must parse");
+        let CComplexObject::CComplexObject(d) = &cco else {
+            panic!("expected a plain complex object root");
+        };
+        let CObject::CComplexObject(CComplexObject::CComplexObject(quantity)) =
+            &d.attributes[0].children[0]
+        else {
+            panic!("expected the lowered DV_QUANTITY object");
+        };
+        let tuple = &quantity.attribute_tuples[0];
+        assert_eq!(
+            tuple
+                .members
+                .iter()
+                .map(|m| m.rm_attribute_name.as_str())
+                .collect::<Vec<_>>(),
+            ["units", "magnitude"]
+        );
+        // Row 0 (`"C"`, >=4.0) admits the assumed combination; row 1 (`"F"`,
+        // >=40.0) does not and must be left untouched.
+        let CPrimitiveObject::CString(units0) = &tuple.tuples[0].members[0] else {
+            panic!("units is a string constraint");
+        };
+        assert_eq!(units0.assumed_value.as_deref(), Some("C"));
+        let CPrimitiveObject::CReal(magnitude0) = &tuple.tuples[0].members[1] else {
+            panic!("magnitude is a real constraint");
+        };
+        assert_eq!(magnitude0.assumed_value, Some(8.0));
+        let CPrimitiveObject::CString(units1) = &tuple.tuples[1].members[0] else {
+            panic!("units is a string constraint");
+        };
+        assert_eq!(units1.assumed_value, None);
+    }
+
+    /// A single-attribute domain block merges its rows into one plain constraint,
+    /// so the `assumed_value` lands directly on that leaf's
+    /// `C_PRIMITIVE_OBJECT.assumed_value` (`AOM2/master04.2` §`Assumed_value`).
+    #[test]
+    fn adl14_domain_assumed_value_lands_on_a_plain_attribute() {
+        let cco = parse_definition_body_adl14(
+            "ELEMENT[at0000] matches {\n\
+             value matches {\n\
+             C_DV_QUANTITY <\n\
+             assumed_value = <units = <\"F\">>\n\
+             list = <\n\
+             [\"1\"] = <units = <\"C\">>\n\
+             [\"2\"] = <units = <\"F\">>\n\
+             >\n\
+             >\n\
+             }\n\
+             }",
+        )
+        .expect("the 1.4 inline domain block must parse");
+        let CComplexObject::CComplexObject(d) = &cco else {
+            panic!("expected a plain complex object root");
+        };
+        let CObject::CComplexObject(CComplexObject::CComplexObject(quantity)) =
+            &d.attributes[0].children[0]
+        else {
+            panic!("expected the lowered DV_QUANTITY object");
+        };
+        let units = quantity
+            .attributes
+            .iter()
+            .find(|a| a.rm_attribute_name == "units")
+            .expect("units attribute");
+        let CObject::CString(c) = &units.children[0] else {
+            panic!("expected a C_STRING units constraint");
+        };
+        assert_eq!(c.constraint, vec!["C".to_owned(), "F".to_owned()]);
+        assert_eq!(c.assumed_value.as_deref(), Some("F"));
+    }
+
+    /// An assumed value satisfying no `list` row is refused: the 1.4 source states
+    /// an assumed instance outside its own constraint, and no tuple row can carry
+    /// it (`AOM2/master04.3` §Tuple Constraints).
+    #[test]
+    fn adl14_domain_assumed_value_outside_every_row_is_refused() {
+        let errs = parse_definition_body_adl14(
+            "ELEMENT[at0000] matches {\n\
+             value matches {\n\
+             C_DV_QUANTITY <\n\
+             assumed_value = <units = <\"kPa\"> magnitude = <8.0>>\n\
+             list = <\n\
+             [\"1\"] = <units = <\"mm[Hg]\"> magnitude = <|>=0.0|>>\n\
+             [\"2\"] = <units = <\"cm[H2O]\"> magnitude = <|>=0.0|>>\n\
+             >\n\
+             >\n\
+             }\n\
+             }",
+        )
+        .expect_err("an unmatched assumed value must be refused");
+        assert!(
+            errs.iter().any(|e| e.code == SyntaxErrorCode::Sdinv),
+            "expected SDINV, got {:?}",
+            errs.iter().map(|e| e.code).collect::<Vec<_>>()
+        );
+    }
+
+    /// An inline dADL domain block whose type is not one this lowering models is
+    /// refused by NAME, never lowered to a different RM type
+    /// (`ADL1.4/master09-customising_adl.adoc` §Introduction admits any
+    /// `C_DOMAIN_TYPE` descendant, each targeting a different RM type).
+    #[test]
+    fn adl14_unsupported_domain_type_is_refused_by_name() {
+        let errs = parse_definition_body_adl14(
+            "ELEMENT[at0000] matches {\n\
+             value matches {\n\
+             DV_CODED_TEXT matches {\n\
+             defining_code matches {\n\
+             (C_CODE_PHRASE) <\n\
+             terminology_id = <value = <\"local\">>\n\
+             code_list = <[\"1\"] = <\"at0001\">>\n\
+             >\n\
+             }\n\
+             }\n\
+             }\n\
+             }",
+        )
+        .expect_err("an unmodelled domain constrainer must be refused");
+        let sdinv = errs
+            .iter()
+            .find(|e| e.code == SyntaxErrorCode::Sdinv)
+            .expect("SDINV");
+        assert!(
+            sdinv.message.contains("C_CODE_PHRASE"),
+            "the message must name the type, got {:?}",
+            sdinv.message
+        );
     }
 
     #[test]

--- a/crates/openehr-adl/src/validate/conformance.rs
+++ b/crates/openehr-adl/src/validate/conformance.rs
@@ -21,7 +21,7 @@ use openehr_base::prelude::{Cardinality, MultiplicityInterval};
 
 use super::rm::{Bounds, RmModel};
 use crate::codes::codes_conformant;
-use crate::paths::object_node_id;
+use crate::paths::{locate, object_node_id};
 
 /// The AOM meta-type (node class) of a [`CObject`], for the VSONT meta-type
 /// conformance rule (`master04.5` §Validity Rules: `C_OBJECT`, VSONT L342).
@@ -258,6 +258,56 @@ pub fn collective_occurrences_of(
         upper.map(|u| i32::try_from(u).unwrap_or(i32::MAX)),
     )
 }
+
+/// The EFFECTIVE `existence` of an attribute in an **ADL 1.4** text: the stated
+/// `existence` if there is one, else the 1.4 default `{1..1}`.
+///
+/// `ADL1.4/master05-cadl.adoc` §Existence L210: "The default existence
+/// constraint, if none is shown, is {1..1}." ADL 1.4 states the default in the
+/// formalism itself, so it is supplied as an ACCESSOR over the parsed model — the
+/// parsed structure is never rewritten, and an absent `existence` stays absent in
+/// the AOM (which is what the 1.4→2 converter and the printer must see).
+#[must_use]
+pub fn effective_existence_adl14(attr: &CAttribute) -> Bounds {
+    attr.existence.as_ref().map_or(BOUNDS_ONE, bounds)
+}
+
+/// The EFFECTIVE `occurrences` of an object node in an **ADL 1.4** text.
+///
+/// - A stated `occurrences` wins.
+/// - A `use_node` internal reference with none takes the referenced node's:
+///   `ADL1.4/master05-cadl.adoc` §Internal References L515 — "Unlike other node
+///   types, if no `occurrences` is mentioned, the value of the `occurrences` is
+///   set to that of the referenced node (which if not explicitly mentioned will be
+///   the default occurrences)". `root` is the archetype's definition root, against
+///   which the proxy's target path resolves; a non-specialised 1.4 archetype is
+///   its own flat form, so the path resolves locally.
+/// - Otherwise the 1.4 default `{1..1}`: `ADL1.4/master05-cadl.adoc`
+///   §Occurrences L316 — "The default occurrences, if none is mentioned, is
+///   `{1..1}`".
+///
+/// As with [`effective_existence_adl14`], this is an accessor: nothing is written
+/// back into the parsed model.
+#[must_use]
+pub fn effective_occurrences_adl14(root: &CComplexObject, obj: &CObject) -> Bounds {
+    if let Some(occ) = child_occurrences(obj) {
+        return bounds(occ);
+    }
+    if let CObject::CComplexObjectProxy(proxy) = obj
+        && let Some(target) = locate(root, &proxy.target_path)
+        && let Some(occ) = child_occurrences(target)
+    {
+        return bounds(occ);
+    }
+    BOUNDS_ONE
+}
+
+/// The ADL 1.4 default multiplicity `{1..1}`, shared by the existence
+/// (`master05` L210) and occurrences (`master05` L316) defaults.
+const BOUNDS_ONE: Bounds = Bounds {
+    lower: 1,
+    upper: Some(1),
+};
 
 /// The `occurrences` interval of any [`CObject`], if it carries one.
 #[must_use]
@@ -617,6 +667,102 @@ mod tests {
             Some(&mi(0, Some(3)))
         ));
     }
+
+    /// Build the definition root of a tiny 1.4 archetype, for the ADL 1.4
+    /// effective-value tests.
+    fn definition_of_adl14(src: &str) -> CComplexObject {
+        let art = crate::assemble::parse_artefact_adl14(src).unwrap();
+        match art {
+            Archetype::AuthoredArchetype(a) => match *a {
+                AuthoredArchetype::AuthoredArchetype(d) => d.definition,
+                AuthoredArchetype::Template(t) => t.definition,
+                AuthoredArchetype::OperationalTemplate(o) => o.definition,
+            },
+            Archetype::TemplateOverlay(t) => t.definition,
+        }
+    }
+
+    /// The ADL 1.4 defaults are EFFECTIVE values, applied by the accessor and
+    /// never written back: `ADL1.4/master05-cadl.adoc` §Existence L210 ("The
+    /// default existence constraint, if none is shown, is {1..1}") and
+    /// §Occurrences L316 ("The default occurrences, if none is mentioned, is
+    /// `{1..1}`").
+    #[test]
+    fn adl14_effective_defaults_are_one_to_one() {
+        let root = definition_of_adl14(ADL14_USE_NODE_SRC);
+        let items = complex_attributes(&root)
+            .iter()
+            .find(|a| a.rm_attribute_name == "items")
+            .unwrap()
+            .clone();
+        // The attribute states no existence ⇒ effective {1..1} (L210); the parsed
+        // structure keeps it absent.
+        assert!(items.existence.is_none());
+        assert_eq!(effective_existence_adl14(&items), Bounds::new(1, Some(1)));
+
+        // at0001 states no occurrences ⇒ effective {1..1} (L316).
+        let plain = &items.children[0];
+        assert!(child_occurrences(plain).is_none());
+        assert_eq!(
+            effective_occurrences_adl14(&root, plain),
+            Bounds::new(1, Some(1))
+        );
+        // at0002 states {0..2} ⇒ that wins.
+        assert_eq!(
+            effective_occurrences_adl14(&root, &items.children[1]),
+            Bounds::new(0, Some(2))
+        );
+    }
+
+    /// `ADL1.4/master05-cadl.adoc` §Internal References L515: a `use_node` with no
+    /// stated `occurrences` takes the REFERENCED node's — here at0002's {0..2},
+    /// not the {1..1} default.
+    #[test]
+    fn adl14_use_node_inherits_the_referenced_node_occurrences() {
+        let root = definition_of_adl14(ADL14_USE_NODE_SRC);
+        let items = complex_attributes(&root)
+            .iter()
+            .find(|a| a.rm_attribute_name == "items")
+            .unwrap()
+            .clone();
+        let proxy = &items.children[2];
+        assert!(child_occurrences(proxy).is_none());
+        assert_eq!(
+            effective_occurrences_adl14(&root, proxy),
+            Bounds::new(0, Some(2))
+        );
+    }
+
+    const ADL14_USE_NODE_SRC: &str = "\
+archetype (adl_version=1.4)
+\topenEHR-EHR-CLUSTER.effective.v1
+
+language
+\toriginal_language = <[ISO_639-1::en]>
+
+description
+\tlifecycle_state = <\"AuthorDraft\">
+
+definition
+\tCLUSTER[at0000] matches {
+\t\titems cardinality matches {0..*; unordered} matches {
+\t\t\tELEMENT[at0001] matches {*}
+\t\t\tELEMENT[at0002] occurrences matches {0..2} matches {*}
+\t\t\tuse_node ELEMENT /items[at0002]
+\t\t}
+\t}
+
+ontology
+\tterm_definitions = <
+\t\t[\"en\"] = <
+\t\t\titems = <
+\t\t\t\t[\"at0000\"] = <text=<\"\"> description=<\"\">>
+\t\t\t\t[\"at0001\"] = <text=<\"\"> description=<\"\">>
+\t\t\t\t[\"at0002\"] = <text=<\"\"> description=<\"\">>
+\t\t\t>
+\t\t>
+\t>
+";
 
     #[test]
     fn node_id_conformance_uses_codes_conformant() {

--- a/crates/openehr-adl/src/validate/mod.rs
+++ b/crates/openehr-adl/src/validate/mod.rs
@@ -252,6 +252,12 @@ pub enum ValidationCode {
     /// VACMCU — cardinality/occurrences upper bound validity (`master04.5`
     /// §`C_ATTRIBUTE`).
     Vacmcu,
+    /// VCOC — ADL 1.4 cardinality/occurrences validity: the interval formed by the
+    /// sums of the children's occurrences minima..maxima must be inside the
+    /// container's cardinality interval (`ADL1.4/master05-cadl.adoc` §Occurrences
+    /// L321-324). The ADL 1.4 formalism's own rule, raised only on the 1.4
+    /// dialect; the AOM2 successor is the VACMCU/WACMCL pair.
+    Vcoc,
     /// VACMCO — cardinality/occurrences orphans: every mandatory child and one
     /// optional child must fit within the container cardinality (`master04.5`
     /// §`C_ATTRIBUTE` VACMCO L158-159; a phase-3 flat-form check, [`phase3`]).
@@ -417,6 +423,7 @@ impl ValidationCode {
             Self::Vrmvav => "VRMVAV",
             Self::Vacso => "VACSO",
             Self::Vacmcu => "VACMCU",
+            Self::Vcoc => "VCOC",
             Self::Vacmco => "VACMCO",
             Self::Vsonif => "VSONIF",
             Self::Vrdla => "VRDLA",
@@ -696,6 +703,17 @@ pub fn validate_source_phase1(
 /// completeness), VDSEV/VDSIV (slot include/exclude consistency), VDFAI (slot
 /// archetype-id validity), VACSD/VASID/VALC (specialisation depth/parent/language
 /// where a parent is resolvable), VRANP/VOKU/VRRLP.
+///
+/// Two checks are 1.4-ONLY (the ADL 1.4 formalism's own rules, absent from AOM2):
+/// - **VCOC** — cardinality/occurrences validity over the children's EFFECTIVE
+///   occurrences (`ADL1.4/master05-cadl.adoc` §Occurrences L321-324; the AOM2
+///   successor is the VACMCU/WACMCL pair). See [`phase1`] for the adjudication of
+///   which half of the literal formula is enforceable.
+/// - **VATDF/VACDF over the 1.4 term-constraint spelling** — the qualified/listed
+///   form `[local:: a, b ; assumed]` of
+///   `ADL1.4/master09-customising_adl.adoc` §Custom Syntax is decomposed into its
+///   codes (assumed code included) so definedness is judged per code; external
+///   terminology codes are not archetype terms and are excluded.
 ///
 /// # Errors
 /// Returns the parse [`SyntaxError`]s if `src` does not parse as ADL 1.4;
@@ -1020,6 +1038,7 @@ mod tests {
             ValidationCode::Vrmvav,
             ValidationCode::Vacso,
             ValidationCode::Vacmcu,
+            ValidationCode::Vcoc,
             ValidationCode::Vacmco,
             ValidationCode::Vsonif,
             ValidationCode::Vrdla,
@@ -1062,6 +1081,6 @@ mod tests {
             };
             assert_eq!(c.severity(), expected, "{c} severity");
         }
-        assert_eq!(seen.len(), 90);
+        assert_eq!(seen.len(), 91);
     }
 }

--- a/crates/openehr-adl/src/validate/phase1.rs
+++ b/crates/openehr-adl/src/validate/phase1.rs
@@ -28,10 +28,12 @@ use openehr_am::am24::aom2::constraint_model::c_complex_object::CComplexObject;
 use openehr_am::am24::aom2::constraint_model::c_object::CObject;
 use openehr_am::am24::aom2::constraint_model::c_primitive_object::CPrimitiveObject;
 use openehr_am::am24::beom::core::assertion::Assertion;
+use openehr_base::base_types::definitions::definitions_impl::LOCAL_TERMINOLOGY_ID;
 use openehr_base::prelude::Interval;
 use openehr_base::prelude::MultiplicityInterval;
 use openehr_lang::odin::{OdinKey, OdinValue};
 
+use super::conformance::effective_occurrences_adl14;
 use super::{ArchetypeRepository, ArchetypeView, ValidationCode, ValidationIssue, view};
 use crate::cadl::Dialect;
 use crate::codes::{
@@ -547,6 +549,16 @@ impl Scan<'_> {
             self.check_container_cardinality(&attr_path, attr);
         }
 
+        // VCOC is the ADL 1.4 formalism's own cardinality/occurrences rule,
+        // distinct from the AOM2 VACMCU/WACMCL pair above, so it runs on the 1.4
+        // dialect only. Gated to the non-specialised (own-flat-form) case for the
+        // same reason as VACMCU: a specialised archetype need not restate the
+        // inherited cardinality, so the sums here would be computed against a
+        // cardinality that is not the effective one.
+        if self.dialect == Dialect::Adl14 && !self.v.is_specialised() {
+            self.check_vcoc(&attr_path, attr);
+        }
+
         // Whether a child object is required to carry a node id. AOM2 requires
         // one on every non-primitive object (master04.5 §`C_OBJECT`); AOM 1.4
         // requires one only for children of a container (multiple) attribute —
@@ -597,6 +609,83 @@ impl Scan<'_> {
             self.push(
                 ValidationCode::Wacmcl,
                 format!("sum of child occurrences lowers {sum_lower} exceeds the cardinality upper {card_upper}"),
+                attr_path,
+            );
+        }
+    }
+
+    /// VCOC (ADL 1.4): cardinality/occurrences validity —
+    /// `ADL1.4/master05-cadl.adoc` §Occurrences L321-324: "the interval
+    /// represented by: (the sum of all occurrences minimum values) .. (the sum of
+    /// all occurrences maximum values) must be inside the interval of the
+    /// cardinality."
+    ///
+    /// The children's occurrences are the EFFECTIVE ones
+    /// ([`effective_occurrences_adl14`]): a child with no stated `occurrences` is
+    /// `{1..1}` (master05 L316), and a `use_node` with none takes the referenced
+    /// node's (master05 L515) — without those defaults the sums would be computed
+    /// from zero-width intervals and the rule would never see a real archetype's
+    /// child set.
+    ///
+    /// NOTE (adjudication): the sum-LOWER half of the literal containment — that
+    /// `cardinality.lower <= Σ occurrences.lower` — is NOT raised, because
+    /// openEHR's own regression corpus contradicts it: `aa.v1.adl`,
+    /// `dimensions.v1.adl` and their siblings are tagged `regression = "PASS"`
+    /// while pairing `items cardinality {1..*}` with a single child of
+    /// `occurrences {0..1}` (Σ lower = 0 < 1). AOM 2, where this rule's successor
+    /// lives, splits VCOC the same way: the upper-bound half is the ERROR VACMCU
+    /// and the lower-bound half is the WARNING WACMCL
+    /// (`AOM2/master04.5-constraint_model-class_definitions.adoc` §Validity Rules:
+    /// `C_ATTRIBUTE`). What IS raised is every part of the containment failure that
+    /// is a genuine defect and corpus-consistent: a sum whose maximum exceeds the
+    /// cardinality upper (the child set can overfill the container) and a sum whose
+    /// maximum cannot reach the cardinality lower (the container's minimum is
+    /// unsatisfiable). Both are strict cases of "not inside the interval of the
+    /// cardinality".
+    fn check_vcoc(&mut self, attr_path: &str, attr: &CAttribute) {
+        let Some(card) = attr.cardinality.as_ref() else {
+            return; // no cardinality ⇒ not a container ⇒ VCOC does not apply.
+        };
+        if attr.children.is_empty() {
+            return;
+        }
+        let card_lower = occurrences_lower(&card.interval);
+        let card_upper = occurrences_upper_finite(Some(&card.interval));
+
+        // Σ of the children's effective occurrences maxima; `None` = unbounded
+        // (any child with an open upper makes the sum open).
+        let mut sum_upper: Option<i64> = Some(0);
+        for child in &attr.children {
+            let occ = effective_occurrences_adl14(self.v.definition, child);
+            match (sum_upper, occ.upper) {
+                (Some(sum), Some(u)) => sum_upper = Some(sum + i64::from(u)),
+                (_, None) => sum_upper = None,
+                (None, _) => {}
+            }
+        }
+        let Some(sum_upper) = sum_upper else {
+            return; // an unbounded sum is inside any cardinality with an open upper
+        };
+
+        if let Some(cu) = card_upper
+            && sum_upper > i64::from(cu)
+        {
+            self.push(
+                ValidationCode::Vcoc,
+                format!(
+                    "the sum of the children's occurrences maxima ({sum_upper}) is outside the \
+                     cardinality {card_lower}..{cu}"
+                ),
+                attr_path,
+            );
+        }
+        if sum_upper < i64::from(card_lower) {
+            self.push(
+                ValidationCode::Vcoc,
+                format!(
+                    "the sum of the children's occurrences maxima ({sum_upper}) cannot reach the \
+                     cardinality lower bound ({card_lower})"
+                ),
                 attr_path,
             );
         }
@@ -1601,40 +1690,72 @@ fn collect_usage_at(obj: &CObject, path: &str, usage: &mut CodeUsage) {
                 for prim_tuple in &tuple.tuples {
                     for member in &prim_tuple.members {
                         if let CPrimitiveObject::CTerminologyCode(tc) = member {
-                            let code = tc
-                                .constraint
-                                .split('@')
-                                .next()
-                                .unwrap_or(&tc.constraint)
-                                .trim();
-                            if !code.is_empty() {
-                                usage.value_codes.insert(code.to_owned());
-                            }
+                            usage.value_codes.extend(constraint_codes(&tc.constraint));
                         }
                     }
                 }
             }
         }
         CObject::CTerminologyCode(tc) => {
-            let code = tc
-                .constraint
-                .split('@')
-                .next()
-                .unwrap_or(&tc.constraint)
-                .trim();
-            if !code.is_empty() {
-                usage.value_codes.insert(code.to_owned());
-            }
+            let codes = constraint_codes(&tc.constraint);
             if let Some(a) = tc.assumed_value.as_ref()
-                && is_ac_code(code)
+                && let Some(ac) = codes.iter().find(|c| is_ac_code(c))
             {
                 usage
                     .assumed_refs
-                    .push((path.to_owned(), code.to_owned(), a.code_string.clone()));
+                    .push((path.to_owned(), ac.clone(), a.code_string.clone()));
             }
+            usage.value_codes.extend(codes);
         }
         _ => {}
     }
+}
+
+/// The ARCHETYPE-LOCAL codes a `C_TERMINOLOGY_CODE.constraint` string names.
+///
+/// Two spellings reach this function, because the constraint string is the
+/// verbatim carrier for both dialects:
+///
+/// - **ADL 2** — a single `at`/`ac` code, optionally suffixed with an operational
+///   binding `@terminology` (`ADL2/master08-terminology_integration.adoc`).
+/// - **ADL 1.4** — the qualified/listed custom-syntax form
+///   `terminology::code[,code]*[;assumed]` of
+///   `ADL1.4/master09-customising_adl.adoc` §Custom Syntax, which the 1.4 dialect
+///   preserves verbatim. This is the DOMINANT 1.4 spelling of a coded value set,
+///   so without decomposing it here the definedness rules never see its codes.
+///
+/// Only `local::` codes are archetype terms: VATDF/VACDF
+/// (`ADL1.4/master08-adl.adoc` §Validity Rules) judge definedness against the
+/// archetype's OWN `term_definitions`/`constraint_definitions`, and a code of an
+/// external terminology (`[openehr::127]`, `[ISO_639-1::en]`) is not an archetype
+/// term — its resolution is a terminology-service question (VETDF), not this one.
+/// The ADL 1.4 assumed code (after `;`) IS an archetype term and is included.
+fn constraint_codes(constraint: &str) -> Vec<String> {
+    // Drop any ADL2 operational-binding suffix first.
+    let body = constraint.split('@').next().unwrap_or(constraint).trim();
+    let Some((terminology, rest)) = body.split_once("::") else {
+        // ADL2 form: the constraint IS the code.
+        return if body.is_empty() {
+            Vec::new()
+        } else {
+            vec![body.to_owned()]
+        };
+    };
+    if terminology.trim() != LOCAL_TERMINOLOGY_ID {
+        return Vec::new();
+    }
+    // `code[,code]*[;assumed]`
+    let (codes, assumed) = match rest.split_once(';') {
+        Some((codes, assumed)) => (codes, Some(assumed)),
+        None => (rest, None),
+    };
+    codes
+        .split(',')
+        .chain(assumed)
+        .map(str::trim)
+        .filter(|c| !c.is_empty())
+        .map(str::to_owned)
+        .collect()
 }
 
 #[cfg(test)]
@@ -1688,5 +1809,49 @@ mod temporal_vobav_tests {
             &[],
             &date("2019-06-15")
         ));
+    }
+}
+
+#[cfg(test)]
+mod constraint_code_tests {
+    use super::constraint_codes;
+
+    /// The ADL2 spelling: the constraint IS the code, with any operational
+    /// binding suffix (`ADL2/master08-terminology_integration.adoc`) stripped.
+    #[test]
+    fn adl2_single_code_and_binding_suffix() {
+        assert_eq!(constraint_codes("at1"), vec!["at1".to_owned()]);
+        assert_eq!(constraint_codes("ac1@snomed"), vec!["ac1".to_owned()]);
+        assert!(constraint_codes("").is_empty());
+    }
+
+    /// The ADL 1.4 spelling (`ADL1.4/master09-customising_adl.adoc` §Custom
+    /// Syntax) decomposes into its listed codes plus the assumed code — all of
+    /// them archetype terms VATDF must see.
+    #[test]
+    fn adl14_listed_codes_and_assumed_code() {
+        assert_eq!(
+            constraint_codes("local::at0136,at0137"),
+            vec!["at0136".to_owned(), "at0137".to_owned()]
+        );
+        assert_eq!(
+            constraint_codes("local::at0136,at0137;at0136"),
+            vec![
+                "at0136".to_owned(),
+                "at0137".to_owned(),
+                "at0136".to_owned()
+            ]
+        );
+        assert_eq!(constraint_codes("local::ac0001"), vec!["ac0001".to_owned()]);
+    }
+
+    /// Codes of an EXTERNAL terminology are not archetype terms, so VATDF/VACDF
+    /// definedness (`ADL1.4/master08-adl.adoc` §Validity Rules, judged against the
+    /// archetype's own terminology) does not apply to them.
+    #[test]
+    fn external_terminology_codes_are_not_archetype_terms() {
+        assert!(constraint_codes("openehr::127").is_empty());
+        assert!(constraint_codes("openehr::253,271,273").is_empty());
+        assert!(constraint_codes("ISO_639-1::en").is_empty());
     }
 }

--- a/crates/openehr-adl/src/validate/phase2.rs
+++ b/crates/openehr-adl/src/validate/phase2.rs
@@ -19,12 +19,15 @@
 //! [`super::FlatParent::NeedsFlattener`]).
 //!
 //! The [`ValidationCode`] variants `Vtpnc`/`Vtpin` (tuple conformance vs the
-//! parent node, `master08` §Phase 2 gloss) and `Vunt` (`use_node` RM type
-//! validity, `master04.5` §`C_COMPLEX_OBJECT_PROXY` VUNT L479-480) are present as
-//! the phase-2 vocabulary but not yet raised here.
+//! parent node, `master08` §Phase 2 gloss) are present as the phase-2 vocabulary
+//! but not yet raised here.
 //! TODO: implement `C_PRIMITIVE_TUPLE` / `C_ATTRIBUTE_TUPLE` conformance
-//! (`master04.5` §`C_SECOND_ORDER` L729-804) to raise VTPNC/VTPIN, and resolve the
-//! `use_node` target node to raise VUNT.
+//! (`master04.5` §`C_SECOND_ORDER` L729-804) to raise VTPNC/VTPIN.
+//!
+//! `Vunt` (`use_node` RM type validity, `master04.5` §`C_COMPLEX_OBJECT_PROXY`
+//! VUNT L479-480) is NOT raised here: the rule is "according to the reference
+//! model", so it lives in the RM pass ([`super::rm`]) where an [`RmModel`] decides
+//! super-type-hood, exactly as VACSO does.
 
 use openehr_am::am24::aom2::archetype::archetype::Archetype;
 use openehr_am::am24::aom2::constraint_model::archetype_slot::ArchetypeSlot;

--- a/crates/openehr-adl/src/validate/rm.rs
+++ b/crates/openehr-adl/src/validate/rm.rs
@@ -31,13 +31,14 @@ use std::collections::BTreeSet;
 use openehr_am::am24::aom2::archetype::archetype::Archetype;
 use openehr_am::am24::aom2::constraint_model::c_attribute::CAttribute;
 use openehr_am::am24::aom2::constraint_model::c_complex_object::CComplexObject;
+use openehr_am::am24::aom2::constraint_model::c_complex_object_proxy::CComplexObjectProxy;
 use openehr_am::am24::aom2::constraint_model::c_object::CObject;
 use openehr_base::prelude::{Interval, MultiplicityInterval, ProperInterval};
 use openehr_rm::model;
 
 use super::{ArchetypeView, ValidationCode, ValidationIssue, view};
 use crate::codes::{is_at_code, is_id_code};
-use crate::paths::{complex_attributes, complex_rm_type, object_node_id, object_rm_type};
+use crate::paths::{complex_attributes, complex_rm_type, locate, object_node_id, object_rm_type};
 
 /// A multiplicity bound, extracted from an RM attribute or a cADL constraint.
 /// `upper == None` denotes an unbounded (∞) upper limit.
@@ -423,6 +424,7 @@ pub fn validate_phase2_rm(archetype: &Archetype, rm: &dyn RmModel) -> Vec<Valida
         .collect();
     let mut scan = RmScan {
         rm,
+        root: v.definition,
         defined,
         is_specialised: v.is_specialised(),
         issues: Vec::new(),
@@ -446,6 +448,8 @@ pub fn validate_phase2_rm(archetype: &Archetype, rm: &dyn RmModel) -> Vec<Valida
 /// Mutable state threaded through the reference-model walk.
 struct RmScan<'a> {
     rm: &'a dyn RmModel,
+    /// The definition root, against which a `use_node` target path resolves (VUNT).
+    root: &'a CComplexObject,
     /// The union of terminology-defined codes (for the interior-node VATID
     /// half); a code defined in any language counts as defined.
     defined: BTreeSet<String>,
@@ -655,9 +659,60 @@ impl RmScan<'_> {
                 }
             }
 
+            if let CObject::CComplexObjectProxy(proxy) = child {
+                self.check_proxy_type(&child_path, proxy);
+            }
+
             if let CObject::CComplexObject(cco) = child {
                 self.walk_complex(&child_path, child_type, cco);
             }
+        }
+    }
+
+    /// VUNT: the type named in a `use_node` must be the same as, or a super-type
+    /// of, the reference-model type of the node it refers to.
+    ///
+    /// `ADL2/master04.5-cadl_primitive_types.adoc` has the AOM2 wording
+    /// (`AOM2/master04.5-constraint_model-class_definitions.adoc` §Validity Rules:
+    /// `C_COMPLEX_OBJECT_PROXY`, VUNT); the ADL 1.4 formalism states the same rule
+    /// in `ADL1.4/master05-cadl.adoc` §Internal References L510-513 — "The type
+    /// mentioned in the `use_node` reference must always be the same type as, or a
+    /// super-type of the referenced type … a `use_node` reference to such a node can
+    /// legally mention the parent type".
+    ///
+    /// It lives HERE, in the reference-model pass, rather than in phase 1, because
+    /// the rule is explicitly "according to the reference model": deciding
+    /// super-type-hood needs [`RmModel::conforms`], which phase 1 does not have.
+    /// (Same reason VACSO moved here.) The target node is resolved against the
+    /// archetype's own definition tree, which is the flat form for a
+    /// non-specialised archetype (`ADL2/master09.02` §Differential and Flat Forms);
+    /// an unresolvable path is VUNP's business, not VUNT's, so it is left alone
+    /// here.
+    fn check_proxy_type(&mut self, path: &str, proxy: &CComplexObjectProxy) {
+        let declared = normalise_type_name(&proxy.rm_type_name);
+        if declared.is_empty() {
+            return; // no declared type ⇒ nothing to compare (1.4 accepts none).
+        }
+        let Some(target) = locate(self.root, &proxy.target_path) else {
+            return; // unresolvable target path ⇒ VUNP (phase 3), not VUNT.
+        };
+        let target_type = object_rm_type(target);
+        if target_type.is_empty() {
+            return;
+        }
+        // `conforms(sub, sup)`: the REFERENCED type must conform to the DECLARED
+        // one (declared is the same type or an ancestor). `None` = a type unknown
+        // to the model, already reported as VCORM — undecidable here.
+        if type_conforms(self.rm, target_type, &proxy.rm_type_name) == Some(false) {
+            self.push(
+                ValidationCode::Vunt,
+                format!(
+                    "use_node type {:?} is neither the same as nor a super-type of the referenced \
+                     node's type {target_type:?} at {:?}",
+                    proxy.rm_type_name, proxy.target_path
+                ),
+                path,
+            );
         }
     }
 
@@ -678,6 +733,11 @@ impl RmScan<'_> {
                     ),
                     &child_path,
                 );
+            }
+            // VUNT does not depend on the owning attribute's declared type, so it
+            // runs on this branch too.
+            if let CObject::CComplexObjectProxy(proxy) = child {
+                self.check_proxy_type(&child_path, proxy);
             }
             if let CObject::CComplexObject(cco) = child {
                 self.walk_complex(&child_path, child_type, cco);
@@ -891,6 +951,71 @@ mod tests {
         let star = Bounds::new(0, None);
         assert!(star.contains(Bounds::new(1, Some(5))));
         assert!(!Bounds::new(1, Some(5)).contains(star)); // {0..*} escapes {1..5}
+    }
+
+    /// A `use_node` archetype built around `body`, for the VUNT pair below.
+    fn cluster_with_proxy(proxy: &str) -> String {
+        format!(
+            "archetype (adl_version=2.0.5; rm_release=1.0.2)\n\
+             \topenEHR-EHR-CLUSTER.vunt.v1.0.0\n\n\
+             language\n\toriginal_language = <[ISO_639-1::en]>\n\n\
+             description\n\tlifecycle_state = <\"draft\">\n\n\
+             definition\n\
+             \tCLUSTER[id1] matches {{\n\
+             \t\titems matches {{\n\
+             \t\t\tELEMENT[id2] matches {{*}}\n\
+             \t\t\t{proxy}\n\
+             \t\t}}\n\
+             \t}}\n\n\
+             terminology\n\tterm_definitions = <\n\
+             \t\t[\"en\"] = <\n\
+             \t\t\t[\"id1\"] = <text=<\"\"> description=<\"\">>\n\
+             \t\t\t[\"id2\"] = <text=<\"\"> description=<\"\">>\n\
+             \t\t\t[\"id5\"] = <text=<\"\"> description=<\"\">>\n\
+             \t\t>\n\
+             \t>\n"
+        )
+    }
+
+    fn rm_codes(src: &str) -> Vec<ValidationCode> {
+        let a = parse_artefact(src).expect("the fixture must parse");
+        validate_phase2_rm(&a, &ProductionRmModel)
+            .into_iter()
+            .map(|i| i.code)
+            .collect()
+    }
+
+    /// VUNT: `ADL1.4/master05-cadl.adoc` §Internal References L510-513 (same rule
+    /// as `AOM2/master04.5` §`C_COMPLEX_OBJECT_PROXY` VUNT) — the `use_node` type
+    /// must be the same as, or a super-type of, the referenced node's type.
+    /// `CLUSTER` is a SIBLING of the referenced `ELEMENT`, not an ancestor.
+    #[test]
+    fn vunt_use_node_type_is_not_a_supertype_of_the_target() {
+        let codes = rm_codes(&cluster_with_proxy("use_node CLUSTER[id5] /items[id2]"));
+        assert!(
+            codes.contains(&ValidationCode::Vunt),
+            "expected VUNT, got {:?}",
+            codes.iter().map(|c| c.mnemonic()).collect::<Vec<_>>()
+        );
+    }
+
+    /// The accepting twin: master05 L510-513 blesses naming an ANCESTOR type ("a
+    /// `use_node` reference to such a node can legally mention the parent type"), so
+    /// `ITEM` over an `ELEMENT` target is clean — a check that only compared type
+    /// names for equality would false-reject this.
+    #[test]
+    fn vunt_use_node_may_name_a_supertype_of_the_target() {
+        for proxy in [
+            "use_node ITEM[id5] /items[id2]",
+            "use_node ELEMENT[id5] /items[id2]",
+        ] {
+            let codes = rm_codes(&cluster_with_proxy(proxy));
+            assert!(
+                !codes.contains(&ValidationCode::Vunt),
+                "{proxy}: expected no VUNT, got {:?}",
+                codes.iter().map(|c| c.mnemonic()).collect::<Vec<_>>()
+            );
+        }
     }
 
     #[test]

--- a/crates/openehr-adl/tests/adl14_cadl_gates.rs
+++ b/crates/openehr-adl/tests/adl14_cadl_gates.rs
@@ -1,0 +1,193 @@
+//! The ADL 1.4 cADL regression corpus (`tests/corpus/adl14-cadl/`).
+//!
+//! Sibling of `adl14-dadl/` (the dADL leaf/structure breadth tree): this one
+//! covers the **cADL** half of an ADL 1.4 text — `master05-cadl.adoc` — where the
+//! vendored `adl2-reference` library gives no coverage because it is an ADL2
+//! corpus. Like its sibling it is **hand-written, not vendored**
+//! (`tests/corpus/PROVENANCE.md` §`adl14-cadl/`), and every expectation is
+//! derived first-hand from the spec text, cited in the fixture beside the
+//! construct it exercises.
+//!
+//! Three families live here:
+//!
+//! 1. **Dialect gates.** ADL 1.4's cADL keyword set is CLOSED
+//!    (`ADL1.4/master05-cadl.adoc` §Keywords L48-53), so a construct ADL 2
+//!    introduced is a syntax error in a 1.4 text, not a tolerated superset. Each
+//!    such construct gets a refusal fixture named for the `S*` code it raises.
+//!    The ACCEPTING twin of every one of them is the vendored ADL2 corpus, which
+//!    exercises the same construct in its own dialect — a parser that stopped
+//!    accepting it there would fail `corpus_definition_parse.rs`.
+//! 2. **Refusals with their accepting twin in-tree** — the inline dADL domain
+//!    lowering (`ADL1.4/master09-customising_adl.adoc`) and the 1.4 term-constraint
+//!    definedness rules (`ADL1.4/master08-adl.adoc` §Validity Rules VATDF/VACDF),
+//!    where the accepted form is itself 1.4-only and so has no ADL2 twin.
+//! 3. **Positive fixtures** for behaviour a lenient OR an over-strict reader would
+//!    get wrong: `before`/`after` sibling order (a 1.4 keyword — L53 — that must
+//!    NOT be gated), the effective occurrences default `{1..1}` (L316), and the
+//!    assumed-value lowering.
+//!
+//! Both twins are kept for every refusal (`.claude/rules/testing.md`).
+
+#![allow(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
+
+use std::path::{Path, PathBuf};
+
+use openehr_adl::assemble::parse_artefact_adl14;
+use openehr_adl::error::SyntaxErrorCode;
+use openehr_adl::validate::{Severity, ValidationCode, validate_source_phase1_adl14};
+
+/// What a fixture must do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Expect {
+    /// Parses in the 1.4 dialect and validates clean under the 1.4 phase-1 subset.
+    Pass,
+    /// Refused at parse with this syntax code.
+    Refuse(SyntaxErrorCode),
+    /// Parses, but the 1.4 phase-1 subset raises this validation code as an error.
+    Invalid(ValidationCode),
+}
+
+/// Every fixture of the tree, with its expected outcome. The coverage gate
+/// (`corpus_coverage.rs`) cross-checks this list against the filesystem.
+const FIXTURES: &[(&str, Expect)] = &[
+    // ── dialect gates (ADL2-only constructs in a 1.4 text) ────────────────
+    (
+        "openEHR-EHR-OBSERVATION.SCOAT_adl2_default_value.v1.adl",
+        Expect::Refuse(SyntaxErrorCode::Scoat),
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.SCOAT_adl2_attribute_tuple.v1.adl",
+        Expect::Refuse(SyntaxErrorCode::Scoat),
+    ),
+    (
+        "openEHR-EHR-CLUSTER.SCCOG_adl2_use_archetype.v1.adl",
+        Expect::Refuse(SyntaxErrorCode::Sccog),
+    ),
+    (
+        "openEHR-EHR-CLUSTER.SCCOG_adl2_slot_closed.v1.adl",
+        Expect::Refuse(SyntaxErrorCode::Sccog),
+    ),
+    (
+        "openEHR-EHR-CLUSTER.STCCP_adl2_constraint_strength.v1.adl",
+        Expect::Refuse(SyntaxErrorCode::Stccp),
+    ),
+    (
+        "openEHR-EHR-CLUSTER.STCCP_adl2_terminology_binding.v1.adl",
+        Expect::Refuse(SyntaxErrorCode::Stccp),
+    ),
+    // ── inline dADL domain lowering (master09) ────────────────────────────
+    (
+        "openEHR-EHR-CLUSTER.SDINV_unsupported_domain_type.v1.adl",
+        Expect::Refuse(SyntaxErrorCode::Sdinv),
+    ),
+    (
+        "openEHR-EHR-CLUSTER.SDINV_assumed_value_unmatched.v1.adl",
+        Expect::Refuse(SyntaxErrorCode::Sdinv),
+    ),
+    (
+        "openEHR-EHR-CLUSTER.domain_assumed_value.v1.adl",
+        Expect::Pass,
+    ),
+    // ── 1.4 term-constraint definedness (master08 VATDF/VACDF) ────────────
+    (
+        "openEHR-EHR-CLUSTER.VATDF_undefined_listed_code.v1.adl",
+        Expect::Invalid(ValidationCode::Vatdf),
+    ),
+    (
+        "openEHR-EHR-CLUSTER.VATDF_undefined_assumed_code.v1.adl",
+        Expect::Invalid(ValidationCode::Vatdf),
+    ),
+    (
+        "openEHR-EHR-CLUSTER.VACDF_undefined_constraint_code.v1.adl",
+        Expect::Invalid(ValidationCode::Vacdf),
+    ),
+    (
+        "openEHR-EHR-CLUSTER.term_constraint_codes_defined.v1.adl",
+        Expect::Pass,
+    ),
+    // ── cardinality/occurrences (master05 VCOC + the {1..1} defaults) ─────
+    (
+        "openEHR-EHR-CLUSTER.VCOC_occurrences_exceed_cardinality.v1.adl",
+        Expect::Invalid(ValidationCode::Vcoc),
+    ),
+    (
+        "openEHR-EHR-CLUSTER.VCOC_occurrences_below_cardinality.v1.adl",
+        Expect::Invalid(ValidationCode::Vcoc),
+    ),
+    (
+        "openEHR-EHR-CLUSTER.default_occurrences.v1.adl",
+        Expect::Pass,
+    ),
+    // ── 1.4 keywords that must stay accepted ──────────────────────────────
+    ("openEHR-EHR-CLUSTER.sibling_order.v1.adl", Expect::Pass),
+];
+
+fn tree() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/corpus/adl14-cadl")
+}
+
+fn read(name: &str) -> String {
+    let path = tree().join(name);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+fn error_codes(src: &str, name: &str) -> Vec<ValidationCode> {
+    validate_source_phase1_adl14(src)
+        .unwrap_or_else(|e| panic!("{name}: must parse, got {e:?}"))
+        .into_iter()
+        .filter(|i| i.severity == Severity::Error)
+        .map(|i| i.code)
+        .collect()
+}
+
+#[test]
+fn every_fixture_meets_its_declared_outcome() {
+    for (name, expect) in FIXTURES {
+        let src = read(name);
+        match expect {
+            Expect::Pass => {
+                parse_artefact_adl14(&src)
+                    .unwrap_or_else(|e| panic!("{name} must parse, got {e:?}"));
+                let codes = error_codes(&src, name);
+                assert!(
+                    codes.is_empty(),
+                    "{name}: expected clean 1.4 validation, got {:?}",
+                    codes.iter().map(|c| c.mnemonic()).collect::<Vec<_>>()
+                );
+            }
+            Expect::Refuse(code) => {
+                let errs = parse_artefact_adl14(&src)
+                    .err()
+                    .unwrap_or_else(|| panic!("{name} must be refused at parse"));
+                assert!(
+                    errs.iter().any(|e| e.code == *code),
+                    "{name}: expected {code}, got {:?}",
+                    errs.iter().map(|e| e.code).collect::<Vec<_>>()
+                );
+            }
+            Expect::Invalid(code) => {
+                let codes = error_codes(&src, name);
+                assert!(
+                    codes.contains(code),
+                    "{name}: expected {code}, got {:?}",
+                    codes.iter().map(|c| c.mnemonic()).collect::<Vec<_>>()
+                );
+            }
+        }
+    }
+}
+
+/// The whole tree is claimed by the table above — no fixture may sit unexercised.
+#[test]
+fn every_fixture_file_is_in_the_table() {
+    let mut on_disk: Vec<String> = std::fs::read_dir(tree())
+        .expect("read the adl14-cadl tree")
+        .flatten()
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .filter(|n| Path::new(n).extension().is_some_and(|e| e == "adl"))
+        .collect();
+    on_disk.sort();
+    let mut listed: Vec<String> = FIXTURES.iter().map(|(n, _)| (*n).to_owned()).collect();
+    listed.sort();
+    assert_eq!(on_disk, listed, "the fixture table and the tree disagree");
+}

--- a/crates/openehr-adl/tests/adl14_conversion.rs
+++ b/crates/openehr-adl/tests/adl14_conversion.rs
@@ -467,3 +467,76 @@ ontology
     openehr_adl::assemble::parse_artefact(&printed)
         .unwrap_or_else(|e| panic!("printed ADL2 does not re-parse: {e:?}\n{printed}"));
 }
+
+/// The ADL 1.4 default `occurrences` is WRITTEN OUT on container children by the
+/// conversion, because the two formalisms read an absent `occurrences`
+/// differently: ADL 1.4 means `{1..1}` (`ADL1.4/master05-cadl.adoc` §Occurrences
+/// L316) while ADL 2 infers `0..cardinality.upper`
+/// (`AOM2/master04.5-constraint_model-class_definitions.adoc` §Occurrences
+/// inferencing rules). Leaving it implicit would widen "exactly once" to "none to
+/// many". A `use_node` proxy stays unstated — master05 L515 gives it the
+/// referenced node's occurrences.
+#[test]
+fn conversion_writes_out_the_14_default_occurrences_on_container_children() {
+    let src = "\
+archetype (adl_version=1.4)
+\topenEHR-EHR-CLUSTER.default_occurrences.v1
+
+language
+\toriginal_language = <[ISO_639-1::en]>
+
+description
+\tlifecycle_state = <\"AuthorDraft\">
+
+definition
+\tCLUSTER[at0000] matches {
+\t\titems cardinality matches {1..*; unordered} matches {
+\t\t\tELEMENT[at0001] matches {*}
+\t\t\tELEMENT[at0002] occurrences matches {0..2} matches {*}
+\t\t\tuse_node ELEMENT /items[at0002]
+\t\t}
+\t}
+
+ontology
+\tterm_definitions = <
+\t\t[\"en\"] = <
+\t\t\titems = <
+\t\t\t\t[\"at0000\"] = <text=<\"\"> description=<\"\">>
+\t\t\t\t[\"at0001\"] = <text=<\"\"> description=<\"\">>
+\t\t\t\t[\"at0002\"] = <text=<\"\"> description=<\"\">>
+\t\t\t>
+\t\t>
+\t>
+";
+    let mut log = ConversionLog::new();
+    let converted = parse_and_convert(src, &ConvertConfig::default(), &mut log).expect("converts");
+    let (definition, _) = data(&converted);
+    let items = openehr_adl::paths::complex_attributes(definition)
+        .iter()
+        .find(|a| a.rm_attribute_name == "items")
+        .expect("the items attribute")
+        .clone();
+
+    // at0001 stated nothing in 1.4 ⇒ explicit {1..1} in the ADL2 output.
+    let first = occurrences_of(&items.children[0]).expect("materialised occurrences");
+    assert_eq!((first.lower, first.upper), (Some(1), Some(1)));
+    // at0002 stated {0..2} ⇒ carried through unchanged.
+    let second = occurrences_of(&items.children[1]).expect("stated occurrences");
+    assert_eq!((second.lower, second.upper), (Some(0), Some(2)));
+    // The use_node keeps no occurrences of its own (master05 L515).
+    assert!(occurrences_of(&items.children[2]).is_none());
+}
+
+/// The `occurrences` of a converted child object, if it carries one.
+fn occurrences_of(
+    obj: &openehr_am::am24::aom2::constraint_model::c_object::CObject,
+) -> Option<&openehr_base::prelude::MultiplicityInterval> {
+    use openehr_am::am24::aom2::constraint_model::c_object::CObject;
+    match obj {
+        CObject::CComplexObject(CComplexObject::CComplexObject(d)) => d.occurrences.as_ref(),
+        CObject::CComplexObject(CComplexObject::CArchetypeRoot(r)) => r.occurrences.as_ref(),
+        CObject::CComplexObjectProxy(p) => p.occurrences.as_ref(),
+        CObject::ArchetypeSlot(s) => s.occurrences.as_ref(),
+        _ => None,
+    }
+}

--- a/crates/openehr-adl/tests/adl14_dadl_breadth.rs
+++ b/crates/openehr-adl/tests/adl14_dadl_breadth.rs
@@ -46,10 +46,6 @@ const FIXTURES: &[(&str, Expect)] = &[
         Expect::Pass,
     ),
     (
-        "openEHR-EHR-OBSERVATION.SDINV_default_interval.v1.adl",
-        Expect::Refuse(SyntaxErrorCode::Sdinv),
-    ),
-    (
         "openEHR-EHR-OBSERVATION.SDINV_duplicate_sibling_attribute.v1.adl",
         Expect::Refuse(SyntaxErrorCode::Sdinv),
     ),

--- a/crates/openehr-adl/tests/corpus/INVENTORY.md
+++ b/crates/openehr-adl/tests/corpus/INVENTORY.md
@@ -14,10 +14,12 @@ it**.
   `tools/src/test/resources/com/nedap/archie/flattener/{specexamples,siblingorder}`,
   commit `e8d92f28aca33f92ea08a826ea19f9581d579720` (2026-07-08).
 
-**One tree here is NOT vendored:** `adl14-dadl/` is hand-written from
+**Two trees here are NOT vendored:** `adl14-dadl/` is hand-written from
 `docs/specs/openehr/AM/docs/ADL1.4/master04-dadl.adoc` (+ `master08-adl.adoc`
-§Revision History Section) — see `PROVENANCE.md` §`adl14-dadl/` and §11 below.
-It is excluded from the vendored file-count ratchet in `corpus_coverage.rs`.
+§Revision History Section) and `adl14-cadl/` from `master05-cadl.adoc` (+
+`master08-adl.adoc` §Validity Rules and `master09-customising_adl.adoc`) — see
+`PROVENANCE.md` and §§11-12 below. Both are excluded from the vendored
+file-count ratchet in `corpus_coverage.rs`.
 
 **Maintenance:** regenerate/update this file whenever the corpus is re-vendored
 (the pins above change). File counts, the code frequency table, and the gap
@@ -471,6 +473,8 @@ tag in `validity/**` should be a hard coverage-gate error (only the two
 | `upgrade/upgrade_from_14/*.adls` | parse + validate clean (also the compare target) | — |
 | `upgrade/upgrade_from_15/*.adls` | parse + validate clean (no conversion input) | — |
 | `flattener/specexamples/**`, `flattener/siblingorder/**` | flatten child→parent, compare to hand-authored spec-derived expected | `AOM2/master08` §Flattening; `ADL2/master09` (hand-authored) |
+| `adl14-dadl/*.adl` | accept/refuse per fixture + leaf-value assertions (`tests/adl14_dadl_breadth.rs`) | file name + `regression` tag |
+| `adl14-cadl/*.adl` | accept/refuse/invalid per fixture (`tests/adl14_cadl_gates.rs`) | file name + `regression` tag |
 
 **Decisions needed for a zero-ambiguity 100% claim:**
 
@@ -505,5 +509,38 @@ assertions).
 |---|---|---|
 | `…dadl_breadth.v1.adl` | PASS | every leaf/structure form of master04: `<...>` empty sections (leaf, nested, behind a cast), the full partial date/time family incl. `T??:??:??`, integer exponents (`29e6`), case-insensitive booleans, intervals incl. `+/-` and the `infinity`/`-infinity`/`*` endpoints, qualified and local (`[at0200]`) term codes, lists + the open-list marker, URIs, characters, multi-line strings, `&quot;` |
 | `…revision_history.v1.adl` | PASS | the master08 §Revision History Section example, incl. its space-separated timestamp |
-| `…SDINV_default_interval.v1.adl` | SDINV | an interval inside a `_default` value — refused, not silently nulled |
 | `…SDINV_duplicate_sibling_attribute.v1.adl` | SDINV | a repeated sibling attribute name (rule VDATU / master04 §General Form) |
+
+---
+
+## 12. `adl14-cadl/` — the hand-written ADL 1.4 cADL tree
+
+Not vendored (PROVENANCE.md §`adl14-cadl/`): authored from
+`docs/specs/openehr/AM/docs/ADL1.4/master05-cadl.adoc` (+ `master08-adl.adoc`
+§Validity Rules, `master09-customising_adl.adoc`) because the vendored
+`adl2-reference` library is an ADL2 corpus and exercises none of the ADL 1.4
+cADL language. File names encode the expectation, corpus-convention style: an
+`S*_` prefix is a parse refusal with that syntax code, a `V*_` prefix is a
+phase-1 validation error with that validation code. Harness:
+`tests/adl14_cadl_gates.rs` (per-file expectation table + a tree/table
+cross-check).
+
+| File | Expects | Exercises |
+|---|---|---|
+| `…SCOAT_adl2_default_value.v1.adl` | SCOAT | the ADL2 `_default` pseudo-attribute refused in a 1.4 text (master05 §Keywords L48-53) |
+| `…SCOAT_adl2_attribute_tuple.v1.adl` | SCOAT | an ADL2 second-order attribute tuple refused in a 1.4 text |
+| `…SCCOG_adl2_use_archetype.v1.adl` | SCCOG | `use_archetype` refused in a 1.4 text (1.4 has `use_node`/`allow_archetype` only) |
+| `…SCCOG_adl2_slot_closed.v1.adl` | SCCOG | the ADL2 slot `closed` marker refused in a 1.4 text |
+| `…STCCP_adl2_constraint_strength.v1.adl` | STCCP | an ADL2 term-constraint strength refused in a 1.4 text |
+| `…STCCP_adl2_terminology_binding.v1.adl` | STCCP | an ADL2 `@terminology` operational binding refused in a 1.4 text |
+| `…SDINV_unsupported_domain_type.v1.adl` | SDINV | an inline dADL `C_CODE_PHRASE` refused BY NAME, never lowered to another RM type |
+| `…SDINV_assumed_value_unmatched.v1.adl` | SDINV | a domain `assumed_value` satisfying no `list` row |
+| `…domain_assumed_value.v1.adl` | PASS | the accepting twin: an `assumed_value` landing on the tuple row it satisfies |
+| `…VATDF_undefined_listed_code.v1.adl` | VATDF | an undefined code inside the 1.4 listed term constraint `[local:: …]` |
+| `…VATDF_undefined_assumed_code.v1.adl` | VATDF | an undefined ASSUMED code of a 1.4 listed term constraint |
+| `…VACDF_undefined_constraint_code.v1.adl` | VACDF | an undefined `ac` code in a 1.4 qualified term constraint |
+| `…term_constraint_codes_defined.v1.adl` | PASS | the accepting twin, incl. that EXTERNAL terminology codes are not archetype terms |
+| `…VCOC_occurrences_exceed_cardinality.v1.adl` | VCOC | master05 L321-324: the occurrences sum overfills the cardinality |
+| `…VCOC_occurrences_below_cardinality.v1.adl` | VCOC | master05 L321-324: the occurrences sum cannot reach the cardinality lower |
+| `…default_occurrences.v1.adl` | PASS | the effective occurrences default `{1..1}` (master05 L316) keeps VCOC quiet |
+| `…sibling_order.v1.adl` | PASS | `before [atNNNN]` — a cADL 1.4 keyword (master05 §Keywords L53), never gated |

--- a/crates/openehr-adl/tests/corpus/PROVENANCE.md
+++ b/crates/openehr-adl/tests/corpus/PROVENANCE.md
@@ -53,4 +53,29 @@
   ever added or corrected against the spec text, never weakened to make a
   build pass, and the accept/refuse twins stay paired.
 
+## `adl14-cadl/`
+
+- **Hand-written in this repository — NOT vendored.** Sibling of `adl14-dadl/`
+  for the **cADL** half of an ADL 1.4 text
+  (`docs/specs/openehr/AM/docs/ADL1.4/master05-cadl.adoc`, plus
+  `master08-adl.adoc` §Validity Rules and `master09-customising_adl.adoc`); the
+  vendored `adl2-reference` library is an ADL2 corpus and covers none of it.
+- Three families: the **dialect gates** (a construct ADL 2 introduced is refused
+  in a 1.4 text — master05 §Keywords L48-53 is a closed keyword set), the
+  **inline dADL domain lowering** refusals with their accepting twin, and
+  **positive fixtures** for behaviour an over-strict reader would break
+  (`before`/`after` sibling order — a 1.4 keyword at L53 — and the effective
+  occurrences default `{1..1}` at L316).
+- File names encode the expected outcome corpus-convention style: an `S*_`
+  prefix is a parse refusal with that syntax code, a `V*_` prefix is a phase-1
+  validation error with that validation code, everything else parses and
+  validates clean and repeats that in its in-file `regression` tag.
+- The accepting twin of every DIALECT-GATE refusal is the vendored ADL2 corpus,
+  which exercises the same construct in its own dialect; the twins of the
+  1.4-only refusals live in this tree.
+- Owner: `crates/openehr-adl/tests/adl14_cadl_gates.rs` (the per-file
+  expectation table lives there; `corpus_coverage.rs` cross-checks the tree).
+- Same editing rule as `adl14-dadl/`: fixtures are added or corrected against
+  the spec text, never weakened to make a build pass.
+
 Never hand-edit vendored fixtures; re-vendor and update the pins here.

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.SCCOG_adl2_slot_closed.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.SCCOG_adl2_slot_closed.v1.adl
@@ -1,0 +1,41 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-CLUSTER.SCCOG_adl2_slot_closed.v1
+
+concept
+	[at0000]	-- ADL2 closed slot in a 1.4 text
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	lifecycle_state = <"AuthorDraft">
+
+definition
+	CLUSTER[at0000] matches {	-- ADL2 closed slot in a 1.4 text
+		items cardinality matches {0..*; unordered} matches {
+			-- The slot `closed` marker is ADL2 only (ADL2/master04.3 §Archetype
+			-- Slots; `ARCHETYPE_SLOT.is_closed`). The cADL 1.4 keyword set
+			-- (ADL1.4/master05-cadl.adoc §Keywords L51-52) has `allow_archetype`
+			-- with `include`/`exclude` only.
+			allow_archetype CLUSTER[at0001] closed
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"ADL2 closed slot in a 1.4 text">
+					description = <"Refusal fixture: an ADL2 `closed` slot in an ADL 1.4 definition.">
+				>
+				["at0001"] = <
+					text = <"Closed slot">
+					description = <"A slot closed to further filling.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.SCCOG_adl2_use_archetype.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.SCCOG_adl2_use_archetype.v1.adl
@@ -1,0 +1,43 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-CLUSTER.SCCOG_adl2_use_archetype.v1
+
+concept
+	[at0000]	-- ADL2 use_archetype in a 1.4 text
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	lifecycle_state = <"AuthorDraft">
+
+definition
+	CLUSTER[at0000] matches {	-- ADL2 use_archetype in a 1.4 text
+		items cardinality matches {0..*; unordered} matches {
+			-- `use_archetype` is ADL2 only (ADL2/master04.3 §Archetype Slots,
+			-- `C_ARCHETYPE_ROOT`). The cADL 1.4 keyword set
+			-- (ADL1.4/master05-cadl.adoc §Keywords L51) has `use_node` and
+			-- `allow_archetype` only; a 1.4 text names an external archetype
+			-- through an `allow_archetype` slot assertion instead
+			-- (ADL1.4/master05-cadl.adoc §Archetype Slots).
+			use_archetype CLUSTER[at0001, openEHR-EHR-CLUSTER.dimensions.v1]
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"ADL2 use_archetype in a 1.4 text">
+					description = <"Refusal fixture: an ADL2 `use_archetype` in an ADL 1.4 definition.">
+				>
+				["at0001"] = <
+					text = <"Nested cluster">
+					description = <"An externally referenced cluster.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.SDINV_assumed_value_unmatched.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.SDINV_assumed_value_unmatched.v1.adl
@@ -1,0 +1,63 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-CLUSTER.SDINV_assumed_value_unmatched.v1
+
+concept
+	[at0000]	-- Assumed value outside the domain list
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	lifecycle_state = <"AuthorDraft">
+
+definition
+	CLUSTER[at0000] matches {	-- Assumed value outside the domain list
+		items cardinality matches {0..*; unordered} matches {
+			ELEMENT[at0001] occurrences matches {0..1} matches {	-- Pressure
+				value matches {
+					-- The assumed value is an instance of the constrained type
+					-- (AOM 1.4 `C_DV_QUANTITY.assumed_value`), so it must satisfy
+					-- one of the `list` rows it is assumed for. "kPa" appears in no
+					-- row, so the assumed value can be bound to no co-constrained
+					-- tuple row (AOM2/master04.3 §Tuple Constraints) and the block
+					-- is refused instead of binding it to an arbitrary row.
+					(C_DV_QUANTITY) <
+						property = <[openehr::122]>
+						assumed_value = <
+							units = <"kPa">
+							magnitude = <8.0>
+						>
+						list = <
+							["1"] = <
+								units = <"mm[Hg]">
+								magnitude = <|>=0.0|>
+							>
+							["2"] = <
+								units = <"cm[H2O]">
+								magnitude = <|>=0.0|>
+							>
+						>
+					>
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Assumed value outside the domain list">
+					description = <"Refusal fixture: a domain `assumed_value` matching no `list` row.">
+				>
+				["at0001"] = <
+					text = <"Pressure">
+					description = <"A pressure measurement.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.SDINV_unsupported_domain_type.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.SDINV_unsupported_domain_type.v1.adl
@@ -1,0 +1,67 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-CLUSTER.SDINV_unsupported_domain_type.v1
+
+concept
+	[at0000]	-- Unsupported inline dADL domain type
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	lifecycle_state = <"AuthorDraft">
+
+definition
+	CLUSTER[at0000] matches {	-- Unsupported inline dADL domain type
+		items cardinality matches {0..*; unordered} matches {
+			ELEMENT[at0001] occurrences matches {0..1} matches {	-- Coded item
+				value matches {
+					DV_CODED_TEXT matches {
+						defining_code matches {
+							-- ADL1.4/master09-customising_adl.adoc §Introduction
+							-- admits ANY `C_DOMAIN_TYPE` descendant in an inline
+							-- dADL block, and each one constrains a DIFFERENT
+							-- reference-model type. `C_CODE_PHRASE` (§Custom Syntax)
+							-- is not lowered yet, so it is refused by type name
+							-- rather than silently lowered to some other RM type.
+							(C_CODE_PHRASE) <
+								terminology_id = <
+									value = <"local">
+								>
+								code_list = <
+									["1"] = <"at0002">
+									["2"] = <"at0003">
+								>
+							>
+						}
+					}
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Unsupported inline dADL domain type">
+					description = <"Refusal fixture: an inline dADL `C_CODE_PHRASE` domain block.">
+				>
+				["at0001"] = <
+					text = <"Coded item">
+					description = <"A coded data item.">
+				>
+				["at0002"] = <
+					text = <"Lying">
+					description = <"Lying position.">
+				>
+				["at0003"] = <
+					text = <"Sitting">
+					description = <"Sitting position.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.STCCP_adl2_constraint_strength.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.STCCP_adl2_constraint_strength.v1.adl
@@ -1,0 +1,51 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-CLUSTER.STCCP_adl2_constraint_strength.v1
+
+concept
+	[at0000]	-- ADL2 constraint strength in a 1.4 text
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	lifecycle_state = <"AuthorDraft">
+
+definition
+	CLUSTER[at0000] matches {	-- ADL2 constraint strength in a 1.4 text
+		items cardinality matches {0..*; unordered} matches {
+			ELEMENT[at0001] occurrences matches {0..1} matches {	-- Coded item
+				value matches {
+					DV_CODED_TEXT matches {
+						defining_code matches {
+							-- Constraint strengths are ADL2 only
+							-- (AOM2/master04.2 §Constraint Strengths,
+							-- `C_TERMINOLOGY_CODE.constraint_status`). The cADL 1.4
+							-- keyword set (ADL1.4/master05-cadl.adoc §Keywords
+							-- L48-53) has no strength vocabulary and AOM 1.4 has no
+							-- such attribute.
+							preferred [ac0001]
+						}
+					}
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"ADL2 constraint strength in a 1.4 text">
+					description = <"Refusal fixture: an ADL2 constraint strength in an ADL 1.4 definition.">
+				>
+				["at0001"] = <
+					text = <"Coded item">
+					description = <"A coded data item.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.STCCP_adl2_terminology_binding.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.STCCP_adl2_terminology_binding.v1.adl
@@ -1,0 +1,52 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-CLUSTER.STCCP_adl2_terminology_binding.v1
+
+concept
+	[at0000]	-- ADL2 operational binding in a 1.4 text
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	lifecycle_state = <"AuthorDraft">
+
+definition
+	CLUSTER[at0000] matches {	-- ADL2 operational binding in a 1.4 text
+		items cardinality matches {0..*; unordered} matches {
+			ELEMENT[at0001] occurrences matches {0..1} matches {	-- Coded item
+				value matches {
+					DV_CODED_TEXT matches {
+						defining_code matches {
+							-- The `[acN@terminology]` operational binding is ADL2
+							-- only (ADL2/master08-terminology_integration.adoc
+							-- §Terminology Bindings). The cADL 1.4 keyword set
+							-- (ADL1.4/master05-cadl.adoc §Keywords L48-53) has no
+							-- `@` operator; 1.4 names an external terminology with
+							-- the qualified `[terminology::code, …]` form of
+							-- ADL1.4/master09-customising_adl.adoc §Custom Syntax.
+							[ac0001@snomed]
+						}
+					}
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"ADL2 operational binding in a 1.4 text">
+					description = <"Refusal fixture: an ADL2 `@terminology` binding in an ADL 1.4 definition.">
+				>
+				["at0001"] = <
+					text = <"Coded item">
+					description = <"A coded data item.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.VACDF_undefined_constraint_code.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.VACDF_undefined_constraint_code.v1.adl
@@ -1,0 +1,54 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-CLUSTER.VACDF_undefined_constraint_code.v1
+
+concept
+	[at0000]	-- Undefined constraint code in a term constraint
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	other_details = <
+		["regression"] = <"VACDF">
+	>
+	lifecycle_state = <"AuthorDraft">
+
+definition
+	CLUSTER[at0000] matches {	-- Undefined constraint code in a term constraint
+		items cardinality matches {0..*; unordered} matches {
+			ELEMENT[at0001] occurrences matches {0..1} matches {	-- Position
+				value matches {
+					DV_CODED_TEXT matches {
+						defining_code matches {
+							-- An `ac` placeholder code stands for an externally
+							-- evaluated value set and is defined in the ontology
+							-- (ADL1.4/master05-cadl.adoc §Placeholder Constraints);
+							-- ac0999 is not, so VACDF
+							-- (ADL1.4/master08-adl.adoc §Validity Rules) applies to
+							-- the qualified 1.4 spelling as well.
+							[local::ac0999]
+						}
+					}
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Undefined constraint code in a term constraint">
+					description = <"Refusal fixture: VACDF on a 1.4 qualified term constraint.">
+				>
+				["at0001"] = <
+					text = <"Position">
+					description = <"The recorded position.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.VATDF_undefined_assumed_code.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.VATDF_undefined_assumed_code.v1.adl
@@ -1,0 +1,65 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-CLUSTER.VATDF_undefined_assumed_code.v1
+
+concept
+	[at0000]	-- Undefined assumed code in a listed term constraint
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	other_details = <
+		["regression"] = <"VATDF">
+	>
+	lifecycle_state = <"AuthorDraft">
+
+definition
+	CLUSTER[at0000] matches {	-- Undefined assumed code in a listed term constraint
+		items cardinality matches {0..*; unordered} matches {
+			ELEMENT[at0001] occurrences matches {0..1} matches {	-- Position
+				value matches {
+					DV_CODED_TEXT matches {
+						defining_code matches {
+							-- The assumed value of a 1.4 listed term constraint is
+							-- itself an archetype term (ADL1.4/master05-cadl.adoc
+							-- §Assumed Values; ADL1.4/master09-customising_adl.adoc
+							-- §Custom Syntax), so VATDF
+							-- (ADL1.4/master08-adl.adoc §Validity Rules) covers it
+							-- too; at0999 is not defined.
+							[local::
+							at0002,
+							at0003;
+							at0999]
+						}
+					}
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Undefined assumed code in a listed term constraint">
+					description = <"Refusal fixture: VATDF on the assumed code of a 1.4 term constraint.">
+				>
+				["at0001"] = <
+					text = <"Position">
+					description = <"The recorded position.">
+				>
+				["at0002"] = <
+					text = <"Lying">
+					description = <"Lying position.">
+				>
+				["at0003"] = <
+					text = <"Sitting">
+					description = <"Sitting position.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.VATDF_undefined_listed_code.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.VATDF_undefined_listed_code.v1.adl
@@ -1,0 +1,59 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-CLUSTER.VATDF_undefined_listed_code.v1
+
+concept
+	[at0000]	-- Undefined code in a listed term constraint
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	other_details = <
+		["regression"] = <"VATDF">
+	>
+	lifecycle_state = <"AuthorDraft">
+
+definition
+	CLUSTER[at0000] matches {	-- Undefined code in a listed term constraint
+		items cardinality matches {0..*; unordered} matches {
+			ELEMENT[at0001] occurrences matches {0..1} matches {	-- Position
+				value matches {
+					DV_CODED_TEXT matches {
+						defining_code matches {
+							-- The dominant 1.4 spelling of a coded value set
+							-- (ADL1.4/master09-customising_adl.adoc §Custom Syntax).
+							-- Every archetype term used here must be defined in the
+							-- ontology (ADL1.4/master08-adl.adoc §Validity Rules
+							-- VATDF); at0999 is not.
+							[local::
+							at0002,
+							at0999]
+						}
+					}
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Undefined code in a listed term constraint">
+					description = <"Refusal fixture: VATDF on a 1.4 listed term constraint.">
+				>
+				["at0001"] = <
+					text = <"Position">
+					description = <"The recorded position.">
+				>
+				["at0002"] = <
+					text = <"Lying">
+					description = <"Lying position.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.VCOC_occurrences_below_cardinality.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.VCOC_occurrences_below_cardinality.v1.adl
@@ -1,0 +1,57 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-CLUSTER.VCOC_occurrences_below_cardinality.v1
+
+concept
+	[at0000]	-- Occurrences sum below the cardinality
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	other_details = <
+		["regression"] = <"VCOC">
+	>
+	lifecycle_state = <"AuthorDraft">
+
+definition
+	CLUSTER[at0000] matches {	-- Occurrences sum below the cardinality
+		-- ADL1.4/master05-cadl.adoc §Occurrences L321-324, VCOC. Two children with
+		-- an occurrences maximum of 1 each can supply at most 2 members, so the
+		-- sum interval 0..2 can never reach the container cardinality lower bound
+		-- of 4 — the cardinality is unsatisfiable by this child set.
+		items cardinality matches {4..*; unordered} matches {
+			ELEMENT[at0001] occurrences matches {0..1} matches {	-- First item
+				value matches {
+					DV_TEXT matches {*}
+				}
+			}
+			ELEMENT[at0002] occurrences matches {0..1} matches {	-- Second item
+				value matches {
+					DV_TEXT matches {*}
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Occurrences sum below the cardinality">
+					description = <"Refusal fixture: VCOC, the occurrences sum cannot reach the cardinality lower.">
+				>
+				["at0001"] = <
+					text = <"First item">
+					description = <"The first item.">
+				>
+				["at0002"] = <
+					text = <"Second item">
+					description = <"The second item.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.VCOC_occurrences_exceed_cardinality.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.VCOC_occurrences_exceed_cardinality.v1.adl
@@ -1,0 +1,67 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-CLUSTER.VCOC_occurrences_exceed_cardinality.v1
+
+concept
+	[at0000]	-- Occurrences sum above the cardinality
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	other_details = <
+		["regression"] = <"VCOC">
+	>
+	lifecycle_state = <"AuthorDraft">
+
+definition
+	CLUSTER[at0000] matches {	-- Occurrences sum above the cardinality
+		-- ADL1.4/master05-cadl.adoc §Occurrences L321-324, VCOC: "the interval
+		-- represented by: (the sum of all occurrences minimum values) .. (the sum
+		-- of all occurrences maximum values) must be inside the interval of the
+		-- cardinality". Three mandatory children sum to 3..3, which is outside the
+		-- container cardinality 0..2.
+		items cardinality matches {0..2; unordered} matches {
+			ELEMENT[at0001] occurrences matches {1..1} matches {	-- First item
+				value matches {
+					DV_TEXT matches {*}
+				}
+			}
+			ELEMENT[at0002] occurrences matches {1..1} matches {	-- Second item
+				value matches {
+					DV_TEXT matches {*}
+				}
+			}
+			ELEMENT[at0003] occurrences matches {1..1} matches {	-- Third item
+				value matches {
+					DV_TEXT matches {*}
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Occurrences sum above the cardinality">
+					description = <"Refusal fixture: VCOC, the occurrences sum exceeds the cardinality upper.">
+				>
+				["at0001"] = <
+					text = <"First item">
+					description = <"The first item.">
+				>
+				["at0002"] = <
+					text = <"Second item">
+					description = <"The second item.">
+				>
+				["at0003"] = <
+					text = <"Third item">
+					description = <"The third item.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.default_occurrences.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.default_occurrences.v1.adl
@@ -1,0 +1,60 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-CLUSTER.default_occurrences.v1
+
+concept
+	[at0000]	-- Default occurrences
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	other_details = <
+		["regression"] = <"PASS">
+	>
+	lifecycle_state = <"AuthorDraft">
+
+definition
+	CLUSTER[at0000] matches {	-- Default occurrences
+		-- The accepting twin of the two VCOC fixtures, and the positive test of the
+		-- ADL 1.4 EFFECTIVE occurrences default: neither child states
+		-- `occurrences`, so each is {1..1} (ADL1.4/master05-cadl.adoc §Occurrences
+		-- L316: "The default occurrences, if none is mentioned, is {1..1}"). The sum
+		-- interval is therefore 2..2, inside the container cardinality 0..3 — a
+		-- reader that treated an absent occurrences as {0..*} would compute an
+		-- unbounded sum and report VCOC here.
+		items cardinality matches {0..3; unordered} matches {
+			ELEMENT[at0001] matches {	-- First item
+				value matches {
+					DV_TEXT matches {*}
+				}
+			}
+			ELEMENT[at0002] matches {	-- Second item
+				value matches {
+					DV_TEXT matches {*}
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Default occurrences">
+					description = <"Accepting fixture: the ADL 1.4 default occurrences {1..1} keeps VCOC quiet.">
+				>
+				["at0001"] = <
+					text = <"First item">
+					description = <"The first item.">
+				>
+				["at0002"] = <
+					text = <"Second item">
+					description = <"The second item.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.domain_assumed_value.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.domain_assumed_value.v1.adl
@@ -1,0 +1,75 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-CLUSTER.domain_assumed_value.v1
+
+concept
+	[at0000]	-- Domain assumed value
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	other_details = <
+		["regression"] = <"PASS">
+	>
+	lifecycle_state = <"AuthorDraft">
+
+definition
+	CLUSTER[at0000] matches {	-- Domain assumed value
+		items cardinality matches {0..*; unordered} matches {
+			ELEMENT[at0001] occurrences matches {0..1} matches {	-- Temperature
+				value matches {
+					-- The accepting twin of SDINV_assumed_value_unmatched: the
+					-- assumed value satisfies the FIRST list row, so its leaves land
+					-- on that row's `C_PRIMITIVE_OBJECT.assumed_value`s
+					-- (AOM2/master04.2 §Assumed_value). `precision` is not
+					-- constrained by the block, so it has no AOM2 carrier.
+					(C_DV_QUANTITY) <
+						property = <[openehr::127]>
+						assumed_value = <
+							units = <"C">
+							precision = <0>
+							magnitude = <8.0>
+						>
+						list = <
+							["1"] = <
+								units = <"C">
+								magnitude = <|>=4.0|>
+							>
+							["2"] = <
+								units = <"F">
+								magnitude = <|>=40.0|>
+							>
+						>
+					>
+				}
+			}
+			ELEMENT[at0002] occurrences matches {0..1} matches {	-- Body site
+				value matches {
+					DV_TEXT matches {*}
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Domain assumed value">
+					description = <"Accepting fixture: a domain `assumed_value` satisfying a `list` row.">
+				>
+				["at0001"] = <
+					text = <"Temperature">
+					description = <"A temperature measurement.">
+				>
+				["at0002"] = <
+					text = <"Body site">
+					description = <"Where the measurement was taken.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.sibling_order.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.sibling_order.v1.adl
@@ -1,0 +1,57 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-CLUSTER.sibling_order.v1
+
+concept
+	[at0000]	-- Sibling order in a 1.4 text
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	other_details = <
+		["regression"] = <"PASS">
+	>
+	lifecycle_state = <"AuthorDraft">
+
+definition
+	CLUSTER[at0000] matches {	-- Sibling order in a 1.4 text
+		items cardinality matches {0..*; unordered} matches {
+			ELEMENT[at0001] occurrences matches {0..1} matches {	-- First item
+				value matches {
+					DV_TEXT matches {*}
+				}
+			}
+			-- `before` and `after` ARE cADL 1.4 keywords:
+			-- ADL1.4/master05-cadl.adoc §Keywords L53 lists both among "the
+			-- keywords … recognised in cADL", so a sibling order in a 1.4 text is
+			-- legal 1.4 and must NOT be dialect-gated.
+			before [at0001] ELEMENT[at0002] occurrences matches {0..1} matches {	-- Second item
+				value matches {
+					DV_TEXT matches {*}
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Sibling order in a 1.4 text">
+					description = <"Accepting fixture: `before [atNNNN]` sibling order in ADL 1.4.">
+				>
+				["at0001"] = <
+					text = <"First item">
+					description = <"The first item.">
+				>
+				["at0002"] = <
+					text = <"Second item">
+					description = <"The re-ordered second item.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.term_constraint_codes_defined.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.term_constraint_codes_defined.v1.adl
@@ -1,0 +1,108 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-CLUSTER.term_constraint_codes_defined.v1
+
+concept
+	[at0000]	-- Defined term constraint codes
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	other_details = <
+		["regression"] = <"PASS">
+	>
+	lifecycle_state = <"AuthorDraft">
+
+definition
+	CLUSTER[at0000] matches {	-- Defined term constraint codes
+		items cardinality matches {0..*; unordered} matches {
+			ELEMENT[at0001] occurrences matches {0..1} matches {	-- Position
+				value matches {
+					DV_CODED_TEXT matches {
+						defining_code matches {
+							-- The accepting twin of the VATDF/VACDF fixtures: every
+							-- archetype term of the 1.4 listed constraint — the
+							-- listed codes AND the assumed code — is defined in the
+							-- ontology (ADL1.4/master08-adl.adoc §Validity Rules
+							-- VATDF).
+							[local::
+							at0002,
+							at0003;
+							at0002]
+						}
+					}
+				}
+			}
+			ELEMENT[at0004] occurrences matches {0..1} matches {	-- Agent
+				value matches {
+					DV_CODED_TEXT matches {
+						defining_code matches {
+							-- The `ac` placeholder is defined in
+							-- `constraint_definitions` (VACDF).
+							[local::ac0001]
+						}
+					}
+				}
+			}
+			ELEMENT[at0005] occurrences matches {0..1} matches {	-- Setting
+				value matches {
+					DV_CODED_TEXT matches {
+						defining_code matches {
+							-- Codes of an EXTERNAL terminology are not archetype
+							-- terms, so VATDF/VACDF definedness does not apply to
+							-- them (ADL1.4/master08-adl.adoc §Validity Rules judges
+							-- the archetype's own `term_definitions`).
+							[openehr::
+							253,
+							271]
+						}
+					}
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Defined term constraint codes">
+					description = <"Accepting fixture: every 1.4 term-constraint code is defined.">
+				>
+				["at0001"] = <
+					text = <"Position">
+					description = <"The recorded position.">
+				>
+				["at0002"] = <
+					text = <"Lying">
+					description = <"Lying position.">
+				>
+				["at0003"] = <
+					text = <"Sitting">
+					description = <"Sitting position.">
+				>
+				["at0004"] = <
+					text = <"Agent">
+					description = <"The responsible agent.">
+				>
+				["at0005"] = <
+					text = <"Setting">
+					description = <"The care setting.">
+				>
+			>
+		>
+	>
+	constraint_definitions = <
+		["en"] = <
+			items = <
+				["ac0001"] = <
+					text = <"Substances or Agents">
+					description = <"All substances or agents of interest.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-OBSERVATION.SCOAT_adl2_attribute_tuple.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-OBSERVATION.SCOAT_adl2_attribute_tuple.v1.adl
@@ -1,0 +1,78 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-OBSERVATION.SCOAT_adl2_attribute_tuple.v1
+
+concept
+	[at0000]	-- ADL2 attribute tuple in a 1.4 text
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	lifecycle_state = <"AuthorDraft">
+
+definition
+	OBSERVATION[at0000] matches {	-- ADL2 attribute tuple in a 1.4 text
+		data matches {
+			HISTORY[at0001] matches {	-- Event Series
+				events cardinality matches {1..*; unordered} matches {
+					EVENT[at0002] matches {	-- Any event
+						data matches {
+							ITEM_TREE[at0003] matches {	-- Tree
+								items cardinality matches {0..*; unordered} matches {
+									ELEMENT[at0004] occurrences matches {0..1} matches {	-- Pressure
+										value matches {
+											DV_QUANTITY matches {
+												-- Second-order attribute tuples are
+												-- ADL2 only (ADL2/master04.4 §Second
+												-- Order Constraints); AOM2/master04.3
+												-- §Tuple Constraints states the tuple
+												-- type "replaces all domain-specific
+												-- constraint types defined in ADL/AOM
+												-- 1.4", so a 1.4 text expresses this
+												-- with an inline dADL `C_DV_QUANTITY`
+												-- block instead.
+												[magnitude, units] matches {
+													[{|>=0.0|}, {"mm[Hg]"}]
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"ADL2 attribute tuple in a 1.4 text">
+					description = <"Refusal fixture: an ADL2 second-order tuple in an ADL 1.4 definition.">
+				>
+				["at0001"] = <
+					text = <"Event Series">
+					description = <"@ internal @">
+				>
+				["at0002"] = <
+					text = <"Any event">
+					description = <"Any event.">
+				>
+				["at0003"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0004"] = <
+					text = <"Pressure">
+					description = <"A pressure measurement.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-OBSERVATION.SCOAT_adl2_default_value.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-OBSERVATION.SCOAT_adl2_default_value.v1.adl
@@ -1,8 +1,8 @@
 archetype (adl_version=1.4)
-	openEHR-EHR-OBSERVATION.SDINV_default_interval.v1
+	openEHR-EHR-OBSERVATION.SCOAT_adl2_default_value.v1
 
 concept
-	[at0000]	-- Interval default value
+	[at0000]	-- ADL2 default value in a 1.4 text
 
 language
 	original_language = <[ISO_639-1::en]>
@@ -14,16 +14,19 @@ description
 	lifecycle_state = <"AuthorDraft">
 
 definition
-	OBSERVATION[at0000] matches {	-- Interval default value
+	OBSERVATION[at0000] matches {	-- ADL2 default value in a 1.4 text
 		data matches {
 			HISTORY[at0001] matches {	-- Event Series
 				events cardinality matches {1..*; unordered} matches {
 					EVENT[at0002] occurrences matches {0..*} matches {	-- Any event
-						-- An interval has no canonical-JSON default encoding, so
-						-- it is refused rather than silently reduced to null.
+						-- The `_default` pseudo-attribute is ADL2 only
+						-- (ADL2/master06-default_values.adoc §Default Values); the
+						-- cADL 1.4 keyword set (ADL1.4/master05-cadl.adoc §Keywords
+						-- L48-53) has no such construct, so a 1.4 text carrying one
+						-- is refused rather than silently accepted.
 						_default = (DV_QUANTITY) <
 							units = <"mm[Hg]">
-							magnitude = <|0.0..5.0|>
+							magnitude = <5.0>
 						>
 					}
 				}
@@ -36,8 +39,8 @@ ontology
 		["en"] = <
 			items = <
 				["at0000"] = <
-					text = <"Interval default value">
-					description = <"Refusal fixture: an interval as a _default value.">
+					text = <"ADL2 default value in a 1.4 text">
+					description = <"Refusal fixture: an ADL2 `_default` in an ADL 1.4 definition.">
 				>
 				["at0001"] = <
 					text = <"Event Series">

--- a/crates/openehr-adl/tests/corpus_coverage.rs
+++ b/crates/openehr-adl/tests/corpus_coverage.rs
@@ -28,10 +28,12 @@
 //! | `FeaturesAdls` | `features/**/*.adls` | `corpus_{outer_parse,definition_parse,roundtrip}.rs` |
 //! | `FeaturesAdl` | `features/**/*.adl` | `legacy14_corpus.rs` (1.4-tolerant parse) |
 //! | `Adl14Dadl` | `adl14-dadl/*.adl` | `adl14_dadl_breadth.rs` (accept/refuse per fixture) |
+//! | `Adl14Cadl` | `adl14-cadl/*.adl` | `adl14_cadl_gates.rs` (accept/refuse/invalid per fixture) |
 //!
-//! `adl14-dadl/` is the one HAND-WRITTEN tree here (`tests/corpus/PROVENANCE.md`
-//! §`adl14-dadl/`); it is counted separately so the vendored-corpus size ratchet
-//! below stays a statement about the vendored trees alone.
+//! `adl14-dadl/` and `adl14-cadl/` are the HAND-WRITTEN trees here
+//! (`tests/corpus/PROVENANCE.md`); they are counted separately so the
+//! vendored-corpus size ratchet below stays a statement about the vendored trees
+//! alone.
 
 use std::path::{Path, PathBuf};
 
@@ -53,6 +55,7 @@ enum Category {
     FeaturesAdls,
     FeaturesAdl,
     Adl14Dadl,
+    Adl14Cadl,
 }
 
 /// Classify a corpus source file (relative to `tests/corpus/`) into exactly one
@@ -69,9 +72,12 @@ fn classify(rel: &str, is_adl: bool) -> Option<Category> {
         }
         return None;
     }
-    // The hand-written ADL 1.4 dADL breadth tree.
+    // The hand-written ADL 1.4 trees.
     if rel.starts_with("adl14-dadl/") {
         return Some(Category::Adl14Dadl);
+    }
+    if rel.starts_with("adl14-cadl/") {
+        return Some(Category::Adl14Cadl);
     }
     // adl2-reference fixtures.
     let r = rel.strip_prefix("adl2-reference/")?;
@@ -142,7 +148,10 @@ fn every_corpus_source_is_claimed_by_exactly_one_harness() {
         PathBuf::from(format!("{CORPUS}/adl2-reference")),
         PathBuf::from(format!("{CORPUS}/flattener")),
     ];
-    let hand_written_roots = [PathBuf::from(format!("{CORPUS}/adl14-dadl"))];
+    let hand_written_roots = [
+        PathBuf::from(format!("{CORPUS}/adl14-dadl")),
+        PathBuf::from(format!("{CORPUS}/adl14-cadl")),
+    ];
 
     let mut counts: std::collections::BTreeMap<String, usize> = std::collections::BTreeMap::new();
     let mut unclaimed: Vec<String> = Vec::new();
@@ -199,7 +208,7 @@ fn every_corpus_source_is_claimed_by_exactly_one_harness() {
     // The hand-written tree only ratchets up: a fixture is added, never
     // removed to go green (`.claude/rules/testing.md`).
     assert!(
-        hand_written >= 4,
-        "expected at least the 4 hand-written adl14-dadl fixtures; found {hand_written}"
+        hand_written >= 20,
+        "expected at least the 20 hand-written adl14-dadl + adl14-cadl fixtures; found {hand_written}"
     );
 }

--- a/crates/openehr-adl/tests/legacy14_corpus.rs
+++ b/crates/openehr-adl/tests/legacy14_corpus.rs
@@ -20,6 +20,8 @@
 //! - `adl14-dadl/*.adl` — the hand-written dADL breadth tree, claimed by
 //!   `adl14_dadl_breadth.rs` (accept/refuse per fixture, leaf values
 //!   asserted).
+//! - `adl14-cadl/*.adl` — the hand-written cADL tree (dialect gates, domain
+//!   lowering, VATDF/VACDF, VCOC), claimed by `adl14_cadl_gates.rs`.
 #![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 
 use std::path::{Path, PathBuf};
@@ -67,8 +69,8 @@ fn rel(p: &Path) -> String {
 fn every_adl_file_is_claimed_with_an_outcome() {
     let files = all_adl_files();
     assert!(
-        files.len() >= 21,
-        "expected the full 1.4 `.adl` census (>= 21), found {}",
+        files.len() >= 37,
+        "expected the full 1.4 `.adl` census (>= 37), found {}",
         files.len()
     );
 
@@ -120,6 +122,10 @@ fn every_adl_file_is_claimed_with_an_outcome() {
             // The hand-written dADL breadth tree, owned by
             // `adl14_dadl_breadth.rs` (which asserts each fixture's declared
             // accept/refuse outcome and its leaf values).
+            claimed += 1;
+        } else if r.starts_with("adl14-cadl/") {
+            // The hand-written cADL tree, owned by `adl14_cadl_gates.rs` (which
+            // asserts each fixture's declared accept/refuse/invalid outcome).
             claimed += 1;
         } else {
             panic!("unclaimed .adl file (no coverage category): {r}");


### PR DESCRIPTION
Closes #1307.

The #767 audit's correctness findings, all spec-cited: the untyped domain-lowering silent wrong answer, the dropped assumed_value, the unvalidated qualified/listed term constraints (VATDF/VACDF now fire on the dominant 1.4 spelling), VCOC (with the corpus-consistent adjudication NOTE), the master05 effective defaults incl. use_node inheritance, the closed 1.4 dialect (six ADL2-only constructs typed-rejected; before/after kept per L53), and VUNT in the RM pass. 17-fixture adl14-cadl corpus tree with refusal twins. Two follow-ups carried onto #1308 (STCAC/STCDC; the VUNT-reachability decision).

Gates: workspace clippy --all-features ZERO warnings; nextest 260/260 (lang+adl) + 707/707 (ehrbase). Changelog entries included.