### PR TITLE
fix(openehr-lang): ODIN ch.3 Basics — value words as attribute names, keyed-object semicolons (audit #853)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **ODIN sections accept `true`/`false`/`infinity` as attribute names and
+  semicolons between keyed objects.** ODIN reserves no keywords
+  (`LANG/docs/odin/master03-basics` §Keywords), so archetype/template
+  uploads whose ODIN sections use those three words as attribute names —
+  previously refused because they lex as ODIN value words — now parse; and
+  the §Semi-colons separator is accepted between keyed-object entries, not
+  only attribute pairs.
+
 ## [3.15.3] - 2026-07-31
 
 ### Fixed

--- a/crates/openehr-lang/src/lexer/mod.rs
+++ b/crates/openehr-lang/src/lexer/mod.rs
@@ -110,7 +110,46 @@ pub fn lex_adl(src: &str) -> Result<Vec<Spanned>, LexError> {
 /// Returns a [`LexError`] at the byte span of the first input that is not an
 /// ODIN token.
 pub fn lex_odin(src: &str) -> Result<Vec<Spanned>, LexError> {
-    lex_with(Language::Odin, src)
+    let mut spanned = lex_with(Language::Odin, src)?;
+    retag_odin_value_words_in_key_position(src, &mut spanned);
+    Ok(spanned)
+}
+
+/// Re-tag `true`/`false`/`infinity` to identifiers where they stand as ODIN
+/// attribute names.
+///
+/// `LANG/docs/odin/master03-basics.adoc` §Keywords: "ODIN has no keywords of
+/// its own: all identifiers are assumed to come from an information model" —
+/// yet these three words stay TOKENS under the ODIN reading because they are
+/// genuine ODIN VALUES (`master07-leaf_data` §Boolean Data; the interval
+/// endpoints of `AM/docs/ADL1.4/master04-dadl` §Intervals of Ordered Primitive
+/// Types), so the per-token [`reclassify`] pass cannot demote them. Key
+/// position is decidable with one token of lookahead instead: an attribute
+/// name is always followed by `=` (`odin.g4` `attr_val : odin_object_key '='
+/// object_block`), and no VALUE position ever is — so a value word
+/// immediately before `SYM_EQ` is re-tagged to the identifier its spelling
+/// gives, exactly as the reclassification pass demotes every other keyword.
+fn retag_odin_value_words_in_key_position(src: &str, spanned: &mut [Spanned]) {
+    let mut index = 0;
+    while index < spanned.len() {
+        let is_value_word = matches!(
+            spanned.get(index).map(|s| &s.token),
+            Some(Token::SymTrue | Token::SymFalse | Token::SymInfinity)
+        );
+        let before_eq = matches!(spanned.get(index + 1).map(|s| &s.token), Some(Token::SymEq));
+        if is_value_word
+            && before_eq
+            && let Some(entry) = spanned.get_mut(index)
+        {
+            let slice = src.get(entry.span.clone()).unwrap_or_default();
+            entry.token = if slice.starts_with(|c: char| c.is_ascii_uppercase()) {
+                Token::AlphaUcId(slice.to_owned())
+            } else {
+                Token::AlphaLcId(slice.to_owned())
+            };
+        }
+        index += 1;
+    }
 }
 
 /// Lex `src` under the BEL reading (`LANG/docs/BEL/`; `base_expressions.g4`).

--- a/crates/openehr-lang/src/odin/mod.rs
+++ b/crates/openehr-lang/src/odin/mod.rs
@@ -529,6 +529,50 @@ mod tests {
         assert!(parse("p = <x = <1>>\nq = <x = <2>>").is_ok());
     }
 
+    /// `LANG/docs/odin/master03-basics` §Keywords: "ODIN has no keywords of
+    /// its own: all identifiers are assumed to come from an information
+    /// model" — so the three words that stay ODIN VALUE tokens
+    /// (`true`/`false` of §Boolean Data, `infinity` of the interval
+    /// endpoints) still parse as attribute names, in the spelling authored,
+    /// while value positions keep the value reading.
+    #[test]
+    fn value_words_parse_as_attribute_names() {
+        let m = obj("true = <1>\nfalse = <2>\ninfinity = <3>\nTrue = <4>");
+        assert_eq!(m.get("true"), Some(&OdinValue::Integer(1)));
+        assert_eq!(m.get("false"), Some(&OdinValue::Integer(2)));
+        assert_eq!(m.get("infinity"), Some(&OdinValue::Integer(3)));
+        assert_eq!(m.get("True"), Some(&OdinValue::Integer(4)));
+
+        // value positions are untouched by the key-position re-tag.
+        let m = obj("a = <true>\nr = <|0..infinity|>");
+        assert_eq!(m.get("a"), Some(&OdinValue::Boolean(true)));
+        let Some(OdinValue::Interval(OdinInterval::Range { upper, .. })) = m.get("r") else {
+            panic!("expected a range interval");
+        };
+        assert_eq!(upper.as_deref(), None);
+    }
+
+    /// `LANG/docs/odin/master03-basics` §Semi-colons: "Semi-colons can be
+    /// used to separate ODIN blocks … Semi-colons make no semantic difference
+    /// at all", with the section's own two `term = <…>` spellings asserted
+    /// equal — and the same separator accepted between keyed objects, whose
+    /// values are ODIN blocks too (a docs-text widening over `odin.g4`, which
+    /// writes the `';'?` only on `attr_vals`).
+    #[test]
+    fn semicolons_separate_blocks_with_no_semantic_difference() {
+        let with = parse(r#"term = <text = <"plan">; description = <"The clinician's advice">>"#)
+            .expect("the §Semi-colons example with separators should parse");
+        let without = parse(r#"term = <text = <"plan"> description = <"The clinician's advice">>"#)
+            .expect("the §Semi-colons example without separators should parse");
+        assert_eq!(with, without);
+
+        let keyed_with = parse(r#"k = <["a"] = <1>; ["b"] = <2>;>"#)
+            .expect("keyed objects with separators should parse");
+        let keyed_without =
+            parse(r#"k = <["a"] = <1> ["b"] = <2>>"#).expect("keyed objects should parse");
+        assert_eq!(keyed_with, keyed_without);
+    }
+
     /// `LANG/docs/odin/master07-leaf_data` §String Data (verbatim in
     /// `AM/docs/ADL1.4/master04-dadl` §String Data): multi-line string
     /// contents drop the white-space leaders of the continuation lines.

--- a/crates/openehr-lang/src/odin/parser.rs
+++ b/crates/openehr-lang/src/odin/parser.rs
@@ -180,11 +180,19 @@ fn object_block<'a>() -> impl Parser<'a, &'a [Token], OdinValue, Err<'a>> + Clon
             Token::Iso8601Time(s) => OdinKey::Time(s),
             Token::Iso8601DateTime(s) => OdinKey::DateTime(s),
         };
+        // NOTE: the trailing optional `';'` is a docs-text widening over the
+        // vendored `odin.g4`, which writes the separator only on `attr_vals`:
+        // "Semi-colons can be used to separate ODIN blocks … Semi-colons make
+        // no semantic difference at all" (`LANG/docs/odin/master03-basics`
+        // §Semi-colons), and a keyed object ends in an ODIN block, so the
+        // separator is accepted (and ignored) here exactly as between
+        // attribute pairs.
         let keyed_list = just(Token::LBracket)
             .ignore_then(key_id)
             .then_ignore(just(Token::RBracket))
             .then_ignore(just(Token::SymEq))
             .then(block.clone())
+            .then_ignore(just(Token::SymSemiColon).or_not())
             .repeated()
             .at_least(1)
             .collect::<Vec<(OdinKey, OdinValue)>>()

--- a/crates/openehr-lang/tests/fixtures/lexer_battery.txt
+++ b/crates/openehr-lang/tests/fixtures/lexer_battery.txt
@@ -506,3 +506,13 @@ c1|c2
 {[local::at0001, at0002]}
 %%
 DV_ORDINAL[id5] matches {value matches {|0|}}
+%%
+true = <1>
+%%
+True = <1>
+%%
+infinity = <1>
+%%
+x = <false>
+%%
+|0..infinity|

--- a/crates/openehr-lang/tests/fixtures/lexer_equivalence_adl.txt
+++ b/crates/openehr-lang/tests/fixtures/lexer_equivalence_adl.txt
@@ -237,3 +237,8 @@
 236|LCurly@0..1 SymIvlDelim@1..2 SymGe@2..4 Integer("0")@4..5 SymIvlDelim@5..6 RCurly@6..7
 237|LCurly@0..1 LBracket@1..2 AlphaLcId("local")@2..7 SymColon@7..8 SymColon@8..9 AtCode("at0001")@9..15 SymComma@15..16 AtCode("at0002")@17..23 RBracket@23..24 RCurly@24..25
 238|AlphaUcId("DV_ORDINAL")@0..10 LBracket@10..11 IdCode("id5")@11..14 RBracket@14..15 SymMatches@16..23 LCurly@24..25 AlphaLcId("value")@25..30 SymMatches@31..38 LCurly@39..40 SymIvlDelim@40..41 Integer("0")@41..42 SymIvlDelim@42..43 RCurly@43..44 RCurly@44..45
+239|SymTrue@0..4 SymEq@5..6 SymLt@7..8 Integer("1")@8..9 SymGt@9..10
+240|SymTrue@0..4 SymEq@5..6 SymLt@7..8 Integer("1")@8..9 SymGt@9..10
+241|SymInfinity@0..8 SymEq@9..10 SymLt@11..12 Integer("1")@12..13 SymGt@13..14
+242|AlphaLcId("x")@0..1 SymEq@2..3 SymLt@4..5 SymFalse@5..10 SymGt@10..11
+243|SymIvlDelim@0..1 Integer("0")@1..2 SymIvlSep@2..4 SymInfinity@4..12 SymIvlDelim@12..13

--- a/crates/openehr-lang/tests/fixtures/lexer_equivalence_bel.txt
+++ b/crates/openehr-lang/tests/fixtures/lexer_equivalence_bel.txt
@@ -237,3 +237,8 @@
 236|LCurly@0..1 SymIvlDelim@1..2 SymGe@2..4 Integer("0")@4..5 SymIvlDelim@5..6 RCurly@6..7
 237|LCurly@0..1 LBracket@1..2 AlphaLcId("local")@2..7 SymColon@7..8 SymColon@8..9 AlphaLcId("at0001")@9..15 SymComma@15..16 AlphaLcId("at0002")@17..23 RBracket@23..24 RCurly@24..25
 238|AlphaUcId("DV_ORDINAL")@0..10 LBracket@10..11 AlphaLcId("id5")@11..14 RBracket@14..15 SymMatches@16..23 LCurly@24..25 AlphaLcId("value")@25..30 SymMatches@31..38 LCurly@39..40 SymIvlDelim@40..41 Integer("0")@41..42 SymIvlDelim@42..43 RCurly@43..44 RCurly@44..45
+239|SymTrue@0..4 SymEq@5..6 SymLt@7..8 Integer("1")@8..9 SymGt@9..10
+240|SymTrue@0..4 SymEq@5..6 SymLt@7..8 Integer("1")@8..9 SymGt@9..10
+241|AlphaLcId("infinity")@0..8 SymEq@9..10 SymLt@11..12 Integer("1")@12..13 SymGt@13..14
+242|AlphaLcId("x")@0..1 SymEq@2..3 SymLt@4..5 SymFalse@5..10 SymGt@10..11
+243|SymIvlDelim@0..1 Integer("0")@1..2 SymIvlSep@2..4 AlphaLcId("infinity")@4..12 SymIvlDelim@12..13

--- a/crates/openehr-lang/tests/fixtures/lexer_equivalence_odin.txt
+++ b/crates/openehr-lang/tests/fixtures/lexer_equivalence_odin.txt
@@ -237,3 +237,8 @@
 236|ERROR@0..1
 237|ERROR@0..1
 238|ERROR@24..25
+239|AlphaLcId("true")@0..4 SymEq@5..6 SymLt@7..8 Integer("1")@8..9 SymGt@9..10
+240|AlphaUcId("True")@0..4 SymEq@5..6 SymLt@7..8 Integer("1")@8..9 SymGt@9..10
+241|AlphaLcId("infinity")@0..8 SymEq@9..10 SymLt@11..12 Integer("1")@12..13 SymGt@13..14
+242|AlphaLcId("x")@0..1 SymEq@2..3 SymLt@4..5 SymFalse@5..10 SymGt@10..11
+243|SymIvlDelim@0..1 Integer("0")@1..2 SymIvlSep@2..4 SymInfinity@4..12 SymIvlDelim@12..13


### PR DESCRIPTION
Closes #1356
Closes #1371
Closes #1105
Closes #1106
Closes #1107
Closes #1108
Closes #1109
Closes #1110
Closes #1111
Closes #853

## What

Second chapter of the #753 LANG compliance program: the ODIN ch.3 Basics audit — all seven section sub-issues walked (checklists on #1105–#1111, coherence pass on #853) — plus the chapter's two findings fixed per the fix-first cadence.

## Audit outcome

§3.1 File Encoding, §3.2 Special Character Sequences, §3.5 Comments, §3.6 IM Identifiers close finding-free (the `\u`/escape machinery in `escape.rs` already carries the adjudicated NOTEs; the App.B grammar grounds the wider `odin_object_key`). Two items carried to their owning audits: plug-in delimiters `<#`/`#>` → ch.9 (#859), URI-encoding depth → §7.3 (#1122).

## Fixes

**#1356 (§3.3 Keywords):** master03 reserves nothing, but `true`/`false`/`infinity` stay ODIN value tokens and were refused as attribute names. Fixed with a one-token-lookahead pass in `lex_odin` (`retag_odin_value_words_in_key_position`): a value word immediately before `SYM_EQ` is an attribute name (`odin.g4` `attr_val`), and no value position is ever followed by `=` — so the re-tag is exact. Spelling preserved (`True` → `AlphaUcId("True")`). The three carried-over widenings (space-separated date-time, `infinity` endpoints, BEL `<>`) are adjudicated KEPT on the issue — their spec-cited NOTEs already sit at the sites.

**#1371 (§3.7 Semi-colons):** the docs text permits separators between ODIN blocks generally; keyed objects end in blocks, so the optional `;` is now accepted (and ignored) after keyed entries — a docs-text widening over `odin.g4` (which writes the separator only on `attr_vals`), NOTE at the site.

## Pinning

Battery records 239–243 (hand-adjudicated dumps for ALL THREE readings — the ADL/BEL readings keep the keyword/value behaviour, only ODIN key position re-tags) + `value_words_parse_as_attribute_names` and `semicolons_separate_blocks_with_no_semantic_difference` (equal-tree for the §3.7 example pair and the keyed form).

## Gates

`cargo fmt` clean; `cargo clippy -p openehr-lang --all-targets` clean; `cargo nextest run -p openehr-lang -p openehr-adl` 372/372 green; rustdoc gate clean. Changelog entry added (ODIN acceptance is upload-visible validation behaviour).