### PR TITLE
ci: restructure the pipeline — no duplicate builds, post-merge coverage + README badge, timeouts, aggregate gate

### DIFF
--- a/.claude/rules/reliability.md
+++ b/.claude/rules/reliability.md
@@ -24,7 +24,9 @@ chapters, the Clippy book, and the Cargo/rustdoc books.)
    both live here, so every pedantic lint is effectively a hard rule —
    including `missing_errors_doc`/`missing_panics_doc`, which are pedantic
    members, not explicit table entries).
-4. **CI job** — codegen drift, machete, cargo-audit/deny, changelog guard,
+4. **CI job** — codegen drift, machete, cargo-deny (which subsumes
+   cargo-audit: same RustSec DB, plus yanked/licenses/bans/sources),
+   changelog guard,
    attribution guard, rustfmt, the rustdoc job (`cargo doc` with
    `RUSTDOCFLAGS=-D warnings` — the `[workspace.lints.rustdoc]` table is
    inert without a doc run), the MSRV job (`cargo hack check
@@ -153,7 +155,9 @@ chapters, the Clippy book, and the Cargo/rustdoc books.)
   no synchronous I/O on the runtime; `spawn_blocking` for the rare
   CPU-heavy transform.
 - **Dependencies are pinned, locked, and vetted** (tier 4): workspace-table
-  only, `cargo audit`/`deny` green at all times, no new dependency for what
+  only, `cargo deny check` green at all times (its advisories check reads
+  the same RustSec DB as cargo-audit and adds yanked/licenses/bans/sources,
+  so CI runs deny alone), no new dependency for what
   the pinned set already provides. CI builds run `--locked` (the Cargo FAQ's
   determinism rationale: CI fails on new commits, never on registry drift);
   the scheduled `latest-deps` workflow is the official strategy for

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,8 @@
+# actionlint configuration (github.com/rhysd/actionlint/blob/main/docs/config.md).
+# actionlint's built-in runner-label list lags GitHub's actual roster; these
+# GitHub-hosted labels are in production use in this repo (containers.yml,
+# release.yml — native amd64/arm64 builds, no QEMU).
+self-hosted-runner:
+  labels:
+    - ubuntu-26.04
+    - ubuntu-26.04-arm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,36 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege for every job; the two jobs that need more (coverage pushes
+# the badge branch) elevate themselves (job-level permissions override
+# workflow-level ones — docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions).
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # CI builds are closer to from-scratch builds; incremental compilation only
+  # adds dependency-tracking overhead and bloats the caches — and sccache
+  # cannot cache incrementally-compiled crates at all
+  # (github.com/mozilla/sccache#known-caveats).
+  CARGO_INCREMENTAL: "0"
+  # No debuginfo in CI test builds: linking is the one cost no compile cache
+  # can remove (sccache never caches linker invocations), and debuginfo is
+  # most of the link weight and most of ./target's cache size. Backtraces
+  # keep symbol names, only source lines are lost (the bevy/polars pattern:
+  # bevy sets exactly these two vars; polars uses `-C debuginfo=0`).
+  CARGO_PROFILE_DEV_DEBUG: "0"
+  CARGO_PROFILE_TEST_DEBUG: "0"
   # The "phases need not compile" gate was retired: every job here is
   # REQUIRED. (The historical PORT_STRICT advisory switch is gone.)
+  #
+  # Cache policy (the ruff/polars `save-if` idiom): only develop writes the
+  # per-job rust-cache entries; PR branches restore develop's warm cache and
+  # never publish their own. PR-branch caches are read by nothing else (GHA
+  # cache scoping), so letting every PR save would only thrash the shared
+  # 10 GB repo quota and evict the caches that matter — including the ui-e2e
+  # exact-key binary caches below.
 
 jobs:
   # ── Change detection: cargo jobs run ONLY when build-relevant paths change ──
@@ -22,13 +47,14 @@ jobs:
   # jobs, workflow-only and docs-only PRs included): app/, crates/, tools/,
   # scripts/, .cargo/, .config/, Cargo.toml, Cargo.lock, rust-toolchain.toml,
   # rustfmt.toml, clippy.toml, deny.toml. Everything else (docs/, website/,
-  # .claude/, .github/, markdown, compose files, assets) skips the nine cargo
+  # .claude/, .github/, markdown, compose files, assets) skips the cargo
   # jobs. GitHub treats a skipped required check as satisfied, so branch
   # protection is unaffected; a workflow-gating bug surfaces on the next
   # code-touching PR, which is acceptable.
   changes:
     name: change detection
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       code: ${{ steps.filter.outputs.code }}
       admin_ui: ${{ steps.filter.outputs.admin_ui }}
@@ -103,17 +129,22 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt
+          # rustfmt compiles nothing — a restored target/registry cache is
+          # pure download time here.
+          cache: false
       - run: cargo fmt --all --check
 
   # ── Always required: no AI/Claude attribution in commit messages ────────────
   no-attribution:
     name: no attribution in commits
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
         with:
@@ -138,44 +169,43 @@ jobs:
           echo "OK: no attribution found."
 
   # ── Always required: supply-chain policy ────────────────────────────────────
+  # cargo-deny alone: `cargo deny check` reads the SAME RustSec advisory DB as
+  # cargo-audit and additionally enforces yanked = "deny" (deny.toml
+  # [advisories]), licenses, bans, and sources — the former cargo-audit job was
+  # a strict subset run twice (embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html).
+  # Cargo.lock IS committed (workspace ships a binary); deny checks the real pins.
   deny:
     name: cargo-deny
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-save-if: ${{ github.ref == 'refs/heads/develop' }}
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-deny
       - run: cargo deny check
-
-  audit:
-    name: cargo-audit
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-audit
-      # Cargo.lock IS committed (workspace ships a binary); audit the real pins.
-      - run: cargo audit
 
   clippy:
     name: clippy
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
+      # rust-cache (not sccache) is load-bearing here: sccache cannot cache
+      # clippy-driver invocations (mozilla/sccache#539), so the restored
+      # target dir is the only compile cache clippy gets.
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
           target: wasm32-unknown-unknown
+          cache-save-if: ${{ github.ref == 'refs/heads/develop' }}
       # The console's `hydrate`/`ssr` features are mutually exclusive (a
       # compile_error! guard per the Cargo book §Mutually exclusive features),
       # so the workspace lane excludes it and the crate gets its own two
@@ -195,13 +225,23 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     env:
       RUSTDOCFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v7
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-save-if: ${{ github.ref == 'refs/heads/develop' }}
       - run: cargo doc --locked --workspace --exclude ferroehr-admin-ui --all-features --no-deps
       - run: cargo doc --locked -p ferroehr-admin-ui --features ssr --no-deps
+      # Doc tests live HERE, not in the pg18 test job: nextest cannot run
+      # doctests, so `cargo test --doc` is its own compile (default features —
+      # doctests document what a default consumer gets), and this job is ~1/10
+      # the length of the test job, so the extra configuration rides the short
+      # lane instead of the critical path. No DB: doctests are examples, never
+      # integration tests.
+      - run: cargo test --locked --workspace --doc
 
   # ── MSRV verification: the declared rust-version must actually build ────────
   # The Cargo book names cargo-hack as the verification tool — a pinned stable
@@ -212,9 +252,12 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-save-if: ${{ github.ref == 'refs/heads/develop' }}
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-hack
@@ -226,46 +269,33 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt
+          cache-save-if: ${{ github.ref == 'refs/heads/develop' }}
       - name: Regenerate and diff
         run: bash scripts/check-codegen-drift.sh
 
-  # ── CNF conformance: the enforced-coverage guard (fast, no DB) ───────────────
-  # The conformance instrument's own test suite: the ECC catalogue guard (every
-  # registered case has an allocated, never-reused ECC number), the
-  # derivation-square guard (every case carries a spec citation, a schedule
-  # trace or stated ECC-original reason, and an ITS-REST binding), the fixture
-  # manifest + adjudication-register validation, and the wire/edition/model
-  # unit tests. The e2e CNF run goes through the Docker compose stack
-  # (scripts/conformance.sh — the CNF 2.0 pipeline over tools/cnf-runner) at
-  # phase gates; this job is the fast always-on signal: the runner's own
-  # test suite (schema drift, artifact gates, interpreter laws, defect
-  # rejection, verification pack, comparison gate) plus the full artifact
-  # validation.
-  conformance:
-    name: cnf coverage guard
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-nextest
-      - run: cargo nextest run --locked -p cnf-runner
-      - run: cargo run --locked -q -p cnf-runner --bin cnf-runner -- validate --root tools/cnf-runner/artifacts --specs docs/specs/openehr
-
-  # ── Build + tests against PostgreSQL 18.4 ────────────────────────────────────
+  # ── Build + tests against PostgreSQL 18.4 (+ the CNF artifact validation) ───
+  # The former standalone "cnf coverage guard" job lives here now: its
+  # `cargo nextest run -p cnf-runner` was a byte-for-byte subset of this job's
+  # `--workspace` nextest run (cnf-runner is a workspace member — its ECC
+  # catalogue guard, derivation-square guard, fixture-manifest and
+  # adjudication-register tests, and the wire/edition/model unit tests all run
+  # here), so the whole suite compiled and ran TWICE per push. Only the
+  # artifact `validate` step was unique, and it rides along at the end — the
+  # `cargo build` step below has already linked the cnf-runner binary, so the
+  # step is pure execution. The e2e CNF run stays where it was: the Docker
+  # compose stack (scripts/conformance.sh) at phase gates.
   test:
     name: build & test (pg18)
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     services:
       postgres:
         image: postgres:18.4
@@ -286,6 +316,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-save-if: ${{ github.ref == 'refs/heads/develop' }}
       - name: Enable required extensions + non-durable test tuning
         # libxml2-utils provides xmllint — the C14N XML parity gate shells out
         # to it (serialization.md); the runner image does not ship it.
@@ -303,18 +335,41 @@ jobs:
           tool: cargo-nextest
       # The console is excluded from --all-features lanes (mutually exclusive
       # hydrate/ssr, compile_error!-guarded) and tested per-feature instead.
+      # The explicit `cargo build` is NOT redundant with nextest: nextest
+      # compiles test targets only, this is the one place every workspace BIN
+      # actually links (clippy type-checks but never links).
       - run: cargo build --locked --workspace --exclude ferroehr-admin-ui --all-features
       - run: cargo build --locked -p ferroehr-admin-ui --features ssr
       # --no-tests=pass: empty crates are expected until P17 (nextest exits 4 otherwise)
       - run: cargo nextest run --locked --workspace --exclude ferroehr-admin-ui --all-features --no-tests=pass --profile ci
       - run: cargo nextest run --locked -p ferroehr-admin-ui --features ssr --no-tests=pass --profile ci
-      - run: cargo test --locked --workspace --doc
+      # Doc tests moved to the rustdoc job: `cargo test --doc` is a third
+      # feature configuration (default features) and compiled the whole
+      # workspace again at the tail of THE critical-path job.
+      # The CNF artifact validation (catalogue/fixture/register gates over
+      # tools/cnf-runner/artifacts) — the binary is already linked by the
+      # build step above, so this is seconds of pure execution.
+      - run: cargo run --locked -q -p cnf-runner --bin cnf-runner -- validate --root tools/cnf-runner/artifacts --specs docs/specs/openehr
 
+  # ── Coverage: develop pushes only ────────────────────────────────────────────
+  # An instrumented build can NEVER reuse the test job's artifacts —
+  # cargo-llvm-cov compiles into its own target dir (llvm-cov-target) because
+  # `-C instrument-coverage` artifacts are incompatible with normal ones — so
+  # on PRs this job was a guaranteed second full build+run of the entire suite
+  # whose lcov artifact nothing consumed. It runs post-merge instead (the
+  # backstop cadence this repo already merges on), publishes the lcov
+  # artifact, and refreshes the README coverage badge on the `badges` branch.
+  # PR-only breakage is impossible by construction: it runs the same tests the
+  # test job just ran, only instrumented.
   coverage:
     name: coverage
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: github.event_name == 'push' && needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      # Pushes the refreshed badge JSON to the `badges` ref below.
+      contents: write
     services:
       postgres:
         image: postgres:18.4
@@ -340,14 +395,44 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: llvm-tools-preview
+          # Only ever runs on develop pushes, so save unconditionally; the
+          # instrumented artifacts get their own key by construction (job id).
+          cache-save-if: ${{ github.ref == 'refs/heads/develop' }}
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-llvm-cov,cargo-nextest
-      - run: cargo llvm-cov nextest --locked --workspace --no-tests=pass --lcov --output-path lcov.info
+      # The same two lanes as the test job (the old single `--workspace` run
+      # measured the console under its bare default features — neither the ssr
+      # nor the hydrate shape anyone ships): everything-but-console with
+      # --all-features, console per-feature; --no-report accumulates both into
+      # one profile, `report` merges them into a single lcov.
+      - run: cargo llvm-cov --no-report nextest --locked --workspace --exclude ferroehr-admin-ui --all-features --no-tests=pass --profile ci
+      - run: cargo llvm-cov --no-report nextest --locked -p ferroehr-admin-ui --features ssr --no-tests=pass --profile ci
+      - run: cargo llvm-cov report --lcov --output-path lcov.info
       - uses: actions/upload-artifact@v7
         with:
           name: coverage-lcov
           path: lcov.info
+      # README badge: line-coverage %, shields.io endpoint JSON, force-pushed
+      # as a single-file orphan commit to `badges` (plumbing — no checkout
+      # juggling, no history growth; the ref only ever holds one commit).
+      # `badges` is not in `on.push.branches`, so this can never retrigger CI.
+      - name: Refresh the coverage badge (badges branch)
+        if: github.ref == 'refs/heads/develop'
+        run: |
+          set -euo pipefail
+          pct=$(cargo llvm-cov report --json --summary-only | jq '.data[0].totals.lines.percent')
+          printf 'line coverage: %s%%\n' "$pct"
+          rounded=$(printf '%.1f' "$pct")
+          color=$(awk -v p="$pct" 'BEGIN { print (p>=90) ? "brightgreen" : (p>=80) ? "green" : (p>=70) ? "yellowgreen" : (p>=60) ? "yellow" : "orange" }')
+          jq -n --arg msg "${rounded}%" --arg color "$color" \
+            '{schemaVersion: 1, label: "coverage", message: $msg, color: $color}' > coverage.json
+          blob=$(git hash-object -w coverage.json)
+          tree=$(printf '100644 blob %s\tcoverage.json\n' "$blob" | git mktree)
+          commit=$(GIT_AUTHOR_NAME=github-actions GIT_AUTHOR_EMAIL=actions@github.com \
+                   GIT_COMMITTER_NAME=github-actions GIT_COMMITTER_EMAIL=actions@github.com \
+                   git commit-tree "$tree" -m "coverage badge: ${rounded}% line coverage")
+          git push --force origin "$commit:refs/heads/badges"
 
   # ── Unused dependencies ──────────────────────────────────────────────────────
   unused-deps:
@@ -355,6 +440,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - uses: taiki-e/install-action@v2
@@ -402,6 +488,10 @@ jobs:
     needs: changes
     if: needs.changes.outputs.admin_ui == 'true'
     runs-on: ubuntu-latest
+    # Generous: a binary-cache miss with a cold sccache is a full release
+    # build of the ~190 kLoC first-party graph (714 s measured cold, plus
+    # dependency compiles on a lockfile bump).
+    timeout-minutes: 60
     # Debian 13 (trixie) container so the binary targets glibc 2.41, matching
     # gcr.io/distroless/cc-debian13 exactly — the same pin and the same reason
     # as containers.yml's `binary` job. It must NOT be compiled on the bare
@@ -502,6 +592,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.admin_ui == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
       # Cache 1 — the built outputs themselves, exact key, no restore-keys
@@ -591,13 +682,10 @@ jobs:
     needs: [changes, ui-e2e-binary, ui-e2e-console]
     if: needs.changes.outputs.admin_ui == 'true'
     runs-on: ubuntu-latest
-    # Least privilege, scoped to THIS job: the workflow declares no top-level
-    # `permissions`, so every other job keeps the repository default and only
-    # ui-e2e states its own (job-level settings override workflow-level ones —
-    # docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions).
-    # `contents: read` for the checkout is all it needs: nothing here writes to
-    # a registry any more (the GHCR buildx layer cache was removed, and the
-    # image is now packaged locally from a job artifact).
+    timeout-minutes: 30
+    # `contents: read` (now also the workflow-level default) is all it needs:
+    # nothing here writes to a registry any more (the GHCR buildx layer cache
+    # was removed, and the image is now packaged locally from a job artifact).
     permissions:
       contents: read
     steps:
@@ -688,6 +776,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.server_dockerfile == 'true'
     runs-on: ubuntu-latest
+    # A deliberate full cold in-image compile (no cache backend at all).
+    timeout-minutes: 60
     permissions:
       contents: read
     steps:
@@ -708,6 +798,7 @@ jobs:
     name: ui-screenshot-guard
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
         with:
@@ -740,6 +831,7 @@ jobs:
     name: changelog-guard
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
         with:
@@ -780,6 +872,7 @@ jobs:
   citation:
     name: citation-guard
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - name: Validate CITATION.cff (CFF 1.2.0 schema)
@@ -798,3 +891,41 @@ jobs:
             exit 1
           fi
           echo "CITATION.cff version $cff_ver matches the workspace version."
+
+  # ── The one-check aggregate gate (the rust-analyzer/ruff pattern) ───────────
+  # A single job that needs everything and passes iff nothing failed — skipped
+  # jobs count as satisfied, exactly like branch protection treats them. Point
+  # branch protection / a future merge queue at THIS check alone, so adding,
+  # renaming, or path-gating jobs never requires touching repository settings.
+  conclusion:
+    name: conclusion
+    if: always()
+    needs:
+      - changes
+      - fmt
+      - no-attribution
+      - deny
+      - clippy
+      - doc
+      - msrv
+      - codegen-drift
+      - test
+      - coverage
+      - unused-deps
+      - ui-e2e-binary
+      - ui-e2e-console
+      - ui-e2e
+      - server-image-from-source
+      - ui-screenshot-guard
+      - changelog
+      - citation
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Every needed job succeeded or was skipped
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          echo "$NEEDS" | jq -r 'to_entries[] | "\(.key): \(.value.result)"'
+          echo "$NEEDS" | jq -e 'all(.[] | .result; . == "success" or . == "skipped")' >/dev/null

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,6 +41,7 @@ jobs:
   analyze:
     name: Analyze (rust)
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       security-events: write # upload the SARIF results / alerts
       contents: read

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -37,17 +37,52 @@ permissions:
 
 jobs:
   # ── Detect which images need (re)building ───────────────────────────────────
+  # The ci.yml owner ruling (2026-07-17) applied to images: a push that touches
+  # none of an image's build inputs must not recompile and republish it. A
+  # docs-only develop push used to run FOUR native release compiles (two
+  # binaries × two arches) plus a cargo-leptos site build for byte-identical
+  # images. Tag pushes and manual dispatches always build everything (the
+  # per-job conditions below), so a release can never miss an image.
   changes:
     name: detect changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
+      app: ${{ steps.filter.outputs.app }}
+      admin_ui: ${{ steps.filter.outputs.admin_ui }}
       postgres: ${{ steps.filter.outputs.postgres }}
     steps:
       - uses: actions/checkout@v7
       - uses: dorny/paths-filter@v4
         id: filter
         with:
+          # The app filter mirrors the ui-e2e-binary cache key in ci.yml (the
+          # inputs the server build reads); admin_ui mirrors the ui-e2e-console
+          # key plus its own Dockerfile. Shared workspace manifests appear in
+          # both — a lockfile bump rebuilds both images, correctly.
           filters: |
+            app:
+              - 'crates/**'
+              - 'app/ferroehr/**'
+              - 'app/ferroehr-rest/**'
+              - 'app/ferroehr-server/**'
+              - 'tools/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - '.cargo/**'
+              - 'docker/Dockerfile'
+              - 'docker/smoke-test.sh'
+              - '.github/workflows/containers.yml'
+            admin_ui:
+              - 'crates/**'
+              - 'app/ferroehr-admin-ui/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - '.cargo/**'
+              - 'docker/admin-ui/**'
+              - '.github/workflows/containers.yml'
             postgres:
               - 'docker/postgres/**'
               - '.github/workflows/containers.yml'
@@ -55,7 +90,16 @@ jobs:
   # ── Compile the server binary natively per arch (no QEMU, no in-Docker cargo) ─
   binary:
     name: binary (${{ matrix.platform }})
+    needs: changes
+    # Skip cascades: app-image needs this job, smoke needs app-image — a
+    # skipped need skips the dependent automatically, so the whole app lane
+    # turns off together.
+    if: >-
+      needs.changes.outputs.app == 'true' ||
+      startsWith(github.ref, 'refs/tags/v') ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
     strategy:
       fail-fast: true
       matrix:
@@ -118,6 +162,7 @@ jobs:
   app-image:
     name: app image
     runs-on: ubuntu-26.04
+    timeout-minutes: 15
     needs: binary
     outputs:
       digest: ${{ steps.build.outputs.digest }}
@@ -182,7 +227,14 @@ jobs:
   # with plain cargo. Same glibc rationale as the app binary job.
   admin-ui-binary:
     name: admin-ui binary (${{ matrix.platform }})
+    needs: changes
+    # Same cascade as the app lane: admin-ui-image skips with this job.
+    if: >-
+      needs.changes.outputs.admin_ui == 'true' ||
+      startsWith(github.ref, 'refs/tags/v') ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
     strategy:
       fail-fast: true
       matrix:
@@ -263,6 +315,7 @@ jobs:
   admin-ui-image:
     name: admin-ui image
     runs-on: ubuntu-26.04
+    timeout-minutes: 15
     needs: admin-ui-binary
     steps:
       - uses: actions/checkout@v7
@@ -322,6 +375,7 @@ jobs:
   postgres-image:
     name: postgres image
     runs-on: ubuntu-26.04
+    timeout-minutes: 15
     needs: changes
     if: >-
       needs.changes.outputs.postgres == 'true' ||
@@ -365,6 +419,7 @@ jobs:
   smoke:
     name: compose smoke (amd64)
     runs-on: ubuntu-26.04
+    timeout-minutes: 20
     needs: app-image
     steps:
       - uses: actions/checkout@v7
@@ -376,9 +431,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pull pushed app image (by digest)
+        env:
+          DIGEST: ${{ needs.app-image.outputs.digest }}
         run: |
-          docker pull "${APP_IMAGE}@${{ needs.app-image.outputs.digest }}"
-          docker tag  "${APP_IMAGE}@${{ needs.app-image.outputs.digest }}" ferroehr:smoke
+          docker pull "${APP_IMAGE}@${DIGEST}"
+          docker tag  "${APP_IMAGE}@${DIGEST}" ferroehr:smoke
 
       - name: Build postgres image (amd64; COPY-only, seconds)
         run: docker build -t ferroehr-postgres:smoke docker/postgres

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,6 +35,7 @@ jobs:
   # ── Build + verify (always; no deploy) ──────────────────────────────────────
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -82,6 +83,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: write        # push to docs-dist
     steps:
@@ -105,6 +107,7 @@ jobs:
         && (needs.version-cut.result == 'success' || needs.version-cut.result == 'skipped')
         && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     environment:
       name: github-pages
       url: ${{ steps.pages.outputs.page_url }}

--- a/.github/workflows/latest-deps.yml
+++ b/.github/workflows/latest-deps.yml
@@ -22,6 +22,13 @@ jobs:
   latest-deps:
     name: build against latest in-range deps
     runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      # A scheduled red is invisible unless someone happens to open the
+      # Actions tab — the failure step below files it on the tracker instead
+      # (the same visibility mechanism as the two spec watchers).
+      issues: write
     steps:
       - uses: actions/checkout@v7
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -34,3 +41,28 @@ jobs:
         run: |
           cargo check --workspace --exclude ferroehr-admin-ui --all-targets --all-features
           cargo check -p ferroehr-admin-ui --all-targets --features ssr
+      - name: Open a tracker issue on failure (deduplicated)
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          title="latest-deps: workspace no longer builds against the newest in-range dependencies"
+          existing=$(gh issue list --state open --search "in:title \"$title\"" --json number --jq 'length')
+          if [ "$existing" -gt 0 ]; then
+            echo "Open issue already tracks this — not filing a duplicate."
+            exit 0
+          fi
+          body_file=$(mktemp)
+          cat > "$body_file" <<EOF
+          The scheduled latest-deps run failed: a newest-in-range dependency set no longer compiles (Cargo book: verifying latest dependencies).
+
+          Run: $RUN_URL
+
+          Triage: reproduce with \`cargo update && cargo check --workspace --exclude ferroehr-admin-ui --all-targets --all-features\`, then either fix the incompatibility or pin the offending range with a dated comment.
+          EOF
+          gh issue create \
+            --title "$title" \
+            --label "bug" --label "P2" --label "ci" \
+            --body-file "$body_file"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,19 +30,29 @@ permissions:
 jobs:
   publish-release:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
     steps:
       - id: tag
         name: Resolve the release tag
+        # The dispatch input reaches the shell via env, never `${{ }}`-inline
+        # (workflow-injection hygiene), and must match a full semver tag shape
+        # before it is used as a checkout ref below — `case v*` accepted any
+        # string starting with "v".
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            tag="${{ inputs.tag }}"
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            tag="$INPUT_TAG"
           else
             tag="${GITHUB_REF_NAME}"
           fi
-          case "$tag" in v*) ;; *) echo "::error::'$tag' is not a vX.Y.Z tag" >&2; exit 1;; esac
+          if ! printf '%s\n' "$tag" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "::error::'$tag' is not a vX.Y.Z tag" >&2
+            exit 1
+          fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v7
         with:
@@ -96,6 +106,8 @@ jobs:
   build-binaries:
     needs: publish-release
     runs-on: ${{ matrix.runner }}
+    # A deliberately cold release build (no cache) of the full workspace.
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/spec-release-watcher.yml
+++ b/.github/workflows/spec-release-watcher.yml
@@ -26,6 +26,7 @@ concurrency:
 jobs:
   watch:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
       - name: Poll upstream release tags, open spec-release issues

--- a/.github/workflows/spec-update-watcher.yml
+++ b/.github/workflows/spec-update-watcher.yml
@@ -39,6 +39,7 @@ concurrency:
 jobs:
   watch:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
       - name: Poll Jira + amendment records, open spec-update issues

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,7 @@ cargo clippy -p ferroehr-admin-ui --all-targets --features ssr -- -D warnings
 cargo clippy -p ferroehr-admin-ui --target wasm32-unknown-unknown --features hydrate -- -D warnings
 cargo fmt --all
 RUSTDOCFLAGS="-D warnings" cargo doc --workspace --exclude ferroehr-admin-ui --all-features --no-deps   # the rustdoc gate (intra-doc links, doc lints)
-cargo audit && cargo deny check
+cargo deny check   # subsumes cargo-audit: same RustSec DB + yanked/licenses/bans/sources
 # conformance pipeline (the acceptance instrument) — the CNF 2.0 runner:
 bash scripts/conformance.sh   # compose up --build (fresh volumes) → the CNF catalogue → verdicts → docs/conformance/<sut>/ (results + verdicts + report/statement/certificate + badges); baseline numbers live ONLY in the committed artifacts
 # measured performance (hour-plus, exclusive SUT): CONF_PERF_CLASS=POC|S|L|R [CONF_PERF_HOURS=1|2|4|6|8|12] bash scripts/conformance.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ cargo nextest run --workspace          # unit + integration (real PG 18 via Dock
 cargo test --workspace --doc
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo fmt --all --check
-cargo deny check && cargo audit && cargo machete
+cargo deny check && cargo machete      # deny subsumes cargo-audit (same RustSec DB + yanked/licenses/bans/sources)
 bash scripts/check-codegen-drift.sh    # generated layer matches the vendored specs
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 ITS-REST 1.1.0 &nbsp;·&nbsp; AQL 1.1 &nbsp;·&nbsp; RM 1.2.0 &nbsp;·&nbsp; ADL 1.4 + 2.4 &nbsp;·&nbsp; PostgreSQL 18 &nbsp;·&nbsp; Rust 1.96
 
 [![CI](https://github.com/rubentalstra/FerroEHR/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/rubentalstra/FerroEHR/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Frubentalstra%2Fferroehr%2Fbadges%2Fcoverage.json)](https://github.com/rubentalstra/FerroEHR/actions/workflows/ci.yml)
 [![openEHR CNF conformance](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Frubentalstra%2Fferroehr%2Fdevelop%2Fdocs%2Fconformance%2Fferroehr%2Fbadge.json)](docs/conformance/ferroehr/CONFORMANCE_REPORT.md)
 [![CNF performance](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Frubentalstra%2Fferroehr%2Fdevelop%2Fdocs%2Fconformance%2Fferroehr%2Fbadge-performance.json)](docs/conformance/ferroehr/CONFORMANCE_CERTIFICATE.md)
 [![GHCR](https://img.shields.io/badge/ghcr.io-ferroehr-2496ED.svg?logo=docker&logoColor=white)](https://github.com/rubentalstra/FerroEHR/pkgs/container/ferroehr)

--- a/website/book/src/contributing.md
+++ b/website/book/src/contributing.md
@@ -39,7 +39,7 @@ cargo nextest run --workspace          # unit + integration (real PostgreSQL 18)
 cargo test --workspace --doc
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo fmt --all --check
-cargo deny check && cargo audit && cargo machete
+cargo deny check && cargo machete      # deny subsumes cargo-audit (same RustSec DB + yanked/licenses/bans/sources)
 bash scripts/check-codegen-drift.sh    # generated layer matches the vendored specs
 ```
 


### PR DESCRIPTION
Closes #1477

## What changed and why

Measured baseline (run 30696507926, a full green run): critical path was `build & test (pg18)` at ~17 min, with the whole cnf-runner suite ALSO built+run in a separate 3-min job, a second full instrumented build+run in the 10-min coverage job on every PR, and doctests (a third feature configuration compile) at the tail of the critical-path job. Patterns cross-checked against how tokio, ruff, uv, rust-analyzer, polars, and bevy structure CI.

### ci.yml
- **cnf coverage guard folded into the pg18 test job.** Its `cargo nextest run -p cnf-runner` was a strict subset of the test job's `--workspace` run — the suite compiled and ran twice per push. The unique part (the artifact `validate` run) now rides at the end of the test job, where the build step has already linked the binary (pure execution, seconds).
- **cargo-audit job removed.** `cargo deny check` reads the same RustSec advisory DB and additionally enforces `yanked = "deny"`, licenses, bans, and sources — the audit job was a subset run twice. Local-gate docs (CLAUDE.md, CONTRIBUTING.md, the book's contributing page, reliability.md) updated to match.
- **Coverage is post-merge (develop pushes) + README badge.** An instrumented build can never reuse the test job's artifacts (`-C instrument-coverage` — cargo-llvm-cov builds into its own `llvm-cov-target`), so on PRs it was a guaranteed duplicate full build+run whose lcov nothing consumed. It now runs on develop pushes, mirrors the test job's two lanes (workspace `--all-features` minus console, console `ssr`) instead of the old default-features single lane, merges them into one lcov, uploads the artifact, and publishes a shields.io endpoint JSON as a single-commit orphan `badges` ref. README gets the coverage badge — the number is generated by cargo-llvm-cov from the actual test run, never hand-typed.
- **Doctests moved to the rustdoc job** — `cargo test --doc` is its own compile configuration and sat at the tail of the critical-path job; the rustdoc job is ~1/10 its length. Doctests cannot touch the DB (std::env::var is a compile-banned API; config flows through the config tree).
- **Workflow-wide `CARGO_INCREMENTAL=0` and `CARGO_PROFILE_DEV_DEBUG=0`/`CARGO_PROFILE_TEST_DEBUG=0`** — linking is the one uncacheable cost and debuginfo is most of its weight and most of the cache size (the bevy/polars lever).
- **`cache-save-if` restricted to develop** on every rust-cache use: PR-branch caches are read by nothing (GHA cache scoping) and only evict the warm develop caches + the ui-e2e exact-key binary caches out of the shared 10 GB quota.
- **`timeout-minutes` on every job** (GitHub's default is 360 min per hung job), **workflow-level `permissions: contents: read`**, and a **`conclusion` aggregate job** (the rust-analyzer/ruff pattern): point branch protection at that one check and job additions/renames never touch repo settings again.
- rustfmt job skips the pointless cache download; clippy keeps rust-cache (sccache cannot cache clippy-driver — mozilla/sccache#539).

### containers.yml
**Per-image change detection.** Every develop push — docs-only included — compiled four native release binaries (two images × two arches) plus a cargo-leptos site build and republished byte-identical images. The app/admin-ui lanes now gate on their actual build inputs (mirroring the ui-e2e cache keys in ci.yml); tag pushes and `workflow_dispatch` always build everything, so a release can never miss an image. Smoke-test digest interpolation moved to env; timeouts added.

### release.yml
The `workflow_dispatch` tag input was interpolated inline into a shell and only checked against `v*` before being used as a checkout ref. It now flows via env and must match a full `^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$` shape. Timeouts added.

### latest-deps.yml
A scheduled red was invisible unless someone opened the Actions tab. Failure now files a deduplicated `bug`/`P2`/`ci` tracker issue with the run URL (the same visibility mechanism as the spec watchers).

### docs.yml / codeql.yml / spec watchers
Timeouts.

### .github/actionlint.yaml
Registers the `ubuntu-26.04(-arm)` runner labels actionlint's built-in roster lags behind; all eight workflows are actionlint-clean.

## Verification
- `actionlint .github/workflows/*.yml` clean.
- This PR's own run exercises the new ci.yml on the pull_request path (workflow-only change → cargo jobs skip via change detection, guards + conclusion run).
- The badge publish path first runs on the merge commit's develop push; the README badge 404s via shields' "invalid" state until that first run completes, then stays current.

`no-changelog`: CI/workflow + contributor-docs only — no user-visible product surface changes.