### PR TITLE
feat(openehr-lang): P_BMM schema reader (audits #880 #881, ch.4 sections)

### DIFF
--- a/crates/openehr-lang/CLAUDE.md
+++ b/crates/openehr-lang/CLAUDE.md
@@ -34,6 +34,23 @@ ADL/ODIN *instance* parsing — deliberately off the codegen path).
     `tests/it/lexer_equivalence.rs` against fixtures captured from the three
     pre-unification lexers. **Editing a fixture line changes an accepted or
     refused lexical surface** and needs an adjudicated, spec-cited reason.
+- **`src/bmm_persistence/` is generated types + a hand-written P_BMM SCHEMA
+  READER.** The `P_BMM_*` type files are generated; beside them live the
+  hand-written pipeline `master02-overview.adoc` §Conceptual Approach
+  prescribes — `reader.rs` (ODIN text → `P_BMM_SCHEMA`, a STRICT read: an
+  attribute the class docs do not declare is a typed error, with two
+  spec-cited tolerance lists), `include_resolution.rs` (transitive inclusion
+  merge, includer wins, collisions marked `is_override`), `create_model.rs`
+  (`P_BMM` → `BMM_MODEL`, all name references resolved to object references),
+  `loader.rs` (the composed `load_model`), `error.rs` (the one typed
+  `PBmmReadError`), plus `p_bmm_*_impl.rs` spec functions. Class-name
+  resolution is case-insensitive (`master04-syntax.adoc` §Non-primitive
+  Classes: `name` — "any capitalisation can be used"); embedding depth and
+  every other cycle/boundary decision is adjudicated in the module docs, with
+  the honest boundaries (`value_constraint` has no `BMM_*` destination; a
+  persisted `P_BMM_INTERFACE` has no `P_BMM_SCHEMA` slot) written out. This
+  reader is NOT the codegen path either — codegen still consumes only the
+  `.bmm.json` serialisation via `openehr-codegen`.
 - **`src/odin/` is the real ODIN reader** (a `chumsky` parser over
   `lexer::lex_odin` + an `OdinValue` tree; `openehr_lang::odin::parse`), NOT
   part of the generated/`bmm*`/`beom` model — never route it through codegen.

--- a/crates/openehr-lang/src/bmm_persistence/create_model.rs
+++ b/crates/openehr-lang/src/bmm_persistence/create_model.rs
@@ -1,0 +1,1047 @@
+//! The `P_BMM_SCHEMA` → `BMM_MODEL` transform: "the in-memory model-to-model
+//! transform step required to produce a materialised BMM model"
+//! (`LANG/docs/bmm_persistence/master02-overview.adoc` §Conceptual Approach).
+//!
+//! `P_BMM_SCHEMA.create_bmm_model` (precondition
+//! `state = P_BMM_PACKAGE_STATE.State_includes_processed`,
+//! `LANG/docs/UML/classes/org.openehr.lang.bmm_persistence.p_bmm_schema.adoc`
+//! §Functions) — so the schema passed here must already be inclusion-resolved
+//! ([`crate::bmm_persistence::include_resolution::resolve_includes`]).
+//!
+//! The transform is where "symbolic referencing via class names, syntactical
+//! type names" becomes "the fully computable in-memory object structure with all
+//! name references resolved to object references"
+//! (`master02-overview.adoc` §Conceptual Approach). Two consequences are pinned
+//! here as adjudications, because the openEHR BMM object graph is cyclic while
+//! Rust values are not:
+//!
+//! * **Embedding depth.** `master03-model.adoc` §Overview calls the `bmm_xxx`
+//!   attributes "in-memory only references to reconstructed instances", i.e. the
+//!   reference semantics the BMM model assumes throughout. `BMM_CLASS.ancestors`
+//!   is a map of `BMM_CLASS` and `BMM_SIMPLE_TYPE.base_class` IS a `BMM_CLASS`,
+//!   so full embedding would not terminate (`DV_TEXT` has a property of type
+//!   `CODE_PHRASE`, whose ancestors reach back through the type system). This
+//!   transform therefore embeds: a class's ancestors as resolved copies carrying
+//!   their own properties, whose own ancestors are name-bearing stubs; and every
+//!   type's base class as a name-bearing stub (name, package, flags, no
+//!   properties, no ancestors). The complete definition of every class is always
+//!   `BMM_MODEL.class_definitions` — "All classes in this schema"
+//!   (`org.openehr.lang.bmm.bmm_model.adoc` §Attributes) — which is exactly the
+//!   source the model-level lookups
+//!   ([`crate::bmm3::core::model::bmm_model::BmmModel::property_definition`])
+//!   already prefer over embedded copies.
+//! * **`value_constraint` has no destination.** `P_BMM_BASE_TYPE.value_constraint`
+//!   (`master04-syntax.adoc` §Value-set Constraints) carries a value-set
+//!   reference such as `openEHR::languages`, but `BMM_SIMPLE_TYPE` declares only
+//!   `base_class` (`org.openehr.lang.bmm.bmm_simple_type.adoc` §Attributes) and
+//!   nothing in the v2 `BMM_*` type family references `BMM_VALUE_SET_SPEC` (which
+//!   is reachable only from the v3 `BMM_MODEL_TYPE`). The constraint is
+//!   therefore preserved in the P_BMM graph and NOT carried into the BMM model —
+//!   an honest boundary, not a shadow field.
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+
+use openehr_base::prelude::Interval;
+use openehr_base::prelude::MultiplicityInterval;
+use openehr_base::prelude::PointInterval;
+use openehr_base::prelude::ProperInterval;
+
+use crate::bmm::core::bmm_generic_parameter::BmmGenericParameter;
+use crate::bmm::core::bmm_open_type::BmmOpenType;
+use crate::bmm_persistence::error::PBmmReadError;
+use crate::bmm_persistence::p_bmm_base_type::PBmmBaseType;
+use crate::bmm_persistence::p_bmm_class::PBmmClass;
+use crate::bmm_persistence::p_bmm_container_property::PBmmContainerProperty;
+use crate::bmm_persistence::p_bmm_container_type::PBmmContainerType;
+use crate::bmm_persistence::p_bmm_enumeration::PBmmEnumeration;
+use crate::bmm_persistence::p_bmm_generic_type::PBmmGenericType;
+use crate::bmm_persistence::p_bmm_package::PBmmPackage;
+use crate::bmm_persistence::p_bmm_property::PBmmProperty;
+use crate::bmm_persistence::p_bmm_schema::PBmmSchema;
+use crate::bmm_persistence::p_bmm_type::PBmmType;
+use crate::bmm3::core::entity::bmm_class::BmmClass;
+use crate::bmm3::core::entity::bmm_container_type::BmmContainerType;
+use crate::bmm3::core::entity::bmm_container_type::BmmContainerTypeData;
+use crate::bmm3::core::entity::bmm_generic_class::BmmGenericClass;
+use crate::bmm3::core::entity::bmm_generic_type::BmmGenericType;
+use crate::bmm3::core::entity::bmm_indexed_container_type::BmmIndexedContainerType;
+use crate::bmm3::core::entity::bmm_simple_class::BmmSimpleClass;
+use crate::bmm3::core::entity::bmm_simple_type::BmmSimpleType;
+use crate::bmm3::core::entity::bmm_type::BmmType;
+use crate::bmm3::core::entity::range_constrained::bmm_enumeration::BmmEnumeration;
+use crate::bmm3::core::entity::range_constrained::bmm_enumeration::BmmEnumerationData;
+use crate::bmm3::core::entity::range_constrained::bmm_enumeration_integer::BmmEnumerationInteger;
+use crate::bmm3::core::entity::range_constrained::bmm_enumeration_string::BmmEnumerationString;
+use crate::bmm3::core::feature::bmm_container_property::BmmContainerProperty;
+use crate::bmm3::core::feature::bmm_container_property::BmmContainerPropertyData;
+use crate::bmm3::core::feature::bmm_indexed_container_property::BmmIndexedContainerProperty;
+use crate::bmm3::core::feature::bmm_property::BmmProperty;
+use crate::bmm3::core::feature::bmm_property::BmmPropertyData;
+use crate::bmm3::core::model::bmm_model::BmmModel;
+use crate::bmm3::core::model::bmm_package::BmmPackage;
+
+/// Materialise the in-memory `BMM_MODEL` of an inclusion-resolved
+/// `P_BMM_SCHEMA`.
+///
+/// # Errors
+/// Returns [`PBmmReadError::UnknownAncestor`], [`PBmmReadError::UnknownType`],
+/// [`PBmmReadError::ClassNotInAnyPackage`], [`PBmmReadError::ClassNotDefined`],
+/// [`PBmmReadError::ContainerTargetTypeMissing`],
+/// [`PBmmReadError::TypeDefinitionMissing`],
+/// [`PBmmReadError::UndeclaredGenericParameter`] or
+/// [`PBmmReadError::NotAGenericClass`] when a symbolic reference in the schema
+/// cannot be resolved to the object reference the `BMM_*` shapes require.
+pub fn create_bmm_model(schema: &PBmmSchema) -> Result<BmmModel, PBmmReadError> {
+    let builder = Builder::new(schema)?;
+    // Keyed by each class's OWN name, the form `BMM_CLASS.name` states and the
+    // form `BMM_MODEL.class_definition` looks up with; the upper-cased keys of
+    // `Builder::classes` are an internal matching index only.
+    let mut class_definitions: BTreeMap<String, BmmClass> = BTreeMap::new();
+    for entry in builder.classes.values() {
+        class_definitions.insert(
+            entry.class.name().to_owned(),
+            builder.build_class(entry, EmbedDepth::Full)?,
+        );
+    }
+    let packages = builder.build_packages(&schema.packages, "")?;
+    Ok(BmmModel {
+        rm_publisher: schema.rm_publisher.clone(),
+        rm_release: schema.rm_release.clone(),
+        schema_name: schema.schema_name.clone(),
+        schema_revision: schema.schema_revision.clone(),
+        schema_lifecycle_state: schema.schema_lifecycle_state.clone(),
+        schema_author: schema.schema_author.clone(),
+        schema_description: schema.schema_description.clone(),
+        schema_contributors: schema.schema_contributors.clone(),
+        archetype_parent_class: schema.archetype_parent_class.clone(),
+        archetype_data_value_parent_class: schema.archetype_data_value_parent_class.clone(),
+        archetype_rm_closure_packages: schema.archetype_rm_closure_packages.clone(),
+        archetype_visualise_descendants_of: schema.archetype_visualise_descendants_of.clone(),
+        // P_BMM_SCHEMA carries no `documentation` attribute (class doc
+        // §Attributes), so the model's inherited BMM_MODEL_ELEMENT.documentation
+        // has no persisted source.
+        documentation: None,
+        packages: if packages.is_empty() {
+            None
+        } else {
+            Some(packages)
+        },
+        class_definitions: if class_definitions.is_empty() {
+            None
+        } else {
+            Some(class_definitions)
+        },
+    })
+}
+
+/// How much of a referenced class is embedded in the value being built (see the
+/// module docs' embedding-depth adjudication).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EmbedDepth {
+    /// The class's own definition: properties built, ancestors embedded at
+    /// [`EmbedDepth::Ancestor`].
+    Full,
+    /// An embedded ancestor copy: properties built, ancestors embedded at
+    /// [`EmbedDepth::Stub`].
+    Ancestor,
+    /// A name-bearing stub: no properties, no ancestors, formal generic
+    /// parameters resolved with their constrainers at [`EmbedDepth::Bare`].
+    Stub,
+    /// The innermost stub: name, package and flags only — no properties, no
+    /// ancestors and no formal generic parameters.
+    ///
+    /// This depth exists because `BMM_GENERIC_PARAMETER.conforms_to_type` is
+    /// itself a `BMM_CLASS` (`org.openehr.lang.bmm.bmm_generic_parameter.adoc`
+    /// §Attributes) that may in turn be generic, so resolving constrainers
+    /// without a floor would not terminate on a schema whose parameter
+    /// constraints are mutually recursive.
+    Bare,
+}
+
+/// One class definition of the schema, with the list it was declared in.
+struct ClassEntry<'a> {
+    /// The persisted definition.
+    class: &'a PBmmClass,
+    /// Whether it was declared in `primitive_types` — `BMM_CLASS.is_primitive_type`,
+    /// "True if this class is designated a primitive type within the overall type
+    /// system of the schema" (`org.openehr.lang.bmm.bmm_class.adoc` §Attributes).
+    is_primitive_type: bool,
+}
+
+/// The resolution indexes the transform needs, all derived from the schema
+/// before any `BMM_*` value is built.
+///
+/// Every class index is keyed by the UPPER-CASED class name, and every
+/// name-based lookup upper-cases its argument.
+///
+/// NOTE (adjudicated): class names in a BMM schema are case-flexible —
+/// `master04-syntax.adoc` §Non-primitive Classes says of `P_BMM_CLASS.name`
+/// "any capitalisation can be used, usually one of CamelCase or so-called
+/// UPPER_SNAKE_CASE" — so a type reference and the class definition it names may
+/// differ in capitalisation, as they do throughout the vendored openEHR schemas
+/// (`openEHR_aom_206.bmm` references `BOOLEAN` where `openehr_base_110.bmm`
+/// defines `Boolean`; `openehr_adltest_100.bmm` references `Iso8601_date` where
+/// `openehr_primitive_types_102.bmm` defines `ISO8601_DATE`). The BMM model
+/// itself takes the same approach for the one map whose keying it specifies:
+/// `BMM_PACKAGE_CONTAINER.packages` has "keys all in upper case for guaranteed
+/// matching" (`org.openehr.lang.bmm.bmm_package_container.adoc` §Attributes).
+/// Every name written into the produced `BMM_*` values is the class's OWN
+/// `name`, never the upper-cased key.
+struct Builder<'a> {
+    /// Class definitions by upper-cased name (`primitive_types` first, then
+    /// `class_definitions`).
+    classes: BTreeMap<String, ClassEntry<'a>>,
+    /// Upper-cased class name → the fully qualified path of the package that
+    /// lists it.
+    owning_package: BTreeMap<String, String>,
+    /// Upper-cased class name → immediate inheritance descendants (their own
+    /// names), sorted.
+    descendants: BTreeMap<String, Vec<String>>,
+}
+
+impl<'a> Builder<'a> {
+    /// Indexes `schema`'s classes, package membership and inverted inheritance
+    /// graph.
+    fn new(schema: &'a PBmmSchema) -> Result<Self, PBmmReadError> {
+        let mut classes: BTreeMap<String, ClassEntry<'a>> = BTreeMap::new();
+        for (class, is_primitive_type) in schema
+            .primitive_types
+            .iter()
+            .map(|class| (class, true))
+            .chain(schema.class_definitions.iter().map(|class| (class, false)))
+        {
+            classes
+                .entry(class.name().to_uppercase())
+                .or_insert(ClassEntry {
+                    class,
+                    is_primitive_type,
+                });
+        }
+
+        let mut owning_package: BTreeMap<String, String> = BTreeMap::new();
+        index_packages(&schema.packages, "", &classes, &mut owning_package)?;
+
+        let mut descendants: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        for entry in classes.values() {
+            for parent in ancestor_names(entry.class) {
+                let key = parent.to_uppercase();
+                if classes.contains_key(&key) {
+                    descendants
+                        .entry(key)
+                        .or_default()
+                        .push(entry.class.name().to_owned());
+                }
+            }
+        }
+        for names in descendants.values_mut() {
+            names.sort_unstable();
+            names.dedup();
+        }
+
+        Ok(Self {
+            classes,
+            owning_package,
+            descendants,
+        })
+    }
+
+    /// The class definition named `name`, matched case-insensitively.
+    fn entry(&self, context: &str, name: &str) -> Result<&ClassEntry<'a>, PBmmReadError> {
+        self.classes
+            .get(&name.to_uppercase())
+            .ok_or_else(|| PBmmReadError::UnknownType {
+                context: context.to_owned(),
+                type_name: name.to_owned(),
+            })
+    }
+
+    /// The owning-package stub of the class named `name`.
+    ///
+    /// `BMM_CLASS.package` is `1..1` and `BMM_CLASS.package_path` is the "Fully
+    /// qualified package name, of form: 'package.package'" (class doc
+    /// §Attributes + §Functions), so the stub carries the class's package path
+    /// from the schema root rather than the tree node's own unqualified segment.
+    /// A class listed by more than one package keeps the first package the
+    /// document declares.
+    fn package_of(&self, name: &str) -> Result<BmmPackage, PBmmReadError> {
+        let path = self
+            .owning_package
+            .get(&name.to_uppercase())
+            .ok_or_else(|| PBmmReadError::ClassNotInAnyPackage {
+                class: name.to_owned(),
+            })?;
+        Ok(BmmPackage {
+            documentation: None,
+            packages: None,
+            name: path.clone(),
+            classes: Vec::new(),
+        })
+    }
+
+    /// Builds one `BMM_CLASS` at the given embedding depth.
+    fn build_class(
+        &self,
+        entry: &ClassEntry<'a>,
+        depth: EmbedDepth,
+    ) -> Result<BmmClass, PBmmReadError> {
+        let persisted = entry.class;
+        let name = persisted.name();
+        let core = ClassCore {
+            documentation: persisted.documentation().map(str::to_owned),
+            name: name.to_owned(),
+            ancestors: self.build_ancestors(persisted, depth)?,
+            package: self.package_of(name)?,
+            properties: match depth {
+                EmbedDepth::Stub | EmbedDepth::Bare => None,
+                EmbedDepth::Full | EmbedDepth::Ancestor => self.build_properties(persisted)?,
+            },
+            source_schema_id: persisted.source_schema_id().to_owned(),
+            immediate_descendants: self
+                .descendants
+                .get(&name.to_uppercase())
+                .cloned()
+                .unwrap_or_default(),
+            is_abstract: persisted.is_abstract(),
+            is_primitive_type: entry.is_primitive_type,
+            is_override: persisted.is_override(),
+        };
+        if let PBmmClass::PBmmEnumeration(enumeration) = persisted {
+            return Ok(BmmClass::BmmEnumeration(build_enumeration(
+                core,
+                enumeration,
+            )));
+        }
+        if persisted.is_generic() {
+            return Ok(BmmClass::BmmGenericClass(BmmGenericClass {
+                documentation: core.documentation,
+                name: core.name,
+                ancestors: core.ancestors,
+                package: core.package,
+                properties: core.properties,
+                source_schema_id: core.source_schema_id,
+                immediate_descendants: core.immediate_descendants,
+                is_abstract: core.is_abstract,
+                is_primitive_type: core.is_primitive_type,
+                is_override: core.is_override,
+                generic_parameters: self.build_generic_parameters(persisted, depth)?,
+            }));
+        }
+        Ok(BmmClass::BmmSimpleClass(BmmSimpleClass {
+            documentation: core.documentation,
+            name: core.name,
+            ancestors: core.ancestors,
+            package: core.package,
+            properties: core.properties,
+            source_schema_id: core.source_schema_id,
+            immediate_descendants: core.immediate_descendants,
+            is_abstract: core.is_abstract,
+            is_primitive_type: core.is_primitive_type,
+            is_override: core.is_override,
+        }))
+    }
+
+    /// Builds a class's `BMM_CLASS.ancestors` map at the depth one level below
+    /// `depth`; `None` at [`EmbedDepth::Stub`].
+    fn build_ancestors(
+        &self,
+        persisted: &PBmmClass,
+        depth: EmbedDepth,
+    ) -> Result<Option<BTreeMap<String, BmmClass>>, PBmmReadError> {
+        let next = match depth {
+            EmbedDepth::Stub | EmbedDepth::Bare => return Ok(None),
+            EmbedDepth::Full => EmbedDepth::Ancestor,
+            EmbedDepth::Ancestor => EmbedDepth::Stub,
+        };
+        let mut out: BTreeMap<String, BmmClass> = BTreeMap::new();
+        for parent in ancestor_names(persisted) {
+            let entry = self.classes.get(&parent.to_uppercase()).ok_or_else(|| {
+                PBmmReadError::UnknownAncestor {
+                    class: persisted.name().to_owned(),
+                    ancestor: parent.clone(),
+                }
+            })?;
+            // Keyed by the ancestor's OWN name, so `BMM_CLASS.all_ancestors`
+            // yields names `BMM_MODEL.class_definitions` can be looked up with.
+            out.insert(
+                entry.class.name().to_owned(),
+                self.build_class(entry, next)?,
+            );
+        }
+        Ok(if out.is_empty() { None } else { Some(out) })
+    }
+
+    /// Builds a generic class's formal parameter declarations.
+    ///
+    /// `BMM_GENERIC_CLASS.generic_parameters` is keyed "by name of generic
+    /// parameter" (`org.openehr.lang.bmm.bmm_generic_class.adoc` §Attributes)
+    /// and `BMM_GENERIC_PARAMETER.conforms_to_type` is an "Optional conformance
+    /// constraint that must be another valid class name"
+    /// (`…bmm.bmm_generic_parameter.adoc` §Attributes), so the constrainer is
+    /// resolved to a class stub.
+    fn build_generic_parameters(
+        &self,
+        persisted: &PBmmClass,
+        depth: EmbedDepth,
+    ) -> Result<BTreeMap<String, BmmGenericParameter>, PBmmReadError> {
+        if depth == EmbedDepth::Bare {
+            return Ok(BTreeMap::new());
+        }
+        let mut out = BTreeMap::new();
+        for (key, parameter) in persisted.generic_parameter_defs().into_iter().flatten() {
+            out.insert(
+                key.clone(),
+                self.build_generic_parameter(persisted.name(), parameter)?,
+            );
+        }
+        Ok(out)
+    }
+
+    /// Builds one `BMM_GENERIC_PARAMETER`.
+    fn build_generic_parameter(
+        &self,
+        owner: &str,
+        parameter: &crate::bmm_persistence::p_bmm_generic_parameter::PBmmGenericParameter,
+    ) -> Result<BmmGenericParameter, PBmmReadError> {
+        let conforms_to_type = match parameter.conforms_to_type.as_deref() {
+            None => None,
+            Some(constrainer) => {
+                let context = format!("class `{owner}` generic parameter `{}`", parameter.name);
+                Some(self.build_class(self.entry(&context, constrainer)?, EmbedDepth::Bare)?)
+            }
+        };
+        Ok(BmmGenericParameter {
+            documentation: parameter.documentation.clone(),
+            name: parameter.name.clone(),
+            conforms_to_type,
+            inheritance_precursor: None,
+        })
+    }
+
+    /// Builds a class's `BMM_CLASS.properties` map.
+    fn build_properties(
+        &self,
+        persisted: &PBmmClass,
+    ) -> Result<Option<BTreeMap<String, BmmProperty<BmmType>>>, PBmmReadError> {
+        let Some(properties) = persisted.properties() else {
+            return Ok(None);
+        };
+        let mut out = BTreeMap::new();
+        for (key, property) in properties {
+            out.insert(key.clone(), self.build_property(persisted, property)?);
+        }
+        Ok(if out.is_empty() { None } else { Some(out) })
+    }
+
+    /// Builds one `BMM_PROPERTY`.
+    ///
+    /// A single, open or generic property becomes the least-rich
+    /// `BMM_PROPERTY` form over a `BMM_TYPE`: `BMM_UNITARY_PROPERTY` redefines
+    /// its type to `BMM_UNITARY_TYPE`
+    /// (`org.openehr.lang.bmm3.bmm_unitary_property.adoc` §Attributes), whose
+    /// members are the parameter/signature/status/tuple meta-types — not
+    /// `BMM_SIMPLE_TYPE` — so a class-typed property is not a unitary property.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one arm per P_BMM_PROPERTY subtype; splitting the dispatch would hide the five-way persisted-property → BMM_PROPERTY mapping"
+    )]
+    fn build_property(
+        &self,
+        owner: &PBmmClass,
+        property: &PBmmProperty,
+    ) -> Result<BmmProperty<BmmType>, PBmmReadError> {
+        let class_name = owner.name();
+        match property {
+            PBmmProperty::PBmmSingleProperty(single) => {
+                let context = property_context(class_name, &single.name);
+                let r#type = match (
+                    single.type_def.as_ref(),
+                    single.type_ref.as_ref(),
+                    single.r#type.as_deref(),
+                ) {
+                    (Some(type_def), _, _) => self.build_type(&context, type_def, owner)?,
+                    (None, Some(type_ref), _) => {
+                        self.build_named_type(&context, &type_ref.r#type, owner)?
+                    }
+                    (None, None, Some(name)) => self.build_named_type(&context, name, owner)?,
+                    (None, None, None) => {
+                        return Err(PBmmReadError::TypeDefinitionMissing { context });
+                    }
+                };
+                Ok(BmmProperty::BmmProperty(BmmPropertyData {
+                    documentation: single.documentation.clone(),
+                    name: single.name.clone(),
+                    is_mandatory: single.is_mandatory,
+                    is_computed: single.is_computed,
+                    r#type,
+                    is_im_runtime: single.is_im_runtime,
+                    is_im_infrastructure: single.is_im_infrastructure,
+                }))
+            }
+            PBmmProperty::PBmmSinglePropertyOpen(open) => {
+                let context = property_context(class_name, &open.name);
+                let parameter = match (open.type_ref.as_ref(), open.r#type.as_deref()) {
+                    (Some(type_ref), _) => type_ref.r#type.as_str(),
+                    (None, Some(name)) => name,
+                    (None, None) => {
+                        return Err(PBmmReadError::TypeDefinitionMissing { context });
+                    }
+                };
+                let r#type =
+                    BmmType::BmmOpenType(self.build_open_type(owner, &open.name, parameter)?);
+                Ok(BmmProperty::BmmProperty(BmmPropertyData {
+                    documentation: open.documentation.clone(),
+                    name: open.name.clone(),
+                    is_mandatory: open.is_mandatory,
+                    is_computed: open.is_computed,
+                    r#type,
+                    is_im_runtime: open.is_im_runtime,
+                    is_im_infrastructure: open.is_im_infrastructure,
+                }))
+            }
+            PBmmProperty::PBmmGenericProperty(generic) => {
+                let context = property_context(class_name, &generic.name);
+                let Some(type_def) = generic.type_def.as_ref() else {
+                    return Err(PBmmReadError::TypeDefinitionMissing { context });
+                };
+                let r#type =
+                    BmmType::BmmGenericType(self.build_generic_type(&context, type_def, owner)?);
+                Ok(BmmProperty::BmmProperty(BmmPropertyData {
+                    documentation: generic.documentation.clone(),
+                    name: generic.name.clone(),
+                    is_mandatory: generic.is_mandatory,
+                    is_computed: generic.is_computed,
+                    r#type,
+                    is_im_runtime: generic.is_im_runtime,
+                    is_im_infrastructure: generic.is_im_infrastructure,
+                }))
+            }
+            PBmmProperty::PBmmContainerProperty(PBmmContainerProperty::PBmmContainerProperty(
+                container,
+            )) => {
+                let context = property_context(class_name, &container.name);
+                let Some(type_def) = container.type_def.as_ref() else {
+                    return Err(PBmmReadError::TypeDefinitionMissing { context });
+                };
+                let r#type = self.build_container_type(&context, type_def, owner)?;
+                Ok(BmmProperty::BmmContainerProperty(
+                    BmmContainerProperty::BmmContainerProperty(BmmContainerPropertyData {
+                        documentation: container.documentation.clone(),
+                        name: container.name.clone(),
+                        is_mandatory: container.is_mandatory,
+                        is_computed: container.is_computed,
+                        r#type,
+                        is_im_runtime: container.is_im_runtime,
+                        is_im_infrastructure: container.is_im_infrastructure,
+                        cardinality: container.cardinality.as_ref().map(multiplicity_of),
+                    }),
+                ))
+            }
+            PBmmProperty::PBmmContainerProperty(
+                PBmmContainerProperty::PBmmIndexedContainerProperty(indexed),
+            ) => {
+                let context = property_context(class_name, &indexed.name);
+                let Some(type_def) = indexed.type_def.as_ref() else {
+                    return Err(PBmmReadError::TypeDefinitionMissing { context });
+                };
+                let r#type = self.build_indexed_container_type(&context, type_def, owner)?;
+                Ok(BmmProperty::BmmContainerProperty(
+                    BmmContainerProperty::BmmIndexedContainerProperty(
+                        BmmIndexedContainerProperty {
+                            documentation: indexed.documentation.clone(),
+                            name: indexed.name.clone(),
+                            is_mandatory: indexed.is_mandatory,
+                            is_computed: indexed.is_computed,
+                            r#type,
+                            is_im_runtime: indexed.is_im_runtime,
+                            is_im_infrastructure: indexed.is_im_infrastructure,
+                            cardinality: indexed.cardinality.as_ref().map(multiplicity_of),
+                        },
+                    ),
+                ))
+            }
+        }
+    }
+
+    /// Builds a `BMM_TYPE` from a bare type NAME.
+    ///
+    /// A name that is a formal generic parameter of `owner` (or of an ancestor)
+    /// becomes a `BMM_OPEN_TYPE` — `master04-syntax.adoc` §Inheritance writes
+    /// exactly that in a generic ancestor's parameter list
+    /// (`generic_parameters = <"T", "SUPPLIER_B">`, "the ancestors are generic
+    /// types, which may be open, partially closed or fully closed"); any other
+    /// name is a class reference and becomes a `BMM_SIMPLE_TYPE`.
+    fn build_named_type(
+        &self,
+        context: &str,
+        name: &str,
+        owner: &PBmmClass,
+    ) -> Result<BmmType, PBmmReadError> {
+        if let Some(parameter) = self.find_generic_parameter(owner, name) {
+            return Ok(BmmType::BmmOpenType(BmmOpenType {
+                documentation: None,
+                generic_constraint: self.build_generic_parameter(owner.name(), parameter)?,
+            }));
+        }
+        Ok(BmmType::BmmSimpleType(BmmSimpleType {
+            documentation: None,
+            base_class: self.build_class(self.entry(context, name)?, EmbedDepth::Stub)?,
+        }))
+    }
+
+    /// Builds a `BMM_TYPE` from a persisted `P_BMM_TYPE`.
+    fn build_type(
+        &self,
+        context: &str,
+        r#type: &PBmmType,
+        owner: &PBmmClass,
+    ) -> Result<BmmType, PBmmReadError> {
+        match r#type {
+            PBmmType::PBmmSimpleType(simple) => {
+                self.build_named_type(context, &simple.r#type, owner)
+            }
+            PBmmType::PBmmOpenType(open) => Ok(BmmType::BmmOpenType(self.build_open_type(
+                owner,
+                context,
+                &open.r#type,
+            )?)),
+            PBmmType::PBmmGenericType(generic) => Ok(BmmType::BmmGenericType(
+                self.build_generic_type(context, generic, owner)?,
+            )),
+            PBmmType::PBmmContainerType(container) => Ok(BmmType::BmmContainerType(Box::new(
+                self.build_container_type(context, container, owner)?,
+            ))),
+        }
+    }
+
+    /// Builds a `BMM_TYPE` from a persisted `P_BMM_BASE_TYPE`.
+    fn build_base_type(
+        &self,
+        context: &str,
+        r#type: &PBmmBaseType,
+        owner: &PBmmClass,
+    ) -> Result<BmmType, PBmmReadError> {
+        match r#type {
+            PBmmBaseType::PBmmSimpleType(simple) => {
+                self.build_named_type(context, &simple.r#type, owner)
+            }
+            PBmmBaseType::PBmmOpenType(open) => Ok(BmmType::BmmOpenType(self.build_open_type(
+                owner,
+                context,
+                &open.r#type,
+            )?)),
+            PBmmBaseType::PBmmGenericType(generic) => Ok(BmmType::BmmGenericType(
+                self.build_generic_type(context, generic, owner)?,
+            )),
+        }
+    }
+
+    /// Builds a `BMM_OPEN_TYPE` for the formal parameter named `parameter`.
+    ///
+    /// `BMM_OPEN_TYPE.generic_constraint` is "The generic constraint, which will
+    /// be 'Any' if nothing set in original model"
+    /// (`org.openehr.lang.bmm.bmm_open_type.adoc` §Attributes) and "The
+    /// parameter must be in the type declaration of the owning `BMM_CLASS`"
+    /// (same class doc, §Description) — hence the refusal when it is not.
+    fn build_open_type(
+        &self,
+        owner: &PBmmClass,
+        property: &str,
+        parameter: &str,
+    ) -> Result<BmmOpenType, PBmmReadError> {
+        let declared = self
+            .find_generic_parameter(owner, parameter)
+            .ok_or_else(|| PBmmReadError::UndeclaredGenericParameter {
+                class: owner.name().to_owned(),
+                property: property.to_owned(),
+                parameter: parameter.to_owned(),
+            })?;
+        Ok(BmmOpenType {
+            documentation: None,
+            generic_constraint: self.build_generic_parameter(owner.name(), declared)?,
+        })
+    }
+
+    /// The formal generic parameter named `parameter`, declared by `owner` or by
+    /// any of its ancestors.
+    ///
+    /// `BMM_GENERIC_CLASS.generic_parameters` are "defined either directly on
+    /// this class or by the addition of an ancestor class which is generic"
+    /// (`org.openehr.lang.bmm.bmm_generic_class.adoc` §Attributes), so the
+    /// lookup walks the ancestor graph; it is cycle-safe.
+    fn find_generic_parameter(
+        &self,
+        owner: &PBmmClass,
+        parameter: &str,
+    ) -> Option<&'a crate::bmm_persistence::p_bmm_generic_parameter::PBmmGenericParameter> {
+        let mut seen: BTreeSet<String> = BTreeSet::new();
+        let mut queue: Vec<String> = vec![owner.name().to_uppercase()];
+        while let Some(key) = queue.pop() {
+            if !seen.insert(key.clone()) {
+                continue;
+            }
+            let Some(entry) = self.classes.get(&key) else {
+                continue;
+            };
+            if let Some(found) = entry
+                .class
+                .generic_parameter_defs()
+                .and_then(|defs| defs.get(parameter))
+            {
+                return Some(found);
+            }
+            for parent in ancestor_names(entry.class) {
+                queue.push(parent.to_uppercase());
+            }
+        }
+        None
+    }
+
+    /// Builds a `BMM_GENERIC_TYPE`.
+    ///
+    /// `BMM_GENERIC_TYPE.base_class` is a `BMM_GENERIC_CLASS`
+    /// (`org.openehr.lang.bmm.bmm_generic_type.adoc` §Attributes), so a
+    /// `root_type` naming a non-generic class is refused. The actual parameters
+    /// are the string list followed by the structural list, in that order —
+    /// "use `_generic_parameters_` for a list of string types; use
+    /// `_generic_parameter_defs_` for a list of complex type references"
+    /// (`master04-syntax.adoc` §Generic Classes).
+    fn build_generic_type(
+        &self,
+        context: &str,
+        generic: &PBmmGenericType,
+        owner: &PBmmClass,
+    ) -> Result<BmmGenericType, PBmmReadError> {
+        let entry = self.entry(context, &generic.root_type)?;
+        let BmmClass::BmmGenericClass(base_class) = self.build_class(entry, EmbedDepth::Stub)?
+        else {
+            return Err(PBmmReadError::NotAGenericClass {
+                context: context.to_owned(),
+                type_name: generic.root_type.clone(),
+            });
+        };
+        let mut generic_parameters: Vec<BmmType> = Vec::new();
+        for name in &generic.generic_parameters {
+            generic_parameters.push(self.build_named_type(context, name, owner)?);
+        }
+        for parameter in &generic.generic_parameter_defs {
+            generic_parameters.push(self.build_type(context, parameter, owner)?);
+        }
+        Ok(BmmGenericType {
+            documentation: None,
+            generic_parameters,
+            base_class,
+        })
+    }
+
+    /// Builds a `BMM_CONTAINER_TYPE`.
+    fn build_container_type(
+        &self,
+        context: &str,
+        container: &PBmmContainerType,
+        owner: &PBmmClass,
+    ) -> Result<BmmContainerType, PBmmReadError> {
+        match container {
+            PBmmContainerType::PBmmIndexedContainerType(indexed) => {
+                Ok(BmmContainerType::BmmIndexedContainerType(Box::new(
+                    self.build_indexed_container_type(context, indexed, owner)?,
+                )))
+            }
+            PBmmContainerType::PBmmContainerType(data) => {
+                Ok(BmmContainerType::BmmContainerType(BmmContainerTypeData {
+                    documentation: None,
+                    container_type: self.build_class(
+                        self.entry(context, &data.container_type)?,
+                        EmbedDepth::Stub,
+                    )?,
+                    base_type: Box::new(self.build_container_target(
+                        context,
+                        data.r#type.as_deref(),
+                        data.type_def.as_ref(),
+                        owner,
+                    )?),
+                }))
+            }
+        }
+    }
+
+    /// Builds a `BMM_INDEXED_CONTAINER_TYPE`.
+    ///
+    /// `BMM_INDEXED_CONTAINER_TYPE.index_type` is a `BMM_SIMPLE_TYPE` — "The key
+    /// (index) type of the container, e.g. `String` in
+    /// `Hash<String,EVENT_ACTION>`"
+    /// (`org.openehr.lang.bmm3.bmm_indexed_container_type.adoc` §Attributes).
+    fn build_indexed_container_type(
+        &self,
+        context: &str,
+        indexed: &crate::bmm_persistence::p_bmm_indexed_container_type::PBmmIndexedContainerType,
+        owner: &PBmmClass,
+    ) -> Result<BmmIndexedContainerType, PBmmReadError> {
+        Ok(BmmIndexedContainerType {
+            documentation: None,
+            container_type: self.build_class(
+                self.entry(context, &indexed.container_type)?,
+                EmbedDepth::Stub,
+            )?,
+            base_type: self.build_container_target(
+                context,
+                indexed.r#type.as_deref(),
+                indexed.type_def.as_ref(),
+                owner,
+            )?,
+            index_type: BmmSimpleType {
+                documentation: None,
+                base_class: self
+                    .build_class(self.entry(context, &indexed.index_type)?, EmbedDepth::Stub)?,
+            },
+        })
+    }
+
+    /// Builds a container's target type from its `type` name or nested
+    /// `type_def`.
+    fn build_container_target(
+        &self,
+        context: &str,
+        name: Option<&str>,
+        type_def: Option<&PBmmBaseType>,
+        owner: &PBmmClass,
+    ) -> Result<BmmType, PBmmReadError> {
+        match (type_def, name) {
+            (Some(nested), _) => self.build_base_type(context, nested, owner),
+            (None, Some(name)) => self.build_named_type(context, name, owner),
+            (None, None) => Err(PBmmReadError::ContainerTargetTypeMissing {
+                context: context.to_owned(),
+            }),
+        }
+    }
+
+    /// Builds the `BMM_PACKAGE` tree, keyed in upper case.
+    ///
+    /// `BMM_PACKAGE_CONTAINER.packages`: "Child packages; keys all in upper case
+    /// for guaranteed matching"
+    /// (`org.openehr.lang.bmm.bmm_package_container.adoc` §Attributes).
+    fn build_packages(
+        &self,
+        packages: &BTreeMap<String, PBmmPackage>,
+        prefix: &str,
+    ) -> Result<BTreeMap<String, BmmPackage>, PBmmReadError> {
+        let mut out = BTreeMap::new();
+        for package in packages.values() {
+            let path = qualify(prefix, &package.name);
+            let mut classes = Vec::new();
+            for class in &package.classes {
+                let entry = self.classes.get(&class.to_uppercase()).ok_or_else(|| {
+                    PBmmReadError::ClassNotDefined {
+                        package: package.name.clone(),
+                        class: class.clone(),
+                    }
+                })?;
+                classes.push(self.build_class(entry, EmbedDepth::Full)?);
+            }
+            let children = self.build_packages(&package.packages, &path)?;
+            out.insert(
+                package.name.to_uppercase(),
+                BmmPackage {
+                    documentation: package.documentation.clone(),
+                    packages: if children.is_empty() {
+                        None
+                    } else {
+                        Some(children)
+                    },
+                    name: package.name.clone(),
+                    classes,
+                },
+            );
+        }
+        Ok(out)
+    }
+}
+
+/// The `BMM_CLASS` attributes every concrete class form carries.
+struct ClassCore {
+    /// `BMM_MODEL_ELEMENT.documentation`.
+    documentation: Option<String>,
+    /// `BMM_CLASS.name`.
+    name: String,
+    /// `BMM_CLASS.ancestors`.
+    ancestors: Option<BTreeMap<String, BmmClass>>,
+    /// `BMM_CLASS.package`.
+    package: BmmPackage,
+    /// `BMM_CLASS.properties`.
+    properties: Option<BTreeMap<String, BmmProperty<BmmType>>>,
+    /// `BMM_CLASS.source_schema_id`.
+    source_schema_id: String,
+    /// `BMM_CLASS.immediate_descendants`.
+    immediate_descendants: Vec<String>,
+    /// `BMM_CLASS.is_abstract`.
+    is_abstract: bool,
+    /// `BMM_CLASS.is_primitive_type`.
+    is_primitive_type: bool,
+    /// `BMM_CLASS.is_override`.
+    is_override: bool,
+}
+
+/// Builds the `BMM_ENUMERATION` form matching the persisted enumeration kind.
+fn build_enumeration(core: ClassCore, persisted: &PBmmEnumeration) -> BmmEnumeration {
+    let item_names = persisted.item_names().to_vec();
+    let item_values = persisted.item_values().to_vec();
+    let underlying_type_name = persisted.underlying_type_name().to_owned();
+    match persisted {
+        PBmmEnumeration::PBmmEnumerationInteger(_) => {
+            BmmEnumeration::BmmEnumerationInteger(BmmEnumerationInteger {
+                documentation: core.documentation,
+                name: core.name,
+                ancestors: core.ancestors,
+                package: core.package,
+                properties: core.properties,
+                source_schema_id: core.source_schema_id,
+                immediate_descendants: core.immediate_descendants,
+                is_abstract: core.is_abstract,
+                is_primitive_type: core.is_primitive_type,
+                is_override: core.is_override,
+                item_names,
+                item_values,
+                underlying_type_name,
+            })
+        }
+        PBmmEnumeration::PBmmEnumerationString(_) => {
+            BmmEnumeration::BmmEnumerationString(BmmEnumerationString {
+                documentation: core.documentation,
+                name: core.name,
+                ancestors: core.ancestors,
+                package: core.package,
+                properties: core.properties,
+                source_schema_id: core.source_schema_id,
+                immediate_descendants: core.immediate_descendants,
+                is_abstract: core.is_abstract,
+                is_primitive_type: core.is_primitive_type,
+                is_override: core.is_override,
+                item_names,
+                item_values,
+                underlying_type_name,
+            })
+        }
+        PBmmEnumeration::PBmmEnumeration(_) => BmmEnumeration::BmmEnumeration(BmmEnumerationData {
+            documentation: core.documentation,
+            name: core.name,
+            ancestors: core.ancestors,
+            package: core.package,
+            properties: core.properties,
+            source_schema_id: core.source_schema_id,
+            immediate_descendants: core.immediate_descendants,
+            is_abstract: core.is_abstract,
+            is_primitive_type: core.is_primitive_type,
+            is_override: core.is_override,
+            item_names,
+            item_values,
+            underlying_type_name,
+        }),
+    }
+}
+
+/// Indexes which package lists each class, recursively; refuses a listed class
+/// the schema does not define.
+///
+/// `master04-syntax.adoc` §Package Definition, second NOTE: "only classes
+/// defined in the same schema can be referenced in the package section in that
+/// schema."
+fn index_packages(
+    packages: &BTreeMap<String, PBmmPackage>,
+    prefix: &str,
+    classes: &BTreeMap<String, ClassEntry<'_>>,
+    out: &mut BTreeMap<String, String>,
+) -> Result<(), PBmmReadError> {
+    for package in packages.values() {
+        let path = qualify(prefix, &package.name);
+        for class in &package.classes {
+            let key = class.to_uppercase();
+            if !classes.contains_key(&key) {
+                return Err(PBmmReadError::ClassNotDefined {
+                    package: package.name.clone(),
+                    class: class.clone(),
+                });
+            }
+            out.entry(key).or_insert_with(|| path.clone());
+        }
+        index_packages(&package.packages, &path, classes, out)?;
+    }
+    Ok(())
+}
+
+/// Joins a package name onto its parent path with the
+/// `BMM_DEFINITIONS.Package_name_delimiter` (`"."`,
+/// `org.openehr.lang.bmm.bmm_definitions.adoc` §Constants).
+fn qualify(prefix: &str, name: &str) -> String {
+    if prefix.is_empty() {
+        name.to_owned()
+    } else {
+        format!(
+            "{prefix}{}{name}",
+            crate::bmm3::bmm_definitions::BmmDefinitionsData::PACKAGE_NAME_DELIMITER
+        )
+    }
+}
+
+/// Every inheritance parent a persisted class names, from `ancestors` and from
+/// the `root_type` of each `ancestor_defs` entry.
+///
+/// NOTE (honest boundary): `BMM_CLASS.ancestors` is a `Hash<String, BMM_CLASS>`
+/// (`org.openehr.lang.bmm.bmm_class.adoc` §Attributes), i.e. a map of CLASSES,
+/// so the parameter substitution a generic ancestor states
+/// (`GENERIC_PARENT<T,SUPPLIER_B>`, `master04-syntax.adoc` §Inheritance) has no
+/// destination in the v2 BMM shape: only the root class is carried into the
+/// model, and the binding stays readable in the `P_BMM_CLASS.ancestor_defs` of
+/// the persisted schema.
+fn ancestor_names(class: &PBmmClass) -> Vec<String> {
+    let mut out: Vec<String> = class.ancestors().to_vec();
+    out.extend(
+        class
+            .ancestor_defs()
+            .iter()
+            .map(|def| def.root_type.clone()),
+    );
+    out
+}
+
+/// The error context naming one class property.
+fn property_context(class: &str, property: &str) -> String {
+    format!("class `{class}` property `{property}`")
+}
+
+/// The `Multiplicity_interval` form of a persisted `Interval<Integer>`
+/// cardinality.
+///
+/// `BMM_CONTAINER_PROPERTY.cardinality` is a `Multiplicity_interval`
+/// (`org.openehr.lang.bmm.bmm_container_property.adoc` §Attributes) — "An
+/// Interval of Integer, used to represent multiplicity, cardinality and
+/// optionality in models" (`BASE` `Multiplicity_interval`).
+fn multiplicity_of(interval: &Interval<i32>) -> MultiplicityInterval {
+    match interval {
+        Interval::PointInterval(PointInterval {
+            lower,
+            upper,
+            lower_unbounded,
+            upper_unbounded,
+            lower_included,
+            upper_included,
+        }) => MultiplicityInterval {
+            lower: *lower,
+            upper: *upper,
+            lower_unbounded: *lower_unbounded,
+            upper_unbounded: *upper_unbounded,
+            lower_included: *lower_included,
+            upper_included: *upper_included,
+        },
+        Interval::ProperInterval(ProperInterval::MultiplicityInterval(multiplicity)) => {
+            multiplicity.clone()
+        }
+        Interval::ProperInterval(ProperInterval::ProperInterval(proper)) => MultiplicityInterval {
+            lower: proper.lower,
+            upper: proper.upper,
+            lower_unbounded: proper.lower_unbounded,
+            upper_unbounded: proper.upper_unbounded,
+            lower_included: proper.lower_included,
+            upper_included: proper.upper_included,
+        },
+    }
+}

--- a/crates/openehr-lang/src/bmm_persistence/error.rs
+++ b/crates/openehr-lang/src/bmm_persistence/error.rs
@@ -1,0 +1,284 @@
+//! The typed failures of the P_BMM schema reader, include resolver and
+//! `BMM_MODEL` transform.
+//!
+//! Every variant is a discriminant a caller can branch on; the display text is
+//! never a decision input. Spec anchors are named per variant.
+
+/// A P_BMM schema could not be read, its inclusions could not be resolved, or
+/// the in-memory `BMM_MODEL` could not be materialised from it.
+///
+/// The three stages
+/// ([`crate::bmm_persistence::reader::read_schema`],
+/// [`crate::bmm_persistence::include_resolution::resolve_includes`],
+/// [`crate::bmm_persistence::create_model::create_bmm_model`]) share one error
+/// type because they are one pipeline: "A schema reading component has to
+/// resolve the schema inclusions and ultimately `BMM_*` object instantiations
+/// to obtain the in-memory form of the model"
+/// (`LANG/docs/bmm_persistence/master02-overview.adoc` §Conceptual Approach).
+///
+/// `path`-carrying variants name the ODIN location as a `/`-joined attribute
+/// path (`class_definitions/ELEMENT/properties/items/type_def`); `context`
+/// carrying variants name the model element being materialised.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum PBmmReadError {
+    /// The schema text is not well-formed ODIN.
+    #[error("the schema text is not valid ODIN: {0}")]
+    Odin(#[from] crate::odin::OdinError),
+
+    /// The ODIN document root is not the attribute object a schema file is:
+    /// "A schema file begins with the header (meta) items corresponding to the
+    /// persisted attributes of `P_BMM_SCHEMA`"
+    /// (`master04-syntax.adoc` §Serialisation Formats).
+    #[error("the schema text is not a P_BMM schema object (the ODIN root is {found})")]
+    NotASchemaObject {
+        /// The ODIN value kind found at the document root.
+        found: &'static str,
+    },
+
+    /// A mandatory (`1..1`) attribute of the block at `path` is absent.
+    #[error("{path}: mandatory attribute `{attribute}` is missing")]
+    MissingAttribute {
+        /// ODIN attribute path of the block.
+        path: String,
+        /// The absent attribute's name.
+        attribute: &'static str,
+    },
+
+    /// The block at `path` carries an attribute the P_BMM model does not
+    /// declare and this reader does not tolerate.
+    #[error("{path}: attribute `{attribute}` is not part of the P_BMM model")]
+    UnknownAttribute {
+        /// ODIN attribute path of the block.
+        path: String,
+        /// The undeclared attribute's name.
+        attribute: String,
+    },
+
+    /// The ODIN value at `path` has the wrong shape for its P_BMM attribute.
+    #[error("{path}: expected {expected}, found {found}")]
+    WrongValueShape {
+        /// ODIN attribute path of the value.
+        path: String,
+        /// What the P_BMM attribute's type admits.
+        expected: &'static str,
+        /// The ODIN value kind found.
+        found: &'static str,
+    },
+
+    /// An ODIN type marker at `path` names a class that is not one of the
+    /// declared attribute's subtypes.
+    #[error("{path}: ODIN type marker `({marker})` is not a {expected}")]
+    UnexpectedTypeMarker {
+        /// ODIN attribute path of the marked value.
+        path: String,
+        /// The marker as written.
+        marker: String,
+        /// The P_BMM class the slot declares.
+        expected: &'static str,
+    },
+
+    /// A polymorphic slot at `path` states no subtype and none can be inferred:
+    /// "Wherever a value may be one of several `P_BMM_*` subtypes … the
+    /// concrete subtype is always stated explicitly via a `_type`
+    /// discriminator" (`master04-syntax.adoc` §Serialisation Formats).
+    #[error("{path}: no ODIN type marker and no inferable {expected} subtype")]
+    MissingTypeMarker {
+        /// ODIN attribute path of the value.
+        path: String,
+        /// The P_BMM class the slot declares.
+        expected: &'static str,
+    },
+
+    /// A keyed block's ODIN key and its `name` attribute disagree — "make sure
+    /// that the ODIN 'keys' are the same as the 'name' attributes in each
+    /// block" (`master04-syntax.adoc` §Package Definition, third NOTE).
+    #[error("{path}: ODIN key `{key}` does not match the block's `name` attribute `{name}`")]
+    KeyNameMismatch {
+        /// ODIN attribute path of the block.
+        path: String,
+        /// The key as written.
+        key: String,
+        /// The `name` attribute as written.
+        name: String,
+    },
+
+    /// A nested package name is a path — "only top-level package ids can be
+    /// paths (i.e. contain the '.' character)"
+    /// (`master04-syntax.adoc` §Package Definition, first NOTE).
+    #[error(
+        "{path}: nested package name `{name}` is qualified; only a top-level package id may contain '.'"
+    )]
+    QualifiedNestedPackage {
+        /// ODIN attribute path of the package block.
+        path: String,
+        /// The qualified name as written.
+        name: String,
+    },
+
+    /// A `cardinality` interval is not an integer range — `P_BMM_CONTAINER_PROPERTY.cardinality`
+    /// "is expressed as a ODIN range" over the `Integer` multiplicity of
+    /// `Multiplicity_interval` (`master04-syntax.adoc` §Container Properties).
+    #[error("{path}: cardinality is not an integer ODIN range")]
+    UnsupportedCardinality {
+        /// ODIN attribute path of the `cardinality` attribute.
+        path: String,
+    },
+
+    /// A persisted `P_BMM_INTERFACE` appears where the schema's class list
+    /// admits only `P_BMM_CLASS`.
+    ///
+    /// `P_BMM_SCHEMA` declares `primitive_types`/`class_definitions` as
+    /// `List<P_BMM_CLASS>`
+    /// (`org.openehr.lang.bmm_persistence.p_bmm_schema.adoc` §Attributes) while
+    /// `P_BMM_INTERFACE` inherits `P_BMM_MODEL_ELEMENT`, not `P_BMM_CLASS`
+    /// (`…p_bmm_interface.adoc` §Inherit), so the pinned P_BMM model has no
+    /// slot for one; `master03-model.adoc` §Overview says only that the model
+    /// "can also represent pure interfaces via `P_BMM_INTERFACE`" and
+    /// `master04-syntax.adoc` never serialises one. The interface is refused
+    /// rather than silently dropped.
+    // TODO: reading a persisted P_BMM_INTERFACE needs a slot for it in
+    // P_BMM_SCHEMA (an `interfaces` attribute, or P_BMM_INTERFACE joining the
+    // P_BMM_CLASS subtype set) in the vendored BMM meta-model, plus an
+    // openehr-codegen regeneration; several vendored openEHR ODIN schemas
+    // (BASE 1.2.0/1.3.0, RM 1.0.2–1.2.0) already declare interfaces.
+    #[error(
+        "{path}: `{name}` is a P_BMM_INTERFACE; the schema's class list admits only P_BMM_CLASS"
+    )]
+    InterfaceInClassList {
+        /// ODIN attribute path of the interface block.
+        path: String,
+        /// The interface's name.
+        name: String,
+    },
+
+    /// A schema includes another that was not supplied to the resolver.
+    ///
+    /// `P_BMM_SCHEMA.merge` has precondition
+    /// `includes_to_process.has (included_schema.schema_id)`
+    /// (`…p_bmm_schema.adoc` §Functions); an include that cannot be located
+    /// leaves the inclusion unresolvable.
+    #[error("schema `{requester}` includes `{id}`, which was not supplied")]
+    MissingInclude {
+        /// `schema_id` of the including schema.
+        requester: String,
+        /// `BMM_INCLUDE_SPEC.id` of the missing schema.
+        id: String,
+    },
+
+    /// The inclusion graph is cyclic.
+    ///
+    /// NOTE: no openEHR spec governs this — our own design/extension. The
+    /// `P_BMM_SCHEMA` load states (`…p_bmm_schema.adoc` §Functions) describe a
+    /// terminating include-processing sequence but state no acyclicity rule, so
+    /// the resolver detects the cycle itself rather than recursing forever.
+    #[error("schema inclusion cycle: {chain}")]
+    IncludeCycle {
+        /// The cycle, as `a -> b -> a`.
+        chain: String,
+    },
+
+    /// Two supplied schemas render the same `schema_id`, so an include cannot
+    /// name one of them unambiguously (`BMM_SCHEMA_CORE.schema_id`,
+    /// `org.openehr.lang.bmm.bmm_schema_core.adoc` §Functions).
+    #[error("two supplied schemas share the schema id `{id}`")]
+    DuplicateSchemaId {
+        /// The shared id.
+        id: String,
+    },
+
+    /// A class names an inheritance parent no class in the schema defines.
+    ///
+    /// `BMM_CLASS.ancestors` is a map of `BMM_CLASS`
+    /// (`org.openehr.lang.bmm.bmm_class.adoc` §Attributes), so an unresolvable
+    /// parent cannot be materialised.
+    #[error("class `{class}` names ancestor `{ancestor}`, which no class in the schema defines")]
+    UnknownAncestor {
+        /// The inheriting class's name.
+        class: String,
+        /// The unresolvable parent's name.
+        ancestor: String,
+    },
+
+    /// A type reference names a class no class definition in the schema
+    /// declares.
+    ///
+    /// Every `BMM_TYPE` form roots in a `BMM_CLASS` (`BMM_SIMPLE_TYPE.base_class`,
+    /// `BMM_GENERIC_TYPE.base_class`, `BMM_CONTAINER_TYPE.container_type`), so
+    /// an unresolvable name cannot be materialised without inventing a class
+    /// the schema does not declare.
+    #[error("{context}: type `{type_name}` is not defined by any class in the schema")]
+    UnknownType {
+        /// The model element being materialised.
+        context: String,
+        /// The unresolvable type name.
+        type_name: String,
+    },
+
+    /// A class definition is in no package of the schema.
+    ///
+    /// `BMM_CLASS.package` is `1..1` ("Package this class belongs to",
+    /// `org.openehr.lang.bmm.bmm_class.adoc` §Attributes), so a class listed in
+    /// no package cannot be materialised.
+    #[error("class `{class}` is not listed in any package of the schema")]
+    ClassNotInAnyPackage {
+        /// The orphaned class's name.
+        class: String,
+    },
+
+    /// A package lists a class the schema does not define — "only classes
+    /// defined in the same schema can be referenced in the package section in
+    /// that schema" (`master04-syntax.adoc` §Package Definition, second NOTE).
+    #[error("package `{package}` lists class `{class}`, which the schema does not define")]
+    ClassNotDefined {
+        /// The listing package's name.
+        package: String,
+        /// The undefined class name.
+        class: String,
+    },
+
+    /// A container type states neither `type` nor `type_def`, so it has no
+    /// target type — `BMM_CONTAINER_TYPE.base_type` is `1..1`
+    /// (`org.openehr.lang.bmm.bmm_container_type.adoc` §Attributes).
+    #[error("{context}: the container type states no target type")]
+    ContainerTargetTypeMissing {
+        /// The model element being materialised.
+        context: String,
+    },
+
+    /// A property or function result states no type at all, so its `BMM_TYPE`
+    /// cannot be materialised (`BMM_PROPERTY.type` is `1..1`,
+    /// `org.openehr.lang.bmm.bmm_property.adoc` §Attributes).
+    #[error("{context}: no type is stated")]
+    TypeDefinitionMissing {
+        /// The model element being materialised.
+        context: String,
+    },
+
+    /// A `P_BMM_SINGLE_PROPERTY_OPEN` names a generic parameter the owning
+    /// class does not declare — "The parameter must be in the type declaration
+    /// of the owning `BMM_CLASS`" (`org.openehr.lang.bmm.bmm_open_type.adoc`
+    /// §Description).
+    #[error(
+        "class `{class}` property `{property}` is of open type `{parameter}`, which is not a generic parameter of the class or of any ancestor"
+    )]
+    UndeclaredGenericParameter {
+        /// The owning class's name.
+        class: String,
+        /// The property's name.
+        property: String,
+        /// The undeclared parameter name.
+        parameter: String,
+    },
+
+    /// A generic type's root class is not generic — `BMM_GENERIC_TYPE.base_class`
+    /// is a `BMM_GENERIC_CLASS` (`org.openehr.lang.bmm.bmm_generic_type.adoc`
+    /// §Attributes).
+    #[error("{context}: `{type_name}` is not a generic class")]
+    NotAGenericClass {
+        /// The model element being materialised.
+        context: String,
+        /// The non-generic root type's name.
+        type_name: String,
+    },
+}

--- a/crates/openehr-lang/src/bmm_persistence/include_resolution.rs
+++ b/crates/openehr-lang/src/bmm_persistence/include_resolution.rs
@@ -1,0 +1,413 @@
+//! Schema inclusion resolution: one `P_BMM_SCHEMA` plus the schemas it includes
+//! (transitively) merged into a single self-contained schema.
+//!
+//! "`.bmm` files function as schemas that support schema inclusion and therefore
+//! re-use, in a similar manner to the XML schema languages. Thus, a single
+//! logical BMM model can be expressed as a _number_ of `.bmm` schema files which
+//! are actually `P_BMM_*` object serialisations of parts of the BMM model. A
+//! schema reading component has to resolve the schema inclusions and ultimately
+//! `BMM_*` object instantiations to obtain the in-memory form of the model"
+//! (`LANG/docs/bmm_persistence/master02-overview.adoc` §Conceptual Approach).
+//!
+//! The merge itself is `P_BMM_SCHEMA.merge (other)` with precondition
+//! `includes_to_process.has (included_schema.schema_id)`, and
+//! `P_BMM_PACKAGE.merge (other)` — "Merge packages and classes from other (from
+//! an included `P_BMM_SCHEMA`) into this package"
+//! (`LANG/docs/UML/classes/org.openehr.lang.bmm_persistence.p_bmm_schema.adoc`
+//! + `…p_bmm_package.adoc` §Functions).
+//!
+//! **Precedence: the includer wins.** That is exactly what
+//! `P_BMM_CLASS.is_override` records — "True if this class definition overrides
+//! one found in an included schema" (`…p_bmm_class.adoc` §Attributes) — so a
+//! class name defined by both the including and an included schema keeps the
+//! including schema's definition, and that definition is marked
+//! `is_override = True`.
+
+use std::collections::BTreeMap;
+
+use crate::bmm_persistence::error::PBmmReadError;
+use crate::bmm_persistence::p_bmm_class::PBmmClass;
+use crate::bmm_persistence::p_bmm_package::PBmmPackage;
+use crate::bmm_persistence::p_bmm_schema::PBmmSchema;
+
+/// Resolve `root`'s inclusions against `loaded`, returning one self-contained
+/// schema.
+///
+/// `loaded` supplies every schema that may be included. Its map KEY is only a
+/// caller-side label: resolution indexes each value by its own
+/// [`PBmmSchema::schema_id`], which renders lower-cased, and matches a
+/// `BMM_INCLUDE_SPEC.id` against it lower-cased too — the vendored schemas write
+/// include ids in either case. Resolution is transitive (an included schema's own
+/// includes are resolved first) and cycle-safe.
+///
+/// The returned schema keeps `root`'s header attributes and its `includes`
+/// record verbatim: `includes` is a persisted attribute stating what the root
+/// schema declares, not a work list to be consumed.
+///
+/// # Errors
+/// Returns [`PBmmReadError::MissingInclude`] when a declared include is not in
+/// `loaded`, [`PBmmReadError::IncludeCycle`] when the inclusion graph is cyclic,
+/// and [`PBmmReadError::DuplicateSchemaId`] when two entries of `loaded` render
+/// the same schema id.
+pub fn resolve_includes(
+    root: PBmmSchema,
+    loaded: &BTreeMap<String, PBmmSchema>,
+) -> Result<PBmmSchema, PBmmReadError> {
+    let mut by_id: BTreeMap<String, &PBmmSchema> = BTreeMap::new();
+    for schema in loaded.values() {
+        let id = schema.schema_id();
+        if by_id.insert(id.clone(), schema).is_some() {
+            return Err(PBmmReadError::DuplicateSchemaId { id });
+        }
+    }
+    let mut chain: Vec<String> = Vec::new();
+    resolve(root, &by_id, &mut chain)
+}
+
+/// Resolves one schema's inclusions, with `chain` as the active inclusion stack.
+fn resolve(
+    schema: PBmmSchema,
+    by_id: &BTreeMap<String, &PBmmSchema>,
+    chain: &mut Vec<String>,
+) -> Result<PBmmSchema, PBmmReadError> {
+    let id = schema.schema_id();
+    if chain.contains(&id) {
+        let mut cycle = chain.clone();
+        cycle.push(id);
+        return Err(PBmmReadError::IncludeCycle {
+            chain: cycle.join(" -> "),
+        });
+    }
+    chain.push(id.clone());
+    let mut merged = schema;
+    // BTreeMap key order — deterministic, so a name collision between two
+    // included schemas always resolves the same way.
+    let include_ids: Vec<String> = merged
+        .includes
+        .iter()
+        .flat_map(BTreeMap::values)
+        .map(|spec| spec.id.clone())
+        .collect();
+    for include_id in include_ids {
+        let key = include_id.to_lowercase();
+        let Some(included) = by_id.get(&key) else {
+            return Err(PBmmReadError::MissingInclude {
+                requester: id.clone(),
+                id: include_id,
+            });
+        };
+        let included = resolve((*included).clone(), by_id, chain)?;
+        absorb(&mut merged, included);
+    }
+    chain.pop();
+    Ok(merged)
+}
+
+/// Merges `included` into `includer`, with `includer` winning every collision.
+fn absorb(target: &mut PBmmSchema, source: PBmmSchema) {
+    absorb_classes(target, source.primitive_types, ClassList::Primitive);
+    absorb_classes(target, source.class_definitions, ClassList::Definitions);
+    merge_packages(&mut target.packages, source.packages);
+}
+
+/// Which of the schema's two class lists an included class joins.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClassList {
+    /// `P_BMM_SCHEMA.primitive_types`.
+    Primitive,
+    /// `P_BMM_SCHEMA.class_definitions`.
+    Definitions,
+}
+
+/// Appends every class of `incoming` the includer does not already define.
+///
+/// A class name is looked up across BOTH of the includer's lists, because
+/// `master04-syntax.adoc` §Classes for Primitive Types says primitive types
+/// "are just normal class definitions within a `primitive_types` block …
+/// otherwise are processed in the same way as types defined in the main
+/// `class_definitions` group" — so one name means one class regardless of which
+/// list holds it. The surviving (including) definition is marked
+/// `is_override = True`.
+fn absorb_classes(includer: &mut PBmmSchema, incoming: Vec<PBmmClass>, list: ClassList) {
+    for class in incoming {
+        let name = class.name().to_owned();
+        if let Some(existing) = find_class_mut(includer, &name) {
+            existing.set_is_override(true);
+            continue;
+        }
+        match list {
+            ClassList::Primitive => includer.primitive_types.push(class),
+            ClassList::Definitions => includer.class_definitions.push(class),
+        }
+    }
+}
+
+/// The schema's own definition of `name`, in either class list.
+fn find_class_mut<'a>(schema: &'a mut PBmmSchema, name: &str) -> Option<&'a mut PBmmClass> {
+    schema
+        .primitive_types
+        .iter_mut()
+        .chain(schema.class_definitions.iter_mut())
+        .find(|class| class.name() == name)
+}
+
+/// Merges an included package tree into the includer's, recursively.
+///
+/// `P_BMM_PACKAGE.merge`: "Merge packages and classes from other (from an
+/// included `P_BMM_SCHEMA`) into this package" (class doc §Functions). A package
+/// the includer does not declare is taken whole; a package both declare keeps the
+/// includer's `name`/`documentation` and gains the included package's classes
+/// (in included order, after the includer's own) and child packages.
+fn merge_packages(
+    target: &mut BTreeMap<String, PBmmPackage>,
+    source: BTreeMap<String, PBmmPackage>,
+) {
+    for (key, package) in source {
+        match target.get_mut(&key) {
+            None => {
+                target.insert(key, package);
+            }
+            Some(existing) => {
+                for class in package.classes {
+                    if !existing.classes.contains(&class) {
+                        existing.classes.push(class);
+                    }
+                }
+                merge_packages(&mut existing.packages, package.packages);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![expect(
+        clippy::panic_in_result_fn,
+        reason = "the Book ch11 test shape: `?` propagates the read/resolve/model plumbing while the assertions ARE the test — an assertion panic is how these tests fail"
+    )]
+    use std::collections::BTreeMap;
+    use std::fmt::Write;
+
+    use crate::bmm_persistence::error::PBmmReadError;
+    use crate::bmm_persistence::include_resolution::resolve_includes;
+    use crate::bmm_persistence::p_bmm_class::PBmmClass;
+    use crate::bmm_persistence::p_bmm_schema::PBmmSchema;
+    use crate::bmm_persistence::reader::read_schema;
+
+    /// Reads one schema fixture.
+    fn read(src: &str) -> PBmmSchema {
+        read_schema(src).expect("the fixture reads")
+    }
+
+    /// The supplied-schemas map, keyed by each schema's own id.
+    fn loaded(schemas: Vec<PBmmSchema>) -> BTreeMap<String, PBmmSchema> {
+        schemas
+            .into_iter()
+            .map(|schema| (schema.schema_id(), schema))
+            .collect()
+    }
+
+    /// A schema named `name` defining `classes`, including `includes`.
+    fn schema_src(name: &str, includes: &[&str], classes: &[(&str, &str)]) -> String {
+        let mut src = format!(
+            r#"
+            bmm_version = <"2.4">
+            rm_publisher = <"openehr">
+            schema_name = <"{name}">
+            rm_release = <"1.0.2">
+        "#
+        );
+        if !includes.is_empty() {
+            src.push_str("includes = <\n");
+            for (index, id) in includes.iter().enumerate() {
+                let key = index + 1;
+                let _ = writeln!(src, "[\"{key}\"] = < id = <\"{id}\"> >");
+            }
+            src.push_str(">\n");
+        }
+        let names: Vec<String> = classes
+            .iter()
+            .map(|(class, _)| format!("\"{class}\""))
+            .collect();
+        let _ = writeln!(
+            src,
+            "packages = <\n[\"org.openehr.{name}\"] = <\nname = <\"org.openehr.{name}\">\nclasses = <{}>\n>\n>",
+            names.join(", ")
+        );
+        src.push_str("class_definitions = <\n");
+        for (class, documentation) in classes {
+            let _ = writeln!(
+                src,
+                "[\"{class}\"] = < name = <\"{class}\"> documentation = <\"{documentation}\"> >"
+            );
+        }
+        src.push_str(">\n");
+        src
+    }
+
+    #[test]
+    fn inclusion_is_transitive() -> Result<(), PBmmReadError> {
+        let leaf = read(&schema_src("primitive_types", &[], &[("Any", "leaf")]));
+        let middle = read(&schema_src(
+            "basic_types",
+            &["openehr_primitive_types_1.0.2"],
+            &[("DV_TEXT", "middle")],
+        ));
+        let root = read(&schema_src(
+            "structures",
+            &["openehr_basic_types_1.0.2"],
+            &[("ELEMENT", "root")],
+        ));
+        let merged = resolve_includes(root, &loaded(vec![leaf, middle]))?;
+        let mut names: Vec<&str> = merged
+            .class_definitions
+            .iter()
+            .map(PBmmClass::name)
+            .collect();
+        names.sort_unstable();
+        assert_eq!(names, ["Any", "DV_TEXT", "ELEMENT"]);
+        // The merged schema keeps the root's own identity and include record.
+        assert_eq!(merged.schema_id(), "openehr_structures_1.0.2");
+        assert_eq!(merged.includes.as_ref().map(BTreeMap::len), Some(1));
+        Ok(())
+    }
+
+    #[test]
+    fn the_includer_wins_a_name_collision_and_is_marked_as_an_override() -> Result<(), PBmmReadError>
+    {
+        let included = read(&schema_src(
+            "primitive_types",
+            &[],
+            &[("Any", "from the included schema")],
+        ));
+        let root = read(&schema_src(
+            "structures",
+            &["openehr_primitive_types_1.0.2"],
+            &[("Any", "from the including schema")],
+        ));
+        let merged = resolve_includes(root, &loaded(vec![included]))?;
+        assert_eq!(merged.class_definitions.len(), 1);
+        let class = merged
+            .class_definitions
+            .first()
+            .expect("the surviving definition");
+        assert_eq!(class.documentation(), Some("from the including schema"));
+        assert!(class.is_override());
+        Ok(())
+    }
+
+    #[test]
+    fn every_class_keeps_the_schema_id_that_defined_it() -> Result<(), PBmmReadError> {
+        let included = read(&schema_src("primitive_types", &[], &[("Any", "leaf")]));
+        let root = read(&schema_src(
+            "structures",
+            &["openehr_primitive_types_1.0.2"],
+            &[("ELEMENT", "root")],
+        ));
+        let merged = resolve_includes(root, &loaded(vec![included]))?;
+        let sources: BTreeMap<&str, &str> = merged
+            .class_definitions
+            .iter()
+            .map(|class| (class.name(), class.source_schema_id()))
+            .collect();
+        assert_eq!(
+            sources.get("Any").copied(),
+            Some("openehr_primitive_types_1.0.2")
+        );
+        assert_eq!(
+            sources.get("ELEMENT").copied(),
+            Some("openehr_structures_1.0.2")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn packages_merge_recursively() -> Result<(), PBmmReadError> {
+        let included = read(
+            r#"
+            bmm_version = <"2.4">
+            rm_publisher = <"openehr">
+            schema_name = <"leaf">
+            rm_release = <"1.0.2">
+            packages = <
+                ["org.openehr.rm"] = <
+                    name = <"org.openehr.rm">
+                    classes = <"Any">
+                    packages = <
+                        ["support"] = <
+                            name = <"support">
+                            classes = <"TERMINOLOGY_ID">
+                        >
+                    >
+                >
+            >
+            class_definitions = <
+                ["Any"] = < name = <"Any"> >
+                ["TERMINOLOGY_ID"] = < name = <"TERMINOLOGY_ID"> >
+            >
+        "#,
+        );
+        let root = read(
+            r#"
+            bmm_version = <"2.4">
+            rm_publisher = <"openehr">
+            schema_name = <"root">
+            rm_release = <"1.0.2">
+            includes = <
+                ["1"] = < id = <"openehr_leaf_1.0.2"> >
+            >
+            packages = <
+                ["org.openehr.rm"] = <
+                    name = <"org.openehr.rm">
+                    classes = <"ELEMENT">
+                    packages = <
+                        ["composition"] = <
+                            name = <"composition">
+                            classes = <"COMPOSITION">
+                        >
+                    >
+                >
+            >
+            class_definitions = <
+                ["ELEMENT"] = < name = <"ELEMENT"> >
+                ["COMPOSITION"] = < name = <"COMPOSITION"> >
+            >
+        "#,
+        );
+        let merged = resolve_includes(root, &loaded(vec![included]))?;
+        let rm = merged
+            .packages
+            .get("org.openehr.rm")
+            .expect("the shared top-level package");
+        assert_eq!(rm.classes, ["ELEMENT".to_owned(), "Any".to_owned()]);
+        assert_eq!(rm.packages.len(), 2);
+        assert!(rm.packages.contains_key("composition"));
+        assert!(rm.packages.contains_key("support"));
+        Ok(())
+    }
+
+    #[test]
+    fn a_missing_include_is_refused() {
+        let root = read(&schema_src("structures", &["openehr_absent_9.9.9"], &[]));
+        let error = resolve_includes(root, &BTreeMap::new()).expect_err("the include is absent");
+        assert_eq!(
+            error,
+            PBmmReadError::MissingInclude {
+                requester: "openehr_structures_1.0.2".to_owned(),
+                id: "openehr_absent_9.9.9".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn an_inclusion_cycle_is_refused() {
+        let first = read(&schema_src("first", &["openehr_second_1.0.2"], &[]));
+        let second = read(&schema_src("second", &["openehr_first_1.0.2"], &[]));
+        let error = resolve_includes(first.clone(), &loaded(vec![first, second]))
+            .expect_err("the graph is cyclic");
+        assert!(
+            matches!(error, PBmmReadError::IncludeCycle { .. }),
+            "expected a cycle refusal, got {error:?}"
+        );
+    }
+}

--- a/crates/openehr-lang/src/bmm_persistence/loader.rs
+++ b/crates/openehr-lang/src/bmm_persistence/loader.rs
@@ -1,0 +1,409 @@
+//! The composed P_BMM load: ODIN schema text (plus the text of every schema it
+//! includes) → an in-memory `BMM_MODEL`.
+//!
+//! This is the whole of what `master02-overview.adoc` §Conceptual Approach asks a
+//! schema reader to do — "A schema reading component has to resolve the schema
+//! inclusions and ultimately `BMM_*` object instantiations to obtain the
+//! in-memory form of the model" — as one call over three stages:
+//! [`crate::bmm_persistence::reader::read_schema`] →
+//! [`crate::bmm_persistence::include_resolution::resolve_includes`] →
+//! [`crate::bmm_persistence::create_model::create_bmm_model`].
+//!
+//! It takes SOURCE TEXT, never paths: locating `.bmm` files on disk is a
+//! repository concern, not a schema-reading one, and keeping it out of this
+//! module keeps the whole pipeline testable from string literals.
+
+use std::collections::BTreeMap;
+
+use crate::bmm_persistence::create_model::create_bmm_model;
+use crate::bmm_persistence::error::PBmmReadError;
+use crate::bmm_persistence::include_resolution::resolve_includes;
+use crate::bmm_persistence::p_bmm_schema::PBmmSchema;
+use crate::bmm_persistence::reader::read_schema;
+use crate::bmm3::core::model::bmm_model::BmmModel;
+
+/// Load the `BMM_MODEL` of `root_src`, resolving its inclusions against
+/// `includes`.
+///
+/// `includes` maps a caller-side label (conventionally the schema id) to that
+/// schema's ODIN text. Resolution keys on each parsed schema's OWN
+/// [`PBmmSchema::schema_id`], so a mislabelled entry still resolves correctly
+/// and a duplicate id is refused rather than silently shadowed. Supplying more
+/// schemas than `root_src` needs is harmless; the unused ones are read (and so
+/// validated) but not merged.
+///
+/// # Errors
+/// Returns any [`PBmmReadError`] the three stages raise: an ODIN or schema-shape
+/// failure while reading `root_src` or any entry of `includes`, an unresolvable
+/// or cyclic inclusion, or an unresolvable symbolic reference while
+/// materialising the model.
+pub fn load_model(
+    root_src: &str,
+    includes: &BTreeMap<String, String>,
+) -> Result<BmmModel, PBmmReadError> {
+    let root = read_schema(root_src)?;
+    let mut loaded: BTreeMap<String, PBmmSchema> = BTreeMap::new();
+    for (label, src) in includes {
+        loaded.insert(label.clone(), read_schema(src)?);
+    }
+    let resolved = resolve_includes(root, &loaded)?;
+    create_bmm_model(&resolved)
+}
+
+#[cfg(test)]
+mod tests {
+    #![expect(
+        clippy::panic_in_result_fn,
+        reason = "the Book ch11 test shape: `?` propagates the read/resolve/model plumbing while the assertions ARE the test — an assertion panic is how these tests fail"
+    )]
+    use std::collections::BTreeMap;
+
+    use crate::bmm_persistence::error::PBmmReadError;
+    use crate::bmm_persistence::loader::load_model;
+    use crate::bmm3::core::entity::bmm_class::BmmClass;
+    use crate::bmm3::core::entity::range_constrained::bmm_enumeration::BmmEnumeration;
+    use crate::bmm3::core::feature::bmm_container_property::BmmContainerProperty;
+    use crate::bmm3::core::feature::bmm_property::BmmProperty;
+    use crate::bmm3::core::model::bmm_model::BmmModel;
+
+    /// A two-file schema set: `primitive_types` defining `Any`/`Ordered`/`String`
+    /// plus the generic `Interval`, and `rm` including it and defining
+    /// `DV_ORDERED` / `DV_QUANTITY` / `ITEM_TREE`.
+    const PRIMITIVE_TYPES: &str = r#"
+        bmm_version = <"2.4">
+        rm_publisher = <"openehr">
+        schema_name = <"primitive_types">
+        rm_release = <"1.0.2">
+        packages = <
+            ["org.openehr.rm.support.assumed_types"] = <
+                name = <"org.openehr.rm.support.assumed_types">
+                classes = <"Any", "Ordered", "String", "Real", "List", "Interval">
+            >
+        >
+        primitive_types = <
+            ["Any"] = <
+                name = <"Any">
+                is_abstract = <True>
+            >
+            ["Ordered"] = <
+                name = <"Ordered">
+                is_abstract = <True>
+                ancestors = <"Any", ...>
+            >
+            ["String"] = <
+                name = <"String">
+                ancestors = <"Any", ...>
+            >
+            ["Real"] = <
+                name = <"Real">
+                ancestors = <"Ordered", ...>
+            >
+            ["List"] = <
+                name = <"List">
+                ancestors = <"Any", ...>
+                generic_parameter_defs = <
+                    ["T"] = <
+                        name = <"T">
+                    >
+                >
+            >
+            ["Interval"] = <
+                name = <"Interval">
+                ancestors = <"Any", ...>
+                generic_parameter_defs = <
+                    ["T"] = <
+                        name = <"T">
+                        conforms_to_type = <"Ordered">
+                    >
+                >
+                properties = <
+                    ["lower"] = (P_BMM_SINGLE_PROPERTY_OPEN) <
+                        name = <"lower">
+                        type = <"T">
+                    >
+                >
+            >
+        >
+    "#;
+
+    const RM: &str = r#"
+        bmm_version = <"2.4">
+        rm_publisher = <"openehr">
+        schema_name = <"rm">
+        rm_release = <"1.0.2">
+        includes = <
+            ["1"] = <
+                id = <"openehr_primitive_types_1.0.2">
+            >
+        >
+        packages = <
+            ["org.openehr.rm.data_types"] = <
+                name = <"org.openehr.rm.data_types">
+                classes = <"DV_ORDERED", "DV_QUANTITY", "MAGNITUDE_STATUS">
+                packages = <
+                    ["item_structure"] = <
+                        name = <"item_structure">
+                        classes = <"ITEM_TREE">
+                    >
+                >
+            >
+        >
+        class_definitions = <
+            ["DV_ORDERED"] = <
+                name = <"DV_ORDERED">
+                ancestors = <"Any">
+                is_abstract = <True>
+                properties = <
+                    ["magnitude_status"] = (P_BMM_SINGLE_PROPERTY) <
+                        name = <"magnitude_status">
+                        type = <"MAGNITUDE_STATUS">
+                    >
+                >
+            >
+            ["DV_QUANTITY"] = <
+                name = <"DV_QUANTITY">
+                ancestors = <"DV_ORDERED">
+                properties = <
+                    ["magnitude"] = (P_BMM_SINGLE_PROPERTY) <
+                        name = <"magnitude">
+                        type = <"Real">
+                        is_mandatory = <True>
+                    >
+                    ["normal_range"] = (P_BMM_GENERIC_PROPERTY) <
+                        name = <"normal_range">
+                        type_def = <
+                            root_type = <"Interval">
+                            generic_parameters = <"DV_QUANTITY">
+                        >
+                    >
+                >
+            >
+            ["MAGNITUDE_STATUS"] = (P_BMM_ENUMERATION_STRING) <
+                name = <"MAGNITUDE_STATUS">
+                ancestors = <"String", ...>
+                item_names = <"le", "ge", "eq">
+                item_values = <"<=", ">=", "=">
+            >
+            ["ITEM_TREE"] = <
+                name = <"ITEM_TREE">
+                ancestors = <"Any">
+                properties = <
+                    ["items"] = (P_BMM_CONTAINER_PROPERTY) <
+                        name = <"items">
+                        type_def = <
+                            container_type = <"List">
+                            type = <"DV_QUANTITY">
+                        >
+                        cardinality = <|>=1|>
+                    >
+                >
+            >
+        >
+    "#;
+
+    /// The `RM` schema loaded over its include.
+    fn model() -> Result<BmmModel, PBmmReadError> {
+        let includes: BTreeMap<String, String> = [(
+            "openehr_primitive_types_1.0.2".to_owned(),
+            PRIMITIVE_TYPES.to_owned(),
+        )]
+        .into_iter()
+        .collect();
+        load_model(RM, &includes)
+    }
+
+    #[test]
+    fn the_loaded_model_carries_the_root_header_and_every_included_class()
+    -> Result<(), PBmmReadError> {
+        let model = model()?;
+        assert_eq!(model.schema_id(), "openehr_rm_1.0.2");
+        let mut names: Vec<&str> = model
+            .class_definitions
+            .iter()
+            .flatten()
+            .map(|(name, _)| name.as_str())
+            .collect();
+        names.sort_unstable();
+        assert_eq!(
+            names,
+            [
+                "Any",
+                "DV_ORDERED",
+                "DV_QUANTITY",
+                "ITEM_TREE",
+                "Interval",
+                "List",
+                "MAGNITUDE_STATUS",
+                "Ordered",
+                "Real",
+                "String",
+            ]
+        );
+        // The primitive_types list is carried into is_primitive_type.
+        let mut primitives = model.primitive_types();
+        primitives.sort_unstable();
+        assert_eq!(
+            primitives,
+            ["Any", "Interval", "List", "Ordered", "Real", "String"]
+        );
+        assert_eq!(model.enumeration_types(), ["MAGNITUDE_STATUS"]);
+        Ok(())
+    }
+
+    #[test]
+    fn a_generic_class_reports_its_type_signature() -> Result<(), PBmmReadError> {
+        let model = model()?;
+        let interval = model
+            .class_definition("Interval")
+            .expect("Interval is defined by the included schema");
+        assert_eq!(interval.type_name(), "Interval<T>");
+        assert_eq!(interval.type_signature(), "Interval<T:Ordered>");
+        assert!(matches!(interval, BmmClass::BmmGenericClass(_)));
+        Ok(())
+    }
+
+    #[test]
+    fn immediate_descendants_invert_the_ancestor_graph() -> Result<(), PBmmReadError> {
+        let model = model()?;
+        let ordered = model
+            .class_definition("DV_ORDERED")
+            .expect("DV_ORDERED is defined");
+        assert_eq!(ordered.immediate_descendants(), ["DV_QUANTITY"]);
+        let any = model.class_definition("Any").expect("Any is defined");
+        let mut descendants = any.immediate_descendants().to_vec();
+        descendants.sort_unstable();
+        assert_eq!(
+            descendants,
+            [
+                "DV_ORDERED".to_owned(),
+                "ITEM_TREE".to_owned(),
+                "Interval".to_owned(),
+                "List".to_owned(),
+                "Ordered".to_owned(),
+                "String".to_owned(),
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn property_definition_at_path_navigates_the_loaded_model() -> Result<(), PBmmReadError> {
+        let model = model()?;
+        // `ITEM_TREE.items` is List<DV_QUANTITY>; the container step navigates
+        // into the contained type, whose `magnitude` is inherited-free and whose
+        // `magnitude_status` comes from DV_ORDERED.
+        let magnitude = model
+            .property_definition_at_path("ITEM_TREE", "items/magnitude")
+            .expect("the nested property resolves through the contained type");
+        assert_eq!(magnitude.type_name(), "Real");
+        let status = model
+            .property_definition_at_path("ITEM_TREE", "items/magnitude_status")
+            .expect("the inherited property resolves too");
+        assert_eq!(status.type_name(), "MAGNITUDE_STATUS");
+        assert!(
+            model
+                .property_definition_at_path("ITEM_TREE", "items/absent")
+                .is_none()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn container_cardinality_and_type_map_onto_the_bmm_shapes() -> Result<(), PBmmReadError> {
+        let model = model()?;
+        let items = model
+            .property_definition("ITEM_TREE", "items")
+            .expect("ITEM_TREE declares items");
+        assert_eq!(items.type_name(), "List<DV_QUANTITY>");
+        assert_eq!(items.conformance_type_name(), "DV_QUANTITY");
+        // `|>=1|` maps onto a lower-bounded, upper-unbounded
+        // Multiplicity_interval (BMM_CONTAINER_PROPERTY.cardinality).
+        let BmmProperty::BmmContainerProperty(BmmContainerProperty::BmmContainerProperty(
+            container,
+        )) = items
+        else {
+            panic!("a (P_BMM_CONTAINER_PROPERTY) maps onto BMM_CONTAINER_PROPERTY");
+        };
+        let cardinality = container
+            .cardinality
+            .as_ref()
+            .expect("the property states a cardinality");
+        assert_eq!(cardinality.lower, Some(1));
+        assert!(cardinality.lower_included);
+        assert_eq!(cardinality.upper, None);
+        assert!(cardinality.upper_unbounded);
+        Ok(())
+    }
+
+    #[test]
+    fn a_generic_property_binds_its_actual_parameter() -> Result<(), PBmmReadError> {
+        let model = model()?;
+        let range = model
+            .property_definition("DV_QUANTITY", "normal_range")
+            .expect("DV_QUANTITY declares normal_range");
+        assert_eq!(range.type_name(), "Interval<DV_QUANTITY>");
+        Ok(())
+    }
+
+    #[test]
+    fn an_enumeration_maps_onto_the_string_enumeration_form() -> Result<(), PBmmReadError> {
+        let model = model()?;
+        let enumeration = model
+            .enumeration_definition("MAGNITUDE_STATUS")
+            .expect("MAGNITUDE_STATUS is an enumeration");
+        let BmmEnumeration::BmmEnumerationString(string) = enumeration else {
+            panic!("a (P_BMM_ENUMERATION_STRING) maps onto BMM_ENUMERATION_STRING");
+        };
+        assert_eq!(string.item_names, ["le", "ge", "eq"]);
+        assert_eq!(string.underlying_type_name, "STRING");
+        assert_eq!(string.item_values.len(), 3);
+        Ok(())
+    }
+
+    #[test]
+    fn a_class_carries_the_fully_qualified_path_of_its_package() -> Result<(), PBmmReadError> {
+        let model = model()?;
+        let item_tree = model
+            .class_definition("ITEM_TREE")
+            .expect("ITEM_TREE is defined");
+        assert_eq!(
+            item_tree.package_path(),
+            "org.openehr.rm.data_types.item_structure"
+        );
+        assert_eq!(
+            item_tree.class_path(),
+            "org.openehr.rm.data_types.item_structure.ITEM_TREE"
+        );
+        // The package TREE keeps each node's own name as written.
+        let nested = model
+            .package_at_path("org.openehr.rm.data_types.item_structure")
+            .expect("the nested package resolves from the model root");
+        assert_eq!(nested.name, "item_structure");
+        assert_eq!(nested.classes.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn an_open_property_resolves_its_formal_parameter() -> Result<(), PBmmReadError> {
+        let model = model()?;
+        let lower = model
+            .property_definition("Interval", "lower")
+            .expect("Interval declares lower");
+        assert_eq!(lower.type_name(), "T");
+        // BMM_OPEN_TYPE.conformance_type_name is the constrainer.
+        assert_eq!(lower.conformance_type_name(), "Ordered");
+        Ok(())
+    }
+
+    #[test]
+    fn a_missing_include_is_reported_from_the_composed_entry_point() {
+        let error = load_model(RM, &BTreeMap::new()).expect_err("the include is not supplied");
+        assert_eq!(
+            error,
+            PBmmReadError::MissingInclude {
+                requester: "openehr_rm_1.0.2".to_owned(),
+                id: "openehr_primitive_types_1.0.2".to_owned(),
+            }
+        );
+    }
+}

--- a/crates/openehr-lang/src/bmm_persistence/mod.rs
+++ b/crates/openehr-lang/src/bmm_persistence/mod.rs
@@ -33,3 +33,14 @@ pub mod p_bmm_single_function_parameter_open;
 pub mod p_bmm_single_property;
 pub mod p_bmm_single_property_open;
 pub mod p_bmm_type;
+
+// hand-written modules (spec behaviour), auto-declared:
+pub mod create_model;
+pub mod error;
+pub mod include_resolution;
+pub mod loader;
+pub mod p_bmm_class_impl;
+pub mod p_bmm_enumeration_impl;
+pub mod p_bmm_schema_impl;
+pub mod p_bmm_type_impl;
+pub mod reader;

--- a/crates/openehr-lang/src/bmm_persistence/p_bmm_class_impl.rs
+++ b/crates/openehr-lang/src/bmm_persistence/p_bmm_class_impl.rs
@@ -1,0 +1,260 @@
+//! Hand-written spec functions of `P_BMM_CLASS` — the declared `is_generic`
+//! predicate plus uniform access to the attributes every concrete
+//! `P_BMM_CLASS` leaf carries.
+//!
+//! Spec: `LANG/docs/UML/classes/org.openehr.lang.bmm_persistence.p_bmm_class.adoc`
+//! §Attributes (`name`, `ancestors`, `constants`, `properties`, `functions`,
+//! `invariants`, `is_abstract`, `is_override`, `generic_parameter_defs`,
+//! `source_schema_id`, `uid`, `ancestor_defs`) and §Functions (`is_generic`,
+//! whose postcondition is `Result := generic_parameter_defs /= Void`).
+//!
+//! `P_BMM_CLASS` is emitted as a polymorphic slot over its own least-rich form
+//! plus the `P_BMM_ENUMERATION` family, so every attribute read here reaches
+//! through both levels; the enumeration-specific attributes live in
+//! [`crate::bmm_persistence::p_bmm_enumeration_impl`].
+
+use std::collections::BTreeMap;
+
+use crate::bmm_persistence::p_bmm_class::PBmmClass;
+use crate::bmm_persistence::p_bmm_constant::PBmmConstant;
+use crate::bmm_persistence::p_bmm_enumeration::PBmmEnumeration;
+use crate::bmm_persistence::p_bmm_function::PBmmFunction;
+use crate::bmm_persistence::p_bmm_generic_parameter::PBmmGenericParameter;
+use crate::bmm_persistence::p_bmm_generic_type::PBmmGenericType;
+use crate::bmm_persistence::p_bmm_property::PBmmProperty;
+
+/// Borrows one `P_BMM_CLASS` attribute from whichever concrete leaf a
+/// [`PBmmClass`] holds.
+macro_rules! class_field {
+    ($value:expr, $field:ident) => {
+        match $value {
+            PBmmClass::PBmmEnumeration(PBmmEnumeration::PBmmEnumerationInteger(leaf)) => {
+                &leaf.$field
+            }
+            PBmmClass::PBmmEnumeration(PBmmEnumeration::PBmmEnumerationString(leaf)) => {
+                &leaf.$field
+            }
+            PBmmClass::PBmmEnumeration(PBmmEnumeration::PBmmEnumeration(leaf)) => &leaf.$field,
+            PBmmClass::PBmmClass(leaf) => &leaf.$field,
+        }
+    };
+}
+
+/// Mutably borrows one `P_BMM_CLASS` attribute from whichever concrete leaf a
+/// [`PBmmClass`] holds.
+macro_rules! class_field_mut {
+    ($value:expr, $field:ident) => {
+        match $value {
+            PBmmClass::PBmmEnumeration(PBmmEnumeration::PBmmEnumerationInteger(leaf)) => {
+                &mut leaf.$field
+            }
+            PBmmClass::PBmmEnumeration(PBmmEnumeration::PBmmEnumerationString(leaf)) => {
+                &mut leaf.$field
+            }
+            PBmmClass::PBmmEnumeration(PBmmEnumeration::PBmmEnumeration(leaf)) => &mut leaf.$field,
+            PBmmClass::PBmmClass(leaf) => &mut leaf.$field,
+        }
+    };
+}
+
+impl PBmmClass {
+    /// `P_BMM_CLASS.name`: "Name of the class" (class doc §Attributes).
+    #[must_use]
+    pub fn name(&self) -> &str {
+        class_field!(self, name).as_str()
+    }
+
+    /// `P_BMM_MODEL_ELEMENT.documentation`: "Optional documentation of this
+    /// element"
+    /// (`org.openehr.lang.bmm_persistence.p_bmm_model_element.adoc`
+    /// §Attributes).
+    #[must_use]
+    pub fn documentation(&self) -> Option<&str> {
+        class_field!(self, documentation).as_deref()
+    }
+
+    /// `P_BMM_CLASS.ancestors`: "List of immediate inheritance parents. If
+    /// there are generic ancestors, use `_ancestor_defs_` instead" (class doc
+    /// §Attributes).
+    #[must_use]
+    pub fn ancestors(&self) -> &[String] {
+        class_field!(self, ancestors).as_slice()
+    }
+
+    /// `P_BMM_CLASS.ancestor_defs`: "List of structured inheritance ancestors,
+    /// used only in the case of generic inheritance" (class doc §Attributes).
+    #[must_use]
+    pub fn ancestor_defs(&self) -> &[PBmmGenericType] {
+        class_field!(self, ancestor_defs).as_slice()
+    }
+
+    /// `P_BMM_CLASS.properties`: "List of attributes defined in this class",
+    /// keyed by property name (class doc §Attributes).
+    #[must_use]
+    pub fn properties(&self) -> Option<&BTreeMap<String, PBmmProperty>> {
+        class_field!(self, properties).as_ref()
+    }
+
+    /// `P_BMM_CLASS.functions`: "List of functions (routines) defined in this
+    /// class, keyed by name" (class doc §Attributes).
+    #[must_use]
+    pub fn functions(&self) -> Option<&BTreeMap<String, PBmmFunction>> {
+        class_field!(self, functions).as_ref()
+    }
+
+    /// `P_BMM_CLASS.constants`: "Constants defined in this class, keyed by
+    /// name" (class doc §Attributes).
+    #[must_use]
+    pub fn constants(&self) -> Option<&BTreeMap<String, PBmmConstant>> {
+        class_field!(self, constants).as_ref()
+    }
+
+    /// `P_BMM_CLASS.invariants`: "Invariants defined on this class, as a Hash
+    /// of assertion expressions keyed by tag" (class doc §Attributes).
+    #[must_use]
+    pub fn invariants(&self) -> Option<&BTreeMap<String, String>> {
+        class_field!(self, invariants).as_ref()
+    }
+
+    /// `P_BMM_CLASS.generic_parameter_defs`: "List of generic parameter
+    /// definitions" (class doc §Attributes).
+    #[must_use]
+    pub fn generic_parameter_defs(&self) -> Option<&BTreeMap<String, PBmmGenericParameter>> {
+        class_field!(self, generic_parameter_defs).as_ref()
+    }
+
+    /// `P_BMM_CLASS.is_abstract`: "True if this is an abstract type" (class doc
+    /// §Attributes) — a `0..1` flag, absent meaning not abstract.
+    #[must_use]
+    pub fn is_abstract(&self) -> bool {
+        class_field!(self, is_abstract).unwrap_or(false)
+    }
+
+    /// `P_BMM_CLASS.is_override`: "True if this class definition overrides one
+    /// found in an included schema" (class doc §Attributes) — a `0..1` flag,
+    /// absent meaning no override.
+    #[must_use]
+    pub fn is_override(&self) -> bool {
+        class_field!(self, is_override).unwrap_or(false)
+    }
+
+    /// Records that this class definition overrides one of the same name in an
+    /// included schema (`P_BMM_CLASS.is_override`, class doc §Attributes) —
+    /// set by [`crate::bmm_persistence::include_resolution::resolve_includes`]
+    /// when it detects the collision.
+    pub fn set_is_override(&mut self, value: bool) {
+        *class_field_mut!(self, is_override) = Some(value);
+    }
+
+    /// `P_BMM_CLASS.source_schema_id`: "Reference to original source schema
+    /// defining this class. Set during `BMM_SCHEMA` materialise" (class doc
+    /// §Attributes).
+    #[must_use]
+    pub fn source_schema_id(&self) -> &str {
+        class_field!(self, source_schema_id).as_str()
+    }
+
+    /// `P_BMM_CLASS.uid`: "Unique id generated for later comparison during
+    /// merging, in order to detect if two classes are the same. Assigned in
+    /// post-load processing" (class doc §Attributes).
+    #[must_use]
+    pub fn uid(&self) -> i32 {
+        *class_field!(self, uid)
+    }
+
+    /// `P_BMM_CLASS.is_generic`: "True if this class is a generic class", with
+    /// postcondition `Result := generic_parameter_defs /= Void` (class doc
+    /// §Functions).
+    ///
+    /// NOTE (adjudicated): the postcondition tests only for the presence of the
+    /// attribute, and an ODIN `generic_parameter_defs = <>` block reads as
+    /// present-but-empty; a class with no formal parameter is not a type
+    /// generator ("Generic classes are those that have one or more
+    /// substitutable generic type parameters",
+    /// `LANG/docs/bmm_persistence/master04-syntax.adoc` §Generic Classes), so
+    /// an empty map answers `False`.
+    #[must_use]
+    pub fn is_generic(&self) -> bool {
+        self.generic_parameter_defs()
+            .is_some_and(|parameters| !parameters.is_empty())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use crate::bmm_persistence::p_bmm_class::PBmmClass;
+    use crate::bmm_persistence::p_bmm_class::PBmmClassData;
+    use crate::bmm_persistence::p_bmm_generic_parameter::PBmmGenericParameter;
+
+    /// A bare class definition named `name`, with the given formal generic
+    /// parameter declarations.
+    fn class(
+        name: &str,
+        generic_parameter_defs: Option<BTreeMap<String, PBmmGenericParameter>>,
+    ) -> PBmmClass {
+        PBmmClass::PBmmClass(PBmmClassData {
+            documentation: None,
+            name: name.to_owned(),
+            ancestors: Vec::new(),
+            constants: None,
+            properties: None,
+            functions: None,
+            invariants: None,
+            is_abstract: None,
+            is_override: None,
+            generic_parameter_defs,
+            source_schema_id: "openehr_test_1.0.0".to_owned(),
+            bmm_class: None,
+            uid: 1,
+            ancestor_defs: Vec::new(),
+        })
+    }
+
+    /// The formal parameter `T` conforming to `Ordered`.
+    fn ordered_t() -> BTreeMap<String, PBmmGenericParameter> {
+        [(
+            "T".to_owned(),
+            PBmmGenericParameter {
+                documentation: None,
+                name: "T".to_owned(),
+                conforms_to_type: Some("Ordered".to_owned()),
+                bmm_generic_parameter: None,
+            },
+        )]
+        .into_iter()
+        .collect()
+    }
+
+    #[test]
+    fn absent_flags_read_as_false() {
+        let class = class("ELEMENT", None);
+        assert!(!class.is_abstract());
+        assert!(!class.is_override());
+        assert!(!class.is_generic());
+        assert_eq!(class.name(), "ELEMENT");
+        assert_eq!(class.source_schema_id(), "openehr_test_1.0.0");
+        assert_eq!(class.uid(), 1);
+        assert!(class.ancestors().is_empty());
+        assert!(class.ancestor_defs().is_empty());
+        assert!(class.properties().is_none());
+        assert!(class.functions().is_none());
+        assert!(class.constants().is_none());
+        assert!(class.invariants().is_none());
+        assert!(class.documentation().is_none());
+    }
+
+    #[test]
+    fn is_generic_needs_at_least_one_formal_parameter() {
+        assert!(!class("Interval", Some(BTreeMap::new())).is_generic());
+        assert!(class("Interval", Some(ordered_t())).is_generic());
+    }
+
+    #[test]
+    fn set_is_override_marks_the_including_definition() {
+        let mut class = class("DV_TEXT", None);
+        class.set_is_override(true);
+        assert!(class.is_override());
+    }
+}

--- a/crates/openehr-lang/src/bmm_persistence/p_bmm_enumeration_impl.rs
+++ b/crates/openehr-lang/src/bmm_persistence/p_bmm_enumeration_impl.rs
@@ -1,0 +1,167 @@
+//! Hand-written spec functions of `P_BMM_ENUMERATION` — uniform access to the
+//! enumeration item lists, plus the underlying-type name each concrete
+//! `BMM_ENUMERATION_*` form is based on.
+//!
+//! Spec:
+//! `LANG/docs/UML/classes/org.openehr.lang.bmm_persistence.p_bmm_enumeration.adoc`
+//! §Attributes (`item_names`, `item_values`, `item_documentations`) and
+//! `LANG/docs/bmm_persistence/master04-syntax.adoc` §Enumerated Types
+//! ("enumerated types are treated as constrained forms of standard types with
+//! open ranges, currently only `Integer` and `String`" — "just names
+//! (`_items_names_` meta-property) or both names and values (`_item_values_`
+//! meta-property) can be specified").
+
+use crate::bmm_persistence::p_bmm_enumeration::PBmmEnumeration;
+
+/// The underlying type name `BMM_ENUMERATION_INTEGER` redefines
+/// `underlying_type_name` to (`org.openehr.lang.bmm.bmm_enumeration_integer.adoc`
+/// §Attributes: `{default = "INTEGER"}`).
+pub const INTEGER_UNDERLYING_TYPE_NAME: &str = "INTEGER";
+
+/// The underlying type name `BMM_ENUMERATION_STRING` redefines
+/// `underlying_type_name` to (`org.openehr.lang.bmm.bmm_enumeration_string.adoc`
+/// §Attributes: `{default = "STRING"}`).
+pub const STRING_UNDERLYING_TYPE_NAME: &str = "STRING";
+
+/// The type an un-subtyped `BMM_ENUMERATION` is based on when the schema states
+/// no ancestor: "It is designed so that the default type is Integer"
+/// (`org.openehr.lang.bmm.bmm_enumeration.adoc` §Description).
+pub const DEFAULT_UNDERLYING_TYPE_NAME: &str = "Integer";
+
+/// Borrows one `P_BMM_ENUMERATION` attribute from whichever concrete leaf a
+/// [`PBmmEnumeration`] holds.
+macro_rules! enumeration_field {
+    ($value:expr, $field:ident) => {
+        match $value {
+            PBmmEnumeration::PBmmEnumerationInteger(leaf) => &leaf.$field,
+            PBmmEnumeration::PBmmEnumerationString(leaf) => &leaf.$field,
+            PBmmEnumeration::PBmmEnumeration(leaf) => &leaf.$field,
+        }
+    };
+}
+
+impl PBmmEnumeration {
+    /// `P_BMM_ENUMERATION.item_names` — "The list of names of the enumeration.
+    /// If no values are supplied, the integer values 0, 1, 2, ... are assumed"
+    /// (`org.openehr.lang.bmm.bmm_enumeration.adoc` §Attributes).
+    #[must_use]
+    pub fn item_names(&self) -> &[String] {
+        enumeration_field!(self, item_names).as_slice()
+    }
+
+    /// `P_BMM_ENUMERATION.item_values` — "Optional list of specific values.
+    /// Must be 1:1 with `item_names` list"
+    /// (`org.openehr.lang.bmm.bmm_enumeration.adoc` §Attributes).
+    #[must_use]
+    pub fn item_values(&self) -> &[serde_json::Value] {
+        enumeration_field!(self, item_values).as_slice()
+    }
+
+    /// `P_BMM_ENUMERATION.item_documentations`: "Optional documentation strings
+    /// for the enumeration items, in the same order as `_item_names_`" (class
+    /// doc §Attributes).
+    #[must_use]
+    pub fn item_documentations(&self) -> &[String] {
+        enumeration_field!(self, item_documentations).as_slice()
+    }
+
+    /// The `BMM_ENUMERATION.underlying_type_name` this persisted enumeration
+    /// materialises to: "Name of type any concrete BMM_ENUMERATION_* sub-type
+    /// is based on, i.e. the name of type bound to 'T' in a declared use of
+    /// this type" (`org.openehr.lang.bmm.bmm_enumeration.adoc` §Attributes).
+    ///
+    /// The two concrete forms redefine it to a constant
+    /// ([`INTEGER_UNDERLYING_TYPE_NAME`], [`STRING_UNDERLYING_TYPE_NAME`]).
+    ///
+    /// NOTE (adjudicated): for the un-subtyped `P_BMM_ENUMERATION` form the
+    /// class docs give no default, so the first declared ancestor is used —
+    /// `master04-syntax.adoc` §Enumerated Types writes every example as a
+    /// class whose `ancestors` names the underlying primitive
+    /// (`ancestors = <"Integer", ...>`, `ancestors = <"String", ...>`) — and
+    /// [`DEFAULT_UNDERLYING_TYPE_NAME`] when there is no ancestor either.
+    #[must_use]
+    pub fn underlying_type_name(&self) -> &str {
+        match self {
+            Self::PBmmEnumerationInteger(_) => INTEGER_UNDERLYING_TYPE_NAME,
+            Self::PBmmEnumerationString(_) => STRING_UNDERLYING_TYPE_NAME,
+            Self::PBmmEnumeration(leaf) => leaf
+                .ancestors
+                .first()
+                .map_or(DEFAULT_UNDERLYING_TYPE_NAME, String::as_str),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::bmm_persistence::p_bmm_enumeration::PBmmEnumeration;
+    use crate::bmm_persistence::p_bmm_enumeration::PBmmEnumerationData;
+    use crate::bmm_persistence::p_bmm_enumeration_integer::PBmmEnumerationInteger;
+
+    /// The `master04-syntax.adoc` §Enumerated Types `PROPORTION_KIND_2` example.
+    fn proportion_kind_2() -> PBmmEnumeration {
+        PBmmEnumeration::PBmmEnumerationInteger(PBmmEnumerationInteger {
+            documentation: None,
+            name: "PROPORTION_KIND_2".to_owned(),
+            ancestors: vec!["Integer".to_owned()],
+            constants: None,
+            properties: None,
+            functions: None,
+            invariants: None,
+            is_abstract: None,
+            is_override: None,
+            generic_parameter_defs: None,
+            source_schema_id: "openehr_test_1.0.0".to_owned(),
+            bmm_class: None,
+            uid: 1,
+            ancestor_defs: Vec::new(),
+            item_names: vec!["pk_ratio".to_owned(), "pk_unitary".to_owned()],
+            item_values: vec![
+                serde_json::Value::from(0),
+                serde_json::Value::from(1001_i64),
+            ],
+            item_documentations: Vec::new(),
+        })
+    }
+
+    #[test]
+    fn integer_enumeration_reports_its_redefined_underlying_type() {
+        let enumeration = proportion_kind_2();
+        assert_eq!(enumeration.underlying_type_name(), "INTEGER");
+        assert_eq!(enumeration.item_names().len(), 2);
+        assert_eq!(enumeration.item_values().len(), 2);
+        assert!(enumeration.item_documentations().is_empty());
+    }
+
+    #[test]
+    fn un_subtyped_enumeration_falls_back_to_its_first_ancestor_then_integer() {
+        let mut data = PBmmEnumerationData {
+            documentation: None,
+            name: "MAGNITUDE_STATUS".to_owned(),
+            ancestors: vec!["String".to_owned()],
+            constants: None,
+            properties: None,
+            functions: None,
+            invariants: None,
+            is_abstract: None,
+            is_override: None,
+            generic_parameter_defs: None,
+            source_schema_id: "openehr_test_1.0.0".to_owned(),
+            bmm_class: None,
+            uid: 1,
+            ancestor_defs: Vec::new(),
+            item_names: Vec::new(),
+            item_values: Vec::new(),
+            item_documentations: Vec::new(),
+        };
+        assert_eq!(
+            PBmmEnumeration::PBmmEnumeration(data.clone()).underlying_type_name(),
+            "String"
+        );
+        data.ancestors.clear();
+        assert_eq!(
+            PBmmEnumeration::PBmmEnumeration(data).underlying_type_name(),
+            "Integer"
+        );
+    }
+}

--- a/crates/openehr-lang/src/bmm_persistence/p_bmm_schema_impl.rs
+++ b/crates/openehr-lang/src/bmm_persistence/p_bmm_schema_impl.rs
@@ -1,0 +1,84 @@
+//! Hand-written spec functions of `P_BMM_SCHEMA` — the derived schema id it
+//! inherits from `BMM_SCHEMA_CORE`.
+//!
+//! Spec: `LANG/docs/UML/classes/org.openehr.lang.bmm_persistence.p_bmm_schema.adoc`
+//! §Inherit (`BMM_SCHEMA_CORE`) and
+//! `…org.openehr.lang.bmm.bmm_schema_core.adoc` §Functions (`schema_id`:
+//! "Derived name of schema, based on model publisher, model name, model
+//! release"), with the rendering pinned by
+//! `LANG/docs/bmm_persistence/master04-syntax.adoc` §Header Items
+//! ("schema_id computed as `<rm_publisher>_<schema_name>_<rm_release>`").
+
+use crate::bmm_persistence::p_bmm_schema::PBmmSchema;
+
+/// Renders a schema id from its three parts, lower-cased.
+///
+/// `LANG/docs/bmm_persistence/master04-syntax.adoc` §Header Items states the
+/// composition verbatim ("schema_id computed as
+/// `<rm_publisher>_<schema_name>_<rm_release>`"); the lower-casing is pinned by
+/// the v3 counterpart `org.openehr.lang.bmm3.bmm_model.adoc` §Functions
+/// (`model_id`: "Identifier of this model, lower-case, formed from:
+/// `<rm_publisher>_<model_name>_<rm_release>`. E.g. `"openehr_ehr_1.0.4"`"),
+/// the same adjudication
+/// [`crate::bmm3::core::model::bmm_model::BmmModel::schema_id`] records.
+pub(crate) fn compose_schema_id(rm_publisher: &str, schema_name: &str, rm_release: &str) -> String {
+    format!("{rm_publisher}_{schema_name}_{rm_release}").to_lowercase()
+}
+
+impl PBmmSchema {
+    /// `BMM_SCHEMA_CORE.schema_id`: "Derived name of schema, based on model
+    /// publisher, model name, model release"
+    /// (`org.openehr.lang.bmm.bmm_schema_core.adoc` §Functions).
+    ///
+    /// Rendered `<rm_publisher>_<schema_name>_<rm_release>`, lower-cased — the
+    /// form `master04-syntax.adoc` §Header Items states and the form the
+    /// `_includes_` blocks of the vendored `.bmm` schemas reference.
+    #[must_use]
+    pub fn schema_id(&self) -> String {
+        compose_schema_id(&self.rm_publisher, &self.schema_name, &self.rm_release)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use crate::bmm_persistence::p_bmm_schema::PBmmSchema;
+
+    /// A header-only schema with the three identifying parts set.
+    fn schema(rm_publisher: &str, schema_name: &str, rm_release: &str) -> PBmmSchema {
+        PBmmSchema {
+            packages: BTreeMap::new(),
+            rm_publisher: rm_publisher.to_owned(),
+            rm_release: rm_release.to_owned(),
+            schema_name: schema_name.to_owned(),
+            schema_revision: String::new(),
+            schema_lifecycle_state: String::new(),
+            schema_author: String::new(),
+            schema_description: String::new(),
+            schema_contributors: Vec::new(),
+            archetype_parent_class: None,
+            archetype_data_value_parent_class: None,
+            archetype_rm_closure_packages: Vec::new(),
+            archetype_visualise_descendants_of: None,
+            bmm_version: "2.4".to_owned(),
+            includes: None,
+            primitive_types: Vec::new(),
+            class_definitions: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn schema_id_is_the_lower_cased_publisher_name_release() {
+        assert_eq!(
+            schema("openehr", "primitive_types", "1.0.2").schema_id(),
+            "openehr_primitive_types_1.0.2"
+        );
+        // The CIMI schemas write the parts in upper case and reference each
+        // other by the lower-cased id (`tests/vendor/bmm/cimi/`).
+        assert_eq!(
+            schema("CIMI", "RM_CORE", "0.0.2").schema_id(),
+            "cimi_rm_core_0.0.2"
+        );
+    }
+}

--- a/crates/openehr-lang/src/bmm_persistence/p_bmm_type_impl.rs
+++ b/crates/openehr-lang/src/bmm_persistence/p_bmm_type_impl.rs
@@ -1,0 +1,237 @@
+//! Hand-written spec functions of the `P_BMM_TYPE` family — the declared
+//! `as_type_string` rendering.
+//!
+//! Spec:
+//! `LANG/docs/UML/classes/org.openehr.lang.bmm_persistence.p_bmm_type.adoc`
+//! §Functions (`as_type_string`: "Formal name of the type for display";
+//! "effected in descendants"), with each descendant's parts from its own class
+//! doc (`…p_bmm_simple_type.adoc` `type`, `…p_bmm_open_type.adoc` `type`,
+//! `…p_bmm_generic_type.adoc` `root_type` + `generic_parameters` +
+//! `generic_parameter_defs`, `…p_bmm_container_type.adoc` `container_type` +
+//! `type`/`type_def`, `…p_bmm_indexed_container_type.adoc` `index_type`) and
+//! the written forms of `LANG/docs/bmm_persistence/master04-syntax.adoc`
+//! §Generic Classes (`DV_INTERVAL<DV_QUANTITY>`, `List<Reference<Party>>`) and
+//! §Container Properties (`Hash <String, EVENT_ACTION>`).
+//!
+//! Generic delimiters `'<'`, `','`, `'>'` per
+//! `org.openehr.lang.bmm3.bmm_definitions.adoc` §Constants
+//! (`Generic_left_delimiter`, `Generic_separator`, `Generic_right_delimiter`) —
+//! the same literals [`crate::bmm3::core::entity::bmm_type_impl`] renders with,
+//! because the generated `BMM_DEFINITIONS` carries no constant for them.
+
+use crate::bmm_persistence::p_bmm_base_type::PBmmBaseType;
+use crate::bmm_persistence::p_bmm_container_type::PBmmContainerType;
+use crate::bmm_persistence::p_bmm_container_type::PBmmContainerTypeData;
+use crate::bmm_persistence::p_bmm_generic_type::PBmmGenericType;
+use crate::bmm_persistence::p_bmm_indexed_container_type::PBmmIndexedContainerType;
+use crate::bmm_persistence::p_bmm_open_type::PBmmOpenType;
+use crate::bmm_persistence::p_bmm_simple_type::PBmmSimpleType;
+use crate::bmm_persistence::p_bmm_type::PBmmType;
+
+/// The display form of a container's target type: its `type` name, else the
+/// nested `type_def`, else the empty string when the schema states neither
+/// (both are `0..1` on `P_BMM_CONTAINER_TYPE`).
+fn container_target(r#type: Option<&String>, type_def: Option<&PBmmBaseType>) -> String {
+    match (r#type, type_def) {
+        (Some(name), _) => name.clone(),
+        (None, Some(nested)) => nested.as_type_string(),
+        (None, None) => String::new(),
+    }
+}
+
+impl PBmmSimpleType {
+    /// `P_BMM_TYPE.as_type_string`: "Formal name of the type for display"
+    /// (`org.openehr.lang.bmm_persistence.p_bmm_type.adoc` §Functions) — for a
+    /// simple type the class name itself ("Name of type - must be a simple
+    /// class name", `…p_bmm_simple_type.adoc` §Attributes).
+    #[must_use]
+    pub fn as_type_string(&self) -> String {
+        self.r#type.clone()
+    }
+}
+
+impl PBmmOpenType {
+    /// `P_BMM_TYPE.as_type_string` for an open type: the generic parameter name,
+    /// "a single letter like 'T', 'G' etc"
+    /// (`…p_bmm_open_type.adoc` §Attributes).
+    #[must_use]
+    pub fn as_type_string(&self) -> String {
+        self.r#type.clone()
+    }
+}
+
+impl PBmmGenericType {
+    /// `P_BMM_TYPE.as_type_string` for a generic type: `root_type<p1,p2>`, the
+    /// form `master04-syntax.adoc` §Generic Classes writes
+    /// (`DV_INTERVAL<DV_QUANTITY>`).
+    ///
+    /// The string parameters (`generic_parameters`) come first, then the
+    /// structural ones (`generic_parameter_defs`) — the two lists are the
+    /// simple and complex halves of one parameter list ("use
+    /// `_generic_parameters_` for a list of string types; use
+    /// `_generic_parameter_defs_` for a list of complex type references",
+    /// §Generic Classes), and a schema uses one or the other, never both for
+    /// the same position.
+    #[must_use]
+    pub fn as_type_string(&self) -> String {
+        let mut parameters: Vec<String> = self.generic_parameters.clone();
+        parameters.extend(
+            self.generic_parameter_defs
+                .iter()
+                .map(PBmmType::as_type_string),
+        );
+        if parameters.is_empty() {
+            return self.root_type.clone();
+        }
+        let root = &self.root_type;
+        let joined = parameters.join(",");
+        format!("{root}<{joined}>")
+    }
+}
+
+impl PBmmContainerTypeData {
+    /// `P_BMM_TYPE.as_type_string` for a container type: `container_type<target>`,
+    /// the form `master04-syntax.adoc` §Container Properties writes
+    /// (`items: List<ITEM>`).
+    #[must_use]
+    pub fn as_type_string(&self) -> String {
+        let container = &self.container_type;
+        let target = container_target(self.r#type.as_ref(), self.type_def.as_ref());
+        format!("{container}<{target}>")
+    }
+}
+
+impl PBmmIndexedContainerType {
+    /// `P_BMM_TYPE.as_type_string` for an indexed container type:
+    /// `container_type<index_type,target>`, the form `master04-syntax.adoc`
+    /// §Container Properties writes (`custom_actions: Hash <String,
+    /// EVENT_ACTION>`).
+    #[must_use]
+    pub fn as_type_string(&self) -> String {
+        let container = &self.container_type;
+        let index = &self.index_type;
+        let target = container_target(self.r#type.as_ref(), self.type_def.as_ref());
+        format!("{container}<{index},{target}>")
+    }
+}
+
+impl PBmmContainerType {
+    /// `P_BMM_TYPE.as_type_string` dispatched over the `P_BMM_CONTAINER_TYPE`
+    /// forms.
+    #[must_use]
+    pub fn as_type_string(&self) -> String {
+        match self {
+            Self::PBmmIndexedContainerType(indexed) => indexed.as_type_string(),
+            Self::PBmmContainerType(data) => data.as_type_string(),
+        }
+    }
+}
+
+impl PBmmBaseType {
+    /// `P_BMM_TYPE.as_type_string` dispatched over the `P_BMM_BASE_TYPE` forms.
+    #[must_use]
+    pub fn as_type_string(&self) -> String {
+        match self {
+            Self::PBmmGenericType(generic) => generic.as_type_string(),
+            Self::PBmmOpenType(open) => open.as_type_string(),
+            Self::PBmmSimpleType(simple) => simple.as_type_string(),
+        }
+    }
+}
+
+impl PBmmType {
+    /// `P_BMM_TYPE.as_type_string`: "Formal name of the type for display"
+    /// (class doc §Functions), dispatched over every `P_BMM_TYPE` form.
+    #[must_use]
+    pub fn as_type_string(&self) -> String {
+        match self {
+            Self::PBmmContainerType(container) => container.as_type_string(),
+            Self::PBmmGenericType(generic) => generic.as_type_string(),
+            Self::PBmmOpenType(open) => open.as_type_string(),
+            Self::PBmmSimpleType(simple) => simple.as_type_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::bmm_persistence::p_bmm_base_type::PBmmBaseType;
+    use crate::bmm_persistence::p_bmm_container_type::PBmmContainerType;
+    use crate::bmm_persistence::p_bmm_container_type::PBmmContainerTypeData;
+    use crate::bmm_persistence::p_bmm_generic_type::PBmmGenericType;
+    use crate::bmm_persistence::p_bmm_indexed_container_type::PBmmIndexedContainerType;
+    use crate::bmm_persistence::p_bmm_simple_type::PBmmSimpleType;
+    use crate::bmm_persistence::p_bmm_type::PBmmType;
+
+    /// A `P_BMM_GENERIC_TYPE` over string parameters.
+    fn generic(root: &str, parameters: &[&str]) -> PBmmGenericType {
+        PBmmGenericType {
+            bmm_type: None,
+            value_constraint: None,
+            root_type: root.to_owned(),
+            generic_parameter_defs: Vec::new(),
+            generic_parameters: parameters.iter().map(|p| (*p).to_owned()).collect(),
+        }
+    }
+
+    #[test]
+    fn simple_and_generic_forms() {
+        let simple = PBmmSimpleType {
+            bmm_type: None,
+            value_constraint: None,
+            r#type: "DV_TEXT".to_owned(),
+        };
+        assert_eq!(simple.as_type_string(), "DV_TEXT");
+        assert_eq!(
+            generic("DV_INTERVAL", &["DV_QUANTITY"]).as_type_string(),
+            "DV_INTERVAL<DV_QUANTITY>"
+        );
+        // A root type with no stated parameters renders bare.
+        assert_eq!(generic("DV_INTERVAL", &[]).as_type_string(), "DV_INTERVAL");
+    }
+
+    #[test]
+    fn nested_container_of_generic_renders_the_master04_example() {
+        // master04-syntax.adoc §Generic Classes: `careProvider:
+        // List<Reference<Party>>`.
+        let nested = PBmmContainerType::PBmmContainerType(PBmmContainerTypeData {
+            bmm_type: None,
+            container_type: "List".to_owned(),
+            type_def: Some(PBmmBaseType::PBmmGenericType(generic(
+                "Reference",
+                &["Party"],
+            ))),
+            r#type: None,
+        });
+        assert_eq!(nested.as_type_string(), "List<Reference<Party>>");
+    }
+
+    #[test]
+    fn indexed_container_names_its_index_type() {
+        // master04-syntax.adoc §Container Properties: `custom_actions: Hash
+        // <String, EVENT_ACTION>`.
+        let indexed = PBmmIndexedContainerType {
+            bmm_type: None,
+            container_type: "Hash".to_owned(),
+            type_def: None,
+            r#type: Some("EVENT_ACTION".to_owned()),
+            index_type: "String".to_owned(),
+        };
+        assert_eq!(indexed.as_type_string(), "Hash<String,EVENT_ACTION>");
+    }
+
+    #[test]
+    fn mixed_generic_parameter_defs_render_after_the_string_parameters() {
+        // master04-syntax.adoc §Generic Classes CRAZY_TYPE shape, reduced: a
+        // structural parameter beside a string one.
+        let mut root = generic("REFERENCE_RANGE", &["Integer"]);
+        root.generic_parameter_defs = vec![PBmmType::PBmmGenericType(generic(
+            "DV_INTERVAL",
+            &["DV_QUANTITY"],
+        ))];
+        assert_eq!(
+            root.as_type_string(),
+            "REFERENCE_RANGE<Integer,DV_INTERVAL<DV_QUANTITY>>"
+        );
+    }
+}

--- a/crates/openehr-lang/src/bmm_persistence/reader.rs
+++ b/crates/openehr-lang/src/bmm_persistence/reader.rs
@@ -1,0 +1,2433 @@
+//! The P_BMM schema reader: ODIN `.bmm` text → a typed `P_BMM_SCHEMA` object
+//! graph.
+//!
+//! "A BMM schema is a serialisation of the `P_BMM_*` object graph … The ODIN
+//! form is described here. The structures are direct ODIN serialisations of the
+//! `P_BMM_XXX` classes in the `persistence` package"
+//! (`LANG/docs/bmm_persistence/master04-syntax.adoc` §Overview +
+//! §Serialisation Formats). This module implements exactly that reading: it
+//! parses the text with [`crate::odin::parse`] and walks the resulting value
+//! tree into the generated `P_BMM_*` types, attribute by attribute, per the
+//! class docs under
+//! `LANG/docs/UML/classes/org.openehr.lang.bmm_persistence.*.adoc`.
+//!
+//! It is the first of the three stages `master02-overview.adoc` §Conceptual
+//! Approach describes — "A schema reading component has to resolve the schema
+//! inclusions and ultimately `BMM_*` object instantiations to obtain the
+//! in-memory form of the model": read
+//! ([`read_schema`]) → resolve inclusions
+//! ([`crate::bmm_persistence::include_resolution::resolve_includes`]) →
+//! instantiate ([`crate::bmm_persistence::create_model::create_bmm_model`]).
+//!
+//! **Strict read.** An attribute the P_BMM class docs do not declare is a typed
+//! [`PBmmReadError::UnknownAttribute`], never silently dropped — with the two
+//! adjudicated tolerances [`TOLERATED_SCHEMA_ATTRIBUTES`] and
+//! [`TOLERATED_PROPERTY_ATTRIBUTES`], each carrying its reason.
+//!
+//! **In-memory-only attributes are not read.** `master03-model.adoc` §Overview:
+//! "attributes named `_bmm_xxx_` and of type `BMM_XXX` … are in-memory only
+//! references to reconstructed instances of `BMM_XXX` types" — so `bmm_class`,
+//! `bmm_property`, `bmm_type`, `bmm_generic_parameter` and
+//! `bmm_package_definition` are left `None` here and the reconstruction is
+//! [`crate::bmm_persistence::create_model`]'s job. Two further attributes are
+//! documented as set by processing rather than persisted and ARE stamped here,
+//! because their inputs are only available while reading the file:
+//! `P_BMM_CLASS.source_schema_id` ("Set during `BMM_SCHEMA` materialise") takes
+//! this schema's own [`crate::bmm_persistence::p_bmm_schema::PBmmSchema::schema_id`],
+//! and `P_BMM_CLASS.uid` ("Assigned in post-load processing") is numbered from
+//! 1 in document order over `primitive_types` then `class_definitions`.
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+
+use indexmap::IndexMap;
+use openehr_base::prelude::Interval;
+use openehr_base::prelude::ProperInterval;
+use openehr_base::prelude::ProperIntervalData;
+
+use crate::bmm_persistence::error::PBmmReadError;
+use crate::bmm_persistence::p_bmm_base_type::PBmmBaseType;
+use crate::bmm_persistence::p_bmm_class::PBmmClass;
+use crate::bmm_persistence::p_bmm_class::PBmmClassData;
+use crate::bmm_persistence::p_bmm_constant::PBmmConstant;
+use crate::bmm_persistence::p_bmm_container_function_parameter::PBmmContainerFunctionParameter;
+use crate::bmm_persistence::p_bmm_container_property::PBmmContainerProperty;
+use crate::bmm_persistence::p_bmm_container_property::PBmmContainerPropertyData;
+use crate::bmm_persistence::p_bmm_container_type::PBmmContainerType;
+use crate::bmm_persistence::p_bmm_container_type::PBmmContainerTypeData;
+use crate::bmm_persistence::p_bmm_enumeration::PBmmEnumeration;
+use crate::bmm_persistence::p_bmm_enumeration::PBmmEnumerationData;
+use crate::bmm_persistence::p_bmm_enumeration_integer::PBmmEnumerationInteger;
+use crate::bmm_persistence::p_bmm_enumeration_string::PBmmEnumerationString;
+use crate::bmm_persistence::p_bmm_function::PBmmFunction;
+use crate::bmm_persistence::p_bmm_function_parameter::PBmmFunctionParameter;
+use crate::bmm_persistence::p_bmm_generic_function_parameter::PBmmGenericFunctionParameter;
+use crate::bmm_persistence::p_bmm_generic_parameter::PBmmGenericParameter;
+use crate::bmm_persistence::p_bmm_generic_property::PBmmGenericProperty;
+use crate::bmm_persistence::p_bmm_generic_type::PBmmGenericType;
+use crate::bmm_persistence::p_bmm_indexed_container_property::PBmmIndexedContainerProperty;
+use crate::bmm_persistence::p_bmm_indexed_container_type::PBmmIndexedContainerType;
+use crate::bmm_persistence::p_bmm_open_type::PBmmOpenType;
+use crate::bmm_persistence::p_bmm_package::PBmmPackage;
+use crate::bmm_persistence::p_bmm_property::PBmmProperty;
+use crate::bmm_persistence::p_bmm_schema::PBmmSchema;
+use crate::bmm_persistence::p_bmm_schema_impl::compose_schema_id;
+use crate::bmm_persistence::p_bmm_simple_type::PBmmSimpleType;
+use crate::bmm_persistence::p_bmm_single_function_parameter::PBmmSingleFunctionParameter;
+use crate::bmm_persistence::p_bmm_single_function_parameter_open::PBmmSingleFunctionParameterOpen;
+use crate::bmm_persistence::p_bmm_single_property::PBmmSingleProperty;
+use crate::bmm_persistence::p_bmm_single_property_open::PBmmSinglePropertyOpen;
+use crate::bmm_persistence::p_bmm_type::PBmmType;
+use crate::bmm3::model_access::bmm_include_spec::BmmIncludeSpec;
+use crate::odin::OdinInterval;
+use crate::odin::OdinKey;
+use crate::odin::OdinValue;
+
+/// Schema-level attributes the pinned P_BMM model does not declare, accepted
+/// and discarded.
+///
+/// `model_name` is written by `master04-syntax.adoc` §Header Items itself
+/// (`model_name = <"TEST_PKG">`) and by the vendored openEHR `adltest` schema,
+/// but neither `P_BMM_SCHEMA` nor `BMM_SCHEMA_CORE` declares it
+/// (`org.openehr.lang.bmm_persistence.p_bmm_schema.adoc` +
+/// `…bmm.bmm_schema_core.adoc` §Attributes); it is the v3
+/// `BMM_MODEL.model_name` (`…bmm3.bmm_model.adoc` §Attributes), outside this
+/// generation. Refusing a form the syntax chapter writes would reject valid
+/// schema text, so it is tolerated.
+pub const TOLERATED_SCHEMA_ATTRIBUTES: &[&str] = &["model_name"];
+
+/// Property-level attributes the pinned P_BMM model does not declare, accepted
+/// and discarded.
+///
+/// `default` appears on `(P_BMM_SINGLE_PROPERTY)` blocks throughout the
+/// vendored openEHR BASE/RM/LANG/TERM ODIN schemas, but no attribute of
+/// `P_BMM_PROPERTY` or `P_BMM_SINGLE_PROPERTY` corresponds to it
+/// (`org.openehr.lang.bmm_persistence.p_bmm_property.adoc` +
+/// `…p_bmm_single_property.adoc` §Attributes) and `master04-syntax.adoc` never
+/// writes one. NOTE: no openEHR spec governs this attribute — accepting and
+/// discarding it is our own decision, taken so the published openEHR schemas
+/// read rather than being refused wholesale.
+pub const TOLERATED_PROPERTY_ATTRIBUTES: &[&str] = &["default"];
+
+/// Read a P_BMM schema from its ODIN serialisation.
+///
+/// The returned `P_BMM_SCHEMA` is the *unresolved* persisted form: its
+/// `includes` are recorded but not merged (that is
+/// [`crate::bmm_persistence::include_resolution::resolve_includes`]) and its
+/// `bmm_*` in-memory caches are `None` (that is
+/// [`crate::bmm_persistence::create_model::create_bmm_model`]).
+///
+/// # Errors
+/// Returns [`PBmmReadError::Odin`] when the text is not well-formed ODIN, and
+/// one of the schema-shape variants (missing/unknown attribute, wrong value
+/// shape, unexpected or missing type marker, key/name mismatch, qualified
+/// nested package, unsupported cardinality, persisted interface) when the ODIN
+/// tree does not match the P_BMM class model.
+pub fn read_schema(src: &str) -> Result<PBmmSchema, PBmmReadError> {
+    let root = crate::odin::parse(src)?;
+    let OdinValue::Object(members) = &root else {
+        return Err(PBmmReadError::NotASchemaObject {
+            found: kind_name(&root),
+        });
+    };
+    let mut block = Block::new(String::new(), members);
+
+    let bmm_version = block.required_string("bmm_version")?;
+    let rm_publisher = block.required_string("rm_publisher")?;
+    let schema_name = block.required_string("schema_name")?;
+    let rm_release = block.required_string("rm_release")?;
+    let schema_id = compose_schema_id(&rm_publisher, &schema_name, &rm_release);
+
+    let schema_revision = block.documentation_string("schema_revision")?;
+    let schema_lifecycle_state = block.documentation_string("schema_lifecycle_state")?;
+    let schema_author = block.documentation_string("schema_author")?;
+    let schema_description = block.documentation_string("schema_description")?;
+    let schema_contributors = block.string_list("schema_contributors")?;
+    let archetype_parent_class = block.optional_string("archetype_parent_class")?;
+    let archetype_data_value_parent_class =
+        block.optional_string("archetype_data_value_parent_class")?;
+    let archetype_rm_closure_packages = block.string_list("archetype_rm_closure_packages")?;
+    let archetype_visualise_descendants_of = block.visualise_descendants_of()?;
+
+    let includes = read_includes(&mut block)?;
+    let mut uid: i32 = 0;
+    let primitive_types = read_class_list(&mut block, "primitive_types", &schema_id, &mut uid)?;
+    let class_definitions = read_class_list(&mut block, "class_definitions", &schema_id, &mut uid)?;
+    let packages = read_packages(&mut block, "packages", PackageLevel::Top)?;
+    block.finish(TOLERATED_SCHEMA_ATTRIBUTES)?;
+
+    Ok(PBmmSchema {
+        packages,
+        rm_publisher,
+        rm_release,
+        schema_name,
+        schema_revision,
+        schema_lifecycle_state,
+        schema_author,
+        schema_description,
+        schema_contributors,
+        archetype_parent_class,
+        archetype_data_value_parent_class,
+        archetype_rm_closure_packages,
+        archetype_visualise_descendants_of,
+        bmm_version,
+        includes,
+        primitive_types,
+        class_definitions,
+    })
+}
+
+/// Whether a package block sits at the schema's top level, where "only
+/// top-level package ids can be paths"
+/// (`master04-syntax.adoc` §Package Definition, first NOTE).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PackageLevel {
+    /// A package declared directly under the schema's `packages` attribute.
+    Top,
+    /// A package declared under another package's `packages` attribute.
+    Nested,
+}
+
+/// The ODIN value kind, for error text.
+fn kind_name(value: &OdinValue) -> &'static str {
+    match value {
+        OdinValue::Object(_) => "an attribute object",
+        OdinValue::KeyedList(_) => "a keyed list",
+        OdinValue::List(_) => "a list",
+        OdinValue::Typed { .. } => "a type-marked value",
+        OdinValue::PathList(_) | OdinValue::Path(_) => "an object reference",
+        OdinValue::Empty => "an empty block",
+        OdinValue::String(_) => "a string",
+        OdinValue::Integer(_) => "an integer",
+        OdinValue::Real(_) => "a real",
+        OdinValue::Boolean(_) => "a boolean",
+        OdinValue::Character(_) => "a character",
+        OdinValue::Date(_) => "a date",
+        OdinValue::Time(_) => "a time",
+        OdinValue::DateTime(_) => "a date/time",
+        OdinValue::Duration(_) => "a duration",
+        OdinValue::Interval(_) => "an interval",
+        OdinValue::TermCode(_) => "a term code",
+        OdinValue::Uri(_) => "a URI",
+        OdinValue::PlugIn { .. } => "a plug-in-syntax block",
+        OdinValue::ListContinue => "a list-continuation marker",
+    }
+}
+
+/// A keyed-list key as written, without ODIN quoting.
+fn key_text(key: &OdinKey) -> String {
+    match key {
+        OdinKey::String(text)
+        | OdinKey::Date(text)
+        | OdinKey::Time(text)
+        | OdinKey::DateTime(text) => text.clone(),
+        OdinKey::Integer(value) => value.to_string(),
+    }
+}
+
+/// Joins an ODIN attribute path segment onto a parent path.
+fn join_path(parent: &str, segment: &str) -> String {
+    if parent.is_empty() {
+        segment.to_owned()
+    } else {
+        format!("{parent}/{segment}")
+    }
+}
+
+/// One ODIN attribute object being read, tracking which of its members have been
+/// consumed so [`Block::finish`] can refuse the rest.
+struct Block<'a> {
+    /// ODIN attribute path of this block, for error reporting.
+    path: String,
+    /// The block's members, in document order.
+    members: &'a IndexMap<String, OdinValue>,
+    /// Names consumed so far.
+    consumed: BTreeSet<&'a str>,
+}
+
+impl<'a> Block<'a> {
+    /// A block over `members` at `path`.
+    fn new(path: String, members: &'a IndexMap<String, OdinValue>) -> Self {
+        Self {
+            path,
+            members,
+            consumed: BTreeSet::new(),
+        }
+    }
+
+    /// The block's members, if `value` is an attribute object (or an empty
+    /// block, which reads as no members).
+    fn open(
+        path: &str,
+        value: &'a OdinValue,
+        empty: &'a IndexMap<String, OdinValue>,
+    ) -> Result<Self, PBmmReadError> {
+        match value {
+            OdinValue::Object(members) => Ok(Self::new(path.to_owned(), members)),
+            OdinValue::Empty => Ok(Self::new(path.to_owned(), empty)),
+            other => Err(PBmmReadError::WrongValueShape {
+                path: path.to_owned(),
+                expected: "an attribute object",
+                found: kind_name(other),
+            }),
+        }
+    }
+
+    /// Marks `name` consumed and returns its value, if present.
+    fn take(&mut self, name: &'static str) -> Option<&'a OdinValue> {
+        self.consumed.insert(name);
+        self.members.get(name)
+    }
+
+    /// The path of member `name`.
+    fn member_path(&self, name: &str) -> String {
+        join_path(&self.path, name)
+    }
+
+    /// A mandatory (`1..1`) `String` attribute.
+    fn required_string(&mut self, name: &'static str) -> Result<String, PBmmReadError> {
+        let path = self.member_path(name);
+        match self.take(name) {
+            Some(value) => as_string(&path, value),
+            None => Err(PBmmReadError::MissingAttribute {
+                path: self.path.clone(),
+                attribute: name,
+            }),
+        }
+    }
+
+    /// An optional (`0..1`) `String` attribute.
+    fn optional_string(&mut self, name: &'static str) -> Result<Option<String>, PBmmReadError> {
+        let path = self.member_path(name);
+        match self.take(name) {
+            Some(value) => as_string(&path, value).map(Some),
+            None => Ok(None),
+        }
+    }
+
+    /// A `String` attribute the class docs declare `1..1` but
+    /// `master04-syntax.adoc` §Header Items treats as optional.
+    ///
+    /// NOTE (adjudicated): `BMM_SCHEMA_CORE` declares `schema_revision`,
+    /// `schema_lifecycle_state`, `schema_author` and `schema_description` all
+    /// `1..1` (`org.openehr.lang.bmm.bmm_schema_core.adoc` §Attributes), yet the
+    /// §Header Items example omits `schema_author` altogether and most vendored
+    /// openEHR/CIMI schemas omit it too. Since the generated field is a plain
+    /// `String`, an absent documentation header reads as the empty string rather
+    /// than refusing published schema text; the four identifying headers
+    /// (`bmm_version`, `rm_publisher`, `schema_name`, `rm_release`) stay
+    /// mandatory, because `schema_id` is derived from three of them.
+    fn documentation_string(&mut self, name: &'static str) -> Result<String, PBmmReadError> {
+        Ok(self.optional_string(name)?.unwrap_or_default())
+    }
+
+    /// `BMM_SCHEMA_CORE.archetype_visualise_descendants_of`, accepting the
+    /// American spelling the vendored `TestBmm1` schema writes.
+    ///
+    /// NOTE (adjudicated): the spec attribute is
+    /// `archetype_visualise_descendants_of`
+    /// (`org.openehr.lang.bmm.bmm_schema_core.adoc` §Attributes); the
+    /// `archetype_visualize_descendants_of` spelling found in schema text is
+    /// read onto the same attribute rather than refused, since the two differ
+    /// only in orthography and no second attribute exists to hold it.
+    fn visualise_descendants_of(&mut self) -> Result<Option<String>, PBmmReadError> {
+        let spec_spelling = self.optional_string("archetype_visualise_descendants_of")?;
+        let variant_spelling = self.optional_string("archetype_visualize_descendants_of")?;
+        Ok(spec_spelling.or(variant_spelling))
+    }
+
+    /// An optional attribute holding a scalar literal in its persisted
+    /// (serialised) form.
+    ///
+    /// `P_BMM_CONSTANT.value` is "The literal value of this constant, in its
+    /// persisted (serialised) form" typed `String`
+    /// (`org.openehr.lang.bmm_persistence.p_bmm_constant.adoc` §Attributes), and
+    /// `master04-syntax.adoc` §Constants writes it quoted
+    /// (`value = <"local">`). The vendored openEHR BASE schemas also write bare
+    /// ODIN scalars there (`value = <60>` on `Time_Definitions`), which are the
+    /// serialised form of a non-`String` constant, so any scalar is accepted and
+    /// its literal text taken.
+    fn literal_text(&mut self, name: &'static str) -> Result<Option<String>, PBmmReadError> {
+        let path = self.member_path(name);
+        match self.take(name) {
+            None => Ok(None),
+            Some(value) => literal_text_of(&path, value).map(Some),
+        }
+    }
+
+    /// An optional (`0..1`) `Boolean` attribute.
+    fn optional_bool(&mut self, name: &'static str) -> Result<Option<bool>, PBmmReadError> {
+        let path = self.member_path(name);
+        match self.take(name) {
+            Some(OdinValue::Boolean(flag)) => Ok(Some(*flag)),
+            Some(other) => Err(PBmmReadError::WrongValueShape {
+                path,
+                expected: "a boolean",
+                found: kind_name(other),
+            }),
+            None => Ok(None),
+        }
+    }
+
+    /// A `List<String>` attribute, empty when absent.
+    fn string_list(&mut self, name: &'static str) -> Result<Vec<String>, PBmmReadError> {
+        let path = self.member_path(name);
+        match self.take(name) {
+            Some(value) => string_list_of(&path, value),
+            None => Ok(Vec::new()),
+        }
+    }
+
+    /// A `Hash<String, String>` attribute (assertion or alias tables), `None`
+    /// when absent.
+    fn string_map(
+        &mut self,
+        name: &'static str,
+    ) -> Result<Option<BTreeMap<String, String>>, PBmmReadError> {
+        let path = self.member_path(name);
+        let Some(value) = self.take(name) else {
+            return Ok(None);
+        };
+        let mut out = BTreeMap::new();
+        for (key, item) in keyed_entries(&path, value)? {
+            let key = key_text(key);
+            let entry_path = join_path(&path, &key);
+            let text = as_string(&entry_path, item)?;
+            out.insert(key, text);
+        }
+        Ok(Some(out))
+    }
+
+    /// A `cardinality` attribute — an ODIN integer range
+    /// (`master04-syntax.adoc` §Container Properties: "The optional
+    /// `_cardinality_` meta-property indicates cardinality of the container, and
+    /// is expressed as a ODIN range").
+    fn cardinality(&mut self) -> Result<Option<Interval<i32>>, PBmmReadError> {
+        let path = self.member_path("cardinality");
+        match self.take("cardinality") {
+            Some(OdinValue::Interval(interval)) => integer_interval(&path, interval).map(Some),
+            Some(other) => Err(PBmmReadError::WrongValueShape {
+                path,
+                expected: "an interval",
+                found: kind_name(other),
+            }),
+            None => Ok(None),
+        }
+    }
+
+    /// Refuses any member neither consumed nor listed in `tolerated`.
+    fn finish(&self, tolerated: &[&str]) -> Result<(), PBmmReadError> {
+        for name in self.members.keys() {
+            if self.consumed.contains(name.as_str()) || tolerated.contains(&name.as_str()) {
+                continue;
+            }
+            return Err(PBmmReadError::UnknownAttribute {
+                path: self.path.clone(),
+                attribute: name.clone(),
+            });
+        }
+        Ok(())
+    }
+}
+
+/// A `String` leaf.
+fn as_string(path: &str, value: &OdinValue) -> Result<String, PBmmReadError> {
+    match value {
+        OdinValue::String(text) => Ok(text.clone()),
+        other => Err(PBmmReadError::WrongValueShape {
+            path: path.to_owned(),
+            expected: "a string",
+            found: kind_name(other),
+        }),
+    }
+}
+
+/// One scalar ODIN leaf as its literal text (see [`Block::literal_text`]).
+///
+/// `True`/`False` are the ODIN boolean literals
+/// (`LANG/docs/odin/master06-primitive_types` §Boolean).
+fn literal_text_of(path: &str, value: &OdinValue) -> Result<String, PBmmReadError> {
+    match value {
+        OdinValue::String(text)
+        | OdinValue::Date(text)
+        | OdinValue::Time(text)
+        | OdinValue::DateTime(text)
+        | OdinValue::Duration(text)
+        | OdinValue::TermCode(text)
+        | OdinValue::Uri(text) => Ok(text.clone()),
+        OdinValue::Integer(number) => Ok(number.to_string()),
+        OdinValue::Real(number) => Ok(number.to_string()),
+        OdinValue::Character(character) => Ok(character.to_string()),
+        OdinValue::Boolean(true) => Ok("True".to_owned()),
+        OdinValue::Boolean(false) => Ok("False".to_owned()),
+        other => Err(PBmmReadError::WrongValueShape {
+            path: path.to_owned(),
+            expected: "a scalar literal",
+            found: kind_name(other),
+        }),
+    }
+}
+
+/// A `List<String>` leaf: a single string, a string list, or an empty block.
+///
+/// NOTE: a trailing ODIN list-continuation marker (`ancestors = <"Any", ...>`,
+/// the form `master04-syntax.adoc` §Simple Classes and the vendored schemas
+/// write) marks the list as open — `LANG/docs/odin/master05-content` §Container
+/// Objects — and contributes no member, so it is dropped.
+fn string_list_of(path: &str, value: &OdinValue) -> Result<Vec<String>, PBmmReadError> {
+    match value {
+        OdinValue::String(text) => Ok(vec![text.clone()]),
+        OdinValue::Empty => Ok(Vec::new()),
+        OdinValue::List(items) => items
+            .iter()
+            .filter(|item| !matches!(item, OdinValue::ListContinue))
+            .map(|item| as_string(path, item))
+            .collect(),
+        other => Err(PBmmReadError::WrongValueShape {
+            path: path.to_owned(),
+            expected: "a string list",
+            found: kind_name(other),
+        }),
+    }
+}
+
+/// A `List<Any>` leaf of enumeration item values, as JSON scalars.
+///
+/// `P_BMM_ENUMERATION.item_values` is `List<Any>` (class doc §Attributes) and
+/// `master04-syntax.adoc` §Enumerated Types writes integer and string members
+/// (`item_values = <0, 1001, 1002, 1003>`, `item_values = <"<=", ">=", "=", "~">`).
+fn any_list_of(path: &str, value: &OdinValue) -> Result<Vec<serde_json::Value>, PBmmReadError> {
+    match value {
+        OdinValue::Empty => Ok(Vec::new()),
+        OdinValue::List(items) => items
+            .iter()
+            .filter(|item| !matches!(item, OdinValue::ListContinue))
+            .map(|item| any_scalar(path, item))
+            .collect(),
+        single => any_scalar(path, single).map(|scalar| vec![scalar]),
+    }
+}
+
+/// One enumeration item value as a JSON scalar.
+fn any_scalar(path: &str, value: &OdinValue) -> Result<serde_json::Value, PBmmReadError> {
+    match value {
+        OdinValue::String(text) => Ok(serde_json::Value::String(text.clone())),
+        OdinValue::Integer(number) => Ok(serde_json::Value::from(*number)),
+        OdinValue::Boolean(flag) => Ok(serde_json::Value::Bool(*flag)),
+        OdinValue::Character(character) => Ok(serde_json::Value::String(character.to_string())),
+        OdinValue::Real(number) => serde_json::Number::from_f64(*number)
+            .map(serde_json::Value::Number)
+            .ok_or_else(|| PBmmReadError::WrongValueShape {
+                path: path.to_owned(),
+                expected: "a finite real",
+                found: "a non-finite real",
+            }),
+        other => Err(PBmmReadError::WrongValueShape {
+            path: path.to_owned(),
+            expected: "an enumeration item value",
+            found: kind_name(other),
+        }),
+    }
+}
+
+/// The entries of a keyed container attribute (`["k"] = <…>`), or none for an
+/// empty block.
+fn keyed_entries<'a>(
+    path: &str,
+    value: &'a OdinValue,
+) -> Result<&'a [(OdinKey, OdinValue)], PBmmReadError> {
+    match value {
+        OdinValue::KeyedList(entries) => Ok(entries.as_slice()),
+        OdinValue::Empty => Ok(&[]),
+        other => Err(PBmmReadError::WrongValueShape {
+            path: path.to_owned(),
+            expected: "a keyed list",
+            found: kind_name(other),
+        }),
+    }
+}
+
+/// An ODIN range as an `Interval<Integer>`.
+///
+/// A `None` endpoint is unbounded on that side (the representation
+/// [`crate::odin::OdinInterval`] already uses), so `|>=1|` reads as
+/// `lower = 1, upper unbounded` and `|0..*|` as `lower = 0, upper unbounded`.
+/// Always the `Proper_interval` form: `Multiplicity_interval` is "any two-sided
+/// or one-sided interval" (`BASE/docs/foundation_types` `Proper_interval`), and
+/// a point cardinality `|1|` is the two-sided `1..1`.
+fn integer_interval(path: &str, interval: &OdinInterval) -> Result<Interval<i32>, PBmmReadError> {
+    let OdinInterval::Range {
+        lower,
+        lower_included,
+        upper,
+        upper_included,
+    } = interval
+    else {
+        return Err(PBmmReadError::UnsupportedCardinality {
+            path: path.to_owned(),
+        });
+    };
+    let lower = interval_bound(path, lower.as_deref())?;
+    let upper = interval_bound(path, upper.as_deref())?;
+    Ok(Interval::ProperInterval(ProperInterval::ProperInterval(
+        ProperIntervalData {
+            lower,
+            upper,
+            lower_unbounded: lower.is_none(),
+            upper_unbounded: upper.is_none(),
+            lower_included: *lower_included,
+            upper_included: *upper_included,
+        },
+    )))
+}
+
+/// One interval endpoint as an `Integer`.
+fn interval_bound(path: &str, bound: Option<&OdinValue>) -> Result<Option<i32>, PBmmReadError> {
+    match bound {
+        None => Ok(None),
+        Some(OdinValue::Integer(number)) => i32::try_from(*number).map(Some).map_err(|_overflow| {
+            PBmmReadError::UnsupportedCardinality {
+                path: path.to_owned(),
+            }
+        }),
+        Some(_) => Err(PBmmReadError::UnsupportedCardinality {
+            path: path.to_owned(),
+        }),
+    }
+}
+
+/// The ODIN type marker on `value`, and the value it wraps.
+///
+/// `master04-syntax.adoc` §Serialisation Formats: "ODIN uses a type marker
+/// `(P_BMM_SINGLE_PROPERTY)`"; "Where the type is unambiguous from context
+/// (such as a class definition or a package), no discriminator is needed".
+fn split_marker(value: &OdinValue) -> (Option<&str>, &OdinValue) {
+    match value {
+        OdinValue::Typed { rm_type, value } => (Some(rm_type.as_str()), value.as_ref()),
+        plain => (None, plain),
+    }
+}
+
+/// Reads the schema's `includes` attribute.
+///
+/// `P_BMM_SCHEMA.includes` is "Other schemas included by this schema, keyed by
+/// schema id" (class doc §Attributes), while `master04-syntax.adoc`
+/// §Inclusions writes the blocks under ordinal keys (`["1"] = < id = <"…"> >`)
+/// and the vendored openEHR component schemas key them by the id itself.
+///
+/// NOTE (adjudicated): the map is therefore keyed by each block's own `id`, the
+/// keying the class doc mandates; the ODIN key is positional in the §Inclusions
+/// form and carries no information the `id` does not.
+fn read_includes(
+    block: &mut Block<'_>,
+) -> Result<Option<BTreeMap<String, BmmIncludeSpec>>, PBmmReadError> {
+    let path = block.member_path("includes");
+    let Some(value) = block.take("includes") else {
+        return Ok(None);
+    };
+    let empty = IndexMap::new();
+    let mut out = BTreeMap::new();
+    for (key, entry) in keyed_entries(&path, value)? {
+        let entry_path = join_path(&path, &key_text(key));
+        let mut entry_block = Block::open(&entry_path, entry, &empty)?;
+        let id = entry_block.required_string("id")?;
+        entry_block.finish(&[])?;
+        out.insert(id.clone(), BmmIncludeSpec { id });
+    }
+    Ok(Some(out))
+}
+
+/// Reads a `packages` attribute into a `P_BMM_PACKAGE` tree.
+///
+/// `master04-syntax.adoc` §Package Definition: "just name the classes and
+/// packages in a recursive fashion", with its three NOTEs enforced —
+/// only a top-level package id may be a path
+/// ([`PBmmReadError::QualifiedNestedPackage`]), and the ODIN key must equal the
+/// block's `name` ([`PBmmReadError::KeyNameMismatch`]). The third NOTE (a
+/// package may reference only classes the same schema defines) is schema-global
+/// rather than local to one block, so it is enforced where the whole schema is
+/// in scope — [`crate::bmm_persistence::create_model::create_bmm_model`]'s
+/// [`PBmmReadError::ClassNotDefined`].
+fn read_packages(
+    block: &mut Block<'_>,
+    name: &'static str,
+    level: PackageLevel,
+) -> Result<BTreeMap<String, PBmmPackage>, PBmmReadError> {
+    let path = block.member_path(name);
+    let Some(value) = block.take(name) else {
+        return Ok(BTreeMap::new());
+    };
+    let empty = IndexMap::new();
+    let mut out = BTreeMap::new();
+    for (key, entry) in keyed_entries(&path, value)? {
+        let key = key_text(key);
+        let entry_path = join_path(&path, &key);
+        let mut entry_block = Block::open(&entry_path, entry, &empty)?;
+        let package_name = read_name(&mut entry_block, &key)?;
+        if level == PackageLevel::Nested && package_name.contains('.') {
+            return Err(PBmmReadError::QualifiedNestedPackage {
+                path: entry_path,
+                name: package_name,
+            });
+        }
+        let documentation = entry_block.optional_string("documentation")?;
+        let classes = entry_block.string_list("classes")?;
+        let packages = read_packages(&mut entry_block, "packages", PackageLevel::Nested)?;
+        entry_block.finish(&[])?;
+        out.insert(
+            key,
+            PBmmPackage {
+                packages,
+                documentation,
+                name: package_name,
+                classes,
+                bmm_package_definition: None,
+            },
+        );
+    }
+    Ok(out)
+}
+
+/// The `name` attribute of a keyed block, defaulting to its ODIN key.
+///
+/// `master04-syntax.adoc` §Non-primitive Classes: "Since `name` is a BMM
+/// meta-model attribute, the class definition always contains its ODIN key";
+/// §Package Definition NOTE: "make sure that the ODIN 'keys' are the same as
+/// the 'name' attributes in each block". A stated `name` that disagrees with the
+/// key is a [`PBmmReadError::KeyNameMismatch`]; an omitted `name` takes the key,
+/// which the chapter says it equals.
+fn read_name(block: &mut Block<'_>, key: &str) -> Result<String, PBmmReadError> {
+    match block.optional_string("name")? {
+        None => Ok(key.to_owned()),
+        Some(name) if name == key => Ok(name),
+        Some(name) => Err(PBmmReadError::KeyNameMismatch {
+            path: block.path.clone(),
+            key: key.to_owned(),
+            name,
+        }),
+    }
+}
+
+/// Reads a `primitive_types` or `class_definitions` attribute.
+///
+/// `master04-syntax.adoc` §Classes for Primitive Types: primitive-type
+/// definitions "are just normal class definitions within a `primitive_types`
+/// block", so both lists read identically; the distinction is carried into the
+/// BMM model by `BMM_CLASS.is_primitive_type`.
+fn read_class_list(
+    block: &mut Block<'_>,
+    name: &'static str,
+    schema_id: &str,
+    uid: &mut i32,
+) -> Result<Vec<PBmmClass>, PBmmReadError> {
+    let path = block.member_path(name);
+    let Some(value) = block.take(name) else {
+        return Ok(Vec::new());
+    };
+    let mut out = Vec::new();
+    for (key, entry) in keyed_entries(&path, value)? {
+        let key = key_text(key);
+        let entry_path = join_path(&path, &key);
+        *uid = uid.saturating_add(1);
+        out.push(read_class(&entry_path, &key, entry, schema_id, *uid)?);
+    }
+    Ok(out)
+}
+
+/// The attributes every `P_BMM_CLASS` leaf carries, read once and distributed
+/// over the concrete generated struct the type marker selects.
+struct ClassParts {
+    /// `P_BMM_MODEL_ELEMENT.documentation`.
+    documentation: Option<String>,
+    /// `P_BMM_CLASS.name`.
+    name: String,
+    /// `P_BMM_CLASS.ancestors`.
+    ancestors: Vec<String>,
+    /// `P_BMM_CLASS.constants`.
+    constants: Option<BTreeMap<String, PBmmConstant>>,
+    /// `P_BMM_CLASS.properties`.
+    properties: Option<BTreeMap<String, PBmmProperty>>,
+    /// `P_BMM_CLASS.functions`.
+    functions: Option<BTreeMap<String, PBmmFunction>>,
+    /// `P_BMM_CLASS.invariants`.
+    invariants: Option<BTreeMap<String, String>>,
+    /// `P_BMM_CLASS.is_abstract`.
+    is_abstract: Option<bool>,
+    /// `P_BMM_CLASS.is_override`.
+    is_override: Option<bool>,
+    /// `P_BMM_CLASS.generic_parameter_defs`.
+    generic_parameter_defs: Option<BTreeMap<String, PBmmGenericParameter>>,
+    /// `P_BMM_CLASS.source_schema_id`, stamped by the reader.
+    source_schema_id: String,
+    /// `P_BMM_CLASS.uid`, stamped by the reader.
+    uid: i32,
+    /// `P_BMM_CLASS.ancestor_defs`.
+    ancestor_defs: Vec<PBmmGenericType>,
+}
+
+/// The enumeration-only attributes of `P_BMM_ENUMERATION`.
+struct EnumerationParts {
+    /// `P_BMM_ENUMERATION.item_names`.
+    item_names: Vec<String>,
+    /// `P_BMM_ENUMERATION.item_values`.
+    item_values: Vec<serde_json::Value>,
+    /// `P_BMM_ENUMERATION.item_documentations`.
+    item_documentations: Vec<String>,
+}
+
+/// Reads one class definition, dispatching on its optional type marker.
+fn read_class(
+    path: &str,
+    key: &str,
+    value: &OdinValue,
+    schema_id: &str,
+    uid: i32,
+) -> Result<PBmmClass, PBmmReadError> {
+    let (marker, body) = split_marker(value);
+    let empty = IndexMap::new();
+    let mut block = Block::open(path, body, &empty)?;
+    if marker == Some("P_BMM_INTERFACE") {
+        return Err(PBmmReadError::InterfaceInClassList {
+            path: path.to_owned(),
+            name: read_name(&mut block, key)?,
+        });
+    }
+    let parts = read_class_parts(&mut block, key, schema_id, uid)?;
+    let class = match marker {
+        None | Some("P_BMM_CLASS") => {
+            block.finish(&[])?;
+            PBmmClass::PBmmClass(class_data(parts))
+        }
+        Some("P_BMM_ENUMERATION") => {
+            let items = read_enumeration_parts(&mut block)?;
+            block.finish(&[])?;
+            PBmmClass::PBmmEnumeration(PBmmEnumeration::PBmmEnumeration(enumeration_data(
+                parts, items,
+            )))
+        }
+        Some("P_BMM_ENUMERATION_INTEGER") => {
+            let items = read_enumeration_parts(&mut block)?;
+            block.finish(&[])?;
+            PBmmClass::PBmmEnumeration(PBmmEnumeration::PBmmEnumerationInteger(
+                enumeration_integer(parts, items),
+            ))
+        }
+        Some("P_BMM_ENUMERATION_STRING") => {
+            let items = read_enumeration_parts(&mut block)?;
+            block.finish(&[])?;
+            PBmmClass::PBmmEnumeration(PBmmEnumeration::PBmmEnumerationString(enumeration_string(
+                parts, items,
+            )))
+        }
+        Some(other) => {
+            return Err(PBmmReadError::UnexpectedTypeMarker {
+                path: path.to_owned(),
+                marker: other.to_owned(),
+                expected: "P_BMM_CLASS",
+            });
+        }
+    };
+    Ok(class)
+}
+
+/// Reads the `P_BMM_CLASS` attribute set shared by every class form.
+fn read_class_parts(
+    block: &mut Block<'_>,
+    key: &str,
+    schema_id: &str,
+    uid: i32,
+) -> Result<ClassParts, PBmmReadError> {
+    let name = read_name(block, key)?;
+    Ok(ClassParts {
+        documentation: block.optional_string("documentation")?,
+        ancestors: block.string_list("ancestors")?,
+        constants: read_constants(block)?,
+        properties: read_properties(block)?,
+        functions: read_functions(block)?,
+        invariants: block.string_map("invariants")?,
+        is_abstract: block.optional_bool("is_abstract")?,
+        is_override: block.optional_bool("is_override")?,
+        generic_parameter_defs: read_generic_parameter_defs(block)?,
+        ancestor_defs: read_ancestor_defs(block)?,
+        source_schema_id: schema_id.to_owned(),
+        uid,
+        name,
+    })
+}
+
+/// Reads the `P_BMM_ENUMERATION` item lists.
+fn read_enumeration_parts(block: &mut Block<'_>) -> Result<EnumerationParts, PBmmReadError> {
+    let values_path = block.member_path("item_values");
+    let item_values = match block.take("item_values") {
+        Some(value) => any_list_of(&values_path, value)?,
+        None => Vec::new(),
+    };
+    Ok(EnumerationParts {
+        item_names: block.string_list("item_names")?,
+        item_documentations: block.string_list("item_documentations")?,
+        item_values,
+    })
+}
+
+/// The least-rich `P_BMM_CLASS` form.
+fn class_data(parts: ClassParts) -> PBmmClassData {
+    PBmmClassData {
+        documentation: parts.documentation,
+        name: parts.name,
+        ancestors: parts.ancestors,
+        constants: parts.constants,
+        properties: parts.properties,
+        functions: parts.functions,
+        invariants: parts.invariants,
+        is_abstract: parts.is_abstract,
+        is_override: parts.is_override,
+        generic_parameter_defs: parts.generic_parameter_defs,
+        source_schema_id: parts.source_schema_id,
+        bmm_class: None,
+        uid: parts.uid,
+        ancestor_defs: parts.ancestor_defs,
+    }
+}
+
+/// The least-rich `P_BMM_ENUMERATION` form.
+fn enumeration_data(parts: ClassParts, items: EnumerationParts) -> PBmmEnumerationData {
+    PBmmEnumerationData {
+        documentation: parts.documentation,
+        name: parts.name,
+        ancestors: parts.ancestors,
+        constants: parts.constants,
+        properties: parts.properties,
+        functions: parts.functions,
+        invariants: parts.invariants,
+        is_abstract: parts.is_abstract,
+        is_override: parts.is_override,
+        generic_parameter_defs: parts.generic_parameter_defs,
+        source_schema_id: parts.source_schema_id,
+        bmm_class: None,
+        uid: parts.uid,
+        ancestor_defs: parts.ancestor_defs,
+        item_names: items.item_names,
+        item_values: items.item_values,
+        item_documentations: items.item_documentations,
+    }
+}
+
+/// The `P_BMM_ENUMERATION_INTEGER` form.
+fn enumeration_integer(parts: ClassParts, items: EnumerationParts) -> PBmmEnumerationInteger {
+    PBmmEnumerationInteger {
+        documentation: parts.documentation,
+        name: parts.name,
+        ancestors: parts.ancestors,
+        constants: parts.constants,
+        properties: parts.properties,
+        functions: parts.functions,
+        invariants: parts.invariants,
+        is_abstract: parts.is_abstract,
+        is_override: parts.is_override,
+        generic_parameter_defs: parts.generic_parameter_defs,
+        source_schema_id: parts.source_schema_id,
+        bmm_class: None,
+        uid: parts.uid,
+        ancestor_defs: parts.ancestor_defs,
+        item_names: items.item_names,
+        item_values: items.item_values,
+        item_documentations: items.item_documentations,
+    }
+}
+
+/// The `P_BMM_ENUMERATION_STRING` form.
+fn enumeration_string(parts: ClassParts, items: EnumerationParts) -> PBmmEnumerationString {
+    PBmmEnumerationString {
+        documentation: parts.documentation,
+        name: parts.name,
+        ancestors: parts.ancestors,
+        constants: parts.constants,
+        properties: parts.properties,
+        functions: parts.functions,
+        invariants: parts.invariants,
+        is_abstract: parts.is_abstract,
+        is_override: parts.is_override,
+        generic_parameter_defs: parts.generic_parameter_defs,
+        source_schema_id: parts.source_schema_id,
+        bmm_class: None,
+        uid: parts.uid,
+        ancestor_defs: parts.ancestor_defs,
+        item_names: items.item_names,
+        item_values: items.item_values,
+        item_documentations: items.item_documentations,
+    }
+}
+
+/// Reads a class's `generic_parameter_defs`.
+///
+/// `master04-syntax.adoc` §Generic Classes: "the usual ODIN keyed hash
+/// structure is used with each member being keyed by a generic parameter name".
+fn read_generic_parameter_defs(
+    block: &mut Block<'_>,
+) -> Result<Option<BTreeMap<String, PBmmGenericParameter>>, PBmmReadError> {
+    let path = block.member_path("generic_parameter_defs");
+    let Some(value) = block.take("generic_parameter_defs") else {
+        return Ok(None);
+    };
+    let empty = IndexMap::new();
+    let mut out = BTreeMap::new();
+    for (key, entry) in keyed_entries(&path, value)? {
+        let key = key_text(key);
+        let entry_path = join_path(&path, &key);
+        let mut entry_block = Block::open(&entry_path, entry, &empty)?;
+        let name = read_name(&mut entry_block, &key)?;
+        let documentation = entry_block.optional_string("documentation")?;
+        let conforms_to_type = entry_block.optional_string("conforms_to_type")?;
+        entry_block.finish(&[])?;
+        out.insert(
+            key,
+            PBmmGenericParameter {
+                documentation,
+                name,
+                conforms_to_type,
+                bmm_generic_parameter: None,
+            },
+        );
+    }
+    Ok(Some(out))
+}
+
+/// Reads a class's `ancestor_defs`.
+///
+/// `P_BMM_CLASS.ancestor_defs` is `List<P_BMM_GENERIC_TYPE>` (class doc
+/// §Attributes) and `master04-syntax.adoc` §Inheritance uses it only "In the
+/// case of generic inheritance", where "the ancestors are generic types"; the
+/// keys are the rendered generic type signatures
+/// (`["GENERIC_PARENT<T,SUPPLIER_B>"]`), not names, so they are not matched
+/// against a `name` attribute.
+fn read_ancestor_defs(block: &mut Block<'_>) -> Result<Vec<PBmmGenericType>, PBmmReadError> {
+    let path = block.member_path("ancestor_defs");
+    let Some(value) = block.take("ancestor_defs") else {
+        return Ok(Vec::new());
+    };
+    let mut out = Vec::new();
+    for (key, entry) in keyed_entries(&path, value)? {
+        let entry_path = join_path(&path, &key_text(key));
+        out.push(read_generic_type(&entry_path, entry)?);
+    }
+    Ok(out)
+}
+
+/// Reads a class's `constants`.
+///
+/// `master04-syntax.adoc` §Constants: "Each constant is a `P_BMM_CONSTANT`
+/// carrying its `_type_` (a simple class name) and its literal `_value_` in
+/// serialised form."
+fn read_constants(
+    block: &mut Block<'_>,
+) -> Result<Option<BTreeMap<String, PBmmConstant>>, PBmmReadError> {
+    let path = block.member_path("constants");
+    let Some(value) = block.take("constants") else {
+        return Ok(None);
+    };
+    let empty = IndexMap::new();
+    let mut out = BTreeMap::new();
+    for (key, entry) in keyed_entries(&path, value)? {
+        let key = key_text(key);
+        let entry_path = join_path(&path, &key);
+        let mut entry_block = Block::open(&entry_path, entry, &empty)?;
+        let name = read_name(&mut entry_block, &key)?;
+        let documentation = entry_block.optional_string("documentation")?;
+        let r#type = entry_block.required_string("type")?;
+        let value = entry_block.literal_text("value")?;
+        entry_block.finish(&[])?;
+        out.insert(
+            key,
+            PBmmConstant {
+                documentation,
+                name,
+                r#type,
+                value,
+            },
+        );
+    }
+    Ok(Some(out))
+}
+
+/// Reads a class's `functions`.
+///
+/// `master04-syntax.adoc` §Functions: functions are "expressed as ODIN object
+/// blocks under the `_functions_` keyword, keyed by function name … whose
+/// formal parameters appear under `_parameters_`, keyed by parameter name, and
+/// whose return type, if any, is stated in `_result_`. A function with no
+/// `_result_` is a procedure."
+fn read_functions(
+    block: &mut Block<'_>,
+) -> Result<Option<BTreeMap<String, PBmmFunction>>, PBmmReadError> {
+    let path = block.member_path("functions");
+    let Some(value) = block.take("functions") else {
+        return Ok(None);
+    };
+    let empty = IndexMap::new();
+    let mut out = BTreeMap::new();
+    for (key, entry) in keyed_entries(&path, value)? {
+        let key = key_text(key);
+        let entry_path = join_path(&path, &key);
+        let mut entry_block = Block::open(&entry_path, entry, &empty)?;
+        let name = read_name(&mut entry_block, &key)?;
+        let documentation = entry_block.optional_string("documentation")?;
+        let aliases = read_aliases(&mut entry_block)?;
+        let is_abstract = entry_block.optional_bool("is_abstract")?;
+        let parameters = read_parameters(&mut entry_block)?;
+        let pre_conditions = entry_block.string_map("pre_conditions")?;
+        let post_conditions = entry_block.string_map("post_conditions")?;
+        let result_path = entry_block.member_path("result");
+        let result = match entry_block.take("result") {
+            Some(value) => Some(read_type(&result_path, value)?),
+            None => None,
+        };
+        let is_nullable = entry_block.optional_bool("is_nullable")?;
+        entry_block.finish(&[])?;
+        out.insert(
+            key,
+            PBmmFunction {
+                documentation,
+                name,
+                aliases,
+                is_abstract,
+                parameters,
+                pre_conditions,
+                post_conditions,
+                result,
+                is_nullable,
+            },
+        );
+    }
+    Ok(Some(out))
+}
+
+/// Reads a function's `aliases`.
+///
+/// NOTE (adjudicated): `P_BMM_FUNCTION.aliases` is declared
+/// `Hash<String, String>` "Optional alias names for this function, keyed by
+/// alias" (class doc §Attributes), while the vendored openEHR schemas write it
+/// as a plain ODIN string list (`aliases = <"=", "==">`). Each alias is
+/// therefore entered under itself — the keying the class doc mandates — since
+/// the list form carries no separate key.
+fn read_aliases(block: &mut Block<'_>) -> Result<Option<BTreeMap<String, String>>, PBmmReadError> {
+    let path = block.member_path("aliases");
+    let Some(value) = block.take("aliases") else {
+        return Ok(None);
+    };
+    if matches!(value, OdinValue::KeyedList(_)) {
+        let mut out = BTreeMap::new();
+        for (key, entry) in keyed_entries(&path, value)? {
+            let key = key_text(key);
+            let entry_path = join_path(&path, &key);
+            let text = as_string(&entry_path, entry)?;
+            out.insert(key, text);
+        }
+        return Ok(Some(out));
+    }
+    let aliases = string_list_of(&path, value)?;
+    Ok(Some(
+        aliases
+            .into_iter()
+            .map(|alias| (alias.clone(), alias))
+            .collect(),
+    ))
+}
+
+/// Reads a function's `parameters`.
+///
+/// `master04-syntax.adoc` §Functions: "Each parameter carries an ODIN type
+/// marker indicating its `P_BMM_FUNCTION_PARAMETER` subtype, in direct analogy
+/// with the property meta-types."
+fn read_parameters(
+    block: &mut Block<'_>,
+) -> Result<Option<BTreeMap<String, PBmmFunctionParameter>>, PBmmReadError> {
+    let path = block.member_path("parameters");
+    let Some(value) = block.take("parameters") else {
+        return Ok(None);
+    };
+    let mut out = BTreeMap::new();
+    for (key, entry) in keyed_entries(&path, value)? {
+        let key = key_text(key);
+        let entry_path = join_path(&path, &key);
+        out.insert(key.clone(), read_parameter(&entry_path, &key, entry)?);
+    }
+    Ok(Some(out))
+}
+
+/// Reads one function parameter.
+fn read_parameter(
+    path: &str,
+    key: &str,
+    value: &OdinValue,
+) -> Result<PBmmFunctionParameter, PBmmReadError> {
+    let (marker, body) = split_marker(value);
+    let empty = IndexMap::new();
+    let mut block = Block::open(path, body, &empty)?;
+    let name = read_name(&mut block, key)?;
+    let documentation = block.optional_string("documentation")?;
+    let is_nullable = block.optional_bool("is_nullable")?;
+    let parameter = match marker {
+        Some("P_BMM_SINGLE_FUNCTION_PARAMETER") => {
+            let r#type = block.required_string("type")?;
+            block.finish(&[])?;
+            PBmmFunctionParameter::PBmmSingleFunctionParameter(PBmmSingleFunctionParameter {
+                documentation,
+                name,
+                is_nullable,
+                r#type,
+            })
+        }
+        Some("P_BMM_SINGLE_FUNCTION_PARAMETER_OPEN") => {
+            let r#type = block.required_string("type")?;
+            block.finish(&[])?;
+            PBmmFunctionParameter::PBmmSingleFunctionParameterOpen(
+                PBmmSingleFunctionParameterOpen {
+                    documentation,
+                    name,
+                    is_nullable,
+                    r#type,
+                },
+            )
+        }
+        Some("P_BMM_CONTAINER_FUNCTION_PARAMETER") => {
+            let type_def = read_required_container_type(&mut block)?;
+            let cardinality = block.cardinality()?;
+            block.finish(&[])?;
+            PBmmFunctionParameter::PBmmContainerFunctionParameter(PBmmContainerFunctionParameter {
+                documentation,
+                name,
+                is_nullable,
+                type_def,
+                cardinality,
+            })
+        }
+        Some("P_BMM_GENERIC_FUNCTION_PARAMETER") => {
+            let type_def_path = block.member_path("type_def");
+            let Some(type_def) = block.take("type_def") else {
+                return Err(PBmmReadError::MissingAttribute {
+                    path: path.to_owned(),
+                    attribute: "type_def",
+                });
+            };
+            let type_def = read_generic_type(&type_def_path, type_def)?;
+            block.finish(&[])?;
+            PBmmFunctionParameter::PBmmGenericFunctionParameter(PBmmGenericFunctionParameter {
+                documentation,
+                name,
+                is_nullable,
+                type_def,
+            })
+        }
+        Some(other) => {
+            return Err(PBmmReadError::UnexpectedTypeMarker {
+                path: path.to_owned(),
+                marker: other.to_owned(),
+                expected: "P_BMM_FUNCTION_PARAMETER",
+            });
+        }
+        None => {
+            return Err(PBmmReadError::MissingTypeMarker {
+                path: path.to_owned(),
+                expected: "P_BMM_FUNCTION_PARAMETER",
+            });
+        }
+    };
+    Ok(parameter)
+}
+
+/// Reads a mandatory `type_def` of `P_BMM_CONTAINER_TYPE`.
+fn read_required_container_type(block: &mut Block<'_>) -> Result<PBmmContainerType, PBmmReadError> {
+    let path = block.member_path("type_def");
+    match block.take("type_def") {
+        Some(value) => read_container_type(&path, value),
+        None => Err(PBmmReadError::MissingAttribute {
+            path: block.path.clone(),
+            attribute: "type_def",
+        }),
+    }
+}
+
+/// Reads a class's `properties`.
+///
+/// `master04-syntax.adoc` §Class properties: "Class properties from the
+/// original model are expressed using ODIN object blocks keyed by property
+/// name. Since there are multiple possible descendants of `P_BMM_PROPERTY`,
+/// ODIN type markers must be used to indicate which subtypes is used in each
+/// case."
+fn read_properties(
+    block: &mut Block<'_>,
+) -> Result<Option<BTreeMap<String, PBmmProperty>>, PBmmReadError> {
+    let path = block.member_path("properties");
+    let Some(value) = block.take("properties") else {
+        return Ok(None);
+    };
+    let mut out = BTreeMap::new();
+    for (key, entry) in keyed_entries(&path, value)? {
+        let key = key_text(key);
+        let entry_path = join_path(&path, &key);
+        out.insert(key.clone(), read_property(&entry_path, &key, entry)?);
+    }
+    Ok(Some(out))
+}
+
+/// The attributes every `P_BMM_PROPERTY` leaf carries.
+struct PropertyParts {
+    /// `P_BMM_MODEL_ELEMENT.documentation`.
+    documentation: Option<String>,
+    /// `P_BMM_PROPERTY.name`.
+    name: String,
+    /// `P_BMM_PROPERTY.is_mandatory`.
+    is_mandatory: Option<bool>,
+    /// `P_BMM_PROPERTY.is_computed`.
+    is_computed: Option<bool>,
+    /// `P_BMM_PROPERTY.is_im_infrastructure`.
+    is_im_infrastructure: Option<bool>,
+    /// `P_BMM_PROPERTY.is_im_runtime`.
+    is_im_runtime: Option<bool>,
+}
+
+/// Reads one class property.
+#[expect(
+    clippy::too_many_lines,
+    reason = "one arm per P_BMM_PROPERTY subtype; splitting the dispatch would hide the five-way marker → generated-struct mapping master04 §Class properties defines"
+)]
+fn read_property(path: &str, key: &str, value: &OdinValue) -> Result<PBmmProperty, PBmmReadError> {
+    let (marker, body) = split_marker(value);
+    let empty = IndexMap::new();
+    let mut block = Block::open(path, body, &empty)?;
+    let parts = PropertyParts {
+        name: read_name(&mut block, key)?,
+        documentation: block.optional_string("documentation")?,
+        is_mandatory: block.optional_bool("is_mandatory")?,
+        is_computed: block.optional_bool("is_computed")?,
+        is_im_infrastructure: block.optional_bool("is_im_infrastructure")?,
+        is_im_runtime: block.optional_bool("is_im_runtime")?,
+    };
+    let property = match marker {
+        Some("P_BMM_SINGLE_PROPERTY") => {
+            let r#type = block.optional_string("type")?;
+            let simple_ref = read_optional_simple_type(&mut block)?;
+            let structural = read_optional_type(&mut block)?;
+            block.finish(TOLERATED_PROPERTY_ATTRIBUTES)?;
+            PBmmProperty::PBmmSingleProperty(PBmmSingleProperty {
+                documentation: parts.documentation,
+                name: parts.name,
+                is_mandatory: parts.is_mandatory,
+                is_computed: parts.is_computed,
+                is_im_infrastructure: parts.is_im_infrastructure,
+                is_im_runtime: parts.is_im_runtime,
+                type_def: structural,
+                bmm_property: None,
+                r#type,
+                type_ref: simple_ref,
+            })
+        }
+        Some("P_BMM_SINGLE_PROPERTY_OPEN") => {
+            let r#type = block.optional_string("type")?;
+            let open_ref = read_optional_open_type(&mut block)?;
+            let structural = read_optional_type(&mut block)?;
+            block.finish(TOLERATED_PROPERTY_ATTRIBUTES)?;
+            PBmmProperty::PBmmSinglePropertyOpen(PBmmSinglePropertyOpen {
+                documentation: parts.documentation,
+                name: parts.name,
+                is_mandatory: parts.is_mandatory,
+                is_computed: parts.is_computed,
+                is_im_infrastructure: parts.is_im_infrastructure,
+                is_im_runtime: parts.is_im_runtime,
+                type_def: structural,
+                bmm_property: None,
+                type_ref: open_ref,
+                r#type,
+            })
+        }
+        Some("P_BMM_GENERIC_PROPERTY") => {
+            let type_def_path = block.member_path("type_def");
+            let type_def = match block.take("type_def") {
+                Some(value) => Some(read_generic_type(&type_def_path, value)?),
+                None => None,
+            };
+            block.finish(TOLERATED_PROPERTY_ATTRIBUTES)?;
+            PBmmProperty::PBmmGenericProperty(PBmmGenericProperty {
+                documentation: parts.documentation,
+                name: parts.name,
+                is_mandatory: parts.is_mandatory,
+                is_computed: parts.is_computed,
+                is_im_infrastructure: parts.is_im_infrastructure,
+                is_im_runtime: parts.is_im_runtime,
+                type_def,
+                bmm_property: None,
+            })
+        }
+        Some("P_BMM_CONTAINER_PROPERTY") => {
+            let type_def_path = block.member_path("type_def");
+            let type_def = match block.take("type_def") {
+                Some(value) => Some(read_container_type(&type_def_path, value)?),
+                None => None,
+            };
+            let cardinality = block.cardinality()?;
+            block.finish(TOLERATED_PROPERTY_ATTRIBUTES)?;
+            PBmmProperty::PBmmContainerProperty(PBmmContainerProperty::PBmmContainerProperty(
+                PBmmContainerPropertyData {
+                    documentation: parts.documentation,
+                    name: parts.name,
+                    is_mandatory: parts.is_mandatory,
+                    is_computed: parts.is_computed,
+                    is_im_infrastructure: parts.is_im_infrastructure,
+                    is_im_runtime: parts.is_im_runtime,
+                    type_def,
+                    bmm_property: None,
+                    cardinality,
+                },
+            ))
+        }
+        Some("P_BMM_INDEXED_CONTAINER_PROPERTY") => {
+            let type_def_path = block.member_path("type_def");
+            let type_def = match block.take("type_def") {
+                Some(value) => Some(read_indexed_container_type(&type_def_path, value)?),
+                None => None,
+            };
+            let cardinality = block.cardinality()?;
+            block.finish(TOLERATED_PROPERTY_ATTRIBUTES)?;
+            PBmmProperty::PBmmContainerProperty(
+                PBmmContainerProperty::PBmmIndexedContainerProperty(PBmmIndexedContainerProperty {
+                    documentation: parts.documentation,
+                    name: parts.name,
+                    is_mandatory: parts.is_mandatory,
+                    is_computed: parts.is_computed,
+                    is_im_infrastructure: parts.is_im_infrastructure,
+                    is_im_runtime: parts.is_im_runtime,
+                    type_def,
+                    bmm_property: None,
+                    cardinality,
+                }),
+            )
+        }
+        Some(other) => {
+            return Err(PBmmReadError::UnexpectedTypeMarker {
+                path: path.to_owned(),
+                marker: other.to_owned(),
+                expected: "P_BMM_PROPERTY",
+            });
+        }
+        None => {
+            return Err(PBmmReadError::MissingTypeMarker {
+                path: path.to_owned(),
+                expected: "P_BMM_PROPERTY",
+            });
+        }
+    };
+    Ok(property)
+}
+
+/// Reads an optional `type_def` of the polymorphic `P_BMM_TYPE` slot.
+fn read_optional_type(block: &mut Block<'_>) -> Result<Option<PBmmType>, PBmmReadError> {
+    let path = block.member_path("type_def");
+    match block.take("type_def") {
+        Some(value) => read_type(&path, value).map(Some),
+        None => Ok(None),
+    }
+}
+
+/// Reads an optional `type_ref` of `P_BMM_SIMPLE_TYPE`.
+///
+/// `master04-syntax.adoc` §Value-set Constraints: "The use of the
+/// `value_constraint` attribute forces the use of the `type_ref` structural form
+/// of the type definition within a `P_BMM_SINGLE_PROPERTY` instance, rather than
+/// the simple `String` form."
+fn read_optional_simple_type(
+    block: &mut Block<'_>,
+) -> Result<Option<PBmmSimpleType>, PBmmReadError> {
+    let path = block.member_path("type_ref");
+    match block.take("type_ref") {
+        Some(value) => read_simple_type(&path, value).map(Some),
+        None => Ok(None),
+    }
+}
+
+/// Reads an optional `type_ref` of `P_BMM_OPEN_TYPE`.
+fn read_optional_open_type(block: &mut Block<'_>) -> Result<Option<PBmmOpenType>, PBmmReadError> {
+    let path = block.member_path("type_ref");
+    match block.take("type_ref") {
+        Some(value) => read_open_type(&path, value).map(Some),
+        None => Ok(None),
+    }
+}
+
+/// Reads a `P_BMM_TYPE`, from its marker where stated and from its member set
+/// otherwise.
+///
+/// `master04-syntax.adoc` §Serialisation Formats requires the discriminator
+/// only "Wherever a value may be one of several `P_BMM_*` subtypes": the
+/// chapter's own examples omit it on a `type_def` whose declaring attribute is
+/// a concrete type (`§Container Properties`, `§Generic Classes`). Where the slot
+/// IS polymorphic and no marker is written, the subtype is inferred from the
+/// attributes present, using the chapter's own rules (§Generic Classes: "use
+/// 'type' for simple string type refs; use `_type_def_` for structure types;
+/// within `P_BMM_GENERIC_TYPE`, use `_generic_parameters_` for a list of string
+/// types") — `container_type` ⇒ a container type (indexed when `index_type` is
+/// present), `root_type` ⇒ a generic type, `type` alone ⇒ a simple type.
+fn read_type(path: &str, value: &OdinValue) -> Result<PBmmType, PBmmReadError> {
+    let (marker, body) = split_marker(value);
+    match marker {
+        Some("P_BMM_SIMPLE_TYPE") => read_simple_type(path, value).map(PBmmType::PBmmSimpleType),
+        Some("P_BMM_OPEN_TYPE") => read_open_type(path, value).map(PBmmType::PBmmOpenType),
+        Some("P_BMM_GENERIC_TYPE") => read_generic_type(path, value).map(PBmmType::PBmmGenericType),
+        Some("P_BMM_CONTAINER_TYPE" | "P_BMM_INDEXED_CONTAINER_TYPE") => {
+            read_container_type(path, value).map(PBmmType::PBmmContainerType)
+        }
+        Some(other) => Err(PBmmReadError::UnexpectedTypeMarker {
+            path: path.to_owned(),
+            marker: other.to_owned(),
+            expected: "P_BMM_TYPE",
+        }),
+        None => match infer_type_kind(body) {
+            Some(TypeKind::Container | TypeKind::IndexedContainer) => {
+                read_container_type(path, value).map(PBmmType::PBmmContainerType)
+            }
+            Some(TypeKind::Generic) => {
+                read_generic_type(path, value).map(PBmmType::PBmmGenericType)
+            }
+            Some(TypeKind::Simple) => read_simple_type(path, value).map(PBmmType::PBmmSimpleType),
+            None => Err(PBmmReadError::MissingTypeMarker {
+                path: path.to_owned(),
+                expected: "P_BMM_TYPE",
+            }),
+        },
+    }
+}
+
+/// Reads a `P_BMM_BASE_TYPE` — the non-container half of the type family
+/// (`…p_bmm_base_type.adoc` §Description: "Persistent form of a proper
+/// (non-container) BMM type").
+fn read_base_type(path: &str, value: &OdinValue) -> Result<PBmmBaseType, PBmmReadError> {
+    let (marker, body) = split_marker(value);
+    match marker {
+        Some("P_BMM_SIMPLE_TYPE") => {
+            read_simple_type(path, value).map(PBmmBaseType::PBmmSimpleType)
+        }
+        Some("P_BMM_OPEN_TYPE") => read_open_type(path, value).map(PBmmBaseType::PBmmOpenType),
+        Some("P_BMM_GENERIC_TYPE") => {
+            read_generic_type(path, value).map(PBmmBaseType::PBmmGenericType)
+        }
+        Some(other) => Err(PBmmReadError::UnexpectedTypeMarker {
+            path: path.to_owned(),
+            marker: other.to_owned(),
+            expected: "P_BMM_BASE_TYPE",
+        }),
+        None => match infer_type_kind(body) {
+            Some(TypeKind::Generic) => {
+                read_generic_type(path, value).map(PBmmBaseType::PBmmGenericType)
+            }
+            Some(TypeKind::Simple) => {
+                read_simple_type(path, value).map(PBmmBaseType::PBmmSimpleType)
+            }
+            Some(TypeKind::Container | TypeKind::IndexedContainer) | None => {
+                Err(PBmmReadError::MissingTypeMarker {
+                    path: path.to_owned(),
+                    expected: "P_BMM_BASE_TYPE",
+                })
+            }
+        },
+    }
+}
+
+/// Which `P_BMM_TYPE` subtype an unmarked type block's members indicate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TypeKind {
+    /// `container_type` + `index_type` present.
+    IndexedContainer,
+    /// `container_type` present.
+    Container,
+    /// `root_type` present.
+    Generic,
+    /// `type` present.
+    Simple,
+}
+
+/// Infers the subtype of an unmarked type block from its members.
+fn infer_type_kind(body: &OdinValue) -> Option<TypeKind> {
+    let OdinValue::Object(members) = body else {
+        return None;
+    };
+    if members.contains_key("container_type") {
+        if members.contains_key("index_type") {
+            return Some(TypeKind::IndexedContainer);
+        }
+        return Some(TypeKind::Container);
+    }
+    if members.contains_key("root_type") {
+        return Some(TypeKind::Generic);
+    }
+    if members.contains_key("type") {
+        return Some(TypeKind::Simple);
+    }
+    None
+}
+
+/// Reads a `P_BMM_SIMPLE_TYPE` (`type`, plus the optional
+/// `P_BMM_BASE_TYPE.value_constraint`).
+fn read_simple_type(path: &str, value: &OdinValue) -> Result<PBmmSimpleType, PBmmReadError> {
+    let body = expect_marker(path, value, "P_BMM_SIMPLE_TYPE", &["P_BMM_SIMPLE_TYPE"])?;
+    let empty = IndexMap::new();
+    let mut block = Block::open(path, body, &empty)?;
+    let r#type = block.required_string("type")?;
+    let value_constraint = block.optional_string("value_constraint")?;
+    block.finish(&[])?;
+    Ok(PBmmSimpleType {
+        bmm_type: None,
+        value_constraint,
+        r#type,
+    })
+}
+
+/// Reads a `P_BMM_OPEN_TYPE` (a generic parameter name, plus the optional
+/// `value_constraint`).
+fn read_open_type(path: &str, value: &OdinValue) -> Result<PBmmOpenType, PBmmReadError> {
+    let body = expect_marker(path, value, "P_BMM_OPEN_TYPE", &["P_BMM_OPEN_TYPE"])?;
+    let empty = IndexMap::new();
+    let mut block = Block::open(path, body, &empty)?;
+    let r#type = block.required_string("type")?;
+    let value_constraint = block.optional_string("value_constraint")?;
+    block.finish(&[])?;
+    Ok(PBmmOpenType {
+        bmm_type: None,
+        value_constraint,
+        r#type,
+    })
+}
+
+/// Reads a `P_BMM_GENERIC_TYPE`.
+///
+/// `master04-syntax.adoc` §Generic Classes: "`DV_INTERVAL` is the `_root_type_`";
+/// "within `P_BMM_GENERIC_TYPE`, use `_generic_parameters_` for a list of
+/// string types; use `_generic_parameter_defs_` for a list of complex type
+/// references" — the latter "a logical list in general, since there can always
+/// be more than one generic parameter", written as an ODIN keyed hash whose
+/// document order is the declaration order the class doc requires.
+fn read_generic_type(path: &str, value: &OdinValue) -> Result<PBmmGenericType, PBmmReadError> {
+    let body = expect_marker(path, value, "P_BMM_GENERIC_TYPE", &["P_BMM_GENERIC_TYPE"])?;
+    let empty = IndexMap::new();
+    let mut block = Block::open(path, body, &empty)?;
+    let root_type = block.required_string("root_type")?;
+    let (generic_parameters, mut generic_parameter_defs) = read_generic_parameters(&mut block)?;
+    let defs_path = block.member_path("generic_parameter_defs");
+    if let Some(defs) = block.take("generic_parameter_defs") {
+        for (key, entry) in keyed_entries(&defs_path, defs)? {
+            let entry_path = join_path(&defs_path, &key_text(key));
+            generic_parameter_defs.push(read_type(&entry_path, entry)?);
+        }
+    }
+    let value_constraint = block.optional_string("value_constraint")?;
+    block.finish(&[])?;
+    Ok(PBmmGenericType {
+        bmm_type: None,
+        value_constraint,
+        root_type,
+        generic_parameter_defs,
+        generic_parameters,
+    })
+}
+
+/// Reads a generic type's `generic_parameters` attribute.
+///
+/// The spec form is a plain ODIN string list — "use `_generic_parameters_` for a
+/// list of string types" (`master04-syntax.adoc` §Generic Classes) — and reads
+/// into `P_BMM_GENERIC_TYPE.generic_parameters`.
+///
+/// NOTE (adjudicated tolerance): the vendored openEHR AM 2.2.0/2.3.0/2.4.0 ODIN
+/// schemas also write it as an INTEGER-KEYED list whose members mix plain type
+/// names with type-marked blocks
+/// (`generic_parameters = < [1] = <"Boolean"> [2] = (P_BMM_GENERIC_TYPE) <…> >`
+/// on `ARCHETYPE_CONSTRAINT.c_conforms_to`). No openEHR spec governs that
+/// positional form; it collapses the chapter's two parameter lists into one. It
+/// is read entirely into `generic_parameter_defs` — the `List<P_BMM_TYPE>` half —
+/// with a bare type name promoted to a `P_BMM_SIMPLE_TYPE`, because that is the
+/// only shape that preserves the declaration ORDER the class doc requires ("The
+/// order must match the order of the owning class's formal generic parameter
+/// declarations").
+fn read_generic_parameters(
+    block: &mut Block<'_>,
+) -> Result<(Vec<String>, Vec<PBmmType>), PBmmReadError> {
+    let path = block.member_path("generic_parameters");
+    let Some(value) = block.take("generic_parameters") else {
+        return Ok((Vec::new(), Vec::new()));
+    };
+    if !matches!(value, OdinValue::KeyedList(_)) {
+        return Ok((string_list_of(&path, value)?, Vec::new()));
+    }
+    let mut defs = Vec::new();
+    for (key, entry) in keyed_entries(&path, value)? {
+        let entry_path = join_path(&path, &key_text(key));
+        match entry {
+            OdinValue::String(name) => defs.push(PBmmType::PBmmSimpleType(PBmmSimpleType {
+                bmm_type: None,
+                value_constraint: None,
+                r#type: name.clone(),
+            })),
+            structured => defs.push(read_type(&entry_path, structured)?),
+        }
+    }
+    Ok((Vec::new(), defs))
+}
+
+/// Reads a `P_BMM_CONTAINER_TYPE`, selecting the indexed form by marker or by
+/// the presence of `index_type`.
+fn read_container_type(path: &str, value: &OdinValue) -> Result<PBmmContainerType, PBmmReadError> {
+    let (marker, body) = split_marker(value);
+    match marker {
+        Some("P_BMM_INDEXED_CONTAINER_TYPE") => read_indexed_container_type(path, value)
+            .map(PBmmContainerType::PBmmIndexedContainerType),
+        Some("P_BMM_CONTAINER_TYPE") | None => {
+            if infer_type_kind(body) == Some(TypeKind::IndexedContainer) {
+                return read_indexed_container_type(path, value)
+                    .map(PBmmContainerType::PBmmIndexedContainerType);
+            }
+            let empty = IndexMap::new();
+            let mut block = Block::open(path, body, &empty)?;
+            let container_type = block.required_string("container_type")?;
+            let r#type = block.optional_string("type")?;
+            let type_def = read_optional_base_type(&mut block)?;
+            block.finish(&[])?;
+            Ok(PBmmContainerType::PBmmContainerType(
+                PBmmContainerTypeData {
+                    bmm_type: None,
+                    container_type,
+                    type_def,
+                    r#type,
+                },
+            ))
+        }
+        Some(other) => Err(PBmmReadError::UnexpectedTypeMarker {
+            path: path.to_owned(),
+            marker: other.to_owned(),
+            expected: "P_BMM_CONTAINER_TYPE",
+        }),
+    }
+}
+
+/// Reads a `P_BMM_INDEXED_CONTAINER_TYPE`.
+///
+/// `master04-syntax.adoc` §Container Properties: "The meta-element `index_type`
+/// is used to state the key type."
+fn read_indexed_container_type(
+    path: &str,
+    value: &OdinValue,
+) -> Result<PBmmIndexedContainerType, PBmmReadError> {
+    let body = expect_marker(
+        path,
+        value,
+        "P_BMM_INDEXED_CONTAINER_TYPE",
+        &["P_BMM_INDEXED_CONTAINER_TYPE"],
+    )?;
+    let empty = IndexMap::new();
+    let mut block = Block::open(path, body, &empty)?;
+    let container_type = block.required_string("container_type")?;
+    let index_type = block.required_string("index_type")?;
+    let r#type = block.optional_string("type")?;
+    let type_def = read_optional_base_type(&mut block)?;
+    block.finish(&[])?;
+    Ok(PBmmIndexedContainerType {
+        bmm_type: None,
+        container_type,
+        type_def,
+        r#type,
+        index_type,
+    })
+}
+
+/// Reads a container type's nested `type_def` (a `P_BMM_BASE_TYPE`).
+fn read_optional_base_type(block: &mut Block<'_>) -> Result<Option<PBmmBaseType>, PBmmReadError> {
+    let path = block.member_path("type_def");
+    match block.take("type_def") {
+        Some(value) => read_base_type(&path, value).map(Some),
+        None => Ok(None),
+    }
+}
+
+/// Unwraps a type block whose ODIN marker, when present, must be one of
+/// `allowed`.
+fn expect_marker<'a>(
+    path: &str,
+    value: &'a OdinValue,
+    expected: &'static str,
+    allowed: &[&str],
+) -> Result<&'a OdinValue, PBmmReadError> {
+    let (marker, body) = split_marker(value);
+    match marker {
+        None => Ok(body),
+        Some(found) if allowed.contains(&found) => Ok(body),
+        Some(found) => Err(PBmmReadError::UnexpectedTypeMarker {
+            path: path.to_owned(),
+            marker: found.to_owned(),
+            expected,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![expect(
+        clippy::panic_in_result_fn,
+        reason = "the Book ch11 test shape: `?` propagates the read/resolve/model plumbing while the assertions ARE the test — an assertion panic is how these tests fail"
+    )]
+    use super::read_schema;
+    use crate::bmm_persistence::error::PBmmReadError;
+    use crate::bmm_persistence::p_bmm_class::PBmmClass;
+    use crate::bmm_persistence::p_bmm_container_property::PBmmContainerProperty;
+    use crate::bmm_persistence::p_bmm_container_type::PBmmContainerType;
+    use crate::bmm_persistence::p_bmm_generic_type::PBmmGenericType;
+    use crate::bmm_persistence::p_bmm_indexed_container_type::PBmmIndexedContainerType;
+    use crate::bmm_persistence::p_bmm_property::PBmmProperty;
+    use crate::bmm_persistence::p_bmm_schema::PBmmSchema;
+    use crate::bmm_persistence::p_bmm_type::PBmmType;
+    use openehr_base::prelude::Interval;
+    use openehr_base::prelude::ProperInterval;
+
+    /// The four identifying header items every fixture below needs.
+    const HEADER: &str = r#"
+        bmm_version = <"2.4">
+        rm_publisher = <"openehr">
+        schema_name = <"adltest">
+        rm_release = <"1.0.2">
+    "#;
+
+    /// Reads `HEADER` plus `body`.
+    fn read(body: &str) -> Result<PBmmSchema, PBmmReadError> {
+        read_schema(&format!("{HEADER}{body}"))
+    }
+
+    /// The class definition named `name` in `schema`.
+    fn class<'a>(schema: &'a PBmmSchema, name: &str) -> &'a PBmmClass {
+        schema
+            .class_definitions
+            .iter()
+            .find(|class| class.name() == name)
+            .expect("the fixture defines the class")
+    }
+
+    /// The property named `property` of the class named `class_name`.
+    fn property<'a>(schema: &'a PBmmSchema, class_name: &str, property: &str) -> &'a PBmmProperty {
+        class(schema, class_name)
+            .properties()
+            .expect("the class declares properties")
+            .get(property)
+            .expect("the class declares the property")
+    }
+
+    #[test]
+    fn header_items_read_verbatim() -> Result<(), PBmmReadError> {
+        // master04-syntax.adoc §Header Items, verbatim (including `model_name`,
+        // which P_BMM_SCHEMA does not declare and the reader tolerates).
+        let schema = read_schema(
+            r#"
+            bmm_version = <"2.3">
+            rm_publisher = <"openehr">
+            schema_name = <"adltest">
+            rm_release = <"1.0.2">
+            model_name = <"TEST_PKG">
+            schema_revision = <"1.0.36">
+            schema_lifecycle_state = <"stable">
+            schema_description = <"openEHR schema to support test archetypes">
+        "#,
+        )?;
+        assert_eq!(schema.bmm_version, "2.3");
+        assert_eq!(schema.schema_id(), "openehr_adltest_1.0.2");
+        assert_eq!(schema.schema_revision, "1.0.36");
+        assert_eq!(schema.schema_lifecycle_state, "stable");
+        // Declared 1..1 but omitted by the chapter's own example.
+        assert_eq!(schema.schema_author, "");
+        Ok(())
+    }
+
+    #[test]
+    fn a_missing_identifying_header_is_refused() {
+        let error = read_schema(r#"bmm_version = <"2.4">"#).expect_err("rm_publisher is missing");
+        assert_eq!(
+            error,
+            PBmmReadError::MissingAttribute {
+                path: String::new(),
+                attribute: "rm_publisher",
+            }
+        );
+    }
+
+    #[test]
+    fn an_undeclared_attribute_is_refused_by_name() {
+        let error = read(r#"not_a_bmm_attribute = <"x">"#).expect_err("the attribute is unknown");
+        assert_eq!(
+            error,
+            PBmmReadError::UnknownAttribute {
+                path: String::new(),
+                attribute: "not_a_bmm_attribute".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn includes_are_keyed_by_their_own_id() -> Result<(), PBmmReadError> {
+        // master04-syntax.adoc §Inclusions, verbatim.
+        let schema = read(
+            r#"
+            includes = <
+                ["1"] = <
+                    id = <"openehr_basic_types_1.0.2">
+                >
+            >
+        "#,
+        )?;
+        let includes = schema.includes.expect("the schema declares an include");
+        assert_eq!(includes.len(), 1);
+        assert_eq!(
+            includes
+                .get("openehr_basic_types_1.0.2")
+                .map(|spec| spec.id.as_str()),
+            Some("openehr_basic_types_1.0.2")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn packages_read_recursively_and_only_top_level_ids_may_be_paths() -> Result<(), PBmmReadError>
+    {
+        // master04-syntax.adoc §Package Definition, verbatim.
+        let schema = read(
+            r#"
+            packages = <
+                ["org.openehr.test_pkg"] = <
+                    name = <"org.openehr.test_pkg">
+                    classes = <"WHOLE", "SOME_TYPE", "BOOK">
+                >
+            >
+        "#,
+        )?;
+        let package = schema
+            .packages
+            .get("org.openehr.test_pkg")
+            .expect("the top-level package reads");
+        assert_eq!(package.classes.len(), 3);
+
+        let error = read(
+            r#"
+            packages = <
+                ["ParentPackage"] = <
+                    name = <"ParentPackage">
+                    packages = <
+                        ["invalid.ChildPackage"] = <
+                            name = <"invalid.ChildPackage">
+                        >
+                    >
+                >
+            >
+        "#,
+        )
+        .expect_err("a nested package id may not be a path");
+        assert!(
+            matches!(error, PBmmReadError::QualifiedNestedPackage { .. }),
+            "expected a qualified-nested-package refusal, got {error:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn a_key_that_disagrees_with_the_name_attribute_is_refused() {
+        let error = read(
+            r#"
+            packages = <
+                ["ParentPackage"] = <
+                    name = <"OtherName">
+                >
+            >
+        "#,
+        )
+        .expect_err("the key and name disagree");
+        assert!(
+            matches!(error, PBmmReadError::KeyNameMismatch { .. }),
+            "expected a key/name refusal, got {error:?}"
+        );
+    }
+
+    #[test]
+    fn single_and_container_properties_read_the_master04_examples() -> Result<(), PBmmReadError> {
+        // master04-syntax.adoc §Class properties + §Container Properties.
+        let schema = read(
+            r#"
+            class_definitions = <
+                ["ELEMENT"] = <
+                    name = <"ELEMENT">
+                    ancestors = <"ITEM">
+                    properties = <
+                        ["null_flavour"] = (P_BMM_SINGLE_PROPERTY) <
+                            name = <"null_flavour">
+                            type = <"DV_CODED_TEXT">
+                            is_mandatory = <True>
+                        >
+                        ["items"] = (P_BMM_CONTAINER_PROPERTY) <
+                            name = <"items">
+                            type_def = <
+                                container_type = <"List">
+                                type = <"ITEM">
+                            >
+                            cardinality = <|>=1|>
+                            is_mandatory = <True>
+                        >
+                        ["custom_actions"] = (P_BMM_INDEXED_CONTAINER_PROPERTY) <
+                            name = <"custom_actions">
+                            type_def = <
+                                container_type = <"Hash">
+                                index_type = <"String">
+                                type = <"EVENT_ACTION">
+                            >
+                            cardinality = <|>=0|>
+                        >
+                    >
+                >
+            >
+        "#,
+        )?;
+        assert_eq!(class(&schema, "ELEMENT").ancestors(), ["ITEM"]);
+        assert_eq!(class(&schema, "ELEMENT").uid(), 1);
+        assert_eq!(
+            class(&schema, "ELEMENT").source_schema_id(),
+            "openehr_adltest_1.0.2"
+        );
+
+        let PBmmProperty::PBmmSingleProperty(single) = property(&schema, "ELEMENT", "null_flavour")
+        else {
+            panic!("null_flavour is a P_BMM_SINGLE_PROPERTY");
+        };
+        assert_eq!(single.r#type.as_deref(), Some("DV_CODED_TEXT"));
+        assert_eq!(single.is_mandatory, Some(true));
+
+        let PBmmProperty::PBmmContainerProperty(PBmmContainerProperty::PBmmContainerProperty(
+            container,
+        )) = property(&schema, "ELEMENT", "items")
+        else {
+            panic!("items is a P_BMM_CONTAINER_PROPERTY");
+        };
+        let type_def = container
+            .type_def
+            .as_ref()
+            .expect("the container states a type_def");
+        assert_eq!(type_def.as_type_string(), "List<ITEM>");
+        // `|>=1|` is lower-bounded and upper-unbounded.
+        let Some(Interval::ProperInterval(ProperInterval::ProperInterval(cardinality))) =
+            container.cardinality.as_ref()
+        else {
+            panic!("the cardinality reads as a proper interval");
+        };
+        assert_eq!(cardinality.lower, Some(1));
+        assert!(cardinality.lower_included);
+        assert_eq!(cardinality.upper, None);
+        assert!(cardinality.upper_unbounded);
+
+        let PBmmProperty::PBmmContainerProperty(
+            PBmmContainerProperty::PBmmIndexedContainerProperty(indexed),
+        ) = property(&schema, "ELEMENT", "custom_actions")
+        else {
+            panic!("custom_actions is a P_BMM_INDEXED_CONTAINER_PROPERTY");
+        };
+        assert_eq!(
+            indexed
+                .type_def
+                .as_ref()
+                .map(PBmmIndexedContainerType::as_type_string)
+                .as_deref(),
+            Some("Hash<String,EVENT_ACTION>")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn a_property_without_a_type_marker_is_refused() {
+        let error = read(
+            r#"
+            class_definitions = <
+                ["ELEMENT"] = <
+                    name = <"ELEMENT">
+                    properties = <
+                        ["value"] = <
+                            name = <"value">
+                            type = <"DATA_VALUE">
+                        >
+                    >
+                >
+            >
+        "#,
+        )
+        .expect_err("§Class properties requires the marker");
+        assert_eq!(
+            error,
+            PBmmReadError::MissingTypeMarker {
+                path: "class_definitions/ELEMENT/properties/value".to_owned(),
+                expected: "P_BMM_PROPERTY",
+            }
+        );
+    }
+
+    #[test]
+    fn crazy_type_reads_every_mixed_generic_parameter_form() -> Result<(), PBmmReadError> {
+        // master04-syntax.adoc §Generic Classes CRAZY_TYPE, verbatim.
+        let schema = read(
+            r#"
+            class_definitions = <
+                ["CRAZY_TYPE"] = <
+                    name = <"CRAZY_TYPE">
+                    ancestors = <"Any">
+                    properties = <
+                        ["range"] = (P_BMM_GENERIC_PROPERTY) <
+                            name = <"range">
+                            type_def = <
+                                root_type = <"REFERENCE_RANGE">
+                                generic_parameter_defs = <
+                                    ["T"] = (P_BMM_GENERIC_TYPE) <
+                                        root_type = <"DV_INTERVAL">
+                                        generic_parameters = <"DV_QUANTITY">
+                                    >
+                                    ["U"] = (P_BMM_SIMPLE_TYPE) <
+                                        type = <"Integer">
+                                    >
+                                    ["V"] = (P_BMM_CONTAINER_TYPE) <
+                                        type = <"DV_QUANTITY">
+                                        container_type = <"List">
+                                    >
+                                    ["W"] = (P_BMM_CONTAINER_TYPE) <
+                                        type_def = (P_BMM_GENERIC_TYPE) <
+                                            root_type = <"DV_INTERVAL">
+                                            generic_parameters = <"DV_QUANTITY">
+                                        >
+                                        container_type = <"List">
+                                    >
+                                >
+                            >
+                        >
+                    >
+                >
+            >
+        "#,
+        )?;
+        let PBmmProperty::PBmmGenericProperty(generic) = property(&schema, "CRAZY_TYPE", "range")
+        else {
+            panic!("range is a P_BMM_GENERIC_PROPERTY");
+        };
+        let type_def = generic.type_def.as_ref().expect("range states a type_def");
+        assert_eq!(
+            type_def.as_type_string(),
+            "REFERENCE_RANGE<DV_INTERVAL<DV_QUANTITY>,Integer,List<DV_QUANTITY>,List<DV_INTERVAL<DV_QUANTITY>>>"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn value_set_constraints_read_in_both_positions() -> Result<(), PBmmReadError> {
+        // master04-syntax.adoc §Value-set Constraints, both forms.
+        let schema = read(
+            r#"
+            class_definitions = <
+                ["TRANSLATION_DETAILS"] = <
+                    name = <"TRANSLATION_DETAILS">
+                    properties = <
+                        ["encoding"] = (P_BMM_SINGLE_PROPERTY) <
+                            name = <"encoding">
+                            type_ref = <
+                                type = <"CODE_PHRASE">
+                                value_constraint = <"openEHR::languages">
+                            >
+                        >
+                        ["language"] = (P_BMM_CONTAINER_PROPERTY) <
+                            name = <"language">
+                            type_def = <
+                                container_type = <"List">
+                                type_def = (P_BMM_SIMPLE_TYPE) <
+                                    type = <"Coding">
+                                    value_constraint = <"hl7::Languages">
+                                >
+                            >
+                        >
+                    >
+                >
+            >
+        "#,
+        )?;
+        let PBmmProperty::PBmmSingleProperty(single) =
+            property(&schema, "TRANSLATION_DETAILS", "encoding")
+        else {
+            panic!("encoding is a P_BMM_SINGLE_PROPERTY");
+        };
+        let type_ref = single
+            .type_ref
+            .as_ref()
+            .expect("encoding states a type_ref");
+        assert_eq!(type_ref.r#type, "CODE_PHRASE");
+        assert_eq!(
+            type_ref.value_constraint.as_deref(),
+            Some("openEHR::languages")
+        );
+
+        let PBmmProperty::PBmmContainerProperty(PBmmContainerProperty::PBmmContainerProperty(
+            container,
+        )) = property(&schema, "TRANSLATION_DETAILS", "language")
+        else {
+            panic!("language is a P_BMM_CONTAINER_PROPERTY");
+        };
+        assert_eq!(
+            container
+                .type_def
+                .as_ref()
+                .map(PBmmContainerType::as_type_string)
+                .as_deref(),
+            Some("List<Coding>")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn functions_constants_and_invariants_read() -> Result<(), PBmmReadError> {
+        // master04-syntax.adoc §Functions, §Constants, §Invariants, verbatim.
+        let schema = read(
+            r#"
+            class_definitions = <
+                ["BMM_MODEL"] = <
+                    name = <"BMM_MODEL">
+                    ancestors = <"BMM_PACKAGE_CONTAINER">
+                    functions = <
+                        ["class_definition"] = <
+                            name = <"class_definition">
+                            parameters = <
+                                ["a_name"] = (P_BMM_SINGLE_FUNCTION_PARAMETER) <
+                                    name = <"a_name">
+                                    type = <"String">
+                                >
+                            >
+                            result = (P_BMM_SIMPLE_TYPE) <
+                                type = <"BMM_CLASS">
+                            >
+                        >
+                    >
+                >
+                ["OPENEHR_DEFINITIONS"] = <
+                    name = <"OPENEHR_DEFINITIONS">
+                    constants = <
+                        ["Local_terminology_id"] = <
+                            name = <"Local_terminology_id">
+                            type = <"String">
+                            value = <"local">
+                        >
+                    >
+                >
+                ["LOCATABLE"] = <
+                    name = <"LOCATABLE">
+                    invariants = <
+                        ["Links_valid"] = <"links /= Void implies not links.is_empty">
+                        ["Archetype_node_id_valid"] = <"not archetype_node_id.is_empty">
+                    >
+                >
+            >
+        "#,
+        )?;
+        let functions = class(&schema, "BMM_MODEL")
+            .functions()
+            .expect("BMM_MODEL declares functions");
+        let function = functions
+            .get("class_definition")
+            .expect("class_definition reads");
+        assert_eq!(
+            function
+                .result
+                .as_ref()
+                .map(PBmmType::as_type_string)
+                .as_deref(),
+            Some("BMM_CLASS")
+        );
+        assert_eq!(
+            function
+                .parameters
+                .as_ref()
+                .map(std::collections::BTreeMap::len),
+            Some(1)
+        );
+
+        let constants = class(&schema, "OPENEHR_DEFINITIONS")
+            .constants()
+            .expect("OPENEHR_DEFINITIONS declares constants");
+        assert_eq!(
+            constants
+                .get("Local_terminology_id")
+                .and_then(|constant| constant.value.as_deref()),
+            Some("local")
+        );
+
+        let invariants = class(&schema, "LOCATABLE")
+            .invariants()
+            .expect("LOCATABLE declares invariants");
+        assert_eq!(invariants.len(), 2);
+        assert_eq!(
+            invariants.get("Links_valid").map(String::as_str),
+            Some("links /= Void implies not links.is_empty")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn enumerations_read_names_and_values() -> Result<(), PBmmReadError> {
+        // master04-syntax.adoc §Enumerated Types, verbatim.
+        let schema = read(
+            r#"
+            class_definitions = <
+                ["PROPORTION_KIND_2"] = (P_BMM_ENUMERATION_INTEGER) <
+                    name = <"PROPORTION_KIND_2">
+                    ancestors = <"Integer">
+                    item_names = <"pk_ratio", "pk_unitary", "pk_percent", "pk_fraction">
+                    item_values = <0, 1001, 1002, 1003>
+                >
+                ["MAGNITUDE_STATUS"] = (P_BMM_ENUMERATION_STRING) <
+                    name = <"MAGNITUDE_STATUS">
+                    ancestors = <"String", ...>
+                    item_names = <"le", "ge", "eq", "approx_eq">
+                    item_values = <"<=", ">=", "=", "~">
+                >
+            >
+        "#,
+        )?;
+        let PBmmClass::PBmmEnumeration(integer) = class(&schema, "PROPORTION_KIND_2") else {
+            panic!("PROPORTION_KIND_2 is a P_BMM_ENUMERATION_INTEGER");
+        };
+        assert_eq!(integer.item_names().len(), 4);
+        assert_eq!(integer.item_values().len(), 4);
+        assert_eq!(integer.underlying_type_name(), "INTEGER");
+
+        let PBmmClass::PBmmEnumeration(string) = class(&schema, "MAGNITUDE_STATUS") else {
+            panic!("MAGNITUDE_STATUS is a P_BMM_ENUMERATION_STRING");
+        };
+        assert_eq!(string.underlying_type_name(), "STRING");
+        // The open-list marker of `ancestors = <"String", ...>` is not an item.
+        assert_eq!(class(&schema, "MAGNITUDE_STATUS").ancestors(), ["String"]);
+        Ok(())
+    }
+
+    #[test]
+    fn generic_inheritance_reads_ancestor_defs() -> Result<(), PBmmReadError> {
+        // master04-syntax.adoc §Inheritance, GENERIC_CHILD_OPEN_T.
+        let schema = read(
+            r#"
+            class_definitions = <
+                ["GENERIC_CHILD_OPEN_T"] = <
+                    name = <"GENERIC_CHILD_OPEN_T">
+                    ancestor_defs = <
+                        ["GENERIC_PARENT<T,SUPPLIER_B>"] = (P_BMM_GENERIC_TYPE) <
+                            root_type = <"GENERIC_PARENT">
+                            generic_parameters = <"T", "SUPPLIER_B">
+                        >
+                    >
+                    generic_parameter_defs = <
+                        ["T"] = <
+                            name = <"T">
+                            conforms_to_type = <"SUPPLIER">
+                        >
+                    >
+                    properties = <
+                        ["gen_child_open_t_prop"] = (P_BMM_SINGLE_PROPERTY) <
+                            name = <"gen_child_open_t_prop">
+                            type = <"String">
+                        >
+                    >
+                >
+            >
+        "#,
+        )?;
+        let child = class(&schema, "GENERIC_CHILD_OPEN_T");
+        assert!(child.is_generic());
+        let defs = child.ancestor_defs();
+        assert_eq!(defs.len(), 1);
+        let signature = defs
+            .first()
+            .map(PBmmGenericType::as_type_string)
+            .expect("the ancestor_defs entry reads");
+        assert_eq!(signature, "GENERIC_PARENT<T,SUPPLIER_B>");
+        Ok(())
+    }
+
+    #[test]
+    fn an_ancestor_def_that_is_not_a_generic_type_is_refused() {
+        // `P_BMM_CLASS.ancestor_defs` is List<P_BMM_GENERIC_TYPE> (class doc
+        // §Attributes) and §Inheritance uses it only for generic ancestors, so a
+        // (P_BMM_SIMPLE_TYPE) entry — as written by the vendored archie fixture
+        // `ancestor_def_doesnt_exist.bmm` — states no `root_type` and cannot be
+        // materialised.
+        let error = read(
+            r#"
+            class_definitions = <
+                ["ParentType1"] = <
+                    name = <"ParentType1">
+                    ancestor_defs = <
+                        ["UNKNOWN"] = (P_BMM_SIMPLE_TYPE) <
+                            type = <"UNKNOWN">
+                        >
+                    >
+                >
+            >
+        "#,
+        )
+        .expect_err("ancestor_defs admits only P_BMM_GENERIC_TYPE");
+        assert_eq!(
+            error,
+            PBmmReadError::UnexpectedTypeMarker {
+                path: "class_definitions/ParentType1/ancestor_defs/UNKNOWN".to_owned(),
+                marker: "P_BMM_SIMPLE_TYPE".to_owned(),
+                expected: "P_BMM_GENERIC_TYPE",
+            }
+        );
+    }
+
+    #[test]
+    fn a_persisted_interface_is_refused_not_dropped() {
+        let error = read(
+            r#"
+            class_definitions = <
+                ["Env"] = (P_BMM_INTERFACE) <
+                    name = <"Env">
+                >
+            >
+        "#,
+        )
+        .expect_err("P_BMM_SCHEMA has no slot for a persisted interface");
+        assert_eq!(
+            error,
+            PBmmReadError::InterfaceInClassList {
+                path: "class_definitions/Env".to_owned(),
+                name: "Env".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn primitive_types_read_as_ordinary_class_definitions() -> Result<(), PBmmReadError> {
+        // master04-syntax.adoc §Classes for Primitive Types, verbatim.
+        let schema = read(
+            r#"
+            primitive_types = <
+                ["Any"] = <
+                    name = <"Any">
+                    is_abstract = <True>
+                >
+                ["Ordered"] = <
+                    name = <"Ordered">
+                    is_abstract = <True>
+                    ancestors = <"Any">
+                >
+            >
+        "#,
+        )?;
+        assert_eq!(schema.primitive_types.len(), 2);
+        assert!(schema.primitive_types.iter().all(PBmmClass::is_abstract));
+        // uid numbering runs over primitive_types first, then class_definitions.
+        assert_eq!(
+            schema
+                .primitive_types
+                .iter()
+                .map(PBmmClass::uid)
+                .collect::<Vec<_>>(),
+            [1, 2]
+        );
+        Ok(())
+    }
+}

--- a/crates/openehr-lang/tests/it/main.rs
+++ b/crates/openehr-lang/tests/it/main.rs
@@ -1,7 +1,8 @@
 //! Integration tests for `openehr-lang`: the shared lexical layer, the ODIN +
-//! BMM reader and the Basic Expression Language parser — the per-language
+//! `P_BMM` readers and the Basic Expression Language parser — the per-language
 //! lexer-surface battery, the vendored-fixture batteries (`tests/vendor/**`),
-//! their 100%-coverage gate, and BEL parsing.
+//! their 100%-coverage gate, the adjudicated `P_BMM` schema→`BMM_MODEL` outcome
+//! table over the same corpus, and BEL parsing.
 //!
 //! One binary per crate, split into topic modules
 //! (`.claude/rules/testing.md` §One integration-test binary per crate).
@@ -11,5 +12,6 @@ mod escape_validation;
 mod lexer_equivalence;
 mod odin_spec_examples;
 mod vendor_bmm_odin;
+mod vendor_bmm_schema;
 mod vendor_coverage;
 mod vendor_odin;

--- a/crates/openehr-lang/tests/it/vendor_bmm_schema.rs
+++ b/crates/openehr-lang/tests/it/vendor_bmm_schema.rs
@@ -1,0 +1,510 @@
+//! Public-API battery for the P_BMM schema pipeline
+//! (`openehr_lang::bmm_persistence`) over every vendored `.bmm` schema under
+//! `tests/vendor/**`: ODIN text → `P_BMM_SCHEMA` → inclusion resolution →
+//! `BMM_MODEL`.
+//!
+//! `vendor_bmm_odin.rs` already pins that all 38 `tests/vendor/bmm/**` files
+//! PARSE as ODIN; this module pins what they mean as P_BMM schemas, and adds the
+//! five `.bmm` schemas under `tests/vendor/odin/odin/`.
+//!
+//! **Every file has an adjudicated expected outcome** — either a materialised
+//! `BMM_MODEL` (with its class count) or a typed refusal at a named stage with
+//! the spec ground for the refusal. There are no silent skips. The archie
+//! fixtures under `bmm/org/openehr/bmm/v2/persistence/validation/` are
+//! deliberately defective schemas, and this table records which stage of the
+//! openEHR-specified pipeline each defect surfaces at.
+//!
+//! Spec oracle: `docs/specs/openehr/LANG/docs/bmm_persistence/`
+//! (`master02-overview.adoc` §Conceptual Approach for the three stages,
+//! `master04-syntax.adoc` for the ODIN form) plus the class docs under
+//! `docs/specs/openehr/LANG/docs/UML/classes/org.openehr.lang.bmm*.adoc`.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    reason = "integration-test assertions and fixture plumbing outside #[test] fns, which the clippy.toml allow-*-in-tests scoping does not reach"
+)]
+#![allow(
+    clippy::doc_markdown,
+    reason = "the module docs name the archie fixture directories and openEHR schema files as prose, not code refs"
+)]
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use openehr_lang::bmm_persistence::create_model::create_bmm_model;
+use openehr_lang::bmm_persistence::error::PBmmReadError;
+use openehr_lang::bmm_persistence::include_resolution::resolve_includes;
+use openehr_lang::bmm_persistence::p_bmm_schema::PBmmSchema;
+use openehr_lang::bmm_persistence::reader::read_schema;
+
+/// The pipeline stage an outcome is observed at
+/// (`master02-overview.adoc` §Conceptual Approach).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Stage {
+    /// `read_schema` — the ODIN → `P_BMM_SCHEMA` walk.
+    Read,
+    /// `resolve_includes` — schema inclusion resolution.
+    Resolve,
+    /// `create_bmm_model` — the `P_BMM` → `BMM` transform.
+    Model,
+}
+
+/// The typed error discriminant an adjudicated refusal must carry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Kind {
+    /// [`PBmmReadError::UnknownAttribute`].
+    UnknownAttribute,
+    /// [`PBmmReadError::UnexpectedTypeMarker`].
+    UnexpectedTypeMarker,
+    /// [`PBmmReadError::KeyNameMismatch`].
+    KeyNameMismatch,
+    /// [`PBmmReadError::QualifiedNestedPackage`].
+    QualifiedNestedPackage,
+    /// [`PBmmReadError::InterfaceInClassList`].
+    InterfaceInClassList,
+    /// [`PBmmReadError::MissingInclude`].
+    MissingInclude,
+    /// [`PBmmReadError::UnknownAncestor`].
+    UnknownAncestor,
+    /// [`PBmmReadError::UnknownType`].
+    UnknownType,
+    /// [`PBmmReadError::ClassNotInAnyPackage`].
+    ClassNotInAnyPackage,
+    /// [`PBmmReadError::ClassNotDefined`].
+    ClassNotDefined,
+    /// [`PBmmReadError::ContainerTargetTypeMissing`].
+    ContainerTargetTypeMissing,
+    /// [`PBmmReadError::TypeDefinitionMissing`].
+    TypeDefinitionMissing,
+    /// [`PBmmReadError::UndeclaredGenericParameter`].
+    UndeclaredGenericParameter,
+}
+
+/// The discriminant of `error`.
+fn kind_of(error: &PBmmReadError) -> Kind {
+    match error {
+        PBmmReadError::UnknownAttribute { .. } => Kind::UnknownAttribute,
+        PBmmReadError::UnexpectedTypeMarker { .. } => Kind::UnexpectedTypeMarker,
+        PBmmReadError::KeyNameMismatch { .. } => Kind::KeyNameMismatch,
+        PBmmReadError::QualifiedNestedPackage { .. } => Kind::QualifiedNestedPackage,
+        PBmmReadError::InterfaceInClassList { .. } => Kind::InterfaceInClassList,
+        PBmmReadError::MissingInclude { .. } => Kind::MissingInclude,
+        PBmmReadError::UnknownAncestor { .. } => Kind::UnknownAncestor,
+        PBmmReadError::UnknownType { .. } => Kind::UnknownType,
+        PBmmReadError::ClassNotInAnyPackage { .. } => Kind::ClassNotInAnyPackage,
+        PBmmReadError::ClassNotDefined { .. } => Kind::ClassNotDefined,
+        PBmmReadError::ContainerTargetTypeMissing { .. } => Kind::ContainerTargetTypeMissing,
+        PBmmReadError::TypeDefinitionMissing { .. } => Kind::TypeDefinitionMissing,
+        PBmmReadError::UndeclaredGenericParameter { .. } => Kind::UndeclaredGenericParameter,
+        other => panic!("unexpected error kind in the vendored corpus: {other:?}"),
+    }
+}
+
+/// What the pipeline must do with one vendored schema.
+#[derive(Debug, Clone, Copy)]
+enum Outcome {
+    /// Reads, resolves and materialises; the model's class count.
+    Model(usize),
+    /// An adjudicated refusal: the stage, the typed discriminant, and a
+    /// substring of the message that pins WHICH element is at fault.
+    Refused(Stage, Kind, &'static str),
+}
+
+/// One row of the corpus expectation table.
+struct Case {
+    /// Path relative to `tests/vendor`.
+    path: &'static str,
+    /// The adjudicated outcome.
+    outcome: Outcome,
+    /// The spec ground for a refusal, or the reason a model is expected.
+    /// Documentation for the reader; not asserted.
+    #[expect(dead_code, reason = "the adjudication rationale documents the row")]
+    adjudication: &'static str,
+}
+
+/// The complete outcome table for every vendored `.bmm` schema — 43 files.
+///
+/// Class counts are the materialised `BMM_MODEL.class_definitions` size after
+/// inclusion resolution against [`include_map`].
+#[expect(
+    clippy::too_many_lines,
+    reason = "one row per vendored fixture; splitting the table hides the corpus"
+)]
+fn cases() -> Vec<Case> {
+    vec![
+        // ── the published openEHR RM 1.0.2 inclusion chain ──────────────────
+        Case {
+            path: "bmm/openehr/openehr_primitive_types_102.bmm",
+            outcome: Outcome::Model(22),
+            adjudication: "self-contained primitive_types schema; master04 §Classes for Primitive Types",
+        },
+        Case {
+            path: "bmm/openehr/openehr_basic_types_102.bmm",
+            outcome: Outcome::Model(71),
+            adjudication: "includes openehr_primitive_types_1.0.2",
+        },
+        Case {
+            path: "bmm/openehr/openehr_structures_102.bmm",
+            outcome: Outcome::Model(105),
+            adjudication: "transitively includes basic_types → primitive_types",
+        },
+        Case {
+            path: "bmm/openehr/openehr_ehr_102.bmm",
+            outcome: Outcome::Model(124),
+            adjudication: "transitively includes structures → basic_types → primitive_types",
+        },
+        Case {
+            path: "bmm/openehr/openehr_demographic_102.bmm",
+            outcome: Outcome::Model(117),
+            adjudication: "transitively includes structures → basic_types → primitive_types",
+        },
+        Case {
+            path: "bmm/openehr/openehr_rm_102.bmm",
+            outcome: Outcome::Model(136),
+            adjudication: "the whole RM 1.0.2: includes ehr + demographic, four levels deep",
+        },
+        // ── further published openEHR schemas ───────────────────────────────
+        Case {
+            path: "bmm/openehr/openehr_base_110.bmm",
+            outcome: Outcome::Model(56),
+            adjudication: "self-contained BASE 1.1.0 schema",
+        },
+        Case {
+            path: "bmm/openehr/openehr_base_for_aom.bmm",
+            outcome: Outcome::Model(52),
+            adjudication: "a second schema rendering the id openehr_base_1.1.0; excluded from the include map (first path wins) but self-contained",
+        },
+        Case {
+            path: "bmm/openehr/openEHR_aom_206.bmm",
+            outcome: Outcome::Model(117),
+            adjudication: "includes openehr_base_1.1.0; references BOOLEAN where BASE defines Boolean — master04 §Non-primitive Classes: 'any capitalisation can be used'",
+        },
+        Case {
+            path: "bmm/openehr/openehr_adltest_100.bmm",
+            outcome: Outcome::Model(94),
+            adjudication: "the master04 §Header Items / §Inheritance example schema: model_name tolerance, generic inheritance via ancestor_defs, mixed-case type refs (Iso8601_date vs ISO8601_DATE)",
+        },
+        // ── the CIMI reference models ───────────────────────────────────────
+        Case {
+            path: "bmm/cimi/CIMI_RM_CORE.v.0.0.2.bmm",
+            outcome: Outcome::Model(41),
+            adjudication: "self-contained CIMI core",
+        },
+        Case {
+            path: "bmm/cimi/CIMI_RM_FOUNDATION.v.0.0.2.bmm",
+            outcome: Outcome::Model(55),
+            adjudication: "includes cimi_rm_core_0.0.2",
+        },
+        Case {
+            path: "bmm/cimi/CIMI_RM_CLINICAL.v.0.0.2.bmm",
+            outcome: Outcome::Model(198),
+            adjudication: "includes cimi_rm_core_0.0.2 + cimi_rm_foundation_0.0.2",
+        },
+        Case {
+            path: "odin/odin/CIMI_RM_CORE.v.0.0.1.bmm",
+            outcome: Outcome::Model(37),
+            adjudication: "the 0.0.1 generation of the same CIMI core",
+        },
+        Case {
+            path: "odin/odin/CIMI_RM_FOUNDATION.v.0.0.1.bmm",
+            outcome: Outcome::Model(50),
+            adjudication: "includes cimi_rm_core_0.0.1",
+        },
+        Case {
+            path: "odin/odin/CIMI_RM_CLINICAL.v.0.0.1.bmm",
+            outcome: Outcome::Model(144),
+            adjudication: "includes cimi_rm_core_0.0.1 + cimi_rm_foundation_0.0.1",
+        },
+        Case {
+            path: "bmm/CIMI-RM-3.0.5.bmm",
+            outcome: Outcome::Refused(Stage::Read, Kind::KeyNameMismatch, "bmmType"),
+            adjudication: "PARTICIPATION declares [\"type\"] with name = <\"bmmType\">, violating master04 §Package Definition's third NOTE ('make sure that the ODIN keys are the same as the name attributes in each block')",
+        },
+        Case {
+            path: "bmm/cimi/CIMI-RM-3.0.5.bmm",
+            outcome: Outcome::Refused(Stage::Read, Kind::KeyNameMismatch, "bmmType"),
+            adjudication: "byte-identical copy of the file above; same key/name defect",
+        },
+        Case {
+            path: "odin/odin/CIMI-RM-3.0.5.bmm",
+            outcome: Outcome::Refused(Stage::Read, Kind::UnknownAttribute, "bmmType"),
+            adjudication: "ARCHETYPED.archetype_id writes `bmmType = <\"String\">`; P_BMM_SINGLE_PROPERTY declares `type`, not `bmmType` (…p_bmm_single_property.adoc §Attributes)",
+        },
+        Case {
+            path: "odin/odin/CIMI-RM-3.0.5_tweaked.bmm",
+            outcome: Outcome::Refused(Stage::Read, Kind::UnknownAttribute, "bmmType"),
+            adjudication: "hand-tweaked variant of the file above; same undeclared attribute",
+        },
+        // ── the archie P_BMM validation fixtures ────────────────────────────
+        Case {
+            path: "bmm/testbmm/TestBmm1.bmm",
+            outcome: Outcome::Refused(Stage::Resolve, Kind::MissingInclude, "my_include.2.1.12"),
+            adjudication: "declares two includes that exist in no repository; P_BMM_SCHEMA.merge's precondition includes_to_process.has(...) cannot be met",
+        },
+        Case {
+            path: "bmm/org/openehr/bmm/v2/persistence/validation/valid.bmm",
+            outcome: Outcome::Model(3),
+            adjudication: "the archie baseline schema its BasicSchemaValidationsTest mutates; semantically valid",
+        },
+        Case {
+            path: "bmm/org/openehr/bmm/v2/persistence/validation/duplicate_class.bmm",
+            outcome: Outcome::Model(3),
+            adjudication: "lists ParentType1 twice in one package; a duplicate entry in BMM_PACKAGE.classes is not a construction failure, so the model materialises",
+        },
+        Case {
+            path: "bmm/org/openehr/bmm/v2/persistence/validation/illegal_sibling_packages.bmm",
+            outcome: Outcome::Model(3),
+            adjudication: "sibling packages ParentPackage / ParentPackages; no P_BMM rule forbids a name that is another's prefix, so the model materialises",
+        },
+        Case {
+            path: "bmm/org/openehr/bmm/v2/persistence/validation/overridden_property_non_conformance.bmm",
+            outcome: Outcome::Model(4),
+            adjudication: "ChildType1 redefines property_1 to a non-conformant type; conformance is a validation question above the transform, so the model materialises",
+        },
+        Case {
+            path: "bmm/org/openehr/bmm/v2/persistence/validation/include_not_found.bmm",
+            outcome: Outcome::Refused(Stage::Resolve, Kind::MissingInclude, "my_include.2.1.12"),
+            adjudication: "an includes entry naming a schema absent from the repository",
+        },
+        Case {
+            path: "bmm/org/openehr/bmm/v2/persistence/validation/ancestor_def_doesnt_exist.bmm",
+            outcome: Outcome::Refused(Stage::Read, Kind::UnexpectedTypeMarker, "P_BMM_SIMPLE_TYPE"),
+            adjudication: "ancestor_defs holds a (P_BMM_SIMPLE_TYPE) entry; P_BMM_CLASS.ancestor_defs is List<P_BMM_GENERIC_TYPE> (class doc §Attributes) and master04 §Inheritance uses it only for generic ancestors, and a simple type states no root_type",
+        },
+        Case {
+            path: "bmm/org/openehr/bmm/v2/persistence/validation/package_illegal_qualified_name.bmm",
+            outcome: Outcome::Refused(
+                Stage::Read,
+                Kind::QualifiedNestedPackage,
+                "invalid.ChildPackage",
+            ),
+            adjudication: "master04 §Package Definition, first NOTE: 'only top-level package ids can be paths (i.e. contain the . character)'",
+        },
+        Case {
+            path: "bmm/org/openehr/bmm/v2/persistence/validation/ancestor_doesnt_exist.bmm",
+            outcome: Outcome::Refused(Stage::Model, Kind::UnknownAncestor, "unknown"),
+            adjudication: "BMM_CLASS.ancestors is a map of BMM_CLASS, so an unresolvable parent cannot be materialised",
+        },
+        Case {
+            path: "bmm/org/openehr/bmm/v2/persistence/validation/ancestor_name_empty.bmm",
+            outcome: Outcome::Refused(Stage::Model, Kind::UnknownAncestor, "ancestor ``"),
+            adjudication: "the empty ancestor name resolves to no class; same BMM_CLASS.ancestors reason",
+        },
+        Case {
+            path: "bmm/org/openehr/bmm/v2/persistence/validation/class_not_in_definition.bmm",
+            outcome: Outcome::Refused(Stage::Model, Kind::ClassNotDefined, "String"),
+            adjudication: "master04 §Package Definition, second NOTE: 'only classes defined in the same schema can be referenced in the package section in that schema'",
+        },
+        Case {
+            path: "bmm/org/openehr/bmm/v2/persistence/validation/package_class_name_empty.bmm",
+            outcome: Outcome::Refused(Stage::Model, Kind::ClassNotDefined, "lists class ``"),
+            adjudication: "an empty class name in a package's classes list names no definition; same second NOTE",
+        },
+        Case {
+            path: "bmm/org/openehr/bmm/v2/persistence/validation/class_not_in_packages.bmm",
+            outcome: Outcome::Refused(Stage::Model, Kind::ClassNotInAnyPackage, "UnknownClass"),
+            adjudication: "BMM_CLASS.package is 1..1 ('Package this class belongs to'), so a class no package lists cannot be materialised",
+        },
+        Case {
+            path: "bmm/org/openehr/bmm/v2/persistence/validation/container_target_type_empty.bmm",
+            outcome: Outcome::Refused(
+                Stage::Model,
+                Kind::ContainerTargetTypeMissing,
+                "careProvider",
+            ),
+            adjudication: "the container type_def states container_type but neither type nor type_def; BMM_CONTAINER_TYPE.base_type is 1..1",
+        },
+        Case {
+            path: "bmm/org/openehr/bmm/v2/persistence/validation/container_target_type_not_found.bmm",
+            outcome: Outcome::Refused(Stage::Model, Kind::UnknownType, "Something"),
+            adjudication: "the container's target type names no class definition",
+        },
+        Case {
+            path: "bmm/org/openehr/bmm/v2/persistence/validation/container_type_not_found.bmm",
+            outcome: Outcome::Refused(Stage::Model, Kind::UnknownType, "List"),
+            adjudication: "master04 §Classes for Primitive Types: 'all container types such as List<T>, Hash<V,K> etc are explicit in a BMM schema' — an undefined container class cannot be materialised",
+        },
+        Case {
+            path: "bmm/org/openehr/bmm/v2/persistence/validation/generic_container_property_not_found.bmm",
+            outcome: Outcome::Refused(Stage::Model, Kind::UnknownType, "X"),
+            adjudication: "the container target type X names no class definition",
+        },
+        Case {
+            path: "bmm/org/openehr/bmm/v2/persistence/validation/generic_parameter_not_found.bmm",
+            outcome: Outcome::Refused(Stage::Model, Kind::UnknownType, "Quantity"),
+            adjudication: "an actual generic parameter naming no class definition",
+        },
+        Case {
+            path: "bmm/org/openehr/bmm/v2/persistence/validation/generic_parameter_type_missing.bmm",
+            outcome: Outcome::Refused(Stage::Model, Kind::UnknownType, "unknown"),
+            adjudication: "BMM_GENERIC_PARAMETER.conforms_to_type 'must be another valid class name' (…bmm.bmm_generic_parameter.adoc §Attributes)",
+        },
+        Case {
+            path: "bmm/org/openehr/bmm/v2/persistence/validation/generic_property_type_def_undefined.bmm",
+            outcome: Outcome::Refused(Stage::Model, Kind::TypeDefinitionMissing, "property_1"),
+            adjudication: "a (P_BMM_GENERIC_PROPERTY) with no type_def at all; BMM_PROPERTY.type is 1..1",
+        },
+        Case {
+            path: "bmm/org/openehr/bmm/v2/persistence/validation/generic_root_type_not_found.bmm",
+            outcome: Outcome::Refused(Stage::Model, Kind::UnknownType, "Intervals"),
+            adjudication: "the generic type's root_type names no class definition",
+        },
+        Case {
+            path: "bmm/org/openehr/bmm/v2/persistence/validation/single_property_type_not_found.bmm",
+            outcome: Outcome::Refused(Stage::Model, Kind::UnknownType, "Unknown"),
+            adjudication: "BMM_SIMPLE_TYPE.base_class IS a BMM_CLASS, so a property type naming no definition cannot be materialised",
+        },
+        Case {
+            path: "bmm/org/openehr/bmm/v2/persistence/validation/single_open_property_type_not_found.bmm",
+            outcome: Outcome::Refused(Stage::Model, Kind::UndeclaredGenericParameter, "`X`"),
+            adjudication: "'The parameter must be in the type declaration of the owning BMM_CLASS' (…bmm.bmm_open_type.adoc §Description); ParentType1 declares T, not X",
+        },
+    ]
+}
+
+/// The `tests/vendor` root.
+fn vendor_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/vendor")
+}
+
+/// The ODIN serialisations of the openEHR component schemas that
+/// `openehr-codegen` vendors.
+///
+/// Referenced by path (never copied) so the boundary test below pins the reader
+/// against the schemas the project actually pins (`docs/VERSIONS.md`). Codegen
+/// itself consumes the `.bmm.json` serialisation of these same models, so these
+/// ODIN files are not part of this crate's committed corpus.
+const CODEGEN_VENDOR_ODIN: &str = "../../tools/openehr-codegen/vendor/bmm/components";
+
+/// Reads `path` relative to `tests/vendor`.
+fn source(path: &str) -> String {
+    let full = vendor_root().join(path);
+    std::fs::read_to_string(&full).unwrap_or_else(|e| panic!("read {}: {e}", full.display()))
+}
+
+/// The schemas available for inclusion resolution: every vendored file that
+/// reads cleanly, keyed by its own `schema_id`, FIRST path in table order
+/// winning a collision.
+///
+/// A collision is real in this corpus: `openehr_base_110.bmm` and
+/// `openehr_base_for_aom.bmm` both render `openehr_base_1.1.0`, and the archie
+/// validation fixtures all render `my publisher_duplicate_class_3.1`. Keeping
+/// the first makes the resolution deterministic; the losing files are still
+/// exercised as roots by [`every_vendored_schema_reaches_its_adjudicated_outcome`].
+fn include_map(cases: &[Case]) -> BTreeMap<String, PBmmSchema> {
+    let mut out: BTreeMap<String, PBmmSchema> = BTreeMap::new();
+    for case in cases {
+        if let Ok(schema) = read_schema(&source(case.path)) {
+            out.entry(schema.schema_id()).or_insert(schema);
+        }
+    }
+    out
+}
+
+/// Runs the three stages over `path` and returns the observed outcome, or the
+/// stage + error it failed at.
+fn run(
+    path: &str,
+    includes: &BTreeMap<String, PBmmSchema>,
+) -> Result<usize, (Stage, PBmmReadError)> {
+    let schema = read_schema(&source(path)).map_err(|error| (Stage::Read, error))?;
+    let resolved = resolve_includes(schema, includes).map_err(|error| (Stage::Resolve, error))?;
+    let model = create_bmm_model(&resolved).map_err(|error| (Stage::Model, error))?;
+    Ok(model.class_definitions.as_ref().map_or(0, BTreeMap::len))
+}
+
+#[test]
+fn every_vendored_schema_reaches_its_adjudicated_outcome() {
+    let cases = cases();
+    let includes = include_map(&cases);
+    for case in &cases {
+        let observed = run(case.path, &includes);
+        match (&case.outcome, observed) {
+            (Outcome::Model(expected), Ok(classes)) => assert_eq!(
+                classes, *expected,
+                "{}: class count changed — re-adjudicate before updating",
+                case.path
+            ),
+            (Outcome::Model(_), Err((stage, error))) => {
+                panic!(
+                    "{}: expected a model, got {stage:?} error {error}",
+                    case.path
+                )
+            }
+            (Outcome::Refused(stage, kind, detail), Err((observed_stage, error))) => {
+                assert_eq!(observed_stage, *stage, "{}: wrong stage", case.path);
+                assert_eq!(kind_of(&error), *kind, "{}: wrong error kind", case.path);
+                let message = error.to_string();
+                assert!(
+                    message.contains(detail),
+                    "{}: message {message:?} does not name {detail:?}",
+                    case.path
+                );
+            }
+            (Outcome::Refused(stage, kind, _), Ok(classes)) => panic!(
+                "{}: expected {stage:?} refusal {kind:?}, got a {classes}-class model",
+                case.path
+            ),
+        }
+    }
+}
+
+#[test]
+fn the_table_covers_every_vendored_bmm_file() {
+    let root = vendor_root();
+    let mut on_disk: Vec<String> = Vec::new();
+    collect_bmm(&root, &root, &mut on_disk);
+    on_disk.sort();
+    let mut claimed: Vec<String> = cases().iter().map(|case| case.path.to_owned()).collect();
+    claimed.sort();
+    assert_eq!(
+        claimed, on_disk,
+        "the P_BMM expectation table and the vendored .bmm files disagree"
+    );
+    // 38 under bmm/** + 5 under odin/odin/.
+    assert_eq!(on_disk.len(), 43);
+}
+
+/// Collects every `.bmm` path under `dir`, relative to `root`.
+fn collect_bmm(dir: &Path, root: &Path, out: &mut Vec<String>) {
+    for entry in std::fs::read_dir(dir).unwrap_or_else(|e| panic!("read_dir: {e}")) {
+        let path = entry.unwrap_or_else(|e| panic!("dir entry: {e}")).path();
+        if path.is_dir() {
+            collect_bmm(&path, root, out);
+        } else if path.extension().and_then(|e| e.to_str()) == Some("bmm") {
+            let rel = path
+                .strip_prefix(root)
+                .unwrap_or_else(|e| panic!("strip_prefix: {e}"));
+            out.push(rel.to_string_lossy().replace('\\', "/"));
+        }
+    }
+}
+
+#[test]
+fn the_pinned_openehr_odin_schemas_hit_the_persisted_interface_boundary() {
+    // `P_BMM_SCHEMA.primitive_types`/`class_definitions` are List<P_BMM_CLASS>
+    // (…p_bmm_schema.adoc §Attributes) while P_BMM_INTERFACE inherits
+    // P_BMM_MODEL_ELEMENT (…p_bmm_interface.adoc §Inherit) — the pinned P_BMM
+    // model has no slot for a persisted interface, and master04-syntax.adoc
+    // never serialises one. The RM and BASE ODIN schemas this project pins
+    // (docs/VERSIONS.md: RM 1.2.0, BASE 1.3.0) DO declare interfaces, so the
+    // boundary is pinned here against the real artefacts rather than a fixture.
+    // The reader refuses them rather than silently dropping the interface.
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(CODEGEN_VENDOR_ODIN);
+    for (file, interface) in [
+        ("RM/odin/openehr_rm_1.2.0.bmm", "CODE_SET_ACCESS"),
+        ("BASE/odin/openehr_base_1.3.0.bmm", "Env"),
+    ] {
+        let full = root.join(file);
+        let src = std::fs::read_to_string(&full)
+            .unwrap_or_else(|e| panic!("read {}: {e}", full.display()));
+        let error = read_schema(&src).expect_err("a persisted P_BMM_INTERFACE is refused");
+        assert_eq!(kind_of(&error), Kind::InterfaceInClassList, "{file}");
+        assert!(
+            error.to_string().contains(interface),
+            "{file}: {error} does not name {interface}"
+        );
+    }
+}

--- a/crates/openehr-lang/tests/it/vendor_coverage.rs
+++ b/crates/openehr-lang/tests/it/vendor_coverage.rs
@@ -9,6 +9,12 @@
 //! `CLAIMED` is the union of the fixture tables in `vendor_odin.rs`
 //! (`ODIN_FIXTURES`, 17 files) and `vendor_bmm_odin.rs` (`BMM_FIXTURES`, 38
 //! files) — every claimed path is genuinely parsed and asserted there.
+//!
+//! `vendor_bmm_schema.rs` carries a SECOND, independent table over the same
+//! files: it claims every `.bmm` schema (the 38 above plus the five under
+//! `odin/odin/`) with an adjudicated `P_BMM` read → resolve → `BMM_MODEL` outcome,
+//! and gates its own completeness against the filesystem. It adds no paths, so
+//! `CLAIMED` is unaffected.
 
 #![allow(
     clippy::unwrap_used,


### PR DESCRIPTION
Closes #1391
Closes #1200
Closes #1201
Closes #880
Closes #1202
Closes #1203
Closes #881
Closes #1204
Closes #1205
Closes #1206
Closes #1207
Closes #1208
Closes #1210

## What

The P_BMM document of the #753 LANG program: the load-bearing finding #1391 implemented — the full schema-reading pipeline `bmm_persistence/master02` prescribes — plus the ch.2/ch.3 audits closed and six of seven ch.4 sections (walked checklists on every issue). §4.6 (#1209) and the ch.4 chapter (#882) stay open on #1396: the `P_BMM_INTERFACE` schema-slot upstream defect (openEHR's own BASE/RM ODIN schemas declare interfaces the pinned `P_BMM_SCHEMA` cannot carry — docs-text-vs-class-definition conflict to adjudicate + implement next). #1397 files the class_definition case-rule divergence for the BMM3 ch.5 audit. **#1391 closing unblocks #1390** (the rm_access facade, BMM v2 ch.4).

## The pipeline

`read_schema` (strict typed read, field-by-field per master04 — type-marker discipline, key==name, the three §4.5 NOTEs, all five property kinds, nested `type_def` recursion incl. the CRAZY_TYPE forms, functions/constants/invariants, enumerations, value-set `type_ref`, `ancestor_defs` generic inheritance) → `resolve_includes` (transitive, includer-wins → `is_override`, cycle-safe) → `create_bmm_model` (name→object resolution, adjudicated embedding depth, `immediate_descendants` inversion, cardinality → `MultiplicityInterval`) → `load_model`. Sixteen NOTE adjudications at the sites; honest boundaries written out (`value_constraint` has no v2 destination; generic-ancestor bindings stay in the P_BMM graph).

## Corpus

43/43 vendored `.bmm` schemas asserted, zero skips: 20 materialise end-to-end (the six-schema openEHR RM 1.0.2 include chain, 136 classes; `aom_206`; both CIMI generations), 23 adjudicated refusals with typed discriminants + spec grounds (incl. two real CIMI authoring defects).

## Gates

fmt + clippy + rustdoc clean; `cargo nextest run -p openehr-lang -p openehr-adl` 471/471 green; emit-weave verified decl-only. Internal spec-crate library (no wire surface): `no-changelog`.