### PR TITLE
fix(openehr-lang): ODIN ch.7 Leaf Data — interval lists + list homogeneity (audit #857)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **ODIN leaf lists are type-homogeneous and admit interval lists.** Mixed-kind
+  lists (`<1, "x">`) are refused per the per-type list productions of the
+  ODIN syntax specification, and interval lists (`<|0..5|, |8..9|>`,
+  including the open `, ...` form) now parse.
 - **Duplicate ODIN container keys are refused (rule VDOBU).** Sibling
   keyed objects sharing a key (`[1] = <…> [1] = <…>`) were silently
   accepted; they now fail with a typed error per

--- a/crates/openehr-lang/src/lexer/token.rs
+++ b/crates/openehr-lang/src/lexer/token.rs
@@ -350,6 +350,14 @@ pub enum Token {
     #[regex(r"\[[a-zA-Z][a-zA-Z0-9._\-]*\]", |lex| lex.slice().to_owned())]
     LocalTermCodeRef(String),
     /// An embedded URI `<scheme:…>` (`EMBEDDED_URI`).
+    ///
+    /// NOTE: captured VERBATIM — the token pins only the `scheme:` shape.
+    /// `LANG/docs/odin/master07-leaf_data` §URIs says ODIN URIs "follow the
+    /// standard syntax from IETF RFC 3986" (percent-encoding per `master03`
+    /// §File Encoding), but RFC 3986 validity is deliberately NOT policed at
+    /// the lexical layer: refusing here would punish real-world authored
+    /// data, and URI validity is the consuming model's typed concern
+    /// (adjudicated at the #1122 §7.3 audit).
     #[regex(r"<[ \t\r\n]*[a-zA-Z][a-zA-Z0-9+.\-]*:[^>]*>", |lex| lex.slice().to_owned())]
     EmbeddedUri(String),
     /// An ADL path (`base_lexer.g4 ADL_PATH`), each segment

--- a/crates/openehr-lang/src/odin/parser.rs
+++ b/crates/openehr-lang/src/odin/parser.rs
@@ -443,49 +443,70 @@ fn rm_type_id<'a>() -> impl Parser<'a, &'a [Token], String, Err<'a>> + Clone {
 }
 
 /// `primitive_object : primitive_value | primitive_list_value |
-/// primitive_interval_value`.
+/// primitive_interval_value` (+ the `*_interval_list_value` productions).
 fn primitive_object<'a>() -> impl Parser<'a, &'a [Token], OdinValue, Err<'a>> + Clone {
     let leaf = leaf_value();
 
-    // primitive_value | primitive_list_value: a single leaf (scalar), or a
-    // comma-separated list of leaves, optionally left open with a trailing
-    // `, ...` continuation marker. Per `master07` §"Lists of Built-in Types",
-    // `...` is the open-list continuation marker: a single-datum list `v, ...`
-    // *requires* it (to distinguish the list from a bare scalar `v`), and a
-    // multi-datum list `v1, v2, ..., vn, ...` may equally be left open with it
-    // (as the published CIMI reference-model schemas do). The `odin_values.g4`
+    // A list item is a leaf value or an interval — `odin_values.g4` (App.B)
+    // defines both the per-type `*_list_value` productions and the per-type
+    // `*_interval_list_value` productions (`|0..5|, |8..9|` and the open
+    // `|0..5|, ...`).
+    let item = choice((interval_value(leaf.clone()), leaf));
+
+    // primitive_value | primitive_list_value | *_interval_list_value: a
+    // single item (scalar), or a comma-separated list, optionally left open
+    // with a trailing `, ...` continuation marker. Per `master07` §"Lists of
+    // Built-in Types", `...` is the open-list continuation marker: a
+    // single-datum list `v, ...` *requires* it (to distinguish the list from
+    // a bare scalar `v`), and a multi-datum list `v1, v2, ..., vn, ...` may
+    // equally be left open with it (as the published CIMI reference-model
+    // schemas do). The `odin_values.g4`
     // `string_list_value : v ( (',' v)+ | ',' SYM_LIST_CONTINUE )` encoding
     // admits only the single-datum-plus-continue and the closed-multi forms;
-    // the general `v (',' v)* (',' '...')?` accepted here is a strict superset
-    // that additionally admits the open multi-datum list the spec prose
-    // describes. A bare leaf with no following comma stays a scalar.
-    let list = leaf
-        .clone()
+    // the general `v (',' v)* (',' '...')?` accepted here is a strict
+    // superset that additionally admits the open multi-datum list the spec
+    // prose describes. A bare item with no following comma stays a scalar.
+    //
+    // Lists are HOMOGENEOUS: every `odin_values.g4` list production is
+    // per-type, and §Lists of Built-in Types says "comma-separated lists of
+    // items, all of the same type" — a kind mismatch is a typed refusal at
+    // the offending item, never a silently mixed list. Kinds compare at the
+    // value-variant level (Integer ≠ Real, Date ≠ Date_time, …); NOTE: an
+    // interval item's ENDPOINT type is not re-checked here — the per-type
+    // interval productions already pin each interval's own endpoints, and
+    // interval-list endpoint homogeneity beyond the variant level is left to
+    // the consuming model.
+    item.clone()
+        .map_with(|value, e| (value, e.span()))
         .then(
             just(Token::SymComma)
-                .ignore_then(leaf.clone())
+                .ignore_then(item.map_with(|value, e| (value, e.span())))
                 .repeated()
-                .collect::<Vec<OdinValue>>(),
+                .collect::<Vec<(OdinValue, SimpleSpan)>>(),
         )
         .then(
             just(Token::SymComma)
                 .ignore_then(just(Token::SymListContinue))
                 .or_not(),
         )
-        .map(|((first, mut more), open)| {
+        .try_map(|(((first, _), more), open), _| {
             if more.is_empty() && open.is_none() {
-                first
-            } else {
-                let mut v = vec![first];
-                v.append(&mut more);
-                if open.is_some() {
-                    v.push(OdinValue::ListContinue);
-                }
-                OdinValue::List(v)
+                return Ok(first);
             }
-        });
-
-    interval_value(leaf).or(list)
+            let kind = std::mem::discriminant(&first);
+            let mut values = Vec::with_capacity(more.len() + 2);
+            values.push(first);
+            for (value, span) in more {
+                if std::mem::discriminant(&value) != kind {
+                    return Err(Failure::Syntax(span));
+                }
+                values.push(value);
+            }
+            if open.is_some() {
+                values.push(OdinValue::ListContinue);
+            }
+            Ok(OdinValue::List(values))
+        })
 }
 
 /// One interval `| … |` (`odin_values.g4` `*_interval_value`).

--- a/crates/openehr-lang/tests/it/odin_spec_examples.rs
+++ b/crates/openehr-lang/tests/it/odin_spec_examples.rs
@@ -515,3 +515,162 @@ fn ch6_across_objects_references_example() {
         "key-rooted reference path missing: {flat}"
     );
 }
+
+/// The `master07-leaf_data` §Lists of Built-in Types examples — homogeneous
+/// leaf lists, singleton `v, ...` lists, and the whitespace-free identity
+/// pair — plus the App.B interval-list productions and the homogeneity
+/// refusal twins (#1384).
+#[test]
+fn ch7_lists_of_built_in_types() {
+    // the section's three list examples.
+    for src in [
+        r#"a = <"cyan", "magenta", "yellow", "black">"#,
+        "a = <1, 1, 2, 3, 5>",
+        "a = <08:02, 08:35, 09:10>",
+    ] {
+        let parsed = parse(src).unwrap_or_else(|e| panic!("{src} should parse: {e}"));
+        let OdinValue::Object(top) = parsed else {
+            panic!("expected object");
+        };
+        assert!(matches!(top.get("a"), Some(OdinValue::List(_))), "{src}");
+    }
+
+    // singleton lists carry the continuation marker.
+    for src in [
+        r#"a = <"en", ...>"#,
+        r#"a = <"icd10", ...>"#,
+        "a = <[at0200], ...>",
+    ] {
+        let parsed = parse(src).unwrap_or_else(|e| panic!("{src} should parse: {e}"));
+        let OdinValue::Object(top) = parsed else {
+            panic!("expected object");
+        };
+        let Some(OdinValue::List(items)) = top.get("a") else {
+            panic!("{src}: expected a list");
+        };
+        assert_eq!(items.last(), Some(&OdinValue::ListContinue), "{src}");
+    }
+
+    // "the following two lists are identical".
+    assert_eq!(parse("a = <1,1,2,3>").ok(), parse("a = <1, 1, 2,3>").ok());
+
+    // interval lists (App.B `*_interval_list_value`), closed and open.
+    for src in [
+        "a = <|0..5|, |8..9|>",
+        "a = <|0..5|, ...>",
+        "a = <|P1D..P2D|, |P3D..P4D|>",
+    ] {
+        assert!(parse(src).is_ok(), "{src} should parse");
+    }
+
+    // homogeneity refusal twins — every list production is per-type.
+    for src in [
+        r#"a = <1, "x">"#,
+        "a = <1, 2.5>",
+        "a = <2004-06-11, 2004-06-11T10:00:00>",
+        r#"a = <|0..5|, "x">"#,
+    ] {
+        assert!(
+            parse(src).is_err(),
+            "{src} must be refused (mixed-kind list)"
+        );
+    }
+}
+
+/// The `master07-leaf_data` §Dates and Times examples — the four complete
+/// forms (incl. the comma-fraction time and the tz-stamped date/time), the
+/// ISO partial patterns, and the `??` partial patterns.
+#[test]
+fn ch7_date_time_forms() {
+    for (src, want) in [
+        ("d = <1919-01-23>", "Date"),
+        ("d = <16:35:04,5>", "Time"),
+        ("d = <2001-05-12T07:35:20+1000>", "DateTime"),
+        ("d = <P22DT4H15M0S>", "Duration"),
+        ("d = <2004-06>", "Date"),
+        ("d = <08:30>", "Time"),
+        ("d = <2004-06-11T10:30>", "DateTime"),
+        ("d = <2004-06-11T10>", "DateTime"),
+        ("d = <2004-06-??>", "Date"),
+        ("d = <2004-??-??>", "Date"),
+        ("d = <10:30:??>", "Time"),
+        ("d = <10:??:??>", "Time"),
+        ("d = <2004-06-11T10:30:??>", "DateTime"),
+        ("d = <2004-06-11T10:??:??>", "DateTime"),
+    ] {
+        let parsed = parse(src).unwrap_or_else(|e| panic!("{src} should parse: {e}"));
+        let OdinValue::Object(top) = parsed else {
+            panic!("expected object");
+        };
+        let got = match top.get("d") {
+            Some(OdinValue::Date(_)) => "Date",
+            Some(OdinValue::Time(_)) => "Time",
+            Some(OdinValue::DateTime(_)) => "DateTime",
+            Some(OdinValue::Duration(_)) => "Duration",
+            other => panic!("{src}: unexpected {other:?}"),
+        };
+        assert_eq!(got, want, "{src}");
+    }
+}
+
+/// The `master07-leaf_data` §Intervals uniform syntax — all ten listed
+/// forms parse (the point/one-sided/plus-minus family plus the section's own
+/// examples).
+#[test]
+fn ch7_interval_uniform_syntax() {
+    for src in [
+        "i = <|0..5|>",
+        "i = <|>0..5|>",
+        "i = <|0..<5|>",
+        "i = <|>0..<5|>",
+        "i = <|<5|>",
+        "i = <|>5|>",
+        "i = <|>=5|>",
+        "i = <|<=5|>",
+        "i = <|5.0 +/-0.5|>",
+        "i = <|5.0 \u{00B1}0.5|>",
+        "i = <|5.0\u{00B1}0.5|>",
+        "i = <|0.0..1000.0|>",
+        "i = <|0.0..<1000.0|>",
+        "i = <|08:02..09:10|>",
+        "i = <|>=1939-02-01|>",
+    ] {
+        assert!(parse(src).is_ok(), "{src} should parse");
+    }
+}
+
+/// The `master07-leaf_data` §Coded Terms examples, incl. the optional
+/// version, and §URIs' verbatim-capture forms.
+#[test]
+fn ch7_coded_terms_and_uris() {
+    for src in [
+        "t = <[icd10AM::F60.1]>",
+        "t = <[snomed_ct::2004950]>",
+        "t = <[snomed_ct(3.1)::2004950]>",
+    ] {
+        let parsed = parse(src).unwrap_or_else(|e| panic!("{src} should parse: {e}"));
+        let OdinValue::Object(top) = parsed else {
+            panic!("expected object");
+        };
+        assert!(
+            matches!(top.get("t"), Some(OdinValue::TermCode(_))),
+            "{src}"
+        );
+    }
+    for uri in [
+        "http://openEHR.org/home",
+        "ftp://get.this.file.com?file=cats.doc#section_5",
+        "http://www.mozilla.org/products/firefox/upgrade/?application=thunderbird",
+    ] {
+        let src = format!("u = <{uri}>");
+        let parsed = parse(&src).unwrap_or_else(|e| panic!("{src} should parse: {e}"));
+        let OdinValue::Object(top) = parsed else {
+            panic!("expected object");
+        };
+        assert_eq!(
+            top.get("u"),
+            Some(&OdinValue::Uri(format!("<{uri}>"))),
+            "verbatim capture incl. delimiters"
+        );
+    }
+}


### PR DESCRIPTION
Closes #1384
Closes #1385
Closes #1120
Closes #1121
Closes #1122
Closes #1123
Closes #857

## What

Sixth chapter of the #753 LANG compliance program: the ODIN ch.7 Leaf Data audit — all four section sub-issues walked (checklists on #1120–#1123, coherence pass on #857) — with the chapter's findings fixed per the fix-first cadence.

## Findings → fixes

**#1384 (§7.4):** two grammar-normative behaviours (App.B includes `odin_values.g4`): interval lists (`<|0..5|, |8..9|>`, open `, ...` form) were refused, and per-type list homogeneity ("all of the same type"; every list production is per-type) was unenforced — mixed lists parsed silently. Fixed: list items are `interval | leaf` with variant-level homogeneity (typed refusal at the offending item). **Strict enforcement proved corpus-safe** — the whole vendored BMM + ADL corpus stays green, so no tolerance carve-out was warranted. Endpoint homogeneity beyond the variant level stays with the consuming model (NOTE).

**#1385 (§7.3):** the deliberate RFC 3986 non-enforcement on `EMBEDDED_URI` (verbatim capture; URI validity is the consuming model's typed concern) was an unrecorded adjudication — now the NOTE at the token, closing the §3.1 deferral.

§7.1 and §7.2 close finding-free with the chapter's full example set pinned in `odin_spec_examples.rs`: every complete/partial date-time form (incl. the comma-fraction time `16:35:04,5` and `…Thh`), the ten uniform interval forms (incl. bare point intervals, both ± spellings, spaced and unspaced), coded terms incl. `(version)`, verbatim URI capture, singleton lists, and the whitespace-identity pair.

## Gates

fmt + clippy + rustdoc clean; `cargo nextest run -p openehr-lang -p openehr-adl` 389/389 green. Changelog entry added (list acceptance is upload-visible validation behaviour).