### PR TITLE
fix: wire cluster — the op-id collision gate and the closed CONTRIBUTION member read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,13 @@ workflow refuses a tag that has no matching section here.
   tag routes' 422 mapping stays); a stored tag row that no longer constructs
   is reported as the server fault it is instead of being served.
 
+- **An undeclared key on a CONTRIBUTION version member is refused (`400`,
+  named at its member path) instead of silently ignored.** The released
+  commit wire declares exactly six member properties
+  (`UpdateVersion.yaml`) plus the adjudicated `_type` self-tag; the member
+  seam was the last non-strict reader, accepting arbitrary extra keys
+  without a diagnostic while every other read surface refuses them.
+
 - **A CONTRIBUTION whose audit omits `committer` is now refused (`422`)
   instead of being attributed to the server's default identity.** The same
   released commit schema that requires `change_type` requires `committer`

--- a/app/ferroehr-rest/src/extensions/access/authz/classify.rs
+++ b/app/ferroehr-rest/src/extensions/access/authz/classify.rs
@@ -79,6 +79,12 @@ pub fn class_of(op: &str) -> Option<OperationClass> {
         | "directory_get_by_version_id" => Clinical,
 
         // ── CONTRIBUTION (op ids shared by the ehr + demographic groups) ─────
+        // ADJUDICATED SHARED IDS (#1707): the released OAS reuses these ids in
+        // the ehr AND demographic bundles; Clinical is deliberately correct
+        // for both families (RM change control governs demographic content
+        // identically), and the RBAC route map is (method, path)-keyed, so
+        // the two families never collide behaviourally. The system_log
+        // classifier's `adjudicated_shared_ids` gate pins collision-freedom.
         "contribution_create" | "contribution_get" => Clinical,
 
         // ── Item tags (clinical-resource metadata) ───────────────────────────

--- a/app/ferroehr-rest/src/system_log/classify.rs
+++ b/app/ferroehr-rest/src/system_log/classify.rs
@@ -116,6 +116,16 @@ pub fn lookup(op: &str) -> Option<Classification> {
         }
 
         // ── CONTRIBUTION (op ids shared by the ehr + demographic groups) ─────
+        //
+        // ADJUDICATED SHARED IDS (#1707): the released OAS reuses these
+        // `operationId`s in BOTH bundles (the vendored artifact is never
+        // edited, so the emitter must not diverge from it), and ONE
+        // classification is deliberately correct for both families — RM
+        // change control governs demographic content exactly as it does EHR
+        // content (RM common master06 applies to every VERSIONED_OBJECT), so
+        // a demographic CONTRIBUTION audits as the same Contribution class.
+        // The `adjudicated_shared_ids` gate below fails on any NEW cross-group
+        // duplicate, so a future reuse must be adjudicated here first.
         "contribution_create" => Classification::audited(Create, Contribution),
         "contribution_get" => Classification::audited(Read, Contribution),
 
@@ -261,6 +271,62 @@ mod tests {
             }
         }
         ops
+    }
+
+    /// The op ids the released OAS deliberately reuses across group bundles,
+    /// each adjudicated to ONE family-invariant classification (see the
+    /// CONTRIBUTION block in [`lookup`]). A NEW cross-group duplicate fails
+    /// [`adjudicated_shared_ids`] until it is adjudicated here (#1707).
+    const ADJUDICATED_SHARED: &[&str] = &["contribution_create", "contribution_get"];
+
+    /// Collision gate (#1707): an op id in more than one generated group
+    /// table is only legal when its shared classification is adjudicated —
+    /// the classifiers are op-id-keyed, so an unadjudicated duplicate could
+    /// silently classify one family as the other.
+    #[test]
+    fn adjudicated_shared_ids() {
+        use std::collections::BTreeMap;
+        let mut owners: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+        for (group, table) in [
+            ("ehr", openehr_its::rest::generated::ehr::ROUTES),
+            (
+                "definition",
+                openehr_its::rest::generated::definition::ROUTES,
+            ),
+            (
+                "demographic",
+                openehr_its::rest::generated::demographic::ROUTES,
+            ),
+            ("query", openehr_its::rest::generated::query::ROUTES),
+            ("admin", openehr_its::rest::generated::admin::ROUTES),
+            ("system", openehr_its::rest::generated::system::ROUTES),
+        ] {
+            for (_m, _p, op) in table {
+                let groups = owners.entry(op).or_default();
+                if !groups.contains(&group) {
+                    groups.push(group);
+                }
+            }
+        }
+        let unadjudicated: Vec<(&str, &Vec<&str>)> = owners
+            .iter()
+            .filter(|(op, groups)| groups.len() > 1 && !ADJUDICATED_SHARED.contains(*op))
+            .map(|(op, groups)| (*op, groups))
+            .collect();
+        assert!(
+            unadjudicated.is_empty(),
+            "op ids reused across generated groups without an adjudicated shared \
+             classification (#1707 — adjudicate in the classifier and extend \
+             ADJUDICATED_SHARED): {unadjudicated:?}"
+        );
+        // …and the adjudicated list itself never rots: every entry is still a
+        // real cross-group duplicate.
+        for op in ADJUDICATED_SHARED {
+            assert!(
+                owners.get(op).is_some_and(|g| g.len() > 1),
+                "{op} is no longer shared across groups — remove it from ADJUDICATED_SHARED"
+            );
+        }
     }
 
     /// Completeness guard: every generated operation id has an **explicit**

--- a/app/ferroehr/src/versioning/contribution.rs
+++ b/app/ferroehr/src/versioning/contribution.rs
@@ -280,7 +280,38 @@ const COMMITTABLE_MEMBER_TYPES: [&str; 2] = ["UPDATE_VERSION", "ORIGINAL_VERSION
 ///
 /// # Errors
 /// [`ServiceError::BadRequest`] naming the offending key.
-fn reject_foreign_version_identity(version: &Value) -> Result<(), ServiceError> {
+fn reject_foreign_version_identity(version: &Value, index: usize) -> Result<(), ServiceError> {
+    // THE CLOSED MEMBER READ (#1753): the released commit wire declares
+    // exactly six member properties (ITS-REST `schemas/ehr/UpdateVersion.yaml`
+    // — `preceding_version_uid`, `signature`, `lifecycle_state`,
+    // `attestations`, `data`, `commit_audit`), plus the adjudicated `_type`
+    // self-tag (overview `Resources.md` §Resource representation — the docs
+    // text outranks the OAS). Everything else is refused with the member
+    // index in the path, exactly like the strict reader everywhere else
+    // post-#1702 — the three keys below keep their richer diagnostics.
+    const DECLARED: [&str; 7] = [
+        "preceding_version_uid",
+        "signature",
+        "lifecycle_state",
+        "attestations",
+        "data",
+        "commit_audit",
+        "_type",
+    ];
+    const SPECIFICALLY_REFUSED: [&str; 3] = ["item", "uid", "other_input_version_uids"];
+    if let Some(map) = version.as_object() {
+        for key in map.keys() {
+            if !DECLARED.contains(&key.as_str()) && !SPECIFICALLY_REFUSED.contains(&key.as_str()) {
+                return Err(ServiceError::BadRequest(format!(
+                    "versions[{index}]/{key} is not a member of UPDATE_VERSION — the \
+                     released commit wire declares preceding_version_uid, signature, \
+                     lifecycle_state, attestations, data, commit_audit (ITS-REST \
+                     UpdateVersion.yaml), and a member may additionally self-tag with \
+                     _type; undeclared members are refused, never silently ignored"
+                )));
+            }
+        }
+    }
     if version.get("item").is_some() {
         return Err(ServiceError::BadRequest(
             "item is not a member of UPDATE_VERSION — it is the sole own attribute of \
@@ -430,8 +461,8 @@ pub(crate) async fn commit_version_set(
     // then existence/kind-checked in ONE batched statement, and the plan is
     // resolved to [`Change`]s without re-reading any JSON.
     let mut plan: Vec<PlannedVersion> = Vec::with_capacity(versions.len());
-    for version in versions {
-        reject_foreign_version_identity(version)?;
+    for (index, version) in versions.iter().enumerate() {
+        reject_foreign_version_identity(version, index)?;
         let token = version
             .get("commit_audit")
             .and_then(|a| a.get("change_type"))

--- a/app/ferroehr/tests/it/service_contribution.rs
+++ b/app/ferroehr/tests/it/service_contribution.rs
@@ -1754,6 +1754,51 @@ async fn foreign_version_identity_is_refused_on_the_commit_wire() {
     .expect("a member self-tagged as the class this wire commits is accepted");
 }
 
+/// THE CLOSED MEMBER READ (#1753): an undeclared key on a CONTRIBUTION
+/// version member is refused with the member index in the path — the released
+/// commit wire declares exactly six member properties (ITS-REST
+/// `UpdateVersion.yaml`) plus the adjudicated `_type` self-tag, and the strict
+/// reader discipline (post-#1702) admits nothing else silently. The valid
+/// twin is every accepted member in this suite.
+#[tokio::test]
+async fn an_undeclared_contribution_member_key_is_refused_with_its_path() {
+    let db = testkit::db().await.expect("testkit database");
+    let svc = FerroEhrService::new(db.pool());
+    let ehr_id = create_ehr(&svc).await;
+    let ehr_uuid: ferroehr::ids::EhrId = ehr_id.parse().expect("ehr uuid");
+
+    let mut member = json!({
+        "commit_audit": {
+            "change_type": change_type("249", "creation"),
+            "committer": committer("author")
+        },
+        "lifecycle_state": change_type("532", "complete"),
+        "data": composition("closed member read")
+    });
+    member
+        .as_object_mut()
+        .expect("member object")
+        .insert("contribution".to_owned(), json!({"id": "x"}));
+
+    let err = svc
+        .create_ehr_contribution(
+            ehr_uuid,
+            json!({
+                "versions": [member],
+                "audit": {
+                    "change_type": change_type("249", "creation"),
+                    "committer": committer("author")
+                }
+            }),
+        )
+        .await
+        .expect_err("an undeclared member key must be refused");
+    assert!(
+        err.message.contains("versions[0]/contribution"),
+        "the refusal names the key at its member path, got {err:?}"
+    );
+}
+
 /// The CONTRIBUTION's own `audit.change_type` is REQUIRED and never derived.
 ///
 /// RM common `UML/classes/org.openehr.rm.common.audit_details.adoc` §Attributes


### PR DESCRIPTION
Two wire-cluster items from the close loop:

- **#1707** — the cross-group operation-id collision is gated and the shared ids adjudicated: the released OAS reuses `contribution_create`/`contribution_get` in the ehr and demographic bundles (the vendored artifact is never edited, so the emitter must not diverge from it); one classification is deliberately correct for both families — RM change control governs demographic content identically, and the RBAC route map is `(method, path)`-keyed. The new `adjudicated_shared_ids` gate fails on any NEW cross-group duplicate and on a rotted allowlist entry, so an unadjudicated reuse can never silently classify one family as the other.
- **#1753** — the CONTRIBUTION member seam is a closed read: the released commit wire declares exactly six member properties (`UpdateVersion.yaml`) plus the adjudicated `_type` self-tag; every other key refuses `400` named at `versions[i]/key` (the three specifically-refused keys keep their richer diagnostics). Refusal twin pinned; the CNF case rides the next catalogue batch.

Gates: fmt, clippy (-D warnings), the contribution/classifier suites 54/54 (full battery ran on the pre-rebase branch; the rebase touched only CHANGELOG).

Closes #1707
Closes #1753