### PR TITLE
fix(codegen): emit-rest keeps $ref names — the generated ITS-REST contract is typed end to end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,18 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **The generated ITS-REST contract is typed end to end.** The `emit-rest`
+  generator resolved `$ref`s before emitting, so every request/response body
+  and parameter lost its schema name and the trait/DTO surface degraded to
+  untyped JSON values; RM/BASE payload references likewise degraded on a
+  rationale that expired with the foundation rewrite (the spec types carry
+  emitted strict serde impls). Body and parameter references now keep their
+  names, RM/BASE references resolve to the typed spec structs — making every
+  DTO field strict by construction — and a `discriminator.mapping` schema
+  (`Versionable`) emits a real `_type`-dispatched enum instead of an untyped
+  alias. Remaining untyped spots are honest: anonymous `oneOf` responses,
+  query result rows, and schema-less OPT objects.
+
 - **A node claiming a `_type` foreign to its slot is now refused everywhere,
   from the RM model.** The whole-instance validation pass dispatched each
   node on its own wire `_type`, so a tagged object sitting in a slot declared

--- a/crates/openehr-its/src/rest/generated/definition.rs
+++ b/crates/openehr-its/src/rest/generated/definition.rs
@@ -572,12 +572,151 @@ pub struct Clstr {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub _type: Option<String>,
     /// The `items` property of `Clstr`.
-    pub items: Vec<serde_json::Value>,
+    pub items: Vec<openehr_rm::prelude::Item>,
 }
 
-/// The `Versionable` ITS-REST OAS component schema (a non-object shape, so
-/// it is an alias rather than a struct).
-pub type Versionable = serde_json::Value;
+/// The `Versionable` ITS-REST OAS component schema: `_type`-discriminated
+/// polymorphism over its OAS `discriminator.mapping` targets.
+#[derive(Debug, Clone)]
+pub enum Versionable {
+    /// `_type: "ACTOR"`
+    Actor(openehr_rm::prelude::Actor),
+    /// `_type: "AGENT"`
+    Agent(openehr_rm::prelude::Agent),
+    /// `_type: "COMPOSITION"`
+    Composition(openehr_rm::prelude::Composition),
+    /// `_type: "EHR_STATUS"`
+    EhrStatus(openehr_rm::prelude::EhrStatus),
+    /// `_type: "FOLDER"`
+    Folder(openehr_rm::prelude::Folder),
+    /// `_type: "GROUP"`
+    Group(openehr_rm::prelude::Group),
+    /// `_type: "ORGANISATION"`
+    Organisation(openehr_rm::prelude::Organisation),
+    /// `_type: "PARTY"`
+    Party(openehr_rm::prelude::Party),
+    /// `_type: "PERSON"`
+    Person(openehr_rm::prelude::Person),
+    /// `_type: "ROLE"`
+    Role(openehr_rm::prelude::Role),
+}
+
+impl ::serde::Serialize for Versionable {
+    fn serialize<__S: ::serde::Serializer>(
+        &self,
+        __serializer: __S,
+    ) -> ::core::result::Result<__S::Ok, __S::Error> {
+        match self {
+            Self::Actor(__x) => ::serde::Serialize::serialize(__x, __serializer),
+            Self::Agent(__x) => ::serde::Serialize::serialize(__x, __serializer),
+            Self::Composition(__x) => ::serde::Serialize::serialize(__x, __serializer),
+            Self::EhrStatus(__x) => ::serde::Serialize::serialize(__x, __serializer),
+            Self::Folder(__x) => ::serde::Serialize::serialize(__x, __serializer),
+            Self::Group(__x) => ::serde::Serialize::serialize(__x, __serializer),
+            Self::Organisation(__x) => ::serde::Serialize::serialize(__x, __serializer),
+            Self::Party(__x) => ::serde::Serialize::serialize(__x, __serializer),
+            Self::Person(__x) => ::serde::Serialize::serialize(__x, __serializer),
+            Self::Role(__x) => ::serde::Serialize::serialize(__x, __serializer),
+        }
+    }
+}
+
+impl<'de> ::serde::Deserialize<'de> for Versionable {
+    fn deserialize<__D: ::serde::Deserializer<'de>>(
+        __deserializer: __D,
+    ) -> ::core::result::Result<Self, __D::Error> {
+        const __TAGS: &[&str] = &[
+            "ACTOR",
+            "AGENT",
+            "COMPOSITION",
+            "EHR_STATUS",
+            "FOLDER",
+            "GROUP",
+            "ORGANISATION",
+            "PARTY",
+            "PERSON",
+            "ROLE",
+        ];
+        struct __Visitor;
+        impl<'de> ::serde::de::Visitor<'de> for __Visitor {
+            type Value = Versionable;
+            fn expecting(&self, __f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                __f.write_str("an ITS-REST `Versionable` object")
+            }
+            fn visit_map<__A: ::serde::de::MapAccess<'de>>(
+                self,
+                mut __map: __A,
+            ) -> ::core::result::Result<Self::Value, __A::Error> {
+                let (__tag, __buffered) =
+                    ::openehr_base::serde_support::read_slot_tag(&mut __map, __TAGS)?;
+                match __tag {
+                    Some(::openehr_base::serde_support::TagMatch::Known(__t)) => {
+                        let __rest = ::openehr_base::serde_support::TaggedRest::new(
+                            Some(__t),
+                            __buffered,
+                            __map,
+                        );
+                        match __t {
+                            "ACTOR" => ::core::result::Result::Ok(Versionable::Actor(
+                                ::serde::Deserialize::deserialize(__rest)?,
+                            )),
+                            "AGENT" => ::core::result::Result::Ok(Versionable::Agent(
+                                ::serde::Deserialize::deserialize(__rest)?,
+                            )),
+                            "COMPOSITION" => ::core::result::Result::Ok(Versionable::Composition(
+                                ::serde::Deserialize::deserialize(__rest)?,
+                            )),
+                            "EHR_STATUS" => ::core::result::Result::Ok(Versionable::EhrStatus(
+                                ::serde::Deserialize::deserialize(__rest)?,
+                            )),
+                            "FOLDER" => ::core::result::Result::Ok(Versionable::Folder(
+                                ::serde::Deserialize::deserialize(__rest)?,
+                            )),
+                            "GROUP" => ::core::result::Result::Ok(Versionable::Group(
+                                ::serde::Deserialize::deserialize(__rest)?,
+                            )),
+                            "ORGANISATION" => {
+                                ::core::result::Result::Ok(Versionable::Organisation(
+                                    ::serde::Deserialize::deserialize(__rest)?,
+                                ))
+                            }
+                            "PARTY" => ::core::result::Result::Ok(Versionable::Party(
+                                ::serde::Deserialize::deserialize(__rest)?,
+                            )),
+                            "PERSON" => ::core::result::Result::Ok(Versionable::Person(
+                                ::serde::Deserialize::deserialize(__rest)?,
+                            )),
+                            "ROLE" => ::core::result::Result::Ok(Versionable::Role(
+                                ::serde::Deserialize::deserialize(__rest)?,
+                            )),
+                            __other => ::core::result::Result::Err(
+                                ::openehr_base::serde_support::unexpected_type(
+                                    "Versionable",
+                                    __other,
+                                    "ACTOR, AGENT, COMPOSITION, EHR_STATUS, FOLDER, GROUP, ORGANISATION, PARTY, PERSON, ROLE",
+                                ),
+                            ),
+                        }
+                    }
+                    Some(::openehr_base::serde_support::TagMatch::Unknown(__other)) => {
+                        ::core::result::Result::Err(::openehr_base::serde_support::unexpected_type(
+                            "Versionable",
+                            &__other,
+                            "ACTOR, AGENT, COMPOSITION, EHR_STATUS, FOLDER, GROUP, ORGANISATION, PARTY, PERSON, ROLE",
+                        ))
+                    }
+                    None => {
+                        ::core::result::Result::Err(::openehr_base::serde_support::missing_type(
+                            "Versionable",
+                            "ACTOR, AGENT, COMPOSITION, EHR_STATUS, FOLDER, GROUP, ORGANISATION, PARTY, PERSON, ROLE",
+                        ))
+                    }
+                }
+            }
+        }
+        ::serde::Deserializer::deserialize_map(__deserializer, __Visitor)
+    }
+}
 
 /// The `DvIntervalOfDateTime` transport DTO of this API group (an ITS-REST OAS
 /// component schema).
@@ -588,36 +727,132 @@ pub struct DvIntervalOfDateTime {
     pub _type: Option<String>,
     /// The `lower` property of `DvIntervalOfDateTime`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub lower: Option<serde_json::Value>,
+    pub lower: Option<openehr_rm::prelude::DvDateTime>,
     /// The `upper` property of `DvIntervalOfDateTime`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub upper: Option<serde_json::Value>,
+    pub upper: Option<openehr_rm::prelude::DvDateTime>,
 }
 
-/// The `AbstractEntry` transport DTO of this API group (an ITS-REST OAS
-/// component schema).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AbstractEntry {
-    /// The `language` property of `AbstractEntry`.
-    pub language: serde_json::Value,
-    /// The `encoding` property of `AbstractEntry`.
-    pub encoding: serde_json::Value,
-    /// The `other_participations` property of `AbstractEntry`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub other_participations: Option<Vec<serde_json::Value>>,
-    /// The `workflow_id` property of `AbstractEntry`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub workflow_id: Option<serde_json::Value>,
-    /// The `subject` property of `AbstractEntry`.
-    pub subject: serde_json::Value,
-    /// The `provider` property of `AbstractEntry`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub provider: Option<serde_json::Value>,
+/// The `AbstractEntry` ITS-REST OAS component schema: `_type`-discriminated
+/// polymorphism over its OAS `discriminator.mapping` targets.
+#[derive(Debug, Clone)]
+pub enum AbstractEntry {
+    /// `_type: "ACTION"`
+    Action(openehr_rm::prelude::Action),
+    /// `_type: "ADMIN_ENTRY"`
+    AdminEntry(openehr_rm::prelude::AdminEntry),
+    /// `_type: "CARE_ENTRY"`
+    CareEntry(openehr_rm::prelude::CareEntry),
+    /// `_type: "EVALUATION"`
+    Evaluation(openehr_rm::prelude::Evaluation),
+    /// `_type: "INSTRUCTION"`
+    Instruction(openehr_rm::prelude::Instruction),
+    /// `_type: "OBSERVATION"`
+    Observation(openehr_rm::prelude::Observation),
+}
+
+impl ::serde::Serialize for AbstractEntry {
+    fn serialize<__S: ::serde::Serializer>(
+        &self,
+        __serializer: __S,
+    ) -> ::core::result::Result<__S::Ok, __S::Error> {
+        match self {
+            Self::Action(__x) => ::serde::Serialize::serialize(__x, __serializer),
+            Self::AdminEntry(__x) => ::serde::Serialize::serialize(__x, __serializer),
+            Self::CareEntry(__x) => ::serde::Serialize::serialize(__x, __serializer),
+            Self::Evaluation(__x) => ::serde::Serialize::serialize(__x, __serializer),
+            Self::Instruction(__x) => ::serde::Serialize::serialize(__x, __serializer),
+            Self::Observation(__x) => ::serde::Serialize::serialize(__x, __serializer),
+        }
+    }
+}
+
+impl<'de> ::serde::Deserialize<'de> for AbstractEntry {
+    fn deserialize<__D: ::serde::Deserializer<'de>>(
+        __deserializer: __D,
+    ) -> ::core::result::Result<Self, __D::Error> {
+        const __TAGS: &[&str] = &[
+            "ACTION",
+            "ADMIN_ENTRY",
+            "CARE_ENTRY",
+            "EVALUATION",
+            "INSTRUCTION",
+            "OBSERVATION",
+        ];
+        struct __Visitor;
+        impl<'de> ::serde::de::Visitor<'de> for __Visitor {
+            type Value = AbstractEntry;
+            fn expecting(&self, __f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                __f.write_str("an ITS-REST `AbstractEntry` object")
+            }
+            fn visit_map<__A: ::serde::de::MapAccess<'de>>(
+                self,
+                mut __map: __A,
+            ) -> ::core::result::Result<Self::Value, __A::Error> {
+                let (__tag, __buffered) =
+                    ::openehr_base::serde_support::read_slot_tag(&mut __map, __TAGS)?;
+                match __tag {
+                    Some(::openehr_base::serde_support::TagMatch::Known(__t)) => {
+                        let __rest = ::openehr_base::serde_support::TaggedRest::new(
+                            Some(__t),
+                            __buffered,
+                            __map,
+                        );
+                        match __t {
+                            "ACTION" => ::core::result::Result::Ok(AbstractEntry::Action(
+                                ::serde::Deserialize::deserialize(__rest)?,
+                            )),
+                            "ADMIN_ENTRY" => ::core::result::Result::Ok(AbstractEntry::AdminEntry(
+                                ::serde::Deserialize::deserialize(__rest)?,
+                            )),
+                            "CARE_ENTRY" => ::core::result::Result::Ok(AbstractEntry::CareEntry(
+                                ::serde::Deserialize::deserialize(__rest)?,
+                            )),
+                            "EVALUATION" => ::core::result::Result::Ok(AbstractEntry::Evaluation(
+                                ::serde::Deserialize::deserialize(__rest)?,
+                            )),
+                            "INSTRUCTION" => {
+                                ::core::result::Result::Ok(AbstractEntry::Instruction(
+                                    ::serde::Deserialize::deserialize(__rest)?,
+                                ))
+                            }
+                            "OBSERVATION" => {
+                                ::core::result::Result::Ok(AbstractEntry::Observation(
+                                    ::serde::Deserialize::deserialize(__rest)?,
+                                ))
+                            }
+                            __other => ::core::result::Result::Err(
+                                ::openehr_base::serde_support::unexpected_type(
+                                    "AbstractEntry",
+                                    __other,
+                                    "ACTION, ADMIN_ENTRY, CARE_ENTRY, EVALUATION, INSTRUCTION, OBSERVATION",
+                                ),
+                            ),
+                        }
+                    }
+                    Some(::openehr_base::serde_support::TagMatch::Unknown(__other)) => {
+                        ::core::result::Result::Err(::openehr_base::serde_support::unexpected_type(
+                            "AbstractEntry",
+                            &__other,
+                            "ACTION, ADMIN_ENTRY, CARE_ENTRY, EVALUATION, INSTRUCTION, OBSERVATION",
+                        ))
+                    }
+                    None => {
+                        ::core::result::Result::Err(::openehr_base::serde_support::missing_type(
+                            "AbstractEntry",
+                            "ACTION, ADMIN_ENTRY, CARE_ENTRY, EVALUATION, INSTRUCTION, OBSERVATION",
+                        ))
+                    }
+                }
+            }
+        }
+        ::serde::Deserializer::deserialize_map(__deserializer, __Visitor)
+    }
 }
 
 /// The `ListOfPartyIdentity` ITS-REST OAS component schema (a non-object shape, so
 /// it is an alias rather than a struct).
-pub type ListOfPartyIdentity = Vec<serde_json::Value>;
+pub type ListOfPartyIdentity = Vec<openehr_rm::prelude::PartyIdentity>;
 
 /// The `DvIntervalOfDate` transport DTO of this API group (an ITS-REST OAS
 /// component schema).
@@ -628,23 +863,23 @@ pub struct DvIntervalOfDate {
     pub _type: Option<String>,
     /// The `lower` property of `DvIntervalOfDate`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub lower: Option<serde_json::Value>,
+    pub lower: Option<openehr_rm::prelude::DvDate>,
     /// The `upper` property of `DvIntervalOfDate`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub upper: Option<serde_json::Value>,
+    pub upper: Option<openehr_rm::prelude::DvDate>,
 }
 
 /// The `ListOfContact` ITS-REST OAS component schema (a non-object shape, so
 /// it is an alias rather than a struct).
-pub type ListOfContact = Vec<serde_json::Value>;
+pub type ListOfContact = Vec<openehr_rm::prelude::Contact>;
 
 /// The `ListOfPartyRelationship` ITS-REST OAS component schema (a non-object shape, so
 /// it is an alias rather than a struct).
-pub type ListOfPartyRelationship = Vec<serde_json::Value>;
+pub type ListOfPartyRelationship = Vec<openehr_rm::prelude::PartyRelationship>;
 
 /// The `ListOfCapability` ITS-REST OAS component schema (a non-object shape, so
 /// it is an alias rather than a struct).
-pub type ListOfCapability = Vec<serde_json::Value>;
+pub type ListOfCapability = Vec<openehr_rm::prelude::Capability>;
 
 /// The `OperationalTemplateV2` ITS-REST OAS component schema (a non-object shape, so
 /// it is an alias rather than a struct).
@@ -844,7 +1079,7 @@ pub struct DefinitionTemplateAdl2VersionGetParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DefinitionQueryListParams {
     /// `qualified_query_name` (path)
-    pub qualified_query_name: String,
+    pub qualified_query_name: QueryName,
     #[serde(rename = "Accept")]
     #[serde(skip_serializing_if = "Option::is_none")]
     /// `Accept` (header)
@@ -855,7 +1090,7 @@ pub struct DefinitionQueryListParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DefinitionQueryStoreYamlParams {
     /// `qualified_query_name` (path)
-    pub qualified_query_name: String,
+    pub qualified_query_name: QueryName,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// `query_type` (query)
     pub query_type: Option<String>,
@@ -873,7 +1108,7 @@ pub struct DefinitionQueryStoreYamlParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DefinitionQueryVersionGetParams {
     /// `qualified_query_name` (path)
-    pub qualified_query_name: String,
+    pub qualified_query_name: QueryName,
     /// `version` (path)
     pub version: String,
     #[serde(rename = "Accept")]
@@ -886,7 +1121,7 @@ pub struct DefinitionQueryVersionGetParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DefinitionQueryVersionStoreYamlParams {
     /// `qualified_query_name` (path)
-    pub qualified_query_name: String,
+    pub qualified_query_name: QueryName,
     /// `version` (path)
     pub version: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -908,7 +1143,7 @@ pub trait DefinitionApi {
     async fn definition_template_adl1_4_list(
         &self,
         params: DefinitionTemplateAdl14ListParams,
-    ) -> Result<Vec<TemplateMetadata>, crate::rest::runtime::ApiError> {
+    ) -> Result<TemplateList, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `POST /definition/template/adl1.4`
@@ -916,7 +1151,7 @@ pub trait DefinitionApi {
         &self,
         params: DefinitionTemplateAdl14UploadParams,
         body: serde_json::Value,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<TemplateIdentifier, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `GET /definition/template/adl1.4/{template_id}`
@@ -937,7 +1172,7 @@ pub trait DefinitionApi {
     async fn definition_template_adl2_list(
         &self,
         params: DefinitionTemplateAdl2ListParams,
-    ) -> Result<Vec<TemplateMetadata>, crate::rest::runtime::ApiError> {
+    ) -> Result<TemplateList, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `POST /definition/template/adl2`
@@ -945,15 +1180,14 @@ pub trait DefinitionApi {
         &self,
         params: DefinitionTemplateAdl2UploadParams,
         body: serde_json::Value,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<TemplateIdentifier, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `GET /definition/template/adl2/{template_id}`
     async fn definition_template_adl2_get(
         &self,
         params: DefinitionTemplateAdl2GetParams,
-    ) -> Result<std::collections::BTreeMap<String, serde_json::Value>, crate::rest::runtime::ApiError>
-    {
+    ) -> Result<OperationalTemplateV2, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `GET /definition/template/adl2/{template_id}/example`
@@ -967,22 +1201,21 @@ pub trait DefinitionApi {
     async fn definition_template_adl2_version_get(
         &self,
         params: DefinitionTemplateAdl2VersionGetParams,
-    ) -> Result<std::collections::BTreeMap<String, serde_json::Value>, crate::rest::runtime::ApiError>
-    {
+    ) -> Result<OperationalTemplateV2, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `GET /definition/query/{qualified_query_name}`
     async fn definition_query_list(
         &self,
         params: DefinitionQueryListParams,
-    ) -> Result<Vec<StoredQuery>, crate::rest::runtime::ApiError> {
+    ) -> Result<QueryList, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `PUT /definition/query/{qualified_query_name}`
     async fn definition_query_store_yaml(
         &self,
         params: DefinitionQueryStoreYamlParams,
-        body: String,
+        body: Aql,
     ) -> Result<(), crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
@@ -990,14 +1223,14 @@ pub trait DefinitionApi {
     async fn definition_query_version_get(
         &self,
         params: DefinitionQueryVersionGetParams,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<StoredQuery, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `PUT /definition/query/{qualified_query_name}/{version}`
     async fn definition_query_version_store_yaml(
         &self,
         params: DefinitionQueryVersionStoreYamlParams,
-        body: String,
+        body: Aql,
     ) -> Result<(), crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }

--- a/crates/openehr-its/src/rest/generated/demographic.rs
+++ b/crates/openehr-its/src/rest/generated/demographic.rs
@@ -25,9 +25,9 @@ pub struct VersionOfParty {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signature: Option<String>,
     /// The `commit_audit` property of `VersionOfParty`.
-    pub commit_audit: serde_json::Value,
+    pub commit_audit: openehr_rm::prelude::AuditDetails,
     /// The `data` property of `VersionOfParty`.
-    pub data: serde_json::Value,
+    pub data: openehr_rm::prelude::Party,
 }
 
 /// The `UpdateItemTag` transport DTO of this API group (an ITS-REST OAS
@@ -56,16 +56,134 @@ pub struct Clstr {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub _type: Option<String>,
     /// The `items` property of `Clstr`.
-    pub items: Vec<serde_json::Value>,
+    pub items: Vec<openehr_rm::prelude::Item>,
 }
 
-/// The `Versionable` ITS-REST OAS component schema (a non-object shape, so
-/// it is an alias rather than a struct).
-pub type Versionable = serde_json::Value;
+/// The `Versionable` ITS-REST OAS component schema: `_type`-discriminated
+/// polymorphism over its OAS `discriminator.mapping` targets.
+#[derive(Debug, Clone)]
+pub enum Versionable {
+    /// `_type: "ACTOR"`
+    Actor(openehr_rm::prelude::Actor),
+    /// `_type: "AGENT"`
+    Agent(openehr_rm::prelude::Agent),
+    /// `_type: "GROUP"`
+    Group(openehr_rm::prelude::Group),
+    /// `_type: "ORGANISATION"`
+    Organisation(openehr_rm::prelude::Organisation),
+    /// `_type: "PARTY"`
+    Party(openehr_rm::prelude::Party),
+    /// `_type: "PERSON"`
+    Person(openehr_rm::prelude::Person),
+    /// `_type: "ROLE"`
+    Role(openehr_rm::prelude::Role),
+}
+
+impl ::serde::Serialize for Versionable {
+    fn serialize<__S: ::serde::Serializer>(
+        &self,
+        __serializer: __S,
+    ) -> ::core::result::Result<__S::Ok, __S::Error> {
+        match self {
+            Self::Actor(__x) => ::serde::Serialize::serialize(__x, __serializer),
+            Self::Agent(__x) => ::serde::Serialize::serialize(__x, __serializer),
+            Self::Group(__x) => ::serde::Serialize::serialize(__x, __serializer),
+            Self::Organisation(__x) => ::serde::Serialize::serialize(__x, __serializer),
+            Self::Party(__x) => ::serde::Serialize::serialize(__x, __serializer),
+            Self::Person(__x) => ::serde::Serialize::serialize(__x, __serializer),
+            Self::Role(__x) => ::serde::Serialize::serialize(__x, __serializer),
+        }
+    }
+}
+
+impl<'de> ::serde::Deserialize<'de> for Versionable {
+    fn deserialize<__D: ::serde::Deserializer<'de>>(
+        __deserializer: __D,
+    ) -> ::core::result::Result<Self, __D::Error> {
+        const __TAGS: &[&str] = &[
+            "ACTOR",
+            "AGENT",
+            "GROUP",
+            "ORGANISATION",
+            "PARTY",
+            "PERSON",
+            "ROLE",
+        ];
+        struct __Visitor;
+        impl<'de> ::serde::de::Visitor<'de> for __Visitor {
+            type Value = Versionable;
+            fn expecting(&self, __f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                __f.write_str("an ITS-REST `Versionable` object")
+            }
+            fn visit_map<__A: ::serde::de::MapAccess<'de>>(
+                self,
+                mut __map: __A,
+            ) -> ::core::result::Result<Self::Value, __A::Error> {
+                let (__tag, __buffered) =
+                    ::openehr_base::serde_support::read_slot_tag(&mut __map, __TAGS)?;
+                match __tag {
+                    Some(::openehr_base::serde_support::TagMatch::Known(__t)) => {
+                        let __rest = ::openehr_base::serde_support::TaggedRest::new(
+                            Some(__t),
+                            __buffered,
+                            __map,
+                        );
+                        match __t {
+                            "ACTOR" => ::core::result::Result::Ok(Versionable::Actor(
+                                ::serde::Deserialize::deserialize(__rest)?,
+                            )),
+                            "AGENT" => ::core::result::Result::Ok(Versionable::Agent(
+                                ::serde::Deserialize::deserialize(__rest)?,
+                            )),
+                            "GROUP" => ::core::result::Result::Ok(Versionable::Group(
+                                ::serde::Deserialize::deserialize(__rest)?,
+                            )),
+                            "ORGANISATION" => {
+                                ::core::result::Result::Ok(Versionable::Organisation(
+                                    ::serde::Deserialize::deserialize(__rest)?,
+                                ))
+                            }
+                            "PARTY" => ::core::result::Result::Ok(Versionable::Party(
+                                ::serde::Deserialize::deserialize(__rest)?,
+                            )),
+                            "PERSON" => ::core::result::Result::Ok(Versionable::Person(
+                                ::serde::Deserialize::deserialize(__rest)?,
+                            )),
+                            "ROLE" => ::core::result::Result::Ok(Versionable::Role(
+                                ::serde::Deserialize::deserialize(__rest)?,
+                            )),
+                            __other => ::core::result::Result::Err(
+                                ::openehr_base::serde_support::unexpected_type(
+                                    "Versionable",
+                                    __other,
+                                    "ACTOR, AGENT, GROUP, ORGANISATION, PARTY, PERSON, ROLE",
+                                ),
+                            ),
+                        }
+                    }
+                    Some(::openehr_base::serde_support::TagMatch::Unknown(__other)) => {
+                        ::core::result::Result::Err(::openehr_base::serde_support::unexpected_type(
+                            "Versionable",
+                            &__other,
+                            "ACTOR, AGENT, GROUP, ORGANISATION, PARTY, PERSON, ROLE",
+                        ))
+                    }
+                    None => {
+                        ::core::result::Result::Err(::openehr_base::serde_support::missing_type(
+                            "Versionable",
+                            "ACTOR, AGENT, GROUP, ORGANISATION, PARTY, PERSON, ROLE",
+                        ))
+                    }
+                }
+            }
+        }
+        ::serde::Deserializer::deserialize_map(__deserializer, __Visitor)
+    }
+}
 
 /// The `ListOfPartyIdentity` ITS-REST OAS component schema (a non-object shape, so
 /// it is an alias rather than a struct).
-pub type ListOfPartyIdentity = Vec<serde_json::Value>;
+pub type ListOfPartyIdentity = Vec<openehr_rm::prelude::PartyIdentity>;
 
 /// The `DvIntervalOfDate` transport DTO of this API group (an ITS-REST OAS
 /// component schema).
@@ -76,19 +194,19 @@ pub struct DvIntervalOfDate {
     pub _type: Option<String>,
     /// The `lower` property of `DvIntervalOfDate`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub lower: Option<serde_json::Value>,
+    pub lower: Option<openehr_rm::prelude::DvDate>,
     /// The `upper` property of `DvIntervalOfDate`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub upper: Option<serde_json::Value>,
+    pub upper: Option<openehr_rm::prelude::DvDate>,
 }
 
 /// The `ListOfContact` ITS-REST OAS component schema (a non-object shape, so
 /// it is an alias rather than a struct).
-pub type ListOfContact = Vec<serde_json::Value>;
+pub type ListOfContact = Vec<openehr_rm::prelude::Contact>;
 
 /// The `ListOfPartyRelationship` ITS-REST OAS component schema (a non-object shape, so
 /// it is an alias rather than a struct).
-pub type ListOfPartyRelationship = Vec<serde_json::Value>;
+pub type ListOfPartyRelationship = Vec<openehr_rm::prelude::PartyRelationship>;
 
 /// The `Identifier` transport DTO of this API group (an ITS-REST OAS
 /// component schema).
@@ -111,7 +229,7 @@ pub struct Error {
 
 /// The `ListOfCapability` ITS-REST OAS component schema (a non-object shape, so
 /// it is an alias rather than a struct).
-pub type ListOfCapability = Vec<serde_json::Value>;
+pub type ListOfCapability = Vec<openehr_rm::prelude::Capability>;
 
 /// The `ObjectRefOfHierObjectId` transport DTO of this API group (an ITS-REST OAS
 /// component schema).
@@ -119,26 +237,85 @@ pub type ListOfCapability = Vec<serde_json::Value>;
 pub struct ObjectRefOfHierObjectId {
     /// The `id` property of `ObjectRefOfHierObjectId`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub id: Option<serde_json::Value>,
+    pub id: Option<openehr_base::prelude::HierObjectId>,
 }
 
-/// The `UpdateAudit` transport DTO of this API group (an ITS-REST OAS
-/// component schema).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct UpdateAudit {
-    /// The `_type` property of `UpdateAudit`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub _type: Option<String>,
-    /// The `system_id` property of `UpdateAudit`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub system_id: Option<String>,
-    /// The `change_type` property of `UpdateAudit`.
-    pub change_type: serde_json::Value,
-    /// The `description` property of `UpdateAudit`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<serde_json::Value>,
-    /// The `committer` property of `UpdateAudit`.
-    pub committer: serde_json::Value,
+/// The `UpdateAudit` ITS-REST OAS component schema: `_type`-discriminated
+/// polymorphism over its OAS `discriminator.mapping` targets.
+#[derive(Debug, Clone)]
+pub enum UpdateAudit {
+    /// `_type: "UPDATE_ATTESTATION"`
+    UpdateAttestation(UpdateAttestation),
+}
+
+impl ::serde::Serialize for UpdateAudit {
+    fn serialize<__S: ::serde::Serializer>(
+        &self,
+        __serializer: __S,
+    ) -> ::core::result::Result<__S::Ok, __S::Error> {
+        match self {
+            Self::UpdateAttestation(__x) => ::serde::Serialize::serialize(__x, __serializer),
+        }
+    }
+}
+
+impl<'de> ::serde::Deserialize<'de> for UpdateAudit {
+    fn deserialize<__D: ::serde::Deserializer<'de>>(
+        __deserializer: __D,
+    ) -> ::core::result::Result<Self, __D::Error> {
+        const __TAGS: &[&str] = &["UPDATE_ATTESTATION"];
+        struct __Visitor;
+        impl<'de> ::serde::de::Visitor<'de> for __Visitor {
+            type Value = UpdateAudit;
+            fn expecting(&self, __f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                __f.write_str("an ITS-REST `UpdateAudit` object")
+            }
+            fn visit_map<__A: ::serde::de::MapAccess<'de>>(
+                self,
+                mut __map: __A,
+            ) -> ::core::result::Result<Self::Value, __A::Error> {
+                let (__tag, __buffered) =
+                    ::openehr_base::serde_support::read_slot_tag(&mut __map, __TAGS)?;
+                match __tag {
+                    Some(::openehr_base::serde_support::TagMatch::Known(__t)) => {
+                        let __rest = ::openehr_base::serde_support::TaggedRest::new(
+                            Some(__t),
+                            __buffered,
+                            __map,
+                        );
+                        match __t {
+                            "UPDATE_ATTESTATION" => {
+                                ::core::result::Result::Ok(UpdateAudit::UpdateAttestation(
+                                    ::serde::Deserialize::deserialize(__rest)?,
+                                ))
+                            }
+                            __other => ::core::result::Result::Err(
+                                ::openehr_base::serde_support::unexpected_type(
+                                    "UpdateAudit",
+                                    __other,
+                                    "UPDATE_ATTESTATION",
+                                ),
+                            ),
+                        }
+                    }
+                    Some(::openehr_base::serde_support::TagMatch::Unknown(__other)) => {
+                        ::core::result::Result::Err(::openehr_base::serde_support::unexpected_type(
+                            "UpdateAudit",
+                            &__other,
+                            "UPDATE_ATTESTATION",
+                        ))
+                    }
+                    None => {
+                        ::core::result::Result::Err(::openehr_base::serde_support::missing_type(
+                            "UpdateAudit",
+                            "UPDATE_ATTESTATION",
+                        ))
+                    }
+                }
+            }
+        }
+        ::serde::Deserializer::deserialize_map(__deserializer, __Visitor)
+    }
 }
 
 /// The `UpdateAttestation` transport DTO of this API group (an ITS-REST OAS
@@ -150,15 +327,15 @@ pub struct UpdateAttestation {
     pub _type: Option<String>,
     /// The `attested_view` property of `UpdateAttestation`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub attested_view: Option<serde_json::Value>,
+    pub attested_view: Option<openehr_rm::prelude::DvMultimedia>,
     /// The `proof` property of `UpdateAttestation`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub proof: Option<String>,
     /// The `items` property of `UpdateAttestation`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub items: Option<Vec<serde_json::Value>>,
+    pub items: Option<Vec<openehr_rm::prelude::DvEhrUri>>,
     /// The `reason` property of `UpdateAttestation`.
-    pub reason: serde_json::Value,
+    pub reason: openehr_rm::prelude::DvText,
     /// The `is_pending` property of `UpdateAttestation`.
     pub is_pending: bool,
 }
@@ -169,12 +346,12 @@ pub struct UpdateAttestation {
 pub struct UpdateVersion {
     /// The `preceding_version_uid` property of `UpdateVersion`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub preceding_version_uid: Option<serde_json::Value>,
+    pub preceding_version_uid: Option<openehr_base::prelude::ObjectVersionId>,
     /// The `signature` property of `UpdateVersion`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signature: Option<String>,
     /// The `lifecycle_state` property of `UpdateVersion`.
-    pub lifecycle_state: serde_json::Value,
+    pub lifecycle_state: openehr_rm::prelude::DvCodedText,
     /// The `attestations` property of `UpdateVersion`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub attestations: Option<Vec<UpdateAttestation>>,
@@ -190,7 +367,7 @@ pub struct UpdateVersion {
 pub struct NewContribution {
     /// The `uid` property of `NewContribution`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub uid: Option<serde_json::Value>,
+    pub uid: Option<openehr_base::prelude::HierObjectId>,
     /// The `versions` property of `NewContribution`.
     pub versions: Vec<UpdateVersion>,
     /// The `audit` property of `NewContribution`.
@@ -203,28 +380,28 @@ pub struct NewContribution {
 pub struct ObjectRefOfObjectVersionId {
     /// The `id` property of `ObjectRefOfObjectVersionId`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub id: Option<serde_json::Value>,
+    pub id: Option<openehr_base::prelude::ObjectVersionId>,
 }
 
 /// The `ItemTagOfPerson` ITS-REST OAS component schema (a non-object shape, so
 /// it is an alias rather than a struct).
-pub type ItemTagOfPerson = serde_json::Value;
+pub type ItemTagOfPerson = openehr_rm::prelude::ItemTag;
 
 /// The `ItemTagOfAgent` ITS-REST OAS component schema (a non-object shape, so
 /// it is an alias rather than a struct).
-pub type ItemTagOfAgent = serde_json::Value;
+pub type ItemTagOfAgent = openehr_rm::prelude::ItemTag;
 
 /// The `ItemTagOfGroup` ITS-REST OAS component schema (a non-object shape, so
 /// it is an alias rather than a struct).
-pub type ItemTagOfGroup = serde_json::Value;
+pub type ItemTagOfGroup = openehr_rm::prelude::ItemTag;
 
 /// The `ItemTagOfOrganisation` ITS-REST OAS component schema (a non-object shape, so
 /// it is an alias rather than a struct).
-pub type ItemTagOfOrganisation = serde_json::Value;
+pub type ItemTagOfOrganisation = openehr_rm::prelude::ItemTag;
 
 /// The `ItemTagOfRole` ITS-REST OAS component schema (a non-object shape, so
 /// it is an alias rather than a struct).
-pub type ItemTagOfRole = serde_json::Value;
+pub type ItemTagOfRole = openehr_rm::prelude::ItemTag;
 
 /// Parameters for `agent_create` (path/query/header).
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -902,7 +1079,7 @@ pub trait DemographicApi {
     async fn agent_create(
         &self,
         params: AgentCreateParams,
-        body: serde_json::Value,
+        body: openehr_rm::prelude::Agent,
     ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
@@ -910,14 +1087,14 @@ pub trait DemographicApi {
     async fn agent_get(
         &self,
         params: AgentGetParams,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<openehr_rm::prelude::Agent, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `PUT /demographic/agent/{uid_based_id}`
     async fn agent_update(
         &self,
         params: AgentUpdateParams,
-        body: serde_json::Value,
+        body: openehr_rm::prelude::Agent,
     ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
@@ -932,7 +1109,7 @@ pub trait DemographicApi {
     async fn group_create(
         &self,
         params: GroupCreateParams,
-        body: serde_json::Value,
+        body: openehr_rm::prelude::Group,
     ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
@@ -940,14 +1117,14 @@ pub trait DemographicApi {
     async fn group_get(
         &self,
         params: GroupGetParams,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<openehr_rm::prelude::Group, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `PUT /demographic/group/{uid_based_id}`
     async fn group_update(
         &self,
         params: GroupUpdateParams,
-        body: serde_json::Value,
+        body: openehr_rm::prelude::Group,
     ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
@@ -962,7 +1139,7 @@ pub trait DemographicApi {
     async fn organisation_create(
         &self,
         params: OrganisationCreateParams,
-        body: serde_json::Value,
+        body: openehr_rm::prelude::Organisation,
     ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
@@ -970,14 +1147,14 @@ pub trait DemographicApi {
     async fn organisation_get(
         &self,
         params: OrganisationGetParams,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<openehr_rm::prelude::Organisation, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `PUT /demographic/organisation/{uid_based_id}`
     async fn organisation_update(
         &self,
         params: OrganisationUpdateParams,
-        body: serde_json::Value,
+        body: openehr_rm::prelude::Organisation,
     ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
@@ -992,7 +1169,7 @@ pub trait DemographicApi {
     async fn person_create(
         &self,
         params: PersonCreateParams,
-        body: serde_json::Value,
+        body: openehr_rm::prelude::Person,
     ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
@@ -1000,14 +1177,14 @@ pub trait DemographicApi {
     async fn person_get(
         &self,
         params: PersonGetParams,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<openehr_rm::prelude::Person, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `PUT /demographic/person/{uid_based_id}`
     async fn person_update(
         &self,
         params: PersonUpdateParams,
-        body: serde_json::Value,
+        body: openehr_rm::prelude::Person,
     ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
@@ -1022,7 +1199,7 @@ pub trait DemographicApi {
     async fn role_create(
         &self,
         params: RoleCreateParams,
-        body: serde_json::Value,
+        body: openehr_rm::prelude::Role,
     ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
@@ -1030,14 +1207,14 @@ pub trait DemographicApi {
     async fn role_get(
         &self,
         params: RoleGetParams,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<openehr_rm::prelude::Role, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `PUT /demographic/role/{uid_based_id}`
     async fn role_update(
         &self,
         params: RoleUpdateParams,
-        body: serde_json::Value,
+        body: openehr_rm::prelude::Role,
     ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
@@ -1052,35 +1229,35 @@ pub trait DemographicApi {
     async fn versioned_party_get(
         &self,
         params: VersionedPartyGetParams,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<openehr_rm::prelude::VersionedParty, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `GET /demographic/versioned_party/{versioned_object_uid}/revision_history`
     async fn versioned_party_revision_history(
         &self,
         params: VersionedPartyRevisionHistoryParams,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<openehr_rm::prelude::RevisionHistory, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `GET /demographic/versioned_party/{versioned_object_uid}/version`
     async fn versioned_party_version_get_at_time(
         &self,
         params: VersionedPartyVersionGetAtTimeParams,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<VersionOfParty, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `GET /demographic/versioned_party/{versioned_object_uid}/version/{version_uid}`
     async fn versioned_party_version_get_by_id(
         &self,
         params: VersionedPartyVersionGetByIdParams,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<VersionOfParty, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `POST /demographic/contribution`
     async fn contribution_create(
         &self,
         params: ContributionCreateParams,
-        body: serde_json::Value,
+        body: NewContribution,
     ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
@@ -1088,7 +1265,7 @@ pub trait DemographicApi {
     async fn contribution_get(
         &self,
         params: ContributionGetParams,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<openehr_rm::prelude::Contribution, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `GET /demographic/tags`

--- a/crates/openehr-its/src/rest/generated/ehr.rs
+++ b/crates/openehr-its/src/rest/generated/ehr.rs
@@ -25,9 +25,9 @@ pub struct VersionOfComposition {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signature: Option<String>,
     /// The `commit_audit` property of `VersionOfComposition`.
-    pub commit_audit: serde_json::Value,
+    pub commit_audit: openehr_rm::prelude::AuditDetails,
     /// The `data` property of `VersionOfComposition`.
-    pub data: serde_json::Value,
+    pub data: openehr_rm::prelude::Composition,
 }
 
 /// The `VersionOfEhrStatus` transport DTO of this API group (an ITS-REST OAS
@@ -43,9 +43,9 @@ pub struct VersionOfEhrStatus {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signature: Option<String>,
     /// The `commit_audit` property of `VersionOfEhrStatus`.
-    pub commit_audit: serde_json::Value,
+    pub commit_audit: openehr_rm::prelude::AuditDetails,
     /// The `data` property of `VersionOfEhrStatus`.
-    pub data: serde_json::Value,
+    pub data: openehr_rm::prelude::EhrStatus,
 }
 
 /// The `ObjectRefOfObjectVersionId` transport DTO of this API group (an ITS-REST OAS
@@ -54,7 +54,7 @@ pub struct VersionOfEhrStatus {
 pub struct ObjectRefOfObjectVersionId {
     /// The `id` property of `ObjectRefOfObjectVersionId`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub id: Option<serde_json::Value>,
+    pub id: Option<openehr_base::prelude::ObjectVersionId>,
 }
 
 /// The `Clstr` transport DTO of this API group (an ITS-REST OAS
@@ -65,12 +65,96 @@ pub struct Clstr {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub _type: Option<String>,
     /// The `items` property of `Clstr`.
-    pub items: Vec<serde_json::Value>,
+    pub items: Vec<openehr_rm::prelude::Item>,
 }
 
-/// The `Versionable` ITS-REST OAS component schema (a non-object shape, so
-/// it is an alias rather than a struct).
-pub type Versionable = serde_json::Value;
+/// The `Versionable` ITS-REST OAS component schema: `_type`-discriminated
+/// polymorphism over its OAS `discriminator.mapping` targets.
+#[derive(Debug, Clone)]
+pub enum Versionable {
+    /// `_type: "COMPOSITION"`
+    Composition(openehr_rm::prelude::Composition),
+    /// `_type: "EHR_STATUS"`
+    EhrStatus(openehr_rm::prelude::EhrStatus),
+    /// `_type: "FOLDER"`
+    Folder(openehr_rm::prelude::Folder),
+}
+
+impl ::serde::Serialize for Versionable {
+    fn serialize<__S: ::serde::Serializer>(
+        &self,
+        __serializer: __S,
+    ) -> ::core::result::Result<__S::Ok, __S::Error> {
+        match self {
+            Self::Composition(__x) => ::serde::Serialize::serialize(__x, __serializer),
+            Self::EhrStatus(__x) => ::serde::Serialize::serialize(__x, __serializer),
+            Self::Folder(__x) => ::serde::Serialize::serialize(__x, __serializer),
+        }
+    }
+}
+
+impl<'de> ::serde::Deserialize<'de> for Versionable {
+    fn deserialize<__D: ::serde::Deserializer<'de>>(
+        __deserializer: __D,
+    ) -> ::core::result::Result<Self, __D::Error> {
+        const __TAGS: &[&str] = &["COMPOSITION", "EHR_STATUS", "FOLDER"];
+        struct __Visitor;
+        impl<'de> ::serde::de::Visitor<'de> for __Visitor {
+            type Value = Versionable;
+            fn expecting(&self, __f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                __f.write_str("an ITS-REST `Versionable` object")
+            }
+            fn visit_map<__A: ::serde::de::MapAccess<'de>>(
+                self,
+                mut __map: __A,
+            ) -> ::core::result::Result<Self::Value, __A::Error> {
+                let (__tag, __buffered) =
+                    ::openehr_base::serde_support::read_slot_tag(&mut __map, __TAGS)?;
+                match __tag {
+                    Some(::openehr_base::serde_support::TagMatch::Known(__t)) => {
+                        let __rest = ::openehr_base::serde_support::TaggedRest::new(
+                            Some(__t),
+                            __buffered,
+                            __map,
+                        );
+                        match __t {
+                            "COMPOSITION" => ::core::result::Result::Ok(Versionable::Composition(
+                                ::serde::Deserialize::deserialize(__rest)?,
+                            )),
+                            "EHR_STATUS" => ::core::result::Result::Ok(Versionable::EhrStatus(
+                                ::serde::Deserialize::deserialize(__rest)?,
+                            )),
+                            "FOLDER" => ::core::result::Result::Ok(Versionable::Folder(
+                                ::serde::Deserialize::deserialize(__rest)?,
+                            )),
+                            __other => ::core::result::Result::Err(
+                                ::openehr_base::serde_support::unexpected_type(
+                                    "Versionable",
+                                    __other,
+                                    "COMPOSITION, EHR_STATUS, FOLDER",
+                                ),
+                            ),
+                        }
+                    }
+                    Some(::openehr_base::serde_support::TagMatch::Unknown(__other)) => {
+                        ::core::result::Result::Err(::openehr_base::serde_support::unexpected_type(
+                            "Versionable",
+                            &__other,
+                            "COMPOSITION, EHR_STATUS, FOLDER",
+                        ))
+                    }
+                    None => {
+                        ::core::result::Result::Err(::openehr_base::serde_support::missing_type(
+                            "Versionable",
+                            "COMPOSITION, EHR_STATUS, FOLDER",
+                        ))
+                    }
+                }
+            }
+        }
+        ::serde::Deserializer::deserialize_map(__deserializer, __Visitor)
+    }
+}
 
 /// The `Identifier` transport DTO of this API group (an ITS-REST OAS
 /// component schema).
@@ -115,7 +199,7 @@ pub struct UpdateItemTag {
 pub struct ObjectRefOfHierObjectId {
     /// The `id` property of `ObjectRefOfHierObjectId`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub id: Option<serde_json::Value>,
+    pub id: Option<openehr_base::prelude::HierObjectId>,
 }
 
 /// The `DvIntervalOfDateTime` transport DTO of this API group (an ITS-REST OAS
@@ -127,50 +211,205 @@ pub struct DvIntervalOfDateTime {
     pub _type: Option<String>,
     /// The `lower` property of `DvIntervalOfDateTime`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub lower: Option<serde_json::Value>,
+    pub lower: Option<openehr_rm::prelude::DvDateTime>,
     /// The `upper` property of `DvIntervalOfDateTime`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub upper: Option<serde_json::Value>,
+    pub upper: Option<openehr_rm::prelude::DvDateTime>,
 }
 
-/// The `AbstractEntry` transport DTO of this API group (an ITS-REST OAS
-/// component schema).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AbstractEntry {
-    /// The `language` property of `AbstractEntry`.
-    pub language: serde_json::Value,
-    /// The `encoding` property of `AbstractEntry`.
-    pub encoding: serde_json::Value,
-    /// The `other_participations` property of `AbstractEntry`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub other_participations: Option<Vec<serde_json::Value>>,
-    /// The `workflow_id` property of `AbstractEntry`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub workflow_id: Option<serde_json::Value>,
-    /// The `subject` property of `AbstractEntry`.
-    pub subject: serde_json::Value,
-    /// The `provider` property of `AbstractEntry`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub provider: Option<serde_json::Value>,
+/// The `AbstractEntry` ITS-REST OAS component schema: `_type`-discriminated
+/// polymorphism over its OAS `discriminator.mapping` targets.
+#[derive(Debug, Clone)]
+pub enum AbstractEntry {
+    /// `_type: "ACTION"`
+    Action(openehr_rm::prelude::Action),
+    /// `_type: "ADMIN_ENTRY"`
+    AdminEntry(openehr_rm::prelude::AdminEntry),
+    /// `_type: "CARE_ENTRY"`
+    CareEntry(openehr_rm::prelude::CareEntry),
+    /// `_type: "EVALUATION"`
+    Evaluation(openehr_rm::prelude::Evaluation),
+    /// `_type: "INSTRUCTION"`
+    Instruction(openehr_rm::prelude::Instruction),
+    /// `_type: "OBSERVATION"`
+    Observation(openehr_rm::prelude::Observation),
 }
 
-/// The `UpdateAudit` transport DTO of this API group (an ITS-REST OAS
-/// component schema).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct UpdateAudit {
-    /// The `_type` property of `UpdateAudit`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub _type: Option<String>,
-    /// The `system_id` property of `UpdateAudit`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub system_id: Option<String>,
-    /// The `change_type` property of `UpdateAudit`.
-    pub change_type: serde_json::Value,
-    /// The `description` property of `UpdateAudit`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<serde_json::Value>,
-    /// The `committer` property of `UpdateAudit`.
-    pub committer: serde_json::Value,
+impl ::serde::Serialize for AbstractEntry {
+    fn serialize<__S: ::serde::Serializer>(
+        &self,
+        __serializer: __S,
+    ) -> ::core::result::Result<__S::Ok, __S::Error> {
+        match self {
+            Self::Action(__x) => ::serde::Serialize::serialize(__x, __serializer),
+            Self::AdminEntry(__x) => ::serde::Serialize::serialize(__x, __serializer),
+            Self::CareEntry(__x) => ::serde::Serialize::serialize(__x, __serializer),
+            Self::Evaluation(__x) => ::serde::Serialize::serialize(__x, __serializer),
+            Self::Instruction(__x) => ::serde::Serialize::serialize(__x, __serializer),
+            Self::Observation(__x) => ::serde::Serialize::serialize(__x, __serializer),
+        }
+    }
+}
+
+impl<'de> ::serde::Deserialize<'de> for AbstractEntry {
+    fn deserialize<__D: ::serde::Deserializer<'de>>(
+        __deserializer: __D,
+    ) -> ::core::result::Result<Self, __D::Error> {
+        const __TAGS: &[&str] = &[
+            "ACTION",
+            "ADMIN_ENTRY",
+            "CARE_ENTRY",
+            "EVALUATION",
+            "INSTRUCTION",
+            "OBSERVATION",
+        ];
+        struct __Visitor;
+        impl<'de> ::serde::de::Visitor<'de> for __Visitor {
+            type Value = AbstractEntry;
+            fn expecting(&self, __f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                __f.write_str("an ITS-REST `AbstractEntry` object")
+            }
+            fn visit_map<__A: ::serde::de::MapAccess<'de>>(
+                self,
+                mut __map: __A,
+            ) -> ::core::result::Result<Self::Value, __A::Error> {
+                let (__tag, __buffered) =
+                    ::openehr_base::serde_support::read_slot_tag(&mut __map, __TAGS)?;
+                match __tag {
+                    Some(::openehr_base::serde_support::TagMatch::Known(__t)) => {
+                        let __rest = ::openehr_base::serde_support::TaggedRest::new(
+                            Some(__t),
+                            __buffered,
+                            __map,
+                        );
+                        match __t {
+                            "ACTION" => ::core::result::Result::Ok(AbstractEntry::Action(
+                                ::serde::Deserialize::deserialize(__rest)?,
+                            )),
+                            "ADMIN_ENTRY" => ::core::result::Result::Ok(AbstractEntry::AdminEntry(
+                                ::serde::Deserialize::deserialize(__rest)?,
+                            )),
+                            "CARE_ENTRY" => ::core::result::Result::Ok(AbstractEntry::CareEntry(
+                                ::serde::Deserialize::deserialize(__rest)?,
+                            )),
+                            "EVALUATION" => ::core::result::Result::Ok(AbstractEntry::Evaluation(
+                                ::serde::Deserialize::deserialize(__rest)?,
+                            )),
+                            "INSTRUCTION" => {
+                                ::core::result::Result::Ok(AbstractEntry::Instruction(
+                                    ::serde::Deserialize::deserialize(__rest)?,
+                                ))
+                            }
+                            "OBSERVATION" => {
+                                ::core::result::Result::Ok(AbstractEntry::Observation(
+                                    ::serde::Deserialize::deserialize(__rest)?,
+                                ))
+                            }
+                            __other => ::core::result::Result::Err(
+                                ::openehr_base::serde_support::unexpected_type(
+                                    "AbstractEntry",
+                                    __other,
+                                    "ACTION, ADMIN_ENTRY, CARE_ENTRY, EVALUATION, INSTRUCTION, OBSERVATION",
+                                ),
+                            ),
+                        }
+                    }
+                    Some(::openehr_base::serde_support::TagMatch::Unknown(__other)) => {
+                        ::core::result::Result::Err(::openehr_base::serde_support::unexpected_type(
+                            "AbstractEntry",
+                            &__other,
+                            "ACTION, ADMIN_ENTRY, CARE_ENTRY, EVALUATION, INSTRUCTION, OBSERVATION",
+                        ))
+                    }
+                    None => {
+                        ::core::result::Result::Err(::openehr_base::serde_support::missing_type(
+                            "AbstractEntry",
+                            "ACTION, ADMIN_ENTRY, CARE_ENTRY, EVALUATION, INSTRUCTION, OBSERVATION",
+                        ))
+                    }
+                }
+            }
+        }
+        ::serde::Deserializer::deserialize_map(__deserializer, __Visitor)
+    }
+}
+
+/// The `UpdateAudit` ITS-REST OAS component schema: `_type`-discriminated
+/// polymorphism over its OAS `discriminator.mapping` targets.
+#[derive(Debug, Clone)]
+pub enum UpdateAudit {
+    /// `_type: "UPDATE_ATTESTATION"`
+    UpdateAttestation(UpdateAttestation),
+}
+
+impl ::serde::Serialize for UpdateAudit {
+    fn serialize<__S: ::serde::Serializer>(
+        &self,
+        __serializer: __S,
+    ) -> ::core::result::Result<__S::Ok, __S::Error> {
+        match self {
+            Self::UpdateAttestation(__x) => ::serde::Serialize::serialize(__x, __serializer),
+        }
+    }
+}
+
+impl<'de> ::serde::Deserialize<'de> for UpdateAudit {
+    fn deserialize<__D: ::serde::Deserializer<'de>>(
+        __deserializer: __D,
+    ) -> ::core::result::Result<Self, __D::Error> {
+        const __TAGS: &[&str] = &["UPDATE_ATTESTATION"];
+        struct __Visitor;
+        impl<'de> ::serde::de::Visitor<'de> for __Visitor {
+            type Value = UpdateAudit;
+            fn expecting(&self, __f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                __f.write_str("an ITS-REST `UpdateAudit` object")
+            }
+            fn visit_map<__A: ::serde::de::MapAccess<'de>>(
+                self,
+                mut __map: __A,
+            ) -> ::core::result::Result<Self::Value, __A::Error> {
+                let (__tag, __buffered) =
+                    ::openehr_base::serde_support::read_slot_tag(&mut __map, __TAGS)?;
+                match __tag {
+                    Some(::openehr_base::serde_support::TagMatch::Known(__t)) => {
+                        let __rest = ::openehr_base::serde_support::TaggedRest::new(
+                            Some(__t),
+                            __buffered,
+                            __map,
+                        );
+                        match __t {
+                            "UPDATE_ATTESTATION" => {
+                                ::core::result::Result::Ok(UpdateAudit::UpdateAttestation(
+                                    ::serde::Deserialize::deserialize(__rest)?,
+                                ))
+                            }
+                            __other => ::core::result::Result::Err(
+                                ::openehr_base::serde_support::unexpected_type(
+                                    "UpdateAudit",
+                                    __other,
+                                    "UPDATE_ATTESTATION",
+                                ),
+                            ),
+                        }
+                    }
+                    Some(::openehr_base::serde_support::TagMatch::Unknown(__other)) => {
+                        ::core::result::Result::Err(::openehr_base::serde_support::unexpected_type(
+                            "UpdateAudit",
+                            &__other,
+                            "UPDATE_ATTESTATION",
+                        ))
+                    }
+                    None => {
+                        ::core::result::Result::Err(::openehr_base::serde_support::missing_type(
+                            "UpdateAudit",
+                            "UPDATE_ATTESTATION",
+                        ))
+                    }
+                }
+            }
+        }
+        ::serde::Deserializer::deserialize_map(__deserializer, __Visitor)
+    }
 }
 
 /// The `UpdateAttestation` transport DTO of this API group (an ITS-REST OAS
@@ -182,15 +421,15 @@ pub struct UpdateAttestation {
     pub _type: Option<String>,
     /// The `attested_view` property of `UpdateAttestation`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub attested_view: Option<serde_json::Value>,
+    pub attested_view: Option<openehr_rm::prelude::DvMultimedia>,
     /// The `proof` property of `UpdateAttestation`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub proof: Option<String>,
     /// The `items` property of `UpdateAttestation`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub items: Option<Vec<serde_json::Value>>,
+    pub items: Option<Vec<openehr_rm::prelude::DvEhrUri>>,
     /// The `reason` property of `UpdateAttestation`.
-    pub reason: serde_json::Value,
+    pub reason: openehr_rm::prelude::DvText,
     /// The `is_pending` property of `UpdateAttestation`.
     pub is_pending: bool,
 }
@@ -201,12 +440,12 @@ pub struct UpdateAttestation {
 pub struct UpdateVersion {
     /// The `preceding_version_uid` property of `UpdateVersion`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub preceding_version_uid: Option<serde_json::Value>,
+    pub preceding_version_uid: Option<openehr_base::prelude::ObjectVersionId>,
     /// The `signature` property of `UpdateVersion`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signature: Option<String>,
     /// The `lifecycle_state` property of `UpdateVersion`.
-    pub lifecycle_state: serde_json::Value,
+    pub lifecycle_state: openehr_rm::prelude::DvCodedText,
     /// The `attestations` property of `UpdateVersion`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub attestations: Option<Vec<UpdateAttestation>>,
@@ -222,7 +461,7 @@ pub struct UpdateVersion {
 pub struct NewContribution {
     /// The `uid` property of `NewContribution`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub uid: Option<serde_json::Value>,
+    pub uid: Option<openehr_base::prelude::HierObjectId>,
     /// The `versions` property of `NewContribution`.
     pub versions: Vec<UpdateVersion>,
     /// The `audit` property of `NewContribution`.
@@ -231,11 +470,11 @@ pub struct NewContribution {
 
 /// The `ItemTagOfComposition` ITS-REST OAS component schema (a non-object shape, so
 /// it is an alias rather than a struct).
-pub type ItemTagOfComposition = serde_json::Value;
+pub type ItemTagOfComposition = openehr_rm::prelude::ItemTag;
 
 /// The `ItemTagOfEhrStatus` ITS-REST OAS component schema (a non-object shape, so
 /// it is an alias rather than a struct).
-pub type ItemTagOfEhrStatus = serde_json::Value;
+pub type ItemTagOfEhrStatus = openehr_rm::prelude::ItemTag;
 
 /// Parameters for `ehr_get_by_subject` (path/query/header).
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -812,14 +1051,14 @@ pub trait EhrApi {
     async fn ehr_get_by_subject(
         &self,
         params: EhrGetBySubjectParams,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<openehr_rm::prelude::Ehr, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `POST /ehr`
     async fn ehr_create(
         &self,
         params: EhrCreateParams,
-        body: Option<serde_json::Value>,
+        body: Option<openehr_rm::prelude::EhrStatus>,
     ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
@@ -827,14 +1066,14 @@ pub trait EhrApi {
     async fn ehr_get_by_id(
         &self,
         params: EhrGetByIdParams,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<openehr_rm::prelude::Ehr, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `PUT /ehr/{ehr_id}`
     async fn ehr_create_with_id(
         &self,
         params: EhrCreateWithIdParams,
-        body: Option<serde_json::Value>,
+        body: Option<openehr_rm::prelude::EhrStatus>,
     ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
@@ -842,21 +1081,21 @@ pub trait EhrApi {
     async fn ehr_status_get_by_version_id(
         &self,
         params: EhrStatusGetByVersionIdParams,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<openehr_rm::prelude::EhrStatus, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `GET /ehr/{ehr_id}/ehr_status`
     async fn ehr_status_get_at_time(
         &self,
         params: EhrStatusGetAtTimeParams,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<openehr_rm::prelude::EhrStatus, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `PUT /ehr/{ehr_id}/ehr_status`
     async fn ehr_status_update(
         &self,
         params: EhrStatusUpdateParams,
-        body: serde_json::Value,
+        body: openehr_rm::prelude::EhrStatus,
     ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
@@ -864,35 +1103,35 @@ pub trait EhrApi {
     async fn versioned_ehr_status_get(
         &self,
         params: VersionedEhrStatusGetParams,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<openehr_rm::prelude::VersionedEhrStatus, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `GET /ehr/{ehr_id}/versioned_ehr_status/revision_history`
     async fn versioned_ehr_status_revision_history(
         &self,
         params: VersionedEhrStatusRevisionHistoryParams,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<openehr_rm::prelude::RevisionHistory, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `GET /ehr/{ehr_id}/versioned_ehr_status/version`
     async fn versioned_ehr_status_version_get_at_time(
         &self,
         params: VersionedEhrStatusVersionGetAtTimeParams,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<VersionOfEhrStatus, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `GET /ehr/{ehr_id}/versioned_ehr_status/version/{version_uid}`
     async fn versioned_ehr_status_version_get_by_id(
         &self,
         params: VersionedEhrStatusVersionGetByIdParams,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<VersionOfEhrStatus, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `POST /ehr/{ehr_id}/composition`
     async fn composition_create(
         &self,
         params: CompositionCreateParams,
-        body: serde_json::Value,
+        body: openehr_rm::prelude::Composition,
     ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
@@ -900,14 +1139,14 @@ pub trait EhrApi {
     async fn composition_get(
         &self,
         params: CompositionGetParams,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<openehr_rm::prelude::Composition, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `PUT /ehr/{ehr_id}/composition/{uid_based_id}`
     async fn composition_update(
         &self,
         params: CompositionUpdateParams,
-        body: serde_json::Value,
+        body: openehr_rm::prelude::Composition,
     ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
@@ -922,42 +1161,42 @@ pub trait EhrApi {
     async fn versioned_composition_get(
         &self,
         params: VersionedCompositionGetParams,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<openehr_rm::prelude::VersionedComposition, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `GET /ehr/{ehr_id}/versioned_composition/{versioned_object_uid}/revision_history`
     async fn versioned_composition_revision_history(
         &self,
         params: VersionedCompositionRevisionHistoryParams,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<openehr_rm::prelude::RevisionHistory, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `GET /ehr/{ehr_id}/versioned_composition/{versioned_object_uid}/version`
     async fn versioned_composition_version_get_at_time(
         &self,
         params: VersionedCompositionVersionGetAtTimeParams,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<VersionOfComposition, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `GET /ehr/{ehr_id}/versioned_composition/{versioned_object_uid}/version/{version_uid}`
     async fn versioned_composition_version_get_by_id(
         &self,
         params: VersionedCompositionVersionGetByIdParams,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<VersionOfComposition, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `GET /ehr/{ehr_id}/directory`
     async fn directory_get_at_time(
         &self,
         params: DirectoryGetAtTimeParams,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<openehr_rm::prelude::Folder, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `PUT /ehr/{ehr_id}/directory`
     async fn directory_update(
         &self,
         params: DirectoryUpdateParams,
-        body: serde_json::Value,
+        body: openehr_rm::prelude::Folder,
     ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
@@ -965,7 +1204,7 @@ pub trait EhrApi {
     async fn directory_create(
         &self,
         params: DirectoryCreateParams,
-        body: serde_json::Value,
+        body: openehr_rm::prelude::Folder,
     ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
@@ -980,14 +1219,14 @@ pub trait EhrApi {
     async fn directory_get_by_version_id(
         &self,
         params: DirectoryGetByVersionIdParams,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<openehr_rm::prelude::Folder, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `POST /ehr/{ehr_id}/contribution`
     async fn contribution_create(
         &self,
         params: ContributionCreateParams,
-        body: serde_json::Value,
+        body: NewContribution,
     ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
@@ -995,7 +1234,7 @@ pub trait EhrApi {
     async fn contribution_get(
         &self,
         params: ContributionGetParams,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<openehr_rm::prelude::Contribution, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `GET /ehr/{ehr_id}/tags`

--- a/crates/openehr-its/src/rest/generated/query.rs
+++ b/crates/openehr-its/src/rest/generated/query.rs
@@ -137,7 +137,7 @@ pub struct Query {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueryExecuteAdhocQueryParams {
     /// `q` (query)
-    pub q: String,
+    pub q: Aql,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// `ehr_id` (query)
     pub ehr_id: Option<String>,
@@ -149,7 +149,7 @@ pub struct QueryExecuteAdhocQueryParams {
     pub fetch: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// `query_parameters` (query)
-    pub query_parameters: Option<std::collections::BTreeMap<String, serde_json::Value>>,
+    pub query_parameters: Option<QueryParameters>,
     #[serde(rename = "Accept")]
     #[serde(skip_serializing_if = "Option::is_none")]
     /// `Accept` (header)
@@ -173,7 +173,7 @@ pub struct QueryExecuteAdhocQueryBodyParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueryExecuteStoredQueryParams {
     /// `qualified_query_name` (path)
-    pub qualified_query_name: String,
+    pub qualified_query_name: QueryName,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// `ehr_id` (query)
     pub ehr_id: Option<String>,
@@ -185,7 +185,7 @@ pub struct QueryExecuteStoredQueryParams {
     pub fetch: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// `query_parameters` (query)
-    pub query_parameters: Option<std::collections::BTreeMap<String, serde_json::Value>>,
+    pub query_parameters: Option<QueryParameters>,
     #[serde(rename = "Accept")]
     #[serde(skip_serializing_if = "Option::is_none")]
     /// `Accept` (header)
@@ -196,7 +196,7 @@ pub struct QueryExecuteStoredQueryParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueryExecuteStoredQueryBodyParams {
     /// `qualified_query_name` (path)
-    pub qualified_query_name: String,
+    pub qualified_query_name: QueryName,
     #[serde(rename = "Accept")]
     #[serde(skip_serializing_if = "Option::is_none")]
     /// `Accept` (header)
@@ -211,7 +211,7 @@ pub struct QueryExecuteStoredQueryBodyParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueryExecuteStoredQueryVersionParams {
     /// `qualified_query_name` (path)
-    pub qualified_query_name: String,
+    pub qualified_query_name: QueryName,
     /// `version` (path)
     pub version: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -225,7 +225,7 @@ pub struct QueryExecuteStoredQueryVersionParams {
     pub fetch: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// `query_parameters` (query)
-    pub query_parameters: Option<std::collections::BTreeMap<String, serde_json::Value>>,
+    pub query_parameters: Option<QueryParameters>,
     #[serde(rename = "Accept")]
     #[serde(skip_serializing_if = "Option::is_none")]
     /// `Accept` (header)
@@ -236,7 +236,7 @@ pub struct QueryExecuteStoredQueryVersionParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueryExecuteStoredQueryVersionBodyParams {
     /// `qualified_query_name` (path)
-    pub qualified_query_name: String,
+    pub qualified_query_name: QueryName,
     /// `version` (path)
     pub version: String,
     #[serde(rename = "Accept")]
@@ -259,45 +259,45 @@ pub trait QueryApi {
     async fn query_execute_adhoc_query(
         &self,
         params: QueryExecuteAdhocQueryParams,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<ResultSet, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `POST /query/aql`
     async fn query_execute_adhoc_query_body(
         &self,
         params: QueryExecuteAdhocQueryBodyParams,
-        body: serde_json::Value,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+        body: AdhocQueryExecute,
+    ) -> Result<ResultSet, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `GET /query/{qualified_query_name}`
     async fn query_execute_stored_query(
         &self,
         params: QueryExecuteStoredQueryParams,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<ResultSet, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `POST /query/{qualified_query_name}`
     async fn query_execute_stored_query_body(
         &self,
         params: QueryExecuteStoredQueryBodyParams,
-        body: serde_json::Value,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+        body: Query,
+    ) -> Result<ResultSet, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `GET /query/{qualified_query_name}/{version}`
     async fn query_execute_stored_query_version(
         &self,
         params: QueryExecuteStoredQueryVersionParams,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<ResultSet, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
     /// `POST /query/{qualified_query_name}/{version}`
     async fn query_execute_stored_query_version_body(
         &self,
         params: QueryExecuteStoredQueryVersionBodyParams,
-        body: serde_json::Value,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+        body: Query,
+    ) -> Result<ResultSet, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
 }

--- a/crates/openehr-its/src/rest/generated/system.rs
+++ b/crates/openehr-its/src/rest/generated/system.rs
@@ -55,7 +55,7 @@ pub trait SystemApi {
     async fn options(
         &self,
         params: OptionsParams,
-    ) -> Result<serde_json::Value, crate::rest::runtime::ApiError> {
+    ) -> Result<Options, crate::rest::runtime::ApiError> {
         Err(crate::rest::runtime::ApiError::NotImplemented)
     }
 }

--- a/tools/openehr-codegen/src/load/oas.rs
+++ b/tools/openehr-codegen/src/load/oas.rs
@@ -148,9 +148,10 @@ impl Oas {
                 name: name.to_string(),
                 location: location.to_string(),
                 required: p.get("required").and_then(Value::as_bool).unwrap_or(false),
-                schema: p
-                    .get("schema")
-                    .map_or(Value::Null, |s| self.resolve(s).clone()),
+                // Kept VERBATIM (a `$ref` keeps its name — issue #1712); the
+                // emitter's parameter mapper resolves structurally only where
+                // the name binds to nothing.
+                schema: p.get("schema").cloned().unwrap_or(Value::Null),
             });
         }
         out
@@ -159,7 +160,7 @@ impl Oas {
     fn parse_request_body(&self, op: &Value) -> Option<(Value, bool)> {
         let rb = self.resolve(op.get("requestBody")?);
         let required = rb.get("required").and_then(Value::as_bool).unwrap_or(false);
-        let schema = self.first_json_schema(rb)?;
+        let schema = Self::first_json_schema(rb)?;
         Some((schema, required))
     }
 
@@ -170,7 +171,7 @@ impl Oas {
         codes.sort();
         for code in codes {
             let resp = self.resolve(&responses[code]);
-            if let Some(schema) = self.first_json_schema(resp) {
+            if let Some(schema) = Self::first_json_schema(resp) {
                 return Some(schema);
             }
         }
@@ -178,13 +179,19 @@ impl Oas {
     }
 
     /// The `application/json` (or first) content schema of a requestBody/response.
-    fn first_json_schema(&self, container: &Value) -> Option<Value> {
+    ///
+    /// The schema is returned VERBATIM — a `$ref` keeps its name, so the
+    /// emitter's type mapper can bind it to the named DTO or spec type instead
+    /// of degrading a pre-resolved anonymous shape to `serde_json::Value`
+    /// (issue #1712; the same discipline `rust_type` applies to array items).
+    /// Container-level refs (the response/requestBody objects themselves) are
+    /// still resolved by the callers before reaching here.
+    fn first_json_schema(container: &Value) -> Option<Value> {
         let content = container.get("content")?.as_object()?;
         let media = content
             .get("application/json")
             .or_else(|| content.values().next())?;
-        let schema = media.get("schema")?;
-        Some(self.resolve(schema).clone())
+        Some(media.get("schema")?.clone())
     }
 }
 

--- a/tools/openehr-codegen/src/render/emit_rest.rs
+++ b/tools/openehr-codegen/src/render/emit_rest.rs
@@ -236,14 +236,18 @@ impl Ctx<'_> {
     fn rust_type(&self, schema: &Value) -> String {
         // A `$ref` (possibly to a name we resolve without following it).
         if let Some(name) = Oas::ref_name(schema) {
-            // RM/BASE spec types are opaque canonical-JSON payloads at the REST
-            // boundary: the application exchanges `serde_json::Value` bodies and
-            // validates them via the native codec + `openehr_its::wire_validate`.
-            // The spec types carry no serde derive (the codec owns the wire), so
-            // the contract DTOs carry any RM/BASE payload as an untyped `Value`
-            // rather than the typed spec struct.
-            if self.names.rm.contains(&name) || self.names.base.contains(&name) {
-                return "serde_json::Value".to_string();
+            // RM/BASE spec types resolve to the TYPED spec structs: since the
+            // foundation rewrite (#1702) every spec type carries emitted manual
+            // `serde::Serialize`/`Deserialize` impls (its crate's
+            // `json_serde.rs`), and those impls ARE the strict canonical-JSON
+            // reader — so a typed field is strict by construction where an
+            // untyped `Value` silently accepted anything (issue #1712; the
+            // former "no serde derive" rationale this branch carried is gone).
+            if self.names.rm.contains(&name) {
+                return format!("openehr_rm::prelude::{name}");
+            }
+            if self.names.base.contains(&name) {
+                return format!("openehr_base::prelude::{name}");
             }
             if self.dtos.contains(&name) {
                 return dto_type(&name);
@@ -349,6 +353,20 @@ impl Ctx<'_> {
 
 fn emit_dto(b: &mut String, name: &str, schema: &Value, ctx: &Ctx) {
     let schema = ctx.oas.resolve(schema);
+    // A `discriminator.mapping` schema is OAS polymorphism over the canonical
+    // `_type` (every released mapping uses `propertyName: _type`): it emits a
+    // real enum over the mapping's targets, dispatched by the same strict
+    // tag-anywhere machinery the spec crates' own emitted impls use — never an
+    // untyped alias (issue #1712; `Versionable` was `pub type … =
+    // serde_json::Value`).
+    if let Some(mapping) = schema
+        .get("discriminator")
+        .and_then(|d| d.get("mapping"))
+        .and_then(Value::as_object)
+    {
+        emit_discriminator_enum(b, name, mapping, ctx);
+        return;
+    }
     // object with named properties → struct; everything else → an alias.
     if schema.get("type").and_then(Value::as_str) == Some("object")
         && let Some(props) = schema.get("properties").and_then(Value::as_object)
@@ -430,6 +448,115 @@ fn emit_dto(b: &mut String, name: &str, schema: &Value, ctx: &Ctx) {
             ctx.rust_type(schema)
         );
     }
+}
+
+/// Emit an OAS `discriminator.mapping` schema as a `_type`-dispatched enum.
+///
+/// One variant per mapping entry, in document order; each carries the mapped
+/// target's Rust type (an RM/BASE spec type or a local DTO, through
+/// [`Ctx::rust_type`]). Serialization delegates to the inner value (whose
+/// emitted impl writes its own `_type`); deserialization dispatches on the
+/// mapping keys with the shared strict tag-anywhere runtime
+/// (`openehr_base::serde_support`) — an unknown or missing `_type` is refused
+/// naming the legal set, exactly like the spec crates' own closed-set enums.
+fn emit_discriminator_enum(
+    b: &mut String,
+    name: &str,
+    mapping: &serde_json::Map<String, Value>,
+    ctx: &Ctx,
+) {
+    let ty_name = dto_type(name);
+    let variants: Vec<(String, String, String)> = mapping
+        .iter()
+        .filter_map(|(tag, target)| {
+            let target = target.as_str()?;
+            let ref_name = target.rsplit('/').next()?.to_string();
+            let rust_ty = ctx.rust_type(&serde_json::json!({ "$ref": target }));
+            Some((tag.clone(), ref_name, rust_ty))
+        })
+        .collect();
+    let tag_list = variants
+        .iter()
+        .map(|(t, _, _)| t.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let _ = write!(
+        b,
+        "/// The `{name}` ITS-REST OAS component schema: `_type`-discriminated\n\
+         /// polymorphism over its OAS `discriminator.mapping` targets.\n\
+         #[derive(Debug, Clone)]\npub enum {ty_name} {{\n"
+    );
+    for (tag, ref_name, rust_ty) in &variants {
+        let _ = writeln!(b, "    /// `_type: \"{tag}\"`\n    {ref_name}({rust_ty}),");
+    }
+    b.push_str("}\n\n");
+    // Serialize: delegate to the inner value (its impl writes `_type`).
+    let _ = write!(
+        b,
+        "impl ::serde::Serialize for {ty_name} {{\n    \
+         fn serialize<__S: ::serde::Serializer>(&self, __serializer: __S) \
+         -> ::core::result::Result<__S::Ok, __S::Error> {{\n        match self {{\n"
+    );
+    for (_, ref_name, _) in &variants {
+        let _ = writeln!(
+            b,
+            "            Self::{ref_name}(__x) => ::serde::Serialize::serialize(__x, __serializer),"
+        );
+    }
+    b.push_str("        }\n    }\n}\n\n");
+    // Deserialize: strict tag-anywhere dispatch on the mapping keys.
+    let _ = write!(
+        b,
+        "impl<'de> ::serde::Deserialize<'de> for {ty_name} {{\n    \
+         fn deserialize<__D: ::serde::Deserializer<'de>>(__deserializer: __D) \
+         -> ::core::result::Result<Self, __D::Error> {{\n        \
+         const __TAGS: &[&str] = &[{tags}];\n        \
+         struct __Visitor;\n        \
+         impl<'de> ::serde::de::Visitor<'de> for __Visitor {{\n            \
+         type Value = {ty_name};\n            \
+         fn expecting(&self, __f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {{\n                \
+         __f.write_str(\"an ITS-REST `{name}` object\")\n            \
+         }}\n            \
+         fn visit_map<__A: ::serde::de::MapAccess<'de>>(\n                \
+         self,\n                mut __map: __A,\n            \
+         ) -> ::core::result::Result<Self::Value, __A::Error> {{\n                \
+         let (__tag, __buffered) =\n                    \
+         ::openehr_base::serde_support::read_slot_tag(&mut __map, __TAGS)?;\n                \
+         match __tag {{\n                    \
+         Some(::openehr_base::serde_support::TagMatch::Known(__t)) => {{\n                        \
+         let __rest = ::openehr_base::serde_support::TaggedRest::new(\n                            \
+         Some(__t),\n                            __buffered,\n                            __map,\n                        \
+         );\n                        match __t {{\n",
+        tags = variants
+            .iter()
+            .map(|(t, _, _)| format!("\"{t}\""))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    for (tag, ref_name, _) in &variants {
+        let _ = write!(
+            b,
+            "                            \"{tag}\" => ::core::result::Result::Ok({ty_name}::{ref_name}(\n                                \
+             ::serde::Deserialize::deserialize(__rest)?,\n                            )),\n"
+        );
+    }
+    let _ = write!(
+        b,
+        "                            __other => ::core::result::Result::Err(\n                                \
+         ::openehr_base::serde_support::unexpected_type(\n                                    \
+         \"{name}\",\n                                    __other,\n                                    \
+         \"{tag_list}\",\n                                ),\n                            ),\n                        \
+         }}\n                    }}\n                    \
+         Some(::openehr_base::serde_support::TagMatch::Unknown(__other)) => {{\n                        \
+         ::core::result::Result::Err(::openehr_base::serde_support::unexpected_type(\n                            \
+         \"{name}\",\n                            &__other,\n                            \"{tag_list}\",\n                        \
+         ))\n                    }}\n                    \
+         None => {{\n                        \
+         ::core::result::Result::Err(::openehr_base::serde_support::missing_type(\n                            \
+         \"{name}\",\n                            \"{tag_list}\",\n                        ))\n                    \
+         }}\n                }}\n            }}\n        }}\n        \
+         ::serde::Deserializer::deserialize_map(__deserializer, __Visitor)\n    }}\n}}\n\n"
+    );
 }
 
 fn param_struct_name(op: &Operation) -> String {


### PR DESCRIPTION
The root fix of the typed-seam chain (#1712 → #1727 → #1709), under the owner's zero-`Value` directive.

- **`load/oas.rs` stops pre-resolving schema `$ref`s** for request bodies, responses, and parameters — the emitter's type mapper now sees the names (container-level response/requestBody refs still resolve). This was the leg-6a array-items discipline applied to the remaining three surfaces.
- **RM/BASE refs resolve to the typed spec structs** (`openehr_rm::prelude::*` / `openehr_base::prelude::*`). The former degradation to `serde_json::Value` cited "the spec types carry no serde derive" — dead since the foundation rewrite (#1702): the emitted manual impls ARE the strict canonical-JSON reader, so every typed DTO field is strict by construction where a `Value` accepted anything.
- **`discriminator.mapping` schemas emit real `_type`-dispatched enums** (`Versionable` was `pub type Versionable = serde_json::Value;`) using the same strict tag-anywhere runtime (`openehr_base::serde_support`) the spec crates' own closed-set enums use — unknown/missing `_type` refused naming the legal set. This fills the #1694 inventory's load-bearing gap (§H.1) for the #1727 commit interior.
- The generated `UpdateVersion`/`UpdateAudit`/`NewContribution` DTOs are now typed; `admin`/`system` groups carry **zero** `Value`s. Residuals adjudicated honest: anonymous `oneOf` responses (`201_EHR`'s representation-or-identifier union), `ResultSetRow` (the approved dynamic family), and the schema-less OPT objects.
- Regeneration is idempotent (second run byte-identical); drift check clean; nothing in `app/` consumed the old untyped surface (the contract is route-table + parity oracle until #1709), so zero app fallout.
- **#1709 next, scope upgraded by owner directive 2026-08-03:** every hand-crafted DTO shadow is deleted onto the generated contract — `version_update.rs` first; a hand shape stronger than the generated one is an emitter gap to fix at the generator, never a kept fork.

Gates: fmt, workspace clippy (all lanes), rustdoc, full workspace suite 3429/3429, `openehr-its` fidelity gates green, regeneration idempotence + codegen-drift clean.

Closes #1712