### PR TITLE
perf(cnf-runner): the seeded-defect battery drops 309s → ~25s without losing a defect

### DIFF
--- a/tools/cnf-runner/src/validate.rs
+++ b/tools/cnf-runner/src/validate.rs
@@ -9,8 +9,10 @@
 //! tree for the two resolution checks); every violation is one typed
 //! [`Finding`].
 
+use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
+use std::rc::Rc;
 
 use crate::artifacts::ArtifactSet;
 use crate::ids::{CapabilityName, CaseId, CorpusKey, SmOperationRef, ViewName};
@@ -172,6 +174,10 @@ pub struct Context<'a> {
 #[must_use]
 pub fn validate(ctx: &Context<'_>) -> Vec<Finding> {
     let mut findings = Vec::new();
+    // One memoizing reader for the whole run: the citation gates otherwise
+    // re-read the same SM class exports and re-walk the same vendored
+    // component directories once per case.
+    let spec = ctx.spec_root.map(SpecIndex::new);
 
     for e in ctx.load_errors {
         findings.push(Finding {
@@ -189,9 +195,9 @@ pub fn validate(ctx: &Context<'_>) -> Vec<Finding> {
         check_literals(case, &who, &mut findings);
         check_capability_tier(case, &who, ctx.set, &mut findings);
         check_links(case, &who, ctx.set, &mut findings);
-        if let Some(spec_root) = ctx.spec_root {
-            check_sm_operations(case, &who, spec_root, &mut findings);
-            check_spec_refs(case, &who, spec_root, &mut findings);
+        if let Some(spec) = spec.as_ref() {
+            check_sm_operations(case, &who, spec, &mut findings);
+            check_spec_refs(case, &who, spec, &mut findings);
         }
     }
     check_binding_completeness(ctx.set, &mut findings);
@@ -214,8 +220,8 @@ pub fn validate(ctx: &Context<'_>) -> Vec<Finding> {
                 ),
             );
         }
-        if let Some(spec_root) = ctx.spec_root {
-            resolve_sm_operation(&binding.sm_operation, &who, spec_root, &mut findings);
+        if let Some(spec) = spec.as_ref() {
+            resolve_sm_operation(&binding.sm_operation, &who, spec, &mut findings);
         }
     }
     check_corpus_integrity(ctx.set, &mut findings);
@@ -225,7 +231,7 @@ pub fn validate(ctx: &Context<'_>) -> Vec<Finding> {
     check_capability_depth(ctx.set, &mut findings);
     check_workload_coverage(ctx.set, &mut findings);
     check_realization_scope(ctx.set, &mut findings);
-    check_surface_coverage(ctx.set, ctx.spec_root, &mut findings);
+    check_surface_coverage(ctx.set, spec.as_ref(), &mut findings);
 
     findings
 }
@@ -1486,6 +1492,86 @@ fn check_links(case: &CaseCore, who: &str, set: &ArtifactSet, findings: &mut Vec
 
 // ── SM + spec-ref resolution ────────────────────────────────────────────────
 
+/// One SM interface's parsed operation list, or the message explaining why it
+/// could not be read.
+type InterfaceOperations = Result<Rc<[String]>, String>;
+
+/// A memoizing reader over the vendored spec tree.
+///
+/// The citation-resolution gates ask the same questions once per case: the
+/// same handful of SM class exports are read thousands of times, and the same
+/// `(component dir, document token)` pairs are answered by re-walking a whole
+/// vendored component directory each time. The vendored tree is read-only for
+/// the lifetime of a validation run, so every answer is a pure function of the
+/// path — the index caches those answers and nothing else. Findings are
+/// byte-identical to an uncached run, including the io-error text a failed
+/// read produces.
+#[derive(Debug)]
+struct SpecIndex<'a> {
+    root: &'a Path,
+    /// `path → file text`, or the io error's display text.
+    texts: RefCell<BTreeMap<PathBuf, Result<Rc<str>, String>>>,
+    /// `(component dir, lowercased token) → any path under the dir matches`.
+    tokens: RefCell<BTreeMap<(PathBuf, String), bool>>,
+    /// `interface → its parsed SM operation names`.
+    interfaces: RefCell<BTreeMap<String, InterfaceOperations>>,
+}
+
+impl<'a> SpecIndex<'a> {
+    /// An empty index over one vendored spec root.
+    fn new(root: &'a Path) -> Self {
+        Self {
+            root,
+            texts: RefCell::new(BTreeMap::new()),
+            tokens: RefCell::new(BTreeMap::new()),
+            interfaces: RefCell::new(BTreeMap::new()),
+        }
+    }
+
+    /// The vendored spec root this index reads.
+    fn root(&self) -> &Path {
+        self.root
+    }
+
+    /// Read one vendored file, once per run.
+    fn read(&self, path: &Path) -> Result<Rc<str>, String> {
+        if let Some(hit) = self.texts.borrow().get(path) {
+            return hit.clone();
+        }
+        let result = std::fs::read_to_string(path)
+            .map(|text| Rc::from(text.as_str()))
+            .map_err(|error| error.to_string());
+        self.texts
+            .borrow_mut()
+            .insert(path.to_owned(), result.clone());
+        result
+    }
+
+    /// Case-insensitive substring match of `token` against any path under
+    /// `dir`, once per `(dir, token)` pair.
+    fn contains_token(&self, dir: &Path, token: &str) -> bool {
+        let key = (dir.to_owned(), token.to_owned());
+        if let Some(hit) = self.tokens.borrow().get(&key) {
+            return *hit;
+        }
+        let hit = path_contains_token(dir, token);
+        self.tokens.borrow_mut().insert(key, hit);
+        hit
+    }
+
+    /// The service operations of an SM interface, parsed once per run.
+    fn interface_operations(&self, interface: &str) -> InterfaceOperations {
+        if let Some(hit) = self.interfaces.borrow().get(interface) {
+            return hit.clone();
+        }
+        let result = parse_sm_interface_operations(self, interface).map(Rc::from);
+        self.interfaces
+            .borrow_mut()
+            .insert(interface.to_owned(), result.clone());
+        result
+    }
+}
+
 fn sm_class_file(spec_root: &Path, interface: &str) -> PathBuf {
     spec_root
         .join("SM/docs/UML/classes")
@@ -1500,7 +1586,7 @@ fn sm_class_file(spec_root: &Path, interface: &str) -> PathBuf {
 fn resolve_sm_operation(
     op: &SmOperationRef,
     who: &str,
-    spec_root: &Path,
+    spec: &SpecIndex<'_>,
     findings: &mut Vec<Finding>,
 ) {
     if non_sm_operation_source(op).is_some() {
@@ -1520,8 +1606,8 @@ fn resolve_sm_operation(
         );
         return;
     }
-    let file = sm_class_file(spec_root, op.interface());
-    match std::fs::read_to_string(&file) {
+    let file = sm_class_file(spec.root(), op.interface());
+    match spec.read(&file) {
         Err(_) => push(
             findings,
             CheckId::SmOperation,
@@ -1548,11 +1634,16 @@ fn resolve_sm_operation(
     }
 }
 
-fn check_sm_operations(case: &CaseCore, who: &str, spec_root: &Path, findings: &mut Vec<Finding>) {
+fn check_sm_operations(
+    case: &CaseCore,
+    who: &str,
+    spec: &SpecIndex<'_>,
+    findings: &mut Vec<Finding>,
+) {
     let Some(anchor) = &case.sm_operation else {
         return;
     };
-    resolve_sm_operation(anchor, who, spec_root, findings);
+    resolve_sm_operation(anchor, who, spec, findings);
     for step in &case.flow {
         let op = if step.call.contains('.') {
             match SmOperationRef::parse(&step.call) {
@@ -1565,7 +1656,7 @@ fn check_sm_operations(case: &CaseCore, who: &str, spec_root: &Path, findings: &
         } else {
             anchor.sibling(&step.call)
         };
-        resolve_sm_operation(&op, who, spec_root, findings);
+        resolve_sm_operation(&op, who, spec, findings);
     }
 }
 
@@ -1587,7 +1678,7 @@ fn component_dir(token: &str) -> Option<&'static str> {
     })
 }
 
-fn check_spec_refs(case: &CaseCore, who: &str, spec_root: &Path, findings: &mut Vec<Finding>) {
+fn check_spec_refs(case: &CaseCore, who: &str, spec: &SpecIndex<'_>, findings: &mut Vec<Finding>) {
     for citation in &case.spec_refs {
         let mut tokens = citation.split_whitespace();
         let Some(component) = tokens.next() else {
@@ -1603,7 +1694,7 @@ fn check_spec_refs(case: &CaseCore, who: &str, spec_root: &Path, findings: &mut 
             );
             continue;
         };
-        let root = spec_root.join(dir);
+        let root = spec.root().join(dir);
         if !root.is_dir() {
             push(
                 findings,
@@ -1621,7 +1712,7 @@ fn check_spec_refs(case: &CaseCore, who: &str, spec_root: &Path, findings: &mut 
         let Some(doc_token) = doc_token.filter(|t| !t.starts_with('§')) else {
             continue; // component-only citation: dir existence was the check
         };
-        if !path_contains_token(&root, &doc_token.to_lowercase()) {
+        if !spec.contains_token(&root, &doc_token.to_lowercase()) {
             push(
                 findings,
                 CheckId::SpecRef,
@@ -2310,11 +2401,17 @@ fn non_sm_operation_source(op: &SmOperationRef) -> Option<&'static str> {
 /// class export to parse and is enumerated from [`NON_SM_REST_OPERATIONS`]
 /// instead — never through this function.
 ///
+/// Callers go through [`SpecIndex::interface_operations`], which parses each
+/// interface once per run.
+///
 /// # Errors
 /// Returns a message when the interface has no vendored class export.
-fn sm_interface_operations(spec_root: &Path, interface: &str) -> Result<Vec<String>, String> {
-    let file = sm_class_file(spec_root, interface);
-    let text = std::fs::read_to_string(&file).map_err(|error| {
+fn parse_sm_interface_operations(
+    spec: &SpecIndex<'_>,
+    interface: &str,
+) -> Result<Vec<String>, String> {
+    let file = sm_class_file(spec.root(), interface);
+    let text = spec.read(&file).map_err(|error| {
         format!(
             "interface {interface} has no vendored SM class export ({}): {error}",
             file.display()
@@ -2348,14 +2445,14 @@ fn sm_interface_operations(spec_root: &Path, interface: &str) -> Result<Vec<Stri
 /// as a finding rather than passing silently.
 fn check_surface_coverage(
     set: &ArtifactSet,
-    spec_root: Option<&Path>,
+    spec: Option<&SpecIndex<'_>>,
     findings: &mut Vec<Finding>,
 ) {
     let empty = WireSurface::default();
     let wire_surface = set.wire_surface.as_ref().map_or(&empty, |(_, w)| w);
-    if let Some(spec_root) = spec_root {
-        check_surface_sm_operations(set, spec_root, wire_surface, findings);
-        check_axis3_section_derivation(wire_surface, spec_root, AXIS3_SECTION_EXCLUSIONS, findings);
+    if let Some(spec) = spec {
+        check_surface_sm_operations(set, spec, wire_surface, findings);
+        check_axis3_section_derivation(wire_surface, spec, AXIS3_SECTION_EXCLUSIONS, findings);
     }
     check_binding_branch_coverage(set, wire_surface, findings);
     check_wire_surface_elements(set, wire_surface, findings);
@@ -2440,19 +2537,19 @@ fn check_served_extensions(
 /// exception.
 fn check_surface_sm_operations(
     set: &ArtifactSet,
-    spec_root: &Path,
+    spec: &SpecIndex<'_>,
     wire_surface: &WireSurface,
     findings: &mut Vec<Finding>,
 ) {
     for interface in PLATFORM_INTERFACES {
-        let ops = match sm_interface_operations(spec_root, interface) {
+        let ops = match spec.interface_operations(interface) {
             Ok(ops) => ops,
             Err(message) => {
                 push(findings, CheckId::SurfaceCoverage, interface, message);
                 continue;
             }
         };
-        for name in ops {
+        for name in ops.iter() {
             let Ok(op) = SmOperationRef::parse(&format!("{interface}.{name}")) else {
                 continue;
             };
@@ -2838,13 +2935,13 @@ struct DocDerivation {
 /// testable without touching the pinned const.
 fn axis3_derivation(
     wire_surface: &WireSurface,
-    spec_root: &Path,
+    spec: &SpecIndex<'_>,
     exclusions: &[(&str, &str)],
 ) -> Vec<DocDerivation> {
     let sources = wire_surface_source_texts(wire_surface);
     let mut out = Vec::new();
     for doc in AXIS3_OVERVIEW_DOCS.iter().copied() {
-        let Ok(text) = std::fs::read_to_string(spec_root.join(doc)) else {
+        let Ok(text) = spec.read(&spec.root().join(doc)) else {
             out.push(DocDerivation {
                 doc,
                 unreadable: true,
@@ -2888,11 +2985,11 @@ fn axis3_derivation(
 /// or naming no heading at all) are findings too — the table only ratchets.
 fn check_axis3_section_derivation(
     wire_surface: &WireSurface,
-    spec_root: &Path,
+    spec: &SpecIndex<'_>,
     exclusions: &[(&str, &str)],
     findings: &mut Vec<Finding>,
 ) {
-    let derivations = axis3_derivation(wire_surface, spec_root, exclusions);
+    let derivations = axis3_derivation(wire_surface, spec, exclusions);
     let mut every_heading: BTreeSet<String> = BTreeSet::new();
     let mut covered_headings: BTreeSet<String> = BTreeSet::new();
     for derivation in &derivations {
@@ -2977,6 +3074,7 @@ pub fn render_coverage_report(set: &ArtifactSet, spec_root: Option<&Path>) -> St
 
     let empty = WireSurface::default();
     let wire_surface = set.wire_surface.as_ref().map_or(&empty, |(_, w)| w);
+    let spec = spec_root.map(SpecIndex::new);
 
     let mut out = String::new();
     out.push_str(
@@ -2989,17 +3087,17 @@ pub fn render_coverage_report(set: &ArtifactSet, spec_root: Option<&Path>) -> St
     );
 
     // ── Axis 1 ──
-    if let Some(spec_root) = spec_root {
+    if let Some(spec) = spec.as_ref() {
         out.push_str("## Axis 1 — SM-operation coverage (per platform interface)\n\n");
         out.push_str("| Interface | Operations | Realized | Unrealized | Off-wire / exception |\n");
         out.push_str("|---|--:|--:|--:|--:|\n");
         for interface in PLATFORM_INTERFACES {
-            let Ok(ops) = sm_interface_operations(spec_root, interface) else {
+            let Ok(ops) = spec.interface_operations(interface) else {
                 let _ = writeln!(out, "| {interface} | (no vendored SM class export) | | | |");
                 continue;
             };
             let (mut realized, mut unrealized, mut excepted) = (0_usize, 0_usize, 0_usize);
-            for name in &ops {
+            for name in ops.iter() {
                 let Ok(op) = SmOperationRef::parse(&format!("{interface}.{name}")) else {
                     continue;
                 };
@@ -3122,7 +3220,7 @@ pub fn render_coverage_report(set: &ArtifactSet, spec_root: Option<&Path>) -> St
     out.push('\n');
 
     // ── Axis 3, derivation half ──
-    if let Some(spec_root) = spec_root {
+    if let Some(spec) = spec.as_ref() {
         out.push_str("### Axis 3 derivation — RELEASED overview sections\n\n");
         out.push_str(
             "The element list above is AUTHORED; this table is DERIVED — every `#`/`##` section \
@@ -3133,7 +3231,7 @@ pub fn render_coverage_report(set: &ArtifactSet, spec_root: Option<&Path>) -> St
             "| Chapter | Sections | Named by a source | Excluded (pinned) | Uncovered |\n",
         );
         out.push_str("|---|--:|--:|--:|--:|\n");
-        for derivation in axis3_derivation(wire_surface, spec_root, AXIS3_SECTION_EXCLUSIONS) {
+        for derivation in axis3_derivation(wire_surface, spec, AXIS3_SECTION_EXCLUSIONS) {
             if derivation.unreadable {
                 let _ = writeln!(out, "| `{}` | (not readable) | | | |", derivation.doc);
                 continue;
@@ -3201,10 +3299,14 @@ h|*1..1*\n\
         std::fs::create_dir_all(&classes).unwrap();
         std::fs::write(classes.join("i_fixture.adoc"), adoc).unwrap();
 
-        let ops = sm_interface_operations(dir.path(), "I_FIXTURE").unwrap();
-        assert_eq!(ops, vec!["create_thing".to_owned(), "get_thing".to_owned()]);
+        let spec = SpecIndex::new(dir.path());
+        let ops = spec.interface_operations("I_FIXTURE").unwrap();
+        assert_eq!(
+            *ops,
+            vec!["create_thing".to_owned(), "get_thing".to_owned()]
+        );
         // A missing class export is an error, not an empty list.
-        assert!(sm_interface_operations(dir.path(), "I_ABSENT").is_err());
+        assert!(spec.interface_operations("I_ABSENT").is_err());
     }
 
     fn build_set(with_exception: bool) -> ArtifactSet {
@@ -3354,15 +3456,17 @@ h|*1..1*\n\
     fn pinned_pseudo_operation_resolves_and_an_unpinned_one_is_a_finding() {
         let empty_root = assert_fs::TempDir::new().unwrap();
 
+        let spec = SpecIndex::new(empty_root.path());
+
         let (pinned_name, _) = *NON_SM_REST_OPERATIONS.first().unwrap();
         let pinned = SmOperationRef::parse(pinned_name).unwrap();
         let mut findings = Vec::new();
-        resolve_sm_operation(&pinned, "b.yaml", empty_root.path(), &mut findings);
+        resolve_sm_operation(&pinned, "b.yaml", &spec, &mut findings);
         assert!(findings.is_empty(), "{findings:?}");
 
         let invented = SmOperationRef::parse("I_ITS_REST_SYSTEM.invented").unwrap();
         let mut findings = Vec::new();
-        resolve_sm_operation(&invented, "b.yaml", empty_root.path(), &mut findings);
+        resolve_sm_operation(&invented, "b.yaml", &spec, &mut findings);
         assert!(
             findings
                 .iter()
@@ -3374,7 +3478,7 @@ h|*1..1*\n\
         // A real SM interface is still resolved against the vendored tree.
         let sm = SmOperationRef::parse("I_EHR_SERVICE.create_ehr").unwrap();
         let mut findings = Vec::new();
-        resolve_sm_operation(&sm, "b.yaml", empty_root.path(), &mut findings);
+        resolve_sm_operation(&sm, "b.yaml", &spec, &mut findings);
         assert!(
             findings
                 .iter()
@@ -3393,7 +3497,12 @@ h|*1..1*\n\
         let (pinned, pinned_source) = *NON_SM_REST_OPERATIONS.first().unwrap();
 
         let mut findings = Vec::new();
-        check_surface_sm_operations(&set, empty_root.path(), &empty, &mut findings);
+        check_surface_sm_operations(
+            &set,
+            &SpecIndex::new(empty_root.path()),
+            &empty,
+            &mut findings,
+        );
         assert!(
             findings
                 .iter()
@@ -3411,7 +3520,12 @@ h|*1..1*\n\
         }))
         .unwrap();
         let mut findings = Vec::new();
-        check_surface_sm_operations(&set, empty_root.path(), &excepted, &mut findings);
+        check_surface_sm_operations(
+            &set,
+            &SpecIndex::new(empty_root.path()),
+            &excepted,
+            &mut findings,
+        );
         assert!(
             !findings.iter().any(|f| f.artifact == pinned),
             "the exception should suppress the finding, got: {findings:?}"
@@ -3446,9 +3560,10 @@ h|*1..1*\n\
         // The reservation holds for EVERY pseudo-interface, not just System:
         // an unpinned ITEM_TAGS reference is still a finding naming the table.
         let empty_root = assert_fs::TempDir::new().unwrap();
+        let spec = SpecIndex::new(empty_root.path());
         let invented = SmOperationRef::parse("I_ITS_REST_ITEM_TAGS.folder_tags_get").unwrap();
         let mut findings = Vec::new();
-        resolve_sm_operation(&invented, "b.yaml", empty_root.path(), &mut findings);
+        resolve_sm_operation(&invented, "b.yaml", &spec, &mut findings);
         assert!(
             findings
                 .iter()
@@ -3536,14 +3651,18 @@ some prose\n\
         }))
         .unwrap();
 
-        let derivations = axis3_derivation(&wire, dir.path(), &[]);
+        let derivations = axis3_derivation(&wire, &SpecIndex::new(dir.path()), &[]);
         for derivation in &derivations {
             assert!(!derivation.unreadable);
             assert_eq!(derivation.covered, vec!["Covered Section".to_owned()]);
             assert_eq!(derivation.uncovered, vec!["Silent Section".to_owned()]);
         }
 
-        let excluded = axis3_derivation(&wire, dir.path(), &[("silent section", "why")]);
+        let excluded = axis3_derivation(
+            &wire,
+            &SpecIndex::new(dir.path()),
+            &[("silent section", "why")],
+        );
         for derivation in &excluded {
             assert_eq!(derivation.excluded, vec!["Silent Section".to_owned()]);
             assert!(derivation.uncovered.is_empty());
@@ -3571,7 +3690,7 @@ some prose\n\
         .unwrap();
 
         let mut findings = Vec::new();
-        check_axis3_section_derivation(&wire, dir.path(), &[], &mut findings);
+        check_axis3_section_derivation(&wire, &SpecIndex::new(dir.path()), &[], &mut findings);
         assert!(
             findings
                 .iter()
@@ -3583,7 +3702,7 @@ some prose\n\
         let mut findings = Vec::new();
         check_axis3_section_derivation(
             &wire,
-            dir.path(),
+            &SpecIndex::new(dir.path()),
             &[
                 ("Covered Section", "already named by a source"),
                 ("No Such Section", "names nothing"),
@@ -3614,7 +3733,7 @@ some prose\n\
         let dir = assert_fs::TempDir::new().unwrap();
         let wire = WireSurface::default();
         let mut findings = Vec::new();
-        check_axis3_section_derivation(&wire, dir.path(), &[], &mut findings);
+        check_axis3_section_derivation(&wire, &SpecIndex::new(dir.path()), &[], &mut findings);
         assert_eq!(findings.len(), AXIS3_OVERVIEW_DOCS.len(), "{findings:?}");
         assert!(
             findings.iter().all(|f| f.message.contains("not readable")),

--- a/tools/cnf-runner/tests/it/defect_rejection.rs
+++ b/tools/cnf-runner/tests/it/defect_rejection.rs
@@ -1,228 +1,224 @@
 //! Every seeded-defect fixture is rejected with the expected gate — the
 //! validator's negative battery (one fixture per machine gate, schema-level
 //! through cross-artifact).
+//!
+//! **One test per defect.** nextest runs each test in its own process, so the
+//! battery fans out across the whole process pool instead of grinding through
+//! ~40 full validation passes in a single serial test body, and a red row
+//! names exactly one fixture instead of aborting the loop. The fixture set and
+//! the per-defect tests are generated from ONE list by `defects!`, so they
+//! cannot drift apart; [`every_defect_fixture_has_a_test`] then compares that
+//! list against the fixture directory, so a fixture added on disk with no test
+//! is a failing check, never a silent skip.
+//!
+//! **The world each defect validates against is materialized, not copied.** A
+//! recursive copy of the artifact tree cost ~1.5–4 s per defect (the tree is
+//! ~220 MB, dominated by the corpus) and evicted the page cache the next
+//! defect's load depends on. [`overlay_world`] instead symlinks the pristine
+//! tree and materializes real directories only along the overlaid file's own
+//! path, so the loader sees a byte-identical tree with one file replaced or
+//! added. Nothing in the battery writes to the tree — `load_root` and
+//! `validate` only read — and the overlaid name is never symlinked, so the
+//! pristine artifacts can never be written through a link.
 
 #![expect(
     clippy::expect_used,
     reason = "test-support helpers (not `#[test]` fns, so the clippy.toml in-tests scoping does not reach them) are panic-idiomatic: a broken fixture must abort the test loudly, Book ch11"
 )]
 
-use cnf_runner::artifacts::load_root;
-use cnf_runner::validate::{CheckId, Context, validate};
+use std::path::{Path, PathBuf};
 
-/// (fixture file, overlay destination inside the copied world, expected gate)
-const DEFECTS: &[(&str, &str, &str)] = &[
+use cnf_runner::artifacts::load_root;
+use cnf_runner::validate::{Context, validate};
+
+/// The seeded-defect battery: one row per fixture, and one `#[test]` per row.
+///
+/// Each row is `<test name> => (<fixture file>, <overlay destination inside
+/// the world>, <the gate that must reject it>)`. The gate is spelled with the
+/// stable token `cnf_runner::validate::CheckId::token` publishes — that enum
+/// is the vocabulary these strings come from.
+macro_rules! defects {
+    ($($test:ident => ($fixture:literal, $dest:literal, $gate:literal)),+ $(,)?) => {
+        /// (fixture file, overlay destination inside the world, expected gate)
+        const DEFECTS: &[(&str, &str, &str)] = &[$(($fixture, $dest, $gate)),+];
+
+        $(
+            #[test]
+            fn $test() {
+                assert_rejected($fixture, $dest, $gate);
+            }
+        )+
+    };
+}
+
+defects! {
     // JSON-Schema-level rejections (the hard file-validation requirement)
-    ("case-unknown-field.yaml", "schedule/zz-defect.yaml", "load"),
-    (
-        "case-bad-outcome-kind.yaml",
-        "schedule/zz-defect.yaml",
-        "load",
-    ),
-    ("case-bad-kind.yaml", "schedule/zz-defect.yaml", "load"),
-    (
-        "binding-bad-status.yaml",
-        "bindings/its-rest/zz-defect.yaml",
-        "load",
-    ),
-    (
-        "binding-unknown-outcome-key.yaml",
-        "bindings/its-rest/zz-defect.yaml",
-        "load",
-    ),
-    (
-        "binding-unrealized-and-realized.yaml",
-        "bindings/its-rest/zz-defect.yaml",
-        "load",
-    ),
-    (
-        "register-bad-disposition.yaml",
-        "registers/ambiguities.yaml",
-        "load",
-    ),
-    (
-        "register-option-select-without-options.yaml",
-        "registers/ambiguities.yaml",
-        "load",
-    ),
-    (
-        "corpus-missing-provenance.yaml",
-        "corpus/MANIFEST.yaml",
-        "load",
-    ),
-    (
-        "corpus-invalid-without-defect.yaml",
-        "corpus/MANIFEST.yaml",
-        "load",
-    ),
+    case_unknown_field => ("case-unknown-field.yaml", "schedule/zz-defect.yaml", "load"),
+    case_bad_outcome_kind => ("case-bad-outcome-kind.yaml", "schedule/zz-defect.yaml", "load"),
+    case_bad_kind => ("case-bad-kind.yaml", "schedule/zz-defect.yaml", "load"),
+    binding_bad_status =>
+        ("binding-bad-status.yaml", "bindings/its-rest/zz-defect.yaml", "load"),
+    binding_unknown_outcome_key =>
+        ("binding-unknown-outcome-key.yaml", "bindings/its-rest/zz-defect.yaml", "load"),
+    binding_unrealized_and_realized =>
+        ("binding-unrealized-and-realized.yaml", "bindings/its-rest/zz-defect.yaml", "load"),
+    register_bad_disposition =>
+        ("register-bad-disposition.yaml", "registers/ambiguities.yaml", "load"),
+    register_option_select_without_options =>
+        ("register-option-select-without-options.yaml", "registers/ambiguities.yaml", "load"),
+    corpus_missing_provenance =>
+        ("corpus-missing-provenance.yaml", "corpus/MANIFEST.yaml", "load"),
+    corpus_invalid_without_defect =>
+        ("corpus-invalid-without-defect.yaml", "corpus/MANIFEST.yaml", "load"),
     // A declared view with no registered evaluator fails corpus-integrity at
     // validate time, never at run time (#971).
-    (
-        "corpus-view-without-evaluator.yaml",
-        "corpus/MANIFEST.yaml",
-        "corpus-integrity",
-    ),
-    (
-        "matrix-bad-tier.yaml",
-        "vocab/capability_matrix.yaml",
-        "load",
-    ),
-    ("outcomes-missing-kind.yaml", "vocab/outcomes.yaml", "load"),
+    corpus_view_without_evaluator =>
+        ("corpus-view-without-evaluator.yaml", "corpus/MANIFEST.yaml", "corpus-integrity"),
+    matrix_bad_tier => ("matrix-bad-tier.yaml", "vocab/capability_matrix.yaml", "load"),
+    outcomes_missing_kind => ("outcomes-missing-kind.yaml", "vocab/outcomes.yaml", "load"),
+
     // typed-model rejections
-    ("case-bad-ref-form.yaml", "schedule/zz-defect.yaml", "load"),
-    (
-        "case-bad-capture-source.yaml",
-        "schedule/zz-defect.yaml",
-        "load",
-    ),
-    (
-        "case-duplicate-yaml-key.yaml",
-        "schedule/zz-defect.yaml",
-        "load",
-    ),
+    case_bad_ref_form => ("case-bad-ref-form.yaml", "schedule/zz-defect.yaml", "load"),
+    case_bad_capture_source => ("case-bad-capture-source.yaml", "schedule/zz-defect.yaml", "load"),
+    case_duplicate_yaml_key =>
+        ("case-duplicate-yaml-key.yaml", "schedule/zz-defect.yaml", "load"),
+
     // cross-artifact rejections
-    (
-        "case-duplicate-id.yaml",
-        "schedule/zz-defect.yaml",
-        "id-uniqueness",
-    ),
-    (
-        "case-unresolved-sm-op.yaml",
-        "schedule/zz-defect.yaml",
-        "sm-operation",
-    ),
-    (
-        "case-bad-spec-ref.yaml",
-        "schedule/zz-defect.yaml",
-        "spec-ref",
-    ),
-    (
-        "case-unmapped-outcome.yaml",
-        "schedule/zz-defect.yaml",
-        "binding-completeness",
-    ),
-    (
-        "case-unmapped-capture.yaml",
-        "schedule/zz-defect.yaml",
-        "binding-completeness",
-    ),
-    (
-        "case-unresolved-verified-by.yaml",
-        "schedule/zz-defect.yaml",
-        "verified-by",
-    ),
-    (
-        "case-missing-corpus-key.yaml",
-        "schedule/zz-defect.yaml",
-        "corpus-integrity",
-    ),
-    (
-        "case-missing-view.yaml",
-        "schedule/zz-defect.yaml",
-        "corpus-integrity",
-    ),
+    case_duplicate_id => ("case-duplicate-id.yaml", "schedule/zz-defect.yaml", "id-uniqueness"),
+    case_unresolved_sm_op =>
+        ("case-unresolved-sm-op.yaml", "schedule/zz-defect.yaml", "sm-operation"),
+    case_bad_spec_ref => ("case-bad-spec-ref.yaml", "schedule/zz-defect.yaml", "spec-ref"),
+    case_unmapped_outcome =>
+        ("case-unmapped-outcome.yaml", "schedule/zz-defect.yaml", "binding-completeness"),
+    case_unmapped_capture =>
+        ("case-unmapped-capture.yaml", "schedule/zz-defect.yaml", "binding-completeness"),
+    case_unresolved_verified_by =>
+        ("case-unresolved-verified-by.yaml", "schedule/zz-defect.yaml", "verified-by"),
+    case_missing_corpus_key =>
+        ("case-missing-corpus-key.yaml", "schedule/zz-defect.yaml", "corpus-integrity"),
+    case_missing_view => ("case-missing-view.yaml", "schedule/zz-defect.yaml", "corpus-integrity"),
     // The EXTRACT a `requires.import` replays resolves like any other corpus
     // reference, so a dangling fixture name is caught before a SUT is composed.
-    (
-        "case-import-missing-corpus-key.yaml",
-        "schedule/zz-defect.yaml",
-        "corpus-integrity",
-    ),
+    case_import_missing_corpus_key =>
+        ("case-import-missing-corpus-key.yaml", "schedule/zz-defect.yaml", "corpus-integrity"),
     // The closed token vocabularies a bundled CONTRIBUTION member may spell
     // (change_type / _type / lifecycle_state) — an out-of-group state would
     // otherwise commit a version the case never asked for.
-    (
-        "case-bad-member-lifecycle-token.yaml",
-        "schedule/zz-defect.yaml",
-        "literal-grammar",
-    ),
-    (
-        "case-unresolved-ambiguity.yaml",
-        "schedule/zz-defect.yaml",
-        "ambiguity-link",
-    ),
-    (
-        "case-unresolved-option.yaml",
-        "schedule/zz-defect.yaml",
-        "option-tag",
-    ),
-    (
-        "case-unknown-capability.yaml",
-        "schedule/zz-defect.yaml",
-        "capability-tier",
-    ),
-    (
-        "case-profile-tier-mismatch.yaml",
-        "schedule/zz-defect.yaml",
-        "capability-tier",
-    ),
-    (
-        "case-aggregate-without-single-pass.yaml",
-        "schedule/zz-defect.yaml",
-        "kind-shape",
-    ),
-    (
-        "case-two-field-predicates.yaml",
-        "schedule/zz-defect.yaml",
-        "kind-shape",
-    ),
-    (
-        "case-signature-no-fact.yaml",
-        "schedule/zz-defect.yaml",
-        "kind-shape",
-    ),
-    (
-        "case-undefined-capture-ref.yaml",
-        "schedule/zz-defect.yaml",
-        "reference-grammar",
-    ),
-    (
-        "case-bad-literal.yaml",
-        "schedule/zz-defect.yaml",
-        "literal-grammar",
-    ),
-    (
-        "corpus-missing-source.yaml",
-        "corpus/MANIFEST.yaml",
-        "corpus-integrity",
-    ),
-    (
-        "outcomes-wrong-class.yaml",
-        "vocab/outcomes.yaml",
-        "vocab-drift",
-    ),
-    (
-        "wire-surface-empty.yaml",
-        "vocab/wire_surface.yaml",
-        "surface-coverage",
-    ),
-];
-
-fn copy_tree(from: &std::path::Path, to: &std::path::Path) {
-    std::fs::create_dir_all(to).expect("mkdir");
-    for entry in std::fs::read_dir(from).expect("read_dir") {
-        let entry = entry.expect("entry");
-        let target = to.join(entry.file_name());
-        if entry.path().is_dir() {
-            copy_tree(&entry.path(), &target);
-        } else {
-            std::fs::copy(entry.path(), &target).expect("copy");
-        }
-    }
+    case_bad_member_lifecycle_token =>
+        ("case-bad-member-lifecycle-token.yaml", "schedule/zz-defect.yaml", "literal-grammar"),
+    case_unresolved_ambiguity =>
+        ("case-unresolved-ambiguity.yaml", "schedule/zz-defect.yaml", "ambiguity-link"),
+    case_unresolved_option =>
+        ("case-unresolved-option.yaml", "schedule/zz-defect.yaml", "option-tag"),
+    case_unknown_capability =>
+        ("case-unknown-capability.yaml", "schedule/zz-defect.yaml", "capability-tier"),
+    case_profile_tier_mismatch =>
+        ("case-profile-tier-mismatch.yaml", "schedule/zz-defect.yaml", "capability-tier"),
+    case_aggregate_without_single_pass =>
+        ("case-aggregate-without-single-pass.yaml", "schedule/zz-defect.yaml", "kind-shape"),
+    case_two_field_predicates =>
+        ("case-two-field-predicates.yaml", "schedule/zz-defect.yaml", "kind-shape"),
+    case_signature_no_fact =>
+        ("case-signature-no-fact.yaml", "schedule/zz-defect.yaml", "kind-shape"),
+    case_undefined_capture_ref =>
+        ("case-undefined-capture-ref.yaml", "schedule/zz-defect.yaml", "reference-grammar"),
+    case_bad_literal => ("case-bad-literal.yaml", "schedule/zz-defect.yaml", "literal-grammar"),
+    corpus_missing_source =>
+        ("corpus-missing-source.yaml", "corpus/MANIFEST.yaml", "corpus-integrity"),
+    outcomes_wrong_class => ("outcomes-wrong-class.yaml", "vocab/outcomes.yaml", "vocab-drift"),
+    wire_surface_empty =>
+        ("wire-surface-empty.yaml", "vocab/wire_surface.yaml", "surface-coverage"),
 }
 
-#[test]
-fn every_seeded_defect_is_rejected_by_its_gate() {
-    let crate_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
-    let specs = crate_dir
+/// This crate's directory (`tools/cnf-runner`).
+fn crate_dir() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// The seeded-defect fixture directory.
+fn fixture_dir() -> PathBuf {
+    crate_dir().join("tests/fixtures/defects")
+}
+
+/// The vendored spec tree the citation-resolution gates read.
+fn spec_root() -> PathBuf {
+    crate_dir()
         .ancestors()
         .nth(2)
         .expect("repo root")
-        .join("docs/specs/openehr");
-    let fixtures = crate_dir.join("tests/fixtures/defects");
+        .join("docs/specs/openehr")
+}
 
-    // Every fixture on disk must be in the table — no silent dead fixtures.
-    let mut on_disk: Vec<String> = std::fs::read_dir(&fixtures)
+/// Build the world one defect validates against: the pristine artifact tree,
+/// with `dest` replaced (or added) from `fixture`.
+///
+/// Every entry the overlaid path does not pass through is a symlink to the
+/// pristine tree; only the directories along `dest` are real, and the overlaid
+/// name itself is never linked, so the copy at the end always creates a fresh
+/// file and can never write through into `artifacts/`.
+fn overlay_world(dest: &str, fixture: &str) -> assert_fs::TempDir {
+    let temp = assert_fs::TempDir::new().expect("temp dir");
+    let mut source = crate_dir().join("artifacts");
+    let mut target = temp.path().to_owned();
+
+    for component in Path::new(dest) {
+        std::fs::create_dir_all(&target).expect("mkdir");
+        for entry in std::fs::read_dir(&source).expect("read_dir") {
+            let entry = entry.expect("entry");
+            if entry.file_name() == component {
+                continue; // the overlaid path: materialized, never linked
+            }
+            std::os::unix::fs::symlink(entry.path(), target.join(entry.file_name()))
+                .expect("symlink");
+        }
+        source = source.join(component);
+        target = target.join(component);
+    }
+
+    assert!(
+        !target.exists(),
+        "{dest}: the overlay destination must not exist yet"
+    );
+    std::fs::copy(fixture_dir().join(fixture), &target).expect("overlay");
+    temp
+}
+
+/// Load the world holding `fixture` at `dest` and assert the `expected` gate
+/// rejected it.
+fn assert_rejected(fixture: &str, dest: &str, expected: &str) {
+    let world = overlay_world(dest, fixture);
+    let specs = spec_root();
+
+    let loaded = load_root(world.path()).expect("schema compilation");
+    let findings = validate(&Context {
+        set: &loaded.set,
+        load_errors: &loaded.errors,
+        spec_root: Some(&specs),
+    });
+
+    // The clean world produces zero findings (`artifact_gates.rs`), so any
+    // finding at all is attributable to the seeded defect; the specific-gate
+    // assertion pins WHICH gate caught it.
+    assert!(
+        !findings.is_empty(),
+        "{fixture}: defect produced no findings at all"
+    );
+    assert!(
+        findings.iter().any(|f| f.check.token() == expected),
+        "{fixture}: expected a `{expected}` finding, got:\n{}",
+        findings
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+}
+
+/// Every fixture on disk has a test — a fixture nobody exercises is a silent
+/// hole in the negative battery, so it fails here rather than passing unseen.
+#[test]
+fn every_defect_fixture_has_a_test() {
+    let mut on_disk: Vec<String> = std::fs::read_dir(fixture_dir())
         .expect("defects dir")
         .map(|e| e.expect("entry").file_name().to_string_lossy().into_owned())
         .collect();
@@ -234,37 +230,4 @@ fn every_seeded_defect_is_rejected_by_its_gate() {
         on_disk, in_table,
         "defect fixtures and the expectation table diverge"
     );
-
-    for (fixture, dest, expected) in DEFECTS {
-        let temp = assert_fs::TempDir::new().expect("temp dir");
-        copy_tree(&crate_dir.join("artifacts"), temp.path());
-        let dest_path = temp.path().join(dest);
-        std::fs::create_dir_all(dest_path.parent().expect("parent")).expect("mkdir");
-        std::fs::copy(fixtures.join(fixture), &dest_path).expect("overlay");
-
-        let loaded = load_root(temp.path()).expect("schema compilation");
-        let findings = validate(&Context {
-            set: &loaded.set,
-            load_errors: &loaded.errors,
-            spec_root: Some(&specs),
-        });
-        let hit = findings.iter().any(|f| f.check.token() == *expected);
-        assert!(
-            hit,
-            "{fixture}: expected a `{expected}` finding, got:\n{}",
-            findings
-                .iter()
-                .map(ToString::to_string)
-                .collect::<Vec<_>>()
-                .join("\n")
-        );
-        // The clean world produced zero findings, so any finding at all is
-        // attributable to the seeded defect; the specific-gate assertion
-        // above pins WHICH gate caught it.
-        assert!(
-            !findings.is_empty(),
-            "{fixture}: defect produced no findings at all"
-        );
-        let _ = CheckId::Load; // the enum is the vocabulary the tokens come from
-    }
 }


### PR DESCRIPTION
Closes #1801. Profile-first: the 365s single test was ~95% of the whole 382s workspace suite. Three fixes — symlink-overlay worlds (the 220MB-per-defect recursive copy was the dominator AND was evicting the page cache for everything after it), one test per fixture from a single-source macro (nextest parallelizes; failures name the defect; an orphan-fixture gate makes silent skips impossible), and a memoized SpecIndex over the vendored spec tree (findings byte-identical — the coverage report regenerates unchanged).

**Battery: 309.7s → 19.5–39.8s. Whole cnf-runner suite: 287.9s → 48–61s.** Zero defects dropped (38, each still running the FULL gate battery — no gate scoping), completeness and strength both mutation-verified.

Findings byte-compatibility: the io-error text is cached verbatim; `docs/conformance/coverage-report.md` regenerates byte-identical.