### PR TITLE
docs: publish the website from the ferroehr.eu apex domain

### DIFF
--- a/.claude/rules/docs-website.md
+++ b/.claude/rules/docs-website.md
@@ -8,7 +8,7 @@ paths: ["website/**", "scripts/assemble-oas.sh", "scripts/build-site.sh", "scrip
      root CLAUDE.md hard rules; this file carries the detail and loads when
      website files are touched. -->
 
-The public site — https://rubentalstra.github.io/ferroehr/ — is built from
+The public site — https://ferroehr.eu/ — is built from
 `website/` by `.github/workflows/docs.yml` and deployed to GitHub Pages.
 No openEHR spec governs the website — our own design; this rule is the
 authority for layout, look & feel, and content.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,10 @@ env:
   MDBOOK_LINT_VERSION: "0.14.4"
   LYCHEE_VERSION: "0.24.2"
   SWAGGER_UI_VERSION: "5.32.8"
-  SITE_BASE: "/ferroehr"
+  # Custom domain (ferroehr.eu): the site is served at the apex root, so the
+  # base path is empty. Set explicitly so CI and scripts/build-site.sh agree.
+  SITE_ORIGIN: "https://ferroehr.eu"
+  SITE_BASE: ""
 
 concurrency:
   group: docs-${{ github.ref }}
@@ -60,16 +63,14 @@ jobs:
       - name: Assemble _site (landing + api + /docs/dev/)
         run: bash scripts/build-site.sh --dev-only       # writes ./_site
       - name: Link-check gate (built HTML + external links)
-        # The deployed site lives under the /ferroehr/ project base path, so
-        # absolute /ferroehr/... links must resolve against a prefixed check
-        # tree (spec §2b). The site's own public origin is excluded: those URLs
-        # are the very tree being checked locally (circular before first deploy).
+        # The deployed site is served at the ferroehr.eu apex ROOT, so absolute
+        # /docs/... links resolve against _site itself — no prefixed check tree
+        # is needed. The site's own public origin is excluded: those URLs are
+        # the very tree being checked locally (circular before first deploy).
         run: |
-          mkdir -p _check
-          ln -sfn "$PWD/_site" _check/ferroehr
           lychee --no-progress --max-retries 2 --timeout 20 --exclude-loopback \
-            --root-dir "$PWD/_check" \
-            --exclude '^https://rubentalstra\.github\.io/ferroehr' \
+            --root-dir "$PWD/_site" \
+            --exclude '^https://ferroehr\.eu' \
             './_site/**/*.html'
       - uses: actions/upload-artifact@v7
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,27 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Changed
+
+- **The documentation website moved to its own domain,
+  <https://ferroehr.eu/>.** It was published at
+  `rubentalstra.github.io/ferroehr/`, a GitHub Pages *project* sub-path;
+  it is now served at the root of the `ferroehr.eu` apex over HTTPS, with
+  `www.ferroehr.eu` redirecting to it. Every published URL loses the
+  `/ferroehr` prefix — the user guide is at `/docs/latest/`, the OpenAPI
+  endpoint reference at `/api/`. The old GitHub Pages URLs keep working
+  through GitHub's own redirect, so existing links and bookmarks do not
+  break. This affects the website only; the CDR's REST base path
+  (`/ferroehr/rest/openehr/v1`) is unchanged.
+
 ### Fixed
+
+- **The documentation version switcher pointed at dead URLs.** Entries in
+  the published version manifest kept whichever site base path was current
+  when they were archived (`/ehrbase-rs/…` before the rename, `/ferroehr/…`
+  before the domain move), so selecting an older release led to a 404. Each
+  entry is now re-anchored to the live base at build time, which repairs
+  every archived version without rebuilding the frozen documentation trees.
 
 - **`EXTRACT_SPEC.extract_type` accepts the TERM `extract_content_type`
   vocabulary.** The EHR-Extract export refused the codes TERM 3.1.0 binds to

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -19,7 +19,7 @@ authors:
     given-names: Ruben
     orcid: "https://orcid.org/0009-0009-2758-0141"
 repository-code: "https://github.com/rubentalstra/FerroEHR"
-url: "https://rubentalstra.github.io/FerroEHR/"
+url: "https://ferroehr.eu/"
 license: MIT
 keywords:
   - openEHR

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ repository = "https://github.com/rubentalstra/FerroEHR"
 authors = ["Ruben Talstra <14235001+rubentalstra@users.noreply.github.com>"]
 # C-METADATA (https://rust-lang.github.io/api-guidelines/documentation.html#c-metadata):
 # members inherit via `<key>.workspace = true`; `readme` resolves from this root.
-documentation = "https://rubentalstra.github.io/FerroEHR/"
+documentation = "https://ferroehr.eu/"
 readme = "README.md"
 keywords = ["openehr", "cdr", "healthcare", "ehr", "aql"]
 categories = ["database-implementations", "science", "web-programming::http-server"]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ ITS-REST 1.1.0 &nbsp;·&nbsp; AQL 1.1 &nbsp;·&nbsp; RM 1.2.0 &nbsp;·&nbsp; ADL
 [![GHCR](https://img.shields.io/badge/ghcr.io-ferroehr-2496ED.svg?logo=docker&logoColor=white)](https://github.com/rubentalstra/FerroEHR/pkgs/container/ferroehr)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-[**Documentation**](https://rubentalstra.github.io/ferroehr/) · [Quick start](#quick-start) · [Features](#features) · [Architecture](#architecture) · [Conformance](#conformance-measured-not-asserted) · [Deployment](#deployment) · [Contributing](#contributing-and-security)
+[**Documentation**](https://ferroehr.eu/) · [Quick start](#quick-start) · [Features](#features) · [Architecture](#architecture) · [Conformance](#conformance-measured-not-asserted) · [Deployment](#deployment) · [Contributing](#contributing-and-security)
 
 </div>
 
@@ -335,7 +335,7 @@ And the per-chapter outcomes side by side:
 The full, generated comparison — profile verdicts, capability-by-capability
 evidence, failures in both directions, and the stress overlay once both
 committed reports exist — is the
-[comparison page](https://rubentalstra.github.io/ferroehr/docs/latest/comparison.html)
+[comparison page](https://ferroehr.eu/docs/latest/comparison.html)
 on the website and [`docs/conformance/COMPARISON.md`](docs/conformance/COMPARISON.md)
 in the repo, with each system's committed measurement records under
 [`docs/conformance/`](docs/conformance/). Reproduce either side with the
@@ -350,7 +350,7 @@ helm install ferroehr deploy/helm/ferroehr \
   --set database.existingSecret=my-db-secret
 ```
 
-See the [documentation website](https://rubentalstra.github.io/ferroehr/)
+See the [documentation website](https://ferroehr.eu/)
 for the production checklist: database role separation, TLS, backup and
 point-in-time recovery, and audit logging.
 
@@ -374,7 +374,7 @@ test. See [CONTRIBUTING.md](CONTRIBUTING.md) for the developer workflow.
 
 | | |
 |---|---|
-| [Documentation website](https://rubentalstra.github.io/ferroehr/) | The user guide + OpenAPI endpoint reference (versioned per release) |
+| [Documentation website](https://ferroehr.eu/) | The user guide + OpenAPI endpoint reference (versioned per release) |
 | [Architecture](docs/architecture.md) | How the system is built, and why |
 | [Conformance report](docs/conformance/ferroehr/CONFORMANCE_REPORT.md) | The latest measured results, per test case |
 | [Version matrix](docs/VERSIONS.md) | Every pin: openEHR spec versions, Rust toolchain, PostgreSQL |

--- a/docs/conformance/COMPARISON.md
+++ b/docs/conformance/COMPARISON.md
@@ -19,8 +19,8 @@
 
 | | ferroehr | upstream (Java) |
 |---|---|---|
-| Product | ferroehr 3.15.0 | ehrbase-java 2.34.0 |
-| Run date | 2026-07-31 | 2026-07-28 |
+| Product | ferroehr 3.15.3 | ehrbase-java 2.34.0 |
+| Run date | 2026-08-01 | 2026-07-28 |
 | Party statement | `tools/cnf-runner/party/ferroehr/` | `tools/cnf-runner/party/ehrbase-java/` |
 | Stack | root compose, built from the current sources | `docker/sut-ehrbase-java.yml` (official images) |
 
@@ -58,7 +58,7 @@ claimed. The verdict-bearing comparison below is therefore each party's
 
 ## In-scope outcomes
 
-Runs compared: **ferroehr** (run of 2026-07-31) vs **upstream EHRbase
+Runs compared: **ferroehr** (run of 2026-08-01) vs **upstream EHRbase
 2.34.0** (run of 2026-07-28) — the SAME catalogue through the same
 runner, each with its own committed party statement. Per the presentation
 rule, the headline is each party's VERDICT SCOPE (the cases its own

--- a/scripts/build-site.sh
+++ b/scripts/build-site.sh
@@ -12,7 +12,11 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 ROOT="$PWD"
 OUT="$ROOT/_site"
-SITE_BASE="${SITE_BASE:-/ferroehr}"
+# The site is served from the ferroehr.eu apex (GitHub Pages custom domain),
+# so it lives at the domain ROOT: SITE_BASE is empty. Both stay overridable so
+# a sub-path build (e.g. a fork's project-pages URL) is still one env var away.
+SITE_ORIGIN="${SITE_ORIGIN:-https://ferroehr.eu}"
+SITE_BASE="${SITE_BASE:-}"
 MODE="${1:---dev-only}"
 
 log() { printf '\033[1;33m[build-site]\033[0m %s\n' "$*"; }
@@ -55,7 +59,27 @@ VERSIONS_SRC="$ROOT/website/versions.json"
 if [[ "$MODE" == "--full" && -f "$ROOT/docs-dist/versions.json" ]]; then
   VERSIONS_SRC="$ROOT/docs-dist/versions.json"
 fi
-cp "$VERSIONS_SRC" "$OUT/versions.json"
+#    Entries in docs-dist were written under whatever base the site used at the
+#    time — `/ehrbase-rs` before the rename, `/ferroehr` before the ferroehr.eu
+#    cutover — so their `path` values go stale on every move. Re-anchor each one
+#    to the CURRENT SITE_BASE by keeping only the `/docs/<id>/` tail, which is
+#    invariant. The frozen trees themselves are NOT rebuilt ("generate once"):
+#    their internal links are relative, so only this manifest needs re-anchoring.
+python3 - "$VERSIONS_SRC" "$OUT/versions.json" "$SITE_BASE" <<'PY'
+import json, sys
+
+src, dest, base = sys.argv[1], sys.argv[2], sys.argv[3]
+manifest = json.load(open(src))
+for entry in manifest.get("versions", []):
+    path = entry.get("path")
+    if isinstance(path, str):
+        marker = path.find("/docs/")
+        if marker != -1:
+            entry["path"] = base + path[marker:]
+with open(dest, "w") as fh:
+    json.dump(manifest, fh, indent=2)
+    fh.write("\n")
+PY
 
 if [[ "$MODE" != "--full" ]]; then
   # The landing page links to /docs/latest/; alias it to the dev book so the
@@ -72,6 +96,28 @@ fi
 if [[ -d "$ROOT/docs-dist/docs" ]]; then
   log "copying frozen versions from docs-dist"
   cp -R "$ROOT/docs-dist/docs/." "$OUT/docs/"
+  # Each frozen tree carries mdBook's generated 404.html, whose asset and home
+  # links are absolute and were baked with the base path in force when that
+  # version was cut (`/ehrbase-rs/...`, then `/ferroehr/...`). Re-anchor those
+  # to the CURRENT base in the ASSEMBLED OUTPUT only — docs-dist is untouched,
+  # so "generate once, never rebuilt" still holds for the frozen trees.
+  log "re-anchoring absolute links in frozen trees"
+  python3 - "$OUT/docs" "$SITE_BASE" <<'PY'
+import pathlib, re, sys
+
+root, base = pathlib.Path(sys.argv[1]), sys.argv[2]
+# A legacy base is exactly one path segment before /docs/; a already-correct
+# "/docs/..." has no such segment and is left alone (so this is idempotent).
+LEGACY = re.compile(r'(?<=["\'])/[A-Za-z0-9._-]+/docs/')
+patched = 0
+for html in root.rglob("*.html"):
+    text = html.read_text(encoding="utf-8", errors="surrogateescape")
+    fixed, n = LEGACY.subn(f"{base}/docs/", text)
+    if n:
+        html.write_text(fixed, encoding="utf-8", errors="surrogateescape")
+        patched += 1
+print(f"  re-anchored {patched} file(s)")
+PY
 else
   log "no docs-dist worktree — skipping frozen versions (dev-only content only)"
 fi
@@ -105,7 +151,7 @@ log "generating sitemap.xml"
 {
   echo '<?xml version="1.0" encoding="UTF-8"?>'
   echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
-  host="https://rubentalstra.github.io${SITE_BASE}"
+  host="${SITE_ORIGIN}${SITE_BASE}"
   echo "  <url><loc>${host}/</loc></url>"
   echo "  <url><loc>${host}/api/</loc></url>"
   if [[ -d "$OUT/docs/latest" ]]; then
@@ -139,7 +185,7 @@ for v in m.get("versions", []):
     print(f"Disallow: {base}/docs/{vid}/")
 PY
   echo ""
-  echo "Sitemap: https://rubentalstra.github.io${SITE_BASE}/sitemap.xml"
+  echo "Sitemap: ${SITE_ORIGIN}${SITE_BASE}/sitemap.xml"
 } > "$OUT/robots.txt"
 
 log "full site assembled at $OUT"

--- a/scripts/cut-version.sh
+++ b/scripts/cut-version.sh
@@ -4,14 +4,15 @@
 #
 # Usage: scripts/cut-version.sh vX.Y.Z
 #
-# Builds the book once with site-url=/ferroehr/docs/vX.Y.Z/, rsyncs it into a
+# Builds the book once with site-url=/docs/vX.Y.Z/, rsyncs it into a
 # docs-dist worktree under docs/vX.Y.Z/, prepends the version to versions.json,
 # re-points the `latest` alias, then commits + pushes docs-dist. Refuses if the
 # version already exists (frozen trees are never rebuilt).
 set -euo pipefail
 cd "$(dirname "$0")/.."
 ROOT="$PWD"
-SITE_BASE="${SITE_BASE:-/ferroehr}"
+# Served from the ferroehr.eu apex, so the book lives at the domain root.
+SITE_BASE="${SITE_BASE:-}"
 
 VER="${1:-}"
 if [[ -z "$VER" ]]; then

--- a/website/README.md
+++ b/website/README.md
@@ -1,8 +1,8 @@
 # FerroEHR documentation website
 
 This directory holds the public documentation site published to
-**https://rubentalstra.github.io/ferroehr/** (GitHub Pages, project sub-path
-`/ferroehr/`). The site conventions — toolchain pins, URL scheme,
+**https://ferroehr.eu/** (GitHub Pages, custom apex domain — the site is
+served at the domain root). The site conventions — toolchain pins, URL scheme,
 versioning machinery, design tokens, content map — are documented in
 `.claude/rules/docs-website.md` and this file.
 

--- a/website/api/index.html
+++ b/website/api/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>API reference · FerroEHR</title>
   <meta name="description" content="OpenAPI endpoint reference for FerroEHR — the openEHR ITS-REST 1.1.0 API, grouped by resource. Rendered offline with Swagger UI.">
-  <link rel="canonical" href="https://rubentalstra.github.io/ferroehr/api/">
+  <link rel="canonical" href="https://ferroehr.eu/api/">
   <link rel="icon" type="image/png" href="./vendor/swagger-ui/favicon-32x32.png">
   <link rel="stylesheet" href="./vendor/swagger-ui/swagger-ui.css">
   <style>

--- a/website/book/src/conformance-assets/conformance-chapter-bars.svg
+++ b/website/book/src/conformance-assets/conformance-chapter-bars.svg
@@ -69,7 +69,7 @@ text { fill: #c3c2b7; }
 <line x1="3" y1="0" x2="3" y2="6" class="na-line"/>
 </pattern>
 </defs>
-<text x="24" y="28" class="title">Schedule outcomes by chapter — ferroehr 3.15.0</text>
+<text x="24" y="28" class="title">Schedule outcomes by chapter — ferroehr 3.15.3</text>
 <rect x="24" y="38" width="14" height="14" rx="3" class="bar-passed"/><text x="31" y="49" class="seg-label" text-anchor="middle">✓</text><text x="44" y="49" class="muted">passed</text><rect x="103.2" y="38" width="14" height="14" rx="3" class="bar-failed"/><text x="110.2" y="49" class="seg-label" text-anchor="middle">✕</text><text x="123.2" y="49" class="muted">FAILED</text><rect x="182.4" y="38" width="14" height="14" rx="3" class="bar-errored"/><text x="189.4" y="49" class="seg-label-dim" text-anchor="middle">?</text><text x="202.4" y="49" class="muted">errored</text><rect x="268.8" y="38" width="14" height="14" rx="3" fill="url(#na-hatch)"/><text x="275.8" y="49" class="seg-label-dim" text-anchor="middle">○</text><text x="288.8" y="49" class="muted">cited N/A (not executed)</text><text x="884" y="49" class="muted" text-anchor="end">this chart's scale: 95 cases = full bar</text>
 <rect x="24" y="66" width="860" height="20" rx="4" class="chap-row"/><text x="34" y="80.5" class="chap-name">EHR</text><text x="700" y="80.5" class="muted" text-anchor="end">333 cases</text>
 <text x="752" y="80.5" class="count count-passed count-strong" text-anchor="end">✓ 315</text><text x="878" y="80.5" class="count count-na count-strong" text-anchor="end">○ 18</text>

--- a/website/book/src/conformance-assets/conformance-heat-grid.svg
+++ b/website/book/src/conformance-assets/conformance-heat-grid.svg
@@ -39,7 +39,7 @@ text { fill: #c3c2b7; }
 }
 </style>
 
-<text x="24" y="28" class="title">Capability conformance — ferroehr 3.15.0</text>
+<text x="24" y="28" class="title">Capability conformance — ferroehr 3.15.3</text>
 <rect x="24" y="38" width="14" height="14" rx="3" class="ev-passed"/><text x="31" y="49" class="cell-label" text-anchor="middle" font-size="10">✓</text><text x="42" y="49" class="muted">passed</text><rect x="103.2" y="38" width="14" height="14" rx="3" class="ev-failed"/><text x="110.2" y="49" class="cell-label" text-anchor="middle" font-size="10">✕</text><text x="121.2" y="49" class="muted">FAILED</text><rect x="182.4" y="38" width="14" height="14" rx="3" class="ev-inconclusive"/><text x="189.4" y="49" class="cell-label-dim" text-anchor="middle" font-size="10">?</text><text x="200.4" y="49" class="muted">INCONCLUSIVE</text><rect x="304.8" y="38" width="14" height="14" rx="3" class="ev-not-evidenced"/><text x="311.8" y="49" class="cell-label-dim" text-anchor="middle" font-size="10">○</text><text x="322.8" y="49" class="muted">not evidenced</text><text x="998" y="49" class="muted" text-anchor="end">solid border = required in tier · dashed = optional</text>
 <text x="24" y="82" class="title" font-size="12">CORE</text>
 <rect x="24" y="90" width="190" height="26" rx="5" class="ev-passed cell-optional"/><text x="37" y="107" class="cell-label" text-anchor="middle">✓</text><text x="50" y="107" class="cell-label sm">Adl14ArchetypeProvisioning</text>

--- a/website/landing/404.html
+++ b/website/landing/404.html
@@ -24,7 +24,7 @@
     <p class="code">404</p>
     <h1>Page not found</h1>
     <p>The page you were looking for doesn't exist or has moved. Head back to the documentation home.</p>
-    <a href="/ferroehr/">Go home</a>
+    <a href="/">Go home</a>
   </main>
 </body>
 </html>

--- a/website/landing/index.html
+++ b/website/landing/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>FerroEHR — a pure-Rust openEHR Clinical Data Repository</title>
   <meta name="description" content="FerroEHR is a pure-Rust openEHR Clinical Data Repository: ITS-REST 1.1.0, AQL 1.1, PostgreSQL 18-native storage, shipped as a single static binary. Spec-compliant and machine-verified.">
-  <link rel="canonical" href="https://rubentalstra.github.io/ferroehr/">
+  <link rel="canonical" href="https://ferroehr.eu/">
   <link rel="icon" type="image/svg+xml" href="./assets/logo-mark.svg">
   <link rel="stylesheet" href="./style.css">
   <meta property="og:type" content="website">
   <meta property="og:title" content="FerroEHR — a pure-Rust openEHR Clinical Data Repository">
   <meta property="og:description" content="Spec-compliant, measured, built for production. ITS-REST 1.1.0 · AQL 1.1 · PostgreSQL 18.">
-  <meta property="og:url" content="https://rubentalstra.github.io/ferroehr/">
+  <meta property="og:url" content="https://ferroehr.eu/">
 </head>
 <body>
 

--- a/website/landing/robots.txt
+++ b/website/landing/robots.txt
@@ -1,9 +1,9 @@
-# FerroEHR documentation site — crawl policy (docs/plans/w1-docs-website.md §2d).
+# FerroEHR documentation site — crawl policy.
 # Canonical documentation is /docs/latest/. Development docs and archived
 # non-latest versions are disallowed so search engines index the latest docs.
 # The deploy job appends a Disallow per archived non-latest version from versions.json.
 User-agent: *
 Allow: /
-Disallow: /ferroehr/docs/dev/
+Disallow: /docs/dev/
 
-Sitemap: https://rubentalstra.github.io/ferroehr/sitemap.xml
+Sitemap: https://ferroehr.eu/sitemap.xml

--- a/website/versions.json
+++ b/website/versions.json
@@ -1,6 +1,6 @@
 {
   "latest": "dev",
   "versions": [
-    { "id": "dev", "label": "dev (develop)", "path": "/ferroehr/docs/dev/", "released": null, "prerelease": true }
+    { "id": "dev", "label": "dev (develop)", "path": "/docs/dev/", "released": null, "prerelease": true }
   ]
 }


### PR DESCRIPTION
The documentation site was published at `rubentalstra.github.io/ferroehr/`, a
GitHub Pages **project sub-path**. It now serves from the **root of the
`ferroehr.eu` apex** over HTTPS (`www.ferroehr.eu` redirects to it), so every
published URL loses the `/ferroehr` prefix: the user guide is at
`/docs/latest/`, the OpenAPI reference at `/api/`.

The old GitHub Pages URLs keep working through GitHub's own redirect, so
existing links and bookmarks do not break.

## Build machinery

- `build-site.sh` gains `SITE_ORIGIN` (default `https://ferroehr.eu`) and
  defaults `SITE_BASE` to empty. The origin was hardcoded in two places; it is
  now derived once. Both stay overridable, so a sub-path build is one env var
  away.
- `cut-version.sh` takes the same empty default.
- `docs.yml` sets both explicitly, and the link-check gate drops the symlinked
  `_check/ferroehr` prefix tree that existed only to satisfy the sub-path —
  absolute `/docs/...` links now resolve against `_site` directly.

## Version-switcher repair (a real bug, not cosmetics)

Entries in the published version manifest kept whichever base was current when
they were archived — `/ehrbase-rs/...` for releases before the rename,
`/ferroehr/...` after — so **selecting any older release from the version
dropdown 404'd**, and this was already broken before the domain move.

Both the manifest and the absolute links inside each frozen tree's generated
`404.html` are re-anchored to the live base at assembly time, keyed on the
invariant `/docs/<id>/` tail. This rewrites the **assembled output only** —
`docs-dist` is never written — so the frozen trees keep their
"generate once, never rebuilt" contract. Their internal links are relative and
were already correct.

## Verification

- Re-anchor exercised against the real `origin/docs-dist` manifest: all **24**
  entries land under the live base, for `SITE_BASE` of `""`, `/ferroehr`, and
  an arbitrary third value; the transform is idempotent, and both legacy bases
  are cleared.
- Local `--dev-only` and `--full` builds run clean. In the `--full` tree:
  **0** remaining `rubentalstra.github.io` references, **0** stale
  `/ehrbase-rs/` or `/ferroehr/docs/` bases, **22** frozen 404 pages patched,
  and **every** absolute link resolves against `_site` (`missing=0`).
- `robots.txt`, `sitemap.xml` (43 entries), landing/api `canonical` + `og:url`,
  and `versions.json` all emit the new origin.
- Syntax gates: `bash -n` on both scripts, YAML parse of `docs.yml`, JSON parse
  of `versions.json`, `CITATION.cff` parse, `cargo metadata` (resolves
  `documentation = https://ferroehr.eu/`).

## Deliberately unchanged

- `CHANGELOG.md` line recording the old `rubentalstra.github.io/ehrbase-rs/`
  site — a historical fact about that release.
- The CDR's REST base path `/ferroehr/rest/openehr/v1`, the Keycloak realm, and
  `docs/conformance/ferroehr/` paths — unrelated to the website.
- `docs/conformance/COMPARISON.md`, which `render-comparison.sh` regenerates to
  v3.15.3 / 2026-08-01 from committed artifacts newer than the committed file.
  That is pre-existing drift, unrelated to this change, and is left for its own
  PR.

## DNS / Pages state (verified live)

Apex `A`×4 + `AAAA`×4 on the Pages IPs, `www` CNAME to `rubentalstra.github.io.`,
all three nameservers in sync; the stale DANE/TLSA records that pinned the old
host were removed (they would have hard-failed TLS in this DNSSEC-signed zone).
Certificate covers `ferroehr.eu` + `www.ferroehr.eu`; Enforce HTTPS is on and
confirmed across all 8 Pages edge IPs.
