### PR TITLE
fix(openehr-term): drop the unfulfilled lint expectation on the PropertyUnitData test

### DIFF
--- a/crates/openehr-term/tests/it/xsd_conformance.rs
+++ b/crates/openehr-term/tests/it/xsd_conformance.rs
@@ -253,11 +253,6 @@ fn external_terminologies_conform_to_their_xsd() {
 }
 
 #[test]
-#[expect(
-    clippy::expect_used,
-    clippy::panic,
-    reason = "a failed lookup after its own presence assertion, and an undeclared element, ARE the test failure (Book ch11 assertion idiom)"
-)]
 fn property_unit_data_conforms_to_property_units_xsd() {
     // assets/schema/PropertyUnitData.xsd: root PropertyUnits in the
     // http://tempuri.org/PropertyUnits.xsd namespace; a sequence of


### PR DESCRIPTION
CI clippy on develop failed with `unfulfilled_lint_expectations` at `xsd_conformance.rs:257-258` (from PR #1428): the `#[expect(clippy::expect_used, clippy::panic)]` sat on a `#[test]` fn, where the `clippy.toml` `allow-*-in-tests` scoping already admits those idioms — so the expectation never fires and self-reports under `-D warnings`. Removed; the free helper fns (where the lints DO fire) keep their fulfilled expects.

Gates: `cargo clippy -p openehr-term --all-targets -- -D warnings` clean, nextest 25/25.