### PR TITLE
fix(openehr-term): parse XSD-declared status attributes + XSD structural-conformance suite

### DIFF
--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -21,6 +21,11 @@ openehr-base = { path = "../openehr-base" }
 roxmltree.workspace = true
 thiserror.workspace = true
 
+[dev-dependencies]
+# The XSD structural-conformance suite (tests/it) re-parses the vendored
+# assets against the vendored schemas' rules.
+roxmltree.workspace = true
+
 [lints]
 workspace = true
 

--- a/crates/openehr-term/src/bundle.rs
+++ b/crates/openehr-term/src/bundle.rs
@@ -33,6 +33,7 @@ use crate::terminology::code_set::CodeSet;
 use crate::terminology::terminology::Terminology;
 use crate::terminology::terminology_concept::TerminologyConcept;
 use crate::terminology::terminology_group::TerminologyGroup;
+use crate::terminology::terminology_status::TerminologyStatus;
 
 // Vendored openEHR terminology assets, embedded at compile time (no runtime I/O).
 const EN_XML: &str = include_str!("../assets/en/openehr_terminology.xml");
@@ -600,7 +601,7 @@ fn parse_code_set(node: &roxmltree::Node) -> CodeSet {
         .map(|c| Code {
             value: attr(&c, "value").unwrap_or_default().to_owned(),
             description: attr(&c, "description").map(ToOwned::to_owned),
-            status: None,
+            status: status_attr(&c),
         })
         .collect();
     CodeSet {
@@ -609,7 +610,7 @@ fn parse_code_set(node: &roxmltree::Node) -> CodeSet {
         issuer: attr(node, "issuer").unwrap_or_default().to_owned(),
         codes,
         external_id: attr(node, "external_id").map(ToOwned::to_owned),
-        status: None,
+        status: status_attr(node),
     }
 }
 
@@ -621,15 +622,26 @@ fn parse_group(node: &roxmltree::Node) -> TerminologyGroup {
         .map(|c| TerminologyConcept {
             id: attr(&c, "id").unwrap_or_default().to_owned(),
             rubric: attr(&c, "rubric").unwrap_or_default().to_owned(),
-            status: None,
+            status: status_attr(&c),
         })
         .collect();
     TerminologyGroup {
         name: attr(node, "name").unwrap_or_default().to_owned(),
         concepts,
         openehr_id: attr(node, "openehr_id").unwrap_or_default().to_owned(),
-        status: None,
+        status: status_attr(node),
     }
+}
+
+/// The optional `status` attribute the terminology XSDs declare on
+/// `codeset`/`code`/`group`/`concept`, parsed with the total,
+/// tolerance-preserving [`TerminologyStatus::from_wire`] (an out-of-set token
+/// survives as [`TerminologyStatus::Other`]). The pinned 3.1.0 assets carry no
+/// `status` attributes, so this reads `None` there — the field exists so a
+/// future re-vendored asset that populates the XSD-declared attribute parses
+/// losslessly into the modelled `TERMINOLOGY_STATUS` fields.
+fn status_attr(node: &roxmltree::Node) -> Option<TerminologyStatus> {
+    attr(node, "status").map(TerminologyStatus::from_wire)
 }
 
 /// Parse `PropertyUnitData.xml` (a `<PropertyUnits>` root of `<Property>` and
@@ -885,6 +897,59 @@ mod tests {
     }
 
     // ── Fallible parser (corrupt-asset path) ──────────────────────────────────
+
+    #[test]
+    fn status_attributes_parse_when_present_and_none_when_absent() {
+        // The XSDs declare an optional `status` on codeset/code/group/concept
+        // (assets/schema/openehr_terminology.xsd); the pinned assets omit it.
+        let t = parse_terminology(
+            r#"<terminology name="openehr" language="en">
+                 <codeset issuer="x" openehr_id="cs" name="cs" status="active">
+                   <code value="A" status="retired"/>
+                   <code value="B"/>
+                 </codeset>
+                 <group name="g" openehr_id="g" status="trial">
+                   <concept id="1" rubric="one" status="experimental"/>
+                   <concept id="2" rubric="two"/>
+                 </group>
+               </terminology>"#,
+        )
+        .expect("synthetic terminology parses");
+        let cs = &t.code_sets[0];
+        assert_eq!(cs.status, Some(TerminologyStatus::Active));
+        assert_eq!(cs.codes[0].status, Some(TerminologyStatus::Retired));
+        assert_eq!(cs.codes[1].status, None);
+        let g = &t.vocabularies[0];
+        assert_eq!(g.status, Some(TerminologyStatus::Trial));
+        // An out-of-set token is preserved, never dropped (from_wire is total).
+        assert_eq!(
+            g.concepts[0].status,
+            Some(TerminologyStatus::Other("experimental".to_owned()))
+        );
+        assert_eq!(g.concepts[1].status, None);
+    }
+
+    #[test]
+    fn vendored_assets_carry_no_status_attributes() {
+        // Pins the current asset reality the doc comment on `status_attr`
+        // relies on: every parsed status is None at the 3.1.0 pin.
+        let t = openehr();
+        let no_status = |term: &Terminology| {
+            term.code_sets
+                .iter()
+                .all(|cs| cs.status.is_none() && cs.codes.iter().all(|c| c.status.is_none()))
+                && term
+                    .vocabularies
+                    .iter()
+                    .all(|g| g.status.is_none() && g.concepts.iter().all(|c| c.status.is_none()))
+        };
+        assert!(no_status(t.terminology()));
+        assert!(
+            t.external_code_sets()
+                .iter()
+                .all(|cs| cs.status.is_none() && cs.codes.iter().all(|c| c.status.is_none()))
+        );
+    }
 
     #[test]
     fn parser_rejects_wrong_root() {

--- a/crates/openehr-term/tests/it/main.rs
+++ b/crates/openehr-term/tests/it/main.rs
@@ -2,3 +2,4 @@
 //! discipline), one module per topic.
 
 mod asset_identity;
+mod xsd_conformance;

--- a/crates/openehr-term/tests/it/xsd_conformance.rs
+++ b/crates/openehr-term/tests/it/xsd_conformance.rs
@@ -1,0 +1,340 @@
+//! The vendored terminology assets conform to the vendored XSDs.
+//!
+//! TERM `SupportTerminology/master04-representation.adoc` §XML Representation:
+//! the concrete representation of the code sets and vocabularies is "the XML
+//! format described by the XML Schema found in the openEHR
+//! `specifications-TERM` repository", and "An XML Schema (XSD) has been
+//! defined for these files, for use with software that processes them". The
+//! three schemas are vendored at `assets/schema/` (byte-identical to upstream
+//! at the pin — `assets/PROVENANCE.md`); no pure-Rust XSD validator is in the
+//! pinned dependency set, so this suite mirrors the schemas' structural rules
+//! directly — every assertion cites the XSD element/attribute declaration it
+//! encodes — and walks all seven vendored assets.
+
+/// The five language bundles governed by `assets/schema/openehr_terminology.xsd`.
+const LANGUAGE_ASSETS: [(&str, &str); 5] = [
+    (
+        "en",
+        include_str!("../../assets/en/openehr_terminology.xml"),
+    ),
+    (
+        "es",
+        include_str!("../../assets/es/openehr_terminology.xml"),
+    ),
+    (
+        "ja",
+        include_str!("../../assets/ja/openehr_terminology.xml"),
+    ),
+    (
+        "pt",
+        include_str!("../../assets/pt/openehr_terminology.xml"),
+    ),
+    (
+        "zh",
+        include_str!("../../assets/zh/openehr_terminology.xml"),
+    ),
+];
+
+const EXTERNAL_XML: &str = include_str!("../../assets/openehr_external_terminologies.xml");
+const PROPERTY_UNITS_XML: &str = include_str!("../../assets/PropertyUnitData.xml");
+
+/// `xs:NCName` per the XSD datatypes spec as the schemas use it: no colon, no
+/// whitespace, and the first character is a letter or underscore (a digit,
+/// dot, or minus may appear only later).
+fn is_ncname(s: &str) -> bool {
+    let mut chars = s.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first.is_alphabetic() || first == '_')
+        && chars.all(|c| c.is_alphanumeric() || matches!(c, '_' | '-' | '.'))
+}
+
+/// `xs:date` in the lexical form the schemas' data uses: `YYYY-MM-DD`.
+fn is_xs_date(s: &str) -> bool {
+    let b = s.as_bytes();
+    b.len() == 10
+        && b.get(4) == Some(&b'-')
+        && b.get(7) == Some(&b'-')
+        && s.char_indices()
+            .all(|(i, c)| matches!(i, 4 | 7) || c.is_ascii_digit())
+}
+
+/// Assert `node` declares no attribute outside `allowed` and every name in
+/// `required` — `xs:complexType` admits only its declared attributes.
+fn check_attrs(label: &str, node: &roxmltree::Node, required: &[&str], optional: &[&str]) {
+    for want in required {
+        assert!(
+            node.attribute(*want).is_some(),
+            "{label}: required attribute {want:?} missing (use=\"required\" in the XSD)"
+        );
+    }
+    for a in node.attributes() {
+        let name = a.name();
+        assert!(
+            required.contains(&name) || optional.contains(&name),
+            "{label}: attribute {name:?} is not declared by the XSD"
+        );
+    }
+}
+
+/// The `terminology` document shape shared by both terminology schemas:
+/// root attributes (`language` + `name` required `NCName`, `version` string,
+/// `date` `xs:date`), `codeset` (1..*) elements each holding `code` (1..*),
+/// and — when `groups_allowed` (`openehr_terminology.xsd`) — `group` (1..*)
+/// elements each holding `concept` (1..*), with every codeset preceding
+/// every group (`xs:sequence`).
+#[expect(
+    clippy::too_many_lines,
+    clippy::expect_used,
+    clippy::panic,
+    reason = "one XSD document type = one walker mirroring the schema top to bottom (splitting would scatter the rule mirror); a failed lookup after its own presence assertion, and an undeclared element, ARE the test failure (Book ch11 assertion idiom)"
+)]
+fn check_terminology_doc(label: &str, xml: &str, groups_allowed: bool, external_id_required: bool) {
+    let doc = roxmltree::Document::parse(xml).expect("well-formed XML");
+    let root = doc.root_element();
+    assert_eq!(
+        root.tag_name().name(),
+        "terminology",
+        "{label}: root element"
+    );
+    check_attrs(
+        &format!("{label}/terminology"),
+        &root,
+        &["language", "name"],
+        &["version", "date"],
+    );
+    for a in ["language", "name"] {
+        let v = root.attribute(a).expect("checked required above");
+        assert!(
+            is_ncname(v),
+            "{label}: terminology@{a}={v:?} is not an NCName"
+        );
+    }
+    if let Some(d) = root.attribute("date") {
+        assert!(
+            is_xs_date(d),
+            "{label}: terminology@date={d:?} is not an xs:date"
+        );
+    }
+
+    let mut seen_codeset = false;
+    let mut seen_group = false;
+    for child in root.children().filter(roxmltree::Node::is_element) {
+        match child.tag_name().name() {
+            "codeset" => {
+                assert!(
+                    !seen_group,
+                    "{label}: <codeset> after <group> — the xs:sequence puts every codeset first"
+                );
+                seen_codeset = true;
+                let cs_label = format!(
+                    "{label}/codeset[{}]",
+                    child.attribute("openehr_id").unwrap_or("?")
+                );
+                let required: &[&str] = if external_id_required {
+                    // openehr_external_terminologies.xsd: external_id use="required".
+                    &["issuer", "openehr_id", "external_id"]
+                } else {
+                    &["issuer", "openehr_id"]
+                };
+                check_attrs(
+                    &cs_label,
+                    &child,
+                    required,
+                    &["external_id", "name", "status"],
+                );
+                for a in ["issuer", "openehr_id"] {
+                    let v = child.attribute(a).expect("checked required above");
+                    assert!(is_ncname(v), "{cs_label}: @{a}={v:?} is not an NCName");
+                }
+                if let Some(v) = child.attribute("external_id") {
+                    assert!(
+                        is_ncname(v),
+                        "{cs_label}: @external_id={v:?} is not an NCName"
+                    );
+                }
+                let mut codes = 0usize;
+                for code in child.children().filter(roxmltree::Node::is_element) {
+                    assert_eq!(
+                        code.tag_name().name(),
+                        "code",
+                        "{cs_label}: only <code> children are declared"
+                    );
+                    codes += 1;
+                    check_attrs(&cs_label, &code, &["value"], &["description", "status"]);
+                    assert!(
+                        !code.children().any(|n| n.is_element()),
+                        "{cs_label}: <code> is empty-content in the XSD"
+                    );
+                }
+                assert!(
+                    codes >= 1,
+                    "{cs_label}: <code> is maxOccurs=unbounded, min 1"
+                );
+            }
+            "group" => {
+                assert!(
+                    groups_allowed,
+                    "{label}: <group> is not declared by this schema"
+                );
+                seen_group = true;
+                let g_label = format!(
+                    "{label}/group[{}]",
+                    child.attribute("openehr_id").unwrap_or("?")
+                );
+                check_attrs(&g_label, &child, &["name", "openehr_id"], &["status"]);
+                let id = child
+                    .attribute("openehr_id")
+                    .expect("checked required above");
+                assert!(
+                    is_ncname(id),
+                    "{g_label}: @openehr_id={id:?} is not an NCName"
+                );
+                let mut concepts = 0usize;
+                for concept in child.children().filter(roxmltree::Node::is_element) {
+                    assert_eq!(
+                        concept.tag_name().name(),
+                        "concept",
+                        "{g_label}: only <concept> children are declared"
+                    );
+                    concepts += 1;
+                    check_attrs(&g_label, &concept, &["id", "rubric"], &["status"]);
+                    let cid = concept.attribute("id").expect("checked required above");
+                    assert!(
+                        cid.parse::<i64>().is_ok(),
+                        "{g_label}: concept@id={cid:?} is not an xs:integer"
+                    );
+                    assert!(
+                        !concept.children().any(|n| n.is_element()),
+                        "{g_label}: <concept> is empty-content in the XSD"
+                    );
+                }
+                assert!(
+                    concepts >= 1,
+                    "{g_label}: <concept> is maxOccurs=unbounded, min 1"
+                );
+            }
+            other => panic!("{label}: element <{other}> is not declared by the schema"),
+        }
+    }
+    assert!(
+        seen_codeset,
+        "{label}: <codeset> is minOccurs>=1 in the sequence"
+    );
+    if groups_allowed {
+        assert!(
+            seen_group,
+            "{label}: <group> is minOccurs>=1 in the sequence"
+        );
+    }
+}
+
+#[test]
+fn language_bundles_conform_to_openehr_terminology_xsd() {
+    for (lang, xml) in LANGUAGE_ASSETS {
+        check_terminology_doc(
+            &format!("{lang}/openehr_terminology.xml"),
+            xml,
+            /* groups_allowed */ true,
+            /* external_id_required */ false,
+        );
+    }
+}
+
+#[test]
+fn external_terminologies_conform_to_their_xsd() {
+    check_terminology_doc(
+        "openehr_external_terminologies.xml",
+        EXTERNAL_XML,
+        /* groups_allowed */ false,
+        /* external_id_required */ true,
+    );
+}
+
+#[test]
+#[expect(
+    clippy::expect_used,
+    clippy::panic,
+    reason = "a failed lookup after its own presence assertion, and an undeclared element, ARE the test failure (Book ch11 assertion idiom)"
+)]
+fn property_unit_data_conforms_to_property_units_xsd() {
+    // assets/schema/PropertyUnitData.xsd: root PropertyUnits in the
+    // http://tempuri.org/PropertyUnits.xsd namespace; a sequence of
+    // Property* then Unit*; PropertyType requires id (xs:int), Text,
+    // openEHR (xs:int); UnitType requires property_id (xs:int) and Text,
+    // with optional name, conversion (xs:float), coefficient (xs:int),
+    // primary (xs:boolean), UCUM.
+    let doc = roxmltree::Document::parse(PROPERTY_UNITS_XML).expect("well-formed XML");
+    let root = doc.root_element();
+    assert_eq!(root.tag_name().name(), "PropertyUnits");
+    assert_eq!(
+        root.tag_name().namespace(),
+        Some("http://tempuri.org/PropertyUnits.xsd"),
+        "the schema's targetNamespace"
+    );
+
+    let mut property_ids = std::collections::BTreeSet::new();
+    let mut seen_unit = false;
+    let mut units = 0usize;
+    for child in root.children().filter(roxmltree::Node::is_element) {
+        match child.tag_name().name() {
+            "Property" => {
+                assert!(
+                    !seen_unit,
+                    "<Property> after <Unit> — the xs:sequence puts every Property first"
+                );
+                check_attrs("Property", &child, &["id", "Text", "openEHR"], &[]);
+                for a in ["id", "openEHR"] {
+                    let v = child.attribute(a).expect("checked required above");
+                    assert!(
+                        v.parse::<i32>().is_ok(),
+                        "Property@{a}={v:?} is not an xs:int"
+                    );
+                }
+                property_ids.insert(child.attribute("id").expect("checked").to_owned());
+            }
+            "Unit" => {
+                seen_unit = true;
+                units += 1;
+                check_attrs(
+                    "Unit",
+                    &child,
+                    &["property_id", "Text"],
+                    &["name", "conversion", "coefficient", "primary", "UCUM"],
+                );
+                let pid = child
+                    .attribute("property_id")
+                    .expect("checked required above");
+                assert!(pid.parse::<i32>().is_ok(), "Unit@property_id is xs:int");
+                // Referential sanity on top of the schema: every unit names a
+                // declared property (the table is a join, not free text).
+                assert!(
+                    property_ids.contains(pid),
+                    "Unit@property_id={pid:?} names no <Property id=…>"
+                );
+                if let Some(v) = child.attribute("conversion") {
+                    assert!(
+                        v.parse::<f32>().is_ok(),
+                        "Unit@conversion={v:?} is not an xs:float"
+                    );
+                }
+                if let Some(v) = child.attribute("coefficient") {
+                    assert!(
+                        v.parse::<i32>().is_ok(),
+                        "Unit@coefficient={v:?} is not an xs:int"
+                    );
+                }
+                if let Some(v) = child.attribute("primary") {
+                    assert!(
+                        matches!(v, "true" | "false" | "1" | "0"),
+                        "Unit@primary={v:?} is not an xs:boolean"
+                    );
+                }
+            }
+            other => panic!("element <{other}> is not declared by PropertyUnitData.xsd"),
+        }
+    }
+    assert!(!property_ids.is_empty(), "at least one Property row");
+    assert!(units >= 1, "at least one Unit row");
+}


### PR DESCRIPTION
TERM ch.4 audit fixes (#1243 §4.1 + #1244 §4.2, program #814):

- **#1425 (§4.1):** the XSDs declare an optional `status` on `codeset`/`code`/`group`/`concept` and the generated model carries `status: Option<TerminologyStatus>` on all four classes — but `bundle.rs` hardcoded `None`. Now parsed via `TerminologyStatus::from_wire` (total, tolerance-preserving; out-of-set token survives as `Other`). Tests: synthetic-XML parse (present → parsed incl. tolerance, absent → `None`) + a pin that the 3.1.0 assets carry zero status attributes (so behaviour today is unchanged, and the byte-identity gate keeps it that way).
- **#1419 (§4.2):** `master04-representation.adoc` defines the concrete representation by the repository XSDs ("for use with software that processes them") — vendored at `assets/schema/` (byte-identical to upstream at the pin) but exercised by nothing. New `tests/it/xsd_conformance.rs` mirrors the three schemas' structural rules — root shape + namespace, xs:sequence order (codesets before groups; Properties before Units), required vs declared attributes per element, NCName/xs:integer/xs:date/xs:float/xs:boolean lexical checks, minOccurs floors, empty-content leaves, plus Unit→Property referential sanity — over all seven vendored assets, each assertion citing its XSD declaration.

Gates: clippy -p openehr-term --all-targets clean, nextest 25/25, fmt clean.

Closes #1425
Closes #1419