### PR TITLE
fix(adl-rules): accept movable '//' path patterns and single-segment relative paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ workflow refuses a tag that has no matching section here.
   quantifier `∃` applied to a path (equivalent to the `exists` keyword per
   the assertion-language symbol table) both parse in `invariant`/`rules`
   sections instead of being rejected.
+- **ADL 1.4 assertions now accept every path form the ADL paths grammar
+  defines**: movable path patterns (leading `//`) and single-segment
+  relative paths with a node predicate (`items[at0001]`) parse instead of
+  being rejected; absolute/relative multi-segment paths and the
+  position/meaning/at-code predicate forms were already accepted.
 
 - **A server-side failure of the password-verification task no longer
   masquerades as `401 Invalid credentials`**: if the blocking Argon2

--- a/crates/openehr-adl/tests/it/adl14_assertions.rs
+++ b/crates/openehr-adl/tests/it/adl14_assertions.rs
@@ -76,3 +76,34 @@ fn for_all_over_paths_stays_a_typed_reject() {
         "a production-less form must not silently parse"
     );
 }
+
+/// Every path form the paths chapter defines parses as an assertion operand
+/// (`ADL1.4/master07-paths.adoc`): absolute and relative paths (incl. the
+/// yacc's single-segment `relative_path: path_segment`), movable `//` path
+/// patterns (§Grammar `movable_path: SYM_MOVABLE_LEADER relative_path`), and
+/// the three §Relationship-with-Xpath predicate forms — position (`[1]`),
+/// meaning (`[systolic]`), node id (`[at0001]`, incl. dotted specialised
+/// codes).
+#[test]
+fn chapter7_path_forms_parse() {
+    let accepted = [
+        // absolute, at-code predicates (incl. specialised/dotted codes)
+        "exists /data[at0001.1]/items[at0001-2]",
+        // position + meaning predicates ("legal for cADL structures")
+        "/data[at0001]/items[1]/value/magnitude > 0",
+        "/data[at0001]/items[systolic]/value/magnitude > 0",
+        // relative paths: multi-segment and the single-segment yacc form
+        "items[at0001]/value/magnitude > 0",
+        "exists items[at0001]",
+        // movable path patterns (leading '//')
+        "exists //items[at0001]",
+        "//items[at0001]/value/magnitude > 0",
+    ];
+    for invariant in accepted {
+        let text = archetype_with_invariant(invariant);
+        assert!(
+            parse_artefact_adl14(&text).is_ok(),
+            "chapter path form must parse: {invariant}"
+        );
+    }
+}

--- a/crates/openehr-lang/src/bel/lexer.rs
+++ b/crates/openehr-lang/src/bel/lexer.rs
@@ -136,10 +136,16 @@ pub(crate) enum Token {
     /// `$name` (`VARIABLE_ID`).
     #[regex(r"\$[a-z][a-zA-Z0-9_]*", |lex| lex.slice().to_owned())]
     Variable(String),
-    /// An ADL path (`ADL_PATH`): absolute `(/seg)+` or relative `seg(/seg)+`,
-    /// each segment `ALPHA_LC_ID ('[' predicate ']')?`.
+    /// An ADL path (`ADL_PATH`), each segment `ALPHA_LC_ID ('[' predicate
+    /// ']')?`: a movable path pattern `//seg(/seg)*` (ADL1.4
+    /// `master07-paths.adoc` §Grammar `movable_path: SYM_MOVABLE_LEADER
+    /// relative_path`), absolute `(/seg)+`, or relative `seg(/seg)*` — a
+    /// single-segment relative path needs its `[predicate]` to be a path
+    /// token (the same yacc's `relative_path: path_segment`; a bare
+    /// identifier stays a name reference, which the parser resolves the
+    /// same way).
     #[regex(
-        r"(/[a-z][a-zA-Z0-9_]*(\[[^\]\r\n]*\])?)+|[a-z][a-zA-Z0-9_]*(\[[^\]\r\n]*\])?(/[a-z][a-zA-Z0-9_]*(\[[^\]\r\n]*\])?)+",
+        r"//?[a-z][a-zA-Z0-9_]*(\[[^\]\r\n]*\])?(/[a-z][a-zA-Z0-9_]*(\[[^\]\r\n]*\])?)*|[a-z][a-zA-Z0-9_]*(\[[^\]\r\n]*\])?(/[a-z][a-zA-Z0-9_]*(\[[^\]\r\n]*\])?)+|[a-z][a-zA-Z0-9_]*\[[^\]\r\n]*\]",
         |lex| lex.slice().to_owned()
     )]
     Path(String),


### PR DESCRIPTION
Closes #1321 (sub-issue of #769, the ADL1.4 ch.7 Paths audit, v3.15.0 AM program).

## What

`ADL1.4/master07-paths.adoc` defines movable path patterns (`movable_path: SYM_MOVABLE_LEADER relative_path`; §Overview: 'Path patterns are indicated with a leading double slash (\"//\") as in Xpath') and allows single-segment relative paths (`relative_path: path_segment` — the chapter's own `items[1]`/`items[systolic]`/`items[at0001]` examples are 'legal for cADL structures'). The shared BEL `Path` token accepted only absolute and ≥2-segment relative forms, so both were rejected in `invariant`/`rules` assertions.

- `openehr-lang` `bel/lexer.rs`: the `Path` regex gains the `//`-leading movable alternative (token slice kept verbatim) and the predicated single-segment relative form. A bare identifier stays a name reference (the parser resolves it identically); unpredicated multi-segment relative paths (slot assertions' `archetype_id/value`) unchanged.

## Tests

`adl14_assertions::chapter7_path_forms_parse` pins the whole master07 form matrix: absolute (incl. dotted specialised codes), relative multi- and single-segment, movable `//`, and the position/meaning/at-code predicate forms.

## Gates

- `cargo fmt --all` clean
- `cargo clippy --workspace --exclude ehrbase-admin-ui --all-targets --all-features` — zero warnings (exact CI flags)
- `cargo nextest run -p openehr-lang -p openehr-adl` — 276/276 pass