### PR TITLE
feat(openehr-lang): BMM v2 core computed-feature surface (audits #862 #863 #865 #866)

### DIFF
--- a/crates/openehr-lang/src/bmm/core/bmm_classifier_impl.rs
+++ b/crates/openehr-lang/src/bmm/core/bmm_classifier_impl.rs
@@ -1,0 +1,391 @@
+//! Hand-written spec functions of `BMM_CLASSIFIER` — the abstract parent of
+//! "anything that functions as the type of a property (viz: classes, types and
+//! generic parameters)".
+//!
+//! Spec: `LANG/docs/bmm/master05-core.adoc` §Semantics §Basics (which defines
+//! the naming trio `type_name` / `type_signature` / `conformance_type_name`
+//! normatively — quoted in full on
+//! [`crate::bmm3::core::entity::bmm_type_impl`]) and
+//! `LANG/docs/UML/classes/org.openehr.lang.bmm.bmm_classifier.adoc` §Functions
+//! (`type_name`, `type_category`, `type_signature`, `base_class`,
+//! `flattened_type_list`).
+//!
+//! Every function here is a pure dispatcher: the per-class behaviour lives with
+//! the class the class definitions declare it on
+//! ([`crate::bmm3::core::entity::bmm_class_impl`],
+//! [`crate::bmm3::core::entity::bmm_type_impl`],
+//! [`crate::bmm::core::bmm_generic_parameter_impl`],
+//! [`crate::bmm::core::bmm_open_type_impl`]).
+
+use crate::bmm::core::bmm_classifier::BmmClassifier;
+use crate::bmm3::core::entity::bmm_class::BmmClass;
+
+impl BmmClassifier {
+    /// `BMM_CLASSIFIER.type_name`: "Formal string form of the type as per UML"
+    /// (class doc §Functions).
+    #[must_use]
+    pub fn type_name(&self) -> String {
+        match self {
+            Self::BmmClass(class) => class.type_name(),
+            Self::BmmContainerType(container) => container.type_name(),
+            Self::BmmGenericParameter(parameter) => parameter.type_name().to_owned(),
+            Self::BmmGenericType(generic) => generic.type_name(),
+            Self::BmmOpenType(open) => open.type_name().to_owned(),
+            Self::BmmParameterType(parameter) => parameter.type_name().to_owned(),
+            Self::BmmSignature(signature) => signature.type_name(),
+            Self::BmmSimpleType(simple) => simple.type_name(),
+            Self::BmmStatusType(status) => status.type_name(),
+            Self::BmmTupleType(tuple) => tuple.type_name(),
+        }
+    }
+
+    /// `BMM_CLASSIFIER.type_signature`: "Signature form of the type, which for
+    /// generics includes generic parameter constrainer types e.g.
+    /// Interval<T:Ordered>" (class doc §Functions).
+    #[must_use]
+    pub fn type_signature(&self) -> String {
+        match self {
+            Self::BmmClass(class) => class.type_signature(),
+            Self::BmmContainerType(container) => container.type_signature(),
+            Self::BmmGenericParameter(parameter) => parameter.type_signature(),
+            Self::BmmGenericType(generic) => generic.type_signature(),
+            Self::BmmOpenType(open) => open.type_signature(),
+            Self::BmmParameterType(parameter) => parameter.type_signature(),
+            Self::BmmSignature(signature) => signature.type_name(),
+            Self::BmmSimpleType(simple) => simple.type_signature(),
+            Self::BmmStatusType(status) => status.type_name(),
+            Self::BmmTupleType(tuple) => tuple.type_name(),
+        }
+    }
+
+    /// `conformance_type_name`: "a reduced form of the type useful in some
+    /// circumstances that is either a simple class name, the _contained_ type
+    /// for a container type (e.g. `ELEMENT` from the type `List<ELEMENT>`), and
+    /// the _root_ type from a generic type (e.g. `Interval` from
+    /// `Interval<T>`)" (`LANG/docs/bmm/master05-core.adoc` §Semantics §Basics —
+    /// the function is defined there in prose; only
+    /// `BMM_OPEN_TYPE`/`BMM_PARAMETER_TYPE` carry it in a §Functions table).
+    #[must_use]
+    pub fn conformance_type_name(&self) -> String {
+        match self {
+            Self::BmmClass(class) => class.name().to_owned(),
+            Self::BmmContainerType(container) => container.conformance_type_name(),
+            Self::BmmGenericParameter(parameter) => parameter.conformance_type_name(),
+            Self::BmmGenericType(generic) => generic.conformance_type_name(),
+            Self::BmmOpenType(open) => open.conformance_type_name(),
+            Self::BmmParameterType(parameter) => parameter.conformance_type_name(),
+            Self::BmmSignature(signature) => signature.conformance_type_name(),
+            Self::BmmSimpleType(simple) => simple.conformance_type_name(),
+            Self::BmmStatusType(status) => status.conformance_type_name(),
+            Self::BmmTupleType(tuple) => tuple.conformance_type_name(),
+        }
+    }
+
+    /// `BMM_CLASSIFIER.flattened_type_list`: "Completely flattened list of type
+    /// names, flattening out all generic parameters" (class doc §Functions).
+    #[must_use]
+    pub fn flattened_type_list(&self) -> Vec<String> {
+        match self {
+            Self::BmmClass(class) => class.suppliers(),
+            Self::BmmContainerType(container) => container.flattened_type_list(),
+            Self::BmmGenericParameter(parameter) => parameter.flattened_type_list(),
+            Self::BmmGenericType(generic) => generic.flattened_type_list(),
+            Self::BmmOpenType(open) => open.flattened_type_list(),
+            Self::BmmParameterType(parameter) => parameter.flattened_type_list(),
+            Self::BmmSignature(signature) => signature.flattened_type_list(),
+            Self::BmmSimpleType(simple) => simple.flattened_type_list(),
+            Self::BmmStatusType(status) => status.flattened_type_list(),
+            Self::BmmTupleType(tuple) => tuple.flattened_type_list(),
+        }
+    }
+
+    /// `BMM_CLASSIFIER.base_class`: "Main design class for this type, from which
+    /// properties etc can be extracted" (class doc §Functions), projected to the
+    /// class NAME.
+    ///
+    /// NOTE (projection, recorded deviation): the class doc's signature returns
+    /// a `BMM_CLASS`, which this enum cannot yield by reference across all its
+    /// variants — a `BMM_GENERIC_TYPE` embeds a bare `BMM_GENERIC_CLASS` struct
+    /// rather than a `BMM_CLASS` enum value, and the built-in meta-types
+    /// (`BMM_SIGNATURE`, `BMM_STATUS_TYPE`, `BMM_TUPLE_TYPE`,
+    /// `BMM_PARAMETER_TYPE`) have no defining model class at all
+    /// (`org.openehr.lang.bmm3.bmm_builtin_type.adoc` §Description: built-in
+    /// types "are treated as being primitive and non-abstract"). Synthesising a
+    /// `BMM_CLASS` for those would be a shadow type, so the enum-level surface
+    /// is the name; the typed fields
+    /// (`BmmSimpleType::base_class`, `BmmGenericType::base_class`,
+    /// `BmmClass` itself) stay directly accessible for the variants that have
+    /// one.
+    #[must_use]
+    pub fn base_class_name(&self) -> String {
+        match self {
+            Self::BmmClass(class) => class.name().to_owned(),
+            Self::BmmContainerType(container) => container.container_type().name().to_owned(),
+            Self::BmmGenericParameter(parameter) => parameter.effective_conforms_to_type_name(),
+            Self::BmmGenericType(generic) => generic.base_class.name.clone(),
+            Self::BmmOpenType(open) => open.conformance_type_name(),
+            Self::BmmParameterType(parameter) => parameter.conformance_type_name(),
+            Self::BmmSignature(signature) => signature.type_name(),
+            Self::BmmSimpleType(simple) => simple.base_class.name().to_owned(),
+            Self::BmmStatusType(status) => status.type_name(),
+            Self::BmmTupleType(tuple) => tuple.type_name(),
+        }
+    }
+
+    /// `BMM_CLASSIFIER.type_category`: "Generate a type category of main target
+    /// type from Type_category_xx values" (class doc §Functions).
+    ///
+    /// NOTE (adjudicated docs silence): the v2 `Type_category_xx` constant set
+    /// is DANGLING in the vendored inputs — neither
+    /// `org.openehr.lang.bmm.bmm_definitions.adoc` §Constants (which defines
+    /// only `Bmm_internal_version`, `Schema_name_delimiter`,
+    /// `Package_name_delimiter`, `Bmm_schema_file_extension`) nor any other v2
+    /// class definition declares a single `Type_category_*` value, so the v2
+    /// vocabulary cannot be quoted. Its successor IS declared:
+    /// `org.openehr.lang.bmm3.bmm_entity_metatype.adoc` §Constants enumerates
+    /// `Entity_metatype_simple`, `…_generic`, `…_generic_parameter`,
+    /// `…_range_constrained`, `…_enumeration`, `…_container` — the same
+    /// category axis, generated as
+    /// [`BmmEntityMetatype`](crate::bmm3::core::entity::bmm_entity_metatype::BmmEntityMetatype).
+    /// This function returns those wire strings, and the
+    /// agreement between the literals below and that generated vocabulary is
+    /// pinned by a unit test in this module.
+    ///
+    /// The mapping: a generic class or generic type is `…_generic`; a generic
+    /// parameter, open type or parameter type is `…_generic_parameter`; an
+    /// enumeration class is `…_enumeration`; a container type is
+    /// `…_container`; a simple class, simple type and the built-in
+    /// signature/status/tuple meta-types are `…_simple`.
+    #[must_use]
+    pub fn type_category(&self) -> &'static str {
+        match self {
+            Self::BmmClass(BmmClass::BmmEnumeration(_)) => "Entity_metatype_enumeration",
+            Self::BmmClass(BmmClass::BmmGenericClass(_)) | Self::BmmGenericType(_) => {
+                "Entity_metatype_generic"
+            }
+            Self::BmmGenericParameter(_) | Self::BmmOpenType(_) | Self::BmmParameterType(_) => {
+                "Entity_metatype_generic_parameter"
+            }
+            Self::BmmContainerType(_) => "Entity_metatype_container",
+            Self::BmmClass(BmmClass::BmmSimpleClass(_) | BmmClass::BmmClass(_))
+            | Self::BmmSignature(_)
+            | Self::BmmSimpleType(_)
+            | Self::BmmStatusType(_)
+            | Self::BmmTupleType(_) => "Entity_metatype_simple",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::bmm::core::bmm_classifier::BmmClassifier;
+    use crate::bmm::core::bmm_generic_parameter::BmmGenericParameter;
+    use crate::bmm::core::bmm_open_type::BmmOpenType;
+    use crate::bmm3::core::entity::bmm_class::BmmClass;
+    use crate::bmm3::core::entity::bmm_container_type::BmmContainerType;
+    use crate::bmm3::core::entity::bmm_container_type::BmmContainerTypeData;
+    use crate::bmm3::core::entity::bmm_entity_metatype::BmmEntityMetatype;
+    use crate::bmm3::core::entity::bmm_generic_class::BmmGenericClass;
+    use crate::bmm3::core::entity::bmm_generic_type::BmmGenericType;
+    use crate::bmm3::core::entity::bmm_simple_class::BmmSimpleClass;
+    use crate::bmm3::core::entity::bmm_simple_type::BmmSimpleType;
+    use crate::bmm3::core::entity::bmm_status_type::BmmStatusType;
+    use crate::bmm3::core::entity::bmm_type::BmmType;
+    use crate::bmm3::core::entity::range_constrained::bmm_enumeration::BmmEnumeration;
+    use crate::bmm3::core::entity::range_constrained::bmm_enumeration::BmmEnumerationData;
+    use crate::bmm3::core::model::bmm_package::BmmPackage;
+
+    /// An empty package node.
+    fn package() -> BmmPackage {
+        BmmPackage {
+            documentation: None,
+            packages: None,
+            name: "org.openehr.base.foundation_types".to_owned(),
+            classes: Vec::new(),
+        }
+    }
+
+    /// A simple class named `name`.
+    fn simple_class(name: &str) -> BmmClass {
+        BmmClass::BmmSimpleClass(BmmSimpleClass {
+            documentation: None,
+            name: name.to_owned(),
+            ancestors: None,
+            package: package(),
+            properties: None,
+            source_schema_id: "openehr_test_1.0.0".to_owned(),
+            immediate_descendants: Vec::new(),
+            is_abstract: false,
+            is_primitive_type: false,
+            is_override: false,
+        })
+    }
+
+    /// A generic class named `name` with one parameter `T`, constrained to
+    /// `constraint`.
+    fn generic_class(name: &str, constraint: Option<&str>) -> BmmGenericClass {
+        BmmGenericClass {
+            documentation: None,
+            name: name.to_owned(),
+            ancestors: None,
+            package: package(),
+            properties: None,
+            source_schema_id: "openehr_test_1.0.0".to_owned(),
+            immediate_descendants: Vec::new(),
+            is_abstract: false,
+            is_primitive_type: false,
+            is_override: false,
+            generic_parameters: [("T".to_owned(), generic_parameter(constraint))]
+                .into_iter()
+                .collect(),
+        }
+    }
+
+    /// A generic parameter `T`, optionally constrained.
+    fn generic_parameter(constraint: Option<&str>) -> BmmGenericParameter {
+        BmmGenericParameter {
+            documentation: None,
+            name: "T".to_owned(),
+            conforms_to_type: constraint.map(simple_class),
+            inheritance_precursor: None,
+        }
+    }
+
+    /// An enumeration class named `name`.
+    fn enumeration_class(name: &str) -> BmmClass {
+        BmmClass::BmmEnumeration(BmmEnumeration::BmmEnumeration(BmmEnumerationData {
+            documentation: None,
+            name: name.to_owned(),
+            ancestors: None,
+            package: package(),
+            properties: None,
+            source_schema_id: "openehr_test_1.0.0".to_owned(),
+            immediate_descendants: Vec::new(),
+            is_abstract: false,
+            is_primitive_type: false,
+            is_override: false,
+            item_names: vec!["equal".to_owned()],
+            item_values: Vec::new(),
+            underlying_type_name: "Integer".to_owned(),
+        }))
+    }
+
+    #[test]
+    fn the_naming_trio_dispatches_over_every_variant() {
+        let simple = BmmClassifier::BmmSimpleType(BmmSimpleType {
+            documentation: None,
+            base_class: simple_class("ELEMENT"),
+        });
+        assert_eq!(simple.type_name(), "ELEMENT");
+        assert_eq!(simple.type_signature(), "ELEMENT");
+        assert_eq!(simple.conformance_type_name(), "ELEMENT");
+        assert_eq!(simple.base_class_name(), "ELEMENT");
+        assert_eq!(simple.flattened_type_list(), ["ELEMENT".to_owned()]);
+
+        let class = BmmClassifier::BmmClass(BmmClass::BmmGenericClass(generic_class(
+            "Interval",
+            Some("Ordered"),
+        )));
+        assert_eq!(class.type_name(), "Interval<T>");
+        assert_eq!(class.type_signature(), "Interval<T:Ordered>");
+        assert_eq!(class.conformance_type_name(), "Interval");
+        assert_eq!(class.base_class_name(), "Interval");
+
+        let generic = BmmClassifier::BmmGenericType(BmmGenericType {
+            documentation: None,
+            generic_parameters: vec![BmmType::BmmSimpleType(BmmSimpleType {
+                documentation: None,
+                base_class: simple_class("Time"),
+            })],
+            base_class: generic_class("Interval", Some("Ordered")),
+        });
+        assert_eq!(generic.type_name(), "Interval<Time>");
+        assert_eq!(generic.conformance_type_name(), "Interval");
+        assert_eq!(
+            generic.flattened_type_list(),
+            ["Interval".to_owned(), "Time".to_owned()]
+        );
+
+        let container = BmmClassifier::BmmContainerType(BmmContainerType::BmmContainerType(
+            BmmContainerTypeData {
+                documentation: None,
+                container_type: simple_class("List"),
+                base_type: Box::new(BmmType::BmmSimpleType(BmmSimpleType {
+                    documentation: None,
+                    base_class: simple_class("ELEMENT"),
+                })),
+            },
+        ));
+        assert_eq!(container.type_name(), "List<ELEMENT>");
+        assert_eq!(container.conformance_type_name(), "ELEMENT");
+        assert_eq!(container.base_class_name(), "List");
+
+        let parameter = BmmClassifier::BmmGenericParameter(generic_parameter(Some("Ordered")));
+        assert_eq!(parameter.type_name(), "T");
+        assert_eq!(parameter.type_signature(), "T:Ordered");
+        assert_eq!(parameter.conformance_type_name(), "Ordered");
+
+        let open = BmmClassifier::BmmOpenType(BmmOpenType {
+            documentation: None,
+            generic_constraint: generic_parameter(None),
+        });
+        assert_eq!(open.type_name(), "T");
+        assert_eq!(open.conformance_type_name(), "Any");
+
+        let status = BmmClassifier::BmmStatusType(BmmStatusType {
+            documentation: None,
+        });
+        assert_eq!(status.type_name(), "Status");
+        assert_eq!(status.type_signature(), "Status");
+    }
+
+    #[test]
+    fn type_category_matches_the_generated_metatype_vocabulary() {
+        // The literals this function returns ARE the BMM_ENTITY_METATYPE wire
+        // strings (bmm3.bmm_entity_metatype.adoc §Constants); this pins the
+        // agreement so the two cannot drift apart.
+        let cases: [(BmmClassifier, BmmEntityMetatype); 6] = [
+            (
+                BmmClassifier::BmmSimpleType(BmmSimpleType {
+                    documentation: None,
+                    base_class: simple_class("ELEMENT"),
+                }),
+                BmmEntityMetatype::EntityMetatypeSimple,
+            ),
+            (
+                BmmClassifier::BmmClass(BmmClass::BmmGenericClass(generic_class("Interval", None))),
+                BmmEntityMetatype::EntityMetatypeGeneric,
+            ),
+            (
+                BmmClassifier::BmmGenericParameter(generic_parameter(None)),
+                BmmEntityMetatype::EntityMetatypeGenericParameter,
+            ),
+            (
+                BmmClassifier::BmmClass(enumeration_class("MATCH_KIND")),
+                BmmEntityMetatype::EntityMetatypeEnumeration,
+            ),
+            (
+                BmmClassifier::BmmContainerType(BmmContainerType::BmmContainerType(
+                    BmmContainerTypeData {
+                        documentation: None,
+                        container_type: simple_class("List"),
+                        base_type: Box::new(BmmType::BmmSimpleType(BmmSimpleType {
+                            documentation: None,
+                            base_class: simple_class("ELEMENT"),
+                        })),
+                    },
+                )),
+                BmmEntityMetatype::EntityMetatypeContainer,
+            ),
+            (
+                BmmClassifier::BmmStatusType(BmmStatusType {
+                    documentation: None,
+                }),
+                BmmEntityMetatype::EntityMetatypeSimple,
+            ),
+        ];
+        for (classifier, expected) in cases {
+            assert_eq!(classifier.type_category(), expected.as_str());
+        }
+    }
+}

--- a/crates/openehr-lang/src/bmm/core/bmm_generic_parameter_impl.rs
+++ b/crates/openehr-lang/src/bmm/core/bmm_generic_parameter_impl.rs
@@ -1,0 +1,206 @@
+//! Hand-written spec functions of `BMM_GENERIC_PARAMETER` — the formal generic
+//! parameter of a generic class definition.
+//!
+//! Spec: `LANG/docs/UML/classes/org.openehr.lang.bmm.bmm_generic_parameter.adoc`
+//! §Functions (`flattened_conforms_to_type`, `effective_conforms_to_type`,
+//! `type_signature`) and §Invariants (`Inv_generic_name`:
+//! `name.count = 1 and name.is_upper`), read together with
+//! `LANG/docs/bmm/master05-core.adoc` §Semantics §Basics (a generic parameter is
+//! one of the things that "functions as the type of a property") and §Classes
+//! and Types (`BMM_OPEN_TYPE` "corresponds to a generic parameter type from the
+//! class type definition, e.g. `T`, `U` etc"). The v3 counterpart of this class
+//! is `BMM_PARAMETER_TYPE` (`…bmm3.bmm_parameter_type.adoc`), whose §Functions
+//! state the same three functions with sharper post-conditions and are cited
+//! where they settle the v2 wording.
+
+use crate::bmm::core::bmm_generic_parameter::BmmGenericParameter;
+use crate::bmm3::core::entity::bmm_class::BmmClass;
+use crate::bmm3::core::entity::bmm_type_impl::ANY_TYPE_NAME;
+
+impl BmmGenericParameter {
+    /// `BMM_GENERIC_PARAMETER.flattened_conforms_to_type`: "Get any ultimate
+    /// type conformance constraint on this generic parameter due to
+    /// inheritance" (class doc §Functions) — i.e. this parameter's own
+    /// `conforms_to_type` when set, else the constraint of its
+    /// `inheritance_precursor`, recursively
+    /// (`org.openehr.lang.bmm3.bmm_parameter_type.adoc` §Functions states the
+    /// rule explicitly: "Result is either `_conforms_to_type_` or
+    /// `_inheritance_precursor.flattened_conforms_to_type_`").
+    ///
+    /// `None` means unconstrained; see
+    /// [`Self::effective_conforms_to_type_name`] for the `Any` projection.
+    #[must_use]
+    pub fn flattened_conforms_to_type(&self) -> Option<&str> {
+        match &self.conforms_to_type {
+            Some(class) => Some(class.name()),
+            None => self
+                .inheritance_precursor
+                .as_ref()
+                .and_then(|precursor| precursor.flattened_conforms_to_type()),
+        }
+    }
+
+    /// `BMM_GENERIC_PARAMETER.conforms_to_type`, resolved to the constraining
+    /// class: this parameter's own constraint when set, else the inherited one
+    /// (class doc §Attributes: "If set, is the corresponding generic parameter
+    /// definition in an ancestor class").
+    #[must_use]
+    pub fn flattened_conforms_to_class(&self) -> Option<&BmmClass> {
+        match &self.conforms_to_type {
+            Some(class) => Some(class),
+            None => self
+                .inheritance_precursor
+                .as_ref()
+                .and_then(|precursor| precursor.flattened_conforms_to_class()),
+        }
+    }
+
+    /// `BMM_GENERIC_PARAMETER.effective_conforms_to_type`: "Generate ultimate
+    /// conformance type, which is either from `conforms_to_type` or if not set,
+    /// 'Any'" (class doc §Functions).
+    ///
+    /// NOTE (projection): the class doc's function returns a `BMM_CLASS`, and
+    /// the `Any` fallback is a class object the schema need not define
+    /// (`org.openehr.lang.bmm3.bmm_definitions.adoc` §Functions `Any_class`:
+    /// "built-in class definition corresponding to the top `Any` class … if
+    /// not, use `BMM_DEFINITIONS._any_class_`"). The generated model carries no
+    /// such built-in singleton, and synthesising one here would be a shadow
+    /// type, so this surface returns the type NAME; the typed constraint stays
+    /// directly reachable through [`Self::flattened_conforms_to_class`] and the
+    /// `conforms_to_type` field.
+    #[must_use]
+    pub fn effective_conforms_to_type_name(&self) -> String {
+        self.flattened_conforms_to_type()
+            .unwrap_or(ANY_TYPE_NAME)
+            .to_owned()
+    }
+
+    /// `BMM_CLASSIFIER.type_name` for a generic parameter: the parameter name
+    /// (`master05-core.adoc` §Semantics §Basics: "for feature types it will be
+    /// the declared type, i.e. a simple name, an open type name (e.g. `T`) …";
+    /// `org.openehr.lang.bmm3.bmm_parameter_type.adoc` §Functions: `type_name`
+    /// "Return `_name_`").
+    #[must_use]
+    pub fn type_name(&self) -> &str {
+        self.name.as_str()
+    }
+
+    /// `BMM_GENERIC_PARAMETER.type_signature` (redefined): "Signature form of
+    /// the open type, including constrainer type if there is one, e.g.
+    /// 'T:Ordered'" (class doc §Functions).
+    ///
+    /// Delimiter per `org.openehr.lang.bmm3.bmm_definitions.adoc` §Constants
+    /// (`Generic_constraint_delimiter` `':'`, "Delimiter between formal type
+    /// parameter and constraint type, as used in `Sortable<T: Ordered>`"); the
+    /// class doc's own example `T:Ordered` carries no whitespace, so neither
+    /// does this rendering.
+    #[must_use]
+    pub fn type_signature(&self) -> String {
+        match self.flattened_conforms_to_type() {
+            Some(constraint) => {
+                let name = &self.name;
+                format!("{name}:{constraint}")
+            }
+            None => self.name.clone(),
+        }
+    }
+
+    /// `BMM_CLASSIFIER.conformance_type_name` for a generic parameter: the
+    /// effective constraint, i.e. the class the parameter is guaranteed to
+    /// conform to — `Any` when unconstrained
+    /// (`org.openehr.lang.bmm.bmm_open_type.adoc` §Functions:
+    /// `conformance_type_name` "Return generic_constraint.conformance_type_name").
+    #[must_use]
+    pub fn conformance_type_name(&self) -> String {
+        self.effective_conforms_to_type_name()
+    }
+
+    /// `BMM_CLASSIFIER.flattened_type_list` for a generic parameter: "Result is
+    /// either `_flattened_conforms_to_type.flattened_type_list_` or the `Any`
+    /// type" (`org.openehr.lang.bmm3.bmm_parameter_type.adoc` §Functions).
+    #[must_use]
+    pub fn flattened_type_list(&self) -> Vec<String> {
+        vec![self.effective_conforms_to_type_name()]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::bmm::core::bmm_generic_parameter::BmmGenericParameter;
+    use crate::bmm3::core::entity::bmm_class::BmmClass;
+    use crate::bmm3::core::entity::bmm_simple_class::BmmSimpleClass;
+    use crate::bmm3::core::model::bmm_package::BmmPackage;
+
+    /// A simple class named `name`.
+    fn simple_class(name: &str) -> BmmClass {
+        BmmClass::BmmSimpleClass(BmmSimpleClass {
+            documentation: None,
+            name: name.to_owned(),
+            ancestors: None,
+            package: BmmPackage {
+                documentation: None,
+                packages: None,
+                name: "org.openehr.base.foundation_types".to_owned(),
+                classes: Vec::new(),
+            },
+            properties: None,
+            source_schema_id: "openehr_test_1.0.0".to_owned(),
+            immediate_descendants: Vec::new(),
+            is_abstract: false,
+            is_primitive_type: false,
+            is_override: false,
+        })
+    }
+
+    /// A generic parameter named `name`, optionally constrained, optionally
+    /// with an inheritance precursor.
+    fn parameter(
+        name: &str,
+        conforms_to: Option<&str>,
+        precursor: Option<BmmGenericParameter>,
+    ) -> BmmGenericParameter {
+        BmmGenericParameter {
+            documentation: None,
+            name: name.to_owned(),
+            conforms_to_type: conforms_to.map(simple_class),
+            inheritance_precursor: precursor.map(Box::new),
+        }
+    }
+
+    #[test]
+    fn own_constraint_wins_over_the_inherited_one() {
+        let precursor = parameter("T", Some("Ordered"), None);
+        let own = parameter("T", Some("Comparable"), Some(precursor));
+        assert_eq!(own.flattened_conforms_to_type(), Some("Comparable"));
+        assert_eq!(own.effective_conforms_to_type_name(), "Comparable");
+    }
+
+    #[test]
+    fn the_constraint_is_inherited_through_the_precursor_chain() {
+        let root = parameter("T", Some("Ordered"), None);
+        let middle = parameter("T", None, Some(root));
+        let leaf = parameter("T", None, Some(middle));
+        assert_eq!(leaf.flattened_conforms_to_type(), Some("Ordered"));
+        assert_eq!(leaf.type_signature(), "T:Ordered");
+    }
+
+    #[test]
+    fn an_unconstrained_parameter_is_any() {
+        let unconstrained = parameter("T", None, None);
+        assert_eq!(unconstrained.flattened_conforms_to_type(), None);
+        assert_eq!(unconstrained.effective_conforms_to_type_name(), "Any");
+        assert_eq!(unconstrained.conformance_type_name(), "Any");
+        assert_eq!(unconstrained.flattened_type_list(), ["Any".to_owned()]);
+        assert_eq!(unconstrained.type_signature(), "T");
+        assert_eq!(unconstrained.type_name(), "T");
+    }
+
+    #[test]
+    fn the_typed_constraint_stays_reachable() {
+        let constrained = parameter("T", Some("Ordered"), None);
+        let class = constrained
+            .flattened_conforms_to_class()
+            .expect("the constraint is set");
+        assert_eq!(class.name(), "Ordered");
+    }
+}

--- a/crates/openehr-lang/src/bmm/core/bmm_open_type_impl.rs
+++ b/crates/openehr-lang/src/bmm/core/bmm_open_type_impl.rs
@@ -1,0 +1,111 @@
+//! Hand-written spec functions of `BMM_OPEN_TYPE` — the use of a formal generic
+//! parameter as the type of a feature.
+//!
+//! Spec: `LANG/docs/UML/classes/org.openehr.lang.bmm.bmm_open_type.adoc`
+//! (§Description: "Open type reference to a single type parameter, i.e.
+//! typically 'T', 'V', 'K' etc. The parameter must be in the type declaration
+//! of the owning BMM_CLASS"; §Attributes `generic_constraint`: "The generic
+//! constraint, which will be 'Any' if nothing set in original model";
+//! §Functions `conformance_type_name`: "Return
+//! generic_constraint.conformance_type_name") and
+//! `LANG/docs/bmm/master05-core.adoc` §Semantics — §Basics ("for feature types
+//! it will be the declared type, i.e. a simple name, an open type name (e.g.
+//! `T`) or a generic type name (e.g. `Interval<Time>`)") and §Classes and Types
+//! ("a `BMM_OPEN_TYPE` — corresponds to a generic parameter type from the class
+//! type definition, e.g. `T`, `U` etc").
+
+use crate::bmm::core::bmm_open_type::BmmOpenType;
+
+impl BmmOpenType {
+    /// `BMM_CLASSIFIER.type_name` for an open type: the open type name, i.e.
+    /// the name of the constrained generic parameter — `T`, `U`, `K`
+    /// (`master05-core.adoc` §Semantics §Basics).
+    #[must_use]
+    pub fn type_name(&self) -> &str {
+        self.generic_constraint.type_name()
+    }
+
+    /// `BMM_OPEN_TYPE.conformance_type_name`: "Return
+    /// generic_constraint.conformance_type_name" (class doc §Functions), which
+    /// for a generic parameter is its effective constraint — the parameter's
+    /// `conforms_to_type` (own or inherited), else `Any` (class doc
+    /// §Attributes: the constraint "will be 'Any' if nothing set in original
+    /// model").
+    #[must_use]
+    pub fn conformance_type_name(&self) -> String {
+        self.generic_constraint.conformance_type_name()
+    }
+
+    /// `BMM_CLASSIFIER.type_signature` for an open type: the parameter's
+    /// signature form, e.g. `T:Ordered`
+    /// (`org.openehr.lang.bmm.bmm_generic_parameter.adoc` §Functions).
+    #[must_use]
+    pub fn type_signature(&self) -> String {
+        self.generic_constraint.type_signature()
+    }
+
+    /// `BMM_CLASSIFIER.flattened_type_list` for an open type: the effective
+    /// constraint of the parameter, or the `Any` type
+    /// (`org.openehr.lang.bmm3.bmm_parameter_type.adoc` §Functions).
+    #[must_use]
+    pub fn flattened_type_list(&self) -> Vec<String> {
+        self.generic_constraint.flattened_type_list()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::bmm::core::bmm_generic_parameter::BmmGenericParameter;
+    use crate::bmm::core::bmm_open_type::BmmOpenType;
+    use crate::bmm3::core::entity::bmm_class::BmmClass;
+    use crate::bmm3::core::entity::bmm_simple_class::BmmSimpleClass;
+    use crate::bmm3::core::model::bmm_package::BmmPackage;
+
+    /// An open type over a parameter named `name`, optionally constrained.
+    fn open_type(name: &str, conforms_to: Option<&str>) -> BmmOpenType {
+        BmmOpenType {
+            documentation: None,
+            generic_constraint: BmmGenericParameter {
+                documentation: None,
+                name: name.to_owned(),
+                conforms_to_type: conforms_to.map(|constraint| {
+                    BmmClass::BmmSimpleClass(BmmSimpleClass {
+                        documentation: None,
+                        name: constraint.to_owned(),
+                        ancestors: None,
+                        package: BmmPackage {
+                            documentation: None,
+                            packages: None,
+                            name: "org.openehr.base.foundation_types".to_owned(),
+                            classes: Vec::new(),
+                        },
+                        properties: None,
+                        source_schema_id: "openehr_test_1.0.0".to_owned(),
+                        immediate_descendants: Vec::new(),
+                        is_abstract: false,
+                        is_primitive_type: false,
+                        is_override: false,
+                    })
+                }),
+                inheritance_precursor: None,
+            },
+        }
+    }
+
+    #[test]
+    fn a_constrained_open_type_names_its_parameter_and_constraint() {
+        let open = open_type("T", Some("Ordered"));
+        assert_eq!(open.type_name(), "T");
+        assert_eq!(open.type_signature(), "T:Ordered");
+        assert_eq!(open.conformance_type_name(), "Ordered");
+        assert_eq!(open.flattened_type_list(), ["Ordered".to_owned()]);
+    }
+
+    #[test]
+    fn an_unconstrained_open_type_conforms_to_any() {
+        let open = open_type("T", None);
+        assert_eq!(open.type_name(), "T");
+        assert_eq!(open.type_signature(), "T");
+        assert_eq!(open.conformance_type_name(), "Any");
+    }
+}

--- a/crates/openehr-lang/src/bmm/core/mod.rs
+++ b/crates/openehr-lang/src/bmm/core/mod.rs
@@ -7,3 +7,8 @@ pub mod bmm_generic_parameter;
 pub mod bmm_open_type;
 pub mod bmm_schema_core;
 pub mod bmm_type_element;
+
+// hand-written modules (spec behaviour), auto-declared:
+pub mod bmm_classifier_impl;
+pub mod bmm_generic_parameter_impl;
+pub mod bmm_open_type_impl;

--- a/crates/openehr-lang/src/bmm3/core/entity/bmm_class_impl.rs
+++ b/crates/openehr-lang/src/bmm3/core/entity/bmm_class_impl.rs
@@ -1,0 +1,670 @@
+//! Hand-written spec functions of `BMM_CLASS` (and its `BMM_GENERIC_CLASS`
+//! refinement) — the BMM v2 core class-level computed features.
+//!
+//! Spec: `LANG/docs/bmm/master05-core.adoc` §Semantics — §Basics (the
+//! `BMM_CLASSIFIER` naming trio `type_name` / `type_signature` /
+//! `conformance_type_name`), §Inheritance ("The evaluation of inheritance
+//! relations defined in a BMM schema results in an acyclic graph such that
+//! ancestors and descendants can be visualised for any class"), §Classes and
+//! Properties ("The features _properties_ and _flat_properties_ defined on
+//! `BMM_CLASS` provide access to these two lists for any class") — plus the
+//! class definitions `LANG/docs/UML/classes/org.openehr.lang.bmm.bmm_class.adoc`
+//! §Functions and `…/org.openehr.lang.bmm.bmm_generic_class.adoc` §Functions.
+//! Where the v2 prose is terse, the v3 counterpart
+//! (`…/org.openehr.lang.bmm3.bmm_class.adoc` §Functions) states the same
+//! function with sharpened wording and is cited at the site it settles.
+//!
+//! NOTE: the persisted BMM graph is upward-complete but downward nominal — a
+//! class embeds its `ancestors` as full `BMM_CLASS` copies, while descendants
+//! are recorded only as names (`immediate_descendants`). The two downward
+//! functions ([`BmmClass::all_descendants`], [`BmmClass::supplier_closure`])
+//! and the primitive-type filter ([`BmmClass::suppliers_non_primitive`],
+//! which the class doc grounds "as defined in input schema") therefore take
+//! the owning [`BmmModel`] to resolve those names. The parameterless
+//! signatures in the class doc assume a live in-memory model with
+//! back-references, which the generated persistence-shaped types deliberately
+//! do not carry (`org.openehr.lang.bmm.bmm_class.adoc` §Attributes:
+//! `immediate_descendants: List<String>`).
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::collections::VecDeque;
+
+use crate::bmm::core::bmm_generic_parameter::BmmGenericParameter;
+use crate::bmm3::core::entity::bmm_class::BmmClass;
+use crate::bmm3::core::entity::bmm_type::BmmType;
+use crate::bmm3::core::entity::range_constrained::bmm_enumeration::BmmEnumeration;
+use crate::bmm3::core::feature::bmm_property::BmmProperty;
+use crate::bmm3::core::model::bmm_model::BmmModel;
+use crate::bmm3::core::model::bmm_package::BmmPackage;
+
+/// The `BMM_CLASS` attributes every generated variant carries, projected out of
+/// the variant's own struct so the computed features are written once.
+struct ClassCommon<'a> {
+    /// `BMM_CLASS.name`.
+    name: &'a str,
+    /// `BMM_CLASS.ancestors` — immediate inheritance parents, embedded whole.
+    ancestors: Option<&'a BTreeMap<String, BmmClass>>,
+    /// `BMM_CLASS.package`.
+    package: &'a BmmPackage,
+    /// `BMM_CLASS.properties` — the *differential* property set.
+    properties: Option<&'a BTreeMap<String, BmmProperty<BmmType>>>,
+    /// `BMM_CLASS.immediate_descendants` — names only.
+    immediate_descendants: &'a [String],
+    /// `BMM_CLASS.is_abstract`.
+    is_abstract: bool,
+    /// `BMM_CLASS.is_primitive_type`.
+    is_primitive_type: bool,
+}
+
+/// Projects one generated `BMM_CLASS`-family struct onto [`ClassCommon`].
+macro_rules! class_common {
+    ($c:expr) => {
+        ClassCommon {
+            name: $c.name.as_str(),
+            ancestors: $c.ancestors.as_ref(),
+            package: &$c.package,
+            properties: $c.properties.as_ref(),
+            immediate_descendants: $c.immediate_descendants.as_slice(),
+            is_abstract: $c.is_abstract,
+            is_primitive_type: $c.is_primitive_type,
+        }
+    };
+}
+
+impl BmmClass {
+    /// The `BMM_CLASS` attributes shared by every variant.
+    fn common(&self) -> ClassCommon<'_> {
+        match self {
+            Self::BmmEnumeration(BmmEnumeration::BmmEnumerationInteger(c)) => class_common!(c),
+            Self::BmmEnumeration(BmmEnumeration::BmmEnumerationString(c)) => class_common!(c),
+            Self::BmmEnumeration(BmmEnumeration::BmmEnumeration(c)) => class_common!(c),
+            Self::BmmGenericClass(c) => class_common!(c),
+            Self::BmmSimpleClass(c) => class_common!(c),
+            Self::BmmClass(c) => class_common!(c),
+        }
+    }
+
+    /// `BMM_CLASS.name`: the root name of this class, "even if the class is
+    /// generic" (class doc §Attributes).
+    #[must_use]
+    pub fn name(&self) -> &str {
+        self.common().name
+    }
+
+    /// `BMM_CLASS.ancestors`: the immediate inheritance parents, keyed by class
+    /// name (class doc §Attributes).
+    #[must_use]
+    pub fn ancestors(&self) -> Option<&BTreeMap<String, BmmClass>> {
+        self.common().ancestors
+    }
+
+    /// `BMM_CLASS.package`: the package this class belongs to (class doc
+    /// §Attributes).
+    #[must_use]
+    pub fn package(&self) -> &BmmPackage {
+        self.common().package
+    }
+
+    /// `BMM_CLASS.properties`: the *differential* property set, i.e. only the
+    /// properties this class introduces with respect to its inheritance parents
+    /// (`master05-core.adoc` §Classes and Properties). The effective set is
+    /// [`Self::flat_properties`].
+    #[must_use]
+    pub fn properties(&self) -> Option<&BTreeMap<String, BmmProperty<BmmType>>> {
+        self.common().properties
+    }
+
+    /// `BMM_CLASS.immediate_descendants`: the names of the immediate
+    /// inheritance descendants (class doc §Attributes).
+    #[must_use]
+    pub fn immediate_descendants(&self) -> &[String] {
+        self.common().immediate_descendants
+    }
+
+    /// `BMM_CLASS.is_abstract`: true if this class is abstract in its model
+    /// (class doc §Attributes).
+    #[must_use]
+    pub fn is_abstract(&self) -> bool {
+        self.common().is_abstract
+    }
+
+    /// `BMM_CLASS.is_primitive_type`: true if this class is designated a
+    /// primitive type "within the overall type system of the schema" (class doc
+    /// §Attributes).
+    #[must_use]
+    pub fn is_primitive_type(&self) -> bool {
+        self.common().is_primitive_type
+    }
+
+    /// `BMM_GENERIC_CLASS.generic_parameters`: the formal generic parameter
+    /// definitions, keyed by parameter name — `Some` only for a generic class
+    /// (`org.openehr.lang.bmm.bmm_generic_class.adoc` §Attributes).
+    #[must_use]
+    pub fn generic_parameters(&self) -> Option<&BTreeMap<String, BmmGenericParameter>> {
+        match self {
+            Self::BmmGenericClass(c) => Some(&c.generic_parameters),
+            Self::BmmEnumeration(_) | Self::BmmSimpleClass(_) | Self::BmmClass(_) => None,
+        }
+    }
+
+    /// `BMM_CLASS.all_ancestors`: "List of all inheritance parent class names,
+    /// recursively" (class doc §Functions).
+    ///
+    /// Walked over the embedded `ancestors` copies — breadth-first over each
+    /// map's (sorted) key order, so the result is deterministic — and deduped:
+    /// multiple inheritance ("`DV_INTERVAL<T>` multiply inheriting from
+    /// `Interval<T>` and `DATA_VALUE`", `master05-core.adoc` §Inheritance) can
+    /// reach the same ancestor by more than one path.
+    #[must_use]
+    pub fn all_ancestors(&self) -> Vec<String> {
+        let mut out = Vec::new();
+        let mut seen = BTreeSet::new();
+        let mut frontier: Vec<&BmmClass> = vec![self];
+        while !frontier.is_empty() {
+            let mut next: Vec<&BmmClass> = Vec::new();
+            for class in frontier {
+                for parent in class.ancestors().into_iter().flat_map(BTreeMap::values) {
+                    if seen.insert(parent.name().to_owned()) {
+                        out.push(parent.name().to_owned());
+                        next.push(parent);
+                    }
+                }
+            }
+            frontier = next;
+        }
+        out
+    }
+
+    /// `BMM_CLASS.suppliers`: "List of names of immediate supplier classes,
+    /// including concrete generic parameters, concrete descendants of abstract
+    /// statically defined types, and inherited suppliers. This list includes
+    /// primitive types." (class doc §Functions).
+    ///
+    /// Composed of the flattened type list of every property type
+    /// ([`BmmType::flattened_type_list`]), the conformance constraint of every
+    /// formal generic parameter for a generic class
+    /// (`org.openehr.lang.bmm.bmm_generic_class.adoc` §Functions: "Add
+    /// suppliers from generic parameters"), and the same computed recursively
+    /// over the embedded ancestors (the "inherited suppliers" clause). The
+    /// result is deduped and sorted.
+    ///
+    /// NOTE (recorded deviation): an *unconstrained* generic parameter
+    /// contributes nothing — `org.openehr.lang.bmm3.bmm_class.adoc` §Functions
+    /// states the rule the v2 prose leaves implicit ("Where generics are
+    /// unconstrained, no class name is added, since logically it would be `Any`
+    /// and this can always be assumed anyway"). The v2 clause "concrete
+    /// descendants of abstract statically defined types" needs the DOWNWARD
+    /// edges, which the persisted class shape records only as names; that
+    /// expansion is [`Self::all_descendants`] over a [`BmmModel`], and is
+    /// deliberately not folded in here so this function stays a pure function
+    /// of the class.
+    #[must_use]
+    pub fn suppliers(&self) -> Vec<String> {
+        let mut acc = BTreeSet::new();
+        self.collect_suppliers(&mut acc);
+        acc.into_iter().collect()
+    }
+
+    /// Accumulates this class's own suppliers and those of its ancestors.
+    fn collect_suppliers(&self, acc: &mut BTreeSet<String>) {
+        for property in self.properties().into_iter().flat_map(BTreeMap::values) {
+            acc.extend(property.flattened_type_list());
+        }
+        for parameter in self
+            .generic_parameters()
+            .into_iter()
+            .flat_map(BTreeMap::values)
+        {
+            if let Some(constraint) = parameter.flattened_conforms_to_type() {
+                acc.insert(constraint.to_owned());
+            }
+        }
+        for parent in self.ancestors().into_iter().flat_map(BTreeMap::values) {
+            parent.collect_suppliers(acc);
+        }
+    }
+
+    /// `BMM_CLASS.suppliers_non_primitive`: "Same as `suppliers` minus
+    /// primitive types, as defined in input schema" (class doc §Functions) —
+    /// hence the [`BmmModel`] argument: "as defined in input schema" means the
+    /// `is_primitive_type` flag on the supplier's own class definition, not a
+    /// property of the supplying reference.
+    #[must_use]
+    pub fn suppliers_non_primitive(&self, model: &BmmModel) -> Vec<String> {
+        self.suppliers()
+            .into_iter()
+            .filter(|name| {
+                !model
+                    .class_definition(name)
+                    .is_some_and(BmmClass::is_primitive_type)
+            })
+            .collect()
+    }
+
+    /// `BMM_CLASS.supplier_closure`: "List of names of all classes in full
+    /// supplier closure, including concrete generic parameters. This list
+    /// includes primitive types." (class doc §Functions).
+    ///
+    /// The transitive closure of [`Self::suppliers`], each supplier name
+    /// resolved through [`BmmModel::class_definition`]. A name with no
+    /// definition in `model` (a type supplied by an included schema that is not
+    /// part of this model) terminates that branch. Cycle-safe: a class already
+    /// in the closure is never expanded twice, which is what makes the function
+    /// total on the recursive type graphs the RM is full of.
+    #[must_use]
+    pub fn supplier_closure(&self, model: &BmmModel) -> Vec<String> {
+        let mut seen: BTreeSet<String> = BTreeSet::new();
+        let mut queue: VecDeque<String> = self.suppliers().into();
+        while let Some(name) = queue.pop_front() {
+            if !seen.insert(name.clone()) {
+                continue;
+            }
+            if let Some(class) = model.class_definition(&name) {
+                for supplier in class.suppliers() {
+                    if !seen.contains(&supplier) {
+                        queue.push_back(supplier);
+                    }
+                }
+            }
+        }
+        seen.into_iter().collect()
+    }
+
+    /// `BMM_CLASS.all_descendants`: "Compute all descendants by following
+    /// immediate_descendants" (class doc §Functions).
+    ///
+    /// Takes the [`BmmModel`] because `immediate_descendants` holds names, not
+    /// class references (module NOTE). Cycle-safe and sorted; the inheritance
+    /// graph is acyclic by construction (`master05-core.adoc` §Inheritance),
+    /// but a malformed schema must not hang the walk.
+    #[must_use]
+    pub fn all_descendants(&self, model: &BmmModel) -> Vec<String> {
+        let mut seen: BTreeSet<String> = BTreeSet::new();
+        let mut queue: VecDeque<String> = self.immediate_descendants().iter().cloned().collect();
+        while let Some(name) = queue.pop_front() {
+            if !seen.insert(name.clone()) {
+                continue;
+            }
+            if let Some(class) = model.class_definition(&name) {
+                queue.extend(class.immediate_descendants().iter().cloned());
+            }
+        }
+        seen.into_iter().collect()
+    }
+
+    /// `BMM_CLASS.base_class` (redefined): "Main design class for this type,
+    /// from which properties etc can be extracted" (class doc §Functions) — a
+    /// class IS its own base class.
+    #[must_use]
+    pub fn base_class(&self) -> &Self {
+        self
+    }
+
+    /// `BMM_CLASS.package_path`: "Fully qualified package name, of form:
+    /// 'package.package'" (class doc §Functions) — i.e.
+    /// [`BmmPackage::path`] of the owning package.
+    #[must_use]
+    pub fn package_path(&self) -> &str {
+        self.package().path()
+    }
+
+    /// `BMM_CLASS.class_path`: "Fully qualified class name, of form:
+    /// 'package.package.CLASS' with package path in lower-case and class in
+    /// original case" (class doc §Functions).
+    #[must_use]
+    pub fn class_path(&self) -> String {
+        let package = self.package_path().to_lowercase();
+        let name = self.name();
+        format!("{package}.{name}")
+    }
+
+    /// `BMM_CLASS.flat_properties`: "List of all properties due to current and
+    /// ancestor classes, keyed by property name" (class doc §Functions) — the
+    /// *effective* (flat) set, "the result of evaluating these lists of
+    /// properties down the inheritance hierarchy" (`master05-core.adoc`
+    /// §Classes and Properties).
+    ///
+    /// Ancestors are merged first (recursively, so the deepest ancestor lands
+    /// first) and this class's own differential properties last, so a
+    /// redefinition in a nearer class wins over the same property name in a
+    /// farther one.
+    #[must_use]
+    pub fn flat_properties(&self) -> BTreeMap<&str, &BmmProperty<BmmType>> {
+        let mut out = BTreeMap::new();
+        self.merge_flat_properties(&mut out);
+        out
+    }
+
+    /// Merges the ancestor-then-own property sets into `out`.
+    fn merge_flat_properties<'a>(&'a self, out: &mut BTreeMap<&'a str, &'a BmmProperty<BmmType>>) {
+        for parent in self.ancestors().into_iter().flat_map(BTreeMap::values) {
+            parent.merge_flat_properties(out);
+        }
+        for property in self.properties().into_iter().flat_map(BTreeMap::values) {
+            out.insert(property.name(), property);
+        }
+    }
+
+    /// `BMM_CLASS.type_name` (redefined): "Formal string form of the type as
+    /// per UML" (class doc §Functions) — the class name for a simple class,
+    /// and the generic form `Name<T,U>` over the FORMAL parameter names for a
+    /// generic class (`master05-core.adoc` §Basics: "for generic and container
+    /// classes it will be generic name such as `List<T>`, `Interval<T>`";
+    /// `org.openehr.lang.bmm3.bmm_class.adoc` §Description: "Use `type_name()`
+    /// to obtain the qualified type name").
+    ///
+    /// NOTE (recorded deviation): the persisted `generic_parameters` is a
+    /// keyed map, so the FORMAL declaration order the class doc mandates for
+    /// `BMM_GENERIC_TYPE.generic_parameters` ("The order must match the order of
+    /// the owning class's formal generic parameter declarations") is not
+    /// recoverable here; parameters are rendered in the map's sorted key order.
+    /// `BMM_GENERIC_PARAMETER` invariant `Inv_generic_name`
+    /// (`name.count = 1 and name.is_upper`) keeps that order stable and,
+    /// for the conventional `T`, `U`, `V` naming, identical to declaration
+    /// order.
+    #[must_use]
+    pub fn type_name(&self) -> String {
+        self.generic_form(|parameter| parameter.name.clone())
+    }
+
+    /// `BMM_GENERIC_CLASS.type_signature` (redefined): "Signature form of the
+    /// type, which for generics includes generic parameter constrainer types
+    /// e.g. Interval<T:Ordered>"
+    /// (`org.openehr.lang.bmm.bmm_generic_class.adoc` §Functions). For a
+    /// non-generic class this is the class name, i.e.
+    /// [`Self::type_name`] (`org.openehr.lang.bmm3.bmm_type.adoc` §Functions:
+    /// `type_signature` "Defaults to the value of `type_name()`").
+    #[must_use]
+    pub fn type_signature(&self) -> String {
+        self.generic_form(BmmGenericParameter::type_signature)
+    }
+
+    /// The `Name<p1,p2>` rendering of this class, each formal parameter
+    /// rendered by `render`; the bare name when the class is not generic.
+    ///
+    /// Delimiters per `org.openehr.lang.bmm3.bmm_definitions.adoc` §Constants
+    /// (`Generic_left_delimiter` `'<'`, `Generic_separator` `','`,
+    /// `Generic_right_delimiter` `'>'`).
+    fn generic_form(&self, render: impl Fn(&BmmGenericParameter) -> String) -> String {
+        match self.generic_parameters() {
+            Some(parameters) if !parameters.is_empty() => {
+                let rendered: Vec<String> = parameters.values().map(render).collect();
+                let name = self.name();
+                let joined = rendered.join(",");
+                format!("{name}<{joined}>")
+            }
+            _ => self.name().to_owned(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use crate::bmm::core::bmm_generic_parameter::BmmGenericParameter;
+    use crate::bmm3::core::entity::bmm_class::BmmClass;
+    use crate::bmm3::core::entity::bmm_class::BmmClassData;
+    use crate::bmm3::core::entity::bmm_generic_class::BmmGenericClass;
+    use crate::bmm3::core::entity::bmm_simple_class::BmmSimpleClass;
+    use crate::bmm3::core::entity::bmm_simple_type::BmmSimpleType;
+    use crate::bmm3::core::entity::bmm_type::BmmType;
+    use crate::bmm3::core::feature::bmm_property::BmmProperty;
+    use crate::bmm3::core::feature::bmm_property::BmmPropertyData;
+    use crate::bmm3::core::model::bmm_package::BmmPackage;
+
+    /// A package node named `name` with no children.
+    fn package(name: &str) -> BmmPackage {
+        BmmPackage {
+            documentation: None,
+            packages: None,
+            name: name.to_owned(),
+            classes: Vec::new(),
+        }
+    }
+
+    /// A `BMM_SIMPLE_CLASS` with the given name, ancestors and properties.
+    fn simple_class(
+        name: &str,
+        ancestors: &[BmmClass],
+        properties: &[(&str, BmmType)],
+    ) -> BmmClass {
+        BmmClass::BmmSimpleClass(BmmSimpleClass {
+            documentation: None,
+            name: name.to_owned(),
+            ancestors: if ancestors.is_empty() {
+                None
+            } else {
+                Some(
+                    ancestors
+                        .iter()
+                        .map(|a| (a.name().to_owned(), a.clone()))
+                        .collect(),
+                )
+            },
+            package: package("org.openehr.rm.test"),
+            properties: if properties.is_empty() {
+                None
+            } else {
+                Some(
+                    properties
+                        .iter()
+                        .map(|(prop, ty)| ((*prop).to_owned(), property(prop, ty.clone())))
+                        .collect(),
+                )
+            },
+            source_schema_id: "openehr_test_1.0.0".to_owned(),
+            immediate_descendants: Vec::new(),
+            is_abstract: false,
+            is_primitive_type: false,
+            is_override: false,
+        })
+    }
+
+    /// A unitary `BMM_PROPERTY` of the given name and type.
+    fn property(name: &str, ty: BmmType) -> BmmProperty<BmmType> {
+        BmmProperty::BmmProperty(BmmPropertyData {
+            documentation: None,
+            name: name.to_owned(),
+            is_mandatory: None,
+            is_computed: None,
+            r#type: ty,
+            is_im_runtime: None,
+            is_im_infrastructure: None,
+        })
+    }
+
+    /// A `BMM_SIMPLE_TYPE` over a freshly minted simple class named `name`.
+    fn simple_type(name: &str) -> BmmType {
+        BmmType::BmmSimpleType(BmmSimpleType {
+            documentation: None,
+            base_class: simple_class(name, &[], &[]),
+        })
+    }
+
+    /// A generic parameter, optionally constrained to a class named
+    /// `conforms_to`.
+    fn generic_parameter(name: &str, conforms_to: Option<&str>) -> BmmGenericParameter {
+        BmmGenericParameter {
+            documentation: None,
+            name: name.to_owned(),
+            conforms_to_type: conforms_to.map(|c| simple_class(c, &[], &[])),
+            inheritance_precursor: None,
+        }
+    }
+
+    /// A `BMM_GENERIC_CLASS` with the given formal parameters.
+    fn generic_class(name: &str, parameters: &[BmmGenericParameter]) -> BmmClass {
+        BmmClass::BmmGenericClass(BmmGenericClass {
+            documentation: None,
+            name: name.to_owned(),
+            ancestors: None,
+            package: package("org.openehr.base.foundation_types"),
+            properties: None,
+            source_schema_id: "openehr_test_1.0.0".to_owned(),
+            immediate_descendants: Vec::new(),
+            is_abstract: false,
+            is_primitive_type: false,
+            is_override: false,
+            generic_parameters: parameters
+                .iter()
+                .map(|p| (p.name.clone(), p.clone()))
+                .collect(),
+        })
+    }
+
+    #[test]
+    fn accessors_read_every_variant() {
+        let class = BmmClass::BmmClass(BmmClassData {
+            documentation: None,
+            name: "LOCATABLE".to_owned(),
+            ancestors: None,
+            package: package("org.openehr.rm.common.archetyped"),
+            properties: None,
+            source_schema_id: "openehr_test_1.0.0".to_owned(),
+            immediate_descendants: vec!["ENTRY".to_owned()],
+            is_abstract: true,
+            is_primitive_type: false,
+            is_override: false,
+        });
+        assert_eq!(class.name(), "LOCATABLE");
+        assert!(class.is_abstract());
+        assert!(!class.is_primitive_type());
+        assert_eq!(class.immediate_descendants(), ["ENTRY".to_owned()]);
+        assert_eq!(class.ancestors(), None);
+        assert_eq!(class.properties(), None);
+        assert_eq!(class.generic_parameters(), None);
+        assert_eq!(class.base_class(), &class);
+    }
+
+    #[test]
+    fn all_ancestors_is_transitive_and_deduped() {
+        // ANY <- DATA_VALUE <- DV_ORDERED, and ANY <- DV_ORDERED directly:
+        // the diamond must yield ANY exactly once.
+        let any = simple_class("ANY", &[], &[]);
+        let data_value = simple_class("DATA_VALUE", std::slice::from_ref(&any), &[]);
+        let dv_ordered = simple_class("DV_ORDERED", &[data_value, any], &[]);
+        assert_eq!(
+            dv_ordered.all_ancestors(),
+            ["ANY".to_owned(), "DATA_VALUE".to_owned()]
+        );
+    }
+
+    #[test]
+    fn flat_properties_lets_the_nearer_class_override() {
+        let ancestor = simple_class(
+            "DV_ORDERED",
+            &[],
+            &[
+                ("magnitude", simple_type("Real")),
+                ("units", simple_type("String")),
+            ],
+        );
+        let class = simple_class(
+            "DV_QUANTITY",
+            &[ancestor],
+            &[("magnitude", simple_type("Integer"))],
+        );
+        let flat = class.flat_properties();
+        assert_eq!(
+            flat.keys().copied().collect::<Vec<_>>(),
+            ["magnitude", "units"]
+        );
+        // The differential (own) definition of `magnitude` wins over the
+        // ancestor's: master05-core.adoc §Classes and Properties.
+        let magnitude = flat.get("magnitude").expect("magnitude is flat-visible");
+        assert_eq!(magnitude.conformance_type_name(), "Integer");
+    }
+
+    #[test]
+    fn suppliers_walks_properties_generic_parameters_and_ancestors() {
+        let ancestor = simple_class(
+            "DATA_VALUE",
+            &[],
+            &[("encoding", simple_type("CODE_PHRASE"))],
+        );
+        let class = simple_class(
+            "DV_TEXT",
+            &[ancestor],
+            &[
+                ("value", simple_type("String")),
+                ("mappings", simple_type("TERM_MAPPING")),
+            ],
+        );
+        assert_eq!(
+            class.suppliers(),
+            [
+                "CODE_PHRASE".to_owned(),
+                "String".to_owned(),
+                "TERM_MAPPING".to_owned()
+            ]
+        );
+
+        // A generic class adds its constrained parameters; an unconstrained
+        // one contributes nothing (bmm3.bmm_class.adoc §Functions).
+        let interval = generic_class(
+            "Interval",
+            &[
+                generic_parameter("T", Some("Ordered")),
+                generic_parameter("U", None),
+            ],
+        );
+        assert_eq!(interval.suppliers(), ["Ordered".to_owned()]);
+    }
+
+    #[test]
+    fn naming_trio_renders_the_generic_forms() {
+        let interval = generic_class("Interval", &[generic_parameter("T", Some("Ordered"))]);
+        assert_eq!(interval.type_name(), "Interval<T>");
+        assert_eq!(interval.type_signature(), "Interval<T:Ordered>");
+
+        let hash = generic_class(
+            "Hash",
+            &[
+                generic_parameter("K", Some("Ordered")),
+                generic_parameter("V", None),
+            ],
+        );
+        assert_eq!(hash.type_name(), "Hash<K,V>");
+        assert_eq!(hash.type_signature(), "Hash<K:Ordered,V>");
+
+        let simple = simple_class("ELEMENT", &[], &[]);
+        assert_eq!(simple.type_name(), "ELEMENT");
+        assert_eq!(simple.type_signature(), "ELEMENT");
+    }
+
+    #[test]
+    fn package_and_class_paths_lower_case_only_the_package() {
+        let class = simple_class("DV_QUANTITY", &[], &[]);
+        assert_eq!(class.package_path(), "org.openehr.rm.test");
+        assert_eq!(class.class_path(), "org.openehr.rm.test.DV_QUANTITY");
+
+        let mixed = BmmClass::BmmSimpleClass(BmmSimpleClass {
+            documentation: None,
+            name: "EHR_STATUS".to_owned(),
+            ancestors: None,
+            package: package("Org.OpenEHR.RM.EHR"),
+            properties: None,
+            source_schema_id: "openehr_test_1.0.0".to_owned(),
+            immediate_descendants: Vec::new(),
+            is_abstract: false,
+            is_primitive_type: false,
+            is_override: false,
+        });
+        assert_eq!(mixed.class_path(), "org.openehr.rm.ehr.EHR_STATUS");
+    }
+
+    #[test]
+    fn generic_parameters_are_visible_only_on_a_generic_class() {
+        let interval = generic_class("Interval", &[generic_parameter("T", Some("Ordered"))]);
+        let parameters = interval
+            .generic_parameters()
+            .expect("a generic class carries formal parameters");
+        assert_eq!(parameters.keys().collect::<Vec<_>>(), ["T"]);
+        assert_eq!(
+            simple_class("ELEMENT", &[], &[]).generic_parameters(),
+            None::<&BTreeMap<String, BmmGenericParameter>>
+        );
+    }
+}

--- a/crates/openehr-lang/src/bmm3/core/entity/bmm_type_impl.rs
+++ b/crates/openehr-lang/src/bmm3/core/entity/bmm_type_impl.rs
@@ -1,0 +1,887 @@
+//! Hand-written spec functions of the `BMM_TYPE` family — the BMM v2 core
+//! type-level computed features (the naming trio plus type substitutions).
+//!
+//! Spec: `LANG/docs/bmm/master05-core.adoc` §Semantics §Basics, which defines
+//! the three naming functions normatively:
+//!
+//! * `type_name` — "the effective type of an entity; for simple classes, this
+//!   will just be the class name (`BMM_CLASS._name_`); for generic and
+//!   container classes it will be generic name such as `List<T>`, `Interval<T>`
+//!   etc; for feature types it will be the declared type, i.e. a simple name,
+//!   an open type name (e.g. `T`) or a generic type name (e.g.
+//!   `Interval<Time>`)";
+//! * `type_signature` — "a form of the type name that can be used as a
+//!   fully-defined type signature, which for generic classes includes generic
+//!   constrainer types, giving a signature such as `Interval<T:Ordered>`";
+//! * `conformance_type_name` — "a reduced form of the type useful in some
+//!   circumstances that is either a simple class name, the _contained_ type for
+//!   a container type (e.g. `ELEMENT` from the type `List<ELEMENT>`), and the
+//!   _root_ type from a generic type (e.g. `Interval` from `Interval<T>`)".
+//!
+//! plus §Classes and Types (the four design-time type meta-types) and the class
+//! definitions under `LANG/docs/UML/classes/`:
+//! `org.openehr.lang.bmm.bmm_classifier.adoc`,
+//! `…bmm.bmm_type.adoc`, `…bmm.bmm_simple_type.adoc`,
+//! `…bmm.bmm_generic_type.adoc`, `…bmm.bmm_container_type.adoc`,
+//! `…bmm.bmm_indexed_container_type.adoc`. The generated model merges the v2
+//! and v3 (`bmm3`) type families into one enum, so the v3 class definitions
+//! (`…bmm3.bmm_type.adoc`, `…bmm3.bmm_parameter_type.adoc`,
+//! `…bmm3.bmm_signature.adoc`, `…bmm3.bmm_tuple_type.adoc`,
+//! `…bmm3.bmm_status_type.adoc`) govern the v3-only leaves and are cited at
+//! each site.
+//!
+//! The per-class functions are implemented on the individual generated structs
+//! (which is where the class definitions declare them) and
+//! [`BmmType`]/[`crate::bmm::core::bmm_classifier::BmmClassifier`] are pure
+//! dispatchers over them.
+//!
+//! NOTE (adjudicated divergence, v2 vs v3 `flattened_type_list`): the v2
+//! definition sits on `BMM_CLASSIFIER` alone — "Completely flattened list of
+//! type names, flattening out all generic parameters"
+//! (`org.openehr.lang.bmm.bmm_classifier.adoc` §Functions) — and no v2 subtype
+//! redefines it, so the whole type expression flattens, container class
+//! included (`Hash<String,Interval<Time>>` → `Hash`, `String`, `Interval`,
+//! `Time`). v3 narrows the container case to the item type only
+//! (`org.openehr.lang.bmm3.bmm_container_type.adoc` §Functions,
+//! `Post_result: Result = item_type.flattened_type_list`). This surface is the
+//! v2 core, so the v2 reading is implemented. Duplicate names are collapsed:
+//! v2 is silent on duplicates, v3 states the intent for the composite types
+//! ("the logical set (i.e. unique items)",
+//! `org.openehr.lang.bmm3.bmm_signature.adoc` §Functions).
+
+use crate::bmm3::core::entity::bmm_class::BmmClass;
+use crate::bmm3::core::entity::bmm_container_type::BmmContainerType;
+use crate::bmm3::core::entity::bmm_effective_type::BmmEffectiveType;
+use crate::bmm3::core::entity::bmm_function_type::BmmFunctionType;
+use crate::bmm3::core::entity::bmm_generic_type::BmmGenericType;
+use crate::bmm3::core::entity::bmm_indexed_container_type::BmmIndexedContainerType;
+use crate::bmm3::core::entity::bmm_parameter_type::BmmParameterType;
+use crate::bmm3::core::entity::bmm_procedure_type::BmmProcedureType;
+use crate::bmm3::core::entity::bmm_routine_type::BmmRoutineType;
+use crate::bmm3::core::entity::bmm_routine_type::BmmRoutineTypeData;
+use crate::bmm3::core::entity::bmm_signature::BmmSignature;
+use crate::bmm3::core::entity::bmm_signature::BmmSignatureData;
+use crate::bmm3::core::entity::bmm_simple_type::BmmSimpleType;
+use crate::bmm3::core::entity::bmm_status_type::BmmStatusType;
+use crate::bmm3::core::entity::bmm_tuple_type::BmmTupleType;
+use crate::bmm3::core::entity::bmm_type::BmmType;
+use crate::bmm3::core::entity::bmm_unitary_type::BmmUnitaryType;
+use crate::bmm3::core::model::bmm_model::BmmModel;
+
+/// The name of the top `Any` type, used wherever an unconstrained generic
+/// parameter has to be reduced to a concrete conformance name
+/// (`org.openehr.lang.bmm.bmm_open_type.adoc` §Attributes: the generic
+/// constraint "will be 'Any' if nothing set in original model";
+/// `org.openehr.lang.bmm3.bmm_definitions.adoc` §Functions `Any_class`:
+/// "built-in class definition corresponding to the top `Any` class").
+pub const ANY_TYPE_NAME: &str = "Any";
+
+/// Collapses `names` to its first-occurrence-ordered set.
+fn unique(names: Vec<String>) -> Vec<String> {
+    let mut out: Vec<String> = Vec::with_capacity(names.len());
+    for name in names {
+        if !out.contains(&name) {
+            out.push(name);
+        }
+    }
+    out
+}
+
+impl BmmSimpleType {
+    /// `BMM_SIMPLE_TYPE.type_name` (redefined): "Return base_class.type_name"
+    /// (`org.openehr.lang.bmm.bmm_simple_type.adoc` §Functions). For the simple
+    /// classes this meta-type is defined over
+    /// (`org.openehr.lang.bmm3.bmm_simple_type.adoc` §Functions sharpens it to
+    /// "Result is `_base_class.name_`") the two coincide.
+    #[must_use]
+    pub fn type_name(&self) -> String {
+        self.base_class.type_name()
+    }
+
+    /// `BMM_CLASSIFIER.type_signature` for a simple type: the type name — a
+    /// simple type has no generic parameters to constrain
+    /// (`org.openehr.lang.bmm3.bmm_type.adoc` §Functions: `type_signature`
+    /// "Defaults to the value of `_type_name()_`").
+    #[must_use]
+    pub fn type_signature(&self) -> String {
+        self.base_class.type_signature()
+    }
+
+    /// `BMM_CLASSIFIER.conformance_type_name` for a simple type: "a simple
+    /// class name" (`master05-core.adoc` §Basics).
+    #[must_use]
+    pub fn conformance_type_name(&self) -> String {
+        self.base_class.name().to_owned()
+    }
+
+    /// `BMM_CLASSIFIER.flattened_type_list` for a simple type: the base class
+    /// name (`org.openehr.lang.bmm3.bmm_simple_type.adoc` §Functions: "Result
+    /// is `_base_class.name_`").
+    #[must_use]
+    pub fn flattened_type_list(&self) -> Vec<String> {
+        vec![self.base_class.name().to_owned()]
+    }
+}
+
+impl BmmGenericType {
+    /// `BMM_GENERIC_TYPE.type_name` (redefined): "Return the full name of the
+    /// type including generic parameters, e.g. `DV_INTERVAL<T>`,
+    /// `TABLE<List<THING>,String>`"
+    /// (`org.openehr.lang.bmm.bmm_generic_type.adoc` §Functions).
+    #[must_use]
+    pub fn type_name(&self) -> String {
+        self.rendered(BmmType::type_name)
+    }
+
+    /// `BMM_GENERIC_TYPE.type_signature` (redefined): the type name with each
+    /// generic parameter rendered in signature form, e.g. `Interval<T:Ordered>`
+    /// (`org.openehr.lang.bmm3.bmm_generic_type.adoc` §Functions).
+    #[must_use]
+    pub fn type_signature(&self) -> String {
+        self.rendered(BmmType::type_signature)
+    }
+
+    /// `BMM_CLASSIFIER.conformance_type_name` for a generic type: "the _root_
+    /// type from a generic type (e.g. `Interval` from `Interval<T>`)"
+    /// (`master05-core.adoc` §Basics).
+    #[must_use]
+    pub fn conformance_type_name(&self) -> String {
+        self.base_class.name.clone()
+    }
+
+    /// `BMM_CLASSIFIER.flattened_type_list` for a generic type: "`_base_class.name_`
+    /// followed by names of all generic parameter type names, which may be open
+    /// or closed" (`org.openehr.lang.bmm3.bmm_generic_type.adoc` §Functions),
+    /// each parameter flattened in turn.
+    #[must_use]
+    pub fn flattened_type_list(&self) -> Vec<String> {
+        let mut out = vec![self.base_class.name.clone()];
+        for parameter in &self.generic_parameters {
+            out.extend(parameter.flattened_type_list());
+        }
+        unique(out)
+    }
+
+    /// `Root<p1,p2>` with each actual generic parameter rendered by `render`.
+    fn rendered(&self, render: impl Fn(&BmmType) -> String) -> String {
+        let root = &self.base_class.name;
+        let parameters: Vec<String> = self.generic_parameters.iter().map(render).collect();
+        let joined = parameters.join(",");
+        format!("{root}<{joined}>")
+    }
+}
+
+impl BmmContainerType {
+    /// `BMM_CONTAINER_TYPE.type_name` (redefined): "Return full type name, e.g.
+    /// `List<ELEMENT>`" (`org.openehr.lang.bmm.bmm_container_type.adoc`
+    /// §Functions).
+    ///
+    /// NOTE: `BMM_INDEXED_CONTAINER_TYPE` does not redefine `type_name`
+    /// (`org.openehr.lang.bmm.bmm_indexed_container_type.adoc` carries only the
+    /// `index_type` attribute), so the two-parameter rendering
+    /// `Hash<String,EVENT_ACTION>` is taken from that class's own §Description
+    /// ("an indexed container such as `Hash<K,V>` … e.g. `String` in
+    /// `Hash<String,EVENT_ACTION>`"), index type first.
+    #[must_use]
+    pub fn type_name(&self) -> String {
+        self.rendered(BmmType::type_name)
+    }
+
+    /// `BMM_CLASSIFIER.type_signature` for a container type: the type name with
+    /// the contained type in signature form
+    /// (`org.openehr.lang.bmm3.bmm_type.adoc` §Functions: `type_signature`
+    /// "Defaults to the value of `_type_name()_`", refined only where a generic
+    /// parameter carries a constrainer).
+    #[must_use]
+    pub fn type_signature(&self) -> String {
+        self.rendered(BmmType::type_signature)
+    }
+
+    /// `BMM_CLASSIFIER.conformance_type_name` for a container type: "the
+    /// _contained_ type for a container type (e.g. `ELEMENT` from the type
+    /// `List<ELEMENT>`)" (`master05-core.adoc` §Basics).
+    #[must_use]
+    pub fn conformance_type_name(&self) -> String {
+        self.base_type().conformance_type_name()
+    }
+
+    /// `BMM_CLASSIFIER.flattened_type_list` for a container type: the container
+    /// class name, the index type (when the container is indexed) and the
+    /// flattened contained type — see the module NOTE on the v2/v3 divergence.
+    #[must_use]
+    pub fn flattened_type_list(&self) -> Vec<String> {
+        match self {
+            Self::BmmIndexedContainerType(indexed) => indexed.flattened_type_list(),
+            Self::BmmContainerType(data) => {
+                let mut out = vec![data.container_type.name().to_owned()];
+                out.extend(data.base_type.flattened_type_list());
+                unique(out)
+            }
+        }
+    }
+
+    /// `BMM_CONTAINER_TYPE.container_type`: "The type of the container"
+    /// (`org.openehr.lang.bmm.bmm_container_type.adoc` §Attributes).
+    #[must_use]
+    pub fn container_type(&self) -> &BmmClass {
+        match self {
+            Self::BmmIndexedContainerType(indexed) => &indexed.container_type,
+            Self::BmmContainerType(data) => &data.container_type,
+        }
+    }
+
+    /// `BMM_CONTAINER_TYPE.base_type`: "The target type", i.e. the contained
+    /// item type (`org.openehr.lang.bmm.bmm_container_type.adoc` §Attributes).
+    #[must_use]
+    pub fn base_type(&self) -> &BmmType {
+        match self {
+            Self::BmmIndexedContainerType(indexed) => &indexed.base_type,
+            Self::BmmContainerType(data) => &data.base_type,
+        }
+    }
+
+    /// `Container<item>` (or `Container<index,item>` when indexed) with each
+    /// parameter rendered by `render`.
+    fn rendered(&self, render: impl Fn(&BmmType) -> String) -> String {
+        match self {
+            Self::BmmIndexedContainerType(indexed) => indexed.rendered(render),
+            Self::BmmContainerType(data) => {
+                let container = data.container_type.name();
+                let item = render(&data.base_type);
+                format!("{container}<{item}>")
+            }
+        }
+    }
+}
+
+impl BmmIndexedContainerType {
+    /// `BMM_CONTAINER_TYPE.type_name` for an indexed container:
+    /// `Hash<String,EVENT_ACTION>` — see the NOTE on
+    /// [`BmmContainerType::type_name`] for why the index type comes first.
+    #[must_use]
+    pub fn type_name(&self) -> String {
+        self.rendered(BmmType::type_name)
+    }
+
+    /// `BMM_CLASSIFIER.type_signature` for an indexed container: the type name
+    /// with its parameters in signature form.
+    #[must_use]
+    pub fn type_signature(&self) -> String {
+        self.rendered(BmmType::type_signature)
+    }
+
+    /// `BMM_CLASSIFIER.conformance_type_name` for an indexed container: "the
+    /// _contained_ type" (`master05-core.adoc` §Semantics §Basics), i.e. the
+    /// VALUE type `base_type` — not the key type.
+    #[must_use]
+    pub fn conformance_type_name(&self) -> String {
+        self.base_type.conformance_type_name()
+    }
+
+    /// `BMM_CLASSIFIER.flattened_type_list` for an indexed container: the
+    /// container class name, then the flattened index and contained types — see
+    /// the module NOTE on the v2/v3 divergence.
+    #[must_use]
+    pub fn flattened_type_list(&self) -> Vec<String> {
+        let mut out = vec![self.container_type.name().to_owned()];
+        out.extend(self.index_type.flattened_type_list());
+        out.extend(self.base_type.flattened_type_list());
+        unique(out)
+    }
+
+    /// `BMM_INDEXED_CONTAINER_TYPE.index_type`: "The key (index) type of the
+    /// container, e.g. `String` in `Hash<String,EVENT_ACTION>`"
+    /// (`org.openehr.lang.bmm.bmm_indexed_container_type.adoc` §Attributes).
+    #[must_use]
+    pub fn index_type_name(&self) -> String {
+        self.index_type.type_name()
+    }
+
+    /// `Container<index,item>` with both parameters rendered by `render`.
+    fn rendered(&self, render: impl Fn(&BmmType) -> String) -> String {
+        let container = self.container_type.name();
+        let index = self.index_type.type_name();
+        let item = render(&self.base_type);
+        format!("{container}<{index},{item}>")
+    }
+}
+
+impl BmmParameterType {
+    /// `BMM_PARAMETER_TYPE.type_name` (effected): "Return `_name_`"
+    /// (`org.openehr.lang.bmm3.bmm_parameter_type.adoc` §Functions) — the open
+    /// type name `T`, `U` etc. of `master05-core.adoc` §Basics.
+    #[must_use]
+    pub fn type_name(&self) -> &str {
+        self.name.as_str()
+    }
+
+    /// `BMM_PARAMETER_TYPE.type_signature` (redefined): "Signature form of the
+    /// open type, including constrainer type if there is one, e.g. `T:Ordered`"
+    /// (`org.openehr.lang.bmm3.bmm_parameter_type.adoc` §Functions).
+    ///
+    /// Delimiter per `org.openehr.lang.bmm3.bmm_definitions.adoc` §Constants
+    /// (`Generic_constraint_delimiter` `':'`).
+    #[must_use]
+    pub fn type_signature(&self) -> String {
+        match self.flattened_conforms_to_type() {
+            Some(constraint) => {
+                let name = &self.name;
+                let constraint = constraint.type_name();
+                format!("{name}:{constraint}")
+            }
+            None => self.name.clone(),
+        }
+    }
+
+    /// `BMM_PARAMETER_TYPE.flattened_conforms_to_type`: "Result is either
+    /// `_conforms_to_type_` or `_inheritance_precursor.flattened_conforms_to_type_`"
+    /// (`org.openehr.lang.bmm3.bmm_parameter_type.adoc` §Functions).
+    #[must_use]
+    pub fn flattened_conforms_to_type(&self) -> Option<&BmmEffectiveType> {
+        match &self.type_constraint {
+            Some(constraint) => Some(constraint),
+            None => self
+                .inheritance_precursor
+                .as_ref()
+                .and_then(|precursor| precursor.flattened_conforms_to_type()),
+        }
+    }
+
+    /// `BMM_PARAMETER_TYPE.effective_type` (effected): "Generate ultimate
+    /// conformance type, which is either `_flattened_conforms_to_type_` or if
+    /// not set, `'Any'`" (`org.openehr.lang.bmm3.bmm_parameter_type.adoc`
+    /// §Functions), projected to the type NAME — see the projection NOTE on
+    /// [`crate::bmm::core::bmm_generic_parameter::BmmGenericParameter::effective_conforms_to_type_name`].
+    #[must_use]
+    pub fn conformance_type_name(&self) -> String {
+        match self.flattened_conforms_to_type() {
+            Some(constraint) => constraint.conformance_type_name(),
+            None => ANY_TYPE_NAME.to_owned(),
+        }
+    }
+
+    /// `BMM_PARAMETER_TYPE.flattened_type_list` (effected): "Result is either
+    /// `_flattened_conforms_to_type.flattened_type_list_` or the `Any` type"
+    /// (`org.openehr.lang.bmm3.bmm_parameter_type.adoc` §Functions).
+    #[must_use]
+    pub fn flattened_type_list(&self) -> Vec<String> {
+        match self.flattened_conforms_to_type() {
+            Some(constraint) => constraint.flattened_type_list(),
+            None => vec![ANY_TYPE_NAME.to_owned()],
+        }
+    }
+}
+
+impl BmmStatusType {
+    /// `BMM_STATUS_TYPE.type_name`: the built-in `base_name` `"Status"`
+    /// (`org.openehr.lang.bmm3.bmm_status_type.adoc` §Constants).
+    #[expect(
+        clippy::unused_self,
+        reason = "the class definitions declare this as an instance function on the meta-type (BMM_CLASSIFIER §Functions); a built-in meta-type's name is simply constant"
+    )]
+    #[must_use]
+    pub fn type_name(&self) -> String {
+        Self::BASE_NAME.to_owned()
+    }
+
+    /// `BMM_CLASSIFIER.conformance_type_name` for the status meta-type: its
+    /// built-in base name (`org.openehr.lang.bmm3.bmm_status_type.adoc`
+    /// §Constants).
+    #[expect(
+        clippy::unused_self,
+        reason = "the class definitions declare this as an instance function on the meta-type (BMM_CLASSIFIER §Functions); a built-in meta-type's name is simply constant"
+    )]
+    #[must_use]
+    pub fn conformance_type_name(&self) -> String {
+        Self::BASE_NAME.to_owned()
+    }
+
+    /// `BMM_CLASSIFIER.flattened_type_list` for the status meta-type: its
+    /// built-in base name (`org.openehr.lang.bmm3.bmm_status_type.adoc`
+    /// §Constants).
+    #[expect(
+        clippy::unused_self,
+        reason = "the class definitions declare this as an instance function on the meta-type (BMM_CLASSIFIER §Functions); a built-in meta-type's name is simply constant"
+    )]
+    #[must_use]
+    pub fn flattened_type_list(&self) -> Vec<String> {
+        vec![Self::BASE_NAME.to_owned()]
+    }
+}
+
+impl BmmTupleType {
+    /// `BMM_TUPLE_TYPE.type_name`: the built-in `base_name` `"Tuple"`
+    /// (`org.openehr.lang.bmm3.bmm_tuple_type.adoc` §Constants).
+    #[expect(
+        clippy::unused_self,
+        reason = "the class definitions declare this as an instance function on the meta-type (BMM_CLASSIFIER §Functions); a built-in meta-type's name is simply constant"
+    )]
+    #[must_use]
+    pub fn type_name(&self) -> String {
+        Self::BASE_NAME.to_owned()
+    }
+
+    /// `BMM_CLASSIFIER.conformance_type_name` for the tuple meta-type: its
+    /// built-in base name (`org.openehr.lang.bmm3.bmm_tuple_type.adoc`
+    /// §Constants).
+    #[expect(
+        clippy::unused_self,
+        reason = "the class definitions declare this as an instance function on the meta-type (BMM_CLASSIFIER §Functions); a built-in meta-type's name is simply constant"
+    )]
+    #[must_use]
+    pub fn conformance_type_name(&self) -> String {
+        Self::BASE_NAME.to_owned()
+    }
+
+    /// `BMM_TUPLE_TYPE.flattened_type_list` (effected): "Return the logical set
+    /// (i.e. unique types) from the merge of `_flattened_type_list_()` called on
+    /// each member of `_item_types_`"
+    /// (`org.openehr.lang.bmm3.bmm_tuple_type.adoc` §Functions).
+    #[must_use]
+    pub fn flattened_type_list(&self) -> Vec<String> {
+        let mut out = Vec::new();
+        for item in self.item_types.values() {
+            out.extend(item.flattened_type_list());
+        }
+        unique(out)
+    }
+}
+
+impl BmmSignature {
+    /// `BMM_SIGNATURE.type_name`: the built-in `base_name` of the effective
+    /// signature meta-type — `"Signature"`, `"Routine"`, `"Function"` or
+    /// `"Procedure"` (`org.openehr.lang.bmm3.bmm_signature.adoc`,
+    /// `…bmm3.bmm_routine_type.adoc`, `…bmm3.bmm_function_type.adoc`,
+    /// `…bmm3.bmm_procedure_type.adoc`, all §Constants).
+    ///
+    /// `BMM_PROPERTY_TYPE` declares no `base_name` of its own
+    /// (`org.openehr.lang.bmm3.bmm_property_type.adoc`), so it takes the
+    /// inherited `BMM_SIGNATURE` one.
+    #[must_use]
+    pub fn type_name(&self) -> String {
+        match self {
+            Self::BmmPropertyType(_) | Self::BmmSignature(_) => {
+                BmmSignatureData::BASE_NAME.to_owned()
+            }
+            Self::BmmRoutineType(routine) => match routine.as_ref() {
+                BmmRoutineType::BmmFunctionType(_) => BmmFunctionType::BASE_NAME.to_owned(),
+                BmmRoutineType::BmmProcedureType(_) => BmmProcedureType::BASE_NAME.to_owned(),
+                BmmRoutineType::BmmRoutineType(_) => BmmRoutineTypeData::BASE_NAME.to_owned(),
+            },
+        }
+    }
+
+    /// `BMM_CLASSIFIER.conformance_type_name` for a signature meta-type: its
+    /// built-in base name — a signature is not a model class, so there is no
+    /// reduced form beyond the name itself (`master05-core.adoc` §Basics).
+    #[must_use]
+    pub fn conformance_type_name(&self) -> String {
+        self.type_name()
+    }
+
+    /// `BMM_SIGNATURE.flattened_type_list` (effected): "Return the logical set
+    /// (i.e. unique items) consisting of `_argument_types.flattened_type_list_()`
+    /// and `_result_type.flattened_type_list_()`"
+    /// (`org.openehr.lang.bmm3.bmm_signature.adoc` §Functions).
+    #[must_use]
+    pub fn flattened_type_list(&self) -> Vec<String> {
+        let mut out = Vec::new();
+        match self {
+            Self::BmmPropertyType(property) => {
+                out.extend(property.result_type.flattened_type_list());
+            }
+            Self::BmmSignature(data) => out.extend(data.result_type.flattened_type_list()),
+            Self::BmmRoutineType(routine) => match routine.as_ref() {
+                BmmRoutineType::BmmFunctionType(function) => {
+                    out.extend(function.result_type.flattened_type_list());
+                    if let Some(arguments) = &function.argument_types {
+                        out.extend(arguments.flattened_type_list());
+                    }
+                }
+                BmmRoutineType::BmmProcedureType(procedure) => {
+                    if let Some(result) = &procedure.result_type {
+                        out.extend(result.flattened_type_list());
+                    }
+                    if let Some(arguments) = &procedure.argument_types {
+                        out.extend(arguments.flattened_type_list());
+                    }
+                }
+                BmmRoutineType::BmmRoutineType(data) => {
+                    out.extend(data.result_type.flattened_type_list());
+                    if let Some(arguments) = &data.argument_types {
+                        out.extend(arguments.flattened_type_list());
+                    }
+                }
+            },
+        }
+        unique(out)
+    }
+}
+
+impl BmmEffectiveType {
+    /// `BMM_CLASSIFIER.type_name` for a concrete unitary type usable as an
+    /// actual generic parameter (`org.openehr.lang.bmm3.bmm_effective_type.adoc`
+    /// §Description).
+    #[must_use]
+    pub fn type_name(&self) -> String {
+        match self {
+            Self::BmmSignature(signature) => signature.type_name(),
+            Self::BmmStatusType(status) => status.type_name(),
+            Self::BmmTupleType(tuple) => tuple.type_name(),
+        }
+    }
+
+    /// `BMM_CLASSIFIER.conformance_type_name` for an effective type.
+    #[must_use]
+    pub fn conformance_type_name(&self) -> String {
+        match self {
+            Self::BmmSignature(signature) => signature.conformance_type_name(),
+            Self::BmmStatusType(status) => status.conformance_type_name(),
+            Self::BmmTupleType(tuple) => tuple.conformance_type_name(),
+        }
+    }
+
+    /// `BMM_CLASSIFIER.flattened_type_list` for an effective type.
+    #[must_use]
+    pub fn flattened_type_list(&self) -> Vec<String> {
+        match self {
+            Self::BmmSignature(signature) => signature.flattened_type_list(),
+            Self::BmmStatusType(status) => status.flattened_type_list(),
+            Self::BmmTupleType(tuple) => tuple.flattened_type_list(),
+        }
+    }
+}
+
+impl BmmUnitaryType {
+    /// `BMM_CLASSIFIER.type_name` for a unitary type, i.e. "the type of any
+    /// instantiated object that is not a container object"
+    /// (`org.openehr.lang.bmm3.bmm_unitary_type.adoc` §Description).
+    #[must_use]
+    pub fn type_name(&self) -> String {
+        match self {
+            Self::BmmParameterType(parameter) => parameter.type_name().to_owned(),
+            Self::BmmSignature(signature) => signature.type_name(),
+            Self::BmmStatusType(status) => status.type_name(),
+            Self::BmmTupleType(tuple) => tuple.type_name(),
+        }
+    }
+
+    /// `BMM_CLASSIFIER.conformance_type_name` for a unitary type.
+    #[must_use]
+    pub fn conformance_type_name(&self) -> String {
+        match self {
+            Self::BmmParameterType(parameter) => parameter.conformance_type_name(),
+            Self::BmmSignature(signature) => signature.conformance_type_name(),
+            Self::BmmStatusType(status) => status.conformance_type_name(),
+            Self::BmmTupleType(tuple) => tuple.conformance_type_name(),
+        }
+    }
+
+    /// `BMM_CLASSIFIER.flattened_type_list` for a unitary type.
+    #[must_use]
+    pub fn flattened_type_list(&self) -> Vec<String> {
+        match self {
+            Self::BmmParameterType(parameter) => parameter.flattened_type_list(),
+            Self::BmmSignature(signature) => signature.flattened_type_list(),
+            Self::BmmStatusType(status) => status.flattened_type_list(),
+            Self::BmmTupleType(tuple) => tuple.flattened_type_list(),
+        }
+    }
+}
+
+impl BmmType {
+    /// `BMM_CLASSIFIER.type_name`: "Formal string form of the type as per UML"
+    /// (`org.openehr.lang.bmm.bmm_classifier.adoc` §Functions), dispatched to
+    /// the effective meta-type — see the module docs for the §Basics
+    /// definition.
+    #[must_use]
+    pub fn type_name(&self) -> String {
+        match self {
+            Self::BmmContainerType(container) => container.type_name(),
+            Self::BmmGenericType(generic) => generic.type_name(),
+            Self::BmmOpenType(open) => open.type_name().to_owned(),
+            Self::BmmParameterType(parameter) => parameter.type_name().to_owned(),
+            Self::BmmSignature(signature) => signature.type_name(),
+            Self::BmmSimpleType(simple) => simple.type_name(),
+            Self::BmmStatusType(status) => status.type_name(),
+            Self::BmmTupleType(tuple) => tuple.type_name(),
+        }
+    }
+
+    /// `BMM_CLASSIFIER.type_signature`: "Signature form of the type, which for
+    /// generics includes generic parameter constrainer types e.g.
+    /// Interval<T:Ordered>" (`org.openehr.lang.bmm.bmm_classifier.adoc`
+    /// §Functions); it "Defaults to the value of `_type_name()_`" for every
+    /// meta-type that carries no constrainer
+    /// (`org.openehr.lang.bmm3.bmm_type.adoc` §Functions).
+    #[must_use]
+    pub fn type_signature(&self) -> String {
+        match self {
+            Self::BmmContainerType(container) => container.type_signature(),
+            Self::BmmGenericType(generic) => generic.type_signature(),
+            Self::BmmOpenType(open) => open.type_signature(),
+            Self::BmmParameterType(parameter) => parameter.type_signature(),
+            Self::BmmSignature(signature) => signature.type_name(),
+            Self::BmmSimpleType(simple) => simple.type_signature(),
+            Self::BmmStatusType(status) => status.type_name(),
+            Self::BmmTupleType(tuple) => tuple.type_name(),
+        }
+    }
+
+    /// `BMM_CLASSIFIER.conformance_type_name`: "a reduced form of the type …
+    /// either a simple class name, the _contained_ type for a container type
+    /// (e.g. `ELEMENT` from the type `List<ELEMENT>`), and the _root_ type from
+    /// a generic type (e.g. `Interval` from `Interval<T>`)"
+    /// (`master05-core.adoc` §Semantics §Basics).
+    #[must_use]
+    pub fn conformance_type_name(&self) -> String {
+        match self {
+            Self::BmmContainerType(container) => container.conformance_type_name(),
+            Self::BmmGenericType(generic) => generic.conformance_type_name(),
+            Self::BmmOpenType(open) => open.conformance_type_name(),
+            Self::BmmParameterType(parameter) => parameter.conformance_type_name(),
+            Self::BmmSignature(signature) => signature.conformance_type_name(),
+            Self::BmmSimpleType(simple) => simple.conformance_type_name(),
+            Self::BmmStatusType(status) => status.conformance_type_name(),
+            Self::BmmTupleType(tuple) => tuple.conformance_type_name(),
+        }
+    }
+
+    /// `BMM_CLASSIFIER.flattened_type_list`: "Completely flattened list of type
+    /// names, flattening out all generic parameters"
+    /// (`org.openehr.lang.bmm.bmm_classifier.adoc` §Functions) — e.g.
+    /// `Hash<String,Interval<Time>>` flattens to `Hash`, `String`, `Interval`,
+    /// `Time`. See the module NOTE for the v2/v3 container divergence.
+    #[must_use]
+    pub fn flattened_type_list(&self) -> Vec<String> {
+        match self {
+            Self::BmmContainerType(container) => container.flattened_type_list(),
+            Self::BmmGenericType(generic) => generic.flattened_type_list(),
+            Self::BmmOpenType(open) => open.flattened_type_list(),
+            Self::BmmParameterType(parameter) => parameter.flattened_type_list(),
+            Self::BmmSignature(signature) => signature.flattened_type_list(),
+            Self::BmmSimpleType(simple) => simple.flattened_type_list(),
+            Self::BmmStatusType(status) => status.flattened_type_list(),
+            Self::BmmTupleType(tuple) => tuple.flattened_type_list(),
+        }
+    }
+
+    /// `BMM_TYPE.has_type_substitutions`: "Determine if there are any type
+    /// substitutions" (`org.openehr.lang.bmm.bmm_type.adoc` §Functions).
+    #[must_use]
+    pub fn has_type_substitutions(&self, model: &BmmModel) -> bool {
+        !self.type_substitutions(model).is_empty()
+    }
+
+    /// `BMM_TYPE.type_substitutions`: "List of type substitutions if any
+    /// available for this type within the current BMM model"
+    /// (`org.openehr.lang.bmm.bmm_type.adoc` §Functions) — the descendants of
+    /// this type's conformance root class, resolved through `model`
+    /// ("`_a_desc_type_` has `_an_anc_type_` in its ancestors" is the
+    /// conformance relation the substitution set realises,
+    /// `org.openehr.lang.bmm.bmm_model.adoc` §Functions `type_conforms_to`).
+    ///
+    /// NOTE: the class doc's signature takes no argument because it assumes a
+    /// live model with back-references; the generated persistence-shaped types
+    /// record descendants as names only, so the model is passed in (see
+    /// [`BmmClass::all_descendants`]).
+    #[must_use]
+    pub fn type_substitutions(&self, model: &BmmModel) -> Vec<String> {
+        match model.class_definition(&self.conformance_type_name()) {
+            Some(class) => class.all_descendants(model),
+            None => Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::bmm::core::bmm_generic_parameter::BmmGenericParameter;
+    use crate::bmm::core::bmm_open_type::BmmOpenType;
+    use crate::bmm3::core::entity::bmm_class::BmmClass;
+    use crate::bmm3::core::entity::bmm_container_type::BmmContainerType;
+    use crate::bmm3::core::entity::bmm_container_type::BmmContainerTypeData;
+    use crate::bmm3::core::entity::bmm_generic_class::BmmGenericClass;
+    use crate::bmm3::core::entity::bmm_generic_type::BmmGenericType;
+    use crate::bmm3::core::entity::bmm_indexed_container_type::BmmIndexedContainerType;
+    use crate::bmm3::core::entity::bmm_simple_class::BmmSimpleClass;
+    use crate::bmm3::core::entity::bmm_simple_type::BmmSimpleType;
+    use crate::bmm3::core::entity::bmm_type::BmmType;
+    use crate::bmm3::core::model::bmm_package::BmmPackage;
+
+    /// An empty package node.
+    fn package() -> BmmPackage {
+        BmmPackage {
+            documentation: None,
+            packages: None,
+            name: "org.openehr.base.foundation_types".to_owned(),
+            classes: Vec::new(),
+        }
+    }
+
+    /// A simple class named `name`.
+    fn simple_class(name: &str) -> BmmClass {
+        BmmClass::BmmSimpleClass(BmmSimpleClass {
+            documentation: None,
+            name: name.to_owned(),
+            ancestors: None,
+            package: package(),
+            properties: None,
+            source_schema_id: "openehr_test_1.0.0".to_owned(),
+            immediate_descendants: Vec::new(),
+            is_abstract: false,
+            is_primitive_type: false,
+            is_override: false,
+        })
+    }
+
+    /// A generic class named `name` with one formal parameter `T`, optionally
+    /// constrained.
+    fn generic_class(name: &str, constraint: Option<&str>) -> BmmGenericClass {
+        BmmGenericClass {
+            documentation: None,
+            name: name.to_owned(),
+            ancestors: None,
+            package: package(),
+            properties: None,
+            source_schema_id: "openehr_test_1.0.0".to_owned(),
+            immediate_descendants: Vec::new(),
+            is_abstract: false,
+            is_primitive_type: false,
+            is_override: false,
+            generic_parameters: [(
+                "T".to_owned(),
+                BmmGenericParameter {
+                    documentation: None,
+                    name: "T".to_owned(),
+                    conforms_to_type: constraint.map(simple_class),
+                    inheritance_precursor: None,
+                },
+            )]
+            .into_iter()
+            .collect(),
+        }
+    }
+
+    /// A `BMM_SIMPLE_TYPE` over the class named `name`.
+    fn simple(name: &str) -> BmmType {
+        BmmType::BmmSimpleType(BmmSimpleType {
+            documentation: None,
+            base_class: simple_class(name),
+        })
+    }
+
+    /// `Root<parameter>` as a `BMM_GENERIC_TYPE`.
+    fn generic(root: &str, parameter: BmmType) -> BmmType {
+        BmmType::BmmGenericType(BmmGenericType {
+            documentation: None,
+            generic_parameters: vec![parameter],
+            base_class: generic_class(root, None),
+        })
+    }
+
+    /// `Container<item>` as a `BMM_CONTAINER_TYPE`.
+    fn container(container_class: &str, item: BmmType) -> BmmType {
+        BmmType::BmmContainerType(Box::new(BmmContainerType::BmmContainerType(
+            BmmContainerTypeData {
+                documentation: None,
+                container_type: simple_class(container_class),
+                base_type: Box::new(item),
+            },
+        )))
+    }
+
+    /// `Hash<index,item>` as a `BMM_INDEXED_CONTAINER_TYPE`.
+    fn indexed(container_class: &str, index: &str, item: BmmType) -> BmmType {
+        BmmType::BmmContainerType(Box::new(BmmContainerType::BmmIndexedContainerType(
+            Box::new(BmmIndexedContainerType {
+                documentation: None,
+                container_type: simple_class(container_class),
+                base_type: item,
+                index_type: BmmSimpleType {
+                    documentation: None,
+                    base_class: simple_class(index),
+                },
+            }),
+        )))
+    }
+
+    #[test]
+    fn type_names_follow_master05_basics() {
+        assert_eq!(simple("ELEMENT").type_name(), "ELEMENT");
+        assert_eq!(
+            container("List", simple("ELEMENT")).type_name(),
+            "List<ELEMENT>"
+        );
+        assert_eq!(
+            generic("Interval", simple("Time")).type_name(),
+            "Interval<Time>"
+        );
+        assert_eq!(
+            indexed("Hash", "String", simple("EVENT_ACTION")).type_name(),
+            "Hash<String,EVENT_ACTION>"
+        );
+    }
+
+    #[test]
+    fn conformance_type_name_reduces_container_and_generic_forms() {
+        // master05-core.adoc §Basics: the contained type for a container, the
+        // root type for a generic type, the class name for a simple type.
+        assert_eq!(simple("ELEMENT").conformance_type_name(), "ELEMENT");
+        assert_eq!(
+            container("List", simple("ELEMENT")).conformance_type_name(),
+            "ELEMENT"
+        );
+        assert_eq!(
+            generic("Interval", simple("Time")).conformance_type_name(),
+            "Interval"
+        );
+    }
+
+    #[test]
+    fn flattened_type_list_flattens_nested_generics() {
+        let nested = indexed("Hash", "String", generic("Interval", simple("Time")));
+        assert_eq!(
+            nested.flattened_type_list(),
+            [
+                "Hash".to_owned(),
+                "String".to_owned(),
+                "Interval".to_owned(),
+                "Time".to_owned()
+            ]
+        );
+    }
+
+    #[test]
+    fn flattened_type_list_collapses_duplicates() {
+        let hash = indexed("Hash", "String", simple("String"));
+        assert_eq!(
+            hash.flattened_type_list(),
+            ["Hash".to_owned(), "String".to_owned()]
+        );
+    }
+
+    #[test]
+    fn generic_type_signature_carries_the_constrainer() {
+        let interval = BmmType::BmmGenericType(BmmGenericType {
+            documentation: None,
+            generic_parameters: vec![BmmType::BmmOpenType(BmmOpenType {
+                documentation: None,
+                generic_constraint: BmmGenericParameter {
+                    documentation: None,
+                    name: "T".to_owned(),
+                    conforms_to_type: Some(simple_class("Ordered")),
+                    inheritance_precursor: None,
+                },
+            })],
+            base_class: generic_class("Interval", Some("Ordered")),
+        });
+        assert_eq!(interval.type_name(), "Interval<T>");
+        assert_eq!(interval.type_signature(), "Interval<T:Ordered>");
+        assert_eq!(interval.conformance_type_name(), "Interval");
+        assert_eq!(
+            interval.flattened_type_list(),
+            ["Interval".to_owned(), "Ordered".to_owned()]
+        );
+    }
+}

--- a/crates/openehr-lang/src/bmm3/core/entity/mod.rs
+++ b/crates/openehr-lang/src/bmm3/core/entity/mod.rs
@@ -23,3 +23,7 @@ pub mod bmm_tuple_type;
 pub mod bmm_type;
 pub mod bmm_unitary_type;
 pub mod range_constrained;
+
+// hand-written modules (spec behaviour), auto-declared:
+pub mod bmm_class_impl;
+pub mod bmm_type_impl;

--- a/crates/openehr-lang/src/bmm3/core/feature/bmm_property_impl.rs
+++ b/crates/openehr-lang/src/bmm3/core/feature/bmm_property_impl.rs
@@ -1,0 +1,288 @@
+//! Hand-written spec functions of `BMM_PROPERTY<T>` — the property definitions
+//! whose differential and flat sets `BMM_CLASS` exposes.
+//!
+//! Spec: `LANG/docs/UML/classes/org.openehr.lang.bmm.bmm_property.adoc`
+//! §Attributes + §Functions (`existence`: "Interval form of `0..1`, `1..1` etc,
+//! generated from `_is_mandatory_`"; `display_name`: "Name of this attribute to
+//! display in UI"), `…bmm.bmm_container_property.adoc` (the container variant,
+//! whose `type` is "Redefined to BMM_CONTAINER_TYPE") and
+//! `LANG/docs/bmm/master05-core.adoc` §Semantics §Classes and Properties
+//! ("Class properties are defined using the generic class
+//! `BMM_PROPERTY <T: BMM_TYPE>`").
+
+use openehr_base::prelude::MultiplicityInterval;
+
+use crate::bmm3::core::entity::bmm_type::BmmType;
+use crate::bmm3::core::feature::bmm_container_property::BmmContainerProperty;
+use crate::bmm3::core::feature::bmm_property::BmmProperty;
+
+impl<T> BmmProperty<T> {
+    /// `BMM_PROPERTY.name`: "Name of this property in the model" (class doc
+    /// §Attributes).
+    #[must_use]
+    pub fn name(&self) -> &str {
+        match self {
+            Self::BmmContainerProperty(BmmContainerProperty::BmmIndexedContainerProperty(
+                indexed,
+            )) => indexed.name.as_str(),
+            Self::BmmContainerProperty(BmmContainerProperty::BmmContainerProperty(container)) => {
+                container.name.as_str()
+            }
+            Self::BmmUnitaryProperty(unitary) => unitary.name.as_str(),
+            Self::BmmProperty(property) => property.name.as_str(),
+        }
+    }
+
+    /// `BMM_PROPERTY.is_mandatory`: "True if this property is mandatory in its
+    /// class" (class doc §Attributes).
+    ///
+    /// The attribute is optional (`0..1`) in the class definition, so an absent
+    /// value is reported as *not mandatory* — the only reading that keeps
+    /// [`Self::existence`] total, and the same reading the class doc's
+    /// `0..1`/`1..1` example pair implies (absent = the weaker `0..1` bound).
+    #[must_use]
+    pub fn is_mandatory(&self) -> bool {
+        let flag = match self {
+            Self::BmmContainerProperty(BmmContainerProperty::BmmIndexedContainerProperty(
+                indexed,
+            )) => indexed.is_mandatory,
+            Self::BmmContainerProperty(BmmContainerProperty::BmmContainerProperty(container)) => {
+                container.is_mandatory
+            }
+            Self::BmmUnitaryProperty(unitary) => unitary.is_mandatory,
+            Self::BmmProperty(property) => property.is_mandatory,
+        };
+        flag == Some(true)
+    }
+
+    /// `BMM_PROPERTY.is_computed`: "True if this property is computed rather
+    /// than stored in objects of this class" (class doc §Attributes); an absent
+    /// optional value reads as *stored*.
+    #[must_use]
+    pub fn is_computed(&self) -> bool {
+        let flag = match self {
+            Self::BmmContainerProperty(BmmContainerProperty::BmmIndexedContainerProperty(
+                indexed,
+            )) => indexed.is_computed,
+            Self::BmmContainerProperty(BmmContainerProperty::BmmContainerProperty(container)) => {
+                container.is_computed
+            }
+            Self::BmmUnitaryProperty(unitary) => unitary.is_computed,
+            Self::BmmProperty(property) => property.is_computed,
+        };
+        flag == Some(true)
+    }
+
+    /// `BMM_PROPERTY.existence`: "Interval form of `0..1`, `1..1` etc, generated
+    /// from `_is_mandatory_`" (class doc §Functions) — a closed, fully bounded
+    /// interval with both limits included, lower `1` when mandatory and `0`
+    /// otherwise, upper always `1` (existence constrains presence of the single
+    /// property slot; a container's item count is `cardinality`,
+    /// `org.openehr.lang.bmm.bmm_container_property.adoc` §Attributes).
+    #[must_use]
+    pub fn existence(&self) -> MultiplicityInterval {
+        MultiplicityInterval {
+            lower: Some(i32::from(self.is_mandatory())),
+            upper: Some(1),
+            lower_unbounded: false,
+            upper_unbounded: false,
+            lower_included: true,
+            upper_included: true,
+        }
+    }
+
+    /// `BMM_PROPERTY.display_name`: "Name of this attribute to display in UI"
+    /// (class doc §Functions) — the property name; `BMM_CONTAINER_PROPERTY`
+    /// redefines the function but restates the same meaning
+    /// (`org.openehr.lang.bmm.bmm_container_property.adoc` §Functions), and
+    /// neither class definition prescribes any transformation of the name.
+    #[must_use]
+    pub fn display_name(&self) -> &str {
+        self.name()
+    }
+}
+
+impl BmmProperty<BmmType> {
+    /// `BMM_CLASSIFIER.type_name` of this property's type — "the declared type"
+    /// of the feature (`LANG/docs/bmm/master05-core.adoc` §Semantics §Basics).
+    #[must_use]
+    pub fn type_name(&self) -> String {
+        match self {
+            Self::BmmContainerProperty(BmmContainerProperty::BmmIndexedContainerProperty(
+                indexed,
+            )) => indexed.r#type.type_name(),
+            Self::BmmContainerProperty(BmmContainerProperty::BmmContainerProperty(container)) => {
+                container.r#type.type_name()
+            }
+            Self::BmmUnitaryProperty(unitary) => unitary.r#type.type_name(),
+            Self::BmmProperty(property) => property.r#type.type_name(),
+        }
+    }
+
+    /// `BMM_CLASSIFIER.conformance_type_name` of this property's type: the
+    /// reduced form that abstracts a container away — "the _contained_ type for
+    /// a container type (e.g. `ELEMENT` from the type `List<ELEMENT>`)"
+    /// (`LANG/docs/bmm/master05-core.adoc` §Semantics §Basics). This is the
+    /// projection `BMM_MODEL.property_definition_at_path` and
+    /// `BMM_MODEL.ms_conformant_property_type` navigate on.
+    #[must_use]
+    pub fn conformance_type_name(&self) -> String {
+        match self {
+            Self::BmmContainerProperty(BmmContainerProperty::BmmIndexedContainerProperty(
+                indexed,
+            )) => indexed.r#type.conformance_type_name(),
+            Self::BmmContainerProperty(BmmContainerProperty::BmmContainerProperty(container)) => {
+                container.r#type.conformance_type_name()
+            }
+            Self::BmmUnitaryProperty(unitary) => unitary.r#type.conformance_type_name(),
+            Self::BmmProperty(property) => property.r#type.conformance_type_name(),
+        }
+    }
+
+    /// `BMM_CLASSIFIER.flattened_type_list` of this property's type — the
+    /// supplier names this property contributes to
+    /// [`BmmClass::suppliers`](crate::bmm3::core::entity::bmm_class::BmmClass::suppliers).
+    #[must_use]
+    pub fn flattened_type_list(&self) -> Vec<String> {
+        match self {
+            Self::BmmContainerProperty(BmmContainerProperty::BmmIndexedContainerProperty(
+                indexed,
+            )) => indexed.r#type.flattened_type_list(),
+            Self::BmmContainerProperty(BmmContainerProperty::BmmContainerProperty(container)) => {
+                container.r#type.flattened_type_list()
+            }
+            Self::BmmUnitaryProperty(unitary) => unitary.r#type.flattened_type_list(),
+            Self::BmmProperty(property) => property.r#type.flattened_type_list(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use openehr_base::prelude::MultiplicityInterval;
+
+    use crate::bmm3::core::entity::bmm_class::BmmClass;
+    use crate::bmm3::core::entity::bmm_container_type::BmmContainerType;
+    use crate::bmm3::core::entity::bmm_container_type::BmmContainerTypeData;
+    use crate::bmm3::core::entity::bmm_simple_class::BmmSimpleClass;
+    use crate::bmm3::core::entity::bmm_simple_type::BmmSimpleType;
+    use crate::bmm3::core::entity::bmm_type::BmmType;
+    use crate::bmm3::core::feature::bmm_container_property::BmmContainerProperty;
+    use crate::bmm3::core::feature::bmm_container_property::BmmContainerPropertyData;
+    use crate::bmm3::core::feature::bmm_property::BmmProperty;
+    use crate::bmm3::core::feature::bmm_property::BmmPropertyData;
+    use crate::bmm3::core::model::bmm_package::BmmPackage;
+
+    /// A simple class named `name`.
+    fn simple_class(name: &str) -> BmmClass {
+        BmmClass::BmmSimpleClass(BmmSimpleClass {
+            documentation: None,
+            name: name.to_owned(),
+            ancestors: None,
+            package: BmmPackage {
+                documentation: None,
+                packages: None,
+                name: "org.openehr.rm.data_structures".to_owned(),
+                classes: Vec::new(),
+            },
+            properties: None,
+            source_schema_id: "openehr_test_1.0.0".to_owned(),
+            immediate_descendants: Vec::new(),
+            is_abstract: false,
+            is_primitive_type: false,
+            is_override: false,
+        })
+    }
+
+    /// A unitary property of the given name, type and mandatory flag.
+    fn property(name: &str, type_name: &str, is_mandatory: Option<bool>) -> BmmProperty<BmmType> {
+        BmmProperty::BmmProperty(BmmPropertyData {
+            documentation: None,
+            name: name.to_owned(),
+            is_mandatory,
+            is_computed: None,
+            r#type: BmmType::BmmSimpleType(BmmSimpleType {
+                documentation: None,
+                base_class: simple_class(type_name),
+            }),
+            is_im_runtime: None,
+            is_im_infrastructure: None,
+        })
+    }
+
+    /// A `List<item>` container property.
+    fn container_property(name: &str, item: &str) -> BmmProperty<BmmType> {
+        BmmProperty::BmmContainerProperty(BmmContainerProperty::BmmContainerProperty(
+            BmmContainerPropertyData {
+                documentation: None,
+                name: name.to_owned(),
+                is_mandatory: Some(true),
+                is_computed: None,
+                r#type: BmmContainerType::BmmContainerType(BmmContainerTypeData {
+                    documentation: None,
+                    container_type: simple_class("List"),
+                    base_type: Box::new(BmmType::BmmSimpleType(BmmSimpleType {
+                        documentation: None,
+                        base_class: simple_class(item),
+                    })),
+                }),
+                is_im_runtime: None,
+                is_im_infrastructure: None,
+                cardinality: None,
+            },
+        ))
+    }
+
+    #[test]
+    fn existence_is_zero_one_or_one_one() {
+        let optional = property("units", "String", None);
+        assert!(!optional.is_mandatory());
+        assert_eq!(
+            optional.existence(),
+            MultiplicityInterval {
+                lower: Some(0),
+                upper: Some(1),
+                lower_unbounded: false,
+                upper_unbounded: false,
+                lower_included: true,
+                upper_included: true,
+            }
+        );
+
+        let mandatory = property("magnitude", "Real", Some(true));
+        assert!(mandatory.is_mandatory());
+        assert_eq!(
+            mandatory.existence(),
+            MultiplicityInterval {
+                lower: Some(1),
+                upper: Some(1),
+                lower_unbounded: false,
+                upper_unbounded: false,
+                lower_included: true,
+                upper_included: true,
+            }
+        );
+    }
+
+    #[test]
+    fn names_and_types_read_through_every_variant() {
+        let unitary = property("magnitude", "Real", Some(true));
+        assert_eq!(unitary.name(), "magnitude");
+        assert_eq!(unitary.display_name(), "magnitude");
+        assert!(!unitary.is_computed());
+        assert_eq!(unitary.type_name(), "Real");
+        assert_eq!(unitary.conformance_type_name(), "Real");
+        assert_eq!(unitary.flattened_type_list(), ["Real".to_owned()]);
+
+        let items = container_property("items", "ELEMENT");
+        assert_eq!(items.name(), "items");
+        assert!(items.is_mandatory());
+        assert_eq!(items.type_name(), "List<ELEMENT>");
+        // The container is abstracted away: master05-core.adoc §Basics.
+        assert_eq!(items.conformance_type_name(), "ELEMENT");
+        assert_eq!(
+            items.flattened_type_list(),
+            ["List".to_owned(), "ELEMENT".to_owned()]
+        );
+    }
+}

--- a/crates/openehr-lang/src/bmm3/core/feature/mod.rs
+++ b/crates/openehr-lang/src/bmm3/core/feature/mod.rs
@@ -30,3 +30,6 @@ pub mod bmm_unitary_property;
 pub mod bmm_variable;
 pub mod bmm_visibility;
 pub mod bmm_writable_variable;
+
+// hand-written modules (spec behaviour), auto-declared:
+pub mod bmm_property_impl;

--- a/crates/openehr-lang/src/bmm3/core/model/bmm_model_impl.rs
+++ b/crates/openehr-lang/src/bmm3/core/model/bmm_model_impl.rs
@@ -1,0 +1,809 @@
+//! Hand-written spec functions of `BMM_MODEL` (plus the `schema_id` it inherits
+//! from `BMM_SCHEMA_CORE`) — the model-level lookups and the type-conformance
+//! relation.
+//!
+//! Spec: `LANG/docs/UML/classes/org.openehr.lang.bmm.bmm_model.adoc` §Functions
+//! (`primitive_types`, `enumeration_types`, `class_definition`,
+//! `enumeration_definition`, `property_definition`,
+//! `ms_conformant_property_type`, `property_definition_at_path`,
+//! `all_ancestor_classes`, `type_conforms_to`),
+//! `…bmm.bmm_schema_core.adoc` §Functions (`schema_id`) and
+//! `…bmm.bmm_package_container.adoc` §Functions (the three package-container
+//! functions, implemented once in
+//! [`crate::bmm3::core::model::bmm_package_impl`]), read against
+//! `LANG/docs/bmm/master05-core.adoc` §Semantics — §Classes and Types (the
+//! class/type distinction the lookups turn on) and §Inheritance (the acyclic
+//! ancestor graph `all_ancestor_classes` walks).
+//!
+//! The v3 counterpart `…bmm3.bmm_model.adoc` §Functions carries the same
+//! function set with the conformance rules written out explicitly, and is cited
+//! at each site where it settles v2 wording.
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::collections::VecDeque;
+
+use crate::bmm3::core::entity::bmm_class::BmmClass;
+use crate::bmm3::core::entity::bmm_type::BmmType;
+use crate::bmm3::core::entity::bmm_type_impl::ANY_TYPE_NAME;
+use crate::bmm3::core::entity::range_constrained::bmm_enumeration::BmmEnumeration;
+use crate::bmm3::core::feature::bmm_property::BmmProperty;
+use crate::bmm3::core::model::bmm_model::BmmModel;
+use crate::bmm3::core::model::bmm_package::BmmPackage;
+use crate::bmm3::core::model::bmm_package_impl::do_recursive_packages_in;
+use crate::bmm3::core::model::bmm_package_impl::package_at_path_in;
+
+/// The delimiter separating the segments of the property path
+/// `BMM_MODEL.property_definition_at_path` navigates.
+///
+/// NOTE: no openEHR spec governs this — our own design/extension. The class doc
+/// (`org.openehr.lang.bmm.bmm_model.adoc` §Functions) names the argument
+/// `a_property_path` without defining its lexis, and `BMM_DEFINITIONS`
+/// (`…bmm.bmm_definitions.adoc` §Constants) defines delimiters only for schema
+/// ids (`"::"`) and package paths (`"."`). `'/'` is the separator openEHR paths
+/// use everywhere else, so it is what this surface accepts.
+const PROPERTY_PATH_DELIMITER: char = '/';
+
+/// The root name of a type reference, i.e. the type name with any generic part
+/// removed: `class_definition` is specified for a name "which may contain a
+/// generic part" (`org.openehr.lang.bmm.bmm_model.adoc` §Functions).
+fn type_root(a_type_name: &str) -> &str {
+    a_type_name.split('<').next().unwrap_or(a_type_name).trim()
+}
+
+/// Splits a type name into its root and its top-level generic parameters:
+/// `Hash<String,Interval<Time>>` → `("Hash", ["String", "Interval<Time>"])`.
+///
+/// Delimiters per `org.openehr.lang.bmm3.bmm_definitions.adoc` §Constants
+/// (`Generic_left_delimiter` `'<'`, `Generic_separator` `','`,
+/// `Generic_right_delimiter` `'>'`).
+fn split_type(a_type_name: &str) -> (&str, Vec<&str>) {
+    let trimmed = a_type_name.trim();
+    let (Some(open), Some(close)) = (trimmed.find('<'), trimmed.rfind('>')) else {
+        return (trimmed, Vec::new());
+    };
+    let (Some(root), Some(inner)) = (trimmed.get(..open), trimmed.get(open + 1..close)) else {
+        return (trimmed, Vec::new());
+    };
+    (root.trim(), split_generic_parameters(inner))
+}
+
+/// Splits a generic parameter list on its TOP-LEVEL separators, so a nested
+/// generic parameter stays one item.
+fn split_generic_parameters(inner: &str) -> Vec<&str> {
+    let mut out = Vec::new();
+    let mut depth: usize = 0;
+    let mut start: usize = 0;
+    for (index, character) in inner.char_indices() {
+        match character {
+            '<' => depth += 1,
+            '>' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => {
+                if let Some(part) = inner.get(start..index) {
+                    out.push(part.trim());
+                }
+                start = index + 1;
+            }
+            _ => {}
+        }
+    }
+    if let Some(part) = inner.get(start..) {
+        let part = part.trim();
+        if !part.is_empty() {
+            out.push(part);
+        }
+    }
+    out
+}
+
+/// Whether `a_type_name` is an OPEN generic parameter name rather than a class
+/// name: `BMM_GENERIC_PARAMETER` invariant `Inv_generic_name`
+/// (`org.openehr.lang.bmm.bmm_generic_parameter.adoc` §Invariants) pins the
+/// lexis exactly — `name.count = 1 and name.is_upper`.
+fn is_open_parameter_name(a_type_name: &str) -> bool {
+    let mut characters = a_type_name.chars();
+    match (characters.next(), characters.next()) {
+        (Some(single), None) => single.is_uppercase(),
+        _ => false,
+    }
+}
+
+impl BmmModel {
+    /// `BMM_SCHEMA_CORE.schema_id`: "Derived name of schema, based on model
+    /// publisher, model name, model release"
+    /// (`org.openehr.lang.bmm.bmm_schema_core.adoc` §Functions).
+    ///
+    /// Rendered `<rm_publisher>_<schema_name>_<rm_release>`, lower-cased.
+    ///
+    /// NOTE (adjudicated): the v2 function states the three inputs but not the
+    /// join. Its v3 counterparts give it twice —
+    /// `org.openehr.lang.bmm3.bmm_model.adoc` §Functions `model_id`
+    /// ("Identifier of this model, lower-case, formed from:
+    /// `<rm_publisher>_<model_name>_<rm_release>`. E.g. `"openehr_ehr_1.0.4"`")
+    /// and `…bmm3.bmm_definitions.adoc` §Functions `create_schema_id`, whose
+    /// examples are `openehr_rm_1.0.3`, `openehr_test_1.0.1`,
+    /// `iso_13606_1_2008_2.1.2`. `create_schema_id`'s prose says the separator
+    /// is `'-'` while every one of its own examples uses `'_'`, and `model_id`'s
+    /// explicit template plus all five examples agree on `'_'`; the underscore
+    /// join therefore wins, and the `'-'` prose is read as an editorial slip.
+    #[must_use]
+    pub fn schema_id(&self) -> String {
+        let publisher = &self.rm_publisher;
+        let name = &self.schema_name;
+        let release = &self.rm_release;
+        format!("{publisher}_{name}_{release}").to_lowercase()
+    }
+
+    /// `BMM_MODEL.class_definition`: "Retrieve the class definition
+    /// corresponding to `a_type_name` (which may contain a generic part)"
+    /// (class doc §Functions) — the generic part is stripped before the lookup,
+    /// because `class_definitions` is keyed by class name and "names of classes
+    /// are just the root name, even if the class is generic"
+    /// (`org.openehr.lang.bmm.bmm_class.adoc` §Attributes).
+    #[must_use]
+    pub fn class_definition(&self, a_type_name: &str) -> Option<&BmmClass> {
+        self.class_definitions.as_ref()?.get(type_root(a_type_name))
+    }
+
+    /// `BMM_MODEL.enumeration_definition`: "Retrieve the enumeration definition
+    /// corresponding to `a_type_name`" (class doc §Functions) — i.e. the class
+    /// definition when, and only when, it is a `BMM_ENUMERATION`.
+    #[must_use]
+    pub fn enumeration_definition(&self, a_type_name: &str) -> Option<&BmmEnumeration> {
+        match self.class_definition(a_type_name) {
+            Some(BmmClass::BmmEnumeration(enumeration)) => Some(enumeration),
+            _ => None,
+        }
+    }
+
+    /// `BMM_MODEL.primitive_types`: "List of keys in `class_definitions` of
+    /// items marked as primitive types, as defined in input schema" (class doc
+    /// §Functions).
+    #[must_use]
+    pub fn primitive_types(&self) -> Vec<&str> {
+        self.class_definitions
+            .iter()
+            .flatten()
+            .filter(|(_, class)| class.is_primitive_type())
+            .map(|(key, _)| key.as_str())
+            .collect()
+    }
+
+    /// `BMM_MODEL.enumeration_types`: "List of keys in `class_definitions` of
+    /// items that are enumeration types, as defined in input schema" (class doc
+    /// §Functions).
+    #[must_use]
+    pub fn enumeration_types(&self) -> Vec<&str> {
+        self.class_definitions
+            .iter()
+            .flatten()
+            .filter(|(_, class)| matches!(class, BmmClass::BmmEnumeration(_)))
+            .map(|(key, _)| key.as_str())
+            .collect()
+    }
+
+    /// `BMM_MODEL.all_ancestor_classes`: "Return all ancestor types of
+    /// `a_class_name` up to root class (usually 'ANY', 'Object' or something
+    /// similar). Does not include current class. Returns empty list if none."
+    /// (class doc §Functions).
+    ///
+    /// The walk unions two sources so it is total on both persisted shapes: the
+    /// embedded ancestor copies a class carries
+    /// ([`BmmClass::all_ancestors`]) and, for every name reached, that name's
+    /// own definition in this model — a class whose embedded copies are shallow
+    /// still resolves all the way up. Cycle-safe; deduped.
+    #[must_use]
+    pub fn all_ancestor_classes(&self, a_class: &str) -> Vec<String> {
+        let mut out: Vec<String> = Vec::new();
+        let mut seen: BTreeSet<String> = BTreeSet::new();
+        let mut queue: VecDeque<String> = VecDeque::new();
+        if let Some(class) = self.class_definition(a_class) {
+            queue.extend(class.all_ancestors());
+        }
+        while let Some(name) = queue.pop_front() {
+            if !seen.insert(name.clone()) {
+                continue;
+            }
+            out.push(name.clone());
+            if let Some(class) = self.class_definition(&name) {
+                for parent in class.all_ancestors() {
+                    if !seen.contains(&parent) {
+                        queue.push_back(parent);
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    /// `BMM_MODEL.property_definition`: "Retrieve the property definition for
+    /// `a_prop_name` in flattened class corresponding to `a_type_name`" (class
+    /// doc §Functions) — the FLAT property set, so an inherited property
+    /// resolves too ("the _effective_ set of properties for a class is the
+    /// result of evaluating these lists of properties down the inheritance
+    /// hierarchy", `master05-core.adoc` §Semantics §Classes and Properties).
+    #[must_use]
+    pub fn property_definition(
+        &self,
+        a_type_name: &str,
+        a_prop_name: &str,
+    ) -> Option<&BmmProperty<BmmType>> {
+        self.flat_properties(a_type_name)?.get(a_prop_name).copied()
+    }
+
+    /// The flat property set of the class named `a_type_name`, flattened DOWN
+    /// THE MODEL: at every inheritance step the ancestor's own definition in
+    /// `class_definitions` is preferred over the copy embedded in the
+    /// descendant's `ancestors` map.
+    ///
+    /// NOTE: [`BmmClass::flat_properties`] is the pure class-level function the
+    /// class doc declares, and it can only see what the class embeds. A schema
+    /// whose embedded ancestor copies are shallow (`BMM_CLASS.ancestors` is a
+    /// keyed map that a loader may populate with reference-shaped stubs, and
+    /// `P_BMM_CLASS.ancestors` is a list of NAMES) would then hide inherited
+    /// properties. Since `BMM_MODEL.class_definitions` is "All classes in this
+    /// schema" (`org.openehr.lang.bmm.bmm_model.adoc` §Attributes), it is the
+    /// richer source, so the model-level flattening consults it — a strict
+    /// superset of the class-level result, with the same override precedence
+    /// (nearer class wins) and cycle-safe.
+    fn flat_properties(&self, a_type_name: &str) -> Option<BTreeMap<&str, &BmmProperty<BmmType>>> {
+        let class = self.class_definition(a_type_name)?;
+        let mut out = BTreeMap::new();
+        let mut seen = BTreeSet::new();
+        self.merge_flat_properties(class, &mut out, &mut seen);
+        Some(out)
+    }
+
+    /// Merges `class`'s model-resolved ancestor properties, then its own, into
+    /// `out`.
+    fn merge_flat_properties<'a>(
+        &'a self,
+        class: &'a BmmClass,
+        out: &mut BTreeMap<&'a str, &'a BmmProperty<BmmType>>,
+        seen: &mut BTreeSet<String>,
+    ) {
+        if !seen.insert(class.name().to_owned()) {
+            return;
+        }
+        for embedded in class.ancestors().into_iter().flatten().map(|(_, a)| a) {
+            let parent = match self.class_definition(embedded.name()) {
+                Some(defined) => defined,
+                None => embedded,
+            };
+            self.merge_flat_properties(parent, out, seen);
+        }
+        for property in class.properties().into_iter().flatten().map(|(_, p)| p) {
+            out.insert(property.name(), property);
+        }
+    }
+
+    /// `BMM_MODEL.property_definition_at_path`: "Retrieve the property
+    /// definition for `a_property_path` in flattened class corresponding to
+    /// `a_type_name`" (class doc §Functions).
+    ///
+    /// Each segment is resolved on the flat property set of the previous
+    /// segment's type, reduced with `conformance_type_name` so a container step
+    /// navigates into the CONTAINED type ("the _contained_ type for a container
+    /// type (e.g. `ELEMENT` from the type `List<ELEMENT>`)",
+    /// `master05-core.adoc` §Semantics §Basics). See
+    /// the module-level `PROPERTY_PATH_DELIMITER` note for the delimiter
+    /// adjudication. An empty
+    /// path, or a segment that does not resolve, yields `None`.
+    #[must_use]
+    pub fn property_definition_at_path(
+        &self,
+        a_type_name: &str,
+        a_property_path: &str,
+    ) -> Option<&BmmProperty<BmmType>> {
+        let mut current_type = a_type_name.to_owned();
+        let mut found: Option<&BmmProperty<BmmType>> = None;
+        for segment in a_property_path
+            .split(PROPERTY_PATH_DELIMITER)
+            .map(str::trim)
+            .filter(|segment| !segment.is_empty())
+        {
+            let property = self.property_definition(&current_type, segment)?;
+            current_type = property.conformance_type_name();
+            found = Some(property);
+        }
+        found
+    }
+
+    /// `BMM_MODEL.type_conforms_to`: "Check conformance of `a_desc_type` to
+    /// `an_anc_type`; the types may be generic, and may contain open generic
+    /// parameters like 'T' etc. These are replaced with their appropriate
+    /// constrainer types, or Any during the conformance testing process."
+    /// (class doc §Functions).
+    ///
+    /// The three rules are stated verbatim in the v3 counterpart
+    /// (`org.openehr.lang.bmm3.bmm_model.adoc` §Functions) and implemented
+    /// exactly as written:
+    ///
+    /// * "[base class test] types are non-generic, and either type names are
+    ///   identical, or else `_a_desc_type_` has `_an_anc_type_` in its
+    ///   ancestors";
+    /// * "both types are generic and pass base class test; number of generic
+    ///   params matches, and each generic parameter type, after 'open parameter'
+    ///   substitution, recursively passes";
+    /// * "descendant type is generic and ancestor type is not, and they pass
+    ///   base classes test".
+    ///
+    /// A non-generic descendant against a generic ancestor is therefore NOT
+    /// conformant — the rule set admits generic parameters only on the
+    /// descendant side.
+    ///
+    /// NOTE (adjudicated): "replaced with their appropriate constrainer types,
+    /// or Any" needs the owning generic class to find a constrainer, and these
+    /// arguments are bare type NAMES with no owner in scope, so an open
+    /// parameter name (`Inv_generic_name`: one upper-case character) is
+    /// substituted by `Any`, the case the class doc names as the fallback.
+    /// Every type conforms to `Any`, the top class
+    /// (`org.openehr.lang.bmm3.bmm_definitions.adoc` §Functions `Any_class`:
+    /// "built-in class definition corresponding to the top `Any` class").
+    #[must_use]
+    pub fn type_conforms_to(&self, a_desc_type: &str, an_anc_type: &str) -> bool {
+        let (descendant_root, descendant_parameters) = split_type(a_desc_type);
+        let (ancestor_root, ancestor_parameters) = split_type(an_anc_type);
+        if !self.base_class_conforms_to(descendant_root, ancestor_root) {
+            return false;
+        }
+        if ancestor_parameters.is_empty() {
+            // Rules 1 and 3: both non-generic, or the descendant alone is
+            // generic — the base class test is the whole test.
+            return true;
+        }
+        if descendant_parameters.len() != ancestor_parameters.len() {
+            return false;
+        }
+        descendant_parameters
+            .iter()
+            .zip(ancestor_parameters.iter())
+            .all(|(descendant, ancestor)| self.type_conforms_to(descendant, ancestor))
+    }
+
+    /// The "base class test" of `BMM_MODEL.type_conforms_to`: identical names,
+    /// or the ancestor among the descendant's ancestors, with open parameter
+    /// names substituted by `Any` first.
+    fn base_class_conforms_to(&self, descendant_root: &str, ancestor_root: &str) -> bool {
+        let descendant = substitute_open_parameter(descendant_root);
+        let ancestor = substitute_open_parameter(ancestor_root);
+        if ancestor == ANY_TYPE_NAME || descendant == ancestor {
+            return true;
+        }
+        self.all_ancestor_classes(descendant)
+            .iter()
+            .any(|name| name == ancestor)
+    }
+
+    /// `BMM_MODEL.ms_conformant_property_type`: "True if `a_ms_property_type` is
+    /// a valid 'MS' dynamic type for `a_property` in BMM type `a_bmm_type_name`.
+    /// 'MS' conformance means 'model-semantic' conformance, which abstracts away
+    /// container types like List<>, Set<> etc and compares the dynamic type with
+    /// the relation target type in the UML sense, i.e. regardless of whether
+    /// there is single or multiple containment." (class doc §Functions).
+    ///
+    /// The container abstraction is exactly `conformance_type_name` on the
+    /// property's declared type (`master05-core.adoc` §Semantics §Basics: "the
+    /// _contained_ type for a container type"); the supplied dynamic type is
+    /// then tested against that target with
+    /// [`Self::type_conforms_to`]. An unknown type or property is not
+    /// conformant.
+    #[must_use]
+    pub fn ms_conformant_property_type(
+        &self,
+        a_bmm_type_name: &str,
+        a_bmm_property_name: &str,
+        a_ms_property_type: &str,
+    ) -> bool {
+        let Some(property) = self.property_definition(a_bmm_type_name, a_bmm_property_name) else {
+            return false;
+        };
+        self.type_conforms_to(a_ms_property_type, &property.conformance_type_name())
+    }
+
+    /// `BMM_PACKAGE_CONTAINER.package_at_path`: "Package at the path `a_path`"
+    /// (`org.openehr.lang.bmm.bmm_package_container.adoc` §Functions).
+    ///
+    /// Keys are matched case-insensitively and the longest matching key prefix
+    /// wins at each level, per
+    /// [`crate::bmm3::core::model::bmm_package_impl`].
+    #[must_use]
+    pub fn package_at_path(&self, a_path: &str) -> Option<&BmmPackage> {
+        package_at_path_in(self.packages.as_ref(), a_path)
+    }
+
+    /// `BMM_PACKAGE_CONTAINER.has_package_path`: "True if there is a package at
+    /// the path `a_path`; paths are delimited with Package_name_delimiter"
+    /// (`org.openehr.lang.bmm.bmm_package_container.adoc` §Functions).
+    #[must_use]
+    pub fn has_package_path(&self, a_path: &str) -> bool {
+        self.package_at_path(a_path).is_some()
+    }
+
+    /// `BMM_PACKAGE_CONTAINER.do_recursive_packages`: "Recursively execute
+    /// `action`, which is a procedure taking a BMM_PACKAGE argument, on all
+    /// members of packages"
+    /// (`org.openehr.lang.bmm.bmm_package_container.adoc` §Functions).
+    pub fn do_recursive_packages(&self, action: &mut dyn FnMut(&BmmPackage)) {
+        do_recursive_packages_in(self.packages.as_ref(), action);
+    }
+}
+
+/// Replaces an open generic parameter name with `Any`, per the
+/// `type_conforms_to` NOTE on [`BmmModel::type_conforms_to`].
+fn substitute_open_parameter(a_type_name: &str) -> &str {
+    if is_open_parameter_name(a_type_name) {
+        ANY_TYPE_NAME
+    } else {
+        a_type_name
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use crate::bmm3::core::entity::bmm_class::BmmClass;
+    use crate::bmm3::core::entity::bmm_container_type::BmmContainerType;
+    use crate::bmm3::core::entity::bmm_container_type::BmmContainerTypeData;
+    use crate::bmm3::core::entity::bmm_simple_class::BmmSimpleClass;
+    use crate::bmm3::core::entity::bmm_simple_type::BmmSimpleType;
+    use crate::bmm3::core::entity::bmm_type::BmmType;
+    use crate::bmm3::core::entity::range_constrained::bmm_enumeration::BmmEnumeration;
+    use crate::bmm3::core::entity::range_constrained::bmm_enumeration::BmmEnumerationData;
+    use crate::bmm3::core::feature::bmm_property::BmmProperty;
+    use crate::bmm3::core::feature::bmm_property::BmmPropertyData;
+    use crate::bmm3::core::model::bmm_model::BmmModel;
+    use crate::bmm3::core::model::bmm_package::BmmPackage;
+
+    /// An empty package node named `name`.
+    fn package(name: &str) -> BmmPackage {
+        BmmPackage {
+            documentation: None,
+            packages: None,
+            name: name.to_owned(),
+            classes: Vec::new(),
+        }
+    }
+
+    /// A unitary property of the given name over the simple type `type_name`.
+    fn property(name: &str, type_name: &str) -> BmmProperty<BmmType> {
+        BmmProperty::BmmProperty(BmmPropertyData {
+            documentation: None,
+            name: name.to_owned(),
+            is_mandatory: Some(true),
+            is_computed: None,
+            r#type: BmmType::BmmSimpleType(BmmSimpleType {
+                documentation: None,
+                base_class: class(type_name, &[], &[], false),
+            }),
+            is_im_runtime: None,
+            is_im_infrastructure: None,
+        })
+    }
+
+    /// A `List<item>` container property.
+    fn container_property(name: &str, item: &str) -> BmmProperty<BmmType> {
+        BmmProperty::BmmProperty(BmmPropertyData {
+            documentation: None,
+            name: name.to_owned(),
+            is_mandatory: Some(true),
+            is_computed: None,
+            r#type: BmmType::BmmContainerType(Box::new(BmmContainerType::BmmContainerType(
+                BmmContainerTypeData {
+                    documentation: None,
+                    container_type: class("List", &[], &[], false),
+                    base_type: Box::new(BmmType::BmmSimpleType(BmmSimpleType {
+                        documentation: None,
+                        base_class: class(item, &[], &[], false),
+                    })),
+                },
+            ))),
+            is_im_runtime: None,
+            is_im_infrastructure: None,
+        })
+    }
+
+    /// A simple class with ancestors (by name only, embedded as shallow copies),
+    /// properties and a primitive flag.
+    fn class(
+        name: &str,
+        ancestors: &[&str],
+        properties: &[BmmProperty<BmmType>],
+        is_primitive_type: bool,
+    ) -> BmmClass {
+        BmmClass::BmmSimpleClass(BmmSimpleClass {
+            documentation: None,
+            name: name.to_owned(),
+            ancestors: if ancestors.is_empty() {
+                None
+            } else {
+                Some(
+                    ancestors
+                        .iter()
+                        .map(|parent| ((*parent).to_owned(), class(parent, &[], &[], false)))
+                        .collect(),
+                )
+            },
+            package: package("org.openehr.rm.test"),
+            properties: if properties.is_empty() {
+                None
+            } else {
+                Some(
+                    properties
+                        .iter()
+                        .map(|p| (p.name().to_owned(), p.clone()))
+                        .collect(),
+                )
+            },
+            source_schema_id: "openehr_test_1.0.0".to_owned(),
+            immediate_descendants: Vec::new(),
+            is_abstract: false,
+            is_primitive_type,
+            is_override: false,
+        })
+    }
+
+    /// A model over the given class definitions and top-level packages.
+    fn model(classes: Vec<BmmClass>, packages: Vec<BmmPackage>) -> BmmModel {
+        BmmModel {
+            rm_publisher: "openEHR".to_owned(),
+            rm_release: "1.2.0".to_owned(),
+            schema_name: "RM".to_owned(),
+            schema_revision: "1.2.0".to_owned(),
+            schema_lifecycle_state: "stable".to_owned(),
+            schema_author: "openEHR SEC".to_owned(),
+            schema_description: "test schema".to_owned(),
+            schema_contributors: Vec::new(),
+            archetype_parent_class: None,
+            archetype_data_value_parent_class: None,
+            archetype_rm_closure_packages: Vec::new(),
+            archetype_visualise_descendants_of: None,
+            documentation: None,
+            packages: if packages.is_empty() {
+                None
+            } else {
+                Some(
+                    packages
+                        .into_iter()
+                        .map(|p| (p.name.to_uppercase(), p))
+                        .collect(),
+                )
+            },
+            class_definitions: if classes.is_empty() {
+                None
+            } else {
+                Some(
+                    classes
+                        .into_iter()
+                        .map(|c| (c.name().to_owned(), c))
+                        .collect(),
+                )
+            },
+        }
+    }
+
+    #[test]
+    fn schema_id_is_the_lower_cased_publisher_name_release() {
+        let model = model(Vec::new(), Vec::new());
+        assert_eq!(model.schema_id(), "openehr_rm_1.2.0");
+    }
+
+    #[test]
+    fn class_definition_strips_the_generic_part() {
+        let model = model(vec![class("Interval", &[], &[], false)], Vec::new());
+        assert_eq!(
+            model.class_definition("Interval<Time>").map(BmmClass::name),
+            Some("Interval")
+        );
+        assert_eq!(
+            model.class_definition("Interval").map(BmmClass::name),
+            Some("Interval")
+        );
+        assert_eq!(model.class_definition("MISSING"), None);
+    }
+
+    #[test]
+    fn primitive_and_enumeration_type_keys() {
+        let enumeration =
+            BmmClass::BmmEnumeration(BmmEnumeration::BmmEnumeration(BmmEnumerationData {
+                documentation: None,
+                name: "MATCH_KIND".to_owned(),
+                ancestors: None,
+                package: package("org.openehr.base"),
+                properties: None,
+                source_schema_id: "openehr_test_1.0.0".to_owned(),
+                immediate_descendants: Vec::new(),
+                is_abstract: false,
+                is_primitive_type: false,
+                is_override: false,
+                item_names: vec!["equal".to_owned()],
+                item_values: Vec::new(),
+                underlying_type_name: "Integer".to_owned(),
+            }));
+        let model = model(
+            vec![
+                class("String", &[], &[], true),
+                class("ELEMENT", &[], &[], false),
+                enumeration,
+            ],
+            Vec::new(),
+        );
+        assert_eq!(model.primitive_types(), ["String"]);
+        assert_eq!(model.enumeration_types(), ["MATCH_KIND"]);
+        assert!(model.enumeration_definition("MATCH_KIND").is_some());
+        assert!(model.enumeration_definition("ELEMENT").is_none());
+    }
+
+    #[test]
+    fn all_ancestor_classes_resolves_through_the_model() {
+        // DV_QUANTITY -> DV_AMOUNT -> DV_ORDERED -> DATA_VALUE, each class
+        // embedding only its IMMEDIATE parent (shallow copies).
+        let model = model(
+            vec![
+                class("DATA_VALUE", &[], &[], false),
+                class("DV_ORDERED", &["DATA_VALUE"], &[], false),
+                class("DV_AMOUNT", &["DV_ORDERED"], &[], false),
+                class("DV_QUANTITY", &["DV_AMOUNT"], &[], false),
+            ],
+            Vec::new(),
+        );
+        let mut ancestors = model.all_ancestor_classes("DV_QUANTITY");
+        ancestors.sort();
+        assert_eq!(
+            ancestors,
+            [
+                "DATA_VALUE".to_owned(),
+                "DV_AMOUNT".to_owned(),
+                "DV_ORDERED".to_owned()
+            ]
+        );
+        assert!(model.all_ancestor_classes("DATA_VALUE").is_empty());
+        assert!(model.all_ancestor_classes("MISSING").is_empty());
+    }
+
+    #[test]
+    fn property_definition_reads_the_flat_set() {
+        let model = model(
+            vec![
+                class(
+                    "DV_ORDERED",
+                    &[],
+                    &[property("normal_status", "CODE_PHRASE")],
+                    false,
+                ),
+                class(
+                    "DV_QUANTITY",
+                    &["DV_ORDERED"],
+                    &[property("magnitude", "Real")],
+                    false,
+                ),
+            ],
+            Vec::new(),
+        );
+        assert!(
+            model
+                .property_definition("DV_QUANTITY", "magnitude")
+                .is_some()
+        );
+        // Inherited through the embedded ancestor copy.
+        assert!(
+            model
+                .property_definition("DV_QUANTITY", "normal_status")
+                .is_some()
+        );
+        assert!(
+            model
+                .property_definition("DV_QUANTITY", "missing")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn property_definition_at_path_walks_one_nesting_step() {
+        let model = model(
+            vec![
+                class("ELEMENT", &[], &[property("value", "DV_TEXT")], false),
+                class(
+                    "ITEM_TREE",
+                    &[],
+                    &[container_property("items", "ELEMENT")],
+                    false,
+                ),
+            ],
+            Vec::new(),
+        );
+        let value = model
+            .property_definition_at_path("ITEM_TREE", "items/value")
+            .expect("the nested property resolves through the contained type");
+        assert_eq!(value.name(), "value");
+        assert_eq!(value.conformance_type_name(), "DV_TEXT");
+        assert!(
+            model
+                .property_definition_at_path("ITEM_TREE", "items/missing")
+                .is_none()
+        );
+        assert!(model.property_definition_at_path("ITEM_TREE", "").is_none());
+    }
+
+    #[test]
+    fn type_conforms_to_covers_the_three_rules() {
+        let model = model(
+            vec![
+                class("DATA_VALUE", &[], &[], false),
+                class("DV_ORDERED", &["DATA_VALUE"], &[], false),
+                class("Ordered", &[], &[], false),
+                class("Time", &["Ordered"], &[], false),
+                class("Interval", &[], &[], false),
+                class("List", &[], &[], false),
+            ],
+            Vec::new(),
+        );
+
+        // Rule 1, identical names and ancestor lookup.
+        assert!(model.type_conforms_to("DV_ORDERED", "DV_ORDERED"));
+        assert!(model.type_conforms_to("DV_ORDERED", "DATA_VALUE"));
+        assert!(!model.type_conforms_to("DATA_VALUE", "DV_ORDERED"));
+
+        // Rule 2, both generic: parameters recurse pairwise.
+        assert!(model.type_conforms_to("Interval<Time>", "Interval<Ordered>"));
+        assert!(!model.type_conforms_to("Interval<Ordered>", "Interval<Time>"));
+        assert!(!model.type_conforms_to("Interval<Time,Time>", "Interval<Ordered>"));
+
+        // Rule 3, descendant generic and ancestor not.
+        assert!(model.type_conforms_to("Interval<Time>", "Interval"));
+        // ... and not the other way round: the rule set admits parameters only
+        // on the descendant side.
+        assert!(!model.type_conforms_to("Interval", "Interval<Time>"));
+
+        // Open parameters substitute to Any, which everything conforms to.
+        assert!(model.type_conforms_to("Interval<Time>", "Interval<T>"));
+        assert!(!model.type_conforms_to("Interval<T>", "Interval<Time>"));
+        assert!(model.type_conforms_to("DV_ORDERED", "Any"));
+        assert!(!model.type_conforms_to("Any", "DV_ORDERED"));
+    }
+
+    #[test]
+    fn ms_conformance_abstracts_the_container_away() {
+        let model = model(
+            vec![
+                class("ELEMENT", &[], &[], false),
+                class("CLUSTER", &["ITEM"], &[], false),
+                class("ITEM", &[], &[], false),
+                class("List", &[], &[], false),
+                class(
+                    "ITEM_TREE",
+                    &[],
+                    &[container_property("items", "ITEM")],
+                    false,
+                ),
+            ],
+            Vec::new(),
+        );
+        // The property is declared List<ITEM>; MS conformance compares the
+        // dynamic type against ITEM regardless of the containment.
+        assert!(model.ms_conformant_property_type("ITEM_TREE", "items", "ITEM"));
+        assert!(model.ms_conformant_property_type("ITEM_TREE", "items", "CLUSTER"));
+        assert!(!model.ms_conformant_property_type("ITEM_TREE", "items", "ELEMENT"));
+        assert!(!model.ms_conformant_property_type("ITEM_TREE", "missing", "ITEM"));
+    }
+
+    #[test]
+    fn package_paths_match_case_insensitively_from_the_model_root() {
+        let mut composition = package("composition");
+        composition.packages = Some(
+            [("CONTENT".to_owned(), package("content"))]
+                .into_iter()
+                .collect::<BTreeMap<String, BmmPackage>>(),
+        );
+        let model = model(Vec::new(), vec![composition]);
+        assert!(model.has_package_path("composition"));
+        assert!(model.has_package_path("COMPOSITION"));
+        assert!(model.has_package_path("Composition.Content"));
+        assert!(!model.has_package_path("ehr"));
+
+        let mut visited: Vec<String> = Vec::new();
+        model.do_recursive_packages(&mut |package| visited.push(package.name.clone()));
+        assert_eq!(visited, ["composition".to_owned(), "content".to_owned()]);
+    }
+}

--- a/crates/openehr-lang/src/bmm3/core/model/bmm_package_impl.rs
+++ b/crates/openehr-lang/src/bmm3/core/model/bmm_package_impl.rs
@@ -1,0 +1,297 @@
+//! Hand-written spec functions of `BMM_PACKAGE` and of the
+//! `BMM_PACKAGE_CONTAINER` surface it shares with `BMM_MODEL`.
+//!
+//! Spec: `LANG/docs/UML/classes/org.openehr.lang.bmm.bmm_package.adoc`
+//! §Functions (`root_classes`, `path`) and
+//! `…bmm.bmm_package_container.adoc` §Attributes + §Functions
+//! (`packages`: "Child packages; keys all in upper case for guaranteed
+//! matching"; `package_at_path`, `do_recursive_packages`, `has_package_path`:
+//! "paths are delimited with Package_name_delimiter"), with the delimiter
+//! itself from `…bmm.bmm_definitions.adoc` §Constants
+//! (`Package_name_delimiter` `"."`).
+//!
+//! The three container functions are implemented once here, as `pub(crate)`
+//! free functions over a `packages` map, and called from both
+//! [`BmmPackage`] and
+//! [`BmmModel`](crate::bmm3::core::model::bmm_model::BmmModel) — the two
+//! `BMM_PACKAGE_CONTAINER` descendants
+//! (`…bmm.bmm_model.adoc` §Inherit lists `BMM_PACKAGE_CONTAINER`).
+
+use std::collections::BTreeMap;
+
+use crate::bmm3::bmm_definitions::BmmDefinitionsData;
+use crate::bmm3::core::entity::bmm_class::BmmClass;
+use crate::bmm3::core::model::bmm_package::BmmPackage;
+
+/// Splits a package path into its non-empty segments, delimited by
+/// `BMM_DEFINITIONS.Package_name_delimiter`
+/// (`org.openehr.lang.bmm.bmm_definitions.adoc` §Constants).
+fn path_segments(path: &str) -> Vec<&str> {
+    path.split(BmmDefinitionsData::PACKAGE_NAME_DELIMITER)
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty())
+        .collect()
+}
+
+/// `BMM_PACKAGE_CONTAINER.package_at_path` over a `packages` map: "Package at
+/// the path `a_path`" (`org.openehr.lang.bmm.bmm_package_container.adoc`
+/// §Functions).
+///
+/// Keys are matched case-insensitively, because the container's `packages` map
+/// is specified as having its "keys all in upper case for guaranteed matching"
+/// (class doc §Attributes) while a package's own `name` keeps its source case.
+/// At each level the LONGEST matching key prefix is tried first, since a
+/// top-level package name "may be qualified"
+/// (`org.openehr.lang.bmm.bmm_package.adoc` §Attributes), i.e. one key can span
+/// several path segments (`org.openehr.rm`).
+pub(crate) fn package_at_path_in<'a>(
+    packages: Option<&'a BTreeMap<String, BmmPackage>>,
+    path: &str,
+) -> Option<&'a BmmPackage> {
+    resolve_segments(packages, &path_segments(path))
+}
+
+/// Resolves `segments` against a `packages` map, longest key prefix first.
+fn resolve_segments<'a>(
+    packages: Option<&'a BTreeMap<String, BmmPackage>>,
+    segments: &[&str],
+) -> Option<&'a BmmPackage> {
+    let packages = packages?;
+    if segments.is_empty() {
+        return None;
+    }
+    for taken in (1..=segments.len()).rev() {
+        let Some(prefix) = segments.get(..taken) else {
+            continue;
+        };
+        let key = prefix.join(BmmDefinitionsData::PACKAGE_NAME_DELIMITER);
+        let hit = packages
+            .iter()
+            .find(|(candidate, _)| candidate.eq_ignore_ascii_case(&key));
+        let Some((_, package)) = hit else {
+            continue;
+        };
+        match segments.get(taken..) {
+            None | Some([]) => return Some(package),
+            Some(rest) => {
+                if let Some(found) = resolve_segments(package.packages.as_ref(), rest) {
+                    return Some(found);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// `BMM_PACKAGE_CONTAINER.do_recursive_packages` over a `packages` map:
+/// "Recursively execute `action`, which is a procedure taking a BMM_PACKAGE
+/// argument, on all members of packages"
+/// (`org.openehr.lang.bmm.bmm_package_container.adoc` §Functions). Each package
+/// is visited before its children, in key order.
+pub(crate) fn do_recursive_packages_in(
+    packages: Option<&BTreeMap<String, BmmPackage>>,
+    action: &mut dyn FnMut(&BmmPackage),
+) {
+    for package in packages.into_iter().flat_map(BTreeMap::values) {
+        action(package);
+        do_recursive_packages_in(package.packages.as_ref(), action);
+    }
+}
+
+impl BmmPackage {
+    /// `BMM_PACKAGE.path`: "Full path of this package back to root package"
+    /// (class doc §Functions).
+    ///
+    /// NOTE: the generated `BMM_PACKAGE` is a standalone tree node — it carries
+    /// its child `packages` but no back-reference to its parent (class doc
+    /// §Attributes lists `name` and `classes` only), so the path can only be
+    /// this package's own `name`, which the class doc states "may be qualified
+    /// if it is a top-level package" and is therefore already the full path for
+    /// every package a schema declares at top level. A nested package reached
+    /// through [`Self::package_at_path`] returns its unqualified segment; the
+    /// caller holds the prefix it navigated with.
+    #[must_use]
+    pub fn path(&self) -> &str {
+        self.name.as_str()
+    }
+
+    /// `BMM_PACKAGE.root_classes`: "Obtain the set of top-level classes in this
+    /// package, either from this package itself or by recursing into the
+    /// structure until classes are obtained from child packages. Recurse into
+    /// each child only far enough to find the first level of classes" (class doc
+    /// §Functions).
+    #[must_use]
+    pub fn root_classes(&self) -> Vec<&BmmClass> {
+        if !self.classes.is_empty() {
+            return self.classes.iter().collect();
+        }
+        let mut out = Vec::new();
+        for child in self.packages.iter().flat_map(BTreeMap::values) {
+            out.extend(child.root_classes());
+        }
+        out
+    }
+
+    /// `BMM_PACKAGE_CONTAINER.package_at_path`: "Package at the path `a_path`"
+    /// (`org.openehr.lang.bmm.bmm_package_container.adoc` §Functions).
+    ///
+    /// Keys are matched case-insensitively and the longest matching key prefix
+    /// wins at each level (module docs).
+    #[must_use]
+    pub fn package_at_path(&self, a_path: &str) -> Option<&Self> {
+        package_at_path_in(self.packages.as_ref(), a_path)
+    }
+
+    /// `BMM_PACKAGE_CONTAINER.has_package_path`: "True if there is a package at
+    /// the path `a_path`; paths are delimited with Package_name_delimiter"
+    /// (`org.openehr.lang.bmm.bmm_package_container.adoc` §Functions).
+    #[must_use]
+    pub fn has_package_path(&self, a_path: &str) -> bool {
+        self.package_at_path(a_path).is_some()
+    }
+
+    /// `BMM_PACKAGE_CONTAINER.do_recursive_packages`: "Recursively execute
+    /// `action`, which is a procedure taking a BMM_PACKAGE argument, on all
+    /// members of packages"
+    /// (`org.openehr.lang.bmm.bmm_package_container.adoc` §Functions).
+    pub fn do_recursive_packages(&self, action: &mut dyn FnMut(&Self)) {
+        do_recursive_packages_in(self.packages.as_ref(), action);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use crate::bmm3::core::entity::bmm_class::BmmClass;
+    use crate::bmm3::core::entity::bmm_simple_class::BmmSimpleClass;
+    use crate::bmm3::core::model::bmm_package::BmmPackage;
+
+    /// A package with the given name, child packages and class names.
+    fn package(name: &str, children: Vec<BmmPackage>, classes: &[&str]) -> BmmPackage {
+        let mut package = BmmPackage {
+            documentation: None,
+            packages: None,
+            name: name.to_owned(),
+            classes: classes.iter().map(|c| simple_class(c)).collect(),
+        };
+        if !children.is_empty() {
+            let map: BTreeMap<String, BmmPackage> = children
+                .into_iter()
+                .map(|child| (child.name.to_uppercase(), child))
+                .collect();
+            package.packages = Some(map);
+        }
+        package
+    }
+
+    /// A simple class named `name`.
+    fn simple_class(name: &str) -> BmmClass {
+        BmmClass::BmmSimpleClass(BmmSimpleClass {
+            documentation: None,
+            name: name.to_owned(),
+            ancestors: None,
+            package: BmmPackage {
+                documentation: None,
+                packages: None,
+                name: "org.openehr.rm".to_owned(),
+                classes: Vec::new(),
+            },
+            properties: None,
+            source_schema_id: "openehr_test_1.0.0".to_owned(),
+            immediate_descendants: Vec::new(),
+            is_abstract: false,
+            is_primitive_type: false,
+            is_override: false,
+        })
+    }
+
+    #[test]
+    fn package_at_path_matches_keys_case_insensitively() {
+        let root = package(
+            "org.openehr.rm",
+            vec![package("composition", Vec::new(), &["COMPOSITION"])],
+            &[],
+        );
+        assert!(root.has_package_path("composition"));
+        assert!(root.has_package_path("COMPOSITION"));
+        assert!(root.has_package_path("Composition"));
+        assert_eq!(
+            root.package_at_path("composition").map(BmmPackage::path),
+            Some("composition")
+        );
+        assert_eq!(root.package_at_path("ehr"), None);
+    }
+
+    #[test]
+    fn package_at_path_walks_nested_segments() {
+        let root = package(
+            "org.openehr.rm",
+            vec![package(
+                "data_structures",
+                vec![package("item_structure", Vec::new(), &["ITEM_TREE"])],
+                &[],
+            )],
+            &[],
+        );
+        let leaf = root
+            .package_at_path("data_structures.item_structure")
+            .expect("the nested package resolves");
+        assert_eq!(leaf.path(), "item_structure");
+        assert!(!root.has_package_path("data_structures.missing"));
+    }
+
+    #[test]
+    fn root_classes_recurse_only_to_the_first_level_of_classes() {
+        let deep = package("deeper", Vec::new(), &["ELEMENT"]);
+        let child = package("data_structures", vec![deep], &[]);
+        let root = package("org.openehr.rm", vec![child], &[]);
+        assert_eq!(
+            root.root_classes()
+                .into_iter()
+                .map(BmmClass::name)
+                .collect::<Vec<_>>(),
+            ["ELEMENT"]
+        );
+
+        let with_own = package(
+            "org.openehr.rm",
+            vec![package("child", Vec::new(), &["IGNORED"])],
+            &["COMPOSITION"],
+        );
+        assert_eq!(
+            with_own
+                .root_classes()
+                .into_iter()
+                .map(BmmClass::name)
+                .collect::<Vec<_>>(),
+            ["COMPOSITION"]
+        );
+    }
+
+    #[test]
+    fn do_recursive_packages_visits_every_descendant() {
+        let root = package(
+            "org.openehr.rm",
+            vec![
+                package("composition", Vec::new(), &[]),
+                package(
+                    "data_structures",
+                    vec![package("item_structure", Vec::new(), &[])],
+                    &[],
+                ),
+            ],
+            &[],
+        );
+        let mut visited: Vec<String> = Vec::new();
+        root.do_recursive_packages(&mut |package| visited.push(package.name.clone()));
+        assert_eq!(
+            visited,
+            [
+                "composition".to_owned(),
+                "data_structures".to_owned(),
+                "item_structure".to_owned()
+            ]
+        );
+    }
+}

--- a/crates/openehr-lang/src/bmm3/core/model/mod.rs
+++ b/crates/openehr-lang/src/bmm3/core/model/mod.rs
@@ -6,3 +6,7 @@ pub mod bmm_model;
 pub mod bmm_model_metadata;
 pub mod bmm_package;
 pub mod bmm_package_container;
+
+// hand-written modules (spec behaviour), auto-declared:
+pub mod bmm_model_impl;
+pub mod bmm_package_impl;


### PR DESCRIPTION
Closes #1389
Closes #1128
Closes #1129
Closes #1130
Closes #1131
Closes #1132
Closes #862
Closes #863
Closes #1135
Closes #1136
Closes #1137
Closes #865
Closes #866

## What

The BMM v2 document of the #753 LANG compliance program: chapters 2 (Overview, five sections), 3 (BMM in Use), 5 (Core, three sections), and 6 (Persistence pointer) audited and closed; chapter 4 (RM Access) stays OPEN on the real dependency chain #1390 ← #1391 (section records posted on #1133/#1134).

## The finding, implemented in full

**#1389:** the crate carried zero hand-written spec behaviour while ch.5 declares a 45-function pure surface. Now: 8 `*_impl.rs` files, **107 public functions, 35 unit tests** — the naming trio (`type_name`/`type_signature`/`conformance_type_name`) on every classifier variant, `flattened_type_list`, the inheritance walks (`all_ancestors`, model-parameterised `all_descendants`/`supplier_closure`/`suppliers_non_primitive`), `flat_properties` with nearer-wins override, the `BMM_MODEL` lookups (`class_definition` incl. generic-part stripping, `property_definition`, `property_definition_at_path`, `all_ancestor_classes`), `type_conforms_to` (generics, open-parameter-as-Any, non-generic-desc vs generic-anc refusal), `ms_conformant_property_type`, `existence`, `schema_id`, and the package-container trio (case-insensitive keys, longest-qualified-prefix).

Ten NOTE adjudications recorded at the sites (details in the commit message + #1137's checklist): the v2/v3 `flattened_type_list` divergence, the `schema_id` underscore join vs the `'-'` editorial slip, the dangling `Type_category_xx` → `BMM_ENTITY_METATYPE` successor vocabulary (drift-pinned against the generated `as_str`), the upward-complete/downward-nominal graph shape, the `base_class_name` projection, the `'/'` path delimiter flagged own-design.

## Codegen discipline

No generated file hand-edited: the 4 `mod.rs` diffs are the emitter's own hand-written-module weave (decl lines only), regenerated via `cargo run -p openehr-codegen -- emit`; the drift check is clean on this commit.

## Gates

fmt + clippy (deny-clean, five scoped `#[expect(reason)]`) + rustdoc clean; `cargo nextest run -p openehr-lang -p openehr-adl` **426/426 green**. Internal spec-crate API only (no wire change): `no-changelog`.