### PR TITLE
refactor(app): ITEM_TAG lists carry the typed ItemTag — the first #1694 typed-carrier unit

### DIFF
--- a/app/ferroehr-rest/src/api/demographic/mod.rs
+++ b/app/ferroehr-rest/src/api/demographic/mod.rs
@@ -262,12 +262,12 @@ fn set_item_tag_headers(resp_out: &mut Response, resp: &ServiceResponse) {
             meta.version_item_tags.as_ref(),
         ),
     ] {
-        let Some(serde_json::Value::Array(tags)) = tags else {
+        let Some(tags) = tags else {
             continue;
         };
         let entries: Vec<ItemTagHeaderEntry> = tags
             .iter()
-            .filter_map(crate::overview::params::item_tag_to_header_entry)
+            .map(crate::overview::params::item_tag_to_header_entry)
             .collect();
         if entries.is_empty() {
             continue;

--- a/app/ferroehr-rest/src/api/demographic/party.rs
+++ b/app/ferroehr-rest/src/api/demographic/party.rs
@@ -202,7 +202,7 @@ async fn persist_request_tags(
             .party_tags_update(kind, container_uid, tags)
             .await?;
         if let Some(meta) = resp.meta.as_mut() {
-            meta.item_tags = Some(stored.body);
+            meta.item_tags = Some(stored);
         }
     }
     if let Some(tags) = version_entries {
@@ -211,7 +211,7 @@ async fn persist_request_tags(
             .party_tags_update(kind, version_uid, tags)
             .await?;
         if let Some(meta) = resp.meta.as_mut() {
-            meta.version_item_tags = Some(stored.body);
+            meta.version_item_tags = Some(stored);
         }
     }
     Ok(())

--- a/app/ferroehr-rest/src/api/demographic/tags.rs
+++ b/app/ferroehr-rest/src/api/demographic/tags.rs
@@ -61,8 +61,12 @@ pub(super) async fn run(
                     params::build::<RoleTagsGetParams>(&parts.path, q, h)?.uid_based_id
                 }
             };
-            let resp = state.backend().party_tags_get(kind, uid_based_id).await?;
-            Ok(negotiate::respond(h, StatusCode::OK, &resp.body))
+            let tags = state.backend().party_tags_get(kind, uid_based_id).await?;
+            Ok(negotiate::respond(
+                h,
+                StatusCode::OK,
+                &openehr_its::json::to_canonical_value(&tags),
+            ))
         }
         "tags_update" => {
             let uid_based_id = match kind {
@@ -87,7 +91,7 @@ pub(super) async fn run(
             // member or a non-string `value`/`target_path` is a 400 naming the
             // member, never a silent drop.
             let body = negotiate::typed_json_vec::<UpdateItemTag>(h, &parts.body)?;
-            let resp = state
+            let tags = state
                 .backend()
                 .party_tags_update(kind, uid_based_id, body)
                 .await?;
@@ -99,7 +103,7 @@ pub(super) async fn run(
                 h,
                 StatusCode::NO_CONTENT,
                 StatusCode::OK,
-                &resp.body,
+                &openehr_its::json::to_canonical_value(&tags),
             ))
         }
         "tags_delete" => {
@@ -145,9 +149,13 @@ pub(super) async fn run_collection(
 ) -> Result<Response, RestError> {
     let h = &parts.headers;
     let p = params::build::<DemographicTagsGetParams>(&parts.path, parts.query.as_deref(), h)?;
-    let resp = state
+    let tags = state
         .backend()
         .demographic_tags_get(p.tag_key, p.tag_value, p.tag_target_path)
         .await?;
-    Ok(negotiate::respond(h, StatusCode::OK, &resp.body))
+    Ok(negotiate::respond(
+        h,
+        StatusCode::OK,
+        &openehr_its::json::to_canonical_value(&tags),
+    ))
 }

--- a/app/ferroehr-rest/src/api/ehr/composition.rs
+++ b/app/ferroehr-rest/src/api/ehr/composition.rs
@@ -377,7 +377,11 @@ pub(super) async fn run(
                 .backend()
                 .target_tags_get(ehr_id, p.uid_based_id, "COMPOSITION")
                 .await?;
-            Ok(negotiate::respond(h, ok, &Value::Array(tags)))
+            Ok(negotiate::respond(
+                h,
+                ok,
+                &openehr_its::json::to_canonical_value(&tags),
+            ))
         }
         "composition_tags_update" => {
             let p = params::build::<CompositionTagsUpdateParams>(&parts.path, q, h)?;
@@ -399,7 +403,7 @@ pub(super) async fn run(
                 h,
                 no_content,
                 ok,
-                &Value::Array(tags),
+                &openehr_its::json::to_canonical_value(&tags),
             ))
         }
         "composition_tags_delete" => {

--- a/app/ferroehr-rest/src/api/ehr/ehr_resource.rs
+++ b/app/ferroehr-rest/src/api/ehr/ehr_resource.rs
@@ -91,7 +91,11 @@ pub(super) async fn run(
                 .backend()
                 .ehr_tags_get(ehr_id, p.tag_key, p.tag_value, p.tag_target_path)
                 .await?;
-            Ok(negotiate::respond(h, ok, &Value::Array(tags)))
+            Ok(negotiate::respond(
+                h,
+                ok,
+                &openehr_its::json::to_canonical_value(&tags),
+            ))
         }
         other => Err(RestError(ApiError::Internal(format!(
             "unrouted ehr operation: {other}"

--- a/app/ferroehr-rest/src/api/ehr/ehr_status.rs
+++ b/app/ferroehr-rest/src/api/ehr/ehr_status.rs
@@ -168,7 +168,11 @@ pub(super) async fn run(
                 .backend()
                 .target_tags_get(ehr_id, p.uid_based_id, "EHR_STATUS")
                 .await?;
-            Ok(negotiate::respond(h, ok, &Value::Array(tags)))
+            Ok(negotiate::respond(
+                h,
+                ok,
+                &openehr_its::json::to_canonical_value(&tags),
+            ))
         }
         "ehr_status_tags_update" => {
             let p = params::build::<EhrStatusTagsUpdateParams>(&parts.path, q, h)?;
@@ -190,7 +194,7 @@ pub(super) async fn run(
                 h,
                 no_content,
                 ok,
-                &Value::Array(tags),
+                &openehr_its::json::to_canonical_value(&tags),
             ))
         }
         "ehr_status_tags_delete" => {

--- a/app/ferroehr-rest/src/api/ehr/mod.rs
+++ b/app/ferroehr-rest/src/api/ehr/mod.rs
@@ -50,7 +50,9 @@ use uuid::Uuid;
 use openehr_base::prelude::{ObjectVersionId, TerminologyCode};
 use openehr_its::rest::generated::ehr::UpdateItemTag;
 use openehr_its::rest::runtime::ApiError;
-use openehr_rm::prelude::{DvIdentifier, PartyIdentified, PartyIdentifiedData, PartyProxy};
+use openehr_rm::prelude::{
+    DvIdentifier, ItemTag, PartyIdentified, PartyIdentifiedData, PartyProxy,
+};
 
 use ferroehr::ids::EhrId;
 use ferroehr::service::response::{ResourceMeta, ServiceResponse};
@@ -273,8 +275,8 @@ pub(super) fn version_components(ovid: &ObjectVersionId) -> Result<(Uuid, String
 /// stays after the commit because the tags target the version the commit
 /// mints, and a tag must not re-version the content it annotates. The
 /// entries are folded onto the existing vo-keyed
-/// [`ItemTagAdapter`](ferroehr::service::ItemTagAdapter) `target_tags_replace` seam
-/// (the same seam the dedicated `*_tags_*` operations use).
+/// `FerroEhrService::target_tags_replace` seam (the same seam the dedicated
+/// `*_tags_*` operations use).
 ///
 /// Returns the stored list **per header**, because the two headers address
 /// distinct targets ([`StoredItemTags`]); a header the request did not carry
@@ -425,9 +427,9 @@ fn validated_entries(
 #[derive(Debug, Default)]
 pub(super) struct StoredItemTags {
     /// The `VERSIONED_OBJECT` container's stored tags (`openehr-item-tag`).
-    object: Option<Vec<Value>>,
+    object: Option<Vec<ItemTag>>,
     /// The committed VERSION's own stored tags (`openehr-version-item-tag`).
-    version: Option<Vec<Value>>,
+    version: Option<Vec<ItemTag>>,
 }
 
 /// Echo the stored `ITEM_TAG` lists onto a create/update response — MAY-level
@@ -461,8 +463,7 @@ pub(super) fn echo_item_tags(resp: &mut Response, stored: &StoredItemTags) {
         let Some(tags) = tags else {
             continue;
         };
-        let entries: Vec<ItemTagHeaderEntry> =
-            tags.iter().filter_map(item_tag_to_header_entry).collect();
+        let entries: Vec<ItemTagHeaderEntry> = tags.iter().map(item_tag_to_header_entry).collect();
         if let Some(value) = emit_item_tag_header(&entries) {
             resp.headers_mut()
                 .insert(HeaderName::from_static(name), value);

--- a/app/ferroehr-rest/src/overview/params.rs
+++ b/app/ferroehr-rest/src/overview/params.rs
@@ -390,26 +390,16 @@ pub(crate) fn emit_item_tag_header(entries: &[ItemTagHeaderEntry]) -> Option<Hea
     HeaderValue::from_str(&rendered).ok()
 }
 
-/// Convert one canonical `ITEM_TAG` JSON object (RM `common.item_tag`) into an
-/// [`ItemTagHeaderEntry`] for [`emit_item_tag_header`]. `None` when the object
-/// carries no `key` (an `ITEM_TAG` without a key is not a valid tag, RM
-/// `ITEM_TAG.Inv_key_valid`).
-pub(crate) fn item_tag_to_header_entry(tag: &serde_json::Value) -> Option<ItemTagHeaderEntry> {
-    let key = tag
-        .get("key")
-        .and_then(serde_json::Value::as_str)?
-        .to_owned();
-    Some(ItemTagHeaderEntry {
-        key,
-        value: tag
-            .get("value")
-            .and_then(serde_json::Value::as_str)
-            .map(str::to_owned),
-        target_path: tag
-            .get("target_path")
-            .and_then(serde_json::Value::as_str)
-            .map(str::to_owned),
-    })
+/// Project one RM [`ItemTag`] (`common.item_tag`) onto the
+/// [`ItemTagHeaderEntry`] [`emit_item_tag_header`] renders — the three members
+/// the header grammar carries (`key`, `value`, `target_path`), read straight off
+/// the typed instance.
+pub(crate) fn item_tag_to_header_entry(tag: &ItemTag) -> ItemTagHeaderEntry {
+    ItemTagHeaderEntry {
+        key: tag.key.clone(),
+        value: tag.value.clone(),
+        target_path: tag.target_path.clone(),
+    }
 }
 
 /// The value of a parsed `key` in a tag-pair segment.

--- a/app/ferroehr/src/service/demographic/api.rs
+++ b/app/ferroehr/src/service/demographic/api.rs
@@ -10,6 +10,7 @@
 //! [`crate::versioning`] (`object_version_id.rs`).
 
 use openehr_base::base_types::identification::lexical::composite_ids_equal;
+use openehr_rm::prelude::ItemTag;
 use serde_json::Value;
 use uuid::Uuid;
 
@@ -27,11 +28,6 @@ use crate::service::version_update::{Committal, UpdateAudit, UpdateVersion};
 use crate::versioning::object_version_id::{
     components, expected_from_if_match, if_match_token, parse_uid_based_id, parse_version_uid,
 };
-
-/// Wrap a JSON array of item-tag objects as a plain (header-free) response.
-fn tags_response(tags: Vec<Value>) -> ServiceResponse {
-    ServiceResponse::plain(Value::Array(tags))
-}
 
 /// The `version_uid` a write produced (the new/deleted `OBJECT_VERSION_ID`),
 /// pulled from the response metadata.
@@ -155,8 +151,8 @@ impl FerroEhrService {
             None => None,
         };
         if let Some(meta) = resp.meta.as_mut() {
-            meta.item_tags = Some(Value::Array(container));
-            meta.version_item_tags = version.map(Value::Array);
+            meta.item_tags = Some(container);
+            meta.version_item_tags = version;
         }
         Ok(())
     }
@@ -644,15 +640,14 @@ impl FerroEhrService {
         tag_key: Option<String>,
         tag_value: Option<String>,
         tag_target_path: Option<String>,
-    ) -> Result<ServiceResponse, SmError> {
-        let tags = self
+    ) -> Result<Vec<ItemTag>, SmError> {
+        Ok(self
             .demographic_tags(
                 tag_key.as_deref(),
                 tag_value.as_deref(),
                 tag_target_path.as_deref(),
             )
-            .await?;
-        Ok(tags_response(tags))
+            .await?)
     }
 
     /// The `ITEM_TAG`s on one party.
@@ -664,17 +659,16 @@ impl FerroEhrService {
         &self,
         kind: PartyKind,
         uid_based_id: String,
-    ) -> Result<ServiceResponse, SmError> {
+    ) -> Result<Vec<ItemTag>, SmError> {
         let (vo_id, version) = crate::service::ehr::tags::parse_tag_target(&uid_based_id)?;
         // The released 404 trigger ("when the `uid_based_id` does not exist")
         // plus the kind-checked-routes law: the guard runs on the GET too; an
         // existing target with no tags stays an empty 200 list.
         self.ensure_party_tag_target(kind, vo_id, version.as_ref())
             .await?;
-        Ok(tags_response(
-            self.party_tags(vo_id, tag_target_tail(version.as_ref()))
-                .await?,
-        ))
+        Ok(self
+            .party_tags(vo_id, tag_target_tail(version.as_ref()))
+            .await?)
     }
 
     /// Replace the whole `ITEM_TAG` collection of a party (PUT full-collection
@@ -691,12 +685,11 @@ impl FerroEhrService {
         kind: PartyKind,
         uid_based_id: String,
         body: Vec<openehr_its::rest::generated::demographic::UpdateItemTag>,
-    ) -> Result<ServiceResponse, SmError> {
+    ) -> Result<Vec<ItemTag>, SmError> {
         let (vo_id, version) = crate::service::ehr::tags::parse_tag_target(&uid_based_id)?;
-        Ok(tags_response(
-            self.replace_party_tags(kind, vo_id, version.as_ref(), &body)
-                .await?,
-        ))
+        Ok(self
+            .replace_party_tags(kind, vo_id, version.as_ref(), &body)
+            .await?)
     }
 
     /// Delete one `ITEM_TAG` by key from a party.

--- a/app/ferroehr/src/service/demographic/tags.rs
+++ b/app/ferroehr/src/service/demographic/tags.rs
@@ -17,7 +17,6 @@ use openehr_base::prelude::{
 };
 use openehr_its::rest::generated::demographic::UpdateItemTag;
 use openehr_rm::prelude::ItemTag;
-use serde_json::Value;
 
 use crate::ids::VoId;
 use crate::service::FerroEhrService;
@@ -35,11 +34,11 @@ impl FerroEhrService {
         key: Option<&str>,
         value: Option<&str>,
         target_path: Option<&str>,
-    ) -> Result<Vec<Value>, ServiceError> {
+    ) -> Result<Vec<ItemTag>, ServiceError> {
         let rows = tag_repo::list_tags(&self.pool, None, None, key, value, target_path).await?;
         let sid = self.effective_system_id();
         rows.iter()
-            .map(|r| party_tag_json(&sid, r))
+            .map(|r| party_item_tag(&sid, r))
             .collect::<Result<Vec<_>, _>>()
             .map_err(Into::into)
     }
@@ -54,7 +53,7 @@ impl FerroEhrService {
         &self,
         vo_id: VoId,
         target_version: Option<&str>,
-    ) -> Result<Vec<Value>, ServiceError> {
+    ) -> Result<Vec<ItemTag>, ServiceError> {
         let rows = tag_repo::list_tags(
             &self.pool,
             None,
@@ -66,7 +65,7 @@ impl FerroEhrService {
         .await?;
         let sid = self.effective_system_id();
         rows.iter()
-            .map(|r| party_tag_json(&sid, r))
+            .map(|r| party_item_tag(&sid, r))
             .collect::<Result<Vec<_>, _>>()
             .map_err(Into::into)
     }
@@ -127,7 +126,7 @@ impl FerroEhrService {
         vo_id: VoId,
         target_version: Option<&ObjectVersionId>,
         tags: &[UpdateItemTag],
-    ) -> Result<Vec<Value>, ServiceError> {
+    ) -> Result<Vec<ItemTag>, ServiceError> {
         self.ensure_party_tag_target(kind, vo_id, target_version)
             .await?;
         // Validate + dedup (last wins) before touching the DB, keyed on the
@@ -224,12 +223,13 @@ impl FerroEhrService {
     }
 }
 
-/// One demographic `ITEM_TAG` in its RM wire shape (`item_tag.adoc`): `key`,
-/// optional `value`/`target_path`, `target` as a bare `UID_BASED_ID` — a
-/// `HIER_OBJECT_ID` for a container target, an `OBJECT_VERSION_ID` for a
-/// VERSION target ("may be a `VERSIONED_OBJECT<T>` or a `VERSION<T>`") —
-/// exactly the EHR sibling's shape (the settled RM-target law; the released
-/// OAS `ItemTag` schema's `OBJECT_REF` wrapper loses the conflict to the RM).
+/// One stored demographic tag row as the RM `ITEM_TAG` it is
+/// (`item_tag.adoc`): `key`, optional `value`/`target_path`, `target` as a bare
+/// `UID_BASED_ID` — a `HIER_OBJECT_ID` for a container target, an
+/// `OBJECT_VERSION_ID` for a VERSION target ("may be a `VERSIONED_OBJECT<T>` or
+/// a `VERSION<T>`") — exactly the EHR sibling's shape (the settled RM-target
+/// law; the released OAS `ItemTag` schema's `OBJECT_REF` wrapper loses the
+/// conflict to the RM).
 ///
 /// NOTE: `owner_id` follows the released examples' shape — an `OBJECT_REF`
 /// `{namespace: local, type: SYSTEM}` whose `id` carries the server's
@@ -241,15 +241,14 @@ impl FerroEhrService {
 /// # Errors
 /// [`VersionIdError`] when the configured `system_id` or the stored tag target
 /// is not a well-formed BASE identifier.
-fn party_tag_json(system_id: &str, row: &tag_repo::TagRow) -> Result<Value, VersionIdError> {
-    let tag = ItemTag {
+fn party_item_tag(system_id: &str, row: &tag_repo::TagRow) -> Result<ItemTag, VersionIdError> {
+    Ok(ItemTag {
         key: row.key.clone(),
         value: row.value.clone(),
         target: crate::service::ehr::tags::tag_target(row)?,
         target_path: row.target_path.clone(),
         owner_id: party_owner_ref(system_id)?,
-    };
-    Ok(openehr_its::json::to_canonical_value(&tag))
+    })
 }
 
 /// The `ITEM_TAG.owner_id` of a demographic (ehr-less) tag — the `OBJECT_REF`

--- a/app/ferroehr/src/service/ehr/tags.rs
+++ b/app/ferroehr/src/service/ehr/tags.rs
@@ -23,7 +23,6 @@ use openehr_base::prelude::{
 use openehr_base::validate::Validate;
 use openehr_its::rest::generated::ehr::UpdateItemTag;
 use openehr_rm::prelude::ItemTag;
-use serde_json::Value;
 
 use crate::ids::{EhrId, VoId};
 use crate::service::FerroEhrService;
@@ -42,7 +41,7 @@ impl FerroEhrService {
         key: Option<&str>,
         value: Option<&str>,
         target_path: Option<&str>,
-    ) -> Result<Vec<Value>, ServiceError> {
+    ) -> Result<Vec<ItemTag>, ServiceError> {
         // The released 404 trigger ("when an EHR with `ehr_id` does not
         // exist", 404_unknown_ehr_id) — an unknown EHR is 404, never an
         // empty 200 list; an EXISTING EHR with no matching tags is [].
@@ -57,7 +56,7 @@ impl FerroEhrService {
         )
         .await?;
         rows.iter()
-            .map(|r| Self::tag_json(ehr_id, r))
+            .map(|r| Self::stored_item_tag(ehr_id, r))
             .collect::<Result<Vec<_>, _>>()
             .map_err(Into::into)
     }
@@ -90,7 +89,7 @@ impl FerroEhrService {
         ehr_id: EhrId,
         target_vo_id: VoId,
         target_version: Option<&str>,
-    ) -> Result<Vec<Value>, ServiceError> {
+    ) -> Result<Vec<ItemTag>, ServiceError> {
         let rows = crate::storage::tag_repo::list_tags(
             &self.pool,
             Some(ehr_id),
@@ -101,7 +100,7 @@ impl FerroEhrService {
         )
         .await?;
         rows.iter()
-            .map(|r| Self::tag_json(ehr_id, r))
+            .map(|r| Self::stored_item_tag(ehr_id, r))
             .collect::<Result<Vec<_>, _>>()
             .map_err(Into::into)
     }
@@ -123,7 +122,7 @@ impl FerroEhrService {
         target_version: Option<&ObjectVersionId>,
         target_type: &str,
         tags: &[UpdateItemTag],
-    ) -> Result<Vec<Value>, ServiceError> {
+    ) -> Result<Vec<ItemTag>, ServiceError> {
         self.ensure_ehr_exists(ehr_id).await?;
         self.ensure_tag_target(ehr_id, target_vo_id, target_version, target_type)
             .await?;
@@ -267,15 +266,17 @@ impl FerroEhrService {
         Ok(())
     }
 
-    /// One `ITEM_TAG` in its RM wire shape (`item_tag.adoc`): `key`, optional
-    /// `value`/`target_path`, `target` as a bare `UID_BASED_ID` — a
+    /// One stored tag row as the RM `ITEM_TAG` it is (`item_tag.adoc`): `key`,
+    /// optional `value`/`target_path`, `target` as a bare `UID_BASED_ID` — a
     /// `HIER_OBJECT_ID` for a container target, an `OBJECT_VERSION_ID` for a
     /// VERSION target ("may be a `VERSIONED_OBJECT<T>` or a `VERSION<T>`") —
-    /// and `owner_id` as the RM's `OBJECT_REF` to the owning EHR.
+    /// and `owner_id` as the RM's `OBJECT_REF` to the owning EHR. The served
+    /// bytes are then the generated canonical-JSON encoding of this instance,
+    /// produced at the protocol edge.
     ///
     /// NOTE: two shape decisions, both register-adjudicated rather than
     /// settled by any single released sentence.
-    /// `_type: "ITEM_TAG"` IS emitted (register AMB-201): the released
+    /// `_type: "ITEM_TAG"` IS on the wire (register AMB-201): the released
     /// `ItemTag.yaml` is `additionalProperties: false` without declaring
     /// `_type`, while the same group's `discriminator.propertyName` names that
     /// member — an OAS-internal self-contradiction, reported upstream, whose
@@ -287,18 +288,17 @@ impl FerroEhrService {
     /// of a model and the RM is the released definition of the model being
     /// projected, so where the projection disagrees with its subject about what
     /// an attribute IS, the subject decides.
-    fn tag_json(
+    fn stored_item_tag(
         ehr_id: EhrId,
         row: &crate::storage::tag_repo::TagRow,
-    ) -> Result<Value, VersionIdError> {
-        let tag = ItemTag {
+    ) -> Result<ItemTag, VersionIdError> {
+        Ok(ItemTag {
             key: row.key.clone(),
             value: row.value.clone(),
             target: tag_target(row)?,
             target_path: row.target_path.clone(),
             owner_id: ehr_owner_ref(ehr_id),
-        };
-        Ok(openehr_its::json::to_canonical_value(&tag))
+        })
     }
 }
 
@@ -413,7 +413,7 @@ impl FerroEhrService {
         key: Option<String>,
         value: Option<String>,
         target_path: Option<String>,
-    ) -> Result<Vec<Value>, SmError> {
+    ) -> Result<Vec<ItemTag>, SmError> {
         Ok(self
             .ehr_tags(
                 an_ehr_id,
@@ -434,7 +434,7 @@ impl FerroEhrService {
         an_ehr_id: EhrId,
         uid_based_id: String,
         target_type: &str,
-    ) -> Result<Vec<Value>, SmError> {
+    ) -> Result<Vec<ItemTag>, SmError> {
         let (vo_id, version) = parse_tag_target(&uid_based_id)?;
         // The released 404 trigger — "when the `uid_based_id` does not
         // exist" — plus the EHR scope and the route-kind discipline
@@ -460,7 +460,7 @@ impl FerroEhrService {
         uid_based_id: String,
         target_type: &str,
         tags: Vec<UpdateItemTag>,
-    ) -> Result<Vec<Value>, SmError> {
+    ) -> Result<Vec<ItemTag>, SmError> {
         let (vo_id, version) = parse_tag_target(&uid_based_id)?;
         Ok(self
             .replace_tags(an_ehr_id, vo_id, version.as_ref(), target_type, &tags)

--- a/app/ferroehr/src/service/response.rs
+++ b/app/ferroehr/src/service/response.rs
@@ -8,6 +8,7 @@
 //! that carries what the headers need.
 
 use jiff::Timestamp;
+use openehr_rm::prelude::ItemTag;
 use serde_json::Value;
 
 /// Typed metadata about a versioned resource a write/read produced, from
@@ -28,8 +29,7 @@ pub struct ResourceMeta {
     /// `VERSION`/`VERSIONED_OBJECT` responses.
     pub last_modified: Option<Timestamp>,
     /// The `ITEM_TAGs` (RM `common.item_tag`) currently associated with this
-    /// resource, as their canonical-JSON list (`Value::Array` of `ITEM_TAG`
-    /// objects), or `None` when the operation carries no tags. The ITS-REST
+    /// resource, or `None` when the operation carries no tags. The ITS-REST
     /// adapter renders this into the `openehr-item-tag` /
     /// `openehr-version-item-tag` response headers
     /// (`headers/openehr-item-tag.yaml`,
@@ -37,13 +37,13 @@ pub struct ResourceMeta {
     ///
     /// No openEHR spec governs this envelope field — our own design: the SM
     /// returns plain values, and this seam carries what the mandated headers
-    /// need. The tag *content* is the RM `common.item_tag.ITEM_TAG` type.
-    pub item_tags: Option<Value>,
+    /// need. The tags are the RM `common.item_tag.ITEM_TAG` type itself.
+    pub item_tags: Option<Vec<ItemTag>>,
     /// The served/committed VERSION's own `ITEM_TAG` collection, when it is
     /// distinct from the container's (`openehr-version-item-tag` — overview
     /// §"openehr-item-tag and openehr-version-item-tag": the two headers
     /// address a `VERSIONED_OBJECT` and a specific VERSION within it).
-    pub version_item_tags: Option<Value>,
+    pub version_item_tags: Option<Vec<ItemTag>>,
 }
 
 impl ResourceMeta {
@@ -67,11 +67,10 @@ impl ResourceMeta {
         self
     }
 
-    /// Attach the resource's `ITEM_TAG` list (canonical-JSON `Value::Array` of
-    /// `ITEM_TAG` objects) for the `openehr-item-tag` /
+    /// Attach the resource's `ITEM_TAG` list for the `openehr-item-tag` /
     /// `openehr-version-item-tag` response headers.
     #[must_use]
-    pub fn with_item_tags(mut self, tags: Value) -> Self {
+    pub fn with_item_tags(mut self, tags: Vec<ItemTag>) -> Self {
         self.item_tags = Some(tags);
         self
     }

--- a/app/ferroehr/tests/it/service_demographic.rs
+++ b/app/ferroehr/tests/it/service_demographic.rs
@@ -584,23 +584,22 @@ async fn party_tags_crud() {
         )
         .await
         .expect("put tags");
-    let arr = tags.body.as_array().expect("tags array");
-    assert_eq!(arr.len(), 1);
-    assert_eq!(arr[0]["key"], "priority");
+    assert_eq!(tags.len(), 1);
+    assert_eq!(tags[0].key, "priority");
 
     // GET tags on the party
     let got = svc
         .party_tags_get(PartyKind::Person, vo.clone())
         .await
         .expect("get tags");
-    assert_eq!(got.body.as_array().expect("arr").len(), 1);
+    assert_eq!(got.len(), 1);
 
     // demographic tags (ehr-less scope) sees it
     let all = svc
         .demographic_tags_get(None, None, None)
         .await
         .expect("all demographic tags");
-    assert_eq!(all.body.as_array().expect("arr").len(), 1);
+    assert_eq!(all.len(), 1);
 
     // DELETE the tag
     svc.party_tags_delete(PartyKind::Person, vo.clone(), "priority".to_owned())
@@ -610,7 +609,7 @@ async fn party_tags_crud() {
         .party_tags_get(PartyKind::Person, vo)
         .await
         .expect("get tags after delete");
-    assert!(empty.body.as_array().expect("arr").is_empty());
+    assert!(empty.is_empty());
 }
 
 /// The `If-Match` precondition compares the FULL `OBJECT_VERSION_ID`

--- a/app/ferroehr/tests/it/service_ehr.rs
+++ b/app/ferroehr/tests/it/service_ehr.rs
@@ -22,7 +22,7 @@
 use serde_json::{Value, json};
 
 use openehr_base::prelude::{ObjectVersionId, TerminologyCode};
-use openehr_rm::prelude::PartyProxy;
+use openehr_rm::prelude::{ItemTag, PartyProxy};
 
 use ferroehr::service::FerroEhrService;
 use ferroehr::service::error::ServiceError;
@@ -68,9 +68,8 @@ fn uv(data: Value, change_code: &str, preceding: Option<&str>) -> UpdateVersion 
     }
 }
 
-fn has_key(tags: &[Value], k: &str) -> bool {
-    tags.iter()
-        .any(|t| t.get("key").and_then(Value::as_str) == Some(k))
+fn has_key(tags: &[ItemTag], k: &str) -> bool {
+    tags.iter().any(|t| t.key == k)
 }
 
 /// A minimal *valid* RM COMPOSITION: `language`, `territory`, `category`, and
@@ -1326,7 +1325,10 @@ async fn item_tag_wire_shape_is_the_rm_item_tag() {
         )
         .await
         .expect("tag put");
-    let tag = &put[0];
+    // The service now carries the typed RM `ITEM_TAG`; the WIRE shape this test
+    // pins is its canonical-JSON encoding, produced here exactly as the
+    // protocol edge produces it.
+    let tag = openehr_its::json::to_canonical_value(&put[0]);
     assert_eq!(tag["_type"], "ITEM_TAG");
     assert_eq!(tag["key"], "priority");
     assert_eq!(tag["value"], "high");
@@ -1389,14 +1391,17 @@ async fn item_tag_identity_is_the_key_and_target_path_pair() {
     let by_path = |path: &str| {
         stored
             .iter()
-            .find(|t| t["target_path"] == path)
+            .find(|t| t.target_path.as_deref() == Some(path))
             .unwrap_or_else(|| panic!("tag at {path}"))
             .clone()
     };
-    assert_eq!(by_path("/context/start_time/value")["value"], "a");
     assert_eq!(
-        by_path("/content[0]/name/value")["value"],
-        "b2",
+        by_path("/context/start_time/value").value.as_deref(),
+        Some("a")
+    );
+    assert_eq!(
+        by_path("/content[0]/name/value").value.as_deref(),
+        Some("b2"),
         "same (key, path) pair: last wins"
     );
 
@@ -1452,24 +1457,26 @@ async fn item_tag_version_and_container_targets_are_distinct() {
     // Each collection holds ONLY its own tag (the container PUT did not wipe
     // the version's), and each target carries the RM UID_BASED_ID shape.
     assert_eq!(on_version.len(), 1);
-    assert_eq!(on_version[0]["target"]["_type"], "OBJECT_VERSION_ID");
-    assert_eq!(on_version[0]["target"]["value"], version_uid);
+    let version_target = openehr_its::json::to_canonical_value(&on_version[0].target);
+    assert_eq!(version_target["_type"], "OBJECT_VERSION_ID");
+    assert_eq!(version_target["value"], version_uid);
     assert_eq!(on_container.len(), 1);
-    assert_eq!(on_container[0]["target"]["_type"], "HIER_OBJECT_ID");
-    assert_eq!(on_container[0]["target"]["value"], vo_id);
+    let container_target = openehr_its::json::to_canonical_value(&on_container[0].target);
+    assert_eq!(container_target["_type"], "HIER_OBJECT_ID");
+    assert_eq!(container_target["value"], vo_id);
 
     let version_list = svc
         .target_tags_get(ehr_uuid, version_uid.clone(), "COMPOSITION")
         .await
         .expect("version list");
     assert_eq!(version_list.len(), 1);
-    assert_eq!(version_list[0]["key"], "reviewed");
+    assert_eq!(version_list[0].key, "reviewed");
     let container_list = svc
         .target_tags_get(ehr_uuid, vo_id.clone(), "COMPOSITION")
         .await
         .expect("container list");
     assert_eq!(container_list.len(), 1);
-    assert_eq!(container_list[0]["key"], "workflow");
+    assert_eq!(container_list[0].key, "workflow");
 
     // A tag addressed to a NONEXISTENT version is refused.
     let ghost = format!("{vo_id}::ghost.system::9");
@@ -1682,7 +1689,7 @@ async fn item_tag_put_replaces_the_whole_collection() {
         .expect("the valid twins are stored");
     assert_eq!(accepted.len(), 2);
     assert!(
-        accepted.iter().all(|t| t.get("target_path").is_none()),
+        accepted.iter().all(|t| t.target_path.is_none()),
         "an empty target_path normalizes to absent, got {accepted:?}"
     );
 }

--- a/app/ferroehr/tests/it/value_carriers.rs
+++ b/app/ferroehr/tests/it/value_carriers.rs
@@ -61,7 +61,7 @@ const ALLOWLIST: &[(&str, &str)] = &[
     ),
     (
         "service/response.rs",
-        "generic RESULT_SET row values (AQL projection class)",
+        "ServiceResponse::body — the hybrid RM/stored/dynamic carrier (commit-seam class, #1694 step 6)",
     ),
     (
         "service/subject_proxy/",


### PR DESCRIPTION
Step 2 of the #1694 parse-don't-validate campaign (the inventory's dependency-ordered plan): the fully-independent ITEM_TAG conversion, under the owner's zero-`Value` directive.

- All tag list fns (`ehr/tags.rs`, `demographic/tags.rs`), `ResourceMeta.item_tags`/`version_item_tags`, and `StoredItemTags` carry `Vec<ItemTag>` (the generated `openehr_rm::common::tags::item_tag::ItemTag`); the two converted service files no longer mention `serde_json::Value` at all.
- **Byte discipline held:** serialization happens once at the REST edge (`to_canonical_value`); all 78 tag wire tests pass **unchanged** — the `_type: "ITEM_TAG"` (AMB-201), bare-`UID_BASED_ID` target (AMB-202) and `additionalProperties: false` assertions still run against real canonical JSON.
- Deleted re-checks: `item_tag_to_header_entry`'s `Inv_key_valid` pointer read and key-absent branch (unrepresentable on the typed carrier — the fn is now infallible); the demographic `tags_response` envelope (a full `ServiceResponse` consumed for one field).
- **Deliberately NOT shrunk:** `validate_item_tag` — the generated `ItemTag` has no validated constructor, so the service-seam refusal of `""`/padded keys is still the only guard on the SM-direct path. That gap is the point of the newly filed #1840 (validated construction for invariant-carrying types); the checks shrink when construction validates.
- En-route findings filed: #1838 (the two item-tag echo paths disagree on the empty collection — a real wire defect), #1839 (stale intra-doc links hiding behind non-pub items), #1840; a stale `ItemTagAdapter` doc link fixed in-fence; the `value_carriers.rs` allowlist reason for `response.rs` re-grounded.

Gates: fmt, clippy (`ferroehr` + `ferroehr-rest`, -D warnings), nextest 1473/1473, rustdoc. No changelog entry — nothing user-visible changed.

Part of #1694.