### PR TITLE
chore: every code TODO references its tracker issue

### DIFF
--- a/app/ferroehr-admin-ui/src/app.rs
+++ b/app/ferroehr-admin-ui/src/app.rs
@@ -18,7 +18,7 @@ pub fn shell(options: LeptosOptions) -> impl IntoView {
         // The console ships one locale, and its copy is written in English, so
         // `en` is the honest declaration rather than a placeholder — an
         // assistive technology must be told which language it is reading.
-        // TODO: drive lang from the active locale when a second locale lands (#300).
+        // TODO(#300): drive lang from the active locale when a second locale lands.
         <html lang="en">
             <head>
                 <meta charset="utf-8" />

--- a/app/ferroehr/src/aql/sql/predicate.rs
+++ b/app/ferroehr/src/aql/sql/predicate.rs
@@ -87,7 +87,7 @@ impl Builder<'_> {
             IrExpr::Exists(target) => Ok(self
                 .value_expr(target, ValueMode::Projection)?
                 .is_not_null()),
-            // TODO: unify `LIKE`/`matches` on anchored multi-valued paths
+            // TODO(#1448): unify `LIKE`/`matches` on anchored multi-valued paths
             // with the existential lowering above (`exists_compare`) — they
             // still take the scalar LIMIT-1 extraction, whose matched-node
             // choice is order-undefined when a path matches several nodes.

--- a/app/ferroehr/src/service/definition/adl2.rs
+++ b/app/ferroehr/src/service/definition/adl2.rs
@@ -269,7 +269,7 @@ impl FerroEhrService {
     /// was engine-validated at its own upload) is skipped rather than failing
     /// the whole build.
     ///
-    /// TODO(perf): cache the parsed archetypes (moka) if the ADL2 registry ever
+    /// TODO(#1446, perf): cache the parsed archetypes (moka) if the ADL2 registry ever
     /// grows large enough that re-parsing it per upload/projection matters; the
     /// registry is an admin surface today, so parse-on-demand is cheap.
     async fn adl2_repository(&self) -> Result<ArchetypeRepository, ServiceError> {

--- a/app/ferroehr/src/service/ehr/composition.rs
+++ b/app/ferroehr/src/service/ehr/composition.rs
@@ -425,7 +425,7 @@ impl FerroEhrService {
     /// (`N` or `N.B.V`); `None` = the current version. The ABAC template
     /// attribute for the access pre-checks / any per-version resolver.
     ///
-    /// TODO(perf): goes through the full version read-back for spec fidelity;
+    /// TODO(#1449, perf): goes through the full version read-back for spec fidelity;
     /// a direct `SELECT template_id FROM vo_version` is a cheaper equivalent
     /// if this ever shows on a hot path.
     ///

--- a/app/ferroehr/src/service/ehr/directory.rs
+++ b/app/ferroehr/src/service/ehr/directory.rs
@@ -15,8 +15,7 @@
 //! CONTRIBUTION — ITS-REST/SM bind only the directory (RM ehr master04
 //! §Folders).
 //
-// TODO: dedicated multi-hierarchy directory write management — tracked as
-// issue #1348.
+// TODO(#1348): dedicated multi-hierarchy directory write management.
 
 use crate::ids::{EhrId, VoId};
 use crate::service::response::ResourceMeta;

--- a/app/ferroehr/src/service/ehr/validation.rs
+++ b/app/ferroehr/src/service/ehr/validation.rs
@@ -47,7 +47,7 @@ impl FerroEhrService {
         let Some(template_id) = composition_template_id(composition) else {
             return Ok(());
         };
-        // TODO(perf): scans the EHR's live COMPOSITIONs and reassembles each to
+        // TODO(#1445, perf): scans the EHR's live COMPOSITIONs and reassembles each to
         // read its category + template (template_id is not promoted onto
         // vo_version). An EHR holds few persistent compositions.
         let vo_ids = crate::storage::version_repo::meta::current_vo_ids(

--- a/app/ferroehr/src/versioning/change.rs
+++ b/app/ferroehr/src/versioning/change.rs
@@ -459,7 +459,7 @@ fn stamp_version_uid(canonical: &mut Value, version_uid: &str) {
     reason = "the three change arms build one resolved write; splitting them \
               would hide that they are alternatives on the same transaction"
 )]
-// TODO: group the commit-scope parameters into one struct — the parameter list
+// TODO(#1447): group the commit-scope parameters into one struct — the parameter list
 // is the whole commit scope threaded through a single private helper.
 #[expect(
     clippy::too_many_arguments,

--- a/crates/openehr-its/src/xml/runtime.rs
+++ b/crates/openehr-its/src/xml/runtime.rs
@@ -252,7 +252,7 @@ impl ToXml for f64 {
     fn write_xml(&self, w: &mut XmlWriter, tag: &str, _d: Option<&str>) -> Result<(), XmlError> {
         // openEHR emits a decimal point on whole reals (`120.0`, not `120`);
         // Rust's default `f64` Display drops it.
-        // TODO(perf): revisit against the fidelity corpus for exact number parity.
+        // TODO(#1453, perf): revisit against the fidelity corpus for exact number parity.
         let s = if self.fract() == 0.0 && self.is_finite() {
             format!("{self:.1}")
         } else {

--- a/crates/openehr-lang/tests/it/vendor_bmm_odin.rs
+++ b/crates/openehr-lang/tests/it/vendor_bmm_odin.rs
@@ -14,11 +14,11 @@
 //!   (duplicate class, missing ancestor, unresolved include, …). Those defects
 //!   are **above the ODIN layer**: the ODIN parse succeeds; only the P_BMM
 //!   semantic validator rejects them. This crate has no P_BMM semantic
-//!   validation layer yet, so those semantic assertions are marked `// TODO:`.
+//!   validation layer yet, so those semantic assertions are marked `// TODO(#1444):`.
 //!
 //! Accordingly every fixture here must parse as ODIN and yield a schema object;
 //! the semantic distinction (valid vs semantically-malformed BMM) is recorded
-//! in the per-fixture comments and left as a `// TODO:` for the future P_BMM
+//! in the per-fixture comments and left as a `// TODO(#1444):` for the future P_BMM
 //! validator.
 
 #![allow(
@@ -120,7 +120,7 @@ const BMM_FIXTURES: &[&str] = &[
 /// Every BMM fixture parses as an ODIN schema object carrying at least the
 /// `rm_publisher` + `schema_name` string headers of the BMM persistence format.
 /// (Semantically-malformed fixtures still parse at the ODIN layer — see the
-/// module docs; the BMM-semantic verdict is a `// TODO:`.)
+/// module docs; the BMM-semantic verdict is a `// TODO(#1444):`.)
 #[test]
 fn every_bmm_file_parses_as_odin_schema() {
     for rel in BMM_FIXTURES {
@@ -195,7 +195,7 @@ fn duplicate_class_parses_at_odin_layer() {
     let v = parse_ok("bmm/org/openehr/bmm/v2/persistence/validation/duplicate_class.bmm");
     assert_eq!(as_str(field(&v, "schema_name")), "duplicate_class");
     assert!(!keyed(field(&v, "packages")).is_empty());
-    // TODO: assert the EC_DUPLICATE_CLASS_IN_PACKAGES BMM-semantic error once a
+    // TODO(#1444): assert the EC_DUPLICATE_CLASS_IN_PACKAGES BMM-semantic error once a
     // P_BMM semantic validation layer exists in openehr-lang.
 }
 
@@ -206,7 +206,7 @@ fn include_not_found_parses_at_odin_layer() {
     // schema absent from the repository) — a BMM-semantic defect above ODIN.
     let v = parse_ok("bmm/org/openehr/bmm/v2/persistence/validation/include_not_found.bmm");
     assert!(!keyed(field(&v, "includes")).is_empty());
-    // TODO: assert the EC_INCLUDE_NOT_FOUND BMM-semantic error once a P_BMM
+    // TODO(#1444): assert the EC_INCLUDE_NOT_FOUND BMM-semantic error once a P_BMM
     // semantic validation layer exists in openehr-lang.
 }
 

--- a/tools/cnf-runner/src/perf_run/pack.rs
+++ b/tools/cnf-runner/src/perf_run/pack.rs
@@ -8,7 +8,7 @@
 //! bytes; stamping mutates only the event-context times and the composer
 //! name, deterministically from the arrival's planned instant — variation
 //! never introduces a validation error a conformant server would reject.
-// TODO: port the benchmark lab's constraint-aware FLAT-leaf value jitter
+// TODO(#1451): port the benchmark lab's constraint-aware FLAT-leaf value jitter
 // (the retired benchmark lab's renderer, in git history) as a richer stamping mode once the
 // benchmark crate migrates into the runner; time/composer stamping is the
 // committed baseline until then.

--- a/tools/cnf-runner/src/vocab.rs
+++ b/tools/cnf-runner/src/vocab.rs
@@ -140,10 +140,12 @@ outcome_kinds! {
 /// Which optional case-core blocks are meaningful.
 ///
 /// The schedule defines three kinds (`functional | content | performance`);
-/// the performance case-core schema is a separate artifact revision (this
-/// crate's W7 scope), so the assertion-machinery model closes over the two
-/// kinds it validates. // TODO: add `performance` with the §8.14 workload
-/// blocks when the performance schedule lands (W7, #202).
+/// the performance case-core schema is a separate artifact revision with its
+/// own model (`perf.rs` — the shipped measured-performance schedule), so the
+/// assertion-machinery model deliberately closes over the two kinds it
+/// validates. NOTE: no openEHR spec governs the runner's internal schema
+/// split — our own design; the once-planned `performance` variant here was
+/// superseded by the separate perf case-core model.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum CaseKind {

--- a/tools/openehr-codegen/src/analyze/mod.rs
+++ b/tools/openehr-codegen/src/analyze/mod.rs
@@ -279,7 +279,7 @@ impl Model {
     }
 
     // ── type rendering ──────────────────────────────────────────────────────
-    // TODO: `render_type` (and the type-resolution cluster it anchors —
+    // TODO(#1452): `render_type` (and the type-resolution cluster it anchors —
     // `effective_roots`, `referenced_specs`, `generic_param_bounds`,
     // `scope_content_types`) produces a Rust type *string*, which is a stage-4
     // RENDER concern; it is kept here in ANALYZE because it is fused with

--- a/tools/openehr-codegen/src/render/emit.rs
+++ b/tools/openehr-codegen/src/render/emit.rs
@@ -842,7 +842,7 @@ fn field_type(
             // convention is settled (root `CLAUDE.md` §Conventions), and it is
             // lossless everywhere the Void state carries no meaning.
             //
-            // TODO: `EL_AGENT.open_args` is the one known site where it IS
+            // TODO(#1450): `EL_AGENT.open_args` is the one known site where it IS
             // lossy — the attribute is `0..1` and its Void state is normatively
             // load-bearing twice: "If not provided, and the `_name_` refers to
             // a routine with more arguments than supplied in `_closed_args_`,


### PR DESCRIPTION
The #1432 sweep (owner rule 2026-08-01). All 13 hand-written `// TODO` markers now reference tracker issues:

| Marker | Issue |
|---|---|
| openehr-lang P_BMM semantic assertions (×2 + module prose) | #1444 |
| openehr-its XML real-formatter number parity | #1453 |
| ferroehr duplicate-persistent scan | #1445 |
| ADL2 registry parse cache | #1446 |
| versioning commit-scope param struct | #1447 |
| AQL LIKE/matches multi-valued lowering | #1448 (P2 — real semantic indeterminism) |
| composition template_id read-back | #1449 |
| codegen EL_AGENT.open_args Void loss | #1450 |
| cnf-runner FLAT-leaf value jitter | #1451 |
| codegen render_type stage relocation | #1452 |
| directory multi-hierarchy (had a prose ref) | #1348 reformatted |
| admin-ui locale lang (had a prose ref) | #300 reformatted |

One stale marker adjudicated: `cnf-runner/vocab.rs`'s planned `performance` CaseKind variant was superseded by the shipped separate perf case-core model — rewritten as a settled-design NOTE (also scrubbing its banned W-nn phase-marker style). The one remaining bare TODO is upstream BMM doc prose inside a `// @generated` file (emitter-owned, hand-edit forbidden) — recorded here as the honest exemption; the sweep grep is `grep -rn "// TODO" --include="*.rs" crates/ app/ tools/ | grep -v "TODO(#"` filtered of generated files and prose mentions.

Also: the `spec:ITS-JSON` / `spec:ITS-XML` / `spec:ITS-REST` / `spec:ITS-BMM` labels now exist beside `spec:ITS` (owner request); #1453 carries `spec:ITS-XML`.

Gates: fmt, scoped clippy `-D warnings` on all six touched crates (incl. admin-ui ssr lane), openehr-lang bmm battery 114/114.

Closes #1432