### PR TITLE
perf: flamegraph profiling instruments — on-demand /management/flamegraph, criterion bench profiler, tracing-flame span capture

### DIFF
--- a/.claude/skills/flamegraph/SKILL.md
+++ b/.claude/skills/flamegraph/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: flamegraph
+description: >
+  Generates a CPU flamegraph to find where the program spends its time —
+  against the running server (the GET /management/flamegraph endpoint), a
+  code path in isolation (the criterion benches under --profile-time), async
+  span attribution (the tracing-flame layer via telemetry.flame_file), or a
+  whole local binary run (cargo flamegraph). Use when the user asks to
+  profile, find hotspots, see "where the time goes", or before any
+  optimization work (profile-first is the standing perf rule).
+allowed-tools: [Read, Bash]
+argument-hint: "[server | bench <name> | binary] [seconds] [frequency-hz]"
+---
+
+# /flamegraph
+
+Four flamegraph instruments, all built on established crates (`pprof`
+sampling, `tracing-flame` span capture, `inferno` rendering — never
+hand-rolled). Pick by what you are profiling; every route ends in an SVG
+whose **wide frames are the hotspots**.
+
+No openEHR spec governs profiling — our own operational tooling (issue
+#1861). User docs: `website/book/src/operations.md` §Profiling (operators)
+and `website/book/src/contributing.md` §Profiling (developers).
+
+## 1. The running server — `GET /management/flamegraph`
+
+The production/staging/composed-stack instrument. Opt-in like the whole
+management surface (`ferroehr::config::management`, default off), endpoint
+key `management.endpoints.flamegraph`, caps under `[management.profiling]`
+(`max_seconds` 30, `max_frequency` 999).
+
+```bash
+# enable on a dev/composed server (env grammar: FERROEHR__ + TOML path):
+#   FERROEHR__MANAGEMENT__ENABLED=true
+#   FERROEHR__MANAGEMENT__ENDPOINTS__FLAMEGRAPH=public   # dev only; admin_only in prod
+curl -o /tmp/flamegraph.svg \
+  "http://localhost:8080/management/flamegraph?seconds=10&frequency=99"
+```
+
+Wire semantics (pinned by `app/ferroehr-rest/tests/it/management.rs`):
+`400` for a parameter beyond a cap (refused, never clamped) · `409` while
+another sample window runs · `404` when not opted in. **Load matters**: an
+idle server flamegraphs its own idling — drive the workload you are
+diagnosing while the window samples (e.g. run the CNF stress instrument
+concurrently).
+
+Implementation seam, when extending: sampling logic in
+`app/ferroehr-rest/src/extensions/management/flamegraph.rs`, handler +
+`#[utoipa::path]` in `.../management/mod.rs`, config in
+`app/ferroehr/src/config/management.rs` (+ the annotated template
+`app/ferroehr/assets/ferroehr.default.toml`, the book pages, and the Helm
+`values.yaml` — same-PR, per the configuration rule).
+
+## 2. A code path in isolation — criterion benches
+
+Every criterion bench emits a per-bench flamegraph under `--profile-time`
+(the profiler only runs under that flag):
+
+```bash
+cargo bench -p ferroehr --bench aql -- --profile-time 10
+# → target/criterion/<bench-name>/profile/flamegraph.svg
+```
+
+The pattern lives in `app/ferroehr/benches/aql.rs`: a small
+`criterion::profiler::Profiler` impl over `pprof`. **Copy that impl into new
+bench files** — do NOT enable pprof's own `criterion` feature: it is pinned
+to criterion ^0.5 (verified on crates.io 2026-08-04) and type-mismatches our
+criterion 0.8. New benches: `[[bench]] name = "…" harness = false` in the
+crate's `Cargo.toml`, `criterion.workspace = true` + `pprof.workspace =
+true` as dev-deps.
+
+## 3. Async span attribution — the `tracing-flame` layer
+
+A sampled stack under tokio often blames the executor's poll loop; a span
+flame attributes wall time to the instrumented operation. Set
+`telemetry.flame_file` (config key, `[telemetry]` section; env
+`FERROEHR__TELEMETRY__FLAME_FILE`) — the layer is installed only when set
+(issue #1862; `ferroehr::telemetry::layers`). Folded stacks render offline:
+
+```bash
+cargo install inferno
+inferno-flamegraph < /tmp/ferroehr.folded > span-flame.svg
+```
+
+Diagnostic sessions only — the folded file grows with span traffic. The
+flush guard rides `TelemetryGuard` (flushes at shutdown).
+
+## 4. A whole local run — `cargo flamegraph`
+
+Zero code changes; a dev TOOL (`cargo install flamegraph`), never a
+dependency:
+
+```bash
+cargo flamegraph --bin ferroehr          # Linux (perf)
+sudo cargo flamegraph --bin ferroehr     # macOS (dtrace needs elevation)
+```
+
+## Ground rules
+
+- **Profile first, then optimize** — a perf change without a profile naming
+  the hotspot is speculation (ROADMAP §Performance: profile-first, one
+  change per ladder).
+- pprof is Linux + macOS only (signal-based sampling) — matches our targets.
+- A flamegraph is an exploration artifact, NEVER a conformance/perf record:
+  committed performance claims come only from the CNF runner's measured
+  instruments (`docs/conformance/`).
+- The endpoint samples the WHOLE process; keep it `admin_only` outside dev
+  and prefer the separate management port.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,22 @@ workflow refuses a tag that has no matching section here.
 ### Added
 
 - EHR-Extract export now evaluates `EXTRACT_SPEC.criteria`: AQL criteria queries select each entity's primary set `$ehr`-bound (the entity's EHR scopes the query and a literal `$ehr` parameter binds to its id); a non-AQL formalism or an unparseable criterion is refused with `400`. The former blanket criteria refusal is gone (#1736).
+- **On-demand CPU flamegraph of the running server:**
+  `GET /management/flamegraph` — a new opt-in management endpoint (default
+  off, like the whole surface) that samples the process with an in-process
+  `pprof` profiler for a bounded window and answers with the rendered
+  flamegraph SVG. `seconds`/`frequency` query parameters are capped by the
+  new `[management.profiling]` config keys (`max_seconds`, `max_frequency`);
+  a request beyond a cap is refused with `400`, a concurrent sample window
+  with `409`. No openEHR spec governs the management surface — our own
+  operational extension (#1861).
+- **Span-timing flamegraph capture:** the new `telemetry.flame_file` config
+  key installs a `tracing-flame` layer that writes folded stack samples of
+  every span to the given file for offline rendering with inferno
+  (`inferno-flamegraph < file > flame.svg`) — the async-attribution
+  complement to the sampled-stack endpoint. Unset (the default) the layer is
+  not installed at all. Our own telemetry extension (#1862).
+
 - EHR Extract import now enforces the copy closure (RM common master06 §Copying): a received branch version is refused with `400` unless its fork-point trunk version and same-branch predecessor travel in the same extract or are already stored (#1770).
 - **FOLDER (DIRECTORY) resources can now carry ITEM_TAGs.** ITS-REST overview
   `Requests_and_responses.md` §openehr-item-tag and openehr-version-item-tag

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,7 @@ bash scripts/conformance.sh   # compose up --build (fresh volumes) → the CNF c
 # measured performance (hour-plus, exclusive SUT): CONF_PERF_CLASS=POC|S|L|R [CONF_PERF_HOURS=1|2|4|6|8|12] bash scripts/conformance.sh
 # step-load STRESS (exploration only, never a conformance record): cargo run -p cnf-runner -- stress --root tools/cnf-runner/artifacts --ixit <party>/ixit.json --out docs/conformance/<sut>/stress.json
 # published perf/stress SVGs + summary regenerate FROM committed artifacts: bash scripts/render-perf-assets.sh (CI diff-guards) — full canonical CLI table: tools/cnf-runner/CLAUDE.md
+# CPU profiling / hotspot hunting (exploration only, never a conformance record): the /flamegraph skill — GET /management/flamegraph on a running server (opt-in), `cargo bench -p ferroehr --bench aql -- --profile-time 10` for a code path, cargo-flamegraph locally
 # admin-console gates: /ui-gates (both-target clippy, nextest, leptosfmt, cargo-leptos build)
 bash scripts/ui-e2e.sh        # the browser journey battery against the composed stack (merge gate in CI)
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,6 +97,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,6 +118,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
+]
+
+[[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -166,6 +193,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "annotate-snippets"
@@ -261,7 +294,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73cd58deff2140a0a8eae87e417bd01db68a33e148aa93d1e8cd837e55e312b6"
 dependencies = [
- "object",
+ "object 0.39.1",
 ]
 
 [[package]]
@@ -703,6 +736,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object 0.37.3",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
 name = "base16"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,6 +1102,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,6 +1134,12 @@ name = "camino"
 version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1307f12aa967b5a58416e87b3653360e0fd614a016b6e970db08fecbb1b80d"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cast5"
@@ -1236,6 +1296,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,7 +1422,7 @@ dependencies = [
  "jsonschema",
  "jsonwebtoken",
  "pgp",
- "quick-xml",
+ "quick-xml 0.41.0",
  "regex",
  "reqwest 0.13.4",
  "semver",
@@ -1606,6 +1693,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpp_demangle"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1661,6 +1757,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -1948,6 +2079,15 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
 
 [[package]]
 name = "default-struct-builder"
@@ -2417,6 +2557,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2518,6 +2678,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "config",
+ "criterion",
  "futures",
  "http",
  "http-body-util",
@@ -2543,7 +2704,8 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "pgp",
- "quick-xml",
+ "pprof",
+ "quick-xml 0.41.0",
  "rand 0.8.7",
  "regex",
  "reqwest 0.13.4",
@@ -2566,6 +2728,7 @@ dependencies = [
  "toml",
  "tower",
  "tracing",
+ "tracing-flame",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "urlencoding",
@@ -2642,6 +2805,7 @@ dependencies = [
  "openehr-rm",
  "openidconnect",
  "opentelemetry",
+ "pprof",
  "reqwest 0.13.4",
  "rustls",
  "serde",
@@ -2726,6 +2890,18 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "fixedbitset"
@@ -3054,6 +3230,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
 name = "globset"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3179,6 +3361,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -3789,6 +3982,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "inferno"
+version = "0.11.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
+dependencies = [
+ "ahash 0.8.12",
+ "indexmap 2.14.0",
+ "is-terminal",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml 0.26.0",
+ "rgb",
+ "str_stack",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3853,6 +4064,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3863,6 +4085,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -4705,6 +4936,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "metrics"
 version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4883,6 +5123,17 @@ checksum = "60993920e071b0c9b66f14e2b32740a4e27ffc82854dcd72035887f336a09a28"
 
 [[package]]
 name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
@@ -4999,6 +5250,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec 0.7.8",
+ "itoa",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5091,6 +5352,15 @@ dependencies = [
 
 [[package]]
 name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
 version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
@@ -5120,10 +5390,10 @@ dependencies = [
  "hyper",
  "itertools 0.15.0",
  "md-5 0.11.0",
- "nix",
+ "nix 0.31.3",
  "parking_lot",
  "percent-encoding",
- "quick-xml",
+ "quick-xml 0.41.0",
  "rand 0.10.2",
  "reqwest 0.13.4",
  "rustls-pki-types",
@@ -5186,6 +5456,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opaque-debug"
@@ -5255,7 +5531,7 @@ dependencies = [
  "openehr-lang",
  "openehr-rm",
  "openehr-term",
- "quick-xml",
+ "quick-xml 0.41.0",
  "regex",
  "serde",
  "serde_json",
@@ -5526,6 +5802,16 @@ dependencies = [
  "primeorder",
  "rand_core 0.6.4",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -5925,6 +6211,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5965,6 +6279,28 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "pprof"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a01da47675efa7673b032bf8efd8214f1917d89685e07e395ab125ea42b187"
+dependencies = [
+ "aligned-vec",
+ "backtrace",
+ "cfg-if",
+ "findshlibs",
+ "inferno",
+ "libc",
+ "log",
+ "nix 0.26.4",
+ "once_cell",
+ "smallvec",
+ "spin 0.10.1",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror 2.0.19",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -6198,6 +6534,15 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
@@ -6422,6 +6767,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
  "bitflags 2.13.1",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -6715,6 +7080,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6885,6 +7259,12 @@ dependencies = [
  "serde_json",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
@@ -7754,6 +8134,9 @@ name = "spin"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"
@@ -7969,6 +8352,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "str_stack"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f446288b699d66d0fd2e30d1cfe7869194312524b3b9252594868ed26ef056a"
+
+[[package]]
 name = "string_cache"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8043,6 +8432,29 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "symbolic-common"
+version = "12.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332615d90111d8eeaf86a84dc9bbe9f65d0d8c5cf11b4caccedc37754eb0dcfd"
+dependencies = [
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "12.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "912017718eb4d21930546245af9a3475c9dccf15675a5c215664e76621afc471"
+dependencies = [
+ "cpp_demangle",
+ "rustc-demangle",
+ "symbolic-common",
+]
 
 [[package]]
 name = "syn"
@@ -8498,6 +8910,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8870,6 +9292,17 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-flame"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bae117ee14789185e129aaee5d93750abe67fdc5a9a62650452bfe4e122a3a9"
+dependencies = [
+ "lazy_static",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -327,6 +327,7 @@ thirtyfour = "0.37.2"               # E2E WebDriver client (dev-dep of the conso
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "registry"] }
 tracing-opentelemetry = "0.33"     # pairs with opentelemetry 0.31 line (verify matching set)
+tracing-flame = "0.2"              # span-timing flamegraph capture (folded stacks; render via inferno)
 opentelemetry = "0.32.0"
 opentelemetry_sdk = { version = "0.32.1", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.32.0", features = ["grpc-tonic"] }
@@ -334,6 +335,11 @@ opentelemetry-semantic-conventions = "0.32.1"
 metrics = "0.24"
 metrics-exporter-prometheus = "0.18.3"   # verify latest
 axum-prometheus = "0.10.0"                # verify latest
+# In-process sampling CPU profiler (flamegraph SVG via inferno). Its own
+# `criterion` feature is pinned to criterion ^0.5 (verified on crates.io
+# 2026-08-04) — incompatible with our criterion 0.8 — so benches implement
+# criterion's `Profiler` trait over this crate directly instead of enabling it.
+pprof = { version = "0.15.0", features = ["flamegraph"] }
 
 # ── Caching, rate limiting, resilience ───────────────────────────────────────
 moka = { version = "0.12", features = ["future"] }   # Caffeine equivalent (template/WebTemplate cache)

--- a/app/ferroehr-rest/CLAUDE.md
+++ b/app/ferroehr-rest/CLAUDE.md
@@ -21,8 +21,11 @@ terminology / management / tenant / event-subscription surfaces). Entry point:
   `/health`, `/health/liveness`, `/health/readiness`), mounted outside the API
   subtree — no auth, no audit, no overload shed, no config switch. The
   `/management` surface is ops introspection only (info/prometheus/metrics/env/
-  loggers) and carries no health route. No openEHR spec governs either — our own
-  operational surface.
+  loggers/flamegraph) and carries no health route. No openEHR spec governs
+  either — our own operational surface. `/management/flamegraph` is the
+  on-demand CPU profiler (pprof sampling → SVG; `extensions/management/
+  flamegraph.rs`, caps in `ferroehr::config::management::ProfilingConfig`) —
+  the `/flamegraph` skill documents all three profiling instruments.
 
 - **The wire is the spec:** status codes, headers (`ETag`, `Location`,
   `Last-Modified`, `Prefer`, committal merge), and content negotiation

--- a/app/ferroehr-rest/Cargo.toml
+++ b/app/ferroehr-rest/Cargo.toml
@@ -56,6 +56,9 @@ jiff = { workspace = true }
 # and the /management/prometheus render surface).
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
+# The on-demand CPU flamegraph behind /management/flamegraph (sampling
+# profiler + inferno SVG render; Linux + macOS only, matching our targets).
+pprof = { workspace = true }
 # Trace-context propagation (W3C traceparent) + the OTel span extension used by
 # the root-span middleware; the export layer itself is installed in the binary.
 opentelemetry = { workspace = true }

--- a/app/ferroehr-rest/src/extensions/management/flamegraph.rs
+++ b/app/ferroehr-rest/src/extensions/management/flamegraph.rs
@@ -1,0 +1,220 @@
+//! The on-demand CPU flamegraph body: pprof sampling + inferno SVG render.
+//!
+//! NOTE: no openEHR spec governs this — our own operational surface (the
+//! `/management` extension). The profiler is the `pprof` crate's `SIGPROF`
+//! sampler (<https://docs.rs/pprof/latest/pprof/>): one guard samples the
+//! whole process for the requested window, then the report renders straight
+//! to a flamegraph SVG. Exactly one sample window may run at a time — the
+//! profiler is process-global state, so a second concurrent request is a
+//! `409`, never a queued wait (an operator retries in seconds; a silent queue
+//! would stack sample windows end-to-end and hold request slots).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::Deserialize;
+use tokio::sync::Mutex;
+
+use ferroehr::config::management::ProfilingConfig;
+use openehr_its::rest::runtime::ApiError;
+
+/// The one process-wide profiling permit. Cheap to clone (an `Arc` handle);
+/// [`try_acquire`](Self::try_acquire) either takes the permit or reports the
+/// running sample window.
+#[derive(Debug, Clone, Default)]
+pub struct ProfilerSlot(Arc<Mutex<()>>);
+
+impl ProfilerSlot {
+    /// Take the permit, or `Err` when a sample window is already running.
+    fn try_acquire(&self) -> Result<tokio::sync::OwnedMutexGuard<()>, ApiError> {
+        Arc::clone(&self.0).try_lock_owned().map_err(|_busy| {
+            ApiError::Conflict(
+                "a profiling sample window is already running; retry when it completes".to_owned(),
+            )
+        })
+    }
+}
+
+/// Query parameters of `GET /management/flamegraph`.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct FlamegraphParams {
+    /// The sample window in seconds (default 10, capped by
+    /// `management.profiling.max_seconds`).
+    pub seconds: Option<u16>,
+    /// The sampling frequency in Hz (default 99, capped by
+    /// `management.profiling.max_frequency`).
+    pub frequency: Option<i32>,
+}
+
+/// The validated sample request: window + frequency, both inside the
+/// configured caps.
+#[derive(Debug, Clone, Copy)]
+struct SamplePlan {
+    seconds: u16,
+    frequency: i32,
+}
+
+/// Validate `params` against the configured caps. A request beyond a cap is a
+/// `400` naming the cap — never silently clamped (the caller must know what
+/// was actually sampled).
+fn plan(params: &FlamegraphParams, limits: ProfilingConfig) -> Result<SamplePlan, ApiError> {
+    let seconds = params.seconds.unwrap_or_else(|| 10.min(limits.max_seconds));
+    if seconds == 0 || seconds > limits.max_seconds {
+        return Err(ApiError::BadRequest(format!(
+            "seconds must be between 1 and {} (management.profiling.max_seconds)",
+            limits.max_seconds
+        )));
+    }
+    let frequency = params
+        .frequency
+        .unwrap_or_else(|| 99.min(limits.max_frequency));
+    if frequency < 1 || frequency > limits.max_frequency {
+        return Err(ApiError::BadRequest(format!(
+            "frequency must be between 1 and {} Hz (management.profiling.max_frequency)",
+            limits.max_frequency
+        )));
+    }
+    Ok(SamplePlan { seconds, frequency })
+}
+
+/// Sample the process for the requested window and render the flamegraph SVG.
+///
+/// The whole session — start the guard, sit out the window, build the report,
+/// render — runs on one blocking-pool thread (`spawn_blocking`): the pprof
+/// guard is not `Send`, and parking a blocking thread for a bounded,
+/// operator-triggered window is the intended use of the blocking pool
+/// (<https://docs.rs/tokio/latest/tokio/task/fn.spawn_blocking.html>).
+///
+/// # Errors
+///
+/// * [`ApiError::BadRequest`] — a parameter outside the configured caps.
+/// * [`ApiError::Conflict`] — a sample window is already running.
+/// * [`ApiError::Internal`] — the profiler failed to start, sample, or render;
+///   the diagnostic goes to the trace record, the body stays curated.
+pub async fn sample_flamegraph_svg(
+    slot: &ProfilerSlot,
+    limits: ProfilingConfig,
+    params: &FlamegraphParams,
+) -> Result<Vec<u8>, ApiError> {
+    let plan = plan(params, limits)?;
+    let permit = slot.try_acquire()?;
+    tracing::info!(
+        seconds = plan.seconds,
+        frequency = plan.frequency,
+        "profiling: CPU sample window started"
+    );
+    let rendered = tokio::task::spawn_blocking(move || {
+        // The permit lives on the blocking thread for the whole session, so a
+        // concurrent request conflicts for exactly as long as sampling runs.
+        let held_permit = permit;
+        let svg = run_sample(plan);
+        drop(held_permit);
+        svg
+    })
+    .await;
+    match rendered {
+        Ok(Ok(svg)) => Ok(svg),
+        Ok(Err(error)) => {
+            tracing::warn!(%error, "profiling: sample window failed");
+            Err(ApiError::Internal("profiling failed".to_owned()))
+        }
+        Err(join_error) => {
+            tracing::warn!(%join_error, "profiling: sampling task did not complete");
+            Err(ApiError::Internal("profiling failed".to_owned()))
+        }
+    }
+}
+
+/// The synchronous profiling session: guard → sleep out the window → report →
+/// SVG bytes. Runs entirely on one blocking-pool thread.
+fn run_sample(plan: SamplePlan) -> Result<Vec<u8>, pprof::Error> {
+    let guard = pprof::ProfilerGuardBuilder::default()
+        .frequency(plan.frequency)
+        // Frames inside these libraries are unwind hazards pprof's own
+        // documentation blocklists (signal handlers interrupting non-reentrant
+        // code); the application frames we profile are unaffected.
+        .blocklist(&["libc", "libgcc", "pthread", "vdso"])
+        .build()?;
+    std::thread::sleep(Duration::from_secs(u64::from(plan.seconds)));
+    let report = guard.report().build()?;
+    let mut svg = Vec::new();
+    report.flamegraph(&mut svg)?;
+    Ok(svg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn limits() -> ProfilingConfig {
+        ProfilingConfig::default()
+    }
+
+    #[test]
+    fn defaults_fit_inside_caps() {
+        let p = plan(&FlamegraphParams::default(), limits()).expect("defaults must plan");
+        assert_eq!(p.seconds, 10);
+        assert_eq!(p.frequency, 99);
+    }
+
+    #[test]
+    fn defaults_shrink_to_a_tighter_cap() {
+        let tight = ProfilingConfig {
+            max_seconds: 5,
+            max_frequency: 50,
+        };
+        let p = plan(&FlamegraphParams::default(), tight).expect("defaults must plan");
+        assert_eq!(p.seconds, 5);
+        assert_eq!(p.frequency, 50);
+    }
+
+    #[test]
+    fn over_cap_is_refused_not_clamped() {
+        let over_seconds = FlamegraphParams {
+            seconds: Some(31),
+            frequency: None,
+        };
+        assert!(matches!(
+            plan(&over_seconds, limits()),
+            Err(ApiError::BadRequest(_))
+        ));
+        let over_frequency = FlamegraphParams {
+            seconds: None,
+            frequency: Some(1000),
+        };
+        assert!(matches!(
+            plan(&over_frequency, limits()),
+            Err(ApiError::BadRequest(_))
+        ));
+    }
+
+    #[test]
+    fn zero_and_negative_are_refused() {
+        let zero_seconds = FlamegraphParams {
+            seconds: Some(0),
+            frequency: None,
+        };
+        assert!(matches!(
+            plan(&zero_seconds, limits()),
+            Err(ApiError::BadRequest(_))
+        ));
+        let negative_frequency = FlamegraphParams {
+            seconds: None,
+            frequency: Some(-1),
+        };
+        assert!(matches!(
+            plan(&negative_frequency, limits()),
+            Err(ApiError::BadRequest(_))
+        ));
+    }
+
+    #[test]
+    fn second_acquire_conflicts_while_held() {
+        let slot = ProfilerSlot::default();
+        let held = slot.try_acquire().expect("first acquire");
+        assert!(matches!(slot.try_acquire(), Err(ApiError::Conflict(_))));
+        drop(held);
+        assert!(slot.try_acquire().is_ok());
+    }
+}

--- a/app/ferroehr-rest/src/extensions/management/mod.rs
+++ b/app/ferroehr-rest/src/extensions/management/mod.rs
@@ -1,5 +1,5 @@
 //! The management surface: **ops introspection only** — info, Prometheus,
-//! metrics, env, and loggers.
+//! metrics, env, loggers, and the on-demand CPU flamegraph.
 //!
 //! NOTE: no openEHR spec governs this — our own operational surface;
 //! disposition recorded on issue #305. That disposition also draws the line
@@ -25,6 +25,7 @@
 //! and the caller lacks the configured admin scope.
 
 mod env;
+pub mod flamegraph;
 pub mod http_metrics;
 mod info_routes;
 mod logger_routes;
@@ -38,7 +39,7 @@ use ferroehr::telemetry::log_reload::LogReload;
 use std::sync::Arc;
 
 use axum::Router;
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::middleware::{Next, from_fn_with_state};
 use axum::response::{IntoResponse, Json, Response};
 use axum::routing::get;
@@ -69,6 +70,8 @@ pub struct ManagementState {
     pub build_info: BuildInfo,
     /// The effective configuration snapshot for `/env` (redacted at render).
     pub env_snapshot: Arc<Value>,
+    /// The one process-wide profiling permit (`/flamegraph` concurrency guard).
+    pub profiler: flamegraph::ProfilerSlot,
 }
 
 impl std::fmt::Debug for ManagementState {
@@ -96,6 +99,7 @@ impl ManagementState {
             log_reload: obs.log_reload,
             build_info: obs.build_info,
             env_snapshot: obs.env_snapshot,
+            profiler: flamegraph::ProfilerSlot::default(),
         }
     }
 }
@@ -212,6 +216,14 @@ pub fn router(state: ManagementState) -> Router {
         );
     }
 
+    // ── On-demand CPU flamegraph ─────────────────────────────────────────────
+    if cfg.endpoints.flamegraph.is_mounted() {
+        router = router.route(
+            &format!("{base}/flamegraph"),
+            get(flamegraph_view).route_layer(mk(cfg.endpoints.flamegraph)),
+        );
+    }
+
     // ── Loggers (only when a reloadable filter is present) ──────────────────
     if cfg.endpoints.loggers.is_mounted() && state.log_reload.is_some() {
         router = router.route(
@@ -245,6 +257,7 @@ pub fn openapi() -> utoipa::openapi::OpenApi {
         .routes(routes!(metrics_detail))
         .routes(routes!(env_view))
         .routes(routes!(loggers_get, loggers_post, loggers_reset))
+        .routes(routes!(flamegraph_view))
         .into_openapi()
 }
 
@@ -450,6 +463,45 @@ async fn loggers_reset(State(s): State<ManagementState>) -> Response {
     match &s.log_reload {
         Some(reload) => logger_routes::reset(reload),
         None => recorder_unavailable(),
+    }
+}
+
+/// Sample the process CPU and render a flamegraph SVG
+/// (`GET /management/flamegraph`).
+///
+/// OUR OWN EXTENSION — no openEHR spec governs this: the ITS-REST resource set
+/// defines no management or introspection surface.
+///
+/// Samples the whole process for `seconds` (default 10) at `frequency` Hz
+/// (default 99) via the `pprof` sampler and answers with the rendered
+/// flamegraph SVG — the "where does the time go" instrument. One sample window
+/// at a time (`409` while one runs); parameters beyond the configured
+/// `management.profiling` caps are refused with `400`, never clamped.
+/// Access-level gated by the `flamegraph` endpoint's configured
+/// [`AccessLevel`]; absent (a router `404`, answered before authentication)
+/// unless opted in.
+#[utoipa::path(
+    get, path = "/management/flamegraph", tag = "management",
+    params(
+        ("seconds" = Option<u16>, Query, description = "Sample window in seconds (default 10; capped by management.profiling.max_seconds)."),
+        ("frequency" = Option<i32>, Query, description = "Sampling frequency in Hz (default 99; capped by management.profiling.max_frequency).")
+    ),
+    responses(
+        (status = 200, description = "The rendered CPU flamegraph.", content_type = "image/svg+xml"),
+        (status = 400, description = "A parameter is outside the configured management.profiling caps.", body = serde_json::Value),
+        (status = 401, description = "Authentication required (access level Private/AdminOnly with auth enabled).", body = serde_json::Value),
+        (status = 403, description = "Caller lacks the configured admin scope (access level AdminOnly).", body = serde_json::Value),
+        (status = 409, description = "A profiling sample window is already running.", body = serde_json::Value),
+        (status = 500, description = "The profiler failed to start, sample, or render.", body = serde_json::Value)
+    )
+)]
+async fn flamegraph_view(
+    State(s): State<ManagementState>,
+    Query(params): Query<flamegraph::FlamegraphParams>,
+) -> Response {
+    match flamegraph::sample_flamegraph_svg(&s.profiler, s.config.profiling, &params).await {
+        Ok(svg) => ([(header::CONTENT_TYPE, "image/svg+xml")], svg).into_response(),
+        Err(err) => RestError(err).into_response(),
     }
 }
 

--- a/app/ferroehr-rest/tests/it/extensions_openapi.rs
+++ b/app/ferroehr-rest/tests/it/extensions_openapi.rs
@@ -456,11 +456,19 @@ async fn full_app() -> Router {
         prometheus: AccessLevel::Public,
         env: AccessLevel::Public,
         loggers: AccessLevel::Public,
+        flamegraph: AccessLevel::Public,
     };
     let observability = Observability {
         management: ManagementConfig {
             enabled: true,
             endpoints: public,
+            // The routing parity test drives every documented op with default
+            // parameters; cap the sample window at 1 s so the flamegraph op
+            // answers quickly (the default window shrinks to the cap).
+            profiling: ferroehr::config::management::ProfilingConfig {
+                max_seconds: 1,
+                ..ferroehr::config::management::ProfilingConfig::default()
+            },
             ..ManagementConfig::default()
         },
         prometheus: Some(recorder().clone()),

--- a/app/ferroehr-rest/tests/it/management.rs
+++ b/app/ferroehr-rest/tests/it/management.rs
@@ -372,3 +372,104 @@ async fn separate_port_mode_keeps_management_off_the_main_app() {
         );
     }
 }
+
+// ── The on-demand CPU flamegraph (`/management/flamegraph`) ─────────────────
+
+/// Build an app with the management surface enabled and only the `flamegraph`
+/// endpoint mounted, at `level`, with the given profiling limits.
+async fn app_with_flamegraph(
+    level: AccessLevel,
+    profiling: ferroehr::config::management::ProfilingConfig,
+) -> Router {
+    let config = AppConfig {
+        server: ServerConfig {
+            swagger_ui: false,
+            ..Default::default()
+        },
+        auth: auth_config(None),
+        ..Default::default()
+    };
+    let observability = Observability {
+        management: ManagementConfig {
+            enabled: true,
+            endpoints: EndpointLevels {
+                flamegraph: level,
+                ..EndpointLevels::default()
+            },
+            profiling,
+            ..ManagementConfig::default()
+        },
+        ..Observability::default()
+    };
+    let (_pg, service) = common::test_service().await;
+    ferroehr_rest::build_full(config, service, None, observability).expect("build")
+}
+
+/// Off (the default) means the route is simply absent — a `404` answered
+/// before authentication.
+#[tokio::test]
+async fn flamegraph_off_is_404() {
+    let app = app_with_flamegraph(
+        AccessLevel::Off,
+        ferroehr::config::management::ProfilingConfig::default(),
+    )
+    .await;
+    assert_eq!(
+        status_of(app, get("/management/flamegraph")).await,
+        StatusCode::NOT_FOUND
+    );
+}
+
+/// Opted in: a short sample window answers `200` with a rendered SVG.
+#[tokio::test]
+async fn flamegraph_samples_and_renders_svg() {
+    let app = app_with_flamegraph(
+        AccessLevel::Public,
+        ferroehr::config::management::ProfilingConfig::default(),
+    )
+    .await;
+    let response = app
+        .oneshot(get("/management/flamegraph?seconds=1&frequency=99"))
+        .await
+        .expect("response");
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .expect("content type"),
+        "image/svg+xml"
+    );
+    let body = response
+        .into_body()
+        .collect()
+        .await
+        .expect("body")
+        .to_bytes();
+    let text = String::from_utf8(body.to_vec()).expect("svg is utf-8");
+    assert!(
+        text.contains("<svg"),
+        "the body must be a rendered flamegraph SVG"
+    );
+}
+
+/// A request beyond a configured cap is refused with `400` — never silently
+/// clamped.
+#[tokio::test]
+async fn flamegraph_over_cap_is_400() {
+    let app = app_with_flamegraph(
+        AccessLevel::Public,
+        ferroehr::config::management::ProfilingConfig::default(),
+    )
+    .await;
+    assert_eq!(
+        status_of(app.clone(), get("/management/flamegraph?seconds=31")).await,
+        StatusCode::BAD_REQUEST,
+        "seconds beyond management.profiling.max_seconds must refuse"
+    );
+    assert_eq!(
+        status_of(app, get("/management/flamegraph?frequency=1000")).await,
+        StatusCode::BAD_REQUEST,
+        "frequency beyond management.profiling.max_frequency must refuse"
+    );
+}

--- a/app/ferroehr/CLAUDE.md
+++ b/app/ferroehr/CLAUDE.md
@@ -41,6 +41,13 @@ module.**
   (`tools/testkit`; template-clone per test). Never start a per-test PG container
   or run migrations in a test. Cluster-global objects a test must create (login
   roles) are named off the clone db name so the testkit sweep reaps them.
+- **Benches** (`benches/aql.rs`, criterion, `harness = false`): every bench
+  emits a CPU flamegraph under `--profile-time`
+  (`cargo bench -p ferroehr --bench aql -- --profile-time 10` →
+  `target/criterion/<bench>/profile/flamegraph.svg`). New benches copy that
+  file's `criterion::profiler::Profiler`-over-`pprof` impl — never enable
+  pprof's own `criterion` feature (pinned to criterion ^0.5, incompatible
+  with our 0.8). Profiling how-to: the `/flamegraph` skill.
 - **One integration-test binary:** `tests/it/main.rs` + one `mod` per topic
   file; `tests/resources/` holds the shared fixtures (paths are anchored at
   `CARGO_MANIFEST_DIR`). A new suite is a module registered in `main.rs`, never

--- a/app/ferroehr/Cargo.toml
+++ b/app/ferroehr/Cargo.toml
@@ -28,6 +28,7 @@ tracing-subscriber.workspace = true
 # Prometheus recorder. The single `tracing` API fans out to stdout logs and
 # (opt-in) OTLP spans; `metrics` is pulled via the Prometheus recorder.
 tracing-opentelemetry.workspace = true
+tracing-flame.workspace = true
 opentelemetry.workspace = true
 opentelemetry_sdk.workspace = true
 opentelemetry-otlp.workspace = true
@@ -130,6 +131,16 @@ tracing-opentelemetry.workspace = true
 opentelemetry.workspace = true
 # The in-memory OTLP exporters for the export-pipeline smoke tests.
 opentelemetry_sdk = { workspace = true, features = ["rt-tokio", "testing"] }
+# The AQL bench harness (`benches/aql.rs`): criterion drives the measurements,
+# pprof renders per-bench flamegraphs under `--profile-time` (pprof's own
+# `criterion` feature is pinned to criterion ^0.5, so the bench implements
+# criterion's `Profiler` trait over pprof directly — see the bench file).
+criterion.workspace = true
+pprof.workspace = true
+
+[[bench]]
+name = "aql"
+harness = false
 
 [lints]
 workspace = true

--- a/app/ferroehr/assets/ferroehr.default.toml
+++ b/app/ferroehr/assets/ferroehr.default.toml
@@ -68,6 +68,10 @@ service_name = "ferroehr"
 environment = "dev"
 traces_sample_ratio = 1.0    # PROD: 0.1 is a common starting point
 metrics_push = false
+# Span-timing flamegraph capture (tracing-flame): write folded stack samples
+# to this file for offline rendering (inferno-flamegraph < file > flame.svg).
+# Unset ⇒ the layer is not installed (zero overhead). Diagnostic sessions only.
+#? flame_file = "/var/log/ferroehr/tracing.folded"
 
 # ── [auth] — authentication (PROD: configure a mechanism) ─────────────────────
 [auth]
@@ -159,8 +163,8 @@ capabilities = []   # extra (HL7 base) capabilities to advertise, e.g. ["launch-
 #? management_endpoint = "https://as.example/manage"
 
 # ── [management] — ops-introspection surface ───────────────────────────────────
-# Introspection only (info / prometheus / metrics / env / loggers), off by
-# default. Health probes are NOT here: /health, /health/liveness and
+# Introspection only (info / prometheus / metrics / env / loggers / flamegraph),
+# off by default. Health probes are NOT here: /health, /health/liveness and
 # /health/readiness are always mounted and public, whatever this section says.
 [management]
 enabled = false
@@ -174,6 +178,13 @@ metrics = "off"
 prometheus = "off"
 env = "off"
 loggers = "off"
+flamegraph = "off"            # on-demand CPU flamegraph (pprof sampling)
+
+# Limits for the on-demand CPU profiler (endpoints.flamegraph). A request
+# asking beyond a cap is refused with 400, never silently clamped.
+[management.profiling]
+max_seconds = 30              # longest sample window one request may take
+max_frequency = 999           # highest sampling frequency (Hz) a request may ask
 
 # ── [signing] — VERSION signing (RM common master06 §Digital Signature) ───────
 [signing]

--- a/app/ferroehr/benches/aql.rs
+++ b/app/ferroehr/benches/aql.rs
@@ -1,0 +1,143 @@
+//! Criterion benches over the AQL front half (parse → plan → SQL build), with
+//! per-bench CPU flamegraphs.
+//!
+//! Plain measurement: `cargo bench -p ferroehr --bench aql`.
+//! Flamegraphs: `cargo bench -p ferroehr --bench aql -- --profile-time 10`
+//! writes `flamegraph.svg` per bench under
+//! `target/criterion/<bench>/profile/` (criterion runs the registered
+//! profiler only under `--profile-time` —
+//! <https://docs.rs/criterion/latest/criterion/profiler/trait.Profiler.html>).
+//!
+//! NOTE: the profiler glue below implements criterion's `Profiler` trait over
+//! the `pprof` sampler directly, because pprof's own `criterion` feature is
+//! pinned to criterion ^0.5 (verified on crates.io 2026-08-04) and this
+//! workspace is on criterion 0.8. The sampling and the flamegraph rendering
+//! are entirely pprof + inferno; only this trait impl is ours.
+
+#![expect(
+    clippy::expect_used,
+    reason = "bench fixture setup and profiler I/O: a malformed fixture query \
+              or an unwritable profile directory must abort the bench loudly \
+              (there is no caller to return an error to)"
+)]
+#![expect(
+    clippy::print_stderr,
+    reason = "the bench harness is a dev binary; profiler lifecycle notes go \
+              to the operator on stderr (no tracing subscriber is installed)"
+)]
+
+use std::fs::File;
+use std::hint::black_box;
+use std::path::Path;
+use std::sync::Arc;
+
+use criterion::profiler::Profiler;
+use criterion::{Criterion, criterion_group, criterion_main};
+
+use ferroehr::aql::ir::Params;
+use ferroehr::aql::lineage::ArchetypeLineage;
+use ferroehr::aql::sql::SqlCtx;
+use openehr_query::parser;
+
+/// A representative clinical query: EHR → COMPOSITION → archetyped
+/// OBSERVATION chain, a typed magnitude predicate, ordering, and paging — it
+/// exercises the CONTAINS planner, path typing, and the ORDER BY/limit
+/// lowering in one shot.
+const QUERY: &str = "SELECT e/ehr_id/value, c/uid/value, \
+     o/data[at0001]/events[at0006]/data[at0003]/items[at0004]/value/magnitude \
+     FROM EHR e CONTAINS COMPOSITION c \
+     CONTAINS OBSERVATION o [openEHR-EHR-OBSERVATION.blood_pressure.v2] \
+     WHERE o/data[at0001]/events[at0006]/data[at0003]/items[at0004]/value/magnitude > 120.0 \
+     ORDER BY c/context/start_time/value DESC \
+     LIMIT 50";
+
+fn bench_ctx() -> SqlCtx {
+    SqlCtx {
+        system_id: "bench.ferroehr.org".to_owned(),
+        ehr_ids: Vec::new(),
+        subject_scope: None,
+        limit: None,
+        offset: None,
+        archetype_lineage: Arc::new(ArchetypeLineage::default()),
+    }
+}
+
+fn aql_front_half(c: &mut Criterion) {
+    let params = Params::new();
+    let ctx = bench_ctx();
+    let ast = parser::parse_str(QUERY).expect("the fixture query must parse");
+    let ir = ferroehr::aql::plan(&ast, &params).expect("the fixture query must plan");
+
+    c.bench_function("aql_parse", |b| {
+        b.iter(|| parser::parse_str(black_box(QUERY)).expect("the fixture query must parse"));
+    });
+    c.bench_function("aql_plan", |b| {
+        b.iter(|| {
+            ferroehr::aql::plan(black_box(&ast), &params).expect("the fixture query must plan")
+        });
+    });
+    c.bench_function("aql_sql_build", |b| {
+        b.iter(|| {
+            ferroehr::aql::sql::build(black_box(&ir), &params, &ctx)
+                .expect("the fixture query must lower to SQL")
+        });
+    });
+    c.bench_function("aql_parse_plan_sql", |b| {
+        b.iter(|| {
+            let ast = parser::parse_str(black_box(QUERY)).expect("the fixture query must parse");
+            let ir = ferroehr::aql::plan(&ast, &params).expect("the fixture query must plan");
+            ferroehr::aql::sql::build(&ir, &params, &ctx)
+                .expect("the fixture query must lower to SQL")
+        });
+    });
+}
+
+/// Criterion `Profiler` glue over the `pprof` sampler: start a guard when
+/// criterion enters profile mode, render `flamegraph.svg` into the bench's
+/// profile directory when it leaves.
+struct FlamegraphProfiler {
+    frequency: i32,
+    guard: Option<pprof::ProfilerGuard<'static>>,
+}
+
+impl FlamegraphProfiler {
+    const fn new(frequency: i32) -> Self {
+        Self {
+            frequency,
+            guard: None,
+        }
+    }
+}
+
+impl Profiler for FlamegraphProfiler {
+    fn start_profiling(&mut self, _benchmark_id: &str, _benchmark_dir: &Path) {
+        self.guard = Some(
+            pprof::ProfilerGuardBuilder::default()
+                .frequency(self.frequency)
+                // The unwind-hazard blocklist pprof's docs recommend
+                // (<https://docs.rs/pprof/latest/pprof/>).
+                .blocklist(&["libc", "libgcc", "pthread", "vdso"])
+                .build()
+                .expect("the pprof sampler must start"),
+        );
+    }
+
+    fn stop_profiling(&mut self, benchmark_id: &str, benchmark_dir: &Path) {
+        let Some(guard) = self.guard.take() else {
+            return;
+        };
+        let report = guard.report().build().expect("the pprof report must build");
+        std::fs::create_dir_all(benchmark_dir).expect("the profile directory must be creatable");
+        let path = benchmark_dir.join("flamegraph.svg");
+        let file = File::create(&path).expect("the flamegraph file must be creatable");
+        report.flamegraph(file).expect("the flamegraph must render");
+        eprintln!("profiled {benchmark_id}: {}", path.display());
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(FlamegraphProfiler::new(999));
+    targets = aql_front_half
+}
+criterion_main!(benches);

--- a/app/ferroehr/src/config/management.rs
+++ b/app/ferroehr/src/config/management.rs
@@ -64,6 +64,34 @@ pub struct EndpointLevels {
     /// `/management/loggers` — the runtime `EnvFilter` control.
     #[serde(default)]
     pub loggers: AccessLevel,
+    /// `/management/flamegraph` — the on-demand CPU flamegraph (pprof sampling).
+    #[serde(default)]
+    pub flamegraph: AccessLevel,
+}
+
+/// Limits for the on-demand CPU profiler behind `/management/flamegraph`.
+///
+/// Sampling is cheap but not free (a `SIGPROF`-driven stack sample at the
+/// requested frequency, per the `pprof` crate —
+/// <https://docs.rs/pprof/latest/pprof/>), so the caps below bound what a
+/// request may ask for; a request outside them is refused with `400`, never
+/// silently clamped.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct ProfilingConfig {
+    /// The longest sample window a single request may ask for, in seconds.
+    pub max_seconds: u16,
+    /// The highest sampling frequency a request may ask for, in Hz.
+    pub max_frequency: i32,
+}
+
+impl Default for ProfilingConfig {
+    fn default() -> Self {
+        Self {
+            max_seconds: 30,
+            max_frequency: 999,
+        }
+    }
 }
 
 /// The management surface configuration.
@@ -88,6 +116,9 @@ pub struct ManagementConfig {
     /// Per-endpoint access levels.
     #[serde(default)]
     pub endpoints: EndpointLevels,
+    /// Limits for the on-demand CPU profiler (`endpoints.flamegraph`).
+    #[serde(default)]
+    pub profiling: ProfilingConfig,
 }
 
 impl Default for ManagementConfig {
@@ -98,6 +129,7 @@ impl Default for ManagementConfig {
             port: None,
             access_default: defaults::access_default(),
             endpoints: EndpointLevels::default(),
+            profiling: ProfilingConfig::default(),
         }
     }
 }
@@ -126,6 +158,9 @@ mod tests {
         assert_eq!(c.access_default, AccessLevel::AdminOnly);
         assert_eq!(c.endpoints.prometheus, AccessLevel::Off);
         assert_eq!(c.endpoints.info, AccessLevel::Off);
+        assert_eq!(c.endpoints.flamegraph, AccessLevel::Off);
+        assert_eq!(c.profiling.max_seconds, 30);
+        assert_eq!(c.profiling.max_frequency, 999);
     }
 
     /// The health probes are not part of this section any more (they are the

--- a/app/ferroehr/src/telemetry/config.rs
+++ b/app/ferroehr/src/telemetry/config.rs
@@ -62,6 +62,13 @@ pub struct OtelConfig {
     /// Whether to also **push** metrics over OTLP (a periodic `OTel` meter
     /// provider alongside the Prometheus pull surface). Off by default.
     pub metrics_push: bool,
+    /// Span-timing flamegraph capture (the `tracing-flame` layer,
+    /// <https://docs.rs/tracing-flame/latest/tracing_flame/>): write folded
+    /// stack samples of every `tracing` span to this file, for offline
+    /// rendering with inferno. **Unset ⇒ the layer is not installed at all**
+    /// (zero overhead) — set it for a diagnostic session, not as a standing
+    /// production posture (the file grows with span traffic).
+    pub flame_file: Option<std::path::PathBuf>,
 }
 
 impl Default for OtelConfig {
@@ -72,6 +79,7 @@ impl Default for OtelConfig {
             environment: defaults::environment(),
             traces_sample_ratio: defaults::sample_ratio(),
             metrics_push: false,
+            flame_file: None,
         }
     }
 }
@@ -123,5 +131,6 @@ mod tests {
         assert_eq!(c.otel.service_name, "ferroehr");
         assert_eq!(c.log.format, LogFormat::Auto);
         assert!(!c.otel.metrics_push);
+        assert!(c.otel.flame_file.is_none());
     }
 }

--- a/app/ferroehr/src/telemetry/layers.rs
+++ b/app/ferroehr/src/telemetry/layers.rs
@@ -1,14 +1,19 @@
 //! Subscriber assembly: a reloadable `EnvFilter` + a stdout
-//! `fmt` layer (json/pretty/auto) + an optional `OTel` export layer.
+//! `fmt` layer (json/pretty/auto) + an optional `OTel` export layer + an
+//! optional span-flamegraph capture layer.
 //!
-//! `tracing` is the single instrumentation API; this module wires the three
+//! `tracing` is the single instrumentation API; this module wires the
 //! consumers. The `EnvFilter` sits behind a `reload::Layer` so
 //! `/management/loggers` can swap it live; the handle is captured behind
 //! type-erased closures into a [`LogReload`]. The `OTel` layer is added **only**
-//! when a tracer is supplied (endpoint configured) — absent, it is not in the
+//! when a tracer is supplied (endpoint configured), and the `tracing-flame`
+//! layer only when `telemetry.flame_file` is set — absent, neither is in the
 //! stack at all (zero overhead).
 
+use std::fs::File;
+use std::io::BufWriter;
 use std::io::IsTerminal;
+use std::path::Path;
 use std::sync::Arc;
 
 use crate::telemetry::log_reload::{ApplyFilter, LogReload, ReadFilter};
@@ -28,16 +33,24 @@ type Base = Layered<reload::Layer<EnvFilter, Registry>, Registry>;
 /// A type-erased data layer over [`Base`].
 type BoxedLayer = Box<dyn Layer<Base> + Send + Sync>;
 
+/// The flush handle of the optional span-flamegraph layer (folded stacks to a
+/// buffered file); flushing on shutdown is what makes a truncated diagnostic
+/// session still render.
+pub(super) type FlameFlush = tracing_flame::FlushGuard<BufWriter<File>>;
+
 /// Build the global subscriber and install it. Returns the [`LogReload`] handle
-/// onto the reloadable filter. Adds the `OTel` layer iff `otel_tracer` is `Some`.
+/// onto the reloadable filter plus the span-flamegraph flush guard when
+/// `flame_file` is set. Adds the `OTel` layer iff `otel_tracer` is `Some`.
 ///
 /// # Errors
-/// Returns [`TelemetryError::Subscriber`] if a global subscriber is already set.
+/// Returns [`TelemetryError::Subscriber`] if a global subscriber is already
+/// set, or [`TelemetryError::Flame`] if the `flame_file` cannot be created.
 pub(super) fn init_subscriber(
     format: super::config::LogFormat,
     boot_filter: &str,
     otel_tracer: Option<SdkTracer>,
-) -> Result<LogReload, TelemetryError> {
+    flame_file: Option<&Path>,
+) -> Result<(LogReload, Option<FlameFlush>), TelemetryError> {
     // Reloadable global filter. A bad boot directive falls back to `info` so the
     // process still starts (and logs the problem).
     let env_filter = EnvFilter::try_new(boot_filter).unwrap_or_else(|_| EnvFilter::new("info"));
@@ -47,6 +60,13 @@ pub(super) fn init_subscriber(
     let mut layers: Vec<BoxedLayer> = vec![fmt_layer(format)];
     if let Some(tracer) = otel_tracer {
         layers.push(tracing_opentelemetry::layer().with_tracer(tracer).boxed());
+    }
+    let mut flame_flush = None;
+    if let Some(path) = flame_file {
+        let (flame_layer, flush) = tracing_flame::FlameLayer::with_file(path)
+            .map_err(|e| TelemetryError::Flame(e.to_string()))?;
+        layers.push(flame_layer.boxed());
+        flame_flush = Some(flush);
     }
 
     Registry::default()
@@ -69,7 +89,7 @@ pub(super) fn init_subscriber(
         reload_handle.reload(new_filter).map_err(|e| e.to_string())
     });
 
-    Ok(LogReload::new(boot_filter, read, apply))
+    Ok((LogReload::new(boot_filter, read, apply), flame_flush))
 }
 
 /// The stdout `fmt` layer for the chosen profile, boxed so the subscriber type
@@ -94,5 +114,39 @@ fn fmt_layer(format: super::config::LogFormat) -> BoxedLayer {
         // force ANSI on. Only `auto`-selected pretty keeps TTY detection.
         let ansi = matches!(format, LogFormat::Pretty) || std::io::stdout().is_terminal();
         fmt::layer().with_target(true).with_ansi(ansi).boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The flame layer records entered spans as folded stack lines the
+    /// flush guard writes out — exercised on a SCOPED subscriber (never the
+    /// global one; tests share the process).
+    #[test]
+    #[expect(
+        clippy::panic_in_result_fn,
+        reason = "Result-returning test with assertions — the Book ch11 shape \
+                  (testing.md adjudication)"
+    )]
+    fn flame_layer_writes_folded_stacks() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = assert_fs::TempDir::new()?;
+        let path = tmp.path().join("tracing.folded");
+        let (flame_layer, flush) = tracing_flame::FlameLayer::with_file(&path)?;
+        let subscriber = Registry::default().with(flame_layer);
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!("flame_probe_span");
+            let entered = span.enter();
+            std::thread::sleep(std::time::Duration::from_millis(5));
+            drop(entered);
+        });
+        flush.flush()?;
+        let folded = std::fs::read_to_string(&path)?;
+        assert!(
+            folded.contains("flame_probe_span"),
+            "the folded stacks must record the entered span: {folded:?}"
+        );
+        Ok(())
     }
 }

--- a/app/ferroehr/src/telemetry/mod.rs
+++ b/app/ferroehr/src/telemetry/mod.rs
@@ -56,6 +56,9 @@ pub enum TelemetryError {
     /// An OTLP exporter could not be built.
     #[error("otlp exporter: {0}")]
     Exporter(String),
+    /// The span-flamegraph capture file could not be created.
+    #[error("flame capture: {0}")]
+    Flame(String),
 }
 
 /// Initialize telemetry from configuration. Call once, early in `main`.
@@ -92,8 +95,14 @@ pub fn init(cfg: &TelemetryConfig, build: &BuildInfo) -> Result<TelemetryGuard, 
         opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
     }
 
-    // 3) Logs + the (optional) OTel span layer.
-    let reload = layers::init_subscriber(cfg.log.format, &cfg.log.filter, tracer)?;
+    // 3) Logs + the (optional) OTel span layer + the (optional) span-flame
+    //    capture layer.
+    let (reload, flame) = layers::init_subscriber(
+        cfg.log.format,
+        &cfg.log.filter,
+        tracer,
+        cfg.otel.flame_file.as_deref(),
+    )?;
 
     Ok(TelemetryGuard {
         reload,
@@ -101,6 +110,7 @@ pub fn init(cfg: &TelemetryConfig, build: &BuildInfo) -> Result<TelemetryGuard, 
         tracer_provider,
         meter_provider,
         meter,
+        flame,
         sampler: None,
         shut: false,
     })
@@ -169,6 +179,7 @@ pub struct TelemetryGuard {
     tracer_provider: Option<SdkTracerProvider>,
     meter_provider: Option<SdkMeterProvider>,
     meter: Option<Meter>,
+    flame: Option<layers::FlameFlush>,
     sampler: Option<JoinHandle<()>>,
     shut: bool,
 }
@@ -178,6 +189,7 @@ impl std::fmt::Debug for TelemetryGuard {
         f.debug_struct("TelemetryGuard")
             .field("otel_traces", &self.tracer_provider.is_some())
             .field("otel_metrics_push", &self.meter_provider.is_some())
+            .field("flame_capture", &self.flame.is_some())
             .field("sampler_running", &self.sampler.is_some())
             .finish_non_exhaustive()
     }
@@ -214,6 +226,13 @@ impl TelemetryGuard {
         if let Some(sampler) = self.sampler.take() {
             sampler.abort();
         }
+        // Flush the span-flame capture first (a buffered local file; dropping
+        // the guard also flushes, but an explicit failure is logged, not lost).
+        if let Some(flame) = self.flame.take()
+            && let Err(e) = flame.flush()
+        {
+            tracing::warn!(error = %e, "span-flame flush at shutdown failed");
+        }
         let tracer = self.tracer_provider.take();
         let meter = self.meter_provider.take();
         self.shut = true;
@@ -248,6 +267,11 @@ impl Drop for TelemetryGuard {
             tracing::warn!(
                 "TelemetryGuard dropped without shutdown(); flushing exporters best-effort"
             );
+            if let Some(flame) = self.flame.take()
+                && let Err(e) = flame.flush()
+            {
+                tracing::warn!(error = %e, "span-flame flush in Drop failed");
+            }
             if let Some(t) = self.tracer_provider.take()
                 && let Err(e) = t.shutdown()
             {

--- a/deny.toml
+++ b/deny.toml
@@ -57,7 +57,14 @@ allow = [
   "CDLA-Permissive-2.0",
 ]
 confidence-threshold = 0.9
-exceptions = []
+exceptions = [
+  # inferno (the flamegraph renderer pprof's `flamegraph` feature uses) is
+  # CDDL-1.0 — a file-scoped weak copyleft (like MPL-2.0): obligations attach
+  # to inferno's own source files, which we consume unmodified as a build
+  # dependency of the profiling instrument; nothing of ours is derivative.
+  # Scoped exception, not a blanket allow (2026-08-04, issue #1861).
+  { allow = ["CDDL-1.0"], crate = "inferno" },
+]
 
 [bans]
 multiple-versions = "warn"

--- a/deploy/helm/ferroehr/values.yaml
+++ b/deploy/helm/ferroehr/values.yaml
@@ -188,11 +188,12 @@ config:
     claim: tenant
 
   # [management] — ops-introspection surface (info / prometheus / metrics / env /
-  # loggers). The master switch is ON here (unlike the bare binary) so scraping is
-  # a one-key change; every endpoint below stays off, so nothing is exposed until
-  # you opt in (set prometheus=public + metrics.enabled to scrape). Health probes
-  # are NOT part of this surface — /health, /health/liveness and /health/readiness
-  # are always served on the HTTP port, whatever this section says.
+  # loggers / flamegraph). The master switch is ON here (unlike the bare binary)
+  # so scraping is a one-key change; every endpoint below stays off, so nothing
+  # is exposed until you opt in (set prometheus=public + metrics.enabled to
+  # scrape). Health probes are NOT part of this surface — /health,
+  # /health/liveness and /health/readiness are always served on the HTTP port,
+  # whatever this section says.
   management:
     enabled: true
     base_path: /management
@@ -205,6 +206,9 @@ config:
       prometheus: "off"
       env: "off"
       loggers: "off"
+      # On-demand CPU flamegraph of the running server (pprof sampling; caps
+      # under [management.profiling] — see the configuration reference).
+      flamegraph: "off"
 
   # [signing] — VERSION signing. On/digest by default (the STANDARD "Signing"
   # capability). pgp mode requires signing.key_path (a mounted config.files key)

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -223,6 +223,7 @@ data:
       port = 9100.0
       [management.endpoints]
         env = "admin_only"
+        flamegraph = "off"
         info = "admin_only"
         loggers = "admin_only"
         metrics = "admin_only"
@@ -333,7 +334,7 @@ spec:
     metadata:
       annotations:
         # Roll pods when the rendered ferroehr.toml changes.
-        checksum/config: a91ae973dbab78d873fc5a1f8b4883126cf8507e4df7987b5814f1617ccbc5ee
+        checksum/config: 9e588a7866c16a223d517366fc5a44d878f3103432598e8f97c8288aebd18b79
         prometheus.io/scrape: "true"
         prometheus.io/port: "9100"
         prometheus.io/path: "/management/prometheus"

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -125,6 +125,7 @@ data:
       enabled = true
       [management.endpoints]
         env = "off"
+        flamegraph = "off"
         info = "off"
         loggers = "off"
         metrics = "off"
@@ -202,7 +203,7 @@ spec:
     metadata:
       annotations:
         # Roll pods when the rendered ferroehr.toml changes.
-        checksum/config: 95c5ce677743a8769a664a7cdf77ecf0f69aefad7ddcd22b686e397ee7bb09a7
+        checksum/config: 243e73a5210c0e28d175690cfe628dbb52e9964da8f75cb4f2f19abbbab3f8d3
       labels:
         app.kubernetes.io/name: ferroehr
         app.kubernetes.io/instance: ferroehr

--- a/website/book/src/contributing.md
+++ b/website/book/src/contributing.md
@@ -62,6 +62,48 @@ A few more conventions worth knowing before you open a pull request:
   the CLI, or the deployment artifacts) adds an entry to the changelog in the
   same pull request — a CI guard enforces this.
 
+## Profiling: finding where the time goes
+
+Four flamegraph instruments, all built on established crates (the sampling is
+[`pprof`](https://docs.rs/pprof/latest/pprof/), the rendering is
+[`inferno`](https://docs.rs/inferno/latest/inferno/)) — pick by situation:
+
+- **A running server** (composed stack, staging, production): the
+  `GET /management/flamegraph` endpoint — see
+  [Operations → Profiling](operations.md#profiling-the-on-demand-cpu-flamegraph).
+- **A code path in isolation**: the criterion benches carry a pprof profiler,
+  so any bench emits a flamegraph under `--profile-time`:
+
+  ```bash
+  cargo bench -p ferroehr --bench aql -- --profile-time 10
+  # → target/criterion/<bench>/profile/flamegraph.svg
+  ```
+
+- **Async attribution** (a sampled stack under tokio often blames the
+  executor's poll loop; a span flame blames the instrumented operation): set
+  `telemetry.flame_file = "/tmp/ferroehr.folded"` — the
+  [`tracing-flame`](https://docs.rs/tracing-flame/latest/tracing_flame/)
+  layer captures span timings as folded stacks, rendered offline:
+
+  ```bash
+  cargo install inferno
+  inferno-flamegraph < /tmp/ferroehr.folded > span-flame.svg
+  ```
+
+- **A whole local binary run** (no code changes needed):
+  [`cargo flamegraph`](https://crates.io/crates/flamegraph) — a dev tool,
+  not a dependency (`cargo install flamegraph`):
+
+  ```bash
+  cargo flamegraph --bin ferroehr            # Linux: perf; add -F 999 for finer sampling
+  cargo flamegraph --bench aql -- --bench    # profile a bench run end to end
+  ```
+
+  On macOS it uses `dtrace`, which needs elevated permissions — run with
+  `sudo cargo flamegraph …` or grant your terminal Developer-Tools access; on
+  Linux you may need `perf` installed and
+  `kernel.perf_event_paranoid` ≤ 2.
+
 ## Reporting issues and vulnerabilities
 
 Use the GitHub issue tracker for bugs and feature requests.

--- a/website/book/src/installation/configuration.md
+++ b/website/book/src/installation/configuration.md
@@ -245,6 +245,7 @@ OpenTelemetry export. Unset `otlp_endpoint` ⇒ the OTel layer is not installed
 | `environment` | string | `dev` | `deployment.environment` resource attribute. |
 | `traces_sample_ratio` | float | `1.0` | Head-sampling ratio (`0.1` is a common prod start). |
 | `metrics_push` | bool | `false` | Also push metrics over OTLP alongside the Prometheus pull surface. |
+| `flame_file` | path | unset ⇒ layer not installed | Span-timing flamegraph capture (`tracing-flame`): write folded stack samples of every span to this file; render offline with `inferno-flamegraph < file > flame.svg`. For diagnostic sessions, not a standing posture — the file grows with span traffic. |
 
 ## `[auth]`
 
@@ -389,6 +390,11 @@ metrics = "off"
 prometheus = "off"
 env = "off"
 loggers = "off"
+flamegraph = "off"
+
+[management.profiling]
+max_seconds = 30
+max_frequency = 999
 ```
 
 | Key | Type | Default | Description |
@@ -399,7 +405,16 @@ loggers = "off"
 | `access_default` | enum{off,admin_only,private,public} | `admin_only` | Global default access level (a per-endpoint level wins). |
 
 `[management.endpoints]` — `info`, `metrics`, `prometheus`, `env`, `loggers`,
-each enum{off,admin_only,private,public}, default `off`.
+`flamegraph`, each enum{off,admin_only,private,public}, default `off`.
+
+`[management.profiling]` — limits for the on-demand CPU flamegraph behind
+`endpoints.flamegraph` (see
+[Operations → Profiling](../operations.md#profiling-the-on-demand-cpu-flamegraph)):
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `max_seconds` | int | `30` | Longest sample window one request may take. A request asking for more is refused with `400`, never clamped. |
+| `max_frequency` | int | `999` | Highest sampling frequency (Hz) a request may ask for. Same refusal semantics. |
 
 > [!WARNING]
 > `probes_enabled` and `endpoints.health` were **removed**. Configuration is

--- a/website/book/src/operations.md
+++ b/website/book/src/operations.md
@@ -434,10 +434,37 @@ The ops endpoints:
 | `GET {base}/metrics` | JSON registry view | `admin_only` |
 | `GET {base}/env` | effective configuration, with secrets redacted | `admin_only` |
 | `GET`/`POST`/`DELETE` `{base}/loggers` | read and change the log level at runtime | `admin_only` |
+| `GET {base}/flamegraph` | on-demand CPU flamegraph of the running server | `admin_only` |
 
 > [!WARNING]
 > `{base}/env` and `{base}/loggers` expose and change server internals — keep
 > them `admin_only`, and prefer binding the surface to an internal-only port.
+
+### Profiling: the on-demand CPU flamegraph
+
+When the server is measurably slow, the metrics tell you *how slow*;
+`{base}/flamegraph` tells you **where the time goes**. The endpoint samples the
+whole process with an in-process sampling profiler (the
+[`pprof`](https://docs.rs/pprof/latest/pprof/) crate) for a bounded window and
+answers with a rendered flamegraph SVG — open it in a browser and read the wide
+frames.
+
+```bash
+# sample 10 s at 99 Hz (the defaults) and open the result
+curl -u admin:… -o flamegraph.svg \
+  "http://cdr.internal:9100/management/flamegraph?seconds=10&frequency=99"
+```
+
+- `seconds` (default 10) and `frequency` (default 99 Hz) are capped by
+  `management.profiling.max_seconds` / `max_frequency`; a request beyond a cap
+  is refused with `400`, never silently clamped.
+- **One sample window at a time**: a second request while one runs answers
+  `409` — retry when the window completes.
+- Sampling is low-overhead but not free; profile under the real load you are
+  diagnosing, and keep the endpoint `admin_only` on an internal port like the
+  rest of the surface.
+- Best results come from the container images and release builds, which keep
+  line tables (`debug = "line-tables-only"`) so frames resolve to `file:line`.
 
 With the surface enabled, the admin console grows an **Operations** screen over
 it — dependency health, build provenance, the metric registry, and runtime log


### PR DESCRIPTION
Closes #1861
Closes #1862

The profiling story for finding where the server spends its time. No openEHR spec governs profiling — our own operational extension throughout.

## What landed

**1. `GET /management/flamegraph` (#1861)** — on-demand CPU flamegraph of the running server. `pprof` samples the whole process for a bounded window on a blocking-pool thread and answers with the rendered SVG (inferno). Follows the management-surface pattern exactly: opt-in endpoint key `management.endpoints.flamegraph` (default off), AccessLevel-gated, documented unconditionally in the served OpenAPI via `#[utoipa::path]`. New `[management.profiling]` caps (`max_seconds` 30, `max_frequency` 999): a request beyond a cap is `400` (refused, never clamped); a concurrent sample window is `409` (one process-wide profiler permit, held for exactly the sampling duration).

**2. Criterion bench flamegraphs (#1861)** — `app/ferroehr/benches/aql.rs`: the first workspace benches (AQL parse → plan → SQL build, the front half of the engine), emitting per-bench flamegraph SVGs under `--profile-time`. pprof's own `criterion` feature is pinned to criterion ^0.5 (verified on crates.io 2026-08-04) — type-incompatible with our criterion 0.8 — so the bench carries a ~30-line `criterion::profiler::Profiler` impl over pprof directly; sampling and rendering remain pprof + inferno.

**3. `telemetry.flame_file` (#1862)** — the `tracing-flame` span-capture layer, installed only when the key is set (zero overhead unset, same posture as the OTel layer). Captures span timings as folded stacks for offline inferno rendering — the async-attribution complement (a sampled stack under tokio blames the executor's poll loop; a span flame blames the instrumented operation). The flush guard rides `TelemetryGuard` and flushes on `shutdown()` and in the `Drop` backstop. #1862 was split out as a follow-up and then pulled back into this PR at the owner's direction.

**4. `cargo flamegraph` dev workflow** — documented (tool, not a dependency), macOS dtrace + Linux perf notes.

## Supporting changes

- `deny.toml`: scoped CDDL-1.0 exception for `inferno` (file-scoped weak copyleft, consumed unmodified); `cargo deny check` green.
- Config: `ferroehr.default.toml` template, book pages (`operations.md` §Profiling, `installation/configuration.md`, `contributing.md` §Profiling), Helm `values.yaml` + regenerated goldens, `CHANGELOG.md`.
- Tests: endpoint matrix in `ferroehr-rest` (`404` off / `200` SVG on a 1-second window / `400` over-cap), plan-validation + concurrency-permit unit tests, a scoped-subscriber `tracing-flame` folded-stacks test, config default tests; the OpenAPI routing-parity fixture mounts the new endpoint with a 1 s cap.

## Verification

Local gates on the pre-rebase tree: `cargo clippy -p ferroehr -p ferroehr-rest --all-targets -- -D warnings` clean, `cargo deny check` green, `cargo fmt` clean, Helm `validate.sh` green. The two-crate nextest run passed 557/558 executed tests; the one failure, `ferroehr::it service_branching::a_version_tree_with_branches_reexports_and_reimports_whole`, is the EHR-Extract re-export/re-import area rewritten by the concurrently merged #1736 work — unrelated to this change and adjudicated out of scope by the owner (a follow-up session picks up anything left open there). Branch rebased onto develop after that merge; `Cargo.lock` re-resolved on develop's version.