### PR TITLE
fix(website): purge split-span old wordmark, align footer with rebrand + relicense

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -153,7 +153,7 @@ services:
       FERROEHR__LOG__FILTER: ${FERROEHR__LOG__FILTER:-info}
     volumes:
       # Auto-discovered at config search-order position 4 (no pointer needed).
-      # Enables Basic auth with the ehrbase/ehrbase user.
+      # Enables Basic auth with the ferroehr/ferroehr user.
       - ./docker/ferroehr.dev.toml:/etc/ferroehr/ferroehr.toml:ro
     ports:
       - "${FERROEHR_PORT:-8080}:8080"
@@ -176,7 +176,7 @@ services:
 
   # The admin console (ferroehr-admin-ui): a standalone Leptos SSR web app +
   # BFF that consumes the CDR strictly over ITS-REST — never the database.
-  # Basic login proxies the CDR's dev users (ehrbase/ehrbase); for OIDC set
+  # Basic login proxies the CDR's dev users (ferroehr/ferroehr); for OIDC set
   # the FERROEHR_ADMIN__AUTH__OIDC__* variables at the Keycloak realm below.
   ferroehr-admin-ui:
     image: ${FERROEHR_ADMIN_UI_IMAGE:-ghcr.io/rubentalstra/ferroehr-admin-ui:local}

--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -5,7 +5,7 @@
 # for the Basic-auth path), then:
 #   1. waits for the app healthcheck to report healthy;
 #   2. asserts GET /rest/status returns 200;
-#   3. creates an EHR with the dev Basic credentials (ehrbase/ehrbase);
+#   3. creates an EHR with the dev Basic credentials (ferroehr/ferroehr);
 #   4. restarts the app and proves the second-boot migration run is a no-op
 #      (the sqlx ledger is unchanged — the library migrator is silent on no-op,
 #      so the row count is the reliable idempotency signal; app logs are dumped

--- a/docker/sut-ehrbase-java.yml
+++ b/docker/sut-ehrbase-java.yml
@@ -6,7 +6,7 @@
 #
 # Image + configuration mirror the benchmark harness's upstream side
 # (docker/benchmark/docker-compose.yml — the fairness-governed definition):
-# the official ehrbase/ehrbase image with its companion ferroehr-v2-postgres,
+# the official ehrbase/ehrbase image with its companion ehrbase-v2-postgres,
 # Basic auth with a clinical user and a distinct admin user, template
 # overwrite allowed for idempotent re-provisioning, and the Admin API active
 # (the catalogue's ADMIN chapter drives it).

--- a/tools/cnf-runner/party/ehrbase-java/ixit.json
+++ b/tools/cnf-runner/party/ehrbase-java/ixit.json
@@ -33,6 +33,6 @@
     "cores": 4,
     "memory_gb": 16,
     "storage_class": "ssd",
-    "topology": "single-node docker compose (docker/sut-ehrbase-java.yml, ehrbase/ehrbase:2.34.0 + ferroehr-v2-postgres:16.2; no readonly principal — EHRbase Basic auth carries one clinical user and one admin user)"
+    "topology": "single-node docker compose (docker/sut-ehrbase-java.yml, ehrbase/ehrbase:2.34.0 + ehrbase-v2-postgres:16.2; no readonly principal — EHRbase Basic auth carries one clinical user and one admin user)"
   }
 }

--- a/website/api/index.html
+++ b/website/api/index.html
@@ -49,7 +49,7 @@
   <header class="rs-header">
     <a class="brand" href="../">
       <img src="../assets/logo-mark.svg" alt="" aria-hidden="true">
-      <span>EHRbase<span class="tld">-rs</span></span>
+      <span>Ferro<span class="tld">EHR</span></span>
     </a>
     <nav aria-label="Primary">
       <a href="../docs/latest/">Docs</a>

--- a/website/book/src/admin-ui/index.md
+++ b/website/book/src/admin-ui/index.md
@@ -14,7 +14,7 @@ on port 3000:
 
 ```bash
 docker compose up ferroehr-postgres ferroehr ferroehr-admin-ui
-# → http://localhost:3000  (log in with the dev users, e.g. ehrbase/ehrbase)
+# → http://localhost:3000  (log in with the dev users, e.g. ferroehr/ferroehr)
 ```
 
 Standalone, point it at any CDR:

--- a/website/landing/index.html
+++ b/website/landing/index.html
@@ -20,7 +20,7 @@
     <div class="wrap">
       <a class="brand" href="./">
         <img src="./assets/logo-mark.svg" alt="" aria-hidden="true">
-        <span>EHRbase<span class="tld">-rs</span></span>
+        <span>Ferro<span class="tld">EHR</span></span>
       </a>
       <nav class="nav-links" aria-label="Primary">
         <a href="./docs/latest/">Docs</a>
@@ -204,12 +204,15 @@
         <div class="footer-brand">
           <a class="brand" href="./">
             <img src="./assets/logo-mark.svg" alt="" aria-hidden="true">
-            <span>EHRbase<span class="tld">-rs</span></span>
+            <span>Ferro<span class="tld">EHR</span></span>
           </a>
-          <p>A pure-Rust openEHR Clinical Data Repository. Licensed under
-            <a href="https://github.com/rubentalstra/FerroEHR/blob/develop/LICENSE" rel="noopener">Apache-2.0</a>.</p>
-          <p>A fork of EHRbase, originally by vitasystems and the Peter L. Reichertz
-            Institute (PLRI). openEHR specifications © the openEHR Foundation.</p>
+          <p>A pure-Rust openEHR® Clinical Data Repository. Code licensed under
+            <a href="https://github.com/rubentalstra/FerroEHR/blob/develop/LICENSE" rel="noopener">MIT</a>;
+            vendored openEHR artifacts under
+            <a href="https://github.com/rubentalstra/FerroEHR/blob/develop/LICENSE-APACHE-2.0" rel="noopener">Apache-2.0</a>.</p>
+          <p>Began as a fork of EHRbase by vitasystems and the Peter L. Reichertz
+            Institute (PLRI). openEHR® is the registered trademark of the openEHR
+            Foundation and is used with the permission of openEHR International.</p>
         </div>
         <div class="footer-links">
           <div>
@@ -234,7 +237,6 @@
       </div>
       <div class="footer-note">
         <span>© FerroEHR contributors.</span>
-        <span>Not affiliated with or endorsed by upstream EHRbase.</span>
       </div>
     </div>
   </footer>


### PR DESCRIPTION
Fixes the last stale brand text the rename sweep could not see:

- `EHRbase<span class=\"tld\">-rs</span>` in the landing header, landing footer, and API-reference header → `Ferro<span class=\"tld\">EHR</span>` (the accent class now colours "EHR", matching the lockup).
- Footer: license line now states the MIT / Apache-2.0 split with both license links, adds the required openEHR® trademark attribution, keeps the factual fork-provenance line, and drops the "not affiliated with upstream EHRbase" disclaimer — the product no longer carries the upstream name (owner call).
- Restores `ehrbase-v2-postgres` (the Java SUT's companion image) in two comments the sweep over-renamed; dev-credential comments `ehrbase/ehrbase` → `ferroehr/ferroehr` (they were hidden behind the docker-image mask).

Part of the #1353 rebrand follow-through.