### PR TITLE
fix(openehr-lang): BEL ch.3 Language fixes (audits #883 #884 #885 #886)

### DIFF
--- a/crates/openehr-adl/src/rules.rs
+++ b/crates/openehr-adl/src/rules.rs
@@ -253,6 +253,24 @@ impl BelBuilder for AmBuilder {
             r#type: object_ref_type(type_id),
         })
     }
+
+    fn constant_declaration(
+        &mut self,
+        name: &str,
+        type_id: &str,
+        value: Option<Expression>,
+    ) -> Statement {
+        // Same beom-normative bound as `variable_declaration`: no constant
+        // class exists (`LANG/docs/BEL/master04-expression_object_model.adoc`
+        // §Core Package), so the model's one declaration shape carries it and
+        // the value is discarded like a variable initialiser. Archetype rules
+        // sections do not use constants in practice.
+        drop(value);
+        Statement::VariableDeclaration(VariableDeclaration {
+            name: name.to_owned(),
+            r#type: object_ref_type(type_id),
+        })
+    }
 }
 
 impl AmBuilder {

--- a/crates/openehr-lang/src/bel/mod.rs
+++ b/crates/openehr-lang/src/bel/mod.rs
@@ -97,6 +97,22 @@ pub enum BelLiteral {
     DateTime(String),
     /// An ISO-8601 duration (verbatim).
     Duration(String),
+    /// A terminology-code reference (verbatim incl. brackets) —
+    /// `LANG/docs/BEL/master03-language.adoc` §Literals lists
+    /// `Terminology_code` among the BEL primitive literal types
+    /// (`[snomed_ct::389086002]`), and the BEL grammar reaches
+    /// `TERM_CODE_REF` through its `odin_values` import.
+    TermCode(String),
+    /// An interval literal, carried as its VERBATIM source text
+    /// (`|105..135|`) — the constant-declaration RHS is the full
+    /// `odin_values` `primitive_object`, which includes the per-type
+    /// interval values (`base_expressions.g4` `constant_declaration`;
+    /// `master03-language.adoc` §Constants' own
+    /// `Systolic_normal_range: Interval<Integer> = |105..135|`). NOTE: the
+    /// beom has no interval-literal class, so the verbatim text is the
+    /// serialisation an `EXPR_LITERAL.item` can carry — the BEOM-normative
+    /// bound (`master02-overview.adoc`).
+    Interval(String),
 }
 
 impl BelLiteral {
@@ -113,7 +129,9 @@ impl BelLiteral {
             | BelLiteral::Date(s)
             | BelLiteral::Time(s)
             | BelLiteral::DateTime(s)
-            | BelLiteral::Duration(s) => serde_json::Value::String(s.clone()),
+            | BelLiteral::Duration(s)
+            | BelLiteral::TermCode(s)
+            | BelLiteral::Interval(s) => serde_json::Value::String(s.clone()),
             BelLiteral::Character(c) => serde_json::Value::String(c.to_string()),
         }
     }
@@ -192,6 +210,16 @@ pub trait BelBuilder {
         name: &str,
         type_id: &str,
         init: Option<Self::Expr>,
+    ) -> Self::Stmt;
+
+    /// Build a constant declaration (`Name : Type [ = primitive_object ]`) —
+    /// `base_expressions.g4` `constant_declaration`;
+    /// `LANG/docs/BEL/master03-language.adoc` §Constants.
+    fn constant_declaration(
+        &mut self,
+        name: &str,
+        type_id: &str,
+        value: Option<Self::Expr>,
     ) -> Self::Stmt;
 }
 
@@ -394,6 +422,30 @@ impl BelBuilder for BeomBuilder {
         // beom VARIABLE_DECLARATION has no initialiser slot (an `:= init` is a
         // separate ASSIGNMENT in the model); the parsed init is discarded here.
         drop(init);
+        Statement::VariableDeclaration(VariableDeclaration {
+            name: name.to_owned(),
+            r#type: ty,
+        })
+    }
+
+    fn constant_declaration(
+        &mut self,
+        name: &str,
+        type_id: &str,
+        value: Option<Expression>,
+    ) -> Statement {
+        // NOTE: the beom defines exactly three statement classes — ASSERTION,
+        // VARIABLE_DECLARATION and ASSIGNMENT
+        // (`LANG/docs/BEL/master04-expression_object_model.adoc` §Core
+        // Package) — and no constant class, while the language chapter
+        // (`master03-language.adoc` §Constants) and the grammar
+        // (`constant_declaration`) both define the construct. The BEOM is the
+        // normative bound (`master02-overview.adoc`), so a constant
+        // materialises as the model's one declaration shape, its value
+        // discarded exactly as a variable initialiser is.
+        let ty = object_ref_type(type_id);
+        self.vars.insert(name.to_owned(), ty.clone());
+        drop(value);
         Statement::VariableDeclaration(VariableDeclaration {
             name: name.to_owned(),
             r#type: ty,

--- a/crates/openehr-lang/src/bel/parser.rs
+++ b/crates/openehr-lang/src/bel/parser.rs
@@ -84,11 +84,18 @@ impl<'a, 'b, B: BelBuilder> Parser<'a, 'b, B> {
                 Some(Token::SymColon) => self.parse_variable_declaration(),
                 _ => self.parse_assertion(),
             },
-            // `tag :` — a tagged assertion (constant declarations, which share
-            // the `NAME : Type` shape, do not appear in archetype rules).
-            Some(Token::AlphaLcId(_) | Token::AlphaUcId(_))
-                if self.peek_at(1) == Some(&Token::SymColon) =>
-            {
+            // `Name : Type [= primitive_object]` — a constant declaration
+            // (`base_expressions.g4` `constant_declaration`), tried first by
+            // backtracking; a UC-tagged assertion resumes when the shape
+            // does not complete as a constant.
+            Some(Token::AlphaUcId(_)) if self.peek_at(1) == Some(&Token::SymColon) => {
+                if let Some(result) = self.try_parse_constant_declaration() {
+                    return result;
+                }
+                self.parse_assertion()
+            }
+            // `tag :` — a tagged assertion.
+            Some(Token::AlphaLcId(_)) if self.peek_at(1) == Some(&Token::SymColon) => {
                 self.parse_assertion()
             }
             _ => self.parse_assertion(),
@@ -111,15 +118,120 @@ impl<'a, 'b, B: BelBuilder> Parser<'a, 'b, B> {
         if !self.eat(&Token::SymColon) {
             return self.err("expected ':' in variable declaration");
         }
-        let Some(Token::AlphaUcId(type_id)) = self.bump() else {
-            return self.err("expected a type name after ':' in a declaration");
-        };
+        let type_id = self.parse_type_id()?;
         let init = if self.eat(&Token::SymAssignment) {
             Some(self.parse_expr()?)
         } else {
             None
         };
         Ok(self.builder.variable_declaration(&name, &type_id, init))
+    }
+
+    /// `type_id : ALPHA_UC_ID ( '<' type_id ( ',' type_id )* '>' )?`
+    /// (`base_expressions.g4`), reconstructed flat (`List<Real>`,
+    /// `Interval<Integer>`, `Hash<String,Integer>`) — the declaration types
+    /// of `LANG/docs/BEL/master03-language.adoc` §Typing.
+    fn parse_type_id(&mut self) -> Result<String, BelError> {
+        let Some(Token::AlphaUcId(root)) = self.peek().cloned() else {
+            return self.err("expected a type name after ':' in a declaration");
+        };
+        self.pos += 1;
+        if !self.eat(&Token::SymLt) {
+            return Ok(root);
+        }
+        let mut parameters = vec![self.parse_type_id()?];
+        while self.eat(&Token::SymComma) {
+            parameters.push(self.parse_type_id()?);
+        }
+        if !self.eat(&Token::SymGt) {
+            return self.err("expected '>' closing the generic type parameters");
+        }
+        Ok(format!("{root}<{}>", parameters.join(",")))
+    }
+
+    /// `constant_declaration : constant_name ':' type_id ( '=' primitive_object )?`
+    /// (`base_expressions.g4`; `LANG/docs/BEL/master03-language.adoc`
+    /// §Constants). Dispatched by backtracking from the shared
+    /// `NAME ':' …` shape: a tagged assertion resumes if what follows the
+    /// `':'` is not `type_id ( '=' … | <end> )` — the grammar leaves the two
+    /// productions ambiguous and the §Constants examples settle the reading.
+    fn try_parse_constant_declaration(&mut self) -> Option<Result<B::Stmt, BelError>> {
+        let start = self.pos;
+        let Some(Token::AlphaUcId(name)) = self.peek().cloned() else {
+            return None;
+        };
+        self.pos += 1;
+        if !self.eat(&Token::SymColon) {
+            self.pos = start;
+            return None;
+        }
+        let Ok(type_id) = self.parse_type_id() else {
+            self.pos = start;
+            return None;
+        };
+        match self.peek() {
+            // `Name : Type = primitive_object` — the valued constant. The RHS
+            // is the odin_values `primitive_object`: an interval value is
+            // carried verbatim ([`BelLiteral::Interval`]), everything else
+            // parses as the expression the scalar literals already are. (The
+            // `primitive_list_value` form is unreachable here — a comma ends
+            // the statement read — an honest boundary recorded on the audit.)
+            Some(Token::SymEq) => {
+                self.pos += 1;
+                let value = if self.peek() == Some(&Token::SymIvlDelim) {
+                    match self.parse_interval_literal() {
+                        Ok(v) => v,
+                        Err(e) => return Some(Err(e)),
+                    }
+                } else {
+                    match self.parse_expr() {
+                        Ok(v) => v,
+                        Err(e) => return Some(Err(e)),
+                    }
+                };
+                Some(Ok(self.builder.constant_declaration(
+                    &name,
+                    &type_id,
+                    Some(value),
+                )))
+            }
+            // `Name : Type` at end of input — a bare constant declaration.
+            None => Some(Ok(self.builder.constant_declaration(&name, &type_id, None))),
+            // anything else: not a constant — backtrack to the assertion read.
+            _ => {
+                self.pos = start;
+                None
+            }
+        }
+    }
+
+    /// An interval `primitive_object` value (`| … |`), captured VERBATIM from
+    /// the source between (and including) its two `|` delimiters — see the
+    /// [`BelLiteral::Interval`] adjudication.
+    fn parse_interval_literal(&mut self) -> Result<B::Expr, BelError> {
+        let open = self.pos;
+        let Some(open_span) = self.toks.get(open).map(|s| s.span.clone()) else {
+            return self.err("expected '|' opening an interval value");
+        };
+        self.pos += 1; // the opening '|'
+        while let Some(token) = self.peek() {
+            if *token == Token::SymIvlDelim {
+                let close_span = self
+                    .toks
+                    .get(self.pos)
+                    .map(|s| s.span.clone())
+                    .unwrap_or_else(|| open_span.clone());
+                self.pos += 1;
+                let text = self
+                    .src
+                    .get(open_span.start..close_span.end)
+                    .unwrap_or_default()
+                    .to_owned();
+                return Ok(self.builder.literal(BelLiteral::Interval(text)));
+            }
+            self.pos += 1;
+        }
+        self.err("expected '|' closing an interval value")
     }
 
     /// `assertion : ( ( ALPHA_LC_ID | ALPHA_UC_ID ) ':' )? boolean_expr`.
@@ -140,6 +252,20 @@ impl<'a, 'b, B: BelBuilder> Parser<'a, 'b, B> {
         match self.bump() {
             Some(Token::VariableId(v)) => Ok(v.trim_start_matches('$').to_owned()),
             _ => self.err("expected a $variable"),
+        }
+    }
+
+    /// A quantifier BINDING variable: the grammar writes `VARIABLE_ID`
+    /// (`$v`), but `LANG/docs/BEL/master03-language.adoc` §Container
+    /// Operators states the textual syntax with a bare identifier
+    /// (`for_all v : container_var | …`) — the docs text wins the conflict,
+    /// so both spellings are accepted here (binding position only; the two
+    /// forms denote the same bound name).
+    fn expect_binding_name(&mut self) -> Result<String, BelError> {
+        match self.bump() {
+            Some(Token::VariableId(v)) => Ok(v.trim_start_matches('$').to_owned()),
+            Some(Token::AlphaLcId(v)) => Ok(v),
+            _ => self.err("expected a binding variable ($name or bare name)"),
         }
     }
 
@@ -322,6 +448,17 @@ impl<'a, 'b, B: BelBuilder> Parser<'a, 'b, B> {
                 self.pos += 1;
                 Ok(self.builder.literal(BelLiteral::Duration(s)))
             }
+            // `[terminology::code]` — a Terminology_code literal
+            // (`LANG/docs/BEL/master03-language.adoc` §Literals; the grammar
+            // reaches TERM_CODE_REF via its odin_values import). NOTE: the
+            // grammar's arithmetic_leaf omits the token — the BEOM-normative
+            // reading (`TYPE_DEF_TERMINOLOGY_CODE` exists precisely for these
+            // values) plus §Literals ground the leaf position, for equality
+            // use.
+            Some(Token::TermCodeRef(code)) => {
+                self.pos += 1;
+                Ok(self.builder.literal(BelLiteral::TermCode(code)))
+            }
             Some(Token::AlphaLcId(name)) if self.peek_at(1) == Some(&Token::LParen) => {
                 self.parse_function_call(&name)
             }
@@ -362,7 +499,7 @@ impl<'a, 'b, B: BelBuilder> Parser<'a, 'b, B> {
     /// `for_all_expr : SYM_FOR_ALL VARIABLE_ID ( ':' | 'in' ) value_ref '|'? boolean_expr`.
     fn parse_for_all(&mut self) -> Result<B::Expr, BelError> {
         self.pos += 1; // for_all
-        let var = self.expect_variable_name()?;
+        let var = self.expect_binding_name()?;
         if !self.eat(&Token::SymColon) && !self.eat(&Token::SymIn) {
             return self.err("expected ':' or 'in' after the for_all variable");
         }
@@ -382,11 +519,14 @@ impl<'a, 'b, B: BelBuilder> Parser<'a, 'b, B> {
     /// same unary the `exists` keyword builds.
     fn parse_there_exists(&mut self) -> Result<B::Expr, BelError> {
         self.pos += 1; // there_exists
-        if !matches!(self.peek(), Some(Token::VariableId(_))) {
+        let is_binding = matches!(self.peek(), Some(Token::VariableId(_)))
+            || (matches!(self.peek(), Some(Token::AlphaLcId(_)))
+                && matches!(self.peek_at(1), Some(Token::SymColon | Token::SymIn)));
+        if !is_binding {
             let operand = self.parse_ref_leaf()?;
             return Ok(self.builder.unary(kind("exists"), "exists", operand));
         }
-        let var = self.expect_variable_name()?;
+        let var = self.expect_binding_name()?;
         if !self.eat(&Token::SymColon) && !self.eat(&Token::SymIn) {
             return self.err("expected ':' or 'in' after the there_exists variable");
         }

--- a/crates/openehr-lang/src/lexer/reclassify.rs
+++ b/crates/openehr-lang/src/lexer/reclassify.rs
@@ -162,9 +162,16 @@ pub(super) fn reclassify(
             Language::Adl | Language::Bel => Some(token.clone()),
             Language::Odin => None,
         },
-        // A qualified term code is a cADL primitive and an ODIN leaf value;
-        // `base_expressions.g4` has no such token.
-        Token::TermCodeRef(_) | Token::EmbeddedUri(_) => match language {
+        // A qualified term code is a cADL primitive, an ODIN leaf value, AND
+        // a BEL literal: `LANG/docs/BEL/master03-language.adoc` §Literals
+        // lists `Terminology_code` among the BEL primitive literal types, and
+        // the BEL grammar reaches `TERM_CODE_REF` through its `odin_values`
+        // import (`constant_declaration`'s `primitive_object`). (#1402)
+        Token::TermCodeRef(_) => Some(token.clone()),
+        // An embedded URI has no `base_expressions.g4` production and the
+        // §Literals `Uri` row shows a BARE URI (lexically unproductive in
+        // expression text) — the BEL boundary recorded at the #884 audit.
+        Token::EmbeddedUri(_) => match language {
             Language::Adl | Language::Odin => Some(token.clone()),
             Language::Bel => None,
         },

--- a/crates/openehr-lang/tests/fixtures/lexer_equivalence_bel.txt
+++ b/crates/openehr-lang/tests/fixtures/lexer_equivalence_bel.txt
@@ -75,10 +75,10 @@
 74|Real("0.0")@0..3
 75|SymMinus@0..1 Real("3.5")@1..4
 76|Integer("5")@0..1
-77|LBracket@0..1 AlphaUcId("ISO_639")@1..8 SymMinus@8..9 Integer("1")@9..10 SymColon@10..11 SymColon@11..12 AlphaLcId("en")@12..14 RBracket@14..15
-78|LBracket@0..1 AlphaUcId("SNOMED")@1..7 SymMinus@7..8 AlphaUcId("CT")@8..10 LParen@10..11 Integer("2020")@11..15 RParen@15..16 SymColon@16..17 SymColon@17..18 Integer("123456")@18..24 RBracket@24..25
+77|TermCodeRef("[ISO_639-1::en]")@0..15
+78|TermCodeRef("[SNOMED-CT(2020)::123456]")@0..25
 79|SymLt@0..1 AlphaLcId("http")@1..5 SymColon@5..6 AdlPath("//loinc")@6..13 SymDot@13..14 AdlPath("org/id")@14..20 SymSlash@20..21 Integer("9272")@21..25 SymMinus@25..26 Integer("6")@26..27 SymGt@27..28
-80|SymLt@0..1 LBracket@1..2 AlphaUcId("ISO_639")@2..9 SymMinus@9..10 Integer("1")@10..11 SymColon@11..12 SymColon@12..13 AlphaLcId("en")@13..15 RBracket@15..16 SymGt@16..17
+80|SymLt@0..1 TermCodeRef("[ISO_639-1::en]")@1..16 SymGt@16..17
 81|LBracket@0..1 AlphaLcId("id2")@1..4 RBracket@4..5
 82|LBracket@0..1 AlphaLcId("ac1")@1..4 RBracket@4..5
 83|LBracket@0..1 AlphaLcId("at0200")@1..7 RBracket@7..8
@@ -87,7 +87,7 @@
 86|LBracket@0..1 Integer("01234")@1..6 RBracket@6..7
 87|LBracket@0..1 Iso8601Date("2004-06-11")@1..11 RBracket@11..12
 88|LBracket@0..1 AlphaLcId("ac1")@1..4 SymAt@4..5 AlphaLcId("openehr")@5..12 RBracket@12..13
-89|LBracket@0..1 AlphaLcId("local")@1..6 SymColon@6..7 SymColon@7..8 AlphaLcId("at0001")@8..14 RBracket@14..15
+89|TermCodeRef("[local::at0001]")@0..15
 90|LBracket@0..1 AlphaLcId("at0010")@1..7 SymDot@7..8 Integer("2")@8..9 RBracket@9..10
 91|SymMatches@0..3
 92|SymAnd@0..3
@@ -208,7 +208,7 @@
 207|AdlPath("/items[at0001]/value")@0..20
 208|AlphaUcId("Foo")@0..3 AdlPath("/bar")@3..7
 209|AlphaLcId("lifecycle_state")@0..15 SymEq@16..17 SymLt@18..19 String("\"published\"")@19..30 SymGt@30..31
-210|AlphaLcId("details")@0..7 SymEq@8..9 SymLt@10..11 LBracket@16..17 String("\"en\"")@17..21 RBracket@21..22 SymEq@23..24 SymLt@25..26 AlphaLcId("language")@35..43 SymEq@44..45 SymLt@46..47 LBracket@47..48 AlphaUcId("ISO_639")@48..55 SymMinus@55..56 Integer("1")@56..57 SymColon@57..58 SymColon@58..59 AlphaLcId("en")@59..61 RBracket@61..62 SymGt@62..63 AlphaLcId("keywords")@72..80 SymEq@81..82 SymLt@83..84 String("\"ADL\"")@84..89 SymComma@89..90 String("\"test\"")@91..97 SymGt@97..98 SymGt@103..104 SymGt@105..106
+210|AlphaLcId("details")@0..7 SymEq@8..9 SymLt@10..11 LBracket@16..17 String("\"en\"")@17..21 RBracket@21..22 SymEq@23..24 SymLt@25..26 AlphaLcId("language")@35..43 SymEq@44..45 SymLt@46..47 TermCodeRef("[ISO_639-1::en]")@47..62 SymGt@62..63 AlphaLcId("keywords")@72..80 SymEq@81..82 SymLt@83..84 String("\"ADL\"")@84..89 SymComma@89..90 String("\"test\"")@91..97 SymGt@97..98 SymGt@103..104 SymGt@105..106
 211|AlphaLcId("a")@0..1 SymEq@2..3 LParen@4..5 AlphaUcId("Interval")@5..13 SymLt@13..14 AlphaUcId("Quantity")@14..22 SymGt@22..23 RParen@23..24 SymLt@25..26 SymIvlDelim@26..27 Integer("0")@27..28 SymIvlSep@28..30 Integer("1")@30..31 SymIvlDelim@31..32 SymGt@32..33
 212|AlphaLcId("ref")@0..3 SymEq@4..5 SymLt@6..7 AdlPath("/data[id2]/items")@7..23 SymGt@23..24
 213|AlphaLcId("time_committed")@0..14 SymEq@15..16 SymLt@17..18 Iso8601Date("2004-11-02")@18..28 Iso8601Time("09:31:04+1000")@29..42 SymGt@42..43

--- a/crates/openehr-lang/tests/it/bel_parse.rs
+++ b/crates/openehr-lang/tests/it/bel_parse.rs
@@ -149,3 +149,87 @@ fn lex_error_is_typed_and_located() {
     let err = parse_statements("a \u{00a7} b").unwrap_err(); // § is not a BEL token
     assert!(matches!(err, BelError::Lex { .. }), "got {err:?}");
 }
+
+/// `LANG/docs/BEL/master03-language.adoc` §Typing/§Statements (#1402):
+/// generic type_ids in declarations (`base_expressions.g4` `type_id`'s
+/// recursive form) and the chapter's own declaration examples.
+#[test]
+fn generic_type_ids_in_declarations() {
+    for src in [
+        "$heart_rate_history: List<Real>",
+        "$table: Hash<String,Integer>",
+        "$age_in_years: Integer := current_date() - $date_of_birth",
+    ] {
+        let stmts = parse_statements(src).unwrap_or_else(|e| panic!("{src}: {e}"));
+        assert!(
+            matches!(&stmts[0], Statement::VariableDeclaration(_)),
+            "{src}"
+        );
+    }
+}
+
+/// `master03-language.adoc` §Constants (#1402): `Name : Type = primitive_object`
+/// parses as a constant declaration (never a silently mis-read assertion),
+/// including the section's interval example; a UC-tagged assertion still
+/// parses when the shape does not complete as a constant.
+#[test]
+fn constant_declarations_parse() {
+    for src in [
+        "Mph_to_kmh_factor: Real = 1.6",
+        "Pounds_to_kg: Real = 0.4536",
+        "Systolic_normal_range: Interval<Integer> = |105..135|",
+    ] {
+        let stmts = parse_statements(src).unwrap_or_else(|e| panic!("{src}: {e}"));
+        // the beom carries a constant as its one declaration shape (no
+        // constant class exists — the NOTE at BeomBuilder::constant_declaration).
+        assert!(
+            matches!(&stmts[0], Statement::VariableDeclaration(_)),
+            "{src}"
+        );
+    }
+    // a UC tag whose body is not a `Type [= …]` shape stays an assertion.
+    let stmts = parse_statements("Check_vs_vars: exists $heart_rate").expect("tagged assertion");
+    assert!(matches!(&stmts[0], Statement::Assertion(_)));
+}
+
+/// `master03-language.adoc` §Container Operators (#1402): the quantifier
+/// binding accepts the docs-text bare identifier alongside the grammar's
+/// `$`-form, with both `:` and `in` separators and the optional `|`.
+#[test]
+fn quantifier_binding_spellings() {
+    for src in [
+        "Check: for_all v : $events | v/value > 0",
+        "Check: for_all v in $events | v/value > 0",
+        "Check: for_all $v : $events | $v/value > 0",
+        "Check: there_exists v : $events | v/value > 0",
+        "Check: \u{2200} v : $events | v/value > 0",
+        "Check: \u{2203} v : $events | v/value > 0",
+    ] {
+        assert!(
+            parse_statements(src).is_ok(),
+            "{src}: {:?}",
+            parse_statements(src).err()
+        );
+    }
+}
+
+/// `master03-language.adoc` §Literals (#1402): terminology-code literals are
+/// BEL primitives; the boundary twins — container literals have no grammar
+/// production and no beom destination (the BEOM-normative bound,
+/// `master02-overview.adoc`) — stay refused.
+#[test]
+fn terminology_code_literals_and_container_literal_boundary() {
+    let stmts =
+        parse_statements("Check: $code = [snomed_ct::389086002]").expect("term-code equality");
+    assert_eq!(stmts.len(), 1);
+
+    for refused in [
+        "$l: List<Integer> := [1, 2, 3]",
+        "$s: Set<Integer> := {1, 2, 3}",
+    ] {
+        assert!(
+            parse_statements(refused).is_err(),
+            "{refused} must stay refused (no grammar production, no beom class)"
+        );
+    }
+}


### PR DESCRIPTION
Closes #1402
Closes #1211
Closes #1212
Closes #1213
Closes #883
Closes #1214
Closes #1215
Closes #1216
Closes #1217
Closes #1218
Closes #1219
Closes #1220
Closes #884
Closes #1221
Closes #1222
Closes #1223
Closes #1224
Closes #885
Closes #886

## What

The whole BEL document of the #753 LANG program (walked checklists on all 14 section issues + 4 chapter records): ch.2 Overview (finding-free; the BEOM-is-normative bound established), ch.3 Language (finding #1402, four fixes), ch.4 Expression Object Model (finding-free; generated beom complete), App.A (the grammar reconciliation record).

## #1402 — the four fixes

1. **Generic type_ids** in declarations (grammar-backed bug — `type_id`'s own recursive rule).
2. **Constant declarations** — previously SILENTLY MIS-PARSED as UC-tagged assertions; now a real production (backtracking dispatch over the grammar's ambiguity, settled by the §Constants examples), RHS reaching `primitive_object` incl. verbatim-carried intervals; constants materialise as the beom's one declaration shape (no constant class exists — NOTE at both builders, the spec's own ch.3-vs-ch.4 inconsistency adjudicated to the normative model).
3. **Quantifier bindings** accept the docs-text bare identifier + the grammar `$`-form, both separators, optional `|` — incl. the symbolic `∀`/`∃` spellings.
4. **Terminology-code literals** admitted under the BEL lexer reading (grammar-backed) and as expression leaves (BEOM-normative + §3.4); five equivalence records re-adjudicated with citations.

Boundaries pinned as refusal twins: container/Set literals, bare-URI literals, list-valued constants (no grammar production and/or no beom destination); evaluation semantics recorded as the §2.2 engine boundary (nothing in-repo executes rules).

## Gates

fmt + clippy + rustdoc clean; `cargo nextest run -p openehr-lang -p openehr-adl` 488/488 green (incl. the ADL2 rules corpus — the AmBuilder gained the constant hook). Internal spec-crate: `no-changelog`.