### PR TITLE
fix(validation): declared-slot-type conformance from the RM model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,19 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **A node claiming a `_type` foreign to its slot is now refused everywhere,
+  from the RM model.** The whole-instance validation pass dispatched each
+  node on its own wire `_type`, so a tagged object sitting in a slot declared
+  as something else was validated as the type it *claimed* to be — a
+  `DV_TEXT` inside `COMPOSITION.content` (declared `List<CONTENT_ITEM>`)
+  validated cleanly as a DV_TEXT. One model-driven rule now asserts every
+  tagged node (root, single slots, and list members alike) conforms to its
+  slot's declared RM type, read from the generated BMM attribute model; a
+  scalar member of a class-typed list slot is refused the same way. The rule
+  never relaxes on a `553|incomplete|` commit ("data may be missing, but it
+  may not be wrong"). The hand-written FOLDER member checks this replaces are
+  removed; their refusals now come from the general rule.
+
 - **`authz.abac.enabled = true` now actually enables ABAC.** The server
   binary built an RBAC-only authorization handle unconditionally — the ABAC
   policy engine and its attribute resolvers were never constructed on the

--- a/app/ferroehr/src/service/ehr/validation.rs
+++ b/app/ferroehr/src/service/ehr/validation.rs
@@ -577,95 +577,31 @@ pub(in crate::service) fn validate_ehr_access(
 }
 
 /// Validate a client-supplied FOLDER tree before it is committed (directory
-/// create/update and the CONTRIBUTION FOLDER path). RM common `folder.adoc` +
-/// RM ehr master04 §Folders:
+/// create/update and the CONTRIBUTION FOLDER path): the whole-instance RM
+/// class-invariant + terminology pass ([`validate_rm_invariants_for_commit`]),
+/// which now carries EVERY rule this function once restated by hand:
 ///
-/// - every node of the tree carries a `_type` conforming to the RM-declared
-///   type of the slot it occupies (`FOLDER.items` → `OBJECT_REF`,
-///   `FOLDER.folders` → `FOLDER`), read from the generated RM model
-///   ([`openehr_rm::model::attribute`] / [`openehr_rm::model::is_a`]). This is
-///   the WRONGNESS half of "Folder structures do not contain Compositions,
-///   only references to them" (master04 §Folders): a COMPOSITION committed by
-///   value into `items` is a positive type contradiction and is refused
-///   whatever the lifecycle state (RM common master06 §Incomplete Content —
-///   "data may be missing, but it may not be wrong").
-///
-/// The PRESENCE half is NOT restated here: an `OBJECT_REF`'s mandatory
-/// `id`/`namespace`/`type`, a member carrying a key `OBJECT_REF` does not
-/// declare, `LOCATABLE.name` mandatoriness, `Archetype_node_id_valid`,
-/// `Links_valid`, and the archetype-root identity rule all come from the
-/// whole-instance RM class-invariant + terminology pass
-/// ([`validate_rm_invariants_for_commit`]), which walks `items`, `folders`,
-/// `archetype_details`, each `LINK` in `links`, and `feeder_audit` — and which
-/// relaxes exactly the presence layer on a `553|incomplete|` commit, so no
-/// lifecycle special-casing is needed here. `archetype_details` itself stays
-/// OPTIONAL on a FOLDER — the RM types it 0..1 and FOLDER carries no
-/// `Is_archetype_root` invariant.
-///
-/// NOTE: the type-conformance rule is enforced here rather than in the
-/// whole-instance pass because that pass dispatches each node on its own wire
-/// `_type` (falling back to the declared type only when the tag is absent), so
-/// a tagged node in a concretely-declared slot is validated as the type it
-/// claims to be, never against the slot. TODO(#1816): fold this into the
-/// whole-instance pass once it checks every tagged node against its declared
-/// slot type; this is the FOLDER-shaped instance of that general rule.
+/// - the declared-slot-type conformance rule (root + every member), from the
+///   generated RM model — `FOLDER.items` → `OBJECT_REF`, `FOLDER.folders` →
+///   `FOLDER`, so a COMPOSITION committed by value into `items` is refused
+///   whatever the lifecycle state ("Folder structures do not contain
+///   Compositions, only references to them", RM ehr master04 §Folders; RM
+///   common master06 §Incomplete Content — "data may be missing, but it may
+///   not be wrong");
+/// - the PRESENCE layer (`OBJECT_REF`'s mandatory `id`/`namespace`/`type`,
+///   `LOCATABLE.name`, `Archetype_node_id_valid`, `Links_valid`, the
+///   archetype-root identity rule), which relaxes exactly on a
+///   `553|incomplete|` commit — so no lifecycle special-casing is needed.
+///   `archetype_details` stays OPTIONAL on a FOLDER (the RM types it 0..1 and
+///   FOLDER carries no `Is_archetype_root` invariant).
 ///
 /// # Errors
-/// [`ServiceError::Unprocessable`] naming the first violated rule and the
-/// offending tree path, or [`ServiceError::ValidationFailed`] carrying the
-/// RM-invariant violations found anywhere in the tree (both → 422).
+/// [`ServiceError::ValidationFailed`] carrying every violation found in the
+/// tree, each at its own path (→ 422).
 pub(in crate::service) fn validate_folder(
     folder: &Value,
     incomplete: bool,
 ) -> Result<(), ServiceError> {
-    /// The RM-declared type of `attr` on `class`, from the generated model.
-    fn declared(class: &str, attr: &str) -> Option<&'static str> {
-        openehr_rm::model::attribute(class, attr).map(|a| a.declared_type)
-    }
-
-    /// Refuse a member whose wire `_type` does not conform to `expected`.
-    fn conforms(member: &Value, expected: &str, path: &str) -> Result<(), ServiceError> {
-        let unproc = |m: String| ServiceError::Unprocessable(Violation::new(m));
-        let obj = member
-            .as_object()
-            .ok_or_else(|| unproc(format!("{path}: must be a JSON object ({expected})")))?;
-        // An untagged member is legal canonical JSON in a concretely-declared
-        // slot; the whole-instance pass then validates it AS `expected`.
-        let Some(tag) = obj.get("_type").and_then(Value::as_str) else {
-            return Ok(());
-        };
-        if openehr_rm::model::is_a(tag, expected) {
-            return Ok(());
-        }
-        Err(unproc(format!(
-            "{path}: expected {expected} (or a subtype), got _type {tag:?} — Folder \
-             structures do not contain Compositions by value, only references to \
-             them (RM ehr master04 §Folders)"
-        )))
-    }
-
-    fn walk(node: &Value, path: &str) -> Result<(), ServiceError> {
-        conforms(node, "FOLDER", if path.is_empty() { "/" } else { path })?;
-        let Some(obj) = node.as_object() else {
-            return Ok(());
-        };
-        if let Some((items, ty)) = obj
-            .get("items")
-            .and_then(Value::as_array)
-            .zip(declared("FOLDER", "items"))
-        {
-            for (i, item) in items.iter().enumerate() {
-                conforms(item, ty, &format!("{path}/items[{i}]"))?;
-            }
-        }
-        if let Some(folders) = obj.get("folders").and_then(Value::as_array) {
-            for (i, sub) in folders.iter().enumerate() {
-                walk(sub, &format!("{path}/folders[{i}]"))?;
-            }
-        }
-        Ok(())
-    }
-    walk(folder, "")?;
     validate_rm_invariants_for_commit(folder, "FOLDER", incomplete)
 }
 

--- a/app/ferroehr/tests/it/persistence.rs
+++ b/app/ferroehr/tests/it/persistence.rs
@@ -82,6 +82,7 @@ async fn migrations_apply_cleanly_and_idempotently() {
             "sp_subject",
             "sp_variable",
             "stored_query",
+            "template_ref",
             "template_store",
             "tenant",
             "vo_archive",

--- a/crates/openehr-its/src/rm_instance/mod.rs
+++ b/crates/openehr-its/src/rm_instance/mod.rs
@@ -233,6 +233,26 @@ pub(crate) enum LowerBounds {
 /// The shared body of the two public entry points.
 fn validate_with(root: &Value, declared: &str, bounds: LowerBounds) -> Vec<ValidationMessage> {
     let mut out = Vec::new();
+    // The ROOT arm of the declared-type conformance rule: the commit kind
+    // declares the root's RM type, and a wire `_type` claiming anything else
+    // is the same positive contradiction the per-slot rule refuses (a
+    // COMPOSITION committed to the directory resource is not a FOLDER,
+    // whatever it validates as). Never relaxed — RM common master06
+    // §Incomplete Content: "data may be missing, but it may not be wrong".
+    if let Some(wire) = root.get("_type").and_then(Value::as_str)
+        && openehr_rm::model::class(declared).is_some()
+        && !openehr_rm::model::is_a(wire, declared)
+    {
+        push(
+            &mut out,
+            "/".to_owned(),
+            format!(
+                "does not conform to RM type {declared}: the root claims `_type` \
+                 {wire}, which is not a {declared}"
+            ),
+            ValidationKind::Invariant,
+        );
+    }
     // One reusable path buffer across both passes (each leaves it empty).
     let mut path = String::new();
     rm_invariant_pass(&mut out, root, &mut path, Some(declared), bounds);
@@ -343,13 +363,38 @@ pub(crate) fn rm_invariant_pass(
             continue;
         }
         let child_declared = ty.and_then(|t| declared_concrete_type(t, k));
+        // The declared-slot-type conformance rule (the WRONGNESS half of slot
+        // typing, never relaxed — RM common master06 §Incomplete Content):
+        // a TAGGED child must claim the slot's declared type or a subtype.
+        // One model-driven rule for single slots and list members alike; the
+        // shallow-pruned typed dispatch cannot see it (each pruned member
+        // re-dispatches on its own `_type`), so the walk owns it.
+        let slot_check = |item: &Value, out: &mut Vec<ValidationMessage>, path: &str| {
+            if let (Some(parent), Some(wire)) = (ty, item.get("_type").and_then(Value::as_str))
+                && let Some(iv) = openehr_rm::validate::check_declared_slot_type(parent, k, wire)
+            {
+                push(out, norm_path(path), iv.message, ValidationKind::Invariant);
+            }
+        };
         match val {
             Value::Array(a) => {
                 for (i, item) in a.iter().enumerate() {
                     if item.is_object() {
                         let base = path.len();
                         let _ = write!(path, "/{k}[{i}]");
+                        slot_check(item, out, path);
                         rm_invariant_pass(out, item, path, child_declared, bounds);
+                        path.truncate(base);
+                    } else if let Some(iv) = ty.and_then(|parent| {
+                        openehr_rm::validate::check_slot_member_is_object(parent, k)
+                    }) {
+                        // A scalar member of a class-typed list slot is the
+                        // same positive contradiction a foreign `_type` is —
+                        // its declared type is an RM class, which no JSON
+                        // scalar can be.
+                        let base = path.len();
+                        let _ = write!(path, "/{k}[{i}]");
+                        push(out, norm_path(path), iv.message, ValidationKind::Invariant);
                         path.truncate(base);
                     }
                 }
@@ -357,6 +402,7 @@ pub(crate) fn rm_invariant_pass(
             Value::Object(_) => {
                 let base = path.len();
                 let _ = write!(path, "/{k}");
+                slot_check(val, out, path);
                 rm_invariant_pass(out, val, path, child_declared, bounds);
                 path.truncate(base);
             }
@@ -374,6 +420,87 @@ mod tests {
     use serde_json::{Value, json};
 
     use super::*;
+
+    // ── Declared-slot-type conformance (the WRONGNESS half of slot typing) ───
+
+    /// RM ehr `composition.adoc` §Attributes types `content`
+    /// `List<CONTENT_ITEM>`: a `DV_TEXT` member is a positive type
+    /// contradiction and is refused — the #1655 shape (the shallow-pruned
+    /// typed dispatch validated it as the DV_TEXT it claims to be).
+    #[test]
+    fn foreign_type_in_a_list_slot_rejected() {
+        let inst = json!({
+            "_type": "COMPOSITION",
+            "content": [{ "_type": "DV_TEXT", "value": "not a content item" }]
+        });
+        let out = rm_only(&inst);
+        assert!(
+            out.iter().any(|m| m.path == "/content[0]"
+                && m.message.contains("`content` is declared CONTENT_ITEM")),
+            "the foreign list member must be refused at its own path: {out:?}"
+        );
+    }
+
+    /// The same contradiction on a SINGLE-VALUED slot (the #1816 shape):
+    /// `COMPOSITION.context` is declared `EVENT_CONTEXT`; a tagged foreign
+    /// object there was previously validated as the type it claims to be.
+    #[test]
+    fn foreign_type_in_a_single_slot_rejected() {
+        let inst = json!({
+            "_type": "COMPOSITION",
+            "context": { "_type": "DV_TEXT", "value": "not a context" }
+        });
+        let out = rm_only(&inst);
+        assert!(
+            out.iter().any(|m| m.path == "/context"
+                && m.message.contains("`context` is declared EVENT_CONTEXT")),
+            "the foreign single member must be refused at its own path: {out:?}"
+        );
+    }
+
+    /// A legitimate subtype in an abstract-declared slot stays accepted —
+    /// strict means exact, in both directions (spec-adherence.md).
+    #[test]
+    fn subtype_in_an_abstract_slot_accepted() {
+        let inst = json!({
+            "_type": "COMPOSITION",
+            "content": [{
+                "_type": "OBSERVATION",
+                "name": { "_type": "DV_TEXT", "value": "o" },
+                "archetype_node_id": "at0001"
+            }]
+        });
+        let out = rm_only(&inst);
+        assert!(
+            !out.iter()
+                .any(|m| m.message.contains("is declared CONTENT_ITEM")),
+            "an OBSERVATION is a CONTENT_ITEM — no slot violation: {out:?}"
+        );
+    }
+
+    /// Type WRONGNESS never relaxes on a `553|incomplete|` commit — "data may
+    /// be missing, but it may not be wrong" (RM common master06 §Incomplete
+    /// Content).
+    #[test]
+    fn slot_type_conformance_survives_the_incomplete_relaxation() {
+        let inst = json!({
+            "_type": "COMPOSITION",
+            "content": [{ "_type": "DV_TEXT", "value": "still wrong" }]
+        });
+        let mut out = Vec::new();
+        rm_invariant_pass(
+            &mut out,
+            &inst,
+            &mut String::new(),
+            Some("COMPOSITION"),
+            LowerBounds::Relaxed,
+        );
+        assert!(
+            out.iter()
+                .any(|m| m.message.contains("`content` is declared CONTENT_ITEM")),
+            "the incomplete relaxation must not admit a wrong type: {out:?}"
+        );
+    }
 
     // ── LOCATABLE root identity + Links_valid (RM invariant pass) ─────────────
 

--- a/crates/openehr-its/tests/it/validation_rules.rs
+++ b/crates/openehr-its/tests/it/validation_rules.rs
@@ -703,9 +703,12 @@ fn dv_ordered_bad_normal_status_reported() {
 /// RM invariant, surfaced through the composition RM-invariant pass.
 #[test]
 fn dv_duration_fractional_non_seconds_rejected() {
+    // The `_as` entry with the instance's true declared type: the composition
+    // entry now (correctly) refuses a bare DV_DURATION root as
+    // not-a-COMPOSITION, which would shadow the no-Invariant assertion below.
     for bad in ["P1Y3M4DT2.5H", "PT2H14.5M"] {
         let inst = json!({"_type": "DV_DURATION", "value": bad});
-        let msgs = validate_rm_and_terminology(&inst);
+        let msgs = validate_rm_and_terminology_as(&inst, "DV_DURATION");
         assert!(
             msgs.iter()
                 .any(|m| m.kind == ValidationKind::Invariant && m.message.contains("Value_valid")),
@@ -715,7 +718,8 @@ fn dv_duration_fractional_non_seconds_rejected() {
     // A fraction on the seconds component is valid.
     let good = json!({"_type": "DV_DURATION", "value": "PT2H30M0.5S"});
     assert!(
-        !kinds(&validate_rm_and_terminology(&good)).contains(&ValidationKind::Invariant),
+        !kinds(&validate_rm_and_terminology_as(&good, "DV_DURATION"))
+            .contains(&ValidationKind::Invariant),
         "a fractional-seconds duration must be accepted"
     );
 }

--- a/crates/openehr-rm/src/validate.rs
+++ b/crates/openehr-rm/src/validate.rs
@@ -230,6 +230,67 @@ pub fn nonempty_list_violations(ty: &str, value: &Value, out: &mut Vec<Invariant
     }
 }
 
+/// The declared-slot-type conformance rule, over the BMM-generated attribute
+/// model: a child node's wire `_type` must name the RM type the parent
+/// attribute declares, or a subtype of it (`docs/specs/openehr/ITS-JSON`
+/// discipline: `_type` names the instance's RM class; the attribute's
+/// declared type comes from the RM UML/BMM — e.g. RM ehr
+/// `composition.adoc` §Attributes types `content` `List<CONTENT_ITEM>`, so a
+/// `DV_TEXT` member of `content` is a positive type contradiction). This is
+/// the WRONGNESS half of slot typing — it never relaxes ("data may be
+/// missing, but it may not be wrong", RM common
+/// `master06-change_control_package.adoc` §Incomplete Content); the
+/// presence/lower-bound half lives in [`check_mandatory_containers`] /
+/// [`nonempty_list_violations`].
+///
+/// Returns `None` (no judgement) when the slot is unknown to the model, the
+/// declared type is not a modelled class (a primitive such as `String`), or
+/// the attribute is a keyed map (`Hash` — its JSON object is a map, not an
+/// RM node). An untagged child is judged elsewhere (the effective-type rule,
+/// [`crate::model::declared_concrete_type`]).
+#[must_use]
+pub fn check_declared_slot_type(
+    parent_type: &str,
+    field: &str,
+    wire_type: &str,
+) -> Option<InvariantViolation> {
+    let attr = crate::model::attribute(parent_type, field)?;
+    if matches!(attr.container, crate::model::Container::Hash) {
+        return None;
+    }
+    crate::model::class(attr.declared_type)?;
+    if crate::model::is_a(wire_type, attr.declared_type) {
+        return None;
+    }
+    Some(InvariantViolation::here(format!(
+        "does not conform to RM type {parent_type}: `{field}` is declared \
+         {declared} and this member claims `_type` {wire_type}, which is not \
+         a {declared}",
+        declared = attr.declared_type,
+    )))
+}
+
+/// The scalar-member arm of the declared-slot-type rule: a NON-OBJECT member
+/// of a list slot whose declared element type is a modelled RM class is the
+/// same positive contradiction a foreign `_type` is — no JSON scalar can be
+/// an instance of an RM class (canonical JSON encodes every RM object as a
+/// JSON object; ITS-JSON). Same guards as [`check_declared_slot_type`]:
+/// `None` for unknown slots, primitive-typed slots (a `List<String>` member
+/// IS legitimately a scalar), and keyed maps. Never relaxed.
+#[must_use]
+pub fn check_slot_member_is_object(parent_type: &str, field: &str) -> Option<InvariantViolation> {
+    let attr = crate::model::attribute(parent_type, field)?;
+    if matches!(attr.container, crate::model::Container::Hash) {
+        return None;
+    }
+    crate::model::class(attr.declared_type)?;
+    Some(InvariantViolation::here(format!(
+        "does not conform to RM type {parent_type}: `{field}` is declared \
+         {declared} and this member is not a JSON object",
+        declared = attr.declared_type,
+    )))
+}
+
 /// `LOCATABLE.Archetyped_valid`: `is_archetype_root xor archetype_details =
 /// Void` (`docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.common.locatable.adoc`
 /// §Invariants). The enforceable arm on an instance is: a **non-root**


### PR DESCRIPTION
The general fix behind the FOLDER stopgap (#1754) and the shallow-container gap (#1651 analysis): the whole-instance validation pass dispatched every node on its own wire `_type`, so a tagged object occupying a slot declared as a different type was validated as whatever it claimed to be — a `DV_TEXT` inside `COMPOSITION.content` (declared `List<CONTENT_ITEM>`) validated cleanly as a DV_TEXT.

- **One model-driven rule, three arms**, all read from the generated BMM attribute model (no hand lists): every tagged node must `is_a` its slot's declared type (`check_declared_slot_type` — list members and single slots via the walker recursion), a scalar member of a class-typed list slot is refused (`check_slot_member_is_object` — the walker previously skipped non-objects silently), and the root must conform to the commit kind's declared type (the `validate_with` entry). Primitive-typed slots, keyed maps, and unknown slots are skipped by the same guards.
- **Never relaxed:** the rule enforces identically under the `553|incomplete|` lane — RM common master06 §Incomplete Content, "data may be missing, but it may not be wrong". Pinned by `slot_type_conformance_survives_the_incomplete_relaxation`.
- **Hand checks folded:** `validate_folder`'s `walk`/`conforms` recursion (the #1754 stopgap, TODO(#1816)) is deleted — the fn now delegates to the whole-instance pass; its 5 refusal tests pass unchanged against the general rule's messages. The `EHR_STATUS.other_details` typing claim in the docs is now actually true.
- Four unit tests pin the two refusal shapes, subtype acceptance in abstract slots, and the relaxation survival; one test harness that pushed bare data values through the composition entry retargeted to the honest `_as` entry; the full vendored corpus stays green under the rule (no false positives).
- The CNF invalid twin (DV_TEXT-in-content catalogue case) lands with #1727's catalogue re-attribution batch — the same case flips 422→400 under the recorded owner ruling, so pinning it twice would be churn (noted on #1655).
- Also: the persistence migrations pin gains `template_ref` (missed in #1826 — develop was red on that one test).

Gates: fmt, workspace clippy (all lanes), rustdoc, full workspace suite 3424/3424, catalogue validate 978/0. Conformance pipeline rerun deferred per owner directive 2026-08-03.

Closes #1816
Closes #1655