### PR TITLE
fix: rapid batch — six adjudications and typed-mutator conversions

### DIFF
--- a/app/ferroehr/src/service/ehr/contributions.rs
+++ b/app/ferroehr/src/service/ehr/contributions.rs
@@ -155,14 +155,18 @@ impl FerroEhrService {
         // lifecycle_state, attestations, signature } … ], audit }`. The typed
         // shapes serialize to exactly those field names.
         //
-        // NOTE: this typed → wire-JSON → re-parse round-trip is a known
-        // glue seam. It is now shape-faithful in both directions — the
-        // generated DTOs ARE the released wire shape (absent optionals are
-        // omitted rather than emitted as JSON `null`, and `change_type` is
-        // the `DV_CODED_TEXT` the released `UpdateAudit.yaml` declares) — so
-        // what is re-parsed is exactly what a client would have sent.
-        // TODO(#1820): replace the serialize→re-parse round trip with a
-        // native typed handoff into `commit_version_set`.
+        // NOTE (adjudicated 2026-08-04, #1820 — no openEHR spec governs the
+        // internal seam; our own design): this typed → wire-JSON bridge is
+        // DELIBERATE, not residue. `commit_version_set` is the ONE
+        // change-set engine (classification, m4 copy-down, attestation-only
+        // and delete members) and deliberately operates on the heterogeneous
+        // wire shape (the owner-approved Value lane — #1694 family 4, ruled
+        // 2026-08-03); a parallel typed entry would fork those semantics for
+        // this SM-only caller. The bridge is shape-faithful in both
+        // directions — the generated DTOs ARE the released wire shape
+        // (absent optionals omitted, `change_type` the `DV_CODED_TEXT` of
+        // the released `UpdateAudit.yaml`) — so what is re-parsed is exactly
+        // what a client would have sent.
         let versions_json = openehr_its::json::to_canonical_value(&versions);
         let audit_json = openehr_its::json::to_canonical_value(&an_audit);
         let body = json!({ "versions": versions_json, "audit": audit_json });

--- a/app/ferroehr/src/service/ehr/status.rs
+++ b/app/ferroehr/src/service/ehr/status.rs
@@ -170,7 +170,7 @@ impl FerroEhrService {
     pub(in crate::service) async fn status_mutate(
         &self,
         ehr_id: EhrId,
-        mutate: impl FnOnce(&mut serde_json::Map<String, Value>),
+        mutate: impl FnOnce(&mut EhrStatus) -> Result<(), ServiceError>,
     ) -> Result<crate::versioning::change::Committed, ServiceError> {
         // Resolve the current EHR_STATUS versioned object once and read its
         // body; the resolved `vo_id` threads into `commit_status` so its commit
@@ -196,30 +196,29 @@ impl FerroEhrService {
             .as_ref()
             .map(|m| m.uid.clone())
             .unwrap_or_default();
-        let mut body = current.body;
-        if let Value::Object(map) = &mut body {
-            // The read injects `uid`; drop it so the re-commit carries only the
-            // mutated EHR_STATUS content (the server assigns the new version
-            // id).
-            map.remove("uid");
-            mutate(map);
-        }
+        // The stored fragment decodes ONCE into the typed EHR_STATUS and the
+        // mutation operates on the typed value (#1846 — no Map round trip):
+        // a mutation that cannot produce a legal EHR_STATUS is unrepresentable
+        // (the typed fields) or refused by the closure itself (the
+        // client-supplied `other_details` decode, SM `i_ehr_status.adoc`
+        // §update_other_details).
+        let mut status: EhrStatus = openehr_its::json::from_canonical_value(&current.body)
+            .map_err(|e| {
+                ServiceError::Unprocessable(
+                    crate::service::error::Violation::new("is not a canonical EHR_STATUS")
+                        .with_path("EHR_STATUS")
+                        .with_decode_failure(&e),
+                )
+            })?;
+        // The read injects `uid`; drop it so the re-commit carries only the
+        // mutated EHR_STATUS content (the server assigns the new version id).
+        status.uid = None;
+        mutate(&mut status)?;
         // The SM flag mutators commit a modification of the existing
         // EHR_STATUS: carry the operation's own change type so the commit
         // audit resolves without a client envelope (the `direct()` placeholder
         // is `249|creation|`, which would contradict this update —
         // `versioning::audit::merged_change_type`).
-        // The mutated root is re-typed through the strict canonical reader:
-        // a mutation that broke the EHR_STATUS shape (an `other_details` that
-        // is not an ITEM_STRUCTURE — SM `i_ehr_status.adoc`
-        // §update_other_details) is refused here rather than committed.
-        let status: EhrStatus = openehr_its::json::from_canonical_value(&body).map_err(|e| {
-            ServiceError::Unprocessable(
-                crate::service::error::Violation::new("is not a canonical EHR_STATUS")
-                    .with_path("EHR_STATUS")
-                    .with_decode_failure(&e),
-            )
-        })?;
         let mut version = crate::service::version_update::direct_envelope(status);
         *crate::service::version_update::audit_base_mut(&mut version.commit_audit).change_type =
             crate::service::version_update::change_type_coded(change_type::MODIFICATION);
@@ -672,8 +671,9 @@ impl FerroEhrService {
     /// fails.
     pub async fn set_ehr_queryable(&self, an_ehr_id: EhrId) -> Result<String, SmError> {
         Ok(self
-            .status_mutate(an_ehr_id, |m| {
-                m.insert("is_queryable".to_owned(), Value::Bool(true));
+            .status_mutate(an_ehr_id, |s| {
+                s.is_queryable = true;
+                Ok(())
             })
             .await?
             .version_uid())
@@ -687,8 +687,9 @@ impl FerroEhrService {
     /// fails.
     pub async fn clear_ehr_queryable(&self, an_ehr_id: EhrId) -> Result<String, SmError> {
         Ok(self
-            .status_mutate(an_ehr_id, |m| {
-                m.insert("is_queryable".to_owned(), Value::Bool(false));
+            .status_mutate(an_ehr_id, |s| {
+                s.is_queryable = false;
+                Ok(())
             })
             .await?
             .version_uid())
@@ -703,8 +704,9 @@ impl FerroEhrService {
     /// fails.
     pub async fn set_ehr_modifiable(&self, an_ehr_id: EhrId) -> Result<String, SmError> {
         Ok(self
-            .status_mutate(an_ehr_id, |m| {
-                m.insert("is_modifiable".to_owned(), Value::Bool(true));
+            .status_mutate(an_ehr_id, |s| {
+                s.is_modifiable = true;
+                Ok(())
             })
             .await?
             .version_uid())
@@ -721,8 +723,9 @@ impl FerroEhrService {
         // Committable on the EHR it disables: the write guard scopes to EHR
         // *contents*, never to EHR_STATUS (RM ehr master04 §EHR Active Status).
         Ok(self
-            .status_mutate(an_ehr_id, |m| {
-                m.insert("is_modifiable".to_owned(), Value::Bool(false));
+            .status_mutate(an_ehr_id, |s| {
+                s.is_modifiable = false;
+                Ok(())
             })
             .await?
             .version_uid())
@@ -742,8 +745,20 @@ impl FerroEhrService {
     ) -> Result<String, SmError> {
         // Boxed: the typed EHR_STATUS envelope makes the mutate future large
         // enough to matter on the stack (clippy `large_futures`).
-        Ok(Box::pin(self.status_mutate(an_ehr_id, move |m| {
-            m.insert("other_details".to_owned(), a_details);
+        Ok(Box::pin(self.status_mutate(an_ehr_id, move |s| {
+            // The client-supplied details decode through the strict reader —
+            // a non-ITEM_STRUCTURE refuses here, path-named (the same
+            // judgement the retired post-mutation re-decode made).
+            s.other_details = Some(openehr_its::json::from_canonical_value(&a_details).map_err(
+                |e| {
+                    ServiceError::Unprocessable(
+                        crate::service::error::Violation::new("is not a canonical ITEM_STRUCTURE")
+                            .with_path("EHR_STATUS/other_details")
+                            .with_decode_failure(&e),
+                    )
+                },
+            )?);
+            Ok(())
         }))
         .await?
         .version_uid())

--- a/app/ferroehr/src/service/mod.rs
+++ b/app/ferroehr/src/service/mod.rs
@@ -17,6 +17,16 @@
 //! authenticated-committer context ([`committer`]), the crate-internal
 //! ITS-REST datetime-request-parameter decoder (`datetime`), and the SM
 //! validity checker ([`validity`]).
+//!
+//! NOTE (adjudicated 2026-08-04, #1845 — no openEHR spec governs the internal
+//! layering; the SM component map in `docs/architecture.md` is our design):
+//! the ~90 one-expression `Ok(self.inner(...).await?)` methods across the SM
+//! modules are DELIBERATE, not dead weight. Each is the SM-named operation
+//! of the platform service model (`docs/specs/openehr/SM/`) AND the error
+//! boundary where a `ServiceError` becomes the SM `SmError` the callers
+//! consume — collapsing them would delete the SM component map and scatter
+//! the conversion across every call site. Keep the layer; a new SM operation
+//! gets its SM-named method here even when the body is one expression.
 
 pub mod admin;
 pub mod definition;

--- a/crates/openehr-its/tests/fixtures/twins/folder_with_items.valid.json
+++ b/crates/openehr-its/tests/fixtures/twins/folder_with_items.valid.json
@@ -56,6 +56,11 @@
   "items": [],
   "details": {
     "_type": "ITEM_TREE",
+    "name": {
+      "_type": "DV_TEXT",
+      "value": "Folder details"
+    },
+    "archetype_node_id": "at0001",
     "items": [
       {
         "_type": "ELEMENT",
@@ -74,5 +79,6 @@
   "name": {
     "_type": "DV_TEXT",
     "value": " 2nd Updated Root name on 27th nov 2019"
-  }
+  },
+  "archetype_node_id": "at0001"
 }

--- a/crates/openehr-its/tests/it/common.rs
+++ b/crates/openehr-its/tests/it/common.rs
@@ -252,17 +252,6 @@ pub(crate) fn excluded(name: &str) -> Option<&'static str> {
         // document's identifier defects, but the FOLDER it corrects also carries
         // an RM-1.1-era `details` ITEM_TREE with neither `name` nor
         // `archetype_node_id`, both mandatory on `LOCATABLE` in RM 1.2
-        // (`docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.common.locatable.adoc`
-        // §Attributes) — the SAME class as `ehr_other_details.json` above.
-        // Completing it means AUTHORING a name and a node id the source document
-        // never stated, which is a fixture-authoring decision, not a re-tagging;
-        // it is registered here rather than left to a silent shape skip (which
-        // is how this twin went unexercised by every gate until the exclusion
-        // mechanisms were unified).
-        "twins/folder_with_items.valid.json" => reason(
-            "RM 1.1-era: FOLDER.details ITEM_TREE omits mandatory LOCATABLE.name + \
-                    archetype_node_id (RM 1.2); completing the twin needs authored values",
-        ),
         _ => None,
     }
 }

--- a/crates/openehr-its/tests/vendor/PROVENANCE.md
+++ b/crates/openehr-its/tests/vendor/PROVENANCE.md
@@ -71,6 +71,20 @@ invalid negatives, defective upstream fixtures (each with a repo-authored
 VALID TWIN under `tests/fixtures/twins/`), and RM-1.1-era documents that
 omit members RM 1.2 makes mandatory.
 
+## `ips_invalid.json` (adjudicated 2026-08-04, #1824)
+
+The `_invalid` in the name is TEMPLATE-relative, not RM-relative: the
+document is a perfectly legal canonical-JSON COMPOSITION (so the
+serialization gates here correctly exercise and PASS it — it needs no
+registry entry), whose defects are out-of-range magnitudes and coded values
+outside the IPS template's value sets. Its refusals are pinned where that
+judgement lives: the template-conformance suite
+(`app/ferroehr/tests/it/service_validation.rs`) commits it against the IPS
+OPT and asserts the 422 class. An earlier revision of this document called
+it "excluded"; that claim was stale — the single registry
+(`tests/it/common.rs`) is the only exclusion source, and this file names
+none.
+
 ## RM version note
 
 The SDK corpus is authored for RM 1.0.4 (its `archetype_details.rm_version`


### PR DESCRIPTION
Speed-mode batch (owner directive: scoped gates per fix, batch verification at boundaries):

- **#1824** — `ips_invalid.json` adjudicated: template-relative invalidity (legal canonical RM), correctly exercised by the serialization gates; the stale "excluded" provenance claim was already superseded by the single registry — the adjudication is now recorded in PROVENANCE.
- **#1845** — the ~90 one-expression SM methods adjudicated DELIBERATE (the SM-named operation surface + the ServiceError→SmError boundary); module-level NOTE.
- **#1846** — the five SM flag mutators operate on the typed `EhrStatus` (one decode, typed mutation, illegal states unrepresentable; `update_other_details` decodes client details through the strict reader at the mutation).
- **#1820** — the SM `commit_contribution` bridge adjudicated deliberate: one heterogeneous change-set engine (the owner-approved Value lane), shape-faithful in both directions; the TODO becomes the settled NOTE.
- **#1825** — the `folder_with_items` valid twin completed (RM 1.2.0 mandatory LOCATABLE members authored); its exclusion-registry entry ratcheted away; exercised green by every gate.
- **#1828** — the typed-FHIR evaluation recorded and closed: typed islands over the Value-based dynamic mapping core (matching the family-8 fixed-shapes ruling); the islands ride #1694's condition scope.

Also closed by adjudication without code (comments on the issues): **#1656** (extract replay is the spec-grounded import contract — master06 §Copying), **#1657** (the JSON/XML 400-422 asymmetry dissolved by the #1727 ruling; residuals re-homed to #1858).

Per-fix scoped suites green (status/tag/corpus/fidelity slices); workspace clippy clean.

Closes #1824
Closes #1846
Closes #1825