### PR TITLE
chore(brand): FerroEHR identity — Fe element-tile logo set + Oxide & Iron palette

### DIFF
--- a/assets/brand/README.md
+++ b/assets/brand/README.md
@@ -1,0 +1,49 @@
+# FerroEHR brand assets
+
+The visual identity approved on issue #1353 (owner decision 2026-07-31):
+logo **"Fe element tile"** — iron's periodic-table tile with a heartbeat
+tick in the atomic-number corner — with the **"Oxide & Iron"** palette.
+
+## Files
+
+| File | Use |
+|---|---|
+| `ferroehr-icon.svg` | Primary icon (rust tile). Carries its own background — works on light and dark. App icon, avatars, social. |
+| `ferroehr-icon-iron.svg` | Iron-tile variant for surfaces where the rust tile is too loud. |
+| `ferroehr-icon-mono.svg` | Single-colour variant (`currentColor`) for stamps/badges/no-colour contexts. |
+| `favicon.svg` | Favicon master: tile + Fe only, no heartbeat tick (illegible below 32 px). |
+| `ferroehr-lockup-light.svg` | Icon + wordmark for light backgrounds. |
+| `ferroehr-lockup-dark.svg` | Icon + wordmark for dark backgrounds. |
+| `tokens.css` | The palette as CSS custom properties — the single source for brand colours. |
+
+## Palette — "Oxide & Iron"
+
+| Token | Hex | Role |
+|---|---|---|
+| Ferro | `#B7431B` | signature / accent — the one loud voice |
+| Ember | `#D97742` | hover, gradients, accent on dark |
+| Iron | `#21262B` | ink, dark ground |
+| Steel | `#4E7382` | links, secondary UI |
+| Porcelain | `#F2F1EF` | light ground |
+| Graphite | `#6B7178` | muted text |
+
+## Usage rules
+
+- The tile always keeps its rounded corners and its own background — never
+  place the bare "Fe" letters on an arbitrary ground.
+- The heartbeat tick drops out below 32 px (use `favicon.svg`).
+- Never recolour outside the palette; the monochrome variant exists for
+  single-colour contexts.
+- Wordmark: "Ferro" in Iron (Porcelain on dark), "EHR" in Ferro (Ember on
+  dark), always set together, never stacked.
+- Clear space around the icon: one tile-corner radius on all sides.
+- The brand never contains "openEHR" (openEHR Foundation trademark); prose
+  describes the product as "an openEHR® CDR" with the Foundation's required
+  attribution line.
+
+<!-- TODO: convert the SVG <text> elements (Fe + wordmark) to outlined paths so
+     rendering stops depending on viewer-installed fonts (Avenir/Futura stack
+     falls back to a generic sans elsewhere), and settle the final wordmark
+     typeface at that point. -->
+<!-- TODO: emit the raster favicon set (32/16 px PNG + .ico) and the README
+     banner from these masters once outline conversion is done. -->

--- a/assets/brand/favicon.svg
+++ b/assets/brand/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-label="FerroEHR">
+  <!-- FerroEHR favicon: tile + Fe only. The heartbeat tick is deliberately dropped —
+       it turns to noise below 32 px. -->
+  <rect x="2" y="2" width="60" height="60" rx="14" fill="#B7431B"/>
+  <text x="30" y="45" font-family="'Avenir Next',Avenir,Futura,'Helvetica Neue',Arial,sans-serif" font-size="32" font-weight="600" fill="#FFF6F0" text-anchor="middle">Fe</text>
+</svg>

--- a/assets/brand/ferroehr-icon-iron.svg
+++ b/assets/brand/ferroehr-icon-iron.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-label="FerroEHR icon, iron variant">
+  <!-- FerroEHR icon, iron-tile variant: for contexts where the rust tile is too loud
+       (dense UI chrome, monochrome-adjacent surfaces). Carries its own background. -->
+  <rect x="2" y="2" width="60" height="60" rx="12" fill="#21262B"/>
+  <text x="30" y="44" font-family="'Avenir Next',Avenir,Futura,'Helvetica Neue',Arial,sans-serif" font-size="30" font-weight="600" fill="#F2F1EF" text-anchor="middle">Fe</text>
+  <polyline points="12,15 17,15 20,9 23,19 26,13 29,15 36,15" fill="none" stroke="#D97742" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/assets/brand/ferroehr-icon-mono.svg
+++ b/assets/brand/ferroehr-icon-mono.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-label="FerroEHR icon, monochrome">
+  <!-- FerroEHR monochrome icon: single-colour via currentColor for stamps,
+       terminal badges, embossing, and anywhere colour is unavailable. -->
+  <rect x="3.5" y="3.5" width="57" height="57" rx="11" fill="none" stroke="currentColor" stroke-width="3"/>
+  <text x="30" y="44" font-family="'Avenir Next',Avenir,Futura,'Helvetica Neue',Arial,sans-serif" font-size="30" font-weight="600" fill="currentColor" text-anchor="middle">Fe</text>
+  <polyline points="12,15 17,15 20,9 23,19 26,13 29,15 36,15" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/assets/brand/ferroehr-icon.svg
+++ b/assets/brand/ferroehr-icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-label="FerroEHR icon">
+  <!-- FerroEHR primary icon: iron element tile (Fe) with heartbeat tick.
+       Rust tile carries its own background, so it works on light and dark grounds. -->
+  <rect x="2" y="2" width="60" height="60" rx="12" fill="#B7431B"/>
+  <text x="30" y="44" font-family="'Avenir Next',Avenir,Futura,'Helvetica Neue',Arial,sans-serif" font-size="30" font-weight="600" fill="#FFF6F0" text-anchor="middle">Fe</text>
+  <polyline points="12,15 17,15 20,9 23,19 26,13 29,15 36,15" fill="none" stroke="#FFD9C2" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/assets/brand/ferroehr-lockup-dark.svg
+++ b/assets/brand/ferroehr-lockup-dark.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="56" viewBox="0 0 300 56" role="img" aria-label="FerroEHR">
+  <!-- FerroEHR lockup for DARK backgrounds: rust tile + porcelain/ember wordmark. -->
+  <rect x="2" y="4" width="48" height="48" rx="10" fill="#B7431B"/>
+  <text x="24.5" y="37.5" font-family="'Avenir Next',Avenir,Futura,'Helvetica Neue',Arial,sans-serif" font-size="24" font-weight="600" fill="#FFF6F0" text-anchor="middle">Fe</text>
+  <polyline points="10,14 14,14 16.4,9.4 18.8,17.4 21.2,12.6 23,14 28,14" fill="none" stroke="#FFD9C2" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="62" y="39" font-family="'Avenir Next',Avenir,Futura,'Helvetica Neue',Arial,sans-serif" font-size="28" font-weight="600" fill="#F2F1EF">Ferro<tspan fill="#D97742" font-weight="700">EHR</tspan></text>
+</svg>

--- a/assets/brand/ferroehr-lockup-light.svg
+++ b/assets/brand/ferroehr-lockup-light.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="56" viewBox="0 0 300 56" role="img" aria-label="FerroEHR">
+  <!-- FerroEHR lockup for LIGHT backgrounds: iron tile + iron/rust wordmark. -->
+  <rect x="2" y="4" width="48" height="48" rx="10" fill="#21262B"/>
+  <text x="24.5" y="37.5" font-family="'Avenir Next',Avenir,Futura,'Helvetica Neue',Arial,sans-serif" font-size="24" font-weight="600" fill="#F2F1EF" text-anchor="middle">Fe</text>
+  <polyline points="10,14 14,14 16.4,9.4 18.8,17.4 21.2,12.6 23,14 28,14" fill="none" stroke="#D97742" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="62" y="39" font-family="'Avenir Next',Avenir,Futura,'Helvetica Neue',Arial,sans-serif" font-size="28" font-weight="600" fill="#21262B">Ferro<tspan fill="#B7431B" font-weight="700">EHR</tspan></text>
+</svg>

--- a/assets/brand/tokens.css
+++ b/assets/brand/tokens.css
@@ -1,0 +1,13 @@
+/* FerroEHR brand palette — "Oxide & Iron" (owner-approved 2026-07-31, issue #1353).
+ * The single source for brand colours; the admin console and website book
+ * consume these custom properties during the rename programme.
+ * Semantic colours (success / warning / error) are deliberately NOT brand
+ * colours — define them per surface, never from this file. */
+:root {
+  --ferroehr-ferro: #b7431b;     /* signature / accent — the one loud voice */
+  --ferroehr-ember: #d97742;     /* hover states, gradients, accents on dark */
+  --ferroehr-iron: #21262b;      /* ink, dark ground */
+  --ferroehr-steel: #4e7382;     /* links, secondary UI */
+  --ferroehr-porcelain: #f2f1ef; /* light ground */
+  --ferroehr-graphite: #6b7178;  /* muted text */
+}

--- a/docs/plans/ferroehr-rename.md
+++ b/docs/plans/ferroehr-rename.md
@@ -21,10 +21,14 @@ Standing constraints (from the decision comments on #1353):
 
 ## Phase 0 — brand assets (blocks everything visual)
 
-- [ ] Owner picks the logo option + palette (proposals reviewed on #1353)
-- [ ] Production SVG set under `assets/brand/`: icon, icon+wordmark lockup,
+- [x] Owner picks the logo option + palette (2026-07-31: the "Fe element
+      tile" logo with the "Oxide & Iron" palette)
+- [x] Production SVG set under `assets/brand/`: icon, icon+wordmark lockup,
       light + dark variants, monochrome variant
-- [ ] Favicon set (SVG + 32/16 px PNG + .ico) and README banner
+- [ ] Convert the SVG `<text>` elements to outlined paths (rendering must not
+      depend on viewer-installed fonts) and settle the final wordmark typeface
+- [ ] Favicon set (32/16 px PNG + .ico from the committed `favicon.svg`) and
+      README banner
 - [ ] Palette committed as design tokens (admin-ui CSS custom properties +
       website book theme)
 - [ ] Admin console logo/title swap (`app/ehrbase-admin-ui`; screenshot-guard


### PR DESCRIPTION
Lands the owner-approved FerroEHR visual identity (decision on #1353, 2026-07-31) under `assets/brand/`:

- `ferroehr-icon.svg` (rust tile, primary) / `ferroehr-icon-iron.svg` / `ferroehr-icon-mono.svg` (currentColor)
- `ferroehr-lockup-light.svg` / `ferroehr-lockup-dark.svg` (icon + wordmark)
- `favicon.svg` (tile + Fe only — the heartbeat tick drops below 32 px)
- `tokens.css` (the Oxide & Iron palette as custom properties) + usage README

Ticks the matching Phase-0 boxes in `docs/plans/ferroehr-rename.md` and adds two follow-up boxes (text→outline conversion, raster favicon set + banner).

Assets only — nothing consumes them yet (integration comes with the rename programme), hence `no-changelog`.

Part of #1353.