### PR TITLE
chore(openehr-adl): drop the orphaned logos dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5194,7 +5194,6 @@ name = "openehr-adl"
 version = "2.4.0"
 dependencies = [
  "indexmap 2.14.0",
- "logos",
  "openehr-am",
  "openehr-base",
  "openehr-lang",

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -14,7 +14,6 @@ categories.workspace = true
 publish = false
 
 [dependencies]
-logos.workspace = true       # DFA lexer (base_lexer.g4 + adl_keywords.g4)
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)


### PR DESCRIPTION
The one-lexer unification (#1352, PR #1355) deleted `openehr-adl`'s `lexer.rs` — the crate's only `logos` consumer (the token stream now comes from `openehr_lang::lexer`). Caught by the `cargo-machete` CI backstop; `cargo machete` + `cargo check -p openehr-adl` clean locally. Invisible change (`no-changelog`).