### PR TITLE
fix(openehr-adl): lower inline dADL C_CODE_PHRASE and parse the 1.4 pipe-ordinal shorthand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,27 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **ADL 1.4 archetypes using the chapter's custom constraint forms now
+  upload.** Two constructs of ADL 1.4 §Customising ADL (master09) were
+  rejected outright:
+  - the inline dADL `C_CODE_PHRASE <…>` section — the chapter's own worked
+    example — is now read and lowered to exactly the constraint its compact
+    `[local:: at0039, at0040]` twin produces (the chapter presents them as two
+    spellings of the same constraint), including an `assumed_value`
+    `CODE_PHRASE`; a block that is not a `C_CODE_PHRASE` instance (no
+    terminology, no or empty code list, an attribute the type does not define)
+    is refused with a syntax error naming the defect instead of being guessed
+    at;
+  - the openEHR-profiled ordinal shorthand `0|[local::at0005],
+    1|[local::at0006]` — ubiquitous in real 1.4 scores and scales, and
+    optionally carrying a `; assumed` value — now parses in ADL 1.4 and is
+    lowered to the generic `DV_ORDINAL` `[value, symbol]` tuple that ADL 2
+    names as its replacement. ADL 2, which removed the form, still refuses it.
+
+  Both forms' codes take part in validation exactly as the equivalent standard
+  spellings do (an undefined at-code still raises `VATDF`). `C_DV_STATE`, the
+  remaining custom constrainer, has no shape in any openEHR specification and
+  stays a loud refusal naming the type.
 - **ADL 1.4 archetypes whose section keywords are not all-lowercase now
   upload.** The ADL 1.4 lexical specification (master08 §Symbols) spells
   every section keyword case-insensitively, so `ARCHETYPE (adl_version=1.4)`,

--- a/crates/openehr-adl/src/cadl.rs
+++ b/crates/openehr-adl/src/cadl.rs
@@ -1071,6 +1071,13 @@ impl Parser<'_> {
             let obj = self.parse_adl14_term_object()?;
             return Ok(vec![obj]);
         }
+        // 1.4-only: the pipe-ordinal shorthand `0|[local::at0005], 1|[…]`
+        // (`cadl14.g4` `c_ordinal`, one of the `c_non_primitive_object`
+        // alternatives — so it stands exactly where an object is expected).
+        if self.dialect == Dialect::Adl14 && self.is_adl14_ordinal_start() {
+            let obj = self.parse_adl14_ordinal()?;
+            return Ok(vec![obj]);
+        }
         if self.is_inline_primitive_start() {
             let obj = self.parse_c_inline_primitive("Primitive_node_id".to_owned())?;
             return Ok(vec![obj]);
@@ -1234,11 +1241,7 @@ impl Parser<'_> {
     ///
     /// The list form additionally carries the two catalogue rules on the code
     /// list itself — STCDC (duplicates) and STCAC (an assumed code outside the
-    /// list), both raised at position below.
-    #[expect(
-        clippy::too_many_lines,
-        reason = "one linear parse: bracket, codes, assumed, the two list rules"
-    )]
+    /// list), both raised by [`Parser::adl14_term_constraint`].
     fn parse_adl14_term_object(&mut self) -> PResult<CObject> {
         let constraint = if let Some(Token::TermCodeRef(raw)) = self.peek().cloned() {
             self.pos += 1;
@@ -1304,83 +1307,265 @@ impl Parser<'_> {
                 SyntaxErrorCode::Stccp,
                 "expecting ']' closing a terminology code",
             )?;
-            // STCDC: "duplicate code(s) found in code list"
-            // (`ADL2/master04.6-cadl_validity_rules.adoc` §Syntax Validity
-            // Rules). A repeated member adds no value to the constrained set
-            // and is a defect in the source, not a silently-collapsed set.
-            let mut seen: Vec<&str> = Vec::with_capacity(codes.len());
-            let duplicates: Vec<&str> = codes
-                .iter()
-                .filter(|c| {
-                    let dup = seen.contains(&c.as_str());
-                    seen.push(c.as_str());
-                    dup
-                })
-                .map(String::as_str)
-                .collect();
-            if !duplicates.is_empty() {
-                self.push(
-                    SyntaxErrorCode::Stcdc,
-                    format!(
-                        "duplicate code(s) found in code list: {}",
-                        duplicates.join(", ")
-                    ),
-                    list_span.clone(),
-                );
-                return Err(());
-            }
-            // STCAC: "assumed value code $1 not found in code list" (same
-            // catalogue). `ADL1.4/master05-cadl.adoc` §Assumed Values L1012
-            // requires the assumed value to be "a value of the same type as
-            // that implied by the preceding part of the constraint" — for a
-            // listed term constraint the implied type is the listed set, so an
-            // assumed code outside it can never be assumed.
-            if let Some(a) = assumed.as_deref()
-                && !codes.iter().any(|c| c == a)
-            {
-                self.push(
-                    SyntaxErrorCode::Stcac,
-                    format!("assumed value code {a} not found in code list"),
-                    list_span,
-                );
-                return Err(());
-            }
-            let mut s = format!("{terminology}::{}", codes.join(","));
-            if let Some(a) = assumed {
-                s.push(';');
-                s.push_str(&a);
-            }
-            s
+            self.adl14_term_constraint(&terminology, &codes, assumed.as_deref(), list_span)?
         };
-        Ok(CObject::CTerminologyCode(CTerminologyCode {
-            parent: None,
-            soc_parent: None,
-            rm_type_name: "Terminology_code".to_owned(),
-            occurrences: None,
-            node_id: "Primitive_node_id".to_owned(),
-            alternative_ids: Vec::new(),
-            is_deprecated: None,
-            sibling_order: None,
-            default_value: None,
-            assumed_value: None,
-            is_enumerated_type_constraint: None,
-            constraint,
-            constraint_status: None,
-        }))
+        Ok(adl14_terminology_code(constraint))
+    }
+
+    /// Build the verbatim `terminology::code[,code]*[;assumed]` constraint string
+    /// of a 1.4 term constraint, enforcing the two catalogue rules that govern
+    /// the code list itself.
+    ///
+    /// Shared by the two 1.4 spellings of one and the same constraint — the
+    /// compact custom syntax `[local:: at0039, at0040]` and the inline dADL
+    /// `C_CODE_PHRASE <…>` block — which
+    /// `ADL1.4/master09-customising_adl.adoc` §Custom Syntax says "express
+    /// exactly the same constraint", so they must also be judged by the same
+    /// rules.
+    fn adl14_term_constraint(
+        &mut self,
+        terminology: &str,
+        codes: &[String],
+        assumed: Option<&str>,
+        span: std::ops::Range<usize>,
+    ) -> PResult<String> {
+        // STCDC: "duplicate code(s) found in code list"
+        // (`ADL2/master04.6-cadl_validity_rules.adoc` §Syntax Validity
+        // Rules). A repeated member adds no value to the constrained set
+        // and is a defect in the source, not a silently-collapsed set.
+        let mut seen: Vec<&str> = Vec::with_capacity(codes.len());
+        let duplicates: Vec<&str> = codes
+            .iter()
+            .filter(|c| {
+                let dup = seen.contains(&c.as_str());
+                seen.push(c.as_str());
+                dup
+            })
+            .map(String::as_str)
+            .collect();
+        if !duplicates.is_empty() {
+            self.push(
+                SyntaxErrorCode::Stcdc,
+                format!(
+                    "duplicate code(s) found in code list: {}",
+                    duplicates.join(", ")
+                ),
+                span,
+            );
+            return Err(());
+        }
+        // STCAC: "assumed value code $1 not found in code list" (same
+        // catalogue). `ADL1.4/master05-cadl.adoc` §Assumed Values L1012
+        // requires the assumed value to be "a value of the same type as
+        // that implied by the preceding part of the constraint" — for a
+        // listed term constraint the implied type is the listed set, so an
+        // assumed code outside it can never be assumed.
+        if let Some(a) = assumed
+            && !codes.iter().any(|c| c == a)
+        {
+            self.push(
+                SyntaxErrorCode::Stcac,
+                format!("assumed value code {a} not found in code list"),
+                span,
+            );
+            return Err(());
+        }
+        let mut s = format!("{terminology}::{}", codes.join(","));
+        if let Some(a) = assumed {
+            s.push(';');
+            s.push_str(a);
+        }
+        Ok(s)
+    }
+
+    /// True if the cursor is at the ADL 1.4 pipe-ordinal shorthand — a numeric
+    /// ordinal value immediately followed by the `|` separator
+    /// (`cadl14.g4` `ordinal_term : (integer_value | real_value) '|'
+    /// c_terminology_code`).
+    ///
+    /// The `|` is what discriminates it from every other numeric constraint: a
+    /// value list continues with `,`, an interval OPENS with `|`, and a range
+    /// separator is `..` — none of them puts `|` directly after a number.
+    fn is_adl14_ordinal_start(&self) -> bool {
+        let signed = usize::from(matches!(
+            self.peek(),
+            Some(Token::SymPlus | Token::SymMinus)
+        ));
+        matches!(
+            self.peek_at(signed),
+            Some(Token::Integer(_) | Token::Real(_))
+        ) && matches!(self.peek_at(signed + 1), Some(Token::SymIvlDelim))
+    }
+
+    /// 1.4-only: the openEHR-profiled ordinal shorthand
+    /// `0|[local::at0005], 1|[local::at0006] ; 0` (`cadl14.g4` `c_ordinal :
+    /// ordinal_term (',' ordinal_term)* (';' assumed_ordinal_value)?`).
+    ///
+    /// `ADL2/master04.4-cadl_second_order.adoc` §Tuple Constraints names this
+    /// exact form deprecated and gives its replacement in the same breath — the
+    /// generic `DV_ORDINAL` tuple `[value, symbol] ∈ { [{0}, {[at1]}], … }`,
+    /// noting that the 1.4 spelling "hides the `DV_ORDINAL` type altogether".
+    /// So it lowers to precisely that replacement: a `DV_ORDINAL`
+    /// `C_COMPLEX_OBJECT` whose single `[value, symbol]` attribute tuple has one
+    /// row per ordinal term, pairing the integer/real value constraint with the
+    /// symbol's terminology-code constraint. `AOM1.4/masterAppA-domain_extension.adoc`
+    /// §ORDINAL is the member typing (`value: Integer`, `symbol: CODE_PHRASE`).
+    ///
+    /// The form is ADL 1.4-only: ADL 2 removed it, so the ADL2 dialect never
+    /// reaches this production and refuses the text.
+    fn parse_adl14_ordinal(&mut self) -> PResult<CObject> {
+        let start = self.cur_span().start;
+        let mut tuples: Vec<CPrimitiveTuple> = Vec::new();
+        loop {
+            let is_real = matches!(
+                self.peek_at(usize::from(matches!(
+                    self.peek(),
+                    Some(Token::SymPlus | Token::SymMinus)
+                ))),
+                Some(Token::Real(_))
+            );
+            let value = if is_real {
+                CPrimitiveObject::CReal(creal_values(vec![point_real(
+                    self.parse_signed_real(SyntaxErrorCode::Scrav)?,
+                )]))
+            } else {
+                CPrimitiveObject::CInteger(cinteger_values(vec![point_int(i64::from(
+                    self.parse_signed_int(SyntaxErrorCode::Sciav)?,
+                ))]))
+            };
+            self.expect(
+                |t| matches!(t, Token::SymIvlDelim),
+                SyntaxErrorCode::Sccog,
+                "expecting '|' between an ordinal value and its symbol",
+            )?;
+            let symbol = self.parse_adl14_ordinal_symbol()?;
+            tuples.push(CPrimitiveTuple {
+                members: vec![value, symbol],
+            });
+            if !self.eat(|t| matches!(t, Token::SymComma)) {
+                break;
+            }
+        }
+        if self.eat(|t| matches!(t, Token::SymSemiColon)) {
+            self.apply_adl14_ordinal_assumed(&mut tuples, start)?;
+        }
+        Ok(complex_object(
+            "DV_ORDINAL".to_owned(),
+            String::new(),
+            Vec::new(),
+            vec![CAttributeTuple {
+                members: vec![cattr_empty("value"), cattr_empty("symbol")],
+                tuples,
+            }],
+            None,
+        ))
+    }
+
+    /// The symbol half of an ordinal term: `c_terminology_code`
+    /// (`cadl14_primitives.g4`), i.e. the qualified `[local::at0005]` /
+    /// `[SNOMED-CT::12345]` form or the bare local `[at0005]` / `[ac0001]` form.
+    fn parse_adl14_ordinal_symbol(&mut self) -> PResult<CPrimitiveObject> {
+        let obj = if self.is_adl14_qualified_code_start() {
+            self.parse_adl14_term_object()?
+        } else if matches!(self.peek(), Some(Token::LBracket))
+            && matches!(self.peek_at(1), Some(Token::AtCode(_) | Token::AcCode(_)))
+        {
+            self.parse_c_terminology_code("Primitive_node_id".to_owned(), None)?
+        } else {
+            return self.err(
+                SyntaxErrorCode::Stccp,
+                "expecting a terminology code as the ordinal symbol",
+            );
+        };
+        cobject_to_primitive(obj).map_or_else(
+            || {
+                self.err(
+                    SyntaxErrorCode::Stccp,
+                    "the ordinal symbol is not a terminology-code constraint",
+                )
+            },
+            Ok,
+        )
+    }
+
+    /// Land the `; assumed_ordinal_value` tail (`cadl14.g4`
+    /// `assumed_ordinal_value : INTEGER | REAL`) on the ordinal term it names.
+    ///
+    /// The assumed value is an ordinal VALUE, so it belongs to exactly one term
+    /// of the list — the AOM2 carrier is that row's own value
+    /// `C_PRIMITIVE_OBJECT.assumed_value` (`AOM2/master04.2` §`Assumed_value` puts
+    /// `assumed_value` on `C_PRIMITIVE_OBJECT`). A value naming no term is
+    /// refused loudly rather than bound to an arbitrary row, on the same reading
+    /// as the listed term constraint's STCAC: `ADL1.4/master05-cadl.adoc`
+    /// §Assumed Values L1012 requires the assumed value to be "a value of the
+    /// same type as that implied by the preceding part of the constraint".
+    fn apply_adl14_ordinal_assumed(
+        &mut self,
+        tuples: &mut [CPrimitiveTuple],
+        start: usize,
+    ) -> PResult<()> {
+        let is_real = matches!(
+            self.peek_at(usize::from(matches!(
+                self.peek(),
+                Some(Token::SymPlus | Token::SymMinus)
+            ))),
+            Some(Token::Real(_))
+        );
+        let code = if is_real {
+            SyntaxErrorCode::Scrav
+        } else {
+            SyntaxErrorCode::Sciav
+        };
+        let assumed = if is_real {
+            self.parse_signed_real(code)?
+        } else {
+            f64::from(self.parse_signed_int(code)?)
+        };
+        let span = start..self.span_at(self.pos.saturating_sub(1)).end;
+        let row = tuples.iter_mut().find(|row| {
+            row.members
+                .first()
+                .and_then(ordinal_point_value)
+                .is_some_and(|v| (v - assumed).abs() < f64::EPSILON)
+        });
+        let Some(row) = row else {
+            self.push(
+                code,
+                format!("assumed ordinal value {assumed} is not one of the listed ordinals"),
+                span,
+            );
+            return Err(());
+        };
+        match row.members.first_mut() {
+            Some(CPrimitiveObject::CInteger(c)) => c.assumed_value = Some(assumed),
+            Some(CPrimitiveObject::CReal(c)) => c.assumed_value = Some(assumed),
+            // Unreachable: `ordinal_point_value` answered `Some` for this member
+            // just above, and it answers `Some` only for those two kinds.
+            _ => {}
+        }
+        Ok(())
     }
 
     /// 1.4-only: an inline dADL domain constraint `(C_DV_QUANTITY) <…>` /
-    /// `C_DV_ORDINAL <…>`. The ODIN block is parsed via `openehr_lang::odin`
-    /// and lowered to a `DV_QUANTITY`/`DV_ORDINAL` `C_COMPLEX_OBJECT` (the RM
-    /// type the domain constrainer targets), carrying the `property` external
-    /// code as a `C_TERMINOLOGY_CODE`, the `list` rows as an attribute tuple
-    /// (multi-member) or plain attributes (single member), and the
-    /// `assumed_value` object as the per-leaf `C_PRIMITIVE_OBJECT.assumed_value`s
-    /// it decomposes into. No openEHR spec governs the 1.4→2 lowering — our own
-    /// design (converter front end); `AOM2/master04.3` §Tuple Constraints is the
-    /// ADL2 target ("The tuple constraint type replaces all domain-specific
-    /// constraint types defined in ADL/AOM 1.4, including `C_DV_QUANTITY` and
-    /// `C_DV_ORDINAL`").
+    /// `C_DV_ORDINAL <…>` / `C_CODE_PHRASE <…>`. The ODIN block is parsed via
+    /// `openehr_lang::odin` and lowered to the constraint the RM type the domain
+    /// constrainer targets takes:
+    ///
+    /// * `C_DV_QUANTITY`/`C_DV_ORDINAL` → a `DV_QUANTITY`/`DV_ORDINAL`
+    ///   `C_COMPLEX_OBJECT`, carrying the `property` external code as a
+    ///   `C_TERMINOLOGY_CODE`, the `list` rows as an attribute tuple
+    ///   (multi-member) or plain attributes (single member), and the
+    ///   `assumed_value` object as the per-leaf
+    ///   `C_PRIMITIVE_OBJECT.assumed_value`s it decomposes into;
+    /// * `C_CODE_PHRASE` → the same `C_TERMINOLOGY_CODE` the compact custom
+    ///   syntax `[local:: at0039, at0040]` produces, because
+    ///   `ADL1.4/master09-customising_adl.adoc` §Custom Syntax presents the two
+    ///   as alternative spellings that "express exactly the same constraint".
+    ///
+    /// No openEHR spec governs the 1.4→2 lowering — our own design (converter
+    /// front end); `AOM2/master04.3` §Tuple Constraints is the ADL2 target ("The
+    /// tuple constraint type replaces all domain-specific constraint types
+    /// defined in ADL/AOM 1.4, including `C_DV_QUANTITY` and `C_DV_ORDINAL`").
     ///
     /// A domain type this lowering does not model is refused with a typed
     /// [`SyntaxErrorCode::Sdinv`] naming the type, never lowered to some other
@@ -1388,10 +1573,19 @@ impl Parser<'_> {
     /// `C_DOMAIN_TYPE` descendant here ("This approach can be used for any custom
     /// type which represents a constraint on a reference model type"), and each
     /// one targets a DIFFERENT RM type, so guessing is a silent wrong answer.
-    // TODO: lower the remaining openEHR Archetype Profile domain constrainers
-    // (`C_CODE_PHRASE` → `CODE_PHRASE`, `C_DV_STATE` → `DV_STATE`;
-    // `ADL1.4/master09-customising_adl.adoc` §Custom Syntax) so they stop being
-    // refused — tracked as the ADL1.4 master09 chapter audit.
+    //
+    // NOTE: `C_DV_STATE` — the one further openEHR Archetype Profile domain
+    // constrainer met in the wild — stays refused: no vendored openEHR spec text
+    // defines C_DV_STATE — the oAP custom type is not vendored, and neither
+    // `ADL1.4/master09-customising_adl.adoc` nor
+    // `AOM1.4/masterAppA-domain_extension.adoc` (whose worked domain classes are
+    // `C_ORDINAL`/`C_QUANTITY`/`C_CODED_TEXT`) gives its attributes or its RM
+    // target — so the typed refusal is the honest boundary; inventing a shape
+    // would be a silent wrong answer.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one linear parse: the type name, the ODIN block's token span, then one dispatch per lowered domain type"
+    )]
     fn parse_adl14_domain_object(&mut self, parenthesised: bool) -> PResult<CObject> {
         let start = self.cur_span().start;
         if parenthesised {
@@ -1457,7 +1651,7 @@ impl Parser<'_> {
                 SyntaxErrorCode::Sdinv,
                 format!(
                     "inline dADL domain constrainer {rm_type:?} is not supported; only \
-                     'C_DV_QUANTITY' and 'C_DV_ORDINAL' are lowered"
+                     'C_DV_QUANTITY', 'C_DV_ORDINAL' and 'C_CODE_PHRASE' are lowered"
                 ),
                 span,
             );
@@ -1471,6 +1665,26 @@ impl Parser<'_> {
             self.push(SyntaxErrorCode::Sdinv, "invalid dADL in domain block", span);
             return Err(());
         };
+        if rm_type == "C_CODE_PHRASE" {
+            let parts = match adl14_code_phrase_parts(&odin) {
+                Ok(parts) => parts,
+                Err(why) => {
+                    self.push(
+                        SyntaxErrorCode::Sdinv,
+                        format!("inline dADL 'C_CODE_PHRASE' block: {why}"),
+                        span,
+                    );
+                    return Err(());
+                }
+            };
+            let constraint = self.adl14_term_constraint(
+                &parts.terminology,
+                &parts.codes,
+                parts.assumed.as_deref(),
+                span,
+            )?;
+            return Ok(adl14_terminology_code(constraint));
+        }
         match lower_adl14_domain(&rm_type, &odin) {
             Ok(obj) => Ok(obj),
             Err(DomainLoweringError::Empty) => {
@@ -3276,19 +3490,203 @@ fn local_term_code(code: &str) -> TerminologyCode {
     }
 }
 
+/// The single ordinal value a lowered `[value, symbol]` tuple row constrains,
+/// as `f64` for the assumed-value lookup. `None` for any other constraint kind.
+fn ordinal_point_value(member: &CPrimitiveObject) -> Option<f64> {
+    match member {
+        CPrimitiveObject::CInteger(c) => c
+            .constraint
+            .first()
+            .and_then(interval_point_i32)
+            .map(f64::from),
+        CPrimitiveObject::CReal(c) => c.constraint.first().and_then(interval_point_f64),
+        _ => None,
+    }
+}
+
+/// A 1.4 term constraint as a `C_TERMINOLOGY_CODE` carrying the verbatim
+/// `terminology::code[,code]*[;assumed]` spelling for `crate::adl14::convert`.
+fn adl14_terminology_code(constraint: String) -> CObject {
+    CObject::CTerminologyCode(CTerminologyCode {
+        parent: None,
+        soc_parent: None,
+        rm_type_name: "Terminology_code".to_owned(),
+        occurrences: None,
+        node_id: "Primitive_node_id".to_owned(),
+        alternative_ids: Vec::new(),
+        is_deprecated: None,
+        sibling_order: None,
+        default_value: None,
+        assumed_value: None,
+        is_enumerated_type_constraint: None,
+        constraint,
+        constraint_status: None,
+    })
+}
+
 // ── ADL 1.4 inline dADL domain lowering (converter front end) ──────────────
 //
 // NOTE: no openEHR spec governs 1.4→2 conversion — the whole `adl14` pipeline
 // (including this lowering) is our own design (archie's converter is prior
-// art). `C_DV_QUANTITY`/`C_DV_ORDINAL` are ADL 1.4-only inline dADL
-// constrainers with no ADL2/AOM2 class; ADL2 expresses the same constraint as
-// a `DV_QUANTITY`/`DV_ORDINAL` `C_COMPLEX_OBJECT` with an attribute tuple
-// (`AOM2/master04.4` §Second-Order Constraints). We lower to that shape and
-// leave code renumbering + `property` binding synthesis to
-// `crate::adl14::convert`.
+// art). `C_DV_QUANTITY`/`C_DV_ORDINAL`/`C_CODE_PHRASE` are ADL 1.4-only inline
+// dADL constrainers with no ADL2/AOM2 class; ADL2 expresses the first two as a
+// `DV_QUANTITY`/`DV_ORDINAL` `C_COMPLEX_OBJECT` with an attribute tuple
+// (`AOM2/master04.4` §Second-Order Constraints) and the third as a plain
+// terminology-code constraint. We lower to those shapes and leave code
+// renumbering + `property` binding synthesis to `crate::adl14::convert`.
 
 fn is_adl14_domain_type(id: &str) -> bool {
-    matches!(id, "C_DV_QUANTITY" | "C_DV_ORDINAL")
+    matches!(id, "C_DV_QUANTITY" | "C_DV_ORDINAL" | "C_CODE_PHRASE")
+}
+
+/// The parts an inline dADL `C_CODE_PHRASE` block constrains, as the 1.4
+/// custom-syntax spelling `[terminology:: code, … ; assumed]` carries them.
+struct CodePhraseParts {
+    /// The `terminology_id`'s value (`"local"`, `"SNOMED-CT"`, …).
+    terminology: String,
+    /// The `code_list` members, in source order.
+    codes: Vec<String>,
+    /// The `assumed_value` `CODE_PHRASE`'s `code_string`, if the block has one.
+    assumed: Option<String>,
+}
+
+/// Read an inline dADL `C_CODE_PHRASE` block into the parts a
+/// `C_TERMINOLOGY_CODE` constraint string is built from.
+///
+/// `ADL1.4/master09-customising_adl.adoc` §Custom Syntax gives the block's shape
+/// verbatim (`terminology_id = <value = <"local">>` plus a keyed `code_list`)
+/// and states that the compact `[local:: at0039, at0040]` custom syntax and this
+/// dADL section "express exactly the same constraint" — so both spellings lower
+/// to the SAME constraint object. `AOM1.4/masterAppA-domain_extension.adoc`
+/// §`C_CODED_TEXT` is the class shape behind it (`terminology: String`,
+/// `code_list: List<String>`), which is why a bare `terminology_id = <"local">`
+/// is read as well as the chapter's nested `TERMINOLOGY_ID` form.
+///
+/// # Errors
+/// The human-readable defect when the block is not a `C_CODE_PHRASE` instance —
+/// a missing/unreadable `terminology_id`, an absent or empty `code_list`, an
+/// `assumed_value` that is not a `CODE_PHRASE` of the same terminology, or an
+/// attribute the class does not define. The caller raises it as `SDINV`.
+fn adl14_code_phrase_parts(odin: &OdinValue) -> Result<CodePhraseParts, String> {
+    let OdinValue::Object(map) = untyped(odin) else {
+        return Err("expecting an object with 'terminology_id' and 'code_list'".to_owned());
+    };
+    if let Some(unknown) = map
+        .keys()
+        .find(|k| !matches!(k.as_str(), "terminology_id" | "code_list" | "assumed_value"))
+    {
+        return Err(format!(
+            "unknown attribute {unknown:?} (expecting 'terminology_id', 'code_list' or \
+             'assumed_value')"
+        ));
+    }
+    let Some(terminology) = map.get("terminology_id").map(untyped) else {
+        return Err("missing 'terminology_id'".to_owned());
+    };
+    let terminology = terminology_id_value(terminology)
+        .ok_or_else(|| "'terminology_id' is not a terminology identifier".to_owned())?;
+    let Some(code_list) = map.get("code_list") else {
+        // NOTE: `AOM1.4/masterAppA-domain_extension.adoc` §C_CODED_TEXT makes
+        // `code_list` optional ("No list means any code from the terminology is
+        // allowed"), but the 1.4 custom syntax this lowering targets carries a
+        // code set and nothing else, so an open constraint has no faithful
+        // carrier here. A loud refusal is the honest boundary: silently emitting
+        // an empty code set would NARROW the constraint to nothing.
+        return Err("missing 'code_list'".to_owned());
+    };
+    let codes = code_list_codes(code_list)?;
+    if codes.is_empty() {
+        return Err("'code_list' constrains no code".to_owned());
+    }
+    let assumed = match map.get("assumed_value").map(untyped) {
+        None => None,
+        Some(value) => {
+            let (assumed_terminology, code) = code_phrase_instance(value)?;
+            if assumed_terminology != terminology {
+                return Err(format!(
+                    "'assumed_value' names terminology {assumed_terminology:?}, but the \
+                     constraint is on {terminology:?}"
+                ));
+            }
+            Some(code)
+        }
+    };
+    Ok(CodePhraseParts {
+        terminology,
+        codes,
+        assumed,
+    })
+}
+
+/// A `TERMINOLOGY_ID` dADL value → its `value` string, in either the nested
+/// object spelling of `ADL1.4/master09-customising_adl.adoc` §Custom Syntax or
+/// the plain-string spelling of `AOM1.4/masterAppA-domain_extension.adoc`
+/// §`C_CODED_TEXT` (`terminology: String`).
+fn terminology_id_value(v: &OdinValue) -> Option<String> {
+    match v {
+        OdinValue::String(s) => Some(s.clone()),
+        OdinValue::Object(map) => match map.get("value").map(untyped) {
+            Some(OdinValue::String(s)) => Some(s.clone()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// A `code_list` dADL value → its code strings, accepting the keyed-container
+/// spelling of the chapter's example, an ODIN primitive list, and a lone string
+/// (`LANG/docs/odin/master05-content.adoc` §Container Objects gives both the
+/// keyed-member and the list-literal spellings of a container attribute).
+///
+/// # Errors
+/// The defect when a member is not a code string.
+fn code_list_codes(v: &OdinValue) -> Result<Vec<String>, String> {
+    let member = |m: &OdinValue| match untyped(m) {
+        OdinValue::String(s) => Ok(s.clone()),
+        other => Err(format!(
+            "'code_list' member is not a code string ({})",
+            odin_kind(other)
+        )),
+    };
+    match untyped(v) {
+        OdinValue::KeyedList(entries) => entries.iter().map(|(_, m)| member(m)).collect(),
+        OdinValue::List(items) => items.iter().map(member).collect(),
+        OdinValue::String(s) => Ok(vec![s.clone()]),
+        OdinValue::Empty => Ok(Vec::new()),
+        other => Err(format!("'code_list' is not a list ({})", odin_kind(other))),
+    }
+}
+
+/// A `CODE_PHRASE` dADL instance → its `(terminology, code_string)`.
+///
+/// # Errors
+/// The defect when the value is not a `CODE_PHRASE` instance.
+fn code_phrase_instance(v: &OdinValue) -> Result<(String, String), String> {
+    let OdinValue::Object(map) = untyped(v) else {
+        return Err("'assumed_value' is not a CODE_PHRASE object".to_owned());
+    };
+    let terminology = map
+        .get("terminology_id")
+        .map(untyped)
+        .and_then(terminology_id_value)
+        .ok_or_else(|| "'assumed_value' has no readable 'terminology_id'".to_owned())?;
+    let Some(OdinValue::String(code)) = map.get("code_string").map(untyped) else {
+        return Err("'assumed_value' has no 'code_string'".to_owned());
+    };
+    Ok((terminology, code.clone()))
+}
+
+/// A one-word name for an ODIN value's kind, for defect messages.
+fn odin_kind(v: &OdinValue) -> &'static str {
+    match v {
+        OdinValue::Object(_) => "an object",
+        OdinValue::KeyedList(_) => "a keyed list",
+        OdinValue::List(_) => "a list",
+        OdinValue::Typed { .. } => "a typed block",
+        OdinValue::PathList(_) => "a path list",
+        OdinValue::Empty => "an empty block",
+        _ => "a leaf value",
+    }
 }
 
 /// Peel any `(TYPE)` casts off an ODIN value: the cast of
@@ -5022,19 +5420,16 @@ mod tests {
     /// refused by NAME, never lowered to a different RM type
     /// (`ADL1.4/master09-customising_adl.adoc` §Introduction admits any
     /// `C_DOMAIN_TYPE` descendant, each targeting a different RM type).
+    /// `C_DV_STATE` is the standing case: no vendored openEHR spec text defines
+    /// it, so it has no citable shape.
     #[test]
     fn adl14_unsupported_domain_type_is_refused_by_name() {
         let errs = parse_definition_body_adl14(
             "ELEMENT[at0000] matches {\n\
              value matches {\n\
-             DV_CODED_TEXT matches {\n\
-             defining_code matches {\n\
-             (C_CODE_PHRASE) <\n\
-             terminology_id = <value = <\"local\">>\n\
-             code_list = <[\"1\"] = <\"at0001\">>\n\
+             (C_DV_STATE) <\n\
+             value = <\"at0001\">\n\
              >\n\
-             }\n\
-             }\n\
              }\n\
              }",
         )
@@ -5044,10 +5439,45 @@ mod tests {
             .find(|e| e.code == SyntaxErrorCode::Sdinv)
             .expect("SDINV");
         assert!(
-            sdinv.message.contains("C_CODE_PHRASE"),
+            sdinv.message.contains("C_DV_STATE"),
             "the message must name the type, got {:?}",
             sdinv.message
         );
+    }
+
+    /// The `C_CODE_PHRASE` block of `master09` §Custom Syntax lowers to the very
+    /// constraint the compact custom syntax produces — the section presents them
+    /// as two spellings that "express exactly the same constraint".
+    #[test]
+    fn adl14_code_phrase_block_lowers_like_the_custom_syntax() {
+        let block = parse_definition_body_adl14(
+            "ELEMENT[at0000] matches {\n\
+             value matches {\n\
+             DV_CODED_TEXT matches {\n\
+             defining_code matches {\n\
+             C_CODE_PHRASE <\n\
+             terminology_id = <value = <\"local\">>\n\
+             code_list = <[\"1\"] = <\"at0039\"> [\"2\"] = <\"at0040\">>\n\
+             >\n\
+             }\n\
+             }\n\
+             }\n\
+             }",
+        )
+        .expect("the dADL block lowers");
+        let custom = parse_definition_body_adl14(
+            "ELEMENT[at0000] matches {\n\
+             value matches {\n\
+             DV_CODED_TEXT matches {\n\
+             defining_code matches {\n\
+             [local:: at0039, at0040]\n\
+             }\n\
+             }\n\
+             }\n\
+             }",
+        )
+        .expect("the custom syntax parses");
+        assert_eq!(block, custom);
     }
 
     #[test]

--- a/crates/openehr-adl/src/validate/mod.rs
+++ b/crates/openehr-adl/src/validate/mod.rs
@@ -723,7 +723,7 @@ pub fn validate_source_phase1(
 /// - **VDFPT** — `use_node` target paths must resolve within the definition
 ///   section (`ADL1.4/master08-adl.adoc` §Definition Section; a 1.4 artefact
 ///   is standalone, so its own assembled definition is the resolution target —
-///   [`phase3::validate_definition_paths_adl14`]).
+///   `phase3::validate_definition_paths_adl14`).
 ///
 /// # Errors
 /// Returns the parse [`SyntaxError`]s if `src` does not parse as ADL 1.4;

--- a/crates/openehr-adl/tests/corpus/INVENTORY.md
+++ b/crates/openehr-adl/tests/corpus/INVENTORY.md
@@ -535,9 +535,11 @@ cross-check).
 | `…SCCOG_adl2_slot_closed.v1.adl` | SCCOG | the ADL2 slot `closed` marker refused in a 1.4 text |
 | `…STCCP_adl2_constraint_strength.v1.adl` | STCCP | an ADL2 term-constraint strength refused in a 1.4 text |
 | `…STCCP_adl2_terminology_binding.v1.adl` | STCCP | an ADL2 `@terminology` operational binding refused in a 1.4 text |
-| `…SDINV_unsupported_domain_type.v1.adl` | SDINV | an inline dADL `C_CODE_PHRASE` refused BY NAME, never lowered to another RM type |
+| `…SDINV_unsupported_domain_type.v1.adl` | SDINV | an inline dADL `C_DV_STATE` refused BY NAME, never lowered to another RM type. **Adjudication (2026-07-30):** the file previously carried `C_CODE_PHRASE`, which master09 §Custom Syntax DOES define and which is now lowered; the refusal it pins is "a domain constrainer with no vendored shape", so the fixture moved to `C_DV_STATE` — the one such type met in the wild, absent from every vendored spec file (the oAP specification is not vendored) |
 | `…SDINV_assumed_value_unmatched.v1.adl` | SDINV | a domain `assumed_value` satisfying no `list` row |
 | `…domain_assumed_value.v1.adl` | PASS | the accepting twin: an `assumed_value` landing on the tuple row it satisfies |
+| `…code_phrase_dadl_block.v1.adl` | PASS | master09 §Custom Syntax's own `C_CODE_PHRASE` dADL example (bare + `(…)`-cast spellings), beside the compact `[local:: …]` form it "express[es] exactly the same constraint" as, plus the `assumed_value` CODE_PHRASE and an external terminology |
+| `…ordinal_pipe_shorthand.v1.adl` | PASS | the deprecated openEHR-profiled 1.4 ordinal syntax `0|[local::at0005], …` (master04.4 §Tuple Constraints; `cadl14.g4` `c_ordinal`), incl. the `; assumed` tail and an external-terminology symbol |
 | `…VATDF_undefined_listed_code.v1.adl` | VATDF | an undefined code inside the 1.4 listed term constraint `[local:: …]` |
 | `…VATDF_undefined_code_with_assumed.v1.adl` | VATDF | an undefined listed code in the assumed-value SPELLING of the 1.4 term constraint (the assumed code itself is a member, so STCAC stays quiet) |
 | `…VACDF_undefined_constraint_code.v1.adl` | VACDF | an undefined `ac` code in a 1.4 qualified term constraint |

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.SDINV_unsupported_domain_type.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.SDINV_unsupported_domain_type.v1.adl
@@ -23,17 +23,15 @@ definition
 							-- ADL1.4/master09-customising_adl.adoc §Introduction
 							-- admits ANY `C_DOMAIN_TYPE` descendant in an inline
 							-- dADL block, and each one constrains a DIFFERENT
-							-- reference-model type. `C_CODE_PHRASE` (§Custom Syntax)
-							-- is not lowered yet, so it is refused by type name
+							-- reference-model type. `C_DV_STATE` is defined by no
+							-- vendored openEHR spec text (the oAP custom type is not
+							-- vendored, and AOM1.4/masterAppA-domain_extension.adoc
+							-- works only C_ORDINAL/C_QUANTITY/C_CODED_TEXT), so it
+							-- has no citable shape and is refused by type name
 							-- rather than silently lowered to some other RM type.
-							(C_CODE_PHRASE) <
-								terminology_id = <
-									value = <"local">
-								>
-								code_list = <
-									["1"] = <"at0002">
-									["2"] = <"at0003">
-								>
+							(C_DV_STATE) <
+								value = <"at0002">
+								is_terminal = <False>
 							>
 						}
 					}
@@ -48,7 +46,7 @@ ontology
 			items = <
 				["at0000"] = <
 					text = <"Unsupported inline dADL domain type">
-					description = <"Refusal fixture: an inline dADL `C_CODE_PHRASE` domain block.">
+					description = <"Refusal fixture: an inline dADL `C_DV_STATE` domain block, a domain constrainer the vendored spec text does not define.">
 				>
 				["at0001"] = <
 					text = <"Coded item">

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.code_phrase_dadl_block.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.code_phrase_dadl_block.v1.adl
@@ -1,0 +1,138 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-CLUSTER.code_phrase_dadl_block.v1
+
+concept
+	[at0000]	-- Inline dADL C_CODE_PHRASE
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	other_details = <
+		["regression"] = <"PASS">
+	>
+	lifecycle_state = <"AuthorDraft">
+
+definition
+	CLUSTER[at0000] matches {	-- Inline dADL C_CODE_PHRASE
+		items cardinality matches {0..*; unordered} matches {
+			ELEMENT[at0001] occurrences matches {0..1} matches {	-- Position
+				value matches {
+					DV_CODED_TEXT matches {
+						-- ADL1.4/master09-customising_adl.adoc §Custom Syntax,
+						-- the chapter's own worked example verbatim. The section
+						-- presents it and the compact `[local:: at0039, at0040]`
+						-- spelling below as alternatives that "express exactly
+						-- the same constraint", so both lower identically.
+						defining_code matches {
+							C_CODE_PHRASE <
+								terminology_id = <
+									value = <"local">
+								>
+								code_list = <
+									["1"] = <"at0039">
+									["2"] = <"at0040">
+								>
+							>
+						}
+					}
+				}
+			}
+			ELEMENT[at0002] occurrences matches {0..1} matches {	-- Position (custom syntax)
+				value matches {
+					DV_CODED_TEXT matches {
+						defining_code matches {
+							[local::
+							at0039,	-- lying
+							at0040]	-- sitting
+						}
+					}
+				}
+			}
+			ELEMENT[at0003] occurrences matches {0..1} matches {	-- Position (assumed)
+				value matches {
+					DV_CODED_TEXT matches {
+						-- AOM1.4/master04-constraint_model_package.adoc
+						-- §Assumed_value: assumed values appear on descendants of
+						-- `C_PRIMITIVE` and `C_DOMAIN_TYPE`; the profiled
+						-- `C_CODE_PHRASE` carries a whole CODE_PHRASE there.
+						defining_code matches {
+							(C_CODE_PHRASE) <
+								terminology_id = <
+									value = <"local">
+								>
+								code_list = <
+									["1"] = <"at0039">
+									["2"] = <"at0040">
+								>
+								assumed_value = <
+									terminology_id = <
+										value = <"local">
+									>
+									code_string = <"at0039">
+								>
+							>
+						}
+					}
+				}
+			}
+			ELEMENT[at0004] occurrences matches {0..1} matches {	-- Finding
+				value matches {
+					DV_CODED_TEXT matches {
+						-- An EXTERNAL terminology in the same block: its codes are
+						-- not archetype terms, so VATDF/VACDF leave them alone
+						-- (ADL1.4/master08-adl.adoc §Validity Rules).
+						defining_code matches {
+							C_CODE_PHRASE <
+								terminology_id = <
+									value = <"SNOMED-CT">
+								>
+								code_list = <
+									["1"] = <"163035008">
+								>
+							>
+						}
+					}
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Inline dADL C_CODE_PHRASE">
+					description = <"Accepting fixture: the master09 §Custom Syntax C_CODE_PHRASE block.">
+				>
+				["at0001"] = <
+					text = <"Position">
+					description = <"Patient position, as an inline dADL block.">
+				>
+				["at0002"] = <
+					text = <"Position (custom syntax)">
+					description = <"Patient position, as the compact custom syntax.">
+				>
+				["at0003"] = <
+					text = <"Position (assumed)">
+					description = <"Patient position, with an assumed value.">
+				>
+				["at0004"] = <
+					text = <"Finding">
+					description = <"A finding coded in an external terminology.">
+				>
+				["at0039"] = <
+					text = <"Lying">
+					description = <"Lying position.">
+				>
+				["at0040"] = <
+					text = <"Sitting">
+					description = <"Sitting position.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.ordinal_pipe_shorthand.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.ordinal_pipe_shorthand.v1.adl
@@ -1,0 +1,88 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-CLUSTER.ordinal_pipe_shorthand.v1
+
+concept
+	[at0000]	-- Pipe-ordinal shorthand
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	other_details = <
+		["regression"] = <"PASS">
+	>
+	lifecycle_state = <"AuthorDraft">
+
+definition
+	CLUSTER[at0000] matches {	-- Pipe-ordinal shorthand
+		items cardinality matches {0..*; unordered} matches {
+			ELEMENT[at0001] occurrences matches {0..1} matches {	-- Severity
+				value matches {
+					-- ADL2/master04.4-cadl_second_order.adoc §Tuple Constraints,
+					-- deprecated block: the openEHR-profiled ADL 1.4 ordinal
+					-- syntax, "now replaced by the above generic form" — the
+					-- DV_ORDINAL [value, symbol] tuple this lowers to.
+					-- Grammar: cadl14.g4 `c_ordinal` / `ordinal_term`.
+					0|[local::at0005],	-- +
+					1|[local::at0006],	-- ++
+					2|[local::at0007]	-- +++
+				}
+			}
+			ELEMENT[at0002] occurrences matches {0..1} matches {	-- Severity (assumed)
+				value matches {
+					-- The `(';' assumed_ordinal_value)?` tail of the same
+					-- production; the value names one of the listed ordinals.
+					0|[local::at0005],
+					1|[local::at0006]; 1
+				}
+			}
+			ELEMENT[at0003] occurrences matches {0..1} matches {	-- Graded finding
+				value matches {
+					-- An EXTERNAL terminology as the symbol: `c_terminology_code`
+					-- (cadl14_primitives.g4) admits any qualified code, and its
+					-- codes are not archetype terms.
+					1|[SNOMED-CT::255604002],
+					2|[SNOMED-CT::6736007]
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Pipe-ordinal shorthand">
+					description = <"Accepting fixture: the deprecated ADL 1.4 ordinal syntax.">
+				>
+				["at0001"] = <
+					text = <"Severity">
+					description = <"An ordinal severity scale.">
+				>
+				["at0002"] = <
+					text = <"Severity (assumed)">
+					description = <"An ordinal scale with an assumed value.">
+				>
+				["at0003"] = <
+					text = <"Graded finding">
+					description = <"An ordinal scale symbolised in an external terminology.">
+				>
+				["at0005"] = <
+					text = <"+">
+					description = <"Mild.">
+				>
+				["at0006"] = <
+					text = <"++">
+					description = <"Moderate.">
+				>
+				["at0007"] = <
+					text = <"+++">
+					description = <"Severe.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/it/adl14_cadl_gates.rs
+++ b/crates/openehr-adl/tests/it/adl14_cadl_gates.rs
@@ -105,6 +105,15 @@ const FIXTURES: &[(&str, Expect)] = &[
         "openEHR-EHR-CLUSTER.domain_assumed_value.v1.adl",
         Expect::Pass,
     ),
+    (
+        "openEHR-EHR-CLUSTER.code_phrase_dadl_block.v1.adl",
+        Expect::Pass,
+    ),
+    // ── the deprecated 1.4 pipe-ordinal shorthand (master04.4) ────────────
+    (
+        "openEHR-EHR-CLUSTER.ordinal_pipe_shorthand.v1.adl",
+        Expect::Pass,
+    ),
     // ── 1.4 term-constraint definedness (master08 VATDF/VACDF) ────────────
     (
         "openEHR-EHR-CLUSTER.VATDF_undefined_listed_code.v1.adl",

--- a/crates/openehr-adl/tests/it/adl14_custom_constraints.rs
+++ b/crates/openehr-adl/tests/it/adl14_custom_constraints.rs
@@ -1,0 +1,542 @@
+//! The ADL 1.4 custom constraint forms of
+//! `docs/specs/openehr/AM/docs/ADL1.4/master09-customising_adl.adoc`
+//! ("Customising ADL") — the two spellings openEHR profiled onto standard ADL,
+//! and the boundary where neither is defined.
+//!
+//! 1. **The inline dADL section.** §Introduction admits any `C_DOMAIN_TYPE`
+//!    descendant as a typed dADL block inside the `{}` where its standard-ADL
+//!    equivalent would stand; §Custom Syntax works `C_CODE_PHRASE` through in
+//!    full and states that the block and the compact `[local:: at0039, at0040]`
+//!    form "express exactly the same constraint" — so the two must lower to the
+//!    same constraint object, which is what these tests pin structurally.
+//! 2. **The pipe-ordinal shorthand.** `ADL2/master04.4-cadl_second_order.adoc`
+//!    §Tuple Constraints records `0|[local::at1], 1|[local::at2]` as the
+//!    deprecated openEHR-profiled 1.4 syntax and names the generic
+//!    `DV_ORDINAL` `[value, symbol]` tuple as its replacement ("This hides the
+//!    `DV_ORDINAL` type altogether"). It is accepted in the 1.4 dialect and
+//!    lowered to exactly that replacement; ADL 2, which removed it, still
+//!    refuses it — both twins are pinned here.
+//! 3. **The refusals.** A domain constrainer with no vendored shape
+//!    (`C_DV_STATE`) and a malformed `C_CODE_PHRASE` block are typed refusals,
+//!    never a silent guess.
+//!
+//! The grammar productions cited (`c_ordinal`, `ordinal_term`,
+//! `assumed_ordinal_value`, `domain_specific_extension`, `c_terminology_code`)
+//! are the vendored normative ANTLR set at `vendor/grammar/cadl14.g4` +
+//! `cadl14_primitives.g4`.
+
+#![allow(
+    clippy::expect_used,
+    clippy::panic,
+    clippy::unwrap_used,
+    reason = "integration-test assertions, diagnostics and fixture plumbing outside #[test] fns, which the clippy.toml allow-*-in-tests scoping does not reach"
+)]
+
+use openehr_adl::adl14::convert::{ConvertConfig, parse_and_convert};
+use openehr_adl::adl14::log::ConversionLog;
+use openehr_adl::assemble::{parse_artefact, parse_artefact_adl14};
+use openehr_adl::error::{SyntaxError, SyntaxErrorCode};
+use openehr_adl::validate::{Severity, ValidationCode, validate_source_phase1_adl14};
+use openehr_am::am24::aom2::archetype::archetype::Archetype;
+use openehr_am::am24::aom2::archetype::authored_archetype::AuthoredArchetype;
+use openehr_am::am24::aom2::constraint_model::c_attribute_tuple::CAttributeTuple;
+use openehr_am::am24::aom2::constraint_model::c_complex_object::CComplexObject;
+use openehr_am::am24::aom2::constraint_model::c_object::CObject;
+use openehr_am::am24::aom2::constraint_model::c_primitive_object::CPrimitiveObject;
+
+/// A whole ADL 1.4 archetype whose single `ELEMENT[at0001]/value` carries
+/// `constraint` verbatim, with `at0039`/`at0040` defined in the ontology.
+fn archetype_with(constraint: &str) -> String {
+    format!(
+        "archetype (adl_version=1.4)
+\topenEHR-EHR-CLUSTER.custom_constraint14.v1
+
+concept
+\t[at0000]\t-- Custom constraint
+language
+\toriginal_language = <[ISO_639-1::en]>
+description
+\tlifecycle_state = <\"AuthorDraft\">
+definition
+\tCLUSTER[at0000] matches {{
+\t\titems matches {{
+\t\t\tELEMENT[at0001] matches {{
+\t\t\t\tvalue matches {{
+{constraint}
+\t\t\t\t}}
+\t\t\t}}
+\t\t}}
+\t}}
+ontology
+\tterm_definitions = <
+\t\t[\"en\"] = <
+\t\t\titems = <
+\t\t\t\t[\"at0000\"] = <text=<\"Custom constraint\"> description=<\"root\">>
+\t\t\t\t[\"at0001\"] = <text=<\"Item\"> description=<\"an item\">>
+\t\t\t\t[\"at0039\"] = <text=<\"Lying\"> description=<\"lying\">>
+\t\t\t\t[\"at0040\"] = <text=<\"Sitting\"> description=<\"sitting\">>
+\t\t\t>
+\t\t>
+\t>
+"
+    )
+}
+
+/// The single object constraining `ELEMENT[at0001]/value` in a parsed 1.4
+/// archetype built by [`archetype_with`].
+fn value_object(src: &str) -> CObject {
+    let archetype = parse_artefact_adl14(src).unwrap_or_else(|e| panic!("must parse: {e:?}"));
+    let Archetype::AuthoredArchetype(authored) = archetype else {
+        panic!("not an authored archetype");
+    };
+    let AuthoredArchetype::AuthoredArchetype(data) = *authored else {
+        panic!("not a plain authored archetype");
+    };
+    let items = openehr_adl::paths::complex_attributes(&data.definition)
+        .iter()
+        .find(|a| a.rm_attribute_name == "items")
+        .expect("the items attribute");
+    let element = items.children.first().expect("the ELEMENT child");
+    let CObject::CComplexObject(element) = element else {
+        panic!("the ELEMENT child is not a complex object");
+    };
+    openehr_adl::paths::complex_attributes(element)
+        .iter()
+        .find(|a| a.rm_attribute_name == "value")
+        .expect("the value attribute")
+        .children
+        .first()
+        .expect("the value constraint")
+        .clone()
+}
+
+/// The refusal codes a 1.4 source raises at parse.
+fn refusal_codes(src: &str) -> Vec<SyntaxErrorCode> {
+    let errors: Vec<SyntaxError> = parse_artefact_adl14(src)
+        .err()
+        .unwrap_or_else(|| panic!("must be refused at parse"));
+    errors.iter().map(|e| e.code).collect()
+}
+
+/// The single `[value, symbol]` attribute tuple of a lowered `DV_ORDINAL`.
+fn ordinal_tuple(obj: &CObject) -> &CAttributeTuple {
+    let CObject::CComplexObject(CComplexObject::CComplexObject(data)) = obj else {
+        panic!("the ordinal must lower to a plain C_COMPLEX_OBJECT, got {obj:?}");
+    };
+    assert_eq!(
+        data.rm_type_name, "DV_ORDINAL",
+        "the ordinal lowers onto the DV_ORDINAL reference-model type"
+    );
+    assert!(
+        data.attributes.is_empty(),
+        "the ordinal tuple is the whole constraint; no plain attribute is emitted"
+    );
+    assert_eq!(data.attribute_tuples.len(), 1, "exactly one tuple");
+    data.attribute_tuples.first().expect("the one tuple")
+}
+
+/// The `(value, symbol-constraint)` pairs of a lowered ordinal tuple.
+fn ordinal_rows(tuple: &CAttributeTuple) -> Vec<(f64, String)> {
+    tuple
+        .tuples
+        .iter()
+        .map(|row| {
+            let value = match row.members.first().expect("the value member") {
+                CPrimitiveObject::CInteger(c) => match c.constraint.first() {
+                    Some(openehr_base::prelude::Interval::PointInterval(p)) => {
+                        f64::from(p.lower.expect("a point ordinal value"))
+                    }
+                    other => panic!("the ordinal value is not a point constraint: {other:?}"),
+                },
+                CPrimitiveObject::CReal(c) => match c.constraint.first() {
+                    Some(openehr_base::prelude::Interval::PointInterval(p)) => {
+                        p.lower.expect("a point ordinal value")
+                    }
+                    other => panic!("the ordinal value is not a point constraint: {other:?}"),
+                },
+                other => panic!("the ordinal value member is not numeric: {other:?}"),
+            };
+            let Some(CPrimitiveObject::CTerminologyCode(symbol)) = row.members.get(1) else {
+                panic!("the ordinal symbol member is not a terminology code");
+            };
+            (value, symbol.constraint.clone())
+        })
+        .collect()
+}
+
+// ── 1. the inline dADL C_CODE_PHRASE section ────────────────────────────────
+
+/// The chapter's own worked example (§Custom Syntax) and the compact custom
+/// syntax it is presented as an alternative spelling of ("While these two ADL
+/// fragments express exactly the same constraint…") must produce the SAME
+/// constraint object — structurally, not merely both-parse.
+#[test]
+fn code_phrase_dadl_block_lowers_like_the_custom_syntax() {
+    let dadl = value_object(&archetype_with(
+        "\t\t\t\t\tC_CODE_PHRASE <
+\t\t\t\t\t\tterminology_id = <
+\t\t\t\t\t\t\tvalue = <\"local\">
+\t\t\t\t\t\t>
+\t\t\t\t\t\tcode_list = <
+\t\t\t\t\t\t\t[\"1\"] = <\"at0039\">
+\t\t\t\t\t\t\t[\"2\"] = <\"at0040\">
+\t\t\t\t\t\t>
+\t\t\t\t\t>",
+    ));
+    let custom = value_object(&archetype_with(
+        "\t\t\t\t\t[local::\n\t\t\t\t\tat0039,\n\t\t\t\t\tat0040]",
+    ));
+    assert_eq!(
+        dadl, custom,
+        "the dADL block and the custom syntax must lower identically"
+    );
+    let CObject::CTerminologyCode(code) = &dadl else {
+        panic!("a CODE_PHRASE constraint lowers to a C_TERMINOLOGY_CODE, got {dadl:?}");
+    };
+    assert_eq!(code.constraint, "local::at0039,at0040");
+    assert_eq!(code.rm_type_name, "Terminology_code");
+}
+
+/// The parenthesised spelling of the same block (`(C_CODE_PHRASE) <…>`, the
+/// ODIN type cast of `LANG/docs/odin/master05-content.adoc` §Adding Type
+/// Information) lowers identically to the bare one.
+#[test]
+fn parenthesised_code_phrase_block_lowers_the_same() {
+    let bare = value_object(&archetype_with(
+        "\t\t\t\t\tC_CODE_PHRASE <
+\t\t\t\t\t\tterminology_id = <value = <\"local\">>
+\t\t\t\t\t\tcode_list = <[\"1\"] = <\"at0039\">>
+\t\t\t\t\t>",
+    ));
+    let cast = value_object(&archetype_with(
+        "\t\t\t\t\t(C_CODE_PHRASE) <
+\t\t\t\t\t\tterminology_id = <value = <\"local\">>
+\t\t\t\t\t\tcode_list = <[\"1\"] = <\"at0039\">>
+\t\t\t\t\t>",
+    ));
+    assert_eq!(bare, cast);
+}
+
+/// `AOM1.4/master04-constraint_model_package.adoc` §`Assumed_value` puts assumed
+/// values on `C_DOMAIN_TYPE` descendants, and the profiled `C_CODE_PHRASE`
+/// carries a whole `CODE_PHRASE` there. It lowers to the `;code` tail the
+/// custom syntax spells with `; at0039]`.
+#[test]
+fn code_phrase_dadl_assumed_value_reaches_the_constraint() {
+    let dadl = value_object(&archetype_with(
+        "\t\t\t\t\tC_CODE_PHRASE <
+\t\t\t\t\t\tterminology_id = <value = <\"local\">>
+\t\t\t\t\t\tcode_list = <
+\t\t\t\t\t\t\t[\"1\"] = <\"at0039\">
+\t\t\t\t\t\t\t[\"2\"] = <\"at0040\">
+\t\t\t\t\t\t>
+\t\t\t\t\t\tassumed_value = <
+\t\t\t\t\t\t\tterminology_id = <value = <\"local\">>
+\t\t\t\t\t\t\tcode_string = <\"at0039\">
+\t\t\t\t\t\t>
+\t\t\t\t\t>",
+    ));
+    let custom = value_object(&archetype_with(
+        "\t\t\t\t\t[local:: at0039, at0040; at0039]",
+    ));
+    assert_eq!(dadl, custom);
+    let CObject::CTerminologyCode(code) = &dadl else {
+        panic!("expected a C_TERMINOLOGY_CODE");
+    };
+    assert_eq!(code.constraint, "local::at0039,at0040;at0039");
+}
+
+/// The codes the block names are real archetype terms: an undefined one raises
+/// VATDF exactly as it does through the custom syntax
+/// (`ADL1.4/master08-adl.adoc` §Validity Rules VATDF).
+#[test]
+fn code_phrase_dadl_undefined_code_raises_vatdf() {
+    let src = archetype_with(
+        "\t\t\t\t\tC_CODE_PHRASE <
+\t\t\t\t\t\tterminology_id = <value = <\"local\">>
+\t\t\t\t\t\tcode_list = <
+\t\t\t\t\t\t\t[\"1\"] = <\"at0039\">
+\t\t\t\t\t\t\t[\"2\"] = <\"at9999\">
+\t\t\t\t\t\t>
+\t\t\t\t\t>",
+    );
+    let codes: Vec<ValidationCode> = validate_source_phase1_adl14(&src)
+        .expect("the block parses")
+        .into_iter()
+        .filter(|i| i.severity == Severity::Error)
+        .map(|i| i.code)
+        .collect();
+    assert!(
+        codes.contains(&ValidationCode::Vatdf),
+        "an undefined lowered code must raise VATDF, got {codes:?}"
+    );
+}
+
+/// An external terminology in the block is not an archetype term, so the
+/// definedness rules stay quiet (the same reading the custom syntax gets).
+#[test]
+fn code_phrase_dadl_external_terminology_is_not_an_archetype_term() {
+    let src = archetype_with(
+        "\t\t\t\t\tC_CODE_PHRASE <
+\t\t\t\t\t\tterminology_id = <value = <\"SNOMED-CT\">>
+\t\t\t\t\t\tcode_list = <[\"1\"] = <\"163035008\">>
+\t\t\t\t\t>",
+    );
+    let codes: Vec<ValidationCode> = validate_source_phase1_adl14(&src)
+        .expect("the block parses")
+        .into_iter()
+        .filter(|i| i.severity == Severity::Error)
+        .map(|i| i.code)
+        .collect();
+    assert!(codes.is_empty(), "expected clean, got {codes:?}");
+    let CObject::CTerminologyCode(code) = &value_object(&src) else {
+        panic!("expected a C_TERMINOLOGY_CODE");
+    };
+    assert_eq!(code.constraint, "SNOMED-CT::163035008");
+}
+
+/// A block that is not a `C_CODE_PHRASE` instance is refused loudly, never
+/// guessed at: the chapter requires the dADL instance to "obey the semantics of
+/// the custom type of which it is an instance, i.e. include the correct
+/// attribute names and relationships" (§Introduction).
+#[test]
+fn malformed_code_phrase_blocks_are_refused() {
+    let cases = [
+        // No terminology at all.
+        "\t\t\t\t\tC_CODE_PHRASE <
+\t\t\t\t\t\tcode_list = <[\"1\"] = <\"at0039\">>
+\t\t\t\t\t>",
+        // No code list.
+        "\t\t\t\t\tC_CODE_PHRASE <
+\t\t\t\t\t\tterminology_id = <value = <\"local\">>
+\t\t\t\t\t>",
+        // An empty code list.
+        "\t\t\t\t\tC_CODE_PHRASE <
+\t\t\t\t\t\tterminology_id = <value = <\"local\">>
+\t\t\t\t\t\tcode_list = <>
+\t\t\t\t\t>",
+        // An attribute the class does not define.
+        "\t\t\t\t\tC_CODE_PHRASE <
+\t\t\t\t\t\tterminology_id = <value = <\"local\">>
+\t\t\t\t\t\tcode_list = <[\"1\"] = <\"at0039\">>
+\t\t\t\t\t\tcode_string = <\"at0039\">
+\t\t\t\t\t>",
+        // An assumed value in another terminology than the constraint.
+        "\t\t\t\t\tC_CODE_PHRASE <
+\t\t\t\t\t\tterminology_id = <value = <\"local\">>
+\t\t\t\t\t\tcode_list = <[\"1\"] = <\"at0039\">>
+\t\t\t\t\t\tassumed_value = <
+\t\t\t\t\t\t\tterminology_id = <value = <\"SNOMED-CT\">>
+\t\t\t\t\t\t\tcode_string = <\"at0039\">
+\t\t\t\t\t\t>
+\t\t\t\t\t>",
+    ];
+    for case in cases {
+        let codes = refusal_codes(&archetype_with(case));
+        assert!(
+            codes.contains(&SyntaxErrorCode::Sdinv),
+            "expected SDINV for {case}, got {codes:?}"
+        );
+    }
+}
+
+/// The list rules that govern the custom syntax govern the block too — the two
+/// spellings are the same constraint, so they are judged the same way
+/// (STCAC: `ADL2/master04.6-cadl_validity_rules.adoc` §Syntax Validity Rules).
+#[test]
+fn code_phrase_dadl_assumed_value_outside_the_list_raises_stcac() {
+    let codes = refusal_codes(&archetype_with(
+        "\t\t\t\t\tC_CODE_PHRASE <
+\t\t\t\t\t\tterminology_id = <value = <\"local\">>
+\t\t\t\t\t\tcode_list = <[\"1\"] = <\"at0039\">>
+\t\t\t\t\t\tassumed_value = <
+\t\t\t\t\t\t\tterminology_id = <value = <\"local\">>
+\t\t\t\t\t\t\tcode_string = <\"at0040\">
+\t\t\t\t\t\t>
+\t\t\t\t\t>",
+    ));
+    assert!(
+        codes.contains(&SyntaxErrorCode::Stcac),
+        "expected STCAC, got {codes:?}"
+    );
+}
+
+// ── 2. the pipe-ordinal shorthand ───────────────────────────────────────────
+
+/// `ADL2/master04.4-cadl_second_order.adoc` §Tuple Constraints, deprecated
+/// block: `0|[local::at1], 1|[local::at2], 2|[local::at3]`. It lowers to the
+/// generic replacement the same section gives — a `DV_ORDINAL` with a
+/// `[value, symbol]` tuple, one row per term.
+#[test]
+fn pipe_ordinal_builds_the_value_symbol_tuple() {
+    let obj = value_object(&archetype_with(
+        "\t\t\t\t\t0|[local::at0039],\n\t\t\t\t\t1|[local::at0040]",
+    ));
+    let tuple = ordinal_tuple(&obj);
+    let members: Vec<&str> = tuple
+        .members
+        .iter()
+        .map(|m| m.rm_attribute_name.as_str())
+        .collect();
+    assert_eq!(members, vec!["value", "symbol"]);
+    assert_eq!(
+        ordinal_rows(tuple),
+        vec![
+            (0.0, "local::at0039".to_owned()),
+            (1.0, "local::at0040".to_owned()),
+        ]
+    );
+}
+
+/// A three-term list with an external-terminology symbol: `c_terminology_code`
+/// (`cadl14_primitives.g4`) admits any qualified code, and the definedness
+/// rules leave a non-archetype terminology alone.
+#[test]
+fn pipe_ordinal_accepts_many_terms_and_external_symbols() {
+    let src = archetype_with(
+        "\t\t\t\t\t0|[local::at0039],\n\t\t\t\t\t1|[local::at0040],\n\t\t\t\t\t2|[SNOMED-CT::163035008]",
+    );
+    let obj = value_object(&src);
+    assert_eq!(
+        ordinal_rows(ordinal_tuple(&obj)),
+        vec![
+            (0.0, "local::at0039".to_owned()),
+            (1.0, "local::at0040".to_owned()),
+            (2.0, "SNOMED-CT::163035008".to_owned()),
+        ]
+    );
+    let codes: Vec<ValidationCode> = validate_source_phase1_adl14(&src)
+        .expect("parses")
+        .into_iter()
+        .filter(|i| i.severity == Severity::Error)
+        .map(|i| i.code)
+        .collect();
+    assert!(codes.is_empty(), "expected clean, got {codes:?}");
+}
+
+/// The lowered symbols ARE archetype terms: an undefined at-code raises VATDF
+/// through the tuple, the same as any other 1.4 term constraint.
+#[test]
+fn pipe_ordinal_undefined_symbol_raises_vatdf() {
+    let src = archetype_with("\t\t\t\t\t0|[local::at0039],\n\t\t\t\t\t1|[local::at9999]");
+    let codes: Vec<ValidationCode> = validate_source_phase1_adl14(&src)
+        .expect("parses")
+        .into_iter()
+        .filter(|i| i.severity == Severity::Error)
+        .map(|i| i.code)
+        .collect();
+    assert!(
+        codes.contains(&ValidationCode::Vatdf),
+        "expected VATDF, got {codes:?}"
+    );
+}
+
+/// `cadl14.g4` `c_ordinal : ordinal_term (',' ordinal_term)* (';'
+/// assumed_ordinal_value)?` — the tail names one of the listed ordinals, and
+/// lands on that row's own value constraint.
+#[test]
+fn pipe_ordinal_assumed_value_lands_on_its_own_row() {
+    let obj = value_object(&archetype_with(
+        "\t\t\t\t\t0|[local::at0039],\n\t\t\t\t\t1|[local::at0040]; 1",
+    ));
+    let tuple = ordinal_tuple(&obj);
+    let assumed: Vec<Option<f64>> = tuple
+        .tuples
+        .iter()
+        .map(|row| match row.members.first().expect("the value member") {
+            CPrimitiveObject::CInteger(c) => c.assumed_value,
+            other => panic!("not an integer ordinal value: {other:?}"),
+        })
+        .collect();
+    assert_eq!(
+        assumed,
+        vec![None, Some(1.0)],
+        "the assumed value belongs to exactly the ordinal it names"
+    );
+}
+
+/// An assumed ordinal value naming no listed term is refused loudly rather than
+/// bound to an arbitrary row (`ADL1.4/master05-cadl.adoc` §Assumed Values
+/// L1012: the assumed value is "of the same type as that implied by the
+/// preceding part of the constraint").
+#[test]
+fn pipe_ordinal_assumed_value_outside_the_list_is_refused() {
+    let codes = refusal_codes(&archetype_with(
+        "\t\t\t\t\t0|[local::at0039],\n\t\t\t\t\t1|[local::at0040]; 7",
+    ));
+    assert!(
+        codes.contains(&SyntaxErrorCode::Sciav),
+        "expected SCIAV, got {codes:?}"
+    );
+}
+
+/// The pipe form is ADL 1.4-ONLY. ADL 2 removed it (§Tuple Constraints: the
+/// custom syntax "is now replaced by the above generic form"), so the ADL2
+/// entry point must keep refusing the identical text.
+#[test]
+fn pipe_ordinal_is_refused_by_the_adl2_dialect() {
+    let src = archetype_with("\t\t\t\t\t0|[local::at0039],\n\t\t\t\t\t1|[local::at0040]");
+    assert!(
+        parse_artefact(&src).is_err(),
+        "the deprecated 1.4 pipe-ordinal must not parse as ADL 2"
+    );
+}
+
+// ── the 1.4→2 conversion of both lowered forms ──────────────────────────────
+
+/// Both custom forms survive the whole 1.4 pipeline: they convert to ADL 2 and
+/// print as the constructs ADL 2 defines for them — the qualified codes become
+/// archetype-local at-codes with a terminology binding, and the ordinal keeps
+/// the `[value, symbol]` tuple `ADL2/master04.4-cadl_second_order.adoc`
+/// §Tuple Constraints prescribes. (No openEHR spec governs 1.4→2 conversion —
+/// our own design; this pins the shapes, not a spec clause.)
+#[test]
+fn both_custom_forms_convert_to_adl2_and_print() {
+    for constraint in [
+        "\t\t\t\t\tC_CODE_PHRASE <
+\t\t\t\t\t\tterminology_id = <value = <\"local\">>
+\t\t\t\t\t\tcode_list = <[\"1\"] = <\"at0039\"> [\"2\"] = <\"at0040\">>
+\t\t\t\t\t>",
+        "\t\t\t\t\t0|[local::at0039],\n\t\t\t\t\t1|[local::at0040]",
+    ] {
+        let mut log = ConversionLog::new();
+        let converted = parse_and_convert(
+            &archetype_with(constraint),
+            &ConvertConfig::default(),
+            &mut log,
+        )
+        .unwrap_or_else(|e| panic!("{constraint} must convert: {e:?}"));
+        let printed = openehr_adl::printer::print(&converted);
+        assert!(
+            parse_artefact(&printed).is_ok(),
+            "the converted ADL 2 text must re-parse as ADL 2:\n{printed}"
+        );
+    }
+}
+
+// ── 3. the adjudicated refusal ──────────────────────────────────────────────
+
+/// `C_DV_STATE` appears nowhere in the vendored openEHR spec text — the oAP
+/// custom type is not vendored, and `AOM1.4/masterAppA-domain_extension.adoc`
+/// works only `C_ORDINAL`/`C_QUANTITY`/`C_CODED_TEXT` — so it has no citable
+/// shape and stays a typed refusal naming the type.
+#[test]
+fn c_dv_state_stays_refused_by_name() {
+    let src = archetype_with(
+        "\t\t\t\t\t(C_DV_STATE) <
+\t\t\t\t\t\tvalue = <\"initial\">
+\t\t\t\t\t>",
+    );
+    let errors = parse_artefact_adl14(&src)
+        .err()
+        .unwrap_or_else(|| panic!("C_DV_STATE must be refused"));
+    assert!(
+        errors.iter().any(|e| e.code == SyntaxErrorCode::Sdinv),
+        "expected SDINV, got {:?}",
+        errors.iter().map(|e| e.code).collect::<Vec<_>>()
+    );
+    assert!(
+        errors.iter().any(|e| e.to_string().contains("C_DV_STATE")),
+        "the refusal must name the unsupported type: {errors:?}"
+    );
+}

--- a/crates/openehr-adl/tests/it/main.rs
+++ b/crates/openehr-adl/tests/it/main.rs
@@ -10,6 +10,7 @@ mod adl14_assertions;
 mod adl14_cadl_gates;
 mod adl14_cnf_fixture_slot;
 mod adl14_conversion;
+mod adl14_custom_constraints;
 mod adl14_dadl_breadth;
 mod adl14_header_sections;
 mod assembly;


### PR DESCRIPTION
Closes #1327 (sub-issue of #771, the ADL1.4 ch.9 audit, v3.15.0 AM program).

## What

Two ADL 1.4 custom-constraint forms from `ADL1.4/master09-customising_adl.adoc` were refused:

1. **Inline dADL `C_CODE_PHRASE <…>`** (the chapter's own 'perfectly legal' §Custom Syntax example) now lowers to the same `C_TERMINOLOGY_CODE` the `[local:: a, b]` custom syntax builds — both spellings share one helper (`adl14_term_constraint`), so STCDC/STCAC and VATDF/VACDF/VETDF apply identically (tests assert structural equality of the two lowerings, not just `is_ok()`). Tolerant reads only where vendored (nested + plain `terminology_id`; keyed/list/lone-string `code_list`); malformed blocks are loud `Sdinv` refusals naming the defect.
2. **The openEHR-profiled 1.4 pipe-ordinal shorthand** (`0|[local::at1], 1|[local::at2]` — the exact form `ADL2/master04.4` documents and deprecates in favour of the generic tuple) parses in `Dialect::Adl14` ONLY, building the `DV_ORDINAL` `[value, symbol]` attribute tuple master04.4 names as its replacement. The assumed tail (`; 1`; vendored `cadl14.g4` `c_ordinal` production) lands on the named row's `assumed_value`; a tail naming no listed row is refused. The ADL2 dialect still refuses the pipe form (pinned twin).

**`C_DV_STATE`**: adjudicated — stays a typed refusal with a settled `// NOTE:` (no vendored openEHR text defines it; `AOM1.4/masterAppA` works only `C_ORDINAL`/`C_QUANTITY`/`C_CODED_TEXT`); the SDINV refusal corpus fixture retargets to it, nothing dropped.

Also fixes the private-intra-doc rustdoc failure introduced with the VDFPT change in PR #1325 (`validate/mod.rs` linked a `pub(super)` fn from a public doc comment — the doc gate fails on develop without this).

## Tests

New `tests/it/adl14_custom_constraints.rs` (15 tests, each spec-cited) + 2 inline unit tests + 2 accepting corpus fixtures with INVENTORY rows.

## Gates

- `cargo fmt --all --check` clean; CI-flag clippy zero warnings
- `RUSTDOCFLAGS="-D warnings" cargo doc -p openehr-adl --no-deps` clean (was red on develop)
- `cargo nextest run -p openehr-adl -p ehrbase` — 970/970 pass