### PR TITLE
docs(openehr-lang): ODIN ch.8/ch.9/App.A/App.B audits — records + boundary pins (#858 #859 #860 #861)

### DIFF
--- a/crates/openehr-lang/src/lexer/reclassify.rs
+++ b/crates/openehr-lang/src/lexer/reclassify.rs
@@ -454,8 +454,16 @@ fn path(language: Language, text: &str) -> bool {
                 && ((shape.leading_slashes == 1 && shape.segments >= 1)
                     || (shape.leading_slashes == 0 && shape.segments >= 2))
         }
-        // `odin.g4`'s object-reference path takes either case on the segment
-        // head (its `odin_path_segment` is an `attr_id`, not an `ALPHA_LC_ID`).
+        // The ODIN reading takes either case on the segment head — a
+        // docs-text-grounded widening over `base_lexer.g4`'s lower-case-only
+        // `ADL_PATH_SEGMENT`: ODIN object keys may be upper-case or
+        // `_`-initial identifiers (`odin.g4` `odin_object_key : ALPHA_UC_ID |
+        // ALPHA_UNDERSCORE_ID | rm_attribute_id`), and every node is
+        // reachable by a path (`LANG/docs/odin/master02-overview`), so a path
+        // must be able to name an upper-case-keyed attribute. (`_`-initial
+        // segment HEADS remain un-lexable in every language — a spec-internal
+        // gap between the object-key and path-segment grammars, recorded at
+        // the #858 ch.8 audit.)
         Language::Odin => {
             (shape.leading_slashes == 1 && shape.segments >= 1)
                 || (shape.leading_slashes == 0 && shape.segments >= 2)

--- a/crates/openehr-lang/tests/it/odin_spec_examples.rs
+++ b/crates/openehr-lang/tests/it/odin_spec_examples.rs
@@ -674,3 +674,31 @@ fn ch7_coded_terms_and_uris() {
         );
     }
 }
+
+/// `master08-path_syntax` §Semantics: the chapter's typical path is exactly
+/// the shape `OdinValue::paths()` emits, and a reference block carries it.
+#[test]
+fn ch8_typical_path_shape() {
+    let parsed = parse(r#"term_definitions = <["en"] = <items = <["at0001"] = <text = <"x">>>>>"#)
+        .unwrap_or_else(|e| panic!("should parse: {e}"));
+    assert!(
+        parsed
+            .paths()
+            .contains(&"/term_definitions[\"en\"]/items[\"at0001\"]/text".to_owned())
+    );
+    // …and the same path is legal as an object reference.
+    assert!(parse(r#"r = </term_definitions["en"]/items["at0001"]/text>"#).is_ok());
+}
+
+/// `master09-plug_in_syntaxes`: plug-in blocks `attr = (syntax) <# … #>` are
+/// NOT supported — the chapter itself waives the obligation ("there is no
+/// guarantee that every ODIN parser will support them"), so the refusal is a
+/// conforming, adjudicated boundary (#859; the optional capability is
+/// tracked as a backlog enhancement). Pinned so the boundary never silently
+/// shifts.
+#[test]
+fn ch9_plug_in_blocks_are_refused() {
+    let err = parse("definition = (cadl) <#\n    ENTRY[at0000]\n#>")
+        .expect_err("plug-in blocks are an unsupported (spec-waived) capability");
+    assert_eq!(err.kind, OdinErrorKind::UnrecognisedToken);
+}


### PR DESCRIPTION
Closes #1124
Closes #1125
Closes #858
Closes #859
Closes #1126
Closes #1127
Closes #860
Closes #861

## What

Chapters 7–10 of the ODIN document in the #753 LANG program: Path Syntax (#858), Plug-in Syntaxes (#859), App.A Other Syntaxes (#860), App.B Syntax Specification (#861) — all finding-free, closing the whole ODIN document (10 chapters, 4 fix PRs #1372/#1375/#1378/#1383/#1386 + this record PR).

- **ch.8:** the App.B `ADL_PATH` grammar is exactly what the ODIN reading admits; §8.2's single-segment forms adjudicated cADL-only per §8.1's own deference; the either-case-head widening's stale citation re-grounded (`reclassify.rs`); the master08 typical path pinned end-to-end; one spec-internal gap recorded (`_`-initial keys unreachable by any path grammar).
- **ch.9:** plug-in blocks adjudicated as a conforming boundary (the chapter waives support); refusal pinned; optional capability tracked as backlog #1387 (no milestone).
- **App.A:** conversion guidance, no reader obligation; our `OdinInterval` is the appendix's own recommended interval model.
- **App.B:** the full docs-text ↔ grammar reconciliation record (eleven adjudicated widenings + two App.B-over-prose rulings), posted on #861.

Test-only/docs-only change (no behaviour): `no-changelog`.

## Gates

fmt + clippy clean; `cargo nextest run -p openehr-lang -p openehr-adl` 391/391 green.