### PR TITLE
fix(adl-validate): VDFAI scope — archetype_id-targeted assertions only

### DIFF
--- a/crates/openehr-adl/src/validate/phase1.rs
+++ b/crates/openehr-adl/src/validate/phase1.rs
@@ -1574,6 +1574,19 @@ fn assertion_constraint_body(text: &str) -> Option<&str> {
 fn assertion_archetype_ids(a: &Assertion) -> Vec<String> {
     // Slot assertions constrain `archetype_id/value matches {/regex/}`; the
     // regex, when it is a literal id (no meta-characters), is itself the id.
+    // VDFAI's subject is the ARCHETYPE IDENTIFIER (ADL1.4 master05 §Archetype
+    // Slots) — an assertion targeting another property (`domain_concept`,
+    // `short_concept_name`, a path) constrains something that is not an
+    // archetype id, so extracting its regex as one is a false positive (#767
+    // audit: `domain_concept matches {/medication\.v1/}` yielded the bogus
+    // id `medication.v1`).
+    let targets_archetype_id = a
+        .string_expression
+        .as_deref()
+        .is_some_and(|s| s.trim_start().starts_with("archetype_id"));
+    if !targets_archetype_id {
+        return Vec::new();
+    }
     let Some(body) = a
         .string_expression
         .as_deref()

--- a/crates/openehr-adl/tests/adl14_cadl_gates.rs
+++ b/crates/openehr-adl/tests/adl14_cadl_gates.rs
@@ -164,6 +164,13 @@ const FIXTURES: &[(&str, Expect)] = &[
     // ── 1.4 keywords that must stay accepted ──────────────────────────────
     ("openEHR-EHR-CLUSTER.sibling_order.v1.adl", Expect::Pass),
     ("openEHR-EHR-CLUSTER.cadl_keyword_case.v1.adl", Expect::Pass),
+    // A slot assertion targeting domain_concept: its literal regex is NOT an
+    // archetype id, so VDFAI must not fire (master05 §Archetype Slots; the
+    // VDFAI subject is the archetype identifier).
+    (
+        "openEHR-EHR-SECTION.slot_domain_concept_regex.v1.adl",
+        Expect::Pass,
+    ),
     // ── the master05 breadth trio (every construct of the chapter) ────────
     (
         "openEHR-EHR-OBSERVATION.cadl_breadth_structure.v1.adl",

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-SECTION.slot_domain_concept_regex.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-SECTION.slot_domain_concept_regex.v1.adl
@@ -1,0 +1,46 @@
+archetype (adl_version=1.4)
+    openEHR-EHR-SECTION.slot_domain_concept_regex.v1
+
+concept
+    [at0000]
+
+language
+    original_language = <[ISO_639-1::en]>
+
+description
+    original_author = <
+        ["name"] = <"cadl audit">
+    >
+    details = <
+        ["en"] = <
+            language = <[ISO_639-1::en]>
+            purpose = <"A slot assertion targeting domain_concept, not archetype_id: its literal regex must NOT be treated as an archetype id (VDFAI false positive, ADL1.4 master05 §Archetype Slots).">
+        >
+    >
+    lifecycle_state = <"unmanaged">
+
+definition
+    SECTION[at0000] matches {
+        items cardinality matches {0..*; unordered} matches {
+            allow_archetype OBSERVATION[at0001] occurrences matches {0..1} matches {
+                include
+                    domain_concept matches {/medication\.v1/}
+            }
+        }
+    }
+
+ontology
+    term_definitions = <
+        ["en"] = <
+            items = <
+                ["at0000"] = <
+                    text = <"section">
+                    description = <"section">
+                >
+                ["at0001"] = <
+                    text = <"slot">
+                    description = <"a domain_concept-constrained slot">
+                >
+            >
+        >
+    >


### PR DESCRIPTION
Closes #1313.

The #767 audit's last finding: `assertion_archetype_ids` extracted an 'id' from any literal slot regex regardless of the targeted property — a `domain_concept` assertion false-fired VDFAI on a valid archetype. Extraction now requires an `archetype_id[/value]` target (master05 §Archetype Slots), pinned by a PASS fixture. `no-changelog`: validation false-positive fix on the artefact-ingestion surface (recorded in the #767 close narrative).

Gates: clippy clean; nextest 273/273 (lang+adl); the CKM parse gate green.