### PR TITLE
release: v3.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+## [3.15.1] - 2026-07-31
+
 ### Added
 
 - **An archetype or template may now give an interval as a node's default
@@ -3844,7 +3846,8 @@ but has not yet run in production.
   seccomp, default-deny NetworkPolicy) and golden-render validation.
 
 
-[unreleased]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.15.0...HEAD
+[unreleased]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.15.1...HEAD
+[3.15.1]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.15.0...v3.15.1
 [3.15.0]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.14.0...v3.15.0
 [3.14.0]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.13.0...v3.14.0
 [3.13.0]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.12.0...v3.13.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,5 +33,5 @@ keywords:
   - ITS-REST
   - Rust
   - PostgreSQL
-version: 3.15.0
-date-released: "2026-07-30"
+version: 3.15.1
+date-released: "2026-07-31"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "cnf-runner"
-version = "3.15.0"
+version = "3.15.1"
 dependencies = [
  "assert_fs",
  "base64 0.22.1",
@@ -2305,7 +2305,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase"
-version = "3.15.0"
+version = "3.15.1"
 dependencies = [
  "assert_fs",
  "async-trait",
@@ -2372,7 +2372,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase-admin-ui"
-version = "3.15.0"
+version = "3.15.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -2412,7 +2412,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase-rest"
-version = "3.15.0"
+version = "3.15.1"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "ehrbase-server"
-version = "3.15.0"
+version = "3.15.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -5223,7 +5223,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-codegen"
-version = "3.15.0"
+version = "3.15.1"
 dependencies = [
  "roxmltree",
  "serde_json",
@@ -8276,7 +8276,7 @@ dependencies = [
 
 [[package]]
 name = "testkit"
-version = "3.15.0"
+version = "3.15.1"
 dependencies = [
  "ehrbase",
  "jiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "3"
 members = ["crates/*", "app/*", "tools/*"]
 
 [workspace.package]
-version = "3.15.0"
+version = "3.15.1"
 edition = "2024"
 rust-version = "1.96"
 license = "Apache-2.0"

--- a/deploy/helm/ehrbase-rs/Chart.yaml
+++ b/deploy/helm/ehrbase-rs/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 # Chart versioning is independent of the application version.
 version: 3.2.0
 # The default container image tag (informational; overridable via image.tag).
-appVersion: "3.15.0"
+appVersion: "3.15.1"
 
 # PDB (policy/v1, GA 1.21), HPA (autoscaling/v2, GA 1.23), and the
 # seccompProfile pod field (GA 1.27) all resolve cleanly at 1.25+.

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.15.0"
+    app.kubernetes.io/version: "3.15.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -58,7 +58,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.15.0"
+    app.kubernetes.io/version: "3.15.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -77,7 +77,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.15.0"
+    app.kubernetes.io/version: "3.15.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
   annotations:
@@ -96,7 +96,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.15.0"
+    app.kubernetes.io/version: "3.15.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 type: Opaque
@@ -120,7 +120,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.15.0"
+    app.kubernetes.io/version: "3.15.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 type: Opaque
@@ -139,7 +139,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.15.0"
+    app.kubernetes.io/version: "3.15.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 data:
@@ -294,7 +294,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.15.0"
+    app.kubernetes.io/version: "3.15.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -321,7 +321,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.15.0"
+    app.kubernetes.io/version: "3.15.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -333,7 +333,7 @@ spec:
     metadata:
       annotations:
         # Roll pods when the rendered ehrbase.toml changes.
-        checksum/config: 9cb27ef19e68d3cf4965761f84be0a9f3018852204a0bc2952a2b5ba1250bae8
+        checksum/config: a9c14bcd041d89e178cde53dc30009ef7e33b646c6a5e13ab08b88cfcdfbcd21
         prometheus.io/scrape: "true"
         prometheus.io/port: "9100"
         prometheus.io/path: "/management/prometheus"
@@ -354,7 +354,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ehrbase
-          image: "ghcr.io/rubentalstra/ehrbase-rs:3.15.0"
+          image: "ghcr.io/rubentalstra/ehrbase-rs:3.15.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -476,7 +476,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.15.0"
+    app.kubernetes.io/version: "3.15.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -509,7 +509,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.15.0"
+    app.kubernetes.io/version: "3.15.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.15.0"
+    app.kubernetes.io/version: "3.15.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -36,7 +36,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.15.0"
+    app.kubernetes.io/version: "3.15.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -55,7 +55,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.15.0"
+    app.kubernetes.io/version: "3.15.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 automountServiceAccountToken: false
@@ -69,7 +69,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.15.0"
+    app.kubernetes.io/version: "3.15.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 data:
@@ -166,7 +166,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.15.0"
+    app.kubernetes.io/version: "3.15.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -189,7 +189,7 @@ metadata:
     helm.sh/chart: ehrbase-rs-3.2.0
     app.kubernetes.io/name: ehrbase-rs
     app.kubernetes.io/instance: ehrbase-rs
-    app.kubernetes.io/version: "3.15.0"
+    app.kubernetes.io/version: "3.15.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ehrbase-rs
 spec:
@@ -202,7 +202,7 @@ spec:
     metadata:
       annotations:
         # Roll pods when the rendered ehrbase.toml changes.
-        checksum/config: 4a0445dad787e6627924093535a274ad3aef28f52ae8dce0d8243136da9341ef
+        checksum/config: bbc64f1544396ab71591c1c5ee58cf1a45015c85da11a28e5c158714626cf8e2
       labels:
         app.kubernetes.io/name: ehrbase-rs
         app.kubernetes.io/instance: ehrbase-rs
@@ -220,7 +220,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ehrbase
-          image: "ghcr.io/rubentalstra/ehrbase-rs:3.15.0"
+          image: "ghcr.io/rubentalstra/ehrbase-rs:3.15.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/docs/conformance/ehrbase-rs/CONFORMANCE_CERTIFICATE.md
+++ b/docs/conformance/ehrbase-rs/CONFORMANCE_CERTIFICATE.md
@@ -4,9 +4,9 @@
 
 | Field | Value |
 | --- | --- |
-| Solution | ehrbase-rs 3.14.0 |
+| Solution | ehrbase-rs 3.15.0 |
 | Vendor | Ruben Talstra |
-| Runner | cnf-runner 3.14.0 |
+| Runner | cnf-runner 3.15.0 |
 | Infrastructure | ixit.json#/environment |
 
 ## Scope of Test

--- a/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ehrbase-rs/CONFORMANCE_REPORT.md
@@ -1,18 +1,18 @@
 # Conformance Report
 
-SUT: ehrbase-rs 3.14.0 · schedule cnf-2.0-w2 · ITS its-rest
-Runner: cnf-runner 3.14.0 · verification pack: passed
+SUT: ehrbase-rs 3.15.0 · schedule cnf-2.0-w2 · ITS its-rest
+Runner: cnf-runner 3.15.0 · verification pack: passed
 
 ## Summary
 
 | Status | Count |
 | --- | --- |
-| passed | 824 |
+| passed | 826 |
 | failed | 0 |
 | errored | 0 |
 | skipped | 0 |
 | not_applicable | 37 |
-| total | 861 |
+| total | 863 |
 
 ## By chapter
 
@@ -20,12 +20,12 @@ Grouping is the published per-chapter chart's taxonomy: chapters with their band
 
 | Chapter / band | passed | failed | errored | cited n/a |
 | --- | --- | --- | --- | --- |
-| **EHR** | 313 | 0 | 0 | 18 |
+| **EHR** | 315 | 0 | 0 | 18 |
 | — EHR resource | 24 | 0 | 0 | 2 |
 | — EHR_STATUS | 42 | 0 | 0 | 5 |
 | — COMPOSITION | 95 | 0 | 0 | 0 |
 | — DIRECTORY | 61 | 0 | 0 | 6 |
-| — CONTRIBUTION | 55 | 0 | 0 | 5 |
+| — CONTRIBUTION | 57 | 0 | 0 | 5 |
 | — Item tags | 30 | 0 | 0 | 0 |
 | — Revision history | 6 | 0 | 0 | 0 |
 | **Definitions** | 91 | 0 | 0 | 10 |
@@ -86,7 +86,7 @@ Selected gating cases per claimed capability. `inconclusive` counts cases whose 
 | EhrStatus | pass | 41 | 0 | 0 | 5 |
 | CompositionOps | pass | 29 | 0 | 0 | 0 |
 | DirectoryOps | pass | 61 | 0 | 0 | 8 |
-| ChangeSets | pass | 48 | 0 | 0 | 5 |
+| ChangeSets | pass | 50 | 0 | 0 | 5 |
 | Versioning | pass | 59 | 0 | 0 | 0 |
 | ArchetypeValidation | pass | 125 | 0 | 0 | 0 |
 | PartyOperations | pass | 48 | 0 | 0 | 4 |
@@ -175,7 +175,7 @@ Percentiles re-derive from the embedded HDR V2 histograms; the class verdict is 
 
 ## Honesty
 
-Coverage: 824 of 861 selected cases driven.
+Coverage: 826 of 863 selected cases driven.
 
 Not-executed verdicts (each cited):
 

--- a/docs/conformance/ehrbase-rs/badge.json
+++ b/docs/conformance/ehrbase-rs/badge.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "openEHR conformance",
-  "message": "CORE+STANDARD PASS \u00b7 824/824 cases",
+  "message": "CORE+STANDARD PASS \u00b7 826/826 cases",
   "color": "brightgreen"
 }

--- a/docs/conformance/ehrbase-rs/results.json
+++ b/docs/conformance/ehrbase-rs/results.json
@@ -1,11 +1,11 @@
 {
   "sut": {
     "name": "ehrbase-rs",
-    "version": "3.14.0"
+    "version": "3.15.0"
   },
   "runner": {
     "name": "cnf-runner",
-    "version": "3.14.0",
+    "version": "3.15.0",
     "verification_pack_status": "passed"
   },
   "schedule_release": "cnf-2.0-w2",
@@ -1811,6 +1811,20 @@
     },
     {
       "case": "I_EHR_CONTRIBUTION.commit_contribution-invalid_ehr_status",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_CONTRIBUTION.commit_contribution-last_modified",
+      "format": "canonical-json",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_CONTRIBUTION.commit_contribution-last_modified_minimal",
+      "format": "canonical-json",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1

--- a/docs/conformance/ehrbase-rs/verdicts.json
+++ b/docs/conformance/ehrbase-rs/verdicts.json
@@ -268,7 +268,7 @@
     [
       "ChangeSets",
       {
-        "passed": 48,
+        "passed": 50,
         "failed": 0,
         "inconclusive": 0,
         "unevidenced": 5
@@ -588,9 +588,9 @@
     }
   ],
   "coverage": {
-    "selected": 861,
-    "driven": 824,
-    "passed": 824,
+    "selected": 863,
+    "driven": 826,
+    "passed": 826,
     "failed": 0,
     "inconclusive": 0
   }


### PR DESCRIPTION
Cuts **v3.15.1** — the AM/LANG/QUERY/ITS patch and the FIRST OFFICIAL (non-prerelease) release under the 2026-07-31 policy.

Contents (milestone v3.15.1, 8 issues, zero open): the openehr-adl full crate rewrite (#1309) + its audited spec fixes (#1339, #1340, #1341), master03 escape hardening (#1344), namespaced ODIN type ids (#1350), ODIN interval default_values (#1346), CONTRIBUTION Last-Modified (#1349), AQL template-derived lineage matching (#1347), and the one-lexer unification (#1352).

This PR: the refreshed conformance baseline from the convergence run (826/863 passed, +2 coverage, zero drift, 0 findings) + the changelog section rename, workspace version bump (Cargo.lock via cargo check), Helm chart/appVersion + regenerated goldens (validate.sh ALL CHECKS PASSED), CITATION.cff version/date.

After merge: tag `v3.15.1` on the merge commit → the release workflow publishes the GitHub Release from the changelog section as an official release; then the milestone closes (v3.16.0 already exists as the next target).