### PR TITLE
fix(auth): sub-less bearer refusal, hmac+jwks boot error, dangling-citation sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- A bearer token whose `sub` claim is missing or blank is now refused with `401`. Previously a validated token without a subject authenticated as a principal literally named `unknown`, and that fabricated identity was stamped into the audit trail; an unattributable caller is now rejected instead of silently mis-attributed.
+- Configuring both a symmetric secret (`auth.oidc.hmac_secret`/`_file`) and a static JWKS (`auth.oidc.jwks_json`/`_file`) is now a boot-time configuration error naming both keys. Previously the server silently used the symmetric secret and ignored the JWKS.
 - An unreachable or unresponsive OAuth2/OIDC issuer no longer stalls bearer-token requests or hammers the issuer with outbound connections. The client that fetches the issuer's discovery document and JWKS now carries explicit timeouts, and a failed fetch is remembered briefly, so bearer requests during an issuer outage are refused fast instead of each one opening a fresh connection and waiting for the operating system's TCP timeout. Three new `[auth.oidc]` keys tune this (they apply only when signing keys come from discovery — that is, when neither `hmac_secret` nor `jwks_json` is set): `connect_timeout_ms` (default `3000`), `request_timeout_ms` (default `5000`), and `negative_cache_ttl_seconds` (default `10`, `0` disables). Successfully fetched keys keep their existing five-minute lifetime, and recovery is automatic once the negative entry expires.
 
 ### Removed

--- a/app/ferroehr-rest/src/api/query/dispatch.rs
+++ b/app/ferroehr-rest/src/api/query/dispatch.rs
@@ -34,7 +34,7 @@ async fn run(
     op: &'static str,
     parts: RequestParts,
 ) -> Result<Response, RestError> {
-    // ABAC (§6.4): the patient subject-scope pre-filter + collection flag. A
+    // ABAC: the patient subject-scope pre-filter + collection flag. A
     // missing configured patient claim is a ready 403. The PEP entry points
     // (`extensions::access::pep::{query_pre,query_post}`) are `pub(crate)`, so
     // this cross-module dispatcher calls them directly.
@@ -64,7 +64,7 @@ async fn run(
         }
     };
 
-    // ABAC query post-check (§6.4): PDP fan-out over the touched template set.
+    // ABAC query post-check: PDP fan-out over the touched template set.
     if let Err(deny) = crate::extensions::access::pep::query_post(&state, op, &outcome).await {
         return Ok(deny);
     }

--- a/app/ferroehr-rest/src/extensions/access/authn/basic.rs
+++ b/app/ferroehr-rest/src/extensions/access/authn/basic.rs
@@ -133,7 +133,7 @@ mod tests {
     #[test]
     fn configured_roles_are_upper_cased() {
         // The configured lower-case `user` role surfaces normalized on the
-        // Principal (§5.1 — Basic role config, upper-casing).
+        // Principal (Basic role config, upper-casing).
         let p = verify(&header("alice", "s3cret"), &store()).expect("ok");
         assert_eq!(p.roles, vec!["USER".to_owned()]);
         assert!(p.claims.is_empty(), "Basic carries no JWT claims");

--- a/app/ferroehr-rest/src/extensions/access/authn/jwt.rs
+++ b/app/ferroehr-rest/src/extensions/access/authn/jwt.rs
@@ -43,7 +43,7 @@ pub(super) struct JwtValidator {
 
 // The role model (default claim paths + extraction algorithm) lives in the leaf
 // `access::authz` module so the REST layer and the RBAC gate share one
-// implementation (§5.1).
+// implementation.
 use crate::extensions::access::authz::roles::extract_roles;
 
 enum KeySource {
@@ -56,7 +56,7 @@ enum KeySource {
 }
 
 impl JwtValidator {
-    /// Build a validator with explicit RBAC role-claim paths (§5.1 —
+    /// Build a validator with explicit RBAC role-claim paths (from
     /// `authz.rbac.role_claims`).
     ///
     /// # Errors
@@ -132,10 +132,21 @@ impl JwtValidator {
             .map_err(|e| AuthError::InvalidToken(e.to_string()))?;
         let claims = data.claims;
 
+        // RFC 7519 §4.1.2 makes `sub` optional, but this principal is stamped
+        // into the ATNA audit trail — an unattributable caller is refused, never
+        // recorded under a fabricated identity.
         let subject = claims
             .get("sub")
             .and_then(serde_json::Value::as_str)
-            .unwrap_or("unknown")
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                AuthError::InvalidToken(
+                    "token carries no usable `sub` claim; an audit-attributable subject is \
+                     required"
+                        .to_owned(),
+                )
+            })?
             .to_owned();
 
         // Scopes: the space-delimited `scope` string plus the `scp` array,
@@ -150,7 +161,7 @@ impl JwtValidator {
         }
 
         // Roles from the configured claim paths (default `realm_access.roles` +
-        // `scope`), normalized to upper-case (§5.1 / v1 authority converter).
+        // `scope`), normalized to upper-case (mirrors EHRbase v1's authority converter).
         let roles = extract_roles(&claims, &self.role_claims);
 
         Ok(Principal {
@@ -339,8 +350,33 @@ mod tests {
         assert_eq!(p.subject, "alice");
         assert_eq!(p.method, AuthMethod::Bearer);
         assert!(p.scopes.contains(&"openid".to_owned()));
-        // The validated claim set is retained on the Principal (§5.1).
+        // The validated claim set is retained on the Principal.
         assert_eq!(p.claims.get("sub").and_then(Value::as_str), Some("alice"));
+    }
+
+    #[tokio::test]
+    async fn token_without_sub_rejected() {
+        let mut c = base_claims();
+        c.as_object_mut().expect("object").remove("sub");
+        let err = validator(&[])
+            .validate(&token(&c))
+            .await
+            .expect_err("reject");
+        assert!(
+            matches!(&err, AuthError::InvalidToken(m) if m.contains("sub")),
+            "got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn token_with_blank_sub_rejected() {
+        let mut c = base_claims();
+        c["sub"] = json!("   ");
+        let err = validator(&[])
+            .validate(&token(&c))
+            .await
+            .expect_err("reject");
+        assert!(matches!(err, AuthError::InvalidToken(_)), "got {err:?}");
     }
 
     #[tokio::test]
@@ -405,7 +441,7 @@ mod tests {
     #[tokio::test]
     async fn keycloak_realm_access_roles_extracted() {
         // Keycloak-shaped token: roles live under `realm_access.roles` and are
-        // upper-cased; the `scope` claim also contributes roles (§5.1 / §9.2).
+        // upper-cased; the `scope` claim also contributes roles.
         let mut c = base_claims();
         c["realm_access"] = json!({ "roles": ["user", "ferroehr-admin"] });
         c["scope"] = json!("openid EHR_READ");

--- a/app/ferroehr-rest/src/extensions/access/authn/mod.rs
+++ b/app/ferroehr-rest/src/extensions/access/authn/mod.rs
@@ -200,7 +200,7 @@ impl Authenticator {
         )
     }
 
-    /// Build from configuration with explicit RBAC role-claim paths (§5.1 —
+    /// Build from configuration with explicit RBAC role-claim paths (from
     /// `authz.rbac.role_claims`), used when an [`crate::extensions::access::authz::AuthzHandle`] is
     /// wired; [`Authenticator::new`] defaults them.
     ///
@@ -370,7 +370,7 @@ pub(crate) async fn middleware(
 
     match auth.authenticate(req.headers()).await {
         Ok(Authenticated { principal, fresh }) => {
-            // RBAC gate (§5.2): resolve the matched operation's class and gate it
+            // RBAC gate: resolve the matched operation's class and gate it
             // against the caller's roles. `None` authz handle = auth-only.
             if let Some(rbac) = layer.authz.as_deref().and_then(AuthzHandle::rbac) {
                 let matched = req
@@ -398,7 +398,7 @@ pub(crate) async fn middleware(
                     )
                     .increment(1);
                     // Attribute the 403 to the authenticated caller so the outer
-                    // ATNA audit layer records the denied access (§7).
+                    // ATNA audit layer records the denied access.
                     let mut resp = RestError(ApiError::Forbidden(reason)).into_response();
                     resp.extensions_mut().insert(principal);
                     return resp;
@@ -648,10 +648,6 @@ mod tests {
             "a first Basic verification is a genuine authentication"
         );
     }
-
-    // The old placeholder `authorize_admin`/`is_admin_path` path-string gate was
-    // deleted (§5.2); the RBAC gate replaces it and is covered by the
-    // `access::authz` unit tests + the `rbac_e2e` integration suite.
 
     #[tokio::test]
     async fn bearer_without_oidc_is_rejected() {

--- a/app/ferroehr-rest/src/extensions/access/authz/cedar.rs
+++ b/app/ferroehr-rest/src/extensions/access/authz/cedar.rs
@@ -8,7 +8,7 @@
 //! policy set on validity ([`arc_swap`]). Multi-valued attributes fan out per
 //! [`AuthzRequest::combinations`] with the same all-must-permit / short-circuit
 //! semantics as the remote PDP, so the two engines are behaviourally identical
-//! (the §9.4 differential test).
+//! (a differential test pins the two against the same request corpus).
 //!
 //! Cedar is deny-by-default with `forbid` overriding `permit`; the shipped
 //! example policies document that.

--- a/app/ferroehr-rest/src/extensions/access/authz/classify.rs
+++ b/app/ferroehr-rest/src/extensions/access/authz/classify.rs
@@ -11,14 +11,14 @@
 //! [`OperationClass::Admin`]; everything else is [`OperationClass::Clinical`]
 //! (any authenticated principal with a role), matching v1's rule that only
 //! `/rest/admin/**` and the management endpoints require `ADMIN` while
-//! "everything else → any authenticated user" (§2.4). [`OperationClass::Public`]
+//! "everything else → any authenticated user". [`OperationClass::Public`]
 //! and [`OperationClass::Management`] are used by the REST layer to classify the
 //! *non-generated* surface (status/health/swagger/management), which never
 //! reaches [`class_of`].
 
 use crate::extensions::access::authz::request::{AccessMode, ResourceKind};
 
-/// The coarse authorization class of an operation (§5.2).
+/// The coarse authorization class of an operation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OperationClass {
     /// No authorization check (root/status/health per the router).
@@ -161,7 +161,7 @@ pub fn class_of(op: &str) -> Option<OperationClass> {
 }
 
 /// The ABAC [`ResourceKind`] of a generated operation, derived from its op-id
-/// prefix (§5.3).
+/// prefix.
 ///
 /// `None` for operations ABAC does not model as resources (`definition_*`,
 /// `demographic_*`, `admin_*`) — those are RBAC-only.
@@ -240,8 +240,7 @@ fn write_verb(op: &str) -> Option<bool> {
     None
 }
 
-/// The ABAC [`AccessMode`] of a generated operation (the Cedar action axis,
-/// §5.6).
+/// The ABAC [`AccessMode`] of a generated operation (the Cedar action axis).
 ///
 /// Returns `None` for operations without a [`ResourceKind`]; for a clinical
 /// op it is always `Some`. Derived from the op-id verb.
@@ -284,7 +283,7 @@ mod tests {
         ops
     }
 
-    /// §9.1(a): every generated operation id has an [`OperationClass`]. A new,
+    /// Every generated operation id has an [`OperationClass`]. A new,
     /// unclassified generated operation fails this test.
     #[test]
     fn every_operation_is_classified() {
@@ -301,7 +300,7 @@ mod tests {
     }
 
     /// The only Admin-class generated routes are the two admin-API deletes;
-    /// everything else generated is Clinical (§2.4 / §5.2).
+    /// everything else generated is Clinical.
     #[test]
     fn admin_routes_are_the_only_admin_class() {
         let mut admin: Vec<&str> = all_route_ops()
@@ -372,7 +371,7 @@ mod tests {
         assert_eq!(access_of("definition_query_list"), None);
     }
 
-    /// §5.3: every generated operation with an ABAC [`ResourceKind`] also has an
+    /// Every generated operation with an ABAC [`ResourceKind`] also has an
     /// [`AccessMode`], and every RBAC-only family (`definition_*`,
     /// `demographic_*`, `admin_*`) maps to no kind. Guards the derivation the
     /// same way the class guard does.

--- a/app/ferroehr-rest/src/extensions/access/authz/engine.rs
+++ b/app/ferroehr-rest/src/extensions/access/authz/engine.rs
@@ -1,7 +1,7 @@
 //! The policy-decision-point (PDP) seam: one async trait behind which the embedded [`CedarEngine`] and the
 //! v1-compatible [`RemotePdp`] are interchangeable.
 //!
-//! The engine **owns** the multi-valued fan-out semantics (§5.4): given an
+//! The engine **owns** the multi-valued fan-out semantics: given an
 //! [`AuthzRequest`] whose `patient`/`template` may be sets, it evaluates every
 //! [`Combination`] (the cartesian product), requires **all** to permit, and
 //! short-circuits on the first deny. Errors are **fail-closed**: the PEP maps

--- a/app/ferroehr-rest/src/extensions/access/authz/mod.rs
+++ b/app/ferroehr-rest/src/extensions/access/authz/mod.rs
@@ -24,7 +24,7 @@
 //! [`AppState`](crate::state::AppState) (the RBAC + ABAC gates), built by the binary
 //! from `ferroehr::config::authz::AuthzConfig`.
 //!
-//! ## Module map (§4.1)
+//! ## Module map
 //! - `config` — the `ferroehr::config::authz::AuthzConfig` serde struct (the `[authz]`
 //!   section of the one server config tree) + boot validation.
 //! - [`roles`] — the role model, JWT-claim role extraction, and the RBAC gate
@@ -58,8 +58,8 @@ use http::Method;
 use self::cedar::CedarEngine;
 use self::remote::RemotePdp;
 
-/// An attribute-resolution failure (a DB lookup error). Fail-closed at the PEP
-/// (§5.7): a resolution failure denies (→ 403/500), never silently permits.
+/// An attribute-resolution failure (a DB lookup error). Fail-closed at the
+/// PEP: a resolution failure denies (→ 403/500), never silently permits.
 #[derive(Debug, thiserror::Error)]
 #[error("attribute resolution failed: {0}")]
 pub struct ResolveError(pub String);
@@ -81,7 +81,7 @@ pub type SubjectFn = Arc<dyn Fn(String) -> ResolverFuture<Option<String>> + Send
 pub type TemplateOfVersionFn =
     Arc<dyn Fn(String, Option<String>) -> ResolverFuture<Option<String>> + Send + Sync>;
 
-/// The DB-backed attribute resolvers the ABAC PEP calls (§6).
+/// The DB-backed attribute resolvers the ABAC PEP calls.
 ///
 /// Defined here so the REST layer can hold them; the closures are built in
 /// the binary (which owns the pool + service), the audit-`SubjectResolver`
@@ -100,7 +100,7 @@ impl std::fmt::Debug for AuthzResolvers {
     }
 }
 
-/// Build the configured ABAC [`PolicyEngine`] (§5.5/§5.6), or `None` when ABAC
+/// Build the configured ABAC [`PolicyEngine`], or `None` when ABAC
 /// is disabled. Called by the binary at boot after [`AuthzConfig::validate`].
 ///
 /// # Errors
@@ -207,7 +207,7 @@ pub(crate) struct AbacGate {
     /// The JWT claim carrying the caller's organization (blank → unused).
     pub(crate) organization_claim: Option<String>,
     /// The JWT claim carrying the patient id; its presence enables the subject
-    /// gate (§5.7).
+    /// gate.
     pub(crate) patient_claim: Option<String>,
     /// Whether a `directory` policy is configured (v1 parity: DIRECTORY is
     /// unchecked unless opted in).

--- a/app/ferroehr-rest/src/extensions/access/authz/remote.rs
+++ b/app/ferroehr-rest/src/extensions/access/authz/remote.rs
@@ -6,8 +6,8 @@
 //! status = deny; the response body is ignored. Connection/IO failure is
 //! fail-closed ([`AuthzError::Unreachable`] → 500 at the PEP). Multi-valued
 //! attributes fan out as the full cartesian product with all-must-permit and
-//! short-circuit deny (§5.4). Unlike v1, the client has explicit connect/request
-//! timeouts (v1 defect #4).
+//! short-circuit deny. The client has explicit connect/request timeouts
+//! (EHRbase v1 had none, so a blackholed PDP parked the request).
 
 #![expect(
     clippy::disallowed_types,
@@ -65,7 +65,7 @@ impl RemotePdp {
     }
 
     /// Build the flat request body for one combination: only the configured
-    /// parameters that have a resolved value (§2.1).
+    /// parameters that have a resolved value.
     fn body(rule: &PolicyRule, combo: &Combination<'_>) -> Value {
         let mut map = Map::new();
         for param in &rule.parameters {
@@ -103,7 +103,7 @@ impl RemotePdp {
 #[async_trait]
 impl PolicyEngine for RemotePdp {
     async fn decide(&self, req: &AuthzRequest<'_>) -> Result<Decision, AuthzError> {
-        // An unconfigured kind is unchecked (v1 parity for `directory`, §2.3).
+        // An unconfigured kind is unchecked (EHRbase v1 parity for `directory`).
         let Some(rule) = self.policies.get(req.kind.config_key()) else {
             return Ok(Decision::Permit);
         };

--- a/app/ferroehr-rest/src/extensions/access/authz/request.rs
+++ b/app/ferroehr-rest/src/extensions/access/authz/request.rs
@@ -1,15 +1,15 @@
 //! The authorization request types the ABAC PDP seam consumes.
 //!
 //! Covers the resource kind, the access mode (the Cedar action axis), the
-//! resolved attributes, and the multi-valued fan-out semantics (§5.4) both
+//! resolved attributes, and the multi-valued fan-out semantics both
 //! engines share.
 //!
 //! Attributes (`organization`, `patient`, `template`) are resolved by the PEP
 //! before the engine is called; `patient`/`template` may be *sets* (query,
 //! contribution), which the engine fans out over as a full cartesian product,
-//! **all-must-permit** (v1 parity, §2.1).
+//! **all-must-permit** (EHRbase v1 parity).
 
-/// The resource family a clinical operation acts on (§5.3). Derived from the
+/// The resource family a clinical operation acts on. Derived from the
 /// operation-id prefix by [`crate::extensions::access::authz::classify::kind_of`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ResourceKind {
@@ -43,7 +43,7 @@ impl ResourceKind {
     }
 }
 
-/// The access mode of an operation (the Cedar *action* axis, §5.6): op ids map
+/// The access mode of an operation (the Cedar *action* axis): op ids map
 /// onto `ResourceKind × AccessMode` rather than 96 raw op ids.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AccessMode {
@@ -81,7 +81,7 @@ pub enum Attr {
     /// Exactly one value.
     One(String),
     /// A set of values (the engine fans out over it; an **empty** set yields no
-    /// combinations, i.e. a vacuous permit — v1's empty-result behaviour, §6.4).
+    /// combinations, i.e. a vacuous permit — EHRbase v1's empty-result behaviour).
     Set(Vec<String>),
 }
 
@@ -117,7 +117,7 @@ pub struct Combination<'a> {
 }
 
 impl AuthzRequest<'_> {
-    /// The cartesian product of the patient × template candidates (§5.4). A
+    /// The cartesian product of the patient × template candidates. A
     /// single-valued or absent attribute contributes one candidate (`None` when
     /// absent); an **empty** set contributes none, so the product is empty and
     /// the all-must-permit fold is a vacuous permit.
@@ -150,7 +150,7 @@ fn candidates(attr: Option<&Attr>) -> Vec<Option<&str>> {
     }
 }
 
-/// The engine's verdict for a request (§5.4).
+/// The engine's verdict for a request.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Decision {
     /// The caller may proceed.
@@ -213,7 +213,7 @@ mod tests {
 
     #[test]
     fn empty_set_yields_no_combinations() {
-        // An empty result set (§6.4) → vacuous permit at the engine.
+        // An empty result set → vacuous permit at the engine.
         let r = req(Some(Attr::Set(vec![])), Some(Attr::One("t1".to_owned())));
         assert!(r.combinations().is_empty());
     }

--- a/app/ferroehr-rest/src/extensions/access/authz/roles.rs
+++ b/app/ferroehr-rest/src/extensions/access/authz/roles.rs
@@ -17,7 +17,7 @@ use crate::extensions::access::authz::classify::OperationClass;
 use ferroehr::config::authz::{ManagementAccess, RbacConfig};
 
 /// The default RBAC role-claim paths (Keycloak `realm_access.roles` + the
-/// `OAuth2` `scope` claim), matching the v1 authorities converter (§2.4).
+/// `OAuth2` `scope` claim), matching the EHRbase v1 authorities converter.
 #[must_use]
 pub fn default_role_claims() -> Vec<String> {
     vec!["realm_access.roles".to_owned(), "scope".to_owned()]
@@ -62,7 +62,7 @@ pub fn extract_roles(claims: &Map<String, Value>, paths: &[String]) -> Vec<Strin
 }
 
 /// Resolve a dotted claim path to a string value (the ABAC `organization` /
-/// `patient` attribute lookup, §6). Returns `None` when the path is absent or
+/// `patient` attribute lookup). Returns `None` when the path is absent or
 /// the value is not a (non-empty) string.
 #[must_use]
 pub fn claim_string(claims: &Map<String, Value>, path: &str) -> Option<String> {
@@ -93,8 +93,8 @@ pub enum RbacDecision {
     Deny(String),
 }
 
-/// Gate an operation class against the caller's roles and the RBAC config
-/// (§5.2). When `rbac.enabled` is `false` every class is allowed (auth-only
+/// Gate an operation class against the caller's roles and the RBAC config.
+/// When `rbac.enabled` is `false` every class is allowed (auth-only
 /// behaviour). Role matching is ASCII-case-insensitive.
 #[must_use]
 pub fn authorize(class: OperationClass, roles: &[String], rbac: &RbacConfig) -> RbacDecision {

--- a/app/ferroehr-rest/src/extensions/access/pep.rs
+++ b/app/ferroehr-rest/src/extensions/access/pep.rs
@@ -38,7 +38,7 @@
 //! Every deny is a `403` and every engine failure a `500` (fail-closed, v1
 //! parity), each carrying the [`Principal`] on the response extensions so the
 //! ATNA audit layer records it for free. Query execution's ABAC scope + post-check
-//! live in the query path (§6.4, step 8). ABAC is inert unless an
+//! live in the query path. ABAC is inert unless an
 //! `crate::extensions::access::authz::AbacGate` is wired
 //! (`abac.enabled`); the SMART gate is inert until SMART is enabled (see
 //! `smart_config`). End-to-end coverage through the assembled router (pre-check
@@ -84,7 +84,7 @@ use openehr_its::rest::smart_scopes::SmartScope;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Mode {
     /// Not ABAC-checked (item tags, definition/demographic/admin — RBAC only —,
-    /// and query, whose scope + check live in the query path, §6.4).
+    /// and query, whose scope + check live in the query path).
     Skip,
     /// Checked before the backend call.
     Pre,
@@ -92,7 +92,7 @@ enum Mode {
     Post,
 }
 
-/// The §7 enforcement matrix, keyed by operation id.
+/// The enforcement matrix, keyed by operation id.
 #[expect(
     clippy::match_same_arms,
     reason = "the arms are grouped by resource family, so naming every operation \
@@ -114,12 +114,12 @@ fn mode_of(op: &str) -> Mode {
         _ if op.starts_with("versioned_composition_") => Mode::Post,
         _ if op.starts_with("ehr_status_") || op.starts_with("versioned_ehr_status_") => Mode::Pre,
         _ if op.starts_with("directory_") => Mode::Pre,
-        // Item tags, query (§6.4), definition/demographic/admin: not ABAC-checked.
+        // Item tags, query, definition/demographic/admin: not ABAC-checked.
         _ => Mode::Skip,
     }
 }
 
-/// The ABAC preparation for a query execution (§6.4): the patient subject scope
+/// The ABAC preparation for a query execution: the patient subject scope
 /// to thread into the SQL, and whether the executor should collect the touched
 /// EHR/template sets for the post-check. `Ok((None, false))` when ABAC is off.
 /// `Err(response)` is a ready 403 (a missing configured patient claim).
@@ -143,7 +143,7 @@ pub(crate) fn query_pre(
     Ok((patient, true))
 }
 
-/// The ABAC post-check for a query execution (§6.4): the PDP fan-out over the
+/// The ABAC post-check for a query execution: the PDP fan-out over the
 /// touched template set. An empty result permits (v1 parity). The patient gate
 /// is already enforced by the subject-scope pre-filter (rows outside the
 /// caller's patient are never fetched), so it is not re-run per EHR here.
@@ -161,7 +161,7 @@ pub(crate) async fn query_post(
     if kind_of(op) != Some(ResourceKind::Query) {
         return Ok(());
     }
-    // Empty result set → nothing touched → permit (§6.4).
+    // Empty result set → nothing touched → permit.
     if outcome.ehr_ids.is_empty() && outcome.template_ids.is_empty() {
         return Ok(());
     }
@@ -217,7 +217,7 @@ pub(crate) async fn pre_check(
     let patient = resolve_patient_claim(abac, &principal)?;
     let ehr_id = parts.path.get("ehr_id").cloned();
 
-    // The local patient gate (§5.7), before any engine call.
+    // The local patient gate, before any engine call.
     patient_gate(
         abac,
         &principal,
@@ -341,7 +341,7 @@ fn organization(abac: &AbacGate, principal: &Principal) -> Option<String> {
         .and_then(|c| crate::extensions::access::authz::roles::claim_string(&principal.claims, c))
 }
 
-/// The full pre-check patient gate (§5.7): the subject match for target-EHR ops,
+/// The full pre-check patient gate: the subject match for target-EHR ops,
 /// plus the by-subject special case (compare the claim to the request subject).
 async fn patient_gate(
     abac: &AbacGate,
@@ -367,7 +367,7 @@ async fn patient_gate(
 }
 
 /// The subject-match gate over a target EHR: the claim must equal the EHR's
-/// subject external ref (a subject-less EHR passes; §5.7).
+/// subject external ref (a subject-less EHR passes).
 async fn subject_gate(
     abac: &AbacGate,
     principal: &Principal,
@@ -459,7 +459,7 @@ fn composition_template(parts: &RequestParts) -> Option<String> {
 }
 
 /// The set of COMPOSITION template ids in a contribution payload. A COMPOSITION
-/// version without a template is unresolvable → fail-closed (403, §6.3).
+/// version without a template is unresolvable → fail-closed (403).
 fn contribution_templates(
     parts: &RequestParts,
     principal: &Principal,
@@ -805,7 +805,7 @@ mod tests {
 
     #[tokio::test]
     async fn null_subject_passes_gate() {
-        // A subject-less EHR is not patient-scoped (v1 parity, §5.7).
+        // A subject-less EHR is not patient-scoped (EHRbase v1 parity).
         let calls = Arc::new(AtomicUsize::new(0));
         let gate = gate_with_subject(None, calls);
         let principal = principal_with_patient("P1");

--- a/app/ferroehr-rest/src/extensions/management/http_metrics.rs
+++ b/app/ferroehr-rest/src/extensions/management/http_metrics.rs
@@ -10,12 +10,12 @@
 //!   installed) records `trace_id`/`span_id` on the span and returns the
 //!   `x-trace-id` response header. Cardinality-safe: the raw path with ids
 //!   never enters the span *name*.
-//! - [`http_metrics`] — records the §1.2 HTTP metric family over the `metrics`
+//! - [`http_metrics`] — records the HTTP metric family over the `metrics`
 //!   facade: request duration by `(http_route, http_request_method,
 //!   status_class)`, an active-requests gauge, and request/response body sizes,
 //!   all keyed by the route *template* only.
 //!
-//! **PHI rule (§8.4):** every label value here is a closed set — route
+//! **PHI rule:** every label value here is a closed set — route
 //! templates, method, status class. No ids ever become a label.
 
 use std::net::SocketAddr;
@@ -33,7 +33,7 @@ use opentelemetry::trace::TraceContextExt;
 use tracing::Instrument;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
-// ── Metric names (§1.2) — the single source of truth for the emitters here and
+// ── Metric names — the single source of truth for the emitters here and
 //    the bucket-ladder / description registration in `ferroehr::telemetry`. ────
 
 /// The label value used when a request did not match any route template (the
@@ -43,7 +43,7 @@ const UNMATCHED_ROUTE: &str = "unmatched";
 /// The response header carrying the current trace id for support correlation.
 const X_TRACE_ID: &str = "x-trace-id";
 
-/// Root-span middleware (§1.1). Creates the per-request span, propagates W3C
+/// Root-span middleware. Creates the per-request span, propagates W3C
 /// trace context, and stamps `x-trace-id` when tracing is active.
 pub async fn root_span(req: Request, next: Next) -> Response {
     let method = req.method().clone();
@@ -103,7 +103,7 @@ pub async fn root_span(req: Request, next: Next) -> Response {
     .await
 }
 
-/// HTTP metrics middleware (§1.2).
+/// HTTP metrics middleware.
 pub async fn http_metrics(req: Request, next: Next) -> Response {
     let route = matched_route(&req);
     let method = req.method().as_str().to_owned();

--- a/app/ferroehr-rest/src/lib.rs
+++ b/app/ferroehr-rest/src/lib.rs
@@ -133,7 +133,7 @@ pub fn build_full(
 
 /// Build the [`Authenticator`], threading the RBAC role-claim paths from the
 /// authorization handle (default paths when none is wired) so Bearer role
-/// extraction matches the gate's configuration (§5.1).
+/// extraction matches the gate's configuration.
 fn build_authenticator(
     config: &AppConfig,
     authz: Option<&AuthzHandle>,

--- a/app/ferroehr-rest/tests/it/abac_e2e.rs
+++ b/app/ferroehr-rest/tests/it/abac_e2e.rs
@@ -476,7 +476,7 @@ async fn abac_disabled_restores_behaviour() {
 #[tokio::test]
 async fn abac_deny_is_audited() {
     // A 403 from the ABAC gate carries the Principal, so the ATNA layer records a
-    // failure audit for the denied caller (§7). The emitter ships a DICOM record
+    // failure audit for the denied caller. The emitter ships a DICOM record
     // over syslog/UDP; we assert on the datagrams: a minor-failure outcome
     // (`EventOutcomeIndicator="4"`) attributed to `svc`.
     let (socket, sender) = audit_capture().await;

--- a/app/ferroehr-rest/tests/it/authz_cedar_engine.rs
+++ b/app/ferroehr-rest/tests/it/authz_cedar_engine.rs
@@ -147,7 +147,7 @@ async fn remote_permit_when_patient_ok() -> (MockServer, RemotePdp) {
     (server, pdp)
 }
 
-/// §9.4 differential test: the same `AuthzRequest` corpus must yield identical
+/// Differential test: the same `AuthzRequest` corpus must yield identical
 /// decisions from the embedded Cedar engine and the v1-compatible remote PDP,
 /// proving the fan-out semantics (cartesian product, all-must-permit,
 /// short-circuit, empty→permit) are engine-independent.

--- a/app/ferroehr-rest/tests/it/rbac_e2e.rs
+++ b/app/ferroehr-rest/tests/it/rbac_e2e.rs
@@ -281,7 +281,7 @@ async fn rbac_disabled_restores_admin_access() {
 async fn scope_role_extraction_clears_admin_gate() {
     // Scope→role extraction: a token whose `scope`
     // carries `ADMIN` surfaces role `ADMIN` and clears the admin gate, while a
-    // non-admin scope is rejected — the automatic migration path (§5.2).
+    // non-admin scope is rejected — the automatic migration path.
     let (_pg, app) = app(true, None).await;
     let denied = status(
         &app,
@@ -373,7 +373,7 @@ async fn oauth2_committer_identifier_names_the_token_issuer() {
 #[tokio::test]
 async fn rbac_deny_is_audited() {
     // A 403 from the RBAC gate carries the Principal, so the ATNA audit layer
-    // records a failure audit for the denied caller (§7). The emitter ships a
+    // records a failure audit for the denied caller. The emitter ships a
     // DICOM record over syslog/UDP; we assert on the datagram: a
     // User-Authentication event (`csd-code="110114"`, DICOM PS3.15 §A.5.1 —
     // a rejected access attempt), a minor-failure outcome

--- a/app/ferroehr-server/src/lib.rs
+++ b/app/ferroehr-server/src/lib.rs
@@ -252,8 +252,8 @@ async fn serve(config_path: Option<&Path>, overrides: &[(String, String)]) -> an
 
     telemetry.start_samplers(pool.clone());
 
-    // `/management/env` reports the whole redacted config tree (secrets rendered
-    // `***` by construction — P-6), replacing the old ad-hoc snapshot.
+    // `/management/env` reports the whole redacted config tree (secrets render
+    // `***` by construction of the Secret type).
     let env_snapshot = Arc::new(serde_json::to_value(&config).unwrap_or(serde_json::Value::Null));
     let observability = Observability {
         management: config.management.clone(),

--- a/app/ferroehr/src/aql/exec.rs
+++ b/app/ferroehr/src/aql/exec.rs
@@ -153,7 +153,7 @@ pub struct QueryScope {
 }
 
 /// Run the scope-collection query for `ir` and return the distinct EHR-id and
-/// template-id sets it touches (§6.4). Empty when the query has no VO root.
+/// template-id sets it touches. Empty when the query has no VO root.
 ///
 /// # Errors
 /// [`AqlError::Sql`] if the scope query cannot be lowered; [`AqlError::Exec`] if

--- a/app/ferroehr/src/config/alias.rs
+++ b/app/ferroehr/src/config/alias.rs
@@ -65,7 +65,7 @@ pub(super) const SECTIONS: &[&str] = &[
     "subject_proxy",
 ];
 
-/// The two PERMANENT conventional aliases (§P-3) — 12-factor ecosystem names,
+/// The two PERMANENT conventional aliases — 12-factor ecosystem names,
 /// not legacy: they sit BELOW their `FERROEHR__` forms within the env layer.
 /// `(external_name, canonical FERROEHR__ env form)`.
 pub(super) const CONVENTIONAL: &[(&str, &str)] = &[
@@ -88,7 +88,7 @@ pub(super) const LIST_KEYS: &[&str] = &[
 ];
 
 /// The `FERROEHR__<SECTION>__<TAIL>` env name for a dotted config key path —
-/// the P-4 grammar in the file→env direction, pinned by the tests below.
+/// the uniform `__` grammar in the file→env direction, pinned by the tests below.
 /// Test-only for now: the deserialize-error enrichment reports serde leaf
 /// fields (not full paths), so it cannot reconstruct env provenance yet.
 #[cfg(test)]

--- a/app/ferroehr/src/config/auth.rs
+++ b/app/ferroehr/src/config/auth.rs
@@ -6,7 +6,7 @@
 //! loader of its own** — the whole tree is assembled once by `ferroehr::config`
 //! and this struct is deserialized as a field of it.
 //!
-//! Secrets use the shared [`crate::config::secret::Secret`] newtype (P-6): a password hash
+//! Secrets use the shared [`crate::config::secret::Secret`] newtype: a password hash
 //! or HMAC secret deserializes from a plain string but never renders itself
 //! (`Debug`, `/management/env`, `ferroehr config check` all show `***`). Each
 //! secret key has a `*_file` sibling for file-based indirection

--- a/app/ferroehr/src/config/authz.rs
+++ b/app/ferroehr/src/config/authz.rs
@@ -18,8 +18,8 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
-/// Management-surface access level — the `rbac.management_access` tri-state
-/// (§5.2). `admin_only` is the default.
+/// Management-surface access level — the `rbac.management_access` tri-state.
+/// `admin_only` is the default.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum ManagementAccess {
@@ -32,7 +32,7 @@ pub enum ManagementAccess {
     Public,
 }
 
-/// The coarse role-based access-control settings (§5.2, §8).
+/// The coarse role-based access-control settings.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct RbacConfig {
@@ -74,7 +74,7 @@ impl Default for RbacConfig {
     }
 }
 
-/// The ABAC policy engine selector (`abac.engine`, §5.6/§5.5). `cedar` is the
+/// The ABAC policy engine selector (`abac.engine`). `cedar` is the
 /// embedded default; `remote` is the v1-compatible external PDP.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
@@ -86,7 +86,7 @@ pub enum AbacEngineKind {
     Remote,
 }
 
-/// One flat parameter a remote PDP body may carry (§5.5): the resolved
+/// One flat parameter a remote PDP body may carry: the resolved
 /// attribute keys, exactly `organization` / `patient` / `template` on the wire.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -100,7 +100,7 @@ pub enum AbacParam {
 }
 
 impl AbacParam {
-    /// The exact wire key v1 uses in the flat PDP request body (§2.1).
+    /// The exact wire key EHRbase v1 uses in the flat PDP request body.
     #[must_use]
     pub const fn wire_key(self) -> &'static str {
         match self {
@@ -111,7 +111,7 @@ impl AbacParam {
     }
 }
 
-/// A per-resource-kind policy binding (§5.5): the policy name appended to the
+/// A per-resource-kind policy binding: the policy name appended to the
 /// remote PDP base URL, and which resolved parameters its request body carries.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -123,7 +123,7 @@ pub struct PolicyRule {
     pub parameters: Vec<AbacParam>,
 }
 
-/// The embedded-Cedar engine settings (§5.6).
+/// The embedded-Cedar engine settings.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct CedarConfig {
@@ -135,7 +135,7 @@ pub struct CedarConfig {
     pub reload_secs: Option<u64>,
 }
 
-/// The v1-compatible remote-PDP client settings (§5.5).
+/// The v1-compatible remote-PDP client settings.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct RemoteConfig {
@@ -143,7 +143,8 @@ pub struct RemoteConfig {
     /// (required when `engine = remote`).
     #[serde(default)]
     pub server: Option<String>,
-    /// TCP connect timeout in milliseconds (v1 defect #4 fixed; default 2000).
+    /// TCP connect timeout in milliseconds (default 2000; EHRbase v1 had none,
+    /// so a blackholed PDP parked the request).
     #[serde(default = "defaults::connect_timeout_ms")]
     pub connect_timeout_ms: u64,
     /// Whole-request timeout in milliseconds (default 5000).
@@ -161,7 +162,7 @@ impl Default for RemoteConfig {
     }
 }
 
-/// The fine-grained attribute-based access-control settings (§5.3–5.7, §8).
+/// The fine-grained attribute-based access-control settings.
 ///
 /// Master switch `enabled` defaults to `false`, so an all-defaults config
 /// preserves today's authentication-plus-RBAC behaviour until an operator
@@ -180,7 +181,7 @@ pub struct AbacConfig {
     #[serde(default = "defaults::organization_claim")]
     pub organization_claim: String,
     /// The JWT claim carrying the patient id (default `patient_id`); its presence
-    /// enables the local subject gate (§5.7). Set to empty to disable the gate.
+    /// enables the local subject gate. Set to empty to disable the gate.
     #[serde(default = "defaults::patient_claim")]
     pub patient_claim: String,
     /// Embedded-Cedar settings.
@@ -226,7 +227,7 @@ impl AbacConfig {
     }
 }
 
-/// Authorization configuration (§8): the coarse RBAC gate plus the opt-in ABAC
+/// Authorization configuration: the coarse RBAC gate plus the opt-in ABAC
 /// policy layer.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
@@ -239,8 +240,8 @@ pub struct AuthzConfig {
     pub abac: AbacConfig,
 }
 
-/// A boot-time authorization-configuration error (§8 — hard errors that must
-/// abort startup rather than silently mis-gate).
+/// A boot-time authorization-configuration error — a hard error that must
+/// abort startup rather than silently mis-gate.
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum AuthzConfigError {
     /// A required role name was blank.
@@ -256,7 +257,7 @@ pub enum AuthzConfigError {
     )]
     UnknownPolicyKind(String),
     /// A `template` parameter was configured for `ehr`/`ehr_status` — illegal
-    /// (v1 made this a runtime 500; §5.5 makes it a boot error).
+    /// (EHRbase v1 made this a runtime 500; here it is a boot error).
     #[error("authz.abac.policy.{0} must not take the `template` parameter")]
     TemplateParamIllegal(&'static str),
     /// `engine = remote` without a configured base URL.
@@ -271,7 +272,7 @@ pub enum AuthzConfigError {
 }
 
 impl AuthzConfig {
-    /// Validate the configuration at boot (§8). All defaults are valid.
+    /// Validate the configuration at boot. All defaults are valid.
     ///
     /// # Errors
     /// [`AuthzConfigError`] when a role name is blank or the role-claim path list
@@ -299,7 +300,7 @@ impl AuthzConfig {
 }
 
 /// The canonical resource-kind keys accepted in the `abac.policy` map, and the
-/// two on which a `template` parameter is illegal (§5.5).
+/// two on which a `template` parameter is illegal.
 const POLICY_KINDS: [&str; 6] = [
     "ehr",
     "ehr_status",
@@ -310,7 +311,7 @@ const POLICY_KINDS: [&str; 6] = [
 ];
 
 impl AbacConfig {
-    /// Validate the ABAC section at boot (§8 hard errors). Only called when
+    /// Validate the ABAC section at boot (hard errors). Only called when
     /// `enabled`.
     fn validate(&self) -> Result<(), AuthzConfigError> {
         for (kind, rule) in &self.policy {

--- a/app/ferroehr/src/config/loader.rs
+++ b/app/ferroehr/src/config/loader.rs
@@ -1,4 +1,4 @@
-//! The one configuration loader (§5.1–5.4).
+//! The one configuration loader.
 //!
 //! Performs file discovery plus the pure `config`-crate assembly
 //! (defaults < file < env < `--set`) with the strict passes, the two
@@ -60,7 +60,7 @@ impl ConfigError {
 }
 
 /// A non-empty batch of configuration errors, rendered as one block so an
-/// operator fixes everything in one iteration (§P-5).
+/// operator fixes everything in one iteration.
 #[derive(Debug)]
 pub struct ConfigErrors(pub Vec<ConfigError>);
 
@@ -76,7 +76,7 @@ impl std::fmt::Display for ConfigErrors {
 
 impl std::error::Error for ConfigErrors {}
 
-/// File discovery (§5.4): `--config` → `FERROEHR_CONFIG` → `./ferroehr.toml` →
+/// File discovery: `--config` → `FERROEHR_CONFIG` → `./ferroehr.toml` →
 /// `/etc/ferroehr/ferroehr.toml`. An explicitly-pointed-at file must exist; the
 /// search-order files are optional.
 ///
@@ -140,7 +140,7 @@ pub fn assemble<S: std::hash::BuildHasher>(
         None => None,
     };
 
-    // The two permanent conventional aliases (§P-3: DATABASE_URL, RUST_LOG) —
+    // The two permanent conventional aliases (DATABASE_URL, RUST_LOG) —
     // layered BELOW the canonical source so an `FERROEHR__` form always wins.
     // There is no legacy remapping (greenfield, owner ruling 2026-07-15):
     // pre-redesign spellings fail the strict sweep above with the exact
@@ -207,7 +207,7 @@ pub fn assemble<S: std::hash::BuildHasher>(
 }
 
 /// An `FERROEHR_`-prefixed environment source over an injected map (the hermetic
-/// seam, §5.1) with the `__` grammar, typed scalars, and comma-separated lists.
+/// seam) with the `__` grammar, typed scalars, and comma-separated lists.
 fn env_source(map: HashMap<String, String>) -> Environment {
     let mut env = Environment::with_prefix("FERROEHR")
         .separator("__")
@@ -267,7 +267,7 @@ fn find_key_line(content: &str, key: &str) -> Option<usize> {
 }
 
 /// Resolve every `*_file` sibling into its `Secret`/string field immediately
-/// after extraction (§5.6): read the file, trim a trailing newline, and reject
+/// after extraction: read the file, trim a trailing newline, and reject
 /// when both the inline value and its `*_file` are set.
 fn resolve_secret_files(config: &mut FerroEhrConfig, errors: &mut Vec<ConfigError>) {
     resolve_secret(
@@ -315,7 +315,7 @@ fn resolve_secret_files(config: &mut FerroEhrConfig, errors: &mut Vec<ConfigErro
 }
 
 /// Read `path`'s contents (trailing newline trimmed) into `target` as a
-/// [`Secret`], unless `target` is already set (both-set is an error, §5.6).
+/// [`Secret`], unless `target` is already set (both-set is an error).
 fn resolve_secret(
     key: &str,
     target: &mut Option<Secret>,

--- a/app/ferroehr/src/config/mod.rs
+++ b/app/ferroehr/src/config/mod.rs
@@ -3,7 +3,7 @@
 //!
 //! No openEHR spec governs configuration — this is entirely our own design.
 //! [`FerroEhrConfig`] is the single serde root; each section is owned by the
-//! crate that consumes it (§5.2) and referenced here. There is exactly one
+//! crate that consumes it and referenced here. There is exactly one
 //! loader ([`load`]/[`assemble`]) replacing the fourteen former per-subsystem
 //! loaders — no figment, no per-subsystem `FERROEHR_*_CONFIG` file pointers.
 //!
@@ -44,8 +44,8 @@ use serde::{Deserialize, Serialize};
 /// The complete server configuration.
 ///
 /// Every section has a `Default`, so the file may be empty or absent
-/// (zero-config boot, §3.16). `deny_unknown_fields` makes a misspelled
-/// top-level table a boot error (§P-5).
+/// (zero-config boot). `deny_unknown_fields` makes a misspelled top-level
+/// table a boot error.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct FerroEhrConfig {
@@ -96,7 +96,7 @@ pub struct FerroEhrConfig {
 pub const DEFAULT_TEMPLATE: &str = include_str!("../../assets/ferroehr.default.toml");
 
 impl FerroEhrConfig {
-    /// Aggregated semantic validation (§5.8): every cross-field rule reported at
+    /// Aggregated semantic validation: every cross-field rule reported at
     /// once, so an operator fixes the config in one iteration.
     ///
     /// # Errors
@@ -159,6 +159,19 @@ impl FerroEhrConfig {
                     "set only one of auth.oidc.jwks_json / auth.oidc.jwks_json_file".to_owned(),
                 ));
             }
+            // A symmetric secret and a static JWKS are competing explicit key
+            // sources; both configured is a contradiction, never resolved by
+            // silent precedence.
+            let hmac_configured = oidc.hmac_secret.is_some() || oidc.hmac_secret_file.is_some();
+            let jwks_configured = oidc.jwks_json.is_some() || oidc.jwks_json_file.is_some();
+            if hmac_configured && jwks_configured {
+                errors.push(ConfigError::semantic(
+                    "auth.oidc configures BOTH a symmetric secret (hmac_secret[_file]) and a \
+                     static JWKS (jwks_json[_file]) — these are competing key sources; set \
+                     exactly one, or neither to use issuer discovery"
+                        .to_owned(),
+                ));
+            }
         }
         if self.multimedia.secret_access_key.is_some()
             && self.multimedia.secret_access_key_file.is_some()
@@ -213,11 +226,10 @@ impl FerroEhrConfig {
     /// leak by being renamed and a secret nested anywhere is masked by its own
     /// type.
     ///
-    /// This is **fail-closed for a newly-added secret**: the configuration
-    /// discipline (`.claude/rules/configuration.md` P-6) requires every secret
-    /// to be a `Secret`/`SecretUrl` with a `*_file` sibling, so a correctly
+    /// This is **fail-closed for a newly-added secret**: every secret field
+    /// is a `Secret`/`SecretUrl` with a `*_file` sibling, so a correctly
     /// typed new secret is redacted automatically with no change here. A secret
-    /// smuggled in as a bare `String` would be a P-6 violation; the
+    /// smuggled in as a bare `String` breaks that property; the
     /// `redacted_json_masks_every_secret_field` test enumerates the current
     /// secret set as the standing CI backstop. Non-secret identifiers (a Basic
     /// user's `username`/`roles`, `multimedia.access_key_id`, an OIDC `issuer`,
@@ -242,8 +254,8 @@ fn server_bind_port(bind: &str) -> Option<u16> {
 /// silently — a route to a missing provider quietly falls back to the default
 /// server, an `oauth2_client` naming a missing client would send
 /// unauthenticated requests, and half a mutual-TLS identity would connect
-/// without a client certificate — so all three are boot errors (§P-5: never
-/// make a bad value a silent default). The TLS material itself (readable PEM,
+/// without a client certificate — so all three are boot errors (never make a
+/// bad value a silent default). The TLS material itself (readable PEM,
 /// a certificate where a certificate belongs, a key where a key belongs) is
 /// validated when the provider is built, which is also boot time. No openEHR
 /// spec governs configuration — our own design.
@@ -314,7 +326,7 @@ fn validate_terminology(
 }
 
 /// Assemble the configuration from explicit inputs — the pure seam every test
-/// drives (§5.1/§6.6).
+/// drives.
 ///
 /// Runs the alias sweep (warning once per set legacy var), the strict env +
 /// file passes, the layered merge, and `*_file` secret resolution.
@@ -334,10 +346,10 @@ pub fn assemble(
     loader::assemble(file, env, overrides)
 }
 
-/// Boot loader: a thin process-environment shim over [`assemble`] (§5.2).
+/// Boot loader: a thin process-environment shim over [`assemble`].
 ///
-/// Discovers the config file (§5.4), snapshots the environment, assembles,
-/// and emits the dev-default-DB boot warning (§3.16 review condition).
+/// Discovers the config file, snapshots the environment, assembles, and emits
+/// the dev-default-DB boot warning.
 ///
 /// # Errors
 /// [`ConfigErrors`] on discovery failure or any assembly error.
@@ -350,7 +362,7 @@ pub fn load(
     let config = assemble(file.as_deref(), &env, overrides)?;
 
     // Review condition 1: never a silent production trap — announce the dev
-    // default DSN prominently at boot (§3.16).
+    // default DSN prominently at boot.
     if config.db.is_dev_default() {
         tracing::warn!(
             url = crate::db::DEFAULT_URL,
@@ -514,7 +526,7 @@ mod tests {
         let c = assemble_ok(Some(file.path()), &env(&[]), &[]);
         assert_eq!(c.server.system_id, "cdr.hospital.example");
 
-        // Env wins over the file (the P-4 uniform grammar).
+        // Env wins over the file (the uniform `__` grammar).
         let c = assemble_ok(
             Some(file.path()),
             &env(&[("FERROEHR__SERVER__SYSTEM_ID", "cdr.env.example")]),
@@ -634,8 +646,8 @@ mod tests {
     /// with a unique high-entropy sentinel; none may appear in the rendered
     /// JSON, while non-secret siblings (a Basic user's `username`/`roles`) stay
     /// visible. This is the standing enumeration of the current secret set: a
-    /// new secret field added without redaction (a P-6 violation) is caught here
-    /// once wired into the fixture.
+    /// new secret field added without redaction is caught here once wired
+    /// into the fixture.
     #[test]
     fn redacted_json_masks_every_secret_field() {
         use crate::config::auth::{BasicConfig, BasicUser, OidcConfig};
@@ -703,7 +715,7 @@ mod tests {
         assert_eq!(value["multimedia"]["access_key_id"], "AKIA_PUBLIC_ID");
     }
 
-    // ── 6. Template sync (§5.5) ───────────────────────────────────────────────
+    // ── 6. Template sync ──────────────────────────────────────────────────────
 
     #[test]
     fn template_parses_to_default() {
@@ -727,7 +739,7 @@ mod tests {
         }
     }
 
-    // ── 7. Semantic validation (§5.8) ─────────────────────────────────────────
+    // ── 7. Semantic validation ────────────────────────────────────────────────
 
     #[test]
     fn validate_pgp_requires_key_path() {
@@ -735,6 +747,24 @@ mod tests {
         c.signing.mode = crate::versioning::signature::config::Mode::Pgp;
         assert!(c.validate().is_err());
         c.signing.key_path = Some(PathBuf::from("/k.asc"));
+        assert!(c.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_hmac_and_jwks_together_is_refused() {
+        let mut c = FerroEhrConfig::default();
+        c.auth.oidc = Some(crate::config::auth::OidcConfig {
+            issuer: "https://idp.example.test".to_owned(),
+            hmac_secret: Some(Secret::new("topsecret")),
+            jwks_json: Some("{\"keys\":[]}".to_owned()),
+            ..crate::config::auth::OidcConfig::default()
+        });
+        let err = c.validate().expect_err("competing key sources must refuse");
+        assert!(err.to_string().contains("competing key sources"), "{err}");
+        // Each source alone stays valid.
+        if let Some(oidc) = c.auth.oidc.as_mut() {
+            oidc.jwks_json = None;
+        }
         assert!(c.validate().is_ok());
     }
 
@@ -896,8 +926,8 @@ mod tests {
         assert!(c.validate().is_ok());
     }
 
-    /// The new terminology keys are reachable through the one env grammar
-    /// (§P-4), map keys included.
+    /// The new terminology keys are reachable through the one env grammar, map
+    /// keys included.
     #[test]
     fn env_mapping_terminology_routes_and_oauth2_clients() {
         let c = assemble_ok(
@@ -1018,7 +1048,7 @@ mod tests {
         assert!(c.validate().is_ok(), "a CA bundle alone is valid");
     }
 
-    /// The mutual-TLS keys are reachable through the one env grammar (§P-4).
+    /// The mutual-TLS keys are reachable through the one env grammar.
     #[test]
     fn env_mapping_terminology_provider_mtls_paths() {
         let c = assemble_ok(

--- a/app/ferroehr/src/config/secret.rs
+++ b/app/ferroehr/src/config/secret.rs
@@ -1,7 +1,7 @@
 //! Shared configuration value types for the whole server configuration tree.
 //!
 //! No openEHR spec governs configuration — our own design. These two newtypes
-//! centralise secret handling (principle P-6) so redaction is a property of the
+//! centralise secret handling so redaction is a property of the
 //! type, not of a per-endpoint redactor list:
 //!
 //! - [`Secret`] wraps a [`secrecy::SecretString`]; it deserializes from a plain
@@ -29,7 +29,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 pub const REDACTED: &str = "***";
 
 /// A secret string that never renders itself. Deserializes from a plain string;
-/// `Serialize`/`Display`/`Debug` all emit [`REDACTED`] (P-6).
+/// `Serialize`/`Display`/`Debug` all emit [`REDACTED`].
 #[derive(Clone)]
 pub struct Secret(SecretString);
 

--- a/app/ferroehr/src/config/server.rs
+++ b/app/ferroehr/src/config/server.rs
@@ -5,7 +5,7 @@
 //! once by the binary. This module owns the REST-adapter's slice of it:
 //!
 //! - [`ServerConfig`] — the `[server]` section (the HTTP listener + REST
-//!   surface + the `OPTIONS /` System-Options identity, §3.1).
+//!   surface + the `OPTIONS /` System-Options identity).
 //! - `AppConfig` — the adapter's runtime view, assembled by the binary (the
 //!   composition root) from the root config's `[server]`, `[auth]`, `[admin]`,
 //!   `[tenancy]`, `[smart]` sections plus the extension-group mount toggles.
@@ -18,7 +18,7 @@
 
 use serde::{Deserialize, Serialize};
 
-/// The `[server]` section — the HTTP listener and REST surface (§3.1).
+/// The `[server]` section — the HTTP listener and REST surface.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct ServerConfig {
@@ -68,8 +68,8 @@ pub struct ServerConfig {
     /// openEHR spec governs the configuration mechanism — our own design; the
     /// specs govern only that a system HAS such an identifier.
     pub system_id: String,
-    /// The `OPTIONS /` System-Options manifest identity (`[server.identity]`,
-    /// §3.1). Sourced from config so the public identity and advertised profile
+    /// The `OPTIONS /` System-Options manifest identity
+    /// (`[server.identity]`). Sourced from config so the public identity and advertised profile
     /// are not string literals in the handler; the live endpoint list is
     /// supplied separately by `ferroehr_rest::router`. This is the *display* identity
     /// of the manifest — the data-authoring identity is [`Self::system_id`].
@@ -180,7 +180,7 @@ const fn default_max_in_flight() -> usize {
     256
 }
 
-/// Multi-tenancy configuration (`[tenancy]`, §3.8).
+/// Multi-tenancy configuration (`[tenancy]`).
 ///
 /// Off by default: with `enabled = false` the tenant middleware is never
 /// installed, the pool takes no per-acquire hook, and the `/admin/tenant` CRUD
@@ -212,7 +212,7 @@ impl Default for TenancyConfig {
     }
 }
 
-/// Configuration of the ADMIN API group (`[admin]`, §3.7; SM `I_ADMIN_SERVICE`).
+/// Configuration of the ADMIN API group (`[admin]`; SM `I_ADMIN_SERVICE`).
 ///
 /// NOTE: gating the admin surface behind an opt-in flag — when inactive every
 /// admin route answers `405 Method Not Allowed` with an empty `Allow`

--- a/app/ferroehr/src/config/strict.rs
+++ b/app/ferroehr/src/config/strict.rs
@@ -1,4 +1,4 @@
-//! Strict-validation helpers (§5.3): the reserved-namespace env sweep, the
+//! Strict-validation helpers: the reserved-namespace env sweep, the
 //! did-you-mean suggester, and its Damerau-Levenshtein metric. No openEHR spec
 //! governs configuration — our own design.
 
@@ -10,8 +10,7 @@ use super::loader::ConfigError;
 /// Sweep the reserved `FERROEHR_` namespace: every such variable must be an
 /// allowlisted non-config name or a known-section uniform key — anything else
 /// is a boot error (with a did-you-mean), which is what makes a
-/// set-but-never-read variable (the historical C-3/C-5 defect class)
-/// impossible. There is no legacy remapping (greenfield, owner ruling
+/// set-but-never-read variable impossible. There is no legacy remapping (greenfield, owner ruling
 /// 2026-07-15): a pre-redesign spelling fails here with the exact uniform
 /// suggestion. Deeper key typos inside a known section are caught at
 /// deserialize by `deny_unknown_fields`.

--- a/app/ferroehr/src/service/demographic/mod.rs
+++ b/app/ferroehr/src/service/demographic/mod.rs
@@ -29,7 +29,7 @@
 //! status/`ETag`/`Location`/`Prefer`/`If-Match`/deleted-read semantics to the
 //! EHR group, by the spec's own design.
 //!
-//! Standing NOTEs (deliberate divergences, register §6):
+//! Standing NOTEs (deliberate divergences):
 //! - The `UV_PARTY`/`UV_PARTY_RELATIONSHIP` envelope (`uv_party.adoc`) is
 //!   realized server-side; the wire seam carries a **bare RM party** and
 //!   `lifecycle_state` defaults to `532|complete|` (a documented

--- a/app/ferroehr/tests/it/persistence.rs
+++ b/app/ferroehr/tests/it/persistence.rs
@@ -523,7 +523,7 @@ async fn node_codec_round_trips_through_the_database() {
     assert_eq!(contains, expected);
 }
 
-/// §6.2: the stored `vo_version.template_id` is read back through the version
+/// The stored `vo_version.template_id` is read back through the version
 /// read-back and surfaced by `FerroEhrService::template_of_version` (the ABAC
 /// template attribute).
 #[tokio::test]
@@ -575,10 +575,11 @@ async fn template_id_is_read_back_from_vo_version() {
     );
 }
 
-/// §6.4 projection-independence regression (v1 defect #1): the ABAC query
-/// subject-scope pre-filter restricts rows to the caller's patient EHRs, and the
-/// executor collects the touched EHR/template sets, **even when the query
-/// projects neither `ehr_id`/`value` nor a template path**.
+/// Projection-independence regression (EHRbase v1 read these attributes off the
+/// SELECT columns): the ABAC query subject-scope pre-filter restricts rows to
+/// the caller's patient EHRs, and the executor collects the touched
+/// EHR/template sets, **even when the query projects neither `ehr_id`/`value`
+/// nor a template path**.
 #[tokio::test]
 async fn query_subject_scope_filters_and_collects_projection_independently() {
     use ferroehr::service::FerroEhrService;

--- a/app/ferroehr/tests/it/service_signing.rs
+++ b/app/ferroehr/tests/it/service_signing.rs
@@ -2,7 +2,7 @@
 //! §"Digital Signature")
 //! against a real `PostgreSQL` 18 (shared testkit harness).
 //!
-//! The strongest assertion (§6.3): the digest recomputes from the **served**
+//! The strongest assertion: the digest recomputes from the **served**
 //! `ORIGINAL_VERSION`'s `canonical_form` — proving commit-time and read-time
 //! object identity. Also: `EHR_STATUS` / FOLDER / contribution versions are all
 //! signed; client-supplied signatures are stored verbatim; `verify_on_read =
@@ -157,7 +157,7 @@ fn change_type(code: &str, value: &str) -> Value {
 }
 
 /// Assert a served `ORIGINAL_VERSION` carries a server digest signature that
-/// recomputes from its own `canonical_form` — the strongest test (§6.3).
+/// recomputes from its own `canonical_form` — the strongest test.
 fn assert_digest_recomputes(ov: &Value) {
     assert_eq!(
         ov["_type"], "ORIGINAL_VERSION",
@@ -262,7 +262,7 @@ async fn ehr_status_versions_are_signed_and_every_vo_version_carries_a_digest() 
         .expect("create_directory");
 
     // Sweep: EHR_STATUS (x2), EHR_ACCESS, FOLDER — every stored version is signed
-    // with a digest (design §3.4: signing on by default).
+    // with a digest (signing is on by default).
     let rows = sqlx::query("SELECT kind, signature FROM vo_version ORDER BY kind, sys_version")
         .fetch_all(&pool)
         .await
@@ -363,7 +363,7 @@ async fn strict_verify_on_read_rejects_a_tampered_row() {
     let db = testkit::db().await.expect("testkit database");
     let pool = db.pool();
     // A strict-verify service: a signature that does not match the served
-    // canonical form is a 5xx integrity failure (design §3.5).
+    // canonical form is a 5xx integrity failure.
     let config = SigningConfig {
         enabled: true,
         mode: Mode::Digest,
@@ -511,7 +511,7 @@ async fn warn_and_off_verify_on_read_serve_a_tampered_row() {
 #[tokio::test]
 async fn canonical_xml_carries_the_signature() {
     // The generated canonical-XML serialization (the same `to_canonical_xml` the
-    // REST negotiate path uses) emits the `signature` element (design §4.4/§6.4).
+    // REST negotiate path uses) emits the `signature` element.
     use openehr_rm::v1_2::common::change_control::original_version::OriginalVersion;
     use openehr_rm::v1_2::composition::composition::Composition;
 

--- a/app/ferroehr/tests/it/signing_pgp.rs
+++ b/app/ferroehr/tests/it/signing_pgp.rs
@@ -1,4 +1,4 @@
-//! `OpenPGP`-mode integration tests (design §6.2): sign→verify round-trip with a
+//! `OpenPGP`-mode integration tests: sign→verify round-trip with a
 //! generated key, tamper detection, armor-parse failures, and the fail-closed
 //! boot validation (missing path, garbled key, wrong passphrase).
 //!

--- a/app/ferroehr/tests/it/telemetry.rs
+++ b/app/ferroehr/tests/it/telemetry.rs
@@ -7,7 +7,7 @@ use ferroehr::telemetry::health::{Health, HealthIndicator, HealthStatus};
 use ferroehr::telemetry::prometheus::{MetricKind, catalog};
 
 /// The full metric catalog as a stable text table: `name kind [buckets]`. A
-/// snapshot pins it so any rename/bucket change is reviewed deliberately (§1.2).
+/// snapshot pins it so any rename/bucket change is reviewed deliberately.
 #[test]
 fn metric_catalog_snapshot() {
     let mut lines = Vec::new();

--- a/website/book/src/installation/configuration.md
+++ b/website/book/src/installation/configuration.md
@@ -321,10 +321,18 @@ algorithms = ["RS256"]
 | `audiences` | list of string | `[]` | Accepted `aud` (empty = not checked). |
 | `algorithms` | list of string | `["RS256"]` | Accepted signature algorithms. |
 | `hmac_secret` / `hmac_secret_file` | secret / path | unset | Symmetric HS256 secret (dev/test). At most one of the pair. |
-| `jwks_json` / `jwks_json_file` | string / path | unset | Static JWKS document; preferred over discovery when present. |
+| `jwks_json` / `jwks_json_file` | string / path | unset | Static JWKS document. At most one of the pair. |
 | `connect_timeout_ms` | int | `3000` | TCP connect timeout for the discovery + JWKS fetches. |
 | `request_timeout_ms` | int | `5000` | Whole-request timeout for the discovery + JWKS fetches (connect, TLS, body read). |
 | `negative_cache_ttl_seconds` | int | `10` | How long a *failed* discovery/JWKS fetch is remembered (`0` disables). |
+
+The signing-key source is exactly one of: the symmetric secret, the static
+JWKS, or (when neither is set) the issuer's OIDC discovery document.
+Configuring both `hmac_secret` and `jwks_json` (in either direct or `_file`
+form) is a boot-time configuration error — never resolved by silent
+precedence. A validated token must also carry a non-blank `sub` claim: the
+authenticated subject is stamped into the audit trail, so a token without one
+is refused with `401` rather than recorded under a placeholder identity.
 
 The last three keys apply only when keys come from the issuer's OIDC discovery
 document — that is, when neither `hmac_secret` nor `jwks_json` is set. The


### PR DESCRIPTION
Closes #1955, closes #1956, closes #1957.

Three auth/config hardening fixes in one branch (owner instruction: one PR for the batch).

**#1956 — audit-attributable subjects.** A validated bearer token with a missing or blank `sub` claim is refused with `401` instead of authenticating as a principal literally named `unknown` and stamping that fabricated identity into the ATNA audit trail. RFC 7519 §4.1.2 makes `sub` optional — but the never-lax posture says an unattributable caller is refused, not mis-recorded. Verified the CNF smart-lane runner mints tokens with `sub` (`cnf-smart-app`), so the conformance record is unaffected. Tests: missing-`sub` and blank-`sub` refusals.

**#1957 — one OIDC key source.** `auth.oidc.hmac_secret[_file]` + `auth.oidc.jwks_json[_file]` configured together is now an aggregated boot-time validation error naming both keys, alongside the existing secret/`*_file` collision checks. Previously the symmetric secret silently won by precedence. Test pins the refusal and that each source alone stays valid. Book page updated (key-source paragraph in the `[auth.oidc]` section).

**#1955 — citation sweep.** 137 markers citing deleted internal design documents (`§N.N`, `§P-N`, `C-N`, `defect #N`) across 29 files in the access/config layer are resolved, grounded in the recovered originals (`docs/enterprise/access-control.md`, `docs/design/configuration.md`, `docs/design/version-signing.md`, recovered from git history) — dropped where the prose already stood alone, reworded into self-contained clauses where they carried content (EHRbase-v1 prior-art mentions stay as prose). Every surviving `§` in `app/**` now names its source in the same comment; the ambiguous ones were verified first-hand (RFC 6749/7519/7231/9110 sections, RM common master06 §6.4.1.2). Comment-style guard green over every touched file. The residual change-narration comment class found en route is tracked as #1959.

Gates: `cargo fmt` clean, clippy clean (`ferroehr`, `ferroehr-rest`, `ferroehr-server`), nextest 1498/1498. CHANGELOG entries for the two behaviour changes (comment sweep is invisible).