### PR TITLE
fix(admin-ui): lazy OIDC discovery — the console boots and serves Basic login while the issuer is unreachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ workflow refuses a tag that has no matching section here.
 
 - The `openehr-rm` and `openehr-base` crates now ALSO emit the latest RELEASED specification generations beside the development pins — `openehr_rm::v1_1` (RM 1.1.0, resolving against BASE 1.2.0 per its own BMM `includes`) and `openehr_base::v1_2` (BASE 1.2.0) — each a complete peer: full type model, canonical-JSON codecs, RM attribute model, invariant cores, and validation behaviour. The served wire is unchanged (the current generations stay `v1_2`/`v1_3`); runtime selection between generations arrives with the `spec_profile` configuration key.
 
+### Fixed
+
+- The admin console no longer refuses to start when OIDC is enabled but the identity provider is unreachable. It used to run discovery at startup and exit on failure, so in a composed deployment the console crash-looped until the identity provider finished importing its realm — even though its username/password sign-in needs nothing from that provider. The console now starts immediately and serves the sign-in page: username/password login works throughout the outage, the OIDC button reports "OIDC sign-in is unavailable: the identity provider at … could not be reached" instead of failing blankly, and the outage is named in the startup log. Discovery is retried on the next OIDC sign-in, so OIDC starts working by itself once the provider answers — no console restart needed. Genuinely broken OIDC *configuration* (a malformed issuer URL, redirect URL, or `resolve` override) still stops startup, as before.
+
 ### Removed
 
 - The generated `openehr-*` spec crates no longer carry a crate-level `SPEC_VERSION` constant: a multi-generation crate has no single implemented spec version, and a fixed crate-root pin would contradict a configured non-current generation. The ONLY pin authority is the emitted `Generation` enum (per-variant `const fn spec_version()`; the derived `Default` variant is the current generation) — the generation modules carry no version constant either; the hand-written single-spec crates (`openehr-its`, `openehr-query`, `openehr-adl`) keep their literal constant.

--- a/app/ferroehr-admin-ui/src/error.rs
+++ b/app/ferroehr-admin-ui/src/error.rs
@@ -28,6 +28,17 @@ pub enum AdminUiError {
     /// The CDR was unreachable (connect/timeout/transport).
     #[error("CDR unreachable: {0}")]
     CdrUnreachable(String),
+    /// The OIDC identity provider could not be reached, so the OIDC sign-in
+    /// path is unavailable while Basic login keeps working. Distinct from
+    /// [`Self::CdrUnreachable`]: a different dependency is down, and the
+    /// console's answer is different (offer the other login mode).
+    #[error("identity provider at {issuer} unavailable: {message}")]
+    IdpUnavailable {
+        /// The configured `auth.oidc.issuer`.
+        issuer: String,
+        /// The discovery diagnostic (transport, status, or malformed document).
+        message: String,
+    },
     /// Bad user input (login form, AQL text, template upload) with the
     /// message to render inline.
     #[error("{0}")]

--- a/app/ferroehr-admin-ui/src/feedback.rs
+++ b/app/ferroehr-admin-ui/src/feedback.rs
@@ -78,6 +78,10 @@ pub fn write_failure_copy(object: &str, error: &AdminUiError) -> String {
             "The CDR is unreachable ({message}), so {object} was not saved. Check the CDR, then \
              retry."
         ),
+        AdminUiError::IdpUnavailable { issuer, message } => format!(
+            "The identity provider at {issuer} is unreachable ({message}), so {object} was not \
+             saved. Retry once it is back, or sign in with a username and password."
+        ),
         AdminUiError::Internal(message) => format!(
             "{object} could not be saved: {message}. Retry; if it persists, check the console \
              logs."

--- a/app/ferroehr-admin-ui/src/lib.rs
+++ b/app/ferroehr-admin-ui/src/lib.rs
@@ -60,6 +60,8 @@ pub mod export;
 #[cfg(feature = "ssr")]
 pub mod oidc;
 #[cfg(feature = "ssr")]
+pub mod server;
+#[cfg(feature = "ssr")]
 pub mod session;
 #[cfg(feature = "ssr")]
 pub mod state;

--- a/app/ferroehr-admin-ui/src/main.rs
+++ b/app/ferroehr-admin-ui/src/main.rs
@@ -1,13 +1,11 @@
-//! The admin-console server binary: config → CDR client → (optional) OIDC
-//! discovery → session layer → axum router (Leptos SSR + the two OIDC
-//! routes). Wiring only — logic lives in the lib.
+//! The admin-console server binary: config → CDR client → (optional, inert)
+//! OIDC client → the router from `ferroehr_admin_ui::server` → serve. Wiring
+//! only — logic lives in the lib.
 
 #[cfg(feature = "ssr")]
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    use axum::Extension;
     use leptos::prelude::LeptosOptions;
-    use leptos_axum::LeptosRoutes;
 
     // Console logs: env-filtered (RUST_LOG), stderr. Without a subscriber
     // every server-side error is invisible — an operational defect.
@@ -46,9 +44,13 @@ async fn main() -> anyhow::Result<()> {
         std::sync::Arc::new(ferroehr_admin_ui::config::load().map_err(|e| anyhow::anyhow!("{e}"))?);
     let cdr =
         ferroehr_admin_ui::cdr::CdrClient::new(&config.cdr).map_err(|e| anyhow::anyhow!("{e}"))?;
+    // OIDC construction is INERT — no discovery here. An unreachable issuer
+    // must not stop the console from booting and serving Basic login; the
+    // discovery document is fetched lazily (and retried) per sign-in.
     let oidc = if config.auth.oidc.enabled {
         Some(std::sync::Arc::new(
-            ferroehr_admin_ui::oidc::discover(&config.auth.oidc).await?,
+            ferroehr_admin_ui::oidc::OidcState::new(&config.auth.oidc)
+                .map_err(|e| anyhow::anyhow!("{e}"))?,
         ))
     } else {
         None
@@ -56,60 +58,19 @@ async fn main() -> anyhow::Result<()> {
     let app_state = ferroehr_admin_ui::state::AppState {
         config: std::sync::Arc::clone(&config),
         cdr,
-        oidc,
+        oidc: oidc.clone(),
     };
 
-    let session_layer =
-        tower_sessions::SessionManagerLayer::new(tower_sessions::MemoryStore::default())
-            .with_secure(config.session.cookie_secure)
-            // Lax, not the Strict default: the OIDC callback arrives as a
-            // top-level cross-site redirect from the identity provider, and
-            // Strict would withhold the session cookie holding the PKCE/state
-            // — the flow would always fail "no login in progress". CSRF on
-            // the callback is covered by the state + PKCE checks.
-            .with_same_site(tower_sessions::cookie::SameSite::Lax)
-            .with_expiry(tower_sessions::Expiry::OnInactivity(
-                tower_sessions::cookie::time::Duration::minutes(
-                    i64::try_from(config.session.idle_minutes).unwrap_or(60),
-                ),
-            ));
+    // One non-fatal warm-up, so an identity provider that is down at startup
+    // is named in the boot log rather than only on someone's first sign-in.
+    if let Some(oidc) = oidc {
+        ferroehr_admin_ui::oidc::prime_in_background(oidc);
+    }
 
     let conf = leptos::config::get_configuration(None)?;
     let leptos_options: LeptosOptions = conf.leptos_options;
     let addr = leptos_options.site_addr;
-    let routes = leptos_axum::generate_route_list(ferroehr_admin_ui::app::App);
-
-    let context_state = app_state.clone();
-    let service = axum::Router::new()
-        .route(
-            "/auth/oidc/login",
-            axum::routing::get(ferroehr_admin_ui::oidc::login),
-        )
-        .route(
-            "/auth/oidc/callback",
-            axum::routing::get(ferroehr_admin_ui::oidc::callback),
-        )
-        // Result export: a plain form-POST download (no WASM required); the
-        // handler enforces the console session itself like every server fn.
-        .route(
-            "/export/aql",
-            axum::routing::post(ferroehr_admin_ui::export::export_aql),
-        )
-        .leptos_routes_with_context(
-            &leptos_options,
-            routes,
-            move || leptos::context::provide_context(context_state.clone()),
-            {
-                let options = leptos_options.clone();
-                move || ferroehr_admin_ui::app::shell(options.clone())
-            },
-        )
-        .fallback(leptos_axum::file_and_error_handler(
-            ferroehr_admin_ui::app::shell,
-        ))
-        .layer(Extension(app_state))
-        .layer(session_layer)
-        .with_state(leptos_options);
+    let service = ferroehr_admin_ui::server::router(app_state, leptos_options);
 
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     tracing::info!(%addr, "ferroehr-admin-ui listening");

--- a/app/ferroehr-admin-ui/src/oidc.rs
+++ b/app/ferroehr-admin-ui/src/oidc.rs
@@ -3,6 +3,10 @@
 //!
 //! The bearer token is stored server-side in the session; the browser only
 //! ever holds the console's session cookie.
+//!
+//! Discovery is lazy and cached ([`OidcState`]): the console boots with a
+//! configured-but-unreachable issuer, serves Basic login, and retries
+//! discovery on each OIDC sign-in until the provider answers.
 
 use axum::response::{IntoResponse, Redirect, Response};
 use http::StatusCode;
@@ -10,13 +14,24 @@ use openidconnect::{OAuth2TokenResponse, TokenResponse};
 use serde::{Deserialize, Serialize};
 
 use crate::config::OidcConfig;
+use crate::error::AdminUiError;
 
-/// Discovery output kept in [`crate::state::AppState`].
+/// The console's OIDC client and its lazily-discovered provider metadata.
+///
+/// Construction is inert: nothing here touches the network, so a configured
+/// but unreachable identity provider cannot stop the console from booting and
+/// serving Basic login. Discovery happens on the first OIDC sign-in (or the
+/// boot-time warm-up, [`prime_in_background`]) and is cached; a failure leaves
+/// the cache empty, so the next attempt retries without a restart.
 #[derive(Debug)]
 pub struct OidcState {
-    metadata: openidconnect::core::CoreProviderMetadata,
+    /// The parsed issuer URL — a local config defect, checked at boot.
+    issuer: openidconnect::IssuerUrl,
     http: openidconnect::reqwest::Client,
     config: OidcConfig,
+    /// The discovery document once fetched. A `tokio` mutex, so concurrent
+    /// first sign-ins collapse into one discovery instead of a thundering herd.
+    discovered: tokio::sync::Mutex<Option<openidconnect::core::CoreProviderMetadata>>,
 }
 
 /// The transient state parked in the session between login and callback.
@@ -29,39 +44,91 @@ struct FlowState {
 
 const FLOW_KEY: &str = "oidc_flow";
 
-/// Run OIDC discovery against the configured issuer.
-///
-/// # Errors
-/// `anyhow::Error` on an unreachable/invalid issuer (boot-time failure —
-/// the binary refuses to start with a broken OIDC config).
-pub async fn discover(config: &OidcConfig) -> anyhow::Result<OidcState> {
-    let mut builder = openidconnect::reqwest::ClientBuilder::new()
-        .redirect(openidconnect::reqwest::redirect::Policy::none()); // SSRF hardening
-    // Split-horizon issuer resolution (`host=ip:port`): the canonical
-    // issuer hostname may only resolve inside a container network; the
-    // override points this client at the mapped address while every URL
-    // (and the token `iss`) keeps the canonical form.
-    if !config.resolve.trim().is_empty() {
-        let (host, addr) = config
-            .resolve
-            .split_once('=')
-            .ok_or_else(|| anyhow::anyhow!("auth.oidc.resolve must be `host=ip:port`"))?;
-        builder = builder.resolve(host.trim(), addr.trim().parse()?);
-    }
-    let http = builder.build()?;
-    let issuer = openidconnect::IssuerUrl::new(config.issuer.clone())?;
-    let metadata = openidconnect::core::CoreProviderMetadata::discover_async(issuer, &http).await?;
-    Ok(OidcState {
-        metadata,
-        http,
-        config: config.clone(),
-    })
-}
-
 impl OidcState {
+    /// Build the console's OIDC client without contacting the issuer.
+    ///
+    /// Everything checked here is LOCAL configuration — the `resolve`
+    /// override's grammar, the socket address it names, and the issuer URL —
+    /// so a failure is a config defect the operator must fix and stays fatal
+    /// at boot. Reaching the identity provider is deferred to
+    /// [`Self::metadata`].
+    ///
+    /// # Errors
+    /// [`AdminUiError::Internal`] on a malformed `auth.oidc.resolve`, an
+    /// unparseable resolve address, an HTTP client that cannot be built, or a
+    /// malformed `auth.oidc.issuer`.
+    pub fn new(config: &OidcConfig) -> Result<Self, AdminUiError> {
+        let mut builder = openidconnect::reqwest::ClientBuilder::new()
+            .redirect(openidconnect::reqwest::redirect::Policy::none()); // SSRF hardening
+        // Split-horizon issuer resolution (`host=ip:port`): the canonical
+        // issuer hostname may only resolve inside a container network; the
+        // override points this client at the mapped address while every URL
+        // (and the token `iss`) keeps the canonical form.
+        if !config.resolve.trim().is_empty() {
+            let (host, addr) = config.resolve.split_once('=').ok_or_else(|| {
+                AdminUiError::Internal("auth.oidc.resolve must be `host=ip:port`".to_owned())
+            })?;
+            let addr: std::net::SocketAddr = addr.trim().parse().map_err(|e| {
+                AdminUiError::Internal(format!("auth.oidc.resolve address `{addr}`: {e}"))
+            })?;
+            builder = builder.resolve(host.trim(), addr);
+        }
+        let http = builder
+            .build()
+            .map_err(|e| AdminUiError::Internal(format!("OIDC HTTP client: {e}")))?;
+        let issuer = openidconnect::IssuerUrl::new(config.issuer.clone()).map_err(|e| {
+            AdminUiError::Internal(format!("auth.oidc.issuer `{}`: {e}", config.issuer))
+        })?;
+        Ok(Self {
+            issuer,
+            http,
+            config: config.clone(),
+            discovered: tokio::sync::Mutex::new(None),
+        })
+    }
+
+    /// The provider metadata: the cached discovery document, or a fresh
+    /// discovery against the issuer.
+    ///
+    /// A failure caches nothing, so the next OIDC sign-in retries — an
+    /// identity provider that comes up late recovers the console's OIDC path
+    /// without a restart.
+    ///
+    /// # Errors
+    /// [`AdminUiError::IdpUnavailable`] when discovery fails (the issuer is
+    /// unreachable, times out, or does not serve a valid discovery document).
+    pub async fn metadata(
+        &self,
+    ) -> Result<openidconnect::core::CoreProviderMetadata, AdminUiError> {
+        let mut cached = self.discovered.lock().await;
+        if let Some(metadata) = cached.as_ref() {
+            return Ok(metadata.clone());
+        }
+        let metadata = openidconnect::core::CoreProviderMetadata::discover_async(
+            self.issuer.clone(),
+            &self.http,
+        )
+        .await
+        .map_err(|e| AdminUiError::IdpUnavailable {
+            issuer: self.config.issuer.clone(),
+            message: e.to_string(),
+        })?;
+        *cached = Some(metadata.clone());
+        Ok(metadata)
+    }
+
+    /// The OAuth2 client for a discovery document.
+    ///
+    /// Synchronous and independent of discovery, so a provider outage and a
+    /// malformed `auth.oidc.public_base_url` stay distinct failure classes.
+    ///
+    /// # Errors
+    /// [`AdminUiError::Internal`] when `auth.oidc.public_base_url` does not
+    /// yield a valid redirect URI.
     fn client(
         &self,
-    ) -> anyhow::Result<
+        metadata: openidconnect::core::CoreProviderMetadata,
+    ) -> Result<
         openidconnect::core::CoreClient<
             openidconnect::EndpointSet,
             openidconnect::EndpointNotSet,
@@ -70,13 +137,20 @@ impl OidcState {
             openidconnect::EndpointMaybeSet,
             openidconnect::EndpointMaybeSet,
         >,
+        AdminUiError,
     > {
         let redirect = openidconnect::RedirectUrl::new(format!(
             "{}/auth/oidc/callback",
             self.config.public_base_url.trim_end_matches('/')
-        ))?;
+        ))
+        .map_err(|e| {
+            AdminUiError::Internal(format!(
+                "auth.oidc.public_base_url `{}`: {e}",
+                self.config.public_base_url
+            ))
+        })?;
         Ok(openidconnect::core::CoreClient::from_provider_metadata(
-            self.metadata.clone(),
+            metadata,
             openidconnect::ClientId::new(self.config.client_id.clone()),
             Some(openidconnect::ClientSecret::new(
                 self.config.client_secret.clone(),
@@ -84,6 +158,40 @@ impl OidcState {
         )
         .set_redirect_uri(redirect))
     }
+}
+
+/// Warm the discovery cache once, in the background, without blocking boot.
+///
+/// The console serves requests immediately either way; this exists so an
+/// identity provider that is down at startup is named loudly in the boot log
+/// instead of only surfacing on someone's first sign-in attempt.
+pub fn prime_in_background(oidc: std::sync::Arc<OidcState>) {
+    tokio::spawn(async move {
+        match oidc.metadata().await {
+            Ok(_) => tracing::info!(
+                issuer = %oidc.config.issuer,
+                "OIDC discovery succeeded; OIDC sign-in is available"
+            ),
+            Err(e) => tracing::warn!(
+                issuer = %oidc.config.issuer,
+                error = %e,
+                "OIDC discovery failed at startup; the console serves Basic login and retries discovery on the next OIDC sign-in"
+            ),
+        }
+    });
+}
+
+/// Report an identity-provider outage on the login screen.
+///
+/// The raw diagnostic goes to the log (operators need it, users cannot act on
+/// it); the browser gets actionable copy and the still-working Basic form.
+fn idp_unavailable(issuer: &str, error: &AdminUiError) -> Response {
+    tracing::warn!(issuer, error = %error, "OIDC discovery failed");
+    let message = format!(
+        "OIDC sign-in is unavailable: the identity provider at {issuer} could not be reached. \
+         Try again shortly, or sign in with a username and password."
+    );
+    Redirect::to(&format!("/login?error={}", urlencoding::encode(&message))).into_response()
 }
 
 fn error_page(status: StatusCode, message: &str) -> Response {
@@ -100,7 +208,11 @@ pub async fn login(
     let Some(oidc) = state.oidc.as_ref() else {
         return error_page(StatusCode::NOT_FOUND, "OIDC is not enabled");
     };
-    let client = match oidc.client() {
+    let metadata = match oidc.metadata().await {
+        Ok(metadata) => metadata,
+        Err(e) => return idp_unavailable(&oidc.config.issuer, &e),
+    };
+    let client = match oidc.client(metadata) {
         Ok(client) => client,
         Err(e) => return error_page(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
     };
@@ -164,7 +276,11 @@ pub async fn callback(
         return error_page(StatusCode::BAD_REQUEST, "state mismatch");
     }
 
-    let client = match oidc.client() {
+    let metadata = match oidc.metadata().await {
+        Ok(metadata) => metadata,
+        Err(e) => return idp_unavailable(&oidc.config.issuer, &e),
+    };
+    let client = match oidc.client(metadata) {
         Ok(client) => client,
         Err(e) => return error_page(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
     };

--- a/app/ferroehr-admin-ui/src/pages/login.rs
+++ b/app/ferroehr-admin-ui/src/pages/login.rs
@@ -20,8 +20,10 @@ use crate::components::surface::CARD_PAD;
 ///
 /// Renders a centered auth card — the wordmark over the Basic credential form
 /// and/or the OIDC button, gated on the CDR's enabled auth modes (read once via
-/// a `Resource` under `<Suspense>`). The action's error value renders in a
-/// MessageBar; the submit button reflects the action's pending state.
+/// a `Resource` under `<Suspense>`). One MessageBar renders either the login
+/// action's error or a `?error=` message redirected here by a BFF route (an
+/// unreachable identity provider); the submit button reflects the action's
+/// pending state.
 #[expect(
     clippy::must_use_candidate,
     reason = "#[component] rewrites the fn; view!/mount always consumes the value"
@@ -46,15 +48,21 @@ pub fn LoginPage() -> impl IntoView {
             .unwrap_or_else(|| "/".to_owned())
     });
 
+    // `?error=…` carries a failure from a BFF axum route that has no action to
+    // report through — today the OIDC login/callback routes redirecting here
+    // when the identity provider cannot be reached. Deterministic from the
+    // URL, so hydration-safe; a live action error wins over a stale param.
     let error_bar = view! {
         {move || {
             value
                 .get()
                 .and_then(Result::err)
-                .map(|err| {
+                .map(|err| err.to_string())
+                .or_else(|| query.with(|q| q.get("error")))
+                .map(|message| {
                     view! {
                         <thaw::MessageBar intent=thaw::MessageBarIntent::Error>
-                            <thaw::MessageBarBody>{err.to_string()}</thaw::MessageBarBody>
+                            <thaw::MessageBarBody>{message}</thaw::MessageBarBody>
                         </thaw::MessageBar>
                     }
                 })

--- a/app/ferroehr-admin-ui/src/server.rs
+++ b/app/ferroehr-admin-ui/src/server.rs
@@ -1,0 +1,64 @@
+//! The console's axum router: the BFF's own routes plus the Leptos SSR
+//! handlers and the session layer.
+//!
+//! It lives in the library rather than the binary so the boot path is
+//! testable — a binary-only wiring path cannot be imported from `tests/`
+//! (the Rust Book's thin-`main`-over-`lib` split, ch12.3,
+//! <https://doc.rust-lang.org/book/ch12-03-improving-error-handling-and-modularity.html>).
+
+use axum::Extension;
+use leptos::prelude::LeptosOptions;
+use leptos_axum::LeptosRoutes;
+
+/// Assemble the console's router: the OIDC + export routes, every Leptos
+/// route with [`crate::state::AppState`] in context, the static-file
+/// fallback, and the session layer.
+///
+/// Nothing here touches the network, so the router is servable even when the
+/// CDR and the identity provider are both down — which is exactly what makes
+/// the login screen reachable during an outage.
+pub fn router(state: crate::state::AppState, leptos_options: LeptosOptions) -> axum::Router {
+    let session_layer =
+        tower_sessions::SessionManagerLayer::new(tower_sessions::MemoryStore::default())
+            .with_secure(state.config.session.cookie_secure)
+            // Lax, not the Strict default: the OIDC callback arrives as a
+            // top-level cross-site redirect from the identity provider, and
+            // Strict would withhold the session cookie holding the PKCE/state
+            // — the flow would always fail "no login in progress". CSRF on
+            // the callback is covered by the state + PKCE checks.
+            .with_same_site(tower_sessions::cookie::SameSite::Lax)
+            .with_expiry(tower_sessions::Expiry::OnInactivity(
+                tower_sessions::cookie::time::Duration::minutes(
+                    i64::try_from(state.config.session.idle_minutes).unwrap_or(60),
+                ),
+            ));
+
+    let routes = leptos_axum::generate_route_list(crate::app::App);
+    let context_state = state.clone();
+
+    axum::Router::new()
+        .route("/auth/oidc/login", axum::routing::get(crate::oidc::login))
+        .route(
+            "/auth/oidc/callback",
+            axum::routing::get(crate::oidc::callback),
+        )
+        // Result export: a plain form-POST download (no WASM required); the
+        // handler enforces the console session itself like every server fn.
+        .route(
+            "/export/aql",
+            axum::routing::post(crate::export::export_aql),
+        )
+        .leptos_routes_with_context(
+            &leptos_options,
+            routes,
+            move || leptos::context::provide_context(context_state.clone()),
+            {
+                let options = leptos_options.clone();
+                move || crate::app::shell(options.clone())
+            },
+        )
+        .fallback(leptos_axum::file_and_error_handler(crate::app::shell))
+        .layer(Extension(state))
+        .layer(session_layer)
+        .with_state(leptos_options)
+}

--- a/app/ferroehr-admin-ui/tests/it/boot_oidc_outage.rs
+++ b/app/ferroehr-admin-ui/tests/it/boot_oidc_outage.rs
@@ -1,0 +1,189 @@
+//! The console's OIDC degradation contract: it boots and serves Basic login
+//! while the identity provider is unreachable, and recovers OIDC without a
+//! restart once the provider answers.
+//!
+//! The outage test uses `.invalid` hostnames — the reserved TLD guaranteed
+//! never to resolve (RFC 2606 §2) — so it fails fast and a developer's own CDR
+//! on port 8080 cannot make it pass or hang. The recovery test runs a local
+//! stand-in provider that answers `503` once and then serves a valid discovery
+//! document.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use axum::response::IntoResponse;
+use ferroehr_admin_ui::cdr::CdrClient;
+use ferroehr_admin_ui::config::{AdminUiConfig, AuthConfig, CdrConfig, OidcConfig, SessionConfig};
+use ferroehr_admin_ui::error::AdminUiError;
+use ferroehr_admin_ui::oidc::OidcState;
+use ferroehr_admin_ui::server::router;
+use ferroehr_admin_ui::state::AppState;
+use leptos::prelude::LeptosOptions;
+
+/// The console configuration under test: Basic enabled, OIDC enabled against
+/// an issuer that cannot resolve, and a CDR that cannot resolve either.
+fn outage_config() -> AdminUiConfig {
+    AdminUiConfig {
+        cdr: CdrConfig {
+            base_url: "http://cdr.invalid:8080".to_owned(),
+            ..CdrConfig::default()
+        },
+        auth: AuthConfig {
+            basic_enabled: true,
+            oidc: OidcConfig {
+                enabled: true,
+                issuer: "https://idp.invalid/realms/console".to_owned(),
+                client_id: "ferroehr-admin-ui".to_owned(),
+                public_base_url: "http://127.0.0.1:3000".to_owned(),
+                ..OidcConfig::default()
+            },
+        },
+        session: SessionConfig::default(),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[expect(
+    clippy::panic_in_result_fn,
+    reason = "the Book's Result-returning test shape asserts by panicking (.claude/rules/testing.md §Test shapes)"
+)]
+async fn login_is_served_with_the_basic_form_while_the_issuer_is_unreachable()
+-> Result<(), Box<dyn std::error::Error>> {
+    let config = outage_config();
+    // The boot path: an enabled-but-unreachable issuer must yield a usable
+    // OidcState, because nothing here contacts the provider.
+    let oidc = OidcState::new(&config.auth.oidc)?;
+    let cdr = CdrClient::new(&config.cdr)?;
+    let state = AppState {
+        config: Arc::new(config),
+        cdr,
+        oidc: Some(Arc::new(oidc)),
+    };
+
+    let service = router(
+        state,
+        LeptosOptions::builder()
+            .output_name("ferroehr-admin-ui")
+            .build(),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    let server =
+        tokio::spawn(async move { axum::serve(listener, service.into_make_service()).await });
+
+    let response = reqwest::Client::new()
+        .get(format!("http://{addr}/login"))
+        .send()
+        .await?;
+    let status = response.status();
+    let body = response.text().await?;
+    server.abort();
+
+    assert_eq!(status, 200, "/login must be served during an IdP outage");
+    // The route is SsrMode::Async, so the resolved form is in the first byte
+    // of the body — no client-side fill-in and no WASM needed.
+    assert!(
+        body.contains(r#"id="login-username""#),
+        "the Basic credential form must be present during an IdP outage: {body}"
+    );
+    Ok(())
+}
+
+/// A minimal OpenID Provider Metadata document (OpenID Connect Discovery 1.0
+/// §3): the required members plus the endpoints the console's client reads.
+fn discovery_document(issuer: &str) -> String {
+    format!(
+        r#"{{"issuer":"{issuer}",
+            "authorization_endpoint":"{issuer}/auth",
+            "token_endpoint":"{issuer}/token",
+            "jwks_uri":"{issuer}/jwks",
+            "response_types_supported":["code"],
+            "subject_types_supported":["public"],
+            "id_token_signing_alg_values_supported":["RS256"]}}"#
+    )
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[expect(
+    clippy::panic_in_result_fn,
+    reason = "the Book's Result-returning test shape asserts by panicking (.claude/rules/testing.md §Test shapes)"
+)]
+async fn discovery_retries_after_an_outage_and_caches_once_it_succeeds()
+-> Result<(), Box<dyn std::error::Error>> {
+    // Bind first: the issuer must carry the port the stand-in provider listens
+    // on, because discovery refuses a document whose `issuer` differs.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let issuer = format!("http://{}", listener.local_addr()?);
+    let discovery_hits = Arc::new(AtomicU32::new(0));
+
+    let idp = axum::Router::new()
+        .route(
+            "/.well-known/openid-configuration",
+            axum::routing::get({
+                let hits = Arc::clone(&discovery_hits);
+                let issuer = issuer.clone();
+                move || {
+                    let hits = Arc::clone(&hits);
+                    let issuer = issuer.clone();
+                    async move {
+                        if hits.fetch_add(1, Ordering::SeqCst) == 0 {
+                            // The realm import is still running — exactly the
+                            // composed-startup race this contract is about.
+                            return (http::StatusCode::SERVICE_UNAVAILABLE, "starting up")
+                                .into_response();
+                        }
+                        (
+                            [(http::header::CONTENT_TYPE, "application/json")],
+                            discovery_document(&issuer),
+                        )
+                            .into_response()
+                    }
+                }
+            }),
+        )
+        .route(
+            "/jwks",
+            axum::routing::get(|| async {
+                (
+                    [(http::header::CONTENT_TYPE, "application/json")],
+                    r#"{"keys":[]}"#,
+                )
+            }),
+        );
+    let idp_server =
+        tokio::spawn(async move { axum::serve(listener, idp.into_make_service()).await });
+
+    let oidc = OidcState::new(&OidcConfig {
+        enabled: true,
+        issuer: issuer.clone(),
+        client_id: "ferroehr-admin-ui".to_owned(),
+        public_base_url: "http://127.0.0.1:3000".to_owned(),
+        ..OidcConfig::default()
+    })?;
+
+    // The provider is not ready: a typed IdP-unavailable error, nothing cached.
+    let during_outage = oidc.metadata().await;
+    assert!(
+        matches!(during_outage, Err(AdminUiError::IdpUnavailable { .. })),
+        "an unready provider must yield IdpUnavailable, got {during_outage:?}"
+    );
+
+    // The provider comes up and the SAME OidcState discovers successfully —
+    // recovery without a restart, which is why failures are not cached.
+    let recovered = oidc.metadata().await?;
+    assert!(
+        recovered.jwks_uri().as_str().ends_with("/jwks"),
+        "the recovered document must be the one the provider served, got {:?}",
+        recovered.jwks_uri()
+    );
+
+    // A success IS cached: no further round trip to the provider.
+    let _cached = oidc.metadata().await?;
+    let hits = discovery_hits.load(Ordering::SeqCst);
+    idp_server.abort();
+    assert_eq!(
+        hits, 2,
+        "discovery must retry after the failure and then be cached"
+    );
+    Ok(())
+}

--- a/app/ferroehr-admin-ui/tests/it/main.rs
+++ b/app/ferroehr-admin-ui/tests/it/main.rs
@@ -4,6 +4,11 @@
 
 mod common;
 
+// A real in-process boot test, not a browser journey: it serves the router
+// itself, so it needs the server build (`--features ssr`).
+#[cfg(feature = "ssr")]
+mod boot_oidc_outage;
+
 mod e2e_admin_ops;
 mod e2e_audit;
 mod e2e_browse;

--- a/website/book/src/admin-ui/index.md
+++ b/website/book/src/admin-ui/index.md
@@ -33,6 +33,11 @@ schemes the CDR advertises (its `WWW-Authenticate` challenge). A Basic
 form is never shown against a bearer-only CDR, and vice versa. The page
 is served fully rendered and works with JavaScript disabled.
 
+When OIDC is configured but the identity provider is unreachable, the
+console still starts and serves username/password sign-in; the OIDC button
+reports the outage, and OIDC begins working on its own once the provider
+answers — no restart needed.
+
 The console ships a full dark theme (the toggle persists per browser),
 and the user menu opens the access drawer:
 


### PR DESCRIPTION
The console ran OIDC discovery at boot and exited on failure, so an unreachable issuer crash-looped the container — while the CDR's equivalent path (`ferroehr-rest` `authn/jwt.rs`) has always been lazy. In a composed deployment that made the console's startup depend on Keycloak's realm import, even though its Basic login path needs nothing from the IdP. Discovery is now lazy, cached, and self-retrying.

Closes #1950

## What changed

**`src/oidc.rs` — lazy, cached, self-retrying discovery.** `oidc::discover()` is replaced by `OidcState::new(&OidcConfig)`, which does **no network I/O**: it builds the openidconnect reqwest client (keeping `redirect::Policy::none()` and the split-horizon `resolve` override) and parses the issuer URL. Everything it checks is LOCAL config — a malformed `resolve`, an unparseable address, a bad issuer URL — so those stay fatal at boot, as before. A new `discovered: tokio::sync::Mutex<Option<CoreProviderMetadata>>` backs `async fn metadata()`, which returns the cached document or runs `CoreProviderMetadata::discover_async`. A failure caches **nothing**, so the next OIDC sign-in retries — recovery without a restart; the tokio mutex collapses concurrent first sign-ins into one discovery instead of a thundering herd. `client()` became synchronous, taking the metadata as an argument, so a provider outage and a malformed `public_base_url` stay distinct failure classes. `prime_in_background(Arc<OidcState>)` runs one spawned, non-fatal warm-up so an IdP that is down at startup is named loudly in the boot log rather than only surfacing on someone's first sign-in.

**In-UI outage reporting.** A new `idp_unavailable(issuer, err)` helper logs the raw diagnostic (operators need it; users cannot act on it) and redirects to `/login?error=<urlencoding::encode(msg)>` with actionable copy: *"OIDC sign-in is unavailable: the identity provider at {issuer} could not be reached. Try again shortly, or sign in with a username and password."* Both `login` and `callback` route their discovery failures through it; every other flow error keeps its existing handling. `pages/login.rs` derives `?error=` from the `use_query_map` it already holds and renders it in the **same** thaw MessageBar the bad-credential path uses — a live action error wins over a stale URL param. Deterministic from the URL, so hydration-safe.

**New typed error variant.** `AdminUiError::IdpUnavailable { issuer, message }` — a distinct variant rather than a stringified `Internal`, because the console's answer to it differs from a CDR outage (offer the other login mode). The compiler's exhaustiveness check surfaced `feedback.rs::write_failure_copy`, which gained a matching arm.

**New `src/server.rs` (ssr-gated).** `pub fn router(AppState, LeptosOptions) -> axum::Router` moves the route table and session layer out of `main.rs`, so the boot path is importable from `tests/` (the Book's thin-`main`-over-`lib` split, ch12.3). `main.rs` keeps tracing init, the unchanged `healthcheck` subcommand, config load, state assembly, the background prime, bind and serve.

## Tests

`tests/it/boot_oidc_outage.rs`, registered as a `#[cfg(feature = "ssr")] mod` (the featureless lane cfg's it out), pins both halves of the contract:

- **`login_is_served_with_the_basic_form_while_the_issuer_is_unreachable`** — AppState with `issuer = https://idp.invalid/realms/console` and `cdr.base_url = http://cdr.invalid:8080` (RFC 2606 §2 reserved TLD: fails fast, and a developer's own CDR on :8080 cannot make it flaky), `server::router` served on an ephemeral port, `GET /login` → 200 containing `id="login-username"`. Under the old code this test could not even be written — `discover()` would have failed before AppState existed.
- **`discovery_retries_after_an_outage_and_caches_once_it_succeeds`** — a local stand-in provider answers `503` once, then serves a valid discovery document. The first `metadata()` yields `IdpUnavailable`; the **same** `OidcState` then discovers successfully (recovery without a restart); a third call adds no round trip, and the request counter must be exactly `2`. Two-sided: a cached failure fails the second assertion, an uncached success fails the third.

## Gates

| Gate | Result |
|---|---|
| `cargo clippy -p ferroehr-admin-ui --all-targets --features ssr -- -D warnings` | green |
| `cargo clippy -p ferroehr-admin-ui --target wasm32-unknown-unknown --features hydrate -- -D warnings` | green |
| `cargo nextest run -p ferroehr-admin-ui --features ssr` | 272/272 passed |
| `cargo nextest run -p ferroehr-admin-ui` (featureless) | 218/218 passed |
| `cargo fmt --all --check` · `leptosfmt --check` | clean |
| `scripts/check-comment-style.sh` (8 touched files) | OK |

`cargo leptos build` was **not** run (stopped at the owner's request to push immediately); CI's build and `ui-e2e` jobs gate the merge. The change touches the login journey that `scripts/ui-e2e.sh` covers — not run locally either.

## Docs

`CHANGELOG.md` `[Unreleased]` → `### Fixed` (end-user voice) and one paragraph in `website/book/src/admin-ui/index.md`. **No configuration keys change.**
