### PR TITLE
feat(openehr-lang): P_BMM interface seam + rm_access facade (audits #864 #882)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5264,6 +5264,7 @@ dependencies = [
 name = "openehr-lang"
 version = "1.0.0"
 dependencies = [
+ "assert_fs",
  "chumsky",
  "indexmap 2.14.0",
  "logos",

--- a/crates/openehr-its/src/json_codec/generated/impls.rs
+++ b/crates/openehr-its/src/json_codec/generated/impls.rs
@@ -15209,12 +15209,14 @@ impl crate::json_codec::runtime::ToJson for openehr_lang::prelude::PBmmClass {
     fn json_type_name(&self) -> &'static str {
         match self {
             openehr_lang::prelude::PBmmClass::PBmmEnumeration(x) => x.json_type_name(),
+            openehr_lang::prelude::PBmmClass::PBmmInterface(x) => x.json_type_name(),
             openehr_lang::prelude::PBmmClass::PBmmClass(x) => x.json_type_name(),
         }
     }
     fn write_json(&self, w: &mut crate::json_codec::runtime::JsonWriter) {
         match self {
             openehr_lang::prelude::PBmmClass::PBmmEnumeration(x) => x.write_json(w),
+            openehr_lang::prelude::PBmmClass::PBmmInterface(x) => x.write_json(w),
             openehr_lang::prelude::PBmmClass::PBmmClass(x) => x.write_json(w),
         }
     }
@@ -15239,12 +15241,15 @@ impl crate::json_codec::runtime::FromJson for openehr_lang::prelude::PBmmClass {
             ::core::option::Option::Some("P_BMM_ENUMERATION_STRING") => ::core::result::Result::Ok(
                 Self::PBmmEnumeration(crate::json_codec::runtime::FromJson::from_json(node)?),
             ),
+            ::core::option::Option::Some("P_BMM_INTERFACE") => ::core::result::Result::Ok(
+                Self::PBmmInterface(crate::json_codec::runtime::FromJson::from_json(node)?),
+            ),
             ::core::option::Option::None => ::core::result::Result::Ok(Self::PBmmClass(
                 crate::json_codec::runtime::FromJson::from_json(node)?,
             )),
             ::core::option::Option::Some(__other) => ::core::result::Result::Err(
                 crate::json_codec::runtime::JsonParseError::custom(::std::format!(
-                    "P_BMM_CLASS: unexpected `_type` {__other:?} (expected one of: P_BMM_CLASS, P_BMM_ENUMERATION, P_BMM_ENUMERATION_INTEGER, P_BMM_ENUMERATION_STRING)"
+                    "P_BMM_CLASS: unexpected `_type` {__other:?} (expected one of: P_BMM_CLASS, P_BMM_ENUMERATION, P_BMM_ENUMERATION_INTEGER, P_BMM_ENUMERATION_STRING, P_BMM_INTERFACE)"
                 )),
             ),
         }
@@ -16271,7 +16276,6 @@ impl crate::json_codec::runtime::ToJson for openehr_lang::prelude::PBmmModelElem
             }
             openehr_lang::prelude::PBmmModelElement::PBmmGenericParameter(x) => x.json_type_name(),
             openehr_lang::prelude::PBmmModelElement::PBmmGenericProperty(x) => x.json_type_name(),
-            openehr_lang::prelude::PBmmModelElement::PBmmInterface(x) => x.json_type_name(),
             openehr_lang::prelude::PBmmModelElement::PBmmPackage(x) => x.json_type_name(),
             openehr_lang::prelude::PBmmModelElement::PBmmSingleFunctionParameter(x) => {
                 x.json_type_name()
@@ -16299,7 +16303,6 @@ impl crate::json_codec::runtime::ToJson for openehr_lang::prelude::PBmmModelElem
             }
             openehr_lang::prelude::PBmmModelElement::PBmmGenericParameter(x) => x.write_json(w),
             openehr_lang::prelude::PBmmModelElement::PBmmGenericProperty(x) => x.write_json(w),
-            openehr_lang::prelude::PBmmModelElement::PBmmInterface(x) => x.write_json(w),
             openehr_lang::prelude::PBmmModelElement::PBmmPackage(x) => x.write_json(w),
             openehr_lang::prelude::PBmmModelElement::PBmmSingleFunctionParameter(x) => {
                 x.write_json(w)
@@ -16363,7 +16366,7 @@ impl crate::json_codec::runtime::FromJson for openehr_lang::prelude::PBmmModelEl
                 ))
             }
             ::core::option::Option::Some("P_BMM_INTERFACE") => ::core::result::Result::Ok(
-                Self::PBmmInterface(crate::json_codec::runtime::FromJson::from_json(node)?),
+                Self::PBmmClass(crate::json_codec::runtime::FromJson::from_json(node)?),
             ),
             ::core::option::Option::Some("P_BMM_PACKAGE") => ::core::result::Result::Ok(
                 Self::PBmmPackage(crate::json_codec::runtime::FromJson::from_json(node)?),

--- a/crates/openehr-lang/CLAUDE.md
+++ b/crates/openehr-lang/CLAUDE.md
@@ -47,10 +47,25 @@ ADL/ODIN *instance* parsing — deliberately off the codegen path).
   resolution is case-insensitive (`master04-syntax.adoc` §Non-primitive
   Classes: `name` — "any capitalisation can be used"); embedding depth and
   every other cycle/boundary decision is adjudicated in the module docs, with
-  the honest boundaries (`value_constraint` has no `BMM_*` destination; a
-  persisted `P_BMM_INTERFACE` has no `P_BMM_SCHEMA` slot) written out. This
-  reader is NOT the codegen path either — codegen still consumes only the
-  `.bmm.json` serialisation via `openehr-codegen`.
+  the honest boundaries (`value_constraint` and P_BMM `functions` have no
+  `BMM_*` destination) written out. A persisted `P_BMM_INTERFACE` IS a class-list
+  member (`master02-overview.adoc` §Conceptual Approach + openEHR's own
+  published BASE/RM schemas): the emitter re-opens the `P_BMM_CLASS` subtype set
+  for it (`plan/overrides.rs` `SUBTYPE_EXTENSIONS`), the reader materialises its
+  name/documentation/functions, and `create_model.rs` projects it as an abstract
+  `BMM_CLASS`. This reader is NOT the codegen path either — codegen still
+  consumes only the `.bmm.json` serialisation via `openehr-codegen`.
+- **`src/bmm/rm_access/` is the schema-REPOSITORY facade over that reader**
+  (`LANG/docs/bmm/master04-rm_access.adoc`): `*_impl.rs` behaviour on the
+  generated `REFERENCE_MODEL_ACCESS` / `SCHEMA_DESCRIPTOR` data classes plus a
+  typed `error.rs`. It is the ONLY module in this crate that touches the
+  filesystem (the spec puts `schema_directories` on the class), and it adds
+  nothing to the pipeline semantics: directory scan → load-list closure →
+  descriptor lifecycle (`load` → `validate` + `validate_includes` →
+  `create_schema`) → `valid_models`. Zero-argument spec signatures that need the
+  candidate set (`is_top_level`, `create_schema`) take it as a parameter, each
+  with the adjudication at the site — never a synthetic `meta_data` key or a
+  shadow field.
 - **`src/odin/` is the real ODIN reader** (a `chumsky` parser over
   `lexer::lex_odin` + an `OdinValue` tree; `openehr_lang::odin::parse`), NOT
   part of the generated/`bmm*`/`beom` model — never route it through codegen.

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -26,6 +26,11 @@ chumsky.workspace = true     # combinator parser for ODIN (odin.g4 / odin_values
 thiserror.workspace = true   # typed OdinError
 indexmap.workspace = true    # insertion-ordered ODIN objects
 
+[dev-dependencies]
+# Temp-directory fixtures for the rm_access schema-repository tests (the one
+# module that exercises real filesystem scanning).
+assert_fs.workspace = true
+
 [lints]
 workspace = true
 

--- a/crates/openehr-lang/src/bmm/rm_access/error.rs
+++ b/crates/openehr-lang/src/bmm/rm_access/error.rs
@@ -1,0 +1,133 @@
+//! The typed failures of the `rm_access` schema-loading facade.
+//!
+//! The `rm_access` package "provides an interface for the application to load
+//! and access BMM schemas" (`LANG/docs/bmm/master04-rm_access.adoc` §Overview),
+//! so it is the one layer of this crate that touches the filesystem: its failure
+//! set is the P_BMM pipeline's failures
+//! ([`crate::bmm_persistence::error::PBmmReadError`], wrapped) plus the
+//! repository-level ones the pipeline cannot see (an unreadable directory or
+//! file, a duplicate schema id, a load-list entry naming no schema, a lifecycle
+//! step run out of order).
+//!
+//! Every variant is a discriminant a caller can branch on; the display text is
+//! never a decision input.
+
+/// A BMM schema repository could not be scanned, a schema file could not be
+/// read, or a schema descriptor's lifecycle step failed.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum RmAccessError {
+    /// A schema directory could not be scanned.
+    ///
+    /// NOTE: no openEHR spec governs the filesystem errors —
+    /// `REFERENCE_MODEL_ACCESS.schema_directories` is only "List of directories
+    /// where all the schemas loaded here are found"
+    /// (`org.openehr.lang.bmm.reference_model_access.adoc` §Attributes) — so the
+    /// I/O failure set is our own design.
+    #[error("schema directory `{directory}` could not be read: {source}")]
+    Directory {
+        /// The directory as listed in `schema_directories`.
+        directory: String,
+        /// The underlying I/O failure.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// A `.bmm` schema file could not be read.
+    #[error("schema file `{path}` could not be read: {source}")]
+    File {
+        /// The file's path.
+        path: String,
+        /// The underlying I/O failure.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The P_BMM pipeline refused a schema file's content.
+    #[error("schema file `{path}`: {source}")]
+    Schema {
+        /// The file's path.
+        path: String,
+        /// The refusal from
+        /// [`crate::bmm_persistence::reader::read_schema`],
+        /// [`crate::bmm_persistence::include_resolution::resolve_includes`] or
+        /// [`crate::bmm_persistence::create_model::create_bmm_model`].
+        #[source]
+        source: crate::bmm_persistence::error::PBmmReadError,
+    },
+
+    /// Two files in the schema directories render the same
+    /// `SCHEMA_DESCRIPTOR.schema_id`, so an include naming it would be
+    /// ambiguous (`org.openehr.lang.bmm.schema_descriptor.adoc` §Attributes:
+    /// the id is "formed from meta_data model_publisher '_' schema_name '_'
+    /// model_release").
+    #[error("schema id `{id}` is rendered by both `{first}` and `{second}`")]
+    DuplicateSchemaId {
+        /// The shared id.
+        id: String,
+        /// The first file rendering it, in scan order.
+        first: String,
+        /// The second file rendering it.
+        second: String,
+    },
+
+    /// A `initialise_with_load_list` entry names a schema no file in the schema
+    /// directories declares.
+    #[error("the load list names schema `{id}`, which no file in the schema directories declares")]
+    UnknownLoadListEntry {
+        /// The unmatched `schema_id`.
+        id: String,
+    },
+
+    /// A schema includes another that is not in the candidate set —
+    /// `SCHEMA_DESCRIPTOR.validate_includes` exists to "see if each mentioned
+    /// schema exists in read schemas" (class doc §Functions).
+    #[error("schema `{requester}` includes `{id}`, which is not among the read schemas")]
+    MissingInclude {
+        /// `schema_id` of the including schema.
+        requester: String,
+        /// The missing schema's id.
+        id: String,
+    },
+
+    /// A lifecycle step needs the schema in memory, but
+    /// `SCHEMA_DESCRIPTOR.load` has not run (or did not complete).
+    #[error("schema `{schema_id}` is not loaded")]
+    NotLoaded {
+        /// The descriptor's `schema_id`.
+        schema_id: String,
+    },
+
+    /// The loaded schema's own `schema_id` disagrees with the descriptor's — the
+    /// file changed between the metadata read and the load.
+    #[error("schema file `{path}` describes `{descriptor}` but loaded as `{loaded}`")]
+    SchemaIdMismatch {
+        /// The file's path.
+        path: String,
+        /// The id the descriptor's `meta_data` states.
+        descriptor: String,
+        /// The id the loaded `P_BMM_SCHEMA` renders.
+        loaded: String,
+    },
+
+    /// The schema's declared BMM version is not one this software processes
+    /// (`SCHEMA_DESCRIPTOR.is_bmm_compatible`, class doc §Functions).
+    #[error(
+        "schema `{schema_id}` declares bmm_version `{found}`, which is not compatible with the P_BMM generation this software reads (`{expected}`)"
+    )]
+    IncompatibleBmmVersion {
+        /// The descriptor's `schema_id`.
+        schema_id: String,
+        /// The `bmm_version` the schema declares.
+        found: String,
+        /// The generation this software reads.
+        expected: String,
+    },
+
+    /// A descriptor carries no `schema_path`, so there is no file to (re)read.
+    #[error("schema `{schema_id}` has no `schema_path` meta-data entry")]
+    NoSchemaPath {
+        /// The descriptor's `schema_id`.
+        schema_id: String,
+    },
+}

--- a/crates/openehr-lang/src/bmm/rm_access/mod.rs
+++ b/crates/openehr-lang/src/bmm/rm_access/mod.rs
@@ -4,3 +4,8 @@
 
 pub mod reference_model_access;
 pub mod schema_descriptor;
+
+// hand-written modules (spec behaviour), auto-declared:
+pub mod error;
+pub mod reference_model_access_impl;
+pub mod schema_descriptor_impl;

--- a/crates/openehr-lang/src/bmm/rm_access/reference_model_access_impl.rs
+++ b/crates/openehr-lang/src/bmm/rm_access/reference_model_access_impl.rs
@@ -1,0 +1,276 @@
+//! Hand-written spec functions of `REFERENCE_MODEL_ACCESS` — the entry point of
+//! the `rm_access` schema-loading facade.
+//!
+//! Spec: `LANG/docs/bmm/master04-rm_access.adoc` §Overview — the `rm_access`
+//! package "provides an interface for the application to load and access BMM
+//! schemas" — and
+//! `LANG/docs/UML/classes/org.openehr.lang.bmm.reference_model_access.adoc`
+//! §Attributes (`schema_directories`, `all_schemas`, `valid_models`) +
+//! §Functions (`initialise_with_load_list`, `initialise_all`,
+//! `reload_schemas`).
+//!
+//! Initialisation runs the descriptor lifecycle
+//! ([`crate::bmm::rm_access::schema_descriptor`]) over every `.bmm` file found in
+//! `schema_directories`: describe → select → `load` → `validate` +
+//! `validate_includes` → `create_schema` for each top-level schema, whose
+//! `BMM_MODEL` lands in `valid_models`.
+//!
+//! This is the layer that touches the filesystem, which is why the spec puts it
+//! here: `schema_directories` is part of the class.
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+use crate::bmm::rm_access::error::RmAccessError;
+use crate::bmm::rm_access::reference_model_access::ReferenceModelAccess;
+use crate::bmm::rm_access::schema_descriptor::SchemaDescriptor;
+use crate::bmm_persistence::p_bmm_schema::PBmmSchema;
+use crate::bmm3::bmm_definitions::BmmDefinitionsData;
+use crate::bmm3::core::model::bmm_model::BmmModel;
+
+impl ReferenceModelAccess {
+    /// A schema repository over `schema_directories`, with nothing loaded yet.
+    ///
+    /// `REFERENCE_MODEL_ACCESS.schema_directories` is "List of directories where
+    /// all the schemas loaded here are found" (class doc §Attributes);
+    /// [`ReferenceModelAccess::initialise_all`] or
+    /// [`ReferenceModelAccess::initialise_with_load_list`] then populates
+    /// `all_schemas` and `valid_models`.
+    #[must_use]
+    pub fn new(schema_directories: Vec<String>) -> Self {
+        Self {
+            schema_directories,
+            all_schemas: None,
+            valid_models: None,
+        }
+    }
+
+    /// `REFERENCE_MODEL_ACCESS.all_schemas`: "All schemas found and loaded from
+    /// `schema_directories`. Keyed by schema_id" (class doc §Attributes).
+    #[must_use]
+    pub fn all_schemas(&self) -> Option<&BTreeMap<String, SchemaDescriptor>> {
+        self.all_schemas.as_ref()
+    }
+
+    /// `REFERENCE_MODEL_ACCESS.valid_models`: "Top-level (root) models in use.
+    /// Keyed by logical schema_name, i.e. model_publisher '_' model_name, e.g.
+    /// \"openehr_rm\"" (class doc §Attributes) — see
+    /// [`SchemaDescriptor::logical_model_name`].
+    #[must_use]
+    pub fn valid_models(&self) -> Option<&BTreeMap<String, BmmModel>> {
+        self.valid_models.as_ref()
+    }
+
+    /// `REFERENCE_MODEL_ACCESS.initialise_all`: "Initialise with all schemas
+    /// found in the schema directories" (class doc §Functions).
+    ///
+    /// # Errors
+    /// Returns any [`RmAccessError`] the scan or the descriptor lifecycle raises
+    /// (see [`ReferenceModelAccess::initialise_with_load_list`]).
+    pub fn initialise_all(&mut self) -> Result<(), RmAccessError> {
+        let directories = self.schema_directories.clone();
+        self.initialise(&directories, None)
+    }
+
+    /// `REFERENCE_MODEL_ACCESS.initialise_with_load_list`: "Initialise with a
+    /// specific schema load list, usually a sub-set of schemas that will be
+    /// found in the directories `a_schema_dirs`" (class doc §Functions).
+    ///
+    /// `a_schema_dirs` replaces `schema_directories` (the class doc passes the
+    /// directories to this function, not to a constructor). The load list names
+    /// `schema_id`s; each listed schema is loaded together with everything it
+    /// includes, transitively — a schema cannot be materialised without them
+    /// (`P_BMM_SCHEMA.merge`'s precondition, `…p_bmm_schema.adoc` §Functions), so
+    /// pulling the closure in is what makes a sub-set load list usable at all.
+    /// Ids are matched case-insensitively, as inclusion resolution does.
+    ///
+    /// # Errors
+    /// Returns [`RmAccessError::Directory`] or [`RmAccessError::File`] on I/O
+    /// failure, [`RmAccessError::Schema`] when a file is not a P_BMM schema,
+    /// [`RmAccessError::DuplicateSchemaId`] when two files render one id,
+    /// [`RmAccessError::UnknownLoadListEntry`] when a listed or included id
+    /// matches no file, and whatever the descriptor lifecycle raises
+    /// ([`SchemaDescriptor::validate`],
+    /// [`SchemaDescriptor::validate_includes`],
+    /// [`SchemaDescriptor::create_schema`]).
+    pub fn initialise_with_load_list(
+        &mut self,
+        a_schema_dirs: Vec<String>,
+        a_schema_load_list: &[String],
+    ) -> Result<(), RmAccessError> {
+        self.schema_directories = a_schema_dirs;
+        let directories = self.schema_directories.clone();
+        self.initialise(&directories, Some(a_schema_load_list))
+    }
+
+    /// `REFERENCE_MODEL_ACCESS.reload_schemas`: "Reload all schemas" (class doc
+    /// §Functions) — re-scans the schema directories and re-reads every schema
+    /// currently in `all_schemas` from disk, so an edited file takes effect.
+    ///
+    /// NOTE (adjudicated): the reload keeps the CURRENT selection, which is the
+    /// key set of `all_schemas` ("All schemas found and loaded from
+    /// `schema_directories`", class doc §Attributes) — the class declares no
+    /// attribute holding the original load list, so there is nothing else to
+    /// replay. A file that appeared since initialisation is therefore picked up
+    /// by a fresh `initialise_*` call, not by a reload; a file that has
+    /// DISAPPEARED fails with [`RmAccessError::UnknownLoadListEntry`]. No
+    /// openEHR spec governs this — our own design/extension.
+    ///
+    /// # Errors
+    /// As [`ReferenceModelAccess::initialise_with_load_list`].
+    pub fn reload_schemas(&mut self) -> Result<(), RmAccessError> {
+        let selection: Vec<String> = self
+            .all_schemas
+            .iter()
+            .flat_map(BTreeMap::keys)
+            .cloned()
+            .collect();
+        let directories = self.schema_directories.clone();
+        if selection.is_empty() {
+            return self.initialise(&directories, None);
+        }
+        self.initialise(&directories, Some(&selection))
+    }
+
+    /// Runs the whole lifecycle over `directories`, loading either everything
+    /// found (`selection` is `None`) or the transitive closure of `selection`.
+    fn initialise(
+        &mut self,
+        directories: &[String],
+        selection: Option<&[String]>,
+    ) -> Result<(), RmAccessError> {
+        let mut found = scan(directories)?;
+        let selected = match selection {
+            None => found.keys().cloned().collect(),
+            Some(list) => closure(&found, list)?,
+        };
+
+        let mut all: BTreeMap<String, SchemaDescriptor> = BTreeMap::new();
+        for id in &selected {
+            let mut descriptor = found
+                .remove(id)
+                .ok_or_else(|| RmAccessError::UnknownLoadListEntry { id: id.clone() })?;
+            descriptor.load()?;
+            all.insert(id.clone(), descriptor);
+        }
+
+        let ids: Vec<String> = all.keys().cloned().collect();
+        for descriptor in all.values() {
+            descriptor.validate()?;
+            descriptor.validate_includes(&ids)?;
+        }
+
+        // The persisted forms every inclusion resolves against, and the
+        // top-level schemas — computed before the mutable materialisation pass.
+        let persisted: BTreeMap<String, PBmmSchema> = all
+            .values()
+            .filter_map(|descriptor| {
+                descriptor
+                    .p_schema()
+                    .map(|schema| (descriptor.schema_id().to_owned(), schema.clone()))
+            })
+            .collect();
+        let top_level: Vec<String> = all
+            .iter()
+            .filter(|(_, descriptor)| descriptor.is_top_level(&all))
+            .map(|(id, _)| id.clone())
+            .collect();
+
+        let mut valid_models: BTreeMap<String, BmmModel> = BTreeMap::new();
+        for id in &top_level {
+            let Some(descriptor) = all.get_mut(id) else {
+                continue;
+            };
+            descriptor.create_schema(&persisted)?;
+            if let Some(model) = descriptor.schema() {
+                valid_models.insert(descriptor.logical_model_name(), model.clone());
+            }
+        }
+
+        self.all_schemas = (!all.is_empty()).then_some(all);
+        self.valid_models = (!valid_models.is_empty()).then_some(valid_models);
+        Ok(())
+    }
+}
+
+/// Describes every schema file in `directories`, keyed by its `schema_id`.
+///
+/// A file is a schema file when its name ends with
+/// `BMM_DEFINITIONS.Bmm_schema_file_extension` ("Extension used for BMM files"
+/// = `".bmm"`, `org.openehr.lang.bmm.bmm_definitions.adoc` §Constants).
+///
+/// NOTE (adjudicated): each listed directory is scanned NON-recursively —
+/// `schema_directories` is "List of directories where all the schemas loaded
+/// here are found" (`…reference_model_access.adoc` §Attributes), i.e. the
+/// directories holding the schemas, so a nested layout is expressed by listing
+/// each directory. No openEHR spec governs the scan depth — our own
+/// design/extension. Entries are processed in sorted path order so a duplicate
+/// id is always reported against the same pair of files.
+fn scan(directories: &[String]) -> Result<BTreeMap<String, SchemaDescriptor>, RmAccessError> {
+    let mut files: Vec<PathBuf> = Vec::new();
+    for directory in directories {
+        let entries = std::fs::read_dir(directory).map_err(|source| RmAccessError::Directory {
+            directory: directory.clone(),
+            source,
+        })?;
+        for entry in entries {
+            let entry = entry.map_err(|source| RmAccessError::Directory {
+                directory: directory.clone(),
+                source,
+            })?;
+            let path = entry.path();
+            let is_schema_file = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.ends_with(BmmDefinitionsData::BMM_SCHEMA_FILE_EXTENSION));
+            if is_schema_file && path.is_file() {
+                files.push(path);
+            }
+        }
+    }
+    files.sort();
+
+    let mut out: BTreeMap<String, SchemaDescriptor> = BTreeMap::new();
+    for path in files {
+        let descriptor = SchemaDescriptor::from_schema_file(&path)?;
+        let id = descriptor.schema_id().to_owned();
+        if let Some(first) = out.get(&id) {
+            return Err(RmAccessError::DuplicateSchemaId {
+                id,
+                first: first.schema_path().unwrap_or("").to_owned(),
+                second: path.display().to_string(),
+            });
+        }
+        out.insert(id, descriptor);
+    }
+    Ok(out)
+}
+
+/// The load-list selection: every listed `schema_id` plus, transitively, every
+/// schema those include. Matched case-insensitively against `found`.
+fn closure(
+    found: &BTreeMap<String, SchemaDescriptor>,
+    load_list: &[String],
+) -> Result<BTreeSet<String>, RmAccessError> {
+    // schema_id lower-cased → the key `found` holds it under.
+    let by_lower: BTreeMap<String, String> = found
+        .keys()
+        .map(|id| (id.to_lowercase(), id.clone()))
+        .collect();
+    let mut selected: BTreeSet<String> = BTreeSet::new();
+    let mut pending: Vec<String> = load_list.to_vec();
+    while let Some(wanted) = pending.pop() {
+        let key = by_lower
+            .get(&wanted.to_lowercase())
+            .ok_or_else(|| RmAccessError::UnknownLoadListEntry { id: wanted.clone() })?;
+        if !selected.insert(key.clone()) {
+            continue;
+        }
+        let Some(descriptor) = found.get(key) else {
+            continue;
+        };
+        pending.extend(descriptor.includes().iter().cloned());
+    }
+    Ok(selected)
+}

--- a/crates/openehr-lang/src/bmm/rm_access/schema_descriptor_impl.rs
+++ b/crates/openehr-lang/src/bmm/rm_access/schema_descriptor_impl.rs
@@ -1,0 +1,491 @@
+//! Hand-written spec functions of `SCHEMA_DESCRIPTOR` — the descriptor
+//! lifecycle of the `rm_access` schema-loading facade.
+//!
+//! Spec: `LANG/docs/UML/classes/org.openehr.lang.bmm.schema_descriptor.adoc`
+//! ("Descriptor for a BMM schema. Contains a meta-data table of attributes
+//! obtained from a mini-ODIN parse of the schema file") §Attributes (`p_schema`,
+//! `schema`, `schema_id`, `meta_data`, `includes`) and §Functions
+//! (`is_top_level`, `is_bmm_compatible`, `load`, `validate`,
+//! `validate_includes`, `create_schema`), within
+//! `LANG/docs/bmm/master04-rm_access.adoc` §Overview: the package "provides an
+//! interface for the application to load and access BMM schemas".
+//!
+//! The behaviour is realized ON the generated data classes (this file's
+//! `*_impl.rs` sibling
+//! [`crate::bmm::rm_access::schema_descriptor::SchemaDescriptor`]), which already
+//! carry every attribute the class doc declares — including `meta_data`'s
+//! `schema_path`, which is where the file to (re)read is remembered.
+//!
+//! Two signature deviations from the class doc, both because the pinned
+//! `SCHEMA_DESCRIPTOR` declares no attribute the zero-argument forms could read
+//! (§Attributes lists exactly `p_schema`, `schema`, `schema_id`, `meta_data`,
+//! `includes` — no `is_included` flag and no back-reference to the loader):
+//! [`SchemaDescriptor::is_top_level`] takes the candidate set, and
+//! [`SchemaDescriptor::create_schema`] takes the persisted forms its inclusions
+//! resolve against. NOTE: no openEHR spec governs these parameters — our own
+//! design/extension; the alternative (a synthetic `meta_data` key, or a shadow
+//! field) would invent model state the spec does not declare.
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use crate::bmm::rm_access::error::RmAccessError;
+use crate::bmm::rm_access::schema_descriptor::SchemaDescriptor;
+use crate::bmm_persistence::create_model::create_bmm_model;
+use crate::bmm_persistence::include_resolution::resolve_includes;
+use crate::bmm_persistence::p_bmm_schema::PBmmSchema;
+use crate::bmm_persistence::p_bmm_schema_descriptor::PBmmSchemaDescriptor;
+use crate::bmm_persistence::reader::read_schema;
+use crate::bmm3::bmm_definitions::BmmDefinitionsData;
+use crate::bmm3::core::model::bmm_model::BmmModel;
+
+/// The P_BMM generation this reader implements, as its major version.
+///
+/// NOTE (adjudicated): `BMM_DEFINITIONS.Bmm_internal_version` is the constant
+/// `SCHEMA_DESCRIPTOR.is_bmm_compatible` is meant to compare against — "Current
+/// internal version of BMM meta-model, used to determine if a given schema can
+/// be processed by a given implementation of the model" — but the pinned LANG
+/// generation declares it with NO VALUE
+/// (`org.openehr.lang.bmm.bmm_definitions.adoc` §Constants:
+/// `Bmm_internal_version: String = `, empty), so it cannot serve as the
+/// comparison operand on its own. This is the generation the P_BMM reader
+/// implements: `master04-syntax.adoc` §Header Items writes
+/// `bmm_version = <"2.3">` and every schema openEHR publishes writes `"2.4"`.
+/// Compatibility is judged on the MAJOR component only, because within a major
+/// line an openEHR release is a compatible superset of its predecessors
+/// (<https://specifications.openehr.org/governance/release_strategy>: a minor
+/// release makes "significant additions that do not change the semantics of the
+/// existing part of the release", while a major one carries "changes to the
+/// semantics or large changes"). Where the constant DOES state a version it
+/// wins; the empty-constant fallback is our own design/extension — no openEHR
+/// spec governs it.
+pub const P_BMM_GENERATION: &str = "2";
+
+/// The `meta_data` key holding the schema file's path.
+///
+/// The key set is the one `SCHEMA_DESCRIPTOR.meta_data` enumerates: "Table of
+/// {key, value} pairs of schema meta-data (bmm_version, model_publisher,
+/// schema_name, model_release, schema_revision, schema_lifecycle_state,
+/// schema_description, schema_path)" (class doc §Attributes).
+pub const META_SCHEMA_PATH: &str = "schema_path";
+
+/// The `meta_data` key holding the P_BMM version the schema conforms to.
+pub const META_BMM_VERSION: &str = "bmm_version";
+
+/// The `meta_data` key holding the publishing organisation.
+///
+/// NOTE (adjudicated): the class doc spells the two identity keys
+/// `model_publisher` and `model_release` while the schema attributes they come
+/// from are `P_BMM_SCHEMA.rm_publisher` and `rm_release`
+/// (`…p_bmm_schema.adoc` §Attributes, and `master04-syntax.adoc` §Header Items,
+/// which writes `rm_publisher`/`rm_release` in the file). The KEYS follow the
+/// class doc, the VALUES come from those attributes.
+pub const META_MODEL_PUBLISHER: &str = "model_publisher";
+
+/// The `meta_data` key holding the schema's own name.
+pub const META_SCHEMA_NAME: &str = "schema_name";
+
+/// The `meta_data` key holding the model release.
+pub const META_MODEL_RELEASE: &str = "model_release";
+
+/// The `meta_data` key holding the schema revision.
+pub const META_SCHEMA_REVISION: &str = "schema_revision";
+
+/// The `meta_data` key holding the schema's lifecycle state.
+pub const META_SCHEMA_LIFECYCLE_STATE: &str = "schema_lifecycle_state";
+
+/// The `meta_data` key holding the schema description.
+pub const META_SCHEMA_DESCRIPTION: &str = "schema_description";
+
+/// Reads one attribute of whichever `SCHEMA_DESCRIPTOR` leaf a
+/// [`SchemaDescriptor`] holds — both leaves carry the same inherited attribute
+/// set.
+macro_rules! descriptor {
+    ($value:expr, |$leaf:ident| $body:expr) => {
+        match $value {
+            SchemaDescriptor::PBmmSchemaDescriptor($leaf) => $body,
+            SchemaDescriptor::SchemaDescriptor($leaf) => $body,
+        }
+    };
+}
+
+impl SchemaDescriptor {
+    /// Describe the schema file at `path` from a metadata read of its header.
+    ///
+    /// This is the "meta-data table of attributes obtained from a mini-ODIN
+    /// parse of the schema file" the class doc describes: the returned
+    /// descriptor carries `schema_id`, `meta_data` and `includes`, and NOTHING
+    /// of the model itself — populating `p_schema` is [`SchemaDescriptor::load`]'s
+    /// job, the next step of the lifecycle.
+    ///
+    /// NOTE (adjudicated): the P_BMM reader is whole-document
+    /// ([`crate::bmm_persistence::reader::read_schema`]), and the pinned syntax
+    /// offers no partial-parse entry point — `master04-syntax.adoc`
+    /// §Serialisation Formats describes one file shape whose "File heading" is
+    /// simply its first attributes — so the metadata read is realized by reading
+    /// the whole document and keeping only the header items. The observable
+    /// behaviour is the class doc's: a descriptor that is not yet loaded.
+    ///
+    /// The built leaf is `P_BMM_SCHEMA_DESCRIPTOR`, the class the spec defines for
+    /// exactly this job: "Concrete descendant of `BMM_SCHEMA_DESCRIPTOR` that
+    /// provides a way to read an ODIN or other similarly encoded P_BMM schema
+    /// file"
+    /// (`org.openehr.lang.bmm_persistence.p_bmm_schema_descriptor.adoc`
+    /// §Description) — exactly what this facade does. Its own `bmm_schema`
+    /// attribute re-declares the inherited `p_schema` verbatim ("Persistent form
+    /// of model"), so only the inherited slot is populated and
+    /// [`SchemaDescriptor::p_schema`] reads either.
+    ///
+    /// # Errors
+    /// Returns [`RmAccessError::File`] when `path` cannot be read and
+    /// [`RmAccessError::Schema`] when its content is not a P_BMM schema.
+    pub fn from_schema_file(path: &Path) -> Result<Self, RmAccessError> {
+        let display = path.display().to_string();
+        let src = std::fs::read_to_string(path).map_err(|source| RmAccessError::File {
+            path: display.clone(),
+            source,
+        })?;
+        let schema = read_schema(&src).map_err(|source| RmAccessError::Schema {
+            path: display.clone(),
+            source,
+        })?;
+        Ok(Self::PBmmSchemaDescriptor(PBmmSchemaDescriptor {
+            p_schema: None,
+            schema: None,
+            schema_id: schema.schema_id(),
+            meta_data: meta_data_of(&schema, &display),
+            includes: include_ids_of(&schema),
+            bmm_schema: None,
+        }))
+    }
+
+    /// `SCHEMA_DESCRIPTOR.schema_id`: "Schema id, formed from meta_data
+    /// model_publisher '_' schema_name '_' model_release, e.g. openehr_rm_1.0.3"
+    /// (class doc §Attributes).
+    #[must_use]
+    pub fn schema_id(&self) -> &str {
+        descriptor!(self, |leaf| leaf.schema_id.as_str())
+    }
+
+    /// `SCHEMA_DESCRIPTOR.meta_data`: the "Table of {key, value} pairs of
+    /// schema meta-data" (class doc §Attributes) — see [`META_SCHEMA_PATH`] and
+    /// the sibling key constants.
+    #[must_use]
+    pub fn meta_data(&self) -> &BTreeMap<String, String> {
+        descriptor!(self, |leaf| &leaf.meta_data)
+    }
+
+    /// `SCHEMA_DESCRIPTOR.includes`: "Schema_ids of schemas included by this
+    /// schema" (class doc §Attributes).
+    #[must_use]
+    pub fn includes(&self) -> &[String] {
+        descriptor!(self, |leaf| leaf.includes.as_slice())
+    }
+
+    /// The path of the file this descriptor was read from
+    /// (the [`META_SCHEMA_PATH`] entry of `meta_data`).
+    #[must_use]
+    pub fn schema_path(&self) -> Option<&str> {
+        self.meta_data().get(META_SCHEMA_PATH).map(String::as_str)
+    }
+
+    /// `SCHEMA_DESCRIPTOR.p_schema`: "Persistent form of model" (class doc
+    /// §Attributes) — `None` until [`SchemaDescriptor::load`] has run.
+    ///
+    /// `P_BMM_SCHEMA_DESCRIPTOR.bmm_schema` re-declares the same attribute with
+    /// the same meaning, so it is read as a fallback (see
+    /// [`SchemaDescriptor::from_schema_file`]).
+    #[must_use]
+    pub fn p_schema(&self) -> Option<&PBmmSchema> {
+        match self {
+            SchemaDescriptor::PBmmSchemaDescriptor(leaf) => {
+                leaf.p_schema.as_ref().or(leaf.bmm_schema.as_ref())
+            }
+            SchemaDescriptor::SchemaDescriptor(leaf) => leaf.p_schema.as_ref(),
+        }
+    }
+
+    /// `SCHEMA_DESCRIPTOR.schema`: "Computable form of model" (class doc
+    /// §Attributes) — `None` until [`SchemaDescriptor::create_schema`] has run.
+    #[must_use]
+    pub fn schema(&self) -> Option<&BmmModel> {
+        descriptor!(self, |leaf| leaf.schema.as_ref())
+    }
+
+    /// `SCHEMA_DESCRIPTOR.is_top_level`: "True if this is a top-level schema,
+    /// i.e. not included by some other schema" (class doc §Functions).
+    ///
+    /// `all_schemas` is the candidate set — conventionally
+    /// [`crate::bmm::rm_access::reference_model_access::ReferenceModelAccess::all_schemas`]
+    /// — matched case-insensitively, because the vendored schemas write include
+    /// ids in either case and
+    /// [`crate::bmm_persistence::include_resolution::resolve_includes`] matches
+    /// them lower-cased. A schema that includes ITSELF does not thereby stop
+    /// being top-level.
+    #[must_use]
+    pub fn is_top_level(&self, all_schemas: &BTreeMap<String, SchemaDescriptor>) -> bool {
+        let own = self.schema_id().to_lowercase();
+        !all_schemas.values().any(|other| {
+            other.schema_id().to_lowercase() != own
+                && other.includes().iter().any(|id| id.to_lowercase() == own)
+        })
+    }
+
+    /// `SCHEMA_DESCRIPTOR.is_bmm_compatible`: "True if the BMM version found in
+    /// the schema (or assumed, if none) is compatible with that in this
+    /// software" (class doc §Functions).
+    ///
+    /// Compared on the major version only, against [`P_BMM_GENERATION`] (see its
+    /// adjudication). A descriptor whose `meta_data` states no `bmm_version` is
+    /// compatible — the class doc's "or assumed, if none".
+    #[must_use]
+    pub fn is_bmm_compatible(&self) -> bool {
+        match self.meta_data().get(META_BMM_VERSION) {
+            None => true,
+            Some(found) => major_of(found) == expected_generation(),
+        }
+    }
+
+    /// `SCHEMA_DESCRIPTOR.load`: "Load schema into in-memory form" (class doc
+    /// §Functions) — reads the file named by
+    /// the [`META_SCHEMA_PATH`] entry of `meta_data`
+    /// into `p_schema`.
+    ///
+    /// Re-reads from disk on every call, which is what makes
+    /// [`crate::bmm::rm_access::reference_model_access::ReferenceModelAccess::reload_schemas`]
+    /// ("Reload all schemas") pick up an edited file. Any previously computed
+    /// `schema` is dropped, because it was materialised from the old text.
+    ///
+    /// # Errors
+    /// Returns [`RmAccessError::NoSchemaPath`] when the descriptor names no
+    /// file, [`RmAccessError::File`] when it cannot be read, and
+    /// [`RmAccessError::Schema`] when its content is not a P_BMM schema.
+    pub fn load(&mut self) -> Result<(), RmAccessError> {
+        let path = self
+            .schema_path()
+            .ok_or_else(|| RmAccessError::NoSchemaPath {
+                schema_id: self.schema_id().to_owned(),
+            })?
+            .to_owned();
+        let src = std::fs::read_to_string(&path).map_err(|source| RmAccessError::File {
+            path: path.clone(),
+            source,
+        })?;
+        let schema = read_schema(&src).map_err(|source| RmAccessError::Schema {
+            path: path.clone(),
+            source,
+        })?;
+        let meta_data = meta_data_of(&schema, &path);
+        let includes = include_ids_of(&schema);
+        match self {
+            SchemaDescriptor::PBmmSchemaDescriptor(leaf) => {
+                leaf.meta_data = meta_data;
+                leaf.includes = includes;
+                leaf.schema = None;
+                leaf.bmm_schema = None;
+                leaf.p_schema = Some(schema);
+            }
+            SchemaDescriptor::SchemaDescriptor(leaf) => {
+                leaf.meta_data = meta_data;
+                leaf.includes = includes;
+                leaf.schema = None;
+                leaf.p_schema = Some(schema);
+            }
+        }
+        Ok(())
+    }
+
+    /// `SCHEMA_DESCRIPTOR.validate`: "Validate entire schema" (class doc
+    /// §Functions).
+    ///
+    /// NOTE (adjudicated): the class doc states no check list, and the P_BMM
+    /// well-formedness rules are enforced by the reader itself (a strict read —
+    /// see [`crate::bmm_persistence::reader`]) and by the transform (every
+    /// symbolic reference resolved — see
+    /// [`crate::bmm_persistence::create_model`]). What is left for the
+    /// descriptor, and what this checks, is the descriptor-level agreement the
+    /// other two stages cannot see: the schema is loaded, its declared BMM
+    /// version is one this software processes
+    /// ([`SchemaDescriptor::is_bmm_compatible`]), and the loaded schema renders
+    /// the id the descriptor's metadata claimed (which a file edited between the
+    /// metadata read and the load would break). No openEHR spec governs this
+    /// check list — our own design/extension.
+    ///
+    /// # Errors
+    /// Returns [`RmAccessError::NotLoaded`],
+    /// [`RmAccessError::IncompatibleBmmVersion`] or
+    /// [`RmAccessError::SchemaIdMismatch`].
+    pub fn validate(&self) -> Result<(), RmAccessError> {
+        let Some(schema) = self.p_schema() else {
+            return Err(RmAccessError::NotLoaded {
+                schema_id: self.schema_id().to_owned(),
+            });
+        };
+        if !self.is_bmm_compatible() {
+            return Err(RmAccessError::IncompatibleBmmVersion {
+                schema_id: self.schema_id().to_owned(),
+                found: self
+                    .meta_data()
+                    .get(META_BMM_VERSION)
+                    .cloned()
+                    .unwrap_or_default(),
+                expected: expected_generation().to_owned(),
+            });
+        }
+        let loaded = schema.schema_id();
+        if loaded != self.schema_id() {
+            return Err(RmAccessError::SchemaIdMismatch {
+                path: self.schema_path().unwrap_or("").to_owned(),
+                descriptor: self.schema_id().to_owned(),
+                loaded,
+            });
+        }
+        Ok(())
+    }
+
+    /// `SCHEMA_DESCRIPTOR.validate_includes`: "Validate includes list for this
+    /// schema, to see if each mentioned schema exists in read schemas" (class
+    /// doc §Functions).
+    ///
+    /// Matched case-insensitively, as
+    /// [`crate::bmm_persistence::include_resolution::resolve_includes`] does.
+    ///
+    /// # Errors
+    /// Returns [`RmAccessError::MissingInclude`] naming the first include that
+    /// is in no entry of `all_schemas_list`.
+    pub fn validate_includes(&self, all_schemas_list: &[String]) -> Result<(), RmAccessError> {
+        let available: BTreeSet<String> = all_schemas_list
+            .iter()
+            .map(|id| id.to_lowercase())
+            .collect();
+        for id in self.includes() {
+            if !available.contains(&id.to_lowercase()) {
+                return Err(RmAccessError::MissingInclude {
+                    requester: self.schema_id().to_owned(),
+                    id: id.clone(),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// `SCHEMA_DESCRIPTOR.create_schema`: "Create `schema`" (class doc
+    /// §Functions) — resolves this schema's inclusions against `all_p_schemas`
+    /// and materialises the `BMM_MODEL` into `schema`.
+    ///
+    /// This is the tail of the pipeline `master02-overview.adoc` §Conceptual
+    /// Approach prescribes, and it carries `P_BMM_SCHEMA.create_bmm_model`'s
+    /// precondition (`state = P_BMM_PACKAGE_STATE.State_includes_processed`,
+    /// `…p_bmm_schema.adoc` §Functions) as its `all_p_schemas` argument: every
+    /// schema this one includes must be present and loaded.
+    ///
+    /// # Errors
+    /// Returns [`RmAccessError::NotLoaded`] when [`SchemaDescriptor::load`] has
+    /// not run, and [`RmAccessError::Schema`] when inclusion resolution or the
+    /// transform refuses the schema.
+    pub fn create_schema(
+        &mut self,
+        all_p_schemas: &BTreeMap<String, PBmmSchema>,
+    ) -> Result<(), RmAccessError> {
+        let Some(persisted) = self.p_schema().cloned() else {
+            return Err(RmAccessError::NotLoaded {
+                schema_id: self.schema_id().to_owned(),
+            });
+        };
+        let path = self.schema_path().unwrap_or("").to_owned();
+        let resolved =
+            resolve_includes(persisted, all_p_schemas).map_err(|source| RmAccessError::Schema {
+                path: path.clone(),
+                source,
+            })?;
+        let model =
+            create_bmm_model(&resolved).map_err(|source| RmAccessError::Schema { path, source })?;
+        descriptor!(self, |leaf| leaf.schema = Some(model));
+        Ok(())
+    }
+
+    /// The logical model name a materialised schema is published under:
+    /// "model_publisher '_' model_name, e.g. \"openehr_rm\""
+    /// (`org.openehr.lang.bmm.reference_model_access.adoc` §Attributes, on
+    /// `valid_models`).
+    ///
+    /// Lower-cased, like
+    /// [`crate::bmm_persistence::p_bmm_schema::PBmmSchema::schema_id`]. Both
+    /// parts are mandatory schema attributes (`P_BMM_SCHEMA.rm_publisher` and
+    /// `schema_name` are `1..1`, `…p_bmm_schema.adoc` §Attributes, and the reader
+    /// refuses a schema missing either), so a descriptor read from a file always
+    /// renders both; a hand-built descriptor whose `meta_data` omits one renders
+    /// that part empty rather than failing.
+    #[must_use]
+    pub fn logical_model_name(&self) -> String {
+        let publisher = self
+            .meta_data()
+            .get(META_MODEL_PUBLISHER)
+            .map(String::as_str)
+            .unwrap_or_default();
+        let name = self
+            .meta_data()
+            .get(META_SCHEMA_NAME)
+            .map(String::as_str)
+            .unwrap_or_default();
+        format!("{publisher}_{name}").to_lowercase()
+    }
+}
+
+/// The BMM generation `is_bmm_compatible` compares against: the
+/// `BMM_DEFINITIONS.Bmm_internal_version` constant where the pinned generation
+/// states one, else [`P_BMM_GENERATION`].
+fn expected_generation() -> &'static str {
+    if BmmDefinitionsData::BMM_INTERNAL_VERSION.is_empty() {
+        P_BMM_GENERATION
+    } else {
+        major_of(BmmDefinitionsData::BMM_INTERNAL_VERSION)
+    }
+}
+
+/// The major component of a dotted version (`"2.4"` → `"2"`).
+fn major_of(version: &str) -> &str {
+    version.split('.').next().unwrap_or(version)
+}
+
+/// The `meta_data` table of `schema`, with `path` recorded under
+/// [`META_SCHEMA_PATH`].
+///
+/// The key set is exactly the one `SCHEMA_DESCRIPTOR.meta_data` enumerates
+/// (class doc §Attributes); an empty header item is omitted rather than stored
+/// as an empty string, so a lookup answers "not stated".
+fn meta_data_of(schema: &PBmmSchema, path: &str) -> BTreeMap<String, String> {
+    let mut out: BTreeMap<String, String> = BTreeMap::new();
+    for (key, value) in [
+        (META_BMM_VERSION, schema.bmm_version.as_str()),
+        (META_MODEL_PUBLISHER, schema.rm_publisher.as_str()),
+        (META_SCHEMA_NAME, schema.schema_name.as_str()),
+        (META_MODEL_RELEASE, schema.rm_release.as_str()),
+        (META_SCHEMA_REVISION, schema.schema_revision.as_str()),
+        (
+            META_SCHEMA_LIFECYCLE_STATE,
+            schema.schema_lifecycle_state.as_str(),
+        ),
+        (META_SCHEMA_DESCRIPTION, schema.schema_description.as_str()),
+        (META_SCHEMA_PATH, path),
+    ] {
+        if !value.is_empty() {
+            out.insert(key.to_owned(), value.to_owned());
+        }
+    }
+    out
+}
+
+/// The `schema_id`s of the schemas `schema` includes
+/// (`BMM_INCLUDE_SPEC.id`, "Full identifier of the included schema",
+/// `org.openehr.lang.bmm.bmm_include_spec.adoc` §Attributes), in the schema's
+/// own key order.
+fn include_ids_of(schema: &PBmmSchema) -> Vec<String> {
+    schema
+        .includes
+        .iter()
+        .flat_map(BTreeMap::values)
+        .map(|spec| spec.id.clone())
+        .collect()
+}

--- a/crates/openehr-lang/src/bmm_persistence/create_model.rs
+++ b/crates/openehr-lang/src/bmm_persistence/create_model.rs
@@ -189,6 +189,11 @@ struct ClassEntry<'a> {
 /// Every name written into the produced `BMM_*` values is the class's OWN
 /// `name`, never the upper-cased key.
 struct Builder<'a> {
+    /// The schema being materialised
+    /// ([`crate::bmm_persistence::p_bmm_schema::PBmmSchema::schema_id`]) — the
+    /// `BMM_CLASS.source_schema_id` of a definition that carries none of its
+    /// own (see [`Builder::build_class`]).
+    schema_id: String,
     /// Class definitions by upper-cased name (`primitive_types` first, then
     /// `class_definitions`).
     classes: BTreeMap<String, ClassEntry<'a>>,
@@ -240,6 +245,7 @@ impl<'a> Builder<'a> {
         }
 
         Ok(Self {
+            schema_id: schema.schema_id(),
             classes,
             owning_package,
             descendants,
@@ -280,6 +286,29 @@ impl<'a> Builder<'a> {
     }
 
     /// Builds one `BMM_CLASS` at the given embedding depth.
+    ///
+    /// NOTE (adjudicated): a persisted `P_BMM_INTERFACE` materialises as an
+    /// ABSTRACT class with no properties. An interface is a class-like
+    /// definition declaring only functions — "In addition to ordinary classes,
+    /// the model can also represent pure interfaces via `P_BMM_INTERFACE`, i.e.
+    /// class-like definitions that declare only functions and carry no state"
+    /// (`master02-overview.adoc` §Conceptual Approach) — and the `BMM_*` model
+    /// has no interface class at all (`org.openehr.lang.bmm.bmm_class.adoc` and
+    /// its descendants are the whole entity family), so the abstract-class
+    /// projection is the only faithful destination: it keeps every package
+    /// listing and every property type reference naming an interface
+    /// (`TERMINOLOGY_SERVICE.terminology: TERMINOLOGY_ACCESS` in the vendored
+    /// RM 1.2.0 schema) resolvable, while `is_abstract` records that an
+    /// interface is not instantiable. Its FUNCTIONS have no destination, exactly
+    /// as class functions do not: `BMM_CLASS` declares `properties` but no
+    /// function map (class doc §Attributes), so `P_BMM_CLASS.functions` is
+    /// preserved in the P_BMM graph and carried no further — an honest boundary,
+    /// not a shadow field.
+    ///
+    /// `BMM_CLASS.source_schema_id` is `1..1` ("Reference to original source
+    /// schema defining this class", class doc §Attributes) while an interface
+    /// declares no such attribute to stamp, so it takes the id of the schema
+    /// being materialised.
     fn build_class(
         &self,
         entry: &ClassEntry<'a>,
@@ -296,7 +325,10 @@ impl<'a> Builder<'a> {
                 EmbedDepth::Stub | EmbedDepth::Bare => None,
                 EmbedDepth::Full | EmbedDepth::Ancestor => self.build_properties(persisted)?,
             },
-            source_schema_id: persisted.source_schema_id().to_owned(),
+            source_schema_id: persisted
+                .source_schema_id()
+                .unwrap_or(&self.schema_id)
+                .to_owned(),
             immediate_descendants: self
                 .descendants
                 .get(&name.to_uppercase())

--- a/crates/openehr-lang/src/bmm_persistence/error.rs
+++ b/crates/openehr-lang/src/bmm_persistence/error.rs
@@ -125,33 +125,6 @@ pub enum PBmmReadError {
         path: String,
     },
 
-    /// A persisted `P_BMM_INTERFACE` appears where the schema's class list
-    /// admits only `P_BMM_CLASS`.
-    ///
-    /// `P_BMM_SCHEMA` declares `primitive_types`/`class_definitions` as
-    /// `List<P_BMM_CLASS>`
-    /// (`org.openehr.lang.bmm_persistence.p_bmm_schema.adoc` §Attributes) while
-    /// `P_BMM_INTERFACE` inherits `P_BMM_MODEL_ELEMENT`, not `P_BMM_CLASS`
-    /// (`…p_bmm_interface.adoc` §Inherit), so the pinned P_BMM model has no
-    /// slot for one; `master03-model.adoc` §Overview says only that the model
-    /// "can also represent pure interfaces via `P_BMM_INTERFACE`" and
-    /// `master04-syntax.adoc` never serialises one. The interface is refused
-    /// rather than silently dropped.
-    // TODO: reading a persisted P_BMM_INTERFACE needs a slot for it in
-    // P_BMM_SCHEMA (an `interfaces` attribute, or P_BMM_INTERFACE joining the
-    // P_BMM_CLASS subtype set) in the vendored BMM meta-model, plus an
-    // openehr-codegen regeneration; several vendored openEHR ODIN schemas
-    // (BASE 1.2.0/1.3.0, RM 1.0.2–1.2.0) already declare interfaces.
-    #[error(
-        "{path}: `{name}` is a P_BMM_INTERFACE; the schema's class list admits only P_BMM_CLASS"
-    )]
-    InterfaceInClassList {
-        /// ODIN attribute path of the interface block.
-        path: String,
-        /// The interface's name.
-        name: String,
-    },
-
     /// A schema includes another that was not supplied to the resolver.
     ///
     /// `P_BMM_SCHEMA.merge` has precondition

--- a/crates/openehr-lang/src/bmm_persistence/include_resolution.rs
+++ b/crates/openehr-lang/src/bmm_persistence/include_resolution.rs
@@ -128,6 +128,15 @@ enum ClassList {
 /// `class_definitions` group" — so one name means one class regardless of which
 /// list holds it. The surviving (including) definition is marked
 /// `is_override = True`.
+///
+/// A persisted `P_BMM_INTERFACE` is one of these list members
+/// (`master02-overview.adoc` §Conceptual Approach; see
+/// [`crate::bmm_persistence::reader::read_schema`]) and takes part in exactly
+/// the same name-collision rule: its `name` is the collision key, and the
+/// includer's definition wins whether either side is an interface or an
+/// ordinary class. The only thing an interface cannot do is RECORD the
+/// override flag — it declares no `is_override` attribute, so
+/// [`PBmmClass::set_is_override`] is a no-op for it (documented there).
 fn absorb_classes(includer: &mut PBmmSchema, incoming: Vec<PBmmClass>, list: ClassList) {
     for class in incoming {
         let name = class.name().to_owned();
@@ -305,19 +314,88 @@ mod tests {
             &[("ELEMENT", "root")],
         ));
         let merged = resolve_includes(root, &loaded(vec![included]))?;
-        let sources: BTreeMap<&str, &str> = merged
+        let sources: BTreeMap<&str, Option<&str>> = merged
             .class_definitions
             .iter()
             .map(|class| (class.name(), class.source_schema_id()))
             .collect();
         assert_eq!(
-            sources.get("Any").copied(),
+            sources.get("Any").copied().flatten(),
             Some("openehr_primitive_types_1.0.2")
         );
         assert_eq!(
-            sources.get("ELEMENT").copied(),
+            sources.get("ELEMENT").copied().flatten(),
             Some("openehr_structures_1.0.2")
         );
+        Ok(())
+    }
+
+    #[test]
+    fn an_included_interface_joins_the_class_list_and_loses_to_the_includer()
+    -> Result<(), PBmmReadError> {
+        // A `(P_BMM_INTERFACE)` entry is a member of `class_definitions`
+        // (master02-overview.adoc §Conceptual Approach), so it merges under the
+        // same includer-wins rule as any other definition.
+        let included = read(
+            r#"
+            bmm_version = <"2.4">
+            rm_publisher = <"openehr">
+            schema_name = <"leaf">
+            rm_release = <"1.0.2">
+            packages = <
+                ["org.openehr.leaf"] = <
+                    name = <"org.openehr.leaf">
+                    classes = <"Math", "TERMINOLOGY_ACCESS">
+                >
+            >
+            class_definitions = <
+                ["Math"] = (P_BMM_INTERFACE) < name = <"Math"> >
+                ["TERMINOLOGY_ACCESS"] = (P_BMM_INTERFACE) <
+                    name = <"TERMINOLOGY_ACCESS">
+                    documentation = <"from the included schema">
+                >
+            >
+        "#,
+        );
+        let root = read(
+            r#"
+            bmm_version = <"2.4">
+            rm_publisher = <"openehr">
+            schema_name = <"root">
+            rm_release = <"1.0.2">
+            includes = <
+                ["1"] = < id = <"openehr_leaf_1.0.2"> >
+            >
+            packages = <
+                ["org.openehr.root"] = <
+                    name = <"org.openehr.root">
+                    classes = <"TERMINOLOGY_ACCESS">
+                >
+            >
+            class_definitions = <
+                ["TERMINOLOGY_ACCESS"] = (P_BMM_INTERFACE) <
+                    name = <"TERMINOLOGY_ACCESS">
+                    documentation = <"from the including schema">
+                >
+            >
+        "#,
+        );
+        let merged = resolve_includes(root, &loaded(vec![included]))?;
+        let mut names: Vec<&str> = merged
+            .class_definitions
+            .iter()
+            .map(PBmmClass::name)
+            .collect();
+        names.sort_unstable();
+        assert_eq!(names, ["Math", "TERMINOLOGY_ACCESS"]);
+        let surviving = merged
+            .class_definitions
+            .iter()
+            .find(|class| class.name() == "TERMINOLOGY_ACCESS")
+            .expect("the surviving definition");
+        assert_eq!(surviving.documentation(), Some("from the including schema"));
+        // An interface has no `is_override` slot, so the flag stays unrecorded.
+        assert!(!surviving.is_override());
         Ok(())
     }
 

--- a/crates/openehr-lang/src/bmm_persistence/p_bmm_class.rs
+++ b/crates/openehr-lang/src/bmm_persistence/p_bmm_class.rs
@@ -9,6 +9,7 @@ use crate::bmm_persistence::p_bmm_enumeration::PBmmEnumeration;
 use crate::bmm_persistence::p_bmm_function::PBmmFunction;
 use crate::bmm_persistence::p_bmm_generic_parameter::PBmmGenericParameter;
 use crate::bmm_persistence::p_bmm_generic_type::PBmmGenericType;
+use crate::bmm_persistence::p_bmm_interface::PBmmInterface;
 use crate::bmm_persistence::p_bmm_property::PBmmProperty;
 use crate::bmm3::core::entity::bmm_class::BmmClass;
 
@@ -55,6 +56,8 @@ pub struct PBmmClassData {
 pub enum PBmmClass {
     /// The `P_BMM_ENUMERATION` subtype of `P_BMM_CLASS`.
     PBmmEnumeration(PBmmEnumeration),
+    /// The `P_BMM_INTERFACE` subtype of `P_BMM_CLASS`.
+    PBmmInterface(PBmmInterface),
     /// An instance of `P_BMM_CLASS` itself (its own, least-rich form).
     PBmmClass(PBmmClassData),
 }

--- a/crates/openehr-lang/src/bmm_persistence/p_bmm_class_impl.rs
+++ b/crates/openehr-lang/src/bmm_persistence/p_bmm_class_impl.rs
@@ -8,10 +8,23 @@
 //! `source_schema_id`, `uid`, `ancestor_defs`) and §Functions (`is_generic`,
 //! whose postcondition is `Result := generic_parameter_defs /= Void`).
 //!
-//! `P_BMM_CLASS` is emitted as a polymorphic slot over its own least-rich form
-//! plus the `P_BMM_ENUMERATION` family, so every attribute read here reaches
-//! through both levels; the enumeration-specific attributes live in
-//! [`crate::bmm_persistence::p_bmm_enumeration_impl`].
+//! `P_BMM_CLASS` is emitted as a polymorphic slot over its own least-rich form,
+//! the `P_BMM_ENUMERATION` family, and `P_BMM_INTERFACE`, so every attribute
+//! read here reaches through all of them; the enumeration-specific attributes
+//! live in [`crate::bmm_persistence::p_bmm_enumeration_impl`].
+//!
+//! NOTE (adjudicated): `P_BMM_INTERFACE` is a member of this slot because
+//! `LANG/docs/bmm_persistence/master02-overview.adoc` §Conceptual Approach says
+//! the model "can also represent pure interfaces via `P_BMM_INTERFACE`, i.e.
+//! class-like definitions that declare only functions and carry no state", and
+//! openEHR's own published schemas serialise them inside `class_definitions`,
+//! while `…p_bmm_interface.adoc` §Inherit records only `P_BMM_MODEL_ELEMENT` as
+//! its parent. Being a `P_BMM_MODEL_ELEMENT`, an interface declares exactly
+//! three of the attributes above — `documentation`, `name` and `functions` — so
+//! every OTHER accessor answers the absent value for an interface (an empty
+//! list, `None`, or the flag default), and the two attributes the reader stamps
+//! during processing (`source_schema_id`, `uid`) are `Option`-valued because an
+//! interface has no slot to stamp.
 
 use std::collections::BTreeMap;
 
@@ -23,45 +36,42 @@ use crate::bmm_persistence::p_bmm_generic_parameter::PBmmGenericParameter;
 use crate::bmm_persistence::p_bmm_generic_type::PBmmGenericType;
 use crate::bmm_persistence::p_bmm_property::PBmmProperty;
 
-/// Borrows one `P_BMM_CLASS` attribute from whichever concrete leaf a
-/// [`PBmmClass`] holds.
-macro_rules! class_field {
-    ($value:expr, $field:ident) => {
+/// Reads an attribute EVERY leaf of the slot declares — the three
+/// `P_BMM_MODEL_ELEMENT`/interface-shared ones — by applying `$body` to the leaf
+/// the value holds.
+macro_rules! every_leaf {
+    ($value:expr, |$leaf:ident| $body:expr) => {
         match $value {
-            PBmmClass::PBmmEnumeration(PBmmEnumeration::PBmmEnumerationInteger(leaf)) => {
-                &leaf.$field
-            }
-            PBmmClass::PBmmEnumeration(PBmmEnumeration::PBmmEnumerationString(leaf)) => {
-                &leaf.$field
-            }
-            PBmmClass::PBmmEnumeration(PBmmEnumeration::PBmmEnumeration(leaf)) => &leaf.$field,
-            PBmmClass::PBmmClass(leaf) => &leaf.$field,
+            PBmmClass::PBmmEnumeration(PBmmEnumeration::PBmmEnumerationInteger($leaf)) => $body,
+            PBmmClass::PBmmEnumeration(PBmmEnumeration::PBmmEnumerationString($leaf)) => $body,
+            PBmmClass::PBmmEnumeration(PBmmEnumeration::PBmmEnumeration($leaf)) => $body,
+            PBmmClass::PBmmClass($leaf) => $body,
+            PBmmClass::PBmmInterface($leaf) => $body,
         }
     };
 }
 
-/// Mutably borrows one `P_BMM_CLASS` attribute from whichever concrete leaf a
-/// [`PBmmClass`] holds.
-macro_rules! class_field_mut {
-    ($value:expr, $field:ident) => {
+/// Reads an attribute only the CLASS-shaped leaves declare, answering `$absent`
+/// for the function-only `P_BMM_INTERFACE` leaf.
+macro_rules! class_leaf {
+    ($value:expr, |$leaf:ident| $body:expr, $absent:expr) => {
         match $value {
-            PBmmClass::PBmmEnumeration(PBmmEnumeration::PBmmEnumerationInteger(leaf)) => {
-                &mut leaf.$field
-            }
-            PBmmClass::PBmmEnumeration(PBmmEnumeration::PBmmEnumerationString(leaf)) => {
-                &mut leaf.$field
-            }
-            PBmmClass::PBmmEnumeration(PBmmEnumeration::PBmmEnumeration(leaf)) => &mut leaf.$field,
-            PBmmClass::PBmmClass(leaf) => &mut leaf.$field,
+            PBmmClass::PBmmEnumeration(PBmmEnumeration::PBmmEnumerationInteger($leaf)) => $body,
+            PBmmClass::PBmmEnumeration(PBmmEnumeration::PBmmEnumerationString($leaf)) => $body,
+            PBmmClass::PBmmEnumeration(PBmmEnumeration::PBmmEnumeration($leaf)) => $body,
+            PBmmClass::PBmmClass($leaf) => $body,
+            PBmmClass::PBmmInterface(_) => $absent,
         }
     };
 }
 
 impl PBmmClass {
-    /// `P_BMM_CLASS.name`: "Name of the class" (class doc §Attributes).
+    /// `P_BMM_CLASS.name`: "Name of the class" (class doc §Attributes) —
+    /// "Name of this interface" for the interface leaf
+    /// (`…p_bmm_interface.adoc` §Attributes).
     #[must_use]
     pub fn name(&self) -> &str {
-        class_field!(self, name).as_str()
+        every_leaf!(self, |leaf| leaf.name.as_str())
     }
 
     /// `P_BMM_MODEL_ELEMENT.documentation`: "Optional documentation of this
@@ -70,96 +80,121 @@ impl PBmmClass {
     /// §Attributes).
     #[must_use]
     pub fn documentation(&self) -> Option<&str> {
-        class_field!(self, documentation).as_deref()
+        every_leaf!(self, |leaf| leaf.documentation.as_deref())
     }
 
     /// `P_BMM_CLASS.ancestors`: "List of immediate inheritance parents. If
     /// there are generic ancestors, use `_ancestor_defs_` instead" (class doc
-    /// §Attributes).
+    /// §Attributes) — empty for an interface, which declares none.
     #[must_use]
     pub fn ancestors(&self) -> &[String] {
-        class_field!(self, ancestors).as_slice()
+        class_leaf!(self, |leaf| leaf.ancestors.as_slice(), &[])
     }
 
     /// `P_BMM_CLASS.ancestor_defs`: "List of structured inheritance ancestors,
-    /// used only in the case of generic inheritance" (class doc §Attributes).
+    /// used only in the case of generic inheritance" (class doc §Attributes) —
+    /// empty for an interface.
     #[must_use]
     pub fn ancestor_defs(&self) -> &[PBmmGenericType] {
-        class_field!(self, ancestor_defs).as_slice()
+        class_leaf!(self, |leaf| leaf.ancestor_defs.as_slice(), &[])
     }
 
     /// `P_BMM_CLASS.properties`: "List of attributes defined in this class",
-    /// keyed by property name (class doc §Attributes).
+    /// keyed by property name (class doc §Attributes) — always `None` for an
+    /// interface: interfaces "declare only functions and carry no state"
+    /// (`master02-overview.adoc` §Conceptual Approach).
     #[must_use]
     pub fn properties(&self) -> Option<&BTreeMap<String, PBmmProperty>> {
-        class_field!(self, properties).as_ref()
+        class_leaf!(self, |leaf| leaf.properties.as_ref(), None)
     }
 
     /// `P_BMM_CLASS.functions`: "List of functions (routines) defined in this
-    /// class, keyed by name" (class doc §Attributes).
+    /// class, keyed by name" (class doc §Attributes) — "Functions (routines)
+    /// declared by this interface" for the interface leaf
+    /// (`…p_bmm_interface.adoc` §Attributes).
     #[must_use]
     pub fn functions(&self) -> Option<&BTreeMap<String, PBmmFunction>> {
-        class_field!(self, functions).as_ref()
+        every_leaf!(self, |leaf| leaf.functions.as_ref())
     }
 
     /// `P_BMM_CLASS.constants`: "Constants defined in this class, keyed by
-    /// name" (class doc §Attributes).
+    /// name" (class doc §Attributes) — `None` for an interface.
     #[must_use]
     pub fn constants(&self) -> Option<&BTreeMap<String, PBmmConstant>> {
-        class_field!(self, constants).as_ref()
+        class_leaf!(self, |leaf| leaf.constants.as_ref(), None)
     }
 
     /// `P_BMM_CLASS.invariants`: "Invariants defined on this class, as a Hash
-    /// of assertion expressions keyed by tag" (class doc §Attributes).
+    /// of assertion expressions keyed by tag" (class doc §Attributes) — `None`
+    /// for an interface.
     #[must_use]
     pub fn invariants(&self) -> Option<&BTreeMap<String, String>> {
-        class_field!(self, invariants).as_ref()
+        class_leaf!(self, |leaf| leaf.invariants.as_ref(), None)
     }
 
     /// `P_BMM_CLASS.generic_parameter_defs`: "List of generic parameter
-    /// definitions" (class doc §Attributes).
+    /// definitions" (class doc §Attributes) — `None` for an interface.
     #[must_use]
     pub fn generic_parameter_defs(&self) -> Option<&BTreeMap<String, PBmmGenericParameter>> {
-        class_field!(self, generic_parameter_defs).as_ref()
+        class_leaf!(self, |leaf| leaf.generic_parameter_defs.as_ref(), None)
     }
 
     /// `P_BMM_CLASS.is_abstract`: "True if this is an abstract type" (class doc
     /// §Attributes) — a `0..1` flag, absent meaning not abstract.
+    ///
+    /// NOTE (adjudicated): an interface answers `True`. It declares no
+    /// `is_abstract` attribute of its own (`…p_bmm_interface.adoc` §Attributes),
+    /// but it is by definition not instantiable, being one of the
+    /// "class-like definitions that declare only functions and carry no state"
+    /// (`master02-overview.adoc` §Conceptual Approach) — so reporting it as
+    /// concrete would be wrong, and this is the same answer
+    /// [`crate::bmm_persistence::create_model`] materialises into
+    /// `BMM_CLASS.is_abstract`.
     #[must_use]
     pub fn is_abstract(&self) -> bool {
-        class_field!(self, is_abstract).unwrap_or(false)
+        class_leaf!(self, |leaf| leaf.is_abstract.unwrap_or(false), true)
     }
 
     /// `P_BMM_CLASS.is_override`: "True if this class definition overrides one
     /// found in an included schema" (class doc §Attributes) — a `0..1` flag,
-    /// absent meaning no override.
+    /// absent meaning no override, and never set for an interface (see
+    /// [`PBmmClass::set_is_override`]).
     #[must_use]
     pub fn is_override(&self) -> bool {
-        class_field!(self, is_override).unwrap_or(false)
+        class_leaf!(self, |leaf| leaf.is_override.unwrap_or(false), false)
     }
 
     /// Records that this class definition overrides one of the same name in an
     /// included schema (`P_BMM_CLASS.is_override`, class doc §Attributes) —
     /// set by [`crate::bmm_persistence::include_resolution::resolve_includes`]
     /// when it detects the collision.
+    ///
+    /// NOTE (honest boundary): an interface has nowhere to record the flag —
+    /// `P_BMM_INTERFACE` inherits `P_BMM_MODEL_ELEMENT`
+    /// (`…p_bmm_interface.adoc` §Inherit), which declares no `is_override`
+    /// attribute — so the call is ignored for an interface leaf. Only the record
+    /// of the override is lost; the merge precedence itself (the includer's
+    /// definition wins) is unaffected.
     pub fn set_is_override(&mut self, value: bool) {
-        *class_field_mut!(self, is_override) = Some(value);
+        class_leaf!(self, |leaf| leaf.is_override = Some(value), ());
     }
 
     /// `P_BMM_CLASS.source_schema_id`: "Reference to original source schema
     /// defining this class. Set during `BMM_SCHEMA` materialise" (class doc
-    /// §Attributes).
+    /// §Attributes) — `None` for an interface, which declares no such
+    /// attribute.
     #[must_use]
-    pub fn source_schema_id(&self) -> &str {
-        class_field!(self, source_schema_id).as_str()
+    pub fn source_schema_id(&self) -> Option<&str> {
+        class_leaf!(self, |leaf| Some(leaf.source_schema_id.as_str()), None)
     }
 
     /// `P_BMM_CLASS.uid`: "Unique id generated for later comparison during
     /// merging, in order to detect if two classes are the same. Assigned in
-    /// post-load processing" (class doc §Attributes).
+    /// post-load processing" (class doc §Attributes) — `None` for an interface,
+    /// which declares no such attribute.
     #[must_use]
-    pub fn uid(&self) -> i32 {
-        *class_field!(self, uid)
+    pub fn uid(&self) -> Option<i32> {
+        class_leaf!(self, |leaf| Some(leaf.uid), None)
     }
 
     /// `P_BMM_CLASS.is_generic`: "True if this class is a generic class", with
@@ -187,6 +222,7 @@ mod tests {
     use crate::bmm_persistence::p_bmm_class::PBmmClass;
     use crate::bmm_persistence::p_bmm_class::PBmmClassData;
     use crate::bmm_persistence::p_bmm_generic_parameter::PBmmGenericParameter;
+    use crate::bmm_persistence::p_bmm_interface::PBmmInterface;
 
     /// A bare class definition named `name`, with the given formal generic
     /// parameter declarations.
@@ -234,8 +270,8 @@ mod tests {
         assert!(!class.is_override());
         assert!(!class.is_generic());
         assert_eq!(class.name(), "ELEMENT");
-        assert_eq!(class.source_schema_id(), "openehr_test_1.0.0");
-        assert_eq!(class.uid(), 1);
+        assert_eq!(class.source_schema_id(), Some("openehr_test_1.0.0"));
+        assert_eq!(class.uid(), Some(1));
         assert!(class.ancestors().is_empty());
         assert!(class.ancestor_defs().is_empty());
         assert!(class.properties().is_none());
@@ -256,5 +292,35 @@ mod tests {
         let mut class = class("DV_TEXT", None);
         class.set_is_override(true);
         assert!(class.is_override());
+    }
+
+    #[test]
+    fn an_interface_leaf_reads_its_own_three_attributes_and_absents_the_rest() {
+        let mut interface = PBmmClass::PBmmInterface(PBmmInterface {
+            documentation: Some("a pure operation interface".to_owned()),
+            name: "TERMINOLOGY_ACCESS".to_owned(),
+            functions: Some(BTreeMap::new()),
+        });
+        assert_eq!(interface.name(), "TERMINOLOGY_ACCESS");
+        assert_eq!(
+            interface.documentation(),
+            Some("a pure operation interface")
+        );
+        assert!(interface.functions().is_some());
+        // An interface declares only functions and carries no state.
+        assert!(interface.ancestors().is_empty());
+        assert!(interface.ancestor_defs().is_empty());
+        assert!(interface.properties().is_none());
+        assert!(interface.constants().is_none());
+        assert!(interface.invariants().is_none());
+        assert!(interface.generic_parameter_defs().is_none());
+        assert!(!interface.is_generic());
+        // Not instantiable, and no slot for either processing-stamped attribute.
+        assert!(interface.is_abstract());
+        assert_eq!(interface.source_schema_id(), None);
+        assert_eq!(interface.uid(), None);
+        // The override flag is unrecordable, so the setter is a no-op.
+        interface.set_is_override(true);
+        assert!(!interface.is_override());
     }
 }

--- a/crates/openehr-lang/src/bmm_persistence/p_bmm_model_element.rs
+++ b/crates/openehr-lang/src/bmm_persistence/p_bmm_model_element.rs
@@ -11,7 +11,6 @@ use crate::bmm_persistence::p_bmm_function::PBmmFunction;
 use crate::bmm_persistence::p_bmm_generic_function_parameter::PBmmGenericFunctionParameter;
 use crate::bmm_persistence::p_bmm_generic_parameter::PBmmGenericParameter;
 use crate::bmm_persistence::p_bmm_generic_property::PBmmGenericProperty;
-use crate::bmm_persistence::p_bmm_interface::PBmmInterface;
 use crate::bmm_persistence::p_bmm_package::PBmmPackage;
 use crate::bmm_persistence::p_bmm_single_function_parameter::PBmmSingleFunctionParameter;
 use crate::bmm_persistence::p_bmm_single_function_parameter_open::PBmmSingleFunctionParameterOpen;
@@ -40,8 +39,6 @@ pub enum PBmmModelElement {
     PBmmGenericParameter(PBmmGenericParameter),
     /// The `P_BMM_GENERIC_PROPERTY` subtype of `P_BMM_MODEL_ELEMENT`.
     PBmmGenericProperty(PBmmGenericProperty),
-    /// The `P_BMM_INTERFACE` subtype of `P_BMM_MODEL_ELEMENT`.
-    PBmmInterface(PBmmInterface),
     /// The `P_BMM_PACKAGE` subtype of `P_BMM_MODEL_ELEMENT`.
     PBmmPackage(PBmmPackage),
     /// The `P_BMM_SINGLE_FUNCTION_PARAMETER` subtype of `P_BMM_MODEL_ELEMENT`.

--- a/crates/openehr-lang/src/bmm_persistence/reader.rs
+++ b/crates/openehr-lang/src/bmm_persistence/reader.rs
@@ -35,7 +35,11 @@
 //! `P_BMM_CLASS.source_schema_id` ("Set during `BMM_SCHEMA` materialise") takes
 //! this schema's own [`crate::bmm_persistence::p_bmm_schema::PBmmSchema::schema_id`],
 //! and `P_BMM_CLASS.uid` ("Assigned in post-load processing") is numbered from
-//! 1 in document order over `primitive_types` then `class_definitions`.
+//! 1 in document order over `primitive_types` then `class_definitions`. A
+//! `(P_BMM_INTERFACE)` entry of either list declares neither attribute
+//! (`…p_bmm_interface.adoc` §Attributes), so it stamps neither: its number in
+//! the document order is simply unused, which leaves the remaining `uid`s
+//! document-ordered and unique.
 
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
@@ -67,6 +71,7 @@ use crate::bmm_persistence::p_bmm_generic_property::PBmmGenericProperty;
 use crate::bmm_persistence::p_bmm_generic_type::PBmmGenericType;
 use crate::bmm_persistence::p_bmm_indexed_container_property::PBmmIndexedContainerProperty;
 use crate::bmm_persistence::p_bmm_indexed_container_type::PBmmIndexedContainerType;
+use crate::bmm_persistence::p_bmm_interface::PBmmInterface;
 use crate::bmm_persistence::p_bmm_open_type::PBmmOpenType;
 use crate::bmm_persistence::p_bmm_package::PBmmPackage;
 use crate::bmm_persistence::p_bmm_property::PBmmProperty;
@@ -121,8 +126,8 @@ pub const TOLERATED_PROPERTY_ATTRIBUTES: &[&str] = &["default"];
 /// Returns [`PBmmReadError::Odin`] when the text is not well-formed ODIN, and
 /// one of the schema-shape variants (missing/unknown attribute, wrong value
 /// shape, unexpected or missing type marker, key/name mismatch, qualified
-/// nested package, unsupported cardinality, persisted interface) when the ODIN
-/// tree does not match the P_BMM class model.
+/// nested package, unsupported cardinality) when the ODIN tree does not match
+/// the P_BMM class model.
 pub fn read_schema(src: &str) -> Result<PBmmSchema, PBmmReadError> {
     let root = crate::odin::parse(src)?;
     let OdinValue::Object(members) = &root else {
@@ -776,6 +781,18 @@ struct EnumerationParts {
 }
 
 /// Reads one class definition, dispatching on its optional type marker.
+///
+/// A `(P_BMM_INTERFACE)`-marked entry reads into
+/// [`PBmmClass::PBmmInterface`]: `master02-overview.adoc` §Conceptual Approach
+/// says the model "can also represent pure interfaces via `P_BMM_INTERFACE`,
+/// i.e. class-like definitions that declare only functions and carry no state",
+/// and openEHR's own published schemas serialise them as members of
+/// `class_definitions` (the vendored BASE 1.3.0 and RM 1.2.0 ODIN schemas mark
+/// `Env`, `Locale`, `Math`, `Quantity_converter`, `Statistical_evaluator`,
+/// `CODE_SET_ACCESS` and `TERMINOLOGY_ACCESS` that way). It declares exactly
+/// three attributes — `name`, `documentation` (inherited) and `functions`
+/// (`…p_bmm_interface.adoc` §Attributes) — so no other class attribute is read
+/// for it.
 fn read_class(
     path: &str,
     key: &str,
@@ -787,10 +804,15 @@ fn read_class(
     let empty = IndexMap::new();
     let mut block = Block::open(path, body, &empty)?;
     if marker == Some("P_BMM_INTERFACE") {
-        return Err(PBmmReadError::InterfaceInClassList {
-            path: path.to_owned(),
-            name: read_name(&mut block, key)?,
-        });
+        let name = read_name(&mut block, key)?;
+        let documentation = block.optional_string("documentation")?;
+        let functions = read_functions(&mut block)?;
+        block.finish(&[])?;
+        return Ok(PBmmClass::PBmmInterface(PBmmInterface {
+            documentation,
+            name,
+            functions,
+        }));
     }
     let parts = read_class_parts(&mut block, key, schema_id, uid)?;
     let class = match marker {
@@ -1985,10 +2007,10 @@ mod tests {
         "#,
         )?;
         assert_eq!(class(&schema, "ELEMENT").ancestors(), ["ITEM"]);
-        assert_eq!(class(&schema, "ELEMENT").uid(), 1);
+        assert_eq!(class(&schema, "ELEMENT").uid(), Some(1));
         assert_eq!(
             class(&schema, "ELEMENT").source_schema_id(),
-            "openehr_adltest_1.0.2"
+            Some("openehr_adltest_1.0.2")
         );
 
         let PBmmProperty::PBmmSingleProperty(single) = property(&schema, "ELEMENT", "null_flavour")
@@ -2379,22 +2401,74 @@ mod tests {
     }
 
     #[test]
-    fn a_persisted_interface_is_refused_not_dropped() {
+    fn a_persisted_interface_reads_its_name_documentation_and_functions()
+    -> Result<(), PBmmReadError> {
+        // master02-overview.adoc §Conceptual Approach: the model "can also
+        // represent pure interfaces via P_BMM_INTERFACE, i.e. class-like
+        // definitions that declare only functions and carry no state".
+        let schema = read(
+            r#"
+            class_definitions = <
+                ["Math"] = (P_BMM_INTERFACE) <
+                    name = <"Math">
+                    documentation = <"Mathematical functions.">
+                    functions = <
+                        ["abs"] = <
+                            name = <"abs">
+                            parameters = <
+                                ["v"] = (P_BMM_SINGLE_FUNCTION_PARAMETER) <
+                                    name = <"v">
+                                    type = <"Real">
+                                >
+                            >
+                            result = (P_BMM_SIMPLE_TYPE) <
+                                type = <"Real">
+                            >
+                        >
+                    >
+                >
+            >
+        "#,
+        )?;
+        let interface = class(&schema, "Math");
+        assert!(matches!(interface, PBmmClass::PBmmInterface(_)));
+        assert_eq!(interface.documentation(), Some("Mathematical functions."));
+        let functions = interface.functions().expect("the declared functions");
+        assert_eq!(functions.keys().collect::<Vec<&String>>(), ["abs"]);
+        // An interface carries no state and no processing-stamped attribute.
+        assert!(interface.properties().is_none());
+        assert!(interface.is_abstract());
+        assert_eq!(interface.source_schema_id(), None);
+        assert_eq!(interface.uid(), None);
+        Ok(())
+    }
+
+    #[test]
+    fn a_persisted_interface_refuses_a_state_carrying_attribute() {
+        // `…p_bmm_interface.adoc` §Attributes declares `name` and `functions`
+        // only (plus the inherited `documentation`), so a property block on an
+        // interface is not part of the P_BMM model.
         let error = read(
             r#"
             class_definitions = <
                 ["Env"] = (P_BMM_INTERFACE) <
                     name = <"Env">
+                    properties = <
+                        ["home"] = (P_BMM_SINGLE_PROPERTY) <
+                            name = <"home">
+                            type = <"String">
+                        >
+                    >
                 >
             >
         "#,
         )
-        .expect_err("P_BMM_SCHEMA has no slot for a persisted interface");
+        .expect_err("an interface declares no properties");
         assert_eq!(
             error,
-            PBmmReadError::InterfaceInClassList {
+            PBmmReadError::UnknownAttribute {
                 path: "class_definitions/Env".to_owned(),
-                name: "Env".to_owned(),
+                attribute: "properties".to_owned(),
             }
         );
     }
@@ -2425,8 +2499,8 @@ mod tests {
                 .primitive_types
                 .iter()
                 .map(PBmmClass::uid)
-                .collect::<Vec<_>>(),
-            [1, 2]
+                .collect::<Vec<Option<i32>>>(),
+            [Some(1), Some(2)]
         );
         Ok(())
     }

--- a/crates/openehr-lang/tests/it/main.rs
+++ b/crates/openehr-lang/tests/it/main.rs
@@ -2,7 +2,8 @@
 //! `P_BMM` readers and the Basic Expression Language parser — the per-language
 //! lexer-surface battery, the vendored-fixture batteries (`tests/vendor/**`),
 //! their 100%-coverage gate, the adjudicated `P_BMM` schema→`BMM_MODEL` outcome
-//! table over the same corpus, and BEL parsing.
+//! table over the same corpus, the `rm_access` schema-repository facade over a
+//! temp-directory copy of that corpus, and BEL parsing.
 //!
 //! One binary per crate, split into topic modules
 //! (`.claude/rules/testing.md` §One integration-test binary per crate).
@@ -11,6 +12,7 @@ mod bel_parse;
 mod escape_validation;
 mod lexer_equivalence;
 mod odin_spec_examples;
+mod rm_access;
 mod vendor_bmm_odin;
 mod vendor_bmm_schema;
 mod vendor_coverage;

--- a/crates/openehr-lang/tests/it/rm_access.rs
+++ b/crates/openehr-lang/tests/it/rm_access.rs
@@ -1,0 +1,287 @@
+//! Public-API battery for the `rm_access` schema-loading facade
+//! (`openehr_lang::bmm::rm_access`): a schema DIRECTORY scanned, selected,
+//! loaded, validated and materialised.
+//!
+//! Spec oracle: `docs/specs/openehr/LANG/docs/bmm/master04-rm_access.adoc`
+//! §Overview (the package "provides an interface for the application to load and
+//! access BMM schemas") plus the class docs
+//! `docs/specs/openehr/LANG/docs/UML/classes/org.openehr.lang.bmm.reference_model_access.adoc`
+//! and `…bmm.schema_descriptor.adoc`.
+//!
+//! The fixtures are copies of the vendored openEHR RM 1.0.2 inclusion chain
+//! (`tests/vendor/bmm/openehr/`, whose adjudicated class counts are pinned by
+//! `vendor_bmm_schema.rs`) placed in a temp directory, because a directory scan
+//! is exactly what this facade adds over the `bmm_persistence` pipeline. The
+//! vendored files themselves are never written to.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    reason = "integration-test assertions and fixture plumbing outside #[test] fns, which the clippy.toml allow-*-in-tests scoping does not reach"
+)]
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use openehr_lang::bmm::rm_access::error::RmAccessError;
+use openehr_lang::bmm::rm_access::reference_model_access::ReferenceModelAccess;
+use openehr_lang::bmm::rm_access::schema_descriptor::SchemaDescriptor;
+
+/// The four schemas of the vendored RM 1.0.2 inclusion chain, deepest first:
+/// `ehr` → `structures` → `basic_types` → `primitive_types`.
+const CHAIN: &[(&str, &str)] = &[
+    (
+        "openehr_primitive_types_102.bmm",
+        "openehr_primitive_types_1.0.2",
+    ),
+    ("openehr_basic_types_102.bmm", "openehr_basic_types_1.0.2"),
+    ("openehr_structures_102.bmm", "openehr_structures_1.0.2"),
+    ("openehr_ehr_102.bmm", "openehr_ehr_1.0.2"),
+];
+
+/// The vendored source of one chain file.
+fn vendored(file: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/vendor/bmm/openehr")
+        .join(file);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+/// A temp directory holding `files` (copies of the vendored chain).
+fn repository(files: &[&str]) -> assert_fs::TempDir {
+    let dir = assert_fs::TempDir::new().expect("a temp schema directory");
+    for file in files {
+        std::fs::write(dir.path().join(file), vendored(file))
+            .unwrap_or_else(|e| panic!("write {file}: {e}"));
+    }
+    dir
+}
+
+/// The directory path, as `schema_directories` takes it.
+fn directories(dir: &assert_fs::TempDir) -> Vec<String> {
+    vec![dir.path().display().to_string()]
+}
+
+/// The class count of the model published under `logical_name`.
+fn classes(access: &ReferenceModelAccess, logical_name: &str) -> usize {
+    let models = access.valid_models().expect("materialised models");
+    let model = models
+        .get(logical_name)
+        .unwrap_or_else(|| panic!("no model published as {logical_name}"));
+    model.class_definitions.as_ref().map_or(0, BTreeMap::len)
+}
+
+#[test]
+fn initialise_all_loads_the_whole_inclusion_chain_and_materialises_its_root() {
+    // `initialise_all`: "Initialise with all schemas found in the schema
+    // directories" (…reference_model_access.adoc §Functions).
+    let files: Vec<&str> = CHAIN.iter().map(|(file, _)| *file).collect();
+    let dir = repository(&files);
+    let mut access = ReferenceModelAccess::new(directories(&dir));
+    access.initialise_all().expect("the chain loads");
+
+    let all = access.all_schemas().expect("all_schemas is populated");
+    let ids: Vec<&str> = all.keys().map(String::as_str).collect();
+    let mut expected: Vec<&str> = CHAIN.iter().map(|(_, id)| *id).collect();
+    expected.sort_unstable();
+    assert_eq!(ids, expected, "all_schemas is keyed by schema_id");
+    for descriptor in all.values() {
+        // Every descriptor completed `load` and carries its metadata table.
+        assert!(
+            descriptor.p_schema().is_some(),
+            "{}",
+            descriptor.schema_id()
+        );
+        assert!(
+            descriptor.schema_path().is_some(),
+            "{}",
+            descriptor.schema_id()
+        );
+        assert!(descriptor.is_bmm_compatible(), "{}", descriptor.schema_id());
+        descriptor.validate().expect("the descriptor validates");
+    }
+
+    // `is_top_level`: "True if this is a top-level schema, i.e. not included by
+    // some other schema" — only `ehr` is, in this chain.
+    let top_level: Vec<&str> = all
+        .values()
+        .filter(|descriptor| descriptor.is_top_level(all))
+        .map(SchemaDescriptor::schema_id)
+        .collect();
+    assert_eq!(top_level, ["openehr_ehr_1.0.2"]);
+
+    // `valid_models`: "Top-level (root) models in use. Keyed by logical
+    // schema_name, i.e. model_publisher '_' model_name".
+    let models = access.valid_models().expect("materialised models");
+    assert_eq!(models.keys().collect::<Vec<&String>>(), ["openehr_ehr"]);
+    // The adjudicated class count of the fully resolved RM 1.0.2 ehr schema
+    // (pinned identically by `vendor_bmm_schema.rs`).
+    assert_eq!(classes(&access, "openehr_ehr"), 124);
+}
+
+#[test]
+fn a_load_list_pulls_in_the_transitive_includes_of_what_it_names() {
+    // `initialise_with_load_list`: "Initialise with a specific schema load list,
+    // usually a sub-set of schemas that will be found in the directories".
+    let files: Vec<&str> = CHAIN.iter().map(|(file, _)| *file).collect();
+    let dir = repository(&files);
+    let mut access = ReferenceModelAccess::new(Vec::new());
+    access
+        .initialise_with_load_list(directories(&dir), &["openehr_structures_1.0.2".to_owned()])
+        .expect("the sub-set loads");
+
+    let all = access.all_schemas().expect("all_schemas is populated");
+    assert_eq!(
+        all.keys().map(String::as_str).collect::<Vec<&str>>(),
+        [
+            "openehr_basic_types_1.0.2",
+            "openehr_primitive_types_1.0.2",
+            "openehr_structures_1.0.2",
+        ],
+        "the load list's transitive include closure, and nothing else",
+    );
+    // `ehr` is in the directory but outside the closure, so it is not published.
+    let models = access.valid_models().expect("materialised models");
+    assert_eq!(
+        models.keys().collect::<Vec<&String>>(),
+        ["openehr_structures"]
+    );
+    assert_eq!(classes(&access, "openehr_structures"), 105);
+}
+
+#[test]
+fn a_load_list_entry_naming_no_file_is_refused() {
+    let dir = repository(&["openehr_primitive_types_102.bmm"]);
+    let mut access = ReferenceModelAccess::new(Vec::new());
+    let error = access
+        .initialise_with_load_list(directories(&dir), &["openehr_absent_9.9.9".to_owned()])
+        .expect_err("the load list names no schema in the directory");
+    assert!(
+        matches!(
+            error,
+            RmAccessError::UnknownLoadListEntry { ref id } if id == "openehr_absent_9.9.9"
+        ),
+        "expected an unknown-load-list-entry refusal, got {error:?}",
+    );
+}
+
+#[test]
+fn a_missing_include_surfaces_as_the_typed_refusal() {
+    // `validate_includes`: "Validate includes list for this schema, to see if
+    // each mentioned schema exists in read schemas" — `basic_types` includes
+    // `primitive_types`, which is not in this directory.
+    let dir = repository(&["openehr_basic_types_102.bmm"]);
+    let mut access = ReferenceModelAccess::new(directories(&dir));
+    let error = access
+        .initialise_all()
+        .expect_err("the include is not among the read schemas");
+    assert!(
+        matches!(
+            error,
+            RmAccessError::MissingInclude { ref requester, ref id }
+                if requester == "openehr_basic_types_1.0.2"
+                    && id == "openehr_primitive_types_1.0.2"
+        ),
+        "expected a missing-include refusal, got {error:?}",
+    );
+}
+
+#[test]
+fn a_duplicate_schema_id_in_one_directory_is_refused() {
+    let dir = repository(&["openehr_primitive_types_102.bmm"]);
+    std::fs::write(
+        dir.path().join("a_copy.bmm"),
+        vendored("openehr_primitive_types_102.bmm"),
+    )
+    .expect("write the duplicate");
+    let mut access = ReferenceModelAccess::new(directories(&dir));
+    let error = access
+        .initialise_all()
+        .expect_err("two files, one schema id");
+    assert!(
+        matches!(
+            error,
+            RmAccessError::DuplicateSchemaId { ref id, .. } if id == "openehr_primitive_types_1.0.2"
+        ),
+        "expected a duplicate-schema-id refusal, got {error:?}",
+    );
+}
+
+#[test]
+fn reload_schemas_picks_up_an_edited_file() {
+    // `reload_schemas`: "Reload all schemas" — re-read from disk.
+    let dir = repository(&[]);
+    let path = dir.path().join("edited.bmm");
+    std::fs::write(&path, one_class_schema("")).expect("write the schema");
+    let mut access = ReferenceModelAccess::new(directories(&dir));
+    access.initialise_all().expect("the schema loads");
+    assert_eq!(classes(&access, "openehr_edited"), 1);
+
+    std::fs::write(&path, one_class_schema("SECOND")).expect("rewrite the schema");
+    access.reload_schemas().expect("the reload succeeds");
+    assert_eq!(
+        classes(&access, "openehr_edited"),
+        2,
+        "the reload did not re-read the edited file",
+    );
+}
+
+#[test]
+fn a_foreign_bmm_generation_is_not_compatible() {
+    // `is_bmm_compatible`: "True if the BMM version found in the schema (or
+    // assumed, if none) is compatible with that in this software" — a different
+    // MAJOR P_BMM generation is not.
+    let dir = repository(&[]);
+    let path = dir.path().join("future.bmm");
+    std::fs::write(
+        &path,
+        one_class_schema("").replace(r#"bmm_version = <"2.4">"#, r#"bmm_version = <"9.0">"#),
+    )
+    .expect("write the schema");
+    let descriptor = SchemaDescriptor::from_schema_file(&path).expect("the header reads");
+    assert!(!descriptor.is_bmm_compatible());
+
+    let mut access = ReferenceModelAccess::new(directories(&dir));
+    let error = access
+        .initialise_all()
+        .expect_err("a foreign BMM generation is refused");
+    assert!(
+        matches!(
+            error,
+            RmAccessError::IncompatibleBmmVersion { ref found, .. } if found == "9.0"
+        ),
+        "expected an incompatible-bmm-version refusal, got {error:?}",
+    );
+}
+
+/// A self-contained one- or two-class schema named `edited`; `extra` names a
+/// second class when non-empty.
+fn one_class_schema(extra: &str) -> String {
+    let (packages, definitions) = if extra.is_empty() {
+        ("\"FIRST\"".to_owned(), String::new())
+    } else {
+        (
+            format!("\"FIRST\", \"{extra}\""),
+            format!("[\"{extra}\"] = < name = <\"{extra}\"> >\n"),
+        )
+    };
+    format!(
+        r#"
+        bmm_version = <"2.4">
+        rm_publisher = <"openehr">
+        schema_name = <"edited">
+        rm_release = <"1.0.0">
+        packages = <
+            ["org.openehr.edited"] = <
+                name = <"org.openehr.edited">
+                classes = <{packages}>
+            >
+        >
+        class_definitions = <
+            ["FIRST"] = < name = <"FIRST"> >
+            {definitions}
+        >
+    "#
+    )
+}

--- a/crates/openehr-lang/tests/it/vendor_bmm_schema.rs
+++ b/crates/openehr-lang/tests/it/vendor_bmm_schema.rs
@@ -36,6 +36,7 @@ use std::path::{Path, PathBuf};
 use openehr_lang::bmm_persistence::create_model::create_bmm_model;
 use openehr_lang::bmm_persistence::error::PBmmReadError;
 use openehr_lang::bmm_persistence::include_resolution::resolve_includes;
+use openehr_lang::bmm_persistence::p_bmm_class::PBmmClass;
 use openehr_lang::bmm_persistence::p_bmm_schema::PBmmSchema;
 use openehr_lang::bmm_persistence::reader::read_schema;
 
@@ -62,8 +63,6 @@ enum Kind {
     KeyNameMismatch,
     /// [`PBmmReadError::QualifiedNestedPackage`].
     QualifiedNestedPackage,
-    /// [`PBmmReadError::InterfaceInClassList`].
-    InterfaceInClassList,
     /// [`PBmmReadError::MissingInclude`].
     MissingInclude,
     /// [`PBmmReadError::UnknownAncestor`].
@@ -89,7 +88,6 @@ fn kind_of(error: &PBmmReadError) -> Kind {
         PBmmReadError::UnexpectedTypeMarker { .. } => Kind::UnexpectedTypeMarker,
         PBmmReadError::KeyNameMismatch { .. } => Kind::KeyNameMismatch,
         PBmmReadError::QualifiedNestedPackage { .. } => Kind::QualifiedNestedPackage,
-        PBmmReadError::InterfaceInClassList { .. } => Kind::InterfaceInClassList,
         PBmmReadError::MissingInclude { .. } => Kind::MissingInclude,
         PBmmReadError::UnknownAncestor { .. } => Kind::UnknownAncestor,
         PBmmReadError::UnknownType { .. } => Kind::UnknownType,
@@ -483,28 +481,98 @@ fn collect_bmm(dir: &Path, root: &Path, out: &mut Vec<String>) {
 }
 
 #[test]
-fn the_pinned_openehr_odin_schemas_hit_the_persisted_interface_boundary() {
-    // `P_BMM_SCHEMA.primitive_types`/`class_definitions` are List<P_BMM_CLASS>
-    // (…p_bmm_schema.adoc §Attributes) while P_BMM_INTERFACE inherits
-    // P_BMM_MODEL_ELEMENT (…p_bmm_interface.adoc §Inherit) — the pinned P_BMM
-    // model has no slot for a persisted interface, and master04-syntax.adoc
-    // never serialises one. The RM and BASE ODIN schemas this project pins
-    // (docs/VERSIONS.md: RM 1.2.0, BASE 1.3.0) DO declare interfaces, so the
-    // boundary is pinned here against the real artefacts rather than a fixture.
-    // The reader refuses them rather than silently dropping the interface.
+fn the_pinned_openehr_odin_schemas_read_their_persisted_interfaces() {
+    // master02-overview.adoc §Conceptual Approach: "In addition to ordinary
+    // classes, the model can also represent pure interfaces via
+    // P_BMM_INTERFACE, i.e. class-like definitions that declare only functions
+    // and carry no state" — and the RM and BASE ODIN schemas this project pins
+    // (docs/VERSIONS.md: RM 1.2.0, BASE 1.3.0) serialise them as
+    // `(P_BMM_INTERFACE)`-marked members of `class_definitions`. Those real
+    // artefacts (not a fixture) pin that the reader materialises each one with
+    // its declared functions, and that the whole schema still reads.
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(CODEGEN_VENDOR_ODIN);
-    for (file, interface) in [
-        ("RM/odin/openehr_rm_1.2.0.bmm", "CODE_SET_ACCESS"),
-        ("BASE/odin/openehr_base_1.3.0.bmm", "Env"),
+    for (file, interfaces) in [
+        (
+            "RM/odin/openehr_rm_1.2.0.bmm",
+            ["CODE_SET_ACCESS", "TERMINOLOGY_ACCESS"].as_slice(),
+        ),
+        (
+            "BASE/odin/openehr_base_1.3.0.bmm",
+            ["Env", "Locale", "Math", "Quantity_converter"].as_slice(),
+        ),
     ] {
         let full = root.join(file);
         let src = std::fs::read_to_string(&full)
             .unwrap_or_else(|e| panic!("read {}: {e}", full.display()));
-        let error = read_schema(&src).expect_err("a persisted P_BMM_INTERFACE is refused");
-        assert_eq!(kind_of(&error), Kind::InterfaceInClassList, "{file}");
-        assert!(
-            error.to_string().contains(interface),
-            "{file}: {error} does not name {interface}"
-        );
+        let schema =
+            read_schema(&src).unwrap_or_else(|e| panic!("{file}: the pinned schema reads: {e}"));
+        for name in interfaces {
+            let class = schema
+                .primitive_types
+                .iter()
+                .chain(schema.class_definitions.iter())
+                .find(|class| class.name() == *name)
+                .unwrap_or_else(|| panic!("{file}: {name} is not in the class list"));
+            assert!(
+                matches!(class, PBmmClass::PBmmInterface(_)),
+                "{file}: {name} did not read as a P_BMM_INTERFACE",
+            );
+            assert!(
+                class.functions().is_some_and(|f| !f.is_empty()),
+                "{file}: {name} carries no functions",
+            );
+            // A pure interface declares only functions and carries no state.
+            assert!(class.properties().is_none(), "{file}: {name} has state");
+            assert!(class.is_abstract(), "{file}: {name} is not instantiable");
+        }
+    }
+}
+
+#[test]
+fn the_pinned_openehr_odin_schemas_materialise_their_interfaces_as_abstract_classes() {
+    // The whole pinned RM 1.2.0 + BASE 1.3.0 pair runs the three stages: the
+    // interfaces are listed in packages and referenced as property types
+    // (`TERMINOLOGY_SERVICE.terminology: TERMINOLOGY_ACCESS`), so the transform
+    // has to resolve those references — which it does by materialising each
+    // interface as an abstract `BMM_CLASS` with no properties (see
+    // `create_model::Builder::build_class`).
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(CODEGEN_VENDOR_ODIN);
+    let read_pinned = |file: &str| -> PBmmSchema {
+        let full = root.join(file);
+        let src = std::fs::read_to_string(&full)
+            .unwrap_or_else(|e| panic!("read {}: {e}", full.display()));
+        read_schema(&src).unwrap_or_else(|e| panic!("{file}: the pinned schema reads: {e}"))
+    };
+    let base = read_pinned("BASE/odin/openehr_base_1.3.0.bmm");
+    let rm = read_pinned("RM/odin/openehr_rm_1.2.0.bmm");
+    let mut available: BTreeMap<String, PBmmSchema> = BTreeMap::new();
+    available.insert(base.schema_id(), base.clone());
+
+    for (schema, interfaces) in [
+        (base, ["Env", "Locale", "Math"].as_slice()),
+        (rm, ["CODE_SET_ACCESS", "TERMINOLOGY_ACCESS"].as_slice()),
+    ] {
+        let id = schema.schema_id();
+        let resolved = resolve_includes(schema, &available)
+            .unwrap_or_else(|e| panic!("{id}: inclusion resolution: {e}"));
+        let model =
+            create_bmm_model(&resolved).unwrap_or_else(|e| panic!("{id}: materialisation: {e}"));
+        let classes = model
+            .class_definitions
+            .as_ref()
+            .unwrap_or_else(|| panic!("{id}: the model defines no classes"));
+        for name in interfaces {
+            let class = classes
+                .get(*name)
+                .unwrap_or_else(|| panic!("{id}: {name} is missing from the model"));
+            assert!(
+                class.is_abstract(),
+                "{id}: {name} did not materialise as an abstract class",
+            );
+            assert!(
+                class.properties().is_none(),
+                "{id}: {name} materialised with state",
+            );
+        }
     }
 }

--- a/tools/openehr-codegen/src/analyze/mod.rs
+++ b/tools/openehr-codegen/src/analyze/mod.rs
@@ -9,7 +9,9 @@
 //! decisions in [`crate::plan`].
 
 use crate::load::bmm::{BmmClass, BmmPropKind, BmmSchema, BmmType};
-use crate::plan::overrides::{back_reference, is_mapped_class, primitive};
+use crate::plan::overrides::{
+    back_reference, is_mapped_class, primitive, subtype_extension_parents,
+};
 use crate::plan::{Emission, decide};
 use crate::render::naming;
 use std::collections::{BTreeMap, BTreeSet};
@@ -115,11 +117,26 @@ impl Model {
     }
 
     /// Does `class` inherit from `target` (transitively)?
+    ///
+    /// The declared `ancestors` plus the additional edges
+    /// [`crate::plan::overrides::SUBTYPE_EXTENSIONS`] declares, so a subtype
+    /// seam the vendored BMM under-declares participates in the
+    /// descendant/variant computation exactly like a declared ancestor. Property
+    /// flattening ([`Model::flattened_props`]) reads `ancestors` directly and is
+    /// therefore untouched by an extension edge.
     pub(crate) fn inherits(&self, class: &str, target: &str) -> bool {
         let Some(c) = self.get(class) else {
             return false;
         };
-        for a in &c.ancestors {
+        for a in c.ancestors.iter().map(String::as_str) {
+            if a == target || self.inherits(a, target) {
+                return true;
+            }
+        }
+        // The declared edges are walked first (the common case); the extension
+        // edges are a separate loop because their `&'static str` items would
+        // otherwise force the borrow of `self` above to `'static`.
+        for a in subtype_extension_parents(class) {
             if a == target || self.inherits(a, target) {
                 return true;
             }

--- a/tools/openehr-codegen/src/plan/overrides.rs
+++ b/tools/openehr-codegen/src/plan/overrides.rs
@@ -336,6 +336,61 @@ pub(crate) fn class_binding(class: &str) -> BTreeMap<String, String> {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Additional polymorphic subtype members (subtype seams the BMM under-declares)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// One additional member of a polymorphic subtype set: `subtype` becomes a
+/// variant of `parent`'s untagged enum although the vendored BMM records no
+/// inheritance edge from `subtype` to `parent`.
+pub(crate) struct SubtypeExtension {
+    /// The polymorphic parent whose variant set widens.
+    pub parent: &'static str,
+    /// The class that additionally becomes one of its variants.
+    pub subtype: &'static str,
+    /// Spec citation, or the explicit our-own-design flag.
+    pub citation: &'static str,
+    /// One-line reason.
+    pub reason: &'static str,
+}
+
+/// Subtype sets the vendored BMM under-declares versus the normative spec text
+/// and openEHR's OWN published schema artifacts.
+///
+/// An entry adds one inheritance edge to the analysed model
+/// ([`crate::analyze::Model::inherits`]), so the class joins its parent's
+/// polymorphic enum exactly as a declared descendant would. Property
+/// flattening is deliberately NOT affected: it reads
+/// `crate::load::bmm::BmmClass::ancestors` verbatim, so an extension subtype
+/// gains none of the parent's attributes — it stays the class the BMM declares,
+/// reachable through the parent's slot.
+pub(crate) const SUBTYPE_EXTENSIONS: &[SubtypeExtension] = &[SubtypeExtension {
+    parent: "P_BMM_CLASS",
+    subtype: "P_BMM_INTERFACE",
+    citation: "LANG bmm_persistence master02-overview.adoc §Conceptual Approach — \"In \
+               addition to ordinary classes, the model can also represent pure interfaces via \
+               P_BMM_INTERFACE, i.e. class-like definitions that declare only functions and \
+               carry no state\" — and openEHR's OWN published schemas serialise them as \
+               members of `class_definitions` (`(P_BMM_INTERFACE)`-marked entries in the \
+               vendored BASE 1.3.0 + RM 1.2.0 ODIN schemas, `\"_type\": \"P_BMM_INTERFACE\"` \
+               members in openehr_base_1.3.0.bmm.json), whereas \
+               `P_BMM_SCHEMA.primitive_types`/`class_definitions` are \
+               `List<P_BMM_CLASS>` (org.openehr.lang.bmm_persistence.p_bmm_schema.adoc \
+               §Attributes) and P_BMM_INTERFACE inherits only P_BMM_MODEL_ELEMENT \
+               (…p_bmm_interface.adoc §Inherit). The docs text plus the published artifacts \
+               win over the under-declared inheritance edge.",
+    reason: "A persisted P_BMM_INTERFACE has to be readable where a schema's class list \
+             admits P_BMM_CLASS.",
+}];
+
+/// The parents `subtype` additionally belongs to.
+pub(crate) fn subtype_extension_parents(subtype: &str) -> impl Iterator<Item = &'static str> {
+    SUBTYPE_EXTENSIONS
+        .iter()
+        .filter(move |e| e.subtype == subtype)
+        .map(|e| e.parent)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // REST DTO required-list overrides (docs-text-wins corrections)
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/tools/openehr-codegen/src/testsupport.rs
+++ b/tools/openehr-codegen/src/testsupport.rs
@@ -488,6 +488,19 @@ pub fn decision_maps() -> Vec<DeclMap> {
                 .collect(),
         },
         DeclMap {
+            map: "subtype_extensions",
+            check_existence: true,
+            entries: overrides::SUBTYPE_EXTENSIONS
+                .iter()
+                .map(|e| DeclEntry {
+                    key: e.subtype.to_string(),
+                    decision: format!("additional variant of {}", e.parent),
+                    citation: e.citation.to_string(),
+                    reason: e.reason.to_string(),
+                })
+                .collect(),
+        },
+        DeclMap {
             map: "dialect_predicates",
             // The keys are BMM assertion-dialect predicate spellings, not
             // class/field names, so existence is checked against the classifier
@@ -514,6 +527,34 @@ pub fn dialect_predicates() -> Vec<(String, String)> {
         .iter()
         .map(|e| (e.predicate.to_string(), e.runtime_fn.to_string()))
         .collect()
+}
+
+/// The declared additional polymorphic subtype members
+/// (`analyze`-level inheritance edges the vendored BMM under-declares), as
+/// `(parent, subtype)` pairs.
+#[must_use]
+pub fn subtype_extensions() -> Vec<(String, String)> {
+    overrides::SUBTYPE_EXTENSIONS
+        .iter()
+        .map(|e| (e.parent.to_string(), e.subtype.to_string()))
+        .collect()
+}
+
+/// The immediate concrete variants the emitter gives `class`'s polymorphic slot
+/// in the composition `key`, or `None` when that composition's model does not
+/// define `class`.
+///
+/// # Errors
+/// Returns an error if the composition's BMM files cannot be loaded.
+pub fn enum_variants(key: &str, class: &str) -> Result<Option<Vec<String>>, Error> {
+    let c = compose(key)?;
+    Ok(c.model
+        .get(class)
+        .map(|_| c.model.enum_variants(class))
+        .map(|mut variants| {
+            variants.sort();
+            variants
+        }))
 }
 
 /// The classifier's recognised runtime-backed leaf predicates

--- a/tools/openehr-codegen/tests/it/emitter_invariants.rs
+++ b/tools/openehr-codegen/tests/it/emitter_invariants.rs
@@ -239,6 +239,36 @@ fn decision_map_integrity_entries_are_cited_and_reference_real_classes() {
     }
 }
 
+/// Every declared additional subtype member actually widens its parent's
+/// polymorphic slot: in every composition whose model defines both classes, the
+/// parent's variant set contains the subtype (and at least one composition does
+/// define both, so no entry is inert).
+#[test]
+fn subtype_extensions_widen_their_parents_variant_set() {
+    for (parent, subtype) in testsupport::subtype_extensions() {
+        let mut seen = 0_usize;
+        for key in testsupport::crate_keys() {
+            let Some(variants) = testsupport::enum_variants(key, &parent).unwrap() else {
+                continue;
+            };
+            if testsupport::enum_variants(key, &subtype).unwrap().is_none() {
+                continue;
+            }
+            seen += 1;
+            assert!(
+                variants.contains(&subtype),
+                "{key}: {parent}'s variants {variants:?} do not include the declared \
+                 extension subtype {subtype}",
+            );
+        }
+        assert!(
+            seen > 0,
+            "no composition defines both {parent} and {subtype}: the subtype_extensions entry \
+             is inert",
+        );
+    }
+}
+
 /// The crate → schema-merge table is itself declarative decision data: every
 /// composition entry carries a non-empty citation, lists at least one own BMM
 /// file, resolves (its member/dependency BMM files load), and references only


### PR DESCRIPTION
Closes #1396
Closes #1209
Closes #882
Closes #1390
Closes #1133
Closes #1134
Closes #864

## What

The final two findings of the BMM v2 + P_BMM documents (#753 LANG program), sequenced: #1396 (the interface-slot defect) then #1390 (the rm_access facade) on top. **This closes both documents** — BMM v2 ch.2–ch.6 and P_BMM ch.2–ch.4, every finding implemented (#1389, #1390, #1391, #1396).

## #1396 — emitter seam, not a consumer workaround

Docs text + upstream's own artifacts adjudicated over the under-declared `List<P_BMM_CLASS>`: the declarative `SUBTYPE_EXTENSIONS` table in `openehr-codegen` (one cited entry, `P_BMM_CLASS ⊕ P_BMM_INTERFACE`) widens the generated enum; a new emitter invariant fails if an entry is ever inert; regeneration ripples exactly three generated files (enum variant, model-element nesting, JSON codec arms) and is byte-idempotent (tree-hash verified). The pinned BASE 1.3.0 + RM 1.2.0 ODIN schemas — previously typed refusals — now read AND materialise end-to-end (interfaces as abstract classes, NOTE-adjudicated; package listings and `TERMINOLOGY_ACCESS`-typed references resolve). Upstream report: #1399 (blocked-upstream by rule).

## #1390 — the facade

`REFERENCE_MODEL_ACCESS`/`SCHEMA_DESCRIPTOR` lifecycle as `*_impl.rs` siblings (no wrapper types): directory scan on `Bmm_schema_file_extension`, `initialise_all` / load-list with transitive include closure / `reload_schemas`, descriptor lifecycle incl. `is_bmm_compatible` against the P_BMM generation (the pinned `Bmm_internal_version` constant is empty — adjudicated), typed `RmAccessError`, 7 integration tests over temp-dir copies of the vendored RM 1.0.2 four-schema chain. Nine NOTE adjudications recorded at the sites.

## Gates

fmt + clippy (openehr-lang + openehr-codegen) clean; `cargo nextest run -p openehr-lang -p openehr-adl -p openehr-codegen` **518/518 green**; full workspace builds; rustdoc clean; emit idempotence verified. Internal spec-crate layer: `no-changelog`.