### PR TITLE
chore(release): publish official releases — prerelease only for suffixed tags

### DIFF
--- a/.claude/rules/changelog.md
+++ b/.claude/rules/changelog.md
@@ -27,8 +27,10 @@ optional:
   match), merge the release PR, then tag
   `vX.Y.Z` on the merge commit. The release workflow publishes the GitHub
   Release from the matching changelog section and **fails if the section or
-  version match is missing**. Releases stay `prerelease: true` until the
-  owner's production sign-off.
+  version match is missing**. Releases publish as OFFICIAL
+  releases — `prerelease` is true only for an explicitly suffixed tag
+  (`vX.Y.Z-rc1`, ...) — owner sign-off 2026-07-31, superseding the
+  2026-07-11 always-prerelease rule.
 - **After the tag:** close the `vX.Y.Z` milestone (`gh api … milestones/N
   -f state=closed`) and make sure the NEXT milestone exists so triage always
   has a target. The milestone's closed-issue list + the changelog section

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,10 +85,11 @@ jobs:
           tag_name: ${{ steps.tag.outputs.tag }}
           name: ${{ steps.tag.outputs.tag }}
           body_path: release-notes.md
-          # Every release is a pre-release until the first production
-          # sign-off (owner decision 2026-07-11); flip to
-          # `contains(<tag>, '-')` at that point.
-          prerelease: true
+          # Releases publish as OFFICIAL releases (owner sign-off
+          # 2026-07-31, superseding the 2026-07-11 always-prerelease rule);
+          # only an explicitly suffixed tag (v3.16.0-rc1, ...) is a
+          # pre-release.
+          prerelease: ${{ contains(steps.tag.outputs.tag, '-') }}
 
   # Native runner per arch (no cross toolchain, no QEMU) — same strategy as
   # .github/workflows/containers.yml, which handles the GHCR images on tags.

--- a/docs/VERSIONS.md
+++ b/docs/VERSIONS.md
@@ -15,7 +15,8 @@ tooling) follows its own SemVer line, starting at **3.0.0**
 (2026-07-11 — the fork's inherited upstream tags/releases were removed; this
 project releases as the successor of the EHRbase 2.x line). Releases are
 changelog-driven (`CHANGELOG.md`, Keep a Changelog 1.1.0) and published as
-pre-releases until production sign-off.
+official releases (owner sign-off 2026-07-31); only an explicitly suffixed
+tag (`vX.Y.Z-rc1`, ...) publishes as a pre-release.
 
 The `openehr-*` **spec crates** are versioned by the openEHR specification
 they implement (the pins below): `openehr-base` 1.3.0, `openehr-rm` 1.2.0,


### PR DESCRIPTION
Supersedes the 2026-07-11 always-prerelease rule (owner sign-off 2026-07-31): the release workflow now sets `prerelease: ${{ contains(tag, '-') }}` — official releases by default, pre-release only for explicitly suffixed tags (`vX.Y.Z-rc1`, …). This is exactly the flip the workflow comment pre-planned. `.claude/rules/changelog.md` and `docs/VERSIONS.md` updated to match. Release-process metadata only — no product behaviour change (`no-changelog`).