### PR TITLE
fix(cnf-runner): citation-resolving spec-ref gate, the contribution-audit knob, and catalogue hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,24 @@ workflow refuses a tag that has no matching section here.
   invariant are enforced exactly as before, so an `incomplete` commit carrying
   data that is WRONG rather than merely missing is still refused ("data may be
   missing, but it may not be wrong").
+- **The conformance catalogue can now state a CONTRIBUTION's commit audit.** A
+  case's `audit:` block states only its delta against the derived envelope
+  audit, and the reserved `absent` sentinel omits a member outright — the seam
+  the mandatory-member refusals need (RM common
+  `UML/classes/org.openehr.rm.common.audit_details.adoc` §Attributes makes
+  `change_type` and `committer` 1..1; the released OAS
+  `specifications/schemas/common/UpdateAudit.yaml` §required lists both on the
+  commit DTO). Three cases land on it: an omitted `change_type`, an
+  out-of-group `change_type` code, and the conformant twin that states both
+  members and proves the client-supplied `time_committed` is not the recorded
+  one. Cases that already authored an `audit:` block now actually put it on
+  the wire.
+- **A case pins which lineage head a default EHR-Extract exports.** With a
+  trunk head and a branch head both open in one container, RM ehr_extract
+  `master04-common_package.adoc` §Version Specification never says which is
+  the "latest available version". The choice — the trunk head — is now
+  adjudicated in the ambiguity register (AMB-206) and pinned by
+  `I_EHR_EXTRACT_SERVICE.export_ehr_extracts-latest_across_lineages`.
 
 ### Fixed
 
@@ -70,6 +88,29 @@ workflow refuses a tag that has no matching section here.
   may not be wrong"). The hand-written FOLDER member checks this replaces are
   removed; their refusals now come from the general rule.
 
+
+- **The conformance suite's spec-citation gate now resolves the cited document
+  and section.** It previously took only the second whitespace token of a
+  citation and asked whether ANY path under the component directory contained
+  it as a substring, so a citation naming a real component plus any common word
+  passed even when the document and §section did not exist. The gate now
+  resolves the whole path hint to a real vendored document (or chapter
+  directory) and verifies every `§section` names a real section of it —
+  following the `include::` directives that pull the UML class and interface
+  tables into a chapter, and reading the class tables' own labels, the
+  markdown chapters' titles, the AM validity-rule anchors and the OAS files'
+  keys. It also covers the citations of fixture-set rows and of the corpus
+  manifest, not just case cores. The 104 citations the strengthened gate found
+  unresolvable — phantom chapters, sections that never existed, class tables
+  cited under the wrong directory, and one citation of an internal proposal
+  instead of a released spec — were re-derived first-hand and corrected.
+- **A vendored corpus that had no vendor script has one.** The real-world
+  canonical-JSON corpus under `crates/openehr-its/tests/vendor/` was
+  hand-downloaded; it is now reproduced byte-identically from its pinned
+  upstream commit by `scripts/vendor-openehr-sdk-json.sh` (with `--check` to
+  report drift and write nothing). Its provenance record also named the wrong
+  upstream repository — a product-rename sweep had rewritten `ehrbase/` to
+  `ferroehr/` in the pin — which is corrected.
 - **`authz.abac.enabled = true` now actually enables ABAC.** The server
   binary built an RBAC-only authorization handle unconditionally — the ABAC
   policy engine and its attribute resolvers were never constructed on the

--- a/crates/openehr-its/tests/vendor/PROVENANCE.md
+++ b/crates/openehr-its/tests/vendor/PROVENANCE.md
@@ -11,16 +11,29 @@ re-vendor from upstream and update the pin below.
 
 | Item     | Value                                                                                               |
 |----------|-----------------------------------------------------------------------------------------------------|
-| Upstream | `ferroehr/openEHR_SDK`                                                                               |
+| Upstream | `ehrbase/openEHR_SDK`                                                                                |
 | Ref      | branch `develop`, commit `22b01e0c99b53669394e56da29c2410838b5cf7e`                                 |
 | Path     | `test-data/src/main/resources/{composition,contribution,ehr,folder,item_structure}/canonical_json/` |
 | License  | Apache-2.0 (see the upstream `LICENSE.md`)                                                          |
-| Fetched  | 2026-07-03                                                                                          |
+| Script   | `scripts/vendor-openehr-sdk-json.sh` (`--check` proves the committed tree is what the pin produces)  |
+| Fetched  | 2026-07-03; reproduced byte-identically from the pin 2026-08-03                                     |
 
-`ferroehr/openEHR_SDK` is the serialization library EHRbase itself uses, so its
+`ehrbase/openEHR_SDK` is the serialization library EHRbase itself uses, so its
 `canonical_json` corpus is the closest available match to our parity baseline
-(EHRbase v2.33.0). Files were downloaded verbatim from the pinned commit via
-the GitHub contents API (raw), preserving the upstream sub-directory layout.
+(EHRbase v2.33.0). The tree is vendored verbatim from the pinned commit by
+**`scripts/vendor-openehr-sdk-json.sh`**, preserving the upstream
+sub-directory layout; `scripts/vendor-openehr-sdk-json.sh --check` reports
+drift and writes nothing. Never hand-edit a vendored fixture and never
+hand-download into this tree — change the script, bump the pin, re-run it
+(`.claude/rules/vendored-corpora.md`).
+
+The script applies exactly ONE adjudicated exclusion, so that its output IS
+the committed tree: upstream carries an editor backup file,
+`composition/canonical_json/compo_feeder_audit_details.json.bak`, beside its
+fixtures. It is not a corpus document — the corpus is the `*.json` canonical
+instances the fidelity gates read — and vendoring it would place a file in
+the tree that no gate can classify. Nothing else upstream publishes under
+these five `canonical_json/` directories is dropped.
 
 ### Corpus composition (72 files)
 

--- a/scripts/vendor-openehr-sdk-json.sh
+++ b/scripts/vendor-openehr-sdk-json.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Vendor the real-world openEHR canonical-JSON corpus that grounds the
+# `openehr-its` fidelity gates (read -> re-serialize -> equality +
+# ITS-JSON schema validation).
+#
+# WHY THIS SOURCE: `ehrbase/openEHR_SDK` is the serialization library EHRbase
+# itself uses, so its `canonical_json` test data is real interoperability
+# ground truth rather than our own assumptions about the wire. It is prior
+# art, never an oracle: where a fixture and the vendored openEHR spec text
+# disagree, the spec text wins and the file is adjudicated in the ONE
+# exclusion registry (`crates/openehr-its/tests/it/common.rs::excluded`), with
+# a repo-authored valid twin under `crates/openehr-its/tests/fixtures/twins/`.
+#
+# The corpus is vendored VERBATIM and never hand-edited: to correct a fixture,
+# bump the pin and re-run this script (`.claude/rules/vendored-corpora.md`).
+#
+# Usage:
+#   scripts/vendor-openehr-sdk-json.sh            # vendor at the pin below
+#   SDK_PIN=<sha> scripts/vendor-openehr-sdk-json.sh
+#   scripts/vendor-openehr-sdk-json.sh --check    # report drift, write nothing
+set -Eeuo pipefail
+
+REPO="ehrbase/openEHR_SDK"
+# The pin. Bump deliberately (a bump is a corpus change: re-run the
+# openehr-its gates and update crates/openehr-its/tests/vendor/PROVENANCE.md
+# in the same commit).
+PIN="${SDK_PIN:-22b01e0c99b53669394e56da29c2410838b5cf7e}"
+
+# Upstream root of the corpus, and the packages taken from it. Each package
+# contributes exactly its `canonical_json/` directory.
+SRC_ROOT="test-data/src/main/resources"
+PACKAGES=(composition contribution ehr folder item_structure)
+DEST="crates/openehr-its/tests/vendor/openehr_sdk"
+
+CHECK=0
+[[ "${1:-}" == "--check" ]] && CHECK=1
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+echo "==> fetching $REPO @ ${PIN:0:12}"
+curl -fsSL "https://codeload.github.com/$REPO/tar.gz/$PIN" -o "$WORK/repo.tar.gz"
+mkdir -p "$WORK/src"
+tar -xzf "$WORK/repo.tar.gz" -C "$WORK/src" --strip-components=1
+
+drift=0
+for package in "${PACKAGES[@]}"; do
+  src="$WORK/src/$SRC_ROOT/$package/canonical_json"
+  [[ -d "$src" ]] || {
+    echo "::error::$SRC_ROOT/$package/canonical_json is absent at ${PIN:0:12} — the upstream layout moved" >&2
+    exit 1
+  }
+  # Stage the package with the one adjudicated exclusion applied, so `--check`
+  # and the write path judge the SAME tree. Upstream carries an editor backup
+  # (`composition/canonical_json/compo_feeder_audit_details.json.bak`) beside
+  # its fixtures; it is not a corpus document — the corpus is the `*.json`
+  # canonical instances the fidelity gates read — and vendoring it would put a
+  # file in the tree that no gate can classify.
+  stage="$WORK/stage/$package"
+  mkdir -p "$stage"
+  rsync -a --exclude='*.bak' "$src/" "$stage/"
+  dest="$DEST/$package/canonical_json"
+  if [[ $CHECK == 1 ]]; then
+    echo "==> check $dest"
+    diff -rq "$stage" "$dest" || drift=1
+    continue
+  fi
+  echo "==> vendor $dest"
+  mkdir -p "$dest"
+  # --delete so a file upstream removed disappears here too; the tree is
+  # vendored verbatim and never hand-edited.
+  rsync -a --delete "$stage/" "$dest/"
+done
+
+if [[ $CHECK == 1 ]]; then
+  [[ $drift == 0 ]] && echo "==> no drift: the committed tree is what the pin produces"
+  exit $drift
+fi
+
+count=$(find "$DEST" -type f -name '*.json' | wc -l | tr -d ' ')
+echo "==> $count canonical-JSON fixtures → $DEST"
+echo "    provenance record: crates/openehr-its/tests/vendor/PROVENANCE.md"
+echo "    exclusion registry: crates/openehr-its/tests/it/common.rs::excluded"

--- a/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
+++ b/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
@@ -336,7 +336,7 @@ cnf.composition.minimal_event.unknown_key_root:
   validity:
     verdict: invalid
     defect: "the COMPOSITION root carries `not_an_rm_attribute`, a member the RM does not declare on COMPOSITION"
-    spec_ref: "ITS-REST overview Resources.md L75/L87 (the payload must validate against the ITS schemas; the ITS-XML schemas are wildcard-free); RM ehr (COMPOSITION attribute set, org.openehr.rm.composition.composition.adoc §Attributes)"
+    spec_ref: "ITS-REST overview Resources.md §XML Format / §JSON Format (the payload must validate against the published ITS schemas; the ITS-XML schemas are wildcard-free); RM ehr (COMPOSITION attribute set, org.openehr.rm.composition.composition.adoc §Attributes)"
   template_id: "minimal_evaluation.en.v1"
   provenance: "derived 2026-08-02 from cnf.composition.minimal_event.v1 by adding one undeclared member at the document ROOT — the strict-reader refusal class (#1695), isolated to the root position"
 cnf.composition.minimal_event.unknown_key_nested:
@@ -346,7 +346,7 @@ cnf.composition.minimal_event.unknown_key_nested:
   validity:
     verdict: invalid
     defect: "a nested ELEMENT carries `not_an_rm_attribute`, a member the RM does not declare on ELEMENT"
-    spec_ref: "ITS-REST overview Resources.md L75/L87 (the payload must validate against the ITS schemas; the ITS-XML schemas are wildcard-free); RM data_structures (ELEMENT attribute set, org.openehr.rm.data_structures.element.adoc §Attributes)"
+    spec_ref: "ITS-REST overview Resources.md §XML Format / §JSON Format (the payload must validate against the published ITS schemas; the ITS-XML schemas are wildcard-free); RM data_structures (ELEMENT attribute set, org.openehr.rm.data_structures.element.adoc §Attributes)"
   template_id: "minimal_evaluation.en.v1"
   provenance: "derived 2026-08-02 from cnf.composition.minimal_event.v1 by adding one undeclared member on a NESTED ELEMENT — the strict-reader refusal class (#1695), isolated to a deep position so the refusal must name the path, not only the key"
 cnf.composition.lab_result.cluster_no_items:
@@ -2058,7 +2058,7 @@ cnf.messaging.extract_spec.empty_manifest:
   validity:
     verdict: invalid
     defect: "manifest.entities present and empty — EXTRACT_MANIFEST.entities is 1..*"
-    spec_ref: "RM ehr_extract UML/classes/org.openehr.rm.ehr_extract.extract_manifest.adoc §Attributes (entities 1..1 List<EXTRACT_ENTITY_MANIFEST>) + RM 1.2.0/1.1.0/1.0.4 BMM EXTRACT_MANIFEST.entities cardinality {lower: 1, upper_unbounded}"
+    spec_ref: "RM ehr_extract UML/classes/org.openehr.rm.ehr_extract.extract_manifest.adoc §Attributes (entities 1..1 List<EXTRACT_ENTITY_MANIFEST>; the RM 1.2.0/1.1.0/1.0.4 BMM gives EXTRACT_MANIFEST.entities cardinality {lower: 1, upper_unbounded})"
   provenance: "authored 2026-07-29 (#659), replacing the documentary cnf.messaging.extract_spec.v1 whose single manifest entity named neither ehr_id nor subject_id (an entity the receiver cannot locate — RM ehr_extract extract_entity_manifest.adoc). RE-ADJUDICATED 2026-08-03 (phase-close triage): the 2026-07-29 claim that an empty entity list is 'the shape that makes an export fulfilled-with-no-content' read only the attribute prose and never the multiplicity — the BMM declares EXTRACT_MANIFEST.entities with item-cardinality lower bound 1 in every published generation, so this shape is an RM-invalid EXTRACT_SPEC and its case is the refusal twin (the -by_spec sibling, one entity, is the acceptance twin). The by-spec case builds its own populated spec inline, because a manifest entity must name the EHR the runner minted and a corpus entry carries no reference substitution"
 cnf.messaging.tdd.v1:
   source: fixtures/messaging/tdd.v1.xml
@@ -2732,7 +2732,7 @@ cnf.opt.invalid.undefined_constraint_code:
   validity:
     verdict: invalid
     defect: "the definition references constraint code ac0001 (CONSTRAINT_REF) and constraint_bindings binds it, but no constraint_definitions entry defines it, and the ontology omits the mandatory term_definitions"
-    spec_ref: "AM ADL1.4 master08-adl.adoc §Coded Term Validity (VATDF: all ac codes used in the definition must be defined in constraint_definitions; VACDF); master05-cadl.adoc §Placeholder Constraints; ITS-XML ALL/Archetype.xsd ARCHETYPE_ONTOLOGY (term_definitions mandatory)"
+    spec_ref: "AM ADL1.4 master08-adl.adoc §Coded Term Validity (VATDF: all ac codes used in the definition must be defined in constraint_definitions; VACDF); master05-cadl.adoc §Placeholder Constraints; ITS-XML components/AM/Release-1.4 §Archetype 1.4 (Archetype.xsd — ARCHETYPE_ONTOLOGY term_definitions mandatory)"
   template_id: "cnf.tpl.dv_coded_text_binding_undefined_ac"
   provenance: "the 2026-07-29 triage's adjudicated-invalid shape, preserved verbatim under its own id per the valid+invalid-twins rule (owner 2026-07-29): the pre-correction dt_coded_text_binding_sct.opt whose upload the SUT was spec-RIGHT to refuse (422 VTCBK). Its corrected valid twin is cnf.tpl.dv_coded_text_binding_sct; this row pins the refusal so a lenient server fails it"
 cnf.tpl.dv_coded_text_binding_sct:

--- a/tools/cnf-runner/artifacts/registers/ambiguities.yaml
+++ b/tools/cnf-runner/artifacts/registers/ambiguities.yaml
@@ -6752,12 +6752,28 @@ AMB-167:
     (1) DOCUMENTED — COMPOSITION reads/writes and the OPT example payload
     (`composition`); every VERSION sub-resource read of any container
     (`version`, whose ORIGINAL_VERSION.data is `xs:anyType`, so the payload
-    type is unconstrained); the VERSIONED_* container reads
-    (`versioned_object`); the ADL 1.4 OPT (`template`, type
+    type is unconstrained); the ADL 1.4 OPT (`template`, type
     OPERATIONAL_TEMPLATE) and the ADL 1.4/2 archetype (`archetype`);
     EHR_EXTRACT (`extract` / `extract_request`); any LOCATABLE served under
     the generic abstract root (`items`, type LOCATABLE).
-    (2) UNDEFINED, media type declared — EHR (Ehr.xsd complexType, NOT
+    (2) UNDEFINED, media type declared — the VERSIONED_* container reads
+    (RE-ADJUDICATED 2026-08-03, first-hand: this entry classified them
+    DOCUMENTED on the `versioned_object` element, contradicting its own
+    source paragraph. That element is typed `X_VERSIONED_OBJECT` — the
+    EXTRACT-package shape (`crates/openehr-its/schemas/xml/
+    its-xml-1.0.2-nsv1/ALL/Extract.xsd` line 8, and the nsv2 twin under every
+    `RM/*/documents/Extract.xsd`), whose sequence makes `total_version_count`
+    and `extract_version_count` MANDATORY and restricts `versions` to
+    `ORIGINAL_VERSION`. The RM `VERSIONED_OBJECT` / `VERSIONED_COMPOSITION` /
+    `VERSIONED_EHR_STATUS` / `VERSIONED_FOLDER` / `VERSIONED_PARTY`
+    complexTypes are declared in Common.xsd / Ehr.xsd / Demographic.xsd with
+    NO global element of their own, and a served VERSIONED_COMPOSITION —
+    which carries neither extract count — cannot conform under the
+    `versioned_object` element. So the release DECLARES the media type and
+    WITHHOLDS the document here exactly as it does for EHR and EHR_STATUS.
+    No case floor changes: `get_versioned_composition-xml` already asserts
+    only an XML-document entity and says why in its own header, which is the
+    class-(2) floor); EHR (Ehr.xsd complexType, NOT
     LOCATABLE-derived, so not even the generic `items` root is available;
     absent entirely from the 1.0.2-nsv1 bundle); EHR_STATUS (LOCATABLE
     subtype, no element; absent from nsv1); FOLDER (LOCATABLE subtype, no
@@ -8866,3 +8882,53 @@ AMB-205:
     request-schema violation on the tag PUTs.
   disposition: fixed_handling
   upstream_issue: 1800
+
+AMB-206:
+  upstream_issue: 1834
+  ambiguity: >-
+    'Latest available version' is undefined when a container carries TWO open
+    lineage heads. The default Extract request has no version specification,
+    "corresponding to the assumption of 'latest available version' for each
+    matched item" (RM ehr_extract master04-common_package.adoc §Version
+    Specification), and the only switch the spec offers beside it is
+    `include_all_versions`, which returns "the whole version stack". Neither
+    sentence says WHICH head is latest when a trunk head (`::2`) and a branch
+    head (`::1.1.1`) are both current — and RM common master06 §Semantics in
+    Distributed Systems makes coexisting lineages a normal state, not an
+    error. The RM itself names the two readings without choosing between them
+    for an Extract: VERSIONED_OBJECT declares BOTH `latest_version()` and
+    `latest_trunk_version()` as distinct functions (RM common
+    UML/classes/org.openehr.rm.common.versioned_object.adoc §Functions), so a
+    conformant implementation could defensibly export either head, or both.
+  source: >-
+    RM ehr_extract master04-common_package.adoc §Version Specification (read
+    first-hand): "An Extract request in its simplest form has no version
+    specification, corresponding to the assumption of 'latest available
+    version' for each matched item", and the two enumerated possibilities
+    (`include_all_versions`, `include_revision_history`) — no third setting
+    and no lineage rule. RM ehr_extract
+    UML/classes/org.openehr.rm.ehr_extract.extract_version_spec.adoc
+    §Attributes: `include_all_versions` "forces all versions to be included",
+    so its FALSE branch is exactly the undefined one. RM common
+    UML/classes/org.openehr.rm.common.versioned_object.adoc §Functions:
+    `latest_version()` and `latest_trunk_version()` are separate functions
+    over the same container. No released sentence in either component picks
+    one for the Extract, and the ITS-REST release publishes no MESSAGE API at
+    all (register AMB-34), so no wire source narrows it either.
+  handling: >-
+    Fixed handling: the default (non-`include_all_versions`) Extract includes
+    the TRUNK head of each matched container and no branch head. The reason is
+    the RM's own trunk-first reading of "latest": master06 §The 'Virtual
+    Version Tree' makes the trunk the lineage every branch descends from,
+    `VERSIONED_OBJECT.latest_trunk_version()` names it without qualification,
+    and a branch is by construction a local divergence that may never have
+    been propagated — the same asymmetry master04 already relies on when it
+    warns that an Extract returns "all available versions from the repository
+    in question", not all that exist. Exporting a branch head under a request
+    that asked for the latest version would hand the receiver a version whose
+    trunk successor it never sees, so the fixed choice is the conservative
+    one; a caller that wants the branch asks for the whole stack with
+    `include_all_versions`, which the same section defines. Pinned by
+    `I_EHR_EXTRACT_SERVICE.export_ehr_extracts-latest_across_lineages`, whose
+    container holds trunk `::2` and branch `::1.1.1` at once.
+  disposition: fixed_handling

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_DUMP_LOAD.export_ehrs-compression_7z.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_DUMP_LOAD.export_ehrs-compression_7z.yaml
@@ -18,7 +18,7 @@ test_purpose: >-
 description: "Export with COMPRESSION_FORMAT 7z"
 spec_refs:
   - "SM openehr_platform §I_ADMIN_DUMP_LOAD.export_ehrs"
-  - "SM openehr_platform UML compression_format.adoc (the 7z member)"
+  - "SM UML/classes/compression_format.adoc (the 7z member)"
 applies: { rm: ">=1.0.2" }
 requires: { ehr: { commits: any } }
 flow:

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_DUMP_LOAD.export_ehrs-export_formats.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_DUMP_LOAD.export_ehrs-export_formats.yaml
@@ -19,7 +19,7 @@ description: "Export all EHRs with explicit logical + compression formats"
 spec_refs:
   - "SM openehr_platform §I_ADMIN_DUMP_LOAD.export_ehrs"
   - "SM openehr_platform §EXPORT_SPEC"
-  - "SM openehr_platform §EXPORT_FORMAT"
+  - "SM UML/classes/export_format.adoc §EXPORT_FORMAT"
   - "SM openehr_platform §COMPRESSION_FORMAT"
   - "CNF platform_test_schedule master12 §export_ehrs"
 applies: { rm: ">=1.0.2" }

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_DUMP_LOAD.export_ehrs-format_not_a_member.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_DUMP_LOAD.export_ehrs-format_not_a_member.yaml
@@ -29,7 +29,7 @@ test_purpose: >-
 description: "Export with a logical format outside the EXPORT_FORMAT enumeration"
 spec_refs:
   - "SM openehr_platform §I_ADMIN_DUMP_LOAD.export_ehrs"
-  - "SM openehr_platform UML export_format.adoc (the closed member set)"
+  - "SM UML/classes/export_format.adoc (the closed member set)"
 applies: { rm: ">=1.0.2" }
 guards:
   - "EXTENSION ROUTE — no openEHR spec governs /admin/dump or /admin/load; our own design/extension, declared in vocab/wire_surface.yaml served_extensions and adjudicated by register AMB-33. The row gates the EhrDumpLoad CAPABILITY verdict only, never ITS-REST wire conformance"

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_DUMP_LOAD.export_ehrs-logical_format_xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_DUMP_LOAD.export_ehrs-logical_format_xml.yaml
@@ -32,8 +32,8 @@ description: "Export with EXPORT_FORMAT openehr_canonical_xml"
 spec_refs:
   - "SM openehr_platform §I_ADMIN_DUMP_LOAD.export_ehrs"
   - "SM openehr_platform §EXPORT_SPEC (logical_format: flavour of XML, JSON etc.)"
-  - "SM openehr_platform UML export_format.adoc (the openehr_canonical_xml member)"
-  - "ITS-XML components §RM documents/Version.xsd (the globally declared `version` element over an ABSTRACT VERSION type)"
+  - "SM UML/classes/export_format.adoc (the openehr_canonical_xml member)"
+  - "ITS-XML components/RM/Release-1.0.2/documents §Validating documents (Version.xsd — the globally declared `version` element over an ABSTRACT VERSION type)"
 applies: { rm: ">=1.0.2" }
 guards:
   - "EXTENSION ROUTE — no openEHR spec governs /admin/dump or /admin/load; our own design/extension, declared in vocab/wire_surface.yaml served_extensions and adjudicated by register AMB-33. The row gates the EhrDumpLoad CAPABILITY verdict only, never ITS-REST wire conformance"

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_DUMP_LOAD.export_ehrs-segment_split_size_non_positive.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_DUMP_LOAD.export_ehrs-segment_split_size_non_positive.yaml
@@ -24,7 +24,7 @@ test_purpose: >-
 description: "Export with a non-positive segment split size"
 spec_refs:
   - "SM openehr_platform §I_ADMIN_DUMP_LOAD.export_ehrs"
-  - "SM openehr_platform UML export_spec.adoc (segment_split_size, kb)"
+  - "SM UML/classes/export_spec.adoc (segment_split_size, kb)"
 applies: { rm: ">=1.0.2" }
 guards:
   - "EXTENSION ROUTE — no openEHR spec governs /admin/dump or /admin/load; our own design/extension, declared in vocab/wire_surface.yaml served_extensions and adjudicated by register AMB-33. The row gates the EhrDumpLoad CAPABILITY verdict only, never ITS-REST wire conformance"

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_DUMP_LOAD.load_ehrs-container_7z.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_DUMP_LOAD.load_ehrs-container_7z.yaml
@@ -19,7 +19,7 @@ test_purpose: >-
 description: "Load a 7z-compressed export archive"
 spec_refs:
   - "SM openehr_platform §I_ADMIN_DUMP_LOAD.load_ehrs"
-  - "SM openehr_platform UML compression_format.adoc (the 7z member)"
+  - "SM UML/classes/compression_format.adoc (the 7z member)"
 applies: { rm: ">=1.0.2" }
 guards:
   - "EXTENSION ROUTE — no openEHR spec governs /admin/dump or /admin/load; our own design/extension, declared in vocab/wire_surface.yaml served_extensions and adjudicated by register AMB-33. The row gates the EhrDumpLoad CAPABILITY verdict only, never ITS-REST wire conformance"

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_DUMP_LOAD.load_ehrs-container_zip.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_DUMP_LOAD.load_ehrs-container_zip.yaml
@@ -23,7 +23,7 @@ test_purpose: >-
 description: "Load a zip-compressed export archive"
 spec_refs:
   - "SM openehr_platform §I_ADMIN_DUMP_LOAD.load_ehrs"
-  - "SM openehr_platform UML compression_format.adoc (the zip member)"
+  - "SM UML/classes/compression_format.adoc (the zip member)"
 applies: { rm: ">=1.0.2" }
 guards:
   - "EXTENSION ROUTE — no openEHR spec governs /admin/dump or /admin/load; our own design/extension, declared in vocab/wire_surface.yaml served_extensions and adjudicated by register AMB-33. The row gates the EhrDumpLoad CAPABILITY verdict only, never ITS-REST wire conformance"

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_DUMP_LOAD.load_ehrs-logical_format_xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_DUMP_LOAD.load_ehrs-logical_format_xml.yaml
@@ -27,7 +27,7 @@ test_purpose: >-
 description: "Load a canonical-XML export archive"
 spec_refs:
   - "SM openehr_platform §I_ADMIN_DUMP_LOAD.load_ehrs"
-  - "SM openehr_platform UML export_format.adoc (the openehr_canonical_xml member)"
+  - "SM UML/classes/export_format.adoc (the openehr_canonical_xml member)"
   - "SM openehr_platform §DUMP_LOAD_FAIL_REPORT"
 applies: { rm: ">=1.0.2" }
 guards:

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.list_contributions-non_content_service.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.list_contributions-non_content_service.yaml
@@ -21,7 +21,7 @@ test_purpose: >-
 description: "Report for a declared service that holds no versioned content"
 spec_refs:
   - "SM openehr_platform §I_ADMIN_SERVICE.list_contributions"
-  - "SM openehr_platform UML platform_service.adoc (the closed member set)"
+  - "SM UML/classes/platform_service.adoc (the closed member set)"
 applies: { rm: ">=1.0.2" }
 guards:
   - "EXTENSION ROUTE — no openEHR spec governs the /admin/report/* routes; our own design/extension, declared in vocab/wire_surface.yaml served_extensions and adjudicated by register AMB-33. The row gates the ActivityReport CAPABILITY verdict only, never ITS-REST wire conformance"

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.list_contributions-service_not_a_member.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_SERVICE.list_contributions-service_not_a_member.yaml
@@ -20,7 +20,7 @@ test_purpose: >-
 description: "Report for a service outside the PLATFORM_SERVICE enumeration"
 spec_refs:
   - "SM openehr_platform §I_ADMIN_SERVICE.list_contributions"
-  - "SM openehr_platform UML platform_service.adoc (the closed member set)"
+  - "SM UML/classes/platform_service.adoc (the closed member set)"
 applies: { rm: ">=1.0.2" }
 guards:
   - "EXTENSION ROUTE — no openEHR spec governs the /admin/report/* routes; our own design/extension, declared in vocab/wire_surface.yaml served_extensions and adjudicated by register AMB-33. The row gates the ActivityReport CAPABILITY verdict only, never ITS-REST wire conformance"

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-unknown_key_nested.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-unknown_key_nested.yaml
@@ -28,7 +28,7 @@ test_purpose: >-
   rejected, and nothing is committed.
 description: "Reject an undeclared member on a nested ELEMENT"
 spec_refs:
-  - "ITS-REST overview Resources.md §Payload (L75 XML / L87 JSON — the payload must validate against the ITS schemas)"
+  - "ITS-REST overview Resources.md §XML Format / §JSON Format (the payload must validate against the published ITS schemas)"
   - "RM data_structures §ELEMENT (org.openehr.rm.data_structures.element.adoc §Attributes)"
   - "SM openehr_platform §I_EHR_COMPOSITION.create_composition"
 applies: { rm: ">=1.0.2" }

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-unknown_key_root.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-unknown_key_root.yaml
@@ -28,7 +28,7 @@ test_purpose: >-
   rejected, and nothing is committed.
 description: "Reject an undeclared member on the COMPOSITION root"
 spec_refs:
-  - "ITS-REST overview Resources.md §Payload (L75 XML / L87 JSON — the payload must validate against the ITS schemas)"
+  - "ITS-REST overview Resources.md §XML Format / §JSON Format (the payload must validate against the published ITS schemas)"
   - "RM ehr §COMPOSITION (org.openehr.rm.composition.composition.adoc §Attributes)"
   - "SM openehr_platform §I_EHR_COMPOSITION.create_composition"
 applies: { rm: ">=1.0.2" }

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-xml.yaml
@@ -35,7 +35,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_COMPOSITION.create_composition"
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §Data representation"
-  - "ITS-XML components §RM documents/Composition.xsd (the globally declared `composition` element)"
+  - "ITS-XML components/RM/Release-1.0.2/documents §Validating documents (Composition.xsd — the globally declared `composition` element)"
 applies: { rm: ">=1.0.2" }
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_at_time-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_at_time-xml.yaml
@@ -35,7 +35,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_COMPOSITION.get_composition_at_time"
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §Data representation"
-  - "ITS-XML components §RM documents/Composition.xsd (the globally declared `composition` element)"
+  - "ITS-XML components/RM/Release-1.0.2/documents §Validating documents (Composition.xsd — the globally declared `composition` element)"
 applies: { rm: ">=1.0.2" }
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_at_version-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_at_version-xml.yaml
@@ -34,7 +34,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_COMPOSITION.get_composition_at_version"
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §Data representation"
-  - "ITS-XML components §RM documents/Composition.xsd (the globally declared `composition` element)"
+  - "ITS-XML components/RM/Release-1.0.2/documents §Validating documents (Composition.xsd — the globally declared `composition` element)"
 applies: { rm: ">=1.0.2" }
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_latest-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_latest-xml.yaml
@@ -40,7 +40,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_COMPOSITION.get_composition_latest"
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §Data representation"
-  - "ITS-XML components §RM documents/Composition.xsd (the globally declared `composition` element)"
+  - "ITS-XML components/RM/Release-1.0.2/documents §Validating documents (Composition.xsd — the globally declared `composition` element)"
 applies: { rm: ">=1.0.2" }
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_latest-xml_root_namespace.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_latest-xml_root_namespace.yaml
@@ -56,7 +56,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_COMPOSITION.get_composition_latest"
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §Data representation"
-  - "ITS-XML components §RM documents/Composition.xsd (targetNamespace + the globally declared `composition` element)"
+  - "ITS-XML components/RM/Release-1.0.2/documents §Validating documents (Composition.xsd — targetNamespace + the globally declared `composition` element)"
   - "ITS-XML README.adoc §Releases and IM Versions (the v1/v2 lineages)"
 applies: { rm: ">=1.0.2" }
 ambiguities: [AMB-169]                 # which of the two published lineages is served is implementation-defined, so the row asserts neither

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_versioned_composition-imported_version_xml_root.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_versioned_composition-imported_version_xml_root.yaml
@@ -61,7 +61,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_COMPOSITION.get_versioned_composition"
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §Data representation"
-  - "ITS-XML components §RM documents/Version.xsd (the globally declared `version` element over the abstract VERSION type; IMPORTED_VERSION extends it with `item`)"
+  - "ITS-XML components/RM/Release-1.0.2/documents §Validating documents (Version.xsd — the globally declared `version` element over the abstract VERSION type; IMPORTED_VERSION extends it with `item`)"
   - "ITS-XML README.adoc §Releases and IM Versions (the v1/v2 lineages)"
   - "RM common §change_control (master06 §Copying — the IMPORTED_VERSION wrapper the receiver commits)"
 applies: { rm: ">=1.0.2" }

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_versioned_composition-version_xml_root.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_versioned_composition-version_xml_root.yaml
@@ -67,7 +67,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_COMPOSITION.get_versioned_composition"
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §Data representation"
-  - "ITS-XML components §RM documents/Version.xsd (the globally declared `version` element over the abstract VERSION type)"
+  - "ITS-XML components/RM/Release-1.0.2/documents §Validating documents (Version.xsd — the globally declared `version` element over the abstract VERSION type)"
   - "ITS-XML README.adoc §Releases and IM Versions (the v1/v2 lineages)"
   - "RM common §change_control (master06 §Version and its Subtypes — ORIGINAL_VERSION and IMPORTED_VERSION are the concrete VERSION classes)"
 applies: { rm: ">=1.0.2" }

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.has_composition-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.has_composition-xml.yaml
@@ -36,7 +36,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_COMPOSITION.has_composition"
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §Data representation"
-  - "ITS-XML components §RM documents/Composition.xsd (the globally declared `composition` element)"
+  - "ITS-XML components/RM/Release-1.0.2/documents §Validating documents (Composition.xsd — the globally declared `composition` element)"
 applies: { rm: ">=1.0.2" }
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/content/CONT-DV_INTERVAL_DV_QUANTITY-validate_upper_lower.yaml
+++ b/tools/cnf-runner/artifacts/schedule/content/CONT-DV_INTERVAL_DV_QUANTITY-validate_upper_lower.yaml
@@ -12,7 +12,7 @@ test_purpose: >-
 description: "DV_INTERVAL<DV_QUANTITY>: C_DV_QUANTITY.list = [Cel 0..100] on lower and upper (temperature)"
 spec_refs:
   - "CNF platform_test_schedule master17.3 §CONT-DV_INTERVAL_DV_QUANTITY-validate_upper_lower"
-  - "AM AOM1.4 §C_DV_QUANTITY"
+  - "AM ADL2 master04.4-cadl_second_order §Tuple Constraints (the ADL 1.4 Archetype Profile C_DV_QUANTITY the tuple constraint replaced; the oAP itself is not part of the released AM)"
   - "RM data_types §DV_INTERVAL"
 applies: { rm: ">=1.0.2" }
 constraint_context:

--- a/tools/cnf-runner/artifacts/schedule/content/CONT-DV_INTERVAL_DV_SCALE-validate_constraint.yaml
+++ b/tools/cnf-runner/artifacts/schedule/content/CONT-DV_INTERVAL_DV_SCALE-validate_constraint.yaml
@@ -12,7 +12,7 @@ test_purpose: >-
 description: "DV_INTERVAL<DV_SCALE> with per-limit C_DV_ORDINAL.list constraints (real values)"
 spec_refs:
   - "CNF platform_test_schedule master17.3 §CONT-DV_INTERVAL_DV_SCALE-validate_constraint"
-  - "AM AOM1.4 §C_DV_SCALE"
+  - "AM ADL2 master04.4-cadl_second_order §Tuple Constraints (no released AM generation defines C_DV_SCALE; the C_DV_ORDINAL-analogous reading is the schedule's own NOTE)"
   - "RM data_types §DV_INTERVAL"
 applies: { rm: ">=1.1.0" }
 guards:

--- a/tools/cnf-runner/artifacts/schedule/content/CONT-DV_INTERVAL_DV_SCALE-validate_open.yaml
+++ b/tools/cnf-runner/artifacts/schedule/content/CONT-DV_INTERVAL_DV_SCALE-validate_open.yaml
@@ -19,7 +19,7 @@ test_purpose: >-
 description: "DV_INTERVAL<DV_SCALE> open ({*}): symbol/value mandatory, comparable limits"
 spec_refs:
   - "CNF platform_test_schedule master17.3 §CONT-DV_INTERVAL_DV_SCALE-validate_open"
-  - "AM AOM1.4 §C_DV_SCALE"
+  - "AM ADL2 master04.4-cadl_second_order §Tuple Constraints (no released AM generation defines C_DV_SCALE; the C_DV_ORDINAL-analogous reading is the schedule's own NOTE)"
   - "RM data_types §DV_INTERVAL"
 applies: { rm: ">=1.1.0" }
 guards:

--- a/tools/cnf-runner/artifacts/schedule/content/CONT-DV_QUANTITY-validate_open.yaml
+++ b/tools/cnf-runner/artifacts/schedule/content/CONT-DV_QUANTITY-validate_open.yaml
@@ -11,7 +11,7 @@ test_purpose: >-
 description: "DV_QUANTITY against an open constraint ({*}): magnitude/units mandatory"
 spec_refs:
   - "CNF platform_test_schedule master17.3 §CONT-DV_QUANTITY-validate_open"
-  - "AM AOM1.4 §C_DV_QUANTITY"
+  - "AM ADL2 master04.4-cadl_second_order §Tuple Constraints (the ADL 1.4 Archetype Profile C_DV_QUANTITY the tuple constraint replaced; the oAP itself is not part of the released AM)"
   - "RM data_types §DV_QUANTITY"
 applies: { rm: ">=1.0.2" }
 constraint_context:

--- a/tools/cnf-runner/artifacts/schedule/content/CONT-DV_QUANTITY-validate_property.yaml
+++ b/tools/cnf-runner/artifacts/schedule/content/CONT-DV_QUANTITY-validate_property.yaml
@@ -11,7 +11,7 @@ test_purpose: >-
 description: "DV_QUANTITY against C_DV_QUANTITY property=openehr::122 (length), no units list"
 spec_refs:
   - "CNF platform_test_schedule master17.3 §CONT-DV_QUANTITY-validate_property"
-  - "AM AOM1.4 §C_DV_QUANTITY"
+  - "AM ADL2 master04.4-cadl_second_order §Tuple Constraints (the ADL 1.4 Archetype Profile C_DV_QUANTITY the tuple constraint replaced; the oAP itself is not part of the released AM)"
   - "RM data_types §DV_QUANTITY"
 applies: { rm: ">=1.0.2" }
 constraint_context:

--- a/tools/cnf-runner/artifacts/schedule/content/CONT-DV_QUANTITY-validate_property_units.yaml
+++ b/tools/cnf-runner/artifacts/schedule/content/CONT-DV_QUANTITY-validate_property_units.yaml
@@ -11,7 +11,7 @@ test_purpose: >-
 description: "DV_QUANTITY against C_DV_QUANTITY property=openehr::122 (length), list=[cm, m]"
 spec_refs:
   - "CNF platform_test_schedule master17.3 §CONT-DV_QUANTITY-validate_property_units"
-  - "AM AOM1.4 §C_DV_QUANTITY"
+  - "AM ADL2 master04.4-cadl_second_order §Tuple Constraints (the ADL 1.4 Archetype Profile C_DV_QUANTITY the tuple constraint replaced; the oAP itself is not part of the released AM)"
   - "RM data_types §DV_QUANTITY"
 applies: { rm: ">=1.0.2" }
 constraint_context:

--- a/tools/cnf-runner/artifacts/schedule/content/CONT-DV_QUANTITY-validate_property_units_mag.yaml
+++ b/tools/cnf-runner/artifacts/schedule/content/CONT-DV_QUANTITY-validate_property_units_mag.yaml
@@ -13,7 +13,7 @@ test_purpose: >-
 description: "DV_QUANTITY against C_DV_QUANTITY with property, units and magnitude range"
 spec_refs:
   - "CNF platform_test_schedule master17.3 §CONT-DV_QUANTITY-validate_property_units_mag"
-  - "AM AOM1.4 §C_DV_QUANTITY"
+  - "AM ADL2 master04.4-cadl_second_order §Tuple Constraints (the ADL 1.4 Archetype Profile C_DV_QUANTITY the tuple constraint replaced; the oAP itself is not part of the released AM)"
   - "RM data_types §DV_QUANTITY"
 applies: { rm: ">=1.0.2" }
 constraint_context:

--- a/tools/cnf-runner/artifacts/schedule/content/CONT-DV_SCALE-validate_constraint.yaml
+++ b/tools/cnf-runner/artifacts/schedule/content/CONT-DV_SCALE-validate_constraint.yaml
@@ -11,7 +11,7 @@ test_purpose: >-
 description: "DV_SCALE against C_DV_SCALE.list = 1.5|[local::at0005], 2.0|[local::at0006]"
 spec_refs:
   - "CNF platform_test_schedule master17.3 §CONT-DV_SCALE-validate_constraint"
-  - "AM AOM1.4 §C_DV_SCALE"
+  - "AM ADL2 master04.4-cadl_second_order §Tuple Constraints (no released AM generation defines C_DV_SCALE; the C_DV_ORDINAL-analogous reading is the schedule's own NOTE)"
   - "RM data_types §DV_SCALE"
 applies: { rm: ">=1.1.0" }
 guards:

--- a/tools/cnf-runner/artifacts/schedule/content/CONT-DV_SCALE-validate_open.yaml
+++ b/tools/cnf-runner/artifacts/schedule/content/CONT-DV_SCALE-validate_open.yaml
@@ -11,7 +11,7 @@ test_purpose: >-
 description: "DV_SCALE against an open C_DV_SCALE ({*}): symbol/value mandatory"
 spec_refs:
   - "CNF platform_test_schedule master17.3 §CONT-DV_SCALE-validate_open"
-  - "AM AOM1.4 §C_DV_SCALE"
+  - "AM ADL2 master04.4-cadl_second_order §Tuple Constraints (no released AM generation defines C_DV_SCALE; the C_DV_ORDINAL-analogous reading is the schedule's own NOTE)"
   - "RM data_types §DV_SCALE"
 applies: { rm: ">=1.1.0" }
 constraint_context:

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-audit_change_type_omitted.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-audit_change_type_omitted.yaml
@@ -1,0 +1,68 @@
+# The COMMIT AUDIT's own change_type is MANDATORY — the envelope-level twin of
+# the member-level audit cases in this directory.
+#
+# THE RULE, verbatim (RM common
+# UML/classes/org.openehr.rm.common.audit_details.adoc §Attributes): the
+# `1..1` row reads "*change_type*: DV_CODED_TEXT — Type of change. Coded using
+# the openEHR Terminology  audit change type  group." A CONTRIBUTION's own
+# `audit` is an AUDIT_DETAILS (RM common
+# UML/classes/org.openehr.rm.common.contribution.adoc §Attributes: "audit:
+# AUDIT_DETAILS, 1..1"), so an envelope that omits `change_type` is an audit
+# the RM cannot represent.
+#
+# THE COMMIT DTO SAYS THE SAME, and the ITS-REST DOCS TEXT IS SILENT on the
+# contribution request body, so the released OAS grounds the wire statement
+# (cited AS the OAS — owner ruling 2026-07-28): ITS-REST OAS
+# specifications/schemas/common/UpdateAudit.yaml §required lists exactly
+# `change_type` and `committer`, and specifications/schemas/ehr/
+# NewContribution.yaml §required lists `versions` and `audit`, so the audit
+# object reaches the server with both members or not at all.
+#
+# THE ACCEPTING TWIN is `-audit_conformant`, which sends the SAME envelope with
+# the change_type present.
+#
+# THE STATUS is the docs text's 422 row (ITS-REST overview
+# Requests_and_responses.md §HTTP status codes, verbatim: "The request was
+# well-formed but was unable to be followed due to semantic errors"); the
+# binding's `validation_failed` also admits the 400 the same table gives a
+# request whose content is structurally invalid, because a missing required
+# member can be read either way and no released sentence separates them.
+id: I_EHR_CONTRIBUTION.commit_contribution-audit_change_type_omitted
+kind: functional
+component: EHR_CONTRIBUTION
+sm_operation: I_EHR_CONTRIBUTION.commit_contribution
+capabilities: [ChangeSets]
+exercises: [Versioning]
+profiles: [CORE]
+test_purpose: >-
+  A CONTRIBUTION whose envelope audit omits change_type is rejected, and
+  nothing is committed.
+description: "Commit CONTRIBUTION whose commit audit has no change_type"
+spec_refs:
+  - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
+  - "RM common §AUDIT_DETAILS (change_type: DV_CODED_TEXT, 1..1)"
+  - "RM common §CONTRIBUTION (audit: AUDIT_DETAILS, 1..1)"
+  - "ITS-REST OAS schemas/common/UpdateAudit.yaml §required (change_type)"
+  - "ITS-REST overview Requests_and_responses §HTTP status codes (422)"
+applies: { rm: ">=1.0.2" }
+formats: [canonical-json]
+requires:
+  server: any
+  templates: [cnf.opt.minimal_event]
+  ehr: { commits: none }                 # mints ${ehr_id}
+data_sets:
+  - cnf.composition.minimal_event.v1
+flow:
+  - step: 1
+    call: commit_contribution
+    with:
+      ehr_id: "${ehr_id}"
+      versions:
+        - data: "${ds:cnf.composition.minimal_event.v1}"
+          change_type: creation
+      audit:
+        change_type: absent              # the mandatory member, omitted
+    expect: validation_failed
+postconditions:
+  # The change set was refused whole: no version and no audit were written.
+  - { assert: version, count: 0 }

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-audit_change_type_out_of_group.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-audit_change_type_out_of_group.yaml
@@ -1,0 +1,71 @@
+# The COMMIT AUDIT's change_type must be a member of the openEHR
+# `audit change type` group — presence alone is not enough.
+#
+# THE INVARIANT, verbatim (RM common
+# UML/classes/org.openehr.rm.common.audit_details.adoc §Invariants):
+# "__Change_type_valid__: `terminology (Terminology_id_openehr).
+# has_code_for_group_id (Group_id_audit_change_type, change_type.defining_code)`"
+# — and the §Attributes row for `change_type` says the same in prose ("Coded
+# using the openEHR Terminology  audit change type  group"). Code `999` is in
+# no openEHR group: TERM SupportTerminology
+# codesets/openehr_terminology-vocabularies.adoc §Audit Change Type publishes
+# the group as the closed, all-active set 249 | 250 | 251 | 252 | 523 | 666 |
+# 816 | 817 | 253.
+#
+# This is the SIBLING of `-audit_change_type_omitted`: that case fails the
+# `1..1` presence rule, this one satisfies presence and fails the terminology
+# binding, so a server that only checks for the KEY passes one and fails the
+# other. The out-of-group code is authored verbatim because the runner's
+# change-type vocabulary is closed and cannot spell a non-member.
+#
+# THE ACCEPTING TWIN is `-audit_conformant`, which sends the SAME envelope with
+# `249|creation|`.
+#
+# THE STATUS is the docs text's 422 row (ITS-REST overview
+# Requests_and_responses.md §HTTP status codes, verbatim: "The request was
+# well-formed but was unable to be followed due to semantic errors") — the
+# request IS well-formed here, and only the terminology binding fails.
+id: I_EHR_CONTRIBUTION.commit_contribution-audit_change_type_out_of_group
+kind: functional
+component: EHR_CONTRIBUTION
+sm_operation: I_EHR_CONTRIBUTION.commit_contribution
+capabilities: [ChangeSets]
+exercises: [Versioning]
+profiles: [CORE]
+test_purpose: >-
+  A CONTRIBUTION whose envelope audit carries a change_type code outside the
+  openEHR audit change type group is rejected, and nothing is committed.
+description: "Commit CONTRIBUTION whose commit audit change_type code is 999"
+spec_refs:
+  - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
+  - "RM common §AUDIT_DETAILS (Change_type_valid: has_code_for_group_id (Group_id_audit_change_type, change_type.defining_code))"
+  - "TERM SupportTerminology §Vocabularies (audit change type)"
+  - "ITS-REST overview Requests_and_responses §HTTP status codes (422)"
+applies: { rm: ">=1.0.2" }
+formats: [canonical-json]
+requires:
+  server: any
+  templates: [cnf.opt.minimal_event]
+  ehr: { commits: none }                 # mints ${ehr_id}
+data_sets:
+  - cnf.composition.minimal_event.v1
+flow:
+  - step: 1
+    call: commit_contribution
+    with:
+      ehr_id: "${ehr_id}"
+      versions:
+        - data: "${ds:cnf.composition.minimal_event.v1}"
+          change_type: creation
+      audit:
+        change_type:                     # authored verbatim: no group member spells this
+          _type: DV_CODED_TEXT
+          value: "not a change type"
+          defining_code:
+            _type: CODE_PHRASE
+            terminology_id: { _type: TERMINOLOGY_ID, value: openehr }
+            code_string: "999"
+    expect: validation_failed
+postconditions:
+  # The change set was refused whole: no version and no audit were written.
+  - { assert: version, count: 0 }

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-audit_conformant.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-audit_conformant.yaml
@@ -1,0 +1,85 @@
+# THE ACCEPTING TWIN of the two envelope-audit refusals in this directory
+# (`-audit_change_type_omitted`, `-audit_change_type_out_of_group`): the SAME
+# commit, with a commit audit that states both mandatory members correctly, is
+# accepted and readable back.
+#
+# WHAT THE ENVELOPE CARRIES, and why: RM common
+# UML/classes/org.openehr.rm.common.audit_details.adoc §Attributes makes
+# `change_type` (DV_CODED_TEXT, "Coded using the openEHR Terminology  audit
+# change type  group") and `committer` (PARTY_PROXY) both `1..1`; TERM
+# SupportTerminology codesets/openehr_terminology-vocabularies.adoc §Audit
+# Change Type gives `249|creation|` as the group member for a creating change
+# set. The ITS-REST docs text is SILENT on the contribution request body, so
+# the commit DTO's member set is grounded on the released OAS (cited AS the
+# OAS — owner ruling 2026-07-28): ITS-REST OAS
+# specifications/schemas/common/UpdateAudit.yaml §required (change_type,
+# committer), whose §description also fixes what this case must NOT assert of
+# the client value — "`time_committed` is always set by the server".
+#
+# The `time_committed` the case sends is therefore a DELIBERATE probe, not a
+# claim: it is offered and must not become the recorded committal instant.
+id: I_EHR_CONTRIBUTION.commit_contribution-audit_conformant
+kind: functional
+component: EHR_CONTRIBUTION
+sm_operation: I_EHR_CONTRIBUTION.commit_contribution
+capabilities: [ChangeSets]
+exercises: [Versioning]
+profiles: [CORE]
+test_purpose: >-
+  A CONTRIBUTION whose envelope audit states change_type and committer is
+  accepted, and the committed audit reports them with a server-set
+  time_committed.
+description: "Commit CONTRIBUTION with a fully stated, conformant commit audit"
+spec_refs:
+  - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
+  - "RM common §AUDIT_DETAILS (change_type: DV_CODED_TEXT 1..1; committer: PARTY_PROXY 1..1; time_committed computed on the server)"
+  - "TERM SupportTerminology §Audit Change Type (249|creation|)"
+  - "ITS-REST OAS schemas/common/UpdateAudit.yaml §required (change_type, committer)"
+applies: { rm: ">=1.0.2" }
+formats: [canonical-json]
+requires:
+  server: any
+  templates: [cnf.opt.minimal_event]
+  ehr: { commits: none }                 # mints ${ehr_id}
+data_sets:
+  - cnf.composition.minimal_event.v1
+flow:
+  - step: 1
+    call: commit_contribution
+    with:
+      ehr_id: "${ehr_id}"
+      versions:
+        - data: "${ds:cnf.composition.minimal_event.v1}"
+          change_type: creation
+      audit:
+        change_type:
+          _type: DV_CODED_TEXT
+          value: creation
+          defining_code:
+            _type: CODE_PHRASE
+            terminology_id: { _type: TERMINOLOGY_ID, value: openehr }
+            code_string: "249"
+        committer:
+          _type: PARTY_IDENTIFIED
+          name: "Dr Conformant"
+        time_committed: "1990-01-01T00:00:00Z"   # offered; the server sets its own
+    expect: created
+    capture:
+      contribution_uid: created.contribution_uid
+  - step: 2
+    call: get_contribution
+    with: { ehr_id: "${ehr_id}", contribution_uid: "${contribution_uid}" }
+    expect: ok
+    assert:
+      - { assert: instance_of, rm_type: CONTRIBUTION }
+      - { assert: field, path: "audit/change_type/defining_code/code_string", equals: "249" }
+      - { assert: field, path: "audit/committer", exists: true }
+      - { assert: field, path: "audit/time_committed", exists: true }
+      # UpdateAudit.yaml §description: "`time_committed` is always set by the
+      # server" — the offered client instant is not the recorded one.
+      - { assert: field, path: "audit/time_committed", not_equals: "1990-01-01T00:00:00Z" }
+postconditions:
+  - assert: state
+    text: >-
+      The change set committed, and its CONTRIBUTION audit reports the stated
+      change_type and committer with a server-set time_committed.

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-imported_version_type.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-imported_version_type.yaml
@@ -45,7 +45,7 @@ test_purpose: >-
   as UPDATE_VERSION commits.
 description: "Commit CONTRIBUTION whose member self-tags as a class the wire does not commit"
 spec_refs:
-  - "ITS-REST overview Resources §Resource representation (the _type attribute; the uppercase RM class name)"
+  - "ITS-REST overview Resources.md §JSON Format (the _type attribute; the uppercase RM class name)"
   - "RM common §change_control (master06 §Copying; commit_imported_version has no released wire)"
   - "RM common UML/classes/org.openehr.rm.common.imported_version.adoc (item is its sole own attribute)"
   - "ITS-REST OAS schemas/ehr/UpdateVersion.yaml + schemas/ehr/NewContribution.yaml (UpdateVersion is the only member schema)"

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-incomplete_wrong_data.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-incomplete_wrong_data.yaml
@@ -27,7 +27,7 @@ test_purpose: >-
 description: "Commit CONTRIBUTION with an incomplete (553) version carrying wrong data"
 spec_refs:
   - "RM common §change_control (master06 §Incomplete Content — \"data may be missing, but it may not be wrong\")"
-  - "RM composition §COMPOSITION (Category_validity)"
+  - "RM ehr master05-composition_package §COMPOSITION (Category_validity)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
   - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
 applies: { rm: ">=1.0.2" }

--- a/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.get_opt-partial_template_id_no_match.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.get_opt-partial_template_id_no_match.yaml
@@ -41,7 +41,7 @@ test_purpose: >-
 description: "retrieve an OPT by a family-name template_id under exact matching"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_ADL14.get_opt"
-  - "ITS-REST specifications §definition_template_adl1.4_get"
+  - "ITS-REST OAS operations/definition_template_adl1.4_get.yaml §responses"
   - "ITS-REST overview Requests_and_responses.md §HTTP status codes"
 applies: { rm: ">=1.0.2" }
 requires:

--- a/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.get_opt-retrieve_latest_version.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.get_opt-retrieve_latest_version.yaml
@@ -26,7 +26,7 @@ test_purpose: "Retrieving a versioned OPT by a partial template_id returns its l
 description: "retrieve last version of versioned OPT"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_ADL14.get_opt"
-  - "ITS-REST specifications §definition_template_adl1.4_get"
+  - "ITS-REST OAS operations/definition_template_adl1.4_get.yaml §responses"
   - "CNF platform_test_schedule master04 §get_opt-retrieve_latest_version"
 applies: { rm: ">=1.0.2" }
 requires:

--- a/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.upload_opt-valid_opt_twice_no_conflict.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl14/I_DEFINITION_ADL14.upload_opt-valid_opt_twice_no_conflict.yaml
@@ -26,7 +26,7 @@ test_purpose: "Uploading two OPTs with distinct template_ids succeeds both times
 description: "upload two valid OPTs with distinct template_ids (no conflict)"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_ADL14.upload_opt"
-  - "ITS-REST definition_template_adl1.4_upload §409 Conflict (the duplicate branch keys on same template_id)"
+  - "ITS-REST OAS operations/definition_template_adl1.4_upload.yaml §responses (the duplicate '409' branch keyed on the same template_id)"
   - "CNF platform_test_schedule master04 §upload_opt-valid_opt_twice_no_conflict"
 applies: { rm: ">=1.0.2" }
 requires: { server: empty }              # "No OPTs should be loaded on the system"

--- a/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.delete_artefact-existing.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.delete_artefact-existing.yaml
@@ -20,7 +20,7 @@ test_purpose: "Deleting an existing ADL2 artefact succeeds and the artefact is n
 description: "delete an existing ADL2 artefact"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_ADL2.delete_artefact"
-  - "ITS-REST definition_template_adl2_get §404 Not Found"
+  - "ITS-REST OAS operations/definition_template_adl2_get.yaml §responses ('404')"
 applies: { rm: ">=1.0.2" }
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.get_artefact-example.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.get_artefact-example.yaml
@@ -15,7 +15,7 @@ description: "get example data by ADL2 template"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_ADL2.get_artefact"
   - "AM AOM2 §Templates (an OPT constrains a COMPOSITION instance)"
-  - "ITS-REST definition_template_adl2_example_get §200 OK"
+  - "ITS-REST OAS operations/definition_template_adl2_example_get.yaml §responses ('200')"
 applies: { rm: ">=1.0.2" }
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.get_artefact-example_unknown.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.get_artefact-example_unknown.yaml
@@ -13,7 +13,7 @@ test_purpose: "Generating an example for an unknown ADL2 template_id is rejected
 description: "get example data for an unknown ADL2 template"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_ADL2.get_artefact"
-  - "ITS-REST definition_template_adl2_example_get §404 Not Found"
+  - "ITS-REST OAS operations/definition_template_adl2_example_get.yaml §responses ('404')"
 applies: { rm: ">=1.0.2" }
 requires: { server: empty }
 flow:

--- a/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.get_artefact-retrieve.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.get_artefact-retrieve.yaml
@@ -14,7 +14,7 @@ description: "retrieve a single ADL2 OPT"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_ADL2.get_artefact"
   - "AM ADL2 §Templates (operational template form)"
-  - "ITS-REST definition_template_adl2_get §200 OK"
+  - "ITS-REST OAS operations/definition_template_adl2_get.yaml §responses ('200')"
 applies: { rm: ">=1.0.2" }
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.get_artefact-unknown.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.get_artefact-unknown.yaml
@@ -11,7 +11,7 @@ test_purpose: "Retrieving an unknown ADL2 template_id is rejected as not-found."
 description: "retrieve an unknown ADL2 OPT"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_ADL2.get_artefact"
-  - "ITS-REST definition_template_adl2_get §404 Not Found"
+  - "ITS-REST OAS operations/definition_template_adl2_get.yaml §responses ('404')"
 applies: { rm: ">=1.0.2" }
 requires: { server: empty }
 flow:

--- a/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.get_artefact-version_get.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.get_artefact-version_get.yaml
@@ -14,7 +14,7 @@ test_purpose: "Retrieving a loaded ADL2 OPT at a specific version (deprecated en
 description: "get an ADL2 OPT at a specific version (deprecated)"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_ADL2.get_artefact"
-  - "ITS-REST definition_template_adl2_version_get §200 OK"
+  - "ITS-REST OAS operations/definition_template_adl2_version_get.yaml §responses ('200')"
 guards:
   - "ADL2 Get-template-at-version is deprecated in ITS-REST 1.1.0 (deprecated: true) — ITS-REST definition_template_adl2_version_get; SPECITS-87 (skip where the deprecated surface is withdrawn)"
 applies: { rm: ">=1.0.2" }

--- a/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.get_artefact-version_prefix.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.get_artefact-version_prefix.yaml
@@ -40,7 +40,7 @@ test_purpose: >-
 description: "get an ADL2 OPT by a partial {major} version prefix"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_ADL2.get_artefact"
-  - "ITS-REST definition_template_adl2_version_get §200 OK"
+  - "ITS-REST OAS operations/definition_template_adl2_version_get.yaml §responses ('200')"
   - "ITS-REST overview Requests_and_responses §ETag and Last-Modified"
 applies: { rm: ">=1.0.2" }
 requires: { server: any }

--- a/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.has_artefact-existing.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.has_artefact-existing.yaml
@@ -11,7 +11,7 @@ test_purpose: "has_artefact reports true for a loaded ADL2 OPT."
 description: "has_artefact for an existing ADL2 OPT"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_ADL2.has_artefact"
-  - "ITS-REST definition_template_adl2_list §200 OK"
+  - "ITS-REST OAS operations/definition_template_adl2_list.yaml §responses ('200')"
 applies: { rm: ">=1.0.2" }
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.has_artefact-non_existing.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.has_artefact-non_existing.yaml
@@ -11,7 +11,7 @@ test_purpose: "has_artefact reports false for an unknown ADL2 template_id."
 description: "has_artefact for a non-existing ADL2 OPT"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_ADL2.has_artefact"
-  - "ITS-REST definition_template_adl2_list §200 OK"
+  - "ITS-REST OAS operations/definition_template_adl2_list.yaml §responses ('200')"
 applies: { rm: ">=1.0.2" }
 requires: { server: exclusive }    # global-state ground — shared instances N/A
 flow:

--- a/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.list_matching_artefacts-filter.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.list_matching_artefacts-filter.yaml
@@ -12,7 +12,7 @@ test_purpose: "Listing ADL2 artefacts by an id pattern returns the matching oper
 description: "list ADL2 artefacts matching an id pattern"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_ADL2.list_matching_artefacts"
-  - "ITS-REST definition_template_adl2_list §200 OK"
+  - "ITS-REST OAS operations/definition_template_adl2_list.yaml §responses ('200')"
 applies: { rm: ">=1.0.2" }
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.list_opts-empty.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.list_opts-empty.yaml
@@ -11,7 +11,7 @@ test_purpose: "Listing ADL2 OPTs on an empty server returns an empty set and doe
 description: "list ADL2 OPTs when none is loaded"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_ADL2.list_opts"
-  - "ITS-REST definition_template_adl2_list §200 OK"
+  - "ITS-REST OAS operations/definition_template_adl2_list.yaml §responses ('200')"
 applies: { rm: ">=1.0.2" }
 requires: { server: exclusive }    # global-state ground (empty listing) — shared instances N/A
 flow:

--- a/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.list_opts-non_empty.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.list_opts-non_empty.yaml
@@ -13,7 +13,7 @@ test_purpose: "Listing ADL2 OPTs returns the loaded operational templates."
 description: "list ADL2 OPTs when some are loaded"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_ADL2.list_opts"
-  - "ITS-REST definition_template_adl2_list §200 OK"
+  - "ITS-REST OAS operations/definition_template_adl2_list.yaml §responses ('200')"
 applies: { rm: ">=1.0.2" }
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.list_templates-non_empty.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.list_templates-non_empty.yaml
@@ -13,7 +13,7 @@ description: "list ADL2 templates when some are loaded"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_ADL2.list_templates"
   - "AM AOM2 §Templates (TEMPLATE vs OPERATIONAL_TEMPLATE)"
-  - "ITS-REST definition_template_adl2_list §200 OK"
+  - "ITS-REST OAS operations/definition_template_adl2_list.yaml §responses ('200')"
 applies: { rm: ">=1.0.2" }
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.upload_artefact-duplicate_conflict.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.upload_artefact-duplicate_conflict.yaml
@@ -16,7 +16,7 @@ description: "upload the same ADL2 OPT twice"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_ADL2.upload_artefact"
   - "AM AOM2 §Identification (archetype/template HRID uniqueness)"
-  - "ITS-REST definition_template_adl2_upload §409 Conflict"
+  - "ITS-REST OAS operations/definition_template_adl2_upload.yaml §responses ('409')"
 applies: { rm: ">=1.0.2" }
 requires: { server: empty }
 data_sets: [cnf.adl2.opt.minimal_d]

--- a/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.upload_artefact-valid_opt.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.upload_artefact-valid_opt.yaml
@@ -16,7 +16,7 @@ spec_refs:
   - "SM openehr_platform §I_DEFINITION_ADL2.upload_artefact"
   - "AM ADL2 §Templates (operational template form)"
   - "AM AOM2 §Validity (an uploaded artefact must validate)"
-  - "ITS-REST definition_template_adl2_upload §201 Created"
+  - "ITS-REST OAS operations/definition_template_adl2_upload.yaml §responses ('201')"
 applies: { rm: ">=1.0.2" }
 requires: { server: empty }
 parameters:

--- a/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.valid_artefact-valid.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_adl2/I_DEFINITION_ADL2.valid_artefact-valid.yaml
@@ -14,7 +14,7 @@ description: "valid_artefact for a valid ADL2 OPT"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_ADL2.valid_artefact"
   - "AM AOM2 §Validity (a valid artefact satisfies the AOM2 validity rules)"
-  - "ITS-REST definition_template_adl2_upload §201 Created"
+  - "ITS-REST OAS operations/definition_template_adl2_upload.yaml §responses ('201')"
 applies: { rm: ">=1.0.2" }
 requires: { server: empty }
 parameters:

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.list_queries-prefix_all_versions.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.list_queries-prefix_all_versions.yaml
@@ -35,7 +35,7 @@ test_purpose: >-
 description: "list by prefix: all matches, all versions, name + SEMVER order"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.list_queries"
-  - "ITS-REST query Qualified_query_name.md §version identifier"
+  - "ITS-REST query Qualified_query_name.md §Qualified query name (the version identifier)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
 applies: { rm: ">=1.0.2" }
 requires: { server: empty }

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.list_queries-version_get_exact.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.list_queries-version_get_exact.yaml
@@ -30,7 +30,7 @@ test_purpose: >-
 description: "get a stored query at an exact version (verbatim definition)"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.list_queries"
-  - "ITS-REST query Qualified_query_name.md §version identifier"
+  - "ITS-REST query Qualified_query_name.md §Qualified query name (the version identifier)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
 applies: { rm: ">=1.0.2" }
 requires: { server: empty }

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.list_queries-version_get_major_prefix.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.list_queries-version_get_major_prefix.yaml
@@ -22,7 +22,7 @@ test_purpose: >-
 description: "get a stored query by a {major} version prefix"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.list_queries"
-  - "ITS-REST query Qualified_query_name.md §version identifier"
+  - "ITS-REST query Qualified_query_name.md §Qualified query name (the version identifier)"
 applies: { rm: ">=1.0.2" }
 requires: { server: empty }
 flow:

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.list_queries-version_get_minor_prefix.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.list_queries-version_get_minor_prefix.yaml
@@ -22,7 +22,7 @@ test_purpose: >-
 description: "get a stored query by a {major}.{minor} version prefix"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.list_queries"
-  - "ITS-REST query Qualified_query_name.md §version identifier"
+  - "ITS-REST query Qualified_query_name.md §Qualified query name (the version identifier)"
 applies: { rm: ">=1.0.2" }
 requires: { server: empty }
 flow:

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.list_queries-version_get_unknown.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.list_queries-version_get_unknown.yaml
@@ -26,7 +26,7 @@ test_purpose: >-
 description: "get a stored query at an unknown version (404)"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.list_queries"
-  - "ITS-REST query Qualified_query_name.md §version identifier"
+  - "ITS-REST query Qualified_query_name.md §Qualified query name (the version identifier)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
 applies: { rm: ">=1.0.2" }
 requires: { server: empty }

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-default_slot_with_higher_version.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-default_slot_with_higher_version.yaml
@@ -36,7 +36,7 @@ description: "version-less store beside a higher stored version (Location names 
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
   - "ITS-REST overview Requests_and_responses §Representation details negotiation"
-  - "ITS-REST query Qualified_query_name.md §version identifier"
+  - "ITS-REST query Qualified_query_name.md §Qualified query name (the version identifier)"
 applies: { rm: ">=1.0.2" }
 requires: { server: empty }
 flow:

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-default_version_slot.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-default_version_slot.yaml
@@ -34,7 +34,7 @@ description: "version-less store: 200 + Location naming the written version"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
   - "ITS-REST overview Requests_and_responses §Representation details negotiation"
-  - "ITS-REST query Qualified_query_name.md §version identifier"
+  - "ITS-REST query Qualified_query_name.md §Qualified query name (the version identifier)"
 applies: { rm: ">=1.0.2" }
 requires: { server: empty }
 flow:

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-update_in_place.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-update_in_place.yaml
@@ -29,7 +29,7 @@ test_purpose: >-
 description: "version-less re-store updates the default slot (no conflict, no new version)"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
-  - "ITS-REST query Qualified_query_name.md §version identifier"
+  - "ITS-REST query Qualified_query_name.md §Qualified query name (the version identifier)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
 applies: { rm: ">=1.0.2" }
 requires: { server: empty }

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-version_duplicate_conflict.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-version_duplicate_conflict.yaml
@@ -28,7 +28,7 @@ description: "versioned store: duplicate (name, version) is a conflict"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
-  - "ITS-REST query Qualified_query_name.md §version identifier"
+  - "ITS-REST query Qualified_query_name.md §Qualified query name (the version identifier)"
 applies: { rm: ">=1.0.2" }
 requires: { server: empty }
 flow:

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-version_malformed_rejected.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-version_malformed_rejected.yaml
@@ -27,7 +27,7 @@ test_purpose: >-
 description: "versioned store: a malformed version (v1.x) is refused"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
-  - "ITS-REST query Qualified_query_name.md §version identifier"
+  - "ITS-REST query Qualified_query_name.md §Qualified query name (the version identifier)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
 applies: { rm: ">=1.0.2" }
 requires: { server: any }

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-version_prefix_rejected.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-version_prefix_rejected.yaml
@@ -41,7 +41,7 @@ test_purpose: >-
 description: "versioned store: a {major} prefix is not a writable version"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
-  - "ITS-REST query Qualified_query_name.md §version identifier"
+  - "ITS-REST query Qualified_query_name.md §Qualified query name (the version identifier)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
 applies: { rm: ">=1.0.2" }
 requires: { server: any }

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-version_prerelease_rejected.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-version_prerelease_rejected.yaml
@@ -30,7 +30,7 @@ test_purpose: >-
 description: "versioned store: a pre-release version (1.0.0-rc.1) is refused"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
-  - "ITS-REST query Qualified_query_name.md §version identifier"
+  - "ITS-REST query Qualified_query_name.md §Qualified query name (the version identifier)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
 applies: { rm: ">=1.0.2" }
 requires: { server: any }

--- a/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-version_stored.yaml
+++ b/tools/cnf-runner/artifacts/schedule/definition_query/I_DEFINITION_QUERY.store_query-version_stored.yaml
@@ -27,7 +27,7 @@ test_purpose: >-
 description: "versioned store: 200 + Location, retrievable at the named version"
 spec_refs:
   - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
-  - "ITS-REST query Qualified_query_name.md §version identifier"
+  - "ITS-REST query Qualified_query_name.md §Qualified query name (the version identifier)"
   - "ITS-REST overview Requests_and_responses §Representation details negotiation"
 applies: { rm: ">=1.0.2" }
 requires: { server: empty }

--- a/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.create_directory-details_not_item_structure.yaml
+++ b/tools/cnf-runner/artifacts/schedule/directory/I_EHR_DIRECTORY.create_directory-details_not_item_structure.yaml
@@ -50,7 +50,7 @@ spec_refs:
   - "SM openehr_platform §I_VALIDITY_CHECKER.content_valid"
   - "RM common §folder (details: ITEM_STRUCTURE, 0..1)"
   - "RM common master05-directory_package §Overview"
-  - "RM data_structures master04-representation_package §Item Structures"
+  - "RM data_structures master04-item_structure_package §Class Descriptions (ITEM_STRUCTURE and its descendants)"
   - "ITS-REST overview Requests_and_responses §HTTP status codes"
 applies: { rm: ">=1.0.2" }
 requires:

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.create_ehr-invalid_status.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.create_ehr-invalid_status.yaml
@@ -15,7 +15,7 @@ test_purpose: >-
 description: "Create EHR with invalid EHR_STATUS data sets"
 spec_refs:
   - "SM openehr_platform §I_EHR_SERVICE.create_ehr"
-  - "CNF platform_test_schedule master06 §create_ehr data sets (INVALID class)"
+  - "CNF platform_test_schedule master06 §Test Data Sets (the INVALID class)"
   - "RM ehr §EHR_STATUS"
 applies: { rm: ">=1.0.2" }
 requires: { server: empty }

--- a/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.create_ehr-main.yaml
+++ b/tools/cnf-runner/artifacts/schedule/ehr/I_EHR_SERVICE.create_ehr-main.yaml
@@ -12,7 +12,7 @@ test_purpose: >-
 description: "Create new EHR"
 spec_refs:
   - "SM openehr_platform §I_EHR_SERVICE.create_ehr"
-  - "CNF platform_test_schedule master06 §create_ehr data sets"
+  - "CNF platform_test_schedule master06 §Test Data Sets (the create_ehr data sets)"
 applies: { rm: ">=1.0.2" }
 requires: { server: empty }
 parameters:

--- a/tools/cnf-runner/artifacts/schedule/messaging/I_EHR_EXTRACT_SERVICE.export_ehr_extracts-latest_across_lineages.yaml
+++ b/tools/cnf-runner/artifacts/schedule/messaging/I_EHR_EXTRACT_SERVICE.export_ehr_extracts-latest_across_lineages.yaml
@@ -1,0 +1,101 @@
+# WHICH head is 'latest' when a container carries TWO of them.
+#
+# THE UNDEFINED POINT (register AMB-206): RM ehr_extract
+# master04-common_package.adoc §Version Specification says an Extract request
+# with no version specification corresponds "to the assumption of 'latest
+# available version' for each matched item", and offers exactly two switches
+# beside it (`include_all_versions`, `include_revision_history`). No released
+# sentence says which head is latest when a trunk head and a branch head are
+# both open — and RM common master06-change_control §Semantics in Distributed
+# Systems makes coexisting lineages a normal state. The RM names both readings
+# without choosing: VERSIONED_OBJECT declares `latest_version()` AND
+# `latest_trunk_version()` (RM common
+# UML/classes/org.openehr.rm.common.versioned_object.adoc §Functions).
+#
+# THE PINNED CHOICE is AMB-206's fixed handling: the default export carries the
+# TRUNK head and no branch head. This case is what makes that choice checkable
+# instead of implicit — the container it exports holds trunk `::1`, trunk `::2`
+# and branch `::1.1.1` at once, so the assertion pair (the trunk head present,
+# the branch head omitted) fails the moment the selection drifts either way.
+#
+# The all-versions twin is `import_ehr_extract-into_branched_lineage`, which
+# drives the SAME container with `include_all_versions: true` and asserts all
+# three positions are held: together the two cases separate "the branch is not
+# stored" from "the branch is not exported by default".
+id: I_EHR_EXTRACT_SERVICE.export_ehr_extracts-latest_across_lineages
+kind: functional
+component: MESSAGING
+sm_operation: I_EHR_EXTRACT_SERVICE.export_ehr_extracts
+capabilities: [EhrExtract]
+exercises: [Versioning]
+profiles: [OPTIONS]
+test_purpose: >-
+  The default (latest-only) Extract of a container with an open trunk head and
+  an open branch head carries the trunk head and omits the branch head.
+description: "Default export of a branched container carries the trunk head"
+spec_refs:
+  - "SM openehr_platform §I_EHR_EXTRACT_SERVICE.export_ehr_extracts"
+  - "RM ehr_extract master04-common_package §Version Specification (the no-version-specification default: 'latest available version' for each matched item)"
+  - "RM ehr_extract UML/classes/org.openehr.rm.ehr_extract.extract_version_spec.adoc §Attributes (include_all_versions)"
+  - "RM common §VERSIONED_OBJECT (latest_version / latest_trunk_version — the two readings the Extract does not choose between)"
+  - "RM common master06-change_control §Semantics in Distributed Systems (coexisting lineages)"
+applies: { rm: ">=1.0.2" }
+ambiguities: [AMB-206]
+guards:
+  - "EXTENSION ROUTE — no openEHR spec governs the /message/* routes; our own design/extension, declared in vocab/wire_surface.yaml served_extensions (family message-extract) and adjudicated by register AMB-34. The row gates the CAPABILITY verdicts only, never ITS-REST wire conformance"
+requires:
+  server: any
+  ehr: { commits: any }                  # mints ${ehr_id}
+  # the first receipt: trunk ::1 plus the branch ::1.1.1 that descends from it
+  import:
+    extract: cnf.messaging.ehr_extract.branch_lineage_v1
+    container: X_VERSIONED_COMPOSITION
+data_sets: [cnf.messaging.ehr_extract.branch_lineage_v2]
+flow:
+  - step: 1                              # append trunk ::2, leaving ::1.1.1 open
+    call: import_ehr_extract
+    with:
+      an_ehr_id: "${ehr_id}"
+      an_extract: "${ds:cnf.messaging.ehr_extract.branch_lineage_v2}"
+    expect: updated
+  - step: 2                              # the default, latest-only export
+    call: export_ehr_extracts
+    with:
+      extract_spec:
+        _type: EXTRACT_SPEC
+        extract_type:
+          _type: DV_CODED_TEXT
+          value: openehr-ehr
+          defining_code:
+            _type: CODE_PHRASE
+            terminology_id: { _type: TERMINOLOGY_ID, value: openehr }
+            code_string: openehr-ehr
+        include_multimedia: false
+        priority: 0
+        link_depth: 0
+        criteria: []
+        version_spec:
+          _type: EXTRACT_VERSION_SPEC
+          # The no-version-specification default: all three Booleans are 1..1
+          # (extract_version_spec.adoc §Attributes), and include_all_versions
+          # false IS the "latest available version" assumption under test.
+          include_all_versions: false
+          include_revision_history: false
+          include_data: true
+        manifest:
+          _type: EXTRACT_MANIFEST
+          entities:
+            - _type: EXTRACT_ENTITY_MANIFEST
+              extract_id_key: "${ehr_id}"
+              ehr_id: "${ehr_id}"
+              other_ids: []
+              item_list: []
+    expect: ok
+    assert:
+      # The trunk head is the exported latest…
+      - { assert: returns, matches: "8b52e0c9-6d31-4f74-a09e-2c47b1d5836f::cnf\\.source\\.openehr\\.org::2" }
+      # …and the open branch head does not ride along under a request that
+      # asked for the latest version only. (The superseded trunk position
+      # `::1` is NOT asserted absent: the exported head names it as its
+      # `preceding_version_uid`, so its uid is legitimately in the body.)
+      - { assert: returns, omits: "8b52e0c9-6d31-4f74-a09e-2c47b1d5836f::cnf\\.branchsys\\.openehr\\.org::1\\.1\\.1" }

--- a/tools/cnf-runner/artifacts/schedule/messaging/I_EHR_EXTRACT_SERVICE.import_ehr-duplicate.yaml
+++ b/tools/cnf-runner/artifacts/schedule/messaging/I_EHR_EXTRACT_SERVICE.import_ehr-duplicate.yaml
@@ -22,7 +22,7 @@ description: "Import a whole EHR under a duplicate id"
 spec_refs:
   - "SM openehr_platform §I_EHR_EXTRACT_SERVICE.import_ehr"
   - "RM common master06-change_control §Copying"
-  - "CNF platform_test_schedule master13 §import_ehr"
+  - "CNF platform_test_schedule master13 §Test Cases (the schedule enumerates only the export_* operations; no import_ehr case)"
 applies: { rm: ">=1.0.2" }
 guards:
   - "EXTENSION ROUTE — no openEHR spec governs the /message/* routes; our own design/extension, declared in vocab/wire_surface.yaml served_extensions (family message-extract) and adjudicated by register AMB-34. The row gates the CAPABILITY verdicts only, never ITS-REST wire conformance"

--- a/tools/cnf-runner/artifacts/schedule/messaging/I_EHR_EXTRACT_SERVICE.import_ehr-malformed.yaml
+++ b/tools/cnf-runner/artifacts/schedule/messaging/I_EHR_EXTRACT_SERVICE.import_ehr-malformed.yaml
@@ -22,7 +22,7 @@ description: "Import a whole EHR from a malformed EXTRACT"
 spec_refs:
   - "SM openehr_platform §I_EHR_EXTRACT_SERVICE.import_ehr"
   - "RM ehr_extract master04-common_package §EXTRACT"
-  - "CNF platform_test_schedule master13 §import_ehr"
+  - "CNF platform_test_schedule master13 §Test Cases (the schedule enumerates only the export_* operations; no import_ehr case)"
 applies: { rm: ">=1.0.2" }
 guards:
   - "EXTENSION ROUTE — no openEHR spec governs the /message/* routes; our own design/extension, declared in vocab/wire_surface.yaml served_extensions (family message-extract) and adjudicated by register AMB-34. The row gates the CAPABILITY verdicts only, never ITS-REST wire conformance"

--- a/tools/cnf-runner/artifacts/schedule/messaging/I_EHR_EXTRACT_SERVICE.import_ehr-new.yaml
+++ b/tools/cnf-runner/artifacts/schedule/messaging/I_EHR_EXTRACT_SERVICE.import_ehr-new.yaml
@@ -22,7 +22,7 @@ description: "Import a whole EHR (source id re-used)"
 spec_refs:
   - "SM openehr_platform §I_EHR_EXTRACT_SERVICE.import_ehr"
   - "RM common master06-change_control §Copying"
-  - "CNF platform_test_schedule master13 §import_ehr"
+  - "CNF platform_test_schedule master13 §Test Cases (the schedule enumerates only the export_* operations; no import_ehr case)"
 applies: { rm: ">=1.0.2" }
 guards:
   - "EXTENSION ROUTE — no openEHR spec governs the /message/* routes; our own design/extension, declared in vocab/wire_surface.yaml served_extensions (family message-extract) and adjudicated by register AMB-34. The row gates the CAPABILITY verdicts only, never ITS-REST wire conformance"

--- a/tools/cnf-runner/artifacts/schedule/messaging/I_EHR_EXTRACT_SERVICE.import_ehr-with_id.yaml
+++ b/tools/cnf-runner/artifacts/schedule/messaging/I_EHR_EXTRACT_SERVICE.import_ehr-with_id.yaml
@@ -22,7 +22,7 @@ description: "Import a whole EHR with a fixed id"
 spec_refs:
   - "SM openehr_platform §I_EHR_EXTRACT_SERVICE.import_ehr"
   - "RM common master06-change_control §Copying"
-  - "CNF platform_test_schedule master13 §import_ehr"
+  - "CNF platform_test_schedule master13 §Test Cases (the schedule enumerates only the export_* operations; no import_ehr case)"
 applies: { rm: ">=1.0.2" }
 guards:
   - "EXTENSION ROUTE — no openEHR spec governs the /message/* routes; our own design/extension, declared in vocab/wire_surface.yaml served_extensions (family message-extract) and adjudicated by register AMB-34. The row gates the CAPABILITY verdicts only, never ITS-REST wire conformance"

--- a/tools/cnf-runner/artifacts/schedule/messaging/I_EHR_EXTRACT_SERVICE.import_ehr_extract-into_existing.yaml
+++ b/tools/cnf-runner/artifacts/schedule/messaging/I_EHR_EXTRACT_SERVICE.import_ehr_extract-into_existing.yaml
@@ -23,7 +23,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_EXTRACT_SERVICE.import_ehr_extract"
   - "RM common master06-change_control §Copying"
   - "RM ehr master04-ehr §Folders"
-  - "CNF platform_test_schedule master13 §import_ehr_extract (chapter: export_ehr_extract)"
+  - "CNF platform_test_schedule master13 §Test Cases (the schedule enumerates only the export_* operations; no import_ehr_extract case)"
 applies: { rm: ">=1.0.2" }
 guards:
   - "EXTENSION ROUTE — no openEHR spec governs the /message/* routes; our own design/extension, declared in vocab/wire_surface.yaml served_extensions (family message-extract) and adjudicated by register AMB-34. The row gates the CAPABILITY verdicts only, never ITS-REST wire conformance"

--- a/tools/cnf-runner/artifacts/schedule/messaging/I_EHR_EXTRACT_SERVICE.import_ehr_extract-invalid.yaml
+++ b/tools/cnf-runner/artifacts/schedule/messaging/I_EHR_EXTRACT_SERVICE.import_ehr_extract-invalid.yaml
@@ -22,7 +22,7 @@ description: "Import a malformed EXTRACT"
 spec_refs:
   - "SM openehr_platform §I_EHR_EXTRACT_SERVICE.import_ehr_extract"
   - "RM ehr_extract master04-common_package §EXTRACT"
-  - "CNF platform_test_schedule master13 §import_ehr_extract (chapter: export_ehr_extract)"
+  - "CNF platform_test_schedule master13 §Test Cases (the schedule enumerates only the export_* operations; no import_ehr_extract case)"
 applies: { rm: ">=1.0.2" }
 guards:
   - "EXTENSION ROUTE — no openEHR spec governs the /message/* routes; our own design/extension, declared in vocab/wire_surface.yaml served_extensions (family message-extract) and adjudicated by register AMB-34. The row gates the CAPABILITY verdicts only, never ITS-REST wire conformance"

--- a/tools/cnf-runner/artifacts/schedule/messaging/I_EHR_EXTRACT_SERVICE.import_ehr_extract-second_status.yaml
+++ b/tools/cnf-runner/artifacts/schedule/messaging/I_EHR_EXTRACT_SERVICE.import_ehr_extract-second_status.yaml
@@ -23,7 +23,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_EXTRACT_SERVICE.import_ehr_extract"
   - "RM ehr master04-ehr §EHR Status"
   - "RM common master06-change_control §Copying"
-  - "CNF platform_test_schedule master13 §import_ehr_extract (chapter: export_ehr_extract)"
+  - "CNF platform_test_schedule master13 §Test Cases (the schedule enumerates only the export_* operations; no import_ehr_extract case)"
 applies: { rm: ">=1.0.2" }
 guards:
   - "EXTENSION ROUTE — no openEHR spec governs the /message/* routes; our own design/extension, declared in vocab/wire_surface.yaml served_extensions (family message-extract) and adjudicated by register AMB-34. The row gates the CAPABILITY verdicts only, never ITS-REST wire conformance"

--- a/tools/cnf-runner/artifacts/schedule/messaging/I_EHR_EXTRACT_SERVICE.import_ehr_extract-unknown_ehr.yaml
+++ b/tools/cnf-runner/artifacts/schedule/messaging/I_EHR_EXTRACT_SERVICE.import_ehr_extract-unknown_ehr.yaml
@@ -21,7 +21,7 @@ test_purpose: "Importing an EXTRACT into a non-existent EHR is rejected as not f
 description: "Import an EXTRACT into a non-existent EHR"
 spec_refs:
   - "SM openehr_platform §I_EHR_EXTRACT_SERVICE.import_ehr_extract"
-  - "CNF platform_test_schedule master13 §import_ehr_extract (chapter: export_ehr_extract)"
+  - "CNF platform_test_schedule master13 §Test Cases (the schedule enumerates only the export_* operations; no import_ehr_extract case)"
 applies: { rm: ">=1.0.2" }
 guards:
   - "EXTENSION ROUTE — no openEHR spec governs the /message/* routes; our own design/extension, declared in vocab/wire_surface.yaml served_extensions (family message-extract) and adjudicated by register AMB-34. The row gates the CAPABILITY verdicts only, never ITS-REST wire conformance"

--- a/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_ad_hoc_query-archetype_subsumption.yaml
+++ b/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_ad_hoc_query-archetype_subsumption.yaml
@@ -23,7 +23,7 @@ test_purpose: >-
 description: "Ad-hoc AQL archetype predicate matches specialisation children of the named archetype"
 spec_refs:
   - "BASE architecture_overview master10 §Design-time Relationships between Archetypes (parent-archetype queries retrieve specialisation-child data)"
-  - "AM AOM1.4 master07 §Querying / §Supporting Archetype-based Querying (the archetype-based matching set)"
+  - "AM Identification master07-referencing §Supporting Archetype-based Querying (the archetype-based matching set)"
   - "QUERY AQL master03 §Archetype predicate (the predicate scopes the data source by archetype)"
   - "SM openehr_platform §I_QUERY_SERVICE.execute_ad_hoc_query"
 ambiguities: [AMB-173]

--- a/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_stored_query-reserved_name.yaml
+++ b/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_stored_query-reserved_name.yaml
@@ -30,7 +30,7 @@ test_purpose: >-
 description: "Stored-query execution under the reserved query-name `aql` is not found"
 spec_refs:
   - "SM openehr_platform §I_QUERY_SERVICE.execute_stored_query"
-  - "ITS-REST query Qualified_query_name.md §NOTE (reserved name)"
+  - "ITS-REST query Qualified_query_name.md §Qualified query name (the reserved-name NOTE)"
   - "ITS-REST query Query_types.md §Ad-hoc queries"
   - "ITS-REST overview Requests_and_responses.md §HTTP status codes"
 applies: { rm: ">=1.0.2", aql: ">=1.1", its_rest: ">=1.1.0" }   # the reserved `aql` query-name resolution arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-46)

--- a/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_stored_query-version_exact.yaml
+++ b/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_stored_query-version_exact.yaml
@@ -30,7 +30,7 @@ description: "Stored-query execution at an exact SEMVER version selector"
 spec_refs:
   - "SM openehr_platform §I_QUERY_SERVICE.execute_stored_query"
   - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
-  - "ITS-REST query Qualified_query_name.md §version identifier"
+  - "ITS-REST query Qualified_query_name.md §Qualified query name (the version identifier)"
   - "ITS-REST query Response.md §RESULT_SET response"
   - "QUERY AQL §SELECT, §FROM, §CONTAINS"
 applies: { rm: ">=1.0.2", aql: ">=1.1" }

--- a/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_stored_query-version_major_prefix.yaml
+++ b/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_stored_query-version_major_prefix.yaml
@@ -26,7 +26,7 @@ description: "Stored-query execution at a {major} version prefix resolves to the
 spec_refs:
   - "SM openehr_platform §I_QUERY_SERVICE.execute_stored_query"
   - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
-  - "ITS-REST query Qualified_query_name.md §version identifier"
+  - "ITS-REST query Qualified_query_name.md §Qualified query name (the version identifier)"
   - "ITS-REST query Response.md §RESULT_SET response"
   - "QUERY AQL §SELECT, §FROM, §CONTAINS"
 applies: { rm: ">=1.0.2", aql: ">=1.1" }

--- a/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_stored_query-version_malformed_selector.yaml
+++ b/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_stored_query-version_malformed_selector.yaml
@@ -28,7 +28,7 @@ description: "Stored-query execution at a malformed version selector is not foun
 spec_refs:
   - "SM openehr_platform §I_QUERY_SERVICE.execute_stored_query"
   - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
-  - "ITS-REST query Qualified_query_name.md §version identifier"
+  - "ITS-REST query Qualified_query_name.md §Qualified query name (the version identifier)"
   - "ITS-REST overview Requests_and_responses.md §HTTP status codes"
 applies: { rm: ">=1.0.2", aql: ">=1.1" }
 ambiguities: [AMB-102]

--- a/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_stored_query-version_minor_prefix.yaml
+++ b/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_stored_query-version_minor_prefix.yaml
@@ -28,7 +28,7 @@ description: "Stored-query execution at a {major}.{minor} version prefix stays i
 spec_refs:
   - "SM openehr_platform §I_QUERY_SERVICE.execute_stored_query"
   - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
-  - "ITS-REST query Qualified_query_name.md §version identifier"
+  - "ITS-REST query Qualified_query_name.md §Qualified query name (the version identifier)"
   - "ITS-REST query Response.md §RESULT_SET response"
   - "QUERY AQL §SELECT, §FROM, §CONTAINS"
 applies: { rm: ">=1.0.2", aql: ">=1.1" }

--- a/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_stored_query-version_unknown_major.yaml
+++ b/tools/cnf-runner/artifacts/schedule/query/I_QUERY_SERVICE.execute_stored_query-version_unknown_major.yaml
@@ -25,7 +25,7 @@ description: "Stored-query execution at an unmatched {major} selector is not fou
 spec_refs:
   - "SM openehr_platform §I_QUERY_SERVICE.execute_stored_query"
   - "SM openehr_platform §I_DEFINITION_QUERY.store_query"
-  - "ITS-REST query Qualified_query_name.md §version identifier"
+  - "ITS-REST query Qualified_query_name.md §Qualified query name (the version identifier)"
   - "ITS-REST overview Requests_and_responses.md §HTTP status codes"
 applies: { rm: ">=1.0.2", aql: ">=1.1" }
 requires:

--- a/tools/cnf-runner/artifacts/schedule/security/SEC-ANONYMOUS_EHRS-anonymous_lifecycle.yaml
+++ b/tools/cnf-runner/artifacts/schedule/security/SEC-ANONYMOUS_EHRS-anonymous_lifecycle.yaml
@@ -21,7 +21,7 @@ spec_refs:
   - "CNF profiles master03-profiles.adoc §Non-Functional (Security & Privacy: Anonymous EHRs)"
 applies: { rm: ">=1.0.2", aql: ">=1.1" }
 guards:
-  - "applies only when the SUT declares the SEC-BASIC security tier — CNF 2.0 security schedule (this proposal; 2017 schedule Security BASIC lineage)"
+  - "applies only when the SUT declares the SEC-BASIC security tier — CNF profiles master03-profiles §Non-Functional (the Security & Privacy product attribute; the SEC-BASIC tier is our own extension — no released openEHR spec defines it)"
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/security/SEC-AUDIT_ACCOUNTABILITY-server_set_commit_audit.yaml
+++ b/tools/cnf-runner/artifacts/schedule/security/SEC-AUDIT_ACCOUNTABILITY-server_set_commit_audit.yaml
@@ -23,10 +23,10 @@ spec_refs:
   - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
   - "RM common §change_control (Committal and Audits: AUDIT_DETAILS.committer, time_committed computed on the server)"
   - "ITS-REST overview Requests_and_responses (openehr-audit-details: client MAY supply change_type/description/committer/system_id; time_committed is server-set)"
-  - "CNF 2.0 security schedule §SEC-BASIC Audit accountability (this proposal; 2017 schedule Security BASIC lineage)"
+  - "CNF profiles master03-profiles §Non-Functional (the Security & Privacy product attribute; the SEC-BASIC tier is our own extension — no released openEHR spec defines it)"
 applies: { rm: ">=1.0.2" }
 guards:
-  - "applies only when the SUT declares the SEC-BASIC security tier — CNF 2.0 security schedule (this proposal; 2017 schedule Security BASIC lineage)"
+  - "applies only when the SUT declares the SEC-BASIC security tier — CNF profiles master03-profiles §Non-Functional (the Security & Privacy product attribute; the SEC-BASIC tier is our own extension — no released openEHR spec defines it)"
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/security/SEC-AUTHENTICATED_ACCESS-unauthenticated_sweep.yaml
+++ b/tools/cnf-runner/artifacts/schedule/security/SEC-AUTHENTICATED_ACCESS-unauthenticated_sweep.yaml
@@ -20,10 +20,10 @@ description: "Unauthenticated requests to protected operations are refused"
 spec_refs:
   - "SM openehr_platform §I_EHR_SERVICE.create_ehr"
   - "ITS-REST overview Requests_and_responses (HTTP status codes: 401 — unauthenticated)"
-  - "CNF 2.0 security schedule §SEC-BASIC Authenticated access (this proposal; 2017 schedule Security BASIC lineage)"
+  - "CNF profiles master03-profiles §Non-Functional (the Security & Privacy product attribute; the SEC-BASIC tier is our own extension — no released openEHR spec defines it)"
 applies: { rm: ">=1.0.2" }
 guards:
-  - "applies only when the SUT declares the SEC-BASIC security tier — CNF 2.0 security schedule (this proposal; 2017 schedule Security BASIC lineage)"
+  - "applies only when the SUT declares the SEC-BASIC security tier — CNF profiles master03-profiles §Non-Functional (the Security & Privacy product attribute; the SEC-BASIC tier is our own extension — no released openEHR spec defines it)"
 requires:
   server: any
 flow:

--- a/tools/cnf-runner/artifacts/schedule/security/SEC-AUTHENTICATED_ACCESS-www_authenticate_challenge.yaml
+++ b/tools/cnf-runner/artifacts/schedule/security/SEC-AUTHENTICATED_ACCESS-www_authenticate_challenge.yaml
@@ -38,10 +38,10 @@ spec_refs:
   - "ITS-REST overview Requests_and_responses (Authentication and authorization: services MUST properly use the WWW-Authenticate and/or Proxy-Authenticate response headers)"
   - "ITS-REST overview Requests_and_responses (HTTP status codes: 401 — lacks valid authentication credentials for the target resource)"
   - "SM openehr_platform §I_EHR_SERVICE.get_ehr"
-  - "CNF 2.0 security schedule §SEC-BASIC Authenticated access (this proposal; 2017 schedule Security BASIC lineage)"
+  - "CNF profiles master03-profiles §Non-Functional (the Security & Privacy product attribute; the SEC-BASIC tier is our own extension — no released openEHR spec defines it)"
 applies: { rm: ">=1.0.2" }
 guards:
-  - "applies only when the SUT declares the SEC-BASIC security tier — CNF 2.0 security schedule (this proposal; 2017 schedule Security BASIC lineage)"
+  - "applies only when the SUT declares the SEC-BASIC security tier — CNF profiles master03-profiles §Non-Functional (the Security & Privacy product attribute; the SEC-BASIC tier is our own extension — no released openEHR spec defines it)"
   - "the challenge is mandated only when the service requires authentication — ITS-REST overview Requests_and_responses §Authentication and authorization ('If authentication and authorization are required'); a service declaring no authentication framework is not in scope"
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/security/SEC-AUTHORIZATION_SEPARATION-readonly_write_denied.yaml
+++ b/tools/cnf-runner/artifacts/schedule/security/SEC-AUTHORIZATION_SEPARATION-readonly_write_denied.yaml
@@ -22,10 +22,10 @@ description: "A read-only principal is forbidden from write operations"
 spec_refs:
   - "SM openehr_platform §I_EHR_SERVICE.create_ehr"
   - "ITS-REST overview Requests_and_responses (HTTP status codes: 403 — forbidden)"
-  - "CNF 2.0 security schedule §SEC-BASIC Authorization separation (this proposal; 2017 schedule Security BASIC lineage)"
+  - "CNF profiles master03-profiles §Non-Functional (the Security & Privacy product attribute; the SEC-BASIC tier is our own extension — no released openEHR spec defines it)"
 applies: { rm: ">=1.0.2" }
 guards:
-  - "applies only when the SUT declares the SEC-BASIC security tier — CNF 2.0 security schedule (this proposal; 2017 schedule Security BASIC lineage)"
+  - "applies only when the SUT declares the SEC-BASIC security tier — CNF profiles master03-profiles §Non-Functional (the Security & Privacy product attribute; the SEC-BASIC tier is our own extension — no released openEHR spec defines it)"
 requires:
   server: any
   templates: [cnf.opt.minimal_event]

--- a/tools/cnf-runner/artifacts/schedule/security/SEC-EHR_DEMOGRAPHIC_SEPARATION-status_subject_opaque.yaml
+++ b/tools/cnf-runner/artifacts/schedule/security/SEC-EHR_DEMOGRAPHIC_SEPARATION-status_subject_opaque.yaml
@@ -19,10 +19,10 @@ description: "EHR_STATUS.subject exposes only opaque refs / PARTY_SELF"
 spec_refs:
   - "SM openehr_platform §I_EHR_STATUS.get_ehr_status"
   - "RM ehr §EHR Status (EHR_STATUS.subject is a PARTY_SELF; anonymous form carries no identifier, otherwise an opaque external ref)"
-  - "CNF 2.0 security schedule §SEC-BASIC EHR/Demographic separation (this proposal; 2017 schedule Security BASIC lineage)"
+  - "CNF profiles master03-profiles §Non-Functional (the Security & Privacy product attribute; the SEC-BASIC tier is our own extension — no released openEHR spec defines it)"
 applies: { rm: ">=1.0.2" }
 guards:
-  - "applies only when the SUT declares the SEC-BASIC security tier — CNF 2.0 security schedule (this proposal; 2017 schedule Security BASIC lineage)"
+  - "applies only when the SUT declares the SEC-BASIC security tier — CNF profiles master03-profiles §Non-Functional (the Security & Privacy product attribute; the SEC-BASIC tier is our own extension — no released openEHR spec defines it)"
 requires:
   server: any
 flow:

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-CONTRIB-flat_commit.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-CONTRIB-flat_commit.yaml
@@ -39,7 +39,7 @@ test_purpose: >-
   reads back as a canonical COMPOSITION.
 description: "CONTRIBUTION commit with FLAT versions[].data, canonical read-back"
 spec_refs:
-  - "ITS-REST overview Amendment_record §SPECITS-84"
+  - "ITS-REST overview Amendment_record.md §Amendment Record (the SPECITS-84 row)"
   - "ITS-REST overview Resources.md §Simplified Formats"
   - "ITS-REST simplified_formats master02 §MIME Types"
   - "ITS-REST overview Requests_and_responses §openehr-template-id"

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-CONTRIB-flat_read.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-CONTRIB-flat_read.yaml
@@ -33,7 +33,7 @@ test_purpose: >-
   unchanged by the simplified negotiation.
 description: "Get CONTRIBUTION with a FLAT Accept, canonical envelope"
 spec_refs:
-  - "ITS-REST overview Amendment_record §SPECITS-84"
+  - "ITS-REST overview Amendment_record.md §Amendment Record (the SPECITS-84 row)"
   - "ITS-REST overview Resources.md §Simplified Formats"
   - "ITS-REST simplified_formats master02 §MIME Types"
   - "SM openehr_platform §I_EHR_CONTRIBUTION.get_contribution"

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-CONTRIB-structured_commit.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-CONTRIB-structured_commit.yaml
@@ -29,7 +29,7 @@ test_purpose: >-
   created VERSION reads back as a canonical COMPOSITION.
 description: "CONTRIBUTION commit with STRUCTURED versions[].data, canonical read-back"
 spec_refs:
-  - "ITS-REST overview Amendment_record §SPECITS-84"
+  - "ITS-REST overview Amendment_record.md §Amendment Record (the SPECITS-84 row)"
   - "ITS-REST overview Resources.md §Simplified Formats"
   - "ITS-REST simplified_formats master04 §Structured format"
   - "ITS-REST overview Requests_and_responses §openehr-template-id"

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-CONTRIB-structured_read.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-CONTRIB-structured_read.yaml
@@ -22,7 +22,7 @@ test_purpose: >-
   audit unchanged by the simplified negotiation.
 description: "Get CONTRIBUTION with a STRUCTURED Accept, canonical envelope"
 spec_refs:
-  - "ITS-REST overview Amendment_record §SPECITS-84"
+  - "ITS-REST overview Amendment_record.md §Amendment Record (the SPECITS-84 row)"
   - "ITS-REST overview Resources.md §Simplified Formats"
   - "ITS-REST simplified_formats master04 §Structured format"
   - "SM openehr_platform §I_EHR_CONTRIBUTION.get_contribution"

--- a/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-context.yaml
+++ b/tools/cnf-runner/artifacts/schedule/simplified_formats/SF-MAP-context.yaml
@@ -23,7 +23,7 @@ spec_refs:
   - "ITS-REST simplified_formats master05 §PARTICIPATION"
   - "ITS-REST simplified_formats master05 §ISM_TRANSITION"
   - "ITS-REST simplified_formats master06 §time + §setting"
-  - "RM composition §EVENT_CONTEXT"
+  - "RM ehr master05-composition_package §EVENT_CONTEXT"
 applies: { rm: ">=1.0.2", its_rest: ">=1.1.0" }   # Simplified-Format media types on the resource endpoints arrived in Release-1.1.0 — ITS-REST overview Amendment_record.md §Release-1.1.0 (SPECITS-61; SPECITS-84 for CONTRIBUTION)
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/vocab/capability_matrix.yaml
+++ b/tools/cnf-runner/artifacts/vocab/capability_matrix.yaml
@@ -140,7 +140,7 @@ EhrOperations: { family: Platform, tier: CORE, required: true, min_cases: 24, so
 EhrStatus: { family: Platform, tier: CORE, required: true, min_cases: 47, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: EHR Status)" }
 CompositionOps: { family: Platform, tier: CORE, required: true, min_cases: 50, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Composition Operations)" }
 DirectoryOps: { family: Platform, tier: STANDARD, required: true, min_cases: 77, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Directory Operations)" }
-ChangeSets: { family: Platform, tier: CORE, required: true, min_cases: 84, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Change sets)" }
+ChangeSets: { family: Platform, tier: CORE, required: true, min_cases: 87, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Change sets)" }
 Versioning: { family: Platform, tier: CORE, required: true, min_cases: 69, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Versioning)" }
 # Floor raised 121 -> 125 (2026-07-29): the four commit-time CONSTRAINT
 # BINDING cases (member accepted / non-member refused / unresolvable under each
@@ -320,7 +320,7 @@ DemographicArchive: { family: Platform, tier: OPTIONS, required: false, realizat
 # The workload_exclusion is GONE: the `integration_poll` journey now exports an
 # EHR as EXTRACTs (`ehr_extract_export`), so the measured hospital simulation
 # exercises the capability.
-EhrExtract: { family: Platform, tier: OPTIONS, required: false, realization: extension, min_cases: 26, source: "CNF profiles master03-profiles.adoc §Functional (Messaging: EHR Extract)" }
+EhrExtract: { family: Platform, tier: OPTIONS, required: false, realization: extension, min_cases: 27, source: "CNF profiles master03-profiles.adoc §Functional (Messaging: EHR Extract)" }
 # REALIZED ON THE EXTENSION SURFACE (#659, 2026-07-29) — no MESSAGE group exists
 # in the release (CONFIRMED unchanged first-hand), but the product serves
 # import_tdd + import_tdds under /message/tdd/ (the `message-tdd`

--- a/tools/cnf-runner/artifacts/vocab/wire_surface.yaml
+++ b/tools/cnf-runner/artifacts/vocab/wire_surface.yaml
@@ -1169,14 +1169,14 @@ elements:
   # (ITS-REST docs/query/Qualified_query_name.md).
   - id: query-stored-version-selector-matching
     description: "A stored query is addressable at a version: an exact major.minor.patch selector executes that definition, a {major} prefix the highest version inside that major, and a {major}.{minor} prefix the highest inside that minor line."
-    source: "ITS-REST query Qualified_query_name.md §version identifier (\"The `version` identifier is in the format specified by SEMVER style (i.e. `major.minor.patch`)\"; \"When only a partial `version` pattern is supplied, or when `version` is not supplied at all, the system must use the latest `version` with the supplied prefix - i.e. if only `major` or `major.minor` is used, then the latest query version matching supplied prefix will be used\")"
+    source: "ITS-REST query Qualified_query_name.md §Qualified query name (the version identifier) (\"The `version` identifier is in the format specified by SEMVER style (i.e. `major.minor.patch`)\"; \"When only a partial `version` pattern is supplied, or when `version` is not supplied at all, the system must use the latest `version` with the supplied prefix - i.e. if only `major` or `major.minor` is used, then the latest query version matching supplied prefix will be used\")"
     covered_by:
       - I_QUERY_SERVICE.execute_stored_query-version_exact
       - I_QUERY_SERVICE.execute_stored_query-version_major_prefix
       - I_QUERY_SERVICE.execute_stored_query-version_minor_prefix
   - id: query-stored-version-unmatchable-selector
     description: "A version selector that matches no stored version — an out-of-range major, or a token that is neither an exact SEMVER nor a legal {major}/{major}.{minor} prefix — is not found, and never falls back to another version."
-    source: "ITS-REST query Qualified_query_name.md §version identifier admits exactly the exact-SEMVER and the {major}/{major}.{minor} prefix shapes and assigns nothing to any other token; adjudicated in register AMB-102 (fixed handling: an unmatchable selector IS a version that does not exist), on Requests_and_responses.md §HTTP status codes row 404 (\"The origin service did not find the target resource or is not willing to disclose that one exists\")"
+    source: "ITS-REST query Qualified_query_name.md §Qualified query name (the version identifier) admits exactly the exact-SEMVER and the {major}/{major}.{minor} prefix shapes and assigns nothing to any other token; adjudicated in register AMB-102 (fixed handling: an unmatchable selector IS a version that does not exist), on Requests_and_responses.md §HTTP status codes row 404 (\"The origin service did not find the target resource or is not willing to disclose that one exists\")"
     covered_by:
       - I_QUERY_SERVICE.execute_stored_query-version_unknown_major
       - I_QUERY_SERVICE.execute_stored_query-version_malformed_selector

--- a/tools/cnf-runner/src/exec/driver.rs
+++ b/tools/cnf-runner/src/exec/driver.rs
@@ -1257,6 +1257,11 @@ const ATTESTATION_TOKEN: &str = "attestation";
 /// The `audit_change_type` code the token above names (`666|attestation|`).
 const ATTESTATION_CODE: &str = "666";
 
+/// The reserved sentinel a case writes in place of a value to say "omit this
+/// member entirely" — the same word the parameter matrix reserves
+/// ([`crate::model::case::MatrixCell::Absent`]).
+const ABSENT_SENTINEL: &str = "absent";
+
 impl HttpDriver<'_> {
     /// An openEHR `DV_CODED_TEXT` over the `openehr` terminology.
     fn openehr_coded_text(code: &str, rubric: &str) -> Value {
@@ -1349,7 +1354,10 @@ impl HttpDriver<'_> {
     /// A message naming the offending member when an override token is outside
     /// its closed vocabulary — never a silent fallback to the derived value,
     /// which would commit a version the case did not ask for.
-    fn contribution_envelope(versions: &[Value]) -> Result<Value, String> {
+    fn contribution_envelope(
+        versions: &[Value],
+        commit_audit: Option<&Value>,
+    ) -> Result<Value, String> {
         // The envelope audit's aggregate change type. RM common
         // `master06-change_control_package.adoc` §Contributions fixes the
         // attestation-only value verbatim — "`666|attestation|`: used when the
@@ -1359,7 +1367,7 @@ impl HttpDriver<'_> {
         // creation default.
         let all_attestations = !versions.is_empty()
             && versions.iter().all(|member| {
-                member.get("change_type").and_then(Value::as_str) == Some(ATTESTATION_TOKEN)
+                Self::member_change_type(member) == Ok(MemberChangeType::Attestation)
             });
         let members: Vec<Value> = versions
             .iter()
@@ -1368,18 +1376,66 @@ impl HttpDriver<'_> {
         let aggregate = if all_attestations {
             Self::openehr_coded_text(ATTESTATION_CODE, ATTESTATION_TOKEN)
         } else {
-            Self::openehr_coded_text("249", "creation")
+            Self::openehr_coded_text(
+                MemberChangeType::Creation.code(),
+                MemberChangeType::Creation.token(),
+            )
         };
+        let mut audit = serde_json::json!({
+            "_type": "AUDIT_DETAILS",
+            "system_id": "cnf-runner",
+            "committer": { "_type": "PARTY_IDENTIFIED", "name": "cnf runner" },
+            "change_type": aggregate
+        });
+        Self::apply_commit_audit_override(&mut audit, commit_audit)?;
         Ok(serde_json::json!({
             "_type": "CONTRIBUTION",
             "versions": members,
-            "audit": {
-                "_type": "AUDIT_DETAILS",
-                "system_id": "cnf-runner",
-                "committer": { "_type": "PARTY_IDENTIFIED", "name": "cnf runner" },
-                "change_type": aggregate
-            }
+            "audit": audit
         }))
+    }
+
+    /// Apply a case's `audit:` override onto the derived commit audit.
+    ///
+    /// The derived envelope audit is what a conformant commit carries, so a
+    /// case that is ABOUT the audit states only its delta: each key the
+    /// override names replaces the derived value verbatim, and the reserved
+    /// `absent` sentinel OMITS the key entirely. Omission is what the
+    /// mandatory-member refusals need — RM common
+    /// `UML/classes/org.openehr.rm.common.audit_details.adoc` §Attributes
+    /// makes `change_type` and `committer` 1..1, and the released OAS
+    /// `specifications/schemas/common/UpdateAudit.yaml` §required lists both
+    /// on the commit DTO — and a verbatim value is what an out-of-group
+    /// `change_type` code needs, since the closed vocabulary cannot spell one
+    /// (§Invariants `Change_type_valid`).
+    ///
+    /// # Errors
+    /// A message when the override is not an object — never a silent ignore,
+    /// which would send the derived audit a case deliberately altered.
+    fn apply_commit_audit_override(
+        audit: &mut Value,
+        commit_audit: Option<&Value>,
+    ) -> Result<(), String> {
+        let Some(commit_audit) = commit_audit else {
+            return Ok(());
+        };
+        let Some(overrides) = commit_audit.as_object() else {
+            return Err(format!(
+                "`audit:` must be an AUDIT_DETAILS object stating the members to override \
+                 (or `absent` to omit one), got {commit_audit}"
+            ));
+        };
+        let Some(target) = audit.as_object_mut() else {
+            return Err("the derived commit audit is not an object".to_owned());
+        };
+        for (key, value) in overrides {
+            if value.as_str() == Some(ABSENT_SENTINEL) {
+                target.remove(key);
+            } else {
+                target.insert(key.clone(), value.clone());
+            }
+        }
+        Ok(())
     }
 
     /// One CONTRIBUTION member of the bundled `versions:` construct, in its
@@ -1612,7 +1668,7 @@ impl HttpDriver<'_> {
                 if name == "contribution"
                     && let Some(versions) = with.get("versions").and_then(Value::as_array)
                 {
-                    return Self::contribution_envelope(versions)
+                    return Self::contribution_envelope(versions, with.get("audit"))
                         .map(Some)
                         .map_err(|e| format!("step {}: {e}", step.step));
                 }
@@ -3670,15 +3726,18 @@ mod tests {
     /// attestation of one or more of the member versions").
     #[test]
     fn an_attestation_member_commits_no_version_and_carries_the_fixture_audit() {
-        let envelope = HttpDriver::contribution_envelope(&[serde_json::json!({
-            "change_type": "attestation",
-            "preceding_version_uid": "8849182c-82ad-4088-a07f-48ead4180515::cnf::1",
-            "attestation": {
-                "_type": "UPDATE_ATTESTATION",
-                "reason": { "_type": "DV_TEXT", "value": "witnessed" },
-                "is_pending": false
-            }
-        })])
+        let envelope = HttpDriver::contribution_envelope(
+            &[serde_json::json!({
+                "change_type": "attestation",
+                "preceding_version_uid": "8849182c-82ad-4088-a07f-48ead4180515::cnf::1",
+                "attestation": {
+                    "_type": "UPDATE_ATTESTATION",
+                    "reason": { "_type": "DV_TEXT", "value": "witnessed" },
+                    "is_pending": false
+                }
+            })],
+            None,
+        )
         .expect("the attestation member builds");
         let member = &envelope["versions"][0];
         assert_eq!(member["_type"], serde_json::json!("ORIGINAL_VERSION"));
@@ -3714,11 +3773,14 @@ mod tests {
     /// `ATTESTATION` invariants rather than the runner's defaults.
     #[test]
     fn an_invalid_attestation_fixture_is_not_repaired() {
-        let envelope = HttpDriver::contribution_envelope(&[serde_json::json!({
-            "change_type": "attestation",
-            "preceding_version_uid": "8849182c-82ad-4088-a07f-48ead4180515::cnf::1",
-            "attestation": { "_type": "UPDATE_ATTESTATION", "is_pending": false, "items": [] }
-        })])
+        let envelope = HttpDriver::contribution_envelope(
+            &[serde_json::json!({
+                "change_type": "attestation",
+                "preceding_version_uid": "8849182c-82ad-4088-a07f-48ead4180515::cnf::1",
+                "attestation": { "_type": "UPDATE_ATTESTATION", "is_pending": false, "items": [] }
+            })],
+            None,
+        )
         .expect("the attestation member builds");
         let audit = &envelope["versions"][0]["commit_audit"];
         assert!(
@@ -3738,7 +3800,7 @@ mod tests {
                 "preceding_version_uid": "8849182c-82ad-4088-a07f-48ead4180515::cnf::1",
                 "attestation": { "is_pending": true, "reason": { "value": "witnessed" } }
             }),
-        ])
+        ], None)
         .expect("the mixed change set builds");
         assert_eq!(
             envelope["audit"]["change_type"]["defining_code"]["code_string"],
@@ -3754,12 +3816,15 @@ mod tests {
     /// Lifecycle transitions).
     #[test]
     fn member_overrides_are_closed_vocabularies() {
-        let envelope = HttpDriver::contribution_envelope(&[serde_json::json!({
-            "change_type": "modification",
-            "_type": "IMPORTED_VERSION",
-            "lifecycle_state": "abandoned",
-            "data": { "_type": "COMPOSITION" }
-        })])
+        let envelope = HttpDriver::contribution_envelope(
+            &[serde_json::json!({
+                "change_type": "modification",
+                "_type": "IMPORTED_VERSION",
+                "lifecycle_state": "abandoned",
+                "data": { "_type": "COMPOSITION" }
+            })],
+            None,
+        )
         .expect("the overridden member builds");
         let member = &envelope["versions"][0];
         assert_eq!(member["_type"], serde_json::json!("IMPORTED_VERSION"));
@@ -3778,9 +3843,10 @@ mod tests {
         );
 
         // Absent overrides keep the derived shape.
-        let derived = HttpDriver::contribution_envelope(&[
-            serde_json::json!({ "change_type": "creation", "data": { "_type": "COMPOSITION" } }),
-        ])
+        let derived = HttpDriver::contribution_envelope(
+            &[serde_json::json!({ "change_type": "creation", "data": { "_type": "COMPOSITION" } })],
+            None,
+        )
         .expect("the derived member builds");
         assert_eq!(
             derived["versions"][0]["_type"],
@@ -3797,7 +3863,7 @@ mod tests {
             serde_json::json!({ "change_type": "creation", "lifecycle_state": "finished" }),
         ] {
             assert!(
-                HttpDriver::contribution_envelope(std::slice::from_ref(&bad)).is_err(),
+                HttpDriver::contribution_envelope(std::slice::from_ref(&bad), None).is_err(),
                 "{bad} must be refused"
             );
         }
@@ -3805,21 +3871,78 @@ mod tests {
         // A verbatim member already spells its own shape — an override beside
         // it would state it twice.
         assert!(
-            HttpDriver::contribution_envelope(&[serde_json::json!({
-                "_type": "ORIGINAL_VERSION",
-                "data": { "_type": "ORIGINAL_VERSION" }
-            })])
+            HttpDriver::contribution_envelope(
+                &[serde_json::json!({
+                    "_type": "ORIGINAL_VERSION",
+                    "data": { "_type": "ORIGINAL_VERSION" }
+                })],
+                None
+            )
             .is_err()
         );
         // An attestation member commits no version, so it has no lifecycle.
         assert!(
-            HttpDriver::contribution_envelope(&[serde_json::json!({
-                "change_type": "attestation",
-                "lifecycle_state": "complete",
-                "attestation": { "is_pending": false }
-            })])
+            HttpDriver::contribution_envelope(
+                &[serde_json::json!({
+                    "change_type": "attestation",
+                    "lifecycle_state": "complete",
+                    "attestation": { "is_pending": false }
+                })],
+                None
+            )
             .is_err()
         );
+    }
+
+    /// A case's `audit:` override states only its delta against the derived
+    /// commit audit, and the `absent` sentinel omits a member outright — the
+    /// seam the mandatory-member refusals need (RM common
+    /// `UML/classes/org.openehr.rm.common.audit_details.adoc` §Attributes:
+    /// `change_type` and `committer` are 1..1; released OAS
+    /// `specifications/schemas/common/UpdateAudit.yaml` §required lists both).
+    #[test]
+    fn a_case_overrides_or_omits_the_commit_audit() {
+        let member = serde_json::json!({ "data": { "_type": "COMPOSITION" } });
+        let build = |audit: Option<Value>| {
+            HttpDriver::contribution_envelope(std::slice::from_ref(&member), audit.as_ref())
+        };
+
+        // No override: the derived audit, unchanged.
+        let derived = build(None).expect("the derived envelope builds");
+        assert_eq!(derived["audit"]["change_type"]["value"], "creation");
+        assert_eq!(derived["audit"]["committer"]["name"], "cnf runner");
+
+        // `absent` omits the member entirely — the omitted-change_type and
+        // omitted-committer refusal shapes.
+        let omitted = build(Some(serde_json::json!({ "change_type": "absent" })))
+            .expect("the omission builds");
+        assert!(omitted["audit"].get("change_type").is_none(), "{omitted}");
+        assert!(omitted["audit"].get("committer").is_some(), "{omitted}");
+        let omitted =
+            build(Some(serde_json::json!({ "committer": "absent" }))).expect("the omission builds");
+        assert!(omitted["audit"].get("committer").is_none(), "{omitted}");
+
+        // A verbatim value replaces the derived one — an out-of-group
+        // `change_type` code the closed vocabulary cannot spell.
+        let overridden = build(Some(serde_json::json!({
+            "change_type": {
+                "_type": "DV_CODED_TEXT",
+                "value": "not a change type",
+                "defining_code": {
+                    "_type": "CODE_PHRASE",
+                    "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" },
+                    "code_string": "999"
+                }
+            }
+        })))
+        .expect("the override builds");
+        assert_eq!(
+            overridden["audit"]["change_type"]["defining_code"]["code_string"],
+            "999"
+        );
+
+        // A non-object override is refused, never silently ignored.
+        assert!(build(Some(serde_json::json!("nonsense"))).is_err());
     }
 
     /// The identities a `requires.import` mints come from the EXTRACT itself

--- a/tools/cnf-runner/src/run.rs
+++ b/tools/cnf-runner/src/run.rs
@@ -12,7 +12,7 @@ use crate::exec::{CaseRecord, RowOutcome, run_case};
 use crate::ids::{CapabilityName, InstanceName, SmOperationRef};
 use crate::ixit::Ixit;
 use crate::model::assertion::assertion_refs;
-use crate::model::case::CaseCore;
+use crate::model::case::{CaseCore, PartyRelationshipRequirement};
 use crate::refgrammar::{IxitField, ValueRef};
 use crate::vocab::CaseStatus;
 
@@ -237,12 +237,72 @@ fn unservable_import(
     ) {
         return None;
     }
-    let statement = statement?;
     // Either receiving situation of master06 §Copying drives the same family;
     // whichever binding the catalogue realizes names it.
-    let decl = ["import_ehr_extract", "import_ehr"]
-        .into_iter()
-        .filter_map(|call| SmOperationRef::parse(&format!("I_EHR_EXTRACT_SERVICE.{call}")).ok())
+    unservable_provisioning(
+        set,
+        statement,
+        &[
+            "I_EHR_EXTRACT_SERVICE.import_ehr_extract",
+            "I_EHR_EXTRACT_SERVICE.import_ehr",
+        ],
+        "requires.import",
+        "the received version this case reads cannot exist here",
+    )
+}
+
+/// Why THIS party cannot have a `requires.party_relationship` case driven:
+/// the relationship create is an EXTENSION route (ITS-REST 1.1.0 surfaces no
+/// `PARTY_RELATIONSHIP` resource — register AMB-32), exactly as
+/// [`unservable_import`]'s extract replay is, so a party that claims none of
+/// the capabilities that family's cases gate has no relationship to
+/// precondition with.
+fn unservable_party_relationship(
+    set: &ArtifactSet,
+    statement: Option<&crate::party::Statement>,
+    case: &CaseCore,
+) -> Option<String> {
+    if !matches!(
+        case.requires.party_relationship,
+        Some(PartyRelationshipRequirement::Exists { .. })
+    ) {
+        return None;
+    }
+    unservable_provisioning(
+        set,
+        statement,
+        &["I_DEMOGRAPHIC_SERVICE.create_party_relationship"],
+        "requires.party_relationship",
+        "the relationship this case reads cannot exist here",
+    )
+}
+
+/// The shared scoping for a PRECONDITION that provisions over an EXTENSION
+/// route: a party claiming none of the capabilities that family's cases gate
+/// serves no such route, so the precondition cannot be established there.
+///
+/// The scoping is the same law the extension arm of [`selection_exception`]
+/// applies to a case's FLOW, moved to its PRECONDITION: the case's own
+/// subject is a released operation, and driving it against a party that
+/// serves no provisioning route would record a red row for a ground that
+/// party never offered to establish. Excused at SELECTION time — never as a
+/// drive-time provisioning refusal, which reads like a SUT defect.
+///
+/// `operations` are the SM operations whose realized binding declares the
+/// family (the first one the catalogue realizes decides); `requirement` names
+/// the precondition for the citation, and `consequence` says what the case
+/// therefore cannot read.
+fn unservable_provisioning(
+    set: &ArtifactSet,
+    statement: Option<&crate::party::Statement>,
+    operations: &[&str],
+    requirement: &str,
+    consequence: &str,
+) -> Option<String> {
+    let statement = statement?;
+    let decl = operations
+        .iter()
+        .filter_map(|call| SmOperationRef::parse(call).ok())
         .find_map(|op| {
             set.bindings
                 .iter()
@@ -258,9 +318,9 @@ fn unservable_import(
         return None;
     }
     Some(format!(
-        "requires.import provisions over the {} extension routes ({}): the ICS claims none of \
+        "{requirement} provisions over the {} extension routes ({}): the ICS claims none of \
          the capabilities those routes' cases gate ({}), and no openEHR specification governs \
-         them, so the received version this case reads cannot exist here",
+         them, so {consequence}",
         decl.family,
         decl.ambiguity,
         claiming
@@ -477,6 +537,39 @@ fn not_applicable_record(case: &CaseCore, citation: &str) -> CaseRecord {
 /// party/deployment, or `None` when the case drives. Each arm carries its
 /// citation inside the returned [`Exception`]; the caller records the same
 /// citation as the case's single not-applicable row.
+/// The EXTENSION arm of [`selection_exception`], covering both places an
+/// extension route can enter a case: its FLOW (the case drives the route) and
+/// its PRECONDITION (a received EHR-Extract, a provisioned party
+/// relationship).
+///
+/// A route no openEHR specification governs is our own design/extension, so it
+/// is behaviour only a party that CLAIMS the capability answers for. Driving it
+/// at another vendor's SUT would publish failures for routes that vendor never
+/// offered to serve — the published comparison must be honest in both
+/// directions, and a spurious red row is not honesty.
+fn unserved_extension(
+    set: &ArtifactSet,
+    statement: Option<&crate::party::Statement>,
+    case: &CaseCore,
+) -> Option<String> {
+    if let Some(stmt) = statement
+        && let Some(family) = extension_family(set, case)
+        && !case
+            .capabilities
+            .iter()
+            .any(|c| stmt.claims.capabilities.contains(c))
+    {
+        return Some(format!(
+            "extension realization ({family}): the ICS claims none of this case's \
+             capabilities, and no openEHR specification governs the route — ISO/IEC 9646 \
+             test selection"
+        ));
+    }
+    unservable_import(set, statement, case)
+        .or_else(|| unservable_party_relationship(set, statement, case))
+        .map(|citation| format!("{citation} — ISO/IEC 9646 test selection"))
+}
+
 fn selection_exception(
     set: &ArtifactSet,
     ixit: &Ixit,
@@ -486,31 +579,8 @@ fn selection_exception(
     if let Some(citation) = fully_unrealized(set, case) {
         return Some(Exception::Unrealized(citation));
     }
-    // The EXTENSION arm: a case that drives a route no openEHR specification
-    // governs is our own design/extension, so it is behaviour only a party
-    // that CLAIMS the capability answers for. Driving it at another vendor's
-    // SUT would publish failures for routes that vendor never offered to
-    // serve — the published comparison must be honest in both directions,
-    // and a spurious red row is not honesty.
-    if let Some(stmt) = statement
-        && let Some(family) = extension_family(set, case)
-        && !case
-            .capabilities
-            .iter()
-            .any(|c| stmt.claims.capabilities.contains(c))
-    {
-        return Some(Exception::Unrealized(format!(
-            "extension realization ({family}): the ICS claims none of this case's \
-             capabilities, and no openEHR specification governs the route — ISO/IEC 9646 \
-             test selection"
-        )));
-    }
-    // The same arm for a case whose PRECONDITION (rather than flow) is
-    // established over an extension route: a received EHR-Extract.
-    if let Some(citation) = unservable_import(set, statement, case) {
-        return Some(Exception::Unrealized(format!(
-            "{citation} — ISO/IEC 9646 test selection"
-        )));
+    if let Some(citation) = unserved_extension(set, statement, case) {
+        return Some(Exception::Unrealized(citation));
     }
     // An option branch the party statement does not declare is not this
     // SUT's behaviour — driving it records a spurious failure the verdict
@@ -1037,6 +1107,108 @@ mod tests {
         }))
         .unwrap();
         assert!(unservable_import(&set, Some(&read_only), &plain).is_none());
+    }
+
+    /// `requires.party_relationship` provisions over the SAME extension seam
+    /// as `requires.import` (register AMB-32: ITS-REST 1.1.0 surfaces no
+    /// `PARTY_RELATIONSHIP` resource), so a party claiming none of that
+    /// family's capabilities is excused at SELECTION time with the citation —
+    /// never driven into a provisioning refusal that reads like a SUT defect.
+    #[test]
+    fn a_party_relationship_precondition_is_scoped_at_selection() {
+        let create: crate::model::binding::OperationBinding =
+            serde_json::from_value(serde_json::json!({
+                "sm_operation": "I_DEMOGRAPHIC_SERVICE.create_party_relationship",
+                "its": "its-rest",
+                "extension": {
+                    "family": "party-relationship",
+                    "reason": "the release surfaces no PARTY_RELATIONSHIP resource",
+                    "source": "SM docs/UML/classes/i_demographic_service.adoc",
+                    "ambiguity": "AMB-32"
+                },
+                "request": { "method": "POST", "path": "/demographic/party_relationship" },
+                "outcomes": { "created": { "status": 201 } }
+            }))
+            .unwrap();
+        let released: crate::model::binding::OperationBinding =
+            serde_json::from_value(serde_json::json!({
+                "sm_operation": "I_PARTY.get_party",
+                "its": "its-rest",
+                "request": { "method": "GET", "path": "/demographic/party/{party_id}" },
+                "outcomes": { "ok": { "status": 200 } }
+            }))
+            .unwrap();
+        // The family's own case is what says which capability claims it.
+        let creator: CaseCore = serde_json::from_value(serde_json::json!({
+            "id": "X-rel", "kind": "functional", "component": "DEMOGRAPHIC",
+            "sm_operation": "I_DEMOGRAPHIC_SERVICE.create_party_relationship",
+            "test_purpose": "t", "description": "d", "spec_refs": [],
+            "capabilities": ["PartyRelationships"],
+            "flow": [{ "step": 1, "call": "create_party_relationship", "expect": "created" }]
+        }))
+        .unwrap();
+        let mut set = ArtifactSet::default();
+        set.bindings
+            .push((std::path::PathBuf::from("c.yaml"), create));
+        set.bindings
+            .push((std::path::PathBuf::from("r.yaml"), released));
+        set.cases
+            .push((std::path::PathBuf::from("c-case.yaml"), creator));
+
+        let reader: CaseCore = serde_json::from_value(serde_json::json!({
+            "id": "X-party-read", "kind": "functional", "component": "DEMOGRAPHIC",
+            "sm_operation": "I_PARTY.get_party",
+            "test_purpose": "t", "description": "d", "spec_refs": [],
+            "capabilities": ["Demographics"],
+            "requires": {
+                "party_relationship": {
+                    "source": "cnf.demographic.person.v1",
+                    "target": "cnf.demographic.organisation.v1",
+                    "relationship": "cnf.demographic.party_relationship.v1"
+                }
+            },
+            "flow": [{ "step": 1, "call": "get_party", "expect": "ok" }]
+        }))
+        .unwrap();
+        let statement = |caps: &[&str]| -> crate::party::Statement {
+            serde_json::from_value(serde_json::json!({
+                "product": { "name": "p", "version": "1", "vendor": "v", "identifier": "i" },
+                "schedule_release": "CNF-2.0",
+                "spec_versions": { "rm": "1.2.0", "its_rest": "1.1.0" },
+                "claims": { "capabilities": caps, "profiles": ["CORE"] },
+                "tech_profiles": [ { "its": "its-rest", "formats": ["canonical-json"] } ],
+                "options": []
+            }))
+            .unwrap()
+        };
+        let serving = statement(&["PartyRelationships", "Demographics"]);
+        assert!(
+            unservable_party_relationship(&set, Some(&serving), &reader).is_none(),
+            "a party claiming the family's capability drives the case"
+        );
+
+        // Claims the READ capability but not the relationship family — the
+        // case's own capabilities must not be what decides this.
+        let read_only = statement(&["Demographics"]);
+        let citation = unservable_party_relationship(&set, Some(&read_only), &reader)
+            .expect("excused with a citation");
+        assert!(citation.contains("party-relationship"), "{citation}");
+        assert!(
+            citation.contains("AMB-32"),
+            "the citation stays register-linked: {citation}"
+        );
+
+        // `party_relationship: none` provisions nothing and is untouched.
+        let plain: CaseCore = serde_json::from_value(serde_json::json!({
+            "id": "X-plain-party", "kind": "functional", "component": "DEMOGRAPHIC",
+            "sm_operation": "I_PARTY.get_party",
+            "test_purpose": "t", "description": "d", "spec_refs": [],
+            "capabilities": ["Demographics"],
+            "requires": { "party_relationship": "none" },
+            "flow": [{ "step": 1, "call": "get_party", "expect": "ok" }]
+        }))
+        .unwrap();
+        assert!(unservable_party_relationship(&set, Some(&read_only), &plain).is_none());
     }
 
     /// The SMART-lane marker is the DECLARATION of a `scopes:` key (empty

--- a/tools/cnf-runner/src/validate.rs
+++ b/tools/cnf-runner/src/validate.rs
@@ -225,6 +225,9 @@ pub fn validate(ctx: &Context<'_>) -> Vec<Finding> {
         }
     }
     check_corpus_integrity(ctx.set, &mut findings);
+    if let Some(spec) = spec.as_ref() {
+        check_corpus_spec_refs(ctx.set, spec, &mut findings);
+    }
     check_vocab_drift(ctx.set, &mut findings);
     check_journey_envelope(ctx.set, &mut findings);
     check_claim_completeness(ctx.set, &mut findings);
@@ -1496,6 +1499,10 @@ fn check_links(case: &CaseCore, who: &str, set: &ArtifactSet, findings: &mut Vec
 /// could not be read.
 type InterfaceOperations = Result<Rc<[String]>, String>;
 
+/// A memoized section-name lookup: the component-relative document, and how
+/// many `include::` levels below it were followed.
+type SectionKey = (PathBuf, u8);
+
 /// A memoizing reader over the vendored spec tree.
 ///
 /// The citation-resolution gates ask the same questions once per case: the
@@ -1511,10 +1518,25 @@ struct SpecIndex<'a> {
     root: &'a Path,
     /// `path → file text`, or the io error's display text.
     texts: RefCell<BTreeMap<PathBuf, Result<Rc<str>, String>>>,
-    /// `(component dir, lowercased token) → any path under the dir matches`.
-    tokens: RefCell<BTreeMap<(PathBuf, String), bool>>,
+    /// `component dir → its file listing + basename index`.
+    components: RefCell<BTreeMap<PathBuf, Rc<ComponentFiles>>>,
+    /// `(document, include depth) → the section names it offers`.
+    sections: RefCell<BTreeMap<SectionKey, Rc<BTreeSet<String>>>>,
+    /// `document directory → the asciidoc attributes its book files define`.
+    attributes: RefCell<BTreeMap<PathBuf, Rc<BTreeMap<String, String>>>>,
     /// `interface → its parsed SM operation names`.
     interfaces: RefCell<BTreeMap<String, InterfaceOperations>>,
+}
+
+/// One vendored component directory's file listing, indexed for the two
+/// lookups citation resolution needs.
+#[derive(Debug, Default)]
+struct ComponentFiles {
+    /// Every file under the component dir: its lowercased, `/`-joined
+    /// component-relative path paired with the real relative path.
+    all: Vec<(String, PathBuf)>,
+    /// Lowercased file name → the component-relative paths carrying it.
+    by_name: BTreeMap<String, Vec<PathBuf>>,
 }
 
 impl<'a> SpecIndex<'a> {
@@ -1523,7 +1545,9 @@ impl<'a> SpecIndex<'a> {
         Self {
             root,
             texts: RefCell::new(BTreeMap::new()),
-            tokens: RefCell::new(BTreeMap::new()),
+            components: RefCell::new(BTreeMap::new()),
+            sections: RefCell::new(BTreeMap::new()),
+            attributes: RefCell::new(BTreeMap::new()),
             interfaces: RefCell::new(BTreeMap::new()),
         }
     }
@@ -1547,16 +1571,159 @@ impl<'a> SpecIndex<'a> {
         result
     }
 
-    /// Case-insensitive substring match of `token` against any path under
-    /// `dir`, once per `(dir, token)` pair.
-    fn contains_token(&self, dir: &Path, token: &str) -> bool {
-        let key = (dir.to_owned(), token.to_owned());
-        if let Some(hit) = self.tokens.borrow().get(&key) {
-            return *hit;
+    /// One component directory's file listing, walked once per run.
+    fn component_files(&self, dir: &Path) -> Rc<ComponentFiles> {
+        if let Some(hit) = self.components.borrow().get(dir) {
+            return Rc::clone(hit);
         }
-        let hit = path_contains_token(dir, token);
-        self.tokens.borrow_mut().insert(key, hit);
-        hit
+        let mut listing = ComponentFiles::default();
+        let mut stack = vec![dir.to_owned()];
+        while let Some(current) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&current) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                    continue;
+                }
+                let Ok(relative) = path.strip_prefix(dir) else {
+                    continue;
+                };
+                let lowered = relative
+                    .components()
+                    .filter_map(|c| c.as_os_str().to_str())
+                    .collect::<Vec<_>>()
+                    .join("/")
+                    .to_lowercase();
+                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                    listing
+                        .by_name
+                        .entry(name.to_lowercase())
+                        .or_default()
+                        .push(relative.to_owned());
+                }
+                listing.all.push((lowered, relative.to_owned()));
+            }
+        }
+        listing.all.sort();
+        let listing = Rc::new(listing);
+        self.components
+            .borrow_mut()
+            .insert(dir.to_owned(), Rc::clone(&listing));
+        listing
+    }
+
+    /// The asciidoc attributes the book files of one document directory define
+    /// (`:pkg: org.openehr.rm.common.` and friends), read once per directory.
+    /// They are what an `include::{uml_export_dir}/classes/{pkg}x.adoc[]`
+    /// directive is resolved through.
+    fn attributes(&self, dir: &Path) -> Rc<BTreeMap<String, String>> {
+        if let Some(hit) = self.attributes.borrow().get(dir) {
+            return Rc::clone(hit);
+        }
+        let mut attributes = BTreeMap::new();
+        for book in ["master.adoc", "manifest_vars.adoc"] {
+            let Ok(text) = self.read(&dir.join(book)) else {
+                continue;
+            };
+            for line in text.lines() {
+                let Some(rest) = line.strip_prefix(':') else {
+                    continue;
+                };
+                let Some((name, value)) = rest.split_once(':') else {
+                    continue;
+                };
+                if !name.is_empty()
+                    && name
+                        .chars()
+                        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-'))
+                {
+                    attributes
+                        .entry(name.to_owned())
+                        .or_insert_with(|| value.trim().to_owned());
+                }
+            }
+        }
+        let attributes = Rc::new(attributes);
+        self.attributes
+            .borrow_mut()
+            .insert(dir.to_owned(), Rc::clone(&attributes));
+        attributes
+    }
+
+    /// The section names one vendored document offers, transitively through
+    /// its `include::` directives (the class and interface tables live in the
+    /// component's `UML/classes` export and are pulled into the chapter that
+    /// documents them, so a chapter's section space is not what its own file
+    /// literally contains).
+    fn document_sections(&self, component: &Path, relative: &Path) -> Rc<BTreeSet<String>> {
+        self.sections_at_depth(component, relative, INCLUDE_DEPTH)
+    }
+
+    fn sections_at_depth(
+        &self,
+        component: &Path,
+        relative: &Path,
+        depth: u8,
+    ) -> Rc<BTreeSet<String>> {
+        let key = (relative.to_owned(), depth);
+        if let Some(hit) = self.sections.borrow().get(&key) {
+            return Rc::clone(hit);
+        }
+        // Insert the empty set first: a cyclic include then terminates.
+        self.sections
+            .borrow_mut()
+            .insert(key.clone(), Rc::new(BTreeSet::new()));
+        let path = component.join(relative);
+        let mut names = BTreeSet::new();
+        if let Ok(text) = self.read(&path) {
+            let yaml = matches!(
+                path.extension().and_then(|e| e.to_str()),
+                Some("yaml" | "yml" | "json")
+            );
+            if yaml {
+                names.extend(structured_keys(&text));
+            } else {
+                names.extend(asciidoc_section_names(&text));
+                if depth > 0 {
+                    let directory = path.parent().unwrap_or(component).to_owned();
+                    let attributes = self.attributes(&directory);
+                    for target in include_targets(&text, &attributes) {
+                        for included in self.included_files(component, &target) {
+                            names.extend(
+                                self.sections_at_depth(component, &included, depth - 1)
+                                    .iter()
+                                    .cloned(),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+        let names = Rc::new(names);
+        self.sections.borrow_mut().insert(key, Rc::clone(&names));
+        names
+    }
+
+    /// The vendored files one `include::` target names. The vendored tree
+    /// carries no boilerplate directory, so `{ref_dir}`-style attributes stay
+    /// unresolved: the target is matched by file name, and a still-unresolved
+    /// prefix (`{pkg}extract_manifest.adoc`) by name suffix.
+    fn included_files(&self, component: &Path, target: &str) -> Vec<PathBuf> {
+        let name = target.rsplit('/').next().unwrap_or(target).to_lowercase();
+        let files = self.component_files(component);
+        match name.rsplit_once('}') {
+            None => files.by_name.get(&name).cloned().unwrap_or_default(),
+            Some((_, suffix)) if !suffix.is_empty() => files
+                .by_name
+                .iter()
+                .filter(|(candidate, _)| candidate.ends_with(suffix))
+                .flat_map(|(_, paths)| paths.iter().cloned())
+                .collect(),
+            Some(_) => Vec::new(),
+        }
     }
 
     /// The service operations of an SM interface, parsed once per run.
@@ -1570,6 +1737,145 @@ impl<'a> SpecIndex<'a> {
             .insert(interface.to_owned(), result.clone());
         result
     }
+}
+
+/// How deep a document's `include::` graph is followed when its section space
+/// is collected. Two levels reach the chapter's class/interface tables and the
+/// tables those pull in; deeper is book boilerplate.
+const INCLUDE_DEPTH: u8 = 2;
+
+/// The `include::TARGET[]` targets of one asciidoc text, with the document
+/// directory's attributes substituted where they are known.
+fn include_targets(text: &str, attributes: &BTreeMap<String, String>) -> Vec<String> {
+    let mut out = Vec::new();
+    for line in text.lines() {
+        let Some(rest) = line.trim_start().strip_prefix("include::") else {
+            continue;
+        };
+        let Some((target, _)) = rest.split_once('[') else {
+            continue;
+        };
+        let mut target = target.to_owned();
+        for (name, value) in attributes {
+            if value.is_empty() {
+                continue;
+            }
+            target = target.replace(&format!("{{{name}}}"), value);
+        }
+        out.push(target);
+    }
+    out
+}
+
+/// The section names one asciidoc/markdown text offers: `=`/`#` headings (plus
+/// the bare class/interface name of a `X Class` heading), block anchors, and
+/// the labelled cells of the UML class tables (`h|*Attributes*`,
+/// `|*upload_opt* (`) — the class exports carry their attribute, function and
+/// invariant sections as table labels, not as headings.
+fn asciidoc_section_names(text: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if let Some(heading) = trimmed
+            .strip_prefix('=')
+            .or_else(|| trimmed.strip_prefix('#'))
+        {
+            let heading = heading.trim_start_matches(['=', '#']).trim();
+            if !heading.is_empty() {
+                let name = normalize_section(heading);
+                for suffix in [" class", " interface", " enumeration"] {
+                    if let Some(bare) = name.strip_suffix(suffix) {
+                        out.insert(bare.to_owned());
+                    }
+                }
+                out.insert(name);
+            }
+        }
+        if let Some(anchor) = trimmed.strip_prefix("[[").or_else(|| {
+            trimmed
+                .strip_prefix("[#")
+                .filter(|rest| rest.starts_with(|c: char| c.is_ascii_alphabetic() || c == '_'))
+        }) {
+            let anchor = anchor
+                .split([',', ']'])
+                .next()
+                .unwrap_or_default()
+                .trim_start_matches('_');
+            if !anchor.is_empty() {
+                out.insert(normalize_section(anchor));
+            }
+        }
+        // The AM validity rules are anchored blocks, not headings:
+        // `[.rule,id=VCACA]` names the section a citation addresses.
+        if let Some(attributes) = trimmed.strip_prefix('[').and_then(|r| r.strip_suffix(']')) {
+            for attribute in attributes.split(',') {
+                if let Some(id) = attribute.trim().strip_prefix("id=") {
+                    let id = id.trim_matches(['"', '\'']);
+                    if !id.is_empty() {
+                        out.insert(normalize_section(id));
+                    }
+                }
+            }
+        }
+        if let Some(label) = table_cell_label(trimmed) {
+            out.insert(label);
+        }
+        // An asciidoc block title (`.Parser grammar`) labels the block a
+        // citation addresses when the chapter has no heading for it.
+        if let Some(title) = trimmed.strip_prefix('.')
+            && title.starts_with(|c: char| c.is_ascii_alphabetic())
+            && !title.contains('|')
+        {
+            out.insert(normalize_section(title));
+        }
+        // The ITS-REST markdown chapters carry their own title in a comment
+        // line rather than a `#` heading, and a citation names that title.
+        if let Some(rest) = trimmed.strip_prefix("[comment]: # (title:")
+            && let Some((title, _)) = rest.split_once(')')
+        {
+            out.insert(normalize_section(title));
+        }
+    }
+    out
+}
+
+/// The bolded label of an asciidoc table cell (`h|*Attributes*`,
+/// `2+^h|*OBJECT_REF*`, `|*upload_opt* ( +`), normalized.
+fn table_cell_label(line: &str) -> Option<String> {
+    let (prefix, rest) = line.split_once("|*")?;
+    if !prefix
+        .chars()
+        .all(|c| c.is_ascii_digit() || matches!(c, '+' | '^' | '<' | '>' | 'h' | 'a' | 'm' | 's'))
+    {
+        return None;
+    }
+    let label = rest.split('*').next()?.trim();
+    if label.is_empty() || !label.starts_with(|c: char| c.is_ascii_alphabetic() || c == '_') {
+        return None;
+    }
+    Some(normalize_section(label))
+}
+
+/// The keys of a YAML/JSON document (the OAS operation, response and schema
+/// files a citation addresses by key, e.g. `§requestBody`, `§'409'`).
+fn structured_keys(text: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    for line in text.lines() {
+        let trimmed = line.trim_start().trim_start_matches("- ");
+        let key = trimmed.trim_start_matches(['\'', '"']);
+        let Some((key, _)) = key.split_once(':') else {
+            continue;
+        };
+        let key = key.trim_end_matches(['\'', '"']);
+        if !key.is_empty()
+            && key
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | '$'))
+        {
+            out.insert(normalize_section(key));
+        }
+    }
+    out
 }
 
 fn sm_class_file(spec_root: &Path, interface: &str) -> PathBuf {
@@ -1678,73 +1984,298 @@ fn component_dir(token: &str) -> Option<&'static str> {
     })
 }
 
-fn check_spec_refs(case: &CaseCore, who: &str, spec: &SpecIndex<'_>, findings: &mut Vec<Finding>) {
-    for citation in &case.spec_refs {
-        let mut tokens = citation.split_whitespace();
-        let Some(component) = tokens.next() else {
-            push(findings, CheckId::SpecRef, who, "empty spec_ref".to_owned());
-            continue;
-        };
-        let Some(dir) = component_dir(component) else {
-            push(
-                findings,
-                CheckId::SpecRef,
-                who,
-                format!("{citation:?}: unknown component {component:?}"),
-            );
-            continue;
-        };
-        let root = spec.root().join(dir);
-        if !root.is_dir() {
-            push(
-                findings,
-                CheckId::SpecRef,
-                who,
-                format!(
-                    "{citation:?}: vendored component dir {} missing",
-                    root.display()
-                ),
-            );
+/// Marker tokens a citation may carry between the component and its path
+/// hint: they name the SOURCE the claim is grounded on, not a path segment.
+/// `OAS` is the one in use — the oracle order requires an OAS-only ground to
+/// be cited AS the OAS (`.claude/rules/spec-adherence.md`).
+const CITATION_SOURCE_MARKERS: [&str; 1] = ["OAS"];
+
+/// One `<COMPONENT> <path hint> §<section>` clause of a citation. A citation
+/// may carry several, separated by `;` or ` + `.
+#[derive(Debug)]
+struct CitationClause<'a> {
+    /// The component token opening the clause.
+    component: &'a str,
+    /// The path-hint tokens naming the document (possibly empty: a
+    /// component-only citation).
+    tokens: Vec<&'a str>,
+    /// The `§`-introduced section names, in citation order.
+    sections: Vec<&'a str>,
+}
+
+/// Whether a token can be part of a path hint (a file/directory name, or a
+/// `/`-joined path). Prose stops the hint.
+fn path_like(token: &str) -> bool {
+    !token.is_empty()
+        && token.chars().all(|c| {
+            c.is_ascii_alphanumeric()
+                || matches!(c, '.' | '_' | '/' | '-' | '{' | '}' | ',' | '*' | '+')
+        })
+}
+
+/// Split a citation into its component clauses. A citation cites several
+/// documents by separating the clauses with `;` or ` + `; a fragment that does
+/// not open with a known component is commentary on the preceding clause and
+/// is dropped. A citation naming no component at all yields one clause so the
+/// unknown-component finding still fires.
+fn citation_clauses(citation: &str) -> Vec<CitationClause<'_>> {
+    let mut clauses = Vec::new();
+    for semi in citation.split(';') {
+        for fragment in semi.split(" + ") {
+            let fragment = fragment.trim();
+            let mut words = fragment.split_whitespace();
+            let Some(component) = words.next() else {
+                continue;
+            };
+            if component_dir(component).is_none() {
+                continue;
+            }
+            let mut tokens = Vec::new();
+            for word in words {
+                if word.contains('§') || !path_like(word) {
+                    break;
+                }
+                let word = word.trim_end_matches([',', '.']);
+                if word.is_empty() || CITATION_SOURCE_MARKERS.contains(&word) {
+                    continue;
+                }
+                tokens.push(word);
+            }
+            let sections = fragment
+                .split('§')
+                .skip(1)
+                .map(|rest| {
+                    let rest = rest.trim_start();
+                    match rest.strip_prefix('"') {
+                        Some(quoted) => quoted.split('"').next().unwrap_or(quoted),
+                        None => rest,
+                    }
+                })
+                .filter(|s| !s.trim().is_empty())
+                .collect();
+            clauses.push(CitationClause {
+                component,
+                tokens,
+                sections,
+            });
+        }
+    }
+    if clauses.is_empty() {
+        let component = citation.split_whitespace().next().unwrap_or("");
+        clauses.push(CitationClause {
+            component,
+            tokens: Vec::new(),
+            sections: Vec::new(),
+        });
+    }
+    clauses
+}
+
+/// The vendored documents one path hint names, or `None` when it names none.
+///
+/// Every token must appear in the file's component-relative path, and the LAST
+/// token must name the target: the file name equals it, starts with it
+/// (`master06` → `master06-change_control.adoc`), ends with `.`+it (the
+/// `org.openehr.rm.common.locatable.adoc` UML class-export convention), or it
+/// names one of the file's parent directories — a chapter directory, whose
+/// every file is then a target.
+fn resolve_documents(spec: &SpecIndex<'_>, dir: &Path, tokens: &[&str]) -> Vec<PathBuf> {
+    let Some(last) = tokens.last() else {
+        return Vec::new();
+    };
+    let lowered: Vec<String> = tokens.iter().map(|t| t.to_lowercase()).collect();
+    let last = last.rsplit('/').next().unwrap_or(last).to_lowercase();
+    let files = spec.component_files(dir);
+    let mut out = Vec::new();
+    for (lowered_path, path) in &files.all {
+        if !lowered
+            .iter()
+            .all(|token| lowered_path.contains(token.as_str()))
+        {
             continue;
         }
-        // The document token: the first token before the § section marker.
-        let doc_token = tokens.next().map(|t| t.trim_end_matches(',').to_owned());
-        let Some(doc_token) = doc_token.filter(|t| !t.starts_with('§')) else {
-            continue; // component-only citation: dir existence was the check
-        };
-        if !spec.contains_token(&root, &doc_token.to_lowercase()) {
-            push(
-                findings,
-                CheckId::SpecRef,
-                who,
-                format!("{citation:?}: no vendored path under {dir} matches {doc_token:?}"),
-            );
+        let mut segments = lowered_path.split('/');
+        let name = segments.next_back().unwrap_or_default();
+        let names_file =
+            name == last || name.starts_with(&last) || name.ends_with(&format!(".{last}"));
+        if names_file || segments.any(|segment| segment == last) {
+            out.push(path.clone());
+        }
+    }
+    out
+}
+
+/// Normalize a section name (cited or vendored) for comparison: lowercase,
+/// asciidoc emphasis and underscores flattened to spaces, quotes dropped,
+/// whitespace collapsed.
+fn normalize_section(text: &str) -> String {
+    let mut out = String::new();
+    let mut pending_space = false;
+    for ch in text.chars() {
+        match ch {
+            '"' | '\'' | '‘' | '’' | '“' | '”' => {}
+            '`' | '*' | '_' | '\u{a0}' => pending_space = !out.is_empty(),
+            c if c.is_whitespace() => pending_space = !out.is_empty(),
+            c => {
+                if pending_space {
+                    out.push(' ');
+                    pending_space = false;
+                }
+                out.extend(c.to_lowercase());
+            }
+        }
+    }
+    out
+}
+
+/// The forms a cited section may take once its trailing commentary is cut:
+/// citations routinely append a parenthetical, an em-dash gloss, or a
+/// qualifier after the heading proper.
+fn section_candidates(section: &str) -> BTreeSet<String> {
+    let full = normalize_section(section);
+    let mut out = BTreeSet::new();
+    let mut add = |text: &str| {
+        let text = text
+            .trim()
+            .trim_end_matches([',', ';', '.', '/', '-', ':'])
+            .trim();
+        if !text.is_empty() {
+            out.insert(text.to_owned());
+        }
+    };
+    for cut in [" (", " — ", " -- ", " - ", ", ", ": ", "; ", " §"] {
+        if let Some((head, _)) = full.split_once(cut) {
+            add(head);
+        }
+    }
+    if let Some((head, _)) = full.split_once('.') {
+        add(head);
+    }
+    add(&full);
+    out
+}
+
+/// Whether one cited section resolves against a document's section names.
+/// Equality first; a longer cited form may carry a section name inside it
+/// (`I_DEFINITION_ADL14.upload_opt`), and a section name may carry the cited
+/// form inside it (`OBJECT_REF Class`).
+fn section_resolves(candidates: &BTreeSet<String>, names: &BTreeSet<String>) -> bool {
+    candidates.iter().any(|candidate| {
+        names.iter().any(|name| {
+            name == candidate
+                || (name.len() >= 4 && candidate.contains(name.as_str()))
+                || (candidate.len() >= 3 && name.contains(candidate.as_str()))
+        })
+    })
+}
+
+/// Resolve every citation of one artifact against the vendored spec tree:
+/// the component directory exists, the path hint names a real DOCUMENT, and
+/// every `§section` names a real section of it.
+fn check_citations(
+    citations: &[&str],
+    who: &str,
+    spec: &SpecIndex<'_>,
+    findings: &mut Vec<Finding>,
+) {
+    for citation in citations {
+        if citation.trim().is_empty() {
+            push(findings, CheckId::SpecRef, who, "empty spec_ref".to_owned());
+            continue;
+        }
+        for clause in citation_clauses(citation) {
+            let Some(dir) = component_dir(clause.component) else {
+                push(
+                    findings,
+                    CheckId::SpecRef,
+                    who,
+                    format!("{citation:?}: unknown component {:?}", clause.component),
+                );
+                continue;
+            };
+            let root = spec.root().join(dir);
+            if !root.is_dir() {
+                push(
+                    findings,
+                    CheckId::SpecRef,
+                    who,
+                    format!(
+                        "{citation:?}: vendored component dir {} missing",
+                        root.display()
+                    ),
+                );
+                continue;
+            }
+            if clause.tokens.is_empty() {
+                continue; // component-only citation: dir existence was the check
+            }
+            let documents = resolve_documents(spec, &root, &clause.tokens);
+            if documents.is_empty() {
+                push(
+                    findings,
+                    CheckId::SpecRef,
+                    who,
+                    format!(
+                        "{citation:?}: no vendored document under {dir} matches {:?}",
+                        clause.tokens.join(" ")
+                    ),
+                );
+                continue;
+            }
+            if clause.sections.is_empty() {
+                continue;
+            }
+            let mut names = BTreeSet::new();
+            for document in &documents {
+                names.extend(spec.document_sections(&root, document).iter().cloned());
+            }
+            for section in &clause.sections {
+                if !section_resolves(&section_candidates(section), &names) {
+                    push(
+                        findings,
+                        CheckId::SpecRef,
+                        who,
+                        format!(
+                            "{citation:?}: the {} vendored document(s) matching {:?} carry no \
+                             section matching §{}",
+                            documents.len(),
+                            clause.tokens.join(" "),
+                            section.trim()
+                        ),
+                    );
+                }
+            }
         }
     }
 }
 
-/// Case-insensitive substring match of `token` against any path under `root`.
-fn path_contains_token(root: &Path, token: &str) -> bool {
-    let mut stack = vec![root.to_owned()];
-    while let Some(current) = stack.pop() {
-        let Ok(entries) = std::fs::read_dir(&current) else {
+/// Every citation a case core carries: its own `spec_refs` plus the per-row
+/// grounds of its fixture set.
+fn check_spec_refs(case: &CaseCore, who: &str, spec: &SpecIndex<'_>, findings: &mut Vec<Finding>) {
+    let mut citations: Vec<&str> = case.spec_refs.iter().map(String::as_str).collect();
+    if let Some(fixtures) = case
+        .parameters
+        .as_ref()
+        .and_then(|p| p.fixture_set.as_ref())
+    {
+        citations.extend(fixtures.iter().filter_map(|f| f.spec_ref.as_deref()));
+    }
+    check_citations(&citations, who, spec, findings);
+}
+
+/// The corpus manifest's own citations: every invalid fixture grounds its
+/// defect in a spec rule, and that citation resolves like any other.
+fn check_corpus_spec_refs(set: &ArtifactSet, spec: &SpecIndex<'_>, findings: &mut Vec<Finding>) {
+    let Some((path, manifest)) = &set.corpus else {
+        return;
+    };
+    let who = path.display().to_string();
+    for (key, entry) in manifest.entries() {
+        let Some(citation) = entry.validity.spec_ref.as_deref() else {
             continue;
         };
-        for entry in entries.flatten() {
-            let path = entry.path();
-            let matches = path
-                .file_name()
-                .and_then(|n| n.to_str())
-                .is_some_and(|n| n.to_lowercase().contains(token));
-            if matches {
-                return true;
-            }
-            if path.is_dir() {
-                stack.push(path);
-            }
-        }
+        check_citations(&[citation], &format!("{who} [{key}]"), spec, findings);
     }
-    false
 }
 
 // ── binding completeness ────────────────────────────────────────────────────
@@ -3307,6 +3838,129 @@ h|*1..1*\n\
         );
         // A missing class export is an error, not an empty list.
         assert!(spec.interface_operations("I_ABSENT").is_err());
+    }
+
+    /// A minimal vendored RM tree: one chapter that pulls its class table in
+    /// through the `include::{uml_export_dir}/classes/{pkg}…` indirection the
+    /// real spec uses, plus the class export itself.
+    fn spec_tree_fixture() -> assert_fs::TempDir {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let chapter = dir.path().join("RM/docs/ehr_extract");
+        let classes = dir.path().join("RM/docs/UML/classes");
+        std::fs::create_dir_all(&chapter).unwrap();
+        std::fs::create_dir_all(&classes).unwrap();
+        std::fs::write(
+            chapter.join("master.adoc"),
+            ":pkg: org.openehr.rm.ehr_extract.\n",
+        )
+        .unwrap();
+        std::fs::write(
+            chapter.join("master04-common_package.adoc"),
+            "= Common Package\n\n== Version Specification\n\n\
+             include::{uml_export_dir}/classes/{pkg}extract_manifest.adoc[]\n",
+        )
+        .unwrap();
+        std::fs::write(
+            classes.join("org.openehr.rm.ehr_extract.extract_manifest.adoc"),
+            "=== EXTRACT_MANIFEST Class\n\n|===\nh|*Attributes*\nh|*1..1*\n\
+             |*entities*: `List<EXTRACT_ENTITY_MANIFEST>`\n|===\n",
+        )
+        .unwrap();
+        dir
+    }
+
+    fn citation_findings(citation: &str, spec: &SpecIndex<'_>) -> Vec<Finding> {
+        let mut findings = Vec::new();
+        check_citations(&[citation], "T-1", spec, &mut findings);
+        findings
+    }
+
+    #[test]
+    fn spec_ref_gate_resolves_documents_and_sections() {
+        let dir = spec_tree_fixture();
+        let spec = SpecIndex::new(dir.path());
+
+        // The chapter resolves, and so does a section it declares itself.
+        assert!(
+            citation_findings(
+                "RM ehr_extract master04-common_package §Version Specification",
+                &spec
+            )
+            .is_empty()
+        );
+        // A section the chapter only carries THROUGH its class-table include
+        // resolves too — the included table is part of the document.
+        assert!(
+            citation_findings(
+                "RM ehr_extract master04-common_package §EXTRACT_MANIFEST",
+                &spec
+            )
+            .is_empty()
+        );
+        // So does a class-table label, and the class export addressed directly.
+        assert!(
+            citation_findings(
+                "RM ehr_extract UML/classes/org.openehr.rm.ehr_extract.extract_manifest.adoc \
+                 §Attributes (entities 1..1)",
+                &spec
+            )
+            .is_empty()
+        );
+        // A component-only citation checks the component directory alone.
+        assert!(citation_findings("RM", &spec).is_empty());
+    }
+
+    #[test]
+    fn spec_ref_gate_refuses_a_phantom_document() {
+        let dir = spec_tree_fixture();
+        let spec = SpecIndex::new(dir.path());
+        // Seeded defect: the chapter number does not exist. The pre-#1807
+        // gate passed this on the `ehr_extract` token alone.
+        let findings = citation_findings(
+            "RM ehr_extract master99-invented_package §Version Specification",
+            &spec,
+        );
+        assert_eq!(findings.len(), 1, "{findings:?}");
+        let message = &findings.first().unwrap().message;
+        assert!(message.contains("no vendored document"), "{message}");
+        // Seeded defect: a real chapter name under the WRONG component.
+        let findings = citation_findings("BASE ehr_extract master04-common_package", &spec);
+        assert_eq!(findings.len(), 1, "{findings:?}");
+        // Seeded defect: a component that does not exist at all.
+        let findings = citation_findings("NONESUCH master04 §Whatever", &spec);
+        assert_eq!(findings.len(), 1, "{findings:?}");
+        assert!(
+            findings
+                .first()
+                .unwrap()
+                .message
+                .contains("unknown component"),
+            "{findings:?}"
+        );
+    }
+
+    #[test]
+    fn spec_ref_gate_refuses_a_phantom_section() {
+        let dir = spec_tree_fixture();
+        let spec = SpecIndex::new(dir.path());
+        // Seeded defect: the document resolves, the section does not — the
+        // phantom-citation class (#1738): a real chapter plus a §heading that
+        // exists nowhere in it.
+        let findings = citation_findings(
+            "RM ehr_extract master04-common_package §Invented Section",
+            &spec,
+        );
+        assert_eq!(findings.len(), 1, "{findings:?}");
+        let message = &findings.first().unwrap().message;
+        assert!(message.contains("carry no section matching"), "{message}");
+        // Every clause of a multi-document citation is resolved, not just the
+        // first: the second clause's section is the seeded defect here.
+        let findings = citation_findings(
+            "RM ehr_extract master04-common_package §Version Specification; \
+             RM ehr_extract master04-common_package §Invented Section",
+            &spec,
+        );
+        assert_eq!(findings.len(), 1, "{findings:?}");
     }
 
     fn build_set(with_exception: bool) -> ArtifactSet {


### PR DESCRIPTION
Runner/catalogue batch from the close loop: 7 issues landed (3 honest skips stay open with boundary comments). All spec-facing expectations re-derived first-hand from the vendored text; the CNF attribution law respected throughout (no expectation bent to the SUT).

- **#1807** — the spec-ref gate stops substring-matching one token: citations resolve against the real vendored tree (documents/chapter dirs + the full section space: asciidoc/markdown headings, anchors, UML class-table labels, block titles, OAS keys, and `include::{uml_export_dir}` closures at depth ≤ 2, memoized). Fixture rows and the corpus manifest are now gated too. Three seeded-defect tests pin the refusal modes.
- **#1738** — the strengthened gate found 116 findings / 51 distinct phantom citations; 104 occurrences corrected first-hand (SM UML re-points, OAS operation-file forms, real ITS-REST chapter sections, the nonexistent `AM AOM1.4 §C_DV_QUANTITY/§C_DV_SCALE` re-grounded on ADL2 tuple constraints, and four citations of an internal proposal — a banned internal-doc citation — re-grounded on CNF profiles master03 with the our-own-extension flag). Validate: 982 cases, **0 findings**.
- **#1818** — cases can override or omit the CONTRIBUTION commit audit; three new cases pin the merged #1688 behaviour (omitted `change_type` → 422, out-of-group code → 422, conformant twin). En route: the SEC audit-accountability case's authored `audit:` block was being silently dropped by the runner — its key assertion was vacuous for its entire life (sweep filed as its own issue). #1817's committer case now unblocked.
- **#1773** — `party_relationship` requirements scope at selection time; the last raw `change_type` string compare goes typed (`MemberChangeType`).
- **#1774** — AMB-167 re-adjudicated against both XSD bundles: the only published `versioned_object` element is the EXTRACT shape (`X_VERSIONED_OBJECT`); no case floors changed.
- **#1777** — AMB-206 registers the "latest available version across coexisting lineages" spec silence (`fixed_handling`: trunk head; upstream report #1834) with the pinning case `export_ehr_extracts-latest_across_lineages`.
- **#1720** — `scripts/vendor-openehr-sdk-json.sh` (with `--check`), re-run byte-identical; one adjudicated exclusion (an upstream editor backup file). The PROVENANCE upstream pin named a nonexistent repo — the product rename had rewritten the upstream org; corrected, and the rename-damage sweep filed as its own issue.

Capability floors ratchet 978 → 982 cases (`ChangeSets` 84→87, `EhrExtract` 26→27), enforced by the derivation-equality gate.

Gates (main tree): fmt, clippy (`cnf-runner` + `openehr-its`, -D warnings), nextest 879/879, `validate --specs` 982/0, rustdoc. Conformance pipeline rerun deferred per owner directive 2026-08-03.

Closes #1807
Closes #1738
Closes #1818
Closes #1773
Closes #1774
Closes #1777
Closes #1720