### PR TITLE
fix(openehr-lang): ODIN ch.5 Content — VDOBU enforcement + path extraction (audit #855)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,18 @@ workflow refuses a tag that has no matching section here.
   `odin::parse_document`; the anonymous and implicit forms were already
   supported.
 
+- **ODIN path extraction.** `OdinValue::paths()` extracts the
+  `master05-content` tree-path set (attribute paths, `attr[key]` container
+  paths, nested bare-key segments) from any parsed ODIN structure.
+
 ### Fixed
 
+- **Duplicate ODIN container keys are refused (rule VDOBU).** Sibling
+  keyed objects sharing a key (`[1] = <…> [1] = <…>`) were silently
+  accepted; they now fail with a typed error per
+  `LANG/docs/odin/master05-content` §Container Objects — archetype uploads
+  whose terminology sections duplicate a term code are refused at the ODIN
+  layer.
 - **ODIN sections accept `true`/`false`/`infinity` as attribute names and
   semicolons between keyed objects.** ODIN reserves no keywords
   (`LANG/docs/odin/master03-basics` §Keywords), so archetype/template

--- a/crates/openehr-adl/tests/it/corpus_outer_parse.rs
+++ b/crates/openehr-adl/tests/it/corpus_outer_parse.rs
@@ -58,6 +58,14 @@ const EXCLUSIONS: &[(&str, &str)] = &[
         "openEHR-TEST_PKG-ENTRY.FAIL_terminology_term_definitions_missing.v1.0.0.adls",
         "terminology section is empty (no ODIN body) — violates `terminology_section : SYM_TERMINOLOGY odin_text` (SDINV)",
     ),
+    (
+        "openEHR-TEST_PKG-ENTRY.VOKU_ac_code_duplicated_in_terminology.v1.0.0.adls",
+        "duplicate sibling container keys in the terminology ODIN — refused at the ODIN layer per LANG/docs/odin/master05-content §Container Objects rule VDOBU (#1376), pre-empting the AOM-level VOKU tag (SDINV)",
+    ),
+    (
+        "openEHR-TEST_PKG-ENTRY.VOKU_at_code_duplicated_in_terminology.v1.0.0.adls",
+        "duplicate sibling container keys in the terminology ODIN — refused at the ODIN layer per LANG/docs/odin/master05-content §Container Objects rule VDOBU (#1376), pre-empting the AOM-level VOKU tag (SDINV)",
+    ),
 ];
 
 fn corpus_root() -> PathBuf {
@@ -124,4 +132,25 @@ fn every_adl2_source_outer_parses() {
         "these .adls files failed to outer-parse:\n{}",
         failures.join("\n")
     );
+}
+
+/// Every `EXCLUSIONS` entry is an intentional-FAIL fixture the outer parser
+/// must actually REJECT — an exclusion that silently starts parsing would
+/// otherwise decay into dead adjudication text.
+#[test]
+fn every_excluded_file_is_actually_rejected() {
+    let root = corpus_root();
+    let mut files = Vec::new();
+    collect_adls(&root, &mut files);
+    for (name, reason) in EXCLUSIONS {
+        let path = files
+            .iter()
+            .find(|p| p.file_name().and_then(|n| n.to_str()) == Some(name))
+            .unwrap_or_else(|| panic!("excluded fixture {name} missing from the corpus"));
+        let src = std::fs::read_to_string(path).expect("read corpus file");
+        assert!(
+            openehr_adl::source::parse_source(&src, Dialect::Adl2).is_err(),
+            "{name} parses but is excluded as: {reason}"
+        );
+    }
 }

--- a/crates/openehr-adl/tests/it/corpus_validity_integrity.rs
+++ b/crates/openehr-adl/tests/it/corpus_validity_integrity.rs
@@ -58,6 +58,20 @@ fn adjudicated_skip(name: &str) -> Option<&'static str> {
         // a documented tag/spec inconsistency (INVENTORY §3). Adjudicated in
         // both harnesses rather than weakening VARDT.
         Some("VARDT fires (ENTRY != ENTRY_WRONG, master03 L238); corpus PASS tag inconsistent")
+    } else if name.ends_with("VOKU_ac_code_duplicated_in_terminology.v1.0.0.adls")
+        || name.ends_with("VOKU_at_code_duplicated_in_terminology.v1.0.0.adls")
+    {
+        // Duplicate sibling container keys are invalid ODIN — rule VDOBU
+        // (`LANG/docs/odin/master05-content` §Container Objects), enforced at
+        // the ODIN parse since #1376 — so the terminology section is refused
+        // (SDINV) before the AOM-level VOKU check these tags name can run.
+        // Through ADL2 TEXT a terminology key duplicate is therefore
+        // structurally unreachable past the parser; the VOKU source-level
+        // check stays for programmatically-built sources and its own unit
+        // coverage.
+        Some(
+            "duplicate ODIN container keys refused at parse (VDOBU, master05) before VOKU is reachable",
+        )
     } else if name.ends_with("FAIL_dadl_spurious_delimiter.v1.0.0.adls") {
         // The file carries a spurious ODIN delimiter that the ADL2 lexer/parser
         // rejects at parse time (SDINV, `ADL2/master04.6`), before the VOTM

--- a/crates/openehr-lang/src/odin/mod.rs
+++ b/crates/openehr-lang/src/odin/mod.rs
@@ -82,6 +82,54 @@ pub enum OdinValue {
     ListContinue,
 }
 
+impl OdinValue {
+    /// The set of paths of this structure, in document order — one entry per
+    /// attribute node and per keyed container item.
+    ///
+    /// `LANG/docs/odin/master05-content` §Paths: "For any ODIN structure, a
+    /// set of paths can be extracted that correspond to the tree structure of
+    /// the data" — with the keyed forms of §Container Objects
+    /// (`/school_schedule/locations[1]`) and §Nested Container Objects
+    /// (`/list_of_string_lists[1]/[1]`). A key attaches to its attribute
+    /// segment; a key nested directly under another key opens a new bare-key
+    /// segment; typed casts are transparent; leaf values add no path beyond
+    /// their attribute's. Path SEMANTICS (Xpath mapping) are `master08`'s
+    /// subject and live with consumers.
+    #[must_use]
+    pub fn paths(&self) -> Vec<String> {
+        let mut out = Vec::new();
+        collect_paths(self, "", &mut out);
+        out
+    }
+}
+
+/// Walk `value` under `prefix`, appending every attribute and keyed-item path
+/// (see [`OdinValue::paths`]).
+fn collect_paths(value: &OdinValue, prefix: &str, out: &mut Vec<String>) {
+    match value {
+        OdinValue::Object(members) => {
+            for (name, child) in members {
+                let path = format!("{prefix}/{name}");
+                out.push(path.clone());
+                collect_paths(child, &path, out);
+            }
+        }
+        OdinValue::KeyedList(entries) => {
+            for (key, child) in entries {
+                let path = if prefix.is_empty() || prefix.ends_with(']') {
+                    format!("{prefix}/[{}]", key.path_text())
+                } else {
+                    format!("{prefix}[{}]", key.path_text())
+                };
+                out.push(path.clone());
+                collect_paths(child, &path, out);
+            }
+        }
+        OdinValue::Typed { value: inner, .. } => collect_paths(inner, prefix, out),
+        _ => {}
+    }
+}
+
 /// A keyed-list key (`key_id` in `odin.g4`).
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum OdinKey {
@@ -95,6 +143,20 @@ pub enum OdinKey {
     Time(String),
     /// An ISO8601 date/time key.
     DateTime(String),
+}
+
+impl OdinKey {
+    /// The key as written inside a path predicate — integers, dates and
+    /// times bare, strings double-quoted (`LANG/docs/odin/master05-content`
+    /// §Container Objects: `locations[1]`, `subjects["philosophy:kant"]`).
+    #[must_use]
+    pub fn path_text(&self) -> String {
+        match self {
+            Self::String(text) => format!("\"{text}\""),
+            Self::Integer(value) => value.to_string(),
+            Self::Date(text) | Self::Time(text) | Self::DateTime(text) => text.clone(),
+        }
+    }
 }
 
 /// An ODIN interval value (`odin_values.g4` `*_interval_value`).
@@ -140,6 +202,13 @@ pub enum OdinErrorKind {
     /// unique" of `AM/docs/ADL1.4/master04-dadl` §General Form. Carries the
     /// repeated name.
     DuplicateAttribute(String),
+    /// Two sibling objects of one container attribute share a key — rule
+    /// *VDOBU* of `LANG/docs/odin/master05-content` §Container Objects
+    /// ("sibling objects occurring within a container attribute must be
+    /// uniquely identified with respect to each other"). Keys compare as
+    /// their typed values, so `[01]` duplicates `[1]`. Carries the repeated
+    /// key in its path-predicate rendering.
+    DuplicateKey(String),
 }
 
 /// An ODIN parse or lex failure, with a 1-based line/column and a byte span.
@@ -228,6 +297,10 @@ pub fn parse_document(src: &str) -> Result<OdinDocument, OdinError> {
             parser::Failure::DuplicateAttribute { name, .. } => (
                 OdinErrorKind::DuplicateAttribute(name.clone()),
                 format!("duplicate sibling attribute {name:?} (VDATU)"),
+            ),
+            parser::Failure::DuplicateKey { key, .. } => (
+                OdinErrorKind::DuplicateKey(key.clone()),
+                format!("duplicate sibling container key [{key}] (VDOBU)"),
             ),
         };
         OdinError {
@@ -551,6 +624,28 @@ mod tests {
             panic!("expected keyed list");
         };
         assert_eq!(entries[0].0, OdinKey::Integer(1));
+    }
+
+    /// Rule *VDOBU* (`LANG/docs/odin/master05-content` §Container Objects):
+    /// sibling container keys must be unique; keys compare as their typed
+    /// values, so `[01]` duplicates `[1]`.
+    #[test]
+    fn duplicate_sibling_container_keys_are_refused() {
+        for src in [
+            "k = <[1] = <1> [1] = <2>>",
+            r#"k = <["a"] = <1> ["a"] = <2>>"#,
+            "k = <[1] = <1> [01] = <2>>",
+            "[1] = <1>\n[1] = <2>",
+        ] {
+            let err = parse(src).expect_err("duplicate keys must be refused (VDOBU)");
+            assert!(
+                matches!(err.kind, OdinErrorKind::DuplicateKey(_)),
+                "{src}: {err:?}"
+            );
+        }
+        // distinct keys, and the same key under different parents, are fine.
+        assert!(parse("k = <[1] = <1> [2] = <2>>").is_ok());
+        assert!(parse("p = <[1] = <1>>\nq = <[1] = <2>>").is_ok());
     }
 
     /// Rule *VDATU* (`LANG/docs/odin/master05-content` §General Structure) /

--- a/crates/openehr-lang/src/odin/parser.rs
+++ b/crates/openehr-lang/src/odin/parser.rs
@@ -35,24 +35,34 @@ pub(super) enum Failure {
         /// Token-index span of the offending (second) occurrence.
         span: SimpleSpan,
     },
+    /// VDOBU: two sibling container objects share a key
+    /// (`LANG/docs/odin/master05-content` §Container Objects).
+    DuplicateKey {
+        /// The repeated key, in its path-predicate rendering.
+        key: String,
+        /// Token-index span of the offending (second) occurrence.
+        span: SimpleSpan,
+    },
 }
 
 impl Failure {
     /// The token-index span the failure points at.
     fn span(&self) -> SimpleSpan {
         match self {
-            Self::Syntax(s) | Self::DuplicateAttribute { span: s, .. } => *s,
+            Self::Syntax(s)
+            | Self::DuplicateAttribute { span: s, .. }
+            | Self::DuplicateKey { span: s, .. } => *s,
         }
     }
 
     /// Keep whichever failure carries the most information: a typed
-    /// duplicate-attribute violation always outranks a bare syntax conflict
-    /// (the enclosing `choice`s retry other alternatives after it, and each of
-    /// those contributes a syntax error at the same position).
+    /// uniqueness violation (VDATU/VDOBU) always outranks a bare syntax
+    /// conflict (the enclosing `choice`s retry other alternatives after it,
+    /// and each of those contributes a syntax error at the same position).
     fn preferred(self, other: Self) -> Self {
         match (&self, &other) {
-            (Self::DuplicateAttribute { .. }, _) => self,
-            (_, Self::DuplicateAttribute { .. }) => other,
+            (Self::DuplicateAttribute { .. } | Self::DuplicateKey { .. }, _) => self,
+            (_, Self::DuplicateAttribute { .. } | Self::DuplicateKey { .. }) => other,
             _ => self,
         }
     }
@@ -221,6 +231,12 @@ fn attr_vals<'a>(
 fn keyed_objects<'a>(
     block: impl Parser<'a, &'a [Token], OdinValue, Err<'a>> + Clone + 'a,
 ) -> impl Parser<'a, &'a [Token], OdinValue, Err<'a>> + Clone {
+    // NOTE: the five key types are App.B's `odin.g4` `key_id : string_value |
+    // integer_value | date_value | time_value | date_time_value` — the
+    // appendix includes the grammar as its normative text. §Container Objects
+    // prose says more broadly "any primitive comparable value is allowed as
+    // the key"; the syntax appendix is the specific syntax authority, so the
+    // five-type set stands and the tension is recorded here (#1376).
     let key_id = select! {
         Token::String(s) => OdinKey::String(decode_string(&s)),
         Token::Integer(s) => OdinKey::Integer(s.parse::<i64>().unwrap_or(0)),
@@ -228,16 +244,38 @@ fn keyed_objects<'a>(
         Token::Iso8601Time(s) => OdinKey::Time(s),
         Token::Iso8601DateTime(s) => OdinKey::DateTime(s),
     };
+    // Sibling keys must be unique — rule *VDOBU*
+    // (`LANG/docs/odin/master05-content` §Container Objects: "object
+    // identifier uniqueness: sibling objects occurring within a container
+    // attribute must be uniquely identified with respect to each other").
+    // Keys compare as their typed values, so `[01]` duplicates `[1]`. A
+    // repeat is a typed [`Failure::DuplicateKey`], never a silent
+    // last-one-wins overwrite.
     just(Token::LBracket)
         .ignore_then(key_id)
         .then_ignore(just(Token::RBracket))
         .then_ignore(just(Token::SymEq))
         .then(block)
         .then_ignore(just(Token::SymSemiColon).or_not())
+        .map_with(|pair, e| (pair, e.span()))
         .repeated()
         .at_least(1)
-        .collect::<Vec<(OdinKey, OdinValue)>>()
-        .map(OdinValue::KeyedList)
+        .collect::<Vec<((OdinKey, OdinValue), SimpleSpan)>>()
+        .try_map(|entries, _| {
+            let mut seen: std::collections::HashSet<OdinKey> =
+                std::collections::HashSet::with_capacity(entries.len());
+            let mut list = Vec::with_capacity(entries.len());
+            for ((key, value), span) in entries {
+                if !seen.insert(key.clone()) {
+                    return Err(Failure::DuplicateKey {
+                        key: key.path_text(),
+                        span,
+                    });
+                }
+                list.push((key, value));
+            }
+            Ok(OdinValue::KeyedList(list))
+        })
 }
 
 /// `object_block : object_value_block | object_reference_block` (+ the

--- a/crates/openehr-lang/tests/it/odin_spec_examples.rs
+++ b/crates/openehr-lang/tests/it/odin_spec_examples.rs
@@ -278,3 +278,156 @@ fn ch4_schema_identifier_prefix() {
     // a misplaced `@` is still a parse error.
     assert!(parse("a = <1> @ b").is_err());
 }
+
+/// The `master05-content` §General Structure typical structure (its
+/// `leaf_value` placeholders materialized) and the COMPLETE 9-path set
+/// §Paths extracts from it, verbatim (#1377).
+#[test]
+fn ch5_typical_structure_and_its_complete_path_set() {
+    let src = r#"attr_1 = <
+    attr_2 = <
+        attr_3 = <"leaf">
+        attr_4 = <"leaf">
+    >
+    attr_5 = <
+        attr_3 = <
+            attr_6 = <"leaf">
+        >
+        attr_7 = <"leaf">
+    >
+>
+attr_8 = <...>"#;
+    let parsed = parse(src).unwrap_or_else(|e| panic!("the §5.1 structure should parse: {e}"));
+    assert_eq!(
+        parsed.paths(),
+        vec![
+            "/attr_1",
+            "/attr_1/attr_2",
+            "/attr_1/attr_2/attr_3",
+            "/attr_1/attr_2/attr_4",
+            "/attr_1/attr_5",
+            "/attr_1/attr_5/attr_3",
+            "/attr_1/attr_5/attr_3/attr_6",
+            "/attr_1/attr_5/attr_7",
+            "/attr_8",
+        ]
+    );
+}
+
+/// The `master05-content` §Container Objects `school_schedule` example. The
+/// VERBATIM text is refused — its `weighting = <76%>` uses a percent literal
+/// no leaf-data production defines (`master07-leaf_data`'s type set is
+/// closed; `%` is not an ODIN token) — and the materialized twin (weighting
+/// as the plain Real it is declared as) parses, with the section's two
+/// listed container paths present in its path set.
+#[test]
+fn ch5_school_schedule_twins_and_container_paths() {
+    let verbatim_weighting = "s = <weighting = <76%>>";
+    let err = parse(verbatim_weighting).expect_err("`76%` is not a leaf of any production");
+    assert_eq!(err.kind, OdinErrorKind::UnrecognisedToken);
+
+    let src = r#"school_schedule = <
+    lesson_times = <08:30:00, 09:30:00, 10:30:00, ...>
+    locations = <
+        [1] = <"under the big plane tree">
+        [2] = <"under the north arch">
+        [3] = <"in a garden">
+    >
+    subjects = <
+        ["philosophy:plato"] = <
+            name = <"philosophy">
+            teacher = <"plato">
+            topics = <"meta-physics", "natural science">
+            weighting = <76.0>
+        >
+        ["philosophy:kant"] = <
+            name = <"philosophy">
+            teacher = <"kant">
+            topics = <"meaning and reason", "meta-physics", "ethics">
+            weighting = <80.0>
+        >
+        ["art"] = <
+            name = <"art">
+            teacher = <"goya">
+            topics = <"technique", "portraiture", "satire">
+            weighting = <78.0>
+        >
+    >
+>"#;
+    let parsed =
+        parse(src).unwrap_or_else(|e| panic!("the materialized schedule should parse: {e}"));
+    let paths = parsed.paths();
+    for expected in [
+        "/school_schedule/locations[1]",
+        "/school_schedule/subjects[\"philosophy:kant\"]",
+    ] {
+        assert!(
+            paths.contains(&expected.to_owned()),
+            "{expected} missing from {paths:?}"
+        );
+    }
+}
+
+/// The `master05-content` §Nested Container Objects `List<List<String>>`
+/// example, with its listed nested-key paths (`/list_of_string_lists[1]/[1]`
+/// …) present in the extracted set.
+#[test]
+fn ch5_nested_containers_and_their_paths() {
+    let src = r#"list_of_string_lists = <
+    [1] = <
+        [1] = <"first string in first list">
+        [2] = <"second string in first list">
+    >
+    [2] = <
+        [1] = <"first string in second list">
+        [2] = <"second string in second list">
+        [3] = <"third string in second list">
+    >
+    [3] = <
+        [1] = <"only string in third list">
+    >
+>"#;
+    let parsed = parse(src).unwrap_or_else(|e| panic!("the §5.5 example should parse: {e}"));
+    let paths = parsed.paths();
+    for expected in [
+        "/list_of_string_lists[1]/[1]",
+        "/list_of_string_lists[1]/[2]",
+        "/list_of_string_lists[2]/[1]",
+    ] {
+        assert!(
+            paths.contains(&expected.to_owned()),
+            "{expected} missing from {paths:?}"
+        );
+    }
+}
+
+/// The `master05-content` §Adding Type Information `destinations` example
+/// (placeholders materialized as the `<...>` voids the chapter itself
+/// writes): dynamic-type casts at keyed and attribute positions, incl. the
+/// statically-typed-attribute default (no cast on `hotels`/`attractions`)
+/// and the fully-typed `(List<HOTEL>)` variant.
+#[test]
+fn ch5_adding_type_information_example() {
+    let src = r#"destinations = <
+    ["seville"] = (TOURIST_DESTINATION) <
+        profile = (DESTINATION_PROFILE) <...>
+        hotels = <
+            ["gran sevilla"] = (HISTORIC_HOTEL) <...>
+            ["sofitel"] = (LUXURY_HOTEL) <...>
+            ["hotel real"] = (PENSION) <...>
+        >
+        attractions = <
+            ["la corrida"] = (SPORT_VENUE) <...>
+            ["Alcázar"] = (HISTORIC_SITE) <...>
+        >
+    >
+>"#;
+    let parsed =
+        parse(src).unwrap_or_else(|e| panic!("the destinations example should parse: {e}"));
+    let paths = parsed.paths();
+    assert!(paths.contains(&"/destinations[\"seville\"]/hotels[\"gran sevilla\"]".to_owned()));
+
+    let typed = parse(r#"hotels = (List<HOTEL>) <["gran sevilla"] = (HISTORIC_HOTEL) <...>>"#)
+        .unwrap_or_else(|e| panic!("the fully-typed variant should parse: {e}"));
+    assert!(matches!(typed, OdinValue::Object(_)));
+}


### PR DESCRIPTION
Closes #1376
Closes #1377
Closes #1114
Closes #1115
Closes #1116
Closes #1117
Closes #1118
Closes #1119
Closes #855

## What

Fourth chapter of the #753 LANG compliance program: the ODIN ch.5 Content audit — all six section sub-issues walked (checklists on #1114–#1119, coherence pass on #855) — with the chapter's two findings fixed per the fix-first cadence.

## Findings → fixes

**#1376 (§5.4):** rule VDOBU was unenforced — duplicate sibling container keys parsed silently (probed: integer, string, and leading-zero variants). Fixed mirroring the existing VDATU shape: typed `OdinErrorKind::DuplicateKey` refusal at any depth, keys comparing as typed values (`[01]` ≡ `[1]`). The §5.4-prose vs App.B-grammar key-type tension is adjudicated for the grammar's five types (App.B includes `odin.g4` as its normative text), NOTE at the site.

Corpus ripple, spec-adjudicated: the two ADL2 validity fixtures that test the AOM **VOKU** rule via duplicated terminology codes now refuse at the ODIN layer before VOKU is reachable — their expectations re-grounded with master05 citations (outer-parse `EXCLUSIONS` + validity `adjudicated_skip`, same shape as the existing `FAIL_dadl_spurious_delimiter` precedent). Through ADL2 text a terminology key duplicate is now structurally unreachable past the parser; the VOKU source-level check stays for programmatic sources. A new companion test asserts every corpus exclusion actually REJECTS — closing a latent silent-skip gap for all nine entries.

**#1377 (§5.2, spanning §5.4/§5.5 path forms):** path extraction was unimplemented (carried from the ch.2 audit). `OdinValue::paths()` lands with the exact semantics the chapter's examples pin: the §5.2 9-path set asserted verbatim-complete (including the void `/attr_8`), the §5.4 `locations[1]` / `subjects["philosophy:kant"]` forms, the §5.5 nested `/list_of_string_lists[1]/[1]` bare-key segments.

**Spec-example defect:** `weighting = <76%>` — no production defines a percent literal (master07's leaf set is closed) — pinned as twins.

## Gates

fmt + clippy + rustdoc clean; `cargo nextest run -p openehr-lang -p openehr-adl` 383/383 green. Changelog entries added (VDOBU is upload-visible validation behaviour; `paths()` is new API).