### PR TITLE
chore(website): gate the book against documented keys that do not exist

### DIFF
--- a/.claude/rules/docs-website.md
+++ b/.claude/rules/docs-website.md
@@ -53,6 +53,41 @@ The `/phase-done` checklist enforces it at phase close.
 - Every endpoint, header, status code, and config key must be verified
   against the code or the vendored OAS before it is written down.
 
+## What a gate checks, and what only review can (#1984)
+
+The v3.17.4 book sweep found five substantive defects that had already shipped
+to the published site, and no gate had caught any of them: `mdbook-lint`
+checks style, `lychee` checks that links resolve, and both pass on a page
+whose every technical claim is false. Per the reliability convention that an
+unenforced rule is labelled as one, here is the honest split.
+
+**Machine-checked** — `scripts/checks/docs-claims.sh`, the `docs-claims` CI
+job, `--all` over the whole book:
+
+- Every `FERROEHR__…` environment form resolves to a key in
+  `app/ferroehr/assets/ferroehr.default.toml`.
+- Every Helm values path on a chart page resolves — against `values.yaml`, or
+  for `config.*` against the TOML schema, since the chart renders `config:`
+  verbatim into `ferroehr.toml`.
+- Every committed chart under a `*-assets/` directory is embedded by a page or
+  by an mdBook `{{#include}}` source.
+
+**Review-only, deliberately:**
+
+- **Documented Rust paths.** A grep-level existence check for `crate::a::b` /
+  `openehr_x::y::Z` was measured and rejected: prose names types under a
+  different module path than the sentence implies, and the generated crates'
+  generation modules give one type several valid paths. It found less than it
+  cried wolf about.
+- **Prose claims** — "six endpoints exist", "the chart renders one key",
+  behaviour descriptions of any kind. No machine authority exists for these,
+  which is exactly why the same-PR rule above still carries the weight.
+
+A guard is only worth having if it is trusted, so when `docs-claims` reports
+something, check whether the *guard* is wrong before editing the page: its
+first run reported a published chart as orphaned because it searched only
+`website/book/src` and the reference lived in `website/book/generated`.
+
 ## Never hand-edit
 
 - `website/api/spec/**` — produced by `scripts/site/assemble-oas.sh` from the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,28 @@ jobs:
       - name: Access-layer rationale cites durable sources
         run: bash scripts/checks/access-provenance.sh
 
+  # Docs-claim guard (#1984): a documented KEY must exist in the thing it
+  # documents. `mdbook-lint` checks style and `lychee` checks links; both pass on
+  # a page whose every technical claim is false, which is how a fabricated Helm
+  # values table reached the published site. `--all` from the start: the three
+  # defects this found on its first run are fixed in the same change, so the
+  # corpus is clean. What it deliberately does NOT check is recorded in the
+  # script's header and in `.claude/rules/docs-website.md`.
+  docs-claims:
+    name: docs-claims
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Documented keys resolve in their source
+        run: bash scripts/checks/docs-claims.sh --all
+
   # String-built-SQL guard: the AQL engine composes SQL from attacker-supplied
   # query text, so a `format!`/`push_str`-assembled clause in `app/ferroehr/src/
   # aql/` or `app/ferroehr/src/storage/` is refused — the OWASP SQL Injection
@@ -1391,6 +1413,7 @@ jobs:
       - workflow-audit
       - comment-style
       - default-style
+      - docs-claims
       - sql-string-building
       - error-hygiene
       - deny

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
+- **The Helm chart can deploy by digest.** `image.digest` renders the pod's
+  image as `repository@sha256:…` and takes precedence over `image.tag`. The
+  hardening chapter had been telling operators to deploy by digest "so what you
+  verified is what runs" — and the chart had no such key and no template that
+  read one, so the instruction silently did nothing. A digest is what a build
+  provenance attestation is made over, so this is what makes verification bind
+  to the image actually running. The value is accepted with or without the
+  `sha256:` prefix.
+
 - The [OpenSSF Best Practices badge](https://www.bestpractices.dev/projects/13982) at
   the passing level, alongside the Scorecard badge in the README. Every
   criterion is answered from something a reader can check — the vulnerability
@@ -232,6 +241,12 @@ workflow refuses a tag that has no matching section here.
 
 
 ### Fixed
+
+- `auth.oidc.hmac_secret_file` and `auth.oidc.jwks_json_file` now appear as
+  their own reference lines in the shipped `ferroehr.toml` template, so
+  `ferroehr config default` teaches them. Both were real configuration keys
+  mentioned only inside a trailing comment on another key's line, in a file
+  whose header calls itself the complete server configuration.
 
 - Documented `gh attestation verify` invocations no longer promise a result on
   the Helm chart or on `3.17.3`: no chart version has been published, and signing

--- a/app/ferroehr/assets/ferroehr.default.toml
+++ b/app/ferroehr/assets/ferroehr.default.toml
@@ -188,8 +188,10 @@ verified_cache_ttl_seconds = 60
 # and never a memorizable password (RFC 8725 §3.5). A development posture: the
 # key is shared with the authorization server, so this server could mint the
 # tokens it accepts. Boot warns when it is set.
-#? hmac_secret = "..."            # or hmac_secret_file = "/run/secrets/hmac"
-#? jwks_json = "{...}"            # or jwks_json_file = "/etc/ferroehr/jwks.json"
+#? hmac_secret = "..."
+#? hmac_secret_file = "/run/secrets/hmac"
+#? jwks_json = "{...}"
+#? jwks_json_file = "/etc/ferroehr/jwks.json"
 # Discovery/JWKS fetch hardening (used only when neither hmac_secret nor
 # jwks_json is set, i.e. keys come from the issuer's OIDC discovery document):
 #? connect_timeout_ms = 3000

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # (https://helm.sh/docs/topics/charts/#charts-and-versioning). 4.0.0 is a major
 # bump because a values file that set a secret-bearing key under `config:` used
 # to render (into a ConfigMap) and is now refused.
-version: 4.0.0
+version: 4.1.0
 # The default container image tag (overridable via image.tag), and the released
 # application version — kept equal to the workspace version by the
 # `chart-appversion` CI guard, so a release cannot ship a chart pointing at the

--- a/deploy/helm/ferroehr/README.md
+++ b/deploy/helm/ferroehr/README.md
@@ -2,7 +2,7 @@
 
 Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.1.0 + AQL 1.1). A single static binary deployed with a hardened-by-default security posture: runs as a non-root, read-only-rootfs, default-deny-ingress workload that connects to an EXTERNAL PostgreSQL 18 as an unprivileged app role (migrations are run out of band by a separate migrator role).
 
-![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.17.3](https://img.shields.io/badge/AppVersion-3.17.3-informational?style=flat-square)
+![Version: 4.1.0](https://img.shields.io/badge/Version-4.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.17.3](https://img.shields.io/badge/AppVersion-3.17.3-informational?style=flat-square)
 
 FerroEHR is a pure-Rust openEHR Clinical Data Repository: ITS-REST 1.1.0 at the
 API, AQL 1.1 as the query language, PostgreSQL 18-native storage, shipped as a
@@ -33,7 +33,7 @@ add — `helm repo add` does not apply to this chart and never will:
 
 ```console
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 4.0.0 \
+  --version 4.1.0 \
   --namespace ferroehr --create-namespace \
   --set database.existingSecret=ferroehr-db \
   --set image.tag=3.17.3
@@ -47,7 +47,7 @@ They are independent SemVer lines and they move independently:
 
 | What | Set with | This release |
 |---|---|---|
-| the **chart** (templates, defaults, this document) | `--version` | `4.0.0` |
+| the **chart** (templates, defaults, this document) | `--version` | `4.1.0` |
 | the **server image** | `image.tag` | `3.17.3` |
 
 `appVersion` is the image the chart defaults to; pinning `image.tag` explicitly
@@ -58,7 +58,7 @@ is what keeps an upgrade of one from silently moving the other.
 Both the chart and the images carry Sigstore-signed build provenance:
 
 ```console
-gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:4.0.0 \
+gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:4.1.0 \
   -R rubentalstra/FerroEHR
 gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:3.17.3 \
   -R rubentalstra/FerroEHR
@@ -190,9 +190,10 @@ Kubernetes: `>=1.25.0-0`
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` | Extra volumes / volumeMounts (e.g. an external secret store for the PGP key). |
 | fullnameOverride | string | `""` | Override the full resource name. |
+| image.digest | string | `""` | Image digest (`sha256:…`). Set it and the pod runs `repository@digest`, ignoring `tag` entirely: a digest is what the provenance attestation is made over, so deploying by digest is what makes verification bind to the running image. A tag can be moved afterwards; a digest cannot. |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy. IfNotPresent + an immutable pinned tag/digest in production. |
 | image.repository | string | `"ghcr.io/rubentalstra/ferroehr"` | Image repository. Multi-arch distroless (gcr.io/distroless/cc-debian12:nonroot base). |
-| image.tag | string | `""` | Image tag. Empty string falls back to .Chart.appVersion. PIN a version or, better, a @sha256 digest in production (never `latest`). |
+| image.tag | string | `""` | Image tag. Empty string falls back to .Chart.appVersion. Pin a version in production, never `latest` — and prefer `digest` below, which a tag cannot be substituted for once it is set. |
 | imagePullSecrets | list | `[]` | imagePullSecrets for private registries. |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |

--- a/deploy/helm/ferroehr/templates/_helpers.tpl
+++ b/deploy/helm/ferroehr/templates/_helpers.tpl
@@ -75,6 +75,28 @@ never on this port-selection path: they are always served on the main HTTP port.
 {{- end }}
 
 {{/*
+The container image reference.
+
+A digest wins over a tag, and the separator differs: `repository@sha256:…` versus
+`repository:tag`. A digest is what a build-provenance attestation is made over, so
+deploying by digest is what makes `gh attestation verify` bind to the image that
+is actually running — a tag can be moved after it is verified.
+
+`sha256:` is accepted with or without the prefix, because both spellings are in
+circulation and the one-character difference between them is an unhelpful way to
+fail a deployment.
+*/}}
+{{- define "ferroehr.image" -}}
+{{- if .Values.image.digest }}
+{{- $digest := .Values.image.digest }}
+{{- if not (hasPrefix "sha256:" $digest) }}{{- $digest = printf "sha256:%s" $digest }}{{- end }}
+{{- printf "%s@%s" .Values.image.repository $digest }}
+{{- else }}
+{{- printf "%s:%s" .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) }}
+{{- end }}
+{{- end }}
+
+{{/*
 The chart-managed Secret name (env-borne secrets: DB DSN, passphrases, keys).
 */}}
 {{- define "ferroehr.secretName" -}}

--- a/deploy/helm/ferroehr/templates/deployment.yaml
+++ b/deploy/helm/ferroehr/templates/deployment.yaml
@@ -58,7 +58,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: ferroehr
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "ferroehr.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/deploy/helm/ferroehr/values.yaml
+++ b/deploy/helm/ferroehr/values.yaml
@@ -60,9 +60,15 @@ image:
   repository: ghcr.io/rubentalstra/ferroehr
   # -- Pull policy. IfNotPresent + an immutable pinned tag/digest in production.
   pullPolicy: IfNotPresent
-  # -- Image tag. Empty string falls back to .Chart.appVersion. PIN a version
-  # or, better, a @sha256 digest in production (never `latest`).
+  # -- Image tag. Empty string falls back to .Chart.appVersion. Pin a version in
+  # production, never `latest` — and prefer `digest` below, which a tag cannot be
+  # substituted for once it is set.
   tag: ""
+  # -- Image digest (`sha256:…`). Set it and the pod runs `repository@digest`,
+  # ignoring `tag` entirely: a digest is what the provenance attestation is made
+  # over, so deploying by digest is what makes verification bind to the running
+  # image. A tag can be moved afterwards; a digest cannot.
+  digest: ""
 
 # -- imagePullSecrets for private registries.
 imagePullSecrets: []

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -12,7 +12,7 @@ kind: NetworkPolicy
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.0.0
+    helm.sh/chart: ferroehr-4.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -82,7 +82,7 @@ kind: PodDisruptionBudget
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.0.0
+    helm.sh/chart: ferroehr-4.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -101,7 +101,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.0.0
+    helm.sh/chart: ferroehr-4.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -132,7 +132,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-4.0.0
+    helm.sh/chart: ferroehr-4.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -158,7 +158,7 @@ kind: Secret
 metadata:
   name: ferroehr-config
   labels:
-    helm.sh/chart: ferroehr-4.0.0
+    helm.sh/chart: ferroehr-4.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -177,7 +177,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.0.0
+    helm.sh/chart: ferroehr-4.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -355,7 +355,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.0.0
+    helm.sh/chart: ferroehr-4.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -382,7 +382,7 @@ kind: Deployment
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.0.0
+    helm.sh/chart: ferroehr-4.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -585,7 +585,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.0.0
+    helm.sh/chart: ferroehr-4.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -618,7 +618,7 @@ kind: Ingress
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.0.0
+    helm.sh/chart: ferroehr-4.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -655,7 +655,7 @@ kind: ServiceMonitor
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.0.0
+    helm.sh/chart: ferroehr-4.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"

--- a/deploy/helm/golden/basic-auth.yaml
+++ b/deploy/helm/golden/basic-auth.yaml
@@ -12,7 +12,7 @@ kind: NetworkPolicy
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.0.0
+    helm.sh/chart: ferroehr-4.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -36,7 +36,7 @@ kind: PodDisruptionBudget
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.0.0
+    helm.sh/chart: ferroehr-4.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -55,7 +55,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.0.0
+    helm.sh/chart: ferroehr-4.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -84,7 +84,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-4.0.0
+    helm.sh/chart: ferroehr-4.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -100,7 +100,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.0.0
+    helm.sh/chart: ferroehr-4.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -227,7 +227,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.0.0
+    helm.sh/chart: ferroehr-4.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -250,7 +250,7 @@ kind: Deployment
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.0.0
+    helm.sh/chart: ferroehr-4.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -12,7 +12,7 @@ kind: NetworkPolicy
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.0.0
+    helm.sh/chart: ferroehr-4.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -36,7 +36,7 @@ kind: PodDisruptionBudget
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.0.0
+    helm.sh/chart: ferroehr-4.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -55,7 +55,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.0.0
+    helm.sh/chart: ferroehr-4.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -69,7 +69,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.0.0
+    helm.sh/chart: ferroehr-4.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -190,7 +190,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.0.0
+    helm.sh/chart: ferroehr-4.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -213,7 +213,7 @@ kind: Deployment
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.0.0
+    helm.sh/chart: ferroehr-4.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"

--- a/scripts/checks/docs-claims.sh
+++ b/scripts/checks/docs-claims.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# Docs-claim guard: a documented KEY must exist in the thing it documents.
+#
+# The v3.17.4 book sweep found five substantive defects that had shipped to the
+# published site — a fabricated Helm values table, a page asserting endpoints did
+# not exist when six did, a `SPEC_VERSION` constant taught for crates that have
+# none. None was caught by a gate: `mdbook-lint` checks style, `lychee` checks
+# link reachability, and both pass happily on a page whose every technical claim
+# is false. The same-PR docs rule depended entirely on an author noticing.
+#
+# This guard checks the claims that have a machine-readable authority to check
+# against, and nothing else. Three of them:
+#
+#   1. Every `FERROEHR__…` environment form a page shows resolves to a real key
+#      in `app/ferroehr/assets/ferroehr.default.toml`.
+#   2. Every Helm values path a chart page shows resolves — against
+#      `values.yaml`, or for the `config.*` subtree against the TOML schema,
+#      because the chart renders `config:` VERBATIM to ferroehr.toml (so
+#      `config.<any-toml-path>` is legitimate whether or not values.yaml
+#      enumerates it, and the one non-TOML child, `config.files`, resolves in
+#      values.yaml instead).
+#   3. Every committed generated chart under a `*-assets/` directory is embedded
+#      by some page. An unreferenced chart is either a page that lost its figure
+#      or a renderer emitting output nobody reads.
+#
+# What is NOT checked, and why — an unenforced rule is labelled as such
+# (`.claude/rules/reliability.md`):
+#
+#   * **Documented Rust paths.** A grep-level existence check for
+#     `crate::a::b` / `openehr_x::y::Z` was measured and rejected: prose names
+#     types that exist under a different module path than the sentence implies,
+#     and the generated crates' generation modules mean one type has several
+#     valid paths. It produced more false positives than findings. Review-only.
+#   * **Prose claims of any kind** — "six endpoints exist", "the chart renders
+#     one key" — have no machine authority. Review-only, and the reason the
+#     same-PR docs rule still matters.
+#
+# Scope note on check 2: the values vocabulary is only in scope on pages that
+# document the chart. `configuration.md` legitimately writes
+# `` `service.name` `` for the OpenTelemetry resource attribute, which collides
+# with the chart's top-level `service:` key and is not a values path at all.
+# Widening the check to every page turns that into a false failure, so the check
+# reads the chart pages and the chart pages only.
+#
+# Usage: scripts/checks/docs-claims.sh [--all | <file>...]
+#   no args  → the book files changed against origin/develop
+#   --all    → every tracked book page
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+BOOK=website/book/src
+TOML=app/ferroehr/assets/ferroehr.default.toml
+VALUES=deploy/helm/ferroehr/values.yaml
+# The pages that document the Helm chart, and therefore the only pages on which a
+# dotted token is read as a chart values path.
+CHART_PAGES="$BOOK/installation/kubernetes.md $BOOK/installation/kubernetes-hardening.md"
+
+for required in "$TOML" "$VALUES"; do
+  [ -f "$required" ] || { echo "docs-claims: missing authority file $required" >&2; exit 1; }
+done
+
+collect() {
+  if [ "${1:-}" = "--all" ]; then
+    git ls-files "$BOOK/**/*.md" "$BOOK/*.md"
+  elif [ "$#" -gt 0 ]; then
+    printf '%s\n' "$@"
+  else
+    git diff --name-only origin/develop...HEAD -- "$BOOK/*.md" "$BOOK/**/*.md" 2>/dev/null \
+      || git ls-files "$BOOK/**/*.md" "$BOOK/*.md"
+  fi
+}
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# ── the authorities ──────────────────────────────────────────────────────────
+
+# Every TOML path, plus every ancestor table (a page may document `[audit]` as
+# `config.audit`). A `#?` line documents a real optional/secret/derived key and
+# counts; a plain `#` comment does not.
+toml_paths() {
+  awk '
+    { line = $0
+      sub(/^[[:space:]]*/, "", line)
+      if (line ~ /^#\?[[:space:]]*/) sub(/^#\?[[:space:]]*/, "", line)
+      else if (line ~ /^#/) next
+      if (line ~ /^\[\[?[A-Za-z0-9_.]+\]\]?/) { sec = line; gsub(/^\[\[?|\]\]?.*$/, "", sec); next }
+      if (line ~ /^[A-Za-z0-9_]+[[:space:]]*=/) {
+        k = line; sub(/[[:space:]]*=.*$/, "", k)
+        path = (sec == "" ? k : sec "." k)
+        print path
+        n = split(path, seg, ".")
+        acc = seg[1]
+        for (i = 2; i < n; i++) { print acc; acc = acc "." seg[i] }
+        if (n > 1) print acc
+      }
+    }' "$1" | sort -u
+}
+
+# values.yaml flattened to dotted paths by indentation. Our own file, two-space
+# indented; list items and comments are skipped.
+values_paths() {
+  awk '
+    /^[[:space:]]*#/ { next }
+    /^[[:space:]]*$/ { next }
+    /^[[:space:]]*-/ { next }
+    { line = $0
+      sub(/[[:space:]]+#.*$/, "", line)
+      match(line, /^[[:space:]]*/); ind = RLENGTH
+      key = line; sub(/^[[:space:]]*/, "", key)
+      if (key !~ /^[A-Za-z_][A-Za-z0-9_]*:/) next
+      sub(/:.*$/, "", key)
+      lvl = int(ind / 2)
+      stack[lvl] = key
+      path = stack[0]
+      for (i = 1; i <= lvl; i++) path = path "." stack[i]
+      print path
+    }' "$1" | sort -u
+}
+
+toml_paths "$TOML" > "$work/toml"
+values_paths "$VALUES" > "$work/values"
+# Env forms: the TOML path upper-cased with `__` between segments.
+sed 's/\./__/g' "$work/toml" | tr 'a-z' 'A-Z' | sed 's/^/FERROEHR__/' | sort -u > "$work/env"
+grep -vE '\.' "$work/values" > "$work/values_top"
+
+failures=0
+report() {
+  printf '%s: %s\n' "$1" "$2" >&2
+  failures=$((failures + 1))
+}
+
+files=$(collect "$@")
+
+# ── 1. configuration keys ────────────────────────────────────────────────────
+for f in $files; do
+  [ -f "$f" ] || continue
+  # A form ending in `__` is prose naming a prefix ("FERROEHR__AUDIT__…"), not a
+  # key. Anything else must resolve.
+  while read -r form; do
+    [ -n "$form" ] || continue
+    case "$form" in *__) continue ;; esac
+    grep -qxF "$form" "$work/env" \
+      || report "$f" "documents \`$form\`, which is not a key in $TOML"
+  done < <(grep -ohE 'FERROEHR__[A-Z0-9_]+' "$f" | sort -u)
+done
+
+# ── 2. Helm values paths (chart pages only) ──────────────────────────────────
+for f in $files; do
+  case " $CHART_PAGES " in *" $f "*) ;; *) continue ;; esac
+  [ -f "$f" ] || continue
+  while read -r path; do
+    [ -n "$path" ] || continue
+    first=${path%%.*}
+    # Only a token rooted at a real top-level values key is read as a values
+    # path; anything else is ordinary prose that happens to contain a dot.
+    grep -qxF "$first" "$work/values_top" || continue
+    if grep -qxF "$path" "$work/values"; then continue; fi
+    # `config.*` is rendered verbatim into ferroehr.toml, so the TOML schema is
+    # its authority.
+    case "$path" in
+      config.*) grep -qxF "${path#config.}" "$work/toml" && continue ;;
+    esac
+    report "$f" "documents Helm value \`$path\`, which the chart does not define"
+  done < <(grep -ohE '`[a-z][A-Za-z0-9]*(\.[A-Za-z0-9_]+)+`' "$f" | tr -d '`' | sort -u)
+  # `--set` is unambiguous wherever it appears, so it is checked without the
+  # top-level-key filter above.
+  while read -r path; do
+    [ -n "$path" ] || continue
+    grep -qxF "$path" "$work/values" && continue
+    case "$path" in
+      config.*) grep -qxF "${path#config.}" "$work/toml" && continue ;;
+    esac
+    report "$f" "\`--set $path=\` names a value the chart does not define"
+  done < <(grep -ohE '\-\-set +[a-z][A-Za-z0-9_.]*=' "$f" | sed -E 's/--set +//; s/=$//' | sort -u)
+done
+
+# ── 3. generated charts nothing embeds ───────────────────────────────────────
+# Whole-corpus by nature: a page deleting its figure is exactly the case to
+# catch, and that page may not be in a narrow diff.
+#
+# The reference may sit in an mdBook `{{#include}}` source rather than in a page
+# — `comparison.md` pulls three of its figures in from `website/book/generated/`
+# — so both trees are searched. Searching only the pages reported a chart as
+# orphaned when it was in fact published, which is the failure mode that gets a
+# guard ignored.
+while read -r svg; do
+  [ -n "$svg" ] || continue
+  base=${svg##*/}
+  grep -rqF "$base" --include='*.md' "$BOOK" website/book/generated \
+    || report "$svg" "is committed but nothing embeds it"
+done < <(git ls-files "$BOOK/*-assets/*.svg")
+
+if [ "$failures" -gt 0 ]; then
+  echo "docs-claims: $failures unresolvable claim(s) — see above." >&2
+  echo "  A documented key must exist in its source. Fix the page, or fix the" >&2
+  echo "  source if the page is describing what the software should do." >&2
+  exit 1
+fi
+echo "docs-claims: OK."

--- a/website/book/src/installation/kubernetes-hardening.md
+++ b/website/book/src/installation/kubernetes-hardening.md
@@ -679,7 +679,7 @@ database genuinely external to it:
 - **the chart installs and serves unchanged** — both replicas `1/1 Running`, zero
   restarts, readiness `UP`, `POST /ehr` → `201`. No warnings for its pods.
 - **a regression of the chart's own pod spec is refused.** Upgrading with
-  `--set securityContext.privileged=true --set allowPrivilegeEscalation=true`
+  `--set securityContext.privileged=true --set securityContext.allowPrivilegeEscalation=true`
   produced a ReplicaSet with `DESIRED 1, CURRENT 0` and:
 
   ```text


### PR DESCRIPTION
Closes #1984.

The v3.17.4 book sweep found five substantive defects already published to the site, and no gate had caught any of them — `mdbook-lint` checks style, `lychee` checks that links resolve, and both pass happily on a page whose every technical claim is false. `scripts/checks/docs-claims.sh` (a `--all` CI job) checks the claims that have a machine-readable authority to check against:

- every `FERROEHR__…` form resolves to a key in `ferroehr.default.toml`
- every Helm values path on a chart page resolves — against `values.yaml`, or for `config.*` against the TOML schema, since the chart renders `config:` **verbatim** into `ferroehr.toml` (so `config.<any-toml-path>` is legitimate whether or not values.yaml enumerates it)
- every committed `*-assets/*.svg` is embedded by a page or an mdBook `{{#include}}` source

## Three real defects, all fixed here

**The chart could not deploy by digest — and this one is a security defect, not a docs nit.** The hardening chapter instructs operators to deploy by digest "so what you verified is what runs", naming `image.digest`. No such key existed, no template read one, and the deployment's image line hardcoded a `:` separator, so a digest could not be passed through `image.tag` either. A digest is what a provenance attestation is made over — so the step that binds `gh attestation verify` to the *running* image was silently a no-op, on the page whose whole subject is that binding. Added via a `ferroehr.image` helper: digest wins over tag, `sha256:` prefix optional (both spellings circulate, and a one-character difference is an unhelpful way to fail a deploy). Verified across all four render paths:

```
default                      → ghcr.io/rubentalstra/ferroehr:3.17.3
--set image.digest=abc123    → ghcr.io/rubentalstra/ferroehr@sha256:abc123
digest + tag together        → ghcr.io/rubentalstra/ferroehr@sha256:abc123
--set image.tag=3.17.4       → ghcr.io/rubentalstra/ferroehr:3.17.4
```

That is an additive chart feature, so the chart's own SemVer line moves 4.0.0 → 4.1.0, with regenerated goldens and README.

**`--set allowPrivilegeEscalation=true`** in the recorded PSA regression test names nothing — the chart's key is `securityContext.allowPrivilegeEscalation`. The recorded outcome still stands (the sibling `securityContext.privileged=true` is what admission refused), but a reader copying the command ran a half-effective test.

**Two configuration keys were undiscoverable.** `auth.oidc.hmac_secret_file` and `auth.oidc.jwks_json_file` are real fields that appeared in the shipped template only inside a trailing comment on *another key's* line, in a file whose header calls itself the complete server configuration. Both are the file-indirection form of a secret — exactly what an operator goes hunting for. Now their own `#?` lines.

## Mutation-tested, not assumed

| mutation | result |
|---|---|
| `FERROEHR__REST__FABRICATED` | caught |
| `--set rest.enabled=true` | caught |
| `` `config.nonexistent.key` ``, `` `image.fabricated` ``, `` `secrets.notAThing` `` | all three caught |
| a chart stripped of its only reference | caught |

Each exits 1 naming the right file.

## One finding was the guard's own fault

Its first run reported a published chart as orphaned, because it searched only `website/book/src` while the reference lived in `website/book/generated/` behind an mdBook `{{#include}}`. Fixed in the guard, not in the docs — and written down, because a guard that cries wolf is a guard people switch off. The rule file now tells readers to check whether the guard is wrong before editing the page.

## What is deliberately not checked

Recorded in both the script header and `.claude/rules/docs-website.md`, per the convention that an unenforced rule is labelled as one:

- **Documented Rust paths** — measured and rejected. Prose names types under a different module path than the sentence implies, and the generated crates' generation modules give one type several valid paths; it found less than it cried wolf about.
- **Prose claims of any kind** ("six endpoints exist", "the chart renders one key") — no machine authority exists, which is why the same-PR docs rule still carries the weight.

## Found en route

**#2154** — the template has two tests and neither could have caught the missing config keys. `template_parses_to_default` passes because a commented-out key is absent from both sides; `template_mentions_every_section` checks *sections*, and a section is present the moment any one of its keys is. Filed rather than fixed, because `app/ferroehr/src/config/` is being refactored under #2124 in the same tree.

## Gates

- `bash scripts/checks/docs-claims.sh --all` — OK
- `bash deploy/helm/validate.sh` — ALL CHECKS PASSED (goldens and chart README regenerated)
- `mdbook-lint lint website/book/src` — 0 errors, pre-existing warning count unchanged
- `zizmor --min-severity=low .github/workflows/ci.yml` — no findings
- `bash scripts/checks/compose-hardening.sh` — OK

No cargo run: the only Rust-adjacent file is a TOML asset, and its two tests are comment-insensitive (`app/ferroehr` is mid-refactor under #2124 in this tree, so a workspace build would say nothing about this change).
