### PR TITLE
docs: spell the product name FerroEHR in prose (identifiers stay lowercase)

### DIFF
--- a/app/ferroehr-rest/examples/policies/README.md
+++ b/app/ferroehr-rest/examples/policies/README.md
@@ -1,6 +1,6 @@
 # Example Cedar policies
 
-Illustrative embedded-Cedar policies for the ferroehr ABAC layer
+Illustrative embedded-Cedar policies for the FerroEHR ABAC layer
 (no openEHR spec governs authorization — our own design; the shipped rules
 live in `.claude/rules/auth.md`). Point `abac.cedar.policy_dir` at a
 copy of this directory (or your own) to try the embedded engine.

--- a/app/ferroehr-rest/src/extensions/access/authz/mod.rs
+++ b/app/ferroehr-rest/src/extensions/access/authz/mod.rs
@@ -1,4 +1,4 @@
-//! Authorization for the ferroehr CDR — the two composable layers,
+//! Authorization for the FerroEHR CDR — the two composable layers,
 //! folded into the protocol adapter
 //! (authorization is an adapter concern by design; the former `ferroehr-authz`
 //! crate is dissolved here).

--- a/app/ferroehr-rest/src/extensions/access/authz/roles.rs
+++ b/app/ferroehr-rest/src/extensions/access/authz/roles.rs
@@ -133,7 +133,7 @@ pub fn authorize(class: OperationClass, roles: &[String], rbac: &RbacConfig) -> 
 // NOTE: no openEHR spec governs this — our own design/extension. The SM places
 // authorization out of band (SM `openehr_platform/master02-overview.adoc`
 // §General Assumptions) and no CNF profile carries a role requirement; the
-// read-only role is an ferroehr enterprise capability supporting the CNF
+// read-only role is a FerroEHR enterprise capability supporting the CNF
 // SEC-BASIC authorization-separation profile (an authenticated principal
 // refused on every write). It composes on top of the [`authorize`] class gate.
 #[must_use]

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -28,5 +28,5 @@ home: https://github.com/rubentalstra/FerroEHR
 sources:
   - https://github.com/rubentalstra/FerroEHR
 maintainers:
-  - name: ferroehr maintainers
+  - name: FerroEHR maintainers
     url: https://github.com/rubentalstra/FerroEHR

--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -1,4 +1,4 @@
-# Observability overlay for the ferroehr dev stack.
+# Observability overlay for the FerroEHR dev stack.
 #
 #   docker compose -f docker-compose.yml -f docker-compose.observability.yml up --build
 #

--- a/docker/postgres/README.md
+++ b/docker/postgres/README.md
@@ -1,6 +1,6 @@
 # ferroehr-postgres
 
-A preconfigured PostgreSQL 18 image for ferroehr, mirroring the official
+A preconfigured PostgreSQL 18 image for FerroEHR, mirroring the official
 `ehrbase/ehrbase-v2-postgres` two-image model built fresh for this stack
 (the greenfield PG18 storage design, `docs/architecture.md` §Storage). It is `postgres:18.4` plus one-time init scripts.
 

--- a/docs/conformance/cnf-design.md
+++ b/docs/conformance/cnf-design.md
@@ -71,7 +71,7 @@ SM-anchors/ITS-executes split, tech profiles, and the global ID scheme are
 the 2021–2022 community's work. The deltas are five: one-file-per-case data
 with generated prose; CI enforcement of the derivation chain; computable
 Statement/results schemas with mechanically computed verdicts; the
-governance/resourcing charter; and the ISO/EHDS grounding. ferroehr's ECC
+governance/resourcing charter; and the ISO/EHDS grounding. FerroEHR's ECC
 (394 cases, both wire formats, machine-computed verdicts on the CNF profiles
 model) is the working draft and one reference implementation — explicitly
 not "the standard": the standard is community-owned, vendor-neutral, and
@@ -1920,7 +1920,7 @@ latencies are recorded as lineage only. Procurers who need tighter tails or
 the read-heavy band ceiling tighten per tender via the §10 template
 parameters. Corpus sizes are the 2017 D-row scale ladder. Feasibility is
 evidenced by the committed measurement artifacts (`docs/benchmarks/`,
-regenerated per release, never hand-typed): ferroehr sustains a
+regenerated per release, never hand-typed): FerroEHR sustains a
 631.5 req/s knee at p99 204.7 ms and upstream EHRbase 475.0 req/s
 (`ferroehr/KNEE.md`, `ehrbase-java/KNEE.md`) on 8-core consumer hardware —
 the class-L floor (150/s) is comfortably attainable — a consumer laptop
@@ -2186,7 +2186,7 @@ once §8.3 makes cases enumerable files:
    archives); off-wire capabilities move to statement-declared, not
    schedule-tested — the honest boundary.
 8. **N/A re-adjudication of donated material (hard gate)** — every donated
-   case whose evidence or N/A justification points at ferroehr internal
+   case whose evidence or N/A justification points at FerroEHR internal
    tests is re-adjudicated to spec-text-only evidence **before** entering the
    normative catalogue. No exceptions; this is a scoped workstream, not an
    assumption.
@@ -2251,7 +2251,7 @@ the difference between "nice idea, same risk" and "resourced program".
   be — and a sponsoring vendor is never the sole adjudicator of its own
   sponsored cases: sponsored work is scoped to case authorship reviewed
   against spec text by non-sponsor maintainers.
-- **Commitments in hand**: ferroehr commits the pilot engineering (§14).
+- **Commitments in hand**: FerroEHR commits the pilot engineering (§14).
   The upstream ask explicitly requests matching co-commitments — a second
   vendor's engineering time and 2–3 maintainer volunteers — before the SEC
   agenda item, so the SEC decides on a resourced plan, not a hope.
@@ -2270,7 +2270,7 @@ the difference between "nice idea, same risk" and "resourced program".
 3. **SEC agenda item**: adopt-the-format decision, the maintainer-group
    charter, the AQL chapter blessed as the pilot.
 4. **Execution**: the §14.1 PR series; the registry the moment two products
-   publish (ferroehr volunteers; upstream EHRbase, already assessed by ECC,
+   publish (FerroEHR volunteers; upstream EHRbase, already assessed by ECC,
    is the natural second); an EHRCON26 conformance slot; EHDS liaison per
    §6.5 (track the Art 36/15 implementing acts; revisit the EEHRxF-seam
    profile when they land in 2027).
@@ -2312,7 +2312,7 @@ acceptance gate:
 | U5 | **master11/AQL — the first new chapter**: the §8.6 equivalence rules as normative schema text + ~37 cases seeded from ECC QRY/SQR/AQT (25 QRY + 8 SQR + 4 AQT) + the EHRbase AQL corpus | SEC ratifies the §8.6 [legislated] defaults FIRST; every case spec-cited to AQL 1.1 |
 | U6 | **Simplified-Formats chapter** (new): the §8.7 fifteen categories, ~60 cases driven from the master04/05/06 spec-example blocks | Every case cites its simplified_formats section; OPTIONS-profile placement |
 | U7 | statement/results/ixit schemas + verdict rules + the reference verdict implementation + the runner verification pack (transcripts + adjudications) | Two independent runners (ECC + the rescued Robot suite or another vendor's) compute identical verdicts on the pack |
-| U8 | The registry (production, on openehr.org): statement rendering, attestation-level labels, badges, dispute log | First two products listed (ferroehr + upstream EHRbase baselines) |
+| U8 | The registry (production, on openehr.org): statement rendering, attestation-level labels, badges, dispute log | First two products listed (FerroEHR + upstream EHRbase baselines) |
 
 The performance & volumetrics chapter (§8.14 + §11.4), Demographic
 (master10), and Admin/Messaging (master12/13) follow as U9+ per the §11

--- a/tools/cnf-runner/CLAUDE.md
+++ b/tools/cnf-runner/CLAUDE.md
@@ -104,7 +104,7 @@ the dev-compose defaults are exported by `scripts/conformance.sh`.
   §Supported Authentication Flows, so the runner takes the Authorization-Server
   role for that lane only). Undeclared => not-applicable with the citation,
   never a driven guess. The SMART resource-server posture IS the standard
-  ferroehr conformance posture (owner ruling 2026-07-28): the pipeline
+  FerroEHR conformance posture (owner ruling 2026-07-28): the pipeline
   always overlays `docker/sut-smart.yml`, the ixit's principals mint scoped
   Bearer tokens (per-instance standing grants; a step-level `scopes:`
   overrides for the boundary cases), and the ONE committed record covers the

--- a/tools/cnf-runner/party/smart/README.md
+++ b/tools/cnf-runner/party/smart/README.md
@@ -39,7 +39,7 @@ openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 \
    the `sut`/`admin`/`readonly` principals carry `bearer_mint` auth with
    per-instance roles + standing scope grants, and the `smart_app` instance
    mints exactly the step-declared `scopes` for the boundary cases.
-3. `scripts/conformance.sh` composes the posture on every ferroehr run —
+3. `scripts/conformance.sh` composes the posture on every FerroEHR run —
    it IS the standard conformance posture (owner ruling 2026-07-28), so the
    one committed record covers the whole claimed surface in one invocation.
 

--- a/website/book/src/benchmarks.md
+++ b/website/book/src/benchmarks.md
@@ -76,7 +76,7 @@ on its own freshly composed stack with its own committed party statement;
 payload skeletons are byte-identical; database maintenance is settled
 deterministically on both sides before every measured window; configuration
 parity is explicit (connection pools raised in lockstep; version signing —
-an ferroehr extension upstream does not perform — disabled for throughput
+a FerroEHR extension upstream does not perform — disabled for throughput
 comparisons and labeled). Both directions publish on equal footing: where
 upstream sustains more, its curve says so exactly like the reverse — see
 [Comparison](comparison.md).

--- a/website/book/src/beyond-core/demographics.md
+++ b/website/book/src/beyond-core/demographics.md
@@ -47,7 +47,7 @@ tags (`/demographic/tags`, `/demographic/{kind}/{uid_based_id}/tags`, and
 
 ## Relationships
 
-Party relationships are managed through a parallel set of routes (an FerroEHR
+Party relationships are managed through a parallel set of routes (a FerroEHR
 extension), with the same versioned shape as parties:
 
 | Method | Path | Purpose |

--- a/website/book/src/operations.md
+++ b/website/book/src/operations.md
@@ -189,7 +189,7 @@ but currently serves no method (see
   reach this response.
 
 > [!NOTE]
-> The template and stored-query deletes and the config view are ferroehr
+> The template and stored-query deletes and the config view are FerroEHR
 > extensions — the openEHR admin API defines only EHR deletes. They share the
 > same admin gate and authorization as the EHR deletes.
 
@@ -306,7 +306,7 @@ while the rest of the archive loads.
 
 > [!NOTE]
 > The activity report, the archive routes, and the dump/load pair are
-> ferroehr extensions too — the openEHR *service model* defines these
+> FerroEHR extensions too — the openEHR *service model* defines these
 > operations, but the released REST API surfaces no endpoint for them, so their
 > URLs are our own. They gate no openEHR conformance claim; see
 > [Conformance](conformance.md).
@@ -369,7 +369,7 @@ clinical content.
   limit, which answers **413** when exceeded.
 
 > [!NOTE]
-> The whole `/message` group is an ferroehr extension: the openEHR service
+> The whole `/message` group is a FerroEHR extension: the openEHR service
 > model defines a Message component, but the released REST API publishes no
 > message, extract, or TDD endpoints at all. These URLs are our own and gate no
 > openEHR conformance claim; see [Conformance](conformance.md).

--- a/website/book/src/security.md
+++ b/website/book/src/security.md
@@ -132,7 +132,7 @@ switches that EHR to explicit policy:
   `EHR_ACCESS` endpoint in the openEHR REST API). Changes are versioned and
   audited like all record content.
 
-The scheme is an FerroEHR extension: openEHR mandates the `EHR_ACCESS`
+The scheme is a FerroEHR extension: openEHR mandates the `EHR_ACCESS`
 object and its change control but publishes no concrete access-control
 scheme. Query (AQL) results are not filtered by privacy level in this
 release; the per-EHR gate still applies to EHR-scoped query routes.

--- a/website/book/src/using-the-api/content-negotiation.md
+++ b/website/book/src/using-the-api/content-negotiation.md
@@ -76,7 +76,7 @@ What to expect:
   canonical RM resource.
 
 > [!NOTE]
-> The `version` parameter is an FerroEHR extension: the openEHR REST
+> The `version` parameter is a FerroEHR extension: the openEHR REST
 > specification predates the two schema lineages and says nothing about
 > selecting one. It never changes the media type itself — responses are always
 > `application/xml` — so a client that ignores it behaves exactly as the

--- a/website/book/src/using-the-api/resources.md
+++ b/website/book/src/using-the-api/resources.md
@@ -237,7 +237,7 @@ invalid input, unknown EHR, or a uid conflict.
 contribution, or **404**.
 
 `GET /ehr/{ehr_id}/contribution` (no uid) lists the EHR's contributions,
-newest first — an ferroehr extension (the openEHR REST API defines only the
+newest first — a FerroEHR extension (the openEHR REST API defines only the
 by-uid read). Paginate with `?offset=` (default 0) and `?fetch=` (default 20,
 capped at 100). It returns **200** with a JSON summary, or **404** for an
 unknown EHR:


### PR DESCRIPTION
## What

FerroEHR is the official product name (#1353); prose still said lowercase \`ferroehr\` in a number of hand-written places. This sweep fixes every prose mention of the *product* while leaving every technical identifier untouched — crate/bin names, \`/ferroehr/rest\` paths, \`FERROEHR_*\`/\`FERROEHR__*\` env vars, dev credentials (\`ferroehr:ferroehr\`), DB/schema/user names, compose service + Helm chart/release names, SUT ids, urns, and log-filter targets (\`ferroehr=info\`) all stay lowercase by design.

Fixed:
- website book prose (operations, benchmarks, resources, content-negotiation, security, demographics) — including the pre-existing "an ferroehr/an FerroEHR extension" article bugs → "a FerroEHR extension"
- \`docker/postgres/README.md\`, \`app/ferroehr-rest/examples/policies/README.md\`, \`docker-compose.observability.yml\` header comment
- \`docs/conformance/cnf-design.md\` (the permanent design record) prose
- \`tools/cnf-runner/CLAUDE.md\` + \`tools/cnf-runner/party/smart/README.md\` prose
- \`deploy/helm/ferroehr/Chart.yaml\` maintainers display name (chart \`name:\` stays \`ferroehr\`)
- two Rust doc comments in \`ferroehr-rest::extensions::access::authz\` (comment-only; no code change)

Deliberately NOT touched:
- **Generated conformance run records** (\`docs/conformance/ferroehr/CONFORMANCE_*\`, \`COMPARISON.md\`) — never hand-edited; the renderer-side display-name fix is filed as #1381 and lands with the next conformance run.
- **CNF catalogue/register artifacts** (\`tools/cnf-runner/artifacts/**\`) — "the ferroehr statement" there names the SUT identity, and adjudication records stay as written.
- CHANGELOG history and all code identifiers.

Docs/comment spelling only — no user-visible behaviour change (\`no-changelog\`).