### PR TITLE
release: v3.17.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+## [3.17.3] - 2026-08-05
+
 ### Added
 
 - Archiving an EHR or a party (`POST /admin/archive/ehrs`,
@@ -5430,7 +5432,8 @@ but has not yet run in production.
   seccomp, default-deny NetworkPolicy) and golden-render validation.
 
 
-[unreleased]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.2...HEAD
+[unreleased]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.3...HEAD
+[3.17.3]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.2...v3.17.3
 [3.17.2]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.1...v3.17.2
 [3.17.1]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.0...v3.17.1
 [3.17.0]: https://github.com/rubentalstra/FerroEHR/compare/v3.16.0...v3.17.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,5 +33,5 @@ keywords:
   - ITS-REST
   - Rust
   - PostgreSQL
-version: 3.17.2
-date-released: 2026-08-04
+version: 3.17.3
+date-released: 2026-08-05

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "cnf-runner"
-version = "3.17.2"
+version = "3.17.3"
 dependencies = [
  "assert_fs",
  "base64 0.22.1",
@@ -2669,7 +2669,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ferroehr"
-version = "3.17.2"
+version = "3.17.3"
 dependencies = [
  "assert_fs",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-admin-ui"
-version = "3.17.2"
+version = "3.17.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -2779,7 +2779,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-ext"
-version = "3.17.2"
+version = "3.17.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2802,7 +2802,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-rest"
-version = "3.17.2"
+version = "3.17.3"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -2856,7 +2856,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-server"
-version = "3.17.2"
+version = "3.17.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -5541,7 +5541,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-codegen"
-version = "3.17.2"
+version = "3.17.3"
 dependencies = [
  "roxmltree",
  "serde_json",
@@ -8715,7 +8715,7 @@ dependencies = [
 
 [[package]]
 name = "testkit"
-version = "3.17.2"
+version = "3.17.3"
 dependencies = [
  "ferroehr",
  "jiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "3"
 members = ["crates/*", "app/*", "tools/*"]
 
 [workspace.package]
-version = "3.17.2"
+version = "3.17.3"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT"

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 # Chart versioning is independent of the application version.
 version: 3.2.0
 # The default container image tag (informational; overridable via image.tag).
-appVersion: "3.17.2"
+appVersion: "3.17.3"
 
 # PDB (policy/v1, GA 1.21), HPA (autoscaling/v2, GA 1.23), and the
 # seccompProfile pod field (GA 1.27) all resolve cleanly at 1.25+.

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.2"
+    app.kubernetes.io/version: "3.17.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -58,7 +58,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.2"
+    app.kubernetes.io/version: "3.17.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -77,7 +77,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.2"
+    app.kubernetes.io/version: "3.17.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -96,7 +96,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.2"
+    app.kubernetes.io/version: "3.17.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -120,7 +120,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.2"
+    app.kubernetes.io/version: "3.17.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -139,7 +139,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.2"
+    app.kubernetes.io/version: "3.17.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -295,7 +295,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.2"
+    app.kubernetes.io/version: "3.17.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -322,7 +322,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.2"
+    app.kubernetes.io/version: "3.17.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -334,7 +334,7 @@ spec:
     metadata:
       annotations:
         # Roll pods when the rendered ferroehr.toml changes.
-        checksum/config: b41959fc801354715e99a5387514c0a8474628f9f31eeebffa80f011d5cb1d4f
+        checksum/config: 773326e914859d0ea3aac35699bf12691b23600e379b93ea1d77d971fc5f51fa
         prometheus.io/scrape: "true"
         prometheus.io/port: "9100"
         prometheus.io/path: "/management/prometheus"
@@ -355,7 +355,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:3.17.2"
+          image: "ghcr.io/rubentalstra/ferroehr:3.17.3"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -477,7 +477,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.2"
+    app.kubernetes.io/version: "3.17.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -510,7 +510,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.2"
+    app.kubernetes.io/version: "3.17.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.2"
+    app.kubernetes.io/version: "3.17.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -36,7 +36,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.2"
+    app.kubernetes.io/version: "3.17.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -55,7 +55,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.2"
+    app.kubernetes.io/version: "3.17.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 automountServiceAccountToken: false
@@ -69,7 +69,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.2"
+    app.kubernetes.io/version: "3.17.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -167,7 +167,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.2"
+    app.kubernetes.io/version: "3.17.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -190,7 +190,7 @@ metadata:
     helm.sh/chart: ferroehr-3.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.2"
+    app.kubernetes.io/version: "3.17.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -203,7 +203,7 @@ spec:
     metadata:
       annotations:
         # Roll pods when the rendered ferroehr.toml changes.
-        checksum/config: f9a00cfa399b6e9804ac994e60d7dd2e02b1a0d6c1e9997e9ba684cf326e58df
+        checksum/config: d22562d7cd3111b552eac17cce7c11445a6dca8fa2546445b8cc3fd442f76c85
       labels:
         app.kubernetes.io/name: ferroehr
         app.kubernetes.io/instance: ferroehr
@@ -221,7 +221,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:3.17.2"
+          image: "ghcr.io/rubentalstra/ferroehr:3.17.3"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
Cuts v3.17.3 from the changelog: the CNF red-run remediation batch (52 issues; PR #1933) — conformance baseline 1049 cases, 1011 passed / 0 failed / 0 errored / 38 adjudicated N-A. Workspace 3.17.2 → 3.17.3; Helm appVersion + goldens; CITATION.cff.