### PR TITLE
fix(adl14): cADL syntax-form completion (#767 syntax half)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,47 @@ workflow refuses a tag that has no matching section here.
   different.
 - **`use_node` type conformance is enforced (VUNT).** An internal reference
   whose declared type is neither the referenced node's type nor an ancestor of
-  it is now a validation error instead of passing silently.
+  it is now a validation error instead of passing silently. It is also reached
+  by an ADL 1.4 upload: VUNT is a rule of the ADL 1.4 specification itself
+  (master05 §Internal References), so the 1.4 validity check now runs the
+  reference-model pass for that rule instead of stopping before it.
+- **cADL keywords are recognised in any case.** `MATCHES`, `Occurrences`,
+  `CARDINALITY`, `Is_In`, `TRUE` and every other keyword are now lexed as
+  keywords, as both the ADL 1.4 specification's own lexical rules (master05
+  §Symbols) and the normative ANTLR grammars require; previously only the
+  lower-case spelling worked, so an upper-case archetype failed to parse.
+- **`infinity` is accepted as an interval bound in cADL constraints.**
+  `rate matches {|0..infinity|}` — the ADL 1.4 specification's own worked
+  example (master05 §Interval of Integer) — parsed in a dADL section but was
+  rejected in a cADL constraint. `-infinity` and `*` are accepted likewise,
+  and each yields a genuinely unbounded endpoint.
+- **The `^…^` regular-expression delimiter survives a re-print.** A constraint
+  written `{^km/h|mi/h^}` (master05 §Regular Expression) was normalised to
+  `{/km/h|mi/h/}`, which no longer re-parsed; the inner delimiters are now
+  escaped, so parse → print → parse is lossless.
+- **More date/time constraint-pattern forms are accepted:** patterns with
+  literal date/time numbers substituted for the placeholder fields
+  (`1995-??-XX`, master05 §Patterns), the ASCII timezone modifiers `+hh:mm` /
+  `+hhmm` / `-hh` (previously only the literal `±` character worked), and the
+  space-separated date/time pattern (`yyyy-mm-dd hh:mm:XX`), which the
+  specification's own assumed-value example uses.
+- **Character constraints are accepted** (`color_name matches {'r','g','b'}`,
+  master05 §Constraints on Character), as are the `, ...` list-continuation
+  marker on every primitive list and the exclusive-lower interval spelling the
+  ADL 1.4 chapters write (`|0>..<1000|`).
+- **An inline ADL 1.4 domain block containing a one-sided interval now
+  parses.** A `C_DV_QUANTITY <… magnitude = <|>0.0|> …>` block was cut short at
+  the interval's own `>`, so the archetype was rejected as invalid dADL.
+- **Defects inside an ADL 1.4 listed term constraint are now reported**: a
+  repeated code (STCDC) and an assumed-value code that is not a member of the
+  list (STCAC).
+- **A date/time interval must use a timezone on both endpoints or on neither**
+  (master05 §Intervals), so two endpoints that cannot be compared are rejected
+  instead of silently accepted.
+- **Operators the ADL 1.4 chapter names but no grammar defines are refused
+  with a message that says so** — the negated `~matches` / `~is_in` / `∉`
+  family and the `=~` / `!~` regex-match operators — instead of being read as
+  their affirmative counterparts, which would invert the constraint.
 
 ### Changed
 

--- a/app/ehrbase/src/service/definition/adl14.rs
+++ b/app/ehrbase/src/service/definition/adl14.rs
@@ -6,8 +6,10 @@
 //! 1.4**: an upload parses via [`openehr_adl::assemble::parse_artefact_adl14`]
 //! (the 1.4-shaped `openehr_am::am24` model) and validates against the subset
 //! of the phase-1 catalogue that corresponds to the ADL 1.4 / AOM 1.4 standalone
-//! validity rules ([`openehr_adl::validate::validate_source_phase1_adl14`];
-//! ADL1.4 `master08` §Validity Rules + AOM1.4 class invariants). A 1.4 source is
+//! validity rules, plus the one 1.4 rule stated "according to the reference
+//! model" — VUNT ([`openehr_adl::validate::validate_source_adl14`]; ADL1.4
+//! `master08` §Validity Rules + `master05-cadl.adoc` §Internal References
+//! L512-513 + AOM1.4 class invariants). A 1.4 source is
 //! validated **as 1.4**, never post-conversion — converting the artefact would
 //! change what is being judged.
 //!
@@ -23,7 +25,8 @@ use std::str::FromStr;
 use openehr_adl::adl14::convert::{ConvertConfig, parse_and_convert};
 use openehr_adl::adl14::log::ConversionLog;
 use openehr_adl::error::SyntaxError;
-use openehr_adl::validate::{Severity, ValidationIssue, validate_source_phase1_adl14};
+use openehr_adl::validate::rm::ProductionRmModel;
+use openehr_adl::validate::{Severity, ValidationIssue, validate_source_adl14};
 use openehr_base::prelude::ArchetypeId;
 use openehr_its::rest::runtime::ValidationError;
 use uuid::Uuid;
@@ -60,7 +63,7 @@ impl EhrbaseService {
     /// in the `Ok` boolean.
     pub fn valid_archetype(&self, adl: &str) -> Result<bool, SmError> {
         Ok(matches!(
-            validate_source_phase1_adl14(adl),
+            validate_source_adl14(adl, &ProductionRmModel),
             Ok(issues) if issues.iter().all(|i| i.severity != Severity::Error)
         ))
     }
@@ -609,13 +612,20 @@ impl EhrbaseService {
 // ── stateless validity helpers ────────────────────────────────────────────────
 
 /// Validate an ADL 1.4 source through the `openehr-adl` engine, judged **as
-/// 1.4** (`openehr_adl::validate::validate_source_phase1_adl14`). An unparseable
-/// source (S-codes) or a phase-1 catalogue failure (V-codes) is a
+/// 1.4** (`openehr_adl::validate::validate_source_adl14`). An unparseable
+/// source (S-codes) or a catalogue failure (V-codes) is a
 /// [`ServiceError::ValidationFailed`] carrying the rule-code mnemonics — the SM
 /// `upload_archetype` maps it to `invalid_archetype` / `content_invalid`
 /// (`422`, `i_definition_adl14.adoc`; ADL1.4 `master08` §Validity Rules).
+///
+/// The reference model is the generated openEHR RM 1.2.0
+/// ([`ProductionRmModel`]), so the one ADL 1.4 validity rule that is stated
+/// "according to the reference model" — VUNT, `use_node` type conformance
+/// (`ADL1.4/master05-cadl.adoc` §Internal References L512-513) — is reached by
+/// an upload instead of being unreachable behind a phase-1-only entry point.
 fn archetype_validate(adl: &str) -> Result<(), ServiceError> {
-    let issues = validate_source_phase1_adl14(adl).map_err(archetype_syntax_failure)?;
+    let issues =
+        validate_source_adl14(adl, &ProductionRmModel).map_err(archetype_syntax_failure)?;
     let errors: Vec<ValidationError> = issues
         .iter()
         .filter(|i| i.severity == Severity::Error)

--- a/app/ehrbase/tests/adl14_knowledge_archetypes.rs
+++ b/app/ehrbase/tests/adl14_knowledge_archetypes.rs
@@ -1,0 +1,115 @@
+//! Parse gate over the ADL 1.4 archetype resources this crate ships as test
+//! knowledge (`tests/resources/service/knowledge/archetypes/`).
+//!
+//! These are real-world CKM-lineage 1.4 sources (Ocean Informatics, 2007) —
+//! the only artefacts in the tree that carry `ac`-code constraints with a
+//! `constraint_definitions` ontology section and the inline dADL
+//! `C_DV_QUANTITY` domain blocks of
+//! `docs/specs/openehr/AM/docs/ADL1.4/master09-customising_adl.adoc`. Most were
+//! reachable only through the database-backed `service_definition` suite, so a
+//! parser regression on the constructs unique to them went unseen; this gate is
+//! DB-free and pins each file's outcome by name.
+//!
+//! The outcome is the SPEC's verdict on the artefact, not an assumption that a
+//! published artefact must be valid: two of them state an assumed value their
+//! own constraint excludes, which `ADL1.4/master05-cadl.adoc` §Assumed Values
+//! L1012 forbids ("a value of the same type as that implied by the preceding
+//! part of the constraint"), and the parser refuses them loudly rather than
+//! binding the assumed instance to an arbitrary alternative. Both the accepted
+//! and the refused shapes are pinned, so neither a newly-lenient nor a
+//! newly-strict parser passes silently.
+
+#![allow(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
+
+use std::path::{Path, PathBuf};
+
+use openehr_adl::assemble::parse_artefact_adl14;
+use openehr_adl::error::SyntaxErrorCode;
+
+/// What the ADL 1.4 parser must do with a knowledge-resource archetype.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Expect {
+    /// Parses in the 1.4 dialect.
+    Parses,
+    /// Refused at parse with this syntax code.
+    Refuse(SyntaxErrorCode),
+}
+
+/// Every `.adl` resource in the knowledge tree, with its expected outcome.
+const ARCHETYPES: &[(&str, Expect)] = &[
+    // A COMPOSITION with an archetype slot; the `service_definition` suite's
+    // upload fixture.
+    (
+        "openEHR-EHR-COMPOSITION.prescription.v1.adl",
+        Expect::Parses,
+    ),
+    // An INSTRUCTION with an activity slot and an ISO8601 duration constraint.
+    ("openEHR-EHR-INSTRUCTION.medication.v1.adl", Expect::Parses),
+    // The two `ac`-code + `constraint_definitions` artefacts, each with 18
+    // inline `C_DV_QUANTITY` domain blocks. Both state
+    // `assumed_value.magnitude = 0.0` against a `magnitude` constrained to
+    // `|>0.0|` — an assumed value outside the constraint's own value space,
+    // which `ADL1.4/master05-cadl.adoc` §Assumed Values L1012 does not admit.
+    (
+        "openEHR-EHR-ITEM_TREE.medication.v1.adl",
+        Expect::Refuse(SyntaxErrorCode::Sdinv),
+    ),
+    (
+        "openEHR-EHR-ITEM_TREE.medication_mod.v1.adl",
+        Expect::Refuse(SyntaxErrorCode::Sdinv),
+    ),
+    // The master08 §Revision History Section example (shared with the
+    // `adl14-dadl` breadth tree).
+    (
+        "openEHR-EHR-OBSERVATION.revision_history.v1.adl",
+        Expect::Parses,
+    ),
+    // Two SECTIONs whose slots carry `include`/`exclude` assertion pairs.
+    ("openEHR-EHR-SECTION.medication.v1.adl", Expect::Parses),
+    ("openEHR-EHR-SECTION.medications.v1.adl", Expect::Parses),
+];
+
+fn tree() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/resources/service/knowledge/archetypes")
+}
+
+#[test]
+fn every_knowledge_archetype_meets_its_declared_parse_outcome() {
+    for (name, expect) in ARCHETYPES {
+        let path = tree().join(name);
+        let src = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+        match expect {
+            Expect::Parses => {
+                parse_artefact_adl14(&src)
+                    .unwrap_or_else(|e| panic!("{name} must parse as ADL 1.4, got {e:?}"));
+            }
+            Expect::Refuse(code) => {
+                let errs = parse_artefact_adl14(&src)
+                    .err()
+                    .unwrap_or_else(|| panic!("{name} must be refused at parse"));
+                assert!(
+                    errs.iter().any(|e| e.code == *code),
+                    "{name}: expected {code}, got {:?}",
+                    errs.iter().map(|e| e.code).collect::<Vec<_>>()
+                );
+            }
+        }
+    }
+}
+
+/// No `.adl` resource may sit unexercised: a new or renamed knowledge archetype
+/// breaks this gate rather than silently escaping the parser.
+#[test]
+fn every_knowledge_archetype_file_is_in_the_table() {
+    let mut on_disk: Vec<String> = std::fs::read_dir(tree())
+        .expect("read the knowledge archetype tree")
+        .flatten()
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .filter(|n| Path::new(n).extension().is_some_and(|e| e == "adl"))
+        .collect();
+    on_disk.sort();
+    let mut listed: Vec<String> = ARCHETYPES.iter().map(|(n, _)| (*n).to_owned()).collect();
+    listed.sort();
+    assert_eq!(on_disk, listed, "the archetype table and the tree disagree");
+}

--- a/crates/openehr-adl/CLAUDE.md
+++ b/crates/openehr-adl/CLAUDE.md
@@ -41,7 +41,11 @@ into the generated `openehr_am::am24::aom2` model — never re-model AOM2.
   file names encode the expected rule code) plus two HAND-WRITTEN ADL 1.4 trees
   the vendored ADL2 library cannot cover — `adl14-dadl/` (master04 dADL breadth)
   and `adl14-cadl/` (master05 cADL: dialect gates, domain lowering,
-  VATDF/VACDF, VCOC). Corpus cases are the regression net — never delete/weaken
+  VATDF/VACDF/STCDC/STCAC, VCOC, the operators the chapter names but no grammar
+  defines — `~matches`/`~is_in`/`∉`, `=~`/`!~` — and the
+  `cadl_breadth_{structure,primitives,datetime}` trio covering every construct
+  of the chapter). `app/ehrbase/tests/adl14_knowledge_archetypes.rs` is the
+  DB-free parse gate over the app's real-world CKM 1.4 knowledge resources. Corpus cases are the regression net — never delete/weaken
   one to get green; a defect goes through adjudication, not case edits, and
   every refusal keeps its accepting twin.
 - Dependencies point downward only: `openehr-am`, `openehr-base`, `openehr-lang`

--- a/crates/openehr-adl/src/cadl.rs
+++ b/crates/openehr-adl/src/cadl.rs
@@ -283,6 +283,54 @@ impl Parser<'_> {
         )
     }
 
+    /// True if the cursor is at a NEGATED matches operator (`~matches`,
+    /// `~is_in`, `∉`) — lexically `SymNot SymMatches` or the single `∉`.
+    fn at_negated_matches(&self) -> bool {
+        matches!(self.peek(), Some(Token::SymNotMatches))
+            || (matches!(self.peek(), Some(Token::SymNot))
+                && matches!(self.peek_at(1), Some(Token::SymMatches)))
+    }
+
+    /// True if the cursor is at a regex-match operator (`=~` or `!~`).
+    ///
+    /// Neither is a token in any normative lexical specification, so both
+    /// arrive here as a token PAIR: `=~` as `SymEq SymNot` and `!~` as
+    /// `SymNot SymNot` (`!` and `~` both fold into `SYM_NOT` —
+    /// `adl_keywords.g4` `SYM_NOT : [Nn][Oo][Tt] | '!' | '∼' | '~' | '¬'`).
+    fn at_regex_match_operator(&self) -> bool {
+        matches!(self.peek(), Some(Token::SymEq | Token::SymNot))
+            && matches!(self.peek_at(1), Some(Token::SymNot))
+    }
+
+    /// Refuse a negated matches operator with a message that says where the
+    /// negation IS admitted.
+    ///
+    /// `ADL1.4/master05-cadl.adoc` §Keywords lists `~matches`/`~is_in` (L47)
+    /// and glosses them at L91-98 ("Occasionally, the matches operator needs to
+    /// be used in the negative, usually at a leaf block"), but NO production of
+    /// any normative grammar admits them:
+    /// * the chapter's own §Syntax has one `SYM_MATCHES` in `c_attribute`,
+    ///   `c_complex_object` and `archetype_slot` (L1069-1120) and its §Symbols
+    ///   lexer (L1300-1354) has no `~` symbol and no `∉` token at all;
+    /// * the vendored ANTLR set is identical — `cadl14.g4` uses `SYM_MATCHES`
+    ///   only, and `adl_keywords.g4` `SYM_MATCHES` folds `matches`/`is_in`/`∈`
+    ///   with no negated counterpart.
+    ///
+    /// The only negation the grammars DO admit is prefix `not`/`~`/`!`/`¬` on a
+    /// whole boolean expression (`base_expressions.g4` `boolean_expr : SYM_NOT
+    /// boolean_expr`), i.e. inside a slot `include`/`exclude` assertion or the
+    /// rules section, which this crate parses through `openehr_lang::bel`. So
+    /// the negated operator is refused HERE, in cADL constraint position, and
+    /// accepted there — never silently read as an affirmative `matches`, which
+    /// would invert the constraint.
+    fn negated_matches_reject<T>(&mut self, code: SyntaxErrorCode) -> PResult<T> {
+        self.err(
+            code,
+            "a negated matches operator ('~matches' / '~is_in' / '∉') is not a cADL production; \
+             negation is available as the prefix 'not' operator of a slot include/exclude assertion",
+        )
+    }
+
     /// Consume a token matching `pred` or record `code`/`msg` and bail.
     fn expect(
         &mut self,
@@ -480,6 +528,9 @@ impl Parser<'_> {
             None
         };
 
+        if self.at_negated_matches() {
+            return self.negated_matches_reject(SyntaxErrorCode::Sccog);
+        }
         let mut obj = if matches!(self.peek(), Some(Token::SymMatches)) {
             self.pos += 1; // SYM_MATCHES
             self.expect(
@@ -651,6 +702,9 @@ impl Parser<'_> {
         };
         let is_multiple = cardinality.is_some();
 
+        if self.at_negated_matches() {
+            return self.negated_matches_reject(SyntaxErrorCode::Scoat);
+        }
         let children = if self.eat(|t| matches!(t, Token::SymMatches)) {
             if let Some(Token::ContainedRegexp(raw)) = self.peek().cloned() {
                 // `attr matches {/re/}` — a C_STRING regex shortcut (`cadl2.g4`).
@@ -1066,7 +1120,32 @@ impl Parser<'_> {
 
     /// `c_regular_object : c_complex_object | c_archetype_root |
     /// c_complex_object_proxy | archetype_slot | c_regular_primitive_object`.
+    /// One object inside an attribute body.
+    ///
+    /// NOTE: the `=~` / `!~` regex-match operators the chapter's prose shows
+    /// (`ADL1.4/master05-cadl.adoc` §Regular Expression L691-693:
+    /// `string_attr matches {=~ /regular expression}` …
+    /// `{!~ /regular expression}`) are refused here, because no normative
+    /// grammar defines them and the prose that does is itself malformed — both
+    /// example regexes are UNTERMINATED (opening `/` with no closing `/`),
+    /// while the sentence that follows says the first two forms are "identical",
+    /// i.e. `=~` adds nothing. The chapter's own §Syntax gives
+    /// `c_string_spec : V_STRING | string_list_value | string_list_value ','
+    /// SYM_LIST_CONTINUE | V_REGEXP` (L1244-1249) with `V_REGEXP` the bare
+    /// delimited form (L1471-1476), its §Symbols lexer has no `=~`/`!~` token,
+    /// and `cadl14_primitives.g4` `c_string` is `( string_value |
+    /// string_list_value | regex_constraint )` with `regex_constraint :
+    /// SLASH_REGEX | CARET_REGEX`. Guessing a negated-regex semantics from
+    /// defective prose would be a silent wrong answer, so the operator is a
+    /// typed refusal naming the defect.
     fn parse_c_regular_object(&mut self) -> PResult<CObject> {
+        if self.at_regex_match_operator() {
+            return self.err(
+                SyntaxErrorCode::Sccog,
+                "the '=~' / '!~' regex-match operators are not a cADL production; \
+                 write the regex constraint directly, as '{/re/}' or '{^re^}'",
+            );
+        }
         if self.dialect == Dialect::Adl14 {
             // 1.4-only object forms (converter front end; no openEHR spec —
             // see `crate::adl14`): a bare qualified/listed terminology
@@ -1146,6 +1225,11 @@ impl Parser<'_> {
     /// form is preserved verbatim in `C_TERMINOLOGY_CODE.constraint` for
     /// `crate::adl14::convert` to rewrite. No openEHR spec governs this — our
     /// own design (1.4→2 converter front end).
+    ///
+    /// The list form additionally carries the two catalogue rules on the code
+    /// list itself — STCDC (duplicates) and STCAC (an assumed code outside the
+    /// list), both raised at position below.
+    #[allow(clippy::too_many_lines)] // one linear parse: bracket, codes, assumed, the two list rules
     fn parse_adl14_term_object(&mut self) -> PResult<CObject> {
         let constraint = if let Some(Token::TermCodeRef(raw)) = self.peek().cloned() {
             self.pos += 1;
@@ -1153,6 +1237,7 @@ impl Parser<'_> {
             raw.trim_start_matches('[').trim_end_matches(']').to_owned()
         } else {
             // `[` terminology `::` code ( `,` code )* ( `;` assumed )? `]`.
+            let start = self.cur_span().start;
             self.expect(
                 |t| matches!(t, Token::LBracket),
                 SyntaxErrorCode::Stccp,
@@ -1204,11 +1289,53 @@ impl Parser<'_> {
                 }
                 break;
             }
+            let list_span = start..self.cur_span().end;
             self.expect(
                 |t| matches!(t, Token::RBracket),
                 SyntaxErrorCode::Stccp,
                 "expecting ']' closing a terminology code",
             )?;
+            // STCDC: "duplicate code(s) found in code list"
+            // (`ADL2/master04.6-cadl_validity_rules.adoc` §Syntax Validity
+            // Rules). A repeated member adds no value to the constrained set
+            // and is a defect in the source, not a silently-collapsed set.
+            let mut seen: Vec<&str> = Vec::with_capacity(codes.len());
+            let duplicates: Vec<&str> = codes
+                .iter()
+                .filter(|c| {
+                    let dup = seen.contains(&c.as_str());
+                    seen.push(c.as_str());
+                    dup
+                })
+                .map(String::as_str)
+                .collect();
+            if !duplicates.is_empty() {
+                self.push(
+                    SyntaxErrorCode::Stcdc,
+                    format!(
+                        "duplicate code(s) found in code list: {}",
+                        duplicates.join(", ")
+                    ),
+                    list_span.clone(),
+                );
+                return Err(());
+            }
+            // STCAC: "assumed value code $1 not found in code list" (same
+            // catalogue). `ADL1.4/master05-cadl.adoc` §Assumed Values L1012
+            // requires the assumed value to be "a value of the same type as
+            // that implied by the preceding part of the constraint" — for a
+            // listed term constraint the implied type is the listed set, so an
+            // assumed code outside it can never be assumed.
+            if let Some(a) = assumed.as_deref()
+                && !codes.iter().any(|c| c == a)
+            {
+                self.push(
+                    SyntaxErrorCode::Stcac,
+                    format!("assumed value code {a} not found in code list"),
+                    list_span,
+                );
+                return Err(());
+            }
             let mut s = format!("{terminology}::{}", codes.join(","));
             if let Some(a) = assumed {
                 s.push(';');
@@ -1275,6 +1402,17 @@ impl Parser<'_> {
             )?;
         }
         // The ODIN block spans from the opening '<' to its matching '>'.
+        //
+        // The `<`/`>` nesting depth is counted OUTSIDE `|…|` intervals only: a
+        // one-sided interval endpoint carries its own `<`/`>` relational
+        // operator (`magnitude = <|>0.0|>`), which would otherwise close the
+        // block early and hand `openehr_lang::odin` a truncated text. The 1.4
+        // chapter flags exactly this hazard in its own scanner specification —
+        // `ADL1.4/master05-cadl.adoc` §Symbols L1448-1453,
+        // `V_C_DOMAIN_TYPE`: "this is an attempt to match a dADL section inside
+        // cADL. It will probably never work 100% properly since there can be
+        // '>' inside '||' ranges" — so the interval delimiter is tracked
+        // instead of scanning raw characters.
         let open = self.pos;
         if !matches!(self.peek(), Some(Token::SymLt)) {
             return self.err(
@@ -1283,11 +1421,13 @@ impl Parser<'_> {
             );
         }
         let mut depth = 0usize;
+        let mut in_interval = false;
         let mut close = None;
         while let Some(tok) = self.peek() {
             match tok {
-                Token::SymLt => depth += 1,
-                Token::SymGt => {
+                Token::SymIvlDelim => in_interval = !in_interval,
+                Token::SymLt if !in_interval => depth += 1,
+                Token::SymGt if !in_interval => {
                     depth -= 1;
                     if depth == 0 {
                         close = Some(self.pos);
@@ -1516,6 +1656,9 @@ impl Parser<'_> {
             if matches!(self.peek(), Some(Token::SymOccurrences)) {
                 occurrences = Some(self.parse_occurrences()?);
             }
+            if self.at_negated_matches() {
+                return self.negated_matches_reject(SyntaxErrorCode::Sccog);
+            }
             if self.eat(|t| matches!(t, Token::SymMatches)) {
                 self.expect(
                     |t| matches!(t, Token::LCurly),
@@ -1631,6 +1774,7 @@ impl Parser<'_> {
                 Token::SymTrue
                 | Token::SymFalse
                 | Token::String(_)
+                | Token::Character(_)
                 | Token::Integer(_)
                 | Token::Real(_)
                 | Token::Iso8601Date(_)
@@ -1657,6 +1801,7 @@ impl Parser<'_> {
         match self.peek().cloned() {
             Some(Token::SymTrue | Token::SymFalse) => self.parse_c_boolean(node_id),
             Some(Token::String(_)) => self.parse_c_string(node_id),
+            Some(Token::Character(_)) => self.parse_c_character(node_id),
             Some(Token::LBracket) => self.parse_c_terminology_code(node_id, None),
             Some(Token::AlphaLcId(s)) if is_strength_keyword(&s) => {
                 // ADL2-only: constraint strengths (`required`/`extensible`/
@@ -1711,7 +1856,8 @@ impl Parser<'_> {
     }
 
     /// Peek inside a `|…|` interval to classify its value kind by the first
-    /// endpoint token (skipping relational operators and signs).
+    /// endpoint token (skipping relational operators, signs, and the unbounded
+    /// endpoint markers — `|-infinity..5.0|` is typed by its UPPER endpoint).
     fn classify_bar_kind(&mut self) -> PResult<PrimKind> {
         let mut i = self.pos + 1;
         while matches!(
@@ -1723,6 +1869,9 @@ impl Parser<'_> {
                     | Token::SymLe
                     | Token::SymPlus
                     | Token::SymMinus
+                    | Token::SymInfinity
+                    | Token::SymStar
+                    | Token::SymIvlSep
             )
         ) {
             i += 1;
@@ -1752,7 +1901,7 @@ impl Parser<'_> {
                 }
                 _ => return self.err(SyntaxErrorCode::Scbav, "expecting 'True' or 'False'"),
             }
-            if !self.eat(|t| matches!(t, Token::SymComma)) {
+            if !self.eat(|t| matches!(t, Token::SymComma)) || self.eat_list_continue() {
                 break;
             }
         }
@@ -1792,6 +1941,67 @@ impl Parser<'_> {
         }))
     }
 
+    /// `c_character` — a `Character` constraint written as a list of
+    /// single-quoted characters (`ADL1.4/master05-cadl.adoc` §Constraints on
+    /// Character L813-825, identically `ADL2/master04.5` §Constraints on
+    /// Character L160-172: "`color_name matches {'r', 'g', 'b'}`"). The
+    /// single-character regex form (L827-841) needs no separate production —
+    /// it is a `CONTAINED_REGEXP` and lands on the same carrier.
+    ///
+    /// NOTE: there is no `C_CHARACTER` class to build. Neither vendored AOM
+    /// generation defines one — the AM 1.4.0 BMM's constraint model has
+    /// `C_BOOLEAN`/`C_STRING`/`C_INTEGER`/`C_REAL`/`C_DATE`/`C_TIME`/
+    /// `C_DATE_TIME`/`C_DURATION`/`C_ORDINAL`/`C_CODED_TEXT`/`C_QUANTITY` and
+    /// the AM 2.4.0 BMM's has the AOM2 successors of the same set, neither with
+    /// a character constrainer, and `cadl14_primitives.g4` `c_primitive_object`
+    /// likewise has no `c_character` alternative. The carrier is therefore
+    /// `C_STRING` — whose value space, a set of literal strings, contains the
+    /// single-character strings exactly — with the constrained RM type name
+    /// (`Character`) kept on the object so nothing downstream has to guess.
+    /// No openEHR spec governs this mapping — our own design/extension.
+    fn parse_c_character(&mut self, node_id: String) -> PResult<CObject> {
+        let mut constraint = Vec::new();
+        loop {
+            match self.peek().cloned() {
+                Some(Token::Character(c)) => {
+                    self.pos += 1;
+                    constraint.push(decode_character(&c));
+                }
+                _ => return self.err(SyntaxErrorCode::Scsav, "expecting a character value"),
+            }
+            if !self.eat(|t| matches!(t, Token::SymComma)) || self.eat_list_continue() {
+                break;
+            }
+        }
+        let assumed_value = if self.eat(|t| matches!(t, Token::SymSemiColon)) {
+            match self.peek().cloned() {
+                Some(Token::Character(c)) => {
+                    self.pos += 1;
+                    Some(decode_character(&c))
+                }
+                _ => {
+                    return self.err(SyntaxErrorCode::Scsav, "assumed value must be a character");
+                }
+            }
+        } else {
+            None
+        };
+        Ok(CObject::CString(CString {
+            parent: None,
+            soc_parent: None,
+            rm_type_name: "Character".to_owned(),
+            occurrences: None,
+            node_id,
+            alternative_ids: Vec::new(),
+            is_deprecated: None,
+            sibling_order: None,
+            default_value: None,
+            assumed_value,
+            is_enumerated_type_constraint: None,
+            constraint,
+        }))
+    }
+
     fn parse_c_string(&mut self, node_id: String) -> PResult<CObject> {
         let mut constraint = Vec::new();
         loop {
@@ -1802,7 +2012,7 @@ impl Parser<'_> {
                 }
                 _ => return self.err(SyntaxErrorCode::Scsav, "expecting a string value"),
             }
-            if !self.eat(|t| matches!(t, Token::SymComma)) {
+            if !self.eat(|t| matches!(t, Token::SymComma)) || self.eat_list_continue() {
                 break;
             }
         }
@@ -2146,6 +2356,32 @@ impl Parser<'_> {
         }))
     }
 
+    /// Consume a trailing list-continuation marker (`, ...`) — the comma is
+    /// already eaten by the caller, so this only tests for the `...`.
+    ///
+    /// Every ODIN list production ends with the alternative
+    /// `',' SYM_LIST_CONTINUE` (`odin_values.g4` `string_list_value` and its
+    /// siblings), and the cADL 1.4 grammar spells it out for strings as
+    /// `c_string_spec : … | string_list_value ',' SYM_LIST_CONTINUE`
+    /// (`ADL1.4/master05-cadl.adoc` §Syntax L1244-1249).
+    ///
+    /// NOTE: the marker adds no member and no openness flag. Its only normative
+    /// gloss in the vendored specs is a LIST INDICATOR — `ADL1.4/master04-dadl`
+    /// §Data of any primitive type L686 and `LANG/docs/odin/master07-leaf_data`
+    /// §Lists L208, both: "Lists which happen to have only one datum are
+    /// indicated by using a comma followed by a list continuation marker of
+    /// three dots". AOM 1.4's `C_STRING.list_open` ("the list … is not
+    /// considered exhaustive") is the only model property the marker could
+    /// otherwise set, but no vendored ADL 1.4 text binds the syntax to it, and
+    /// the AOM2 `C_STRING` this parser builds has no such property at all
+    /// (AM 2.4.0 BMM: `constraint` / `default_value` / `assumed_value` only).
+    /// Inferring openness from the marker would silently turn a stated
+    /// constraint into "any value"; the list-indicator reading is the one the
+    /// spec states, so the constraint is exactly the listed values.
+    fn eat_list_continue(&mut self) -> bool {
+        self.eat(|t| matches!(t, Token::SymListContinue))
+    }
+
     /// Parse a comma-separated list of `Interval<V>` items (a value list, an
     /// interval, or a list of intervals — the AOM2 constraint is a flat
     /// `Vec<Interval<V>>` regardless).
@@ -2153,7 +2389,7 @@ impl Parser<'_> {
         let mut out = Vec::new();
         loop {
             out.push(self.parse_value_item::<V>()?);
-            if !self.eat(|t| matches!(t, Token::SymComma)) {
+            if !self.eat(|t| matches!(t, Token::SymComma)) || self.eat_list_continue() {
                 break;
             }
         }
@@ -2172,42 +2408,79 @@ impl Parser<'_> {
     }
 
     /// A `|…|` interval (`odin_values.g4` interval forms): two-sided
-    /// (`|a..b|`, `|>a..<b|`), single-relop (`|>a|`,`|<=a|`), point (`|a|`),
-    /// or centre±delta (`|a+/-b|`).
+    /// (`|a..b|`, `|>a..<b|`, `|a>..<b|`), single-relop (`|>a|`,`|<=a|`), point
+    /// (`|a|`), or centre±delta (`|a+/-b|`). Either endpoint may be an unbounded
+    /// marker (see [`Parser::parse_endpoint`]).
+    ///
+    /// The exclusive LOWER bound of a two-sided interval has two spellings and
+    /// both are accepted: the prefix `>` of the normative grammar
+    /// (`odin_values.g4` `integer_interval_value : '|' SYM_GT? integer_value
+    /// '..' SYM_LT? integer_value '|'`) and the postfix `>` the ADL 1.4 chapters
+    /// write — `ADL1.4/master04-dadl.adoc` §Intervals of Ordered Primitive Types
+    /// L611-614 (`|N>..M|` "the two-sided range N > x <= M", `|N>..<M|`) and the
+    /// cADL chapter's own worked example `length matches {|0>..<1000|}`
+    /// (`ADL1.4/master05-cadl.adoc` §Interval of Integer L769). Accepting both is
+    /// a superset that rejects nothing either source admits.
     fn parse_bar_interval<V: CadlValue>(&mut self) -> PResult<Interval<V>> {
+        self.check_interval_timezone_symmetry()?;
         self.pos += 1; // opening '|'
         let lower_rel = self.eat_relop();
-        let first = V::parse_one(self)?;
+        let first = self.parse_endpoint::<V>()?;
+        // Only a `>` that immediately precedes the `..` is the postfix
+        // exclusive-lower marker; anywhere else it is not part of the form.
+        let lower_excl_postfix = matches!(self.peek(), Some(Token::SymGt))
+            && matches!(self.peek_at(1), Some(Token::SymIvlSep));
+        if lower_excl_postfix {
+            self.pos += 1;
+        }
         let ivl = if self.eat(|t| matches!(t, Token::SymIvlSep)) {
-            // Two-sided: [rel] first '..' ['<'] upper.
+            // Two-sided: [rel] first ['>'] '..' ['<'] upper.
             let upper_excl = self.eat(|t| matches!(t, Token::SymLt));
-            let upper = V::parse_one(self)?;
-            let lower_included = !matches!(lower_rel, Some(Relop::Gt));
+            let upper = self.parse_endpoint::<V>()?;
+            let lower_included =
+                first.is_some() && !lower_excl_postfix && !matches!(lower_rel, Some(Relop::Gt));
+            let lower_unbounded = first.is_none();
+            let upper_unbounded = upper.is_none();
             proper_interval(
-                Some(first),
-                Some(upper),
+                first,
+                upper,
                 lower_included,
-                !upper_excl,
-                false,
-                false,
+                !upper_excl && !upper_unbounded,
+                lower_unbounded,
+                upper_unbounded,
             )
         } else if self.eat(|t| matches!(t, Token::SymPlusOrMinus)) {
-            let delta = V::parse_one(self)?;
-            match V::plus_minus(&first, &delta) {
-                Some((lo, hi)) => proper_interval(Some(lo), Some(hi), true, true, false, false),
-                // NOTE: `±` on a non-numeric type is not reducible without RM
-                // type context; represented as a point at the centre for now
-                // (rare — not exercised by the primitive corpus).
-                None => point_interval(first),
+            let delta = self.parse_endpoint::<V>()?;
+            match (&first, &delta) {
+                (Some(centre), Some(delta)) => match V::plus_minus(centre, delta) {
+                    Some((lo, hi)) => proper_interval(Some(lo), Some(hi), true, true, false, false),
+                    // NOTE: `±` on a non-numeric type is not reducible without
+                    // RM type context; represented as a point at the centre for
+                    // now (rare — not exercised by the primitive corpus).
+                    None => point_interval(centre.clone()),
+                },
+                // An unbounded centre or half-width constrains nothing.
+                _ => proper_interval(None, None, false, false, true, true),
             }
         } else {
             // Point `|a|` or single-relop `|>a|`,`|<=a|`.
-            match lower_rel {
-                None => point_interval(first),
-                Some(Relop::Gt) => proper_interval(Some(first), None, false, false, false, true),
-                Some(Relop::Ge) => proper_interval(Some(first), None, true, false, false, true),
-                Some(Relop::Lt) => proper_interval(None, Some(first), false, false, true, false),
-                Some(Relop::Le) => proper_interval(None, Some(first), false, true, true, false),
+            match (lower_rel, first) {
+                (None, Some(v)) => point_interval(v),
+                (Some(Relop::Gt), Some(v)) => {
+                    proper_interval(Some(v), None, false, false, false, true)
+                }
+                (Some(Relop::Ge), Some(v)) => {
+                    proper_interval(Some(v), None, true, false, false, true)
+                }
+                (Some(Relop::Lt), Some(v)) => {
+                    proper_interval(None, Some(v), false, false, true, false)
+                }
+                (Some(Relop::Le), Some(v)) => {
+                    proper_interval(None, Some(v), false, true, true, false)
+                }
+                // A one-sided form whose single endpoint is itself an unbounded
+                // marker (`|>=-infinity|`, `|<*|`) constrains nothing at all.
+                (_, None) => proper_interval(None, None, false, false, true, true),
             }
         };
         self.expect(
@@ -2216,6 +2489,80 @@ impl Parser<'_> {
             "expecting '|' closing the interval",
         )?;
         Ok(ivl)
+    }
+
+    /// The timezone-symmetry rule for a two-sided date/time interval, checked
+    /// with the cursor still on the opening `|`.
+    ///
+    /// `ADL1.4/master05-cadl.adoc` §Intervals L932: "Within any interval
+    /// containing two literal date/time values (i.e. not one-sided intervals),
+    /// if a timezone is used on one, it must be used on both, to ensure
+    /// comparability. The timezones need not be identical." So the rule fires
+    /// exactly when the `|…|` window holds TWO literal time / date-time values
+    /// whose timezone presence differs; a one-sided form (one value) and a
+    /// date interval (dates carry no timezone) are outside its scope.
+    ///
+    /// NOTE: the openEHR `S*` catalogue
+    /// (`ADL2/master04.6-cadl_validity_rules.adoc` §Syntax Validity Rules) has
+    /// no dedicated code for this rule, and this crate never invents one — so
+    /// the refusal reuses the catalogue code this parser already uses for a bad
+    /// time / date-time value in a constraint position (`SCTAV` / `SCDTAV`) and
+    /// names the rule in the message.
+    fn check_interval_timezone_symmetry(&mut self) -> PResult<()> {
+        let mut endpoints: Vec<(bool, SyntaxErrorCode)> = Vec::new();
+        let mut i = self.pos + 1;
+        while let Some(spanned) = self.toks.get(i) {
+            match &spanned.token {
+                Token::SymIvlDelim => break,
+                Token::Iso8601Time(v) => {
+                    endpoints.push((iso_has_timezone(v), SyntaxErrorCode::Sctav));
+                }
+                Token::Iso8601DateTime(v) => {
+                    endpoints.push((iso_has_timezone(v), SyntaxErrorCode::Scdtav));
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+        if let [(lower_tz, code), (upper_tz, _)] = endpoints[..]
+            && lower_tz != upper_tz
+        {
+            let span = self.cur_span().start..self.span_at(i).end;
+            self.push(
+                code,
+                "a two-sided date/time interval must use a timezone on both endpoints or on \
+                 neither (the timezones need not be identical)",
+                span,
+            );
+            return Err(());
+        }
+        Ok(())
+    }
+
+    /// One interval endpoint: a value, or an unbounded marker yielding `None`.
+    ///
+    /// The markers are `infinity`, `-infinity` and `*`. `infinity` is a cADL
+    /// keyword in its own right (`ADL1.4/master05-cadl.adoc` §Keywords L50 and
+    /// §Symbols L1349 `[Ii][Nn][Ff][Ii][Nn][Ii][Tt][Yy] -> SYM_INFINITY`) and
+    /// the chapter's own §Interval of Integer example is
+    /// `rate matches {|0..infinity|}  -- allow 0 - infinity, i.e. same as >= 0`
+    /// (L771); L761 defers the interval syntax itself to dADL, whose §Intervals
+    /// of Ordered Primitive Types lists `infinity` / `-infinity` / `*` as
+    /// allowable endpoint values (`ADL1.4/master04-dadl.adoc` L628-643). The
+    /// sign carried by `-infinity` is not recorded separately: the side of the
+    /// interval the endpoint sits on already fixes the direction — the same
+    /// representation `openehr_lang::odin` uses for the identical markers.
+    fn parse_endpoint<V: CadlValue>(&mut self) -> PResult<Option<V>> {
+        if self.eat(|t| matches!(t, Token::SymStar)) {
+            return Ok(None);
+        }
+        let save = self.pos;
+        self.eat(|t| matches!(t, Token::SymMinus));
+        if self.eat(|t| matches!(t, Token::SymInfinity)) {
+            return Ok(None);
+        }
+        self.pos = save;
+        V::parse_one(self).map(Some)
     }
 
     fn eat_relop(&mut self) -> Option<Relop> {
@@ -2312,26 +2659,25 @@ impl Parser<'_> {
             );
             return Err(());
         }
-        Ok((format!("/{inner}/"), assumed))
+        Ok((format!("/{}/", escape_regex_delimiter(inner)), assumed))
     }
 
     // ── constraint-pattern validators (`master04.5` valid-pattern tables) ──
 
     fn validate_date_pattern(&mut self, p: &str, code: SyntaxErrorCode) -> PResult<()> {
         // Fields: year(4)-month(2)-day(2). Degradation: after a `??` field, only
-        // `??`/`XX`; after `XX`, only `XX`.
+        // `??`/`XX`; after `XX`, only `XX`. A date pattern carries NO timezone
+        // modifier — `master05` §Patterns L896 admits one on "any of the time or
+        // date/time (but not date) patterns".
         let fields: Vec<&str> = p.split('-').collect();
-        if fields.len() != 3
-            || !fields[0].eq_ignore_ascii_case("yyyy") && !fields[0].eq_ignore_ascii_case("yyy")
-        {
+        if fields.len() != 3 || !is_year_field(fields[0]) {
             return self.pattern_err(code, p);
         }
         self.validate_pattern_degradation(&fields[1..], code, p)
     }
 
     fn validate_time_pattern(&mut self, p: &str, code: SyntaxErrorCode) -> PResult<()> {
-        let time_core = p.split(['+', '\u{00B1}', 'Z']).next().unwrap_or(p);
-        let fields: Vec<&str> = time_core.split(':').collect();
+        let fields: Vec<&str> = pattern_time_core(p).split(':').collect();
         if fields.len() != 3 || !is_present_field(fields[0], "hh") {
             return self.pattern_err(code, p);
         }
@@ -2339,17 +2685,17 @@ impl Parser<'_> {
     }
 
     fn validate_date_time_pattern(&mut self, p: &str, code: SyntaxErrorCode) -> PResult<()> {
-        let Some((date, time)) = p.split_once('T') else {
+        // The date/time separator is `T` or a space: the chapter's own
+        // `V_ISO8601_DATE_TIME_CONSTRAINT_PATTERN` spells `…[dD?X][dD?X][ T]…`
+        // (`ADL1.4/master05-cadl.adoc` §Symbols L1422) and its assumed-value
+        // example uses the space form (`yyyy-mm-dd hh:mm:XX; 1800-01-01T00:00:00`,
+        // §Assumed Values L1018).
+        let Some((date, time)) = p.split_once(['T', ' ']) else {
             return self.pattern_err(code, p);
         };
         let date_fields: Vec<&str> = date.split('-').collect();
-        let time_core = time.split(['+', '\u{00B1}', 'Z']).next().unwrap_or(time);
-        let time_fields: Vec<&str> = time_core.split(':').collect();
-        if date_fields.len() != 3
-            || time_fields.len() != 3
-            || !(date_fields[0].eq_ignore_ascii_case("yyyy")
-                || date_fields[0].eq_ignore_ascii_case("yyy"))
-        {
+        let time_fields: Vec<&str> = pattern_time_core(time).split(':').collect();
+        if date_fields.len() != 3 || time_fields.len() != 3 || !is_year_field(date_fields[0]) {
             return self.pattern_err(code, p);
         }
         // Degradation flows date → time as one chain (`master04.5`): the hour
@@ -3773,9 +4119,84 @@ fn regex_inner(delimited: &str) -> &str {
     }
 }
 
-/// Whether a date/time pattern field is the "present" placeholder (e.g. `hh`).
+/// Backslash-escape every UNESCAPED `/` in a regex body.
+///
+/// `AOM2/master04.5` §`C_STRING` types `constraint` as "a list of literal
+/// strings and / or regular expression strings **delimited by the '/'
+/// character**", so the AOM carrier is always the `/…/` form — which makes the
+/// `^…^` delimiter a purely lexical alternative that has to be normalised on
+/// the way in. The chapter states the two forms' equivalence with its own
+/// worked pair (`ADL1.4/master05-cadl.adoc` §Regular Expression L696-702:
+/// "If the delimiter character is required in the pattern, it must be quoted
+/// with the backslash ('\\') character, or else alternative delimiters can be
+/// used … The following two patterns are equivalent: `{/km\\/h|mi\\/h/}` …
+/// `{^km/h|mi/h^}`"), so escaping on normalisation is the spec's own mapping
+/// and keeps parse → print → parse lossless. An already-escaped `\/` (a
+/// slash-delimited source) is left alone, so the transform is idempotent.
+fn escape_regex_delimiter(inner: &str) -> String {
+    let mut out = String::with_capacity(inner.len());
+    let mut escaped = false;
+    for ch in inner.chars() {
+        if escaped {
+            out.push(ch);
+            escaped = false;
+            continue;
+        }
+        match ch {
+            '\\' => {
+                escaped = true;
+                out.push(ch);
+            }
+            '/' => out.push_str("\\/"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+/// Whether a date/time pattern field is the "present" placeholder (e.g. `hh`)
+/// or a literal date/time number substituted for it.
+///
+/// `ADL1.4/master05-cadl.adoc` §Patterns L894: "In the above patterns, the
+/// 'yyyy' etc match strings can be replaced by literal date/time numbers. For
+/// example, `yyyy-??-XX` could be transformed into `1995-??-XX`". A literal
+/// field constrains the value to exactly that number, so it is "present" in
+/// the same sense the placeholder is — which is what the degradation rules
+/// (L860-861) range over.
 fn is_present_field(f: &str, present: &str) -> bool {
-    f.eq_ignore_ascii_case(present)
+    f.eq_ignore_ascii_case(present) || is_literal_field(f, 2)
+}
+
+/// Whether an ISO8601 time / date-time literal carries a timezone modifier
+/// (`Z` or a `±hh[:mm]` offset). Only the part after the `T` is examined, so
+/// the `-` separators of the date part are never mistaken for a sign
+/// (`base_lexer.g4` `ISO8601_DATE_TIME` / `ISO8601_TIME`).
+fn iso_has_timezone(v: &str) -> bool {
+    let tail = v.split_once('T').map_or(v, |(_, t)| t);
+    tail.ends_with('Z') || tail.contains('+') || tail.contains('-')
+}
+
+/// The year field: the `yyyy`/`yyy` placeholder or a literal 4-digit year
+/// (`master05` §Patterns L894).
+fn is_year_field(f: &str) -> bool {
+    f.eq_ignore_ascii_case("yyyy") || f.eq_ignore_ascii_case("yyy") || is_literal_field(f, 4)
+}
+
+/// Whether `f` is exactly `width` ASCII digits — a literal-substituted field.
+fn is_literal_field(f: &str, width: usize) -> bool {
+    f.len() == width && f.bytes().all(|b| b.is_ascii_digit())
+}
+
+/// The time part of a pattern with its timezone modifier stripped.
+///
+/// The modifier is `Z` or a sign-led `hh`/`hh:mm`/`hhmm` group; the sign is
+/// `+`, `-` or the literal `±` — `master05` §Patterns L852 ("the addition of a
+/// patterns such as `+hh:mm`, `+hhmm`, and `-hh`") and the
+/// `<<timezone_constraints>>` table L900-906, whose `±` rows are glossed
+/// "commencing with '+' or '-'". A time never contains `+`/`-`/`Z` otherwise,
+/// so the split is unambiguous.
+fn pattern_time_core(t: &str) -> &str {
+    t.split(['+', '-', '\u{00B1}', 'Z']).next().unwrap_or(t)
 }
 
 /// The strength-keyword set (`master04.5` §Constraint strengths).
@@ -3800,6 +4221,16 @@ fn decode_string(raw: &str) -> String {
     let inner = raw
         .strip_prefix('"')
         .and_then(|s| s.strip_suffix('"'))
+        .unwrap_or(raw);
+    decode_string_inner(inner)
+}
+
+/// Decode a single-quoted `CHARACTER` literal (delimiters included) into the
+/// one-character string that carries it (`base_lexer.g4` `CHARACTER`).
+fn decode_character(raw: &str) -> String {
+    let inner = raw
+        .strip_prefix('\'')
+        .and_then(|s| s.strip_suffix('\''))
         .unwrap_or(raw);
     decode_string_inner(inner)
 }
@@ -4777,6 +5208,242 @@ mod tests {
         match &d.attributes[1].children[0] {
             CObject::CString(cs) => assert_eq!(cs.assumed_value.as_deref(), Some("y")),
             _ => panic!("expected CString with assumed"),
+        }
+    }
+
+    /// The `(lower, upper, lower_included, upper_included)` of the single
+    /// interval an integer constraint carries; an unbounded endpoint is `None`.
+    fn int_bounds(o: &CObject) -> (Option<f64>, Option<f64>, bool, bool) {
+        match o {
+            CObject::CInteger(ci) => interval_bounds_f64(&ci.constraint[0]),
+            other => panic!("expected CInteger, got {other:?}"),
+        }
+    }
+
+    /// `ADL1.4/master05-cadl.adoc` §Interval of Integer L771 —
+    /// `rate matches {|0..infinity|}` — plus the `-infinity` and `*` endpoint
+    /// spellings of `master04-dadl` §Intervals of Ordered Primitive Types
+    /// L625-630.
+    #[test]
+    fn infinity_endpoints_are_unbounded() {
+        let cco = parse(
+            "WHOLE[id1] matches {\n\
+             a matches {|0..infinity|}\n\
+             b matches {|-infinity..5|}\n\
+             c matches {|0..*|}\n\
+             d matches {|0..10|}\n\
+             }",
+        );
+        let d = data(&cco);
+        assert_eq!(
+            int_bounds(&d.attributes[0].children[0]),
+            (Some(0.0), None, true, false)
+        );
+        assert_eq!(
+            int_bounds(&d.attributes[1].children[0]),
+            (None, Some(5.0), false, true)
+        );
+        assert_eq!(
+            int_bounds(&d.attributes[2].children[0]),
+            (Some(0.0), None, true, false)
+        );
+        assert_eq!(
+            int_bounds(&d.attributes[3].children[0]),
+            (Some(0.0), Some(10.0), true, true)
+        );
+    }
+
+    /// Both spellings of the exclusive lower bound denote the same interval:
+    /// the prefix `>` of `odin_values.g4` and the postfix `>` of
+    /// `ADL1.4/master04-dadl.adoc` §Intervals L611-614 (used by `master05` L769
+    /// as `length matches {|0>..<1000|}`).
+    #[test]
+    fn both_exclusive_lower_spellings_agree() {
+        let cco = parse(
+            "WHOLE[id1] matches {\n\
+             a matches {|>0..<1000|}\n\
+             b matches {|0>..<1000|}\n\
+             c matches {|0>..1000|}\n\
+             }",
+        );
+        let d = data(&cco);
+        assert_eq!(
+            int_bounds(&d.attributes[0].children[0]),
+            (Some(0.0), Some(1000.0), false, false)
+        );
+        assert_eq!(
+            int_bounds(&d.attributes[1].children[0]),
+            (Some(0.0), Some(1000.0), false, false)
+        );
+        assert_eq!(
+            int_bounds(&d.attributes[2].children[0]),
+            (Some(0.0), Some(1000.0), false, true)
+        );
+    }
+
+    /// `ADL1.4/master05-cadl.adoc` §Regular Expression L696-702: the `^…^` and
+    /// the backslash-escaped `/…/` spellings "are equivalent", so the caret form
+    /// normalises onto the AOM's `/`-delimited carrier WITH the inner delimiters
+    /// escaped — and the result re-parses to itself (parse → print → parse is
+    /// lossless; the printer emits `C_STRING.constraint` verbatim).
+    #[test]
+    fn caret_regex_normalises_losslessly() {
+        let cco = parse("WHOLE[id1] matches {\n u matches {^km/h|mi/h^}\n}");
+        let printed = match &data(&cco).attributes[0].children[0] {
+            CObject::CString(cs) => cs.constraint[0].clone(),
+            other => panic!("expected CString regex, got {other:?}"),
+        };
+        assert_eq!(printed, r"/km\/h|mi\/h/");
+        // The chapter's own equivalent slash spelling yields the same carrier…
+        let slash = parse(
+            r"WHOLE[id1] matches {\n u matches {/km\/h|mi\/h/}\n}"
+                .replace("\\n", "\n")
+                .as_str(),
+        );
+        match &data(&slash).attributes[0].children[0] {
+            CObject::CString(cs) => assert_eq!(cs.constraint[0], printed),
+            other => panic!("expected CString regex, got {other:?}"),
+        }
+        // …and re-parsing the printed form reproduces it unchanged.
+        let again = parse(&format!(
+            "WHOLE[id1] matches {{\n u matches {{{printed}}}\n}}"
+        ));
+        match &data(&again).attributes[0].children[0] {
+            CObject::CString(cs) => assert_eq!(cs.constraint[0], printed),
+            other => panic!("expected CString regex, got {other:?}"),
+        }
+    }
+
+    /// `ADL1.4/master05-cadl.adoc` §Constraints on Character L813-825 —
+    /// `color_name matches {'r', 'g', 'b'}`. No AOM generation defines a
+    /// `C_CHARACTER`, so the carrier is `C_STRING` with the constrained RM type
+    /// name kept (see [`Parser::parse_c_character`]).
+    #[test]
+    fn character_lists_land_on_c_string() {
+        let cco = parse(
+            "WHOLE[id1] matches {\n\
+             a matches {'r'}\n\
+             b matches {'r', 'g', 'b'}\n\
+             c matches {'r', 'g'; 'r'}\n\
+             }",
+        );
+        let d = data(&cco);
+        match &d.attributes[0].children[0] {
+            CObject::CString(cs) => {
+                assert_eq!(cs.rm_type_name, "Character");
+                assert_eq!(cs.constraint, vec!["r".to_owned()]);
+            }
+            other => panic!("expected CString, got {other:?}"),
+        }
+        match &d.attributes[1].children[0] {
+            CObject::CString(cs) => assert_eq!(cs.constraint.len(), 3),
+            other => panic!("expected CString, got {other:?}"),
+        }
+        match &d.attributes[2].children[0] {
+            CObject::CString(cs) => assert_eq!(cs.assumed_value.as_deref(), Some("r")),
+            other => panic!("expected CString, got {other:?}"),
+        }
+    }
+
+    /// The `, ...` list-continuation marker (`ADL1.4/master05-cadl.adoc` §Syntax
+    /// L1244-1249 for strings, `master04-dadl` §Syntax L985-1160 for every other
+    /// primitive list) is a list INDICATOR, not a member and not an openness
+    /// flag — see [`Parser::eat_list_continue`].
+    #[test]
+    fn list_continuation_adds_no_member() {
+        let cco = parse(
+            "WHOLE[id1] matches {\n\
+             a matches {\"en\", ...}\n\
+             b matches {1, 2, ...}\n\
+             c matches {True, ...}\n\
+             }",
+        );
+        let d = data(&cco);
+        match &d.attributes[0].children[0] {
+            CObject::CString(cs) => assert_eq!(cs.constraint, vec!["en".to_owned()]),
+            other => panic!("expected CString, got {other:?}"),
+        }
+        match &d.attributes[1].children[0] {
+            CObject::CInteger(ci) => assert_eq!(ci.constraint.len(), 2),
+            other => panic!("expected CInteger, got {other:?}"),
+        }
+        match &d.attributes[2].children[0] {
+            CObject::CBoolean(cb) => assert_eq!(cb.constraint, vec![true]),
+            other => panic!("expected CBoolean, got {other:?}"),
+        }
+    }
+
+    /// `ADL1.4/master05-cadl.adoc` §Intervals L932: a two-sided date/time
+    /// interval must carry a timezone on both endpoints or on neither; a
+    /// one-sided interval is outside the rule by its own wording.
+    #[test]
+    fn interval_timezone_symmetry_is_enforced() {
+        let asymmetric = parse_definition_body(
+            "WHOLE[id1] matches {\n d matches {|2004-05-20T00:00:00Z..2005-05-19T23:59:59|}\n}",
+        )
+        .expect_err("an asymmetric-timezone interval must be refused");
+        assert!(
+            asymmetric.iter().any(|e| e.code == SyntaxErrorCode::Scdtav),
+            "expected SCDTAV, got {:?}",
+            asymmetric.iter().map(|e| e.code).collect::<Vec<_>>()
+        );
+        let time_asymmetric = parse_definition_body(
+            "WHOLE[id1] matches {\n t matches {|09:30:00+0200..10:30:00|}\n}",
+        )
+        .expect_err("an asymmetric-timezone time interval must be refused");
+        assert!(
+            time_asymmetric
+                .iter()
+                .any(|e| e.code == SyntaxErrorCode::Sctav),
+            "expected SCTAV, got {:?}",
+            time_asymmetric.iter().map(|e| e.code).collect::<Vec<_>>()
+        );
+        // Both endpoints with a timezone, both without, and the one-sided form
+        // all parse.
+        parse(
+            "WHOLE[id1] matches {\n\
+             a matches {|2004-05-20T00:00:00Z..2005-05-19T23:59:59Z|}\n\
+             b matches {|2004-05-20T00:00:00..2005-05-19T23:59:59|}\n\
+             c matches {|>09:30:00+0200|}\n\
+             }",
+        );
+    }
+
+    /// The negated-matches family and the `=~`/`!~` regex-match operators are
+    /// named by `ADL1.4/master05-cadl.adoc` (§Keywords L47/L95-98, §Regular
+    /// Expression L691-693) but defined by no grammar production, so each is a
+    /// typed refusal rather than a silent affirmative reading.
+    #[test]
+    fn operators_without_a_production_are_refused() {
+        for (src, code) in [
+            (
+                "WHOLE[id1] matches {\n v matches {\n TEXT ~matches {\"a\"}\n }\n}",
+                SyntaxErrorCode::Sccog,
+            ),
+            (
+                "WHOLE[id1] matches {\n v ~is_in {\n TEXT matches {*}\n }\n}",
+                SyntaxErrorCode::Scoat,
+            ),
+            (
+                "WHOLE[id1] matches {\n v \u{2209} {\n TEXT matches {*}\n }\n}",
+                SyntaxErrorCode::Scoat,
+            ),
+            (
+                "WHOLE[id1] matches {\n v matches {=~ /[a-z]+/}\n}",
+                SyntaxErrorCode::Sccog,
+            ),
+            (
+                "WHOLE[id1] matches {\n v matches {!~ /[a-z]+/}\n}",
+                SyntaxErrorCode::Sccog,
+            ),
+        ] {
+            let errs = parse_definition_body(src)
+                .expect_err("an operator with no cADL production must be refused");
+            assert!(
+                errs.iter().any(|e| e.code == code),
+                "expected {code} for {src:?}, got {:?}",
+                errs.iter().map(|e| e.code).collect::<Vec<_>>()
+            );
         }
     }
 

--- a/crates/openehr-adl/src/lexer.rs
+++ b/crates/openehr-adl/src/lexer.rs
@@ -21,10 +21,19 @@
 //!   strings safe: a `STRING` token maximally munches across newlines, so a
 //!   section keyword appearing inside a quoted value can never be mistaken for
 //!   a header.
-//! - `// NOTE:` Booleans are accepted in the canonical `True`/`False` and the
-//!   all-lower `true`/`false` forms; the grammar's fully case-insensitive
-//!   `SYM_TRUE`/`SYM_FALSE` (`base_lexer.g4`) is a superset — an all-caps
-//!   `TRUE` lexes as an identifier here. ODIN corpora use the canonical forms.
+//! - `// NOTE:` Keywords are lexed CASE-INSENSITIVELY, as both normative
+//!   lexical specifications require: `adl_keywords.g4` spells every keyword
+//!   `[Mm][Aa][Tt][Cc][Hh][Ee][Ss]`-style, and the ADL 1.4 chapter's own
+//!   lexical specification does the same
+//!   (`ADL1.4/master05-cadl.adoc` §Symbols L1326-1354, incl.
+//!   `[Ii][Nn][Ff][Ii][Nn][Ii][Tt][Yy] -> SYM_INFINITY`). Identifiers cannot
+//!   collide: an RM type id or attribute id that IS a keyword in some casing
+//!   (`MATCHES`, `ORDERED`) would be unlexable as an identifier in ANY casing
+//!   under those lexers too, so the keyword reading is the spec's own.
+//!   Booleans follow the same rule (`base_lexer.g4` `SYM_TRUE`,
+//!   `master05` L1337), so `TRUE`/`fAlSe` lex as booleans. The single
+//!   exception is `there_exists`, which both lexers spell case-SENSITIVELY —
+//!   see the note on [`Token::SymThereExists`].
 //! - `// NOTE:` A leading UTF-8 BOM is skipped though `master03` forbids it;
 //!   18 vendored ADL2 corpus sources carry one, so tolerating it is the
 //!   pragmatic superset (a rejection would be a lexer-level FAIL the corpus
@@ -57,101 +66,112 @@ pub enum Token {
     //    fold to one variant. Exact-literal `#[token]`s outrank the
     //    ALPHA_*_ID regexes by logos priority, so keywords beat identifiers. ──
     /// `matches` / `is_in` / `∈` (`SYM_MATCHES`).
-    #[token("matches")]
-    #[token("is_in")]
+    #[token("matches", ignore(case))]
+    #[token("is_in", ignore(case))]
     #[token("\u{2208}")]
     SymMatches,
     /// `∉` — "not in" (`~matches` is lexed as `SymNot` `SymMatches`).
     #[token("\u{2209}")]
     SymNotMatches,
     /// `and` / `∧` (`SYM_AND`).
-    #[token("and")]
+    #[token("and", ignore(case))]
     #[token("\u{2227}")]
     SymAnd,
     /// `or` / `∨` (`SYM_OR`).
-    #[token("or")]
+    #[token("or", ignore(case))]
     #[token("\u{2228}")]
     SymOr,
     /// `xor` (`SYM_XOR`).
-    #[token("xor")]
+    #[token("xor", ignore(case))]
     SymXor,
     /// `not` / `~` / `∼` / `¬` / `!` (`SYM_NOT`).
-    #[token("not")]
+    #[token("not", ignore(case))]
     #[token("~")]
     #[token("\u{223C}")]
     #[token("\u{00AC}")]
     #[token("!")]
     SymNot,
     /// `implies` / `®` / `->` (`SYM_IMPLIES`).
-    #[token("implies")]
+    #[token("implies", ignore(case))]
     #[token("\u{00AE}")]
     #[token("->")]
     SymImplies,
     /// `for_all` / `∀` (`SYM_FOR_ALL`).
-    #[token("for_all")]
+    #[token("for_all", ignore(case))]
     #[token("\u{2200}")]
     SymForAll,
     /// `exists` (`SYM_EXISTS`).
-    #[token("exists")]
+    #[token("exists", ignore(case))]
     SymExists,
     /// `there_exists` / `∃` (`SYM_THERE_EXISTS`).
+    ///
+    /// The ONE keyword that is NOT case-folded: `adl_keywords.g4` spells it as
+    /// the plain literal `SYM_THERE_EXISTS: 'there_exists' | '∃' ;` rather than
+    /// in the `[Tt][Hh]…` form every other keyword on that list uses, and the
+    /// ADL 1.4 chapter's own §Symbols lexer has no `there_exists` rule at all
+    /// (`ADL1.4/master05-cadl.adoc` L1329-1340 stops at `SYM_EXISTS`). Folding
+    /// it anyway would swallow `There_Exists`, a well-formed `ALPHA_UC_ID`
+    /// under both lexers.
     #[token("there_exists")]
     #[token("\u{2203}")]
     SymThereExists,
     /// `occurrences` (`SYM_OCCURRENCES`).
-    #[token("occurrences")]
+    #[token("occurrences", ignore(case))]
     SymOccurrences,
     /// `existence` (`SYM_EXISTENCE`).
-    #[token("existence")]
+    #[token("existence", ignore(case))]
     SymExistence,
     /// `cardinality` (`SYM_CARDINALITY`).
-    #[token("cardinality")]
+    #[token("cardinality", ignore(case))]
     SymCardinality,
     /// `ordered` (`SYM_ORDERED`).
-    #[token("ordered")]
+    #[token("ordered", ignore(case))]
     SymOrdered,
     /// `unordered` (`SYM_UNORDERED`).
-    #[token("unordered")]
+    #[token("unordered", ignore(case))]
     SymUnordered,
     /// `unique` (`SYM_UNIQUE`).
-    #[token("unique")]
+    #[token("unique", ignore(case))]
     SymUnique,
+    /// `infinity` (`SYM_INFINITY`) — the unbounded interval endpoint of
+    /// `ADL1.4/master05-cadl.adoc` §Keywords L50 + §Symbols L1349, whose own
+    /// worked example is `rate matches {|0..infinity|}` (L771).
+    #[token("infinity", ignore(case))]
+    SymInfinity,
     /// `use_node` (`SYM_USE_NODE`).
-    #[token("use_node")]
+    #[token("use_node", ignore(case))]
     SymUseNode,
     /// `use_archetype` (`SYM_USE_ARCHETYPE`).
-    #[token("use_archetype")]
+    #[token("use_archetype", ignore(case))]
     SymUseArchetype,
     /// `allow_archetype` (`SYM_ALLOW_ARCHETYPE`).
-    #[token("allow_archetype")]
+    #[token("allow_archetype", ignore(case))]
     SymAllowArchetype,
     /// `include` (`SYM_INCLUDE`).
-    #[token("include")]
+    #[token("include", ignore(case))]
     SymInclude,
     /// `exclude` (`SYM_EXCLUDE`).
-    #[token("exclude")]
+    #[token("exclude", ignore(case))]
     SymExclude,
     /// `after` (`SYM_AFTER`).
-    #[token("after")]
+    #[token("after", ignore(case))]
     SymAfter,
     /// `before` (`SYM_BEFORE`).
-    #[token("before")]
+    #[token("before", ignore(case))]
     SymBefore,
     /// `closed` (`SYM_CLOSED`).
-    #[token("closed")]
+    #[token("closed", ignore(case))]
     SymClosed,
     /// `then` (`SYM_THEN`).
-    #[token("then")]
+    #[token("then", ignore(case))]
     SymThen,
 
     // ── boolean word symbols (base_lexer.g4 SYM_TRUE / SYM_FALSE) ──
-    /// `True` / `true`.
-    #[token("True")]
-    #[token("true")]
+    /// `True` / `true` (case-insensitive per `base_lexer.g4` `SYM_TRUE`).
+    #[token("true", ignore(case))]
     SymTrue,
-    /// `False` / `false`.
-    #[token("False")]
-    #[token("false")]
+    /// `False` / `false` (case-insensitive per `base_lexer.g4` `SYM_FALSE`).
+    #[token("false", ignore(case))]
     SymFalse,
 
     // ── codes (base_lexer.g4). Higher priority than ALPHA_*_ID so `id1`/`at3`
@@ -192,6 +212,14 @@ pub enum Token {
     Guid(String),
 
     // ── ISO8601 date/time/duration VALUES (base_lexer.g4) ──
+    //
+    // The three date/time VALUE tokens carry an explicit high priority so they
+    // win every tie against the constraint-PATTERN tokens below, whose fields
+    // admit literal date/time numbers (`ADL1.4/master05-cadl.adoc` §Patterns
+    // L894). Where a text is BOTH a legal value and a legal all-literal
+    // pattern (`1995-??-??`), the value reading is the established one and the
+    // pattern adds nothing — the pattern tokens keep the shapes only they
+    // match (`1995-??-XX`, `1995-mm-dd`).
     /// `ISO8601_DATE_TIME` (with optional partial `??` fields / timezone).
     ///
     /// The `??`-partial family covers the whole set of
@@ -201,23 +229,27 @@ pub enum Token {
     /// ODIN sections `openehr_lang::odin` accepts.
     #[regex(
         r"[0-9]{4}-[0-9]{2}-[0-9]{2}T([0-9]{2}(:[0-9]{2}(:([0-9]{2}([.,][0-9]+)?|\?\?))?|:\?\?:\?\?)?|\?\?:\?\?:\?\?)(Z|[+\-][0-9]{4})?",
-        |lex| lex.slice().to_owned()
+        |lex| lex.slice().to_owned(),
+        priority = 30
     )]
     #[regex(
         r"[0-9]{4}-([0-9]{2}-\?\?|\?\?-\?\?)T\?\?:\?\?:\?\?(Z|[+\-][0-9]{4})?",
-        |lex| lex.slice().to_owned()
+        |lex| lex.slice().to_owned(),
+        priority = 30
     )]
     Iso8601DateTime(String),
     /// `ISO8601_DATE` (with optional partial `??` fields).
     #[regex(
         r"[0-9]{4}-([0-9]{2}(-([0-9]{2}|\?\?))?|\?\?-\?\?)",
-        |lex| lex.slice().to_owned()
+        |lex| lex.slice().to_owned(),
+        priority = 30
     )]
     Iso8601Date(String),
     /// `ISO8601_TIME` (with optional partial `??` fields / timezone).
     #[regex(
         r"[0-9]{2}:([0-9]{2}(:([0-9]{2}([.,][0-9]+)?|\?\?))?|\?\?:\?\?)(Z|[+\-][0-9]{4})?",
-        |lex| lex.slice().to_owned()
+        |lex| lex.slice().to_owned(),
+        priority = 30
     )]
     Iso8601Time(String),
     /// `ISO8601_DURATION`, requiring at least one component (never bare `P`).
@@ -227,23 +259,46 @@ pub enum Token {
     )]
     Iso8601Duration(String),
 
-    // ── constraint PATTERNS (base_lexer.g4) ──
+    // ── constraint PATTERNS (base_lexer.g4 + the ADL 1.4 chapter's own
+    //    lexical spec, `ADL1.4/master05-cadl.adoc` §Symbols L1415-1426) ──
+    //
+    // Three spec-grounded widenings over `base_lexer.g4`'s transcription, all
+    // supersets that reject nothing the narrower form accepted:
+    // 1. Every field also admits a LITERAL date/time number — master05 L894:
+    //    "the 'yyyy' etc match strings can be replaced by literal date/time
+    //    numbers. For example, `yyyy-??-XX` could be transformed into
+    //    `1995-??-XX`".
+    // 2. The timezone modifier admits the ASCII `+`/`-` forms, not only the
+    //    literal `±` character — master05 §Patterns L852 ("the addition of a
+    //    patterns such as `+hh:mm`, `+hhmm`, and `-hh`") and the
+    //    <<timezone_constraints>> table L900-906, whose `±` column head is
+    //    glossed "commencing with '+' or '-'".
+    // 3. The date/time separator is `[T ]`, per the chapter's own
+    //    `V_ISO8601_DATE_TIME_CONSTRAINT_PATTERN` (master05 L1422:
+    //    `…[dD?X][dD?X][ T][hH?X][hH?X]:…`); `base_lexer.g4` L37 spells only
+    //    `'T'`, so the space form is the 1.4 chapter's superset.
+    //
+    // The explicit low priority keeps the date/time VALUE tokens above winning
+    // every equal-length tie (see the note on those tokens).
     /// `DATE_TIME_CONSTRAINT_PATTERN` — e.g. `yyyy-mm-ddThh:mm:ss`.
     #[regex(
-        r"(yyyy|YYYY|yyy|YYY)-(mm|MM|\?\?|XX|xx)-(dd|DD|\?\?|XX|xx)T(hh|HH|\?\?|XX|xx):(mm|MM|\?\?|XX|xx):(ss|SS|\?\?|XX|xx)(\u{00B1}(hh|HH)(:?(mm|MM))?|Z)?",
-        |lex| lex.slice().to_owned()
+        r"(yyyy|YYYY|yyy|YYY|[0-9]{4})-(mm|MM|\?\?|XX|xx|[0-9]{2})-(dd|DD|\?\?|XX|xx|[0-9]{2})[T ](hh|HH|\?\?|XX|xx|[0-9]{2}):(mm|MM|\?\?|XX|xx|[0-9]{2}):(ss|SS|\?\?|XX|xx|[0-9]{2})([+\-\u{00B1}](hh|HH)(:?(mm|MM))?|Z)?",
+        |lex| lex.slice().to_owned(),
+        priority = 3
     )]
     DateTimeConstraintPattern(String),
-    /// `DATE_CONSTRAINT_PATTERN` — e.g. `yyyy-mm-??`.
+    /// `DATE_CONSTRAINT_PATTERN` — e.g. `yyyy-mm-??`, `1995-??-XX`.
     #[regex(
-        r"(yyyy|YYYY|yyy|YYY)-(mm|MM|\?\?|XX|xx)-(dd|DD|\?\?|XX|xx)",
-        |lex| lex.slice().to_owned()
+        r"(yyyy|YYYY|yyy|YYY|[0-9]{4})-(mm|MM|\?\?|XX|xx|[0-9]{2})-(dd|DD|\?\?|XX|xx|[0-9]{2})",
+        |lex| lex.slice().to_owned(),
+        priority = 3
     )]
     DateConstraintPattern(String),
-    /// `TIME_CONSTRAINT_PATTERN` — e.g. `hh:??:XX`.
+    /// `TIME_CONSTRAINT_PATTERN` — e.g. `hh:??:XX`, `hh:mm:ss+hh:mm`.
     #[regex(
-        r"(hh|HH|\?\?|XX|xx):(mm|MM|\?\?|XX|xx):(ss|SS|\?\?|XX|xx)(\u{00B1}(hh|HH)(:?(mm|MM))?|Z)?",
-        |lex| lex.slice().to_owned()
+        r"(hh|HH|\?\?|XX|xx|[0-9]{2}):(mm|MM|\?\?|XX|xx|[0-9]{2}):(ss|SS|\?\?|XX|xx|[0-9]{2})([+\-\u{00B1}](hh|HH)(:?(mm|MM))?|Z)?",
+        |lex| lex.slice().to_owned(),
+        priority = 3
     )]
     TimeConstraintPattern(String),
     /// `DURATION_CONSTRAINT_PATTERN` — letters only, e.g. `PYMD`, `PWD`, `PT`.
@@ -698,5 +753,126 @@ mod tests {
         assert_eq!(toks("True"), vec![Token::SymTrue]);
         assert_eq!(toks("False"), vec![Token::SymFalse]);
         assert_eq!(toks("true"), vec![Token::SymTrue]);
+    }
+
+    /// `ADL1.4/master05-cadl.adoc` §Symbols L1326-1354 + `adl_keywords.g4`
+    /// spell every keyword in the `[Mm][Aa]…` case-insensitive form.
+    #[test]
+    fn keywords_are_case_insensitive() {
+        assert_eq!(toks("MATCHES"), vec![Token::SymMatches]);
+        assert_eq!(toks("Is_In"), vec![Token::SymMatches]);
+        assert_eq!(toks("OCCURRENCES"), vec![Token::SymOccurrences]);
+        assert_eq!(toks("Existence"), vec![Token::SymExistence]);
+        assert_eq!(toks("CaRdInAlItY"), vec![Token::SymCardinality]);
+        assert_eq!(toks("ORDERED"), vec![Token::SymOrdered]);
+        assert_eq!(toks("UNORDERED"), vec![Token::SymUnordered]);
+        assert_eq!(toks("Unique"), vec![Token::SymUnique]);
+        assert_eq!(toks("INFINITY"), vec![Token::SymInfinity]);
+        assert_eq!(toks("Use_Node"), vec![Token::SymUseNode]);
+        assert_eq!(toks("ALLOW_ARCHETYPE"), vec![Token::SymAllowArchetype]);
+        assert_eq!(toks("Include"), vec![Token::SymInclude]);
+        assert_eq!(toks("EXCLUDE"), vec![Token::SymExclude]);
+        assert_eq!(toks("Before"), vec![Token::SymBefore]);
+        assert_eq!(toks("AFTER"), vec![Token::SymAfter]);
+        assert_eq!(toks("TRUE"), vec![Token::SymTrue]);
+        assert_eq!(toks("fAlSe"), vec![Token::SymFalse]);
+        assert_eq!(toks("NOT"), vec![Token::SymNot]);
+        assert_eq!(toks("Implies"), vec![Token::SymImplies]);
+        // The one keyword the grammars spell case-sensitively.
+        assert_eq!(toks("there_exists"), vec![Token::SymThereExists]);
+        assert_eq!(
+            toks("There_Exists"),
+            vec![Token::AlphaUcId("There_Exists".into())]
+        );
+    }
+
+    /// `infinity` is its own keyword token (`master05` §Keywords L50, §Symbols
+    /// L1349), used as an interval endpoint (`|0..infinity|`, L771).
+    #[test]
+    fn infinity_is_a_keyword_not_an_identifier() {
+        assert_eq!(
+            toks("|0..infinity|"),
+            vec![
+                Token::SymIvlDelim,
+                Token::Integer("0".into()),
+                Token::SymIvlSep,
+                Token::SymInfinity,
+                Token::SymIvlDelim,
+            ]
+        );
+        assert_eq!(
+            toks("|-infinity..5.0|"),
+            vec![
+                Token::SymIvlDelim,
+                Token::SymMinus,
+                Token::SymInfinity,
+                Token::SymIvlSep,
+                Token::Real("5.0".into()),
+                Token::SymIvlDelim,
+            ]
+        );
+    }
+
+    /// Literal-substituted pattern fields (`master05` §Patterns L894), the
+    /// ASCII timezone modifiers (L852 + the tz table L900-906) and the
+    /// space-separated date/time pattern (§Symbols L1422 `[ T]`).
+    #[test]
+    fn pattern_variants() {
+        assert_eq!(
+            toks("1995-??-XX"),
+            vec![Token::DateConstraintPattern("1995-??-XX".into())]
+        );
+        assert_eq!(
+            toks("1995-mm-dd"),
+            vec![Token::DateConstraintPattern("1995-mm-dd".into())]
+        );
+        assert_eq!(
+            toks("hh:mm:ss+hh:mm"),
+            vec![Token::TimeConstraintPattern("hh:mm:ss+hh:mm".into())]
+        );
+        assert_eq!(
+            toks("hh:mm:ss-hh"),
+            vec![Token::TimeConstraintPattern("hh:mm:ss-hh".into())]
+        );
+        assert_eq!(
+            toks("hh:mm:ss+hhmm"),
+            vec![Token::TimeConstraintPattern("hh:mm:ss+hhmm".into())]
+        );
+        assert_eq!(
+            toks("hh:mm:ssZ"),
+            vec![Token::TimeConstraintPattern("hh:mm:ssZ".into())]
+        );
+        assert_eq!(
+            toks("yyyy-mm-dd hh:mm:XX"),
+            vec![Token::DateTimeConstraintPattern(
+                "yyyy-mm-dd hh:mm:XX".into()
+            )]
+        );
+        assert_eq!(
+            toks("yyyy-mm-ddThh:mm:ss\u{00B1}hh:mm"),
+            vec![Token::DateTimeConstraintPattern(
+                "yyyy-mm-ddThh:mm:ss\u{00B1}hh:mm".into()
+            )]
+        );
+        // A text that is both a legal VALUE and a legal all-literal pattern
+        // stays the value reading (see the note on the ISO8601 value tokens).
+        assert_eq!(
+            toks("2004-06-01"),
+            vec![Token::Iso8601Date("2004-06-01".into())]
+        );
+    }
+
+    /// The `^…^` regex delimiter is a `CONTAINED_REGEXP` in its own right
+    /// (`master05` §Regular Expression L696-702; `V_REGEXP` L1476).
+    #[test]
+    fn caret_delimited_regexp_lexes() {
+        assert_eq!(
+            toks("{^km/h|mi/h^}"),
+            vec![Token::ContainedRegexp("{^km/h|mi/h^}".into())]
+        );
+        assert_eq!(
+            toks(r"{/km\/h|mi\/h/}"),
+            vec![Token::ContainedRegexp(r"{/km\/h|mi\/h/}".into())]
+        );
     }
 }

--- a/crates/openehr-adl/src/validate/mod.rs
+++ b/crates/openehr-adl/src/validate/mod.rs
@@ -732,6 +732,42 @@ pub fn validate_source_phase1_adl14(src: &str) -> Result<Vec<ValidationIssue>, V
     Ok(issues)
 }
 
+/// Parse an **ADL 1.4** source and validate it against the FULL ADL 1.4
+/// catalogue: [`validate_source_phase1_adl14`] plus the one 1.4 validity rule
+/// that needs a reference model, VUNT ([`rm::validate_adl14_rm`]).
+///
+/// VUNT is a rule of the ADL 1.4 formalism itself — `ADL1.4/master05-cadl.adoc`
+/// §Internal References L512-513 — so a 1.4 artefact that violates it is
+/// invalid 1.4, and a 1.4 upload path that stops at phase 1 can never reach it.
+/// The RM pass runs only when phase 1 raised no [`Severity::Error`] — the
+/// `master08` §Overview phase gate ("more basic kinds of errors being checked
+/// first"). A type `rm` does not know is undecidable rather than wrong
+/// ([`rm::type_conforms`] returns `None`), so an artefact built on a reference
+/// model the supplied [`rm::RmModel`] does not carry simply raises no VUNT.
+///
+/// # Errors
+/// Returns the parse [`SyntaxError`]s if `src` does not parse as ADL 1.4;
+/// validation runs only on a successful parse.
+pub fn validate_source_adl14(
+    src: &str,
+    rm: &dyn rm::RmModel,
+) -> Result<Vec<ValidationIssue>, Vec<SyntaxError>> {
+    let source = parse_source(src)?;
+    let archetype = crate::assemble::assemble_adl14(&source, src)?;
+    let mut issues = Vec::new();
+    phase1::run(
+        &view(&archetype),
+        None,
+        Some((&source, src)),
+        crate::cadl::Dialect::Adl14,
+        &mut issues,
+    );
+    if issues.iter().all(|i| i.severity != Severity::Error) {
+        issues.extend(rm::validate_adl14_rm(&archetype, rm));
+    }
+    Ok(issues)
+}
+
 /// Validate an assembled [`Archetype`] against phase 1 and — only if phase 1
 /// raised no [`Severity::Error`] — the phase-2 reference-model checks against
 /// `rm`.

--- a/crates/openehr-adl/src/validate/rm.rs
+++ b/crates/openehr-adl/src/validate/rm.rs
@@ -445,6 +445,29 @@ pub fn validate_phase2_rm(archetype: &Archetype, rm: &dyn RmModel) -> Vec<Valida
     scan.issues
 }
 
+/// Validate `archetype` against `rm` with the **ADL 1.4** reference-model rule
+/// set — which is VUNT and nothing else.
+///
+/// The ADL 1.4 formalism defines exactly two cADL validity rules of its own:
+/// VCOC (`ADL1.4/master05-cadl.adoc` §Occurrences L324), which needs no RM and
+/// runs in the 1.4 phase-1 pass, and **VUNT** (§Internal References L512-513:
+/// "the type mentioned in a `use_node` must be the same as or a super-type
+/// (according to the reference model) of the reference model type of the node
+/// referred to"), whose "according to the reference model" clause puts it here.
+/// Every other check [`validate_phase2_rm`] performs (VCORM, VCORMT, VCARM,
+/// VCAEX, VCACA, VCAM, VACSO, the interior-node VATID half, the enumeration
+/// family) is an AOM2 rule with no ADL 1.4 counterpart — running them would
+/// judge a 1.4 artefact by ADL 2's catalogue, which this crate does not do (a
+/// 1.4 upload is judged AS 1.4). So the walk runs once and only VUNT is
+/// reported.
+#[must_use]
+pub fn validate_adl14_rm(archetype: &Archetype, rm: &dyn RmModel) -> Vec<ValidationIssue> {
+    validate_phase2_rm(archetype, rm)
+        .into_iter()
+        .filter(|i| i.code == ValidationCode::Vunt)
+        .collect()
+}
+
 /// Mutable state threaded through the reference-model walk.
 struct RmScan<'a> {
     rm: &'a dyn RmModel,

--- a/crates/openehr-adl/tests/adl14_cadl_gates.rs
+++ b/crates/openehr-adl/tests/adl14_cadl_gates.rs
@@ -8,7 +8,7 @@
 //! derived first-hand from the spec text, cited in the fixture beside the
 //! construct it exercises.
 //!
-//! Three families live here:
+//! Four families live here:
 //!
 //! 1. **Dialect gates.** ADL 1.4's cADL keyword set is CLOSED
 //!    (`ADL1.4/master05-cadl.adoc` §Keywords L48-53), so a construct ADL 2
@@ -25,6 +25,18 @@
 //!    get wrong: `before`/`after` sibling order (a 1.4 keyword — L53 — that must
 //!    NOT be gated), the effective occurrences default `{1..1}` (L316), and the
 //!    assumed-value lowering.
+//! 4. **The breadth trio** — `cadl_breadth_{structure,primitives,datetime}` —
+//!    which exercises every construct `master05-cadl.adoc` defines (existence
+//!    and occurrences and cardinality spellings incl. two modifiers and the bare
+//!    star, the whole interval shape set incl. the `infinity` endpoints and both
+//!    exclusive-lower spellings, every string/boolean/character/term-code form,
+//!    every date/time/date-time/duration pattern family incl. the
+//!    literal-substituted and ASCII-timezone variants and the mixed
+//!    `pattern/interval` form, assumed values on every primitive, `use_node`
+//!    with and without occurrences, generic type names, and the bare and
+//!    identified slot forms) plus `cadl_keyword_case`, which repeats a whole
+//!    definition in upper/mixed case because the chapter's own lexical
+//!    specification is case-insensitive (§Symbols L1326-1354).
 //!
 //! Both twins are kept for every refusal (`.claude/rules/testing.md`).
 
@@ -94,7 +106,7 @@ const FIXTURES: &[(&str, Expect)] = &[
         Expect::Invalid(ValidationCode::Vatdf),
     ),
     (
-        "openEHR-EHR-CLUSTER.VATDF_undefined_assumed_code.v1.adl",
+        "openEHR-EHR-CLUSTER.VATDF_undefined_code_with_assumed.v1.adl",
         Expect::Invalid(ValidationCode::Vatdf),
     ),
     (
@@ -104,6 +116,37 @@ const FIXTURES: &[(&str, Expect)] = &[
     (
         "openEHR-EHR-CLUSTER.term_constraint_codes_defined.v1.adl",
         Expect::Pass,
+    ),
+    // ── 1.4 term-constraint LIST integrity (master04.6 STCDC/STCAC) ───────
+    (
+        "openEHR-EHR-CLUSTER.STCDC_duplicate_code_in_list.v1.adl",
+        Expect::Refuse(SyntaxErrorCode::Stcdc),
+    ),
+    (
+        "openEHR-EHR-CLUSTER.STCAC_assumed_code_not_in_list.v1.adl",
+        Expect::Refuse(SyntaxErrorCode::Stcac),
+    ),
+    // ── operators the chapter names but no grammar defines ────────────────
+    (
+        "openEHR-EHR-CLUSTER.SCCOG_negated_matches.v1.adl",
+        Expect::Refuse(SyntaxErrorCode::Sccog),
+    ),
+    (
+        "openEHR-EHR-CLUSTER.SCOAT_negated_is_in.v1.adl",
+        Expect::Refuse(SyntaxErrorCode::Scoat),
+    ),
+    (
+        "openEHR-EHR-CLUSTER.SCOAT_not_in_symbol.v1.adl",
+        Expect::Refuse(SyntaxErrorCode::Scoat),
+    ),
+    (
+        "openEHR-EHR-CLUSTER.SCCOG_regex_match_operator.v1.adl",
+        Expect::Refuse(SyntaxErrorCode::Sccog),
+    ),
+    // ── the date/time interval timezone-symmetry rule (master05 L932) ─────
+    (
+        "openEHR-EHR-CLUSTER.SCDTAV_interval_timezone_asymmetry.v1.adl",
+        Expect::Refuse(SyntaxErrorCode::Scdtav),
     ),
     // ── cardinality/occurrences (master05 VCOC + the {1..1} defaults) ─────
     (
@@ -120,6 +163,20 @@ const FIXTURES: &[(&str, Expect)] = &[
     ),
     // ── 1.4 keywords that must stay accepted ──────────────────────────────
     ("openEHR-EHR-CLUSTER.sibling_order.v1.adl", Expect::Pass),
+    ("openEHR-EHR-CLUSTER.cadl_keyword_case.v1.adl", Expect::Pass),
+    // ── the master05 breadth trio (every construct of the chapter) ────────
+    (
+        "openEHR-EHR-OBSERVATION.cadl_breadth_structure.v1.adl",
+        Expect::Pass,
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.cadl_breadth_primitives.v1.adl",
+        Expect::Pass,
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.cadl_breadth_datetime.v1.adl",
+        Expect::Pass,
+    ),
 ];
 
 fn tree() -> PathBuf {

--- a/crates/openehr-adl/tests/corpus/INVENTORY.md
+++ b/crates/openehr-adl/tests/corpus/INVENTORY.md
@@ -537,10 +537,21 @@ cross-check).
 | `…SDINV_assumed_value_unmatched.v1.adl` | SDINV | a domain `assumed_value` satisfying no `list` row |
 | `…domain_assumed_value.v1.adl` | PASS | the accepting twin: an `assumed_value` landing on the tuple row it satisfies |
 | `…VATDF_undefined_listed_code.v1.adl` | VATDF | an undefined code inside the 1.4 listed term constraint `[local:: …]` |
-| `…VATDF_undefined_assumed_code.v1.adl` | VATDF | an undefined ASSUMED code of a 1.4 listed term constraint |
+| `…VATDF_undefined_code_with_assumed.v1.adl` | VATDF | an undefined listed code in the assumed-value SPELLING of the 1.4 term constraint (the assumed code itself is a member, so STCAC stays quiet) |
 | `…VACDF_undefined_constraint_code.v1.adl` | VACDF | an undefined `ac` code in a 1.4 qualified term constraint |
 | `…term_constraint_codes_defined.v1.adl` | PASS | the accepting twin, incl. that EXTERNAL terminology codes are not archetype terms |
+| `…STCDC_duplicate_code_in_list.v1.adl` | STCDC | a repeated code in the 1.4 listed term constraint (master04.6 §Syntax Validity Rules) |
+| `…STCAC_assumed_code_not_in_list.v1.adl` | STCAC | an assumed code that is not a member of its own code list (master04.6; master05 §Assumed Values L1012). **Adjudication (2026-07-30):** this file previously carried the name `VATDF_undefined_assumed_code` and asserted VATDF over an assumed code that was both undefined AND outside the list. With STCAC raised at the parse site the source never reaches validation, and an assumed code is by construction a member — so "undefined assumed code" collapses into "undefined listed code". The invalid shape is kept (renamed to the rule that now governs it) and the VATDF-over-the-assumed-spelling coverage moved to `VATDF_undefined_code_with_assumed`; nothing was dropped |
+| `…SCCOG_negated_matches.v1.adl` | SCCOG | `~matches` in OBJECT position — named at master05 §Keywords L47/L95-98, defined by no grammar production |
+| `…SCOAT_negated_is_in.v1.adl` | SCOAT | `~is_in` in ATTRIBUTE position (the chapter's own worked spelling, L96) |
+| `…SCOAT_not_in_symbol.v1.adl` | SCOAT | the `∉` symbol (L97), which no §Symbols lexical rule produces |
+| `…SCCOG_regex_match_operator.v1.adl` | SCCOG | `=~` — shown at L691-693 in prose whose example regexes are unterminated, and absent from every grammar |
+| `…SCDTAV_interval_timezone_asymmetry.v1.adl` | SCDTAV | a two-sided date/time interval with a timezone on one endpoint only (master05 §Intervals L932) |
 | `…VCOC_occurrences_exceed_cardinality.v1.adl` | VCOC | master05 L321-324: the occurrences sum overfills the cardinality |
 | `…VCOC_occurrences_below_cardinality.v1.adl` | VCOC | master05 L321-324: the occurrences sum cannot reach the cardinality lower |
 | `…default_occurrences.v1.adl` | PASS | the effective occurrences default `{1..1}` (master05 L316) keeps VCOC quiet |
 | `…sibling_order.v1.adl` | PASS | `before [atNNNN]` — a cADL 1.4 keyword (master05 §Keywords L53), never gated |
+| `…cadl_keyword_case.v1.adl` | PASS | a whole definition in upper/mixed case — the chapter's lexical spec is case-insensitive (§Symbols L1326-1354) — plus the `is_in` and `∈` spellings of `matches` |
+| `…cadl_breadth_structure.v1.adl` | PASS | every existence/occurrences/cardinality spelling (incl. two modifiers, both modifier orderings, the bare `{*}`), `use_node` with and without occurrences, generic type names, mixed object kinds under one attribute, and the bare + identified slot forms |
+| `…cadl_breadth_primitives.v1.adl` | PASS | every integer/real list and interval shape (incl. `infinity`/`-infinity`, `+/-`, and BOTH exclusive-lower spellings), string lists + the `...` continuation + both regex delimiters, booleans, characters, listed term codes, and assumed values on each |
+| `…cadl_breadth_datetime.v1.adl` | PASS | every date/time/date-time pattern of the valid-pattern table incl. literal substitution (L894) and the ASCII/`±`/`Z` timezone modifiers (L852, L900-906), the space-separated date-time pattern (§Symbols L1422), every duration pattern family, negative durations, the mixed `pattern/interval` form, and symmetric-timezone intervals |

--- a/crates/openehr-adl/tests/corpus/PROVENANCE.md
+++ b/crates/openehr-adl/tests/corpus/PROVENANCE.md
@@ -60,12 +60,21 @@
   (`docs/specs/openehr/AM/docs/ADL1.4/master05-cadl.adoc`, plus
   `master08-adl.adoc` §Validity Rules and `master09-customising_adl.adoc`); the
   vendored `adl2-reference` library is an ADL2 corpus and covers none of it.
-- Three families: the **dialect gates** (a construct ADL 2 introduced is refused
+- Four families: the **dialect gates** (a construct ADL 2 introduced is refused
   in a 1.4 text — master05 §Keywords L48-53 is a closed keyword set), the
-  **inline dADL domain lowering** refusals with their accepting twin, and
+  **inline dADL domain lowering** refusals with their accepting twin,
   **positive fixtures** for behaviour an over-strict reader would break
   (`before`/`after` sibling order — a 1.4 keyword at L53 — and the effective
-  occurrences default `{1..1}` at L316).
+  occurrences default `{1..1}` at L316), and the **breadth trio**
+  (`cadl_breadth_{structure,primitives,datetime}`) covering every construct
+  master05 defines, alongside `cadl_keyword_case` for the case-insensitive
+  lexis of §Symbols L1326-1354.
+- **Operators the chapter NAMES but no grammar DEFINES** get refusal fixtures of
+  their own: the negated-matches family (`~matches`/`~is_in`/`∉`, §Keywords L47
+  + L95-98) and the regex-match operators (`=~`/`!~`, §Regular Expression
+  L691-693, whose example regexes are themselves unterminated). Their accepting
+  twins are the affirmative `matches` and the bare delimited regex, exercised
+  throughout the tree.
 - File names encode the expected outcome corpus-convention style: an `S*_`
   prefix is a parse refusal with that syntax code, a `V*_` prefix is a phase-1
   validation error with that validation code, everything else parses and

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.SCCOG_negated_matches.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.SCCOG_negated_matches.v1.adl
@@ -1,0 +1,63 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-CLUSTER.SCCOG_negated_matches.v1
+
+concept
+	[at0000]	-- Negated matches in object position
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	other_details = <
+		["regression"] = <"SCCOG">
+	>
+	lifecycle_state = <"AuthorDraft">
+
+definition
+	CLUSTER[at0000] matches {	-- Negated matches in object position
+		items cardinality matches {0..*; unordered} matches {
+			ELEMENT[at0001] occurrences matches {0..1} matches {	-- Position
+				value matches {
+					-- `~matches` / `~is_in` / `∉` are listed among the cADL keywords
+					-- (ADL1.4/master05-cadl.adoc §Keywords L47) and glossed at L91-98
+					-- ("Occasionally, the matches operator needs to be used in the
+					-- negative, usually at a leaf block"), but NO production of any
+					-- normative grammar admits them: the chapter's own §Syntax uses a
+					-- single `SYM_MATCHES` in `c_complex_object`, `c_attribute` and
+					-- `archetype_slot` (L1038-1120), its §Symbols lexer (L1300-1354)
+					-- defines neither a `~` symbol nor a `∉` token, and `cadl14.g4`
+					-- + `adl_keywords.g4` are identical. Reading the operator as an
+					-- affirmative `matches` would INVERT the constraint, so it is a
+					-- typed refusal.
+					DV_TEXT ~matches {"lying", "sitting"}
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Negated matches in object position">
+					description = <"Refusal fixture: '~matches' has no cADL production.">
+				>
+				["at0001"] = <
+					text = <"Position">
+					description = <"The recorded position.">
+				>
+				["at0002"] = <
+					text = <"Lying">
+					description = <"Lying position.">
+				>
+				["at0003"] = <
+					text = <"Sitting">
+					description = <"Sitting position.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.SCCOG_regex_match_operator.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.SCCOG_regex_match_operator.v1.adl
@@ -1,0 +1,69 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-CLUSTER.SCCOG_regex_match_operator.v1
+
+concept
+	[at0000]	-- Regex-match operator in a string constraint
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	other_details = <
+		["regression"] = <"SCCOG">
+	>
+	lifecycle_state = <"AuthorDraft">
+
+definition
+	CLUSTER[at0000] matches {	-- Regex-match operator in a string constraint
+		items cardinality matches {0..*; unordered} matches {
+			ELEMENT[at0001] occurrences matches {0..1} matches {	-- Position
+				value matches {
+					DV_TEXT matches {
+						-- ADL1.4/master05-cadl.adoc §Regular Expression L691-693 shows
+						-- `string_attr matches {=~ /regular expression}` and
+						-- `{!~ /regular expression}`, but that prose is itself
+						-- malformed — BOTH example regexes are unterminated (an
+						-- opening `/` with no closing `/`) — and the sentence at L696
+						-- says the first two forms "are identical", i.e. `=~` adds
+						-- nothing to the bare form. No normative grammar defines the
+						-- operators: `c_string_spec` is `V_STRING | string_list_value
+						-- | string_list_value ',' SYM_LIST_CONTINUE | V_REGEXP`
+						-- (§Syntax L1244-1249) with `V_REGEXP` the bare delimited form
+						-- (§Symbols L1471-1476), §Symbols has no `=~`/`!~` token, and
+						-- `cadl14_primitives.g4` `c_string` is `( string_value |
+						-- string_list_value | regex_constraint )`. Guessing a
+						-- negated-regex semantics from defective prose would be a
+						-- silent wrong answer, so the operator is refused.
+						value matches {=~ /[a-z]+/}
+					}
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Regex-match operator in a string constraint">
+					description = <"Refusal fixture: the '=~' operator has no cADL production.">
+				>
+				["at0001"] = <
+					text = <"Position">
+					description = <"The recorded position.">
+				>
+				["at0002"] = <
+					text = <"Lying">
+					description = <"Lying position.">
+				>
+				["at0003"] = <
+					text = <"Sitting">
+					description = <"Sitting position.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.SCDTAV_interval_timezone_asymmetry.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.SCDTAV_interval_timezone_asymmetry.v1.adl
@@ -1,0 +1,60 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-CLUSTER.SCDTAV_interval_timezone_asymmetry.v1
+
+concept
+	[at0000]	-- Timezone on one interval endpoint only
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	other_details = <
+		["regression"] = <"SCDTAV">
+	>
+	lifecycle_state = <"AuthorDraft">
+
+definition
+	CLUSTER[at0000] matches {	-- Timezone on one interval endpoint only
+		items cardinality matches {0..*; unordered} matches {
+			ELEMENT[at0001] occurrences matches {0..1} matches {	-- Position
+				value matches {
+					DV_DATE_TIME matches {
+						-- ADL1.4/master05-cadl.adoc §Intervals L932: "Within any
+						-- interval containing two literal date/time values (i.e. not
+						-- one-sided intervals), if a timezone is used on one, it must
+						-- be used on both, to ensure comparability. The timezones need
+						-- not be identical." Here only the lower endpoint carries one,
+						-- so the two endpoints are not comparable.
+						value matches {|2004-05-20T00:00:00Z..2005-05-19T23:59:59|}
+					}
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Timezone on one interval endpoint only">
+					description = <"Refusal fixture: an asymmetric-timezone date/time interval.">
+				>
+				["at0001"] = <
+					text = <"Position">
+					description = <"The recorded position.">
+				>
+				["at0002"] = <
+					text = <"Lying">
+					description = <"Lying position.">
+				>
+				["at0003"] = <
+					text = <"Sitting">
+					description = <"Sitting position.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.SCOAT_negated_is_in.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.SCOAT_negated_is_in.v1.adl
@@ -1,0 +1,57 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-CLUSTER.SCOAT_negated_is_in.v1
+
+concept
+	[at0000]	-- Negated is_in in attribute position
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	other_details = <
+		["regression"] = <"SCOAT">
+	>
+	lifecycle_state = <"AuthorDraft">
+
+definition
+	CLUSTER[at0000] matches {	-- Negated is_in in attribute position
+		items cardinality matches {0..*; unordered} matches {
+			ELEMENT[at0001] occurrences matches {0..1} matches {	-- Position
+				-- The attribute-position twin of the object-position refusal: the
+				-- chapter's own worked negation examples are attribute-level
+				-- (ADL1.4/master05-cadl.adoc L95-97 — `aaa ~matches {5}`,
+				-- `aaa ~is_in {5}`, `aaa ∉ {5}`), and `c_attribute`
+				-- (§Syntax L1107-1109) admits `SYM_MATCHES` only.
+				value ~is_in {
+					DV_TEXT matches {*}
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Negated is_in in attribute position">
+					description = <"Refusal fixture: '~is_in' has no cADL production.">
+				>
+				["at0001"] = <
+					text = <"Position">
+					description = <"The recorded position.">
+				>
+				["at0002"] = <
+					text = <"Lying">
+					description = <"Lying position.">
+				>
+				["at0003"] = <
+					text = <"Sitting">
+					description = <"Sitting position.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.SCOAT_not_in_symbol.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.SCOAT_not_in_symbol.v1.adl
@@ -1,0 +1,57 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-CLUSTER.SCOAT_not_in_symbol.v1
+
+concept
+	[at0000]	-- Not-in symbol in attribute position
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	other_details = <
+		["regression"] = <"SCOAT">
+	>
+	lifecycle_state = <"AuthorDraft">
+
+definition
+	CLUSTER[at0000] matches {	-- Not-in symbol in attribute position
+		items cardinality matches {0..*; unordered} matches {
+			ELEMENT[at0001] occurrences matches {0..1} matches {	-- Position
+				-- `∉` is the symbolic spelling of the same absent production
+				-- (ADL1.4/master05-cadl.adoc L97: `aaa ∉ {5}`). The §Keywords
+				-- symbol-equivalence table (L57-64) pairs `matches` with `∈` and
+				-- `not`/`~` with `∼`; it never introduces `∉`, and no lexical rule
+				-- in §Symbols produces it.
+				value ∉ {
+					DV_TEXT matches {*}
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Not-in symbol in attribute position">
+					description = <"Refusal fixture: the not-in symbol has no cADL production.">
+				>
+				["at0001"] = <
+					text = <"Position">
+					description = <"The recorded position.">
+				>
+				["at0002"] = <
+					text = <"Lying">
+					description = <"Lying position.">
+				>
+				["at0003"] = <
+					text = <"Sitting">
+					description = <"Sitting position.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.STCAC_assumed_code_not_in_list.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.STCAC_assumed_code_not_in_list.v1.adl
@@ -1,0 +1,73 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-CLUSTER.STCAC_assumed_code_not_in_list.v1
+
+concept
+	[at0000]	-- Assumed code outside its own code list
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	other_details = <
+		["regression"] = <"STCAC">
+	>
+	lifecycle_state = <"AuthorDraft">
+
+definition
+	CLUSTER[at0000] matches {	-- Assumed code outside its own code list
+		items cardinality matches {0..*; unordered} matches {
+			ELEMENT[at0001] occurrences matches {0..1} matches {	-- Position
+				value matches {
+					DV_CODED_TEXT matches {
+						defining_code matches {
+							-- STCAC — "Syntax error: assumed value code $1 not found in
+							-- code list" (ADL2/master04.6-cadl_validity_rules.adoc
+							-- §Syntax Validity Rules). ADL1.4/master05-cadl.adoc
+							-- §Assumed Values L1012 requires the assumed value to be
+							-- "a value of the same type as that implied by the preceding
+							-- part of the constraint"; for a listed term constraint the
+							-- implied value space IS the list, so a code outside it can
+							-- never be assumed. at0999 is a defined archetype term —
+							-- the defect is membership, not definedness, which is what
+							-- separates STCAC from VATDF.
+							[local::
+							at0002,
+							at0003;
+							at0999]
+						}
+					}
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Assumed code outside its own code list">
+					description = <"Refusal fixture: STCAC on an assumed code that is not a member of the list.">
+				>
+				["at0001"] = <
+					text = <"Position">
+					description = <"The recorded position.">
+				>
+				["at0002"] = <
+					text = <"Lying">
+					description = <"Lying position.">
+				>
+				["at0003"] = <
+					text = <"Sitting">
+					description = <"Sitting position.">
+				>
+				["at0999"] = <
+					text = <"Standing">
+					description = <"A defined term that is nonetheless outside the constraint's own list.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.STCDC_duplicate_code_in_list.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.STCDC_duplicate_code_in_list.v1.adl
@@ -1,8 +1,8 @@
 archetype (adl_version=1.4)
-	openEHR-EHR-CLUSTER.VATDF_undefined_assumed_code.v1
+	openEHR-EHR-CLUSTER.STCDC_duplicate_code_in_list.v1
 
 concept
-	[at0000]	-- Undefined assumed code in a listed term constraint
+	[at0000]	-- Duplicate code in a listed term constraint
 
 language
 	original_language = <[ISO_639-1::en]>
@@ -12,27 +12,26 @@ description
 		["name"] = <"openEHR-rs regression corpus">
 	>
 	other_details = <
-		["regression"] = <"VATDF">
+		["regression"] = <"STCDC">
 	>
 	lifecycle_state = <"AuthorDraft">
 
 definition
-	CLUSTER[at0000] matches {	-- Undefined assumed code in a listed term constraint
+	CLUSTER[at0000] matches {	-- Duplicate code in a listed term constraint
 		items cardinality matches {0..*; unordered} matches {
 			ELEMENT[at0001] occurrences matches {0..1} matches {	-- Position
 				value matches {
 					DV_CODED_TEXT matches {
 						defining_code matches {
-							-- The assumed value of a 1.4 listed term constraint is
-							-- itself an archetype term (ADL1.4/master05-cadl.adoc
-							-- §Assumed Values; ADL1.4/master09-customising_adl.adoc
-							-- §Custom Syntax), so VATDF
-							-- (ADL1.4/master08-adl.adoc §Validity Rules) covers it
-							-- too; at0999 is not defined.
+							-- STCDC — "Syntax error: duplicate code(s) found in code
+							-- list" (ADL2/master04.6-cadl_validity_rules.adoc §Syntax
+							-- Validity Rules). A repeated member adds nothing to the
+							-- constrained set and is a defect in the source, never a
+							-- silently-collapsed set.
 							[local::
 							at0002,
-							at0003;
-							at0999]
+							at0003,
+							at0002]
 						}
 					}
 				}
@@ -45,8 +44,8 @@ ontology
 		["en"] = <
 			items = <
 				["at0000"] = <
-					text = <"Undefined assumed code in a listed term constraint">
-					description = <"Refusal fixture: VATDF on the assumed code of a 1.4 term constraint.">
+					text = <"Duplicate code in a listed term constraint">
+					description = <"Refusal fixture: STCDC on a repeated code.">
 				>
 				["at0001"] = <
 					text = <"Position">

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.VATDF_undefined_code_with_assumed.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.VATDF_undefined_code_with_assumed.v1.adl
@@ -1,0 +1,63 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-CLUSTER.VATDF_undefined_code_with_assumed.v1
+
+concept
+	[at0000]	-- Undefined code in a term constraint carrying an assumed value
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	other_details = <
+		["regression"] = <"VATDF">
+	>
+	lifecycle_state = <"AuthorDraft">
+
+definition
+	CLUSTER[at0000] matches {	-- Undefined code in a term constraint carrying an assumed value
+		items cardinality matches {0..*; unordered} matches {
+			ELEMENT[at0001] occurrences matches {0..1} matches {	-- Position
+				value matches {
+					DV_CODED_TEXT matches {
+						defining_code matches {
+							-- The assumed-value SPELLING of the 1.4 listed term
+							-- constraint (ADL1.4/master09-customising_adl.adoc §Custom
+							-- Syntax; the `;`-separated form of master05 §Symbols
+							-- L1378-1381) must still be decomposed into its member
+							-- codes so definedness is judged per code
+							-- (ADL1.4/master08-adl.adoc §Validity Rules VATDF). The
+							-- assumed code at0002 IS a member (so STCAC is quiet), but
+							-- the listed code at0999 is not defined in the ontology.
+							[local::
+							at0002,
+							at0999;
+							at0002]
+						}
+					}
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Undefined code in a term constraint carrying an assumed value">
+					description = <"Refusal fixture: VATDF on a listed code, with the assumed-value spelling in play.">
+				>
+				["at0001"] = <
+					text = <"Position">
+					description = <"The recorded position.">
+				>
+				["at0002"] = <
+					text = <"Lying">
+					description = <"Lying position.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.cadl_keyword_case.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.cadl_keyword_case.v1.adl
@@ -1,0 +1,91 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-CLUSTER.cadl_keyword_case.v1
+
+concept
+	[at0000]	-- Case-insensitive cADL keywords
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	other_details = <
+		["regression"] = <"PASS">
+	>
+	lifecycle_state = <"AuthorDraft">
+
+definition
+	-- Every cADL keyword is CASE-INSENSITIVE. The ADL 1.4 chapter's own lexical
+	-- specification spells each one in the bracketed-alternative form —
+	-- ADL1.4/master05-cadl.adoc §Symbols L1326-1354, e.g.
+	-- `[Mm][Aa][Tt][Cc][Hh][Ee][Ss] -- -> SYM_MATCHES`,
+	-- `[Ii][Nn][Ff][Ii][Nn][Ii][Tt][Yy] -- -> SYM_INFINITY` — and so does the
+	-- normative ANTLR set (`cadl14.g4` SYM_EXISTENCE … SYM_EXCLUDE,
+	-- `adl_keywords.g4` SYM_MATCHES/SYM_NOT/…, `base_lexer.g4` SYM_TRUE/SYM_FALSE).
+	CLUSTER[at0000] MATCHES {	-- Case-insensitive cADL keywords
+		items CARDINALITY MATCHES {0..*; UNORDERED; UNIQUE} MATCHES {
+			ELEMENT[at0001] OCCURRENCES MATCHES {0..1} Matches {	-- Rate
+				value EXISTENCE matches {1..1} matches {
+					DV_QUANTITY matches {
+						magnitude matches {|0..INFINITY|}
+					}
+				}
+			}
+			-- `is_in` and `∈` are the same token as `matches` (§Symbols L1326-1327:
+			-- both `[Mm][Aa][Tt][Cc][Hh][Ee][Ss]` and `[Ii][Ss]_[Ii][Nn]` map to
+			-- SYM_MATCHES; the §Keywords symbol table L57-64 adds `∈`).
+			ELEMENT[at0002] occurrences Is_In {0..1} IS_IN {	-- Flag
+				value ∈ {
+					DV_BOOLEAN ∈ {
+						value ∈ {TRUE, fAlSe; TRUE}
+					}
+				}
+			}
+			BEFORE [at0002] ELEMENT[at0003] occurrences matches {0..1} matches {	-- Re-ordered item
+				value matches {
+					DV_TEXT matches {*}
+				}
+			}
+			Allow_Archetype CLUSTER[at0004] OCCURRENCES matches {0..*} matches {	-- Slot
+				INCLUDE
+					archetype_id/value matches {/openEHR-EHR-CLUSTER\.device\.v1/}
+				Exclude
+					archetype_id/value matches {/.*/}
+			}
+			USE_NODE ELEMENT[at0005] Occurrences matches {0..2} /items[at0001]
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Case-insensitive cADL keywords">
+					description = <"Accepting fixture: cADL keywords lexed in mixed and upper case.">
+				>
+				["at0001"] = <
+					text = <"Rate">
+					description = <"A quantity with an unbounded upper interval endpoint.">
+				>
+				["at0002"] = <
+					text = <"Flag">
+					description = <"A boolean written with the is_in and set-membership operators.">
+				>
+				["at0003"] = <
+					text = <"Re-ordered item">
+					description = <"An element carrying an upper-case sibling order.">
+				>
+				["at0004"] = <
+					text = <"Slot">
+					description = <"An archetype slot written with upper-case keywords.">
+				>
+				["at0005"] = <
+					text = <"Re-used rate">
+					description = <"An internal reference written with upper-case keywords.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-OBSERVATION.cadl_breadth_datetime.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-OBSERVATION.cadl_breadth_datetime.v1.adl
@@ -1,0 +1,508 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-OBSERVATION.cadl_breadth_datetime.v1
+
+concept
+	[at0000]	-- cADL 1.4 date/time/duration breadth
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	other_details = <
+		["regression"] = <"PASS">
+	>
+	lifecycle_state = <"AuthorDraft">
+
+definition
+	OBSERVATION[at0000] matches {	-- cADL 1.4 date/time/duration breadth
+		data matches {
+			ITEM_TREE[at0001] matches {	-- Date/time constraints
+				items cardinality matches {0..*} matches {
+					-- ── DATE patterns: the whole valid-pattern table of
+					-- ADL1.4/master05-cadl.adoc §Patterns L868-874.
+					ELEMENT[at0002] occurrences matches {0..1} matches {	-- Full date
+						value matches {
+							DV_DATE matches {
+								value matches {yyyy-mm-dd}
+							}
+						}
+					}
+					ELEMENT[at0003] occurrences matches {0..1} matches {	-- Optional day
+						value matches {
+							DV_DATE matches {
+								value matches {yyyy-mm-??}
+							}
+						}
+					}
+					ELEMENT[at0004] occurrences matches {0..1} matches {	-- Any date
+						value matches {
+							DV_DATE matches {
+								-- With the assumed value of §Patterns L912:
+								-- "`yyyy-??-??; 1970-01-01`".
+								value matches {yyyy-??-??; 1970-01-01}
+							}
+						}
+					}
+					ELEMENT[at0005] occurrences matches {0..1} matches {	-- Month, no day
+						value matches {
+							DV_DATE matches {
+								value matches {yyyy-mm-XX}
+							}
+						}
+					}
+					ELEMENT[at0006] occurrences matches {0..1} matches {	-- Optional month, no day
+						value matches {
+							DV_DATE matches {
+								value matches {yyyy-??-XX}
+							}
+						}
+					}
+					ELEMENT[at0007] occurrences matches {0..1} matches {	-- Literal-substituted year
+						value matches {
+							DV_DATE matches {
+								-- §Patterns L894: "the 'yyyy' etc match strings can be
+								-- replaced by literal date/time numbers. For example,
+								-- `yyyy-??-XX` could be transformed into `1995-??-XX`".
+								value matches {1995-??-XX}
+							}
+						}
+					}
+					-- ── TIME patterns (L876-882) + the timezone modifiers of the
+					-- <<timezone_constraints>> table (L900-906), whose `±` rows are
+					-- glossed "commencing with '+' or '-'"; L852 spells the ASCII
+					-- forms `+hh:mm`, `+hhmm`, `-hh` directly.
+					ELEMENT[at0008] occurrences matches {0..1} matches {	-- Full time
+						value matches {
+							DV_TIME matches {
+								value matches {hh:mm:ss}
+							}
+						}
+					}
+					ELEMENT[at0009] occurrences matches {0..1} matches {	-- No seconds
+						value matches {
+							DV_TIME matches {
+								value matches {hh:mm:XX}
+							}
+						}
+					}
+					ELEMENT[at0010] occurrences matches {0..1} matches {	-- Optional minutes, no seconds
+						value matches {
+							DV_TIME matches {
+								value matches {hh:??:XX}
+							}
+						}
+					}
+					ELEMENT[at0011] occurrences matches {0..1} matches {	-- Any time
+						value matches {
+							DV_TIME matches {
+								value matches {hh:??:??}
+							}
+						}
+					}
+					ELEMENT[at0012] occurrences matches {0..1} matches {	-- Full timezone required
+						value matches {
+							DV_TIME matches {
+								value matches {hh:mm:ss+hh:mm; 09:30:00+0200}
+							}
+						}
+					}
+					ELEMENT[at0013] occurrences matches {0..1} matches {	-- Compact timezone required
+						value matches {
+							DV_TIME matches {
+								value matches {hh:mm:ss+hhmm}
+							}
+						}
+					}
+					ELEMENT[at0014] occurrences matches {0..1} matches {	-- Hours-only timezone required
+						value matches {
+							DV_TIME matches {
+								value matches {hh:mm:ss-hh}
+							}
+						}
+					}
+					ELEMENT[at0015] occurrences matches {0..1} matches {	-- UTC required
+						value matches {
+							DV_TIME matches {
+								value matches {hh:mm:ssZ}
+							}
+						}
+					}
+					-- ── DATE/TIME patterns (L884-891).
+					ELEMENT[at0016] occurrences matches {0..1} matches {	-- Full date/time
+						value matches {
+							DV_DATE_TIME matches {
+								value matches {yyyy-mm-ddThh:mm:ss}
+							}
+						}
+					}
+					ELEMENT[at0017] occurrences matches {0..1} matches {	-- Optional seconds
+						value matches {
+							DV_DATE_TIME matches {
+								value matches {yyyy-mm-ddThh:mm:??}
+							}
+						}
+					}
+					ELEMENT[at0018] occurrences matches {0..1} matches {	-- No seconds
+						value matches {
+							DV_DATE_TIME matches {
+								value matches {yyyy-mm-ddThh:mm:XX}
+							}
+						}
+					}
+					ELEMENT[at0019] occurrences matches {0..1} matches {	-- Optional minutes, no seconds
+						value matches {
+							DV_DATE_TIME matches {
+								value matches {yyyy-mm-ddThh:??:XX}
+							}
+						}
+					}
+					ELEMENT[at0020] occurrences matches {0..1} matches {	-- Minimum date/time
+						value matches {
+							DV_DATE_TIME matches {
+								value matches {yyyy-??-??T??:??:??}
+							}
+						}
+					}
+					ELEMENT[at0021] occurrences matches {0..1} matches {	-- Space-separated date/time
+						value matches {
+							DV_DATE_TIME matches {
+								-- The chapter's own §Symbols lexical rule spells the
+								-- separator `[ T]` (L1422
+								-- `V_ISO8601_DATE_TIME_CONSTRAINT_PATTERN`) and its
+								-- §Assumed Values example L1018 uses the space form:
+								-- "`some_date matches {yyyy-mm-dd hh:mm:XX;
+								-- 1800-01-01T00:00:00}`".
+								value matches {yyyy-mm-dd hh:mm:XX; 1800-01-01T00:00:00}
+							}
+						}
+					}
+					ELEMENT[at0022] occurrences matches {0..1} matches {	-- Date/time with timezone
+						value matches {
+							DV_DATE_TIME matches {
+								value matches {yyyy-mm-ddThh:mm:ss±hh:mm}
+							}
+						}
+					}
+					-- ── DATE/TIME intervals (L914-930).
+					ELEMENT[at0023] occurrences matches {0..1} matches {	-- Time point and one-sided
+						value matches {
+							DV_TIME matches {
+								value matches {|09:30:00|}
+							}
+						}
+					}
+					ELEMENT[at0024] occurrences matches {0..1} matches {	-- One-sided time with timezone
+						value matches {
+							DV_TIME matches {
+								-- L924: "|> 09:30:00+0200| -- any time after 9:30 am in
+								-- UTC+0200 timezone". A one-sided interval is outside
+								-- the timezone-symmetry rule of L932 by its own wording.
+								value matches {|>09:30:00+0200|}
+							}
+						}
+					}
+					ELEMENT[at0025] occurrences matches {0..1} matches {	-- Date range
+						value matches {
+							DV_DATE matches {
+								value matches {|2004-05-20..2004-06-02|}
+							}
+						}
+					}
+					ELEMENT[at0026] occurrences matches {0..1} matches {	-- Date/time range in UTC
+						value matches {
+							DV_DATE_TIME matches {
+								-- L932: within a two-sided interval "if a timezone is
+								-- used on one, it must be used on both". Both carry one.
+								value matches {|2004-05-20T00:00:00Z..2005-05-19T23:59:59Z|}
+							}
+						}
+					}
+					ELEMENT[at0027] occurrences matches {0..1} matches {	-- Date/time range without timezone
+						value matches {
+							DV_DATE_TIME matches {
+								value matches {|2004-05-20T00:00:00..2005-05-19T23:59:59|}
+							}
+						}
+					}
+					-- ── DURATION patterns, values, intervals and the mixed form
+					-- (§Duration Constraints L936-987).
+					ELEMENT[at0028] occurrences matches {0..1} matches {	-- Days only
+						value matches {
+							DV_DURATION matches {
+								value matches {Pd}
+							}
+						}
+					}
+					ELEMENT[at0029] occurrences matches {0..1} matches {	-- Months only
+						value matches {
+							DV_DURATION matches {
+								value matches {Pm}
+							}
+						}
+					}
+					ELEMENT[at0030] occurrences matches {0..1} matches {	-- Minutes only
+						value matches {
+							DV_DURATION matches {
+								value matches {PTm}
+							}
+						}
+					}
+					ELEMENT[at0031] occurrences matches {0..1} matches {	-- Weeks and/or days
+						value matches {
+							DV_DURATION matches {
+								value matches {Pwd}
+							}
+						}
+					}
+					ELEMENT[at0032] occurrences matches {0..1} matches {	-- Hours and/or minutes
+						value matches {
+							DV_DURATION matches {
+								value matches {PThm}
+							}
+						}
+					}
+					ELEMENT[at0033] occurrences matches {0..1} matches {	-- All designators
+						value matches {
+							DV_DURATION matches {
+								value matches {PYMWD}
+							}
+						}
+					}
+					ELEMENT[at0034] occurrences matches {0..1} matches {	-- Duration values
+						value matches {
+							DV_DURATION matches {
+								value matches {PT1m}
+							}
+						}
+					}
+					ELEMENT[at0035] occurrences matches {0..1} matches {	-- Compound duration value
+						value matches {
+							DV_DURATION matches {
+								value matches {P1dT8h}
+							}
+						}
+					}
+					ELEMENT[at0036] occurrences matches {0..1} matches {	-- Duration interval
+						value matches {
+							DV_DURATION matches {
+								value matches {|PT0m..PT1m30s|}
+							}
+						}
+					}
+					ELEMENT[at0037] occurrences matches {0..1} matches {	-- Negative duration
+						value matches {
+							DV_DURATION matches {
+								-- L953: "Pure pattern constraints are used to constrain
+								-- negative durations as well as positive durations …
+								-- any of the above constraints may be used for values
+								-- such as `'-P5d'`".
+								value matches {-P5D}
+							}
+						}
+					}
+					ELEMENT[at0038] occurrences matches {0..1} matches {	-- Mixed pattern and interval
+						value matches {
+							DV_DURATION matches {
+								-- L971: "PWD/|P0W..P50W| -- 0-50 weeks, expressed only
+								-- using weeks and days"; the general form is
+								-- `duration_constraint: duration_pattern '/'
+								-- duration_interval` (L986).
+								value matches {PWD/|P0W..P50W|}
+							}
+						}
+					}
+					ELEMENT[at0039] occurrences matches {0..1} matches {	-- Mixed pattern and one-sided interval
+						value matches {
+							DV_DURATION matches {
+								-- L977: "PYMWD/|<=P0Y| -- negative age, with
+								-- years/months/weeks/days allowed".
+								value matches {PYMWD/|<=P0Y|}
+							}
+						}
+					}
+					ELEMENT[at0040] occurrences matches {0..1} matches {	-- Duration with assumed value
+						value matches {
+							DV_DURATION matches {
+								value matches {|PT0m..PT1m30s|; PT0m}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"cADL 1.4 date/time/duration breadth">
+					description = <"Accepting fixture: every date/time/duration pattern, value and interval form of master05.">
+				>
+				["at0001"] = <
+					text = <"Date/time constraints">
+					description = <"The tree holding the date/time constraints.">
+				>
+				["at0002"] = <
+					text = <"Full date">
+					description = <"Pattern yyyy-mm-dd.">
+				>
+				["at0003"] = <
+					text = <"Optional day">
+					description = <"Pattern yyyy-mm-??.">
+				>
+				["at0004"] = <
+					text = <"Any date">
+					description = <"Pattern yyyy-??-?? with an assumed value.">
+				>
+				["at0005"] = <
+					text = <"Month, no day">
+					description = <"Pattern yyyy-mm-XX.">
+				>
+				["at0006"] = <
+					text = <"Optional month, no day">
+					description = <"Pattern yyyy-??-XX.">
+				>
+				["at0007"] = <
+					text = <"Literal-substituted year">
+					description = <"Pattern 1995-??-XX.">
+				>
+				["at0008"] = <
+					text = <"Full time">
+					description = <"Pattern hh:mm:ss.">
+				>
+				["at0009"] = <
+					text = <"No seconds">
+					description = <"Pattern hh:mm:XX.">
+				>
+				["at0010"] = <
+					text = <"Optional minutes, no seconds">
+					description = <"Pattern hh:??:XX.">
+				>
+				["at0011"] = <
+					text = <"Any time">
+					description = <"Pattern hh:??:??.">
+				>
+				["at0012"] = <
+					text = <"Full timezone required">
+					description = <"Pattern hh:mm:ss+hh:mm with an assumed value.">
+				>
+				["at0013"] = <
+					text = <"Compact timezone required">
+					description = <"Pattern hh:mm:ss+hhmm.">
+				>
+				["at0014"] = <
+					text = <"Hours-only timezone required">
+					description = <"Pattern hh:mm:ss-hh.">
+				>
+				["at0015"] = <
+					text = <"UTC required">
+					description = <"Pattern hh:mm:ssZ.">
+				>
+				["at0016"] = <
+					text = <"Full date/time">
+					description = <"Pattern yyyy-mm-ddThh:mm:ss.">
+				>
+				["at0017"] = <
+					text = <"Optional seconds">
+					description = <"Pattern yyyy-mm-ddThh:mm:??.">
+				>
+				["at0018"] = <
+					text = <"No seconds">
+					description = <"Pattern yyyy-mm-ddThh:mm:XX.">
+				>
+				["at0019"] = <
+					text = <"Optional minutes, no seconds">
+					description = <"Pattern yyyy-mm-ddThh:??:XX.">
+				>
+				["at0020"] = <
+					text = <"Minimum date/time">
+					description = <"Pattern yyyy-??-??T??:??:??.">
+				>
+				["at0021"] = <
+					text = <"Space-separated date/time">
+					description = <"Pattern yyyy-mm-dd hh:mm:XX with an assumed value.">
+				>
+				["at0022"] = <
+					text = <"Date/time with timezone">
+					description = <"Pattern yyyy-mm-ddThh:mm:ss with a required timezone.">
+				>
+				["at0023"] = <
+					text = <"Time point and one-sided">
+					description = <"A point time interval.">
+				>
+				["at0024"] = <
+					text = <"One-sided time with timezone">
+					description = <"A one-sided time interval whose endpoint carries a timezone.">
+				>
+				["at0025"] = <
+					text = <"Date range">
+					description = <"A two-sided date interval.">
+				>
+				["at0026"] = <
+					text = <"Date/time range in UTC">
+					description = <"A two-sided date/time interval with a timezone on both endpoints.">
+				>
+				["at0027"] = <
+					text = <"Date/time range without timezone">
+					description = <"A two-sided date/time interval with a timezone on neither endpoint.">
+				>
+				["at0028"] = <
+					text = <"Days only">
+					description = <"Duration pattern Pd.">
+				>
+				["at0029"] = <
+					text = <"Months only">
+					description = <"Duration pattern Pm.">
+				>
+				["at0030"] = <
+					text = <"Minutes only">
+					description = <"Duration pattern PTm.">
+				>
+				["at0031"] = <
+					text = <"Weeks and/or days">
+					description = <"Duration pattern Pwd.">
+				>
+				["at0032"] = <
+					text = <"Hours and/or minutes">
+					description = <"Duration pattern PThm.">
+				>
+				["at0033"] = <
+					text = <"All designators">
+					description = <"Duration pattern PYMWD.">
+				>
+				["at0034"] = <
+					text = <"Duration values">
+					description = <"A fixed duration value.">
+				>
+				["at0035"] = <
+					text = <"Compound duration value">
+					description = <"A duration value with day and hour components.">
+				>
+				["at0036"] = <
+					text = <"Duration interval">
+					description = <"A two-sided duration interval.">
+				>
+				["at0037"] = <
+					text = <"Negative duration">
+					description = <"A negative duration value.">
+				>
+				["at0038"] = <
+					text = <"Mixed pattern and interval">
+					description = <"A duration pattern followed by a duration interval.">
+				>
+				["at0039"] = <
+					text = <"Mixed pattern and one-sided interval">
+					description = <"A duration pattern followed by a one-sided duration interval.">
+				>
+				["at0040"] = <
+					text = <"Duration with assumed value">
+					description = <"A duration interval carrying an assumed value.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-OBSERVATION.cadl_breadth_primitives.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-OBSERVATION.cadl_breadth_primitives.v1.adl
@@ -1,0 +1,371 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-OBSERVATION.cadl_breadth_primitives.v1
+
+concept
+	[at0000]	-- cADL 1.4 primitive-constraint breadth
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	other_details = <
+		["regression"] = <"PASS">
+	>
+	lifecycle_state = <"AuthorDraft">
+
+definition
+	OBSERVATION[at0000] matches {	-- cADL 1.4 primitive-constraint breadth
+		data matches {
+			ITEM_TREE[at0001] matches {	-- Primitive constraints
+				items cardinality matches {0..*} matches {
+					ELEMENT[at0002] occurrences matches {0..1} matches {	-- Integer constraints
+						-- ADL1.4/master05-cadl.adoc §Constraints on Integer
+						-- L749-782: the list forms, every two-sided interval shape
+						-- and every one-sided interval shape.
+						value matches {
+							DV_COUNT matches {
+								magnitude matches {1000}
+							}
+						}
+						-- `is_in` is the exact synonym of `matches` (§Keywords L47 +
+						-- §Symbols L1326-1327, both folding to `SYM_MATCHES`).
+						null_flavour is_in {
+							DV_CODED_TEXT matches {
+								defining_code matches {[local::at0020]}
+							}
+						}
+					}
+					ELEMENT[at0003] occurrences matches {0..1} matches {	-- Integer intervals
+						value matches {
+							DV_COUNT matches {
+								-- `{0, 5, 8}` list, point interval, closed interval,
+								-- half-open, the postfix and prefix exclusive-lower
+								-- spellings (master04-dadl §Intervals L611-614 vs
+								-- `odin_values.g4`), `+/-`, and `infinity` (L771).
+								magnitude matches {|950..1050|}
+							}
+							DV_ORDINAL matches {
+								value matches {0, 5, 8}
+							}
+						}
+					}
+					ELEMENT[at0004] occurrences matches {0..1} matches {	-- More integer intervals
+						value matches {
+							DV_COUNT matches {
+								magnitude matches {|0..<1000|}
+							}
+						}
+					}
+					ELEMENT[at0005] occurrences matches {0..1} matches {	-- Exclusive-lower intervals
+						value matches {
+							DV_COUNT matches {
+								magnitude matches {|0>..<1000|}
+							}
+						}
+					}
+					ELEMENT[at0006] occurrences matches {0..1} matches {	-- Prefix exclusive-lower
+						value matches {
+							DV_COUNT matches {
+								magnitude matches {|>0..<1000|}
+							}
+						}
+					}
+					ELEMENT[at0007] occurrences matches {0..1} matches {	-- Centre plus/minus
+						value matches {
+							DV_COUNT matches {
+								magnitude matches {|100+/-5|}
+							}
+						}
+					}
+					ELEMENT[at0008] occurrences matches {0..1} matches {	-- Unbounded upper
+						value matches {
+							DV_COUNT matches {
+								-- The chapter's own worked example, L771:
+								-- `rate matches {|0..infinity|}` — "allow 0 - infinity,
+								-- i.e. same as >= 0". `INFINITY` is case-insensitive
+								-- (§Symbols L1349).
+								magnitude matches {|0..INFINITY|}
+							}
+						}
+					}
+					ELEMENT[at0009] occurrences matches {0..1} matches {	-- One-sided integers
+						value matches {
+							DV_COUNT matches {
+								magnitude matches {|<10|}
+							}
+							DV_QUANTITY matches {
+								magnitude matches {|>=10.0|}
+							}
+						}
+					}
+					ELEMENT[at0010] occurrences matches {0..1} matches {	-- Integer with assumed value
+						value matches {
+							DV_COUNT matches {
+								-- §Assumed Values L1016: `length matches {|0..1000|; 200}`.
+								magnitude matches {|0..1000|; 200}
+							}
+						}
+					}
+					ELEMENT[at0011] occurrences matches {0..1} matches {	-- Real constraints
+						-- §Constraints on Real L786-800.
+						value matches {
+							DV_QUANTITY matches {
+								magnitude matches {5.5, 6.0, 6.5}
+							}
+						}
+					}
+					ELEMENT[at0012] occurrences matches {0..1} matches {	-- Real intervals
+						value matches {
+							DV_QUANTITY matches {
+								magnitude matches {|0.0..<1000.0|}
+							}
+						}
+					}
+					ELEMENT[at0013] occurrences matches {0..1} matches {	-- Real plus/minus and assumed
+						value matches {
+							DV_QUANTITY matches {
+								magnitude matches {|80.0+/-12.0|; 80.0}
+							}
+						}
+					}
+					ELEMENT[at0014] occurrences matches {0..1} matches {	-- Real unbounded lower
+						value matches {
+							DV_QUANTITY matches {
+								-- `-infinity` and `*` are the other two unbounded
+								-- endpoint spellings (master04-dadl §Intervals of
+								-- Ordered Primitive Types L625-630).
+								magnitude matches {|-infinity..0.0|}
+							}
+						}
+					}
+					ELEMENT[at0015] occurrences matches {0..1} matches {	-- String list
+						-- §Constraints on String L672-683.
+						value matches {
+							DV_TEXT matches {
+								value matches {"platypus", "kangaroo", "wombat"}
+							}
+						}
+					}
+					ELEMENT[at0016] occurrences matches {0..1} matches {	-- String open list
+						value matches {
+							DV_TEXT matches {
+								-- The list-continuation marker of §Syntax L1244-1249
+								-- (`string_list_value ',' SYM_LIST_CONTINUE`); its only
+								-- normative gloss is the single-datum list indicator
+								-- (master04-dadl §Data of any primitive type L686).
+								value matches {"en", ...}
+							}
+						}
+					}
+					ELEMENT[at0017] occurrences matches {0..1} matches {	-- String with assumed value
+						value matches {
+							DV_TEXT matches {
+								value matches {"lying", "sitting"; "lying"}
+							}
+						}
+					}
+					ELEMENT[at0018] occurrences matches {0..1} matches {	-- Slash-delimited regex
+						-- §Regular Expression L687-702, the `//` delimiter, used as a
+						-- plain string constraint.
+						value matches {
+							DV_TEXT matches {
+								value matches {/[a-z][a-z0-9]*/}
+							}
+						}
+					}
+					ELEMENT[at0019] occurrences matches {0..1} matches {	-- Caret-delimited regex
+						value matches {
+							DV_TEXT matches {
+								-- The chapter's own equivalence pair, L700-701:
+								-- `units ∈ {/km\/h|mi\/h/}` and `units ∈ {^km/h|mi/h^}`
+								-- "are equivalent".
+								value matches {^km/h|mi/h^}
+							}
+						}
+					}
+					ELEMENT[at0021] occurrences matches {0..1} matches {	-- Booleans
+						-- §Constraints on Boolean L804-810: `{True}`, `{False}`,
+						-- `{True, False}`; §Assumed Values L1017 adds the assumed form.
+						value matches {
+							DV_BOOLEAN matches {
+								value matches {True}
+							}
+						}
+					}
+					ELEMENT[at0022] occurrences matches {0..1} matches {	-- Boolean pair with assumed
+						value matches {
+							DV_BOOLEAN matches {
+								value matches {True, False; True}
+							}
+						}
+					}
+					ELEMENT[at0023] occurrences matches {0..1} matches {	-- Character list
+						-- §Constraints on Character L813-825:
+						-- `color_name matches {'r', 'g', 'b'}`.
+						value matches {
+							DV_TEXT matches {
+								value matches {'r', 'g', 'b'}
+							}
+						}
+					}
+					ELEMENT[at0024] occurrences matches {0..1} matches {	-- Single character with assumed
+						value matches {
+							DV_TEXT matches {
+								value matches {'r', 'g'; 'r'}
+							}
+						}
+					}
+					ELEMENT[at0025] occurrences matches {0..1} matches {	-- Character class regex
+						-- §Constraints on Character L827-835: a single-character
+						-- regular-expression character class.
+						value matches {
+							DV_TEXT matches {
+								value matches {/[rgbcmyk]/}
+							}
+						}
+					}
+					ELEMENT[at0026] ∈ {	-- Term code list
+						-- `∈` is the symbolic rendering of `matches` (§Keywords, the
+						-- symbol-equivalence table L57-64).
+						value ∈ {
+							DV_CODED_TEXT ∈ {
+								defining_code ∈ {
+									[local::
+									at0027,
+									at0028;
+									at0027]
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"cADL 1.4 primitive-constraint breadth">
+					description = <"Accepting fixture: every primitive constraint form of master05.">
+				>
+				["at0001"] = <
+					text = <"Primitive constraints">
+					description = <"The tree holding the primitive constraints.">
+				>
+				["at0002"] = <
+					text = <"Integer constraints">
+					description = <"A fixed integer value.">
+				>
+				["at0003"] = <
+					text = <"Integer intervals">
+					description = <"A two-sided integer interval and an integer list.">
+				>
+				["at0004"] = <
+					text = <"More integer intervals">
+					description = <"A half-open integer interval.">
+				>
+				["at0005"] = <
+					text = <"Exclusive-lower intervals">
+					description = <"The postfix exclusive-lower interval spelling.">
+				>
+				["at0006"] = <
+					text = <"Prefix exclusive-lower">
+					description = <"The prefix exclusive-lower interval spelling.">
+				>
+				["at0007"] = <
+					text = <"Centre plus/minus">
+					description = <"A centre plus-or-minus interval.">
+				>
+				["at0008"] = <
+					text = <"Unbounded upper">
+					description = <"An interval whose upper endpoint is infinity.">
+				>
+				["at0009"] = <
+					text = <"One-sided integers">
+					description = <"One-sided integer and real intervals.">
+				>
+				["at0010"] = <
+					text = <"Integer with assumed value">
+					description = <"An integer interval carrying an assumed value.">
+				>
+				["at0011"] = <
+					text = <"Real constraints">
+					description = <"A list of real values.">
+				>
+				["at0012"] = <
+					text = <"Real intervals">
+					description = <"A half-open real interval.">
+				>
+				["at0013"] = <
+					text = <"Real plus/minus and assumed">
+					description = <"A real plus-or-minus interval with an assumed value.">
+				>
+				["at0014"] = <
+					text = <"Real unbounded lower">
+					description = <"An interval whose lower endpoint is minus infinity.">
+				>
+				["at0015"] = <
+					text = <"String list">
+					description = <"A list of fixed strings.">
+				>
+				["at0016"] = <
+					text = <"String open list">
+					description = <"A string list written with the continuation marker.">
+				>
+				["at0017"] = <
+					text = <"String with assumed value">
+					description = <"A string list carrying an assumed value.">
+				>
+				["at0018"] = <
+					text = <"Slash-delimited regex">
+					description = <"A regular expression in the slash delimiters.">
+				>
+				["at0019"] = <
+					text = <"Caret-delimited regex">
+					description = <"A regular expression in the caret delimiters.">
+				>
+				["at0020"] = <
+					text = <"Null flavour">
+					description = <"The null-flavour code.">
+				>
+				["at0021"] = <
+					text = <"Booleans">
+					description = <"A single boolean value.">
+				>
+				["at0022"] = <
+					text = <"Boolean pair with assumed">
+					description = <"Both boolean values with an assumed value.">
+				>
+				["at0023"] = <
+					text = <"Character list">
+					description = <"A list of single-character values.">
+				>
+				["at0024"] = <
+					text = <"Single character with assumed">
+					description = <"A character list carrying an assumed value.">
+				>
+				["at0025"] = <
+					text = <"Character class regex">
+					description = <"A single-character regular-expression class.">
+				>
+				["at0026"] = <
+					text = <"Term code list">
+					description = <"A listed terminology constraint with an assumed code.">
+				>
+				["at0027"] = <
+					text = <"Lying">
+					description = <"Lying position.">
+				>
+				["at0028"] = <
+					text = <"Sitting">
+					description = <"Sitting position.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-OBSERVATION.cadl_breadth_structure.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-OBSERVATION.cadl_breadth_structure.v1.adl
@@ -1,0 +1,199 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-OBSERVATION.cadl_breadth_structure.v1
+
+concept
+	[at0000]	-- cADL 1.4 structural breadth
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	other_details = <
+		["regression"] = <"PASS">
+	>
+	lifecycle_state = <"AuthorDraft">
+
+definition
+	OBSERVATION[at0000] matches {	-- cADL 1.4 structural breadth
+		-- EXISTENCE is an ATTRIBUTE modifier (`c_attr_head : V_ATTRIBUTE_IDENTIFIER
+		-- c_existence …`, ADL1.4/master05-cadl.adoc §Syntax L1111-1114); both
+		-- spellings of `existence_spec` (L1137-1140) — the single value and the
+		-- two-value range — appear below, in all four legal combinations.
+		protocol existence matches {0..1} matches {
+			ITEM_TREE[at0001] matches {	-- Protocol
+				items cardinality matches {0..*} matches {
+					ELEMENT[at0002] occurrences matches {1} matches {	-- Device
+						value existence matches {1..1} matches {
+							DV_TEXT matches {*}
+						}
+					}
+					ELEMENT[at0003] occurrences matches {0..1} matches {	-- Site
+						value existence matches {1} matches {
+							DV_TEXT matches {*}
+						}
+						null_flavour existence matches {0} matches {
+							DV_CODED_TEXT matches {*}
+						}
+					}
+					ELEMENT[at0013] occurrences matches {0..1} matches {	-- Comment
+						value existence matches {0..0} matches {
+							DV_TEXT matches {*}
+						}
+					}
+				}
+			}
+		}
+		data matches {
+			HISTORY[at0004] matches {	-- History
+				events cardinality matches {1..*; unordered} matches {
+					-- OCCURRENCES is an OBJECT modifier, and `multiplicity`
+					-- (§Syntax L1163-1171) has four spellings — `{n}`, `{n..m}`,
+					-- `{n..*}` and the bare `{*}` of `cardinality_limit_value`.
+					EVENT[at0005] occurrences matches {1} matches {	-- Fixed-occurrence event
+						data matches {
+							ITEM_TREE[at0006] matches {	-- Event data
+								-- Cardinality with TWO modifiers, in both of the
+								-- orderings `cardinality_spec` admits (§Syntax
+								-- L1147-1156: `ordered;unique` … `unique;unordered`).
+								items cardinality matches {0..*; ordered; unique} matches {
+									ELEMENT[at0007] occurrences matches {0..*} matches {	-- Any number
+										value matches {*}
+									}
+								}
+							}
+						}
+					}
+					EVENT[at0008] occurrences matches {*} matches {	-- Bare-star occurrences
+						data matches {
+							ITEM_TREE[at0009] matches {	-- Second event data
+								items cardinality matches {0..*; unique; unordered} matches {
+									-- One attribute carrying several DIFFERENT object
+									-- kinds: `c_attr_values` is a list of `c_object`,
+									-- whose alternatives include the complex object, the
+									-- internal reference and the archetype slot alike
+									-- (§Syntax L1056-1063 + L1116-1120).
+									ELEMENT[at0010] occurrences matches {0..1} matches {	-- Mixed-structure element
+										value matches {
+											-- A generic (parameterised) type name —
+											-- §Information Model Identifiers L116: "A
+											-- generic type name (including nested forms)
+											-- additionally may include commas, angle
+											-- brackets and spaces".
+											DV_INTERVAL<DV_QUANTITY> matches {*}
+										}
+										null_flavour matches {
+											-- A BARE (anonymous) archetype slot: §Archetype
+											-- Slots writes the un-bracketed form in its own
+											-- normative examples, with both an `include` and
+											-- an `exclude` list (`c_includes`/`c_excludes`,
+											-- §Syntax L1122-1130). A specific `include`
+											-- pairs only with an empty or match-any
+											-- `exclude` (AOM2/master04.5 §`ARCHETYPE_SLOT`
+											-- VDSEV), so the exclusion here is the any-form.
+											allow_archetype CLUSTER occurrences matches {0..1} matches {
+												include
+													archetype_id/value matches {/openEHR-EHR-CLUSTER\.exam\.v1/}
+												exclude
+													archetype_id/value matches {/.*/}
+											}
+										}
+									}
+									-- `use_node` WITH an identifying bracket and an
+									-- overriding occurrences — the §Internal References
+									-- L528 spelling.
+									use_node ELEMENT[at0012] occurrences matches {0..2} /data[at0004]/events[at0005]/data[at0006]/items[at0007]
+									-- An IDENTIFIED archetype slot (§cADL node types).
+									allow_archetype CLUSTER[at0011] occurrences matches {0..*} matches {	-- Identified slot
+										include
+											archetype_id/value matches {/openEHR-EHR-CLUSTER\.device\.v1/}
+									}
+								}
+							}
+						}
+					}
+					EVENT[at0014] occurrences matches {0..1} matches {	-- Inheriting event
+						data matches {
+							-- `use_node` WITHOUT occurrences: §Internal References L515
+							-- — "if no `occurrences` is mentioned, the value of the
+							-- `occurrences` is set to that of the referenced node".
+							use_node ITEM_TREE /data[at0004]/events[at0005]/data[at0006]
+						}
+					}
+				}
+			}
+		}
+		-- The `matches {*}` == "any" attribute body (`c_any : '*'`, §Syntax
+		-- L1098-1100, also used on `value` above).
+		state matches {*}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"cADL 1.4 structural breadth">
+					description = <"Accepting fixture: existence/occurrences/cardinality/use_node/slot forms of master05.">
+				>
+				["at0001"] = <
+					text = <"Protocol">
+					description = <"The protocol tree.">
+				>
+				["at0002"] = <
+					text = <"Device">
+					description = <"The measuring device.">
+				>
+				["at0003"] = <
+					text = <"Site">
+					description = <"The measurement site.">
+				>
+				["at0004"] = <
+					text = <"History">
+					description = <"The event history.">
+				>
+				["at0005"] = <
+					text = <"Fixed-occurrence event">
+					description = <"An event that must occur exactly once.">
+				>
+				["at0006"] = <
+					text = <"Event data">
+					description = <"The data tree of the first event.">
+				>
+				["at0007"] = <
+					text = <"Any number">
+					description = <"An element with unbounded occurrences.">
+				>
+				["at0008"] = <
+					text = <"Bare-star occurrences">
+					description = <"An event whose occurrences are the bare star form.">
+				>
+				["at0009"] = <
+					text = <"Second event data">
+					description = <"The data tree of the second event.">
+				>
+				["at0010"] = <
+					text = <"Mixed-structure element">
+					description = <"An element sharing its attribute with a proxy and a slot.">
+				>
+				["at0011"] = <
+					text = <"Identified slot">
+					description = <"An archetype slot carrying its own node id.">
+				>
+				["at0012"] = <
+					text = <"Re-used element">
+					description = <"An internal reference to the first event's element.">
+				>
+				["at0013"] = <
+					text = <"Comment">
+					description = <"An element whose value existence is constrained away.">
+				>
+				["at0014"] = <
+					text = <"Inheriting event">
+					description = <"An event whose internal reference inherits its occurrences.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/validation_adl14.rs
+++ b/crates/openehr-adl/tests/validation_adl14.rs
@@ -102,3 +102,108 @@ fn undefined_node_code_raises_vatdf() {
 fn unparseable_source_is_a_parse_error() {
     assert!(validate_source_phase1_adl14("this is not an archetype").is_err());
 }
+
+// ── the one 1.4 rule that needs a reference model: VUNT ──────────────────────
+
+/// A 1.4 archetype whose `use_node` names `rm_type` and points at an
+/// `ELEMENT[at0002]` node. `master05-cadl.adoc` §Internal References L510-513:
+/// the type named must be the same as, or a super-type of, the referenced
+/// node's type.
+fn use_node_archetype(rm_type: &str) -> String {
+    format!(
+        "archetype (adl_version=1.4)
+\topenEHR-EHR-CLUSTER.use_node14.v1
+
+concept
+\t[at0000]\t-- Use node 14
+language
+\toriginal_language = <[ISO_639-1::en]>
+description
+\tlifecycle_state = <\"Initial\">
+definition
+\tCLUSTER[at0000] matches {{
+\t\titems cardinality matches {{0..*}} matches {{
+\t\t\tCLUSTER[at0001] occurrences matches {{0..1}} matches {{
+\t\t\t\titems cardinality matches {{0..*}} matches {{
+\t\t\t\t\tELEMENT[at0002] occurrences matches {{0..1}} matches {{
+\t\t\t\t\t\tvalue matches {{
+\t\t\t\t\t\t\tDV_TEXT matches {{*}}
+\t\t\t\t\t\t}}
+\t\t\t\t\t}}
+\t\t\t\t}}
+\t\t\t}}
+\t\t\tuse_node {rm_type}[at0003] occurrences matches {{0..1}} /items[at0001]/items[at0002]
+\t\t}}
+\t}}
+ontology
+\tterm_definitions = <
+\t\t[\"en\"] = <
+\t\t\titems = <
+\t\t\t\t[\"at0000\"] = <
+\t\t\t\t\ttext = <\"Use node 14\">
+\t\t\t\t\tdescription = <\"A 1.4 archetype with an internal reference.\">
+\t\t\t\t>
+\t\t\t\t[\"at0001\"] = <
+\t\t\t\t\ttext = <\"Group\">
+\t\t\t\t\tdescription = <\"A group of items.\">
+\t\t\t\t>
+\t\t\t\t[\"at0002\"] = <
+\t\t\t\t\ttext = <\"Item\">
+\t\t\t\t\tdescription = <\"The referenced item.\">
+\t\t\t\t>
+\t\t\t\t[\"at0003\"] = <
+\t\t\t\t\ttext = <\"Re-used item\">
+\t\t\t\t\tdescription = <\"The internal reference.\">
+\t\t\t\t>
+\t\t\t>
+\t\t>
+\t>
+"
+    )
+}
+
+fn adl14_codes(src: &str) -> Vec<String> {
+    let issues = openehr_adl::validate::validate_source_adl14(
+        src,
+        &openehr_adl::validate::rm::ProductionRmModel,
+    )
+    .expect("1.4 source parses");
+    issues
+        .iter()
+        .filter(|i| i.severity == Severity::Error)
+        .map(|i| i.code.mnemonic().to_owned())
+        .collect()
+}
+
+#[test]
+fn use_node_type_conformance_is_reachable_for_a_14_source() {
+    // VUNT is a rule of the ADL 1.4 formalism itself (`master05-cadl.adoc`
+    // §Internal References L512-513), so a 1.4 source must be able to fail it —
+    // which the phase-1-only entry point can never report, because deciding
+    // super-type-hood is "according to the reference model".
+    let bad = use_node_archetype("CLUSTER"); // CLUSTER is not a super-type of ELEMENT
+    assert!(
+        adl14_codes(&bad).contains(&"VUNT".to_owned()),
+        "a use_node naming a non-super-type must raise VUNT, got {:?}",
+        adl14_codes(&bad)
+    );
+    // The phase-1-only entry point is the contrast: it cannot see the rule.
+    assert!(
+        !errors(&bad).contains(&"VUNT".to_owned()),
+        "phase 1 has no reference model and must not claim VUNT"
+    );
+}
+
+#[test]
+fn use_node_naming_the_same_or_a_super_type_is_clean() {
+    // The same type, and the super-type the chapter's own example relies on
+    // ("a use_node reference to such a node can legally mention the parent
+    // type", L510) — `ITEM` is the RM parent of `ELEMENT`.
+    for ty in ["ELEMENT", "ITEM"] {
+        let codes = adl14_codes(&use_node_archetype(ty));
+        assert!(
+            codes.is_empty(),
+            "use_node {ty} must validate clean, got {codes:?}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #1308.

The syntax half of the #767 cADL walk (sibling of PR #1310). Everything spec-cited; the negated-matches adjudication (no normative production admits them — typed rejects everywhere), the C_CHARACTER absence (verified in all four vendored AM BMMs), and the list_open NOTE are the review-worthy calls. Two latent defects surfaced and fixed: the inline-dADL scanner truncating on one-sided intervals (the chapter's own §Symbols hazard warning — two CKM archetypes were being rejected), and the postfix exclusive-lower interval form. One follow-up filed separately (VDFAI false-positive on domain_concept slot regexes).

Gates: workspace clippy --all-features ZERO warnings; nextest 273/273 (lang+adl) + 709/709 (ehrbase). Changelog entries included.