### PR TITLE
fix(codegen): the default facet loaded, RM monomorphizations resolve typed, ItemTag constructs validated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,14 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **A malformed ITEM_TAG refuses at construction, not after the fact.** The
+  generated `ItemTag` type gains a validated constructor running its RM
+  invariants (`Inv_key_valid`/`Inv_value_valid`), so a violating tag cannot
+  exist as a typed value anywhere in the application — the JSON and XML
+  readers refuse it at parse, path-named. Wire statuses are unchanged (the
+  tag routes' 422 mapping stays); a stored tag row that no longer constructs
+  is reported as the server fault it is instead of being served.
+
 - **A CONTRIBUTION whose audit omits `committer` is now refused (`422`)
   instead of being attributed to the server's default identity.** The same
   released commit schema that requires `change_type` requires `committer`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -401,6 +401,24 @@ workflow refuses a tag that has no matching section here.
 
 ### Changed
 
+- **An `ITEM_TAG` whose key or value violates its own RM invariants is now
+  refused when the payload is read, not after it is built.** RM
+  `UML/classes/org.openehr.rm.common.item_tag.adoc` §Invariants states
+  `Inv_key_valid` (`not key.is_empty and key.is_justified` — no leading or
+  trailing whitespace) and `Inv_value_valid` (a present value must be
+  non-empty) over `ITEM_TAG`'s own fields. Both now run at the type's
+  construction door, which the canonical-JSON and canonical-XML readers build
+  through, so an empty or whitespace-padded tag key is rejected at parse — in
+  any document position, named by its path — instead of producing a value that
+  existed in violation of its own class definition until something validated
+  it. Tag requests that already conformed are unaffected.
+- **The canonical-JSON reader honours the default values the vendored
+  meta-model states.** A `Point_interval` payload that omits
+  `lower_included`/`upper_included`/`lower_unbounded`/`upper_unbounded` now
+  reads back with the schema's own declared defaults (included, bounded),
+  matching what `Proper_interval` and `Multiplicity_interval` already did — the
+  meta-model states those four values on `Point_interval` and only there, and
+  the reader had been ignoring them.
 - **BREAKING: a structurally invalid RM request body now answers `400`, not
   `422`, and the commit audit's coded members carry their released wire
   shape.** The commit routes (COMPOSITION, `EHR_STATUS`, DIRECTORY, EHR

--- a/app/ferroehr-rest/src/overview/params.rs
+++ b/app/ferroehr-rest/src/overview/params.rs
@@ -406,9 +406,9 @@ pub(crate) fn emit_item_tag_header(entries: &[ItemTagHeaderEntry]) -> Option<Hea
 /// the typed instance.
 pub(crate) fn item_tag_to_header_entry(tag: &ItemTag) -> ItemTagHeaderEntry {
     ItemTagHeaderEntry {
-        key: tag.key.clone(),
-        value: tag.value.clone(),
-        target_path: tag.target_path.clone(),
+        key: tag.key().to_owned(),
+        value: tag.value().map(str::to_owned),
+        target_path: tag.target_path().map(str::to_owned),
     }
 }
 

--- a/app/ferroehr/src/service/demographic/tags.rs
+++ b/app/ferroehr/src/service/demographic/tags.rs
@@ -21,7 +21,7 @@ use openehr_rm::prelude::ItemTag;
 use crate::ids::VoId;
 use crate::service::FerroEhrService;
 use crate::service::demographic::types::PartyKind;
-use crate::service::ehr::tags::{normalized_target_path, tag_target_tail, validate_item_tag};
+use crate::service::ehr::tags::{item_tag_refusal, normalized_target_path, tag_target_tail};
 use crate::service::error::ServiceError;
 use crate::service::status::CallStatusType;
 use crate::storage::tag_repo;
@@ -40,7 +40,6 @@ impl FerroEhrService {
         rows.iter()
             .map(|r| party_item_tag(&sid, r))
             .collect::<Result<Vec<_>, _>>()
-            .map_err(Into::into)
     }
 
     /// The tags on one party target — the `VERSIONED_PARTY` container
@@ -67,7 +66,6 @@ impl FerroEhrService {
         rows.iter()
             .map(|r| party_item_tag(&sid, r))
             .collect::<Result<Vec<_>, _>>()
-            .map_err(Into::into)
     }
 
     /// The demographic tag-target guard, mirroring the EHR side
@@ -152,13 +150,15 @@ impl FerroEhrService {
         let mut deduped: BTreeMap<(String, Option<String>), Option<String>> = BTreeMap::new();
         for tag in tags {
             let target_path = normalized_target_path(tag.target_path.as_deref());
-            validate_item_tag(
-                &tag.key,
-                tag.value.as_deref(),
-                target_path,
+            // Construction IS the invariant check (#1839).
+            ItemTag::new(
+                tag.key.clone(),
+                tag.value.clone(),
                 target.clone(),
+                target_path.map(str::to_owned),
                 owner_id.clone(),
-            )?;
+            )
+            .map_err(|e| item_tag_refusal(&e))?;
             deduped.insert(
                 (tag.key.clone(), target_path.map(str::to_owned)),
                 tag.value.clone(),
@@ -241,14 +241,18 @@ impl FerroEhrService {
 /// # Errors
 /// [`VersionIdError`] when the configured `system_id` or the stored tag target
 /// is not a well-formed BASE identifier.
-fn party_item_tag(system_id: &str, row: &tag_repo::TagRow) -> Result<ItemTag, VersionIdError> {
-    Ok(ItemTag {
-        key: row.key.clone(),
-        value: row.value.clone(),
-        target: crate::service::ehr::tags::tag_target(row)?,
-        target_path: row.target_path.clone(),
-        owner_id: party_owner_ref(system_id)?,
-    })
+fn party_item_tag(system_id: &str, row: &tag_repo::TagRow) -> Result<ItemTag, ServiceError> {
+    // A stored row that no longer constructs is storage corruption, not a
+    // client fault — fail loud (the write path validated at commit; #1839
+    // made construction the invariant check).
+    ItemTag::new(
+        row.key.clone(),
+        row.value.clone(),
+        crate::service::ehr::tags::tag_target(row)?,
+        row.target_path.clone(),
+        party_owner_ref(system_id)?,
+    )
+    .map_err(|e| ServiceError::Internal(format!("stored ITEM_TAG row: {e}")))
 }
 
 /// The `ITEM_TAG.owner_id` of a demographic (ehr-less) tag — the `OBJECT_REF`

--- a/app/ferroehr/src/service/ehr/tags.rs
+++ b/app/ferroehr/src/service/ehr/tags.rs
@@ -20,7 +20,6 @@
 use openehr_base::prelude::{
     HierObjectId, ObjectId, ObjectRef, ObjectRefData, ObjectVersionId, UidBasedId,
 };
-use openehr_base::validate::Validate;
 use openehr_its::rest::generated::common::UpdateItemTag;
 use openehr_rm::prelude::ItemTag;
 
@@ -58,7 +57,6 @@ impl FerroEhrService {
         rows.iter()
             .map(|r| Self::stored_item_tag(ehr_id, r))
             .collect::<Result<Vec<_>, _>>()
-            .map_err(Into::into)
     }
 
     /// Tags on one target object (a COMPOSITION or `EHR_STATUS`). The caller
@@ -102,7 +100,6 @@ impl FerroEhrService {
         rows.iter()
             .map(|r| Self::stored_item_tag(ehr_id, r))
             .collect::<Result<Vec<_>, _>>()
-            .map_err(Into::into)
     }
 
     /// Replace the **whole** tag collection of a target with the posted set,
@@ -145,13 +142,16 @@ impl FerroEhrService {
             Vec::with_capacity(tags.len());
         for tag in tags {
             let target_path = normalized_target_path(tag.target_path.as_deref());
-            validate_item_tag(
-                &tag.key,
-                tag.value.as_deref(),
-                target_path,
+            // Construction IS the invariant check (#1839): a violating tag
+            // cannot exist as a typed ItemTag.
+            ItemTag::new(
+                tag.key.clone(),
+                tag.value.clone(),
                 target.clone(),
+                target_path.map(str::to_owned),
                 owner_id.clone(),
-            )?;
+            )
+            .map_err(|e| item_tag_refusal(&e))?;
             new_tags.push(crate::storage::tag_repo::NewTag {
                 target_type,
                 key: &tag.key,
@@ -291,14 +291,18 @@ impl FerroEhrService {
     fn stored_item_tag(
         ehr_id: EhrId,
         row: &crate::storage::tag_repo::TagRow,
-    ) -> Result<ItemTag, VersionIdError> {
-        Ok(ItemTag {
-            key: row.key.clone(),
-            value: row.value.clone(),
-            target: tag_target(row)?,
-            target_path: row.target_path.clone(),
-            owner_id: ehr_owner_ref(ehr_id),
-        })
+    ) -> Result<ItemTag, ServiceError> {
+        // A stored row that no longer constructs is storage corruption, not a
+        // client fault — fail loud as the 500 class (the write path validated
+        // at commit; #1839 made construction the invariant check).
+        ItemTag::new(
+            row.key.clone(),
+            row.value.clone(),
+            tag_target(row)?,
+            row.target_path.clone(),
+            ehr_owner_ref(ehr_id),
+        )
+        .map_err(|e| ServiceError::Internal(format!("stored ITEM_TAG row: {e}")))
     }
 }
 
@@ -359,45 +363,16 @@ fn ehr_owner_ref(ehr_id: EhrId) -> ObjectRef {
 pub(in crate::service) fn normalized_target_path(raw: Option<&str>) -> Option<&str> {
     raw.filter(|p| !p.is_empty())
 }
-
-/// Judge one incoming `UPDATE_ITEM_TAG` by building the `ITEM_TAG` the write
-/// would store and running the RM's own invariants over it.
-///
-/// This is the single seam both tag families go through: the RM invariants
-/// (`Inv_key_valid`, `Inv_value_valid` —
-/// `docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.common.item_tag.adoc`)
-/// are implemented exactly once, in `openehr_rm`'s `Validate` impl for
-/// `ItemTag`, and reached from here rather than restated per family. `target`
-/// and `owner_id` are the values the SERVER assigns from the route — which is
-/// why `schemas/common/UpdateItemTag.yaml` omits them from the write schema —
-/// so the instance validated is the instance stored.
-///
-/// # Errors
-/// [`ServiceError::Unprocessable`] carrying the RM invariant violations as
-/// causes (the `422` family).
-pub(in crate::service) fn validate_item_tag(
-    key: &str,
-    value: Option<&str>,
-    target_path: Option<&str>,
-    target: UidBasedId,
-    owner_id: ObjectRef,
-) -> Result<(), ServiceError> {
-    let candidate = ItemTag {
-        key: key.to_owned(),
-        value: value.map(str::to_owned),
-        target,
-        target_path: target_path.map(str::to_owned),
-        owner_id,
-    };
-    let violations = candidate.invariants();
-    if violations.is_empty() {
-        return Ok(());
-    }
-    Err(ServiceError::Unprocessable(
-        Violation::new(format!("item tag {key:?} violates its RM invariants"))
-            .with_path("ITEM_TAG")
-            .with_causes(violations),
-    ))
+/// Refuse an [`ItemTagError`] as the ITS-REST 422 shape (the same
+/// `Violation` the pre-constructor `validate_item_tag` produced): the typed
+/// constructor IS the invariant check now (#1839 — construction =
+/// validation), so the service seam only maps the refusal onto the wire.
+pub(in crate::service) fn item_tag_refusal(
+    err: &openehr_rm::common::tags::item_tag_impl::ItemTagError,
+) -> ServiceError {
+    ServiceError::Unprocessable(
+        Violation::new(format!("item tag violates its RM invariants: {err}")).with_path("ITEM_TAG"),
+    )
 }
 
 // ── The ITS-REST tags call surface ────────────────────────────────────────────

--- a/app/ferroehr/tests/it/service_demographic.rs
+++ b/app/ferroehr/tests/it/service_demographic.rs
@@ -596,7 +596,7 @@ async fn party_tags_crud() {
         .await
         .expect("put tags");
     assert_eq!(tags.len(), 1);
-    assert_eq!(tags[0].key, "priority");
+    assert_eq!(tags[0].key(), "priority");
 
     // GET tags on the party
     let got = svc

--- a/app/ferroehr/tests/it/service_ehr.rs
+++ b/app/ferroehr/tests/it/service_ehr.rs
@@ -67,7 +67,7 @@ fn uv<T: serde::de::DeserializeOwned>(
 }
 
 fn has_key(tags: &[ItemTag], k: &str) -> bool {
-    tags.iter().any(|t| t.key == k)
+    tags.iter().any(|t| t.key() == k)
 }
 
 /// A minimal *valid* RM COMPOSITION: `language`, `territory`, `category`, and
@@ -1400,16 +1400,13 @@ async fn item_tag_identity_is_the_key_and_target_path_pair() {
     let by_path = |path: &str| {
         stored
             .iter()
-            .find(|t| t.target_path.as_deref() == Some(path))
+            .find(|t| t.target_path() == Some(path))
             .unwrap_or_else(|| panic!("tag at {path}"))
             .clone()
     };
+    assert_eq!(by_path("/context/start_time/value").value(), Some("a"));
     assert_eq!(
-        by_path("/context/start_time/value").value.as_deref(),
-        Some("a")
-    );
-    assert_eq!(
-        by_path("/content[0]/name/value").value.as_deref(),
+        by_path("/content[0]/name/value").value(),
         Some("b2"),
         "same (key, path) pair: last wins"
     );
@@ -1466,11 +1463,11 @@ async fn item_tag_version_and_container_targets_are_distinct() {
     // Each collection holds ONLY its own tag (the container PUT did not wipe
     // the version's), and each target carries the RM UID_BASED_ID shape.
     assert_eq!(on_version.len(), 1);
-    let version_target = openehr_its::json::to_canonical_value(&on_version[0].target);
+    let version_target = openehr_its::json::to_canonical_value(&on_version[0].target());
     assert_eq!(version_target["_type"], "OBJECT_VERSION_ID");
     assert_eq!(version_target["value"], version_uid);
     assert_eq!(on_container.len(), 1);
-    let container_target = openehr_its::json::to_canonical_value(&on_container[0].target);
+    let container_target = openehr_its::json::to_canonical_value(&on_container[0].target());
     assert_eq!(container_target["_type"], "HIER_OBJECT_ID");
     assert_eq!(container_target["value"], vo_id);
 
@@ -1479,13 +1476,13 @@ async fn item_tag_version_and_container_targets_are_distinct() {
         .await
         .expect("version list");
     assert_eq!(version_list.len(), 1);
-    assert_eq!(version_list[0].key, "reviewed");
+    assert_eq!(version_list[0].key(), "reviewed");
     let container_list = svc
         .target_tags_get(ehr_uuid, vo_id.clone(), "COMPOSITION")
         .await
         .expect("container list");
     assert_eq!(container_list.len(), 1);
-    assert_eq!(container_list[0].key, "workflow");
+    assert_eq!(container_list[0].key(), "workflow");
 
     // A tag addressed to a NONEXISTENT version is refused.
     let ghost = format!("{vo_id}::ghost.system::9");
@@ -1698,7 +1695,7 @@ async fn item_tag_put_replaces_the_whole_collection() {
         .expect("the valid twins are stored");
     assert_eq!(accepted.len(), 2);
     assert!(
-        accepted.iter().all(|t| t.target_path.is_none()),
+        accepted.iter().all(|t| t.target_path().is_none()),
         "an empty target_path normalizes to absent, got {accepted:?}"
     );
 }

--- a/crates/openehr-am/src/json_serde.rs
+++ b/crates/openehr-am/src/json_serde.rs
@@ -13182,7 +13182,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::am24::prelude::BmmFeatureGroup {
                 ::core::result::Result::Ok(crate::am24::prelude::BmmFeatureGroup {
                     name: __s0
                         .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("name"))?,
+                        .unwrap_or(::std::string::String::from("feature")),
                     properties: __s1
                         .flatten()
                         .ok_or_else(|| ::serde::de::Error::missing_field("properties"))?,
@@ -18947,7 +18947,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::am24::prelude::BmmResult {
                 ::core::result::Result::Ok(crate::am24::prelude::BmmResult {
                     name: __s0
                         .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("name"))?,
+                        .unwrap_or(::std::string::String::from("Result")),
                     documentation: __s1.flatten(),
                     extensions: __s2.flatten(),
                     r#type: __s3
@@ -20481,7 +20481,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::am24::prelude::BmmSelf {
                 ::core::result::Result::Ok(crate::am24::prelude::BmmSelf {
                     name: __s0
                         .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("name"))?,
+                        .unwrap_or(::std::string::String::from("Self")),
                     documentation: __s1.flatten(),
                     extensions: __s2.flatten(),
                     r#type: __s3
@@ -30974,9 +30974,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::am24::prelude::ElFunctionAgent {
                     }
                 }
                 ::core::result::Result::Ok(crate::am24::prelude::ElFunctionAgent {
-                    is_writable: __s0
-                        .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("is_writable"))?,
+                    is_writable: __s0.flatten().unwrap_or(false),
                     name: __s1
                         .flatten()
                         .ok_or_else(|| ::serde::de::Error::missing_field("name"))?,
@@ -31134,9 +31132,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::am24::prelude::ElFunctionCall {
                     }
                 }
                 ::core::result::Result::Ok(crate::am24::prelude::ElFunctionCall {
-                    is_writable: __s0
-                        .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("is_writable"))?,
+                    is_writable: __s0.flatten().unwrap_or(false),
                     name: __s1
                         .flatten()
                         .ok_or_else(|| ::serde::de::Error::missing_field("name"))?,
@@ -31604,9 +31600,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::am24::prelude::ElProcedureAgent {
                     }
                 }
                 ::core::result::Result::Ok(crate::am24::prelude::ElProcedureAgent {
-                    is_writable: __s0
-                        .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("is_writable"))?,
+                    is_writable: __s0.flatten().unwrap_or(false),
                     name: __s1
                         .flatten()
                         .ok_or_else(|| ::serde::de::Error::missing_field("name"))?,
@@ -31763,9 +31757,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::am24::prelude::ElPropertyRef {
                     }
                 }
                 ::core::result::Result::Ok(crate::am24::prelude::ElPropertyRef {
-                    is_writable: __s0
-                        .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("is_writable"))?,
+                    is_writable: __s0.flatten().unwrap_or(true),
                     name: __s1
                         .flatten()
                         .ok_or_else(|| ::serde::de::Error::missing_field("name"))?,
@@ -31906,9 +31898,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::am24::prelude::ElReadonlyVariable
                     }
                 }
                 ::core::result::Result::Ok(crate::am24::prelude::ElReadonlyVariable {
-                    is_writable: __s0
-                        .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("is_writable"))?,
+                    is_writable: __s0.flatten().unwrap_or(false),
                     name: __s1
                         .flatten()
                         .ok_or_else(|| ::serde::de::Error::missing_field("name"))?,
@@ -32228,9 +32218,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::am24::prelude::ElStaticRef {
                     }
                 }
                 ::core::result::Result::Ok(crate::am24::prelude::ElStaticRef {
-                    is_writable: __s0
-                        .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("is_writable"))?,
+                    is_writable: __s0.flatten().unwrap_or(false),
                     name: __s1
                         .flatten()
                         .ok_or_else(|| ::serde::de::Error::missing_field("name"))?,
@@ -32821,9 +32809,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::am24::prelude::ElTypeRef {
                     r#type: __s2
                         .flatten()
                         .ok_or_else(|| ::serde::de::Error::missing_field("type"))?,
-                    is_mutable: __s3
-                        .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("is_mutable"))?,
+                    is_mutable: __s3.flatten().unwrap_or(false),
                 })
             }
         }
@@ -33337,9 +33323,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::am24::prelude::ElWritableVariable
                     }
                 }
                 ::core::result::Result::Ok(crate::am24::prelude::ElWritableVariable {
-                    is_writable: __s0
-                        .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("is_writable"))?,
+                    is_writable: __s0.flatten().unwrap_or(true),
                     name: __s1
                         .flatten()
                         .ok_or_else(|| ::serde::de::Error::missing_field("name"))?,

--- a/crates/openehr-base/src/base_types/identification/hier_object_id.rs
+++ b/crates/openehr-base/src/base_types/identification/hier_object_id.rs
@@ -15,14 +15,15 @@ pub struct HierObjectId {
 
 /// Read access to the `pub(crate)` fields of [`HierObjectId`].
 ///
-/// The fields are not `pub`: this class has a released **lexical form**, so
-/// construction runs a grammar and is the only door — docs/specs/openehr/BASE/docs/base_types/master05-identification_package.adoc §Syntaxes: `hier_object_id = uid_based_id`, `uid_based_id = root, [ '::', extension ]`, `root = uid`.
+/// The fields are not `pub`: the release states a **constraint over this
+/// class's own field values** (a lexical form, or a class invariant), so
+/// construction checks it and is the only door — docs/specs/openehr/BASE/docs/base_types/master05-identification_package.adoc §Syntaxes: `hier_object_id = uid_based_id`, `uid_based_id = root, [ '::', extension ]`, `root = uid`.
 ///
 /// The validating constructor lives in the hand-written `*_impl.rs` sibling
 /// (the generator never writes into it); every generated codec builds this
 /// type through that constructor.
 impl HierObjectId {
-    /// The validated `value` this identifier was constructed from.
+    /// The `value` this instance was constructed with, checked at the door.
     #[must_use]
     pub fn value(&self) -> &str {
         &self.value

--- a/crates/openehr-base/src/base_types/identification/internet_id.rs
+++ b/crates/openehr-base/src/base_types/identification/internet_id.rs
@@ -15,14 +15,15 @@ pub struct InternetId {
 
 /// Read access to the `pub(crate)` fields of [`InternetId`].
 ///
-/// The fields are not `pub`: this class has a released **lexical form**, so
-/// construction runs a grammar and is the only door — docs/specs/openehr/BASE/docs/base_types/master05-identification_package.adoc §Syntaxes: `internet_id = subdomain`, `subdomain = label | subdomain, '.', label`.
+/// The fields are not `pub`: the release states a **constraint over this
+/// class's own field values** (a lexical form, or a class invariant), so
+/// construction checks it and is the only door — docs/specs/openehr/BASE/docs/base_types/master05-identification_package.adoc §Syntaxes: `internet_id = subdomain`, `subdomain = label | subdomain, '.', label`.
 ///
 /// The validating constructor lives in the hand-written `*_impl.rs` sibling
 /// (the generator never writes into it); every generated codec builds this
 /// type through that constructor.
 impl InternetId {
-    /// The validated `value` this identifier was constructed from.
+    /// The `value` this instance was constructed with, checked at the door.
     #[must_use]
     pub fn value(&self) -> &str {
         &self.value

--- a/crates/openehr-base/src/base_types/identification/iso_oid.rs
+++ b/crates/openehr-base/src/base_types/identification/iso_oid.rs
@@ -15,14 +15,15 @@ pub struct IsoOid {
 
 /// Read access to the `pub(crate)` fields of [`IsoOid`].
 ///
-/// The fields are not `pub`: this class has a released **lexical form**, so
-/// construction runs a grammar and is the only door — docs/specs/openehr/BASE/docs/base_types/master05-identification_package.adoc §Syntaxes: `iso_oid = number, { '.', number }`.
+/// The fields are not `pub`: the release states a **constraint over this
+/// class's own field values** (a lexical form, or a class invariant), so
+/// construction checks it and is the only door — docs/specs/openehr/BASE/docs/base_types/master05-identification_package.adoc §Syntaxes: `iso_oid = number, { '.', number }`.
 ///
 /// The validating constructor lives in the hand-written `*_impl.rs` sibling
 /// (the generator never writes into it); every generated codec builds this
 /// type through that constructor.
 impl IsoOid {
-    /// The validated `value` this identifier was constructed from.
+    /// The `value` this instance was constructed with, checked at the door.
     #[must_use]
     pub fn value(&self) -> &str {
         &self.value

--- a/crates/openehr-base/src/base_types/identification/object_version_id.rs
+++ b/crates/openehr-base/src/base_types/identification/object_version_id.rs
@@ -15,14 +15,15 @@ pub struct ObjectVersionId {
 
 /// Read access to the `pub(crate)` fields of [`ObjectVersionId`].
 ///
-/// The fields are not `pub`: this class has a released **lexical form**, so
-/// construction runs a grammar and is the only door — docs/specs/openehr/BASE/docs/base_types/master05-identification_package.adoc §Syntaxes: `object_version_id = object_id, '::', creating_system_id, '::', version_tree_id` with `object_id = uid` and `creating_system_id = uid`.
+/// The fields are not `pub`: the release states a **constraint over this
+/// class's own field values** (a lexical form, or a class invariant), so
+/// construction checks it and is the only door — docs/specs/openehr/BASE/docs/base_types/master05-identification_package.adoc §Syntaxes: `object_version_id = object_id, '::', creating_system_id, '::', version_tree_id` with `object_id = uid` and `creating_system_id = uid`.
 ///
 /// The validating constructor lives in the hand-written `*_impl.rs` sibling
 /// (the generator never writes into it); every generated codec builds this
 /// type through that constructor.
 impl ObjectVersionId {
-    /// The validated `value` this identifier was constructed from.
+    /// The `value` this instance was constructed with, checked at the door.
     #[must_use]
     pub fn value(&self) -> &str {
         &self.value

--- a/crates/openehr-base/src/base_types/identification/uuid.rs
+++ b/crates/openehr-base/src/base_types/identification/uuid.rs
@@ -15,14 +15,15 @@ pub struct Uuid {
 
 /// Read access to the `pub(crate)` fields of [`Uuid`].
 ///
-/// The fields are not `pub`: this class has a released **lexical form**, so
-/// construction runs a grammar and is the only door — docs/specs/openehr/BASE/docs/base_types/master05-identification_package.adoc §Syntaxes: `uuid = hex-number, '-', hex-number, '-', hex-number, '-', hex-number, '-', hex-number`. The field carries the pinned `uuid` crate's RFC-4122 type (the settled strong-typing override), so parsing IS validation and the constructor is total — but the door is still the only way in, so the value can never be replaced by an unparsed one after the fact.
+/// The fields are not `pub`: the release states a **constraint over this
+/// class's own field values** (a lexical form, or a class invariant), so
+/// construction checks it and is the only door — docs/specs/openehr/BASE/docs/base_types/master05-identification_package.adoc §Syntaxes: `uuid = hex-number, '-', hex-number, '-', hex-number, '-', hex-number, '-', hex-number`. The field carries the pinned `uuid` crate's RFC-4122 type (the settled strong-typing override), so parsing IS validation and the constructor is total — but the door is still the only way in, so the value can never be replaced by an unparsed one after the fact.
 ///
 /// The validating constructor lives in the hand-written `*_impl.rs` sibling
 /// (the generator never writes into it); every generated codec builds this
 /// type through that constructor.
 impl Uuid {
-    /// The validated `value` this identifier was constructed from.
+    /// The `value` this instance was constructed with, checked at the door.
     #[must_use]
     pub fn value(&self) -> &uuid::Uuid {
         &self.value

--- a/crates/openehr-base/src/base_types/identification/version_tree_id.rs
+++ b/crates/openehr-base/src/base_types/identification/version_tree_id.rs
@@ -16,14 +16,15 @@ pub struct VersionTreeId {
 
 /// Read access to the `pub(crate)` fields of [`VersionTreeId`].
 ///
-/// The fields are not `pub`: this class has a released **lexical form**, so
-/// construction runs a grammar and is the only door — docs/specs/openehr/BASE/docs/base_types/master05-identification_package.adoc §Syntaxes: `version_tree_id = trunk_version, [ '.', branch_number, '.', branch_version ]`, each part a `number`; RM common master06-change_control_package.adoc §“The 'Virtual Version Tree'” starts every part at 1 (`VERSION_TREE_ID.Trunk_version_valid` / `.Branch_validity`).
+/// The fields are not `pub`: the release states a **constraint over this
+/// class's own field values** (a lexical form, or a class invariant), so
+/// construction checks it and is the only door — docs/specs/openehr/BASE/docs/base_types/master05-identification_package.adoc §Syntaxes: `version_tree_id = trunk_version, [ '.', branch_number, '.', branch_version ]`, each part a `number`; RM common master06-change_control_package.adoc §“The 'Virtual Version Tree'” starts every part at 1 (`VERSION_TREE_ID.Trunk_version_valid` / `.Branch_validity`).
 ///
 /// The validating constructor lives in the hand-written `*_impl.rs` sibling
 /// (the generator never writes into it); every generated codec builds this
 /// type through that constructor.
 impl VersionTreeId {
-    /// The validated `value` this identifier was constructed from.
+    /// The `value` this instance was constructed with, checked at the door.
     #[must_use]
     pub fn value(&self) -> &str {
         &self.value

--- a/crates/openehr-base/src/json_serde.rs
+++ b/crates/openehr-base/src/json_serde.rs
@@ -3013,18 +3013,10 @@ impl<'de, T: ::serde::de::DeserializeOwned> ::serde::Deserialize<'de>
                 ::core::result::Result::Ok(crate::prelude::PointInterval {
                     lower: __s0.flatten(),
                     upper: __s1.flatten(),
-                    lower_unbounded: __s2
-                        .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("lower_unbounded"))?,
-                    upper_unbounded: __s3
-                        .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("upper_unbounded"))?,
-                    lower_included: __s4
-                        .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("lower_included"))?,
-                    upper_included: __s5
-                        .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("upper_included"))?,
+                    lower_unbounded: __s2.flatten().unwrap_or(false),
+                    upper_unbounded: __s3.flatten().unwrap_or(false),
+                    lower_included: __s4.flatten().unwrap_or(true),
+                    upper_included: __s5.flatten().unwrap_or(true),
                 })
             }
         }

--- a/crates/openehr-its/src/rest/generated/common.rs
+++ b/crates/openehr-its/src/rest/generated/common.rs
@@ -25,32 +25,6 @@ pub struct Error {
     pub validation_errors: Vec<String>,
 }
 
-/// The `Clstr` transport DTO of this API group (an ITS-REST OAS
-/// component schema).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Clstr {
-    /// The `_type` property of `Clstr`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub _type: Option<String>,
-    /// The `items` property of `Clstr`.
-    pub items: Vec<openehr_rm::prelude::Item>,
-}
-
-/// The `DvIntervalOfDateTime` transport DTO of this API group (an ITS-REST OAS
-/// component schema).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DvIntervalOfDateTime {
-    /// The `_type` property of `DvIntervalOfDateTime`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub _type: Option<String>,
-    /// The `lower` property of `DvIntervalOfDateTime`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub lower: Option<openehr_rm::prelude::DvDateTime>,
-    /// The `upper` property of `DvIntervalOfDateTime`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub upper: Option<openehr_rm::prelude::DvDateTime>,
-}
-
 /// The `AbstractEntry` ITS-REST OAS component schema: `_type`-discriminated
 /// polymorphism over its OAS `discriminator.mapping` targets.
 #[derive(Debug, Clone)]
@@ -172,21 +146,6 @@ impl<'de> ::serde::Deserialize<'de> for AbstractEntry {
 /// it is an alias rather than a struct).
 pub type ListOfPartyIdentity = Vec<openehr_rm::prelude::PartyIdentity>;
 
-/// The `DvIntervalOfDate` transport DTO of this API group (an ITS-REST OAS
-/// component schema).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DvIntervalOfDate {
-    /// The `_type` property of `DvIntervalOfDate`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub _type: Option<String>,
-    /// The `lower` property of `DvIntervalOfDate`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub lower: Option<openehr_rm::prelude::DvDate>,
-    /// The `upper` property of `DvIntervalOfDate`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub upper: Option<openehr_rm::prelude::DvDate>,
-}
-
 /// The `ListOfContact` ITS-REST OAS component schema (a non-object shape, so
 /// it is an alias rather than a struct).
 pub type ListOfContact = Vec<openehr_rm::prelude::Contact>;
@@ -231,15 +190,6 @@ pub struct UpdateItemTag {
 pub struct Identifier {
     /// The `uid` property of `Identifier`.
     pub uid: String,
-}
-
-/// The `ObjectRefOfHierObjectId` transport DTO of this API group (an ITS-REST OAS
-/// component schema).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ObjectRefOfHierObjectId {
-    /// The `id` property of `ObjectRefOfHierObjectId`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub id: Option<openehr_base::prelude::HierObjectId>,
 }
 
 /// The `UpdateAudit` transport DTO of this API group (an ITS-REST OAS
@@ -397,13 +347,4 @@ pub struct UpdateVersion<T> {
     pub data: T,
     /// The `commit_audit` property of `UpdateVersion`.
     pub commit_audit: UpdateAudit,
-}
-
-/// The `ObjectRefOfObjectVersionId` transport DTO of this API group (an ITS-REST OAS
-/// component schema).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ObjectRefOfObjectVersionId {
-    /// The `id` property of `ObjectRefOfObjectVersionId`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub id: Option<openehr_base::prelude::ObjectVersionId>,
 }

--- a/crates/openehr-its/src/rest/generated/demographic.rs
+++ b/crates/openehr-its/src/rest/generated/demographic.rs
@@ -20,7 +20,7 @@ pub struct VersionOfParty {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub _type: Option<String>,
     /// The `contribution` property of `VersionOfParty`.
-    pub contribution: super::common::ObjectRefOfHierObjectId,
+    pub contribution: openehr_base::prelude::ObjectRef,
     /// The `signature` property of `VersionOfParty`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signature: Option<String>,

--- a/crates/openehr-its/src/rest/generated/ehr.rs
+++ b/crates/openehr-its/src/rest/generated/ehr.rs
@@ -20,7 +20,7 @@ pub struct VersionOfComposition {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub _type: Option<String>,
     /// The `contribution` property of `VersionOfComposition`.
-    pub contribution: super::common::ObjectRefOfHierObjectId,
+    pub contribution: openehr_base::prelude::ObjectRef,
     /// The `signature` property of `VersionOfComposition`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signature: Option<String>,
@@ -38,7 +38,7 @@ pub struct VersionOfEhrStatus {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub _type: Option<String>,
     /// The `contribution` property of `VersionOfEhrStatus`.
-    pub contribution: super::common::ObjectRefOfHierObjectId,
+    pub contribution: openehr_base::prelude::ObjectRef,
     /// The `signature` property of `VersionOfEhrStatus`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signature: Option<String>,

--- a/crates/openehr-its/src/xml/generated/impls.rs
+++ b/crates/openehr-its/src/xml/generated/impls.rs
@@ -1620,18 +1620,10 @@ impl<T: crate::xml::runtime::FromXml> crate::xml::runtime::FromXml
         Ok(openehr_base::prelude::PointInterval {
             lower: __lower,
             upper: __upper,
-            lower_unbounded: __lower_unbounded.ok_or_else(|| {
-                crate::xml::runtime::XmlError::Parse("missing element lower_unbounded".into())
-            })?,
-            upper_unbounded: __upper_unbounded.ok_or_else(|| {
-                crate::xml::runtime::XmlError::Parse("missing element upper_unbounded".into())
-            })?,
-            lower_included: __lower_included.ok_or_else(|| {
-                crate::xml::runtime::XmlError::Parse("missing element lower_included".into())
-            })?,
-            upper_included: __upper_included.ok_or_else(|| {
-                crate::xml::runtime::XmlError::Parse("missing element upper_included".into())
-            })?,
+            lower_unbounded: __lower_unbounded.unwrap_or(false),
+            upper_unbounded: __upper_unbounded.unwrap_or(false),
+            lower_included: __lower_included.unwrap_or(true),
+            upper_included: __upper_included.unwrap_or(true),
         })
     }
 }
@@ -12620,15 +12612,16 @@ impl crate::xml::runtime::ToXml for openehr_rm::prelude::ItemTag {
             __e.push_attribute((*k, v.as_str()));
         }
         w.write_start(__e)?;
-        self.key.write_xml(w, "key", Some("String"))?;
-        if let Some(v) = &self.value {
+        self.key().write_xml(w, "key", Some("String"))?;
+        if let Some(v) = &self.value() {
             v.write_xml(w, "value", Some("String"))?;
         }
-        self.target.write_xml(w, "target", Some("UID_BASED_ID"))?;
-        if let Some(v) = &self.target_path {
+        self.target().write_xml(w, "target", Some("UID_BASED_ID"))?;
+        if let Some(v) = &self.target_path() {
             v.write_xml(w, "target_path", Some("String"))?;
         }
-        self.owner_id.write_xml(w, "owner_id", Some("OBJECT_REF"))?;
+        self.owner_id()
+            .write_xml(w, "owner_id", Some("OBJECT_REF"))?;
         w.write_end(tag)?;
         Ok(())
     }
@@ -12673,18 +12666,17 @@ impl crate::xml::runtime::FromXml for openehr_rm::prelude::ItemTag {
                 }
             }
         }
-        Ok(openehr_rm::prelude::ItemTag {
-            key: __key.ok_or_else(|| {
-                crate::xml::runtime::XmlError::Parse("missing element key".into())
-            })?,
-            value: __value,
-            target: __target.ok_or_else(|| {
-                crate::xml::runtime::XmlError::Parse("missing element target".into())
-            })?,
-            target_path: __target_path,
-            owner_id: __owner_id.ok_or_else(|| {
-                crate::xml::runtime::XmlError::Parse("missing element owner_id".into())
-            })?,
+        let __a0: String = __key
+            .ok_or_else(|| crate::xml::runtime::XmlError::Parse("missing element key".into()))?;
+        let __a1: Option<String> = __value;
+        let __a2: openehr_base::prelude::UidBasedId = __target
+            .ok_or_else(|| crate::xml::runtime::XmlError::Parse("missing element target".into()))?;
+        let __a3: Option<String> = __target_path;
+        let __a4: openehr_base::prelude::ObjectRef = __owner_id.ok_or_else(|| {
+            crate::xml::runtime::XmlError::Parse("missing element owner_id".into())
+        })?;
+        openehr_rm::prelude::ItemTag::new(__a0, __a1, __a2, __a3, __a4).map_err(|__e| {
+            crate::xml::runtime::XmlError::Parse(::std::format!("ITEM_TAG: {__e}").into())
         })
     }
 }

--- a/crates/openehr-its/tests/it/model_walkgen_register.txt
+++ b/crates/openehr-its/tests/it/model_walkgen_register.txt
@@ -12,14 +12,25 @@
 #
 # What remains is NOT a reach gap: the `Interval` inclusivity/boundedness
 # flags are mandatory in the BMM, but the codec fills them from a literal
-# default on read (the emitter's `plan::overrides::FIELD_DEFAULTS` entries:
-# "a bounded interval limit is included by default", "an unstated interval
-# limit is bounded by default" — BASE foundation_types (Interval) for the
-# semantics; no openEHR spec governs the wire omission, it is the
-# archie/EHRbase interop convention, our own design). A defaulted field cannot
-# fail to decode: the omission IS the documented wire form, so refusing it
-# would contradict the codec's own contract. (They are also exempted from the
-# mandatory-container check by shape: they are scalars, not containers.)
+# default on read. A defaulted field cannot fail to decode: the omission IS the
+# documented wire form, so refusing it would contradict the codec's own
+# contract. (They are also exempted from the mandatory-container check by
+# shape: they are scalars, not containers.)
+#
+# The default itself is VENDORED, not invented: the BASE 1.3.0 schema states
+# `default = <False>` on `lower_unbounded`/`upper_unbounded` and
+# `default = <True>` on `lower_included`/`upper_included` — on `Point_interval`,
+# the one Interval descendant that redeclares the four properties. The emitter
+# reads the facet there and propagates the identical values to the inherited
+# sites through `plan::overrides::FIELD_DEFAULTS` ("a bounded interval limit is
+# included by default", "an unstated interval limit is bounded by default"; the
+# WIRE omission itself is governed by no openEHR spec — it is the
+# archie/EHRbase interop convention, our own design).
+#
+# The four `Point_interval` rows are the schema's OWN statement of the default
+# and joined this register when the loader stopped dropping the `default` facet:
+# they were the one place the vendored input states the rule and the only place
+# the reader was not applying it.
 DV_INTERVAL.lower_included
 DV_INTERVAL.lower_unbounded
 DV_INTERVAL.upper_included
@@ -28,6 +39,10 @@ Multiplicity_interval.lower_included
 Multiplicity_interval.lower_unbounded
 Multiplicity_interval.upper_included
 Multiplicity_interval.upper_unbounded
+Point_interval.lower_included
+Point_interval.lower_unbounded
+Point_interval.upper_included
+Point_interval.upper_unbounded
 Proper_interval.lower_included
 Proper_interval.lower_unbounded
 Proper_interval.upper_included

--- a/crates/openehr-lang/src/json_serde.rs
+++ b/crates/openehr-lang/src/json_serde.rs
@@ -2279,9 +2279,9 @@ impl<'de> ::serde::Deserialize<'de>
                             .ok_or_else(|| ::serde::de::Error::missing_field("is_override"))?,
                         item_names: __s10,
                         item_values: __s11,
-                        underlying_type_name: __s12.flatten().ok_or_else(|| {
-                            ::serde::de::Error::missing_field("underlying_type_name")
-                        })?,
+                        underlying_type_name: __s12
+                            .flatten()
+                            .unwrap_or(::std::string::String::from("INTEGER")),
                     },
                 )
             }
@@ -2643,9 +2643,9 @@ impl<'de> ::serde::Deserialize<'de>
                             .ok_or_else(|| ::serde::de::Error::missing_field("is_override"))?,
                         item_names: __s10,
                         item_values: __s11,
-                        underlying_type_name: __s12.flatten().ok_or_else(|| {
-                            ::serde::de::Error::missing_field("underlying_type_name")
-                        })?,
+                        underlying_type_name: __s12
+                            .flatten()
+                            .unwrap_or(::std::string::String::from("STRING")),
                     },
                 )
             }
@@ -15614,7 +15614,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::prelude::TypeDefBoolean {
                 ::core::result::Result::Ok(crate::prelude::TypeDefBoolean {
                     type_name: __s0
                         .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("type_name"))?,
+                        .unwrap_or(::std::string::String::from("Boolean")),
                     type_anchor: __s1
                         .flatten()
                         .ok_or_else(|| ::serde::de::Error::missing_field("type_anchor"))?,
@@ -15740,7 +15740,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::prelude::TypeDefDate {
                 ::core::result::Result::Ok(crate::prelude::TypeDefDate {
                     type_name: __s0
                         .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("type_name"))?,
+                        .unwrap_or(::std::string::String::from("Date")),
                     type_anchor: __s1
                         .flatten()
                         .ok_or_else(|| ::serde::de::Error::missing_field("type_anchor"))?,
@@ -15867,7 +15867,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::prelude::TypeDefDateTime {
                 ::core::result::Result::Ok(crate::prelude::TypeDefDateTime {
                     type_name: __s0
                         .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("type_name"))?,
+                        .unwrap_or(::std::string::String::from("Date_time")),
                     type_anchor: __s1
                         .flatten()
                         .ok_or_else(|| ::serde::de::Error::missing_field("type_anchor"))?,
@@ -15994,7 +15994,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::prelude::TypeDefDuration {
                 ::core::result::Result::Ok(crate::prelude::TypeDefDuration {
                     type_name: __s0
                         .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("type_name"))?,
+                        .unwrap_or(::std::string::String::from("Duration")),
                     type_anchor: __s1
                         .flatten()
                         .ok_or_else(|| ::serde::de::Error::missing_field("type_anchor"))?,
@@ -16121,7 +16121,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::prelude::TypeDefInteger {
                 ::core::result::Result::Ok(crate::prelude::TypeDefInteger {
                     type_name: __s0
                         .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("type_name"))?,
+                        .unwrap_or(::std::string::String::from("Integer")),
                     type_anchor: __s1
                         .flatten()
                         .ok_or_else(|| ::serde::de::Error::missing_field("type_anchor"))?,
@@ -16248,7 +16248,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::prelude::TypeDefObjectRef {
                 ::core::result::Result::Ok(crate::prelude::TypeDefObjectRef {
                     type_name: __s0
                         .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("type_name"))?,
+                        .unwrap_or(::std::string::String::from("Object_ref")),
                     type_anchor: __s1
                         .flatten()
                         .ok_or_else(|| ::serde::de::Error::missing_field("type_anchor"))?,
@@ -16374,7 +16374,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::prelude::TypeDefReal {
                 ::core::result::Result::Ok(crate::prelude::TypeDefReal {
                     type_name: __s0
                         .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("type_name"))?,
+                        .unwrap_or(::std::string::String::from("Real")),
                     type_anchor: __s1
                         .flatten()
                         .ok_or_else(|| ::serde::de::Error::missing_field("type_anchor"))?,
@@ -16500,7 +16500,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::prelude::TypeDefString {
                 ::core::result::Result::Ok(crate::prelude::TypeDefString {
                     type_name: __s0
                         .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("type_name"))?,
+                        .unwrap_or(::std::string::String::from("String")),
                     type_anchor: __s1
                         .flatten()
                         .ok_or_else(|| ::serde::de::Error::missing_field("type_anchor"))?,
@@ -16633,7 +16633,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::prelude::TypeDefTerminologyCode {
                 ::core::result::Result::Ok(crate::prelude::TypeDefTerminologyCode {
                     type_name: __s0
                         .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("type_name"))?,
+                        .unwrap_or(::std::string::String::from("Terminology_code")),
                     type_anchor: __s1
                         .flatten()
                         .ok_or_else(|| ::serde::de::Error::missing_field("type_anchor"))?,
@@ -16759,7 +16759,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::prelude::TypeDefTime {
                 ::core::result::Result::Ok(crate::prelude::TypeDefTime {
                     type_name: __s0
                         .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("type_name"))?,
+                        .unwrap_or(::std::string::String::from("Time")),
                     type_anchor: __s1
                         .flatten()
                         .ok_or_else(|| ::serde::de::Error::missing_field("type_anchor"))?,
@@ -16883,9 +16883,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::prelude::TypeDefUri {
                     }
                 }
                 ::core::result::Result::Ok(crate::prelude::TypeDefUri {
-                    type_name: __s0
-                        .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("type_name"))?,
+                    type_name: __s0.flatten().unwrap_or(::std::string::String::from("Uri")),
                     type_anchor: __s1
                         .flatten()
                         .ok_or_else(|| ::serde::de::Error::missing_field("type_anchor"))?,
@@ -21468,7 +21466,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::prelude::BmmFeatureGroup {
                 ::core::result::Result::Ok(crate::prelude::BmmFeatureGroup {
                     name: __s0
                         .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("name"))?,
+                        .unwrap_or(::std::string::String::from("feature")),
                     properties: __s1
                         .flatten()
                         .ok_or_else(|| ::serde::de::Error::missing_field("properties"))?,
@@ -27557,7 +27555,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::prelude::BmmResult {
                 ::core::result::Result::Ok(crate::prelude::BmmResult {
                     name: __s0
                         .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("name"))?,
+                        .unwrap_or(::std::string::String::from("Result")),
                     documentation: __s1.flatten(),
                     extensions: __s2.flatten(),
                     r#type: __s3
@@ -28702,7 +28700,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::prelude::BmmSelf {
                 ::core::result::Result::Ok(crate::prelude::BmmSelf {
                     name: __s0
                         .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("name"))?,
+                        .unwrap_or(::std::string::String::from("Self")),
                     documentation: __s1.flatten(),
                     extensions: __s2.flatten(),
                     r#type: __s3
@@ -33816,9 +33814,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::prelude::ElFunctionAgent {
                     }
                 }
                 ::core::result::Result::Ok(crate::prelude::ElFunctionAgent {
-                    is_writable: __s0
-                        .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("is_writable"))?,
+                    is_writable: __s0.flatten().unwrap_or(false),
                     name: __s1
                         .flatten()
                         .ok_or_else(|| ::serde::de::Error::missing_field("name"))?,
@@ -33976,9 +33972,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::prelude::ElFunctionCall {
                     }
                 }
                 ::core::result::Result::Ok(crate::prelude::ElFunctionCall {
-                    is_writable: __s0
-                        .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("is_writable"))?,
+                    is_writable: __s0.flatten().unwrap_or(false),
                     name: __s1
                         .flatten()
                         .ok_or_else(|| ::serde::de::Error::missing_field("name"))?,
@@ -34446,9 +34440,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::prelude::ElProcedureAgent {
                     }
                 }
                 ::core::result::Result::Ok(crate::prelude::ElProcedureAgent {
-                    is_writable: __s0
-                        .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("is_writable"))?,
+                    is_writable: __s0.flatten().unwrap_or(false),
                     name: __s1
                         .flatten()
                         .ok_or_else(|| ::serde::de::Error::missing_field("name"))?,
@@ -34605,9 +34597,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::prelude::ElPropertyRef {
                     }
                 }
                 ::core::result::Result::Ok(crate::prelude::ElPropertyRef {
-                    is_writable: __s0
-                        .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("is_writable"))?,
+                    is_writable: __s0.flatten().unwrap_or(true),
                     name: __s1
                         .flatten()
                         .ok_or_else(|| ::serde::de::Error::missing_field("name"))?,
@@ -34748,9 +34738,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::prelude::ElReadonlyVariable {
                     }
                 }
                 ::core::result::Result::Ok(crate::prelude::ElReadonlyVariable {
-                    is_writable: __s0
-                        .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("is_writable"))?,
+                    is_writable: __s0.flatten().unwrap_or(false),
                     name: __s1
                         .flatten()
                         .ok_or_else(|| ::serde::de::Error::missing_field("name"))?,
@@ -35070,9 +35058,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::prelude::ElStaticRef {
                     }
                 }
                 ::core::result::Result::Ok(crate::prelude::ElStaticRef {
-                    is_writable: __s0
-                        .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("is_writable"))?,
+                    is_writable: __s0.flatten().unwrap_or(false),
                     name: __s1
                         .flatten()
                         .ok_or_else(|| ::serde::de::Error::missing_field("name"))?,
@@ -35663,9 +35649,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::prelude::ElTypeRef {
                     r#type: __s2
                         .flatten()
                         .ok_or_else(|| ::serde::de::Error::missing_field("type"))?,
-                    is_mutable: __s3
-                        .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("is_mutable"))?,
+                    is_mutable: __s3.flatten().unwrap_or(false),
                 })
             }
         }
@@ -36179,9 +36163,7 @@ impl<'de> ::serde::Deserialize<'de> for crate::prelude::ElWritableVariable {
                     }
                 }
                 ::core::result::Result::Ok(crate::prelude::ElWritableVariable {
-                    is_writable: __s0
-                        .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("is_writable"))?,
+                    is_writable: __s0.flatten().unwrap_or(true),
                     name: __s1
                         .flatten()
                         .ok_or_else(|| ::serde::de::Error::missing_field("name"))?,

--- a/crates/openehr-rm/src/common/tags/item_tag.rs
+++ b/crates/openehr-rm/src/common/tags/item_tag.rs
@@ -12,13 +12,54 @@ use openehr_base::prelude::UidBasedId;
 #[derive(Debug, Clone, PartialEq)]
 pub struct ItemTag {
     /// The tag key. May not be empty or contain leading or trailing whitespace.
-    pub key: String,
+    pub(crate) key: String,
     /// The value. If set, may not be empty.
-    pub value: Option<String>,
+    pub(crate) value: Option<String>,
     /// Identifier of target, which may be a `VERSIONED_OBJECT<T>` or a `VERSION<T>`.
-    pub target: UidBasedId,
+    pub(crate) target: UidBasedId,
     /// Optional archetype (i.e. AQL) or RM path within `_target_`, used to tag a fine-grained element.
-    pub target_path: Option<String>,
+    pub(crate) target_path: Option<String>,
     /// Identifier of owner object, such as EHR.
-    pub owner_id: ObjectRef,
+    pub(crate) owner_id: ObjectRef,
+}
+
+/// Read access to the `pub(crate)` fields of [`ItemTag`].
+///
+/// The fields are not `pub`: the release states a **constraint over this
+/// class's own field values** (a lexical form, or a class invariant), so
+/// construction checks it and is the only door — docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.common.item_tag.adoc §Invariants: `Inv_key_valid: not key.is_empty and key.is_justified` and `Inv_value_valid: value /= Void implies not value.is_empty`. Both are stated over ITEM_TAG's own fields and decidable from them alone, so an instance violating either is not an instance of the class — the same standing the §Syntaxes grammar has for an identifier. The remaining checks an ITEM_TAG needs (does `target` exist, does `target_path` resolve within it) read state the instance does NOT carry and stay in the service layer.
+///
+/// The validating constructor lives in the hand-written `*_impl.rs` sibling
+/// (the generator never writes into it); every generated codec builds this
+/// type through that constructor.
+impl ItemTag {
+    /// The `key` this instance was constructed with, checked at the door.
+    #[must_use]
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+
+    /// The `value` this instance was constructed with, checked at the door.
+    #[must_use]
+    pub fn value(&self) -> Option<&str> {
+        self.value.as_deref()
+    }
+
+    /// The `target` this instance was constructed with, checked at the door.
+    #[must_use]
+    pub fn target(&self) -> &UidBasedId {
+        &self.target
+    }
+
+    /// The `target_path` this instance was constructed with, checked at the door.
+    #[must_use]
+    pub fn target_path(&self) -> Option<&str> {
+        self.target_path.as_deref()
+    }
+
+    /// The `owner_id` this instance was constructed with, checked at the door.
+    #[must_use]
+    pub fn owner_id(&self) -> &ObjectRef {
+        &self.owner_id
+    }
 }

--- a/crates/openehr-rm/src/common/tags/item_tag_impl.rs
+++ b/crates/openehr-rm/src/common/tags/item_tag_impl.rs
@@ -1,13 +1,75 @@
-//! Hand-written RM class invariants for `ITEM_TAG`.
+//! Hand-written validating construction + RM class invariants for `ITEM_TAG`.
 //!
 //! Spec: RM 1.2.0
 //! `docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.common.item_tag.adoc`:
 //! - `Inv_key_valid`: `not key.is_empty and key.is_justified` (no leading or
 //!   trailing whitespace).
 //! - `Inv_value_valid`: `value /= Void implies not value.is_empty`.
+//!
+//! Both invariants are stated over `ITEM_TAG`'s OWN fields and are decidable
+//! from them alone, so they are enforced at the construction door: the generated
+//! struct's fields are `pub(crate)` (the emitter's construction-door scheme,
+//! `plan::construction`), and [`ItemTag::new`] is the only way to obtain the
+//! type outside `openehr-rm`. The canonical-JSON and canonical-XML readers build
+//! through the same door, so a violating payload refuses at PARSE, path-named,
+//! in every document position — an `ITEM_TAG` can no longer exist in violation
+//! of its own invariants.
+//!
+//! What stays OUTSIDE the door: whether `target` names an existing versioned
+//! object and whether `target_path` resolves inside it. Those read state the
+//! instance does not carry, so they remain service-layer checks.
 
 use crate::common::tags::item_tag::ItemTag;
+use openehr_base::prelude::{ObjectRef, UidBasedId};
 use openehr_base::validate::{InvariantViolation, Validate};
+
+/// Why an [`ItemTag`] could not be constructed — one variant per released
+/// invariant, so a caller branches on the failure instead of matching prose.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ItemTagError {
+    /// `Inv_key_valid` failed: the key was empty, or carried leading/trailing
+    /// whitespace (RM `org.openehr.rm.common.item_tag.adoc` §Invariants).
+    #[error("Inv_key_valid: key {0:?} must be non-empty and free of leading/trailing whitespace")]
+    KeyInvalid(String),
+    /// `Inv_value_valid` failed: the value was present and empty (RM
+    /// `org.openehr.rm.common.item_tag.adoc` §Invariants).
+    #[error("Inv_value_valid: a present value must be non-empty")]
+    ValueEmpty,
+}
+
+impl ItemTag {
+    /// Build an `ITEM_TAG`, checking the two released §Invariants over its own
+    /// fields.
+    ///
+    /// This is THE door: the generated fields are `pub(crate)`, so outside
+    /// `openehr-rm` no other construction exists, and the generated codecs route
+    /// through here.
+    ///
+    /// # Errors
+    /// [`ItemTagError::KeyInvalid`] when `key` violates `Inv_key_valid`, and
+    /// [`ItemTagError::ValueEmpty`] when `value` violates `Inv_value_valid`.
+    pub fn new(
+        key: String,
+        value: Option<String>,
+        target: UidBasedId,
+        target_path: Option<String>,
+        owner_id: ObjectRef,
+    ) -> Result<Self, ItemTagError> {
+        if !Self::key_valid(&key) {
+            return Err(ItemTagError::KeyInvalid(key));
+        }
+        if !Self::value_valid(value.as_deref()) {
+            return Err(ItemTagError::ValueEmpty);
+        }
+        Ok(Self {
+            key,
+            value,
+            target,
+            target_path,
+            owner_id,
+        })
+    }
+}
 
 impl ItemTag {
     /// `Inv_key_valid` as a predicate on a candidate key: `not key.is_empty and
@@ -76,6 +138,62 @@ mod tests {
                 ),
             }),
         }
+    }
+
+    /// The door REFUSES what `Inv_key_valid` forbids, so an `ITEM_TAG` in
+    /// violation of it cannot be constructed at all — the structural half of
+    /// the `key_must_be_non_empty_and_justified` validation test below.
+    #[test]
+    fn the_door_refuses_an_invalid_key() {
+        let t = tag("ok", None);
+        for bad in ["", " padded", "padded ", " both "] {
+            assert_eq!(
+                ItemTag::new(
+                    bad.to_owned(),
+                    None,
+                    t.target.clone(),
+                    None,
+                    t.owner_id.clone(),
+                ),
+                Err(ItemTagError::KeyInvalid(bad.to_owned())),
+                "key {bad:?} must be refused at construction"
+            );
+        }
+    }
+
+    /// The door REFUSES what `Inv_value_valid` forbids.
+    #[test]
+    fn the_door_refuses_a_present_empty_value() {
+        let t = tag("ok", None);
+        assert_eq!(
+            ItemTag::new(
+                "k".to_owned(),
+                Some(String::new()),
+                t.target.clone(),
+                None,
+                t.owner_id.clone(),
+            ),
+            Err(ItemTagError::ValueEmpty),
+        );
+    }
+
+    /// A conforming tag passes the door and reads back exactly what went in.
+    #[test]
+    fn the_door_admits_a_conforming_tag() {
+        let t = tag("ok", None);
+        let built = ItemTag::new(
+            "severity".to_owned(),
+            Some("high".to_owned()),
+            t.target.clone(),
+            Some("/content[0]".to_owned()),
+            t.owner_id.clone(),
+        )
+        .expect("a conforming ITEM_TAG should construct");
+        assert_eq!(built.key(), "severity");
+        assert_eq!(built.value(), Some("high"));
+        assert_eq!(built.target_path(), Some("/content[0]"));
+        assert_eq!(built.target(), &t.target);
+        assert_eq!(built.owner_id(), &t.owner_id);
     }
 
     #[test]

--- a/crates/openehr-rm/src/json_serde.rs
+++ b/crates/openehr-rm/src/json_serde.rs
@@ -18754,19 +18754,19 @@ impl<'de> ::serde::Deserialize<'de> for crate::prelude::ItemTag {
                         }
                     }
                 }
-                ::core::result::Result::Ok(crate::prelude::ItemTag {
-                    key: __s0
-                        .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("key"))?,
-                    value: __s1.flatten(),
-                    target: __s2
-                        .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("target"))?,
-                    target_path: __s3.flatten(),
-                    owner_id: __s4
-                        .flatten()
-                        .ok_or_else(|| ::serde::de::Error::missing_field("owner_id"))?,
-                })
+                let __a0: String = __s0
+                    .flatten()
+                    .ok_or_else(|| ::serde::de::Error::missing_field("key"))?;
+                let __a1: Option<String> = __s1.flatten();
+                let __a2: openehr_base::prelude::UidBasedId = __s2
+                    .flatten()
+                    .ok_or_else(|| ::serde::de::Error::missing_field("target"))?;
+                let __a3: Option<String> = __s3.flatten();
+                let __a4: openehr_base::prelude::ObjectRef = __s4
+                    .flatten()
+                    .ok_or_else(|| ::serde::de::Error::missing_field("owner_id"))?;
+                let __built = crate::prelude::ItemTag::new(__a0, __a1, __a2, __a3, __a4);
+                __built.map_err(|__e| ::serde::de::Error::custom(::std::format!("ITEM_TAG: {__e}")))
             }
         }
         ::serde::Deserializer::deserialize_struct(__deserializer, "ITEM_TAG", __FIELDS, __Visitor)

--- a/tools/openehr-codegen/src/load/bmm.rs
+++ b/tools/openehr-codegen/src/load/bmm.rs
@@ -150,6 +150,19 @@ pub(crate) struct BmmProperty {
     pub documentation: Option<String>,
     /// `is_mandatory = true` → an obligatory attribute (else optional/`Option`).
     pub is_mandatory: bool,
+    /// The vendored `default` facet, verbatim, if the schema carries one.
+    ///
+    /// The value is the schema's own text for the attribute's initial value —
+    /// ODIN `default = <False>` / `<"Boolean">` arrives here as `"False"` /
+    /// `"\"Boolean\""`. It is kept unparsed because the facet is NOT part of the
+    /// released persistence model: LANG
+    /// `docs/UML/classes/org.openehr.lang.bmm_persistence.p_bmm_property.adoc`
+    /// §Attributes lists `name`, `is_mandatory`, `is_computed`,
+    /// `is_im_infrastructure`, `is_im_runtime`, `type_def` and `bmm_property`
+    /// and no `default`, so every vendored occurrence is an undeclared extension
+    /// whose meaning is adjudicated in `plan::overrides`, not assumed here. The
+    /// loader's job is only to stop dropping it.
+    pub default: Option<String>,
     /// The property's shape and type.
     pub kind: BmmPropKind,
 }
@@ -498,6 +511,15 @@ fn parse_property(node: &Value) -> BmmProperty {
         .get("is_mandatory")
         .and_then(Value::as_bool)
         .unwrap_or(false);
+    // The `default` facet, verbatim. The JSON export stringifies every ODIN
+    // literal (`<False>` → `"False"`, `<"Boolean">` → `"\"Boolean\""`), but a
+    // schema that writes a real JSON scalar is read too, so the value is
+    // normalized to its text rather than required to be a string.
+    let default = node.get("default").and_then(|v| match v {
+        Value::String(s) => Some(s.clone()),
+        Value::Bool(_) | Value::Number(_) => Some(v.to_string()),
+        Value::Null | Value::Array(_) | Value::Object(_) => None,
+    });
     let ptype = node.get("_type").and_then(Value::as_str).unwrap_or("");
 
     let kind = if ptype == "P_BMM_CONTAINER_PROPERTY" {
@@ -531,6 +553,7 @@ fn parse_property(node: &Value) -> BmmProperty {
         name,
         documentation,
         is_mandatory,
+        default,
         kind,
     }
 }

--- a/tools/openehr-codegen/src/load/oas.rs
+++ b/tools/openehr-codegen/src/load/oas.rs
@@ -59,15 +59,42 @@ impl Oas {
     /// schema across `bundles` — the shared-module fallback when no single
     /// bundle declares every hoisted schema (the copies are identical by the
     /// hoist analysis, so first-declarer is deterministic and lossless).
+    ///
+    /// **The `allOf` base closure comes with them.** A kept schema that composes
+    /// `allOf: [{$ref: Base}]` is only half a schema without `Base`: the emitter
+    /// resolves that `$ref` through this same document to flatten the inherited
+    /// members, and a document holding `keep` alone leaves the ref dangling, so
+    /// the emitted struct silently carries only the schema's OWN `properties`.
+    /// The closure is transitive (a base may compose a base of its own) and
+    /// carries the bases as ordinary schemas — being reachable does not make a
+    /// base hoisted, so `keep` itself is unchanged.
     #[must_use]
     pub(crate) fn merged_schemas(
         bundles: &[(&str, Oas)],
         keep: &std::collections::BTreeSet<String>,
     ) -> Oas {
+        let mut wanted = keep.clone();
+        // Fixpoint over the `allOf` bases of everything already wanted.
+        loop {
+            let mut added = false;
+            for (_, o) in bundles {
+                for (name, schema) in o.schemas() {
+                    if !wanted.contains(&name) {
+                        continue;
+                    }
+                    for base in Self::allof_bases(schema) {
+                        added |= wanted.insert(base);
+                    }
+                }
+            }
+            if !added {
+                break;
+            }
+        }
         let mut schemas = serde_json::Map::new();
         for (_, o) in bundles {
             for (name, schema) in o.schemas() {
-                if keep.contains(&name) && !schemas.contains_key(&name) {
+                if wanted.contains(&name) && !schemas.contains_key(&name) {
                     schemas.insert(name, schema.clone());
                 }
             }
@@ -75,6 +102,15 @@ impl Oas {
         Oas {
             root: serde_json::json!({ "components": { "schemas": schemas } }),
         }
+    }
+
+    /// The component-schema names a schema's `allOf` members `$ref`.
+    fn allof_bases(schema: &Value) -> Vec<String> {
+        schema
+            .get("allOf")
+            .and_then(Value::as_array)
+            .map(|members| members.iter().filter_map(Self::ref_name).collect())
+            .unwrap_or_default()
     }
 
     /// The component schemas (`#/components/schemas`), in document order.

--- a/tools/openehr-codegen/src/plan/composition.rs
+++ b/tools/openehr-codegen/src/plan/composition.rs
@@ -16,6 +16,49 @@
 //! name and discards the other's attributes. The merged
 //! [`BmmSchema::dependency_view`] is built only as the crate's *naming* view
 //! (one type per Rust name for the prelude and for downstream crates).
+//!
+//! # NOTE: the five RM/BASE twin classes are spec-mandated, not accidental
+//!
+//! `AUTHORED_RESOURCE`, `RESOURCE_DESCRIPTION`, `RESOURCE_DESCRIPTION_ITEM`,
+//! `TRANSLATION_DETAILS` and `CODE_PHRASE` are declared by BOTH the RM 1.2.0 and
+//! the BASE 1.3.0 BMM, with materially different shapes, and BOTH generations
+//! are emitted (the RM twin into `openehr-rm`, the BASE twin into
+//! `openehr-base`). That is what the vendored components state, first-hand:
+//!
+//! - **The resource package.** RM `docs/common/master08-resource_package.adoc`
+//!   opens with the normative note that "the version of the Resource package
+//!   described below is used only in ADL 1.4 archetypes, i.e. via the AOM 1.4
+//!   archetype model. A newer version of this package is defined in the openEHR
+//!   Resource Specification in the BASE component, and is used in ADL 2
+//!   archetypes … with the older form here retained only while needed by AOM 1.4
+//!   based archetypes and tools." Two versions of one package, kept side by side
+//!   on purpose — the AM `am14`/`am24` situation, in the components that own
+//!   them. The RM twin is therefore NOT a stale copy to retire, and the two
+//!   member-level differences that look like defects are the older generation's
+//!   real shape: `TRANSLATION_DETAILS.accreditaton` (RM
+//!   `docs/UML/classes/org.openehr.rm.common.translation_details.adoc`) and
+//!   `copyright` on `RESOURCE_DESCRIPTION_ITEM` rather than
+//!   `RESOURCE_DESCRIPTION` (RM
+//!   `docs/UML/classes/org.openehr.rm.common.resource_description_item.adoc`).
+//!   The published ADL-1.4 schema agrees on the second one — `Resource.xsd`
+//!   in the vendored `AM/Release-1.4` bundle declares `copyright` inside
+//!   `RESOURCE_DESCRIPTION_ITEM` — so only the `accreditaton` spelling is a
+//!   genuine upstream defect: BASE `docs/resource/master00-amendment_record.adoc`
+//!   records SPECPUB-6, "Correct spelling error in
+//!   `TRANSLATION_DETAILS._accreditation_`", against the BASE copy alone, and
+//!   every published `Resource.xsd` in BOTH ITS-XML lineages spells the element
+//!   `accreditation`, leaving the RM component's retained copy the only artifact
+//!   still carrying the typo. The emitter reproduces its input; correcting the
+//!   RM spelling is an upstream matter, not an override.
+//! - **`CODE_PHRASE`.** BASE `docs/foundation_types/master00-amendment_record.adoc`
+//!   records SPECAM-82 as "Add **legacy** `CODE_PHRASE` class to Foundation Types
+//!   to support AOM 1.4 model", and the vendored BASE 1.3.0 BMM's own class
+//!   documentation says "Retain for LEGACY only, while ADL1.4 requires
+//!   `CODE_PHRASE`" (that sentence is propagated into the generated
+//!   `openehr_base` type). It is an ADDITION for AM 1.4's benefit — AM's BMM
+//!   includes BASE, not RM — not a relocation of the RM class, so
+//!   `openehr_rm::data_types::text::CODE_PHRASE` stays the live domain type and
+//!   there is no move to finish.
 
 use crate::analyze::{External, Model, emittable_specs};
 use crate::load::bmm::BmmSchema;
@@ -113,7 +156,10 @@ pub(crate) const COMPOSITIONS: &[CrateComposition] = &[
         model_deps: &["base"],
         prelude_deps: &["base"],
         doc: RM_DOC,
-        citation: "RM 1.2.0 BMM includes openehr_base_1.3.0 (ancestors resolve to BASE).",
+        citation: "RM 1.2.0 BMM includes openehr_base_1.3.0 (ancestors resolve to BASE). Five \
+                   class names are declared by BOTH files and the RM declaration wins the merge, \
+                   which is correct in every case — see the module NOTE on the RM/BASE \
+                   twin classes.",
         reason: "The domain model; depends on BASE.",
     },
     CrateComposition {

--- a/tools/openehr-codegen/src/plan/construction.rs
+++ b/tools/openehr-codegen/src/plan/construction.rs
@@ -8,12 +8,25 @@
 //! released spec states no constraint over the field values — privacy there
 //! would guarantee nothing and only add ceremony.
 //!
-//! It is *wrong* wherever the released spec defines a **lexical form**: BASE
-//! `base_types/master05-identification_package.adoc` §Syntaxes gives an EBNF
-//! grammar for every identifier class, so a `HIER_OBJECT_ID` whose `value` is
-//! `"1234-5678"` is not a valid instance of the spec type at all. With a public
-//! field the type can hold it anyway, and the validating constructor beside it
-//! is merely *a* door rather than *the* door.
+//! It is *wrong* wherever the released spec states a **constraint over the
+//! field values that is decidable from those fields alone**. Two shapes qualify:
+//!
+//! * a **lexical form** — BASE `base_types/master05-identification_package.adoc`
+//!   §Syntaxes gives an EBNF grammar for every identifier class, so a
+//!   `HIER_OBJECT_ID` whose `value` is `"1234-5678"` is not a valid instance of
+//!   the spec type at all;
+//! * a **class invariant over its own fields** — RM
+//!   `UML/classes/org.openehr.rm.common.item_tag.adoc` §Invariants states
+//!   `Inv_key_valid` and `Inv_value_valid` over `ITEM_TAG.key`/`.value`, so an
+//!   `ITEM_TAG` with an empty key is likewise not an instance of the class.
+//!
+//! With a public field the type can hold the invalid value anyway, and the
+//! validating constructor beside it is merely *a* door rather than *the* door.
+//!
+//! The boundary is decidability *from the fields*: an invariant that needs
+//! anything the instance does not carry — terminology lookup, the existence of
+//! the `target` an `ITEM_TAG` points at, a parent's node id — cannot move to the
+//! door and stays at the `Validate` tier or in the service layer.
 //!
 //! An entry with [`Door::Validated`] closes that: the emitter renders the
 //! class's fields `pub(crate)` and emits read accessors, so **outside the
@@ -56,12 +69,13 @@ pub(crate) enum Door {
         /// constructor cannot answer.
         params: &'static [&'static str],
         /// `true` when `new` returns `Result` (the normal case: the constructor
-        /// runs a grammar over a raw string). `false` when the field types
-        /// already make an invalid value unrepresentable, so the door exists to
-        /// be the ONLY door, not to reject anything — a `Result` there would be
-        /// a lie the `unnecessary_wraps` lint is right to flag.
+        /// runs a grammar or an invariant over the incoming values). `false`
+        /// when the field types already make an invalid value unrepresentable,
+        /// so the door exists to be the ONLY door, not to reject anything — a
+        /// `Result` there would be a lie the `unnecessary_wraps` lint is right
+        /// to flag.
         fallible: bool,
-        /// The released grammar the constructor runs.
+        /// The released grammar or invariant the constructor runs.
         citation: &'static str,
     },
     /// Fields stay `pub`: the released spec states **no** constraint over this
@@ -94,10 +108,18 @@ pub(crate) struct Construction {
 
 /// Every adjudicated construction decision.
 ///
-/// The identification family is the whole of it today (owner scope pin, issue
-/// #1695): it is the one package where the released spec gives a complete
-/// machine-checkable grammar for the field value, so it is the one package
-/// where a construction door buys a real guarantee.
+/// The identification family is the lexical-form half: it is the package where
+/// the released spec gives a complete machine-checkable grammar for the field
+/// value. `ITEM_TAG` is the invariant half — the RM class whose §Invariants are
+/// stated purely over its OWN fields, so the same door closes them.
+///
+/// **The set is adjudicated per class, never swept.** The emit-validate
+/// classification knows which invariants are mechanically evaluable, but
+/// mechanical evaluability is not sufficient: an invariant may only move to the
+/// door when it is decidable from the class's own fields AND refusing at
+/// construction is the right accept/reject boundary (see [`Door::TierEnforced`]
+/// for a case where it is not). The invariant families still at the `Validate`
+/// tier are recorded in `openehr-rm`'s generated realization register.
 pub(crate) static CONSTRUCTION: &[Construction] = &[
     // ── the UID hierarchy (uid = iso_oid | uuid | internet_id) ──────────────
     Construction {
@@ -169,6 +191,29 @@ pub(crate) static CONSTRUCTION: &[Construction] = &[
                        master06-change_control_package.adoc \u{a7}\u{201c}The 'Virtual Version \
                        Tree'\u{201d} starts every part at 1 (`VERSION_TREE_ID.\
                        Trunk_version_valid` / `.Branch_validity`).",
+        },
+    },
+    // ── the invariant half: a class constrained by its OWN §Invariants ──────
+    Construction {
+        class: "ITEM_TAG",
+        door: Door::Validated {
+            params: &[
+                "String",
+                "Option<String>",
+                "openehr_base::prelude::UidBasedId",
+                "Option<String>",
+                "openehr_base::prelude::ObjectRef",
+            ],
+            fallible: true,
+            citation: "docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.common.item_tag.adoc \
+                       \u{a7}Invariants: `Inv_key_valid: not key.is_empty and key.is_justified` \
+                       and `Inv_value_valid: value /= Void implies not value.is_empty`. Both are \
+                       stated over ITEM_TAG's own fields and decidable from them alone, so an \
+                       instance violating either is not an instance of the class \u{2014} the \
+                       same standing the \u{a7}Syntaxes grammar has for an identifier. The \
+                       remaining checks an ITEM_TAG needs (does `target` exist, does \
+                       `target_path` resolve within it) read state the instance does NOT carry \
+                       and stay in the service layer.",
         },
     },
     // ── recorded NON-entries: identifier classes that stay plain records ────

--- a/tools/openehr-codegen/src/plan/mod.rs
+++ b/tools/openehr-codegen/src/plan/mod.rs
@@ -331,7 +331,7 @@ impl Model {
                     wire_name: p.name.clone(),
                     rust_name: naming::field_ident(&p.name),
                     kind,
-                    default: field_default(&rp.owner, &p.name).map(str::to_string),
+                    default: field_default(&rp.owner, p),
                 }
             })
             .collect()
@@ -487,7 +487,7 @@ impl Model {
                         && !cardinality_contradicted(&rp.owner, &p.name),
                     target,
                     map_value,
-                    default: field_default(&rp.owner, &p.name).map(str::to_string),
+                    default: field_default(&rp.owner, p),
                 }
             })
             .collect()

--- a/tools/openehr-codegen/src/plan/overrides.rs
+++ b/tools/openehr-codegen/src/plan/overrides.rs
@@ -19,6 +19,7 @@
 use std::collections::BTreeMap;
 
 use crate::analyze::invariants::{Bucket, classify};
+use crate::load::bmm::{BmmPropKind, BmmProperty, BmmType};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Primitive type map (spec foundation type → Rust type)
@@ -573,45 +574,174 @@ pub(crate) struct FieldDefault {
     pub reason: &'static str,
 }
 
-/// Serde defaults for fields the canonical wire may omit. `Interval`'s
-/// inclusivity/boundedness flags are mandatory in the BMM but archie/EHRbase
-/// omit them: a bounded limit is *included* by default, an unstated limit is
-/// *bounded* by default. The value is a literal Rust expression consumed by
-/// `#[openehr(default = …)]`.
+/// Serde defaults the vendored BMM does NOT state, for fields the canonical
+/// wire may omit.
+///
+/// **This table is the residue, not the source.** The vendored schemas carry a
+/// `default` facet on 44 properties ([`BmmProperty::default`]), and
+/// [`vendored_default`] renders it wherever it is renderable — that derivation
+/// is the primary path. Entries survive here only where the vendored input
+/// states nothing and a decision is still required.
+///
+/// The four that remain are `Interval`'s inclusivity/boundedness flags. The
+/// BASE 1.3.0 `Interval` primitive type declares all four as mandatory with NO
+/// `default` facet, yet its own `Point_interval` descendant REDECLARES the same
+/// four properties carrying exactly the values below — so the schema states the
+/// convention once, on one descendant, and leaves the inherited sites silent.
+/// These entries propagate that same statement to the inherited sites
+/// (`Proper_interval`, `Multiplicity_interval`), which is also what archie and
+/// EHRbase emit on the wire: a bounded limit is *included* by default, an
+/// unstated limit is *bounded* by default. The value is a literal Rust
+/// expression.
 pub(crate) const FIELD_DEFAULTS: &[FieldDefault] = &[
     FieldDefault {
         owner: "Interval",
         field: "lower_included",
         default: "true",
-        citation: "BASE foundation_types (Interval) for the semantics; no openEHR spec governs \
-                   the wire omission — archie/EHRbase interop convention (our own design)",
+        citation: "BASE docs/UML/classes/org.openehr.base.foundation_types.interval.adoc \
+                   (Interval) for the semantics; the identical value is the vendored `default` \
+                   facet on Point_interval.lower_included. No openEHR spec governs the wire \
+                   omission itself — archie/EHRbase interop convention (our own design)",
         reason: "A bounded interval limit is included by default.",
     },
     FieldDefault {
         owner: "Interval",
         field: "upper_included",
         default: "true",
-        citation: "BASE foundation_types (Interval) for the semantics; no openEHR spec governs \
-                   the wire omission — archie/EHRbase interop convention (our own design)",
+        citation: "BASE docs/UML/classes/org.openehr.base.foundation_types.interval.adoc \
+                   (Interval) for the semantics; the identical value is the vendored `default` \
+                   facet on Point_interval.upper_included. No openEHR spec governs the wire \
+                   omission itself — archie/EHRbase interop convention (our own design)",
         reason: "A bounded interval limit is included by default.",
     },
     FieldDefault {
         owner: "Interval",
         field: "lower_unbounded",
         default: "false",
-        citation: "BASE foundation_types (Interval) for the semantics; no openEHR spec governs \
-                   the wire omission — archie/EHRbase interop convention (our own design)",
+        citation: "BASE docs/UML/classes/org.openehr.base.foundation_types.interval.adoc \
+                   (Interval) for the semantics; the identical value is the vendored `default` \
+                   facet on Point_interval.lower_unbounded. No openEHR spec governs the wire \
+                   omission itself — archie/EHRbase interop convention (our own design)",
         reason: "An unstated interval limit is bounded by default.",
     },
     FieldDefault {
         owner: "Interval",
         field: "upper_unbounded",
         default: "false",
-        citation: "BASE foundation_types (Interval) for the semantics; no openEHR spec governs \
-                   the wire omission — archie/EHRbase interop convention (our own design)",
+        citation: "BASE docs/UML/classes/org.openehr.base.foundation_types.interval.adoc \
+                   (Interval) for the semantics; the identical value is the vendored `default` \
+                   facet on Point_interval.upper_unbounded. No openEHR spec governs the wire \
+                   omission itself — archie/EHRbase interop convention (our own design)",
         reason: "An unstated interval limit is bounded by default.",
     },
 ];
+
+/// Render a property's vendored `default` facet as a literal Rust expression of
+/// the field's own type, or `None` when the facet cannot be one.
+///
+/// The facet is an **undeclared extension**: LANG
+/// `docs/UML/classes/org.openehr.lang.bmm_persistence.p_bmm_property.adoc`
+/// §Attributes declares `name`, `is_mandatory`, `is_computed`,
+/// `is_im_infrastructure`, `is_im_runtime`, `type_def` and `bmm_property` — no
+/// `default` — so the vendored schemas' 44 occurrences carry no normative
+/// reading and the emitter derives from them only where the facet is
+/// unambiguous in the property's own declared type:
+///
+/// * `Boolean` ← the ODIN literals `False`/`True` (the JSON export stringifies
+///   them) or a real JSON boolean.
+/// * `String` ← an ODIN-QUOTED literal (`<"Boolean">` arrives as `"\"Boolean\""`).
+///   The quoting is what distinguishes a string value from a stray annotation:
+///   the one bare non-empty facet in the vendored set is RM
+///   `RESOURCE_DESCRIPTION.parent_resource = "0..1"`, a cardinality that leaked
+///   into the default slot of an `AUTHORED_RESOURCE`-typed property.
+///
+/// Everything else is un-renderable and is listed in [`UNRENDERABLE_DEFAULTS`],
+/// so the vendored set is partitioned totally: derived, or named with a reason.
+pub(crate) fn vendored_default(prop: &BmmProperty) -> Option<String> {
+    let facet = prop.default.as_deref()?;
+    let BmmPropKind::Single(BmmType::Simple(ty)) = &prop.kind else {
+        return None;
+    };
+    match ty.as_str() {
+        "Boolean" => match facet {
+            "False" | "false" => Some("false".to_string()),
+            "True" | "true" => Some("true".to_string()),
+            _ => None,
+        },
+        "String" => {
+            let inner = facet.strip_prefix('"')?.strip_suffix('"')?;
+            (!inner.is_empty()).then(|| format!("::std::string::String::from({inner:?})"))
+        }
+        _ => None,
+    }
+}
+
+/// One vendored `default` facet the emitter deliberately does NOT realize.
+pub(crate) struct UnrenderableDefault {
+    /// The declaring BMM class.
+    pub owner: &'static str,
+    /// The property carrying the facet.
+    pub field: &'static str,
+    /// The spec/schema evidence for leaving it unrealized.
+    pub citation: &'static str,
+    /// One-line reason.
+    pub reason: &'static str,
+}
+
+/// Every vendored `default` facet [`vendored_default`] declines to render, named
+/// and cited — the completeness half of the partition, so a facet is never just
+/// dropped.
+///
+/// A new un-renderable facet (a re-vendored schema, a pin bump) fails the
+/// emitter's own test suite until it is adjudicated here.
+pub(crate) const UNRENDERABLE_DEFAULTS: &[UnrenderableDefault] = &[
+    UnrenderableDefault {
+        owner: "RESOURCE_DESCRIPTION",
+        field: "parent_resource",
+        citation: "The property is typed AUTHORED_RESOURCE, not a primitive: the BASE 1.3.0 \
+                   schema gives it the facet `\"\"` and the RM 1.2.0 schema `\"0..1\"` (a \
+                   cardinality string in the default slot). It is also a designated owner/parent \
+                   back-reference (see BACK_REFERENCES), so no struct field exists to default.",
+        reason: "Class-typed back-reference; both vendored facet values are authoring slips.",
+    },
+    UnrenderableDefault {
+        owner: "CODE_SET",
+        field: "status",
+        citation: "TERM 3.1.0 types the property TERMINOLOGY_STATUS and gives it the facet \
+                   `\"\"`; an empty string is not a value of that type.",
+        reason: "Empty facet on a non-primitive type.",
+    },
+    UnrenderableDefault {
+        owner: "TERMINOLOGY_GROUP",
+        field: "status",
+        citation: "TERM 3.1.0 types the property TERMINOLOGY_STATUS and gives it the facet \
+                   `\"\"`; an empty string is not a value of that type.",
+        reason: "Empty facet on a non-primitive type.",
+    },
+    UnrenderableDefault {
+        owner: "CODE",
+        field: "status",
+        citation: "TERM 3.1.0 types the property TERMINOLOGY_STATUS and gives it the facet \
+                   `\"\"`; an empty string is not a value of that type.",
+        reason: "Empty facet on a non-primitive type.",
+    },
+    UnrenderableDefault {
+        owner: "TERMINOLOGY_CONCEPT",
+        field: "status",
+        citation: "TERM 3.1.0 types the property TERMINOLOGY_STATUS and gives it the facet \
+                   `\"\"`; an empty string is not a value of that type.",
+        reason: "Empty facet on a non-primitive type.",
+    },
+];
+
+/// Whether `(owner, field)`'s vendored `default` facet is an adjudicated
+/// un-renderable one.
+#[must_use]
+pub(crate) fn default_unrenderable(owner: &str, field: &str) -> bool {
+    UNRENDERABLE_DEFAULTS
+        .iter()
+        .any(|u| u.owner == owner && u.field == field)
+}
 
 /// A container attribute whose vendored cardinality lower bound is CONTRADICTED
 /// by the same release's normative syntax, with the citation that resolves it.
@@ -657,13 +787,124 @@ pub(crate) fn cardinality_contradicted(owner: &str, field: &str) -> bool {
         .any(|c| c.owner == owner && c.field == field)
 }
 
-/// The serde default expression for `(owner, field)`, or `None`. Behaviour-
-/// identical to the former inline `field_default`.
-pub(crate) fn field_default(owner: &str, field: &str) -> Option<&'static str> {
-    FIELD_DEFAULTS
+/// The serde default expression for a resolved property, or `None`.
+///
+/// The vendored `default` facet on the DECLARING class wins; [`FIELD_DEFAULTS`]
+/// supplies only what the schemas leave unstated. The two can never disagree —
+/// an entry in the hand table for a property that carries a renderable facet
+/// fails the emitter's own test suite.
+pub(crate) fn field_default(owner: &str, prop: &BmmProperty) -> Option<String> {
+    vendored_default(prop).or_else(|| {
+        FIELD_DEFAULTS
+            .iter()
+            .find(|d| d.owner == owner && d.field == prop.name)
+            .map(|d| d.default.to_string())
+    })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ITS-REST OAS schema names that ARE spec types under a different spelling
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// One ITS-REST OAS component schema whose *key* name does not match the spec
+/// class it renders, mapped to the generated spec type it must resolve to.
+pub(crate) struct OasMonomorphization {
+    /// The OAS `components/schemas` key.
+    pub schema: &'static str,
+    /// The `title` that same schema declares — the openEHR spec name, which is
+    /// what grounds the mapping in the vendored input rather than in a guess.
+    pub title: &'static str,
+    /// The fully-qualified generated Rust type.
+    pub rust_type: &'static str,
+    /// The spec/OAS evidence.
+    pub citation: &'static str,
+    /// One-line reason.
+    pub reason: &'static str,
+}
+
+/// OAS component schemas that ARE generated spec types spelled differently.
+///
+/// `emit_rest` binds a `$ref` to a spec type by matching the schema KEY against
+/// the emittable class names, which works for the ~200 schemas the released
+/// bundles name after their class (`Ehr`, `DvText`, …) and fails for the five
+/// below: OAS keys must be unique and ASCII, so the released bundles rename a
+/// class whose Rust name collides (`Clstr`) and give each generic
+/// INSTANTIATION its own key (`DvIntervalOfDate`, `ObjectRefOfHierObjectId`).
+/// Every one of them declares its real spec name in `title`, so the mapping is
+/// read out of the vendored bundle, not invented — the emitter's test suite
+/// asserts each entry's `title` against the bundle.
+///
+/// Without the mapping they emit as DTO structs, which is doubly wrong: the
+/// payload loses the spec type's strict canonical-JSON reader, and the DTO is
+/// `allOf`-truncated (it carries only the schema's OWN `properties`, so
+/// `Clstr` loses every `ITEM`/`LOCATABLE` member and `ObjectRefOfHierObjectId`
+/// loses the mandatory `namespace` and `type`).
+pub(crate) const OAS_MONOMORPHIZATIONS: &[OasMonomorphization] = &[
+    OasMonomorphization {
+        schema: "Clstr",
+        title: "CLUSTER",
+        rust_type: "openehr_rm::prelude::Cluster",
+        citation: "The schema declares `title: CLUSTER` and
+                   `x-discriminator-value: CLUSTER`, and every ITEM discriminator mapping in the \
+                   released bundles routes `CLUSTER: '#/components/schemas/Clstr'`. RM \
+                   docs/data_structures/master03-item_structure_package.adoc §CLUSTER is the \
+                   class; `openehr_rm::prelude::Cluster` is its generated form.",
+        reason: "OAS key abbreviated to avoid a name clash; the class is RM CLUSTER.",
+    },
+    OasMonomorphization {
+        schema: "DvIntervalOfDate",
+        title: "DV_INTERVAL_of_DATE",
+        rust_type: "openehr_rm::prelude::DvInterval<openehr_rm::prelude::DvDate>",
+        citation: "The schema declares `title: DV_INTERVAL_of_DATE`, composes \
+                   `allOf: [DvInterval]`, and narrows `lower`/`upper` to `DvDate`. RM \
+                   docs/data_types/master04-quantity_package.adoc §DV_INTERVAL is the generic \
+                   class `DV_INTERVAL<T: DV_ORDERED>`; this is its DV_DATE instantiation.",
+        reason: "A generic instantiation the OAS must give a flat key; the class is DV_INTERVAL.",
+    },
+    OasMonomorphization {
+        schema: "DvIntervalOfDateTime",
+        title: "DV_INTERVAL_of_DATE_TIME",
+        rust_type: "openehr_rm::prelude::DvInterval<openehr_rm::prelude::DvDateTime>",
+        citation: "The schema declares `title: DV_INTERVAL_of_DATE_TIME`, composes \
+                   `allOf: [DvInterval]`, and narrows `lower`/`upper` to `DvDateTime`. RM \
+                   docs/data_types/master04-quantity_package.adoc §DV_INTERVAL is the generic \
+                   class `DV_INTERVAL<T: DV_ORDERED>`; this is its DV_DATE_TIME instantiation.",
+        reason: "A generic instantiation the OAS must give a flat key; the class is DV_INTERVAL.",
+    },
+    OasMonomorphization {
+        schema: "ObjectRefOfHierObjectId",
+        title: "OBJECT_REF",
+        rust_type: "openehr_base::prelude::ObjectRef",
+        citation: "The schema declares `title: OBJECT_REF`, composes `allOf: [ObjectRef]`, and \
+                   narrows `id` to `HierObjectId`. BASE \
+                   docs/base_types/master05-identification_package.adoc §OBJECT_REF declares \
+                   `id: OBJECT_ID`, of which HIER_OBJECT_ID is a subtype, so the generated \
+                   `openehr_base::prelude::ObjectRef` already accepts this narrowing — and \
+                   carries the mandatory `namespace`/`type` members the truncated DTO dropped.",
+        reason: "An id-narrowed OBJECT_REF given its own OAS key; the class is OBJECT_REF.",
+    },
+    OasMonomorphization {
+        schema: "ObjectRefOfObjectVersionId",
+        title: "OBJECT_REF",
+        rust_type: "openehr_base::prelude::ObjectRef",
+        citation: "The schema declares `title: OBJECT_REF`, composes `allOf: [ObjectRef]`, and \
+                   narrows `id` to `ObjectVersionId`. BASE \
+                   docs/base_types/master05-identification_package.adoc §OBJECT_REF declares \
+                   `id: OBJECT_ID`, of which OBJECT_VERSION_ID is a subtype, so the generated \
+                   `openehr_base::prelude::ObjectRef` already accepts this narrowing — and \
+                   carries the mandatory `namespace`/`type` members the truncated DTO dropped.",
+        reason: "An id-narrowed OBJECT_REF given its own OAS key; the class is OBJECT_REF.",
+    },
+];
+
+/// The generated spec type an OAS component schema key resolves to, or `None`
+/// when the key is not one of the renamed/monomorphized spellings.
+#[must_use]
+pub(crate) fn oas_monomorphization(schema: &str) -> Option<&'static str> {
+    OAS_MONOMORPHIZATIONS
         .iter()
-        .find(|d| d.owner == owner && d.field == field)
-        .map(|d| d.default)
+        .find(|m| m.schema == schema)
+        .map(|m| m.rust_type)
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tools/openehr-codegen/src/render/emit.rs
+++ b/tools/openehr-codegen/src/render/emit.rs
@@ -740,8 +740,9 @@ fn render_accessors(
     b.push_str(&format!(
         "\n/// Read access to the `pub(crate)` fields of [`{struct_ty}`].\n\
          ///\n\
-         /// The fields are not `pub`: this class has a released **lexical form**, so\n\
-         /// construction runs a grammar and is the only door \u{2014} {citation}\n\
+         /// The fields are not `pub`: the release states a **constraint over this\n\
+         /// class's own field values** (a lexical form, or a class invariant), so\n\
+         /// construction checks it and is the only door \u{2014} {citation}\n\
          ///\n\
          /// The validating constructor lives in the hand-written `*_impl.rs` sibling\n\
          /// (the generator never writes into it); every generated codec builds this\n\
@@ -752,13 +753,27 @@ fn render_accessors(
         if i > 0 {
             b.push('\n');
         }
-        let (ret, expr) = if rust_ty == "String" {
-            ("&str".to_owned(), format!("&self.{ident}"))
-        } else {
-            (format!("&{rust_ty}"), format!("&self.{ident}"))
+        // `&Option<T>` is never the right accessor return (clippy::ref_option:
+        // it forces the caller to reborrow and blocks passing a plain `Some(&x)`)
+        // — an optional field reads back as `Option<&T>`, with `Option<String>`
+        // borrowing all the way down to `Option<&str>`.
+        let (ret, expr) = match rust_ty
+            .strip_prefix("Option<")
+            .and_then(|inner| inner.strip_suffix('>'))
+        {
+            Some("String") => (
+                "Option<&str>".to_owned(),
+                format!("self.{ident}.as_deref()"),
+            ),
+            Some(inner) => (
+                format!("Option<&{inner}>"),
+                format!("self.{ident}.as_ref()"),
+            ),
+            None if rust_ty == "String" => ("&str".to_owned(), format!("&self.{ident}")),
+            None => (format!("&{rust_ty}"), format!("&self.{ident}")),
         };
         b.push_str(&format!(
-            "    /// The validated `{ident}` this identifier was constructed from.\n    \
+            "    /// The `{ident}` this instance was constructed with, checked at the door.\n    \
              #[must_use]\n    \
              pub fn {ident}(&self) -> {ret} {{\n        {expr}\n    }}\n"
         ));

--- a/tools/openehr-codegen/src/render/emit_rest.rs
+++ b/tools/openehr-codegen/src/render/emit_rest.rs
@@ -10,6 +10,7 @@
 //! (the handler logic is hand-written application code, not generatable).
 
 use crate::load::oas::{Oas, Operation};
+use crate::plan::overrides::oas_monomorphization;
 use crate::render::naming;
 use serde_json::Value;
 use std::collections::BTreeSet;
@@ -240,6 +241,7 @@ pub(crate) fn hoist_set(bundles: &[(&str, Oas)], names: &RmNames) -> BTreeSet<St
                 && reprs.get(*n).is_some_and(|r| r.len() == 1)
                 && !names.rm.contains(*n)
                 && !names.base.contains(*n)
+                && oas_monomorphization(n).is_none()
         })
         .map(|(n, _)| n.clone())
         .collect();
@@ -248,8 +250,12 @@ pub(crate) fn hoist_set(bundles: &[(&str, Oas)], names: &RmNames) -> BTreeSet<St
         let snapshot = hoisted.clone();
         hoisted.retain(|n| {
             refs.get(n).is_some_and(|rs| {
-                rs.iter()
-                    .all(|r| names.rm.contains(r) || names.base.contains(r) || snapshot.contains(r))
+                rs.iter().all(|r| {
+                    names.rm.contains(r)
+                        || names.base.contains(r)
+                        || oas_monomorphization(r).is_some()
+                        || snapshot.contains(r)
+                })
             })
         });
         if hoisted.len() == snapshot.len() {
@@ -317,7 +323,9 @@ pub(crate) fn emit_group(
         .schemas()
         .iter()
         .map(|(n, _)| n.clone())
-        .filter(|n| !names.rm.contains(n) && !names.base.contains(n))
+        .filter(|n| {
+            !names.rm.contains(n) && !names.base.contains(n) && oas_monomorphization(n).is_none()
+        })
         .collect();
     let ctx = Ctx {
         oas,
@@ -437,6 +445,15 @@ impl Ctx<'_> {
     fn rust_type(&self, schema: &Value) -> String {
         // A `$ref` (possibly to a name we resolve without following it).
         if let Some(name) = Oas::ref_name(schema) {
+            // A schema whose KEY does not match its class — the released
+            // bundles rename `CLUSTER` to `Clstr` and give every generic
+            // INSTANTIATION its own flat key. The mapping is read from each
+            // schema's own `title` (see `plan::overrides::OAS_MONOMORPHIZATIONS`);
+            // without it these emit as `allOf`-truncated DTOs that drop their
+            // inherited members and the spec type's strict reader.
+            if let Some(spec) = oas_monomorphization(&name) {
+                return spec.to_string();
+            }
             // RM/BASE spec types resolve to the TYPED spec structs: since the
             // foundation rewrite (#1702) every spec type carries emitted manual
             // `serde::Serialize`/`Deserialize` impls (its crate's

--- a/tools/openehr-codegen/src/testsupport.rs
+++ b/tools/openehr-codegen/src/testsupport.rs
@@ -10,13 +10,14 @@ use crate::analyze::invariants::{self, Bucket};
 use crate::analyze::{Model, augment_with_reemit, class_paths, cross_schema_reemit};
 use crate::load::bmm::BmmSchema;
 use crate::load::impls::SiblingImpls;
+use crate::load::oas;
 use crate::plan::composition::{self, compose};
 use crate::plan::overrides;
 use crate::plan::{Emission, decide};
 use crate::render::emit::{
     CrateGeneration, GenFile, crate_generations, emit_crate, emit_generations, emit_multi_crate,
 };
-use crate::render::{emit_rm_model, emit_validate, model_query, naming};
+use crate::render::{emit_rest, emit_rm_model, emit_validate, model_query, naming};
 use std::collections::{BTreeMap, BTreeSet};
 
 type Error = Box<dyn std::error::Error>;
@@ -564,8 +565,21 @@ pub fn am24_reemit_mirrors() -> Result<Vec<Mirror>, Error> {
 /// # Errors
 /// Returns an error if the AM/BASE/LANG BMM files cannot be loaded.
 pub fn am24_reemit_closure() -> Result<BTreeSet<String>, Error> {
-    let am24 = compose("am24")?;
-    Ok(cross_schema_reemit(&am24.model, &am24.own_schema))
+    reemit_closure("am24")
+}
+
+/// One composition's raw downstream re-emission closure — the upstream classes
+/// [`cross_schema_reemit`] reports for crate `key`.
+///
+/// Queryable per composition (not just AM 2.4) so the "which compositions have a
+/// non-empty closure, and does the emitter act on it" question is answered from
+/// the analysis itself rather than from a citation that can go stale.
+///
+/// # Errors
+/// Returns an error if the composition's BMM files cannot be loaded.
+pub fn reemit_closure(key: &str) -> Result<BTreeSet<String>, Error> {
+    let c = compose(key)?;
+    Ok(cross_schema_reemit(&c.model, &c.own_schema))
 }
 
 /// The set of type files (`"<crate>/<path>"`) emitted for one composition
@@ -679,6 +693,35 @@ pub fn decision_maps() -> Vec<DeclMap> {
                 .map(|e| DeclEntry {
                     key: format!("{}.{}", e.owner, e.field),
                     decision: format!("default = {}", e.default),
+                    citation: e.citation.to_string(),
+                    reason: e.reason.to_string(),
+                })
+                .collect(),
+        },
+        DeclMap {
+            // The keys are OAS component-schema names, not BMM classes, so
+            // existence is checked against the vendored bundles by
+            // `oas_monomorphizations`, not by the BMM class/field scan.
+            map: "oas_monomorphization",
+            check_existence: false,
+            entries: overrides::OAS_MONOMORPHIZATIONS
+                .iter()
+                .map(|e| DeclEntry {
+                    key: e.schema.to_string(),
+                    decision: format!("{} → {}", e.title, e.rust_type),
+                    citation: e.citation.to_string(),
+                    reason: e.reason.to_string(),
+                })
+                .collect(),
+        },
+        DeclMap {
+            map: "unrenderable_default",
+            check_existence: true,
+            entries: overrides::UNRENDERABLE_DEFAULTS
+                .iter()
+                .map(|e| DeclEntry {
+                    key: format!("{}.{}", e.owner, e.field),
+                    decision: "vendored `default` facet deliberately not realized".to_string(),
                     citation: e.citation.to_string(),
                     reason: e.reason.to_string(),
                 })
@@ -943,6 +986,200 @@ pub fn field_exists(class: &str, field: &str) -> Result<bool, Error> {
         }
     }
     Ok(false)
+}
+
+/// The attribute names composition `key`'s OWN schema declares on `class`
+/// (declared, not inherited), or `None` if that schema declares no such class.
+///
+/// Used to pin the RM/BASE twin classes: five class names are declared by both
+/// components with materially different member sets, and both generations are
+/// emitted deliberately (see `plan::composition`'s module note).
+///
+/// # Errors
+/// Returns an error if the composition's BMM files cannot be loaded.
+pub fn declared_attributes(key: &str, class: &str) -> Result<Option<BTreeSet<String>>, Error> {
+    let c = compose(key)?;
+    Ok(c.own_schema
+        .classes
+        .get(class)
+        .map(|cls| cls.properties.iter().map(|p| p.name.clone()).collect()))
+}
+
+/// One vendored `default` facet, with the emitter's disposition of it.
+#[derive(Debug, Clone)]
+pub struct VendoredDefault {
+    /// Composition key the facet was read from.
+    pub key: String,
+    /// The DECLARING class.
+    pub owner: String,
+    /// The property carrying the facet.
+    pub field: String,
+    /// The facet text, verbatim from the schema.
+    pub facet: String,
+    /// The literal Rust expression the emitter derives, or `None` when the
+    /// facet is not renderable in the property's declared type.
+    pub rendered: Option<String>,
+}
+
+/// Every `default` facet the vendored schemas carry, across every composition
+/// generation, with what the emitter makes of it.
+///
+/// This is the reconciliation surface for the hand-written `field_default`
+/// table: the vendored facet is the source, the table is the residue, and the
+/// two must not overlap.
+///
+/// # Errors
+/// Returns an error if a vendored BMM file cannot be loaded.
+pub fn vendored_defaults() -> Result<Vec<VendoredDefault>, Error> {
+    let mut out = Vec::new();
+    for key in crate_keys() {
+        for g in &compose(key)?.generations {
+            for (owner, class) in &g.schema.classes {
+                for prop in &class.properties {
+                    if let Some(facet) = &prop.default {
+                        out.push(VendoredDefault {
+                            key: key.to_string(),
+                            owner: owner.clone(),
+                            field: prop.name.clone(),
+                            facet: facet.clone(),
+                            rendered: overrides::vendored_default(prop),
+                        });
+                    }
+                }
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Whether `(owner, field)` is an adjudicated un-renderable `default` facet.
+#[must_use]
+pub fn default_unrenderable(owner: &str, field: &str) -> bool {
+    overrides::default_unrenderable(owner, field)
+}
+
+/// The hand-written `field_default` residue as `(owner, field)` pairs.
+#[must_use]
+pub fn hand_written_defaults() -> Vec<(String, String)> {
+    overrides::FIELD_DEFAULTS
+        .iter()
+        .map(|d| (d.owner.to_string(), d.field.to_string()))
+        .collect()
+}
+
+/// One adjudicated OAS monomorphization, paired with what the VENDORED bundles
+/// actually declare for that schema key.
+#[derive(Debug, Clone)]
+pub struct OasMonomorphizationCheck {
+    /// The OAS `components/schemas` key.
+    pub schema: String,
+    /// The `title` the decision map claims the schema declares.
+    pub declared_title: String,
+    /// The generated Rust type the map resolves it to.
+    pub rust_type: String,
+    /// The `title` values the vendored bundles really declare for that key
+    /// (empty when no bundle declares the key at all).
+    pub vendored_titles: BTreeSet<String>,
+}
+
+/// Every `OAS_MONOMORPHIZATIONS` entry checked against the vendored ITS-REST
+/// bundles: the mapping is only legitimate because each schema declares its real
+/// spec name in `title`, so the entry must still match the vendored text.
+///
+/// # Errors
+/// Returns an error if a vendored OAS bundle cannot be read or parsed.
+pub fn oas_monomorphizations() -> Result<Vec<OasMonomorphizationCheck>, Error> {
+    let oas_dir = std::path::Path::new(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../crates/openehr-its/vendor/rest-oas"
+    ))
+    .to_path_buf();
+    let mut bundles = Vec::new();
+    for entry in std::fs::read_dir(&oas_dir).map_err(|e| e.to_string())? {
+        let path = entry.map_err(|e| e.to_string())?.path();
+        if path.extension().is_some_and(|x| x == "yaml") {
+            bundles.push(oas::Oas::parse_file(&path)?);
+        }
+    }
+    Ok(overrides::OAS_MONOMORPHIZATIONS
+        .iter()
+        .map(|m| OasMonomorphizationCheck {
+            schema: m.schema.to_string(),
+            declared_title: m.title.to_string(),
+            rust_type: m.rust_type.to_string(),
+            vendored_titles: bundles
+                .iter()
+                .flat_map(oas::Oas::schemas)
+                .filter(|(name, _)| name == m.schema)
+                .filter_map(|(_, s)| {
+                    s.get("title")
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_string)
+                })
+                .collect(),
+        })
+        .collect())
+}
+
+/// The schema names the shared-module fallback document carries, paired with
+/// the `allOf` base names the hoisted schemas reach.
+///
+/// The second set must be a subset of the first, or `emit_common` flattens
+/// `allOf` compositions against a document that cannot resolve their bases.
+///
+/// # Errors
+/// Returns an error if a vendored OAS bundle or a BMM file cannot be loaded.
+pub fn merged_fallback_schema_names() -> Result<(BTreeSet<String>, BTreeSet<String>), Error> {
+    let oas_dir = std::path::Path::new(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../crates/openehr-its/vendor/rest-oas"
+    ))
+    .to_path_buf();
+    let mut paths: Vec<std::path::PathBuf> = std::fs::read_dir(&oas_dir)
+        .map_err(|e| e.to_string())?
+        .map(|e| e.map(|e| e.path()))
+        .collect::<Result<_, _>>()
+        .map_err(|e| e.to_string())?;
+    paths.retain(|p| p.extension().is_some_and(|x| x == "yaml"));
+    paths.sort();
+    let mut bundles: Vec<(&str, oas::Oas)> = Vec::new();
+    for path in &paths {
+        bundles.push(("", oas::Oas::parse_file(path)?));
+    }
+
+    let base = compose("base")?;
+    let rm = compose("rm")?;
+    let names = emit_rest::RmNames {
+        base: crate::analyze::emittable_specs(&base.model, &base.own_schema)
+            .iter()
+            .map(|s| naming::type_name(s))
+            .collect(),
+        rm: crate::analyze::emittable_specs(&rm.model, &rm.own_schema)
+            .iter()
+            .map(|s| naming::type_name(s))
+            .collect(),
+    };
+    let hoisted = emit_rest::hoist_set(&bundles, &names);
+    let merged = oas::Oas::merged_schemas(&bundles, &hoisted);
+    let carried: BTreeSet<String> = merged.schemas().iter().map(|(n, _)| n.clone()).collect();
+
+    // The `allOf` bases the hoisted schemas reach, from the source bundles.
+    let mut bases = BTreeSet::new();
+    for (_, o) in &bundles {
+        for (name, schema) in o.schemas() {
+            if !hoisted.contains(&name) {
+                continue;
+            }
+            if let Some(members) = schema
+                .get("allOf")
+                .and_then(serde_json::Value::as_array)
+                .map(|m| m.iter().filter_map(oas::Oas::ref_name).collect::<Vec<_>>())
+            {
+                bases.extend(members);
+            }
+        }
+    }
+    Ok((carried, bases))
 }
 
 // ── model-query report ──────────────────────────────────────────────────────

--- a/tools/openehr-codegen/tests/it/emitter_invariants.rs
+++ b/tools/openehr-codegen/tests/it/emitter_invariants.rs
@@ -847,3 +847,255 @@ fn register_records_terminology_invariants_as_enforced() {
         "register split is not total"
     );
 }
+
+// ── ITS-REST OAS monomorphizations ──────────────────────────────────────────
+
+/// Every `OAS_MONOMORPHIZATIONS` entry is grounded in the vendored bundles: the
+/// schema key exists, and the `title` the entry cites is the `title` the bundles
+/// really declare for it. The mapping is only legitimate because the OAS names
+/// its own spec class there — an entry that no longer matches is a guess.
+#[test]
+fn oas_monomorphizations_match_the_vendored_titles() {
+    let checks = testsupport::oas_monomorphizations().unwrap();
+    assert!(!checks.is_empty(), "empty monomorphization map");
+    for c in &checks {
+        assert!(
+            !c.vendored_titles.is_empty(),
+            "{}: no vendored ITS-REST bundle declares this schema (stale entry)",
+            c.schema,
+        );
+        assert!(
+            c.vendored_titles.len() == 1 && c.vendored_titles.contains(&c.declared_title),
+            "{}: the decision map cites title {:?} but the vendored bundles declare {:?}",
+            c.schema,
+            c.declared_title,
+            c.vendored_titles,
+        );
+        assert!(
+            c.rust_type.starts_with("openehr_rm::") || c.rust_type.starts_with("openehr_base::"),
+            "{}: resolves to {:?}, which is not a generated spec type",
+            c.schema,
+            c.rust_type,
+        );
+    }
+}
+
+/// The generated ITS-REST contract carries NO DTO struct for a monomorphized
+/// schema, and the sites that referenced one now name the spec type.
+///
+/// The DTO form was doubly wrong: it lost the spec type's strict canonical-JSON
+/// reader, and it was `allOf`-truncated (only the schema's OWN properties), so
+/// `ObjectRefOfHierObjectId` shipped without the mandatory `namespace`/`type`.
+#[test]
+fn oas_monomorphizations_emit_as_spec_types_not_dtos() {
+    let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../crates/openehr-its/src/rest/generated");
+    let mut bodies = String::new();
+    for entry in std::fs::read_dir(&dir).unwrap() {
+        let path = entry.unwrap().path();
+        if path.extension().is_some_and(|x| x == "rs") {
+            bodies.push_str(&std::fs::read_to_string(&path).unwrap());
+        }
+    }
+    for c in testsupport::oas_monomorphizations().unwrap() {
+        assert!(
+            !bodies.contains(&format!("pub struct {} {{", c.schema)),
+            "{} still emits as a transport DTO instead of resolving to {}",
+            c.schema,
+            c.rust_type,
+        );
+    }
+    assert!(
+        bodies.contains("pub contribution: openehr_base::prelude::ObjectRef,"),
+        "the VERSION `contribution` field no longer resolves to the spec OBJECT_REF",
+    );
+}
+
+/// The shared-module fallback document carries the `allOf` BASE closure of the
+/// hoisted schemas, not the hoisted names alone.
+///
+/// `emit_common` flattens an `allOf` composition by resolving the base `$ref`
+/// through the very document it is emitting from. A document holding only the
+/// hoisted names leaves that ref dangling, and the struct silently ships with
+/// just its own `properties` — the truncation that shipped `Clstr` without a
+/// single `ITEM`/`LOCATABLE` member.
+#[test]
+fn merged_schema_fallback_carries_the_allof_base_closure() {
+    let (names, bases) = testsupport::merged_fallback_schema_names().unwrap();
+    assert!(
+        !bases.is_empty(),
+        "no hoisted schema composes an `allOf` base — this test has lost its subject",
+    );
+    for base in &bases {
+        assert!(
+            names.contains(base),
+            "the merged fallback document omits the `allOf` base {base:?}, so every schema \
+             composing it emits allOf-truncated",
+        );
+    }
+}
+
+// ── vendored `default` facet ↔ the hand-written residue ─────────────────────
+
+/// Every `default` facet the vendored schemas carry is accounted for: either
+/// the emitter renders it into a literal Rust default, or it is a NAMED
+/// un-renderable adjudication. Nothing is silently dropped.
+///
+/// The facet is an undeclared extension to the released persistence model (LANG
+/// `docs/UML/classes/org.openehr.lang.bmm_persistence.p_bmm_property.adoc`
+/// declares no `default` attribute), which is exactly why every occurrence needs
+/// a disposition rather than an assumption.
+#[test]
+fn vendored_default_facets_are_totally_partitioned() {
+    let facets = testsupport::vendored_defaults().unwrap();
+    assert!(
+        !facets.is_empty(),
+        "the vendored schemas carry `default` facets — the loader dropped them again",
+    );
+    for f in &facets {
+        assert!(
+            f.rendered.is_some() || testsupport::default_unrenderable(&f.owner, &f.field),
+            "{}: {}.{} carries the vendored default {:?}, which the emitter neither renders nor \
+             adjudicates as un-renderable — add the derivation or an UNRENDERABLE_DEFAULTS entry",
+            f.key,
+            f.owner,
+            f.field,
+            f.facet,
+        );
+    }
+    // and the reverse: no adjudicated exclusion is stale (it must still be an
+    // un-rendered vendored facet).
+    for (owner, field) in [
+        ("RESOURCE_DESCRIPTION", "parent_resource"),
+        ("CODE_SET", "status"),
+        ("TERMINOLOGY_GROUP", "status"),
+        ("CODE", "status"),
+        ("TERMINOLOGY_CONCEPT", "status"),
+    ] {
+        assert!(
+            facets
+                .iter()
+                .any(|f| f.owner == owner && f.field == field && f.rendered.is_none()),
+            "{owner}.{field} is adjudicated un-renderable but carries no un-rendered vendored \
+             facet — the entry is stale",
+        );
+    }
+}
+
+/// The hand-written `field_default` table is the RESIDUE of the vendored facet,
+/// never a duplicate of it: no entry may name a property that already carries a
+/// renderable vendored `default`.
+///
+/// Without this, the loaded input and the hand table can silently disagree —
+/// which is precisely what happened while the loader dropped the facet
+/// (`Point_interval` declared all four flags WITH defaults and got none, because
+/// the table keyed only the inherited `Interval` sites).
+#[test]
+fn hand_written_field_defaults_never_duplicate_a_vendored_facet() {
+    let facets = testsupport::vendored_defaults().unwrap();
+    for (owner, field) in testsupport::hand_written_defaults() {
+        assert!(
+            !facets
+                .iter()
+                .any(|f| f.owner == owner && f.field == field && f.rendered.is_some()),
+            "field_default entry {owner}.{field} duplicates a renderable vendored `default` \
+             facet — delete it and let the derivation win",
+        );
+    }
+}
+
+/// The vendored facet reaches the emitted canonical-JSON reader: the four
+/// `Point_interval` flags — the ONLY place the BASE schema states the interval
+/// default — now carry it, exactly as the inherited `Proper_interval` sites do.
+#[test]
+fn point_interval_flags_carry_their_vendored_defaults() {
+    let facets = testsupport::vendored_defaults().unwrap();
+    for (field, expected) in [
+        ("lower_unbounded", "false"),
+        ("upper_unbounded", "false"),
+        ("lower_included", "true"),
+        ("upper_included", "true"),
+    ] {
+        let f = facets
+            .iter()
+            .find(|f| f.owner == "Point_interval" && f.field == field)
+            .unwrap_or_else(|| panic!("Point_interval.{field} carries no vendored default"));
+        assert_eq!(
+            f.rendered.as_deref(),
+            Some(expected),
+            "Point_interval.{field}",
+        );
+    }
+}
+
+// ── RM/BASE twin classes (two spec generations, both emitted) ───────────────
+
+/// Five class names are declared by BOTH the RM 1.2.0 and the BASE 1.3.0 BMM.
+/// That is spec-mandated, not accidental duplication (RM
+/// `docs/common/master08-resource_package.adoc` keeps the ADL-1.4 resource
+/// package "retained only while needed by AOM 1.4 based archetypes and tools",
+/// and BASE `docs/foundation_types/master00-amendment_record.adoc` adds
+/// `CODE_PHRASE` to Foundation Types as a LEGACY class for AOM 1.4) — so both
+/// generations are emitted, each into its owning component's crate.
+///
+/// This pins the twin set and the member divergences that motivate it, so a
+/// re-vendored input that silently unifies or further diverges them fails here
+/// with the adjudication in view (`plan::composition`'s module note).
+#[test]
+fn rm_base_twin_classes_keep_both_generations() {
+    let twins = [
+        "AUTHORED_RESOURCE",
+        "CODE_PHRASE",
+        "RESOURCE_DESCRIPTION",
+        "RESOURCE_DESCRIPTION_ITEM",
+        "TRANSLATION_DETAILS",
+    ];
+    for class in twins {
+        for key in ["rm", "base"] {
+            assert!(
+                testsupport::declared_attributes(key, class)
+                    .unwrap()
+                    .is_some(),
+                "{key} no longer declares the twin class {class}",
+            );
+        }
+    }
+
+    // The ADL-1.4 generation's two member placements that look like defects and
+    // are not: the RM twin keeps the pre-SPECPUB-6 spelling, and puts
+    // `copyright` on the ITEM (which the vendored ADL-1.4 `Resource.xsd` also
+    // does), while the BASE twin carries the corrected/relocated forms.
+    let rm_translation = testsupport::declared_attributes("rm", "TRANSLATION_DETAILS")
+        .unwrap()
+        .unwrap();
+    let base_translation = testsupport::declared_attributes("base", "TRANSLATION_DETAILS")
+        .unwrap()
+        .unwrap();
+    assert!(
+        rm_translation.contains("accreditaton") && !rm_translation.contains("accreditation"),
+        "the RM (ADL-1.4) TRANSLATION_DETAILS no longer carries the retained `accreditaton` \
+         spelling — re-adjudicate against RM \
+         docs/UML/classes/org.openehr.rm.common.translation_details.adoc",
+    );
+    assert!(
+        base_translation.contains("accreditation") && !base_translation.contains("accreditaton"),
+        "the BASE TRANSLATION_DETAILS no longer carries the SPECPUB-6-corrected `accreditation` \
+         spelling",
+    );
+
+    let rm_item = testsupport::declared_attributes("rm", "RESOURCE_DESCRIPTION_ITEM")
+        .unwrap()
+        .unwrap();
+    let base_description = testsupport::declared_attributes("base", "RESOURCE_DESCRIPTION")
+        .unwrap()
+        .unwrap();
+    assert!(
+        rm_item.contains("copyright"),
+        "the RM (ADL-1.4) RESOURCE_DESCRIPTION_ITEM lost `copyright`, which the vendored \
+         AM/Release-1.4 Resource.xsd also declares there",
+    );
+    assert!(
+        base_description.contains("copyright"),
+        "the BASE RESOURCE_DESCRIPTION lost `copyright`",
+    );
+}


### PR DESCRIPTION
The codegen cluster batch: 3 fixes landed, 2 issues refuted first-hand with pin tests, 2 rewrite-scale items adjudicated and deferred with their evidence recorded.

- **#1700** — the BMM loader reads the vendored `default` facet (44 properties); the hand `FIELD_DEFAULTS` table shrinks to its honest 4-entry residue; the 6 unrenderable facet values live in a named total-partition map. The bug this exposed: `Point_interval` — the one class the schema actually states the interval flags on — was the one class not getting them (the register grew 4 cited rows). Also recorded: the `default` facet is itself an undeclared P_BMM extension (LANG declares no such attribute), which is why the emitter derives conservatively.
- **#1844** — the five RM monomorphizations (`Clstr`, `DvIntervalOfDate(Time)`, `ObjectRefOf*`) stop emitting as `allOf`-truncated DTOs and resolve to the typed spec forms via a cited OAS-`title` decision map — restoring the mandatory `namespace`/`type` members the truncated `ObjectRef` DTO had dropped; `merged_schemas` carries the transitive `allOf` base closure.
- **#1839** — `ITEM_TAG` joins the validated-construction door scheme (extended from lexical forms to class invariants stated over own fields, with the decidability boundary documented): `ItemTag::new` runs `Inv_key_valid`/`Inv_value_valid`, the generated JSON/XML readers route through it, fields are private with accessors. App side (this PR): `validate_item_tag` is **deleted** — its callers construct through the door and map the refusal onto the same 422; a stored row that no longer constructs fails loud as the 500 class. Wire statuses unchanged.
- **#1665 / #1704 — refuted, closed as adjudicated:** the RM resource package is a deliberately-retained ADL-1.4 generation (RM master08 says so in its opening note; `copyright` is that generation's real shape per the released `Resource.xsd`), and BASE's legacy `CODE_PHRASE` is a deliberate SPECAM-82 *addition* for AOM 1.4 ("Retain for LEGACY only" in the BMM's own doc). Both pinned by `rm_base_twin_classes_keep_both_generations` + a module NOTE with the full citation chain. The one genuine defect (`accreditaton`) is upstream's — reported.
- **#1699 / #1730 — deferred with evidence:** the re-emission closures are real (computed first-hand, the helper left in-tree) but applying them re-points type families across `openehr-rm`/`openehr-its`/`app` — one regeneration phase for both, recorded on the issues.

Gates: fmt, clippy (codegen + all five spec crates + its + app, -D warnings), spec-crate suites 1047/1047, app suites 1477/1477 with the fallout, 8-target regeneration idempotence (shasum-identical double run).

Closes #1700
Closes #1844
Closes #1839
Closes #1665
Closes #1704