### PR TITLE
chore(conformance): LANG program close — zero-drift baseline refresh

### DIFF
--- a/docs/conformance/ferroehr/CONFORMANCE_CERTIFICATE.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_CERTIFICATE.md
@@ -4,9 +4,9 @@
 
 | Field | Value |
 | --- | --- |
-| Solution | ferroehr 3.15.0 |
+| Solution | ferroehr 3.15.3 |
 | Vendor | Ruben Talstra |
-| Runner | cnf-runner 3.15.0 |
+| Runner | cnf-runner 3.15.3 |
 | Infrastructure | ixit.json#/environment |
 
 ## Scope of Test

--- a/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
@@ -1,7 +1,7 @@
 # Conformance Report
 
-SUT: ferroehr 3.15.0 · schedule cnf-2.0-w2 · ITS its-rest
-Runner: cnf-runner 3.15.0 · verification pack: passed
+SUT: ferroehr 3.15.3 · schedule cnf-2.0-w2 · ITS its-rest
+Runner: cnf-runner 3.15.3 · verification pack: passed
 
 ## Summary
 

--- a/docs/conformance/ferroehr/results.json
+++ b/docs/conformance/ferroehr/results.json
@@ -1,11 +1,11 @@
 {
   "sut": {
     "name": "ferroehr",
-    "version": "3.15.0"
+    "version": "3.15.3"
   },
   "runner": {
     "name": "cnf-runner",
-    "version": "3.15.0",
+    "version": "3.15.3",
     "verification_pack_status": "passed"
   },
   "schedule_release": "cnf-2.0-w2",
@@ -18,7 +18,7 @@
       "wt-structured"
     ]
   },
-  "ixit_digest": "e3e980f7315ba23c",
+  "ixit_digest": "160895d92245739c",
   "restapi_specs_version": "1.1.0",
   "outcomes": [
     {


### PR DESCRIPTION
Closes #753

## What

The final exit criterion of the LANG compliance program: the full CNF 2.0 pipeline run on the post-program tree — **863 case-records: 826 passed / 0 failed / 0 errored / 37 adjudicated-n-a; 43 capability verdicts; 0 review findings; `verdicts.json` byte-identical to the committed baseline (zero drift)**. The only artifact deltas are the SUT/runner version stamps (3.15.0 → 3.15.3) and the version-derived ixit digest — refreshed here.

The program close-out narrative (all 41 chapters, the fix-first record, the honest coverage statement, pin honesty, upstream registers) is on #753. With this merge the v3.16.0 milestone reaches zero open issues and the release cuts next.