### PR TITLE
fix(validation): archetype-root node-id identity + Links_valid on every commit path

### DIFF
--- a/.claude/agent-memory/spec-conformance-reviewer/MEMORY.md
+++ b/.claude/agent-memory/spec-conformance-reviewer/MEMORY.md
@@ -13,3 +13,4 @@
 - [LANG bmm3 two-schema chimera](lang-bmm3-two-schema-chimera.md) — VERIFIED DEFECT: src/bmm3/ carries RELEASED-v2 shapes at bmm3 paths (18 collisions, 2 classes never emitted); diff both LANG schemas before any BMM audit
 - [Codegen degrade + optionality conventions](codegen-degrade-and-optionality-conventions.md) — the two invisible emission conventions (serde_json::Value degrade, Vec-for-optional-container) and where each loses spec semantics
 - [BMM3 spec-internal inconsistencies](bmm3-spec-internal-inconsistencies.md) — ch.10-12 prose vs bmm3 class docs: the model governs; the nine slips + the EL-vs-BEL OR/XOR precedence conflict
+- [RM archetyped master03 §3.1](rm-archetyped-master03-overview.md) — root-LOCATABLE validation is asymmetric (COMPOSITION/FOLDER skip validate_root_locatable); FEEDER_AUDIT.change_type doesn't exist in RM 1.2.0; AMB-65 covers the uid form

--- a/.claude/agent-memory/spec-conformance-reviewer/rm-archetyped-master03-overview.md
+++ b/.claude/agent-memory/spec-conformance-reviewer/rm-archetyped-master03-overview.md
@@ -1,0 +1,56 @@
+---
+name: rm-archetyped-master03-overview
+description: Verified findings for RM common master03 §3.1 (PATHABLE/LOCATABLE/Feeder audit prose) — where the app enforces root-LOCATABLE rules and where it does not, plus the FEEDER_AUDIT.change_type spec-internal gap
+metadata:
+  type: feedback
+---
+
+Verified 2026-08-01 against RM 1.2.0
+`docs/specs/openehr/RM/docs/common/master03-archetyped_package.adoc` §Overview.
+
+**Root-LOCATABLE enforcement is ASYMMETRIC (confirmed defect).**
+`app/ferroehr/src/service/ehr/validation.rs:338 validate_root_locatable`
+(archetype_details mandatory + root `archetype_node_id` == stringified
+`archetype_details.archetype_id.value` + `Links_valid`) is called ONLY from
+`validation.rs:420` (EHR_STATUS), `:549` (EHR_ACCESS) and
+`service/demographic/validate.rs:126` (PARTY). COMPOSITION
+(`service/ehr/composition.rs`) and FOLDER (`validate_folder`,
+`validation.rs:580`) never call it — a COMPOSITION whose root
+`archetype_node_id` disagrees with its `archetype_details.archetype_id` commits
+200/201. `flat/validation/mod.rs check_archetyped_valid` (:731) only enforces
+the NEGATIVE arm (at/id-code node must NOT carry archetype_details); no
+positive equality check exists anywhere in `openehr-its` or `app/ferroehr`.
+Same asymmetry for `LOCATABLE.Links_valid` (`"links": []` accepted on
+COMPOSITION/FOLDER; `check_nonempty_lists` :775 has no `links` rule).
+
+**§3.1 prose references a nonexistent attribute.** "Structural Correspondence"
+says to mark a synthesised node by setting FEEDER_AUDIT's `change_type` to
+"synthesised", but RM 1.2.0 `UML/classes/org.openehr.rm.common.feeder_audit.adoc`
+declares only 5 attributes (no change_type) and `…feeder_audit_details.adoc`
+likewise. Terminology group "audit change type" has 252 `synthesis`
+(TERM `SupportTerminology/master04-representation.adoc:78`) but it is only
+reachable from AUDIT_DETAILS.change_type. Unrepresentable → no ambiguity-register
+entry exists (`tools/cnf-runner/artifacts/registers/ambiguities.yaml` has no
+FEEDER_AUDIT change_type entry).
+
+**Already-adjudicated, do NOT re-report:** the uid-copy form (RM says copy the
+object_id GUID only; ITS-REST says copy the full 3-part id) is AMB-65
+(ambiguities.yaml:1646, disposition report_only, upstream UPR-29); the server
+stamps the FULL OBJECT_VERSION_ID in `versioning/change.rs:448
+stamp_version_uid`, cited correctly.
+
+**Conformant, verified:** all 5 PATHABLE spec functions + parent exist in
+`crates/openehr-rm/src/paths.rs` (:755/:779/:786/:793/:802/:823) over the
+canonical-JSON tree, consumed at `service/ehr/uri.rs:106`. No
+identical-content refusal on update (Version Detection prose satisfied);
+`reject_duplicate_persistent` (validation.rs:39) is create-only + CNF-derived.
+feeder_audit survives storage (not a structure type → stays inline in the
+node `data` fragment, `storage/codec.rs`) and is not pinned across versions
+(`check_versioned_composition_invariants` :239 pins only archetype_node_id +
+is_persistent).
+
+**Coverage gaps:** no CNF case commits canonical JSON carrying feeder_audit
+(only `simplified_formats/SF-MAP-events_audit.yaml` via FLAT at content[0], and
+`composition/…null_empty_absent.yaml` asserts ABSENCE); no case commits a new
+version with unchanged content; no case with feeder_audit at CLUSTER/ELEMENT
+granularity.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,36 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Added
+
+- **New conformance cases for the LOCATABLE root rules and the feeder-system
+  audit.** The catalogue now pins the two refusals above from the wire side
+  (a COMPOSITION root whose `archetype_node_id` contradicts its ARCHETYPED
+  block; a COMPOSITION carrying an empty `links` list), and four cases cover
+  `FEEDER_AUDIT` end to end: a commit carrying audits at the COMPOSITION root
+  *and* on an interior data node round-trips every modelled attribute
+  (identifiers, inline `original_content`, both system audits, and the
+  originating audit's `other_details`), an update that retains the feeder
+  audit keeps it on the new version, an update that drops it is accepted and
+  does not carry it forward, and an update whose content is identical to the
+  preceding version still creates version 2.
+
+### Fixed
+
+- **Compositions and directories that contradict the RM's archetype-root rule
+  are now refused (422) instead of stored.** At an archetype root the
+  `archetype_node_id` is the archetype identifier in string form, so a node
+  carrying `archetype_details` whose `archetype_id` names a *different*
+  archetype declares two conflicting identities and can no longer be
+  committed. Payloads that were accepted before and are affected by this must
+  correct the mismatched root before they will commit.
+
+- **A present-but-empty `links` list is now refused (422).** `links` is
+  optional, but the RM forbids it from being present and empty, so
+  `"links": []` on any node of a committed COMPOSITION — or on any FOLDER of
+  a committed directory — is now rejected rather than stored. Omit the
+  attribute instead of sending an empty array.
+
 ## [3.17.1] - 2026-08-01
 
 ### Added

--- a/app/ferroehr/src/extensions/fhir/feeder_audit.rs
+++ b/app/ferroehr/src/extensions/fhir/feeder_audit.rs
@@ -4,13 +4,16 @@
 //! FHIR↔openEHR mapping — our own design/extension). **This submodule,
 //! however, builds RM-typed data**: the `FEEDER_AUDIT` /
 //! `FEEDER_AUDIT_DETAILS` provenance stamped on the imported COMPOSITION. That
-//! shape is governed by **RM common `feeder_audit`** (`FEEDER_AUDIT`,
+//! shape is governed by **RM common `FEEDER_AUDIT`** (`FEEDER_AUDIT`,
 //! `FEEDER_AUDIT_DETAILS.system_id`/`time`/`version_id`,
-//! `originating_system_item_ids: List<DV_IDENTIFIER>`) —
-//! `docs/specs/openehr/RM/docs/common/feeder_audit.adoc`; the `DV_IDENTIFIER`
-//! shape (with its `Id_valid` non-empty-id invariant) is RM `data_types`
-//! `DV_IDENTIFIER`. (master14's *integration* model is archetype-level and does
-//! not govern this builder; the RM `FEEDER_AUDIT` types do.)
+//! `originating_system_item_ids: List<DV_IDENTIFIER>`) — the class shape at
+//! `docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.common.feeder_audit.adoc`
+//! and `…org.openehr.rm.common.feeder_audit_details.adoc`, the semantics at
+//! `docs/specs/openehr/RM/docs/common/master03-archetyped_package.adoc`
+//! §Feeder System Audit; the `DV_IDENTIFIER` shape (with its `Id_valid`
+//! non-empty-id invariant) is RM `data_types` `DV_IDENTIFIER`. (master14's
+//! *integration* model is archetype-level and does not govern this builder;
+//! the RM `FEEDER_AUDIT` types do.)
 //!
 //! Gate: the connector's inbound routes are config-gated in `ferroehr-rest`;
 //! this builder only runs on the ingest path.

--- a/app/ferroehr/src/service/ehr/validation.rs
+++ b/app/ferroehr/src/service/ehr/validation.rs
@@ -572,6 +572,17 @@ pub(in crate::service) fn validate_ehr_access(access: &Value) -> Result<(), Serv
 ///   Compositions, only references to them" (master04 §Folders): a member must
 ///   carry `id` + `namespace` + `type`, and a LOCATABLE-by-value payload is
 ///   rejected;
+/// - `links`, when present, is non-empty (`LOCATABLE.Links_valid`:
+///   `links /= Void implies not links.is_empty`, RM common
+///   `org.openehr.rm.common.locatable.adoc` §Invariants);
+/// - a node carrying `archetype_details` is an archetype root, so its
+///   `archetype_node_id` is the stringified `archetype_details.archetype_id`
+///   (RM common `org.openehr.rm.common.locatable.adoc` §Attributes: "At an
+///   archetype root point, the value of this attribute is always the
+///   stringified form of the `archetype_id` found in the `archetype_details`
+///   object"; RM common `master03-archetyped_package.adoc` §The LOCATABLE
+///   Class). `archetype_details` itself stays OPTIONAL on a FOLDER — the RM
+///   types it 0..1 and FOLDER carries no `Is_archetype_root` invariant;
 /// - `folders` members recurse.
 ///
 /// # Errors
@@ -596,14 +607,35 @@ pub(in crate::service) fn validate_folder(folder: &Value) -> Result<(), ServiceE
                 "{path}: FOLDER.name is mandatory (LOCATABLE.name 1..1)"
             )));
         }
-        if obj
-            .get("archetype_node_id")
-            .and_then(Value::as_str)
-            .is_none_or(str::is_empty)
-        {
+        let node_id = obj.get("archetype_node_id").and_then(Value::as_str);
+        let Some(node_id) = node_id.filter(|s| !s.is_empty()) else {
             return Err(unproc(format!(
                 "{path}: FOLDER.archetype_node_id is mandatory and non-empty \
                  (LOCATABLE.Archetype_node_id_valid)"
+            )));
+        };
+        if obj
+            .get("links")
+            .and_then(Value::as_array)
+            .is_some_and(Vec::is_empty)
+        {
+            return Err(unproc(format!(
+                "{path}: FOLDER.links is present but empty — a present list must be \
+                 non-empty (LOCATABLE.Links_valid)"
+            )));
+        }
+        if let Some(archetype_id) = obj
+            .get("archetype_details")
+            .and_then(|d| d.get("archetype_id"))
+            .and_then(|a| a.get("value"))
+            .and_then(Value::as_str)
+            && archetype_id != node_id
+        {
+            return Err(unproc(format!(
+                "{path}: archetype root archetype_node_id {node_id:?} is not the \
+                 stringified archetype_details.archetype_id {archetype_id:?} — at an \
+                 archetype root the two are always the same value \
+                 (LOCATABLE.archetype_node_id)"
             )));
         }
         if let Some(items) = obj.get("items").and_then(Value::as_array) {
@@ -872,5 +904,73 @@ mod tests {
         bad["folders"][0].as_object_mut().unwrap().remove("name");
         let err = validate_folder(&bad).expect_err("nameless sub-folder rejected");
         assert!(err.to_string().contains("name"), "got {err}");
+    }
+
+    /// A minimal valid FOLDER tree the LOCATABLE-rule tests below perturb.
+    fn folder_fixture() -> Value {
+        json!({
+            "_type": "FOLDER",
+            "name": { "_type": "DV_TEXT", "value": "root" },
+            "archetype_node_id": "openEHR-EHR-FOLDER.generic.v1",
+            "archetype_details": {
+                "_type": "ARCHETYPED",
+                "archetype_id": { "_type": "ARCHETYPE_ID",
+                                  "value": "openEHR-EHR-FOLDER.generic.v1" },
+                "rm_version": "1.2.0"
+            },
+            "folders": [{
+                "_type": "FOLDER",
+                "name": { "_type": "DV_TEXT", "value": "sub" },
+                "archetype_node_id": "at0001"
+            }]
+        })
+    }
+
+    /// `LOCATABLE.Links_valid` (`links /= Void implies not links.is_empty`,
+    /// RM common `org.openehr.rm.common.locatable.adoc` §Invariants): a
+    /// present-but-empty `links` list on any FOLDER node is refused; a
+    /// non-empty one is accepted.
+    #[test]
+    fn folder_links_present_must_be_non_empty() {
+        validate_folder(&folder_fixture()).expect("the baseline folder tree is valid");
+
+        let mut bad = folder_fixture();
+        bad["folders"][0]
+            .as_object_mut()
+            .unwrap()
+            .insert("links".into(), json!([]));
+        let err = validate_folder(&bad).expect_err("an empty links list must be rejected");
+        assert!(err.to_string().contains("Links_valid"), "got {err}");
+
+        let mut good = folder_fixture();
+        good["folders"][0].as_object_mut().unwrap().insert(
+            "links".into(),
+            json!([{
+                "_type": "LINK",
+                "meaning": { "_type": "DV_TEXT", "value": "follow up" },
+                "type": { "_type": "DV_TEXT", "value": "issue" },
+                "target": { "_type": "DV_EHR_URI", "value": "ehr://example/x" }
+            }]),
+        );
+        validate_folder(&good).expect("a non-empty links list is valid");
+    }
+
+    /// RM common `org.openehr.rm.common.locatable.adoc` §Attributes
+    /// (`archetype_node_id`): at an archetype root the node id is the
+    /// stringified `archetype_details.archetype_id`. A FOLDER without
+    /// `archetype_details` stays valid — the attribute is 0..1.
+    #[test]
+    fn folder_archetype_root_node_id_must_match_details() {
+        let mut bad = folder_fixture();
+        bad["archetype_details"]["archetype_id"]["value"] = json!("openEHR-EHR-FOLDER.other.v1");
+        let err = validate_folder(&bad).expect_err("a contradicting root identity is rejected");
+        assert!(
+            err.to_string().contains("LOCATABLE.archetype_node_id"),
+            "got {err}"
+        );
+
+        let mut without = folder_fixture();
+        without.as_object_mut().unwrap().remove("archetype_details");
+        validate_folder(&without).expect("archetype_details stays optional on a FOLDER");
     }
 }

--- a/crates/openehr-its/src/flat/validation/mod.rs
+++ b/crates/openehr-its/src/flat/validation/mod.rs
@@ -614,6 +614,22 @@ struct Validator {
     bindings: Vec<ConstraintBindingCheck>,
 }
 
+/// The present-but-empty state of the attribute-keyed RM list invariants, read
+/// once per node by [`Validator::rm_invariant_pass`] and handed to
+/// [`Validator::check_nonempty_lists`] (an absent list and a present-empty list
+/// are indistinguishable after typed deserialize, so the distinction only
+/// exists at the JSON level).
+#[derive(Clone, Copy, Debug, Default)]
+struct NonEmptyListFlags {
+    /// `DV_TEXT.mappings` is present as an empty array (`Mappings_valid`).
+    mappings_empty: bool,
+    /// `DV_ORDERED.other_reference_ranges` is present as an empty array
+    /// (`Other_reference_ranges_validity`).
+    reference_ranges_empty: bool,
+    /// `LOCATABLE.links` is present as an empty array (`Links_valid`).
+    links_empty: bool,
+}
+
 impl Validator {
     fn push(&mut self, path: impl Into<String>, message: impl Into<String>, kind: ValidationKind) {
         self.out.push(ValidationMessage {
@@ -646,17 +662,26 @@ impl Validator {
         let mut ty: Option<&str> = None;
         let mut node_id: Option<&str> = None;
         let mut has_archetype_details = false;
+        let mut details_archetype_id: Option<&str> = None;
         let mut mappings_empty = false;
         let mut reference_ranges_empty = false;
+        let mut links_empty = false;
         for (k, val) in obj {
             match k.as_str() {
                 "_type" => ty = val.as_str(),
                 "archetype_node_id" => node_id = val.as_str(),
-                "archetype_details" => has_archetype_details = !val.is_null(),
+                "archetype_details" => {
+                    has_archetype_details = !val.is_null();
+                    details_archetype_id = val
+                        .get("archetype_id")
+                        .and_then(|a| a.get("value"))
+                        .and_then(Value::as_str);
+                }
                 "mappings" => mappings_empty = val.as_array().is_some_and(Vec::is_empty),
                 "other_reference_ranges" => {
                     reference_ranges_empty = val.as_array().is_some_and(Vec::is_empty);
                 }
+                "links" => links_empty = val.as_array().is_some_and(Vec::is_empty),
                 _ => {}
             }
         }
@@ -683,8 +708,17 @@ impl Validator {
                 self.push(p, iv.message, ValidationKind::Invariant);
             }
         }
-        self.check_archetyped_valid(node_id, has_archetype_details, path);
-        self.check_nonempty_lists(obj, ty, mappings_empty, reference_ranges_empty, path);
+        self.check_archetyped_valid(node_id, has_archetype_details, details_archetype_id, path);
+        self.check_nonempty_lists(
+            obj,
+            ty,
+            NonEmptyListFlags {
+                mappings_empty,
+                reference_ranges_empty,
+                links_empty,
+            },
+            path,
+        );
         self.check_data_structure_shapes(obj, ty, path);
         for (k, val) in obj {
             if k.starts_with('_') {
@@ -725,13 +759,26 @@ impl Validator {
     /// `is_archetype_root` from `archetype_details` presence (making that reading
     /// tautological), and the CNF's own valid data sets + the canonical-JSON
     /// corpus systematically omit `archetype_details` on nested archetype roots
-    /// (182 occurrences measured); the CNF fixtures win over a prose reading that
-    /// would reject them (`.claude/rules/spec-adherence.md`). The COMPOSITION root
+    /// (182 occurrences measured); the released reference data sets win over a
+    /// prose reading that would reject them. The COMPOSITION root
     /// arm stays separately enforced (`composition_impl.rs` `Is_archetype_root`).
+    ///
+    /// The second arm is the root node-id **identity** rule: a node that DOES
+    /// carry `archetype_details` is an archetype root, and
+    /// `RM/docs/UML/classes/org.openehr.rm.common.locatable.adoc`
+    /// §Attributes (`archetype_node_id`) fixes its value verbatim — "At an
+    /// archetype root point, the value of this attribute is always the
+    /// stringified form of the `archetype_id` found in the `archetype_details`
+    /// object" (restated in `RM/docs/common/master03-archetyped_package.adoc`
+    /// §The LOCATABLE Class: "the only exception is at archetype root points in
+    /// data, where `archetype_node_id` carries the archetype identifier in
+    /// string form"). A root whose two archetype identities disagree names no
+    /// resolvable generating archetype.
     fn check_archetyped_valid(
         &mut self,
         node_id: Option<&str>,
         has_archetype_details: bool,
+        details_archetype_id: Option<&str>,
         path: &str,
     ) {
         let Some(node_id) = node_id else {
@@ -751,6 +798,19 @@ impl Validator {
                 ValidationKind::Invariant,
             );
         }
+        if let Some(archetype_id) = details_archetype_id
+            && archetype_id != node_id
+        {
+            self.push(
+                norm_path(path),
+                format!(
+                    "archetype root archetype_node_id {node_id:?} is not the stringified \
+                     archetype_details.archetype_id {archetype_id:?} — at an archetype root \
+                     the two are always the same value (LOCATABLE.archetype_node_id)"
+                ),
+                ValidationKind::Invariant,
+            );
+        }
     }
 
     /// The RM's "present implies non-empty" list invariants, checkable only at
@@ -763,13 +823,13 @@ impl Validator {
     /// - `SECTION.Items_valid` (`section.adoc`);
     /// - `ENTRY.Other_participations_valid` (`entry.adoc`, every concrete
     ///   ENTRY subtype);
-    /// - `INSTRUCTION.Activities_valid` (`instruction.adoc`).
+    /// - `INSTRUCTION.Activities_valid` (`instruction.adoc`);
+    /// - `LOCATABLE.Links_valid` (`locatable.adoc`), attribute-keyed.
     fn check_nonempty_lists(
         &mut self,
         obj: &Map<String, Value>,
         ty: Option<&str>,
-        mappings_empty: bool,
-        reference_ranges_empty: bool,
+        flags: NonEmptyListFlags,
         path: &str,
     ) {
         const RULES: &[(&str, &str, &str)] = &[
@@ -810,16 +870,19 @@ impl Validator {
         ];
         // Attribute-keyed rules that apply on ANY node carrying the attribute
         // (like the terminology pass's null_flavour handling):
-        // `DV_TEXT.Mappings_valid` and `DV_ORDERED.Other_reference_ranges_validity`
-        // (`dv_text.adoc` / `dv_ordered.adoc`) — no other RM attribute shares
-        // these names.
+        // `DV_TEXT.Mappings_valid`, `DV_ORDERED.Other_reference_ranges_validity`
+        // and `LOCATABLE.Links_valid` (`links /= Void implies not
+        // links.is_empty` — `locatable.adoc` §Invariants; every archetyped RM
+        // node inherits it, so it is keyed on the attribute rather than on a
+        // class list) — no other RM attribute shares these names.
         for (attr, invariant, is_empty) in [
-            ("mappings", "Mappings_valid", mappings_empty),
+            ("mappings", "Mappings_valid", flags.mappings_empty),
             (
                 "other_reference_ranges",
                 "Other_reference_ranges_validity",
-                reference_ranges_empty,
+                flags.reference_ranges_empty,
             ),
+            ("links", "Links_valid", flags.links_empty),
         ] {
             if is_empty {
                 self.push(
@@ -2772,6 +2835,114 @@ mod tests {
                 .any(|m| m.message.contains("at0013")),
             "the residual instance is still closed-world checked against the \
              unqualified overlay"
+        );
+    }
+
+    // ── LOCATABLE root identity + Links_valid (RM invariant pass) ─────────────
+
+    /// Run only pass 1 (the RM class invariants over the whole instance).
+    fn rm_only(instance: &Value) -> Vec<ValidationMessage> {
+        let mut v = Validator::default();
+        v.rm_invariant_pass(instance, &mut String::new(), Some("COMPOSITION"));
+        v.out
+    }
+
+    /// A minimal archetype-root node carrying an ARCHETYPED block, used to
+    /// isolate the `LOCATABLE` root/link rules from every other invariant.
+    fn root_node(node_id: &str, archetype_id: &str) -> Value {
+        json!({
+            "_type": "SECTION",
+            "name": { "_type": "DV_TEXT", "value": "s" },
+            "archetype_node_id": node_id,
+            "archetype_details": {
+                "_type": "ARCHETYPED",
+                "archetype_id": { "_type": "ARCHETYPE_ID", "value": archetype_id },
+                "rm_version": "1.2.0"
+            },
+            "items": [{
+                "_type": "OBSERVATION", "archetype_node_id": "at0001",
+                "name": { "_type": "DV_TEXT", "value": "o" }
+            }]
+        })
+    }
+
+    /// `RM/docs/UML/classes/org.openehr.rm.common.locatable.adoc` §Attributes
+    /// (`archetype_node_id`): "At an archetype root point, the value of this
+    /// attribute is always the stringified form of the `archetype_id` found in
+    /// the `archetype_details` object" — a root whose two archetype identities
+    /// disagree is refused.
+    #[test]
+    fn archetype_root_node_id_mismatch_rejected() {
+        let inst = root_node(
+            "openEHR-EHR-SECTION.other.v1",
+            "openEHR-EHR-SECTION.adhoc.v1",
+        );
+        let msgs = rm_only(&inst);
+        assert!(
+            msgs.iter().any(|m| m.kind == ValidationKind::Invariant
+                && m.message.contains("LOCATABLE.archetype_node_id")),
+            "expected a root node-id identity violation, got {msgs:?}"
+        );
+    }
+
+    /// The accepting twin: the same root whose `archetype_node_id` IS the
+    /// stringified `archetype_details.archetype_id` raises no identity finding.
+    #[test]
+    fn archetype_root_node_id_match_accepted() {
+        let inst = root_node(
+            "openEHR-EHR-SECTION.adhoc.v1",
+            "openEHR-EHR-SECTION.adhoc.v1",
+        );
+        let msgs = rm_only(&inst);
+        assert!(
+            !msgs
+                .iter()
+                .any(|m| m.message.contains("LOCATABLE.archetype_node_id")),
+            "a matching root must not violate the node-id identity rule: {msgs:?}"
+        );
+    }
+
+    /// `locatable.adoc` §Invariants `Links_valid`: `links /= Void implies not
+    /// links.is_empty` — a present-but-empty `links` list is refused on ANY
+    /// LOCATABLE node (the invariant is inherited, so the rule is
+    /// attribute-keyed).
+    #[test]
+    fn links_present_but_empty_rejected() {
+        let mut inst = root_node(
+            "openEHR-EHR-SECTION.adhoc.v1",
+            "openEHR-EHR-SECTION.adhoc.v1",
+        );
+        inst.as_object_mut()
+            .expect("root object")
+            .insert("links".into(), json!([]));
+        let msgs = rm_only(&inst);
+        assert!(
+            msgs.iter()
+                .any(|m| m.kind == ValidationKind::Invariant && m.message.contains("Links_valid")),
+            "expected a Links_valid violation, got {msgs:?}"
+        );
+    }
+
+    /// The accepting twin: a non-empty `links` list satisfies `Links_valid`.
+    #[test]
+    fn links_non_empty_accepted() {
+        let mut inst = root_node(
+            "openEHR-EHR-SECTION.adhoc.v1",
+            "openEHR-EHR-SECTION.adhoc.v1",
+        );
+        inst.as_object_mut().expect("root object").insert(
+            "links".into(),
+            json!([{
+                "_type": "LINK",
+                "meaning": { "_type": "DV_TEXT", "value": "follow up" },
+                "type": { "_type": "DV_TEXT", "value": "issue" },
+                "target": { "_type": "DV_EHR_URI", "value": "ehr://example/x" }
+            }]),
+        );
+        let msgs = rm_only(&inst);
+        assert!(
+            !msgs.iter().any(|m| m.message.contains("Links_valid")),
+            "a non-empty links list must not violate Links_valid: {msgs:?}"
         );
     }
 

--- a/crates/openehr-its/tests/it/validation.rs
+++ b/crates/openehr-its/tests/it/validation.rs
@@ -140,7 +140,16 @@ fn kinds(msgs: &[ValidationMessage]) -> Vec<ValidationKind> {
 ///   (pk_fraction), precision: 1}`: invalid under RM `data_types`
 ///   `dv_proportion` `Fraction_validity` ("(type = `pk_fraction` or type =
 ///   `pk_integer_fraction`) implies `is_integral`", with `is_integral()` =
-///   "True ... if precision is 0").
+///   "True ... if precision is 0"). It ALSO violates the archetype-root
+///   node-id identity rule: its `/content[0]` ACTION carries an `ARCHETYPED`
+///   block copied from the COMPOSITION root, so `archetype_node_id` differs
+///   from `archetype_details.archetype_id.value` (RM
+///   `org.openehr.rm.common.locatable.adoc` §Attributes,
+///   `archetype_node_id`).
+/// - `informe_amb_1_arquetip_OBS.json` — the same root-copied `ARCHETYPED`
+///   defect on its `/content[0]` OBSERVATION (an
+///   `openEHR-EHR-COMPOSITION.*` `archetype_id` claimed by a non-COMPOSITION
+///   node), violating the same identity rule.
 const CLEAN_COMPOSITIONS: &[&str] = &[
     "choice_validation_test.json",
     "compo_corona.json",

--- a/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
+++ b/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
@@ -132,6 +132,40 @@ cnf.composition.minimal_event.invalid_structure:
     spec_ref: "RM ehr (EVALUATION.data is mandatory, 1..1)"
   template_id: "minimal_evaluation.en.v1"
   provenance: "derived 2026-07-21 by removing the mandatory EVALUATION.data from the real v1 payload (RM ehr: EVALUATION.data 1..1)"
+cnf.composition.minimal_event.root_archetype_id_mismatch:
+  source: fixtures/composition/minimal_event.root_archetype_id_mismatch.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "the root archetype_node_id is not the stringified archetype_details.archetype_id"
+    spec_ref: "RM common locatable.adoc §Attributes (archetype_node_id: \"At an archetype root point, the value of this attribute is always the stringified form of the archetype_id found in the archetype_details object\"); RM common master03-archetyped_package.adoc §The LOCATABLE Class"
+  template_id: "minimal_evaluation.en.v1"
+  provenance: "derived 2026-08-01 from cnf.composition.minimal_event.v1 by changing the root archetype_node_id to openEHR-EHR-COMPOSITION.other.v1 while leaving the ARCHETYPED block naming openEHR-EHR-COMPOSITION.minimal.v1 — one string changed, so the refusal isolates the root node-id identity rule; the invalid twin of the valid cnf.composition.minimal_event.v1"
+cnf.composition.minimal_event.links_empty:
+  source: fixtures/composition/minimal_event.links_empty.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "LOCATABLE.links is present as an empty list at the COMPOSITION root"
+    spec_ref: "RM common locatable.adoc §Invariants (Links_valid: links /= Void implies not links.is_empty)"
+  template_id: "minimal_evaluation.en.v1"
+  provenance: "derived 2026-08-01 from cnf.composition.minimal_event.v1 by adding an explicit empty links list at the root; everything else valid, so the refusal isolates Links_valid"
+cnf.composition.minimal_event.feeder_audit.v1:
+  source: fixtures/composition/minimal_event.feeder_audit.v1.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity: { verdict: valid }
+  template_id: "minimal_evaluation.en.v1"
+  provenance: "derived 2026-08-01 from cnf.composition.minimal_event.v1 by attaching FEEDER_AUDIT at the COMPOSITION root and a second one on the interior ELEMENT — the granularity RM common master03-archetyped_package.adoc §Structural Correspondence describes (\"separate FEEDER_AUDIT objects may need to be generated for parts of a Composition\"). The root instance populates every modelled FEEDER_AUDIT attribute: originating_system_item_ids, an inline original_content DV_PARSABLE (§Original Content: \"allows the original content item itself to be either included inline or pointed to\"), originating_system_audit and feeder_system_audit, the former carrying FEEDER_AUDIT_DETAILS.other_details as a small ITEM_TREE (\"Optional attribute to carry any custom meta-data\", feeder_audit_details.adoc §Attributes)"
+cnf.composition.minimal_event.feeder_audit.v2:
+  source: fixtures/composition/minimal_event.feeder_audit.v2.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity: { verdict: valid }
+  template_id: "minimal_evaluation.en.v1"
+  provenance: "the v2 content state of cnf.composition.minimal_event.feeder_audit.v1 — cnf.composition.minimal_event.v2 carrying the identical FEEDER_AUDIT pair, so an update can prove the feeder audit is RETAINED across versioning (RM common master03-archetyped_package.adoc §Structural Correspondence: \"when a new version is created, the feeder information is retained as part of the current version\")"
 cnf.composition.minimal_event.territory_invalid:
   source: fixtures/composition/minimal_event.territory_invalid.json
   format: canonical-json

--- a/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_event.feeder_audit.v1.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_event.feeder_audit.v1.json
@@ -1,0 +1,223 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "archetype_id": {
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "value": "minimal_evaluation.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "feeder_audit": {
+    "_type": "FEEDER_AUDIT",
+    "originating_system_item_ids": [
+      {
+        "_type": "DV_IDENTIFIER",
+        "issuer": "Lab Uruguay",
+        "assigner": "Lab Uruguay",
+        "id": "ACC-2021-0917",
+        "type": "accession"
+      }
+    ],
+    "original_content": {
+      "_type": "DV_PARSABLE",
+      "value": "MSH|^~\\&|LAB|URY|CDR|URY|20210921215231||ORU^R01|MSG0001|P|2.5",
+      "formalism": "HL7v2.5"
+    },
+    "originating_system_audit": {
+      "_type": "FEEDER_AUDIT_DETAILS",
+      "system_id": "lab.example.org",
+      "time": {
+        "value": "2021-09-21T21:50:00-03:00"
+      },
+      "version_id": "final",
+      "other_details": {
+        "_type": "ITEM_TREE",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "feeder meta-data"
+        },
+        "archetype_node_id": "at0000",
+        "items": [
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "order id"
+            },
+            "archetype_node_id": "at0001",
+            "value": {
+              "_type": "DV_TEXT",
+              "value": "PLC-77421"
+            }
+          }
+        ]
+      }
+    },
+    "feeder_system_audit": {
+      "_type": "FEEDER_AUDIT_DETAILS",
+      "system_id": "gateway.example.org",
+      "time": {
+        "value": "2021-09-21T21:51:00-03:00"
+      }
+    }
+  },
+  "language": {
+    "terminology_id": {
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "terminology_id": {
+      "value": "ISO_3166-1"
+    },
+    "code_string": "UY"
+  },
+  "category": {
+    "value": "event",
+    "defining_code": {
+      "terminology_id": {
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "external_ref": {
+      "id": {
+        "_type": "HIER_OBJECT_ID",
+        "value": "fc376c46-29c1-4090-bc01-5cc046af7f26"
+      },
+      "namespace": "DEMOGRAPHIC",
+      "type": "PERSON"
+    },
+    "name": "Dr. House"
+  },
+  "context": {
+    "start_time": {
+      "value": "2021-09-21T21:52:31.927-03:00"
+    },
+    "setting": {
+      "value": "primary medical care",
+      "defining_code": {
+        "terminology_id": {
+          "value": "openehr"
+        },
+        "code_string": "228"
+      }
+    },
+    "participations": [
+      {
+        "function": {
+          "value": "legal guardian consent author"
+        },
+        "performer": {
+          "_type": "PARTY_RELATED",
+          "name": "Alexandra Alamo",
+          "relationship": {
+            "value": "mother",
+            "defining_code": {
+              "terminology_id": {
+                "value": "openehr"
+              },
+              "code_string": "10"
+            }
+          }
+        },
+        "mode": {
+          "value": "not specified",
+          "defining_code": {
+            "terminology_id": {
+              "value": "openehr"
+            },
+            "code_string": "193"
+          }
+        }
+      }
+    ]
+  },
+  "content": [
+    {
+      "_type": "EVALUATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Minimal"
+      },
+      "archetype_details": {
+        "archetype_id": {
+          "value": "openEHR-EHR-EVALUATION.minimal.v1"
+        },
+        "template_id": {
+          "value": "minimal_evaluation.en.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "archetype_node_id": "openEHR-EHR-EVALUATION.minimal.v1",
+      "language": {
+        "terminology_id": {
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "terminology_id": {
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "ITEM_TREE",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Arbol"
+        },
+        "archetype_node_id": "at0001",
+        "items": [
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "quantity"
+            },
+            "archetype_node_id": "at0002",
+            "value": {
+              "_type": "DV_QUANTITY",
+              "magnitude": 78.5,
+              "units": "kg"
+            },
+            "feeder_audit": {
+              "_type": "FEEDER_AUDIT",
+              "originating_system_item_ids": [
+                {
+                  "_type": "DV_IDENTIFIER",
+                  "issuer": "Lab Uruguay",
+                  "assigner": "Lab Uruguay",
+                  "id": "OBX-1",
+                  "type": "observation"
+                }
+              ],
+              "originating_system_audit": {
+                "_type": "FEEDER_AUDIT_DETAILS",
+                "system_id": "lab.example.org",
+                "time": {
+                  "value": "2021-09-21T21:50:00-03:00"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_event.feeder_audit.v2.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_event.feeder_audit.v2.json
@@ -1,0 +1,223 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "archetype_id": {
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "value": "minimal_evaluation.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "feeder_audit": {
+    "_type": "FEEDER_AUDIT",
+    "originating_system_item_ids": [
+      {
+        "_type": "DV_IDENTIFIER",
+        "issuer": "Lab Uruguay",
+        "assigner": "Lab Uruguay",
+        "id": "ACC-2021-0917",
+        "type": "accession"
+      }
+    ],
+    "original_content": {
+      "_type": "DV_PARSABLE",
+      "value": "MSH|^~\\&|LAB|URY|CDR|URY|20210921215231||ORU^R01|MSG0001|P|2.5",
+      "formalism": "HL7v2.5"
+    },
+    "originating_system_audit": {
+      "_type": "FEEDER_AUDIT_DETAILS",
+      "system_id": "lab.example.org",
+      "time": {
+        "value": "2021-09-21T21:50:00-03:00"
+      },
+      "version_id": "final",
+      "other_details": {
+        "_type": "ITEM_TREE",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "feeder meta-data"
+        },
+        "archetype_node_id": "at0000",
+        "items": [
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "order id"
+            },
+            "archetype_node_id": "at0001",
+            "value": {
+              "_type": "DV_TEXT",
+              "value": "PLC-77421"
+            }
+          }
+        ]
+      }
+    },
+    "feeder_system_audit": {
+      "_type": "FEEDER_AUDIT_DETAILS",
+      "system_id": "gateway.example.org",
+      "time": {
+        "value": "2021-09-21T21:51:00-03:00"
+      }
+    }
+  },
+  "language": {
+    "terminology_id": {
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "terminology_id": {
+      "value": "ISO_3166-1"
+    },
+    "code_string": "UY"
+  },
+  "category": {
+    "value": "event",
+    "defining_code": {
+      "terminology_id": {
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "external_ref": {
+      "id": {
+        "_type": "HIER_OBJECT_ID",
+        "value": "fc376c46-29c1-4090-bc01-5cc046af7f26"
+      },
+      "namespace": "DEMOGRAPHIC",
+      "type": "PERSON"
+    },
+    "name": "Dr. House"
+  },
+  "context": {
+    "start_time": {
+      "value": "2021-09-21T21:52:31.927-03:00"
+    },
+    "setting": {
+      "value": "primary medical care",
+      "defining_code": {
+        "terminology_id": {
+          "value": "openehr"
+        },
+        "code_string": "228"
+      }
+    },
+    "participations": [
+      {
+        "function": {
+          "value": "legal guardian consent author"
+        },
+        "performer": {
+          "_type": "PARTY_RELATED",
+          "name": "Alexandra Alamo",
+          "relationship": {
+            "value": "mother",
+            "defining_code": {
+              "terminology_id": {
+                "value": "openehr"
+              },
+              "code_string": "10"
+            }
+          }
+        },
+        "mode": {
+          "value": "not specified",
+          "defining_code": {
+            "terminology_id": {
+              "value": "openehr"
+            },
+            "code_string": "193"
+          }
+        }
+      }
+    ]
+  },
+  "content": [
+    {
+      "_type": "EVALUATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Minimal (updated)"
+      },
+      "archetype_details": {
+        "archetype_id": {
+          "value": "openEHR-EHR-EVALUATION.minimal.v1"
+        },
+        "template_id": {
+          "value": "minimal_evaluation.en.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "archetype_node_id": "openEHR-EHR-EVALUATION.minimal.v1",
+      "language": {
+        "terminology_id": {
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "terminology_id": {
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "ITEM_TREE",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Arbol"
+        },
+        "archetype_node_id": "at0001",
+        "items": [
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "quantity"
+            },
+            "archetype_node_id": "at0002",
+            "value": {
+              "_type": "DV_QUANTITY",
+              "magnitude": 78.5,
+              "units": "kg"
+            },
+            "feeder_audit": {
+              "_type": "FEEDER_AUDIT",
+              "originating_system_item_ids": [
+                {
+                  "_type": "DV_IDENTIFIER",
+                  "issuer": "Lab Uruguay",
+                  "assigner": "Lab Uruguay",
+                  "id": "OBX-1",
+                  "type": "observation"
+                }
+              ],
+              "originating_system_audit": {
+                "_type": "FEEDER_AUDIT_DETAILS",
+                "system_id": "lab.example.org",
+                "time": {
+                  "value": "2021-09-21T21:50:00-03:00"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_event.links_empty.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_event.links_empty.json
@@ -1,0 +1,151 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "archetype_id": {
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "value": "minimal_evaluation.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "links": [],
+  "language": {
+    "terminology_id": {
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "terminology_id": {
+      "value": "ISO_3166-1"
+    },
+    "code_string": "UY"
+  },
+  "category": {
+    "value": "event",
+    "defining_code": {
+      "terminology_id": {
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "external_ref": {
+      "id": {
+        "_type": "HIER_OBJECT_ID",
+        "value": "fc376c46-29c1-4090-bc01-5cc046af7f26"
+      },
+      "namespace": "DEMOGRAPHIC",
+      "type": "PERSON"
+    },
+    "name": "Dr. House"
+  },
+  "context": {
+    "start_time": {
+      "value": "2021-09-21T21:52:31.927-03:00"
+    },
+    "setting": {
+      "value": "primary medical care",
+      "defining_code": {
+        "terminology_id": {
+          "value": "openehr"
+        },
+        "code_string": "228"
+      }
+    },
+    "participations": [
+      {
+        "function": {
+          "value": "legal guardian consent author"
+        },
+        "performer": {
+          "_type": "PARTY_RELATED",
+          "name": "Alexandra Alamo",
+          "relationship": {
+            "value": "mother",
+            "defining_code": {
+              "terminology_id": {
+                "value": "openehr"
+              },
+              "code_string": "10"
+            }
+          }
+        },
+        "mode": {
+          "value": "not specified",
+          "defining_code": {
+            "terminology_id": {
+              "value": "openehr"
+            },
+            "code_string": "193"
+          }
+        }
+      }
+    ]
+  },
+  "content": [
+    {
+      "_type": "EVALUATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Minimal"
+      },
+      "archetype_details": {
+        "archetype_id": {
+          "value": "openEHR-EHR-EVALUATION.minimal.v1"
+        },
+        "template_id": {
+          "value": "minimal_evaluation.en.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "archetype_node_id": "openEHR-EHR-EVALUATION.minimal.v1",
+      "language": {
+        "terminology_id": {
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "terminology_id": {
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "ITEM_TREE",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Arbol"
+        },
+        "archetype_node_id": "at0001",
+        "items": [
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "quantity"
+            },
+            "archetype_node_id": "at0002",
+            "value": {
+              "_type": "DV_QUANTITY",
+              "magnitude": 78.5,
+              "units": "kg"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_event.root_archetype_id_mismatch.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_event.root_archetype_id_mismatch.json
@@ -1,0 +1,150 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "archetype_id": {
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "value": "minimal_evaluation.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.other.v1",
+  "language": {
+    "terminology_id": {
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "terminology_id": {
+      "value": "ISO_3166-1"
+    },
+    "code_string": "UY"
+  },
+  "category": {
+    "value": "event",
+    "defining_code": {
+      "terminology_id": {
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "external_ref": {
+      "id": {
+        "_type": "HIER_OBJECT_ID",
+        "value": "fc376c46-29c1-4090-bc01-5cc046af7f26"
+      },
+      "namespace": "DEMOGRAPHIC",
+      "type": "PERSON"
+    },
+    "name": "Dr. House"
+  },
+  "context": {
+    "start_time": {
+      "value": "2021-09-21T21:52:31.927-03:00"
+    },
+    "setting": {
+      "value": "primary medical care",
+      "defining_code": {
+        "terminology_id": {
+          "value": "openehr"
+        },
+        "code_string": "228"
+      }
+    },
+    "participations": [
+      {
+        "function": {
+          "value": "legal guardian consent author"
+        },
+        "performer": {
+          "_type": "PARTY_RELATED",
+          "name": "Alexandra Alamo",
+          "relationship": {
+            "value": "mother",
+            "defining_code": {
+              "terminology_id": {
+                "value": "openehr"
+              },
+              "code_string": "10"
+            }
+          }
+        },
+        "mode": {
+          "value": "not specified",
+          "defining_code": {
+            "terminology_id": {
+              "value": "openehr"
+            },
+            "code_string": "193"
+          }
+        }
+      }
+    ]
+  },
+  "content": [
+    {
+      "_type": "EVALUATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Minimal"
+      },
+      "archetype_details": {
+        "archetype_id": {
+          "value": "openEHR-EHR-EVALUATION.minimal.v1"
+        },
+        "template_id": {
+          "value": "minimal_evaluation.en.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "archetype_node_id": "openEHR-EHR-EVALUATION.minimal.v1",
+      "language": {
+        "terminology_id": {
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "terminology_id": {
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "ITEM_TREE",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Arbol"
+        },
+        "archetype_node_id": "at0001",
+        "items": [
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "quantity"
+            },
+            "archetype_node_id": "at0002",
+            "value": {
+              "_type": "DV_QUANTITY",
+              "magnitude": 78.5,
+              "units": "kg"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/registers/ambiguities.yaml
+++ b/tools/cnf-runner/artifacts/registers/ambiguities.yaml
@@ -7159,3 +7159,62 @@ AMB-175:
     the whole-set reading (created-then-amended: the creation predicate
     answers exactly the first version).
   disposition: fixed_handling
+AMB-176:
+  ambiguity: >-
+    The released RM PRESCRIBES A WIRE VALUE ON AN ATTRIBUTE ITS OWN CLASS MODEL
+    DOES NOT DEFINE. RM common master03-archetyped_package.adoc §Structural
+    Correspondence tells a converter how to mark a node it had to invent:
+    "To indicate synthesis of a data node, a `FEEDER_AUDIT` instance is
+    attached to the `LOCATABLE` in question, and its `_change_type_` set to
+    'synthesised'." The same chapter's §Meta-data lists "type of change, e.g.
+    initial creation, correction ..., logical deletion" among the medico-legal
+    meta-data the feeder-audit model is designed to carry. But RM 1.2.0's
+    class model defines NO `change_type` anywhere on the feeder-audit types:
+    FEEDER_AUDIT has exactly five attributes
+    (`originating_system_item_ids`, `feeder_system_item_ids`,
+    `original_content`, `originating_system_audit`, `feeder_system_audit`) and
+    FEEDER_AUDIT_DETAILS exactly seven (`system_id`, `location`, `subject`,
+    `provider`, `time`, `version_id`, `other_details`) — verified attribute by
+    attribute in the two class tables. The only `change_type` in RM common is
+    `AUDIT_DETAILS.change_type`, which lives on the VERSION commit audit and
+    is unreachable from a LOCATABLE's `feeder_audit`. So the sentence names an
+    attribute that does not exist on the object it names, and there is no
+    released way to express the synthesised marking the chapter mandates.
+    A second, smaller mismatch rides along: the prose spells the value
+    "synthesised" while the openEHR terminology group the only real
+    `change_type` is bound to spells the concept `252|synthesis|` — so even
+    reading the sentence as AUDIT_DETAILS.change_type does not yield a legal
+    rubric.
+  source: >-
+    RM common docs/common/master03-archetyped_package.adoc §Structural
+    Correspondence (the "change_type set to 'synthesised'" sentence) and
+    §Meta-data ("type of change ..."); RM common
+    docs/UML/classes/org.openehr.rm.common.feeder_audit.adoc §Attributes (the
+    five-attribute list, no change_type) and
+    docs/UML/classes/org.openehr.rm.common.feeder_audit_details.adoc
+    §Attributes (the seven-attribute list, no change_type); RM common
+    docs/UML/classes/org.openehr.rm.common.audit_details.adoc §Attributes
+    (`change_type: DV_CODED_TEXT`) + §Invariants (`Change_type_valid`, bound to
+    the openEHR `audit change type` group); TERM
+    docs/SupportTerminology/codesets/openehr_terminology-vocabularies.adoc
+    §Audit Change Type (`| *252* a| synthesis | active`) and
+    docs/SupportTerminology/master04-representation.adoc
+    (`<group openehr_id="audit_change_type" …>` / `<concept id="252"
+    rubric="synthesis"/>`) — contradiction CONFIRMED first-hand.
+  handling: >-
+    Report-only, no gate. The generated RM types mirror the vendored BMM
+    faithfully, so `FEEDER_AUDIT` has no `change_type` member to populate or
+    validate, and inventing one would fork the spec model — exactly what the
+    generated layer exists to prevent. The canonical-JSON reader ignores
+    unknown keys by design (an RM-version-skew tolerance), so a client that
+    follows §Structural Correspondence literally and sends
+    `feeder_audit.change_type` has that member silently dropped: it is not
+    refused, but it is not stored or served either, and no released sentence
+    makes either outcome wrong. No case can gate a behaviour with no
+    released model behind it; the feeder-audit round-trip cases therefore
+    exercise only the five modelled FEEDER_AUDIT attributes. Recording the
+    contradiction upstream is the only sound action — flips to a gating
+    expectation only if a future RM release adds the attribute (or reworks
+    the sentence onto an existing mechanism).
+  disposition: report_only
+  upstream_ref: "TBD"

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-feeder_audit_roundtrip.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-feeder_audit_roundtrip.yaml
@@ -1,0 +1,92 @@
+# FEEDER SYSTEM AUDIT — the whole modelled FEEDER_AUDIT survives a commit.
+#
+# RM common docs/common/master03-archetyped_package.adoc §Structural
+# Correspondence puts the audit on the LOCATABLE rather than the version audit
+# trail and states BOTH the usual and the exceptional granularity: "feeder
+# audit information is attached to the `LOCATABLE` class via the feeder_audit
+# attribute … Its usual usage is to attach it to the outermost object to which
+# it applies … In exceptional cases … separate `FEEDER_AUDIT` objects may need
+# to be generated for parts of a Composition … attached to internal data
+# nodes." The same section states the retention rule this case's committed
+# state establishes: "The Feeder audit information is included as part of the
+# data of the Composition, rather than part of the audit trail of version
+# committal."
+#
+# §Original Content licenses the inline original: "the `_original_content_`
+# attribute allows the original content item itself to be either included
+# inline or pointed to." FEEDER_AUDIT_DETAILS.other_details is "Optional
+# attribute to carry any custom meta-data. May be archetyped."
+# (docs/UML/classes/org.openehr.rm.common.feeder_audit_details.adoc
+# §Attributes), so an ITEM_TREE there is the modelled shape, not an extension.
+#
+# The payload populates every attribute the RM defines on FEEDER_AUDIT — the
+# five of docs/UML/classes/org.openehr.rm.common.feeder_audit.adoc §Attributes
+# (originating_system_item_ids, feeder_system_item_ids, original_content,
+# originating_system_audit, feeder_system_audit) minus feeder_system_item_ids,
+# which the interior instance is deliberately without so the two audits differ.
+# NOTE: master03 §Structural Correspondence also instructs a converter to set a
+# FEEDER_AUDIT `change_type` to "synthesised", an attribute the RM class model
+# does not define on either feeder-audit type — register AMB-176 (report_only);
+# this case therefore asserts only the modelled attributes.
+#
+# One behaviour per case: the commit is a plain valid create; the assertions
+# are all about the feeder-audit content read back at the committed version.
+id: I_EHR_COMPOSITION.create_composition-feeder_audit_roundtrip
+kind: functional
+component: EHR_COMPOSITION
+sm_operation: I_EHR_COMPOSITION.create_composition
+capabilities: [CompositionOps]
+exercises: [EhrApi]
+profiles: [CORE]
+test_purpose: >-
+  A COMPOSITION carrying FEEDER_AUDIT at the root and on an interior data node
+  is committed, and every modelled FEEDER_AUDIT attribute — including the
+  inline original_content and the originating-system audit's other_details —
+  round-trips unchanged on read.
+description: "Commit and read back a COMPOSITION carrying root and interior FEEDER_AUDITs"
+spec_refs:
+  - "RM common master03-archetyped_package §Structural Correspondence"
+  - "RM common master03-archetyped_package §Original Content"
+  - "RM common §FEEDER_AUDIT, §FEEDER_AUDIT_DETAILS"
+  - "SM openehr_platform §I_EHR_COMPOSITION.create_composition"
+applies: { rm: ">=1.0.2" }
+requires:
+  server: any
+  templates: [cnf.opt.minimal_event]
+  ehr: { commits: none }                 # mints ${ehr_id}
+data_sets: [cnf.composition.minimal_event.feeder_audit.v1]
+flow:
+  - step: 1
+    call: create_composition
+    format: canonical-json
+    with:
+      ehr_id: "${ehr_id}"
+      composition: "${ds:cnf.composition.minimal_event.feeder_audit.v1}"
+    expect: created
+    capture: { version_uid: created.version_uid }
+  - step: 2
+    call: get_composition_at_version
+    format: canonical-json
+    with: { ehr_id: "${ehr_id}", version_uid: "${version_uid}" }
+    expect: ok
+    assert:
+      - { assert: instance_of, rm_type: COMPOSITION }
+      # The root FEEDER_AUDIT: identifiers, both system audits, and the inline
+      # original content (master03 §Original Content).
+      - { assert: field, path: "feeder_audit/originating_system_item_ids[0]/id", equals: "ACC-2021-0917" }
+      - { assert: field, path: "feeder_audit/originating_system_audit/system_id", equals: "lab.example.org" }
+      - { assert: field, path: "feeder_audit/originating_system_audit/version_id", equals: "final" }
+      - { assert: field, path: "feeder_audit/feeder_system_audit/system_id", equals: "gateway.example.org" }
+      - { assert: field, path: "feeder_audit/original_content/formalism", equals: "HL7v2.5" }
+      # FEEDER_AUDIT_DETAILS.other_details — "any custom meta-data", here a
+      # small ITEM_TREE whose leaf must survive verbatim.
+      - { assert: field, path: "feeder_audit/originating_system_audit/other_details/items[0]/value/value", equals: "PLC-77421" }
+      # The interior FEEDER_AUDIT on the ELEMENT (master03: "attached to
+      # internal data nodes"), distinguishable from the root one.
+      - { assert: field, path: "content[0]/data/items[0]/feeder_audit/originating_system_item_ids[0]/id", equals: "OBX-1" }
+      - { assert: field, path: "content[0]/data/items[0]/feeder_audit/originating_system_audit/system_id", equals: "lab.example.org" }
+      # The interior audit carries no feeder-system half — absent, not null
+      # (ITS-REST overview Resources.md §JSON Format).
+      - { assert: field, path: "content[0]/data/items[0]/feeder_audit/feeder_system_audit", absent: true }
+postconditions:
+  - { assert: version, count: 1 }

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-links_empty.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-links_empty.yaml
@@ -1,0 +1,50 @@
+# LOCATABLE.Links_valid — the present-but-empty link list.
+#
+# RM common UML/classes/org.openehr.rm.common.locatable.adoc §Invariants
+# states the rule verbatim: `Links_valid: links /= Void implies not
+# links.is_empty`. `links` is 0..1 (§Attributes), so absence is legal and an
+# EMPTY list is not: an instance that serializes `"links": []` asserts the
+# attribute is present while violating the invariant that governs it.
+#
+# This is the REQUEST-side half of the rule. The response-side half is already
+# covered by I_EHR_COMPOSITION.create_composition-null_empty_absent, whose own
+# comment records why it cannot probe this half: an empty links list is an
+# invalid instance, so a conformant server must never accept one. This case
+# closes that gap from the other direction.
+#
+# DECISIVE DOCS TEXT for the wire (ITS-REST specifications/docs/overview/
+# Requests_and_responses.md §HTTP status codes, the 422 row verbatim): "The
+# request was well-formed but was unable to be followed due to semantic
+# errors."
+#
+# One behaviour per case: the payload is cnf.composition.minimal_event.v1 with
+# ONE member added — an empty links list at the root.
+id: I_EHR_COMPOSITION.create_composition-links_empty
+kind: functional
+component: EHR_COMPOSITION
+sm_operation: I_EHR_COMPOSITION.create_composition
+capabilities: [CompositionOps]
+profiles: [CORE]
+test_purpose: >-
+  A COMPOSITION carrying LOCATABLE.links as an empty list is refused as a
+  semantic error, and nothing is committed.
+description: "Reject a COMPOSITION with a present-but-empty links list (422)"
+spec_refs:
+  - "RM common §LOCATABLE (Links_valid: links /= Void implies not links.is_empty)"
+  - "ITS-REST overview Requests_and_responses §HTTP status codes (422)"
+  - "SM openehr_platform §I_EHR_COMPOSITION.create_composition"
+applies: { rm: ">=1.0.2" }
+requires:
+  server: any
+  templates: [cnf.opt.minimal_event]
+  ehr: { commits: none }                 # mints ${ehr_id}
+data_sets: [cnf.composition.minimal_event.links_empty]
+flow:
+  - step: 1
+    call: create_composition
+    with:
+      ehr_id: "${ehr_id}"
+      composition: "${ds:cnf.composition.minimal_event.links_empty}"
+    expect: validation_failed             # overview §HTTP status codes, the 422 row
+postconditions:
+  - { assert: version, count: 0 }         # nothing committed

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-root_archetype_id_mismatch.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-root_archetype_id_mismatch.yaml
@@ -1,0 +1,55 @@
+# THE ROOT NODE-ID IDENTITY RULE on the composition surface.
+#
+# RM common UML/classes/org.openehr.rm.common.locatable.adoc §Attributes fixes
+# the value of `archetype_node_id` at a root verbatim: "At an archetype root
+# point, the value of this attribute is always the stringified form of the
+# `_archetype_id_` found in the `_archetype_details_` object." RM common
+# docs/common/master03-archetyped_package.adoc §The LOCATABLE Class states the
+# same rule as the ONE exception to the at-code form: "The only exception is at
+# archetype root points in data, where `_archetype_node_id_` carries the
+# archetype identifier in string form rather than an interior node id from an
+# archetype." A COMPOSITION root that carries an ARCHETYPED block naming a
+# DIFFERENT archetype than its own archetype_node_id therefore contradicts the
+# model — the node declares two archetype identities and no archetype-driven
+# validation can decide which one governs it.
+#
+# DECISIVE DOCS TEXT for the wire (ITS-REST specifications/docs/overview/
+# Requests_and_responses.md §HTTP status codes, the 422 row verbatim): "The
+# request was well-formed but was unable to be followed due to semantic
+# errors."
+#
+# One behaviour per case: the payload is cnf.composition.minimal_event.v1 with
+# ONE string changed — the root archetype_node_id. The composition surface's
+# twin of the demographic
+# I_DEMOGRAPHIC_SERVICE.create_party-archetype_node_id_mismatch case.
+id: I_EHR_COMPOSITION.create_composition-root_archetype_id_mismatch
+kind: functional
+component: EHR_COMPOSITION
+sm_operation: I_EHR_COMPOSITION.create_composition
+capabilities: [CompositionOps]
+profiles: [CORE]
+test_purpose: >-
+  A COMPOSITION whose root archetype_node_id is not the stringified form of its
+  own archetype_details.archetype_id is refused as a semantic error, and
+  nothing is committed.
+description: "Reject a COMPOSITION root whose archetype_node_id contradicts its ARCHETYPED block (422)"
+spec_refs:
+  - "RM common §LOCATABLE (archetype_node_id at an archetype root)"
+  - "RM common master03-archetyped_package §The LOCATABLE Class"
+  - "ITS-REST overview Requests_and_responses §HTTP status codes (422)"
+  - "SM openehr_platform §I_EHR_COMPOSITION.create_composition"
+applies: { rm: ">=1.0.2" }
+requires:
+  server: any
+  templates: [cnf.opt.minimal_event]
+  ehr: { commits: none }                 # mints ${ehr_id}
+data_sets: [cnf.composition.minimal_event.root_archetype_id_mismatch]
+flow:
+  - step: 1
+    call: create_composition
+    with:
+      ehr_id: "${ehr_id}"
+      composition: "${ds:cnf.composition.minimal_event.root_archetype_id_mismatch}"
+    expect: validation_failed             # overview §HTTP status codes, the 422 row
+postconditions:
+  - { assert: version, count: 0 }         # nothing committed

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-feeder_audit_carried.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-feeder_audit_carried.yaml
@@ -1,0 +1,76 @@
+# FEEDER AUDIT IS PART OF THE CONTENT, so it RIDES a new version.
+#
+# RM common docs/common/master03-archetyped_package.adoc §Structural
+# Correspondence states the retention rule verbatim: "The Feeder audit
+# information is included as part of the data of the Composition, rather than
+# part of the audit trail of version committal, because it remains relevant
+# throughout the versioning of a logical Composition, i.e. when a new version
+# is created, the feeder information is retained as part of the current version
+# to be seen and possibly modified, just as for the rest of its content."
+#
+# So a v2 whose body carries the same FEEDER_AUDIT pair must be stored and
+# served with it — the feeder audit is ordinary content, not version metadata a
+# server may strip or regenerate. The removal branch (the same section's next
+# clause: "If the main part of the content is modified so drastically as to
+# make the feeder audit irrelevant, it too can be removed") is the sibling case
+# I_EHR_COMPOSITION.update_composition-feeder_audit_removed.
+#
+# One behaviour per case: the only thing under test is that the retained feeder
+# audit survives to version 2.
+id: I_EHR_COMPOSITION.update_composition-feeder_audit_carried
+kind: functional
+component: EHR_COMPOSITION
+sm_operation: I_EHR_COMPOSITION.update_composition
+capabilities: [Versioning]
+exercises: [CompositionOps]
+profiles: [CORE]
+test_purpose: >-
+  Updating a COMPOSITION whose new content retains its FEEDER_AUDITs creates
+  version 2 with the feeder audit intact at the root and on the interior data
+  node.
+description: "Update a COMPOSITION retaining its FEEDER_AUDIT"
+spec_refs:
+  - "RM common master03-archetyped_package §Structural Correspondence"
+  - "RM common §FEEDER_AUDIT"
+  - "SM openehr_platform §I_EHR_COMPOSITION.update_composition"
+applies: { rm: ">=1.0.2" }
+requires:
+  server: any
+  templates: [cnf.opt.minimal_event]
+  ehr: { commits: none }                 # mints ${ehr_id}
+data_sets:
+  - cnf.composition.minimal_event.feeder_audit.v1
+  - cnf.composition.minimal_event.feeder_audit.v2
+flow:
+  - step: 1
+    call: create_composition
+    with:
+      ehr_id: "${ehr_id}"
+      composition: "${ds:cnf.composition.minimal_event.feeder_audit.v1}"
+    expect: created
+    capture:
+      preceding_version_uid: created.version_uid
+      versioned_object_uid: created.versioned_object_uid
+  - step: 2
+    call: update_composition
+    with:
+      ehr_id: "${ehr_id}"
+      composition: "${ds:cnf.composition.minimal_event.feeder_audit.v2}"
+      versioned_object_uid: "${versioned_object_uid}"
+      preceding_version_uid: "${preceding_version_uid}"   # ITS-REST: If-Match (ITS-REST overview §If-Match)
+    expect: updated
+    capture: { v2_uid: updated.version_uid }
+    assert:
+      - { assert: version, of: "${v2_uid}", uid_pattern: "${versioned_object_uid}::<system>::2" }
+  - step: 3
+    call: get_composition_at_version
+    format: canonical-json
+    with: { ehr_id: "${ehr_id}", version_uid: "${v2_uid}" }
+    expect: ok
+    assert:
+      - { assert: instance_of, rm_type: COMPOSITION }
+      - { assert: field, path: "feeder_audit/originating_system_audit/system_id", equals: "lab.example.org" }
+      - { assert: field, path: "feeder_audit/original_content/formalism", equals: "HL7v2.5" }
+      - { assert: field, path: "content[0]/data/items[0]/feeder_audit/originating_system_item_ids[0]/id", equals: "OBX-1" }
+postconditions:
+  - { assert: version, count: 2 }

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-feeder_audit_removed.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-feeder_audit_removed.yaml
@@ -1,0 +1,72 @@
+# THE REMOVAL BRANCH of the feeder-audit retention rule.
+#
+# RM common docs/common/master03-archetyped_package.adoc §Structural
+# Correspondence, immediately after establishing that the feeder audit rides a
+# new version as ordinary content: "If the main part of the content is modified
+# so drastically as to make the feeder audit irrelevant, it too can be removed."
+#
+# So a client MAY commit a next version whose body carries no FEEDER_AUDIT at
+# all, and the update is a normal accepted update — the server neither refuses
+# it nor carries the previous version's feeder audit forward. Carrying it
+# forward would make the removal the spec permits unexpressible; refusing the
+# update would contradict the same sentence.
+#
+# The retention branch is the sibling case
+# I_EHR_COMPOSITION.update_composition-feeder_audit_carried; the pair is the
+# two halves of one released sentence, one behaviour each.
+id: I_EHR_COMPOSITION.update_composition-feeder_audit_removed
+kind: functional
+component: EHR_COMPOSITION
+sm_operation: I_EHR_COMPOSITION.update_composition
+capabilities: [Versioning]
+exercises: [CompositionOps]
+profiles: [CORE]
+test_purpose: >-
+  Updating a COMPOSITION with content that drops the FEEDER_AUDITs is accepted,
+  and version 2 is served without them — the previous version's feeder audit is
+  not carried forward.
+description: "Update a COMPOSITION removing its FEEDER_AUDIT"
+spec_refs:
+  - "RM common master03-archetyped_package §Structural Correspondence"
+  - "RM common §FEEDER_AUDIT"
+  - "SM openehr_platform §I_EHR_COMPOSITION.update_composition"
+applies: { rm: ">=1.0.2" }
+requires:
+  server: any
+  templates: [cnf.opt.minimal_event]
+  ehr: { commits: none }                 # mints ${ehr_id}
+data_sets:
+  - cnf.composition.minimal_event.feeder_audit.v1
+  - cnf.composition.minimal_event.v2
+flow:
+  - step: 1
+    call: create_composition
+    with:
+      ehr_id: "${ehr_id}"
+      composition: "${ds:cnf.composition.minimal_event.feeder_audit.v1}"
+    expect: created
+    capture:
+      preceding_version_uid: created.version_uid
+      versioned_object_uid: created.versioned_object_uid
+  - step: 2
+    call: update_composition
+    with:
+      ehr_id: "${ehr_id}"
+      composition: "${ds:cnf.composition.minimal_event.v2}"
+      versioned_object_uid: "${versioned_object_uid}"
+      preceding_version_uid: "${preceding_version_uid}"   # ITS-REST: If-Match (ITS-REST overview §If-Match)
+    expect: updated
+    capture: { v2_uid: updated.version_uid }
+  - step: 3
+    call: get_composition_at_version
+    format: canonical-json
+    with: { ehr_id: "${ehr_id}", version_uid: "${v2_uid}" }
+    expect: ok
+    assert:
+      - { assert: instance_of, rm_type: COMPOSITION }
+      # Absent, not `null` (ITS-REST overview Resources.md §JSON Format) — and
+      # not carried over from version 1.
+      - { assert: field, path: "feeder_audit", absent: true }
+      - { assert: field, path: "content[0]/data/items[0]/feeder_audit", absent: true }
+postconditions:
+  - { assert: version, count: 2 }

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-same_content.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.update_composition-same_content.yaml
@@ -1,0 +1,71 @@
+# AN UNCHANGED CONTENT STATE STILL MAKES A NEW VERSION.
+#
+# RM common docs/common/master03-archetyped_package.adoc §Version Detection
+# states it verbatim, with the clinical reason attached: "A new openEHR
+# Composition version should always be created for each received version, even
+# where the content does not change at all (e.g. a microbiology test where the
+# result is "no growth" in both interim and final results)."
+#
+# So a server may not treat an identical body as a no-op, a conflict, or a
+# duplicate to fold away: the version count after an update whose content
+# equals version 1's is 2, and version 2 is addressable in its own right. This
+# is the content-identity boundary of the ordinary update case
+# (I_EHR_COMPOSITION.update_composition-event), which changes a leaf.
+#
+# One behaviour per case: the SAME data set is committed and then re-committed
+# as the update body, so content identity is the only variable. The update's
+# required mechanics are unchanged — preceding_version_uid realized as If-Match
+# (ITS-REST overview §If-Match) — because they are not what is under test.
+id: I_EHR_COMPOSITION.update_composition-same_content
+kind: functional
+component: EHR_COMPOSITION
+sm_operation: I_EHR_COMPOSITION.update_composition
+capabilities: [Versioning]
+exercises: [CompositionOps, ChangeSets]
+profiles: [CORE]
+test_purpose: >-
+  An update whose body is identical in content to the preceding version is
+  accepted and creates version 2 — an unchanged content state is never folded
+  away as a duplicate or refused as a no-op.
+description: "Update a COMPOSITION with content identical to the preceding version"
+spec_refs:
+  - "RM common master03-archetyped_package §Version Detection"
+  - "RM common §change_control (VERSION.commit_audit.change_type)"
+  - "SM openehr_platform §I_EHR_COMPOSITION.update_composition"
+applies: { rm: ">=1.0.2" }
+requires:
+  server: any
+  templates: [cnf.opt.minimal_event]
+  ehr: { commits: none }                 # mints ${ehr_id}
+data_sets: [cnf.composition.minimal_event.v1]
+flow:
+  - step: 1
+    call: create_composition
+    with: { ehr_id: "${ehr_id}", composition: "${ds:cnf.composition.minimal_event.v1}" }
+    expect: created
+    capture:
+      preceding_version_uid: created.version_uid
+      versioned_object_uid: created.versioned_object_uid
+  - step: 2
+    call: update_composition
+    with:
+      ehr_id: "${ehr_id}"
+      composition: "${ds:cnf.composition.minimal_event.v1}"   # byte-identical content state
+      versioned_object_uid: "${versioned_object_uid}"
+      preceding_version_uid: "${preceding_version_uid}"       # ITS-REST: If-Match (ITS-REST overview §If-Match)
+    expect: updated
+    capture: { v2_uid: updated.version_uid }
+    assert:
+      - { assert: version, of: "${v2_uid}", uid_pattern: "${versioned_object_uid}::<system>::2" }
+  - step: 3
+    call: get_composition_at_version
+    format: canonical-json
+    with: { ehr_id: "${ehr_id}", version_uid: "${v2_uid}" }
+    expect: ok
+    assert:
+      - { assert: instance_of, rm_type: COMPOSITION }
+      - { assert: equivalent, to: committed, ignoring: server_assigned }
+postconditions:
+  - { assert: version, count: 2 }
+  - { assert: version, of: "${preceding_version_uid}", change_type: CREATE }
+  - { assert: version, of: "${v2_uid}", change_type: MODIFY }


### PR DESCRIPTION
From the #983 audit (RM common master03, Archetyped package §3.1).

## What

Two wire-visible leniencies closed, one RM self-contradiction registered, CNF coverage extended:

- **Root node-id identity everywhere** (RM `master03-archetyped_package.adoc` §The LOCATABLE Class; `locatable.adoc` §Attributes): a node carrying `archetype_details` must have `archetype_node_id` equal to `archetype_details.archetype_id.value`. Was enforced only on EHR_STATUS/EHR_ACCESS/PARTY roots; now enforced in the shared RM-invariant walker (every composition commit path, interior roots included) and in `validate_folder`.
- **Links_valid on the wire** (`locatable.adoc`: `links /= Void implies not links.is_empty`): `"links": []` now refused (422) on any node — attribute-keyed rule in the walker + the folder walk. The typed model cannot see present-empty (Vec emission), so the wire-level check is the enforcement point.
- **AMB-176**: master03 §Structural Correspondence mandates `FEEDER_AUDIT.change_type = 'synthesised'` but RM 1.2.0 defines no such attribute on FEEDER_AUDIT (5 attrs) or FEEDER_AUDIT_DETAILS (7 attrs); TERM's `252|synthesis|` is reachable only via AUDIT_DETAILS. Registered report_only; empirically verified the tolerant reader drops the key. The upstream-report issue gets created in the register migration and the TBD ref replaced there.
- **6 new CNF cases** (881 total, validate 0 findings): the two invalid twins (root mismatch, links empty), the feeder_audit acceptance family (root + interior granularity roundtrip, carried across update, removable), and the same-content-update acceptance case (§Version Detection — pins that no content-dedup ever refuses a legitimate new version).
- Corpus doc: the two vendored SDK fixtures carrying the root-copied ARCHETYPED defect are now named with citations; a dead spec citation in the FHIR feeder_audit module repointed.

## Gates

fmt ✓ · clippy (openehr-its, ferroehr, -D warnings) ✓ · nextest: openehr-its 540/540, ferroehr 730/730, cnf-runner 251/251 ✓ · `cnf-runner validate`: 881 cases, 0 findings ✓ · coverage-report regenerated byte-identical ✓

Closes #1479
Closes #1480
Closes #1481