### PR TITLE
fix(adl-rules): accept the ADL 1.4 '<>' inequality and '∃ /path' existence forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **ADL 1.4 assertion expressions now accept the chapter's full operator
+  set**: the ADL 1.4 inequality spelling `<>` and the symbolic existential
+  quantifier `∃` applied to a path (equivalent to the `exists` keyword per
+  the assertion-language symbol table) both parse in `invariant`/`rules`
+  sections instead of being rejected.
+
 - **A server-side failure of the password-verification task no longer
   masquerades as `401 Invalid credentials`**: if the blocking Argon2
   verification task itself fails (panic/cancellation), the API now returns

--- a/crates/openehr-adl/tests/it/adl14_assertions.rs
+++ b/crates/openehr-adl/tests/it/adl14_assertions.rs
@@ -1,0 +1,78 @@
+//! The ADL 1.4 assertion sub-language operator/symbol matrix
+//! (`ADL1.4/master06-assertions.adoc`): every operator the chapter defines —
+//! textual and symbolic renderings alike — parses in a 1.4 `invariant`
+//! section, and the reserved-but-undefined forms reject loudly.
+//!
+//! The chapter's own yacc omits `%` (prose §Arithmetic Operators defines it)
+//! and gives `for_all` no production at all (it is only a listed keyword) —
+//! both upstream defects recorded in the #768 audit; the prose-defined `%`
+//! parses, the production-less `for_all`-over-paths stays a typed reject.
+
+use openehr_adl::assemble::parse_artefact_adl14;
+
+/// Wrap one invariant line in a minimal, valid 1.4 archetype.
+fn archetype_with_invariant(invariant: &str) -> String {
+    format!(
+        "archetype (adl_version=1.4)\n    openEHR-EHR-OBSERVATION.inv.v1\n\nconcept\n    [at0000]\n\n\
+         language\n    original_language = <[ISO_639-1::en]>\n\ndescription\n    original_author = <\n        [\"name\"] = <\"t\">\n    >\n    \
+         details = <\n        [\"en\"] = <\n            language = <[ISO_639-1::en]>\n            purpose = <\"t\">\n        >\n    >\n    \
+         lifecycle_state = <\"unmanaged\">\n\ndefinition\n    OBSERVATION[at0000] matches {{\n        data matches {{\n            HISTORY[at0001] matches {{*}}\n        }}\n    }}\n\n\
+         invariant\n    {invariant}\n\nontology\n    term_definitions = <\n        [\"en\"] = <\n            items = <\n                [\"at0000\"] = <\n                    text = <\"t\">\n                    description = <\"t\">\n                >\n                [\"at0001\"] = <\n                    text = <\"h\">\n                    description = <\"h\">\n                >\n            >\n        >\n    >\n"
+    )
+}
+
+/// Every chapter-defined assertion form parses (§Keywords, §Operators,
+/// §Operands — textual and symbolic renderings).
+#[test]
+fn chapter_operator_matrix_parses() {
+    let accepted = [
+        // tagged assertion + arithmetic (§Overview's own example)
+        "validity: /speed[at0002]/kilometres/magnitude = /speed[at0004]/miles/magnitude * 1.6",
+        // arithmetic operators (§Arithmetic Operators) — incl. the
+        // prose-defined `%` the chapter yacc omits, and `^`
+        "/a[at0001]/b % 2 = 0",
+        "/a[at0001]/b ^ 2 > 4",
+        "/a[at0001]/b + 1 - 2 * 3 / 4 < 9",
+        // equality (§Equality Operators) — both `=` and the 1.4 `<>`
+        "/a[at0001]/b <> 3",
+        // relational (§Relational Operators)
+        "/a[at0001]/b < 1 and /a[at0001]/b <= 1 and /a[at0001]/b > 0 and /a[at0001]/b >= 0",
+        // boolean operators + quantifier keyword `exists` (§Boolean
+        // Operators, §Quantifiers)
+        "exists /data[at0001]",
+        "True or False",
+        "not (/data[at0001]/origin/value matches {\"x\"})",
+        "/a[at0001]/b > 3 and /a[at0001]/c <= 2 xor True implies False",
+        // symbolic renderings (§Keywords table): ∃ over a path ≡ exists,
+        // ∧ ∨ ¬ ~ ∈
+        "\u{2203} /data[at0001]",
+        "True \u{2227} False",
+        "True \u{2228} False",
+        "\u{ac} True",
+        "~ True",
+        "/a[at0001]/b \u{2208} {1, 2}",
+        "/a[at0001]/b is_in {1, 2}",
+        // `not`/`~` as a prefix on other operators (§Keywords: applies to
+        // all operators except for_all)
+        "~ (/a[at0001]/b matches {3})",
+    ];
+    for invariant in accepted {
+        let text = archetype_with_invariant(invariant);
+        assert!(
+            parse_artefact_adl14(&text).is_ok(),
+            "chapter form must parse: {invariant}"
+        );
+    }
+}
+
+/// `for_all` is a listed keyword the chapter's own grammar gives NO
+/// production (and the prose exempts it from `not`-prefixing) — a
+/// path-quantified spelling has no defined 1.4 form and rejects loudly.
+#[test]
+fn for_all_over_paths_stays_a_typed_reject() {
+    let text = archetype_with_invariant("for_all /data[at0001]/events : /a[at0001]/b > 0");
+    assert!(
+        parse_artefact_adl14(&text).is_err(),
+        "a production-less form must not silently parse"
+    );
+}

--- a/crates/openehr-adl/tests/it/main.rs
+++ b/crates/openehr-adl/tests/it/main.rs
@@ -6,6 +6,7 @@
 //! One binary per crate, split into topic modules
 //! (`.claude/rules/testing.md` §One integration-test binary per crate).
 
+mod adl14_assertions;
 mod adl14_cadl_gates;
 mod adl14_cnf_fixture_slot;
 mod adl14_conversion;

--- a/crates/openehr-lang/src/bel/lexer.rs
+++ b/crates/openehr-lang/src/bel/lexer.rs
@@ -193,9 +193,12 @@ pub(crate) enum Token {
     /// `@` (terminology binding separator in `[ac1@terminology]`).
     #[token("@")]
     At,
-    /// `/=` / `!=` / `≠` (`SYM_NE`).
+    /// `/=` / `!=` / `≠` (`SYM_NE`) — plus the ADL 1.4 spelling `<>`
+    /// (ADL1.4 `master06-assertions.adoc` §Equality Operators and its yacc
+    /// `SYM_NE`; a superset for the BEL callers).
     #[token("/=")]
     #[token("!=")]
+    #[token("<>")]
     #[token("\u{2260}")]
     Ne,
     /// `=` (`SYM_EQ`).

--- a/crates/openehr-lang/src/bel/parser.rs
+++ b/crates/openehr-lang/src/bel/parser.rs
@@ -374,8 +374,18 @@ impl<'a, 'b, B: BelBuilder> Parser<'a, 'b, B> {
 
     /// `there_exists_expr` — existential quantification (mapped to the same
     /// quantifier node as `for_all` with an `exists` operator via the builder).
+    ///
+    /// The `∃` symbol is ALSO the symbolic rendering of the path-existence
+    /// operator in ADL 1.4 assertions (ADL1.4 `master06-assertions.adoc`
+    /// §Keywords equates `exists` ↔ `∃`), whose operand is a path, not a
+    /// `$variable` binding — so a non-variable operand dispatches to the
+    /// same unary the `exists` keyword builds.
     fn parse_there_exists(&mut self) -> Result<B::Expr, BelError> {
         self.pos += 1; // there_exists
+        if !matches!(self.peek(), Some(Token::Variable(_))) {
+            let operand = self.parse_ref_leaf()?;
+            return Ok(self.builder.unary(kind("exists"), "exists", operand));
+        }
         let var = self.expect_variable_name()?;
         if !self.eat(&Token::Colon) && !self.eat(&Token::In) {
             return self.err("expected ':' or 'in' after the there_exists variable");


### PR DESCRIPTION
Closes #1319 (sub-issue of #768, the ADL1.4 ch.6 Assertions audit, v3.15.0 AM program).

## What

ADL1.4 `master06-assertions.adoc` defines `<>` as the assertion inequality operator (§Equality Operators; yacc `SYM_NE`) and its keyword table equates the `∃` symbol with the textual `exists` path-existence operator. Both forms were rejected by the shared BEL front end (`openehr-lang::bel`) that `openehr-adl` parses `invariant`/`rules` assertions with.

- `bel/lexer.rs`: `<>` folds into the `Ne` token beside `/=`, `!=`, `≠`.
- `bel/parser.rs`: a `∃` whose operand is not a `$variable` binding builds the same exists-path unary as the textual keyword; the variable-bound `there_exists` quantifier form is unchanged.

## Tests

New `openehr-adl` integration module `adl14_assertions` (in the one-binary `tests/it` layout) pins the whole chapter operator matrix — arithmetic incl. the prose-defined `%`, equality/relational incl. `<>`, boolean keywords + symbols (∧ ∨ ¬ ~), `exists`/`∃`, `is_in`/`∈`, `not`/`~` prefixing — and keeps the production-less `for_all`-over-paths spelling a typed reject (the chapter's yacc gives `for_all` no production; upstream defect recorded in the #768 audit).

## Gates

- `cargo fmt --all` clean
- `cargo clippy --workspace --exclude ehrbase-admin-ui --all-targets --all-features` — zero warnings (exact CI flags)
- `cargo nextest run -p openehr-lang -p openehr-adl` — 275/275 pass