### PR TITLE
refactor(openehr-query): the AQL parser reports a typed error, not a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,16 @@ workflow refuses a tag that has no matching section here.
 
 ### Changed
 
+- **The AQL parser reports a typed error instead of a string.**
+  `openehr_query::parser::parse_str` and `parse` now return `ParseError`, which
+  separates a lexing refusal — carrying the lexer's own error as a real
+  `source()`, so the cause chain is walkable — from a grammar refusal, which
+  carries every position the parser reported along with the token found there.
+  A caller can finally branch on *which pass* refused without matching a
+  substring. The message text is unchanged, so the `400` body for an invalid
+  query reads exactly as before and no wire behaviour moves. The published
+  crate also no longer exposes `chumsky`'s error type in its public API.
+
 - The Kubernetes hardening chapter's image-provenance admission policies now
   carry the certificate identity the publishing lanes actually issue — read off a
   published image rather than inferred from the workflow files — and both are

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5589,7 +5589,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "indexmap 2.14.0",
  "openehr-am",
@@ -5604,7 +5604,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -5614,7 +5614,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "serde",
  "serde_json",
@@ -5633,7 +5633,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "async-trait",
  "axum",
@@ -5662,7 +5662,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "assert_fs",
  "chumsky",
@@ -5676,7 +5676,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "chumsky",
  "logos",
@@ -5685,7 +5685,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "insta",
  "jsonschema",
@@ -5702,7 +5702,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/app/ferroehr-admin-ui/src/builder/lift.rs
+++ b/app/ferroehr-admin-ui/src/builder/lift.rs
@@ -118,10 +118,12 @@ pub fn from_aql(aql: &str) -> Result<BuilderQuery, LiftError> {
     if !crate::aql_text::placeholders(aql).is_empty() {
         return Err(LiftError::Parameterised);
     }
-    let parsed = openehr_query::parser::parse_str(aql).map_err(LiftError::NotAql)?;
+    let parsed =
+        openehr_query::parser::parse_str(aql).map_err(|e| LiftError::NotAql(e.to_string()))?;
     let lifted = lift_query(&parsed)?;
     let relowered = crate::builder::lower::to_aql(&lifted).map_err(LiftError::Invalid)?;
-    let reparsed = openehr_query::parser::parse_str(&relowered).map_err(LiftError::NotAql)?;
+    let reparsed = openehr_query::parser::parse_str(&relowered)
+        .map_err(|e| LiftError::NotAql(e.to_string()))?;
     if reparsed == parsed {
         Ok(lifted)
     } else {

--- a/app/ferroehr-admin-ui/src/builder/lower.rs
+++ b/app/ferroehr-admin-ui/src/builder/lower.rs
@@ -381,7 +381,7 @@ fn parse_path_rooted(rooted: &str) -> Result<IdentifiedPath, BuilderError> {
     let parsed =
         openehr_query::parser::parse_str(&probe).map_err(|e| BuilderError::InvalidPath {
             path: rooted.to_owned(),
-            detail: e,
+            detail: e.to_string(),
         })?;
     match parsed.select.columns.into_iter().next() {
         Some(SelectExpr {

--- a/app/ferroehr-admin-ui/src/queries_api.rs
+++ b/app/ferroehr-admin-ui/src/queries_api.rs
@@ -46,7 +46,7 @@ pub async fn validate_aql(
     crate::session::require_session().await?;
     openehr_query::parser::parse_str(&aql)
         .map(|_| ())
-        .map_err(AdminUiError::Invalid)
+        .map_err(|e| AdminUiError::Invalid(e.to_string()))
 }
 
 /// Run ad-hoc AQL via `POST query/aql` with parameter bindings (a JSON
@@ -249,7 +249,7 @@ pub async fn store_query(
              query; leave the field empty to let the server assign the version."
         )));
     }
-    openehr_query::parser::parse_str(&aql).map_err(AdminUiError::Invalid)?;
+    openehr_query::parser::parse_str(&aql).map_err(|e| AdminUiError::Invalid(e.to_string()))?;
     let state: crate::state::AppState = leptos::prelude::expect_context();
     let path = match version.as_deref() {
         Some(version) => format!(

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-adl"
-version = "0.0.13"
+version = "0.0.14"
 description = "openEHR ADL 2.4.0: hand-written ADL2/cADL/ODIN parser, AOM2 validation catalogue, specialisation flattener, OPT2 generator, and ADL 1.4→2 conversion over the generated openehr_am::v2_4::aom2 model"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,10 +16,10 @@ include = ["src/**", "README.md", "LICENSE-MIT"]
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)
-openehr-base = { path = "../openehr-base", version = "0.0.13" }   # VersionStatus for the parsed HRID
-openehr-am = { path = "../openehr-am", version = "0.0.13" }       # v2_4 ArchetypeHrid (the identification target type)
-openehr-rm = { path = "../openehr-rm", version = "0.0.13" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
-openehr-lang = { path = "../openehr-lang", version = "0.0.13" }   # openehr_lang::odin — the ODIN section parser
+openehr-base = { path = "../openehr-base", version = "0.0.14" }   # VersionStatus for the parsed HRID
+openehr-am = { path = "../openehr-am", version = "0.0.14" }       # v2_4 ArchetypeHrid (the identification target type)
+openehr-rm = { path = "../openehr-rm", version = "0.0.14" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
+openehr-lang = { path = "../openehr-lang", version = "0.0.14" }   # openehr_lang::odin — the ODIN section parser
 uuid.workspace = true        # meta uid/build_uid (AUTHORED_ARCHETYPE.uid: Uuid)
 indexmap.workspace = true    # OdinValue::Object body (insertion-ordered map)
 

--- a/crates/openehr-am/Cargo.toml
+++ b/crates/openehr-am/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-am"
-version = "0.0.13"
+version = "0.0.14"
 description = "openEHR AM Archetype Model, generated from BMM: generations v1_4 (AM 1.4.0, ADL 1.4) and v2_4 (AM 2.4.0, ADL 2; current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,8 +13,8 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.13" }
-openehr-lang = { path = "../openehr-lang", version = "0.0.13" }
+openehr-base = { path = "../openehr-base", version = "0.0.14" }
+openehr-lang = { path = "../openehr-lang", version = "0.0.14" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also carries the untyped `Value` fields the generator

--- a/crates/openehr-base/Cargo.toml
+++ b/crates/openehr-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-base"
-version = "0.0.13"
+version = "0.0.14"
 description = "openEHR BASE foundation + base types, generated from BMM: generations v1_2 (BASE 1.2.0) and v1_3 (BASE 1.3.0, current)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-its"
-version = "0.0.13"
+version = "0.0.14"
 description = "openEHR ITS (Implementation Technology Specifications): canonical JSON + canonical XML serialization of the RM, the generated ITS-REST 1.1.0 API contract, OPT 1.4 and AOM2 archetype XML codecs, and the Simplified Formats (FLAT / STRUCTURED / Web Template)"
 edition.workspace = true
 rust-version.workspace = true
@@ -41,14 +41,14 @@ regex = { workspace = true, optional = true }
 fancy-regex = { workspace = true, optional = true }
 # The generated XML (de)serializers impl the crate's ToXml/FromXml traits for the
 # RM/BASE spec types, so these are real (non-dev) deps.
-openehr-base = { path = "../openehr-base", version = "0.0.13", optional = true }
-openehr-rm = { path = "../openehr-rm", version = "0.0.13", optional = true }
+openehr-base = { path = "../openehr-base", version = "0.0.14", optional = true }
+openehr-rm = { path = "../openehr-rm", version = "0.0.14", optional = true }
 # The native canonical-JSON codec (`json_codec/generated`, emit-json) implements
 # `ToJson` for EVERY generated spec type the `OpenEhrType` derive covers, so it
 # spans all five spec crates (not just the RM/BASE the XML codec needs).
-openehr-lang = { path = "../openehr-lang", version = "0.0.13", optional = true }
-openehr-am = { path = "../openehr-am", version = "0.0.13", optional = true }
-openehr-term = { path = "../openehr-term", version = "0.0.13", optional = true }
+openehr-lang = { path = "../openehr-lang", version = "0.0.14", optional = true }
+openehr-am = { path = "../openehr-am", version = "0.0.14", optional = true }
+openehr-term = { path = "../openehr-term", version = "0.0.14", optional = true }
 
 # `full` — every ITS surface (canonical JSON/XML, the generated ITS-REST
 # contract, `opt14`, Simplified Formats). ON BY DEFAULT, so every consumer sees

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-lang"
-version = "0.0.13"
+version = "0.0.14"
 description = "openEHR LANG BMM/P_BMM object model, generated from BMM: generations v1_0 (LANG 1.0.0) and v1_1 (LANG 1.1.0, current; the stable BMM v2.x unit beside the paused BMM3 unit), plus hand-written ODIN/BEL/EL readers"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["parser-implementations", "data-structures"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.13" }
+openehr-base = { path = "../openehr-base", version = "0.0.14" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the
 # generated types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) —
 # never a derive. `serde_json` also carries the untyped `Value` fields the

--- a/crates/openehr-query/Cargo.toml
+++ b/crates/openehr-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-query"
-version = "0.0.13"
+version = "0.0.14"
 description = "openEHR QUERY (AQL 1.1.0): hand-written lexer, parser, typed AST and canonical printer from the official grammar (no ANTLR runtime)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-query/README.md
+++ b/crates/openehr-query/README.md
@@ -10,7 +10,11 @@ ANTLR runtime.
   `FROM`/`CONTAINS`, `WHERE`, `ORDER BY`, `LIMIT`, path expressions with
   predicates, parameters, functions), corpus-validated against the official
   grammar's example set.
-- Typed parse errors with source positions — a refusal names what and where.
+- Typed parse errors: `ParseError` separates a lexing refusal (carrying the
+  lexer's error as a real `source()`) from a grammar refusal (carrying every
+  position the parser reported, as token-stream indices), so a caller branches
+  on the failure instead of reading its message. `Display` is the located
+  diagnostic to show a human.
 - `printer::to_aql` — canonical AQL rendering of the AST, the parser's
   inverse, for programmatic query construction (corpus-verified fixed point:
   `parse(to_aql(ast)) == ast`).

--- a/crates/openehr-query/src/parser.rs
+++ b/crates/openehr-query/src/parser.rs
@@ -33,30 +33,77 @@ use chumsky::prelude::*;
 )]
 type Err<'a> = chumsky::extra::Err<Simple<'a, Token>>;
 
+/// One position at which the token stream left the grammar.
+///
+/// The position is an index into the TOKEN stream, not a byte offset into the
+/// source: the parser's input is [`crate::lexer::lex`]'s output, so a caller
+/// that needs a source location maps the index back through the token stream
+/// it lexed.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SyntaxFault {
+    /// The half-open range of token indices the parser was looking at.
+    pub tokens: core::ops::Range<usize>,
+    /// The token found there, or `None` when the input ended early.
+    pub found: Option<Token>,
+}
+
+impl std::fmt::Display for SyntaxFault {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.found {
+            Some(token) => write!(f, "found '{token:?}' at {:?}", self.tokens),
+            None => write!(f, "found end of input at {:?}", self.tokens),
+        }
+    }
+}
+
+/// Why an AQL source failed to become a [`SelectQuery`].
+///
+/// The two variants are the two passes, so a caller branches on the pass that
+/// refused rather than reading the message. Semantic rejections — an unknown
+/// archetype path, an unsupported construct — are NOT here: this crate stops
+/// at the AST, and those are typed errors of the engine that consumes it.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum ParseError {
+    /// The source did not tokenize.
+    // NOTE: `#[error("{0}")]` and not `transparent`, which forwards `source()`
+    // to the inner error and so erases the lex error from the cause chain
+    // (<https://docs.rs/thiserror/latest/thiserror/derive.Error.html>).
+    #[error("{0}")]
+    Lex(#[from] crate::lexer::LexError),
+    /// The tokens did not match the grammar.
+    #[error("{}", faults.iter().map(ToString::to_string).collect::<Vec<_>>().join("; "))]
+    Syntax {
+        /// Every position the parser reported, in report order.
+        faults: Vec<SyntaxFault>,
+    },
+}
+
 /// Parse a token slice into a [`SelectQuery`].
 ///
 /// # Errors
-/// Returns a list of [`Simple`] parse errors (with token spans) on failure.
-pub fn parse(tokens: &[Token]) -> Result<SelectQuery, Vec<Simple<'_, Token>>> {
-    query().parse(tokens).into_result()
+/// [`ParseError::Syntax`], carrying every token position the parser reported.
+pub fn parse(tokens: &[Token]) -> Result<SelectQuery, ParseError> {
+    query().parse(tokens).into_result().map_err(|errs| {
+        let faults = errs
+            .iter()
+            .map(|e: &Simple<'_, Token>| SyntaxFault {
+                tokens: e.span().into_range(),
+                found: e.found().cloned(),
+            })
+            .collect();
+        ParseError::Syntax { faults }
+    })
 }
 
 /// Lex then parse `src` in one step.
 ///
 /// # Errors
-/// Returns a human-readable message on a lex or parse failure.
-///
-/// NOTE: the lexer and parser diagnostics stay flattened into that message
-/// rather than carried as a source (RFC 0201) — a positional AQL diagnostic IS
-/// the answer, and `chumsky`'s error type is deliberately not in this API.
-pub fn parse_str(src: &str) -> Result<SelectQuery, String> {
-    let tokens = crate::lexer::lex(src).map_err(|e| e.to_string())?;
-    parse(&tokens).map_err(|errs| {
-        errs.iter()
-            .map(ToString::to_string)
-            .collect::<Vec<_>>()
-            .join("; ")
-    })
+/// [`ParseError::Lex`] if the source does not tokenize, otherwise
+/// [`ParseError::Syntax`]. Its `Display` is the located diagnostic a client
+/// should see; its variant is what a caller branches on.
+pub fn parse_str(src: &str) -> Result<SelectQuery, ParseError> {
+    let tokens = crate::lexer::lex(src)?;
+    parse(&tokens)
 }
 
 // ── leaf parsers ─────────────────────────────────────────────────────────────

--- a/crates/openehr-query/tests/it/corpus.rs
+++ b/crates/openehr-query/tests/it/corpus.rs
@@ -136,7 +136,7 @@ fn official_aql_corpus_parses() {
                         )),
                     }
                 }
-                Err(e) => failures.push((query, e)),
+                Err(e) => failures.push((query, e.to_string())),
             }
         }
     }

--- a/crates/openehr-query/tests/it/main.rs
+++ b/crates/openehr-query/tests/it/main.rs
@@ -5,4 +5,5 @@
 //! (`.claude/rules/testing.md` §One integration-test binary per crate).
 
 mod corpus;
+mod parse_errors;
 mod printer_round_trip;

--- a/crates/openehr-query/tests/it/parse_errors.rs
+++ b/crates/openehr-query/tests/it/parse_errors.rs
@@ -1,0 +1,74 @@
+//! The parser's error contract: a caller branches on the failure, and reads
+//! the located diagnostic only to show it to a human.
+
+use openehr_query::lexer::LexError;
+use openehr_query::parser::{ParseError, SyntaxFault, parse_str};
+
+/// A lex failure and a syntax failure are DIFFERENT variants, so telling them
+/// apart never means matching a substring — the property the typed error
+/// exists for.
+#[test]
+fn the_two_passes_are_distinguishable_without_reading_the_message() {
+    // `#` is in no AQL token, so the lexer refuses before the parser runs.
+    let lexed = parse_str("SELECT # FROM EHR e").expect_err("`#` lexes as nothing");
+    assert!(
+        matches!(lexed, ParseError::Lex(_)),
+        "a character outside every token is a lex failure, got {lexed:?}"
+    );
+
+    // Every token here is valid AQL; the sequence is not.
+    let syntax = parse_str("SELECT FROM WHERE").expect_err("keywords in that order are no query");
+    assert!(
+        matches!(syntax, ParseError::Syntax { .. }),
+        "well-formed tokens in an invalid order are a syntax failure, got {syntax:?}"
+    );
+}
+
+/// The lex variant carries the lexer's own error as its `source`, so the cause
+/// chain is walkable rather than flattened into text (RFC 0201).
+#[test]
+fn a_lex_failure_carries_the_lexer_error_as_its_source() {
+    let err = parse_str("SELECT # FROM EHR e").expect_err("`#` lexes as nothing");
+    let source = std::error::Error::source(&err).expect("the lex variant carries its cause");
+    let lex: &LexError = source
+        .downcast_ref()
+        .expect("and that cause is the lexer's own error type");
+    assert_eq!(lex.slice, "#", "the offending slice survives the hop");
+
+    // Display is unchanged by the wrapping: the message a client sees is still
+    // the lexer's located diagnostic verbatim.
+    assert_eq!(err.to_string(), lex.to_string());
+}
+
+/// A syntax failure carries the position and the token found, so a caller can
+/// act on WHERE the query broke instead of parsing a sentence.
+#[test]
+fn a_syntax_failure_carries_its_position_and_the_token_found() {
+    let err = parse_str("SELECT FROM WHERE").expect_err("keywords in that order are no query");
+    let ParseError::Syntax { faults } = err else {
+        panic!("expected a syntax failure, got {err:?}");
+    };
+    let SyntaxFault { tokens, found } = faults.first().expect("at least one reported position");
+    assert!(
+        tokens.start < tokens.end,
+        "the reported token range is non-empty: {tokens:?}"
+    );
+    assert!(
+        found.is_some(),
+        "the input did not end early, so a token was found"
+    );
+}
+
+/// An empty source ends before any token, which the parser reports as a
+/// position with no token found rather than as a lex failure.
+#[test]
+fn end_of_input_is_reported_with_no_token_found() {
+    let err = parse_str("").expect_err("an empty source is not a query");
+    let ParseError::Syntax { faults } = err else {
+        panic!("an empty source lexes cleanly and fails the grammar, got {err:?}");
+    };
+    assert!(
+        faults.iter().any(|f| f.found.is_none()),
+        "the end-of-input position is reported: {faults:?}"
+    );
+}

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-rm"
-version = "0.0.13"
+version = "0.0.14"
 description = "openEHR RM Reference Model, generated from BMM: generations v1_1 (RM 1.1.0) and v1_2 (RM 1.2.0, current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,11 +13,11 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.13" }
+openehr-base = { path = "../openehr-base", version = "0.0.14" }
 # The terminology-backed RM class invariants (`validate::terminology`) resolve
 # openEHR terminology groups + code sets against the vendored TERM 3.1.0 bundle.
 # `openehr-term` itself depends only on `openehr-base`, so this is acyclic.
-openehr-term = { path = "../openehr-term", version = "0.0.13" }
+openehr-term = { path = "../openehr-term", version = "0.0.14" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also backs the untyped `Value` RM representation used by

--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-term"
-version = "0.0.13"
+version = "0.0.14"
 description = "openEHR TERM terminology data model, generated from BMM (generation v3_1 = TERM 3.1.0), plus the embedded official terminology XML bundle"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["data-structures", "science"]
 include = ["src/**", "assets/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.13" }
+openehr-base = { path = "../openehr-base", version = "0.0.14" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive.


### PR DESCRIPTION
Advances #2126. **Does not close it** — one criterion is deliberately left for after #2124 lands; details below.

`openehr_query::parser::parse_str` returned `Result<_, String>`, so no caller could branch on a parse failure without matching a substring, and `parse` leaked `chumsky`'s `Simple<'_, Token>` — lifetime and all — into a published crate's public API. Both now return a typed error.

```rust
pub enum ParseError {
    Lex(#[from] LexError),                  // #[error("{0}")]
    Syntax { faults: Vec<SyntaxFault> },
}

pub struct SyntaxFault {
    pub tokens: Range<usize>,
    pub found: Option<Token>,
}
```

**The failure kind is the enum, not a field.** Two variants for the two passes is the only distinction the parser can honestly draw, and the issue's own example deserves precision: "unknown archetype path" is deliberately *not* available here. This crate stops at the AST (`aql-engine.md`), so a path that parses but names nothing real is a typed rejection of the engine consuming the AST. What the parser knows is whether the bytes tokenized, whether the tokens matched the grammar, and where.

## The non-obvious part

`#[error(transparent)]` on the `Lex` variant looks exactly right — it forwards `Display` to the inner error, which is the message preservation this change needs. It also forwards `source()`, which means the `LexError` **disappears from the cause chain** rather than becoming a hop in it. The test caught it immediately: `source()` came back `None`. `#[error("{0}")]` with `#[from]` gives both properties, and a `// NOTE:` at the variant records it with the thiserror doc link.

## Wire text is unchanged by construction

`SyntaxFault`'s `Display` reproduces `Simple`'s rendering byte for byte — `found '<Token:?>' at <start>..<end>`, or `found end of input at …` — because `Range<usize>` and `SimpleSpan` both `Debug`-render as `start..end`. Every call site that interpolates the error compiles unchanged and emits the same string, so the AQL `400` body does not move. That is a documented surface, which is why it was worth getting exactly rather than approximately.

`Eq` is absent from both types on purpose: `Token` carries an `f64` for real literals, so it is `PartialEq` and not `Eq`, and a derived `Eq` would not compile.

## Call sites

The admin console's four sites render the error at a serde boundary — `AdminUiError`, `BuilderError` and `LiftError` all cross the server-fn wire and must stay `String`-carrying — which is a rendering, not a lost cause.

**The two `app/ferroehr` sites keep their current shape deliberately.** Whether they can carry `ParseError` as a real source depends on the error types #2124 is producing *in those same files right now*, so editing them from two directions would only produce a conflict. They compile unchanged in the meantime (they interpolate `Display`), so nothing is broken while this waits. That criterion stays unticked on #2126.

## Found en route

The crate README claimed "typed parse errors with **source** positions". The "typed" half was untrue before this change; the "source positions" half still is — the position is a token-stream index, because `lexer::lex` discards every byte span on the way out even though `logos` has it at every step (and `LexError` already carries one). The README now says token indices, and **#2145** tracks making the stronger claim real.

## Tests

Four, each pinning one property rather than restating the implementation: that the two passes are distinguishable by variant with no substring match; that a lex failure's `source()` downcasts to `LexError` and its `Display` is unchanged; that a syntax failure carries a non-empty token range and the token found; and that end-of-input is reported as a position with `found: None` rather than as a lex failure.

## Gates

- `cargo nextest run -p openehr-query` — 58 passed
- `cargo clippy -p openehr-query --all-targets --all-features -- -D warnings` — clean
- `cargo clippy -p ferroehr-admin-ui --all-targets --features ssr` and `--target wasm32-unknown-unknown --features hydrate` — both clean
- `cargo nextest run -p ferroehr-admin-ui` — 218 passed
- `cargo fmt --all` clean

Workspace-wide gates are not run here: `app/ferroehr/src/**` is mid-refactor under #2124 in the same tree, so a red workspace build would say nothing about this change. The crates this touches are green.

`no-ui-visual-change` is set: the console diff is three `.to_string()` calls and one test expectation, with no rendered output affected.

Packaged `crates/*` content changed, so all eight members and their internal version requirements move 0.0.13 → 0.0.14 in lockstep.
