### PR TITLE
fix(app): 500-class bodies carry curated messages — the diagnostics leak family closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,18 @@ workflow refuses a tag that has no matching section here.
   version identifiers this server's own reader refuses. The configured value is
   now validated against the openEHR `uid` grammar itself
   (`iso_oid | uuid | internet_id`).
+- **`500`-class responses no longer echo internal diagnostics.** A server-side
+  fault previously rendered whatever produced it straight into the response
+  body: serde's parser message (naming Rust fields and byte offsets), the AQL
+  executor's PostgreSQL driver string (naming generated SQL and schema
+  objects), the node codec's RM attribute names and internal row shape, the
+  authorization engine's failure reason, and the XML/Simplified-Format
+  serializers' diagnostics. Every `500`-class body now carries a curated,
+  opaque message and the full detail goes to the server's own log instead.
+  `4xx` refusals are unchanged and still name the client-caused defect — a
+  malformed request payload is still refused `400` with the parse error that
+  explains it, which is the only thing a caller can act on.
+
 - **A tag PUT body is now validated against the released write schema.**
   `schemas/common/UpdateItemTag.yaml` declares exactly `key` (required),
   `value` and `target_path`, with `additionalProperties: false`. Previously the

--- a/app/ferroehr-rest/src/api/definition/template_adl14.rs
+++ b/app/ferroehr-rest/src/api/definition/template_adl14.rs
@@ -286,9 +286,10 @@ async fn web_template_response(
         .await
         .map_err(RestError::from)?;
     let json = serde_json::to_string(&*built).map_err(|e| {
-        RestError(ApiError::Internal(format!(
-            "WebTemplate JSON serialization failed: {e}"
-        )))
+        RestError(crate::overview::error::internal_fault(
+            "serialize the WebTemplate response",
+            &e,
+        ))
     })?;
     let mut resp = match fmt {
         WireFormat::CanonicalJson => negotiate::json_body(StatusCode::OK, json),

--- a/app/ferroehr-rest/src/api/demographic/party.rs
+++ b/app/ferroehr-rest/src/api/demographic/party.rs
@@ -188,10 +188,10 @@ async fn persist_request_tags(
     // never a client one.
     let container_uid = ObjectVersionId::new(version_uid.clone())
         .map_err(|e| {
-            ApiError::Internal(format!(
-                "the committed version uid {version_uid:?} is not a well-formed \
-                 OBJECT_VERSION_ID: {e}"
-            ))
+            crate::overview::error::internal_fault(
+                "read the committed version uid",
+                &format!("{version_uid:?}: {e}"),
+            )
         })?
         .object_id()
         .value()

--- a/app/ferroehr-rest/src/api/ehr/mod.rs
+++ b/app/ferroehr-rest/src/api/ehr/mod.rs
@@ -313,10 +313,10 @@ pub(super) async fn apply_item_tag_headers(
     // never a client one.
     let container_uid = ObjectVersionId::new(version_uid)
         .map_err(|e| {
-            ApiError::Internal(format!(
-                "the committed version uid {version_uid:?} is not a well-formed \
-                 OBJECT_VERSION_ID: {e}"
-            ))
+            crate::overview::error::internal_fault(
+                "read the committed version uid",
+                &format!("{version_uid:?}: {e}"),
+            )
         })?
         .object_id()
         .value()

--- a/app/ferroehr-rest/src/extensions/access/authn/mod.rs
+++ b/app/ferroehr-rest/src/extensions/access/authn/mod.rs
@@ -143,7 +143,11 @@ impl AuthError {
     fn to_api_error(&self) -> ApiError {
         match self {
             AuthError::Forbidden(m) => ApiError::Forbidden(m.clone()),
-            AuthError::VerificationUnavailable(m) => ApiError::Internal(m.clone()),
+            // A server fault: the reason names an internal task/KDF failure,
+            // so it is traced and the body carries the curated message.
+            AuthError::VerificationUnavailable(m) => {
+                crate::overview::error::internal_fault("verify the supplied credentials", m)
+            }
             other => ApiError::Unauthorized(other.to_string()),
         }
     }

--- a/app/ferroehr-rest/src/extensions/access/ehr_access.rs
+++ b/app/ferroehr-rest/src/extensions/access/ehr_access.rs
@@ -263,9 +263,10 @@ fn forbidden(principal: Option<&Principal>, detail: &str) -> Response {
 /// A `500` (fail-closed) when the settings cannot be read — an access decision
 /// must never proceed on unknown policy.
 fn server_error(principal: Option<&Principal>, detail: &str) -> Response {
-    let mut resp = RestError(ApiError::Internal(format!(
-        "authorization unavailable: {detail}"
-    )))
+    let mut resp = RestError(crate::overview::error::internal_fault(
+        "read the EHR access-control settings",
+        &detail,
+    ))
     .into_response();
     if let Some(principal) = principal {
         resp.extensions_mut().insert(principal.clone());

--- a/app/ferroehr-rest/src/extensions/access/pep.rs
+++ b/app/ferroehr-rest/src/extensions/access/pep.rs
@@ -537,11 +537,14 @@ fn forbidden(principal: &Principal, detail: &str) -> Response {
     resp
 }
 
-/// A 500 (fail-closed) carrying the principal.
+/// A 500 (fail-closed) carrying the principal. `detail` names why the policy
+/// engine could not decide — server-internal, so it goes to the trace record
+/// and the body carries the curated opaque message.
 fn engine_error(principal: &Principal, detail: &str) -> Response {
-    let mut resp = RestError(ApiError::Internal(format!(
-        "authorization unavailable: {detail}"
-    )))
+    let mut resp = RestError(crate::overview::error::internal_fault(
+        "reach an authorization decision",
+        &detail,
+    ))
     .into_response();
     resp.extensions_mut().insert(principal.clone());
     resp

--- a/app/ferroehr-rest/src/formats/dispatch.rs
+++ b/app/ferroehr-rest/src/formats/dispatch.rs
@@ -59,8 +59,16 @@ fn now() -> String {
     jiff::Timestamp::now().to_string()
 }
 
-fn internal(msg: impl Into<String>) -> RestError {
-    RestError(ApiError::Internal(msg.into()))
+/// A server-side fault raised while converting between the canonical and
+/// simplified representations. `detail` (a serde diagnostic, a missing stored
+/// attribute, an unreachable branch) is server-internal, so it goes to the
+/// trace record and the `500` body carries the curated opaque message
+/// ([`crate::overview::error::internal_fault`]).
+fn internal(detail: impl std::fmt::Display) -> RestError {
+    RestError(crate::overview::error::internal_fault(
+        "convert between the canonical and Simplified Formats",
+        &detail,
+    ))
 }
 
 /// The `422` for a simplified COMPOSITION commit that supplies no template id.
@@ -93,9 +101,7 @@ fn flat_input_err(e: &openehr_its::flat::error::FlatError) -> RestError {
 /// a server fault → `500` (`Requests_and_responses.md §HTTP status codes`, row
 /// `500`).
 fn flat_output_err(e: &openehr_its::flat::error::FlatError) -> RestError {
-    RestError(ApiError::Internal(format!(
-        "Simplified-Format conversion failed: {e}"
-    )))
+    internal(e)
 }
 
 // ── COMPOSITION: request side ──────────────────────────────────────────────

--- a/app/ferroehr-rest/src/overload.rs
+++ b/app/ferroehr-rest/src/overload.rs
@@ -73,9 +73,10 @@ pub(crate) async fn handle_overload(err: BoxError) -> Response {
         );
         resp
     } else {
-        RestError(ApiError::Internal(format!(
-            "unexpected overload-layer error: {err}"
-        )))
+        RestError(crate::overview::error::internal_fault(
+            "run the overload-shedding layer",
+            &err,
+        ))
         .into_response()
     }
 }

--- a/app/ferroehr-rest/src/overview/error.rs
+++ b/app/ferroehr-rest/src/overview/error.rs
@@ -35,6 +35,27 @@ use openehr_its::rest::runtime::ApiError;
 #[derive(Debug)]
 pub struct RestError(pub ApiError);
 
+/// The client-visible message of a server-side fault (`500`) raised inside the
+/// protocol adapter. Deliberately opaque, for the same reason the platform's
+/// own 500-class message is: a codec/serializer diagnostic names Rust types,
+/// RM element names and parser offsets — server-internal detail the client can
+/// neither act on nor be trusted with. The detail rides one structured
+/// `tracing` record instead ([`internal_fault`]). ITS-REST overview §HTTP
+/// status codes fixes the `{ error, message }` shape but not the wording; the
+/// opacity is our own design.
+pub(crate) const INTERNAL_MESSAGE: &str = "the server encountered an internal error";
+
+/// Record an adapter-side fault on the trace record and return the curated
+/// opaque `500` [`ApiError`] its body carries.
+///
+/// `context` names the step that failed (a static call-site label); `detail` is
+/// the raw diagnostic — a serde error, an XML codec failure, a middleware error
+/// — which is written to `tracing` and NEVER to the wire.
+pub(crate) fn internal_fault(context: &'static str, detail: &dyn std::fmt::Display) -> ApiError {
+    tracing::error!(context, error = %detail, "protocol adapter: internal fault → 500");
+    ApiError::Internal(INTERNAL_MESSAGE.to_owned())
+}
+
 impl From<ApiError> for RestError {
     fn from(e: ApiError) -> Self {
         Self(e)

--- a/app/ferroehr-rest/src/overview/negotiate.rs
+++ b/app/ferroehr-rest/src/overview/negotiate.rs
@@ -685,9 +685,8 @@ pub(crate) fn respond<T: Serialize>(
                 );
                 resp
             }
-            Err(e) => {
-                ApiError::Internal(format!("JSON serialization failed: {e}")).into_response_body()
-            }
+            Err(e) => crate::overview::error::internal_fault("serialize the JSON response", &e)
+                .into_response_body(),
         },
         None => ApiError::NotAcceptable(
             "this response is available as application/json only".to_owned(),
@@ -768,9 +767,10 @@ where
             let typed: T = match openehr_its::json::from_canonical_value(value) {
                 Ok(t) => t,
                 Err(e) => {
-                    return ApiError::Internal(format!(
-                        "re-typing canonical JSON to <{root_tag}> for the XML response failed: {e}"
-                    ))
+                    return crate::overview::error::internal_fault(
+                        "re-type the canonical JSON for the XML response",
+                        &format!("<{root_tag}>: {e}"),
+                    )
                     .into_response_body();
                 }
             };
@@ -782,7 +782,7 @@ where
             };
             match serialized {
                 Ok(xml) => xml_body_ns(status, xml, ns),
-                Err(e) => ApiError::Internal(format!("XML serialization failed: {e}"))
+                Err(e) => crate::overview::error::internal_fault("serialize the XML response", &e)
                     .into_response_body(),
             }
         }

--- a/app/ferroehr-rest/src/router.rs
+++ b/app/ferroehr-rest/src/router.rs
@@ -294,10 +294,7 @@ fn handle_panic(err: Box<dyn Any + Send + 'static>) -> Response {
         "unknown panic payload".to_owned()
     };
     tracing::error!(panic = %detail, "request handler panicked");
-    error::RestError(ApiError::Internal(
-        "the server encountered an internal error".to_owned(),
-    ))
-    .into_response()
+    error::RestError(ApiError::Internal(error::INTERNAL_MESSAGE.to_owned())).into_response()
 }
 
 /// Align the two **transport-layer** error responses the `tower-http` stack

--- a/app/ferroehr/src/extensions/fhir/mod.rs
+++ b/app/ferroehr/src/extensions/fhir/mod.rs
@@ -37,7 +37,7 @@ use uuid::Uuid;
 use crate::ids::{EhrId, VoId};
 use crate::service::FerroEhrService;
 use crate::service::ehr_index::types::SubjectRef;
-use crate::service::error::{ServiceError, Violation};
+use crate::service::error::{ServiceError, Violation, internal_fault};
 use crate::service::query::request::AqlQueryRequest;
 use crate::service::response::ServiceResponse;
 use crate::service::status::{CallStatusType, SmError};
@@ -228,12 +228,9 @@ impl FerroEhrService {
     async fn ensure_ehr_for_subject(&self, subject: SubjectRef) -> Result<EhrId, SmError> {
         let existing = self.get_ehrs_for_subject(subject.clone()).await?;
         if let Some(summary) = existing.first() {
-            return Uuid::parse_str(&summary.ehr_id).map(EhrId).map_err(|e| {
-                SmError::new(
-                    CallStatusType::Exception,
-                    format!("stored ehr id invalid: {e}"),
-                )
-            });
+            return Uuid::parse_str(&summary.ehr_id)
+                .map(EhrId)
+                .map_err(|e| internal_fault("read a stored EHR id", &e));
         }
         self.create_ehr_for_subject(subject, None).await
     }
@@ -297,12 +294,8 @@ impl FerroEhrService {
         let scope = self.resolve_patient_scope(patient).await?;
         let mut entries: Vec<Value> = Vec::new();
         for raw in self.enabled_definitions_for_type(resource_type).await? {
-            let def: FhirMappingDefinition = serde_json::from_value(raw).map_err(|e| {
-                SmError::new(
-                    CallStatusType::Exception,
-                    format!("stored FHIR mapping definition is invalid: {e}"),
-                )
-            })?;
+            let def: FhirMappingDefinition = serde_json::from_value(raw)
+                .map_err(|e| internal_fault("read a stored FHIR mapping definition", &e))?;
             let wt = self.web_template_for(&def.template_id).await?;
             let request = AqlQueryRequest {
                 ehr_ids: scope.ehr_id.map(|u| u.to_string()).into_iter().collect(),
@@ -357,7 +350,7 @@ impl FerroEhrService {
                     &def,
                     scope.subject_id.as_deref(),
                 )
-                .map_err(|e| SmError::new(CallStatusType::Exception, e.to_string()))?;
+                .map_err(|e| internal_fault("render a stored COMPOSITION as FHIR", &e))?;
                 // The versioned-object id (a UUID) is the FHIR logical id + the
                 // `urn:uuid:` fullUrl.
                 if let Value::Object(m) = &mut fhir {
@@ -606,12 +599,8 @@ impl FerroEhrService {
                     format!("no enabled FHIR mapping for resource type '{resource_type}'"),
                 )
             })?;
-        let def: FhirMappingDefinition = serde_json::from_value(def_value).map_err(|e| {
-            SmError::new(
-                CallStatusType::Exception,
-                format!("stored FHIR mapping definition is invalid: {e}"),
-            )
-        })?;
+        let def: FhirMappingDefinition = serde_json::from_value(def_value)
+            .map_err(|e| internal_fault("read a stored FHIR mapping definition", &e))?;
 
         // 2. Resolve-or-create the target EHR from the resource's subject.
         let subject = mapping::extract_subject(&a_resource, &def)

--- a/app/ferroehr/src/service/ehr/composition.rs
+++ b/app/ferroehr/src/service/ehr/composition.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 use crate::ids::{EhrId, VoId};
 use crate::service::FerroEhrService;
 use crate::service::datetime::parse_at_time;
-use crate::service::error::{ServiceError, Violation};
+use crate::service::error::{ServiceError, Violation, internal_fault};
 use crate::service::response::{ResourceMeta, ServiceResponse};
 use crate::service::status::{CallStatusType, SmError};
 use crate::service::version_update::UpdateVersion;
@@ -927,7 +927,7 @@ impl FerroEhrService {
         engine
             .expand(&mut body)
             .await
-            .map_err(|e| SmError::exception(e.to_string()))?;
+            .map_err(|e| internal_fault("expand a multimedia reference", &e))?;
         Ok(body)
     }
 }

--- a/app/ferroehr/src/service/ehr/contributions.rs
+++ b/app/ferroehr/src/service/ehr/contributions.rs
@@ -20,7 +20,7 @@ use serde_json::{Value, json};
 use uuid::Uuid;
 
 use crate::service::FerroEhrService;
-use crate::service::error::ServiceError;
+use crate::service::error::{ServiceError, internal_fault};
 use crate::versioning::contribution::{
     commit_version_set, count_contributions, get_contribution, list_contributions,
 };
@@ -162,10 +162,10 @@ impl FerroEhrService {
         // `update_audit.adoc`), not a `DV_CODED_TEXT` (see the NOTEs in
         // `versioning/contribution.rs` `coded_value`/`classify`). A native
         // typed path skipping the JSON round-trip is a future cleanup.
-        let versions_json =
-            serde_json::to_value(&versions).map_err(|e| SmError::exception(e.to_string()))?;
-        let audit_json =
-            serde_json::to_value(&an_audit).map_err(|e| SmError::exception(e.to_string()))?;
+        let versions_json = serde_json::to_value(&versions)
+            .map_err(|e| internal_fault("serialize the CONTRIBUTION version set", &e))?;
+        let audit_json = serde_json::to_value(&an_audit)
+            .map_err(|e| internal_fault("serialize the CONTRIBUTION audit", &e))?;
         let body = json!({ "versions": versions_json, "audit": audit_json });
         let committed = commit_version_set(self, Some(an_ehr_id), &body, false).await?;
         Ok(committed.id.to_string())

--- a/app/ferroehr/src/service/error.rs
+++ b/app/ferroehr/src/service/error.rs
@@ -171,19 +171,63 @@ pub enum ServiceError {
     /// A database failure.
     #[error("database: {0}")]
     Database(#[from] sqlx::Error),
-    /// A JSON (de)serialization failure.
-    #[error("json: {0}")]
-    Json(#[from] serde_json::Error),
+    /// A JSON payload the server was asked to READ is malformed — a
+    /// client-caused refusal (`400`) whose wire message NAMES the defect
+    /// (offset, expected token), because that is the only thing the caller can
+    /// act on. Constructed explicitly at a read site; never by `?`.
+    #[error("malformed json: {0}")]
+    JsonRead(serde_json::Error),
+    /// The server failed to serialize its OWN data — a server-side fault
+    /// (`500`). This is the `From<serde_json::Error>` default (a bare `?` on a
+    /// `serde_json` failure lands here), because the safe classification of an
+    /// unattributed codec failure is "our fault, say nothing": a serde
+    /// diagnostic names Rust type and field names, which is server-internal
+    /// detail no client can act on. The full diagnostic goes to `tracing`
+    /// instead, and the wire body carries `INTERNAL_MESSAGE`.
+    #[error("json serialization failed: {0}")]
+    JsonWrite(#[from] serde_json::Error),
     /// A version-signing or read-time integrity failure (RM common master06
     /// §Digital Signature) — either signing at commit failed, or
     /// `verify_on_read = strict` found a stored signature that does not match
     /// the served version.
+    ///
+    /// The carried text is a LOG detail, not a wire message: both bridges
+    /// below trace it and answer with `INTERNAL_MESSAGE`.
     #[error("signing: {0}")]
     Signing(String),
     /// A server-side fault with no more specific variant (SM
     /// `CALL_STATUS_TYPE.exception` / `file_not_writable` — → HTTP 500).
+    ///
+    /// The carried text is a LOG detail, not a wire message. Sites construct
+    /// it with whatever diagnoses the fault (a codec error, an unexpected
+    /// stored shape, a failed conversion); both bridges below put that on the
+    /// trace record and answer with `INTERNAL_MESSAGE`, because a `500` is
+    /// by definition something the client cannot act on.
     #[error("internal: {0}")]
     Internal(String),
+}
+
+/// The client-visible message of a server-side fault (`500`). Deliberately
+/// opaque: a serde/codec/driver diagnostic names Rust types, RM attribute
+/// names, SQL aliases and schema objects — server-internal detail the client
+/// can neither act on nor be trusted with. The diagnosis belongs in the
+/// server's own logs, so every 500-class body carries this sentence and the
+/// detail rides one structured `tracing` record instead. (No openEHR spec
+/// governs error-body wording beyond the `{ error, message }` shape —
+/// ITS-REST overview §HTTP status codes; the opacity is our own design.)
+pub(crate) const INTERNAL_MESSAGE: &str = "the server encountered an internal error";
+
+/// Record a server-side fault on the trace record and return the curated
+/// opaque `exception` [`SmError`] its 500-class body carries.
+///
+/// `context` names the operation that failed (a static call-site label);
+/// `detail` is the raw diagnostic — a serde error, a codec failure, a driver
+/// string — which is written to `tracing` and NEVER to the wire. Use this at
+/// every site that would otherwise render a foreign error's `Display` into a
+/// 500 body.
+pub(crate) fn internal_fault(context: &'static str, detail: &dyn std::fmt::Display) -> SmError {
+    tracing::error!(context, error = %detail, "internal server fault → 500");
+    SmError::new(CallStatusType::Exception, INTERNAL_MESSAGE.to_owned())
 }
 
 impl ServiceError {
@@ -270,7 +314,8 @@ impl From<ServiceError> for SmError {
     /// | `ValidationFailed`        | `ContentInvalid`             | 422  |
     /// | `BadRequest`              | `PreconditionViolation`      | 400  |
     /// | `Storage`/`Database`      | classified: 409/503/500      |      |
-    /// | `Json`/`Signing`/`Internal` | `Exception`                | 500  |
+    /// | `JsonRead`                | `PreconditionViolation`      | 400  |
+    /// | `JsonWrite`/`Signing`/`Internal` | `Exception`           | 500  |
     ///
     /// `NotFound` carries the granular does-not-exist [`SmError`] it was
     /// constructed with ([`ServiceError::sm`]), so the round-trip restores the
@@ -326,8 +371,13 @@ impl From<ServiceError> for SmError {
             // instead of collapsing every database error to a blanket 500.
             // The classifier emits the structured trace.
             ServiceError::Database(e) => crate::storage::error::classify_sqlx(&e),
-            ServiceError::Json(e) => SmError::new(S::Exception, e.to_string()),
-            ServiceError::Signing(m) | ServiceError::Internal(m) => SmError::new(S::Exception, m),
+            // A malformed payload the server was asked to read names its own
+            // defect (`400`); a failure to serialize the server's own data is
+            // a server fault whose diagnostic stays in the log (`500`).
+            ServiceError::JsonRead(e) => SmError::new(S::PreconditionViolation, e.to_string()),
+            ServiceError::JsonWrite(e) => internal_fault("serialize a JSON payload", &e),
+            ServiceError::Signing(m) => internal_fault("sign or verify a version", &m),
+            ServiceError::Internal(m) => internal_fault("complete the request", &m),
         }
     }
 }
@@ -353,12 +403,24 @@ impl From<ServiceError> for ApiError {
             ServiceError::Database(e) => {
                 sqlx_conflict_api_error(crate::storage::error::classify_sqlx(&e))
             }
-            // A JSON (de)serialization failure at the service boundary is a
-            // malformed client payload → 400.
-            ServiceError::Json(e) => ApiError::BadRequest(e.to_string()),
+            // A malformed payload the server was asked to read is a client
+            // defect → `400`, and the body names it (that IS the strict
+            // reader's contract). A failure to serialize the server's own data
+            // is a server fault → `500` with the curated opaque message; the
+            // serde diagnostic rides the trace record only.
+            ServiceError::JsonRead(e) => ApiError::BadRequest(e.to_string()),
+            ServiceError::JsonWrite(e) => {
+                ApiError::Internal(internal_fault("serialize a JSON payload", &e).message)
+            }
             // Signing/integrity failures and generic faults are server-side
-            // (5xx).
-            ServiceError::Signing(m) | ServiceError::Internal(m) => ApiError::Internal(m),
+            // (`500`): the carried text is the log detail, the body is the
+            // curated message.
+            ServiceError::Signing(m) => {
+                ApiError::Internal(internal_fault("sign or verify a version", &m).message)
+            }
+            ServiceError::Internal(m) => {
+                ApiError::Internal(internal_fault("complete the request", &m).message)
+            }
         }
     }
 }
@@ -524,6 +586,94 @@ mod tests {
         for (status, expected) in rows {
             let got = ApiError::from(ServiceError::sm(status, "m")).status();
             assert_eq!(got, expected, "row {} diverged", status.sm_name());
+        }
+    }
+
+    /// The JSON twins: a payload the server was asked to READ names its own
+    /// defect on a `400` (the strict reader's contract — the client can only
+    /// fix what it is told), while a failure to serialize the server's OWN
+    /// data is a `500` whose body says nothing about serde's diagnosis. Both
+    /// bridges (`SmError` and `ApiError`) must agree, on both twins.
+    #[test]
+    fn json_read_names_its_defect_and_json_write_stays_opaque() {
+        use http::StatusCode as C;
+
+        // A serde diagnostic names Rust field/type names and the byte offset —
+        // the "internal markers" that must not reach a 500-class body.
+        let markers = ["invalid type", "line", "column"];
+        let parse_failure = || {
+            let failure: Result<std::collections::BTreeMap<String, i32>, _> =
+                serde_json::from_str("{\"committer\":\"not an integer\"}");
+            failure.expect_err("the fixture should fail to deserialize")
+        };
+        let rendered = parse_failure().to_string();
+        assert!(
+            markers.iter().any(|m| rendered.contains(m)),
+            "the fixture must actually produce a serde diagnostic, got {rendered:?}"
+        );
+
+        // READ → 400 on both bridges, naming the defect.
+        let read = ServiceError::JsonRead(parse_failure());
+        assert_eq!(
+            crate::service::status::SmError::from(ServiceError::JsonRead(parse_failure())).status,
+            S::PreconditionViolation
+        );
+        let api = ApiError::from(read);
+        assert_eq!(api.status(), C::BAD_REQUEST);
+        assert!(
+            markers.iter().any(|m| api.to_string().contains(m)),
+            "a parse refusal must name its defect, got {:?}",
+            api.to_string()
+        );
+
+        // WRITE → 500 on both bridges, carrying nothing of the diagnostic.
+        let sm = crate::service::status::SmError::from(ServiceError::JsonWrite(parse_failure()));
+        assert_eq!(sm.status, S::Exception);
+        let api = ApiError::from(ServiceError::JsonWrite(parse_failure()));
+        assert_eq!(api.status(), C::INTERNAL_SERVER_ERROR);
+        for leaked in markers {
+            assert!(
+                !sm.message.contains(leaked),
+                "the SM 500 message leaked {leaked:?}: {:?}",
+                sm.message
+            );
+            assert!(
+                !api.to_string().contains(leaked),
+                "the wire 500 body leaked {leaked:?}: {:?}",
+                api.to_string()
+            );
+        }
+    }
+
+    /// A `500`-class `ServiceError` carries its diagnosis to the LOG, never to
+    /// the client: whatever the fault site wrote into `Internal`/`Signing`
+    /// (a codec message, an unexpected stored shape, a failed conversion) stays
+    /// out of the body on BOTH bridges.
+    #[test]
+    fn internal_faults_never_render_their_diagnosis_on_the_wire() {
+        use http::StatusCode as C;
+
+        let detail = "typing the ORIGINAL_VERSION: unknown field `_kind` at line 3 column 12";
+        let markers = ["ORIGINAL_VERSION", "unknown field", "_kind", "line 3"];
+        let variants: [fn(String) -> ServiceError; 2] =
+            [ServiceError::Internal, ServiceError::Signing];
+        for make in variants {
+            let sm = crate::service::status::SmError::from(make(detail.to_owned()));
+            assert_eq!(sm.status, S::Exception);
+            let api = ApiError::from(make(detail.to_owned()));
+            assert_eq!(api.status(), C::INTERNAL_SERVER_ERROR);
+            for leaked in markers {
+                assert!(
+                    !sm.message.contains(leaked),
+                    "the SM 500 message leaked {leaked:?}: {:?}",
+                    sm.message
+                );
+                assert!(
+                    !api.to_string().contains(leaked),
+                    "the wire 500 body leaked {leaked:?}: {:?}",
+                    api.to_string()
+                );
+            }
         }
     }
 

--- a/app/ferroehr/src/service/query/execute.rs
+++ b/app/ferroehr/src/service/query/execute.rs
@@ -22,6 +22,7 @@ use crate::aql::error::{AqlError, ExecError};
 use crate::aql::ir::{Params, QueryIr};
 use crate::aql::sql::SqlCtx;
 use crate::service::FerroEhrService;
+use crate::service::error::internal_fault;
 use crate::service::query::request::{AqlQueryRequest, QueryOutcome};
 use crate::service::status::{QUERY_TIMEOUT_TAG, SmError};
 use crate::telemetry::prometheus::{AQL_QUERIES, AQL_QUERY_DURATION};
@@ -264,7 +265,7 @@ impl FerroEhrService {
             .bind(&ids)
             .fetch_all(&self.pool)
             .await
-            .map_err(|e| Failure::analysis(SmError::exception(e.to_string())))?;
+            .map_err(|e| Failure::analysis(internal_fault("resolve the requested ehr_ids", &e)))?;
         if let Some(missing) = ids.iter().find(|id| !present.contains(id)) {
             return Err(Failure::analysis(SmError::ehr_not_found(format!(
                 "no EHR with id {missing}"
@@ -419,13 +420,19 @@ fn map_plan_error(e: AqlError) -> SmError {
 /// Map an execution error: a database/assembly/terminology failure is the
 /// server's fault (`500`); a SQL-lowering failure that surfaces here is still
 /// a bad query (`400`).
+///
+/// The `500` legs carry the curated opaque message: a driver string names the
+/// schema objects the generated SQL touched, an assembly failure names the
+/// internal node-row shape, and a missing column alias names a generated SQL
+/// alias — server-internal detail that goes to `tracing` instead
+/// ([`internal_fault`]).
 fn map_exec_error(e: AqlError) -> SmError {
     match e {
-        AqlError::Exec(ExecError::Database(db)) => SmError::exception(db.to_string()),
-        AqlError::Exec(ExecError::Assembly(a)) => SmError::exception(a.to_string()),
+        AqlError::Exec(ExecError::Database(db)) => internal_fault("execute the generated SQL", &db),
+        AqlError::Exec(ExecError::Assembly(a)) => internal_fault("assemble the RESULT_SET", &a),
         AqlError::Exec(ExecError::Terminology(msg)) => SmError::exception(msg),
         AqlError::Exec(e @ ExecError::MissingColumnAlias { .. }) => {
-            SmError::exception(e.to_string())
+            internal_fault("bind a RESULT_SET column to its generated SQL alias", &e)
         }
         AqlError::Feature(_) | AqlError::Analysis(_) | AqlError::Sql(_) => {
             SmError::precondition(e.to_string())

--- a/app/ferroehr/src/service/subject_proxy/service.rs
+++ b/app/ferroehr/src/service/subject_proxy/service.rs
@@ -10,6 +10,7 @@
 use serde_json::Value;
 
 use crate::service::FerroEhrService;
+use crate::service::error::internal_fault;
 use crate::service::status::SmError;
 use crate::service::subject_proxy::binding::{DataFrame, EnvBinding};
 use crate::service::subject_proxy::data_set::{DataSetResult, SubjectDataSet};
@@ -105,7 +106,7 @@ impl FerroEhrService {
         .map_err(db_err)?;
         let Some(vars) = vars else { return Ok(None) };
         let map: std::collections::BTreeMap<String, SubjectVariable> = serde_json::from_value(vars)
-            .map_err(|e| SmError::exception(format!("stored data-set variables malformed: {e}")))?;
+            .map_err(|e| internal_fault("read the stored data-set variables", &e))?;
         Ok(Some(map.into_values().collect()))
     }
 }
@@ -237,9 +238,9 @@ impl FerroEhrService {
             using.push(app.clone());
         }
         let using_json = serde_json::to_value(&using)
-            .map_err(|e| SmError::exception(format!("serialize using_app_ids: {e}")))?;
+            .map_err(|e| internal_fault("serialize the data-set app ids", &e))?;
         let vars_json = serde_json::to_value(&definition.variables)
-            .map_err(|e| SmError::exception(format!("serialize data-set variables: {e}")))?;
+            .map_err(|e| internal_fault("serialize the data-set variables", &e))?;
 
         sqlx::query(
             "INSERT INTO sp_data_set (subject_id, id, creating_app_id, using_app_ids, variables) \

--- a/app/ferroehr/src/service/subject_proxy/store.rs
+++ b/app/ferroehr/src/service/subject_proxy/store.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 use sqlx::Row;
 
 use crate::service::FerroEhrService;
-use crate::service::error::ServiceError;
+use crate::service::error::{ServiceError, internal_fault};
 use crate::service::status::SmError;
 use crate::service::subject_proxy::binding::{DataFrame, SystemCall};
 use crate::service::subject_proxy::sample::{DataFrameSample, VariableSample};
@@ -103,7 +103,7 @@ impl FerroEhrService {
         .flatten();
         let Some(def) = def else { return Ok(None) };
         let var: SubjectVariable = serde_json::from_value(def)
-            .map_err(|e| SmError::exception(format!("stored data-set variable malformed: {e}")))?;
+            .map_err(|e| internal_fault("read a stored subject variable", &e))?;
         Ok(Some(var.canonical_name()))
     }
 
@@ -190,9 +190,10 @@ impl FerroEhrService {
         let parse_method = |v: Option<Value>, which: &str| -> Result<Option<SystemCall>, SmError> {
             v.map(|v| {
                 serde_json::from_value(v).map_err(|e| {
-                    SmError::exception(format!(
-                        "stored {which} method for frame {frame_id:?} is malformed: {e}"
-                    ))
+                    internal_fault(
+                        "read a stored data-frame method",
+                        &format!("{which} method of frame {frame_id:?}: {e}"),
+                    )
                 })
             })
             .transpose()
@@ -253,11 +254,11 @@ impl FerroEhrService {
         frame_sample: Option<&DataFrameSample>,
     ) -> Result<(), SmError> {
         let sample_json = serde_json::to_value(sample)
-            .map_err(|e| SmError::exception(format!("serialize variable sample: {e}")))?;
+            .map_err(|e| internal_fault("serialize a variable sample", &e))?;
         let frame_json = frame_sample
             .map(serde_json::to_value)
             .transpose()
-            .map_err(|e| SmError::exception(format!("serialize frame sample: {e}")))?;
+            .map_err(|e| internal_fault("serialize a data-frame sample", &e))?;
         let mut tx = self.pool.begin().await.map_err(db_err)?;
         sqlx::query(
             "INSERT INTO sp_sample (subject_id, canonical_name, frame_id, retrieve_time, \
@@ -340,11 +341,11 @@ fn parse_sample_row(
     let sample: Value = row.try_get("sample").map_err(db_err)?;
     let frame: Option<Value> = row.try_get("frame_sample").map_err(db_err)?;
     let sample: VariableSample = serde_json::from_value(sample)
-        .map_err(|e| SmError::exception(format!("stored variable sample malformed: {e}")))?;
+        .map_err(|e| internal_fault("read a stored variable sample", &e))?;
     let frame: Option<DataFrameSample> = frame
         .map(serde_json::from_value)
         .transpose()
-        .map_err(|e| SmError::exception(format!("stored frame sample malformed: {e}")))?;
+        .map_err(|e| internal_fault("read a stored data-frame sample", &e))?;
     Ok((sample, frame))
 }
 
@@ -393,13 +394,13 @@ pub(super) async fn insert_frame(
         .as_ref()
         .map(serde_json::to_value)
         .transpose()
-        .map_err(|e| SmError::exception(format!("serialize frame primary_method: {e}")))?;
+        .map_err(|e| internal_fault("serialize a data-frame primary method", &e))?;
     let fallback = frame
         .fallback_method
         .as_ref()
         .map(serde_json::to_value)
         .transpose()
-        .map_err(|e| SmError::exception(format!("serialize frame fallback_method: {e}")))?;
+        .map_err(|e| internal_fault("serialize a data-frame fallback method", &e))?;
     sqlx::query(
         "INSERT INTO sp_data_frame (env_id, frame_id, model_type, primary_method, fallback_method) \
          VALUES ($1, $2, $3, $4, $5)",

--- a/app/ferroehr/src/storage/error.rs
+++ b/app/ferroehr/src/storage/error.rs
@@ -99,11 +99,17 @@ impl From<StorageError> for crate::service::status::SmError {
                 SmError::new(CallStatusType::EhrForSubjectAlreadyExists, e.to_string())
             }
             // Codec faults (a non-structure root, a mixed array, malformed node
-            // rows) are our own bugs, not client errors → `500`.
+            // rows) are our own bugs, not client errors → `500`. Their text
+            // names RM attributes and the internal node-row shape, so the wire
+            // body carries the curated message and the detail is traced.
             StorageError::NotAStructureRoot(_)
             | StorageError::MixedArray { .. }
             | StorageError::InvalidRows(_) => {
-                SmError::new(CallStatusType::Exception, e.to_string())
+                tracing::error!(
+                    error = %e,
+                    "storage bridge: node-codec invariant violated → 500"
+                );
+                SmError::new(CallStatusType::Exception, CODEC_MESSAGE.to_owned())
             }
         }
     }
@@ -126,6 +132,14 @@ const RETRYABLE_CONFLICT_MESSAGE: &str =
 /// the client cannot act on it, and the diagnosis belongs in the server's own
 /// logs.
 const INTERNAL_MESSAGE: &str = "the server encountered an internal database error";
+
+/// The client-visible message of a node-codec fault — a versioned-object tree
+/// the decomposer could not take apart, or stored node rows that do not
+/// reassemble into one tree. Opaque for the same reason the driver string is:
+/// the error text names RM attribute names and the internal nested-set row
+/// shape, which is server-internal detail with no client action attached. The
+/// full detail goes to `tracing` at the bridge below.
+const CODEC_MESSAGE: &str = "the server encountered an internal storage-codec error";
 
 /// Classify a raw [`sqlx::Error`] at the storage boundary into the SM call
 /// status it should surface, emitting **one** structured trace record so the
@@ -252,9 +266,9 @@ mod tests {
 
     use sqlx::error::{DatabaseError, ErrorKind};
 
-    use crate::service::status::CallStatusType;
+    use crate::service::status::{CallStatusType, SmError};
 
-    use super::classify_sqlx;
+    use super::{StorageError, classify_sqlx};
 
     /// A driver-error double carrying one SQLSTATE plus the schema names a real
     /// PostgreSQL error would carry, so the classification and the
@@ -368,6 +382,36 @@ mod tests {
                 CallStatusType::Exception,
                 "SQLSTATE {sqlstate} is a server-side invariant failure, not a 409"
             );
+        }
+    }
+
+    #[test]
+    fn no_codec_internal_shape_reaches_the_client_message() {
+        // A node-codec fault is a violated SERVER-side invariant: the client
+        // gets the curated `500` message, never the RM attribute name or the
+        // internal node-row shape the error text carries.
+        let faults = [
+            StorageError::NotAStructureRoot(Some("DV_TEXT".to_owned())),
+            StorageError::MixedArray {
+                attribute: "content".to_owned(),
+            },
+            StorageError::InvalidRows("row num 7 has no parent at num 3".to_owned()),
+        ];
+        for fault in faults {
+            let rendered = fault.to_string();
+            let sm = SmError::from(fault);
+            assert_eq!(
+                sm.status,
+                CallStatusType::Exception,
+                "a codec fault is a server fault, not a client error"
+            );
+            for leaked in ["DV_TEXT", "content", "num", "structure", "array", "rows"] {
+                assert!(
+                    !sm.message.contains(leaked),
+                    "codec fault {rendered:?} leaked {leaked:?} into the client message {:?}",
+                    sm.message
+                );
+            }
         }
     }
 

--- a/app/ferroehr/src/system_log/mod.rs
+++ b/app/ferroehr/src/system_log/mod.rs
@@ -149,9 +149,8 @@ impl FerroEhrService {
                 "the local audit record repository is not enabled ([audit.store])",
             ));
         };
-        audit_store
-            .search(filter)
-            .await
-            .map_err(|e| crate::service::status::SmError::exception(e.to_string()))
+        audit_store.search(filter).await.map_err(|e| {
+            crate::service::error::internal_fault("search the audit record repository", &e)
+        })
     }
 }


### PR DESCRIPTION
Closes #1802. The non-driver half of the #1794 family: ~40 sites curated (serde messages, driver strings on the AQL path, node-codec shapes, authz internals, serializer diagnostics) — one trace record + one opaque body per fault; the JsonRead/JsonWrite split keeps 400s defect-naming; twins both directions. Follow-ups: #1809 #1810 #1811.