### PR TITLE
fix(openehr-lang): master03 escape hardening + namespaced ODIN type identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,25 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **A backslash sequence the ADL/ODIN escape rules do not define is now
+  refused with a clear message instead of read as literal text.** The escape
+  set is closed — `\r`, `\n`, `\t`, `\\`, `\"`, `\'` and the two `\u` unicode
+  forms — and anything else in a quoted string (a stray `\q`, a regex class
+  such as `\d` written outside a regex, a string ending in a lone backslash,
+  a `\u` with the wrong number of hex digits) is an authoring defect. Such a
+  string used to be carried through as-is, so the defect reached the stored
+  archetype as text; it is now reported at the offending literal. Regular
+  expressions are unaffected: the backslash patterns inside a `matches {/…/}`
+  constraint are still passed to the regex engine untouched.
+- **A type cast written with its package path now parses.** ODIN and ADL 1.4
+  dADL allow a type identifier to be qualified with dot-separated package
+  names — `(org.openehr.rm.ehr.content.ENTRY)`,
+  `(Core.Abstractions.Relationships.Relationship)`, and the same inside a
+  generic such as `(List<org.openehr.rm.ehr.content.ENTRY>)` — which is how
+  authors disambiguate same-named types from different models. Such a cast
+  used to fail the parse and reject the whole archetype. The qualified name
+  is kept exactly as authored; where the cast becomes a JSON `_type` tag, the
+  class name is used.
 - **Archetype text that carries a non-BMP character now reads correctly.**
   ADL and ODIN allow a unicode character above the base multilingual plane to
   be written as an eight-hex-digit `\uHHHHHHHH` escape (emoji, historic

--- a/app/ehrbase/src/aql/sql/expr.rs
+++ b/app/ehrbase/src/aql/sql/expr.rs
@@ -210,7 +210,8 @@ pub(super) fn aql_like_to_sql(pattern: &str) -> String {
 // Semantics"), so their specialisation parents are obtainable only from the
 // operational template (AM master07 §Supporting Archetype-based Querying);
 // completing this requires resolving the queried id's lineage through the
-// stored ADL2/OPT2 template family instead of the concept-prefix rule.
+// stored ADL2/OPT2 template family instead of the concept-prefix rule —
+// tracked as issue #1347.
 pub(super) fn archetype_predicate(node: &str, value: &str) -> Expr {
     if let Ok(id) = value.parse::<ArchetypeId>()
         && let Ok(major) = id.major_version().parse::<i32>()

--- a/app/ehrbase/src/service/ehr/contributions.rs
+++ b/app/ehrbase/src/service/ehr/contributions.rs
@@ -263,7 +263,8 @@ impl EhrbaseService {
     // branches below can attach `with_last_modified` — ITS-REST
     // `Requests_and_responses.md` §"ETag and Last-Modified" asks for the
     // header on any resource with a unique state identifier, and a
-    // CONTRIBUTION has one; today only the `ETag`/`Location` uid is emitted.
+    // CONTRIBUTION has one; today only the `ETag`/`Location` uid is emitted —
+    // tracked as issue #1349.
     pub async fn ehr_contribution_commit(
         &self,
         an_ehr_id: EhrId,

--- a/app/ehrbase/src/service/ehr/directory.rs
+++ b/app/ehrbase/src/service/ehr/directory.rs
@@ -15,7 +15,8 @@
 //! CONTRIBUTION — ITS-REST/SM bind only the directory (RM ehr master04
 //! §Folders).
 //
-// TODO: dedicated multi-hierarchy directory write management.
+// TODO: dedicated multi-hierarchy directory write management — tracked as
+// issue #1348.
 
 use crate::ids::{EhrId, VoId};
 use crate::service::response::ResourceMeta;

--- a/crates/openehr-adl/CLAUDE.md
+++ b/crates/openehr-adl/CLAUDE.md
@@ -89,8 +89,9 @@ else; each helper has exactly ONE home.
   (`aom/interval::point_value_{i32,f64}`): both sides bounded, both bounds
   included, both bounds equal — irrespective of point/proper tagging. The
   `master03` escape semantics likewise have exactly ONE implementation for the
-  whole workspace — `openehr_lang::escape` (both `\uHHHH` and `\uHHHHHHHH`,
-  with a typed decode error) — which the cADL parser, the ODIN lexer and the
+  whole workspace — `openehr_lang::escape` (a CLOSED set: the six quoted forms
+  plus `\uHHHH` and `\uHHHHHHHH`, everything else a typed decode error) — which
+  the cADL parser, the ODIN lexer and the
   BEL lexer all read through; the cADL side reports a decode defect as `SUNK`
   at the literal's span, the two `openehr-lang` lexers refuse it at the lex.
   The two full-pipeline entries run the SAME schedule: `validate` and

--- a/crates/openehr-adl/src/error.rs
+++ b/crates/openehr-adl/src/error.rs
@@ -10,6 +10,8 @@
 //! are present-but-unused here by design — the enum is the catalogue, not only
 //! the slice this outer parser reaches.
 
+use openehr_lang::position::line_col;
+
 /// An ADL2 syntax-error code.
 ///
 /// Each variant's doc comment is the normative gloss verbatim from
@@ -243,28 +245,6 @@ impl SyntaxError {
     }
 }
 
-/// Resolve a byte offset into a 1-based `(line, column)` pair.
-///
-/// `column` counts Unicode scalar values (`char`s) from the line start, not
-/// bytes, so multi-byte clinical text reports an intuitive column.
-fn line_col(src: &str, offset: usize) -> (usize, usize) {
-    let clamped = offset.min(src.len());
-    let mut line = 1usize;
-    let mut col = 1usize;
-    for (idx, ch) in src.char_indices() {
-        if idx >= clamped {
-            break;
-        }
-        if ch == '\n' {
-            line += 1;
-            col = 1;
-        } else {
-            col += 1;
-        }
-    }
-    (line, col)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -326,13 +306,15 @@ mod tests {
         assert_eq!(seen.len(), 45);
     }
 
+    /// A defect's reported position comes from the shared
+    /// [`openehr_lang::position::line_col`] (whose own tests pin the
+    /// arithmetic); what this crate owns is that `SyntaxError::at` resolves the
+    /// SPAN START against the source it was handed.
     #[test]
-    fn line_col_is_one_based_and_counts_chars() {
+    fn a_syntax_error_reports_the_span_start_as_a_line_and_column() {
         let src = "ab\ncdé/f";
-        assert_eq!(line_col(src, 0), (1, 1));
-        assert_eq!(line_col(src, 3), (2, 1)); // 'c'
-        // byte offset of '/' (after the 2-byte 'é'): still column 4 by chars.
-        let slash = src.find('/').expect("slash present");
-        assert_eq!(line_col(src, slash), (2, 4));
+        let slash = src.find('/').expect("the fixture contains a slash");
+        let err = SyntaxError::at(SyntaxErrorCode::Sunk, "x", slash..slash + 1, src);
+        assert_eq!((err.line, err.column), (2, 4));
     }
 }

--- a/crates/openehr-adl/src/lexer.rs
+++ b/crates/openehr-adl/src/lexer.rs
@@ -430,6 +430,20 @@ pub enum Token {
     /// `..` (`SYM_IVL_SEP`).
     #[token("..")]
     SymIvlSep,
+    /// `.` — the namespace separator of a qualified ODIN type identifier.
+    ///
+    /// NOTE: the outer artefact scan lexes the WHOLE source, ODIN sections
+    /// included, before handing each section's raw text to
+    /// `openehr_lang::odin`, so a construct legal inside an ODIN section must
+    /// have a token here even though no cADL production consumes it. The
+    /// qualified type identifier is such a construct: "Namespaces are included
+    /// by prepending package names, separated by the '.' character"
+    /// (`AM/docs/ADL1.4/master04-dadl` §Adding Type Information, verbatim in
+    /// `LANG/docs/odin/master05-content` §Adding Type Information). Every
+    /// dotted composite above (`...`, `..`, the code and identifier regexes,
+    /// `REAL`) is a longer match, so logos still prefers it.
+    #[token(".")]
+    SymDot,
     /// `|` (`SYM_IVL_DELIM`).
     #[token("|")]
     SymIvlDelim,
@@ -461,17 +475,14 @@ pub enum Token {
     SymAt,
 }
 
-/// Validate `master03` string escapes and return the raw slice (delimiters
-/// retained; the parser decodes).
+/// Validate a `CHARACTER` token's escape and return the raw slice
+/// (delimiters retained; the parser decodes).
 ///
-/// Illegal escapes (anything other than `\r \n \t \\ \" \'` or a
-/// `\u` + 4/8 hex-digit sequence) fail the lex, per
-/// `ADL2/master03-file_encoding.adoc`.
-/// Validate a `CHARACTER` token: an escaped character must be one of the six
-/// legal quoted forms `\r \n \t \\ \" \'` — "Any other character combination
-/// starting with a backslash is illegal" (`ADL2/master03-file_encoding.adoc`
-/// §Special Character Sequences). The `\uHHHH` forms cannot fit the
-/// single-character token.
+/// The escape rules are [`openehr_lang::escape`]'s — the ONE `master03`
+/// implementation the whole workspace shares — so an illegal escape fails the
+/// lex here rather than being judged a second time against a drifting local
+/// copy of the same rules. A `\uHHHH` form cannot fit the single-character
+/// token, and the shared decoder refuses it as a malformed unicode escape.
 fn validate_char(lex: &logos::Lexer<Token>) -> Result<String, ()> {
     let raw = lex.slice();
     let bytes = raw.as_bytes();
@@ -486,6 +497,13 @@ fn validate_char(lex: &logos::Lexer<Token>) -> Result<String, ()> {
     Ok(raw.to_owned())
 }
 
+/// Validate a `STRING` token's `master03` escapes and return the raw slice
+/// (delimiters retained; the parser decodes).
+///
+/// As [`validate_char`], the rules come from [`openehr_lang::escape`]: the six
+/// customary quoted forms plus `\uHHHH`/`\uHHHHHHHH`, and nothing else — "Any
+/// other character combination starting with a backslash is illegal"
+/// (`ADL2/master03-file_encoding.adoc` §Special Character Sequences).
 fn validate_string(lex: &logos::Lexer<Token>) -> Result<String, ()> {
     let raw = lex.slice();
     let bytes = raw.as_bytes();
@@ -498,7 +516,6 @@ fn validate_string(lex: &logos::Lexer<Token>) -> Result<String, ()> {
             match next {
                 b'r' | b'n' | b't' | b'\\' | b'"' | b'\'' => i += 2,
                 b'u' => {
-                    // \uHHHH (4) or \uHHHHHHHH (8) hex digits.
                     let hex_start = i + 2;
                     let count = raw
                         .get(hex_start..)
@@ -522,7 +539,6 @@ fn validate_string(lex: &logos::Lexer<Token>) -> Result<String, ()> {
     }
     Ok(raw.to_owned())
 }
-
 /// Lex `src` into a spanned token vector.
 ///
 /// # Errors

--- a/crates/openehr-adl/src/lexer.rs
+++ b/crates/openehr-adl/src/lexer.rs
@@ -485,15 +485,7 @@ pub enum Token {
 /// token, and the shared decoder refuses it as a malformed unicode escape.
 fn validate_char(lex: &logos::Lexer<Token>) -> Result<String, ()> {
     let raw = lex.slice();
-    let bytes = raw.as_bytes();
-    if bytes.get(1) == Some(&b'\\')
-        && !matches!(
-            bytes.get(2),
-            Some(b'r' | b'n' | b't' | b'\\' | b'"' | b'\'')
-        )
-    {
-        return Err(());
-    }
+    openehr_lang::escape::validate(raw).map_err(|_defect| ())?;
     Ok(raw.to_owned())
 }
 
@@ -506,37 +498,7 @@ fn validate_char(lex: &logos::Lexer<Token>) -> Result<String, ()> {
 /// (`ADL2/master03-file_encoding.adoc` §Special Character Sequences).
 fn validate_string(lex: &logos::Lexer<Token>) -> Result<String, ()> {
     let raw = lex.slice();
-    let bytes = raw.as_bytes();
-    let mut i = 0;
-    while let Some(&byte) = bytes.get(i) {
-        if byte == b'\\' {
-            let Some(&next) = bytes.get(i + 1) else {
-                return Err(());
-            };
-            match next {
-                b'r' | b'n' | b't' | b'\\' | b'"' | b'\'' => i += 2,
-                b'u' => {
-                    let hex_start = i + 2;
-                    let count = raw
-                        .get(hex_start..)
-                        .unwrap_or_default()
-                        .chars()
-                        .take_while(char::is_ascii_hexdigit)
-                        .count();
-                    if count >= 8 {
-                        i = hex_start + 8;
-                    } else if count >= 4 {
-                        i = hex_start + 4;
-                    } else {
-                        return Err(());
-                    }
-                }
-                _ => return Err(()),
-            }
-        } else {
-            i += 1;
-        }
-    }
+    openehr_lang::escape::validate(raw).map_err(|_defect| ())?;
     Ok(raw.to_owned())
 }
 /// Lex `src` into a spanned token vector.

--- a/crates/openehr-adl/src/odin.rs
+++ b/crates/openehr-adl/src/odin.rs
@@ -370,11 +370,7 @@ fn class_name(rm_type: &str) -> &str {
 /// digits), so this is where such a defect is caught, with the offending
 /// literal's span.
 pub(crate) fn decode_string(raw: &str) -> Result<String, openehr_lang::escape::EscapeError> {
-    let inner = raw
-        .strip_prefix('"')
-        .and_then(|s| s.strip_suffix('"'))
-        .unwrap_or(raw);
-    openehr_lang::escape::decode(inner)
+    openehr_lang::escape::decode_string_literal(raw)
 }
 
 /// Decode a single-quoted `CHARACTER` literal (delimiters included) into the
@@ -384,11 +380,7 @@ pub(crate) fn decode_string(raw: &str) -> Result<String, openehr_lang::escape::E
 /// As [`decode_string`]. The lexer admits only the six quoted forms inside a
 /// character literal, so no `\u` escape reaches here in practice.
 pub(crate) fn decode_character(raw: &str) -> Result<String, openehr_lang::escape::EscapeError> {
-    let inner = raw
-        .strip_prefix('\'')
-        .and_then(|s| s.strip_suffix('\''))
-        .unwrap_or(raw);
-    openehr_lang::escape::decode(inner)
+    openehr_lang::escape::decode_character_literal(raw)
 }
 
 // ── delimited regex (`AOM2/master04.5` §`C_STRING`) ───────────────────────

--- a/crates/openehr-adl/src/odin.rs
+++ b/crates/openehr-adl/src/odin.rs
@@ -279,7 +279,8 @@ pub(crate) fn odin_contains_interval(v: &OdinValue) -> bool {
 ///
 // TODO: encode ODIN interval values (`|0..5|`) as a typed default instead of
 // `null` — [`odin_contains_interval`] refuses them at the parse for now, so a
-// `_default = <|0..5|>` is an error rather than a silent null.
+// `_default = <|0..5|>` is an error rather than a silent null — tracked as
+// issue #1346.
 pub(crate) fn odin_to_json(v: &OdinValue) -> serde_json::Value {
     match v {
         OdinValue::String(s)

--- a/crates/openehr-adl/src/odin.rs
+++ b/crates/openehr-adl/src/odin.rs
@@ -320,11 +320,37 @@ pub(crate) fn odin_to_json(v: &OdinValue) -> serde_json::Value {
             if let serde_json::Value::Object(m) = &mut inner {
                 m.insert(
                     "_type".to_owned(),
-                    serde_json::Value::String(rm_type.clone()),
+                    serde_json::Value::String(class_name(rm_type).to_owned()),
                 );
             }
             inner
         }
+    }
+}
+
+/// The class name a (possibly namespaced) ODIN type cast denotes.
+///
+/// `LANG/docs/odin/master05-content` §Adding Type Information (verbatim in
+/// `AM/docs/ADL1.4/master04-dadl` §Adding Type Information) builds a qualified
+/// type identifier "by prepending package names, separated by the '.'
+/// character" to the type name, so the dotted prefix says which package the
+/// class comes from and the class itself is the terminal segment:
+/// `org.openehr.rm.ehr.content.ENTRY` and a bare `ENTRY` name the same type.
+/// The canonical-JSON `_type` tag carries the class name, so the package path
+/// is dropped on the way into JSON; the cast keeps its fully-qualified
+/// spelling, as authored, on the ODIN tree.
+///
+/// A generic head is qualified independently of its parameters
+/// (`org.openehr.base.Interval<Quantity>`), so only the text before the first
+/// `<` is unqualified.
+fn class_name(rm_type: &str) -> &str {
+    let head_end = rm_type.find('<').unwrap_or(rm_type.len());
+    let Some(head) = rm_type.get(..head_end) else {
+        return rm_type;
+    };
+    match head.rfind('.') {
+        Some(dot) => rm_type.get(dot + 1..).unwrap_or(rm_type),
+        None => rm_type,
     }
 }
 
@@ -446,4 +472,42 @@ pub(crate) fn is_delimited_regex_trimmed(s: &str) -> bool {
     let t = s.trim();
     t.len() >= 2
         && ((t.starts_with('/') && t.ends_with('/')) || (t.starts_with('^') && t.ends_with('^')))
+}
+#[cfg(test)]
+mod tests {
+    use super::{class_name, odin_to_json};
+
+    /// A namespaced ODIN cast names the same class as its bare spelling
+    /// (`LANG/docs/odin/master05-content` §Adding Type Information), so the
+    /// package path is dropped on the way into the canonical-JSON `_type`
+    /// tag while a generic head is unqualified independently of its
+    /// parameters.
+    #[test]
+    fn a_namespaced_cast_reduces_to_its_class_name() {
+        assert_eq!(class_name("ENTRY"), "ENTRY");
+        assert_eq!(class_name("org.openehr.rm.ehr.content.ENTRY"), "ENTRY");
+        assert_eq!(
+            class_name("Core.Abstractions.Relationships.Relationship"),
+            "Relationship"
+        );
+        assert_eq!(class_name("Interval<Quantity>"), "Interval<Quantity>");
+        assert_eq!(
+            class_name("org.openehr.base.Interval<org.openehr.base.Quantity>"),
+            "Interval<org.openehr.base.Quantity>"
+        );
+    }
+
+    /// The `_default` value block a namespaced cast heads carries the class
+    /// name as its `_type`, so a qualified spelling in the source does not
+    /// produce a dotted tag no RM reader recognises.
+    #[test]
+    fn a_namespaced_cast_tags_a_default_value_with_the_class_name() {
+        let value = openehr_lang::odin::parse(
+            "a = (org.openehr.rm.data_types.text.DV_TEXT) <value = <\"x\">>",
+        )
+        .expect("the namespaced cast should parse");
+        let json = odin_to_json(&value);
+        assert_eq!(json["a"]["_type"], serde_json::json!("DV_TEXT"));
+        assert_eq!(json["a"]["value"], serde_json::json!("x"));
+    }
 }

--- a/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.SUNK_illegal_string_escape.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-cadl/openEHR-EHR-CLUSTER.SUNK_illegal_string_escape.v1.adl
@@ -1,0 +1,61 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-CLUSTER.SUNK_illegal_string_escape.v1
+
+concept
+	[at0000]	-- Illegal backslash escape in a C_STRING
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"openEHR-rs regression corpus">
+	>
+	other_details = <
+		["regression"] = <"SUNK">
+	>
+	lifecycle_state = <"AuthorDraft">
+
+definition
+	CLUSTER[at0000] matches {	-- Illegal backslash escape in a C_STRING
+		items cardinality matches {0..*; unordered} matches {
+			ELEMENT[at0001] occurrences matches {0..1} matches {	-- Escaped label
+				value matches {
+					DV_TEXT matches {
+						value matches {
+							-- The invalid twin of `unicode_escape_8_digit`, whose three
+							-- legal spellings decode: the escape set is closed at the six
+							-- customary quoted forms plus the two `\u` spellings, and
+							-- "Any other character combination starting with a backslash
+							-- is illegal; to get the effect of a literal backslash, the
+							-- `\\` sequence should always be used"
+							-- (ADL1.4/master03-file_encoding.adoc §Special Character
+							-- Sequences, verbatim ADL2 master03-file_encoding.adoc).
+							-- `\q` is no such combination, and the PERL classes the same
+							-- section names (`\s`, `\d`) are legal ONLY inside a regex
+							-- literal, which is never escape-decoded. Passing the
+							-- sequence through verbatim would make an authoring defect
+							-- silently readable clinical text.
+							"a\qb"
+						}
+					}
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Illegal backslash escape in a C_STRING">
+					description = <"Refusal fixture: a backslash sequence outside the closed master03 set.">
+				>
+				["at0001"] = <
+					text = <"Escaped label">
+					description = <"A label carrying an illegal backslash escape.">
+				>
+			>
+		>
+	>

--- a/crates/openehr-adl/tests/corpus/adl14-dadl/openEHR-EHR-OBSERVATION.dadl_breadth.v1.adl
+++ b/crates/openehr-adl/tests/corpus/adl14-dadl/openEHR-EHR-OBSERVATION.dadl_breadth.v1.adl
@@ -43,6 +43,25 @@ description
 		>
 		["empty_cast"] = (PENSION) <...>
 
+		-- master04 §Adding Type Information: "Type identifiers can also
+		-- include namespace information, which is necessary when same-named
+		-- types appear in different packages of a model. Namespaces are
+		-- included by prepending package names, separated by the '.'
+		-- character, in the same way as in most programming languages, as in
+		-- the qualified type names `org.openehr.rm.ehr.content.ENTRY` and
+		-- `Core.Abstractions.Relationships.Relationship`" — both example
+		-- spellings, plus the principle box's combination of "Dot-separated
+		-- namespace identifiers AND template parameters".
+		["namespaced_cast_lc_package"] = (org.openehr.rm.ehr.content.ENTRY) <
+			name = <"qualified by a lower-case package path">
+		>
+		["namespaced_cast_uc_package"] = (Core.Abstractions.Relationships.Relationship) <
+			name = <"qualified by an upper-case package path">
+		>
+		["namespaced_cast_generic"] = (List<org.openehr.rm.ehr.content.ENTRY>) <
+			[1] = <"a qualified template parameter">
+		>
+
 		-- master04 §Complete Date/Times + §Partial Date/Times.
 		["date_full"] = <1919-01-23>
 		["date_no_day"] = <2004-06>

--- a/crates/openehr-adl/tests/it/adl14_cadl_gates.rs
+++ b/crates/openehr-adl/tests/it/adl14_cadl_gates.rs
@@ -222,6 +222,18 @@ const FIXTURES: &[(&str, Expect)] = &[
         "openEHR-EHR-CLUSTER.SUNK_unicode_escape_out_of_range.v1.adl",
         Expect::Refuse(SyntaxErrorCode::Sunk),
     ),
+    // The escape set is CLOSED — the six customary quoted forms plus the two
+    // `\u` spellings — because "Any other character combination starting with
+    // a backslash is illegal" (§Special Character Sequences). The accepting
+    // twin of this one is `unicode_escape_8_digit` above, whose three legal
+    // spellings decode; the PERL classes the same section names (`\s`, `\d`)
+    // are legal only inside a regex literal, which is never escape-decoded
+    // (`slot_domain_concept_regex` and `cadl_breadth_primitives` are their
+    // accepting twins).
+    (
+        "openEHR-EHR-CLUSTER.SUNK_illegal_string_escape.v1.adl",
+        Expect::Refuse(SyntaxErrorCode::Sunk),
+    ),
     // ── the master05 breadth trio (every construct of the chapter) ────────
     (
         "openEHR-EHR-OBSERVATION.cadl_breadth_structure.v1.adl",
@@ -319,6 +331,23 @@ fn the_unicode_escape_twins_decode_and_refuse_on_content() {
     assert!(
         messages.iter().any(|m| m.contains("0000FFFF")),
         "the refusal must name the offending escape, got {messages:?}"
+    );
+}
+/// The illegal-escape twin: the escape set is CLOSED at the six customary
+/// quoted forms plus the two `\u` spellings, so a `C_STRING` carrying any
+/// other backslash combination is refused at the lex rather than read as
+/// literal text (`ADL1.4/master03-file_encoding.adoc` §Special Character
+/// Sequences: "Any other character combination starting with a backslash is
+/// illegal"). Its accepting twin is `unicode_escape_8_digit` above.
+#[test]
+fn an_illegal_string_escape_is_refused_naming_the_literal() {
+    let src = read("openEHR-EHR-CLUSTER.SUNK_illegal_string_escape.v1.adl");
+    let errs =
+        parse_artefact(&src, Dialect::Adl14).expect_err("the illegal escape must be refused");
+    let messages: Vec<&str> = errs.iter().map(|e| e.message.as_str()).collect();
+    assert!(
+        messages.iter().any(|m| m.contains("qb")),
+        "the refusal must name the offending literal, got {messages:?}"
     );
 }
 

--- a/crates/openehr-adl/tests/it/adl14_dadl_breadth.rs
+++ b/crates/openehr-adl/tests/it/adl14_dadl_breadth.rs
@@ -131,6 +131,24 @@ fn breadth_fixture_leaf_values() {
         }
     );
 
+    // Namespaced type casts (master04 §Adding Type Information): the package
+    // path is preserved flat, exactly as authored, for both the lower-case and
+    // the upper-case package spelling the chapter exemplifies, and on a
+    // template parameter.
+    let OdinValue::Typed { rm_type, value } = get("namespaced_cast_lc_package") else {
+        panic!("expected a namespaced typed cast");
+    };
+    assert_eq!(rm_type, "org.openehr.rm.ehr.content.ENTRY");
+    assert!(matches!(**value, OdinValue::Object(_)));
+    let OdinValue::Typed { rm_type, .. } = get("namespaced_cast_uc_package") else {
+        panic!("expected a namespaced typed cast");
+    };
+    assert_eq!(rm_type, "Core.Abstractions.Relationships.Relationship");
+    let OdinValue::Typed { rm_type, .. } = get("namespaced_cast_generic") else {
+        panic!("expected a namespaced generic typed cast");
+    };
+    assert_eq!(rm_type, "List<org.openehr.rm.ehr.content.ENTRY>");
+
     // Partial date/times (master04 §Partial Date/Times).
     assert_eq!(
         get("date_time_unknown_time"),

--- a/crates/openehr-lang/CLAUDE.md
+++ b/crates/openehr-lang/CLAUDE.md
@@ -21,8 +21,11 @@ ADL/ODIN *instance* parsing — deliberately off the codegen path).
 - **`src/escape.rs` is the ONE home for `master03` string-escape semantics**
   (`LANG/docs/odin/master03-basics.adoc` §File Encoding + §Special Character
   Sequences, verbatim in `AM/docs/ADL2/master03-file_encoding.adoc`): the six
-  quoted forms plus BOTH `\uHHHH` and `\uHHHHHHHH`, with a typed
-  `EscapeError` for a `\u` escape that denotes no character. The ODIN and BEL
+  quoted forms plus BOTH `\uHHHH` and `\uHHHHHHHH`, and NOTHING else — the set
+  is closed ("Any other character combination starting with a backslash is
+  illegal"), so an unknown sequence, an unpaired trailing backslash, a `\u`
+  with the wrong digit count, and a `\u` that denotes no character are each a
+  typed `EscapeError`, never pass-through text. The ODIN and BEL
   lexers call `escape::validate` beside their structural escape scan (so a
   token never carries an undecodable escape, which is what lets their parsers
   decode infallibly), and `openehr-adl`'s cADL parser calls `escape::decode`

--- a/crates/openehr-lang/src/bel/lexer.rs
+++ b/crates/openehr-lang/src/bel/lexer.rs
@@ -251,68 +251,32 @@ pub(crate) enum Token {
     Caret,
 }
 
-/// Validate a `STRING` token's escape sequences: the six legal quoted forms
-/// `\r \n \t \\ \" \'` plus the `\uHHHH`/`\uHHHHHHHH` ASCII-encoded-unicode
-/// forms — "Any other character combination starting with a backslash is
-/// illegal" (`ADL2/master03-file_encoding.adoc` §Special Character Sequences +
-/// §File Encoding). The BEL lexer keeps the slice verbatim (this lexer is
-/// deliberately self-contained — the ODIN reader carries its own copy with
-/// multi-line leader stripping on top).
+/// Validate a `STRING` token's `master03` escapes and return the raw slice.
+///
+/// The escape rules come from [`crate::escape`], the one `master03`
+/// implementation this workspace has: the six customary quoted forms plus
+/// `\uHHHH`/`\uHHHHHHHH`, and nothing else — "Any other character combination
+/// starting with a backslash is illegal" (`ADL2/master03-file_encoding.adoc`
+/// §Special Character Sequences + §File Encoding). Refusing at the lex keeps
+/// the token stream free of escapes the reader cannot decode, which is what
+/// lets the parser decode infallibly. The slice is kept verbatim; unlike the
+/// ODIN reader this lexer has no multi-line leader stripping to apply.
 fn validate_string(lex: &logos::Lexer<Token>) -> Result<String, ()> {
     let raw = lex.slice();
-    let bytes = raw.as_bytes();
-    let mut i = 0;
-    while let Some(&byte) = bytes.get(i) {
-        if byte == b'\\' {
-            match bytes.get(i + 1) {
-                Some(b'r' | b'n' | b't' | b'\\' | b'"' | b'\'') => i += 2,
-                Some(b'u') => {
-                    let hex_start = i + 2;
-                    let count = raw
-                        .get(hex_start..)
-                        .unwrap_or_default()
-                        .chars()
-                        .take_while(char::is_ascii_hexdigit)
-                        .count();
-                    if count >= 8 {
-                        i = hex_start + 8;
-                    } else if count >= 4 {
-                        i = hex_start + 4;
-                    } else {
-                        return Err(());
-                    }
-                }
-                _ => return Err(()),
-            }
-        } else {
-            i += 1;
-        }
-    }
-    // The structural scan above accepts any 4/8 hex-digit `\u` run; the shared
-    // decoder is what decides whether it names a character at all.
     crate::escape::validate(raw).map_err(|_defect| ())?;
     Ok(raw.to_owned())
 }
 
-/// Validate a `CHARACTER` token: an escaped character must be one of the six
-/// legal quoted forms — "Any other character combination starting with a
-/// backslash is illegal" (`ADL2/master03-file_encoding.adoc` §Special
-/// Character Sequences). The `\uHHHH` forms cannot fit the single-character
-/// token.
+/// Validate a `CHARACTER` token's escape and return the raw slice.
+///
+/// As [`validate_string`], by exactly the same [`crate::escape`] rules. The
+/// `\uHHHH` forms cannot fit the single-character token and are refused as
+/// malformed unicode escapes.
 fn validate_char(lex: &logos::Lexer<Token>) -> Result<String, ()> {
     let raw = lex.slice();
-    let bytes = raw.as_bytes();
-    if bytes.get(1) == Some(&b'\\')
-        && !matches!(
-            bytes.get(2),
-            Some(b'r' | b'n' | b't' | b'\\' | b'"' | b'\'')
-        )
-    {
-        return Err(());
-    }
+    crate::escape::validate(raw).map_err(|_defect| ())?;
     Ok(raw.to_owned())
 }
-
 /// Lex `src` into a spanned token vector.
 ///
 /// # Errors

--- a/crates/openehr-lang/src/bel/parser.rs
+++ b/crates/openehr-lang/src/bel/parser.rs
@@ -468,11 +468,8 @@ fn relational(t: &Token) -> Option<(&'static str, &'static str)> {
     reason = "`Token::String` only exists when the lexer's validate_string ran crate::escape::validate over the same body and it succeeded, so this decode of that body cannot fail"
 )]
 fn decode_string(raw: &str) -> String {
-    let inner = raw
-        .strip_prefix('"')
-        .and_then(|s| s.strip_suffix('"'))
-        .unwrap_or(raw);
-    crate::escape::decode(inner).expect("a lexer-validated string literal should decode")
+    crate::escape::decode_string_literal(raw)
+        .expect("a lexer-validated string literal should decode")
 }
 
 /// Decode a single-quoted character literal to a `char`.
@@ -484,11 +481,7 @@ fn decode_string(raw: &str) -> String {
     reason = "`Token::Character` only exists when the lexer's validate_char admitted the body, which restricts an escape to the six quoted forms none of which can fail to decode"
 )]
 fn decode_char(raw: &str) -> char {
-    let inner = raw
-        .strip_prefix('\'')
-        .and_then(|s| s.strip_suffix('\''))
-        .unwrap_or(raw);
-    crate::escape::decode(inner)
+    crate::escape::decode_character_literal(raw)
         .expect("a lexer-validated character literal should decode")
         .chars()
         .next()

--- a/crates/openehr-lang/src/escape.rs
+++ b/crates/openehr-lang/src/escape.rs
@@ -15,6 +15,17 @@
 //! plus the six customary quoted forms `\r \n \t \\ \" \'` of §Special
 //! Character Sequences.
 //!
+//! Those eight forms are the WHOLE set: §Special Character Sequences closes
+//! it with "Any other character combination starting with a backslash is
+//! illegal; to get the effect of a literal backslash, the `\\` sequence should
+//! always be used", so every other backslash sequence is a typed decode
+//! defect here rather than pass-through text. Regular expressions are the one
+//! exemption, and they never reach this decoder: the PERL classes a cADL
+//! string constraint carries "should not be treated as anything other than
+//! literal strings, since they are processed by a regular expression parser"
+//! (§Special Character Sequences, final paragraph), so `openehr-adl` decodes
+//! only the `;"assumed"` suffix of a regex constraint, never its body.
+//!
 //! NOTE: the released text contradicts itself about `\u`. §File Encoding
 //! sanctions the two `\u` spellings; §Special Character Sequences, some ten
 //! lines later, closes its six-item list (which does NOT include `\u`) with
@@ -44,6 +55,42 @@
 /// verbatim, both of which turn an authoring defect into silently wrong text.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum EscapeError {
+    /// A backslash sequence outside the sanctioned set — the six customary
+    /// quoted forms of §Special Character Sequences plus the two `\u`
+    /// spellings of §File Encoding. "Any other character combination starting
+    /// with a backslash is illegal; to get the effect of a literal backslash,
+    /// the `\\` sequence should always be used" (§Special Character
+    /// Sequences).
+    #[error(
+        "the escape sequence '{sequence}' at byte {at} is illegal; the legal forms are \\r \\n \\t \\\\ \\\" \\' and \\u"
+    )]
+    IllegalEscape {
+        /// The two-character sequence, as authored.
+        sequence: String,
+        /// Its byte offset in the undelimited string body.
+        at: usize,
+    },
+    /// A string body ending in an unpaired backslash. A backslash carries no
+    /// meaning on its own: "to get the effect of a literal backslash, the
+    /// `\\` sequence should always be used" (§Special Character Sequences).
+    #[error(
+        "the string body ends with an unpaired backslash at byte {at}; a literal backslash is written \\\\"
+    )]
+    DanglingBackslash {
+        /// The byte offset of the unpaired backslash.
+        at: usize,
+    },
+    /// A `\u` escape carrying neither of the two digit counts §File Encoding
+    /// defines (4 for the BMP form, 8 for the non-BMP form).
+    #[error(
+        "the unicode escape at byte {at} carries {digits} hex digits; the \\u forms take 4 (BMP) or 8 (non-BMP)"
+    )]
+    MalformedUnicodeEscape {
+        /// How many hex digits followed the `\u`.
+        digits: usize,
+        /// The byte offset of the backslash opening the escape.
+        at: usize,
+    },
     /// A `\uHHHHHHHH` escape read as a zero-filled scalar whose code point
     /// falls outside `U+10000`-`U+10FFFF`, the only range the 8-digit form
     /// encodes (§File Encoding).
@@ -95,40 +142,49 @@ const NON_BMP_LAST: u32 = 0x0010_FFFF;
 /// Decode the `master03` escape sequences of an undelimited string body.
 ///
 /// # Errors
-/// [`EscapeError`] for a `\u` escape that denotes no character: an 8-digit
-/// form outside `U+10000`-`U+10FFFF`, a malformed surrogate pair, or a lone
-/// surrogate.
+/// [`EscapeError`] for any backslash sequence the two chapters do not
+/// sanction — an unknown letter after the backslash, an unpaired trailing
+/// backslash, a `\u` with neither 4 nor 8 hex digits — and for a `\u` escape
+/// that denotes no character: an 8-digit form outside `U+10000`-`U+10FFFF`, a
+/// malformed surrogate pair, or a lone surrogate.
 pub fn decode(inner: &str) -> Result<String, EscapeError> {
     if !inner.contains('\\') {
         return Ok(inner.to_owned());
     }
     let mut out = String::with_capacity(inner.len());
     let mut chars = inner.chars();
+    // The byte offset of the character `chars` is about to yield, so an error
+    // can name where in the body the offending sequence sits.
+    let mut at = 0usize;
     while let Some(c) = chars.next() {
         if c != '\\' {
             out.push(c);
+            at += c.len_utf8();
             continue;
         }
         match chars.next() {
             Some('r') => out.push('\r'),
             Some('n') => out.push('\n'),
             Some('t') => out.push('\t'),
-            // `\\` and a lone trailing `\` both yield one literal backslash.
-            Some('\\') | None => out.push('\\'),
+            Some('\\') => out.push('\\'),
             Some('"') => out.push('"'),
             Some('\'') => out.push('\''),
-            Some('u') => decode_unicode(&mut chars, &mut out)?,
-            // TODO: reject every backslash sequence outside the six §Special
-            // Character Sequences forms plus `\u` ("Any other character
-            // combination starting with a backslash is illegal") instead of
-            // passing it through verbatim; each lexer that feeds this decoder
-            // rejects them structurally today, so the pass-through only serves
-            // direct callers — tracked as issue #1344.
+            // The `\u` arm consumes its own hex digits on top of the two bytes
+            // the backslash and the `u` take.
+            Some('u') => at += decode_unicode(&mut chars, &mut out, at)?,
+            // "Any other character combination starting with a backslash is
+            // illegal" (§Special Character Sequences). Passing it through
+            // verbatim would make an authoring defect silently readable text.
             Some(other) => {
-                out.push('\\');
-                out.push(other);
+                return Err(EscapeError::IllegalEscape {
+                    sequence: format!("\\{other}"),
+                    at,
+                });
             }
+            None => return Err(EscapeError::DanglingBackslash { at }),
         }
+        // Every arm above consumed the backslash and one ASCII selector.
+        at += 2;
     }
     Ok(out)
 }
@@ -145,31 +201,39 @@ pub fn validate(inner: &str) -> Result<(), EscapeError> {
     decode(inner).map(|_| ())
 }
 
-/// Decode one `\u…` escape, whose `\u` prefix `chars` has already yielded.
+/// Decode one `\u…` escape, whose `\u` prefix `chars` has already yielded, and
+/// report how many bytes of hex digits it consumed (4 or 8 — every digit is
+/// ASCII, so the byte and character counts coincide).
 ///
 /// Consumes exactly the hex digits the chosen spelling uses, so any trailing
-/// hex text stays literal.
-fn decode_unicode(chars: &mut std::str::Chars<'_>, out: &mut String) -> Result<(), EscapeError> {
+/// hex text stays literal. `at` is the byte offset of the backslash that opens
+/// the escape, carried only so a defect can name its position.
+fn decode_unicode(
+    chars: &mut std::str::Chars<'_>,
+    out: &mut String,
+    at: usize,
+) -> Result<usize, EscapeError> {
     let digits: String = chars
         .clone()
         .take(8)
         .take_while(char::is_ascii_hexdigit)
         .collect();
+    let digit_count = digits.chars().count();
     let first: String = digits.chars().take(4).collect();
-    let first_value = if first.chars().count() == 4 {
+    let first_value = if digit_count >= 4 {
         hex_value(&first)
     } else {
         None
     };
     let Some(first_value) = first_value else {
-        // Fewer than four hex digits: not a well-formed `\u` escape at all.
-        // Every lexer feeding this decoder already refuses it; a direct caller
-        // gets it back verbatim.
-        out.push('\\');
-        out.push('u');
-        return Ok(());
+        // Fewer than four hex digits: neither of the two spellings §File
+        // Encoding defines, so the escape names no character.
+        return Err(EscapeError::MalformedUnicodeEscape {
+            digits: digit_count,
+            at,
+        });
     };
-    let has_eight = digits.chars().count() >= 8;
+    let has_eight = digit_count >= 8;
 
     if has_eight && (HIGH_SURROGATE_FIRST..=HIGH_SURROGATE_LAST).contains(&first_value) {
         let second: String = digits.chars().skip(4).take(4).collect();
@@ -185,18 +249,19 @@ fn decode_unicode(chars: &mut std::str::Chars<'_>, out: &mut String) -> Result<(
             + (low - LOW_SURROGATE_FIRST);
         push_non_bmp(code_point, digits, out)?;
         advance(chars, 8);
-        return Ok(());
+        return Ok(8);
     }
 
     if has_eight && first_value <= 0x0001 {
         let Some(code_point) = hex_value(&digits) else {
-            out.push('\\');
-            out.push('u');
-            return Ok(());
+            return Err(EscapeError::MalformedUnicodeEscape {
+                digits: digit_count,
+                at,
+            });
         };
         push_non_bmp(code_point, digits, out)?;
         advance(chars, 8);
-        return Ok(());
+        return Ok(8);
     }
 
     // The 4-digit BMP form.
@@ -214,7 +279,7 @@ fn decode_unicode(chars: &mut std::str::Chars<'_>, out: &mut String) -> Result<(
     };
     out.push(ch);
     advance(chars, 4);
-    Ok(())
+    Ok(4)
 }
 
 /// Push the character an 8-digit escape denotes, refusing anything outside the
@@ -335,5 +400,92 @@ mod tests {
     #[test]
     fn hex_text_after_a_four_digit_escape_stays_literal() {
         assert_eq!(decoded(r"\u00410042"), "A0042");
+    }
+
+    /// "Any other character combination starting with a backslash is illegal"
+    /// (§Special Character Sequences) — including the PERL regex classes that
+    /// are legal only INSIDE a cADL regex literal, which is never decoded.
+    #[test]
+    fn a_backslash_sequence_outside_the_sanctioned_set_is_refused() {
+        for (body, sequence, at) in [
+            (r"\q", r"\q", 0),
+            (r"a\d", r"\d", 1),
+            (r"ab\s.*", r"\s", 2),
+            (r"\0", r"\0", 0),
+            (r"\ ", r"\ ", 0),
+            (r"\U0041", r"\U", 0),
+        ] {
+            assert_eq!(
+                decode(body),
+                Err(EscapeError::IllegalEscape {
+                    sequence: sequence.to_owned(),
+                    at,
+                }),
+                "{body:?} must be refused"
+            );
+        }
+    }
+
+    /// The offset an illegal escape reports counts BYTES of the AUTHORED body,
+    /// so multi-byte text before it does not shift the position it names, and a
+    /// preceding escape counts its two authored characters rather than the one
+    /// it decodes to.
+    #[test]
+    fn the_illegal_escape_offset_counts_authored_bytes() {
+        assert_eq!(
+            decode("\u{e9}\\q"),
+            Err(EscapeError::IllegalEscape {
+                sequence: r"\q".to_owned(),
+                at: 2,
+            })
+        );
+        assert_eq!(
+            decode(r"\t\q"),
+            Err(EscapeError::IllegalEscape {
+                sequence: r"\q".to_owned(),
+                at: 2,
+            })
+        );
+        assert_eq!(
+            decode("\\u00E9\\q"),
+            Err(EscapeError::IllegalEscape {
+                sequence: r"\q".to_owned(),
+                at: 6,
+            })
+        );
+    }
+
+    /// A backslash carries no meaning on its own: "to get the effect of a
+    /// literal backslash, the `\\` sequence should always be used".
+    #[test]
+    fn an_unpaired_trailing_backslash_is_refused() {
+        assert_eq!(decode("\\"), Err(EscapeError::DanglingBackslash { at: 0 }));
+        assert_eq!(
+            decode(r"a\\b\"),
+            Err(EscapeError::DanglingBackslash { at: 4 })
+        );
+    }
+
+    /// §File Encoding defines exactly two `\u` spellings, of 4 and 8 hex
+    /// digits; anything shorter names no character.
+    #[test]
+    fn a_unicode_escape_shorter_than_four_digits_is_refused() {
+        for (body, digits) in [(r"\u", 0), (r"\u4", 1), (r"\u00", 2), (r"\uFFF", 3)] {
+            assert_eq!(
+                decode(body),
+                Err(EscapeError::MalformedUnicodeEscape { digits, at: 0 }),
+                "{body:?} must be refused"
+            );
+        }
+    }
+
+    /// The whole sanctioned set decodes in one body: the six quoted forms, the
+    /// 4-digit spelling, the surrogate pair and the zero-filled 8-digit form.
+    #[test]
+    fn the_whole_sanctioned_set_decodes_together() {
+        assert_eq!(
+            decoded("\\r\\n\\t\\\\\\\"\\'\\u00E9\\uD83DDE00\\u0001F600"),
+            "\r\n\t\\\"'\u{e9}\u{1F600}\u{1F600}"
+        );
     }
 }

--- a/crates/openehr-lang/src/escape.rs
+++ b/crates/openehr-lang/src/escape.rs
@@ -201,6 +201,42 @@ pub fn validate(inner: &str) -> Result<(), EscapeError> {
     decode(inner).map(|_| ())
 }
 
+/// Decode a double-quoted `STRING` literal — strip the `"` delimiters, then
+/// decode the body with [`decode`].
+///
+/// The delimiters are `master03`'s (`LANG/docs/odin/master03-basics` §Special
+/// Character Sequences: `\"` is the escape *because* `"` delimits), and every
+/// reader of a `master03` string literal — the ODIN parser, the BEL parser and
+/// the cADL parser — strips them the same way, so the rule lives here once. A
+/// slice that is not delimited is decoded as-is rather than losing a
+/// character.
+///
+/// # Errors
+/// As [`decode`].
+pub fn decode_string_literal(raw: &str) -> Result<String, EscapeError> {
+    decode(strip_delimiters(raw, '"'))
+}
+
+/// Decode a single-quoted `CHARACTER` literal — strip the `'` delimiters, then
+/// decode the body with [`decode`].
+///
+/// Returns a `String` rather than a `char` because the caller decides what an
+/// empty literal means; the grammars admit exactly one character, so a
+/// well-formed literal yields exactly one.
+///
+/// # Errors
+/// As [`decode`].
+pub fn decode_character_literal(raw: &str) -> Result<String, EscapeError> {
+    decode(strip_delimiters(raw, '\''))
+}
+
+/// The body of a `delimiter`-quoted literal, or the whole slice when it is not
+/// delimited.
+fn strip_delimiters(raw: &str, delimiter: char) -> &str {
+    raw.strip_prefix(delimiter)
+        .and_then(|s| s.strip_suffix(delimiter))
+        .unwrap_or(raw)
+}
 /// Decode one `\u…` escape, whose `\u` prefix `chars` has already yielded, and
 /// report how many bytes of hex digits it consumed (4 or 8 — every digit is
 /// ASCII, so the byte and character counts coincide).

--- a/crates/openehr-lang/src/lib.rs
+++ b/crates/openehr-lang/src/lib.rs
@@ -33,3 +33,4 @@ pub const SPEC_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub mod bel;
 pub mod escape;
 pub mod odin;
+pub mod position;

--- a/crates/openehr-lang/src/odin/lexer.rs
+++ b/crates/openehr-lang/src/odin/lexer.rs
@@ -240,15 +240,7 @@ pub(crate) enum Token {
 /// single-character token and are refused as malformed unicode escapes.
 fn validate_char(lex: &logos::Lexer<Token>) -> Result<String, ()> {
     let raw = lex.slice();
-    let bytes = raw.as_bytes();
-    if bytes.get(1) == Some(&b'\\')
-        && !matches!(
-            bytes.get(2),
-            Some(b'r' | b'n' | b't' | b'\\' | b'"' | b'\'')
-        )
-    {
-        return Err(());
-    }
+    crate::escape::validate(raw).map_err(|_defect| ())?;
     Ok(raw.to_owned())
 }
 
@@ -274,39 +266,7 @@ fn validate_char(lex: &logos::Lexer<Token>) -> Result<String, ()> {
 /// irreversible for text that legitimately contains it. The sequence is
 /// therefore carried through verbatim, as authored.
 fn validate_string(lex: &logos::Lexer<Token>) -> Result<String, ()> {
-    let raw = lex.slice();
-    let bytes = raw.as_bytes();
-    let mut i = 0;
-    while let Some(&byte) = bytes.get(i) {
-        if byte == b'\\' {
-            let Some(&next) = bytes.get(i + 1) else {
-                return Err(());
-            };
-            match next {
-                b'r' | b'n' | b't' | b'\\' | b'"' | b'\'' => i += 2,
-                b'u' => {
-                    let hex_start = i + 2;
-                    let count = raw
-                        .get(hex_start..)
-                        .unwrap_or_default()
-                        .chars()
-                        .take_while(char::is_ascii_hexdigit)
-                        .count();
-                    if count >= 8 {
-                        i = hex_start + 8;
-                    } else if count >= 4 {
-                        i = hex_start + 4;
-                    } else {
-                        return Err(());
-                    }
-                }
-                _ => return Err(()),
-            }
-        } else {
-            i += 1;
-        }
-    }
-    let stripped = strip_line_leaders(raw, leader_budget(lex));
+    let stripped = strip_line_leaders(lex.slice(), leader_budget(lex));
     crate::escape::validate(&stripped).map_err(|_defect| ())?;
     Ok(stripped)
 }

--- a/crates/openehr-lang/src/odin/lexer.rs
+++ b/crates/openehr-lang/src/odin/lexer.rs
@@ -198,6 +198,18 @@ pub(crate) enum Token {
     /// `..` (`SYM_IVL_SEP`).
     #[token("..")]
     IvlSep,
+    /// `.` — the namespace separator of a qualified type identifier.
+    ///
+    /// NOTE: the vendored `odin.g4` has no such token, because its
+    /// `rm_type_id` rule admits only `ALPHA_UC_ID`. The docs text is the
+    /// oracle and allows the qualified form: "Namespaces are included by
+    /// prepending package names, separated by the '.' character, in the same
+    /// way as in most programming languages" (`LANG/docs/odin/master05-content`
+    /// §Adding Type Information, verbatim in `AM/docs/ADL1.4/master04-dadl`
+    /// §Adding Type Information). `..`, `...`, `REAL` and every dotted
+    /// composite token above are longer matches, so logos still prefers them.
+    #[token(".")]
+    Dot,
     /// `|` (`SYM_IVL_DELIM`).
     #[token("|")]
     IvlDelim,
@@ -220,28 +232,12 @@ pub(crate) enum Token {
     Star,
 }
 
-/// Validate `master03` string escapes and return the raw (still-quoted) slice
-/// with multi-line whitespace leaders removed.
+/// Validate a `CHARACTER` token's escape and return the raw slice.
 ///
-/// Illegal escapes (anything other than `\r \n \t \\ \" \'` or a `\u` + 4/8
-/// hex-digit sequence) fail the lex (`LANG/docs/odin/master03-basics`
-/// §Special Character Sequences + `AM/docs/ADL1.4/master03-file_encoding`
-/// §Special Character Sequences, which define `\"` as *the* encoding of a
-/// literal double quote).
-///
-/// NOTE (adjudicated as descriptive, not a decoding rule):
-/// `AM/docs/ADL1.4/master04-dadl` §String Data — and verbatim
-/// `LANG/docs/odin/master07-leaf_data` §String Data — illustrate quoting with
-/// `"… what one might call a &quot;phrase&quot;."`. No chapter defines a
-/// decoding step for that form, the two `master03` chapters make `\"` the
-/// normative literal-quote encoding, and decoding `&quot;` would be
-/// irreversible for text that legitimately contains it. The sequence is
-/// therefore carried through verbatim, as authored.
-/// Validate a `CHARACTER` token: an escaped character must be one of the six
-/// legal quoted forms `\r \n \t \\ \" \'` — "Any other character combination
-/// starting with a backslash is illegal" (`ADL2/master03-file_encoding.adoc`
-/// §Special Character Sequences, verbatim in `ADL1.4/master03-file_encoding.adoc`).
-/// The `\uHHHH` forms cannot fit the single-character token.
+/// The escape rules come from [`crate::escape`], the one `master03`
+/// implementation this workspace has, so a `CHARACTER` is judged by exactly
+/// the rules a `STRING` is. The `\uHHHH` forms cannot fit the
+/// single-character token and are refused as malformed unicode escapes.
 fn validate_char(lex: &logos::Lexer<Token>) -> Result<String, ()> {
     let raw = lex.slice();
     let bytes = raw.as_bytes();
@@ -256,6 +252,27 @@ fn validate_char(lex: &logos::Lexer<Token>) -> Result<String, ()> {
     Ok(raw.to_owned())
 }
 
+/// Validate a `STRING` token's `master03` escapes and return the raw
+/// (still-quoted) slice with multi-line whitespace leaders removed.
+///
+/// The escape rules are [`crate::escape`]'s — the six customary quoted forms
+/// plus `\uHHHH`/`\uHHHHHHHH`, nothing else legal, and a `\u` naming no
+/// character a defect as well (`LANG/docs/odin/master03-basics` §Special
+/// Character Sequences + §File Encoding, verbatim in
+/// `AM/docs/ADL1.4/master03-file_encoding`, which define `\"` as *the*
+/// encoding of a literal double quote). Refusing at the lex keeps the token
+/// stream free of escapes the reader cannot decode, which is what lets the
+/// parser decode infallibly. The leader stripping runs first, so the validated
+/// text is exactly the text the parser will decode.
+///
+/// NOTE (adjudicated as descriptive, not a decoding rule):
+/// `AM/docs/ADL1.4/master04-dadl` §String Data — and verbatim
+/// `LANG/docs/odin/master07-leaf_data` §String Data — illustrate quoting with
+/// `"… what one might call a &quot;phrase&quot;."`. No chapter defines a
+/// decoding step for that form, the two `master03` chapters make `\"` the
+/// normative literal-quote encoding, and decoding `&quot;` would be
+/// irreversible for text that legitimately contains it. The sequence is
+/// therefore carried through verbatim, as authored.
 fn validate_string(lex: &logos::Lexer<Token>) -> Result<String, ()> {
     let raw = lex.slice();
     let bytes = raw.as_bytes();
@@ -290,15 +307,9 @@ fn validate_string(lex: &logos::Lexer<Token>) -> Result<String, ()> {
         }
     }
     let stripped = strip_line_leaders(raw, leader_budget(lex));
-    // The structural scan above accepts any 4/8 hex-digit `\u` run; the shared
-    // decoder is what decides whether it names a character at all (an 8-digit
-    // form outside U+10000-U+10FFFF, a malformed surrogate pair, a lone
-    // surrogate). Refusing here keeps the token stream free of escapes the
-    // reader cannot decode.
     crate::escape::validate(&stripped).map_err(|_defect| ())?;
     Ok(stripped)
 }
-
 /// How many leading whitespace characters may be removed from each
 /// continuation line of a multi-line string: the column at which the string's
 /// first line of content starts.

--- a/crates/openehr-lang/src/odin/mod.rs
+++ b/crates/openehr-lang/src/odin/mod.rs
@@ -328,6 +328,68 @@ mod tests {
         );
     }
 
+    /// Qualified (namespaced) type identifiers, both spellings the chapter
+    /// exemplifies: "Namespaces are included by prepending package names,
+    /// separated by the '.' character … as in the qualified type names
+    /// `org.openehr.rm.ehr.content.ENTRY` and
+    /// `Core.Abstractions.Relationships.Relationship`"
+    /// (`LANG/docs/odin/master05-content` §Adding Type Information, verbatim
+    /// in `AM/docs/ADL1.4/master04-dadl` §Adding Type Information). The
+    /// vendored `odin.g4` admits only the bare `ALPHA_UC_ID`; the docs text
+    /// wins, and the qualified name is preserved flat.
+    #[test]
+    fn namespaced_type_casts_parse_and_keep_the_dotted_name() {
+        for qualified in [
+            "org.openehr.rm.ehr.content.ENTRY",
+            "Core.Abstractions.Relationships.Relationship",
+            "org.openehr.rm.data_types.text.DV_TEXT",
+        ] {
+            let m = obj(&format!("a = ({qualified}) <b = <1>>"));
+            let OdinValue::Typed { rm_type, value } = m.get("a").expect("a") else {
+                panic!("expected a typed cast for {qualified}");
+            };
+            assert_eq!(rm_type, qualified);
+            assert!(matches!(**value, OdinValue::Object(_)));
+        }
+    }
+
+    /// The `master04-dadl` principle box allows "Dot-separated namespace
+    /// identifiers AND template parameters" on the same identifier, and a
+    /// template parameter is itself a type identifier — so both the generic
+    /// and its parameters may be qualified, and the unqualified generic form
+    /// is unchanged.
+    #[test]
+    fn namespaced_and_plain_generic_type_casts_parse() {
+        for (src, expected) in [
+            ("Interval<Quantity>", "Interval<Quantity>"),
+            (
+                "List<org.openehr.rm.ehr.content.ENTRY>",
+                "List<org.openehr.rm.ehr.content.ENTRY>",
+            ),
+            (
+                "org.openehr.base.foundation_types.Interval<org.openehr.base.Quantity>",
+                "org.openehr.base.foundation_types.Interval<org.openehr.base.Quantity>",
+            ),
+            (
+                "Hash<org.openehr.rm.HOTEL,String>",
+                "Hash<org.openehr.rm.HOTEL,String>",
+            ),
+        ] {
+            let m = obj(&format!("a = ({src}) <...>"));
+            let OdinValue::Typed { rm_type, .. } = m.get("a").expect("a") else {
+                panic!("expected a typed cast for {src}");
+            };
+            assert_eq!(rm_type, expected);
+        }
+    }
+
+    /// The qualification names a package path, so the segment it qualifies
+    /// stays the `ALPHA_UC_ID` type identifier: a lower-case terminal segment
+    /// is an attribute path, not a type, and must not be read as a cast.
+    #[test]
+    fn a_lowercase_terminal_segment_is_not_a_type_identifier() {
+        assert!(parse("a = (org.openehr.rm.content) <b = <1>>").is_err());
+    }
     #[test]
     fn illegal_escape_is_error() {
         assert!(parse(r#"a = <"bad \d">"#).is_err());

--- a/crates/openehr-lang/src/odin/mod.rs
+++ b/crates/openehr-lang/src/odin/mod.rs
@@ -16,6 +16,8 @@ mod parser;
 
 use indexmap::IndexMap;
 
+use crate::position::line_col;
+
 /// A parsed ODIN value.
 ///
 /// The tree mirrors `odin.g4`: an object (`attr = <…>` pairs), an
@@ -193,25 +195,6 @@ pub fn parse(src: &str) -> Result<OdinValue, OdinError> {
             span: located.offset..located.offset,
         }
     })
-}
-
-/// Resolve a byte offset to a 1-based `(line, column)` (columns count `char`s).
-fn line_col(src: &str, offset: usize) -> (usize, usize) {
-    let clamped = offset.min(src.len());
-    let mut line = 1usize;
-    let mut col = 1usize;
-    for (idx, ch) in src.char_indices() {
-        if idx >= clamped {
-            break;
-        }
-        if ch == '\n' {
-            line += 1;
-            col = 1;
-        } else {
-            col += 1;
-        }
-    }
-    (line, col)
 }
 
 #[cfg(test)]

--- a/crates/openehr-lang/src/odin/parser.rs
+++ b/crates/openehr-lang/src/odin/parser.rs
@@ -260,18 +260,57 @@ fn object_block<'a>() -> impl Parser<'a, &'a [Token], OdinValue, Err<'a>> + Clon
     })
 }
 
-/// `rm_type_id : ALPHA_UC_ID ( '<' rm_type_id ( ',' rm_type_id )* '>' )?`,
-/// reconstructed as a flat string (e.g. `Interval<Quantity>`).
+/// `rm_type_id : ( package_id '.' )* ALPHA_UC_ID ( '<' rm_type_id ( ','
+/// rm_type_id )* '>' )?`, reconstructed as a flat string (e.g.
+/// `Interval<Quantity>`, `org.openehr.rm.ehr.content.ENTRY`).
 ///
-// TODO: accept the dot-separated namespace form of a type identifier
-// (`org.openehr.rm.ehr.content.ENTRY`, `Core.Abstractions.Relationships.
-// Relationship`) — `AM/docs/ADL1.4/master04-dadl` §Adding Type Information and
-// `LANG/docs/odin/master05-content` §Adding Type Information both allow it,
-// but the vendored `odin.g4` `rm_type_id` rule this parser transcribes does
-// not, so such a cast currently fails the parse.
+/// NOTE: the vendored `odin.g4` writes this rule as bare
+/// `ALPHA_UC_ID ( '<' rm_type_id ( ',' rm_type_id )* '>' )?` — no namespace
+/// form. The docs text, which is the oracle where it and a grammar artefact
+/// disagree, allows the qualified spelling on any type identifier:
+/// "Type identifiers can also include namespace information, which is
+/// necessary when same-named types appear in different packages of a model.
+/// Namespaces are included by prepending package names, separated by the '.'
+/// character, in the same way as in most programming languages, as in the
+/// qualified type names `org.openehr.rm.ehr.content.ENTRY` and
+/// `Core.Abstractions.Relationships.Relationship`"
+/// (`LANG/docs/odin/master05-content` §Adding Type Information, verbatim in
+/// `AM/docs/ADL1.4/master04-dadl` §Adding Type Information, whose principle
+/// box restates it normatively: "Type Information can be included optionally
+/// on any node immediately before the opening '<' of any block, in the form
+/// of a UML-style type identifier in parentheses. Dot-separated namespace
+/// identifiers and template parameters may be used.").
+///
+/// Two consequences of that wording are honoured here. The package segments
+/// take either case — the chapter's own two examples are a lowercase package
+/// path (`org.openehr.rm.ehr.content`) and an upper-case one
+/// (`Core.Abstractions.Relationships`) — while the TYPE the qualification
+/// names stays `ALPHA_UC_ID`, since a package prefix qualifies the same type
+/// identifier the unqualified form spells. And because a template parameter
+/// is itself a type identifier, a parameter may be qualified too
+/// (`List<org.openehr.rm.ehr.content.ENTRY>`); the recursion gives that for
+/// free.
+///
+/// The qualified name is preserved FLAT, exactly as authored, so no caller
+/// loses the package information the author supplied.
 fn rm_type_id<'a>() -> impl Parser<'a, &'a [Token], String, Err<'a>> + Clone {
     recursive(|t| {
-        select! { Token::AlphaUcId(s) => s }
+        let package_segment = select! {
+            Token::AlphaUcId(s) => s,
+            Token::AlphaLcId(s) => s,
+        };
+        package_segment
+            .then_ignore(just(Token::Dot))
+            .repeated()
+            .collect::<Vec<String>>()
+            .then(select! { Token::AlphaUcId(s) => s })
+            .map(|(namespace, name)| {
+                if namespace.is_empty() {
+                    name
+                } else {
+                    format!("{}.{name}", namespace.join("."))
+                }
+            })
             .then(
                 t.separated_by(just(Token::Comma))
                     .at_least(1)

--- a/crates/openehr-lang/src/odin/parser.rs
+++ b/crates/openehr-lang/src/odin/parser.rs
@@ -555,11 +555,8 @@ fn integer_lexeme(s: &str) -> Option<i64> {
     reason = "`Token::String` only exists when the lexer's validate_string ran crate::escape::validate over the same body and it succeeded, so this decode of that body cannot fail"
 )]
 fn decode_string(raw: &str) -> String {
-    let inner = raw
-        .strip_prefix('"')
-        .and_then(|s| s.strip_suffix('"'))
-        .unwrap_or(raw);
-    crate::escape::decode(inner).expect("a lexer-validated string literal should decode")
+    crate::escape::decode_string_literal(raw)
+        .expect("a lexer-validated string literal should decode")
 }
 
 /// Decode a single-quoted `CHARACTER` literal to its `char`.
@@ -571,11 +568,9 @@ fn decode_string(raw: &str) -> String {
     reason = "`Token::Character` only exists when the lexer's validate_char admitted the body, which restricts an escape to the six quoted forms none of which can fail to decode"
 )]
 fn decode_char(raw: &str) -> char {
-    let inner = raw
-        .strip_prefix('\'')
-        .and_then(|s| s.strip_suffix('\''))
-        .unwrap_or(raw);
-    let decoded =
-        crate::escape::decode(inner).expect("a lexer-validated character literal should decode");
-    decoded.chars().next().unwrap_or('\u{fffd}')
+    crate::escape::decode_character_literal(raw)
+        .expect("a lexer-validated character literal should decode")
+        .chars()
+        .next()
+        .unwrap_or('\u{fffd}')
 }

--- a/crates/openehr-lang/src/position.rs
+++ b/crates/openehr-lang/src/position.rs
@@ -1,0 +1,56 @@
+//! Source-text position arithmetic — one home for every LANG-family parser.
+//!
+//! ODIN, BEL and the ADL/cADL front end all report defects at a byte offset in
+//! the source they were handed and all need to present that offset to a human
+//! as a line and column. The mapping is a property of the text, not of any one
+//! grammar, so it lives here once rather than being re-derived per parser.
+
+/// The 1-based line and column of a byte `offset` in `src`, counting COLUMNS
+/// IN CHARACTERS.
+///
+/// Columns count characters rather than bytes so a line of clinical text with
+/// non-ASCII content reports the column an author sees in an editor. An offset
+/// past the end of `src` clamps to the end, so a defect reported at
+/// end-of-input still names a real position.
+#[must_use]
+pub fn line_col(src: &str, offset: usize) -> (usize, usize) {
+    let clamped = offset.min(src.len());
+    let mut line = 1usize;
+    let mut col = 1usize;
+    for (idx, ch) in src.char_indices() {
+        if idx >= clamped {
+            break;
+        }
+        if ch == '\n' {
+            line += 1;
+            col = 1;
+        } else {
+            col += 1;
+        }
+    }
+    (line, col)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::line_col;
+
+    /// Both axes are 1-based, and a multi-byte character advances the column
+    /// by one, not by its byte length.
+    #[test]
+    fn line_and_column_are_one_based_and_count_characters() {
+        let src = "ab\ncdé/f";
+        assert_eq!(line_col(src, 0), (1, 1));
+        assert_eq!(line_col(src, 3), (2, 1));
+        let slash = src.find('/').expect("the fixture contains a slash");
+        assert_eq!(line_col(src, slash), (2, 4));
+    }
+
+    /// An offset past the end clamps rather than running off the text.
+    #[test]
+    fn an_offset_past_the_end_clamps() {
+        let src = "ab\ncd";
+        assert_eq!(line_col(src, src.len()), (2, 3));
+        assert_eq!(line_col(src, src.len() + 100), (2, 3));
+    }
+}


### PR DESCRIPTION
Closes #1344
Closes #1350

Four commits:

- **#1344** (`86e0b608a`): the shared escape decoder now rejects every backslash sequence outside the master03 set (`\r \n \t \\ \" \'` + both `\u` forms) with typed errors (`IllegalEscape`/`DanglingBackslash`/`MalformedUnicodeEscape`). Corpus sweep first: no vendored file trips the rule (all other backslashes live inside never-decoded regex literals). Invalid twin `SUNK_illegal_string_escape.v1.adl` added beside the existing valid 8-digit twin.
- **#1350** (`b32c2ad2e`): ODIN type casts accept the dot-separated namespaced form the docs text allows (`LANG/docs/odin/master05-content` §Adding Type Information, verbatim twin in `AM/docs/ADL1.4/master04-dadl`): `org.openehr.rm.ehr.content.ENTRY`, `Core.Abstractions.Relationships.Relationship`. The vendored `odin.g4` grammar gap is NOTE'd — docs text wins. `_type` derivation takes the terminal class name; dADL corpus case added.
- Dedup (`fe904a51e`): the three hand-rolled master03 byte scans and six strip-then-decode sites now read through `openehr_lang::escape`; the duplicated `line_col` pair moved to `openehr_lang::position` (−213/+81).
- TODO links (`a3c699895`): the four open TODOs now cite their tracker issues (#1346, #1347, #1348, #1349).

Gates: `cargo nextest run --workspace` 3,155 passed; workspace clippy `-D warnings`, rustdoc `-D warnings`, fmt all clean. CHANGELOG carries the two user-visible fixes.