### PR TITLE
fix(openehr-its): resolve the effective RM type for legally untagged nodes

### DIFF
--- a/.claude/agent-memory/cnf-triage/MEMORY.md
+++ b/.claude/agent-memory/cnf-triage/MEMORY.md
@@ -28,4 +28,5 @@
 - [ITS-REST 1.1.0-dated surfaces](its-rest-1-1-0-dated-surfaces.md) — the Amendment_record dating table (SF/item-tags/demographic/admin-delete/W-ETag…) = the ground for every version floor
 - [SHOULD headers over-gated](should-headers-over-gated.md) — Last-Modified presence + the 412 ETag are SHOULDs; bare `present` matchers must be `present?`
 - [OPT 1.4 ac-code definedness](opt14-ac-code-definedness.md) — VATDF/VACDF: only a `constraint_definitions` entry defines an ac-code; `term_definitions` is XSD-mandatory; component ontology → `component_ontologies`
+- [`_type`-tag-driven validation walk](type-tag-driven-validation-walk-skips-untagged-nodes.md) — APP defect class: untagged concretely-declared nodes (context/participations/…) escape ALL invariants on the JSON commit path; XML twin refuses
 - [AMB-167 documented-family root-name gap](amb167-documented-family-root-name-gap.md) — the handling carve-out contradicts the classification; DOCUMENTED XML root+namespace is a MUST with no case

--- a/.claude/agent-memory/cnf-triage/type-tag-driven-validation-walk-skips-untagged-nodes.md
+++ b/.claude/agent-memory/cnf-triage/type-tag-driven-validation-walk-skips-untagged-nodes.md
@@ -1,0 +1,47 @@
+---
+name: type-tag-driven-validation-walk-skips-untagged-nodes
+description: APP defect class — both RM validation passes dispatch on the JSON `_type` tag, so any node whose `_type` is legitimately omitted (concretely-declared slot) escapes every invariant on the canonical-JSON commit path
+metadata:
+  type: project
+---
+
+Confirmed 2026-08-01 (red row
+`I_EHR_COMPOSITION.create_composition-setting_invalid`, 201 instead of 422).
+
+**Mechanism.** `crates/openehr-its/src/flat/validation/terminology.rs:38`
+(`obj.get("_type")…unwrap_or("")` → `slots_for("")` = empty) and
+`crates/openehr-its/src/rm_validate.rs:147`/`164` (`let Some(ty) = value.get("_type")
+… else { return }`) both key on the **wire tag**. Canonical JSON only requires
+`_type` where the declared slot type is abstract (ITS-JSON
+`crates/openehr-its/schemas/json/openehr_rm_1.1.0_all.json`: `COMPOSITION.context`
+is a bare `$ref` to `EVENT_CONTEXT`, whose `required` list is
+`["start_time","setting"]` — no `_type`), so a spec-valid payload can omit it and
+every invariant on that node — terminology AND core — silently does not run.
+Canonical **XML** bodies go typed (`app/ferroehr-rest/src/overview/negotiate.rs:511`
+→ `to_canonical_value`, which injects `_type`), so the SAME content is refused as
+XML and accepted as JSON — the asymmetry is the proof it is a walk defect, not a
+spec-permitted leniency.
+
+Reproduced on the composed SUT, one EHR, `Content-Type: application/json`:
+- setting 999, untagged context → **201**; `+ "_type":"EVENT_CONTEXT"` → **422**
+  `/context/setting: code '999' is not a valid setting (openEHR terminology)`
+- same content as canonical XML → **422** (same message)
+- `PARTICIPATION.mode` 999 untagged → **201**; tagged → **422** (Mode_valid)
+- `EVENT_CONTEXT.location: ""` untagged → **201**; tagged → **422**
+  `Invariant location_valid failed on type EVENT_CONTEXT` (core invariants escape too)
+- `COMPOSITION.category` 999 with the ROOT `_type` stripped → still 422, but only
+  from the WebTemplate pass ("not in the constrained value set") — which is why the
+  three sibling cases (category/language/territory) pass and setting does not:
+  the OPT constrains `category`, nothing constrains RM-level `context/setting`.
+
+**How to apply.** The fix is *effective-type resolution*, not a new slot entry:
+resolve each child node's RM type as `_type` if present else
+`openehr_rm::model::attribute(parent_type, field).declared_type` when that class
+is concrete (`RmClass.is_abstract == false`) — the generated static model already
+carries it (`crates/openehr-rm/src/model/data.rs:1451` context → EVENT_CONTEXT,
+:4093 participations → PARTICIPATION). Both walk sites are HAND-WRITTEN
+(`openehr-its` is a mixed crate) → normal edit, **no emitter/regen needed**.
+Suspect this pattern for any red row where a nested-node invariant did not fire
+on a JSON commit but the same shape is refused via XML; the escape class is every
+concretely-declared slot (context, participations, archetype_details, ism_transition,
+activities, mappings, reference ranges, instruction_details, …).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,20 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **RM validation reaches legally untagged canonical-JSON nodes.** Canonical
+  JSON requires `_type` only on polymorphic slots, so a node under a
+  concretely-declared attribute (`COMPOSITION.context`,
+  `EVENT_CONTEXT.participations`, …) may omit its tag — and the validation
+  walk, dispatching on the wire tag alone, silently skipped every RM class
+  invariant and terminology binding on such nodes (the same content was
+  refused over canonical XML but committed over JSON). The walk now resolves
+  an untagged node's effective RM type from the parent's declared attribute
+  type (the BMM-generated static RM model), so commits like an out-of-group
+  `EVENT_CONTEXT.setting` are refused 422 regardless of tag presence or
+  format.
+
 ### Changed
 
 - **The documentation website moved to its own domain,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,20 +15,6 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
-### Fixed
-
-- **RM validation reaches legally untagged canonical-JSON nodes.** Canonical
-  JSON requires `_type` only on polymorphic slots, so a node under a
-  concretely-declared attribute (`COMPOSITION.context`,
-  `EVENT_CONTEXT.participations`, …) may omit its tag — and the validation
-  walk, dispatching on the wire tag alone, silently skipped every RM class
-  invariant and terminology binding on such nodes (the same content was
-  refused over canonical XML but committed over JSON). The walk now resolves
-  an untagged node's effective RM type from the parent's declared attribute
-  type (the BMM-generated static RM model), so commits like an out-of-group
-  `EVENT_CONTEXT.setting` are refused 422 regardless of tag presence or
-  format.
-
 ### Changed
 
 - **The documentation website moved to its own domain,
@@ -43,6 +29,18 @@ workflow refuses a tag that has no matching section here.
   (`/ferroehr/rest/openehr/v1`) is unchanged.
 
 ### Fixed
+
+- **RM validation reaches legally untagged canonical-JSON nodes.** Canonical
+  JSON requires `_type` only on polymorphic slots, so a node under a
+  concretely-declared attribute (`COMPOSITION.context`,
+  `EVENT_CONTEXT.participations`, …) may omit its tag — and the validation
+  walk, dispatching on the wire tag alone, silently skipped every RM class
+  invariant and terminology binding on such nodes (the same content was
+  refused over canonical XML but committed over JSON). The walk now resolves
+  an untagged node's effective RM type from the parent's declared attribute
+  type (the BMM-generated static RM model), so commits like an out-of-group
+  `EVENT_CONTEXT.setting` are refused 422 regardless of tag presence or
+  format.
 
 - **The documentation version switcher pointed at dead URLs.** Entries in
   the published version manifest kept whichever site base path was current

--- a/crates/openehr-its/src/flat/validation/mod.rs
+++ b/crates/openehr-its/src/flat/validation/mod.rs
@@ -61,7 +61,7 @@ mod leaf;
 mod subtype;
 mod terminology;
 
-use crate::rm_validate::validate_rm_invariants;
+use crate::rm_validate::{declared_concrete_type, validate_rm_invariants_as};
 use indexmap::IndexMap;
 use openehr_rm::paths::PathSegment;
 use serde_json::{Map, Value};
@@ -124,9 +124,12 @@ pub fn validate_composition(composition: &Value, wt: &WebTemplate) -> Vec<Valida
     // One reusable path buffer across passes 1 and 2 (each leaves it empty).
     let mut path = String::new();
     // Pass 1: RM class invariants over the whole instance (compaction-independent).
-    v.rm_invariant_pass(composition, &mut path);
+    // The root's declared type is COMPOSITION — an untagged root is legal
+    // canonical JSON (the ITS-JSON schema requires `_type` only on
+    // polymorphic slots, and the resource root is concretely COMPOSITION).
+    v.rm_invariant_pass(composition, &mut path, Some("COMPOSITION"));
     // Pass 2: RM-mandated openEHR terminology.
-    v.terminology_pass(composition, &mut path, None);
+    v.terminology_pass(composition, &mut path, Some("COMPOSITION"));
     // Pass 3: archetype conformance guided by the WebTemplate tree.
     v.walk(composition, &wt.tree);
     v.out
@@ -142,8 +145,8 @@ pub fn validate_composition(composition: &Value, wt: &WebTemplate) -> Vec<Valida
 pub fn validate_rm_and_terminology(composition: &Value) -> Vec<ValidationMessage> {
     let mut v = Validator::default();
     let mut path = String::new();
-    v.rm_invariant_pass(composition, &mut path);
-    v.terminology_pass(composition, &mut path, None);
+    v.rm_invariant_pass(composition, &mut path, Some("COMPOSITION"));
+    v.terminology_pass(composition, &mut path, Some("COMPOSITION"));
     v.out
 }
 
@@ -624,14 +627,19 @@ impl Validator {
     // back after, so the full path string is materialized only when a violation
     // is actually recorded — not `format!`-allocated afresh at every one of the
     // ~1.5k nodes an IPS commit visits.
-    fn rm_invariant_pass(&mut self, v: &Value, path: &mut String) {
+    //
+    // `declared` is the parent attribute's declared RM type when concrete — the
+    // effective type of a node whose wire `_type` is legitimately absent
+    // (canonical JSON requires `_type` only on polymorphic slots), so untagged
+    // nodes like `COMPOSITION.context` still run their class invariants
+    // (`crate::rm_validate::declared_concrete_type`).
+    fn rm_invariant_pass(&mut self, v: &Value, path: &mut String, declared: Option<&str>) {
         use std::fmt::Write as _;
         let Some(obj) = v.as_object() else { return };
         // One projection pass over the node's entries collects every field the
         // per-node checks below read, so none of them pays a hashed map lookup
         // (this runs for every node of every commit; the only remaining per-node
         // gets are gated behind a matching `_type`).
-        let mut has_type = false;
         let mut ty: Option<&str> = None;
         let mut node_id: Option<&str> = None;
         let mut has_archetype_details = false;
@@ -639,10 +647,7 @@ impl Validator {
         let mut reference_ranges_empty = false;
         for (k, val) in obj {
             match k.as_str() {
-                "_type" => {
-                    has_type = true;
-                    ty = val.as_str();
-                }
+                "_type" => ty = val.as_str(),
                 "archetype_node_id" => node_id = val.as_str(),
                 "archetype_details" => has_archetype_details = !val.is_null(),
                 "mappings" => mappings_empty = val.as_array().is_some_and(Vec::is_empty),
@@ -652,13 +657,16 @@ impl Validator {
                 _ => {}
             }
         }
-        if has_type {
+        // The node's effective RM type: the wire tag, else the parent's
+        // concretely-declared attribute type (untagged nodes are legal there).
+        let ty = ty.or(declared);
+        if let Some(effective) = ty {
             // The core (fast/typed) RM invariants only — the terminology-backed
             // invariants are enforced by the dedicated `terminology_pass` (its
             // own `ValidationKind::Terminology` rendering), so calling the
             // core-only entry here avoids double-reporting them.
             let mut inv = Vec::new();
-            validate_rm_invariants(v, &mut inv);
+            validate_rm_invariants_as(effective, v, &mut inv);
             for iv in inv {
                 let p = if iv.path.is_empty() {
                     norm_path(path)
@@ -675,13 +683,14 @@ impl Validator {
             if k.starts_with('_') {
                 continue;
             }
+            let child_declared = ty.and_then(|t| declared_concrete_type(t, k));
             match val {
                 Value::Array(a) => {
                     for (i, item) in a.iter().enumerate() {
                         if item.is_object() {
                             let base = path.len();
                             let _ = write!(path, "/{k}[{i}]");
-                            self.rm_invariant_pass(item, path);
+                            self.rm_invariant_pass(item, path, child_declared);
                             path.truncate(base);
                         }
                     }
@@ -689,7 +698,7 @@ impl Validator {
                 Value::Object(_) => {
                     let base = path.len();
                     let _ = write!(path, "/{k}");
-                    self.rm_invariant_pass(val, path);
+                    self.rm_invariant_pass(val, path, child_declared);
                     path.truncate(base);
                 }
                 _ => {}
@@ -2817,12 +2826,12 @@ mod tests {
         let iters = 50;
         let t_rm = time_pass(iters, || {
             let mut v = Validator::default();
-            v.rm_invariant_pass(&comp, &mut String::new());
+            v.rm_invariant_pass(&comp, &mut String::new(), Some("COMPOSITION"));
             v.out.len()
         });
         let t_term = time_pass(iters, || {
             let mut v = Validator::default();
-            v.terminology_pass(&comp, &mut String::new(), None);
+            v.terminology_pass(&comp, &mut String::new(), Some("COMPOSITION"));
             v.out.len()
         });
         let t_both = time_pass(iters, || validate_rm_and_terminology(&comp).len());

--- a/crates/openehr-its/src/flat/validation/terminology.rs
+++ b/crates/openehr-its/src/flat/validation/terminology.rs
@@ -18,6 +18,7 @@
 //! bundle in [`openehr_term::bundle`] (TERM 3.1.0).
 
 use crate::rm_terminology::{Slot, slot_is_violated, slots_for};
+use crate::rm_validate::declared_concrete_type;
 use serde_json::Value;
 
 use super::{ValidationKind, Validator, norm_path};
@@ -27,15 +28,24 @@ impl Validator {
     // mirroring [`super::Validator::rm_invariant_pass`]: a segment is appended
     // before a coded-slot check or a recursion and truncated back after, so the
     // full path string is materialized only when a violation is recorded.
+    // `declared` is the parent attribute's declared RM type when concrete —
+    // the effective type of a node whose wire `_type` is legitimately absent
+    // (canonical JSON requires `_type` only on polymorphic slots), so untagged
+    // nodes like `COMPOSITION.context` still get their coded slots checked
+    // (`crate::rm_validate::declared_concrete_type`).
     pub(super) fn terminology_pass(
         &mut self,
         v: &Value,
         path: &mut String,
-        _parent_type: Option<&str>,
+        declared: Option<&str>,
     ) {
         use std::fmt::Write as _;
         let Some(obj) = v.as_object() else { return };
-        let this_type = obj.get("_type").and_then(Value::as_str).unwrap_or("");
+        let this_type = obj
+            .get("_type")
+            .and_then(Value::as_str)
+            .or(declared)
+            .unwrap_or("");
 
         // Coded slots fixed by the owning RM type (the shared binding table).
         for slot in slots_for(this_type) {
@@ -51,13 +61,14 @@ impl Validator {
             if k.starts_with('_') {
                 continue;
             }
+            let child_declared = declared_concrete_type(this_type, k);
             match val {
                 Value::Array(a) => {
                     for (i, item) in a.iter().enumerate() {
                         if item.is_object() {
                             let base = path.len();
                             let _ = write!(path, "/{k}[{i}]");
-                            self.terminology_pass(item, path, Some(this_type));
+                            self.terminology_pass(item, path, child_declared);
                             path.truncate(base);
                         }
                     }
@@ -65,7 +76,7 @@ impl Validator {
                 Value::Object(_) => {
                     let base = path.len();
                     let _ = write!(path, "/{k}");
-                    self.terminology_pass(val, path, Some(this_type));
+                    self.terminology_pass(val, path, child_declared);
                     path.truncate(base);
                 }
                 _ => {}

--- a/crates/openehr-its/src/rm_validate.rs
+++ b/crates/openehr-its/src/rm_validate.rs
@@ -37,27 +37,25 @@ use crate::json_codec::runtime::{FromJson, JsonParseError, from_json_value};
 /// corpus deserializes cleanly at every node, so this never rejects a valid
 /// input; if it ever did, that would expose a codegen field-optionality bug to
 /// fix in the emitter.)
-fn record_type_mismatch(value: &Value, err: &JsonParseError, out: &mut Vec<InvariantViolation>) {
-    let ty = value
-        .get("_type")
-        .and_then(Value::as_str)
-        .unwrap_or("<unknown>");
+fn record_type_mismatch(ty: &str, err: &JsonParseError, out: &mut Vec<InvariantViolation>) {
     out.push(InvariantViolation::here(format!(
         "does not conform to RM type {ty}: {err}"
     )));
 }
 
-fn run<T: FromJson + Validate>(value: &Value, out: &mut Vec<InvariantViolation>) {
+fn run<T: FromJson + Validate>(ty: &str, value: &Value, out: &mut Vec<InvariantViolation>) {
     match from_json_value::<T>(value) {
         Ok(v) => v.validate_invariants(out),
-        Err(e) => record_type_mismatch(value, &e, out),
+        Err(e) => record_type_mismatch(ty, &e, out),
     }
 }
 
 /// Like [`run`], but deserialize `T` from a copy of `value` whose nested
 /// RM-node child collections have been emptied ([`prune_child_nodes`]).
 ///
-/// TODO(perf): the RM-invariant pass ([`validate_rm_value`]) is called once per
+/// NOTE (settled perf design — no openEHR spec governs validation-pass
+/// mechanics; our own design): the RM-invariant pass ([`validate_rm_value`])
+/// is called once per
 /// `_type` node while the composition validator recurses the live JSON tree, so
 /// deserializing each node's *whole* subtree (as `from_json_value` does for a
 /// concrete container type) re-parses every descendant once per ancestor —
@@ -86,10 +84,10 @@ fn run<T: FromJson + Validate>(value: &Value, out: &mut Vec<InvariantViolation>)
 /// byte-identical, and the ITS-JSON schema gate remains the exhaustive
 /// structural oracle where one is required (this pass is the RM class-invariant
 /// check, not a schema validator — `422_COMPOSITION.yaml`).
-fn run_shallow<T: FromJson + Validate>(value: &Value, out: &mut Vec<InvariantViolation>) {
+fn run_shallow<T: FromJson + Validate>(ty: &str, value: &Value, out: &mut Vec<InvariantViolation>) {
     match from_json_value::<T>(&prune_child_nodes(value)) {
         Ok(v) => v.validate_invariants(out),
-        Err(e) => record_type_mismatch(value, &e, out),
+        Err(e) => record_type_mismatch(ty, &e, out),
     }
 }
 
@@ -147,10 +145,38 @@ pub fn validate_rm_invariants(value: &Value, out: &mut Vec<InvariantViolation>) 
     let Some(ty) = value.get("_type").and_then(Value::as_str) else {
         return;
     };
+    validate_rm_invariants_as(ty, value, out);
+}
+
+/// [`validate_rm_invariants`] with the node's RM type supplied by the caller —
+/// the entry a tree walker uses for a node whose wire `_type` is legitimately
+/// absent (canonical JSON requires `_type` only where the declared attribute
+/// type is abstract; see [`declared_concrete_type`]). The `_type`-reading
+/// wrapper stays for callers with no declaration context.
+pub fn validate_rm_invariants_as(ty: &str, value: &Value, out: &mut Vec<InvariantViolation>) {
     if openehr_rm::validate::try_fast_validate(ty, value, out) {
         return;
     }
     validate_rm_value_typed(ty, value, out);
+}
+
+/// The declared RM type of `field` on `parent_type` when that type is
+/// concrete, else `None`.
+///
+/// This is the effective-type rule for an UNTAGGED canonical-JSON node: the
+/// ITS-JSON schema requires `_type` only on polymorphic slots, so a node under
+/// a concretely-declared attribute (`COMPOSITION.context` → `EVENT_CONTEXT`,
+/// `EVENT_CONTEXT.participations` → `PARTICIPATION`, …) may legally omit it —
+/// and a validation walk that dispatches on the wire tag alone would skip every
+/// RM invariant on such a node. The BMM-generated static RM model
+/// ([`openehr_rm::model`]) supplies the declaration; an abstract declared type
+/// yields `None` (there the wire MUST tag, and an untagged node is unreadable
+/// rather than silently valid).
+#[must_use]
+pub fn declared_concrete_type(parent_type: &str, field: &str) -> Option<&'static str> {
+    let attr = openehr_rm::model::attribute(parent_type, field)?;
+    let class = openehr_rm::model::class(attr.declared_type)?;
+    (!class.is_abstract).then_some(class.name)
 }
 
 /// Run **all** RM class invariants for a single canonical-JSON node — the core
@@ -251,28 +277,28 @@ pub fn validate_rm_value_typed(ty: &str, value: &Value, out: &mut Vec<InvariantV
 
     match ty {
         // data_types
-        "CODE_PHRASE" => run::<CodePhrase>(value, out),
+        "CODE_PHRASE" => run::<CodePhrase>(ty, value, out),
         // DV_TEXT + DV_CODED_TEXT share the DvText enum (Valid_value /
         // Formatting_valid, dv_text.adoc; DV_CODED_TEXT adds the structural
         // defining_code 1..1 at deserialize).
-        "DV_TEXT" | "DV_CODED_TEXT" => run::<DvText>(value, out),
-        "DV_URI" => run::<DvUriData>(value, out),
-        "DV_EHR_URI" => run::<DvEhrUri>(value, out),
-        "DV_IDENTIFIER" => run::<DvIdentifier>(value, out),
-        "TERM_MAPPING" => run::<TermMapping>(value, out),
-        "DV_MULTIMEDIA" => run::<DvMultimedia>(value, out),
-        "DV_PROPORTION" => run::<DvProportion>(value, out),
-        "DV_QUANTITY" => run::<DvQuantity>(value, out),
-        "DV_COUNT" => run::<DvCount>(value, out),
-        "DV_DURATION" => run::<DvDuration>(value, out),
-        "DV_DATE" => run::<DvDate>(value, out),
-        "DV_TIME" => run::<DvTime>(value, out),
-        "DV_DATE_TIME" => run::<DvDateTime>(value, out),
-        "DV_ORDINAL" => run::<DvOrdinal>(value, out),
-        "DV_SCALE" => run::<DvScale>(value, out),
-        "DV_PARSABLE" => run::<DvParsable>(value, out),
-        "DV_PERIODIC_TIME_SPECIFICATION" => run::<DvPeriodicTimeSpecification>(value, out),
-        "REFERENCE_RANGE" => run::<ReferenceRange>(value, out),
+        "DV_TEXT" | "DV_CODED_TEXT" => run::<DvText>(ty, value, out),
+        "DV_URI" => run::<DvUriData>(ty, value, out),
+        "DV_EHR_URI" => run::<DvEhrUri>(ty, value, out),
+        "DV_IDENTIFIER" => run::<DvIdentifier>(ty, value, out),
+        "TERM_MAPPING" => run::<TermMapping>(ty, value, out),
+        "DV_MULTIMEDIA" => run::<DvMultimedia>(ty, value, out),
+        "DV_PROPORTION" => run::<DvProportion>(ty, value, out),
+        "DV_QUANTITY" => run::<DvQuantity>(ty, value, out),
+        "DV_COUNT" => run::<DvCount>(ty, value, out),
+        "DV_DURATION" => run::<DvDuration>(ty, value, out),
+        "DV_DATE" => run::<DvDate>(ty, value, out),
+        "DV_TIME" => run::<DvTime>(ty, value, out),
+        "DV_DATE_TIME" => run::<DvDateTime>(ty, value, out),
+        "DV_ORDINAL" => run::<DvOrdinal>(ty, value, out),
+        "DV_SCALE" => run::<DvScale>(ty, value, out),
+        "DV_PARSABLE" => run::<DvParsable>(ty, value, out),
+        "DV_PERIODIC_TIME_SPECIFICATION" => run::<DvPeriodicTimeSpecification>(ty, value, out),
+        "REFERENCE_RANGE" => run::<ReferenceRange>(ty, value, out),
         // DV_INTERVAL: prefer the DV_ORDERED-typed element so the
         // Limits_consistent ordering invariant runs; fall back to
         // Value elements (boundary flags only) for non-DV_ORDERED payloads.
@@ -280,52 +306,52 @@ pub fn validate_rm_value_typed(ty: &str, value: &Value, out: &mut Vec<InvariantV
             if let Ok(v) = from_json_value::<DvInterval<DvOrdered>>(value) {
                 v.validate_invariants(out);
             } else {
-                run::<DvInterval<Value>>(value, out);
+                run::<DvInterval<Value>>(ty, value, out);
             }
         }
         // data_structures. HISTORY and ITEM_TABLE keep the full deserialize —
         // their own invariants read a child collection (`events` / `rows`); the
         // rest are structural containers with scalar-only invariants, so they
         // deserialize shallowly (see `run_shallow`).
-        "ELEMENT" => run::<Element>(value, out),
-        "CLUSTER" => run_shallow::<Cluster>(value, out),
-        "HISTORY" => run::<History<Value>>(value, out),
-        "POINT_EVENT" => run_shallow::<PointEvent<Value>>(value, out),
-        "INTERVAL_EVENT" => run_shallow::<IntervalEvent<Value>>(value, out),
-        "ITEM_TABLE" => run::<ItemTable>(value, out),
+        "ELEMENT" => run::<Element>(ty, value, out),
+        "CLUSTER" => run_shallow::<Cluster>(ty, value, out),
+        "HISTORY" => run::<History<Value>>(ty, value, out),
+        "POINT_EVENT" => run_shallow::<PointEvent<Value>>(ty, value, out),
+        "INTERVAL_EVENT" => run_shallow::<IntervalEvent<Value>>(ty, value, out),
+        "ITEM_TABLE" => run::<ItemTable>(ty, value, out),
         // common
-        "PARTY_IDENTIFIED" => run::<PartyIdentifiedData>(value, out),
-        "PARTY_RELATED" => run::<PartyRelated>(value, out),
-        "AUDIT_DETAILS" => run::<AuditDetailsData>(value, out),
-        "ATTESTATION" => run::<Attestation>(value, out),
-        "FEEDER_AUDIT_DETAILS" => run::<FeederAuditDetails>(value, out),
-        "ARCHETYPED" => run::<Archetyped>(value, out),
+        "PARTY_IDENTIFIED" => run::<PartyIdentifiedData>(ty, value, out),
+        "PARTY_RELATED" => run::<PartyRelated>(ty, value, out),
+        "AUDIT_DETAILS" => run::<AuditDetailsData>(ty, value, out),
+        "ATTESTATION" => run::<Attestation>(ty, value, out),
+        "FEEDER_AUDIT_DETAILS" => run::<FeederAuditDetails>(ty, value, out),
+        "ARCHETYPED" => run::<Archetyped>(ty, value, out),
         // ehr / composition — structural containers (scalar-only invariants),
         // deserialized shallowly (see `run_shallow`). GENERIC_ENTRY's `data:
         // ITEM [1..1]` is a single-valued node, so `run_shallow` keeps it and
         // still enforces its presence.
-        "COMPOSITION" => run_shallow::<Composition>(value, out),
-        "EVENT_CONTEXT" => run_shallow::<EventContext>(value, out),
-        "ACTIVITY" => run_shallow::<Activity>(value, out),
-        "INSTRUCTION_DETAILS" => run::<InstructionDetails>(value, out),
-        "OBSERVATION" => run_shallow::<Observation>(value, out),
-        "INSTRUCTION" => run_shallow::<Instruction>(value, out),
-        "ACTION" => run_shallow::<Action>(value, out),
-        "EVALUATION" => run_shallow::<Evaluation>(value, out),
-        "ADMIN_ENTRY" => run_shallow::<AdminEntry>(value, out),
-        "GENERIC_ENTRY" => run_shallow::<GenericEntry>(value, out),
-        "SECTION" => run_shallow::<Section>(value, out),
-        "FOLDER" => run_shallow::<Folder>(value, out),
-        "ITEM_TAG" => run::<ItemTag>(value, out),
+        "COMPOSITION" => run_shallow::<Composition>(ty, value, out),
+        "EVENT_CONTEXT" => run_shallow::<EventContext>(ty, value, out),
+        "ACTIVITY" => run_shallow::<Activity>(ty, value, out),
+        "INSTRUCTION_DETAILS" => run::<InstructionDetails>(ty, value, out),
+        "OBSERVATION" => run_shallow::<Observation>(ty, value, out),
+        "INSTRUCTION" => run_shallow::<Instruction>(ty, value, out),
+        "ACTION" => run_shallow::<Action>(ty, value, out),
+        "EVALUATION" => run_shallow::<Evaluation>(ty, value, out),
+        "ADMIN_ENTRY" => run_shallow::<AdminEntry>(ty, value, out),
+        "GENERIC_ENTRY" => run_shallow::<GenericEntry>(ty, value, out),
+        "SECTION" => run_shallow::<Section>(ty, value, out),
+        "FOLDER" => run_shallow::<Folder>(ty, value, out),
+        "ITEM_TAG" => run::<ItemTag>(ty, value, out),
         // base identification
-        "OBJECT_REF" => run::<ObjectRefData>(value, out),
-        "PARTY_REF" => run::<PartyRef>(value, out),
-        "VERSION_TREE_ID" => run::<VersionTreeId>(value, out),
-        "OBJECT_VERSION_ID" => run::<ObjectVersionId>(value, out),
-        "ISO_OID" => run::<IsoOid>(value, out),
-        "ARCHETYPE_ID" => run::<ArchetypeId>(value, out),
-        "TERMINOLOGY_ID" => run::<TerminologyId>(value, out),
-        "INTERNET_ID" => run::<InternetId>(value, out),
+        "OBJECT_REF" => run::<ObjectRefData>(ty, value, out),
+        "PARTY_REF" => run::<PartyRef>(ty, value, out),
+        "VERSION_TREE_ID" => run::<VersionTreeId>(ty, value, out),
+        "OBJECT_VERSION_ID" => run::<ObjectVersionId>(ty, value, out),
+        "ISO_OID" => run::<IsoOid>(ty, value, out),
+        "ARCHETYPE_ID" => run::<ArchetypeId>(ty, value, out),
+        "TERMINOLOGY_ID" => run::<TerminologyId>(ty, value, out),
+        "INTERNET_ID" => run::<InternetId>(ty, value, out),
         _ => {}
     }
 }

--- a/crates/openehr-its/tests/it/main.rs
+++ b/crates/openehr-its/tests/it/main.rs
@@ -31,6 +31,7 @@ mod rm_validation;
 mod spec_vectors;
 mod structured;
 mod tdd;
+mod untagged_nodes;
 mod validation;
 mod validation_checklist;
 mod validation_rules;

--- a/crates/openehr-its/tests/it/untagged_nodes.rs
+++ b/crates/openehr-its/tests/it/untagged_nodes.rs
@@ -1,0 +1,169 @@
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic,
+    reason = "test assertions/diagnostics/fixtures"
+)]
+//! Untagged canonical-JSON nodes run the full validation walk.
+//!
+//! Canonical JSON requires `_type` only on polymorphic slots (the ITS-JSON
+//! schema declares `COMPOSITION.context` as a bare `$ref` to the concrete
+//! `EVENT_CONTEXT`, with `_type` not among its `required` members), so a node
+//! under a concretely-declared attribute may legally omit its tag. A walk that
+//! dispatches on the wire tag alone therefore silently skips every RM
+//! invariant on such nodes — the escape the CNF red row
+//! `create_composition-setting_invalid` exposed (adjudicated to the
+//! application per `.claude/rules/cnf-triage.md`; RM ehr `EVENT_CONTEXT`
+//! §Invariants `Setting_valid`). These tests pin the fix: the effective RM
+//! type of an untagged node is its parent's declared attribute type
+//! (`openehr_its::rm_validate::declared_concrete_type`), and validation
+//! verdicts are tag-presence-independent wherever the tag is omittable.
+
+use openehr_its::flat::validation::{ValidationKind, validate_rm_and_terminology};
+use openehr_its::rm_validate::declared_concrete_type;
+use serde_json::{Value, json};
+
+use crate::common::corpus_files;
+
+/// A minimal event COMPOSITION whose `context` node carries NO `_type` tag —
+/// legal canonical JSON (`EVENT_CONTEXT` is the concretely-declared type of
+/// `COMPOSITION.context`).
+fn composition_with_untagged_context(setting_code: &str) -> Value {
+    json!({
+        "_type": "COMPOSITION",
+        "name": {"_type": "DV_TEXT", "value": "Minimal"},
+        "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+        "language": {"terminology_id": {"value": "ISO_639-1"}, "code_string": "en"},
+        "territory": {"terminology_id": {"value": "ISO_3166-1"}, "code_string": "UY"},
+        "category": {"value": "event", "defining_code": {
+            "terminology_id": {"value": "openehr"}, "code_string": "433"}},
+        "composer": {"_type": "PARTY_IDENTIFIED", "name": "Dr. House"},
+        "context": {
+            // deliberately untagged
+            "start_time": {"value": "2021-09-21T21:52:31.927-03:00"},
+            "setting": {"value": "primary medical care", "defining_code": {
+                "terminology_id": {"value": "openehr"}, "code_string": setting_code}},
+        },
+        "content": [],
+    })
+}
+
+/// The red-row regression: an out-of-group `EVENT_CONTEXT.setting` on an
+/// UNTAGGED `context` node is a terminology violation (RM ehr `EVENT_CONTEXT`
+/// §Invariants `Setting_valid`; TERM `SupportTerminology` §Vocabularies
+/// `setting`) — and the valid twin stays clean.
+#[test]
+fn untagged_context_setting_is_enforced() {
+    let bad = composition_with_untagged_context("999");
+    let violations = validate_rm_and_terminology(&bad);
+    assert!(
+        violations
+            .iter()
+            .any(|m| m.kind == ValidationKind::Terminology && m.path.contains("context/setting")),
+        "an out-of-group setting on an untagged EVENT_CONTEXT must be a \
+         terminology violation, got: {violations:?}"
+    );
+
+    let good = composition_with_untagged_context("228");
+    let violations = validate_rm_and_terminology(&good);
+    assert!(
+        !violations
+            .iter()
+            .any(|m| m.path.contains("context/setting")),
+        "the valid twin (setting 228) must raise nothing on the setting slot, \
+         got: {violations:?}"
+    );
+}
+
+/// Core (non-terminology) invariants reach untagged nodes too: an empty
+/// `EVENT_CONTEXT.location` violates `Location_valid` (RM ehr `EVENT_CONTEXT`
+/// §Invariants) whether or not the context node is tagged.
+#[test]
+fn untagged_context_runs_core_invariants() {
+    let mut comp = composition_with_untagged_context("228");
+    comp["context"]["location"] = json!("");
+    let violations = validate_rm_and_terminology(&comp);
+    assert!(
+        violations
+            .iter()
+            .any(|m| m.kind == ValidationKind::Invariant && m.path.contains("context")),
+        "an empty location on an untagged EVENT_CONTEXT must violate a core \
+         invariant, got: {violations:?}"
+    );
+}
+
+/// Strip every LEGALLY-omittable `_type` from a node tree: a tag is removed
+/// exactly where the parent attribute's declared RM type is concrete AND names
+/// the same class the tag carries (omission elsewhere would change the
+/// instance's meaning, so those tags stay).
+fn strip_omittable_tags(v: &mut Value, declared: Option<&str>) {
+    let Some(obj) = v.as_object_mut() else { return };
+    let this_type: Option<String> = obj
+        .get("_type")
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .or_else(|| declared.map(str::to_owned));
+    if let (Some(tag), Some(decl)) = (obj.get("_type").and_then(Value::as_str), declared)
+        && tag == decl
+    {
+        obj.remove("_type");
+    }
+    let Some(this_type) = this_type else { return };
+    let keys: Vec<String> = obj
+        .keys()
+        .filter(|k| !k.starts_with('_'))
+        .cloned()
+        .collect();
+    for k in keys {
+        let child_declared = declared_concrete_type(&this_type, &k);
+        match obj.get_mut(&k) {
+            Some(Value::Array(items)) => {
+                for item in items {
+                    strip_omittable_tags(item, child_declared);
+                }
+            }
+            Some(child @ Value::Object(_)) => strip_omittable_tags(child, child_declared),
+            _ => {}
+        }
+    }
+}
+
+/// **The tag-independence property over the whole valid corpus:** stripping
+/// every legally-omittable `_type` from a valid COMPOSITION changes NO
+/// validation verdict — the effective-type resolution makes the walk
+/// tag-presence-independent, so a format or client that omits optional tags
+/// gets the same conformance answer as one that writes them all.
+#[test]
+fn corpus_verdicts_are_tag_presence_independent() {
+    let mut checked = 0usize;
+    for path in corpus_files() {
+        let text = std::fs::read_to_string(&path).expect("read corpus file");
+        let Ok(doc) = serde_json::from_str::<Value>(&text) else {
+            continue;
+        };
+        if doc.get("_type").and_then(Value::as_str) != Some("COMPOSITION") {
+            continue;
+        }
+        let tagged: Vec<String> = validate_rm_and_terminology(&doc)
+            .into_iter()
+            .map(|m| format!("{}|{:?}|{}", m.path, m.kind, m.message))
+            .collect();
+        let mut stripped = doc.clone();
+        strip_omittable_tags(&mut stripped, Some("COMPOSITION"));
+        let untagged: Vec<String> = validate_rm_and_terminology(&stripped)
+            .into_iter()
+            .map(|m| format!("{}|{:?}|{}", m.path, m.kind, m.message))
+            .collect();
+        assert_eq!(
+            tagged,
+            untagged,
+            "verdicts changed after stripping omittable tags in {}",
+            path.display()
+        );
+        checked += 1;
+    }
+    assert!(
+        checked > 20,
+        "expected a real corpus, checked {checked} compositions"
+    );
+}

--- a/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
+++ b/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
@@ -172,6 +172,26 @@ cnf.composition.minimal_event.setting_invalid:
     spec_ref: "TERM SupportTerminology §Vocabularies (setting); RM ehr (EVENT_CONTEXT Setting_valid)"
   template_id: "minimal_evaluation.en.v1"
   provenance: "derived 2026-08-01 from cnf.composition.minimal_event.v1 by replacing EVENT_CONTEXT.setting.defining_code.code_string 228 with 999 (no member of the setting group — TERM SupportTerminology §Vocabularies); the TERM ch.3 §3.2 audit wire-refusal twin (#1418)"
+cnf.composition.minimal_event.participation_mode_invalid:
+  source: fixtures/composition/minimal_event.participation_mode_invalid.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "PARTICIPATION.mode defining_code 999 (terminology openehr) is no member of the participation_mode group; the PARTICIPATION node is legally untagged"
+    spec_ref: "TERM SupportTerminology §Vocabularies (participation mode); RM common (PARTICIPATION Mode_valid)"
+  template_id: "minimal_evaluation.en.v1"
+  provenance: "derived 2026-08-01 from cnf.composition.minimal_event.v1 by replacing context.participations[0].mode.defining_code.code_string 193 with 999 — an UNTAGGED node (canonical JSON omits _type on the concretely-declared EVENT_CONTEXT.participations slot), pinning the untagged-node escape class the #1431 triage attributed to the application"
+cnf.composition.minimal_event.location_empty:
+  source: fixtures/composition/minimal_event.location_empty.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "EVENT_CONTEXT.location is the empty string on a legally untagged context node"
+    spec_ref: "RM ehr (EVENT_CONTEXT location_valid: location /= Void implies not location.is_empty)"
+  template_id: "minimal_evaluation.en.v1"
+  provenance: "derived 2026-08-01 from cnf.composition.minimal_event.v1 by adding context.location = \"\" — a CORE invariant violation on an UNTAGGED node (the context object carries no _type, which canonical JSON permits for the concrete COMPOSITION.context slot), pinning the untagged-node escape class of #1431"
 cnf.composition.unknown_template:
   source: fixtures/composition/unknown_template.json
   format: canonical-json

--- a/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_event.location_empty.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_event.location_empty.json
@@ -1,0 +1,151 @@
+{
+    "_type": "COMPOSITION",
+    "name": {
+        "_type": "DV_TEXT",
+        "value": "Minimal"
+    },
+    "archetype_details": {
+        "archetype_id": {
+            "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+        },
+        "template_id": {
+            "value": "minimal_evaluation.en.v1"
+        },
+        "rm_version": "1.0.2"
+    },
+    "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+    "language": {
+        "terminology_id": {
+            "value": "ISO_639-1"
+        },
+        "code_string": "en"
+    },
+    "territory": {
+        "terminology_id": {
+            "value": "ISO_3166-1"
+        },
+        "code_string": "UY"
+    },
+    "category": {
+        "value": "event",
+        "defining_code": {
+            "terminology_id": {
+                "value": "openehr"
+            },
+            "code_string": "433"
+        }
+    },
+    "composer": {
+        "_type": "PARTY_IDENTIFIED",
+        "external_ref": {
+            "id": {
+                "_type": "HIER_OBJECT_ID",
+                "value": "fc376c46-29c1-4090-bc01-5cc046af7f26"
+            },
+            "namespace": "DEMOGRAPHIC",
+            "type": "PERSON"
+        },
+        "name": "Dr. House"
+    },
+    "context": {
+        "start_time": {
+            "value": "2021-09-21T21:52:31.927-03:00"
+        },
+        "setting": {
+            "value": "primary medical care",
+            "defining_code": {
+                "terminology_id": {
+                    "value": "openehr"
+                },
+                "code_string": "228"
+            }
+        },
+        "participations": [
+            {
+                "function": {
+                    "value": "legal guardian consent author"
+                },
+                "performer": {
+                    "_type": "PARTY_RELATED",
+                    "name": "Alexandra Alamo",
+                    "relationship": {
+                        "value": "mother",
+                        "defining_code": {
+                            "terminology_id": {
+                                "value": "openehr"
+                            },
+                            "code_string": "10"
+                        }
+                    }
+                },
+                "mode": {
+                    "value": "not specified",
+                    "defining_code": {
+                        "terminology_id": {
+                            "value": "openehr"
+                        },
+                        "code_string": "193"
+                    }
+                }
+            }
+        ],
+        "location": ""
+    },
+    "content": [
+        {
+            "_type": "EVALUATION",
+            "name": {
+                "_type": "DV_TEXT",
+                "value": "Minimal"
+            },
+            "archetype_details": {
+                "archetype_id": {
+                    "value": "openEHR-EHR-EVALUATION.minimal.v1"
+                },
+                "template_id": {
+                    "value": "minimal_evaluation.en.v1"
+                },
+                "rm_version": "1.0.2"
+            },
+            "archetype_node_id": "openEHR-EHR-EVALUATION.minimal.v1",
+            "language": {
+                "terminology_id": {
+                    "value": "ISO_639-1"
+                },
+                "code_string": "en"
+            },
+            "encoding": {
+                "terminology_id": {
+                    "value": "IANA_character-sets"
+                },
+                "code_string": "UTF-8"
+            },
+            "subject": {
+                "_type": "PARTY_SELF"
+            },
+            "data": {
+                "_type": "ITEM_TREE",
+                "name": {
+                    "_type": "DV_TEXT",
+                    "value": "Arbol"
+                },
+                "archetype_node_id": "at0001",
+                "items": [
+                    {
+                        "_type": "ELEMENT",
+                        "name": {
+                            "_type": "DV_TEXT",
+                            "value": "quantity"
+                        },
+                        "archetype_node_id": "at0002",
+                        "value": {
+                            "_type": "DV_QUANTITY",
+                            "magnitude": 78.5,
+                            "units": "kg"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_event.participation_mode_invalid.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_event.participation_mode_invalid.json
@@ -1,0 +1,150 @@
+{
+    "_type": "COMPOSITION",
+    "name": {
+        "_type": "DV_TEXT",
+        "value": "Minimal"
+    },
+    "archetype_details": {
+        "archetype_id": {
+            "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+        },
+        "template_id": {
+            "value": "minimal_evaluation.en.v1"
+        },
+        "rm_version": "1.0.2"
+    },
+    "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+    "language": {
+        "terminology_id": {
+            "value": "ISO_639-1"
+        },
+        "code_string": "en"
+    },
+    "territory": {
+        "terminology_id": {
+            "value": "ISO_3166-1"
+        },
+        "code_string": "UY"
+    },
+    "category": {
+        "value": "event",
+        "defining_code": {
+            "terminology_id": {
+                "value": "openehr"
+            },
+            "code_string": "433"
+        }
+    },
+    "composer": {
+        "_type": "PARTY_IDENTIFIED",
+        "external_ref": {
+            "id": {
+                "_type": "HIER_OBJECT_ID",
+                "value": "fc376c46-29c1-4090-bc01-5cc046af7f26"
+            },
+            "namespace": "DEMOGRAPHIC",
+            "type": "PERSON"
+        },
+        "name": "Dr. House"
+    },
+    "context": {
+        "start_time": {
+            "value": "2021-09-21T21:52:31.927-03:00"
+        },
+        "setting": {
+            "value": "primary medical care",
+            "defining_code": {
+                "terminology_id": {
+                    "value": "openehr"
+                },
+                "code_string": "228"
+            }
+        },
+        "participations": [
+            {
+                "function": {
+                    "value": "legal guardian consent author"
+                },
+                "performer": {
+                    "_type": "PARTY_RELATED",
+                    "name": "Alexandra Alamo",
+                    "relationship": {
+                        "value": "mother",
+                        "defining_code": {
+                            "terminology_id": {
+                                "value": "openehr"
+                            },
+                            "code_string": "10"
+                        }
+                    }
+                },
+                "mode": {
+                    "value": "not specified",
+                    "defining_code": {
+                        "terminology_id": {
+                            "value": "openehr"
+                        },
+                        "code_string": "999"
+                    }
+                }
+            }
+        ]
+    },
+    "content": [
+        {
+            "_type": "EVALUATION",
+            "name": {
+                "_type": "DV_TEXT",
+                "value": "Minimal"
+            },
+            "archetype_details": {
+                "archetype_id": {
+                    "value": "openEHR-EHR-EVALUATION.minimal.v1"
+                },
+                "template_id": {
+                    "value": "minimal_evaluation.en.v1"
+                },
+                "rm_version": "1.0.2"
+            },
+            "archetype_node_id": "openEHR-EHR-EVALUATION.minimal.v1",
+            "language": {
+                "terminology_id": {
+                    "value": "ISO_639-1"
+                },
+                "code_string": "en"
+            },
+            "encoding": {
+                "terminology_id": {
+                    "value": "IANA_character-sets"
+                },
+                "code_string": "UTF-8"
+            },
+            "subject": {
+                "_type": "PARTY_SELF"
+            },
+            "data": {
+                "_type": "ITEM_TREE",
+                "name": {
+                    "_type": "DV_TEXT",
+                    "value": "Arbol"
+                },
+                "archetype_node_id": "at0001",
+                "items": [
+                    {
+                        "_type": "ELEMENT",
+                        "name": {
+                            "_type": "DV_TEXT",
+                            "value": "quantity"
+                        },
+                        "archetype_node_id": "at0002",
+                        "value": {
+                            "_type": "DV_QUANTITY",
+                            "magnitude": 78.5,
+                            "units": "kg"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-context_location_empty.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-context_location_empty.yaml
@@ -1,0 +1,41 @@
+# An empty EVENT_CONTEXT.location on an UNTAGGED context node is a 422: RM
+# ehr EVENT_CONTEXT invariant location_valid ("location /= Void implies not
+# location.is_empty") is a CORE class invariant, and the context node's
+# missing `_type` is legal canonical JSON (`COMPOSITION.context` declares the
+# concrete EVENT_CONTEXT). This is the core-invariant twin of the
+# untagged-node escape class (#1431 triage) beside the terminology twin
+# `-participation_mode_invalid`: together they pin that BOTH invariant
+# families reach legally untagged nodes.
+#
+# Derived from the RM invariant + the ITS-REST status table
+# (Requests_and_responses.md: 422 "well-formed but was unable to be followed
+# due to semantic errors"), not from any SUT.
+id: I_EHR_COMPOSITION.create_composition-context_location_empty
+kind: functional
+component: EHR_COMPOSITION
+sm_operation: I_EHR_COMPOSITION.create_composition
+capabilities: [CompositionOps]
+profiles: [CORE]
+test_purpose: >-
+  A COMPOSITION whose (legally untagged) EVENT_CONTEXT carries an empty
+  location string is rejected 422 (location_valid), and nothing is committed.
+description: "Reject an empty EVENT_CONTEXT.location on an untagged node (422)"
+spec_refs:
+  - "RM ehr §EVENT_CONTEXT (location_valid)"
+  - "ITS-REST overview Requests_and_responses §HTTP status codes (422)"
+  - "SM openehr_platform §I_EHR_COMPOSITION.create_composition"
+applies: { rm: ">=1.0.2" }
+requires:
+  server: any
+  templates: [cnf.opt.minimal_event]
+  ehr: { commits: none }                 # mints ${ehr_id}
+data_sets: [cnf.composition.minimal_event.location_empty]
+flow:
+  - step: 1
+    call: create_composition
+    with: { ehr_id: "${ehr_id}", composition: "${ds:cnf.composition.minimal_event.location_empty}" }
+    expect: validation_failed
+    assert:
+      - { assert: message_exemplar, text: "information about the errors in the provided COMPOSITION" }
+postconditions:
+  - { assert: version, count: 0 }        # nothing committed

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-participation_mode_invalid.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-participation_mode_invalid.yaml
@@ -1,0 +1,46 @@
+# An out-of-group participation mode on an UNTAGGED node is a 422:
+# PARTICIPATION.mode's defining_code (terminology `openehr`) must be a member
+# of the `participation_mode` vocabulary (TERM SupportTerminology
+# §Vocabularies; RM common PARTICIPATION Mode_valid). The PARTICIPATION node
+# carries no `_type` — legal canonical JSON, since `EVENT_CONTEXT.
+# participations` declares the concrete type — so this row also pins the
+# untagged-node escape class (#1431 triage: a `_type`-driven validation walk
+# skipped every invariant on legally untagged nodes; same content refused
+# over XML but committed over JSON).
+#
+# Derived from the TERM vocabulary tables + the RM invariant + the ITS-REST
+# status table (Requests_and_responses.md: 422 "well-formed but was unable to
+# be followed due to semantic errors"), not from any SUT. The valid twin is
+# every accepted minimal_event.v1 commit (mode 193|not specified|, equally
+# untagged).
+id: I_EHR_COMPOSITION.create_composition-participation_mode_invalid
+kind: functional
+component: EHR_COMPOSITION
+sm_operation: I_EHR_COMPOSITION.create_composition
+capabilities: [CompositionOps]
+profiles: [CORE]
+test_purpose: >-
+  A COMPOSITION whose (legally untagged) PARTICIPATION.mode defining_code is
+  no member of the openEHR participation_mode vocabulary is rejected 422, and
+  nothing is committed.
+description: "Reject an out-of-group PARTICIPATION.mode on an untagged node (422)"
+spec_refs:
+  - "TERM SupportTerminology §Vocabularies (participation mode)"
+  - "RM common §generic (PARTICIPATION Mode_valid)"
+  - "ITS-REST overview Requests_and_responses §HTTP status codes (422)"
+  - "SM openehr_platform §I_EHR_COMPOSITION.create_composition"
+applies: { rm: ">=1.0.2" }
+requires:
+  server: any
+  templates: [cnf.opt.minimal_event]
+  ehr: { commits: none }                 # mints ${ehr_id}
+data_sets: [cnf.composition.minimal_event.participation_mode_invalid]
+flow:
+  - step: 1
+    call: create_composition
+    with: { ehr_id: "${ehr_id}", composition: "${ds:cnf.composition.minimal_event.participation_mode_invalid}" }
+    expect: validation_failed
+    assert:
+      - { assert: message_exemplar, text: "information about the errors in the provided COMPOSITION" }
+postconditions:
+  - { assert: version, count: 0 }        # nothing committed


### PR DESCRIPTION
CNF red-row fix (triage-attributed application defect; program #814 close run). TERM ch.3's new `setting_invalid` case exposed an escape CLASS: the validation walk dispatched on the wire `_type` tag, and canonical JSON legitimately omits the tag on concretely-declared slots — so untagged nodes (e.g. `COMPOSITION.context`) skipped EVERY RM invariant, and the same semantic content was refused over canonical XML but committed over canonical JSON.

**Fix (mechanism, per the triage):** effective-type resolution — the wire tag when present, else the parent's declared attribute type when concrete, from the BMM-generated static RM model (`openehr_rm::model`) — threaded through all three dispatch sites (`rm_invariant_pass`, `terminology_pass`, `validate_rm_invariants_as`). No emitter change needed; no consumer workaround; the slot table was already right, just unreachable.

**Hardening (the systemic piece):** beside the red-row regression and a core-invariant twin, a corpus-wide **tag-independence property** now pins the class: stripping every legally-omittable `_type` from every valid corpus COMPOSITION changes no validation verdict. CNF gains two escape-class refusal cases (untagged `PARTICIPATION.mode` out-of-group → `Mode_valid`; untagged empty `EVENT_CONTEXT.location` → `location_valid`, both invariants quoted first-hand from the RM UML class texts). Also: the mislabeled `TODO(perf)` in `rm_validate.rs` relabeled to a NOTE (settled design; owner rule — TODO sweep tracked in #1432).

Gates: workspace clippy `-D warnings` clean, openehr-its 518/518 + the 3 new untagged tests, ferroehr+ferroehr-rest 1352/1352, `cnf-runner validate` 871 cases / 0 findings, changelog entry added. Full pipeline rerun follows this merge for the #814 zero-drift close.

Closes #1431