### PR TITLE
fix(openehr-lang,openehr-adl): reject illegal backslash escapes in character tokens and BEL strings

### DIFF
--- a/crates/openehr-adl/src/lexer.rs
+++ b/crates/openehr-adl/src/lexer.rs
@@ -345,8 +345,9 @@ pub enum Token {
     /// `master03` (`\r \n \t \\ \" \'` + `\uHHHH`/`\uHHHHHHHH`).
     #[regex(r#""([^"\\]|\\.)*""#, validate_string)]
     String(String),
-    /// A single-quoted `CHARACTER`.
-    #[regex(r"'([^'\\\r\n]|\\.)'", |lex| lex.slice().to_owned())]
+    /// A single-quoted `CHARACTER`. An escaped character must be one of the
+    /// six legal quoted forms (see [`validate_char`]).
+    #[regex(r"'([^'\\\r\n]|\\.)'", validate_char)]
     Character(String),
 
     // ── rule/assertion variable ids (base_lexer.g4) ──
@@ -466,6 +467,25 @@ pub enum Token {
 /// Illegal escapes (anything other than `\r \n \t \\ \" \'` or a
 /// `\u` + 4/8 hex-digit sequence) fail the lex, per
 /// `ADL2/master03-file_encoding.adoc`.
+/// Validate a `CHARACTER` token: an escaped character must be one of the six
+/// legal quoted forms `\r \n \t \\ \" \'` — "Any other character combination
+/// starting with a backslash is illegal" (`ADL2/master03-file_encoding.adoc`
+/// §Special Character Sequences). The `\uHHHH` forms cannot fit the
+/// single-character token.
+fn validate_char(lex: &logos::Lexer<Token>) -> Result<String, ()> {
+    let raw = lex.slice();
+    let bytes = raw.as_bytes();
+    if bytes.get(1) == Some(&b'\\')
+        && !matches!(
+            bytes.get(2),
+            Some(b'r' | b'n' | b't' | b'\\' | b'"' | b'\'')
+        )
+    {
+        return Err(());
+    }
+    Ok(raw.to_owned())
+}
+
 fn validate_string(lex: &logos::Lexer<Token>) -> Result<String, ()> {
     let raw = lex.slice();
     let bytes = raw.as_bytes();
@@ -747,6 +767,21 @@ mod tests {
             toks("\u{feff}archetype"),
             vec![Token::AlphaLcId("archetype".into())]
         );
+    }
+
+    #[test]
+    fn character_escapes() {
+        // The six legal quoted forms and a plain/unicode character lex
+        // (`ADL2/master03-file_encoding.adoc` §Special Character Sequences).
+        for ok in [
+            r"'\n'", r"'\t'", r"'\r'", r"'\\'", r#"'\"'"#, r"'\''", "'x'", "'ü'",
+        ] {
+            assert!(lex(ok).is_ok(), "legal character must lex: {ok}");
+        }
+        // "Any other character combination starting with a backslash is
+        // illegal" — an unknown escape fails the lex.
+        assert!(lex(r"'\q'").is_err());
+        assert!(lex(r"'\d'").is_err());
     }
 
     #[test]

--- a/crates/openehr-lang/src/bel/lexer.rs
+++ b/crates/openehr-lang/src/bel/lexer.rs
@@ -113,11 +113,14 @@ pub(crate) enum Token {
     /// `INTEGER`.
     #[regex(r"[0-9]+", |lex| lex.slice().to_owned())]
     Integer(String),
-    /// A double-quoted `STRING` (may span lines).
-    #[regex(r#""([^"\\]|\\.)*""#, |lex| lex.slice().to_owned())]
+    /// A double-quoted `STRING` (may span lines). Escapes are validated per
+    /// `ADL2/master03-file_encoding.adoc` §Special Character Sequences (see
+    /// [`validate_string`]).
+    #[regex(r#""([^"\\]|\\.)*""#, validate_string)]
     String(String),
-    /// A single-quoted `CHARACTER`.
-    #[regex(r"'([^'\\\r\n]|\\.)'", |lex| lex.slice().to_owned())]
+    /// A single-quoted `CHARACTER`. An escaped character must be one of the
+    /// six legal quoted forms (see [`validate_char`]).
+    #[regex(r"'([^'\\\r\n]|\\.)'", validate_char)]
     Character(String),
 
     /// A delimited contained regexp `{ /re/ }` / `{ ^re^ }` — a single token so
@@ -246,6 +249,65 @@ pub(crate) enum Token {
     /// `^` (`SYM_CARAT` — exponent).
     #[token("^")]
     Caret,
+}
+
+/// Validate a `STRING` token's escape sequences: the six legal quoted forms
+/// `\r \n \t \\ \" \'` plus the `\uHHHH`/`\uHHHHHHHH` ASCII-encoded-unicode
+/// forms — "Any other character combination starting with a backslash is
+/// illegal" (`ADL2/master03-file_encoding.adoc` §Special Character Sequences +
+/// §File Encoding). The BEL lexer keeps the slice verbatim (this lexer is
+/// deliberately self-contained — the ODIN reader carries its own copy with
+/// multi-line leader stripping on top).
+fn validate_string(lex: &logos::Lexer<Token>) -> Result<String, ()> {
+    let raw = lex.slice();
+    let bytes = raw.as_bytes();
+    let mut i = 0;
+    while let Some(&byte) = bytes.get(i) {
+        if byte == b'\\' {
+            match bytes.get(i + 1) {
+                Some(b'r' | b'n' | b't' | b'\\' | b'"' | b'\'') => i += 2,
+                Some(b'u') => {
+                    let hex_start = i + 2;
+                    let count = raw
+                        .get(hex_start..)
+                        .unwrap_or_default()
+                        .chars()
+                        .take_while(char::is_ascii_hexdigit)
+                        .count();
+                    if count >= 8 {
+                        i = hex_start + 8;
+                    } else if count >= 4 {
+                        i = hex_start + 4;
+                    } else {
+                        return Err(());
+                    }
+                }
+                _ => return Err(()),
+            }
+        } else {
+            i += 1;
+        }
+    }
+    Ok(raw.to_owned())
+}
+
+/// Validate a `CHARACTER` token: an escaped character must be one of the six
+/// legal quoted forms — "Any other character combination starting with a
+/// backslash is illegal" (`ADL2/master03-file_encoding.adoc` §Special
+/// Character Sequences). The `\uHHHH` forms cannot fit the single-character
+/// token.
+fn validate_char(lex: &logos::Lexer<Token>) -> Result<String, ()> {
+    let raw = lex.slice();
+    let bytes = raw.as_bytes();
+    if bytes.get(1) == Some(&b'\\')
+        && !matches!(
+            bytes.get(2),
+            Some(b'r' | b'n' | b't' | b'\\' | b'"' | b'\'')
+        )
+    {
+        return Err(());
+    }
+    Ok(raw.to_owned())
 }
 
 /// Lex `src` into a spanned token vector.

--- a/crates/openehr-lang/src/odin/lexer.rs
+++ b/crates/openehr-lang/src/odin/lexer.rs
@@ -142,8 +142,9 @@ pub(crate) enum Token {
     /// [`validate_string`]).
     #[regex(r#""([^"\\]|\\.)*""#, validate_string)]
     String(String),
-    /// A single-quoted `CHARACTER`.
-    #[regex(r"'([^'\\\r\n]|\\.)'", |lex| lex.slice().to_owned())]
+    /// A single-quoted `CHARACTER`. An escaped character must be one of the
+    /// six legal quoted forms (see [`validate_char`]).
+    #[regex(r"'([^'\\\r\n]|\\.)'", validate_char)]
     Character(String),
 
     /// `ALPHA_UC_ID` — upper-initial identifier (ODIN keys / `rm_type_id`).
@@ -236,6 +237,25 @@ pub(crate) enum Token {
 /// normative literal-quote encoding, and decoding `&quot;` would be
 /// irreversible for text that legitimately contains it. The sequence is
 /// therefore carried through verbatim, as authored.
+/// Validate a `CHARACTER` token: an escaped character must be one of the six
+/// legal quoted forms `\r \n \t \\ \" \'` — "Any other character combination
+/// starting with a backslash is illegal" (`ADL2/master03-file_encoding.adoc`
+/// §Special Character Sequences, verbatim in `ADL1.4/master03-adl_basics`).
+/// The `\uHHHH` forms cannot fit the single-character token.
+fn validate_char(lex: &logos::Lexer<Token>) -> Result<String, ()> {
+    let raw = lex.slice();
+    let bytes = raw.as_bytes();
+    if bytes.get(1) == Some(&b'\\')
+        && !matches!(
+            bytes.get(2),
+            Some(b'r' | b'n' | b't' | b'\\' | b'"' | b'\'')
+        )
+    {
+        return Err(());
+    }
+    Ok(raw.to_owned())
+}
+
 fn validate_string(lex: &logos::Lexer<Token>) -> Result<String, ()> {
     let raw = lex.slice();
     let bytes = raw.as_bytes();

--- a/crates/openehr-lang/tests/it/escape_validation.rs
+++ b/crates/openehr-lang/tests/it/escape_validation.rs
@@ -1,0 +1,54 @@
+//! Escape-sequence validation in the ODIN and BEL lexers
+//! (`AM/docs/ADL2/master03-file_encoding.adoc` §Special Character Sequences):
+//! only `\r \n \t \\ \" \'` are legal quoted forms (strings additionally take
+//! the §File Encoding `\uHHHH`/`\uHHHHHHHH` ASCII-encoded-unicode forms) —
+//! "Any other character combination starting with a backslash is illegal."
+
+/// The ODIN reader rejects an illegal escape in a character value and keeps
+/// accepting the six legal forms plus plain/unicode characters.
+#[test]
+fn odin_character_escapes() {
+    for ok in [
+        r"x = <'\n'>",
+        r"x = <'\t'>",
+        r"x = <'\r'>",
+        r"x = <'\\'>",
+        r#"x = <'\"'>"#,
+        r"x = <'\''>",
+        "x = <'ü'>",
+    ] {
+        assert!(
+            openehr_lang::odin::parse(ok).is_ok(),
+            "legal character must parse: {ok}"
+        );
+    }
+    for bad in [r"x = <'\q'>", r"x = <'\d'>"] {
+        assert!(
+            openehr_lang::odin::parse(bad).is_err(),
+            "illegal escape must be rejected: {bad}"
+        );
+    }
+}
+
+/// The BEL lexer rejects illegal escapes in strings and characters, and keeps
+/// accepting the legal forms including `\u`-encoded unicode in strings.
+#[test]
+fn bel_string_and_character_escapes() {
+    let parses = |expr: &str| openehr_lang::bel::parse_statements(expr).is_ok();
+    for ok in [
+        r#"/a[at0001]/b = "a\n\t\\\"z""#,
+        r#"/a[at0001]/b = "grüße""#,
+        "/a[at0001]/b = \"grüße 中文\"",
+        r"/a[at0001]/b = '\''",
+        r"/a[at0001]/b = 'x'",
+    ] {
+        assert!(parses(ok), "legal form must parse: {ok}");
+    }
+    for bad in [
+        r#"/a[at0001]/b = "a\qz""#,
+        r#"/a[at0001]/b = "a\u12z""#,
+        r"/a[at0001]/b = '\q'",
+    ] {
+        assert!(!parses(bad), "illegal escape must be rejected: {bad}");
+    }
+}

--- a/crates/openehr-lang/tests/it/main.rs
+++ b/crates/openehr-lang/tests/it/main.rs
@@ -6,6 +6,7 @@
 //! (`.claude/rules/testing.md` §One integration-test binary per crate).
 
 mod bel_parse;
+mod escape_validation;
 mod vendor_bmm_odin;
 mod vendor_coverage;
 mod vendor_odin;


### PR DESCRIPTION
Closes #1331 (sub-issue of #776, the ADL2 ch.3 audit, v3.15.0 AM program).

## What

`ADL2/master03-file_encoding.adoc` §Special Character Sequences allows exactly six quoted forms — 'Any other character combination starting with a backslash is illegal' — with `\uHHHH`/`\uHHHHHHHH` additionally legal in strings (§File Encoding). Probe-verified: `'\q'` lexed silently in all three lexers (ODIN / BEL / ADL — the `Character` token had no escape validation), and BEL strings took the raw slice unvalidated. String validation already existed in the ODIN and ADL lexers.

- `validate_char` on the `Character` token in all three lexers (six legal forms; `\u` cannot fit the single-char token).
- BEL `String` gains the mirrored `validate_string` (the lexers are deliberately self-contained).
- Regex-pattern tokens stay verbatim per the chapter (PERL escapes are the regex engine's business).

## Tests

New `openehr-lang` `tests/it/escape_validation.rs` (ODIN + BEL, legal/illegal/unicode matrices) + the ADL lexer's `character_escapes` unit test.

## Gates

- `cargo fmt --all` clean; CI-flag clippy zero warnings
- `cargo nextest run -p openehr-lang -p openehr-adl -p ehrbase --no-fail-fast` — 1030/1030 pass