### PR TITLE
feat(openehr-lang): ODIN plug-in syntax blocks (#1387)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
+- **ODIN plug-in syntax blocks parse.** `attr = (syntax) <# … #>`
+  (`master09-plug_in_syntaxes`) is accepted, with the tag and the verbatim
+  foreign-text body exposed as `OdinValue::PlugIn`; the body is handed to
+  consumers uninterpreted, and a plug-in block is refused as an archetype
+  `default_value` (it denotes no RM instance).
+
 - **ODIN document artefacts parse in all three `master04` forms.** The ODIN
   reader now accepts Identified Object Documents (top-level
   `["id"] = <…>` keyed objects) and the optional leading

--- a/crates/openehr-adl/src/odin.rs
+++ b/crates/openehr-adl/src/odin.rs
@@ -292,6 +292,19 @@ pub(crate) enum OdinJsonError {
         "a '|centre +/- delta|' interval whose bounds leave the representable numeric range has no lower/upper reduction"
     )]
     PlusMinusOutOfRange,
+    /// A plug-in-syntax block (`(syntax) <# … #>`,
+    /// `LANG/docs/odin/master09-plug_in_syntaxes`) as a default value. Its
+    /// body is raw foreign text for a plug-in parser — it denotes no RM
+    /// instance, so it has no canonical-JSON encoding as a
+    /// `C_DEFINED_OBJECT.default_value`. Refused rather than smuggled through
+    /// as a string.
+    #[error(
+        "a plug-in-syntax block (({syntax}) <# … #>) is foreign text, not an RM instance; it has no default_value encoding"
+    )]
+    PlugInBlock {
+        /// The plug-in syntax tag.
+        syntax: String,
+    },
 }
 
 /// Convert an [`OdinValue`] to canonical JSON for a
@@ -332,6 +345,11 @@ pub(crate) fn odin_to_json(v: &OdinValue) -> Result<serde_json::Value, OdinJsonE
         OdinValue::Boolean(b) => serde_json::Value::from(*b),
         OdinValue::Character(c) => serde_json::Value::String(c.to_string()),
         OdinValue::Empty => serde_json::Value::Null,
+        OdinValue::PlugIn { syntax, .. } => {
+            return Err(OdinJsonError::PlugInBlock {
+                syntax: syntax.clone(),
+            });
+        }
         OdinValue::Interval(iv) => interval_to_json(iv)?,
         OdinValue::ListContinue => serde_json::Value::String("...".to_owned()),
         OdinValue::List(items) => serde_json::Value::Array(

--- a/crates/openehr-lang/src/lexer/reclassify.rs
+++ b/crates/openehr-lang/src/lexer/reclassify.rs
@@ -172,6 +172,13 @@ pub(super) fn reclassify(
             Language::Odin => Some(token.clone()),
             Language::Adl | Language::Bel => None,
         },
+        // `<# … #>` is the ODIN plug-in-syntax block
+        // (`LANG/docs/odin/master09-plug_in_syntaxes`); neither the ADL nor
+        // the BEL grammar has any `#` production, so both refuse it.
+        Token::PlugInBlock(_) => match language {
+            Language::Odin => Some(token.clone()),
+            Language::Adl | Language::Bel => None,
+        },
         Token::AdlPath(text) => path(language, text).then(|| token.clone()),
 
         // ── atomic primitives ──

--- a/crates/openehr-lang/src/lexer/token.rs
+++ b/crates/openehr-lang/src/lexer/token.rs
@@ -349,6 +349,15 @@ pub enum Token {
     /// their passes split the token back into `'['`, the inner code and `']'`.
     #[regex(r"\[[a-zA-Z][a-zA-Z0-9._\-]*\]", |lex| lex.slice().to_owned())]
     LocalTermCodeRef(String),
+    /// A plug-in-syntax object block `<# … #>`, captured verbatim including
+    /// the delimiters (`LANG/docs/odin/master09-plug_in_syntaxes`: "the `<>`
+    /// delimiters are modified to `<# #>`, to allow for easier parser design";
+    /// the delimiters are reserved by `master03-basics` §Reserved
+    /// Characters). ODIN-only — the vendored ADL/BEL grammars have no `#`
+    /// production at all, so the other readings refuse the token. The body is
+    /// raw foreign text ("expressed in some other syntax"), never lexed.
+    #[regex(r"<#([^#]|#[^>])*#*#>", |lex| lex.slice().to_owned())]
+    PlugInBlock(String),
     /// An embedded URI `<scheme:…>` (`EMBEDDED_URI`).
     ///
     /// NOTE: captured VERBATIM — the token pins only the `scheme:` shape.

--- a/crates/openehr-lang/src/odin/mod.rs
+++ b/crates/openehr-lang/src/odin/mod.rs
@@ -76,6 +76,16 @@ pub enum OdinValue {
     TermCode(String),
     /// An embedded URI value (verbatim incl. the `<>` delimiters).
     Uri(String),
+    /// A plug-in-syntax object block `attr = (syntax) <# … #>`
+    /// (`LANG/docs/odin/master09-plug_in_syntaxes`): an object value
+    /// "expressed in some other syntax". The body is raw foreign text for a
+    /// plug-in parser — never interpreted here.
+    PlugIn {
+        /// The plug-in syntax tag from the parentheses (e.g. `cadl`).
+        syntax: String,
+        /// The block body between the `<#` and `#>` delimiters, verbatim.
+        text: String,
+    },
     /// A single object-reference path (`odin_path`).
     Path(String),
     /// The list-continuation marker (`...`), the final element of an open list.

--- a/crates/openehr-lang/src/odin/parser.rs
+++ b/crates/openehr-lang/src/odin/parser.rs
@@ -373,7 +373,33 @@ fn object_block<'a>() -> impl Parser<'a, &'a [Token], OdinValue, Err<'a>> + Clon
 
         let uri = select! { Token::EmbeddedUri(s) => OdinValue::Uri(s) };
 
-        choice((uri, value_block))
+        // `attr_name = (syntax) <# … #>` — a plug-in-syntax object block
+        // (`LANG/docs/odin/master09-plug_in_syntaxes`: "Plug-in syntaxes are
+        // indicated in ODIN in a similar way as typed objects, i.e. by the
+        // use of the syntax type in parentheses preceding the `<>` block. For
+        // a plug-in section, the `<>` delimiters are modified to `<# #>`").
+        // The general form makes the `(syntax)` tag part of the construct —
+        // it names the plug-in parser the body is for — so a bare `<# … #>`
+        // with no tag stays a parse error. The tag is an ordinary identifier
+        // (the chapter's example tag is the lower-case `cadl`), and the body
+        // is handed over verbatim.
+        let plug_in_tag = select! {
+            Token::AlphaLcId(s) => s,
+            Token::AlphaUcId(s) => s,
+        };
+        let plug_in = plug_in_tag
+            .delimited_by(just(Token::LParen), just(Token::RParen))
+            .then(select! { Token::PlugInBlock(s) => s })
+            .map(|(syntax, raw)| OdinValue::PlugIn {
+                syntax,
+                text: raw
+                    .strip_prefix("<#")
+                    .and_then(|t| t.strip_suffix("#>"))
+                    .unwrap_or(&raw)
+                    .to_owned(),
+            });
+
+        choice((uri, plug_in, value_block))
     })
 }
 

--- a/crates/openehr-lang/tests/fixtures/lexer_battery.txt
+++ b/crates/openehr-lang/tests/fixtures/lexer_battery.txt
@@ -518,3 +518,5 @@ x = <false>
 |0..infinity|
 %%
 @schema = <http://openehr.org/bmm>
+%%
+a = (cadl) <# x #>

--- a/crates/openehr-lang/tests/fixtures/lexer_equivalence_adl.txt
+++ b/crates/openehr-lang/tests/fixtures/lexer_equivalence_adl.txt
@@ -243,3 +243,4 @@
 242|AlphaLcId("x")@0..1 SymEq@2..3 SymLt@4..5 SymFalse@5..10 SymGt@10..11
 243|SymIvlDelim@0..1 Integer("0")@1..2 SymIvlSep@2..4 SymInfinity@4..12 SymIvlDelim@12..13
 244|SymAt@0..1 AlphaLcId("schema")@1..7 SymEq@8..9 EmbeddedUri("<http://openehr.org/bmm>")@10..34
+245|ERROR@12..13

--- a/crates/openehr-lang/tests/fixtures/lexer_equivalence_bel.txt
+++ b/crates/openehr-lang/tests/fixtures/lexer_equivalence_bel.txt
@@ -243,3 +243,4 @@
 242|AlphaLcId("x")@0..1 SymEq@2..3 SymLt@4..5 SymFalse@5..10 SymGt@10..11
 243|SymIvlDelim@0..1 Integer("0")@1..2 SymIvlSep@2..4 AlphaLcId("infinity")@4..12 SymIvlDelim@12..13
 244|SymAt@0..1 AlphaLcId("schema")@1..7 SymEq@8..9 SymLt@10..11 AlphaLcId("http")@11..15 SymColon@15..16 AdlPath("//openehr")@16..25 SymDot@25..26 AdlPath("org/bmm")@26..33 SymGt@33..34
+245|ERROR@12..13

--- a/crates/openehr-lang/tests/fixtures/lexer_equivalence_odin.txt
+++ b/crates/openehr-lang/tests/fixtures/lexer_equivalence_odin.txt
@@ -243,3 +243,4 @@
 242|AlphaLcId("x")@0..1 SymEq@2..3 SymLt@4..5 SymFalse@5..10 SymGt@10..11
 243|SymIvlDelim@0..1 Integer("0")@1..2 SymIvlSep@2..4 SymInfinity@4..12 SymIvlDelim@12..13
 244|SymAt@0..1 AlphaLcId("schema")@1..7 SymEq@8..9 EmbeddedUri("<http://openehr.org/bmm>")@10..34
+245|AlphaLcId("a")@0..1 SymEq@2..3 LParen@4..5 AlphaLcId("cadl")@5..9 RParen@9..10 PlugInBlock("<# x #>")@11..18

--- a/crates/openehr-lang/tests/it/odin_spec_examples.rs
+++ b/crates/openehr-lang/tests/it/odin_spec_examples.rs
@@ -690,15 +690,55 @@ fn ch8_typical_path_shape() {
     assert!(parse(r#"r = </term_definitions["en"]/items["at0001"]/text>"#).is_ok());
 }
 
-/// `master09-plug_in_syntaxes`: plug-in blocks `attr = (syntax) <# … #>` are
-/// NOT supported — the chapter itself waives the obligation ("there is no
-/// guarantee that every ODIN parser will support them"), so the refusal is a
-/// conforming, adjudicated boundary (#859; the optional capability is
-/// tracked as a backlog enhancement). Pinned so the boundary never silently
-/// shifts.
+/// `master09-plug_in_syntaxes` (#1387): plug-in blocks
+/// `attr = (syntax) <# … #>` parse to [`OdinValue::PlugIn`] with the tag from
+/// the parentheses and the body carried verbatim ("expressed in some other
+/// syntax" — the body is for a plug-in parser, never interpreted here). The
+/// chapter's own cADL example is the pinned acceptance twin; a tag-less
+/// `<# … #>` stays refused (the general form makes the syntax tag part of
+/// the construct), as does a plug-in block under every non-ODIN reading.
 #[test]
-fn ch9_plug_in_blocks_are_refused() {
-    let err = parse("definition = (cadl) <#\n    ENTRY[at0000]\n#>")
-        .expect_err("plug-in blocks are an unsupported (spec-waived) capability");
-    assert_eq!(err.kind, OdinErrorKind::UnrecognisedToken);
+fn ch9_plug_in_blocks_parse() {
+    // the chapter's example: a cADL plug-in section in an archetype.
+    let src = "definition = (cadl) <#
+    ENTRY[at0000] \u{2208} { -- blood pressure measurement
+        name \u{2208} { -- any synonym of BP
+            CODED_TEXT \u{2208} {
+                code \u{2208} {
+                    CODE_PHRASE \u{2208} {[ac0001]}
+                }
+            }
+        }
+    }
+#>";
+    let parsed = parse(src).unwrap_or_else(|e| panic!("the master09 example should parse: {e}"));
+    let OdinValue::Object(top) = parsed else {
+        panic!("expected a top-level attribute object");
+    };
+    let Some(OdinValue::PlugIn { syntax, text }) = top.get("definition") else {
+        panic!("expected a plug-in block, got {:?}", top.get("definition"));
+    };
+    assert_eq!(syntax, "cadl");
+    assert!(
+        text.contains("ENTRY[at0000]") && text.contains("[ac0001]"),
+        "the body is carried verbatim: {text}"
+    );
+
+    // `#` inside the body does not close the block; only `#>` does.
+    let parsed = parse("a = (xml) <# a # b ## c #>").unwrap_or_else(|e| panic!("{e}"));
+    let OdinValue::Object(top) = parsed else {
+        panic!("expected object");
+    };
+    assert_eq!(
+        top.get("a"),
+        Some(&OdinValue::PlugIn {
+            syntax: "xml".to_owned(),
+            text: " a # b ## c ".to_owned(),
+        })
+    );
+
+    // the refusal twins: a tag-less block, and a tagged block whose body
+    // never closes.
+    assert!(parse("a = <# no tag #>").is_err());
+    assert!(parse("a = (cadl) <# never closed").is_err());
 }


### PR DESCRIPTION
Closes #1387

## What

Implements master09 plug-in syntax blocks, superseding the ch.9 boundary adjudication per the owner directive (everything filed gets implemented; recorded on the issue).

- **Lexer:** raw-capture `PlugInBlock` token for `<# … #>` (interior `#`s handled; only `#>` closes). ODIN-only: the ADL and BEL readings refuse it (no `#` production in either grammar) — battery record 245 pins all three readings.
- **Parser:** `(syntax) <# … #>` → `OdinValue::PlugIn { syntax, text }` — the tag is required (the chapter's general form makes it part of the construct; it names the plug-in parser), the body is verbatim foreign text, never interpreted — exactly the chapter's recommended plug-in-parser architecture.
- **Pinned:** the master09 cADL example parses (tag `cadl`, body verbatim incl. the `∈` symbols and `[ac0001]`); interior-`#` handling; refusal twins (tag-less block, unclosed body).
- **Consumer:** `openehr-adl`'s `default_value` encoder refuses a plug-in block with a typed `OdinJsonError::PlugInBlock` — foreign text denotes no RM instance (spec-silent, refused rather than smuggled through as a string).

## Gates

fmt + clippy + rustdoc clean; `cargo nextest run -p openehr-lang -p openehr-adl` 426/426 green; full workspace builds (one stale pre-rename swagger-ui build artifact cleaned en route). Changelog entry added.