### PR TITLE
feat(openehr-lang): bmm3 behavioural surface — #1405 #1406 #1409 (closes the BMM3 chapters)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,35 @@ workflow refuses a tag that has no matching section here.
 - **ODIN path extraction.** `OdinValue::paths()` extracts the
   `master05-content` tree-path set (attribute paths, `attr[key]` container
   paths, nested bare-key segments) from any parsed ODIN structure.
+- **The BMM v3 behavioural surface: type lattice, class/feature functions and a
+  v3 materialisation.** `openehr-lang` now answers the `master06-core-types`
+  meta-type lattice (`is_abstract`, `is_primitive`, `type_base_name`,
+  `unitary_type`, `effective_type`, `effective_base_class`,
+  `is_open`/`is_closed`/`is_partially_closed`), the `master07`/`master08` class
+  and feature functions (`BMM_SIMPLE_CLASS.type`, `BMM_GENERIC_CLASS.type` +
+  `generic_parameter_conformance_type`, `has_ancestor_class`, `all_ancestors`,
+  `flat_features`, `BMM_ENUMERATION.name_map`, `signature`, `arity`,
+  `is_boolean`), and materialises a v3 `BMM_MODEL` from a P_BMM schema
+  (`create_bmm3_model`) — which lands three things the v2.x transform cannot: a
+  generic ancestor's parameter substitution, a class's routines and constants, and
+  a `value_constraint` on the type it constrains.
 
 ### Fixed
+
+- **A malformed enumeration is refused instead of loaded silently.** A P_BMM
+  enumeration with more than one ancestor, or with `item_values` that are not 1:1
+  with `item_names`, now fails model materialisation with a typed error
+  (`EnumerationAncestorCount`, `EnumerationItemListsNotOneToOne`) — the two rules
+  `master07-core-classes` §Range-Constrained Classes and the `BMM_ENUMERATION`
+  class definition state. Stating names without values stays valid (the assumed
+  values 0, 1, 2, … apply).
+- **Container literal values are typed on the wire.** `BMM_CONTAINER_VALUE` and
+  `BMM_INDEXED_CONTAINER_VALUE` bound their inherited `type` slot to free-form
+  JSON; they now carry `BMM_CONTAINER_TYPE` / `BMM_INDEXED_CONTAINER_TYPE`, so a
+  container literal's `type` member is a `_type`-tagged container type in
+  canonical JSON instead of an arbitrary value. The two slots openEHR genuinely
+  leaves untyped (`BMM_INTERVAL_VALUE.type`, `EL_CASE.value_constraint`) now carry
+  their adjudication as a generated `NOTE` at the field.
 
 - **The generated LANG model carries both extant BMM generations in full.**
   `openehr-lang` was generated from the two vendored LANG schemas name-merged

--- a/crates/openehr-lang/CLAUDE.md
+++ b/crates/openehr-lang/CLAUDE.md
@@ -28,16 +28,50 @@ ADL/ODIN *instance* parsing — deliberately off the codegen path).
   Never "unify" the two, never reach across generations in a type position,
   and never add a shadow/adapter type: a shape gap is a
   `tools/openehr-codegen` fix + regeneration.
-- **The hand-written spec-function surface is the v2.x one** (`src/bmm/core/*_impl.rs`:
-  `BMM_CLASSIFIER`, `BMM_CLASS`, `BMM_TYPE`, `BMM_PROPERTY`, `BMM_MODEL`,
-  `BMM_PACKAGE`, `BMM_GENERIC_PARAMETER`, `BMM_OPEN_TYPE`), because P_BMM and
-  `rm_access` materialise the v2.x model. The v3 tree carries only its own
-  type-naming surface (`src/bmm3/core/entity/bmm_type_impl.rs`); the rest of the
-  v3 function surface, its invariants, and a v3 materialisation from P_BMM are
-  unimplemented and marked `TODO` at their sites. When a v2/v3 boundary is
-  recorded, name WHICH generation it belongs to — attributing a
-  generation-specific gap to "the openEHR specs" is a misattribution the
-  citation rule exists to prevent.
+- **BOTH generations now carry a hand-written spec-function surface, and they
+  never share code.** v2.x: `src/bmm/core/*_impl.rs` (`BMM_CLASSIFIER`,
+  `BMM_CLASS`, `BMM_TYPE`, `BMM_PROPERTY`, `BMM_MODEL`, `BMM_PACKAGE`,
+  `BMM_GENERIC_PARAMETER`, `BMM_OPEN_TYPE`) — the generation `rm_access`
+  publishes. v3: `src/bmm3/core/entity/bmm_type_impl.rs` (the type naming trio +
+  flattening + the meta-type lattice: `is_abstract`/`is_primitive`/
+  `type_base_name`/`unitary_type`/`effective_type`/`effective_base_class`/
+  `is_open`/`is_closed`/`is_partially_closed`, plus the `From` impls that ARE the
+  `BMM_TYPE ⊃ BMM_UNITARY_TYPE ⊃ BMM_EFFECTIVE_TYPE ⊃ BMM_MODEL_TYPE` lattice),
+  `src/bmm3/core/entity/bmm_class_impl.rs` (class attributes, `type()` generators,
+  `generic_parameter_conformance_type`, `has_ancestor_class`, `all_ancestors`,
+  `flat_features`, `BMM_ENUMERATION.name_map`),
+  `src/bmm3/core/feature/bmm_feature_impl.rs` (`signature()`/`arity()`/
+  `is_boolean()`), `src/bmm3/core/literal_value/bmm_literal_value_impl.rs`
+  (`value_literal`/`syntax` + the literal-evaluation boundary). When a v2/v3
+  boundary is recorded, name WHICH generation it belongs to — attributing a
+  generation-specific gap to "the openEHR specs" is a misattribution the citation
+  rule exists to prevent.
+- **`src/bmm3/expression/` and `src/bmm3/statement/` are DELIBERATELY inert (an
+  adjudicated boundary, not an oversight).** All 33 expression classes and the
+  statement package are emitted completely, with a canonical-JSON codec, and carry
+  **no** behaviour: none of `eval_type()`, `reference()`, `is_callable()`,
+  `operator_definition()`, `equivalent_call()` exists, none of the 9 declared
+  invariants is enforced, and no `*_impl.rs` should be added speculatively. Why:
+  the Expression Language is DEVELOPMENT status with no vendored grammar
+  (`LANG/docs/EL/masterAppA-syntax.adoc` points at an external ANTLR repo — the
+  same reason `src/lexer/` excludes EL), and the statement package is optional by
+  the spec's own words (`LANG/docs/bmm3/master12-statements.adoc` §Overview: "This
+  facility is not needed for achieving the original purpose of BMM"). The one
+  consequence to know: `BMM_ASSERTION.expression` is a `1..1`
+  `EL_BOOLEAN_EXPRESSION`, so the P_BMM→v3 materialisation cannot land class
+  invariants or routine pre/post-conditions (they stay opaque tagged strings in the
+  P_BMM graph) — the `TODO` is at `src/bmm_persistence/create_bmm3_model.rs`.
+  `beom` is a DIFFERENT spec's object model (BEL, STABLE) and is never wired into
+  `BMM_ASSERTION`; that would be a category error.
+- **Two abstract, attribute-free v3 classes emit as instantiable empty structs** —
+  `BMM_VISIBILITY` and `BMM_FEATURE_EXTENSION` (`bmm3/core/feature/`). Upstream
+  declares them abstract with zero attributes and zero descendants, and marks the
+  visibility meta-model unfinished (`LANG/docs/bmm3/master08-core-features.adoc`
+  §Feature Groups and Visibility: "TBD: define visibility meta-model"), so the
+  emitter has no better shape; the adjudication is recorded at the decision site
+  (`tools/openehr-codegen/src/plan/mod.rs`, the abstract-with-no-descendants
+  branch). Do not "fix" this in the crate — a declared subtype set upstream turns
+  each into an untagged enum automatically.
 - Codegen consumes the JSON BMM serialization only
   (`tools/openehr-codegen/vendor/bmm/`); the ODIN reader exists for
   ADL/ODIN instance text, not for loading meta-models.
@@ -71,20 +105,28 @@ ADL/ODIN *instance* parsing — deliberately off the codegen path).
   attribute the class docs do not declare is a typed error, with two
   spec-cited tolerance lists), `include_resolution.rs` (transitive inclusion
   merge, includer wins, collisions marked `is_override`), `create_model.rs`
-  (`P_BMM` → `BMM_MODEL`, all name references resolved to object references),
-  `loader.rs` (the composed `load_model`), `error.rs` (the one typed
-  `PBmmReadError`), plus `p_bmm_*_impl.rs` spec functions. Class-name
+  (`P_BMM` → **v2.x** `BMM_MODEL`, all name references resolved to object
+  references), `create_bmm3_model.rs` (`P_BMM` → **v3** `BMM_MODEL` — its own
+  module precisely because the two generations give the same Rust NAMES to
+  different types and import renaming is forbidden), `loader.rs` (the composed
+  `load_model`), `error.rs` (the one typed `PBmmReadError`), plus
+  `p_bmm_*_impl.rs` spec functions. Class-name
   resolution is case-insensitive (`master04-syntax.adoc` §Non-primitive
   Classes: `name` — "any capitalisation can be used"); embedding depth and
   every other cycle/boundary decision is adjudicated in the module docs, with
   the boundaries written out — and each one names the GENERATION it belongs to:
-  `value_constraint`, P_BMM `functions`/`invariants` and a generic ancestor's
-  parameter binding have no destination in the **v2.x** `BMM_*` model this
-  materialises (P_BMM is the v2.x persistence form,
-  `LANG/docs/bmm/master06-persistence.adoc`), while the **v3** classes DO
-  declare all three (`org.openehr.lang.bmm3.bmm_class.adoc` §Attributes,
-  `…bmm3.bmm_model_type.adoc` §Attributes), so a v3 materialisation is the
-  recorded `TODO`. A persisted `P_BMM_INTERFACE` IS a class-list
+  `value_constraint`, P_BMM `functions`/`constants` and a generic ancestor's
+  parameter binding have no destination in the **v2.x** `BMM_*` model
+  `create_model.rs` materialises (P_BMM is the v2.x persistence form,
+  `LANG/docs/bmm/master06-persistence.adoc`), while the **v3** classes DO declare
+  all three (`org.openehr.lang.bmm3.bmm_class.adoc` §Attributes,
+  `…bmm3.bmm_model_type.adoc` §Attributes) — and `create_bmm3_model.rs` lands
+  them. The one thing NO generation can land is a class invariant or routine
+  pre/post-condition, because that needs an EL parse (see the inert
+  expression/statement bullet above). Both transforms share one index +
+  enumeration-validity check (`Builder`, `check_enumeration_validity`, module-
+  private via `pub(super)`), so they can never disagree about what a class or a
+  valid enumeration IS. A persisted `P_BMM_INTERFACE` IS a class-list
   member (`master02-overview.adoc` §Conceptual Approach + openEHR's own
   published BASE/RM schemas): the emitter re-opens the `P_BMM_CLASS` subtype set
   for it (`plan/overrides.rs` `SUBTYPE_EXTENSIONS`), the reader materialises its

--- a/crates/openehr-lang/src/bel/parser.rs
+++ b/crates/openehr-lang/src/bel/parser.rs
@@ -4,6 +4,20 @@
 //! normative BEL syntax; `docs/specs/openehr/LANG/docs/BEL/masterAppA-syntax`).
 //! Operator precedence follows that grammar: `implies` < `or` < `xor` < `and` <
 //! `not` < comparison/`matches` < `+ -` < `* / %` < `^` < unary < primary.
+//!
+//! NOTE (adjudicated, cross-spec conflict): that order is **BEL's** — the
+//! `boolean_expr` alternatives of `base_expressions.g4` are listed in ascending
+//! precedence (`SYM_NOT` … `SYM_AND`, `SYM_XOR`, `SYM_OR`, `SYM_IMPLIES`), so
+//! `xor` binds TIGHTER than `or`. The openEHR Expression Language states the
+//! opposite: its Logical Operators table
+//! (`docs/specs/openehr/LANG/docs/EL/master05-expressions.adoc` §Primitive
+//! Operators, "descending precendence order") lists `NOT` > `AND` > `OR` >
+//! `XOR` > `IMPLIES`, and §Precedence and Parentheses makes that table
+//! normative for EL. The two therefore disagree on `a xor b or c`: BEL (and
+//! this parser) reads `(a xor b) or c`, EL reads `a xor (b or c)`. This parser
+//! implements BEL, which is the STABLE spec whose grammar openEHR vendors —
+//! EL is DEVELOPMENT with no vendored grammar. Any future EL parser must take
+//! its precedence from the EL tables and must NOT reuse this ordering.
 
 use crate::bel::{BelBuilder, BelError, BelLiteral};
 use crate::beom::core::operator_kind::OperatorKind;

--- a/crates/openehr-lang/src/bmm3/core/entity/bmm_class_impl.rs
+++ b/crates/openehr-lang/src/bmm3/core/entity/bmm_class_impl.rs
@@ -1,0 +1,554 @@
+//! Hand-written spec functions of the BMM **v3** `BMM_CLASS` family — the
+//! class-side surface of the v3 (`org.openehr.lang.bmm3`) generation: the
+//! shared-attribute accessors, the inheritance walks, the class→type generators
+//! and the enumeration name map.
+//!
+//! Spec: `LANG/docs/bmm3/master07-core-classes.adoc` (§Overview, §Simple
+//! Classes, §Generic Classes, §Range-Constrained Classes, §Inheritance) plus the
+//! class definitions under `LANG/docs/UML/classes/`:
+//! `org.openehr.lang.bmm3.bmm_class.adoc` §Attributes + §Functions,
+//! `…bmm3.bmm_simple_class.adoc` §Functions (`type`),
+//! `…bmm3.bmm_generic_class.adoc` §Functions (`type`,
+//! `generic_parameter_conformance_type`), `…bmm3.bmm_enumeration.adoc`
+//! §Functions (`name_map`).
+//!
+//! This is the v3 generation's OWN surface: in v3 a class inherits from
+//! **types** ("the `_ancestors_` attribute … contains a list of _types_ rather
+//! than classes", `…bmm3.bmm_class.adoc` §Description), where the v2.x
+//! generation's `BMM_CLASS.ancestors` is a map of CLASSES
+//! (`org.openehr.lang.bmm.bmm_class.adoc` §Attributes). The two surfaces are
+//! therefore never shared; the v2.x one is
+//! [`crate::bmm::core::bmm_class_impl`].
+//!
+//! NOTE (adjudicated): the walks here read the ancestor graph the way the v3
+//! model states it — each `BMM_MODEL_TYPE` ancestor carries its `base_class`
+//! whole — so they need no `BMM_MODEL` argument, unlike their v2.x counterparts
+//! (whose `immediate_descendants` are names only). Downward navigation
+//! (`all_descendants`) is not reimplemented here: v3's
+//! `immediate_descendants: List<BMM_CLASS>` (`…bmm3.bmm_class.adoc`
+//! §Attributes) is a BMM-mandatory back-reference the emitter cannot own as
+//! forward data, so no v3 instance carries one to follow.
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+
+use crate::bmm3::core::entity::bmm_class::BmmClass;
+use crate::bmm3::core::entity::bmm_effective_type::BmmEffectiveType;
+use crate::bmm3::core::entity::bmm_generic_class::BmmGenericClass;
+use crate::bmm3::core::entity::bmm_generic_type::BmmGenericType;
+use crate::bmm3::core::entity::bmm_model_type::BmmModelType;
+use crate::bmm3::core::entity::bmm_parameter_type::BmmParameterType;
+use crate::bmm3::core::entity::bmm_simple_class::BmmSimpleClass;
+use crate::bmm3::core::entity::bmm_simple_type::BmmSimpleType;
+use crate::bmm3::core::entity::bmm_type_impl::ANY_TYPE_NAME;
+use crate::bmm3::core::entity::bmm_unitary_type::BmmUnitaryType;
+use crate::bmm3::core::entity::range_constrained::bmm_enumeration::BmmEnumeration;
+use crate::bmm3::core::feature::bmm_feature::BmmFeature;
+use crate::bmm3::core::feature::bmm_function::BmmFunction;
+use crate::bmm3::core::feature::bmm_procedure::BmmProcedure;
+use crate::bmm3::core::feature::bmm_property::BmmProperty;
+use crate::bmm3::core::feature::bmm_static::BmmStatic;
+use crate::bmm3::core::literal_value::bmm_primitive_value::BmmPrimitiveValue;
+use crate::bmm3::core::model::bmm_package::BmmPackage;
+use crate::bmm3::statement::bmm_assertion::BmmAssertion;
+
+/// The `BMM_CLASS` attributes every generated v3 variant carries, projected out
+/// of the variant's own struct so the computed features are written once
+/// (`org.openehr.lang.bmm3.bmm_class.adoc` §Attributes).
+struct ClassCommon<'a> {
+    /// `BMM_CLASS.name` (from `BMM_MODEL_ELEMENT`).
+    name: &'a str,
+    /// `BMM_CLASS.ancestors` — immediate inheritance parents, as TYPES.
+    ancestors: Option<&'a BTreeMap<String, BmmModelType>>,
+    /// `BMM_CLASS.package`.
+    package: &'a BmmPackage,
+    /// `BMM_CLASS.features` — "Features of this module".
+    features: &'a [BmmFeature],
+    /// `BMM_CLASS.properties` — the *differential* property set.
+    properties: Option<&'a BTreeMap<String, BmmProperty>>,
+    /// `BMM_CLASS.static_properties`.
+    static_properties: Option<&'a BTreeMap<String, BmmStatic>>,
+    /// `BMM_CLASS.functions`.
+    functions: Option<&'a BTreeMap<String, BmmFunction>>,
+    /// `BMM_CLASS.procedures`.
+    procedures: Option<&'a BTreeMap<String, BmmProcedure>>,
+    /// `BMM_CLASS.creators`.
+    creators: Option<&'a BTreeMap<String, BmmProcedure>>,
+    /// `BMM_CLASS.converters`.
+    converters: Option<&'a BTreeMap<String, BmmProcedure>>,
+    /// `BMM_CLASS.invariants`.
+    invariants: &'a [BmmAssertion],
+    /// `BMM_CLASS.is_abstract` (`{default = false}`).
+    is_abstract: Option<bool>,
+    /// `BMM_CLASS.is_primitive` (`{default = false}`).
+    is_primitive: Option<bool>,
+    /// `BMM_CLASS.source_schema_id`.
+    source_schema_id: &'a str,
+}
+
+/// Projects one generated v3 `BMM_CLASS`-family struct onto [`ClassCommon`].
+macro_rules! class_common {
+    ($c:expr) => {
+        ClassCommon {
+            name: $c.name.as_str(),
+            ancestors: $c.ancestors.as_ref(),
+            package: &$c.package,
+            features: $c.features.as_slice(),
+            properties: $c.properties.as_ref(),
+            static_properties: $c.static_properties.as_ref(),
+            functions: $c.functions.as_ref(),
+            procedures: $c.procedures.as_ref(),
+            creators: $c.creators.as_ref(),
+            converters: $c.converters.as_ref(),
+            invariants: $c.invariants.as_slice(),
+            is_abstract: $c.is_abstract,
+            is_primitive: $c.is_primitive,
+            source_schema_id: $c.source_schema_id.as_str(),
+        }
+    };
+}
+
+/// The shared `BMM_CLASS` attributes of an enumeration class.
+fn enumeration_common(enumeration: &BmmEnumeration) -> ClassCommon<'_> {
+    match enumeration {
+        BmmEnumeration::BmmEnumerationInteger(c) => class_common!(c),
+        BmmEnumeration::BmmEnumerationString(c) => class_common!(c),
+        BmmEnumeration::BmmEnumeration(c) => class_common!(c),
+    }
+}
+
+/// The shared `BMM_CLASS` attributes of a simple class.
+fn simple_class_common(class: &BmmSimpleClass) -> ClassCommon<'_> {
+    match class {
+        BmmSimpleClass::BmmEnumeration(e) => enumeration_common(e),
+        BmmSimpleClass::BmmSimpleClass(c) => class_common!(c),
+    }
+}
+
+/// The shared `BMM_CLASS` attributes of the class generating a model type — the
+/// `_base_class_` every `BMM_MODEL_TYPE` carries
+/// (`org.openehr.lang.bmm3.bmm_model_type.adoc` §Attributes).
+fn model_type_base_class_common(model_type: &BmmModelType) -> ClassCommon<'_> {
+    match model_type {
+        BmmModelType::BmmGenericType(generic) => class_common!(generic.base_class),
+        BmmModelType::BmmSimpleType(simple) => simple_class_common(&simple.base_class),
+    }
+}
+
+/// Does the class described by `class` inherit, at any depth, from a class named
+/// `name`? The recursive half of [`BmmClass::has_ancestor_class`].
+fn walk_has_ancestor(class: &ClassCommon<'_>, name: &str, seen: &mut BTreeSet<String>) -> bool {
+    let Some(ancestors) = class.ancestors else {
+        return false;
+    };
+    for ancestor in ancestors.values() {
+        let base = model_type_base_class_common(ancestor);
+        if base.name.eq_ignore_ascii_case(name) {
+            return true;
+        }
+        if !seen.insert(base.name.to_uppercase()) {
+            continue;
+        }
+        if walk_has_ancestor(&base, name, seen) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Collects every ancestor class name reachable from `class`. The recursive half
+/// of [`BmmClass::all_ancestors`].
+fn walk_ancestor_names(
+    class: &ClassCommon<'_>,
+    out: &mut Vec<String>,
+    seen: &mut BTreeSet<String>,
+) {
+    let Some(ancestors) = class.ancestors else {
+        return;
+    };
+    for ancestor in ancestors.values() {
+        let base = model_type_base_class_common(ancestor);
+        if !seen.insert(base.name.to_uppercase()) {
+            continue;
+        }
+        out.push(base.name.to_owned());
+        walk_ancestor_names(&base, out, seen);
+    }
+}
+
+/// Merges the flattened feature set of `class`: ancestors first, own features
+/// last so the nearer definition wins. The recursive half of
+/// [`BmmClass::flat_features`].
+fn walk_flat_features(
+    class: &ClassCommon<'_>,
+    by_name: &mut BTreeMap<String, BmmFeature>,
+    seen: &mut BTreeSet<String>,
+) {
+    if let Some(ancestors) = class.ancestors {
+        for ancestor in ancestors.values() {
+            let base = model_type_base_class_common(ancestor);
+            if !seen.insert(base.name.to_uppercase()) {
+                continue;
+            }
+            walk_flat_features(&base, by_name, seen);
+        }
+    }
+    for feature in class.features {
+        by_name.insert(feature.name().to_owned(), feature.clone());
+    }
+}
+
+impl BmmEnumeration {
+    /// `BMM_MODEL_ELEMENT.name`: "Name of this model element"
+    /// (`org.openehr.lang.bmm3.bmm_model_element.adoc` §Attributes).
+    #[must_use]
+    pub fn name(&self) -> &str {
+        match self {
+            Self::BmmEnumerationInteger(e) => e.name.as_str(),
+            Self::BmmEnumerationString(e) => e.name.as_str(),
+            Self::BmmEnumeration(e) => e.name.as_str(),
+        }
+    }
+
+    /// `BMM_ENUMERATION.item_names`: "The list of names of the enumeration"
+    /// (`org.openehr.lang.bmm3.bmm_enumeration.adoc` §Attributes).
+    #[must_use]
+    pub fn item_names(&self) -> &[String] {
+        match self {
+            Self::BmmEnumerationInteger(e) => e.item_names.as_slice(),
+            Self::BmmEnumerationString(e) => e.item_names.as_slice(),
+            Self::BmmEnumeration(e) => e.item_names.as_slice(),
+        }
+    }
+
+    /// The enumeration's item values in their serialised (`_value_literal_`)
+    /// form, empty when the enumeration states names only.
+    ///
+    /// Each `item_values` member is a literal-value meta-object whose
+    /// `_value_literal_` is "A serial representation of the value"
+    /// (`org.openehr.lang.bmm3.bmm_literal_value.adoc` §Attributes) — which is
+    /// exactly the "(stringified)" form [`BmmEnumeration::name_map`] states. The
+    /// two degenerate leaves redefine the list's item type
+    /// (`…bmm3.bmm_enumeration_integer.adoc`,
+    /// `…bmm3.bmm_enumeration_string.adoc` §Attributes), so the projection is
+    /// per leaf.
+    #[must_use]
+    pub fn item_value_literals(&self) -> Vec<&str> {
+        match self {
+            Self::BmmEnumerationInteger(e) => e
+                .item_values
+                .iter()
+                .map(|v| v.value_literal.as_str())
+                .collect(),
+            Self::BmmEnumerationString(e) => e
+                .item_values
+                .iter()
+                .map(|v| v.value_literal.as_str())
+                .collect(),
+            Self::BmmEnumeration(e) => e
+                .item_values
+                .iter()
+                .map(BmmPrimitiveValue::value_literal)
+                .collect(),
+        }
+    }
+
+    /// `BMM_ENUMERATION.name_map`: "Map of `_item_names_` to `_item_values_`
+    /// (stringified)" (`org.openehr.lang.bmm3.bmm_enumeration.adoc` §Functions).
+    ///
+    /// When no values are stated the spec supplies them: "If no values are
+    /// supplied, the integer values 0, 1, 2, ... are assumed" (same
+    /// §Attributes), so each name maps to its ordinal. A stated value list is
+    /// "1:1 with `_item_names_`" (same §Attributes) — a name beyond the value
+    /// list is therefore a malformed enumeration, and mapping it to its ordinal
+    /// keeps the map total over `_item_names_` rather than silently dropping the
+    /// name; the P_BMM pipeline refuses that shape up front
+    /// ([`crate::bmm_persistence::error::PBmmReadError::EnumerationItemListsNotOneToOne`]).
+    #[must_use]
+    pub fn name_map(&self) -> BTreeMap<String, String> {
+        let values = self.item_value_literals();
+        self.item_names()
+            .iter()
+            .enumerate()
+            .map(|(index, name)| {
+                let value = values
+                    .get(index)
+                    .map_or_else(|| index.to_string(), |literal| (*literal).to_owned());
+                (name.clone(), value)
+            })
+            .collect()
+    }
+}
+
+impl BmmSimpleClass {
+    /// `BMM_MODEL_ELEMENT.name`: "Name of this model element"
+    /// (`org.openehr.lang.bmm3.bmm_model_element.adoc` §Attributes).
+    #[must_use]
+    pub fn name(&self) -> &str {
+        match self {
+            Self::BmmEnumeration(e) => e.name(),
+            Self::BmmSimpleClass(c) => c.name.as_str(),
+        }
+    }
+
+    /// `BMM_SIMPLE_CLASS.type` (effected): "Generate a type object that
+    /// represents the type of this class. Can only be an instance of
+    /// `BMM_SIMPLE_TYPE` or a descendant"
+    /// (`org.openehr.lang.bmm3.bmm_simple_class.adoc` §Functions).
+    ///
+    /// The generated type carries no `_value_constraint_`: a value-set
+    /// constraint belongs to a type's USE, not to the generating class
+    /// (`LANG/docs/bmm3/master07-core-classes.adoc` §Range-Constrained Classes —
+    /// the value-set mechanism "applied to the use of a type").
+    #[must_use]
+    pub fn r#type(&self) -> BmmSimpleType {
+        BmmSimpleType {
+            value_constraint: None,
+            base_class: self.clone(),
+        }
+    }
+}
+
+impl BmmGenericClass {
+    /// `BMM_GENERIC_CLASS.type` (effected): "Generate a fully open
+    /// `BMM_GENERIC_TYPE` instance that corresponds to this class definition"
+    /// (`org.openehr.lang.bmm3.bmm_generic_class.adoc` §Functions).
+    ///
+    /// "Fully open" means every generic parameter is the formal parameter itself
+    /// (`BMM_PARAMETER_TYPE`), not a substitution — the `Interval<T>` form of
+    /// `master06-core-types.adoc` §Generic Type.
+    ///
+    /// NOTE (recorded deviation): parameter ORDER follows the keyed map's sorted
+    /// keys. openEHR keys `generic_parameters` by name (same §Attributes) while
+    /// `BMM_GENERIC_TYPE.generic_parameters` is an ordered list whose "order must
+    /// match the order of the owning class's formal generic parameter
+    /// declarations" (`…bmm3.bmm_generic_type.adoc` §Attributes) — a keyed map
+    /// does not preserve declaration order, and for the single-upper-case-letter
+    /// names the model mandates (`…bmm3.bmm_parameter_type.adoc`
+    /// `Inv_generic_name`: "`name.count = 1 and name.is_upper`") sorted order IS
+    /// declaration order for the conventional `T`, `U`, `V`.
+    #[must_use]
+    pub fn r#type(&self) -> BmmGenericType {
+        BmmGenericType {
+            value_constraint: None,
+            base_class: self.clone(),
+            generic_parameters: self
+                .generic_parameters
+                .values()
+                .map(|p| BmmUnitaryType::BmmParameterType(Box::new(p.clone())))
+                .collect(),
+        }
+    }
+
+    /// The formal generic parameter named `name`, matched case-insensitively
+    /// ("it is assumed that case-insensitive matching is used",
+    /// `LANG/docs/bmm3/master05-core-model.adoc` §Naming Convention).
+    #[must_use]
+    pub fn generic_parameter(&self, name: &str) -> Option<&BmmParameterType> {
+        self.generic_parameters.get(name).or_else(|| {
+            self.generic_parameters
+                .iter()
+                .find(|(key, _)| key.eq_ignore_ascii_case(name))
+                .map(|(_, parameter)| parameter)
+        })
+    }
+
+    /// `BMM_GENERIC_CLASS.generic_parameter_conformance_type`: "For a generic
+    /// class, type to which generic parameter `a_name` conforms e.g. if this
+    /// class is `Interval <T:Comparable>` then the Result will be the single type
+    /// `Comparable`. For an unconstrained type `T`, the Result will be `Any`"
+    /// (`org.openehr.lang.bmm3.bmm_generic_class.adoc` §Functions).
+    ///
+    /// `None` when this class declares no such parameter — the class definition
+    /// states no result for that case, and answering `Any` would claim a
+    /// conformance type for a parameter that does not exist. The constraint
+    /// itself resolves through the parameter's inheritance precursor
+    /// (`…bmm3.bmm_parameter_type.adoc` §Functions
+    /// `flattened_conforms_to_type`).
+    #[must_use]
+    pub fn generic_parameter_conformance_type(&self, name: &str) -> Option<String> {
+        self.generic_parameter(name).map(|parameter| {
+            parameter
+                .flattened_conforms_to_type()
+                .map_or_else(|| ANY_TYPE_NAME.to_owned(), BmmEffectiveType::type_name)
+        })
+    }
+}
+
+impl BmmClass {
+    /// The `BMM_CLASS` attributes shared by every v3 variant.
+    fn common(&self) -> ClassCommon<'_> {
+        match self {
+            Self::BmmGenericClass(c) => class_common!(c),
+            Self::BmmSimpleClass(c) => simple_class_common(c),
+        }
+    }
+
+    /// `BMM_MODEL_ELEMENT.name`: "Name of this model element"
+    /// (`org.openehr.lang.bmm3.bmm_model_element.adoc` §Attributes). Note that
+    /// unlike UML this is "just the root name, even if the class is generic"
+    /// (`org.openehr.lang.bmm3.bmm_class.adoc` §Description NOTE).
+    #[must_use]
+    pub fn name(&self) -> &str {
+        self.common().name
+    }
+
+    /// `BMM_CLASS.ancestors`: "List of immediate inheritance parents", as TYPES
+    /// (`org.openehr.lang.bmm3.bmm_class.adoc` §Attributes).
+    #[must_use]
+    pub fn ancestors(&self) -> Option<&BTreeMap<String, BmmModelType>> {
+        self.common().ancestors
+    }
+
+    /// `BMM_CLASS.package`: "Package this class belongs to" (class doc
+    /// §Attributes).
+    #[must_use]
+    pub fn package(&self) -> &BmmPackage {
+        self.common().package
+    }
+
+    /// `BMM_CLASS.features` / `features()`: "Features of this module" — the
+    /// differential set introduced by this class (class doc §Attributes +
+    /// §Functions).
+    #[must_use]
+    pub fn features(&self) -> &[BmmFeature] {
+        self.common().features
+    }
+
+    /// `BMM_CLASS.properties`: "Properties defined in this class (subset of
+    /// `_features_`)" (class doc §Attributes) — the differential set.
+    #[must_use]
+    pub fn properties(&self) -> Option<&BTreeMap<String, BmmProperty>> {
+        self.common().properties
+    }
+
+    /// `BMM_CLASS.static_properties`: "Static properties defined in this class
+    /// (subset of `_features_`)" (class doc §Attributes).
+    #[must_use]
+    pub fn static_properties(&self) -> Option<&BTreeMap<String, BmmStatic>> {
+        self.common().static_properties
+    }
+
+    /// `BMM_CLASS.functions`: "Functions defined in this class (subset of
+    /// `_features_`)" (class doc §Attributes).
+    #[must_use]
+    pub fn functions(&self) -> Option<&BTreeMap<String, BmmFunction>> {
+        self.common().functions
+    }
+
+    /// `BMM_CLASS.procedures`: "Procedures defined in this class (subset of
+    /// `_features_`)" (class doc §Attributes).
+    #[must_use]
+    pub fn procedures(&self) -> Option<&BTreeMap<String, BmmProcedure>> {
+        self.common().procedures
+    }
+
+    /// `BMM_CLASS.creators`: "Subset of `_procedures_` that may be used to
+    /// initialise a new instance of an object" (class doc §Attributes).
+    #[must_use]
+    pub fn creators(&self) -> Option<&BTreeMap<String, BmmProcedure>> {
+        self.common().creators
+    }
+
+    /// `BMM_CLASS.converters`: "Subset of `_creators_` that create a new
+    /// instance from a single argument of another type" (class doc §Attributes).
+    #[must_use]
+    pub fn converters(&self) -> Option<&BTreeMap<String, BmmProcedure>> {
+        self.common().converters
+    }
+
+    /// `BMM_CLASS.invariants`: the class's assertions, which are "always in the
+    /// form of an `BMM_ASSERTION`" (`LANG/docs/bmm3/master10-expressions.adoc`
+    /// §Usage in BMM Models; `org.openehr.lang.bmm3.bmm_class.adoc` §Attributes).
+    #[must_use]
+    pub fn invariants(&self) -> &[BmmAssertion] {
+        self.common().invariants
+    }
+
+    /// `BMM_CLASS.source_schema_id`: "Reference to original source schema
+    /// defining this class" (class doc §Attributes).
+    #[must_use]
+    pub fn source_schema_id(&self) -> &str {
+        self.common().source_schema_id
+    }
+
+    /// `BMM_CLASS.is_abstract`: "True if this class is marked as abstract, i.e.
+    /// direct instances cannot be created from its direct type" — `{default =
+    /// false}` (`org.openehr.lang.bmm3.bmm_class.adoc` §Attributes).
+    #[must_use]
+    pub fn is_abstract(&self) -> bool {
+        self.common().is_abstract.unwrap_or(false)
+    }
+
+    /// `BMM_CLASS.is_primitive`: "True if this class represents a type
+    /// considered to be primitive in the type system" — `{default = false}`
+    /// (`org.openehr.lang.bmm3.bmm_class.adoc` §Attributes).
+    #[must_use]
+    pub fn is_primitive(&self) -> bool {
+        self.common().is_primitive.unwrap_or(false)
+    }
+
+    /// `BMM_CLASS.type` (abstract): "Generate a type object that represents the
+    /// type for which this class is the definer"
+    /// (`org.openehr.lang.bmm3.bmm_class.adoc` §Functions), effected per subtype
+    /// ([`BmmSimpleClass::type`], [`BmmGenericClass::type`]).
+    #[must_use]
+    pub fn r#type(&self) -> BmmModelType {
+        match self {
+            Self::BmmGenericClass(c) => BmmModelType::BmmGenericType(c.r#type()),
+            Self::BmmSimpleClass(c) => BmmModelType::BmmSimpleType(c.r#type()),
+        }
+    }
+
+    /// `BMM_CLASS.has_ancestor_class(a_class_name)` — the test
+    /// `master06-core-types.adoc` §Type Conformance calls in its base-class
+    /// branch: does this class inherit, at any depth, from a class of that name?
+    ///
+    /// Names are matched case-insensitively ("`base_class.is_case_insensitive_equal
+    /// (anc_base_class)`", same §Type Conformance). The walk carries its own
+    /// visited set so a malformed (cyclic) ancestor graph cannot hang it — the
+    /// spec states inheritance "results in an acyclic graph"
+    /// (`LANG/docs/bmm3/master13-model_semantics.adoc` §Simple Inheritance) but
+    /// nothing enforces that on a loaded model.
+    #[must_use]
+    pub fn has_ancestor_class(&self, name: &str) -> bool {
+        walk_has_ancestor(&self.common(), name, &mut BTreeSet::new())
+    }
+
+    /// `BMM_CLASS.all_ancestors`: "List of all inheritance parent class names,
+    /// recursively" (`org.openehr.lang.bmm3.bmm_class.adoc` §Functions).
+    ///
+    /// Deduplicated — multiple inheritance means the same ancestor can be
+    /// reached by more than one path (`master13-model_semantics.adoc` §Multiple
+    /// Inheritance) — and cycle-guarded, as in
+    /// [`BmmClass::has_ancestor_class`].
+    #[must_use]
+    pub fn all_ancestors(&self) -> Vec<String> {
+        let mut out: Vec<String> = Vec::new();
+        walk_ancestor_names(&self.common(), &mut out, &mut BTreeSet::new());
+        out
+    }
+
+    /// `BMM_CLASS.flat_features`: "Consolidated list of all feature definitions
+    /// from this class and all inheritance ancestors"
+    /// (`org.openehr.lang.bmm3.bmm_class.adoc` §Functions).
+    ///
+    /// Ancestor features are merged first and this class's own last, so a
+    /// redefinition in the nearer class replaces the inherited definition of the
+    /// same name — the differential-vs-flat distinction of
+    /// `LANG/docs/bmm3/master08-core-features.adoc` §Overview ("Differential vs
+    /// flat feature sets"). The result is name-ordered, so it is deterministic.
+    ///
+    /// NOTE (adjudicated): same-named features arriving from DIFFERENT ancestors
+    /// are a clash the spec says needs resolution
+    /// (`master07-core-classes.adoc` §Inheritance), and the model records no
+    /// resolution a schema chose; the merge order here is a total function over
+    /// the graph, not a clash verdict. Reporting clashes would need a
+    /// validation-report shape openEHR does not define.
+    #[must_use]
+    pub fn flat_features(&self) -> Vec<BmmFeature> {
+        let mut by_name: BTreeMap<String, BmmFeature> = BTreeMap::new();
+        walk_flat_features(&self.common(), &mut by_name, &mut BTreeSet::new());
+        by_name.into_values().collect()
+    }
+}

--- a/crates/openehr-lang/src/bmm3/core/entity/bmm_type_impl.rs
+++ b/crates/openehr-lang/src/bmm3/core/entity/bmm_type_impl.rs
@@ -24,17 +24,26 @@
 //! (`LANG/docs/bmm3/master00-amendment_record.adoc` SPECLANG-14, "Formalise the
 //! BMM v2/v3 split").
 //!
-//! TODO: only the naming/flattening surface is implemented here. The rest of the
-//! v3 type lattice declared by those class definitions — `is_abstract`,
-//! `is_open`/`is_closed`/`is_partially_closed`, `effective_base_class`,
-//! `unitary_type`, `effective_type`, `is_primitive`, `type_base_name` — and the
-//! v3 class/feature/model function surface (`BMM_CLASS.flat_features`,
-//! `BMM_MODEL` navigation, the declared invariants) are unimplemented.
+//! The naming/flattening surface and the meta-type LATTICE
+//! (`is_abstract`, `is_primitive`, `type_base_name`, `unitary_type`,
+//! `effective_type`, `effective_base_class`, `is_open`/`is_closed`/
+//! `is_partially_closed`) both live here; the class and feature surfaces are the
+//! siblings [`crate::bmm3::core::entity::bmm_class_impl`] and
+//! [`crate::bmm3::core::feature::bmm_feature_impl`].
+//!
+//! TODO: implement v3 MODEL-level navigation (a `BMM_MODEL` counterpart of
+//! [`crate::bmm::core::bmm_model_impl`]'s `type_conforms_to` /
+//! `all_ancestor_classes` / `property_definition` over
+//! `crate::bmm3::core::model::bmm_model::BmmModel`). The type-level lattice above
+//! is its precondition and is now in place; §Type Conformance
+//! (`LANG/docs/bmm3/master06-core-types.adoc`) is the algorithm to implement, and
+//! its Tuple and Signature branches are empty upstream (L251, L253).
 
 use crate::bmm3::core::entity::bmm_class::BmmClass;
 use crate::bmm3::core::entity::bmm_container_type::BmmContainerType;
 use crate::bmm3::core::entity::bmm_effective_type::BmmEffectiveType;
 use crate::bmm3::core::entity::bmm_function_type::BmmFunctionType;
+use crate::bmm3::core::entity::bmm_generic_class::BmmGenericClass;
 use crate::bmm3::core::entity::bmm_generic_type::BmmGenericType;
 use crate::bmm3::core::entity::bmm_indexed_container_type::BmmIndexedContainerType;
 use crate::bmm3::core::entity::bmm_model_type::BmmModelType;
@@ -50,7 +59,6 @@ use crate::bmm3::core::entity::bmm_status_type::BmmStatusType;
 use crate::bmm3::core::entity::bmm_tuple_type::BmmTupleType;
 use crate::bmm3::core::entity::bmm_type::BmmType;
 use crate::bmm3::core::entity::bmm_unitary_type::BmmUnitaryType;
-use crate::bmm3::core::entity::range_constrained::bmm_enumeration::BmmEnumeration;
 
 /// The name of the top `Any` type, used wherever an unconstrained generic
 /// parameter has to be reduced to a concrete conformance name
@@ -69,45 +77,6 @@ fn unique(names: Vec<String>) -> Vec<String> {
         }
     }
     out
-}
-
-impl BmmEnumeration {
-    /// `BMM_MODEL_ELEMENT.name`: "Name of this model element"
-    /// (`org.openehr.lang.bmm3.bmm_model_element.adoc` §Attributes).
-    #[must_use]
-    pub fn name(&self) -> &str {
-        match self {
-            Self::BmmEnumerationInteger(e) => e.name.as_str(),
-            Self::BmmEnumerationString(e) => e.name.as_str(),
-            Self::BmmEnumeration(e) => e.name.as_str(),
-        }
-    }
-}
-
-impl BmmSimpleClass {
-    /// `BMM_MODEL_ELEMENT.name`: "Name of this model element"
-    /// (`org.openehr.lang.bmm3.bmm_model_element.adoc` §Attributes).
-    #[must_use]
-    pub fn name(&self) -> &str {
-        match self {
-            Self::BmmEnumeration(e) => e.name(),
-            Self::BmmSimpleClass(c) => c.name.as_str(),
-        }
-    }
-}
-
-impl BmmClass {
-    /// `BMM_MODEL_ELEMENT.name`: "Name of this model element"
-    /// (`org.openehr.lang.bmm3.bmm_model_element.adoc` §Attributes). Note that
-    /// unlike UML this is "just the root name, even if the class is generic"
-    /// (`org.openehr.lang.bmm3.bmm_class.adoc` §Description NOTE).
-    #[must_use]
-    pub fn name(&self) -> &str {
-        match self {
-            Self::BmmGenericClass(c) => c.name.as_str(),
-            Self::BmmSimpleClass(c) => c.name(),
-        }
-    }
 }
 
 impl BmmSimpleType {
@@ -716,5 +685,643 @@ impl BmmType {
             Self::BmmStatusType(status) => status.flattened_type_list(),
             Self::BmmTupleType(tuple) => tuple.flattened_type_list(),
         }
+    }
+}
+
+// ── the meta-type lattice (master06-core-types.adoc §Overview) ───────────────
+// `BMM_TYPE` splits into the abstract `BMM_UNITARY_TYPE` and the concrete
+// container meta-types; unitary splits into `BMM_PARAMETER_TYPE` and
+// `BMM_EFFECTIVE_TYPE`; effective splits into `BMM_MODEL_TYPE`,
+// `BMM_TUPLE_TYPE` and `BMM_SIGNATURE` (L39-45). Rust models each level as its
+// own closed enum, so moving UP a level is a total conversion — these `From`
+// impls are that lattice, and they are what makes `unitary_type()` /
+// `effective_type()` typeable.
+
+impl From<BmmUnitaryType> for BmmType {
+    fn from(unitary: BmmUnitaryType) -> Self {
+        match unitary {
+            BmmUnitaryType::BmmGenericType(generic) => Self::BmmGenericType(generic),
+            BmmUnitaryType::BmmParameterType(parameter) => Self::BmmParameterType(parameter),
+            BmmUnitaryType::BmmSignature(signature) => Self::BmmSignature(signature),
+            BmmUnitaryType::BmmSimpleType(simple) => Self::BmmSimpleType(simple),
+            BmmUnitaryType::BmmStatusType(status) => Self::BmmStatusType(status),
+            BmmUnitaryType::BmmTupleType(tuple) => Self::BmmTupleType(tuple),
+        }
+    }
+}
+
+impl From<BmmEffectiveType> for BmmUnitaryType {
+    fn from(effective: BmmEffectiveType) -> Self {
+        match effective {
+            BmmEffectiveType::BmmGenericType(generic) => Self::BmmGenericType(generic),
+            BmmEffectiveType::BmmSignature(signature) => Self::BmmSignature(signature),
+            BmmEffectiveType::BmmSimpleType(simple) => Self::BmmSimpleType(simple),
+            BmmEffectiveType::BmmStatusType(status) => Self::BmmStatusType(status),
+            BmmEffectiveType::BmmTupleType(tuple) => Self::BmmTupleType(tuple),
+        }
+    }
+}
+
+impl From<BmmEffectiveType> for BmmType {
+    fn from(effective: BmmEffectiveType) -> Self {
+        Self::from(BmmUnitaryType::from(effective))
+    }
+}
+
+impl From<BmmModelType> for BmmEffectiveType {
+    fn from(model_type: BmmModelType) -> Self {
+        match model_type {
+            BmmModelType::BmmGenericType(generic) => Self::BmmGenericType(generic),
+            BmmModelType::BmmSimpleType(simple) => Self::BmmSimpleType(simple),
+        }
+    }
+}
+
+impl From<BmmModelType> for BmmUnitaryType {
+    fn from(model_type: BmmModelType) -> Self {
+        Self::from(BmmEffectiveType::from(model_type))
+    }
+}
+
+impl From<BmmModelType> for BmmType {
+    fn from(model_type: BmmModelType) -> Self {
+        Self::from(BmmEffectiveType::from(model_type))
+    }
+}
+
+impl BmmSimpleType {
+    /// `BMM_SIMPLE_TYPE.is_abstract` (effected): "Result is
+    /// `_base_class.is_abstract_`" (`org.openehr.lang.bmm3.bmm_simple_type.adoc`
+    /// §Functions).
+    #[must_use]
+    pub fn is_abstract(&self) -> bool {
+        BmmClass::BmmSimpleClass(self.base_class.clone()).is_abstract()
+    }
+
+    /// `BMM_MODEL_TYPE.is_primitive` (effected): "Result =
+    /// `_base_class.is_primitive_`" (`org.openehr.lang.bmm3.bmm_model_type.adoc`
+    /// §Functions).
+    #[must_use]
+    pub fn is_primitive(&self) -> bool {
+        BmmClass::BmmSimpleClass(self.base_class.clone()).is_primitive()
+    }
+
+    /// `BMM_MODEL_TYPE.type_base_name` (effected): "Result = `_base_class.name_`"
+    /// (`org.openehr.lang.bmm3.bmm_model_type.adoc` §Functions).
+    #[must_use]
+    pub fn type_base_name(&self) -> &str {
+        self.base_class.name()
+    }
+
+    /// `BMM_SIMPLE_TYPE.effective_base_class`: "Main design class for this type,
+    /// from which properties etc can be extracted"
+    /// (`org.openehr.lang.bmm3.bmm_simple_type.adoc` §Functions).
+    ///
+    /// A simple type is 1:1 with its generating class
+    /// (`…bmm3.bmm_simple_class.adoc` §Description), so the effective base class
+    /// IS `_base_class_`; the function exists because the generic form abstracts
+    /// a container away ([`BmmGenericType::effective_base_class`]).
+    #[must_use]
+    pub fn effective_base_class(&self) -> &BmmSimpleClass {
+        &self.base_class
+    }
+}
+
+impl BmmGenericType {
+    /// `BMM_GENERIC_TYPE.is_abstract` (effected): "True if
+    /// `_base_class.is_abstract_` or if any (non-open) parameter type is
+    /// abstract" (`org.openehr.lang.bmm3.bmm_generic_type.adoc` §Functions).
+    ///
+    /// "Non-open" excludes a formal parameter (`BMM_PARAMETER_TYPE`), which the
+    /// class definition declares non-abstract by definition
+    /// (`…bmm3.bmm_parameter_type.adoc` §Functions `is_abstract`: "Result =
+    /// `False`").
+    #[must_use]
+    pub fn is_abstract(&self) -> bool {
+        BmmClass::BmmGenericClass(self.base_class.clone()).is_abstract()
+            || self
+                .generic_parameters
+                .iter()
+                .any(BmmUnitaryType::is_abstract)
+    }
+
+    /// `BMM_MODEL_TYPE.is_primitive` (effected): "Result =
+    /// `_base_class.is_primitive_`" (`org.openehr.lang.bmm3.bmm_model_type.adoc`
+    /// §Functions) — the generating class's own designation, not the parameters'.
+    #[must_use]
+    pub fn is_primitive(&self) -> bool {
+        BmmClass::BmmGenericClass(self.base_class.clone()).is_primitive()
+    }
+
+    /// `BMM_MODEL_TYPE.type_base_name` (effected): "Result = `_base_class.name_`"
+    /// — "Name of base generator type, i.e. excluding any generic parts if
+    /// present" (`org.openehr.lang.bmm3.bmm_model_type.adoc` §Functions,
+    /// `…bmm3.bmm_effective_type.adoc` §Functions).
+    #[must_use]
+    pub fn type_base_name(&self) -> &str {
+        self.base_class.name.as_str()
+    }
+
+    /// `BMM_GENERIC_TYPE.effective_base_class`: "Effective underlying class for
+    /// this type, abstracting away any container type"
+    /// (`org.openehr.lang.bmm3.bmm_generic_type.adoc` §Functions).
+    #[must_use]
+    pub fn effective_base_class(&self) -> &BmmGenericClass {
+        &self.base_class
+    }
+
+    /// `BMM_GENERIC_TYPE.is_open`: "True if all generic parameters from ancestor
+    /// generic types have been substituted in this type"
+    /// (`org.openehr.lang.bmm3.bmm_generic_type.adoc` §Functions).
+    ///
+    /// NOTE (upstream naming slip, adjudicated to the class definition): the
+    /// function is NAMED `is_open` while its stated semantics are those of
+    /// CLOSURE, and `master06-core-types.adoc` §Generic Type calls the same
+    /// property "detected via the function `_is_closed_`" (L81) — a function no
+    /// class definition declares. This implementation follows the class
+    /// definition's SEMANTICS under its own name: `is_open()` is true when no
+    /// parameter is still a formal (open) parameter, i.e. when the type is fully
+    /// substituted. [`BmmGenericType::is_closed`] is the same predicate under the
+    /// chapter's name, so a caller can spell it either way without guessing which
+    /// reading it gets.
+    #[must_use]
+    pub fn is_open(&self) -> bool {
+        !self
+            .generic_parameters
+            .iter()
+            .any(|p| matches!(p, BmmUnitaryType::BmmParameterType(_)))
+    }
+
+    /// `master06-core-types.adoc` §Generic Type L81's name for the fully
+    /// substituted state ("closure is detected via the function `_is_closed_`") —
+    /// identical to [`BmmGenericType::is_open`], see its NOTE for the upstream
+    /// naming slip.
+    #[must_use]
+    pub fn is_closed(&self) -> bool {
+        self.is_open()
+    }
+
+    /// `BMM_GENERIC_TYPE.is_partially_closed`: "Returns True if there is any
+    /// substituted generic parameter"
+    /// (`org.openehr.lang.bmm3.bmm_generic_type.adoc` §Functions).
+    #[must_use]
+    pub fn is_partially_closed(&self) -> bool {
+        self.generic_parameters
+            .iter()
+            .any(|p| !matches!(p, BmmUnitaryType::BmmParameterType(_)))
+    }
+}
+
+impl BmmModelType {
+    /// `BMM_MODEL_TYPE.type_base_name` (effected): "Result = `_base_class.name_`"
+    /// (`org.openehr.lang.bmm3.bmm_model_type.adoc` §Functions).
+    #[must_use]
+    pub fn type_base_name(&self) -> &str {
+        match self {
+            Self::BmmGenericType(generic) => generic.type_base_name(),
+            Self::BmmSimpleType(simple) => simple.type_base_name(),
+        }
+    }
+
+    /// `BMM_TYPE.is_abstract`: "indicates a type based on an abstract class,
+    /// i.e. a type that cannot be directly instantiated"
+    /// (`org.openehr.lang.bmm3.bmm_type.adoc` §Functions).
+    #[must_use]
+    pub fn is_abstract(&self) -> bool {
+        match self {
+            Self::BmmGenericType(generic) => generic.is_abstract(),
+            Self::BmmSimpleType(simple) => simple.is_abstract(),
+        }
+    }
+
+    /// `BMM_MODEL_TYPE.is_primitive` (effected): "Result =
+    /// `_base_class.is_primitive_`" (`org.openehr.lang.bmm3.bmm_model_type.adoc`
+    /// §Functions).
+    #[must_use]
+    pub fn is_primitive(&self) -> bool {
+        match self {
+            Self::BmmGenericType(generic) => generic.is_primitive(),
+            Self::BmmSimpleType(simple) => simple.is_primitive(),
+        }
+    }
+
+    /// The class that generates this type — the `_base_class_` every model type
+    /// carries (`org.openehr.lang.bmm3.bmm_model_type.adoc` §Attributes).
+    #[must_use]
+    pub fn base_class(&self) -> BmmClass {
+        match self {
+            Self::BmmGenericType(generic) => BmmClass::BmmGenericClass(generic.base_class.clone()),
+            Self::BmmSimpleType(simple) => BmmClass::BmmSimpleClass(simple.base_class.clone()),
+        }
+    }
+}
+
+impl BmmParameterType {
+    /// `BMM_PARAMETER_TYPE.is_abstract` (effected): "Result = `False` - generic
+    /// parameters are understood by definition to be non-abstract"
+    /// (`org.openehr.lang.bmm3.bmm_parameter_type.adoc` §Functions).
+    #[expect(
+        clippy::unused_self,
+        reason = "the class definition declares this as an instance function whose result is the constant False"
+    )]
+    #[must_use]
+    pub fn is_abstract(&self) -> bool {
+        false
+    }
+
+    /// `BMM_PARAMETER_TYPE.is_primitive` (effected): "Result = `False` - generic
+    /// parameters are understood by definition to be non-primitive"
+    /// (`org.openehr.lang.bmm3.bmm_parameter_type.adoc` §Functions).
+    ///
+    /// NOTE (upstream contradiction, adjudicated to the stated result): the same
+    /// entry also carries `Post_validity: Result = base_class.is_primitive`, a
+    /// post-condition naming an attribute `BMM_PARAMETER_TYPE` does not have
+    /// (only `BMM_MODEL_TYPE` has `base_class`) — a copy-paste from that class.
+    /// The prose result ("`False`") is the only consistent reading and is the one
+    /// implemented.
+    #[expect(
+        clippy::unused_self,
+        reason = "the class definition declares this as an instance function whose result is the constant False"
+    )]
+    #[must_use]
+    pub fn is_primitive(&self) -> bool {
+        false
+    }
+
+    /// `BMM_PARAMETER_TYPE.effective_type` (effected): "Generate ultimate
+    /// conformance type, which is either `_flattened_conforms_to_type_` or if not
+    /// set, `'Any'`" (`org.openehr.lang.bmm3.bmm_parameter_type.adoc`
+    /// §Functions).
+    ///
+    /// `None` is the `'Any'` case: `Any` is the model's top class
+    /// (`…bmm3.bmm_definitions.adoc` §Functions `Any_class`), so returning it as
+    /// a `BMM_EFFECTIVE_TYPE` would mean inventing a `BMM_SIMPLE_TYPE` over a
+    /// class definition this parameter does not carry. The name is available as
+    /// [`ANY_TYPE_NAME`], and [`BmmParameterType::conformance_type_name`] is the
+    /// name-level answer that already applies it.
+    #[must_use]
+    pub fn effective_type(&self) -> Option<BmmEffectiveType> {
+        self.flattened_conforms_to_type().cloned()
+    }
+}
+
+impl BmmSignature {
+    /// `BMM_BUILTIN_TYPE.is_abstract` (effected): "Return False" — built-in types
+    /// "are treated as being primitive and non-abstract"
+    /// (`org.openehr.lang.bmm3.bmm_builtin_type.adoc` §Functions + §Description).
+    #[expect(
+        clippy::unused_self,
+        reason = "the class definition declares this as an instance function whose result is the constant False"
+    )]
+    #[must_use]
+    pub fn is_abstract(&self) -> bool {
+        false
+    }
+
+    /// `BMM_BUILTIN_TYPE.is_primitive` (effected): "Return True"
+    /// (`org.openehr.lang.bmm3.bmm_builtin_type.adoc` §Functions).
+    #[expect(
+        clippy::unused_self,
+        reason = "the class definition declares this as an instance function whose result is the constant True"
+    )]
+    #[must_use]
+    pub fn is_primitive(&self) -> bool {
+        true
+    }
+
+    /// `BMM_BUILTIN_TYPE.type_base_name` (effected): "Return `_base_name_`"
+    /// (`org.openehr.lang.bmm3.bmm_builtin_type.adoc` §Functions) — the
+    /// `"Signature"` / `"Routine"` / `"Function"` / `"Procedure"` constants of
+    /// the signature family.
+    #[must_use]
+    pub fn type_base_name(&self) -> &'static str {
+        match self {
+            // `BMM_PROPERTY_TYPE` declares no `base_name` of its own
+            // (`org.openehr.lang.bmm3.bmm_property_type.adoc`), so it inherits
+            // `BMM_SIGNATURE`'s — the same answer as the base form.
+            Self::BmmPropertyType(_) | Self::BmmSignature(_) => BmmSignatureData::BASE_NAME,
+            Self::BmmRoutineType(routine) => match routine.as_ref() {
+                BmmRoutineType::BmmFunctionType(_) => BmmFunctionType::BASE_NAME,
+                BmmRoutineType::BmmProcedureType(_) => BmmProcedureType::BASE_NAME,
+                BmmRoutineType::BmmRoutineType(_) => BmmRoutineTypeData::BASE_NAME,
+            },
+        }
+    }
+}
+
+impl BmmStatusType {
+    /// `BMM_BUILTIN_TYPE.is_abstract` (effected): "Return False"
+    /// (`org.openehr.lang.bmm3.bmm_builtin_type.adoc` §Functions).
+    #[expect(
+        clippy::unused_self,
+        reason = "the class definition declares this as an instance function whose result is the constant False"
+    )]
+    #[must_use]
+    pub fn is_abstract(&self) -> bool {
+        false
+    }
+
+    /// `BMM_BUILTIN_TYPE.is_primitive` (effected): "Return True"
+    /// (`org.openehr.lang.bmm3.bmm_builtin_type.adoc` §Functions).
+    #[expect(
+        clippy::unused_self,
+        reason = "the class definition declares this as an instance function whose result is the constant True"
+    )]
+    #[must_use]
+    pub fn is_primitive(&self) -> bool {
+        true
+    }
+
+    /// `BMM_BUILTIN_TYPE.type_base_name` (effected): "Return `_base_name_`"
+    /// (`org.openehr.lang.bmm3.bmm_status_type.adoc` §Constants: `"Status"`).
+    #[expect(
+        clippy::unused_self,
+        reason = "a built-in meta-type's base name is its declared constant"
+    )]
+    #[must_use]
+    pub fn type_base_name(&self) -> &'static str {
+        Self::BASE_NAME
+    }
+}
+
+impl BmmTupleType {
+    /// `BMM_BUILTIN_TYPE.is_abstract` (effected): "Return False"
+    /// (`org.openehr.lang.bmm3.bmm_builtin_type.adoc` §Functions).
+    #[expect(
+        clippy::unused_self,
+        reason = "the class definition declares this as an instance function whose result is the constant False"
+    )]
+    #[must_use]
+    pub fn is_abstract(&self) -> bool {
+        false
+    }
+
+    /// `BMM_BUILTIN_TYPE.is_primitive` (effected): "Return True"
+    /// (`org.openehr.lang.bmm3.bmm_builtin_type.adoc` §Functions).
+    #[expect(
+        clippy::unused_self,
+        reason = "the class definition declares this as an instance function whose result is the constant True"
+    )]
+    #[must_use]
+    pub fn is_primitive(&self) -> bool {
+        true
+    }
+
+    /// `BMM_BUILTIN_TYPE.type_base_name` (effected): "Return `_base_name_`"
+    /// (`org.openehr.lang.bmm3.bmm_tuple_type.adoc` §Constants: `"Tuple"`).
+    #[expect(
+        clippy::unused_self,
+        reason = "a built-in meta-type's base name is its declared constant"
+    )]
+    #[must_use]
+    pub fn type_base_name(&self) -> &'static str {
+        Self::BASE_NAME
+    }
+}
+
+impl BmmContainerType {
+    /// `BMM_CONTAINER_TYPE.is_abstract` (effected): "True if the container class
+    /// is abstract", `Post_is_abstract: Result = container_type.is_abstract`
+    /// (`org.openehr.lang.bmm3.bmm_container_type.adoc` §Functions — the
+    /// post-condition's `container_type` is the attribute now spelled
+    /// `_container_class_`, same §Attributes).
+    #[must_use]
+    pub fn is_abstract(&self) -> bool {
+        BmmClass::BmmGenericClass(self.container_class().clone()).is_abstract()
+    }
+
+    /// `BMM_CONTAINER_TYPE.is_primitive` (effected): "True if `_item_type_` is
+    /// primitive", `Post_result: Result = item_type.is_primitive`
+    /// (`org.openehr.lang.bmm3.bmm_container_type.adoc` §Functions).
+    ///
+    /// NOTE (upstream contradiction, adjudicated to `Post_result`): the same
+    /// entry also carries `Post_validity: Result = base_class.is_primitive`,
+    /// naming an attribute `BMM_CONTAINER_TYPE` does not have (it has
+    /// `_container_class_` and `_item_type_`; `base_class` belongs to
+    /// `BMM_MODEL_TYPE`). `Post_result` agrees with the prose description, so it
+    /// is the implemented reading.
+    #[must_use]
+    pub fn is_primitive(&self) -> bool {
+        self.item_type().is_primitive()
+    }
+
+    /// `BMM_CONTAINER_TYPE.container_class`: "The type of the container"
+    /// (`org.openehr.lang.bmm3.bmm_container_type.adoc` §Attributes), for either
+    /// container form.
+    #[must_use]
+    pub fn container_class(&self) -> &BmmGenericClass {
+        match self {
+            Self::BmmIndexedContainerType(indexed) => &indexed.container_class,
+            Self::BmmContainerType(data) => &data.container_class,
+        }
+    }
+
+    /// `BMM_CONTAINER_TYPE.item_type`: "The container item type"
+    /// (`org.openehr.lang.bmm3.bmm_container_type.adoc` §Attributes), for either
+    /// container form.
+    #[must_use]
+    pub fn item_type(&self) -> &BmmUnitaryType {
+        match self {
+            Self::BmmIndexedContainerType(indexed) => &indexed.item_type,
+            Self::BmmContainerType(data) => data.item_type.as_ref(),
+        }
+    }
+
+    /// `BMM_CONTAINER_TYPE.unitary_type` (effected): "Return `_item_type_`"
+    /// (`org.openehr.lang.bmm3.bmm_container_type.adoc` §Functions) — the type
+    /// "with any container abstracted away"
+    /// (`…bmm3.bmm_type.adoc` §Functions).
+    #[must_use]
+    pub fn unitary_type(&self) -> BmmUnitaryType {
+        self.item_type().clone()
+    }
+
+    /// `BMM_CONTAINER_TYPE.effective_type` (effected): "Return
+    /// `_item_type.effective_type_()`"
+    /// (`org.openehr.lang.bmm3.bmm_container_type.adoc` §Functions).
+    ///
+    /// `None` carries the `'Any'` case through from
+    /// [`BmmParameterType::effective_type`] — a container of an unconstrained
+    /// formal parameter has no effective type object.
+    #[must_use]
+    pub fn effective_type(&self) -> Option<BmmEffectiveType> {
+        self.item_type().effective_type()
+    }
+}
+
+impl BmmUnitaryType {
+    /// `BMM_TYPE.is_abstract` for a unitary type
+    /// (`org.openehr.lang.bmm3.bmm_type.adoc` §Functions).
+    #[must_use]
+    pub fn is_abstract(&self) -> bool {
+        match self {
+            Self::BmmGenericType(generic) => generic.is_abstract(),
+            Self::BmmParameterType(parameter) => parameter.is_abstract(),
+            Self::BmmSignature(signature) => signature.is_abstract(),
+            Self::BmmSimpleType(simple) => simple.is_abstract(),
+            Self::BmmStatusType(status) => status.is_abstract(),
+            Self::BmmTupleType(tuple) => tuple.is_abstract(),
+        }
+    }
+
+    /// `BMM_TYPE.is_primitive` for a unitary type: "If True, indicates that a
+    /// type based solely on primitive classes"
+    /// (`org.openehr.lang.bmm3.bmm_type.adoc` §Functions).
+    #[must_use]
+    pub fn is_primitive(&self) -> bool {
+        match self {
+            Self::BmmGenericType(generic) => generic.is_primitive(),
+            Self::BmmParameterType(parameter) => parameter.is_primitive(),
+            Self::BmmSignature(signature) => signature.is_primitive(),
+            Self::BmmSimpleType(simple) => simple.is_primitive(),
+            Self::BmmStatusType(status) => status.is_primitive(),
+            Self::BmmTupleType(tuple) => tuple.is_primitive(),
+        }
+    }
+
+    /// `BMM_UNITARY_TYPE.unitary_type` (effected): "Result = self"
+    /// (`org.openehr.lang.bmm3.bmm_unitary_type.adoc` §Functions).
+    #[must_use]
+    pub fn unitary_type(&self) -> Self {
+        self.clone()
+    }
+
+    /// `BMM_TYPE.effective_type`: "Type with any container abstracted away, and
+    /// any formal parameter replaced by its effective constraint type"
+    /// (`org.openehr.lang.bmm3.bmm_type.adoc` §Functions). For an effective type
+    /// this is the identity ("Result = self",
+    /// `…bmm3.bmm_effective_type.adoc` §Functions); for a formal parameter it is
+    /// the parameter's constraint ([`BmmParameterType::effective_type`], whose
+    /// `None` = the `'Any'` top).
+    #[must_use]
+    pub fn effective_type(&self) -> Option<BmmEffectiveType> {
+        match self {
+            Self::BmmGenericType(generic) => {
+                Some(BmmEffectiveType::BmmGenericType(generic.clone()))
+            }
+            Self::BmmParameterType(parameter) => parameter.effective_type(),
+            Self::BmmSignature(signature) => {
+                Some(BmmEffectiveType::BmmSignature(signature.clone()))
+            }
+            Self::BmmSimpleType(simple) => Some(BmmEffectiveType::BmmSimpleType(simple.clone())),
+            Self::BmmStatusType(status) => Some(BmmEffectiveType::BmmStatusType(status.clone())),
+            Self::BmmTupleType(tuple) => Some(BmmEffectiveType::BmmTupleType(tuple.clone())),
+        }
+    }
+}
+
+impl BmmEffectiveType {
+    /// `BMM_EFFECTIVE_TYPE.type_base_name` (abstract): "Name of base generator
+    /// type, i.e. excluding any generic parts if present"
+    /// (`org.openehr.lang.bmm3.bmm_effective_type.adoc` §Functions), effected by
+    /// `BMM_MODEL_TYPE` ("`_base_class.name_`") and `BMM_BUILTIN_TYPE`
+    /// ("`_base_name_`").
+    #[must_use]
+    pub fn type_base_name(&self) -> &str {
+        match self {
+            Self::BmmGenericType(generic) => generic.type_base_name(),
+            Self::BmmSignature(signature) => signature.type_base_name(),
+            Self::BmmSimpleType(simple) => simple.type_base_name(),
+            Self::BmmStatusType(status) => status.type_base_name(),
+            Self::BmmTupleType(tuple) => tuple.type_base_name(),
+        }
+    }
+
+    /// `BMM_TYPE.is_abstract` for an effective type
+    /// (`org.openehr.lang.bmm3.bmm_type.adoc` §Functions).
+    #[must_use]
+    pub fn is_abstract(&self) -> bool {
+        match self {
+            Self::BmmGenericType(generic) => generic.is_abstract(),
+            Self::BmmSignature(signature) => signature.is_abstract(),
+            Self::BmmSimpleType(simple) => simple.is_abstract(),
+            Self::BmmStatusType(status) => status.is_abstract(),
+            Self::BmmTupleType(tuple) => tuple.is_abstract(),
+        }
+    }
+
+    /// `BMM_TYPE.is_primitive` for an effective type
+    /// (`org.openehr.lang.bmm3.bmm_type.adoc` §Functions).
+    #[must_use]
+    pub fn is_primitive(&self) -> bool {
+        match self {
+            Self::BmmGenericType(generic) => generic.is_primitive(),
+            Self::BmmSignature(signature) => signature.is_primitive(),
+            Self::BmmSimpleType(simple) => simple.is_primitive(),
+            Self::BmmStatusType(status) => status.is_primitive(),
+            Self::BmmTupleType(tuple) => tuple.is_primitive(),
+        }
+    }
+
+    /// `BMM_EFFECTIVE_TYPE.effective_type` (effected): "Result = self"
+    /// (`org.openehr.lang.bmm3.bmm_effective_type.adoc` §Functions).
+    #[must_use]
+    pub fn effective_type(&self) -> Self {
+        self.clone()
+    }
+}
+
+impl BmmType {
+    /// `BMM_TYPE.is_abstract` (abstract): "If true, indicates a type based on an
+    /// abstract class, i.e. a type that cannot be directly instantiated"
+    /// (`org.openehr.lang.bmm3.bmm_type.adoc` §Functions).
+    #[must_use]
+    pub fn is_abstract(&self) -> bool {
+        match self {
+            Self::BmmContainerType(container) => container.is_abstract(),
+            Self::BmmGenericType(generic) => generic.is_abstract(),
+            Self::BmmParameterType(parameter) => parameter.is_abstract(),
+            Self::BmmSignature(signature) => signature.is_abstract(),
+            Self::BmmSimpleType(simple) => simple.is_abstract(),
+            Self::BmmStatusType(status) => status.is_abstract(),
+            Self::BmmTupleType(tuple) => tuple.is_abstract(),
+        }
+    }
+
+    /// `BMM_TYPE.is_primitive` (abstract): "If True, indicates that a type based
+    /// solely on primitive classes" (`org.openehr.lang.bmm3.bmm_type.adoc`
+    /// §Functions).
+    #[must_use]
+    pub fn is_primitive(&self) -> bool {
+        match self {
+            Self::BmmContainerType(container) => container.is_primitive(),
+            Self::BmmGenericType(generic) => generic.is_primitive(),
+            Self::BmmParameterType(parameter) => parameter.is_primitive(),
+            Self::BmmSignature(signature) => signature.is_primitive(),
+            Self::BmmSimpleType(simple) => simple.is_primitive(),
+            Self::BmmStatusType(status) => status.is_primitive(),
+            Self::BmmTupleType(tuple) => tuple.is_primitive(),
+        }
+    }
+
+    /// `BMM_TYPE.unitary_type` (abstract): "Type with any container abstracted
+    /// away; may be a formal generic type"
+    /// (`org.openehr.lang.bmm3.bmm_type.adoc` §Functions) — `_item_type_` for a
+    /// container (`…bmm3.bmm_container_type.adoc` §Functions), self for every
+    /// unitary meta-type (`…bmm3.bmm_unitary_type.adoc` §Functions).
+    #[must_use]
+    pub fn unitary_type(&self) -> BmmUnitaryType {
+        match self {
+            Self::BmmContainerType(container) => container.unitary_type(),
+            Self::BmmGenericType(generic) => BmmUnitaryType::BmmGenericType(generic.clone()),
+            Self::BmmParameterType(parameter) => {
+                BmmUnitaryType::BmmParameterType(parameter.clone())
+            }
+            Self::BmmSignature(signature) => BmmUnitaryType::BmmSignature(signature.clone()),
+            Self::BmmSimpleType(simple) => BmmUnitaryType::BmmSimpleType(simple.clone()),
+            Self::BmmStatusType(status) => BmmUnitaryType::BmmStatusType(status.clone()),
+            Self::BmmTupleType(tuple) => BmmUnitaryType::BmmTupleType(tuple.clone()),
+        }
+    }
+
+    /// `BMM_TYPE.effective_type` (abstract): "Type with any container abstracted
+    /// away, and any formal parameter replaced by its effective constraint type"
+    /// (`org.openehr.lang.bmm3.bmm_type.adoc` §Functions).
+    ///
+    /// `None` is the `'Any'` case of an unconstrained formal parameter — see
+    /// [`BmmParameterType::effective_type`].
+    #[must_use]
+    pub fn effective_type(&self) -> Option<BmmEffectiveType> {
+        self.unitary_type().effective_type()
     }
 }

--- a/crates/openehr-lang/src/bmm3/core/entity/mod.rs
+++ b/crates/openehr-lang/src/bmm3/core/entity/mod.rs
@@ -27,4 +27,5 @@ pub mod bmm_unitary_type;
 pub mod range_constrained;
 
 // hand-written modules (spec behaviour), auto-declared:
+pub mod bmm_class_impl;
 pub mod bmm_type_impl;

--- a/crates/openehr-lang/src/bmm3/core/feature/bmm_feature_impl.rs
+++ b/crates/openehr-lang/src/bmm3/core/feature/bmm_feature_impl.rs
@@ -1,0 +1,462 @@
+//! Hand-written spec functions of the BMM **v3** class-feature family
+//! (`BMM_FORMAL_ELEMENT` / `BMM_FEATURE` / `BMM_ROUTINE` and their leaves) — and
+//! the home of that family's invariant boundary.
+//!
+//! Spec: `LANG/docs/bmm3/master08-core-features.adoc` plus the class definitions
+//! under `LANG/docs/UML/classes/`: `org.openehr.lang.bmm3.bmm_formal_element.adoc`
+//! §Functions (`signature`, `is_boolean`), `…bmm3.bmm_routine.adoc` §Functions
+//! (`arity`), `…bmm3.bmm_function.adoc`, `…bmm3.bmm_procedure.adoc`,
+//! `…bmm3.bmm_property.adoc`, `…bmm3.bmm_constant.adoc`, all §Functions and
+//! §Invariants.
+//!
+//! NOTE (adjudicated boundary — the declared feature INVARIANTS are not
+//! enforced): `BMM_FUNCTION.Operator_validity` ("`operator_def /= Void implies
+//! arity in |1..2|`"), `BMM_FUNCTION.Inv_signature_has_result`,
+//! `BMM_FUNCTION.Inv_result_type` ("`type = Result.type`"),
+//! `BMM_PROCEDURE.Inv_signature_no_result`, `BMM_PROPERTY.Inv_signature_no_args`
+//! and `BMM_CONSTANT.Inv_not_nullable` are class-definition invariants of a
+//! meta-model this workspace only ever CONSTRUCTS from a vendored schema, never
+//! edits: the v3 generation has no materialisation source that could produce a
+//! violating instance (P_BMM is the v2.x persistence form,
+//! `LANG/docs/bmm/master06-persistence.adoc`, and its routine/constant
+//! attributes are opaque strings), and openEHR publishes no validation-report
+//! shape for a BMM model. Enforcement would therefore be a check with no input
+//! and no consumer. The functions the invariants are written against
+//! ([`crate::bmm3::core::feature::bmm_feature_impl`]'s `signature`, `arity`) ARE
+//! implemented here, so an invariant pass becomes ordinary work the day a v3
+//! model is built from an editable source.
+
+use crate::bmm3::core::bmm_formal_element::BmmFormalElement;
+use crate::bmm3::core::entity::bmm_container_type::BmmContainerType;
+use crate::bmm3::core::entity::bmm_function_type::BmmFunctionType;
+use crate::bmm3::core::entity::bmm_procedure_type::BmmProcedureType;
+use crate::bmm3::core::entity::bmm_property_type::BmmPropertyType;
+use crate::bmm3::core::entity::bmm_routine_type::BmmRoutineType;
+use crate::bmm3::core::entity::bmm_signature::BmmSignature;
+use crate::bmm3::core::entity::bmm_tuple_type::BmmTupleType;
+use crate::bmm3::core::entity::bmm_type::BmmType;
+use crate::bmm3::core::feature::bmm_constant::BmmConstant;
+use crate::bmm3::core::feature::bmm_container_property::BmmContainerProperty;
+use crate::bmm3::core::feature::bmm_feature::BmmFeature;
+use crate::bmm3::core::feature::bmm_function::BmmFunction;
+use crate::bmm3::core::feature::bmm_parameter::BmmParameter;
+use crate::bmm3::core::feature::bmm_procedure::BmmProcedure;
+use crate::bmm3::core::feature::bmm_property::BmmProperty;
+use crate::bmm3::core::feature::bmm_routine::BmmRoutine;
+use crate::bmm3::core::feature::bmm_singleton::BmmSingleton;
+use crate::bmm3::core::feature::bmm_unitary_property::BmmUnitaryProperty;
+
+/// The type name a notionally-Boolean element's type carries
+/// (`org.openehr.lang.bmm3.bmm_formal_element.adoc` §Functions `is_boolean`:
+/// "a `BMM_SIMPLE_TYPE` with `_type_name()_` = `'Boolean'`").
+pub const BOOLEAN_TYPE_NAME: &str = "Boolean";
+
+/// The `_argument_types_` tuple of a routine signature: each parameter's type,
+/// keyed by the parameter name — "represented as a type-tuple (list of arbitrary
+/// types)" whose items are "keyed by purpose in the tuple"
+/// (`org.openehr.lang.bmm3.bmm_routine_type.adoc` §Attributes,
+/// `…bmm3.bmm_tuple_type.adoc` §Attributes). `None` for a routine with no
+/// parameters, since `_argument_types_` is `0..1` ("Type of arguments in the
+/// signature, **if any**").
+fn argument_types(parameters: &[BmmParameter]) -> Option<BmmTupleType> {
+    if parameters.is_empty() {
+        return None;
+    }
+    Some(BmmTupleType {
+        item_types: parameters
+            .iter()
+            .map(|p| (p.name.clone(), p.r#type.clone()))
+            .collect(),
+    })
+}
+
+/// Is `t` the notionally-Boolean type — "a `BMM_SIMPLE_TYPE` with
+/// `_type_name()_` = `'Boolean'`" (`…bmm3.bmm_formal_element.adoc` §Functions)?
+///
+/// The name comparison is case-insensitive per the BMM naming convention
+/// ("it is assumed that case-insensitive matching is used",
+/// `LANG/docs/bmm3/master05-core-model.adoc` §Naming Convention).
+fn type_is_boolean(t: &BmmType) -> bool {
+    matches!(t, BmmType::BmmSimpleType(simple)
+        if simple.type_name().eq_ignore_ascii_case(BOOLEAN_TYPE_NAME))
+}
+
+impl BmmContainerProperty {
+    /// `BMM_CONTAINER_PROPERTY.type` (redefined): the container type of this
+    /// property (`org.openehr.lang.bmm3.bmm_container_property.adoc` §Attributes),
+    /// for either container-property form.
+    #[must_use]
+    pub fn r#type(&self) -> BmmContainerType {
+        match self {
+            Self::BmmIndexedContainerProperty(indexed) => {
+                BmmContainerType::BmmIndexedContainerType(Box::new(indexed.r#type.clone()))
+            }
+            Self::BmmContainerProperty(data) => data.r#type.clone(),
+        }
+    }
+
+    /// `BMM_MODEL_ELEMENT.name`: "Name of this model element"
+    /// (`org.openehr.lang.bmm3.bmm_model_element.adoc` §Attributes).
+    #[must_use]
+    pub fn name(&self) -> &str {
+        match self {
+            Self::BmmIndexedContainerProperty(indexed) => indexed.name.as_str(),
+            Self::BmmContainerProperty(data) => data.name.as_str(),
+        }
+    }
+}
+
+impl BmmProperty {
+    /// `BMM_MODEL_ELEMENT.name`: "Name of this model element"
+    /// (`org.openehr.lang.bmm3.bmm_model_element.adoc` §Attributes).
+    #[must_use]
+    pub fn name(&self) -> &str {
+        match self {
+            Self::BmmContainerProperty(property) => property.name(),
+            Self::BmmUnitaryProperty(property) => property.name.as_str(),
+        }
+    }
+}
+
+impl BmmFeature {
+    /// `BMM_MODEL_ELEMENT.name`: "Name of this model element"
+    /// (`org.openehr.lang.bmm3.bmm_model_element.adoc` §Attributes) — the key
+    /// every feature map of `BMM_CLASS` is keyed by (`…bmm3.bmm_class.adoc`
+    /// §Attributes).
+    #[must_use]
+    pub fn name(&self) -> &str {
+        match self {
+            Self::BmmConstant(constant) => constant.name.as_str(),
+            Self::BmmContainerProperty(property) => property.name(),
+            Self::BmmFunction(function) => function.name.as_str(),
+            Self::BmmProcedure(procedure) => procedure.name.as_str(),
+            Self::BmmSingleton(singleton) => singleton.name.as_str(),
+            Self::BmmUnitaryProperty(property) => property.name.as_str(),
+        }
+    }
+}
+
+impl BmmFunction {
+    /// `BMM_ROUTINE.arity`: "Return number of arguments of this routine"
+    /// (`org.openehr.lang.bmm3.bmm_routine.adoc` §Functions).
+    #[must_use]
+    pub fn arity(&self) -> i32 {
+        i32::try_from(self.parameters.len()).unwrap_or(i32::MAX)
+    }
+
+    /// `BMM_FORMAL_ELEMENT.signature` as effected for a function: the
+    /// `BMM_FUNCTION_TYPE` of its parameters and result
+    /// (`org.openehr.lang.bmm3.bmm_function_type.adoc` §Description "Meta-type
+    /// for function object signatures"; `…bmm3.bmm_formal_element.adoc`
+    /// §Functions "Formal signature of this element, in the form: `name
+    /// [arg1_name: T_arg1, ...][:T_value]`").
+    ///
+    /// The result type is the function's own `_type_`, which
+    /// `BMM_FUNCTION.Inv_result_type` states equals `Result.type`
+    /// (`…bmm3.bmm_function.adoc` §Invariants).
+    #[must_use]
+    pub fn signature(&self) -> BmmFunctionType {
+        BmmFunctionType {
+            result_type: self.r#type.clone(),
+            argument_types: argument_types(&self.parameters),
+        }
+    }
+
+    /// `BMM_FORMAL_ELEMENT.is_boolean`: "True if `_type_` is notionally Boolean"
+    /// (`org.openehr.lang.bmm3.bmm_formal_element.adoc` §Functions).
+    #[must_use]
+    pub fn is_boolean(&self) -> bool {
+        type_is_boolean(&self.r#type)
+    }
+}
+
+impl BmmProcedure {
+    /// `BMM_ROUTINE.arity`: "Return number of arguments of this routine"
+    /// (`org.openehr.lang.bmm3.bmm_routine.adoc` §Functions).
+    #[must_use]
+    pub fn arity(&self) -> i32 {
+        i32::try_from(self.parameters.len()).unwrap_or(i32::MAX)
+    }
+
+    /// `BMM_PROCEDURE.signature` (effected): the `BMM_PROCEDURE_TYPE` whose
+    /// `_result_type_` is the built-in Status type
+    /// (`org.openehr.lang.bmm3.bmm_procedure.adoc` §Functions + §Attributes —
+    /// `type` is redefined to `BMM_STATUS_TYPE`;
+    /// `…bmm3.bmm_procedure_type.adoc` §Description "with `_result_type_` being
+    /// the special Status meta-type").
+    #[must_use]
+    pub fn signature(&self) -> BmmProcedureType {
+        BmmProcedureType {
+            result_type: Some(self.r#type.clone()),
+            argument_types: argument_types(&self.parameters),
+        }
+    }
+
+    /// `BMM_FORMAL_ELEMENT.is_boolean` — always false for a procedure, whose
+    /// `_type_` is the Status meta-type, not a `BMM_SIMPLE_TYPE`
+    /// (`org.openehr.lang.bmm3.bmm_procedure.adoc` §Attributes).
+    #[expect(
+        clippy::unused_self,
+        reason = "the class definitions declare is_boolean() on BMM_FORMAL_ELEMENT; for a procedure the redefined `type` makes the answer constant"
+    )]
+    #[must_use]
+    pub fn is_boolean(&self) -> bool {
+        false
+    }
+}
+
+impl BmmRoutine {
+    /// `BMM_ROUTINE.arity`: "Return number of arguments of this routine"
+    /// (`org.openehr.lang.bmm3.bmm_routine.adoc` §Functions).
+    #[must_use]
+    pub fn arity(&self) -> i32 {
+        match self {
+            Self::BmmFunction(function) => function.arity(),
+            Self::BmmProcedure(procedure) => procedure.arity(),
+        }
+    }
+
+    /// `BMM_FORMAL_ELEMENT.signature` for either routine kind, as the
+    /// `BMM_ROUTINE_TYPE` slot both effected forms belong to
+    /// (`org.openehr.lang.bmm3.bmm_routine_type.adoc`).
+    #[must_use]
+    pub fn signature(&self) -> BmmRoutineType {
+        match self {
+            Self::BmmFunction(function) => BmmRoutineType::BmmFunctionType(function.signature()),
+            Self::BmmProcedure(procedure) => {
+                BmmRoutineType::BmmProcedureType(procedure.signature())
+            }
+        }
+    }
+
+    /// `BMM_FORMAL_ELEMENT.is_boolean`
+    /// (`org.openehr.lang.bmm3.bmm_formal_element.adoc` §Functions).
+    #[must_use]
+    pub fn is_boolean(&self) -> bool {
+        match self {
+            Self::BmmFunction(function) => function.is_boolean(),
+            Self::BmmProcedure(procedure) => procedure.is_boolean(),
+        }
+    }
+}
+
+impl BmmUnitaryProperty {
+    /// `BMM_FORMAL_ELEMENT.signature` for a property: a `BMM_PROPERTY_TYPE`
+    /// carrying only the result type — "Meta-type for property and variable
+    /// signatures" (`org.openehr.lang.bmm3.bmm_property_type.adoc`
+    /// §Description), which is the degree-zero signature
+    /// `BMM_PROPERTY.Inv_signature_no_args` states
+    /// (`…bmm3.bmm_property.adoc` §Invariants).
+    #[must_use]
+    pub fn signature(&self) -> BmmPropertyType {
+        BmmPropertyType {
+            result_type: BmmType::from(self.r#type.clone()),
+        }
+    }
+
+    /// `BMM_FORMAL_ELEMENT.is_boolean`
+    /// (`org.openehr.lang.bmm3.bmm_formal_element.adoc` §Functions).
+    #[must_use]
+    pub fn is_boolean(&self) -> bool {
+        type_is_boolean(&BmmType::from(self.r#type.clone()))
+    }
+}
+
+impl BmmContainerProperty {
+    /// `BMM_FORMAL_ELEMENT.signature` for a container property: the
+    /// `BMM_PROPERTY_TYPE` whose result type is the container type itself
+    /// (`org.openehr.lang.bmm3.bmm_container_property.adoc` §Attributes redefines
+    /// `type` to `BMM_CONTAINER_TYPE`; `…bmm3.bmm_property_type.adoc`
+    /// §Description).
+    #[must_use]
+    pub fn signature(&self) -> BmmPropertyType {
+        BmmPropertyType {
+            result_type: BmmType::BmmContainerType(Box::new(self.r#type())),
+        }
+    }
+
+    /// `BMM_FORMAL_ELEMENT.is_boolean` — always false for a container property:
+    /// its `_type_` is a `BMM_CONTAINER_TYPE`, never a `BMM_SIMPLE_TYPE`
+    /// (`org.openehr.lang.bmm3.bmm_container_property.adoc` §Attributes).
+    #[expect(
+        clippy::unused_self,
+        reason = "the class definitions declare is_boolean() on BMM_FORMAL_ELEMENT; for a container property the redefined `type` makes the answer constant"
+    )]
+    #[must_use]
+    pub fn is_boolean(&self) -> bool {
+        false
+    }
+}
+
+impl BmmProperty {
+    /// `BMM_FORMAL_ELEMENT.signature` for either property kind
+    /// (`org.openehr.lang.bmm3.bmm_property_type.adoc`).
+    #[must_use]
+    pub fn signature(&self) -> BmmPropertyType {
+        match self {
+            Self::BmmContainerProperty(property) => property.signature(),
+            Self::BmmUnitaryProperty(property) => property.signature(),
+        }
+    }
+
+    /// `BMM_FORMAL_ELEMENT.is_boolean`
+    /// (`org.openehr.lang.bmm3.bmm_formal_element.adoc` §Functions).
+    #[must_use]
+    pub fn is_boolean(&self) -> bool {
+        match self {
+            Self::BmmContainerProperty(property) => property.is_boolean(),
+            Self::BmmUnitaryProperty(property) => property.is_boolean(),
+        }
+    }
+}
+
+impl BmmConstant {
+    /// `BMM_FORMAL_ELEMENT.signature` for a constant — the argument-less
+    /// `BMM_PROPERTY_TYPE` of its type
+    /// (`org.openehr.lang.bmm3.bmm_property_type.adoc` §Description "Meta-type
+    /// for property and variable signatures").
+    #[must_use]
+    pub fn signature(&self) -> BmmPropertyType {
+        BmmPropertyType {
+            result_type: self.r#type.clone(),
+        }
+    }
+
+    /// `BMM_FORMAL_ELEMENT.is_boolean`
+    /// (`org.openehr.lang.bmm3.bmm_formal_element.adoc` §Functions).
+    #[must_use]
+    pub fn is_boolean(&self) -> bool {
+        type_is_boolean(&self.r#type)
+    }
+}
+
+impl BmmSingleton {
+    /// `BMM_FORMAL_ELEMENT.signature` for a singleton — the argument-less
+    /// `BMM_PROPERTY_TYPE` of its type
+    /// (`org.openehr.lang.bmm3.bmm_property_type.adoc` §Description).
+    #[must_use]
+    pub fn signature(&self) -> BmmPropertyType {
+        BmmPropertyType {
+            result_type: self.r#type.clone(),
+        }
+    }
+
+    /// `BMM_FORMAL_ELEMENT.is_boolean`
+    /// (`org.openehr.lang.bmm3.bmm_formal_element.adoc` §Functions).
+    #[must_use]
+    pub fn is_boolean(&self) -> bool {
+        type_is_boolean(&self.r#type)
+    }
+}
+
+impl BmmFormalElement {
+    /// `BMM_FORMAL_ELEMENT.signature` (abstract, "Specific implementations in
+    /// descendants" — `org.openehr.lang.bmm3.bmm_formal_element.adoc`
+    /// §Functions), dispatched to the effected form of each leaf.
+    #[must_use]
+    pub fn signature(&self) -> BmmSignature {
+        match self {
+            Self::BmmConstant(constant) => {
+                BmmSignature::BmmPropertyType(Box::new(constant.signature()))
+            }
+            Self::BmmContainerProperty(property) => {
+                BmmSignature::BmmPropertyType(Box::new(property.signature()))
+            }
+            Self::BmmFunction(function) => BmmSignature::BmmRoutineType(Box::new(
+                BmmRoutineType::BmmFunctionType(function.signature()),
+            )),
+            Self::BmmProcedure(procedure) => BmmSignature::BmmRoutineType(Box::new(
+                BmmRoutineType::BmmProcedureType(procedure.signature()),
+            )),
+            Self::BmmSingleton(singleton) => {
+                BmmSignature::BmmPropertyType(Box::new(singleton.signature()))
+            }
+            Self::BmmUnitaryProperty(property) => {
+                BmmSignature::BmmPropertyType(Box::new(property.signature()))
+            }
+            // The four variable leaves (`BMM_LOCAL`, `BMM_PARAMETER`,
+            // `BMM_RESULT`, `BMM_SELF`) are `BMM_VARIABLE`s, i.e. formal
+            // elements with no arguments, so their signature is the same
+            // argument-less `BMM_PROPERTY_TYPE` — "Meta-type for property and
+            // variable signatures" (`…bmm3.bmm_property_type.adoc`
+            // §Description).
+            Self::BmmLocal(local) => BmmSignature::BmmPropertyType(Box::new(BmmPropertyType {
+                result_type: local.r#type.clone(),
+            })),
+            Self::BmmParameter(parameter) => {
+                BmmSignature::BmmPropertyType(Box::new(BmmPropertyType {
+                    result_type: parameter.r#type.clone(),
+                }))
+            }
+            Self::BmmResult(result) => BmmSignature::BmmPropertyType(Box::new(BmmPropertyType {
+                result_type: result.r#type.clone(),
+            })),
+            Self::BmmSelf(self_variable) => {
+                BmmSignature::BmmPropertyType(Box::new(BmmPropertyType {
+                    result_type: self_variable.r#type.clone(),
+                }))
+            }
+        }
+    }
+
+    /// `BMM_FORMAL_ELEMENT.is_boolean`: "True if `_type_` is notionally Boolean
+    /// (i.e. a `BMM_SIMPLE_TYPE` with `_type_name()_` = `'Boolean'`)"
+    /// (`org.openehr.lang.bmm3.bmm_formal_element.adoc` §Functions).
+    #[must_use]
+    pub fn is_boolean(&self) -> bool {
+        match self {
+            Self::BmmConstant(constant) => constant.is_boolean(),
+            Self::BmmContainerProperty(property) => property.is_boolean(),
+            Self::BmmFunction(function) => function.is_boolean(),
+            Self::BmmProcedure(procedure) => procedure.is_boolean(),
+            Self::BmmSingleton(singleton) => singleton.is_boolean(),
+            Self::BmmUnitaryProperty(property) => property.is_boolean(),
+            Self::BmmLocal(local) => type_is_boolean(&local.r#type),
+            Self::BmmParameter(parameter) => type_is_boolean(&parameter.r#type),
+            Self::BmmResult(result) => type_is_boolean(&result.r#type),
+            Self::BmmSelf(self_variable) => type_is_boolean(&self_variable.r#type),
+        }
+    }
+}
+
+impl BmmFeature {
+    /// `BMM_FORMAL_ELEMENT.signature` for any feature of a class
+    /// (`org.openehr.lang.bmm3.bmm_formal_element.adoc` §Functions).
+    #[must_use]
+    pub fn signature(&self) -> BmmSignature {
+        match self {
+            Self::BmmConstant(constant) => {
+                BmmSignature::BmmPropertyType(Box::new(constant.signature()))
+            }
+            Self::BmmContainerProperty(property) => {
+                BmmSignature::BmmPropertyType(Box::new(property.signature()))
+            }
+            Self::BmmFunction(function) => BmmSignature::BmmRoutineType(Box::new(
+                BmmRoutineType::BmmFunctionType(function.signature()),
+            )),
+            Self::BmmProcedure(procedure) => BmmSignature::BmmRoutineType(Box::new(
+                BmmRoutineType::BmmProcedureType(procedure.signature()),
+            )),
+            Self::BmmSingleton(singleton) => {
+                BmmSignature::BmmPropertyType(Box::new(singleton.signature()))
+            }
+            Self::BmmUnitaryProperty(property) => {
+                BmmSignature::BmmPropertyType(Box::new(property.signature()))
+            }
+        }
+    }
+
+    /// `BMM_FORMAL_ELEMENT.is_boolean`
+    /// (`org.openehr.lang.bmm3.bmm_formal_element.adoc` §Functions).
+    #[must_use]
+    pub fn is_boolean(&self) -> bool {
+        match self {
+            Self::BmmConstant(constant) => constant.is_boolean(),
+            Self::BmmContainerProperty(property) => property.is_boolean(),
+            Self::BmmFunction(function) => function.is_boolean(),
+            Self::BmmProcedure(procedure) => procedure.is_boolean(),
+            Self::BmmSingleton(singleton) => singleton.is_boolean(),
+            Self::BmmUnitaryProperty(property) => property.is_boolean(),
+        }
+    }
+}

--- a/crates/openehr-lang/src/bmm3/core/feature/mod.rs
+++ b/crates/openehr-lang/src/bmm3/core/feature/mod.rs
@@ -30,3 +30,6 @@ pub mod bmm_unitary_property;
 pub mod bmm_variable;
 pub mod bmm_visibility;
 pub mod bmm_writable_variable;
+
+// hand-written modules (spec behaviour), auto-declared:
+pub mod bmm_feature_impl;

--- a/crates/openehr-lang/src/bmm3/core/literal_value/bmm_container_value.rs
+++ b/crates/openehr-lang/src/bmm3/core/literal_value/bmm_container_value.rs
@@ -4,6 +4,8 @@
 //! The openEHR `BMM_CONTAINER_VALUE` spec class, generated from the vendored BMM
 //! meta-model.
 
+use crate::bmm3::core::entity::bmm_container_type::BmmContainerType;
+
 /// Meta-type for literals whose concrete type is a linear container type, i.e. array, list or set.
 #[doc(alias = "BMM_CONTAINER_VALUE")]
 #[derive(Debug, Clone, PartialEq)]
@@ -16,5 +18,5 @@ pub struct BmmContainerValue {
     /// Optional specification of formalism of the `_value_literal_` attribute for complex values. Value may be any of `json | json5 | yawl | xml | odin | rdf` or another value agreed by the user community. If not set, `json` is assumed.
     pub syntax: Option<String>,
     /// Concrete type of this literal.
-    pub r#type: serde_json::Value,
+    pub r#type: BmmContainerType,
 }

--- a/crates/openehr-lang/src/bmm3/core/literal_value/bmm_indexed_container_value.rs
+++ b/crates/openehr-lang/src/bmm3/core/literal_value/bmm_indexed_container_value.rs
@@ -4,6 +4,8 @@
 //! The openEHR `BMM_INDEXED_CONTAINER_VALUE` spec class, generated from the vendored BMM
 //! meta-model.
 
+use crate::bmm3::core::entity::bmm_indexed_container_type::BmmIndexedContainerType;
+
 /// Meta-type for literals whose concrete type is an indexed container, i.e. Hash table, Map etc.
 #[doc(alias = "BMM_INDEXED_CONTAINER_VALUE")]
 #[derive(Debug, Clone, PartialEq)]
@@ -16,5 +18,5 @@ pub struct BmmIndexedContainerValue {
     /// Optional specification of formalism of the `_value_literal_` attribute for complex values. Value may be any of `json | json5 | yawl | xml | odin | rdf` or another value agreed by the user community. If not set, `json` is assumed.
     pub syntax: Option<String>,
     /// Concrete type of this literal.
-    pub r#type: serde_json::Value,
+    pub r#type: BmmIndexedContainerType,
 }

--- a/crates/openehr-lang/src/bmm3/core/literal_value/bmm_interval_value.rs
+++ b/crates/openehr-lang/src/bmm3/core/literal_value/bmm_interval_value.rs
@@ -16,5 +16,6 @@ pub struct BmmIntervalValue {
     /// Optional specification of formalism of the `_value_literal_` attribute for complex values. Value may be any of `json | json5 | yawl | xml | odin | rdf` or another value agreed by the user community. If not set, `json` is assumed.
     pub syntax: Option<String>,
     /// Concrete type of this literal.
+    // NOTE: free-form JSON is adjudicated here, not accidental — LANG bmm3 master09-core-values.adoc §Container Literals narrows the container literals only; `…bmm3.bmm_interval_value.adoc` declares no attributes at all, so `BMM_LITERAL_VALUE<T>.type` stays open — no openEHR spec text narrows T for an interval literal. Spec silence: unlike BMM_CONTAINER_VALUE/BMM_INDEXED_CONTAINER_VALUE, no chapter or class definition states the interval literal's concrete type meta-class, so binding T here would be a guess.
     pub r#type: serde_json::Value,
 }

--- a/crates/openehr-lang/src/bmm3/core/literal_value/bmm_literal_value_impl.rs
+++ b/crates/openehr-lang/src/bmm3/core/literal_value/bmm_literal_value_impl.rs
@@ -1,0 +1,91 @@
+//! Hand-written surface of the BMM **v3** literal-value package — and the home
+//! of its evaluation boundary.
+//!
+//! Spec: `LANG/docs/bmm3/master09-core-values.adoc` (§General Model, §Container
+//! Literals) plus the class definitions
+//! `org.openehr.lang.bmm3.bmm_literal_value.adoc`,
+//! `…bmm3.bmm_primitive_value.adoc`, `…bmm3.bmm_container_value.adoc`,
+//! `…bmm3.bmm_indexed_container_value.adoc`, `…bmm3.bmm_interval_value.adoc`.
+//!
+//! NOTE (adjudicated boundary — nothing in this workspace EVALUATES a BMM
+//! literal): the package's nine classes are the meta-types of literal values
+//! declared inside a BMM model ("constant values (e.g. `Real Pi = 3.1415926`),
+//! default values …", §General Model). No component consumes them: `openehr-lang`
+//! materialises models from P_BMM, whose persistence form carries constant values
+//! as opaque strings (`P_BMM_CONSTANT`,
+//! `LANG/docs/bmm_persistence/master04-syntax.adoc`), and no other crate
+//! interprets a BMM model at runtime. The classes therefore exist as the complete
+//! emitted model (the emitter never trims) with data accessors only, which is an
+//! honest maturity boundary rather than a gap in the model.
+//!
+//! What that boundary defers is exactly one behaviour, named here so a future
+//! evaluator does not have to re-derive it:
+//!
+//! TODO: implement the `_value_literal_` → `_value_` deserialisation. §General
+//! Model states that `_value_literal_` "is assumed to carry a serialised form of
+//! the value expressed in a syntax known to the model processing environment",
+//! and `…bmm3.bmm_literal_value.adoc` §Attributes describes `value` as "A native
+//! representation of the value, possibly derived by deserialising
+//! `_value_literal_`" — i.e. the two fields are related by a parse this crate
+//! does not perform, so a literal read from a schema populates only
+//! `_value_literal_`. The formalism to parse it in is already resolved by
+//! [`BmmLiteralValue::syntax`] (which applies the `json` default), and the
+//! stringified form the enumeration name map needs is
+//! [`BmmLiteralValue::value_literal`] — the parse itself is the missing half.
+
+use crate::bmm3::core::literal_value::bmm_literal_value::BmmLiteralValue;
+use crate::bmm3::core::literal_value::bmm_primitive_value::BmmPrimitiveValue;
+
+/// The formalism assumed for a literal's `_value_literal_` when `_syntax_` is
+/// not set: "If not set, `json` is assumed"
+/// (`org.openehr.lang.bmm3.bmm_literal_value.adoc` §Attributes).
+pub const DEFAULT_SYNTAX: &str = "json";
+
+impl BmmPrimitiveValue {
+    /// `BMM_LITERAL_VALUE.value_literal`: "A serial representation of the value"
+    /// (`org.openehr.lang.bmm3.bmm_literal_value.adoc` §Attributes), for any
+    /// primitive-literal leaf.
+    #[must_use]
+    pub fn value_literal(&self) -> &str {
+        match self {
+            Self::BmmBooleanValue(v) => v.value_literal.as_str(),
+            Self::BmmIntegerValue(v) => v.value_literal.as_str(),
+            Self::BmmStringValue(v) => v.value_literal.as_str(),
+            Self::BmmPrimitiveValue(v) => v.value_literal.as_str(),
+        }
+    }
+}
+
+impl BmmLiteralValue {
+    /// `BMM_LITERAL_VALUE.value_literal`: "A serial representation of the value"
+    /// (`org.openehr.lang.bmm3.bmm_literal_value.adoc` §Attributes), for any
+    /// literal-value leaf.
+    #[must_use]
+    pub fn value_literal(&self) -> &str {
+        match self {
+            Self::BmmContainerValue(v) => v.value_literal.as_str(),
+            Self::BmmIndexedContainerValue(v) => v.value_literal.as_str(),
+            Self::BmmIntervalValue(v) => v.value_literal.as_str(),
+            Self::BmmPrimitiveValue(v) => v.value_literal(),
+        }
+    }
+
+    /// The formalism of this literal's `_value_literal_`, with the spec's default
+    /// applied: "If not set, `json` is assumed"
+    /// (`org.openehr.lang.bmm3.bmm_literal_value.adoc` §Attributes).
+    #[must_use]
+    pub fn syntax(&self) -> &str {
+        let stated = match self {
+            Self::BmmContainerValue(v) => v.syntax.as_deref(),
+            Self::BmmIndexedContainerValue(v) => v.syntax.as_deref(),
+            Self::BmmIntervalValue(v) => v.syntax.as_deref(),
+            Self::BmmPrimitiveValue(v) => match v {
+                BmmPrimitiveValue::BmmBooleanValue(v) => v.syntax.as_deref(),
+                BmmPrimitiveValue::BmmIntegerValue(v) => v.syntax.as_deref(),
+                BmmPrimitiveValue::BmmStringValue(v) => v.syntax.as_deref(),
+                BmmPrimitiveValue::BmmPrimitiveValue(v) => v.syntax.as_deref(),
+            },
+        };
+        stated.unwrap_or(DEFAULT_SYNTAX)
+    }
+}

--- a/crates/openehr-lang/src/bmm3/core/literal_value/mod.rs
+++ b/crates/openehr-lang/src/bmm3/core/literal_value/mod.rs
@@ -11,3 +11,6 @@ pub mod bmm_literal_value;
 pub mod bmm_primitive_value;
 pub mod bmm_string_value;
 pub mod bmm_unitary_value;
+
+// hand-written modules (spec behaviour), auto-declared:
+pub mod bmm_literal_value_impl;

--- a/crates/openehr-lang/src/bmm3/expression/el_case.rs
+++ b/crates/openehr-lang/src/bmm3/expression/el_case.rs
@@ -12,5 +12,6 @@ pub struct ElCase<T> {
     /// Result expression of conditional, if its `_condition_` evaluates to True.
     pub result: T,
     /// Constraint on
+    // NOTE: free-form JSON is adjudicated here, not accidental — LANG `…bmm3.el_case.adoc` §Attributes types `value_constraint: C_OBJECT` (1..1), but C_OBJECT is an AM class (`AM aom2 …c_object.adoc`) and AM depends on LANG — an upstream→downstream dependency inversion in the vendored model. openehr-lang cannot name an openehr-am type; the AM24 downstream re-emission of the same class DOES carry `value_constraint: CObject`, so the typed form exists exactly where C_OBJECT does.
     pub value_constraint: serde_json::Value,
 }

--- a/crates/openehr-lang/src/bmm_persistence/create_bmm3_model.rs
+++ b/crates/openehr-lang/src/bmm_persistence/create_bmm3_model.rs
@@ -1,0 +1,1641 @@
+//! The `P_BMM_SCHEMA` → **v3** (`org.openehr.lang.bmm3`) `BMM_MODEL` transform.
+//!
+//! The sibling of [`crate::bmm_persistence::create_model`] against the other BMM
+//! generation's shapes. It lives in its own module because the two generations
+//! give the same Rust NAMES to structurally different types (`BmmModel`,
+//! `BmmClass`, `BmmSimpleType`, …) and this workspace forbids import renaming, so
+//! each transform imports exactly one generation.
+//!
+//! Why a v3 transform at all: three things the v2.x materialisation must leave in
+//! the P_BMM graph have a declared destination in v3, so they reach a model here.
+//!
+//! * **A generic ancestor's parameter binding.** v3 states inheritance as a map
+//!   of TYPES — "the `_ancestors_` attribute … contains a list of _types_ rather
+//!   than classes" (`org.openehr.lang.bmm3.bmm_class.adoc` §Description), typed
+//!   `Hash<String, BMM_MODEL_TYPE>` (same §Attributes) — so
+//!   `P_BMM_CLASS.ancestor_defs`' `GENERIC_PARENT<T,SUPPLIER_B>`
+//!   (`LANG/docs/bmm_persistence/master04-syntax.adoc` §Inheritance) materialises
+//!   as a `BMM_GENERIC_TYPE` ancestor carrying its substitutions.
+//! * **A class's routines and constants.** v3 `BMM_CLASS` declares `features`,
+//!   `functions`, `procedures` and `static_properties` (same §Attributes), the
+//!   destination `P_BMM_CLASS.functions`/`constants` has in no v2 class.
+//! * **`value_constraint`.** v3 puts it on the TYPE
+//!   (`BMM_MODEL_TYPE.value_constraint: BMM_VALUE_SET_SPEC`,
+//!   `…bmm3.bmm_model_type.adoc` §Attributes), which is where
+//!   `P_BMM_BASE_TYPE.value_constraint` ("openEHR::languages",
+//!   `master04-syntax.adoc` §Value-set Constraints) belongs — the `::`-split of
+//!   `master07-core-classes.adoc` §Value-set Types.
+//!
+//! Three boundaries are load-bearing and stated here rather than left implicit:
+//!
+//! TODO: synthesise generic-substituted properties and stamp
+//! `is_synthesised_generic`. `master13-model_semantics.adoc` §Generic Inheritance
+//! requires that where an ancestor's formal parameter is substituted, the
+//! properties whose type was that parameter "are synthesised within
+//! `DV_INTERVAL<T>` with their new concrete types. Their BMM meta-type objects
+//! (type `BMM_UNITARY_PROPERTY`) will both have the meta-attribute
+//! `_is_synthesised_generic_` set to `True`". Every materialised property
+//! therefore leaves the flag unset today. The substitution machinery this needs is
+//! now all present — the ancestor type carries its bindings (above), and
+//! `BmmClass::flat_features` walks the lineage — but doing it correctly means
+//! deciding how a synthesised property interacts with a redefinition of the same
+//! name, and how far a partially-closed chain propagates, which is a design step
+//! rather than plumbing.
+//!
+//! TODO: land class INVARIANTS and routine pre-/post-conditions. v3 requires them
+//! as `BMM_ASSERTION` ("Expressions as used in BMM models to express class
+//! invariants and routine pre- and post-conditions are always in the form of an
+//! `BMM_ASSERTION`", `LANG/docs/bmm3/master10-expressions.adoc` §Usage in BMM
+//! Models) and `BMM_ASSERTION.expression: EL_BOOLEAN_EXPRESSION` is `1..1`
+//! (`…bmm3.bmm_assertion.adoc` §Attributes), while P_BMM persists each assertion
+//! as an opaque expression STRING keyed by tag (`P_BMM_CLASS.invariants`:
+//! "Invariants defined on this class, as a Hash of assertion expressions keyed by
+//! tag", `…bmm_persistence.p_bmm_class.adoc` §Attributes). Turning that string
+//! into an `EL_BOOLEAN_EXPRESSION` needs an Expression Language parser: EL is
+//! DEVELOPMENT status and its grammar is not vendored
+//! (`LANG/docs/EL/masterAppA-syntax.adoc` points at an external ANTLR
+//! repository), so this transform SKIPS invariants and pre/post-conditions rather
+//! than inventing an expression tree. They stay readable in the P_BMM graph.
+//!
+//! NOTE (embedding depth, the same adjudication as the v2.x transform): a v3
+//! `BMM_CLASS.ancestors` entry is a type whose `base_class` is a `BMM_CLASS`, so
+//! full embedding would not terminate. An ancestor type's base class is therefore
+//! a name-bearing STUB (name, package, flags — no features, no ancestors, no
+//! generic parameters), and the complete definition of every class is always
+//! `BMM_MODEL.class_definitions` ("All classes in this model, keyed by type
+//! name", `…bmm3.bmm_model.adoc` §Attributes).
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+
+use crate::bmm_persistence::create_model::Builder;
+use crate::bmm_persistence::create_model::ClassEntry;
+use crate::bmm_persistence::create_model::check_enumeration_validity;
+use crate::bmm_persistence::create_model::multiplicity_of;
+use crate::bmm_persistence::create_model::property_context;
+use crate::bmm_persistence::create_model::qualify;
+use crate::bmm_persistence::error::PBmmReadError;
+use crate::bmm_persistence::p_bmm_base_type::PBmmBaseType;
+use crate::bmm_persistence::p_bmm_class::PBmmClass;
+use crate::bmm_persistence::p_bmm_constant::PBmmConstant;
+use crate::bmm_persistence::p_bmm_container_property::PBmmContainerProperty;
+use crate::bmm_persistence::p_bmm_container_type::PBmmContainerType;
+use crate::bmm_persistence::p_bmm_enumeration::PBmmEnumeration;
+use crate::bmm_persistence::p_bmm_function::PBmmFunction;
+use crate::bmm_persistence::p_bmm_function_parameter::PBmmFunctionParameter;
+use crate::bmm_persistence::p_bmm_generic_type::PBmmGenericType;
+use crate::bmm_persistence::p_bmm_indexed_container_type::PBmmIndexedContainerType;
+use crate::bmm_persistence::p_bmm_package::PBmmPackage;
+use crate::bmm_persistence::p_bmm_property::PBmmProperty;
+use crate::bmm_persistence::p_bmm_schema::PBmmSchema;
+use crate::bmm_persistence::p_bmm_type::PBmmType;
+use crate::bmm3::core::entity::bmm_class::BmmClass;
+use crate::bmm3::core::entity::bmm_container_type::BmmContainerType;
+use crate::bmm3::core::entity::bmm_container_type::BmmContainerTypeData;
+use crate::bmm3::core::entity::bmm_generic_class::BmmGenericClass;
+use crate::bmm3::core::entity::bmm_generic_type::BmmGenericType;
+use crate::bmm3::core::entity::bmm_indexed_container_type::BmmIndexedContainerType;
+use crate::bmm3::core::entity::bmm_model_type::BmmModelType;
+use crate::bmm3::core::entity::bmm_module::BmmModule;
+use crate::bmm3::core::entity::bmm_parameter_type::BmmParameterType;
+use crate::bmm3::core::entity::bmm_simple_class::BmmSimpleClass;
+use crate::bmm3::core::entity::bmm_simple_class::BmmSimpleClassData;
+use crate::bmm3::core::entity::bmm_type::BmmType;
+use crate::bmm3::core::entity::bmm_unitary_type::BmmUnitaryType;
+use crate::bmm3::core::entity::range_constrained::bmm_enumeration::BmmEnumeration;
+use crate::bmm3::core::entity::range_constrained::bmm_enumeration::BmmEnumerationData;
+use crate::bmm3::core::entity::range_constrained::bmm_enumeration_integer::BmmEnumerationInteger;
+use crate::bmm3::core::entity::range_constrained::bmm_enumeration_string::BmmEnumerationString;
+use crate::bmm3::core::entity::range_constrained::bmm_value_set_spec::BmmValueSetSpec;
+use crate::bmm3::core::feature::bmm_constant::BmmConstant;
+use crate::bmm3::core::feature::bmm_container_property::BmmContainerProperty;
+use crate::bmm3::core::feature::bmm_container_property::BmmContainerPropertyData;
+use crate::bmm3::core::feature::bmm_feature::BmmFeature;
+use crate::bmm3::core::feature::bmm_feature_group::BmmFeatureGroup;
+use crate::bmm3::core::feature::bmm_function::BmmFunction;
+use crate::bmm3::core::feature::bmm_indexed_container_property::BmmIndexedContainerProperty;
+use crate::bmm3::core::feature::bmm_parameter::BmmParameter;
+use crate::bmm3::core::feature::bmm_procedure::BmmProcedure;
+use crate::bmm3::core::feature::bmm_property::BmmProperty;
+use crate::bmm3::core::feature::bmm_result::BmmResult;
+use crate::bmm3::core::feature::bmm_static::BmmStatic;
+use crate::bmm3::core::literal_value::bmm_literal_value::BmmLiteralValue;
+use crate::bmm3::core::literal_value::bmm_primitive_value::BmmPrimitiveValue;
+use crate::bmm3::core::literal_value::bmm_primitive_value::BmmPrimitiveValueData;
+use crate::bmm3::core::model::bmm_model::BmmModel;
+use crate::bmm3::core::model::bmm_package::BmmPackage;
+
+/// The default feature-group name every feature is placed in: "Name of this
+/// feature group; defaults to 'feature'"
+/// (`org.openehr.lang.bmm3.bmm_feature_group.adoc` §Attributes;
+/// `LANG/docs/bmm3/master08-core-features.adoc` §Feature Groups and Visibility).
+pub const DEFAULT_FEATURE_GROUP_NAME: &str = "feature";
+
+/// The `::` separator a persisted `value_constraint` is split on: "The
+/// construction within the `<<>>` is parsed into two pieces around the `::`
+/// separator, which are then used to populate the `BMM_VALUE_SET_SPEC` for a
+/// type" (`LANG/docs/bmm3/master07-core-classes.adoc` §Value-set Types).
+const VALUE_SET_SEPARATOR: &str = "::";
+
+/// Materialise the in-memory **v3** `BMM_MODEL` of an inclusion-resolved
+/// `P_BMM_SCHEMA` (see the module docs for what this generation carries that the
+/// v2.x one cannot, and for the two recorded boundaries).
+///
+/// # Errors
+/// The same failures as [`crate::bmm_persistence::create_model::create_bmm_model`]:
+/// [`PBmmReadError::UnknownAncestor`], [`PBmmReadError::UnknownType`],
+/// [`PBmmReadError::ClassNotInAnyPackage`], [`PBmmReadError::ClassNotDefined`],
+/// [`PBmmReadError::ContainerTargetTypeMissing`],
+/// [`PBmmReadError::TypeDefinitionMissing`],
+/// [`PBmmReadError::UndeclaredGenericParameter`],
+/// [`PBmmReadError::NotAGenericClass`],
+/// [`PBmmReadError::EnumerationAncestorCount`] and
+/// [`PBmmReadError::EnumerationItemListsNotOneToOne`] — the two transforms share
+/// one enumeration-validity check, so they refuse the same schemas.
+pub fn create_bmm3_model(schema: &PBmmSchema) -> Result<BmmModel, PBmmReadError> {
+    let builder = Builder::new(schema)?;
+    let mut class_definitions: BTreeMap<String, BmmClass> = BTreeMap::new();
+    for entry in builder.classes.values() {
+        class_definitions.insert(
+            entry.class.name().to_owned(),
+            build_class(&builder, entry, Depth::Full, &mut BTreeSet::new())?,
+        );
+    }
+    let modules: BTreeMap<String, BmmModule> = class_definitions
+        .iter()
+        .map(|(name, class)| (name.clone(), as_module(class)))
+        .collect();
+    let packages = build_packages(&builder, &schema.packages, "")?;
+    Ok(BmmModel {
+        // `BMM_MODEL_ELEMENT.name` of the model is the schema's own name —
+        // `P_BMM_SCHEMA.schema_name` (`…bmm_persistence.p_bmm_schema.adoc`
+        // §Attributes).
+        name: schema.schema_name.clone(),
+        // P_BMM_SCHEMA declares neither a keyed `documentation` nor `extensions`
+        // (same §Attributes), so both inherited `BMM_MODEL_ELEMENT` attributes
+        // have no persisted source.
+        documentation: None,
+        extensions: None,
+        packages: (!packages.is_empty()).then_some(packages),
+        rm_publisher: schema.rm_publisher.clone(),
+        rm_release: schema.rm_release.clone(),
+        class_definitions: (!class_definitions.is_empty()).then_some(class_definitions),
+        // `BMM_MODEL.used_models` is v3's model-import list
+        // (`org.openehr.lang.bmm3.bmm_model.adoc` §Attributes). P_BMM composes
+        // models by INCLUSION instead, and inclusion is already resolved into
+        // this schema before the transform runs
+        // (`LANG/docs/bmm_persistence/master02-overview.adoc` §Conceptual
+        // Approach), so a materialised schema uses no separate model.
+        used_models: Vec::new(),
+        // `BMM_MODEL.modules` — "All classes in this model, keyed by type name"
+        // (same §Attributes): the same population as `class_definitions`, viewed
+        // under the module meta-type every v3 class is one of
+        // (`…bmm3.bmm_class.adoc` §Inherit — `BMM_CLASS : BMM_MODULE`).
+        modules: (!modules.is_empty()).then_some(modules),
+    })
+}
+
+/// One class under the `BMM_MODULE` meta-type it inherits
+/// (`org.openehr.lang.bmm3.bmm_class.adoc` §Inherit).
+fn as_module(class: &BmmClass) -> BmmModule {
+    match class {
+        BmmClass::BmmGenericClass(generic) => BmmModule::BmmGenericClass(generic.clone()),
+        BmmClass::BmmSimpleClass(simple) => BmmModule::BmmSimpleClass(simple.clone()),
+    }
+}
+
+/// How much of a referenced class is embedded (see the module docs' depth
+/// adjudication).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Depth {
+    /// A class definition: features, properties, routines and the ancestor chain
+    /// built. Used for a `BMM_MODEL.class_definitions` entry and for every
+    /// ancestor of one, so the class-level walks
+    /// ([`crate::bmm3::core::entity::bmm_class::BmmClass::all_ancestors`],
+    /// `has_ancestor_class`, `flat_features`) see the whole lineage.
+    Full,
+    /// A name-bearing stub: no features, no generic parameters, ancestors as
+    /// stubs. Used for the base class of a TYPE, which is where full embedding
+    /// would stop terminating (a property's type resolves to a class whose own
+    /// properties have types …).
+    Stub,
+}
+
+/// The `BMM_CLASS` attributes built once for every class form.
+struct ClassCore {
+    /// `BMM_CLASS.name`.
+    name: String,
+    /// `BMM_CLASS.documentation` — the persisted scalar text under the
+    /// recommended `"purpose"` key (see [`documentation_of`]).
+    documentation: Option<BTreeMap<String, serde_json::Value>>,
+    /// `BMM_CLASS.feature_groups`.
+    feature_groups: Vec<BmmFeatureGroup>,
+    /// `BMM_CLASS.features`.
+    features: Vec<BmmFeature>,
+    /// `BMM_CLASS.ancestors` — as TYPES.
+    ancestors: Option<BTreeMap<String, BmmModelType>>,
+    /// `BMM_CLASS.package`.
+    package: BmmPackage,
+    /// `BMM_CLASS.properties`.
+    properties: Option<BTreeMap<String, BmmProperty>>,
+    /// `BMM_CLASS.static_properties`.
+    static_properties: Option<BTreeMap<String, BmmStatic>>,
+    /// `BMM_CLASS.functions`.
+    functions: Option<BTreeMap<String, BmmFunction>>,
+    /// `BMM_CLASS.procedures`.
+    procedures: Option<BTreeMap<String, BmmProcedure>>,
+    /// `BMM_CLASS.source_schema_id`.
+    source_schema_id: String,
+    /// `BMM_CLASS.is_abstract`.
+    is_abstract: Option<bool>,
+    /// `BMM_CLASS.is_primitive`.
+    is_primitive: Option<bool>,
+    /// `BMM_CLASS.is_override`.
+    is_override: bool,
+}
+
+/// The v3 keyed `documentation` form of a persisted scalar documentation string.
+///
+/// `BMM_MODEL_ELEMENT.documentation` is a `Hash<String, Any>` whose recommended
+/// keys include `"purpose": String` and where "Other keys and value types may be
+/// freely added" (`org.openehr.lang.bmm3.bmm_model_element.adoc` §Attributes),
+/// while P_BMM persists a single `documentation: String`
+/// (`…bmm_persistence.p_bmm_model_element.adoc` §Attributes). The scalar
+/// therefore lands under `"purpose"`, the key the spec names for exactly that
+/// content.
+fn documentation_of(text: Option<&str>) -> Option<BTreeMap<String, serde_json::Value>> {
+    text.map(|text| {
+        let mut out = BTreeMap::new();
+        out.insert(
+            "purpose".to_owned(),
+            serde_json::Value::String(text.to_owned()),
+        );
+        out
+    })
+}
+
+/// The feature group a materialised feature belongs to: the default group, whose
+/// own `features` list is left empty because `BMM_FEATURE.group` and
+/// `BMM_FEATURE_GROUP.features` are the two directions of one relation
+/// (`org.openehr.lang.bmm3.bmm_feature.adoc` /
+/// `…bmm3.bmm_feature_group.adoc` §Attributes) — the group the CLASS carries
+/// (`BMM_CLASS.feature_groups`) is the populated one.
+fn default_group() -> BmmFeatureGroup {
+    BmmFeatureGroup {
+        name: DEFAULT_FEATURE_GROUP_NAME.to_owned(),
+        properties: BTreeMap::new(),
+        features: Vec::new(),
+        visibility: None,
+    }
+}
+
+/// The `BMM_VALUE_SET_SPEC` of a persisted `value_constraint`, split on `::`
+/// (`LANG/docs/bmm3/master07-core-classes.adoc` §Value-set Types). A constraint
+/// with no separator is taken as a value-set id in an unnamed resource: BMM "does
+/// not impose any particular format or resolution algorithm on these identifiers"
+/// (same §Value-set Types), so neither half is refused.
+fn value_set_spec(constraint: Option<&str>) -> Option<BmmValueSetSpec> {
+    constraint.map(
+        |constraint| match constraint.split_once(VALUE_SET_SEPARATOR) {
+            Some((resource_id, value_set_id)) => BmmValueSetSpec {
+                resource_id: resource_id.to_owned(),
+                value_set_id: value_set_id.to_owned(),
+            },
+            None => BmmValueSetSpec {
+                resource_id: String::new(),
+                value_set_id: constraint.to_owned(),
+            },
+        },
+    )
+}
+
+/// Builds one v3 `BMM_CLASS` at the given embedding depth.
+fn build_class(
+    builder: &Builder<'_>,
+    entry: &ClassEntry<'_>,
+    depth: Depth,
+    visiting: &mut BTreeSet<String>,
+) -> Result<BmmClass, PBmmReadError> {
+    let persisted = entry.class;
+    let core = build_core(builder, entry, depth, visiting)?;
+    if let PBmmClass::PBmmEnumeration(enumeration) = persisted {
+        check_enumeration_validity(core.name.as_str(), enumeration)?;
+        return Ok(BmmClass::BmmSimpleClass(BmmSimpleClass::BmmEnumeration(
+            build_enumeration(builder, core, enumeration, visiting)?,
+        )));
+    }
+    if persisted.is_generic() {
+        return Ok(BmmClass::BmmGenericClass(BmmGenericClass {
+            name: core.name,
+            documentation: core.documentation,
+            extensions: None,
+            feature_groups: core.feature_groups,
+            features: core.features,
+            ancestors: core.ancestors,
+            package: core.package,
+            properties: core.properties,
+            source_schema_id: core.source_schema_id,
+            // `BMM_CLASS.immediate_descendants` is `List<BMM_CLASS>` in v3
+            // (`…bmm3.bmm_class.adoc` §Attributes) — a downward reference the
+            // emitter cannot own without making the type non-constructible, so
+            // the inverted graph stays a model-level query.
+            immediate_descendants: Vec::new(),
+            is_override: core.is_override,
+            static_properties: core.static_properties,
+            functions: core.functions,
+            procedures: core.procedures,
+            is_primitive: core.is_primitive,
+            is_abstract: core.is_abstract,
+            // See the module docs' invariants TODO.
+            invariants: Vec::new(),
+            // `creators`/`converters` are subsets of `procedures` a schema
+            // designates (`…bmm3.bmm_class.adoc` §Attributes); P_BMM has no
+            // attribute designating them, so no subset can be computed.
+            creators: None,
+            converters: None,
+            generic_parameters: build_generic_parameters(builder, persisted, depth, visiting)?,
+        }));
+    }
+    Ok(BmmClass::BmmSimpleClass(BmmSimpleClass::BmmSimpleClass(
+        BmmSimpleClassData {
+            name: core.name,
+            documentation: core.documentation,
+            extensions: None,
+            feature_groups: core.feature_groups,
+            features: core.features,
+            ancestors: core.ancestors,
+            package: core.package,
+            properties: core.properties,
+            source_schema_id: core.source_schema_id,
+            immediate_descendants: Vec::new(),
+            is_override: core.is_override,
+            static_properties: core.static_properties,
+            functions: core.functions,
+            procedures: core.procedures,
+            is_primitive: core.is_primitive,
+            is_abstract: core.is_abstract,
+            invariants: Vec::new(),
+            creators: None,
+            converters: None,
+        },
+    )))
+}
+
+/// Builds the shared `BMM_CLASS` attributes.
+fn build_core(
+    builder: &Builder<'_>,
+    entry: &ClassEntry<'_>,
+    depth: Depth,
+    visiting: &mut BTreeSet<String>,
+) -> Result<ClassCore, PBmmReadError> {
+    let persisted = entry.class;
+    let name = persisted.name();
+    let (properties, statics, functions, procedures) = match depth {
+        Depth::Stub => (None, None, None, None),
+        Depth::Full => (
+            build_properties(builder, persisted, visiting)?,
+            build_constants(builder, persisted, visiting)?,
+            build_functions(builder, persisted, visiting)?,
+            build_procedures(builder, persisted, visiting)?,
+        ),
+    };
+    let features = collect_features(
+        properties.as_ref(),
+        statics.as_ref(),
+        functions.as_ref(),
+        procedures.as_ref(),
+    );
+    Ok(ClassCore {
+        name: name.to_owned(),
+        documentation: documentation_of(persisted.documentation()),
+        // `BMM_MODULE.feature_groups` is "List of feature groups in this class"
+        // (`org.openehr.lang.bmm3.bmm_module.adoc` §Attributes). P_BMM declares no
+        // grouping, so every feature is in the one default group
+        // ([`DEFAULT_FEATURE_GROUP_NAME`]), which the class carries populated.
+        feature_groups: if features.is_empty() {
+            Vec::new()
+        } else {
+            vec![BmmFeatureGroup {
+                name: DEFAULT_FEATURE_GROUP_NAME.to_owned(),
+                properties: BTreeMap::new(),
+                features: features.clone(),
+                visibility: None,
+            }]
+        },
+        features,
+        ancestors: build_ancestors(builder, persisted, depth, visiting)?,
+        package: package_of(builder, name)?,
+        properties,
+        static_properties: statics,
+        functions,
+        procedures,
+        source_schema_id: persisted
+            .source_schema_id()
+            .unwrap_or(builder.schema_id.as_str())
+            .to_owned(),
+        is_abstract: Some(persisted.is_abstract()),
+        is_primitive: Some(entry.is_primitive_type),
+        is_override: persisted.is_override(),
+    })
+}
+
+/// The owning-package stub of the class named `name` — the v3 `BMM_PACKAGE`
+/// counterpart of the v2.x one (`BMM_CLASS.package` is `1..1`,
+/// `org.openehr.lang.bmm3.bmm_class.adoc` §Attributes).
+fn package_of(builder: &Builder<'_>, name: &str) -> Result<BmmPackage, PBmmReadError> {
+    let path = builder
+        .owning_package
+        .get(&name.to_uppercase())
+        .ok_or_else(|| PBmmReadError::ClassNotInAnyPackage {
+            class: name.to_owned(),
+        })?;
+    Ok(BmmPackage {
+        name: path.clone(),
+        documentation: None,
+        extensions: None,
+        packages: None,
+        members: Vec::new(),
+    })
+}
+
+/// Every feature of the class, as the union of the specific maps — "all features
+/// are contained in the `_features_` attribute … features of each specific type
+/// being referenced in a dedicated map"
+/// (`LANG/docs/bmm3/master07-core-classes.adoc` §Overview).
+fn collect_features(
+    properties: Option<&BTreeMap<String, BmmProperty>>,
+    statics: Option<&BTreeMap<String, BmmStatic>>,
+    functions: Option<&BTreeMap<String, BmmFunction>>,
+    procedures: Option<&BTreeMap<String, BmmProcedure>>,
+) -> Vec<BmmFeature> {
+    let mut out: Vec<BmmFeature> = Vec::new();
+    for property in properties.into_iter().flatten().map(|(_, p)| p) {
+        out.push(match property {
+            BmmProperty::BmmContainerProperty(container) => {
+                BmmFeature::BmmContainerProperty(container.clone())
+            }
+            BmmProperty::BmmUnitaryProperty(unitary) => {
+                BmmFeature::BmmUnitaryProperty(unitary.clone())
+            }
+        });
+    }
+    for value in statics.into_iter().flatten().map(|(_, s)| s) {
+        out.push(match value {
+            BmmStatic::BmmConstant(constant) => BmmFeature::BmmConstant(constant.clone()),
+            BmmStatic::BmmSingleton(singleton) => BmmFeature::BmmSingleton(singleton.clone()),
+        });
+    }
+    for function in functions.into_iter().flatten().map(|(_, f)| f) {
+        out.push(BmmFeature::BmmFunction(function.clone()));
+    }
+    for procedure in procedures.into_iter().flatten().map(|(_, p)| p) {
+        out.push(BmmFeature::BmmProcedure(procedure.clone()));
+    }
+    out
+}
+
+/// Builds `BMM_CLASS.ancestors` as a map of TYPES, carrying a generic ancestor's
+/// parameter substitutions (`org.openehr.lang.bmm3.bmm_class.adoc` §Attributes +
+/// §Description; `LANG/docs/bmm_persistence/master04-syntax.adoc` §Inheritance).
+fn build_ancestors(
+    builder: &Builder<'_>,
+    persisted: &PBmmClass,
+    depth: Depth,
+    visiting: &mut BTreeSet<String>,
+) -> Result<Option<BTreeMap<String, BmmModelType>>, PBmmReadError> {
+    // The chain is only followed once per lineage: re-entering a class already on
+    // the stack would not terminate on a schema whose inheritance is cyclic,
+    // which the spec forbids ("results in an acyclic graph",
+    // `LANG/docs/bmm3/master13-model_semantics.adoc` §Simple Inheritance) but
+    // nothing in the persisted form enforces.
+    if !visiting.insert(persisted.name().to_uppercase()) {
+        return Ok(None);
+    }
+    let mut out: BTreeMap<String, BmmModelType> = BTreeMap::new();
+    // The structured generic ancestors first: each carries the substitution the
+    // plain name list cannot express.
+    for def in persisted.ancestor_defs() {
+        let context = format!("class `{}` ancestor `{}`", persisted.name(), def.root_type);
+        let entry = builder.entry(&context, &def.root_type)?;
+        out.insert(
+            entry.class.name().to_owned(),
+            BmmModelType::BmmGenericType(build_generic_type(
+                builder, &context, def, persisted, visiting,
+            )?),
+        );
+    }
+    for parent in persisted.ancestors() {
+        let entry = builder.classes.get(&parent.to_uppercase()).ok_or_else(|| {
+            PBmmReadError::UnknownAncestor {
+                class: persisted.name().to_owned(),
+                ancestor: parent.clone(),
+            }
+        })?;
+        // Keyed by the ancestor's OWN name, so a name read back out of the map
+        // looks up in `BMM_MODEL.class_definitions`.
+        let key = entry.class.name().to_owned();
+        if out.contains_key(&key) {
+            continue;
+        }
+        // An ancestor is embedded at the SAME depth as the class being built, so
+        // a class definition carries its whole lineage and the class-level walks
+        // are transitive; a stub's ancestors stay stubs.
+        let ancestor = build_class(builder, entry, depth, visiting)?;
+        out.insert(key, class_as_type(ancestor));
+    }
+    visiting.remove(&persisted.name().to_uppercase());
+    Ok((!out.is_empty()).then_some(out))
+}
+
+/// The type a class generates — `BMM_CLASS.type` ("Generate a type object that
+/// represents the type for which this class is the definer",
+/// `org.openehr.lang.bmm3.bmm_class.adoc` §Functions), applied to a stub class.
+fn class_as_type(class: BmmClass) -> BmmModelType {
+    match class {
+        BmmClass::BmmGenericClass(generic) => BmmModelType::BmmGenericType(generic.r#type()),
+        BmmClass::BmmSimpleClass(simple) => BmmModelType::BmmSimpleType(simple.r#type()),
+    }
+}
+
+/// Builds a generic class's formal parameter declarations as
+/// `BMM_PARAMETER_TYPE`s (`org.openehr.lang.bmm3.bmm_generic_class.adoc`
+/// §Attributes — "List of formal generic parameters, keyed by name").
+fn build_generic_parameters(
+    builder: &Builder<'_>,
+    persisted: &PBmmClass,
+    depth: Depth,
+    visiting: &mut BTreeSet<String>,
+) -> Result<BTreeMap<String, BmmParameterType>, PBmmReadError> {
+    if depth == Depth::Stub {
+        return Ok(BTreeMap::new());
+    }
+    let mut out = BTreeMap::new();
+    for (key, parameter) in persisted.generic_parameter_defs().into_iter().flatten() {
+        out.insert(
+            key.clone(),
+            build_parameter_type(
+                builder,
+                persisted.name(),
+                &parameter.name,
+                parameter.conforms_to_type.as_deref(),
+                visiting,
+            )?,
+        );
+    }
+    Ok(out)
+}
+
+/// Builds one `BMM_PARAMETER_TYPE`: the formal parameter `name` with its optional
+/// conformance constraint (`org.openehr.lang.bmm3.bmm_parameter_type.adoc`
+/// §Attributes — `type_constraint` is an "Optional conformance constraint that
+/// must be the name of a defined type").
+fn build_parameter_type(
+    builder: &Builder<'_>,
+    owner: &str,
+    name: &str,
+    constraint: Option<&str>,
+    visiting: &mut BTreeSet<String>,
+) -> Result<BmmParameterType, PBmmReadError> {
+    let type_constraint = match constraint {
+        None => None,
+        Some(constrainer) => {
+            let context = format!("class `{owner}` generic parameter `{name}`");
+            let stub = build_class(
+                builder,
+                builder.entry(&context, constrainer)?,
+                Depth::Stub,
+                visiting,
+            )?;
+            Some(Box::new(
+                crate::bmm3::core::entity::bmm_effective_type::BmmEffectiveType::from(
+                    class_as_type(stub),
+                ),
+            ))
+        }
+    };
+    Ok(BmmParameterType {
+        name: name.to_owned(),
+        type_constraint,
+        // `inheritance_precursor` is "the corresponding generic parameter
+        // definition in an ancestor class" (same §Attributes) — P_BMM declares no
+        // such link, and computing one would guess which same-named ancestor
+        // parameter is meant.
+        inheritance_precursor: None,
+    })
+}
+
+/// Builds a class's `BMM_CLASS.properties` map.
+fn build_properties(
+    builder: &Builder<'_>,
+    persisted: &PBmmClass,
+    visiting: &mut BTreeSet<String>,
+) -> Result<Option<BTreeMap<String, BmmProperty>>, PBmmReadError> {
+    let Some(properties) = persisted.properties() else {
+        return Ok(None);
+    };
+    let mut out = BTreeMap::new();
+    for (key, property) in properties {
+        out.insert(
+            key.clone(),
+            build_property(builder, persisted, property, visiting)?,
+        );
+    }
+    Ok((!out.is_empty()).then_some(out))
+}
+
+/// Builds one v3 `BMM_PROPERTY`.
+///
+/// A single/open/generic property is a `BMM_UNITARY_PROPERTY` whose type is
+/// narrowed to `BMM_UNITARY_TYPE`
+/// (`org.openehr.lang.bmm3.bmm_unitary_property.adoc` §Attributes) — in v3 that
+/// enum DOES contain the model types, so an ordinary class-typed property is a
+/// unitary property. `is_nullable` is the v3 spelling of optionality ("True if
+/// this element can be null (Void) at execution time",
+/// `…bmm3.bmm_formal_element.adoc` §Attributes), which is the negation of P_BMM's
+/// `is_mandatory` (`…bmm_persistence.p_bmm_property.adoc` §Attributes).
+#[expect(
+    clippy::too_many_lines,
+    reason = "one arm per P_BMM_PROPERTY subtype; splitting the dispatch would hide the five-way persisted-property → v3 BMM_PROPERTY mapping"
+)]
+fn build_property(
+    builder: &Builder<'_>,
+    owner: &PBmmClass,
+    property: &PBmmProperty,
+    visiting: &mut BTreeSet<String>,
+) -> Result<BmmProperty, PBmmReadError> {
+    let class_name = owner.name();
+    match property {
+        PBmmProperty::PBmmSingleProperty(single) => {
+            let context = property_context(class_name, &single.name);
+            let (r#type, constraint) = match (
+                single.type_def.as_ref(),
+                single.type_ref.as_ref(),
+                single.r#type.as_deref(),
+            ) {
+                (Some(type_def), _, _) => (
+                    build_unitary_type(builder, &context, type_def, owner, visiting)?,
+                    None,
+                ),
+                (None, Some(type_ref), _) => (
+                    build_named_unitary_type(builder, &context, &type_ref.r#type, owner, visiting)?,
+                    type_ref.value_constraint.as_deref(),
+                ),
+                (None, None, Some(name)) => (
+                    build_named_unitary_type(builder, &context, name, owner, visiting)?,
+                    None,
+                ),
+                (None, None, None) => {
+                    return Err(PBmmReadError::TypeDefinitionMissing { context });
+                }
+            };
+            Ok(BmmProperty::BmmUnitaryProperty(unitary_property(
+                &single.name,
+                single.documentation.as_deref(),
+                with_value_constraint(r#type, constraint),
+                single.is_mandatory,
+                single.is_im_runtime,
+                single.is_im_infrastructure,
+            )))
+        }
+        PBmmProperty::PBmmSinglePropertyOpen(open) => {
+            let context = property_context(class_name, &open.name);
+            let parameter = match (open.type_ref.as_ref(), open.r#type.as_deref()) {
+                (Some(type_ref), _) => type_ref.r#type.as_str(),
+                (None, Some(name)) => name,
+                (None, None) => {
+                    return Err(PBmmReadError::TypeDefinitionMissing { context });
+                }
+            };
+            let r#type = BmmUnitaryType::BmmParameterType(Box::new(open_parameter_type(
+                builder, owner, &open.name, parameter, visiting,
+            )?));
+            Ok(BmmProperty::BmmUnitaryProperty(unitary_property(
+                &open.name,
+                open.documentation.as_deref(),
+                r#type,
+                open.is_mandatory,
+                open.is_im_runtime,
+                open.is_im_infrastructure,
+            )))
+        }
+        PBmmProperty::PBmmGenericProperty(generic) => {
+            let context = property_context(class_name, &generic.name);
+            let Some(type_def) = generic.type_def.as_ref() else {
+                return Err(PBmmReadError::TypeDefinitionMissing { context });
+            };
+            let r#type = BmmUnitaryType::BmmGenericType(build_generic_type(
+                builder, &context, type_def, owner, visiting,
+            )?);
+            Ok(BmmProperty::BmmUnitaryProperty(unitary_property(
+                &generic.name,
+                generic.documentation.as_deref(),
+                r#type,
+                generic.is_mandatory,
+                generic.is_im_runtime,
+                generic.is_im_infrastructure,
+            )))
+        }
+        PBmmProperty::PBmmContainerProperty(PBmmContainerProperty::PBmmContainerProperty(
+            container,
+        )) => {
+            let context = property_context(class_name, &container.name);
+            let Some(type_def) = container.type_def.as_ref() else {
+                return Err(PBmmReadError::TypeDefinitionMissing { context });
+            };
+            let r#type = build_container_type(builder, &context, type_def, owner, visiting)?;
+            Ok(BmmProperty::BmmContainerProperty(
+                BmmContainerProperty::BmmContainerProperty(BmmContainerPropertyData {
+                    name: container.name.clone(),
+                    documentation: documentation_of(container.documentation.as_deref()),
+                    extensions: None,
+                    r#type,
+                    is_nullable: is_nullable(container.is_mandatory),
+                    is_synthesised_generic: None,
+                    feature_extensions: Vec::new(),
+                    group: default_group(),
+                    is_im_runtime: container.is_im_runtime,
+                    is_im_infrastructure: container.is_im_infrastructure,
+                    // P_BMM declares no composition flag
+                    // (`…bmm_persistence.p_bmm_property.adoc` §Attributes), so
+                    // v3's `is_composition` ("True if this property instance is a
+                    // compositional sub-part of the owning class instance",
+                    // `…bmm3.bmm_property.adoc` §Attributes) has no source.
+                    is_composition: None,
+                    cardinality: container.cardinality.as_ref().map(multiplicity_of),
+                }),
+            ))
+        }
+        PBmmProperty::PBmmContainerProperty(
+            PBmmContainerProperty::PBmmIndexedContainerProperty(indexed),
+        ) => {
+            let context = property_context(class_name, &indexed.name);
+            let Some(type_def) = indexed.type_def.as_ref() else {
+                return Err(PBmmReadError::TypeDefinitionMissing { context });
+            };
+            let r#type =
+                build_indexed_container_type(builder, &context, type_def, owner, visiting)?;
+            Ok(BmmProperty::BmmContainerProperty(
+                BmmContainerProperty::BmmIndexedContainerProperty(BmmIndexedContainerProperty {
+                    name: indexed.name.clone(),
+                    documentation: documentation_of(indexed.documentation.as_deref()),
+                    extensions: None,
+                    r#type,
+                    is_nullable: is_nullable(indexed.is_mandatory),
+                    is_synthesised_generic: None,
+                    feature_extensions: Vec::new(),
+                    group: default_group(),
+                    is_im_runtime: indexed.is_im_runtime,
+                    is_im_infrastructure: indexed.is_im_infrastructure,
+                    is_composition: None,
+                    cardinality: indexed.cardinality.as_ref().map(multiplicity_of),
+                }),
+            ))
+        }
+    }
+}
+
+/// The v3 `is_nullable` of a persisted `is_mandatory`: an element that must be
+/// present cannot be null, and vice versa
+/// (`org.openehr.lang.bmm3.bmm_formal_element.adoc` §Attributes vs
+/// `…bmm_persistence.p_bmm_property.adoc` §Attributes). An unstated
+/// `is_mandatory` leaves `is_nullable` unstated too, so its `{default = false}`
+/// applies rather than a guess.
+fn is_nullable(is_mandatory: Option<bool>) -> Option<bool> {
+    is_mandatory.map(|mandatory| !mandatory)
+}
+
+/// Assembles one `BMM_UNITARY_PROPERTY`.
+fn unitary_property(
+    name: &str,
+    documentation: Option<&str>,
+    r#type: BmmUnitaryType,
+    is_mandatory: Option<bool>,
+    is_im_runtime: Option<bool>,
+    is_im_infrastructure: Option<bool>,
+) -> crate::bmm3::core::feature::bmm_unitary_property::BmmUnitaryProperty {
+    crate::bmm3::core::feature::bmm_unitary_property::BmmUnitaryProperty {
+        name: name.to_owned(),
+        documentation: documentation_of(documentation),
+        extensions: None,
+        r#type,
+        is_nullable: is_nullable(is_mandatory),
+        is_synthesised_generic: None,
+        feature_extensions: Vec::new(),
+        group: default_group(),
+        is_im_runtime,
+        is_im_infrastructure,
+        is_composition: None,
+    }
+}
+
+/// Attaches a value-set constraint to a model type
+/// (`BMM_MODEL_TYPE.value_constraint`,
+/// `org.openehr.lang.bmm3.bmm_model_type.adoc` §Attributes). A constraint on a
+/// non-model type (a formal parameter, a built-in) has nowhere to attach — only
+/// `BMM_MODEL_TYPE` declares the attribute — and P_BMM only ever states one on a
+/// `type_ref` naming a class, so the other forms pass through unchanged.
+fn with_value_constraint(r#type: BmmUnitaryType, constraint: Option<&str>) -> BmmUnitaryType {
+    let Some(spec) = value_set_spec(constraint) else {
+        return r#type;
+    };
+    match r#type {
+        BmmUnitaryType::BmmSimpleType(mut simple) => {
+            simple.value_constraint = Some(spec);
+            BmmUnitaryType::BmmSimpleType(simple)
+        }
+        BmmUnitaryType::BmmGenericType(mut generic) => {
+            generic.value_constraint = Some(spec);
+            BmmUnitaryType::BmmGenericType(generic)
+        }
+        other => other,
+    }
+}
+
+/// Builds a `BMM_UNITARY_TYPE` from a persisted `P_BMM_TYPE`.
+///
+/// A container type is not unitary (`org.openehr.lang.bmm3.bmm_unitary_type.adoc`
+/// §Description — "the type of any instantiated object that is **not** a
+/// container object"), so a persisted container in a single-property slot is
+/// reduced to its item type, which is what `unitary_type()` returns for it
+/// (`…bmm3.bmm_container_type.adoc` §Functions).
+fn build_unitary_type(
+    builder: &Builder<'_>,
+    context: &str,
+    r#type: &PBmmType,
+    owner: &PBmmClass,
+    visiting: &mut BTreeSet<String>,
+) -> Result<BmmUnitaryType, PBmmReadError> {
+    match r#type {
+        PBmmType::PBmmSimpleType(simple) => {
+            let built =
+                build_named_unitary_type(builder, context, &simple.r#type, owner, visiting)?;
+            Ok(with_value_constraint(
+                built,
+                simple.value_constraint.as_deref(),
+            ))
+        }
+        PBmmType::PBmmOpenType(open) => Ok(BmmUnitaryType::BmmParameterType(Box::new(
+            open_parameter_type(builder, owner, context, &open.r#type, visiting)?,
+        ))),
+        PBmmType::PBmmGenericType(generic) => Ok(BmmUnitaryType::BmmGenericType(
+            build_generic_type(builder, context, generic, owner, visiting)?,
+        )),
+        PBmmType::PBmmContainerType(container) => {
+            Ok(build_container_type(builder, context, container, owner, visiting)?.unitary_type())
+        }
+    }
+}
+
+/// Builds a `BMM_UNITARY_TYPE` from a persisted `P_BMM_BASE_TYPE`.
+fn build_base_unitary_type(
+    builder: &Builder<'_>,
+    context: &str,
+    r#type: &PBmmBaseType,
+    owner: &PBmmClass,
+    visiting: &mut BTreeSet<String>,
+) -> Result<BmmUnitaryType, PBmmReadError> {
+    match r#type {
+        PBmmBaseType::PBmmSimpleType(simple) => {
+            let built =
+                build_named_unitary_type(builder, context, &simple.r#type, owner, visiting)?;
+            Ok(with_value_constraint(
+                built,
+                simple.value_constraint.as_deref(),
+            ))
+        }
+        PBmmBaseType::PBmmOpenType(open) => Ok(BmmUnitaryType::BmmParameterType(Box::new(
+            open_parameter_type(builder, owner, context, &open.r#type, visiting)?,
+        ))),
+        PBmmBaseType::PBmmGenericType(generic) => Ok(BmmUnitaryType::BmmGenericType(
+            build_generic_type(builder, context, generic, owner, visiting)?,
+        )),
+    }
+}
+
+/// Builds the `BMM_UNITARY_TYPE` a bare type NAME denotes: a formal generic
+/// parameter of the owning class if it declares one, else the simple type of the
+/// named class.
+fn build_named_unitary_type(
+    builder: &Builder<'_>,
+    context: &str,
+    name: &str,
+    owner: &PBmmClass,
+    visiting: &mut BTreeSet<String>,
+) -> Result<BmmUnitaryType, PBmmReadError> {
+    if builder.find_generic_parameter(owner, name).is_some() {
+        return Ok(BmmUnitaryType::BmmParameterType(Box::new(
+            open_parameter_type(builder, owner, context, name, visiting)?,
+        )));
+    }
+    let stub = build_class(
+        builder,
+        builder.entry(context, name)?,
+        Depth::Stub,
+        visiting,
+    )?;
+    Ok(match class_as_type(stub) {
+        BmmModelType::BmmGenericType(generic) => BmmUnitaryType::BmmGenericType(generic),
+        BmmModelType::BmmSimpleType(simple) => BmmUnitaryType::BmmSimpleType(simple),
+    })
+}
+
+/// Builds the `BMM_PARAMETER_TYPE` of the formal parameter `parameter`, refusing
+/// a parameter the owning class does not declare — "The parameter must be in the
+/// type declaration of the owning `BMM_CLASS`"
+/// (`org.openehr.lang.bmm.bmm_open_type.adoc` §Description, the persisted form's
+/// own rule).
+fn open_parameter_type(
+    builder: &Builder<'_>,
+    owner: &PBmmClass,
+    property: &str,
+    parameter: &str,
+    visiting: &mut BTreeSet<String>,
+) -> Result<BmmParameterType, PBmmReadError> {
+    let declared = builder
+        .find_generic_parameter(owner, parameter)
+        .ok_or_else(|| PBmmReadError::UndeclaredGenericParameter {
+            class: owner.name().to_owned(),
+            property: property.to_owned(),
+            parameter: parameter.to_owned(),
+        })?;
+    build_parameter_type(
+        builder,
+        owner.name(),
+        &declared.name,
+        declared.conforms_to_type.as_deref(),
+        visiting,
+    )
+}
+
+/// Builds a `BMM_GENERIC_TYPE`, carrying its actual parameters — "the string
+/// types … then the complex type references"
+/// (`LANG/docs/bmm_persistence/master04-syntax.adoc` §Generic Classes), each of
+/// which is a `BMM_UNITARY_TYPE` (`org.openehr.lang.bmm3.bmm_generic_type.adoc`
+/// §Attributes).
+fn build_generic_type(
+    builder: &Builder<'_>,
+    context: &str,
+    generic: &PBmmGenericType,
+    owner: &PBmmClass,
+    visiting: &mut BTreeSet<String>,
+) -> Result<BmmGenericType, PBmmReadError> {
+    let entry = builder.entry(context, &generic.root_type)?;
+    let BmmClass::BmmGenericClass(base_class) = build_class(builder, entry, Depth::Stub, visiting)?
+    else {
+        return Err(PBmmReadError::NotAGenericClass {
+            context: context.to_owned(),
+            type_name: generic.root_type.clone(),
+        });
+    };
+    let mut generic_parameters: Vec<BmmUnitaryType> = Vec::new();
+    for name in &generic.generic_parameters {
+        generic_parameters.push(build_named_unitary_type(
+            builder, context, name, owner, visiting,
+        )?);
+    }
+    for parameter in &generic.generic_parameter_defs {
+        generic_parameters.push(build_unitary_type(
+            builder, context, parameter, owner, visiting,
+        )?);
+    }
+    Ok(BmmGenericType {
+        value_constraint: value_set_spec(generic.value_constraint.as_deref()),
+        base_class,
+        generic_parameters,
+    })
+}
+
+/// Builds a `BMM_CONTAINER_TYPE`.
+///
+/// `is_ordered`/`is_unique` carry the List/Set/Bag semantics
+/// (`org.openehr.lang.bmm3.bmm_container_type.adoc` §Attributes); P_BMM states
+/// only the container CLASS name (`master04-syntax.adoc` §Container Properties),
+/// so both are left unstated and their declared defaults (`is_ordered = true`,
+/// `is_unique = false`) apply — the container class name is the discriminator the
+/// persisted form actually carries.
+fn build_container_type(
+    builder: &Builder<'_>,
+    context: &str,
+    container: &PBmmContainerType,
+    owner: &PBmmClass,
+    visiting: &mut BTreeSet<String>,
+) -> Result<BmmContainerType, PBmmReadError> {
+    match container {
+        PBmmContainerType::PBmmIndexedContainerType(indexed) => {
+            Ok(BmmContainerType::BmmIndexedContainerType(Box::new(
+                build_indexed_container_type(builder, context, indexed, owner, visiting)?,
+            )))
+        }
+        PBmmContainerType::PBmmContainerType(data) => {
+            Ok(BmmContainerType::BmmContainerType(BmmContainerTypeData {
+                container_class: generic_container_class(
+                    builder,
+                    context,
+                    &data.container_type,
+                    visiting,
+                )?,
+                item_type: Box::new(build_container_target(
+                    builder,
+                    context,
+                    data.r#type.as_deref(),
+                    data.type_def.as_ref(),
+                    owner,
+                    visiting,
+                )?),
+                is_ordered: None,
+                is_unique: None,
+            }))
+        }
+    }
+}
+
+/// Builds a `BMM_INDEXED_CONTAINER_TYPE` (`index_type` is a `BMM_SIMPLE_TYPE`,
+/// `org.openehr.lang.bmm3.bmm_indexed_container_type.adoc` §Attributes).
+fn build_indexed_container_type(
+    builder: &Builder<'_>,
+    context: &str,
+    indexed: &PBmmIndexedContainerType,
+    owner: &PBmmClass,
+    visiting: &mut BTreeSet<String>,
+) -> Result<BmmIndexedContainerType, PBmmReadError> {
+    let index_stub = build_class(
+        builder,
+        builder.entry(context, &indexed.index_type)?,
+        Depth::Stub,
+        visiting,
+    )?;
+    let BmmModelType::BmmSimpleType(index_type) = class_as_type(index_stub) else {
+        return Err(PBmmReadError::NotAGenericClass {
+            context: context.to_owned(),
+            type_name: indexed.index_type.clone(),
+        });
+    };
+    Ok(BmmIndexedContainerType {
+        container_class: generic_container_class(
+            builder,
+            context,
+            &indexed.container_type,
+            visiting,
+        )?,
+        item_type: build_container_target(
+            builder,
+            context,
+            indexed.r#type.as_deref(),
+            indexed.type_def.as_ref(),
+            owner,
+            visiting,
+        )?,
+        is_ordered: None,
+        is_unique: None,
+        index_type,
+    })
+}
+
+/// The container's own class, which v3 requires to be a `BMM_GENERIC_CLASS`
+/// ("The type of the container. This converts to the `_root_type_` in
+/// `BMM_GENERIC_TYPE`", `org.openehr.lang.bmm3.bmm_container_type.adoc`
+/// §Attributes) — `List<T>`, `Hash<K,V>` etc.
+fn generic_container_class(
+    builder: &Builder<'_>,
+    context: &str,
+    name: &str,
+    visiting: &mut BTreeSet<String>,
+) -> Result<BmmGenericClass, PBmmReadError> {
+    let stub = build_class(
+        builder,
+        builder.entry(context, name)?,
+        Depth::Stub,
+        visiting,
+    )?;
+    match stub {
+        BmmClass::BmmGenericClass(generic) => Ok(generic),
+        BmmClass::BmmSimpleClass(_) => Err(PBmmReadError::NotAGenericClass {
+            context: context.to_owned(),
+            type_name: name.to_owned(),
+        }),
+    }
+}
+
+/// Builds a container's item type from its `type` name or nested `type_def`.
+fn build_container_target(
+    builder: &Builder<'_>,
+    context: &str,
+    name: Option<&str>,
+    type_def: Option<&PBmmBaseType>,
+    owner: &PBmmClass,
+    visiting: &mut BTreeSet<String>,
+) -> Result<BmmUnitaryType, PBmmReadError> {
+    match (type_def, name) {
+        (Some(nested), _) => build_base_unitary_type(builder, context, nested, owner, visiting),
+        (None, Some(name)) => build_named_unitary_type(builder, context, name, owner, visiting),
+        (None, None) => Err(PBmmReadError::ContainerTargetTypeMissing {
+            context: context.to_owned(),
+        }),
+    }
+}
+
+/// Builds a class's `BMM_CLASS.functions` map — the persisted functions that
+/// state a result ("Type definition of the function result, if any (absent for
+/// procedures)", `…bmm_persistence.p_bmm_function.adoc` §Attributes).
+fn build_functions(
+    builder: &Builder<'_>,
+    persisted: &PBmmClass,
+    visiting: &mut BTreeSet<String>,
+) -> Result<Option<BTreeMap<String, BmmFunction>>, PBmmReadError> {
+    let Some(functions) = persisted.functions() else {
+        return Ok(None);
+    };
+    let mut out = BTreeMap::new();
+    for (key, function) in functions {
+        if function.result.is_none() {
+            continue;
+        }
+        out.insert(
+            key.clone(),
+            build_function(builder, persisted, function, visiting)?,
+        );
+    }
+    Ok((!out.is_empty()).then_some(out))
+}
+
+/// Builds a class's `BMM_CLASS.procedures` map — the persisted functions with no
+/// result (same §Attributes: a result is "absent for procedures").
+fn build_procedures(
+    builder: &Builder<'_>,
+    persisted: &PBmmClass,
+    visiting: &mut BTreeSet<String>,
+) -> Result<Option<BTreeMap<String, BmmProcedure>>, PBmmReadError> {
+    let Some(functions) = persisted.functions() else {
+        return Ok(None);
+    };
+    let mut out = BTreeMap::new();
+    for (key, function) in functions {
+        if function.result.is_some() {
+            continue;
+        }
+        out.insert(
+            key.clone(),
+            build_procedure(builder, persisted, function, visiting)?,
+        );
+    }
+    Ok((!out.is_empty()).then_some(out))
+}
+
+/// Builds one `BMM_FUNCTION`.
+///
+/// `BMM_FUNCTION.result` is `1..1` — the "Automatically created Result variable"
+/// (`org.openehr.lang.bmm3.bmm_function.adoc` §Attributes) — and
+/// `Inv_result_type` states `type = Result.type`, so both carry the persisted
+/// result type. `pre_conditions`/`post_conditions` stay empty per the module
+/// docs' invariants TODO. `operator_definition` has no persisted source (P_BMM
+/// declares no operator meta-data).
+fn build_function(
+    builder: &Builder<'_>,
+    owner: &PBmmClass,
+    function: &PBmmFunction,
+    visiting: &mut BTreeSet<String>,
+) -> Result<BmmFunction, PBmmReadError> {
+    let context = format!("class `{}` function `{}`", owner.name(), function.name);
+    let result = function
+        .result
+        .as_ref()
+        .ok_or_else(|| PBmmReadError::TypeDefinitionMissing {
+            context: context.clone(),
+        })?;
+    let result_type = BmmType::from(build_unitary_type(
+        builder, &context, result, owner, visiting,
+    )?);
+    Ok(BmmFunction {
+        name: function.name.clone(),
+        documentation: documentation_of(function.documentation.as_deref()),
+        extensions: None,
+        r#type: result_type.clone(),
+        is_nullable: function.is_nullable,
+        is_synthesised_generic: None,
+        feature_extensions: Vec::new(),
+        group: default_group(),
+        parameters: build_parameters(builder, owner, function, visiting)?,
+        pre_conditions: Vec::new(),
+        post_conditions: Vec::new(),
+        // `BMM_ROUTINE.definition` is the routine BODY
+        // (`org.openehr.lang.bmm3.bmm_routine.adoc` §Attributes); P_BMM persists
+        // no bodies, only signatures.
+        definition: None,
+        operator_definition: None,
+        result: Box::new(BmmResult {
+            // `BMM_RESULT` "redefines" its name to the pre-defined `Result`
+            // variable (`…bmm3.bmm_result.adoc` §Description — "Automatically
+            // declared variable representing result of a Function call").
+            name: RESULT_VARIABLE_NAME.to_owned(),
+            documentation: None,
+            extensions: None,
+            r#type: result_type,
+            is_nullable: function.is_nullable,
+        }),
+    })
+}
+
+/// The name of a function's automatically declared result variable
+/// (`org.openehr.lang.bmm3.bmm_result.adoc` §Description; the `Result` keyword of
+/// `LANG/docs/bmm3/master08-core-features.adoc` §Variables — "the pre-defined
+/// `Result`").
+pub const RESULT_VARIABLE_NAME: &str = "Result";
+
+/// Builds one `BMM_PROCEDURE` — a routine whose result meta-type is the built-in
+/// Status type (`org.openehr.lang.bmm3.bmm_procedure.adoc` §Attributes: `type` is
+/// redefined to `BMM_STATUS_TYPE`).
+fn build_procedure(
+    builder: &Builder<'_>,
+    owner: &PBmmClass,
+    function: &PBmmFunction,
+    visiting: &mut BTreeSet<String>,
+) -> Result<BmmProcedure, PBmmReadError> {
+    Ok(BmmProcedure {
+        name: function.name.clone(),
+        documentation: documentation_of(function.documentation.as_deref()),
+        extensions: None,
+        r#type: crate::bmm3::core::entity::bmm_status_type::BmmStatusType {},
+        is_nullable: function.is_nullable,
+        is_synthesised_generic: None,
+        feature_extensions: Vec::new(),
+        group: default_group(),
+        parameters: build_parameters(builder, owner, function, visiting)?,
+        pre_conditions: Vec::new(),
+        post_conditions: Vec::new(),
+        definition: None,
+    })
+}
+
+/// Builds a routine's ordered parameter list — "Formal parameters of the routine"
+/// (`org.openehr.lang.bmm3.bmm_routine.adoc` §Attributes) from the persisted map
+/// keyed by parameter name (`…bmm_persistence.p_bmm_function.adoc` §Attributes).
+///
+/// NOTE (recorded deviation, the same one the v2.x transform records for generic
+/// parameters): `BMM_ROUTINE.parameters` is an ORDERED list while P_BMM keys them
+/// by name, so declaration order is not preserved and sorted-key order is used.
+fn build_parameters(
+    builder: &Builder<'_>,
+    owner: &PBmmClass,
+    function: &PBmmFunction,
+    visiting: &mut BTreeSet<String>,
+) -> Result<Vec<BmmParameter>, PBmmReadError> {
+    let mut out: Vec<BmmParameter> = Vec::new();
+    for parameter in function.parameters.iter().flatten().map(|(_, p)| p) {
+        let (name, documentation, r#type, is_nullable) = match parameter {
+            PBmmFunctionParameter::PBmmSingleFunctionParameter(single) => {
+                let context = parameter_context(owner.name(), &function.name, &single.name);
+                let r#type = build_named_unitary_type(
+                    builder,
+                    &context,
+                    single.r#type.as_str(),
+                    owner,
+                    visiting,
+                )?;
+                (
+                    single.name.clone(),
+                    single.documentation.clone(),
+                    r#type,
+                    single.is_nullable,
+                )
+            }
+            PBmmFunctionParameter::PBmmSingleFunctionParameterOpen(open) => {
+                let context = parameter_context(owner.name(), &function.name, &open.name);
+                let r#type = BmmUnitaryType::BmmParameterType(Box::new(open_parameter_type(
+                    builder,
+                    owner,
+                    &context,
+                    open.r#type.as_str(),
+                    visiting,
+                )?));
+                (
+                    open.name.clone(),
+                    open.documentation.clone(),
+                    r#type,
+                    open.is_nullable,
+                )
+            }
+            PBmmFunctionParameter::PBmmGenericFunctionParameter(generic) => {
+                let context = parameter_context(owner.name(), &function.name, &generic.name);
+                (
+                    generic.name.clone(),
+                    generic.documentation.clone(),
+                    BmmUnitaryType::BmmGenericType(build_generic_type(
+                        builder,
+                        &context,
+                        &generic.type_def,
+                        owner,
+                        visiting,
+                    )?),
+                    generic.is_nullable,
+                )
+            }
+            PBmmFunctionParameter::PBmmContainerFunctionParameter(container) => {
+                let context = parameter_context(owner.name(), &function.name, &container.name);
+                (
+                    container.name.clone(),
+                    container.documentation.clone(),
+                    build_container_type(builder, &context, &container.type_def, owner, visiting)?
+                        .unitary_type(),
+                    container.is_nullable,
+                )
+            }
+        };
+        out.push(BmmParameter {
+            name,
+            documentation: documentation_of(documentation.as_deref()),
+            extensions: None,
+            r#type: BmmType::from(r#type),
+            is_nullable,
+            // `BMM_PARAMETER.direction` — "If none-supplied, the parameter is
+            // treated as `in`" (`org.openehr.lang.bmm3.bmm_parameter.adoc`
+            // §Attributes); P_BMM states no direction.
+            direction: None,
+        });
+    }
+    Ok(out)
+}
+
+/// The error context naming one routine parameter.
+fn parameter_context(class: &str, routine: &str, parameter: &str) -> String {
+    format!("class `{class}` routine `{routine}` parameter `{parameter}`")
+}
+
+/// Builds a class's `BMM_CLASS.static_properties` map from its persisted
+/// constants — "Static properties defined in this class"
+/// (`org.openehr.lang.bmm3.bmm_class.adoc` §Attributes), of which `BMM_CONSTANT`
+/// is the literal-valued form (`…bmm3.bmm_static.adoc`).
+fn build_constants(
+    builder: &Builder<'_>,
+    persisted: &PBmmClass,
+    visiting: &mut BTreeSet<String>,
+) -> Result<Option<BTreeMap<String, BmmStatic>>, PBmmReadError> {
+    let Some(constants) = persisted.constants() else {
+        return Ok(None);
+    };
+    let mut out = BTreeMap::new();
+    for (key, constant) in constants {
+        out.insert(
+            key.clone(),
+            BmmStatic::BmmConstant(build_constant(builder, persisted, constant, visiting)?),
+        );
+    }
+    Ok((!out.is_empty()).then_some(out))
+}
+
+/// Builds one `BMM_CONSTANT`.
+///
+/// `BMM_CONSTANT.generator` is `1..1` — "Literal value of the constant"
+/// (`org.openehr.lang.bmm3.bmm_constant.adoc` §Attributes) — and P_BMM persists
+/// the value as a serialised string (`…bmm_persistence.p_bmm_constant.adoc`
+/// §Attributes), which is exactly `BMM_LITERAL_VALUE.value_literal` ("A serial
+/// representation of the value", `…bmm3.bmm_literal_value.adoc` §Attributes). The
+/// native `value` is left unset, per the literal-evaluation boundary recorded in
+/// [`crate::bmm3::core::literal_value::bmm_literal_value_impl`]. `Inv_not_nullable`
+/// makes a constant non-nullable (`…bmm3.bmm_constant.adoc` §Invariants).
+fn build_constant(
+    builder: &Builder<'_>,
+    owner: &PBmmClass,
+    constant: &PBmmConstant,
+    visiting: &mut BTreeSet<String>,
+) -> Result<BmmConstant, PBmmReadError> {
+    let context = format!("class `{}` constant `{}`", owner.name(), constant.name);
+    let unitary = build_named_unitary_type(builder, &context, &constant.r#type, owner, visiting)?;
+    // `BMM_PRIMITIVE_VALUE.type` is a `BMM_SIMPLE_TYPE`
+    // (`org.openehr.lang.bmm3.bmm_primitive_value.adoc` §Attributes), so a
+    // constant of a non-simple type carries its literal under the least-rich
+    // literal form's simple type; only a simple type can be stated there.
+    let BmmUnitaryType::BmmSimpleType(simple) = unitary.clone() else {
+        return Err(PBmmReadError::UnknownType {
+            context,
+            type_name: constant.r#type.clone(),
+        });
+    };
+    Ok(BmmConstant {
+        name: constant.name.clone(),
+        documentation: documentation_of(constant.documentation.as_deref()),
+        extensions: None,
+        r#type: BmmType::from(unitary),
+        is_nullable: Some(false),
+        is_synthesised_generic: None,
+        feature_extensions: Vec::new(),
+        group: default_group(),
+        generator: BmmLiteralValue::BmmPrimitiveValue(BmmPrimitiveValue::BmmPrimitiveValue(
+            BmmPrimitiveValueData {
+                value_literal: constant.value.clone().unwrap_or_default(),
+                value: None,
+                // `_syntax_` unset means the `json` default applies
+                // (`…bmm3.bmm_literal_value.adoc` §Attributes); P_BMM states no
+                // syntax for a constant value.
+                syntax: None,
+                r#type: simple,
+            },
+        )),
+    })
+}
+
+/// Builds one `BMM_ENUMERATION` form, with `item_values` as typed literal values.
+///
+/// v3 types `item_values` as `List<BMM_PRIMITIVE_VALUE>` and its two degenerate
+/// subtypes redefine it to `List<BMM_INTEGER_VALUE>` / `List<BMM_STRING_VALUE>`
+/// (`org.openehr.lang.bmm3.bmm_enumeration.adoc`,
+/// `…bmm3.bmm_enumeration_integer.adoc`, `…bmm3.bmm_enumeration_string.adoc`
+/// §Attributes), where P_BMM persists them as `List<Any>` (JSON scalars). Each
+/// persisted scalar therefore becomes the matching literal-value object over the
+/// enumeration's underlying simple type, with `value_literal` carrying its serial
+/// form.
+#[expect(
+    clippy::too_many_lines,
+    reason = "one arm per BMM_ENUMERATION form, each assembling the same 20-attribute class shape with its own redefined item_values type"
+)]
+fn build_enumeration(
+    builder: &Builder<'_>,
+    core: ClassCore,
+    persisted: &PBmmEnumeration,
+    visiting: &mut BTreeSet<String>,
+) -> Result<BmmEnumeration, PBmmReadError> {
+    let context = format!("enumeration class `{}`", core.name);
+    let underlying = build_named_unitary_type(
+        builder,
+        &context,
+        persisted.underlying_type_name(),
+        &PBmmClass::PBmmEnumeration(persisted.clone()),
+        visiting,
+    )?;
+    let BmmUnitaryType::BmmSimpleType(underlying) = underlying else {
+        return Err(PBmmReadError::UnknownType {
+            context,
+            type_name: persisted.underlying_type_name().to_owned(),
+        });
+    };
+    let item_names = persisted.item_names().to_vec();
+    match persisted {
+        PBmmEnumeration::PBmmEnumerationInteger(_) => Ok(BmmEnumeration::BmmEnumerationInteger(
+            BmmEnumerationInteger {
+                name: core.name,
+                documentation: core.documentation,
+                extensions: None,
+                feature_groups: core.feature_groups,
+                features: core.features,
+                ancestors: core.ancestors,
+                package: core.package,
+                properties: core.properties,
+                source_schema_id: core.source_schema_id,
+                immediate_descendants: Vec::new(),
+                is_override: core.is_override,
+                static_properties: core.static_properties,
+                functions: core.functions,
+                procedures: core.procedures,
+                is_primitive: core.is_primitive,
+                is_abstract: core.is_abstract,
+                invariants: Vec::new(),
+                creators: None,
+                converters: None,
+                item_names,
+                item_values: persisted
+                    .item_values()
+                    .iter()
+                    .map(|value| {
+                        crate::bmm3::core::literal_value::bmm_integer_value::BmmIntegerValue {
+                            value_literal: literal_form(value),
+                            value: value
+                                .as_i64()
+                                .and_then(|v| i32::try_from(v).ok())
+                                .unwrap_or_default(),
+                            syntax: None,
+                            r#type: underlying.clone(),
+                        }
+                    })
+                    .collect(),
+            },
+        )),
+        PBmmEnumeration::PBmmEnumerationString(_) => {
+            Ok(BmmEnumeration::BmmEnumerationString(BmmEnumerationString {
+                name: core.name,
+                documentation: core.documentation,
+                extensions: None,
+                feature_groups: core.feature_groups,
+                features: core.features,
+                ancestors: core.ancestors,
+                package: core.package,
+                properties: core.properties,
+                source_schema_id: core.source_schema_id,
+                immediate_descendants: Vec::new(),
+                is_override: core.is_override,
+                static_properties: core.static_properties,
+                functions: core.functions,
+                procedures: core.procedures,
+                is_primitive: core.is_primitive,
+                is_abstract: core.is_abstract,
+                invariants: Vec::new(),
+                creators: None,
+                converters: None,
+                item_names,
+                item_values: persisted
+                    .item_values()
+                    .iter()
+                    .map(|value| {
+                        crate::bmm3::core::literal_value::bmm_string_value::BmmStringValue {
+                            value_literal: literal_form(value),
+                            value: value
+                                .as_str()
+                                .map_or_else(|| literal_form(value), str::to_owned),
+                            syntax: None,
+                            r#type: underlying.clone(),
+                        }
+                    })
+                    .collect(),
+            }))
+        }
+        PBmmEnumeration::PBmmEnumeration(_) => {
+            Ok(BmmEnumeration::BmmEnumeration(BmmEnumerationData {
+                name: core.name,
+                documentation: core.documentation,
+                extensions: None,
+                feature_groups: core.feature_groups,
+                features: core.features,
+                ancestors: core.ancestors,
+                package: core.package,
+                properties: core.properties,
+                source_schema_id: core.source_schema_id,
+                immediate_descendants: Vec::new(),
+                is_override: core.is_override,
+                static_properties: core.static_properties,
+                functions: core.functions,
+                procedures: core.procedures,
+                is_primitive: core.is_primitive,
+                is_abstract: core.is_abstract,
+                invariants: Vec::new(),
+                creators: None,
+                converters: None,
+                item_names,
+                item_values: persisted
+                    .item_values()
+                    .iter()
+                    .map(|value| {
+                        BmmPrimitiveValue::BmmPrimitiveValue(BmmPrimitiveValueData {
+                            value_literal: literal_form(value),
+                            value: Some(value.clone()),
+                            syntax: None,
+                            r#type: underlying.clone(),
+                        })
+                    })
+                    .collect(),
+            }))
+        }
+    }
+}
+
+/// The serial form of a persisted enumeration value — `BMM_LITERAL_VALUE.value_literal`,
+/// "A serial representation of the value"
+/// (`org.openehr.lang.bmm3.bmm_literal_value.adoc` §Attributes). A JSON string
+/// contributes its text (a quoted literal would double-quote it); every other
+/// scalar contributes its JSON rendering.
+fn literal_form(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(text) => text.clone(),
+        other => other.to_string(),
+    }
+}
+
+/// Builds the v3 `BMM_PACKAGE` tree, keyed in upper case
+/// (`BMM_PACKAGE_CONTAINER.packages` — "Child packages; keys all in upper case
+/// for guaranteed matching", `org.openehr.lang.bmm3.bmm_package_container.adoc`
+/// §Attributes). A package's `members` are the modules (classes) it lists
+/// (`…bmm3.bmm_package.adoc` §Attributes).
+fn build_packages(
+    builder: &Builder<'_>,
+    packages: &BTreeMap<String, PBmmPackage>,
+    prefix: &str,
+) -> Result<BTreeMap<String, BmmPackage>, PBmmReadError> {
+    let mut out = BTreeMap::new();
+    for package in packages.values() {
+        let path = qualify(prefix, &package.name);
+        let mut members: Vec<BmmModule> = Vec::new();
+        for class in &package.classes {
+            let entry = builder.classes.get(&class.to_uppercase()).ok_or_else(|| {
+                PBmmReadError::ClassNotDefined {
+                    package: package.name.clone(),
+                    class: class.clone(),
+                }
+            })?;
+            members.push(as_module(&build_class(
+                builder,
+                entry,
+                Depth::Stub,
+                &mut BTreeSet::new(),
+            )?));
+        }
+        let children = build_packages(builder, &package.packages, &path)?;
+        out.insert(
+            package.name.to_uppercase(),
+            BmmPackage {
+                name: path,
+                documentation: None,
+                extensions: None,
+                packages: (!children.is_empty()).then_some(children),
+                members,
+            },
+        );
+    }
+    Ok(out)
+}

--- a/crates/openehr-lang/src/bmm_persistence/create_model.rs
+++ b/crates/openehr-lang/src/bmm_persistence/create_model.rs
@@ -46,12 +46,11 @@
 //!   The **v3** generation DOES declare the destination:
 //!   `org.openehr.lang.bmm3.bmm_model_type.adoc` §Attributes types
 //!   `value_constraint: BMM_VALUE_SET_SPEC` on every model type, and
-//!   `crate::bmm3` emits it.
-//!   TODO: materialise a v3 `BMM_MODEL` from P_BMM (or its v3 successor) so
-//!   `value_constraint`, class `functions`/`procedures`/`invariants` and generic
-//!   ancestor bindings reach a model; the v3 generation's own function surface is
-//!   a precondition (`crate::bmm3::core::entity::bmm_type_impl` has the naming
-//!   surface only).
+//!   `crate::bmm3` emits it — and
+//!   [`crate::bmm_persistence::create_bmm3_model::create_bmm3_model`] materialises
+//!   that generation from the same persisted schema, where the constraint DOES
+//!   land on the type. So the boundary is this transform's target generation, and
+//!   the other transform is the way to keep the constraint.
 
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
@@ -103,7 +102,13 @@ use crate::bmm_persistence::p_bmm_type::PBmmType;
 /// [`PBmmReadError::TypeDefinitionMissing`],
 /// [`PBmmReadError::UndeclaredGenericParameter`] or
 /// [`PBmmReadError::NotAGenericClass`] when a symbolic reference in the schema
-/// cannot be resolved to the object reference the `BMM_*` shapes require.
+/// cannot be resolved to the object reference the `BMM_*` shapes require, and
+/// [`PBmmReadError::EnumerationAncestorCount`] /
+/// [`PBmmReadError::EnumerationItemListsNotOneToOne`] when an enumeration class
+/// violates a `BMM_ENUMERATION` validity rule — "may have only one ancestor"
+/// (`LANG/docs/bmm3/master07-core-classes.adoc` §Range-Constrained Classes) and
+/// `item_values` "Must be 1:1 with `item_names` list"
+/// (`org.openehr.lang.bmm.bmm_enumeration.adoc` §Attributes).
 pub fn create_bmm_model(schema: &PBmmSchema) -> Result<BmmModel, PBmmReadError> {
     let builder = Builder::new(schema)?;
     // Keyed by each class's OWN name, the form `BMM_CLASS.name` states and the
@@ -172,13 +177,13 @@ enum EmbedDepth {
 }
 
 /// One class definition of the schema, with the list it was declared in.
-struct ClassEntry<'a> {
+pub(super) struct ClassEntry<'a> {
     /// The persisted definition.
-    class: &'a PBmmClass,
+    pub(super) class: &'a PBmmClass,
     /// Whether it was declared in `primitive_types` — `BMM_CLASS.is_primitive_type`,
     /// "True if this class is designated a primitive type within the overall type
     /// system of the schema" (`org.openehr.lang.bmm.bmm_class.adoc` §Attributes).
-    is_primitive_type: bool,
+    pub(super) is_primitive_type: bool,
 }
 
 /// The resolution indexes the transform needs, all derived from the schema
@@ -200,18 +205,18 @@ struct ClassEntry<'a> {
 /// matching" (`org.openehr.lang.bmm.bmm_package_container.adoc` §Attributes).
 /// Every name written into the produced `BMM_*` values is the class's OWN
 /// `name`, never the upper-cased key.
-struct Builder<'a> {
+pub(super) struct Builder<'a> {
     /// The schema being materialised
     /// ([`crate::bmm_persistence::p_bmm_schema::PBmmSchema::schema_id`]) — the
     /// `BMM_CLASS.source_schema_id` of a definition that carries none of its
     /// own (see [`Builder::build_class`]).
-    schema_id: String,
+    pub(super) schema_id: String,
     /// Class definitions by upper-cased name (`primitive_types` first, then
     /// `class_definitions`).
-    classes: BTreeMap<String, ClassEntry<'a>>,
+    pub(super) classes: BTreeMap<String, ClassEntry<'a>>,
     /// Upper-cased class name → the fully qualified path of the package that
     /// lists it.
-    owning_package: BTreeMap<String, String>,
+    pub(super) owning_package: BTreeMap<String, String>,
     /// Upper-cased class name → immediate inheritance descendants (their own
     /// names), sorted.
     descendants: BTreeMap<String, Vec<String>>,
@@ -220,7 +225,7 @@ struct Builder<'a> {
 impl<'a> Builder<'a> {
     /// Indexes `schema`'s classes, package membership and inverted inheritance
     /// graph.
-    fn new(schema: &'a PBmmSchema) -> Result<Self, PBmmReadError> {
+    pub(super) fn new(schema: &'a PBmmSchema) -> Result<Self, PBmmReadError> {
         let mut classes: BTreeMap<String, ClassEntry<'a>> = BTreeMap::new();
         for (class, is_primitive_type) in schema
             .primitive_types
@@ -265,7 +270,11 @@ impl<'a> Builder<'a> {
     }
 
     /// The class definition named `name`, matched case-insensitively.
-    fn entry(&self, context: &str, name: &str) -> Result<&ClassEntry<'a>, PBmmReadError> {
+    pub(super) fn entry(
+        &self,
+        context: &str,
+        name: &str,
+    ) -> Result<&ClassEntry<'a>, PBmmReadError> {
         self.classes
             .get(&name.to_uppercase())
             .ok_or_else(|| PBmmReadError::UnknownType {
@@ -318,14 +327,13 @@ impl<'a> Builder<'a> {
     /// materialisation targets the v2.x model because P_BMM is that generation's
     /// persistence form (`LANG/docs/bmm/master06-persistence.adoc`). So
     /// `P_BMM_CLASS.functions` is preserved in the P_BMM graph and carried no
-    /// further. That is a boundary of the v2 model, NOT of the openEHR specs: the
-    /// **v3** `BMM_CLASS` declares `features`, `functions`, `procedures`,
-    /// `static_properties`, `invariants`, `creators` and `converters`
-    /// (`org.openehr.lang.bmm3.bmm_class.adoc` §Attributes), all of which
-    /// `crate::bmm3` emits.
-    /// TODO: materialise a v3 `BMM_MODEL` so class functions/procedures/invariants
-    /// reach a model (see the module docs' `value_constraint` boundary — the same
-    /// follow-on).
+    /// further HERE. That is a boundary of the v2 model, NOT of the openEHR
+    /// specs: the **v3** `BMM_CLASS` declares `features`, `functions`,
+    /// `procedures`, `static_properties`, `invariants`, `creators` and
+    /// `converters` (`org.openehr.lang.bmm3.bmm_class.adoc` §Attributes), and
+    /// [`crate::bmm_persistence::create_bmm3_model::create_bmm3_model`] lands the
+    /// routines and constants there (invariants excepted — they need an EL parse,
+    /// see that module's docs).
     ///
     /// `BMM_CLASS.source_schema_id` is `1..1` ("Reference to original source
     /// schema defining this class", class doc §Attributes) while an interface
@@ -361,6 +369,7 @@ impl<'a> Builder<'a> {
             is_override: persisted.is_override(),
         };
         if let PBmmClass::PBmmEnumeration(enumeration) = persisted {
+            check_enumeration_validity(name, enumeration)?;
             return Ok(BmmClass::BmmEnumeration(build_enumeration(
                 core,
                 enumeration,
@@ -731,7 +740,7 @@ impl<'a> Builder<'a> {
     /// this class or by the addition of an ancestor class which is generic"
     /// (`org.openehr.lang.bmm.bmm_generic_class.adoc` §Attributes), so the
     /// lookup walks the ancestor graph; it is cycle-safe.
-    fn find_generic_parameter(
+    pub(super) fn find_generic_parameter(
         &self,
         owner: &PBmmClass,
         parameter: &str,
@@ -943,6 +952,48 @@ struct ClassCore {
     is_override: bool,
 }
 
+/// Checks the two `BMM_ENUMERATION` validity rules a persisted enumeration must
+/// satisfy before it can be materialised.
+///
+/// * "may have only one ancestor" (`LANG/docs/bmm3/master07-core-classes.adoc`
+///   §Range-Constrained Classes; `org.openehr.lang.bmm3.bmm_enumeration.adoc`
+///   §Description) — the ancestor provides the base type the range constraint
+///   applies to, which is what `BMM_ENUMERATION.underlying_type_name` names
+///   (`org.openehr.lang.bmm.bmm_enumeration.adoc` §Attributes), so two ancestors
+///   leave it ambiguous. An enumeration with NO ancestor stays legal: the v2
+///   class doc's "It is designed so that the default type is Integer"
+///   (§Description) supplies the base type
+///   ([`crate::bmm_persistence::p_bmm_enumeration_impl::DEFAULT_UNDERLYING_TYPE_NAME`]).
+/// * `item_values` "Must be 1:1 with `item_names` list" (same §Attributes) —
+///   checked only when values are stated, since "If no values are supplied, the
+///   integer values 0, 1, 2, ... are assumed".
+///
+/// # Errors
+/// [`PBmmReadError::EnumerationAncestorCount`] or
+/// [`PBmmReadError::EnumerationItemListsNotOneToOne`].
+pub(super) fn check_enumeration_validity(
+    name: &str,
+    persisted: &PBmmEnumeration,
+) -> Result<(), PBmmReadError> {
+    let ancestors = persisted.ancestors();
+    if ancestors.len() > 1 {
+        return Err(PBmmReadError::EnumerationAncestorCount {
+            class: name.to_owned(),
+            ancestors: ancestors.to_vec(),
+        });
+    }
+    let names = persisted.item_names().len();
+    let values = persisted.item_values().len();
+    if values > 0 && values != names {
+        return Err(PBmmReadError::EnumerationItemListsNotOneToOne {
+            class: name.to_owned(),
+            names,
+            values,
+        });
+    }
+    Ok(())
+}
+
 /// Builds the `BMM_ENUMERATION` form matching the persisted enumeration kind.
 fn build_enumeration(core: ClassCore, persisted: &PBmmEnumeration) -> BmmEnumeration {
     let item_names = persisted.item_names().to_vec();
@@ -1033,7 +1084,7 @@ fn index_packages(
 /// Joins a package name onto its parent path with the
 /// `BMM_DEFINITIONS.Package_name_delimiter` (`"."`,
 /// `org.openehr.lang.bmm.bmm_definitions.adoc` §Constants).
-fn qualify(prefix: &str, name: &str) -> String {
+pub(super) fn qualify(prefix: &str, name: &str) -> String {
     if prefix.is_empty() {
         name.to_owned()
     } else {
@@ -1058,11 +1109,11 @@ fn qualify(prefix: &str, name: &str) -> String {
 /// `ancestors: Hash<String, BMM_MODEL_TYPE>` and states in its §Description that
 /// it "contains a list of _types_ rather than classes"
 /// (`org.openehr.lang.bmm3.bmm_class.adoc`), which DOES carry the binding —
-/// `crate::bmm3` emits that shape.
-/// TODO: materialise a v3 `BMM_MODEL` so a generic ancestor's parameter binding
-/// reaches the model (see the module docs' `value_constraint` boundary — the same
-/// follow-on).
-fn ancestor_names(class: &PBmmClass) -> Vec<String> {
+/// `crate::bmm3` emits that shape, and
+/// [`crate::bmm_persistence::create_bmm3_model::create_bmm3_model`] carries the
+/// binding into it — so the loss is this transform's target generation, not the
+/// pipeline's.
+pub(super) fn ancestor_names(class: &PBmmClass) -> Vec<String> {
     let mut out: Vec<String> = class.ancestors().to_vec();
     out.extend(
         class
@@ -1074,7 +1125,7 @@ fn ancestor_names(class: &PBmmClass) -> Vec<String> {
 }
 
 /// The error context naming one class property.
-fn property_context(class: &str, property: &str) -> String {
+pub(super) fn property_context(class: &str, property: &str) -> String {
     format!("class `{class}` property `{property}`")
 }
 
@@ -1085,7 +1136,7 @@ fn property_context(class: &str, property: &str) -> String {
 /// (`org.openehr.lang.bmm.bmm_container_property.adoc` §Attributes) — "An
 /// Interval of Integer, used to represent multiplicity, cardinality and
 /// optionality in models" (`BASE` `Multiplicity_interval`).
-fn multiplicity_of(interval: &Interval<i32>) -> MultiplicityInterval {
+pub(super) fn multiplicity_of(interval: &Interval<i32>) -> MultiplicityInterval {
     match interval {
         Interval::PointInterval(PointInterval {
             lower,

--- a/crates/openehr-lang/src/bmm_persistence/error.rs
+++ b/crates/openehr-lang/src/bmm_persistence/error.rs
@@ -244,6 +244,52 @@ pub enum PBmmReadError {
         parameter: String,
     },
 
+    /// An enumeration class states more than one inheritance ancestor.
+    ///
+    /// "the `BMM_ENUMERATION` meta-type is defined as a descendant of
+    /// `BMM_SIMPLE_CLASS`, and may have only one ancestor"
+    /// (`LANG/docs/bmm3/master07-core-classes.adoc` §Range-Constrained Classes);
+    /// the class definition repeats it — "Only one inheritance ancestor is
+    /// allowed in order to provide the base type to which the range constraint
+    /// is applied" (`org.openehr.lang.bmm3.bmm_enumeration.adoc` §Description).
+    /// The single ancestor IS the enumeration's underlying type
+    /// (`BMM_ENUMERATION.underlying_type_name` is "the name of type bound to 'T'",
+    /// `org.openehr.lang.bmm.bmm_enumeration.adoc` §Attributes), so a second
+    /// ancestor leaves the underlying type ambiguous.
+    #[error(
+        "enumeration class `{class}` states {} ancestors ({}); an enumeration may have only one",
+        ancestors.len(),
+        ancestors.join(", ")
+    )]
+    EnumerationAncestorCount {
+        /// The enumeration class's name.
+        class: String,
+        /// The ancestors as stated, in schema order.
+        ancestors: Vec<String>,
+    },
+
+    /// An enumeration states `item_values` that are not 1:1 with `item_names`.
+    ///
+    /// `BMM_ENUMERATION.item_values` is an "Optional list of specific values.
+    /// Must be 1:1 with `item_names` list"
+    /// (`org.openehr.lang.bmm.bmm_enumeration.adoc` §Attributes, identically in
+    /// `org.openehr.lang.bmm3.bmm_enumeration.adoc`). Omitting the values
+    /// entirely stays legal — "If no values are supplied, the integer values 0,
+    /// 1, 2, ... are assumed" (same §Attributes) — so only a non-empty list of
+    /// the wrong length is a violation.
+    #[error(
+        "enumeration class `{class}` states {values} item value(s) for {names} item name(s); \
+         `item_values` must be 1:1 with `item_names`"
+    )]
+    EnumerationItemListsNotOneToOne {
+        /// The enumeration class's name.
+        class: String,
+        /// The number of `item_names` stated.
+        names: usize,
+        /// The number of `item_values` stated.
+        values: usize,
+    },
+
     /// A generic type's root class is not generic — `BMM_GENERIC_TYPE.base_class`
     /// is a `BMM_GENERIC_CLASS` (`org.openehr.lang.bmm.bmm_generic_type.adoc`
     /// §Attributes).

--- a/crates/openehr-lang/src/bmm_persistence/mod.rs
+++ b/crates/openehr-lang/src/bmm_persistence/mod.rs
@@ -35,6 +35,7 @@ pub mod p_bmm_single_property_open;
 pub mod p_bmm_type;
 
 // hand-written modules (spec behaviour), auto-declared:
+pub mod create_bmm3_model;
 pub mod create_model;
 pub mod error;
 pub mod include_resolution;

--- a/crates/openehr-lang/src/bmm_persistence/p_bmm_enumeration_impl.rs
+++ b/crates/openehr-lang/src/bmm_persistence/p_bmm_enumeration_impl.rs
@@ -57,6 +57,19 @@ impl PBmmEnumeration {
         enumeration_field!(self, item_values).as_slice()
     }
 
+    /// The inheritance ancestors this persisted enumeration states
+    /// (`P_BMM_CLASS.ancestors`, `org.openehr.lang.bmm_persistence.p_bmm_class.adoc`
+    /// §Attributes).
+    ///
+    /// An enumeration "may have only one ancestor"
+    /// (`LANG/docs/bmm3/master07-core-classes.adoc` §Range-Constrained Classes),
+    /// so this list is the input to that validity rule and to
+    /// [`PBmmEnumeration::underlying_type_name`].
+    #[must_use]
+    pub fn ancestors(&self) -> &[String] {
+        enumeration_field!(self, ancestors).as_slice()
+    }
+
     /// `P_BMM_ENUMERATION.item_documentations`: "Optional documentation strings
     /// for the enumeration items, in the same order as `_item_names_`" (class
     /// doc §Attributes).

--- a/crates/openehr-lang/tests/it/bmm3_model.rs
+++ b/crates/openehr-lang/tests/it/bmm3_model.rs
@@ -1,0 +1,571 @@
+//! The **v3** (`org.openehr.lang.bmm3`) behavioural surface, through its public
+//! API: the type lattice of `LANG/docs/bmm3/master06-core-types.adoc`, the
+//! class/feature functions of `master07-core-classes.adoc` +
+//! `master08-core-features.adoc`, and the `P_BMM` → v3 `BMM_MODEL`
+//! materialisation.
+//!
+//! Most cases run over the vendored openEHR RM 1.0.2 inclusion chain
+//! (`tests/vendor/bmm/openehr/`), so what is pinned is the real corpus rather than
+//! a hand-shaped fixture. Three v3-only capabilities the RM 1.0.2 corpus never
+//! states — a generic ancestor's parameter SUBSTITUTION, class routines, and a
+//! value-set constrained type — are exercised over the small hand-written
+//! [`ROUTINE_SCHEMA`], whose every construct is taken from
+//! `LANG/docs/bmm_persistence/master04-syntax.adoc`.
+
+#![expect(
+    clippy::panic_in_result_fn,
+    reason = "the Book ch11 test shape: `?` propagates the read/resolve/model plumbing while the assertions ARE the test — an assertion panic is how these tests fail"
+)]
+#![expect(
+    clippy::expect_used,
+    clippy::panic,
+    reason = "integration-test assertions and fixture plumbing outside #[test] fns, which the clippy.toml allow-*-in-tests scoping does not reach"
+)]
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use openehr_lang::bmm_persistence::create_bmm3_model::create_bmm3_model;
+use openehr_lang::bmm_persistence::error::PBmmReadError;
+use openehr_lang::bmm_persistence::include_resolution::resolve_includes;
+use openehr_lang::bmm_persistence::p_bmm_schema::PBmmSchema;
+use openehr_lang::bmm_persistence::reader::read_schema;
+use openehr_lang::bmm3::core::entity::bmm_class::BmmClass;
+use openehr_lang::bmm3::core::entity::bmm_model_type::BmmModelType;
+use openehr_lang::bmm3::core::entity::bmm_simple_class::BmmSimpleClass;
+use openehr_lang::bmm3::core::entity::bmm_type::BmmType;
+use openehr_lang::bmm3::core::entity::bmm_unitary_type::BmmUnitaryType;
+use openehr_lang::bmm3::core::entity::range_constrained::bmm_enumeration::BmmEnumeration;
+use openehr_lang::bmm3::core::feature::bmm_property::BmmProperty;
+use openehr_lang::bmm3::core::model::bmm_model::BmmModel;
+
+/// The vendored openEHR RM 1.0.2 inclusion chain, deepest first.
+const CHAIN: &[&str] = &[
+    "openehr_primitive_types_102.bmm",
+    "openehr_basic_types_102.bmm",
+    "openehr_structures_102.bmm",
+    "openehr_ehr_102.bmm",
+];
+
+/// The source of one vendored chain file.
+fn vendored(file: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/vendor/bmm/openehr")
+        .join(file);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+/// The v3 model of the RM 1.0.2 chain's top schema (`openehr_ehr_102.bmm`), with
+/// the three included schemas resolved into it.
+fn rm_model() -> Result<BmmModel, PBmmReadError> {
+    let mut available: BTreeMap<String, PBmmSchema> = BTreeMap::new();
+    let mut top: Option<PBmmSchema> = None;
+    for file in CHAIN {
+        let schema = read_schema(&vendored(file))?;
+        available.insert(schema.schema_id(), schema.clone());
+        top = Some(schema);
+    }
+    let resolved = resolve_includes(top.expect("the chain is non-empty"), &available)?;
+    create_bmm3_model(&resolved)
+}
+
+/// The class named `name` in `model`.
+fn class<'a>(model: &'a BmmModel, name: &str) -> &'a BmmClass {
+    model
+        .class_definitions
+        .as_ref()
+        .expect("the model defines classes")
+        .get(name)
+        .unwrap_or_else(|| panic!("{name} is missing from the model"))
+}
+
+/// `master07-core-classes.adoc` §Overview: the model materialises as v3 classes,
+/// each of which is also a `BMM_MODULE` (§Inherit), and both maps cover the same
+/// population (`…bmm3.bmm_model.adoc` §Attributes).
+#[test]
+fn the_vendored_rm_chain_materialises_a_v3_model() -> Result<(), PBmmReadError> {
+    let model = rm_model()?;
+    let classes = model
+        .class_definitions
+        .as_ref()
+        .expect("the model defines classes");
+    let modules = model.modules.as_ref().expect("the model lists modules");
+    assert_eq!(classes.len(), modules.len());
+    assert!(
+        classes.len() > 100,
+        "the RM 1.0.2 chain materialised only {} classes",
+        classes.len(),
+    );
+    assert_eq!(model.rm_publisher, "openehr");
+    assert_eq!(model.rm_release, "1.0.2");
+    assert!(model.packages.is_some(), "no package tree materialised");
+    Ok(())
+}
+
+/// `…bmm3.bmm_class.adoc` §Description: `_ancestors_` "contains a list of _types_
+/// rather than classes" — so an ordinary ancestor is a `BMM_SIMPLE_TYPE` over the
+/// parent class, and `has_ancestor_class` walks it (case-insensitively, per
+/// `master06-core-types.adoc` §Type Conformance).
+#[test]
+fn ancestors_are_types_and_the_inheritance_walk_reads_them() -> Result<(), PBmmReadError> {
+    let model = rm_model()?;
+    let element = class(&model, "ELEMENT");
+    let ancestors = element.ancestors().expect("ELEMENT states ancestors");
+    assert!(
+        ancestors
+            .values()
+            .any(|a| matches!(a, BmmModelType::BmmSimpleType(_))),
+        "no simple-type ancestor materialised for ELEMENT",
+    );
+    assert!(element.has_ancestor_class("LOCATABLE"));
+    assert!(element.has_ancestor_class("locatable"));
+    assert!(!element.has_ancestor_class("DV_TEXT"));
+    assert!(element.all_ancestors().iter().any(|n| n == "ITEM"));
+    Ok(())
+}
+
+/// `master13-model_semantics.adoc` §Generic Inheritance: an ancestor that is a
+/// generic class materialises as a generic TYPE carrying its parameter list —
+/// `DV_INTERVAL` inherits `Interval<T>` in the vendored RM chain, where the
+/// persisted form names the ancestor without a substitution, so the ancestor type
+/// is the parent's fully open one.
+#[test]
+fn a_generic_ancestor_materialises_as_a_generic_type() -> Result<(), PBmmReadError> {
+    let model = rm_model()?;
+    let interval = class(&model, "DV_INTERVAL");
+    let ancestors = interval.ancestors().expect("DV_INTERVAL states ancestors");
+    let generic = ancestors
+        .values()
+        .find_map(|a| match a {
+            BmmModelType::BmmGenericType(generic) => Some(generic),
+            BmmModelType::BmmSimpleType(_) => None,
+        })
+        .expect("DV_INTERVAL inherits a generic type");
+    assert_eq!(generic.base_class.name, "Interval");
+    assert_eq!(
+        generic
+            .generic_parameters
+            .iter()
+            .map(BmmUnitaryType::type_name)
+            .collect::<Vec<_>>(),
+        vec!["T".to_owned()],
+        "the ancestor's parameter substitution was not carried",
+    );
+    Ok(())
+}
+
+/// `master07-core-classes.adoc` §Range-Constrained Classes + §7.8: enumeration
+/// values are literal-value objects, not raw JSON — `item_values` is
+/// `List<BMM_PRIMITIVE_VALUE>` (`…bmm3.bmm_enumeration.adoc` §Attributes),
+/// redefined to `List<BMM_INTEGER_VALUE>` by the integer form.
+#[test]
+fn an_enumeration_lands_typed_item_values_and_a_name_map() -> Result<(), PBmmReadError> {
+    let model = rm_model()?;
+    let BmmClass::BmmSimpleClass(BmmSimpleClass::BmmEnumeration(enumeration)) =
+        class(&model, "PROPORTION_KIND")
+    else {
+        panic!("PROPORTION_KIND did not materialise as an enumeration");
+    };
+    let BmmEnumeration::BmmEnumerationInteger(integer) = enumeration else {
+        panic!("PROPORTION_KIND is an integer enumeration");
+    };
+    assert_eq!(integer.item_names.len(), 5);
+    // The vendored PROPORTION_KIND states names only, so the spec's assumed
+    // values (0, 1, 2, ...) are what the name map reports
+    // (`…bmm3.bmm_enumeration.adoc` §Attributes).
+    assert!(integer.item_values.is_empty());
+    let names = enumeration.name_map();
+    assert_eq!(names.get("pk_ratio").map(String::as_str), Some("0"));
+    assert_eq!(names.get("pk_percent").map(String::as_str), Some("2"));
+    assert_eq!(names.len(), 5);
+    Ok(())
+}
+
+/// `master08-core-features.adoc` §Overview: a v3 class carries its features in
+/// `_features_` with the specific maps as subsets — and `flat_features` is
+/// "Consolidated list of all feature definitions from this class and all
+/// inheritance ancestors" (`…bmm3.bmm_class.adoc` §Functions).
+#[test]
+fn class_features_are_populated_and_flatten_over_ancestors() -> Result<(), PBmmReadError> {
+    let model = rm_model()?;
+    let element = class(&model, "ELEMENT");
+    let properties = element.properties().expect("ELEMENT declares properties");
+    assert!(properties.contains_key("value"));
+    assert_eq!(element.features().len(), properties.len());
+    let flat = element.flat_features();
+    assert!(
+        flat.len() > element.features().len(),
+        "flat_features did not pick up inherited features ({} vs {})",
+        flat.len(),
+        element.features().len(),
+    );
+    // `name` is declared by LOCATABLE, an ancestor — the flat set has it, the
+    // differential set does not.
+    assert!(flat.iter().any(|f| f.name() == "name"));
+    assert!(!element.features().iter().any(|f| f.name() == "name"));
+    Ok(())
+}
+
+/// `master06-core-types.adoc` §Overview rows 2-3 + `…bmm3.bmm_model_type.adoc`
+/// §Functions: a type answers `is_abstract` / `is_primitive` / `type_base_name`
+/// from its base class.
+#[test]
+fn a_model_type_answers_abstractness_primitiveness_and_base_name()
+-> Result<(), Box<dyn std::error::Error>> {
+    let model = rm_model()?;
+    // LOCATABLE is abstract in the RM; String is a primitive_types class.
+    let locatable = class(&model, "LOCATABLE").r#type();
+    assert!(locatable.is_abstract());
+    assert!(!locatable.is_primitive());
+    assert_eq!(locatable.type_base_name(), "LOCATABLE");
+
+    let element = class(&model, "ELEMENT").r#type();
+    assert!(!element.is_abstract());
+
+    let value = class(&model, "ELEMENT")
+        .properties()
+        .ok_or("ELEMENT declares properties")?
+        .get("value")
+        .ok_or("ELEMENT.value")?;
+    let BmmProperty::BmmUnitaryProperty(value) = value else {
+        return Err("ELEMENT.value is a unitary property".into());
+    };
+    // DATA_VALUE is abstract, so the type of `value` is an abstract type.
+    assert!(value.r#type.is_abstract());
+    assert_eq!(value.r#type.type_name(), "DATA_VALUE");
+    Ok(())
+}
+
+/// `…bmm3.bmm_container_type.adoc` §Functions: `unitary_type()` returns
+/// `_item_type_`, `effective_type()` returns the item's effective type, and
+/// `flattened_type_list` is the item's — while `…bmm3.bmm_unitary_type.adoc`
+/// §Functions makes `unitary_type()` the identity on a unitary type.
+#[test]
+fn a_container_type_reduces_to_its_item_type() -> Result<(), Box<dyn std::error::Error>> {
+    let model = rm_model()?;
+    let items = class(&model, "ITEM_LIST")
+        .properties()
+        .ok_or("ITEM_LIST declares properties")?
+        .get("items")
+        .ok_or("ITEM_LIST.items")?;
+    let BmmProperty::BmmContainerProperty(items) = items else {
+        return Err("ITEM_LIST.items is a container property".into());
+    };
+    let container = items.r#type();
+    assert_eq!(container.type_name(), "List<ELEMENT>");
+    assert_eq!(container.unitary_type().type_name(), "ELEMENT");
+    assert_eq!(container.flattened_type_list(), vec!["ELEMENT".to_owned()]);
+    assert_eq!(
+        container
+            .effective_type()
+            .map(|effective| effective.type_name()),
+        Some("ELEMENT".to_owned()),
+    );
+    // The whole-type dispatch agrees with the container-level one.
+    let whole = BmmType::BmmContainerType(Box::new(container));
+    assert_eq!(whole.unitary_type().type_name(), "ELEMENT");
+    Ok(())
+}
+
+/// `…bmm3.bmm_generic_class.adoc` §Functions: `type()` generates a "fully open"
+/// generic type, `generic_parameter_conformance_type` answers the parameter's
+/// constraint (`Any` when unconstrained), and `…bmm3.bmm_generic_type.adoc`
+/// §Functions distinguishes open from partially closed.
+#[test]
+fn a_generic_class_generates_its_fully_open_type() -> Result<(), Box<dyn std::error::Error>> {
+    let model = rm_model()?;
+    let BmmClass::BmmGenericClass(interval) = class(&model, "Interval") else {
+        return Err("Interval is a generic class".into());
+    };
+    let open = interval.r#type();
+    assert_eq!(open.type_name(), "Interval<T>");
+    // Fully open: no parameter has been substituted.
+    assert!(!open.is_partially_closed());
+    assert!(!open.is_open(), "a fully open type is not closed");
+    assert_eq!(
+        interval.generic_parameter_conformance_type("T"),
+        Some("Ordered".to_owned()),
+    );
+    // Case-insensitive parameter lookup, and no answer for a parameter the class
+    // does not declare.
+    assert_eq!(
+        interval.generic_parameter_conformance_type("t"),
+        Some("Ordered".to_owned()),
+    );
+    assert_eq!(interval.generic_parameter_conformance_type("Z"), None);
+
+    // The DV_INTERVAL ancestor type substitutes T, so it IS partially closed
+    // relative to its own parameter list only when the substitution is concrete;
+    // the ancestor here carries the still-formal `T`.
+    let signature = open.type_signature();
+    assert_eq!(signature, "Interval<T:Ordered>");
+    Ok(())
+}
+
+/// `master06-core-types.adoc` §Overview L41-45: a formal parameter is a unitary
+/// type whose effective type is its constraint, "or if not set, `'Any'`"
+/// (`…bmm3.bmm_parameter_type.adoc` §Functions) — the `None` case here, since
+/// `Any` is a class of the model rather than a type object the parameter carries.
+#[test]
+fn a_formal_parameter_reduces_to_its_constraint() -> Result<(), Box<dyn std::error::Error>> {
+    let model = rm_model()?;
+    let BmmClass::BmmGenericClass(interval) = class(&model, "Interval") else {
+        return Err("Interval is a generic class".into());
+    };
+    let parameter = interval
+        .generic_parameters
+        .get("T")
+        .ok_or("Interval declares T")?;
+    assert!(!parameter.is_abstract());
+    assert!(!parameter.is_primitive());
+    assert_eq!(
+        parameter.effective_type().map(|e| e.type_name()),
+        Some("Ordered".to_owned()),
+    );
+    assert_eq!(parameter.type_signature(), "T:Ordered");
+
+    // An unconstrained parameter has no effective type object; its conformance
+    // name is the `Any` top.
+    let unconstrained = openehr_lang::bmm3::core::entity::bmm_parameter_type::BmmParameterType {
+        name: "U".to_owned(),
+        type_constraint: None,
+        inheritance_precursor: None,
+    };
+    assert_eq!(unconstrained.effective_type(), None);
+    assert_eq!(unconstrained.conformance_type_name(), "Any");
+    Ok(())
+}
+
+/// A hand-written schema exercising the three things the v3 materialisation
+/// carries and the vendored RM 1.0.2 corpus does not state: generic inheritance
+/// WITH a substitution, class routines, and a value-set constrained property
+/// type.
+///
+/// `master04-syntax.adoc` §Inheritance (`ancestor_defs`), §Class Definitions
+/// (`functions`), §Value-set Constraints (`value_constraint`).
+const ROUTINE_SCHEMA: &str = r#"
+    bmm_version = <"2.4">
+    rm_publisher = <"openehr">
+    schema_name = <"bmm3_routines">
+    rm_release = <"1.0.2">
+    packages = <
+        ["test"] = <
+            name = <"test">
+            classes = <"String", "Boolean", "Integer", "SUPPLIER", "SUPPLIER_A", "SUPPLIER_B", "CODE_PHRASE", "GENERIC_PARENT", "GENERIC_CHILD_OPEN_T", "SERVICE">
+        >
+    >
+    class_definitions = <
+        ["String"] = < name = <"String"> >
+        ["Boolean"] = < name = <"Boolean"> >
+        ["Integer"] = < name = <"Integer"> >
+        ["CODE_PHRASE"] = < name = <"CODE_PHRASE"> >
+        ["SUPPLIER"] = < name = <"SUPPLIER"> >
+        ["SUPPLIER_A"] = < name = <"SUPPLIER_A"> ancestors = <"SUPPLIER"> >
+        ["SUPPLIER_B"] = < name = <"SUPPLIER_B"> ancestors = <"SUPPLIER"> >
+        ["GENERIC_PARENT"] = <
+            name = <"GENERIC_PARENT">
+            generic_parameter_defs = <
+                ["T"] = < name = <"T"> conforms_to_type = <"SUPPLIER"> >
+                ["U"] = < name = <"U"> conforms_to_type = <"SUPPLIER"> >
+            >
+            properties = <
+                ["parent_prop"] = (P_BMM_SINGLE_PROPERTY_OPEN) < name = <"parent_prop"> type = <"T"> >
+            >
+        >
+        ["GENERIC_CHILD_OPEN_T"] = <
+            name = <"GENERIC_CHILD_OPEN_T">
+            ancestor_defs = <
+                ["GENERIC_PARENT<T,SUPPLIER_B>"] = (P_BMM_GENERIC_TYPE) <
+                    root_type = <"GENERIC_PARENT">
+                    generic_parameters = <"T", "SUPPLIER_B">
+                >
+            >
+            generic_parameter_defs = <
+                ["T"] = < name = <"T"> conforms_to_type = <"SUPPLIER"> >
+            >
+            properties = <
+                ["child_prop"] = (P_BMM_SINGLE_PROPERTY) < name = <"child_prop"> type = <"String"> >
+            >
+        >
+        ["SERVICE"] = <
+            name = <"SERVICE">
+            properties = <
+                ["language"] = (P_BMM_SINGLE_PROPERTY) <
+                    name = <"language">
+                    type_ref = <
+                        type = <"CODE_PHRASE">
+                        value_constraint = <"openEHR::languages">
+                    >
+                >
+            >
+            constants = <
+                ["Max_retries"] = < name = <"Max_retries"> type = <"Integer"> value = <"3"> >
+            >
+            functions = <
+                ["is_available"] = <
+                    name = <"is_available">
+                    result = (P_BMM_SIMPLE_TYPE) < type = <"Boolean"> >
+                >
+                ["has_code"] = <
+                    name = <"has_code">
+                    parameters = <
+                        ["a_code"] = (P_BMM_SINGLE_FUNCTION_PARAMETER) < name = <"a_code"> type = <"String"> >
+                    >
+                    result = (P_BMM_SIMPLE_TYPE) < type = <"Boolean"> >
+                >
+                ["reset"] = <
+                    name = <"reset">
+                >
+            >
+        >
+    >
+"#;
+
+/// The v3 model of [`ROUTINE_SCHEMA`].
+fn routine_model() -> Result<BmmModel, PBmmReadError> {
+    create_bmm3_model(&read_schema(ROUTINE_SCHEMA)?)
+}
+
+/// `master13-model_semantics.adoc` §Generic Inheritance: "the formal parameters
+/// of the inheriting class may further constrain any of the ancestor type's
+/// formal parameters", and a substituted parameter is carried — the binding the
+/// v2.x `ancestors: Hash<String, BMM_CLASS>` cannot hold.
+#[test]
+fn a_generic_ancestor_carries_its_parameter_substitution() -> Result<(), Box<dyn std::error::Error>>
+{
+    let model = routine_model()?;
+    let child = class(&model, "GENERIC_CHILD_OPEN_T");
+    let ancestors = child
+        .ancestors()
+        .ok_or("GENERIC_CHILD_OPEN_T states ancestors")?;
+    let parent = ancestors
+        .get("GENERIC_PARENT")
+        .ok_or("the generic ancestor")?;
+    let BmmModelType::BmmGenericType(parent) = parent else {
+        return Err("the ancestor is a generic type".into());
+    };
+    assert_eq!(
+        parent
+            .generic_parameters
+            .iter()
+            .map(BmmUnitaryType::type_name)
+            .collect::<Vec<_>>(),
+        vec!["T".to_owned(), "SUPPLIER_B".to_owned()],
+        "the ancestor's `<T,SUPPLIER_B>` substitution was not carried",
+    );
+    // The still-open half is a formal parameter, the substituted half a model
+    // type — so the ancestor type is partially closed
+    // (`…bmm3.bmm_generic_type.adoc` §Functions).
+    assert!(parent.is_partially_closed());
+    assert!(!parent.is_open());
+    assert_eq!(parent.type_name(), "GENERIC_PARENT<T,SUPPLIER_B>");
+    Ok(())
+}
+
+/// `master08-core-features.adoc` §Functions and Procedures + §Class Definitions:
+/// a persisted function with a result materialises as a `BMM_FUNCTION` (with its
+/// `Result` variable, `arity()` and `signature()`), one without as a
+/// `BMM_PROCEDURE` (`…bmm_persistence.p_bmm_function.adoc` §Attributes: a result
+/// is "absent for procedures").
+#[test]
+fn class_routines_reach_the_model_with_signatures_and_arity()
+-> Result<(), Box<dyn std::error::Error>> {
+    let model = routine_model()?;
+    let service = class(&model, "SERVICE");
+    let functions = service.functions().ok_or("SERVICE declares functions")?;
+    let procedures = service.procedures().ok_or("SERVICE declares procedures")?;
+    assert_eq!(functions.len(), 2);
+    assert_eq!(procedures.len(), 1);
+
+    let is_available = functions
+        .get("is_available")
+        .ok_or("SERVICE.is_available")?;
+    assert_eq!(is_available.arity(), 0);
+    assert!(is_available.is_boolean());
+    assert_eq!(is_available.signature().argument_types, None);
+    assert_eq!(is_available.signature().result_type.type_name(), "Boolean");
+    // `Inv_result_type`: `type = Result.type` (`…bmm3.bmm_function.adoc`
+    // §Invariants).
+    assert_eq!(is_available.result.r#type.type_name(), "Boolean");
+    assert_eq!(is_available.result.name, "Result");
+
+    let has_code = functions.get("has_code").ok_or("SERVICE.has_code")?;
+    assert_eq!(has_code.arity(), 1);
+    let signature = has_code.signature();
+    let arguments = signature.argument_types.ok_or("has_code takes arguments")?;
+    assert_eq!(
+        arguments
+            .item_types
+            .iter()
+            .map(|(name, r#type)| (name.clone(), r#type.type_name()))
+            .collect::<Vec<_>>(),
+        vec![("a_code".to_owned(), "String".to_owned())],
+    );
+
+    let reset = procedures.get("reset").ok_or("SERVICE.reset")?;
+    assert_eq!(reset.arity(), 0);
+    assert!(!reset.is_boolean());
+    // A procedure's signature result is the built-in Status meta-type
+    // (`…bmm3.bmm_procedure_type.adoc` §Description).
+    assert!(reset.signature().result_type.is_some());
+
+    // Every routine is also a feature of the class (`master07-core-classes.adoc`
+    // §Overview — the specific maps are subsets of `_features_`).
+    assert!(
+        service
+            .features()
+            .iter()
+            .any(|f| f.name() == "is_available")
+    );
+    assert!(service.features().iter().any(|f| f.name() == "reset"));
+    Ok(())
+}
+
+/// `master07-core-classes.adoc` §Value-set Types: a persisted `value_constraint`
+/// lands on the TYPE as a `BMM_VALUE_SET_SPEC`, split around `::`.
+#[test]
+fn a_value_set_constraint_lands_on_the_property_type() -> Result<(), Box<dyn std::error::Error>> {
+    let model = routine_model()?;
+    let language = class(&model, "SERVICE")
+        .properties()
+        .ok_or("SERVICE declares properties")?
+        .get("language")
+        .ok_or("SERVICE.language")?;
+    let BmmProperty::BmmUnitaryProperty(language) = language else {
+        return Err("SERVICE.language is a unitary property".into());
+    };
+    let BmmUnitaryType::BmmSimpleType(simple) = &language.r#type else {
+        return Err("SERVICE.language is of a simple type".into());
+    };
+    let spec = simple
+        .value_constraint
+        .as_ref()
+        .ok_or("the value-set constraint reached the type")?;
+    assert_eq!(spec.resource_id, "openEHR");
+    assert_eq!(spec.value_set_id, "languages");
+    Ok(())
+}
+
+/// `master08-core-features.adoc` §Properties: a persisted constant materialises
+/// as a `BMM_CONSTANT` static property whose `generator` carries the serialised
+/// literal (`…bmm3.bmm_constant.adoc` §Attributes).
+#[test]
+fn a_class_constant_materialises_with_its_literal_generator()
+-> Result<(), Box<dyn std::error::Error>> {
+    let model = routine_model()?;
+    let statics = class(&model, "SERVICE")
+        .static_properties()
+        .ok_or("SERVICE declares static properties")?;
+    let openehr_lang::bmm3::core::feature::bmm_static::BmmStatic::BmmConstant(constant) =
+        statics.get("Max_retries").ok_or("SERVICE.Max_retries")?
+    else {
+        return Err("Max_retries is a constant".into());
+    };
+    assert_eq!(constant.r#type.type_name(), "Integer");
+    assert_eq!(constant.is_nullable, Some(false));
+    assert_eq!(constant.generator.value_literal(), "3");
+    // `_syntax_` unset means the `json` default applies
+    // (`…bmm3.bmm_literal_value.adoc` §Attributes).
+    assert_eq!(constant.generator.syntax(), "json");
+    Ok(())
+}

--- a/crates/openehr-lang/tests/it/bmm_enumeration_validity.rs
+++ b/crates/openehr-lang/tests/it/bmm_enumeration_validity.rs
@@ -1,0 +1,181 @@
+//! The `BMM_ENUMERATION` validity rules, driven through the public `P_BMM`
+//! pipeline (`read_schema` → `create_bmm_model`).
+//!
+//! Two rules, each with BOTH twins — the accepted valid shape and the refused
+//! invalid one:
+//!
+//! * an enumeration "may have only one ancestor"
+//!   (`docs/specs/openehr/LANG/docs/bmm3/master07-core-classes.adoc`
+//!   §Range-Constrained Classes; `org.openehr.lang.bmm3.bmm_enumeration.adoc`
+//!   §Description: "Only one inheritance ancestor is allowed in order to provide
+//!   the base type to which the range constraint is applied");
+//! * `item_values` is "Optional list of specific values. Must be 1:1 with
+//!   `item_names` list" (`org.openehr.lang.bmm.bmm_enumeration.adoc`
+//!   §Attributes), while omitting the values entirely stays legal ("If no values
+//!   are supplied, the integer values 0, 1, 2, ... are assumed").
+
+#![expect(
+    clippy::panic_in_result_fn,
+    reason = "the Book ch11 test shape: `?` propagates the read/model plumbing while the assertions ARE the test — an assertion panic is how these tests fail"
+)]
+
+use openehr_lang::bmm_persistence::create_model::create_bmm_model;
+use openehr_lang::bmm_persistence::error::PBmmReadError;
+use openehr_lang::bmm_persistence::p_bmm_schema::PBmmSchema;
+use openehr_lang::bmm_persistence::reader::read_schema;
+
+/// `master04-syntax.adoc` §Header Items — the four mandatory header items.
+const HEADER: &str = r#"
+    bmm_version = <"2.4">
+    rm_publisher = <"openehr">
+    schema_name = <"enum_validity">
+    rm_release = <"1.0.2">
+"#;
+
+/// A schema whose single package lists the two primitive base classes plus the
+/// enumeration under test, with `enumeration` supplying the enumeration's own
+/// `class_definitions` block.
+fn schema(enumeration: &str) -> Result<PBmmSchema, PBmmReadError> {
+    read_schema(&format!(
+        r#"{HEADER}
+        packages = <
+            ["test"] = <
+                name = <"test">
+                classes = <"Integer", "String", "TASK_LIFECYCLE">
+            >
+        >
+        class_definitions = <
+            ["Integer"] = <
+                name = <"Integer">
+            >
+            ["String"] = <
+                name = <"String">
+            >
+            {enumeration}
+        >
+        "#
+    ))
+}
+
+/// The `master07-core-classes.adoc` §Range-Constrained Classes `TASK_LIFECYCLE`
+/// example: one ancestor, names and values 1:1.
+#[test]
+fn a_single_ancestor_enumeration_with_paired_values_materialises()
+-> Result<(), Box<dyn std::error::Error>> {
+    let parsed = schema(
+        r#"["TASK_LIFECYCLE"] = (P_BMM_ENUMERATION_INTEGER) <
+                name = <"TASK_LIFECYCLE">
+                ancestors = <"Integer">
+                item_names = <"planned", "available", "cancelled">
+                item_values = <0, 1, 2>
+            >"#,
+    )?;
+    let model = create_bmm_model(&parsed)?;
+    let classes = model
+        .class_definitions
+        .as_ref()
+        .ok_or("the model defines no classes")?;
+    let enumeration = classes
+        .get("TASK_LIFECYCLE")
+        .ok_or("TASK_LIFECYCLE is missing from the model")?;
+    assert_eq!(
+        enumeration.ancestors().map(std::collections::BTreeMap::len),
+        Some(1),
+    );
+    Ok(())
+}
+
+/// "If no values are supplied, the integer values 0, 1, 2, ... are assumed" — an
+/// enumeration stating names only is valid.
+#[test]
+fn an_enumeration_stating_names_only_materialises() -> Result<(), Box<dyn std::error::Error>> {
+    let parsed = schema(
+        r#"["TASK_LIFECYCLE"] = (P_BMM_ENUMERATION_STRING) <
+                name = <"TASK_LIFECYCLE">
+                ancestors = <"String">
+                item_names = <"planned", "available", "cancelled">
+            >"#,
+    )?;
+    create_bmm_model(&parsed)?;
+    Ok(())
+}
+
+/// An enumeration with NO ancestor is still valid — the v2 class doc supplies
+/// the base type ("It is designed so that the default type is Integer",
+/// `org.openehr.lang.bmm.bmm_enumeration.adoc` §Description).
+#[test]
+fn an_enumeration_without_an_ancestor_materialises() -> Result<(), Box<dyn std::error::Error>> {
+    let parsed = schema(
+        r#"["TASK_LIFECYCLE"] = (P_BMM_ENUMERATION) <
+                name = <"TASK_LIFECYCLE">
+                item_names = <"planned", "available">
+            >"#,
+    )?;
+    create_bmm_model(&parsed)?;
+    Ok(())
+}
+
+/// The invalid twin of the one-ancestor rule: two ancestors leave the base type
+/// the range constraint applies to ambiguous, so materialisation refuses.
+#[test]
+fn two_ancestors_are_refused() -> Result<(), PBmmReadError> {
+    let parsed = schema(
+        r#"["TASK_LIFECYCLE"] = (P_BMM_ENUMERATION) <
+                name = <"TASK_LIFECYCLE">
+                ancestors = <"Integer", "String">
+                item_names = <"planned", "available">
+            >"#,
+    )?;
+    assert_eq!(
+        create_bmm_model(&parsed).err(),
+        Some(PBmmReadError::EnumerationAncestorCount {
+            class: "TASK_LIFECYCLE".to_owned(),
+            ancestors: vec!["Integer".to_owned(), "String".to_owned()],
+        }),
+    );
+    Ok(())
+}
+
+/// The invalid twin of the 1:1 rule: three names against two stated values.
+#[test]
+fn item_values_that_are_not_one_to_one_are_refused() -> Result<(), PBmmReadError> {
+    let parsed = schema(
+        r#"["TASK_LIFECYCLE"] = (P_BMM_ENUMERATION_INTEGER) <
+                name = <"TASK_LIFECYCLE">
+                ancestors = <"Integer">
+                item_names = <"planned", "available", "cancelled">
+                item_values = <0, 1>
+            >"#,
+    )?;
+    assert_eq!(
+        create_bmm_model(&parsed).err(),
+        Some(PBmmReadError::EnumerationItemListsNotOneToOne {
+            class: "TASK_LIFECYCLE".to_owned(),
+            names: 3,
+            values: 2,
+        }),
+    );
+    Ok(())
+}
+
+/// More values than names is the same violation from the other side.
+#[test]
+fn more_values_than_names_are_refused() -> Result<(), PBmmReadError> {
+    let parsed = schema(
+        r#"["TASK_LIFECYCLE"] = (P_BMM_ENUMERATION_INTEGER) <
+                name = <"TASK_LIFECYCLE">
+                ancestors = <"Integer">
+                item_names = <"planned">
+                item_values = <0, 1, 2>
+            >"#,
+    )?;
+    assert_eq!(
+        create_bmm_model(&parsed).err(),
+        Some(PBmmReadError::EnumerationItemListsNotOneToOne {
+            class: "TASK_LIFECYCLE".to_owned(),
+            names: 1,
+            values: 3,
+        }),
+    );
+    Ok(())
+}

--- a/crates/openehr-lang/tests/it/main.rs
+++ b/crates/openehr-lang/tests/it/main.rs
@@ -9,6 +9,8 @@
 //! (`.claude/rules/testing.md` §One integration-test binary per crate).
 
 mod bel_parse;
+mod bmm3_model;
+mod bmm_enumeration_validity;
 mod escape_validation;
 mod lexer_equivalence;
 mod odin_spec_examples;

--- a/tools/openehr-codegen/src/plan/mod.rs
+++ b/tools/openehr-codegen/src/plan/mod.rs
@@ -72,6 +72,21 @@ pub(crate) fn decide<'a>(
             // in this schema (e.g. `AUTHORED_RESOURCE` in BASE — its concretes
             // live in AM). Emit its own fields as a struct so the reference
             // resolves; a cross-schema pass can promote it to an enum later.
+            //
+            // NOTE (adjudicated boundary): when such a class also declares NO
+            // attributes, the emission is an instantiable EMPTY struct, so the
+            // class's abstractness is not encoded. LANG BMM3's `BMM_VISIBILITY`
+            // and `BMM_FEATURE_EXTENSION` are the live instances
+            // (`…bmm3.bmm_visibility.adoc`, `…bmm3.bmm_feature_extension.adoc`:
+            // abstract, zero attributes, zero declared descendants — upstream
+            // states the visibility meta-model is unfinished,
+            // `LANG/docs/bmm3/master08-core-features.adoc` §Feature Groups and
+            // Visibility "TBD: define visibility meta-model"). No better shape
+            // exists: an enum needs variants, and inventing them would fork the
+            // vendored model. A future declared subtype set turns each into an
+            // untagged enum through this same branch, and a hand-written
+            // extender would be a `plan::overrides::SUBTYPE_EXTENSIONS` entry
+            // rather than a Rust `impl`.
             Emission::Struct
         } else {
             Emission::Skip

--- a/tools/openehr-codegen/src/plan/overrides.rs
+++ b/tools/openehr-codegen/src/plan/overrides.rs
@@ -289,6 +289,20 @@ pub(crate) const CLASS_BINDINGS: &[ClassBinding] = &[
         reason: "openEHR files it under primitive_types without carrying the Interval<Integer> binding.",
     },
     ClassBinding {
+        class: "BMM_CONTAINER_VALUE",
+        param: "T",
+        concrete: "BMM_CONTAINER_TYPE",
+        citation: "LANG bmm3 master09-core-values.adoc §Container Literals — a container literal's \"`_type_` will be `BMM_CONTAINER_TYPE`\"",
+        reason: "BMM_LITERAL_VALUE<T>.type is inherited open; the chapter states the narrowing the bmm3 class definition omits (openEHR's own LANG 1.0.0 BMM declares `type: BMM_CONTAINER_TYPE` here).",
+    },
+    ClassBinding {
+        class: "BMM_INDEXED_CONTAINER_VALUE",
+        param: "T",
+        concrete: "BMM_INDEXED_CONTAINER_TYPE",
+        citation: "LANG bmm3 master09-core-values.adoc §Container Literals — a `Hash<K,V>` literal \"has as its meta-type `BMM_INDEXED_CONTAINER_VALUE`\", the indexed analogue of the container-literal narrowing",
+        reason: "BMM_LITERAL_VALUE<T>.type is inherited open; openEHR's own LANG 1.0.0 BMM declares `type: BMM_INDEXED_CONTAINER_TYPE` here.",
+    },
+    ClassBinding {
         class: "X_VERSIONED_COMPOSITION",
         param: "T",
         concrete: "COMPOSITION",
@@ -482,6 +496,65 @@ pub(crate) fn type_override(class: &str, field: &str) -> Option<&'static str> {
         .iter()
         .find(|o| o.class == class && o.field == field)
         .map(|o| o.rust_type)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Adjudicated free-form (`serde_json::Value`) fields
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// One adjudicated free-form field: `(class, field)` renders as
+/// `serde_json::Value` and that degrade is a recorded decision, not an
+/// oversight. The emitter writes the citation + reason as a `// NOTE:` directly
+/// above the generated field, so the adjudication is readable where the untyped
+/// slot is.
+pub(crate) struct UntypedField {
+    /// The BMM class owning (or inheriting) the field.
+    pub class: &'static str,
+    /// The BMM property name.
+    pub field: &'static str,
+    /// Spec citation, or the explicit our-own-design flag.
+    pub citation: &'static str,
+    /// One-line reason the field cannot be narrowed here.
+    pub reason: &'static str,
+}
+
+/// Fields whose free-form JSON rendering is adjudicated rather than accidental.
+///
+/// Two distinct causes, both real and both recorded at the site:
+/// * an inherited OPEN generic parameter no vendored declaration narrows
+///   (`BMM_LITERAL_VALUE<T>.type` on `BMM_INTERVAL_VALUE`) — genuine spec
+///   silence, so no [`CLASS_BINDINGS`] entry can be justified;
+/// * an upstream→downstream layering inversion (a LANG class referencing an AM
+///   class), where the typed field DOES appear in the downstream re-emission.
+pub(crate) const UNTYPED_FIELDS: &[UntypedField] = &[
+    UntypedField {
+        class: "BMM_INTERVAL_VALUE",
+        field: "type",
+        citation: "LANG bmm3 master09-core-values.adoc §Container Literals narrows the container \
+                   literals only; `…bmm3.bmm_interval_value.adoc` declares no attributes at all, \
+                   so `BMM_LITERAL_VALUE<T>.type` stays open — no openEHR spec text narrows T for \
+                   an interval literal",
+        reason: "Spec silence: unlike BMM_CONTAINER_VALUE/BMM_INDEXED_CONTAINER_VALUE, no chapter \
+                 or class definition states the interval literal's concrete type meta-class, so \
+                 binding T here would be a guess.",
+    },
+    UntypedField {
+        class: "EL_CASE",
+        field: "value_constraint",
+        citation: "LANG `…bmm3.el_case.adoc` §Attributes types `value_constraint: C_OBJECT` (1..1), \
+                   but C_OBJECT is an AM class (`AM aom2 …c_object.adoc`) and AM depends on LANG — \
+                   an upstream→downstream dependency inversion in the vendored model",
+        reason: "openehr-lang cannot name an openehr-am type; the AM24 downstream re-emission of \
+                 the same class DOES carry `value_constraint: CObject`, so the typed form exists \
+                 exactly where C_OBJECT does.",
+    },
+];
+
+/// The free-form-field adjudication for `(class, field)`, or `None`.
+pub(crate) fn untyped_field(class: &str, field: &str) -> Option<&'static UntypedField> {
+    UNTYPED_FIELDS
+        .iter()
+        .find(|u| u.class == class && u.field == field)
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tools/openehr-codegen/src/render/emit.rs
+++ b/tools/openehr-codegen/src/render/emit.rs
@@ -34,7 +34,7 @@ use crate::load::bmm::{
     BmmClass, BmmConstant, BmmEnumValue, BmmEnumeration, BmmPropKind, BmmSchema, BmmType,
 };
 use crate::plan::composition::Composed;
-use crate::plan::overrides::{back_reference, class_binding, type_override};
+use crate::plan::overrides::{back_reference, class_binding, type_override, untyped_field};
 use crate::plan::{Emission, decide};
 use crate::render::naming;
 use std::collections::{BTreeMap, BTreeSet};
@@ -626,6 +626,21 @@ fn render_struct_def(
         // struct attribute — so no serde/`openehr` field attribute is emitted here.
         let ident = naming::field_ident(&p.name);
         let rust_ty = field_type(model, class, p, generics, subst, local, external);
+        // A field that degraded to free-form JSON *and* carries an adjudication
+        // gets the decision written at the site: silence over an untyped slot in
+        // a generated spec crate is indistinguishable from an oversight. The
+        // NOTE is conditional on the degrade actually happening, so a
+        // composition where the type IS resolvable (the AM24 re-emission of
+        // `EL_CASE`, where `C_OBJECT` is local) emits the typed field with no note.
+        if rust_ty.contains("serde_json::Value")
+            && let Some(adj) =
+                untyped_field(&rp.owner, &p.name).or_else(|| untyped_field(&class.name, &p.name))
+        {
+            b.push_str(&format!(
+                "    // NOTE: free-form JSON is adjudicated here, not accidental — {}. {}\n",
+                adj.citation, adj.reason
+            ));
+        }
         b.push_str(&format!("    pub {ident}: {rust_ty},\n"));
     }
 
@@ -821,6 +836,28 @@ fn field_type(
                     "Option<String>".to_string()
                 };
             }
+            // A container property is `Vec<T>` regardless of its BMM
+            // optionality: absent and empty are the same JSON array on the
+            // canonical wire, and the codec omits an empty vector. That
+            // convention is settled (root `CLAUDE.md` §Conventions), and it is
+            // lossless everywhere the Void state carries no meaning.
+            //
+            // TODO: `EL_AGENT.open_args` is the one known site where it IS
+            // lossy — the attribute is `0..1` and its Void state is normatively
+            // load-bearing twice: "If not provided, and the `_name_` refers to
+            // a routine with more arguments than supplied in `_closed_args_`,
+            // the missing arguments are inferred from the `_definition_`"
+            // (`…bmm3.el_agent.adoc` §Attributes), and `is_callable()` is
+            // defined as `Result = open_arguments = Void` (same file
+            // §Functions), which `EL_AGENT_CALL.Inv_valid_call`
+            // (`…bmm3.el_agent_call.adoc` §Invariants),
+            // `EL_FUNCTION_CALL.Inv_valid_agent` (`…bmm3.el_function_call.adoc`
+            // §Invariants) and `BMM_PROCEDURE_CALL.Inv_valid_agent`
+            // (`…bmm3.bmm_procedure_call.adoc` §Invariants) all reduce to. Give
+            // this field `Option<Vec<String>>` (a `type_override`-style entry,
+            // or optionality-aware container rendering) before any EL agent
+            // evaluation or invariant check lands; nothing evaluates EL today,
+            // which is why the convention still stands here.
             format!(
                 "Vec<{}>",
                 model.render_type(item, generics, subst, local, external)

--- a/tools/openehr-codegen/src/testsupport.rs
+++ b/tools/openehr-codegen/src/testsupport.rs
@@ -613,6 +613,19 @@ pub fn decision_maps() -> Vec<DeclMap> {
                 .collect(),
         },
         DeclMap {
+            map: "untyped_field",
+            check_existence: true,
+            entries: overrides::UNTYPED_FIELDS
+                .iter()
+                .map(|e| DeclEntry {
+                    key: format!("{}.{}", e.class, e.field),
+                    decision: "adjudicated free-form JSON (serde_json::Value)".to_string(),
+                    citation: e.citation.to_string(),
+                    reason: e.reason.to_string(),
+                })
+                .collect(),
+        },
+        DeclMap {
             map: "field_default",
             check_existence: true,
             entries: overrides::FIELD_DEFAULTS
@@ -714,6 +727,22 @@ pub fn subtype_extensions() -> Vec<(String, String)> {
     overrides::SUBTYPE_EXTENSIONS
         .iter()
         .map(|e| (e.parent.to_string(), e.subtype.to_string()))
+        .collect()
+}
+
+/// The adjudicated free-form (`serde_json::Value`) fields, as
+/// `(class, field, citation)` triples.
+#[must_use]
+pub fn untyped_fields() -> Vec<(String, String, String)> {
+    overrides::UNTYPED_FIELDS
+        .iter()
+        .map(|e| {
+            (
+                e.class.to_string(),
+                e.field.to_string(),
+                e.citation.to_string(),
+            )
+        })
         .collect()
 }
 

--- a/tools/openehr-codegen/tests/it/emitter_invariants.rs
+++ b/tools/openehr-codegen/tests/it/emitter_invariants.rs
@@ -347,6 +347,36 @@ fn decision_map_integrity_entries_are_cited_and_reference_real_classes() {
     }
 }
 
+/// Every adjudicated free-form field is a REAL degrade whose adjudication is
+/// written at the site: some generated file renders the field as
+/// `serde_json::Value` and carries the `// NOTE:` with the entry's citation.
+///
+/// This is the non-vacuity half of the decision-map integrity test — an entry
+/// for a field that turned out to be typeable would otherwise sit unnoticed,
+/// which is exactly the "silence over an untyped slot" this map exists to end.
+#[test]
+fn untyped_field_adjudications_land_on_a_real_free_form_field() {
+    let files = testsupport::render_all_to_memory().unwrap();
+    for (class, field, citation) in testsupport::untyped_fields() {
+        let ident = if field == "type" {
+            "r#type".to_string()
+        } else {
+            field.clone()
+        };
+        let hit = files.values().any(|body| {
+            body.contains(&citation)
+                && body.contains(&format!("pub {ident}: serde_json::Value"))
+                && body.contains(&format!("(`{class}`)"))
+        });
+        assert!(
+            hit,
+            "{class}.{field}: no generated file carries the adjudication NOTE above a free-form \
+             `{ident}: serde_json::Value` field — the entry is stale (the field is typed now) or \
+             the NOTE is not being emitted",
+        );
+    }
+}
+
 /// Every declared additional subtype member actually widens its parent's
 /// polymorphic slot: in every composition whose model defines both classes, the
 /// parent's variant set contains the subtype (and at least one composition does


### PR DESCRIPTION
Closes #1405
Closes #1406
Closes #1409
Closes #1177
Closes #1186
Closes #871
Closes #872
Closes #873
Closes #875
Closes #879

## What

The final implementation batch of the #753 LANG program — the three consolidated BMM3 fix issues, closing the last five chapter issues and two blocked sections.

- **#1405** — typed bound-fills via `CLASS_BINDINGS` (container literal `T`s per master09) + the new `UNTYPED_FIELDS` decision map that emits spec-cited NOTEs onto genuinely free-form generated fields (`BMM_INTERVAL_VALUE` spec-silence; `EL_CASE.value_constraint` LANG→AM inversion, whose typed twin the AM24 re-emission already carries — the degrade+NOTE adjudication), with a non-vacuity invariant. Closes #1177/#1186.
- **#1406** — enumeration validity as typed refusals with twins both ways; every audit-flagged boundary written down (silence is no longer a boundary anywhere in the LANG surface).
- **#1409** — the bmm3 function surface over the true v3 shapes (type lattice, class/feature functions) and `create_bmm3_model`: the P_BMM→bmm3 materialisation carrying what v2 could not (generic-ancestor bindings as model types, value-set constraints, typed enumeration values, functions/constants); invariants skipped with the EL-parser TODO (mandatory `BMM_ASSERTION.expression` is unbuildable — EL DEVELOPMENT, grammar unvendored); generic-property synthesis deferred with its design TODO. +19 tests incl. the RM 1.0.2 chain materialising to a bmm3 model end-to-end.

Chapters #871/#872/#873/#875/#879 close: every section closed, every finding fixed or riding a written-down boundary/TODO/upstream register (#1407).

## Gates (verified independently by the orchestrator)

`cargo clippy --workspace --exclude ferroehr-admin-ui --all-targets --all-features` 0 warnings; `cargo nextest run -p openehr-lang -p openehr-adl -p openehr-codegen -p openehr-its` **1063/1063**; fmt + rustdoc clean; regeneration idempotent. Changelog entries included.