### PR TITLE
fix(openehr-adl): raise VDFPT for unresolvable ADL 1.4 use_node target paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ workflow refuses a tag that has no matching section here.
   relative paths with a node predicate (`items[at0001]`) parse instead of
   being rejected; absolute/relative multi-segment paths and the
   position/meaning/at-code predicate forms were already accepted.
+- **ADL 1.4 `use_node` internal references with a target path that does not
+  resolve within the definition are now reported as a `VDFPT` validation
+  error** (path validity in definition) instead of passing silently; a
+  resolving target stays clean.
 
 - **A server-side failure of the password-verification task no longer
   masquerades as `401 Invalid credentials`**: if the blocking Argon2

--- a/crates/openehr-adl/src/validate/mod.rs
+++ b/crates/openehr-adl/src/validate/mod.rs
@@ -239,6 +239,12 @@ pub enum ValidationCode {
     /// VDFAI — archetype id validity in slot definition (`master04.5`
     /// §`ARCHETYPE_SLOT`).
     Vdfai,
+    /// VDFPT — path validity in definition: any path mentioned in the
+    /// definition section must be valid syntactically and valid with respect
+    /// to the hierarchical structure of the definition section (ADL 1.4 only;
+    /// `ADL1.4/master08-adl.adoc` §Definition Section validity rules — the
+    /// AOM2 mirror is [`ValidationCode::Vunp`] on the flat form).
+    Vdfpt,
     /// VOBAV — object node assumed value validity (`master04.5`
     /// §`C_PRIMITIVE_OBJECT`).
     Vobav,
@@ -417,6 +423,7 @@ impl ValidationCode {
             Self::Vcosu => "VCOSU",
             Self::Vcatu => "VCATU",
             Self::Vdfai => "VDFAI",
+            Self::Vdfpt => "VDFPT",
             Self::Vobav => "VOBAV",
             Self::Vrmvp => "VRMVP",
             Self::Vrmvav => "VRMVAV",
@@ -713,6 +720,10 @@ pub fn validate_source_phase1(
 ///   `ADL1.4/master09-customising_adl.adoc` §Custom Syntax is decomposed into its
 ///   codes (assumed code included) so definedness is judged per code; external
 ///   terminology codes are not archetype terms and are excluded.
+/// - **VDFPT** — `use_node` target paths must resolve within the definition
+///   section (`ADL1.4/master08-adl.adoc` §Definition Section; a 1.4 artefact
+///   is standalone, so its own assembled definition is the resolution target —
+///   [`phase3::validate_definition_paths_adl14`]).
 ///
 /// # Errors
 /// Returns the parse [`SyntaxError`]s if `src` does not parse as ADL 1.4;
@@ -728,6 +739,7 @@ pub fn validate_source_phase1_adl14(src: &str) -> Result<Vec<ValidationIssue>, V
         crate::cadl::Dialect::Adl14,
         &mut issues,
     );
+    issues.extend(phase3::validate_definition_paths_adl14(&archetype));
     Ok(issues)
 }
 
@@ -761,6 +773,7 @@ pub fn validate_source_adl14(
         crate::cadl::Dialect::Adl14,
         &mut issues,
     );
+    issues.extend(phase3::validate_definition_paths_adl14(&archetype));
     if issues.iter().all(|i| i.severity != Severity::Error) {
         issues.extend(rm::validate_adl14_rm(&archetype, rm));
     }

--- a/crates/openehr-adl/src/validate/phase3.rs
+++ b/crates/openehr-adl/src/validate/phase3.rs
@@ -31,6 +31,29 @@ pub(super) fn validate_phase3(flat: &Archetype) -> Vec<ValidationIssue> {
     let mut scan = Phase3 {
         root: v.definition,
         issues: Vec::new(),
+        proxy_code: ValidationCode::Vunp,
+        check_cardinality: true,
+    };
+    scan.walk(v.definition, "");
+    scan.issues
+}
+
+/// VDFPT for an assembled **ADL 1.4** archetype: every `use_node` internal
+/// reference (a `C_COMPLEX_OBJECT_PROXY` after assembly) must carry a target
+/// path that resolves within the definition section (`ADL1.4/master08-adl.adoc`
+/// §Definition Section validity rules, VDFPT). A 1.4 artefact is standalone —
+/// no differential lineage — so its own definition tree IS the resolution
+/// target; the AOM2 flat-form mirror of this rule is VUNP
+/// ([`validate_phase3`]). Cardinality/occurrences stay with the 1.4-dialect
+/// VCOC check in phase 1, so only the proxy walk runs here.
+#[must_use]
+pub(super) fn validate_definition_paths_adl14(archetype: &Archetype) -> Vec<ValidationIssue> {
+    let v = view(archetype);
+    let mut scan = Phase3 {
+        root: v.definition,
+        issues: Vec::new(),
+        proxy_code: ValidationCode::Vdfpt,
+        check_cardinality: false,
     };
     scan.walk(v.definition, "");
     scan.issues
@@ -39,13 +62,21 @@ pub(super) fn validate_phase3(flat: &Archetype) -> Vec<ValidationIssue> {
 struct Phase3<'a> {
     root: &'a CComplexObject,
     issues: Vec<ValidationIssue>,
+    /// The catalogue code a non-resolving proxy target raises: VUNP on the
+    /// AOM2 flat form, VDFPT on an assembled ADL 1.4 definition.
+    proxy_code: ValidationCode,
+    /// VACMCO runs on the AOM2 flat form only — the ADL 1.4 dialect enforces
+    /// its own VCOC in phase 1 instead.
+    check_cardinality: bool,
 }
 
 impl Phase3<'_> {
     fn walk(&mut self, node: &CComplexObject, path: &str) {
         for attr in complex_attributes(node) {
             let attr_path = format!("{path}/{}", attr.rm_attribute_name);
-            self.check_cardinality_occurrences(attr, &attr_path);
+            if self.check_cardinality {
+                self.check_cardinality_occurrences(attr, &attr_path);
+            }
             for child in &attr.children {
                 let child_path = child_path(&attr_path, object_node_id(child));
                 match child {
@@ -63,12 +94,14 @@ impl Phase3<'_> {
         }
     }
 
-    /// VUNP: the proxy target path must resolve to an object node in the flat
-    /// form (`master04.5` §`C_COMPLEX_OBJECT_PROXY`, VUNP L482-483).
+    /// The proxy target path must resolve to an object node in the walked
+    /// definition — VUNP on the AOM2 flat form (`master04.5`
+    /// §`C_COMPLEX_OBJECT_PROXY`, VUNP L482-483), VDFPT on an assembled
+    /// ADL 1.4 definition (`ADL1.4/master08-adl.adoc` §Definition Section).
     fn check_proxy(&mut self, target_path: &str, path: &str) {
         if target_path.is_empty() {
             self.issues.push(
-                ValidationIssue::new(ValidationCode::Vunp, "use_node proxy has no target path")
+                ValidationIssue::new(self.proxy_code, "use_node proxy has no target path")
                     .at_path(path.to_owned()),
             );
             return;
@@ -76,9 +109,9 @@ impl Phase3<'_> {
         if resolve(self.root, target_path) != Resolution::Found {
             self.issues.push(
                 ValidationIssue::new(
-                    ValidationCode::Vunp,
+                    self.proxy_code,
                     format!(
-                        "use_node target path {target_path:?} does not resolve to an object node in the flat form"
+                        "use_node target path {target_path:?} does not resolve to an object node in the definition"
                     ),
                 )
                 .at_path(path.to_owned()),

--- a/crates/openehr-adl/tests/it/validation_adl14.rs
+++ b/crates/openehr-adl/tests/it/validation_adl14.rs
@@ -212,3 +212,39 @@ fn use_node_naming_the_same_or_a_super_type_is_clean() {
         );
     }
 }
+
+// ── VDFPT: path validity in the 1.4 definition section ───────────────────────
+
+#[test]
+fn use_node_target_that_does_not_resolve_raises_vdfpt() {
+    // `ADL1.4/master08-adl.adoc` §Definition Section, VDFPT: any path mentioned
+    // in the definition section must be valid with respect to its hierarchical
+    // structure. The helper's resolving target is the accepting twin
+    // (`use_node_naming_the_same_or_a_super_type_is_clean` proves it stays
+    // clean); here the same archetype pointing at a node that does not exist
+    // must be reported.
+    let bad = use_node_archetype("ELEMENT").replace(
+        "/items[at0001]/items[at0002]",
+        "/items[at0001]/items[at0099]",
+    );
+    assert!(
+        errors(&bad).contains(&"VDFPT".to_owned()),
+        "a use_node target that does not resolve must raise VDFPT, got {:?}",
+        errors(&bad)
+    );
+    // The full-catalogue entry reports it too.
+    assert!(adl14_codes(&bad).contains(&"VDFPT".to_owned()));
+}
+
+#[test]
+fn use_node_target_leaving_the_archetype_raises_vdfpt() {
+    // A target whose first segment is not a constrained attribute of the root:
+    // syntactically fine, structurally invalid per VDFPT.
+    let bad = use_node_archetype("ELEMENT")
+        .replace("/items[at0001]/items[at0002]", "/no_such_attr[at0002]");
+    assert!(
+        errors(&bad).contains(&"VDFPT".to_owned()),
+        "a use_node path outside the definition structure must raise VDFPT, got {:?}",
+        errors(&bad)
+    );
+}


### PR DESCRIPTION
Closes #1324 (sub-issue of #770, the ADL1.4 ch.8 audit, v3.15.0 AM program).

## What

`ADL1.4/master08-adl.adoc` §Validity Rules **VDFPT** requires every path mentioned in the definition section to be valid against its hierarchical structure. The 1.4 validation entries ran phase 1 (+ VUNT) only; proxy-target resolution lived solely in the AOM2 flat-form phase 3 (VUNP), so a 1.4 `use_node` pointing at a nonexistent node validated with zero issues (probe-verified in the audit).

- New `ValidationCode::Vdfpt` (the spec-published 1.4 catalogue id — 'It is recommended that parsing tools use the identifiers published here'; VUNP is its AOM2 flat-form mirror).
- Both 1.4 entries now run the proxy walk over the assembled definition (a 1.4 artefact is standalone — its own definition tree is the resolution target). The phase-3 walker is parameterized by proxy code and by whether VACMCO runs (flat form only; the 1.4 dialect enforces its own VCOC in phase 1).

## Tests

Failing twins (non-resolving target → VDFPT; outside-the-structure first segment → VDFPT) beside the existing clean `use_node` tests as the accepting twin.

## Gates

- `cargo fmt --all` clean; CI-flag clippy zero warnings
- `cargo nextest run -p openehr-adl -p ehrbase` — 944/944 + 225/225 pass