### PR TITLE
docs(security): point the admission policies at the identity the lanes issue, and at a signature that exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,26 @@ workflow refuses a tag that has no matching section here.
 
 ### Changed
 
+- The Kubernetes hardening chapter's image-provenance admission policies now
+  carry the certificate identity the publishing lanes actually issue — read off a
+  published image rather than inferred from the workflow files — and both are
+  corrected to the form that can read a GitHub Artifact Attestation at all.
+  Kyverno needs `type: SigstoreBundle` with an `attestations:` block (the field
+  defaults to `Cosign`, which looks for a detached signature these images do not
+  carry and so refuses every one of them), and `sigstore-policy-controller` needs
+  `signatureFormat: bundle` with an `attestations:` entry. Minimum versions are
+  stated, `failureAction` moves off the deprecated spec-level field, and each
+  policy names the ref set it admits: as published they accept released images
+  only and deliberately refuse the `develop` tag, with the one-word change a
+  staging cluster needs spelled out.
+- Provenance verification commands across the security and Kubernetes chapters
+  now point at artifacts that actually answer. `gh attestation verify` on the
+  three `:develop` images succeeds today, and `--signer-workflow` is shown as the
+  way to require the specific publishing lane rather than any workflow in the
+  repository. The release-tag, release-binary and chart forms are marked as
+  starting at the `3.17.4` cut instead of being demonstrated against a tag that
+  returns `HTTP 404`.
+
 - **Release binaries reach SLSA v1.0 Build Level 3, and carry provenance a scanner and an offline verifier can both read.** Build L3's distinguishing requirement is that signing material must be out of reach of the build steps — and every step of a GitHub Actions job shares one runner VM, so attesting inside the building job cannot satisfy it. The release build now happens inside a *reusable* workflow: it runs on its own VM, a caller passes declared inputs and cannot add steps, and the caller job has no steps at all. You can now **require** that signer rather than trusting any workflow in the repository: `gh attestation verify <tarball> -R rubentalstra/FerroEHR --signer-workflow rubentalstra/FerroEHR/.github/workflows/release-build.yml`. Each release also carries its provenance as `<tarball>.intoto.jsonl` beside the Sigstore bundles. The container images and the Helm chart remain Build L2 and now say so where they are built, rather than leaving the level to be assumed.
 
 - **A direct push to `develop` is refused.** The branch ruleset already blocked deletion and force-pushes and required signed commits, but not a pull request — so the discipline every change has followed was convention rather than enforcement, and the `main` ruleset had the rule all along. Requiring zero approvals, so it changes nothing about how a maintainer merges their own work.
@@ -202,6 +222,13 @@ workflow refuses a tag that has no matching section here.
 
 
 ### Fixed
+
+- Documented `gh attestation verify` invocations no longer promise a result on
+  the Helm chart or on `3.17.3`: no chart version has been published, and signing
+  landed after that tag was built. Both chapters now say so, and the stale
+  "no published artifact carries an attestation" warning on the admission
+  policies is replaced by a narrower note about the one thing still unproven —
+  that no admission controller has yet run these policies against a live image.
 
 - **The AQL printer emitted queries that meant something different when read back.** Found by the new fuzzer, and it is a correctness defect rather than a formatting one: `to_aql` dropped parentheses that the grammar needs, so re-parsing the printed text produced a *different* query. Two causes. The `AND`/`OR` operators are stated in the grammar as binary alternatives of one recursive rule, which resolves left-associatively — so a same-precedence operand survives a re-parse on the left and silently **re-associates** on the right, and the printer treated both sides alike. And a `CONTAINS` chain used as a boolean operand absorbs whatever operator follows it, moving that operator *inside* the CONTAINS scope. The printer's own documented invariant — parse(print(q)) == q — now holds across every boolean shape, asserted rather than assumed.
 

--- a/docs/conformance/COMPARISON.md
+++ b/docs/conformance/COMPARISON.md
@@ -20,7 +20,7 @@
 | | ferroehr | EHRbase |
 |---|---|---|
 | Product | ferroehr 3.17.3 | ehrbase 2.34.0 |
-| Run date | 2026-08-05 | 2026-07-28 |
+| Run date | 2026-08-07 | 2026-08-07 |
 | Party statement | `tools/cnf-runner/party/ferroehr/` | `tools/cnf-runner/party/ehrbase/` |
 | Stack | root compose, built from the current sources | `docker/sut-ehrbase.yml` (official images) |
 
@@ -58,8 +58,8 @@ claimed. The verdict-bearing comparison below is therefore each party's
 
 ## In-scope outcomes
 
-Runs compared: **ferroehr** (run of 2026-08-05) vs **EHRbase
-2.34.0** (run of 2026-07-28) — the SAME catalogue through the same
+Runs compared: **ferroehr** (run of 2026-08-07) vs **EHRbase
+2.34.0** (run of 2026-08-07) — the SAME catalogue through the same
 runner, each with its own committed party statement. Per the presentation
 rule, the headline is each party's VERDICT SCOPE (the cases its own
 declarations select), never the raw record: a raw count would book

--- a/website/book/src/installation/kubernetes-hardening.md
+++ b/website/book/src/installation/kubernetes-hardening.md
@@ -372,51 +372,92 @@ same.
 
 **The operator's — and this is provenance nobody currently checks.**
 
-The publishing lanes attest both the images and the chart through **keyless
-Sigstore**, which means a verifier can establish that an artifact came from this
-repository's build. Nothing in a cluster *requires* that check before running one,
-and a signature nobody verifies changes nothing about what actually runs.
+The publishing lanes attest their artifacts through **keyless Sigstore**, so a
+verifier can establish that an artifact came from this repository's build — the
+three published images carry a signed SLSA v1 provenance attestation today.
+Nothing in a cluster *requires* that check before running one, and a signature
+nobody verifies changes nothing about what actually runs. That is what the
+policies below close.
 
-> [!WARNING]
-> **No published artifact carries an attestation yet, so the policies below are
-> written from the workflow definitions and have not been verified against a live
-> attestation.** The signing step was added after the most recent release, and no
-> publishing run has executed since: `gh attestation verify` on the current
-> `ferroehr:3.17.3` and `ferroehr:develop` images both return HTTP 404, and the
-> repository's attestation list is empty. Before relying on either policy, confirm
-> the identity it trusts against a real artifact:
->
-> ```shell
-> gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:<tag> \
->   -R rubentalstra/FerroEHR --format json | jq '.[0].verificationResult.signature.certificate'
-> ```
->
-> and reconcile `certificateIdentity` / `certificateOidcIssuer` with the values
-> below. A `--certificate-identity` that does not match what the lane issues fails
-> **closed** — it blocks a legitimate image — which is worse than no policy.
+### The identity to trust, read off a real artifact
 
-The identity to trust, derived from the lanes themselves: GitHub's OIDC issuer,
-and a subject that is the publishing workflow's own ref.
+Each lane signs with a short-lived Fulcio certificate whose **subject
+alternative name is the workflow that issued the token**, and whose issuer is
+GitHub's OIDC provider. The values below are not derived from the workflow
+files — they are read out of the certificate on a published image:
 
-| Artifact | Built by | Certificate identity (SAN) |
-|---|---|---|
-| the three images | `.github/workflows/containers.yml` | `https://github.com/rubentalstra/FerroEHR/.github/workflows/containers.yml@refs/tags/vX.Y.Z` |
-| the chart | `.github/workflows/publish-chart.yml` | `https://github.com/rubentalstra/FerroEHR/.github/workflows/publish-chart.yml@refs/tags/vX.Y.Z` |
+```shell
+gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:develop \
+  -R rubentalstra/FerroEHR --format json \
+  | jq '.[0].verificationResult.signature.certificate
+        | {subjectAlternativeName, issuer, sourceRepositoryRef, runnerEnvironment}'
+```
 
-with issuer `https://token.actions.githubusercontent.com` in both cases.
+```json
+{
+  "subjectAlternativeName": "https://github.com/rubentalstra/FerroEHR/.github/workflows/containers.yml@refs/heads/develop",
+  "issuer": "https://token.actions.githubusercontent.com",
+  "sourceRepositoryRef": "refs/heads/develop",
+  "runnerEnvironment": "github-hosted"
+}
+```
 
-**Kyverno** (`verifyImages`, keyless) — the engine [chosen
-below](#centralized-policy-and-which-engine):
+**The SAN's ref varies with the trigger, and that is the part a policy gets
+wrong.** Each lane runs on more than one ref, so each issues more than one
+identity:
+
+| Artifact | Signing workflow | SAN on a release build | SAN on a development build |
+|---|---|---|---|
+| the three images | `containers.yml` | `…/containers.yml@refs/tags/vX.Y.Z` | `…/containers.yml@refs/heads/develop` |
+| the chart | `publish-chart.yml` | `…/publish-chart.yml@refs/tags/vX.Y.Z` | `…/publish-chart.yml@refs/heads/develop` (a `workflow_dispatch` chart-only publish) |
+| the release binaries | `release-build.yml` | `…/release-build.yml@refs/tags/vX.Y.Z` | *(none — the lane only runs on a tag)* |
+
+All three prefixed with `https://github.com/rubentalstra/FerroEHR/.github/workflows/`,
+and all with issuer `https://token.actions.githubusercontent.com`.
+
+The release binaries are signed by `release-build.yml` rather than by
+`release.yml` because the build lives in a **reusable** workflow — the
+certificate names the workflow that owns the build definition, which is what
+makes the `--signer-workflow` pin below meaningful.
+
+**Pick the ref set deliberately, because the choice is a refusal.** A policy
+matching `refs/tags/v…` only admits released images and **refuses
+`ghcr.io/rubentalstra/ferroehr:develop`** — correct for production, and the
+reason a policy tested against `:develop` appears broken when it is working. A
+staging cluster that runs `:develop` needs both refs. Nothing accepts an
+arbitrary branch: `refs/heads/develop` is exact, not a prefix match.
+
+### Kyverno
+
+The engine [chosen below](#centralized-policy-and-which-engine). Two details
+decide whether this policy works at all:
+
+- **`type: SigstoreBundle`.** These attestations are GitHub Artifact
+  Attestations, stored in the [Sigstore bundle
+  format](https://docs.sigstore.dev/about/bundle/) as an OCI referrer. Kyverno
+  reads that format only under this type; the field
+  [defaults to `Cosign`](https://kyverno.io/docs/policy-types/cluster-policy/verify-images/sigstore/),
+  which looks for a `sha256-<digest>.sig` tag that these images do not have (it
+  returns 404 — the bundle is a referrer, not a cosign tag). Requires
+  **Kyverno 1.13 or newer**.
+- **`attestations:`, not `attestors:` alone.** Kyverno's own rule is that
+  "each `verifyImages` rule can be used to verify signatures or attestations,
+  but not both", and what the lane produces is a signed *attestation* — there
+  is no detached image signature. A rule with `attestors:` at the top level
+  therefore fails **closed** on a perfectly legitimate image.
 
 ```yaml
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: ferroehr-image-provenance
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: none
 spec:
-  validationFailureAction: Enforce
+  background: false
+  webhookTimeoutSeconds: 30
   rules:
-    - name: verify-ferroehr-images
+    - name: verify-ferroehr-provenance
       match:
         any:
           - resources:
@@ -424,17 +465,53 @@ spec:
               namespaces: [ferroehr]
       verifyImages:
         - imageReferences:
-            - "ghcr.io/rubentalstra/ferroehr*"
-          attestors:
-            - entries:
-                - keyless:
-                    subject: "https://github.com/rubentalstra/FerroEHR/.github/workflows/containers.yml@refs/tags/*"
-                    issuer: "https://token.actions.githubusercontent.com"
-                    rekor:
-                      url: https://rekor.sigstore.dev
+            - "ghcr.io/rubentalstra/ferroehr"
+            - "ghcr.io/rubentalstra/ferroehr:*"
+            - "ghcr.io/rubentalstra/ferroehr-admin-ui*"
+            - "ghcr.io/rubentalstra/ferroehr-postgres*"
+          # Sigstore bundle format — GitHub Artifact Attestations. Omitting
+          # this defaults to Cosign, which looks for a signature that does not
+          # exist and refuses every image.
+          type: SigstoreBundle
+          failureAction: Enforce
+          attestations:
+            - type: https://slsa.dev/provenance/v1
+              attestors:
+                - count: 1
+                  entries:
+                    - keyless:
+                        issuer: https://token.actions.githubusercontent.com
+                        # Released images only. For a staging cluster that runs
+                        # the development tag, make the group
+                        # `(heads/develop|tags/v.+)`.
+                        subjectRegExp: '^https://github\.com/rubentalstra/FerroEHR/\.github/workflows/containers\.yml@refs/(tags/v.+)$'
+                        rekor:
+                          url: https://rekor.sigstore.dev
+              conditions:
+                - all:
+                    - key: '{{ buildDefinition.buildType }}'
+                      operator: Equals
+                      value: https://actions.github.io/buildtypes/workflow/v1
 ```
 
-**sigstore-policy-controller**, if you already run it:
+`failureAction` sits on the `verifyImages` entry: the spec-level
+`validationFailureAction` is
+[deprecated in the CRD](https://github.com/kyverno/kyverno/blob/main/config/crds/kyverno/kyverno.io_clusterpolicies.yaml)
+("use `validationFailureAction` under the validate rule instead"), and a
+`verifyImages` rule has no validate block. `mutateDigest`, `verifyDigest` and
+`required` all default to `true`, which is what you want: a tag is rewritten to
+the digest that was verified, and an image with no attestation is refused
+rather than passed.
+
+### sigstore-policy-controller
+
+If you already run it. The equivalent two details:
+
+- **`signatureFormat: bundle`** on the authority. The default is `legacy`
+  (cosign's own), which cannot read these attestations. Requires
+  **policy-controller v0.13.0 or newer**.
+- **an `attestations:` entry**, because in bundle format policy-controller
+  supports "only attestations, not plain signatures".
 
 ```yaml
 apiVersion: policy.sigstore.dev/v1beta1
@@ -449,8 +526,33 @@ spec:
         url: https://fulcio.sigstore.dev
         identities:
           - issuer: https://token.actions.githubusercontent.com
-            subjectRegExp: "^https://github\\.com/rubentalstra/FerroEHR/\\.github/workflows/containers\\.yml@refs/tags/v.*$"
+            # Same group as the Kyverno policy: `(heads/develop|tags/v.+)` for a
+            # staging cluster that runs the development tag.
+            subjectRegExp: '^https://github\.com/rubentalstra/FerroEHR/\.github/workflows/containers\.yml@refs/(tags/v.+)$'
+      signatureFormat: bundle
+      attestations:
+        - name: require-slsa-provenance
+          predicateType: https://slsa.dev/provenance/v1
 ```
+
+> [!NOTE]
+> **What has been checked, and what has not.** The identity, the issuer and the
+> predicate type above are verified first-hand against the three published
+> images — `cosign verify --certificate-identity-regexp …` (cosign 3.1.3) admits
+> all three and refuses both an unsigned image and, under a tags-only pattern, a
+> `:develop` image, so the matcher is neither vacuous nor accidentally
+> permissive. The manifests are checked field-by-field against the published
+> `ClusterPolicy` and `ClusterImagePolicy` CRDs. **Neither policy has been
+> exercised by a running admission controller**, and the Kyverno CLI is no
+> substitute: `kyverno test` reports a `verifyImages` rule as `Excluded` and
+> returns the same verdict whichever result you assert. Before enforcing, run
+> the policy in `Audit` (Kyverno) or as a `warn` policy (policy-controller) long
+> enough to see one real deployment pass.
+
+**No chart policy is offered yet.** No chart version has been published, so
+there is nothing to reconcile a chart identity against; the row in the table
+above is what the lane *will* issue, not something read off an artifact. Verify
+the chart with the manual command below once a chart version exists.
 
 **Should the chart ship one? No, and the reason is structural:** an admission
 policy is cluster-scoped and governs workloads the chart knows nothing about,
@@ -461,12 +563,25 @@ to depend on. The chart's contribution is the policy *document*, here, versioned
 with the lanes whose identity it encodes.
 
 **Without an admission controller**, the manual equivalent is a release-time
-check rather than a per-pod one:
+check rather than a per-pod one. Add `--signer-workflow` to insist on the lane
+as well as the repository — without it you are trusting that *some* workflow
+here signed the image:
 
 ```shell
-gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:3.17.3 -R rubentalstra/FerroEHR
-gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:4.0.0 -R rubentalstra/FerroEHR
+gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:develop \
+  -R rubentalstra/FerroEHR \
+  --signer-workflow rubentalstra/FerroEHR/.github/workflows/containers.yml
 ```
+
+Substitute a `vX.Y.Z` tag for `develop` on a release; the signer workflow is the
+same. Both forms are verified working on the current `develop` images.
+
+> [!IMPORTANT]
+> Signing landed in the publishing lanes during the `3.17.4` cycle, so
+> `ferroehr:3.17.3` and every earlier tag answer `HTTP 404: Not Found` — there is
+> nothing to verify, not a verification failure. The chart command
+> (`oci://ghcr.io/rubentalstra/charts/ferroehr:<chart-version>`) has nothing to
+> answer for yet either: no chart version has been published.
 
 Then deploy **by digest** (`image.digest`), so what you verified is what runs — a
 tag can be moved afterwards, a digest cannot.

--- a/website/book/src/installation/kubernetes.md
+++ b/website/book/src/installation/kubernetes.md
@@ -81,9 +81,13 @@ gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:<tag> -R rubentalstra/
 > [!IMPORTANT]
 > Signing was added to the publishing lanes **after** `3.17.3` was built, so that
 > tag and everything before it carry no attestation and the command above answers
-> `no attestations found` for them. Attestations exist from the first release
+> `HTTP 404: Not Found` for them. Attestations exist from the first release
 > published by the signing lane onward. If you are pinning an older tag and need
-> provenance, pin a newer one.
+> provenance, pin a newer one — the development images
+> (`ghcr.io/rubentalstra/ferroehr:develop`) already verify. **No chart version has
+> been published yet**, so the chart command has nothing to answer for until the
+> first release cut by the signing lanes; the images it deploys are already
+> verifiable.
 
 > [!NOTE]
 > `helm install --verify` and `helm verify` do **not** apply: they check a PGP

--- a/website/book/src/security.md
+++ b/website/book/src/security.md
@@ -426,16 +426,23 @@ and not verifiable. It is signed through Sigstore from this release on.
 
 > [!IMPORTANT]
 > Signing landed in the publishing lanes during the `3.17.4` cycle, so **`3.17.3`
-> and every earlier tag carry no attestation**: the commands below answer `no
-> attestations found` for them. That is the honest state, not a verification
+> and every earlier tag carry no attestation**: the commands below answer
+> `HTTP 404: Not Found` for them. That is the honest state, not a verification
 > failure — there is nothing to verify, because those artifacts were built before
-> the lane signed anything.
+> the lane signed anything. The development images
+> (`ghcr.io/rubentalstra/ferroehr:develop` and its two siblings) are signed and
+> verify now; the release-tag, release-binary and chart forms below start
+> answering at the `3.17.4` cut.
 
-**An image:**
+**An image** — signed and verifying today on the development tag:
 
 ```bash
-gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:3.17.4   -R rubentalstra/FerroEHR
+gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:develop -R rubentalstra/FerroEHR
 ```
+
+Add `--signer-workflow rubentalstra/FerroEHR/.github/workflows/containers.yml` to
+require the image lane specifically, not merely some workflow in this repository.
+On a release, substitute the `vX.Y.Z` tag for `develop`.
 
 **A release binary:**
 


### PR DESCRIPTION
Advances #2120 and #2085. Closes neither: two of #2120's criteria need artifacts that do not exist until the v3.17.4 tag, and #2085's last criterion needs a live admission run. Both are recorded honestly on their issues rather than ticked.

## The identity, and the bigger problem behind it

#2085 shipped Kyverno and `sigstore-policy-controller` policies labelled unverified, because a `--certificate-identity` that does not match what the lane issues fails closed on a legitimate image — worse than no policy. The identity is now read off a published image rather than inferred from the workflow files:

    https://github.com/rubentalstra/FerroEHR/.github/workflows/containers.yml@refs/tags/vX.Y.Z

Reconciling it turned up something the ref discussion had hidden. **Both policies were looking for a signature these images do not carry.** `push-to-registry: true` stores a Sigstore *bundle* as an OCI referrer — the fallback tag holds one manifest with `artifactType: application/vnd.dev.sigstore.bundle.v0.3+json`, and `.sig`/`.att` both 404 — while Kyverno's `type` field **defaults to `Cosign`**, which looks for a detached signature. As shipped, the Kyverno policy would have refused every image we build.

Corrected, with every field name checked against the published CRDs (`ClusterPolicy` v1.18.2, `ClusterImagePolicy` v0.15.1) rather than against blog examples:

- Kyverno: `type: SigstoreBundle` (≥ 1.13) with an `attestations:` block — its own constraint is that a `verifyImages` rule verifies signatures *or* attestations, never both, and the old policy used the signature branch.
- policy-controller: `signatureFormat: bundle` (≥ 0.13.0) with an `attestations[].predicateType` entry, since that mode supports attestations only.
- `failureAction` moves onto the `verifyImages` entry; the spec-level `validationFailureAction` is marked deprecated in the CRD.
- `subjectRegExp` rather than a wildcard `subject`, published as `@refs/(tags/v.+)$` — released images only — with the one-word edit a staging cluster needs spelled out beside it.

## Verified, and what could not be

cosign 3.1.3 running the exact regexes the chapter publishes:

| check | result |
|---|---|
| production regex vs the `develop` digest | refused — correct, it is a tags-only policy |
| staging regex vs `develop`, all three images | admitted |
| `verify-attestation --type https://slsa.dev/provenance/v1` | admitted |
| staging regex vs pre-signing `sha-f81d2c2` | refused, "no signatures found" |
| staging regex vs upstream `postgres:18.4` | refused, "no signatures found" |

**No live admission run** — no cluster is reachable. The chapter says so, and records why the obvious substitute does not count: `kyverno test --registry` reports the `verifyImages` rule as `Excluded` and returns "1 tests passed" *whichever* result you assert (inverting pass to fail still passed), and `kyverno apply --registry` produces zero results. Operators are told to start in Audit/warn.

## Verification commands that answer

The three `:develop` images verify today, and `--signer-workflow` is now shown as the way to pin the specific publishing lane rather than any workflow in the repository. The chart and release-binary forms are marked as starting at the 3.17.4 cut instead of being demonstrated against a tag that returns HTTP 404, and the stale "no published artifact carries an attestation" warning is replaced by a narrower note about the one thing still unproven.

## Second commit: a stale generated document

`docs/conformance/COMPARISON.md` reported the run dates of the runs *before* the last conformance cycle — 2026-08-05 and 2026-07-28, when both `results.json` files record 2026-08-07. Commit `6ffd14ed6` updated both result sets without re-running the renderer, and nothing catches that: `docs.yml` diff-guards the perf and conformance assets but not this file. Regenerated from the committed artifacts. The missing gate is #2150.

## Deliberately left alone

`deploy/helm/ferroehr/README.md.gotmpl` states unconditionally that the chart and images carry Sigstore-signed provenance, and in the develop tree its commands render against artifacts that 404. It is packaged chart content, so a caveat costs a `Chart.yaml` version bump under `chart-version-guard` — and the sentence becomes true at the cut, since the versions are templated and no *published* chart ever carries a false command. Churning the chart version to caveat a statement only ever shipped when accurate is the wrong trade. Recorded on #2120.

## Also corrected on #2120

The issue's own log reading was wrong twice. `digest-mismatch: error` is an `actions/download-artifact` **input echo**, not an error — there was no second cause. And the 403 was a **GitHub secondary rate limit** surfaced through GHCR's generic registry error mapping (the body says so, with a `documentation_url` to the secondary-rate-limit docs); auth had already succeeded, the admin-ui lane pushed fine nine minutes later with the same token, and attempt 2 replayed the identical commit against the identical workflow and succeeded. Transient, with the evidence rather than as a default.

## En-route issues filed

- **#2149** — `containers.yml` and `publish-chart.yml` both fire on `v*`, so the chart's acceptance gate pulls the image tag the other lane is still publishing.
- **#2150** — `COMPARISON.md` is generated but ungated, which is why the staleness above went unnoticed.

## Gates

- `bash deploy/helm/validate.sh` — ALL CHECKS PASSED (goldens unchanged; no chart file touched)
- `mdbook-lint lint website/book/src` — exit 0, 0 errors (pre-existing warning count unchanged)
- `bash scripts/site/build.sh --dev-only` — exit 0
- `lychee` on the three rebuilt pages — 225 OK, 0 errors in this diff
- No cargo run: nothing here is Rust.
