### PR TITLE
fix(containers): write OCI annotations, complete the key set, and stop claiming the wrong licence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,6 +323,15 @@ jobs:
           fetch-depth: 0
       - name: Documented keys resolve in their source
         run: bash scripts/checks/docs-claims.sh --all
+      # Image metadata (#2146): the OCI keys are declared in two places — the
+      # Dockerfile, so a direct build is labelled correctly, and the publishing
+      # workflow, whose repo-derived defaults are wrong for a repo shipping three
+      # images. Two declarations of one fact drift; this fails instead. It also
+      # holds base.name/base.digest to the runtime stage's actual FROM pin, and
+      # checks that annotations reach the INDEX (the only place GHCR reads a
+      # package description from).
+      - name: Image metadata is declared once and agrees
+        run: bash scripts/checks/image-labels.sh
 
   # String-built-SQL guard: the AQL engine composes SQL from attacker-supplied
   # query text, so a `format!`/`push_str`-assembled clause in `app/ferroehr/src/

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -264,9 +264,22 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # ANNOTATIONS_LEVELS is not cosmetic. A LABEL lives in the image config
+      # blob; an ANNOTATION lives in the manifest or the index — and GHCR reads
+      # the package description from the INDEX annotation, which is why a
+      # perfectly good description label showed as "No description provided".
+      # The action attaches annotations to manifests only by default.
+      #
+      # The `labels:` block overrides the action's repository-derived guesses,
+      # which are wrong for a repository that publishes three images: title
+      # comes from the repo NAME, so all three would claim to be "FerroEHR".
+      # These values mirror the Dockerfile's, and scripts/checks/image-labels.sh
+      # fails if the two ever disagree.
       - name: Metadata
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: index,manifest
         with:
           images: ${{ env.APP_IMAGE }}
           tags: |
@@ -275,6 +288,17 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+          labels: |
+            org.opencontainers.image.title=ferroehr
+            org.opencontainers.image.description=Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.1.0 + AQL 1.1)
+            org.opencontainers.image.source=https://github.com/rubentalstra/FerroEHR
+            org.opencontainers.image.url=https://ferroehr.eu/
+            org.opencontainers.image.documentation=https://ferroehr.eu/docs/latest/
+            org.opencontainers.image.vendor=FerroEHR
+            org.opencontainers.image.authors=Ruben Talstra <https://github.com/rubentalstra>
+            org.opencontainers.image.licenses=MIT
+            org.opencontainers.image.base.name=gcr.io/distroless/cc-debian13:nonroot
+            org.opencontainers.image.base.digest=sha256:d97bc0a941b8d4be647dc0ee75b264ddbb772f1ac5ba690a4309c00723b23775
 
       - name: Package and push
         id: build
@@ -287,6 +311,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
           # REVISION is the OCI-standard git-SHA arg (org.opencontainers.image.revision).
           # runtime-prebuilt is COPY-only, so it only sets the label here; the
           # binary's own /management/info SHA was stamped in the compile job below.
@@ -458,9 +483,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # See the app lane for why ANNOTATIONS_LEVELS and the explicit labels are
+      # both required.
       - name: Metadata
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: index,manifest
         with:
           images: ${{ env.ADMIN_UI_IMAGE }}
           tags: |
@@ -469,6 +498,17 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+          labels: |
+            org.opencontainers.image.title=ferroehr-admin-ui
+            org.opencontainers.image.description=Admin console for openEHR ITS-REST CDRs — pure-Rust Leptos web app (template manager, visual AQL query builder, EHR browser)
+            org.opencontainers.image.source=https://github.com/rubentalstra/FerroEHR
+            org.opencontainers.image.url=https://ferroehr.eu/
+            org.opencontainers.image.documentation=https://ferroehr.eu/docs/latest/
+            org.opencontainers.image.vendor=FerroEHR
+            org.opencontainers.image.authors=Ruben Talstra <https://github.com/rubentalstra>
+            org.opencontainers.image.licenses=MIT
+            org.opencontainers.image.base.name=gcr.io/distroless/cc-debian13:nonroot
+            org.opencontainers.image.base.digest=sha256:d97bc0a941b8d4be647dc0ee75b264ddbb772f1ac5ba690a4309c00723b23775
 
       - name: Package and push
         id: build_admin_ui
@@ -481,6 +521,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
           build-args: |
             VERSION=${{ steps.meta.outputs.version }}
             REVISION=${{ github.sha }}
@@ -524,9 +565,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # See the app lane for why ANNOTATIONS_LEVELS and the explicit labels are
+      # both required. `licenses` is an SPDX expression here because the image
+      # really is mixed: our init scripts over an upstream `postgres` base.
       - name: Metadata
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: index,manifest
         with:
           images: ${{ env.POSTGRES_IMAGE }}
           tags: |
@@ -535,6 +581,17 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+          labels: |
+            org.opencontainers.image.title=ferroehr-postgres
+            org.opencontainers.image.description=PostgreSQL 18 preconfigured (role/db/schemas/extensions) for ferroehr
+            org.opencontainers.image.source=https://github.com/rubentalstra/FerroEHR
+            org.opencontainers.image.url=https://ferroehr.eu/
+            org.opencontainers.image.documentation=https://ferroehr.eu/docs/latest/
+            org.opencontainers.image.vendor=FerroEHR
+            org.opencontainers.image.authors=Ruben Talstra <https://github.com/rubentalstra>
+            org.opencontainers.image.licenses=MIT AND PostgreSQL
+            org.opencontainers.image.base.name=postgres:18.4
+            org.opencontainers.image.base.digest=sha256:3a82e1f56c8f0f5616a11103ac3d47e632c3938698946a7ad26da0df1334744a
 
       - name: Build and push
         id: build_postgres
@@ -546,6 +603,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
           # Full provenance attestation (docs.docker.com/build/metadata/attestations).
           provenance: mode=max
           sbom: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
+- Six more OCI annotation keys on every image: `authors`, `vendor`,
+  `documentation` (the docs site, which no image pointed at), `url`, and
+  `base.name`/`base.digest` naming the exact pinned base image each one is built
+  on — so "what is this built from" is answerable from the image rather than from
+  the Dockerfile. Every image also reports its own title and description now,
+  where all three previously inherited the repository's.
+
 - **The Helm chart can deploy by digest.** `image.digest` renders the pod's
   image as `repository@sha256:…` and takes precedence over `image.tag`. The
   hardening chapter had been telling operators to deploy by digest "so what you
@@ -241,6 +248,20 @@ workflow refuses a tag that has no matching section here.
 
 
 ### Fixed
+
+- **The published images carry OCI annotations, so registries can read their
+  description.** GHCR showed "No description provided" for all three packages
+  even though each carried a description *label*: a label lives in the image
+  config blob, while a registry reads the description from the image *index*
+  annotation, and no annotation was being written at all. All three lanes now
+  emit annotations at both index and manifest level.
+- **The container images no longer claim the wrong licence.** All three
+  Dockerfiles declared `org.opencontainers.image.licenses="Apache-2.0"` for an
+  MIT-licensed project. Images published by CI were unaffected — the workflow's
+  label overrode the Dockerfile's — so this was only ever visible to someone
+  building the Dockerfiles directly, which is the documented compose path. The
+  app and console images now declare `MIT`, and the postgres image the SPDX
+  expression `MIT AND PostgreSQL`, which is what it actually contains.
 
 - Service-layer refusals now report the precise openEHR Service Model call
   status they were raised with, instead of a generic stand-in. An unusable

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -112,10 +112,25 @@ ENTRYPOINT ["/usr/local/bin/ferroehr"]
 # version/created at build time; these are sensible static defaults.
 ARG VERSION="0.1.0"
 ARG REVISION=""
+# The OCI predefined annotation keys (image-spec annotations.md). Split by who
+# can know the value: everything build-INDEPENDENT is declared here so a direct
+# `docker build` produces a correctly-labelled image, and the four
+# build-DEPENDENT ones (created, version, revision, ref.name) come from the
+# publishing workflow, which is the only place they exist.
+#
+# base.name/base.digest name the IMMEDIATE parent — the `FROM` of this runtime
+# stage, not an intermediate build stage. They are kept in step with that pin by
+# scripts/checks/image-labels.sh.
 LABEL org.opencontainers.image.title="ferroehr" \
       org.opencontainers.image.description="Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.1.0 + AQL 1.1)" \
+      org.opencontainers.image.url="https://ferroehr.eu/" \
+      org.opencontainers.image.documentation="https://ferroehr.eu/docs/latest/" \
       org.opencontainers.image.source="https://github.com/rubentalstra/FerroEHR" \
-      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="FerroEHR" \
+      org.opencontainers.image.authors="Ruben Talstra <https://github.com/rubentalstra>" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.base.name="gcr.io/distroless/cc-debian13:nonroot" \
+      org.opencontainers.image.base.digest="sha256:d97bc0a941b8d4be647dc0ee75b264ddbb772f1ac5ba690a4309c00723b23775" \
       org.opencontainers.image.version="${VERSION}" \
       org.opencontainers.image.revision="${REVISION}"
 

--- a/docker/admin-ui/Dockerfile
+++ b/docker/admin-ui/Dockerfile
@@ -142,10 +142,19 @@ ENTRYPOINT ["/usr/local/bin/ferroehr-admin-ui"]
 # version/created at build time; these are sensible static defaults.
 ARG VERSION="0.1.0"
 ARG REVISION=""
+# See docker/Dockerfile for the split: build-independent keys here, the four
+# build-dependent ones from the publishing workflow. base.* names this runtime
+# stage's `FROM`, kept in step by scripts/checks/image-labels.sh.
 LABEL org.opencontainers.image.title="ferroehr-admin-ui" \
       org.opencontainers.image.description="Admin console for openEHR ITS-REST CDRs — pure-Rust Leptos web app (template manager, visual AQL query builder, EHR browser)" \
+      org.opencontainers.image.url="https://ferroehr.eu/" \
+      org.opencontainers.image.documentation="https://ferroehr.eu/docs/latest/" \
       org.opencontainers.image.source="https://github.com/rubentalstra/FerroEHR" \
-      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="FerroEHR" \
+      org.opencontainers.image.authors="Ruben Talstra <https://github.com/rubentalstra>" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.base.name="gcr.io/distroless/cc-debian13:nonroot" \
+      org.opencontainers.image.base.digest="sha256:d97bc0a941b8d4be647dc0ee75b264ddbb772f1ac5ba690a4309c00723b23775" \
       org.opencontainers.image.version="${VERSION}" \
       org.opencontainers.image.revision="${REVISION}"
 

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -18,7 +18,21 @@ FROM postgres:18.4@sha256:3a82e1f56c8f0f5616a11103ac3d47e632c3938698946a7ad26da0
 # Init scripts run once, on an empty data directory, as the bootstrap superuser.
 COPY initdb/ /docker-entrypoint-initdb.d/
 
+# See docker/Dockerfile for the split: build-independent keys here, the four
+# build-dependent ones from the publishing workflow. base.* names the `FROM`
+# above, kept in step by scripts/checks/image-labels.sh.
+#
+# `licenses` is an SPDX EXPRESSION and this image genuinely is one: our init
+# scripts are MIT, and every layer under them is upstream `postgres`, which is
+# PostgreSQL-licensed. Claiming only MIT would understate what the image
+# contains.
 LABEL org.opencontainers.image.title="ferroehr-postgres" \
       org.opencontainers.image.description="PostgreSQL 18 preconfigured (role/db/schemas/extensions) for ferroehr" \
+      org.opencontainers.image.url="https://ferroehr.eu/" \
+      org.opencontainers.image.documentation="https://ferroehr.eu/docs/latest/" \
       org.opencontainers.image.source="https://github.com/rubentalstra/FerroEHR" \
-      org.opencontainers.image.licenses="Apache-2.0"
+      org.opencontainers.image.vendor="FerroEHR" \
+      org.opencontainers.image.authors="Ruben Talstra <https://github.com/rubentalstra>" \
+      org.opencontainers.image.licenses="MIT AND PostgreSQL" \
+      org.opencontainers.image.base.name="postgres:18.4" \
+      org.opencontainers.image.base.digest="sha256:3a82e1f56c8f0f5616a11103ac3d47e632c3938698946a7ad26da0df1334744a"

--- a/scripts/checks/image-labels.sh
+++ b/scripts/checks/image-labels.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Image-metadata guard: the OCI annotation keys are declared once, correctly, and
+# the two places that declare them agree.
+#
+# Three defects motivated this, all found on the published images (#2146):
+#
+#   * No annotations existed at all. A LABEL lives in the image config blob; an
+#     ANNOTATION lives in the manifest or the index. GHCR reads a package's
+#     description from the INDEX annotation, so three images carrying a perfectly
+#     good description LABEL all displayed "No description provided".
+#   * Six of the spec's fourteen predefined keys were unset, including
+#     `documentation` (we publish a docs site and never pointed at it) and
+#     `base.name`/`base.digest`, whose values were already pinned in the `FROM`.
+#   * All three Dockerfiles declared `licenses="Apache-2.0"` for an MIT project.
+#     That was invisible on GHCR because `build-push-action`'s `labels:` input
+#     overrides a Dockerfile LABEL, so CI published the correct `MIT` — and
+#     anyone building the Dockerfile directly, the documented compose path,
+#     shipped an image asserting a licence the project does not use.
+#
+# The third is the one this guard exists for. The same metadata is declared in
+# two places — the Dockerfile, so a direct build is correct, and the publishing
+# workflow, whose repository-derived defaults are wrong for a repo that ships
+# three images (title comes from the repo NAME, so all three would claim to be
+# "FerroEHR"). Two declarations of one fact drift; this makes them fail instead.
+#
+# Ownership, which is what the checks below encode:
+#   build-INDEPENDENT (title, description, url, documentation, source, vendor,
+#     authors, licenses, base.name, base.digest) — both places, identical values
+#   build-DEPENDENT (created, version, revision, ref.name) — the workflow only,
+#     since a Dockerfile cannot know them
+#   ref.name — deliberately unset; see the waiver below
+#
+# Usage: scripts/checks/image-labels.sh
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+WORKFLOW=.github/workflows/containers.yml
+# image name : Dockerfile : the workflow env var naming that lane's image.
+# The lane is keyed by the env var, not by the image name: `ferroehr` is a prefix
+# of `ferroehr-admin-ui`, so a name match reads the wrong lane's labels.
+IMAGES="ferroehr:docker/Dockerfile:APP_IMAGE
+ferroehr-admin-ui:docker/admin-ui/Dockerfile:ADMIN_UI_IMAGE
+ferroehr-postgres:docker/postgres/Dockerfile:POSTGRES_IMAGE"
+
+# The keys both places must declare, identically.
+SHARED="title description url documentation source vendor authors licenses base.name base.digest"
+
+failures=0
+report() { printf '%s\n' "$*" >&2; failures=$((failures + 1)); }
+
+# The value of `org.opencontainers.image.<key>` in a Dockerfile LABEL block.
+dockerfile_label() {
+  awk -v key="org.opencontainers.image.$2=" '
+    index($0, key) {
+      i = index($0, key) + length(key)
+      v = substr($0, i)
+      sub(/^"/, "", v); sub(/"[[:space:]]*\\?[[:space:]]*$/, "", v)
+      print v; exit
+    }' "$1"
+}
+
+# The value declared in the workflow's `labels:` block for one lane. The lane
+# opens at its `images: ${{ env.<VAR> }}` line and closes at the next lane's, so
+# a key is always read from the lane that declared it.
+workflow_label() {
+  awk -v var="images: \${{ env.$1 }}" -v key="org.opencontainers.image.$2=" '
+    index($0, "images: ${{ env.") && index($0, "_IMAGE }}") { inlane = index($0, var) > 0 }
+    inlane && index($0, key) {
+      i = index($0, key) + length(key)
+      v = substr($0, i)
+      sub(/^[[:space:]]*/, "", v); sub(/[[:space:]]*$/, "", v)
+      print v; exit
+    }' "$WORKFLOW"
+}
+
+for entry in $IMAGES; do
+  image=${entry%%:*}
+  rest=${entry#*:}
+  dockerfile=${rest%%:*}
+  envvar=${rest#*:}
+  [ -f "$dockerfile" ] || { report "image-labels: missing $dockerfile"; continue; }
+
+  for key in $SHARED; do
+    d=$(dockerfile_label "$dockerfile" "$key" || true)
+    w=$(workflow_label "$envvar" "$key" || true)
+    if [ -z "$d" ]; then
+      report "image-labels: $dockerfile declares no org.opencontainers.image.$key"
+      continue
+    fi
+    if [ -z "$w" ]; then
+      report "image-labels: $WORKFLOW declares no org.opencontainers.image.$key for $image"
+      continue
+    fi
+    # The Dockerfile substitutes ${VERSION}/${REVISION} from build args; the
+    # shared keys are all literals, so a plain comparison is right.
+    if [ "$d" != "$w" ]; then
+      report "image-labels: $image .$key disagrees —
+    $dockerfile: $d
+    $WORKFLOW: $w"
+    fi
+  done
+
+  # base.name/base.digest must match the runtime stage's actual FROM pin, or the
+  # image claims a parent it was not built on — worse than claiming none.
+  from=$(grep -E '^FROM [^ ]+@sha256:' "$dockerfile" | tail -1 || true)
+  if [ -z "$from" ]; then
+    report "image-labels: $dockerfile has no digest-pinned FROM to check base.* against"
+  else
+    ref=$(printf '%s' "$from" | awk '{print $2}')
+    want_name=${ref%@*}
+    want_digest=${ref#*@}
+    got_name=$(dockerfile_label "$dockerfile" base.name || true)
+    got_digest=$(dockerfile_label "$dockerfile" base.digest || true)
+    [ "$got_name" = "$want_name" ] \
+      || report "image-labels: $dockerfile base.name is '$got_name', but its FROM is '$want_name'"
+    [ "$got_digest" = "$want_digest" ] \
+      || report "image-labels: $dockerfile base.digest is '$got_digest', but its FROM pins '$want_digest'"
+  fi
+done
+
+# Annotations must reach the INDEX, which is the only place GHCR reads a package
+# description from. Three lanes, three declarations.
+levels=$(grep -c 'DOCKER_METADATA_ANNOTATIONS_LEVELS: index,manifest' "$WORKFLOW" || true)
+[ "$levels" -eq 3 ] \
+  || report "image-labels: expected 3 metadata steps with DOCKER_METADATA_ANNOTATIONS_LEVELS: index,manifest, found $levels"
+annots=$(grep -c 'annotations: ${{ steps.meta.outputs.annotations }}' "$WORKFLOW" || true)
+[ "$annots" -eq 3 ] \
+  || report "image-labels: expected 3 build steps passing the annotations output, found $annots"
+
+# The one predefined key we deliberately leave unset, recorded rather than
+# silently skipped: `ref.name` is "name of the reference for a target", which the
+# spec leaves to the consumer and which our tags already express — an image
+# carries several tags, so a single ref.name would have to pick one arbitrarily.
+# `created` is set by the action from the build time and needs no declaration.
+
+if [ "$failures" -gt 0 ]; then
+  echo "image-labels: $failures problem(s) — see above." >&2
+  exit 1
+fi
+echo "image-labels: OK."


### PR DESCRIPTION
Closes #2146.

Chasing GHCR's "No description provided" turned up three defects, one of which is a false licence claim on artifacts people build themselves. Everything below was read off the published `develop` images with `docker buildx imagetools inspect`, not inferred from the workflow.

## 1. No annotations existed

```
$ docker buildx imagetools inspect --raw ghcr.io/rubentalstra/ferroehr:develop | jq '.annotations // "NONE"'
"NONE"
```

All three lanes passed `labels:` and never `annotations:`. A **label** lives in the image config blob; an **annotation** lives in the manifest or the index — and GHCR reads a package's description from the **index** annotation, so a perfectly good description label was invisible to it.

Two things are needed together, and either alone is insufficient: pass the action's `annotations` output, **and** set `DOCKER_METADATA_ANNOTATIONS_LEVELS: index,manifest`, because the action attaches annotations to manifests only by default. There is no per-annotation `index:` prefix — the level is chosen for the whole set.

## 2. Six of the spec's fourteen keys were unset

Added `authors`, `vendor`, `documentation` (we publish a docs site and no image pointed at it), `url`, and `base.name`/`base.digest`. The last two were free: the runtime `FROM` is already digest-pinned. The spec is specific that `base.*` names the *immediate* parent — the `FROM`, not an intermediate multi-stage image — and that `base.digest` is the digest of the manifest `base.name` references. Publishing them makes "what is this built on" answerable from the image instead of from the Dockerfile.

## 3. The Dockerfiles claimed Apache-2.0 on an MIT project

```
docker/Dockerfile:118            org.opencontainers.image.licenses="Apache-2.0"
docker/admin-ui/Dockerfile:148   org.opencontainers.image.licenses="Apache-2.0"
docker/postgres/Dockerfile:24    org.opencontainers.image.licenses="Apache-2.0"
```

Invisible on GHCR, because `build-push-action`'s `labels:` input overrides a Dockerfile `LABEL` and the published value correctly read `MIT`. So the wrong claim only ever reached someone running `docker build` directly — the documented compose path. App and console now say `MIT`; postgres says `MIT AND PostgreSQL`, an SPDX expression for what the image actually contains (our init scripts over an upstream PostgreSQL-licensed base).

## The structural cause, and the guard for it

That third defect is a symptom: the same metadata was declared in two places with no reconciliation, so **which value won depended on the build path**. The same cause made all three images report `title=FerroEHR`, taken from the repository name.

Ownership is now explicit — build-independent keys in both places with identical values (so a direct build is correct too), build-dependent ones (`created`, `version`, `revision`) only in the workflow, which is the only place they exist. `scripts/checks/image-labels.sh` fails when:

- the Dockerfile and the workflow disagree on any shared key
- `base.name`/`base.digest` drift from the runtime stage's actual `FROM` pin — an image claiming a parent it was not built on is worse than one claiming none
- a lane stops emitting index-level annotations

`ref.name` is deliberately unset and recorded in the script rather than silently skipped: an image carries several tags, so a single `ref.name` would have to pick one arbitrarily.

## Verified, not asserted

| mutation | result |
|---|---|
| reinstate `licenses="Apache-2.0"` in the Dockerfile | caught, naming both values |
| drift `base.digest` from its `FROM` | caught |
| remove one lane's `annotations:` | caught (`found 2`, expected 3) |

And an actual `docker build` of the postgres image reads back every build-independent label correctly — the path that had been wrong:

```
authors      = Ruben Talstra <https://github.com/rubentalstra>
base.digest  = sha256:3a82e1f56c8f0f5616a11103ac3d47e632c3938698946a7ad26da0df1334744a
base.name    = postgres:18.4
description  = PostgreSQL 18 preconfigured (role/db/schemas/extensions) for ferroehr
documentation= https://ferroehr.eu/docs/latest/
licenses     = MIT AND PostgreSQL
source       = https://github.com/rubentalstra/FerroEHR
title        = ferroehr-postgres
url          = https://ferroehr.eu/
vendor       = FerroEHR
```

## Gates

- `bash scripts/checks/image-labels.sh` — OK
- `hadolint --config .hadolint.yaml --failure-threshold warning` on all three Dockerfiles — OK
- `docker build` of the runtime-base stage and the full postgres image — both succeed
- `zizmor --min-severity=low` on `containers.yml` and `ci.yml` — no findings

No `website/book/src` change: the only page describing image metadata is `installation/compose.md`, and its subject is the `REVISION` build argument, which is unchanged. The index-annotation fix is verifiable only after the next `containers.yml` run publishes — the guard covers the workflow's shape; GHCR showing the description is the observable outcome to confirm on merge.
