### PR TITLE
chore(memory): LANG program completion record

### DIFF
--- a/.claude/memory/spec-chapter-audit-programs.md
+++ b/.claude/memory/spec-chapter-audit-programs.md
@@ -5,7 +5,7 @@ metadata:
   node_type: memory
   type: feedback
   originSessionId: 871531fb-1884-468e-9033-ae616ae2eb2b
-  modified: 2026-07-29T23:18:28.454Z
+  modified: 2026-08-01T06:30:12.656Z
 ---
 
 Owner directive 2026-07-29: systematic code compliance is driven as **one
@@ -16,9 +16,17 @@ BASE 1.3.0 program (#686, 29 chapter children) = v3.13.0, **completed and
 released 2026-07-30** (8 findings, all fixed under the cadence; zero-drift
 close run 809/809; tag v3.13.0). v3.14.0 = QUERY, **completed and released 2026-07-30** (9 findings incl. six
 wire-visible engine defects the green suite had never caught; catalogue
-28→45 query cases; AMB-174/175). Queue: v3.15.0 = AM (89 children),
-v3.16.0 = LANG (41), v3.17.0 = TERM (5), v3.18.0 = RM (47), v3.19.0 = SM
-(20), then v4.0.0 = the admin-UI program.
+28→45 query cases; AMB-174/175). v3.15.x = AM, completed. v3.16.0 = LANG
+(41 chapters, 198 issues), **completed and released 2026-08-01** — the
+big catch was the two-schema merge chimera (v2 shapes emitted at bmm3
+paths; fixed by per-generation emission + attribute-level emitter
+invariants, PR #1410); read-only spec-conformance-reviewer agents in
+parallel worked well for bulk chapter audits (evidence-verified
+checklists pasted from their report files), and posting GH comment
+bodies MUST use heredocs (backticks in double-quoted `--body` get
+shell-executed and silently mangle the comment). Queue: v3.17.0 = TERM
+(5), v3.18.0 = RM (47), v3.19.0 = SM (20), then v4.0.0 = the admin-UI
+program.
 (CDS/GDL2 was briefly v3.13.0 but adjudicated OUT after a first-hand spec
 read: CDS is a separate application layer consuming the CDR, not a CDR
 component — #716 closed with the citation.) Per-chapter mechanics that


### PR DESCRIPTION
Updates the spec-chapter-audit-programs memory: v3.16.0 LANG completed + released 2026-08-01; the merge-chimera catch, the parallel read-only reviewer pattern, and the gh-comment heredoc discipline recorded for the next programs (TERM next).