### PR TITLE
chore(lints): remove the inert arithmetic_side_effects entry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,13 +149,14 @@ trivial_casts = "warn"
 trivial_numeric_casts = "warn"
 ambiguous_negative_literals = "deny"  # `-x.pow(2)` reads wrong — numeric clarity
 # NOTE: clippy::arithmetic_side_effects (checked-math-everywhere) is NOT
-# enabled: it is a CLIPPY restriction lint (a bare entry in this rust table
-# is inert and only warns), enabling it for real is a ~600-site remediation
-# program, and silent-overflow safety is already guaranteed by
-# `overflow-checks = true` in [profile.release] — an overflow panics loudly
-# instead of wrapping into a wrong value
-# (https://doc.rust-lang.org/cargo/reference/profiles.html#overflow-checks).
-# The enable-or-not ruling is tracked on issue #1426.
+# enabled (owner ruling 2026-08-01, issue #1426): silent-overflow safety is
+# already guaranteed by `overflow-checks = true` in [profile.release] — an
+# overflow panics loudly instead of wrapping into a wrong clinical value
+# (https://doc.rust-lang.org/cargo/reference/profiles.html#overflow-checks) —
+# and a blanket checked-math mandate would invite the silent saturating/
+# default dodges this table exists to prevent. Do not re-add it here: it is
+# a CLIPPY restriction lint, so a bare entry in this rust table is inert and
+# only emits a deprecated-lint-name warning on every crate.
 
 [workspace.lints.rustdoc]
 # Enforced by the CI doc job (RUSTDOCFLAGS=-D warnings, cargo doc --workspace)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,14 @@ redundant_lifetimes = "warn"
 trivial_casts = "warn"
 trivial_numeric_casts = "warn"
 ambiguous_negative_literals = "deny"  # `-x.pow(2)` reads wrong — numeric clarity
-arithmetic_side_effects = "deny"  # `x + y` where x or y is a side-effecting call (e.g., `x() + y()`) is a silent bug
+# NOTE: clippy::arithmetic_side_effects (checked-math-everywhere) is NOT
+# enabled: it is a CLIPPY restriction lint (a bare entry in this rust table
+# is inert and only warns), enabling it for real is a ~600-site remediation
+# program, and silent-overflow safety is already guaranteed by
+# `overflow-checks = true` in [profile.release] — an overflow panics loudly
+# instead of wrapping into a wrong value
+# (https://doc.rust-lang.org/cargo/reference/profiles.html#overflow-checks).
+# The enable-or-not ruling is tracked on issue #1426.
 
 [workspace.lints.rustdoc]
 # Enforced by the CI doc job (RUSTDOCFLAGS=-D warnings, cargo doc --workspace)


### PR DESCRIPTION
Follow-up to #1427 per the owner's call: `arithmetic_side_effects` is a **clippy** restriction lint, so the bare entry in `[workspace.lints.rust]` applied nothing and emitted a deprecated-lint-name warning on every crate. Removed; a NOTE in the lint table records why it is not enabled (release `overflow-checks = true` already panics loudly on overflow — no silent wrong values) and points at #1426 for the deliberate enable-or-not ruling (~600-site remediation program if enabled).

Gates: clippy spot-lanes clean, warning gone.