### PR TITLE
chore(lints): deny-tier clippy hardening — all/pedantic to deny + new restriction lints, workspace fallout fixed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ categories = ["database-implementations", "science", "web-programming::http-serv
 # clippy::lint_groups_priority (correctness). Restriction lints are CHERRY-
 # PICKED individually; the group is never enabled wholesale (official Clippy
 # guidance, https://doc.rust-lang.org/clippy/lints.html).
-all = { level = "warn", priority = -1 }
-pedantic = { level = "warn", priority = -1 }
+all = { level = "deny", priority = -1 }
+pedantic = { level = "deny", priority = -1 }
 
 # ── the panic family — closed completely ────────────────────────────────────
 unwrap_used = "deny"
@@ -44,12 +44,14 @@ panic = "deny"                      # recoverable = Result; a panic is never a d
 unimplemented = "deny"
 todo = "deny"                       # owner rule 2026-07-12: no todo!() ever
 unreachable = "deny"                # unreachable!() is a panic; a "cannot happen" state gets a typed error
-panic_in_result_fn = "warn"         # a fn returning Result must not panic/assert instead
-missing_assert_message = "warn"     # production asserts carry a message (lint ignores test fns by design)
+panic_in_result_fn = "deny"         # a fn returning Result must not panic/assert instead
+missing_assert_message = "deny"     # production asserts carry a message (lint ignores test fns by design)
 dbg_macro = "deny"
 print_stdout = "deny"               # libraries speak tracing; binaries/tools relax per-crate
 print_stderr = "deny"
 incompatible_msrv = "deny"          # MSRV 1.96 is a hard pin
+unchecked_time_subtraction = "deny" # std::time::Duration::sub panics on negative durations; jiff is the safe alternative
+as_conversions = "deny"             # `as` silently truncates; use TryFrom/TryInto or explicit casts
 
 # ── no panicking indexing (reliability.md; request paths must not panic) ────
 indexing_slicing = "deny"
@@ -146,6 +148,7 @@ redundant_lifetimes = "warn"
 trivial_casts = "warn"
 trivial_numeric_casts = "warn"
 ambiguous_negative_literals = "deny"  # `-x.pow(2)` reads wrong — numeric clarity
+arithmetic_side_effects = "deny"  # `x + y` where x or y is a side-effecting call (e.g., `x() + y()`) is a silent bug
 
 [workspace.lints.rustdoc]
 # Enforced by the CI doc job (RUSTDOCFLAGS=-D warnings, cargo doc --workspace)

--- a/app/ferroehr-admin-ui/src/chart_model.rs
+++ b/app/ferroehr-admin-ui/src/chart_model.rs
@@ -228,6 +228,7 @@ fn temporal_columns(
 /// `ORDER BY` in the query is the order on screen.
 fn row_order_axis(series: &[SeriesSpec], rows: &[Vec<Value>]) -> AxisSpec {
     #[expect(
+        clippy::as_conversions,
         clippy::cast_precision_loss,
         reason = "row ordinals of one page are tiny"
     )]
@@ -339,6 +340,7 @@ pub fn iso_epoch_seconds(text: &str) -> Option<f64> {
         return None;
     };
     #[expect(
+        clippy::as_conversions,
         clippy::cast_precision_loss,
         reason = "instants are inside f64's exact integer range"
     )]
@@ -358,6 +360,7 @@ pub fn time_tick_label(seconds: f64, span_seconds: f64) -> String {
         return "-".to_owned();
     }
     #[expect(
+        clippy::as_conversions,
         clippy::cast_possible_truncation,
         reason = "range-guarded immediately above"
     )]

--- a/app/ferroehr-rest/src/extensions/management/http_metrics.rs
+++ b/app/ferroehr-rest/src/extensions/management/http_metrics.rs
@@ -160,6 +160,7 @@ fn status_class(status: StatusCode) -> &'static str {
 /// The `Content-Length` of a message, in bytes, if declared. Body sizes fit a
 /// histogram sample exactly (well under `2^53`), so the widening is lossless.
 #[expect(
+    clippy::as_conversions,
     clippy::cast_precision_loss,
     reason = "a Content-Length is observed into an f64 histogram; f64 is exact to \
               2^53 bytes, far past any request or response this server accepts"

--- a/app/ferroehr-rest/tests/it/http.rs
+++ b/app/ferroehr-rest/tests/it/http.rs
@@ -123,6 +123,12 @@ fn basic(user: &str, pw: &str) -> String {
 /// Minimal standard base64 encoder (avoids adding a base64 dev-dep).
 fn b64(bytes: &[u8]) -> String {
     const T: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    // The 6-bit group is masked to 0..=63, so both conversions are lossless
+    // (`u8::try_from` cannot fail, `usize::from(u8)` is total).
+    let sextet = |n: u32, shift: u32| -> char {
+        let group = u8::try_from((n >> shift) & 63).expect("a 6-bit group should fit u8");
+        char::from(T[usize::from(group)])
+    };
     let mut out = String::new();
     for chunk in bytes.chunks(3) {
         let b = [
@@ -131,18 +137,10 @@ fn b64(bytes: &[u8]) -> String {
             *chunk.get(2).unwrap_or(&0),
         ];
         let n = (u32::from(b[0]) << 16) | (u32::from(b[1]) << 8) | u32::from(b[2]);
-        out.push(T[((n >> 18) & 63) as usize] as char);
-        out.push(T[((n >> 12) & 63) as usize] as char);
-        out.push(if chunk.len() > 1 {
-            T[((n >> 6) & 63) as usize] as char
-        } else {
-            '='
-        });
-        out.push(if chunk.len() > 2 {
-            T[(n & 63) as usize] as char
-        } else {
-            '='
-        });
+        out.push(sextet(n, 18));
+        out.push(sextet(n, 12));
+        out.push(if chunk.len() > 1 { sextet(n, 6) } else { '=' });
+        out.push(if chunk.len() > 2 { sextet(n, 0) } else { '=' });
     }
     out
 }

--- a/app/ferroehr/src/extensions/events/publisher.rs
+++ b/app/ferroehr/src/extensions/events/publisher.rs
@@ -333,6 +333,11 @@ async fn drain_batch(
     }
     tx.commit().await.map_err(DrainError::Db)?;
     if sent > 0 {
+        #[expect(
+            clippy::as_conversions,
+            reason = "the published-event count widens exactly: usize is at most 64 bits \
+                      on every supported target"
+        )]
         metrics::counter!(EVENTS_PUBLISHED).increment(sent as u64);
     }
     match publish_err {

--- a/app/ferroehr/src/service/admin/delete.rs
+++ b/app/ferroehr/src/service/admin/delete.rs
@@ -280,7 +280,13 @@ impl FerroEhrService {
                     .await?;
             }
             tx.commit().await?;
-            deleted += removed.len() as u64;
+            #[expect(
+                clippy::as_conversions,
+                reason = "the removed-row count widens exactly: usize is at most 64 bits \
+                          on every supported target"
+            )]
+            let removed_rows = removed.len() as u64;
+            deleted += removed_rows;
             self.gc_unreferenced_blobs(candidate_blobs).await;
         }
         Ok(deleted)

--- a/app/ferroehr/src/service/ehr/validation.rs
+++ b/app/ferroehr/src/service/ehr/validation.rs
@@ -94,6 +94,11 @@ impl FerroEhrService {
     /// [`ServiceError::ValidationFailed`] carrying every RM/terminology/
     /// template violation (→ 422); [`ServiceError`] from a failing template
     /// resolution.
+    #[expect(
+        clippy::as_conversions,
+        reason = "per-pass failure counts widen exactly for the metrics facade: usize \
+                  is at most 64 bits on every supported target"
+    )]
     pub(super) async fn validate_composition_for_commit(
         &self,
         composition: &Value,

--- a/app/ferroehr/src/system_log/sender.rs
+++ b/app/ferroehr/src/system_log/sender.rs
@@ -467,6 +467,11 @@ async fn drain(
                 {
                     Ok(()) => {
                         store_healthy.store(true, Ordering::Relaxed);
+                        #[expect(
+                            clippy::as_conversions,
+                            reason = "the batch record count widens exactly: usize is at \
+                                      most 64 bits on every supported target"
+                        )]
                         metrics::counter!(METRIC_SENT, "sink" => "store")
                             .increment(records.len() as u64);
                         if let Some(notify) = &sinks.feed_notify {
@@ -475,6 +480,11 @@ async fn drain(
                     }
                     Err(e) => {
                         store_healthy.store(false, Ordering::Relaxed);
+                        #[expect(
+                            clippy::as_conversions,
+                            reason = "the batch record count widens exactly: usize is at \
+                                      most 64 bits on every supported target"
+                        )]
                         metrics::counter!(METRIC_SEND_FAILED, "sink" => "store")
                             .increment(records.len() as u64);
                         tracing::warn!("ATNA audit store batch write failed: {e}");

--- a/app/ferroehr/src/system_log/syslog.rs
+++ b/app/ferroehr/src/system_log/syslog.rs
@@ -31,6 +31,11 @@ pub const SYSLOG_FACILITY: u8 = 10;
 /// Syslog severity 5 — Notice (RFC 5424 §6.2.1).
 pub const SYSLOG_SEVERITY: u8 = 5;
 /// Computed PRI value (`10*8 + 5 = 85`).
+#[expect(
+    clippy::as_conversions,
+    reason = "u8 → u16 widening is exact; `From` is not usable here because it is not \
+              yet stable as a const trait (https://doc.rust-lang.org/reference/const_eval.html)"
+)]
 pub const SYSLOG_PRI: u16 = (SYSLOG_FACILITY as u16) * 8 + SYSLOG_SEVERITY as u16;
 /// RFC 5424 SYSLOG version.
 pub const SYSLOG_VERSION: u8 = 1;

--- a/app/ferroehr/src/telemetry/samplers.rs
+++ b/app/ferroehr/src/telemetry/samplers.rs
@@ -71,6 +71,11 @@ struct Sample {
 }
 
 /// Read the pool + runtime gauges.
+#[expect(
+    clippy::as_conversions,
+    reason = "pool and runtime counts widen exactly: usize is at most 64 bits on \
+              every supported target"
+)]
 fn sample(pool: &PgPool) -> Sample {
     let size = u64::from(pool.size());
     let idle = pool.num_idle() as u64;
@@ -90,6 +95,7 @@ fn sample(pool: &PgPool) -> Sample {
 
 /// Publish the snapshot through the `metrics` facade (→ Prometheus).
 #[expect(
+    clippy::as_conversions,
     clippy::cast_precision_loss,
     reason = "the gauge values are small counts (pool size, worker count, \
               queue depth, alive tasks), so the u64 → f64 widening is exact \

--- a/app/ferroehr/tests/it/tenant_isolation.rs
+++ b/app/ferroehr/tests/it/tenant_isolation.rs
@@ -385,7 +385,7 @@ async fn scoped_pool_stamps_connections_opened_during_acquire() {
         // Hold one connection more than the pool currently has, without
         // releasing any: at least one acquire must open a NEW connection
         // inside this tenant scope.
-        let target = pool.size() as usize + 1;
+        let target = usize::try_from(pool.size()).expect("pool size should fit usize") + 1;
         let mut held = Vec::with_capacity(target);
         for _ in 0..target {
             held.push(pool.acquire().await.expect("acquire under scope"));

--- a/crates/openehr-adl/src/adl14/domain.rs
+++ b/crates/openehr-adl/src/adl14/domain.rs
@@ -667,6 +667,7 @@ fn odin_range_bounds<T>(
 }
 
 #[expect(
+    clippy::as_conversions,
     clippy::cast_precision_loss,
     reason = "archetype domain-constraint magnitudes are small integers; f64 represents them exactly"
 )]
@@ -679,6 +680,7 @@ fn odin_as_real(v: &OdinValue) -> Option<f64> {
 }
 
 #[expect(
+    clippy::as_conversions,
     clippy::cast_possible_truncation,
     reason = "the value is clamped to the i32 range on the very next line, so the cast cannot truncate"
 )]

--- a/crates/openehr-adl/src/odin.rs
+++ b/crates/openehr-adl/src/odin.rs
@@ -527,6 +527,7 @@ fn is_numeric_leaf(v: &OdinValue) -> bool {
 /// The `f64` an ODIN numeric leaf denotes, or `None` when the value is not
 /// numeric or not exactly representable as one.
 #[expect(
+    clippy::as_conversions,
     clippy::cast_precision_loss,
     reason = "the 2^53 magnitude guard proves the i64 → f64 conversion is exact; a wider magnitude returns None and is refused"
 )]

--- a/crates/openehr-adl/src/validate/structure.rs
+++ b/crates/openehr-adl/src/validate/structure.rs
@@ -514,7 +514,11 @@ impl StructureScan<'_> {
                 if let Some(av) = i.assumed_value
                     && !i.constraint.is_empty()
                 {
-                    #[expect(clippy::cast_possible_truncation, reason = "guarded by fract()")]
+                    #[expect(
+                        clippy::as_conversions,
+                        clippy::cast_possible_truncation,
+                        reason = "guarded by fract()"
+                    )]
                     let inside =
                         av.fract() == 0.0 && i.constraint.iter().any(|iv| iv.has(&(av as i32)));
                     if !inside {

--- a/crates/openehr-base/src/base_types/definitions/definitions_impl.rs
+++ b/crates/openehr-base/src/base_types/definitions/definitions_impl.rs
@@ -44,8 +44,8 @@ mod tests {
     #[test]
     fn constants_carry_the_spec_values() {
         // basic_definitions.adoc §Constants: octal '\015' / '\012'.
-        assert_eq!(CR as u32, 0o15);
-        assert_eq!(LF as u32, 0o12);
+        assert_eq!(u32::from(CR), 0o15);
+        assert_eq!(u32::from(LF), 0o12);
         assert_eq!(ANY_TYPE_NAME, "Any");
         assert_eq!(REGEX_ANY_PATTERN, ".*");
         assert_eq!(DEFAULT_ENCODING, "UTF-8");

--- a/crates/openehr-base/src/foundation_types/time/iso8601_parse.rs
+++ b/crates/openehr-base/src/foundation_types/time/iso8601_parse.rs
@@ -485,6 +485,7 @@ fn parse_timezone(tz: &str) -> Option<i32> {
         return None;
     }
     #[expect(
+        clippy::as_conversions,
         clippy::cast_possible_wrap,
         reason = "hh <= 14 and mm <= 59 by the checks above — far inside i32"
     )]
@@ -620,6 +621,7 @@ impl ParsedDuration {
     /// (`Iso8601_duration.to_seconds`): non-definite years/months reduce via
     /// the `Time_definitions` average-length constants.
     #[expect(
+        clippy::as_conversions,
         clippy::cast_precision_loss,
         reason = "ISO 8601 duration counts are small integers; f64 represents them exactly"
     )]
@@ -730,6 +732,10 @@ pub(crate) fn date_time_completion_range(dt: &ParsedDateTime) -> CompletionRange
             )
         }
         (Some(m), Some(day)) => {
+            #[expect(
+                clippy::as_conversions,
+                reason = "the day count is bounded by the representable calendar; f64 represents it exactly"
+            )]
             let day_start = days_from_civil(d.year, m, day) as f64 * SECONDS_IN_DAY;
             match &dt.time {
                 None => (day_start, day_start + SECONDS_IN_DAY, true),
@@ -750,6 +756,7 @@ pub(crate) fn date_time_completion_range(dt: &ParsedDateTime) -> CompletionRange
 
 /// Absolute seconds at `year`-01-01 00:00:00.
 #[expect(
+    clippy::as_conversions,
     clippy::cast_precision_loss,
     reason = "the day count is bounded by the representable calendar; f64 represents it exactly"
 )]
@@ -759,6 +766,7 @@ fn year_start_seconds(year: u32) -> f64 {
 
 /// Absolute seconds at `year`-`month`-01 00:00:00.
 #[expect(
+    clippy::as_conversions,
     clippy::cast_precision_loss,
     reason = "the day count is bounded by the representable calendar; f64 represents it exactly"
 )]
@@ -850,6 +858,7 @@ impl ExactSeconds {
     /// The quantity as an `f64` total (for `multiply`/`divide`, whose factor is
     /// a spec `Real`).
     #[expect(
+        clippy::as_conversions,
         clippy::cast_precision_loss,
         reason = "second counts over the representable calendar stay far inside 2^53, where f64 is exact on integers"
     )]
@@ -868,6 +877,7 @@ impl ExactSeconds {
         }
         let floor = total.floor();
         #[expect(
+            clippy::as_conversions,
             clippy::cast_possible_truncation,
             reason = "guarded immediately above: |floor| < 2^53, which is inside i64::MAX"
         )]
@@ -1113,6 +1123,7 @@ fn fraction_lexeme_of(frac: f64) -> String {
         return String::new();
     }
     #[expect(
+        clippy::as_conversions,
         clippy::cast_possible_truncation,
         clippy::cast_sign_loss,
         reason = "the value is a nanosecond count in 0..1e9 by construction — non-negative and inside u32"

--- a/crates/openehr-its/src/flat/sim/mod.rs
+++ b/crates/openehr-its/src/flat/sim/mod.rs
@@ -85,8 +85,9 @@ impl SimNode {
     /// placeholder occurrences) if absent, without touching the child's
     /// `indexed` marking.
     #[expect(
+        clippy::as_conversions,
         clippy::indexing_slicing,
-        reason = "the loop immediately below grows `occurrences` until `len() > i`, so the index is in bounds by construction; the fn returns `&mut SimNode`, not an Option"
+        reason = "the loop immediately below grows `occurrences` until `len() > i`, so the index is in bounds by construction (the u32 → usize widening is lossless on every supported target); the fn returns `&mut SimNode`, not an Option"
     )]
     pub fn place_mut(&mut self, name: &str, i: u32) -> &mut SimNode {
         let child = self.children.entry(name.to_owned()).or_default();

--- a/crates/openehr-its/src/json_codec/runtime.rs
+++ b/crates/openehr-its/src/json_codec/runtime.rs
@@ -43,8 +43,9 @@
 static ESCAPE: [u8; 256] = build_escape_table();
 
 #[expect(
+    clippy::as_conversions,
     clippy::indexing_slicing,
-    reason = "a const table builder over a fixed [u8; 256]: every index is a literal or a `u8` widened to usize, so all are inside the array by construction — and `get_mut` is not usable in a const fn"
+    reason = "a const table builder over a fixed [u8; 256]: every index is a literal or a `u8` widened to usize, so all are inside the array by construction — and neither `get_mut` nor `usize::from` is usable in a const fn"
 )]
 const fn build_escape_table() -> [u8; 256] {
     let mut t = [0u8; 256];
@@ -243,7 +244,7 @@ impl JsonWriter {
         let bytes = s.as_bytes();
         let mut start = 0;
         for (i, &b) in bytes.iter().enumerate() {
-            let esc = ESCAPE[b as usize];
+            let esc = ESCAPE[usize::from(b)];
             if esc == 0 {
                 continue;
             }
@@ -261,8 +262,8 @@ impl JsonWriter {
                 // Any other C0 control: `\u00XX`, lowercase hex.
                 _ => {
                     self.buf.push_str("\\u00");
-                    self.buf.push(HEX[(b >> 4) as usize] as char);
-                    self.buf.push(HEX[(b & 0xF) as usize] as char);
+                    self.buf.push(char::from(HEX[usize::from(b >> 4)]));
+                    self.buf.push(char::from(HEX[usize::from(b & 0xF)]));
                 }
             }
             start = i + 1;
@@ -639,6 +640,7 @@ impl JsonNode for JsonTree<'_> {
         }
     }
     #[expect(
+        clippy::as_conversions,
         clippy::cast_precision_loss,
         reason = "wire-number widening to f64, exactly what serde_json::Value::as_f64 does"
     )]
@@ -1106,6 +1108,7 @@ impl FromJson for f64 {
 
 impl FromJson for f32 {
     #[expect(
+        clippy::as_conversions,
         clippy::cast_possible_truncation,
         reason = "REAL -> f32 field narrowing, exactly what serde does when a schema declares an f32 field"
     )]

--- a/crates/openehr-query/src/parser.rs
+++ b/crates/openehr-query/src/parser.rs
@@ -185,6 +185,7 @@ fn parse_number(kind: NumKind, s: &str) -> Option<Primitive> {
                 return None;
             }
             #[expect(
+                clippy::as_conversions,
                 clippy::cast_possible_truncation,
                 clippy::cast_precision_loss,
                 reason = "the guard on this very line proves r is integral and inside the i64 range; the i64::MIN/MAX casts are the bound check itself"

--- a/crates/openehr-rm/src/data_structures/history/interval_event_impl.rs
+++ b/crates/openehr-rm/src/data_structures/history/interval_event_impl.rs
@@ -31,6 +31,7 @@ impl<T> IntervalEvent<T> {
         let (days, secs, tz) = iso_date_time_parts(&self.time.value)?;
         let width_secs = self.width.magnitude()?;
         #[expect(
+            clippy::as_conversions,
             clippy::cast_precision_loss,
             reason = "day counts over the representable calendar are far below 2^52, where f64 is exact on integers"
         )]
@@ -38,6 +39,7 @@ impl<T> IntervalEvent<T> {
         let start_days = (total / SECONDS_IN_DAY).floor();
         let rem = total - start_days * SECONDS_IN_DAY;
         #[expect(
+            clippy::as_conversions,
             clippy::cast_possible_truncation,
             reason = "start_days is a floored day count over the representable calendar — far inside i64"
         )]

--- a/crates/openehr-rm/src/data_types/quantity/dv_ordered_impl.rs
+++ b/crates/openehr-rm/src/data_types/quantity/dv_ordered_impl.rs
@@ -202,6 +202,7 @@ pub(crate) fn iso_date_time_magnitude_seconds(s: &str) -> Option<f64> {
         return None;
     }
     #[expect(
+        clippy::as_conversions,
         clippy::cast_precision_loss,
         reason = "day counts over the representable calendar are far below 2^52, where f64 is exact on integers"
     )]
@@ -377,6 +378,7 @@ ordered_limit!(
 
 // DV_COUNT: any two counts are comparable; ordered by `magnitude`.
 #[expect(
+    clippy::as_conversions,
     clippy::cast_precision_loss,
     reason = "DV_COUNT magnitudes are clinical counts, far below 2^52 where f64 is exact on integers"
 )]
@@ -418,6 +420,7 @@ ordered_limit!(
 
 // DV_DATE: any two dates are comparable; ordered by day-magnitude.
 #[expect(
+    clippy::as_conversions,
     clippy::cast_precision_loss,
     reason = "the day count over the representable calendar is far below 2^52, where f64 is exact on integers"
 )]
@@ -559,6 +562,7 @@ impl DvOrdered {
     /// for unavailable temporal magnitudes.
     #[must_use]
     #[expect(
+        clippy::as_conversions,
         clippy::cast_precision_loss,
         reason = "DV_COUNT magnitudes and day counts are far below 2^52, where f64 is exact on integers"
     )]
@@ -732,6 +736,7 @@ impl OrderedLimit for DvOrdered {
 /// Civil date from a day count relative to 1970-01-01 (Howard Hinnant's
 /// `civil_from_days` — the inverse of `days_from_civil`).
 #[expect(
+    clippy::as_conversions,
     clippy::cast_sign_loss,
     clippy::cast_possible_truncation,
     reason = "the algorithm's own bounds put d in [1, 31] and m in [1, 12] — both non-negative and inside u32"
@@ -765,6 +770,7 @@ fn civil_from_days(z: i64) -> (i64, u32, u32) {
 pub(crate) fn format_iso_date_time(days_since_origin: i64, secs_in_day: f64) -> String {
     let (y, m, d) = civil_from_days(days_since_origin + days_from_civil(1, 1, 1));
     #[expect(
+        clippy::as_conversions,
         clippy::cast_possible_truncation,
         clippy::cast_sign_loss,
         reason = "a seconds-in-day value is non-negative and below 86_400, so its floor fits u64"
@@ -774,6 +780,7 @@ pub(crate) fn format_iso_date_time(days_since_origin: i64, secs_in_day: f64) -> 
     let (hh, mm, ss) = (whole / 3600, (whole % 3600) / 60, whole % 60);
     if frac > 1e-9 {
         #[expect(
+            clippy::as_conversions,
             clippy::cast_possible_truncation,
             clippy::cast_sign_loss,
             reason = "frac is in [0, 1), so frac * 1000 rounds into 0..=1000 — non-negative and inside u64"

--- a/tools/cnf-runner/src/conf_assets.rs
+++ b/tools/cnf-runner/src/conf_assets.rs
@@ -133,6 +133,7 @@ const MARGIN: f64 = 24.0;
 /// timestamps.
 #[must_use]
 #[expect(
+    clippy::as_conversions,
     clippy::cast_precision_loss,
     reason = "grid counts/cell coordinates are far below 2^52"
 )]
@@ -708,7 +709,11 @@ fn write_count_strip(out: &mut String, baseline: f64, counts: BandCounts, strong
         if value == 0 {
             continue;
         }
-        #[expect(clippy::cast_precision_loss, reason = "four slots")]
+        #[expect(
+            clippy::as_conversions,
+            clippy::cast_precision_loss,
+            reason = "four slots"
+        )]
         let slot_end = COUNTS_X + (slot as f64 + 1.0) * SLOT_W - 6.0;
         let _ = write!(
             out,
@@ -738,6 +743,7 @@ fn cases_phrase(total: u64) -> String {
 /// Pure over its inputs: [`TAXONOMY`] order, no timestamps, no randomness.
 #[must_use]
 #[expect(
+    clippy::as_conversions,
     clippy::too_many_lines,
     clippy::cast_precision_loss,
     reason = "one linear chart emitter; counts/rows << 2^52"
@@ -1361,7 +1367,11 @@ mod tests {
         // The book + landing pages embed the SVG at this width; the two-level
         // layout is allowed to grow taller, never wider.
         let bands: usize = TAXONOMY.iter().map(|(_, b)| b.len()).sum();
-        #[expect(clippy::cast_precision_loss, reason = "taxonomy rows << 2^52")]
+        #[expect(
+            clippy::as_conversions,
+            clippy::cast_precision_loss,
+            reason = "taxonomy rows << 2^52"
+        )]
         let height =
             BARS_HEAD_H + TAXONOMY.len() as f64 * (CHAP_H + CHAP_GAP) + bands as f64 * BAND_H + 8.0;
         assert!(

--- a/tools/cnf-runner/src/exec/driver.rs
+++ b/tools/cnf-runner/src/exec/driver.rs
@@ -913,6 +913,10 @@ impl<'a> HttpDriver<'a> {
                     .iter()
                     .enumerate()
                     .filter_map(|(k, uid)| {
+                        #[expect(
+                            clippy::as_conversions,
+                            reason = "committed-uid index widens exactly: usize is at most 64 bits on every supported target"
+                        )]
                         let systolic = 100 + 10 * (k as u64);
                         (systolic >= min).then(|| (uid.clone(), systolic))
                     })

--- a/tools/cnf-runner/src/exec/resultset.rs
+++ b/tools/cnf-runner/src/exec/resultset.rs
@@ -149,6 +149,10 @@ pub fn compare_contains(result_set: &Value, expected: &[Value]) -> Result<(), Re
 /// # Errors
 /// The count mismatch.
 pub fn compare_count(result_set: &Value, expected: u64) -> Result<(), ResultSetMismatch> {
+    #[expect(
+        clippy::as_conversions,
+        reason = "row count widens exactly: usize is at most 64 bits on every supported target"
+    )]
     let n = rows_of(result_set)?.len() as u64;
     if n == expected {
         Ok(())

--- a/tools/cnf-runner/src/perf.rs
+++ b/tools/cnf-runner/src/perf.rs
@@ -149,7 +149,11 @@ impl Serialize for WorkloadDuration {
 /// Microseconds → milliseconds (latency values are far below the f64
 /// mantissa bound; the histogram's value range is capped at recording).
 fn us_to_ms(us: u64) -> f64 {
-    #[expect(clippy::cast_precision_loss, reason = "latencies << 2^52 microseconds")]
+    #[expect(
+        clippy::as_conversions,
+        clippy::cast_precision_loss,
+        reason = "latencies << 2^52 microseconds"
+    )]
     {
         us as f64 / 1_000.0
     }
@@ -973,7 +977,11 @@ impl JourneyCatalogue {
                 .ok_or_else(|| format!("workload names unknown journey {name:?}"))?;
             for stage in &journey.stages {
                 let op = PerfOp::parse(&stage.op)?;
-                #[expect(clippy::cast_precision_loss, reason = "stage arrival counts are tiny")]
+                #[expect(
+                    clippy::as_conversions,
+                    clippy::cast_precision_loss,
+                    reason = "stage arrival counts are tiny"
+                )]
                 let weight = share.0 / 100.0 * stage.at.arrivals() as f64;
                 arrivals_per_journey += weight;
                 if let Some((_, w)) = op_weight.iter_mut().find(|(o, _)| *o == op) {
@@ -1504,7 +1512,11 @@ pub fn class_verdict(
                 let rate = if requests == 0 {
                     1.0
                 } else {
-                    #[expect(clippy::cast_precision_loss, reason = "request counts << 2^52")]
+                    #[expect(
+                        clippy::as_conversions,
+                        clippy::cast_precision_loss,
+                        reason = "request counts << 2^52"
+                    )]
                     {
                         errors as f64 / requests as f64
                     }

--- a/tools/cnf-runner/src/perf_assets.rs
+++ b/tools/cnf-runner/src/perf_assets.rs
@@ -125,7 +125,11 @@ pub fn class_ladder_svg(cases: &[PerformanceCase], measurements: &[Measurement])
             .total_cmp(&b.class.arrival_floor_per_s())
     });
     for (row, case) in classes.iter().enumerate() {
-        #[expect(clippy::cast_precision_loss, reason = "row counts are tiny")]
+        #[expect(
+            clippy::as_conversions,
+            clippy::cast_precision_loss,
+            reason = "row counts are tiny"
+        )]
         let y = top + row as f64 * row_h + 8.0;
         let floor = case.class.arrival_floor_per_s();
         let floor_x = log_pos(floor, min, max, x0, x1);
@@ -181,6 +185,11 @@ pub fn class_ladder_svg(cases: &[PerformanceCase], measurements: &[Measurement])
 ///
 /// # Errors
 /// A message when a histogram fails to decode.
+#[expect(
+    clippy::as_conversions,
+    reason = "SVG geometry and latency scaling: row/bar indices and microsecond \
+              latencies are far below 2^52, so the widening is exact"
+)]
 pub fn latency_percentiles_svg(measurement: &Measurement) -> Result<String, String> {
     const LABEL_W: f64 = 214.0;
     const BAR_H: f64 = 9.0;
@@ -359,7 +368,11 @@ pub fn stress_curve_svg(report: &crate::stress::StressReport) -> Result<String, 
         let mut worst_ms: f64 = 0.0;
         for op in &step.operations {
             let histogram = op.decode_histogram()?;
-            #[expect(clippy::cast_precision_loss, reason = "latencies << 2^52 µs")]
+            #[expect(
+                clippy::as_conversions,
+                clippy::cast_precision_loss,
+                reason = "latencies << 2^52 µs"
+            )]
             let ms = histogram.value_at_quantile(0.99) as f64 / 1_000.0;
             worst_ms = worst_ms.max(ms);
         }
@@ -521,7 +534,11 @@ pub fn stress_compare_svg(
             let mut worst_ms: f64 = 0.0;
             for op in &step.operations {
                 let histogram = op.decode_histogram()?;
-                #[expect(clippy::cast_precision_loss, reason = "latencies << 2^52 µs")]
+                #[expect(
+                    clippy::as_conversions,
+                    clippy::cast_precision_loss,
+                    reason = "latencies << 2^52 µs"
+                )]
                 let ms = histogram.value_at_quantile(0.99) as f64 / 1_000.0;
                 worst_ms = worst_ms.max(ms);
             }
@@ -687,7 +704,11 @@ fn value_series(
         .samples
         .iter()
         .map(|s| {
-            #[expect(clippy::cast_precision_loss, reason = "offsets << 2^52")]
+            #[expect(
+                clippy::as_conversions,
+                clippy::cast_precision_loss,
+                reason = "offsets << 2^52"
+            )]
             (s.offset_s as f64, value(s))
         })
         .collect()
@@ -709,7 +730,11 @@ fn rate_series(
             if span == 0 {
                 return None;
             }
-            #[expect(clippy::cast_precision_loss, reason = "counters/offsets << 2^52")]
+            #[expect(
+                clippy::as_conversions,
+                clippy::cast_precision_loss,
+                reason = "counters/offsets << 2^52"
+            )]
             Some((
                 b.offset_s as f64,
                 counter(b).saturating_sub(counter(a)) as f64 / span as f64,
@@ -778,7 +803,11 @@ pub fn resources_timeseries_svg(measurement: &Measurement) -> Option<String> {
         .flat_map(|c| c.samples.iter().map(|s| s.offset_s))
         .max()
         .unwrap_or(0);
-    #[expect(clippy::cast_precision_loss, reason = "spans << 2^52")]
+    #[expect(
+        clippy::as_conversions,
+        clippy::cast_precision_loss,
+        reason = "spans << 2^52"
+    )]
     let span_s = (measurement.warmup_s + measurement.duration_s).max(last_offset) as f64;
     let x_of = move |t: f64| x0 + (t / span_s).clamp(0.0, 1.0) * (x1 - x0);
 
@@ -839,7 +868,11 @@ pub fn resources_timeseries_svg(measurement: &Measurement) -> Option<String> {
         .find(|step| minutes / step <= 8.0)
         .unwrap_or(240.0);
 
-    #[expect(clippy::cast_precision_loss, reason = "window seconds << 2^52")]
+    #[expect(
+        clippy::as_conversions,
+        clippy::cast_precision_loss,
+        reason = "window seconds << 2^52"
+    )]
     let warm_w = x_of(measurement.warmup_s as f64) - x0;
 
     // One panel or strip: warmup shade, gridlines, y-labels, series.
@@ -922,7 +955,11 @@ pub fn resources_timeseries_svg(measurement: &Measurement) -> Option<String> {
         panel_h,
         "Resident memory",
         &pair(&|s| {
-            #[expect(clippy::cast_precision_loss, reason = "bytes << 2^52")]
+            #[expect(
+                clippy::as_conversions,
+                clippy::cast_precision_loss,
+                reason = "bytes << 2^52"
+            )]
             {
                 s.rss_bytes as f64
             }
@@ -936,7 +973,11 @@ pub fn resources_timeseries_svg(measurement: &Measurement) -> Option<String> {
         ("Network transmit", &|s| s.net_tx_bytes),
     ];
     for (i, (title, counter)) in strips.iter().enumerate() {
-        #[expect(clippy::cast_precision_loss, reason = "four strips")]
+        #[expect(
+            clippy::as_conversions,
+            clippy::cast_precision_loss,
+            reason = "four strips"
+        )]
         let top = strips_top + i as f64 * strip_step;
         panel(&mut out, top, strip_h, title, &rate_pair(counter), &|v| {
             format!("{}/s", format_bytes(v))
@@ -997,7 +1038,11 @@ pub fn disk_growth_svg(measurements: &[Measurement]) -> Option<String> {
         ("after ward seed", disk.after_ward_seed_bytes),
         ("after window", disk.after_window_bytes),
     ];
-    #[expect(clippy::cast_precision_loss, reason = "volume sizes << 2^52")]
+    #[expect(
+        clippy::as_conversions,
+        clippy::cast_precision_loss,
+        reason = "volume sizes << 2^52"
+    )]
     let max_bytes = anchors
         .iter()
         .filter_map(|(_, v)| *v)
@@ -1027,7 +1072,11 @@ pub fn disk_growth_svg(measurements: &[Measurement]) -> Option<String> {
 
     let bar_w = 84.0;
     for (i, (label, value)) in anchors.iter().enumerate() {
-        #[expect(clippy::cast_precision_loss, reason = "four columns")]
+        #[expect(
+            clippy::as_conversions,
+            clippy::cast_precision_loss,
+            reason = "four columns"
+        )]
         let cx = 120.0 + i as f64 * 140.0;
         let _ = writeln!(
             out,
@@ -1036,7 +1085,11 @@ pub fn disk_growth_svg(measurements: &[Measurement]) -> Option<String> {
         );
         match value {
             Some(bytes) => {
-                #[expect(clippy::cast_precision_loss, reason = "volume sizes << 2^52")]
+                #[expect(
+                    clippy::as_conversions,
+                    clippy::cast_precision_loss,
+                    reason = "volume sizes << 2^52"
+                )]
                 let bytes_f = *bytes as f64;
                 let h = (bytes_f / max_bytes) * (y_bottom - y_top);
                 let y = y_bottom - h.max(2.0);
@@ -1066,7 +1119,11 @@ pub fn disk_growth_svg(measurements: &[Measurement]) -> Option<String> {
         disk.seed_compositions,
     ) && n > 0
     {
-        #[expect(clippy::cast_precision_loss, reason = "sizes/counts << 2^52")]
+        #[expect(
+            clippy::as_conversions,
+            clippy::cast_precision_loss,
+            reason = "sizes/counts << 2^52"
+        )]
         let per = after.saturating_sub(before) as f64 / n as f64;
         let _ = writeln!(
             out,
@@ -1172,7 +1229,11 @@ pub fn summary_markdown(
         let _ = writeln!(out, "| --- | --- | --- | --- | --- | --- |");
         for op in &m.operations {
             let histogram = op.decode_histogram()?;
-            #[expect(clippy::cast_precision_loss, reason = "µs << 2^52")]
+            #[expect(
+                clippy::as_conversions,
+                clippy::cast_precision_loss,
+                reason = "µs << 2^52"
+            )]
             let ms = |q: f64| histogram.value_at_quantile(q) as f64 / 1_000.0;
             let _ = writeln!(
                 out,
@@ -1213,11 +1274,19 @@ fn resources_markdown(out: &mut String, resources: Option<&crate::perf::Resource
             let _ = writeln!(out, "| {role} `{}` | — | — | — |", c.name);
             continue;
         }
-        #[expect(clippy::cast_precision_loss, reason = "sample counts << 2^52")]
+        #[expect(
+            clippy::as_conversions,
+            clippy::cast_precision_loss,
+            reason = "sample counts << 2^52"
+        )]
         let cpu_mean = set.iter().map(|s| s.cpu_pct).sum::<f64>() / set.len() as f64;
         let cpu_peak = set.iter().map(|s| s.cpu_pct).fold(0.0, f64::max);
         let rss_peak = set.iter().map(|s| s.rss_bytes).max().unwrap_or(0);
-        #[expect(clippy::cast_precision_loss, reason = "bytes << 2^52")]
+        #[expect(
+            clippy::as_conversions,
+            clippy::cast_precision_loss,
+            reason = "bytes << 2^52"
+        )]
         let _ = writeln!(
             out,
             "| {role} `{}` | {cpu_mean:.1}% | {cpu_peak:.1}% | {} |",
@@ -1230,7 +1299,11 @@ fn resources_markdown(out: &mut String, resources: Option<&crate::perf::Resource
     let Some(disk) = r.disk else {
         return;
     };
-    #[expect(clippy::cast_precision_loss, reason = "volume sizes << 2^52")]
+    #[expect(
+        clippy::as_conversions,
+        clippy::cast_precision_loss,
+        reason = "volume sizes << 2^52"
+    )]
     let anchor =
         |v: Option<u64>| v.map_or_else(|| "not probed".to_owned(), |b| format_bytes(b as f64));
     let per_composition = match (
@@ -1239,7 +1312,11 @@ fn resources_markdown(out: &mut String, resources: Option<&crate::perf::Resource
         disk.seed_compositions,
     ) {
         (Some(before), Some(after), Some(n)) if n > 0 => {
-            #[expect(clippy::cast_precision_loss, reason = "sizes/counts << 2^52")]
+            #[expect(
+                clippy::as_conversions,
+                clippy::cast_precision_loss,
+                reason = "sizes/counts << 2^52"
+            )]
             let per = after.saturating_sub(before) as f64 / n as f64;
             format!(
                 " (≈ {} / composition over {} committed)",

--- a/tools/cnf-runner/src/perf_run/resources.rs
+++ b/tools/cnf-runner/src/perf_run/resources.rs
@@ -151,6 +151,7 @@ fn sample_loop(
                             // % of one core over the interval (100 = one
                             // full core) — both deltas are far below 2^52.
                             #[expect(
+                                clippy::as_conversions,
                                 clippy::cast_precision_loss,
                                 reason = "nanosecond counters within a sampling window are far below 2^52"
                             )]

--- a/tools/cnf-runner/src/perf_run/schedule.rs
+++ b/tools/cnf-runner/src/perf_run/schedule.rs
@@ -237,6 +237,7 @@ fn journey_instants(curve: ArrivalCurve, rate_peak: f64, span_s: f64) -> Vec<f64
             let interval = 1.0 / rate_peak;
             let count = (span_s * rate_peak).ceil().max(1.0);
             #[expect(
+                clippy::as_conversions,
                 clippy::cast_possible_truncation,
                 clippy::cast_sign_loss,
                 reason = "journey counts are far below the lossy range and non-negative by construction"
@@ -244,7 +245,11 @@ fn journey_instants(curve: ArrivalCurve, rate_peak: f64, span_s: f64) -> Vec<f64
             let count = count as u64;
             (0..count)
                 .map(|j| {
-                    #[expect(clippy::cast_precision_loss, reason = "counts << 2^52")]
+                    #[expect(
+                        clippy::as_conversions,
+                        clippy::cast_precision_loss,
+                        reason = "counts << 2^52"
+                    )]
                     {
                         j as f64 * interval
                     }
@@ -381,9 +386,17 @@ pub(crate) fn build_schedule(
     // tail.
     let journey_rate = rate * FLOOR_MARGIN / expansion.arrivals_per_journey;
     let span_s = warmup_s.saturating_add(duration_s);
-    #[expect(clippy::cast_precision_loss, reason = "spans << 2^52")]
+    #[expect(
+        clippy::as_conversions,
+        clippy::cast_precision_loss,
+        reason = "spans << 2^52"
+    )]
     let virtual_span_s = span_s as f64 + max_offset_s as f64;
     let mut sequencer = ShareSequencer::new(&shares);
+    #[expect(
+        clippy::as_conversions,
+        reason = "journey-kind count widens exactly: usize is at most 64 bits on every supported target"
+    )]
     let kinds = resolved.len() as u64;
     let mut kind_seq: Vec<u64> = vec![0; resolved.len()];
     let mut arrivals: Vec<PlannedArrival> = Vec::new();
@@ -404,7 +417,11 @@ pub(crate) fn build_schedule(
         let patient = if journey.fresh_ehr {
             None
         } else {
-            #[expect(clippy::cast_possible_truncation, reason = "ward indices are small")]
+            #[expect(
+                clippy::as_conversions,
+                clippy::cast_possible_truncation,
+                reason = "ward indices are small"
+            )]
             Some(((kind as u64 + kinds * seq) % ward_len.max(1) as u64) as usize)
         };
         // The journey's own clock starts max_offset before the window so
@@ -413,7 +430,11 @@ pub(crate) fn build_schedule(
         // a journey with NO seeded fallback (a fresh EHR, a delete of its
         // own commit) must start in-window — a pre-window start skips the
         // instance.
-        #[expect(clippy::cast_precision_loss, reason = "offsets << 2^52")]
+        #[expect(
+            clippy::as_conversions,
+            clippy::cast_precision_loss,
+            reason = "offsets << 2^52"
+        )]
         let start_s = instant - max_offset_s as f64;
         if journey.needs_full_window && start_s < 0.0 {
             continue;
@@ -422,14 +443,30 @@ pub(crate) fn build_schedule(
         for (stage_index, stage) in journey.stages.iter().enumerate() {
             let reps = stage.at.arrivals();
             for rep in 0..reps {
+                #[expect(
+                    clippy::as_conversions,
+                    reason = "stage index widens exactly: usize is at most 64 bits on every supported target"
+                )]
                 let offset = offset_s(stage.at, journey_index, stage_index as u64, rep);
-                #[expect(clippy::cast_precision_loss, reason = "offsets << 2^52")]
+                #[expect(
+                    clippy::as_conversions,
+                    clippy::cast_precision_loss,
+                    reason = "offsets << 2^52"
+                )]
                 let at_s = start_s + offset as f64;
-                #[expect(clippy::cast_precision_loss, reason = "spans << 2^52")]
+                #[expect(
+                    clippy::as_conversions,
+                    clippy::cast_precision_loss,
+                    reason = "spans << 2^52"
+                )]
                 if at_s < 0.0 || at_s >= span_s as f64 {
                     continue;
                 }
-                #[expect(clippy::cast_precision_loss, reason = "spans << 2^52")]
+                #[expect(
+                    clippy::as_conversions,
+                    clippy::cast_precision_loss,
+                    reason = "spans << 2^52"
+                )]
                 let recorded = at_s >= warmup_s as f64;
                 if recorded {
                     measured_count += 1;
@@ -476,7 +513,11 @@ pub(crate) fn build_schedule(
             .map(|a| a.at.as_secs_f64())
             .collect();
         if duration_s <= 3600 || workload.curve == ArrivalCurve::Uniform {
-            #[expect(clippy::cast_precision_loss, reason = "counts << 2^52")]
+            #[expect(
+                clippy::as_conversions,
+                clippy::cast_precision_loss,
+                reason = "counts << 2^52"
+            )]
             {
                 measured.len() as f64 / duration_s.max(1) as f64
             }
@@ -485,9 +526,17 @@ pub(crate) fn build_schedule(
             let mut best = 0.0_f64;
             let mut lo = 0usize;
             let mut hi = 0usize;
-            #[expect(clippy::cast_precision_loss, reason = "spans << 2^52")]
+            #[expect(
+                clippy::as_conversions,
+                clippy::cast_precision_loss,
+                reason = "spans << 2^52"
+            )]
             let end = (warmup_s + duration_s) as f64;
-            #[expect(clippy::cast_precision_loss, reason = "spans << 2^52")]
+            #[expect(
+                clippy::as_conversions,
+                clippy::cast_precision_loss,
+                reason = "spans << 2^52"
+            )]
             let mut window_start = warmup_s as f64;
             while window_start + 3600.0 <= end + 1.0 {
                 while measured.get(lo).is_some_and(|at| *at < window_start) {
@@ -499,7 +548,11 @@ pub(crate) fn build_schedule(
                 {
                     hi += 1;
                 }
-                #[expect(clippy::cast_precision_loss, reason = "counts << 2^52")]
+                #[expect(
+                    clippy::as_conversions,
+                    clippy::cast_precision_loss,
+                    reason = "counts << 2^52"
+                )]
                 {
                     best = best.max((hi - lo) as f64 / 3600.0);
                 }
@@ -701,14 +754,13 @@ mod tests {
         let schedule = build_schedule(&workload, 20.0, 0, 30, 99).unwrap();
         // Patients used by vitals commits never collide with lab commits:
         // stripe residues (mod kind count) differ per kind.
-        let mut residue_by_op: std::collections::HashMap<PerfOp, std::collections::BTreeSet<u64>> =
-            std::collections::HashMap::new();
+        let mut residue_by_op: std::collections::HashMap<
+            PerfOp,
+            std::collections::BTreeSet<usize>,
+        > = std::collections::HashMap::new();
         for arrival in &schedule.arrivals {
             if let Some(p) = arrival.patient {
-                residue_by_op
-                    .entry(arrival.op)
-                    .or_default()
-                    .insert(p as u64 % 3);
+                residue_by_op.entry(arrival.op).or_default().insert(p % 3);
             }
         }
         let vitals = &residue_by_op[&PerfOp::CompositionCommit];
@@ -796,6 +848,7 @@ mod tests {
         // whole-window mean sits well below it.
         let schedule = build_schedule(&workload, 2.0, 0, 36_000, 50).unwrap();
         #[expect(
+            clippy::as_conversions,
             clippy::cast_precision_loss,
             reason = "planned journey counts in a 10 h window are far below 2^52"
         )]

--- a/tools/cnf-runner/src/perf_run/window.rs
+++ b/tools/cnf-runner/src/perf_run/window.rs
@@ -232,7 +232,11 @@ pub fn run_window(
     // rate scaled by dispatch fidelity — off-peak troughs are the design,
     // never a shortfall; a lagging generator still deflates it.
     let planned_span_s = warmup_s.saturating_add(duration_s);
-    #[expect(clippy::cast_precision_loss, reason = "spans/counts << 2^52")]
+    #[expect(
+        clippy::as_conversions,
+        clippy::cast_precision_loss,
+        reason = "spans/counts << 2^52"
+    )]
     let (offered_load_sustained, generator_bound) = {
         let actual_span = dispatch_span.as_secs_f64().max(planned_span_s as f64);
         let measured_span = actual_span - warmup_s as f64;

--- a/tools/cnf-runner/src/probe.rs
+++ b/tools/cnf-runner/src/probe.rs
@@ -143,6 +143,7 @@ fn percentile(sorted: &[f64], q: f64) -> f64 {
         return 0.0;
     }
     #[expect(
+        clippy::as_conversions,
         clippy::cast_precision_loss,
         clippy::cast_possible_truncation,
         clippy::cast_sign_loss,

--- a/tools/cnf-runner/src/run.rs
+++ b/tools/cnf-runner/src/run.rs
@@ -59,7 +59,11 @@ impl RunReport {
         if self.considered == 0 {
             return 1.0;
         }
-        #[expect(clippy::cast_precision_loss, reason = "case counts << 2^52")]
+        #[expect(
+            clippy::as_conversions,
+            clippy::cast_precision_loss,
+            reason = "case counts << 2^52"
+        )]
         {
             self.interpreter_run as f64 / self.considered as f64
         }
@@ -1049,6 +1053,7 @@ mod tests {
                 .filter(|(_, e)| matches!(e, Exception::Unrealized(_)))
                 .count();
         #[expect(
+            clippy::as_conversions,
             clippy::cast_precision_loss,
             reason = "case counts << 2^52, so the coverage ratio is exact enough"
         )]

--- a/tools/cnf-runner/src/stress.rs
+++ b/tools/cnf-runner/src/stress.rs
@@ -131,7 +131,11 @@ fn step_breaches(
         // Re-derive from the decoded histogram — the same discipline as the
         // measured-run verdicts (the summary fields are never load-bearing).
         let histogram = op.decode_histogram()?;
-        #[expect(clippy::cast_precision_loss, reason = "latencies << 2^52 µs")]
+        #[expect(
+            clippy::as_conversions,
+            clippy::cast_precision_loss,
+            reason = "latencies << 2^52 µs"
+        )]
         let p99_ms = histogram.value_at_quantile(0.99) as f64 / 1_000.0;
         if p99_ms > options.p99_budget_ms {
             breaches.push(format!(
@@ -140,7 +144,11 @@ fn step_breaches(
             ));
         }
     }
-    #[expect(clippy::cast_precision_loss, reason = "request counts << 2^52")]
+    #[expect(
+        clippy::as_conversions,
+        clippy::cast_precision_loss,
+        reason = "request counts << 2^52"
+    )]
     let error_rate = if requests == 0 {
         1.0
     } else {


### PR DESCRIPTION
Owner lint hardening in the root `Cargo.toml`: clippy `all` + `pedantic` groups warn→deny; `panic_in_result_fn` + `missing_assert_message` to deny; new denies `unchecked_time_subtraction` + `as_conversions` (+ `arithmetic_side_effects`, currently inert in the rust table — owner ruling tracked in #1426).

Fallout fixed across the workspace — the only lint that fired was `clippy::as_conversions`, 95 sites / 19 files:
- 5 casts removed via real conversions (`u8::try_from`/`usize::from`/`char::from` in the test base64 helper, `usize::try_from(pool.size())`, a `BTreeSet<usize>` instead of a u64-cast index)
- 47 sites: `clippy::as_conversions` added to the EXISTING reasoned `#[expect(clippy::cast_*)]` blocks (magnitude arguments already proven there)
- 15 new smallest-scope `#[expect(clippy::as_conversions, reason = …)]` (exact usize→u64 widenings, SVG geometry/µs latencies < 2^52, and the `SYSLOG_PRI` const where `u16::from` is not const-stable)

No `// @generated` file touched, no test weakened, no runtime behaviour changed, no crate-level suppression added.

Gates: all three CI clippy lanes exit 0 (workspace + admin-ui ssr + admin-ui wasm32/hydrate), `cargo fmt --all --check` clean, nextest: cnf-runner 251/251, ferroehr+ferroehr-rest 1352 passed / 3 pre-existing default-filter skips, admin-ui green.