### PR TITLE
fix(openehr-its): repair the module-doc link broken by the effective-type rename

### DIFF
--- a/crates/openehr-its/src/flat/validation/mod.rs
+++ b/crates/openehr-its/src/flat/validation/mod.rs
@@ -15,8 +15,9 @@
 //! Validation runs three independent collecting passes over the instance:
 //!
 //! 1. **RM-invariant pass** — recurse the whole instance; for every node with a
-//!    `_type`, run its core RM class invariants ([`validate_rm_invariants`]).
-//!    This is
+//!    `_type` — or whose parent attribute declares a concrete RM type
+//!    ([`crate::rm_validate::declared_concrete_type`]) — run its core RM class
+//!    invariants ([`crate::rm_validate::validate_rm_invariants_as`]). This is
 //!    independent of the (compacted) `WebTemplate`, so class invariants on nodes
 //!    the `WebTemplate` folds away (ELEMENT / `ITEM_TREE` / HISTORY / EVENT) are
 //!    still checked. Paths are RM *instance* paths (`/content[0]/…`).


### PR DESCRIPTION
The develop rustdoc lane fails on a broken intra-doc link left by #1433's dispatcher split: `flat/validation/mod.rs:18` linked `[validate_rm_invariants]`, unresolvable in that scope. The pass description now covers the effective-type dispatch and links `crate::rm_validate::validate_rm_invariants_as` + `declared_concrete_type`. Full-workspace rustdoc lane green locally.

Closes #1441