### PR TITLE
fix(openehr-adl): convert all App.B standardised meta-data items in the 1.4→2 converter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,21 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **Converting an ADL 1.4 archetype to ADL 2 now carries its extended
+  meta-data across.** The standardised `description/other_details` items of
+  ADL 1.4 App.B (Extended Meta-data Guide) — items "intended to be
+  implemented by any ADL 1.4 => ADL 2 conversion tool" — previously survived
+  conversion only as opaque `other_details` strings (only `revision` was
+  converted). They now land in their ADL 2 homes: `build_uid` becomes the
+  archetype's build identifier; `original_namespace`, `original_publisher`,
+  `custodian_namespace`, `custodian_organisation` and `licence` become the
+  matching description attributes; and `references` / `ip_acknowledgements`
+  become keyed lists, one entry per line with surrounding whitespace
+  stripped. Each converted item is removed from `other_details`; a value that
+  does not match its documented syntax (e.g. a `build_uid` that is not a
+  GUID) is left in `other_details` untouched rather than guessed at, and the
+  guide's "other items" (`MD5-CAM-1.0.1`, `current_contact`, `review_date`,
+  `responsible_organisation`) pass through unchanged as before.
 - **ADL 1.4 archetypes using the chapter's custom constraint forms now
   upload.** Two constructs of ADL 1.4 §Customising ADL (master09) were
   rejected outright:

--- a/crates/openehr-adl/src/adl14/convert.rs
+++ b/crates/openehr-adl/src/adl14/convert.rs
@@ -6,6 +6,12 @@
 //! spec clause; where a comment cites an AOM2/ADL2 section, it pins the
 //! validity of the ADL2 OUTPUT form (which is spec-governed), not the
 //! conversion procedure.
+//!
+//! The one exception is the standardised `description/other_details` meta-data
+//! mapping (`build_uid` + the `RESOURCE_DESCRIPTION` governance items), which
+//! `ADL1.4/masterAppB-extended_metadata.adoc` §Standardised Items governs
+//! directly — those items are "intended to be implemented by any ADL 1.4 =>
+//! ADL 2 conversion tool". It is applied by the description transform below.
 
 use std::collections::BTreeMap;
 
@@ -715,6 +721,26 @@ impl<'a> Converter<'a> {
         let version = revision.clone().unwrap_or_else(|| "1.0.0".to_owned());
         set_release_version(&mut data.archetype_id, &version);
 
+        // `other_details["build_uid"]` → the archetype's `build_uid`
+        // (`ADL1.4/masterAppB-extended_metadata.adoc` §Standardised Items:
+        // "Guid string … See AOM2 spec, Machine Identifiers section"). Only a
+        // well-formed GUID is consumed — a value violating the stated syntax
+        // stays in `other_details` verbatim rather than being guessed at — and
+        // an already-populated `build_uid` (a 1.4 header `build_uid=` meta
+        // item) is never overwritten by the meta-data section.
+        if data.build_uid.value.is_nil()
+            && let Some(other) = data
+                .description
+                .as_mut()
+                .and_then(|d| d.other_details.as_mut())
+            && let Some(value) = other
+                .get("build_uid")
+                .and_then(|raw| uuid::Uuid::parse_str(raw.trim()).ok())
+        {
+            data.build_uid = openehr_base::prelude::Uuid { value };
+            other.remove("build_uid");
+        }
+
         if let Some(desc) = data.description.as_mut() {
             transform_description(desc);
             // Surface the conversion's non-mechanical decisions (collapse
@@ -756,10 +782,113 @@ fn transform_description(
         desc.copyright = Some(cr);
     }
 
+    convert_standardised_meta_data(desc);
+
     // Drop the consumed `revision` from other_details.
     if let Some(o) = desc.other_details.as_mut() {
         o.remove("revision");
     }
+}
+
+/// Convert the ADL 1.4 standardised `description/other_details` meta-data items
+/// to their AOM2 `RESOURCE_DESCRIPTION` homes, consuming each converted key.
+///
+/// `ADL1.4/masterAppB-extended_metadata.adoc` §Standardised Items is the one
+/// part of 1.4→2 conversion the spec text governs directly: the items' "naming
+/// and rules should be followed, and … are intended to be implemented by any
+/// ADL 1.4 => ADL 2 conversion tool". The mapping applied here is the table's:
+///
+/// - `original_namespace`, `original_publisher`, `custodian_namespace`,
+///   `custodian_organisation`, `licence` transfer verbatim to the same-named
+///   `RESOURCE_DESCRIPTION` attributes. The table's `"name <URN>"` shapes are
+///   DISPLAY conventions ("the use of the typical string for a person or
+///   organisation of the form \"name \<URN\>\", which enables email addresses,
+///   website URLs etc to be easily extracted", §Extended Meta-data Guide
+///   preamble) — the AOM2 attributes are single strings, so the value is not
+///   decomposed.
+/// - `references` and `ip_acknowledgements` are "string with one LF (`\n`)
+///   terminated line for each reference. Intervening LFs and leading and
+///   trailing whitespace may be added for clarity, to be stripped on
+///   conversion to ADL2" — so the value splits on LF, each line is trimmed,
+///   and blank lines are dropped.
+///
+/// §Other Items (`MD5-CAM-1.0.1`, `current_contact`, `review_date`,
+/// `responsible_organisation`) are reserved/display-only names with no
+/// conversion mandated; they stay in `other_details` untouched, as does any
+/// value that violates its item's stated syntax.
+///
+/// An AOM2 attribute already populated from elsewhere is never overwritten, and
+/// its `other_details` key is then left in place (nothing was consumed).
+fn convert_standardised_meta_data(
+    desc: &mut openehr_am::am24::resource::resource_description::ResourceDescription,
+) {
+    let Some(other) = desc.other_details.as_mut() else {
+        return;
+    };
+    take_verbatim(other, "original_namespace", &mut desc.original_namespace);
+    take_verbatim(other, "original_publisher", &mut desc.original_publisher);
+    take_verbatim(other, "custodian_namespace", &mut desc.custodian_namespace);
+    take_verbatim(
+        other,
+        "custodian_organisation",
+        &mut desc.custodian_organisation,
+    );
+    take_verbatim(other, "licence", &mut desc.licence);
+    take_keyed_lines(other, "references", &mut desc.references);
+    take_keyed_lines(other, "ip_acknowledgements", &mut desc.ip_acknowledgements);
+}
+
+/// Move `other[key]` verbatim into `target`, consuming the key; a no-op when
+/// `target` is already populated or the key is absent.
+fn take_verbatim(other: &mut BTreeMap<String, String>, key: &str, target: &mut Option<String>) {
+    if target.is_some() {
+        return;
+    }
+    if let Some(value) = other.remove(key) {
+        *target = Some(value);
+    }
+}
+
+/// Move the LF-separated lines of `other[key]` into `target` as a keyed list,
+/// consuming the key; a no-op when `target` is already populated, the key is
+/// absent, or no non-blank line survives the strip (nothing to convert — the
+/// value stays in `other_details` rather than being dropped).
+fn take_keyed_lines(
+    other: &mut BTreeMap<String, String>,
+    key: &str,
+    target: &mut Option<BTreeMap<String, String>>,
+) {
+    if target.is_some() {
+        return;
+    }
+    let Some(raw) = other.get(key) else {
+        return;
+    };
+    let lines: Vec<String> = raw
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_owned)
+        .collect();
+    if lines.is_empty() {
+        return;
+    }
+    // NOTE: the appendix prescribes the LF-per-entry SOURCE syntax and the
+    // AOM2 target ("a keyed list of strings"), but no key scheme for the
+    // converted entries — no openEHR spec governs the key scheme, so this is
+    // our own design: stable 1-based ordinals in source line order, matching
+    // the `["1"]`/`["2"]` keys the vendored `upgrade_from_14` reference output
+    // carries. (Ordinals are unpadded, so a list of ten or more entries sorts
+    // lexicographically in the `BTreeMap` — a display order, not a semantic
+    // one; the ordinal itself still names the source line.)
+    *target = Some(
+        lines
+            .into_iter()
+            .enumerate()
+            .map(|(index, line)| ((index + 1).to_string(), line))
+            .collect(),
+    );
+    other.remove(key);
 }
 
 // ── free-function tree walks ─────────────────────────────────────────────────

--- a/crates/openehr-adl/tests/it/adl14_conversion.rs
+++ b/crates/openehr-adl/tests/it/adl14_conversion.rs
@@ -548,3 +548,281 @@ fn occurrences_of(
         _ => None,
     }
 }
+
+// ── App.B extended meta-data (`description/other_details`) ───────────────────
+
+/// The archetype data of a converted plain authored archetype.
+fn authored(
+    a: &Archetype,
+) -> &openehr_am::am24::aom2::archetype::authored_archetype::AuthoredArchetypeData {
+    match a {
+        Archetype::AuthoredArchetype(b) => match b.as_ref() {
+            AuthoredArchetype::AuthoredArchetype(d) => d,
+            _ => panic!("not a plain authored archetype"),
+        },
+        Archetype::TemplateOverlay(_) => panic!("template overlay"),
+    }
+}
+
+/// A minimal 1.4 archetype carrying `other_details_block` verbatim.
+fn meta_data_source(other_details_block: &str) -> String {
+    format!(
+        "\
+archetype (adl_version=1.4)
+    openEHR-EHR-CLUSTER.app_b_meta_data.v1
+
+concept
+    [at0000]
+
+language
+    original_language = <[ISO_639-1::en]>
+
+description
+    lifecycle_state = <\"AuthorDraft\">
+{other_details_block}
+
+definition
+    CLUSTER[at0000] matches {{
+        items cardinality matches {{0..*; unordered}} matches {{
+            ELEMENT[at0001] matches {{*}}
+        }}
+    }}
+
+ontology
+    term_definitions = <
+        [\"en\"] = <
+            items = <
+                [\"at0000\"] = <text=<\"root\"> description=<\"root\">>
+                [\"at0001\"] = <text=<\"item\"> description=<\"item\">>
+            >
+        >
+    >
+"
+    )
+}
+
+fn convert_source(src: &str) -> Archetype {
+    let mut log = ConversionLog::new();
+    parse_and_convert(src, &ConvertConfig::default(), &mut log).expect("converts")
+}
+
+/// A 1.4 source carrying the appendix's §Standardised Items example block
+/// verbatim (`ADL1.4/masterAppB-extended_metadata.adoc`).
+fn app_b_standardised_items_source() -> String {
+    meta_data_source(
+        r#"    other_details = <
+        ["licence"] = <"This work is licensed under the Creative Commons Attribution-ShareAlike 3.0 License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/3.0/.">
+        ["original_namespace"] = <"au.gov.nehta">
+        ["original_publisher"] = <"NEHTA CTI Team, National E-Health Transition Authority <clinicalinfo@nehta.gov.au>">
+        ["custodian_organisation"] = <"openEHR Foundation <http://www.openEHR.org>">
+        ["custodian_namespace"] = <"org.openehr">
+        ["build_uid"] = <"3076af96-e1dd-4f9b-abf2-23913fcf52b1">
+        ["revision"] = <"0.0.1-alpha">
+        ["references"] = <"
+            O'Brien E, Asmar R, Beilin L, et al. European Society of Hypertension recommendations for conventional, ambulatory and home blood pressure measurement. Journal of Hypertension. 2003; 21(5):821-848. Available from: http://www.ncbi.nlm.nih.gov/pubmed/12714851
+            Perloff D, Grim C, Flack J, Frohlich ED, Hill M, McDonald M, Morgenstern BZ. Human blood pressure determination by sphygmomanometry. Circulation. 1993; 88(5):2460. Available from: http://circ.ahajournals.org/cgi/reprint/88/5/2460
+        ">
+        ["ip_acknowledgements"] = <"
+            Content from LOINC® is copyright © 1995 Regenstrief Institute, Inc. and the LOINC Committee, and available at no cost under the license at http://loinc.org/terms-of-use.
+            Content from SNOMED CT® is copyright © 2007 IHTSDO <ihtsdo.org>.
+        ">
+    >"#,
+    )
+}
+
+/// The appendix's §Standardised Items example block converts to its AOM2
+/// homes: the five governance strings transfer verbatim, `build_uid` parses
+/// into the archetype's `build_uid`, and `revision` still sets the release
+/// version.
+#[test]
+fn app_b_standardised_items_convert_to_their_aom2_homes() {
+    let converted = convert_source(&app_b_standardised_items_source());
+    let archetype = authored(&converted);
+    let desc = archetype.description.as_ref().expect("a description");
+
+    // The five governance strings transfer VERBATIM — the "name <URN>" shapes
+    // are display conventions, never decomposed.
+    assert_eq!(desc.original_namespace.as_deref(), Some("au.gov.nehta"));
+    assert_eq!(
+        desc.original_publisher.as_deref(),
+        Some("NEHTA CTI Team, National E-Health Transition Authority <clinicalinfo@nehta.gov.au>")
+    );
+    assert_eq!(desc.custodian_namespace.as_deref(), Some("org.openehr"));
+    assert_eq!(
+        desc.custodian_organisation.as_deref(),
+        Some("openEHR Foundation <http://www.openEHR.org>")
+    );
+    assert_eq!(
+        desc.licence.as_deref(),
+        Some(
+            "This work is licensed under the Creative Commons Attribution-ShareAlike 3.0 License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/3.0/."
+        )
+    );
+
+    // `build_uid` is a GUID string → the archetype's typed `build_uid`.
+    assert_eq!(
+        archetype.build_uid.value,
+        uuid::Uuid::parse_str("3076af96-e1dd-4f9b-abf2-23913fcf52b1").expect("a valid GUID")
+    );
+
+    // `revision` still drives the release version (unchanged behaviour).
+    assert_eq!(archetype.archetype_id.release_version, "0.0.1");
+}
+
+/// `references` and `ip_acknowledgements` are "string with one LF (`\n`)
+/// terminated line for each reference … Intervening LFs and leading and
+/// trailing whitespace may be added for clarity, to be stripped on conversion
+/// to ADL2" (`ADL1.4/masterAppB-extended_metadata.adoc` §Standardised Items):
+/// one keyed entry per non-blank line, trimmed. Every converted key is
+/// consumed from `other_details`, and the result prints + re-parses as ADL2.
+#[test]
+fn app_b_reference_lists_split_on_lf_into_keyed_entries() {
+    let converted = convert_source(&app_b_standardised_items_source());
+    let desc = authored(&converted)
+        .description
+        .as_ref()
+        .expect("a description");
+
+    let references = desc.references.as_ref().expect("references");
+    assert_eq!(
+        references.keys().collect::<Vec<_>>(),
+        vec!["1", "2"],
+        "1-based ordinals in source line order"
+    );
+    assert_eq!(
+        references.get("1").map(String::as_str),
+        Some(
+            "O'Brien E, Asmar R, Beilin L, et al. European Society of Hypertension recommendations for conventional, ambulatory and home blood pressure measurement. Journal of Hypertension. 2003; 21(5):821-848. Available from: http://www.ncbi.nlm.nih.gov/pubmed/12714851"
+        )
+    );
+    assert_eq!(
+        references.get("2").map(String::as_str),
+        Some(
+            "Perloff D, Grim C, Flack J, Frohlich ED, Hill M, McDonald M, Morgenstern BZ. Human blood pressure determination by sphygmomanometry. Circulation. 1993; 88(5):2460. Available from: http://circ.ahajournals.org/cgi/reprint/88/5/2460"
+        )
+    );
+    let ip = desc
+        .ip_acknowledgements
+        .as_ref()
+        .expect("ip_acknowledgements");
+    assert_eq!(ip.keys().collect::<Vec<_>>(), vec!["1", "2"]);
+    assert_eq!(
+        ip.get("1").map(String::as_str),
+        Some(
+            "Content from LOINC® is copyright © 1995 Regenstrief Institute, Inc. and the LOINC Committee, and available at no cost under the license at http://loinc.org/terms-of-use."
+        )
+    );
+    assert_eq!(
+        ip.get("2").map(String::as_str),
+        Some("Content from SNOMED CT® is copyright © 2007 IHTSDO <ihtsdo.org>.")
+    );
+
+    // Every converted key is consumed.
+    let left: Vec<&String> = desc
+        .other_details
+        .as_ref()
+        .map(|o| o.keys().collect())
+        .unwrap_or_default();
+    assert!(
+        left.is_empty(),
+        "every standardised item is consumed from other_details: {left:?}"
+    );
+
+    // The converted homes are visible in the printed ADL2, which re-parses.
+    let printed = openehr_adl::printer::print(&converted);
+    for token in [
+        "build_uid=3076af96-e1dd-4f9b-abf2-23913fcf52b1",
+        "original_namespace = <\"au.gov.nehta\">",
+        "custodian_namespace = <\"org.openehr\">",
+        "references = <",
+        "ip_acknowledgements = <",
+    ] {
+        assert!(
+            printed.contains(token),
+            "printed ADL2 is missing {token:?}:\n{printed}"
+        );
+    }
+    assert!(
+        !printed.contains("other_details"),
+        "no other_details section survives:\n{printed}"
+    );
+    parse_artefact(&printed)
+        .unwrap_or_else(|e| panic!("printed ADL2 does not re-parse: {e:?}\n{printed}"));
+}
+
+/// The appendix's §Other Items example block passes through untouched: those
+/// names are reserved/display-only ("CKM does nothing with this, except
+/// display") and no conversion is mandated for them.
+#[test]
+fn app_b_other_items_pass_through_other_details_unchanged() {
+    let src = meta_data_source(
+        r#"    other_details = <
+        ["review_date"] = <"2014-06-10">
+        ["current_contact"] = <"Ian McNicoll, freshEHR Clinical Informatics Ltd <ian.mcnicoll@freshehr.com>">
+        ["responsible_organisation"] = <"Nehta">
+        ["MD5-CAM-1.0.1"] = <"C5016B71B55DBDCBCAA8531CC1A982E3">
+    >"#,
+    );
+    let converted = convert_source(&src);
+    let desc = authored(&converted)
+        .description
+        .as_ref()
+        .expect("a description");
+    let other = desc.other_details.as_ref().expect("other_details");
+    assert_eq!(
+        other.get("review_date").map(String::as_str),
+        Some("2014-06-10")
+    );
+    assert_eq!(
+        other.get("current_contact").map(String::as_str),
+        Some("Ian McNicoll, freshEHR Clinical Informatics Ltd <ian.mcnicoll@freshehr.com>")
+    );
+    assert_eq!(
+        other.get("responsible_organisation").map(String::as_str),
+        Some("Nehta")
+    );
+    assert_eq!(
+        other.get("MD5-CAM-1.0.1").map(String::as_str),
+        Some("C5016B71B55DBDCBCAA8531CC1A982E3")
+    );
+    assert_eq!(other.len(), 4, "nothing added, nothing removed");
+}
+
+/// A `build_uid` that violates the table's "Guid string" syntax is never
+/// guessed at: it stays in `other_details` verbatim, the archetype keeps its
+/// nil `build_uid`, and the remaining standardised items still convert.
+#[test]
+fn malformed_build_uid_stays_in_other_details() {
+    let src = meta_data_source(
+        r#"    other_details = <
+        ["build_uid"] = <"not-a-guid">
+        ["custodian_namespace"] = <"org.openehr">
+    >"#,
+    );
+    let converted = convert_source(&src);
+    let archetype = authored(&converted);
+    assert!(
+        archetype.build_uid.value.is_nil(),
+        "a non-GUID build_uid is not converted"
+    );
+    let other = archetype
+        .description
+        .as_ref()
+        .expect("a description")
+        .other_details
+        .as_ref()
+        .expect("other_details");
+    assert_eq!(
+        other.get("build_uid").map(String::as_str),
+        Some("not-a-guid")
+    );
+    assert_eq!(other.len(), 1, "only the unconvertible value is left");
+    assert_eq!(
+        archetype
+            .description
+            .as_ref()
+            .and_then(|d| d.custodian_namespace.as_deref()),
+        Some("org.openehr"),
+        "the other standardised items still convert"
+    );
+}


### PR DESCRIPTION
Closes #1329 (sub-issue of #773, the ADL1.4 App.B audit, v3.15.0 AM program).

## What

`ADL1.4/masterAppB-extended_metadata.adoc` §Standardised Items is explicit converter guidance ('intended to be implemented by any ADL 1.4 => ADL 2 conversion tool'); `adl14/convert.rs` implemented only `revision`. Now all nine standardised `other_details` items map to their AOM2 homes:

- `build_uid` → the typed `Uuid` field (only when currently nil — a 1.4 header `build_uid=` wins — and the GUID parses; malformed values stay in `other_details`, pinned).
- The five governance/licence strings → the same-named `RESOURCE_DESCRIPTION` fields, verbatim (`name <URN>` is a display convention, never decomposed).
- `references`/`ip_acknowledgements` → the keyed AOM2 maps: LF-split + per-line whitespace stripped per the table's rule, 1-based ordinal keys (no spec-governed key scheme — NOTE-flagged; matches the vendored `upgrade_from_14` reference output's own `["1"]`/`["2"]` keys).

Consumed keys leave `other_details` (the established `revision` pattern); §Other Items pass through unchanged (pinned).

**Deliberate prior-art divergence**: the vendored reference `.adls` leaves `build_uid` inside `other_details` (the reference converter skipped that table row); App.B says to type it, so we do. No fixture assertion was weakened — the fixture comparison is scoped to definition + terminology by documented design.

## Tests

Four new tests in `adl14_conversion.rs`, driven by the appendix's own two example blocks as vectors (round-trip incl. the printed ADL2 re-parsing).

## Gates

- `cargo fmt --all --check` clean; CI-flag clippy zero warnings; `cargo doc -p openehr-adl` clean under `-D warnings`
- `cargo nextest run -p openehr-adl -p ehrbase` — 255 + 719 pass