### PR TITLE
refactor(errors): ServiceError carries its SmError, and the 500-body guard follows the SmError path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,18 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- Service-layer refusals now report the precise openEHR Service Model call
+  status they were raised with, instead of a generic stand-in. An unusable
+  archetype-id regex pattern answers `invalid_id_pattern` (not
+  `precondition_violation`) and an invalid stored query `invalid_query` (not
+  `content_invalid`), and every conflict, bad request and semantic refusal
+  keeps its own status through the service boundary. The HTTP status and
+  response body of every affected request are unchanged — only the status a
+  Service Model caller reads back becomes accurate.
+- An unusable id pattern, an unparseable stored query and an unparseable
+  ad-hoc AQL query now carry the underlying parser failure as an error cause,
+  so an operator can read the full diagnosis from the server log.
+
 - `auth.oidc.hmac_secret_file` and `auth.oidc.jwks_json_file` now appear as
   their own reference lines in the shipped `ferroehr.toml` template, so
   `ferroehr config default` teaches them. Both were real configuration keys
@@ -323,6 +335,13 @@ workflow refuses a tag that has no matching section here.
 
 
 ### Security
+
+- The error-body hygiene check now also covers Service Model faults
+  (`SmError::exception` and `exception`-coded call statuses), which are a
+  second route to a `500` response body it previously did not inspect. Three
+  boot-time terminology and subject-proxy failures were rewritten to keep the
+  underlying diagnostic out of the message and carry it as an error cause
+  instead, so it reaches the server log and never a client.
 
 - Every one of the 20 GitHub Actions referenced by the build, test, release and publish pipelines is now pinned to a full commit SHA instead of a mutable tag, so a retagged or compromised upstream release can no longer change what runs against the tokens that publish this project's releases, container images and crates. Each pin carries its human-readable version in a trailing comment and was verified to belong to the named repository.
 - 38 of the 40 repository checkouts in CI no longer leave the job's API token in `.git/config` for the rest of the job (`persist-credentials: false`), so a later step — a third-party action, a build script, an uploaded artifact — can no longer pick it up and push with it. The two exceptions are the documentation jobs that genuinely use git against the remote, and both are now annotated with the reason.

--- a/app/ferroehr-rest/tests/it/error_chain.rs
+++ b/app/ferroehr-rest/tests/it/error_chain.rs
@@ -15,6 +15,7 @@ use http::StatusCode;
 use http_body_util::BodyExt;
 
 use ferroehr::service::error::ServiceError;
+use ferroehr::service::status::{CallStatusType, SmError};
 use ferroehr_rest::overview::error::RestError;
 
 use crate::common;
@@ -126,7 +127,92 @@ async fn a_carried_cause_leaves_a_4xx_body_byte_identical() {
     let parse_failure = serde_json::from_str::<u32>("\"not a number\"")
         .expect_err("the fixture must fail to deserialize");
 
-    let flat = rendered(ServiceError::BadRequest(detail.to_owned())).await;
+    let flat = rendered(ServiceError::precondition(detail.to_owned())).await;
     let carried = rendered(ServiceError::bad_request(detail, parse_failure)).await;
     assert_eq!(carried, flat);
+}
+
+/// Every granular SM status renders the SAME wire response whether it reaches
+/// the adapter as a bare `SmError` (the SM bridge, `sm_api_error`) or through
+/// `ServiceError` (the service bridge) — so restoring the granular statuses
+/// changed nothing a client can observe.
+///
+/// The `500`-class statuses are deliberately excluded: the `ServiceError` route
+/// curates their body to a fixed message where the bare-`SmError` route renders
+/// what the fault site wrote, and that difference is the point of both bridges.
+#[tokio::test]
+async fn a_granular_status_renders_identically_on_both_bridges() {
+    let statuses = [
+        CallStatusType::PreconditionViolation,
+        CallStatusType::InvalidIdPattern,
+        CallStatusType::EhrCreateFailDuplicateId,
+        CallStatusType::CompositionAlreadyExists,
+        CallStatusType::EhrForSubjectAlreadyExists,
+        CallStatusType::Conflict,
+        CallStatusType::VersionMismatch,
+        CallStatusType::CompositionArchetypeInvalid,
+        CallStatusType::InvalidArchetype,
+        CallStatusType::InvalidTemplate,
+        CallStatusType::InvalidArtefact,
+        CallStatusType::InvalidQuery,
+        CallStatusType::DefinitionUnknown,
+        CallStatusType::ContentInvalid,
+        CallStatusType::EhrIdDoesNotExist,
+        CallStatusType::TemplateDoesNotExist,
+    ];
+    for status in statuses {
+        let detail = "the refusal detail";
+        let direct = RestError::from(SmError::new(status, detail)).into_response();
+        let direct_status = direct.status();
+        let via_service = rendered(ServiceError::sm(status, detail)).await;
+        assert_eq!(
+            via_service.0,
+            direct_status,
+            "{} diverged on the wire status",
+            status.sm_name()
+        );
+        assert!(
+            via_service.1.contains(detail),
+            "{} must keep its client-facing detail, got {}",
+            status.sm_name(),
+            via_service.1
+        );
+    }
+}
+
+/// A refusal that carries a cause reports the granular SM status back — the
+/// property #2124 restored — while the wire response is byte-identical to the
+/// cause-less twin's.
+#[tokio::test]
+async fn a_granular_status_survives_the_service_round_trip_at_the_wire_seam() {
+    let parse_failure = serde_json::from_str::<u32>("\"not a number\"")
+        .expect_err("the fixture must fail to deserialize");
+    let caused = ServiceError::from(
+        SmError::new(CallStatusType::InvalidIdPattern, "invalid id pattern")
+            .with_source(parse_failure),
+    );
+
+    // The status the caller reads back is the granular one, not a generic
+    // `precondition_violation`.
+    let restored = SmError::from(ServiceError::from(SmError::new(
+        CallStatusType::InvalidIdPattern,
+        "invalid id pattern",
+    )));
+    assert_eq!(restored.status, CallStatusType::InvalidIdPattern);
+
+    // And the CONCRETE cause is reachable — `source().is_some()` would also
+    // pass on a smart-pointer hop, which is exactly the defect that hides a
+    // lost cause — while the response is unchanged.
+    let reached_concrete = std::iter::successors(Error::source(&caused), |e| Error::source(*e))
+        .any(|e| e.downcast_ref::<serde_json::Error>().is_some());
+    assert!(
+        reached_concrete,
+        "walking the chain must reach the concrete serde_json::Error, got {caused:?}"
+    );
+    let flat = rendered(ServiceError::sm(
+        CallStatusType::InvalidIdPattern,
+        "invalid id pattern",
+    ))
+    .await;
+    assert_eq!(rendered(caused).await, flat);
 }

--- a/app/ferroehr/src/extensions/events/subscription.rs
+++ b/app/ferroehr/src/extensions/events/subscription.rs
@@ -243,7 +243,7 @@ impl FerroEhrService {
 fn validated_name(raw: &str) -> Result<String, ServiceError> {
     let name = raw.trim();
     if name.is_empty() {
-        return Err(ServiceError::BadRequest(
+        return Err(ServiceError::precondition(
             "event subscription requires a non-empty 'name'".to_owned(),
         ));
     }
@@ -251,7 +251,7 @@ fn validated_name(raw: &str) -> Result<String, ServiceError> {
         .chars()
         .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '-'))
     {
-        return Err(ServiceError::BadRequest(
+        return Err(ServiceError::precondition(
             "event subscription 'name' must match [A-Za-z0-9_.-]".to_owned(),
         ));
     }
@@ -273,7 +273,7 @@ fn map_insert_error(e: sqlx::Error) -> ServiceError {
     if let sqlx::Error::Database(db) = &e
         && db.is_unique_violation()
     {
-        return ServiceError::Conflict("an event subscription with that name exists".to_owned());
+        return ServiceError::conflict("an event subscription with that name exists".to_owned());
     }
     ServiceError::Database(e)
 }

--- a/app/ferroehr/src/extensions/fhir/ingest.rs
+++ b/app/ferroehr/src/extensions/fhir/ingest.rs
@@ -440,7 +440,7 @@ impl FerroEhrService {
                 subject_id.as_deref(),
             )
             .map_err(|e| {
-                ServiceError::Unprocessable(Violation::new(e.to_string()).with_source(e))
+                ServiceError::content_invalid(Violation::new(e.to_string()).with_source(e))
             })?;
             out.push((resource_type, template_id.clone(), resource));
         }
@@ -456,15 +456,13 @@ fn validated_name(body: &Value) -> Result<String, ServiceError> {
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|s| !s.is_empty())
-        .ok_or_else(|| {
-            ServiceError::BadRequest("FHIR mapping requires a non-empty 'name'".into())
-        })?;
+        .ok_or_else(|| ServiceError::precondition("FHIR mapping requires a non-empty 'name'"))?;
     if !name
         .chars()
         .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '-'))
     {
-        return Err(ServiceError::BadRequest(
-            "FHIR mapping 'name' must match [A-Za-z0-9_.-]".into(),
+        return Err(ServiceError::precondition(
+            "FHIR mapping 'name' must match [A-Za-z0-9_.-]",
         ));
     }
     Ok(name.to_owned())
@@ -477,7 +475,7 @@ fn validated_definition(body: &Value) -> Result<(Value, FhirMappingDefinition), 
     let raw = body
         .get("definition")
         .cloned()
-        .ok_or_else(|| ServiceError::BadRequest("FHIR mapping requires a 'definition'".into()))?;
+        .ok_or_else(|| ServiceError::precondition("FHIR mapping requires a 'definition'"))?;
     let def: FhirMappingDefinition = serde_json::from_value(raw.clone()).map_err(|e| {
         ServiceError::bad_request(format!("invalid FHIR mapping definition: {e}"), e)
     })?;
@@ -490,11 +488,11 @@ fn validated_definition(body: &Value) -> Result<(Value, FhirMappingDefinition), 
 fn map_insert_error(e: sqlx::Error) -> ServiceError {
     if let sqlx::Error::Database(db) = &e {
         if db.is_unique_violation() {
-            return ServiceError::Conflict("a FHIR mapping with that name exists".into());
+            return ServiceError::conflict("a FHIR mapping with that name exists");
         }
         if db.is_foreign_key_violation() {
-            return ServiceError::BadRequest(
-                "FHIR mapping references an unknown template_id (ingest the OPT first)".into(),
+            return ServiceError::precondition(
+                "FHIR mapping references an unknown template_id (ingest the OPT first)",
             );
         }
     }

--- a/app/ferroehr/src/extensions/tenancy.rs
+++ b/app/ferroehr/src/extensions/tenancy.rs
@@ -144,7 +144,7 @@ impl FerroEhrService {
         // `ext.current_tenant_id()`'s fallback in
         // `migrations/ext/0002_tenant_context.sql`.
         if id == Uuid::nil() {
-            return Err(ServiceError::Conflict(
+            return Err(ServiceError::conflict(
                 "the reserved default tenant cannot be deleted".to_owned(),
             ));
         }
@@ -168,7 +168,7 @@ impl FerroEhrService {
         .fetch_one(&mut *tx)
         .await?;
         if owned > 0 {
-            return Err(ServiceError::Conflict(format!(
+            return Err(ServiceError::conflict(format!(
                 "tenant {id} is not empty ({owned} owned object(s)); purge its data first"
             )));
         }
@@ -226,7 +226,7 @@ impl FerroEhrService {
 fn required_str<'a>(raw: &'a str, field: &str) -> Result<&'a str, ServiceError> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
-        return Err(ServiceError::BadRequest(format!(
+        return Err(ServiceError::precondition(format!(
             "`{field}` is required and non-empty"
         )));
     }
@@ -238,7 +238,7 @@ fn map_insert_error(e: sqlx::Error) -> ServiceError {
     if let sqlx::Error::Database(db) = &e
         && db.is_unique_violation()
     {
-        return ServiceError::Conflict("a tenant with that name already exists".to_owned());
+        return ServiceError::conflict("a tenant with that name already exists".to_owned());
     }
     ServiceError::Database(e)
 }

--- a/app/ferroehr/src/service/admin/delete.rs
+++ b/app/ferroehr/src/service/admin/delete.rs
@@ -137,7 +137,7 @@ impl FerroEhrService {
                 .fetch_one(&mut *tx)
                 .await?;
         if refs > 0 {
-            return Err(ServiceError::Conflict(format!(
+            return Err(ServiceError::conflict(format!(
                 "template '{stored}' is still referenced by {refs} committed version(s); \
                  delete those compositions before deleting the template"
             )));

--- a/app/ferroehr/src/service/admin/dump_load.rs
+++ b/app/ferroehr/src/service/admin/dump_load.rs
@@ -674,14 +674,14 @@ fn original_version_envelope(
     let (contribution, commit_audit, signature) = if let Some(wrapped) = &v.wrapped_original {
         (
             wrapped.get("contribution").cloned().ok_or_else(|| {
-                ServiceError::Internal(format!(
+                ServiceError::exception(format!(
                     "version {} of {} is imported but its wrapped ORIGINAL_VERSION carries no \
                      contribution",
                     v.sys_version, v.vo_id
                 ))
             })?,
             wrapped.get("commit_audit").cloned().ok_or_else(|| {
-                ServiceError::Internal(format!(
+                ServiceError::exception(format!(
                     "version {} of {} is imported but its wrapped ORIGINAL_VERSION carries no \
                      commit_audit",
                     v.sys_version, v.vo_id
@@ -787,7 +787,7 @@ fn version_document(kind: &str, envelope: &Value) -> Result<String, ServiceError
         "EHR_STATUS" => version_document_of::<EhrStatus>(envelope),
         "EHR_ACCESS" => version_document_of::<EhrAccess>(envelope),
         "FOLDER" => version_document_of::<Folder>(envelope),
-        other => Err(ServiceError::Internal(format!(
+        other => Err(ServiceError::exception(format!(
             "no canonical-XML payload type for versioned-object kind {other}"
         ))),
     }
@@ -1104,11 +1104,11 @@ impl FerroEhrService {
                     // load into a non-empty repository. Reported and skipped
                     // (its transaction rolled back) exactly like a duplicate
                     // EHR id, so the rest of the archive still loads.
-                    Err(ServiceError::Conflict(message)) => reports.push(DumpLoadFailReport {
+                    Err(ServiceError::Conflict(e)) => reports.push(DumpLoadFailReport {
                         entity_type: "EHR".to_owned(),
                         entity_id: ehr_id.to_string(),
                         dump_status: false,
-                        error: Some(message),
+                        error: Some(e.message),
                     }),
                     Err(e) => return Err(e.into()),
                 }
@@ -1556,7 +1556,7 @@ impl FerroEhrService {
         .fetch_one(&mut *tx)
         .await?;
         if overlap {
-            return Err(ServiceError::Unprocessable(
+            return Err(ServiceError::content_invalid(
                 crate::service::error::Violation::new(format!(
                     "archive for EHR {ehr_id} carries overlapping version validity periods"
                 )),
@@ -1604,7 +1604,7 @@ async fn insert_ehr_row(tx: &mut PgConnection, ehr: &EhrRow) -> Result<(), Servi
         if let sqlx::Error::Database(db) = &e
             && db.constraint() == Some("uq_ehr_subject")
         {
-            return ServiceError::Conflict(format!(
+            return ServiceError::conflict(format!(
                 "EHR {} names subject {}@{}, which another EHR in this repository already \
                  holds (one EHR per subject)",
                 ehr.id,

--- a/app/ferroehr/src/service/definition/adl14.rs
+++ b/app/ferroehr/src/service/definition/adl14.rs
@@ -139,12 +139,12 @@ impl FerroEhrService {
         let mut log = ConversionLog::new();
         let converted =
             parse_and_convert(&source, &ConvertConfig::default(), &mut log).map_err(|e| {
-                ServiceError::Unprocessable(
+                ServiceError::content_invalid(
                     Violation::new(format!("1.4 → 2 conversion failed: {e}")).with_source(e),
                 )
             })?;
         openehr_adl::print::print(&converted).map_err(|e| {
-            SmError::from(ServiceError::Unprocessable(
+            SmError::from(ServiceError::content_invalid(
                 Violation::new(format!("1.4 → 2 conversion produced unprintable ADL2: {e}"))
                     .with_source(e),
             ))
@@ -186,12 +186,12 @@ impl FerroEhrService {
         // boundary re-raise needed.
         let xml = self.opt_get(&an_opt_id).await?;
         let opt = openehr_its::opt14::from_xml(&xml).map_err(|e| {
-            ServiceError::Unprocessable(
+            ServiceError::content_invalid(
                 Violation::new(format!("stored OPT no longer parses: {e:?}")).with_source(e),
             )
         })?;
         let conversion = super::opt14_convert::convert_opt_to_adl2(&opt).map_err(|e| {
-            ServiceError::Unprocessable(
+            ServiceError::content_invalid(
                 Violation::new(format!("OPT 1.4 → 2 conversion failed: {e}")).with_source(e),
             )
         })?;
@@ -611,7 +611,7 @@ impl FerroEhrService {
                 .fetch_one(&mut *tx)
                 .await?;
         if refs > 0 {
-            return Err(ServiceError::Conflict(format!(
+            return Err(ServiceError::conflict(format!(
                 "template '{template_id}' is still referenced by {refs} committed version(s); \
                  delete those compositions before deleting the template"
             )));
@@ -732,7 +732,7 @@ fn valid_opt_xml(opt_xml: &str) -> bool {
 )]
 fn parse_opt_uuid(an_opt_id: &str) -> Result<Uuid, ServiceError> {
     Uuid::parse_str(an_opt_id)
-        .map_err(|_| ServiceError::BadRequest(format!("OPT id is not a UUID: {an_opt_id}")))
+        .map_err(|_| ServiceError::precondition(format!("OPT id is not a UUID: {an_opt_id}")))
 }
 
 /// Extract the `ARCHETYPE_ID` from ADL 1.4 source: the source must begin with

--- a/app/ferroehr/src/service/definition/adl2.rs
+++ b/app/ferroehr/src/service/definition/adl2.rs
@@ -448,7 +448,7 @@ impl FerroEhrService {
     pub(super) async fn adl2_wire_upload(&self, source: &str) -> Result<String, ServiceError> {
         let summary = self.adl2_validate(source).await?;
         if self.adl2_exists(&summary.archetype_id).await? {
-            return Err(ServiceError::Conflict(format!(
+            return Err(ServiceError::conflict(format!(
                 "an ADL2 template with id '{}' already exists",
                 summary.archetype_id
             )));
@@ -533,7 +533,7 @@ impl FerroEhrService {
     ///   `Unprocessable` (`422`).
     pub(super) async fn adl2_opt_json(&self, source: &str) -> Result<String, ServiceError> {
         let archetype = parse_artefact(source, Dialect::Adl2).map_err(|errs| {
-            ServiceError::Internal(format!(
+            ServiceError::exception(format!(
                 "stored ADL2 source no longer parses: {}",
                 join_syntax_errors(&errs)
             ))
@@ -545,7 +545,7 @@ impl FerroEhrService {
         }
         let repo = self.adl2_repository().await?;
         let opt = create_opt(&archetype, &repo).map_err(|e| {
-            ServiceError::Unprocessable(
+            ServiceError::content_invalid(
                 Violation::new(format!("cannot project OperationalTemplateV2: {e}")).with_source(e),
             )
         })?;
@@ -609,7 +609,7 @@ impl FerroEhrService {
     pub async fn web_template_adl2(&self, template_id: &str) -> Result<WebTemplate, ServiceError> {
         let opt = self.adl2_operational_template_for(template_id).await?;
         build_web_template_v2_4(&opt).map_err(|e| {
-            ServiceError::Unprocessable(
+            ServiceError::content_invalid(
                 Violation::new(format!(
                     "ADL2 template {template_id} could not be built into a WebTemplate: {e}"
                 ))
@@ -664,7 +664,7 @@ impl FerroEhrService {
         let opt = match self.adl2_operational_template_for(template_id).await {
             Ok(opt) => opt,
             Err(ServiceError::NotFound(_)) => {
-                return Err(ServiceError::Unprocessable(Violation::new(format!(
+                return Err(ServiceError::content_invalid(Violation::new(format!(
                     "operational template not known: {template_id}"
                 ))));
             }
@@ -674,7 +674,7 @@ impl FerroEhrService {
             .get_or_build(&key, || build_web_template_v2_4(&opt))
             .await
             .map_err(|e| {
-                ServiceError::Unprocessable(
+                ServiceError::content_invalid(
                     Violation::new(format!(
                         "ADL2 template {template_id} could not be built into a WebTemplate: {e}"
                     ))
@@ -710,7 +710,7 @@ impl FerroEhrService {
         source: &str,
     ) -> Result<OperationalTemplate, ServiceError> {
         let archetype = parse_artefact(source, Dialect::Adl2).map_err(|errs| {
-            ServiceError::Internal(format!(
+            ServiceError::exception(format!(
                 "stored ADL2 source no longer parses: {}",
                 join_syntax_errors(&errs)
             ))
@@ -722,7 +722,7 @@ impl FerroEhrService {
         }
         let repo = self.adl2_repository().await?;
         create_opt(&archetype, &repo).map_err(|e| {
-            ServiceError::Unprocessable(
+            ServiceError::content_invalid(
                 Violation::new(format!("cannot compile operational template: {e}")).with_source(e),
             )
         })
@@ -821,7 +821,7 @@ impl FerroEhrService {
             .fetch_one(&mut *tx)
             .await?;
             if refs > 0 {
-                return Err(ServiceError::Conflict(format!(
+                return Err(ServiceError::conflict(format!(
                     "template '{hrid}' is still referenced by {refs} committed version(s); \
                      delete those compositions before deleting the template"
                 )));
@@ -938,7 +938,7 @@ fn join_syntax_errors(errs: &[openehr_adl::error::SyntaxError]) -> String {
 /// content)"). AOM2 validation-phase failures (V-codes) on a *parsed* source
 /// are the semantic `422` branch instead (see [`FerroEhrService::adl2_validate`]).
 fn syntax_bad_request(errs: &[openehr_adl::error::SyntaxError]) -> ServiceError {
-    ServiceError::BadRequest(format!(
+    ServiceError::precondition(format!(
         "syntactically invalid ADL2 content: {}",
         join_syntax_errors(errs)
     ))

--- a/app/ferroehr/src/service/definition/mod.rs
+++ b/app/ferroehr/src/service/definition/mod.rs
@@ -52,7 +52,7 @@ pub mod types;
 use regex::Regex;
 
 use crate::service::list::Page;
-use crate::service::status::CallStatusType;
+use crate::service::status::{CallStatusType, SmError};
 
 use crate::service::error::ServiceError;
 
@@ -86,13 +86,42 @@ pub(super) fn page_bounds(page: Page) -> (i64, Option<i64>) {
 /// `invalid_id_pattern`, the correct SM outcome for an unusable pattern (a
 /// narrower accept envelope, never a wrong status).
 pub(super) fn compile_pattern(pattern: &str) -> Result<Regex, ServiceError> {
-    // NOTE: no cause is carried here, because `ServiceError::sm` normalizes
-    // `invalid_id_pattern` into the bare-string `BadRequest` row that the
-    // cause-carrying `ServiceError::Caused` row deliberately does not.
     Regex::new(pattern).map_err(|e| {
-        ServiceError::sm(
-            CallStatusType::InvalidIdPattern,
-            format!("invalid id pattern: {e}"),
+        let message = format!("invalid id pattern: {e}");
+        ServiceError::BadRequest(
+            SmError::new(CallStatusType::InvalidIdPattern, message).with_source(e),
         )
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::compile_pattern;
+    use crate::service::error::ServiceError;
+    use crate::service::status::CallStatusType;
+
+    /// An uncompilable id pattern reports the SM status
+    /// `i_definition_adl14.adoc` §`list_matching_archetypes` declares
+    /// (`.Errors`: `invalid_id_pattern`) and carries the `regex` compile
+    /// failure as a walkable cause
+    /// ([RFC 0201](https://rust-lang.github.io/rfcs/0201-error-chaining.html)).
+    #[test]
+    fn an_uncompilable_pattern_is_invalid_id_pattern_and_carries_its_cause() {
+        use std::error::Error;
+
+        let err = compile_pattern("(").expect_err("an unbalanced group must not compile");
+        let ServiceError::BadRequest(sm) = &err else {
+            panic!("an unusable pattern is a 400, got {err:?}");
+        };
+        assert_eq!(sm.status, CallStatusType::InvalidIdPattern);
+        // Two hops: the refusal carries its `SmError`, which carries the
+        // concrete compile failure.
+        let hops = std::iter::successors(Error::source(&err), |e| Error::source(*e))
+            .map(|e| e.downcast_ref::<regex::Error>().is_some())
+            .collect::<Vec<_>>();
+        assert!(
+            hops.contains(&true),
+            "walking the chain must reach the concrete regex::Error, got {err:?}"
+        );
+    }
 }

--- a/app/ferroehr/src/service/definition/query.rs
+++ b/app/ferroehr/src/service/definition/query.rs
@@ -435,7 +435,7 @@ impl FerroEhrService {
             .name
             .eq_ignore_ascii_case("aql")
         {
-            return Err(ServiceError::BadRequest(format!(
+            return Err(ServiceError::precondition(format!(
                 "`{qualified_name}`: the query-name `aql` is reserved \
                  (ITS-REST Qualified_query_name)"
             )));
@@ -445,13 +445,11 @@ impl FerroEhrService {
         // stored-query table only holds AQL (`query_type = 'AQL'`), so a non-AQL
         // or syntactically-invalid body is a `400 Bad Request`
         // (`definition_query_store` lists only `200`/`400`).
-        // NOTE: `openehr_query::parser::parse_str` reports a located grammar
-        // diagnostic as a `String`, so there is no cause to carry — the
-        // diagnostic IS the answer the client acts on.
         if let Err(err) = openehr_query::parser::parse_str(&query_text) {
-            return Err(ServiceError::BadRequest(format!(
-                "stored query text is not valid AQL: {err}"
-            )));
+            return Err(ServiceError::bad_request(
+                format!("stored query text is not valid AQL: {err}"),
+                err,
+            ));
         }
 
         // ONE canonical key for every surface (SM master04 §Registered
@@ -502,7 +500,7 @@ impl FerroEhrService {
         // create, so the refusal status is the docs text's own generic client
         // error (`Requests_and_responses.md` §"HTTP status codes", `400`).
         if !is_exact_semver(v) {
-            return Err(ServiceError::BadRequest(format!(
+            return Err(ServiceError::precondition(format!(
                 "`{v}` is not an exact SEMVER version: the versioned store requires \
                  `major.minor.patch` (the {{major}}/{{major}}.{{minor}} prefix forms are \
                  read-side resolution patterns, parameters/path/version.yaml)"
@@ -525,7 +523,7 @@ impl FerroEhrService {
         .fetch_one(&self.pool)
         .await?;
         if exists {
-            return Err(ServiceError::Conflict(format!(
+            return Err(ServiceError::conflict(format!(
                 "a stored query '{qualified_name}' at version '{v}' already exists"
             )));
         }
@@ -543,7 +541,7 @@ impl FerroEhrService {
         .await?
         .rows_affected();
         if inserted == 0 {
-            return Err(ServiceError::Conflict(format!(
+            return Err(ServiceError::conflict(format!(
                 "a stored query '{qualified_name}' at version '{v}' already exists"
             )));
         }

--- a/app/ferroehr/src/service/definition/wire.rs
+++ b/app/ferroehr/src/service/definition/wire.rs
@@ -134,8 +134,8 @@ impl FerroEhrService {
         kind: Option<String>,
     ) -> Result<Value, ServiceError> {
         let level =
-            DetailLevel::from_query(detail_level.as_deref()).map_err(ServiceError::BadRequest)?;
-        let kind = ExampleType::from_query(kind.as_deref()).map_err(ServiceError::BadRequest)?;
+            DetailLevel::from_query(detail_level.as_deref()).map_err(ServiceError::precondition)?;
+        let kind = ExampleType::from_query(kind.as_deref()).map_err(ServiceError::precondition)?;
         self.adl2_example(&template_id, level, kind).await
     }
 

--- a/app/ferroehr/src/service/demographic/party.rs
+++ b/app/ferroehr/src/service/demographic/party.rs
@@ -362,7 +362,7 @@ impl FerroEhrService {
         update_audit: Option<&UpdateAudit>,
     ) -> Result<ServiceResponse, ServiceError> {
         if current.deleted {
-            return Err(ServiceError::BadRequest(format!(
+            return Err(ServiceError::precondition(format!(
                 "{} {} is already deleted",
                 current.kind.rm_type(),
                 current.vo_id
@@ -376,7 +376,7 @@ impl FerroEhrService {
             // (`responses/409_PERSON_with_uid_based_id.yaml`: "Returns also
             // latest `version_uid` in the `ETag` header") — the handler's
             // mismatch arm keys on this variant.
-            return Err(ServiceError::VersionConflict(format!(
+            return Err(ServiceError::version_conflict(format!(
                 "preceding_version_uid names version {expected}, latest is {}",
                 current.tree
             )));

--- a/app/ferroehr/src/service/demographic/relationship.rs
+++ b/app/ferroehr/src/service/demographic/relationship.rs
@@ -330,7 +330,7 @@ impl FerroEhrService {
         update_audit: Option<&UpdateAudit>,
     ) -> Result<ServiceResponse, ServiceError> {
         if current.deleted {
-            return Err(ServiceError::BadRequest(format!(
+            return Err(ServiceError::precondition(format!(
                 "PARTY_RELATIONSHIP {} is already deleted",
                 current.vo_id
             )));
@@ -342,7 +342,7 @@ impl FerroEhrService {
             // answers `409` and echoes the latest `version_uid` in `ETag`,
             // mirroring the party delete's convention
             // (`responses/409_PERSON_with_uid_based_id.yaml`).
-            return Err(ServiceError::VersionConflict(format!(
+            return Err(ServiceError::version_conflict(format!(
                 "preceding_version_uid names version {expected}, latest is {}",
                 current.tree
             )));

--- a/app/ferroehr/src/service/demographic/validate.rs
+++ b/app/ferroehr/src/service/demographic/validate.rs
@@ -49,7 +49,7 @@ const RELATIONSHIP_RM_TYPE: &str = "PARTY_RELATIONSHIP";
 /// §Attributes), which a partial hand check cannot see.
 fn validate_party_ref(reference: &Value, context: &str) -> Result<(), ServiceError> {
     let typed = openehr_its::json::from_canonical_value::<PartyRef>(reference).map_err(|e| {
-        ServiceError::Unprocessable(
+        ServiceError::content_invalid(
             Violation::new("is not a well-formed PARTY_REF")
                 .with_path(context)
                 .with_decode_failure(&e),
@@ -59,7 +59,7 @@ fn validate_party_ref(reference: &Value, context: &str) -> Result<(), ServiceErr
     if !violations.is_empty() {
         // The class's own `InvariantViolation`s travel on as data; only the
         // first is rendered, exactly as before.
-        return Err(ServiceError::Unprocessable(
+        return Err(ServiceError::content_invalid(
             Violation::new("fails its BASE class invariants")
                 .with_path(context)
                 .with_causes(violations.into_iter().take(1).collect()),
@@ -98,7 +98,7 @@ pub(crate) fn party_check(
         "PERSON" => openehr_its::json::from_canonical_value::<Person>(data).map(drop),
         "ROLE" => openehr_its::json::from_canonical_value::<Role>(data).map(drop),
         other => {
-            return Err(ServiceError::Unprocessable(
+            return Err(ServiceError::content_invalid(
                 Violation::new(format!("not a demographic party type: {other:?}"))
                     .with_path("_type"),
             ));
@@ -171,7 +171,7 @@ pub(super) fn party_invariants(
         for (i, rel) in relationships.iter().enumerate() {
             let source = rel.pointer("/source/id/value").and_then(Value::as_str);
             if source.is_some_and(|s| !composite_ids_equal(s, &container_id)) {
-                return Err(ServiceError::Unprocessable(
+                return Err(ServiceError::content_invalid(
                     Violation::new(format!(
                         "must reference this party's version container \
                          ({container_id}) — relationships are stored under their \
@@ -253,7 +253,7 @@ pub(crate) fn relationship_check(data: &Value, incomplete: bool) -> Result<(), S
         // OBJECT_VERSION_ID (one particular version) — RM demographic
         // master02 §Modelling of Parties and Relationships.
         if matches!(reference.id, ObjectId::ObjectVersionId(_)) {
-            return Err(ServiceError::Unprocessable(
+            return Err(ServiceError::content_invalid(
                 Violation::new(
                     "must identify the party's version container (HIER_OBJECT_ID), \
                      not one version (OBJECT_VERSION_ID)",
@@ -267,7 +267,7 @@ pub(crate) fn relationship_check(data: &Value, incomplete: bool) -> Result<(), S
         // ref: no second decode, so no second way to answer the same question.
         let violations = reference.invariants();
         if !violations.is_empty() {
-            return Err(ServiceError::Unprocessable(
+            return Err(ServiceError::content_invalid(
                 Violation::new("fails its BASE class invariants")
                     .with_path(format!("PARTY_RELATIONSHIP.{field}"))
                     .with_causes(violations.into_iter().take(1).collect()),
@@ -337,7 +337,7 @@ mod tests {
             .unwrap()
             .remove("archetype_details");
         let msg = match party_check("PERSON", &no_details, false) {
-            Err(ServiceError::Unprocessable(v)) => v,
+            Err(ServiceError::Unprocessable { violation: v, .. }) => v,
             other => panic!("expected Unprocessable, got {other:?}"),
         };
         assert_eq!(msg.path(), Some("PERSON.archetype_details"));
@@ -408,7 +408,7 @@ mod tests {
         let bad_type = json!({ "_type": "PARTY_REF", "namespace": "demographic",
             "type": "COMPOSITION", "id": { "_type": "HIER_OBJECT_ID", "value": "x" } });
         match validate_party_ref(&bad_type, "ctx") {
-            Err(ServiceError::Unprocessable(v)) => assert!(
+            Err(ServiceError::Unprocessable { violation: v, .. }) => assert!(
                 v.causes()
                     .iter()
                     .any(|c| c.message.contains("Type_validity")),
@@ -440,7 +440,7 @@ mod tests {
         let bad_ns = json!({ "_type": "PARTY_REF", "namespace": "1nope",
             "type": "PERSON", "id": { "_type": "HIER_OBJECT_ID", "value": "x" } });
         match validate_party_ref(&bad_ns, "ctx") {
-            Err(ServiceError::Unprocessable(v)) => {
+            Err(ServiceError::Unprocessable { violation: v, .. }) => {
                 assert!(
                     v.causes()
                         .iter()
@@ -462,13 +462,13 @@ mod tests {
         let no_id = json!({ "_type": "PARTY_REF", "namespace": "local", "type": "PERSON" });
         assert!(matches!(
             validate_party_ref(&no_id, "ctx"),
-            Err(ServiceError::Unprocessable(_))
+            Err(ServiceError::Unprocessable { .. })
         ));
         let no_type = json!({ "_type": "PARTY_REF", "namespace": "local",
             "id": { "_type": "HIER_OBJECT_ID", "value": "x" } });
         assert!(matches!(
             validate_party_ref(&no_type, "ctx"),
-            Err(ServiceError::Unprocessable(_))
+            Err(ServiceError::Unprocessable { .. })
         ));
     }
 
@@ -492,7 +492,7 @@ mod tests {
         };
         party_check("ROLE", &role("PERSON"), false).expect("a legal performer ref is accepted");
         match party_check("ROLE", &role("COMPOSITION"), false) {
-            Err(ServiceError::Unprocessable(v)) => assert!(
+            Err(ServiceError::Unprocessable { violation: v, .. }) => assert!(
                 v.causes()
                     .iter()
                     .any(|c| c.message.contains("Type_validity")),

--- a/app/ferroehr/src/service/ehr/composition.rs
+++ b/app/ferroehr/src/service/ehr/composition.rs
@@ -389,7 +389,7 @@ impl FerroEhrService {
             (stored_template, composition_template_id(&composition))
             && stored != incoming
         {
-            return Err(ServiceError::Unprocessable(
+            return Err(ServiceError::content_invalid(
                 Violation::new(format!(
                     "is {incoming} on the update, but the stored composition was \
                      committed against template {stored} (template_id mismatch)"
@@ -531,7 +531,7 @@ impl FerroEhrService {
                     )
                 })?;
         if current.lifecycle_state == crate::versioning::lifecycle::state::DELETED {
-            return Err(ServiceError::BadRequest(format!(
+            return Err(ServiceError::precondition(format!(
                 "COMPOSITION {vo_id} is already deleted"
             )));
         }
@@ -562,7 +562,7 @@ impl FerroEhrService {
             current_tree,
         );
         if !composite_ids_equal(&latest_uid, a_version_uid.value()) {
-            return Err(ServiceError::Conflict(format!(
+            return Err(ServiceError::conflict(format!(
                 "preceding_version_uid names version {}, latest is {latest_uid}",
                 a_version_uid.value()
             )));

--- a/app/ferroehr/src/service/ehr/directory.rs
+++ b/app/ferroehr/src/service/ehr/directory.rs
@@ -96,7 +96,7 @@ impl FerroEhrService {
         // is our choice (CNF master09 E.2 requires an error for a live
         // directory only).
         if crate::storage::ehr_repo::live_directory_exists(&self.pool, ehr_id).await? {
-            return Err(ServiceError::Conflict(format!(
+            return Err(ServiceError::conflict(format!(
                 "EHR {ehr_id} already has a directory"
             )));
         }

--- a/app/ferroehr/src/service/ehr/mod.rs
+++ b/app/ferroehr/src/service/ehr/mod.rs
@@ -124,7 +124,7 @@ fn ensure_if_match(
         // base_types master05 §"Composite Identifiers and Case": two
         // identifiers identical apart from case identify the same thing).
         Some(meta) if composite_ids_equal(&meta.uid, pre.value()) => Ok(()),
-        Some(meta) => Err(crate::service::error::ServiceError::VersionConflict(
+        Some(meta) => Err(crate::service::error::ServiceError::version_conflict(
             format!(
                 "If-Match {:?} does not match the current latest version {:?}",
                 pre.value(),

--- a/app/ferroehr/src/service/ehr/service.rs
+++ b/app/ferroehr/src/service/ehr/service.rs
@@ -114,12 +114,12 @@ impl FerroEhrService {
         {
             Ok(Some(t)) => t,
             Ok(None) => {
-                return Err(ServiceError::Conflict(format!(
+                return Err(ServiceError::conflict(format!(
                     "EHR {ehr_id} already exists"
                 )));
             }
             Err(crate::storage::error::StorageError::SubjectInUse(id, ns)) => {
-                return Err(ServiceError::Conflict(format!(
+                return Err(ServiceError::conflict(format!(
                     "an EHR already exists for subject {id}@{ns}"
                 )));
             }
@@ -399,7 +399,7 @@ fn ehr_object(
         .map(|vo| container_ref("VERSIONED_EHR_ACCESS", vo))
         .transpose()?;
     let (Some(ehr_status), Some(ehr_access)) = (ehr_status, ehr_access) else {
-        return Err(ServiceError::Internal(format!(
+        return Err(ServiceError::exception(format!(
             "EHR {ehr_id} has no EHR_STATUS or no EHR_ACCESS version; both are \
              mandatory on the RM EHR class"
         )));

--- a/app/ferroehr/src/service/ehr/status.rs
+++ b/app/ferroehr/src/service/ehr/status.rs
@@ -210,7 +210,7 @@ impl FerroEhrService {
         // §update_other_details).
         let mut status: EhrStatus = openehr_its::json::from_canonical_value(&current.body)
             .map_err(|e| {
-                ServiceError::Unprocessable(
+                ServiceError::content_invalid(
                     crate::service::error::Violation::new("is not a canonical EHR_STATUS")
                         .with_path("EHR_STATUS")
                         .with_decode_failure(&e),
@@ -443,7 +443,7 @@ impl FerroEhrService {
     /// [`Self::ensure_ehr_content_writable`] pre-check so the message stays
     /// single-sourced.
     pub(in crate::service) fn not_modifiable_error(ehr_id: EhrId) -> ServiceError {
-        ServiceError::Conflict(format!(
+        ServiceError::conflict(format!(
             "EHR {ehr_id} is not modifiable (EHR_STATUS.is_modifiable = false); its \
              contents cannot be created, updated or deleted (RM ehr master04 §EHR Active \
              Status). Set EHR_STATUS.is_modifiable = true to reactivate it."
@@ -499,7 +499,7 @@ impl FerroEhrService {
             if let sqlx::Error::Database(db) = &e
                 && db.constraint() == Some("uq_ehr_subject")
             {
-                return ServiceError::Conflict(format!(
+                return ServiceError::conflict(format!(
                     "an EHR already exists for subject {}@{}",
                     subject_id.unwrap_or("?"),
                     namespace.unwrap_or("?"),
@@ -550,7 +550,7 @@ impl FerroEhrService {
                 crate::storage::ehr_repo::ehr_id_by_subject(&mut *tx, subject_id, namespace).await?
             && owner != ehr_id
         {
-            return Err(ServiceError::Conflict(format!(
+            return Err(ServiceError::conflict(format!(
                 "EHR {ehr_id} names subject {subject_id}@{namespace}, which EHR {owner} \
                  already holds (one EHR per subject)"
             )));
@@ -757,7 +757,7 @@ impl FerroEhrService {
             // judgement the retired post-mutation re-decode made).
             s.other_details = Some(openehr_its::json::from_canonical_value(&a_details).map_err(
                 |e| {
-                    ServiceError::Unprocessable(
+                    ServiceError::content_invalid(
                         crate::service::error::Violation::new("is not a canonical ITEM_STRUCTURE")
                             .with_path("EHR_STATUS/other_details")
                             .with_decode_failure(&e),

--- a/app/ferroehr/src/service/ehr/tags.rs
+++ b/app/ferroehr/src/service/ehr/tags.rs
@@ -369,7 +369,7 @@ pub(in crate::service) fn normalized_target_path(raw: Option<&str>) -> Option<&s
 pub(in crate::service) fn item_tag_refusal(
     err: &openehr_rm::v1_2::common::tags::item_tag_impl::ItemTagError,
 ) -> ServiceError {
-    ServiceError::Unprocessable(
+    ServiceError::content_invalid(
         Violation::new(format!("item tag violates its RM invariants: {err}"))
             .with_path("ITEM_TAG")
             .with_source(err.clone()),

--- a/app/ferroehr/src/service/ehr/uri.rs
+++ b/app/ferroehr/src/service/ehr/uri.rs
@@ -60,7 +60,7 @@ impl FerroEhrService {
                 format!("ehr: URI {uri} resolved to no item"),
             )),
             1 => Ok(items.remove(0)),
-            n => Err(ServiceError::BadRequest(format!(
+            n => Err(ServiceError::precondition(format!(
                 "ehr: URI {uri} path is not unique ({n} matches); item_at_path requires \
                  path_unique (RM common pathable)"
             ))),
@@ -93,7 +93,7 @@ impl FerroEhrService {
         }
         // A relative URI (no ehr_id) carries no EHR context to resolve against.
         let ehr_id = EhrId(uri.ehr_id.ok_or_else(|| {
-            ServiceError::BadRequest(
+            ServiceError::precondition(
                 "relative ehr: URI (no ehr_id) has no EHR context to resolve against".to_owned(),
             )
         })?);
@@ -162,14 +162,14 @@ impl FerroEhrService {
                         .0
                 }
                 other => {
-                    return Err(ServiceError::BadRequest(format!(
+                    return Err(ServiceError::precondition(format!(
                         "ehr: locator {other:?} requires a versioned-object id"
                     )));
                 }
             };
             (vo_id, None)
         } else {
-            return Err(ServiceError::BadRequest(
+            return Err(ServiceError::precondition(
                 "ehr: URI locator identifies no top-level structure".to_owned(),
             ));
         };
@@ -209,7 +209,7 @@ fn resolve_object_ref(object: &VersionLocator) -> Result<(VoId, Option<TreeId>),
     match object {
         VersionLocator::VersionedObject(uid) => {
             let vo_id = Uuid::parse_str(uid).map_err(|_| {
-                ServiceError::BadRequest(format!("ehr: locator uid {uid:?} is not a UUID"))
+                ServiceError::precondition(format!("ehr: locator uid {uid:?} is not a UUID"))
             })?;
             // A locator uid names a versioned object.
             Ok((VoId(vo_id), None))

--- a/app/ferroehr/src/service/ehr/validation.rs
+++ b/app/ferroehr/src/service/ehr/validation.rs
@@ -84,7 +84,7 @@ impl FerroEhrService {
                 && is_persistent(&read.canonical)
                 && composition_template_id(&read.canonical) == Some(template_id)
             {
-                return Err(ServiceError::Conflict(format!(
+                return Err(ServiceError::conflict(format!(
                     "EHR {ehr_id} already has a persistent COMPOSITION for template \
                      {template_id}; only one create is allowed (subsequent commits must \
                      be modifications)"
@@ -351,7 +351,7 @@ pub(in crate::service) async fn check_versioned_composition_invariants(
     if let (Some(stored), Some(incoming)) = (first_ani.as_deref(), incoming_ani)
         && stored != incoming
     {
-        return Err(ServiceError::Unprocessable(
+        return Err(ServiceError::content_invalid(
             Violation::new(format!(
                 "{incoming:?} differs from the versioned object's first version {stored:?}"
             ))
@@ -365,7 +365,7 @@ pub(in crate::service) async fn check_versioned_composition_invariants(
     if let (Some(stored), Some(incoming)) = (first_category.as_deref(), incoming_category)
         && (stored == code::PERSISTENT) != (incoming == code::PERSISTENT)
     {
-        return Err(ServiceError::Unprocessable(
+        return Err(ServiceError::content_invalid(
             Violation::new(format!(
                 "{incoming} changes the persistence of the versioned object \
                  (first version: {stored}) — is_persistent is fixed across versions"
@@ -420,7 +420,7 @@ pub(in crate::service) fn validate_root_locatable(
         .get("archetype_details")
         .filter(|v| v.is_object())
         .ok_or_else(|| {
-            ServiceError::Unprocessable(
+            ServiceError::content_invalid(
                 Violation::new(format!(
                     "is mandatory: {kind} is an archetype root (Is_archetype_root), \
                      and a root without ARCHETYPED is invalid"
@@ -435,7 +435,7 @@ pub(in crate::service) fn validate_root_locatable(
         .and_then(Value::as_str)
         .filter(|s| !s.is_empty())
         .ok_or_else(|| {
-            ServiceError::Unprocessable(
+            ServiceError::content_invalid(
                 Violation::new("is mandatory")
                     .with_path(format!("{kind}.archetype_details.archetype_id.value"))
                     .with_invariant("ARCHETYPED.archetype_id 1..1"),
@@ -474,7 +474,7 @@ pub(in crate::service) fn validate_root_locatable(
 /// [`ServiceError::ValidationFailed`] carrying the RM-invariant violations
 /// (both → 422).
 pub(in crate::service) fn validate_ehr_status(status: &Value) -> Result<(), ServiceError> {
-    let unproc = |m: String| ServiceError::Unprocessable(Violation::new(m));
+    let unproc = |m: String| ServiceError::content_invalid(Violation::new(m));
     let obj = status
         .as_object()
         .ok_or_else(|| unproc("EHR_STATUS must be a JSON object".to_owned()))?;
@@ -519,7 +519,7 @@ pub(in crate::service) fn validate_ehr_access(
     access: &Value,
     incomplete: bool,
 ) -> Result<(), ServiceError> {
-    let unproc = |m: String| ServiceError::Unprocessable(Violation::new(m));
+    let unproc = |m: String| ServiceError::content_invalid(Violation::new(m));
     let obj = access
         .as_object()
         .ok_or_else(|| unproc("EHR_ACCESS must be a JSON object".to_owned()))?;

--- a/app/ferroehr/src/service/ehr_index/mod.rs
+++ b/app/ferroehr/src/service/ehr_index/mod.rs
@@ -110,7 +110,7 @@ fn parse_valid_time(raw: Option<&str>) -> Result<Option<jiff_sqlx::Timestamp>, S
         Some(s) => s
             .parse::<jiff::Timestamp>()
             .map(|t| Some(t.to_sqlx()))
-            .map_err(|_| ServiceError::BadRequest(format!("invalid valid_time: {s}"))),
+            .map_err(|_| ServiceError::precondition(format!("invalid valid_time: {s}"))),
     }
 }
 

--- a/app/ferroehr/src/service/error.rs
+++ b/app/ferroehr/src/service/error.rs
@@ -176,33 +176,61 @@ impl std::fmt::Display for Violation {
 
 /// Service-layer error, mapped to the ITS-REST [`ApiError`] at the protocol
 /// boundary so the REST layer stays free of persistence concerns.
+///
+/// Every variant that stands for an SM `CALL_STATUS_TYPE` row carries the
+/// status it was classified from — as an [`SmError`], which also carries the
+/// failure that caused it — so the `ServiceError → SmError` conversion below
+/// restores both verbatim. The one deliberate exception is the `500`-class
+/// [`ServiceError::Internal`] row, whose body and reported status are curated
+/// (see its docs).
 #[derive(Debug, thiserror::Error)]
 pub enum ServiceError {
     /// The requested resource does not exist. Carries the granular SM
     /// does-not-exist status ([`CallStatusType`] `*_does_not_exist` family,
-    /// `master03-common_package.adoc` §Representing Call Status) so the
-    /// [`SmError`] conversion below restores it losslessly — construct via
-    /// [`ServiceError::sm`] naming the precise status; extension resources the
-    /// SM has no status for (tenants, event subscriptions, FHIR mappings, item
-    /// tags) use the generic `versioned_object_does_not_exist`.
+    /// `master03-common_package.adoc` §Representing Call Status) — construct
+    /// via [`ServiceError::sm`] naming the precise status; extension resources
+    /// the SM has no status for (tenants, event subscriptions, FHIR mappings,
+    /// item tags) use the generic `versioned_object_does_not_exist`.
     #[error("{0} not found")]
     NotFound(#[source] SmError),
     /// The request is malformed at the semantic level (e.g. a stale/invalid
     /// `preceding_version_uid`, or an operation on an already-deleted object) —
     /// ITS-REST `400 Bad Request` (`400_already_deleted.yaml`).
+    ///
+    /// Carries the `400`-class SM status: the generic
+    /// `precondition_violation` ([`ServiceError::precondition`]) or the
+    /// definition service's `invalid_id_pattern`
+    /// (`definition_call_status_type.adoc`).
     #[error("bad request: {0}")]
-    BadRequest(String),
-    /// The request conflicts with current state (e.g. EHR already exists).
+    BadRequest(#[source] SmError),
+    /// The request conflicts with current state (e.g. EHR already exists) —
+    /// ITS-REST `409 Conflict`.
+    ///
+    /// Carries the `409`-class SM status: `composition_already_exists`,
+    /// `ehr_create_fail_duplicate_id` or `ehr_for_subject_already_exists`
+    /// (`ehr_call_status_type.adoc`), or the generic `conflict` the storage
+    /// bridge classifies.
     #[error("conflict: {0}")]
-    Conflict(String),
-    /// Optimistic-concurrency precondition (`If-Match`) failed.
+    Conflict(#[source] SmError),
+    /// Optimistic-concurrency precondition (`If-Match`) failed — the SM
+    /// `version_mismatch` status (`call_status_type.adoc`), ITS-REST `412`.
     #[error("version conflict: {0}")]
-    VersionConflict(String),
+    VersionConflict(#[source] SmError),
     /// The submitted payload is malformed or fails a structural rule —
     /// carrying the violated rule as DATA ([`Violation`]: path, invariant,
     /// causes), rendered into prose only at the protocol edge.
-    #[error("unprocessable: {0}")]
-    Unprocessable(#[source] Violation),
+    #[error("unprocessable: {violation}")]
+    Unprocessable {
+        /// The `422`-class SM status the refusal reports: the generic
+        /// `content_invalid` ([`ServiceError::content_invalid`]), an
+        /// `invalid_archetype`/`invalid_template`/`invalid_artefact`/
+        /// `invalid_query` from `definition_call_status_type.adoc`, or
+        /// `composition_archetype_invalid` from `ehr_call_status_type.adoc`.
+        status: CallStatusType,
+        /// The violated rule, as data.
+        #[source]
+        violation: Violation,
+    },
     /// A well-formed payload that fails semantic (template/RM/terminology)
     /// validation — carries the per-path violations as the RM validation data
     /// type ([`InvariantViolation`]), which the protocol bridges below render
@@ -240,33 +268,19 @@ pub enum ServiceError {
     /// below trace it and answer with `INTERNAL_MESSAGE`.
     #[error("signing: {0}")]
     Signing(String),
-    /// A server-side fault with no more specific variant (SM
-    /// `CALL_STATUS_TYPE.exception` / `file_not_writable` — → HTTP 500).
+    /// A server-side fault with no more specific variant (the `500`-class SM
+    /// statuses — `exception`, `file_not_writable`, `auth_failure`,
+    /// `not_implemented`, `service_overloaded`).
     ///
-    /// The carried text is a LOG detail, not a wire message. Sites construct
-    /// it with whatever diagnoses the fault (a codec error, an unexpected
-    /// stored shape, a failed conversion); both bridges below put that on the
-    /// trace record and answer with `INTERNAL_MESSAGE`, because a `500` is
-    /// by definition something the client cannot act on.
+    /// The carried [`SmError`]'s message is a LOG detail, not a wire message,
+    /// and this is the ONE row whose SM status does not survive the round trip:
+    /// both bridges below trace the detail (and the whole cause chain) and
+    /// answer with `exception` + `INTERNAL_MESSAGE`, because a `500` is by
+    /// definition something the client cannot act on and must disclose no
+    /// internal error value. Construct with [`ServiceError::exception`], or
+    /// with [`ServiceError::internal`] to carry the failure that caused it.
     #[error("internal: {0}")]
-    Internal(String),
-    /// A failure carrying the error that CAUSED it, beside the SM status and
-    /// message the variants above carry as a bare string.
-    ///
-    /// The carried status routes to exactly the wire outcome
-    /// [`ServiceError::sm`] gives it, and the message is what the equivalent
-    /// flat variant would carry, so no response body changes. What the flat
-    /// variants cannot hold is the cause: a `String` payload has nowhere to put
-    /// the `sqlx`/codec/transport error that actually failed, and
-    /// `format!("…{e}")` destroys it before anything can walk it
-    /// ([RFC 0201](https://rust-lang.github.io/rfcs/0201-error-chaining.html)).
-    /// Here it rides [`SmError`]'s source field, out of the message — a
-    /// `500`-class body must disclose no internal error value.
-    ///
-    /// Construct via [`ServiceError::internal`] (a `500`) or
-    /// [`ServiceError::bad_request`] (a `400`).
-    #[error("{0}")]
-    Caused(#[source] SmError),
+    Internal(#[source] SmError),
 }
 
 /// The client-visible message of a server-side fault (`500`). Deliberately
@@ -363,30 +377,32 @@ impl std::fmt::Display for ErrorChain<'_> {
     }
 }
 
-impl ServiceError {
-    /// Construct the [`ServiceError`] variant for an SM call status — the
+impl From<SmError> for ServiceError {
+    /// Classify an SM call status into its [`ServiceError`] row — the
     /// service-side entry into the single SM ↔ `ServiceError` ↔ HTTP table
     /// (statuses per `CALL_STATUS_TYPE` + descendants, [`super::status`]).
     ///
-    /// Consistency with the wire is test-enforced: for every status,
-    /// `ApiError::from(ServiceError::sm(s, m))` and the protocol adapter's
-    /// SM → HTTP row (`ferroehr-rest::overview::error::sm_api_error`) produce
-    /// the same HTTP status.
-    #[must_use]
-    pub fn sm(status: CallStatusType, message: impl Into<String>) -> Self {
+    /// The whole [`SmError`] travels into the classified variant, so the
+    /// granular status and the carried cause both survive the return trip
+    /// through `From<ServiceError> for SmError`. The `500`-class rows are the
+    /// one deliberate exception (see [`ServiceError::Internal`]).
+    fn from(e: SmError) -> Self {
         use super::status::CallStatusType as S;
-        let m = message.into();
-        match status {
+        match e.status {
             // `success` is not an error; constructing it is a server bug.
             // Auth is decided at the adapter (401/403 before dispatch), so a
-            // service-side auth failure is likewise a server fault.
-            S::Success | S::Exception | S::FileNotWritable | S::AuthFailure => {
-                ServiceError::Internal(m)
-            }
-            S::PreconditionViolation | S::InvalidIdPattern => ServiceError::BadRequest(m),
-            // The does-not-exist family keeps its granular status inside the
-            // variant, so the `SmError` round-trip below is lossless — no
-            // per-method boundary re-raise needed.
+            // service-side auth failure is likewise a server fault. A
+            // not-implemented status is unreachable (the service implements
+            // every catalog call), and `service_overloaded` originates at the
+            // storage bridge and flows *up* to the wire as an `SmError`
+            // (→ `503`) rather than back into a `ServiceError`.
+            S::Success
+            | S::Exception
+            | S::FileNotWritable
+            | S::AuthFailure
+            | S::NotImplemented
+            | S::ServiceOverloaded => ServiceError::Internal(e),
+            S::PreconditionViolation | S::InvalidIdPattern => ServiceError::BadRequest(e),
             S::ObjectVersionDoesNotExist
             | S::VersionedObjectDoesNotExist
             | S::EhrIdDoesNotExist
@@ -397,64 +413,140 @@ impl ServiceError {
             | S::TemplateDoesNotExist
             | S::VersionDoesNotExist
             | S::SubjectIdDoesNotExist
-            | S::VersionedCompositionDoesNotExist => {
-                ServiceError::NotFound(SmError::new(status, m))
-            }
-            S::VersionMismatch => ServiceError::VersionConflict(m),
+            | S::VersionedCompositionDoesNotExist => ServiceError::NotFound(e),
+            S::VersionMismatch => ServiceError::VersionConflict(e),
             S::EhrCreateFailDuplicateId
             | S::CompositionAlreadyExists
             | S::EhrForSubjectAlreadyExists
             // A storage-classified generic conflict is also a `409`.
-            | S::Conflict => ServiceError::Conflict(m),
+            | S::Conflict => ServiceError::Conflict(e),
             S::CompositionArchetypeInvalid
             | S::InvalidArchetype
             | S::InvalidTemplate
             | S::InvalidArtefact
             | S::InvalidQuery
             | S::DefinitionUnknown
-            // An SM status arrives with a message and no separable facts, so
-            // the violation it becomes carries only its detail.
-            | S::ContentInvalid => ServiceError::Unprocessable(Violation::new(m)),
-            // No service-side `ServiceError::NotImplemented`; a not-implemented
-            // status surfaces as a server fault (the service implements every
-            // catalog call, so this row is unreachable in practice).
-            // `ServiceOverloaded` originates only at the storage bridge and
-            // flows *up* to the wire as an `SmError` (→ `503`); it never
-            // round-trips back into a `ServiceError`, so this defensive reverse
-            // mapping degrades to a server fault too.
-            S::NotImplemented | S::ServiceOverloaded => ServiceError::Internal(m),
+            | S::ContentInvalid => unprocessable_from_sm(e),
         }
+    }
+}
+
+/// The `422`-class row of the `From<SmError>` classifier: an SM status arrives
+/// with a message and no separable facts, so the [`Violation`] it becomes
+/// carries only its detail — plus the SM error itself as the violation's cause
+/// when one was attached, so no chain is dropped on the way in.
+fn unprocessable_from_sm(e: SmError) -> ServiceError {
+    let status = e.status;
+    let violation = Violation::new(e.message.clone());
+    let violation = if std::error::Error::source(&e).is_some() {
+        violation.with_source(e)
+    } else {
+        violation
+    };
+    ServiceError::Unprocessable { status, violation }
+}
+
+impl ServiceError {
+    /// Construct the [`ServiceError`] variant for an SM call status and message.
+    ///
+    /// Consistency with the wire is test-enforced: for every status,
+    /// `ApiError::from(ServiceError::sm(s, m))` and the protocol adapter's
+    /// SM → HTTP row (`ferroehr-rest::overview::error::sm_api_error`) produce
+    /// the same HTTP status.
+    #[must_use]
+    pub fn sm(status: CallStatusType, message: impl Into<String>) -> Self {
+        Self::from(SmError::new(status, message))
+    }
+
+    /// A malformed-request refusal (`400`) reporting the generic SM
+    /// `precondition_violation` status.
+    ///
+    /// The message is client-visible: a `4xx` describes the caller's own
+    /// request, so naming the defect there is the contract. A `400` the SM
+    /// names more precisely (`invalid_id_pattern`) is built with
+    /// [`ServiceError::sm`] instead.
+    #[must_use]
+    pub fn precondition(message: impl Into<String>) -> Self {
+        ServiceError::BadRequest(SmError::precondition(message))
+    }
+
+    /// A state-conflict refusal (`409`) reporting the SM
+    /// `composition_already_exists` status.
+    ///
+    /// That is the representative `409` of `ehr_call_status_type.adoc`; a
+    /// conflict the SM names more precisely
+    /// (`ehr_create_fail_duplicate_id`, `ehr_for_subject_already_exists`) is
+    /// built with [`ServiceError::sm`] instead.
+    #[must_use]
+    pub fn conflict(message: impl Into<String>) -> Self {
+        ServiceError::Conflict(SmError::new(
+            CallStatusType::CompositionAlreadyExists,
+            message,
+        ))
+    }
+
+    /// An optimistic-concurrency refusal (`412`) — the SM `version_mismatch`
+    /// status.
+    #[must_use]
+    pub fn version_conflict(message: impl Into<String>) -> Self {
+        ServiceError::VersionConflict(SmError::version_mismatch(message))
+    }
+
+    /// A semantic refusal (`422`) reporting the generic SM `content_invalid`
+    /// status, carrying the violated rule as data.
+    ///
+    /// A `422` the SM names more precisely (`invalid_archetype`,
+    /// `invalid_template`, `invalid_artefact`, `invalid_query`,
+    /// `composition_archetype_invalid`) is built with [`ServiceError::sm`], or
+    /// by naming the `status` field directly when the [`Violation`] carries
+    /// separable facts.
+    #[must_use]
+    pub fn content_invalid(violation: Violation) -> Self {
+        ServiceError::Unprocessable {
+            status: CallStatusType::ContentInvalid,
+            violation,
+        }
+    }
+
+    /// A server-side fault (`500`) whose diagnosis is a log detail.
+    ///
+    /// `detail` diagnoses the fault (a codec error, an unexpected stored shape,
+    /// a failed conversion); both bridges below put it on the trace record and
+    /// answer with `INTERNAL_MESSAGE`. Use [`ServiceError::internal`] when the
+    /// failure that caused it is available as an error value.
+    #[must_use]
+    pub fn exception(detail: impl Into<String>) -> Self {
+        ServiceError::Internal(SmError::exception(detail))
     }
 
     /// A server-side fault (`500`) that carries the failure which caused it.
     ///
     /// `context` names the step that failed and is a LOG detail: the client
-    /// body is the fixed internal message on both bridges, never this text and never
-    /// the cause. The cause is reachable through
+    /// body is the fixed internal message on both bridges, never this text and
+    /// never the cause. The cause is reachable through
     /// [`std::error::Error::source`], which is what lets an operator read the
-    /// `sqlx`/codec diagnosis the flat [`ServiceError::Internal`] string
-    /// destroys.
+    /// `sqlx`/codec diagnosis a stringified cause destroys
+    /// ([RFC 0201](https://rust-lang.github.io/rfcs/0201-error-chaining.html)).
     #[must_use]
     pub fn internal(
         context: impl Into<String>,
         source: impl std::error::Error + Send + Sync + 'static,
     ) -> Self {
-        ServiceError::Caused(SmError::exception(context).with_source(source))
+        ServiceError::Internal(SmError::exception(context).with_source(source))
     }
 
     /// A malformed-request refusal (`400`) that carries the failure which
     /// caused it.
     ///
-    /// `detail` is the client-visible text, unchanged from what the flat
-    /// [`ServiceError::BadRequest`] carried: a `4xx` describes the caller's own
-    /// request, so naming the defect there is the contract. The cause rides the
-    /// source chain for the log and for callers that branch on it.
+    /// `detail` is the client-visible text, identical to what
+    /// [`ServiceError::precondition`] carries; the cause rides the source chain
+    /// for the log and for callers that branch on it.
     #[must_use]
     pub fn bad_request(
         detail: impl Into<String>,
         source: impl std::error::Error + Send + Sync + 'static,
     ) -> Self {
-        ServiceError::Caused(SmError::precondition(detail).with_source(source))
+        ServiceError::BadRequest(SmError::precondition(detail).with_source(source))
     }
 }
 
@@ -470,21 +562,22 @@ impl From<ServiceError> for SmError {
     /// | `ServiceError`            | `CallStatusType`             | HTTP |
     /// |---------------------------|------------------------------|------|
     /// | `NotFound`                | its carried granular status  | 404  |
-    /// | `VersionConflict`         | `VersionMismatch`            | 412  |
-    /// | `Conflict`                | `CompositionAlreadyExists`   | 409  |
-    /// | `Unprocessable`           | `ContentInvalid`             | 422  |
+    /// | `BadRequest`              | its carried granular status  | 400  |
+    /// | `Conflict`                | its carried granular status  | 409  |
+    /// | `VersionConflict`         | its carried `VersionMismatch`| 412  |
+    /// | `Unprocessable`           | its carried granular status  | 422  |
     /// | `ValidationFailed`        | `ContentInvalid`             | 422  |
-    /// | `BadRequest`              | `PreconditionViolation`      | 400  |
     /// | `Storage`/`Database`      | classified: 409/503/500      |      |
     /// | `JsonRead`                | `PreconditionViolation`      | 400  |
-    /// | `JsonWrite`/`Signing`/`Internal` | `Exception`           | 500  |
-    /// | `Caused`                  | its carried status            |      |
+    /// | `JsonWrite`/`Signing`     | `Exception`                  | 500  |
+    /// | `Internal`                | `Exception` (curated)        | 500  |
     ///
-    /// `NotFound` carries the granular does-not-exist [`SmError`] it was
-    /// constructed with ([`ServiceError::sm`]), so the round-trip restores the
-    /// precise status — `ehr_id_does_not_exist` stays `ehr_id_does_not_exist`,
-    /// never a resurrected generic. `Conflict` maps to a representative
-    /// already-exists status (all 409s).
+    /// Every status-carrying row restores the [`SmError`] it was constructed
+    /// with ([`ServiceError::sm`]), so the round-trip is lossless —
+    /// `ehr_id_does_not_exist` stays `ehr_id_does_not_exist` and
+    /// `invalid_id_pattern` stays `invalid_id_pattern`, never a resurrected
+    /// generic. Only the `500`-class `Internal` row substitutes a curated
+    /// status and message, because its detail must not reach a client.
     ///
     /// NOTE (wire — settled, adjudicated divergence): the structured per-path
     /// violations of `ValidationFailed` (the ITS-REST `Error.validationErrors[]`
@@ -511,14 +604,17 @@ impl From<ServiceError> for SmError {
     fn from(e: ServiceError) -> Self {
         use super::status::CallStatusType as S;
         match e {
-            // Lossless: the granular does-not-exist status travels inside the
-            // variant (see `ServiceError::sm`).
-            ServiceError::NotFound(e) => e,
-            ServiceError::VersionConflict(m) => SmError::new(S::VersionMismatch, m),
-            ServiceError::Conflict(m) => SmError::new(S::CompositionAlreadyExists, m),
+            // Lossless: the granular status travels inside the variant, cause
+            // and message untouched (see `From<SmError> for ServiceError`).
+            ServiceError::NotFound(e)
+            | ServiceError::BadRequest(e)
+            | ServiceError::Conflict(e)
+            | ServiceError::VersionConflict(e) => e,
             // The ONE rendering point of a `Violation` on the SM bridge: the
             // facts travel as data all the way from the throw site to here.
-            ServiceError::Unprocessable(v) => SmError::new(S::ContentInvalid, v.to_string()),
+            ServiceError::Unprocessable { status, violation } => {
+                SmError::new(status, violation.to_string())
+            }
             ServiceError::ValidationFailed(v) => {
                 let joined = v
                     .into_iter()
@@ -527,7 +623,6 @@ impl From<ServiceError> for SmError {
                     .join("; ");
                 SmError::new(S::ContentInvalid, joined)
             }
-            ServiceError::BadRequest(m) => SmError::new(S::PreconditionViolation, m),
             ServiceError::Storage(e) => SmError::from(e),
             // A raw `sqlx` error carries SQLSTATE/constraint detail: classify it
             // (integrity/serialization conflict → 409, pool exhaustion → 503)
@@ -540,41 +635,11 @@ impl From<ServiceError> for SmError {
             ServiceError::JsonRead(e) => SmError::new(S::PreconditionViolation, e.to_string()),
             ServiceError::JsonWrite(e) => internal_fault("serialize a JSON payload", &e),
             ServiceError::Signing(m) => internal_fault("sign or verify a version", &m),
-            ServiceError::Internal(m) => internal_fault("complete the request", &m),
-            ServiceError::Caused(sm) => caused_sm_error(sm),
+            // The curated row: the detail and the whole cause chain go to the
+            // trace record, the client gets `exception` + `INTERNAL_MESSAGE`.
+            ServiceError::Internal(sm) => internal_fault_caused("complete the request", &sm),
         }
     }
-}
-
-/// The SM half of the [`ServiceError::Caused`] row: a `500`-class status
-/// answers the curated opaque message (with the whole cause chain traced),
-/// every other status IS already the [`SmError`] the wire needs — cause
-/// included, message untouched.
-fn caused_sm_error(sm: SmError) -> SmError {
-    if is_server_fault(sm.status) {
-        internal_fault_caused("complete the request", &sm)
-    } else {
-        sm
-    }
-}
-
-/// Whether an SM status is one [`ServiceError::sm`] routes to
-/// [`ServiceError::Internal`] — the `500`-class rows whose body is the curated
-/// opaque message, never the carried detail.
-///
-/// The single authority both [`ServiceError::Caused`] bridges consult, so a
-/// cause-carrying failure lands on exactly the wire outcome its flat twin does.
-fn is_server_fault(status: CallStatusType) -> bool {
-    use super::status::CallStatusType as S;
-    matches!(
-        status,
-        S::Success
-            | S::Exception
-            | S::FileNotWritable
-            | S::AuthFailure
-            | S::NotImplemented
-            | S::ServiceOverloaded
-    )
 }
 
 impl From<ServiceError> for ApiError {
@@ -583,11 +648,13 @@ impl From<ServiceError> for ApiError {
             // Every does-not-exist status is a wire 404; the message is the
             // carried `SmError`'s text (unchanged from construction).
             ServiceError::NotFound(e) => ApiError::NotFound(e.message),
-            ServiceError::BadRequest(m) => ApiError::BadRequest(m),
-            ServiceError::Conflict(m) => ApiError::Conflict(m),
-            ServiceError::VersionConflict(m) => ApiError::PreconditionFailed(m),
+            ServiceError::BadRequest(e) => ApiError::BadRequest(e.message),
+            ServiceError::Conflict(e) => ApiError::Conflict(e.message),
+            ServiceError::VersionConflict(e) => ApiError::PreconditionFailed(e.message),
             // The ONE rendering point of a `Violation` on the wire bridge.
-            ServiceError::Unprocessable(v) => ApiError::Unprocessable(v.to_string()),
+            ServiceError::Unprocessable { violation, .. } => {
+                ApiError::Unprocessable(violation.to_string())
+            }
             // The ONE place the RM violation data becomes the protocol's
             // `validationErrors[]` shape (the two carry the same `{path,
             // message}` facts).
@@ -623,15 +690,9 @@ impl From<ServiceError> for ApiError {
             ServiceError::Signing(m) => {
                 ApiError::Internal(internal_fault("sign or verify a version", &m).message)
             }
-            ServiceError::Internal(m) => {
-                ApiError::Internal(internal_fault("complete the request", &m).message)
-            }
-            // The cause-carrying row: routed by its SM status through exactly
-            // the table above, so the wire outcome equals the flat variant's.
-            ServiceError::Caused(sm) if is_server_fault(sm.status) => {
+            ServiceError::Internal(sm) => {
                 ApiError::Internal(internal_fault_caused("complete the request", &sm).message)
             }
-            ServiceError::Caused(sm) => ApiError::from(ServiceError::sm(sm.status, sm.message)),
         }
     }
 }
@@ -861,7 +922,7 @@ mod tests {
         let detail = "typing the ORIGINAL_VERSION: unknown field `_kind` at line 3 column 12";
         let markers = ["ORIGINAL_VERSION", "unknown field", "_kind", "line 3"];
         let variants: [fn(String) -> ServiceError; 2] =
-            [ServiceError::Internal, ServiceError::Signing];
+            [ServiceError::exception, ServiceError::Signing];
         for make in variants {
             let sm = crate::service::status::SmError::from(make(detail.to_owned()));
             assert_eq!(sm.status, S::Exception);
@@ -882,8 +943,9 @@ mod tests {
         }
     }
 
-    /// Every SM status a [`ServiceError::Caused`] can carry lands on exactly
-    /// the wire outcome — status AND body text — its cause-less twin produces.
+    /// Every SM status carried with a cause lands on exactly the wire outcome —
+    /// status AND body text — its cause-less twin produces, and reports the
+    /// same SM status back.
     ///
     /// This is the whole safety property of carrying a cause: the chain is a
     /// new fact for the operator, never a change to what the client is told.
@@ -891,10 +953,13 @@ mod tests {
     #[test]
     fn a_carried_cause_changes_no_wire_outcome() {
         for status in every_status() {
+            let caused = || {
+                ServiceError::from(
+                    crate::service::status::SmError::new(status, "m").with_source(cause()),
+                )
+            };
             let flat_api = ApiError::from(ServiceError::sm(status, "m"));
-            let caused_api = ApiError::from(ServiceError::Caused(
-                crate::service::status::SmError::new(status, "m").with_source(cause()),
-            ));
+            let caused_api = ApiError::from(caused());
             assert_eq!(
                 caused_api.status(),
                 flat_api.status(),
@@ -909,25 +974,17 @@ mod tests {
             );
 
             let flat_sm = crate::service::status::SmError::from(ServiceError::sm(status, "m"));
-            let caused_sm = crate::service::status::SmError::from(ServiceError::Caused(
-                crate::service::status::SmError::new(status, "m").with_source(cause()),
-            ));
+            let caused_sm = crate::service::status::SmError::from(caused());
             assert_eq!(
                 caused_sm.message,
                 flat_sm.message,
                 "row {} diverged on the SM message",
                 status.sm_name()
             );
-            // The two SM statuses need not be the same NAME: a flat variant with
-            // a bare-string payload (`Conflict`, `Unprocessable`) has no slot for
-            // WHICH conflict or WHICH 422 it was, so its bridge substitutes a
-            // representative status (see the conversion table above) where the
-            // cause-carrying row keeps the one it was built with. What must hold
-            // is that both land on the same wire outcome.
             assert_eq!(
-                ApiError::from(ServiceError::sm(caused_sm.status, "m")).status(),
-                ApiError::from(ServiceError::sm(flat_sm.status, "m")).status(),
-                "row {} routed the two SM statuses to different wire codes",
+                caused_sm.status,
+                flat_sm.status,
+                "row {} diverged on the SM status",
                 status.sm_name()
             );
         }
@@ -1002,10 +1059,10 @@ mod tests {
             Some(std::io::ErrorKind::PermissionDenied)
         );
 
-        let api = ApiError::from(ServiceError::Unprocessable(carried));
+        let api = ApiError::from(ServiceError::content_invalid(carried));
         assert_eq!(
             api.to_string(),
-            ApiError::from(ServiceError::Unprocessable(plain)).to_string()
+            ApiError::from(ServiceError::content_invalid(plain)).to_string()
         );
     }
 
@@ -1094,5 +1151,142 @@ mod tests {
             );
             assert_eq!(restored.message, "m", "message must survive unchanged");
         }
+    }
+
+    /// EVERY SM status survives the `ServiceError` round-trip verbatim, except
+    /// the `500`-class rows that are curated by design.
+    ///
+    /// The total form of the property the does-not-exist test above pins for one
+    /// family: the SM models each of these as a distinct `CALL_STATUS_TYPE`
+    /// code (`master03-common_package.adoc` §Representing Call Status,
+    /// `ehr_call_status_type.adoc`, `definition_call_status_type.adoc`), so a
+    /// status normalized away on the way through is information the caller
+    /// cannot get back. The exceptions are enumerated here rather than skipped:
+    /// a `500` answers `exception` + the curated message because its detail
+    /// must not reach a client (see [`ServiceError::Internal`]).
+    #[test]
+    fn every_status_round_trips_except_the_curated_server_faults() {
+        let curated = [
+            S::Success,
+            S::Exception,
+            S::FileNotWritable,
+            S::AuthFailure,
+            S::NotImplemented,
+            S::ServiceOverloaded,
+        ];
+        for status in every_status() {
+            let restored = crate::service::status::SmError::from(ServiceError::sm(status, "m"));
+            if curated.contains(&status) {
+                assert_eq!(
+                    restored.status,
+                    S::Exception,
+                    "{} is a curated server fault and must answer `exception`",
+                    status.sm_name()
+                );
+                assert_eq!(
+                    restored.message,
+                    super::INTERNAL_MESSAGE,
+                    "{} must answer the curated opaque message",
+                    status.sm_name()
+                );
+                continue;
+            }
+            assert_eq!(
+                restored.status,
+                status,
+                "{} resurrected as {}",
+                status.sm_name(),
+                restored.status.sm_name()
+            );
+            assert_eq!(
+                restored.message,
+                "m",
+                "{} must carry its message unchanged",
+                status.sm_name()
+            );
+        }
+    }
+
+    /// The three families #2124 named — the `400`, `409` and `422` rows — each
+    /// classify into their own variant AND report their granular status back.
+    ///
+    /// Named separately from the total sweep above because it is the specific
+    /// regression: `invalid_id_pattern` used to return as
+    /// `precondition_violation`, every `409` as `composition_already_exists`,
+    /// and the whole `422` family as `content_invalid`.
+    #[test]
+    fn the_bad_request_conflict_and_unprocessable_families_keep_their_status() {
+        let rows = [
+            (S::PreconditionViolation, "BadRequest"),
+            (S::InvalidIdPattern, "BadRequest"),
+            (S::EhrCreateFailDuplicateId, "Conflict"),
+            (S::CompositionAlreadyExists, "Conflict"),
+            (S::EhrForSubjectAlreadyExists, "Conflict"),
+            (S::Conflict, "Conflict"),
+            (S::VersionMismatch, "VersionConflict"),
+            (S::CompositionArchetypeInvalid, "Unprocessable"),
+            (S::InvalidArchetype, "Unprocessable"),
+            (S::InvalidTemplate, "Unprocessable"),
+            (S::InvalidArtefact, "Unprocessable"),
+            (S::InvalidQuery, "Unprocessable"),
+            (S::DefinitionUnknown, "Unprocessable"),
+            (S::ContentInvalid, "Unprocessable"),
+        ];
+        for (status, variant) in rows {
+            let service_err = ServiceError::sm(status, "m");
+            let classified = match &service_err {
+                ServiceError::BadRequest(_) => "BadRequest",
+                ServiceError::Conflict(_) => "Conflict",
+                ServiceError::VersionConflict(_) => "VersionConflict",
+                ServiceError::Unprocessable { .. } => "Unprocessable",
+                other => panic!("{} classified as {other:?}", status.sm_name()),
+            };
+            assert_eq!(
+                classified,
+                variant,
+                "row {} classified wrong",
+                status.sm_name()
+            );
+            let restored = crate::service::status::SmError::from(service_err);
+            assert_eq!(
+                restored.status,
+                status,
+                "{} resurrected as {}",
+                status.sm_name(),
+                restored.status.sm_name()
+            );
+            assert_eq!(restored.message, "m", "message must survive unchanged");
+        }
+    }
+
+    /// A cause attached to a `422`-class SM status survives the classifier: the
+    /// chain reaches the concrete underlying error and the rendered body is
+    /// unchanged.
+    #[test]
+    fn a_cause_on_an_unprocessable_status_stays_walkable() {
+        use std::error::Error;
+
+        let caused = ServiceError::from(
+            crate::service::status::SmError::new(S::InvalidQuery, "not valid AQL")
+                .with_source(cause()),
+        );
+        let mut found = None;
+        let mut next = Error::source(&caused);
+        while let Some(step) = next {
+            if let Some(io) = step.downcast_ref::<std::io::Error>() {
+                found = Some(io.kind());
+            }
+            next = step.source();
+        }
+        assert_eq!(
+            found,
+            Some(std::io::ErrorKind::PermissionDenied),
+            "the cause attached to a 422 status must stay reachable"
+        );
+        assert_eq!(
+            ApiError::from(caused).to_string(),
+            ApiError::from(ServiceError::sm(S::InvalidQuery, "not valid AQL")).to_string(),
+            "a carried cause must not change the 422 body"
+        );
     }
 }

--- a/app/ferroehr/src/service/message/import.rs
+++ b/app/ferroehr/src/service/message/import.rs
@@ -215,7 +215,7 @@ impl FerroEhrService {
                 && let Some((existing_vo, _)) = self.current_vo(an_ehr_id, container.kind).await?
                 && existing_vo != container.vo_id
             {
-                return Err(ServiceError::Conflict(format!(
+                return Err(ServiceError::conflict(format!(
                     "EHR {an_ehr_id} already has a {} ({existing_vo}); cannot import a \
                      second one ({})",
                     container.kind.as_str(),

--- a/app/ferroehr/src/service/query/execute.rs
+++ b/app/ferroehr/src/service/query/execute.rs
@@ -228,10 +228,10 @@ impl FerroEhrService {
             return Ok(ir);
         }
         // Miss: full parse → terminology expansion → lowering.
-        // NOTE: `parse_str` reports a located grammar diagnostic as a `String`,
-        // so there is no cause to carry — the diagnostic IS the answer.
-        let mut ast = parse_str(aql)
-            .map_err(|e| Failure::analysis(SmError::precondition(format!("invalid AQL: {e}"))))?;
+        let mut ast = parse_str(aql).map_err(|e| {
+            let message = format!("invalid AQL: {e}");
+            Failure::analysis(SmError::precondition(message).with_source(e))
+        })?;
         // Semantic-analysis pre-pass: resolve every `TERMINOLOGY('expand', …)`
         // used in a `matches` operand through the terminology-service seam
         // and merge the codes into the value list, before planning

--- a/app/ferroehr/src/service/subject_proxy/config.rs
+++ b/app/ferroehr/src/service/subject_proxy/config.rs
@@ -116,7 +116,7 @@ impl FhirSystemClient {
             .build()
             .map_err(|e| {
                 SmError::exception(format!(
-                    "building subject-proxy FHIR client for system '{name}': {e}"
+                    "building the subject-proxy FHIR client for system '{name}' failed"
                 ))
                 .with_source(e)
             })?;

--- a/app/ferroehr/src/service/terminology/fhir.rs
+++ b/app/ferroehr/src/service/terminology/fhir.rs
@@ -125,11 +125,14 @@ impl FhirTerminologyProvider {
         // material is a boot failure here, never a first-request surprise
         // ([`super::tls`]).
         let builder = super::tls::apply(builder, cfg).map_err(|e| {
-            SmError::exception(format!("terminology provider '{name}': {e}")).with_source(e)
+            SmError::exception(format!(
+                "terminology provider '{name}': the configured TLS material is unusable"
+            ))
+            .with_source(e)
         })?;
         let client = builder.build().map_err(|e| {
             SmError::exception(format!(
-                "building terminology client for provider '{name}': {e}"
+                "building the terminology client for provider '{name}' failed"
             ))
             .with_source(e)
         })?;

--- a/app/ferroehr/src/service/validity.rs
+++ b/app/ferroehr/src/service/validity.rs
@@ -77,7 +77,9 @@ impl FerroEhrService {
         };
         match self.validate_for_commit(kind, a_content, false).await {
             Ok(()) => Ok(true),
-            Err(ServiceError::ValidationFailed(_) | ServiceError::Unprocessable(_)) => Ok(false),
+            Err(ServiceError::ValidationFailed(_) | ServiceError::Unprocessable { .. }) => {
+                Ok(false)
+            }
             Err(other) => Err(other.into()),
         }
     }

--- a/app/ferroehr/src/templates/ingest.rs
+++ b/app/ferroehr/src/templates/ingest.rs
@@ -54,7 +54,7 @@ use crate::service::error::ServiceError;
 pub(crate) fn parse_opt(xml: &str) -> Result<OperationalTemplate, ServiceError> {
     require_well_formed_xml(xml)?;
     openehr_its::opt14::from_xml(xml).map_err(|e| {
-        ServiceError::Unprocessable(crate::service::error::Violation::new(format!(
+        ServiceError::content_invalid(crate::service::error::Violation::new(format!(
             "invalid OPT 1.4 XML: {e}"
         )))
     })
@@ -76,7 +76,7 @@ fn require_well_formed_xml(xml: &str) -> Result<(), ServiceError> {
             }
             Ok(_) => {}
             Err(e) => {
-                return Err(ServiceError::BadRequest(format!(
+                return Err(ServiceError::precondition(format!(
                     "syntactically invalid XML content: {e}"
                 )));
             }
@@ -85,7 +85,7 @@ fn require_well_formed_xml(xml: &str) -> Result<(), ServiceError> {
     if saw_root {
         Ok(())
     } else {
-        Err(ServiceError::BadRequest(
+        Err(ServiceError::precondition(
             "syntactically invalid XML content: the document has no root element".to_owned(),
         ))
     }

--- a/app/ferroehr/src/templates/runtime.rs
+++ b/app/ferroehr/src/templates/runtime.rs
@@ -176,7 +176,7 @@ impl FerroEhrService {
             })
             .await
             .map_err(|e| {
-                ServiceError::Unprocessable(Violation::new(format!(
+                ServiceError::content_invalid(Violation::new(format!(
                     "operational template {template_id} could not be built into a WebTemplate: {e}"
                 )))
             })

--- a/app/ferroehr/src/templates/store.rs
+++ b/app/ferroehr/src/templates/store.rs
@@ -96,14 +96,14 @@ impl FerroEhrService {
 
         let template_id = opt.template_id.value;
         if template_id.trim().is_empty() {
-            return Err(ServiceError::Unprocessable(
+            return Err(ServiceError::content_invalid(
                 Violation::new("is missing from the operational template").with_path("template_id"),
             ));
         }
         // `concept` is a mandatory `OPERATIONAL_TEMPLATE` attribute; an empty one
         // is a malformed OPT (CNF `removed_mandatory_elements/…removed_concept_value`).
         if opt.concept.trim().is_empty() {
-            return Err(ServiceError::Unprocessable(
+            return Err(ServiceError::content_invalid(
                 Violation::new("of the operational template is empty").with_path("concept"),
             ));
         }
@@ -131,7 +131,7 @@ impl FerroEhrService {
         .fetch_optional(&mut *tx)
         .await?
         .ok_or_else(|| {
-            ServiceError::Conflict(format!(
+            ServiceError::conflict(format!(
                 "an operational template with template_id '{template_id}' already exists"
             ))
         })?;

--- a/app/ferroehr/src/validation/structure.rs
+++ b/app/ferroehr/src/validation/structure.rs
@@ -56,7 +56,7 @@ pub(super) fn validate_opt_structure(xml: &str) -> Result<(), ServiceError> {
     let mut check = |raw: &[u8]| -> Result<(), ServiceError> {
         let name = String::from_utf8_lossy(raw).into_owned();
         if !OPT_TOP_LEVEL.contains(&name.as_str()) {
-            return Err(ServiceError::Unprocessable(
+            return Err(ServiceError::content_invalid(
                 Violation::new(
                     "is an unexpected top-level element of an operational template \
                      (not an OPERATIONAL_TEMPLATE attribute)",
@@ -67,7 +67,7 @@ pub(super) fn validate_opt_structure(xml: &str) -> Result<(), ServiceError> {
         let count = seen.entry(name.clone()).or_insert(0);
         *count += 1;
         if *count > 1 && !OPT_TOP_LEVEL_MULTIPLE.contains(&name.as_str()) {
-            return Err(ServiceError::Unprocessable(
+            return Err(ServiceError::content_invalid(
                 Violation::new("is a duplicate single-valued element of an operational template")
                     .with_path(format!("<{name}>")),
             ));
@@ -93,7 +93,7 @@ pub(super) fn validate_opt_structure(xml: &str) -> Result<(), ServiceError> {
             Ok(Event::End(_)) => depth -= 1,
             Ok(Event::Eof) => break,
             Err(e) => {
-                return Err(ServiceError::Unprocessable(Violation::new(format!(
+                return Err(ServiceError::content_invalid(Violation::new(format!(
                     "operational template XML is malformed: {e}"
                 ))));
             }

--- a/app/ferroehr/src/versioning/attestation.rs
+++ b/app/ferroehr/src/versioning/attestation.rs
@@ -115,7 +115,7 @@ pub(crate) async fn attest(
     // §Copying — "the ORIGINAL_VERSION instance is never modified"), so it is
     // not an attestable target.
     if target.imported {
-        return Err(ServiceError::Unprocessable(
+        return Err(ServiceError::content_invalid(
             Violation::new(
                 "names an IMPORTED_VERSION — attestations can only be added to \
                  Original versions",
@@ -251,7 +251,7 @@ impl AttestationParts {
     pub(crate) fn decode(partial: &Value) -> Result<Self, ServiceError> {
         // reason (1..1)
         let reason = partial.get("reason").ok_or_else(|| {
-            ServiceError::Unprocessable(
+            ServiceError::content_invalid(
                 Violation::new("is required (1..1)").with_path("ATTESTATION.reason"),
             )
         })?;
@@ -270,7 +270,7 @@ impl AttestationParts {
             .get("is_pending")
             .and_then(Value::as_bool)
             .ok_or_else(|| {
-                ServiceError::Unprocessable(
+                ServiceError::content_invalid(
                     Violation::new("is required (1..1 Boolean)")
                         .with_path("ATTESTATION.is_pending"),
                 )
@@ -310,7 +310,7 @@ impl AttestationParts {
                 .filter(|v| !v.is_null())
                 .map(|v| {
                     v.as_str().map(str::to_owned).ok_or_else(|| {
-                        ServiceError::Unprocessable(
+                        ServiceError::content_invalid(
                             Violation::new("must be a String (0..1)")
                                 .with_path("ATTESTATION.proof"),
                         )
@@ -512,7 +512,7 @@ fn reason_code_valid(code: &str) -> Result<(), ServiceError> {
     if openehr_term::bundle::openehr().is_valid_attestation_reason(code) {
         return Ok(());
     }
-    Err(ServiceError::Unprocessable(
+    Err(ServiceError::content_invalid(
         Violation::new(format!(
             "{code:?} is not in the openEHR `attestation reason` group"
         ))
@@ -537,7 +537,7 @@ fn reason_valid(reason: &DvText) -> Result<(), ServiceError> {
 /// common `UML/classes/org.openehr.rm.common.attestation.adoc` §Invariants) —
 /// the single violation both arrival routes raise for a present-but-empty list.
 fn items_valid_violation() -> ServiceError {
-    ServiceError::Unprocessable(
+    ServiceError::content_invalid(
         Violation::new("must be a non-empty list when present")
             .with_path("ATTESTATION.items")
             .with_invariant("ATTESTATION.Items_valid"),
@@ -552,7 +552,7 @@ fn decode<T: serde::de::DeserializeOwned>(
     rm_type: &str,
 ) -> Result<T, ServiceError> {
     openehr_its::json::from_canonical_value::<T>(value).map_err(|e| {
-        ServiceError::Unprocessable(
+        ServiceError::content_invalid(
             Violation::new(format!("is not a valid {rm_type}"))
                 .with_path(attribute)
                 .with_decode_failure(&e),
@@ -684,7 +684,7 @@ mod tests {
         // Asserted as DATA: the refused attribute path, and the decode
         // failure's own JSON path carried in the causes.
         match err {
-            ServiceError::Unprocessable(v) => {
+            ServiceError::Unprocessable { violation: v, .. } => {
                 assert_eq!(v.path(), Some("AUDIT_DETAILS.description"));
                 assert_eq!(v.causes().len(), 1, "the decode failure is the cause");
             }
@@ -708,7 +708,7 @@ mod tests {
             }))
             .expect_err("a malformed attested_view must be refused");
             match err {
-                ServiceError::Unprocessable(v) => {
+                ServiceError::Unprocessable { violation: v, .. } => {
                     assert_eq!(v.path(), Some("ATTESTATION.attested_view"));
                     assert_eq!(v.detail(), "is not a valid DV_MULTIMEDIA");
                 }
@@ -727,7 +727,7 @@ mod tests {
         }))
         .expect_err("a non-string proof must be refused");
         match err {
-            ServiceError::Unprocessable(v) => {
+            ServiceError::Unprocessable { violation: v, .. } => {
                 assert_eq!(v.path(), Some("ATTESTATION.proof"));
                 assert_eq!(v.detail(), "must be a String (0..1)");
             }
@@ -747,7 +747,9 @@ mod tests {
         .expect_err("a malformed items member must be refused");
         match err {
             // The offending INDEX is data on the path, not a substring hunt.
-            ServiceError::Unprocessable(v) => assert_eq!(v.path(), Some("ATTESTATION.items[1]")),
+            ServiceError::Unprocessable { violation: v, .. } => {
+                assert_eq!(v.path(), Some("ATTESTATION.items[1]"));
+            }
             other => panic!("expected Unprocessable, got {other:?}"),
         }
     }
@@ -773,7 +775,7 @@ mod tests {
         }))
         .expect_err("an out-of-group coded reason must be refused");
         match err {
-            ServiceError::Unprocessable(v) => {
+            ServiceError::Unprocessable { violation: v, .. } => {
                 assert_eq!(v.path(), Some("ATTESTATION.reason.defining_code"));
                 assert_eq!(v.invariant(), Some("ATTESTATION.Reason_valid"));
             }
@@ -875,7 +877,7 @@ mod tests {
             "is_pending": false
         }));
         match AttestationInput::from_update(&update) {
-            Err(ServiceError::Unprocessable(v)) => {
+            Err(ServiceError::Unprocessable { violation: v, .. }) => {
                 assert_eq!(v.path(), Some("ATTESTATION.reason.defining_code"));
                 assert_eq!(v.invariant(), Some("ATTESTATION.Reason_valid"));
             }
@@ -897,7 +899,7 @@ mod tests {
             .expect("built as an object above")
             .insert("items".to_owned(), json!([]));
         match AttestationInput::from_update(&update_attestation(&empty)) {
-            Err(ServiceError::Unprocessable(v)) => {
+            Err(ServiceError::Unprocessable { violation: v, .. }) => {
                 assert_eq!(v.path(), Some("ATTESTATION.items"));
                 assert_eq!(v.invariant(), Some("ATTESTATION.Items_valid"));
             }
@@ -957,7 +959,7 @@ mod tests {
         }))
         .expect_err("a present-but-empty items list must be refused");
         match err {
-            ServiceError::Unprocessable(v) => {
+            ServiceError::Unprocessable { violation: v, .. } => {
                 assert_eq!(v.path(), Some("ATTESTATION.items"));
                 assert_eq!(v.invariant(), Some("ATTESTATION.Items_valid"));
             }

--- a/app/ferroehr/src/versioning/audit.rs
+++ b/app/ferroehr/src/versioning/audit.rs
@@ -113,7 +113,7 @@ fn merged_change_type(supplied: &str, operation: &str) -> Result<String, Service
         return Ok(operation.to_owned());
     }
     let code = change_type_code(token).ok_or_else(|| {
-        ServiceError::Unprocessable(
+        ServiceError::content_invalid(
             Violation::new(format!(
                 "{token:?} is not a code in the openEHR audit_change_type group"
             ))
@@ -140,7 +140,7 @@ fn merged_change_type(supplied: &str, operation: &str) -> Result<String, Service
     if compatible {
         Ok(code)
     } else {
-        Err(ServiceError::BadRequest(format!(
+        Err(ServiceError::precondition(format!(
             "change_type {code} does not match the operation (its change type is \
              {operation}) — the modification type must match the operation \
              (RM change_control §Contributions; ITS-REST overview \
@@ -375,7 +375,7 @@ impl AuditInput {
 /// §Attributes).
 pub(crate) fn decode_description(fragment: &Value) -> Result<DvText, ServiceError> {
     openehr_its::json::from_canonical_value::<DvText>(fragment).map_err(|e| {
-        ServiceError::Unprocessable(
+        ServiceError::content_invalid(
             Violation::new("is not a canonical DV_TEXT")
                 .with_path("AUDIT_DETAILS.description")
                 .with_decode_failure(&e),
@@ -445,7 +445,7 @@ pub(crate) fn dv_text(value: &str) -> DvText {
 /// `UML/classes/org.openehr.rm.common.audit_details.adoc` §Attributes).
 pub(crate) fn party_proxy(committer: &Value) -> Result<PartyProxy, ServiceError> {
     openehr_its::json::from_canonical_value::<PartyProxy>(committer).map_err(|e| {
-        ServiceError::Unprocessable(
+        ServiceError::content_invalid(
             Violation::new("is not a canonical PARTY_PROXY")
                 .with_path("AUDIT_DETAILS.committer")
                 .with_decode_failure(&e),
@@ -476,7 +476,7 @@ pub(crate) fn party_proxy(committer: &Value) -> Result<PartyProxy, ServiceError>
 ///   committer is stored verbatim, so it is checked here.
 pub(crate) fn validate_commit_audit(audit: &AuditInput) -> Result<(), ServiceError> {
     if audit.system_id.is_empty() {
-        return Err(ServiceError::Unprocessable(
+        return Err(ServiceError::content_invalid(
             Violation::new("is mandatory and non-void")
                 .with_path("AUDIT_DETAILS.system_id")
                 .with_invariant("AUDIT_DETAILS.System_id_valid"),
@@ -525,7 +525,7 @@ fn validate_committer(committer: &PartyProxy) -> Result<(), ServiceError> {
     }
     // The dispatcher's own `InvariantViolation`s travel on as DATA — the
     // service never flattens them into a sentence here.
-    Err(ServiceError::Unprocessable(
+    Err(ServiceError::content_invalid(
         Violation::new("is not a valid PARTY_PROXY")
             .with_path("AUDIT_DETAILS.committer")
             .with_causes(violations),
@@ -598,7 +598,7 @@ mod tests {
             match merged_change_type(token, change_type::MODIFICATION) {
                 // The refusal is asserted as DATA: the attribute path and the
                 // named RM invariant, not a fragment of the sentence.
-                Err(ServiceError::Unprocessable(v)) => {
+                Err(ServiceError::Unprocessable { violation: v, .. }) => {
                     assert_eq!(v.path(), Some("change_type"), "{token}");
                     assert_eq!(
                         v.invariant(),
@@ -691,7 +691,7 @@ mod tests {
             &json!({ "_type": "PARTY_IDENTIFIED", "name": "Dr Jones" }),
         );
         match validate_commit_audit(&audit) {
-            Err(ServiceError::Unprocessable(v)) => {
+            Err(ServiceError::Unprocessable { violation: v, .. }) => {
                 assert_eq!(v.path(), Some("AUDIT_DETAILS.system_id"));
                 assert_eq!(v.invariant(), Some("AUDIT_DETAILS.System_id_valid"));
             }
@@ -705,7 +705,7 @@ mod tests {
         match validate_commit_audit(&audit) {
             // The nested dispatcher violations survive as DATA: the causes
             // list is asserted, not a substring of the rendered message.
-            Err(ServiceError::Unprocessable(v)) => {
+            Err(ServiceError::Unprocessable { violation: v, .. }) => {
                 assert_eq!(v.path(), Some("AUDIT_DETAILS.committer"));
                 assert!(
                     v.causes()
@@ -726,7 +726,7 @@ mod tests {
             &json!({ "_type": "PARTY_IDENTIFIED", "name": "" }),
         );
         match validate_commit_audit(&audit) {
-            Err(ServiceError::Unprocessable(v)) => assert!(
+            Err(ServiceError::Unprocessable { violation: v, .. }) => assert!(
                 v.causes().iter().any(|c| c.message.contains("Name_valid")),
                 "causes must carry Name_valid, got {:?}",
                 v.causes()
@@ -749,7 +749,7 @@ mod tests {
                     "relationship": { "_type": "DV_TEXT", "value": "mother" } }),
         ] {
             match party_proxy(&bad) {
-                Err(ServiceError::Unprocessable(v)) => {
+                Err(ServiceError::Unprocessable { violation: v, .. }) => {
                     assert_eq!(v.path(), Some("AUDIT_DETAILS.committer"));
                     assert!(
                         v.causes().iter().any(|c| c.message.contains("relationship")
@@ -782,7 +782,7 @@ mod tests {
         // The refusal is produced by the generated `PARTY_RELATED` core, whose
         // violation message names the invariant, not the rejected code.
         match validate_commit_audit(&bad) {
-            Err(ServiceError::Unprocessable(v)) => {
+            Err(ServiceError::Unprocessable { violation: v, .. }) => {
                 assert!(
                     v.causes()
                         .iter()

--- a/app/ferroehr/src/versioning/change.rs
+++ b/app/ferroehr/src/versioning/change.rs
@@ -234,7 +234,7 @@ fn preceding_tip(
     row: crate::storage::version_repo::placement::TipRow,
 ) -> Result<PrecedingTip, ServiceError> {
     let kind = Kind::from_type(&row.kind).ok_or_else(|| {
-        ServiceError::Internal(format!("unknown versioned-object kind {:?}", row.kind))
+        ServiceError::exception(format!("unknown versioned-object kind {:?}", row.kind))
     })?;
     Ok(PrecedingTip {
         ehr_id: row.ehr_id,
@@ -318,7 +318,7 @@ async fn next_version(
             .map(preceding_tip)
             .transpose()?;
         return match (expected, current) {
-            (Some(tree), Some(current)) => Err(ServiceError::VersionConflict(format!(
+            (Some(tree), Some(current)) => Err(ServiceError::version_conflict(format!(
                 "expected version {tree}, which does not exist (current is {})",
                 current.tree
             ))),
@@ -337,7 +337,7 @@ async fn next_version(
         ));
     }
     if !tip.open {
-        return Err(ServiceError::VersionConflict(format!(
+        return Err(ServiceError::version_conflict(format!(
             "expected version {} has been superseded",
             tip.tree
         )));
@@ -545,7 +545,7 @@ async fn apply_change(
                 engine
                     .offload(&mut canonical)
                     .await
-                    .map_err(|e| ServiceError::Internal(e.to_string()))?;
+                    .map_err(|e| ServiceError::exception(e.to_string()))?;
             }
             let lifecycle = resolve_lifecycle(lifecycle_state)?;
             // This arm commits CONTENT, so the deleted state is refused here
@@ -596,7 +596,7 @@ async fn apply_change(
                 engine
                     .offload(&mut canonical)
                     .await
-                    .map_err(|e| ServiceError::Internal(e.to_string()))?;
+                    .map_err(|e| ServiceError::exception(e.to_string()))?;
             }
             let lifecycle = resolve_lifecycle(lifecycle_state)?;
             // Same coupling as the create arm: a modification carries content,

--- a/app/ferroehr/src/versioning/contribution.rs
+++ b/app/ferroehr/src/versioning/contribution.rs
@@ -85,7 +85,7 @@ fn classify(
 ) -> Result<(Action, String), ServiceError> {
     let code = match token {
         Some(t) => change_type_code(t).ok_or_else(|| {
-            ServiceError::Unprocessable(
+            ServiceError::content_invalid(
                 Violation::new(format!(
                     "{t:?} is not a code in the openEHR audit_change_type group"
                 ))
@@ -108,7 +108,7 @@ fn classify(
                 // change-control semantics cannot be followed (RM
                 // change_control §Contributions: creation commits a NEW
                 // VERSIONED_OBJECT).
-                return Err(ServiceError::Unprocessable(
+                return Err(ServiceError::content_invalid(
                     Violation::new(
                         "249|creation| is invalid for an existing object \
                          (preceding_version_uid present); creation commits a new \
@@ -119,7 +119,7 @@ fn classify(
                 ));
             }
             if !has_data {
-                return Err(ServiceError::Unprocessable(
+                return Err(ServiceError::content_invalid(
                     Violation::new("is required on a creation version").with_path("data"),
                 ));
             }
@@ -131,7 +131,7 @@ fn classify(
                 // `400_CONTRIBUTION` trigger family ("the modification type
                 // does not match the operation - i.e. first version of a
                 // MODIFICATION") → 400.
-                return Err(ServiceError::BadRequest(
+                return Err(ServiceError::precondition(
                     "deleted (523) version requires preceding_version_uid — a first \
                      version's change type is 249|creation| (ITS-REST contribution \
                      400: the modification type does not match the operation)"
@@ -139,7 +139,7 @@ fn classify(
                 ));
             }
             if has_data {
-                return Err(ServiceError::Unprocessable(
+                return Err(ServiceError::content_invalid(
                     Violation::new(
                         "must not be set on a deleted (523) version — its data attribute \
                          is set to Void",
@@ -160,7 +160,7 @@ fn classify(
             // `ATTESTATION._commit_audit_._change_type_`, a path ATTESTATION
             // cannot have; the repaired reading `ATTESTATION.change_type` is used.
             if !has_preceding {
-                return Err(ServiceError::BadRequest(
+                return Err(ServiceError::precondition(
                     "change_type 666|attestation| requires preceding_version_uid to \
                      identify the ORIGINAL_VERSION being attested (RM change_control \
                      §Contributions; VERSIONED_OBJECT.commit_attestation pre \
@@ -169,7 +169,7 @@ fn classify(
                 ));
             }
             if has_data {
-                return Err(ServiceError::Unprocessable(
+                return Err(ServiceError::content_invalid(
                     Violation::new(
                         "must not be set on a 666 attestation version — attesting an \
                          existing item adds no content",
@@ -188,7 +188,7 @@ fn classify(
                 // THE released assignment: `400_CONTRIBUTION` — "the
                 // modification type does not match the operation - i.e. first
                 // version of a MODIFICATION" → 400.
-                return Err(ServiceError::BadRequest(format!(
+                return Err(ServiceError::precondition(format!(
                     "change_type {code} requires preceding_version_uid — a first \
                      version's change type is 249|creation| (ITS-REST contribution \
                      400: the modification type does not match the operation; RM \
@@ -196,7 +196,7 @@ fn classify(
                 )));
             }
             if !has_data {
-                return Err(ServiceError::Unprocessable(
+                return Err(ServiceError::content_invalid(
                     Violation::new(format!("is required on a change_type {code} version"))
                         .with_path("data"),
                 ));
@@ -305,7 +305,7 @@ fn reject_foreign_version_identity(version: &Value, index: usize) -> Result<(), 
     if let Some(map) = version.as_object() {
         for key in map.keys() {
             if !DECLARED.contains(&key.as_str()) && !SPECIFICALLY_REFUSED.contains(&key.as_str()) {
-                return Err(ServiceError::BadRequest(format!(
+                return Err(ServiceError::precondition(format!(
                     "versions[{index}]/{key} is not a member of UPDATE_VERSION — the \
                      released commit wire declares preceding_version_uid, signature, \
                      lifecycle_state, attestations, data, commit_audit (ITS-REST \
@@ -316,7 +316,7 @@ fn reject_foreign_version_identity(version: &Value, index: usize) -> Result<(), 
         }
     }
     if version.get("item").is_some() {
-        return Err(ServiceError::BadRequest(
+        return Err(ServiceError::precondition(
             "item is not a member of UPDATE_VERSION — it is the sole own attribute of \
              IMPORTED_VERSION, and the released commit wire declares no import shape \
              (ITS-REST UpdateVersion.yaml / NewContribution.yaml). An imported \
@@ -326,7 +326,7 @@ fn reject_foreign_version_identity(version: &Value, index: usize) -> Result<(), 
         ));
     }
     if version.get("uid").is_some() {
-        return Err(ServiceError::BadRequest(
+        return Err(ServiceError::precondition(
             "uid is not carried on a CONTRIBUTION version member — the member is the \
              commit-wire PARTIAL of the version it becomes (ITS-REST \
              UpdateVersion.yaml declares six properties and no uid), and the version \
@@ -342,7 +342,7 @@ fn reject_foreign_version_identity(version: &Value, index: usize) -> Result<(), 
     match version.get("_type") {
         None => Ok(()),
         Some(Value::String(name)) if COMMITTABLE_MEMBER_TYPES.contains(&name.as_str()) => Ok(()),
-        Some(other) => Err(ServiceError::BadRequest(format!(
+        Some(other) => Err(ServiceError::precondition(format!(
             "_type {other} does not name a class the CONTRIBUTION commit wire commits \
              — a member self-tags as UPDATE_VERSION or ORIGINAL_VERSION or not at all \
              (ITS-REST Resources.md: the value \"MUST be the uppercase class name from \
@@ -395,7 +395,7 @@ pub(crate) async fn commit_version_set(
         .and_then(Value::as_array)
         .filter(|v| !v.is_empty())
         .ok_or_else(|| {
-            ServiceError::Unprocessable(
+            ServiceError::content_invalid(
                 Violation::new("must contain at least one version").with_path("versions"),
             )
         })?;
@@ -416,7 +416,7 @@ pub(crate) async fn commit_version_set(
                       is not part of the wire contract"
         )]
         Some(raw) => Some(raw.parse::<Uuid>().map_err(|_| {
-            ServiceError::Unprocessable(
+            ServiceError::content_invalid(
                 Violation::new(format!("{raw:?} is not a valid HIER_OBJECT_ID UUID"))
                     .with_path("CONTRIBUTION.uid"),
             )
@@ -433,7 +433,7 @@ pub(crate) async fn commit_version_set(
     let contrib_committer = match body.get("audit").and_then(|a| a.get("committer")) {
         Some(supplied) => party_proxy(supplied)?,
         None => {
-            return Err(ServiceError::Unprocessable(
+            return Err(ServiceError::content_invalid(
                 Violation::new(
                     "is required on a CONTRIBUTION audit — the change set's committer is the \
                      client's account of who committed it and is never invented by the server",
@@ -502,7 +502,7 @@ pub(crate) async fn commit_version_set(
         // and only it — it commits no new version (master06 §Contributions), so
         // it has no version lifecycle state to supply; the RM governs the gap.
         if version.get("other_input_version_uids").is_some() {
-            return Err(ServiceError::BadRequest(
+            return Err(ServiceError::precondition(
                 "other_input_version_uids is not a member of UPDATE_VERSION — the \
                  released commit wire declares no merge shape (ITS-REST \
                  UpdateVersion.yaml); merge provenance is served on reads only \
@@ -511,7 +511,7 @@ pub(crate) async fn commit_version_set(
             ));
         }
         if action != Action::Attest && lifecycle_state.is_none() {
-            return Err(ServiceError::BadRequest(
+            return Err(ServiceError::precondition(
                 "lifecycle_state is required on every CONTRIBUTION version \
                  (SM master03 §Version Update Semantics: \"The lifecycle_state must \
                  be supplied in all cases\"; ITS-REST UpdateVersion.yaml lists it \
@@ -564,7 +564,7 @@ pub(crate) async fn commit_version_set(
     // content the committed CONTRIBUTION refers to.
     let require_kind = |vo_id: VoId| -> Result<Kind, ServiceError> {
         target_kinds.get(&vo_id).copied().ok_or_else(|| {
-            ServiceError::BadRequest(format!(
+            ServiceError::precondition(format!(
                 "modification target does not exist: versioned object {vo_id} \
                  (ITS-REST contribution 400 — the modification does not match \
                  a stored object)"
@@ -579,14 +579,14 @@ pub(crate) async fn commit_version_set(
     for v in plan {
         if v.action == Action::Attest {
             let Some((vo_id, expected)) = v.target else {
-                return Err(ServiceError::Internal(
+                return Err(ServiceError::exception(
                     "attest plan entry lost its parsed preceding target".to_owned(),
                 ));
             };
             let kind = require_kind(vo_id)?;
             check_kind_scope(kind, party_only)?;
             let partial = v.commit_audit.ok_or_else(|| {
-                ServiceError::Unprocessable(
+                ServiceError::content_invalid(
                     Violation::new(
                         "is required on a 666 attestation version (the UPDATE_ATTESTATION)",
                     )
@@ -607,7 +607,7 @@ pub(crate) async fn commit_version_set(
         let change = match v.action {
             Action::Create => {
                 let data = v.data.ok_or_else(|| {
-                    ServiceError::Unprocessable(
+                    ServiceError::content_invalid(
                         Violation::new("is required on a creation version").with_path("data"),
                     )
                 })?;
@@ -646,12 +646,12 @@ pub(crate) async fn commit_version_set(
             }
             Action::Modify => {
                 let data = v.data.ok_or_else(|| {
-                    ServiceError::Unprocessable(
+                    ServiceError::content_invalid(
                         Violation::new("is required on a modification version").with_path("data"),
                     )
                 })?;
                 let Some((vo_id, expected)) = v.target else {
-                    return Err(ServiceError::Internal(
+                    return Err(ServiceError::exception(
                         "modify plan entry lost its parsed preceding target".to_owned(),
                     ));
                 };
@@ -680,7 +680,7 @@ pub(crate) async fn commit_version_set(
             }
             Action::Delete => {
                 let Some((vo_id, expected)) = v.target else {
-                    return Err(ServiceError::Internal(
+                    return Err(ServiceError::exception(
                         "delete plan entry lost its parsed preceding target".to_owned(),
                     ));
                 };
@@ -691,7 +691,7 @@ pub(crate) async fn commit_version_set(
                 // leave the EHR violating its own invariant, so a delete
                 // member targeting it is refused as a version conflict.
                 if kind == Kind::EhrStatus {
-                    return Err(ServiceError::Conflict(
+                    return Err(ServiceError::conflict(
                         "the EHR_STATUS cannot be deleted — EHR.ehr_status is mandatory \
                          (RM ehr, EHR class, ehr_status: 1..1)"
                             .to_owned(),
@@ -709,7 +709,7 @@ pub(crate) async fn commit_version_set(
             // against that branch ever stopping to cover the action — the same
             // shape the lost-target arms above use.
             Action::Attest => {
-                return Err(ServiceError::Internal(
+                return Err(ServiceError::exception(
                     "attestation version reached the change-building match".to_owned(),
                 ));
             }
@@ -741,7 +741,7 @@ pub(crate) async fn commit_version_set(
             .and_then(|a| a.get("change_type"))
             .and_then(coded_value)
             .ok_or_else(|| {
-                ServiceError::Unprocessable(
+                ServiceError::content_invalid(
                     Violation::new(
                         "is required on a CONTRIBUTION audit — the change set's own change \
                          type is the client's account of it and is never derived by the server",
@@ -750,7 +750,7 @@ pub(crate) async fn commit_version_set(
                 )
             })?;
         change_type_code(&token).ok_or_else(|| {
-            ServiceError::Unprocessable(
+            ServiceError::content_invalid(
                 Violation::new(format!(
                     "{token:?} is not a code in the openEHR audit_change_type group"
                 ))
@@ -864,7 +864,7 @@ async fn reject_duplicate_singleton(
     match kind {
         Kind::EhrStatus | Kind::EhrAccess => {
             if cx.current_vo(ehr_id, kind).await?.is_some() {
-                return Err(ServiceError::Conflict(format!(
+                return Err(ServiceError::conflict(format!(
                     "EHR {ehr_id} already has a {}; only one is permitted (RM ehr, EHR class)",
                     kind.as_str()
                 )));
@@ -880,7 +880,7 @@ async fn reject_duplicate_singleton(
                 .and_then(Value::as_str)
                 .unwrap_or_default();
             if cx.folder_root_exists(ehr_id, root, name).await? {
-                return Err(ServiceError::Conflict(format!(
+                return Err(ServiceError::conflict(format!(
                     "EHR {ehr_id} already has a folder hierarchy rooted at \
                      {root:?} named {name:?}; re-creating an existing directory \
                      is invalid (CNF schedule master08 §commit_contribution \
@@ -919,7 +919,7 @@ fn commit_audit_is_attestation(audit: &Value) -> Result<bool, ServiceError> {
     match audit.get("_type").and_then(Value::as_str) {
         None | Some("UPDATE_AUDIT" | "AUDIT_DETAILS") => Ok(false),
         Some("UPDATE_ATTESTATION" | "ATTESTATION") => Ok(true),
-        Some(other) => Err(ServiceError::Unprocessable(
+        Some(other) => Err(ServiceError::content_invalid(
             Violation::new(format!(
                 "_type {other:?} is not an AUDIT_DETAILS or its ATTESTATION subtype"
             ))
@@ -1040,7 +1040,7 @@ fn parse_audit(
 /// direction.
 fn check_kind_scope(kind: Kind, party_only: bool) -> Result<(), ServiceError> {
     if party_only && !kind.is_demographic() {
-        return Err(ServiceError::Unprocessable(
+        return Err(ServiceError::content_invalid(
             Violation::new(format!(
                 "of a demographic CONTRIBUTION may only be demographic versions, got {}",
                 kind.as_str()
@@ -1049,7 +1049,7 @@ fn check_kind_scope(kind: Kind, party_only: bool) -> Result<(), ServiceError> {
         ));
     }
     if !party_only && kind.is_demographic() {
-        return Err(ServiceError::Unprocessable(
+        return Err(ServiceError::content_invalid(
             Violation::new(format!(
                 "of an EHR CONTRIBUTION may not be demographic versions, got {}",
                 kind.as_str()
@@ -1109,7 +1109,7 @@ fn data_kind(data: &Value) -> Result<Kind, ServiceError> {
         .and_then(Value::as_str)
         .unwrap_or_default();
     Kind::from_type(rm_type).ok_or_else(|| {
-        ServiceError::Unprocessable(
+        ServiceError::content_invalid(
             Violation::new(format!(
                 "names {rm_type:?}, which is not a versioned root type"
             ))
@@ -1169,7 +1169,7 @@ fn typed_decode_gate(kind: Kind, data: &Value, incomplete: bool) -> Result<(), S
         | Kind::PartyRelationship => None,
     };
     match refused {
-        Some(e) => Err(ServiceError::BadRequest(format!(
+        Some(e) => Err(ServiceError::precondition(format!(
             "invalid canonical JSON body: {e}"
         ))),
         None => Ok(()),
@@ -1194,7 +1194,7 @@ fn parse_preceding(version: &Value) -> Result<(VoId, TreeId), ServiceError> {
                 .or_else(|| p.get("value").and_then(Value::as_str))
         })
         .ok_or_else(|| {
-            ServiceError::Unprocessable(
+            ServiceError::content_invalid(
                 Violation::new("required for modify/delete").with_path("preceding_version_uid"),
             )
         })?;
@@ -1381,7 +1381,7 @@ async fn ensure_ehr_exists(pool: &sqlx::PgPool, ehr_id: EhrId) -> Result<(), Ser
 /// `400_CONTRIBUTION` scope — never a 404.
 fn body_target_not_found_is_bad_request(e: ServiceError) -> ServiceError {
     match e {
-        ServiceError::NotFound(m) => ServiceError::BadRequest(format!(
+        ServiceError::NotFound(m) => ServiceError::precondition(format!(
             "modification target does not exist: {m} (ITS-REST contribution 400 — \
              the modification does not match a stored object)"
         )),
@@ -1546,7 +1546,7 @@ mod tests {
             match err {
                 // Asserted as DATA: the refused attribute path, and the
                 // offending `_type` in the violation's own detail.
-                ServiceError::Unprocessable(v) => {
+                ServiceError::Unprocessable { violation: v, .. } => {
                     assert_eq!(v.path(), Some("VERSION.commit_audit"), "{bad}");
                     assert_eq!(
                         v.invariant(),
@@ -1570,21 +1570,23 @@ mod tests {
         )
         .expect_err("an ATTESTATION without reason must be refused");
         match err {
-            ServiceError::Unprocessable(v) => assert_eq!(v.path(), Some("ATTESTATION.reason")),
+            ServiceError::Unprocessable { violation: v, .. } => {
+                assert_eq!(v.path(), Some("ATTESTATION.reason"));
+            }
             other => panic!("expected Unprocessable, got {other:?}"),
         }
     }
 
     fn classify_err(token: Option<&str>, has_preceding: bool, has_data: bool) -> Violation {
         match classify(token, has_preceding, has_data) {
-            Err(ServiceError::Unprocessable(v)) => v,
+            Err(ServiceError::Unprocessable { violation: v, .. }) => v,
             other => panic!("expected Unprocessable, got {other:?}"),
         }
     }
 
     fn classify_bad_request(token: Option<&str>, has_preceding: bool, has_data: bool) -> String {
         match classify(token, has_preceding, has_data) {
-            Err(ServiceError::BadRequest(msg)) => msg,
+            Err(ServiceError::BadRequest(e)) => e.message,
             other => panic!("expected BadRequest, got {other:?}"),
         }
     }

--- a/app/ferroehr/src/versioning/import.rs
+++ b/app/ferroehr/src/versioning/import.rs
@@ -79,7 +79,7 @@ async fn container_state(
     let kind = match row.kind {
         None => None,
         Some(text) => Some(Kind::from_type(&text).ok_or_else(|| {
-            ServiceError::Internal(format!("unknown versioned-object kind {text:?}"))
+            ServiceError::exception(format!("unknown versioned-object kind {text:?}"))
         })?),
     };
     Ok(ContainerState {
@@ -259,7 +259,7 @@ async fn enforce_copy_closure(
             )
             .await?
         {
-            return Err(ServiceError::BadRequest(format!(
+            return Err(ServiceError::precondition(format!(
                 "the extract violates the copy closure (RM common master06 §Copying): \
                  branch version {}::{}::{} arrives without its fork-point trunk \
                  version {trunk_version} (neither in the extract nor already stored)",
@@ -287,7 +287,7 @@ async fn enforce_copy_closure(
             )
             .await?
         {
-            return Err(ServiceError::BadRequest(format!(
+            return Err(ServiceError::precondition(format!(
                 "the extract violates the copy closure (RM common master06 §Copying): \
                  branch version {}::{}::{} arrives without its same-branch \
                  predecessor (branch version {}) — neither in the extract nor \
@@ -357,7 +357,7 @@ async fn commit_import_scoped(
         for pair in container.versions.windows(2) {
             let [first, second] = pair else { continue };
             if first.creating_system_id == second.creating_system_id && first.tree == second.tree {
-                return Err(ServiceError::Conflict(format!(
+                return Err(ServiceError::conflict(format!(
                     "version {}::{}::{} appears more than once in the import",
                     container.vo_id, first.creating_system_id, first.tree
                 )));
@@ -373,13 +373,13 @@ async fn commit_import_scoped(
             // to the existing clone — the kind must match, the EHR must own it,
             // and every imported trunk version must be strictly newer.
             if state.owner != ehr_id {
-                return Err(ServiceError::Conflict(format!(
+                return Err(ServiceError::conflict(format!(
                     "versioned object {} already exists in another EHR",
                     container.vo_id
                 )));
             }
             if existing_kind != container.kind {
-                return Err(ServiceError::Conflict(format!(
+                return Err(ServiceError::conflict(format!(
                     "versioned object {} is a {}, cannot import a {}",
                     container.vo_id,
                     existing_kind.as_str(),
@@ -394,7 +394,7 @@ async fn commit_import_scoped(
                 .min()
                 && first_trunk <= state.max_trunk
             {
-                return Err(ServiceError::Conflict(format!(
+                return Err(ServiceError::conflict(format!(
                     "versioned object {} already has trunk version {} — cannot \
                      re-import trunk version {first_trunk}",
                     container.vo_id, state.max_trunk

--- a/app/ferroehr/src/versioning/lifecycle.rs
+++ b/app/ferroehr/src/versioning/lifecycle.rs
@@ -69,7 +69,7 @@ pub(crate) fn lifecycle_rubric(code: &str) -> String {
 pub(crate) fn resolve_lifecycle(token: Option<String>) -> Result<String, ServiceError> {
     match token {
         Some(token) => lifecycle_state_code(&token).ok_or_else(|| {
-            ServiceError::Unprocessable(
+            ServiceError::content_invalid(
                 Violation::new(format!(
                     "{token:?} is not a code in the openEHR version_lifecycle_state group"
                 ))
@@ -109,7 +109,7 @@ pub(crate) fn reject_deleted_with_data(lifecycle: &str) -> Result<(), ServiceErr
     if lifecycle != state::DELETED {
         return Ok(());
     }
-    Err(ServiceError::Unprocessable(
+    Err(ServiceError::content_invalid(
         Violation::new(
             "523|deleted| is invalid on a version that carries data — logical deletion \
              deletes the version's data and sets the deleted state in one act",
@@ -165,7 +165,7 @@ pub(crate) fn validate_transition(from: Option<&str>, to: &str) -> Result<(), Se
         Some(c) => (c, lifecycle_rubric(c)),
         None => ("(new)", "new".to_owned()),
     };
-    Err(ServiceError::Unprocessable(
+    Err(ServiceError::content_invalid(
         Violation::new(format!(
             "illegal version lifecycle transition {from_code}|{from_rubric}| -> {to}|{}|",
             lifecycle_rubric(to),
@@ -239,7 +239,7 @@ mod tests {
         // The refusal is asserted as DATA: the path and the named invariant,
         // not a substring of the rendered sentence.
         match resolve_lifecycle(Some("nonsense".into())) {
-            Err(ServiceError::Unprocessable(v)) => {
+            Err(ServiceError::Unprocessable { violation: v, .. }) => {
                 assert_eq!(v.path(), Some("lifecycle_state"));
                 assert_eq!(
                     v.invariant(),
@@ -258,7 +258,7 @@ mod tests {
     fn deleted_state_is_refused_on_a_data_carrying_commit() {
         // The refusal, asserted as DATA (path + named spec rule).
         match reject_deleted_with_data(state::DELETED) {
-            Err(ServiceError::Unprocessable(v)) => {
+            Err(ServiceError::Unprocessable { violation: v, .. }) => {
                 assert_eq!(v.path(), Some("lifecycle_state"));
                 assert_eq!(v.invariant(), Some("RM common master06 §Logical Deletion"));
             }
@@ -307,7 +307,7 @@ mod tests {
         // Illegal transitions. The first is asserted as DATA — the refusal
         // names the state machine it enforces, readable off the value.
         match validate_transition(Some(COMPLETE), ABANDONED) {
-            Err(ServiceError::Unprocessable(v)) => assert_eq!(
+            Err(ServiceError::Unprocessable { violation: v, .. }) => assert_eq!(
                 v.invariant(),
                 Some("RM common master06 §Version Lifecycle state machine")
             ),

--- a/app/ferroehr/src/versioning/object_version_id.rs
+++ b/app/ferroehr/src/versioning/object_version_id.rs
@@ -218,7 +218,7 @@ impl From<VersionIdError> for ApiError {
 
 impl From<VersionIdError> for ServiceError {
     fn from(e: VersionIdError) -> Self {
-        ServiceError::Unprocessable(crate::service::error::Violation::new(e.to_string()))
+        ServiceError::content_invalid(crate::service::error::Violation::new(e.to_string()))
     }
 }
 

--- a/app/ferroehr/src/versioning/read.rs
+++ b/app/ferroehr/src/versioning/read.rs
@@ -53,7 +53,7 @@ impl WrappedOriginal {
     fn decode(vo_id: VoId, fragment: &Value) -> Result<Self, ServiceError> {
         let field = |name: &str| {
             fragment.get(name).cloned().ok_or_else(|| {
-                ServiceError::Unprocessable(
+                ServiceError::content_invalid(
                     Violation::new(format!(
                         "is missing from the wrapped ORIGINAL_VERSION stored for \
                          versioned object {vo_id}"

--- a/app/ferroehr/src/versioning/wire.rs
+++ b/app/ferroehr/src/versioning/wire.rs
@@ -129,13 +129,13 @@ pub(crate) async fn revision_history(
     let last_modified = history
         .most_recent_version_time_committed()
         .ok_or_else(|| {
-            ServiceError::Internal(format!(
+            ServiceError::exception(format!(
                 "the REVISION_HISTORY built for versioned object {vo_id} has no commit audit"
             ))
         })?
         .parse::<jiff::Timestamp>()
         .map_err(|e| {
-            ServiceError::Internal(format!(
+            ServiceError::exception(format!(
                 "the commit instant of versioned object {vo_id}'s newest version is not a \
                  valid instant: {e}"
             ))
@@ -156,7 +156,7 @@ pub(crate) async fn revision_history(
 /// `AUDIT_DETAILS` / `ATTESTATION`.
 fn stored_attestation(stored: &Value) -> Result<AuditDetails, ServiceError> {
     openehr_its::json::from_canonical_value::<AuditDetails>(stored).map_err(|e| {
-        ServiceError::Unprocessable(
+        ServiceError::content_invalid(
             Violation::new("a stored attestation is not a canonical ATTESTATION")
                 .with_decode_failure(&e),
         )
@@ -403,7 +403,7 @@ fn build_wrapped_original(
     wrapped: &WrappedOriginal,
 ) -> Result<Value, ServiceError> {
     if !wrapped.commit_audit.is_object() {
-        return Err(ServiceError::Unprocessable(
+        return Err(ServiceError::content_invalid(
             Violation::new(format!(
                 "of the wrapped ORIGINAL_VERSION stored for versioned object {} is not \
                  an object",

--- a/app/ferroehr/tests/it/service_contribution.rs
+++ b/app/ferroehr/tests/it/service_contribution.rs
@@ -1086,10 +1086,10 @@ async fn create_composition_gate_error_surface_survives_the_writability_fold() {
         .create_composition(ehr_uuid, uv(&composition("obs2"), "249", None))
         .await
         .expect_err("non-modifiable EHR blocks content writes");
-    let ServiceError::Conflict(message) = &blocked else {
+    let ServiceError::Conflict(sm) = &blocked else {
         panic!("is_modifiable = false → 409 conflict, got {blocked:?}");
     };
-    assert!(message.contains("not modifiable"), "got {message}");
+    assert!(sm.message.contains("not modifiable"), "got {}", sm.message);
 }
 
 /// The temporal non-overlap invariant survives the removal of the `GiST`

--- a/app/ferroehr/tests/it/service_definition.rs
+++ b/app/ferroehr/tests/it/service_definition.rs
@@ -148,10 +148,11 @@ async fn archetype_errors() {
     let db = testkit::db().await.expect("testkit database");
     let svc = FerroEhrService::new(db.pool());
 
-    // Invalid ADL → 422 invalid_archetype.
-    // NOTE: the SM-specific Definition statuses (invalid_archetype,
-    // artefact_does_not_exist, …) flatten through `ServiceError::sm()` to the
-    // generic `content_invalid` (422) / `precondition_violation` (400).
+    // Invalid ADL → 422. The ADL 1.4 engine refuses the source first and
+    // reports the generic `content_invalid` with its rule code, where
+    // `i_definition_adl14.adoc` §`upload_archetype` declares
+    // `invalid_archetype`; the wire status is `422` either way.
+    // TODO(#2151): name `invalid_archetype` at the 1.4 validation sites.
     let bad = svc
         .upload_archetype("this is not an archetype".to_owned())
         .await
@@ -197,7 +198,10 @@ async fn archetype_errors() {
         "got {del_missing:?}"
     );
 
-    // Uncompilable regex → 400 invalid_id_pattern (unbalanced group).
+    // Uncompilable regex → 400 invalid_id_pattern (unbalanced group) — the
+    // status `i_definition_adl14.adoc` §`list_matching_archetypes` declares
+    // (.Errors: `invalid_id_pattern`), not the generic
+    // `precondition_violation`.
     let bad_re = svc
         .list_matching_archetypes("(".to_owned(), Page::all())
         .await
@@ -206,7 +210,7 @@ async fn archetype_errors() {
         matches!(
             bad_re,
             SmError {
-                status: CallStatusType::PreconditionViolation,
+                status: CallStatusType::InvalidIdPattern,
                 ..
             }
         ),
@@ -698,13 +702,14 @@ async fn opt_errors() {
     let db = testkit::db().await.expect("testkit database");
     let svc = FerroEhrService::new(db.pool());
 
-    // Invalid OPT → 422 invalid_template.
+    // Invalid OPT → 422. The OPT ingestion path reports the generic
+    // `content_invalid`, where `i_definition_adl14.adoc` §`upload_opt`
+    // declares `invalid_template`; the wire status is `422` either way.
+    // TODO(#2151): name `invalid_template` at the OPT ingestion sites.
     let bad = svc
         .upload_opt("<not-a-template/>".to_owned())
         .await
         .expect_err("invalid opt");
-    // NOTE: the OPT ingestion path returns `ServiceError::Unprocessable`,
-    // flattened at the SM boundary to `content_invalid`.
     assert!(
         matches!(
             bad,
@@ -929,7 +934,8 @@ async fn adl2_errors() {
         "got {del_missing:?}"
     );
 
-    // Uncompilable regex → 400 invalid_id_pattern.
+    // Uncompilable regex → 400 invalid_id_pattern (`i_definition_adl2.adoc`
+    // §`list_matching_artefacts` .Errors: `invalid_id_pattern`).
     let bad_re = svc
         .list_matching_artefacts("(".to_owned(), Page::all())
         .await
@@ -938,7 +944,7 @@ async fn adl2_errors() {
         matches!(
             bad_re,
             SmError {
-                status: CallStatusType::PreconditionViolation,
+                status: CallStatusType::InvalidIdPattern,
                 ..
             }
         ),
@@ -1101,14 +1107,15 @@ async fn query_valid_store_list_match_delete() {
         matches!(
             bad,
             SmError {
-                status: CallStatusType::ContentInvalid,
+                status: CallStatusType::InvalidQuery,
                 ..
             }
         ),
         "got {bad:?}"
     );
 
-    // Bad id-pattern regex → 400.
+    // Bad id-pattern regex → 400 invalid_id_pattern
+    // (`i_definition_query.adoc` §`list_matching_queries`).
     let bad_re = svc
         .list_matching_queries("(".to_owned(), None, Page::all())
         .await
@@ -1117,7 +1124,7 @@ async fn query_valid_store_list_match_delete() {
         matches!(
             bad_re,
             SmError {
-                status: CallStatusType::PreconditionViolation,
+                status: CallStatusType::InvalidIdPattern,
                 ..
             }
         ),
@@ -1165,7 +1172,7 @@ async fn adl2_template_upload_wire_conflicts_on_duplicate() {
         .await
         .expect_err("duplicate template id conflicts on the wire surface");
     assert!(
-        matches!(&dup, ServiceError::Conflict(m) if m.contains("already exists")),
+        matches!(&dup, ServiceError::Conflict(e) if e.message.contains("already exists")),
         "got {dup:?}"
     );
 
@@ -1183,7 +1190,7 @@ async fn adl2_template_upload_wire_conflicts_on_duplicate() {
         .await
         .expect_err("invalid source rejected");
     assert!(
-        matches!(&bad, ServiceError::BadRequest(m) if m.contains("syntactically invalid")),
+        matches!(&bad, ServiceError::BadRequest(e) if e.message.contains("syntactically invalid")),
         "got {bad:?}"
     );
 }

--- a/app/ferroehr/tests/it/service_ehr_package.rs
+++ b/app/ferroehr/tests/it/service_ehr_package.rs
@@ -113,7 +113,7 @@ async fn versioned_composition_cannot_switch_archetype() {
         .expect_err("switching archetype across versions must be rejected");
     match err {
         // The invariant is DATA on the violation, not a substring of prose.
-        ServiceError::Unprocessable(v) => {
+        ServiceError::Unprocessable { violation: v, .. } => {
             assert_eq!(v.path(), Some("COMPOSITION.archetype_node_id"));
             assert_eq!(
                 v.invariant(),
@@ -163,7 +163,7 @@ async fn versioned_composition_cannot_flip_persistence() {
         .await
         .expect_err("flipping is_persistent across versions must be rejected");
     match err {
-        ServiceError::Unprocessable(v) => {
+        ServiceError::Unprocessable { violation: v, .. } => {
             assert_eq!(v.path(), Some("COMPOSITION.category"));
             assert_eq!(
                 v.invariant(),

--- a/app/ferroehr/tests/it/service_validation.rs
+++ b/app/ferroehr/tests/it/service_validation.rs
@@ -165,7 +165,7 @@ async fn composition_validation_gates_persistence() {
         .expect_err("unknown template rejected");
     // An unknown template is a 422 `ServiceError::Unprocessable`; the cause
     // still rides in the message.
-    let ServiceError::Unprocessable(violation) = &err else {
+    let ServiceError::Unprocessable { violation, .. } = &err else {
         panic!("expected content_invalid (422) for unknown template, got {err:?}");
     };
     assert!(
@@ -547,7 +547,7 @@ async fn deleting_a_template_invalidates_its_web_template_cache() {
         )
         .await
         .expect_err("commit against a deleted template is rejected");
-    let ServiceError::Unprocessable(violation) = &err else {
+    let ServiceError::Unprocessable { violation, .. } = &err else {
         panic!("expected content_invalid (422) for the deleted template, got {err:?}");
     };
     assert!(

--- a/app/ferroehr/tests/it/terminology_mtls.rs
+++ b/app/ferroehr/tests/it/terminology_mtls.rs
@@ -39,7 +39,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use ferroehr::service::status::CallStatusType;
+use ferroehr::service::status::{CallStatusType, SmError};
 use ferroehr::service::terminology::config::{
     ExternalTerminologyConfig, FhirOperation, FhirProviderConfig, ProviderKind,
 };
@@ -333,7 +333,7 @@ fn external(cfg: FhirProviderConfig) -> ExternalTerminologyConfig {
 }
 
 /// Build the router, take its sole provider, and run one `$lookup`.
-async fn lookup(cfg: FhirProviderConfig) -> Result<bool, ferroehr::service::status::SmError> {
+async fn lookup(cfg: FhirProviderConfig) -> Result<bool, SmError> {
     let router = TerminologyRouter::build(&external(cfg))?.expect("router");
     let provider = router.default_provider().expect("default provider");
     provider
@@ -434,6 +434,13 @@ async fn a_custom_ca_bundle_trusts_a_private_server_that_default_trust_refuses()
 /// (d) Broken TLS material is a BOOT failure, not a first-request surprise: the
 /// router refuses to build. Both shapes are covered — a path that does not
 /// exist, and a file that exists but holds the wrong PEM object.
+///
+/// The diagnosis is read off the CAUSE CHAIN
+/// ([RFC 0201](https://rust-lang.github.io/rfcs/0201-error-chaining.html)), not
+/// off the message: the message is the one thing that could reach a client on
+/// a `500`, so it names the provider and the failure class only, while the
+/// `TlsMaterialError` naming the offending configuration key rides
+/// [`std::error::Error::source`] for the operator's boot log.
 #[tokio::test]
 async fn broken_tls_material_fails_at_boot() {
     let pki = Pki::write();
@@ -444,11 +451,7 @@ async fn broken_tls_material_fails_at_boot() {
     missing.client_key_path = Some(pki.client_key.clone());
     let err = TerminologyRouter::build(&external(missing))
         .expect_err("a missing certificate file must fail the build");
-    assert!(
-        err.message.contains("client_cert_path"),
-        "got {}",
-        err.message
-    );
+    assert_cause_names(&err, "client_cert_path");
 
     // A key path pointing at a certificate — readable, but not a private key.
     let mut wrong_key = provider_cfg("https://ts.example.org/fhir");
@@ -456,31 +459,38 @@ async fn broken_tls_material_fails_at_boot() {
     wrong_key.client_key_path = Some(pki.ca.clone());
     let err = TerminologyRouter::build(&external(wrong_key))
         .expect_err("a key file holding no private key must fail the build");
-    assert!(
-        err.message.contains("no PEM private key"),
-        "got {}",
-        err.message
-    );
+    assert_cause_names(&err, "no PEM private key");
 
     // A CA bundle path pointing at a private key — no trust anchor in it.
     let mut wrong_ca = provider_cfg("https://ts.example.org/fhir");
     wrong_ca.ca_bundle_path = Some(pki.client_key.clone());
     let err = TerminologyRouter::build(&external(wrong_ca))
         .expect_err("a CA bundle holding no certificate must fail the build");
-    assert!(
-        err.message.contains("ca_bundle_path"),
-        "got {}",
-        err.message
-    );
+    assert_cause_names(&err, "ca_bundle_path");
 
     // And half an identity never reaches the network either.
     let mut half = provider_cfg("https://ts.example.org/fhir");
     half.client_key_path = Some(pki.client_key.clone());
     let err = TerminologyRouter::build(&external(half))
         .expect_err("half a client identity must fail the build");
+    assert_cause_names(&err, "must be set together");
+}
+
+/// Assert that walking the boot failure's cause chain reaches `expected`, and
+/// that the client-visible message does NOT carry it.
+fn assert_cause_names(err: &SmError, expected: &str) {
+    let chain = std::iter::successors(std::error::Error::source(err), |e| {
+        std::error::Error::source(*e)
+    })
+    .map(ToString::to_string)
+    .collect::<Vec<_>>();
     assert!(
-        err.message.contains("must be set together"),
-        "got {}",
+        chain.iter().any(|hop| hop.contains(expected)),
+        "the cause chain must name {expected:?}, got {chain:?}"
+    );
+    assert!(
+        !err.message.contains(expected),
+        "the client-visible message must not carry the diagnosis, got {}",
         err.message
     );
 }

--- a/scripts/checks/error-hygiene.sh
+++ b/scripts/checks/error-hygiene.sh
@@ -25,11 +25,18 @@
 # client's `provider_fault` keeps the upstream diagnostic off the wire), and
 # this guard is what keeps it true as new error paths are added.
 #
+# What it CANNOT see, stated so nobody reads a pass as a proof: it is a textual
+# scan of a three-line window around a constructor, so an error value that is
+# stringified into a differently-named local first (`let detail =
+# e.to_string();`), interpolated more than two lines below the constructor, or
+# formatted inside a helper the constructor merely calls, passes it.
+#
 # Usage: scripts/checks/error-hygiene.sh
 set -euo pipefail
 cd "$(dirname "$0")/../.."
 
-# The guarded constructors:
+# The guarded constructors — every spelling that renders a free-form string into
+# a 5xx body:
 #
 #   - `ApiError::Internal` / `ApiError::ServiceUnavailable` — the 5xx bodies.
 #     (`ValidationFailed` and `NotImplemented` carry no free-form string.)
@@ -38,7 +45,21 @@ cd "$(dirname "$0")/../.."
 #     exposed string the server emits. Two indicators used to interpolate the
 #     raw `sqlx::Error` there, whose Display can name the DSN host, the
 #     database, the role or SQL text (found and fixed under issue #2022).
-CONSTRUCTORS='ApiError::(Internal|ServiceUnavailable)|Health::(down|degraded)'
+#   - `SmError::exception` and `SmError::new(CallStatusType::Exception, …)` —
+#     the SECOND route to a 500 body (issue #2125). A service chapter method
+#     returns `Result<_, SmError>`, and `sm_api_error`
+#     (app/ferroehr-rest/src/overview/error.rs) renders the `exception`,
+#     `success` and `file_not_writable` statuses as `ApiError::Internal(message)`
+#     — so that `message` IS a 500 body, with no curation in between. The
+#     multi-line spelling is caught by matching the status token on its own
+#     line, which is where `SmError::new(` wraps.
+#
+# NOT guarded, deliberately: `ServiceError::exception` /
+# `ServiceError::Internal`. Both `From<ServiceError>` bridges
+# (app/ferroehr/src/service/error.rs) discard that message and substitute
+# `INTERNAL_MESSAGE`, tracing the detail instead — the message is a log detail
+# by construction and never reaches a client.
+CONSTRUCTORS='ApiError::(Internal|ServiceUnavailable)\(|Health::(down|degraded)\(|SmError::exception\(|SmError::new\([[:space:]]*CallStatusType::Exception|^[[:space:]]*CallStatusType::Exception[,[:space:]]*$'
 # The shapes that put an error's Display into a string: a `{e}`-style
 # interpolation of a conventionally-named error binding, or an explicit
 # `.to_string()` on one.
@@ -48,7 +69,7 @@ failures=0
 # A constructor call plus the two lines after it, so a wrapped `format!` is seen.
 # Comment lines are dropped first: this guard's own rule is documented in prose
 # above several of the sites it scans.
-hits=$(grep -rn -A 2 -E "${CONSTRUCTORS}\(" app/ferroehr-rest/src app/ferroehr/src crates/openehr-its/src 2>/dev/null \
+hits=$(grep -rn -A 2 -E "${CONSTRUCTORS}" app/ferroehr-rest/src app/ferroehr/src crates/openehr-its/src 2>/dev/null \
   | grep -vE '^[^:]+[:-][0-9]*[:-]?[[:space:]]*//' \
   | grep -E "$ERROR_VALUE" || true)
 if [ -n "$hits" ]; then
@@ -62,8 +83,10 @@ error-hygiene: a 5xx error body or a health `detail` interpolates an error value
 that can carry SQL, a DSN, a filesystem path, an internal URL or a whole
 thiserror chain to a client (and the health family is unauthenticated).
 Substitute a fixed message and put the detail on the trace record instead (see
-`classify_sqlx` in app/ferroehr/src/storage/error.rs for the pattern). A 4xx may
-keep its specific, client-facing detail; only 5xx is guarded.
+`classify_sqlx` in app/ferroehr/src/storage/error.rs for the pattern), or carry
+the failure as a source (`SmError::with_source`) so the operator can walk the
+chain while the client sees none of it. A 4xx may keep its specific,
+client-facing detail; only 5xx is guarded.
 MSG
   exit 1
 fi


### PR DESCRIPTION
Closes #2124. Closes #2125.

Two halves of one seam: the SM service layer produces granular, spec-named outcomes, `ServiceError` flattened them into bare strings on the way out, and the guard that keeps a diagnostic out of a `500` body did not follow that path.

## The type

| variant | was | now |
|---|---|---|
| `BadRequest` | `String` | `#[source] SmError` |
| `Conflict` | `String` | `#[source] SmError` |
| `VersionConflict` | `String` | `#[source] SmError` |
| `Unprocessable` | `Violation` | `{ status: CallStatusType, #[source] violation }` |
| `Internal` | `String` | `#[source] SmError` |
| `Caused` | `SmError` | **removed** |

`Caused` existed only because the flat variants had nowhere to put a cause. Once every family carries its own, it was a second spelling of `BadRequest`/`Internal`. The classification table moved into `impl From<SmError> for ServiceError`, and bare-variant construction is replaced by constructors named after the SM status they emit — `precondition`, `conflict`, `version_conflict`, `content_invalid`, `exception` — so a site whose status is inaccurate is now visibly so.

Each distinction is grounded in the SM UML class docs (`docs/specs/openehr/SM/docs/UML/classes/`): `invalid_id_pattern` survives from `i_definition_adl14.adoc` §`list_matching_archetypes`/§`list_matching_opts`, `i_definition_adl2.adoc` §`list_matching_artefacts` and `i_definition_query.adoc` §`list_matching_queries`; `store_query` now returns `invalid_query` (`definition_call_status_type.adoc`) instead of `content_invalid`; the 409 and 422 families round-trip losslessly.

**No wire status or body moved**, pinned by a new test comparing both bridges across 16 statuses at the real response seam. No CNF case is affected.

The two AQL parse sites from #2126 now carry the cause, and their stale `// NOTE:`s claiming there was none to carry are deleted.

## The guard

`error-hygiene.sh` now also matches `SmError::exception(`, `SmError::new(CallStatusType::Exception`, and the wrapped multi-line spelling. `ServiceError::exception`/`Internal` are deliberately **not** guarded, with the reason in the header: both bridges discard that message and substitute `INTERNAL_MESSAGE`.

The three boot-time sites are **not exempted**. They already carried `.with_source(e)`, so the redundant `{e}` came out of their messages and the rule is satisfied rather than dodged; four mTLS assertions now read the diagnosis off `Error::source` instead of the message, which is a stronger assertion than the one they replaced.

**Mutation-proven.** Reinstating the exact removed interpolation at a real site:

```
"terminology provider '{name}': the configured TLS material is unusable"  →  "…: {e}"
error-hygiene: app/ferroehr/src/service/terminology/fhir.rs-129- "terminology provider '{name}': {e}"
exit=1
```

and a probe file carrying both `SmError::new` spellings fired on both, while the two controls (`ServiceError::exception(…{e})`, `SmError::precondition(…{e})`) correctly stayed silent.

**What the guard still cannot see**, one sentence in its header: it scans a three-line window, so a diagnostic stringified into a differently-named local first, interpolated more than two lines below the constructor, or formatted inside a helper, passes it. There is one live instance — see below.

## Tests

`every_status_round_trips_except_the_curated_server_faults` (the total form, curated 500 rows enumerated rather than skipped), the family-preservation and walkable-cause tests, `compile_pattern`'s chain reaching the concrete `regex::Error`, and two `ferroehr-rest` tests at the wire seam — the second downcasting to the concrete `serde_json::Error` rather than asserting `source().is_some()`, per the `reliability.md` caveat about `Option<Arc<…>>` sources.

Two tests failed on the way and both were findings rather than flakes: the `regex::Error` chain is two hops, not one, and `archetype_errors` disproved an `invalid_archetype` expectation — see below.

## Left open, honestly

`upload_archetype` with junk input is refused by the ADL 1.4 engine *before* reaching the `sm(InvalidArchetype, …)` site, so it still reports the generic `content_invalid` where `i_definition_adl14.adoc` §`upload_archetype` declares `invalid_archetype`; same for OPT ingestion vs `invalid_template`. All six rows are on **#2151** (blocked by this) with their SM citations, and a `// TODO(#2151):` sits at the two tests that pin the generic status. Every row is wire-identical, so none of it is a conformance change.

## En-route findings filed as notes, not fixed

1. `service/query/execute.rs:455` — `AqlError::Exec(ExecError::Terminology(msg)) => SmError::exception(msg)` puts an upstream FHIR server's diagnostic straight into a `500` body. This is the one live instance of the guard's stated blind spot: `msg` is a pre-stringified `String`, not an interpolation of a conventionally-named error.
2. `service/status.rs:325` — the `QUERY_TIMEOUT_TAG` seam depends on the tagged `exception` reaching the adapter directly; routing it through `ServiceError::Internal` would substitute `INTERNAL_MESSAGE` and silently turn a `408` into a `500`. Nothing pins that coupling.
3. `error-hygiene.sh` references no `$1` at all — `--all` is silently ignored, unlike its three sibling guards. Harmless today, but a caller can believe it selected a wider scope than it did.
4. `ServiceError::Signing(String)` is now the only status-bearing variant that cannot carry a cause. Part of the #2034 sweep.

## Gates

- `cargo clippy -p ferroehr -p ferroehr-rest --all-targets --all-features -- -D warnings` — exit 0, zero diagnostics
- `cargo nextest run -p ferroehr -p ferroehr-rest` — **1605 passed**, 0 failed, 3 skipped
- `cargo fmt --all --check` — clean
- `error-hygiene.sh`, `comment-style.sh --all` (2336 files), `typed-status.sh --all`, `default-style.sh --all` — all exit 0
