### PR TITLE
fix: quick-win batch C — app-side leak/status/carrier fixes + the template_ref registry

### DIFF
--- a/.claude/memory/session-workflow-gotchas.md
+++ b/.claude/memory/session-workflow-gotchas.md
@@ -73,3 +73,7 @@ commit-message wording; close/reopen for late labels.
    `cargo fmt --check` leaves the tree rustfmt-dirty. Always finish with
    `cargo fmt --all && cargo fmt --all --check`.
 - **Changelog inserts:** a section (`### Fixed` etc.) may already exist in the target release block — ALWAYS merge the entry into the existing subsection header; blindly inserting a new header creates a duplicate (happened twice, owner-corrected 2026-08-01). Check `grep -n '^###' CHANGELOG.md` for the block first.
+- **PR close keywords:** GitHub closes ONE issue per keyword — `Closes #1, #2, #3`
+  closes only #1. Every issue needs its own `Closes #N` (one per line is
+  clearest). Happened on PR #1821 (14 of 15 left open, owner-corrected
+  2026-08-03); Batch A (#1812) had the correct per-issue form.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,62 @@ workflow refuses a tag that has no matching section here.
   Conformance), which the contract generator skipped: its group list omitted
   `system` and its HTTP-method table omitted `OPTIONS` entirely.
 
+- **A composition committed against an ADL2-registered template is no longer
+  refused with a `409`, and an in-use ADL2 template now refuses physical
+  deletion.** The stored template identity on a version row was
+  foreign-key-checked against the OPT 1.4 store only, so a commit whose
+  template was provisioned through the ADL2 DEFINITION surface failed the
+  constraint; the key now targets a registry spanning both template dialects.
+  With that, the ADL2 template delete gains the same never-orphan guard the
+  OPT 1.4 delete always had — deleting a template still referenced by
+  committed versions answers `409` with the reference count (previously the
+  row was deleted silently) — and it now also evicts the template's compiled
+  WebTemplate, so a re-uploaded template is never served from the deleted
+  artefact's cached form.
+
+- **Template-scoped authorization rules now bind to compositions committed
+  through the direct routes.** A COMPOSITION committed with `POST`/`PUT
+  /ehr/{ehr_id}/composition` stored no template identity alongside its version,
+  while the same composition committed inside a CONTRIBUTION did — so an ABAC
+  policy scoped to a template silently failed to match direct-route
+  compositions (the attribute resolved to "no template" rather than to the
+  template the composition declares). Both direct routes now record the
+  template the version was committed against, exactly as the CONTRIBUTION
+  route always has. Compositions committed before this release carry no
+  template identity on their existing version rows; re-committing a new
+  version records it.
+
+- **A CONTRIBUTION whose audit omits `change_type` is now refused (`422`)
+  instead of being given a server-invented one.** The released commit schema
+  makes the change set's audit mandatory and its `change_type` a required
+  member (`NewContribution.yaml` over `UpdateAudit.yaml`, for both the EHR and
+  the demographic contribution routes), and RM common `master06`
+  §Contributions calls the contribution-level value approximate and "not
+  expected to be used as a computable value" — it is the client's account of
+  its own change set. The server previously derived an aggregate from the
+  member versions when the attribute was absent, putting an approximation into
+  the audit trail under the client's name; it now answers `422` naming
+  `CONTRIBUTION.audit.change_type`. A conformant client is unaffected. (The
+  direct COMPOSITION/DIRECTORY routes are unchanged: there the committal
+  headers stay optional and the server default still applies, exactly as the
+  ITS-REST overview requires.)
+
+- **An undecodable request-header value is refused instead of silently
+  ignored.** A header whose bytes are not decodable as text — including the
+  committal (`openehr-version`, `openehr-audit-details`) and item-tag wrapper
+  headers — was dropped from the request as if it had never been sent, so a
+  commit could carry different audit attributes or tags than the client
+  supplied, with nothing on the wire saying so. Such a request now answers
+  `400` naming the header.
+
+- **An AQL query that cannot get a database connection now sheds with `503` +
+  `Retry-After` instead of reporting `500`.** The query path's database leg is
+  classified like every other one, so a pool-acquire timeout is reported as a
+  temporary overload (retryable) rather than as a server fault. A corrupt
+  stored FHIR mapping definition is likewise reported as a server fault
+  (`500`) rather than as a client error (`422`) — it is not something the
+  caller supplied.
+
 - **A round-tripped demographic party carrying inline relationships is no
   longer refused.** `PARTY.Relationships_validity` requires every inline
   `relationships[i].source` to reference the party itself, and RM demographic
@@ -221,6 +277,24 @@ workflow refuses a tag that has no matching section here.
   then read back as deleted (`204`) while its content stayed stored and
   AQL-queryable. Both routes now refuse it. Deleting through `DELETE`, or
   through a data-less `523` CONTRIBUTION member, is unaffected.
+
+### Security
+
+- **Admin dump/load failures no longer expose server filesystem paths.** The
+  `file_not_writable` and container-fault bodies of the EHR export/import
+  operations carried the configured archive path (server deployment layout)
+  and the raw archive-parse diagnostics. The bodies now carry a curated message
+  — a defect in the CALLER's archive still names the offending archive ENTRY,
+  which is the actionable fact — and the path plus the underlying diagnostic go
+  to the server's trace record only.
+
+- **Terminology-server failures no longer expose the deployment's terminology
+  configuration.** A `500` raised by an upstream FHIR terminology server (or by
+  its OAuth2 client-credentials grant) named the configured provider, its
+  operation and the upstream error in the response body. The body is now the
+  curated internal-error message; the operator detail (provider name,
+  operation, upstream diagnostic) is emitted on the trace record. Boot-time
+  configuration errors are unchanged — they never reach a response body.
 
 ### Changed
 

--- a/app/ferroehr-rest/src/api/system/options.rs
+++ b/app/ferroehr-rest/src/api/system/options.rs
@@ -14,10 +14,10 @@
 //! bundle is `emit-rest` codegen-input provenance only, never a behavioural
 //! oracle.
 //!
-//! The System API is **not** part of the generated ITS-REST contract — the
-//! `emit-rest` groups are `ehr`/`query`/`definition`/`admin`/`demographic`
-//! only (`crates/openehr-its/src/rest/generated/` has no `system` group) — so
-//! this one standalone operation is hand-written here, correctly.
+//! TODO(#1822): the generated ITS-REST contract now emits the System group
+//! (`crates/openehr-its/src/rest/generated/system.rs`, `SystemApi::options`);
+//! this module predates it and is still hand-written — adopt the generated
+//! trait and diff [`SystemManifest`] against the emitted `Options` DTO.
 //!
 //! This module owns the manifest's *shape and content*; the wiring layer
 //! (`crate::router::router`) constructs the [`SystemManifest`] from config plus the

--- a/app/ferroehr-rest/src/overview/committal.rs
+++ b/app/ferroehr-rest/src/overview/committal.rs
@@ -116,7 +116,7 @@ pub(crate) fn merge_committal_headers(
     uv: &mut UpdateVersion,
     headers: &HeaderMap,
 ) -> Result<(), ApiError> {
-    apply_attrs(uv, &collect_attrs(headers))
+    apply_attrs(uv, &collect_attrs(headers)?)
 }
 
 /// Overlay already-collected committal attributes onto a commit envelope —
@@ -229,7 +229,7 @@ fn merged_committal(
     headers: &HeaderMap,
     committer: Option<PartyProxy>,
 ) -> Result<Option<ferroehr::service::version_update::Committal>, ApiError> {
-    let attrs = collect_attrs(headers);
+    let attrs = collect_attrs(headers)?;
     if attrs.is_empty() {
         return Ok(None);
     }
@@ -258,7 +258,11 @@ fn merged_committal(
 /// Collect all committal-header attributes into `target → [(subkey, value)]`,
 /// deprecated forms first and the development-edition forms last so the new form
 /// wins on conflict.
-fn collect_attrs(headers: &HeaderMap) -> IndexMap<String, Vec<(String, String)>> {
+///
+/// # Errors
+/// [`ApiError::BadRequest`] when a committal header carries an undecodable
+/// value ([`header_values`]).
+fn collect_attrs(headers: &HeaderMap) -> Result<IndexMap<String, Vec<(String, String)>>, ApiError> {
     // Deprecated forms: the attribute target is the header NAME suffix; the value
     // is a bare `key="value"` list (subkeys carry no `target.` prefix).
     let mut attrs: IndexMap<String, Vec<(String, String)>> = IndexMap::new();
@@ -269,7 +273,7 @@ fn collect_attrs(headers: &HeaderMap) -> IndexMap<String, Vec<(String, String)>>
         (H_DEP_COMMITTER, T_COMMITTER),
         (H_DEP_SYSTEM_ID, T_SYSTEM_ID),
     ] {
-        for raw in header_values(headers, name) {
+        for raw in header_values(headers, name)? {
             attrs.insert(target.to_owned(), key_value_pairs(&raw));
         }
     }
@@ -283,7 +287,7 @@ fn collect_attrs(headers: &HeaderMap) -> IndexMap<String, Vec<(String, String)>>
     // dotted < bare-deprecated < new. (`openEHR-VERSION` needs no entry —
     // it lowercases to the new `openehr-version` name and is read there.)
     let mut bare_dep: IndexMap<String, Vec<(String, String)>> = IndexMap::new();
-    for raw in header_values(headers, H_DEP_AUDIT_DETAILS_BARE) {
+    for raw in header_values(headers, H_DEP_AUDIT_DETAILS_BARE)? {
         collect_path_pairs(&raw, &mut bare_dep);
     }
     for (target, pairs) in bare_dep {
@@ -298,7 +302,7 @@ fn collect_attrs(headers: &HeaderMap) -> IndexMap<String, Vec<(String, String)>>
     // new form wins), rather than being appended to it.
     let mut dev: IndexMap<String, Vec<(String, String)>> = IndexMap::new();
     for name in [H_VERSION, H_AUDIT_DETAILS] {
-        for raw in header_values(headers, name) {
+        for raw in header_values(headers, name)? {
             collect_path_pairs(&raw, &mut dev);
         }
     }
@@ -306,7 +310,7 @@ fn collect_attrs(headers: &HeaderMap) -> IndexMap<String, Vec<(String, String)>>
         attrs.insert(target, pairs);
     }
 
-    attrs
+    Ok(attrs)
 }
 
 /// Parse an attribute-path-in-value header (`change_type.code_string="251"`)
@@ -322,12 +326,28 @@ fn collect_path_pairs(raw: &str, map: &mut IndexMap<String, Vec<(String, String)
     }
 }
 
-/// All decodable values of a (possibly repeated) request header.
-fn header_values(headers: &HeaderMap, name: &str) -> Vec<String> {
+/// Every value of a (possibly repeated) request header.
+///
+/// A value that is not decodable as text is a client defect the caller must
+/// hear about: dropping it silently would commit a version whose audit
+/// attributes differ from the ones the client sent, with nothing on the wire
+/// saying so. (No openEHR spec governs undecodable header bytes — our own
+/// design: refuse rather than guess.)
+///
+/// # Errors
+/// [`ApiError::BadRequest`] naming the header whose value is not decodable.
+fn header_values(headers: &HeaderMap, name: &str) -> Result<Vec<String>, ApiError> {
     headers
         .get_all(name)
         .iter()
-        .filter_map(|v| v.to_str().ok().map(str::to_owned))
+        .map(|v| {
+            v.to_str().map(str::to_owned).map_err(|e| {
+                tracing::debug!(header = name, error = %e, "undecodable header value → 400");
+                ApiError::BadRequest(format!(
+                    "header {name} carries a value that is not decodable as text"
+                ))
+            })
+        })
         .collect()
 }
 

--- a/app/ferroehr-rest/src/overview/params.rs
+++ b/app/ferroehr-rest/src/overview/params.rs
@@ -57,11 +57,22 @@ pub(crate) fn build<P: DeserializeOwned>(
         // canonical spelling (`Accept`, `Content-Type`, `openehr-item-tag`).
         // Deserialization is case-sensitive on the rename, so expose both the
         // wire name and the canonical spelling used by the contract.
+        // A header value that is not decodable as text is a client defect, not
+        // an absent parameter: dropping it would deserialize the request as if
+        // the header had never been sent. (No openEHR spec governs undecodable
+        // header bytes — our own design: refuse rather than guess.)
         let entry: Vec<String> = headers
             .get_all(name)
             .iter()
-            .filter_map(|v| v.to_str().ok().map(str::to_owned))
-            .collect();
+            .map(|v| {
+                v.to_str().map(str::to_owned).map_err(|e| {
+                    tracing::debug!(header = %name, error = %e, "undecodable header value → 400");
+                    ApiError::BadRequest(format!(
+                        "header {name} carries a value that is not decodable as text"
+                    ))
+                })
+            })
+            .collect::<Result<_, _>>()?;
         if entry.is_empty() {
             continue;
         }
@@ -258,11 +269,21 @@ pub(crate) fn parse_item_tag_header(
     headers: &HeaderMap,
     name: &str,
 ) -> Result<Option<Vec<ItemTagHeaderEntry>>, ApiError> {
+    // An undecodable value is refused, never skipped: silently dropping it
+    // would remove a tag the client believes it set (the same reasoning the
+    // doc comment above gives for a keyless entry).
     let raws: Vec<String> = headers
         .get_all(name)
         .iter()
-        .filter_map(|v| v.to_str().ok().map(str::to_owned))
-        .collect();
+        .map(|v| {
+            v.to_str().map(str::to_owned).map_err(|e| {
+                tracing::debug!(header = name, error = %e, "undecodable header value → 400");
+                ApiError::BadRequest(format!(
+                    "header {name} carries a value that is not decodable as text"
+                ))
+            })
+        })
+        .collect::<Result<_, _>>()?;
     if raws.is_empty() {
         return Ok(None);
     }

--- a/app/ferroehr-rest/tests/it/abac_e2e.rs
+++ b/app/ferroehr-rest/tests/it/abac_e2e.rs
@@ -39,7 +39,7 @@ use ferroehr::system_log::config::{AuditConfig, FailMode, StoreConfig, SyslogCon
 use ferroehr::system_log::sender::{AuditSender, start};
 use ferroehr_rest::config::AppConfig;
 use ferroehr_rest::extensions::access::authz::engine::{AuthzError, PolicyEngine};
-use ferroehr_rest::extensions::access::authz::request::{AuthzRequest, Decision};
+use ferroehr_rest::extensions::access::authz::request::{Attr, AuthzRequest, Decision};
 use ferroehr_rest::extensions::access::authz::{AuthzHandle, AuthzResolvers, ResolveError};
 use ferroehr_rest::extensions::management::Observability;
 use ferroehr_rest::{build_full, build_with};
@@ -166,12 +166,47 @@ fn resolvers() -> AuthzResolvers {
     }
 }
 
+/// The same subject map, with the template attribute resolved from the REAL
+/// service — i.e. from the `vo_version.template_id` the commit routes stamp.
+fn service_resolvers(svc: Arc<FerroEhrService>) -> AuthzResolvers {
+    AuthzResolvers {
+        template_of_version: Arc::new(move |vo: String, version: Option<String>| {
+            let svc = Arc::clone(&svc);
+            Box::pin(async move {
+                let vo_id = vo
+                    .parse::<ferroehr::ids::VoId>()
+                    .map_err(|e| ResolveError(format!("vo id: {e}")))?;
+                svc.template_of_version(vo_id, version.as_deref())
+                    .await
+                    .map_err(|e| ResolveError(format!("{e}")))
+            })
+        }),
+        ..resolvers()
+    }
+}
+
 fn authz(abac_enabled: bool) -> Option<Arc<AuthzHandle>> {
     let mut cfg = AuthzConfig::default();
     cfg.abac.enabled = abac_enabled;
     let engine: Option<Arc<dyn PolicyEngine>> =
         abac_enabled.then(|| -> Arc<dyn PolicyEngine> { Arc::new(PermitAll) });
     AuthzHandle::build(&cfg, &rest_config().server.base_path, engine, resolvers()).map(Arc::new)
+}
+
+/// An ABAC handle with a caller-chosen PDP engine and resolvers.
+fn authz_with(
+    engine: Arc<dyn PolicyEngine>,
+    resolvers: AuthzResolvers,
+) -> Option<Arc<AuthzHandle>> {
+    let mut cfg = AuthzConfig::default();
+    cfg.abac.enabled = true;
+    AuthzHandle::build(
+        &cfg,
+        &rest_config().server.base_path,
+        Some(engine),
+        resolvers,
+    )
+    .map(Arc::new)
 }
 
 /// A real service over a fresh DB, optionally wired with an ATNA audit sender.
@@ -467,5 +502,150 @@ async fn abac_deny_is_audited() {
             .any(|xml| xml.contains(r#"EventOutcomeIndicator="4""#)
                 && xml.contains(r#"UserID="svc""#)),
         "expected a minor-failure audit for `svc`, got {records:?}"
+    );
+}
+
+// ── the template attribute binds on direct-route compositions ────────────────
+
+/// The `template_id` the vendored IPS operational template declares.
+const IPS_TEMPLATE_ID: &str = "International Patient Summary";
+
+fn ips_opt_xml() -> String {
+    std::fs::read_to_string(
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../crates/openehr-its/tests/fixtures/sdk/ips.v0.opt"),
+    )
+    .expect("ips.v0.opt vendored in openehr-its")
+}
+
+fn ips_composition() -> Value {
+    let text = std::fs::read_to_string(
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(
+            "../../crates/openehr-its/tests/vendor/openehr_sdk/composition/canonical_json/ips_canonical.json",
+        ),
+    )
+    .expect("ips_canonical.json vendored in openehr-its");
+    serde_json::from_str(&text).expect("valid canonical composition")
+}
+
+/// A PDP that permits ONLY when the request carries the IPS template attribute
+/// — a template-scoped rule. With `vo_version.template_id` unstamped the
+/// attribute resolves to `None` and the rule silently stops binding, which is
+/// exactly the defect this pins.
+#[derive(Debug)]
+struct RequireIpsTemplate;
+
+#[async_trait]
+impl PolicyEngine for RequireIpsTemplate {
+    async fn decide(&self, req: &AuthzRequest<'_>) -> Result<Decision, AuthzError> {
+        let bound = match &req.template {
+            Some(Attr::One(t)) => t == IPS_TEMPLATE_ID,
+            Some(Attr::Set(set)) => set.iter().any(|t| t == IPS_TEMPLATE_ID),
+            None => false,
+        };
+        Ok(if bound {
+            Decision::Permit
+        } else {
+            Decision::Deny
+        })
+    }
+}
+
+/// Upload the IPS OPT and commit one of its compositions through the DIRECT
+/// composition route; return the committed version uid.
+async fn seed_templated_composition(seed: &Router, ehr_id: &str) -> String {
+    let upload = Request::builder()
+        .method("POST")
+        .uri(format!("{BASE}/definition/template/adl1.4"))
+        .header("content-type", "application/xml")
+        .body(Body::from(ips_opt_xml()))
+        .expect("request");
+    let resp = seed.clone().oneshot(upload).await.expect("upload OPT");
+    assert_eq!(resp.status(), StatusCode::CREATED, "IPS OPT upload");
+
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("{BASE}/ehr/{ehr_id}/composition"))
+        .header("content-type", "application/json")
+        .body(Body::from(ips_composition().to_string()))
+        .expect("request");
+    let resp = seed.clone().oneshot(req).await.expect("seed composition");
+    assert_eq!(
+        resp.status(),
+        StatusCode::CREATED,
+        "seed templated composition in {ehr_id}"
+    );
+    let etag = resp
+        .headers()
+        .get(http::header::ETAG)
+        .and_then(|v| v.to_str().ok())
+        .expect("ETag on create");
+    etag.trim_start_matches("W/").trim_matches('"').to_owned()
+}
+
+#[tokio::test]
+async fn template_scoped_rule_binds_on_a_direct_route_composition() {
+    let (_pg, svc) = service(None).await;
+    let seed = build_with(seed_config(), Arc::clone(&svc)).expect("seed app");
+    seed_ehr(&seed, EHR_OWN).await;
+    let uid = seed_templated_composition(&seed, EHR_OWN).await;
+
+    let app = build_full(
+        rest_config(),
+        Arc::clone(&svc),
+        authz_with(Arc::new(RequireIpsTemplate), service_resolvers(svc)),
+        Observability::default(),
+    )
+    .expect("build app");
+
+    let s = status(
+        &app,
+        request(
+            "GET",
+            &format!("/ehr/{EHR_OWN}/composition/{uid}"),
+            &bearer(Some(PATIENT_OWN)),
+        ),
+    )
+    .await;
+    assert_eq!(
+        s,
+        StatusCode::OK,
+        "the template-scoped rule must bind: the direct-route commit stamps \
+         vo_version.template_id, so the post-check resolves the attribute"
+    );
+}
+
+#[tokio::test]
+async fn template_scoped_rule_does_not_bind_a_templateless_composition() {
+    // The refusing twin: a composition carrying no `archetype_details.template_id`
+    // genuinely has no template attribute, so the same rule denies — the
+    // resolver answering `None` must mean "no template", never "unstamped".
+    let (_pg, svc) = service(None).await;
+    let seed = build_with(seed_config(), Arc::clone(&svc)).expect("seed app");
+    seed_ehr(&seed, EHR_OWN).await;
+    let uid = seed_composition(&seed, EHR_OWN).await;
+
+    let app = build_full(
+        rest_config(),
+        Arc::clone(&svc),
+        authz_with(Arc::new(RequireIpsTemplate), service_resolvers(svc)),
+        Observability::default(),
+    )
+    .expect("build app");
+
+    let s = status(
+        &app,
+        request(
+            "GET",
+            &format!("/ehr/{EHR_OWN}/composition/{uid}"),
+            &bearer(Some(PATIENT_OWN)),
+        ),
+    )
+    .await;
+    assert_eq!(
+        s,
+        StatusCode::FORBIDDEN,
+        "a templateless composition carries no template attribute, so the \
+         template-scoped rule must deny"
     );
 }

--- a/app/ferroehr-rest/tests/it/ehr_access_gate.rs
+++ b/app/ferroehr-rest/tests/it/ehr_access_gate.rs
@@ -136,7 +136,7 @@ async fn seed_scheme(svc: &FerroEhrService, ehr_id: ferroehr::ids::EhrId, scheme
                 "settings": scheme
             }
         } ],
-        "audit": { "committer": committer("alice") }
+        "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } },  "committer": committer("alice") }
     });
     svc.create_ehr_contribution(ehr_id, contribution)
         .await
@@ -344,7 +344,7 @@ async fn gate_keeper_guards_ehr_access_commits() {
             "_type": "ORIGINAL_VERSION",
             "data": { "_type": "EHR_ACCESS", "archetype_node_id": "openEHR-EHR-EHR_ACCESS.generic.v1" }
         } ],
-        "audit": { "committer": { "_type": "PARTY_IDENTIFIED", "name": "x" } }
+        "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } },  "committer": { "_type": "PARTY_IDENTIFIED", "name": "x" } }
     })
     .to_string();
 
@@ -391,7 +391,7 @@ async fn gate_keeper_ignores_non_ehr_access_contributions() {
     let contribution = json!({
         "_type": "CONTRIBUTION",
         "versions": [ { "_type": "ORIGINAL_VERSION", "data": { "_type": "COMPOSITION" } } ],
-        "audit": { "committer": { "_type": "PARTY_IDENTIFIED", "name": "x" } }
+        "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } },  "committer": { "_type": "PARTY_IDENTIFIED", "name": "x" } }
     })
     .to_string();
 

--- a/app/ferroehr-rest/tests/it/headers.rs
+++ b/app/ferroehr-rest/tests/it/headers.rs
@@ -1504,3 +1504,52 @@ async fn tag_collection_disciplines() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body.trim(), "[]", "an empty list clears all: {body}");
 }
+
+/// A request header whose value is not decodable as text is REFUSED, never
+/// silently skipped — a skipped committal/tag header would commit a version
+/// whose attributes differ from the ones the client sent, with nothing on the
+/// wire saying so. (No openEHR spec governs undecodable header bytes — our own
+/// design.)
+#[tokio::test]
+async fn an_undecodable_header_value_is_refused_not_dropped() {
+    let (_pg, app) = app().await;
+    let ehr_id = create_ehr(&app).await;
+    upload_opt(&app).await;
+
+    // `0xFF` is not valid in a `to_str`-decodable header value.
+    let opaque = http::HeaderValue::from_bytes(&[0xff]).expect("a byte header value");
+
+    for header_name in [
+        "openehr-audit-details",
+        "openehr-item-tag",
+        "openEHR-VERSION.lifecycle_state",
+    ] {
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("{BASE}/ehr/{ehr_id}/composition"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .header(header_name, opaque.clone())
+            .body(Body::from(canonical_composition().to_string()))
+            .unwrap();
+        let (status, _h, body) = send(&app, req).await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "an undecodable {header_name} value must be refused, got {status} {body}"
+        );
+    }
+
+    // The twin: the same write with no undecodable header commits.
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("{BASE}/ehr/{ehr_id}/composition"))
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(canonical_composition().to_string()))
+        .unwrap();
+    let (status, _h, body) = send(&app, req).await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "the clean twin commits: {body}"
+    );
+}

--- a/app/ferroehr/migrations/ehr/0001_baseline.sql
+++ b/app/ferroehr/migrations/ehr/0001_baseline.sql
@@ -227,6 +227,27 @@ CREATE INDEX idx_audit_time_committed ON audit (time_committed);
 COMMENT ON TABLE contribution IS 'The change-set envelope (RM common master06 §Contributions); one per change set, strictly transactional (master06 §Committal and Audits: a Contribution commits only if every member Version/Attestation commits).';
 COMMENT ON COLUMN contribution.ehr_id IS 'Owning EHR, or NULL for a demographic (party) contribution (RM demographic content is not EHR-owned).';
 
+-- ── template_ref ─────────────────────────────────────────────────────────────
+-- The registry of PROVISIONED template wire addresses across BOTH template
+-- dialects: `template_store` rows (OPT 1.4 `template_id`) and `adl2_artefact`
+-- template-kind rows (ADL2 template / operational_template HRIDs — the AM
+-- component keeps the two generations side by side, BASE architecture_overview
+-- master05 §Package Structure). `vo_version.template_id` references THIS
+-- table, so a committed version's template identity is FK-guarded whichever
+-- DEFINITION surface provisioned the template, and a physical delete of an
+-- in-use template fails loud even under a concurrent commit (the NO ACTION
+-- check at delete time) — the same race guard the former template_store-only
+-- FK provided, made dialect-complete. Rows are maintained in the same
+-- transaction as the owning store row (insert on provisioning; delete when the
+-- last owning store row goes). No openEHR spec governs storage integrity —
+-- our own design.
+CREATE TABLE template_ref (
+    template_id text NOT NULL,
+    CONSTRAINT pk_template_ref PRIMARY KEY (template_id)
+);
+
+COMMENT ON TABLE template_ref IS 'Registry of provisioned template wire addresses (union of template_store.template_id and template-kind adl2_artefact.hrid). FK target of vo_version.template_id: the dialect-complete delete/commit race guard (an extension — no openEHR spec governs storage integrity).';
+
 -- ── template_store ───────────────────────────────────────────────────────────
 -- Operational templates (OPT 1.4 XML); the parsed model is built in the
 -- application, not stored here.
@@ -252,14 +273,14 @@ COMMENT ON COLUMN template_store.id IS 'The SM OPT-by-UUID handle (SM openehr_pl
 -- it is the `.vN` version axis of template_id (filter_version: "taken from
 -- template_id"), a pure function of the id, so it is derived on read rather than
 -- denormalised into a column (see crate::templates::identity::template_version).
-COMMENT ON COLUMN template_store.template_id IS 'The wire address (ITS-REST DEFINITION API + vo_version.template_id FK target); also the source of the reported TemplateMetadata.version (its `.vN` axis).';
+COMMENT ON COLUMN template_store.template_id IS 'The wire address (ITS-REST DEFINITION API; registered in template_ref, the vo_version.template_id FK target); also the source of the reported TemplateMetadata.version (its `.vN` axis).';
 -- Case-insensitive uniqueness of TEMPLATE_ID (BASE base_types master05
 -- §Composite Identifiers and Case: identifier equality — and thus uniqueness —
 -- is case-insensitive, so a case variant is the SAME template id and the
 -- upload endpoint rejects it as a duplicate, ITS-REST
--- 409_template_already_exists). The exact-case UNIQUE above stays — it backs
--- the vo_version.template_id foreign key; this functional unique index is the
--- race-free case-insensitive guard.
+-- 409_template_already_exists). The exact-case UNIQUE above stays as the
+-- natural-key anchor; this functional unique index is the race-free
+-- case-insensitive guard.
 CREATE UNIQUE INDEX ux_template_store_template_id_ci
     ON template_store (lower(template_id));
 
@@ -431,7 +452,7 @@ CREATE TABLE vo_version (
     -- the semantics stay master06.
     CONSTRAINT fk_vo_version_contribution FOREIGN KEY (contribution_id) REFERENCES contribution (id),
     CONSTRAINT fk_vo_version_audit FOREIGN KEY (audit_id) REFERENCES audit (id),
-    CONSTRAINT fk_vo_version_template FOREIGN KEY (template_id) REFERENCES template_store (template_id),
+    CONSTRAINT fk_vo_version_template FOREIGN KEY (template_id) REFERENCES template_ref (template_id),
     CONSTRAINT fk_vo_version_ehr FOREIGN KEY (ehr_id) REFERENCES ehr (id) ON DELETE CASCADE
 ) WITH (fillfactor = 90);
 -- LATEST_VERSION (= the current trunk tip, RM common master06

--- a/app/ferroehr/migrations/ehr/0004_multitenancy.sql
+++ b/app/ferroehr/migrations/ehr/0004_multitenancy.sql
@@ -32,7 +32,8 @@
 -- multi-tenant mode").
 --
 -- NOTE: the pre-existing service-wide UNIQUE
--- constraints (uq_ehr_subject, uq_template_store_template_id,
+-- constraints (uq_ehr_subject, uq_template_store_template_id, pk_template_ref
+-- (the template registry mirrors the global template_store/adl2_artefact keys),
 -- pk_stored_query, uq_event_subscription_name, uq_sp_data_frame_frame_id,
 -- and uq_item_tag_identity — practically unreachable cross-tenant since a
 -- target_vo_id belongs to one tenant, listed for completeness)

--- a/app/ferroehr/src/aql/error.rs
+++ b/app/ferroehr/src/aql/error.rs
@@ -5,8 +5,10 @@
 //! * [`AqlFeatureError`] — the feature-envelope rejections. Every variant names
 //!   the rejected construct and cites the governing QUERY 1.1 spec section, so a
 //!   rejection is always explainable against the vendored spec
-//!   (`docs/specs/openehr/QUERY/docs/AQL/`). The accept/reject envelope must remain
-//!   a superset of `EHRbase`'s.
+//!   (`docs/specs/openehr/QUERY/docs/AQL/`), which is the ONLY authority for the
+//!   accept/reject envelope: a construct the released QUERY 1.1 text defines is
+//!   accepted or rejected on that text alone. Other implementations' envelopes
+//!   are prior art and never widen or narrow this one.
 //! * [`AnalysisError`] — path analysis / typing failures (unknown class or
 //!   variable, unresolvable attribute, type mismatch, unbound parameter).
 //! * [`SqlError`] — IR→SQL lowering failures (a construct the planner accepted

--- a/app/ferroehr/src/extensions/fhir/mod.rs
+++ b/app/ferroehr/src/extensions/fhir/mod.rs
@@ -449,10 +449,15 @@ impl FerroEhrService {
         for row in &rows {
             let resource_type: String = row.try_get("resource_type")?;
             let definition: Value = row.try_get("definition")?;
+            // A STORED mapping definition that no longer parses is a
+            // server-side fault, not a client error: the caller supplied
+            // nothing wrong, so the class is `exception` (500) with the
+            // diagnostic traced — the sibling read paths already classify it
+            // that way.
             let def: FhirMappingDefinition = serde_json::from_value(definition).map_err(|e| {
-                ServiceError::Unprocessable(Violation::new(format!(
-                    "stored FHIR mapping definition is invalid: {e}"
-                )))
+                ServiceError::Internal(format!(
+                    "read a stored FHIR mapping definition for {resource_type}: {e}"
+                ))
             })?;
             let resource = reverse::to_fhir(
                 &resource_type,

--- a/app/ferroehr/src/service/admin/delete.rs
+++ b/app/ferroehr/src/service/admin/delete.rs
@@ -97,9 +97,9 @@ impl FerroEhrService {
     /// Delete one template by its wire id, refusing (409) while any committed
     /// version still references it. The reference count and the delete run in
     /// one transaction so the friendly 409 is consistent with the delete; the
-    /// `vo_version.template_id` foreign key (`0001_baseline.sql`, NO ACTION) is
-    /// the underlying integrity guard that makes orphaning impossible even under
-    /// a concurrent commit.
+    /// `vo_version.template_id` → `template_ref` foreign key
+    /// (`0001_baseline.sql`, NO ACTION) is the underlying integrity guard that
+    /// makes orphaning impossible even under a concurrent commit.
     async fn delete_template_by_id(&self, template_id: &str) -> Result<(), ServiceError> {
         let mut tx = self.pool.begin().await?;
         // Resolve the stored (case-preserved) id; absent → 404 (§Composite
@@ -133,6 +133,18 @@ impl FerroEhrService {
             .bind(&stored)
             .execute(&mut *tx)
             .await?;
+        // Deregister the wire address unless a template-kind ADL2 artefact
+        // also claims it (`template_ref` is the union of both dialects'
+        // addresses; the FK blocks the deregistration if a concurrent commit
+        // referenced it after the count above).
+        sqlx::query(
+            "DELETE FROM template_ref WHERE template_id = $1 AND NOT EXISTS \
+             (SELECT 1 FROM adl2_artefact WHERE lower(hrid) = lower($1) \
+              AND kind IN ('template', 'operational_template'))",
+        )
+        .bind(&stored)
+        .execute(&mut *tx)
+        .await?;
         tx.commit().await?;
         // Evict the derived-runtime cache for the deleted id (case-canonical key,
         // matching the SM delete path). No openEHR spec governs the cache.

--- a/app/ferroehr/src/service/admin/dump_load.rs
+++ b/app/ferroehr/src/service/admin/dump_load.rs
@@ -67,10 +67,10 @@
 //! `vo_version`, `node`, `ehr_folder` (the `EHR.folders` membership rows — RM
 //! ehr master04 §Folders), `item_tag`, and any `vo_archive` markers for the
 //! EHR's versioned objects. Global DEFINITION artefacts a version references
-//! (`template_store` OPTs via `vo_version.template_id`, `stored_query`) are NOT
-//! carried — they are provisioned through the DEFINITION API and must pre-exist
-//! (a COMPOSITION referencing an absent template fails its FK on load, reported
-//! per EHR). Demographic parties (ehr-less versioned objects) and
+//! (OPT 1.4 / ADL2 templates via `vo_version.template_id` → `template_ref`,
+//! `stored_query`) are NOT carried — they are provisioned through the
+//! DEFINITION API and must pre-exist (a COMPOSITION referencing an absent
+//! template fails its FK on load, reported per EHR). Demographic parties (ehr-less versioned objects) and
 //! `vo_attestation` rows are out of this EHR-scoped dump; a whole-repository
 //! back-up would need a demographic dump wave (deferred).
 //! TODO(#1685): carry the `vo_attestation` rows (with their `at_committal`
@@ -300,13 +300,24 @@ fn plan_segments(sizes: &[usize], limit_bytes: usize) -> Vec<std::ops::Range<usi
     segments
 }
 
+/// The wire message of every filesystem-access failure of these operations.
+/// Deliberately opaque: the configured `file_sys_loc` is SERVER deployment
+/// layout, and the OS error names the same path — neither belongs in a
+/// response body. The path and the OS diagnostic go to the trace record.
+const LOCATION_MESSAGE: &str =
+    "the configured archive location could not be read or written; see the server log";
+
 /// Build a `file_not_writable` [`SmError`] (the only error `I_ADMIN_DUMP_LOAD`
 /// declares) for a failed filesystem access to `path`.
+///
+/// The body carries [`LOCATION_MESSAGE`]; `path` + `err` are traced.
 fn file_not_writable(path: &Path, err: &std::io::Error) -> SmError {
-    SmError::new(
-        CallStatusType::FileNotWritable,
-        format!("{}: {err}", path.display()),
-    )
+    tracing::error!(
+        path = %path.display(),
+        error = %err,
+        "dump/load: archive location access failed → file_not_writable"
+    );
+    SmError::new(CallStatusType::FileNotWritable, LOCATION_MESSAGE.to_owned())
 }
 
 /// Build a `file_not_writable` [`SmError`] for an archive entry that was read
@@ -320,13 +331,21 @@ fn file_not_writable(path: &Path, err: &std::io::Error) -> SmError {
 /// a readable archive — so they carry the SAME SM error. Reporting a corrupt
 /// input as `exception` instead would blame the server for the caller's
 /// archive.
+///
+/// The body NAMES THE ENTRY — that is the caller-actionable fact about the
+/// caller's own archive — but carries neither the server path nor the serde
+/// diagnostic (offsets and Rust field names of our archive structs); both are
+/// traced.
 fn unreadable_archive_entry(path: &Path, entry: &str, err: &serde_json::Error) -> SmError {
+    tracing::warn!(
+        path = %path.display(),
+        entry,
+        error = %err,
+        "dump/load: archive entry is not parseable → file_not_writable"
+    );
     SmError::new(
         CallStatusType::FileNotWritable,
-        format!(
-            "{}/{entry} is not readable as part of this export archive: {err}",
-            path.display()
-        ),
+        format!("archive entry {entry} is not readable as part of this export archive"),
     )
 }
 
@@ -530,17 +549,23 @@ impl ArchiveReader {
 /// same SM error the loose form raises, since from the operation's point of
 /// view the archive file could not be written/read either way.
 fn sevenz_fault(path: &Path, what: &str, err: &sevenz_rust2::Error) -> SmError {
-    SmError::new(
-        CallStatusType::FileNotWritable,
-        format!("{} ({what}): {err}", path.display()),
-    )
+    tracing::error!(
+        path = %path.display(),
+        operation = what,
+        error = %err,
+        "dump/load: 7z container fault → file_not_writable"
+    );
+    SmError::new(CallStatusType::FileNotWritable, LOCATION_MESSAGE.to_owned())
 }
 
 fn zip_fault(path: &Path, what: &str, err: &zip::result::ZipError) -> SmError {
-    SmError::new(
-        CallStatusType::FileNotWritable,
-        format!("{} ({what}): {err}", path.display()),
-    )
+    tracing::error!(
+        path = %path.display(),
+        operation = what,
+        error = %err,
+        "dump/load: zip container fault → file_not_writable"
+    );
+    SmError::new(CallStatusType::FileNotWritable, LOCATION_MESSAGE.to_owned())
 }
 
 // ── the openehr_canonical_xml payload form ───────────────────────────────────
@@ -589,10 +614,21 @@ fn version_entry_name(version_uid: &str) -> Result<String, SmError> {
 /// missing a mandatory `VERSION` attribute; the [`AuditInput::canonical`]
 /// rejection when the committer is not a canonical `PARTY_PROXY`.
 fn original_version_envelope(v: &VersionRecord, audit: &AuditRow) -> Result<Value, ServiceError> {
+    // Same discipline as the version read-back: an archived
+    // `other_input_version_uids` that does not decode is a corrupt record, not
+    // an absent merge list — restoring the version without its merge inputs
+    // would silently rewrite history (RM common master06 §Distributed
+    // Versioning).
     let other_input_version_uids: Vec<String> = v
         .other_input_version_uids
         .as_ref()
-        .and_then(|value| serde_json::from_value(value.clone()).ok())
+        .map(|value| serde_json::from_value(value.clone()))
+        .transpose()
+        .map_err(|e| {
+            ServiceError::Internal(format!(
+                "archived other_input_version_uids is not a list of version uids: {e}"
+            ))
+        })?
         .unwrap_or_default();
     let tree = TreeId::from_columns(v.trunk_version, v.branch_number, v.branch_version);
     // An IMPORTED_VERSION row's document is the WRAPPED original — its own
@@ -956,12 +992,13 @@ impl FerroEhrService {
         // The manifest's own EXPORT_FORMAT member is what tells the format-less
         // operation which payload form the segments carry.
         let format: ExportFormat = manifest.format.parse().map_err(|()| {
+            // The manifest's declared value IS the caller's archive content, so
+            // the body names it; the server path stays out of the body.
             SmError::new(
                 CallStatusType::FileNotWritable,
                 format!(
-                    "{}/{MANIFEST_ENTRY} declares logical format {:?}, which names no \
-                     EXPORT_FORMAT member",
-                    dir.display(),
+                    "archive entry {MANIFEST_ENTRY} declares logical format {:?}, which names \
+                     no EXPORT_FORMAT member",
                     manifest.format
                 ),
             )
@@ -1048,11 +1085,9 @@ impl FerroEhrService {
         keys.sort_unstable();
         keys.dedup();
         for hex in &keys {
-            let bytes = engine
-                .store()
-                .get(hex)
-                .await
-                .map_err(|e| SmError::exception(format!("exporting blob {hex}: {e}")))?;
+            let bytes = engine.store().get(hex).await.map_err(|e| {
+                crate::service::error::internal_fault("export a multimedia blob", &e)
+            })?;
             archive.write(&format!("{BLOB_PREFIX}{hex}"), &bytes)?;
         }
         Ok(keys)
@@ -1082,7 +1117,9 @@ impl FerroEhrService {
                 .store()
                 .put_if_absent(hex, bytes)
                 .await
-                .map_err(|e| SmError::exception(format!("importing blob {hex}: {e}")))?;
+                .map_err(|e| {
+                    crate::service::error::internal_fault("import a multimedia blob", &e)
+                })?;
         }
         Ok(())
     }

--- a/app/ferroehr/src/service/definition/adl14.rs
+++ b/app/ferroehr/src/service/definition/adl14.rs
@@ -30,7 +30,7 @@ use openehr_adl::validate::catalogue::Severity;
 use openehr_adl::validate::rm::ProductionRmModel;
 use openehr_adl::validate::{ValidationIssue, validate_adl14_source};
 use openehr_base::prelude::ArchetypeId;
-use openehr_its::rest::runtime::ValidationError;
+use openehr_base::validate::InvariantViolation;
 use uuid::Uuid;
 
 use crate::service::FerroEhrService;
@@ -577,8 +577,9 @@ impl FerroEhrService {
         // Resolve, count references, and delete in ONE transaction so the
         // friendly 409 is consistent with the delete (mirroring the admin
         // wire delete, `delete_template_by_id`); the `vo_version.template_id`
-        // foreign key (`0001_baseline.sql`, NO ACTION) remains the underlying
-        // integrity guard even under a concurrent commit. Absent row → 404.
+        // → `template_ref` foreign key (`0001_baseline.sql`, NO ACTION)
+        // remains the underlying integrity guard even under a concurrent
+        // commit. Absent row → 404.
         let mut tx = self.pool.begin().await?;
         let template_id: Option<String> =
             sqlx::query_scalar("SELECT template_id FROM template_store WHERE id = $1")
@@ -609,6 +610,18 @@ impl FerroEhrService {
             .bind(id)
             .execute(&mut *tx)
             .await?;
+        // Deregister the wire address unless a template-kind ADL2 artefact
+        // also claims it (`template_ref` is the union of both dialects'
+        // addresses; the FK blocks the deregistration if a concurrent commit
+        // referenced it after the count above).
+        sqlx::query(
+            "DELETE FROM template_ref WHERE template_id = $1 AND NOT EXISTS \
+             (SELECT 1 FROM adl2_artefact WHERE lower(hrid) = lower($1) \
+              AND kind IN ('template', 'operational_template'))",
+        )
+        .bind(&template_id)
+        .execute(&mut *tx)
+        .await?;
         tx.commit().await?;
         // Delete is the only mutation that ends a stored template's lifetime
         // (uploads are create-only — `store_template`'s `ON CONFLICT DO NOTHING`
@@ -652,7 +665,7 @@ impl FerroEhrService {
 fn archetype_validate(adl: &str) -> Result<(), ServiceError> {
     let issues =
         validate_adl14_source(adl, &ProductionRmModel).map_err(archetype_syntax_failure)?;
-    let errors: Vec<ValidationError> = issues
+    let errors: Vec<InvariantViolation> = issues
         .iter()
         .filter(|i| i.severity == Severity::Error)
         .map(issue_to_validation_error)
@@ -673,25 +686,27 @@ fn archetype_validate(adl: &str) -> Result<(), ServiceError> {
 fn archetype_syntax_failure(errs: Vec<SyntaxError>) -> ServiceError {
     ServiceError::ValidationFailed(
         errs.into_iter()
-            .map(|e| ValidationError {
-                path: e.code.mnemonic().to_owned(),
-                message: format!("{} (line {}, column {})", e.message, e.line, e.column),
+            .map(|e| {
+                InvariantViolation::at(
+                    e.code.mnemonic(),
+                    format!("{} (line {}, column {})", e.message, e.line, e.column),
+                )
             })
             .collect(),
     )
 }
 
-/// Render one [`ValidationIssue`] as a wire [`ValidationError`]: the rule-code
+/// Render one [`ValidationIssue`] as an [`InvariantViolation`]: the rule-code
 /// mnemonic is the machine-readable key, the human detail (plus the archetype
 /// path where derivable) is the message.
-fn issue_to_validation_error(i: &ValidationIssue) -> ValidationError {
-    ValidationError {
-        path: i.code.mnemonic().to_owned(),
-        message: match &i.path {
+fn issue_to_validation_error(i: &ValidationIssue) -> InvariantViolation {
+    InvariantViolation::at(
+        i.code.mnemonic(),
+        match &i.path {
             Some(p) => format!("{} (at {p})", i.message),
             None => i.message.clone(),
         },
-    }
+    )
 }
 
 /// `valid_opt` core — the OPT parses (`opt14::from_xml`) and passes the

--- a/app/ferroehr/src/service/definition/adl2.rs
+++ b/app/ferroehr/src/service/definition/adl2.rs
@@ -26,9 +26,9 @@ use openehr_adl::validate::{validate_source, validate_source_integrity};
 use openehr_am::am24::aom2::archetype::archetype::Archetype;
 use openehr_am::am24::aom2::archetype::authored_archetype::AuthoredArchetype;
 use openehr_am::am24::aom2::archetype::operational_template::OperationalTemplate;
+use openehr_base::validate::InvariantViolation;
 use openehr_its::flat::example::{DetailLevel, ExampleType, apply_output_uid, example_composition};
 use openehr_its::flat::webtemplate::{WebTemplate, build_web_template_am24};
-use openehr_its::rest::runtime::ValidationError;
 use serde_json::Value;
 use sqlx::Row;
 
@@ -323,17 +323,19 @@ impl FerroEhrService {
         }
         .map_err(|errs| syntax_bad_request(&errs))?;
 
-        let errors: Vec<ValidationError> = issues
+        let errors: Vec<InvariantViolation> = issues
             .iter()
             .filter(|i| i.severity == Severity::Error)
-            .map(|i| ValidationError {
+            .map(|i| {
                 // The rule-code mnemonic is the machine-readable key; the human
                 // detail (and the archetype path where derivable) is the message.
-                path: i.code.mnemonic().to_owned(),
-                message: match &i.path {
-                    Some(p) => format!("{} (at {p})", i.message),
-                    None => i.message.clone(),
-                },
+                InvariantViolation::at(
+                    i.code.mnemonic(),
+                    match &i.path {
+                        Some(p) => format!("{} (at {p})", i.message),
+                        None => i.message.clone(),
+                    },
+                )
             })
             .collect();
         if !errors.is_empty() {
@@ -398,6 +400,28 @@ impl FerroEhrService {
         .bind(summary.parent_archetype_id.as_deref())
         .execute(&mut *tx)
         .await?;
+        // Maintain the `template_ref` registry (the vo_version.template_id FK
+        // target) in the same transaction: a template-kind HRID is a commit
+        // addressable wire identity (`0001_baseline.sql` §template_ref). A
+        // replace that DEMOTES a template to an archetype deregisters the id
+        // unless the OPT 1.4 store also claims it — and the FK blocks the
+        // deregistration loudly when committed versions still reference it.
+        if matches!(kind, "template" | "operational_template") {
+            sqlx::query(
+                "INSERT INTO template_ref (template_id) VALUES ($1) ON CONFLICT DO NOTHING",
+            )
+            .bind(&summary.archetype_id)
+            .execute(&mut *tx)
+            .await?;
+        } else if replace {
+            sqlx::query(
+                "DELETE FROM template_ref WHERE template_id = $1 AND NOT EXISTS \
+                 (SELECT 1 FROM template_store WHERE lower(template_id) = lower($1))",
+            )
+            .bind(&summary.archetype_id)
+            .execute(&mut *tx)
+            .await?;
+        }
         tx.commit().await?;
         self.invalidate_archetype_lineage().await;
         Ok(())
@@ -750,18 +774,69 @@ impl FerroEhrService {
     }
 
     /// Delete the ADL2 artefact with `ARCHETYPE_HRID` `an_id`
-    /// (case-insensitive); absent → `artefact_does_not_exist` (`404`).
+    /// (case-insensitive); absent → `artefact_does_not_exist` (`404`); a
+    /// template-kind artefact still referenced by committed versions →
+    /// `Conflict` (`409`, with the reference count — the same
+    /// never-orphan-clinical-data guard the OPT 1.4 delete carries; no openEHR
+    /// spec governs the in-use refusal, our own integrity design).
     async fn adl2_delete(&self, an_id: &str) -> Result<(), ServiceError> {
-        let deleted = sqlx::query("DELETE FROM adl2_artefact WHERE lower(hrid) = lower($1)")
-            .bind(an_id)
-            .execute(&self.pool)
-            .await?
-            .rows_affected();
-        if deleted == 0 {
+        // Resolve the stored (case-preserved) HRID + kind, count references,
+        // and delete in ONE transaction, mirroring `opt_delete`; the
+        // `vo_version.template_id` → `template_ref` foreign key (NO ACTION)
+        // remains the race-free backstop under a concurrent commit.
+        let mut tx = self.pool.begin().await?;
+        let stored: Option<(String, String)> =
+            sqlx::query_as("SELECT hrid, kind FROM adl2_artefact WHERE lower(hrid) = lower($1)")
+                .bind(an_id)
+                .fetch_optional(&mut *tx)
+                .await?;
+        let Some((hrid, kind)) = stored else {
             return Err(ServiceError::sm(
                 CallStatusType::ArtefactDoesNotExist,
                 format!("ADL2 artefact {an_id}"),
             ));
+        };
+        let is_template = matches!(kind.as_str(), "template" | "operational_template");
+        if is_template {
+            let refs: i64 = sqlx::query_scalar(
+                "SELECT count(*) FROM vo_version WHERE lower(template_id) = lower($1)",
+            )
+            .bind(&hrid)
+            .fetch_one(&mut *tx)
+            .await?;
+            if refs > 0 {
+                return Err(ServiceError::Conflict(format!(
+                    "template '{hrid}' is still referenced by {refs} committed version(s); \
+                     delete those compositions before deleting the template"
+                )));
+            }
+        }
+        sqlx::query("DELETE FROM adl2_artefact WHERE hrid = $1")
+            .bind(&hrid)
+            .execute(&mut *tx)
+            .await?;
+        if is_template {
+            // Deregister the wire address unless the OPT 1.4 store also claims
+            // it (`template_ref` is the union of both dialects' addresses).
+            sqlx::query(
+                "DELETE FROM template_ref WHERE template_id = $1 AND NOT EXISTS \
+                 (SELECT 1 FROM template_store WHERE lower(template_id) = lower($1))",
+            )
+            .bind(&hrid)
+            .execute(&mut *tx)
+            .await?;
+        }
+        tx.commit().await?;
+        if is_template {
+            // Evict the built `WebTemplate` so a re-uploaded template is never
+            // served from the deleted artefact's compiled form (the OPT 1.4
+            // delete paths do the same; no openEHR spec governs the cache).
+            self.web_templates
+                .invalidate(&format!(
+                    "{ADL2_CACHE_NS}{}",
+                    crate::templates::identity::canonical_key(&hrid)
+                ))
+                .await;
         }
         self.invalidate_archetype_lineage().await;
         Ok(())

--- a/app/ferroehr/src/service/ehr/composition.rs
+++ b/app/ferroehr/src/service/ehr/composition.rs
@@ -73,13 +73,19 @@ impl FerroEhrService {
         self.reject_duplicate_persistent(ehr_id, &composition)
             .await?;
 
+        // The committed template identity is promoted to `vo_version.template_id`
+        // — the ABAC template attribute resolver (`template_of_version`) and the
+        // template-delete guard both read that column, so the direct route
+        // stamps it exactly like the CONTRIBUTION route.
+        let template_id = composition_template_id(&composition).map(str::to_owned);
+
         let mut tx = self.pool.begin().await?;
         let committed = create(
             &mut tx,
             Some(ehr_id),
             Kind::Composition,
             composition,
-            None,
+            template_id.as_deref(),
             &audit,
             envelope,
             &self.signing_ctx(),
@@ -370,6 +376,10 @@ impl FerroEhrService {
         self.validate_composition_for_commit(&composition, incomplete)
             .await?;
 
+        // Same template stamping as the create arm — every version row carries
+        // the template it was committed against.
+        let template_id = composition_template_id(&composition).map(str::to_owned);
+
         let mut tx = self.pool.begin().await?;
         // VERSIONED_COMPOSITION cross-version invariants (RM ehr
         // `versioned_composition.adoc`), lifted out of the versioning write
@@ -383,7 +393,7 @@ impl FerroEhrService {
             Kind::Composition,
             composition,
             expected,
-            None,
+            template_id.as_deref(),
             &audit,
             envelope,
             &self.signing_ctx(),

--- a/app/ferroehr/src/service/ehr/contributions.rs
+++ b/app/ferroehr/src/service/ehr/contributions.rs
@@ -160,8 +160,9 @@ impl FerroEhrService {
         // None` serializes to JSON `null` (not absent), and `change_type` is a
         // `Terminology_code` (`{terminology_id, code_string}`, SM
         // `update_audit.adoc`), not a `DV_CODED_TEXT` (see the NOTEs in
-        // `versioning/contribution.rs` `coded_value`/`classify`). A native
-        // typed path skipping the JSON round-trip is a future cleanup.
+        // `versioning/contribution.rs` `coded_value`/`classify`).
+        // TODO(#1820): replace the serialize→re-parse round trip with a
+        // native typed handoff into `commit_version_set`.
         let versions_json = serde_json::to_value(&versions)
             .map_err(|e| internal_fault("serialize the CONTRIBUTION version set", &e))?;
         let audit_json = serde_json::to_value(&an_audit)

--- a/app/ferroehr/src/service/ehr/validation.rs
+++ b/app/ferroehr/src/service/ehr/validation.rs
@@ -20,6 +20,7 @@
 //! (INVALID class 2) + `master07-func_tc_ehr_composition.adoc` (the
 //! persistent-cardinality convention).
 
+use openehr_base::validate::InvariantViolation;
 use serde_json::Value;
 use sqlx::PgConnection;
 
@@ -198,10 +199,7 @@ impl FerroEhrService {
         }
         let errors = messages
             .into_iter()
-            .map(|m| openehr_its::rest::runtime::ValidationError {
-                path: m.path,
-                message: m.message,
-            })
+            .map(|m| InvariantViolation::at(m.path, m.message))
             .collect();
         Err(ServiceError::ValidationFailed(errors))
     }
@@ -311,10 +309,7 @@ pub(in crate::service) fn validate_rm_invariants_for_commit(
     Err(ServiceError::ValidationFailed(
         messages
             .into_iter()
-            .map(|m| openehr_its::rest::runtime::ValidationError {
-                path: m.path,
-                message: m.message,
-            })
+            .map(|m| InvariantViolation::at(m.path, m.message))
             .collect(),
     ))
 }
@@ -585,22 +580,35 @@ pub(in crate::service) fn validate_ehr_access(
 /// create/update and the CONTRIBUTION FOLDER path). RM common `folder.adoc` +
 /// RM ehr master04 §Folders:
 ///
-/// - each node is a `FOLDER` (a foreign `_type` is rejected: a FOLDER tree
-///   carries only FOLDERs, which the containment shape alone cannot say);
-/// - `items` members are `OBJECT_REF`s — "Folder structures do not contain
-///   Compositions, only references to them" (master04 §Folders): a member must
-///   carry `id` + `namespace` + `type`, and a LOCATABLE-by-value payload is
-///   rejected;
-/// - `folders` members recurse.
+/// - every node of the tree carries a `_type` conforming to the RM-declared
+///   type of the slot it occupies (`FOLDER.items` → `OBJECT_REF`,
+///   `FOLDER.folders` → `FOLDER`), read from the generated RM model
+///   ([`openehr_rm::model::attribute`] / [`openehr_rm::model::is_a`]). This is
+///   the WRONGNESS half of "Folder structures do not contain Compositions,
+///   only references to them" (master04 §Folders): a COMPOSITION committed by
+///   value into `items` is a positive type contradiction and is refused
+///   whatever the lifecycle state (RM common master06 §Incomplete Content —
+///   "data may be missing, but it may not be wrong").
 ///
-/// The `LOCATABLE` rules a FOLDER node inherits are NOT restated here: `name`
-/// mandatoriness, `Archetype_node_id_valid`, `Links_valid`, and the
-/// archetype-root identity rule (`archetype_node_id` is the stringified
-/// `archetype_details.archetype_id`) all come from the whole-instance RM
-/// class-invariant + terminology pass ([`validate_rm_invariants_for_commit`]),
-/// which also reaches `archetype_details`, each `LINK` in `links`, and
-/// `feeder_audit`. `archetype_details` itself stays OPTIONAL on a FOLDER — the
-/// RM types it 0..1 and FOLDER carries no `Is_archetype_root` invariant.
+/// The PRESENCE half is NOT restated here: an `OBJECT_REF`'s mandatory
+/// `id`/`namespace`/`type`, a member carrying a key `OBJECT_REF` does not
+/// declare, `LOCATABLE.name` mandatoriness, `Archetype_node_id_valid`,
+/// `Links_valid`, and the archetype-root identity rule all come from the
+/// whole-instance RM class-invariant + terminology pass
+/// ([`validate_rm_invariants_for_commit`]), which walks `items`, `folders`,
+/// `archetype_details`, each `LINK` in `links`, and `feeder_audit` — and which
+/// relaxes exactly the presence layer on a `553|incomplete|` commit, so no
+/// lifecycle special-casing is needed here. `archetype_details` itself stays
+/// OPTIONAL on a FOLDER — the RM types it 0..1 and FOLDER carries no
+/// `Is_archetype_root` invariant.
+///
+/// NOTE: the type-conformance rule is enforced here rather than in the
+/// whole-instance pass because that pass dispatches each node on its own wire
+/// `_type` (falling back to the declared type only when the tag is absent), so
+/// a tagged node in a concretely-declared slot is validated as the type it
+/// claims to be, never against the slot. TODO(#1816): fold this into the
+/// whole-instance pass once it checks every tagged node against its declared
+/// slot type; this is the FOLDER-shaped instance of that general rule.
 ///
 /// # Errors
 /// [`ServiceError::Unprocessable`] naming the first violated rule and the
@@ -610,59 +618,54 @@ pub(in crate::service) fn validate_folder(
     folder: &Value,
     incomplete: bool,
 ) -> Result<(), ServiceError> {
-    fn walk(node: &Value, path: &str, incomplete: bool) -> Result<(), ServiceError> {
+    /// The RM-declared type of `attr` on `class`, from the generated model.
+    fn declared(class: &str, attr: &str) -> Option<&'static str> {
+        openehr_rm::model::attribute(class, attr).map(|a| a.declared_type)
+    }
+
+    /// Refuse a member whose wire `_type` does not conform to `expected`.
+    fn conforms(member: &Value, expected: &str, path: &str) -> Result<(), ServiceError> {
         let unproc = |m: String| ServiceError::Unprocessable(Violation::new(m));
-        let obj = node
+        let obj = member
             .as_object()
-            .ok_or_else(|| unproc(format!("{path}: FOLDER must be a JSON object")))?;
-        match obj.get("_type").and_then(Value::as_str) {
-            None | Some("FOLDER") => {}
-            Some(other) => {
-                return Err(unproc(format!(
-                    "{path}: expected a FOLDER, got _type {other:?}"
-                )));
-            }
+            .ok_or_else(|| unproc(format!("{path}: must be a JSON object ({expected})")))?;
+        // An untagged member is legal canonical JSON in a concretely-declared
+        // slot; the whole-instance pass then validates it AS `expected`.
+        let Some(tag) = obj.get("_type").and_then(Value::as_str) else {
+            return Ok(());
+        };
+        if openehr_rm::model::is_a(tag, expected) {
+            return Ok(());
         }
-        if let Some(items) = obj.get("items").and_then(Value::as_array) {
+        Err(unproc(format!(
+            "{path}: expected {expected} (or a subtype), got _type {tag:?} — Folder \
+             structures do not contain Compositions by value, only references to \
+             them (RM ehr master04 §Folders)"
+        )))
+    }
+
+    fn walk(node: &Value, path: &str) -> Result<(), ServiceError> {
+        conforms(node, "FOLDER", if path.is_empty() { "/" } else { path })?;
+        let Some(obj) = node.as_object() else {
+            return Ok(());
+        };
+        if let Some((items, ty)) = obj
+            .get("items")
+            .and_then(Value::as_array)
+            .zip(declared("FOLDER", "items"))
+        {
             for (i, item) in items.iter().enumerate() {
-                // The PRESENCE half (`id`/`namespace`/`type` supplied) is a
-                // mandatory-attribute duty, so a `553|incomplete|` commit is
-                // allowed to leave it unmet (RM common master06 §Incomplete
-                // Content). The WRONGNESS half — a LOCATABLE committed by
-                // value rather than by reference — is enforced either way:
-                // "Folder structures do not contain Compositions, only
-                // references to them" (RM ehr master04 §Folders).
-                let present = incomplete
-                    || (item.get("id").is_some_and(Value::is_object)
-                        && item
-                            .get("namespace")
-                            .and_then(Value::as_str)
-                            .is_some_and(|s| !s.is_empty())
-                        && item
-                            .get("type")
-                            .and_then(Value::as_str)
-                            .is_some_and(|s| !s.is_empty()));
-                // A LOCATABLE by value carries archetype_node_id — an
-                // OBJECT_REF never does.
-                let ok = present && item.get("archetype_node_id").is_none();
-                if !ok {
-                    return Err(unproc(format!(
-                        "{path}/items[{i}]: FOLDER.items members must be OBJECT_REFs \
-                         (id + namespace + type) — Folder structures do not contain \
-                         Compositions by value, only references to them \
-                         (RM ehr master04 §Folders)"
-                    )));
-                }
+                conforms(item, ty, &format!("{path}/items[{i}]"))?;
             }
         }
         if let Some(folders) = obj.get("folders").and_then(Value::as_array) {
             for (i, sub) in folders.iter().enumerate() {
-                walk(sub, &format!("{path}/folders[{i}]"), incomplete)?;
+                walk(sub, &format!("{path}/folders[{i}]"))?;
             }
         }
         Ok(())
     }
-    walk(folder, "", incomplete)?;
+    walk(folder, "")?;
     validate_rm_invariants_for_commit(folder, "FOLDER", incomplete)
 }
 
@@ -923,6 +926,31 @@ mod tests {
         bad["folders"][0].as_object_mut().unwrap().remove("name");
         let err = validate_folder(&bad, false).expect_err("nameless sub-folder rejected");
         assert!(format!("{err:?}").contains("name"), "got {err:?}");
+    }
+
+    /// The `FOLDER.items` PRESENCE duty is owned by the whole-instance RM pass
+    /// (`OBJECT_REF`'s mandatory `id`/`namespace`/`type`), which relaxes exactly
+    /// that layer on a `553|incomplete|` commit (RM common master06 §Incomplete
+    /// Content) — so `validate_folder` needs no lifecycle special-casing of its
+    /// own.
+    #[test]
+    fn folder_item_presence_is_owned_by_the_rm_pass() {
+        let missing_id = json!({
+            "_type": "FOLDER",
+            "name": { "_type": "DV_TEXT", "value": "root" },
+            "archetype_node_id": "openEHR-EHR-FOLDER.generic.v1",
+            "items": [{
+                "_type": "OBJECT_REF", "namespace": "local", "type": "VERSIONED_COMPOSITION"
+            }]
+        });
+        let err = validate_folder(&missing_id, false)
+            .expect_err("an OBJECT_REF without its mandatory id is refused");
+        assert!(
+            matches!(err, ServiceError::ValidationFailed(_)),
+            "the refusal comes from the RM pass, got {err:?}"
+        );
+        validate_folder(&missing_id, true)
+            .expect("a 553|incomplete| commit may leave mandatory data missing");
     }
 
     /// A minimal valid FOLDER tree the LOCATABLE-rule tests below perturb.

--- a/app/ferroehr/src/service/error.rs
+++ b/app/ferroehr/src/service/error.rs
@@ -162,9 +162,12 @@ pub enum ServiceError {
     #[error("unprocessable: {0}")]
     Unprocessable(Violation),
     /// A well-formed payload that fails semantic (template/RM/terminology)
-    /// validation — carries the per-path violations for the ITS-REST 422 body.
+    /// validation — carries the per-path violations as the RM validation data
+    /// type ([`InvariantViolation`]), which the protocol bridges below render
+    /// into the ITS-REST 422 body. The service layer never names a protocol
+    /// type: the wire shape is chosen at the edge, not at the throw site.
     #[error("{} validation error(s)", .0.len())]
-    ValidationFailed(Vec<openehr_its::rest::runtime::ValidationError>),
+    ValidationFailed(Vec<InvariantViolation>),
     /// A storage/codec failure.
     #[error("storage: {0}")]
     Storage(#[from] crate::storage::error::StorageError),
@@ -393,7 +396,17 @@ impl From<ServiceError> for ApiError {
             ServiceError::VersionConflict(m) => ApiError::PreconditionFailed(m),
             // The ONE rendering point of a `Violation` on the wire bridge.
             ServiceError::Unprocessable(v) => ApiError::Unprocessable(v.to_string()),
-            ServiceError::ValidationFailed(v) => ApiError::ValidationFailed(v),
+            // The ONE place the RM violation data becomes the protocol's
+            // `validationErrors[]` shape (the two carry the same `{path,
+            // message}` facts).
+            ServiceError::ValidationFailed(v) => ApiError::ValidationFailed(
+                v.into_iter()
+                    .map(|e| openehr_its::rest::runtime::ValidationError {
+                        path: e.path,
+                        message: e.message,
+                    })
+                    .collect(),
+            ),
             // Storage/DB failures carry SQLSTATE/constraint detail: classify
             // them (integrity/serialization conflict → 409, pool exhaustion →
             // 503) rather than blanket-500. A genuine fault stays 500. This
@@ -504,14 +517,8 @@ mod tests {
     fn validation_failed_renders_two_bodies_but_one_status() {
         let violations = || {
             vec![
-                openehr_its::rest::runtime::ValidationError {
-                    path: "/content[0]/data".to_owned(),
-                    message: "missing mandatory attribute".to_owned(),
-                },
-                openehr_its::rest::runtime::ValidationError {
-                    path: "/context/start_time".to_owned(),
-                    message: "not a valid DV_DATE_TIME".to_owned(),
-                },
+                InvariantViolation::at("/content[0]/data", "missing mandatory attribute"),
+                InvariantViolation::at("/context/start_time", "not a valid DV_DATE_TIME"),
             ]
         };
 

--- a/app/ferroehr/src/service/query/execute.rs
+++ b/app/ferroehr/src/service/query/execute.rs
@@ -417,9 +417,12 @@ fn map_plan_error(e: AqlError) -> SmError {
     }
 }
 
-/// Map an execution error: a database/assembly/terminology failure is the
-/// server's fault (`500`); a SQL-lowering failure that surfaces here is still
-/// a bad query (`400`).
+/// Map an execution error: an assembly/terminology failure is the server's
+/// fault (`500`); a SQL-lowering failure that surfaces here is still a bad
+/// query (`400`); a raw driver failure is CLASSIFIED like every other database
+/// leg (`crate::storage::error::classify_sqlx`), so a pool-acquire timeout on
+/// the query path sheds as `503 service-overloaded` exactly as it does on the
+/// write paths instead of reporting a blanket `500`.
 ///
 /// The `500` legs carry the curated opaque message: a driver string names the
 /// schema objects the generated SQL touched, an assembly failure names the
@@ -428,7 +431,7 @@ fn map_plan_error(e: AqlError) -> SmError {
 /// ([`internal_fault`]).
 fn map_exec_error(e: AqlError) -> SmError {
     match e {
-        AqlError::Exec(ExecError::Database(db)) => internal_fault("execute the generated SQL", &db),
+        AqlError::Exec(ExecError::Database(db)) => crate::storage::error::classify_sqlx(&db),
         AqlError::Exec(ExecError::Assembly(a)) => internal_fault("assemble the RESULT_SET", &a),
         AqlError::Exec(ExecError::Terminology(msg)) => SmError::exception(msg),
         AqlError::Exec(e @ ExecError::MissingColumnAlias { .. }) => {
@@ -437,5 +440,41 @@ fn map_exec_error(e: AqlError) -> SmError {
         AqlError::Feature(_) | AqlError::Analysis(_) | AqlError::Sql(_) => {
             SmError::precondition(e.to_string())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AqlError, ExecError, map_exec_error};
+    use crate::service::status::CallStatusType;
+
+    /// The query path's database leg is classified, not blanket-500: a
+    /// pool-acquire timeout sheds as `service_overloaded` (→ 503 +
+    /// `Retry-After`) exactly as every other database leg does, while a
+    /// genuine driver fault stays an `exception` (→ 500) with the curated
+    /// message.
+    #[test]
+    fn query_database_failures_are_classified() {
+        let shed = map_exec_error(AqlError::Exec(ExecError::Database(
+            sqlx::Error::PoolTimedOut,
+        )));
+        assert_eq!(
+            shed.status,
+            CallStatusType::ServiceOverloaded,
+            "a pool-acquire timeout on the query path sheds, got {shed:?}"
+        );
+
+        let fault = map_exec_error(AqlError::Exec(ExecError::Database(
+            sqlx::Error::RowNotFound,
+        )));
+        assert_eq!(
+            fault.status,
+            CallStatusType::Exception,
+            "an unclassified driver failure is still a server fault, got {fault:?}"
+        );
+        assert!(
+            !fault.message.contains("RowNotFound"),
+            "the driver diagnostic never reaches the wire body, got {fault:?}"
+        );
     }
 }

--- a/app/ferroehr/src/service/terminology/fhir.rs
+++ b/app/ferroehr/src/service/terminology/fhir.rs
@@ -174,12 +174,8 @@ impl FhirTerminologyProvider {
         op_path: &str,
         query: &[(&str, &str)],
     ) -> Result<Option<T>, SmError> {
-        let mut url = reqwest::Url::parse(&format!("{}{op_path}", self.base)).map_err(|e| {
-            SmError::exception(format!(
-                "terminology provider '{}': invalid url for {op_path}: {e}",
-                self.name
-            ))
-        })?;
+        let mut url = reqwest::Url::parse(&format!("{}{op_path}", self.base))
+            .map_err(|e| self.provider_fault(op_path, &format_args!("invalid url: {e}")))?;
         {
             let mut pairs = url.query_pairs_mut();
             for (k, v) in query {
@@ -191,10 +187,7 @@ impl FhirTerminologyProvider {
         {
             return match hit {
                 Some(body) => serde_json::from_value(body).map(Some).map_err(|e| {
-                    SmError::exception(format!(
-                        "terminology provider '{}' {op_path}: cached response decode: {e}",
-                        self.name
-                    ))
+                    self.provider_fault(op_path, &format_args!("cached response decode: {e}"))
                 }),
                 None => Ok(None),
             };
@@ -222,26 +215,19 @@ impl FhirTerminologyProvider {
             return Ok(None);
         }
         if !status.is_success() {
-            return Err(SmError::exception(format!(
-                "terminology provider '{}' {op_path} returned HTTP {}",
-                self.name,
-                status.as_u16()
-            )));
+            return Err(self.provider_fault(
+                op_path,
+                &format_args!("upstream returned HTTP {}", status.as_u16()),
+            ));
         }
         let body = response.json::<serde_json::Value>().await.map_err(|e| {
-            SmError::exception(format!(
-                "terminology provider '{}' {op_path}: malformed FHIR response: {e}",
-                self.name
-            ))
+            self.provider_fault(op_path, &format_args!("malformed FHIR response: {e}"))
         })?;
         if let Some(cache) = &self.cache {
             cache.insert(cache_key, Some(body.clone())).await;
         }
         serde_json::from_value(body).map(Some).map_err(|e| {
-            SmError::exception(format!(
-                "terminology provider '{}' {op_path}: malformed FHIR response: {e}",
-                self.name
-            ))
+            self.provider_fault(op_path, &format_args!("malformed FHIR response: {e}"))
         })
     }
 
@@ -254,10 +240,30 @@ impl FhirTerminologyProvider {
         } else {
             "transport error"
         };
-        SmError::exception(format!(
-            "terminology provider '{}' {op_path}: {kind}: {e}",
-            self.name
-        ))
+        self.provider_fault(op_path, &format_args!("{kind}: {e}"))
+    }
+
+    /// A `500` for an upstream-terminology fault, with the OPERATOR detail
+    /// (which provider, which operation, the upstream diagnostic) on the trace
+    /// record and NOT on the wire.
+    ///
+    /// The detail here is the deployment's own configuration — the provider's
+    /// configured name and the upstream server's error — which is exactly the
+    /// class of fact a tenant's clients must not be able to read out of a
+    /// response body, while the operator still needs it in full. The server
+    /// carries no per-request diagnostic surface (`/management` mounts
+    /// info/prometheus/metrics/env/loggers only), so the trace record IS the
+    /// operator channel. (No openEHR spec governs the content of a `500` body
+    /// — our own design/extension; the status itself is the ITS-REST overview
+    /// `Requests_and_responses.md` §HTTP status codes row.)
+    fn provider_fault(&self, op_path: &str, detail: &dyn std::fmt::Display) -> SmError {
+        tracing::error!(
+            provider = %self.name,
+            operation = op_path,
+            error = %detail,
+            "terminology provider fault → 500"
+        );
+        SmError::exception(crate::service::error::INTERNAL_MESSAGE.to_owned())
     }
 
     /// A `Pre_has_*` precondition failure (`VersionedObjectDoesNotExist`).

--- a/app/ferroehr/src/service/terminology/oauth2.rs
+++ b/app/ferroehr/src/service/terminology/oauth2.rs
@@ -170,10 +170,18 @@ impl TokenSource {
             .request_async(&self.http)
             .await
             .map_err(|e| {
-                SmError::exception(format!(
-                    "terminology oauth2 client '{}': client-credentials grant failed: {e}",
-                    self.name
-                ))
+                // The OPERATOR detail — which configured client, and the
+                // upstream authorization server's own error — goes to the
+                // trace record; the wire body stays the curated 500 message.
+                // A tenant's clients must not be able to read the deployment's
+                // credential configuration out of a response. (No openEHR spec
+                // governs 500 body content — our own design/extension.)
+                tracing::error!(
+                    oauth2_client = %self.name,
+                    error = %e,
+                    "terminology oauth2 client-credentials grant failed → 500"
+                );
+                SmError::exception(crate::service::error::INTERNAL_MESSAGE.to_owned())
             })?;
         // Refresh a leeway before the stated expiry so an in-flight request
         // never carries a token that expires mid-call. A leeway at or beyond

--- a/app/ferroehr/src/storage/version_repo/read.rs
+++ b/app/ferroehr/src/storage/version_repo/read.rs
@@ -143,9 +143,21 @@ async fn stored_version(
     row: &PgRow,
 ) -> Result<StoredVersion, StorageError> {
     let sys_version: i32 = row.try_get("sys_version")?;
+    // A stored `other_input_version_uids` that does not decode is OUR data
+    // gone wrong (the merge inputs of an IMPORTED_VERSION, RM common master06
+    // §Distributed Versioning) — serving the version with an empty merge list
+    // would answer wrongly rather than loudly, so the decode failure is a codec
+    // fault, not a default.
     let other_input_version_uids: Vec<String> = row
         .try_get::<Option<Value>, _>("other_input_version_uids")?
-        .and_then(|v| serde_json::from_value(v).ok())
+        .map(serde_json::from_value)
+        .transpose()
+        .map_err(|e| {
+            StorageError::InvalidRows(format!(
+                "vo_version.other_input_version_uids of {vo_id} is not a list of \
+                 version uids: {e}"
+            ))
+        })?
         .unwrap_or_default();
     let canonical = read_version_canonical(pool, vo_id, sys_version).await?;
     // The attestations arrive folded into the version-select row (the LATERAL

--- a/app/ferroehr/src/templates/store.rs
+++ b/app/ferroehr/src/templates/store.rs
@@ -111,6 +111,7 @@ impl FerroEhrService {
         // index (`lower(template_id)`) rejects exact and case-variant duplicates
         // alike (a case variant is the *same* id, §Composite Identifiers
         // and Case) — no row returned means the template already exists → 409.
+        let mut tx = self.pool.begin().await?;
         let row = sqlx::query(
             "INSERT INTO template_store (template_id, concept, root_archetype, content) \
              VALUES ($1, $2, $3, $4) \
@@ -121,13 +122,22 @@ impl FerroEhrService {
         .bind(&concept)
         .bind(&root_archetype)
         .bind(xml)
-        .fetch_optional(&self.pool)
+        .fetch_optional(&mut *tx)
         .await?
         .ok_or_else(|| {
             ServiceError::Conflict(format!(
                 "an operational template with template_id '{template_id}' already exists"
             ))
         })?;
+        // Register the wire address in `template_ref` (the vo_version.template_id
+        // FK target) in the same transaction — the registry is the union of both
+        // template dialects' addresses, so `DO NOTHING` absorbs an ADL2 claim of
+        // the same id (`0001_baseline.sql` §template_ref).
+        sqlx::query("INSERT INTO template_ref (template_id) VALUES ($1) ON CONFLICT DO NOTHING")
+            .bind(&template_id)
+            .execute(&mut *tx)
+            .await?;
+        tx.commit().await?;
 
         // No `WebTemplate`-cache invalidation is needed on the create path: this
         // insert is create-only (`ON CONFLICT DO NOTHING` never overwrites), and

--- a/app/ferroehr/src/validation/opt/mod.rs
+++ b/app/ferroehr/src/validation/opt/mod.rs
@@ -157,10 +157,10 @@ fn attribute_children(attr: &CAttribute) -> &[CObject] {
 /// syntactic `400` branch of `responses/400.yaml`.
 pub(super) fn validate_opt_artefact(opt: &OperationalTemplate) -> Result<(), ServiceError> {
     check(opt).map_err(|v| {
-        ServiceError::ValidationFailed(vec![openehr_its::rest::runtime::ValidationError {
-            path: v.code.to_string(),
-            message: v.detail,
-        }])
+        ServiceError::ValidationFailed(vec![openehr_base::validate::InvariantViolation::at(
+            v.code.to_string(),
+            v.detail,
+        )])
     })
 }
 

--- a/app/ferroehr/src/validation/opt/rm_conformance.rs
+++ b/app/ferroehr/src/validation/opt/rm_conformance.rs
@@ -30,8 +30,9 @@ use super::interval::{iv_lower, iv_upper};
 use super::{NodeView, RuleViolation};
 
 /// LOCATABLE meta attributes tolerated on any RM class (see the NOTE in
-/// [`check_attribute`]: archie-era OPTs constrain these on PATHABLE-only
-/// classes) — the class's OWN attribute set, read from the BMM-generated static
+/// [`check_attribute`]: the constraint binds to a serialized meta field the
+/// canonical form of a PATHABLE-only node still carries) — the class's OWN
+/// attribute set, read from the BMM-generated static
 /// RM model, never a hand-kept list: a LOCATABLE attribute added or renamed by
 /// a spec-pin bump follows automatically. PATHABLE's inherited members
 /// (`parent`, which the flattened model also reports) are excluded, since the
@@ -134,15 +135,18 @@ pub(super) fn check_attribute(
         return Ok(());
     }
     match model::attribute(parent_rm, attr_name) {
-        // NOTE (prior-art OPT tolerance): archie/openEHR-SDK tooling
-        // models every constrainable node as Locatable, so published OPTs
-        // (incl. the vendored IPS template) constrain LOCATABLE meta attributes
-        // (`name`, `archetype_node_id`, …) on classes the RM derives from
-        // PATHABLE only (e.g. ISM_TRANSITION —
-        // org.openehr.rm.composition.ism_transition.adoc inherits PATHABLE).
-        // Rejecting them per strict VCARM would refuse real-world templates; the
-        // constraints are tolerated (they bind to the serialized meta fields,
-        // which canonical JSON carries).
+        // NOTE (why this is not a VCARM violation): a LOCATABLE meta attribute
+        // (`name`, `archetype_node_id`, …) constrained on a class the RM
+        // derives from PATHABLE only (e.g. ISM_TRANSITION —
+        // `RM/docs/UML/classes/org.openehr.rm.composition.ism_transition.adoc`
+        // inherits PATHABLE) binds to a field the canonical serialization of
+        // that node carries, so the constraint has a referent and nothing in
+        // the released text makes it invalid. The tolerance is therefore
+        // grounded on the RM + the serialization, not on any implementation.
+        // (Prior art, named only as where the shape is OBSERVED and never as
+        // its authority: archie/openEHR-SDK-generated OPTs — including the
+        // vendored IPS template — model every constrainable node as Locatable
+        // and emit exactly these constraints.)
         None if LOCATABLE_META_ATTRS.contains(attr_name)
             || is_us_orthography_of_rm_attribute(parent_rm, attr_name)
             || LEGACY_RM_ATTRS.contains(&(parent_rm, attr_name)) =>

--- a/app/ferroehr/src/validation/opt/terminology.rs
+++ b/app/ferroehr/src/validation/opt/terminology.rs
@@ -68,12 +68,14 @@ pub(super) fn check_term_bindings(
     defined_at: &HashSet<String>,
 ) -> Result<(), RuleViolation> {
     let check = |code: &str| -> Result<(), RuleViolation> {
-        // NOTE (flattened-OPT tolerance): a *specialised* code
-        // (`at0.23`, dot-notation — AOM2 §specialisation depth) may be bound
-        // without a re-emitted local term definition: archie-era flattening
-        // keeps parent-archetype bindings whose definitions live in the parent
-        // (the vendored blood-pressure corpus OPTs carry these). A dotted
-        // code is therefore accepted as a valid binding key.
+        // NOTE (flattened-OPT tolerance): a *specialised* code (`at0.23`,
+        // dot-notation — AOM2 §specialisation depth) names a code DEFINED IN
+        // THE PARENT archetype, so a flattened template legitimately binds it
+        // without re-emitting the definition locally; the released AM text
+        // never requires the definition to be repeated at the specialisation
+        // level. A dotted code is therefore accepted as a valid binding key.
+        // (Observed in the vendored blood-pressure corpus OPTs — evidence that
+        // the shape occurs, never the authority for accepting it.)
         let specialised = code.contains('.');
         if code.starts_with('/')
             || !archetype_node_id_is_term_code(code)

--- a/app/ferroehr/src/versioning/contribution.rs
+++ b/app/ferroehr/src/versioning/contribution.rs
@@ -412,7 +412,6 @@ pub(crate) async fn commit_version_set(
     // then existence/kind-checked in ONE batched statement, and the plan is
     // resolved to [`Change`]s without re-reading any JSON.
     let mut plan: Vec<PlannedVersion> = Vec::with_capacity(versions.len());
-    let mut version_codes: Vec<String> = Vec::with_capacity(versions.len());
     for version in versions {
         reject_foreign_version_identity(version)?;
         let token = version
@@ -430,7 +429,6 @@ pub(crate) async fn commit_version_set(
             .get("preceding_version_uid")
             .is_some_and(|v| !v.is_null());
         let (action, code) = classify(token.as_deref(), has_preceding, data.is_some())?;
-        version_codes.push(code.clone());
 
         let target = if action == Action::Create {
             None
@@ -707,15 +705,38 @@ pub(crate) async fn commit_version_set(
         cx.ensure_content_writable(ehr_id).await?;
     }
 
-    // The CONTRIBUTION's own audit: a client change_type is validated and
-    // preserved; otherwise the spec's aggregate guidance applies (master06
-    // §Contributions).
-    let contribution_code = match body
-        .get("audit")
-        .and_then(|a| a.get("change_type"))
-        .and_then(coded_value)
-    {
-        Some(token) => change_type_code(&token).ok_or_else(|| {
+    // The CONTRIBUTION's own audit change type is the CLIENT's account of its
+    // change set, and it is REQUIRED: RM common
+    // `UML/classes/org.openehr.rm.common.audit_details.adoc` §Attributes types
+    // `change_type` 1..1 on the mandatory `CONTRIBUTION.audit`, and the released
+    // commit schema says the same on the wire —
+    // `specifications/schemas/ehr/NewContribution.yaml` (`required: [versions,
+    // audit]`) over `specifications/schemas/common/UpdateAudit.yaml`
+    // (`required: [change_type, committer]`), the demographic
+    // `NewContribution.yaml` identically. The ITS-REST docs text is silent on
+    // the contribution BODY (its `openehr-audit-details` §"None of these headers
+    // are mandatory" sentence governs the DIRECT resource routes' header merge,
+    // where the server does supply the default), so the released OAS grounds
+    // the requirement — and an omitted change type is refused rather than
+    // derived: master06 §Contributions itself says the aggregate "may sometimes
+    // be approximate, and is not expected to be used as a computable value", so
+    // a server-guessed aggregate would put an approximation into the audit trail
+    // under the client's name.
+    let contribution_code = {
+        let token = body
+            .get("audit")
+            .and_then(|a| a.get("change_type"))
+            .and_then(coded_value)
+            .ok_or_else(|| {
+                ServiceError::Unprocessable(
+                    Violation::new(
+                        "is required on a CONTRIBUTION audit — the change set's own change \
+                         type is the client's account of it and is never derived by the server",
+                    )
+                    .with_path("CONTRIBUTION.audit.change_type"),
+                )
+            })?;
+        change_type_code(&token).ok_or_else(|| {
             ServiceError::Unprocessable(
                 Violation::new(format!(
                     "{token:?} is not a code in the openEHR audit_change_type group"
@@ -723,8 +744,7 @@ pub(crate) async fn commit_version_set(
                 .with_path("contribution audit change_type")
                 .with_invariant("AUDIT_DETAILS.Change_type_valid"),
             )
-        })?,
-        None => aggregate_change_type(&version_codes),
+        })?
     };
     let contribution_audit = parse_audit(
         body.get("audit"),
@@ -981,62 +1001,16 @@ fn parse_audit(
     })
 }
 
-/// The CONTRIBUTION-level aggregate change type when the client supplied none.
-///
-/// RM common `master06-change_control_package.adoc` §Contributions gives the
-/// rule as a list of "typical values", in this order:
-///
-/// * "any code: when all member versions have the same change type, that change
-///   type may be used for the Contribution as well" — the uniform case;
-/// * "`250|amendment|`: corresponds to a mixture of amendments and deletions
-///   that logically constitute a correction to the content" — the one NAMED
-///   mixture, and therefore the one mixture that does not fall to the general
-///   rule below;
-/// * "`251|modification|`: this accommodates cases where there is a mixture of
-///   creation, deletion, modification that constitute a change of content" —
-///   the general mixture.
-///
-/// (`666|attestation|` — "used when the only changes are attestation of one or
-/// more of the member versions" — is the uniform case of the first bullet: an
-/// attestation-only change set has no member version codes other than 666.)
-///
-/// NOTE: the same section states its own limit — the aggregate "may sometimes
-/// be approximate, and is not expected to be used as a computable value" — so
-/// this derivation is a best statement of the change set, never a datum a
-/// caller may reason over. A client-supplied `CONTRIBUTION.audit.change_type`
-/// always wins (the caller's own account of its change set); this runs only
-/// when none was supplied.
-///
-/// NOTE (why this is not asserted on the wire): on the ITS-REST contribution
-/// route it is unreachable from a conformant request. The released schema makes
-/// the change set's audit mandatory and its change type a required member —
-/// `specifications/schemas/ehr/NewContribution.yaml` (`required: [versions,
-/// audit]`) over `specifications/schemas/common/UpdateAudit.yaml` (`required:
-/// [change_type, committer]`) — so a conformant client always states the
-/// aggregate itself and this fallback never fires. On the direct
-/// resource routes the server does supply the default (ITS-REST overview
-/// `Requests_and_responses.md` §"openehr-version and openehr-audit-details":
-/// "None of these headers are mandatory, but whatever is provided it MUST be
-/// merged with the default VERSION and `VERSION.audit_details` attributes on
-/// commit runtime"), but each such write is a single-version change set, so
-/// only the uniform arm can be reached there. The mixture arms are therefore
-/// pinned by the unit tests below rather than by a CNF case.
-fn aggregate_change_type(version_codes: &[String]) -> String {
-    match version_codes.split_first() {
-        Some((first, rest)) if rest.iter().all(|c| c == first) => first.clone(),
-        // The named amendment/deletion mixture: every member is an amendment or
-        // a deletion, and (by the arm above) they are not all the same code, so
-        // both kinds are present — "a mixture of amendments and deletions".
-        Some(_)
-            if version_codes
-                .iter()
-                .all(|c| c == change_type::AMENDMENT || c == change_type::DELETED) =>
-        {
-            change_type::AMENDMENT.to_owned()
-        }
-        _ => change_type::MODIFICATION.to_owned(),
-    }
-}
+// NOTE (the aggregate derivation is deliberately absent): RM common
+// `master06-change_control_package.adoc` §Contributions describes what a
+// CONTRIBUTION-level change type typically holds for a mixed change set, and
+// says in the same breath that the value "may sometimes be approximate, and is
+// not expected to be used as a computable value". That makes it the client's
+// statement about its own change set, never a server derivation — so the commit
+// path above REFUSES an omitted `CONTRIBUTION.audit.change_type` (the released
+// commit schema requires it: `schemas/ehr/NewContribution.yaml` +
+// `schemas/common/UpdateAudit.yaml`) instead of guessing an aggregate into the
+// audit trail under the client's name.
 
 /// Enforce that a version's object kind matches the contribution's scope: a
 /// demographic contribution (`party_only`) may carry only party roots +
@@ -1622,42 +1596,5 @@ mod tests {
         assert_eq!((action, code.as_str()), (Action::Create, "249"));
         let (action, code) = classify(None, true, true).unwrap();
         assert_eq!((action, code.as_str()), (Action::Modify, "251"));
-    }
-
-    /// The three aggregate outcomes RM common master06 §Contributions lists,
-    /// each on the shape its own sentence describes.
-    #[test]
-    fn contribution_aggregate_change_type() {
-        // "any code: when all member versions have the same change type, that
-        // change type may be used for the Contribution as well"
-        let same = vec!["250".to_owned(), "250".to_owned()];
-        assert_eq!(aggregate_change_type(&same), "250");
-        assert_eq!(
-            aggregate_change_type(&["666".to_owned(), "666".to_owned()]),
-            "666",
-            "an attestation-only change set is the uniform case"
-        );
-        // "251|modification|: this accommodates cases where there is a mixture
-        // of creation, deletion, modification that constitute a change of
-        // content"
-        let mixed = vec!["249".to_owned(), "523".to_owned()];
-        assert_eq!(aggregate_change_type(&mixed), "251");
-        assert_eq!(aggregate_change_type(&[]), "251");
-        // "250|amendment|: corresponds to a mixture of amendments and
-        // deletions that logically constitute a correction to the content"
-        assert_eq!(
-            aggregate_change_type(&["250".to_owned(), "523".to_owned()]),
-            "250"
-        );
-        assert_eq!(
-            aggregate_change_type(&["523".to_owned(), "250".to_owned(), "523".to_owned()]),
-            "250"
-        );
-        // …but only that mixture: add any other kind and the general mixture
-        // rule applies again.
-        assert_eq!(
-            aggregate_change_type(&["250".to_owned(), "523".to_owned(), "249".to_owned()]),
-            "251"
-        );
     }
 }

--- a/app/ferroehr/tests/it/persistence.rs
+++ b/app/ferroehr/tests/it/persistence.rs
@@ -514,7 +514,7 @@ async fn template_id_is_read_back_from_vo_version() {
     let pool = db.pool();
     let (vo, ehr_id) = seed_version(&pool).await;
     // Production sets this on commit (service/vobject.rs); set it directly here.
-    // vo_version.template_id has an FK into template_store — seed the template.
+    // vo_version.template_id has an FK into template_ref — seed the template.
     seed_template(&pool, "org.openehr::vital_signs.v1").await;
     sqlx::query("UPDATE vo_version SET template_id = $2 WHERE vo_id = $1")
         .bind(vo)
@@ -645,6 +645,13 @@ async fn seed_template(pool: &PgPool, template_id: &str) {
     .execute(pool)
     .await
     .expect("seed template_store");
+    // Register the wire address exactly as `store_template` does — the
+    // vo_version.template_id FK targets the template_ref registry.
+    sqlx::query("INSERT INTO template_ref (template_id) VALUES ($1) ON CONFLICT DO NOTHING")
+        .bind(template_id)
+        .execute(pool)
+        .await
+        .expect("seed template_ref");
 }
 
 async fn seed_version(pool: &PgPool) -> (Uuid, Uuid) {

--- a/app/ferroehr/tests/it/service_contribution.rs
+++ b/app/ferroehr/tests/it/service_contribution.rs
@@ -175,7 +175,7 @@ async fn accompanying_attestation_then_standalone_666_attestation() {
             "data": composition("v1"),
             "attestations": [ attestation("witnessed", false) ]
         }],
-        "audit": { "committer": committer("author") }
+        "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } },  "committer": committer("author") }
     });
     let created = svc
         .create_ehr_contribution(ehr_id.parse().expect("ehr uuid"), contribution)
@@ -207,7 +207,14 @@ async fn accompanying_attestation_then_standalone_666_attestation() {
                 "reason": { "_type": "DV_TEXT", "value": "authorised" },
                 "is_pending": false
             }
-        }]
+        }],
+        // The change set's own change type is the CLIENT's account of it (the
+        // released commit schema requires it), never a server-derived
+        // aggregate.
+        "audit": {
+            "change_type": change_type("666", "attestation"),
+            "committer": committer("senior reviewer")
+        }
     });
     let attest_created = svc
         .create_ehr_contribution(ehr_id.parse().expect("ehr uuid"), attest_contribution)
@@ -284,7 +291,7 @@ async fn attestation_error_cases() {
 
     // 666 without preceding_version_uid → 400 (cannot name its target).
     let err = attempt(json!({
-        "versions": [{
+        "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } }, "committer": { "_type": "PARTY_IDENTIFIED", "name": "conformance tester" } }, "versions": [{
             "commit_audit": {
                 "change_type": change_type("666", "attestation"),
                 "committer": committer("x"),
@@ -308,7 +315,7 @@ async fn attestation_error_cases() {
 
     // 666 carrying data → 422 (attestation adds no content).
     let err = attempt(json!({
-        "versions": [{
+        "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } }, "committer": { "_type": "PARTY_IDENTIFIED", "name": "conformance tester" } }, "versions": [{
             "preceding_version_uid": { "value": ovid_v1.clone() },
             "commit_audit": {
                 "change_type": change_type("666", "attestation"),
@@ -334,7 +341,7 @@ async fn attestation_error_cases() {
 
     // Attestation missing reason → 422 (ATTESTATION.reason 1..1).
     let err = attempt(json!({
-        "versions": [{
+        "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } }, "committer": { "_type": "PARTY_IDENTIFIED", "name": "conformance tester" } }, "versions": [{
             "preceding_version_uid": { "value": ovid_v1.clone() },
             "commit_audit": {
                 "change_type": change_type("666", "attestation"),
@@ -358,7 +365,7 @@ async fn attestation_error_cases() {
 
     // Attestation missing is_pending → 422 (ATTESTATION.is_pending 1..1).
     let err = attempt(json!({
-        "versions": [{
+        "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } }, "committer": { "_type": "PARTY_IDENTIFIED", "name": "conformance tester" } }, "versions": [{
             "preceding_version_uid": { "value": ovid_v1.clone() },
             "commit_audit": {
                 "change_type": change_type("666", "attestation"),
@@ -387,7 +394,7 @@ async fn attestation_error_cases() {
     // `400_CONTRIBUTION`: the modification does not match a stored object).
     let ghost = "00000000-0000-7000-8000-000000000000::ferroehr.local::1";
     let err = attempt(json!({
-        "versions": [{
+        "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } }, "committer": { "_type": "PARTY_IDENTIFIED", "name": "conformance tester" } }, "versions": [{
             "preceding_version_uid": { "value": ghost },
             "commit_audit": {
                 "change_type": change_type("666", "attestation"),
@@ -698,7 +705,7 @@ async fn contribution_honors_the_five_lifecycle_states() {
                     "lifecycle_state": lifecycle("553"),
                     "data": composition("incomplete v1")
                 }],
-                "audit": { "committer": committer("author") }
+                "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } },  "committer": committer("author") }
             }),
         )
         .await
@@ -741,7 +748,7 @@ async fn contribution_honors_the_five_lifecycle_states() {
                     "lifecycle_state": lifecycle("800"),
                     "data": composition("edited")
                 }],
-                "audit": { "committer": committer("author") }
+                "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } },  "committer": committer("author") }
             }),
         )
         .await
@@ -774,7 +781,7 @@ async fn contribution_honors_the_five_lifecycle_states() {
                         "lifecycle_state": lifecycle(code),
                         "data": composition("edited")
                     }],
-                    "audit": { "committer": committer("author") }
+                    "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } },  "committer": committer("author") }
                 }),
             )
             .await
@@ -802,7 +809,7 @@ async fn contribution_honors_the_five_lifecycle_states() {
                     "lifecycle_state": lifecycle("999"),
                     "data": composition("bad state")
                 }],
-                "audit": { "committer": committer("author") }
+                "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } },  "committer": committer("author") }
             }),
         )
         .await
@@ -831,7 +838,7 @@ async fn contribution_honors_the_five_lifecycle_states() {
                 "lifecycle_state": lifecycle("523"),
                 "preceding_version_uid": { "value": current }
             }],
-            "audit": { "committer": committer("author") }
+            "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } },  "committer": committer("author") }
         }),
     )
     .await
@@ -882,7 +889,7 @@ async fn version_commit_audit_defaults_from_the_contribution_audit() {
                         "data": composition("keeps its own audit")
                     }
                 ],
-                "audit": {
+                "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } }, 
                     "committer": committer("contribution committer"),
                     "system_id": "contribution.system"
                 }
@@ -994,7 +1001,7 @@ async fn contribution_supplied_uid() {
             "commit_audit": { "change_type": { "value": "creation",
                 "defining_code": { "code_string": "249", "terminology_id": { "value": "openehr" } } } }
         }],
-        "audit": { "committer": { "_type": "PARTY_IDENTIFIED", "name": "T" } }
+        "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } },  "committer": { "_type": "PARTY_IDENTIFIED", "name": "T" } }
     });
     let resp = svc
         .create_ehr_contribution(ehr_uuid, body.clone())
@@ -1186,7 +1193,7 @@ async fn contribution_cannot_delete_the_ehr_status() {
                     "lifecycle_state": { "terminology_id": "openehr", "code_string": "523" },
                     "preceding_version_uid": { "value": status_uid }
                 }],
-                "audit": { "committer": committer("author") }
+                "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } },  "committer": committer("author") }
             }),
         )
         .await
@@ -1251,7 +1258,7 @@ async fn data_carrying_deleted_lifecycle_is_refused_on_both_routes() {
                     "lifecycle_state": lifecycle("523"),
                     "data": composition("deleted but full")
                 }],
-                "audit": { "committer": committer("author") }
+                "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } },  "committer": committer("author") }
             }),
         )
         .await
@@ -1364,7 +1371,7 @@ async fn incomplete_admits_missing_composition_data_but_never_wrong_data() {
                 "lifecycle_state": lifecycle(state),
                 "data": data
             }],
-            "audit": { "committer": committer("author") }
+            "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } },  "committer": committer("author") }
         })
     };
 
@@ -1462,7 +1469,7 @@ async fn incomplete_relaxes_the_folder_kind_too() {
                 "lifecycle_state": lifecycle(lifecycle_code),
                 "data": nameless
             }],
-            "audit": { "committer": committer("author") }
+            "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } },  "committer": committer("author") }
         })
     };
 
@@ -1509,7 +1516,7 @@ async fn contribution_member_without_lifecycle_state_is_refused() {
                     },
                     "data": composition("no lifecycle")
                 }],
-                "audit": { "committer": committer("author") }
+                "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } },  "committer": committer("author") }
             }),
         )
         .await
@@ -1537,7 +1544,7 @@ async fn contribution_member_without_lifecycle_state_is_refused() {
                 "lifecycle_state": lifecycle("532"),
                 "data": composition("with lifecycle")
             }],
-            "audit": { "committer": committer("author") }
+            "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } },  "committer": committer("author") }
         }),
     )
     .await
@@ -1579,7 +1586,7 @@ async fn merge_provenance_is_refused_on_the_commit_wire() {
         }
         json!({
             "versions": [version],
-            "audit": { "committer": committer("author") }
+            "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } },  "committer": committer("author") }
         })
     };
 
@@ -1668,7 +1675,7 @@ async fn foreign_version_identity_is_refused_on_the_commit_wire() {
         }
         json!({
             "versions": [version],
-            "audit": { "committer": committer("author") }
+            "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } },  "committer": committer("author") }
         })
     };
 
@@ -1742,9 +1749,90 @@ async fn foreign_version_identity_is_refused_on_the_commit_wire() {
                 "lifecycle_state": lifecycle("532"),
                 "data": composition("v3")
             }],
-            "audit": { "committer": committer("author") }
+            "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } },  "committer": committer("author") }
         }),
     )
     .await
     .expect("a member self-tagged as the class this wire commits is accepted");
+}
+
+/// The CONTRIBUTION's own `audit.change_type` is REQUIRED and never derived.
+///
+/// RM common `UML/classes/org.openehr.rm.common.audit_details.adoc` §Attributes
+/// types `change_type` 1..1 on the mandatory `CONTRIBUTION.audit`, and the
+/// released commit schema requires it on the wire
+/// (`specifications/schemas/ehr/NewContribution.yaml` `required: [versions,
+/// audit]` over `specifications/schemas/common/UpdateAudit.yaml` `required:
+/// [change_type, committer]`). The ITS-REST docs text is silent on the
+/// contribution BODY — its "None of these headers are mandatory" sentence
+/// governs the direct routes' header merge — so the released OAS grounds the
+/// requirement. master06 §Contributions calls the aggregate value approximate
+/// and "not expected to be used as a computable value", which is precisely why
+/// the server must not invent one under the client's name.
+#[tokio::test]
+async fn contribution_audit_change_type_is_required_not_derived() {
+    let db = testkit::db().await.expect("testkit database");
+    let svc = FerroEhrService::new(db.pool());
+    let ehr_id = create_ehr(&svc).await;
+    let ehr_uuid: ferroehr::ids::EhrId = ehr_id.parse().expect("ehr uuid");
+
+    let member = || {
+        json!({
+            "commit_audit": {
+                "change_type": change_type("249", "creation"),
+                "committer": committer("author")
+            },
+            "lifecycle_state": change_type("532", "complete"),
+            "data": composition("audit twin")
+        })
+    };
+
+    // The invalid twin: an audit that names a committer but no change type.
+    let err = svc
+        .create_ehr_contribution(
+            ehr_uuid,
+            json!({
+                "versions": [member()],
+                "audit": { "committer": committer("author") }
+            }),
+        )
+        .await
+        .expect_err("a CONTRIBUTION audit without a change type must be refused");
+    assert_eq!(
+        err.status,
+        CallStatusType::ContentInvalid,
+        "the refusal is the 422 content-invalid row, got {err:?}"
+    );
+    assert!(
+        err.message.contains("CONTRIBUTION.audit.change_type"),
+        "the refusal names the missing attribute, got {err:?}"
+    );
+
+    // …and an entirely absent audit is the same refusal (the change type is
+    // absent either way).
+    let err = svc
+        .create_ehr_contribution(ehr_uuid, json!({ "versions": [member()] }))
+        .await
+        .expect_err("a CONTRIBUTION with no audit at all must be refused");
+    assert_eq!(err.status, CallStatusType::ContentInvalid, "got {err:?}");
+
+    // The valid twin: the client states its own change type and the commit
+    // succeeds, storing that code verbatim.
+    let created = svc
+        .create_ehr_contribution(
+            ehr_uuid,
+            json!({
+                "versions": [member()],
+                "audit": {
+                    "change_type": change_type("249", "creation"),
+                    "committer": committer("author")
+                }
+            }),
+        )
+        .await
+        .expect("a CONTRIBUTION stating its change type commits");
+    assert_eq!(
+        created.body["audit"]["change_type"]["defining_code"]["code_string"], "249",
+        "the client's own change type is stored verbatim"
+    );
 }

--- a/app/ferroehr/tests/it/service_demographic.rs
+++ b/app/ferroehr/tests/it/service_demographic.rs
@@ -534,7 +534,7 @@ async fn demographic_contribution_multi_version() {
                 "data": role("Nurse")
             }
         ],
-        "audit": {
+        "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } },
             "committer": { "_type": "PARTY_IDENTIFIED", "name": "tester" }
         }
     });

--- a/app/ferroehr/tests/it/service_dump_load.rs
+++ b/app/ferroehr/tests/it/service_dump_load.rs
@@ -952,11 +952,23 @@ async fn load_from_a_location_with_no_archive_is_file_not_writable() {
     let db = testkit::db().await.expect("testkit database");
     let service = FerroEhrService::new(db.pool());
 
+    let dir = archive_dir();
     let err = service
-        .load_ehrs(archive_dir())
+        .load_ehrs(dir.clone())
         .await
         .expect_err("no archive at the location");
     assert_eq!(err.status, CallStatusType::FileNotWritable);
+    // The SERVER FILESYSTEM PATH never reaches the body: it is deployment
+    // layout, and the caller supplied only the configured location name. The
+    // path + the OS diagnostic ride the trace record instead.
+    assert!(
+        !err.message.contains(&dir),
+        "the configured server path must not reach the wire body, got {err:?}"
+    );
+    assert!(
+        !err.message.contains('/'),
+        "no filesystem path fragment reaches the wire body, got {err:?}"
+    );
 }
 
 /// Whether the target repository holds an EHR row — the no-partial-write proof
@@ -1006,6 +1018,20 @@ async fn load_from_an_archive_with_a_mangled_manifest_is_file_not_writable() {
         .await
         .expect_err("a mangled manifest is refused");
     assert_eq!(err.status, CallStatusType::FileNotWritable);
+    // The caller's-archive defect NAMES THE ENTRY (that is what the caller can
+    // act on) and nothing else: no server path, no serde offsets/field names.
+    assert!(
+        err.message.contains("manifest.json"),
+        "the refusal names the offending archive entry, got {err:?}"
+    );
+    assert!(
+        !err.message.contains(&dir),
+        "the server path must not reach the wire body, got {err:?}"
+    );
+    assert!(
+        !err.message.contains("column") && !err.message.contains("line "),
+        "the serde diagnostic must not reach the wire body, got {err:?}"
+    );
     assert!(
         !ehr_row_exists(&dst_pool, ehr.into()).await,
         "a refused load commits nothing"
@@ -1050,6 +1076,10 @@ async fn load_from_a_truncated_container_is_file_not_writable() {
         .await
         .expect_err("a truncated container is refused");
     assert_eq!(err.status, CallStatusType::FileNotWritable);
+    assert!(
+        !err.message.contains(&dir) && !err.message.contains("archive.zip"),
+        "the container path must not reach the wire body, got {err:?}"
+    );
     assert!(
         !ehr_row_exists(&dst_pool, ehr.into()).await,
         "a refused load commits nothing"

--- a/app/ferroehr/tests/it/service_ehr.rs
+++ b/app/ferroehr/tests/it/service_ehr.rs
@@ -538,7 +538,7 @@ async fn is_modifiable_false_blocks_content_writes_but_not_ehr_status() {
         .create_ehr_contribution(
             ehr_uuid,
             json!({
-                "versions": [{
+                "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } }, "committer": { "_type": "PARTY_IDENTIFIED", "name": "conformance tester" } }, "versions": [{
                     "lifecycle_state": { "terminology_id": "openehr", "code_string": "532" },
                     "data": composition("Via contribution"),
                     "commit_audit": { "change_type": change_type("249", "creation") }
@@ -874,7 +874,7 @@ async fn contribution_preserves_the_client_change_type_and_rejects_invalid_combo
         .create_ehr_contribution(
             ehr_uuid,
             json!({
-                "versions": [{
+                "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } }, "committer": { "_type": "PARTY_IDENTIFIED", "name": "conformance tester" } }, "versions": [{
                     "lifecycle_state": { "terminology_id": "openehr", "code_string": "532" },
                     "data": composition("v1"),
                     "commit_audit": { "change_type": change_type("249", "creation") }
@@ -893,6 +893,10 @@ async fn contribution_preserves_the_client_change_type_and_rejects_invalid_combo
         .create_ehr_contribution(
             ehr_uuid,
             json!({
+                "audit": {
+                    "change_type": change_type("250", "amendment"),
+                    "committer": { "_type": "PARTY_IDENTIFIED", "name": "conformance tester" }
+                },
                 "versions": [{
                     "lifecycle_state": { "terminology_id": "openehr", "code_string": "532" },
                     "data": composition("v2 corrected"),
@@ -907,9 +911,10 @@ async fn contribution_preserves_the_client_change_type_and_rejects_invalid_combo
         .as_str()
         .unwrap()
         .to_owned();
-    // With no contribution-level audit given, the aggregate change type is the
-    // members' shared code (RM change_control §"Contributions": "any code:
-    // when all member versions have the same change type…").
+    // The client's own contribution-level change type is stored and echoed
+    // verbatim — never narrowed to `modification` (RM change_control
+    // §"Contributions": "any code: when all member versions have the same
+    // change type, that change type may be used for the Contribution as well").
     assert_eq!(
         amended.body["audit"]["change_type"]["defining_code"]["code_string"],
         "250"
@@ -933,7 +938,7 @@ async fn contribution_preserves_the_client_change_type_and_rejects_invalid_combo
         .create_ehr_contribution(
             ehr_uuid,
             json!({
-                "versions": [{
+                "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } }, "committer": { "_type": "PARTY_IDENTIFIED", "name": "conformance tester" } }, "versions": [{
                     "lifecycle_state": { "terminology_id": "openehr", "code_string": "532" },
                     "data": composition("v3"),
                     "preceding_version_uid": ovid_v2,
@@ -962,7 +967,7 @@ async fn contribution_preserves_the_client_change_type_and_rejects_invalid_combo
         .create_ehr_contribution(
             ehr_uuid,
             json!({
-                "versions": [{
+                "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } }, "committer": { "_type": "PARTY_IDENTIFIED", "name": "conformance tester" } }, "versions": [{
                     "lifecycle_state": { "terminology_id": "openehr", "code_string": "532" },
                     "data": composition("v3"),
                     "preceding_version_uid": ovid_v2,
@@ -1895,7 +1900,7 @@ async fn ehr_folders_indexes_multiple_hierarchies_in_rank_order() {
         .create_ehr_contribution(
             ehr_uuid,
             json!({
-                "versions": [{
+                "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } }, "committer": { "_type": "PARTY_IDENTIFIED", "name": "conformance tester" } }, "versions": [{
                     "lifecycle_state": { "terminology_id": "openehr", "code_string": "532" },
                     "data": secondary,
                     "commit_audit": { "change_type": change_type("249", "creation") }
@@ -1941,7 +1946,7 @@ async fn ehr_folders_indexes_multiple_hierarchies_in_rank_order() {
         .create_ehr_contribution(
             ehr_uuid,
             json!({
-                "versions": [{
+                "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } }, "committer": { "_type": "PARTY_IDENTIFIED", "name": "conformance tester" } }, "versions": [{
                     "lifecycle_state": { "terminology_id": "openehr", "code_string": "532" },
                     "data": secondary_v2,
                     "preceding_version_uid": f2_ovid_v1,
@@ -2010,7 +2015,7 @@ async fn logical_delete_of_a_secondary_hierarchy_drops_it_from_folders() {
         .create_ehr_contribution(
             ehr_uuid,
             json!({
-                "versions": [{
+                "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } }, "committer": { "_type": "PARTY_IDENTIFIED", "name": "conformance tester" } }, "versions": [{
                     "lifecycle_state": { "terminology_id": "openehr", "code_string": "532" },
                     "data": folder("primary"),
                     "commit_audit": { "change_type": change_type("249", "creation") }
@@ -2030,7 +2035,7 @@ async fn logical_delete_of_a_secondary_hierarchy_drops_it_from_folders() {
         .create_ehr_contribution(
             ehr_uuid,
             json!({
-                "versions": [{
+                "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } }, "committer": { "_type": "PARTY_IDENTIFIED", "name": "conformance tester" } }, "versions": [{
                     "lifecycle_state": { "terminology_id": "openehr", "code_string": "532" },
                     "data": folder("secondary"),
                     "commit_audit": { "change_type": change_type("249", "creation") }
@@ -2055,7 +2060,7 @@ async fn logical_delete_of_a_secondary_hierarchy_drops_it_from_folders() {
     svc.create_ehr_contribution(
         ehr_uuid,
         json!({
-            "versions": [{
+            "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } }, "committer": { "_type": "PARTY_IDENTIFIED", "name": "conformance tester" } }, "versions": [{
                 "lifecycle_state": { "terminology_id": "openehr", "code_string": "523" },
                 "preceding_version_uid": f2_ovid,
                 "commit_audit": { "change_type": change_type("523", "deleted") }

--- a/app/ferroehr/tests/it/service_ehr_access.rs
+++ b/app/ferroehr/tests/it/service_ehr_access.rs
@@ -98,7 +98,7 @@ async fn ehr_access_settings_round_trip_through_contribution() {
             "preceding_version_uid": preceding,
             "data": ehr_access_with_settings()
         } ],
-        "audit": { "committer": committer("alice") }
+        "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } },  "committer": committer("alice") }
     });
     svc.create_ehr_contribution(ehr_id, contribution)
         .await

--- a/app/ferroehr/tests/it/service_events.rs
+++ b/app/ferroehr/tests/it/service_events.rs
@@ -251,7 +251,7 @@ async fn composition_and_contribution_commits_each_write_one_phi_free_outbox_row
                     "code_string": "532" } },
             "data": composition("c1")
         }],
-        "audit": { "committer": committer("author") }
+        "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } },  "committer": committer("author") }
     });
     svc.create_ehr_contribution(ehr, contribution)
         .await
@@ -309,7 +309,7 @@ async fn outbox_disabled_writes_no_rows() {
                     "code_string": "532" } },
             "data": composition("c1")
         }],
-        "audit": { "committer": committer("author") }
+        "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } },  "committer": committer("author") }
     });
     svc.create_ehr_contribution(ehr, contribution)
         .await

--- a/app/ferroehr/tests/it/service_import.rs
+++ b/app/ferroehr/tests/it/service_import.rs
@@ -1155,7 +1155,7 @@ async fn attesting_an_imported_version_is_refused() {
         .expect("import_ehr");
 
     let attest_contribution = json!({
-        "versions": [{
+        "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } }, "committer": { "_type": "PARTY_IDENTIFIED", "name": "conformance tester" } }, "versions": [{
             "preceding_version_uid": { "value": imported_uid },
             "commit_audit": {
                 "change_type": {

--- a/app/ferroehr/tests/it/service_signing.rs
+++ b/app/ferroehr/tests/it/service_signing.rs
@@ -844,7 +844,7 @@ async fn after_committal_attestation_is_outside_the_signed_form() {
     svc.create_ehr_contribution(
         ehr_uuid,
         json!({
-            "versions": [{
+            "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } }, "committer": { "_type": "PARTY_IDENTIFIED", "name": "conformance tester" } }, "versions": [{
                 "preceding_version_uid": { "value": ovid.clone() },
                 "commit_audit": {
                     "change_type": change_type("666", "attestation"),

--- a/app/ferroehr/tests/it/service_sm3.rs
+++ b/app/ferroehr/tests/it/service_sm3.rs
@@ -388,7 +388,7 @@ async fn relationship_via_demographic_contribution() {
             },
             "data": relationship("colleague-of", "p1", "p2")
         }],
-        "audit": { "committer": { "_type": "PARTY_IDENTIFIED", "name": "tester" } }
+        "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } },  "committer": { "_type": "PARTY_IDENTIFIED", "name": "tester" } }
     });
 
     let created = svc

--- a/app/ferroehr/tests/it/service_validation.rs
+++ b/app/ferroehr/tests/it/service_validation.rs
@@ -84,6 +84,10 @@ fn composition(name: &str) -> Value {
 
 const IPS_OPT: &str = "../../crates/openehr-its/tests/fixtures/sdk/ips.v0.opt";
 
+/// The `template_id` the IPS OPT declares (and its canonical compositions
+/// carry in `archetype_details.template_id.value`).
+const IPS_TEMPLATE_ID: &str = "International Patient Summary";
+
 /// Count the persisted COMPOSITION versions (kind discriminator on `vo_version`).
 async fn composition_versions(pool: &PgPool) -> i64 {
     sqlx::query_scalar("SELECT count(*) FROM vo_version WHERE kind = 'COMPOSITION'")
@@ -226,6 +230,90 @@ async fn composition_update_is_validated() {
     );
 }
 
+/// The direct COMPOSITION routes stamp `vo_version.template_id` on every
+/// version they commit, exactly like the CONTRIBUTION route — the promoted
+/// column the ABAC template attribute (`template_of_version`) and the
+/// template-delete guard both read.
+///
+/// The silent-unbind twin is pinned by the same assertions: were the stamp to
+/// go back to `NULL`, `template_of_version` would answer `None` and a
+/// template-scoped ABAC rule would stop binding without any error.
+/// (`vo_version.template_id` is our own promoted column — no openEHR spec
+/// governs the storage mechanics.)
+#[tokio::test]
+async fn direct_route_commits_stamp_the_template_id() {
+    let db = testkit::db().await.expect("testkit database");
+    let pool = db.pool();
+    let svc = FerroEhrService::new(pool.clone());
+
+    svc.template_adl14_upload(fixture(IPS_OPT))
+        .await
+        .expect("upload IPS OPT");
+    let ehr_id = svc.create_ehr(None).await.expect("create_ehr").to_string();
+    let ehr_uuid = ferroehr::ids::EhrId(ehr_id.parse::<uuid::Uuid>().expect("ehr uuid"));
+
+    // ── create (direct route) ────────────────────────────────────────────────
+    let ovid_v1 = svc
+        .create_composition(ehr_uuid, uv(composition("ips_canonical.json"), "249", None))
+        .await
+        .expect("valid v1")
+        .version_uid();
+    let vo_uuid = ovid_v1
+        .split("::")
+        .next()
+        .expect("vo_id segment")
+        .parse::<ferroehr::ids::VoId>()
+        .expect("vo uuid");
+
+    assert_eq!(
+        svc.template_of_version(vo_uuid, None)
+            .await
+            .expect("resolve template of the current version")
+            .as_deref(),
+        Some(IPS_TEMPLATE_ID),
+        "a direct-route create binds its template attribute"
+    );
+
+    // ── update (direct route) ────────────────────────────────────────────────
+    let ovid_v2 = svc
+        .update_composition(
+            ehr_uuid,
+            vo_uuid,
+            uv(composition("ips_canonical.json"), "251", Some(&ovid_v1)),
+        )
+        .await
+        .expect("valid v2")
+        .version_uid();
+    assert_ne!(ovid_v1, ovid_v2, "the update advanced the version");
+    assert_eq!(
+        svc.template_of_version(vo_uuid, Some("2"))
+            .await
+            .expect("resolve template of version 2")
+            .as_deref(),
+        Some(IPS_TEMPLATE_ID),
+        "a direct-route update stamps the template on the new version too"
+    );
+
+    // Every stored version row carries it — the cheap SQL prefilter the
+    // template-delete guard counts.
+    let stamped: i64 = sqlx::query_scalar("SELECT count(*) FROM vo_version WHERE template_id = $1")
+        .bind(IPS_TEMPLATE_ID)
+        .fetch_one(&pool)
+        .await
+        .expect("count stamped versions");
+    assert_eq!(stamped, 2, "both direct-route versions are stamped");
+    let unstamped: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM vo_version WHERE kind = 'COMPOSITION' AND template_id IS NULL",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("count unstamped versions");
+    assert_eq!(
+        unstamped, 0,
+        "no direct-route COMPOSITION version is left unbound"
+    );
+}
+
 /// A version-item `commit_audit.change_type` as a coded openEHR audit change type.
 fn change_type_coded(code: &str, value: &str) -> Value {
     json!({
@@ -241,7 +329,7 @@ fn change_type_coded(code: &str, value: &str) -> Value {
 /// A `553|incomplete|` CONTRIBUTION carrying a single `creation` version.
 fn incomplete_creation_contribution(data: &Value) -> Value {
     json!({
-        "versions": [{
+        "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } }, "committer": { "_type": "PARTY_IDENTIFIED", "name": "conformance tester" } }, "versions": [{
             "data": data,
             "commit_audit": { "change_type": change_type_coded("249", "creation") },
             "lifecycle_state": {
@@ -535,4 +623,103 @@ async fn element_without_value_or_null_flavour_is_rejected_at_commit() {
         0,
         "the RM-invalid composition was not persisted"
     );
+}
+
+/// The ADL2 twin of [`direct_route_commits_stamp_the_template_id`]: a
+/// direct-route commit against an **ADL2-registered** operational template is
+/// accepted and stamps `vo_version.template_id` — the FK target is the
+/// `template_ref` registry (the union of BOTH template dialects' wire
+/// addresses, `0001_baseline.sql`), so the stamp is not refused as a foreign
+/// key violation the way a `template_store`-only FK would (the CNF
+/// `SF-FLAT-adl2_commit` regression). The in-use delete guard then refuses the
+/// ADL2 template's physical delete while the version references it (the same
+/// never-orphan guard the OPT 1.4 delete carries; no openEHR spec governs the
+/// storage mechanics — our own design; FLAT-over-ADL2 is grounded in the AM
+/// side-by-side mandate, BASE `architecture_overview/master05-package_structure.adoc`).
+#[tokio::test]
+async fn direct_route_commit_against_an_adl2_template_stamps_and_guards() {
+    const ADL2_TEMPLATE_ID: &str = "openEHR-EHR-COMPOSITION.cnf_adl2_flat_a.v1.0.0";
+    let db = testkit::db().await.expect("testkit database");
+    let pool = db.pool();
+    let svc = FerroEhrService::new(pool.clone());
+
+    // The CNF `SF-FLAT-adl2_commit` provisioning pair + FLAT body, read from
+    // the committed catalogue corpus (golden vectors over hand-written
+    // fixtures, `.claude/rules/testing.md` §Oracles).
+    let artifacts = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tools/cnf-runner/artifacts/corpus/fixtures");
+    let archetype = std::fs::read_to_string(artifacts.join("adl2/archetype/cnf_count_a.adls"))
+        .expect("CNF count archetype source");
+    let opt2 = std::fs::read_to_string(artifacts.join("adl2/opt/flat_parity_a.adls"))
+        .expect("CNF FLAT-parity OPT2 source");
+    svc.upload_artefact(archetype)
+        .await
+        .expect("upload the ADL2 archetype");
+    svc.upload_artefact(opt2)
+        .await
+        .expect("upload the ADL2 operational template");
+
+    // Convert the FLAT body exactly as the REST edge does (WebTemplate via the
+    // dialect-resolving public seam, `openehr_its::flat` conversion).
+    let wt = svc
+        .web_template(ADL2_TEMPLATE_ID)
+        .await
+        .expect("the ADL2-backed WebTemplate resolves");
+    let flat: serde_json::Map<String, Value> = serde_json::from_str(
+        &std::fs::read_to_string(artifacts.join("sf/flat.adl2_valid.json"))
+            .expect("CNF FLAT fixture"),
+    )
+    .expect("FLAT JSON");
+    let composition =
+        openehr_its::flat::convert::composition_from_flat(&flat, &wt, "2026-08-03T12:00:00Z")
+            .expect("FLAT converts to a canonical COMPOSITION");
+
+    let ehr_id = svc.create_ehr(None).await.expect("create_ehr").to_string();
+    let ehr_uuid = ferroehr::ids::EhrId(ehr_id.parse::<uuid::Uuid>().expect("ehr uuid"));
+    let ovid = svc
+        .create_composition(ehr_uuid, uv(composition, "249", None))
+        .await
+        .expect("a commit against an ADL2-registered template is accepted")
+        .version_uid();
+    let vo_uuid = ovid
+        .split("::")
+        .next()
+        .expect("vo_id segment")
+        .parse::<ferroehr::ids::VoId>()
+        .expect("vo uuid");
+    assert_eq!(
+        svc.template_of_version(vo_uuid, None)
+            .await
+            .expect("resolve template of the current version")
+            .as_deref(),
+        Some(ADL2_TEMPLATE_ID),
+        "an ADL2-templated direct-route create binds its template attribute"
+    );
+
+    // In use → the physical delete refuses (the 409-class conflict status,
+    // the same mapping every `ServiceError::Conflict` carries), naming the
+    // reference count; the OPT2 row and the registry row both survive.
+    let in_use = svc
+        .delete_artefact(ADL2_TEMPLATE_ID.to_owned())
+        .await
+        .expect_err("an in-use ADL2 template must refuse physical deletion");
+    assert!(
+        matches!(
+            &in_use,
+            SmError {
+                status: CallStatusType::CompositionAlreadyExists,
+                ..
+            }
+        ) && in_use
+            .message
+            .contains("still referenced by 1 committed version"),
+        "got {in_use:?}"
+    );
+    let registered: i64 =
+        sqlx::query_scalar("SELECT count(*) FROM template_ref WHERE template_id = $1")
+            .bind(ADL2_TEMPLATE_ID)
+            .fetch_one(&pool)
+            .await
+            .expect("count registry rows");
+    assert_eq!(registered, 1, "the refused delete left the registry intact");
 }

--- a/app/ferroehr/tests/it/telemetry_metrics.rs
+++ b/app/ferroehr/tests/it/telemetry_metrics.rs
@@ -226,7 +226,7 @@ async fn compositions_committed_total_counts_every_committed_composition_version
             "lifecycle_state": change_type("532", "complete"),
             "data": composition("contributed")
         }],
-        "audit": { "committer": committer("metrics tester") }
+        "audit": { "change_type": { "_type": "DV_CODED_TEXT", "value": "modification", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "251" } },  "committer": committer("metrics tester") }
     });
     svc.create_ehr_contribution(ehr_id, contribution)
         .await

--- a/app/ferroehr/tests/it/terminology_fhir.rs
+++ b/app/ferroehr/tests/it/terminology_fhir.rs
@@ -277,6 +277,18 @@ async fn server_5xx_is_an_exception() {
         .await
         .expect_err("5xx → exception");
     assert_eq!(err.status, CallStatusType::Exception);
+    // The OPERATOR detail stays off the wire: a 500 body names neither the
+    // configured provider, nor its URL, nor the upstream status — a tenant's
+    // clients cannot read the deployment's terminology configuration out of a
+    // failure. (The operator gets all of it on the trace record.)
+    assert!(
+        !err.message.contains("test"),
+        "the configured provider name must not reach the body, got {err:?}"
+    );
+    assert!(
+        !err.message.contains(&server.uri()) && !err.message.contains("503"),
+        "the upstream URL/status must not reach the body, got {err:?}"
+    );
 }
 
 #[tokio::test]

--- a/app/ferroehr/tests/it/terminology_mtls.rs
+++ b/app/ferroehr/tests/it/terminology_mtls.rs
@@ -39,6 +39,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use ferroehr::service::status::CallStatusType;
 use ferroehr::service::terminology::config::{
     ExternalTerminologyConfig, FhirOperation, FhirProviderConfig, ProviderKind,
 };
@@ -380,9 +381,13 @@ async fn the_same_server_refuses_a_provider_without_the_identity() {
     let err = lookup(cfg)
         .await
         .expect_err("a client-authenticating server must refuse an anonymous client");
+    // The failure is typed and loud (never a silent success), while the
+    // OPERATOR detail — which configured provider, and the TLS diagnostic —
+    // stays on the trace record and off the wire body.
+    assert_eq!(err.status, CallStatusType::Exception, "got {err:?}");
     assert!(
-        err.message.contains("terminology provider 'default'"),
-        "got {}",
+        !err.message.contains("terminology provider 'default'"),
+        "the configured provider must not be named on the wire, got {}",
         err.message
     );
     assert_eq!(
@@ -422,9 +427,10 @@ async fn a_custom_ca_bundle_trusts_a_private_server_that_default_trust_refuses()
     let err = lookup(untrusted)
         .await
         .expect_err("default trust must refuse a privately-issued certificate");
+    assert_eq!(err.status, CallStatusType::Exception, "got {err:?}");
     assert!(
-        err.message.contains("terminology provider 'default'"),
-        "got {}",
+        !err.message.contains("terminology provider 'default'"),
+        "the configured provider must not be named on the wire, got {}",
         err.message
     );
 }

--- a/app/ferroehr/tests/it/terminology_multi_provider.rs
+++ b/app/ferroehr/tests/it/terminology_multi_provider.rs
@@ -426,9 +426,18 @@ async fn a_refused_grant_is_a_typed_error_not_an_anonymous_request() {
         .get_term(SNOMED, "38341003", None, None)
         .await
         .expect_err("a refused grant must fail the call");
+    // The refused grant is a TYPED failure — never an anonymous retry — while
+    // the operator detail (which client, and the authorization server's own
+    // error) stays on the trace record, off the wire body.
+    assert_eq!(
+        err.status,
+        ferroehr::service::status::CallStatusType::Exception,
+        "got {err:?}"
+    );
     assert!(
-        err.message.contains("client-credentials grant failed"),
-        "the error names the failing grant, got: {}",
+        !err.message.contains("client-credentials grant failed")
+            && !err.message.contains("ts-client"),
+        "the deployment's credential configuration must not reach the wire body, got: {}",
         err.message
     );
     assert_eq!(

--- a/website/book/src/templates-validation.md
+++ b/website/book/src/templates-validation.md
@@ -62,7 +62,10 @@ conformance). An invalid artefact is rejected with **422 Unprocessable
 Entity** whose error body lists the offending rule codes in `validationErrors`
 (the S-codes for a source that cannot be parsed, the V-codes for a
 validation-phase failure, e.g. `VARD`, `VCORM`, `VACSD`). A duplicate ADL2
-template id returns **409 Conflict** on this endpoint.
+template id returns **409 Conflict** on this endpoint. Deleting an ADL2
+template that committed compositions still reference is also a
+**409 Conflict** naming the reference count — the same never-orphan guard the
+OPT 1.4 delete applies; delete the compositions first.
 
 A loaded ADL2 template is retrieved in either of two representations, chosen
 by `Accept`: the stored ADL2 **source** (`text/plain`, the default) or the

--- a/website/book/src/using-the-api/resources.md
+++ b/website/book/src/using-the-api/resources.md
@@ -248,9 +248,11 @@ curl -u ferroehr:ferroehr \
 `POST /ehr/{ehr_id}/contribution` takes a contribution whose `versions` array
 each describe a change (the RM object, its `change_type`, its `lifecycle_state`,
 and per-version `commit_audit`) plus a shared `audit`. The audit objects are of
-type `UPDATE_AUDIT` (the server fills in `time_committed` and `system_id`). It
-returns **201** with the contribution id in `ETag`, or **400**/**404**/**409**
-on invalid input, unknown EHR, or a uid conflict.
+type `UPDATE_AUDIT` (the server fills in `time_committed` and `system_id`). The
+shared `audit` must carry its own `change_type`: it is your account of the
+change set as a whole and is never derived by the server — omitting it is a
+**422**. It returns **201** with the contribution id in `ETag`, or
+**400**/**404**/**409** on invalid input, unknown EHR, or a uid conflict.
 
 Two things about a version entry are worth calling out:
 


### PR DESCRIPTION
Third quick-win batch: 10 app-side fixes from the backlog triage, converged with the two-dialect `template_ref` registry that the CNF pipeline forced out during verification.

**Security (P1):**
- Direct-route COMPOSITION commits stamp `vo_version.template_id` — template-scoped ABAC rules previously bound only for CONTRIBUTION-committed compositions and silently did not match direct-route ones (the attribute resolved to "no template"). Both routes now derive the identity from `archetype_details.template_id`, exactly like the CONTRIBUTION path. Pre-existing rows keep NULL; a re-commit records it.
- **`template_ref` registry** (found by the conformance pipeline on this branch — `SF-FLAT-adl2_commit` went red): the stamp's FK targeted `template_store` only, so a commit against an **ADL2-registered** template died with a foreign-key violation classified 409. Three-way attribution per the triage law: catalogue expectation (`created`) matches the spec (simplified_formats master04 is dialect-neutral; AM keeps 1.4/2 side by side); the application's storage design was guilty. The FK now targets a registry spanning both dialects' wire addresses, maintained transactionally at all four provisioning/delete sites — and the ADL2 delete gains the never-orphan in-use guard (409 + reference count) and WebTemplate cache eviction it was missing entirely.

**Wire honesty:**
- A CONTRIBUTION audit lacking `change_type` is refused `422` instead of receiving a server-derived aggregate (RM `audit_details` 1..1; released `NewContribution.yaml`/`UpdateAudit.yaml` require it; master06 calls the aggregate approximate — a guessed value under the client's name has no place in an audit trail). Direct-route committal headers unchanged.
- Undecodable header bytes answer `400` naming the header instead of being silently dropped (committal + item-tag wrapper headers included).
- An AQL pool-acquire timeout sheds `503` + `Retry-After` (was `500`); a corrupt stored FHIR mapping is a `500` server fault (was `422`).
- Dump/load and terminology/subject-proxy failure bodies carry curated messages — server paths, provider names, config keys, TLS/OAuth diagnostics and serde internals go to the trace record only (boot-time config errors keep operator text; three tests that asserted the leak as the contract re-pinned to assert absence while keeping the typed-failure assertions).

**Structure:**
- `ServiceError::ValidationFailed` carries `Vec<InvariantViolation>`; the REST `ValidationError` shape is built only at the protocol bridge (wire bodies unchanged, pinned).
- `validate_folder` checks declared-slot-type conformance read from the generated RM model; presence rules stay with the whole-instance RM pass (no more lifecycle special-casing). The general slot-type gap is #1816.
- Archie-as-authority phrasing re-grounded on the released text (app half of #1668).

**Verification:** fmt, workspace clippy (all lanes), rustdoc, the pre-registry full workspace suite (3416/3416), and an 85-test targeted slice after the registry fix are green; the catalogue validates (978 cases, 0 findings). The full workspace + conformance rerun is deferred by owner directive (2026-08-03) to keep the fix cadence — the next pipeline run will verify the `SF-FLAT-adl2_commit` row and ratchet the baseline.

Closes #1813
Closes #1754
Closes #1728
Closes #1688
Closes #1811
Closes #1810
Closes #1809