### PR TITLE
fix(openehr-its): enforce mandatory 1..* container lower bounds from the RM model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **Mandatory `1..*` container attributes are enforced.** The canonical-JSON
+  reader deliberately treats an absent list and an empty list as the same
+  value (wire tolerance), so a committed `CLUSTER` with no `items`, a
+  demographic `PERSON` with no `identities`, or a `REVISION_HISTORY` with no
+  `items` was accepted although the RM declares those containers `1..*`. The
+  validation walk now checks every model-declared mandatory container —
+  absent, or empty where the lower bound is 1 — uniformly from the generated
+  RM model, and such commits are refused 422.
 - **Structurally defective RM nodes are now refused for EVERY openEHR class,
   not only the ones carrying a class invariant.** The per-node validation step
   deserialized a wire node into its concrete RM type — the check that surfaces

--- a/crates/openehr-its/src/flat/validation/mod.rs
+++ b/crates/openehr-its/src/flat/validation/mod.rs
@@ -62,7 +62,9 @@ mod leaf;
 mod subtype;
 mod terminology;
 
-use crate::rm_validate::{declared_concrete_type, validate_rm_invariants_as};
+use crate::rm_validate::{
+    check_mandatory_containers, declared_concrete_type, validate_rm_invariants_as,
+};
 use indexmap::IndexMap;
 use openehr_rm::paths::PathSegment;
 use serde_json::{Map, Value};
@@ -668,6 +670,10 @@ impl Validator {
             // core-only entry here avoids double-reporting them.
             let mut inv = Vec::new();
             validate_rm_invariants_as(effective, v, &mut inv);
+            // The orthogonal model-driven layer: mandatory-container lower
+            // bounds (kept outside the core pair so the fast-vs-typed
+            // equivalence property stays exact).
+            check_mandatory_containers(effective, v, &mut inv);
             for iv in inv {
                 let p = if iv.path.is_empty() {
                     norm_path(path)

--- a/crates/openehr-its/src/rm_validate.rs
+++ b/crates/openehr-its/src/rm_validate.rs
@@ -155,10 +155,55 @@ pub fn validate_rm_invariants(value: &Value, out: &mut Vec<InvariantViolation>) 
 /// type is abstract; see [`declared_concrete_type`]). The `_type`-reading
 /// wrapper stays for callers with no declaration context.
 pub fn validate_rm_invariants_as(ty: &str, value: &Value, out: &mut Vec<InvariantViolation>) {
-    if openehr_rm::validate::try_fast_validate(ty, value, out) {
-        return;
+    if !openehr_rm::validate::try_fast_validate(ty, value, out) {
+        validate_rm_value_typed(ty, value, out);
     }
-    validate_rm_value_typed(ty, value, out);
+}
+
+/// The model-driven mandatory-container lower-bound check: every attribute the
+/// static RM model declares as a MANDATORY container must be present, and one
+/// whose BMM cardinality has a lower bound ≥ 1 must be non-empty — e.g.
+/// `CLUSTER.items: List<ITEM>` is `1..*`
+/// (`docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.data_structures.cluster.adoc`
+/// §Attributes), so a CLUSTER with an absent or empty `items` does not conform.
+///
+/// This is a distinct mechanism from the codec decode: the canonical-JSON
+/// reader deliberately treats an absent array as an empty `Vec` (wire
+/// tolerance), so the omission is invisible to [`structural_check`]-style
+/// typed decoding — the lower bound is enforced HERE, from the model, for
+/// every class uniformly. The optional-attribute family
+/// (`x /= Void implies not x.is_empty`, e.g. `COMPOSITION.content`) stays with
+/// the invariant checks — this function only judges MANDATORY containers, so
+/// the two never double-report. `List<Octet>` is exempt by shape: canonical
+/// JSON renders it as an inline base64 string, which presence-checks as a
+/// non-array member.
+pub fn check_mandatory_containers(ty: &str, value: &Value, out: &mut Vec<InvariantViolation>) {
+    for attr in openehr_rm::model::attributes(ty) {
+        if !attr.is_mandatory
+            || matches!(attr.container, openehr_rm::model::Container::None)
+            || attr.declared_type == "Octet"
+        {
+            continue;
+        }
+        match value.get(attr.name) {
+            None | Some(Value::Null) => {
+                out.push(InvariantViolation::here(format!(
+                    "does not conform to RM type {ty}: mandatory container `{}` is absent",
+                    attr.name
+                )));
+            }
+            Some(Value::Array(a))
+                if a.is_empty() && attr.cardinality.is_some_and(|c| c.lower >= 1) =>
+            {
+                out.push(InvariantViolation::here(format!(
+                    "does not conform to RM type {ty}: mandatory container `{}` is empty \
+                     (cardinality lower bound 1)",
+                    attr.name
+                )));
+            }
+            _ => {}
+        }
+    }
 }
 
 /// The declared RM type of `field` on `parent_type` when that type is
@@ -191,13 +236,12 @@ pub fn validate_rm_value(value: &Value, out: &mut Vec<InvariantViolation>) {
     let Some(ty) = value.get("_type").and_then(Value::as_str) else {
         return;
     };
-    if openehr_rm::validate::try_fast_validate(ty, value, out) {
-        // The fast path handled the core invariants; still run the orthogonal
-        // terminology layer (it dispatches on the same `_type`).
-        crate::rm_terminology::validate_rm_terminology(ty, value, out);
-        return;
-    }
-    validate_rm_value_typed(ty, value, out);
+    // The core path (fast/typed), then the two orthogonal layers — the
+    // model-driven mandatory-container lower bounds and the terminology-backed
+    // invariants (each dispatches on the same `_type`). The core tiers stay a
+    // pure pair so the fast-vs-typed equivalence property holds exactly.
+    validate_rm_invariants_as(ty, value, out);
+    check_mandatory_containers(ty, value, out);
     crate::rm_terminology::validate_rm_terminology(ty, value, out);
 }
 

--- a/crates/openehr-its/tests/it/format_parity.rs
+++ b/crates/openehr-its/tests/it/format_parity.rs
@@ -117,10 +117,11 @@ fn invalid_fixture_verdicts_agree_across_canonical_formats() {
     for entry in std::fs::read_dir(&dir).expect("catalogue fixture dir") {
         let path = entry.expect("dir entry").path();
         if path.extension().and_then(|e| e.to_str()) != Some("json")
-            || !path
-                .file_name()
-                .and_then(|n| n.to_str())
-                .is_some_and(|n| n.contains("invalid") || n.contains("location_empty"))
+            || !path.file_name().and_then(|n| n.to_str()).is_some_and(|n| {
+                n.contains("invalid")
+                    || n.contains("location_empty")
+                    || n.contains("cluster_no_items")
+            })
         {
             continue;
         }

--- a/crates/openehr-its/tests/it/model_walkgen.rs
+++ b/crates/openehr-its/tests/it/model_walkgen.rs
@@ -305,3 +305,61 @@ fn dropped_mandatory_attributes_are_refused() {
         "mandatory-drop reach register drifted (the register file states each entry's adjudicated reason)"
     );
 }
+
+/// The model-driven mandatory-container lower bound (#1461): a CLUSTER whose
+/// RM-mandatory 1..* `items` is absent or empty is refused; a populated one is
+/// clean of that violation (RM `data_structures`
+/// `org.openehr.rm.data_structures.cluster.adoc` §Attributes).
+#[test]
+fn mandatory_container_lower_bound_is_enforced() {
+    use openehr_its::rm_validate::validate_rm_value;
+    let mk = |items: Option<Value>| {
+        let mut c = json!({
+            "_type": "CLUSTER",
+            "name": {"_type": "DV_TEXT", "value": "specimen"},
+            "archetype_node_id": "at0001",
+        });
+        if let Some(i) = items {
+            c["items"] = i;
+        }
+        c
+    };
+    let judge = |v: &Value| {
+        let mut out = Vec::new();
+        validate_rm_value(v, &mut out);
+        out.iter()
+            .any(|iv| iv.message.contains("mandatory container `items`"))
+    };
+    assert!(judge(&mk(None)), "absent items must be refused");
+    assert!(judge(&mk(Some(json!([])))), "empty items must be refused");
+    let element = json!([{
+        "_type": "ELEMENT",
+        "name": {"_type": "DV_TEXT", "value": "x"},
+        "archetype_node_id": "at0002",
+    }]);
+    assert!(
+        !judge(&mk(Some(element))),
+        "populated items must not raise the container violation"
+    );
+}
+
+/// The wire-reachable representative fixture of the family: the CKM
+/// lab-result example with the specimen CLUSTER's items deleted (the CNF
+/// `create_composition-cluster_no_items` case's payload) is refused by the
+/// full walk.
+#[test]
+fn cluster_no_items_fixture_is_refused() {
+    let text = std::fs::read_to_string(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../tools/cnf-runner/artifacts/corpus/fixtures/composition/lab_result.cluster_no_items.json"),
+    )
+    .expect("fixture exists");
+    let doc: Value = serde_json::from_str(&text).expect("fixture parses");
+    let violations = openehr_its::flat::validation::validate_rm_and_terminology(&doc);
+    assert!(
+        violations
+            .iter()
+            .any(|m| m.message.contains("mandatory container `items`")),
+        "the cluster-without-items fixture must be refused, got: {violations:?}"
+    );
+}

--- a/crates/openehr-its/tests/it/model_walkgen_register.txt
+++ b/crates/openehr-its/tests/it/model_walkgen_register.txt
@@ -1,44 +1,25 @@
 # The mandatory-drop reach register (Lane 3): mandatory attributes whose
 # omission the per-node dispatcher does not surface as a STRUCTURAL violation.
 #
-# Emptied of every TYPE-REACH entry by #1458: the generated structural dispatch
-# (`openehr_its::json_codec::generated::structural::structural_check`, emitted by
-# `openehr-codegen -- emit-json`) decodes EVERY emitted class, so a class no
-# longer needs a class invariant to have its shape checked. What remains is not
-# a reach gap at all — the dispatch does reach these classes; the codec
-# deliberately ACCEPTS the omission, for exactly two reasons, both stated below.
-# SHRINK-only: a new entry needs an adjudicated, spec-cited reason written above
-# it.
+# Emptied of every TYPE-REACH entry by #1458 (the generated structural dispatch
+# `openehr_its::json_codec::generated::structural::structural_check` decodes
+# EVERY emitted class) and of every mandatory-CONTAINER entry by #1461 (the
+# model-driven lower-bound check `rm_validate::check_mandatory_containers`
+# judges every mandatory container — absent, or empty with a cardinality lower
+# bound >= 1 — uniformly from the static model).
+# SHRINK-only: a new entry needs an adjudicated, spec-cited reason written
+# above it.
 #
-# (1) Mandatory 1..* CONTAINER attributes. The codec reads an absent array as an
-# empty `Vec` (`runtime::container_field`; the deliberate tolerance rule the
-# emitter documents: "`Vec` attribute: absent -> empty"), so at the decode step
-# an omitted list and a present empty list are the same value — the omission is
-# not representable as a decode error. Enforcing the container's lower bound is a
-# distinct mechanism (cardinality, not type reach) and a wire-tolerance change
-# for every codec caller, so it is out of this register's scope.
-ADDRESSED_MESSAGE.addressees
-AGENT.identities
-CLUSTER.items
-CONTACT.addresses
-CONTRIBUTION.versions
-DV_PARAGRAPH.items
-EXTRACT_MANIFEST.entities
-GROUP.identities
-ORGANISATION.identities
-PERSON.identities
-REVISION_HISTORY.items
-REVISION_HISTORY_ITEM.audits
-ROLE.identities
-#
-# (2) The `Interval` inclusivity/boundedness flags. Mandatory in the BMM, but
-# the codec fills them from a literal default on read (the emitter's
-# `plan::overrides::FIELD_DEFAULTS` entries: "a bounded interval limit is
-# included by default", "an unstated interval limit is bounded by default" —
-# BASE foundation_types (Interval) for the semantics; no openEHR spec governs the
-# wire omission, it is the archie/EHRbase interop convention, our own design).
-# A defaulted field cannot fail to decode: the omission IS the documented wire
-# form, so refusing it here would contradict the codec's own contract.
+# What remains is NOT a reach gap: the `Interval` inclusivity/boundedness
+# flags are mandatory in the BMM, but the codec fills them from a literal
+# default on read (the emitter's `plan::overrides::FIELD_DEFAULTS` entries:
+# "a bounded interval limit is included by default", "an unstated interval
+# limit is bounded by default" — BASE foundation_types (Interval) for the
+# semantics; no openEHR spec governs the wire omission, it is the
+# archie/EHRbase interop convention, our own design). A defaulted field cannot
+# fail to decode: the omission IS the documented wire form, so refusing it
+# would contradict the codec's own contract. (They are also exempted from the
+# mandatory-container check by shape: they are scalars, not containers.)
 DV_INTERVAL.lower_included
 DV_INTERVAL.lower_unbounded
 DV_INTERVAL.upper_included

--- a/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
+++ b/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
@@ -202,6 +202,16 @@ cnf.composition.minimal_event.setting_invalid.xml:
     spec_ref: "TERM SupportTerminology §Vocabularies (setting); RM ehr (EVENT_CONTEXT Setting_valid)"
   template_id: "minimal_evaluation.en.v1"
   provenance: "codec-derived 2026-08-01 from cnf.composition.minimal_event.setting_invalid (fixtures/composition/minimal_event.setting_invalid.json) via crates/openehr-its/examples/canonical_convert.rs — the gate-proven FromJson + ToXml codec pair; carries the identical single defect so the refusal-symmetry case (#1435) can pin that both canonical formats get the same conformance answer"
+cnf.composition.lab_result.cluster_no_items:
+  source: fixtures/composition/lab_result.cluster_no_items.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "the specimen CLUSTER carries no items — CLUSTER.items is List<ITEM> [1..*]"
+    spec_ref: "RM data_structures (CLUSTER.items 1..*, org.openehr.rm.data_structures.cluster.adoc §Attributes)"
+  template_id: "Generic lab test result example simple"
+  provenance: "derived 2026-08-01 from cnf.ckm.lab_result.example (the CKM cid 1013.26.408 template's committed example skeleton) by deleting the single CLUSTER node's items member — the wire-reachable representative of the mandatory 1..* container family (#1461)"
 cnf.composition.unknown_template:
   source: fixtures/composition/unknown_template.json
   format: canonical-json

--- a/tools/cnf-runner/artifacts/corpus/fixtures/composition/lab_result.cluster_no_items.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/composition/lab_result.cluster_no_items.json
@@ -1,0 +1,172 @@
+{
+  "_type": "COMPOSITION",
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.report-result.v1"
+    },
+    "rm_version": "1.2.0",
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "Generic lab test result example simple"
+    }
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.report-result.v1",
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "code_string": "433",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      }
+    },
+    "value": "event"
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "name": "Example composer"
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.laboratory_test_result.v1"
+        },
+        "rm_version": "1.2.0"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.laboratory_test_result.v1",
+      "data": {
+        "_type": "HISTORY",
+        "archetype_node_id": "at0001",
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "archetype_node_id": "at0002",
+            "data": {
+              "_type": "ITEM_TREE",
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "archetype_node_id": "at0005",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "Test name"
+                  },
+                  "value": {
+                    "_type": "DV_TEXT",
+                    "value": "Liver function panel"
+                  }
+                },
+                {
+                  "_type": "CLUSTER",
+                  "archetype_details": {
+                    "_type": "ARCHETYPED",
+                    "archetype_id": {
+                      "_type": "ARCHETYPE_ID",
+                      "value": "openEHR-EHR-CLUSTER.laboratory_test_analyte.v1"
+                    },
+                    "rm_version": "1.2.0"
+                  },
+                  "archetype_node_id": "openEHR-EHR-CLUSTER.laboratory_test_analyte.v1",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "Laboratory analyte result"
+                  }
+                }
+              ],
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "at0003"
+              }
+            },
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Any event"
+            },
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2022-02-03T04:05:06Z"
+            }
+          }
+        ],
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "at0001"
+        },
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2022-02-03T04:05:06Z"
+        }
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "code_string": "UTF-8",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        }
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "code_string": "en",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        }
+      },
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Laboratory test result"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      }
+    }
+  ],
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "code_string": "238",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        }
+      },
+      "value": "other care"
+    },
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2022-02-03T04:05:06Z"
+    }
+  },
+  "language": {
+    "_type": "CODE_PHRASE",
+    "code_string": "en",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    }
+  },
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Generic lab test result example"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "code_string": "US",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    }
+  }
+}

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-cluster_no_items.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-cluster_no_items.yaml
@@ -1,0 +1,43 @@
+# A CLUSTER with no items is a 422: RM data_structures declares
+# `CLUSTER.items: List<ITEM>` with multiplicity `1..*`
+# (`org.openehr.rm.data_structures.cluster.adoc` §Attributes), so a committed
+# CLUSTER node whose `items` member is absent (or empty — the canonical-JSON
+# reader treats the two spellings as the same empty list) does not conform to
+# the RM. The wire-reachable representative of the mandatory 1..* container
+# family (#1461); the sibling family member on the contribution surface is
+# the long-standing `commit_contribution-empty` case (CONTRIBUTION.versions).
+#
+# Derived from the RM attribute declaration + the ITS-REST status table
+# (Requests_and_responses.md: 422 "well-formed but was unable to be followed
+# due to semantic errors"), not from any SUT. The payload is the CKM
+# generic-lab-test-result example (the committed, SUT-accepted valid twin)
+# with the single specimen CLUSTER's `items` deleted — one defect, one case.
+id: I_EHR_COMPOSITION.create_composition-cluster_no_items
+kind: functional
+component: EHR_COMPOSITION
+sm_operation: I_EHR_COMPOSITION.create_composition
+capabilities: [CompositionOps]
+profiles: [CORE]
+test_purpose: >-
+  A COMPOSITION containing a CLUSTER without its RM-mandatory 1..* items is
+  rejected 422, and nothing is committed.
+description: "Reject a CLUSTER with no items (422)"
+spec_refs:
+  - "RM data_structures §CLUSTER (items: List<ITEM> 1..*)"
+  - "ITS-REST overview Requests_and_responses §HTTP status codes (422)"
+  - "SM openehr_platform §I_EHR_COMPOSITION.create_composition"
+applies: { rm: ">=1.0.2" }
+requires:
+  server: any
+  templates: [cnf.ckm.lab_result]
+  ehr: { commits: none }                 # mints ${ehr_id}
+data_sets: [cnf.composition.lab_result.cluster_no_items]
+flow:
+  - step: 1
+    call: create_composition
+    with: { ehr_id: "${ehr_id}", composition: "${ds:cnf.composition.lab_result.cluster_no_items}" }
+    expect: validation_failed
+    assert:
+      - { assert: message_exemplar, text: "information about the errors in the provided COMPOSITION" }
+postconditions:
+  - { assert: version, count: 0 }        # nothing committed


### PR DESCRIPTION
Closes the last accept-defect family from the #1458 register adjudication (program #1434, v3.17.1).

- **`rm_validate::check_mandatory_containers`** — a third orthogonal validation layer (beside the fast/typed core pair and terminology): every attribute the generated static RM model declares as a MANDATORY container must be present, and non-empty where the BMM cardinality lower bound is 1 (`CLUSTER.items: List<ITEM> [1..*]`, RM `data_structures` cluster class text). Model-driven — no hand list; the optional `x /= Void implies not x.is_empty` family stays with the invariant checks (no double-reporting); `List<Octet>` exempt by its base64 wire shape; the core pair untouched so the fast-vs-typed equivalence property stays exact (its gate caught my first placement — the check moved out of the core entry).
- Wired in the unified per-node dispatcher AND the composition walker (both effective-type aware), so untagged nodes are covered too.
- **Lane-3 register: 25 → 12** — only the defaulted Interval boundary flags remain (the omission IS the documented wire form; scalars, cited in the register).
- **CNF**: `create_composition-cluster_no_items` — the CKM `generic-lab-test-result` example (cid 1013.26.408, the committed valid twin) with the single specimen CLUSTER's `items` deleted → 422, nothing committed; `CONTRIBUTION.versions` was already wire-cased (`commit_contribution-empty`). Catalogue 873 cases / 0 findings; the parity sweep includes the new invalid fixture.
- Changelog entry under [Unreleased] ### Fixed.

Gates: workspace clippy `-D warnings` exit 0, openehr-its 527/527, ferroehr+rest 1352/1352, cnf validate, fmt.

Closes #1461