### PR TITLE
feat(openehr-its): enforcement-reach instrumentation for the terminology slot table

### DIFF
--- a/crates/openehr-its/tests/it/enforcement_reach.rs
+++ b/crates/openehr-its/tests/it/enforcement_reach.rs
@@ -1,0 +1,137 @@
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic,
+    reason = "test assertions/diagnostics/fixtures"
+)]
+//! Enforcement-reach instrumentation (Lane 4 of the hardening program):
+//! every terminology slot in the RM binding table is PROVABLY reachable —
+//! a violating instance is detected and its valid twin is clean — so a
+//! never-exercised enforcement site is a failing test instead of a latent
+//! gap (`EVENT_CONTEXT.setting` had zero wire exercise until the TERM
+//! program added it, and the escape behind it survived precisely because
+//! nothing measured reach).
+//!
+//! The slot inventory is DERIVED (`openehr_rm::model::classes()` ×
+//! `rm_terminology::slots_for`), never a second hand list; the total is
+//! pinned so an arm for a type outside the static model cannot vanish
+//! silently. The invariant-core dimension (the generated cores in
+//! `openehr_rm::validate::generated`) is deliberately OUT of constructive
+//! scope: cores are arbitrary predicates whose violating instances are not
+//! mechanically derivable from the model — their reach is carried by the
+//! fast-vs-typed corpus equivalence battery and the per-invariant unit tests
+//! beside each `*_impl.rs`, and the boundary is recorded here rather than
+//! silently skipped.
+
+use openehr_its::rm_terminology::{Binding, CodeSet, Group, Slot, slot_is_violated, slots_for};
+use serde_json::{Value, json};
+
+/// A known-member code for each vocabulary binding (bundle facts, pinned the
+/// same way the `openehr-term` bundle tests pin them) and a code that is a
+/// member of NO openEHR group or code set.
+fn valid_code(binding: Binding) -> (&'static str, &'static str) {
+    // (terminology_id, code_string)
+    match binding {
+        Binding::Group(g) => (
+            "openehr",
+            match g {
+                Group::CompositionCategory => "433",
+                Group::Setting => "228",
+                Group::NullFlavour => "271",
+                Group::InstructionState => "245",
+                Group::InstructionTransition => "535",
+                Group::ParticipationFunction => "253",
+                Group::ParticipationMode => "216",
+                Group::EventMathFunction => "146",
+                Group::TermMappingPurpose => "669",
+                Group::AuditChangeType => "249",
+                Group::AttestationReason => "240",
+                Group::SubjectRelationship => "0",
+                Group::VersionLifecycleState => "532",
+            },
+        ),
+        Binding::CodeSet(cs) => match cs {
+            CodeSet::Languages => ("ISO_639-1", "en"),
+            CodeSet::Countries => ("ISO_3166-1", "UY"),
+            CodeSet::CharacterSets => ("IANA_character-sets", "UTF-8"),
+            CodeSet::MediaTypes => ("IANA_media-types", "text/plain"),
+            CodeSet::NormalStatuses => ("openehr_normal_statuses", "N"),
+            CodeSet::CompressionAlgorithms => ("openehr_compression_algorithms", "gzip"),
+            CodeSet::IntegrityCheckAlgorithms => ("openehr_integrity_check_algorithms", "SHA-256"),
+        },
+    }
+}
+
+fn coded(terminology: &str, code: &str) -> Value {
+    json!({
+        "_type": "DV_CODED_TEXT",
+        "value": "x",
+        "defining_code": {
+            "_type": "CODE_PHRASE",
+            "terminology_id": {"_type": "TERMINOLOGY_ID", "value": terminology},
+            "code_string": code,
+        },
+    })
+}
+
+/// Every (type, slot) pair of the binding table, derived from the model.
+fn all_slots() -> Vec<(&'static str, &'static Slot)> {
+    let mut out = Vec::new();
+    for class in openehr_rm::model::classes() {
+        for slot in slots_for(class.name) {
+            out.push((class.name, slot));
+        }
+    }
+    out
+}
+
+/// **Constructive slot reach:** for EVERY slot, an out-of-vocabulary code is
+/// detected — at the slot predicate itself and through the full per-type
+/// dispatcher — and the valid twin is clean at the slot.
+#[test]
+fn every_terminology_slot_detects_a_violation_and_passes_its_valid_twin() {
+    let slots = all_slots();
+    // The pinned table size: an arm can only leave this table together with a
+    // deliberate register/test change, never silently. (Types outside the
+    // static model would silently drop out of `all_slots` — the pin catches
+    // that shrinkage too; 55 = the whole binding table, verified in-audit:
+    // every match arm of `slots_for` names a static-model class.)
+    assert_eq!(
+        slots.len(),
+        55,
+        "the slot table changed size — re-pin deliberately"
+    );
+
+    for (ty, slot) in slots {
+        // Group bindings are guarded on the openehr terminology; code-set
+        // bindings judge every terminology. An out-of-set code under the
+        // binding's own terminology id must violate in BOTH families.
+        let (valid_terminology, valid) = valid_code(slot.binding);
+        let bad = coded(valid_terminology, "no-such-code-999");
+        assert!(
+            slot_is_violated(slot, &bad),
+            "{ty}.{} ({}): the out-of-vocabulary twin was not detected",
+            slot.field,
+            slot.invariant,
+        );
+        let good = coded(valid_terminology, valid);
+        assert!(
+            !slot_is_violated(slot, &good),
+            "{ty}.{} ({}): the valid twin was rejected",
+            slot.field,
+            slot.invariant,
+        );
+
+        // Full-dispatcher reach: the same violation surfaces through
+        // validate_rm_terminology for the owning type.
+        let node = json!({ "_type": ty, slot.field: coded(valid_terminology, "no-such-code-999") });
+        let mut out = Vec::new();
+        openehr_its::rm_terminology::validate_rm_terminology(ty, &node, &mut out);
+        assert!(
+            out.iter().any(|iv| iv.message.contains(slot.invariant)),
+            "{ty}.{}: the dispatcher did not surface {} (got {out:?})",
+            slot.field,
+            slot.invariant,
+        );
+    }
+}

--- a/crates/openehr-its/tests/it/main.rs
+++ b/crates/openehr-its/tests/it/main.rs
@@ -18,6 +18,7 @@ mod constraint_binding_capture;
 mod content_constraint_capture;
 mod content_existence_capture;
 mod corpus;
+mod enforcement_reach;
 mod example_rm_validity;
 mod example_stub;
 mod fidelity;


### PR DESCRIPTION
Lane 4 of the #1434 hardening program (v3.17.1). `tests/it/enforcement_reach.rs`:

- **Constructive slot reach over all 55 (type, slot) pairs** — inventory derived from `openehr_rm::model::classes()` × `rm_terminology::slots_for` (no second hand list), total pinned at 55 (verified in-audit that every match arm names a static-model class, so the derivation misses none). Per slot: the out-of-vocabulary twin is detected at `slot_is_violated` AND surfaces through `validate_rm_terminology` with the right invariant name; the valid twin (pinned bundle member per binding, same style as the openehr-term bundle tests) is clean.
- **The invariant-core boundary recorded honestly**: generated cores are arbitrary predicates whose violating instances aren't model-derivable — their reach stays with the fast-vs-typed corpus equivalence battery and the per-invariant `*_impl.rs` unit tests, stated in the module docs rather than silently skipped.

Gates: workspace clippy `-D warnings` exit 0, openehr-its 528/528, fmt.

Closes #1438