### PR TITLE
test(cnf): wire refusal cases for the TERM envelope slots

### DIFF
--- a/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
+++ b/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
@@ -132,6 +132,46 @@ cnf.composition.minimal_event.invalid_structure:
     spec_ref: "RM ehr (EVALUATION.data is mandatory, 1..1)"
   template_id: "minimal_evaluation.en.v1"
   provenance: "derived 2026-07-21 by removing the mandatory EVALUATION.data from the real v1 payload (RM ehr: EVALUATION.data 1..1)"
+cnf.composition.minimal_event.territory_invalid:
+  source: fixtures/composition/minimal_event.territory_invalid.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "COMPOSITION.territory code_string ZZ is no member of the countries code set"
+    spec_ref: "TERM SupportTerminology §Code Sets (countries / ISO_3166-1); RM ehr (COMPOSITION.territory: a valid ISO 3166-1 country code)"
+  template_id: "minimal_evaluation.en.v1"
+  provenance: "derived 2026-08-01 from cnf.composition.minimal_event.v1 by replacing COMPOSITION.territory.code_string UY with ZZ (a code outside the openEHR countries code set — TERM SupportTerminology §Code Sets); the TERM ch.3 §3.1 audit wire-refusal twin (#1417)"
+cnf.composition.minimal_event.language_invalid:
+  source: fixtures/composition/minimal_event.language_invalid.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "COMPOSITION.language code_string zz is no member of the languages code set"
+    spec_ref: "TERM SupportTerminology §Code Sets (languages / ISO_639-1); RM ehr (COMPOSITION.language: a valid ISO 639-1 language code)"
+  template_id: "minimal_evaluation.en.v1"
+  provenance: "derived 2026-08-01 from cnf.composition.minimal_event.v1 by replacing COMPOSITION.language.code_string en with zz (a code outside the openEHR languages code set — TERM SupportTerminology §Code Sets); the TERM ch.3 §3.1 audit wire-refusal twin (#1417)"
+cnf.composition.minimal_event.category_invalid:
+  source: fixtures/composition/minimal_event.category_invalid.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "COMPOSITION.category defining_code 999 (terminology openehr) is no member of the composition_category group"
+    spec_ref: "TERM SupportTerminology §Vocabularies (composition category: 431|451|433|815); RM ehr (COMPOSITION Category_validity)"
+  template_id: "minimal_evaluation.en.v1"
+  provenance: "derived 2026-08-01 from cnf.composition.minimal_event.v1 by replacing COMPOSITION.category.defining_code.code_string 433 with 999 (no member of the composition_category group — TERM SupportTerminology §Vocabularies); the TERM ch.3 §3.2 audit wire-refusal twin (#1418)"
+cnf.composition.minimal_event.setting_invalid:
+  source: fixtures/composition/minimal_event.setting_invalid.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "EVENT_CONTEXT.setting defining_code 999 (terminology openehr) is no member of the setting group"
+    spec_ref: "TERM SupportTerminology §Vocabularies (setting); RM ehr (EVENT_CONTEXT Setting_valid)"
+  template_id: "minimal_evaluation.en.v1"
+  provenance: "derived 2026-08-01 from cnf.composition.minimal_event.v1 by replacing EVENT_CONTEXT.setting.defining_code.code_string 228 with 999 (no member of the setting group — TERM SupportTerminology §Vocabularies); the TERM ch.3 §3.2 audit wire-refusal twin (#1418)"
 cnf.composition.unknown_template:
   source: fixtures/composition/unknown_template.json
   format: canonical-json

--- a/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_event.category_invalid.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_event.category_invalid.json
@@ -1,0 +1,150 @@
+{
+    "_type": "COMPOSITION",
+    "name": {
+        "_type": "DV_TEXT",
+        "value": "Minimal"
+    },
+    "archetype_details": {
+        "archetype_id": {
+            "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+        },
+        "template_id": {
+            "value": "minimal_evaluation.en.v1"
+        },
+        "rm_version": "1.0.2"
+    },
+    "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+    "language": {
+        "terminology_id": {
+            "value": "ISO_639-1"
+        },
+        "code_string": "en"
+    },
+    "territory": {
+        "terminology_id": {
+            "value": "ISO_3166-1"
+        },
+        "code_string": "UY"
+    },
+    "category": {
+        "value": "event",
+        "defining_code": {
+            "terminology_id": {
+                "value": "openehr"
+            },
+            "code_string": "999"
+        }
+    },
+    "composer": {
+        "_type": "PARTY_IDENTIFIED",
+        "external_ref": {
+            "id": {
+                "_type": "HIER_OBJECT_ID",
+                "value": "fc376c46-29c1-4090-bc01-5cc046af7f26"
+            },
+            "namespace": "DEMOGRAPHIC",
+            "type": "PERSON"
+        },
+        "name": "Dr. House"
+    },
+    "context": {
+        "start_time": {
+            "value": "2021-09-21T21:52:31.927-03:00"
+        },
+        "setting": {
+            "value": "primary medical care",
+            "defining_code": {
+                "terminology_id": {
+                    "value": "openehr"
+                },
+                "code_string": "228"
+            }
+        },
+        "participations": [
+            {
+                "function": {
+                    "value": "legal guardian consent author"
+                },
+                "performer": {
+                    "_type": "PARTY_RELATED",
+                    "name": "Alexandra Alamo",
+                    "relationship": {
+                        "value": "mother",
+                        "defining_code": {
+                            "terminology_id": {
+                                "value": "openehr"
+                            },
+                            "code_string": "10"
+                        }
+                    }
+                },
+                "mode": {
+                    "value": "not specified",
+                    "defining_code": {
+                        "terminology_id": {
+                            "value": "openehr"
+                        },
+                        "code_string": "193"
+                    }
+                }
+            }
+        ]
+    },
+    "content": [
+        {
+            "_type": "EVALUATION",
+            "name": {
+                "_type": "DV_TEXT",
+                "value": "Minimal"
+            },
+            "archetype_details": {
+                "archetype_id": {
+                    "value": "openEHR-EHR-EVALUATION.minimal.v1"
+                },
+                "template_id": {
+                    "value": "minimal_evaluation.en.v1"
+                },
+                "rm_version": "1.0.2"
+            },
+            "archetype_node_id": "openEHR-EHR-EVALUATION.minimal.v1",
+            "language": {
+                "terminology_id": {
+                    "value": "ISO_639-1"
+                },
+                "code_string": "en"
+            },
+            "encoding": {
+                "terminology_id": {
+                    "value": "IANA_character-sets"
+                },
+                "code_string": "UTF-8"
+            },
+            "subject": {
+                "_type": "PARTY_SELF"
+            },
+            "data": {
+                "_type": "ITEM_TREE",
+                "name": {
+                    "_type": "DV_TEXT",
+                    "value": "Arbol"
+                },
+                "archetype_node_id": "at0001",
+                "items": [
+                    {
+                        "_type": "ELEMENT",
+                        "name": {
+                            "_type": "DV_TEXT",
+                            "value": "quantity"
+                        },
+                        "archetype_node_id": "at0002",
+                        "value": {
+                            "_type": "DV_QUANTITY",
+                            "magnitude": 78.5,
+                            "units": "kg"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_event.language_invalid.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_event.language_invalid.json
@@ -1,0 +1,150 @@
+{
+    "_type": "COMPOSITION",
+    "name": {
+        "_type": "DV_TEXT",
+        "value": "Minimal"
+    },
+    "archetype_details": {
+        "archetype_id": {
+            "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+        },
+        "template_id": {
+            "value": "minimal_evaluation.en.v1"
+        },
+        "rm_version": "1.0.2"
+    },
+    "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+    "language": {
+        "terminology_id": {
+            "value": "ISO_639-1"
+        },
+        "code_string": "zz"
+    },
+    "territory": {
+        "terminology_id": {
+            "value": "ISO_3166-1"
+        },
+        "code_string": "UY"
+    },
+    "category": {
+        "value": "event",
+        "defining_code": {
+            "terminology_id": {
+                "value": "openehr"
+            },
+            "code_string": "433"
+        }
+    },
+    "composer": {
+        "_type": "PARTY_IDENTIFIED",
+        "external_ref": {
+            "id": {
+                "_type": "HIER_OBJECT_ID",
+                "value": "fc376c46-29c1-4090-bc01-5cc046af7f26"
+            },
+            "namespace": "DEMOGRAPHIC",
+            "type": "PERSON"
+        },
+        "name": "Dr. House"
+    },
+    "context": {
+        "start_time": {
+            "value": "2021-09-21T21:52:31.927-03:00"
+        },
+        "setting": {
+            "value": "primary medical care",
+            "defining_code": {
+                "terminology_id": {
+                    "value": "openehr"
+                },
+                "code_string": "228"
+            }
+        },
+        "participations": [
+            {
+                "function": {
+                    "value": "legal guardian consent author"
+                },
+                "performer": {
+                    "_type": "PARTY_RELATED",
+                    "name": "Alexandra Alamo",
+                    "relationship": {
+                        "value": "mother",
+                        "defining_code": {
+                            "terminology_id": {
+                                "value": "openehr"
+                            },
+                            "code_string": "10"
+                        }
+                    }
+                },
+                "mode": {
+                    "value": "not specified",
+                    "defining_code": {
+                        "terminology_id": {
+                            "value": "openehr"
+                        },
+                        "code_string": "193"
+                    }
+                }
+            }
+        ]
+    },
+    "content": [
+        {
+            "_type": "EVALUATION",
+            "name": {
+                "_type": "DV_TEXT",
+                "value": "Minimal"
+            },
+            "archetype_details": {
+                "archetype_id": {
+                    "value": "openEHR-EHR-EVALUATION.minimal.v1"
+                },
+                "template_id": {
+                    "value": "minimal_evaluation.en.v1"
+                },
+                "rm_version": "1.0.2"
+            },
+            "archetype_node_id": "openEHR-EHR-EVALUATION.minimal.v1",
+            "language": {
+                "terminology_id": {
+                    "value": "ISO_639-1"
+                },
+                "code_string": "en"
+            },
+            "encoding": {
+                "terminology_id": {
+                    "value": "IANA_character-sets"
+                },
+                "code_string": "UTF-8"
+            },
+            "subject": {
+                "_type": "PARTY_SELF"
+            },
+            "data": {
+                "_type": "ITEM_TREE",
+                "name": {
+                    "_type": "DV_TEXT",
+                    "value": "Arbol"
+                },
+                "archetype_node_id": "at0001",
+                "items": [
+                    {
+                        "_type": "ELEMENT",
+                        "name": {
+                            "_type": "DV_TEXT",
+                            "value": "quantity"
+                        },
+                        "archetype_node_id": "at0002",
+                        "value": {
+                            "_type": "DV_QUANTITY",
+                            "magnitude": 78.5,
+                            "units": "kg"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_event.setting_invalid.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_event.setting_invalid.json
@@ -1,0 +1,150 @@
+{
+    "_type": "COMPOSITION",
+    "name": {
+        "_type": "DV_TEXT",
+        "value": "Minimal"
+    },
+    "archetype_details": {
+        "archetype_id": {
+            "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+        },
+        "template_id": {
+            "value": "minimal_evaluation.en.v1"
+        },
+        "rm_version": "1.0.2"
+    },
+    "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+    "language": {
+        "terminology_id": {
+            "value": "ISO_639-1"
+        },
+        "code_string": "en"
+    },
+    "territory": {
+        "terminology_id": {
+            "value": "ISO_3166-1"
+        },
+        "code_string": "UY"
+    },
+    "category": {
+        "value": "event",
+        "defining_code": {
+            "terminology_id": {
+                "value": "openehr"
+            },
+            "code_string": "433"
+        }
+    },
+    "composer": {
+        "_type": "PARTY_IDENTIFIED",
+        "external_ref": {
+            "id": {
+                "_type": "HIER_OBJECT_ID",
+                "value": "fc376c46-29c1-4090-bc01-5cc046af7f26"
+            },
+            "namespace": "DEMOGRAPHIC",
+            "type": "PERSON"
+        },
+        "name": "Dr. House"
+    },
+    "context": {
+        "start_time": {
+            "value": "2021-09-21T21:52:31.927-03:00"
+        },
+        "setting": {
+            "value": "primary medical care",
+            "defining_code": {
+                "terminology_id": {
+                    "value": "openehr"
+                },
+                "code_string": "999"
+            }
+        },
+        "participations": [
+            {
+                "function": {
+                    "value": "legal guardian consent author"
+                },
+                "performer": {
+                    "_type": "PARTY_RELATED",
+                    "name": "Alexandra Alamo",
+                    "relationship": {
+                        "value": "mother",
+                        "defining_code": {
+                            "terminology_id": {
+                                "value": "openehr"
+                            },
+                            "code_string": "10"
+                        }
+                    }
+                },
+                "mode": {
+                    "value": "not specified",
+                    "defining_code": {
+                        "terminology_id": {
+                            "value": "openehr"
+                        },
+                        "code_string": "193"
+                    }
+                }
+            }
+        ]
+    },
+    "content": [
+        {
+            "_type": "EVALUATION",
+            "name": {
+                "_type": "DV_TEXT",
+                "value": "Minimal"
+            },
+            "archetype_details": {
+                "archetype_id": {
+                    "value": "openEHR-EHR-EVALUATION.minimal.v1"
+                },
+                "template_id": {
+                    "value": "minimal_evaluation.en.v1"
+                },
+                "rm_version": "1.0.2"
+            },
+            "archetype_node_id": "openEHR-EHR-EVALUATION.minimal.v1",
+            "language": {
+                "terminology_id": {
+                    "value": "ISO_639-1"
+                },
+                "code_string": "en"
+            },
+            "encoding": {
+                "terminology_id": {
+                    "value": "IANA_character-sets"
+                },
+                "code_string": "UTF-8"
+            },
+            "subject": {
+                "_type": "PARTY_SELF"
+            },
+            "data": {
+                "_type": "ITEM_TREE",
+                "name": {
+                    "_type": "DV_TEXT",
+                    "value": "Arbol"
+                },
+                "archetype_node_id": "at0001",
+                "items": [
+                    {
+                        "_type": "ELEMENT",
+                        "name": {
+                            "_type": "DV_TEXT",
+                            "value": "quantity"
+                        },
+                        "archetype_node_id": "at0002",
+                        "value": {
+                            "_type": "DV_QUANTITY",
+                            "magnitude": 78.5,
+                            "units": "kg"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_event.territory_invalid.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_event.territory_invalid.json
@@ -1,0 +1,150 @@
+{
+    "_type": "COMPOSITION",
+    "name": {
+        "_type": "DV_TEXT",
+        "value": "Minimal"
+    },
+    "archetype_details": {
+        "archetype_id": {
+            "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+        },
+        "template_id": {
+            "value": "minimal_evaluation.en.v1"
+        },
+        "rm_version": "1.0.2"
+    },
+    "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+    "language": {
+        "terminology_id": {
+            "value": "ISO_639-1"
+        },
+        "code_string": "en"
+    },
+    "territory": {
+        "terminology_id": {
+            "value": "ISO_3166-1"
+        },
+        "code_string": "ZZ"
+    },
+    "category": {
+        "value": "event",
+        "defining_code": {
+            "terminology_id": {
+                "value": "openehr"
+            },
+            "code_string": "433"
+        }
+    },
+    "composer": {
+        "_type": "PARTY_IDENTIFIED",
+        "external_ref": {
+            "id": {
+                "_type": "HIER_OBJECT_ID",
+                "value": "fc376c46-29c1-4090-bc01-5cc046af7f26"
+            },
+            "namespace": "DEMOGRAPHIC",
+            "type": "PERSON"
+        },
+        "name": "Dr. House"
+    },
+    "context": {
+        "start_time": {
+            "value": "2021-09-21T21:52:31.927-03:00"
+        },
+        "setting": {
+            "value": "primary medical care",
+            "defining_code": {
+                "terminology_id": {
+                    "value": "openehr"
+                },
+                "code_string": "228"
+            }
+        },
+        "participations": [
+            {
+                "function": {
+                    "value": "legal guardian consent author"
+                },
+                "performer": {
+                    "_type": "PARTY_RELATED",
+                    "name": "Alexandra Alamo",
+                    "relationship": {
+                        "value": "mother",
+                        "defining_code": {
+                            "terminology_id": {
+                                "value": "openehr"
+                            },
+                            "code_string": "10"
+                        }
+                    }
+                },
+                "mode": {
+                    "value": "not specified",
+                    "defining_code": {
+                        "terminology_id": {
+                            "value": "openehr"
+                        },
+                        "code_string": "193"
+                    }
+                }
+            }
+        ]
+    },
+    "content": [
+        {
+            "_type": "EVALUATION",
+            "name": {
+                "_type": "DV_TEXT",
+                "value": "Minimal"
+            },
+            "archetype_details": {
+                "archetype_id": {
+                    "value": "openEHR-EHR-EVALUATION.minimal.v1"
+                },
+                "template_id": {
+                    "value": "minimal_evaluation.en.v1"
+                },
+                "rm_version": "1.0.2"
+            },
+            "archetype_node_id": "openEHR-EHR-EVALUATION.minimal.v1",
+            "language": {
+                "terminology_id": {
+                    "value": "ISO_639-1"
+                },
+                "code_string": "en"
+            },
+            "encoding": {
+                "terminology_id": {
+                    "value": "IANA_character-sets"
+                },
+                "code_string": "UTF-8"
+            },
+            "subject": {
+                "_type": "PARTY_SELF"
+            },
+            "data": {
+                "_type": "ITEM_TREE",
+                "name": {
+                    "_type": "DV_TEXT",
+                    "value": "Arbol"
+                },
+                "archetype_node_id": "at0001",
+                "items": [
+                    {
+                        "_type": "ELEMENT",
+                        "name": {
+                            "_type": "DV_TEXT",
+                            "value": "quantity"
+                        },
+                        "archetype_node_id": "at0002",
+                        "value": {
+                            "_type": "DV_QUANTITY",
+                            "magnitude": 78.5,
+                            "units": "kg"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-category_invalid.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-category_invalid.yaml
@@ -1,0 +1,42 @@
+# An out-of-group category is a 422: COMPOSITION.category's defining_code
+# (terminology `openehr`) must be a member of the `composition_category`
+# vocabulary — 431|persistent|, 451|episodic|, 433|event|, 815|report|
+# (TERM SupportTerminology §Vocabularies; RM ehr COMPOSITION
+# Category_validity). "999" is no member, so the commit is semantically
+# unprocessable and nothing is committed.
+#
+# Derived from the TERM vocabulary tables + the RM invariant + the ITS-REST
+# status table (Requests_and_responses.md: 422 "well-formed but was unable to
+# be followed due to semantic errors"), not from any SUT. One of the TERM
+# ch.3 §3.2 wire-refusal twins (#1418); the valid twin is every accepted
+# minimal_event.v1 commit (category 433|event|).
+id: I_EHR_COMPOSITION.create_composition-category_invalid
+kind: functional
+component: EHR_COMPOSITION
+sm_operation: I_EHR_COMPOSITION.create_composition
+capabilities: [CompositionOps]
+profiles: [CORE]
+test_purpose: >-
+  A COMPOSITION whose category defining_code is no member of the openEHR
+  composition_category vocabulary is rejected 422, and nothing is committed.
+description: "Reject an out-of-group COMPOSITION.category (422)"
+spec_refs:
+  - "TERM SupportTerminology §Vocabularies (composition category)"
+  - "RM ehr §COMPOSITION (Category_validity)"
+  - "ITS-REST overview Requests_and_responses §HTTP status codes (422)"
+  - "SM openehr_platform §I_EHR_COMPOSITION.create_composition"
+applies: { rm: ">=1.0.2" }
+requires:
+  server: any
+  templates: [cnf.opt.minimal_event]
+  ehr: { commits: none }                 # mints ${ehr_id}
+data_sets: [cnf.composition.minimal_event.category_invalid]
+flow:
+  - step: 1
+    call: create_composition
+    with: { ehr_id: "${ehr_id}", composition: "${ds:cnf.composition.minimal_event.category_invalid}" }
+    expect: validation_failed
+    assert:
+      - { assert: message_exemplar, text: "information about the errors in the provided COMPOSITION" }
+postconditions:
+  - { assert: version, count: 0 }        # nothing committed

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-language_invalid.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-language_invalid.yaml
@@ -1,0 +1,41 @@
+# An out-of-code-set language is a 422: COMPOSITION.language must be a member
+# of the openEHR `languages` code set (TERM SupportTerminology §Code Sets
+# binds ISO_639-1 to COMPOSITION.language; RM ehr COMPOSITION
+# Language_valid). "zz" is no member, so the commit is semantically
+# unprocessable and nothing is committed.
+#
+# Derived from the TERM code-set tables + the RM invariant + the ITS-REST
+# status table (Requests_and_responses.md: 422 "well-formed but was unable to
+# be followed due to semantic errors"), not from any SUT. One of the TERM
+# ch.3 §3.1 wire-refusal twins (#1417); the valid twin is every accepted
+# minimal_event.v1 commit (language en).
+id: I_EHR_COMPOSITION.create_composition-language_invalid
+kind: functional
+component: EHR_COMPOSITION
+sm_operation: I_EHR_COMPOSITION.create_composition
+capabilities: [CompositionOps]
+profiles: [CORE]
+test_purpose: >-
+  A COMPOSITION whose language code is no member of the openEHR languages
+  code set (ISO 639-1) is rejected 422, and nothing is committed.
+description: "Reject an out-of-code-set COMPOSITION.language (422)"
+spec_refs:
+  - "TERM SupportTerminology §Code Sets (languages / ISO_639-1)"
+  - "RM ehr §COMPOSITION (Language_valid)"
+  - "ITS-REST overview Requests_and_responses §HTTP status codes (422)"
+  - "SM openehr_platform §I_EHR_COMPOSITION.create_composition"
+applies: { rm: ">=1.0.2" }
+requires:
+  server: any
+  templates: [cnf.opt.minimal_event]
+  ehr: { commits: none }                 # mints ${ehr_id}
+data_sets: [cnf.composition.minimal_event.language_invalid]
+flow:
+  - step: 1
+    call: create_composition
+    with: { ehr_id: "${ehr_id}", composition: "${ds:cnf.composition.minimal_event.language_invalid}" }
+    expect: validation_failed
+    assert:
+      - { assert: message_exemplar, text: "information about the errors in the provided COMPOSITION" }
+postconditions:
+  - { assert: version, count: 0 }        # nothing committed

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-setting_invalid.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-setting_invalid.yaml
@@ -1,0 +1,41 @@
+# An out-of-group setting is a 422: EVENT_CONTEXT.setting's defining_code
+# (terminology `openehr`) must be a member of the `setting` vocabulary
+# (TERM SupportTerminology §Vocabularies; RM ehr EVENT_CONTEXT
+# Setting_valid). "999" is no member, so the commit is semantically
+# unprocessable and nothing is committed.
+#
+# Derived from the TERM vocabulary tables + the RM invariant + the ITS-REST
+# status table (Requests_and_responses.md: 422 "well-formed but was unable to
+# be followed due to semantic errors"), not from any SUT. One of the TERM
+# ch.3 §3.2 wire-refusal twins (#1418); the valid twin is every accepted
+# minimal_event.v1 commit (setting 228|primary medical care|).
+id: I_EHR_COMPOSITION.create_composition-setting_invalid
+kind: functional
+component: EHR_COMPOSITION
+sm_operation: I_EHR_COMPOSITION.create_composition
+capabilities: [CompositionOps]
+profiles: [CORE]
+test_purpose: >-
+  A COMPOSITION whose EVENT_CONTEXT.setting defining_code is no member of the
+  openEHR setting vocabulary is rejected 422, and nothing is committed.
+description: "Reject an out-of-group EVENT_CONTEXT.setting (422)"
+spec_refs:
+  - "TERM SupportTerminology §Vocabularies (setting)"
+  - "RM ehr §EVENT_CONTEXT (Setting_valid)"
+  - "ITS-REST overview Requests_and_responses §HTTP status codes (422)"
+  - "SM openehr_platform §I_EHR_COMPOSITION.create_composition"
+applies: { rm: ">=1.0.2" }
+requires:
+  server: any
+  templates: [cnf.opt.minimal_event]
+  ehr: { commits: none }                 # mints ${ehr_id}
+data_sets: [cnf.composition.minimal_event.setting_invalid]
+flow:
+  - step: 1
+    call: create_composition
+    with: { ehr_id: "${ehr_id}", composition: "${ds:cnf.composition.minimal_event.setting_invalid}" }
+    expect: validation_failed
+    assert:
+      - { assert: message_exemplar, text: "information about the errors in the provided COMPOSITION" }
+postconditions:
+  - { assert: version, count: 0 }        # nothing committed

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-territory_invalid.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-territory_invalid.yaml
@@ -1,0 +1,41 @@
+# An out-of-code-set territory is a 422: COMPOSITION.territory must be a
+# member of the openEHR `countries` code set (TERM SupportTerminology §Code
+# Sets binds ISO_3166-1 to COMPOSITION.territory; RM ehr COMPOSITION
+# Territory_valid). "ZZ" is no member, so the commit is semantically
+# unprocessable and nothing is committed.
+#
+# Derived from the TERM code-set tables + the RM invariant + the ITS-REST
+# status table (Requests_and_responses.md: 422 "well-formed but was unable to
+# be followed due to semantic errors"), not from any SUT. One of the TERM
+# ch.3 §3.1 wire-refusal twins (#1417); the valid twin is every accepted
+# minimal_event.v1 commit (territory UY).
+id: I_EHR_COMPOSITION.create_composition-territory_invalid
+kind: functional
+component: EHR_COMPOSITION
+sm_operation: I_EHR_COMPOSITION.create_composition
+capabilities: [CompositionOps]
+profiles: [CORE]
+test_purpose: >-
+  A COMPOSITION whose territory code is no member of the openEHR countries
+  code set (ISO 3166-1) is rejected 422, and nothing is committed.
+description: "Reject an out-of-code-set COMPOSITION.territory (422)"
+spec_refs:
+  - "TERM SupportTerminology §Code Sets (countries / ISO_3166-1)"
+  - "RM ehr §COMPOSITION (Territory_valid)"
+  - "ITS-REST overview Requests_and_responses §HTTP status codes (422)"
+  - "SM openehr_platform §I_EHR_COMPOSITION.create_composition"
+applies: { rm: ">=1.0.2" }
+requires:
+  server: any
+  templates: [cnf.opt.minimal_event]
+  ehr: { commits: none }                 # mints ${ehr_id}
+data_sets: [cnf.composition.minimal_event.territory_invalid]
+flow:
+  - step: 1
+    call: create_composition
+    with: { ehr_id: "${ehr_id}", composition: "${ds:cnf.composition.minimal_event.territory_invalid}" }
+    expect: validation_failed
+    assert:
+      - { assert: message_exemplar, text: "information about the errors in the provided COMPOSITION" }
+postconditions:
+  - { assert: version, count: 0 }        # nothing committed


### PR DESCRIPTION
TERM ch.3 audit fixes (#1241 §3.1 + #1242 §3.2, program #814): the catalogue had no wire case refusing an out-of-code-set or out-of-group envelope code — audit_change_type and lifecycle_state were the only TERM-membership behaviours exercised on the wire. Adds four isolated create_composition refusal cases (one behaviour per case) with their own invalid fixtures (minimal_event.v1, one field mutated, MANIFEST-registered with defect + spec_ref):

- `-territory_invalid` — territory `ZZ` outside the `countries` code set (TERM §Code Sets, RM ehr Territory_valid) → 422, nothing committed
- `-language_invalid` — language `zz` outside the `languages` code set (TERM §Code Sets, RM ehr Language_valid) → 422
- `-category_invalid` — category `999` outside `composition_category` (TERM §Vocabularies, RM ehr Category_validity) → 422
- `-setting_invalid` — setting `999` outside `setting` (TERM §Vocabularies, RM ehr Setting_valid) → 422

All expectations derived first-hand from the vendored spec text (never the SUT); exemplar text is the adjudicated create_composition 422 form. `cnf-runner validate`: 868 cases, 0 findings (coverage-report.md regenerated).

Closes #1417
Closes #1418