### PR TITLE
fix(openehr-lang): ODIN ch.6 References — cross-object reference paths (audit #856)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ workflow refuses a tag that has no matching section here.
   `odin::parse_document`; the anonymous and implicit forms were already
   supported.
 
+- **ODIN cross-object references parse.** Reference paths rooted at an
+  object identifier (`<["tourism_db_13"]/hotels["sofitel"]>`,
+  `master06-references` §Across Objects) are accepted alongside the
+  existing within-object reference forms.
 - **ODIN path extraction.** `OdinValue::paths()` extracts the
   `master05-content` tree-path set (attribute paths, `attr[key]` container
   paths, nested bare-key segments) from any parsed ODIN structure.

--- a/crates/openehr-lang/src/odin/parser.rs
+++ b/crates/openehr-lang/src/odin/parser.rs
@@ -231,19 +231,7 @@ fn attr_vals<'a>(
 fn keyed_objects<'a>(
     block: impl Parser<'a, &'a [Token], OdinValue, Err<'a>> + Clone + 'a,
 ) -> impl Parser<'a, &'a [Token], OdinValue, Err<'a>> + Clone {
-    // NOTE: the five key types are App.B's `odin.g4` `key_id : string_value |
-    // integer_value | date_value | time_value | date_time_value` — the
-    // appendix includes the grammar as its normative text. §Container Objects
-    // prose says more broadly "any primitive comparable value is allowed as
-    // the key"; the syntax appendix is the specific syntax authority, so the
-    // five-type set stands and the tension is recorded here (#1376).
-    let key_id = select! {
-        Token::String(s) => OdinKey::String(decode_string(&s)),
-        Token::Integer(s) => OdinKey::Integer(s.parse::<i64>().unwrap_or(0)),
-        Token::Iso8601Date(s) => OdinKey::Date(s),
-        Token::Iso8601Time(s) => OdinKey::Time(s),
-        Token::Iso8601DateTime(s) => OdinKey::DateTime(s),
-    };
+    let key_id = key_id();
     // Sibling keys must be unique — rule *VDOBU*
     // (`LANG/docs/odin/master05-content` §Container Objects: "object
     // identifier uniqueness: sibling objects occurring within a container
@@ -278,6 +266,24 @@ fn keyed_objects<'a>(
         })
 }
 
+/// `'[' key_id ']'`'s inner key (`odin.g4 key_id`).
+///
+/// NOTE: the five key types are App.B's `odin.g4` `key_id : string_value |
+/// integer_value | date_value | time_value | date_time_value` — the appendix
+/// includes the grammar as its normative text. §Container Objects prose says
+/// more broadly "any primitive comparable value is allowed as the key"; the
+/// syntax appendix is the specific syntax authority, so the five-type set
+/// stands and the tension is recorded here (#1376).
+fn key_id<'a>() -> impl Parser<'a, &'a [Token], OdinKey, Err<'a>> + Clone {
+    select! {
+        Token::String(s) => OdinKey::String(decode_string(&s)),
+        Token::Integer(s) => OdinKey::Integer(s.parse::<i64>().unwrap_or(0)),
+        Token::Iso8601Date(s) => OdinKey::Date(s),
+        Token::Iso8601Time(s) => OdinKey::Time(s),
+        Token::Iso8601DateTime(s) => OdinKey::DateTime(s),
+    }
+}
+
 /// `object_block : object_value_block | object_reference_block` (+ the
 /// `EMBEDDED_URI` and typed-cast forms).
 fn object_block<'a>() -> impl Parser<'a, &'a [Token], OdinValue, Err<'a>> + Clone {
@@ -285,7 +291,23 @@ fn object_block<'a>() -> impl Parser<'a, &'a [Token], OdinValue, Err<'a>> + Clon
         let keyed_list = keyed_objects(block.clone());
 
         // object_reference_block : odin_path ( (',' odin_path)+ | '...' )?
-        let path = select! { Token::AdlPath(s) => s }.or(just(Token::SymSlash).to("/".to_owned()));
+        //
+        // A reference path may be rooted at an object identifier —
+        // `<["tourism_db_13"]/hotels["sofitel"]>` — for references across the
+        // identified objects of one document
+        // (`LANG/docs/odin/master06-references` §Across Objects; the vendored
+        // `odin.g4` `odin_path` lacks the form, and the docs text wins). The
+        // key is reconstructed verbatim into the path text.
+        let bare_path =
+            select! { Token::AdlPath(s) => s }.or(just(Token::SymSlash).to("/".to_owned()));
+        let path = key_id()
+            .delimited_by(just(Token::LBracket), just(Token::RBracket))
+            .or_not()
+            .then(bare_path)
+            .map(|(root, p)| match root {
+                Some(key) => format!("[{}]{p}", key.path_text()),
+                None => p,
+            });
         let ref_list = path
             .clone()
             .then(
@@ -324,8 +346,8 @@ fn object_block<'a>() -> impl Parser<'a, &'a [Token], OdinValue, Err<'a>> + Clon
 
         let inner = choice((
             void,
-            ref_list,
             keyed_list,
+            ref_list,
             attr_vals(block.clone()),
             primitive_object(),
         ));

--- a/crates/openehr-lang/tests/it/odin_spec_examples.rs
+++ b/crates/openehr-lang/tests/it/odin_spec_examples.rs
@@ -431,3 +431,87 @@ fn ch5_adding_type_information_example() {
         .unwrap_or_else(|e| panic!("the fully-typed variant should parse: {e}"));
     assert!(matches!(typed, OdinValue::Object(_)));
 }
+
+/// The `master06-references` §Within An Object example — associations as
+/// fully-qualified reference paths (`</hotels["sofitel"]>`), shared objects
+/// under a sibling top-level attribute.
+#[test]
+fn ch6_within_object_references_example() {
+    let src = r#"destinations = <
+    ["seville"] = <
+        hotels = <
+            ["gran sevilla"] = </hotels["gran sevilla"]>
+            ["sofitel"] = </hotels["sofitel"]>
+            ["hotel real"] = </hotels["hotel real"]>
+        >
+    >
+>
+
+bookings = <
+    ["seville:0134"] = <
+        customer_id = <"0134">
+        period = <...>
+        hotel = </hotels["sofitel"]>
+    >
+>
+
+hotels = <
+    ["gran sevilla"] = (HISTORIC_HOTEL) <...>
+    ["sofitel"] = (LUXURY_HOTEL) <...>
+    ["hotel real"] = (PENSION) <...>
+>"#;
+    let parsed = parse(src).unwrap_or_else(|e| panic!("the §Within example should parse: {e}"));
+    let OdinValue::Object(top) = &parsed else {
+        panic!("expected a top-level object");
+    };
+    assert_eq!(top.len(), 3);
+    // the booking's hotel association is a single-path reference block.
+    let paths = parsed.paths();
+    assert!(paths.contains(&"/bookings[\"seville:0134\"]/hotel".to_owned()));
+}
+
+/// The `master06-references` §Across Objects example — an Identified Object
+/// Document whose reference paths are rooted at object identifiers
+/// (`<["tourism_db_13"]/hotels["sofitel"]>`; #1380).
+#[test]
+fn ch6_across_objects_references_example() {
+    let src = r#"["travel_db_0293822"] = <
+    destinations = <
+        ["seville"] = <
+            hotels = <
+                ["gran sevilla"] = <["tourism_db_13"]/hotels["gran sevilla"]>
+                ["sofitel"] = <["tourism_db_13"]/hotels["sofitel"]>
+                ["hotel real"] = <["tourism_db_13"]/hotels["hotel real"]>
+            >
+        >
+    >
+
+    bookings = <
+        ["seville:0134"] = <
+            customer_id = <"0134">
+            period = <...>
+            hotel = <["tourism_db_13"]/hotels["sofitel"]>
+        >
+    >
+>
+
+["tourism_db_13"] = <
+    hotels = <
+        ["gran sevilla"] = (HISTORIC_HOTEL) <...>
+        ["sofitel"] = (LUXURY_HOTEL) <...>
+        ["hotel real"] = (PENSION) <...>
+    >
+>"#;
+    let parsed = parse(src).unwrap_or_else(|e| panic!("the §Across example should parse: {e}"));
+    let OdinValue::KeyedList(entries) = &parsed else {
+        panic!("expected a top-level identified document");
+    };
+    assert_eq!(entries.len(), 2);
+
+    // the association carries the key-rooted path verbatim.
+    let flat = format!("{parsed:?}");
+    assert!(
+        flat.contains(r#"[\"tourism_db_13\"]/hotels[\"sofitel\"]"#),
+        "key-rooted reference path missing: {flat}"
+    );
+}


### PR DESCRIPTION
Closes #1380
Closes #856

## What

Fifth chapter of the #753 LANG compliance program: the ODIN ch.6 References audit (single-section chapter; walked checklist on #856) and its one finding fixed.

## Finding → fix

**#1380:** §Across Objects reference paths root at object identifiers (`<["tourism_db_13"]/hotels["sofitel"]>`) — refused, since `odin_path` (vendored grammar) has no key-rooted form; the docs text wins. Fixed with an optional leading `[key_id]` segment per reference path (shared `key_id` production, key reconstructed verbatim into the path text). Everything else in the chapter already parsed (within-object references incl. spaced string predicates, typed casts before references, multi-path blocks, URI references) — probed and the two chapter examples pinned in `odin_spec_examples.rs`. Resolution semantics are recorded as the honest boundary (representation only; no normative resolution procedure, no in-repo consumer dereferences ODIN references).

Incidental hardening: `keyed_objects` now precedes the reference block in the inner choice, keeping the typed VDOBU refusal the winning error now that references can also begin with `[`.

## Gates

fmt + clippy + rustdoc clean; `cargo nextest run -p openehr-lang -p openehr-adl` 385/385 green. Changelog entry added.