### PR TITLE
fix(auth): explicit timeouts + negative caching for the JWKS/OIDC discovery client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ workflow refuses a tag that has no matching section here.
 
 - The `openehr-rm` and `openehr-base` crates now ALSO emit the latest RELEASED specification generations beside the development pins — `openehr_rm::v1_1` (RM 1.1.0, resolving against BASE 1.2.0 per its own BMM `includes`) and `openehr_base::v1_2` (BASE 1.2.0) — each a complete peer: full type model, canonical-JSON codecs, RM attribute model, invariant cores, and validation behaviour. The served wire is unchanged (the current generations stay `v1_2`/`v1_3`); runtime selection between generations arrives with the `spec_profile` configuration key.
 
+### Fixed
+
+- An unreachable or unresponsive OAuth2/OIDC issuer no longer stalls bearer-token requests or hammers the issuer with outbound connections. The client that fetches the issuer's discovery document and JWKS now carries explicit timeouts, and a failed fetch is remembered briefly, so bearer requests during an issuer outage are refused fast instead of each one opening a fresh connection and waiting for the operating system's TCP timeout. Three new `[auth.oidc]` keys tune this (they apply only when signing keys come from discovery — that is, when neither `hmac_secret` nor `jwks_json` is set): `connect_timeout_ms` (default `3000`), `request_timeout_ms` (default `5000`), and `negative_cache_ttl_seconds` (default `10`, `0` disables). Successfully fetched keys keep their existing five-minute lifetime, and recovery is automatic once the negative entry expires.
+
 ### Removed
 
 - The generated `openehr-*` spec crates no longer carry a crate-level `SPEC_VERSION` constant: a multi-generation crate has no single implemented spec version, and a fixed crate-root pin would contradict a configured non-current generation. The ONLY pin authority is the emitted `Generation` enum (per-variant `const fn spec_version()`; the derived `Default` variant is the current generation) — the generation modules carry no version constant either; the hand-written single-spec crates (`openehr-its`, `openehr-query`, `openehr-adl`) keep their literal constant.

--- a/app/ferroehr-rest/src/extensions/access/authn/jwt.rs
+++ b/app/ferroehr-rest/src/extensions/access/authn/jwt.rs
@@ -89,7 +89,7 @@ impl JwtValidator {
                 .map_err(|e| format!("invalid oidc.jwks_json: {e}"))?;
             KeySource::Static(set)
         } else {
-            KeySource::Remote(RemoteJwks::new(cfg.issuer.clone()))
+            KeySource::Remote(RemoteJwks::new(cfg)?)
         };
 
         Ok(Self {
@@ -184,45 +184,90 @@ fn jwk_to_key(set: &JwkSet, kid: Option<&str>) -> Result<DecodingKey, AuthError>
     DecodingKey::from_jwk(jwk).map_err(|e| AuthError::InvalidToken(format!("invalid JWK: {e}")))
 }
 
+/// How long successfully fetched key material stays usable without a refetch.
+const JWKS_TTL: Duration = Duration::from_mins(5);
+
+/// The single cache slot: one issuer per validator, so the key is a constant.
+const CACHE_KEY: &str = "jwks";
+
 /// A JWKS fetched from an issuer's OIDC discovery document, cached briefly.
+///
+/// Both outcomes are cached, with different lifetimes ([`JwksExpiry`]): success
+/// for [`JWKS_TTL`], failure for `oidc.negative_cache_ttl_seconds`. Caching the
+/// failure is what keeps an issuer outage from turning every bearer request into
+/// a fresh discovery attempt. No openEHR spec governs this — our own design.
 struct RemoteJwks {
     issuer: String,
-    cache: moka::future::Cache<&'static str, Arc<JwkSet>>,
+    /// Built once, so the timeouts are a configuration-time property and the
+    /// connection pool survives across fetches.
+    http: openidconnect::reqwest::Client,
+    cache: moka::future::Cache<&'static str, Result<Arc<JwkSet>, AuthError>>,
+}
+
+/// Per-entry lifetimes for the [`RemoteJwks`] cache.
+struct JwksExpiry {
+    negative_ttl: Duration,
+}
+
+impl moka::Expiry<&'static str, Result<Arc<JwkSet>, AuthError>> for JwksExpiry {
+    fn expire_after_create(
+        &self,
+        _key: &&'static str,
+        value: &Result<Arc<JwkSet>, AuthError>,
+        _created_at: std::time::Instant,
+    ) -> Option<Duration> {
+        match value {
+            Ok(_) => Some(JWKS_TTL),
+            // A zero negative TTL expires the entry on the next read, which is
+            // the documented "negative caching off" setting.
+            Err(_) => Some(self.negative_ttl),
+        }
+    }
 }
 
 impl RemoteJwks {
-    fn new(issuer: String) -> Self {
-        Self {
-            issuer,
+    /// Builds the discovery client and its cache from the `[auth.oidc]` section.
+    ///
+    /// # Errors
+    /// Returns a message when `reqwest` cannot build a client with the
+    /// configured timeouts.
+    fn new(cfg: &OidcConfig) -> Result<Self, String> {
+        let http = openidconnect::reqwest::ClientBuilder::new()
+            // SSRF hardening: an issuer must not redirect us anywhere.
+            .redirect(openidconnect::reqwest::redirect::Policy::none())
+            .connect_timeout(Duration::from_millis(cfg.connect_timeout_ms))
+            .timeout(Duration::from_millis(cfg.request_timeout_ms))
+            .build()
+            .map_err(|e| format!("oidc discovery HTTP client: {e}"))?;
+        let expiry = JwksExpiry {
+            negative_ttl: Duration::from_secs(cfg.negative_cache_ttl_seconds),
+        };
+        Ok(Self {
+            issuer: cfg.issuer.clone(),
+            http,
             cache: moka::future::Cache::builder()
                 .max_capacity(1)
-                .time_to_live(Duration::from_mins(5))
+                .expire_after(expiry)
                 .build(),
-        }
+        })
     }
 
     async fn jwks(&self) -> Result<Arc<JwkSet>, AuthError> {
-        self.cache
-            .try_get_with("jwks", Self::fetch(self.issuer.clone()))
-            .await
-            .map_err(|e: Arc<AuthError>| (*e).clone())
+        // `get_with` coalesces concurrent misses onto one fetch AND stores the
+        // outcome whichever way it went; `try_get_with` would discard the error.
+        self.cache.get_with(CACHE_KEY, self.fetch()).await
     }
 
-    async fn fetch(issuer: String) -> Result<Arc<JwkSet>, AuthError> {
-        use openidconnect::core::CoreProviderMetadata;
-        use openidconnect::{IssuerUrl, reqwest};
-
-        let http = reqwest::ClientBuilder::new()
-            .redirect(reqwest::redirect::Policy::none()) // SSRF hardening
-            .build()
-            .map_err(|e| AuthError::KeyResolution(format!("HTTP client: {e}")))?;
-        let issuer_url = IssuerUrl::new(issuer)
+    async fn fetch(&self) -> Result<Arc<JwkSet>, AuthError> {
+        let issuer_url = openidconnect::IssuerUrl::new(self.issuer.clone())
             .map_err(|e| AuthError::KeyResolution(format!("issuer URL: {e}")))?;
-        let metadata = CoreProviderMetadata::discover_async(issuer_url, &http)
-            .await
-            .map_err(|e| AuthError::KeyResolution(format!("OIDC discovery: {e}")))?;
+        let metadata =
+            openidconnect::core::CoreProviderMetadata::discover_async(issuer_url, &self.http)
+                .await
+                .map_err(|e| AuthError::KeyResolution(format!("OIDC discovery: {e}")))?;
         let jwks_uri = metadata.jwks_uri().url().clone();
-        let body = http
+        let body = self
+            .http
             .get(jwks_uri)
             .send()
             .await
@@ -408,5 +453,169 @@ mod tests {
             .unwrap();
         let roles = extract_roles(&claims, &["resource_access.client.roles".to_owned()]);
         assert_eq!(roles, vec!["WRITER".to_owned()]);
+    }
+
+    /// The remote (OIDC-discovery) key source: timeout budget + negative
+    /// caching. No openEHR spec governs auth transport hardening — our own
+    /// design.
+    mod remote_discovery {
+        use std::time::Instant;
+
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        use super::*;
+
+        const DISCOVERY_PATH: &str = "/.well-known/openid-configuration";
+        const JWKS_PATH: &str = "/jwks";
+
+        /// A discovery-key-source config: no HMAC secret, no static JWKS.
+        fn oidc(
+            issuer: &str,
+            negative_cache_ttl_seconds: u64,
+            request_timeout_ms: u64,
+        ) -> OidcConfig {
+            OidcConfig {
+                issuer: issuer.to_owned(),
+                algorithms: vec!["HS256".to_owned()],
+                request_timeout_ms,
+                negative_cache_ttl_seconds,
+                ..OidcConfig::default()
+            }
+        }
+
+        /// The minimum OIDC provider metadata `CoreProviderMetadata` accepts;
+        /// `issuer` must echo the requested issuer exactly.
+        fn metadata(issuer: &str) -> Value {
+            json!({
+                "issuer": issuer,
+                "authorization_endpoint": format!("{issuer}/authorize"),
+                "token_endpoint": format!("{issuer}/token"),
+                "jwks_uri": format!("{issuer}{JWKS_PATH}"),
+                "response_types_supported": ["code"],
+                "subject_types_supported": ["public"],
+                "id_token_signing_alg_values_supported": ["HS256"],
+            })
+        }
+
+        /// A JWKS carrying the same HS256 secret [`token`] signs with, so a
+        /// recovered issuer can actually validate a token.
+        fn jwks_body() -> Value {
+            let jwk = jsonwebtoken::jwk::Jwk::from_encoding_key(
+                &EncodingKey::from_secret(SECRET.as_bytes()),
+                Algorithm::HS256,
+            )
+            .expect("jwk from secret");
+            json!({ "keys": [jwk] })
+        }
+
+        async fn mount_healthy(server: &MockServer) {
+            Mock::given(method("GET"))
+                .and(path(DISCOVERY_PATH))
+                .respond_with(ResponseTemplate::new(200).set_body_json(metadata(&server.uri())))
+                .mount(server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path(JWKS_PATH))
+                .respond_with(ResponseTemplate::new(200).set_body_json(jwks_body()))
+                .mount(server)
+                .await;
+        }
+
+        #[tokio::test]
+        async fn stalled_issuer_fails_within_the_configured_request_timeout() {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path(DISCOVERY_PATH))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_json(metadata(&server.uri()))
+                        .set_delay(Duration::from_secs(30)),
+                )
+                .mount(&server)
+                .await;
+
+            let remote = RemoteJwks::new(&oidc(&server.uri(), 10, 300)).expect("client");
+            let started = Instant::now();
+            let err = remote.jwks().await.expect_err("the timeout must fire");
+            let elapsed = started.elapsed();
+
+            assert!(matches!(err, AuthError::KeyResolution(_)), "got {err:?}");
+            // The 300 ms budget, generously slacked; without it the request
+            // would park for the mock's 30 s (or, on a blackhole, the OS TCP
+            // timeout — 75 s+).
+            assert!(
+                elapsed < Duration::from_secs(5),
+                "discovery took {elapsed:?}: the request timeout did not fire"
+            );
+        }
+
+        #[tokio::test]
+        async fn failed_fetch_is_cached_so_no_second_request_reaches_the_issuer() {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path(DISCOVERY_PATH))
+                .respond_with(ResponseTemplate::new(500))
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let remote = RemoteJwks::new(&oidc(&server.uri(), 60, 5_000)).expect("client");
+            assert!(remote.jwks().await.is_err(), "issuer is down");
+            assert!(
+                remote.jwks().await.is_err(),
+                "still down, answered from cache"
+            );
+
+            // The mock's `.expect(1)` is verified when the server drops; the
+            // explicit count names the failure if a second attempt goes out.
+            let attempts = server.received_requests().await.expect("recorded requests");
+            assert_eq!(
+                attempts.len(),
+                1,
+                "the negative cache did not suppress the second discovery attempt"
+            );
+        }
+
+        #[tokio::test]
+        async fn negative_entry_expires_and_a_recovered_issuer_validates() {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path(DISCOVERY_PATH))
+                .respond_with(ResponseTemplate::new(503))
+                .mount(&server)
+                .await;
+
+            let cfg = oidc(&server.uri(), 1, 5_000);
+            let validator =
+                JwtValidator::with_role_claims(&cfg, default_role_claims()).expect("validator");
+            let mut claims = base_claims();
+            claims["iss"] = json!(server.uri());
+            let token = token(&claims);
+
+            let err = validator
+                .validate(&token)
+                .await
+                .expect_err("issuer is down");
+            assert!(matches!(err, AuthError::KeyResolution(_)), "got {err:?}");
+
+            server.reset().await;
+            mount_healthy(&server).await;
+
+            // Still inside the 1 s negative TTL: refused from cache, no wire I/O.
+            assert!(validator.validate(&token).await.is_err());
+            let during_ttl = server.received_requests().await.expect("recorded requests");
+            assert!(
+                during_ttl.is_empty(),
+                "a request escaped during the negative TTL: {during_ttl:?}"
+            );
+
+            tokio::time::sleep(Duration::from_millis(1_200)).await;
+            let principal = validator
+                .validate(&token)
+                .await
+                .expect("the recovered issuer must validate");
+            assert_eq!(principal.subject, "alice");
+        }
     }
 }

--- a/app/ferroehr/assets/ferroehr.default.toml
+++ b/app/ferroehr/assets/ferroehr.default.toml
@@ -102,6 +102,13 @@ verified_cache_ttl_seconds = 60
 #? algorithms = ["RS256"]
 #? hmac_secret = "..."            # or hmac_secret_file = "/run/secrets/hmac"
 #? jwks_json = "{...}"            # or jwks_json_file = "/etc/ferroehr/jwks.json"
+# Discovery/JWKS fetch hardening (used only when neither hmac_secret nor
+# jwks_json is set, i.e. keys come from the issuer's OIDC discovery document):
+#? connect_timeout_ms = 3000
+#? request_timeout_ms = 5000
+#? negative_cache_ttl_seconds = 10   # remember a FAILED fetch this long (0 = off);
+                                     # a down issuer then yields fast 401s instead of
+                                     # one discovery attempt per bearer request
 
 # ── [authz] — RBAC + ABAC ─────────────────────────────────────────────────────
 [authz.rbac]

--- a/app/ferroehr/src/config/auth.rs
+++ b/app/ferroehr/src/config/auth.rs
@@ -117,6 +117,26 @@ pub struct OidcConfig {
     /// File-based indirection for [`Self::jwks_json`] — a JWKS is a file-shaped
     /// blob that never belonged in an env var. The loader reads the file.
     pub jwks_json_file: Option<PathBuf>,
+    /// TCP connect timeout in milliseconds for the OIDC discovery + JWKS
+    /// fetches (default 3000).
+    ///
+    /// Applies to the discovery key source only (no [`Self::hmac_secret`], no
+    /// [`Self::jwks_json`]): without it an issuer that blackholes packets parks
+    /// the bearer request until the OS TCP timeout, holding a request slot.
+    pub connect_timeout_ms: u64,
+    /// Whole-request timeout in milliseconds for the OIDC discovery + JWKS
+    /// fetches (default 5000), covering connect, TLS, and body read.
+    pub request_timeout_ms: u64,
+    /// How long a FAILED discovery/JWKS fetch is remembered, in seconds
+    /// (default 10; `0` disables negative caching).
+    ///
+    /// Without it every bearer request during an issuer outage re-attempts
+    /// discovery, so an unreachable issuer produces one outbound connection
+    /// attempt per incoming request. Remembering the failure degrades the outage to
+    /// fast `401`s instead. Keep it short — it is also the recovery lag once
+    /// the issuer returns. Successfully fetched key material keeps its own,
+    /// longer lifetime and is unaffected.
+    pub negative_cache_ttl_seconds: u64,
 }
 
 impl Default for OidcConfig {
@@ -129,10 +149,31 @@ impl Default for OidcConfig {
             hmac_secret_file: None,
             jwks_json: None,
             jwks_json_file: None,
+            connect_timeout_ms: default_connect_timeout_ms(),
+            request_timeout_ms: default_request_timeout_ms(),
+            negative_cache_ttl_seconds: default_negative_cache_ttl_seconds(),
         }
     }
 }
 
 fn default_algorithms() -> Vec<String> {
     vec!["RS256".to_owned()]
+}
+
+/// 3 s: ample for a TCP+TLS handshake to a healthy issuer on any realistic
+/// network, short enough that a blackholed one fails fast.
+const fn default_connect_timeout_ms() -> u64 {
+    3_000
+}
+
+/// 5 s: the whole-request budget the remote-PDP and terminology clients already
+/// use, so one outbound-HTTP posture spans the server.
+const fn default_request_timeout_ms() -> u64 {
+    5_000
+}
+
+/// 10 s: long enough that an outage costs one discovery attempt per issuer
+/// rather than one per request, short enough that recovery is barely noticed.
+const fn default_negative_cache_ttl_seconds() -> u64 {
+    10
 }

--- a/app/ferroehr/src/config/mod.rs
+++ b/app/ferroehr/src/config/mod.rs
@@ -472,6 +472,7 @@ mod tests {
                 ("FERROEHR__SERVER__MAX_IN_FLIGHT", "64"),
                 ("FERROEHR__AUTH__OIDC__ISSUER", "https://idp"),
                 ("FERROEHR__AUTH__OIDC__AUDIENCES", "ferroehr,other"),
+                ("FERROEHR__AUTH__OIDC__REQUEST_TIMEOUT_MS", "1500"),
                 (
                     "FERROEHR__SUBJECT_PROXY__SYSTEMS__PAS__BASE_URL",
                     "https://pas/r4",
@@ -486,6 +487,11 @@ mod tests {
             oidc.audiences,
             vec!["ferroehr".to_owned(), "other".to_owned()]
         );
+        // The discovery-client hardening keys: one overridden from the env, the
+        // other two at their documented defaults.
+        assert_eq!(oidc.request_timeout_ms, 1_500);
+        assert_eq!(oidc.connect_timeout_ms, 3_000);
+        assert_eq!(oidc.negative_cache_ttl_seconds, 10);
         assert_eq!(
             c.subject_proxy.systems.get("pas").expect("pas").base_url,
             "https://pas/r4"

--- a/website/book/src/installation/configuration.md
+++ b/website/book/src/installation/configuration.md
@@ -322,6 +322,18 @@ algorithms = ["RS256"]
 | `algorithms` | list of string | `["RS256"]` | Accepted signature algorithms. |
 | `hmac_secret` / `hmac_secret_file` | secret / path | unset | Symmetric HS256 secret (dev/test). At most one of the pair. |
 | `jwks_json` / `jwks_json_file` | string / path | unset | Static JWKS document; preferred over discovery when present. |
+| `connect_timeout_ms` | int | `3000` | TCP connect timeout for the discovery + JWKS fetches. |
+| `request_timeout_ms` | int | `5000` | Whole-request timeout for the discovery + JWKS fetches (connect, TLS, body read). |
+| `negative_cache_ttl_seconds` | int | `10` | How long a *failed* discovery/JWKS fetch is remembered (`0` disables). |
+
+The last three keys apply only when keys come from the issuer's OIDC discovery
+document — that is, when neither `hmac_secret` nor `jwks_json` is set. The
+timeouts stop an unresponsive identity provider from parking bearer requests
+until the operating system's TCP timeout; the negative cache means an identity
+provider outage costs one discovery attempt per `negative_cache_ttl_seconds`
+rather than one per incoming request, so callers get fast `401`s instead of slow
+ones. Keep the negative TTL short: it is also how long recovery takes to be
+noticed after the provider comes back.
 
 ## `[authz]`
 


### PR DESCRIPTION
The bearer-auth path's remote key source (`RemoteJwks` in
`app/ferroehr-rest/src/extensions/access/authn/jwt.rs`) built its `reqwest`
client with `redirect(Policy::none())` but **no timeouts**, and cached only
successes (`try_get_with`). Two consequences, both of them worst exactly when
an identity provider is unhealthy:

- an issuer that blackholes packets parked the bearer request until the OS TCP
  timeout, holding a request slot the whole time;
- while the issuer was down, *every* bearer request re-attempted discovery +
  JWKS fetch, so an idle IdP outage became a burst of outbound connections
  proportional to incoming traffic.

No openEHR spec governs auth transport hardening — this is our own design, and
it is flagged as such in the code.

## What changed

**Explicit timeouts, applied at configuration time.** The discovery client is
now built **once** in `RemoteJwks::new(&OidcConfig)` (previously rebuilt on
every fetch, which also threw away connection pooling) with
`connect_timeout` + `timeout` from three new `[auth.oidc]` keys, named to match
the existing remote-PDP and terminology-provider clients so the server has one
outbound-HTTP posture:

| key | default | meaning |
|---|---|---|
| `connect_timeout_ms` | `3000` | TCP connect budget — ample for a TCP+TLS handshake, short enough that a blackholed issuer fails fast |
| `request_timeout_ms` | `5000` | whole-request budget (connect, TLS, body read) — the same 5 s the PDP/terminology clients use |
| `negative_cache_ttl_seconds` | `10` | how long a **failed** fetch is remembered; `0` disables |

All three apply only to the discovery key source (no `hmac_secret`, no
`jwks_json`); `RemoteJwks::new` is now fallible so a client-build failure is a
boot error rather than a per-request one.

**Negative caching via moka's own per-entry expiry — no hand-rolled cache.**
The cache value became `Result<Arc<JwkSet>, AuthError>` and the fetch goes
through `get_with` instead of `try_get_with`, so the outcome is stored whichever
way it went. Lifetimes are per entry, via a `moka::Expiry` impl
(`expire_after_create`): `Ok` keeps the existing 5-minute TTL, `Err` gets
`negative_cache_ttl_seconds`. That is what makes a negative entry unable to mask
a recovered issuer beyond its TTL — expiry is computed from the entry's own
creation time, and moka evicts it on the next read. A zero TTL yields an
expiration time equal to creation time, which moka treats as expired on the next
read (`ts <= now`) — the documented "negative caching off" setting.
`get_with` also coalesces concurrent misses onto one fetch, so the first miss
after an expiry is a single outbound attempt, not one per in-flight request.

Behaviour that did **not** change: the positive 5-minute cache, the
`redirect(Policy::none())` SSRF hardening, and the error mapping
(`AuthError::KeyResolution` → 401, no new wire shape).

## Tests

Three new `wiremock`-backed tests beside the existing JWT tests
(`jwt::tests::remote_discovery`), each pinning one of the acceptance criteria:

- `stalled_issuer_fails_within_the_configured_request_timeout` — discovery mock
  delayed 30 s against a 300 ms configured budget; asserts a
  `KeyResolution` error and elapsed well under any OS TCP timeout. Measured
  0.325 s.
- `failed_fetch_is_cached_so_no_second_request_reaches_the_issuer` — failing
  discovery mock with `.expect(1)`; two `jwks()` calls, both `Err`, and the
  recorded-request count asserted to be exactly 1, so the second bearer request
  answered from cache with no wire I/O.
- `negative_entry_expires_and_a_recovered_issuer_validates` — full
  `JwtValidator` over a 1 s negative TTL: fails while down, still refused
  (zero requests recorded) after the mock is switched to healthy inside the TTL,
  then validates a real HS256 token against the recovered issuer's JWKS once the
  TTL lapses. The healthy JWKS is minted with
  `jsonwebtoken::jwk::Jwk::from_encoding_key`, so recovery is proven end to end
  through `validate()`, not just at the fetch seam.

The existing `[auth.oidc]` env-mapping test was extended (not weakened) to
cover `FERROEHR__AUTH__OIDC__REQUEST_TIMEOUT_MS` and to pin the two other new
defaults, per the configuration rule that every documented env form has a live
test.

## Same-change bookkeeping

- `app/ferroehr/assets/ferroehr.default.toml` — the three annotated keys under
  the `[auth.oidc]` block (template-sync tests green).
- `website/book/src/installation/configuration.md` — the `[auth.oidc]` table
  plus a short operator note on when the keys apply and why the negative TTL
  should stay short.
- `CHANGELOG.md` — `[Unreleased] / ### Fixed`, end-user voice.
- Helm was checked and deliberately left alone: `deploy/helm/ferroehr/values.yaml`
  spells out only `config.auth.enabled`, no `[auth.oidc]` keys, so there is
  nothing to mirror (and no golden renders to update).

## Gates

Run scoped, from the worktree:

- `cargo fmt --all` — clean
- `cargo clippy -p ferroehr -p ferroehr-rest --all-targets -- -D warnings` — clean
- `cargo nextest run -p ferroehr -p ferroehr-rest` — **1481 passed, 0 failed**, 3 skipped
- `scripts/check-comment-style.sh --files …` — OK

Closes #1949
