### PR TITLE
feat(openehr-lang): ODIN ch.4 artefact forms — schema identifier + Identified Object Documents (audit #854)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Added
+
+- **ODIN document artefacts parse in all three `master04` forms.** The ODIN
+  reader now accepts Identified Object Documents (top-level
+  `["id"] = <…>` keyed objects) and the optional leading
+  `@schema = <uri>` schema identifier, exposed via the new
+  `odin::parse_document`; the anonymous and implicit forms were already
+  supported.
+
 ### Fixed
 
 - **ODIN sections accept `true`/`false`/`infinity` as attribute names and

--- a/crates/openehr-lang/src/lexer/mod.rs
+++ b/crates/openehr-lang/src/lexer/mod.rs
@@ -722,9 +722,14 @@ mod tests {
             ]
         );
         // `$variable`, `{`, `:` and `%` have no ODIN production at all.
-        for refused in ["$v", "{", ":", "%", "^", "@", "!="] {
+        for refused in ["$v", "{", ":", "%", "^", "!="] {
             assert!(lex_odin(refused).is_err(), "ODIN must refuse {refused:?}");
         }
+        // `@` IS an ODIN token since #1373: it opens the document prefix
+        // `schema_identifier ::= '@' schema '=' URI`
+        // (`LANG/docs/odin/master04-odin_artefacts` intro); a misplaced `@`
+        // is the parser's refusal, not the lexer's.
+        assert_eq!(odin("@"), vec![Token::SymAt]);
     }
 
     /// `AM/docs/ADL1.4/master04-dadl` §Symbols `V_LOCAL_TERM_CODE_REF` is an

--- a/crates/openehr-lang/src/lexer/reclassify.rs
+++ b/crates/openehr-lang/src/lexer/reclassify.rs
@@ -219,14 +219,18 @@ pub(super) fn reclassify(
         // ── symbols only some layers carry ──
         // `odin.g4` has neither an assignment nor a bare colon, and no
         // arithmetic/binding operators.
-        Token::SymAssignment
-        | Token::SymColon
-        | Token::SymPercent
-        | Token::SymCarat
-        | Token::SymAt => match language {
-            Language::Adl | Language::Bel => Some(token.clone()),
-            Language::Odin => None,
-        },
+        Token::SymAssignment | Token::SymColon | Token::SymPercent | Token::SymCarat => {
+            match language {
+                Language::Adl | Language::Bel => Some(token.clone()),
+                Language::Odin => None,
+            }
+        }
+        // `@` opens the optional document prefix `schema_identifier ::= '@'
+        // schema '=' URI` (`LANG/docs/odin/master04-odin_artefacts` intro),
+        // so the ODIN reading admits it — a misplaced `@` is the parser's
+        // refusal, not the lexer's. (The vendored `odin.g4` start rule lacks
+        // the production; the docs text wins.)
+        Token::SymAt => Some(token.clone()),
         // `<>` is the ADL 1.4 assertion spelling of `SYM_NE` and is admitted
         // only by BEL; under cADL and ODIN the two characters are the separate
         // `SYM_LT` `SYM_GT` an empty ODIN block is written with.

--- a/crates/openehr-lang/src/odin/mod.rs
+++ b/crates/openehr-lang/src/odin/mod.rs
@@ -158,16 +158,56 @@ pub struct OdinError {
     pub span: std::ops::Range<usize>,
 }
 
+/// A parsed ODIN artefact: the optional leading schema identifier plus the
+/// main text (`LANG/docs/odin/master04-odin_artefacts` intro:
+/// `odin_text ::= ( schema_identifier )? main_text`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct OdinDocument {
+    /// The optional `@<name> = <uri>` schema identifier ("used to indicate
+    /// the schema, including its version, on which the main ODIN text is
+    /// based" — `master04-odin_artefacts`).
+    pub schema: Option<OdinSchemaId>,
+    /// The main text: an attribute object (embedded fragment / implicit
+    /// object document), a keyed list (Identified Object Document), or a
+    /// bare object block (Anonymous Object Document).
+    pub root: OdinValue,
+}
+
+/// The `schema_identifier ::= '@' schema '=' URI` document prefix of
+/// `LANG/docs/odin/master04-odin_artefacts`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OdinSchemaId {
+    /// The identifier between `@` and `=` (the chapter's undefined `schema`
+    /// nonterminal — commonly the literal word `schema`), verbatim.
+    pub name: String,
+    /// The schema URI, verbatim including its `<>` delimiters (the same
+    /// spelling [`OdinValue::Uri`] keeps).
+    pub uri: String,
+}
+
 /// Parse ODIN source text into an [`OdinValue`] tree.
 ///
-/// Accepts either a set of top-level `attr = <…>` pairs (an
-/// [`OdinValue::Object`], the usual ADL-section shape) or a bare
-/// object-value block.
+/// Accepts every `master04-odin_artefacts` main-text form — a set of
+/// top-level `attr = <…>` pairs (an [`OdinValue::Object`], the usual
+/// ADL-section shape), a top-level keyed-object list (an Identified Object
+/// Document), or a bare object-value block — and tolerates a leading
+/// `@<name> = <uri>` schema identifier, which it discards; use
+/// [`parse_document`] to read it.
 ///
 /// # Errors
 /// Returns an [`OdinError`] (with line/column) on the first lexical or
 /// syntactic error.
 pub fn parse(src: &str) -> Result<OdinValue, OdinError> {
+    parse_document(src).map(|document| document.root)
+}
+
+/// Parse ODIN source text into an [`OdinDocument`], keeping the optional
+/// schema identifier.
+///
+/// # Errors
+/// Returns an [`OdinError`] (with line/column) on the first lexical or
+/// syntactic error.
+pub fn parse_document(src: &str) -> Result<OdinDocument, OdinError> {
     let spanned = crate::lexer::lex_odin(src).map_err(|failure| {
         let (line, column) = line_col(src, failure.span.start);
         OdinError {

--- a/crates/openehr-lang/src/odin/parser.rs
+++ b/crates/openehr-lang/src/odin/parser.rs
@@ -100,12 +100,12 @@ pub(super) struct Located {
     pub(super) offset: usize,
 }
 
-/// Parse a spanned ODIN token stream into an [`OdinValue`].
+/// Parse a spanned ODIN token stream into an [`super::OdinDocument`].
 ///
 /// # Errors
 /// Returns the first failure, resolved to a byte offset in the original
 /// source.
-pub(super) fn parse_tokens(spanned: &[Spanned]) -> Result<OdinValue, Located> {
+pub(super) fn parse_tokens(spanned: &[Spanned]) -> Result<super::OdinDocument, Located> {
     let tokens: Vec<Token> = spanned.iter().map(|s| s.token.clone()).collect();
     odin_text().parse(&tokens).into_result().map_err(|errs| {
         let failure = errs
@@ -125,11 +125,48 @@ pub(super) fn parse_tokens(spanned: &[Spanned]) -> Result<OdinValue, Located> {
     })
 }
 
-/// `odin_text : attr_vals | object_value_block`.
-fn odin_text<'a>() -> impl Parser<'a, &'a [Token], OdinValue, Err<'a>> {
+/// `odin_text : ( schema_identifier )? main_text`, where the main text is
+/// `attr_vals | keyed_objects | object_value_block`.
+///
+/// The prefix and the top-level keyed-object form are both docs-text
+/// productions of `LANG/docs/odin/master04-odin_artefacts`: the chapter intro
+/// defines `odin_text ::= ( schema_identifier )? main_text`, and §Identified
+/// Object Document defines the multi-object document as top-level
+/// `["id"] = <…>` entries — the vendored `odin.g4` start rule
+/// (`attr_vals | object_value_block`) carries neither, and the docs text
+/// wins.
+fn odin_text<'a>() -> impl Parser<'a, &'a [Token], super::OdinDocument, Err<'a>> {
     let block = object_block();
     let attrs = attr_vals(block.clone());
-    choice((attrs, block)).then_ignore(end())
+    let keyed = keyed_objects(block.clone());
+    schema_identifier()
+        .or_not()
+        .then(choice((attrs, keyed, block)))
+        .map(|(schema, root)| super::OdinDocument { schema, root })
+        .then_ignore(end())
+}
+
+/// `schema_identifier ::= '@' schema '=' URI`
+/// (`LANG/docs/odin/master04-odin_artefacts` intro: "used to indicate the
+/// schema, including its version, on which the main ODIN text is based").
+///
+/// NOTE: two ambiguities in that production, adjudicated here (the chapter
+/// defines neither and gives no example): its `schema` is an unquoted,
+/// never-defined nonterminal — read as the identifier naming the schema
+/// (commonly the literal word `schema`), in the same identifier classes as an
+/// ODIN object key; and its `URI` ("a value of the URI primitive type") is
+/// taken in the embedded `<uri>` spelling every other ODIN URI value uses.
+fn schema_identifier<'a>() -> impl Parser<'a, &'a [Token], super::OdinSchemaId, Err<'a>> + Clone {
+    let name = select! {
+        Token::AlphaUcId(s) => s,
+        Token::AlphaLcId(s) => s,
+        Token::AlphaUnderscoreId(s) => s,
+    };
+    just(Token::SymAt)
+        .ignore_then(name)
+        .then_ignore(just(Token::SymEq))
+        .then(select! { Token::EmbeddedUri(s) => s })
+        .map(|(name, uri)| super::OdinSchemaId { name, uri })
 }
 
 /// `attr_vals : ( attr_val ';'? )+` → [`OdinValue::Object`].
@@ -168,35 +205,46 @@ fn attr_vals<'a>(
         })
 }
 
+/// `( keyed_object ';'? )+` with `keyed_object : '[' key_id ']' '='
+/// object_block` → [`OdinValue::KeyedList`] — the container-item form, both
+/// inside a block and as a whole Identified Object Document
+/// (`LANG/docs/odin/master04-odin_artefacts` §Identified Object Document;
+/// "Identifiers can be values of the String, Integer or any Date/Time
+/// primitive types").
+///
+/// NOTE: the trailing optional `';'` is a docs-text widening over the
+/// vendored `odin.g4`, which writes the separator only on `attr_vals`:
+/// "Semi-colons can be used to separate ODIN blocks … Semi-colons make no
+/// semantic difference at all" (`LANG/docs/odin/master03-basics`
+/// §Semi-colons), and a keyed object ends in an ODIN block, so the separator
+/// is accepted (and ignored) here exactly as between attribute pairs.
+fn keyed_objects<'a>(
+    block: impl Parser<'a, &'a [Token], OdinValue, Err<'a>> + Clone + 'a,
+) -> impl Parser<'a, &'a [Token], OdinValue, Err<'a>> + Clone {
+    let key_id = select! {
+        Token::String(s) => OdinKey::String(decode_string(&s)),
+        Token::Integer(s) => OdinKey::Integer(s.parse::<i64>().unwrap_or(0)),
+        Token::Iso8601Date(s) => OdinKey::Date(s),
+        Token::Iso8601Time(s) => OdinKey::Time(s),
+        Token::Iso8601DateTime(s) => OdinKey::DateTime(s),
+    };
+    just(Token::LBracket)
+        .ignore_then(key_id)
+        .then_ignore(just(Token::RBracket))
+        .then_ignore(just(Token::SymEq))
+        .then(block)
+        .then_ignore(just(Token::SymSemiColon).or_not())
+        .repeated()
+        .at_least(1)
+        .collect::<Vec<(OdinKey, OdinValue)>>()
+        .map(OdinValue::KeyedList)
+}
+
 /// `object_block : object_value_block | object_reference_block` (+ the
 /// `EMBEDDED_URI` and typed-cast forms).
 fn object_block<'a>() -> impl Parser<'a, &'a [Token], OdinValue, Err<'a>> + Clone {
     recursive(|block| {
-        // keyed list: ( '[' key_id ']' '=' object_block )+
-        let key_id = select! {
-            Token::String(s) => OdinKey::String(decode_string(&s)),
-            Token::Integer(s) => OdinKey::Integer(s.parse::<i64>().unwrap_or(0)),
-            Token::Iso8601Date(s) => OdinKey::Date(s),
-            Token::Iso8601Time(s) => OdinKey::Time(s),
-            Token::Iso8601DateTime(s) => OdinKey::DateTime(s),
-        };
-        // NOTE: the trailing optional `';'` is a docs-text widening over the
-        // vendored `odin.g4`, which writes the separator only on `attr_vals`:
-        // "Semi-colons can be used to separate ODIN blocks … Semi-colons make
-        // no semantic difference at all" (`LANG/docs/odin/master03-basics`
-        // §Semi-colons), and a keyed object ends in an ODIN block, so the
-        // separator is accepted (and ignored) here exactly as between
-        // attribute pairs.
-        let keyed_list = just(Token::LBracket)
-            .ignore_then(key_id)
-            .then_ignore(just(Token::RBracket))
-            .then_ignore(just(Token::SymEq))
-            .then(block.clone())
-            .then_ignore(just(Token::SymSemiColon).or_not())
-            .repeated()
-            .at_least(1)
-            .collect::<Vec<(OdinKey, OdinValue)>>()
-            .map(OdinValue::KeyedList);
+        let keyed_list = keyed_objects(block.clone());
 
         // object_reference_block : odin_path ( (',' odin_path)+ | '...' )?
         let path = select! { Token::AdlPath(s) => s }.or(just(Token::SymSlash).to("/".to_owned()));

--- a/crates/openehr-lang/tests/fixtures/lexer_battery.txt
+++ b/crates/openehr-lang/tests/fixtures/lexer_battery.txt
@@ -516,3 +516,5 @@ infinity = <1>
 x = <false>
 %%
 |0..infinity|
+%%
+@schema = <http://openehr.org/bmm>

--- a/crates/openehr-lang/tests/fixtures/lexer_equivalence_adl.txt
+++ b/crates/openehr-lang/tests/fixtures/lexer_equivalence_adl.txt
@@ -242,3 +242,4 @@
 241|SymInfinity@0..8 SymEq@9..10 SymLt@11..12 Integer("1")@12..13 SymGt@13..14
 242|AlphaLcId("x")@0..1 SymEq@2..3 SymLt@4..5 SymFalse@5..10 SymGt@10..11
 243|SymIvlDelim@0..1 Integer("0")@1..2 SymIvlSep@2..4 SymInfinity@4..12 SymIvlDelim@12..13
+244|SymAt@0..1 AlphaLcId("schema")@1..7 SymEq@8..9 EmbeddedUri("<http://openehr.org/bmm>")@10..34

--- a/crates/openehr-lang/tests/fixtures/lexer_equivalence_bel.txt
+++ b/crates/openehr-lang/tests/fixtures/lexer_equivalence_bel.txt
@@ -242,3 +242,4 @@
 241|AlphaLcId("infinity")@0..8 SymEq@9..10 SymLt@11..12 Integer("1")@12..13 SymGt@13..14
 242|AlphaLcId("x")@0..1 SymEq@2..3 SymLt@4..5 SymFalse@5..10 SymGt@10..11
 243|SymIvlDelim@0..1 Integer("0")@1..2 SymIvlSep@2..4 AlphaLcId("infinity")@4..12 SymIvlDelim@12..13
+244|SymAt@0..1 AlphaLcId("schema")@1..7 SymEq@8..9 SymLt@10..11 AlphaLcId("http")@11..15 SymColon@15..16 AdlPath("//openehr")@16..25 SymDot@25..26 AdlPath("org/bmm")@26..33 SymGt@33..34

--- a/crates/openehr-lang/tests/fixtures/lexer_equivalence_odin.txt
+++ b/crates/openehr-lang/tests/fixtures/lexer_equivalence_odin.txt
@@ -86,7 +86,7 @@
 85|LBracket@0..1 Integer("1")@1..2 RBracket@2..3
 86|LBracket@0..1 Integer("01234")@1..6 RBracket@6..7
 87|LBracket@0..1 Iso8601Date("2004-06-11")@1..11 RBracket@11..12
-88|ERROR@4..5
+88|LBracket@0..1 AlphaLcId("ac1")@1..4 SymAt@4..5 AlphaLcId("openehr")@5..12 RBracket@12..13
 89|TermCodeRef("[local::at0001]")@0..15
 90|LocalTermCodeRef("[at0010.2]")@0..10
 91|ERROR@0..3
@@ -186,7 +186,7 @@
 185|SymPlusOrMinus@0..3
 186|ERROR@0..1
 187|ERROR@0..1
-188|ERROR@0..1
+188|SymAt@0..1
 189|ERROR@0..1
 190|ERROR@0..1
 191|ERROR@0..1
@@ -242,3 +242,4 @@
 241|AlphaLcId("infinity")@0..8 SymEq@9..10 SymLt@11..12 Integer("1")@12..13 SymGt@13..14
 242|AlphaLcId("x")@0..1 SymEq@2..3 SymLt@4..5 SymFalse@5..10 SymGt@10..11
 243|SymIvlDelim@0..1 Integer("0")@1..2 SymIvlSep@2..4 SymInfinity@4..12 SymIvlDelim@12..13
+244|SymAt@0..1 AlphaLcId("schema")@1..7 SymEq@8..9 EmbeddedUri("<http://openehr.org/bmm>")@10..34

--- a/crates/openehr-lang/tests/it/odin_spec_examples.rs
+++ b/crates/openehr-lang/tests/it/odin_spec_examples.rs
@@ -1,9 +1,11 @@
-//! Pins the ODIN specification's own example documents against the reader —
-//! currently the ch.2 overview exemplar of
-//! `docs/specs/openehr/LANG/docs/odin/master02-overview.adoc`, as its valid +
-//! invalid twins (the #852 ch.2 audit, finding R1).
+//! Pins the ODIN specification's own example documents against the reader:
+//! the ch.2 overview exemplar of
+//! `docs/specs/openehr/LANG/docs/odin/master02-overview.adoc` as its valid +
+//! invalid twins (the #852 ch.2 audit, finding R1), and the ch.4 artefact
+//! forms of `master04-odin_artefacts.adoc` — the schema-identifier prefix and
+//! the three §Document shapes (the #854 ch.4 audit).
 
-use openehr_lang::odin::{OdinErrorKind, OdinValue, parse};
+use openehr_lang::odin::{OdinErrorKind, OdinKey, OdinSchemaId, OdinValue, parse, parse_document};
 
 /// The master02 exemplar VERBATIM (its lines 7–22). The line
 /// `[01235] = < -- etc >` is lexically self-inconsistent with the spec's own
@@ -116,4 +118,163 @@ fn ch2_exemplar_materialized_parses_to_the_expected_tree() {
         OdinValue::Empty,
         "the elliptical second item is an empty block"
     );
+}
+
+/// The `master04-odin_artefacts` §Embedded Fragment example, with the
+/// illustrative `leaf_value` barewords materialized as real leaves (the
+/// verbatim placeholder form is pinned refused by the vendored
+/// `anonymous_odin.txt` adjudication in `vendor_odin.rs`). Fragments carry
+/// "no object identifiers nor schema identifier".
+#[test]
+fn ch4_embedded_fragment_form_parses() {
+    let src = r#"--
+-- ODIN Embedded Fragment
+--
+    attr_1 = <
+        attr_12 = <
+            attr_13 = <"leaf">
+        >
+    >
+    attr_2 = <
+        attr_22 = <"leaf">
+    >
+"#;
+    let parsed = parse(src).unwrap_or_else(|e| panic!("the fragment form should parse: {e}"));
+    let OdinValue::Object(top) = parsed else {
+        panic!("expected an attribute object, got {parsed:?}");
+    };
+    assert_eq!(top.len(), 2);
+}
+
+/// The `master04-odin_artefacts` §Anonymous Object Document form — an outer
+/// `<>` pair around an embedded fragment; "syntactically more correct, and
+/// should be supported by parsers".
+#[test]
+fn ch4_anonymous_object_document_form_parses() {
+    let src = r#"--
+-- ODIN Anonymous Object Document
+--
+<
+    attr_1 = <
+        attr_12 = <
+            attr_13 = <"leaf">
+        >
+    >
+    attr_2 = <
+        attr_22 = <"leaf">
+    >
+>
+"#;
+    let parsed = parse(src).unwrap_or_else(|e| panic!("the anonymous form should parse: {e}"));
+    assert!(
+        matches!(parsed, OdinValue::Object(_)),
+        "the outer block holds the fragment's attribute object"
+    );
+}
+
+/// The `master04-odin_artefacts` §Identified Object Document form —
+/// top-level keyed objects, one per identified object (the docs-text
+/// production the vendored `odin.g4` start rule lacks; #1374). The verbatim
+/// chapter example keeps a bare top-level `...` ellipsis line and stays
+/// refused (pinned by the `identified_object_document.txt` adjudication in
+/// `vendor_odin.rs`); this is its materialized twin.
+#[test]
+fn ch4_identified_object_document_form_parses() {
+    let src = r#"--
+-- ODIN Identified Object Document
+--
+["id_1"] = <
+    attr_1 = <
+        attr_12 = <
+            attr_13 = <"leaf">
+        >
+    >
+>
+
+["id_2"] = <
+    attr_1 = <
+        attr_12 = <
+            attr_13 = <"leaf">
+        >
+    >
+>
+
+["id_N"] = <
+    attr_1 = <
+        attr_12 = <
+            attr_13 = <"leaf">
+        >
+    >
+>
+"#;
+    let parsed = parse(src).unwrap_or_else(|e| panic!("the identified form should parse: {e}"));
+    let OdinValue::KeyedList(entries) = parsed else {
+        panic!("expected a top-level keyed list, got {parsed:?}");
+    };
+    assert_eq!(
+        entries.iter().map(|(k, _)| k.clone()).collect::<Vec<_>>(),
+        vec![
+            OdinKey::String("id_1".to_owned()),
+            OdinKey::String("id_2".to_owned()),
+            OdinKey::String("id_N".to_owned()),
+        ]
+    );
+}
+
+/// "Identifiers can be values of the String, Integer or any Date/Time
+/// primitive types" (`master04-odin_artefacts` §Identified Object Document)
+/// — the non-String identifier types at top level.
+#[test]
+fn ch4_identified_document_identifier_types() {
+    let parsed = parse("[1] = <a = <1>>\n[2004-06-11] = <a = <2>>\n[10:30:00] = <a = <3>>")
+        .unwrap_or_else(|e| panic!("typed identifiers should parse: {e}"));
+    let OdinValue::KeyedList(entries) = parsed else {
+        panic!("expected a keyed list");
+    };
+    assert_eq!(
+        entries.iter().map(|(k, _)| k.clone()).collect::<Vec<_>>(),
+        vec![
+            OdinKey::Integer(1),
+            OdinKey::Date("2004-06-11".to_owned()),
+            OdinKey::Time("10:30:00".to_owned()),
+        ]
+    );
+}
+
+/// `odin_text ::= ( schema_identifier )? main_text` with
+/// `schema_identifier ::= '@' schema '=' URI`
+/// (`master04-odin_artefacts` intro; #1373 — the chapter gives no example,
+/// so the shape here is the adjudicated reading recorded at the parser
+/// site). The prefix composes with every main-text form, `parse_document`
+/// preserves it, and `parse` discards it.
+#[test]
+fn ch4_schema_identifier_prefix() {
+    let doc = parse_document("@schema = <http://openehr.org/bmm/1.0>\na = <1>")
+        .unwrap_or_else(|e| panic!("the schema-identified fragment should parse: {e}"));
+    assert_eq!(
+        doc.schema,
+        Some(OdinSchemaId {
+            name: "schema".to_owned(),
+            uri: "<http://openehr.org/bmm/1.0>".to_owned(),
+        })
+    );
+    assert!(matches!(doc.root, OdinValue::Object(_)));
+
+    // …with the anonymous and identified forms too.
+    for src in [
+        "@schema = <http://x.org/s>\n<a = <1>>",
+        "@schema = <http://x.org/s>\n[\"id\"] = <a = <1>>",
+    ] {
+        let doc = parse_document(src)
+            .unwrap_or_else(|e| panic!("the schema prefix should compose with {src:?}: {e}"));
+        assert!(doc.schema.is_some(), "{src}");
+    }
+
+    // `parse` accepts and discards the prefix.
+    let root = parse("@schema = <http://x.org/s>\na = <1>")
+        .unwrap_or_else(|e| panic!("parse should tolerate the prefix: {e}"));
+    assert!(matches!(root, OdinValue::Object(_)));
+
+    // a misplaced `@` is still a parse error.
+    assert!(parse("a = <1> @ b").is_err());
 }

--- a/crates/openehr-lang/tests/it/vendor_odin.rs
+++ b/crates/openehr-lang/tests/it/vendor_odin.rs
@@ -613,25 +613,32 @@ fn log4j2_xml_is_not_odin() {
 }
 
 #[test]
-fn anonymous_document_is_illustrative_not_grammar_valid() {
-    // Adjudication: this illustrative "ODIN Anonymous Object Document" uses the
-    // bareword meta-placeholder `leaf_value` as a leaf. Per `odin.g4`
-    // `object_value_block` a bareword is neither a `primitive_object`, an
-    // `attr_vals`, a `keyed_object`, nor an `object_reference_block` path
-    // (`base_lexer.g4` ADL_PATH requires a `/`), so it is not grammar-valid.
-    // archie has no test referencing it.
+fn anonymous_document_placeholder_leaf_is_refused() {
+    // Adjudication (re-grounded by the #854 ch.4 audit): the Anonymous
+    // Object Document FORM — an outer `<>` around a fragment — is normative
+    // and "should be supported by parsers"
+    // (`LANG/docs/odin/master04-odin_artefacts` §Anonymous Object Document);
+    // its materialized twin parses in `odin_spec_examples.rs`. What keeps
+    // THIS fixture refused is only its illustrative bareword
+    // meta-placeholder `leaf_value`: a bareword is neither a
+    // `primitive_object`, an `attr_vals`, a `keyed_object`, nor an
+    // `object_reference_block` path (`base_lexer.g4` ADL_PATH requires a
+    // `/`). archie has no test referencing it.
     let err = parse(&read("odin/odin/anonymous_odin.txt")).expect_err("bareword leaf is invalid");
     assert!(err.line >= 1 && err.column >= 1);
 }
 
 #[test]
-fn identified_document_is_illustrative_not_grammar_valid() {
-    // Adjudication: this illustrative "ODIN Identified Object Document" places
-    // keyed objects (`["id_1"] = <...>`) and a bare `...` at the top level.
-    // The `odin.g4` start rule `odin_text : attr_vals | object_value_block`
-    // does not accept a top-level keyed-object list, so it is not
-    // grammar-valid. archie has no test referencing it.
+fn identified_document_placeholder_ellipsis_is_refused() {
+    // Adjudication (re-grounded by the #854 ch.4 audit / #1374): the
+    // Identified Object Document FORM — top-level `["id"] = <…>` keyed
+    // objects — is normative (`LANG/docs/odin/master04-odin_artefacts`
+    // §Identified Object Document) and parses since #1374; its materialized
+    // twin is pinned in `odin_spec_examples.rs`. What keeps THIS fixture
+    // refused is only the illustrative bare `...` ellipsis line standing
+    // BETWEEN two keyed objects at the top level, which no production
+    // admits. archie has no test referencing it.
     let err = parse(&read("odin/odin/identified_object_document.txt"))
-        .expect_err("top-level keyed list is invalid");
+        .expect_err("a bare top-level `...` between keyed objects is invalid");
     assert!(err.line >= 1 && err.column >= 1);
 }


### PR DESCRIPTION
Closes #1373
Closes #1374
Closes #1112
Closes #1113
Closes #854

## What

Third chapter of the #753 LANG compliance program: the ODIN ch.4 ODIN Artefacts audit — both section sub-issues walked (checklists on #1112/#1113, coherence pass on #854) — with the chapter's two findings fixed per the fix-first cadence.

## Findings → fixes

**#1373 (chapter intro):** `odin_text ::= ( schema_identifier )? main_text`, `schema_identifier ::= '@' schema '=' URI` was wholly unimplemented — the ODIN reading refused `@` at the lexer and `odin_text` had no prefix production (the vendored `odin.g4` lacks it; docs text wins). Fixed: `SymAt` admitted under the ODIN reading (misplaced `@` stays a parse error — pinned), the prefix parsed, and the new `odin::parse_document` exposes it losslessly (`OdinDocument { schema: Option<OdinSchemaId>, root }`) while `parse` keeps its signature. The production's two ambiguities (undefined `schema` nonterminal, URI spelling) are adjudicated in the `// NOTE:` at the site.

**#1374 (§4.2):** Identified Object Documents — top-level keyed objects — were refused. Fixed by hoisting `keyed_objects` into `odin_text`. The two archie master-style fixture adjudications re-grounded on master04 (the FORMS are normative; only the illustrative placeholders — bareword `leaf_value`, bare top-level `...` — keep the verbatim texts refused), with materialized valid twins for both chapter examples plus the String/Integer/Date/Time identifier spread.

## Pinning

`odin_spec_examples.rs`: fragment, anonymous, identified forms + schema prefix composing with all three + `parse` discarding it + misplaced-`@` refusal. Equivalence records 88/188 re-adjudicated (cited), record 244 added (all three readings hand-checked). Lexer unit test updated with the citation (`@` moves from the refused list to a positive assertion).

## Gates

fmt + clippy + rustdoc clean; `cargo nextest run -p openehr-lang -p openehr-adl` 377/377 green. Changelog entry added.