### PR TITLE
release: v3.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ workflow refuses a tag that has no matching section here.
 
 ## [3.17.1] - 2026-08-01
 
+### Fixed
+
+- **`openehr-its` builds again for minimal consumers.** The `opt14` module
+  (OPT 1.4 model + XML codec) was declared without the `full` feature gate
+  its codec dependency carries, so any `default-features = false` consumer
+  of the crate — whose documented minimal surface is only the dependency-free
+  SMART scope grammar — failed to compile with 1,191 errors (first visible on
+  the admin console's WebAssembly lane). The module is now gated like its
+  siblings; default builds are unchanged.
+
 ### Added
 
 - **Deprecated ADL 1.4 spellings are warned at ingest.** The paren-less

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,16 +17,6 @@ workflow refuses a tag that has no matching section here.
 
 ## [3.17.1] - 2026-08-01
 
-### Fixed
-
-- **`openehr-its` builds again for minimal consumers.** The `opt14` module
-  (OPT 1.4 model + XML codec) was declared without the `full` feature gate
-  its codec dependency carries, so any `default-features = false` consumer
-  of the crate — whose documented minimal surface is only the dependency-free
-  SMART scope grammar — failed to compile with 1,191 errors (first visible on
-  the admin console's WebAssembly lane). The module is now gated like its
-  siblings; default builds are unchanged.
-
 ### Added
 
 - **Deprecated ADL 1.4 spellings are warned at ingest.** The paren-less
@@ -59,6 +49,14 @@ workflow refuses a tag that has no matching section here.
   different root types.
 
 ### Fixed
+
+- **`openehr-its` builds again for minimal consumers.** The `opt14` module
+  (OPT 1.4 model + XML codec) was declared without the `full` feature gate
+  its codec dependency carries, so any `default-features = false` consumer
+  of the crate — whose documented minimal surface is only the dependency-free
+  SMART scope grammar — failed to compile with 1,191 errors (first visible on
+  the admin console's WebAssembly lane). The module is now gated like its
+  siblings; default builds are unchanged.
 
 - **Empty inline dADL domain blocks parse (`C_DV_QUANTITY <>`).** The ADL 1.4
   reader refused an empty domain block outright; the dADL chapter's own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+## [3.17.1] - 2026-08-01
+
 ### Added
 
 - **Deprecated ADL 1.4 spellings are warned at ingest.** The paren-less
@@ -4105,7 +4107,8 @@ but has not yet run in production.
   seccomp, default-deny NetworkPolicy) and golden-render validation.
 
 
-[unreleased]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.0...HEAD
+[unreleased]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.1...HEAD
+[3.17.1]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.0...v3.17.1
 [3.17.0]: https://github.com/rubentalstra/FerroEHR/compare/v3.16.0...v3.17.0
 [3.16.0]: https://github.com/rubentalstra/FerroEHR/compare/v3.15.3...v3.16.0
 [3.15.3]: https://github.com/rubentalstra/FerroEHR/compare/v3.15.2...v3.15.3

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,5 +33,5 @@ keywords:
   - ITS-REST
   - Rust
   - PostgreSQL
-version: 3.17.0
+version: 3.17.1
 date-released: 2026-08-01

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "cnf-runner"
-version = "3.17.0"
+version = "3.17.1"
 dependencies = [
  "assert_fs",
  "base64 0.22.1",
@@ -2509,7 +2509,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferroehr"
-version = "3.17.0"
+version = "3.17.1"
 dependencies = [
  "assert_fs",
  "async-trait",
@@ -2576,7 +2576,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-admin-ui"
-version = "3.17.0"
+version = "3.17.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -2616,7 +2616,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-rest"
-version = "3.17.0"
+version = "3.17.1"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -2668,7 +2668,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-server"
-version = "3.17.0"
+version = "3.17.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -5223,7 +5223,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-codegen"
-version = "3.17.0"
+version = "3.17.1"
 dependencies = [
  "roxmltree",
  "serde_json",
@@ -8277,7 +8277,7 @@ dependencies = [
 
 [[package]]
 name = "testkit"
-version = "3.17.0"
+version = "3.17.1"
 dependencies = [
  "ferroehr",
  "jiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "3"
 members = ["crates/*", "app/*", "tools/*"]
 
 [workspace.package]
-version = "3.17.0"
+version = "3.17.1"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT"

--- a/crates/openehr-its/src/lib.rs
+++ b/crates/openehr-its/src/lib.rs
@@ -61,6 +61,7 @@ pub mod flat;
 pub mod json;
 #[cfg(feature = "full")]
 pub mod json_codec;
+#[cfg(feature = "full")]
 pub mod opt14;
 pub mod rest;
 #[cfg(feature = "full")]

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 # Chart versioning is independent of the application version.
 version: 3.2.0
 # The default container image tag (informational; overridable via image.tag).
-appVersion: "3.17.0"
+appVersion: "3.17.1"
 
 # PDB (policy/v1, GA 1.21), HPA (autoscaling/v2, GA 1.23), and the
 # seccompProfile pod field (GA 1.27) all resolve cleanly at 1.25+.

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.0"
+    app.kubernetes.io/version: "3.17.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -58,7 +58,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.0"
+    app.kubernetes.io/version: "3.17.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -77,7 +77,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.0"
+    app.kubernetes.io/version: "3.17.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -96,7 +96,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.0"
+    app.kubernetes.io/version: "3.17.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -120,7 +120,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.0"
+    app.kubernetes.io/version: "3.17.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -139,7 +139,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.0"
+    app.kubernetes.io/version: "3.17.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -294,7 +294,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.0"
+    app.kubernetes.io/version: "3.17.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -321,7 +321,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.0"
+    app.kubernetes.io/version: "3.17.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -333,7 +333,7 @@ spec:
     metadata:
       annotations:
         # Roll pods when the rendered ferroehr.toml changes.
-        checksum/config: ccfe01889289f18b7d34d1bf6a69257d296eac925e0d133497a6be70dbd7a075
+        checksum/config: a91ae973dbab78d873fc5a1f8b4883126cf8507e4df7987b5814f1617ccbc5ee
         prometheus.io/scrape: "true"
         prometheus.io/port: "9100"
         prometheus.io/path: "/management/prometheus"
@@ -354,7 +354,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:3.17.0"
+          image: "ghcr.io/rubentalstra/ferroehr:3.17.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -476,7 +476,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.0"
+    app.kubernetes.io/version: "3.17.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -509,7 +509,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.0"
+    app.kubernetes.io/version: "3.17.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.0"
+    app.kubernetes.io/version: "3.17.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -36,7 +36,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.0"
+    app.kubernetes.io/version: "3.17.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -55,7 +55,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.0"
+    app.kubernetes.io/version: "3.17.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 automountServiceAccountToken: false
@@ -69,7 +69,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.0"
+    app.kubernetes.io/version: "3.17.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -166,7 +166,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.0"
+    app.kubernetes.io/version: "3.17.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -189,7 +189,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.0"
+    app.kubernetes.io/version: "3.17.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -202,7 +202,7 @@ spec:
     metadata:
       annotations:
         # Roll pods when the rendered ferroehr.toml changes.
-        checksum/config: 708194a006e3703847f5db9dba75d9f63ec5aba0b03431a6c2c9c8bf65e76d23
+        checksum/config: 95c5ce677743a8769a664a7cdf77ecf0f69aefad7ddcd22b686e397ee7bb09a7
       labels:
         app.kubernetes.io/name: ferroehr
         app.kubernetes.io/instance: ferroehr
@@ -220,7 +220,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:3.17.0"
+          image: "ghcr.io/rubentalstra/ferroehr:3.17.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
Cut of milestone v3.17.1 (15 issues, 0 open).

The openehr-its hardening program (#1434: differential JSON↔XML verdict parity, shape-tolerance verdict-invariance properties, model-derived proptest walkers, enforcement-reach instrumentation, the generated structural dispatch, mandatory 1..* container bounds), the complete official CKM corpus vendored + exercised with the largest published OPT as an asserted scale probe (#1462/#1471/#1473), the audited ADL 1.4 corpus adjudications (#1465/#1466/#1467 under #1468), W14DEP deprecation warnings (#1470), the TODO(#issue) sweep (#1432), and the clippy hardening fallout.

Conformance baseline: 875 cases, 837 passed + 37 N/A, zero failures, zero drift (committed docs/conformance/ferroehr/).

- CHANGELOG: [Unreleased] → [3.17.1] - 2026-08-01, link refs updated
- Workspace version 3.17.0 → 3.17.1 (+ Cargo.lock)
- Helm appVersion + golden renders (validate.sh --update, ALL CHECKS PASSED)
- CITATION.cff version (date-released already 2026-08-01)

Tag v3.17.1 goes on the merge commit; milestone closes after the tag.