### PR TITLE
fix(openehr-adl): ch.8 ADL 1.4 header-section conformance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,28 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **ADL 1.4 archetypes whose section keywords are not all-lowercase now
+  upload.** The ADL 1.4 lexical specification (master08 §Symbols) spells
+  every section keyword case-insensitively, so `ARCHETYPE (adl_version=1.4)`,
+  `Specialise`, `CONCEPT`, `DEFINITION` and `ONTOLOGY` are valid headers; they
+  were previously rejected with "expected an artefact keyword" / "expected a
+  section header". ADL 2 keeps the exact lowercase spelling its own grammar
+  defines.
+- **Old-form ADL 1.4 archetypes with no `language` section now upload.** Where
+  the archetype carries `primary_language`/`languages_available` in its
+  `ontology` section instead — the form master08 §Language Section and
+  §Ontology Header Statements tell tools to accept and upgrade — the language
+  is now lifted into `original_language` plus one translation entry per other
+  available language, instead of the upload failing with "no language section
+  found". An archetype with neither a `language` section nor a
+  `primary_language` is still rejected.
+- **A missing or undefined ADL 1.4 `concept` section is now reported instead
+  of passing silently.** The 1.4 grammar makes the `concept` section mandatory
+  and master08 §Validity Rules VARCN requires its term to exist in the
+  archetype ontology: an archetype with no concept section (or a concept
+  clause that is not a term-code reference) is refused with a `SACO` syntax
+  error, and a concept term missing from `term_definitions` now raises `VARCN`
+  on the 1.4 validation path.
 - **ADL 1.4 assertion expressions now accept the chapter's full operator
   set**: the ADL 1.4 inequality spelling `<>` and the symbolic existential
   quantifier `∃` applied to a path (equivalent to the `exists` keyword per

--- a/crates/openehr-adl/CLAUDE.md
+++ b/crates/openehr-adl/CLAUDE.md
@@ -19,7 +19,15 @@ into the generated `openehr_am::am24::aom2` model — never re-model AOM2.
   `cadl::Dialect::Adl14` both ADDS the 1.4-only forms (qualified/listed term
   constraints, inline dADL domain blocks) and REMOVES the constructs ADL 2
   introduced — the cADL 1.4 keyword set is closed (`ADL1.4/master05-cadl.adoc`
-  §Keywords). The 1.4-only validity rules (VCOC; VATDF/VACDF over the
+  §Keywords). The dialect reaches the OUTER structure too
+  (`source::parse_source_adl14`, the entry every 1.4 caller uses): 1.4 section
+  keywords are case-insensitive (`master08-adl.adoc` §Symbols), an old-form
+  archetype with `primary_language`/`languages_available` in its ontology and
+  no `language` section is accepted and upgraded on parse (§Language Section +
+  §Ontology Header Statements), and the `concept` section is mandatory
+  (§Syntax Specification `arch_concept`; VARCN). ADL2 outer parsing is
+  unchanged — exact lowercase keywords, unconditional `SALAN`, no concept
+  clause. The 1.4-only validity rules (VCOC; VATDF/VACDF over the
   qualified/listed spelling) run on the `Dialect::Adl14` phase-1 path only.
   The `S*` error space is a verbatim 1:1 mirror of the openEHR catalogue
   (`ADL2/master04.6`): never invent a code — reuse the catalogue code for the

--- a/crates/openehr-adl/src/assemble.rs
+++ b/crates/openehr-adl/src/assemble.rs
@@ -49,7 +49,7 @@ use openehr_lang::odin::{OdinKey, OdinValue};
 use crate::cadl::parse_definition_body;
 use crate::error::{SyntaxError, SyntaxErrorCode};
 use crate::rules::parse_artefact_rules;
-use crate::source::{ArtefactKind, ArtefactMeta, SourceArtefact, parse_source};
+use crate::source::{ArtefactKind, ArtefactMeta, SourceArtefact, parse_source, parse_source_adl14};
 
 /// Parse an ADL2 source into a fully-assembled [`Archetype`].
 ///
@@ -68,7 +68,9 @@ pub fn parse_artefact(src: &str) -> Result<Archetype, Vec<SyntaxError>> {
 }
 
 /// Parse an **ADL 1.4-dialect** source into an [`Archetype`] (the 1.4→2
-/// converter front end): identical to [`parse_artefact`] except the cADL
+/// converter front end): identical to [`parse_artefact`] except that the outer
+/// structure is read by [`crate::source::parse_source_adl14`] (case-insensitive
+/// section keywords, the old-form language tolerance) and the cADL
 /// `definition` is parsed with [`crate::cadl::parse_definition_body_adl14`],
 /// which tolerates the 1.4-only object forms. The result is a *1.4-shaped*
 /// `Archetype` (at-code node ids, qualified/listed terminology constraints in
@@ -81,7 +83,7 @@ pub fn parse_artefact(src: &str) -> Result<Archetype, Vec<SyntaxError>> {
 /// Returns every [`SyntaxError`] found across the outer parse, the cADL
 /// definition, the rules, and the ODIN-section-to-model mapping.
 pub fn parse_artefact_adl14(src: &str) -> Result<Archetype, Vec<SyntaxError>> {
-    let art = parse_source(src)?;
+    let art = parse_source_adl14(src)?;
     assemble_with(&art, src, crate::cadl::Dialect::Adl14)
 }
 
@@ -125,12 +127,27 @@ fn assemble_with(
         }
     };
 
-    let original_language = assemble_original_language(art, &mut errors);
-    let translations = art
-        .language
-        .as_ref()
-        .and_then(assemble_translations)
-        .filter(|t| !t.is_empty());
+    // ADL 1.4 mandates the `concept` section: `master08` §Syntax Specification
+    // gives `arch_concept: SYM_CONCEPT V_LOCAL_TERM_CODE_REF | SYM_CONCEPT
+    // error` — no empty alternative, unlike `arch_specialisation`/
+    // `arch_language`/`arch_description`/`arch_invariant` — and §Validity Rules
+    // VARCN requires "an archetype term value in the concept section". ADL2
+    // derives the concept from the HRID (`ADL2/master07.09`), so the section is
+    // obsolete there and its absence is not an error.
+    if dialect == crate::cadl::Dialect::Adl14
+        && art.kind != ArtefactKind::TemplateOverlay
+        && art.concept.is_none()
+    {
+        errors.push(SyntaxError::at(
+            SyntaxErrorCode::Saco,
+            "missing concept section",
+            0..0,
+            src,
+        ));
+    }
+
+    let original_language = assemble_original_language(art, dialect, &mut errors);
+    let translations = assemble_translations_of(art, dialect).filter(|t| !t.is_empty());
     let description = art
         .description
         .as_ref()
@@ -236,15 +253,22 @@ fn root_node_id(def: &CComplexObject) -> String {
 // ── language (master07.07) ────────────────────────────────────────────────
 
 /// `original_language = <[ISO_639-1::en]>` → a [`TerminologyCode`]. A missing
-/// `language` section is tolerated (`master07.07` legacy upgrade): the language
-/// falls back to `ISO_639-1::en` so the model stays constructible; the absence
-/// is not itself a hard error here (the outer parser already raised `SALAN`
-/// where required).
+/// `language` section is tolerated (`master07.07` legacy upgrade): in the ADL
+/// 1.4 dialect the old form's ontology `primary_language` is lifted into it
+/// (see [`old_form_primary_language`]), otherwise the language falls back to
+/// `ISO_639-1::en` so the model stays constructible; the absence is not itself
+/// a hard error here (the outer parser already raised `SALAN` where required).
 fn assemble_original_language(
     art: &SourceArtefact,
+    dialect: crate::cadl::Dialect,
     errors: &mut Vec<SyntaxError>,
 ) -> TerminologyCode {
     let Some(map) = art.language.as_ref().and_then(as_object) else {
+        if dialect == crate::cadl::Dialect::Adl14
+            && let Some(code) = old_form_primary_language(art)
+        {
+            return code;
+        }
         return term_code("ISO_639-1", "en");
     };
     match map.get("original_language") {
@@ -260,6 +284,71 @@ fn assemble_original_language(
         }
         None => term_code("ISO_639-1", "en"),
     }
+}
+
+/// The artefact's translations: from the `language` section where it has one,
+/// and — in the ADL 1.4 dialect only — from the old form's ontology
+/// `languages_available` where it has none (see
+/// [`old_form_primary_language`]).
+fn assemble_translations_of(
+    art: &SourceArtefact,
+    dialect: crate::cadl::Dialect,
+) -> Option<BTreeMap<String, TranslationDetails>> {
+    match art.language.as_ref() {
+        Some(language) => assemble_translations(language),
+        None if dialect == crate::cadl::Dialect::Adl14 => old_form_translations(art),
+        None => None,
+    }
+}
+
+/// The old-form ontology `primary_language` lifted into `original_language`
+/// (`AM/docs/ADL1.4/master08-adl` §Ontology Header Statements).
+///
+/// NOTE: the upgrade is the spec's own instruction, stated twice — §Language
+/// Section and Language Translation: "some non-conforming ADL tools in the past
+/// created archetypes without a `language` section, relying on the `ontology`
+/// section to provide the `original_language` (there called `primary_language`)
+/// and list of languages (`languages_available`). In the interests of backward
+/// compatibility, tool builders should consider accepting archetypes of the old
+/// form and upgrading them when parsing to the correct form, which should then
+/// be used for serialising/saving" — and §Ontology Header Statements, in the
+/// same words for `primary_language`/`languages_available`. It runs on the 1.4
+/// path only: ADL2 has no old form.
+fn old_form_primary_language(art: &SourceArtefact) -> Option<TerminologyCode> {
+    let map = art.terminology.as_ref().and_then(as_object)?;
+    let value = map.get("primary_language")?;
+    match untyped(value) {
+        OdinValue::TermCode(code) => Some(parse_term_code(code)),
+        other => string_of(Some(other)).map(|s| term_code("ISO_639-1", &s)),
+    }
+}
+
+/// The old form's `languages_available` lifted into `translations`: one minimal
+/// [`TranslationDetails`] per listed language other than the primary one (the
+/// old form carries no translator metadata to fill the other fields with) —
+/// `master08` §Ontology Header Statements NOTE, quoted on
+/// [`old_form_primary_language`].
+fn old_form_translations(art: &SourceArtefact) -> Option<BTreeMap<String, TranslationDetails>> {
+    let map = art.terminology.as_ref().and_then(as_object)?;
+    let primary = old_form_primary_language(art).map(|c| c.code_string);
+    let mut out = BTreeMap::new();
+    for lang in string_list(map.get("languages_available")?) {
+        if Some(&lang) == primary.as_ref() {
+            continue;
+        }
+        out.insert(
+            lang.clone(),
+            TranslationDetails {
+                language: term_code("ISO_639-1", &lang),
+                author: BTreeMap::new(),
+                accreditation: None,
+                other_details: None,
+                version_last_translated: None,
+                other_contributors: Vec::new(),
+            },
+        );
+    }
+    Some(out)
 }
 
 /// `translations = <["de"] = < language=<…> author=<…> … >>` →

--- a/crates/openehr-adl/src/source.rs
+++ b/crates/openehr-adl/src/source.rs
@@ -18,6 +18,7 @@
 use openehr_am::am24::aom2::archetype::archetype_hrid::ArchetypeHrid;
 use openehr_base::prelude::VersionStatus;
 
+use crate::cadl::Dialect;
 use crate::error::{SyntaxError, SyntaxErrorCode};
 use crate::lexer::{Spanned, Token};
 
@@ -79,6 +80,18 @@ pub struct SourceArtefact {
     pub hrid: ArchetypeHrid,
     /// The `specialise`/`specialize` parent reference, if any.
     pub parent_ref: Option<ArchetypeHrid>,
+    /// The ADL **1.4** `concept` section's local term code, without its
+    /// brackets (`concept [at0000]` ⇒ `"at0000"`).
+    ///
+    /// `AM/docs/ADL1.4/master08-adl` §Concept Section: "All archetypes
+    /// represent some real world concept … The concept is always coded". The
+    /// section is mandatory in the 1.4 grammar (§Syntax Specification
+    /// `arch_concept`, which — unlike `arch_specialisation`/`arch_language`/
+    /// `arch_description`/`arch_invariant` — has no empty alternative) and its
+    /// term is the subject of §Validity Rules VARCN. It is captured for every
+    /// dialect; ADL2 derives the concept from the HRID instead and ignores it
+    /// (`ADL2/master07.09` lists `concept` among the obsolete clauses).
+    pub concept: Option<String>,
     /// The `language` section (ODIN).
     pub language: Option<openehr_lang::odin::OdinValue>,
     /// The `description` section (ODIN).
@@ -128,6 +141,42 @@ pub struct SourceArtefact {
 /// or missing-required-section). ODIN parse failures surface as
 /// [`SyntaxErrorCode::Sdinv`] carrying the section name.
 pub fn parse_source(src: &str) -> Result<SourceArtefact, Vec<SyntaxError>> {
+    parse_source_with(src, Dialect::Adl2)
+}
+
+/// Parse an **ADL 1.4** source into a [`SourceArtefact`] — the outer-structure
+/// twin of [`parse_source`] for the 1.4 dialect, and the entry every 1.4 caller
+/// uses ([`crate::assemble::parse_artefact_adl14`],
+/// [`crate::validate::validate_source_phase1_adl14`],
+/// [`crate::validate::validate_source_adl14`]).
+///
+/// Three outer-structure behaviours differ from ADL2, each 1.4-only so ADL2
+/// parsing is byte-identical:
+/// - **Section and artefact keywords are case-insensitive**
+///   (`AM/docs/ADL1.4/master08-adl` §Syntax Specification/§Symbols spells every
+///   one of them `^[Aa][Rr][Cc][Hh][Ee][Tt][Yy][Pp][Ee]`-style), so
+///   `ARCHETYPE`/`Specialise`/`CONCEPT`/`ONTOLOGY` are headers. Column-0
+///   anchoring is unchanged, so a keyword used as an identifier inside a
+///   section is still never a header (§Basics/§Keywords: "All of these words
+///   can safely appear as identifiers in the `definition` and `ontology`
+///   sections").
+/// - **A missing `language` section is accepted** when the ontology carries the
+///   old-form `primary_language` (§Language Section NOTE + §Ontology Header
+///   Statements NOTE); [`crate::assemble::assemble_adl14`] performs the
+///   upgrade. With no `primary_language` to upgrade from, the
+///   [`SyntaxErrorCode::Salan`] of the grammar's mandatory-language reading
+///   stands.
+/// - **A malformed `concept` clause is refused** with
+///   [`SyntaxErrorCode::Saco`] (§Syntax Specification `arch_concept:
+///   SYM_CONCEPT V_LOCAL_TERM_CODE_REF | SYM_CONCEPT error`).
+///
+/// # Errors
+/// Returns every [`SyntaxError`] found, exactly as [`parse_source`] does.
+pub fn parse_source_adl14(src: &str) -> Result<SourceArtefact, Vec<SyntaxError>> {
+    parse_source_with(src, Dialect::Adl14)
+}
+
+fn parse_source_with(src: &str, dialect: Dialect) -> Result<SourceArtefact, Vec<SyntaxError>> {
     let toks = match crate::lexer::lex(src) {
         Ok(t) => t,
         Err(e) => return Err(vec![e]),
@@ -136,6 +185,7 @@ pub fn parse_source(src: &str) -> Result<SourceArtefact, Vec<SyntaxError>> {
         src,
         toks: &toks,
         pos: 0,
+        dialect,
         errors: Vec::new(),
     };
     let artefact = outer.parse_artefact(false);
@@ -233,6 +283,7 @@ struct Outer<'a> {
     src: &'a str,
     toks: &'a [Spanned],
     pos: usize,
+    dialect: Dialect,
     errors: Vec<SyntaxError>,
 }
 
@@ -265,28 +316,37 @@ impl Outer<'_> {
         start == 0 || self.src.as_bytes().get(start - 1) == Some(&b'\n')
     }
 
+    /// The keyword spelling of the identifier token at `idx`, ready for
+    /// classification: the token text as written in ADL2, and case-folded in
+    /// the 1.4 dialect, where `master08` §Symbols spells every section keyword
+    /// case-insensitively (`^[Aa][Rr][Cc][Hh][Ee][Tt][Yy][Pp][Ee]`, …). An
+    /// upper-initial word lexes as [`Token::AlphaUcId`], so 1.4 reads both
+    /// identifier tokens and ADL2 only the lower-initial one.
+    fn keyword_at(&self, idx: usize) -> Option<String> {
+        match self.toks.get(idx).map(|s| &s.token) {
+            Some(Token::AlphaLcId(s)) if self.dialect == Dialect::Adl2 => Some(s.clone()),
+            Some(Token::AlphaLcId(s) | Token::AlphaUcId(s)) if self.dialect == Dialect::Adl14 => {
+                Some(s.to_ascii_lowercase())
+            }
+            _ => None,
+        }
+    }
+
     /// The section-keyword class at `idx`, if that token is a column-0 keyword.
     fn section_kw_at(&self, idx: usize) -> Option<SectionKw> {
         if !self.is_line_start(idx) {
             return None;
         }
-        if let Some(Token::AlphaLcId(s)) = self.toks.get(idx).map(|s| &s.token) {
-            classify_section(s)
-        } else {
-            None
-        }
+        classify_section(&self.keyword_at(idx)?)
     }
 
     fn parse_artefact(&mut self, overlay: bool) -> Option<SourceArtefact> {
         // Artefact kind keyword (accept an optional leading `flat`).
-        if matches!(self.current(), Some(Token::AlphaLcId(s)) if s == "flat") {
+        if self.keyword_at(self.pos).as_deref() == Some("flat") {
             self.pos += 1;
         }
         let kind_span = self.span_at(self.pos);
-        let kind = match self.current() {
-            Some(Token::AlphaLcId(s)) => classify_kind(s),
-            _ => None,
-        };
+        let kind = self.keyword_at(self.pos).as_deref().and_then(classify_kind);
         let Some(kind) = kind else {
             self.push(
                 SyntaxErrorCode::Sunk,
@@ -326,6 +386,7 @@ impl Outer<'_> {
             meta,
             hrid,
             parent_ref: None,
+            concept: None,
             language: None,
             description: None,
             terminology: None,
@@ -361,7 +422,7 @@ impl Outer<'_> {
         // A `template` (and, defensively, any root) collects trailing
         // `template_overlay` blocks (`adl2.g4` `template`).
         if !overlay {
-            while matches!(self.current(), Some(Token::AlphaLcId(s)) if s == "template_overlay")
+            while self.keyword_at(self.pos).as_deref() == Some("template_overlay")
                 && self.is_line_start(self.pos)
             {
                 if let Some(ov) = self.parse_artefact(true) {
@@ -452,9 +513,57 @@ impl Outer<'_> {
             SectionKw::RevisionHistory => {
                 art.revision_history = self.parse_odin(body, header_idx, "revision_history");
             }
-            // The obsolete `concept` clause is consumed and ignored in ADL2.
-            SectionKw::Concept | SectionKw::ArtefactBoundary => {}
+            SectionKw::Concept => {
+                art.concept = self.parse_concept(&body, header_idx);
+            }
+            SectionKw::ArtefactBoundary => {}
         }
+    }
+
+    /// The `concept` clause's local term code (`master08` §Concept Section;
+    /// §Syntax Specification `arch_concept: SYM_CONCEPT V_LOCAL_TERM_CODE_REF`,
+    /// lexed `\[[a-zA-Z0-9][a-zA-Z0-9.-]*\]` by §Symbols).
+    ///
+    /// A body that is not a term-code reference is the grammar's
+    /// `SYM_CONCEPT error` alternative: refused with
+    /// [`SyntaxErrorCode::Saco`] in the 1.4 dialect. ADL2 derives the concept
+    /// from the HRID and treats the clause as obsolete (`ADL2/master07.09`), so
+    /// there the code is captured where it is well-formed and never diagnosed.
+    fn parse_concept(
+        &mut self,
+        body: &std::ops::Range<usize>,
+        header_idx: usize,
+    ) -> Option<String> {
+        let tokens: Vec<&Token> = self
+            .toks
+            .get(body.clone())
+            .unwrap_or_default()
+            .iter()
+            .map(|t| &t.token)
+            .collect();
+        let code = match tokens.as_slice() {
+            // `[at0000]` — the bracketed local term code.
+            [Token::LBracket, inner, Token::RBracket] => local_code_text(inner),
+            // `[local::at0000]` — the qualified term-code spelling of
+            // `ADL1.4/master05-cadl.adoc` §Symbols `V_QUALIFIED_TERM_CODE_REF`
+            // (the same bracketed form with a terminology prefix), read
+            // tolerantly here for an archetype that writes its concept that way.
+            [Token::TermCodeRef(t)] => t
+                .trim_start_matches('[')
+                .trim_end_matches(']')
+                .rsplit("::")
+                .next()
+                .map(str::to_owned),
+            _ => None,
+        };
+        if code.is_none() && self.dialect == Dialect::Adl14 {
+            self.push(
+                SyntaxErrorCode::Saco,
+                "expected a local term code reference in the concept section",
+                self.span_at(header_idx),
+            );
+        }
+        code
     }
 
     fn raw_span(&self, tokens: std::ops::Range<usize>) -> RawSpan {
@@ -559,7 +668,26 @@ impl Outer<'_> {
         // template_overlay inherits language/description from its root
         // (`master07.07` / `master10`); every other kind requires a language
         // section.
-        if !overlay && art.kind != ArtefactKind::TemplateOverlay && art.language.is_none() {
+        //
+        // NOTE: the ADL 1.4 grammar's `arch_language` carries an empty
+        // alternative (`master08` §Syntax Specification: "arch_language: //
+        // empty OK"), and §Language Section + §Ontology Header Statements both
+        // NOTE that "some non-conforming ADL tools in the past created
+        // archetypes without a `language` section, relying on the `ontology`
+        // section to provide the `original_language` (there called
+        // `primary_language`) and list of languages (`languages_available`) …
+        // tool builders should consider accepting archetypes of the old form
+        // and upgrading them when parsing to the correct form". So a 1.4 source
+        // whose ontology carries `primary_language` is accepted here and
+        // upgraded in `crate::assemble`; with nothing to upgrade from, SALAN
+        // stands. ADL2 has no old form and keeps SALAN unconditionally.
+        let old_form_language = self.dialect == Dialect::Adl14
+            && art.terminology.as_ref().is_some_and(has_primary_language);
+        if !overlay
+            && art.kind != ArtefactKind::TemplateOverlay
+            && art.language.is_none()
+            && !old_form_language
+        {
             self.push(
                 SyntaxErrorCode::Salan,
                 "missing language section",
@@ -567,6 +695,28 @@ impl Outer<'_> {
             );
         }
     }
+}
+
+/// The bare code text of a local term-code reference's inner token
+/// (`[at0000]` ⇒ `at0000`), for the forms `master08` §Symbols
+/// `V_LOCAL_TERM_CODE_REF` (`\[[a-zA-Z0-9][a-zA-Z0-9.-]*\]`) admits.
+fn local_code_text(t: &Token) -> Option<String> {
+    match t {
+        Token::AtCode(s)
+        | Token::AcCode(s)
+        | Token::IdCode(s)
+        | Token::RootIdCode(s)
+        | Token::AlphaLcId(s)
+        | Token::AlphaUcId(s)
+        | Token::Integer(s) => Some(s.clone()),
+        _ => None,
+    }
+}
+
+/// True if an ODIN `ontology`/`terminology` section carries the old-form
+/// `primary_language` statement (`master08` §Ontology Header Statements NOTE).
+fn has_primary_language(section: &openehr_lang::odin::OdinValue) -> bool {
+    matches!(section, openehr_lang::odin::OdinValue::Object(map) if map.contains_key("primary_language"))
 }
 
 /// The text a meta value token carries, if any.

--- a/crates/openehr-adl/src/validate/conformance.rs
+++ b/crates/openehr-adl/src/validate/conformance.rs
@@ -736,6 +736,9 @@ mod tests {
 archetype (adl_version=1.4)
 \topenEHR-EHR-CLUSTER.effective.v1
 
+concept
+\t[at0000]
+
 language
 \toriginal_language = <[ISO_639-1::en]>
 

--- a/crates/openehr-adl/src/validate/mod.rs
+++ b/crates/openehr-adl/src/validate/mod.rs
@@ -56,7 +56,7 @@ use openehr_am::am24::resource::resource_description::ResourceDescription;
 use openehr_base::prelude::{ResourceAnnotations, TerminologyCode};
 
 use crate::error::SyntaxError;
-use crate::source::{ArtefactKind, parse_source};
+use crate::source::{ArtefactKind, parse_source, parse_source_adl14};
 
 /// The severity of a [`ValidationIssue`].
 ///
@@ -729,7 +729,7 @@ pub fn validate_source_phase1(
 /// Returns the parse [`SyntaxError`]s if `src` does not parse as ADL 1.4;
 /// validation runs only on a successful parse.
 pub fn validate_source_phase1_adl14(src: &str) -> Result<Vec<ValidationIssue>, Vec<SyntaxError>> {
-    let source = parse_source(src)?;
+    let source = parse_source_adl14(src)?;
     let archetype = crate::assemble::assemble_adl14(&source, src)?;
     let mut issues = Vec::new();
     phase1::run(
@@ -763,7 +763,7 @@ pub fn validate_source_adl14(
     src: &str,
     rm: &dyn rm::RmModel,
 ) -> Result<Vec<ValidationIssue>, Vec<SyntaxError>> {
-    let source = parse_source(src)?;
+    let source = parse_source_adl14(src)?;
     let archetype = crate::assemble::assemble_adl14(&source, src)?;
     let mut issues = Vec::new();
     phase1::run(

--- a/crates/openehr-adl/src/validate/phase1.rs
+++ b/crates/openehr-adl/src/validate/phase1.rs
@@ -99,6 +99,9 @@ pub(super) fn run(
     if let Some((src, text)) = source {
         check_object_key_unique(src, issues); // VOKU (source-level)
         check_rule_paths(v, src, text, issues); // VRRLP (raw rules text)
+        if dialect == Dialect::Adl14 {
+            check_concept_term_adl14(v, src, issues); // VARCN (terminology half)
+        }
     }
 
     let basic_clean = basic.is_empty();
@@ -219,6 +222,40 @@ fn check_identification(
     // VALC: language conformance to the flat parent (master03 §Validity Rules,
     // G3) — needs the parent; runs only when resolvable.
     check_language_conformance(v, repo, out);
+}
+
+/// VARCN (ADL 1.4, terminology half): the `concept` section's term must exist
+/// in the archetype ontology — `ADL1.4/master08-adl.adoc` §Validity Rules
+/// VARCN: "archetype concept validity. The archetype must have an archetype
+/// term value in the concept section. The term must exist in the archetype
+/// ontology."
+///
+/// The FORM half (a root code well-formed for the specialisation depth) is
+/// checked for every dialect in [`check_identification`]; this half needs the
+/// parsed 1.4 `concept` clause, which only the source-level entry points carry
+/// (ADL2 has no concept section — `ADL2/master07.09`). A concept term is judged
+/// defined when any language's `term_definitions` bucket carries it, matching
+/// the definedness union [`check_terminology`] uses. An ABSENT concept section
+/// is refused earlier, at assembly ([`crate::error::SyntaxErrorCode::Saco`]).
+fn check_concept_term_adl14(
+    v: &ArchetypeView<'_>,
+    source: &SourceArtefact,
+    out: &mut Vec<ValidationIssue>,
+) {
+    let Some(code) = source.concept.as_deref() else {
+        return;
+    };
+    let defined = v
+        .terminology
+        .term_definitions
+        .values()
+        .any(|bucket| bucket.contains_key(code));
+    if !defined {
+        out.push(ValidationIssue::new(
+            ValidationCode::Varcn,
+            format!("concept term {code:?} is not defined in the archetype ontology"),
+        ));
+    }
 }
 
 /// VACSD: the specialisation depth of the archetype must be one greater than

--- a/crates/openehr-adl/tests/corpus/INVENTORY.md
+++ b/crates/openehr-adl/tests/corpus/INVENTORY.md
@@ -158,6 +158,8 @@ No `.adlf` files; expected flats are not vendored (§7).
 | SCAS | basics · SCAS_attribute_empty.v1.0.0.adls |
 | SCOAT | basics · SCOAT_object_empty.v1.0.0.adls |
 | SDINV | legacy_adl_1.4 · FAIL_c_dv_quantity_minimal.v1.adl *(filename FAIL)* |
+| SACO | legacy_adl_1.4 · openehr-test_pkg-SOME_TYPE.c_dv_quantity.v1.adl *(tag PASS — adjudicated)* |
+| SACO | legacy_adl_1.4 · openehr-test_pkg-SOME_TYPE.code_phrase.v1.adl *(tag PASS — adjudicated)* |
 | SEXLU | structure · SEXLU_attribute_wrong_existence.v1.0.0.adls *(SEXLU1/2 family)* |
 | STCNT | consistency · VOTM_terminology_term_definitions_empty.v1.0.0.adls *(filename VOTM)* |
 | SUNK | basics · FAIL_definition_missing.v1.0.0.adls *(filename FAIL)* |
@@ -467,7 +469,7 @@ tag in `validity/**` should be a hard coverage-gate error (only the two
 | `validity/**/*.adls` (all tagged) | validate-expect-code: PASS→clean; FAIL→any typed error; code→exactly that code; W*→warning | `regression` tag (NOT filename) |
 | `validity/templates/*.adls` | filler validation (`validate_fillers`): VTPL→template/filler language mismatch, VARXR→unresolved external ref; PASS/support→clean (`tests/templates_corpus.rs`) | `regression` tag |
 | `validity/legacy_adl_1.4/*.adls` | parse + validate clean | tag = PASS |
-| `validity/legacy_adl_1.4/*.adl` | 1.4-tolerance parse; `FAIL_c_dv_quantity_minimal.v1.adl`→SDINV | tag |
+| `validity/legacy_adl_1.4/*.adl` | 1.4-tolerance parse; `FAIL_c_dv_quantity_minimal.v1.adl`→SDINV; the two concept-less fixtures→SACO | tag, except the two SACO adjudications |
 | `robustness/**` | parse + validate → assert PASS (never-panic floor) | tag = PASS |
 | `upgrade/upgrade_from_14/*.adl` | convert (adl14) → compare to paired `.adls` | the paired `.adls` |
 | `upgrade/upgrade_from_14/*.adls` | parse + validate clean (also the compare target) | — |
@@ -555,3 +557,5 @@ cross-check).
 | `…cadl_breadth_structure.v1.adl` | PASS | every existence/occurrences/cardinality spelling (incl. two modifiers, both modifier orderings, the bare `{*}`), `use_node` with and without occurrences, generic type names, mixed object kinds under one attribute, and the bare + identified slot forms |
 | `…cadl_breadth_primitives.v1.adl` | PASS | every integer/real list and interval shape (incl. `infinity`/`-infinity`, `+/-`, and BOTH exclusive-lower spellings), string lists + the `...` continuation + both regex delimiters, booleans, characters, listed term codes, and assumed values on each |
 | `…cadl_breadth_datetime.v1.adl` | PASS | every date/time/date-time pattern of the valid-pattern table incl. literal substitution (L894) and the ASCII/`±`/`Z` timezone modifiers (L852, L900-906), the space-separated date-time pattern (§Symbols L1422), every duration pattern family, negative durations, the mixed `pattern/interval` form, and symmetric-timezone intervals |
+| `…c_dv_quantity_concept.v1.adl` | PASS | the concept-carrying twin of the vendored `legacy_adl_1.4/openehr-test_pkg-SOME_TYPE.c_dv_quantity.v1.adl`, which master08 refuses (SACO, §2b): the 1.4 inline dADL `C_DV_QUANTITY` blocks keep their accepted-and-validates-clean coverage |
+| `…code_phrase_concept.v1.adl` | PASS | the concept-carrying twin of the vendored `legacy_adl_1.4/openehr-test_pkg-SOME_TYPE.code_phrase.v1.adl` (same SACO adjudication): the vanilla and 1.4-qualified `CODE_PHRASE` constraint spellings keep theirs |

--- a/crates/openehr-adl/tests/corpus/PROVENANCE.md
+++ b/crates/openehr-adl/tests/corpus/PROVENANCE.md
@@ -82,6 +82,13 @@
 - The accepting twin of every DIALECT-GATE refusal is the vendored ADL2 corpus,
   which exercises the same construct in its own dialect; the twins of the
   1.4-only refusals live in this tree.
+- Two fixtures here (`openehr-TEST_PKG-SOME_TYPE.{c_dv_quantity,code_phrase}_
+  concept.v1.adl`) are DERIVED from vendored `legacy_adl_1.4` sources: they are
+  those files with the `concept` section the ADL 1.4 grammar requires
+  (`master08-adl.adoc` §Syntax Specification `arch_concept`; §Validity Rules
+  VARCN), added so the constructs they exercise keep an accepting twin now that
+  the concept-less originals are pinned as SACO refusals. Their origin is
+  recorded in each file's `purpose`; the vendored originals are untouched.
 - Owner: `crates/openehr-adl/tests/adl14_cadl_gates.rs` (the per-file
   expectation table lives there; `corpus_coverage.rs` cross-checks the tree).
 - Same editing rule as `adl14-dadl/`: fixtures are added or corrected against

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openehr-TEST_PKG-SOME_TYPE.c_dv_quantity_concept.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openehr-TEST_PKG-SOME_TYPE.c_dv_quantity_concept.v1.adl
@@ -1,0 +1,114 @@
+archetype (adl_version=1.4)
+	openehr-TEST_PKG-SOME_TYPE.c_dv_quantity_concept.v1
+
+concept
+	[at0000]	-- root item
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	details = <
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"The concept-carrying twin of adl2-reference/validity/legacy_adl_1.4/openehr-test_pkg-SOME_TYPE.c_dv_quantity.v1.adl, which master08 refuses (SACO) for its missing concept section: Illustrates the use of inline dADL representing C_DV_QUANTITY, including with no magnitude">
+			keywords = <"ADL", "test">
+			copyright = <"copyright (c) 2004 The openEHR Foundation">
+		>
+	>
+	other_details = <
+		["regression"] = <"PASS">
+	>
+	lifecycle_state = <"draft">
+
+definition
+	SOME_TYPE[at0000] matches {	-- root item
+		standard_quantity_attr matches {
+			DV_QUANTITY [at0001] matches {
+				-- property matches {"temperature"}
+				units matches {"C"}
+				magnitude matches {|>=4.0|}
+			}
+			DV_QUANTITY [at0002] matches {
+				-- property matches {"temperature"}
+				units matches {"F"}
+				magnitude matches {|>=40.0|}
+			}
+		}
+		clinical_quantity_attr_1 matches {
+			(C_DV_QUANTITY) <
+				assumed_value = <
+					units = <"C">
+					precision = <0>
+					magnitude = <8.0>
+				>
+				property = <[openehr::127]>
+				list = <
+					["1"] = <
+						units = <"C">
+						magnitude = <|>=4.0|>
+					>
+					["2"] = <
+						units = <"F">
+						magnitude = <|>=40.0|>
+					>
+				>
+			>
+		}
+		clinical_quantity_attr_2 matches {
+			(C_DV_QUANTITY) <
+				property = <[openehr::127]>
+				list = <
+					["1"] = <
+						units = <"C">
+					>
+					["2"] = <
+						units = <"F">
+					>
+				>
+			>
+		}
+		clinical_quantity_attr_4 matches {
+			DV_COUNT matches {
+				magnitude matches {|>=0|}
+			}
+		}
+		clinical_quantity_attr_5 matches {
+			DV_COUNT matches {
+				magnitude matches {|>=0|}
+			}
+		}
+		clinical_quantity_attr_6 matches {
+			(C_DV_QUANTITY) <
+				property = <[openehr::127]>
+				list = <
+					["1"] = <
+						precision = <|2|>
+					>
+				>
+			>
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					description = <"xxxx">
+					text = <"root item">
+				>
+				["at0001"] = <
+					description = <"Centigrade temperature">
+					text = <"Centigrade temperature">
+				>
+				["at0002"] = <
+					description = <"Fahrenheit temperature">
+					text = <"Fahrenheit temperature">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openehr-TEST_PKG-SOME_TYPE.code_phrase_concept.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openehr-TEST_PKG-SOME_TYPE.code_phrase_concept.v1.adl
@@ -1,0 +1,153 @@
+archetype (adl_version=1.4)
+	openehr-TEST_PKG-SOME_TYPE.code_phrase_concept.v1
+
+concept
+	[at0000]	-- Test
+
+language
+	original_language = <[ISO_639-1::en]>
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	details = <
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"The concept-carrying twin of adl2-reference/validity/legacy_adl_1.4/openehr-test_pkg-SOME_TYPE.code_phrase.v1.adl, which master08 refuses (SACO) for its missing concept section: Test terms expressed both as vanilla C_CODE_PHRASEs and as syntax equivalents">
+			keywords = <"ADL", "test">
+			copyright = <"copyright (c) 2004 The openEHR Foundation">
+		>
+	>
+	other_details = <
+		["regression"] = <"PASS">
+	>
+	lifecycle_state = <"draft">
+
+definition
+	SOME_TYPE[at0000] matches {	-- Test
+		standard_coded_text_attr matches {
+			DV_CODED_TEXT matches {
+				defining_code matches {
+					CODE_PHRASE[at0001] matches {
+						terminology_id matches {
+							TERMINOLOGY_ID matches {
+								value matches {"local"}
+							}
+						}
+						code_string matches {"at0111"}
+					}
+					CODE_PHRASE[at0002] matches {
+						terminology_id matches {
+							TERMINOLOGY_ID matches {
+								value matches {"local"}
+							}
+						}
+						code_string matches {"at0112"}
+					}
+					CODE_PHRASE[at0003] matches {
+						terminology_id matches {
+							TERMINOLOGY_ID matches {
+								value matches {"local"}
+							}
+						}
+						code_string matches {"at0113"}
+					}
+					CODE_PHRASE[at0004] matches {
+						terminology_id matches {
+							TERMINOLOGY_ID matches {
+								value matches {"local"}
+							}
+						}
+						code_string matches {"at0114"}
+					}
+					CODE_PHRASE[at0005] matches {
+						terminology_id matches {
+							TERMINOLOGY_ID matches {
+								value matches {"local"}
+							}
+						}
+						code_string matches {"at0115"}
+					}
+				}
+			}
+		}
+		standard_coded_text_attr_2 matches {
+			DV_CODED_TEXT matches {
+				defining_code matches {
+					CODE_PHRASE[at0001] matches {
+						terminology_id matches {
+							TERMINOLOGY_ID matches {
+								value matches {"local"}
+							}
+						}
+						code_string matches {"at0111", "at0112", "at0113", "at0114", "at0115"}
+					}
+				}
+			}
+		}
+		clinical_coded_text_attr_1 matches {
+			DV_CODED_TEXT matches {
+				defining_code matches {
+					[local::
+					at0111, 	-- Anus
+					at0112, 	-- Rectum
+					at0113, 	-- Sigmoid
+					at0114, 	-- Descending
+					at0115; 	-- Splenic
+					at0111]	-- assumed value
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					description = <"Test">
+					text = <"Test">
+				>
+				["at0001"] = <
+					description = <"coded node">
+					text = <"coded node">
+				>
+				["at0002"] = <
+					description = <"coded node">
+					text = <"coded node">
+				>
+				["at0003"] = <
+					description = <"coded node">
+					text = <"coded node">
+				>
+				["at0004"] = <
+					description = <"coded node">
+					text = <"coded node">
+				>
+				["at0005"] = <
+					description = <"coded node">
+					text = <"coded node">
+				>
+				["at0111"] = <
+					description = <"Site">
+					text = <"Anus">
+				>
+				["at0112"] = <
+					description = <"Site">
+					text = <"Rectum">
+				>
+				["at0113"] = <
+					description = <"Site">
+					text = <"Sigmoid">
+				>
+				["at0114"] = <
+					description = <"Site">
+					text = <"Descending">
+				>
+				["at0115"] = <
+					description = <"Site">
+					text = <"Splenic">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/it/adl14_cadl_gates.rs
+++ b/crates/openehr-adl/tests/it/adl14_cadl_gates.rs
@@ -169,6 +169,23 @@ const FIXTURES: &[(&str, Expect)] = &[
     // ── 1.4 keywords that must stay accepted ──────────────────────────────
     ("openEHR-EHR-CLUSTER.sibling_order.v1.adl", Expect::Pass),
     ("openEHR-EHR-CLUSTER.cadl_keyword_case.v1.adl", Expect::Pass),
+    // ── the accepting twins of the two vendored concept-less 1.4 fixtures ─
+    // `ADL1.4/master08-adl.adoc` §Syntax Specification makes `arch_concept`
+    // mandatory and §Validity Rules VARCN requires its term, so
+    // `adl2-reference/validity/legacy_adl_1.4/openehr-test_pkg-SOME_TYPE.
+    // {c_dv_quantity,code_phrase}.v1.adl` are refused (SACO — pinned as such in
+    // `legacy14_corpus.rs`). These are their concept-carrying twins, so the
+    // constructs they exercise (1.4 inline dADL `C_DV_QUANTITY` blocks; the
+    // vanilla and 1.4-qualified `CODE_PHRASE` constraint spellings) keep their
+    // accepted-and-validates-clean coverage.
+    (
+        "openehr-TEST_PKG-SOME_TYPE.c_dv_quantity_concept.v1.adl",
+        Expect::Pass,
+    ),
+    (
+        "openehr-TEST_PKG-SOME_TYPE.code_phrase_concept.v1.adl",
+        Expect::Pass,
+    ),
     // A slot assertion targeting domain_concept: its literal regex is NOT an
     // archetype id, so VDFAI must not fire (master05 §Archetype Slots; the
     // VDFAI subject is the archetype identifier).

--- a/crates/openehr-adl/tests/it/adl14_conversion.rs
+++ b/crates/openehr-adl/tests/it/adl14_conversion.rs
@@ -487,6 +487,9 @@ fn conversion_writes_out_the_14_default_occurrences_on_container_children() {
 archetype (adl_version=1.4)
 \topenEHR-EHR-CLUSTER.default_occurrences.v1
 
+concept
+\t[at0000]
+
 language
 \toriginal_language = <[ISO_639-1::en]>
 

--- a/crates/openehr-adl/tests/it/adl14_header_sections.rs
+++ b/crates/openehr-adl/tests/it/adl14_header_sections.rs
@@ -1,0 +1,391 @@
+//! The ADL 1.4 **header sections** — `AM/docs/ADL1.4/master08-adl.adoc`
+//! §Header Sections, §Syntax Specification (the grammar + §Symbols lexical
+//! rules) and §Validity Rules.
+//!
+//! Three behaviours of the 1.4 outer structure that ADL2 does not share, each
+//! pinned here with both twins (`.claude/rules/testing.md`):
+//!
+//! 1. **Section keywords are case-insensitive.** §Symbols spells every one of
+//!    them in the bracketed-alternative form
+//!    (`^[Aa][Rr][Cc][Hh][Ee][Tt][Yy][Pp][Ee][ \t\r]*\n -> SYM_ARCHETYPE`, and
+//!    likewise `SYM_SPECIALIZE`/`SYM_CONCEPT`/`SYM_DEFINITION`/`SYM_LANGUAGE`/
+//!    `SYM_DESCRIPTION`/`SYM_INVARIANT`/`SYM_ONTOLOGY`). The ADL2 grammar
+//!    (`adl_keywords.g4`) spells them as exact lowercase literals, so the
+//!    tolerance is `Dialect::Adl14`-only — the refusing twin is an ADL2 source.
+//! 2. **The old form without a `language` section is accepted and upgraded.**
+//!    §Syntax Specification has `arch_language: // empty OK`, and both
+//!    §Language Section and Language Translation and §Ontology Header
+//!    Statements instruct tool builders to accept archetypes carrying
+//!    `primary_language`/`languages_available` in the ontology and upgrade them
+//!    on parse to `original_language`/`translations`. With no
+//!    `primary_language` to upgrade from, `SALAN` stands.
+//! 3. **The `concept` section is mandatory and its term must be defined.**
+//!    §Syntax Specification gives `arch_concept: SYM_CONCEPT
+//!    V_LOCAL_TERM_CODE_REF | SYM_CONCEPT error` — the only header production
+//!    with no empty alternative — and §Validity Rules VARCN: "The archetype
+//!    must have an archetype term value in the concept section. The term must
+//!    exist in the archetype ontology."
+
+#![allow(
+    clippy::expect_used,
+    clippy::panic,
+    reason = "integration-test assertions and fixture plumbing outside #[test] fns, which the clippy.toml allow-*-in-tests scoping does not reach"
+)]
+
+use openehr_adl::assemble::parse_artefact_adl14;
+use openehr_adl::error::{SyntaxError, SyntaxErrorCode};
+use openehr_adl::source::{parse_source, parse_source_adl14};
+use openehr_adl::validate::{Severity, ValidationCode, validate_source_phase1_adl14};
+use openehr_am::am24::aom2::archetype::archetype::Archetype;
+use openehr_am::am24::aom2::archetype::authored_archetype::{
+    AuthoredArchetype, AuthoredArchetypeData,
+};
+
+/// A well-formed ADL 1.4 archetype in the canonical lower-case spelling.
+const LOWER_CASE_14: &str = "\
+archetype (adl_version=1.4)
+\topenEHR-EHR-CLUSTER.header_sections.v1
+
+concept
+\t[at0000]\t-- Header sections
+
+language
+\toriginal_language = <[ISO_639-1::en]>
+
+description
+\tlifecycle_state = <\"AuthorDraft\">
+
+definition
+\tCLUSTER[at0000] matches {
+\t\titems cardinality matches {0..*; unordered} matches {
+\t\t\tELEMENT[at0001] occurrences matches {0..1} matches {*}
+\t\t}
+\t}
+
+ontology
+\tterm_definitions = <
+\t\t[\"en\"] = <
+\t\t\titems = <
+\t\t\t\t[\"at0000\"] = <text=<\"root\"> description=<\"root\">>
+\t\t\t\t[\"at0001\"] = <text=<\"element\"> description=<\"element\">>
+\t\t\t>
+\t\t>
+\t>
+";
+
+/// The same archetype with every SECTION KEYWORD in a different case — the
+/// §Symbols lexical rules fold all of them.
+const MIXED_CASE_14: &str = "\
+ARCHETYPE (adl_version=1.4)
+\topenEHR-EHR-CLUSTER.header_sections.v1
+
+Concept
+\t[at0000]\t-- Header sections
+
+LANGUAGE
+\toriginal_language = <[ISO_639-1::en]>
+
+DeScRiPtIoN
+\tlifecycle_state = <\"AuthorDraft\">
+
+DEFINITION
+\tCLUSTER[at0000] matches {
+\t\titems cardinality matches {0..*; unordered} matches {
+\t\t\tELEMENT[at0001] occurrences matches {0..1} matches {*}
+\t\t}
+\t}
+
+ONTOLOGY
+\tterm_definitions = <
+\t\t[\"en\"] = <
+\t\t\titems = <
+\t\t\t\t[\"at0000\"] = <text=<\"root\"> description=<\"root\">>
+\t\t\t\t[\"at0001\"] = <text=<\"element\"> description=<\"element\">>
+\t\t\t>
+\t\t>
+\t>
+";
+
+/// A minimal ADL2 source (exact-lowercase keywords, `adl_keywords.g4`).
+const LOWER_CASE_ADL2: &str = "\
+archetype (adl_version=2.0.5; rm_release=1.0.2)
+\topenehr-TEST_PKG-WHOLE.case.v1.0.0
+
+language
+\toriginal_language = <[ISO_639-1::en]>
+
+description
+\tlifecycle_state = <\"published\">
+
+definition
+\tWHOLE[id1]
+
+terminology
+\tterm_definitions = <
+\t\t[\"en\"] = <
+\t\t\t[\"id1\"] = <text=<\"root\"> description=<\"root\">>
+\t\t>
+\t>
+";
+
+/// The `AUTHORED_ARCHETYPE` data of an assembled archetype.
+fn authored(archetype: &Archetype) -> &AuthoredArchetypeData {
+    match archetype {
+        Archetype::AuthoredArchetype(a) => match a.as_ref() {
+            AuthoredArchetype::AuthoredArchetype(d) => d,
+            other
+            @ (AuthoredArchetype::Template(_) | AuthoredArchetype::OperationalTemplate(_)) => {
+                panic!("expected a plain AUTHORED_ARCHETYPE, got {other:?}")
+            }
+        },
+        other @ Archetype::TemplateOverlay(_) => {
+            panic!("expected an AUTHORED_ARCHETYPE, got {other:?}")
+        }
+    }
+}
+
+/// The phase-1 error codes a 1.4 source raises.
+fn error_codes(src: &str) -> Vec<ValidationCode> {
+    validate_source_phase1_adl14(src)
+        .expect("the 1.4 source parses")
+        .into_iter()
+        .filter(|i| i.severity == Severity::Error)
+        .map(|i| i.code)
+        .collect()
+}
+
+/// §Symbols: `^[Aa][Rr][Cc][Hh][Ee][Tt][Yy][Pp][Ee]…` — every 1.4 section
+/// keyword lexes case-insensitively, so the mixed-case spelling must parse,
+/// assemble and validate exactly like the canonical one.
+#[expect(
+    clippy::panic_in_result_fn,
+    reason = "the Book ch11 test shape: `?` propagates the parse plumbing while the \
+              assertions ARE the test — an assertion panic is how this test fails, and \
+              the clippy.toml allow-*-in-tests scoping does not reach an integration \
+              test binary"
+)]
+#[test]
+fn adl14_section_keywords_are_case_insensitive() -> Result<(), Vec<SyntaxError>> {
+    let lower = parse_artefact_adl14(LOWER_CASE_14)?;
+    let mixed = parse_artefact_adl14(MIXED_CASE_14)?;
+    assert_eq!(authored(&mixed).archetype_id, authored(&lower).archetype_id);
+    assert_eq!(authored(&mixed).definition, authored(&lower).definition);
+    assert_eq!(authored(&mixed).terminology, authored(&lower).terminology);
+    assert!(error_codes(MIXED_CASE_14).is_empty());
+    Ok(())
+}
+
+/// §Specialise Section + §Symbols
+/// (`^[Ss][Pp][Ee][Cc][Ii][Aa][Ll][Ii][SsZz][Ee]`): both spellings of the word
+/// AND any case of either are the same keyword.
+#[expect(
+    clippy::panic_in_result_fn,
+    reason = "the Book ch11 test shape: `?` propagates the parse plumbing while the \
+              assertions ARE the test — an assertion panic is how this test fails, and \
+              the clippy.toml allow-*-in-tests scoping does not reach an integration \
+              test binary"
+)]
+#[test]
+fn adl14_specialise_keyword_is_case_insensitive() -> Result<(), Vec<SyntaxError>> {
+    for spelling in ["Specialise", "SPECIALIZE", "specialise", "specialize"] {
+        let src = LOWER_CASE_14.replacen(
+            "\nconcept\n\t[at0000]",
+            &format!(
+                "\n{spelling}\n\topenEHR-EHR-CLUSTER.header_sections.v1\n\nconcept\n\t[at0000.1]"
+            ),
+            1,
+        );
+        let parsed = parse_source_adl14(&src)?;
+        let parent = parsed
+            .parent_ref
+            .expect("the specialise parent is captured");
+        assert_eq!(parent.concept_id, "header_sections");
+        assert_eq!(parsed.concept.as_deref(), Some("at0000.1"));
+    }
+    Ok(())
+}
+
+/// The refusing twin of the two tests above: the ADL2 grammar spells its
+/// keywords as exact lowercase literals (`adl_keywords.g4`), so an upper-case
+/// word is not a keyword there. `ARCHETYPE` is no artefact keyword (`SUNK`),
+/// and `TERMINOLOGY` is no section header — the word is swallowed by the
+/// preceding section's body, leaving the artefact without a terminology
+/// section (`SAON`).
+#[expect(
+    clippy::panic_in_result_fn,
+    reason = "the Book ch11 test shape: `?` propagates the parse plumbing while the \
+              assertions ARE the test — an assertion panic is how this test fails, and \
+              the clippy.toml allow-*-in-tests scoping does not reach an integration \
+              test binary"
+)]
+#[test]
+fn adl2_rejects_upper_case_section_keywords() -> Result<(), Vec<SyntaxError>> {
+    parse_source(LOWER_CASE_ADL2)?;
+
+    let upper_artefact = LOWER_CASE_ADL2.replacen("archetype", "ARCHETYPE", 1);
+    let errs = parse_source(&upper_artefact).expect_err("ADL2 keywords are case-sensitive");
+    assert!(
+        errs.iter().any(|e| e.code == SyntaxErrorCode::Sunk),
+        "{errs:?}"
+    );
+
+    let upper_section = LOWER_CASE_ADL2.replacen("\nterminology\n", "\nTERMINOLOGY\n", 1);
+    let errs = parse_source(&upper_section).expect_err("ADL2 keywords are case-sensitive");
+    assert!(
+        errs.iter().any(|e| e.code == SyntaxErrorCode::Saon),
+        "{errs:?}"
+    );
+    Ok(())
+}
+
+/// An old-form 1.4 archetype: no `language` section, `primary_language` +
+/// `languages_available` in the ontology instead. §Language Section and
+/// Language Translation + §Ontology Header Statements: "tool builders should
+/// consider accepting archetypes of the old form and upgrading them when
+/// parsing to the correct form, which should then be used for
+/// serialising/saving."
+const OLD_FORM_14: &str = "\
+archetype (adl_version=1.4)
+\topenEHR-EHR-CLUSTER.old_form_language.v1
+
+concept
+\t[at0000]\t-- Old-form language
+
+description
+\tlifecycle_state = <\"AuthorDraft\">
+
+definition
+\tCLUSTER[at0000] matches {
+\t\titems cardinality matches {0..*; unordered} matches {
+\t\t\tELEMENT[at0001] occurrences matches {0..1} matches {*}
+\t\t}
+\t}
+
+ontology
+\tprimary_language = <\"en\">
+\tlanguages_available = <\"en\", \"de\", ...>
+\tterm_definitions = <
+\t\t[\"en\"] = <
+\t\t\titems = <
+\t\t\t\t[\"at0000\"] = <text=<\"root\"> description=<\"root\">>
+\t\t\t\t[\"at0001\"] = <text=<\"element\"> description=<\"element\">>
+\t\t\t>
+\t\t>
+\t\t[\"de\"] = <
+\t\t\titems = <
+\t\t\t\t[\"at0000\"] = <text=<\"wurzel\"> description=<\"wurzel\">>
+\t\t\t\t[\"at0001\"] = <text=<\"element\"> description=<\"element\">>
+\t\t\t>
+\t\t>
+\t>
+";
+
+#[expect(
+    clippy::panic_in_result_fn,
+    reason = "the Book ch11 test shape: `?` propagates the parse plumbing while the \
+              assertions ARE the test — an assertion panic is how this test fails, and \
+              the clippy.toml allow-*-in-tests scoping does not reach an integration \
+              test binary"
+)]
+#[test]
+fn adl14_old_form_language_is_upgraded_from_the_ontology() -> Result<(), Vec<SyntaxError>> {
+    let archetype = parse_artefact_adl14(OLD_FORM_14)?;
+    let data = authored(&archetype);
+    // `primary_language` → `original_language`.
+    assert_eq!(data.original_language.code_string, "en");
+    assert_eq!(data.original_language.terminology_id, "ISO_639-1");
+    // every other `languages_available` entry → a minimal translation.
+    let translations = data
+        .translations
+        .as_ref()
+        .expect("languages_available yields translations");
+    assert_eq!(translations.keys().collect::<Vec<_>>(), vec!["de"]);
+    assert_eq!(
+        translations
+            .get("de")
+            .expect("the de translation")
+            .language
+            .code_string,
+        "de"
+    );
+    // the terminology's own original_language follows the upgrade.
+    assert_eq!(data.terminology.original_language, "en");
+    Ok(())
+}
+
+/// The refusing twin: with NO `primary_language` in the ontology there is
+/// nothing to upgrade from, so the missing `language` section stays `SALAN`.
+#[test]
+fn adl14_old_form_without_primary_language_is_salan() {
+    let src = OLD_FORM_14.replacen("\tprimary_language = <\"en\">\n", "", 1);
+    let errs = parse_artefact_adl14(&src).expect_err("nothing to upgrade from");
+    assert!(
+        errs.iter().any(|e| e.code == SyntaxErrorCode::Salan),
+        "{errs:?}"
+    );
+}
+
+/// ADL2 keeps `SALAN` unconditionally: it has no old form to upgrade.
+#[test]
+fn adl2_missing_language_section_is_salan() {
+    let src = LOWER_CASE_ADL2.replacen(
+        "language\n\toriginal_language = <[ISO_639-1::en]>\n\n",
+        "",
+        1,
+    );
+    let errs = parse_source(&src).expect_err("ADL2 requires a language section");
+    assert!(
+        errs.iter().any(|e| e.code == SyntaxErrorCode::Salan),
+        "{errs:?}"
+    );
+}
+
+/// §Syntax Specification `arch_concept` has no empty alternative (unlike
+/// `arch_specialisation`/`arch_language`/`arch_description`/`arch_invariant`),
+/// and §Validity Rules VARCN requires the term value: a 1.4 archetype without a
+/// `concept` section is refused with the concept clause's catalogue code.
+#[test]
+fn adl14_missing_concept_section_is_saco() {
+    let src = LOWER_CASE_14.replacen("concept\n\t[at0000]\t-- Header sections\n\n", "", 1);
+    assert!(!src.contains("concept"), "the concept section was removed");
+    let errs = parse_artefact_adl14(&src).expect_err("1.4 mandates the concept section");
+    assert!(
+        errs.iter().any(|e| e.code == SyntaxErrorCode::Saco),
+        "{errs:?}"
+    );
+}
+
+/// The same code for the grammar's `SYM_CONCEPT error` alternative: a `concept`
+/// clause whose body is not a local term-code reference.
+#[test]
+fn adl14_malformed_concept_clause_is_saco() {
+    let src = LOWER_CASE_14.replacen("\t[at0000]\t-- Header sections", "\t\"at0000\"", 1);
+    let errs = parse_artefact_adl14(&src).expect_err("the concept clause needs a term code");
+    assert!(
+        errs.iter().any(|e| e.code == SyntaxErrorCode::Saco),
+        "{errs:?}"
+    );
+}
+
+/// VARCN, terminology half: "The term must exist in the archetype ontology."
+/// `[at0099]` is defined nowhere in `term_definitions`.
+#[test]
+fn adl14_undefined_concept_term_raises_varcn() {
+    let src = LOWER_CASE_14.replacen("\t[at0000]\t-- Header", "\t[at0099]\t-- Header", 1);
+    assert!(
+        error_codes(&src).contains(&ValidationCode::Varcn),
+        "expected VARCN, got {:?}",
+        error_codes(&src)
+    );
+}
+
+/// The accepting twin: the concept term IS defined in the ontology, so VARCN
+/// stays quiet and the whole 1.4 phase-1 subset is clean.
+#[test]
+fn adl14_defined_concept_term_validates_clean() {
+    assert!(
+        error_codes(LOWER_CASE_14).is_empty(),
+        "expected a clean 1.4 validation, got {:?}",
+        error_codes(LOWER_CASE_14)
+    );
+}

--- a/crates/openehr-adl/tests/it/legacy14_corpus.rs
+++ b/crates/openehr-adl/tests/it/legacy14_corpus.rs
@@ -15,7 +15,9 @@
 //!   ([`openehr_adl::validate::validate_source_phase1_adl14`]; every file here
 //!   is `regression`-tagged PASS), EXCEPT `FAIL_c_dv_quantity_minimal.v1.adl`
 //!   which rejects at parse with `SDINV` (its `regression` tag) — an empty
-//!   `(C_DV_QUANTITY) <>` inline dADL block.
+//!   `(C_DV_QUANTITY) <>` inline dADL block — and the two concept-less
+//!   fixtures, which reject with `SACO` against the spec text over their own
+//!   `PASS` tag (adjudication + citation at the assertion site).
 //! - `features/**/*.adl` — parse (1.4 dialect) clean.
 //! - `adl14-dadl/*.adl` — the hand-written dADL breadth tree, claimed by
 //!   `adl14_dadl_breadth.rs` (accept/refuse per fixture, leaf values
@@ -36,6 +38,14 @@ use openehr_adl::adl14::log::ConversionLog;
 use openehr_adl::assemble::parse_artefact_adl14;
 use openehr_adl::error::SyntaxErrorCode;
 use openehr_adl::validate::{Severity, validate_source_phase1_adl14};
+
+/// The vendored `legacy_adl_1.4` fixtures that carry no `concept` section and
+/// are therefore refused with `SACO` (the adjudication is stated at the
+/// assertion site below).
+const CONCEPT_LESS: &[&str] = &[
+    "openehr-test_pkg-SOME_TYPE.c_dv_quantity.v1.adl",
+    "openehr-test_pkg-SOME_TYPE.code_phrase.v1.adl",
+];
 
 fn corpus_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/corpus")
@@ -97,6 +107,27 @@ fn every_adl_file_is_claimed_with_an_outcome() {
                 assert!(
                     err.iter().any(|e| e.code == SyntaxErrorCode::Sdinv),
                     "{r}: expected SDINV, got {:?}",
+                    err.iter().map(|e| e.code).collect::<Vec<_>>()
+                );
+            } else if CONCEPT_LESS.iter().any(|f| r.ends_with(f)) {
+                // Adjudicated against the spec text, over the file's own `PASS`
+                // tag: these two vendored fixtures carry NO `concept` section,
+                // which ADL 1.4 does not allow. `ADL1.4/master08-adl.adoc`
+                // §Syntax Specification gives `arch_concept: SYM_CONCEPT
+                // V_LOCAL_TERM_CODE_REF | SYM_CONCEPT error` — no empty
+                // alternative, unlike `arch_specialisation`/`arch_language`/
+                // `arch_description`/`arch_invariant` — and §Validity Rules
+                // VARCN: "The archetype must have an archetype term value in the
+                // concept section." The ADL Workbench that produced the tag is
+                // prior art, not the oracle. Their concept-carrying twins live
+                // in `adl14-cadl/` (see `adl14_cadl_gates.rs`), so the
+                // constructs they exercise keep their accepting coverage.
+                let err = parse_artefact_adl14(&src)
+                    .err()
+                    .unwrap_or_else(|| panic!("{r}: a concept-less 1.4 source must reject"));
+                assert!(
+                    err.iter().any(|e| e.code == SyntaxErrorCode::Saco),
+                    "{r}: expected SACO, got {:?}",
                     err.iter().map(|e| e.code).collect::<Vec<_>>()
                 );
             } else {

--- a/crates/openehr-adl/tests/it/main.rs
+++ b/crates/openehr-adl/tests/it/main.rs
@@ -11,6 +11,7 @@ mod adl14_cadl_gates;
 mod adl14_cnf_fixture_slot;
 mod adl14_conversion;
 mod adl14_dadl_breadth;
+mod adl14_header_sections;
 mod assembly;
 mod corpus_coverage;
 mod corpus_definition_parse;


### PR DESCRIPTION
Closes #1323 (sub-issue of #770, the ADL1.4 ch.8 audit, v3.15.0 AM program).

## What

Three outer-structure divergences from `ADL1.4/master08-adl.adoc`:

1. **Case-insensitive section keywords** (§Symbols `^[Aa][Rr]…` lex patterns): new `source::parse_source_adl14` — the entry every 1.4 caller now uses — classifies keywords case-folded (`AlphaLcId`/`AlphaUcId`); ADL2 parsing stays byte-identical (exact lowercase, pinned by a rejecting twin test).
2. **Old-form language compat** (§Language Section NOTE + §Ontology Header Statements NOTE): a 1.4 archetype with `primary_language`/`languages_available` in its ontology and no `language` section is accepted and upgraded on parse to `original_language` + minimal `translations`; absent both, `SALAN` stands. ADL2 keeps `SALAN` unconditionally.
3. **Concept section enforced** (§Syntax Specification `arch_concept` — no empty alternative; §Validity Rules VARCN): the concept code is captured; missing/malformed clause → `SACO` (the existing catalogue code); a concept term absent from `term_definitions` → `VARCN` on the `Dialect::Adl14` phase-1 path.

## Corpus adjudication

Two vendored `legacy_adl_1.4` fixtures (`openehr-test_pkg-SOME_TYPE.{c_dv_quantity,code_phrase}.v1`) carry no concept section yet are tagged `regression = PASS`. Under `arch_concept` + VARCN they are invalid 1.4 — the ADL Workbench tag is prior art, not the oracle — so they are pinned as `SACO` refusals with the citation at the assertion site, and concept-carrying twins were added under `tests/corpus/adl14-cadl/` so the inline-dADL `C_DV_QUANTITY`/`CODE_PHRASE` coverage is preserved (valid+invalid twins rule; INVENTORY/PROVENANCE updated).

## Tests

New `tests/it/adl14_header_sections.rs` module: case-insensitivity accept + ADL2 reject twins, old-form upgrade + no-primary-language SALAN + ADL2 SALAN, missing/malformed concept SACO, undefined-concept VARCN + defined-concept clean twin.

## Gates

- `cargo fmt --all --check` clean
- `cargo clippy --workspace --exclude ehrbase-admin-ui --all-targets --all-features` — zero warnings (exact CI flags)
- `cargo nextest run -p openehr-adl -p ehrbase` — 954/954 pass