### PR TITLE
release: v3.15.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+## [3.15.3] - 2026-07-31
+
 ### Fixed
 
 - **The quickstart dev credentials authenticate again.** The v3.15.2 rename
@@ -3893,7 +3895,8 @@ but has not yet run in production.
   seccomp, default-deny NetworkPolicy) and golden-render validation.
 
 
-[unreleased]: https://github.com/rubentalstra/FerroEHR/compare/v3.15.2...HEAD
+[unreleased]: https://github.com/rubentalstra/FerroEHR/compare/v3.15.3...HEAD
+[3.15.3]: https://github.com/rubentalstra/FerroEHR/compare/v3.15.2...v3.15.3
 [3.15.2]: https://github.com/rubentalstra/FerroEHR/compare/v3.15.1...v3.15.2
 [3.15.1]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.15.0...v3.15.1
 [3.15.0]: https://github.com/rubentalstra/ehrbase-rs/compare/v3.14.0...v3.15.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,5 +33,5 @@ keywords:
   - ITS-REST
   - Rust
   - PostgreSQL
-version: 3.15.2
+version: 3.15.3
 date-released: "2026-07-31"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "cnf-runner"
-version = "3.15.2"
+version = "3.15.3"
 dependencies = [
  "assert_fs",
  "base64 0.22.1",
@@ -2509,7 +2509,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferroehr"
-version = "3.15.2"
+version = "3.15.3"
 dependencies = [
  "assert_fs",
  "async-trait",
@@ -2576,7 +2576,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-admin-ui"
-version = "3.15.2"
+version = "3.15.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -2616,7 +2616,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-rest"
-version = "3.15.2"
+version = "3.15.3"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -2668,7 +2668,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-server"
-version = "3.15.2"
+version = "3.15.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -5223,7 +5223,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-codegen"
-version = "3.15.2"
+version = "3.15.3"
 dependencies = [
  "roxmltree",
  "serde_json",
@@ -8276,7 +8276,7 @@ dependencies = [
 
 [[package]]
 name = "testkit"
-version = "3.15.2"
+version = "3.15.3"
 dependencies = [
  "ferroehr",
  "jiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "3"
 members = ["crates/*", "app/*", "tools/*"]
 
 [workspace.package]
-version = "3.15.2"
+version = "3.15.3"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT"

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 # Chart versioning is independent of the application version.
 version: 3.2.0
 # The default container image tag (informational; overridable via image.tag).
-appVersion: "3.15.2"
+appVersion: "3.15.3"
 
 # PDB (policy/v1, GA 1.21), HPA (autoscaling/v2, GA 1.23), and the
 # seccompProfile pod field (GA 1.27) all resolve cleanly at 1.25+.

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.15.2"
+    app.kubernetes.io/version: "3.15.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -58,7 +58,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.15.2"
+    app.kubernetes.io/version: "3.15.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -77,7 +77,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.15.2"
+    app.kubernetes.io/version: "3.15.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -96,7 +96,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.15.2"
+    app.kubernetes.io/version: "3.15.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -120,7 +120,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.15.2"
+    app.kubernetes.io/version: "3.15.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -139,7 +139,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.15.2"
+    app.kubernetes.io/version: "3.15.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -294,7 +294,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.15.2"
+    app.kubernetes.io/version: "3.15.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -321,7 +321,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.15.2"
+    app.kubernetes.io/version: "3.15.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -333,7 +333,7 @@ spec:
     metadata:
       annotations:
         # Roll pods when the rendered ferroehr.toml changes.
-        checksum/config: 6761c0327b716dbea9acb13d5021f2e6f3d1060903b6c4efb384c90f7077045c
+        checksum/config: dc728d48cbff8643fb5474832e21b3471d2f32a280b2f55c7155e22967a4ee97
         prometheus.io/scrape: "true"
         prometheus.io/port: "9100"
         prometheus.io/path: "/management/prometheus"
@@ -354,7 +354,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:3.15.2"
+          image: "ghcr.io/rubentalstra/ferroehr:3.15.3"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -476,7 +476,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.15.2"
+    app.kubernetes.io/version: "3.15.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -509,7 +509,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.15.2"
+    app.kubernetes.io/version: "3.15.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.15.2"
+    app.kubernetes.io/version: "3.15.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -36,7 +36,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.15.2"
+    app.kubernetes.io/version: "3.15.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -55,7 +55,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.15.2"
+    app.kubernetes.io/version: "3.15.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 automountServiceAccountToken: false
@@ -69,7 +69,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.15.2"
+    app.kubernetes.io/version: "3.15.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -166,7 +166,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.15.2"
+    app.kubernetes.io/version: "3.15.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -189,7 +189,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.15.2"
+    app.kubernetes.io/version: "3.15.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -202,7 +202,7 @@ spec:
     metadata:
       annotations:
         # Roll pods when the rendered ferroehr.toml changes.
-        checksum/config: 4b9d8754081de1499135d8809e73066f6e1b8332baea76f0ef225b954f45d7e6
+        checksum/config: 643d5d14fc4726c99fc92148714ce393c18146ddf709fea93764e4ac25d51e63
       labels:
         app.kubernetes.io/name: ferroehr
         app.kubernetes.io/instance: ferroehr
@@ -220,7 +220,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:3.15.2"
+          image: "ghcr.io/rubentalstra/ferroehr:3.15.3"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
Cuts **v3.15.3** — the first fully usable release under the FerroEHR name. v3.15.2's Containers workflow failed at the compose-smoke gate (dev credentials 401, fixed in #1367), leaving an incomplete unvalidated image set; this tag republishes everything.

- Changelog `[Unreleased]` → `[3.15.3] - 2026-07-31`, fresh Unreleased, link refs.
- Workspace `3.15.3` (+ lock), Helm `appVersion` + regolded renders (validate green), `CITATION.cff`.