### PR TITLE
chore(github): issue forms — real /rest/status example, render code blocks, drop internal maintainer notes

### DIFF
--- a/.github/ISSUE_TEMPLATE/defect.yml
+++ b/.github/ISSUE_TEMPLATE/defect.yml
@@ -1,8 +1,9 @@
 name: Bug Report
-description: Report a defect in ferroehr (wrong wire behaviour, a crash, a conformance divergence)
+description: Report a defect in FerroEHR (wrong wire behaviour, a crash, a conformance divergence)
 labels: ["bug"]
 body:
   - type: checkboxes
+    id: preflight
     attributes:
       label: Before reporting an issue
       options:
@@ -11,41 +12,70 @@ body:
         - label: I have reproduced the issue on the latest release
           required: true
   - type: textarea
+    id: server-status
+    attributes:
+      label: Server status
+      description: >
+        Paste the response of `GET <server>/ferroehr/rest/status` (unauthenticated;
+        default deployment: `http://localhost:8080/ferroehr/rest/status`).
+        It reports the server and openEHR REST API versions.
+      render: json
+      placeholder: |
+        {
+          "status": "UP",
+          "server_version": "3.15.3",
+          "openehr_rest_api_version": "1.1.0",
+          "timestamp": "2026-07-31T12:34:56.789Z"
+        }
+    validations:
+      required: true
+  - type: textarea
+    id: environment
     attributes:
       label: Environment
-      description: You can get most of this from `GET %baseUri%/ferroehr/rest/status`.
-      placeholder: |
-        - ferroehr version:
+      description: The parts the status endpoint does not report.
+      value: |
         - PostgreSQL version:
         - Deployment (compose / Helm / binary):
         - Operating system:
     validations:
       required: true
   - type: textarea
+    id: steps
     attributes:
       label: Steps to reproduce
       description: Include requests, payloads, and templates as attachments where possible.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
     validations:
       required: true
   - type: textarea
+    id: expected
     attributes:
       label: Expected behaviour
       description: For spec-governed behaviour, cite the openEHR spec section (component + document + heading) that defines the expectation.
     validations:
       required: true
   - type: textarea
+    id: actual
     attributes:
       label: Actual result
+      description: The actual response — status code, headers, and body where relevant.
     validations:
       required: true
   - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Server log lines around the failure. This is automatically formatted into a code block — no backticks needed.
+      render: shell
+    validations:
+      required: false
+  - type: textarea
+    id: further-information
     attributes:
       label: Further information
     validations:
       required: false
-  - type: markdown
-    attributes:
-      value: >
-        **Relationships** are GitHub metadata, not body text. If this defect is
-        **blocked by** or **blocks** another issue, a maintainer links it with
-        `scripts/gh-rel.sh` (policy: `.claude/rules/issue-relationships.md`).

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,34 +1,28 @@
 name: Enhancement Request
-description: Request new or extended functionality in ferroehr
+description: Request new or extended functionality in FerroEHR
 labels: ["enhancement"]
 body:
   - type: textarea
+    id: contract
     attributes:
       label: Contract
       description: What should exist and why — the context, the benefit, and any governing openEHR spec sections (or the explicit "no openEHR spec governs this" flag for an extension).
     validations:
       required: true
   - type: textarea
+    id: exit-criteria
     attributes:
       label: Exit criteria
       description: The checklist that defines "done" — observable, verifiable outcomes.
-      placeholder: |
+      value: |
         - [ ] ...
         - [ ] ...
     validations:
       required: true
   - type: textarea
+    id: further-information
     attributes:
       label: Further information
       description: Discussion links, prior art, related issues.
     validations:
       required: false
-  - type: markdown
-    attributes:
-      value: >
-        **Relationships** are GitHub metadata, not body text. After filing, link
-        this issue as a **sub-issue** (`Add parent`) if it decomposes a larger
-        issue, or with **blocked-by / blocking** for real sequencing — a
-        maintainer sets these with `scripts/gh-rel.sh`
-        (policy: `.claude/rules/issue-relationships.md`). Milestones, not epics,
-        group a release.

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -3,31 +3,25 @@ description: A general work item (maintenance, research, tooling, docs)
 labels: ["chore"]
 body:
   - type: textarea
+    id: contract
     attributes:
       label: Contract
       description: The goal of this task and its impact once completed.
     validations:
       required: true
   - type: textarea
+    id: exit-criteria
     attributes:
       label: Exit criteria
       description: The checklist that defines "done".
-      placeholder: |
+      value: |
         - [ ] ...
         - [ ] ...
     validations:
       required: true
   - type: textarea
+    id: further-information
     attributes:
       label: Further information
     validations:
       required: false
-  - type: markdown
-    attributes:
-      value: >
-        **Relationships** are GitHub metadata, not body text. After filing, link
-        this issue as a **sub-issue** (`Add parent`) if it decomposes a larger
-        issue, or with **blocked-by / blocking** for real sequencing — a
-        maintainer sets these with `scripts/gh-rel.sh`
-        (policy: `.claude/rules/issue-relationships.md`). Milestones, not epics,
-        group a release.


### PR DESCRIPTION
## What

Reworks the three issue forms in `.github/ISSUE_TEMPLATE/` against the GitHub issue-forms syntax docs and the actual server surface.

### Bug Report (`defect.yml`)
- The Environment field claimed \`GET %baseUri%/ferroehr/rest/status\` provides "most of" the environment info — wrong on both counts. The real endpoint is \`GET <server>/ferroehr/rest/status\` (unauthenticated, mounted outside the auth layer; default \`http://localhost:8080/ferroehr/rest/status\`), and it reports only \`{status, server_version, openehr_rest_api_version, timestamp}\` (\`app/ferroehr-rest/src/overview/status.rs\`) — no PostgreSQL/OS info.
- Split into a dedicated **Server status** textarea with \`render: json\` (submitted content is auto-wrapped in a code block per the issue-forms syntax — no backticks needed) whose placeholder shows the real response shape, plus a slimmed **Environment** field pre-filled (\`value:\`) with only the parts the status document does not report.
- Added an optional **Relevant log output** textarea with \`render: shell\`, and a description on **Actual result** asking for status code/headers/body.
- Numbered-steps placeholder on **Steps to reproduce**.

### All three forms
- Removed the "Relationships are GitHub metadata… \`scripts/gh-rel.sh\`" markdown blocks — internal maintainer/agent workflow notes that mean nothing to an outside reporter (they cannot run repo scripts; relationship discipline lives in \`.claude/rules/issue-relationships.md\` for maintainers).
- Added stable \`id:\` attributes to every field (issue-forms best practice).
- Exit-criteria checklists moved from \`placeholder:\` to \`value:\` so the checklist skeleton actually lands in the filed issue instead of vanishing on first keystroke.
- Product name spelled FerroEHR in template descriptions.

Not adopted: the top-level \`type:\` key (GitHub issue types are an organization feature; this repo is user-owned) and \`config.yml\` (blank issues must stay enabled — the maintainer workflow files issues via \`gh issue create\`).

No user-visible product change (templates only) — \`no-changelog\`.