### PR TITLE
fix(service/message): accept the TERM extract_content_type group on EXTRACT_SPEC.extract_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`EXTRACT_SPEC.extract_type` accepts the TERM `extract_content_type`
+  vocabulary.** The EHR-Extract export refused the codes TERM 3.1.0 binds to
+  the attribute (803 "openEHR EHR" … 808 "other", openEHR terminology —
+  `SupportTerminology` §Vocabularies) and accepted only the RM-named string
+  tokens (`openehr-ehr`, …). Both value spaces are now accepted; anything
+  outside their union is still refused with a 400-family precondition error.
+
 ## [3.16.0] - 2026-08-01
 
 ### Added

--- a/app/ferroehr/src/service/message/export.rs
+++ b/app/ferroehr/src/service/message/export.rs
@@ -770,23 +770,26 @@ fn link_target_uuids(items: &[Value]) -> Vec<VoId> {
     out
 }
 
-/// The extract-content-type codes `EXTRACT_SPEC.extract_type` may carry.
+/// The RM-named string tokens `EXTRACT_SPEC.extract_type` may carry, beside
+/// the TERM `extract_content_type` vocabulary codes.
 ///
 /// The first five are the ones the RM names outright — RM `ehr_extract`
 /// `master04-common_package.adoc` §Content Criteria Specification:
 /// "`_extract_type_`: what kind of Extract this is, e.g. `|openehr-ehr|`,
 /// `|openehr-demographic|`, `|openehr-synchronisation|`, `|openehr-generic|`,
-/// `|generic-emr|`, etc". No terminology group binds the attribute (it appears
-/// in no `openehr_terminology` group and in no external-terminology binding),
-/// so there is nothing to validate against but that sentence.
+/// `|generic-emr|`, etc". TERM `SupportTerminology/master03-terminology.adoc`
+/// §Vocabularies additionally binds the attribute to the
+/// `extract_content_type` group (concepts 803 "openEHR EHR" … 808 "other"),
+/// validated against the bundle in [`validate_extract_type`] — the two value
+/// spaces are never reconciled upstream, so both are accepted.
 ///
-/// NOTE (no openEHR spec closes this set — our own design/extension): the RM's
-/// "etc" makes the list illustrative, so a service could accept anything. This
-/// one validates, because an unrecognized type silently exporting an
-/// openEHR-EHR extract would misdescribe its own payload — but the accepted
-/// set is a superset of every code the RM names, plus the catch-all `other`
-/// for a caller that has no better label. Refusing a code the RM itself names
-/// would be refusing what must be accepted.
+/// NOTE (RM `ehr_extract` `master04-common_package.adoc` §Content Criteria
+/// Specification): the RM's "etc" makes its list illustrative, so a service
+/// could accept anything. This one validates, because an unrecognized type
+/// silently exporting an openEHR-EHR extract would misdescribe its own
+/// payload — but the accepted set is a superset of every code the RM names
+/// (plus the catch-all `other`) and of the whole TERM group. Refusing a code
+/// either spec names would be refusing what must be accepted.
 const EXTRACT_CONTENT_TYPES: [&str; 6] = [
     "openehr-ehr",
     "openehr-demographic",
@@ -796,19 +799,32 @@ const EXTRACT_CONTENT_TYPES: [&str; 6] = [
     "other",
 ];
 
-/// `EXTRACT_SPEC.extract_type` must be coded from [`EXTRACT_CONTENT_TYPES`].
+/// `EXTRACT_SPEC.extract_type` must be coded from the TERM
+/// `extract_content_type` vocabulary (openEHR terminology, concepts 803–808 —
+/// TERM `SupportTerminology/master03-terminology.adoc` §Vocabularies) or from
+/// the RM-named tokens in [`EXTRACT_CONTENT_TYPES`].
 fn validate_extract_type(spec: &ExtractSpec) -> Result<(), SmError> {
     let value = openehr_its::json::to_canonical_value(&spec.extract_type);
     let code = value
         .pointer("/defining_code/code_string")
         .and_then(Value::as_str)
         .unwrap_or_default();
+    let terminology = value
+        .pointer("/defining_code/terminology_id/value")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if terminology == "openehr"
+        && openehr_term::bundle::openehr().is_valid_code("extract_content_type", code)
+    {
+        return Ok(());
+    }
     if EXTRACT_CONTENT_TYPES.contains(&code) {
         return Ok(());
     }
     Err(SmError::precondition(format!(
-        "EXTRACT_SPEC.extract_type {code:?} is not an openEHR extract content \
-         type ({})",
+        "EXTRACT_SPEC.extract_type {code:?} is neither a member of the openEHR \
+         extract_content_type vocabulary nor an RM-named extract content type \
+         ({})",
         EXTRACT_CONTENT_TYPES.join(" | ")
     )))
 }

--- a/app/ferroehr/tests/it/service_extract.rs
+++ b/app/ferroehr/tests/it/service_extract.rs
@@ -330,6 +330,32 @@ async fn extract_spec_flags_are_honoured() {
             .unwrap_or_else(|e| panic!("extract_type {named:?} must be accepted: {}", e.message));
     }
 
+    // TERM `SupportTerminology/master03-terminology.adoc` §Vocabularies binds
+    // the attribute to the `extract_content_type` group (803 "openEHR EHR" …
+    // 808 "other"), so every group member coded in the openEHR terminology
+    // must be accepted too.
+    for term_coded in ["803", "804", "805", "806", "807", "808"] {
+        spec["extract_type"]["defining_code"]["code_string"] = json!(term_coded);
+        svc.export_ehr_extracts(openehr_its::json::from_canonical_value(&spec).expect("spec"))
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "TERM-coded extract_type {term_coded:?} must be accepted: {}",
+                    e.message
+                )
+            });
+    }
+
+    // A TERM group code under a FOREIGN terminology id is not a group member:
+    // the openEHR concept codes are meaningful only in the openehr
+    // terminology, and "803" is no RM-named token either.
+    spec["extract_type"]["defining_code"]["code_string"] = json!("803");
+    spec["extract_type"]["defining_code"]["terminology_id"]["value"] = json!("SNOMED-CT");
+    svc.export_ehr_extracts(openehr_its::json::from_canonical_value(&spec).expect("spec"))
+        .await
+        .expect_err("a foreign-terminology 803 must be rejected");
+    spec["extract_type"]["defining_code"]["terminology_id"]["value"] = json!("openehr");
+
     // Valid type + include_multimedia = false → exported bodies carry no
     // inline DV_MULTIMEDIA data.
     spec["extract_type"]["defining_code"]["code_string"] = json!("openehr-ehr");

--- a/tools/cnf-runner/artifacts/schedule/messaging/I_EHR_EXTRACT_SERVICE.export_ehr_extracts-term_coded_extract_type.yaml
+++ b/tools/cnf-runner/artifacts/schedule/messaging/I_EHR_EXTRACT_SERVICE.export_ehr_extracts-term_coded_extract_type.yaml
@@ -1,0 +1,62 @@
+# The TERM-vocabulary ACCEPT side of the extract_type validation.
+#
+# TERM `SupportTerminology/master03-terminology.adoc` §Vocabularies defines
+# the `extract_content_type` group — 803 "openEHR EHR", 804 "openEHR
+# Demographic", 805 "openEHR synchronisation", 806 "openEHR generic",
+# 807 "generic EMR", 808 "other" — and binds it to `EXTRACT_SPEC.extract_type`
+# (`terminology_vocabularies_vars.adoc` :extract_content_type_links:). A
+# service refusing a group member coded in the openEHR terminology would be
+# refusing what TERM itself names — the same must-not-narrow edge the
+# `-spec_named_extract_type` sibling pins for the RM's illustrative string
+# tokens (the two value spaces are never reconciled upstream; both are
+# normative-named and both must be accepted).
+#
+# This row drives 803|openEHR EHR| coded in the openehr terminology; the
+# refusal edge is the `-unknown_extract_type` sibling.
+id: I_EHR_EXTRACT_SERVICE.export_ehr_extracts-term_coded_extract_type
+kind: functional
+component: MESSAGING
+sm_operation: I_EHR_EXTRACT_SERVICE.export_ehr_extracts
+capabilities: [EhrExtract]
+profiles: [OPTIONS]
+test_purpose: >-
+  An EXTRACT_SPEC whose extract_type is a member of the TERM
+  extract_content_type vocabulary (803, openEHR terminology) is accepted and
+  exported — the validation may not narrow the attribute below the group TERM
+  binds to it.
+description: "Export by an EXTRACT_SPEC with the TERM-coded extract_type 803|openEHR EHR|"
+spec_refs:
+  - "SM openehr_platform §I_EHR_EXTRACT_SERVICE.export_ehr_extracts"
+  - "TERM SupportTerminology §Vocabularies (extract content type; bound to EXTRACT_SPEC.extract_type)"
+  - "RM ehr_extract master04-common_package §Content Criteria Specification (extract_type)"
+applies: { rm: ">=1.0.2" }
+guards:
+  - "EXTENSION ROUTE — no openEHR spec governs the /message/* routes; our own design/extension, declared in vocab/wire_surface.yaml served_extensions (family message-extract) and adjudicated by register AMB-34. The row gates the CAPABILITY verdicts only, never ITS-REST wire conformance"
+requires: { ehr: { commits: any } }        # mints ${ehr_id}
+flow:
+  - step: 1
+    call: export_ehr_extracts
+    with:
+      extract_spec:
+        _type: EXTRACT_SPEC
+        extract_type:
+          _type: DV_CODED_TEXT
+          value: openEHR EHR
+          defining_code:
+            _type: CODE_PHRASE
+            terminology_id: { _type: TERMINOLOGY_ID, value: openehr }
+            code_string: "803"
+        include_multimedia: false
+        priority: 0
+        link_depth: 0
+        criteria: []
+        manifest:
+          _type: EXTRACT_MANIFEST
+          entities:
+            - _type: EXTRACT_ENTITY_MANIFEST
+              extract_id_key: "${ehr_id}"
+              ehr_id: "${ehr_id}"
+              other_ids: []
+              item_list: []
+    expect: ok
+ambiguities: [AMB-34]

--- a/tools/cnf-runner/artifacts/schedule/messaging/I_EHR_EXTRACT_SERVICE.export_ehr_extracts-unknown_extract_type.yaml
+++ b/tools/cnf-runner/artifacts/schedule/messaging/I_EHR_EXTRACT_SERVICE.export_ehr_extracts-unknown_extract_type.yaml
@@ -5,14 +5,16 @@
 # `master04-common_package.adoc` §Content Criteria Specification says
 # "_extract_type_: what kind of Extract this is, e.g. `|openehr-ehr|`,
 # `|openehr-demographic|`, `|openehr-synchronisation|`, `|openehr-generic|`,
-# `|generic-emr|`, etc" — an ILLUSTRATIVE list, bound to no terminology group,
-# so the spec closes nothing. The served route nevertheless validates, and says
-# so in its own contract, because an unrecognized type silently exporting an
-# openEHR-EHR extract would misdescribe its own payload. That is our own
-# design/extension, and the accepted set is a SUPERSET of every code the RM
-# names (plus the catch-all `other`) precisely so the validation cannot refuse
-# what the RM itself names — the accept side is pinned by the
-# `-spec_named_extract_type` sibling.
+# `|generic-emr|`, etc" — an ILLUSTRATIVE list — and TERM
+# `SupportTerminology/master03-terminology.adoc` §Vocabularies binds the
+# attribute to the `extract_content_type` group (803–808). The served route
+# validates against the UNION of the two value spaces (they are never
+# reconciled upstream), because an unrecognized type silently exporting an
+# openEHR-EHR extract would misdescribe its own payload; the accepted set is
+# a SUPERSET of every code either spec names precisely so the validation
+# cannot refuse what a spec itself names — the accept sides are pinned by the
+# `-spec_named_extract_type` (RM tokens) and `-term_coded_extract_type`
+# (TERM group) siblings.
 #
 # The value driven here is outside any reading of the attribute, so the row
 # tests the refusal and not the boundary of a private list.
@@ -29,6 +31,7 @@ description: "Export by an EXTRACT_SPEC with an out-of-group extract_type"
 spec_refs:
   - "SM openehr_platform §I_EHR_EXTRACT_SERVICE.export_ehr_extracts"
   - "RM ehr_extract master04-common_package §Content Criteria Specification (extract_type)"
+  - "TERM SupportTerminology §Vocabularies (extract content type)"
 applies: { rm: ">=1.0.2" }
 guards:
   - "EXTENSION ROUTE — no openEHR spec governs the /message/* routes; our own design/extension, declared in vocab/wire_surface.yaml served_extensions (family message-extract) and adjudicated by register AMB-34. The row gates the CAPABILITY verdicts only, never ITS-REST wire conformance"


### PR DESCRIPTION
TERM ch.3 §3.2 audit fix (#1242, program #814). TERM 3.1.0 `SupportTerminology/master03-terminology.adoc` §Vocabularies defines the `extract_content_type` vocabulary (803 "openEHR EHR" … 808 "other") and binds it to `EXTRACT_SPEC.extract_type` (`terminology_vocabularies_vars.adoc`); `validate_extract_type` accepted only the RM-prose string tokens and its NOTE claimed "it appears in no `openehr_terminology` group" — false at TERM 3.1.0.

- `validate_extract_type` now accepts the union: openEHR-terminology members of the `extract_content_type` group (bundle-driven) + the RM-named tokens; a group code under a foreign terminology id is still refused. Doc comment corrected with the TERM citation.
- Integration test extended: all six 803–808 accepted, foreign-terminology 803 refused, RM tokens unchanged.
- CNF: new `-term_coded_extract_type` valid twin; `-unknown_extract_type` adjudication + spec_refs updated to cite the TERM group. `cnf-runner validate`: 869 cases, 0 findings.
- Changelog entry under [Unreleased] ### Fixed.

Gates: fmt, clippy -p ferroehr --all-targets, nextest (extract battery), cnf validate.

Closes #1416