### PR TITLE
fix(docker): dev credentials verify the documented password again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The quickstart dev credentials authenticate again.** The v3.15.2 rename
+  updated the dev usernames and documented passwords to `ferroehr` but left
+  the committed Argon2id hashes (and the dev Keycloak realm's stored
+  password hashes) verifying the old secret, so every Basic-auth request
+  against the compose stack returned 401. The dev user store now carries
+  hashes of the documented password, and the Keycloak realm import sets the
+  dev passwords at import time. Development stacks only; no production
+  surface stores these credentials.
+
 ## [3.15.2] - 2026-07-31
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -404,10 +404,9 @@ project. The openEHR specifications and the machine-readable models this
 project generates from are published by the
 [openEHR Foundation](https://www.openehr.org/).
 
-openEHR® is the registered trademark of the openEHR Foundation and is used
-with the permission of openEHR International. FerroEHR is an independent
-implementation of the openEHR® specifications and is not endorsed by the
-openEHR Foundation.
+openEHR® is the registered trademark of the openEHR Foundation. FerroEHR is
+an independent implementation of the openEHR® specifications and is not
+endorsed by the openEHR Foundation.
 
 The admin console's feature set — the Template Manager, the point-and-click
 Query Builder, and saved/grouped/cohort queries — is inspired by

--- a/docker/ferroehr.dev.toml
+++ b/docker/ferroehr.dev.toml
@@ -121,7 +121,7 @@ cache_ttl_secs = 0
 [[auth.basic.users]]
 username = "ferroehr"
 # Argon2id hash of the password "ferroehr".
-password_hash = "$argon2id$v=19$m=4096,t=2,p=1$ZWhyYmFzZURldlNhbHQ$4Cf1W/JiP800r2sbj8/y0HbNAcwMb/YseM1fTINO3Dc"
+password_hash = "$argon2id$v=19$m=4096,t=2,p=1$ZmVycm9laHJEZXZTYWx0$Q0QFn5AN9941PDEcY+c9oKApFK7oGnhig+JpIwZkLWc"
 
 # Dev-only ADMIN account for the admin API (`DELETE /admin/...`) and the
 # conformance suite's AdminApi cases (scripts/conformance.sh CONF_ADMIN_AUTH
@@ -129,7 +129,7 @@ password_hash = "$argon2id$v=19$m=4096,t=2,p=1$ZWhyYmFzZURldlNhbHQ$4Cf1W/JiP800r
 # roles. Do NOT use in production.
 [[auth.basic.users]]
 username = "ferroehr-admin"
-password_hash = "$argon2id$v=19$m=4096,t=2,p=1$ZWhyYmFzZURldlNhbHQ$4Cf1W/JiP800r2sbj8/y0HbNAcwMb/YseM1fTINO3Dc"
+password_hash = "$argon2id$v=19$m=4096,t=2,p=1$ZmVycm9laHJEZXZTYWx0$Q0QFn5AN9941PDEcY+c9oKApFK7oGnhig+JpIwZkLWc"
 roles = ["ADMIN", "USER"]
 
 # Dev-only READ-ONLY account for the conformance suite's authorization-
@@ -137,5 +137,5 @@ roles = ["ADMIN", "USER"]
 # refused by the RBAC read-only gate. Do NOT use in production.
 [[auth.basic.users]]
 username = "ferroehr-readonly"
-password_hash = "$argon2id$v=19$m=4096,t=2,p=1$ZWhyYmFzZURldlNhbHQ$4Cf1W/JiP800r2sbj8/y0HbNAcwMb/YseM1fTINO3Dc"
+password_hash = "$argon2id$v=19$m=4096,t=2,p=1$ZmVycm9laHJEZXZTYWx0$Q0QFn5AN9941PDEcY+c9oKApFK7oGnhig+JpIwZkLWc"
 roles = ["READONLY"]

--- a/docker/keycloak/import/ferroehr-realm-exported.json
+++ b/docker/keycloak/import/ferroehr-realm-exported.json
@@ -1,2030 +1,2425 @@
 {
-  "id" : "ca3e0ff6-5282-4d18-b860-8d28d7ac1b86",
-  "realm" : "ferroehr",
-  "displayName" : "FerroEHR",
-  "displayNameHtml" : "",
-  "notBefore" : 0,
-  "defaultSignatureAlgorithm" : "RS256",
-  "revokeRefreshToken" : false,
-  "refreshTokenMaxReuse" : 0,
-  "accessTokenLifespan" : 300,
-  "accessTokenLifespanForImplicitFlow" : 900,
-  "ssoSessionIdleTimeout" : 1800,
-  "ssoSessionMaxLifespan" : 36000,
-  "ssoSessionIdleTimeoutRememberMe" : 0,
-  "ssoSessionMaxLifespanRememberMe" : 0,
-  "offlineSessionIdleTimeout" : 2592000,
-  "offlineSessionMaxLifespanEnabled" : false,
-  "offlineSessionMaxLifespan" : 5184000,
-  "clientSessionIdleTimeout" : 0,
-  "clientSessionMaxLifespan" : 0,
-  "clientOfflineSessionIdleTimeout" : 0,
-  "clientOfflineSessionMaxLifespan" : 0,
-  "accessCodeLifespan" : 60,
-  "accessCodeLifespanUserAction" : 300,
-  "accessCodeLifespanLogin" : 1800,
-  "actionTokenGeneratedByAdminLifespan" : 43200,
-  "actionTokenGeneratedByUserLifespan" : 300,
-  "oauth2DeviceCodeLifespan" : 600,
-  "oauth2DevicePollingInterval" : 5,
-  "enabled" : true,
-  "sslRequired" : "none",
-  "registrationAllowed" : false,
-  "registrationEmailAsUsername" : false,
-  "rememberMe" : false,
-  "verifyEmail" : false,
-  "loginWithEmailAllowed" : true,
-  "duplicateEmailsAllowed" : false,
-  "resetPasswordAllowed" : true,
-  "editUsernameAllowed" : false,
-  "bruteForceProtected" : false,
-  "permanentLockout" : false,
-  "maxTemporaryLockouts" : 0,
-  "maxFailureWaitSeconds" : 900,
-  "minimumQuickLoginWaitSeconds" : 60,
-  "waitIncrementSeconds" : 60,
-  "quickLoginCheckMilliSeconds" : 1000,
-  "maxDeltaTimeSeconds" : 43200,
-  "failureFactor" : 30,
-  "roles" : {
-    "realm" : [ {
-      "id" : "de2ada1d-99b3-4de1-8c2d-6da1598ef2dd",
-      "name" : "uma_authorization",
-      "description" : "${role_uma_authorization}",
-      "composite" : false,
-      "clientRole" : false,
-      "containerId" : "ca3e0ff6-5282-4d18-b860-8d28d7ac1b86",
-      "attributes" : { }
-    }, {
-      "id" : "4eab895c-d58d-47cc-b208-89322ae9afed",
-      "name" : "USER",
-      "description" : "",
-      "composite" : false,
-      "clientRole" : false,
-      "containerId" : "ca3e0ff6-5282-4d18-b860-8d28d7ac1b86",
-      "attributes" : { }
-    }, {
-      "id" : "78453e11-8080-4e37-9cda-d92b83f22512",
-      "name" : "default-roles-cdr-core-sanity-check",
-      "description" : "${role_default-roles}",
-      "composite" : true,
-      "composites" : {
-        "realm" : [ "offline_access", "uma_authorization" ],
-        "client" : {
-          "account" : [ "manage-account", "view-profile" ]
+  "id": "ca3e0ff6-5282-4d18-b860-8d28d7ac1b86",
+  "realm": "ferroehr",
+  "displayName": "FerroEHR",
+  "displayNameHtml": "",
+  "notBefore": 0,
+  "defaultSignatureAlgorithm": "RS256",
+  "revokeRefreshToken": false,
+  "refreshTokenMaxReuse": 0,
+  "accessTokenLifespan": 300,
+  "accessTokenLifespanForImplicitFlow": 900,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "ssoSessionIdleTimeoutRememberMe": 0,
+  "ssoSessionMaxLifespanRememberMe": 0,
+  "offlineSessionIdleTimeout": 2592000,
+  "offlineSessionMaxLifespanEnabled": false,
+  "offlineSessionMaxLifespan": 5184000,
+  "clientSessionIdleTimeout": 0,
+  "clientSessionMaxLifespan": 0,
+  "clientOfflineSessionIdleTimeout": 0,
+  "clientOfflineSessionMaxLifespan": 0,
+  "accessCodeLifespan": 60,
+  "accessCodeLifespanUserAction": 300,
+  "accessCodeLifespanLogin": 1800,
+  "actionTokenGeneratedByAdminLifespan": 43200,
+  "actionTokenGeneratedByUserLifespan": 300,
+  "oauth2DeviceCodeLifespan": 600,
+  "oauth2DevicePollingInterval": 5,
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "registrationEmailAsUsername": false,
+  "rememberMe": false,
+  "verifyEmail": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": true,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "permanentLockout": false,
+  "maxTemporaryLockouts": 0,
+  "maxFailureWaitSeconds": 900,
+  "minimumQuickLoginWaitSeconds": 60,
+  "waitIncrementSeconds": 60,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 30,
+  "roles": {
+    "realm": [
+      {
+        "id": "de2ada1d-99b3-4de1-8c2d-6da1598ef2dd",
+        "name": "uma_authorization",
+        "description": "${role_uma_authorization}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "ca3e0ff6-5282-4d18-b860-8d28d7ac1b86",
+        "attributes": {}
+      },
+      {
+        "id": "4eab895c-d58d-47cc-b208-89322ae9afed",
+        "name": "USER",
+        "description": "",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "ca3e0ff6-5282-4d18-b860-8d28d7ac1b86",
+        "attributes": {}
+      },
+      {
+        "id": "78453e11-8080-4e37-9cda-d92b83f22512",
+        "name": "default-roles-cdr-core-sanity-check",
+        "description": "${role_default-roles}",
+        "composite": true,
+        "composites": {
+          "realm": [
+            "offline_access",
+            "uma_authorization"
+          ],
+          "client": {
+            "account": [
+              "manage-account",
+              "view-profile"
+            ]
+          }
+        },
+        "clientRole": false,
+        "containerId": "ca3e0ff6-5282-4d18-b860-8d28d7ac1b86",
+        "attributes": {}
+      },
+      {
+        "id": "3b27defc-2ad4-4db3-9921-17d45d294d61",
+        "name": "offline_access",
+        "description": "${role_offline-access}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "ca3e0ff6-5282-4d18-b860-8d28d7ac1b86",
+        "attributes": {}
+      },
+      {
+        "id": "243cd507-dd35-4cd6-a7d5-b620743189ad",
+        "name": "ADMIN",
+        "description": "",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "ca3e0ff6-5282-4d18-b860-8d28d7ac1b86",
+        "attributes": {}
+      }
+    ],
+    "client": {
+      "ferroehr": [
+        {
+          "id": "8cc84b69-f611-4a3d-bfc9-4f5aaccc06f5",
+          "name": "uma_protection",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "6bf4fbb5-e031-49e1-b2b3-de38dd7938b7",
+          "attributes": {}
+        }
+      ],
+      "realm-management": [
+        {
+          "id": "32bfca88-d2de-45e9-b6fa-f186dddae22e",
+          "name": "view-authorization",
+          "description": "${role_view-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "42198dc6-1c53-4135-bf8e-958f4aee8858",
+          "attributes": {}
+        },
+        {
+          "id": "d782c61b-b284-4303-8d38-d867159acafa",
+          "name": "impersonation",
+          "description": "${role_impersonation}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "42198dc6-1c53-4135-bf8e-958f4aee8858",
+          "attributes": {}
+        },
+        {
+          "id": "c6a68a59-1733-4517-8cec-daa990b9b39e",
+          "name": "query-groups",
+          "description": "${role_query-groups}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "42198dc6-1c53-4135-bf8e-958f4aee8858",
+          "attributes": {}
+        },
+        {
+          "id": "2e005b5e-4f8a-4227-9f56-ae9bc5f5d0dc",
+          "name": "manage-users",
+          "description": "${role_manage-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "42198dc6-1c53-4135-bf8e-958f4aee8858",
+          "attributes": {}
+        },
+        {
+          "id": "3981f9fd-83db-4e95-afb1-9f2f9db1ca30",
+          "name": "manage-authorization",
+          "description": "${role_manage-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "42198dc6-1c53-4135-bf8e-958f4aee8858",
+          "attributes": {}
+        },
+        {
+          "id": "6cfff4e3-3dc2-4b53-aa61-77035f3fe2ba",
+          "name": "view-realm",
+          "description": "${role_view-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "42198dc6-1c53-4135-bf8e-958f4aee8858",
+          "attributes": {}
+        },
+        {
+          "id": "aacbe325-1e21-40b5-a156-d70a0d571c34",
+          "name": "manage-clients",
+          "description": "${role_manage-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "42198dc6-1c53-4135-bf8e-958f4aee8858",
+          "attributes": {}
+        },
+        {
+          "id": "d959763c-c498-4803-9b82-5e2d98f85488",
+          "name": "view-events",
+          "description": "${role_view-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "42198dc6-1c53-4135-bf8e-958f4aee8858",
+          "attributes": {}
+        },
+        {
+          "id": "15ad936e-fafd-4e7a-928a-31f127f4efff",
+          "name": "manage-events",
+          "description": "${role_manage-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "42198dc6-1c53-4135-bf8e-958f4aee8858",
+          "attributes": {}
+        },
+        {
+          "id": "8f3e1718-b42f-4a47-aff6-e609b39742ce",
+          "name": "query-clients",
+          "description": "${role_query-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "42198dc6-1c53-4135-bf8e-958f4aee8858",
+          "attributes": {}
+        },
+        {
+          "id": "0bd014fa-baaf-4df6-8e7c-1ab57ac8aee9",
+          "name": "query-realms",
+          "description": "${role_query-realms}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "42198dc6-1c53-4135-bf8e-958f4aee8858",
+          "attributes": {}
+        },
+        {
+          "id": "0153b7a0-a638-41de-9b60-e0ff2bd2060c",
+          "name": "create-client",
+          "description": "${role_create-client}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "42198dc6-1c53-4135-bf8e-958f4aee8858",
+          "attributes": {}
+        },
+        {
+          "id": "371c859f-716f-46d1-86d1-a2a113b967e0",
+          "name": "view-identity-providers",
+          "description": "${role_view-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "42198dc6-1c53-4135-bf8e-958f4aee8858",
+          "attributes": {}
+        },
+        {
+          "id": "1eb4e962-769f-4911-aa8e-fcebd5a37d38",
+          "name": "manage-realm",
+          "description": "${role_manage-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "42198dc6-1c53-4135-bf8e-958f4aee8858",
+          "attributes": {}
+        },
+        {
+          "id": "52daa4a4-b187-405b-837f-59548fa1ff70",
+          "name": "manage-identity-providers",
+          "description": "${role_manage-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "42198dc6-1c53-4135-bf8e-958f4aee8858",
+          "attributes": {}
+        },
+        {
+          "id": "c03a2be5-ffe5-4e5d-8af6-e9cb37aae85e",
+          "name": "view-clients",
+          "description": "${role_view-clients}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-clients"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "42198dc6-1c53-4135-bf8e-958f4aee8858",
+          "attributes": {}
+        },
+        {
+          "id": "b9834dfd-833c-460d-a1ee-a4210b479f7f",
+          "name": "query-users",
+          "description": "${role_query-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "42198dc6-1c53-4135-bf8e-958f4aee8858",
+          "attributes": {}
+        },
+        {
+          "id": "f64f84db-18a7-4c36-95db-707edac3044d",
+          "name": "realm-admin",
+          "description": "${role_realm-admin}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "view-authorization",
+                "query-groups",
+                "impersonation",
+                "manage-users",
+                "manage-authorization",
+                "view-realm",
+                "manage-clients",
+                "view-events",
+                "manage-events",
+                "query-clients",
+                "query-realms",
+                "create-client",
+                "view-identity-providers",
+                "manage-realm",
+                "manage-identity-providers",
+                "view-clients",
+                "view-users",
+                "query-users"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "42198dc6-1c53-4135-bf8e-958f4aee8858",
+          "attributes": {}
+        },
+        {
+          "id": "b8d88057-17c9-4629-b1dd-0a725e1fd57c",
+          "name": "view-users",
+          "description": "${role_view-users}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-groups",
+                "query-users"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "42198dc6-1c53-4135-bf8e-958f4aee8858",
+          "attributes": {}
+        }
+      ],
+      "security-admin-console": [],
+      "admin-cli": [],
+      "account-console": [],
+      "broker": [
+        {
+          "id": "84786fc0-7ba3-47ac-8b36-6c5ed820bd78",
+          "name": "read-token",
+          "description": "${role_read-token}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "a2e78276-afcc-4424-8977-0c59a4de7215",
+          "attributes": {}
+        }
+      ],
+      "account": [
+        {
+          "id": "1bc6d999-2e1d-4dea-9288-a518d3da9bb1",
+          "name": "delete-account",
+          "description": "${role_delete-account}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "54161586-b938-487e-bd77-340b17f9e4c4",
+          "attributes": {}
+        },
+        {
+          "id": "72ce9088-fb6c-4082-a9f0-4373685d437c",
+          "name": "manage-account",
+          "description": "${role_manage-account}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "manage-account-links"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "54161586-b938-487e-bd77-340b17f9e4c4",
+          "attributes": {}
+        },
+        {
+          "id": "bf49026e-0c30-4218-adff-91bb811405d3",
+          "name": "view-profile",
+          "description": "${role_view-profile}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "54161586-b938-487e-bd77-340b17f9e4c4",
+          "attributes": {}
+        },
+        {
+          "id": "ef5d1562-3a01-4987-aca8-b51843f1de62",
+          "name": "manage-account-links",
+          "description": "${role_manage-account-links}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "54161586-b938-487e-bd77-340b17f9e4c4",
+          "attributes": {}
+        },
+        {
+          "id": "0ddf0daa-2608-4c28-93b5-03cda6975359",
+          "name": "manage-consent",
+          "description": "${role_manage-consent}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "view-consent"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "54161586-b938-487e-bd77-340b17f9e4c4",
+          "attributes": {}
+        },
+        {
+          "id": "c0a090ad-60c3-479b-9f5b-a8718a87e089",
+          "name": "view-applications",
+          "description": "${role_view-applications}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "54161586-b938-487e-bd77-340b17f9e4c4",
+          "attributes": {}
+        },
+        {
+          "id": "7c6e9a5a-1784-4fb3-be49-8ce725878061",
+          "name": "view-groups",
+          "description": "${role_view-groups}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "54161586-b938-487e-bd77-340b17f9e4c4",
+          "attributes": {}
+        },
+        {
+          "id": "b0451a79-903d-4d51-a4b7-e38cd15d640a",
+          "name": "view-consent",
+          "description": "${role_view-consent}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "54161586-b938-487e-bd77-340b17f9e4c4",
+          "attributes": {}
+        }
+      ]
+    }
+  },
+  "groups": [],
+  "defaultRole": {
+    "id": "78453e11-8080-4e37-9cda-d92b83f22512",
+    "name": "default-roles-cdr-core-sanity-check",
+    "description": "${role_default-roles}",
+    "composite": true,
+    "clientRole": false,
+    "containerId": "ca3e0ff6-5282-4d18-b860-8d28d7ac1b86"
+  },
+  "requiredCredentials": [
+    "password"
+  ],
+  "passwordPolicy": "length(8) and upperCase(1) and lowerCase(1) and digits(1) and specialChars(1)",
+  "otpPolicyType": "totp",
+  "otpPolicyAlgorithm": "HmacSHA1",
+  "otpPolicyInitialCounter": 0,
+  "otpPolicyDigits": 6,
+  "otpPolicyLookAheadWindow": 1,
+  "otpPolicyPeriod": 30,
+  "otpPolicyCodeReusable": false,
+  "otpSupportedApplications": [
+    "totpAppFreeOTPName",
+    "totpAppGoogleName",
+    "totpAppMicrosoftAuthenticatorName"
+  ],
+  "localizationTexts": {},
+  "webAuthnPolicyRpEntityName": "keycloak",
+  "webAuthnPolicySignatureAlgorithms": [
+    "ES256"
+  ],
+  "webAuthnPolicyRpId": "",
+  "webAuthnPolicyAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyRequireResidentKey": "not specified",
+  "webAuthnPolicyUserVerificationRequirement": "not specified",
+  "webAuthnPolicyCreateTimeout": 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyAcceptableAaguids": [],
+  "webAuthnPolicyExtraOrigins": [],
+  "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms": [
+    "ES256"
+  ],
+  "webAuthnPolicyPasswordlessRpId": "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout": 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+  "webAuthnPolicyPasswordlessExtraOrigins": [],
+  "users": [
+    {
+      "id": "d06b336b-8343-4253-b5e5-e6dace5cff0c",
+      "username": "ferroehr-admin",
+      "email": "ferroehr-admin@test.de",
+      "emailVerified": true,
+      "attributes": {
+        "locale": [
+          "en"
+        ]
+      },
+      "createdTimestamp": 1716991758389,
+      "enabled": true,
+      "totp": false,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "ferroehr",
+          "temporary": false
+        }
+      ],
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "ADMIN"
+      ],
+      "notBefore": 0,
+      "groups": []
+    },
+    {
+      "id": "aca7c611-779e-4f68-99fb-06cc57e7ed26",
+      "username": "ferroehr-user",
+      "email": "ferroehr-user@test.de",
+      "emailVerified": true,
+      "attributes": {
+        "locale": [
+          "en"
+        ]
+      },
+      "createdTimestamp": 1716991714172,
+      "enabled": true,
+      "totp": false,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "ferroehr",
+          "temporary": false
+        }
+      ],
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "USER"
+      ],
+      "notBefore": 0,
+      "groups": []
+    },
+    {
+      "id": "48f25621-f66f-4299-b12c-79282e599b05",
+      "username": "service-account-ferroehr",
+      "emailVerified": false,
+      "createdTimestamp": 1688738365099,
+      "enabled": true,
+      "totp": false,
+      "serviceAccountClientId": "ferroehr",
+      "credentials": [],
+      "disableableCredentialTypes": [],
+      "requiredActions": [
+        "TERMS_AND_CONDITIONS",
+        "VERIFY_EMAIL",
+        "UPDATE_PASSWORD",
+        "UPDATE_PROFILE"
+      ],
+      "realmRoles": [
+        "default-roles-cdr-core-sanity-check"
+      ],
+      "clientRoles": {
+        "ferroehr": [
+          "uma_protection"
+        ]
+      },
+      "notBefore": 0,
+      "groups": []
+    }
+  ],
+  "scopeMappings": [
+    {
+      "clientScope": "offline_access",
+      "roles": [
+        "offline_access"
+      ]
+    }
+  ],
+  "clientScopeMappings": {
+    "account": [
+      {
+        "client": "account-console",
+        "roles": [
+          "manage-account",
+          "view-groups"
+        ]
+      }
+    ]
+  },
+  "clients": [
+    {
+      "id": "54161586-b938-487e-bd77-340b17f9e4c4",
+      "clientId": "account",
+      "name": "${client_account}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/ferroehr/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/realms/ferroehr/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "post.logout.redirect.uris": "+"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [],
+      "optionalClientScopes": []
+    },
+    {
+      "id": "cc1e3247-dc40-4c07-b0d2-78c8dfddbdc3",
+      "clientId": "account-console",
+      "name": "${client_account-console}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/ferroehr/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/realms/ferroehr/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "post.logout.redirect.uris": "+",
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "da01db37-b0bb-4822-932d-73a120155e9b",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ],
+      "defaultClientScopes": [],
+      "optionalClientScopes": []
+    },
+    {
+      "id": "9ed4c5dc-6e75-40a4-a15a-f61ce8a215a3",
+      "clientId": "admin-cli",
+      "name": "${client_admin-cli}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "post.logout.redirect.uris": "+"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [],
+      "optionalClientScopes": []
+    },
+    {
+      "id": "a2e78276-afcc-4424-8977-0c59a4de7215",
+      "clientId": "broker",
+      "name": "${client_broker}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "post.logout.redirect.uris": "+"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [],
+      "optionalClientScopes": []
+    },
+    {
+      "id": "6bf4fbb5-e031-49e1-b2b3-de38dd7938b7",
+      "clientId": "ferroehr",
+      "name": "FerroEHR",
+      "description": "",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "bT5T4oWn3xNdBytQsl2cfpBDi1pp15Va",
+      "redirectUris": [
+        "/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "authorizationServicesEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "oidc.ciba.grant.enabled": "false",
+        "client.secret.creation.time": "1696233968",
+        "backchannel.logout.session.required": "true",
+        "post.logout.redirect.uris": "+",
+        "display.on.consent.screen": "false",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "5298cf35-97a6-4965-bf64-07e639898524",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "992a2bac-5c38-4ae4-8938-a83ecbc914e8",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "df7d4ce9-5b37-4ca1-80ad-30ad38f0c310",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "fed7572e-0aac-4c54-a866-3299db0f5844",
+          "name": "tenant_id",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "ca3e0ff6-5282-4d18-b860-8d28d7ac1b86",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "tnt",
+            "access.tokenResponse.claim": "false"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "email",
+        "hip-scope-ca3e0ff6-5282-4d18-b"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ],
+      "authorizationSettings": {
+        "allowRemoteResourceManagement": true,
+        "policyEnforcementMode": "ENFORCING",
+        "resources": [],
+        "policies": [],
+        "scopes": [],
+        "decisionStrategy": "UNANIMOUS"
+      }
+    },
+    {
+      "id": "42198dc6-1c53-4135-bf8e-958f4aee8858",
+      "clientId": "realm-management",
+      "name": "${client_realm-management}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "post.logout.redirect.uris": "+"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [],
+      "optionalClientScopes": []
+    },
+    {
+      "id": "50209af3-f537-45a8-b148-6db3f52bc49d",
+      "clientId": "security-admin-console",
+      "name": "${client_security-admin-console}",
+      "rootUrl": "${authAdminUrl}",
+      "baseUrl": "/admin/ferroehr/console/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/admin/ferroehr/console/*"
+      ],
+      "webOrigins": [
+        "+"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "post.logout.redirect.uris": "+",
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "f0447a0e-e245-43a1-9110-6ccd4bca519a",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [],
+      "optionalClientScopes": []
+    }
+  ],
+  "clientScopes": [
+    {
+      "id": "c39c4c37-bc5a-44b3-b5b8-9da88e838c79",
+      "name": "profile",
+      "description": "OpenID Connect built-in scope: profile",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${profileScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "485925ca-f501-4544-958f-d3b322ad8261",
+          "name": "updated at",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "updatedAt",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "updated_at",
+            "jsonType.label": "long"
+          }
+        },
+        {
+          "id": "a53cf2dd-c64b-4348-a0dc-251be30ed3cf",
+          "name": "website",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "website",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "website",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "5fa55c53-cbfa-4a04-ad5c-cc0ae6d9dbb8",
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "8d9a4e04-85c7-4ab3-993c-6952bf1bc99d",
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "7c3be8a7-ecbd-4b9b-a626-f356584d7686",
+          "name": "zoneinfo",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "zoneinfo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "zoneinfo",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "c98bb606-5da8-43b0-91ea-bf34382cf0b6",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "5ca52951-8662-49aa-a3bd-0d81822a8f41",
+          "name": "birthdate",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "birthdate",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "birthdate",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "b731b7e0-3a75-493a-b658-6b1400cfda5b",
+          "name": "gender",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "gender",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "gender",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "bee3a4ec-f696-42a3-9ad3-db69dd3fbb6b",
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "97d30e24-c73c-4fe6-8249-0ed29d8c68f9",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "88c6eef4-e6c1-4171-a902-acf197b13dea",
+          "name": "profile",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "profile",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "profile",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "3670907b-1b5c-48b7-b5de-19b446d7315d",
+          "name": "nickname",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "nickname",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "nickname",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "7839f90b-5204-43eb-b68c-3caeaa6c0f80",
+          "name": "picture",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "picture",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "picture",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "34b8420a-b6a7-4b7b-9506-73a5e18f528f",
+          "name": "middle name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "middleName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "middle_name",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "a10677ca-553e-4aa5-8be5-d5bc3f94d145",
+      "name": "address",
+      "description": "OpenID Connect built-in scope: address",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${addressScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "10339fb9-fb22-42c4-bd5e-011d6ce1c115",
+          "name": "address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-address-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute.formatted": "formatted",
+            "user.attribute.country": "country",
+            "user.attribute.postal_code": "postal_code",
+            "userinfo.token.claim": "true",
+            "user.attribute.street": "street",
+            "id.token.claim": "true",
+            "user.attribute.region": "region",
+            "access.token.claim": "true",
+            "user.attribute.locality": "locality"
+          }
+        }
+      ]
+    },
+    {
+      "id": "0594e35c-4353-4a61-bfda-3c628797b723",
+      "name": "phone",
+      "description": "OpenID Connect built-in scope: phone",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${phoneScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "39cec2e6-49c8-49b9-a265-644595237587",
+          "name": "phone number verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumberVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number_verified",
+            "jsonType.label": "boolean"
+          }
+        },
+        {
+          "id": "f4096e64-50f5-4243-bb16-fc6984913f94",
+          "name": "phone number",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumber",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "a3e60283-2d33-4ec6-8c76-510b40dbc202",
+      "name": "role_list",
+      "description": "SAML role list",
+      "protocol": "saml",
+      "attributes": {
+        "consent.screen.text": "${samlRoleListScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "5199afb7-5507-40d4-9d32-6407591998b3",
+          "name": "role list",
+          "protocol": "saml",
+          "protocolMapper": "saml-role-list-mapper",
+          "consentRequired": false,
+          "config": {
+            "single": "false",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "Role"
+          }
+        }
+      ]
+    },
+    {
+      "id": "43194d99-8ea1-45f8-9eeb-873b1f3bc115",
+      "name": "acr",
+      "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "d03c6a78-cad9-42c5-a33b-6761b2d211d2",
+          "name": "acr loa level",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-acr-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "9cbead67-1823-4d98-acd2-fc591a78c969",
+      "name": "roles",
+      "description": "OpenID Connect scope for add user roles to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${rolesScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "b7f4031c-d8e2-45ab-a2f7-17bdfbe39923",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {}
+        },
+        {
+          "id": "6804b9d0-2aea-431b-a376-34ed8be3b40c",
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        },
+        {
+          "id": "dc5d2f14-ab59-4070-bf11-616901a481ae",
+          "name": "client roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-client-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "access.token.claim": "true",
+            "claim.name": "resource_access.${client_id}.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "b1f8a2e0-965b-4b1c-a9d6-365362c7f7ed",
+      "name": "web-origins",
+      "description": "OpenID Connect scope for add allowed web origins to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false",
+        "consent.screen.text": ""
+      },
+      "protocolMappers": [
+        {
+          "id": "555aa7ba-d1ad-432b-9c25-10ad85e0373c",
+          "name": "allowed web origins",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-allowed-origins-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ]
+    },
+    {
+      "id": "003de353-d038-430d-9486-49306b45aee7",
+      "name": "email",
+      "description": "OpenID Connect built-in scope: email",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${emailScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "6789c8e8-7cf4-4495-b38f-e03c0c3c6d02",
+          "name": "email verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "emailVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email_verified",
+            "jsonType.label": "boolean"
+          }
+        },
+        {
+          "id": "5b79ea96-85b3-4f98-8133-e85056e700d5",
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "26a49187-cb72-4c42-b27e-f43645b734da",
+      "name": "offline_access",
+      "description": "OpenID Connect built-in scope: offline_access",
+      "protocol": "openid-connect",
+      "attributes": {
+        "consent.screen.text": "${offlineAccessScopeConsentText}",
+        "display.on.consent.screen": "true"
+      }
+    },
+    {
+      "id": "711a336d-3639-4a70-8cee-ef5b9c5fd953",
+      "name": "microprofile-jwt",
+      "description": "Microprofile - JWT built-in scope",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "f91ce935-d38f-4558-be19-7b8c53305f2e",
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "multivalued": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "foo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "426dbe55-8104-4c88-991a-7192a2faae5d",
+          "name": "upn",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "upn",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "hip-scope-ca3e0ff6-5282-4d18-b",
+      "name": "hip-scope-ca3e0ff6-5282-4d18-b",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "42bdcf9a-e3a8-4933-8e28-e7874818427d",
+          "name": "selected-tenant-uuid-mapper",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "selected_tenant_uuid",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "set",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "a3cf1113-7d2e-4224-866c-e3fdba34436b",
+          "name": "tenant-uuid-mapper",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "tenant_uuid",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "tnt",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "98f2e3b0-76d1-4c72-bf44-f0de4706a877",
+          "name": "organization-uuid-mapper",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "organization_uuid",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "org",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    }
+  ],
+  "defaultDefaultClientScopes": [
+    "role_list",
+    "profile",
+    "email",
+    "roles",
+    "web-origins",
+    "acr",
+    "hip-scope-ca3e0ff6-5282-4d18-b"
+  ],
+  "defaultOptionalClientScopes": [
+    "offline_access",
+    "address",
+    "phone",
+    "microprofile-jwt"
+  ],
+  "browserSecurityHeaders": {
+    "contentSecurityPolicyReportOnly": "",
+    "xContentTypeOptions": "nosniff",
+    "referrerPolicy": "no-referrer",
+    "xRobotsTag": "none",
+    "xFrameOptions": "SAMEORIGIN",
+    "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xXSSProtection": "1; mode=block",
+    "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer": {
+    "password": "**********",
+    "starttls": "true",
+    "auth": "true",
+    "port": "465",
+    "host": "mail.vitasystems.dev",
+    "from": "cdt-dev@vitasystems.dev",
+    "ssl": "true",
+    "user": "cdt-dev"
+  },
+  "loginTheme": "vitagroup",
+  "emailTheme": "vitagroup",
+  "eventsEnabled": false,
+  "eventsListeners": [
+    "jboss-logging"
+  ],
+  "enabledEventTypes": [],
+  "adminEventsEnabled": false,
+  "adminEventsDetailsEnabled": false,
+  "identityProviders": [],
+  "identityProviderMappers": [],
+  "components": {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+      {
+        "id": "59a32fb9-5d19-4e04-811b-be2e5457adb5",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
         }
       },
-      "clientRole" : false,
-      "containerId" : "ca3e0ff6-5282-4d18-b860-8d28d7ac1b86",
-      "attributes" : { }
-    }, {
-      "id" : "3b27defc-2ad4-4db3-9921-17d45d294d61",
-      "name" : "offline_access",
-      "description" : "${role_offline-access}",
-      "composite" : false,
-      "clientRole" : false,
-      "containerId" : "ca3e0ff6-5282-4d18-b860-8d28d7ac1b86",
-      "attributes" : { }
-    }, {
-      "id" : "243cd507-dd35-4cd6-a7d5-b620743189ad",
-      "name" : "ADMIN",
-      "description" : "",
-      "composite" : false,
-      "clientRole" : false,
-      "containerId" : "ca3e0ff6-5282-4d18-b860-8d28d7ac1b86",
-      "attributes" : { }
-    } ],
-    "client" : {
-      "ferroehr" : [ {
-        "id" : "8cc84b69-f611-4a3d-bfc9-4f5aaccc06f5",
-        "name" : "uma_protection",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "6bf4fbb5-e031-49e1-b2b3-de38dd7938b7",
-        "attributes" : { }
-      } ],
-      "realm-management" : [ {
-        "id" : "32bfca88-d2de-45e9-b6fa-f186dddae22e",
-        "name" : "view-authorization",
-        "description" : "${role_view-authorization}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "42198dc6-1c53-4135-bf8e-958f4aee8858",
-        "attributes" : { }
-      }, {
-        "id" : "d782c61b-b284-4303-8d38-d867159acafa",
-        "name" : "impersonation",
-        "description" : "${role_impersonation}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "42198dc6-1c53-4135-bf8e-958f4aee8858",
-        "attributes" : { }
-      }, {
-        "id" : "c6a68a59-1733-4517-8cec-daa990b9b39e",
-        "name" : "query-groups",
-        "description" : "${role_query-groups}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "42198dc6-1c53-4135-bf8e-958f4aee8858",
-        "attributes" : { }
-      }, {
-        "id" : "2e005b5e-4f8a-4227-9f56-ae9bc5f5d0dc",
-        "name" : "manage-users",
-        "description" : "${role_manage-users}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "42198dc6-1c53-4135-bf8e-958f4aee8858",
-        "attributes" : { }
-      }, {
-        "id" : "3981f9fd-83db-4e95-afb1-9f2f9db1ca30",
-        "name" : "manage-authorization",
-        "description" : "${role_manage-authorization}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "42198dc6-1c53-4135-bf8e-958f4aee8858",
-        "attributes" : { }
-      }, {
-        "id" : "6cfff4e3-3dc2-4b53-aa61-77035f3fe2ba",
-        "name" : "view-realm",
-        "description" : "${role_view-realm}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "42198dc6-1c53-4135-bf8e-958f4aee8858",
-        "attributes" : { }
-      }, {
-        "id" : "aacbe325-1e21-40b5-a156-d70a0d571c34",
-        "name" : "manage-clients",
-        "description" : "${role_manage-clients}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "42198dc6-1c53-4135-bf8e-958f4aee8858",
-        "attributes" : { }
-      }, {
-        "id" : "d959763c-c498-4803-9b82-5e2d98f85488",
-        "name" : "view-events",
-        "description" : "${role_view-events}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "42198dc6-1c53-4135-bf8e-958f4aee8858",
-        "attributes" : { }
-      }, {
-        "id" : "15ad936e-fafd-4e7a-928a-31f127f4efff",
-        "name" : "manage-events",
-        "description" : "${role_manage-events}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "42198dc6-1c53-4135-bf8e-958f4aee8858",
-        "attributes" : { }
-      }, {
-        "id" : "8f3e1718-b42f-4a47-aff6-e609b39742ce",
-        "name" : "query-clients",
-        "description" : "${role_query-clients}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "42198dc6-1c53-4135-bf8e-958f4aee8858",
-        "attributes" : { }
-      }, {
-        "id" : "0bd014fa-baaf-4df6-8e7c-1ab57ac8aee9",
-        "name" : "query-realms",
-        "description" : "${role_query-realms}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "42198dc6-1c53-4135-bf8e-958f4aee8858",
-        "attributes" : { }
-      }, {
-        "id" : "0153b7a0-a638-41de-9b60-e0ff2bd2060c",
-        "name" : "create-client",
-        "description" : "${role_create-client}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "42198dc6-1c53-4135-bf8e-958f4aee8858",
-        "attributes" : { }
-      }, {
-        "id" : "371c859f-716f-46d1-86d1-a2a113b967e0",
-        "name" : "view-identity-providers",
-        "description" : "${role_view-identity-providers}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "42198dc6-1c53-4135-bf8e-958f4aee8858",
-        "attributes" : { }
-      }, {
-        "id" : "1eb4e962-769f-4911-aa8e-fcebd5a37d38",
-        "name" : "manage-realm",
-        "description" : "${role_manage-realm}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "42198dc6-1c53-4135-bf8e-958f4aee8858",
-        "attributes" : { }
-      }, {
-        "id" : "52daa4a4-b187-405b-837f-59548fa1ff70",
-        "name" : "manage-identity-providers",
-        "description" : "${role_manage-identity-providers}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "42198dc6-1c53-4135-bf8e-958f4aee8858",
-        "attributes" : { }
-      }, {
-        "id" : "c03a2be5-ffe5-4e5d-8af6-e9cb37aae85e",
-        "name" : "view-clients",
-        "description" : "${role_view-clients}",
-        "composite" : true,
-        "composites" : {
-          "client" : {
-            "realm-management" : [ "query-clients" ]
-          }
+      {
+        "id": "d0fe175e-6352-473a-9973-7b8505deddff",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-full-name-mapper",
+            "saml-user-property-mapper",
+            "saml-role-list-mapper",
+            "oidc-address-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "saml-user-attribute-mapper",
+            "oidc-usermodel-property-mapper",
+            "oidc-sha256-pairwise-sub-mapper"
+          ]
+        }
+      },
+      {
+        "id": "b08207ff-99f3-4679-967e-07e0a9e7e37e",
+        "name": "Full Scope Disabled",
+        "providerId": "scope",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "41620ac1-14da-424b-ba81-cea7168f20aa",
+        "name": "Consent Required",
+        "providerId": "consent-required",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "3157e10f-aa9e-42b4-94d2-d8fb640d13ba",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "1d4bf3b0-8f72-4983-b571-2793484d3327",
+        "name": "Trusted Hosts",
+        "providerId": "trusted-hosts",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "host-sending-registration-request-must-match": [
+            "true"
+          ],
+          "client-uris-must-match": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "18f1970a-5127-40e6-bdba-1b7455922490",
+        "name": "Max Clients Limit",
+        "providerId": "max-clients",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "max-clients": [
+            "200"
+          ]
+        }
+      },
+      {
+        "id": "f2546877-7cb2-45ad-a487-092916848bea",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-address-mapper",
+            "saml-user-attribute-mapper",
+            "saml-role-list-mapper",
+            "oidc-usermodel-property-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "saml-user-property-mapper",
+            "oidc-full-name-mapper"
+          ]
+        }
+      }
+    ],
+    "org.keycloak.userprofile.UserProfileProvider": [
+      {
+        "id": "22a6839a-62d7-4dec-b8a8-667498a41bb4",
+        "providerId": "declarative-user-profile",
+        "subComponents": {},
+        "config": {
+          "kc.user.profile.config": [
+            "{\"attributes\":[{\"name\":\"username\",\"displayName\":\"${username}\",\"validations\":{\"length\":{\"min\":3,\"max\":255},\"username-prohibited-characters\":{},\"up-username-not-idn-homograph\":{}},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"email\",\"displayName\":\"${email}\",\"validations\":{\"email\":{},\"length\":{\"max\":255}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"firstName\",\"displayName\":\"${firstName}\",\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"lastName\",\"displayName\":\"${lastName}\",\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false}],\"groups\":[{\"name\":\"user-metadata\",\"displayHeader\":\"User metadata\",\"displayDescription\":\"Attributes, which refer to user metadata\"}],\"unmanagedAttributePolicy\":\"ENABLED\"}"
+          ]
+        }
+      }
+    ],
+    "org.keycloak.keys.KeyProvider": [
+      {
+        "id": "ded58cac-ea24-406e-b43a-6dfe156a1156",
+        "name": "hmac-generated",
+        "providerId": "hmac-generated",
+        "subComponents": {},
+        "config": {
+          "kid": [
+            "462a27c8-3e87-4b84-a96d-30515703c6c4"
+          ],
+          "secret": [
+            "szxaUOTYngHiyPVaL8jkWc_eUvgQQjaTvQLDTV4tO-OZBp1W4kW62BALXbKlF48WJo8_A-CwFkWYupYUF4-OesFA1zW8oarwTfNDYnwuhuTZtUe5td2c0hcwt7dwhuo9gUUWUOXsbycOIGL5uQpFvhx0xlsn_R2JG1BQy90v8ik"
+          ],
+          "priority": [
+            "100"
+          ],
+          "algorithm": [
+            "HS256"
+          ]
+        }
+      },
+      {
+        "id": "07079ca0-51a5-4eba-8b8b-d403a648a101",
+        "name": "rsa-generated",
+        "providerId": "rsa-generated",
+        "subComponents": {},
+        "config": {
+          "privateKey": [
+            "MIIEpAIBAAKCAQEA2b1cmURklORMn077bgtCivUGZsUVdDlKpUto+7BvqaiQG/bAS96T+G3s+Gt4SWLkHfUTa9LwBGuq89OoWKIVKFJWZzvipUSXRjo3N2Ha2/e+RhqbIMbeXygijVe+Lsujj1ZZdDv848wEnpG1C2BsX2qUvFuxM7IJm8NmLdbxhAYni6YGMil/J3gt7WUYf/8xMtl+pI7XKHEFlzn9/CY45ThcJtqsBM2/U9VTMCBA8oXmL8KG88qUaCMy3c4ObJP/XkJJWGKeii60zW2ufBWSvtFRhdt461t8s9UlvdlFGdVKW+AjtG57BfU6ja/WNBooFKHgmM/iP9rmT2mX9fVRSwIDAQABAoIBAAj8jJioyXaZsOM2/nU4EsArGl9dzU5gL56rLO3iW3bG8GJZve2uWzC60g0eBmIPqkw65APPD2fnTQVw3AxYbYNzWSyRPKqcg5p65vIqtZPe4Y6sJMXmtKEnG2dLp/DvfP8lTbODPE3nNYjuiOiAy3LpXQfPHaeoC/HOpTt0GRYH8Ct109I0YbmSby4H/OKnqYmOoS2vmRJMzRBIbrfaT8BYL6y1iXNe/L+3YQa0OreQ1sh7HpubuqcuyGz/mFhMDUbaPsda8+OAVC6RmnAVqZgn6kvDNRxc0GWlWDCktl/vn6pFptELFdlN9/WTSBERzA37DRkAVVN1hLwhJAzSkTUCgYEA8PDzoLboaQVYx3GrtunRPKwUplGcZWGzmaN2RPZV2Bff47hnaROMCo24ZnKnY5mAXchVRAEobbevU1oXKDYQMMDpsZ2GqA/g2xW4W/elnnQFlbQ2poqs/jiGuHiwjA7XeektZld5BHQ5XHb+zsWeQ8maGypRfSlLjxwtvxJm158CgYEA51kvznS4ZMWvtfD9XDnFAb2BZ1W6jDk9yh3NoPzButOhMBW/W2azoc9MGSsUL2iuHE3x4gJkOnJrK9XNM/14II4XHgGl2ZFkjEqmWhpMfhzwceJRHrPZuPHbv3iHehb22SZGC/63k0XkklYtAES1/gavtkiMJowTrxB6qLO71tUCgYEA0FmMU43Xq/lTrCQ/uQy4Qx8LPEeWVpUGGfWgcEIUOalrkiAETHj6wKWMsAq1dQtoVbDHCud1bmtI0Ws2Wy9lEMPBUjZGG06fwtQleGHOdhcePTZ5i8qfjbaTyTGUeYjcDC/3cmhx3cgjUjIUZfm9wiCzgoo1rWXoUPitFm1zQUECgYEAtyudN1ig2mDO8z4AS/INcohJmbh9wCJeMtYQBiO5e6Ot3rWJUePp2/aWaOL702GNYSmxluGP29rV0dow47YPU69MzFw/pRiBxLYiKfrij4N4OKMY2TdK7izIcTwL//WIsnukQEEHthpDlD2Y2bqNYbiHjMq59Jc5yoVAqKvN0JUCgYA+/DgLFGkS+77cj0sca6Yt4U2ytNHuhsnEDx+RjDOR/I8ymcU+sJBw0NT+cCUl/65UZVvFuBvFQ+jAQPLs03P2Pa3yReHtWTZ6OFeV7Q3K5EZwM6HDXF6oTLrl+cLG+8mlThx0S+0UACzlcZGkbcVA9GqJhdIJiTrnBfPpnes3lA=="
+          ],
+          "certificate": [
+            "MIICuTCCAaECBgGK72wUEDANBgkqhkiG9w0BAQsFADAgMR4wHAYDVQQDDBVjZHItY29yZS1zYW5pdHktY2hlY2swHhcNMjMxMDAyMDgwNDEyWhcNMzMxMDAyMDgwNTUyWjAgMR4wHAYDVQQDDBVjZHItY29yZS1zYW5pdHktY2hlY2swggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDZvVyZRGSU5EyfTvtuC0KK9QZmxRV0OUqlS2j7sG+pqJAb9sBL3pP4bez4a3hJYuQd9RNr0vAEa6rz06hYohUoUlZnO+KlRJdGOjc3Ydrb975GGpsgxt5fKCKNV74uy6OPVll0O/zjzASekbULYGxfapS8W7Ezsgmbw2Yt1vGEBieLpgYyKX8neC3tZRh//zEy2X6kjtcocQWXOf38JjjlOFwm2qwEzb9T1VMwIEDyheYvwobzypRoIzLdzg5sk/9eQklYYp6KLrTNba58FZK+0VGF23jrW3yz1SW92UUZ1Upb4CO0bnsF9TqNr9Y0GigUoeCYz+I/2uZPaZf19VFLAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAF/hyDobpxspcPow/wOkhKtCLjANKLs0q/+swyYxCO71KT5RMDAQLC1u6/H6uHU4dqSbXH6HRNsC/AzMg3AUWnJwlECXqtfNNYMmtyQaOIpPUxLrXSTHF2xm83z+egO/C0pNgoPJXqxASyt1E8+Lqi5PGMS0vUjjryBtEvieQi4WX6BqFn1Vtqt2wHIZDwbB8Wjei5xsAFbbYnjTPDm/rooa8CZG/AXqLWjPFScJRnEKCZhQ3cq0OKmwXKPGBOMbI8nGYDgt41i/fyBPzKom2iR/fSxpiHfQUeFmu6GYRTJbBPy9zaRUIjCCNU1QwUp/K6iHoyr9JcW40mi666mGPJ0="
+          ],
+          "priority": [
+            "100"
+          ]
+        }
+      },
+      {
+        "id": "5eba2551-adb6-4136-b9e0-bebc9448b384",
+        "name": "hmac-generated-hs512",
+        "providerId": "hmac-generated",
+        "subComponents": {},
+        "config": {
+          "kid": [
+            "f49268c7-20ad-42ab-b231-a86550980747"
+          ],
+          "secret": [
+            "zCLMCDV5EnuKyGNFudo71SHljzaOSSjMIMqOLBOZpe3gOQUmdgUMaBPG52djQ9aNUiYoltm2w6QgLlmFY4keGeQ60psLoGqcwgcMKQnxnM7a4KcRpB3vgaJEAYuGaVcV-G7IiOlccwpzmnNMAPy53oqz64TFtqunc3PyepeM0zs"
+          ],
+          "priority": [
+            "100"
+          ],
+          "algorithm": [
+            "HS512"
+          ]
+        }
+      },
+      {
+        "id": "97b477fb-4c0e-4556-8b0f-814043dab0d1",
+        "name": "rsa-enc-generated",
+        "providerId": "rsa-enc-generated",
+        "subComponents": {},
+        "config": {
+          "privateKey": [
+            "MIIEowIBAAKCAQEArJv4sEsFxmkHoN7MQrIUWuj+BkcPlCKqj2Bp/+IiyspEt49T6j67mTofRfoRq59yV9Ij9B43fcy+U7HAltxJWGXPc1BQ05S4xWhgLpF0FBRqUXJ2YbYfG89TzUEJZxmJ0WgjzMZx1/hsq3WBg5S5b391mULL7Ogj88eqMxdZIa/t2kWNAizoRWhaJpmmvO+WakQKwHFnrFb5Dj+RzwaL1lyByzLLveWc/jeNP+48m/to1TocE95JEcySz5HOO1Z6x3gFDS0odYyDs0deeK7eFusJUvD4BycUmFUCnFo+K5037YF1evpEP2q4CIOSVyLbjW2KqYBSk4Biy2vptv/CYwIDAQABAoIBADNSqxbML9rndt+z73szVQ8U8RcvwOeUiS9ZhRsTA7JVgyorQVHItmIgoJTffqqPneGT96HJ7EkI/FyJYVDaDirtFspcSrQmp+v2lYazNBcWXOh7xsxV6RkNRAcnO+L+enab5u0n4kjLspAmv8w+iAapmO9pp5X5DluZdjd7zUJQ/oXtlUerc3bkNgFLDX8LSkhs80+A0dh1BMVBkQCOLmos7qVRDsXPW+2zxZ7oo0/thlOO+OtFRryBufi+YynLlbrrfKWlVPBy6hjchPa8MPxOEni5BS0xXvmWmuQRONSnOUeZ6yILhhqMWBONYGf7D7BDG8UjF2zUUJlofHvyGf0CgYEA3zq1CoFrX4+rmbXuj6KBbNRRUm5TDOleV2oBT80rD35dMSyVTy80OHlAiz2N46XMx4YpLXNS5vNJHzWWKzfry4qe6K4Rs3hHc27I6lRgO4VRG3kDEB3w5mpNIwikUOGsILgbhm054cIJ5BFI1idor9DpJ3mjwupQxFxkVXkE2aUCgYEAxfLi7ISETJ85aAappd1xdlFf+tXlqZn6Yds7RAWw6HqOl7jSSMCPdmKkG3QwHhlfX2rpzZBdAi4qxLzj/1cDP2ZYkWqisPUZrVBUQkuqG26VQwDeToKwAca5e7zhp997oYU3wnq10FYa3sdzHvYKsZaNketwEOMQ2H9lxmGqnWcCgYAlt2SZVs6OgdbLjMq26A0YFzN6SvurRc7T1CxOkGrDHmWehlrf2yjmlc4K+KZ9nSjhWVChxkdukBJ9vG8X9EXZyR0aUTbabOsdnM1DkmgEBn1yt9qFoZlvROyti6s/ozGTAahc6R2LgF5tc2IsFNKCSjjqm4nIyBBHbRjivCTOpQKBgQClCpftP6fXAsKoWzXDV1isn7h4uTKdMAa05EcLtfsEOnr9QVoC0ppKyH+vbDZaQilksw1xGTaTBM8f7aXjVTcd+0VJKTGwfQsFl/5IsDGKYa8NiIHRz+DT+k7YPmmewBSiXSJagllo9QG+UWlInTfZTX+H9FchnVCEUeQXfYL1bQKBgBJVYBqE6qs3urg38Sj/322BkH19+Twep00JqQW6ZIivw/9dihHzXY+Rp/hjxZGwI41NRrhE5kmV2W32oL1l+x9vfYCBRSH653ZYAU9dRkztOIN6h1ORXgMx4eYKHPlxrrRJzod+9AkI2dXLPgsAGKo3QLyT963wNgoLGkzl+fth"
+          ],
+          "certificate": [
+            "MIICuTCCAaECBgGK72wVPTANBgkqhkiG9w0BAQsFADAgMR4wHAYDVQQDDBVjZHItY29yZS1zYW5pdHktY2hlY2swHhcNMjMxMDAyMDgwNDEyWhcNMzMxMDAyMDgwNTUyWjAgMR4wHAYDVQQDDBVjZHItY29yZS1zYW5pdHktY2hlY2swggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCsm/iwSwXGaQeg3sxCshRa6P4GRw+UIqqPYGn/4iLKykS3j1PqPruZOh9F+hGrn3JX0iP0Hjd9zL5TscCW3ElYZc9zUFDTlLjFaGAukXQUFGpRcnZhth8bz1PNQQlnGYnRaCPMxnHX+GyrdYGDlLlvf3WZQsvs6CPzx6ozF1khr+3aRY0CLOhFaFommaa875ZqRArAcWesVvkOP5HPBovWXIHLMsu95Zz+N40/7jyb+2jVOhwT3kkRzJLPkc47VnrHeAUNLSh1jIOzR154rt4W6wlS8PgHJxSYVQKcWj4rnTftgXV6+kQ/argIg5JXItuNbYqpgFKTgGLLa+m2/8JjAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAHhe1UqhYTXWbreHvNvFMd4CDXiKD+ISExF/wQFfLJTBMIaIWS6mVJ48wscxZeTMq+WlW9L42NtOb8eyiSSaWCuvhijUqf088wPD1ZOD8soUdiHcs1Z6W0dpSwGQfIrmCvucuDVab2owp+SyaITPQmnQWeaPf7exG1qMyAE0kev4ky0h9WaNYNWj0fQ1fgn+zAubpMeT7NenLc8mpqKQA+pIDg6vIDJDIqD6r346jxBj0s7DzCtgnxAnO5eV3zA5urqXUXgrdtjBResZOte4t1yiQ4MS/i0Ahoov/QtFTcUQRr1dwWS/o0BNO1tPw9MomqQyslL3XlKrBkuVuYFogIo="
+          ],
+          "priority": [
+            "100"
+          ],
+          "algorithm": [
+            "RSA-OAEP"
+          ]
+        }
+      },
+      {
+        "id": "b541c7c1-d569-4367-8a38-381f9710932e",
+        "name": "aes-generated",
+        "providerId": "aes-generated",
+        "subComponents": {},
+        "config": {
+          "kid": [
+            "eaad2638-ccaa-422e-beaf-e6ecbfb4fc4a"
+          ],
+          "secret": [
+            "ua7-NOK8Fk_G3L6w3wYWeg"
+          ],
+          "priority": [
+            "100"
+          ]
+        }
+      }
+    ]
+  },
+  "internationalizationEnabled": true,
+  "supportedLocales": [
+    "de",
+    "en"
+  ],
+  "defaultLocale": "de",
+  "authenticationFlows": [
+    {
+      "id": "287ea54b-fe74-4aed-b495-83dd5ea33883",
+      "alias": "Account verification options",
+      "description": "Method with which to verity the existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-email-verification",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
         },
-        "clientRole" : true,
-        "containerId" : "42198dc6-1c53-4135-bf8e-958f4aee8858",
-        "attributes" : { }
-      }, {
-        "id" : "b9834dfd-833c-460d-a1ee-a4210b479f7f",
-        "name" : "query-users",
-        "description" : "${role_query-users}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "42198dc6-1c53-4135-bf8e-958f4aee8858",
-        "attributes" : { }
-      }, {
-        "id" : "f64f84db-18a7-4c36-95db-707edac3044d",
-        "name" : "realm-admin",
-        "description" : "${role_realm-admin}",
-        "composite" : true,
-        "composites" : {
-          "client" : {
-            "realm-management" : [ "view-authorization", "query-groups", "impersonation", "manage-users", "manage-authorization", "view-realm", "manage-clients", "view-events", "manage-events", "query-clients", "query-realms", "create-client", "view-identity-providers", "manage-realm", "manage-identity-providers", "view-clients", "view-users", "query-users" ]
-          }
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Verify Existing Account by Re-authentication",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "44e4f079-2f74-4f8e-9f59-f5bf2ef1cb36",
+      "alias": "Browser - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
         },
-        "clientRole" : true,
-        "containerId" : "42198dc6-1c53-4135-bf8e-958f4aee8858",
-        "attributes" : { }
-      }, {
-        "id" : "b8d88057-17c9-4629-b1dd-0a725e1fd57c",
-        "name" : "view-users",
-        "description" : "${role_view-users}",
-        "composite" : true,
-        "composites" : {
-          "client" : {
-            "realm-management" : [ "query-groups", "query-users" ]
-          }
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "0d881e86-0935-4e27-8aaa-4e80660de2eb",
+      "alias": "Direct Grant - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
         },
-        "clientRole" : true,
-        "containerId" : "42198dc6-1c53-4135-bf8e-958f4aee8858",
-        "attributes" : { }
-      } ],
-      "security-admin-console" : [ ],
-      "admin-cli" : [ ],
-      "account-console" : [ ],
-      "broker" : [ {
-        "id" : "84786fc0-7ba3-47ac-8b36-6c5ed820bd78",
-        "name" : "read-token",
-        "description" : "${role_read-token}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "a2e78276-afcc-4424-8977-0c59a4de7215",
-        "attributes" : { }
-      } ],
-      "account" : [ {
-        "id" : "1bc6d999-2e1d-4dea-9288-a518d3da9bb1",
-        "name" : "delete-account",
-        "description" : "${role_delete-account}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "54161586-b938-487e-bd77-340b17f9e4c4",
-        "attributes" : { }
-      }, {
-        "id" : "72ce9088-fb6c-4082-a9f0-4373685d437c",
-        "name" : "manage-account",
-        "description" : "${role_manage-account}",
-        "composite" : true,
-        "composites" : {
-          "client" : {
-            "account" : [ "manage-account-links" ]
-          }
+        {
+          "authenticator": "direct-grant-validate-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "757c2668-6953-460b-801c-04724268c5fe",
+      "alias": "First broker login - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
         },
-        "clientRole" : true,
-        "containerId" : "54161586-b938-487e-bd77-340b17f9e4c4",
-        "attributes" : { }
-      }, {
-        "id" : "bf49026e-0c30-4218-adff-91bb811405d3",
-        "name" : "view-profile",
-        "description" : "${role_view-profile}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "54161586-b938-487e-bd77-340b17f9e4c4",
-        "attributes" : { }
-      }, {
-        "id" : "ef5d1562-3a01-4987-aca8-b51843f1de62",
-        "name" : "manage-account-links",
-        "description" : "${role_manage-account-links}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "54161586-b938-487e-bd77-340b17f9e4c4",
-        "attributes" : { }
-      }, {
-        "id" : "0ddf0daa-2608-4c28-93b5-03cda6975359",
-        "name" : "manage-consent",
-        "description" : "${role_manage-consent}",
-        "composite" : true,
-        "composites" : {
-          "client" : {
-            "account" : [ "view-consent" ]
-          }
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "590e3d8f-e89b-44df-8703-591a8e1d4720",
+      "alias": "Handle Existing Account",
+      "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-confirm-link",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
         },
-        "clientRole" : true,
-        "containerId" : "54161586-b938-487e-bd77-340b17f9e4c4",
-        "attributes" : { }
-      }, {
-        "id" : "c0a090ad-60c3-479b-9f5b-a8718a87e089",
-        "name" : "view-applications",
-        "description" : "${role_view-applications}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "54161586-b938-487e-bd77-340b17f9e4c4",
-        "attributes" : { }
-      }, {
-        "id" : "7c6e9a5a-1784-4fb3-be49-8ce725878061",
-        "name" : "view-groups",
-        "description" : "${role_view-groups}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "54161586-b938-487e-bd77-340b17f9e4c4",
-        "attributes" : { }
-      }, {
-        "id" : "b0451a79-903d-4d51-a4b7-e38cd15d640a",
-        "name" : "view-consent",
-        "description" : "${role_view-consent}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "54161586-b938-487e-bd77-340b17f9e4c4",
-        "attributes" : { }
-      } ]
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Account verification options",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "d3344b77-feb7-4b42-9436-4a3ea67f14b6",
+      "alias": "Reset - Conditional OTP",
+      "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "e1002483-4b33-4d5a-a55c-5ea4e81f3c95",
+      "alias": "User creation or linking",
+      "description": "Flow for the existing/non-existing user alternatives",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "create unique user config",
+          "authenticator": "idp-create-user-if-unique",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Handle Existing Account",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "3551707c-df3b-427d-9456-16f042d1af34",
+      "alias": "Verify Existing Account by Re-authentication",
+      "description": "Reauthentication of existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "First broker login - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "85168b8d-3731-4b4d-8cf7-53cb1bb5e9eb",
+      "alias": "browser",
+      "description": "browser based authentication",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "identity-provider-redirector",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 25,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "autheticatorFlow": true,
+          "flowAlias": "forms",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "0bf9e9e6-f04f-49c3-96d2-8d5841adbbb0",
+      "alias": "clients",
+      "description": "Base authentication for clients",
+      "providerId": "client-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "client-secret",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-secret-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-x509",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 40,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "f0066f2e-f830-454e-a507-054b49708e46",
+      "alias": "direct grant",
+      "description": "OpenID Connect Resource Owner Grant",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "direct-grant-validate-username",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "direct-grant-validate-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 30,
+          "autheticatorFlow": true,
+          "flowAlias": "Direct Grant - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "8f545cb5-c4ac-42ac-9e6f-8aa173df4bbb",
+      "alias": "docker auth",
+      "description": "Used by Docker clients to authenticate against the IDP",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "docker-http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "b6beb772-8e87-4e04-ae49-8662c215902c",
+      "alias": "first broker login",
+      "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "review profile config",
+          "authenticator": "idp-review-profile",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "User creation or linking",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "75ba7352-f7bd-4237-ac74-aa69727eae25",
+      "alias": "forms",
+      "description": "Username, password, otp and other auth forms.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Browser - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "0bdd7edd-67a4-4d50-8acf-ddab41538092",
+      "alias": "registration",
+      "description": "registration flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-page-form",
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": true,
+          "flowAlias": "registration form",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "b637d219-e3e7-49eb-8c00-7051ef59ea7e",
+      "alias": "registration form",
+      "description": "registration form",
+      "providerId": "form-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-user-creation",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-password-action",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 50,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-recaptcha-action",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 60,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "0fb060b2-fc5b-4582-878e-837d6c8fc5c1",
+      "alias": "reset credentials",
+      "description": "Reset credentials for a user if they forgot their password or something",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "reset-credentials-choose-user",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-credential-email",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 40,
+          "autheticatorFlow": true,
+          "flowAlias": "Reset - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "af3c1b14-7cb0-40fd-a324-c49a9c5a936e",
+      "alias": "saml ecp",
+      "description": "SAML ECP Profile Authentication Flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
     }
-  },
-  "groups" : [ ],
-  "defaultRole" : {
-    "id" : "78453e11-8080-4e37-9cda-d92b83f22512",
-    "name" : "default-roles-cdr-core-sanity-check",
-    "description" : "${role_default-roles}",
-    "composite" : true,
-    "clientRole" : false,
-    "containerId" : "ca3e0ff6-5282-4d18-b860-8d28d7ac1b86"
-  },
-  "requiredCredentials" : [ "password" ],
-  "passwordPolicy" : "length(8) and upperCase(1) and lowerCase(1) and digits(1) and specialChars(1)",
-  "otpPolicyType" : "totp",
-  "otpPolicyAlgorithm" : "HmacSHA1",
-  "otpPolicyInitialCounter" : 0,
-  "otpPolicyDigits" : 6,
-  "otpPolicyLookAheadWindow" : 1,
-  "otpPolicyPeriod" : 30,
-  "otpPolicyCodeReusable" : false,
-  "otpSupportedApplications" : [ "totpAppFreeOTPName", "totpAppGoogleName", "totpAppMicrosoftAuthenticatorName" ],
-  "localizationTexts" : { },
-  "webAuthnPolicyRpEntityName" : "keycloak",
-  "webAuthnPolicySignatureAlgorithms" : [ "ES256" ],
-  "webAuthnPolicyRpId" : "",
-  "webAuthnPolicyAttestationConveyancePreference" : "not specified",
-  "webAuthnPolicyAuthenticatorAttachment" : "not specified",
-  "webAuthnPolicyRequireResidentKey" : "not specified",
-  "webAuthnPolicyUserVerificationRequirement" : "not specified",
-  "webAuthnPolicyCreateTimeout" : 0,
-  "webAuthnPolicyAvoidSameAuthenticatorRegister" : false,
-  "webAuthnPolicyAcceptableAaguids" : [ ],
-  "webAuthnPolicyExtraOrigins" : [ ],
-  "webAuthnPolicyPasswordlessRpEntityName" : "keycloak",
-  "webAuthnPolicyPasswordlessSignatureAlgorithms" : [ "ES256" ],
-  "webAuthnPolicyPasswordlessRpId" : "",
-  "webAuthnPolicyPasswordlessAttestationConveyancePreference" : "not specified",
-  "webAuthnPolicyPasswordlessAuthenticatorAttachment" : "not specified",
-  "webAuthnPolicyPasswordlessRequireResidentKey" : "not specified",
-  "webAuthnPolicyPasswordlessUserVerificationRequirement" : "not specified",
-  "webAuthnPolicyPasswordlessCreateTimeout" : 0,
-  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister" : false,
-  "webAuthnPolicyPasswordlessAcceptableAaguids" : [ ],
-  "webAuthnPolicyPasswordlessExtraOrigins" : [ ],
-  "users" : [ {
-    "id" : "d06b336b-8343-4253-b5e5-e6dace5cff0c",
-    "username" : "ferroehr-admin",
-    "email" : "ferroehr-admin@test.de",
-    "emailVerified" : true,
-    "attributes" : {
-      "locale" : [ "en" ]
-    },
-    "createdTimestamp" : 1716991758389,
-    "enabled" : true,
-    "totp" : false,
-    "credentials" : [ {
-      "id" : "f851ff40-861e-426f-ac38-be4f37160e5a",
-      "type" : "password",
-      "userLabel" : "My password",
-      "createdDate" : 1716991949487,
-      "secretData" : "{\"value\":\"nPQg0BnKeZe89vi3j37k63iJPCI9n6aPVWYybBDY5LhoSmwp+BkpEtrbTnjGkLumfidOSJ64+nufMGPu5ROzzA==\",\"salt\":\"gxobrk6vbKXe1Kv3B1Nmow==\",\"additionalParameters\":{}}",
-      "credentialData" : "{\"hashIterations\":210000,\"algorithm\":\"pbkdf2-sha512\",\"additionalParameters\":{}}"
-    } ],
-    "disableableCredentialTypes" : [ ],
-    "requiredActions" : [ ],
-    "realmRoles" : [ "ADMIN" ],
-    "notBefore" : 0,
-    "groups" : [ ]
-  }, {
-    "id" : "aca7c611-779e-4f68-99fb-06cc57e7ed26",
-    "username" : "ferroehr-user",
-    "email" : "ferroehr-user@test.de",
-    "emailVerified" : true,
-    "attributes" : {
-      "locale" : [ "en" ]
-    },
-    "createdTimestamp" : 1716991714172,
-    "enabled" : true,
-    "totp" : false,
-    "credentials" : [ {
-      "id" : "a098e3a5-60bf-492d-b605-75e62cf3df95",
-      "type" : "password",
-      "userLabel" : "My password",
-      "createdDate" : 1716991976476,
-      "secretData" : "{\"value\":\"UPfyDt7fu/VPsIh/1QQjS6koH0envCLzqKrX91Hh3z2pd/aQLwmvfJ0gLbmSNHt/vNL9bU0L2IwDhPN+46m2nQ==\",\"salt\":\"+GuxblKXjF6SUrKwfQJEHg==\",\"additionalParameters\":{}}",
-      "credentialData" : "{\"hashIterations\":210000,\"algorithm\":\"pbkdf2-sha512\",\"additionalParameters\":{}}"
-    } ],
-    "disableableCredentialTypes" : [ ],
-    "requiredActions" : [ ],
-    "realmRoles" : [ "USER" ],
-    "notBefore" : 0,
-    "groups" : [ ]
-  }, {
-    "id" : "48f25621-f66f-4299-b12c-79282e599b05",
-    "username" : "service-account-ferroehr",
-    "emailVerified" : false,
-    "createdTimestamp" : 1688738365099,
-    "enabled" : true,
-    "totp" : false,
-    "serviceAccountClientId" : "ferroehr",
-    "credentials" : [ ],
-    "disableableCredentialTypes" : [ ],
-    "requiredActions" : [ "TERMS_AND_CONDITIONS", "VERIFY_EMAIL", "UPDATE_PASSWORD", "UPDATE_PROFILE" ],
-    "realmRoles" : [ "default-roles-cdr-core-sanity-check" ],
-    "clientRoles" : {
-      "ferroehr" : [ "uma_protection" ]
-    },
-    "notBefore" : 0,
-    "groups" : [ ]
-  } ],
-  "scopeMappings" : [ {
-    "clientScope" : "offline_access",
-    "roles" : [ "offline_access" ]
-  } ],
-  "clientScopeMappings" : {
-    "account" : [ {
-      "client" : "account-console",
-      "roles" : [ "manage-account", "view-groups" ]
-    } ]
-  },
-  "clients" : [ {
-    "id" : "54161586-b938-487e-bd77-340b17f9e4c4",
-    "clientId" : "account",
-    "name" : "${client_account}",
-    "rootUrl" : "${authBaseUrl}",
-    "baseUrl" : "/realms/ferroehr/account/",
-    "surrogateAuthRequired" : false,
-    "enabled" : true,
-    "alwaysDisplayInConsole" : false,
-    "clientAuthenticatorType" : "client-secret",
-    "redirectUris" : [ "/realms/ferroehr/account/*" ],
-    "webOrigins" : [ ],
-    "notBefore" : 0,
-    "bearerOnly" : false,
-    "consentRequired" : false,
-    "standardFlowEnabled" : true,
-    "implicitFlowEnabled" : false,
-    "directAccessGrantsEnabled" : false,
-    "serviceAccountsEnabled" : false,
-    "publicClient" : true,
-    "frontchannelLogout" : false,
-    "protocol" : "openid-connect",
-    "attributes" : {
-      "post.logout.redirect.uris" : "+"
-    },
-    "authenticationFlowBindingOverrides" : { },
-    "fullScopeAllowed" : false,
-    "nodeReRegistrationTimeout" : 0,
-    "defaultClientScopes" : [ ],
-    "optionalClientScopes" : [ ]
-  }, {
-    "id" : "cc1e3247-dc40-4c07-b0d2-78c8dfddbdc3",
-    "clientId" : "account-console",
-    "name" : "${client_account-console}",
-    "rootUrl" : "${authBaseUrl}",
-    "baseUrl" : "/realms/ferroehr/account/",
-    "surrogateAuthRequired" : false,
-    "enabled" : true,
-    "alwaysDisplayInConsole" : false,
-    "clientAuthenticatorType" : "client-secret",
-    "redirectUris" : [ "/realms/ferroehr/account/*" ],
-    "webOrigins" : [ ],
-    "notBefore" : 0,
-    "bearerOnly" : false,
-    "consentRequired" : false,
-    "standardFlowEnabled" : true,
-    "implicitFlowEnabled" : false,
-    "directAccessGrantsEnabled" : false,
-    "serviceAccountsEnabled" : false,
-    "publicClient" : true,
-    "frontchannelLogout" : false,
-    "protocol" : "openid-connect",
-    "attributes" : {
-      "post.logout.redirect.uris" : "+",
-      "pkce.code.challenge.method" : "S256"
-    },
-    "authenticationFlowBindingOverrides" : { },
-    "fullScopeAllowed" : false,
-    "nodeReRegistrationTimeout" : 0,
-    "protocolMappers" : [ {
-      "id" : "da01db37-b0bb-4822-932d-73a120155e9b",
-      "name" : "audience resolve",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-audience-resolve-mapper",
-      "consentRequired" : false,
-      "config" : { }
-    } ],
-    "defaultClientScopes" : [ ],
-    "optionalClientScopes" : [ ]
-  }, {
-    "id" : "9ed4c5dc-6e75-40a4-a15a-f61ce8a215a3",
-    "clientId" : "admin-cli",
-    "name" : "${client_admin-cli}",
-    "surrogateAuthRequired" : false,
-    "enabled" : true,
-    "alwaysDisplayInConsole" : false,
-    "clientAuthenticatorType" : "client-secret",
-    "redirectUris" : [ ],
-    "webOrigins" : [ ],
-    "notBefore" : 0,
-    "bearerOnly" : false,
-    "consentRequired" : false,
-    "standardFlowEnabled" : false,
-    "implicitFlowEnabled" : false,
-    "directAccessGrantsEnabled" : true,
-    "serviceAccountsEnabled" : false,
-    "publicClient" : true,
-    "frontchannelLogout" : false,
-    "protocol" : "openid-connect",
-    "attributes" : {
-      "post.logout.redirect.uris" : "+"
-    },
-    "authenticationFlowBindingOverrides" : { },
-    "fullScopeAllowed" : false,
-    "nodeReRegistrationTimeout" : 0,
-    "defaultClientScopes" : [ ],
-    "optionalClientScopes" : [ ]
-  }, {
-    "id" : "a2e78276-afcc-4424-8977-0c59a4de7215",
-    "clientId" : "broker",
-    "name" : "${client_broker}",
-    "surrogateAuthRequired" : false,
-    "enabled" : true,
-    "alwaysDisplayInConsole" : false,
-    "clientAuthenticatorType" : "client-secret",
-    "redirectUris" : [ ],
-    "webOrigins" : [ ],
-    "notBefore" : 0,
-    "bearerOnly" : true,
-    "consentRequired" : false,
-    "standardFlowEnabled" : true,
-    "implicitFlowEnabled" : false,
-    "directAccessGrantsEnabled" : false,
-    "serviceAccountsEnabled" : false,
-    "publicClient" : false,
-    "frontchannelLogout" : false,
-    "protocol" : "openid-connect",
-    "attributes" : {
-      "post.logout.redirect.uris" : "+"
-    },
-    "authenticationFlowBindingOverrides" : { },
-    "fullScopeAllowed" : false,
-    "nodeReRegistrationTimeout" : 0,
-    "defaultClientScopes" : [ ],
-    "optionalClientScopes" : [ ]
-  }, {
-    "id" : "6bf4fbb5-e031-49e1-b2b3-de38dd7938b7",
-    "clientId" : "ferroehr",
-    "name" : "FerroEHR",
-    "description" : "",
-    "rootUrl" : "",
-    "adminUrl" : "",
-    "baseUrl" : "",
-    "surrogateAuthRequired" : false,
-    "enabled" : true,
-    "alwaysDisplayInConsole" : false,
-    "clientAuthenticatorType" : "client-secret",
-    "secret" : "bT5T4oWn3xNdBytQsl2cfpBDi1pp15Va",
-    "redirectUris" : [ "/*" ],
-    "webOrigins" : [ ],
-    "notBefore" : 0,
-    "bearerOnly" : false,
-    "consentRequired" : false,
-    "standardFlowEnabled" : true,
-    "implicitFlowEnabled" : false,
-    "directAccessGrantsEnabled" : true,
-    "serviceAccountsEnabled" : true,
-    "authorizationServicesEnabled" : true,
-    "publicClient" : false,
-    "frontchannelLogout" : false,
-    "protocol" : "openid-connect",
-    "attributes" : {
-      "oidc.ciba.grant.enabled" : "false",
-      "client.secret.creation.time" : "1696233968",
-      "backchannel.logout.session.required" : "true",
-      "post.logout.redirect.uris" : "+",
-      "display.on.consent.screen" : "false",
-      "oauth2.device.authorization.grant.enabled" : "false",
-      "backchannel.logout.revoke.offline.tokens" : "false"
-    },
-    "authenticationFlowBindingOverrides" : { },
-    "fullScopeAllowed" : true,
-    "nodeReRegistrationTimeout" : -1,
-    "protocolMappers" : [ {
-      "id" : "5298cf35-97a6-4965-bf64-07e639898524",
-      "name" : "Client Host",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "user.session.note" : "clientHost",
-        "userinfo.token.claim" : "true",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "clientHost",
-        "jsonType.label" : "String"
+  ],
+  "authenticatorConfig": [
+    {
+      "id": "17a733e8-c264-42fc-b89f-c1598551adef",
+      "alias": "create unique user config",
+      "config": {
+        "require.password.update.after.registration": "false"
       }
-    }, {
-      "id" : "992a2bac-5c38-4ae4-8938-a83ecbc914e8",
-      "name" : "Client IP Address",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "user.session.note" : "clientAddress",
-        "userinfo.token.claim" : "true",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "clientAddress",
-        "jsonType.label" : "String"
+    },
+    {
+      "id": "ccbf5b7b-7dd2-49ae-ae69-c438d8163ba0",
+      "alias": "review profile config",
+      "config": {
+        "update.profile.on.first.login": "missing"
       }
-    }, {
-      "id" : "df7d4ce9-5b37-4ca1-80ad-30ad38f0c310",
-      "name" : "Client ID",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "user.session.note" : "clientId",
-        "userinfo.token.claim" : "true",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "clientId",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "fed7572e-0aac-4c54-a866-3299db0f5844",
-      "name" : "tenant_id",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-hardcoded-claim-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "claim.value" : "ca3e0ff6-5282-4d18-b860-8d28d7ac1b86",
-        "userinfo.token.claim" : "true",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "tnt",
-        "access.tokenResponse.claim" : "false"
-      }
-    } ],
-    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email", "hip-scope-ca3e0ff6-5282-4d18-b" ],
-    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ],
-    "authorizationSettings" : {
-      "allowRemoteResourceManagement" : true,
-      "policyEnforcementMode" : "ENFORCING",
-      "resources" : [ ],
-      "policies" : [ ],
-      "scopes" : [ ],
-      "decisionStrategy" : "UNANIMOUS"
     }
-  }, {
-    "id" : "42198dc6-1c53-4135-bf8e-958f4aee8858",
-    "clientId" : "realm-management",
-    "name" : "${client_realm-management}",
-    "surrogateAuthRequired" : false,
-    "enabled" : true,
-    "alwaysDisplayInConsole" : false,
-    "clientAuthenticatorType" : "client-secret",
-    "redirectUris" : [ ],
-    "webOrigins" : [ ],
-    "notBefore" : 0,
-    "bearerOnly" : true,
-    "consentRequired" : false,
-    "standardFlowEnabled" : true,
-    "implicitFlowEnabled" : false,
-    "directAccessGrantsEnabled" : false,
-    "serviceAccountsEnabled" : false,
-    "publicClient" : false,
-    "frontchannelLogout" : false,
-    "protocol" : "openid-connect",
-    "attributes" : {
-      "post.logout.redirect.uris" : "+"
+  ],
+  "requiredActions": [
+    {
+      "alias": "CONFIGURE_TOTP",
+      "name": "Configure OTP",
+      "providerId": "CONFIGURE_TOTP",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 10,
+      "config": {}
     },
-    "authenticationFlowBindingOverrides" : { },
-    "fullScopeAllowed" : false,
-    "nodeReRegistrationTimeout" : 0,
-    "defaultClientScopes" : [ ],
-    "optionalClientScopes" : [ ]
-  }, {
-    "id" : "50209af3-f537-45a8-b148-6db3f52bc49d",
-    "clientId" : "security-admin-console",
-    "name" : "${client_security-admin-console}",
-    "rootUrl" : "${authAdminUrl}",
-    "baseUrl" : "/admin/ferroehr/console/",
-    "surrogateAuthRequired" : false,
-    "enabled" : true,
-    "alwaysDisplayInConsole" : false,
-    "clientAuthenticatorType" : "client-secret",
-    "redirectUris" : [ "/admin/ferroehr/console/*" ],
-    "webOrigins" : [ "+" ],
-    "notBefore" : 0,
-    "bearerOnly" : false,
-    "consentRequired" : false,
-    "standardFlowEnabled" : true,
-    "implicitFlowEnabled" : false,
-    "directAccessGrantsEnabled" : false,
-    "serviceAccountsEnabled" : false,
-    "publicClient" : true,
-    "frontchannelLogout" : false,
-    "protocol" : "openid-connect",
-    "attributes" : {
-      "post.logout.redirect.uris" : "+",
-      "pkce.code.challenge.method" : "S256"
+    {
+      "alias": "VERIFY_EMAIL",
+      "name": "Verify Email",
+      "providerId": "VERIFY_EMAIL",
+      "enabled": true,
+      "defaultAction": true,
+      "priority": 10,
+      "config": {}
     },
-    "authenticationFlowBindingOverrides" : { },
-    "fullScopeAllowed" : false,
-    "nodeReRegistrationTimeout" : 0,
-    "protocolMappers" : [ {
-      "id" : "f0447a0e-e245-43a1-9110-6ccd4bca519a",
-      "name" : "locale",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "locale",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "locale",
-        "jsonType.label" : "String"
-      }
-    } ],
-    "defaultClientScopes" : [ ],
-    "optionalClientScopes" : [ ]
-  } ],
-  "clientScopes" : [ {
-    "id" : "c39c4c37-bc5a-44b3-b5b8-9da88e838c79",
-    "name" : "profile",
-    "description" : "OpenID Connect built-in scope: profile",
-    "protocol" : "openid-connect",
-    "attributes" : {
-      "include.in.token.scope" : "true",
-      "display.on.consent.screen" : "true",
-      "consent.screen.text" : "${profileScopeConsentText}"
+    {
+      "alias": "UPDATE_PROFILE",
+      "name": "Update Profile",
+      "providerId": "UPDATE_PROFILE",
+      "enabled": true,
+      "defaultAction": true,
+      "priority": 20,
+      "config": {}
     },
-    "protocolMappers" : [ {
-      "id" : "485925ca-f501-4544-958f-d3b322ad8261",
-      "name" : "updated at",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "updatedAt",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "updated_at",
-        "jsonType.label" : "long"
-      }
-    }, {
-      "id" : "a53cf2dd-c64b-4348-a0dc-251be30ed3cf",
-      "name" : "website",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "website",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "website",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "5fa55c53-cbfa-4a04-ad5c-cc0ae6d9dbb8",
-      "name" : "full name",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-full-name-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "userinfo.token.claim" : "true"
-      }
-    }, {
-      "id" : "8d9a4e04-85c7-4ab3-993c-6952bf1bc99d",
-      "name" : "given name",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-property-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "firstName",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "given_name",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "7c3be8a7-ecbd-4b9b-a626-f356584d7686",
-      "name" : "zoneinfo",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "zoneinfo",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "zoneinfo",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "c98bb606-5da8-43b0-91ea-bf34382cf0b6",
-      "name" : "username",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-property-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "username",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "preferred_username",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "5ca52951-8662-49aa-a3bd-0d81822a8f41",
-      "name" : "birthdate",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "birthdate",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "birthdate",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "b731b7e0-3a75-493a-b658-6b1400cfda5b",
-      "name" : "gender",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "gender",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "gender",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "bee3a4ec-f696-42a3-9ad3-db69dd3fbb6b",
-      "name" : "family name",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-property-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "lastName",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "family_name",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "97d30e24-c73c-4fe6-8249-0ed29d8c68f9",
-      "name" : "locale",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "locale",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "locale",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "88c6eef4-e6c1-4171-a902-acf197b13dea",
-      "name" : "profile",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "profile",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "profile",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "3670907b-1b5c-48b7-b5de-19b446d7315d",
-      "name" : "nickname",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "nickname",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "nickname",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "7839f90b-5204-43eb-b68c-3caeaa6c0f80",
-      "name" : "picture",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "picture",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "picture",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "34b8420a-b6a7-4b7b-9506-73a5e18f528f",
-      "name" : "middle name",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "middleName",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "middle_name",
-        "jsonType.label" : "String"
-      }
-    } ]
-  }, {
-    "id" : "a10677ca-553e-4aa5-8be5-d5bc3f94d145",
-    "name" : "address",
-    "description" : "OpenID Connect built-in scope: address",
-    "protocol" : "openid-connect",
-    "attributes" : {
-      "include.in.token.scope" : "true",
-      "display.on.consent.screen" : "true",
-      "consent.screen.text" : "${addressScopeConsentText}"
+    {
+      "alias": "UPDATE_PASSWORD",
+      "name": "Update Password",
+      "providerId": "UPDATE_PASSWORD",
+      "enabled": true,
+      "defaultAction": true,
+      "priority": 30,
+      "config": {}
     },
-    "protocolMappers" : [ {
-      "id" : "10339fb9-fb22-42c4-bd5e-011d6ce1c115",
-      "name" : "address",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-address-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "user.attribute.formatted" : "formatted",
-        "user.attribute.country" : "country",
-        "user.attribute.postal_code" : "postal_code",
-        "userinfo.token.claim" : "true",
-        "user.attribute.street" : "street",
-        "id.token.claim" : "true",
-        "user.attribute.region" : "region",
-        "access.token.claim" : "true",
-        "user.attribute.locality" : "locality"
-      }
-    } ]
-  }, {
-    "id" : "0594e35c-4353-4a61-bfda-3c628797b723",
-    "name" : "phone",
-    "description" : "OpenID Connect built-in scope: phone",
-    "protocol" : "openid-connect",
-    "attributes" : {
-      "include.in.token.scope" : "true",
-      "display.on.consent.screen" : "true",
-      "consent.screen.text" : "${phoneScopeConsentText}"
+    {
+      "alias": "TERMS_AND_CONDITIONS",
+      "name": "Terms and Conditions",
+      "providerId": "TERMS_AND_CONDITIONS",
+      "enabled": true,
+      "defaultAction": true,
+      "priority": 40,
+      "config": {}
     },
-    "protocolMappers" : [ {
-      "id" : "39cec2e6-49c8-49b9-a265-644595237587",
-      "name" : "phone number verified",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "phoneNumberVerified",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "phone_number_verified",
-        "jsonType.label" : "boolean"
-      }
-    }, {
-      "id" : "f4096e64-50f5-4243-bb16-fc6984913f94",
-      "name" : "phone number",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "phoneNumber",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "phone_number",
-        "jsonType.label" : "String"
-      }
-    } ]
-  }, {
-    "id" : "a3e60283-2d33-4ec6-8c76-510b40dbc202",
-    "name" : "role_list",
-    "description" : "SAML role list",
-    "protocol" : "saml",
-    "attributes" : {
-      "consent.screen.text" : "${samlRoleListScopeConsentText}",
-      "display.on.consent.screen" : "true"
+    {
+      "alias": "delete_account",
+      "name": "Delete Account",
+      "providerId": "delete_account",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 60,
+      "config": {}
     },
-    "protocolMappers" : [ {
-      "id" : "5199afb7-5507-40d4-9d32-6407591998b3",
-      "name" : "role list",
-      "protocol" : "saml",
-      "protocolMapper" : "saml-role-list-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "single" : "false",
-        "attribute.nameformat" : "Basic",
-        "attribute.name" : "Role"
-      }
-    } ]
-  }, {
-    "id" : "43194d99-8ea1-45f8-9eeb-873b1f3bc115",
-    "name" : "acr",
-    "description" : "OpenID Connect scope for add acr (authentication context class reference) to the token",
-    "protocol" : "openid-connect",
-    "attributes" : {
-      "include.in.token.scope" : "false",
-      "display.on.consent.screen" : "false"
+    {
+      "alias": "webauthn-register",
+      "name": "Webauthn Register",
+      "providerId": "webauthn-register",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 70,
+      "config": {}
     },
-    "protocolMappers" : [ {
-      "id" : "d03c6a78-cad9-42c5-a33b-6761b2d211d2",
-      "name" : "acr loa level",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-acr-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "userinfo.token.claim" : "true"
-      }
-    } ]
-  }, {
-    "id" : "9cbead67-1823-4d98-acd2-fc591a78c969",
-    "name" : "roles",
-    "description" : "OpenID Connect scope for add user roles to the access token",
-    "protocol" : "openid-connect",
-    "attributes" : {
-      "include.in.token.scope" : "false",
-      "display.on.consent.screen" : "true",
-      "consent.screen.text" : "${rolesScopeConsentText}"
+    {
+      "alias": "webauthn-register-passwordless",
+      "name": "Webauthn Register Passwordless",
+      "providerId": "webauthn-register-passwordless",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 80,
+      "config": {}
     },
-    "protocolMappers" : [ {
-      "id" : "b7f4031c-d8e2-45ab-a2f7-17bdfbe39923",
-      "name" : "audience resolve",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-audience-resolve-mapper",
-      "consentRequired" : false,
-      "config" : { }
-    }, {
-      "id" : "6804b9d0-2aea-431b-a376-34ed8be3b40c",
-      "name" : "realm roles",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "user.attribute" : "foo",
-        "access.token.claim" : "true",
-        "claim.name" : "realm_access.roles",
-        "jsonType.label" : "String",
-        "multivalued" : "true"
-      }
-    }, {
-      "id" : "dc5d2f14-ab59-4070-bf11-616901a481ae",
-      "name" : "client roles",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-client-role-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "user.attribute" : "foo",
-        "access.token.claim" : "true",
-        "claim.name" : "resource_access.${client_id}.roles",
-        "jsonType.label" : "String",
-        "multivalued" : "true"
-      }
-    } ]
-  }, {
-    "id" : "b1f8a2e0-965b-4b1c-a9d6-365362c7f7ed",
-    "name" : "web-origins",
-    "description" : "OpenID Connect scope for add allowed web origins to the access token",
-    "protocol" : "openid-connect",
-    "attributes" : {
-      "include.in.token.scope" : "false",
-      "display.on.consent.screen" : "false",
-      "consent.screen.text" : ""
+    {
+      "alias": "delete_credential",
+      "name": "Delete Credential",
+      "providerId": "delete_credential",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 100,
+      "config": {}
     },
-    "protocolMappers" : [ {
-      "id" : "555aa7ba-d1ad-432b-9c25-10ad85e0373c",
-      "name" : "allowed web origins",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-allowed-origins-mapper",
-      "consentRequired" : false,
-      "config" : { }
-    } ]
-  }, {
-    "id" : "003de353-d038-430d-9486-49306b45aee7",
-    "name" : "email",
-    "description" : "OpenID Connect built-in scope: email",
-    "protocol" : "openid-connect",
-    "attributes" : {
-      "include.in.token.scope" : "true",
-      "display.on.consent.screen" : "true",
-      "consent.screen.text" : "${emailScopeConsentText}"
-    },
-    "protocolMappers" : [ {
-      "id" : "6789c8e8-7cf4-4495-b38f-e03c0c3c6d02",
-      "name" : "email verified",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-property-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "emailVerified",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "email_verified",
-        "jsonType.label" : "boolean"
-      }
-    }, {
-      "id" : "5b79ea96-85b3-4f98-8133-e85056e700d5",
-      "name" : "email",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-property-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "email",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "email",
-        "jsonType.label" : "String"
-      }
-    } ]
-  }, {
-    "id" : "26a49187-cb72-4c42-b27e-f43645b734da",
-    "name" : "offline_access",
-    "description" : "OpenID Connect built-in scope: offline_access",
-    "protocol" : "openid-connect",
-    "attributes" : {
-      "consent.screen.text" : "${offlineAccessScopeConsentText}",
-      "display.on.consent.screen" : "true"
+    {
+      "alias": "update_user_locale",
+      "name": "Update User Locale",
+      "providerId": "update_user_locale",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 1000,
+      "config": {}
     }
-  }, {
-    "id" : "711a336d-3639-4a70-8cee-ef5b9c5fd953",
-    "name" : "microprofile-jwt",
-    "description" : "Microprofile - JWT built-in scope",
-    "protocol" : "openid-connect",
-    "attributes" : {
-      "include.in.token.scope" : "true",
-      "display.on.consent.screen" : "false"
-    },
-    "protocolMappers" : [ {
-      "id" : "f91ce935-d38f-4558-be19-7b8c53305f2e",
-      "name" : "groups",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "multivalued" : "true",
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "foo",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "groups",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "426dbe55-8104-4c88-991a-7192a2faae5d",
-      "name" : "upn",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-property-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "username",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "upn",
-        "jsonType.label" : "String"
-      }
-    } ]
-  }, {
-    "id" : "hip-scope-ca3e0ff6-5282-4d18-b",
-    "name" : "hip-scope-ca3e0ff6-5282-4d18-b",
-    "protocol" : "openid-connect",
-    "attributes" : {
-      "include.in.token.scope" : "true"
-    },
-    "protocolMappers" : [ {
-      "id" : "42bdcf9a-e3a8-4933-8e28-e7874818427d",
-      "name" : "selected-tenant-uuid-mapper",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "selected_tenant_uuid",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "set",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "a3cf1113-7d2e-4224-866c-e3fdba34436b",
-      "name" : "tenant-uuid-mapper",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "tenant_uuid",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "tnt",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "98f2e3b0-76d1-4c72-bf44-f0de4706a877",
-      "name" : "organization-uuid-mapper",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "organization_uuid",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "org",
-        "jsonType.label" : "String"
-      }
-    } ]
-  } ],
-  "defaultDefaultClientScopes" : [ "role_list", "profile", "email", "roles", "web-origins", "acr", "hip-scope-ca3e0ff6-5282-4d18-b" ],
-  "defaultOptionalClientScopes" : [ "offline_access", "address", "phone", "microprofile-jwt" ],
-  "browserSecurityHeaders" : {
-    "contentSecurityPolicyReportOnly" : "",
-    "xContentTypeOptions" : "nosniff",
-    "referrerPolicy" : "no-referrer",
-    "xRobotsTag" : "none",
-    "xFrameOptions" : "SAMEORIGIN",
-    "contentSecurityPolicy" : "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
-    "xXSSProtection" : "1; mode=block",
-    "strictTransportSecurity" : "max-age=31536000; includeSubDomains"
+  ],
+  "browserFlow": "browser",
+  "registrationFlow": "registration",
+  "directGrantFlow": "direct grant",
+  "resetCredentialsFlow": "reset credentials",
+  "clientAuthenticationFlow": "clients",
+  "dockerAuthenticationFlow": "docker auth",
+  "firstBrokerLoginFlow": "first broker login",
+  "attributes": {
+    "cibaBackchannelTokenDeliveryMode": "poll",
+    "cibaAuthRequestedUserHint": "login_hint",
+    "provisioning_state": "[]",
+    "clientOfflineSessionMaxLifespan": "0",
+    "oauth2DevicePollingInterval": "5",
+    "clientSessionIdleTimeout": "0",
+    "organization_uuid": "2e92f530-c97b-48e1-923a-05c481a41f26",
+    "clientOfflineSessionIdleTimeout": "0",
+    "cibaInterval": "5",
+    "realmReusableOtpCode": "false",
+    "cibaExpiresIn": "120",
+    "oauth2DeviceCodeLifespan": "600",
+    "tenant_url": "",
+    "parRequestUriLifespan": "60",
+    "clientSessionMaxLifespan": "0",
+    "frontendUrl": "",
+    "acr.loa.map": "{}"
   },
-  "smtpServer" : {
-    "password" : "**********",
-    "starttls" : "true",
-    "auth" : "true",
-    "port" : "465",
-    "host" : "mail.vitasystems.dev",
-    "from" : "cdt-dev@vitasystems.dev",
-    "ssl" : "true",
-    "user" : "cdt-dev"
+  "keycloakVersion": "24.0.3",
+  "userManagedAccessAllowed": false,
+  "clientProfiles": {
+    "profiles": []
   },
-  "loginTheme" : "vitagroup",
-  "emailTheme" : "vitagroup",
-  "eventsEnabled" : false,
-  "eventsListeners" : [ "jboss-logging" ],
-  "enabledEventTypes" : [ ],
-  "adminEventsEnabled" : false,
-  "adminEventsDetailsEnabled" : false,
-  "identityProviders" : [ ],
-  "identityProviderMappers" : [ ],
-  "components" : {
-    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" : [ {
-      "id" : "59a32fb9-5d19-4e04-811b-be2e5457adb5",
-      "name" : "Allowed Client Scopes",
-      "providerId" : "allowed-client-templates",
-      "subType" : "anonymous",
-      "subComponents" : { },
-      "config" : {
-        "allow-default-scopes" : [ "true" ]
-      }
-    }, {
-      "id" : "d0fe175e-6352-473a-9973-7b8505deddff",
-      "name" : "Allowed Protocol Mapper Types",
-      "providerId" : "allowed-protocol-mappers",
-      "subType" : "anonymous",
-      "subComponents" : { },
-      "config" : {
-        "allowed-protocol-mapper-types" : [ "oidc-full-name-mapper", "saml-user-property-mapper", "saml-role-list-mapper", "oidc-address-mapper", "oidc-usermodel-attribute-mapper", "saml-user-attribute-mapper", "oidc-usermodel-property-mapper", "oidc-sha256-pairwise-sub-mapper" ]
-      }
-    }, {
-      "id" : "b08207ff-99f3-4679-967e-07e0a9e7e37e",
-      "name" : "Full Scope Disabled",
-      "providerId" : "scope",
-      "subType" : "anonymous",
-      "subComponents" : { },
-      "config" : { }
-    }, {
-      "id" : "41620ac1-14da-424b-ba81-cea7168f20aa",
-      "name" : "Consent Required",
-      "providerId" : "consent-required",
-      "subType" : "anonymous",
-      "subComponents" : { },
-      "config" : { }
-    }, {
-      "id" : "3157e10f-aa9e-42b4-94d2-d8fb640d13ba",
-      "name" : "Allowed Client Scopes",
-      "providerId" : "allowed-client-templates",
-      "subType" : "authenticated",
-      "subComponents" : { },
-      "config" : {
-        "allow-default-scopes" : [ "true" ]
-      }
-    }, {
-      "id" : "1d4bf3b0-8f72-4983-b571-2793484d3327",
-      "name" : "Trusted Hosts",
-      "providerId" : "trusted-hosts",
-      "subType" : "anonymous",
-      "subComponents" : { },
-      "config" : {
-        "host-sending-registration-request-must-match" : [ "true" ],
-        "client-uris-must-match" : [ "true" ]
-      }
-    }, {
-      "id" : "18f1970a-5127-40e6-bdba-1b7455922490",
-      "name" : "Max Clients Limit",
-      "providerId" : "max-clients",
-      "subType" : "anonymous",
-      "subComponents" : { },
-      "config" : {
-        "max-clients" : [ "200" ]
-      }
-    }, {
-      "id" : "f2546877-7cb2-45ad-a487-092916848bea",
-      "name" : "Allowed Protocol Mapper Types",
-      "providerId" : "allowed-protocol-mappers",
-      "subType" : "authenticated",
-      "subComponents" : { },
-      "config" : {
-        "allowed-protocol-mapper-types" : [ "oidc-address-mapper", "saml-user-attribute-mapper", "saml-role-list-mapper", "oidc-usermodel-property-mapper", "oidc-usermodel-attribute-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-user-property-mapper", "oidc-full-name-mapper" ]
-      }
-    } ],
-    "org.keycloak.userprofile.UserProfileProvider" : [ {
-      "id" : "22a6839a-62d7-4dec-b8a8-667498a41bb4",
-      "providerId" : "declarative-user-profile",
-      "subComponents" : { },
-      "config" : {
-        "kc.user.profile.config" : [ "{\"attributes\":[{\"name\":\"username\",\"displayName\":\"${username}\",\"validations\":{\"length\":{\"min\":3,\"max\":255},\"username-prohibited-characters\":{},\"up-username-not-idn-homograph\":{}},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"email\",\"displayName\":\"${email}\",\"validations\":{\"email\":{},\"length\":{\"max\":255}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"firstName\",\"displayName\":\"${firstName}\",\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"lastName\",\"displayName\":\"${lastName}\",\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false}],\"groups\":[{\"name\":\"user-metadata\",\"displayHeader\":\"User metadata\",\"displayDescription\":\"Attributes, which refer to user metadata\"}],\"unmanagedAttributePolicy\":\"ENABLED\"}" ]
-      }
-    } ],
-    "org.keycloak.keys.KeyProvider" : [ {
-      "id" : "ded58cac-ea24-406e-b43a-6dfe156a1156",
-      "name" : "hmac-generated",
-      "providerId" : "hmac-generated",
-      "subComponents" : { },
-      "config" : {
-        "kid" : [ "462a27c8-3e87-4b84-a96d-30515703c6c4" ],
-        "secret" : [ "szxaUOTYngHiyPVaL8jkWc_eUvgQQjaTvQLDTV4tO-OZBp1W4kW62BALXbKlF48WJo8_A-CwFkWYupYUF4-OesFA1zW8oarwTfNDYnwuhuTZtUe5td2c0hcwt7dwhuo9gUUWUOXsbycOIGL5uQpFvhx0xlsn_R2JG1BQy90v8ik" ],
-        "priority" : [ "100" ],
-        "algorithm" : [ "HS256" ]
-      }
-    }, {
-      "id" : "07079ca0-51a5-4eba-8b8b-d403a648a101",
-      "name" : "rsa-generated",
-      "providerId" : "rsa-generated",
-      "subComponents" : { },
-      "config" : {
-        "privateKey" : [ "MIIEpAIBAAKCAQEA2b1cmURklORMn077bgtCivUGZsUVdDlKpUto+7BvqaiQG/bAS96T+G3s+Gt4SWLkHfUTa9LwBGuq89OoWKIVKFJWZzvipUSXRjo3N2Ha2/e+RhqbIMbeXygijVe+Lsujj1ZZdDv848wEnpG1C2BsX2qUvFuxM7IJm8NmLdbxhAYni6YGMil/J3gt7WUYf/8xMtl+pI7XKHEFlzn9/CY45ThcJtqsBM2/U9VTMCBA8oXmL8KG88qUaCMy3c4ObJP/XkJJWGKeii60zW2ufBWSvtFRhdt461t8s9UlvdlFGdVKW+AjtG57BfU6ja/WNBooFKHgmM/iP9rmT2mX9fVRSwIDAQABAoIBAAj8jJioyXaZsOM2/nU4EsArGl9dzU5gL56rLO3iW3bG8GJZve2uWzC60g0eBmIPqkw65APPD2fnTQVw3AxYbYNzWSyRPKqcg5p65vIqtZPe4Y6sJMXmtKEnG2dLp/DvfP8lTbODPE3nNYjuiOiAy3LpXQfPHaeoC/HOpTt0GRYH8Ct109I0YbmSby4H/OKnqYmOoS2vmRJMzRBIbrfaT8BYL6y1iXNe/L+3YQa0OreQ1sh7HpubuqcuyGz/mFhMDUbaPsda8+OAVC6RmnAVqZgn6kvDNRxc0GWlWDCktl/vn6pFptELFdlN9/WTSBERzA37DRkAVVN1hLwhJAzSkTUCgYEA8PDzoLboaQVYx3GrtunRPKwUplGcZWGzmaN2RPZV2Bff47hnaROMCo24ZnKnY5mAXchVRAEobbevU1oXKDYQMMDpsZ2GqA/g2xW4W/elnnQFlbQ2poqs/jiGuHiwjA7XeektZld5BHQ5XHb+zsWeQ8maGypRfSlLjxwtvxJm158CgYEA51kvznS4ZMWvtfD9XDnFAb2BZ1W6jDk9yh3NoPzButOhMBW/W2azoc9MGSsUL2iuHE3x4gJkOnJrK9XNM/14II4XHgGl2ZFkjEqmWhpMfhzwceJRHrPZuPHbv3iHehb22SZGC/63k0XkklYtAES1/gavtkiMJowTrxB6qLO71tUCgYEA0FmMU43Xq/lTrCQ/uQy4Qx8LPEeWVpUGGfWgcEIUOalrkiAETHj6wKWMsAq1dQtoVbDHCud1bmtI0Ws2Wy9lEMPBUjZGG06fwtQleGHOdhcePTZ5i8qfjbaTyTGUeYjcDC/3cmhx3cgjUjIUZfm9wiCzgoo1rWXoUPitFm1zQUECgYEAtyudN1ig2mDO8z4AS/INcohJmbh9wCJeMtYQBiO5e6Ot3rWJUePp2/aWaOL702GNYSmxluGP29rV0dow47YPU69MzFw/pRiBxLYiKfrij4N4OKMY2TdK7izIcTwL//WIsnukQEEHthpDlD2Y2bqNYbiHjMq59Jc5yoVAqKvN0JUCgYA+/DgLFGkS+77cj0sca6Yt4U2ytNHuhsnEDx+RjDOR/I8ymcU+sJBw0NT+cCUl/65UZVvFuBvFQ+jAQPLs03P2Pa3yReHtWTZ6OFeV7Q3K5EZwM6HDXF6oTLrl+cLG+8mlThx0S+0UACzlcZGkbcVA9GqJhdIJiTrnBfPpnes3lA==" ],
-        "certificate" : [ "MIICuTCCAaECBgGK72wUEDANBgkqhkiG9w0BAQsFADAgMR4wHAYDVQQDDBVjZHItY29yZS1zYW5pdHktY2hlY2swHhcNMjMxMDAyMDgwNDEyWhcNMzMxMDAyMDgwNTUyWjAgMR4wHAYDVQQDDBVjZHItY29yZS1zYW5pdHktY2hlY2swggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDZvVyZRGSU5EyfTvtuC0KK9QZmxRV0OUqlS2j7sG+pqJAb9sBL3pP4bez4a3hJYuQd9RNr0vAEa6rz06hYohUoUlZnO+KlRJdGOjc3Ydrb975GGpsgxt5fKCKNV74uy6OPVll0O/zjzASekbULYGxfapS8W7Ezsgmbw2Yt1vGEBieLpgYyKX8neC3tZRh//zEy2X6kjtcocQWXOf38JjjlOFwm2qwEzb9T1VMwIEDyheYvwobzypRoIzLdzg5sk/9eQklYYp6KLrTNba58FZK+0VGF23jrW3yz1SW92UUZ1Upb4CO0bnsF9TqNr9Y0GigUoeCYz+I/2uZPaZf19VFLAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAF/hyDobpxspcPow/wOkhKtCLjANKLs0q/+swyYxCO71KT5RMDAQLC1u6/H6uHU4dqSbXH6HRNsC/AzMg3AUWnJwlECXqtfNNYMmtyQaOIpPUxLrXSTHF2xm83z+egO/C0pNgoPJXqxASyt1E8+Lqi5PGMS0vUjjryBtEvieQi4WX6BqFn1Vtqt2wHIZDwbB8Wjei5xsAFbbYnjTPDm/rooa8CZG/AXqLWjPFScJRnEKCZhQ3cq0OKmwXKPGBOMbI8nGYDgt41i/fyBPzKom2iR/fSxpiHfQUeFmu6GYRTJbBPy9zaRUIjCCNU1QwUp/K6iHoyr9JcW40mi666mGPJ0=" ],
-        "priority" : [ "100" ]
-      }
-    }, {
-      "id" : "5eba2551-adb6-4136-b9e0-bebc9448b384",
-      "name" : "hmac-generated-hs512",
-      "providerId" : "hmac-generated",
-      "subComponents" : { },
-      "config" : {
-        "kid" : [ "f49268c7-20ad-42ab-b231-a86550980747" ],
-        "secret" : [ "zCLMCDV5EnuKyGNFudo71SHljzaOSSjMIMqOLBOZpe3gOQUmdgUMaBPG52djQ9aNUiYoltm2w6QgLlmFY4keGeQ60psLoGqcwgcMKQnxnM7a4KcRpB3vgaJEAYuGaVcV-G7IiOlccwpzmnNMAPy53oqz64TFtqunc3PyepeM0zs" ],
-        "priority" : [ "100" ],
-        "algorithm" : [ "HS512" ]
-      }
-    }, {
-      "id" : "97b477fb-4c0e-4556-8b0f-814043dab0d1",
-      "name" : "rsa-enc-generated",
-      "providerId" : "rsa-enc-generated",
-      "subComponents" : { },
-      "config" : {
-        "privateKey" : [ "MIIEowIBAAKCAQEArJv4sEsFxmkHoN7MQrIUWuj+BkcPlCKqj2Bp/+IiyspEt49T6j67mTofRfoRq59yV9Ij9B43fcy+U7HAltxJWGXPc1BQ05S4xWhgLpF0FBRqUXJ2YbYfG89TzUEJZxmJ0WgjzMZx1/hsq3WBg5S5b391mULL7Ogj88eqMxdZIa/t2kWNAizoRWhaJpmmvO+WakQKwHFnrFb5Dj+RzwaL1lyByzLLveWc/jeNP+48m/to1TocE95JEcySz5HOO1Z6x3gFDS0odYyDs0deeK7eFusJUvD4BycUmFUCnFo+K5037YF1evpEP2q4CIOSVyLbjW2KqYBSk4Biy2vptv/CYwIDAQABAoIBADNSqxbML9rndt+z73szVQ8U8RcvwOeUiS9ZhRsTA7JVgyorQVHItmIgoJTffqqPneGT96HJ7EkI/FyJYVDaDirtFspcSrQmp+v2lYazNBcWXOh7xsxV6RkNRAcnO+L+enab5u0n4kjLspAmv8w+iAapmO9pp5X5DluZdjd7zUJQ/oXtlUerc3bkNgFLDX8LSkhs80+A0dh1BMVBkQCOLmos7qVRDsXPW+2zxZ7oo0/thlOO+OtFRryBufi+YynLlbrrfKWlVPBy6hjchPa8MPxOEni5BS0xXvmWmuQRONSnOUeZ6yILhhqMWBONYGf7D7BDG8UjF2zUUJlofHvyGf0CgYEA3zq1CoFrX4+rmbXuj6KBbNRRUm5TDOleV2oBT80rD35dMSyVTy80OHlAiz2N46XMx4YpLXNS5vNJHzWWKzfry4qe6K4Rs3hHc27I6lRgO4VRG3kDEB3w5mpNIwikUOGsILgbhm054cIJ5BFI1idor9DpJ3mjwupQxFxkVXkE2aUCgYEAxfLi7ISETJ85aAappd1xdlFf+tXlqZn6Yds7RAWw6HqOl7jSSMCPdmKkG3QwHhlfX2rpzZBdAi4qxLzj/1cDP2ZYkWqisPUZrVBUQkuqG26VQwDeToKwAca5e7zhp997oYU3wnq10FYa3sdzHvYKsZaNketwEOMQ2H9lxmGqnWcCgYAlt2SZVs6OgdbLjMq26A0YFzN6SvurRc7T1CxOkGrDHmWehlrf2yjmlc4K+KZ9nSjhWVChxkdukBJ9vG8X9EXZyR0aUTbabOsdnM1DkmgEBn1yt9qFoZlvROyti6s/ozGTAahc6R2LgF5tc2IsFNKCSjjqm4nIyBBHbRjivCTOpQKBgQClCpftP6fXAsKoWzXDV1isn7h4uTKdMAa05EcLtfsEOnr9QVoC0ppKyH+vbDZaQilksw1xGTaTBM8f7aXjVTcd+0VJKTGwfQsFl/5IsDGKYa8NiIHRz+DT+k7YPmmewBSiXSJagllo9QG+UWlInTfZTX+H9FchnVCEUeQXfYL1bQKBgBJVYBqE6qs3urg38Sj/322BkH19+Twep00JqQW6ZIivw/9dihHzXY+Rp/hjxZGwI41NRrhE5kmV2W32oL1l+x9vfYCBRSH653ZYAU9dRkztOIN6h1ORXgMx4eYKHPlxrrRJzod+9AkI2dXLPgsAGKo3QLyT963wNgoLGkzl+fth" ],
-        "certificate" : [ "MIICuTCCAaECBgGK72wVPTANBgkqhkiG9w0BAQsFADAgMR4wHAYDVQQDDBVjZHItY29yZS1zYW5pdHktY2hlY2swHhcNMjMxMDAyMDgwNDEyWhcNMzMxMDAyMDgwNTUyWjAgMR4wHAYDVQQDDBVjZHItY29yZS1zYW5pdHktY2hlY2swggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCsm/iwSwXGaQeg3sxCshRa6P4GRw+UIqqPYGn/4iLKykS3j1PqPruZOh9F+hGrn3JX0iP0Hjd9zL5TscCW3ElYZc9zUFDTlLjFaGAukXQUFGpRcnZhth8bz1PNQQlnGYnRaCPMxnHX+GyrdYGDlLlvf3WZQsvs6CPzx6ozF1khr+3aRY0CLOhFaFommaa875ZqRArAcWesVvkOP5HPBovWXIHLMsu95Zz+N40/7jyb+2jVOhwT3kkRzJLPkc47VnrHeAUNLSh1jIOzR154rt4W6wlS8PgHJxSYVQKcWj4rnTftgXV6+kQ/argIg5JXItuNbYqpgFKTgGLLa+m2/8JjAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAHhe1UqhYTXWbreHvNvFMd4CDXiKD+ISExF/wQFfLJTBMIaIWS6mVJ48wscxZeTMq+WlW9L42NtOb8eyiSSaWCuvhijUqf088wPD1ZOD8soUdiHcs1Z6W0dpSwGQfIrmCvucuDVab2owp+SyaITPQmnQWeaPf7exG1qMyAE0kev4ky0h9WaNYNWj0fQ1fgn+zAubpMeT7NenLc8mpqKQA+pIDg6vIDJDIqD6r346jxBj0s7DzCtgnxAnO5eV3zA5urqXUXgrdtjBResZOte4t1yiQ4MS/i0Ahoov/QtFTcUQRr1dwWS/o0BNO1tPw9MomqQyslL3XlKrBkuVuYFogIo=" ],
-        "priority" : [ "100" ],
-        "algorithm" : [ "RSA-OAEP" ]
-      }
-    }, {
-      "id" : "b541c7c1-d569-4367-8a38-381f9710932e",
-      "name" : "aes-generated",
-      "providerId" : "aes-generated",
-      "subComponents" : { },
-      "config" : {
-        "kid" : [ "eaad2638-ccaa-422e-beaf-e6ecbfb4fc4a" ],
-        "secret" : [ "ua7-NOK8Fk_G3L6w3wYWeg" ],
-        "priority" : [ "100" ]
-      }
-    } ]
-  },
-  "internationalizationEnabled" : true,
-  "supportedLocales" : [ "de", "en" ],
-  "defaultLocale" : "de",
-  "authenticationFlows" : [ {
-    "id" : "287ea54b-fe74-4aed-b495-83dd5ea33883",
-    "alias" : "Account verification options",
-    "description" : "Method with which to verity the existing account",
-    "providerId" : "basic-flow",
-    "topLevel" : false,
-    "builtIn" : true,
-    "authenticationExecutions" : [ {
-      "authenticator" : "idp-email-verification",
-      "authenticatorFlow" : false,
-      "requirement" : "ALTERNATIVE",
-      "priority" : 10,
-      "autheticatorFlow" : false,
-      "userSetupAllowed" : false
-    }, {
-      "authenticatorFlow" : true,
-      "requirement" : "ALTERNATIVE",
-      "priority" : 20,
-      "autheticatorFlow" : true,
-      "flowAlias" : "Verify Existing Account by Re-authentication",
-      "userSetupAllowed" : false
-    } ]
-  }, {
-    "id" : "44e4f079-2f74-4f8e-9f59-f5bf2ef1cb36",
-    "alias" : "Browser - Conditional OTP",
-    "description" : "Flow to determine if the OTP is required for the authentication",
-    "providerId" : "basic-flow",
-    "topLevel" : false,
-    "builtIn" : true,
-    "authenticationExecutions" : [ {
-      "authenticator" : "conditional-user-configured",
-      "authenticatorFlow" : false,
-      "requirement" : "REQUIRED",
-      "priority" : 10,
-      "autheticatorFlow" : false,
-      "userSetupAllowed" : false
-    }, {
-      "authenticator" : "auth-otp-form",
-      "authenticatorFlow" : false,
-      "requirement" : "REQUIRED",
-      "priority" : 20,
-      "autheticatorFlow" : false,
-      "userSetupAllowed" : false
-    } ]
-  }, {
-    "id" : "0d881e86-0935-4e27-8aaa-4e80660de2eb",
-    "alias" : "Direct Grant - Conditional OTP",
-    "description" : "Flow to determine if the OTP is required for the authentication",
-    "providerId" : "basic-flow",
-    "topLevel" : false,
-    "builtIn" : true,
-    "authenticationExecutions" : [ {
-      "authenticator" : "conditional-user-configured",
-      "authenticatorFlow" : false,
-      "requirement" : "REQUIRED",
-      "priority" : 10,
-      "autheticatorFlow" : false,
-      "userSetupAllowed" : false
-    }, {
-      "authenticator" : "direct-grant-validate-otp",
-      "authenticatorFlow" : false,
-      "requirement" : "REQUIRED",
-      "priority" : 20,
-      "autheticatorFlow" : false,
-      "userSetupAllowed" : false
-    } ]
-  }, {
-    "id" : "757c2668-6953-460b-801c-04724268c5fe",
-    "alias" : "First broker login - Conditional OTP",
-    "description" : "Flow to determine if the OTP is required for the authentication",
-    "providerId" : "basic-flow",
-    "topLevel" : false,
-    "builtIn" : true,
-    "authenticationExecutions" : [ {
-      "authenticator" : "conditional-user-configured",
-      "authenticatorFlow" : false,
-      "requirement" : "REQUIRED",
-      "priority" : 10,
-      "autheticatorFlow" : false,
-      "userSetupAllowed" : false
-    }, {
-      "authenticator" : "auth-otp-form",
-      "authenticatorFlow" : false,
-      "requirement" : "REQUIRED",
-      "priority" : 20,
-      "autheticatorFlow" : false,
-      "userSetupAllowed" : false
-    } ]
-  }, {
-    "id" : "590e3d8f-e89b-44df-8703-591a8e1d4720",
-    "alias" : "Handle Existing Account",
-    "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
-    "providerId" : "basic-flow",
-    "topLevel" : false,
-    "builtIn" : true,
-    "authenticationExecutions" : [ {
-      "authenticator" : "idp-confirm-link",
-      "authenticatorFlow" : false,
-      "requirement" : "REQUIRED",
-      "priority" : 10,
-      "autheticatorFlow" : false,
-      "userSetupAllowed" : false
-    }, {
-      "authenticatorFlow" : true,
-      "requirement" : "REQUIRED",
-      "priority" : 20,
-      "autheticatorFlow" : true,
-      "flowAlias" : "Account verification options",
-      "userSetupAllowed" : false
-    } ]
-  }, {
-    "id" : "d3344b77-feb7-4b42-9436-4a3ea67f14b6",
-    "alias" : "Reset - Conditional OTP",
-    "description" : "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
-    "providerId" : "basic-flow",
-    "topLevel" : false,
-    "builtIn" : true,
-    "authenticationExecutions" : [ {
-      "authenticator" : "conditional-user-configured",
-      "authenticatorFlow" : false,
-      "requirement" : "REQUIRED",
-      "priority" : 10,
-      "autheticatorFlow" : false,
-      "userSetupAllowed" : false
-    }, {
-      "authenticator" : "reset-otp",
-      "authenticatorFlow" : false,
-      "requirement" : "REQUIRED",
-      "priority" : 20,
-      "autheticatorFlow" : false,
-      "userSetupAllowed" : false
-    } ]
-  }, {
-    "id" : "e1002483-4b33-4d5a-a55c-5ea4e81f3c95",
-    "alias" : "User creation or linking",
-    "description" : "Flow for the existing/non-existing user alternatives",
-    "providerId" : "basic-flow",
-    "topLevel" : false,
-    "builtIn" : true,
-    "authenticationExecutions" : [ {
-      "authenticatorConfig" : "create unique user config",
-      "authenticator" : "idp-create-user-if-unique",
-      "authenticatorFlow" : false,
-      "requirement" : "ALTERNATIVE",
-      "priority" : 10,
-      "autheticatorFlow" : false,
-      "userSetupAllowed" : false
-    }, {
-      "authenticatorFlow" : true,
-      "requirement" : "ALTERNATIVE",
-      "priority" : 20,
-      "autheticatorFlow" : true,
-      "flowAlias" : "Handle Existing Account",
-      "userSetupAllowed" : false
-    } ]
-  }, {
-    "id" : "3551707c-df3b-427d-9456-16f042d1af34",
-    "alias" : "Verify Existing Account by Re-authentication",
-    "description" : "Reauthentication of existing account",
-    "providerId" : "basic-flow",
-    "topLevel" : false,
-    "builtIn" : true,
-    "authenticationExecutions" : [ {
-      "authenticator" : "idp-username-password-form",
-      "authenticatorFlow" : false,
-      "requirement" : "REQUIRED",
-      "priority" : 10,
-      "autheticatorFlow" : false,
-      "userSetupAllowed" : false
-    }, {
-      "authenticatorFlow" : true,
-      "requirement" : "CONDITIONAL",
-      "priority" : 20,
-      "autheticatorFlow" : true,
-      "flowAlias" : "First broker login - Conditional OTP",
-      "userSetupAllowed" : false
-    } ]
-  }, {
-    "id" : "85168b8d-3731-4b4d-8cf7-53cb1bb5e9eb",
-    "alias" : "browser",
-    "description" : "browser based authentication",
-    "providerId" : "basic-flow",
-    "topLevel" : true,
-    "builtIn" : true,
-    "authenticationExecutions" : [ {
-      "authenticator" : "auth-cookie",
-      "authenticatorFlow" : false,
-      "requirement" : "ALTERNATIVE",
-      "priority" : 10,
-      "autheticatorFlow" : false,
-      "userSetupAllowed" : false
-    }, {
-      "authenticator" : "auth-spnego",
-      "authenticatorFlow" : false,
-      "requirement" : "DISABLED",
-      "priority" : 20,
-      "autheticatorFlow" : false,
-      "userSetupAllowed" : false
-    }, {
-      "authenticator" : "identity-provider-redirector",
-      "authenticatorFlow" : false,
-      "requirement" : "ALTERNATIVE",
-      "priority" : 25,
-      "autheticatorFlow" : false,
-      "userSetupAllowed" : false
-    }, {
-      "authenticatorFlow" : true,
-      "requirement" : "ALTERNATIVE",
-      "priority" : 30,
-      "autheticatorFlow" : true,
-      "flowAlias" : "forms",
-      "userSetupAllowed" : false
-    } ]
-  }, {
-    "id" : "0bf9e9e6-f04f-49c3-96d2-8d5841adbbb0",
-    "alias" : "clients",
-    "description" : "Base authentication for clients",
-    "providerId" : "client-flow",
-    "topLevel" : true,
-    "builtIn" : true,
-    "authenticationExecutions" : [ {
-      "authenticator" : "client-secret",
-      "authenticatorFlow" : false,
-      "requirement" : "ALTERNATIVE",
-      "priority" : 10,
-      "autheticatorFlow" : false,
-      "userSetupAllowed" : false
-    }, {
-      "authenticator" : "client-jwt",
-      "authenticatorFlow" : false,
-      "requirement" : "ALTERNATIVE",
-      "priority" : 20,
-      "autheticatorFlow" : false,
-      "userSetupAllowed" : false
-    }, {
-      "authenticator" : "client-secret-jwt",
-      "authenticatorFlow" : false,
-      "requirement" : "ALTERNATIVE",
-      "priority" : 30,
-      "autheticatorFlow" : false,
-      "userSetupAllowed" : false
-    }, {
-      "authenticator" : "client-x509",
-      "authenticatorFlow" : false,
-      "requirement" : "ALTERNATIVE",
-      "priority" : 40,
-      "autheticatorFlow" : false,
-      "userSetupAllowed" : false
-    } ]
-  }, {
-    "id" : "f0066f2e-f830-454e-a507-054b49708e46",
-    "alias" : "direct grant",
-    "description" : "OpenID Connect Resource Owner Grant",
-    "providerId" : "basic-flow",
-    "topLevel" : true,
-    "builtIn" : true,
-    "authenticationExecutions" : [ {
-      "authenticator" : "direct-grant-validate-username",
-      "authenticatorFlow" : false,
-      "requirement" : "REQUIRED",
-      "priority" : 10,
-      "autheticatorFlow" : false,
-      "userSetupAllowed" : false
-    }, {
-      "authenticator" : "direct-grant-validate-password",
-      "authenticatorFlow" : false,
-      "requirement" : "REQUIRED",
-      "priority" : 20,
-      "autheticatorFlow" : false,
-      "userSetupAllowed" : false
-    }, {
-      "authenticatorFlow" : true,
-      "requirement" : "CONDITIONAL",
-      "priority" : 30,
-      "autheticatorFlow" : true,
-      "flowAlias" : "Direct Grant - Conditional OTP",
-      "userSetupAllowed" : false
-    } ]
-  }, {
-    "id" : "8f545cb5-c4ac-42ac-9e6f-8aa173df4bbb",
-    "alias" : "docker auth",
-    "description" : "Used by Docker clients to authenticate against the IDP",
-    "providerId" : "basic-flow",
-    "topLevel" : true,
-    "builtIn" : true,
-    "authenticationExecutions" : [ {
-      "authenticator" : "docker-http-basic-authenticator",
-      "authenticatorFlow" : false,
-      "requirement" : "REQUIRED",
-      "priority" : 10,
-      "autheticatorFlow" : false,
-      "userSetupAllowed" : false
-    } ]
-  }, {
-    "id" : "b6beb772-8e87-4e04-ae49-8662c215902c",
-    "alias" : "first broker login",
-    "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
-    "providerId" : "basic-flow",
-    "topLevel" : true,
-    "builtIn" : true,
-    "authenticationExecutions" : [ {
-      "authenticatorConfig" : "review profile config",
-      "authenticator" : "idp-review-profile",
-      "authenticatorFlow" : false,
-      "requirement" : "REQUIRED",
-      "priority" : 10,
-      "autheticatorFlow" : false,
-      "userSetupAllowed" : false
-    }, {
-      "authenticatorFlow" : true,
-      "requirement" : "REQUIRED",
-      "priority" : 20,
-      "autheticatorFlow" : true,
-      "flowAlias" : "User creation or linking",
-      "userSetupAllowed" : false
-    } ]
-  }, {
-    "id" : "75ba7352-f7bd-4237-ac74-aa69727eae25",
-    "alias" : "forms",
-    "description" : "Username, password, otp and other auth forms.",
-    "providerId" : "basic-flow",
-    "topLevel" : false,
-    "builtIn" : true,
-    "authenticationExecutions" : [ {
-      "authenticator" : "auth-username-password-form",
-      "authenticatorFlow" : false,
-      "requirement" : "REQUIRED",
-      "priority" : 10,
-      "autheticatorFlow" : false,
-      "userSetupAllowed" : false
-    }, {
-      "authenticatorFlow" : true,
-      "requirement" : "CONDITIONAL",
-      "priority" : 20,
-      "autheticatorFlow" : true,
-      "flowAlias" : "Browser - Conditional OTP",
-      "userSetupAllowed" : false
-    } ]
-  }, {
-    "id" : "0bdd7edd-67a4-4d50-8acf-ddab41538092",
-    "alias" : "registration",
-    "description" : "registration flow",
-    "providerId" : "basic-flow",
-    "topLevel" : true,
-    "builtIn" : true,
-    "authenticationExecutions" : [ {
-      "authenticator" : "registration-page-form",
-      "authenticatorFlow" : true,
-      "requirement" : "REQUIRED",
-      "priority" : 10,
-      "autheticatorFlow" : true,
-      "flowAlias" : "registration form",
-      "userSetupAllowed" : false
-    } ]
-  }, {
-    "id" : "b637d219-e3e7-49eb-8c00-7051ef59ea7e",
-    "alias" : "registration form",
-    "description" : "registration form",
-    "providerId" : "form-flow",
-    "topLevel" : false,
-    "builtIn" : true,
-    "authenticationExecutions" : [ {
-      "authenticator" : "registration-user-creation",
-      "authenticatorFlow" : false,
-      "requirement" : "REQUIRED",
-      "priority" : 20,
-      "autheticatorFlow" : false,
-      "userSetupAllowed" : false
-    }, {
-      "authenticator" : "registration-password-action",
-      "authenticatorFlow" : false,
-      "requirement" : "REQUIRED",
-      "priority" : 50,
-      "autheticatorFlow" : false,
-      "userSetupAllowed" : false
-    }, {
-      "authenticator" : "registration-recaptcha-action",
-      "authenticatorFlow" : false,
-      "requirement" : "DISABLED",
-      "priority" : 60,
-      "autheticatorFlow" : false,
-      "userSetupAllowed" : false
-    } ]
-  }, {
-    "id" : "0fb060b2-fc5b-4582-878e-837d6c8fc5c1",
-    "alias" : "reset credentials",
-    "description" : "Reset credentials for a user if they forgot their password or something",
-    "providerId" : "basic-flow",
-    "topLevel" : true,
-    "builtIn" : true,
-    "authenticationExecutions" : [ {
-      "authenticator" : "reset-credentials-choose-user",
-      "authenticatorFlow" : false,
-      "requirement" : "REQUIRED",
-      "priority" : 10,
-      "autheticatorFlow" : false,
-      "userSetupAllowed" : false
-    }, {
-      "authenticator" : "reset-credential-email",
-      "authenticatorFlow" : false,
-      "requirement" : "REQUIRED",
-      "priority" : 20,
-      "autheticatorFlow" : false,
-      "userSetupAllowed" : false
-    }, {
-      "authenticator" : "reset-password",
-      "authenticatorFlow" : false,
-      "requirement" : "REQUIRED",
-      "priority" : 30,
-      "autheticatorFlow" : false,
-      "userSetupAllowed" : false
-    }, {
-      "authenticatorFlow" : true,
-      "requirement" : "CONDITIONAL",
-      "priority" : 40,
-      "autheticatorFlow" : true,
-      "flowAlias" : "Reset - Conditional OTP",
-      "userSetupAllowed" : false
-    } ]
-  }, {
-    "id" : "af3c1b14-7cb0-40fd-a324-c49a9c5a936e",
-    "alias" : "saml ecp",
-    "description" : "SAML ECP Profile Authentication Flow",
-    "providerId" : "basic-flow",
-    "topLevel" : true,
-    "builtIn" : true,
-    "authenticationExecutions" : [ {
-      "authenticator" : "http-basic-authenticator",
-      "authenticatorFlow" : false,
-      "requirement" : "REQUIRED",
-      "priority" : 10,
-      "autheticatorFlow" : false,
-      "userSetupAllowed" : false
-    } ]
-  } ],
-  "authenticatorConfig" : [ {
-    "id" : "17a733e8-c264-42fc-b89f-c1598551adef",
-    "alias" : "create unique user config",
-    "config" : {
-      "require.password.update.after.registration" : "false"
-    }
-  }, {
-    "id" : "ccbf5b7b-7dd2-49ae-ae69-c438d8163ba0",
-    "alias" : "review profile config",
-    "config" : {
-      "update.profile.on.first.login" : "missing"
-    }
-  } ],
-  "requiredActions" : [ {
-    "alias" : "CONFIGURE_TOTP",
-    "name" : "Configure OTP",
-    "providerId" : "CONFIGURE_TOTP",
-    "enabled" : true,
-    "defaultAction" : false,
-    "priority" : 10,
-    "config" : { }
-  }, {
-    "alias" : "VERIFY_EMAIL",
-    "name" : "Verify Email",
-    "providerId" : "VERIFY_EMAIL",
-    "enabled" : true,
-    "defaultAction" : true,
-    "priority" : 10,
-    "config" : { }
-  }, {
-    "alias" : "UPDATE_PROFILE",
-    "name" : "Update Profile",
-    "providerId" : "UPDATE_PROFILE",
-    "enabled" : true,
-    "defaultAction" : true,
-    "priority" : 20,
-    "config" : { }
-  }, {
-    "alias" : "UPDATE_PASSWORD",
-    "name" : "Update Password",
-    "providerId" : "UPDATE_PASSWORD",
-    "enabled" : true,
-    "defaultAction" : true,
-    "priority" : 30,
-    "config" : { }
-  }, {
-    "alias" : "TERMS_AND_CONDITIONS",
-    "name" : "Terms and Conditions",
-    "providerId" : "TERMS_AND_CONDITIONS",
-    "enabled" : true,
-    "defaultAction" : true,
-    "priority" : 40,
-    "config" : { }
-  }, {
-    "alias" : "delete_account",
-    "name" : "Delete Account",
-    "providerId" : "delete_account",
-    "enabled" : false,
-    "defaultAction" : false,
-    "priority" : 60,
-    "config" : { }
-  }, {
-    "alias" : "webauthn-register",
-    "name" : "Webauthn Register",
-    "providerId" : "webauthn-register",
-    "enabled" : true,
-    "defaultAction" : false,
-    "priority" : 70,
-    "config" : { }
-  }, {
-    "alias" : "webauthn-register-passwordless",
-    "name" : "Webauthn Register Passwordless",
-    "providerId" : "webauthn-register-passwordless",
-    "enabled" : true,
-    "defaultAction" : false,
-    "priority" : 80,
-    "config" : { }
-  }, {
-    "alias" : "delete_credential",
-    "name" : "Delete Credential",
-    "providerId" : "delete_credential",
-    "enabled" : true,
-    "defaultAction" : false,
-    "priority" : 100,
-    "config" : { }
-  }, {
-    "alias" : "update_user_locale",
-    "name" : "Update User Locale",
-    "providerId" : "update_user_locale",
-    "enabled" : true,
-    "defaultAction" : false,
-    "priority" : 1000,
-    "config" : { }
-  } ],
-  "browserFlow" : "browser",
-  "registrationFlow" : "registration",
-  "directGrantFlow" : "direct grant",
-  "resetCredentialsFlow" : "reset credentials",
-  "clientAuthenticationFlow" : "clients",
-  "dockerAuthenticationFlow" : "docker auth",
-  "firstBrokerLoginFlow" : "first broker login",
-  "attributes" : {
-    "cibaBackchannelTokenDeliveryMode" : "poll",
-    "cibaAuthRequestedUserHint" : "login_hint",
-    "provisioning_state" : "[]",
-    "clientOfflineSessionMaxLifespan" : "0",
-    "oauth2DevicePollingInterval" : "5",
-    "clientSessionIdleTimeout" : "0",
-    "organization_uuid" : "2e92f530-c97b-48e1-923a-05c481a41f26",
-    "clientOfflineSessionIdleTimeout" : "0",
-    "cibaInterval" : "5",
-    "realmReusableOtpCode" : "false",
-    "cibaExpiresIn" : "120",
-    "oauth2DeviceCodeLifespan" : "600",
-    "tenant_url" : "",
-    "parRequestUriLifespan" : "60",
-    "clientSessionMaxLifespan" : "0",
-    "frontendUrl" : "",
-    "acr.loa.map" : "{}"
-  },
-  "keycloakVersion" : "24.0.3",
-  "userManagedAccessAllowed" : false,
-  "clientProfiles" : {
-    "profiles" : [ ]
-  },
-  "clientPolicies" : {
-    "policies" : [ ]
+  "clientPolicies": {
+    "policies": []
   }
 }

--- a/website/landing/index.html
+++ b/website/landing/index.html
@@ -212,7 +212,7 @@
             <a href="https://github.com/rubentalstra/FerroEHR/blob/develop/LICENSE-APACHE-2.0" rel="noopener">Apache-2.0</a>.</p>
           <p>Began as a fork of EHRbase by vitasystems and the Peter L. Reichertz
             Institute (PLRI). openEHR® is the registered trademark of the openEHR
-            Foundation and is used with the permission of openEHR International.</p>
+            Foundation.</p>
         </div>
         <div class="footer-links">
           <div>


### PR DESCRIPTION
Fixes the v3.15.2 Containers smoke failure (`POST /ehr` → 401): the rename could not rewrite committed password *hashes*, so the dev users still verified the old secret. New Argon2id hashes for the documented dev password (cryptographically verified in-change), Keycloak dev realm switched to plaintext-at-import credentials, changelog `Fixed` entry added. Also removes the unlicensed 'used with the permission of openEHR International' wording (plain trademark attribution remains).

Verified locally: both images built, `docker/smoke-test.sh` passes end to end (status 200, EHR create 201, migration no-op on second boot).