### PR TITLE
feat(openehr-adl): W14DEP — deprecated ADL 1.4 spellings warn at ingest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
+- **Deprecated ADL 1.4 spellings are warned at ingest.** The paren-less
+  domain-block spelling (`C_DV_QUANTITY <…>`) is marked deprecated by the
+  ADL 1.4 text while its normative grammar defines only that form; it stays
+  accepted (refusing it would reject the whole published CKM library), and
+  every occurrence now raises the advisory `W14DEP` validation warning naming
+  the preferred parenthesised spelling — the deprecation is enforced at
+  exactly the strength the spec gives it, never silently absorbed.
+
 - **ADL 2 (AOM2) archetypes can arrive as XML, in both serializations openEHR
   publishes.** Only the AM 1.4 archetype XML was readable before; the generated
   canonical-XML codec now also covers the AOM2 **persistent** form

--- a/crates/openehr-adl/src/validate/catalogue.rs
+++ b/crates/openehr-adl/src/validate/catalogue.rs
@@ -234,6 +234,16 @@ pub enum ValidationCode {
     /// WOUC — defined terminology code unused in the definition (archie parity;
     /// no openEHR spec governs this — our own design/extension; WARNING).
     Wouc,
+    /// W14DEP — a deprecated ADL 1.4 spelling was used
+    /// (`ADL1.4/master05-cadl.adoc` §Symbols `V_C_DOMAIN_TYPE` marks the
+    /// paren-less `Type <` domain-block spelling deprecated and the
+    /// parenthesised `(Type) <` form "correct ADL 1.4/ADL 1.5"; WARNING).
+    ///
+    /// NOTE: no openEHR validity code covers deprecated-spelling use — our own
+    /// extension (owner ruling 2026-08-01, spec-adherence §NEVER LAX:
+    /// deprecations are enforced at exactly the deprecation's strength —
+    /// accepted, never silently absorbed).
+    W14dep,
     // ── phase-2 specialisation-vs-flat-parent codes (`master04.5` §Validity
     //    Rules: `C_ATTRIBUTE` / `C_OBJECT` / `ARCHETYPE_SLOT` / `C_ARCHETYPE_ROOT` /
     //    `C_COMPLEX_OBJECT_PROXY`; `master08` §Phase 2 → Validate Specialised
@@ -387,6 +397,7 @@ impl ValidationCode {
             Self::Vrdla => "VRDLA",
             Self::Wacmcl => "WACMCL",
             Self::Wouc => "WOUC",
+            Self::W14dep => "W14DEP",
             Self::Vsance => "VSANCE",
             Self::Vsancc => "VSANCC",
             Self::Vsam => "VSAM",
@@ -421,7 +432,7 @@ impl ValidationCode {
     #[must_use]
     pub fn severity(self) -> Severity {
         match self {
-            Self::Wacmcl | Self::Wouc => Severity::Warning,
+            Self::Wacmcl | Self::Wouc | Self::W14dep => Severity::Warning,
             _ => Severity::Error,
         }
     }

--- a/crates/openehr-adl/src/validate/mod.rs
+++ b/crates/openehr-adl/src/validate/mod.rs
@@ -200,6 +200,7 @@ fn run_integrity_checks(
         source_level::check_rule_paths(v, src, text, issues); // VRRLP (raw rules text)
         if dialect == Dialect::Adl14 {
             identification::check_concept_term_adl14(v, src, issues); // VARCN (terminology half)
+            source_level::check_deprecated_domain_spelling_adl14(text, issues); // W14DEP
         }
     }
 

--- a/crates/openehr-adl/src/validate/source_level.rs
+++ b/crates/openehr-adl/src/validate/source_level.rs
@@ -142,3 +142,50 @@ fn scan_predicated_paths(text: &str) -> Vec<String> {
     }
     out
 }
+
+/// W14DEP: the paren-less inline dADL domain-block spelling is deprecated —
+/// `ADL1.4/master05-cadl.adoc` §Symbols `V_C_DOMAIN_TYPE` marks `Type <`
+/// "deprecated" and `(Type) <` "correct ADL 1.4/ADL 1.5". The form stays
+/// ACCEPTED (the normative grammar defines only the paren-less spelling, and
+/// the live CKM library uses it exclusively — the docs-vs-grammar inversion is
+/// reported upstream); this check surfaces the deprecation at exactly its
+/// spec strength: a warning naming the preferred spelling, per occurrence.
+///
+/// Token-level scan (comments and string literals are not tokens, so neither
+/// can false-positive): a lowered domain-type name (`C_DV_QUANTITY`,
+/// `C_DV_ORDINAL`, `C_CODE_PHRASE`) followed by `<`, with no `(` immediately
+/// before the name.
+pub(super) fn check_deprecated_domain_spelling_adl14(
+    text: &str,
+    issues: &mut Vec<ValidationIssue>,
+) {
+    use openehr_lang::lexer::{Token, lex_adl};
+    // A lex failure never reaches here on the validation path (the artefact
+    // already parsed), so an Err simply yields no warnings.
+    let Ok(tokens) = lex_adl(text) else { return };
+    for (i, spanned) in tokens.iter().enumerate() {
+        let Token::AlphaUcId(name) = &spanned.token else {
+            continue;
+        };
+        if !crate::adl14::domain::is_adl14_domain_type(name.as_str()) {
+            continue;
+        }
+        let followed_by_lt = matches!(tokens.get(i + 1).map(|s| &s.token), Some(Token::SymLt));
+        let preceded_by_paren = i
+            .checked_sub(1)
+            .and_then(|j| tokens.get(j))
+            .is_some_and(|s| matches!(s.token, Token::LParen));
+        if followed_by_lt && !preceded_by_paren {
+            issues.push(ValidationIssue {
+                code: ValidationCode::W14dep,
+                severity: ValidationCode::W14dep.severity(),
+                message: format!(
+                    "the paren-less domain-block spelling `{name} <…>` is deprecated \
+                     (master05-cadl §Symbols); write `({name}) <…>`"
+                ),
+                path: None,
+                span: Some(spanned.span.clone()),
+            });
+        }
+    }
+}

--- a/crates/openehr-adl/tests/it/adl14_cadl_gates.rs
+++ b/crates/openehr-adl/tests/it/adl14_cadl_gates.rs
@@ -410,3 +410,34 @@ fn every_fixture_file_is_in_the_table() {
     listed.sort();
     assert_eq!(on_disk, listed, "the fixture table and the tree disagree");
 }
+
+/// W14DEP (#1470): the deprecated paren-less domain-block spelling is
+/// ACCEPTED but WARNED, per occurrence, at exactly the deprecation's spec
+/// strength (`master05-cadl` §Symbols `V_C_DOMAIN_TYPE`); the parenthesised
+/// spelling warns nothing. The `empty_domain_block` fixture carries exactly
+/// one of each spelling, so the warning count pins both directions.
+#[test]
+fn deprecated_paren_less_domain_spelling_warns_once() {
+    let src = std::fs::read_to_string(tree().join("openEHR-EHR-CLUSTER.empty_domain_block.v1.adl"))
+        .expect("fixture exists");
+    let issues = validate_source_integrity(&src, Dialect::Adl14, None).expect("the fixture parses");
+    let warnings: Vec<_> = issues
+        .iter()
+        .filter(|i| i.code == ValidationCode::W14dep)
+        .collect();
+    assert_eq!(
+        warnings.len(),
+        1,
+        "exactly the bare `C_DV_QUANTITY <` spelling warns (the parenthesised \
+         `(C_DV_ORDINAL) <` does not), got: {warnings:?}"
+    );
+    assert!(
+        warnings[0].severity == Severity::Warning,
+        "W14DEP is advisory, never an error"
+    );
+    assert!(
+        warnings[0].message.contains("(C_DV_QUANTITY) <"),
+        "the warning names the preferred spelling: {}",
+        warnings[0].message
+    );
+}


### PR DESCRIPTION
Implements the owner's never-lax posture for deprecations (spec-adherence §NEVER LAX; #1470): the paren-less domain-block spelling stays ACCEPTED (`master05-cadl` §Symbols marks it deprecated, the normative grammar defines only it, and the CKM library uses it exclusively — refusing grammar-conformant content is the mirror defect of leniency) but is never silently absorbed — every occurrence raises the advisory **W14DEP** warning naming the preferred `(Type) <…>` spelling.

- Catalogue: `W14dep` (Warning) via the established VRDLA/WOUC adjudicated-extension pattern, NOTE-flagged (no openEHR validity code covers deprecated-spelling use — our own extension per the owner ruling).
- Check: token-level scan in the source-level topic module (comments/strings are single tokens — no false positives), 1.4 dialect only, span-anchored.
- Pin: the `empty_domain_block` fixture carries exactly one spelling of each form → exactly one warning, message asserted.

Gates: clippy `-D warnings` exit 0, openehr-adl 277/277, fmt, changelog Added entry.

Closes #1470