### PR TITLE
fix(cnf-runner): runner sweeps — the step-arguments gate, rename-damage repair, citation grammar for bindings, the ITS-XML gate root

### DIFF
--- a/.claude/rules/reliability.md
+++ b/.claude/rules/reliability.md
@@ -95,6 +95,26 @@ chapters, the Clippy book, and the Cargo/rustdoc books.)
   — never rely on it inside `else`; rewrite as `match` when the guard must
   span both arms. Tail-expression temporaries drop at end of block, before
   locals (temporary-tail-expr-scope.html) — same discipline.
+- **`Result → Option` inside a chain is a DECISION, and it carries NO
+  automated guard** (review-enforced; the honest no-guard record, issue
+  #1733). `.filter_map(|x| f(x).ok())`, `.and_then(|x| f(x).ok())` and
+  `f(x).ok()?` turn an error into a missing element with no trace — the
+  silent-data-loss shape that dropped a client-supplied attestation from a
+  commit and a non-decoding version uid from an admin merge list. The rule:
+  **a fallible conversion whose failure means "the input is DEFECTIVE"
+  propagates a typed error; only a fallible conversion whose failure means
+  "this input is legitimately ABSENT / not of this form" may become
+  `Option`, and it carries a `// NOTE:` saying so.** Enforcement is honest
+  about its own limits: this is the one rule in this file with no failing
+  check, because there is no lint (the Clippy book lists none —
+  https://rust-lang.github.io/rust-clippy/master/) and a grep gate cannot
+  make the distinction the rule turns on. The two shapes are
+  *textually identical* — a grammar probe where a parse failure IS the
+  answer (`CaptureName::parse(a).ok()?` in the reference-grammar reader)
+  reads exactly like a defect swallowed in a codec — and the repo carries
+  ~300 `.ok()` sites, the vast majority legitimate, so a pattern gate would
+  be ~99% false positives and would be blanket-suppressed within a release.
+  A wish honestly labelled beats a check that trains people to ignore it.
 - **Determinism is lint-backed** (deny tier: `iter_over_hash_type`):
   HashMap/HashSet iteration order is undefined; anything that feeds
   canonical JSON/XML, SQL generation, or emitted code iterates ordered

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -61,7 +61,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-[ferroehr-code-of-conduct@vitagroup.ag](mailto:ferroehr-code-of-conduct@vitagroup.ag).
+the maintainer privately via GitHub (<https://github.com/rubentalstra>).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/app/ferroehr/tests/it/service_ehr.rs
+++ b/app/ferroehr/tests/it/service_ehr.rs
@@ -722,7 +722,7 @@ async fn ehr_status_subject_type_is_enforced_end_to_end() {
     // ("could not be parsed or is invalid"), not the semantic `422`. The
     // anonymous empty PARTY_SELF stays accepted.
     // Regression for the upstream diff findings B1/B2 (the X1 upstream
-    // triage ledger; in git history at docs/conformance/upstream-ferroehr/TRIAGE.md).
+    // triage ledger; in git history at the upstream-triage record (git history: docs/conformance/upstream-ehrbase/TRIAGE.md)).
     let db = testkit::db().await.expect("testkit database");
     let svc = FerroEhrService::new(db.pool());
 

--- a/docs/conformance/cnf-design.md
+++ b/docs/conformance/cnf-design.md
@@ -2157,7 +2157,7 @@ once §8.3 makes cases enumerable files:
    ratification of the [legislated] points, not de-novo design. Seed
    material: this repo's 25 QRY + 8 SQR + 4 AQT case
    designs (each carrying AQL 1.1 citations) and EHRbase's AQL conformance
-   corpus ([ferroehr/conformance-testing-documentation](https://github.com/ehrbase/conformance-testing-documentation),
+   corpus ([ehrbase/conformance-testing-documentation](https://github.com/ehrbase/conformance-testing-documentation),
    SELECT/WHERE/ORDER BY/LIMIT/FROM/parameter suites).
 2. **The maximal-coverage template round-trip** (the 2017 "template
    injection test"): one template exercising ALL RM types (every DV_* incl.
@@ -2548,7 +2548,7 @@ proposing a format and demonstrating one.
   <https://openehr.atlassian.net/wiki/spaces/resources/pages/416514052/>.
 
 **Ecosystem:**
-- [ferroehr/conformance-testing-documentation](https://github.com/ehrbase/conformance-testing-documentation)
+- [ehrbase/conformance-testing-documentation](https://github.com/ehrbase/conformance-testing-documentation)
   (AQL suites + fixtures, last push 2025-01-30);
   [CaboLabs openEHR Conformance Framework](https://www.cabolabs.com/blog/article/openehr_conformance_framework-61ef4f513f7c5.html).
 - Rust crates (verified live 2026-07-21): serde-saphyr

--- a/tools/cnf-runner/CLAUDE.md
+++ b/tools/cnf-runner/CLAUDE.md
@@ -229,6 +229,37 @@ the dev-compose defaults are exported by `scripts/conformance.sh`.
   two released overview chapters — every section must be named by an authored
   `elements`/`branches` source or pinned in `AXIS3_SECTION_EXCLUSIONS` with
   its citation.
+- **An authored input the driver never reads is a CATALOGUE DEFECT, not
+  decoration** — the `step-arguments` gate (`validate.rs`, issue #1830).
+  Every `with:` key a flow step authors must be consumed by the binding the
+  driver would select for it (path param, declared query parameter, a
+  header/query/body template reference, the payload role and its aliases, the
+  bundled-CONTRIBUTION `versions`/`audit` pair, a `required` format header's
+  `${ds:…}` source, or a `with_<p>` auto-variant selector). An unread key
+  never reaches the SUT, so whatever the case asserts about it passes
+  VACUOUSLY however the server behaves — the live instance was the SEC audit
+  case's deliberately ancient client-supplied `audit.time_committed`, dropped
+  for its whole life. The gate models `select_body`'s short-circuit ORDER, so
+  it is sharp where the driver is deterministic and generous only where the
+  choice is a runtime property (the single-payload scan).
+- **Every CITATION inside a binding declaration is machine-resolved** — the
+  `spec-ref` gate now reads `unrealized.source` / `extension.source` too
+  (issue #1832). Those fields are DERIVATIONS (what the SM defines; what the
+  released ITS surfaces, or does not; the spec-silence flag), authored as
+  `;`-separated clauses each opening with its component token — because a
+  fragment that opens with anything else is DROPPED unread by the citation
+  splitter, which is how the ITS-REST half of a `A vs B` derivation used to
+  escape the gate entirely. The sibling `reason` field stays free-text
+  prose by design: `source` + `reason` are the citation/note split.
+- **ITS-XML citations resolve against TWO roots** (issue #1833):
+  `scripts/vendor-spec-docs.sh` vendors prose, so the docs tree's
+  `ITS-XML/components/**` holds only upstream README stubs, while the
+  released XSD bundles are vendored ONCE at `crates/openehr-its/schemas/xml/`
+  as the canonical-XML codec's input. The gate learns the bundle as a second
+  root — one vendored copy, two readers, never a duplicated bundle — and an
+  XSD's `§` sections are its declared `name="…"` values, so
+  `ITS-XML components/RM/Release-1.0.2/documents/Composition.xsd §composition`
+  resolves and a phantom element is a finding.
 - **Verdicts are computed, never asserted** — pure functions of
   (statement, results, catalogue, capability matrix).
 - **The measurement machinery is conformance-by-measurement** (`perf.rs`,

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_ADMIN_ARCHIVE.archive_ehrs.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_ADMIN_ARCHIVE.archive_ehrs.yaml
@@ -24,10 +24,10 @@ extension:
     serves the operation on its own /admin/archive/ehrs route, which is what the cases
     drive.
   source: >-
-    SM docs/UML/classes/i_admin_archive.adoc (archive_ehrs) vs released ITS-REST
-    specifications/admin.openapi.yaml (admin_ehr_delete + admin_ehr_delete_all
-    only) + specifications/docs/admin/** (no archive resource) — no openEHR
-    spec governs the extension route, our own design/extension
+    SM docs/UML/classes/i_admin_archive.adoc (archive_ehrs); ITS-REST
+    specifications/admin.openapi.yaml (the released admin API declares admin_ehr_delete and
+    admin_ehr_delete_all only); ITS-REST specifications/docs/admin (no archive resource); no
+    openEHR spec governs this — our own design/extension
   ambiguity: AMB-33
 request:
   method: POST

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_ADMIN_ARCHIVE.archive_parties.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_ADMIN_ARCHIVE.archive_parties.yaml
@@ -24,10 +24,10 @@ extension:
     serves the operation on its own /admin/archive/parties route, which is what the cases
     drive.
   source: >-
-    SM docs/UML/classes/i_admin_archive.adoc (archive_parties) vs released ITS-REST
-    specifications/admin.openapi.yaml (admin_ehr_delete + admin_ehr_delete_all
-    only) + specifications/docs/admin/** (no archive resource) — no openEHR
-    spec governs the extension route, our own design/extension
+    SM docs/UML/classes/i_admin_archive.adoc (archive_parties); ITS-REST
+    specifications/admin.openapi.yaml (the released admin API declares admin_ehr_delete and
+    admin_ehr_delete_all only); ITS-REST specifications/docs/admin (no archive resource); no
+    openEHR spec governs this — our own design/extension
   ambiguity: AMB-33
 request:
   method: POST

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_ADMIN_DUMP_LOAD.export_ehrs.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_ADMIN_DUMP_LOAD.export_ehrs.yaml
@@ -31,12 +31,12 @@ extension:
     serves the operation on its own /admin/dump route, which is what the cases
     drive.
   source: >-
-    SM docs/UML/classes/i_admin_dump_load.adoc (export_ehrs, error
-    file_not_writable) + export_spec.adoc / export_format.adoc /
-    compression_format.adoc / encoding_format.adoc vs released ITS-REST
-    specifications/admin.openapi.yaml (admin_ehr_delete + admin_ehr_delete_all
-    only) + specifications/docs/admin/** (no dump/load resource) — no openEHR
-    spec governs the extension route, our own design/extension
+    SM docs/UML/classes/i_admin_dump_load.adoc (export_ehrs, error file_not_writable); SM
+    docs/UML/classes/export_spec.adoc; SM docs/UML/classes/export_format.adoc; SM
+    docs/UML/classes/compression_format.adoc; SM docs/UML/classes/encoding_format.adoc; ITS-REST
+    specifications/admin.openapi.yaml (the released admin API declares admin_ehr_delete and
+    admin_ehr_delete_all only); ITS-REST specifications/docs/admin (no dump/load resource); no
+    openEHR spec governs this — our own design/extension
   ambiguity: AMB-33
 request:
   method: POST

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_ADMIN_DUMP_LOAD.load_ehrs.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_ADMIN_DUMP_LOAD.load_ehrs.yaml
@@ -26,13 +26,12 @@ extension:
     serves the operation on its own /admin/load route, which is what the cases
     drive.
   source: >-
-    SM docs/UML/classes/i_admin_dump_load.adoc (load_ehrs — "Populate EHR
-    repository from export archive on file system. Repository need not be
-    empty, but import EHRs with duplicate EHR ids will fail") +
-    dump_load_fail_report.adoc vs released ITS-REST
-    specifications/admin.openapi.yaml (admin_ehr_delete + admin_ehr_delete_all
-    only) + specifications/docs/admin/** (no dump/load resource) — no openEHR
-    spec governs the extension route, our own design/extension
+    SM docs/UML/classes/i_admin_dump_load.adoc (load_ehrs — "Populate EHR repository from export
+    archive on file system. Repository need not be empty, but import EHRs with duplicate EHR ids
+    will fail"); SM docs/UML/classes/dump_load_fail_report.adoc; ITS-REST
+    specifications/admin.openapi.yaml (the released admin API declares admin_ehr_delete and
+    admin_ehr_delete_all only); ITS-REST specifications/docs/admin (no dump/load resource); no
+    openEHR spec governs this — our own design/extension
   ambiguity: AMB-33
 request:
   method: POST

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_ADMIN_SERVICE.composition_version_count.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_ADMIN_SERVICE.composition_version_count.yaml
@@ -29,10 +29,10 @@ extension:
     serves the operation on its own /admin/report/composition_version/count route,
     which is what the cases drive.
   source: >-
-    SM docs/UML/classes/i_admin_service.adoc (composition_version_count) vs released ITS-REST
-    specifications/admin.openapi.yaml (admin_ehr_delete + admin_ehr_delete_all
-    only) + specifications/docs/admin/** (no reporting resource) — no openEHR
-    spec governs the extension route, our own design/extension
+    SM docs/UML/classes/i_admin_service.adoc (composition_version_count); ITS-REST
+    specifications/admin.openapi.yaml (the released admin API declares admin_ehr_delete and
+    admin_ehr_delete_all only); ITS-REST specifications/docs/admin (no reporting resource); no
+    openEHR spec governs this — our own design/extension
   ambiguity: AMB-33
 request:
   method: GET

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_ADMIN_SERVICE.contribution_count.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_ADMIN_SERVICE.contribution_count.yaml
@@ -29,10 +29,10 @@ extension:
     serves the operation on its own /admin/report/contribution/count route,
     which is what the cases drive.
   source: >-
-    SM docs/UML/classes/i_admin_service.adoc (contribution_count) vs released ITS-REST
-    specifications/admin.openapi.yaml (admin_ehr_delete + admin_ehr_delete_all
-    only) + specifications/docs/admin/** (no reporting resource) — no openEHR
-    spec governs the extension route, our own design/extension
+    SM docs/UML/classes/i_admin_service.adoc (contribution_count); ITS-REST
+    specifications/admin.openapi.yaml (the released admin API declares admin_ehr_delete and
+    admin_ehr_delete_all only); ITS-REST specifications/docs/admin (no reporting resource); no
+    openEHR spec governs this — our own design/extension
   ambiguity: AMB-33
 request:
   method: GET

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_ADMIN_SERVICE.list_contributions.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_ADMIN_SERVICE.list_contributions.yaml
@@ -29,10 +29,10 @@ extension:
     serves the operation on its own /admin/report/contribution route,
     which is what the cases drive.
   source: >-
-    SM docs/UML/classes/i_admin_service.adoc (list_contributions) vs released ITS-REST
-    specifications/admin.openapi.yaml (admin_ehr_delete + admin_ehr_delete_all
-    only) + specifications/docs/admin/** (no reporting resource) — no openEHR
-    spec governs the extension route, our own design/extension
+    SM docs/UML/classes/i_admin_service.adoc (list_contributions); ITS-REST
+    specifications/admin.openapi.yaml (the released admin API declares admin_ehr_delete and
+    admin_ehr_delete_all only); ITS-REST specifications/docs/admin (no reporting resource); no
+    openEHR spec governs this — our own design/extension
   ambiguity: AMB-33
 request:
   method: GET

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_ADMIN_SERVICE.physical_party_delete.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_ADMIN_SERVICE.physical_party_delete.yaml
@@ -8,5 +8,7 @@ unrealized:
     No admin party-deletion operation exists in ITS-REST 1.1.0. The only admin
     operations in the OAS are admin_ehr_delete and admin_ehr_delete_all, both
     scoped to EHRs; there is no admin endpoint for physical Party deletion.
-  source: "ITS-REST specifications/operations (admin_ehr_delete, admin_ehr_delete_all only) vs SM docs/UML/classes/i_admin_service.adoc (physical_party_delete)"
+  source: >-
+    ITS-REST specifications/operations (admin_ehr_delete, admin_ehr_delete_all only); SM
+    docs/UML/classes/i_admin_service.adoc (physical_party_delete)
   ambiguity: AMB-33

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_ADMIN_SERVICE.versioned_composition_count.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_ADMIN_SERVICE.versioned_composition_count.yaml
@@ -29,10 +29,10 @@ extension:
     serves the operation on its own /admin/report/versioned_composition/count route,
     which is what the cases drive.
   source: >-
-    SM docs/UML/classes/i_admin_service.adoc (versioned_composition_count) vs released ITS-REST
-    specifications/admin.openapi.yaml (admin_ehr_delete + admin_ehr_delete_all
-    only) + specifications/docs/admin/** (no reporting resource) — no openEHR
-    spec governs the extension route, our own design/extension
+    SM docs/UML/classes/i_admin_service.adoc (versioned_composition_count); ITS-REST
+    specifications/admin.openapi.yaml (the released admin API declares admin_ehr_delete and
+    admin_ehr_delete_all only); ITS-REST specifications/docs/admin (no reporting resource); no
+    openEHR spec governs this — our own design/extension
   ambiguity: AMB-33
 request:
   method: GET

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL14.delete_archetype.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL14.delete_archetype.yaml
@@ -21,10 +21,9 @@ extension:
     excused claim — the book-CORE required marker drops with the register
     derivation, since an extension realization may never be required).
   source: >-
-    SM docs/UML/classes/i_definition_adl14.adoc (archetype provisioning) vs
-    released ITS-REST specifications/operations (definition_template_adl1.4_*
-    only — no archetype path anywhere) + specifications/docs/definition/**
-    (no mention) — no openEHR spec governs the extension routes, our own
+    SM docs/UML/classes/i_definition_adl14.adoc (archetype provisioning); ITS-REST
+    specifications/operations (definition_template_adl1.4_* only, no archetype path anywhere);
+    ITS-REST specifications/docs/definition (no mention); no openEHR spec governs this — our own
     design/extension
   ambiguity: AMB-41
 request:

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL14.delete_opt.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL14.delete_opt.yaml
@@ -9,5 +9,7 @@ unrealized:
     No DELETE operation exists on any /definition/template/adl1.4* path in
     ITS-REST 1.1.0 (the only DELETEs in the OAS are admin_ehr_delete*,
     composition_delete, directory_delete and the demographic deletes).
-  source: "ITS-REST specifications/operations (definition template operations) vs SM docs/UML/classes/i_definition_adl14.adoc (delete_opt)"
+  source: >-
+    ITS-REST specifications/operations (definition template operations); SM
+    docs/UML/classes/i_definition_adl14.adoc (delete_opt)
   ambiguity: AMB-17

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL14.get_archetype.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL14.get_archetype.yaml
@@ -21,10 +21,9 @@ extension:
     excused claim — the book-CORE required marker drops with the register
     derivation, since an extension realization may never be required).
   source: >-
-    SM docs/UML/classes/i_definition_adl14.adoc (archetype provisioning) vs
-    released ITS-REST specifications/operations (definition_template_adl1.4_*
-    only — no archetype path anywhere) + specifications/docs/definition/**
-    (no mention) — no openEHR spec governs the extension routes, our own
+    SM docs/UML/classes/i_definition_adl14.adoc (archetype provisioning); ITS-REST
+    specifications/operations (definition_template_adl1.4_* only, no archetype path anywhere);
+    ITS-REST specifications/docs/definition (no mention); no openEHR spec governs this — our own
     design/extension
   ambiguity: AMB-41
 request:

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL14.list_archetypes.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL14.list_archetypes.yaml
@@ -25,10 +25,9 @@ extension:
     excused claim — the book-CORE required marker drops with the register
     derivation, since an extension realization may never be required).
   source: >-
-    SM docs/UML/classes/i_definition_adl14.adoc (archetype provisioning) vs
-    released ITS-REST specifications/operations (definition_template_adl1.4_*
-    only — no archetype path anywhere) + specifications/docs/definition/**
-    (no mention) — no openEHR spec governs the extension routes, our own
+    SM docs/UML/classes/i_definition_adl14.adoc (archetype provisioning); ITS-REST
+    specifications/operations (definition_template_adl1.4_* only, no archetype path anywhere);
+    ITS-REST specifications/docs/definition (no mention); no openEHR spec governs this — our own
     design/extension
   ambiguity: AMB-41
 request:

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL14.upload_archetype-wrong_media_type.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL14.upload_archetype-wrong_media_type.yaml
@@ -26,10 +26,10 @@ extension:
     excused claim — the book-CORE required marker drops with the register
     derivation, since an extension realization may never be required).
   source: >-
-    SM docs/UML/classes/i_definition_adl14.adoc (upload_archetype) vs released
-    ITS-REST specifications/operations (definition_template_adl1.4_* only — no
-    archetype path anywhere) + specifications/docs/definition/** (no mention) —
-    no openEHR spec governs the extension routes, our own design/extension
+    SM docs/UML/classes/i_definition_adl14.adoc (upload_archetype); ITS-REST
+    specifications/operations (definition_template_adl1.4_* only, no archetype path anywhere);
+    ITS-REST specifications/docs/definition (no mention); no openEHR spec governs this — our own
+    design/extension
   ambiguity: AMB-41
 request:
   method: POST

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL14.upload_archetype.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL14.upload_archetype.yaml
@@ -21,10 +21,9 @@ extension:
     excused claim — the book-CORE required marker drops with the register
     derivation, since an extension realization may never be required).
   source: >-
-    SM docs/UML/classes/i_definition_adl14.adoc (archetype provisioning) vs
-    released ITS-REST specifications/operations (definition_template_adl1.4_*
-    only — no archetype path anywhere) + specifications/docs/definition/**
-    (no mention) — no openEHR spec governs the extension routes, our own
+    SM docs/UML/classes/i_definition_adl14.adoc (archetype provisioning); ITS-REST
+    specifications/operations (definition_template_adl1.4_* only, no archetype path anywhere);
+    ITS-REST specifications/docs/definition (no mention); no openEHR spec governs this — our own
     design/extension
   ambiguity: AMB-41
 request:

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL2.archetypes_count.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL2.archetypes_count.yaml
@@ -22,10 +22,10 @@ extension:
     its own /definition/archetype/adl2/count route, whose body is the bare
     Integer the SM operation returns.
   source: >-
-    SM docs/UML/classes/i_definition_adl2.adoc (archetypes_count) vs released
-    ITS-REST specifications/definition.openapi.yaml (definition_template_adl2_*
-    only — no count path anywhere) + specifications/docs/definition/** (no mention) — no
-    openEHR spec governs the extension route, our own design/extension
+    SM docs/UML/classes/i_definition_adl2.adoc (archetypes_count); ITS-REST
+    specifications/definition.openapi.yaml (definition_template_adl2_* only, no count path
+    anywhere); ITS-REST specifications/docs/definition (no mention); no openEHR spec governs
+    this — our own design/extension
   ambiguity: AMB-37
 request:
   method: GET

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL2.artefacts_count.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL2.artefacts_count.yaml
@@ -22,10 +22,10 @@ extension:
     its own /definition/artefact/adl2/count route, whose body is the bare
     Integer the SM operation returns.
   source: >-
-    SM docs/UML/classes/i_definition_adl2.adoc (artefacts_count) vs released
-    ITS-REST specifications/definition.openapi.yaml (definition_template_adl2_*
-    only — no count path anywhere) + specifications/docs/definition/** (no mention) — no
-    openEHR spec governs the extension route, our own design/extension
+    SM docs/UML/classes/i_definition_adl2.adoc (artefacts_count); ITS-REST
+    specifications/definition.openapi.yaml (definition_template_adl2_* only, no count path
+    anywhere); ITS-REST specifications/docs/definition (no mention); no openEHR spec governs
+    this — our own design/extension
   ambiguity: AMB-37
 request:
   method: GET

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL2.delete_artefact.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL2.delete_artefact.yaml
@@ -21,10 +21,10 @@ extension:
     so the SM delete_artefact has no released wire; this product serves the
     operation on its own /definition/artefact/adl2/{artefact_id} route.
   source: >-
-    SM docs/UML/classes/i_definition_adl2.adoc (delete_artefact) vs released
-    ITS-REST specifications/definition.openapi.yaml (definition_template_adl2_*
-    only — no DELETE on any ADL 2 path) + specifications/docs/definition/** (no mention) — no
-    openEHR spec governs the extension route, our own design/extension
+    SM docs/UML/classes/i_definition_adl2.adoc (delete_artefact); ITS-REST
+    specifications/definition.openapi.yaml (definition_template_adl2_* only, no DELETE on any
+    ADL 2 path); ITS-REST specifications/docs/definition (no mention); no openEHR spec governs
+    this — our own design/extension
   ambiguity: AMB-37
 request:
   method: DELETE

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL2.list_archetypes.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL2.list_archetypes.yaml
@@ -21,10 +21,10 @@ extension:
     list_archetypes has no released wire; this product serves the operation on
     its own /definition/archetype/adl2 route, which is what the cases drive.
   source: >-
-    SM docs/UML/classes/i_definition_adl2.adoc (list_archetypes) vs released
-    ITS-REST specifications/definition.openapi.yaml (definition_template_adl2_*
-    only — no archetype path anywhere) + specifications/docs/definition/** (no mention) — no
-    openEHR spec governs the extension route, our own design/extension
+    SM docs/UML/classes/i_definition_adl2.adoc (list_archetypes); ITS-REST
+    specifications/definition.openapi.yaml (definition_template_adl2_* only, no archetype path
+    anywhere); ITS-REST specifications/docs/definition (no mention); no openEHR spec governs
+    this — our own design/extension
   ambiguity: AMB-37
 request:
   method: GET

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL2.list_artefacts.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL2.list_artefacts.yaml
@@ -21,10 +21,10 @@ extension:
     union, so the SM list_artefacts has no released wire; this product serves
     the operation on its own /definition/artefact/adl2 route.
   source: >-
-    SM docs/UML/classes/i_definition_adl2.adoc (list_artefacts) vs released
-    ITS-REST specifications/definition.openapi.yaml (definition_template_adl2_*
-    only — no generic artefact path anywhere) + specifications/docs/definition/** (no mention) — no
-    openEHR spec governs the extension route, our own design/extension
+    SM docs/UML/classes/i_definition_adl2.adoc (list_artefacts); ITS-REST
+    specifications/definition.openapi.yaml (definition_template_adl2_* only, no generic artefact
+    path anywhere); ITS-REST specifications/docs/definition (no mention); no openEHR spec
+    governs this — our own design/extension
   ambiguity: AMB-37
 request:
   method: GET

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL2.opts_count.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL2.opts_count.yaml
@@ -9,5 +9,7 @@ unrealized:
   reason: >-
     No artefact/template/OPT count operation exists in ITS-REST 1.1.0; counts
     are derivable from list length client-side but have no dedicated wire.
-  source: "SM docs/UML/classes/i_definition_adl2.adoc (opts_count) vs ITS-REST specifications/operations (no ADL2 count endpoint)"
+  source: >-
+    SM docs/UML/classes/i_definition_adl2.adoc (opts_count); ITS-REST specifications/operations
+    (no ADL2 count endpoint)
   ambiguity: AMB-37

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL2.templates_count.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_ADL2.templates_count.yaml
@@ -9,5 +9,7 @@ unrealized:
   reason: >-
     No artefact/template/OPT count operation exists in ITS-REST 1.1.0; counts
     are derivable from list length client-side but have no dedicated wire.
-  source: "SM docs/UML/classes/i_definition_adl2.adoc (templates_count) vs ITS-REST specifications/operations (no ADL2 count endpoint)"
+  source: >-
+    SM docs/UML/classes/i_definition_adl2.adoc (templates_count); ITS-REST
+    specifications/operations (no ADL2 count endpoint)
   ambiguity: AMB-37

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_QUERY.delete_query.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_QUERY.delete_query.yaml
@@ -15,5 +15,11 @@ unrealized:
     {version}` is an extension of our own and is deliberately NOT bound here:
     it removes one `(name, version)` row and therefore cannot establish the SM
     postcondition.
-  source: "ITS-REST specifications/definition.openapi.yaml (the two /definition/query paths) + operations/definition_query_{list,store,version_get,version_store}.yaml vs SM docs/UML/classes/i_definition_query.adoc §delete_query"
+  source: >-
+    ITS-REST specifications/definition.openapi.yaml (the two /definition/query paths); ITS-REST
+    specifications/operations/definition_query_list.yaml; ITS-REST
+    specifications/operations/definition_query_store.yaml; ITS-REST
+    specifications/operations/definition_query_version_get.yaml; ITS-REST
+    specifications/operations/definition_query_version_store.yaml; SM
+    docs/UML/classes/i_definition_query.adoc §delete_query
   ambiguity: AMB-127

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_QUERY.list_matching_queries.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_QUERY.list_matching_queries.yaml
@@ -16,5 +16,9 @@ unrealized:
     filter, the paging, nor a branch the declared error could wear. Bound
     unrealized rather than folded into the prefix list, which is a different
     operation (`list_queries`) with its own binding.
-  source: "SM docs/UML/classes/i_definition_query.adoc §list_matching_queries (the two regex patterns, the paging pair, the `invalid_id_pattern` error) vs ITS-REST specifications/operations/definition_query_list.yaml (the prefix description + a single '200') and definition.openapi.yaml (no other list path)"
+  source: >-
+    SM docs/UML/classes/i_definition_query.adoc §list_matching_queries (the two regex patterns,
+    the paging pair, the `invalid_id_pattern` error); ITS-REST
+    specifications/operations/definition_query_list.yaml (the prefix description, a single
+    '200'); ITS-REST specifications/definition.openapi.yaml (no other list path)
   ambiguity: AMB-121

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_QUERY.queries_count.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_QUERY.queries_count.yaml
@@ -12,5 +12,8 @@ unrealized:
     there is no request that enumerates the whole registry ("Return total count
     of queries") — the description's empty-pattern wildcard clause names a
     request the released paths cannot express (register AMB-124(d)).
-  source: "SM docs/UML/classes/i_definition_query.adoc §queries_count vs ITS-REST specifications/definition.openapi.yaml (the two /definition/query paths, no count resource) + parameters/path/qualified_query_name.yaml (`required: true`)"
+  source: >-
+    SM docs/UML/classes/i_definition_query.adoc §queries_count; ITS-REST
+    specifications/definition.openapi.yaml (the two /definition/query paths, no count resource);
+    ITS-REST specifications/parameters/path/qualified_query_name.yaml (`required: true`)
   ambiguity: AMB-127

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_QUERY.store_query_set.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_DEFINITION_QUERY.store_query_set.yaml
@@ -14,5 +14,7 @@ unrealized:
     no result beyond a UUID, so even a hypothetical binding would have nothing
     to bind. The case anchored here is therefore not-applicable with citation
     on BOTH counts.
-  source: "SM docs/UML/classes/i_definition_query.adoc §store_query_set (\"Register a query set. TODO: determine details.\") vs ITS-REST specifications/definition.openapi.yaml (no query-set path)"
+  source: >-
+    SM docs/UML/classes/i_definition_query.adoc §store_query_set ("Register a query set. TODO:
+    determine details."); ITS-REST specifications/definition.openapi.yaml (no query-set path)
   ambiguity: AMB-127

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_DEMOGRAPHIC_SERVICE.create_party_relationship.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_DEMOGRAPHIC_SERVICE.create_party_relationship.yaml
@@ -31,10 +31,10 @@ extension:
     operation on its own /demographic/party_relationship route, which is what
     the cases drive.
   source: >-
-    SM docs/UML/classes/i_demographic_service.adoc (create_party_relationship)
-    vs released ITS-REST specifications/demographic.openapi.yaml (no
-    party_relationship path) + specifications/docs/demographic/** (no mention) —
-    no openEHR spec governs the extension route, our own design/extension
+    SM docs/UML/classes/i_demographic_service.adoc (create_party_relationship); ITS-REST
+    specifications/demographic.openapi.yaml (no party_relationship path); ITS-REST
+    specifications/docs/demographic (no mention); no openEHR spec governs this — our own
+    design/extension
   ambiguity: AMB-32
 request:
   method: POST

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_CONTRIBUTION.list_contributions.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_CONTRIBUTION.list_contributions.yaml
@@ -15,5 +15,7 @@ unrealized:
     (ehr.openapi.yaml wires only contribution_create on the collection path and
     contribution_get on the {contribution_uid} item path); the SM
     list_contributions has no bindable wire realization.
-  source: "SM docs/UML/classes/i_ehr_contribution.adoc (list_contributions) vs ITS-REST specifications/ehr.openapi.yaml (contribution paths: no collection GET)"
+  source: >-
+    SM docs/UML/classes/i_ehr_contribution.adoc (list_contributions); ITS-REST
+    specifications/ehr.openapi.yaml (contribution paths, no collection GET)
   ambiguity: AMB-22

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_DIRECTORY.get_versioned_directory.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_DIRECTORY.get_versioned_directory.yaml
@@ -13,5 +13,8 @@ unrealized:
     ITS-REST 1.1.0; the VERSIONED_FOLDER container has no REST resource (the
     only directory paths are /ehr/{ehr_id}/directory and
     /ehr/{ehr_id}/directory/{version_uid}).
-  source: "SM docs/UML/classes/i_ehr_directory.adoc (get_versioned_directory -> VERSIONED_FOLDER) vs ITS-REST specifications/ehr.openapi.yaml (directory paths: no versioned_directory)"
+  source: >-
+    SM docs/UML/classes/i_ehr_directory.adoc (get_versioned_directory returning
+    VERSIONED_FOLDER); ITS-REST specifications/ehr.openapi.yaml (directory paths, no
+    versioned_directory)
   ambiguity: AMB-24

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_EXTRACT_SERVICE.export_ehr_extracts.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_EXTRACT_SERVICE.export_ehr_extracts.yaml
@@ -23,11 +23,10 @@ extension:
     export_ehr_extracts has no released wire; this product serves the operation on its
     own /message/export route, which is what the cases drive.
   source: >-
-    SM docs/openehr_platform/master09-message_service.adoc +
-    docs/UML/classes/i_ehr_extract_service.adoc (export_ehr_extracts) vs released ITS-REST
-    specifications/*.openapi.yaml (seven groups, none of them
-    message/extract/tdd) + specifications/docs/** (no such API) — no openEHR
-    spec governs the extension route, our own design/extension
+    SM docs/openehr_platform/master09-message_service.adoc; SM
+    docs/UML/classes/i_ehr_extract_service.adoc (export_ehr_extracts); ITS-REST specifications
+    (the seven released API groups, none of them message/extract/tdd); ITS-REST
+    specifications/docs (no such API); no openEHR spec governs this — our own design/extension
   ambiguity: AMB-34
 request:
   method: POST

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_EXTRACT_SERVICE.export_ehrs.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_EXTRACT_SERVICE.export_ehrs.yaml
@@ -23,11 +23,10 @@ extension:
     export_ehrs has no released wire; this product serves the operation on its
     own /message/export/{ehr_id} route, which is what the cases drive.
   source: >-
-    SM docs/openehr_platform/master09-message_service.adoc +
-    docs/UML/classes/i_ehr_extract_service.adoc (export_ehrs) vs released
-    ITS-REST specifications/*.openapi.yaml (seven groups, none of them
-    message/extract/tdd) + specifications/docs/** (no such API) — no openEHR
-    spec governs the extension route, our own design/extension
+    SM docs/openehr_platform/master09-message_service.adoc; SM
+    docs/UML/classes/i_ehr_extract_service.adoc (export_ehrs); ITS-REST specifications (the
+    seven released API groups, none of them message/extract/tdd); ITS-REST specifications/docs
+    (no such API); no openEHR spec governs this — our own design/extension
   ambiguity: AMB-34
 request:
   method: GET

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_EXTRACT_SERVICE.import_ehr-wrong_media_type.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_EXTRACT_SERVICE.import_ehr-wrong_media_type.yaml
@@ -22,11 +22,10 @@ extension:
     import_ehr has no released wire; this product serves the operation on its
     own /message/import route, which is what the cases drive.
   source: >-
-    SM docs/openehr_platform/master09-message_service.adoc +
-    docs/UML/classes/i_ehr_extract_service.adoc (import_ehr) vs released
-    ITS-REST specifications/*.openapi.yaml (seven groups, none of them
-    message/extract/tdd) + specifications/docs/** (no such API) — no openEHR
-    spec governs the extension route, our own design/extension
+    SM docs/openehr_platform/master09-message_service.adoc; SM
+    docs/UML/classes/i_ehr_extract_service.adoc (import_ehr); ITS-REST specifications (the seven
+    released API groups, none of them message/extract/tdd); ITS-REST specifications/docs (no
+    such API); no openEHR spec governs this — our own design/extension
   ambiguity: AMB-34
 request:
   method: POST

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_EXTRACT_SERVICE.import_ehr.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_EXTRACT_SERVICE.import_ehr.yaml
@@ -23,11 +23,10 @@ extension:
     import_ehr has no released wire; this product serves the operation on its
     own /message/import route, which is what the cases drive.
   source: >-
-    SM docs/openehr_platform/master09-message_service.adoc +
-    docs/UML/classes/i_ehr_extract_service.adoc (import_ehr) vs released ITS-REST
-    specifications/*.openapi.yaml (seven groups, none of them
-    message/extract/tdd) + specifications/docs/** (no such API) — no openEHR
-    spec governs the extension route, our own design/extension
+    SM docs/openehr_platform/master09-message_service.adoc; SM
+    docs/UML/classes/i_ehr_extract_service.adoc (import_ehr); ITS-REST specifications (the seven
+    released API groups, none of them message/extract/tdd); ITS-REST specifications/docs (no
+    such API); no openEHR spec governs this — our own design/extension
   ambiguity: AMB-34
 request:
   method: POST

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_EXTRACT_SERVICE.import_ehr_extract.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_EHR_EXTRACT_SERVICE.import_ehr_extract.yaml
@@ -23,11 +23,10 @@ extension:
     import_ehr_extract has no released wire; this product serves the operation on its
     own /message/import/{ehr_id} route, which is what the cases drive.
   source: >-
-    SM docs/openehr_platform/master09-message_service.adoc +
-    docs/UML/classes/i_ehr_extract_service.adoc (import_ehr_extract) vs released ITS-REST
-    specifications/*.openapi.yaml (seven groups, none of them
-    message/extract/tdd) + specifications/docs/** (no such API) — no openEHR
-    spec governs the extension route, our own design/extension
+    SM docs/openehr_platform/master09-message_service.adoc; SM
+    docs/UML/classes/i_ehr_extract_service.adoc (import_ehr_extract); ITS-REST specifications
+    (the seven released API groups, none of them message/extract/tdd); ITS-REST
+    specifications/docs (no such API); no openEHR spec governs this — our own design/extension
   ambiguity: AMB-34
 request:
   method: POST

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_PARTY_RELATIONSHIP.delete_party_relationship.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_PARTY_RELATIONSHIP.delete_party_relationship.yaml
@@ -33,9 +33,9 @@ extension:
     the preceding version in the path.
   source: >-
     SM docs/UML/classes/i_party_relationship.adoc (delete_party_relationship,
-    Post_relationship_deleted) vs released ITS-REST
-    specifications/demographic.openapi.yaml (no party_relationship path) — no
-    openEHR spec governs the extension route, our own design/extension
+    Post_relationship_deleted); ITS-REST specifications/demographic.openapi.yaml (no
+    party_relationship path); ITS-REST specifications/docs/demographic (no mention); no openEHR
+    spec governs this — our own design/extension
   ambiguity: AMB-32
 request:
   method: DELETE

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_PARTY_RELATIONSHIP.get_party_relationship.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_PARTY_RELATIONSHIP.get_party_relationship.yaml
@@ -25,10 +25,10 @@ extension:
     get_party_relationship has no released wire; this product serves the read on
     its own /demographic/party_relationship/{uid_based_id} route.
   source: >-
-    SM docs/UML/classes/i_party_relationship.adoc (get_party_relationship) vs
-    released ITS-REST specifications/demographic.openapi.yaml (no
-    party_relationship path) — no openEHR spec governs the extension route, our
-    own design/extension
+    SM docs/UML/classes/i_party_relationship.adoc (get_party_relationship); ITS-REST
+    specifications/demographic.openapi.yaml (no party_relationship path); ITS-REST
+    specifications/docs/demographic (no mention); no openEHR spec governs this — our own
+    design/extension
   ambiguity: AMB-32
 request:
   method: GET

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_PARTY_RELATIONSHIP.get_party_relationship_at_time.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_PARTY_RELATIONSHIP.get_party_relationship_at_time.yaml
@@ -21,10 +21,10 @@ extension:
     at-time read as the version_at_time query on its own
     /demographic/party_relationship/{uid_based_id} route.
   source: >-
-    SM docs/UML/classes/i_party_relationship.adoc
-    (get_party_relationship_at_time) vs released ITS-REST
-    specifications/demographic.openapi.yaml (no party_relationship path) — no
-    openEHR spec governs the extension route, our own design/extension
+    SM docs/UML/classes/i_party_relationship.adoc (get_party_relationship_at_time); ITS-REST
+    specifications/demographic.openapi.yaml (no party_relationship path); ITS-REST
+    specifications/docs/demographic (no mention); no openEHR spec governs this — our own
+    design/extension
   ambiguity: AMB-32
 request:
   method: GET

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_PARTY_RELATIONSHIP.get_party_relationship_at_version.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_PARTY_RELATIONSHIP.get_party_relationship_at_version.yaml
@@ -22,10 +22,10 @@ extension:
     the version read as the OBJECT_VERSION_ID form of its own
     /demographic/party_relationship/{uid_based_id} route.
   source: >-
-    SM docs/UML/classes/i_party_relationship.adoc
-    (get_party_relationship_at_version) vs released ITS-REST
-    specifications/demographic.openapi.yaml (no party_relationship path) — no
-    openEHR spec governs the extension route, our own design/extension
+    SM docs/UML/classes/i_party_relationship.adoc (get_party_relationship_at_version); ITS-REST
+    specifications/demographic.openapi.yaml (no party_relationship path); ITS-REST
+    specifications/docs/demographic (no mention); no openEHR spec governs this — our own
+    design/extension
   ambiguity: AMB-32
 request:
   method: GET

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_PARTY_RELATIONSHIP.update_party_relationship-missing_if_match.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_PARTY_RELATIONSHIP.update_party_relationship-missing_if_match.yaml
@@ -23,9 +23,9 @@ extension:
     refusal.
   source: >-
     SM docs/UML/classes/i_party_relationship.adoc (update_party_relationship,
-    Pre_has_relationship) vs released ITS-REST
-    specifications/demographic.openapi.yaml (no party_relationship path) — no
-    openEHR spec governs the extension route, our own design/extension
+    Pre_has_relationship); ITS-REST specifications/demographic.openapi.yaml (no
+    party_relationship path); ITS-REST specifications/docs/demographic (no mention); no openEHR
+    spec governs this — our own design/extension
   ambiguity: AMB-32
 request:
   method: PUT

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_PARTY_RELATIONSHIP.update_party_relationship.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_PARTY_RELATIONSHIP.update_party_relationship.yaml
@@ -23,9 +23,9 @@ extension:
     realizing the SM preceding_version_uid as the If-Match header.
   source: >-
     SM docs/UML/classes/i_party_relationship.adoc (update_party_relationship,
-    Pre_has_relationship) vs released ITS-REST
-    specifications/demographic.openapi.yaml (no party_relationship path) — no
-    openEHR spec governs the extension route, our own design/extension
+    Pre_has_relationship); ITS-REST specifications/demographic.openapi.yaml (no
+    party_relationship path); ITS-REST specifications/docs/demographic (no mention); no openEHR
+    spec governs this — our own design/extension
   ambiguity: AMB-32
 request:
   method: PUT

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_TDD_SERVICE.import_tdd-wrong_media_type.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_TDD_SERVICE.import_tdd-wrong_media_type.yaml
@@ -21,11 +21,10 @@ extension:
     import_tdd has no released wire; this product serves the operation on its
     own /message/tdd/{ehr_id} route, which is what the cases drive.
   source: >-
-    SM docs/openehr_platform/master09-message_service.adoc +
-    docs/UML/classes/i_tdd_service.adoc (import_tdd) vs released ITS-REST
-    specifications/*.openapi.yaml (seven groups, none of them
-    message/extract/tdd) + specifications/docs/** (no such API) — no openEHR
-    spec governs the extension route, our own design/extension
+    SM docs/openehr_platform/master09-message_service.adoc; SM
+    docs/UML/classes/i_tdd_service.adoc (import_tdd); ITS-REST specifications (the seven
+    released API groups, none of them message/extract/tdd); ITS-REST specifications/docs (no
+    such API); no openEHR spec governs this — our own design/extension
   ambiguity: AMB-34
 request:
   method: POST

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_TDD_SERVICE.import_tdd.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_TDD_SERVICE.import_tdd.yaml
@@ -23,11 +23,10 @@ extension:
     import_tdd has no released wire; this product serves the operation on its
     own /message/tdd/{ehr_id} route, which is what the cases drive.
   source: >-
-    SM docs/openehr_platform/master09-message_service.adoc +
-    docs/UML/classes/i_tdd_service.adoc (import_tdd) vs released ITS-REST
-    specifications/*.openapi.yaml (seven groups, none of them
-    message/extract/tdd) + specifications/docs/** (no such API) — no openEHR
-    spec governs the extension route, our own design/extension
+    SM docs/openehr_platform/master09-message_service.adoc; SM
+    docs/UML/classes/i_tdd_service.adoc (import_tdd); ITS-REST specifications (the seven
+    released API groups, none of them message/extract/tdd); ITS-REST specifications/docs (no
+    such API); no openEHR spec governs this — our own design/extension
   ambiguity: AMB-34
 request:
   method: POST

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_TDD_SERVICE.import_tdds-wrong_media_type.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_TDD_SERVICE.import_tdds-wrong_media_type.yaml
@@ -19,11 +19,10 @@ extension:
     import_tdds has no released wire; this product serves the operation on its
     own /message/tdd/{ehr_id}/batch route, which is what the cases drive.
   source: >-
-    SM docs/openehr_platform/master09-message_service.adoc +
-    docs/UML/classes/i_tdd_service.adoc (import_tdds) vs released ITS-REST
-    specifications/*.openapi.yaml (seven groups, none of them
-    message/extract/tdd) + specifications/docs/** (no such API) — no openEHR
-    spec governs the extension route, our own design/extension
+    SM docs/openehr_platform/master09-message_service.adoc; SM
+    docs/UML/classes/i_tdd_service.adoc (import_tdds); ITS-REST specifications (the seven
+    released API groups, none of them message/extract/tdd); ITS-REST specifications/docs (no
+    such API); no openEHR spec governs this — our own design/extension
   ambiguity: AMB-34
 request:
   method: POST

--- a/tools/cnf-runner/artifacts/bindings/its-rest/I_TDD_SERVICE.import_tdds.yaml
+++ b/tools/cnf-runner/artifacts/bindings/its-rest/I_TDD_SERVICE.import_tdds.yaml
@@ -23,11 +23,10 @@ extension:
     import_tdds has no released wire; this product serves the operation on its
     own /message/tdd/{ehr_id}/batch route, which is what the cases drive.
   source: >-
-    SM docs/openehr_platform/master09-message_service.adoc +
-    docs/UML/classes/i_tdd_service.adoc (import_tdds) vs released ITS-REST
-    specifications/*.openapi.yaml (seven groups, none of them
-    message/extract/tdd) + specifications/docs/** (no such API) — no openEHR
-    spec governs the extension route, our own design/extension
+    SM docs/openehr_platform/master09-message_service.adoc; SM
+    docs/UML/classes/i_tdd_service.adoc (import_tdds); ITS-REST specifications (the seven
+    released API groups, none of them message/extract/tdd); ITS-REST specifications/docs (no
+    such API); no openEHR spec governs this — our own design/extension
   ambiguity: AMB-34
 request:
   method: POST

--- a/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
+++ b/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
@@ -2759,7 +2759,7 @@ cnf.opt.invalid.undefined_constraint_code:
   validity:
     verdict: invalid
     defect: "the definition references constraint code ac0001 (CONSTRAINT_REF) and constraint_bindings binds it, but no constraint_definitions entry defines it, and the ontology omits the mandatory term_definitions"
-    spec_ref: "AM ADL1.4 master08-adl.adoc §Coded Term Validity (VATDF: all ac codes used in the definition must be defined in constraint_definitions; VACDF); master05-cadl.adoc §Placeholder Constraints; ITS-XML components/AM/Release-1.4 §Archetype 1.4 (Archetype.xsd — ARCHETYPE_ONTOLOGY term_definitions mandatory)"
+    spec_ref: "AM ADL1.4 master08-adl.adoc §Coded Term Validity (VATDF: all ac codes used in the definition must be defined in constraint_definitions; VACDF); master05-cadl.adoc §Placeholder Constraints; ITS-XML components/AM/Release-1.4 §Archetype 1.4; ITS-XML components/AM/Release-1.4/Archetype.xsd §ARCHETYPE_ONTOLOGY (term_definitions mandatory)"
   template_id: "cnf.tpl.dv_coded_text_binding_undefined_ac"
   provenance: "the 2026-07-29 triage's adjudicated-invalid shape, preserved verbatim under its own id per the valid+invalid-twins rule (owner 2026-07-29): the pre-correction dt_coded_text_binding_sct.opt whose upload the SUT was spec-RIGHT to refuse (422 VTCBK). Its corrected valid twin is cnf.tpl.dv_coded_text_binding_sct; this row pins the refusal so a lenient server fails it"
 cnf.tpl.dv_coded_text_binding_sct:

--- a/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_DUMP_LOAD.export_ehrs-logical_format_xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/admin/I_ADMIN_DUMP_LOAD.export_ehrs-logical_format_xml.yaml
@@ -33,7 +33,7 @@ spec_refs:
   - "SM openehr_platform §I_ADMIN_DUMP_LOAD.export_ehrs"
   - "SM openehr_platform §EXPORT_SPEC (logical_format: flavour of XML, JSON etc.)"
   - "SM UML/classes/export_format.adoc (the openehr_canonical_xml member)"
-  - "ITS-XML components/RM/Release-1.0.2/documents §Validating documents (Version.xsd — the globally declared `version` element over an ABSTRACT VERSION type)"
+  - "ITS-XML components/RM/Release-1.0.2/documents §Validating documents; ITS-XML components/RM/Release-1.0.2/documents/Version.xsd §version (the one globally declared element, over an ABSTRACT VERSION type)"
 applies: { rm: ">=1.0.2" }
 guards:
   - "EXTENSION ROUTE — no openEHR spec governs /admin/dump or /admin/load; our own design/extension, declared in vocab/wire_surface.yaml served_extensions and adjudicated by register AMB-33. The row gates the EhrDumpLoad CAPABILITY verdict only, never ITS-REST wire conformance"

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.create_composition-xml.yaml
@@ -35,7 +35,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_COMPOSITION.create_composition"
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §Data representation"
-  - "ITS-XML components/RM/Release-1.0.2/documents §Validating documents (Composition.xsd — the globally declared `composition` element)"
+  - "ITS-XML components/RM/Release-1.0.2/documents §Validating documents; ITS-XML components/RM/Release-1.0.2/documents/Composition.xsd §composition (the one globally declared element)"
 applies: { rm: ">=1.0.2" }
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_at_time-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_at_time-xml.yaml
@@ -35,7 +35,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_COMPOSITION.get_composition_at_time"
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §Data representation"
-  - "ITS-XML components/RM/Release-1.0.2/documents §Validating documents (Composition.xsd — the globally declared `composition` element)"
+  - "ITS-XML components/RM/Release-1.0.2/documents §Validating documents; ITS-XML components/RM/Release-1.0.2/documents/Composition.xsd §composition (the one globally declared element)"
 applies: { rm: ">=1.0.2" }
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_at_version-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_at_version-xml.yaml
@@ -34,7 +34,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_COMPOSITION.get_composition_at_version"
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §Data representation"
-  - "ITS-XML components/RM/Release-1.0.2/documents §Validating documents (Composition.xsd — the globally declared `composition` element)"
+  - "ITS-XML components/RM/Release-1.0.2/documents §Validating documents; ITS-XML components/RM/Release-1.0.2/documents/Composition.xsd §composition (the one globally declared element)"
 applies: { rm: ">=1.0.2" }
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_latest-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_latest-xml.yaml
@@ -40,7 +40,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_COMPOSITION.get_composition_latest"
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §Data representation"
-  - "ITS-XML components/RM/Release-1.0.2/documents §Validating documents (Composition.xsd — the globally declared `composition` element)"
+  - "ITS-XML components/RM/Release-1.0.2/documents §Validating documents; ITS-XML components/RM/Release-1.0.2/documents/Composition.xsd §composition (the one globally declared element)"
 applies: { rm: ">=1.0.2" }
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_latest-xml_root_namespace.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_composition_latest-xml_root_namespace.yaml
@@ -56,7 +56,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_COMPOSITION.get_composition_latest"
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §Data representation"
-  - "ITS-XML components/RM/Release-1.0.2/documents §Validating documents (Composition.xsd — targetNamespace + the globally declared `composition` element)"
+  - "ITS-XML components/RM/Release-1.0.2/documents §Validating documents; ITS-XML components/RM/Release-1.0.2/documents/Composition.xsd §composition (targetNamespace, the one globally declared element)"
   - "ITS-XML README.adoc §Releases and IM Versions (the v1/v2 lineages)"
 applies: { rm: ">=1.0.2" }
 ambiguities: [AMB-169]                 # which of the two published lineages is served is implementation-defined, so the row asserts neither

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_versioned_composition-imported_version_xml_root.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_versioned_composition-imported_version_xml_root.yaml
@@ -61,7 +61,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_COMPOSITION.get_versioned_composition"
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §Data representation"
-  - "ITS-XML components/RM/Release-1.0.2/documents §Validating documents (Version.xsd — the globally declared `version` element over the abstract VERSION type; IMPORTED_VERSION extends it with `item`)"
+  - "ITS-XML components/RM/Release-1.0.2/documents §Validating documents; ITS-XML components/RM/Release-1.0.2/documents/Version.xsd §version (the one globally declared element, over the abstract VERSION type); ITS-XML components/RM/Release-1.0.2/Common.xsd §IMPORTED_VERSION (extends VERSION with `item`)"
   - "ITS-XML README.adoc §Releases and IM Versions (the v1/v2 lineages)"
   - "RM common §change_control (master06 §Copying — the IMPORTED_VERSION wrapper the receiver commits)"
 applies: { rm: ">=1.0.2" }

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_versioned_composition-version_xml_root.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.get_versioned_composition-version_xml_root.yaml
@@ -67,7 +67,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_COMPOSITION.get_versioned_composition"
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §Data representation"
-  - "ITS-XML components/RM/Release-1.0.2/documents §Validating documents (Version.xsd — the globally declared `version` element over the abstract VERSION type)"
+  - "ITS-XML components/RM/Release-1.0.2/documents §Validating documents; ITS-XML components/RM/Release-1.0.2/documents/Version.xsd §version (the one globally declared element, over the abstract VERSION type)"
   - "ITS-XML README.adoc §Releases and IM Versions (the v1/v2 lineages)"
   - "RM common §change_control (master06 §Version and its Subtypes — ORIGINAL_VERSION and IMPORTED_VERSION are the concrete VERSION classes)"
 applies: { rm: ">=1.0.2" }

--- a/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.has_composition-xml.yaml
+++ b/tools/cnf-runner/artifacts/schedule/composition/I_EHR_COMPOSITION.has_composition-xml.yaml
@@ -36,7 +36,7 @@ spec_refs:
   - "SM openehr_platform §I_EHR_COMPOSITION.has_composition"
   - "ITS-REST overview Resources.md §XML Format"
   - "ITS-REST overview Resources.md §Data representation"
-  - "ITS-XML components/RM/Release-1.0.2/documents §Validating documents (Composition.xsd — the globally declared `composition` element)"
+  - "ITS-XML components/RM/Release-1.0.2/documents §Validating documents; ITS-XML components/RM/Release-1.0.2/documents/Composition.xsd §composition (the one globally declared element)"
 applies: { rm: ">=1.0.2" }
 requires:
   server: any

--- a/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.update_party-prefer_minimal.yaml
+++ b/tools/cnf-runner/artifacts/schedule/demographic/I_DEMOGRAPHIC_SERVICE.update_party-prefer_minimal.yaml
@@ -52,8 +52,10 @@ flow:
     capture: { v2_uid: updated.version_uid }
   - step: 3                              # the empty answer still committed the version the ETag names
     call: get_party_at_version
+    # The read is version-addressed: GET /demographic/person/{version_uid}
+    # takes the OBJECT_VERSION_ID alone (person_get.yaml), so the version uid
+    # the 204's ETag named is the whole argument.
     with:
-      versioned_object_uid: "${versioned_object_uid}"
       version_uid: "${v2_uid}"
     expect: ok
 postconditions:

--- a/tools/cnf-runner/party/ehrbase-java/statement.json
+++ b/tools/cnf-runner/party/ehrbase-java/statement.json
@@ -3,7 +3,7 @@
     "name": "EHRbase",
     "version": "2.34.0",
     "vendor": "EHRbase (vitagroup / upstream open-source project)",
-    "identifier": "urn:ferroehr:ferroehr"
+    "identifier": "urn:ehrbase:ehrbase"
   },
   "schedule_release": "cnf-2.0-w2",
   "spec_versions": {

--- a/tools/cnf-runner/src/exec/opt_synth.rs
+++ b/tools/cnf-runner/src/exec/opt_synth.rs
@@ -97,7 +97,7 @@ pub fn synthesize_value_opt(
         "DV_CODED_TEXT" => build_coded_text(&row),
         "DV_IDENTIFIER" => (build_identifier(&row), Vec::new()),
         "DV_PARSABLE" => (build_parsable(&row), Vec::new()),
-        "DV_MULTIMEDIA" => (build_multimedia(&row), Vec::new()),
+        "DV_MULTIMEDIA" => (build_multimedia(&row)?, Vec::new()),
         "DV_INTERVAL" => build_interval(case_id, &row),
         other => {
             return Err(SynthError::Unsupported(format!(
@@ -639,7 +639,7 @@ fn build_parsable(row: &Row<'_>) -> String {
     c_complex("DV_PARSABLE", &attrs)
 }
 
-fn build_multimedia(row: &Row<'_>) -> String {
+fn build_multimedia(row: &Row<'_>) -> Result<String, SynthError> {
     let mut attrs = String::new();
     let media = parse_list(row.literal("C_CODE_PHRASE"));
     if !media.is_empty() {
@@ -649,9 +649,8 @@ fn build_multimedia(row: &Row<'_>) -> String {
             (1, 1),
         ));
     }
-    if let Some(range) = row.text("C_INTEGER.range")
-        && let Some((lo, hi)) = parse_int_range(range)
-    {
+    if let Some(range) = row.text("C_INTEGER.range") {
+        let (lo, hi) = parse_int_range(range)?;
         // DV_MULTIMEDIA.size is RM-mandatory (existence 1..1 in the reference
         // model — RM data_types §DV_MULTIMEDIA); the archetype must not relax it.
         attrs.push_str(&c_single_attr(
@@ -660,7 +659,7 @@ fn build_multimedia(row: &Row<'_>) -> String {
             (1, 1),
         ));
     } else {
-        let ints = parse_int_list(row.literal("C_INTEGER.list"));
+        let ints = parse_int_list(row.literal("C_INTEGER.list"))?;
         if !ints.is_empty() {
             attrs.push_str(&c_single_attr(
                 "size",
@@ -669,20 +668,49 @@ fn build_multimedia(row: &Row<'_>) -> String {
             ));
         }
     }
-    c_complex("DV_MULTIMEDIA", &attrs)
+    Ok(c_complex("DV_MULTIMEDIA", &attrs))
 }
 
-fn parse_int_list(cell: Option<&Value>) -> Vec<i64> {
+/// Parse an integer list cell into its bounds.
+///
+/// A non-integer entry is a CATALOGUE defect, never a silently narrower
+/// constraint: dropping it would emit an OPT whose `C_INTEGER.list` is missing
+/// the very value the row's expected-rejection rests on, so the row would pass
+/// vacuously.
+fn parse_int_list(cell: Option<&Value>) -> Result<Vec<i64>, SynthError> {
     parse_list(cell)
         .into_iter()
-        .filter_map(|s| s.parse::<i64>().ok())
+        .map(|s| {
+            s.parse::<i64>().map_err(|e| {
+                SynthError::Unsupported(format!(
+                    "C_INTEGER.list entry {s:?} is not an integer: {e}"
+                ))
+            })
+        })
         .collect()
 }
 
 /// Parse a range cell authored as `lo..hi` (or `[lo, hi]`) into integer bounds.
-fn parse_int_range(cell: &str) -> Option<(i64, i64)> {
-    let (lo, hi) = split_range(cell)?;
-    Some((lo.parse().ok()?, hi.parse().ok()?))
+///
+/// # Errors
+/// [`SynthError::Unsupported`] when the cell is not a two-bound range or a
+/// bound is not an integer — a catalogue defect, never a silent fall-through
+/// to the list branch (which would emit an OPT with no `size` constraint at
+/// all).
+fn parse_int_range(cell: &str) -> Result<(i64, i64), SynthError> {
+    let defect = |detail: String| SynthError::Unsupported(detail);
+    let (lo, hi) = split_range(cell).ok_or_else(|| {
+        defect(format!(
+            "C_INTEGER.range cell {cell:?} is not a `lo..hi` range"
+        ))
+    })?;
+    let lo: i64 = lo
+        .parse()
+        .map_err(|e| defect(format!("C_INTEGER.range lower bound {lo:?}: {e}")))?;
+    let hi: i64 = hi
+        .parse()
+        .map_err(|e| defect(format!("C_INTEGER.range upper bound {hi:?}: {e}")))?;
+    Ok((lo, hi))
 }
 
 /// Split a `lo..hi` (or `[lo, hi]`) range cell into its two string bounds.
@@ -725,7 +753,7 @@ fn interval_inner(case_id: &str) -> &'static str {
     }
 }
 
-/// A `DV_INTERVAL`<inner> value `C_COMPLEX_OBJECT` with optional lower/upper limit
+/// A `DV_INTERVAL<inner>` value `C_COMPLEX_OBJECT` with optional lower/upper limit
 /// object constraints (`None` => that side unconstrained).
 fn dv_interval(inner: &str, lower: Option<&str>, upper: Option<&str>) -> String {
     let mut attrs = String::new();

--- a/tools/cnf-runner/src/exec/recipes.rs
+++ b/tools/cnf-runner/src/exec/recipes.rs
@@ -760,7 +760,7 @@ fn min_observation(events: Vec<Value>, state: Option<Value>, protocol: Option<Va
     Value::Object(obs)
 }
 
-/// The COMPOSITION shell (category/composer/[context]) carrying `content`
+/// The COMPOSITION shell (category/composer/\[context\]) carrying `content`
 /// (omitted entirely when empty — COMPOSITION.content existence 0..1, so an
 /// absent list is 0 items; a present-but-empty list is an RM error).
 fn comp_shell(template_id: &str, content: Vec<Value>, with_context: bool) -> Value {

--- a/tools/cnf-runner/src/run.rs
+++ b/tools/cnf-runner/src/run.rs
@@ -226,16 +226,20 @@ fn capabilities_claiming_family(set: &ArtifactSet, family: &str) -> Vec<Capabili
 /// against a party that serves no import route would record a red row for a
 /// ground that party never offered to establish. Excused at SELECTION time —
 /// never as a drive-time provisioning refusal, which reads like a SUT defect.
+///
+/// # Errors
+/// An interpreter defect: one of the SM operation anchors this arm is written
+/// against is not a well-formed `I_<INTERFACE>.<operation>` reference.
 fn unservable_import(
     set: &ArtifactSet,
     statement: Option<&crate::party::Statement>,
     case: &CaseCore,
-) -> Option<String> {
+) -> Result<Option<String>, String> {
     if !matches!(
         case.requires.import,
         Some(crate::model::case::ImportRequirement::Received { .. })
     ) {
-        return None;
+        return Ok(None);
     }
     // Either receiving situation of master06 §Copying drives the same family;
     // whichever binding the catalogue realizes names it.
@@ -257,16 +261,20 @@ fn unservable_import(
 /// [`unservable_import`]'s extract replay is, so a party that claims none of
 /// the capabilities that family's cases gate has no relationship to
 /// precondition with.
+///
+/// # Errors
+/// An interpreter defect: an SM operation anchor this arm is written against
+/// is not a well-formed `I_<INTERFACE>.<operation>` reference.
 fn unservable_party_relationship(
     set: &ArtifactSet,
     statement: Option<&crate::party::Statement>,
     case: &CaseCore,
-) -> Option<String> {
+) -> Result<Option<String>, String> {
     if !matches!(
         case.requires.party_relationship,
         Some(PartyRelationshipRequirement::Exists { .. })
     ) {
-        return None;
+        return Ok(None);
     }
     unservable_provisioning(
         set,
@@ -292,32 +300,47 @@ fn unservable_party_relationship(
 /// family (the first one the catalogue realizes decides); `requirement` names
 /// the precondition for the citation, and `consequence` says what the case
 /// therefore cannot read.
+///
+/// # Errors
+/// An interpreter defect: an `operations` anchor is not a well-formed
+/// `I_<INTERFACE>.<operation>` reference. A malformed anchor matches no
+/// binding, so swallowing the parse would silently turn this whole arm off —
+/// every `requires`-provisioned case would then DRIVE against a party that
+/// serves no such route and record a red row for a ground it never offered to
+/// establish, which is the opposite of what this selection law exists to do.
 fn unservable_provisioning(
     set: &ArtifactSet,
     statement: Option<&crate::party::Statement>,
     operations: &[&str],
     requirement: &str,
     consequence: &str,
-) -> Option<String> {
-    let statement = statement?;
-    let decl = operations
-        .iter()
-        .filter_map(|call| SmOperationRef::parse(call).ok())
-        .find_map(|op| {
-            set.bindings
-                .iter()
-                .map(|(_, b)| b)
-                .find(|b| b.sm_operation == op)
-                .and_then(|b| b.extension.as_ref())
-        })?;
+) -> Result<Option<String>, String> {
+    let Some(statement) = statement else {
+        return Ok(None);
+    };
+    let mut parsed: Vec<SmOperationRef> = Vec::with_capacity(operations.len());
+    for call in operations {
+        parsed.push(SmOperationRef::parse(call).map_err(|e| {
+            format!("interpreter defect: selection-law SM operation anchor {call:?}: {e}")
+        })?);
+    }
+    let Some(decl) = parsed.iter().find_map(|op| {
+        set.bindings
+            .iter()
+            .map(|(_, b)| b)
+            .find(|b| b.sm_operation == *op)
+            .and_then(|b| b.extension.as_ref())
+    }) else {
+        return Ok(None);
+    };
     let claiming = capabilities_claiming_family(set, &decl.family);
     if claiming
         .iter()
         .any(|c| statement.claims.capabilities.contains(c))
     {
-        return None;
+        return Ok(None);
     }
-    Some(format!(
+    Ok(Some(format!(
         "{requirement} provisions over the {} extension routes ({}): the ICS claims none of \
          the capabilities those routes' cases gate ({}), and no openEHR specification governs \
          them, so {consequence}",
@@ -328,7 +351,7 @@ fn unservable_provisioning(
             .map(ToString::to_string)
             .collect::<Vec<_>>()
             .join(", ")
-    ))
+    )))
 }
 
 /// The `${ixit:…}` facts a case reads that THIS party's ixit does not
@@ -547,11 +570,15 @@ fn not_applicable_record(case: &CaseCore, citation: &str) -> CaseRecord {
 /// at another vendor's SUT would publish failures for routes that vendor never
 /// offered to serve — the published comparison must be honest in both
 /// directions, and a spurious red row is not honesty.
+///
+/// # Errors
+/// An interpreter defect propagated from the provisioning arms (a malformed
+/// SM operation anchor).
 fn unserved_extension(
     set: &ArtifactSet,
     statement: Option<&crate::party::Statement>,
     case: &CaseCore,
-) -> Option<String> {
+) -> Result<Option<String>, String> {
     if let Some(stmt) = statement
         && let Some(family) = extension_family(set, case)
         && !case
@@ -559,28 +586,33 @@ fn unserved_extension(
             .iter()
             .any(|c| stmt.claims.capabilities.contains(c))
     {
-        return Some(format!(
+        return Ok(Some(format!(
             "extension realization ({family}): the ICS claims none of this case's \
              capabilities, and no openEHR specification governs the route — ISO/IEC 9646 \
              test selection"
-        ));
+        )));
     }
-    unservable_import(set, statement, case)
-        .or_else(|| unservable_party_relationship(set, statement, case))
-        .map(|citation| format!("{citation} — ISO/IEC 9646 test selection"))
+    let citation = match unservable_import(set, statement, case)? {
+        Some(citation) => Some(citation),
+        None => unservable_party_relationship(set, statement, case)?,
+    };
+    Ok(citation.map(|citation| format!("{citation} — ISO/IEC 9646 test selection")))
 }
 
+/// # Errors
+/// An interpreter defect propagated from the extension arm (a malformed SM
+/// operation anchor in the selection law).
 fn selection_exception(
     set: &ArtifactSet,
     ixit: &Ixit,
     statement: Option<&crate::party::Statement>,
     case: &CaseCore,
-) -> Option<Exception> {
+) -> Result<Option<Exception>, String> {
     if let Some(citation) = fully_unrealized(set, case) {
-        return Some(Exception::Unrealized(citation));
+        return Ok(Some(Exception::Unrealized(citation)));
     }
-    if let Some(citation) = unserved_extension(set, statement, case) {
-        return Some(Exception::Unrealized(citation));
+    if let Some(citation) = unserved_extension(set, statement, case)? {
+        return Ok(Some(Exception::Unrealized(citation)));
     }
     // An option branch the party statement does not declare is not this
     // SUT's behaviour — driving it records a spurious failure the verdict
@@ -590,10 +622,10 @@ fn selection_exception(
         && let Some(tag) = &case.option
         && !stmt.options.contains(tag)
     {
-        return Some(Exception::Unrealized(format!(
+        return Ok(Some(Exception::Unrealized(format!(
             "option {tag}: the ICS does not declare this register branch \
              (statement.options) — ISO/IEC 9646 test selection"
-        )));
+        ))));
     }
     // Case-level spec-version floors (`CaseCore.applies`): a behaviour the
     // spec dates to a release the party does not declare is out of scope for
@@ -611,11 +643,11 @@ fn selection_exception(
             .into_iter()
             .map(|(component, range)| format!("{} {}", component.token(), range.raw()))
             .collect();
-        return Some(Exception::Unrealized(format!(
+        return Ok(Some(Exception::Unrealized(format!(
             "case version floor unmet ({}) — the party's declared spec versions do not \
              satisfy the case's applies ranges; ISO/IEC 9646 test selection",
             declared.join(", ")
-        )));
+        ))));
     }
     // Operation-level spec-version floors (`OperationBinding.applies`): a
     // wire a later release introduced is not this party's behaviour to
@@ -624,11 +656,11 @@ fn selection_exception(
     if let Some(stmt) = statement {
         let unmet = unmet_binding_floors(set, case, &stmt.spec_versions);
         if !unmet.is_empty() {
-            return Some(Exception::Unrealized(format!(
+            return Ok(Some(Exception::Unrealized(format!(
                 "operation version floor unmet ({}) — the party's declared spec versions \
                  predate the release that introduced this wire; ISO/IEC 9646 test selection",
                 unmet.join("; ")
-            )));
+            ))));
         }
     }
     // The SMART lane is a party declaration, exactly like the ixit facts
@@ -639,12 +671,12 @@ fn selection_exception(
     // Undeclared => not-applicable with the citation, never a spurious
     // failure against a deployment that legitimately does not run SMART.
     if needs_smart_lane(case) && ixit.smart.is_none() {
-        return Some(Exception::Guarded(
+        return Ok(Some(Exception::Guarded(
             "the ixit declares no `smart` lane — the case needs a SMART-enabled \
              deployment and a minted, scope-carrying access token, neither of which any \
              released operation discloses or provides; ISO/IEC 9646 test selection"
                 .to_owned(),
-        ));
+        )));
     }
     // The terminology deployment is a party declaration exactly like the
     // SMART lane above: released ITS-REST surfaces no terminology resource,
@@ -653,31 +685,31 @@ fn selection_exception(
     // or differently declared => not-applicable with the citation, never a
     // red row against a deployment that legitimately runs the other posture.
     if let Some(citation) = unsatisfied_terminology(case, ixit) {
-        return Some(Exception::Guarded(format!(
+        return Ok(Some(Exception::Guarded(format!(
             "{citation}; ISO/IEC 9646 test selection"
-        )));
+        ))));
     }
     // A flow step addressing an instance this party does not declare has no
     // ground to run on (the deployment or principal simply does not exist
     // here).
     let missing_instances = undeclared_instances(case, ixit);
     if !missing_instances.is_empty() {
-        return Some(Exception::Guarded(format!(
+        return Ok(Some(Exception::Guarded(format!(
             "the ixit declares no instance {} — the case's flow addresses it with `on:` and \
              this party runs no such deployment/principal; ISO/IEC 9646 test selection",
             missing_instances.join(", ")
-        )));
+        ))));
     }
     // A case reading a party-declared SUT fact this ixit does not carry
     // cannot be driven: the fact is not on the wire, so the alternative to a
     // declaration is a guess.
     let missing = undeclared_ixit_facts(case, ixit);
     if !missing.is_empty() {
-        return Some(Exception::Guarded(format!(
+        return Ok(Some(Exception::Guarded(format!(
             "the ixit declares no {} — the case reads it as ${{ixit:…}} and no released \
              operation discloses the value; ISO/IEC 9646 test selection",
             missing.join(", ")
-        )));
+        ))));
     }
     // Global-state grounds (an empty template list, a globally-absent
     // artefact) hold only on an exclusively-owned SUT; on a shared instance
@@ -690,14 +722,14 @@ fn selection_exception(
         .as_ref()
         .is_some_and(|env| env.exclusive_server)
     {
-        return Some(Exception::Unrealized(
+        return Ok(Some(Exception::Unrealized(
             "requires.server: exclusive — the ixit declares a shared SUT instance \
              (environment.exclusive_server: false); the global-state ground cannot \
              be established"
                 .to_owned(),
-        ));
+        )));
     }
-    None
+    Ok(None)
 }
 
 /// Execute every runnable case against the ixit's default topology.
@@ -737,7 +769,7 @@ pub fn execute(
             ));
             continue;
         }
-        if let Some(exception) = selection_exception(set, ixit, statement, case) {
+        if let Some(exception) = selection_exception(set, ixit, statement, case)? {
             let citation = match &exception {
                 Exception::Unrealized(c)
                 | Exception::ContentGeneration(c)
@@ -1082,15 +1114,18 @@ mod tests {
         };
         let serving = statement(&["EhrExtract", "Versioning"]);
         assert!(
-            unservable_import(&set, Some(&serving), &reader).is_none(),
+            unservable_import(&set, Some(&serving), &reader)
+                .expect("well-formed anchors")
+                .is_none(),
             "a party claiming the family's capability drives the case"
         );
 
         // Claims the READ capability but not the import family — the case's
         // own capabilities must not be what decides this.
         let read_only = statement(&["Versioning"]);
-        let citation =
-            unservable_import(&set, Some(&read_only), &reader).expect("excused with a citation");
+        let citation = unservable_import(&set, Some(&read_only), &reader)
+            .expect("well-formed anchors")
+            .expect("excused with a citation");
         assert!(citation.contains("message-extract"), "{citation}");
         assert!(
             citation.contains("AMB-34"),
@@ -1106,7 +1141,11 @@ mod tests {
             "flow": [{ "step": 1, "call": "get_versioned_composition", "expect": "ok" }]
         }))
         .unwrap();
-        assert!(unservable_import(&set, Some(&read_only), &plain).is_none());
+        assert!(
+            unservable_import(&set, Some(&read_only), &plain)
+                .expect("well-formed anchors")
+                .is_none()
+        );
     }
 
     /// `requires.party_relationship` provisions over the SAME extension seam
@@ -1183,7 +1222,9 @@ mod tests {
         };
         let serving = statement(&["PartyRelationships", "Demographics"]);
         assert!(
-            unservable_party_relationship(&set, Some(&serving), &reader).is_none(),
+            unservable_party_relationship(&set, Some(&serving), &reader)
+                .expect("well-formed anchors")
+                .is_none(),
             "a party claiming the family's capability drives the case"
         );
 
@@ -1191,6 +1232,7 @@ mod tests {
         // case's own capabilities must not be what decides this.
         let read_only = statement(&["Demographics"]);
         let citation = unservable_party_relationship(&set, Some(&read_only), &reader)
+            .expect("well-formed anchors")
             .expect("excused with a citation");
         assert!(citation.contains("party-relationship"), "{citation}");
         assert!(
@@ -1208,7 +1250,11 @@ mod tests {
             "flow": [{ "step": 1, "call": "get_party", "expect": "ok" }]
         }))
         .unwrap();
-        assert!(unservable_party_relationship(&set, Some(&read_only), &plain).is_none());
+        assert!(
+            unservable_party_relationship(&set, Some(&read_only), &plain)
+                .expect("well-formed anchors")
+                .is_none()
+        );
     }
 
     /// The SMART-lane marker is the DECLARATION of a `scopes:` key (empty

--- a/tools/cnf-runner/src/validate.rs
+++ b/tools/cnf-runner/src/validate.rs
@@ -53,6 +53,11 @@ pub enum CheckId {
     /// A binding file's stem states the binding it holds:
     /// `<sm_operation>[-<variant>]`.
     BindingFilename,
+    /// Every `with:` key a flow step authors is CONSUMED by the binding the
+    /// driver would select for it (issue #1830): an argument no request form
+    /// reads is decoration the SUT never sees, so the case's assertion about
+    /// it passes vacuously — the whole reason the gate exists.
+    StepArguments,
     /// `verified_by` targets exist.
     VerifiedBy,
     /// Corpus keys/views/sources exist; entry invariants hold.
@@ -119,6 +124,7 @@ impl CheckId {
             Self::SpecRef => "spec-ref",
             Self::BindingCompleteness => "binding-completeness",
             Self::BindingFilename => "binding-filename",
+            Self::StepArguments => "step-arguments",
             Self::VerifiedBy => "verified-by",
             Self::CorpusIntegrity => "corpus-integrity",
             Self::AmbiguityLink => "ambiguity-link",
@@ -201,6 +207,7 @@ pub fn validate(ctx: &Context<'_>) -> Vec<Finding> {
         }
     }
     check_binding_completeness(ctx.set, &mut findings);
+    check_step_arguments(ctx.set, &mut findings);
     for (path, binding) in &ctx.set.bindings {
         let who = path.display().to_string();
         if let Err(message) = binding.check_invariants() {
@@ -222,6 +229,7 @@ pub fn validate(ctx: &Context<'_>) -> Vec<Finding> {
         }
         if let Some(spec) = spec.as_ref() {
             resolve_sm_operation(&binding.sm_operation, &who, spec, &mut findings);
+            check_binding_sources(binding, &who, spec, &mut findings);
         }
     }
     check_corpus_integrity(ctx.set, &mut findings);
@@ -1526,6 +1534,24 @@ struct SpecIndex<'a> {
     attributes: RefCell<BTreeMap<PathBuf, Rc<BTreeMap<String, String>>>>,
     /// `interface → its parsed SM operation names`.
     interfaces: RefCell<BTreeMap<String, InterfaceOperations>>,
+    /// The ITS-XML component's SECOND root: the released XSD bundles.
+    /// See [`SpecIndex::component_roots`].
+    xml_schemas: Option<PathBuf>,
+}
+
+/// The vendored ITS-XML schema bundle, located from the vendored spec root.
+///
+/// Both are repo-relative and both are vendored by committed scripts, so the
+/// spec root's grandparent IS the workspace root (`docs/specs/openehr` →
+/// `docs/specs` → `docs` → the workspace). The same derivation already
+/// locates `docs/conformance/` for the coverage report. `None` when the
+/// bundle is not there (a spec tree used outside the workspace, e.g. a test
+/// fixture): ITS-XML citations then resolve against the docs tree alone,
+/// exactly as before issue #1833.
+fn xml_schema_root(spec_root: &Path) -> Option<PathBuf> {
+    let workspace = spec_root.parent()?.parent()?.parent()?;
+    let bundle = workspace.join("crates/openehr-its/schemas/xml");
+    bundle.is_dir().then_some(bundle)
 }
 
 /// One vendored component directory's file listing, indexed for the two
@@ -1549,7 +1575,39 @@ impl<'a> SpecIndex<'a> {
             sections: RefCell::new(BTreeMap::new()),
             attributes: RefCell::new(BTreeMap::new()),
             interfaces: RefCell::new(BTreeMap::new()),
+            xml_schemas: xml_schema_root(root),
         }
+    }
+
+    /// The directories a citation of `component` may resolve against, most
+    /// authoritative first.
+    ///
+    /// Every component has exactly one — its vendored docs directory —
+    /// except **ITS-XML**, which has two. `scripts/vendor-spec-docs.sh`
+    /// vendors PROSE, so the docs tree's `ITS-XML/components/**` holds only
+    /// the upstream `README.adoc` stubs; the released XSD bundles themselves
+    /// are vendored ONCE, at `crates/openehr-its/schemas/xml/`, as the
+    /// canonical-XML codec's input (`docs/VERSIONS.md` §openEHR
+    /// specification matrix). An XSD-element citation therefore resolved
+    /// nowhere. Adjudication (issue #1833): the gate learns the bundle as a
+    /// SECOND ROOT — one vendored copy, two readers — rather than the
+    /// bundle being copied into the docs tree, which would fork the
+    /// schemas the codec and the citations speak about.
+    ///
+    /// A root that does not exist is dropped, so an empty result is the
+    /// "component dir missing" finding.
+    fn component_roots(&self, component: &str, dir: &str) -> Vec<PathBuf> {
+        let mut roots = Vec::new();
+        let docs = self.root.join(dir);
+        if docs.is_dir() {
+            roots.push(docs);
+        }
+        if component == "ITS-XML"
+            && let Some(schemas) = &self.xml_schemas
+        {
+            roots.push(schemas.clone());
+        }
+        roots
     }
 
     /// The vendored spec root this index reads.
@@ -1683,7 +1741,10 @@ impl<'a> SpecIndex<'a> {
                 path.extension().and_then(|e| e.to_str()),
                 Some("yaml" | "yml" | "json")
             );
-            if yaml {
+            let xsd = matches!(path.extension().and_then(|e| e.to_str()), Some("xsd"));
+            if xsd {
+                names.extend(xsd_declared_names(&text));
+            } else if yaml {
                 names.extend(structured_keys(&text));
             } else {
                 names.extend(asciidoc_section_names(&text));
@@ -1854,6 +1915,34 @@ fn table_cell_label(line: &str) -> Option<String> {
         return None;
     }
     Some(normalize_section(label))
+}
+
+/// The declared names of an XSD — its `name="…"` values, which are exactly
+/// what an ITS-XML citation addresses with `§`: a globally declared element
+/// (`§composition`), a `complexType` (`§COMPOSITION`), an attribute or a
+/// group. A schema is the one vendored artifact with no headings, so without
+/// this its `§` citations could never resolve (issue #1833).
+///
+/// Deliberately a lexical scan, not an XML parse: the gate needs the set of
+/// declared names, and an XSD's `name` attribute is unambiguous — nothing
+/// else in the grammar spells `name="`.
+fn xsd_declared_names(text: &str) -> BTreeSet<String> {
+    let mut names = BTreeSet::new();
+    for tail in text.split("name=").skip(1) {
+        let Some(rest) = tail.strip_prefix('"').or_else(|| tail.strip_prefix('\'')) else {
+            continue;
+        };
+        let quote = if tail.starts_with('"') { '"' } else { '\'' };
+        let Some(value) = rest.split(quote).next() else {
+            continue;
+        };
+        // A qualified name cites its local part (`openehr:COMPOSITION`).
+        let local = value.rsplit(':').next().unwrap_or(value).trim();
+        if !local.is_empty() {
+            names.insert(normalize_section(local));
+        }
+    }
+    names
 }
 
 /// The keys of a YAML/JSON document (the OAS operation, response and schema
@@ -2193,23 +2282,34 @@ fn check_citations(
                 );
                 continue;
             };
-            let root = spec.root().join(dir);
-            if !root.is_dir() {
+            let roots = spec.component_roots(clause.component, dir);
+            let Some(first) = roots.first() else {
                 push(
                     findings,
                     CheckId::SpecRef,
                     who,
                     format!(
                         "{citation:?}: vendored component dir {} missing",
-                        root.display()
+                        spec.root().join(dir).display()
                     ),
                 );
                 continue;
-            }
+            };
             if clause.tokens.is_empty() {
-                continue; // component-only citation: dir existence was the check
+                let _ = first; // component-only citation: dir existence was the check
+                continue;
             }
-            let documents = resolve_documents(spec, &root, &clause.tokens);
+            // Each root is resolved independently and the hits pooled: an
+            // ITS-XML citation may name a docs-tree chapter OR an XSD of the
+            // vendored schema bundle (issue #1833).
+            let mut documents: Vec<(&PathBuf, PathBuf)> = Vec::new();
+            for root in &roots {
+                documents.extend(
+                    resolve_documents(spec, root, &clause.tokens)
+                        .into_iter()
+                        .map(|document| (root, document)),
+                );
+            }
             if documents.is_empty() {
                 push(
                     findings,
@@ -2226,8 +2326,8 @@ fn check_citations(
                 continue;
             }
             let mut names = BTreeSet::new();
-            for document in &documents {
-                names.extend(spec.document_sections(&root, document).iter().cloned());
+            for (root, document) in &documents {
+                names.extend(spec.document_sections(root, document).iter().cloned());
             }
             for section in &clause.sections {
                 if !section_resolves(&section_candidates(section), &names) {
@@ -2263,6 +2363,97 @@ fn check_spec_refs(case: &CaseCore, who: &str, spec: &SpecIndex<'_>, findings: &
     check_citations(&citations, who, spec, findings);
 }
 
+/// The one non-citation clause a binding `source` may carry: the explicit
+/// spec-silence flag an `unrealized`/`extension` declaration must state
+/// (`.claude/rules/spec-adherence.md` — where the specs are SILENT, flag it).
+const SPEC_SILENCE_FLAG_PREFIX: &str = "no openehr spec governs";
+/// The other non-citation clause: the ambiguity-register entry that
+/// adjudicated the boundary (`ambiguity:` carries the id; the `source` may
+/// repeat it as the closing clause of the derivation).
+const REGISTER_CLAUSE_PREFIX: &str = "register amb-";
+
+/// A binding's `unrealized.source` / `extension.source` is a DERIVATION, not
+/// a sentence: what the SM defines, what the released ITS surfaces (or does
+/// not), and the spec-silence flag that follows. This gate pins it to the
+/// `spec_ref` clause grammar so every citation inside it is machine-resolved
+/// like a case's `spec_refs`.
+///
+/// Two halves:
+///
+/// 1. **Every clause is accounted for.** [`citation_clauses`] silently DROPS
+///    a fragment that does not open with a known component token — that is
+///    what let these fields escape the citation gate (issue #1832): a
+///    derivation written `SM x.adoc … vs ITS-REST y.yaml …` reads as ONE
+///    clause, so the ITS-REST half was never checked, and a typo in a
+///    component token vanished with it. Here a fragment must open with a
+///    component, state the spec-silence flag, or name the register entry.
+/// 2. **Every citation resolves**, via the shared [`check_citations`].
+///
+/// The sibling `reason` field is deliberately NOT gated: `source` and
+/// `reason` are the citation/free-text SPLIT of one declaration — `source`
+/// carries the citations, `reason` says in prose why the released ITS
+/// surfaces no wire and what this product serves instead. Gating prose would
+/// only push it back into `source`.
+fn check_binding_sources(
+    binding: &OperationBinding,
+    who: &str,
+    spec: &SpecIndex<'_>,
+    findings: &mut Vec<Finding>,
+) {
+    let sources = [
+        binding
+            .unrealized
+            .as_ref()
+            .map(|d| ("unrealized", &d.source)),
+        binding.extension.as_ref().map(|d| ("extension", &d.source)),
+    ];
+    for (field, source) in sources.into_iter().flatten() {
+        let source = source.trim();
+        if source.is_empty() {
+            push(
+                findings,
+                CheckId::SpecRef,
+                who,
+                format!("{field}.source is empty"),
+            );
+            continue;
+        }
+        for fragment in source.split(';').flat_map(|semi| semi.split(" + ")) {
+            let fragment = fragment.trim();
+            if fragment.is_empty() {
+                continue;
+            }
+            let opens_component = fragment
+                .split_whitespace()
+                .next()
+                .is_some_and(|word| component_dir(word).is_some());
+            let normalized = normalize_section(fragment);
+            if opens_component
+                || normalized.starts_with(SPEC_SILENCE_FLAG_PREFIX)
+                || normalized.starts_with(REGISTER_CLAUSE_PREFIX)
+            {
+                continue;
+            }
+            push(
+                findings,
+                CheckId::SpecRef,
+                who,
+                format!(
+                    "{field}.source clause {fragment:?} opens with neither a spec component nor \
+                     the spec-silence flag nor the register entry — the citation gate would drop \
+                     it unread; separate the derivation's citations with `;` or ` + `"
+                ),
+            );
+        }
+        check_citations(
+            &[source],
+            &format!("{who} [{field}.source]"),
+            spec,
+            findings,
+        );
+    }
+}
+
 /// The corpus manifest's own citations: every invalid fixture grounds its
 /// defect in a spec rule, and that citation resolves like any other.
 fn check_corpus_spec_refs(set: &ArtifactSet, spec: &SpecIndex<'_>, findings: &mut Vec<Finding>) {
@@ -2275,6 +2466,287 @@ fn check_corpus_spec_refs(set: &ArtifactSet, spec: &SpecIndex<'_>, findings: &mu
             continue;
         };
         check_citations(&[citation], &format!("{who} [{key}]"), spec, findings);
+    }
+}
+
+// ── step arguments (no vacuous `with:` key) ─────────────────────────────────
+
+/// The payload-role aliases [`crate::exec::driver`]'s `select_body` accepts
+/// for a `Named` body beside the declared role name.
+const BODY_ROLE_ALIASES: [&str; 2] = ["composition", "opt"];
+/// The two keys the bundled-CONTRIBUTION construct reads when the declared
+/// body role is `contribution`: the version set and the client-supplied
+/// commit audit (the latter is what issue #1818 wired through).
+const CONTRIBUTION_KEYS: [&str; 2] = ["versions", "audit"];
+
+/// Every `${name}` a template addresses as a capture/handle.
+fn template_capture_names(template: &crate::refgrammar::Template, into: &mut BTreeSet<String>) {
+    for reference in template.refs() {
+        if let ValueRef::Capture { name, .. } = reference {
+            into.insert(name.to_string());
+        }
+    }
+}
+
+/// The same, over a whole templated value tree.
+fn value_capture_names(value: &TemplatedValue, into: &mut BTreeSet<String>) {
+    match value {
+        TemplatedValue::Text(template) => template_capture_names(template, into),
+        TemplatedValue::Seq(items) => {
+            for item in items {
+                value_capture_names(item, into);
+            }
+        }
+        TemplatedValue::Map(entries) => {
+            for (_, item) in entries {
+                value_capture_names(item, into);
+            }
+        }
+        TemplatedValue::Null | TemplatedValue::Bool(_) | TemplatedValue::Number(_) => {}
+    }
+}
+
+/// Every `${ds:…}` a templated value tree addresses.
+fn value_data_set_refs(value: &TemplatedValue, into: &mut BTreeSet<String>) {
+    match value {
+        TemplatedValue::Text(template) => {
+            for reference in template.refs() {
+                if let ValueRef::DataSet { key, .. } = reference {
+                    into.insert(key.to_string());
+                }
+            }
+        }
+        TemplatedValue::Seq(items) => {
+            for item in items {
+                value_data_set_refs(item, into);
+            }
+        }
+        TemplatedValue::Map(entries) => {
+            for (_, item) in entries {
+                value_data_set_refs(item, into);
+            }
+        }
+        TemplatedValue::Null | TemplatedValue::Bool(_) | TemplatedValue::Number(_) => {}
+    }
+}
+
+/// Whether a `with:` value could resolve to the single-payload body the
+/// `Named` role's fallback picks.
+///
+/// Mirrors `select_body`'s own test on the RESOLVED value — an object, an
+/// array, or (for a `*_text` role, whose payload IS a string) any string.
+/// Statically, a reference-bearing string may resolve to either: a
+/// `${ds:…}` resolves to the corpus entry's parsed JSON, a capture to
+/// whatever was captured.
+fn could_be_payload(value: &TemplatedValue, text_role: bool) -> bool {
+    match value {
+        TemplatedValue::Seq(_) | TemplatedValue::Map(_) => true,
+        TemplatedValue::Text(template) => {
+            text_role
+                || template.refs().any(|r| {
+                    matches!(
+                        r,
+                        ValueRef::DataSet { .. }
+                            | ValueRef::FixtureDataSet
+                            | ValueRef::Recipe(_)
+                            | ValueRef::Capture { .. }
+                            | ValueRef::Row(_)
+                            | ValueRef::Fixture(_)
+                    )
+                })
+        }
+        TemplatedValue::Null | TemplatedValue::Bool(_) | TemplatedValue::Number(_) => false,
+    }
+}
+
+/// The `with:` keys the driver would READ when it drives `step` through
+/// `binding` — the union of every consumption path in
+/// [`crate::exec::driver`].
+fn consumed_with_keys(
+    set: &ArtifactSet,
+    binding: &OperationBinding,
+    step: &FlowStep,
+) -> BTreeSet<String> {
+    let mut consumed = BTreeSet::new();
+    // `auto_variant`: a sibling binding named `with_<p>` is selected BY the
+    // step binding `<p>` non-null, so `<p>` is read even when the selected
+    // binding's own request never names it.
+    for (_, sibling) in &set.bindings {
+        if sibling.sm_operation == binding.sm_operation
+            && let Some(param) = sibling
+                .variant
+                .as_deref()
+                .and_then(|v| v.strip_prefix("with_"))
+        {
+            consumed.insert(param.to_owned());
+        }
+    }
+    let Some(request) = &binding.request else {
+        return consumed;
+    };
+    // `build_url`: path params, declared query names, and every capture name
+    // a query template addresses (scalars are promoted by `merge_with_vars`).
+    for param in request.path.params() {
+        consumed.insert(param.to_string());
+    }
+    for (name, value) in request.query.iter().flatten() {
+        consumed.insert(name.clone());
+        for template in value.templates() {
+            template_capture_names(template, &mut consumed);
+        }
+    }
+    // `compose_headers` resolves header templates over the same merged vars.
+    for (_, template) in request.headers.iter().flatten() {
+        template_capture_names(template, &mut consumed);
+    }
+    // A `required` format header (`openehr-template-id`) takes its value from
+    // the step's own `${ds:…}` argument — the committed data set's
+    // manifest-declared template identity — so a data-set key is read there
+    // even when the request declares no body of its own.
+    let requires_template_id = binding.format_headers.iter().flatten().any(|(_, map)| {
+        map.0
+            .iter()
+            .any(|(_, req)| matches!(req, crate::model::binding::FormatHeaderReq::Required))
+    });
+    if requires_template_id {
+        for (key, value) in step.with_entries() {
+            let mut refs = BTreeSet::new();
+            value_data_set_refs(value, &mut refs);
+            if !refs.is_empty() {
+                consumed.insert(key.clone());
+            }
+        }
+    }
+    // `select_body`.
+    match &request.body {
+        None => {}
+        Some(crate::model::binding::RequestBody::Named { name, .. }) => {
+            let authored = |key: &str| step.with_entries().iter().any(|(k, _)| k == key);
+            // `select_body` resolves the payload in a fixed ORDER, and each
+            // arm short-circuits the ones after it. Modelling the order is
+            // what makes this gate sharp: once an earlier arm answers, the
+            // later arms read nothing, so a key they might have picked up is
+            // genuinely unread.
+            //
+            // 1. the bundled-CONTRIBUTION construct, when `versions:` is
+            //    authored: the envelope is built from `versions` + `audit`
+            //    (the client-supplied committal metadata) and NOTHING else.
+            if name == "contribution" && authored("versions") {
+                consumed.extend(CONTRIBUTION_KEYS.iter().map(|k| (*k).to_owned()));
+            }
+            // 2. the declared role name, then the two aliases, in that order.
+            else if let Some(hit) = std::iter::once(name.as_str())
+                .chain(BODY_ROLE_ALIASES)
+                .find(|key| authored(key))
+            {
+                consumed.insert(hit.to_owned());
+            }
+            // 3. only with none of those authored does the single-payload
+            //    scan run. It picks ONE key, but WHICH one is a runtime
+            //    property (the resolved values' JSON shapes, in the driver's
+            //    `BTreeMap` order), so every key that could be it counts —
+            //    an accusation must be certain.
+            else {
+                let text_role = name.ends_with("_text");
+                for (key, value) in step.with_entries() {
+                    if could_be_payload(value, text_role) {
+                        consumed.insert(key.clone());
+                    }
+                }
+            }
+        }
+        Some(crate::model::binding::RequestBody::Structured(template)) => {
+            value_capture_names(template, &mut consumed);
+        }
+        Some(crate::model::binding::RequestBody::Patched { from_capture, set }) => {
+            consumed.insert(from_capture.to_string());
+            for (_, value) in set {
+                if let Ok(value) = TemplatedValue::from_value(value) {
+                    value_capture_names(&value, &mut consumed);
+                }
+            }
+        }
+    }
+    consumed
+}
+
+/// No flow step authors a `with:` key its binding never reads (issue #1830).
+///
+/// A `with:` key is an ARGUMENT, and an argument the request form does not
+/// consume never leaves the runner: the SUT is driven exactly as if the key
+/// were absent. That is worse than a no-op — it makes the case ASSERT
+/// vacuously about an input it never sent. The live instance was
+/// `SEC-AUDIT_ACCOUNTABILITY-server_set_commit_audit`, whose deliberately
+/// ancient client-supplied `audit.time_committed` was dropped by the driver,
+/// so its `not_equals` assertion could not have failed however the server
+/// behaved.
+///
+/// The consumption model is [`consumed_with_keys`] — the union of every path
+/// `crate::exec::driver` reads a key by. It is deliberately GENEROUS where a
+/// path's choice is a runtime property (the single-payload body fallback),
+/// because an accusation must be certain: a key this gate names is one no
+/// request form can reach.
+///
+/// A step whose binding is `unrealized` is skipped — nothing is driven, so
+/// nothing can be vacuous; its case is not-applicable with the citation.
+fn check_step_arguments(set: &ArtifactSet, findings: &mut Vec<Finding>) {
+    for (_, case) in &set.cases {
+        let Some(anchor) = &case.sm_operation else {
+            continue;
+        };
+        let who = case.id.to_string();
+        for step in &case.flow {
+            if step.with_entries().is_empty() {
+                continue;
+            }
+            let op = if step.call.contains('.') {
+                match SmOperationRef::parse(&step.call) {
+                    Ok(op) => op,
+                    Err(_) => continue, // reported by the SM check
+                }
+            } else {
+                anchor.sibling(&step.call)
+            };
+            let mut bindings: Vec<&OperationBinding> = set
+                .bindings
+                .iter()
+                .map(|(_, b)| b)
+                .filter(|b| b.sm_operation == op)
+                .collect();
+            if let Some(v) = &step.variant
+                && bindings
+                    .iter()
+                    .any(|b| b.variant.as_deref() == Some(v.as_str()))
+            {
+                bindings.retain(|b| b.variant.as_deref() == Some(v.as_str()));
+            } else if bindings.iter().any(|b| b.variant.is_none()) {
+                bindings.retain(|b| b.variant.is_none());
+            }
+            let Some(binding) = bindings.first() else {
+                continue; // reported by binding-completeness
+            };
+            if binding.is_unrealized() {
+                continue;
+            }
+            let consumed = consumed_with_keys(set, binding, step);
+            for (key, _) in step.with_entries() {
+                if consumed.contains(key) {
+                    continue;
+                }
+                push(
+                    findings,
+                    CheckId::StepArguments,
+                    &who,
+                    format!(
+                        "step {}: `with.{key}` is authored but {} reads it on no request path \
+                         (not a path param, query parameter, header/body template reference, \
+                         payload role or variant selector) — the SUT is driven as if the key \
+                         were absent, so anything the case asserts about it passes vacuously",
+                        step.step, binding.sm_operation
+                    ),
+                );
+            }
+        }
     }
 }
 
@@ -2656,7 +3128,7 @@ fn check_vocab_drift(set: &ArtifactSet, findings: &mut Vec<Finding>) {
 /// `I_ADMIN_SERVICE` because the catalogue binds them (unrealized) as the SM
 /// Admin surface. Sub-interface navigation accessors (return type an
 /// interface — `i_ehr`, `i_party`, `i_party_relationship`) are not service
-/// operations and are excluded by [`sm_interface_operations`].
+/// operations and are excluded by `sm_interface_operations`.
 ///
 /// This table is the SM half of the Axis-1 domain only. A RELEASED ITS-REST
 /// operation the SM defines no interface for is invisible to it by
@@ -3875,6 +4347,101 @@ h|*1..1*\n\
         findings
     }
 
+    /// A workspace-shaped fixture: `docs/specs/openehr` beside the vendored
+    /// XSD bundle at `crates/openehr-its/schemas/xml`, mirroring the real
+    /// layout [`xml_schema_root`] derives.
+    fn workspace_fixture() -> assert_fs::TempDir {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let docs = dir
+            .path()
+            .join("docs/specs/openehr/ITS-XML/components/RM/Release-1.0.2");
+        let schemas = dir
+            .path()
+            .join("crates/openehr-its/schemas/xml/components/RM/Release-1.0.2/documents");
+        std::fs::create_dir_all(&docs).unwrap();
+        std::fs::create_dir_all(&schemas).unwrap();
+        // What `vendor-spec-docs.sh` actually vendors into the docs tree: the
+        // upstream README stub, no schemas.
+        std::fs::write(docs.join("README.adoc"), "= XML Schemas\n\n== Releases\n").unwrap();
+        std::fs::write(
+            schemas.join("Composition.xsd"),
+            "<xs:schema targetNamespace=\"http://schemas.openehr.org/v1\">\n\
+             <xs:element name=\"composition\" type=\"COMPOSITION\"/>\n\
+             <xs:complexType name=\"COMPOSITION\"/>\n</xs:schema>\n",
+        )
+        .unwrap();
+        dir
+    }
+
+    /// ITS-XML is the one component with TWO roots (issue #1833): the docs
+    /// tree carries only prose, the released XSDs are vendored once under
+    /// `crates/openehr-its/schemas/xml`, and a citation of an XSD element
+    /// must resolve without the bundle being duplicated into the docs tree.
+    #[test]
+    fn its_xml_citations_resolve_against_the_vendored_schema_bundle() {
+        let dir = workspace_fixture();
+        let root = dir.path().join("docs/specs/openehr");
+        let spec = SpecIndex::new(&root);
+
+        // Both roots are offered for ITS-XML, the docs tree first.
+        let roots = spec.component_roots("ITS-XML", "ITS-XML");
+        assert_eq!(roots.len(), 2, "{roots:?}");
+        // Every other component keeps exactly one.
+        assert_eq!(spec.component_roots("RM", "RM").len(), 0, "no RM docs dir");
+
+        // The docs-tree half still resolves.
+        assert!(
+            citation_findings(
+                "ITS-XML components/RM/Release-1.0.2/README.adoc §Releases",
+                &spec
+            )
+            .is_empty()
+        );
+        // The XSD half resolves — the document AND its declared element, the
+        // citation that could not be machine-resolved at all before.
+        assert!(
+            citation_findings(
+                "ITS-XML components/RM/Release-1.0.2/documents/Composition.xsd §composition",
+                &spec
+            )
+            .is_empty()
+        );
+        assert!(
+            citation_findings(
+                "ITS-XML components/RM/Release-1.0.2/documents/Composition.xsd §COMPOSITION",
+                &spec
+            )
+            .is_empty()
+        );
+        // Seeded defect: an element the schema does not declare.
+        let out = citation_findings(
+            "ITS-XML components/RM/Release-1.0.2/documents/Composition.xsd §invented_element",
+            &spec,
+        );
+        assert_eq!(out.len(), 1, "{out:?}");
+        // Seeded defect: the overlay is ITS-XML-only — the same path under
+        // another component resolves nowhere.
+        let out = citation_findings(
+            "ITS-JSON components/RM/Release-1.0.2/documents/Composition.xsd",
+            &spec,
+        );
+        assert_eq!(out.len(), 1, "{out:?}");
+    }
+
+    #[test]
+    fn xsd_declared_names_reads_every_name_attribute() {
+        let names = xsd_declared_names(
+            "<xs:element name=\"composition\" type=\"openehr:COMPOSITION\"/>\
+             <xs:complexType name='LOCATABLE'><xs:attribute name=\"archetype_node_id\"/>\
+             </xs:complexType>",
+        );
+        // Declared names only — `type=` references are not declarations.
+        assert!(names.contains("composition"), "{names:?}");
+        assert!(names.contains("locatable"), "{names:?}");
+        assert!(names.contains("archetype node id"), "{names:?}");
+        assert_eq!(names.len(), 3, "{names:?}");
+    }
+
     #[test]
     fn spec_ref_gate_resolves_documents_and_sections() {
         let dir = spec_tree_fixture();
@@ -3961,6 +4528,280 @@ h|*1..1*\n\
             &spec,
         );
         assert_eq!(findings.len(), 1, "{findings:?}");
+    }
+
+    /// A binding `extension`/`unrealized` `source` is a DERIVATION, and every
+    /// clause of it is read (issue #1832): before this gate a derivation
+    /// written `SM x.adoc … vs ITS-REST y.yaml …` was ONE clause to
+    /// [`citation_clauses`], so the ITS-REST half — and any typo in it —
+    /// never reached the resolver.
+    #[test]
+    fn binding_source_gate_reads_every_clause_of_the_derivation() {
+        let dir = spec_tree_fixture();
+        let spec = SpecIndex::new(dir.path());
+        let binding = |source: &str| -> OperationBinding {
+            serde_json::from_value(serde_json::json!({
+                "sm_operation": "I_EHR_SERVICE.create_ehr",
+                "its": "its-rest",
+                "unrealized": {
+                    "reason": "r",
+                    "source": source,
+                    "ambiguity": "AMB-1"
+                }
+            }))
+            .expect("fixture binding parses")
+        };
+        let findings = |source: &str| -> Vec<Finding> {
+            let mut out = Vec::new();
+            check_binding_sources(&binding(source), "b.yaml", &spec, &mut out);
+            out
+        };
+
+        // Normalized: one `;`-separated clause per citation, each resolving.
+        assert!(
+            findings(
+                "RM ehr_extract master04-common_package §Version Specification; \
+                 RM ehr_extract master04-common_package §EXTRACT_MANIFEST"
+            )
+            .is_empty()
+        );
+        // The spec-silence flag is the one allowed non-citation clause.
+        assert!(
+            findings(
+                "RM ehr_extract master04-common_package; \
+                 no openEHR spec governs this — our own design/extension"
+            )
+            .is_empty()
+        );
+        // Seeded defect: a separated fragment that names a document without
+        // its component. `citation_clauses` DROPS it unread, so the gate
+        // refuses the shape rather than passing it vacuously.
+        let out = findings(
+            "RM ehr_extract master04-common_package; \
+             UML/classes/org.openehr.rm.ehr_extract.extract_manifest.adoc (a gloss)",
+        );
+        assert_eq!(out.len(), 1, "{out:?}");
+        assert!(
+            out.first().expect("one finding").message.contains(
+                "opens with neither a spec component nor the spec-silence flag nor the register"
+            ),
+            "{out:?}"
+        );
+        // Seeded defect: the un-normalized `vs` form, which reads as ONE
+        // clause whose token run swallows the connective — it resolves to no
+        // document at all, so it cannot pass either.
+        let out = findings(
+            "RM ehr_extract master04-common_package vs RM ehr_extract master99-invented_package",
+        );
+        assert_eq!(out.len(), 1, "{out:?}");
+        // Seeded defect: normalized shape, phantom document in the SECOND
+        // clause — exactly what the old form hid.
+        let out = findings(
+            "RM ehr_extract master04-common_package; RM ehr_extract master99-invented_package",
+        );
+        assert_eq!(out.len(), 1, "{out:?}");
+        assert!(
+            out.first()
+                .expect("one finding")
+                .message
+                .contains("no vendored document"),
+            "{out:?}"
+        );
+    }
+
+    /// Drive one step through one binding and return the gate's findings.
+    fn step_argument_findings(
+        binding: serde_json::Value,
+        with: &serde_json::Value,
+    ) -> Vec<Finding> {
+        let binding: OperationBinding =
+            serde_json::from_value(binding).expect("fixture binding parses");
+        let case: CaseCore = serde_json::from_value(serde_json::json!({
+            "id": "T-ARG", "kind": "functional", "component": "EHR",
+            "sm_operation": "I_EHR_CONTRIBUTION.commit_contribution",
+            "test_purpose": "t", "description": "d", "spec_refs": [],
+            "capabilities": [],
+            "flow": [ {
+                "step": 1, "call": "commit_contribution",
+                "with": with, "expect": "created"
+            } ]
+        }))
+        .expect("fixture case parses");
+        let mut set = ArtifactSet::default();
+        set.bindings.push((PathBuf::from("b.yaml"), binding));
+        set.cases.push((PathBuf::from("c.yaml"), case));
+        let mut out = Vec::new();
+        check_step_arguments(&set, &mut out);
+        out
+    }
+
+    /// The bundled-CONTRIBUTION binding: a path param, a declared query
+    /// parameter, and the `contribution` body role.
+    fn contribution_binding() -> serde_json::Value {
+        serde_json::json!({
+            "sm_operation": "I_EHR_CONTRIBUTION.commit_contribution",
+            "its": "its-rest",
+            "request": {
+                "method": "POST",
+                "path": "/ehr/{ehr_id}/contribution",
+                "query": { "dry_run": "${dry_run?}" },
+                "body": "contribution"
+            },
+            "outcomes": { "created": { "status": 201 } }
+        })
+    }
+
+    /// A key every request path reads is not accused: a path param, a
+    /// declared query parameter, and the two keys the bundled-CONTRIBUTION
+    /// construct reads — `versions` and `audit`, the client-supplied
+    /// committal metadata issue #1818 wired through.
+    #[test]
+    fn step_arguments_gate_credits_every_read_key() {
+        let out = step_argument_findings(
+            contribution_binding(),
+            &serde_json::json!({
+                "ehr_id": "${ehr_id}",
+                "dry_run": "true",
+                "versions": [{ "data": "${ds:x}", "change_type": "creation" }],
+                "audit": { "committer": { "name": "Dr Example" } }
+            }),
+        );
+        assert!(out.is_empty(), "{out:?}");
+    }
+
+    /// A `with:` key the driver reads on no request path never reaches the
+    /// SUT, so anything the case asserts about it passes vacuously (issue
+    /// #1830 — the live instance was the SEC audit case's client-supplied
+    /// `audit.time_committed`, dropped for its whole life).
+    ///
+    /// The seeded defect is that very block on a binding whose body role is
+    /// NOT `contribution`: `select_body` resolves the `composition` role
+    /// directly, so the single-payload scan that might otherwise have picked
+    /// the object up never runs.
+    #[test]
+    fn step_arguments_gate_accuses_an_unread_payload_key() {
+        let out = step_argument_findings(
+            serde_json::json!({
+                "sm_operation": "I_EHR_CONTRIBUTION.commit_contribution",
+                "its": "its-rest",
+                "request": {
+                    "method": "POST",
+                    "path": "/ehr/{ehr_id}/composition",
+                    "body": "composition"
+                },
+                "outcomes": { "created": { "status": 201 } }
+            }),
+            &serde_json::json!({
+                "ehr_id": "${ehr_id}",
+                "composition": "${ds:x}",
+                "audit": { "time_committed": "1990-01-01T00:00:00Z" }
+            }),
+        );
+        assert_eq!(out.len(), 1, "{out:?}");
+        let finding = out.first().expect("one finding");
+        assert_eq!(finding.check, CheckId::StepArguments);
+        assert!(finding.message.contains("with.audit"), "{finding:?}");
+        assert!(finding.message.contains("vacuously"), "{finding:?}");
+    }
+
+    /// A key that names nothing on the wire at all.
+    #[test]
+    fn step_arguments_gate_accuses_a_key_no_form_declares() {
+        let out = step_argument_findings(
+            contribution_binding(),
+            &serde_json::json!({ "ehr_id": "${ehr_id}", "decoration": "x" }),
+        );
+        assert_eq!(out.len(), 1, "{out:?}");
+        assert!(
+            out.first()
+                .expect("one finding")
+                .message
+                .contains("with.decoration"),
+            "{out:?}"
+        );
+    }
+
+    /// A `*_text` payload role takes a plain STRING as its body, so the one
+    /// non-path string key is the payload, not decoration.
+    #[test]
+    fn step_arguments_gate_credits_a_text_role_payload() {
+        let out = step_argument_findings(
+            serde_json::json!({
+                "sm_operation": "I_EHR_CONTRIBUTION.commit_contribution",
+                "its": "its-rest",
+                "request": {
+                    "method": "PUT",
+                    "path": "/definition/query/{qualified_query_name}",
+                    "body": "aql_text"
+                },
+                "outcomes": { "created": { "status": 200 } }
+            }),
+            &serde_json::json!({
+                "qualified_query_name": "org.openehr.cnf::q",
+                "query": "SELECT c FROM EHR e CONTAINS COMPOSITION c"
+            }),
+        );
+        assert!(out.is_empty(), "{out:?}");
+    }
+
+    /// A structured body reads its `${…}` members from the step's `with:`.
+    #[test]
+    fn step_arguments_gate_credits_structured_body_members() {
+        let out = step_argument_findings(
+            serde_json::json!({
+                "sm_operation": "I_EHR_CONTRIBUTION.commit_contribution",
+                "its": "its-rest",
+                "request": {
+                    "method": "POST",
+                    "path": "/query/aql",
+                    "body": { "q": "${q}", "offset": "${offset?}" }
+                },
+                "outcomes": { "created": { "status": 200 } }
+            }),
+            &serde_json::json!({ "q": "SELECT c FROM EHR e", "offset": "0" }),
+        );
+        assert!(out.is_empty(), "{out:?}");
+    }
+
+    /// A `with_<p>` sibling binding is SELECTED BY the step binding `<p>`, so
+    /// `<p>` is read even though the variant-less binding's own request never
+    /// names it (`HttpDriver::auto_variant`).
+    #[test]
+    fn step_arguments_gate_credits_the_auto_variant_selector() {
+        let variantless: OperationBinding = serde_json::from_value(serde_json::json!({
+            "sm_operation": "I_EHR_SERVICE.create_ehr",
+            "its": "its-rest",
+            "request": { "method": "POST", "path": "/ehr" },
+            "outcomes": { "created": { "status": 201 } }
+        }))
+        .expect("fixture binding parses");
+        let with_ehr_id: OperationBinding = serde_json::from_value(serde_json::json!({
+            "sm_operation": "I_EHR_SERVICE.create_ehr",
+            "its": "its-rest",
+            "variant": "with_ehr_id",
+            "request": { "method": "PUT", "path": "/ehr/{ehr_id}" },
+            "outcomes": { "created": { "status": 201 } }
+        }))
+        .expect("fixture binding parses");
+        let case: CaseCore = serde_json::from_value(serde_json::json!({
+            "id": "T-VAR", "kind": "functional", "component": "EHR",
+            "sm_operation": "I_EHR_SERVICE.create_ehr",
+            "test_purpose": "t", "description": "d", "spec_refs": [],
+            "capabilities": [],
+            "flow": [ {
+                "step": 1, "call": "create_ehr",
+                "with": { "ehr_id": "11111111-1111-4111-8111-111111111111" },
+                "expect": "created"
+            } ]
+        }))
+        .expect("fixture case parses");
+        let mut set = ArtifactSet::default();
+        set.bindings.push((PathBuf::from("a.yaml"), variantless));
+        set.bindings.push((PathBuf::from("b.yaml"), with_ehr_id));
+        set.cases.push((PathBuf::from("c.yaml"), case));
+        let mut findings = Vec::new();
+        check_step_arguments(&set, &mut findings);
+        assert!(findings.is_empty(), "{findings:?}");
     }
 
     fn build_set(with_exception: bool) -> ArtifactSet {


### PR DESCRIPTION
The runner-sweeps batch (5 issues), plus the last three private-item doc links and the most serious rename-damage hit.

- **#1830** — the `step-arguments` gate: a case authoring a `with:` key the driver provably never reads is a validate failure (the gate mirrors `select_body`'s short-circuit order, so accusations are certain). One vacuous case re-authored; seeded proofs show the gate catches the exact pre-#1818 SEC defect class, across 4 sibling cases.
- **#1831** — rename-damage sweep over 50 external references from the rename commit, each verified against the live upstream: the upstream Java SUT's statement `identifier` restored (`urn:ehrbase:ehrbase`), two doc link texts fixed, and — found out of fence, fixed here — the **Code-of-Conduct reporting mailbox** had been rewritten to a nonexistent address at an unrelated third party; it now points at the maintainer via GitHub, inventing no email. All `scripts/vendor-*.sh` + 29 PROVENANCE files verified clean, 6 upstream repos verified live.
- **#1832** — binding `source:` citations normalized to the `spec_ref` grammar and gated (50 findings → 0); `reason` stays free-text by design (the citation/note split).
- **#1833** — ITS-XML citations machine-resolve against the vendored schema bundle as a second gate root (single source of truth kept — no schema copies); `§` on an XSD means its declared elements/types; 10 citations upgraded; seeded-defect proof.
- **#1733** (runner half, completing the issue) — the silent-drop sites propagate typed errors (a malformed selection anchor used to silently disable a whole selection law; a malformed OPT range emitted a constraint-free OPT); the guard-vs-no-guard decision recorded in reliability.md with the defect-vs-absent adjudication rule.
- **#1838** (completing) — the three cnf-runner private-item doc links fixed; the CI doc lane already carries `--document-private-items` from #1847.

Gates: fmt, clippy (-D warnings), cnf-runner 312/312, `validate --specs` 987/0, the private-items doc sweep clean. En-route findings filed separately (the stale coverage-report with no CI guard; the wildcard-on-unresolved placeholder class; the remaining `.ok()` triage inventory).

Closes #1830
Closes #1831
Closes #1832
Closes #1833
Closes #1733
Closes #1838