### PR TITLE
test(openehr-term): pin assets byte-identical to the vendored computable expression

### DIFF
--- a/crates/openehr-term/assets/PROVENANCE.md
+++ b/crates/openehr-term/assets/PROVENANCE.md
@@ -1,0 +1,25 @@
+# Vendored openEHR terminology assets
+
+- Source: https://github.com/openEHR/specifications-TERM
+- Ref: master (TERM 3.1.0)
+- Commit: `007d0dddcdd77648711681878b54ace021b2fbd5`
+- Upstream paths:
+  - `computable/XML/{en,es,ja,pt,zh}/openehr_terminology.xml` → `assets/<lang>/openehr_terminology.xml`
+  - `computable/XML/openehr_external_terminologies.xml` → `assets/openehr_external_terminologies.xml`
+  - `computable/XML/PropertyUnitData.xml` → `assets/PropertyUnitData.xml`
+  - `computable/XML/schema/*.xsd` → `assets/schema/`
+
+The computable form is the definitive expression of the openEHR Support
+Terminology (`docs/specs/openehr/TERM/docs/SupportTerminology/master02-overview.adoc`),
+so every asset here must stay **byte-identical** to the upstream file at the
+pinned commit — never "clean up", reformat, or re-indent them; known upstream
+defects (e.g. SPECPR-51) are handled in access logic with a citation, never by
+editing the asset.
+
+The same commit is vendored as spec text + computable XML at
+`docs/specs/openehr/TERM/` (see its `PROVENANCE.md`); the `asset_identity`
+test in `tests/it/` byte-compares this directory against that copy, so a
+re-vendor of either side fails loudly until both move together. The XSDs are
+excluded from the spec-text vendoring (text-formats-only script), so their
+byte-identity to upstream was verified directly at the pinned commit
+(2026-08-01).

--- a/crates/openehr-term/tests/it/asset_identity.rs
+++ b/crates/openehr-term/tests/it/asset_identity.rs
@@ -1,0 +1,76 @@
+//! The vendored terminology assets are byte-identical to the definitive
+//! computable expression.
+//!
+//! TERM `SupportTerminology/master02-overview.adoc` names the computable form
+//! in the openEHR `specifications-TERM` repository as "the definitive
+//! expression" of the Support Terminology. That repository is vendored twice
+//! in this workspace at the same pinned commit (`assets/PROVENANCE.md` and
+//! `docs/specs/openehr/TERM/PROVENANCE.md`): the crate embeds the XML under
+//! `assets/`, and the spec-text vendoring carries the same files under
+//! `docs/specs/openehr/TERM/computable/XML/`. Each pair must stay
+//! byte-identical — an edit to either side (a "cleanup", a re-vendor of one
+//! copy without the other) is a defect this test makes loud.
+
+/// One (crate asset, vendored computable expression) pair, both embedded at
+/// compile time so the test needs no runtime filesystem layout assumptions.
+const PAIRS: [(&str, &str, &str); 7] = [
+    (
+        "en/openehr_terminology.xml",
+        include_str!("../../assets/en/openehr_terminology.xml"),
+        include_str!(
+            "../../../../docs/specs/openehr/TERM/computable/XML/en/openehr_terminology.xml"
+        ),
+    ),
+    (
+        "es/openehr_terminology.xml",
+        include_str!("../../assets/es/openehr_terminology.xml"),
+        include_str!(
+            "../../../../docs/specs/openehr/TERM/computable/XML/es/openehr_terminology.xml"
+        ),
+    ),
+    (
+        "ja/openehr_terminology.xml",
+        include_str!("../../assets/ja/openehr_terminology.xml"),
+        include_str!(
+            "../../../../docs/specs/openehr/TERM/computable/XML/ja/openehr_terminology.xml"
+        ),
+    ),
+    (
+        "pt/openehr_terminology.xml",
+        include_str!("../../assets/pt/openehr_terminology.xml"),
+        include_str!(
+            "../../../../docs/specs/openehr/TERM/computable/XML/pt/openehr_terminology.xml"
+        ),
+    ),
+    (
+        "zh/openehr_terminology.xml",
+        include_str!("../../assets/zh/openehr_terminology.xml"),
+        include_str!(
+            "../../../../docs/specs/openehr/TERM/computable/XML/zh/openehr_terminology.xml"
+        ),
+    ),
+    (
+        "openehr_external_terminologies.xml",
+        include_str!("../../assets/openehr_external_terminologies.xml"),
+        include_str!(
+            "../../../../docs/specs/openehr/TERM/computable/XML/openehr_external_terminologies.xml"
+        ),
+    ),
+    (
+        "PropertyUnitData.xml",
+        include_str!("../../assets/PropertyUnitData.xml"),
+        include_str!("../../../../docs/specs/openehr/TERM/computable/XML/PropertyUnitData.xml"),
+    ),
+];
+
+#[test]
+fn assets_are_byte_identical_to_the_vendored_computable_expression() {
+    for (name, asset, definitive) in PAIRS {
+        assert_eq!(
+            asset, definitive,
+            "crate asset {name} diverged from the vendored definitive \
+             computable expression (docs/specs/openehr/TERM/computable/XML) — \
+             re-vendor both sides together at the same pinned commit",
+        );
+    }
+}

--- a/crates/openehr-term/tests/it/main.rs
+++ b/crates/openehr-term/tests/it/main.rs
@@ -1,0 +1,4 @@
+//! Integration tests for `openehr-term` — one binary per crate (Cargo target
+//! discipline), one module per topic.
+
+mod asset_identity;


### PR DESCRIPTION
TERM ch.2 audit fix (#893 program #814): adds `crates/openehr-term/assets/PROVENANCE.md` (source repo, ref, pinned commit `007d0ddd`, byte-identity rule) and an `openehr-term` `tests/it` integration binary whose `asset_identity` test byte-compares all 7 embedded assets against the vendored definitive computable expression at `docs/specs/openehr/TERM/computable/XML/` (TERM `master02-overview.adoc`: the computable form is the definitive expression). Verified in-audit: all pairs identical; XSDs additionally verified byte-identical to upstream at the pinned commit.

Gates: fmt, clippy -p openehr-term --all-targets, nextest -p openehr-term (20/20).

Closes #1415