### PR TITLE
fix: rapid batch 4 — ITS-JSON oracle pin, AQL existential LIKE/matches, EXTRACT criteria, dispatch move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- AQL `LIKE` and `matches` predicates on multi-valued paths now use the existential (any-match) lowering the comparison operators already use — a row is matched when ANY node on the path satisfies the predicate, instead of an order-undefined single-node pick (#1448).
 - The admin EHR dump/load archive now carries every `vo_attestation` row (with its `at_committal` flag), and load re-persists them verbatim — a restored version keeps its attestations and its stored signature verifies under `verify_on_read = strict` (#1685).
 - **A node id carrying the at/id code leader but failing the code grammar is
   refused (`at0abc`).** AOM2's own code predicate is leader-based, so such a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
+- EHR-Extract export now evaluates `EXTRACT_SPEC.criteria`: AQL criteria queries select each entity's primary set `$ehr`-bound (the entity's EHR scopes the query and a literal `$ehr` parameter binds to its id); a non-AQL formalism or an unparseable criterion is refused with `400`. The former blanket criteria refusal is gone (#1736).
 - EHR Extract import now enforces the copy closure (RM common master06 §Copying): a received branch version is refused with `400` unless its fork-point trunk version and same-branch predecessor travel in the same extract or are already stored (#1770).
 - **FOLDER (DIRECTORY) resources can now carry ITEM_TAGs.** ITS-REST overview
   `Requests_and_responses.md` §openehr-item-tag and openehr-version-item-tag

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5301,6 +5301,7 @@ dependencies = [
  "serde",
  "serde_jcs",
  "serde_json",
+ "serde_path_to_error",
  "thiserror 2.0.19",
  "uuid",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "bytes",
- "crypto-common 0.1.6",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -80,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -110,9 +110,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amq-protocol"
-version = "10.6.2"
+version = "10.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eab68e8836c5812a01b34c5364d28db50bf686b442e902d9d93e4472318d86e"
+checksum = "b63f30a81ad95c7a278080be6d993d5b3e971d93e1b00bd894067220fc756804"
 dependencies = [
  "amq-protocol-tcp",
  "amq-protocol-types",
@@ -124,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol-tcp"
-version = "10.6.2"
+version = "10.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8689f976dbd9864922f4f53e01ad2b43700ed3eb1bb5667b260522f291434dae"
+checksum = "2b1bcecdd743111f05c26294d26b887ba6b2e4789c27515aa48f0fe32066e96c"
 dependencies = [
  "amq-protocol-uri",
  "async-rs",
@@ -137,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol-types"
-version = "10.6.2"
+version = "10.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27894e9e57d07f701251aeee3d2ab3d7d114bc830bf722d6626027eb55f3b222"
+checksum = "8a268a50e97bd5d52292a8b96636f6436215def6f3d128fb8218318f5feb4c33"
 dependencies = [
  "cookie-factory",
  "nom 8.0.0",
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol-uri"
-version = "10.6.2"
+version = "10.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64fd5ca63f1b8cba2309aaec8595483c36f3a671225d5ab9fe8265adb9213514"
+checksum = "8a34581b010818ef3da6b5a853e94f6438b3903914baba77a15f7fb2c7ad8958"
 dependencies = [
  "amq-protocol-types",
  "percent-encoding",
@@ -235,16 +235,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1384d3fe1eecb464229fcf6eebb72306591c56bf27b373561489458a7c73027d"
 dependencies = [
  "futures",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "approx"
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "ar_archive_writer"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4087686b4b0a3427190bae57a1d9a478dbb2d40c5dc1bd6e2b6d797913bdd348"
+checksum = "73cd58deff2140a0a8eae87e417bd01db68a33e148aa93d1e8cd837e55e312b6"
 dependencies = [
  "object",
 ]
@@ -334,7 +334,7 @@ dependencies = [
  "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 
@@ -346,7 +346,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -358,7 +358,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -387,15 +387,15 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08648fef353ab39a9d26f909ad53fc4f071be4c91853b78523f5cc3d9e5ebffd"
+checksum = "b18457efd137254e016bbde5e1d88df61c4e1a5ae2223746e56123bac6af2463"
 dependencies = [
  "futures-core",
  "libc",
  "portable-atomic",
  "rustc-hash",
- "rustix 0.38.44",
+ "rustix",
  "tokio",
  "tokio-stream",
  "xattr",
@@ -428,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -518,7 +518,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -529,13 +529,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -564,7 +564,7 @@ dependencies = [
  "manyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -580,7 +580,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "quote-use",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -591,9 +591,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.1"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -602,9 +602,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
@@ -640,7 +640,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1 0.10.6",
+ "sha1 0.10.7",
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
@@ -727,6 +727,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,8 +770,8 @@ checksum = "f2c044f98f86f15414668d6c8187c7e4fadab1ad2b31680f648703e0fe07c555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
- "thiserror 2.0.18",
+ "syn 2.0.119",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -776,9 +782,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
 ]
@@ -862,7 +868,7 @@ checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bollard-buildkit-proto",
  "bollard-stubs",
  "bytes",
@@ -880,7 +886,7 @@ dependencies = [
  "log",
  "num",
  "pin-project-lite",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
@@ -888,7 +894,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "tokio",
  "tokio-stream",
@@ -936,9 +942,9 @@ checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "borsh"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
+checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
 dependencies = [
  "borsh-derive",
  "bytes",
@@ -947,15 +953,15 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
+checksum = "d8f347189c62a579b8cd5f80714efa178f52e461dc2e6d701d264f5ff22e566c"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1055,9 +1061,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "camellia"
@@ -1071,9 +1077,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.2.4"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
+checksum = "bb1307f12aa967b5a58416e87b3653360e0fd614a016b6e970db08fecbb1b80d"
 
 [[package]]
 name = "cast5"
@@ -1095,9 +1101,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1107,14 +1113,15 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy"
-version = "4.11.2"
+version = "4.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fdd98501120bc31fc09f92d3f58c489f4ee4b846904109ac63dd8256de7b84d"
+checksum = "f73547a0114dff845fcb8d4877548a665fb8ff949a30cb0963444d6c30ffd962"
 dependencies = [
  "cedar-policy-core",
  "cedar-policy-formatter",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "linked-hash-map",
+ "linked_hash_set",
  "miette",
  "ref-cast",
  "semver",
@@ -1122,19 +1129,19 @@ dependencies = [
  "serde_json",
  "serde_with",
  "smol_str",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "cedar-policy-core"
-version = "4.11.2"
+version = "4.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1d41088b497e39b6789e87e05ad6549b7f64a663a4d6ecd73a748dc3a9a98a9"
+checksum = "c9d9ec16707c7b60aa73b922dc255ec0b97b6892e8e58e45188b15d874ca3590"
 dependencies = [
  "chrono",
  "educe",
  "either",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "lalrpop",
  "lalrpop-util",
  "linked-hash-map",
@@ -1149,18 +1156,18 @@ dependencies = [
  "serde_with",
  "smol_str",
  "stacker",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "unicode-security",
 ]
 
 [[package]]
 name = "cedar-policy-formatter"
-version = "4.11.2"
+version = "4.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb6c28be47d77dcbc04c2a80181a2c0db9725ed60d24832c6401396cc2ae114b"
+checksum = "2483b2fa74f74b1b3945bec59feb7a3fc0ea56b6fb35564ef300884dd8415d4b"
 dependencies = [
  "cedar-policy-core",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "logos",
  "miette",
  "pretty",
@@ -1185,9 +1192,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -1234,15 +1241,15 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common 0.1.6",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1250,9 +1257,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1262,14 +1269,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1328,7 +1335,7 @@ dependencies = [
  "jsonschema",
  "jsonwebtoken",
  "pgp",
- "quick-xml 0.41.0",
+ "quick-xml",
  "regex",
  "reqwest 0.13.4",
  "semver",
@@ -1337,7 +1344,7 @@ dependencies = [
  "serde_jcs",
  "serde_json",
  "sha2 0.11.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "urlencoding",
  "uuid",
 ]
@@ -1350,7 +1357,7 @@ checksum = "a9dbbdc4b4d349732bc6690de10a9de952bd39ba6a065c586e26600b6b0b91f5"
 dependencies = [
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -1725,9 +1732,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
@@ -1806,7 +1813,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1857,7 +1864,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1870,7 +1877,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1881,7 +1888,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1892,7 +1899,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1911,9 +1918,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "dbl"
@@ -1951,7 +1958,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1973,7 +1980,7 @@ dependencies = [
  "defmt-parser",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1982,7 +1989,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -2020,7 +2027,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2040,7 +2047,7 @@ checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2051,7 +2058,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2072,7 +2079,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2082,7 +2089,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2104,7 +2111,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.118",
+ "syn 2.0.119",
  "unicode-xid",
 ]
 
@@ -2131,7 +2138,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "const-oid 0.9.6",
- "crypto-common 0.1.6",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -2170,13 +2177,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2293,21 +2300,21 @@ dependencies = [
 
 [[package]]
 name = "educe"
-version = "0.6.0"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+checksum = "e451fac8dd8dece16234604bf1efce6e90fddd8ab6ad4d66eec0eca5160959dd"
 dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 dependencies = [
  "serde",
 ]
@@ -2391,22 +2398,22 @@ dependencies = [
 
 [[package]]
 name = "enum-ordinalize"
-version = "4.4.1"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
+checksum = "89dd01549b09589510cf0647475075d12071456586d70f5c75c98ae2a5537677"
 dependencies = [
  "enum-ordinalize-derive",
 ]
 
 [[package]]
 name = "enum-ordinalize-derive"
-version = "4.4.1"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
+checksum = "a65863d15a4ce2888bd2f0f543cc963d3879c3a022c8ee43f6141d479a3ac815"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2454,11 +2461,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -2496,16 +2502,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "fast-srgb8"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
-
-[[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ferroehr"
@@ -2543,8 +2543,8 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "pgp",
- "quick-xml 0.41.0",
- "rand 0.8.6",
+ "quick-xml",
+ "rand 0.8.7",
  "regex",
  "reqwest 0.13.4",
  "rustls",
@@ -2560,7 +2560,7 @@ dependencies = [
  "testcontainers",
  "testcontainers-modules",
  "testkit",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-rustls",
  "toml",
@@ -2604,7 +2604,7 @@ dependencies = [
  "serde_json",
  "thaw",
  "thirtyfour",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tower-sessions",
  "tracing",
@@ -2652,7 +2652,7 @@ dependencies = [
  "testcontainers",
  "testcontainers-modules",
  "testkit",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tower",
  "tower-http 0.7.0",
@@ -2825,7 +2825,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
 dependencies = [
- "rustix 1.1.4",
+ "rustix",
  "tokio",
  "windows-sys 0.61.2",
 ]
@@ -2844,9 +2844,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2859,9 +2859,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2869,15 +2869,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2897,9 +2897,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-lite"
@@ -2916,13 +2916,13 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2938,21 +2938,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2982,9 +2982,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.9"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -3040,7 +3040,7 @@ checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3055,9 +3055,9 @@ dependencies = [
 
 [[package]]
 name = "globset"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -3072,7 +3072,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "ignore",
  "walkdir",
 ]
@@ -3137,9 +3137,9 @@ dependencies = [
 
 [[package]]
 name = "granit-parser"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a8a3d7c6a0b0e077d7f8d21df7ec74ce97870ef25f40af4336df33b6cfdf1d4"
+checksum = "c60388b03522b86e24b6b45952255279936b08a871775156fc89c94e792d21d8"
 dependencies = [
  "arraydeque",
  "smallvec",
@@ -3241,15 +3241,15 @@ dependencies = [
 
 [[package]]
 name = "hdrhistogram"
-version = "7.5.4"
+version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+checksum = "f49d1053f4708f0af3cf9fc5bffc7e68a914a3c45becb231c80068c9c3f78bea"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "byteorder",
  "crossbeam-channel",
  "flate2",
- "nom 7.1.3",
+ "nom 8.0.0",
  "num-traits",
 ]
 
@@ -3294,7 +3294,7 @@ dependencies = [
  "ipnet",
  "jni",
  "rand 0.10.2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tokio",
  "tracing",
@@ -3315,7 +3315,7 @@ dependencies = [
  "prefix-trie",
  "rand 0.10.2",
  "ring",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "url",
@@ -3342,7 +3342,7 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "system-configuration",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -3394,15 +3394,15 @@ dependencies = [
 
 [[package]]
 name = "html-escape"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c1ff2d1cbf39efe5af0900ced8a069b5e61557a17544eb0c4a50239937389e"
+checksum = "c9356095b4b41197bba32173600e1582792cda618f65d12f68e2e77d273413c5"
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -3410,9 +3410,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -3420,9 +3420,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3457,9 +3457,9 @@ checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
@@ -3481,9 +3481,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3503,9 +3503,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-named-pipe"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+checksum = "fab3637d6b04a8037af8a266fdf6cf92ea957e8c53981a2bf6136572531025bf"
 dependencies = [
  "hex",
  "hyper",
@@ -3513,7 +3513,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tower-service",
- "winapi",
 ]
 
 [[package]]
@@ -3752,9 +3751,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.28"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2adf14691c72bcfc1058740436a35bdd3ae9c07d1a941ef00b749e9ea16aefa7"
+checksum = "0b17771570a2b94107741a7b033f19132c2eee21d59d21b24d2ced26500bd66e"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -3846,9 +3845,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 dependencies = [
  "serde",
 ]
@@ -3894,11 +3893,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.31"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
  "defmt",
+ "jiff-core",
  "jiff-static",
  "jiff-tzdb-platform",
  "log",
@@ -3906,6 +3906,15 @@ dependencies = [
  "portable-atomic-util",
  "serde_core",
  "windows-link",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
 ]
 
 [[package]]
@@ -3920,20 +3929,21 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.31"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
 dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6142247df1a93c2b3587402a19710be3e6e942f1581a1702e76408f2c21d6590"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
 
 [[package]]
 name = "jiff-tzdb-platform"
@@ -3956,7 +3966,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "walkdir",
  "windows-link",
 ]
@@ -3971,7 +3981,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3990,7 +4000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4180,9 +4190,9 @@ dependencies = [
 
 [[package]]
 name = "left-right"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0c21e4c8ff95f487fb34e6f9182875f42c84cef966d29216bf115d9bba835a"
+checksum = "8bc015ded5d9b3054dbbdb63332cdd6ee42352ccef19e911e25117490e2f48ee"
 dependencies = [
  "crossbeam-utils",
  "loom",
@@ -4210,7 +4220,7 @@ dependencies = [
  "oco_ref",
  "or_poisoned",
  "paste",
- "rand 0.9.4",
+ "rand 0.9.5",
  "reactive_graph",
  "rustc-hash",
  "rustc_version",
@@ -4221,7 +4231,7 @@ dependencies = [
  "server_fn",
  "slotmap",
  "tachys",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "throw_error",
  "typed-builder",
  "typed-builder-macro",
@@ -4262,7 +4272,7 @@ dependencies = [
  "leptos",
  "paste",
  "send_wrapper",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "unic-langid",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -4289,7 +4299,7 @@ dependencies = [
  "leptos_axum",
  "paste",
  "send_wrapper",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "unic-langid",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -4328,7 +4338,7 @@ dependencies = [
  "config",
  "regex",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "typed-builder",
 ]
 
@@ -4361,7 +4371,7 @@ dependencies = [
  "quote",
  "rstml",
  "serde",
- "syn 2.0.118",
+ "syn 2.0.119",
  "walkdir",
 ]
 
@@ -4410,7 +4420,7 @@ dependencies = [
  "rstml",
  "rustc_version",
  "server_fn_macro",
- "syn 2.0.118",
+ "syn 2.0.119",
  "uuid",
 ]
 
@@ -4431,9 +4441,9 @@ dependencies = [
 
 [[package]]
 name = "leptos_router"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "253962f9371a2fcf432eff991efc6da58de383c1cbcc332aaff7b8b22f6d778e"
+checksum = "318c035b5995324c2f60900978ac67da3b21e6062a6e904f8b93b38eddc4e3a2"
 dependencies = [
  "any_spawner",
  "either_of",
@@ -4448,7 +4458,7 @@ dependencies = [
  "rustc_version",
  "send_wrapper",
  "tachys",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "url",
  "wasm-bindgen",
  "web-sys",
@@ -4463,7 +4473,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4499,9 +4509,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -4511,9 +4521,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
  "libc",
 ]
@@ -4545,12 +4555,6 @@ checksum = "984fb35d06508d1e69fc91050cceba9c0b748f983e6739fa2c7a9237154c52c8"
 dependencies = [
  "linked-hash-map",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -4599,7 +4603,7 @@ dependencies = [
  "quote",
  "regex-automata",
  "regex-syntax",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4632,9 +4636,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lzma-rust2"
-version = "0.16.5"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca93e534d1142d1d0dcca6d25fe302508a5dfb40b302802904577725ea0b695b"
+checksum = "12931b17820a3a0c48e46359d2be49ef57b5d50509fd5baba43e6c654977aa66"
 
 [[package]]
 name = "manyhow"
@@ -4645,7 +4649,7 @@ dependencies = [
  "manyhow-macros",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4696,9 +4700,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "metrics"
@@ -4728,7 +4732,7 @@ dependencies = [
  "metrics-util",
  "quanta",
  "rustls",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -4744,7 +4748,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "metrics",
  "quanta",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_xoshiro",
  "rapidhash",
  "sketches-ddsketch",
@@ -4776,7 +4780,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4813,9 +4817,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -4883,7 +4887,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -4967,7 +4971,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
  "serde",
  "smallvec",
  "zeroize",
@@ -5005,11 +5009,10 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -5063,7 +5066,7 @@ checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5076,7 +5079,7 @@ dependencies = [
  "chrono",
  "getrandom 0.2.17",
  "http",
- "rand 0.8.6",
+ "rand 0.8.7",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -5088,18 +5091,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.37.3"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "object_store"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765784b4390c6bcf80316e5a22f4e3661b639c9d8c83246856643c27d8ce9dbe"
+checksum = "d354792e39fa5f0009e47623cf8b15b099bf9a652fa55c6f817fe28ac84fea50"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
@@ -5120,14 +5123,14 @@ dependencies = [
  "nix",
  "parking_lot",
  "percent-encoding",
- "quick-xml 0.40.1",
+ "quick-xml",
  "rand 0.10.2",
  "reqwest 0.13.4",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "url",
@@ -5156,7 +5159,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed0423ff9973dea4d6bd075934fdda86ebb8c05bdf9d6b0507067d4a1226371d"
 dependencies = [
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5201,7 +5204,7 @@ dependencies = [
  "openehr-rm",
  "regex",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "uuid",
 ]
 
@@ -5221,7 +5224,7 @@ version = "1.3.0"
 dependencies = [
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "uuid",
 ]
 
@@ -5252,13 +5255,13 @@ dependencies = [
  "openehr-lang",
  "openehr-rm",
  "openehr-term",
- "quick-xml 0.41.0",
+ "quick-xml",
  "regex",
  "serde",
  "serde_json",
  "serde_path_to_error",
  "sha2 0.11.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "uuid",
 ]
@@ -5274,7 +5277,7 @@ dependencies = [
  "openehr-base",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5283,7 +5286,7 @@ version = "1.1.0"
 dependencies = [
  "chumsky",
  "logos",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5298,7 +5301,7 @@ dependencies = [
  "serde",
  "serde_jcs",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "uuid",
 ]
 
@@ -5309,7 +5312,7 @@ dependencies = [
  "openehr-base",
  "roxmltree",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5329,7 +5332,7 @@ dependencies = [
  "oauth2",
  "p256",
  "p384",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rsa",
  "serde",
  "serde-value",
@@ -5359,7 +5362,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -5389,7 +5392,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "reqwest 0.13.4",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tonic",
  "tonic-types",
@@ -5420,8 +5423,8 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "portable-atomic",
- "rand 0.9.4",
- "thiserror 2.0.18",
+ "rand 0.9.5",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
 ]
@@ -5480,9 +5483,9 @@ dependencies = [
  "pkcs5",
  "rand 0.10.2",
  "rc2",
- "sha1 0.10.6",
+ "sha1 0.10.7",
  "sha2 0.10.9",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "x509-parser",
 ]
 
@@ -5526,27 +5529,33 @@ dependencies = [
 
 [[package]]
 name = "palette"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+checksum = "ddeed8580d347d2abf3dcf06a5f0b3dc020258338526b277847cd4248a70fc64"
 dependencies = [
  "approx",
- "fast-srgb8",
  "palette_derive",
+ "palette_math",
  "phf",
 ]
 
 [[package]]
 name = "palette_derive"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+checksum = "88537020289b719d81be994ccf1bbf4990f477e2f69ee52fe3e45f43a02e56be"
 dependencies = [
  "by_address",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
+
+[[package]]
+name = "palette_math"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e6eb142958d64335fb0e345c5b9ead2ecd6fc438c307e9d7d3c4fd428dbaf12"
 
 [[package]]
 name = "parking"
@@ -5599,7 +5608,7 @@ dependencies = [
  "regex",
  "regex-syntax",
  "structmeta",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5668,9 +5677,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -5678,9 +5687,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58"
+checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
 dependencies = [
  "pest",
  "pest_generator",
@@ -5688,22 +5697,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7"
+checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
+checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
 dependencies = [
  "pest",
 ]
@@ -5770,11 +5779,11 @@ dependencies = [
  "p256",
  "p384",
  "p521",
- "rand 0.8.6",
+ "rand 0.8.7",
  "replace_with",
  "ripemd",
  "rsa",
- "sha1 0.10.6",
+ "sha1 0.10.7",
  "sha1-checked",
  "sha2 0.10.9",
  "sha3",
@@ -5789,35 +5798,11 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared",
- "rand 0.8.6",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -5825,6 +5810,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -5852,7 +5846,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5943,9 +5937,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "portable-atomic-util"
@@ -6042,7 +6036,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6082,7 +6076,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6098,9 +6092,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -6113,7 +6107,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "version_check",
  "yansi",
 ]
@@ -6138,7 +6132,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6152,9 +6146,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+checksum = "4dcd034599e63b970727f70d79e02d62390a4a84f7c6b827c27c46d5ac3fa622"
 dependencies = [
  "ar_archive_writer",
  "cc",
@@ -6203,16 +6197,6 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.40.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
@@ -6235,7 +6219,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "web-time",
@@ -6258,7 +6242,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -6280,9 +6264,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -6306,7 +6290,7 @@ dependencies = [
  "proc-macro-utils",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6329,9 +6313,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -6340,9 +6324,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -6436,7 +6420,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -6468,7 +6452,7 @@ dependencies = [
  "send_wrapper",
  "serde",
  "slotmap",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "web-sys",
 ]
 
@@ -6516,7 +6500,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6529,7 +6513,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6538,7 +6522,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -6549,27 +6533,27 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -6591,9 +6575,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6603,9 +6587,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6787,7 +6771,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81116b9531d61eabc41aeb228e4b6b2435bcca3233b98cf3b3077d4e6e9debb3"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "once_cell",
  "serde",
  "serde_derive",
@@ -6834,16 +6818,16 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "syn_derive",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "rust-embed"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+checksum = "e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -6852,24 +6836,25 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+checksum = "3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097"
 dependencies = [
+ "mime_guess",
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.118",
+ "syn 2.0.119",
  "walkdir",
 ]
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
 dependencies = [
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "walkdir",
 ]
 
@@ -6893,7 +6878,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rkyv",
  "serde",
  "serde_json",
@@ -6908,9 +6893,9 @@ checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc-literal-escaper"
-version = "0.0.7"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be87abb9e40db7466e0681dc8ecd9dcfd40360cb10b4c8fe24a7c4c3669b198"
+checksum = "bfe6f213fb658c8fb95baabd5420393438cf5a98d707f5dd701d9197c705f71e"
 
 [[package]]
 name = "rustc_version"
@@ -6932,35 +6917,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.13.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -6974,9 +6946,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-connector"
-version = "0.23.6"
+version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7664e32b0ffbec386bdf1d7cbca51a89551a90d3278f135186cd6cb3cfa889c"
+checksum = "09a5abe04eec18f8b9fbe87885bcaee6426de80bbc579958c0bc064b728ee617"
 dependencies = [
  "futures-io",
  "futures-rustls",
@@ -7001,9 +6973,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -7050,9 +7022,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -7107,9 +7079,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -7163,8 +7135,8 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
- "thiserror 2.0.18",
+ "syn 2.0.119",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -7213,7 +7185,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -7247,9 +7219,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -7257,12 +7229,12 @@ dependencies = [
 
 [[package]]
 name = "serde-saphyr"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f585dc5cd9a358fd20811c238205b1bf009f061de1d0477263159631dd4cc92"
+checksum = "5bb49c0aa8a5bb88c00b833c11bae50d1611fb89e01336f53b05f7c643b1c883"
 dependencies = [
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.23.0",
  "encoding_rs_io",
  "granit-parser",
  "nohash-hasher",
@@ -7296,22 +7268,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -7327,9 +7299,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",
@@ -7380,18 +7352,18 @@ checksum = "f3faaf9e727533a19351a43cc5a8de957372163c7d35cc48c90b75cdda13c352"
 dependencies = [
  "percent-encoding",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "serde_repr"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -7428,7 +7400,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.14.0",
  "schemars 0.9.0",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -7444,7 +7416,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7494,7 +7466,7 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "server_fn_macro_default",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "throw_error",
  "tokio",
  "tower",
@@ -7518,7 +7490,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.118",
+ "syn 2.0.119",
  "xxhash-rust",
 ]
 
@@ -7529,14 +7501,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63eb08f80db903d3c42f64e60ebb3875e0305be502bdc064ec0a0eab42207f00"
 dependencies = [
  "server_fn_macro",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "sevenz-rust2"
-version = "0.21.3"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5d71c87d24cb22976f3f6e6c2c9296ef1f6958394e2b868d56ca01b082798a"
+checksum = "20acd38118edb830eb5a0bfacaf83c687b9995f48d6983cdac3cb18ce1d571cc"
 dependencies = [
  "crc32fast",
  "js-sys",
@@ -7546,9 +7518,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -7573,7 +7545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
 dependencies = [
  "digest 0.10.7",
- "sha1 0.10.6",
+ "sha1 0.10.7",
  "zeroize",
 ]
 
@@ -7652,15 +7624,15 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -7686,7 +7658,7 @@ checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 
@@ -7738,30 +7710,30 @@ dependencies = [
 
 [[package]]
 name = "snafu"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a012328be2e3f5d5f6f3218147ca02588cea4cb865e876849ab6debcf36522"
+checksum = "e45cb604038abb7b926b679887b3226d8d0f23874b66623625a0454be425a4b7"
 dependencies = [
  "snafu-derive",
 ]
 
 [[package]]
 name = "snafu-derive"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f103c50866b8743da9429b8a581d81a27c2d3a9c4ac7df8f8571c1dd7896eda"
+checksum = "287f59010008f0d7cf5e3b03196d666c1acc46c8d3e9cf34c28a1a7157601e72"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -7835,7 +7807,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -7854,7 +7826,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7877,8 +7849,8 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.118",
- "thiserror 2.0.18",
+ "syn 2.0.119",
+ "thiserror 2.0.19",
  "tokio",
  "url",
 ]
@@ -7889,7 +7861,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "byteorder",
  "bytes",
  "chrono",
@@ -7907,7 +7879,7 @@ dependencies = [
  "sha1 0.11.0",
  "sha2 0.11.0",
  "sqlx-core",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "uuid",
 ]
@@ -7920,7 +7892,7 @@ checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "byteorder",
  "chrono",
  "crc",
@@ -7944,7 +7916,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "uuid",
  "whoami",
@@ -7970,7 +7942,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "sqlx-core",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "url",
  "uuid",
@@ -7984,9 +7956,9 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stacker"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+checksum = "707f49d46706bacf8a2b00d51dace3f9de527c13eec3778f570c411f89e69967"
 dependencies = [
  "cc",
  "cfg-if",
@@ -8003,7 +7975,7 @@ checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared",
+ "phf_shared 0.11.3",
  "precomputed-hash",
 ]
 
@@ -8051,7 +8023,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8062,7 +8034,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8084,9 +8056,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8102,7 +8085,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8122,7 +8105,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8131,7 +8114,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -8223,7 +8206,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.3",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -8266,7 +8249,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -8291,7 +8274,7 @@ dependencies = [
  "sqlx",
  "testcontainers",
  "testcontainers-modules",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "uuid",
@@ -8342,7 +8325,7 @@ source = "git+https://github.com/thaw-ui/thaw?rev=0726a3d6788f07e929996e77399d83
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8362,9 +8345,9 @@ dependencies = [
 
 [[package]]
 name = "thirtyfour"
-version = "0.37.2"
+version = "0.37.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799b1de3a58f1ed82060fbee54cc27bc87523e35ade57d9c80bc88ffc1420044"
+checksum = "7cde234b9eff7d8f7e05e8af9de9c315f4500512a0a52535d7c6140bd2c54b7c"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -8386,7 +8369,7 @@ dependencies = [
  "stringmatch",
  "tar",
  "thirtyfour-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -8396,13 +8379,13 @@ dependencies = [
 
 [[package]]
 name = "thirtyfour-macros"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cf0ffc3ba4368e99597bd6afd83f4ff6febad66d9ae541ab46e697d32285fc0"
+checksum = "d712d0fd1988fb67a3fd89d10ead116544448bad01e43d326bd64dd8e09b5ea4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8416,11 +8399,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -8431,25 +8414,25 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -8465,9 +8448,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",
@@ -8485,9 +8468,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -8515,9 +8498,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -8530,9 +8513,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -8546,13 +8529,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -8567,9 +8550,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -8591,22 +8574,23 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
@@ -8628,9 +8612,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime",
@@ -8640,18 +8624,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tonic"
@@ -8746,7 +8730,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -8774,7 +8758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
 dependencies = [
  "async-compression",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -8833,10 +8817,10 @@ dependencies = [
  "futures",
  "http",
  "parking_lot",
- "rand 0.9.4",
+ "rand 0.9.5",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "tokio",
  "tracing",
@@ -8874,7 +8858,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8962,9 +8946,9 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.4",
- "sha1 0.10.6",
- "thiserror 2.0.18",
+ "rand 0.9.5",
+ "sha1 0.10.7",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -8999,7 +8983,7 @@ checksum = "076a02dc54dd46795c2e9c8282ed40bcfb1e22747e955de9389a1de28190fb26"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9129,7 +9113,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common 0.1.6",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -9249,7 +9233,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.118",
+ "syn 2.0.119",
  "uuid",
 ]
 
@@ -9280,9 +9264,9 @@ checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -9411,7 +9395,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -9456,7 +9440,7 @@ dependencies = [
  "base16",
  "quote",
  "sha2 0.10.9",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9481,18 +9465,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -9561,7 +9545,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9572,7 +9556,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9615,15 +9599,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]
@@ -9703,9 +9678,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -9790,7 +9765,7 @@ dependencies = [
  "nom 7.1.3",
  "oid-registry",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 
@@ -9801,14 +9776,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix 1.1.4",
+ "rustix",
 ]
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.17"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "985eec839aaf2a1270af8f4ebcf63cf9401cfd90f0902f97c28d9f104ffbde72"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
 
 [[package]]
 name = "yaml-rust2"
@@ -9846,28 +9821,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.53"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.53"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9887,7 +9862,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -9908,7 +9883,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9942,7 +9917,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9975,15 +9950,15 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.5"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zopfli"

--- a/app/ferroehr/src/aql/sql/predicate.rs
+++ b/app/ferroehr/src/aql/sql/predicate.rs
@@ -10,8 +10,8 @@ use sea_query::{Expr, ExprTrait as _};
 
 use crate::aql::error::{AqlError, SqlError};
 use crate::aql::ir::{
-    ArchetypeConstraint, Bind, Coercion, EhrField, Expr as IrExpr, LikePattern, NameConstraint,
-    NodeConstraint, Operand, PathTarget, ScalarFn, StdPredicate, TypedLit,
+    ArchetypeConstraint, Bind, Coercion, EhrField, Expr as IrExpr, LeafPath, LikePattern,
+    NameConstraint, NodeConstraint, Operand, PathTarget, ScalarFn, StdPredicate, TypedLit,
 };
 use openehr_query::lexer::CompOp;
 
@@ -87,16 +87,29 @@ impl Builder<'_> {
             IrExpr::Exists(target) => Ok(self
                 .value_expr(target, ValueMode::Projection)?
                 .is_not_null()),
-            // TODO(#1448): unify `LIKE`/`matches` on anchored multi-valued paths
-            // with the existential lowering above (`exists_compare`) — they
-            // still take the scalar LIMIT-1 extraction, whose matched-node
-            // choice is order-undefined when a path matches several nodes.
             IrExpr::Like { path, pattern } => {
-                let lhs = self.value_expr(path, ValueMode::Value(Coercion::Text))?;
                 let pat = match pattern {
                     LikePattern::Literal(s) => aql_like_to_sql(s),
                     LikePattern::Param(p) => aql_like_to_sql(&self.param_str(p)?),
                 };
+                // Existential lowering on an anchored multi-valued path
+                // (any-match, the same #1448 unification as `exists_compare`
+                // above): the scalar LIMIT-1 extraction's matched-node choice
+                // is order-undefined when the path matches several nodes —
+                // positive polarity only, like every existential arm.
+                if positive && let Some(leaf) = Self::existential_leaf(path) {
+                    let leaf = leaf.clone();
+                    self.ensure_leaf_root(path)?;
+                    let pat = pat.clone();
+                    if let Some(expr) =
+                        self.data_leaf_exists(&leaf, ValueMode::Value(Coercion::Text), |extract| {
+                            extract.like(pat)
+                        })?
+                    {
+                        return Ok(expr);
+                    }
+                }
+                let lhs = self.value_expr(path, ValueMode::Value(Coercion::Text))?;
                 Ok(lhs.like(pat))
             }
             IrExpr::Const(b) => Ok(Expr::val(*b)),
@@ -111,10 +124,10 @@ impl Builder<'_> {
                     && values.iter().any(|b| {
                         matches!(b, Bind::Literal(TypedLit::Integer(_) | TypedLit::Real(_)))
                     });
-                let lhs = if numeric {
-                    self.value_expr(path, ValueMode::RawNumeric)?
+                let mode = if numeric {
+                    ValueMode::RawNumeric
                 } else {
-                    self.value_expr(path, ValueMode::Value(*coercion))?
+                    ValueMode::Value(*coercion)
                 };
                 let mut members = Vec::with_capacity(values.len());
                 for b in values {
@@ -125,6 +138,18 @@ impl Builder<'_> {
                         coerce_rhs(v, *coercion)
                     });
                 }
+                // The same #1448 existential unification as LIKE above.
+                if positive && let Some(leaf) = Self::existential_leaf(path) {
+                    let leaf = leaf.clone();
+                    self.ensure_leaf_root(path)?;
+                    let members = members.clone();
+                    if let Some(expr) =
+                        self.data_leaf_exists(&leaf, mode, |extract| extract.is_in(members))?
+                    {
+                        return Ok(expr);
+                    }
+                }
+                let lhs = self.value_expr(path, mode)?;
                 Ok(lhs.is_in(members))
             }
         }
@@ -277,6 +302,25 @@ impl Builder<'_> {
     /// literal/param/scalar-function (never a second path — correlating two
     /// walks stays scalar). Returns `Ok(None)` where the lowering does not
     /// apply; the caller falls back to the scalar comparison.
+    /// The anchored data leaf of an existential-lowering candidate path —
+    /// the same `PathTarget` arms [`exists_compare`](Self::exists_compare)
+    /// admits (#1448). `None` falls back to the scalar lowering.
+    fn existential_leaf(target: &PathTarget) -> Option<&LeafPath> {
+        match target {
+            PathTarget::Data(leaf) | PathTarget::EhrStatus(leaf) => Some(leaf),
+            _ => None,
+        }
+    }
+
+    /// The `EHR_STATUS` root join an existential `EhrStatus` leaf needs before
+    /// its walk (the `exists_compare` preamble, shared by LIKE/matches).
+    fn ensure_leaf_root(&mut self, target: &PathTarget) -> Result<(), AqlError> {
+        if let PathTarget::EhrStatus(leaf) = target {
+            self.ensure_ehr_status_root(leaf.source.0)?;
+        }
+        Ok(())
+    }
+
     fn exists_compare(
         &mut self,
         lhs: &Operand,

--- a/app/ferroehr/src/service/message/export.rs
+++ b/app/ferroehr/src/service/message/export.rs
@@ -173,53 +173,9 @@ impl FerroEhrService {
                 resolve_entity_ehr(self, entity.ehr_id.as_deref(), entity.subject_id.as_deref())
                     .await?;
 
-            // The primary set: an explicit item_list, else every VO of the EHR.
-            // TODO(#1736): `EXTRACT_SPEC.criteria` (`master04-common_package.adoc`,
-            // an AQL primary-set query) is a typed reject until the
-            // `$ehr`-bound AQL criteria selection lands — never a silent
-            // over-export.
-            let vo_kinds: Vec<(VoId, String)> =
-                if entity.item_list.as_ref().is_none_or(Vec::is_empty) {
-                    if criteria_present {
-                        return Err(SmError::precondition(
-                            "EXTRACT_SPEC.criteria (AQL selection) is not supported in this stage; \
-                         provide EXTRACT_ENTITY_MANIFEST.item_list instead",
-                        ));
-                    }
-                    self.ehr_versioned_objects(ehr_id).await?
-                } else {
-                    let mut resolved =
-                        Vec::with_capacity(entity.item_list.as_ref().map_or(0, Vec::len));
-                    for obj_ref in entity.item_list.iter().flatten() {
-                        let value = openehr_its::json::to_canonical_value(obj_ref);
-                        let raw = value
-                            .pointer("/id/value")
-                            .and_then(Value::as_str)
-                            .ok_or_else(|| {
-                                SmError::precondition("item_list OBJECT_REF has no id.value")
-                            })?;
-                        #[expect(
-                            clippy::map_err_ignore,
-                            reason = "the mapped error already echoes the rejected \
-                                  token; the discarded `uuid::Error` adds only \
-                                  its own wording, which is not part of the wire \
-                                  contract"
-                        )]
-                        let vo_id: VoId = raw.parse().map_err(|_| {
-                            SmError::precondition(format!(
-                                "item_list id {raw:?} is not a version-container UUID"
-                            ))
-                        })?;
-                        let kind = self.ehr_vo_kind(ehr_id, vo_id).await?.ok_or_else(|| {
-                            SmError::new(
-                                CallStatusType::VersionedObjectDoesNotExist,
-                                format!("version container {vo_id} not found in EHR {ehr_id}"),
-                            )
-                        })?;
-                        resolved.push((vo_id, kind));
-                    }
-                    resolved
-                };
+            let vo_kinds = self
+                .entity_primary_set(ehr_id, entity, criteria_present, &extract_spec)
+                .await?;
 
             let mut included: Vec<VoId> = vo_kinds.iter().map(|(vo, _)| *vo).collect();
             let mut items = Vec::with_capacity(vo_kinds.len());
@@ -286,6 +242,156 @@ impl FerroEhrService {
     /// The `(vo_id, kind)` of every versioned object currently in the EHR (one
     /// row per version container — its current, `upper_inf`, trunk version),
     /// ordered by id for a deterministic extract.
+    /// The primary set of one manifest entity: an explicit `item_list`; else
+    /// the criteria queries (`master04-common_package.adoc` §`EXTRACT_SPEC`:
+    /// criteria define "which items are to be retrieved from each entity's
+    /// record"); else every VO of the EHR. `item_list` wins when both are
+    /// given — master04 keeps the two mechanisms distinct ("only expected to
+    /// be used when a specific identifier is known, rather than when items
+    /// corresponding to filtering criteria are requested").
+    ///
+    /// # Errors
+    /// The [`Self::criteria_primary_set`] refusals; `precondition_violation`
+    /// for a malformed `item_list` entry; `versioned_object_does_not_exist`
+    /// for an `item_list` container outside the entity's EHR.
+    async fn entity_primary_set(
+        &self,
+        ehr_id: EhrId,
+        entity: &openehr_rm::ehr_extract::common::extract_entity_manifest::ExtractEntityManifest,
+        criteria_present: bool,
+        extract_spec: &ExtractSpec,
+    ) -> Result<Vec<(VoId, String)>, SmError> {
+        if entity.item_list.as_ref().is_none_or(Vec::is_empty) {
+            if criteria_present {
+                return self
+                    .criteria_primary_set(
+                        ehr_id,
+                        extract_spec.criteria.as_deref().unwrap_or_default(),
+                    )
+                    .await;
+            }
+            return Ok(self.ehr_versioned_objects(ehr_id).await?);
+        }
+        let mut resolved = Vec::with_capacity(entity.item_list.as_ref().map_or(0, Vec::len));
+        for obj_ref in entity.item_list.iter().flatten() {
+            let value = openehr_its::json::to_canonical_value(obj_ref);
+            let raw = value
+                .pointer("/id/value")
+                .and_then(Value::as_str)
+                .ok_or_else(|| SmError::precondition("item_list OBJECT_REF has no id.value"))?;
+            #[expect(
+                clippy::map_err_ignore,
+                reason = "the mapped error already echoes the rejected \
+                      token; the discarded `uuid::Error` adds only \
+                      its own wording, which is not part of the wire \
+                      contract"
+            )]
+            let vo_id: VoId = raw.parse().map_err(|_| {
+                SmError::precondition(format!(
+                    "item_list id {raw:?} is not a version-container UUID"
+                ))
+            })?;
+            let kind = self.ehr_vo_kind(ehr_id, vo_id).await?.ok_or_else(|| {
+                SmError::new(
+                    CallStatusType::VersionedObjectDoesNotExist,
+                    format!("version container {vo_id} not found in EHR {ehr_id}"),
+                )
+            })?;
+            resolved.push((vo_id, kind));
+        }
+        Ok(resolved)
+    }
+
+    /// The `$ehr`-bound criteria primary set (#1736): evaluate each
+    /// `EXTRACT_SPEC.criteria` query against the entity's EHR and collect the
+    /// version containers its result rows identify (RM `ehr_extract`
+    /// `master04-common_package.adoc` §`EXTRACT_SPEC`: criteria "defines in the
+    /// form of generic queries … which items are to be retrieved from each
+    /// entity's record"; "Query expressions use variables such as $ehr to
+    /// mean the current EHR from the `manifest` list").
+    ///
+    /// Realization decisions (the released text names AQL as an example
+    /// formalism and stops there — the mechanics below are our own design,
+    /// flagged per rule):
+    /// - The formalism must be AQL (`DV_PARSABLE.formalism`,
+    ///   case-insensitive `"aql"`) — any other formalism is a typed refusal,
+    ///   never a silent skip.
+    /// - The `$ehr` binding is realized twice over: the engine call is scoped
+    ///   to the entity's EHR (`ehr_ids = [entity]` — the SM
+    ///   `i_query_service.adoc` EHR scope), and a literal `$ehr` parameter in
+    ///   the query text binds to the EHR id, so both spellings work.
+    /// - A result row identifies a version container through any cell that is
+    ///   an `OBJECT_VERSION_ID`/UID string or an object carrying
+    ///   `uid.value`; cells that resolve to no container in this EHR are data
+    ///   values, not selections. The union across rows and criteria, in
+    ///   first-seen order, is the primary set — possibly empty (a criterion
+    ///   may legitimately match nothing).
+    /// - NOTE: the engine's SM population gate applies — a non-queryable EHR
+    ///   yields no rows (SM `i_query_service.adoc`: queries run over
+    ///   `is_queryable` EHRs). No openEHR spec relates EXTRACT criteria to
+    ///   that gate — our own design keeps criteria exactly as powerful as
+    ///   the query service they are defined in terms of.
+    ///
+    /// # Errors
+    /// `precondition_violation` — a non-AQL formalism, or a criterion that
+    /// does not parse/execute as AQL (the refusal names the criterion index).
+    async fn criteria_primary_set(
+        &self,
+        ehr_id: EhrId,
+        criteria: &[openehr_rm::data_types::encapsulated::dv_parsable::DvParsable],
+    ) -> Result<Vec<(VoId, String)>, SmError> {
+        let mut out: Vec<(VoId, String)> = Vec::new();
+        for (idx, criterion) in criteria.iter().enumerate() {
+            if !criterion.formalism.eq_ignore_ascii_case("aql") {
+                return Err(SmError::precondition(format!(
+                    "EXTRACT_SPEC.criteria[{idx}] formalism {:?} is not supported: this \
+                     service evaluates AQL criteria (master04-common_package.adoc \
+                     names AQL as the openEHR query formalism)",
+                    criterion.formalism
+                )));
+            }
+            let request = crate::service::query::request::AqlQueryRequest {
+                ehr_ids: vec![ehr_id.to_string()],
+                parameters: std::iter::once(("ehr".to_owned(), json!(ehr_id.to_string())))
+                    .collect(),
+                ..crate::service::query::request::AqlQueryRequest::default()
+            };
+            let outcome = self
+                .execute_ad_hoc_query(criterion.value.clone(), request)
+                .await
+                .map_err(|e| {
+                    SmError::precondition(format!(
+                        "EXTRACT_SPEC.criteria[{idx}] did not evaluate as AQL: {}",
+                        e.message
+                    ))
+                })?;
+            let empty = Vec::new();
+            let rows = outcome
+                .result_set
+                .get("rows")
+                .and_then(Value::as_array)
+                .unwrap_or(&empty);
+            for cell in rows.iter().filter_map(Value::as_array).flatten() {
+                let candidate = match cell {
+                    Value::String(s) => Some(s.as_str()),
+                    Value::Object(_) => cell.pointer("/uid/value").and_then(Value::as_str),
+                    _ => None,
+                };
+                let Some(raw) = candidate else { continue };
+                let Ok(vo_id) = raw.split("::").next().unwrap_or(raw).parse::<VoId>() else {
+                    continue;
+                };
+                if out.iter().any(|(v, _)| *v == vo_id) {
+                    continue;
+                }
+                if let Some(kind) = self.ehr_vo_kind(ehr_id, vo_id).await? {
+                    out.push((vo_id, kind));
+                }
+            }
+        }
+        Ok(out)
+    }
+
     async fn ehr_versioned_objects(
         &self,
         ehr_id: EhrId,

--- a/app/ferroehr/tests/it/aql_planner.rs
+++ b/app/ferroehr/tests/it/aql_planner.rs
@@ -1459,3 +1459,42 @@ fn version_coded_field_subpaths() {
         "bare coded object rejects: {e}"
     );
 }
+
+/// #1448 — LIKE and `matches` on an anchored data leaf lower through the
+/// EXISTENTIAL shape (`EXISTS(SELECT 1 …)`), the same lowering the comparison
+/// operators use, never the scalar LIMIT-1 extraction (order-undefined on a
+/// multi-valued path).
+#[test]
+fn like_and_matches_lower_existentially_on_anchored_leaves() {
+    let like_sql = build_sql(
+        "SELECT c/uid/value FROM EHR e CONTAINS COMPOSITION c \
+         WHERE c/context/other_context[at0001]/items[at0002]/value/value LIKE 'x*'",
+    );
+    assert!(
+        like_sql.contains("EXISTS(SELECT") && like_sql.contains("LIKE"),
+        "LIKE on an anchored leaf is existential: {like_sql}"
+    );
+    assert!(
+        !like_sql.contains("LIMIT 1"),
+        "no scalar LIMIT-1 extraction remains under the LIKE: {like_sql}"
+    );
+
+    let matches_sql = build_sql(
+        "SELECT c/uid/value FROM EHR e CONTAINS COMPOSITION c \
+         WHERE c/context/other_context[at0001]/items[at0002]/value/value MATCHES {'a', 'b'}",
+    );
+    assert!(
+        matches_sql.contains("EXISTS(SELECT") && matches_sql.contains("IN ("),
+        "matches on an anchored leaf is existential: {matches_sql}"
+    );
+    // NOT flips the polarity back to the scalar shape (three-valued SQL
+    // semantics preserved for absent leaves) — same rule as the comparisons.
+    let negated = build_sql(
+        "SELECT c/uid/value FROM EHR e CONTAINS COMPOSITION c \
+         WHERE NOT c/context/other_context[at0001]/items[at0002]/value/value LIKE 'x*'",
+    );
+    assert!(
+        !negated.contains("EXISTS(SELECT"),
+        "negative polarity keeps the scalar lowering: {negated}"
+    );
+}

--- a/app/ferroehr/tests/it/service_aql.rs
+++ b/app/ferroehr/tests/it/service_aql.rs
@@ -1610,3 +1610,72 @@ async fn distinct_order_by_limit_and_now_comparison() {
     let r = run_aql(&svc, aql, ehr_scope(&ehr_id)).await;
     assert_eq!(rows(&r).len(), 3, "all compositions precede NOW()");
 }
+
+/// #1448 — LIKE and `matches` on an anchored MULTI-VALUED path lower
+/// existentially (any-match), exactly as the comparison operators do: with two
+/// sibling ELEMENTs on the same `items[at0004]` path where only the SECOND
+/// satisfies the predicate, the row must still return. The scalar LIMIT-1
+/// extraction this replaces picked an order-undefined single node and could
+/// silently miss it. (QUERY master03 is silent on predicates over
+/// multi-valued paths — any-match is the adjudicated own-design semantics
+/// recorded on `data_leaf_exists`.)
+#[tokio::test]
+async fn like_and_matches_are_any_match_on_multi_valued_paths() {
+    let db = testkit::db().await.expect("testkit database");
+    let svc = FerroEhrService::new(db.pool());
+    let ehr_id = create_ehr(&svc).await;
+
+    let mut c = composition("multi-item", 1.0);
+    // A second ELEMENT on the SAME items[at0004] path: first carries a
+    // non-matching DV_TEXT, the second the value the predicates target.
+    let items = c["content"][0]["data"]["events"][0]["data"]["items"]
+        .as_array_mut()
+        .expect("items");
+    let mut first = items[0].clone();
+    first["value"] = json!({ "_type": "DV_TEXT", "value": "alpha" });
+    let mut second = items[0].clone();
+    second["value"] = json!({ "_type": "DV_TEXT", "value": "zeta match" });
+    *items = vec![first, second];
+    svc.create_composition(ehr_id.parse().expect("ehr_id uuid"), uv(&c, "249", None))
+        .await
+        .expect("multi-item composition");
+
+    let like = run_aql(
+        &svc,
+        "SELECT c/uid/value FROM EHR e CONTAINS COMPOSITION c CONTAINS OBSERVATION o \
+         WHERE o/data[at0001]/events[at0002]/data[at0003]/items[at0004]/value/value \
+         LIKE 'zeta*'",
+        ehr_scope(&ehr_id),
+    )
+    .await;
+    assert_eq!(
+        rows(&like).len(),
+        1,
+        "LIKE matches when ANY node on the multi-valued path satisfies it: {like}"
+    );
+
+    let matches = run_aql(
+        &svc,
+        "SELECT c/uid/value FROM EHR e CONTAINS COMPOSITION c CONTAINS OBSERVATION o \
+         WHERE o/data[at0001]/events[at0002]/data[at0003]/items[at0004]/value/value \
+         MATCHES {'zeta match'}",
+        ehr_scope(&ehr_id),
+    )
+    .await;
+    assert_eq!(
+        rows(&matches).len(),
+        1,
+        "matches is any-match on the multi-valued path: {matches}"
+    );
+
+    // The non-matching pattern still returns nothing (no vacuous truth).
+    let none = run_aql(
+        &svc,
+        "SELECT c/uid/value FROM EHR e CONTAINS COMPOSITION c CONTAINS OBSERVATION o \
+         WHERE o/data[at0001]/events[at0002]/data[at0003]/items[at0004]/value/value \
+         LIKE 'omega*'",
+        ehr_scope(&ehr_id),
+    )
+    .await;
+    assert_eq!(rows(&none).len(), 0, "no node satisfies: {none}");
+}

--- a/app/ferroehr/tests/it/service_extract.rs
+++ b/app/ferroehr/tests/it/service_extract.rs
@@ -379,3 +379,135 @@ async fn extract_spec_flags_are_honoured() {
         .expect_err("masked item carrying content must be rejected");
     assert!(err.message.contains("Item_validity"), "{}", err.message);
 }
+
+/// The `EXTRACT_SPEC` skeleton the criteria tests share: one entity, no
+/// `item_list`, the given criteria list (RM ehr_extract
+/// `master04-common_package.adoc` §`EXTRACT_SPEC` — criteria "defines in the
+/// form of generic queries … which items are to be retrieved from each
+/// entity's record").
+fn criteria_spec(ehr: &str, criteria: Value) -> ExtractSpec {
+    openehr_its::json::from_canonical_value(&json!({
+        "_type": "EXTRACT_SPEC",
+        "version_spec": {
+            "_type": "EXTRACT_VERSION_SPEC",
+            "include_all_versions": false,
+            "include_revision_history": false,
+            "include_data": true
+        },
+        "manifest": {
+            "_type": "EXTRACT_MANIFEST",
+            "entities": [ {
+                "_type": "EXTRACT_ENTITY_MANIFEST",
+                "extract_id_key": ehr,
+                "ehr_id": ehr,
+                "other_ids": [],
+                "item_list": []
+            } ]
+        },
+        "extract_type": {
+            "_type": "DV_CODED_TEXT",
+            "value": "openehr-ehr",
+            "defining_code": {
+                "_type": "CODE_PHRASE",
+                "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" },
+                "code_string": "openehr-ehr"
+            }
+        },
+        "include_multimedia": true,
+        "priority": 0,
+        "link_depth": 0,
+        "criteria": criteria
+    }))
+    .expect("EXTRACT_SPEC")
+}
+
+/// #1736 — `EXTRACT_SPEC.criteria` selects the primary set: an AQL criterion
+/// whose rows identify the `EHR_STATUS` version container yields an extract
+/// carrying exactly that container, not the whole EHR (master04
+/// §`EXTRACT_SPEC`: criteria define "which items are to be retrieved";
+/// "Query expressions use variables such as $ehr to mean the current EHR").
+#[tokio::test]
+async fn criteria_select_the_primary_set_ehr_bound() {
+    let db = testkit::db().await.expect("testkit database");
+    let svc = FerroEhrService::new(db.pool());
+    let (ehr, _status_vo) = seed_ehr(&svc).await;
+
+    let spec = criteria_spec(
+        &ehr.to_string(),
+        json!([{
+            "_type": "DV_PARSABLE",
+            "value": "SELECT s/uid/value FROM EHR e CONTAINS EHR_STATUS s",
+            "formalism": "AQL"
+        }]),
+    );
+    let extracts = svc
+        .export_ehr_extracts(spec)
+        .await
+        .expect("criteria-driven export");
+    assert_eq!(extracts.len(), 1, "one entity → one EXTRACT");
+    let its = items(&extracts[0]);
+    assert_eq!(
+        its.len(),
+        1,
+        "the criterion selects exactly the EHR_STATUS container: {its:#?}"
+    );
+    assert!(
+        find_by_xtype(&extracts[0], "X_VERSIONED_EHR_STATUS").is_some(),
+        "the selected container is the EHR_STATUS"
+    );
+}
+
+/// #1736, refusal twin (a): a criterion in a formalism this service does not
+/// evaluate is a typed precondition refusal — never a silent skip or a silent
+/// whole-EHR over-export.
+#[tokio::test]
+async fn criteria_in_a_foreign_formalism_are_refused() {
+    let db = testkit::db().await.expect("testkit database");
+    let svc = FerroEhrService::new(db.pool());
+    let (ehr, _status_vo) = seed_ehr(&svc).await;
+
+    let spec = criteria_spec(
+        &ehr.to_string(),
+        json!([{ "_type": "DV_PARSABLE", "value": "irrelevant", "formalism": "xquery" }]),
+    );
+    let err = svc
+        .export_ehr_extracts(spec)
+        .await
+        .expect_err("a non-AQL criteria formalism must be refused");
+    assert_eq!(
+        err.status,
+        ferroehr::service::status::CallStatusType::PreconditionViolation
+    );
+    assert!(
+        err.message.contains("formalism"),
+        "the refusal names the formalism: {}",
+        err.message
+    );
+}
+
+/// #1736, refusal twin (b): a criterion that does not parse as AQL is a typed
+/// precondition refusal naming the criterion index.
+#[tokio::test]
+async fn criteria_that_do_not_parse_as_aql_are_refused() {
+    let db = testkit::db().await.expect("testkit database");
+    let svc = FerroEhrService::new(db.pool());
+    let (ehr, _status_vo) = seed_ehr(&svc).await;
+
+    let spec = criteria_spec(
+        &ehr.to_string(),
+        json!([{ "_type": "DV_PARSABLE", "value": "THIS IS NOT AQL", "formalism": "aql" }]),
+    );
+    let err = svc
+        .export_ehr_extracts(spec)
+        .await
+        .expect_err("an unparseable AQL criterion must be refused");
+    assert_eq!(
+        err.status,
+        ferroehr::service::status::CallStatusType::PreconditionViolation
+    );
+    assert!(
+        err.message.contains("criteria[0]"),
+        "the refusal names the criterion: {}",
+        err.message
+    );
+}

--- a/app/ferroehr/tests/it/service_extract.rs
+++ b/app/ferroehr/tests/it/service_extract.rs
@@ -381,11 +381,11 @@ async fn extract_spec_flags_are_honoured() {
 }
 
 /// The `EXTRACT_SPEC` skeleton the criteria tests share: one entity, no
-/// `item_list`, the given criteria list (RM ehr_extract
+/// `item_list`, the given criteria list (RM `ehr_extract`
 /// `master04-common_package.adoc` §`EXTRACT_SPEC` — criteria "defines in the
 /// form of generic queries … which items are to be retrieved from each
 /// entity's record").
-fn criteria_spec(ehr: &str, criteria: Value) -> ExtractSpec {
+fn criteria_spec(ehr: &str, criteria: &Value) -> ExtractSpec {
     openehr_its::json::from_canonical_value(&json!({
         "_type": "EXTRACT_SPEC",
         "version_spec": {
@@ -434,7 +434,7 @@ async fn criteria_select_the_primary_set_ehr_bound() {
 
     let spec = criteria_spec(
         &ehr.to_string(),
-        json!([{
+        &json!([{
             "_type": "DV_PARSABLE",
             "value": "SELECT s/uid/value FROM EHR e CONTAINS EHR_STATUS s",
             "formalism": "AQL"
@@ -468,7 +468,7 @@ async fn criteria_in_a_foreign_formalism_are_refused() {
 
     let spec = criteria_spec(
         &ehr.to_string(),
-        json!([{ "_type": "DV_PARSABLE", "value": "irrelevant", "formalism": "xquery" }]),
+        &json!([{ "_type": "DV_PARSABLE", "value": "irrelevant", "formalism": "xquery" }]),
     );
     let err = svc
         .export_ehr_extracts(spec)
@@ -495,7 +495,7 @@ async fn criteria_that_do_not_parse_as_aql_are_refused() {
 
     let spec = criteria_spec(
         &ehr.to_string(),
-        json!([{ "_type": "DV_PARSABLE", "value": "THIS IS NOT AQL", "formalism": "aql" }]),
+        &json!([{ "_type": "DV_PARSABLE", "value": "THIS IS NOT AQL", "formalism": "aql" }]),
     );
     let err = svc
         .export_ehr_extracts(spec)

--- a/crates/openehr-its/CLAUDE.md
+++ b/crates/openehr-its/CLAUDE.md
@@ -37,14 +37,18 @@ every spec crate at once.
 `from_canonical_value` ARE the entry points (reads wrapped once in
 `serde_path_to_error`, so every refusal carries the JSON path);
 `json::JsonParseError` is the refusal type. `wire_validate::validate_rm_value` is the wire-boundary
-RM class-invariant DISPATCH LAYER that drives the reader — its hand-written
-table holds the invariant-bearing classes, and everything else falls through to
-the generated `structural_check` dispatch, so the codec is the
-structural-conformance authority for EVERY emitted class (a defective node of a
-class with no invariant is refused too). It only ROUTES: every value-level
-decision (the fast path, the invariant cores, the mandatory-container bounds,
-the JSON-level per-node checks, the terminology binding table) is defined in
-`openehr_rm::validate`. The template-independent whole-instance passes live in
+RM class-invariant DISPATCH LAYER — thin entry points that COMPOSE the tiers in
+a fixed order. Both tiers live upstream in `openehr_rm::validate` (the fast path
+`try_fast_validate`; the authoritative `_type` → concrete-type table
+`typed_dispatch::dispatch_typed`); what stays here is the part that needs this
+crate: the undeclared-key door over the generated `declared_fields` table, and
+the generated `structural_check` fallthrough for every class the typed table
+declines (`dispatch_typed` returns `false`) — which spans all five spec crates
+at once, so the codec is the structural-conformance authority for EVERY emitted
+class (a defective node of a class with no invariant is refused too). It only
+ROUTES: every value-level decision (the fast path, the typed table, the
+invariant cores, the mandatory-container bounds, the JSON-level per-node checks,
+the terminology binding table) is defined in `openehr_rm::validate`. The template-independent whole-instance passes live in
 `rm_instance` (`validate_rm_and_terminology{,_as}`, the composed
 `validate_composition`); `flat::validation` holds ONLY the template-driven
 archetype-conformance pass. Proven by

--- a/crates/openehr-its/schemas/json/PROVENANCE.md
+++ b/crates/openehr-its/schemas/json/PROVENANCE.md
@@ -28,8 +28,13 @@ self-tagging; there are no JSON structs to generate. `openehr-its::json` reads
 `openehr_rm_1.1.0_all.json` (via `include_str!`) to validate canonical-JSON
 output in the fidelity gate (`tests/`).
 
-## Known version divergence (accepted Stage-1 parity nuance)
+## Known version divergence (adjudicated, machine-pinned — #1697)
 
-ITS-JSON tops out at RM 1.1.0 while our generated RM is 1.2.0 (from BMM). The
-schema validates against 1.1.0-era shapes; this is a documented parity
-consideration (see `docs/VERSIONS.md`), not something to reconcile here.
+ITS-JSON tops out at RM 1.1.0 while our generated RM is 1.2.0 (from BMM), and
+the all-schema is CLOSED (`additionalProperties: false` per class) — so the
+first RM 1.2.0-only attribute on the wire (e.g. `EHR.tags`) FAILS the oracle
+for a reason that is not a defect in our output. The full per-class attribute
+delta between this schema and the generated RM 1.2.0 model is machine-derived
+and pinned by `tests/it/its_json_delta.rs` (the XSD-gate precedent): the known
+1.1.0↔1.2.0 divergence is adjudicated there, and any NEW divergence fails that
+gate loudly instead of surfacing later as a spurious validation failure.

--- a/crates/openehr-its/src/wire_validate.rs
+++ b/crates/openehr-its/src/wire_validate.rs
@@ -14,7 +14,7 @@
 //!   emitted downstream of all of them;
 //! - the undeclared-key refusal, which reads the generated declared-key table
 //!   ([`declared_fields`]) and renders the reader's own
-//!   [`JsonParseError`](crate::json::JsonParseError);
+//!   [`crate::json::JsonParseError`];
 //! - the entry points themselves ([`validate_rm_value`],
 //!   [`validate_rm_invariants`], [`validate_rm_invariants_as`],
 //!   [`validate_rm_invariants_relaxed_as`], [`validate_rm_value_typed`]), which

--- a/crates/openehr-its/src/wire_validate.rs
+++ b/crates/openehr-its/src/wire_validate.rs
@@ -1,160 +1,40 @@
-//! The **wire-boundary RM class-invariant dispatcher** — the `_type`→`Validate`
-//! typed dispatch tier.
+//! The **wire-boundary RM class-invariant dispatcher** — the thin entry points
+//! that compose the validation tiers at the codec boundary.
 //!
-//! This is a wire-boundary operation: it consumes a canonical-JSON node and
-//! *deserializes* it into its concrete RM type through the emitted canonical-JSON
-//! `serde` impls ([`crate::json::from_canonical_value`]), then runs that type's
-//! RM class invariants. It lives in `openehr-its` (not `openehr-rm`) because it
-//! drives the codec's entry points, which are defined here; the `Validate` trait and the
-//! invariant impls (`*_impl.rs`) stay in `openehr-rm`/`openehr-base` as pure RM
-//! model semantics. The two-tier entry point [`validate_rm_value`] calls the
-//! allocation-free fast path ([`openehr_rm::validate::try_fast_validate`]) first
-//! and falls back to the typed dispatch below.
+//! The tiers themselves are RM model semantics and live upstream in
+//! [`openehr_rm::validate`]: the allocation-free fast path
+//! ([`openehr_rm::validate::try_fast_validate`]) and the authoritative typed
+//! dispatch ([`openehr_rm::validate::typed_dispatch::dispatch_typed`], the
+//! `_type` → concrete-RM-type table). What stays HERE is what genuinely needs
+//! this crate:
+//!
+//! - the GENERATED five-crate structural fallthrough
+//!   ([`structural_check`]) the typed table declines to — it spans
+//!   `openehr-base`/`-rm`/`-am`/`-term`/`-lang` at once, so it can only be
+//!   emitted downstream of all of them;
+//! - the undeclared-key refusal, which reads the generated declared-key table
+//!   ([`declared_fields`]) and renders the reader's own
+//!   [`JsonParseError`](crate::json::JsonParseError);
+//! - the entry points themselves ([`validate_rm_value`],
+//!   [`validate_rm_invariants`], [`validate_rm_invariants_as`],
+//!   [`validate_rm_invariants_relaxed_as`], [`validate_rm_value_typed`]), which
+//!   fix the ORDER the tiers and orthogonal layers run in.
 //!
 //! # Fidelity to the reference implementation (archie)
 //!
 //! The RM class invariants (in `openehr-rm`'s `*_impl.rs`) mirror openEHR's
 //! reference implementation archie; this module only routes a node to the right
-//! concrete type. A node that does not deserialize into its declared concrete RM
-//! type surfaces `does not conform to RM type …` (see `record_type_mismatch`).
+//! tier. A node that does not deserialize into its declared concrete RM type
+//! surfaces `does not conform to RM type …` (see
+//! [`openehr_rm::validate::typed_dispatch::record_type_mismatch`]).
 
 use serde_json::Value;
 
-use openehr_base::validate::{InvariantViolation, Validate};
+use openehr_base::validate::InvariantViolation;
+use openehr_rm::validate::typed_dispatch::record_type_mismatch;
 
-use serde::de::DeserializeOwned;
-
-use crate::json::{JsonParseError, from_canonical_value};
+use crate::json::JsonParseError;
 use crate::json_codec::generated::structural::{declared_fields, structural_check};
-
-/// Record a typed-deserialize failure as a validation violation.
-///
-/// A node that does not deserialize into its declared concrete RM type is NOT
-/// "caught by the codec/schema layer" on the commit path: the node codec stores
-/// the raw canonical-JSON fragment verbatim (no openEHR spec governs the storage
-/// mechanics — our own storage design) and the ITS-JSON schema is not enforced
-/// at commit, so a missing mandatory attribute (e.g. `COMPOSITION.composer [1]`)
-/// or a wrong nested type (e.g. an `EHR_STATUS.subject` that is not `PARTY_SELF`)
-/// reaches here and nowhere else. Per ITS-REST `422_COMPOSITION.yaml` ("converts,
-/// but does not validate") this is a validation failure — surface it. (The valid
-/// corpus deserializes cleanly at every node, so this never rejects a valid
-/// input; if it ever did, that would expose a codegen field-optionality bug to
-/// fix in the emitter.)
-fn record_type_mismatch(ty: &str, err: &dyn std::fmt::Display, out: &mut Vec<InvariantViolation>) {
-    out.push(InvariantViolation::here(format!(
-        "does not conform to RM type {ty}: {err}"
-    )));
-}
-
-fn run<T: DeserializeOwned + Validate>(ty: &str, value: &Value, out: &mut Vec<InvariantViolation>) {
-    match from_canonical_value::<T>(value) {
-        Ok(v) => v.validate_invariants(out),
-        Err(e) => record_type_mismatch(ty, &e, out),
-    }
-}
-
-/// Like [`run`], but deserialize `T` from a copy of `value` whose nested
-/// RM-node child collections have been emptied ([`prune_child_nodes`]).
-///
-/// NOTE (settled perf design — no openEHR spec governs validation-pass
-/// mechanics; our own design): the RM-invariant pass ([`validate_rm_value`])
-/// is called once per
-/// `_type` node while the composition validator recurses the live JSON tree, so
-/// deserializing each node's *whole* subtree (as `from_json_value` does for a
-/// concrete container type) re-parses every descendant once per ancestor —
-/// O(Σ subtree sizes) for overlapping subtrees. This shallow variant is used for
-/// the LOCATABLE structural containers whose own class invariants inspect only
-/// scalar / single-object attributes (never a child collection): with the child
-/// arrays emptied, each node deserializes only its own immediate shape, so the
-/// pass is O(total nodes) instead of O(Σ subtree sizes). The node's own
-/// single-valued attributes are KEPT (only collections are emptied), so its
-/// mandatory-attribute presence and single-object type conformance are still
-/// enforced on deserialize — the missing-mandatory-attribute rejection
-/// (`422_COMPOSITION`, e.g. a dropped `COMPOSITION.composer [1]`) and every class
-/// invariant result are unchanged. Types whose own invariants DO read a child
-/// collection (`HISTORY.events`, `ITEM_TABLE.rows`) keep the full [`run`]
-/// deserialize.
-///
-/// NOTE: emptying a child *collection* here means a malformation *inside*
-/// an array element is no longer reported at this ancestor's path — it is
-/// reported at that element's own recursion step instead (each collection member
-/// is a separate `_type` node the composition validator visits and dispatches).
-/// For array-element types the dispatcher does not cover (embedded non-LOCATABLE
-/// helpers such as `LINK` / `PARTICIPATION`, which carry no class invariant), a
-/// structural malformation that the full ancestor deserialize used to surface is
-/// no longer surfaced. This narrows only the redundant ancestor-cascade reporting
-/// on already-invalid input; the valid path and every test-pinned rejection are
-/// byte-identical, and the ITS-JSON schema gate remains the exhaustive
-/// structural oracle where one is required (this pass is the RM class-invariant
-/// check, not a schema validator — `422_COMPOSITION.yaml`).
-fn run_shallow<T: DeserializeOwned + Validate>(
-    ty: &str,
-    value: &Value,
-    out: &mut Vec<InvariantViolation>,
-) {
-    match from_canonical_value::<T>(&prune_child_nodes(value)) {
-        Ok(v) => v.validate_invariants(out),
-        Err(e) => record_type_mismatch(ty, &e, out),
-    }
-}
-
-/// A shallow copy of an RM node with every nested RM-node **collection** emptied,
-/// recursing through single-valued nested nodes (which are kept, so the node's
-/// own mandatory single attributes stay enforced on deserialize). Scalar arrays
-/// (e.g. `DV_MULTIMEDIA.data` octets) are kept as-is. See [`run_shallow`] for why
-/// this is sound for the structural container types.
-fn prune_child_nodes(value: &Value) -> Value {
-    let Value::Object(map) = value else {
-        return value.clone();
-    };
-    let ty = map.get("_type").and_then(Value::as_str);
-    let mut out = serde_json::Map::with_capacity(map.len());
-    for (key, child) in map {
-        let pruned = match child {
-            // An array of RM nodes: the children are recursed into (and fully
-            // validated) individually by the composition validator, so this
-            // node's own invariants never need them.
-            //
-            // A `1..*` container keeps ONE member (itself pruned), because its
-            // emission shape is non-empty by construction
-            // (`openehr_base::containers::NonEmptyVec`) and an emptied array
-            // would fail to decode — a false structural violation on valid
-            // input. Everything else is emptied outright.
-            //
-            // NOTE: emptying leaves an OPTIONAL container decoding to
-            // `Some(vec![])` — a present-but-empty list, the state
-            // `x /= Void implies not x.is_empty` forbids. That is safe here
-            // because the run_shallow classes' own invariants never read a child
-            // collection (this function's documented precondition), and that
-            // invariant family is judged on the RAW node by
-            // `openehr_rm::validate::nonempty_list_violations`, a layer outside
-            // the fast/typed pair — never on this pruned copy.
-            Value::Array(items) if items.iter().any(Value::is_object) => {
-                if ty.is_some_and(|t| lower_bound_one(t, key)) {
-                    Value::Array(items.first().map(prune_child_nodes).into_iter().collect())
-                } else {
-                    Value::Array(Vec::new())
-                }
-            }
-            // A single nested node: keep it (its presence is a structural
-            // constraint this node's deserialize must still enforce), but recurse
-            // to empty ITS child collections.
-            Value::Object(_) => prune_child_nodes(child),
-            // Scalars and scalar arrays: keep verbatim.
-            other => other.clone(),
-        };
-        out.insert(key.clone(), pruned);
-    }
-    Value::Object(out)
-}
-
-/// Whether the static RM model declares `attribute` of `ty` as a container with
-/// a cardinality lower bound of 1 — the attributes whose emission shape is
-/// `NonEmptyVec<T>` and which therefore cannot decode from an emptied array.
-fn lower_bound_one(ty: &str, attribute: &str) -> bool {
-    openehr_rm::model::attributes(ty)
-        .any(|a| a.name == attribute && a.cardinality.is_some_and(|c| c.lower >= 1))
-}
 
 /// Run the **core** (non-terminology) RM class invariants for a single
 /// canonical-JSON node, dispatching on its `_type`. A node with no (or an
@@ -311,38 +191,40 @@ pub fn validate_rm_value(value: &Value, out: &mut Vec<InvariantViolation>) {
 /// every node (the fast path may only *skip* it when its result is provably
 /// identical); also the oracle the fast-path equivalence tests compare against.
 ///
-/// The hand-written table below covers the concrete `openehr-rm` /
-/// `openehr-base` types that carry a non-terminology class invariant (the ones
-/// with a `*_impl.rs` sibling) — those need a typed value to run the invariant
-/// on. **Every other class falls through to the GENERATED structural dispatch**
-/// ([`structural_check`], emitted by `openehr-codegen -- emit-json`), which
-/// decodes the node into that class's own Rust type and discards it: the codec
-/// is the structural-conformance authority for the whole emitted model, so a
-/// class with no invariant is still refused when it is structurally defective
-/// (a missing mandatory attribute, a wrong JSON kind, an unresolvable nested
-/// slot `_type`). `DV_INTERVAL` is dispatched with a `DvOrdered` element type so
-/// the `Limits_consistent` ordering invariant is reached, falling
-/// back to `serde_json::Value` (own boundary-flag invariants only) when the
-/// limits do not deserialize as typed `DV_ORDERED` values. The other generic
-/// containers (`HISTORY`, `POINT_EVENT`, `INTERVAL_EVENT`) are checked with
-/// `serde_json::Value` as the element type — enough for their own (non-child)
-/// invariants.
+/// The tier is composed here from three parts, in this exact order:
+///
+/// 1. the **undeclared-key refusal**, ahead of any decode (the private
+///    `undeclared_key` walk over [`declared_fields`]);
+/// 2. the **typed table**
+///    ([`openehr_rm::validate::typed_dispatch::dispatch_typed`]), which covers
+///    the concrete `openehr-rm` / `openehr-base` types carrying a
+///    non-terminology class invariant — those need a typed value to run the
+///    invariant on;
+/// 3. for every class the table declines (`false`), the **GENERATED structural
+///    dispatch** ([`structural_check`], emitted by
+///    `openehr-codegen -- emit-json`), which decodes the
+///    node into that class's own Rust type and discards it: the codec is the
+///    structural-conformance authority for the whole emitted model, so a class
+///    with no invariant is still refused when it is structurally defective (a
+///    missing mandatory attribute, a wrong JSON kind, an unresolvable nested
+///    slot `_type`). This step is what keeps the composition here rather than
+///    upstream — the generated dispatch spans every spec crate at once.
 ///
 /// # The inherited LOCATABLE invariant
 ///
-/// After the table runs, the inherited `LOCATABLE.Archetype_node_id_valid`
+/// After the dispatch runs, the inherited `LOCATABLE.Archetype_node_id_valid`
 /// (`not archetype_node_id.is_empty`,
 /// `docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.common.locatable.adoc`
 /// §Invariants) is closed out for **every** concrete LOCATABLE descendant via
 /// [`openehr_rm::validate::locatable_node_id_violation`], whose applicable-type
 /// set is the generated RM model's transitive concrete-descendant closure of
-/// LOCATABLE — not a hand-maintained list. The arms above realize it themselves
-/// through their typed `Validate` impls, so the violation is appended only when
-/// this node's own pass did not already report it (reported exactly once per
-/// node). The classes with no arm — `ITEM_TREE`, `ITEM_LIST`, `ITEM_SINGLE`,
-/// `EHR_STATUS`, and the demographic / EHR_EXTRACT LOCATABLEs — reach the
-/// generated structural fallthrough, which decodes but runs no invariant, so
-/// this is where the inherited invariant becomes theirs too.
+/// LOCATABLE — not a hand-maintained list. The typed table's arms realize it
+/// themselves through their typed `Validate` impls, so the violation is appended
+/// only when this node's own pass did not already report it (reported exactly
+/// once per node). The classes with no arm — `ITEM_TREE`, `ITEM_LIST`,
+/// `ITEM_SINGLE`, `EHR_STATUS`, and the demographic / EHR_EXTRACT LOCATABLEs —
+/// reach the generated structural fallthrough, which decodes but runs no
+/// invariant, so this is where the inherited invariant becomes theirs too.
 ///
 /// Placing the closeout in the typed tier (rather than above both tiers) keeps
 /// the fast-vs-typed equivalence property exact: the fast path vouches only for
@@ -362,7 +244,9 @@ pub fn validate_rm_value_typed(ty: &str, value: &Value, out: &mut Vec<InvariantV
         return;
     }
     let before = out.len();
-    dispatch_typed(ty, value, out);
+    if !openehr_rm::validate::typed_dispatch::dispatch_typed(ty, value, out) {
+        run_structural(ty, value, out);
+    }
     if let Some(v) = openehr_rm::validate::locatable_node_id_violation(ty, value)
         && !out.get(before..).is_some_and(|added| added.contains(&v))
     {
@@ -370,160 +254,14 @@ pub fn validate_rm_value_typed(ty: &str, value: &Value, out: &mut Vec<InvariantV
     }
 }
 
-/// The `_type` → `run::<T>` table of [`validate_rm_value_typed`].
-#[expect(
-    clippy::too_many_lines,
-    reason = "a flat `_type` -> `run::<T>` dispatch table; the length is the size of the RM type set, not logic"
-)]
-fn dispatch_typed(ty: &str, value: &Value, out: &mut Vec<InvariantViolation>) {
-    use openehr_base::base_types::identification::archetype_id::ArchetypeId;
-    use openehr_base::base_types::identification::internet_id::InternetId;
-    use openehr_base::base_types::identification::iso_oid::IsoOid;
-    use openehr_base::base_types::identification::object_ref::ObjectRefData;
-    use openehr_base::base_types::identification::object_version_id::ObjectVersionId;
-    use openehr_base::base_types::identification::party_ref::PartyRef;
-    use openehr_base::base_types::identification::terminology_id::TerminologyId;
-    use openehr_base::base_types::identification::version_tree_id::VersionTreeId;
-
-    use openehr_rm::common::archetyped::archetyped::Archetyped;
-    use openehr_rm::common::archetyped::feeder_audit_details::FeederAuditDetails;
-    use openehr_rm::common::directory::folder::Folder;
-    use openehr_rm::common::generic::attestation::Attestation;
-    use openehr_rm::common::generic::audit_details::AuditDetailsData;
-    use openehr_rm::common::generic::party_identified::PartyIdentifiedData;
-    use openehr_rm::common::generic::party_related::PartyRelated;
-    use openehr_rm::common::tags::item_tag::ItemTag;
-    use openehr_rm::composition::composition::Composition;
-    use openehr_rm::composition::content::entry::action::Action;
-    use openehr_rm::composition::content::entry::activity::Activity;
-    use openehr_rm::composition::content::entry::admin_entry::AdminEntry;
-    use openehr_rm::composition::content::entry::evaluation::Evaluation;
-    use openehr_rm::composition::content::entry::instruction::Instruction;
-    use openehr_rm::composition::content::entry::instruction_details::InstructionDetails;
-    use openehr_rm::composition::content::entry::observation::Observation;
-    use openehr_rm::composition::content::navigation::section::Section;
-    use openehr_rm::composition::event_context::EventContext;
-    use openehr_rm::data_structures::history::history::History;
-    use openehr_rm::data_structures::history::interval_event::IntervalEvent;
-    use openehr_rm::data_structures::history::point_event::PointEvent;
-    use openehr_rm::data_structures::item_structure::item_table::ItemTable;
-    use openehr_rm::data_structures::representation::cluster::Cluster;
-    use openehr_rm::data_structures::representation::element::Element;
-    use openehr_rm::data_types::basic::dv_identifier::DvIdentifier;
-    use openehr_rm::data_types::encapsulated::dv_multimedia::DvMultimedia;
-    use openehr_rm::data_types::encapsulated::dv_parsable::DvParsable;
-    use openehr_rm::data_types::quantity::date_time::dv_date::DvDate;
-    use openehr_rm::data_types::quantity::date_time::dv_date_time::DvDateTime;
-    use openehr_rm::data_types::quantity::date_time::dv_duration::DvDuration;
-    use openehr_rm::data_types::quantity::date_time::dv_time::DvTime;
-    use openehr_rm::data_types::quantity::dv_count::DvCount;
-    use openehr_rm::data_types::quantity::dv_interval::DvInterval;
-    use openehr_rm::data_types::quantity::dv_ordered::DvOrdered;
-    use openehr_rm::data_types::quantity::dv_ordinal::DvOrdinal;
-    use openehr_rm::data_types::quantity::dv_proportion::DvProportion;
-    use openehr_rm::data_types::quantity::dv_quantity::DvQuantity;
-    use openehr_rm::data_types::quantity::dv_scale::DvScale;
-    use openehr_rm::data_types::quantity::reference_range::ReferenceRange;
-    use openehr_rm::data_types::text::code_phrase::CodePhrase;
-    use openehr_rm::data_types::text::dv_text::DvText;
-    use openehr_rm::data_types::text::term_mapping::TermMapping;
-    use openehr_rm::data_types::time_specification::dv_periodic_time_specification::DvPeriodicTimeSpecification;
-    use openehr_rm::data_types::uri::dv_ehr_uri::DvEhrUri;
-    use openehr_rm::data_types::uri::dv_uri::DvUriData;
-    use openehr_rm::integration::generic_entry::GenericEntry;
-
-    match ty {
-        // data_types
-        "CODE_PHRASE" => run::<CodePhrase>(ty, value, out),
-        // DV_TEXT + DV_CODED_TEXT share the DvText enum (Valid_value /
-        // Formatting_valid, dv_text.adoc; DV_CODED_TEXT adds the structural
-        // defining_code 1..1 at deserialize).
-        "DV_TEXT" | "DV_CODED_TEXT" => run::<DvText>(ty, value, out),
-        "DV_URI" => run::<DvUriData>(ty, value, out),
-        "DV_EHR_URI" => run::<DvEhrUri>(ty, value, out),
-        "DV_IDENTIFIER" => run::<DvIdentifier>(ty, value, out),
-        "TERM_MAPPING" => run::<TermMapping>(ty, value, out),
-        "DV_MULTIMEDIA" => run::<DvMultimedia>(ty, value, out),
-        "DV_PROPORTION" => run::<DvProportion>(ty, value, out),
-        "DV_QUANTITY" => run::<DvQuantity>(ty, value, out),
-        "DV_COUNT" => run::<DvCount>(ty, value, out),
-        "DV_DURATION" => run::<DvDuration>(ty, value, out),
-        "DV_DATE" => run::<DvDate>(ty, value, out),
-        "DV_TIME" => run::<DvTime>(ty, value, out),
-        "DV_DATE_TIME" => run::<DvDateTime>(ty, value, out),
-        "DV_ORDINAL" => run::<DvOrdinal>(ty, value, out),
-        "DV_SCALE" => run::<DvScale>(ty, value, out),
-        "DV_PARSABLE" => run::<DvParsable>(ty, value, out),
-        "DV_PERIODIC_TIME_SPECIFICATION" => run::<DvPeriodicTimeSpecification>(ty, value, out),
-        "REFERENCE_RANGE" => run::<ReferenceRange>(ty, value, out),
-        // DV_INTERVAL: prefer the DV_ORDERED-typed element so the
-        // Limits_consistent ordering invariant runs; fall back to
-        // Value elements (boundary flags only) for non-DV_ORDERED payloads.
-        "DV_INTERVAL" => {
-            if let Ok(v) = from_canonical_value::<DvInterval<DvOrdered>>(value) {
-                v.validate_invariants(out);
-            } else {
-                run::<DvInterval<Value>>(ty, value, out);
-            }
-        }
-        // data_structures. HISTORY and ITEM_TABLE keep the full deserialize —
-        // their own invariants read a child collection (`events` / `rows`); the
-        // rest are structural containers with scalar-only invariants, so they
-        // deserialize shallowly (see `run_shallow`).
-        "ELEMENT" => run::<Element>(ty, value, out),
-        "CLUSTER" => run_shallow::<Cluster>(ty, value, out),
-        "HISTORY" => run::<History<Value>>(ty, value, out),
-        "POINT_EVENT" => run_shallow::<PointEvent<Value>>(ty, value, out),
-        "INTERVAL_EVENT" => run_shallow::<IntervalEvent<Value>>(ty, value, out),
-        "ITEM_TABLE" => run::<ItemTable>(ty, value, out),
-        // common
-        "PARTY_IDENTIFIED" => run::<PartyIdentifiedData>(ty, value, out),
-        "PARTY_RELATED" => run::<PartyRelated>(ty, value, out),
-        "AUDIT_DETAILS" => run::<AuditDetailsData>(ty, value, out),
-        "ATTESTATION" => run::<Attestation>(ty, value, out),
-        "FEEDER_AUDIT_DETAILS" => run::<FeederAuditDetails>(ty, value, out),
-        "ARCHETYPED" => run::<Archetyped>(ty, value, out),
-        // ehr / composition — structural containers (scalar-only invariants),
-        // deserialized shallowly (see `run_shallow`). GENERIC_ENTRY's `data:
-        // ITEM [1..1]` is a single-valued node, so `run_shallow` keeps it and
-        // still enforces its presence.
-        "COMPOSITION" => run_shallow::<Composition>(ty, value, out),
-        "EVENT_CONTEXT" => run_shallow::<EventContext>(ty, value, out),
-        "ACTIVITY" => run_shallow::<Activity>(ty, value, out),
-        "INSTRUCTION_DETAILS" => run::<InstructionDetails>(ty, value, out),
-        "OBSERVATION" => run_shallow::<Observation>(ty, value, out),
-        "INSTRUCTION" => run_shallow::<Instruction>(ty, value, out),
-        "ACTION" => run_shallow::<Action>(ty, value, out),
-        "EVALUATION" => run_shallow::<Evaluation>(ty, value, out),
-        "ADMIN_ENTRY" => run_shallow::<AdminEntry>(ty, value, out),
-        "GENERIC_ENTRY" => run_shallow::<GenericEntry>(ty, value, out),
-        "SECTION" => run_shallow::<Section>(ty, value, out),
-        "FOLDER" => run_shallow::<Folder>(ty, value, out),
-        "ITEM_TAG" => run::<ItemTag>(ty, value, out),
-        // base identification
-        "OBJECT_REF" => run::<ObjectRefData>(ty, value, out),
-        "PARTY_REF" => run::<PartyRef>(ty, value, out),
-        "VERSION_TREE_ID" => run::<VersionTreeId>(ty, value, out),
-        "OBJECT_VERSION_ID" => run::<ObjectVersionId>(ty, value, out),
-        "ISO_OID" => run::<IsoOid>(ty, value, out),
-        "ARCHETYPE_ID" => run::<ArchetypeId>(ty, value, out),
-        "TERMINOLOGY_ID" => run::<TerminologyId>(ty, value, out),
-        "INTERNET_ID" => run::<InternetId>(ty, value, out),
-        // Every other class: the GENERATED structural dispatch decodes the node
-        // into that class's own Rust type and discards it, so the codec is the
-        // structural-conformance authority for the whole emitted model instead of
-        // only the invariant-bearing classes above.
-        other => run_structural(other, value, out),
-    }
-}
-
 /// The generated-dispatch fallthrough of [`validate_rm_value_typed`]: decode the
 /// node as the class its `_type` names and record a structural violation when it
 /// does not conform.
 ///
-/// The classes handled by the hand-written dispatch above already decode (their
-/// arm calls [`run`] / [`run_shallow`], which reports the same
-/// `does not conform to RM type …` on failure), so they never reach here — no
+/// The classes the typed table
+/// ([`openehr_rm::validate::typed_dispatch::dispatch_typed`]) handles already
+/// decode there — its arms report the same `does not conform to RM type …` on
+/// failure — and the table returns `true` for them, so they never reach here: no
 /// node is decoded twice. A `_type` naming no emitted class
 /// ([`structural_check`] returns `None`) runs no check, unchanged: an
 /// unrecognised type is not a structural claim this layer can adjudicate.

--- a/crates/openehr-its/tests/it/dispatch_lockstep.rs
+++ b/crates/openehr-its/tests/it/dispatch_lockstep.rs
@@ -10,7 +10,7 @@
 //!
 //! Two dispatch tables decide which tier judges an RM node: the allocation-free
 //! fast path (`openehr_rm::validate::fast::try_validate`) and the authoritative
-//! typed dispatch (`openehr_its::wire_validate::validate_rm_value_typed`). A
+//! typed dispatch (`openehr_rm::validate::typed_dispatch::dispatch_typed`). A
 //! class present in one and absent from the other silently changes which tier
 //! judges it, and a class whose DEPTH disagrees (`run` vs `run_shallow`) changes
 //! which of its children are decoded — both are wire-visible. Until now the only
@@ -33,8 +33,10 @@
 
 use std::collections::BTreeMap;
 
-/// The typed dispatch source (`validate_rm_value_typed`'s `match ty` block).
-const TYPED_SRC: &str = include_str!("../../src/wire_validate.rs");
+/// The typed dispatch source (`dispatch_typed`'s `match ty` block). It lives in
+/// `openehr-rm` beside the fast path; this crate keeps only the generated
+/// five-crate structural fallthrough and the thin wire entry points.
+const TYPED_SRC: &str = include_str!("../../../openehr-rm/src/validate/typed_dispatch.rs");
 /// The fast-path dispatch source (`try_validate`'s `let shallow = match ty`).
 const FAST_SRC: &str = include_str!("../../../openehr-rm/src/validate/fast.rs");
 
@@ -84,20 +86,20 @@ fn depth_of(text: &str) -> Option<Depth> {
     }
 }
 
-/// Extract the typed dispatch table from `validate_rm_value_typed`.
+/// Extract the typed dispatch table from `dispatch_typed`.
 ///
 /// Each arm is `<literals> => <body>`; the body names `run::<T>` (full) or
 /// `run_shallow::<T>` (shallow). The one block-bodied arm (`DV_INTERVAL`)
 /// spans several lines and is attributed by the first runner call inside it.
 fn typed_table(src: &str) -> BTreeMap<String, Depth> {
     let src = without_comments(src);
-    let start = src
-        .find("fn validate_rm_value_typed")
-        .expect("typed dispatch fn");
+    let start = src.find("fn dispatch_typed").expect("typed dispatch fn");
     let body = &src[start..];
     let m = body.find("match ty {").expect("typed match block");
     let body = &body[m..];
-    let end = body.find("other =>").expect("typed fallthrough arm");
+    let end = body
+        .find("_ => return false")
+        .expect("typed fallthrough arm");
     let block = &body[..end];
 
     let mut arms: Vec<(Vec<String>, Option<Depth>)> = Vec::new();

--- a/crates/openehr-its/tests/it/fidelity.rs
+++ b/crates/openehr-its/tests/it/fidelity.rs
@@ -299,9 +299,11 @@ fn generated_rm_round_trips_the_openehr_sdk_corpus() {
 /// generated RM types, **validates against the vendored ITS-JSON schema**
 /// (`openehr_rm_1.1.0_all.json`). This proves our output conforms to the openEHR
 /// JSON contract, not merely that it round-trips. All 53 canonical files
-/// conform with no schema-specific exclusions (the RM 1.1↔1.2 divergence does
-/// not break validation — the schema's per-class definitions accept our output);
-/// only the shared readability/round-trip exclusions apply.
+/// conform with no schema-specific exclusions (none of the current corpus
+/// carries an RM 1.2.0-only attribute); the CLOSED schema's exact
+/// 1.1.0↔1.2.0 attribute delta — what WOULD fail here and why — is
+/// machine-pinned by `its_json_delta.rs` (#1697). Only the shared
+/// readability/round-trip exclusions apply.
 #[test]
 fn generated_rm_output_validates_against_its_json_schema() {
     let mut ok = 0;

--- a/crates/openehr-its/tests/it/its_json_delta.rs
+++ b/crates/openehr-its/tests/it/its_json_delta.rs
@@ -1,0 +1,153 @@
+#![allow(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test fixtures/diagnostics — a malformed vendored schema should fail loudly"
+)]
+//! The ITS-JSON oracle-age pin (#1697): the fidelity gate's validation oracle
+//! (`openehr_its::json::RM_SCHEMA_JSON`, the vendored RM **1.1.0** ITS-JSON
+//! all-schema) is a CLOSED schema (`additionalProperties: false` per class)
+//! judging RM **1.2.0**-generation output. This module machine-derives the
+//! full per-class attribute delta between that schema and the generated RM
+//! 1.2.0 model (`openehr_rm::model`) on every run and pins it — the XSD-gate
+//! precedent (`xml_xsd_validity.rs`): the known 1.1.0↔1.2.0 divergence is
+//! ADJUDICATED and visible, and any NEW divergence (a pin bump, an emitter
+//! change, a re-vendored schema) fails loud instead of surfacing later as a
+//! spurious wire-validation failure.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Attributes the generated RM 1.2.0 model declares that the 1.1.0 schema's
+/// CLOSED class definition does not — an instance carrying one is REFUSED by
+/// the oracle even though it is correct RM 1.2.0. Format: `CLASS.attribute`.
+const MODEL_ONLY: &[&str] = &[
+    // RM 1.2.0 addition (RM ehr master04 §EHR: `tags`): the first RM
+    // 1.2.0-only attribute; a served EHR carrying tags fails the 1.1.0 oracle.
+    "EHR.tags",
+    // The RM 1.2.0 development text's misspelled attribute (upstream report
+    // #1849 — SPECPUB-6 was applied to BASE's resource copy only); the 1.1.0
+    // schema spells `accreditation`.
+    "TRANSLATION_DETAILS.accreditaton",
+];
+
+/// Properties the 1.1.0 schema declares that the RM 1.2.0 model has dropped —
+/// the oracle ACCEPTS shapes that are no longer valid RM 1.2.0. Format:
+/// `CLASS.attribute`.
+const SCHEMA_ONLY: &[&str] = &[
+    // RM 1.2.0 removed PARTY.reverse_relationships (RM demographic master05
+    // §PARTY class — the attribute is gone from the 1.2.0 generation); the
+    // 1.1.0 schema still declares it on every concrete PARTY subtype.
+    "AGENT.reverse_relationships",
+    "GROUP.reverse_relationships",
+    "ORGANISATION.reverse_relationships",
+    "PERSON.reverse_relationships",
+    "ROLE.reverse_relationships",
+    // RM 1.2.0 removed DV_QUANTITY.property (RM data_types master04
+    // §DV_QUANTITY — the 1.1.0-era attribute is gone from the class table).
+    "DV_QUANTITY.property",
+    // The 1.1.0 schema derives SYNC_EXTRACT(_REQUEST) from LOCATABLE; the RM
+    // 1.2.0 sync package no longer does, so the LOCATABLE member set is
+    // schema-only there.
+    "SYNC_EXTRACT.archetype_details",
+    "SYNC_EXTRACT.archetype_node_id",
+    "SYNC_EXTRACT.feeder_audit",
+    "SYNC_EXTRACT.links",
+    "SYNC_EXTRACT.name",
+    "SYNC_EXTRACT.uid",
+    "SYNC_EXTRACT_REQUEST.archetype_details",
+    "SYNC_EXTRACT_REQUEST.archetype_node_id",
+    "SYNC_EXTRACT_REQUEST.feeder_audit",
+    "SYNC_EXTRACT_REQUEST.links",
+    "SYNC_EXTRACT_REQUEST.name",
+    "SYNC_EXTRACT_REQUEST.uid",
+    // The correctly-spelled 1.1.0 property — the twin of the MODEL_ONLY
+    // `accreditaton` pin (upstream report #1849).
+    "TRANSLATION_DETAILS.accreditation",
+];
+
+/// Schema class definitions with no generated RM 1.2.0 class of that name.
+const SCHEMA_ONLY_CLASSES: &[&str] = &[
+    // BASE foundation/base-types classes the schema embeds for reference —
+    // they live in `openehr-base`, not the RM attribute model, so a name
+    // lookup in `openehr_rm::model` legitimately misses them. Their per-class
+    // property shape is exercised structurally through the RM classes that
+    // embed them.
+    "ARCHETYPE_HRID",
+    "ARRAY",
+    "DATE",
+    "DATE_TIME",
+    "DURATION",
+    "INTERVAL",
+    "ISO8601_TYPE",
+    "LIST",
+    "SET",
+    "TERMINOLOGY_CODE",
+    "TERMINOLOGY_TERM",
+    "TIME",
+    "URI",
+];
+
+fn schema_definitions() -> BTreeMap<String, BTreeSet<String>> {
+    let schema: serde_json::Value =
+        serde_json::from_str(openehr_its::json::RM_SCHEMA_JSON).expect("vendored schema parses");
+    let defs = schema["definitions"].as_object().expect("definitions");
+    defs.iter()
+        .filter_map(|(name, def)| {
+            let props = def.get("properties")?.as_object()?;
+            Some((
+                name.clone(),
+                props.keys().filter(|k| *k != "_type").cloned().collect(),
+            ))
+        })
+        .collect()
+}
+
+#[test]
+fn the_1_1_0_oracle_delta_is_exactly_the_pinned_set() {
+    let defs = schema_definitions();
+    let mut model_only = BTreeSet::new();
+    let mut schema_only = BTreeSet::new();
+    let mut schema_only_classes = BTreeSet::new();
+
+    for (class, props) in &defs {
+        let Some(rm) = openehr_rm::model::class(class) else {
+            schema_only_classes.insert(class.clone());
+            continue;
+        };
+        let model_attrs: BTreeSet<&str> = rm.attributes.iter().map(|a| a.name).collect();
+        for attr in &model_attrs {
+            if !props.contains(*attr) {
+                model_only.insert(format!("{class}.{attr}"));
+            }
+        }
+        for prop in props {
+            if !model_attrs.contains(prop.as_str()) {
+                schema_only.insert(format!("{class}.{prop}"));
+            }
+        }
+    }
+
+    let pin = |set: &BTreeSet<String>, pinned: &[&str], what: &str| {
+        let pinned: BTreeSet<String> = pinned.iter().map(|s| (*s).to_owned()).collect();
+        let new: Vec<&String> = set.difference(&pinned).collect();
+        let gone: Vec<&String> = pinned.difference(set).collect();
+        assert!(
+            new.is_empty() && gone.is_empty(),
+            "{what} delta drifted from the adjudicated pin (#1697)\n  NEW (adjudicate + pin): {new:#?}\n  GONE (unpin): {gone:#?}"
+        );
+    };
+    pin(
+        &model_only,
+        MODEL_ONLY,
+        "model-only (RM 1.2.0 attribute the CLOSED 1.1.0 oracle refuses)",
+    );
+    pin(
+        &schema_only,
+        SCHEMA_ONLY,
+        "schema-only (1.1.0 property RM 1.2.0 dropped)",
+    );
+    pin(
+        &schema_only_classes,
+        SCHEMA_ONLY_CLASSES,
+        "schema-only classes",
+    );
+}

--- a/crates/openehr-its/tests/it/main.rs
+++ b/crates/openehr-its/tests/it/main.rs
@@ -30,6 +30,7 @@ mod fidelity;
 mod fixture_twins;
 mod flat;
 mod format_parity;
+mod its_json_delta;
 mod json_codec_parity;
 mod master05_tables;
 mod model_walkgen;

--- a/crates/openehr-its/tests/it/rm_validation.rs
+++ b/crates/openehr-its/tests/it/rm_validation.rs
@@ -9,15 +9,19 @@
 //! The **wire-boundary RM class-invariant dispatcher** gate
 //! (`openehr_its::wire_validate`).
 //!
-//! These tests moved here with the typed dispatcher (from `openehr-rm`'s
-//! `validate.rs`/`validate/fast.rs`): the fast path (`openehr_rm::validate::
-//! try_fast_validate`, untyped, in `openehr-rm`) and the typed path
-//! (`validate_rm_value_typed`, via the native codec, in this crate) are only both
-//! reachable here — `openehr-rm` is upstream of the codec. The assertions are
-//! unchanged: the two-tier entry point must produce byte-identical violations to
-//! the authoritative typed oracle over the whole corpus, and the fast path must
-//! vouch only when it is provably equivalent (declining to the typed path
-//! otherwise).
+//! Both validation tiers are RM model semantics and live in `openehr-rm`: the
+//! fast path (`openehr_rm::validate::try_fast_validate`, untyped) and the typed
+//! dispatch (`openehr_rm::validate::typed_dispatch::dispatch_typed`, which
+//! decodes through the emitted canonical-JSON `serde` impls). What this crate
+//! keeps — and why the gate runs HERE — is the composition: the GENERATED
+//! five-crate structural fallthrough
+//! (`openehr_its::json_codec::generated::structural`, which spans every spec
+//! crate at once and can only be emitted downstream of all of them) and the thin
+//! wire entry points that fix the order the tiers and the orthogonal layers run
+//! in. The assertions are unchanged: the two-tier entry point must produce
+//! byte-identical violations to the authoritative typed oracle over the whole
+//! corpus, and the fast path must vouch only when it is provably equivalent
+//! (declining to the typed path otherwise).
 
 use openehr_base::validate::InvariantViolation;
 use openehr_its::wire_validate::{

--- a/crates/openehr-rm/CLAUDE.md
+++ b/crates/openehr-rm/CLAUDE.md
@@ -32,8 +32,17 @@ BMM** by `openehr-codegen -- emit`. Versioned by the spec
   `validate/terminology.rs` is the openEHR terminology-group / code-set binding
   table over the `openehr-term` bundle — **this crate DOES depend on
   `openehr-term`** (`openehr-term` reaches only `openehr-base`, so there is no
-  cycle). Every RM decision belongs here; `openehr-its` only dispatches, walks
-  instances, and prefixes paths.
+  cycle). Its sibling `validate/typed_dispatch.rs` is the AUTHORITATIVE typed
+  tier: the `_type` → concrete-RM-type table that decodes a node through the
+  emitted canonical-JSON `serde` impls and runs that class's `Validate` impl,
+  returning `false` for a class it does not name (the caller then runs the
+  GENERATED five-crate structural fallthrough, which can only be emitted
+  downstream in `openehr-its`). Its table must stay in LOCKSTEP with
+  `validate/fast.rs` — class membership and decode depth (`run` vs
+  `run_shallow`) — a relationship the `dispatch_lockstep` gate in
+  `openehr-its/tests/it/` derives from both sources. Every RM decision belongs
+  here; `openehr-its` only composes the tiers, walks instances, and prefixes
+  paths.
 - Emission conventions are settled — do not re-litigate per class: closed
   subtype sets → untagged enums; recursion → `Box`; `_type` via the EMITTED
   manual `serde::Serialize`/`Deserialize` impls in `src/json_serde.rs` (never a

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -27,6 +27,10 @@ openehr-term = { path = "../openehr-term" }
 serde.workspace = true
 serde_json.workspace = true
 serde_jcs.workspace = true
+# The typed-dispatch tier (`validate::typed_dispatch`) re-reads a failing node
+# with the path tracker so a refusal names the offending JSON node, exactly as
+# the canonical-JSON entry points do.
+serde_path_to_error.workspace = true
 thiserror.workspace = true
 uuid.workspace = true
 

--- a/crates/openehr-rm/src/validate.rs
+++ b/crates/openehr-rm/src/validate.rs
@@ -28,15 +28,20 @@
 //!    `master06-change_control_package.adoc` §Incomplete Content splits a
 //!    node's structural judgement into. Used only by the relaxed
 //!    (`553|incomplete|`) commit path; the strict path never calls them.
+//! 5. **The typed-dispatch tier**, in the sibling [`typed_dispatch`] module:
+//!    the `_type` → concrete-RM-type table that *deserializes* a node through
+//!    the emitted canonical-JSON `serde` impls (`crate::json_serde`) and runs
+//!    that class's `Validate` impl — the authoritative oracle the fast path may
+//!    only skip when its result is provably identical.
 //!
-//! Kept OUT of this crate, in `openehr-its`: the typed-dispatch tier that
-//! *deserializes* a node into its concrete RM type, because it drives the
-//! native canonical-JSON codec (`from_json_value`) defined downstream there,
-//! and the walkers that recurse an instance and prefix absolute RM paths. The
-//! `Validate` trait and the invariant impls (`*_impl.rs`) stay here as model
-//! semantics; the wire-boundary entry point
+//! Kept OUT of this crate, in `openehr-its`: the GENERATED five-crate
+//! structural dispatch that [`typed_dispatch::dispatch_typed`] falls through to
+//! (it spans `openehr-base`/`-rm`/`-am`/`-term`/`-lang` at once, so it can only
+//! be emitted downstream of all of them), the thin wire-boundary entry points
+//! that compose the tiers, and the walkers that recurse an instance and prefix
+//! absolute RM paths. The wire-boundary entry point
 //! `openehr_its::wire_validate::validate_rm_value` calls [`try_fast_validate`]
-//! then falls back to its typed dispatch.
+//! then falls back to [`typed_dispatch::dispatch_typed`].
 //!
 //! # Fidelity to the reference implementation (archie)
 //!
@@ -83,6 +88,10 @@ pub mod incomplete;
 // the detail — an outer doc attribute here would force rustdoc to resolve the
 // module's intra-doc links in THIS module's scope instead of its own).
 pub mod terminology;
+// The typed-dispatch tier (its own `//!` module docs carry the detail — an
+// outer doc attribute here would force rustdoc to resolve the module's
+// intra-doc links in THIS module's scope instead of its own).
+pub mod typed_dispatch;
 
 /// Run the allocation-free fast-path RM class-invariant check for a single
 /// canonical-JSON node, dispatching on its `_type`. Returns `true` when the fast
@@ -877,10 +886,13 @@ mod tests {
     }
 
     // NOTE: the `_type`-dispatch tests (fast/typed equivalence, corpus, mutation
-    // battery) moved with the typed dispatcher to
-    // `openehr-its/tests/rm_validation.rs`, where both the fast path
-    // (`try_fast_validate`) and the typed path (`from_json_value`) are reachable.
-    // The ISO-8601 helper tests below stay with the helpers they exercise.
+    // battery) live in `openehr-its/tests/it/rm_validation.rs`, where the tiers
+    // are reachable through the COMPOSED wire entry points — the fast path
+    // (`try_fast_validate`) and the typed table
+    // (`typed_dispatch::dispatch_typed`) both live in this crate, but the
+    // generated five-crate structural fallthrough they are composed with can
+    // only exist downstream. The ISO-8601 helper tests below stay with the
+    // helpers they exercise.
 
     /// BASE `Iso8601_timezone`: `+` offsets reach +14:00, `-` offsets stop at
     /// -12:00; ±00:00 accepted per the corpus (see `is_valid_tz`).

--- a/crates/openehr-rm/src/validate/fast.rs
+++ b/crates/openehr-rm/src/validate/fast.rs
@@ -1,12 +1,14 @@
 //! The allocation-free fast path of the RM class-invariant check (hand-written),
-//! exposed via [`super::try_fast_validate`]. The wire-boundary two-tier entry
-//! point that calls it then falls back to the typed dispatch lives in
+//! exposed via [`super::try_fast_validate`]. The authoritative tier it declines
+//! to is the sibling [`super::typed_dispatch`]; the wire-boundary entry point
+//! that runs the two in order lives in
 //! `openehr_its::wire_validate::validate_rm_value`.
 //!
 //! No openEHR spec governs this module — it is our own performance design; the
 //! *semantics* it realizes are exactly those of the typed dispatch in
-//! [`super`] (the RM class invariants of the `*_impl.rs` siblings plus the
-//! structural type-conformance rejection of a typed deserialize).
+//! [`super::typed_dispatch`] (the RM class invariants of the `*_impl.rs`
+//! siblings plus the structural type-conformance rejection of a typed
+//! deserialize).
 //!
 //! # Design: vouch-or-fall-back
 //!
@@ -56,7 +58,7 @@
 //!   [`fast_spec`], the `Interval` default-able bound flags) → fall back.
 //!
 //! **Shallow mode** mirrors the typed dispatcher's `prune_child_nodes` (in
-//! `openehr_its::wire_validate`) for the structural container classes the typed
+//! [`super::typed_dispatch`]) for the structural container classes the typed
 //! path checks via `run_shallow`: a child
 //! *collection* is vouched without descending iff it is empty or contains at
 //! least one object (exactly the arrays the prune empties before the typed
@@ -88,7 +90,7 @@ pub(super) fn try_validate(ty: &str, value: &Value, out: &mut Vec<InvariantViola
     // Dispatch mode: which classes have a fast invariant evaluator, and
     // whether the typed path would deserialize them shallowly (`run_shallow`)
     // or in full (`run`). Must stay in lockstep with the typed dispatch table
-    // in `openehr_its::wire_validate` (`validate_rm_value_typed`).
+    // in `super::typed_dispatch` (`dispatch_typed`).
     let shallow = match ty {
         // `run_shallow` classes (structural containers, scalar-only invariants).
         "CLUSTER" | "POINT_EVENT" | "INTERVAL_EVENT" | "COMPOSITION" | "EVENT_CONTEXT"

--- a/crates/openehr-rm/src/validate/typed_dispatch.rs
+++ b/crates/openehr-rm/src/validate/typed_dispatch.rs
@@ -1,0 +1,409 @@
+//! The **typed dispatch tier** of the RM class-invariant check (hand-written):
+//! the `_type` → concrete-RM-type table that deserializes a canonical-JSON node
+//! into its class through the emitted canonical-JSON `serde` impls
+//! (`crate::json_serde`, `openehr-codegen -- emit-json`) and runs that class's
+//! [`Validate`] impl.
+//!
+//! It lives here, beside the fast path ([`super::try_fast_validate`]) and the
+//! invariant cores, because every decision it makes is RM model semantics: the
+//! set of classes carrying a class invariant, how deeply each is decoded before
+//! its invariants are read, and the message a non-conforming node produces. The
+//! spec types carry their own `serde` impls since the foundation-phase codec
+//! rewrite, so no downstream codec crate is needed to drive them.
+//!
+//! What is NOT here, and cannot be: the fallthrough for every class this table
+//! does not name. That is the GENERATED five-crate structural dispatch
+//! (`openehr_its::json_codec::generated::structural`), which spans
+//! `openehr-base`/`-rm`/`-am`/`-term`/`-lang` at once and therefore can only be
+//! emitted downstream of all of them. [`dispatch_typed`] reports the
+//! fallthrough as `false` and the wire-boundary entry point
+//! (`openehr_its::wire_validate::validate_rm_value_typed`) runs the generated
+//! dispatch for it, then closes out the inherited
+//! `LOCATABLE.Archetype_node_id_valid` rule
+//! ([`super::locatable_node_id_violation`]).
+//!
+//! # Fidelity to the reference implementation (archie)
+//!
+//! The RM class invariants (the `*_impl.rs` siblings) mirror openEHR's
+//! reference implementation archie; this module only routes a node to the right
+//! concrete type. A node that does not deserialize into its declared concrete
+//! RM type surfaces `does not conform to RM type …` (see
+//! [`record_type_mismatch`]).
+
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+use openehr_base::validate::{InvariantViolation, Validate};
+
+/// Record a typed-deserialize failure as a validation violation.
+///
+/// A node that does not deserialize into its declared concrete RM type is NOT
+/// "caught by the codec/schema layer" on the commit path: the node codec stores
+/// the raw canonical-JSON fragment verbatim (no openEHR spec governs the storage
+/// mechanics — our own storage design) and the ITS-JSON schema is not enforced
+/// at commit, so a missing mandatory attribute (e.g. `COMPOSITION.composer [1]`)
+/// or a wrong nested type (e.g. an `EHR_STATUS.subject` that is not `PARTY_SELF`)
+/// reaches here and nowhere else. Per ITS-REST `422_COMPOSITION.yaml` ("converts,
+/// but does not validate") this is a validation failure — surface it. (The valid
+/// corpus deserializes cleanly at every node, so this never rejects a valid
+/// input; if it ever did, that would expose a codegen field-optionality bug to
+/// fix in the emitter.)
+///
+/// Public because the two tiers that report the SAME refusal live on both sides
+/// of the crate boundary: this module's typed decode, and the wire-boundary
+/// layer's undeclared-key door plus the generated structural fallthrough. One
+/// message shape, one source.
+pub fn record_type_mismatch(
+    ty: &str,
+    err: &dyn std::fmt::Display,
+    out: &mut Vec<InvariantViolation>,
+) {
+    out.push(InvariantViolation::here(format!(
+        "does not conform to RM type {ty}: {err}"
+    )));
+}
+
+/// Deserialize `value` into `T` through the emitted canonical-JSON `serde`
+/// impls, rendering a failure exactly as the canonical-JSON entry point
+/// `openehr_its::json::from_canonical_value` renders it: the `serde_json`
+/// message, then ` (at $<path>)` when the path tracker located the offending
+/// node.
+///
+/// Two-phase, for the same reason the entry point is: the happy path reads
+/// WITHOUT the path tracker (`serde_path_to_error` wraps every key and value
+/// seed, which costs a large fraction of total read time on this corpus), and a
+/// failed read re-runs the same deterministic decode WITH the tracker purely to
+/// build the diagnostic (<https://docs.rs/serde_path_to_error/0.1>).
+fn decode<T: DeserializeOwned>(value: &Value) -> Result<T, String> {
+    match T::deserialize(value) {
+        Ok(decoded) => Ok(decoded),
+        Err(plain) => Err(match serde_path_to_error::deserialize::<_, T>(value) {
+            Err(located) => render_path_error(&located),
+            // A deterministic re-read of the same value cannot succeed where the
+            // first read failed; if it ever does, the original diagnostic still
+            // describes the failure — just without its path.
+            Ok(_) => plain.to_string(),
+        }),
+    }
+}
+
+/// Render a tracked read failure as `<message> (at $<path>)`, the shape
+/// `openehr_its::json::JsonParseError` displays.
+fn render_path_error(error: &serde_path_to_error::Error<serde_json::Error>) -> String {
+    let path: Vec<String> = error
+        .path()
+        .iter()
+        .map(|segment| match segment {
+            serde_path_to_error::Segment::Seq { index } => format!("[{index}]"),
+            serde_path_to_error::Segment::Map { key } => format!(".{key}"),
+            serde_path_to_error::Segment::Enum { variant } => format!(".{variant}"),
+            serde_path_to_error::Segment::Unknown => ".?".to_owned(),
+        })
+        .collect();
+    let message = error.inner().to_string();
+    if path.is_empty() {
+        message
+    } else {
+        format!("{message} (at ${})", path.join(""))
+    }
+}
+
+fn run<T: DeserializeOwned + Validate>(ty: &str, value: &Value, out: &mut Vec<InvariantViolation>) {
+    match decode::<T>(value) {
+        Ok(v) => v.validate_invariants(out),
+        Err(e) => record_type_mismatch(ty, &e, out),
+    }
+}
+
+/// Like [`run`], but deserialize `T` from a copy of `value` whose nested
+/// RM-node child collections have been emptied ([`prune_child_nodes`]).
+///
+/// NOTE (settled perf design — no openEHR spec governs validation-pass
+/// mechanics; our own design): the RM-invariant pass
+/// (`openehr_its::wire_validate::validate_rm_value`) is called once per
+/// `_type` node while the composition validator recurses the live JSON tree, so
+/// deserializing each node's *whole* subtree re-parses every descendant once per
+/// ancestor — O(Σ subtree sizes) for overlapping subtrees. This shallow variant
+/// is used for
+/// the LOCATABLE structural containers whose own class invariants inspect only
+/// scalar / single-object attributes (never a child collection): with the child
+/// arrays emptied, each node deserializes only its own immediate shape, so the
+/// pass is O(total nodes) instead of O(Σ subtree sizes). The node's own
+/// single-valued attributes are KEPT (only collections are emptied), so its
+/// mandatory-attribute presence and single-object type conformance are still
+/// enforced on deserialize — the missing-mandatory-attribute rejection
+/// (`422_COMPOSITION`, e.g. a dropped `COMPOSITION.composer [1]`) and every class
+/// invariant result are unchanged. Types whose own invariants DO read a child
+/// collection (`HISTORY.events`, `ITEM_TABLE.rows`) keep the full [`run`]
+/// deserialize.
+///
+/// NOTE: emptying a child *collection* here means a malformation *inside*
+/// an array element is no longer reported at this ancestor's path — it is
+/// reported at that element's own recursion step instead (each collection member
+/// is a separate `_type` node the composition validator visits and dispatches).
+/// For array-element types the dispatcher does not cover (embedded non-LOCATABLE
+/// helpers such as `LINK` / `PARTICIPATION`, which carry no class invariant), a
+/// structural malformation that the full ancestor deserialize used to surface is
+/// no longer surfaced. This narrows only the redundant ancestor-cascade reporting
+/// on already-invalid input; the valid path and every test-pinned rejection are
+/// byte-identical, and the ITS-JSON schema gate remains the exhaustive
+/// structural oracle where one is required (this pass is the RM class-invariant
+/// check, not a schema validator — `422_COMPOSITION.yaml`).
+fn run_shallow<T: DeserializeOwned + Validate>(
+    ty: &str,
+    value: &Value,
+    out: &mut Vec<InvariantViolation>,
+) {
+    match decode::<T>(&prune_child_nodes(value)) {
+        Ok(v) => v.validate_invariants(out),
+        Err(e) => record_type_mismatch(ty, &e, out),
+    }
+}
+
+/// A shallow copy of an RM node with every nested RM-node **collection** emptied,
+/// recursing through single-valued nested nodes (which are kept, so the node's
+/// own mandatory single attributes stay enforced on deserialize). Scalar arrays
+/// (e.g. `DV_MULTIMEDIA.data` octets) are kept as-is. See [`run_shallow`] for why
+/// this is sound for the structural container types.
+fn prune_child_nodes(value: &Value) -> Value {
+    let Value::Object(map) = value else {
+        return value.clone();
+    };
+    let ty = map.get("_type").and_then(Value::as_str);
+    let mut out = serde_json::Map::with_capacity(map.len());
+    for (key, child) in map {
+        let pruned = match child {
+            // An array of RM nodes: the children are recursed into (and fully
+            // validated) individually by the composition validator, so this
+            // node's own invariants never need them.
+            //
+            // A `1..*` container keeps ONE member (itself pruned), because its
+            // emission shape is non-empty by construction
+            // (`openehr_base::containers::NonEmptyVec`) and an emptied array
+            // would fail to decode — a false structural violation on valid
+            // input. Everything else is emptied outright.
+            //
+            // NOTE: emptying leaves an OPTIONAL container decoding to
+            // `Some(vec![])` — a present-but-empty list, the state
+            // `x /= Void implies not x.is_empty` forbids. That is safe here
+            // because the run_shallow classes' own invariants never read a child
+            // collection (this function's documented precondition), and that
+            // invariant family is judged on the RAW node by
+            // `super::nonempty_list_violations`, a layer outside
+            // the fast/typed pair — never on this pruned copy.
+            Value::Array(items) if items.iter().any(Value::is_object) => {
+                if ty.is_some_and(|t| lower_bound_one(t, key)) {
+                    Value::Array(items.first().map(prune_child_nodes).into_iter().collect())
+                } else {
+                    Value::Array(Vec::new())
+                }
+            }
+            // A single nested node: keep it (its presence is a structural
+            // constraint this node's deserialize must still enforce), but recurse
+            // to empty ITS child collections.
+            Value::Object(_) => prune_child_nodes(child),
+            // Scalars and scalar arrays: keep verbatim.
+            other => other.clone(),
+        };
+        out.insert(key.clone(), pruned);
+    }
+    Value::Object(out)
+}
+
+/// Whether the static RM model declares `attribute` of `ty` as a container with
+/// a cardinality lower bound of 1 — the attributes whose emission shape is
+/// `NonEmptyVec<T>` and which therefore cannot decode from an emptied array.
+fn lower_bound_one(ty: &str, attribute: &str) -> bool {
+    crate::model::attributes(ty)
+        .any(|a| a.name == attribute && a.cardinality.is_some_and(|c| c.lower >= 1))
+}
+
+/// The `_type` → concrete-RM-type table: deserialize the node into the class its
+/// `_type` names and run that class's `Validate` impl. Returns `true` when the
+/// class was handled here, `false` for the fallthrough — the caller then runs the
+/// GENERATED five-crate structural dispatch
+/// (`openehr_its::json_codec::generated::structural`), which cannot live in this
+/// crate because it spans every spec crate at once.
+///
+/// Authoritative for every node it handles (the fast path
+/// [`super::try_fast_validate`] may only *skip* it when its result is provably
+/// identical); also the oracle the fast-path equivalence tests compare against.
+///
+/// The table below covers the concrete `openehr-rm` / `openehr-base` types that
+/// carry a non-terminology class invariant (the ones with a `*_impl.rs` sibling)
+/// — those need a typed value to run the invariant on. **Every other class falls
+/// through**, and the generated structural dispatch decodes the node into that
+/// class's own Rust type and discards it: the codec is the structural-conformance
+/// authority for the whole emitted model, so a class with no invariant is still
+/// refused when it is structurally defective (a missing mandatory attribute, a
+/// wrong JSON kind, an unresolvable nested slot `_type`). `DV_INTERVAL` is
+/// dispatched with a `DvOrdered` element type so the `Limits_consistent` ordering
+/// invariant is reached, falling back to `serde_json::Value` (own boundary-flag
+/// invariants only) when the limits do not deserialize as typed `DV_ORDERED`
+/// values. The other generic containers (`HISTORY`, `POINT_EVENT`,
+/// `INTERVAL_EVENT`) are checked with `serde_json::Value` as the element type —
+/// enough for their own (non-child) invariants.
+///
+/// # The inherited LOCATABLE invariant
+///
+/// The inherited `LOCATABLE.Archetype_node_id_valid`
+/// (`not archetype_node_id.is_empty`,
+/// `docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.common.locatable.adoc`
+/// §Invariants) is closed out for **every** concrete LOCATABLE descendant by the
+/// caller, via [`super::locatable_node_id_violation`], whose applicable-type set
+/// is the generated RM model's transitive concrete-descendant closure of
+/// LOCATABLE — not a hand-maintained list. The arms below realize it themselves
+/// through their typed `Validate` impls, so the violation is appended only when
+/// this node's own pass did not already report it (reported exactly once per
+/// node). The classes with no arm — `ITEM_TREE`, `ITEM_LIST`, `ITEM_SINGLE`,
+/// `EHR_STATUS`, and the demographic / EHR_EXTRACT LOCATABLEs — reach the
+/// generated structural fallthrough, which decodes but runs no invariant, so
+/// that is where the inherited invariant becomes theirs too.
+#[must_use]
+#[expect(
+    clippy::too_many_lines,
+    reason = "a flat `_type` -> concrete-type dispatch table; the length is the size of the RM type set, not logic"
+)]
+pub fn dispatch_typed(ty: &str, value: &Value, out: &mut Vec<InvariantViolation>) -> bool {
+    use openehr_base::base_types::identification::archetype_id::ArchetypeId;
+    use openehr_base::base_types::identification::internet_id::InternetId;
+    use openehr_base::base_types::identification::iso_oid::IsoOid;
+    use openehr_base::base_types::identification::object_ref::ObjectRefData;
+    use openehr_base::base_types::identification::object_version_id::ObjectVersionId;
+    use openehr_base::base_types::identification::party_ref::PartyRef;
+    use openehr_base::base_types::identification::terminology_id::TerminologyId;
+    use openehr_base::base_types::identification::version_tree_id::VersionTreeId;
+
+    use crate::common::archetyped::archetyped::Archetyped;
+    use crate::common::archetyped::feeder_audit_details::FeederAuditDetails;
+    use crate::common::directory::folder::Folder;
+    use crate::common::generic::attestation::Attestation;
+    use crate::common::generic::audit_details::AuditDetailsData;
+    use crate::common::generic::party_identified::PartyIdentifiedData;
+    use crate::common::generic::party_related::PartyRelated;
+    use crate::common::tags::item_tag::ItemTag;
+    use crate::composition::composition::Composition;
+    use crate::composition::content::entry::action::Action;
+    use crate::composition::content::entry::activity::Activity;
+    use crate::composition::content::entry::admin_entry::AdminEntry;
+    use crate::composition::content::entry::evaluation::Evaluation;
+    use crate::composition::content::entry::instruction::Instruction;
+    use crate::composition::content::entry::instruction_details::InstructionDetails;
+    use crate::composition::content::entry::observation::Observation;
+    use crate::composition::content::navigation::section::Section;
+    use crate::composition::event_context::EventContext;
+    use crate::data_structures::history::history::History;
+    use crate::data_structures::history::interval_event::IntervalEvent;
+    use crate::data_structures::history::point_event::PointEvent;
+    use crate::data_structures::item_structure::item_table::ItemTable;
+    use crate::data_structures::representation::cluster::Cluster;
+    use crate::data_structures::representation::element::Element;
+    use crate::data_types::basic::dv_identifier::DvIdentifier;
+    use crate::data_types::encapsulated::dv_multimedia::DvMultimedia;
+    use crate::data_types::encapsulated::dv_parsable::DvParsable;
+    use crate::data_types::quantity::date_time::dv_date::DvDate;
+    use crate::data_types::quantity::date_time::dv_date_time::DvDateTime;
+    use crate::data_types::quantity::date_time::dv_duration::DvDuration;
+    use crate::data_types::quantity::date_time::dv_time::DvTime;
+    use crate::data_types::quantity::dv_count::DvCount;
+    use crate::data_types::quantity::dv_interval::DvInterval;
+    use crate::data_types::quantity::dv_ordered::DvOrdered;
+    use crate::data_types::quantity::dv_ordinal::DvOrdinal;
+    use crate::data_types::quantity::dv_proportion::DvProportion;
+    use crate::data_types::quantity::dv_quantity::DvQuantity;
+    use crate::data_types::quantity::dv_scale::DvScale;
+    use crate::data_types::quantity::reference_range::ReferenceRange;
+    use crate::data_types::text::code_phrase::CodePhrase;
+    use crate::data_types::text::dv_text::DvText;
+    use crate::data_types::text::term_mapping::TermMapping;
+    use crate::data_types::time_specification::dv_periodic_time_specification::DvPeriodicTimeSpecification;
+    use crate::data_types::uri::dv_ehr_uri::DvEhrUri;
+    use crate::data_types::uri::dv_uri::DvUriData;
+    use crate::integration::generic_entry::GenericEntry;
+
+    match ty {
+        // data_types
+        "CODE_PHRASE" => run::<CodePhrase>(ty, value, out),
+        // DV_TEXT + DV_CODED_TEXT share the DvText enum (Valid_value /
+        // Formatting_valid, dv_text.adoc; DV_CODED_TEXT adds the structural
+        // defining_code 1..1 at deserialize).
+        "DV_TEXT" | "DV_CODED_TEXT" => run::<DvText>(ty, value, out),
+        "DV_URI" => run::<DvUriData>(ty, value, out),
+        "DV_EHR_URI" => run::<DvEhrUri>(ty, value, out),
+        "DV_IDENTIFIER" => run::<DvIdentifier>(ty, value, out),
+        "TERM_MAPPING" => run::<TermMapping>(ty, value, out),
+        "DV_MULTIMEDIA" => run::<DvMultimedia>(ty, value, out),
+        "DV_PROPORTION" => run::<DvProportion>(ty, value, out),
+        "DV_QUANTITY" => run::<DvQuantity>(ty, value, out),
+        "DV_COUNT" => run::<DvCount>(ty, value, out),
+        "DV_DURATION" => run::<DvDuration>(ty, value, out),
+        "DV_DATE" => run::<DvDate>(ty, value, out),
+        "DV_TIME" => run::<DvTime>(ty, value, out),
+        "DV_DATE_TIME" => run::<DvDateTime>(ty, value, out),
+        "DV_ORDINAL" => run::<DvOrdinal>(ty, value, out),
+        "DV_SCALE" => run::<DvScale>(ty, value, out),
+        "DV_PARSABLE" => run::<DvParsable>(ty, value, out),
+        "DV_PERIODIC_TIME_SPECIFICATION" => run::<DvPeriodicTimeSpecification>(ty, value, out),
+        "REFERENCE_RANGE" => run::<ReferenceRange>(ty, value, out),
+        // DV_INTERVAL: prefer the DV_ORDERED-typed element so the
+        // Limits_consistent ordering invariant runs; fall back to
+        // Value elements (boundary flags only) for non-DV_ORDERED payloads.
+        "DV_INTERVAL" => {
+            if let Ok(v) = decode::<DvInterval<DvOrdered>>(value) {
+                v.validate_invariants(out);
+            } else {
+                run::<DvInterval<Value>>(ty, value, out);
+            }
+        }
+        // data_structures. HISTORY and ITEM_TABLE keep the full deserialize —
+        // their own invariants read a child collection (`events` / `rows`); the
+        // rest are structural containers with scalar-only invariants, so they
+        // deserialize shallowly (see `run_shallow`).
+        "ELEMENT" => run::<Element>(ty, value, out),
+        "CLUSTER" => run_shallow::<Cluster>(ty, value, out),
+        "HISTORY" => run::<History<Value>>(ty, value, out),
+        "POINT_EVENT" => run_shallow::<PointEvent<Value>>(ty, value, out),
+        "INTERVAL_EVENT" => run_shallow::<IntervalEvent<Value>>(ty, value, out),
+        "ITEM_TABLE" => run::<ItemTable>(ty, value, out),
+        // common
+        "PARTY_IDENTIFIED" => run::<PartyIdentifiedData>(ty, value, out),
+        "PARTY_RELATED" => run::<PartyRelated>(ty, value, out),
+        "AUDIT_DETAILS" => run::<AuditDetailsData>(ty, value, out),
+        "ATTESTATION" => run::<Attestation>(ty, value, out),
+        "FEEDER_AUDIT_DETAILS" => run::<FeederAuditDetails>(ty, value, out),
+        "ARCHETYPED" => run::<Archetyped>(ty, value, out),
+        // ehr / composition — structural containers (scalar-only invariants),
+        // deserialized shallowly (see `run_shallow`). GENERIC_ENTRY's `data:
+        // ITEM [1..1]` is a single-valued node, so `run_shallow` keeps it and
+        // still enforces its presence.
+        "COMPOSITION" => run_shallow::<Composition>(ty, value, out),
+        "EVENT_CONTEXT" => run_shallow::<EventContext>(ty, value, out),
+        "ACTIVITY" => run_shallow::<Activity>(ty, value, out),
+        "INSTRUCTION_DETAILS" => run::<InstructionDetails>(ty, value, out),
+        "OBSERVATION" => run_shallow::<Observation>(ty, value, out),
+        "INSTRUCTION" => run_shallow::<Instruction>(ty, value, out),
+        "ACTION" => run_shallow::<Action>(ty, value, out),
+        "EVALUATION" => run_shallow::<Evaluation>(ty, value, out),
+        "ADMIN_ENTRY" => run_shallow::<AdminEntry>(ty, value, out),
+        "GENERIC_ENTRY" => run_shallow::<GenericEntry>(ty, value, out),
+        "SECTION" => run_shallow::<Section>(ty, value, out),
+        "FOLDER" => run_shallow::<Folder>(ty, value, out),
+        "ITEM_TAG" => run::<ItemTag>(ty, value, out),
+        // base identification
+        "OBJECT_REF" => run::<ObjectRefData>(ty, value, out),
+        "PARTY_REF" => run::<PartyRef>(ty, value, out),
+        "VERSION_TREE_ID" => run::<VersionTreeId>(ty, value, out),
+        "OBJECT_VERSION_ID" => run::<ObjectVersionId>(ty, value, out),
+        "ISO_OID" => run::<IsoOid>(ty, value, out),
+        "ARCHETYPE_ID" => run::<ArchetypeId>(ty, value, out),
+        "TERMINOLOGY_ID" => run::<TerminologyId>(ty, value, out),
+        "INTERNET_ID" => run::<InternetId>(ty, value, out),
+        // Every other class: not handled here. The caller runs the GENERATED
+        // structural dispatch, which decodes the node into that class's own Rust
+        // type and discards it, so the codec is the structural-conformance
+        // authority for the whole emitted model instead of only the
+        // invariant-bearing classes above.
+        _ => return false,
+    }
+    true
+}

--- a/tools/cnf-runner/artifacts/schedule/messaging/I_EHR_EXTRACT_SERVICE.export_ehr_extracts-criteria_foreign_formalism.yaml
+++ b/tools/cnf-runner/artifacts/schedule/messaging/I_EHR_EXTRACT_SERVICE.export_ehr_extracts-criteria_foreign_formalism.yaml
@@ -1,0 +1,56 @@
+# EXTRACT_SPEC.criteria, the REFUSAL side (#1736): a criterion in a formalism
+# the service does not evaluate is refused typed — never a silent skip and
+# never a silent whole-EHR over-export. master04-common_package §Content
+# Criteria Specification makes DV_PARSABLE.formalism the criterion's language
+# tag ("enabling any formalism to be used") and names AQL as the openEHR
+# formalism; a service that evaluates only AQL must therefore say so when
+# handed anything else. The accept edge is the -criteria_selects_primary_set
+# sibling.
+id: I_EHR_EXTRACT_SERVICE.export_ehr_extracts-criteria_foreign_formalism
+kind: functional
+component: MESSAGING
+sm_operation: I_EHR_EXTRACT_SERVICE.export_ehr_extracts
+capabilities: [EhrExtract]
+profiles: [OPTIONS]
+test_purpose: >-
+  An EXTRACT_SPEC criterion whose DV_PARSABLE.formalism names a language the
+  service does not evaluate is refused as a precondition violation.
+description: "Refuse an EXTRACT_SPEC.criteria entry in a foreign formalism"
+spec_refs:
+  - "SM openehr_platform §I_EHR_EXTRACT_SERVICE.export_ehr_extracts"
+  - "RM ehr_extract master04-common_package §Content Criteria Specification (EXTRACT_SPEC.criteria)"
+applies: { rm: ">=1.0.2" }
+guards:
+  - "EXTENSION ROUTE — no openEHR spec governs the /message/* routes; our own design/extension, declared in vocab/wire_surface.yaml served_extensions (family message-extract) and adjudicated by register AMB-34. The row gates the CAPABILITY verdicts only, never ITS-REST wire conformance"
+  - "The criteria evaluation mechanics (AQL-only formalism, result rows identifying version containers, the engine EHR scope as the $ehr binding) are the declaring party's own realization — master04 names AQL only as an example formalism and defines no result-to-item mapping"
+requires: { ehr: { commits: any } }        # mints ${ehr_id}
+flow:
+  - step: 1
+    call: export_ehr_extracts
+    with:
+      extract_spec:
+        _type: EXTRACT_SPEC
+        extract_type:
+          _type: DV_CODED_TEXT
+          value: openehr-ehr
+          defining_code:
+            _type: CODE_PHRASE
+            terminology_id: { _type: TERMINOLOGY_ID, value: openehr }
+            code_string: openehr-ehr
+        include_multimedia: false
+        priority: 0
+        link_depth: 0
+        criteria:
+          - _type: DV_PARSABLE
+            value: "for $x in collection() return $x"
+            formalism: xquery
+        manifest:
+          _type: EXTRACT_MANIFEST
+          entities:
+            - _type: EXTRACT_ENTITY_MANIFEST
+              extract_id_key: "${ehr_id}"
+              ehr_id: "${ehr_id}"
+              other_ids: []
+              item_list: []
+    expect: bad_request
+ambiguities: [AMB-34]

--- a/tools/cnf-runner/artifacts/schedule/messaging/I_EHR_EXTRACT_SERVICE.export_ehr_extracts-criteria_selects_primary_set.yaml
+++ b/tools/cnf-runner/artifacts/schedule/messaging/I_EHR_EXTRACT_SERVICE.export_ehr_extracts-criteria_selects_primary_set.yaml
@@ -1,0 +1,60 @@
+# EXTRACT_SPEC.criteria, the ACCEPT side (#1736): a criteria query selects the
+# primary set of the entity's record. RM ehr_extract master04-common_package
+# §Content Criteria Specification — criteria "defines in the form of generic
+# queries (i.e. queries that apply sensibly to any record) which items are to
+# be retrieved from each entity's record", "Query expressions use variables
+# such as $ehr to mean the current EHR from the `manifest` list". An AQL
+# criterion whose rows identify the EHR_STATUS version container yields an
+# extract carrying that container — not a whole-EHR over-export and not a
+# refusal. The refusal edge is the -criteria_foreign_formalism sibling.
+id: I_EHR_EXTRACT_SERVICE.export_ehr_extracts-criteria_selects_primary_set
+kind: functional
+component: MESSAGING
+sm_operation: I_EHR_EXTRACT_SERVICE.export_ehr_extracts
+capabilities: [EhrExtract]
+profiles: [OPTIONS]
+test_purpose: >-
+  An EXTRACT_SPEC whose entity carries no item_list but whose criteria hold an
+  AQL query selecting the EHR_STATUS is exported with the criteria-selected
+  primary set.
+description: "Export by an EXTRACT_SPEC.criteria AQL primary-set query"
+spec_refs:
+  - "SM openehr_platform §I_EHR_EXTRACT_SERVICE.export_ehr_extracts"
+  - "RM ehr_extract master04-common_package §Content Criteria Specification (EXTRACT_SPEC.criteria)"
+applies: { rm: ">=1.0.2" }
+guards:
+  - "EXTENSION ROUTE — no openEHR spec governs the /message/* routes; our own design/extension, declared in vocab/wire_surface.yaml served_extensions (family message-extract) and adjudicated by register AMB-34. The row gates the CAPABILITY verdicts only, never ITS-REST wire conformance"
+  - "The criteria evaluation mechanics (AQL-only formalism, result rows identifying version containers, the engine EHR scope as the $ehr binding) are the declaring party's own realization — master04 names AQL only as an example formalism and defines no result-to-item mapping"
+requires: { ehr: { commits: any } }        # mints ${ehr_id}
+flow:
+  - step: 1
+    call: export_ehr_extracts
+    with:
+      extract_spec:
+        _type: EXTRACT_SPEC
+        extract_type:
+          _type: DV_CODED_TEXT
+          value: openehr-ehr
+          defining_code:
+            _type: CODE_PHRASE
+            terminology_id: { _type: TERMINOLOGY_ID, value: openehr }
+            code_string: openehr-ehr
+        include_multimedia: false
+        priority: 0
+        link_depth: 0
+        criteria:
+          - _type: DV_PARSABLE
+            value: "SELECT s/uid/value FROM EHR e CONTAINS EHR_STATUS s"
+            formalism: AQL
+        manifest:
+          _type: EXTRACT_MANIFEST
+          entities:
+            - _type: EXTRACT_ENTITY_MANIFEST
+              extract_id_key: "${ehr_id}"
+              ehr_id: "${ehr_id}"
+              other_ids: []
+              item_list: []
+    expect: ok
+    assert:
+      - { assert: returns, matches: 'X_VERSIONED_EHR_STATUS' }
+ambiguities: [AMB-34]


### PR DESCRIPTION
Five issue closes, per the standing autonomous burn-down.

- **#1697 — the ITS-JSON 1.1.0 oracle delta machine-pinned**: a new gate derives the full per-class attribute delta between the CLOSED vendored RM 1.1.0 all-schema and the generated RM 1.2.0 model on every run (EHR.tags + the accreditaton twins model-side; DV_QUANTITY.property, the PARTY reverse_relationships family, the SYNC_EXTRACT LOCATABLE members schema-side; the embedded BASE class list) — any NEW divergence fails loud. PROVENANCE + fidelity-gate docs updated.
- **#1786 — latest-deps triaged**: not a dependency break — the lane tripped on an unused_qualifications lint already removed by PR #1860; Cargo.lock refreshed to the newest in-range set, whole workspace checks clean.
- **#1448 — AQL LIKE/matches existential lowering**: both now share the any-match `data_leaf_exists` lowering the comparison operators use (positive polarity; NOT keeps the scalar shape); SQL-shape pins + a behavioural two-sibling-ELEMENTs test.
- **#1736 — EXTRACT_SPEC.criteria implemented** (RM ehr_extract master04 §Content Criteria Specification): AQL criteria select each entity's primary set $ehr-bound through the query engine; non-AQL formalism / unparseable criteria refuse 400; item_list still wins. Service twins + catalogue accept/refusal pair (990 cases, 0 findings).
- **#1823 — the RM typed validation dispatch moved to `openehr_rm::validate::typed_dispatch`** (its stated ITS-side justification expired with #1702); ITS keeps the five-crate structural fallthrough + thin wire entry, ordering unchanged; the dispatch-lockstep gate repoints with an unchanged snapshot.

Gates: workspace clippy + the CI-exact rustdoc lane clean, openehr-rm/openehr-its suites 792/792, AQL slice 121/121, criteria/extract slices green, catalogue validate 0 findings.

Closes #1697
Closes #1786
Closes #1448
Closes #1736
Closes #1823