### PR TITLE
fix(cnf-runner): loud unresolvable outcome-matcher placeholders (#1852)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- CNF runner: an unresolvable `<name>` placeholder in an outcome header matcher is now a loud case failure instead of silently wildcarding to `.*`; the structural tokens `<n>`/`<system_id>` resolve to their real grammars, and outcome matchers see the same merged variable scope as request building (#1852).
 - AQL `LIKE` and `matches` predicates on multi-valued paths now use the existential (any-match) lowering the comparison operators already use — a row is matched when ANY node on the path satisfies the predicate, instead of an order-undefined single-node pick (#1448).
 - The admin EHR dump/load archive now carries every `vo_attestation` row (with its `at_committal` flag), and load re-persists them verbatim — a restored version keeps its attestations and its stored signature verifies under `verify_on_read = strict` (#1685).
 - **A node id carrying the at/id code leader but failing the code grammar is

--- a/tools/cnf-runner/artifacts/vocab/capability_matrix.yaml
+++ b/tools/cnf-runner/artifacts/vocab/capability_matrix.yaml
@@ -55,7 +55,7 @@ TemplateExamples: { family: Platform, tier: OPTIONS, required: false, min_cases:
 QueryProvisioning: { family: Platform, tier: STANDARD, required: true, min_cases: 27, source: "CNF profiles master03-profiles.adoc §Functional (Definitions: Query provisioning)" }
 EhrOperations: { family: Platform, tier: CORE, required: true, min_cases: 24, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: EHR Operations)" }
 EhrStatus: { family: Platform, tier: CORE, required: true, min_cases: 47, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: EHR Status)" }
-CompositionOps: { family: Platform, tier: CORE, required: true, min_cases: 51, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Composition Operations)" }
+CompositionOps: { family: Platform, tier: CORE, required: true, min_cases: 52, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Composition Operations)" }
 DirectoryOps: { family: Platform, tier: STANDARD, required: true, min_cases: 77, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Directory Operations)" }
 ChangeSets: { family: Platform, tier: CORE, required: true, min_cases: 87, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Change sets)" }
 Versioning: { family: Platform, tier: CORE, required: true, min_cases: 69, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Versioning)" }
@@ -182,7 +182,7 @@ DemographicArchive: { family: Platform, tier: OPTIONS, required: false, realizat
 # The workload_exclusion is GONE: the `integration_poll` journey now exports an
 # EHR as EXTRACTs (`ehr_extract_export`), so the measured hospital simulation
 # exercises the capability.
-EhrExtract: { family: Platform, tier: OPTIONS, required: false, realization: extension, min_cases: 27, source: "CNF profiles master03-profiles.adoc §Functional (Messaging: EHR Extract)" }
+EhrExtract: { family: Platform, tier: OPTIONS, required: false, realization: extension, min_cases: 29, source: "CNF profiles master03-profiles.adoc §Functional (Messaging: EHR Extract)" }
 # REALIZED ON THE EXTENSION SURFACE (#659, 2026-07-29) — no MESSAGE group exists
 # in the release (CONFIRMED unchanged first-hand), but the product serves
 # import_tdd + import_tdds under /message/tdd/ (the `message-tdd`

--- a/tools/cnf-runner/src/exec/driver.rs
+++ b/tools/cnf-runner/src/exec/driver.rs
@@ -3081,11 +3081,14 @@ impl StepDriver for HttpDriver<'_> {
         if observation == Observation::Kind(expected)
             && let Some(expectation) = binding.outcome(expected)
         {
+            // The SAME merged scope request building used (#1852): a step
+            // that supplies a value inline (`with:`) instead of capturing it
+            // must be able to pin it in its outcome matchers too.
             assertion_failures.extend(self.eval_wire_expectation(
                 expectation,
                 &exchange,
                 &headers,
-                vars,
+                &header_vars,
             ));
         }
         Ok(StepObservation {

--- a/tools/cnf-runner/src/exec/headers.rs
+++ b/tools/cnf-runner/src/exec/headers.rs
@@ -183,7 +183,16 @@ fn judge(
                     "header {name}: expected a value matching {pattern:?}, got none"
                 ));
             };
-            let resolved = resolve_placeholders(pattern, vars);
+            let resolved = match resolve_placeholders(pattern, vars) {
+                Ok(resolved) => resolved,
+                Err(missing) => {
+                    return Some(format!(
+                        "header {name}: pattern {pattern:?} names <{missing}>, which is \
+                         neither a captured/with-supplied case variable nor a structural \
+                         token (<n>, <system_id>) — refusing the vacuous wildcard (#1852)"
+                    ));
+                }
+            };
             match regex::Regex::new(&format!("^(?:{resolved})$")) {
                 Ok(re) if re.is_match(v) => None,
                 Ok(_) => Some(format!(
@@ -231,10 +240,20 @@ fn strip_entity_tag(value: &str) -> &str {
     v.trim_matches('"')
 }
 
-/// Substitute `<name>` placeholders: a resolvable case variable inserts its
-/// regex-escaped scalar; an unresolvable one wildcards to `.*` (mirroring
-/// the parse-time compile probe).
-fn resolve_placeholders(pattern: &str, vars: &VarStore) -> String {
+/// Substitute `<name>` placeholders. A resolvable case variable inserts its
+/// regex-escaped scalar; the two STRUCTURAL tokens the catalogue vocabulary
+/// declares resolve to their grammars when no variable shadows them —
+/// `<n>` to the `VERSION_TREE_ID` shape (BASE `base_types` master05
+/// §`VERSION_TREE_ID`: a trunk ordinal or `trunk.branch.version`) and
+/// `<system_id>` to a non-empty `::`-free segment. Any OTHER unresolvable
+/// placeholder is a LOUD error, never a silent `.*` wildcard: a matcher like
+/// `W/"<versioned_object_uid>::…"` degrading to a near-tautology is the
+/// vacuous-assertion class of #1830, on the expectation side (#1852).
+///
+/// # Errors
+/// The name of the first placeholder that is neither a case variable nor a
+/// structural token.
+fn resolve_placeholders(pattern: &str, vars: &VarStore) -> Result<String, String> {
     let mut out = String::new();
     let mut rest = pattern;
     while let Some(start) = rest.find('<') {
@@ -242,12 +261,18 @@ fn resolve_placeholders(pattern: &str, vars: &VarStore) -> String {
         out.push_str(head);
         if let Some(end) = tail.find('>') {
             let name = tail.get(1..end).unwrap_or_default();
-            match crate::ids::CaptureName::parse(name)
+            let captured = crate::ids::CaptureName::parse(name)
                 .ok()
-                .and_then(|n| vars.scalar(&n).map(str::to_owned))
-            {
-                Some(value) => out.push_str(&regex::escape(&value)),
-                None => out.push_str(".*"),
+                .and_then(|n| vars.scalar(&n).map(str::to_owned));
+            match (captured, name) {
+                (Some(value), _) => out.push_str(&regex::escape(&value)),
+                // VERSION_TREE_ID: `[1-9][0-9]*` or dotted triple (BASE
+                // base_types master05 §VERSION_TREE_ID).
+                (None, "n") => out.push_str(r"[1-9][0-9]*(?:\.[0-9]+\.[0-9]+)?"),
+                // A creating-system-id segment: non-empty, free of the `::`
+                // separator and the quote that closes a weak ETag.
+                (None, "system_id") => out.push_str(r#"[^:"]+"#),
+                (None, missing) => return Err(missing.to_owned()),
             }
             rest = tail.get(end + 1..).unwrap_or_default();
         } else {
@@ -256,7 +281,7 @@ fn resolve_placeholders(pattern: &str, vars: &VarStore) -> String {
         }
     }
     out.push_str(rest);
-    out
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -352,10 +377,35 @@ mod tests {
         );
         let ok = response(&[("etag", "W/\"abc-123::any.system::2\"")]);
         assert!(evaluate(&e, &ok, &ctx(), &vars).is_empty());
-        // A different resolved uid fails; the unresolved placeholders stay
-        // wildcards.
+        // A different resolved uid fails; the structural tokens (<system_id>,
+        // <n>) resolve to their grammars, not to a `.*` wildcard (#1852).
         let bad = response(&[("etag", "W/\"other-uid::any.system::2\"")]);
         assert_eq!(evaluate(&e, &bad, &ctx(), &vars).len(), 1);
+        // The structural grammars are real constraints: an empty system
+        // segment and a zero-led tree ordinal both fail.
+        let empty_system = response(&[("etag", "W/\"abc-123::::2\"")]);
+        assert_eq!(evaluate(&e, &empty_system, &ctx(), &vars).len(), 1);
+        let zero_led = response(&[("etag", "W/\"abc-123::any.system::02\"")]);
+        assert_eq!(evaluate(&e, &zero_led, &ctx(), &vars).len(), 1);
+    }
+
+    /// #1852 seeded defect: a placeholder naming neither a case variable nor
+    /// a structural token is a loud failure — never a silent `.*` that turns
+    /// the matcher into a tautology.
+    #[test]
+    fn unresolvable_placeholder_is_a_loud_failure_not_a_wildcard() {
+        let e = expectation(&serde_json::json!({
+            "ETag": "pattern:W/\"<no_such_capture>::x\""
+        }));
+        // The observed value would MATCH a `.*` degradation — the failure
+        // must come from the refusal, not from a mismatch.
+        let would_pass = response(&[("etag", "W/\"anything::x\"")]);
+        let failures = evaluate(&e, &would_pass, &ctx(), &VarStore::default());
+        assert_eq!(failures.len(), 1, "{failures:?}");
+        assert!(
+            failures[0].contains("no_such_capture") && failures[0].contains("#1852"),
+            "the failure names the unresolvable placeholder: {failures:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Finishes the in-flight #1852 before the app-side pivot (owner directive 2026-08-04: app + openehr-* crates first, CNF runner later).

- Outcome header matchers evaluate against the same merged variable scope as request building (inline `with:` values are visible).
- `resolve_placeholders` no longer wildcards: `<n>` resolves to the BASE VERSION_TREE_ID grammar, `<system_id>` to a non-empty `::`-free segment, and any OTHER unresolvable placeholder is a loud failure naming itself (#1852 marker in the message).
- Seeded-defect tests pin the refusal + both structural grammars; capability floors ratchet for the batch-3/4 catalogue additions (CompositionOps 52, EhrExtract 29).

Gates: cnf-runner clippy clean, full suite 313/313, catalogue validate 0 findings.

Closes #1852