### PR TITLE
fix(security): wire the ABAC engine and resolvers in the shipped binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,17 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **`authz.abac.enabled = true` now actually enables ABAC.** The server
+  binary built an RBAC-only authorization handle unconditionally — the ABAC
+  policy engine and its attribute resolvers were never constructed on the
+  shipped run path, so a deployment that configured attribute-based rules ran
+  without them, silently. The binary now boots the configured engine (Cedar
+  or remote PDP) with database-backed attribute resolvers, logs the active
+  authorization layers at startup, and **refuses to start** when an enabled
+  ABAC block cannot be built (missing/invalid policy directory, unbuildable
+  PDP client) — configuration that promises fine-grained authorization never
+  degrades to authorization-off.
+
 - **A one-group ISO OID now classifies as `ISO_OID`, not `INTERNET_ID`.** BASE
   `base_types` `master05-identification_package.adoc` §Syntaxes gives
   `iso_oid = number, { '.', number }` — one or more groups — while the UID

--- a/app/ferroehr-rest/src/extensions/access/authz/mod.rs
+++ b/app/ferroehr-rest/src/extensions/access/authz/mod.rs
@@ -128,21 +128,6 @@ pub struct AuthzHandle {
 }
 
 impl AuthzHandle {
-    /// Build an RBAC-only handle from config + the REST base path. `None` when
-    /// RBAC is disabled — the caller then leaves the
-    /// [`AppState`](crate::state::AppState) slot empty, preserving auth-only behaviour.
-    /// (The binary uses [`AuthzHandle::build`] to attach ABAC.)
-    #[must_use]
-    pub fn from_config(config: &AuthzConfig, base_path: &str) -> Option<Self> {
-        if !config.rbac.enabled {
-            return None;
-        }
-        Some(Self {
-            rbac: Some(RbacGate::new(config.rbac.clone(), base_path)),
-            abac: None,
-        })
-    }
-
     /// Build the full handle (the binary): the RBAC gate (when enabled) plus the
     /// ABAC gate (when `engine` is `Some`, i.e. `abac.enabled`). `None` when
     /// neither layer is active, so `AppState` stays empty (auth-only).
@@ -172,6 +157,21 @@ impl AuthzHandle {
     /// The fine-grained ABAC gate, if enabled.
     pub(crate) fn abac(&self) -> Option<&AbacGate> {
         self.abac.as_ref()
+    }
+
+    /// Whether the coarse RBAC gate is live on this handle (boot logging +
+    /// wiring tests).
+    #[must_use]
+    pub fn rbac_active(&self) -> bool {
+        self.rbac.is_some()
+    }
+
+    /// Whether the fine-grained ABAC gate is live on this handle — the loud
+    /// counterpart of the silent `abac: None` mis-wiring this seam once
+    /// carried (boot logging + wiring tests).
+    #[must_use]
+    pub fn abac_active(&self) -> bool {
+        self.abac.is_some()
     }
 
     /// The configured JWT role-claim paths (fed into the [`Authenticator`] so
@@ -478,12 +478,27 @@ mod tests {
         );
     }
 
+    /// Inert resolvers for handle-shape tests (nothing resolves).
+    fn inert_resolvers() -> AuthzResolvers {
+        AuthzResolvers {
+            subject: Arc::new(|_| Box::pin(async { Ok::<_, ResolveError>(None) })),
+            template_of_version: Arc::new(|_, _| Box::pin(async { Ok::<_, ResolveError>(None) })),
+        }
+    }
+
     #[test]
     fn handle_absent_when_rbac_disabled() {
         let mut cfg = AuthzConfig::default();
         cfg.rbac.enabled = false;
-        assert!(AuthzHandle::from_config(&cfg, BASE).is_none());
-        assert!(AuthzHandle::from_config(&AuthzConfig::default(), BASE).is_some());
+        let handle = AuthzHandle::build(&cfg, BASE, None, inert_resolvers());
+        assert!(handle.is_none());
+        let default = AuthzHandle::build(&AuthzConfig::default(), BASE, None, inert_resolvers())
+            .expect("RBAC on by default");
+        assert!(default.rbac_active());
+        assert!(
+            !default.abac_active(),
+            "no engine supplied → no ABAC gate on the handle"
+        );
     }
 
     #[test]

--- a/app/ferroehr-rest/tests/it/audit_iti81.rs
+++ b/app/ferroehr-rest/tests/it/audit_iti81.rs
@@ -29,7 +29,7 @@ use ferroehr::system_log::fhir;
 use ferroehr::system_log::message::AuditContext;
 use ferroehr::system_log::store::AuditStore;
 use ferroehr_rest::config::AppConfig;
-use ferroehr_rest::extensions::access::authz::AuthzHandle;
+use ferroehr_rest::extensions::access::authz::{AuthzHandle, AuthzResolvers, ResolveError};
 use http::{Request, StatusCode};
 use jiff::Timestamp;
 use serde_json::Value;
@@ -71,7 +71,12 @@ fn rest_config() -> AppConfig {
 fn authz(enabled: bool) -> Option<Arc<AuthzHandle>> {
     let mut cfg = AuthzConfig::default();
     cfg.rbac.enabled = enabled;
-    AuthzHandle::from_config(&cfg, &rest_config().server.base_path).map(Arc::new)
+    // RBAC-only: no engine, inert resolvers (nothing here consults ABAC).
+    let resolvers = AuthzResolvers {
+        subject: Arc::new(|_| Box::pin(async { Ok::<_, ResolveError>(None) })),
+        template_of_version: Arc::new(|_, _| Box::pin(async { Ok::<_, ResolveError>(None) })),
+    };
+    AuthzHandle::build(&cfg, &rest_config().server.base_path, None, resolvers).map(Arc::new)
 }
 
 fn basic(name: &str) -> String {

--- a/app/ferroehr-rest/tests/it/rbac_e2e.rs
+++ b/app/ferroehr-rest/tests/it/rbac_e2e.rs
@@ -36,7 +36,7 @@ use ferroehr::service::FerroEhrService;
 use ferroehr::system_log::config::{AuditConfig, FailMode, StoreConfig, SyslogConfig, Transport};
 use ferroehr::system_log::sender::{AuditSender, start};
 use ferroehr_rest::config::AppConfig;
-use ferroehr_rest::extensions::access::authz::AuthzHandle;
+use ferroehr_rest::extensions::access::authz::{AuthzHandle, AuthzResolvers, ResolveError};
 
 use crate::common;
 use http::{Request, StatusCode};
@@ -107,7 +107,12 @@ fn rest_config() -> AppConfig {
 fn authz(enabled: bool) -> Option<Arc<AuthzHandle>> {
     let mut cfg = AuthzConfig::default();
     cfg.rbac.enabled = enabled;
-    AuthzHandle::from_config(&cfg, &rest_config().server.base_path).map(Arc::new)
+    // RBAC-only: no engine, inert resolvers (nothing here consults ABAC).
+    let resolvers = AuthzResolvers {
+        subject: Arc::new(|_| Box::pin(async { Ok::<_, ResolveError>(None) })),
+        template_of_version: Arc::new(|_, _| Box::pin(async { Ok::<_, ResolveError>(None) })),
+    };
+    AuthzHandle::build(&cfg, &rest_config().server.base_path, None, resolvers).map(Arc::new)
 }
 
 /// A real service over a fresh DB, optionally wired with an ATNA audit sender.

--- a/app/ferroehr-server/src/lib.rs
+++ b/app/ferroehr-server/src/lib.rs
@@ -25,7 +25,9 @@ use ferroehr::telemetry::build_info::BuildInfo;
 use ferroehr::telemetry::health::{HealthIndicator, HealthRegistry};
 use ferroehr::versioning::signature::signer::Signer;
 use ferroehr_rest::config::AppConfig;
-use ferroehr_rest::extensions::access::authz::AuthzHandle;
+use ferroehr_rest::extensions::access::authz::{
+    AuthzHandle, AuthzResolvers, ResolveError, build_engine,
+};
 use ferroehr_rest::extensions::management::Observability;
 use sqlx::PgPool;
 use uuid::Uuid;
@@ -340,12 +342,26 @@ async fn serve(config_path: Option<&Path>, overrides: &[(String, String)]) -> an
         None
     };
 
-    // The RBAC gate — only wired when authentication is enabled.
+    // Authorization — only wired when authentication is enabled: the RBAC gate
+    // plus the ABAC engine + DB-backed attribute resolvers. A misconfigured
+    // ABAC block (enabled but unbuildable) aborts BOOT — configuration that
+    // promises fine-grained authorization must never degrade to authz-off.
     let authz = if config.auth.enabled {
-        AuthzHandle::from_config(&config.authz, &config.server.base_path).map(Arc::new)
+        build_authz(
+            &config.authz,
+            &config.server.base_path,
+            authz_resolvers(pool.clone(), Arc::clone(&service)),
+        )?
     } else {
         None
     };
+    if let Some(handle) = &authz {
+        tracing::info!(
+            rbac = handle.rbac_active(),
+            abac = handle.abac_active(),
+            "authorization enabled"
+        );
+    }
 
     // Assemble the REST adapter's runtime config view from the tree.
     let app_config = AppConfig {
@@ -402,6 +418,63 @@ async fn start_audit(
             tracing::error!("ATNA audit failed to start ({e}); continuing without auditing");
             (None, None)
         }
+    }
+}
+
+/// Build the full authorization handle the binary serves with: the RBAC gate
+/// (when `rbac.enabled`) plus the ABAC gate over the boot-built policy engine
+/// (when `abac.enabled`). `None` when neither layer is active (auth-only
+/// behaviour). Fine-grained authorization is our own extension — no openEHR
+/// spec governs it (ITS-REST places authorization out of band).
+///
+/// # Errors
+/// An ABAC block that is enabled but unbuildable (missing/invalid Cedar
+/// policies, an unbuildable remote-PDP client) — startup must abort rather
+/// than silently run without the promised gate.
+pub fn build_authz(
+    config: &ferroehr::config::authz::AuthzConfig,
+    base_path: &str,
+    resolvers: AuthzResolvers,
+) -> anyhow::Result<Option<Arc<AuthzHandle>>> {
+    let engine = build_engine(&config.abac).context("building the ABAC policy engine")?;
+    Ok(AuthzHandle::build(config, base_path, engine, resolvers).map(Arc::new))
+}
+
+/// The DB-backed ABAC attribute resolvers
+/// (`ferroehr_rest::extensions::access::authz::AuthzResolvers`): the EHR
+/// subject external-ref id (the promoted `ehr.subject_id` column — the same
+/// query the audit [`SubjectResolver`] runs) and the committed template of a
+/// COMPOSITION version (`vo_version.template_id` via the service read-back).
+/// Failures are typed [`ResolveError`]s — the PEP fails closed on them, never
+/// silently permits.
+#[must_use]
+pub fn authz_resolvers(pool: PgPool, service: Arc<FerroEhrService>) -> AuthzResolvers {
+    AuthzResolvers {
+        subject: Arc::new(move |ehr_id: String| {
+            let pool = pool.clone();
+            Box::pin(async move {
+                let id = Uuid::parse_str(&ehr_id)
+                    .map_err(|e| ResolveError(format!("ehr id {ehr_id}: {e}")))?;
+                sqlx::query_scalar::<_, Option<String>>("SELECT subject_id FROM ehr WHERE id = $1")
+                    .bind(id)
+                    .fetch_optional(&pool)
+                    .await
+                    .map(Option::flatten)
+                    .map_err(|e| ResolveError(format!("ehr subject lookup: {e}")))
+            })
+        }),
+        template_of_version: Arc::new(move |vo: String, version: Option<String>| {
+            let service = Arc::clone(&service);
+            Box::pin(async move {
+                let vo_id = vo
+                    .parse::<ferroehr::ids::VoId>()
+                    .map_err(|e| ResolveError(format!("vo id {vo}: {e}")))?;
+                service
+                    .template_of_version(vo_id, version.as_deref())
+                    .await
+                    .map_err(|e| ResolveError(format!("template lookup: {e}")))
+            })
+        }),
     }
 }
 

--- a/app/ferroehr-server/tests/it/authz_wiring.rs
+++ b/app/ferroehr-server/tests/it/authz_wiring.rs
@@ -1,0 +1,82 @@
+//! The binary's authorization construction seam
+//! ([`ferroehr_server::build_authz`]): the shipped run path builds the RBAC
+//! gate AND the ABAC engine, and an enabled-but-unbuildable ABAC block aborts
+//! boot instead of silently degrading to authz-off (the mis-wiring #1815
+//! caught: the binary once constructed an RBAC-only handle unconditionally).
+//!
+//! Offline by design, like the rest of this crate's suite: handle
+//! CONSTRUCTION touches no database — the resolvers are inert stubs here, and
+//! the DB-backed enforcement path is proven end to end where it lives
+//! (`app/ferroehr-rest/tests/it/abac_e2e.rs`, service-backed resolvers).
+//! Fine-grained authorization is our own extension — no openEHR spec governs
+//! it (ITS-REST places authorization out of band).
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use ferroehr::config::authz::AuthzConfig;
+use ferroehr_rest::extensions::access::authz::{AuthzResolvers, ResolveError};
+
+use ferroehr_server::build_authz;
+
+/// Inert resolvers: construction under test, resolution out of scope.
+fn inert_resolvers() -> AuthzResolvers {
+    AuthzResolvers {
+        subject: Arc::new(|_| Box::pin(async { Ok::<_, ResolveError>(None) })),
+        template_of_version: Arc::new(|_, _| Box::pin(async { Ok::<_, ResolveError>(None) })),
+    }
+}
+
+/// The shipped Cedar example policy set (the same fixture the engine's own
+/// golden-decision tests load).
+fn example_policies() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../ferroehr-rest/examples/policies")
+}
+
+/// `abac.enabled = true` with a valid policy directory → the handle the
+/// binary serves with carries a LIVE ABAC gate (the regression assertion).
+#[test]
+fn enabled_abac_is_live_on_the_built_handle() {
+    let mut cfg = AuthzConfig::default();
+    cfg.abac.enabled = true;
+    cfg.abac.cedar.policy_dir = Some(example_policies());
+    let handle = build_authz(&cfg, "/ferroehr/rest/openehr/v1", inert_resolvers())
+        .expect("a valid ABAC block builds")
+        .expect("RBAC default-on + ABAC on → a handle");
+    assert!(handle.rbac_active(), "the RBAC gate is on by default");
+    assert!(
+        handle.abac_active(),
+        "abac.enabled must produce a live ABAC gate on the served handle"
+    );
+}
+
+/// `abac.enabled = true` with no policy directory → boot ABORTS. A
+/// configuration that promises fine-grained authorization must never degrade
+/// to authz-off.
+#[test]
+fn enabled_but_unbuildable_abac_fails_boot() {
+    let mut cfg = AuthzConfig::default();
+    cfg.abac.enabled = true;
+    cfg.abac.cedar.policy_dir = None;
+    let err = build_authz(&cfg, "/ferroehr/rest/openehr/v1", inert_resolvers())
+        .expect_err("an enabled ABAC block without policies must refuse to boot");
+    assert!(
+        format!("{err:#}").contains("policy_dir"),
+        "the boot error names the missing setting: {err:#}"
+    );
+}
+
+/// The default config (RBAC on, ABAC off) keeps today's shape: a handle with
+/// the RBAC gate only.
+#[test]
+fn default_config_builds_an_rbac_only_handle() {
+    let handle = build_authz(
+        &AuthzConfig::default(),
+        "/ferroehr/rest/openehr/v1",
+        inert_resolvers(),
+    )
+    .expect("the default block builds")
+    .expect("RBAC is on by default");
+    assert!(handle.rbac_active());
+    assert!(!handle.abac_active(), "ABAC stays off unless enabled");
+}

--- a/app/ferroehr-server/tests/it/main.rs
+++ b/app/ferroehr-server/tests/it/main.rs
@@ -3,7 +3,8 @@
 //! shape, because a bin-only crate cannot be imported from `tests/`).
 //!
 //! Only the seam that needs no database, no listener, and no network is
-//! exercised here: [`Cli`](ferroehr_server::Cli) parsing (including the
+//! exercised here: the authorization construction seam
+//! ([`build_authz`](ferroehr_server::build_authz), `authz_wiring`), [`Cli`](ferroehr_server::Cli) parsing (including the
 //! `--set key=value` override parser and the subcommand shapes) and the
 //! pure-stdout `ferroehr config default` path through
 //! [`run`](ferroehr_server::run). Everything past that seam is tested where it
@@ -13,4 +14,5 @@
 //! One binary per crate, split into topic modules
 //! (`.claude/rules/testing.md` §One integration-test binary per crate).
 
+mod authz_wiring;
 mod wiring;

--- a/website/book/src/security.md
+++ b/website/book/src/security.md
@@ -170,7 +170,11 @@ dev compose stack ships one such account (`ferroehr-readonly`, password
 
 For attribute-level decisions — "may this user touch this patient's data,
 under this organisation, for this template?" — enable ABAC. A policy decision
-point is consulted per clinical operation with resolved attributes.
+point is consulted per clinical operation with resolved attributes. An
+enabled ABAC block that cannot be built — a missing or invalid policy
+directory, an unreachable-by-construction PDP client — aborts server startup:
+a configuration that promises fine-grained authorization never silently runs
+without it.
 
 | Environment variable | Default | Meaning |
 |---|---|---|


### PR DESCRIPTION
The shipped binary constructed authorization with `AuthzHandle::from_config`, which hard-set `abac: None` — `build_engine` and `AuthzHandle::build` (the ABAC path) had no production caller, so a deployment setting `abac.enabled = true` ran **without** the promised fine-grained gate, silently. Found verifying batch C's en-route reports; the worst-silent-failure class this repo exists to prevent.

- The binary now builds the configured PDP engine (Cedar or remote) at boot and wires `AuthzHandle::build` with database-backed attribute resolvers: the EHR subject external-ref id (`ehr.subject_id`, same query as the audit `SubjectResolver`) and the committed template of a version (`vo_version.template_id` via the service read-back). Resolution failures are typed and the PEP fails closed on them.
- An enabled-but-unbuildable ABAC block **aborts startup** (missing/invalid Cedar policy dir, unbuildable remote-PDP client) — never a degrade to authz-off. The active layers are logged at boot (`rbac`/`abac`).
- The caller-less `from_config` footgun is deleted; `rbac_active`/`abac_active` expose the handle's live layers; the three RBAC-only test sites moved to `build` with inert resolvers.
- New offline suite `ferroehr-server/tests/it/authz_wiring.rs` pins the construction seam: enabled ABAC → live gate on the served handle; enabled + no policies → boot error naming the setting; default → RBAC-only. End-to-end enforcement stays proven in `abac_e2e` (service-backed resolvers, from #1826).
- Docs: security.md states the boot-abort contract; changelog entry added.

Gates: fmt, clippy (`ferroehr-rest` + `ferroehr-server`, all targets, -D warnings), rustdoc, `ferroehr-server` 14/14, `ferroehr-rest` 678/678. Full battery + CNF rerun deferred per owner directive 2026-08-03.

Closes #1815