### PR TITLE
release: v3.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+## [3.17.0] - 2026-08-01
+
 ### Changed
 
 - **The documentation website moved to its own domain,
@@ -4018,7 +4020,8 @@ but has not yet run in production.
   seccomp, default-deny NetworkPolicy) and golden-render validation.
 
 
-[unreleased]: https://github.com/rubentalstra/FerroEHR/compare/v3.16.0...HEAD
+[unreleased]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.0...HEAD
+[3.17.0]: https://github.com/rubentalstra/FerroEHR/compare/v3.16.0...v3.17.0
 [3.16.0]: https://github.com/rubentalstra/FerroEHR/compare/v3.15.3...v3.16.0
 [3.15.3]: https://github.com/rubentalstra/FerroEHR/compare/v3.15.2...v3.15.3
 [3.15.2]: https://github.com/rubentalstra/FerroEHR/compare/v3.15.1...v3.15.2

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,5 +33,5 @@ keywords:
   - ITS-REST
   - Rust
   - PostgreSQL
-version: 3.16.0
-date-released: "2026-08-01"
+version: 3.17.0
+date-released: 2026-08-01

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "cnf-runner"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "assert_fs",
  "base64 0.22.1",
@@ -2509,7 +2509,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferroehr"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "assert_fs",
  "async-trait",
@@ -2576,7 +2576,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-admin-ui"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2616,7 +2616,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-rest"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -2668,7 +2668,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-server"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -5223,7 +5223,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-codegen"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "roxmltree",
  "serde_json",
@@ -8277,7 +8277,7 @@ dependencies = [
 
 [[package]]
 name = "testkit"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "ferroehr",
  "jiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "3"
 members = ["crates/*", "app/*", "tools/*"]
 
 [workspace.package]
-version = "3.16.0"
+version = "3.17.0"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT"

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 # Chart versioning is independent of the application version.
 version: 3.2.0
 # The default container image tag (informational; overridable via image.tag).
-appVersion: "3.16.0"
+appVersion: "3.17.0"
 
 # PDB (policy/v1, GA 1.21), HPA (autoscaling/v2, GA 1.23), and the
 # seccompProfile pod field (GA 1.27) all resolve cleanly at 1.25+.

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.16.0"
+    app.kubernetes.io/version: "3.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -58,7 +58,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.16.0"
+    app.kubernetes.io/version: "3.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -77,7 +77,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.16.0"
+    app.kubernetes.io/version: "3.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -96,7 +96,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.16.0"
+    app.kubernetes.io/version: "3.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -120,7 +120,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.16.0"
+    app.kubernetes.io/version: "3.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -139,7 +139,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.16.0"
+    app.kubernetes.io/version: "3.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -294,7 +294,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.16.0"
+    app.kubernetes.io/version: "3.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -321,7 +321,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.16.0"
+    app.kubernetes.io/version: "3.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -333,7 +333,7 @@ spec:
     metadata:
       annotations:
         # Roll pods when the rendered ferroehr.toml changes.
-        checksum/config: 928cf8821fb7828b02bed2b8ce6c2dc242f127f4cbe7dc1dd7ebb85c56c25c57
+        checksum/config: ccfe01889289f18b7d34d1bf6a69257d296eac925e0d133497a6be70dbd7a075
         prometheus.io/scrape: "true"
         prometheus.io/port: "9100"
         prometheus.io/path: "/management/prometheus"
@@ -354,7 +354,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:3.16.0"
+          image: "ghcr.io/rubentalstra/ferroehr:3.17.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -476,7 +476,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.16.0"
+    app.kubernetes.io/version: "3.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -509,7 +509,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.16.0"
+    app.kubernetes.io/version: "3.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.16.0"
+    app.kubernetes.io/version: "3.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -36,7 +36,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.16.0"
+    app.kubernetes.io/version: "3.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -55,7 +55,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.16.0"
+    app.kubernetes.io/version: "3.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 automountServiceAccountToken: false
@@ -69,7 +69,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.16.0"
+    app.kubernetes.io/version: "3.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -166,7 +166,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.16.0"
+    app.kubernetes.io/version: "3.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -189,7 +189,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.16.0"
+    app.kubernetes.io/version: "3.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -202,7 +202,7 @@ spec:
     metadata:
       annotations:
         # Roll pods when the rendered ferroehr.toml changes.
-        checksum/config: de613573c9decf1631cae5ac1f2a2abf145a0d09f39cb502627e09efb96932cf
+        checksum/config: 708194a006e3703847f5db9dba75d9f63ec5aba0b03431a6c2c9c8bf65e76d23
       labels:
         app.kubernetes.io/name: ferroehr
         app.kubernetes.io/instance: ferroehr
@@ -220,7 +220,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:3.16.0"
+          image: "ghcr.io/rubentalstra/ferroehr:3.17.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
Cut of **v3.17.0 — the TERM 3.1.0 compliance program** (milestone at zero open issues; program record on #814).

- `CHANGELOG.md`: `[Unreleased]` → `## [3.17.0] - 2026-08-01` (+ fresh empty Unreleased, link refs)
- Workspace `version` 3.16.0 → 3.17.0 (+ `Cargo.lock` via cargo check)
- Helm `appVersion` + goldens (`deploy/helm/validate.sh --update` — ALL CHECKS PASSED)
- `CITATION.cff` version + date-released

Release record: 870 CNF case-records, 833 passed / 0 failed / 0 errored / 37 n-a (committed baseline artifacts); all workflows incl. Docs green on the develop head. Tag `v3.17.0` goes on the merge commit; the release workflow publishes from the changelog section.