### PR TITLE
v3.17.4 batch: signing rotation, audit tamper detection, DDL-free runtime role, CSP nonce, bootable chart values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
       admin_ui: ${{ steps.filter.outputs.admin_ui }}
       server_dockerfile: ${{ steps.filter.outputs.server_dockerfile }}
       helm: ${{ steps.filter.outputs.helm }}
+      chart_boot: ${{ steps.filter.outputs.chart_boot }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -98,13 +99,25 @@ jobs:
               echo "admin_ui=true"
               echo "server_dockerfile=true"
               echo "helm=true"
+              echo "chart_boot=true"
             } >> "$GITHUB_OUTPUT"
             exit 0
           fi
           changed=$(git diff --name-only "$base" "$head")
           echo "Changed files:"; echo "$changed"
+          # Every output is written here for the reason the fallback above
+          # states: an unset output reads as `false` downstream and a skipped
+          # job counts as satisfied, so writing only `code` would leave the
+          # other gates unset rather than deliberately false.
           if [ -z "$changed" ]; then
-            echo "code=false" >> "$GITHUB_OUTPUT"; exit 0
+            {
+              echo "code=false"
+              echo "admin_ui=false"
+              echo "server_dockerfile=false"
+              echo "helm=false"
+              echo "chart_boot=false"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
           fi
           # scripts/ is NOT build-relevant by default: the cargo jobs never
           # execute repo scripts, so a new watcher/site/release script must
@@ -147,6 +160,21 @@ jobs:
             echo "helm=true" >> "$GITHUB_OUTPUT"
           else
             echo "helm=false" >> "$GITHUB_OUTPUT"
+          fi
+          # Chart BOOT gate (#2159), a strict superset of the helm filter: the
+          # overlays are only half of the pair under test, the other half being
+          # the configuration vocabulary they are written against. Both sides
+          # can break it — the overlays went un-bootable because the SERVER
+          # tightened validation (an auth mechanism became mandatory, the HMAC
+          # floor arrived, a password hash started being parsed at boot) while
+          # the values files stood still and every render stayed green. So a
+          # change to the config tree, its validators or the annotated template
+          # that is the schema of record re-boots the overlays too. The
+          # Dockerfile is in because it decides what the binary is packaged into.
+          if echo "$changed" | grep -qE '^(deploy/helm/|\.github/workflows/ci\.yml$|docker/Dockerfile$|app/ferroehr/src/config/|app/ferroehr/assets/ferroehr\.default\.toml$|app/ferroehr-rest/src/config\.rs$)' ; then
+            echo "chart_boot=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "chart_boot=false" >> "$GITHUB_OUTPUT"
           fi
 
   # ── Required for code changes: formatting ───────────────────────────────────
@@ -741,6 +769,70 @@ jobs:
       - name: Chart validation + golden renders
         run: bash deploy/helm/validate.sh
 
+  # ── Every committed values overlay must BOOT, not merely render (#2159) ─────
+  # helm-golden above proves the manifests are well-formed, hardened and
+  # unchanged. It proved exactly that while all three overlays carried
+  # configurations the server refuses to start on: `auth.enabled` with no
+  # mechanism, a placeholder that is not an Argon2id PHC string, a 15-byte HMAC
+  # secret under a 32-byte floor, SMART enabled with no public base URL. Four
+  # boot failures, four green renders. Nothing but the server can tell the
+  # difference, so this job runs it.
+  #
+  # It runs on every PR that can break the pair (see the `chart_boot` filter),
+  # NOT only on a tag — the tag lane's identical check is the last line of
+  # defence, and by then the release cut is already failing.
+  #
+  # The image is packaged from THIS TREE's server binary rather than pulled from
+  # GHCR, which is the difference between a gate and a trap: `appVersion` and the
+  # chart's config defaults advance on different clocks, so judging a PR against
+  # a published image would fail every PR that adds a configuration key, from the
+  # commit that adds it until the next release. The binary comes from the
+  # ui-e2e-binary job, whose exact-key cache makes a chart-only PR pay nothing
+  # for it, and packaging is the COPY-only `runtime-prebuilt` target — seconds.
+  chart-boot:
+    name: chart-boot
+    needs: [changes, ui-e2e-binary]
+    if: needs.changes.outputs.chart_boot == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      # The same pin as the goldens, from the same file: `azure/setup-helm` takes
+      # `version`, never `version-file`, and an unknown input is only a warning.
+      - name: Read the pinned helm version
+        id: helm-pin
+        run: |
+          set -euo pipefail
+          version="$(awk '$1 == "helm" { print $2 }' deploy/helm/.tool-versions)"
+          [ -n "$version" ] || { echo "::error::no helm line in deploy/helm/.tool-versions"; exit 1; }
+          echo "version=v${version}" >> "$GITHUB_OUTPUT"
+      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: ${{ steps.helm-pin.outputs.version }}
+      # The artifact download loses the executable bit; the Dockerfile COPYs the
+      # binary with `--chmod=0755`, which is why that does not matter here.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ui-e2e-server-binary
+          path: bin/amd64
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - name: Package the app image (COPY-only, seconds)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: docker/Dockerfile
+          target: runtime-prebuilt
+          load: true
+          tags: ferroehr:chart-boot
+      - name: Boot every committed values overlay
+        env:
+          FERROEHR_IMAGE: ferroehr:chart-boot
+        run: bash deploy/helm/ci/boot-check.sh
+
   # ── Unused dependencies ──────────────────────────────────────────────────────
   unused-deps:
     name: cargo-machete
@@ -794,10 +886,15 @@ jobs:
   # build.rs degrades to SHA=unknown BY DESIGN, and the battery asserts
   # behaviour, never provenance. The PUBLISHED images are untouched:
   # containers.yml still stamps github.sha into them.
+  #
+  # Two consumers now (#2159): the ui-e2e battery below, and the `chart-boot`
+  # job, which boots the chart's values overlays against an image packaged from
+  # this same binary. Hence the widened condition — the job id and name are
+  # unchanged on purpose, because they are branch-protection check names.
   ui-e2e-binary:
     name: ui-e2e server binary
     needs: changes
-    if: needs.changes.outputs.admin_ui == 'true'
+    if: needs.changes.outputs.admin_ui == 'true' || needs.changes.outputs.chart_boot == 'true'
     runs-on: ubuntu-latest
     # Generous: a binary-cache miss with a cold sccache is a full release
     # build of the ~190 kLoC first-party graph (714 s measured cold, plus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,62 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
+- **The PGP signing key can be rotated without losing history.** Signing now
+  uses a signing-capable *subkey* selected by its OpenPGP key flags, which is
+  the rotation mechanism the standard provides: issue a new subkey, the
+  certificate retains the old one, and every previously-signed version keeps
+  verifying with no configuration change. For a certificate that is genuinely
+  replaced — a compromised key, an organisational change — `signing.retired_key_paths`
+  holds the retired **public** keys, verify-only, so a retired key can never
+  sign again. Verification also no longer ignores subkeys, which it did before.
+
+- **`deploy/helm/ci/boot-check.sh`** — runs a real ferroehr image against every
+  values overlay the chart ships, replaying the complete delivery surface: the
+  rendered `ferroehr.toml`, every `config.files` entry, every file-borne secret
+  at its real value, and the environment the Deployment declares (including
+  `valueFrom.secretKeyRef`). Point `FERROEHR_IMAGE` at the tag you intend to
+  deploy and pass your own values file to check it before installing. (#2159)
+- **CI lane `chart-boot`** — boots every committed values overlay against an
+  image packaged from the branch under test, on every pull request that touches
+  the chart or the configuration vocabulary the overlays are written against.
+  Previously the equivalent check ran only on a release tag, which is after the
+  cut has already failed. (#2159)
+
+- **The server can run with no DDL rights at all.** `db.migrate = "verify"`
+  makes it issue no schema statements: at boot it checks that the database
+  already carries exactly this build's migrations and refuses to start
+  otherwise, naming the schema and what is wrong with it (never migrated,
+  behind this build, ahead of it, a failed migration, or a migration applied
+  from different source text). The runtime DSN can then authenticate as
+  `ferroehr_app` alone, so an application-level SQL flaw reaches rows and never
+  the schema. `apply` remains the default, so an empty configuration still
+  boots against an empty database. (#2049)
+- **`ferroehr db migrate` and `ferroehr db verify`** — the out-of-band schema
+  step and its read-only check, for running migrations under a
+  `ferroehr_migrator` DSN separately from the serving process. (#2049)
+- **A migration Job in the Helm chart** (`migrations.job.enabled`): a
+  `pre-install,pre-upgrade` hook Job that Helm waits on, so a failed migration
+  fails the release instead of rolling pods against a schema that was never
+  applied. It authenticates from its own Secret — deliberately a different
+  credential from `database.existingSecret` — and rendering is refused if that
+  Secret is not named. The install NOTES report the resulting posture,
+  including the case where the Job is enabled but `config.db.migrate` is still
+  `apply`. (#2049)
+- **Tamper evidence on the audit trail.** Every record in the local Audit
+  Record Repository is linked into a SHA-256 hash chain maintained inside
+  PostgreSQL, committing to its predecessor and to its own content, so the
+  protection covers every writer rather than only the server's own code. The
+  table now refuses every rewrite path but the per-sink forwarding stamp — a
+  content `UPDATE`, a `DELETE` and a `TRUNCATE` are all rejected — and
+  retention pruning goes through the one sanctioned deletion path, which
+  records which positions it removed so reaping is distinguishable from
+  tampering. `SELECT * FROM audit.verify_audit_chain()` reports one row per
+  damaged record naming what is wrong with it, and nothing at all when the
+  trail is intact; it is also reachable in-process as
+  `AuditStore::verify_chain`. Detection, not prevention: the chain is unkeyed,
+  so the controls for a party with unrestricted write access remain the
+  least-privilege role and the off-box syslog/ATX:FHIR sinks. (#2059)
+
 - `openehr-query`: a spanned lexing entry point, `lexer::lex_spanned`, returning
   each token together with the byte range of the source it was lexed from
   (`lexer::SpannedTokens`, with a `byte_span` mapping from token indices to a
@@ -130,6 +186,35 @@ workflow refuses a tag that has no matching section here.
 - Boot warnings for two deliberate weakenings that are easy to leave switched on: `cors_permissive`, and authentication enabled on a **plaintext** listener bound to a routable address.
 
 ### Changed
+
+- `deploy/helm/validate.sh` now ends every run by stating the properties it does
+  **not** check — that the server accepts the render, that the selected image
+  understands its keys, that a pod starts and serves — each with the command
+  that does check it. A green render was being read as a working deployment.
+  (#2159)
+
+- The Kubernetes, Compose, Operations, Audit, Security, From-source and
+  configuration-reference pages now state both migration postures plainly —
+  what the quickstart does and why, and what a least-privilege deployment does
+  instead — and document the audit trail's tamper evidence and its verification
+  query. The `[db]` reference table gained `migrate` and the previously
+  undocumented `statement_timeout_ms`.
+
+- Bearer-token refusals are now classified: the authentication layer records
+  *why* a token was rejected — expired, not yet valid, bad signature, wrong
+  issuer, wrong audience, missing claim, malformed, unusable key material and
+  twelve more — instead of collapsing every one into a single opaque string.
+  Each refusal reaches the log as a stable `reason` field alongside the
+  authentication mechanism, so a burst of expired tokens (clock skew, or a
+  token lifetime that is too short) is countable and no longer hides a burst of
+  bad signatures (someone presenting tokens this server was never meant to
+  accept). The underlying `jsonwebtoken` error is carried as the error's
+  source, so the cause chain can be walked instead of grepped.
+
+  No wire change: RFC 6750 §3.1 assigns one `invalid_token` code to a token
+  that "is expired, revoked, malformed, or invalid for other reasons", so every
+  refusal keeps answering `401` with the identical `WWW-Authenticate` challenge
+  it did before — now asserted for every refusal kind.
 
 - `openehr-query`: a syntax failure now locates itself in the source.
   `parser::SyntaxFault` carries `bytes: Option<Range<usize>>` — the byte range of
@@ -264,6 +349,24 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **The Helm chart's shipped values overlays now produce configurations the
+  server accepts.** All three rendered, linted and matched their goldens while
+  none of them would boot: `default-values.yaml` enabled authentication with no
+  mechanism, `basic-auth-values.yaml` carried a placeholder that is not an
+  Argon2id PHC string, and `all-features-values.yaml` carried a 15-byte HMAC
+  secret under the RFC 8725 §3.5 32-byte floor and enabled SMART without its
+  required public base URL and endpoint metadata. The tag lane boots the
+  `appVersion` image against the rendered default, so the next release cut would
+  have failed. (#2159)
+
+- **The `audit` schema was unreachable under the least-privilege role model.**
+  It carried no grants at all, so only the database owner could write audit
+  records — a deployment connecting as `ferroehr_app` could not record one. The
+  runtime role now holds exactly `SELECT`, `INSERT`, a column-scoped `UPDATE`
+  on the two delivery stamps, and `EXECUTE` on the reaping and verification
+  functions. The compose PostgreSQL image also pre-creates the `audit` schema
+  alongside `ehr` and `ext`. (#2049, #2059)
+
 - Publishing a chart-only fix between releases works again. The chart lane's
   pre-flight check — that a plain `helm install` of the chart will not
   crash-loop — now compares the chart against the image it is actually judged
@@ -387,6 +490,17 @@ workflow refuses a tag that has no matching section here.
 
 
 ### Security
+
+- The admin console's `Content-Security-Policy` no longer allows inline scripts.
+  `script-src` is now `'self' 'wasm-unsafe-eval' 'nonce-…'`, where the nonce is
+  freshly generated for every response and stamped on the only inline script the
+  console emits — Leptos's hydration bootstrap and its resource-serialization
+  chunks. An injected inline script no longer runs. `style-src` keeps
+  `'unsafe-inline'`, because the console's component library creates its
+  stylesheets in the browser through the DOM without a nonce attribute; adding a
+  nonce there would suppress the inline allowance under CSP Level 3 and leave the
+  console unstyled, so the allowance stays with its reason recorded rather than
+  being traded for a policy that looks stricter and works worse.
 
 - The error-body hygiene check now also covers Service Model faults
   (`SmError::exception` and `exception`-coded call statuses), which are a

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ ITS-REST 1.1.0 &nbsp;·&nbsp; AQL 1.1 &nbsp;·&nbsp; RM 1.2.0 **+ 1.1.0** &nbsp;
 [![Containers](https://github.com/rubentalstra/FerroEHR/actions/workflows/containers.yml/badge.svg?branch=develop)](https://github.com/rubentalstra/FerroEHR/actions/workflows/containers.yml)
 [![CodeQL](https://github.com/rubentalstra/FerroEHR/actions/workflows/codeql.yml/badge.svg?branch=develop)](https://github.com/rubentalstra/FerroEHR/actions/workflows/codeql.yml)
 [![GitHub Release](https://img.shields.io/github/release/rubentalstra/FerroEHR.svg?logo=github)](https://github.com/rubentalstra/FerroEHR/releases/latest)
+[![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/rubentalstra/FerroEHR?utm_source=oss&utm_medium=github&utm_campaign=rubentalstra%2FFerroEHR&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)](https://coderabbit.ai)
 
 [![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Frubentalstra%2Fferroehr%2Fbadges%2Fcoverage.json)](https://github.com/rubentalstra/FerroEHR/actions/workflows/ci.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/rubentalstra/FerroEHR/badge)](https://scorecard.dev/viewer/?uri=github.com/rubentalstra/FerroEHR)

--- a/app/ferroehr-admin-ui/Cargo.toml
+++ b/app/ferroehr-admin-ui/Cargo.toml
@@ -114,6 +114,12 @@ hydrate = [
 ssr = [
     "dep:tower-http",
     "leptos/ssr",
+    # The per-request CSP nonce (src/main.rs): `leptos::nonce::Nonce` +
+    # `HydrationScripts` stamping `nonce=` on the bootstrap script. Named
+    # explicitly rather than inherited from leptos_axum's own dependency
+    # edge, so the strict script-src cannot lose its nonce to a feature
+    # change upstream.
+    "leptos/nonce",
     "leptos_meta/ssr",
     "leptos_router/ssr",
     "thaw/ssr",
@@ -145,6 +151,9 @@ ssr = [
 
 [dev-dependencies]
 indexmap.workspace = true
+# `ServiceExt::oneshot`: the CSP-nonce tests drive a stub router through the
+# security layer in-process, with no listener.
+tower.workspace = true
 # E2E journeys (tests/e2e_*.rs): Rust-native WebDriver + the async runtime;
 # the console gate reads the browser log via thirtyfour's legacy-log API.
 thirtyfour.workspace = true

--- a/app/ferroehr-admin-ui/src/main.rs
+++ b/app/ferroehr-admin-ui/src/main.rs
@@ -80,6 +80,12 @@ async fn main() -> anyhow::Result<()> {
     let routes = leptos_axum::generate_route_list(ferroehr_admin_ui::app::App);
 
     let context_state = app_state.clone();
+    // One context closure for both render entry points (the routed app and the
+    // 404 shell): the app state plus this request's CSP nonce.
+    let provide_console_context = move || {
+        leptos::context::provide_context(context_state.clone());
+        provide_request_nonce();
+    };
     let service = axum::Router::new()
         .route(
             "/auth/oidc/login",
@@ -95,16 +101,12 @@ async fn main() -> anyhow::Result<()> {
             "/export/aql",
             axum::routing::post(ferroehr_admin_ui::export::export_aql),
         )
-        .leptos_routes_with_context(
-            &leptos_options,
-            routes,
-            move || leptos::context::provide_context(context_state.clone()),
-            {
-                let options = leptos_options.clone();
-                move || ferroehr_admin_ui::app::shell(options.clone())
-            },
-        )
-        .fallback(leptos_axum::file_and_error_handler(
+        .leptos_routes_with_context(&leptos_options, routes, provide_console_context.clone(), {
+            let options = leptos_options.clone();
+            move || ferroehr_admin_ui::app::shell(options.clone())
+        })
+        .fallback(leptos_axum::file_and_error_handler_with_context(
+            provide_console_context,
             ferroehr_admin_ui::app::shell,
         ))
         .layer(Extension(app_state))
@@ -137,16 +139,22 @@ fn main() {
 ///   functions, never the browser calling the CDR directly (the BFF boundary in
 ///   `.claude/rules/leptos-ui.md`), so a policy that forbids cross-origin
 ///   connections costs nothing and forecloses exfiltration.
-/// - `'unsafe-inline'` is present for both scripts and styles, and it is the
-///   honest limitation of this policy rather than an oversight: Leptos emits its
-///   hydration bootstrap as an inline script and `thaw` injects generated
-///   `<style>` elements. The strict form is a per-request nonce, which Leptos
-///   supports — that work is tracked separately because a blocked bootstrap
-///   script means a console that renders and never hydrates, so it needs
-///   browser verification rather than a plausible-looking header.
+/// - `script-src` carries no inline allowance: the one inline script the
+///   console emits is Leptos's hydration bootstrap, and it is authorized by a
+///   per-request nonce ([`csp_nonce_layer`]) instead.
+/// - `style-src 'unsafe-inline'` stays, and it is the honest remainder of this
+///   policy rather than an oversight. `thaw` mounts its generated stylesheets
+///   in the browser by creating `<style>` elements through the DOM with no
+///   nonce attribute (`thaw_utils::dom::mount_style`), and both `thaw` and
+///   `leptos-chartistry` render `style="…"` attributes, which `style-src-attr`
+///   inherits. Adding a nonce here would make it strictly WORSE, not better:
+///   CSP Level 3 says a nonce in a directive causes `'unsafe-inline'` in that
+///   same directive to be ignored, so a nonced `style-src` would block every
+///   one of those and leave the console unstyled.
 /// - `X-Frame-Options: DENY` plus `frame-ancestors 'none'` — belt and braces
 ///   against clickjacking a console that performs administrative writes.
-/// - `Cache-Control: no-store` — the console renders patient data into HTML.
+/// - `Cache-Control: no-store` — the console renders patient data into HTML,
+///   and it is also what keeps a nonced document out of any shared cache.
 ///
 /// `Strict-Transport-Security` is left to the TLS edge, for the same reason as
 /// on the API: RFC 6797 §7.2 makes it inert over plain HTTP.
@@ -156,10 +164,7 @@ fn with_security_headers(
 ) -> axum::Router<leptos::prelude::LeptosOptions> {
     use tower_http::set_header::SetResponseHeaderLayer;
     router
-        .layer(SetResponseHeaderLayer::overriding(
-            http::header::CONTENT_SECURITY_POLICY,
-            http::HeaderValue::from_static(CONSOLE_CSP),
-        ))
+        .layer(axum::middleware::from_fn(csp_nonce_layer))
         .layer(SetResponseHeaderLayer::overriding(
             http::header::X_CONTENT_TYPE_OPTIONS,
             http::HeaderValue::from_static("nosniff"),
@@ -178,27 +183,208 @@ fn with_security_headers(
         ))
 }
 
-/// The console's Content-Security-Policy.
+/// Mints this response's script nonce and answers with the policy that names
+/// it.
+///
+/// The nonce is minted here and nowhere else: the layer puts it in the request
+/// extensions on the way in, so the renderer stamps the same value on the
+/// bootstrap script ([`provide_request_nonce`]), and writes the header on the
+/// way out. A fresh value per request is the whole point — a nonce reused
+/// across responses is guessable, and therefore worth no more than
+/// `'unsafe-inline'`.
 #[cfg(feature = "ssr")]
-const CONSOLE_CSP: &str = "default-src 'self'; \
-     script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline'; \
-     style-src 'self' 'unsafe-inline'; \
-     img-src 'self' data:; \
-     font-src 'self'; \
-     connect-src 'self'; \
-     object-src 'none'; \
-     base-uri 'self'; \
-     form-action 'self'; \
-     frame-ancestors 'none'";
+async fn csp_nonce_layer(
+    mut request: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    let nonce = leptos::nonce::Nonce::new();
+    #[expect(
+        clippy::expect_used,
+        reason = "console_csp interpolates a base64url nonce into an ASCII template, so every byte is a legal header-value character; falling back to no policy would silently ship the console unprotected"
+    )]
+    let policy = http::HeaderValue::from_str(&console_csp(&nonce))
+        .expect("an ASCII policy string should be a valid header value");
+    request.extensions_mut().insert(nonce);
+    let mut response = next.run(request).await;
+    response
+        .headers_mut()
+        .insert(http::header::CONTENT_SECURITY_POLICY, policy);
+    response
+}
+
+/// Re-provides this request's nonce into the Leptos render context.
+///
+/// `leptos_axum` provides a nonce of its own before the per-request context
+/// closure runs, and that one is not the value the response header authorizes.
+/// Overriding it here is what makes the two the same string; without it the
+/// bootstrap script carries a nonce the browser has never been told to trust,
+/// and the console renders but never hydrates.
+#[cfg(feature = "ssr")]
+fn provide_request_nonce() {
+    let Some(parts) = leptos::context::use_context::<http::request::Parts>() else {
+        return;
+    };
+    if let Some(nonce) = parts.extensions.get::<leptos::nonce::Nonce>() {
+        leptos::context::provide_context(nonce.clone());
+    }
+}
+
+/// The console's Content-Security-Policy for one request, naming that
+/// request's script nonce.
+#[cfg(feature = "ssr")]
+fn console_csp(nonce: &str) -> String {
+    format!(
+        "default-src 'self'; \
+         script-src 'self' 'wasm-unsafe-eval' 'nonce-{nonce}'; \
+         style-src 'self' 'unsafe-inline'; \
+         img-src 'self' data:; \
+         font-src 'self'; \
+         connect-src 'self'; \
+         object-src 'none'; \
+         base-uri 'self'; \
+         form-action 'self'; \
+         frame-ancestors 'none'"
+    )
+}
 
 #[cfg(all(test, feature = "ssr"))]
 mod tests {
-    use super::CONSOLE_CSP;
+    #![allow(
+        clippy::unwrap_used,
+        clippy::panic,
+        reason = "the exchange helpers panic to report a broken fixture, which is how a test fails (Book ch11); clippy's allow-*-in-tests scoping covers only the #[test] fns themselves"
+    )]
+
+    use super::{console_csp, csp_nonce_layer, provide_request_nonce};
+    use tower::util::ServiceExt;
+
+    /// A sample policy for the directive assertions; the value stands in for a
+    /// minted nonce and is deliberately unlike any other token in the string.
+    const SAMPLE_NONCE: &str = "SAMPLENONCEVALUE";
+
+    /// The response header the stub handler reports the render-context nonce
+    /// through, so a test can compare it with the policy.
+    const RENDERED_NONCE: &str = "x-test-rendered-nonce";
+
+    /// Returns the named directive of `policy`, panicking if it is absent.
+    fn directive<'a>(policy: &'a str, name: &str) -> &'a str {
+        policy
+            .split(';')
+            .map(str::trim)
+            .find(|d| d.starts_with(name))
+            .unwrap_or_else(|| panic!("the policy must carry a {name} directive"))
+    }
+
+    /// Stands in for the Leptos render: it takes the request's `Parts` into a
+    /// reactive owner the way `leptos_axum` does, runs the console's context
+    /// step, and reports whatever `use_nonce` then answers.
+    async fn render_nonce(request: axum::extract::Request) -> axum::response::Response {
+        let (parts, _body) = request.into_parts();
+        let owner = leptos::prelude::Owner::new();
+        let rendered = owner.with(|| {
+            leptos::context::provide_context(parts);
+            provide_request_nonce();
+            leptos::nonce::use_nonce().map(|nonce| nonce.to_string())
+        });
+        let mut response = axum::response::Response::new(axum::body::Body::empty());
+        if let Some(rendered) = rendered {
+            response.headers_mut().insert(
+                http::HeaderName::from_static(RENDERED_NONCE),
+                http::HeaderValue::from_str(&rendered).unwrap(),
+            );
+        }
+        response
+    }
+
+    /// Drives one request through the nonce layer, returning the policy the
+    /// response carries and the nonce the render context saw.
+    async fn one_exchange() -> (String, String) {
+        let response = axum::Router::new()
+            .route("/", axum::routing::get(render_nonce))
+            .layer(axum::middleware::from_fn(csp_nonce_layer))
+            .oneshot(
+                http::Request::builder()
+                    .uri("/")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let header = |name: http::HeaderName| {
+            response
+                .headers()
+                .get(&name)
+                .unwrap_or_else(|| panic!("the response must carry {name}"))
+                .to_str()
+                .unwrap()
+                .to_owned()
+        };
+        (
+            header(http::header::CONTENT_SECURITY_POLICY),
+            header(http::HeaderName::from_static(RENDERED_NONCE)),
+        )
+    }
+
+    /// The whole point of the exercise: the value the renderer stamps on the
+    /// hydration bootstrap is the value the response header authorizes. A
+    /// mismatch is invisible server-side and leaves the console dead in the
+    /// browser.
+    #[tokio::test]
+    async fn the_rendered_nonce_is_the_one_the_header_authorizes() {
+        let (policy, rendered) = one_exchange().await;
+        assert!(
+            directive(&policy, "script-src").contains(&format!("'nonce-{rendered}'")),
+            "script-src must authorize the rendered nonce {rendered}: {policy}"
+        );
+    }
+
+    /// Renders the component that actually stamps the attribute, and pins that
+    /// the `nonce=` it emits is the value the header authorizes. The context
+    /// test above covers our half of the handoff; this covers Leptos's half, so
+    /// an upgrade that stopped stamping the bootstrap script fails here instead
+    /// of in a browser.
+    #[test]
+    fn the_bootstrap_script_carries_the_authorized_nonce() {
+        let nonce = leptos::nonce::Nonce::new();
+        let policy = console_csp(&nonce);
+        let owner = leptos::prelude::Owner::new();
+        let html = owner.with(|| {
+            leptos::context::provide_context(nonce);
+            let options = leptos::config::LeptosOptions::builder()
+                .output_name("ferroehr-admin-ui")
+                .build();
+            leptos::prelude::RenderHtml::to_html(
+                leptos::view! { <leptos::hydration::HydrationScripts options /> },
+            )
+        });
+        let stamped = html
+            .split_once("<script")
+            .and_then(|(_, rest)| rest.split_once("nonce=\""))
+            .and_then(|(_, rest)| rest.split_once('"'));
+        let Some((stamped, _)) = stamped else {
+            panic!("the bootstrap script must carry a nonce: {html}")
+        };
+        assert!(
+            directive(&policy, "script-src").contains(&format!("'nonce-{stamped}'")),
+            "the stamped nonce {stamped} is not the one script-src authorizes: {policy}"
+        );
+    }
+
+    /// A nonce reused across responses is guessable, and then worth no more
+    /// than the `'unsafe-inline'` it replaced.
+    #[tokio::test]
+    async fn every_response_carries_a_fresh_nonce() {
+        let (first_policy, first) = one_exchange().await;
+        let (second_policy, second) = one_exchange().await;
+        assert_ne!(first, second, "two responses reused one nonce");
+        assert_ne!(first_policy, second_policy);
+    }
 
     /// The directives the policy must carry, each for a stated reason.
     #[test]
     fn the_policy_carries_the_audited_directives() {
-        for directive in [
+        let policy = console_csp(SAMPLE_NONCE);
+        for expected in [
             "default-src 'self'",
             // WebAssembly compilation, without permitting eval of JavaScript.
             "'wasm-unsafe-eval'",
@@ -210,8 +396,8 @@ mod tests {
             "frame-ancestors 'none'",
         ] {
             assert!(
-                CONSOLE_CSP.contains(directive),
-                "the policy must carry {directive}"
+                policy.contains(expected),
+                "the policy must carry {expected}"
             );
         }
     }
@@ -221,6 +407,35 @@ mod tests {
     /// error with the bigger hammer.
     #[test]
     fn the_policy_never_permits_eval() {
-        assert!(!CONSOLE_CSP.contains("'unsafe-eval'"));
+        assert!(!console_csp(SAMPLE_NONCE).contains("'unsafe-eval'"));
+    }
+
+    /// The script half is strict: a nonce and no inline allowance. Re-adding
+    /// `'unsafe-inline'` here would not merely widen the policy, it would be
+    /// ignored outright — CSP Level 3 drops it from any directive that also
+    /// carries a nonce — so the regression would look like a working policy.
+    #[test]
+    fn script_src_is_nonce_only() {
+        let policy = console_csp(SAMPLE_NONCE);
+        let script_src = directive(&policy, "script-src");
+        assert!(script_src.contains(&format!("'nonce-{SAMPLE_NONCE}'")));
+        assert!(
+            !script_src.contains("'unsafe-inline'"),
+            "the nonce replaces the inline allowance: {script_src}"
+        );
+    }
+
+    /// The style half keeps its inline allowance and must never gain a nonce:
+    /// `thaw` creates its stylesheets through the DOM without one, so a nonced
+    /// `style-src` would suppress `'unsafe-inline'` and unstyle the console.
+    #[test]
+    fn style_src_keeps_its_inline_allowance_and_no_nonce() {
+        let policy = console_csp(SAMPLE_NONCE);
+        let style_src = directive(&policy, "style-src");
+        assert!(style_src.contains("'unsafe-inline'"));
+        assert!(
+            !style_src.contains("'nonce-"),
+            "a nonce here would disable 'unsafe-inline': {style_src}"
+        );
     }
 }

--- a/app/ferroehr-rest/src/extensions/access/authn/jwt.rs
+++ b/app/ferroehr-rest/src/extensions/access/authn/jwt.rs
@@ -27,7 +27,7 @@ use std::time::Duration;
 use jsonwebtoken::jwk::JwkSet;
 use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode, decode_header};
 
-use super::{AuthError, AuthMethod, Principal};
+use super::{AuthError, AuthMethod, Principal, TokenRejection};
 use ferroehr::config::auth::OidcConfig;
 
 /// A configured bearer-token validator.
@@ -118,14 +118,15 @@ impl JwtValidator {
     /// Validate a raw bearer token (the value after `Bearer `).
     ///
     /// # Errors
-    /// [`AuthError::InvalidToken`] for any signature/claim/format failure.
+    /// [`AuthError::InvalidToken`] for any signature/claim/format failure,
+    /// carrying the [`TokenRejection`] that names which check refused it.
     pub(super) async fn validate(&self, token: &str) -> Result<Principal, AuthError> {
-        let header = decode_header(token).map_err(|e| AuthError::InvalidToken(e.to_string()))?;
+        let header =
+            decode_header(token).map_err(|e| AuthError::InvalidToken(TokenRejection::from(e)))?;
         if !self.algorithms.contains(&header.alg) {
-            return Err(AuthError::InvalidToken(format!(
-                "token algorithm {:?} not accepted",
-                header.alg
-            )));
+            return Err(AuthError::InvalidToken(
+                TokenRejection::AlgorithmNotAccepted(header.alg),
+            ));
         }
 
         // RFC 9068 §4 step 1 / RFC 8725 §3.11: verify the media type BEFORE any
@@ -139,17 +140,15 @@ impl JwtValidator {
             // only requires that a type, if present, is one this server accepts.
             Some(t) if t.eq_ignore_ascii_case("jwt") => false,
             Some(other) => {
-                return Err(AuthError::InvalidToken(format!(
-                    "token type `{other}` is not an access token"
-                )));
+                return Err(AuthError::InvalidToken(
+                    TokenRejection::TokenTypeNotAccessToken(other.to_owned()),
+                ));
             }
             None => false,
         };
         if self.require_at_jwt && !claims_at_jwt_profile {
             return Err(AuthError::InvalidToken(
-                "the token does not claim the RFC 9068 `at+jwt` profile, which \
-                 auth.oidc.require_at_jwt demands"
-                    .to_owned(),
+                TokenRejection::AtJwtProfileRequired,
             ));
         }
 
@@ -175,7 +174,7 @@ impl JwtValidator {
         // `jsonwebtoken` still validates `exp`/`iss`/`aud` from the raw payload
         // independent of the deserialize target.
         let data = decode::<serde_json::Map<String, serde_json::Value>>(token, &key, &validation)
-            .map_err(|e| AuthError::InvalidToken(e.to_string()))?;
+            .map_err(|e| AuthError::InvalidToken(TokenRejection::from(e)))?;
         let claims = data.claims;
 
         // RFC 7519 §4.1.2 makes `sub` optional, but this principal is stamped
@@ -186,13 +185,7 @@ impl JwtValidator {
             .and_then(serde_json::Value::as_str)
             .map(str::trim)
             .filter(|s| !s.is_empty())
-            .ok_or_else(|| {
-                AuthError::InvalidToken(
-                    "token carries no usable `sub` claim; an audit-attributable subject is \
-                     required"
-                        .to_owned(),
-                )
-            })?
+            .ok_or(AuthError::InvalidToken(TokenRejection::SubjectMissing))?
             .to_owned();
 
         // RFC 9068 §4 step 1: a token that CLAIMS the profile is held to the
@@ -203,9 +196,9 @@ impl JwtValidator {
         if claims_at_jwt_profile {
             for required in ["iat", "jti", "client_id"] {
                 if !claims.contains_key(required) {
-                    return Err(AuthError::InvalidToken(format!(
-                        "an `at+jwt` access token must carry `{required}` (RFC 9068 §2.2)"
-                    )));
+                    return Err(AuthError::InvalidToken(
+                        TokenRejection::AtJwtProfileClaimMissing(required.to_owned()),
+                    ));
                 }
             }
         }
@@ -267,9 +260,8 @@ impl JwtValidator {
 /// after narrowing, or when the selected JWK cannot be turned into a key.
 fn jwk_to_key(set: &JwkSet, kid: Option<&str>, alg: Algorithm) -> Result<DecodingKey, AuthError> {
     let jwk = if let Some(kid) = kid {
-        set.find(kid).ok_or_else(|| {
-            AuthError::InvalidToken(format!("the issuer's JWKS carries no key `{kid}`"))
-        })?
+        set.find(kid)
+            .ok_or_else(|| AuthError::InvalidToken(TokenRejection::UnknownKeyId(kid.to_owned())))?
     } else {
         let candidates: Vec<_> = set
             .keys
@@ -295,22 +287,16 @@ fn jwk_to_key(set: &JwkSet, kid: Option<&str>, alg: Algorithm) -> Result<Decodin
         match candidates.as_slice() {
             [single] => *single,
             [] => {
-                return Err(AuthError::InvalidToken(
-                    "the token carries no `kid` and the issuer's JWKS holds no key usable for \
-                     verifying this algorithm"
-                        .to_owned(),
-                ));
+                return Err(AuthError::InvalidToken(TokenRejection::NoUsableKey));
             }
             many => {
-                return Err(AuthError::InvalidToken(format!(
-                    "the token carries no `kid` and {} keys in the issuer's JWKS could verify \
-                     it — the issuer must identify the key",
-                    many.len()
+                return Err(AuthError::InvalidToken(TokenRejection::AmbiguousKey(
+                    many.len(),
                 )));
             }
         }
     };
-    DecodingKey::from_jwk(jwk).map_err(|e| AuthError::InvalidToken(format!("invalid JWK: {e}")))
+    DecodingKey::from_jwk(jwk).map_err(|e| AuthError::InvalidToken(TokenRejection::UnusableJwk(e)))
 }
 
 /// How long successfully fetched key material stays usable without a refetch.
@@ -490,7 +476,7 @@ mod tests {
             .await
             .expect_err("reject");
         assert!(
-            matches!(&err, AuthError::InvalidToken(m) if m.contains("sub")),
+            matches!(&err, AuthError::InvalidToken(TokenRejection::ClaimSet(_))),
             "got {err:?}"
         );
     }
@@ -503,7 +489,10 @@ mod tests {
             .validate(&token(&c))
             .await
             .expect_err("reject");
-        assert!(matches!(err, AuthError::InvalidToken(_)), "got {err:?}");
+        assert!(
+            matches!(err, AuthError::InvalidToken(TokenRejection::SubjectMissing)),
+            "got {err:?}"
+        );
     }
 
     #[tokio::test]
@@ -514,7 +503,63 @@ mod tests {
             .validate(&token(&c))
             .await
             .expect_err("reject");
-        assert!(matches!(err, AuthError::InvalidToken(_)), "got {err:?}");
+        assert!(
+            matches!(err, AuthError::InvalidToken(TokenRejection::Expired(_))),
+            "got {err:?}"
+        );
+    }
+
+    /// RFC 0201 makes the cause chain part of the `Error` contract. It is
+    /// asserted by DOWNCASTING to the concrete types — `source().is_some()`
+    /// stays true even when a hop carries the wrong one.
+    #[tokio::test]
+    async fn a_token_rejection_downcasts_to_its_jsonwebtoken_cause() {
+        let mut c = base_claims();
+        c["exp"] = json!(now() - 3600);
+        let err = validator(&[])
+            .validate(&token(&c))
+            .await
+            .expect_err("reject");
+
+        let rejection = std::error::Error::source(&err)
+            .expect("AuthError carries the typed rejection")
+            .downcast_ref::<TokenRejection>()
+            .expect("the first hop is the TokenRejection");
+        assert_eq!(rejection.label(), "expired");
+
+        let cause = std::error::Error::source(rejection)
+            .expect("the rejection carries its jsonwebtoken error")
+            .downcast_ref::<jsonwebtoken::errors::Error>()
+            .expect("the second hop is the concrete jsonwebtoken error");
+        assert!(
+            matches!(
+                cause.kind(),
+                jsonwebtoken::errors::ErrorKind::ExpiredSignature
+            ),
+            "got {cause:?}"
+        );
+    }
+
+    /// The defect this classification exists to remove: expiry and a bad
+    /// signature used to be one opaque string, so an operator could not tell a
+    /// clock problem from someone presenting tokens this server never minted.
+    #[tokio::test]
+    async fn expired_and_tampered_tokens_report_different_reasons() {
+        let mut c = base_claims();
+        c["exp"] = json!(now() - 3600);
+        let expired = validator(&[])
+            .validate(&token(&c))
+            .await
+            .expect_err("reject");
+
+        let mut t = token(&base_claims());
+        let flip = t.len() - 10;
+        let tampered_char = if t.as_bytes()[flip] == b'A' { 'B' } else { 'A' };
+        t.replace_range(flip..=flip, &tampered_char.to_string());
+        let tampered = validator(&[]).validate(&t).await.expect_err("reject");
+
+        assert_eq!(expired.label(), "expired");
+        assert_eq!(tampered.label(), "signature");
     }
 
     #[tokio::test]
@@ -525,7 +570,10 @@ mod tests {
             .validate(&token(&c))
             .await
             .expect_err("reject");
-        assert!(matches!(err, AuthError::InvalidToken(_)));
+        assert!(
+            matches!(err, AuthError::InvalidToken(TokenRejection::Issuer(_))),
+            "got {err:?}"
+        );
     }
 
     #[tokio::test]
@@ -536,7 +584,10 @@ mod tests {
             .validate(&token(&c))
             .await
             .expect_err("reject");
-        assert!(matches!(err, AuthError::InvalidToken(_)));
+        assert!(
+            matches!(err, AuthError::InvalidToken(TokenRejection::Audience(_))),
+            "got {err:?}"
+        );
     }
 
     #[tokio::test]
@@ -562,7 +613,10 @@ mod tests {
         let tampered = if t.as_bytes()[flip] == b'A' { 'B' } else { 'A' };
         t.replace_range(flip..=flip, &tampered.to_string());
         let err = validator(&[]).validate(&t).await.expect_err("reject");
-        assert!(matches!(err, AuthError::InvalidToken(_)));
+        assert!(
+            matches!(err, AuthError::InvalidToken(TokenRejection::Signature(_))),
+            "got {err:?}"
+        );
     }
 
     /// RFC 7519 §4.1.5: `nbf` is a "MUST NOT be accepted before" claim, and the
@@ -575,7 +629,10 @@ mod tests {
             .validate(&token(&c))
             .await
             .expect_err("a token not yet valid must be refused");
-        assert!(matches!(err, AuthError::InvalidToken(_)), "got {err:?}");
+        assert!(
+            matches!(err, AuthError::InvalidToken(TokenRejection::NotYetValid(_))),
+            "got {err:?}"
+        );
     }
 
     /// RFC 9068 §2.2 requires `iss` on an access token; the crate's default
@@ -589,7 +646,10 @@ mod tests {
             .validate(&token(&c))
             .await
             .expect_err("a token without `iss` must be refused");
-        assert!(matches!(err, AuthError::InvalidToken(_)), "got {err:?}");
+        assert!(
+            matches!(err, AuthError::InvalidToken(TokenRejection::ClaimSet(_))),
+            "got {err:?}"
+        );
     }
 
     /// RFC 7519 §4.1.3 / RFC 9068 §4 step 4: a token minted for a different
@@ -602,7 +662,10 @@ mod tests {
             .validate(&token(&c))
             .await
             .expect_err("a token for another audience must be refused");
-        assert!(matches!(err, AuthError::InvalidToken(_)), "got {err:?}");
+        assert!(
+            matches!(err, AuthError::InvalidToken(TokenRejection::Audience(_))),
+            "got {err:?}"
+        );
     }
 
     /// RFC 9068 §2.1 + §4 step 1: a token CLAIMING the `at+jwt` profile is held
@@ -625,7 +688,13 @@ mod tests {
             .validate(&mint(&base_claims()))
             .await
             .expect_err("an at+jwt token without iat/jti/client_id must be refused");
-        assert!(matches!(err, AuthError::InvalidToken(_)), "got {err:?}");
+        assert!(
+            matches!(
+                err,
+                AuthError::InvalidToken(TokenRejection::AtJwtProfileClaimMissing(_))
+            ),
+            "got {err:?}"
+        );
 
         // Profile claimed and complete → accepted.
         let mut complete = base_claims();
@@ -665,7 +734,13 @@ mod tests {
             .validate(&raw)
             .await
             .expect_err("a non-access-token type must be refused");
-        assert!(matches!(err, AuthError::InvalidToken(_)), "got {err:?}");
+        assert!(
+            matches!(
+                err,
+                AuthError::InvalidToken(TokenRejection::TokenTypeNotAccessToken(_))
+            ),
+            "got {err:?}"
+        );
     }
 
     #[tokio::test]

--- a/app/ferroehr-rest/src/extensions/access/authn/mod.rs
+++ b/app/ferroehr-rest/src/extensions/access/authn/mod.rs
@@ -53,6 +53,8 @@ use openehr_its::rest::runtime::ApiError;
 
 use crate::extensions::access::authz::AuthzHandle;
 use crate::overview::error::RestError;
+use jsonwebtoken::Algorithm;
+use jsonwebtoken::errors::ErrorKind;
 use jwt::JwtValidator;
 
 /// The state the [`middleware`] runs on: the authenticator plus the optional
@@ -117,6 +119,165 @@ pub(crate) struct Authenticated {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct FreshAuthentication;
 
+/// Why a bearer token was refused.
+///
+/// RFC 6750 §3.1 gives every one of these the SAME challenge code —
+/// `invalid_token` covers a token that "is expired, revoked, malformed, or
+/// invalid for other reasons" — so this distinction never reaches the client.
+/// It exists for the operator and the cause chain: a burst of
+/// [`TokenRejection::Expired`] is clock skew or a token lifetime that is too
+/// short, while a burst of [`TokenRejection::Signature`] is someone presenting
+/// tokens this server was never meant to accept.
+///
+/// The variants built from `jsonwebtoken` carry that error as their
+/// [`std::error::Error::source`], so a caller can walk to the concrete kind
+/// instead of matching a substring of another crate's message text.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum TokenRejection {
+    /// The `exp` claim is in the past, beyond the configured clock-skew leeway.
+    #[error("{0}")]
+    Expired(#[source] jsonwebtoken::errors::Error),
+    /// The `nbf` claim puts the token's validity in the future.
+    #[error("{0}")]
+    NotYetValid(#[source] jsonwebtoken::errors::Error),
+    /// The signature does not verify against the selected key.
+    #[error("{0}")]
+    Signature(#[source] jsonwebtoken::errors::Error),
+    /// The `iss` claim is not the configured issuer.
+    #[error("{0}")]
+    Issuer(#[source] jsonwebtoken::errors::Error),
+    /// The `aud` claim names none of the configured audiences.
+    #[error("{0}")]
+    Audience(#[source] jsonwebtoken::errors::Error),
+    /// The `sub` claim is not a subject the validation admits.
+    #[error("{0}")]
+    Subject(#[source] jsonwebtoken::errors::Error),
+    /// A required claim is absent, or carries the wrong JSON type. The message
+    /// names the CLAIM, never its value.
+    #[error("{0}")]
+    ClaimSet(#[source] jsonwebtoken::errors::Error),
+    /// The credential is not a well-formed JWT at all: a bad shape, or base64 /
+    /// JSON / UTF-8 that does not decode.
+    #[error("{0}")]
+    Malformed(#[source] jsonwebtoken::errors::Error),
+    /// The header's algorithm disagrees with the decoding key or the validation.
+    #[error("{0}")]
+    AlgorithmMismatch(#[source] jsonwebtoken::errors::Error),
+    /// The key material the validator holds is unusable — an issuer or
+    /// deployment misconfiguration rather than a client fault.
+    #[error("{0}")]
+    KeyMaterial(#[source] jsonwebtoken::errors::Error),
+    /// A `jsonwebtoken` failure outside the classified set. Its `ErrorKind` is
+    /// `#[non_exhaustive]`, so a crate upgrade can add kinds this mapping has
+    /// not yet named.
+    #[error("{0}")]
+    Unclassified(#[source] jsonwebtoken::errors::Error),
+    /// The header's `alg` is outside `auth.oidc.algorithms`.
+    #[error("token algorithm {0:?} not accepted")]
+    AlgorithmNotAccepted(Algorithm),
+    /// The header's `typ` names a media type that is not an access token
+    /// (RFC 8725 §3.11).
+    #[error("token type `{0}` is not an access token")]
+    TokenTypeNotAccessToken(String),
+    /// `auth.oidc.require_at_jwt` is set and the token does not claim the
+    /// RFC 9068 `at+jwt` profile.
+    #[error(
+        "the token does not claim the RFC 9068 `at+jwt` profile, which \
+         auth.oidc.require_at_jwt demands"
+    )]
+    AtJwtProfileRequired,
+    /// The token claims the `at+jwt` profile but omits a claim RFC 9068 §2.2
+    /// then requires. Carries the claim NAME.
+    #[error("an `at+jwt` access token must carry `{0}` (RFC 9068 §2.2)")]
+    AtJwtProfileClaimMissing(String),
+    /// The token carries no usable `sub`, so the caller would be unattributable
+    /// in the ATNA audit trail.
+    #[error(
+        "token carries no usable `sub` claim; an audit-attributable subject is \
+         required"
+    )]
+    SubjectMissing,
+    /// The token's `kid` names no key in the issuer's JWKS.
+    #[error("the issuer's JWKS carries no key `{0}`")]
+    UnknownKeyId(String),
+    /// The token carries no `kid` and no JWKS key can verify its algorithm.
+    #[error(
+        "the token carries no `kid` and the issuer's JWKS holds no key usable for \
+         verifying this algorithm"
+    )]
+    NoUsableKey,
+    /// The token carries no `kid` and several JWKS keys could verify it, so the
+    /// key cannot be chosen without guessing.
+    #[error(
+        "the token carries no `kid` and {0} keys in the issuer's JWKS could verify \
+         it — the issuer must identify the key"
+    )]
+    AmbiguousKey(usize),
+    /// The selected JWK cannot be turned into a decoding key.
+    #[error("invalid JWK: {0}")]
+    UnusableJwk(#[source] jsonwebtoken::errors::Error),
+}
+
+impl From<jsonwebtoken::errors::Error> for TokenRejection {
+    fn from(error: jsonwebtoken::errors::Error) -> Self {
+        match error.kind() {
+            ErrorKind::ExpiredSignature => Self::Expired(error),
+            ErrorKind::ImmatureSignature => Self::NotYetValid(error),
+            ErrorKind::InvalidSignature => Self::Signature(error),
+            ErrorKind::InvalidIssuer => Self::Issuer(error),
+            ErrorKind::InvalidAudience => Self::Audience(error),
+            ErrorKind::InvalidSubject => Self::Subject(error),
+            ErrorKind::MissingRequiredClaim(_) | ErrorKind::InvalidClaimFormat(_) => {
+                Self::ClaimSet(error)
+            }
+            ErrorKind::InvalidToken
+            | ErrorKind::Base64(_)
+            | ErrorKind::Json(_)
+            | ErrorKind::Utf8(_) => Self::Malformed(error),
+            ErrorKind::InvalidAlgorithm
+            | ErrorKind::InvalidAlgorithmName
+            | ErrorKind::MissingAlgorithm
+            | ErrorKind::UnsupportedAlgorithm => Self::AlgorithmMismatch(error),
+            ErrorKind::InvalidEcdsaKey
+            | ErrorKind::InvalidEddsaKey
+            | ErrorKind::InvalidRsaKey(_)
+            | ErrorKind::InvalidKeyFormat => Self::KeyMaterial(error),
+            _ => Self::Unclassified(error),
+        }
+    }
+}
+
+impl TokenRejection {
+    /// A stable, low-cardinality label naming this rejection.
+    ///
+    /// Carries no token bytes and no claim value, so it is safe as a structured
+    /// log field or a metric label.
+    pub(crate) const fn label(&self) -> &'static str {
+        match self {
+            TokenRejection::Expired(_) => "expired",
+            TokenRejection::NotYetValid(_) => "not_yet_valid",
+            TokenRejection::Signature(_) => "signature",
+            TokenRejection::Issuer(_) => "issuer",
+            TokenRejection::Audience(_) => "audience",
+            TokenRejection::Subject(_) => "subject",
+            TokenRejection::ClaimSet(_) => "claim_set",
+            TokenRejection::Malformed(_) => "malformed",
+            TokenRejection::AlgorithmMismatch(_) => "algorithm_mismatch",
+            TokenRejection::KeyMaterial(_) => "key_material",
+            TokenRejection::Unclassified(_) => "unclassified",
+            TokenRejection::AlgorithmNotAccepted(_) => "algorithm_not_accepted",
+            TokenRejection::TokenTypeNotAccessToken(_) => "token_type",
+            TokenRejection::AtJwtProfileRequired => "at_jwt_profile_required",
+            TokenRejection::AtJwtProfileClaimMissing(_) => "at_jwt_claim_missing",
+            TokenRejection::SubjectMissing => "subject_missing",
+            TokenRejection::UnknownKeyId(_) => "unknown_key_id",
+            TokenRejection::NoUsableKey => "no_usable_key",
+            TokenRejection::AmbiguousKey(_) => "ambiguous_key",
+            TokenRejection::UnusableJwk(_) => "unusable_jwk",
+        }
+    }
+}
+
 /// An authentication failure.
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum AuthError {
@@ -140,8 +301,13 @@ pub enum AuthError {
     #[error("malformed authorization header: {0}")]
     MalformedRequest(String),
     /// A bearer token that failed structural, signature, or claim validation.
+    ///
+    /// The [`TokenRejection`] names WHICH check refused it and carries the
+    /// underlying `jsonwebtoken` error as its source; RFC 6750 §3.1 keeps every
+    /// one of those on the single `invalid_token` challenge code, so the
+    /// distinction is an operator signal, never a wire one.
     #[error("invalid bearer token: {0}")]
-    InvalidToken(String),
+    InvalidToken(#[from] TokenRejection),
     /// The issuer's signing keys (JWKS) could not be fetched or parsed, so no
     /// bearer token can be validated.
     #[error("could not resolve signing keys: {0}")]
@@ -175,7 +341,14 @@ impl AuthError {
             // tell a caller with a perfectly valid token that its credential was
             // rejected, and a client that trusts that stops retrying.
             AuthError::KeyResolution(m) => ApiError::ServiceUnavailable(m.clone()),
-            other => ApiError::Unauthorized(other.to_string()),
+            // The body says nothing about WHY, on purpose. Rendering the
+            // rejection told an UNAUTHENTICATED caller whether a token was
+            // expired or forged — an oracle that separates "a real token, just
+            // stale" from "my forgery was caught", which is exactly the
+            // distinction an attacker probes for. RFC 6750 §3 asks only that the
+            // challenge carry an `error` code, which it does; the reason stays
+            // in the log, where the operator can read it and the caller cannot.
+            _ => ApiError::Unauthorized("authentication failed".to_owned()),
         }
     }
 
@@ -197,6 +370,23 @@ impl AuthError {
             AuthError::MissingCredentials
             | AuthError::KeyResolution(_)
             | AuthError::VerificationUnavailable(_) => None,
+        }
+    }
+
+    /// A stable, low-cardinality label naming this outcome.
+    ///
+    /// Carries no credential material, so it is safe as a structured log field
+    /// or a metric label; a bearer refusal delegates to
+    /// [`TokenRejection::label`] so expired-versus-invalid is countable.
+    pub(crate) const fn label(&self) -> &'static str {
+        match self {
+            AuthError::MissingCredentials => "missing_credentials",
+            AuthError::InvalidCredentials => "invalid_credentials",
+            AuthError::MalformedRequest(_) => "malformed_request",
+            AuthError::InvalidToken(rejection) => rejection.label(),
+            AuthError::KeyResolution(_) => "key_resolution",
+            AuthError::Forbidden(_) => "forbidden",
+            AuthError::VerificationUnavailable(_) => "verification_unavailable",
         }
     }
 }
@@ -553,12 +743,23 @@ pub(crate) async fn middleware(
         Err(e) => {
             let api = e.to_api_error();
             let status = api.status();
+            let mechanism = scheme_label(req.headers());
             metrics::counter!(
                 ferroehr::telemetry::prometheus::AUTH_FAILURES,
-                "mechanism" => scheme_label(req.headers()),
+                "mechanism" => mechanism,
                 "status" => if status == StatusCode::FORBIDDEN { "403" } else { "401" },
             )
             .increment(1);
+            // A refusal that presented no credential is routine (an
+            // unauthenticated probe); a presented-and-rejected one is the
+            // operator's signal. Neither record carries the token or a claim
+            // value.
+            let reason = e.label();
+            if matches!(e, AuthError::MissingCredentials) {
+                tracing::debug!(mechanism, reason, "authentication refused");
+            } else {
+                tracing::warn!(mechanism, reason, detail = %e, "authentication refused");
+            }
             // ITS-REST §Authentication and authorization: a `401` MUST carry a
             // `WWW-Authenticate` challenge. RFC 6750 §3 additionally carries one
             // on a bearer `403` — the `insufficient_scope` case — because there
@@ -580,7 +781,7 @@ pub(crate) async fn middleware(
 /// The RFC 6750 §2.1 grammar and the challenge shapes, asserted per clause.
 #[cfg(test)]
 mod bearer_grammar_tests {
-    use super::{AuthError, bearer_credential};
+    use super::{AuthError, TokenRejection, bearer_credential};
 
     #[test]
     fn bearer_credentials_follow_rfc6750_abnf() {
@@ -625,7 +826,7 @@ mod bearer_grammar_tests {
             Some("invalid_token")
         );
         assert_eq!(
-            AuthError::InvalidToken("x".to_owned()).bearer_error_code(),
+            AuthError::InvalidToken(TokenRejection::NoUsableKey).bearer_error_code(),
             Some("invalid_token")
         );
         assert_eq!(
@@ -885,6 +1086,172 @@ mod tests {
             .authenticate(&headers("Bearer not-a-jwt"))
             .await
             .expect_err("reject");
-        assert!(matches!(err, AuthError::InvalidToken(_)), "got {err:?}");
+        assert!(
+            matches!(err, AuthError::InvalidToken(TokenRejection::Malformed(_))),
+            "got {err:?}"
+        );
+    }
+
+    /// One value of every [`TokenRejection`] variant, for the wire-identity
+    /// assertion below.
+    fn every_token_rejection() -> Vec<TokenRejection> {
+        let cause = || jsonwebtoken::errors::Error::from(ErrorKind::ExpiredSignature);
+        vec![
+            TokenRejection::Expired(cause()),
+            TokenRejection::NotYetValid(cause()),
+            TokenRejection::Signature(cause()),
+            TokenRejection::Issuer(cause()),
+            TokenRejection::Audience(cause()),
+            TokenRejection::Subject(cause()),
+            TokenRejection::ClaimSet(cause()),
+            TokenRejection::Malformed(cause()),
+            TokenRejection::AlgorithmMismatch(cause()),
+            TokenRejection::KeyMaterial(cause()),
+            TokenRejection::Unclassified(cause()),
+            TokenRejection::AlgorithmNotAccepted(Algorithm::HS256),
+            TokenRejection::TokenTypeNotAccessToken("JWT+ID".to_owned()),
+            TokenRejection::AtJwtProfileRequired,
+            TokenRejection::AtJwtProfileClaimMissing("jti".to_owned()),
+            TokenRejection::SubjectMissing,
+            TokenRejection::UnknownKeyId("k1".to_owned()),
+            TokenRejection::NoUsableKey,
+            TokenRejection::AmbiguousKey(2),
+            TokenRejection::UnusableJwk(cause()),
+        ]
+    }
+
+    /// RFC 6750 §3.1 gives ONE code to every rejected token — `invalid_token`
+    /// covers a token that "is expired, revoked, malformed, or invalid for
+    /// other reasons" — so neither the status nor the challenge a client sees
+    /// may vary with the reason the server classified internally.
+    #[test]
+    fn every_token_rejection_renders_one_status_and_one_challenge() {
+        let auth = hmac_oidc();
+        let mut challenges: Vec<HeaderValue> = Vec::new();
+        for rejection in every_token_rejection() {
+            let err = AuthError::InvalidToken(rejection);
+            assert_eq!(
+                err.to_api_error().status(),
+                StatusCode::UNAUTHORIZED,
+                "{err:?}"
+            );
+            assert_eq!(err.bearer_error_code(), Some("invalid_token"), "{err:?}");
+            challenges.push(auth.challenge(Some(&err)));
+        }
+        let first = challenges.first().expect("rejection kinds exist").clone();
+        assert!(
+            challenges.iter().all(|c| *c == first),
+            "the challenge must not vary with the refusal reason: {challenges:?}"
+        );
+        assert_eq!(
+            first,
+            HeaderValue::from_static(r#"Bearer realm="ferroehr", error="invalid_token""#)
+        );
+    }
+
+    /// Collects every tracing EVENT's fields, so the refusal record can be read
+    /// back field by field.
+    #[derive(Clone, Default)]
+    struct EventCapture(Arc<std::sync::Mutex<Vec<std::collections::BTreeMap<String, String>>>>);
+
+    /// Renders one event's fields into `name -> value`.
+    struct FieldSink(std::collections::BTreeMap<String, String>);
+
+    impl tracing::field::Visit for FieldSink {
+        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+            self.0.insert(field.name().to_owned(), format!("{value:?}"));
+        }
+
+        fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+            self.0.insert(field.name().to_owned(), value.to_owned());
+        }
+    }
+
+    impl<S: tracing::Subscriber> tracing_subscriber::layer::Layer<S> for EventCapture {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            let mut sink = FieldSink(std::collections::BTreeMap::new());
+            event.record(&mut sink);
+            self.0.lock().expect("lock").push(sink.0);
+        }
+    }
+
+    /// The refusal reason must reach the LOG as its own field — countable
+    /// rather than greppable — and neither the token nor a claim value may
+    /// appear anywhere in the record.
+    #[tokio::test]
+    async fn a_refused_token_logs_its_reason_and_never_the_token() {
+        use tracing_subscriber::layer::SubscriberExt as _;
+
+        const TOKEN: &str = "not-a-jwt-at-all";
+
+        let capture = EventCapture::default();
+        let subscriber = tracing_subscriber::registry().with(capture.clone());
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let layer = AuthLayer {
+            authenticator: hmac_oidc(),
+            authz: None,
+        };
+        let app = axum::Router::new()
+            .route("/x", axum::routing::get(|| async { "ok" }))
+            .layer(axum::middleware::from_fn_with_state(layer, middleware));
+
+        let response = tower::ServiceExt::oneshot(
+            app,
+            Request::builder()
+                .uri("/x")
+                .header(header::AUTHORIZATION, format!("Bearer {TOKEN}"))
+                .body(axum::body::Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+        let events = capture.0.lock().expect("lock").clone();
+        let refusal = events
+            .iter()
+            .find(|fields| {
+                fields
+                    .get("message")
+                    .is_some_and(|m| m == "authentication refused")
+            })
+            .expect("the refusal is logged");
+        assert_eq!(
+            refusal.get("reason").map(String::as_str),
+            Some("malformed"),
+            "{refusal:?}"
+        );
+        assert_eq!(
+            refusal.get("mechanism").map(String::as_str),
+            Some("bearer"),
+            "{refusal:?}"
+        );
+        for fields in &events {
+            for (name, value) in fields {
+                assert!(
+                    !value.contains(TOKEN),
+                    "the credential leaked into the `{name}` field: {value}"
+                );
+            }
+        }
+    }
+
+    /// Each classified reason gets its own stable label, so a burst of one kind
+    /// is countable in the logs rather than greppable out of a message.
+    #[test]
+    fn token_rejection_labels_are_distinct() {
+        let mut labels: Vec<&'static str> = every_token_rejection()
+            .iter()
+            .map(TokenRejection::label)
+            .collect();
+        let total = labels.len();
+        labels.sort_unstable();
+        labels.dedup();
+        assert_eq!(labels.len(), total, "two rejection kinds share a label");
     }
 }

--- a/app/ferroehr-server/src/lib.rs
+++ b/app/ferroehr-server/src/lib.rs
@@ -76,6 +76,27 @@ pub enum Command {
         #[command(subcommand)]
         cmd: ConfigCmd,
     },
+    /// Database schema utilities (apply / verify the migrations, then exit).
+    Db {
+        /// Which schema utility to run.
+        #[command(subcommand)]
+        cmd: DbCmd,
+    },
+}
+
+/// `ferroehr db …` subcommands.
+///
+/// These exist so a least-privilege deployment can separate the two database
+/// identities: `migrate` runs under the migrator DSN as a one-shot step
+/// (a Kubernetes Job, an init container, a CI/CD stage), and the server then
+/// boots with `[db].migrate = "verify"` under a DSN with no DDL rights at all.
+#[derive(Debug, Subcommand)]
+pub enum DbCmd {
+    /// Apply the embedded migrations and exit; the DSN must hold DDL rights.
+    Migrate,
+    /// Verify, without issuing any DDL, that the database carries exactly this
+    /// build's migrations; exit 0 when it does, 1 otherwise.
+    Verify,
 }
 
 /// `ferroehr config …` subcommands.
@@ -105,8 +126,43 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
     match cli.command {
         Some(Command::Healthcheck { url }) => healthcheck(&url).await,
         Some(Command::Config { cmd }) => run_config(&cmd, cli.config.as_deref(), &cli.set),
+        Some(Command::Db { cmd }) => run_db(&cmd, cli.config.as_deref(), &cli.set).await,
         None => serve(cli.config.as_deref(), &cli.set).await,
     }
+}
+
+/// `ferroehr db migrate` / `ferroehr db verify` — the out-of-band schema step.
+async fn run_db(
+    cmd: &DbCmd,
+    config_path: Option<&Path>,
+    overrides: &[(String, String)],
+) -> anyhow::Result<()> {
+    let config =
+        ferroehr::config::load(config_path, overrides).map_err(|e| anyhow::anyhow!("{e}"))?;
+    config.validate().map_err(|e| anyhow::anyhow!("{e}"))?;
+    let telemetry_config = TelemetryConfig {
+        log: config.log.clone(),
+        otel: config.telemetry.clone(),
+    };
+    let build_info = BuildInfo::for_profile(config.spec_profile);
+    let telemetry =
+        telemetry::init(&telemetry_config, &build_info).context("initialising telemetry")?;
+
+    // The plain pool: the migrator identity is a database role, never a tenant.
+    let pool = db::connect(&config.db)
+        .await
+        .context("connecting to PostgreSQL")?;
+    let outcome = match cmd {
+        DbCmd::Migrate => db::run_migrations(&pool)
+            .await
+            .context("applying migrations"),
+        DbCmd::Verify => db::verify_migrations(&pool)
+            .await
+            .context("verifying the schema"),
+    };
+    pool.close().await;
+    telemetry.shutdown().await;
+    outcome
 }
 
 /// `ferroehr config check` / `ferroehr config default`.
@@ -280,9 +336,9 @@ async fn serve(config_path: Option<&Path>, overrides: &[(String, String)]) -> an
             .await
             .context("connecting to PostgreSQL")?
     };
-    db::run_migrations(&pool)
+    db::prepare(&config.db, &pool)
         .await
-        .context("applying migrations")?;
+        .context("preparing the database schema")?;
 
     // ATNA audit (fail-open at boot). A slim build cannot render the FHIR
     // `AuditEvent` the store and the ATX:FHIR Feed carry, so an enabled

--- a/app/ferroehr/assets/ferroehr.default.toml
+++ b/app/ferroehr/assets/ferroehr.default.toml
@@ -114,6 +114,12 @@ http2_keep_alive_timeout_secs = 10   # PING response deadline before the connect
 [db]
 url = "postgres://ferroehr:ferroehr@localhost:5432/ferroehr"  # PROD: real DSN via env/secret
 #? url_file = "/run/secrets/db-dsn"   # or point at a mounted file instead of passing the DSN as env
+# Whether the server issues DDL at boot. "apply" runs the embedded migrations
+# then verifies, which is what makes an empty configuration boot against an
+# empty database; "verify" never issues DDL and refuses to serve unless the
+# database already carries exactly this build's migrations, so the runtime role
+# needs no schema rights.
+migrate = "apply"            # apply | verify — PROD: verify
 max_connections = 20
 min_connections = 2
 acquire_timeout_secs = 30
@@ -312,7 +318,13 @@ max_frequency = 999           # highest sampling frequency (Hz) a request may as
 enabled = true
 mode = "digest"              # digest | pgp
 #? key_path = "/etc/ferroehr/signing.asc"   # required for mode = pgp
-#? key_passphrase = "..."    # or key_passphrase_file = "/run/secrets/pgp-pass"
+#? key_passphrase = "..."
+#? key_passphrase_file = "/run/secrets/pgp-pass"
+# PUBLIC keys retired from signing and kept for verification, so versions signed
+# before a key rotation keep verifying. A stored signature carries no key id and
+# is an immutable committed fact, so retaining the old key is the only way
+# history stays verifiable. Public keys: a retired key can never sign again.
+retired_key_paths = []       # e.g. ["/etc/ferroehr/signing-2025.pub.asc"]
 # Read-time verification of OUR OWN signatures. UNSET (the default) resolves to
 # `strict` when signing is enabled — a served version whose stored signature no
 # longer recomputes is a 5xx integrity fault. Set explicitly to opt out:
@@ -422,7 +434,8 @@ threshold_bytes = 262144
 bucket = "openehr-multimedia"
 region = "us-east-1"
 #? access_key_id = "..."
-#? secret_access_key = "..."   # or secret_access_key_file = "/run/secrets/s3"
+#? secret_access_key = "..."
+#? secret_access_key_file = "/run/secrets/s3"
 allow_http = false           # PROD: false (HTTPS S3)
 
 # ── [audit] — IHE ATNA audit trail / System Log ──────────────────────────────

--- a/app/ferroehr/migrations/audit/0002_audit_chain.sql
+++ b/app/ferroehr/migrations/audit/0002_audit_chain.sql
@@ -1,0 +1,572 @@
+-- Tamper evidence for the local IHE ATNA Audit Record Repository, plus the
+-- least-privilege grants that make the `audit` schema usable by a role that
+-- holds no DDL rights.
+--
+-- NOTE: no openEHR spec governs audit storage mechanics or database roles —
+-- our own design/extension. The control being implemented is the OWASP
+-- Logging Cheat Sheet's §Log Integrity ("build in tamper detection so you
+-- know if a record has been modified or deleted") and the ATNA posture that
+-- the audit trail is the node's accountability artifact.
+--
+-- The mechanism is an unkeyed SHA-256 hash chain maintained INSIDE the
+-- database, so every writer is covered — the per-event INSERT, the batched
+-- drain INSERT, and any statement issued by hand. Each row stores the hash of
+-- its predecessor (`prev_hash`) and a digest over its own immutable content
+-- including that link (`row_hash`); a single-row `audit_chain_state` carries the
+-- chain head, and `audit_chain_gap` records every span retention reaped.
+-- Verification (`audit.verify_audit_chain()`) recomputes every digest, re-walks
+-- every link, and checks the end against the head, so a modified record, a
+-- deleted record, and a truncated head or tail are each named — while a gap
+-- retention actually produced is recognized as legitimate.
+--
+-- A per-record signature over the existing PGP signer was the alternative, and
+-- it was rejected on both halves of the requirement: an independent signature
+-- proves a record was not MODIFIED but says nothing about one that was
+-- DELETED, and it would put an asymmetric operation on every audit write and
+-- reach only records written by this server. Measured write-path cost of the
+-- chain on PostgreSQL 18: ~0.28 ms per record on the batch path, no quadratic
+-- term.
+--
+-- What it does NOT prove: the chain is unkeyed, so a party that can write
+-- freely to this schema can delete a record and recompute every hash after it.
+-- The controls for that case are the least-privilege grants below (the runtime
+-- role can insert and stamp delivery, and nothing else) and the off-box copies
+-- (RFC 5424 syslog, the ITI-20 ATX:FHIR feed) — the cheat sheet's "copy log
+-- data to read-only media" control. Detection, not prevention.
+--
+-- Rows written before this migration are chained by the backfill below from
+-- their stored order; the chain therefore attests them only from this point
+-- forward.
+
+-- ── chain columns ────────────────────────────────────────────────────────────
+
+ALTER TABLE audit_event
+    ADD COLUMN chain_seq bigint,
+    ADD COLUMN prev_hash bytea,
+    ADD COLUMN row_hash  bytea;
+
+COMMENT ON COLUMN audit_event.chain_seq IS
+    'Position in the tamper-evidence hash chain, assigned by the insert trigger under the chain-state row lock: gapless, so a missing number is a deleted record.';
+COMMENT ON COLUMN audit_event.prev_hash IS
+    'The row_hash of this record''s predecessor in the chain (the genesis digest for the first record).';
+COMMENT ON COLUMN audit_event.row_hash IS
+    'SHA-256 over prev_hash plus this record''s immutable content (audit.audit_event_digest); recomputed by audit.verify_audit_chain().';
+
+-- ── chain state: the head and the retention low-water mark ───────────────────
+
+CREATE TABLE audit_chain_state (
+    -- One row, forever: the CHECK plus the primary key make a second row
+    -- unrepresentable.
+    singleton  boolean     NOT NULL DEFAULT true,
+    -- The chain position and digest of the most recently written record, so a
+    -- deletion at the END of the chain — where no successor would notice — is
+    -- still detected.
+    head_seq   bigint      NOT NULL DEFAULT 0,
+    head_hash  bytea       NOT NULL,
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT pk_audit_chain_state PRIMARY KEY (singleton),
+    CONSTRAINT ck_audit_chain_state_singleton CHECK (singleton)
+);
+
+COMMENT ON TABLE audit_chain_state IS
+    'The audit hash chain''s head: one row, written only by the SECURITY DEFINER chain trigger.';
+
+-- Retention removes records, which by itself is indistinguishable from an
+-- attacker removing them. A reaped span therefore leaves a tombstone recording
+-- WHICH chain positions went and what digest the next surviving record must
+-- link to — so an intact repository has a recorded reason for every gap, and an
+-- unrecorded gap is tampering. Spans, not per-record rows, so ordinary
+-- oldest-first reaping keeps exactly one tombstone however long the system
+-- runs; a tombstone carries a position and a hash, never any record content.
+CREATE TABLE audit_chain_gap (
+    from_seq  bigint      NOT NULL,
+    to_seq    bigint      NOT NULL,
+    -- The row_hash of the LAST record in the span: what the next surviving
+    -- record's prev_hash must equal.
+    link_hash bytea       NOT NULL,
+    reaped_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT pk_audit_chain_gap PRIMARY KEY (from_seq),
+    CONSTRAINT ck_audit_chain_gap_span CHECK (to_seq >= from_seq)
+);
+
+COMMENT ON TABLE audit_chain_gap IS
+    'One row per span of chain positions removed by retention reaping — the recorded reason a gap in the chain is legitimate.';
+
+-- ── the digest ───────────────────────────────────────────────────────────────
+
+CREATE FUNCTION audit.audit_chain_genesis() RETURNS bytea
+    LANGUAGE sql IMMUTABLE PARALLEL SAFE
+    SET search_path = pg_catalog
+    AS $$ SELECT sha256(convert_to('ferroehr.audit_chain.v1', 'UTF8')) $$;
+
+COMMENT ON FUNCTION audit.audit_chain_genesis() IS
+    'The fixed digest the first record in the chain links back to.';
+
+-- The hashed payload is a jsonb array rendered to text: jsonb output is
+-- canonical (normalized numbers, sorted keys, no insignificant whitespace) and
+-- distinguishes a JSON null from an empty string, so no field boundary is
+-- ambiguous. Timestamps are formatted explicitly in UTC with a numeric-only
+-- pattern, so neither the session TimeZone nor lc_time can change the digest
+-- (PostgreSQL 18 docs, "Data Type Formatting Functions":
+-- https://www.postgresql.org/docs/18/functions-formatting.html).
+--
+-- The mutable delivery stamps are deliberately NOT hashed: stamping a record as
+-- forwarded is the one permitted change to a stored row.
+CREATE FUNCTION audit.audit_event_digest(
+    p_prev_hash      bytea,
+    p_chain_seq      bigint,
+    p_id             uuid,
+    p_recorded_at    timestamptz,
+    p_stored_at      timestamptz,
+    p_action         text,
+    p_outcome        smallint,
+    p_event_code     text,
+    p_operation      text,
+    p_principal      text,
+    p_patient_id     text,
+    p_resource_class text,
+    p_resource_id    text,
+    p_client_ip      text,
+    p_token_id       text,
+    p_tenant_id      uuid,
+    p_fhir           jsonb
+) RETURNS bytea
+    LANGUAGE sql STABLE PARALLEL SAFE
+    SET search_path = pg_catalog
+    AS $$
+    SELECT sha256(convert_to(jsonb_build_array(
+        encode(p_prev_hash, 'hex'),
+        p_chain_seq,
+        p_id,
+        to_char(p_recorded_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'),
+        to_char(p_stored_at   AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'),
+        p_action,
+        p_outcome,
+        p_event_code,
+        p_operation,
+        p_principal,
+        p_patient_id,
+        p_resource_class,
+        p_resource_id,
+        p_client_ip,
+        p_token_id,
+        p_tenant_id,
+        p_fhir
+    )::text, 'UTF8'))
+$$;
+
+COMMENT ON FUNCTION audit.audit_event_digest(bytea, bigint, uuid, timestamptz, timestamptz, text, smallint, text, text, text, text, text, text, text, text, uuid, jsonb) IS
+    'SHA-256 over the predecessor link plus one record''s immutable content; the single definition the insert trigger and the verifier both call.';
+
+-- ── seed and backfill ────────────────────────────────────────────────────────
+
+INSERT INTO audit_chain_state (singleton, head_hash)
+VALUES (true, audit.audit_chain_genesis());
+
+-- Records that predate this migration are chained in their stored order. The
+-- loop runs before the triggers exist, so it is the only code that ever writes
+-- these columns without going through the trigger.
+DO $backfill$
+DECLARE
+    record_row audit_event%ROWTYPE;
+    link_hash  bytea  := audit.audit_chain_genesis();
+    next_seq   bigint := 0;
+    this_hash  bytea;
+BEGIN
+    FOR record_row IN SELECT * FROM audit_event ORDER BY stored_at, id LOOP
+        next_seq := next_seq + 1;
+        this_hash := audit.audit_event_digest(
+            link_hash, next_seq, record_row.id, record_row.recorded_at,
+            record_row.stored_at, record_row.action, record_row.outcome,
+            record_row.event_code, record_row.operation, record_row.principal,
+            record_row.patient_id, record_row.resource_class,
+            record_row.resource_id, record_row.client_ip, record_row.token_id,
+            record_row.tenant_id, record_row.fhir);
+        UPDATE audit_event
+           SET chain_seq = next_seq, prev_hash = link_hash, row_hash = this_hash
+         WHERE id = record_row.id;
+        link_hash := this_hash;
+    END LOOP;
+    UPDATE audit_chain_state
+       SET head_seq = next_seq, head_hash = link_hash, updated_at = now()
+     WHERE singleton;
+END
+$backfill$;
+
+ALTER TABLE audit_event
+    ALTER COLUMN chain_seq SET NOT NULL,
+    ALTER COLUMN prev_hash SET NOT NULL,
+    ALTER COLUMN row_hash  SET NOT NULL,
+    ADD CONSTRAINT uq_audit_event_chain_seq UNIQUE (chain_seq);
+
+-- ── the chain writer ─────────────────────────────────────────────────────────
+
+-- The chain is written by three triggers, and the split is a throughput
+-- decision rather than a stylistic one. Advancing the head by UPDATEing the
+-- single state row PER RECORD costs quadratic time inside one transaction: each
+-- update leaves another tuple version on the same page, and every subsequent
+-- read walks the whole chain of them. Measured on PostgreSQL 18 over a 2000
+-- record batch, that one statement was ~60% of the total insert time. So the
+-- head is carried per STATEMENT in a transaction-local setting, and the state
+-- row is read once at the start of a statement and written once at its end.
+--
+-- The setting is a cache, never an input: the BEFORE STATEMENT trigger
+-- OVERWRITES it from the state row every time, so a caller who sets it by hand
+-- has no effect on the chain a subsequent insert builds.
+--
+-- The FOR UPDATE on the state row is what makes the chain a total order:
+-- concurrent inserting transactions serialize on it, and a rolled-back
+-- transaction rolls its head advance back too, so chain_seq is gapless by
+-- construction and a missing number means a deleted record.
+--
+-- SECURITY DEFINER on the two statement triggers so the runtime role can insert
+-- records without holding any write privilege on the chain state (PostgreSQL 18
+-- docs, CREATE FUNCTION §"Writing SECURITY DEFINER Functions Safely":
+-- https://www.postgresql.org/docs/18/sql-createfunction.html).
+CREATE FUNCTION audit.audit_event_chain_begin() RETURNS trigger
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path = audit, pg_catalog
+    AS $$
+DECLARE
+    head_position bigint;
+    head_digest   bytea;
+BEGIN
+    SELECT head_seq, head_hash INTO head_position, head_digest
+      FROM audit.audit_chain_state
+     WHERE singleton
+       FOR UPDATE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'audit chain state is missing: refusing to append an unchained record'
+            USING ERRCODE = 'restrict_violation';
+    END IF;
+    PERFORM set_config('ferroehr.audit_chain_head',
+                       head_position || ':' || encode(head_digest, 'hex'), true);
+    RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER audit_event_chain_begin
+    BEFORE INSERT ON audit_event
+    FOR EACH STATEMENT EXECUTE FUNCTION audit.audit_event_chain_begin();
+
+CREATE FUNCTION audit.audit_event_chain_link() RETURNS trigger
+    LANGUAGE plpgsql
+    SET search_path = audit, pg_catalog
+    AS $$
+DECLARE
+    cursor_value text := current_setting('ferroehr.audit_chain_head', true);
+BEGIN
+    IF cursor_value IS NULL OR cursor_value = '' THEN
+        RAISE EXCEPTION 'the audit chain cursor is unset: refusing to append an unchained record'
+            USING ERRCODE = 'restrict_violation';
+    END IF;
+    NEW.chain_seq := split_part(cursor_value, ':', 1)::bigint + 1;
+    NEW.prev_hash := decode(split_part(cursor_value, ':', 2), 'hex');
+    NEW.row_hash := audit.audit_event_digest(
+        NEW.prev_hash, NEW.chain_seq, NEW.id, NEW.recorded_at, NEW.stored_at,
+        NEW.action, NEW.outcome, NEW.event_code, NEW.operation, NEW.principal,
+        NEW.patient_id, NEW.resource_class, NEW.resource_id, NEW.client_ip,
+        NEW.token_id, NEW.tenant_id, NEW.fhir);
+    PERFORM set_config('ferroehr.audit_chain_head',
+                       NEW.chain_seq || ':' || encode(NEW.row_hash, 'hex'), true);
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER audit_event_chain_link
+    BEFORE INSERT ON audit_event
+    FOR EACH ROW EXECUTE FUNCTION audit.audit_event_chain_link();
+
+CREATE FUNCTION audit.audit_event_chain_commit() RETURNS trigger
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path = audit, pg_catalog
+    AS $$
+DECLARE
+    cursor_value text := current_setting('ferroehr.audit_chain_head', true);
+BEGIN
+    IF cursor_value IS NULL OR cursor_value = '' THEN
+        RETURN NULL;
+    END IF;
+    UPDATE audit.audit_chain_state
+       SET head_seq = split_part(cursor_value, ':', 1)::bigint,
+           head_hash = decode(split_part(cursor_value, ':', 2), 'hex'),
+           updated_at = now()
+     WHERE singleton;
+    RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER audit_event_chain_commit
+    AFTER INSERT ON audit_event
+    FOR EACH STATEMENT EXECUTE FUNCTION audit.audit_event_chain_commit();
+
+-- ── append-only enforcement ──────────────────────────────────────────────────
+
+-- Comparing the whole row minus the two delivery stamps fails CLOSED: a column
+-- added later is immutable unless this exclusion list says otherwise.
+CREATE FUNCTION audit.audit_event_reject_mutation() RETURNS trigger
+    LANGUAGE plpgsql
+    SET search_path = audit, pg_catalog
+    AS $$
+BEGIN
+    IF to_jsonb(NEW) - 'delivered_syslog_at' - 'delivered_fhir_feed_at'
+       IS DISTINCT FROM
+       to_jsonb(OLD) - 'delivered_syslog_at' - 'delivered_fhir_feed_at'
+    THEN
+        RAISE EXCEPTION
+            'audit.audit_event is append-only: only delivered_syslog_at and delivered_fhir_feed_at may change (record %)',
+            OLD.id
+            USING ERRCODE = 'restrict_violation';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER audit_event_reject_mutation
+    BEFORE UPDATE ON audit_event
+    FOR EACH ROW EXECUTE FUNCTION audit.audit_event_reject_mutation();
+
+-- Deletion is legitimate only as retention reaping, which is prefix-only and
+-- records its low-water mark. The transaction-local flag is set exclusively by
+-- audit.reap_audit_events().
+CREATE FUNCTION audit.audit_event_reject_deletion() RETURNS trigger
+    LANGUAGE plpgsql
+    SET search_path = audit, pg_catalog
+    AS $$
+BEGIN
+    IF coalesce(current_setting('ferroehr.audit_reaping', true), 'off') <> 'on' THEN
+        RAISE EXCEPTION
+            'audit.audit_event records are deleted only by audit.reap_audit_events() (record %)',
+            OLD.id
+            USING ERRCODE = 'restrict_violation';
+    END IF;
+    RETURN OLD;
+END;
+$$;
+
+CREATE TRIGGER audit_event_reject_deletion
+    BEFORE DELETE ON audit_event
+    FOR EACH ROW EXECUTE FUNCTION audit.audit_event_reject_deletion();
+
+-- TRUNCATE bypasses row triggers entirely, so it needs its own statement-level
+-- refusal (PostgreSQL 18 docs, CREATE TRIGGER:
+-- https://www.postgresql.org/docs/18/sql-createtrigger.html).
+CREATE FUNCTION audit.audit_event_reject_truncate() RETURNS trigger
+    LANGUAGE plpgsql
+    SET search_path = audit, pg_catalog
+    AS $$
+BEGIN
+    RAISE EXCEPTION 'audit.audit_event cannot be truncated: it is the tamper-evident audit trail'
+        USING ERRCODE = 'restrict_violation';
+END;
+$$;
+
+CREATE TRIGGER audit_event_reject_truncate
+    BEFORE TRUNCATE ON audit_event
+    FOR EACH STATEMENT EXECUTE FUNCTION audit.audit_event_reject_truncate();
+
+-- ── retention reaping ────────────────────────────────────────────────────────
+
+-- Deletes exactly the records older than the horizon — the retention rule is
+-- unchanged — and records every removed span as a tombstone so the resulting
+-- gaps stay accounted for. Adjacent spans are collapsed, so ordinary
+-- oldest-first reaping converges on a single tombstone. Returns the number of
+-- records removed.
+CREATE FUNCTION audit.reap_audit_events(p_retention_days integer) RETURNS bigint
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path = audit, pg_catalog
+    AS $$
+DECLARE
+    cutoff  timestamptz;
+    removed bigint;
+    left_from  bigint;
+    right_from bigint;
+BEGIN
+    IF p_retention_days IS NULL OR p_retention_days <= 0 THEN
+        RETURN 0;
+    END IF;
+    cutoff := now() - make_interval(days => p_retention_days);
+
+    -- Serialize against the chain writer: a record must not be appended while
+    -- the tombstones for this reap are being computed.
+    PERFORM 1 FROM audit.audit_chain_state WHERE singleton FOR UPDATE;
+
+    PERFORM set_config('ferroehr.audit_reaping', 'on', true);
+    -- The island-numbering trick (position minus its ordinal is constant across
+    -- a run of consecutive positions) turns the removed positions into spans.
+    WITH gone AS (
+        DELETE FROM audit.audit_event WHERE recorded_at < cutoff
+        RETURNING chain_seq, row_hash
+    ),
+    islanded AS (
+        SELECT chain_seq, row_hash,
+               chain_seq - row_number() OVER (ORDER BY chain_seq) AS island
+          FROM gone
+    ),
+    spans AS (
+        SELECT min(chain_seq) AS from_seq, max(chain_seq) AS to_seq,
+               (array_agg(row_hash ORDER BY chain_seq DESC))[1] AS link_hash
+          FROM islanded GROUP BY island
+    ),
+    recorded AS (
+        INSERT INTO audit.audit_chain_gap (from_seq, to_seq, link_hash)
+        SELECT from_seq, to_seq, link_hash FROM spans
+        RETURNING 1
+    )
+    SELECT count(*) INTO removed FROM gone;
+    PERFORM set_config('ferroehr.audit_reaping', 'off', true);
+
+    -- Collapse abutting tombstones so a repeatedly-reaped repository keeps one.
+    LOOP
+        SELECT g1.from_seq, g2.from_seq INTO left_from, right_from
+          FROM audit.audit_chain_gap g1
+          JOIN audit.audit_chain_gap g2 ON g2.from_seq = g1.to_seq + 1
+         LIMIT 1;
+        EXIT WHEN left_from IS NULL;
+        UPDATE audit.audit_chain_gap merged
+           SET to_seq = absorbed.to_seq, link_hash = absorbed.link_hash
+          FROM audit.audit_chain_gap absorbed
+         WHERE merged.from_seq = left_from AND absorbed.from_seq = right_from;
+        DELETE FROM audit.audit_chain_gap WHERE from_seq = right_from;
+    END LOOP;
+
+    RETURN coalesce(removed, 0);
+END;
+$$;
+
+COMMENT ON FUNCTION audit.reap_audit_events(integer) IS
+    'Retention reaping: removes records past the horizon and tombstones the chain positions they occupied — the only sanctioned deletion path.';
+
+-- ── verification ─────────────────────────────────────────────────────────────
+
+-- The operator-runnable check. Empty result = the repository is intact; every
+-- returned row names one record (or one boundary) and what is wrong with it.
+-- Runnable straight from psql: SELECT * FROM audit.verify_audit_chain();
+CREATE FUNCTION audit.verify_audit_chain()
+    RETURNS TABLE (chain_seq bigint, record_id uuid, recorded_at timestamptz, finding text)
+    LANGUAGE plpgsql STABLE
+    SET search_path = audit, pg_catalog
+    AS $$
+DECLARE
+    head_position bigint;
+    head_digest   bytea;
+    highest       bigint;
+    highest_row   bytea;
+BEGIN
+    SELECT s.head_seq, s.head_hash INTO head_position, head_digest
+      FROM audit.audit_chain_state s WHERE s.singleton;
+    IF NOT FOUND THEN
+        RETURN QUERY SELECT NULL::bigint, NULL::uuid, NULL::timestamptz,
+            'the audit chain state row is missing: the chain cannot be verified'::text;
+        RETURN;
+    END IF;
+
+    -- Every surviving record, against its own digest and against whatever
+    -- precedes it: the record before it, a recorded reaping tombstone, or (at
+    -- position 1) the genesis digest. A gap with no tombstone is a deletion
+    -- nobody recorded.
+    RETURN QUERY
+    WITH linked AS (
+        SELECT e.chain_seq, e.id, e.recorded_at, e.prev_hash, e.row_hash,
+               lag(e.row_hash)  OVER (ORDER BY e.chain_seq) AS before_hash,
+               coalesce(lag(e.chain_seq) OVER (ORDER BY e.chain_seq), 0) AS before_seq,
+               audit.audit_event_digest(
+                   e.prev_hash, e.chain_seq, e.id, e.recorded_at, e.stored_at,
+                   e.action, e.outcome, e.event_code, e.operation, e.principal,
+                   e.patient_id, e.resource_class, e.resource_id, e.client_ip,
+                   e.token_id, e.tenant_id, e.fhir) AS recomputed
+          FROM audit.audit_event e
+    ),
+    judged AS (
+        SELECT l.*,
+               l.row_hash IS DISTINCT FROM l.recomputed AS modified,
+               l.chain_seq = l.before_seq + 1 AS adjacent,
+               EXISTS (
+                   SELECT 1 FROM audit.audit_chain_gap g
+                    WHERE g.from_seq = l.before_seq + 1
+                      AND g.to_seq = l.chain_seq - 1
+                      AND g.link_hash = l.prev_hash
+               ) AS gap_accounted
+          FROM linked l
+    )
+    SELECT j.chain_seq, j.id, j.recorded_at,
+           CASE
+             WHEN j.modified
+               THEN 'record content was modified after it was written'
+             WHEN NOT j.adjacent
+               THEN 'record(s) deleted between chain position ' || j.before_seq
+                    || ' and this one, with no retention record for the removal'
+             ELSE 'the link to the preceding record does not match'
+           END::text
+      FROM judged j
+     WHERE j.modified
+        OR (NOT j.adjacent AND NOT j.gap_accounted)
+        OR (j.adjacent AND j.prev_hash IS DISTINCT FROM
+              coalesce(j.before_hash, audit.audit_chain_genesis()));
+
+    -- The end of the chain has no successor to notice a deletion, so it is
+    -- checked against the recorded head: either the newest surviving record IS
+    -- the head, or a tombstone accounts for everything between them.
+    SELECT e.chain_seq, e.row_hash INTO highest, highest_row
+      FROM audit.audit_event e ORDER BY e.chain_seq DESC LIMIT 1;
+    highest := coalesce(highest, 0);
+
+    IF highest = head_position THEN
+        IF highest > 0 AND highest_row IS DISTINCT FROM head_digest THEN
+            RETURN QUERY SELECT highest, NULL::uuid, NULL::timestamptz,
+                'the newest record does not match the recorded chain head'::text;
+        END IF;
+    ELSIF NOT EXISTS (
+        SELECT 1 FROM audit.audit_chain_gap g
+         WHERE g.from_seq = highest + 1 AND g.to_seq = head_position
+           AND g.link_hash = head_digest
+    ) THEN
+        RETURN QUERY SELECT highest, NULL::uuid, NULL::timestamptz,
+            'record(s) deleted from the end of the chain, with no retention record for the removal'::text;
+    END IF;
+END;
+$$;
+
+COMMENT ON FUNCTION audit.verify_audit_chain() IS
+    'Tamper check over the whole repository: returns one row per damaged record or boundary, and nothing at all when the trail is intact.';
+
+-- ── least-privilege grants ───────────────────────────────────────────────────
+
+-- The `audit` schema had no grants at all, so the layered role architecture
+-- (created by the ehr/ext baselines) could not reach it: only the owner could
+-- write audit records. These grants give the runtime role exactly what the
+-- server does — insert a record, stamp it delivered, read it back for ITI-81 —
+-- and nothing that can rewrite or remove one.
+DO $grants$
+BEGIN
+    IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'ferroehr_app') THEN
+        GRANT USAGE ON SCHEMA audit TO ferroehr_app, ferroehr_reader;
+
+        -- Revoke first: a table-level REVOKE also removes column-level grants,
+        -- so the column grant below has to come after it (PostgreSQL 18 docs,
+        -- REVOKE: https://www.postgresql.org/docs/18/sql-revoke.html).
+        REVOKE ALL ON audit_event FROM ferroehr_app, ferroehr_reader;
+        GRANT SELECT, INSERT ON audit_event TO ferroehr_app;
+        GRANT UPDATE (delivered_syslog_at, delivered_fhir_feed_at)
+            ON audit_event TO ferroehr_app;
+        GRANT SELECT ON audit_event TO ferroehr_reader;
+
+        REVOKE ALL ON audit_chain_state, audit_chain_gap
+            FROM ferroehr_app, ferroehr_reader;
+        GRANT SELECT ON audit_chain_state, audit_chain_gap
+            TO ferroehr_app, ferroehr_reader;
+
+        REVOKE ALL ON FUNCTION audit.reap_audit_events(integer) FROM PUBLIC;
+        GRANT EXECUTE ON FUNCTION audit.reap_audit_events(integer) TO ferroehr_app;
+        GRANT EXECUTE ON FUNCTION audit.verify_audit_chain()
+            TO ferroehr_app, ferroehr_reader;
+
+        ALTER DEFAULT PRIVILEGES IN SCHEMA audit
+            GRANT SELECT, INSERT ON TABLES TO ferroehr_app;
+        ALTER DEFAULT PRIVILEGES IN SCHEMA audit
+            GRANT SELECT ON TABLES TO ferroehr_reader;
+    ELSE
+        RAISE NOTICE 'skipping audit grants (roles absent — see the ehr baseline role block NOTICE)';
+    END IF;
+END
+$grants$;

--- a/app/ferroehr/src/config/mod.rs
+++ b/app/ferroehr/src/config/mod.rs
@@ -971,6 +971,127 @@ mod tests {
         }
     }
 
+    /// Whether the template declares `key` as a key line — live (`key = …`) or
+    /// as a `#?` reference line for an optional/secret/derived one. A mention
+    /// inside another key's trailing comment does NOT count: that is exactly how
+    /// `auth.oidc.hmac_secret_file` and `jwks_json_file` stayed undiscoverable
+    /// (#2154), invisible to `ferroehr config default`.
+    fn template_declares(key: &str) -> bool {
+        DEFAULT_TEMPLATE.lines().any(|line| {
+            let line = line.trim_start();
+            let line = line.strip_prefix("#?").map_or(line, str::trim_start);
+            line.strip_prefix(key)
+                .is_some_and(|rest| rest.trim_start().starts_with('='))
+        })
+    }
+
+    /// Every field the default config SERIALIZES must be a key in the template.
+    ///
+    /// Total for concrete fields and needs no hand-maintained list: it walks the
+    /// serialized default, so a newly added field is covered the moment it
+    /// exists. `Option::None` fields serialize away and are covered by
+    /// [`template_declares_every_optional_oidc_field`] instead.
+    #[test]
+    fn template_declares_every_serialized_field() {
+        fn walk(value: &serde_json::Value, missing: &mut Vec<String>) {
+            let serde_json::Value::Object(map) = value else {
+                return;
+            };
+            for (key, child) in map {
+                match child {
+                    serde_json::Value::Object(_) => walk(child, missing),
+                    // An absent optional serializes to null, so this walk cannot
+                    // see it at all — that class is the other test's job. An
+                    // absent optional SUB-TABLE lands here too and is declared
+                    // as a `[section]` header rather than a key line.
+                    serde_json::Value::Null => {}
+                    _ if template_declares(key) => {}
+                    _ if DEFAULT_TEMPLATE.contains(&format!(".{key}]")) => {}
+                    _ => missing.push(key.clone()),
+                }
+            }
+        }
+        let mut missing = Vec::new();
+        walk(&json(&FerroEhrConfig::default()), &mut missing);
+        assert!(
+            missing.is_empty(),
+            "the shipped ferroehr.toml template declares no key line for: {}. \
+             Every field belongs in it — the file's own header calls itself the \
+             complete configuration, and `ferroehr config default` is how an \
+             operator discovers a key.",
+            missing.join(", ")
+        );
+    }
+
+    /// The field names a `deny_unknown_fields` struct accepts, taken from serde
+    /// itself: an unknown key is refused with `expected one of …`, which is the
+    /// authoritative set and needs no hand-maintained list.
+    fn accepted_fields<T: serde::de::DeserializeOwned>(section: &str) -> Vec<String> {
+        let Err(err) = toml::from_str::<T>("__probe_unknown_key__ = 1") else {
+            panic!("[{section}] must carry deny_unknown_fields")
+        };
+        let err = err.to_string();
+        let Some((_, list)) = err.split_once("expected one of ") else {
+            panic!("serde no longer reports an accepted-field list for [{section}]: {err}")
+        };
+        let fields: Vec<String> = list
+            .split([',', '`'])
+            .map(|s| s.trim().to_owned())
+            .filter(|s| !s.is_empty())
+            .collect();
+        // Without this the test passes vacuously if serde ever reformats that
+        // message — a guard that silently checks nothing is worse than none.
+        assert!(
+            !fields.is_empty(),
+            "extracted no fields for [{section}]; serde's message format changed \
+             and this test is no longer checking anything: {err}"
+        );
+        fields
+    }
+
+    /// Optional fields serialize away when `None`, so the walk above cannot see
+    /// them — and that is the class that shipped undeclared (#2154:
+    /// `auth.oidc.hmac_secret_file` and `jwks_json_file` existed only inside
+    /// another key's trailing comment).
+    ///
+    /// Covered here are the sections carrying secret or file-indirection keys,
+    /// where an undiscoverable key costs an operator most. Adding another
+    /// section is one line, because the field list comes from serde.
+    #[test]
+    fn template_declares_every_optional_field_of_the_secret_bearing_sections() {
+        let sections = [
+            (
+                "auth.oidc",
+                accepted_fields::<auth::OidcConfig>("auth.oidc"),
+            ),
+            ("db", accepted_fields::<crate::db::DbConfig>("db")),
+            (
+                "signing",
+                accepted_fields::<crate::versioning::signature::config::SigningConfig>("signing"),
+            ),
+            (
+                "multimedia",
+                accepted_fields::<crate::extensions::multimedia::config::MultimediaConfig>(
+                    "multimedia",
+                ),
+            ),
+        ];
+        let missing: Vec<String> = sections
+            .iter()
+            .flat_map(|(section, fields)| {
+                fields
+                    .iter()
+                    .filter(|f| !template_declares(f))
+                    .map(move |f| format!("{section}.{f}"))
+            })
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "the template declares no key line for: {}",
+            missing.join(", ")
+        );
+    }
+
     // ── 7. Semantic validation ────────────────────────────────────────────────
 
     #[test]

--- a/app/ferroehr/src/db/mod.rs
+++ b/app/ferroehr/src/db/mod.rs
@@ -36,6 +36,28 @@ use crate::config::secret::SecretUrl;
 /// [`DbConfig::is_dev_default`] holds.
 pub const DEFAULT_URL: &str = "postgres://ferroehr:ferroehr@localhost:5432/ferroehr";
 
+/// What the server does about schema migrations when it boots.
+///
+/// Migrations are DDL, so a self-migrating server must authenticate as a role
+/// that can execute DDL — and a role that can rewrite the schema is a role an
+/// application-level SQL flaw can rewrite the schema with. This setting is how
+/// a deployment opts out of that: the schema is applied out of band by the
+/// migrator role, and the server connects as the DML-only `ferroehr_app` role.
+///
+/// No openEHR spec governs migration mechanics or database roles — our own
+/// design/extension.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MigrationMode {
+    /// Apply the embedded migrations at boot, then verify (the default, and
+    /// what makes an empty configuration boot against an empty database).
+    #[default]
+    Apply,
+    /// Never issue DDL: verify that the database already carries exactly this
+    /// build's migrations, and refuse to serve when it does not.
+    Verify,
+}
+
 /// Connection settings for the application `PostgreSQL` database — the `[db]`
 /// section of the one config tree ([`crate::config::FerroEhrConfig`]), with no
 /// loader of its own.
@@ -80,6 +102,15 @@ pub struct DbConfig {
     /// engine's typed refusal fires first and this only catches what the engine
     /// does not govern. No openEHR spec governs it — our own design.
     pub statement_timeout_ms: u64,
+    /// Whether the server applies its embedded migrations at boot
+    /// ([`MigrationMode`]).
+    ///
+    /// `apply` (the default) keeps a fresh checkout and a fresh database
+    /// working with no configuration at all. `verify` is the least-privilege
+    /// production posture: the DSN may then authenticate as a role with no DDL
+    /// rights, and the server refuses to boot against a database that is not
+    /// already migrated to exactly this build.
+    pub migrate: MigrationMode,
 }
 
 impl Default for DbConfig {
@@ -95,6 +126,7 @@ impl Default for DbConfig {
             // Twice the engine's own 30 s budget, so the engine refuses first
             // and this remains a backstop rather than the primary control.
             statement_timeout_ms: 60_000,
+            migrate: MigrationMode::Apply,
         }
     }
 }
@@ -133,6 +165,15 @@ pub enum DbError {
     #[error("migration: {0}")]
     Migrate(#[from] sqlx::migrate::MigrateError),
 
+    /// The database does not carry exactly this build's migrations, and
+    /// [`MigrationMode::Verify`] forbids applying them.
+    #[error(
+        "the database is not migrated to this build ({0}). \
+         [db].migrate is `verify`, so this server will not issue DDL: apply the \
+         migrations out of band with the migrator role, then start it again"
+    )]
+    SchemaNotReady(#[source] SchemaMismatch),
+
     /// The cold archival tier outlived the primary tier it mirrors.
     #[error(
         "the cold archival tier (schema `cold`) is present but the primary tier \
@@ -145,6 +186,63 @@ pub enum DbError {
          wipe was intended, `DROP SCHEMA cold CASCADE` and start again"
     )]
     OrphanedArchiveTier,
+}
+
+/// How a database's recorded migration state differs from the one this binary
+/// embeds.
+///
+/// Each variant names a distinct operational situation, so a caller can branch
+/// on it rather than match a message: an unmigrated database, a database behind
+/// the binary, a database ahead of it, and a database whose bookkeeping is
+/// damaged.
+#[derive(Debug, thiserror::Error)]
+pub enum SchemaMismatch {
+    /// The schema carries no `_sqlx_migrations` table at all.
+    #[error("schema `{schema}` has never been migrated")]
+    NeverMigrated {
+        /// The `PostgreSQL` schema that carries the migration set.
+        schema: String,
+    },
+
+    /// Migrations this binary embeds are absent from the database.
+    #[error(
+        "schema `{schema}` is missing migration(s) {versions:?} — the database is older than this build"
+    )]
+    Missing {
+        /// The `PostgreSQL` schema that carries the migration set.
+        schema: String,
+        /// The absent migration versions, ascending.
+        versions: Vec<i64>,
+    },
+
+    /// A migration is recorded as having failed partway through.
+    #[error("schema `{schema}` records migration {version} as failed")]
+    Failed {
+        /// The `PostgreSQL` schema that carries the migration set.
+        schema: String,
+        /// The failed migration's version.
+        version: i64,
+    },
+
+    /// A migration was applied from source text this binary does not carry.
+    #[error("schema `{schema}` applied migration {version} from different source text")]
+    ChecksumMismatch {
+        /// The `PostgreSQL` schema that carries the migration set.
+        schema: String,
+        /// The diverging migration's version.
+        version: i64,
+    },
+
+    /// The database carries migrations this binary does not know about.
+    #[error(
+        "schema `{schema}` carries migration(s) {versions:?} — the database is newer than this build"
+    )]
+    Ahead {
+        /// The `PostgreSQL` schema that carries the migration set.
+        schema: String,
+        /// The unknown migration versions, ascending.
+        versions: Vec<i64>,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -312,6 +410,14 @@ static EHR_MIGRATOR: Migrator = sqlx::migrate!("migrations/ehr");
 /// access logs, never part of the EHR proper); runs after `ehr`.
 static AUDIT_MIGRATOR: Migrator = sqlx::migrate!("migrations/audit");
 
+/// The three migration sets in application order, each paired with the schema
+/// that carries its `_sqlx_migrations` bookkeeping table.
+const MIGRATION_SETS: &[(&str, &Migrator)] = &[
+    ("ext", &EXT_MIGRATOR),
+    ("ehr", &EHR_MIGRATOR),
+    ("audit", &AUDIT_MIGRATOR),
+];
+
 /// Bootstrap done outside the migrations: the three schemas and `btree_gist`
 /// (required by the temporal `WITHOUT OVERLAPS` primary key).
 const BOOTSTRAP: &[&str] = &[
@@ -346,7 +452,7 @@ pub fn migration_fingerprint() -> String {
     for statement in BOOTSTRAP {
         eat(statement.as_bytes());
     }
-    for migrator in [&EXT_MIGRATOR, &EHR_MIGRATOR, &AUDIT_MIGRATOR] {
+    for (_, migrator) in MIGRATION_SETS {
         for migration in migrator.iter() {
             eat(&migration.version.to_le_bytes());
             eat(&migration.checksum);
@@ -385,6 +491,113 @@ pub async fn run_migrations(pool: &PgPool) -> Result<(), DbError> {
         tracing::debug!(%error, "closing the migration connection failed");
     }
     outcome
+}
+
+/// Brings the database to the state this build requires, as
+/// [`DbConfig::migrate`] directs.
+///
+/// [`MigrationMode::Apply`] runs [`run_migrations`]; [`MigrationMode::Verify`]
+/// issues no DDL and only checks, so the DSN may authenticate as a role that
+/// holds no DDL rights at all. This is the boot-path entry point — call it
+/// instead of [`run_migrations`] anywhere the operator's configuration should
+/// decide.
+///
+/// # Errors
+///
+/// In `apply` mode, whatever [`run_migrations`] returns. In `verify` mode,
+/// [`DbError::SchemaNotReady`] when the database does not carry exactly this
+/// build's migrations, or [`DbError::Sqlx`] when the check itself cannot run.
+pub async fn prepare(settings: &DbConfig, pool: &PgPool) -> Result<(), DbError> {
+    match settings.migrate {
+        MigrationMode::Apply => run_migrations(pool).await,
+        MigrationMode::Verify => {
+            tracing::info!(
+                "[db].migrate is `verify`: this server issues no DDL and requires an \
+                 already-migrated database"
+            );
+            verify_migrations(pool).await
+        }
+    }
+}
+
+/// Verifies, without issuing any DDL, that the database carries exactly the
+/// migrations this binary embeds.
+///
+/// Read-only by construction: it reads each set's `_sqlx_migrations`
+/// bookkeeping table and compares versions, success flags and checksums
+/// against the embedded sources. That makes it usable both as the boot gate for
+/// [`MigrationMode::Verify`] and as an operator check against a running
+/// database.
+///
+/// # Errors
+///
+/// [`DbError::SchemaNotReady`] naming the first divergence found, or
+/// [`DbError::Sqlx`] when a connection or the bookkeeping read fails.
+pub async fn verify_migrations(pool: &PgPool) -> Result<(), DbError> {
+    for (schema, migrator) in MIGRATION_SETS {
+        verify_set(pool, schema, migrator).await?;
+    }
+    Ok(())
+}
+
+/// Compare one migration set's bookkeeping table against its embedded source.
+async fn verify_set(pool: &PgPool, schema: &str, migrator: &Migrator) -> Result<(), DbError> {
+    // The schema name is one of the three literals in `MIGRATION_SETS`, never
+    // input: `to_regclass` answers NULL for a missing relation rather than
+    // failing (PostgreSQL 18 docs, "System Information Functions").
+    let bookkeeping = format!("{schema}._sqlx_migrations");
+    let present: bool = sqlx::query_scalar("SELECT to_regclass($1) IS NOT NULL")
+        .bind(&bookkeeping)
+        .fetch_one(pool)
+        .await?;
+    if !present {
+        return Err(DbError::SchemaNotReady(SchemaMismatch::NeverMigrated {
+            schema: schema.to_owned(),
+        }));
+    }
+
+    let query = format!("SELECT version, success, checksum FROM {bookkeeping} ORDER BY version");
+    let applied: Vec<(i64, bool, Vec<u8>)> = sqlx::query_as(sqlx::AssertSqlSafe(query))
+        .fetch_all(pool)
+        .await?;
+
+    let mut unknown: Vec<i64> = applied.iter().map(|(version, _, _)| *version).collect();
+    let mut missing: Vec<i64> = Vec::new();
+    for embedded in migrator.iter() {
+        let Some((version, success, checksum)) = applied
+            .iter()
+            .find(|(version, _, _)| *version == embedded.version)
+        else {
+            missing.push(embedded.version);
+            continue;
+        };
+        unknown.retain(|known| known != version);
+        if !success {
+            return Err(DbError::SchemaNotReady(SchemaMismatch::Failed {
+                schema: schema.to_owned(),
+                version: *version,
+            }));
+        }
+        if checksum.as_slice() != embedded.checksum.as_ref() {
+            return Err(DbError::SchemaNotReady(SchemaMismatch::ChecksumMismatch {
+                schema: schema.to_owned(),
+                version: *version,
+            }));
+        }
+    }
+    if !missing.is_empty() {
+        return Err(DbError::SchemaNotReady(SchemaMismatch::Missing {
+            schema: schema.to_owned(),
+            versions: missing,
+        }));
+    }
+    if !unknown.is_empty() {
+        return Err(DbError::SchemaNotReady(SchemaMismatch::Ahead {
+            schema: schema.to_owned(),
+            versions: unknown,
+        }));
+    }
+    Ok(())
 }
 
 /// The bootstrap + two-migrator sequence on one dedicated connection.

--- a/app/ferroehr/src/system_log/store.rs
+++ b/app/ferroehr/src/system_log/store.rs
@@ -223,20 +223,62 @@ impl AuditStore {
     /// Delete records older than `retention_days` (0 = keep forever).
     /// Returns the number of reaped rows.
     ///
+    /// Reaping goes through `audit.reap_audit_events`, the only deletion path
+    /// the table permits: it removes a PREFIX of the hash chain and advances
+    /// the retention low-water mark in the same transaction, so the surviving
+    /// records still verify and an unrecorded deletion of the oldest records
+    /// remains detectable. A direct `DELETE` is refused by the table's trigger.
+    ///
     /// # Errors
-    /// [`AuditError::Store`] when the DELETE fails.
+    /// [`AuditError::Store`] when the reap fails.
     pub async fn reap(&self, retention_days: u32) -> Result<u64, AuditError> {
         if retention_days == 0 {
             return Ok(0);
         }
-        let result = sqlx::query(
-            "DELETE FROM audit.audit_event \
-             WHERE recorded_at < now() - make_interval(days => $1)",
+        let removed: i64 = sqlx::query_scalar("SELECT audit.reap_audit_events($1)")
+            .bind(i32::try_from(retention_days).unwrap_or(i32::MAX))
+            .fetch_one(&self.pool)
+            .await?;
+        Ok(u64::try_from(removed).unwrap_or(0))
+    }
+
+    /// Check the repository's tamper evidence: recompute every record's digest,
+    /// re-walk every link in the hash chain, and check both ends against the
+    /// recorded chain state.
+    ///
+    /// An empty result means the trail is intact. Any returned
+    /// [`AuditChainFinding`] names one damaged record (or one damaged chain
+    /// boundary) and what is wrong with it — this is the report an operator
+    /// acts on, and the same answer `SELECT * FROM audit.verify_audit_chain()`
+    /// gives from `psql`.
+    ///
+    /// NOTE: no openEHR spec governs audit tamper detection — our own
+    /// design/extension; the chain is unkeyed, so it detects modification and
+    /// deletion but cannot prevent a party with unrestricted write access from
+    /// recomputing the chain wholesale.
+    ///
+    /// # Errors
+    /// [`AuditError::Store`] when the verification query cannot run — which is
+    /// itself a finding, never a pass.
+    pub async fn verify_chain(&self) -> Result<Vec<AuditChainFinding>, AuditError> {
+        let rows = sqlx::query(
+            "SELECT chain_seq, record_id, recorded_at, finding \
+             FROM audit.verify_audit_chain() ORDER BY chain_seq NULLS FIRST",
         )
-        .bind(i32::try_from(retention_days).unwrap_or(i32::MAX))
-        .execute(&self.pool)
+        .fetch_all(&self.pool)
         .await?;
-        Ok(result.rows_affected())
+        rows.into_iter()
+            .map(|row| {
+                Ok(AuditChainFinding {
+                    chain_seq: row.try_get("chain_seq")?,
+                    record_id: row.try_get("record_id")?,
+                    recorded_at: row
+                        .try_get::<Option<Timestamp>, _>("recorded_at")?
+                        .map(Timestamp::to_jiff),
+                    finding: row.try_get("finding")?,
+                })
+            })
+            .collect()
     }
 
     /// The RESTful-ATNA ITI-81 retrieval: filtered, newest-first stored FHIR
@@ -354,6 +396,22 @@ fn build_search_statements(
         .build_sqlx(PostgresQueryBuilder);
 
     (count_sql, count_values, sql, values)
+}
+
+/// One damaged record — or one damaged chain boundary — reported by
+/// [`AuditStore::verify_chain`].
+#[derive(Debug, Clone)]
+pub struct AuditChainFinding {
+    /// The chain position the finding is about; `None` when the chain state
+    /// row itself is missing.
+    pub chain_seq: Option<i64>,
+    /// The damaged record's id, when the finding is about a record that is
+    /// still present rather than about a gap or a boundary.
+    pub record_id: Option<Uuid>,
+    /// The damaged record's event time, when known.
+    pub recorded_at: Option<jiff::Timestamp>,
+    /// What is wrong, in the operator's words.
+    pub finding: String,
 }
 
 /// The supported ITI-81 search-parameter subset, resolved by the REST layer.

--- a/app/ferroehr/src/versioning/signature/config.rs
+++ b/app/ferroehr/src/versioning/signature/config.rs
@@ -74,6 +74,15 @@ pub struct SigningConfig {
     /// File-based indirection for [`Self::key_passphrase`] (K8s/Docker secrets).
     /// Exactly one of the pair may be set; the loader reads and trims the file.
     pub key_passphrase_file: Option<PathBuf>,
+    /// Armored RFC 4880 **public** keys retired from signing but retained for
+    /// verification, so versions signed before a key rotation keep verifying.
+    ///
+    /// A stored `VERSION.signature` records no key identifier, and a signature
+    /// is an immutable committed fact (RM common `master06` §Digital Signature)
+    /// that cannot be re-issued — so keeping the retired key is the only way
+    /// history stays verifiable across a rotation. These are public keys: a
+    /// retired key can verify and can never sign again.
+    pub retired_key_paths: Vec<PathBuf>,
     /// Read-time verification policy: `off` | `warn` | `strict`. **Unset**
     /// (the default) resolves via [`Self::effective_verify_on_read`] to `strict`
     /// when signing is enabled — the explicit "sign but never check" state is
@@ -89,6 +98,7 @@ impl Default for SigningConfig {
             key_path: None,
             key_passphrase: None,
             key_passphrase_file: None,
+            retired_key_paths: Vec::new(),
             verify_on_read: None,
         }
     }
@@ -173,16 +183,15 @@ mod tests {
     /// freed memory. A runtime test cannot observe that; the compiler can.
     #[test]
     fn the_key_loader_takes_the_secret_wrapper_not_a_str() {
-        fn assert_signature(
-            _f: fn(
-                &std::path::Path,
-                Option<&Secret>,
-            ) -> Result<
-                crate::versioning::signature::key::PgpKey,
-                crate::versioning::signature::key::KeyError,
-            >,
-        ) {
-        }
+        type KeyLoader = fn(
+            &std::path::Path,
+            Option<&Secret>,
+            &[PathBuf],
+        ) -> Result<
+            crate::versioning::signature::key::PgpKey,
+            crate::versioning::signature::key::KeyError,
+        >;
+        fn assert_signature(_f: KeyLoader) {}
         assert_signature(crate::versioning::signature::key::PgpKey::load);
     }
 }

--- a/app/ferroehr/src/versioning/signature/key.rs
+++ b/app/ferroehr/src/versioning/signature/key.rs
@@ -62,7 +62,20 @@ pub(crate) enum PgpVerdict {
 /// public key) plus the passphrase that unlocks it. Never logged/serialised.
 pub struct PgpKey {
     secret: SignedSecretKey,
+    /// Index into `secret.secret_subkeys` of the signing-capable subkey, when
+    /// the certificate carries one.
+    ///
+    /// Signing with a subkey is what makes rotation cheap: the operator issues
+    /// a new signing subkey, the certificate retains the old one, and history
+    /// keeps verifying against the same configured key with no retired-keyring
+    /// entry. An index rather than a clone because the subkey is not `Clone`,
+    /// and it stays valid for the lifetime of the owned certificate.
+    signing_subkey: Option<usize>,
     public: SignedPublicKey,
+    /// Certificates retired from signing and retained for verification only, so
+    /// versions signed before a rotation keep verifying. Public keys by
+    /// construction: a retired certificate can never sign again.
+    retired: Vec<SignedPublicKey>,
     password: Password,
 }
 
@@ -82,12 +95,24 @@ impl PgpKey {
     pub fn load(
         path: &Path,
         passphrase: Option<&crate::config::secret::Secret>,
+        retired_paths: &[std::path::PathBuf],
     ) -> Result<Self, KeyError> {
         let armored = std::fs::read_to_string(path).map_err(|source| KeyError::Read {
             path: path.display().to_string(),
             source,
         })?;
-        Self::from_armored(&armored, passphrase)
+        let mut retired = Vec::with_capacity(retired_paths.len());
+        for retired_path in retired_paths {
+            let armored =
+                std::fs::read_to_string(retired_path).map_err(|source| KeyError::Read {
+                    path: retired_path.display().to_string(),
+                    source,
+                })?;
+            let (certificate, _headers) =
+                SignedPublicKey::from_string(&armored).map_err(KeyError::Parse)?;
+            retired.push(certificate);
+        }
+        Self::from_parts(&armored, passphrase, retired)
     }
 
     /// Load an armored RFC 4880 secret key from an in-memory string (used by
@@ -99,6 +124,19 @@ impl PgpKey {
     pub fn from_armored(
         armored: &str,
         passphrase: Option<&crate::config::secret::Secret>,
+    ) -> Result<Self, KeyError> {
+        Self::from_parts(armored, passphrase, Vec::new())
+    }
+
+    /// [`Self::from_armored`] plus the verify-only certificates retired from
+    /// signing.
+    ///
+    /// # Errors
+    /// As [`Self::from_armored`].
+    pub fn from_parts(
+        armored: &str,
+        passphrase: Option<&crate::config::secret::Secret>,
+        retired: Vec<SignedPublicKey>,
     ) -> Result<Self, KeyError> {
         let (secret, _headers) = SignedSecretKey::from_string(armored).map_err(KeyError::Parse)?;
         let public = secret.to_public_key();
@@ -112,9 +150,19 @@ impl PgpKey {
             Some(secret) => Password::from(secret.expose()),
             None => Password::empty(),
         };
+        // RFC 9580 §5.2.3.29 key flag 0x02 ("this key may be used to sign
+        // data"): the subkey is chosen by CAPABILITY, never by position — an
+        // encryption subkey signing would be a key-usage violation a strict
+        // verifier should reject.
+        let signing_subkey = secret
+            .secret_subkeys
+            .iter()
+            .position(|subkey| subkey.signatures.iter().any(|sig| sig.key_flags().sign()));
         let key = Self {
             secret,
+            signing_subkey,
             public,
+            retired,
             password,
         };
         // Fail-closed: a real signature proves the passphrase unlocks the key
@@ -128,13 +176,23 @@ impl PgpKey {
     /// # Errors
     /// [`PgpSignError`] if signing or armoring fails.
     pub fn sign(&self, data: &[u8]) -> Result<String, PgpSignError> {
-        let sig = DetachedSignature::sign_binary_data(
-            OsRng,
-            &self.secret.primary_key,
-            &self.password,
-            HASH,
-            data,
-        )
+        // A certificate with no signing subkey signs with the primary key, as
+        // before — an upgrade changes nothing for a single-key deployment.
+        let sig = match self
+            .signing_subkey
+            .and_then(|index| self.secret.secret_subkeys.get(index))
+        {
+            Some(subkey) => {
+                DetachedSignature::sign_binary_data(OsRng, &subkey.key, &self.password, HASH, data)
+            }
+            None => DetachedSignature::sign_binary_data(
+                OsRng,
+                &self.secret.primary_key,
+                &self.password,
+                HASH,
+                data,
+            ),
+        }
         .map_err(PgpSignError)?;
         sig.to_armored_string(ArmorOptions::default())
             .map_err(PgpSignError)
@@ -145,10 +203,34 @@ impl PgpKey {
         let Ok((sig, _headers)) = DetachedSignature::from_string(armored_sig) else {
             return PgpVerdict::Malformed;
         };
-        if sig.verify(&self.public, data).is_ok() {
-            PgpVerdict::Valid
-        } else {
-            PgpVerdict::Invalid
+        for certificate in std::iter::once(&self.public).chain(&self.retired) {
+            if verify_against_certificate(&sig, certificate, data) {
+                return PgpVerdict::Valid;
+            }
         }
+        PgpVerdict::Invalid
     }
+}
+
+/// Verify `sig` against every component of one certificate — the primary key
+/// and each of its subkeys.
+///
+/// The subkeys are not an optimisation: RFC 9580 §10.1 defines a transferable
+/// public key as a primary key plus its subkeys, and rotating the *signing
+/// subkey* is the mechanism `OpenPGP` provides for rotation without discarding
+/// the primary key's accumulated trust. `rpgp`'s `VerifyingKey for
+/// SignedPublicKey` consults the primary key alone, so a signature made by any
+/// subkey would be rejected by a certificate that legitimately contains it.
+fn verify_against_certificate(
+    sig: &DetachedSignature,
+    certificate: &SignedPublicKey,
+    data: &[u8],
+) -> bool {
+    if sig.verify(certificate, data).is_ok() {
+        return true;
+    }
+    certificate
+        .public_subkeys
+        .iter()
+        .any(|subkey| sig.verify(subkey, data).is_ok())
 }

--- a/app/ferroehr/src/versioning/signature/signer.rs
+++ b/app/ferroehr/src/versioning/signature/signer.rs
@@ -110,6 +110,7 @@ impl Signer {
                 SignerMode::Pgp(Box::new(PgpKey::load(
                     path,
                     config.key_passphrase.as_ref(),
+                    &config.retired_key_paths,
                 )?))
             }
         };

--- a/app/ferroehr/tests/it/audit_chain.rs
+++ b/app/ferroehr/tests/it/audit_chain.rs
@@ -1,0 +1,428 @@
+//! Tamper evidence on the local IHE ATNA Audit Record Repository, and the
+//! privilege posture that backs it, against a real `PostgreSQL` 18 (shared
+//! testkit harness).
+//!
+//! No openEHR spec governs audit storage mechanics, database roles or tamper
+//! detection — our own design/extension. The control under test is the OWASP
+//! Logging Cheat Sheet's §Log Integrity ("build in tamper detection so you know
+//! if a record has been modified or deleted"), and these tests assert the
+//! property rather than the mechanism: a record that changes is NAMED by
+//! verification, a record that disappears is NAMED, and the role the server
+//! actually connects as cannot do either — nor run any DDL.
+
+#![expect(
+    clippy::expect_used,
+    reason = "clippy's in-test lint scoping (clippy.toml `allow-*-in-tests`) only \
+              reaches `#[test]`-annotated functions, so it misses this integration \
+              module's helpers and async bodies; panicking assertions are the \
+              intended shape here (the Rust Book ch11)"
+)]
+
+use jiff::Timestamp;
+use sqlx::{AssertSqlSafe, Connection, PgConnection, PgPool, Row};
+use uuid::Uuid;
+
+use ferroehr::db;
+use ferroehr::system_log::event::{
+    AuditEvent, EventActionCode, EventOutcome, EventType, ObjectClass,
+};
+use ferroehr::system_log::fhir;
+use ferroehr::system_log::message::AuditContext;
+use ferroehr::system_log::store::AuditStore;
+
+fn ctx() -> AuditContext {
+    AuditContext {
+        source_id: "ferroehr".to_owned(),
+        enterprise_site_id: "site-1".to_owned(),
+        server_ip: "10.42.23.77".to_owned(),
+        value_if_missing: "UNKNOWN".to_owned(),
+    }
+}
+
+fn read_event(at: Timestamp, subject: &str) -> AuditEvent {
+    let mut event = AuditEvent::new(
+        EventActionCode::Read,
+        ObjectClass::Composition,
+        EventOutcome::Success,
+    );
+    "alice".clone_into(&mut event.user_id);
+    event.client_ip = Some("10.0.0.9".to_owned());
+    event.object_id = Some(subject.to_owned());
+    event.event_type = Some(EventType::RestOperation("composition_get"));
+    event.timestamp = at;
+    event
+}
+
+/// Write `count` records through the real store path, oldest first.
+async fn seed(store: &AuditStore, count: u32) {
+    for n in 0..count {
+        let at = Timestamp::now() - jiff::SignedDuration::from_hours(i64::from(count - n));
+        let event = read_event(at, &format!("8fa1::ferroehr::{n}"));
+        let rendered = fhir::to_fhir(&event, &ctx(), Some("patient-42")).expect("render");
+        store
+            .insert(&event, Some("patient-42"), &rendered)
+            .await
+            .expect("insert");
+    }
+}
+
+/// Run `sql` with the append-only triggers off, which only the table's OWNER
+/// can do — the attacker this mechanism is designed to catch rather than stop.
+async fn with_triggers_disabled(pool: &PgPool, sql: &str) {
+    sqlx::query("ALTER TABLE audit.audit_event DISABLE TRIGGER USER")
+        .execute(pool)
+        .await
+        .expect("disable the append-only triggers");
+    sqlx::query(AssertSqlSafe(sql.to_owned()))
+        .execute(pool)
+        .await
+        .expect("the tampering statement itself must succeed");
+    sqlx::query("ALTER TABLE audit.audit_event ENABLE TRIGGER USER")
+        .execute(pool)
+        .await
+        .expect("re-enable the append-only triggers");
+}
+
+/// A modified record is detected and named, not silently accepted.
+#[tokio::test]
+async fn a_modified_audit_record_is_detected_and_named() {
+    let testdb = testkit::db().await.expect("testkit database");
+    let pool = testdb.pool();
+    let store = AuditStore::new(pool.clone());
+    seed(&store, 4).await;
+
+    assert!(
+        store.verify_chain().await.expect("verify").is_empty(),
+        "a freshly written trail must verify clean"
+    );
+
+    let target: Uuid = sqlx::query_scalar("SELECT id FROM audit.audit_event WHERE chain_seq = 2")
+        .fetch_one(&pool)
+        .await
+        .expect("the second record");
+
+    // Rewrite who accessed the patient — the exact silent edit the issue is
+    // about.
+    with_triggers_disabled(
+        &pool,
+        "UPDATE audit.audit_event SET principal = 'nobody' WHERE chain_seq = 2",
+    )
+    .await;
+
+    let findings = store.verify_chain().await.expect("verify");
+    assert_eq!(
+        findings.len(),
+        1,
+        "exactly the tampered record must be reported: {findings:?}"
+    );
+    let finding = findings.first().expect("one finding");
+    assert_eq!(finding.chain_seq, Some(2));
+    assert_eq!(finding.record_id, Some(target));
+    assert!(
+        finding.finding.contains("modified"),
+        "the finding must say the content changed: {}",
+        finding.finding
+    );
+}
+
+/// A record removed outside retention is detected — in the middle of the trail,
+/// and at its end where no successor would notice.
+#[tokio::test]
+async fn a_deleted_audit_record_is_detected_in_the_middle_and_at_the_end() {
+    let testdb = testkit::db().await.expect("testkit database");
+    let pool = testdb.pool();
+    let store = AuditStore::new(pool.clone());
+    seed(&store, 5).await;
+
+    with_triggers_disabled(&pool, "DELETE FROM audit.audit_event WHERE chain_seq = 3").await;
+    let findings = store.verify_chain().await.expect("verify");
+    assert_eq!(findings.len(), 1, "one gap must be reported: {findings:?}");
+    let finding = findings.first().expect("one finding");
+    assert_eq!(
+        finding.chain_seq,
+        Some(4),
+        "the gap is reported at the record that should have followed the deleted one"
+    );
+    assert!(
+        finding.finding.contains("deleted"),
+        "the finding must say a record went missing: {}",
+        finding.finding
+    );
+
+    // The newest record has no successor to notice its removal; the recorded
+    // chain head does.
+    with_triggers_disabled(&pool, "DELETE FROM audit.audit_event WHERE chain_seq = 5").await;
+    let findings = store.verify_chain().await.expect("verify");
+    assert!(
+        findings
+            .iter()
+            .any(|f| f.finding.contains("end of the chain")),
+        "removing the newest record must be reported: {findings:?}"
+    );
+}
+
+/// Retention reaping stays legitimate: it deletes exactly what the horizon
+/// says, and the surviving trail still verifies.
+#[tokio::test]
+async fn retention_reaping_leaves_a_verifiable_trail() {
+    let testdb = testkit::db().await.expect("testkit database");
+    let pool = testdb.pool();
+    let store = AuditStore::new(pool.clone());
+
+    let now = Timestamp::now();
+    for at in [
+        now - jiff::SignedDuration::from_hours(60 * 24),
+        now - jiff::SignedDuration::from_hours(40 * 24),
+        now,
+    ] {
+        let event = read_event(at, "8fa1::ferroehr::1");
+        let rendered = fhir::to_fhir(&event, &ctx(), None).expect("render");
+        store.insert(&event, None, &rendered).await.expect("insert");
+    }
+
+    assert_eq!(store.reap(30).await.expect("reap"), 2);
+    assert!(
+        store.verify_chain().await.expect("verify").is_empty(),
+        "a reaped trail must still verify: the removal is recorded"
+    );
+
+    let remaining: i64 = sqlx::query_scalar("SELECT count(*) FROM audit.audit_event")
+        .fetch_one(&pool)
+        .await
+        .expect("count");
+    assert_eq!(remaining, 1);
+
+    // And a deletion on top of the reaping is still caught — the recorded
+    // removal covers only what retention actually took.
+    with_triggers_disabled(&pool, "DELETE FROM audit.audit_event WHERE chain_seq = 3").await;
+    assert!(
+        !store.verify_chain().await.expect("verify").is_empty(),
+        "an unrecorded deletion after reaping must still be detected"
+    );
+}
+
+/// The triggers refuse the ordinary rewrite paths outright, while the one
+/// permitted change — the forwarding delivery stamp — still works.
+#[tokio::test]
+async fn the_audit_table_refuses_mutation_deletion_and_truncation() {
+    let testdb = testkit::db().await.expect("testkit database");
+    let pool = testdb.pool();
+    let store = AuditStore::new(pool.clone());
+    seed(&store, 2).await;
+
+    for statement in [
+        "UPDATE audit.audit_event SET principal = 'nobody'",
+        "UPDATE audit.audit_event SET fhir = '{}'::jsonb",
+        "UPDATE audit.audit_event SET row_hash = '\\x00'::bytea",
+        "DELETE FROM audit.audit_event",
+        "TRUNCATE audit.audit_event",
+    ] {
+        let outcome = sqlx::query(AssertSqlSafe(statement.to_owned()))
+            .execute(&pool)
+            .await;
+        assert!(
+            outcome.is_err(),
+            "the append-only table must refuse `{statement}`"
+        );
+    }
+
+    sqlx::query("UPDATE audit.audit_event SET delivered_syslog_at = now()")
+        .execute(&pool)
+        .await
+        .expect("stamping a record as forwarded is the one permitted change");
+    assert!(
+        store.verify_chain().await.expect("verify").is_empty(),
+        "a delivery stamp must not disturb the chain"
+    );
+}
+
+/// The privilege posture of the role the running server connects as, over the
+/// audit trail specifically: it can record an event and stamp it forwarded, and
+/// it can do nothing else — no DDL, no rewrite, no deletion, and no disabling
+/// of the triggers that enforce that.
+///
+/// Roles are cluster-global on the shared harness server, so the login role is
+/// named off the clone database for the testkit sweep to reap.
+#[tokio::test]
+async fn the_application_role_cannot_run_ddl_or_rewrite_the_audit_trail() {
+    let testdb = testkit::db().await.expect("testkit database");
+    let pool = testdb.pool();
+    let role = format!("{}_auditrole", testdb.name());
+    sqlx::query(AssertSqlSafe(format!(
+        "CREATE ROLE {role} LOGIN PASSWORD 'testpw' IN ROLE ferroehr_app"
+    )))
+    .execute(&pool)
+    .await
+    .expect("create the app-privilege role");
+
+    let (scheme, rest) = testdb.url().split_once("://").expect("dsn scheme");
+    let tail = rest.split_once('@').map_or(rest, |(_, t)| t);
+    let mut conn = PgConnection::connect(&format!("{scheme}://{role}:testpw@{tail}"))
+        .await
+        .expect("connect as the app role");
+
+    // DDL, in every direction an application-level SQL flaw could take it.
+    for statement in [
+        "CREATE TABLE audit.zq_probe (id int)",
+        "DROP TABLE audit.audit_event",
+        "ALTER TABLE audit.audit_event ADD COLUMN zq_probe int",
+        "ALTER TABLE audit.audit_event DISABLE TRIGGER USER",
+        "DROP TRIGGER audit_event_chain_link ON audit.audit_event",
+        "CREATE INDEX zq_probe ON audit.audit_event (chain_seq)",
+        "CREATE SCHEMA zq_probe",
+        "DROP FUNCTION audit.verify_audit_chain()",
+    ] {
+        let outcome = sqlx::query(AssertSqlSafe(statement.to_owned()))
+            .execute(&mut conn)
+            .await;
+        assert!(
+            outcome.is_err(),
+            "the application role must not be able to run `{statement}`"
+        );
+    }
+
+    // Recording an event is exactly what it may do.
+    sqlx::query(
+        "INSERT INTO audit.audit_event \
+         (recorded_at, action, outcome, event_code, resource_class, fhir) \
+         VALUES (now(), 'R', 0, '110110', 'composition', '{}'::jsonb)",
+    )
+    .execute(&mut conn)
+    .await
+    .expect("the application role must be able to record an audit event");
+
+    // Rewriting or removing one is not.
+    for statement in [
+        "UPDATE audit.audit_event SET principal = 'nobody'",
+        "UPDATE audit.audit_event SET row_hash = '\\x00'::bytea",
+        "DELETE FROM audit.audit_event",
+        "TRUNCATE audit.audit_event",
+        "UPDATE audit.audit_chain_state SET head_hash = '\\x00'::bytea",
+        "INSERT INTO audit.audit_chain_gap (from_seq, to_seq, link_hash) \
+         VALUES (1, 99, '\\x00'::bytea)",
+    ] {
+        let outcome = sqlx::query(AssertSqlSafe(statement.to_owned()))
+            .execute(&mut conn)
+            .await;
+        assert!(
+            outcome.is_err(),
+            "the application role must not be able to run `{statement}`"
+        );
+    }
+
+    // …while the forwarding stamp and the ITI-81 read the server performs work.
+    sqlx::query("UPDATE audit.audit_event SET delivered_fhir_feed_at = now()")
+        .execute(&mut conn)
+        .await
+        .expect("the application role must be able to stamp delivery");
+    let recorded: i64 = sqlx::query_scalar("SELECT count(*) FROM audit.audit_event")
+        .fetch_one(&mut conn)
+        .await
+        .expect("the application role must be able to read the audit trail");
+    assert_eq!(recorded, 1);
+
+    // And it can run the verification itself, which is how an operator asks the
+    // question without a privileged credential.
+    let findings: i64 = sqlx::query_scalar("SELECT count(*) FROM audit.verify_audit_chain()")
+        .fetch_one(&mut conn)
+        .await
+        .expect("the application role must be able to verify the chain");
+    assert_eq!(findings, 0);
+}
+
+/// `[db].migrate = "verify"` issues no DDL: it accepts a database migrated to
+/// exactly this build and refuses one that is not, naming the schema.
+#[tokio::test]
+async fn verify_mode_accepts_a_migrated_database_and_refuses_a_stale_one() {
+    let testdb = testkit::db().await.expect("testkit database");
+    let pool = testdb.pool();
+
+    let mut settings = db::DbConfig::new(testdb.url());
+    settings.migrate = db::MigrationMode::Verify;
+    db::prepare(&settings, &pool)
+        .await
+        .expect("a fully migrated database must satisfy verify mode");
+
+    // A schema this build owns but the database has never seen.
+    sqlx::query("DROP SCHEMA audit CASCADE")
+        .execute(&pool)
+        .await
+        .expect("drop one migration set");
+
+    let error = db::prepare(&settings, &pool)
+        .await
+        .expect_err("verify mode must refuse an unmigrated schema");
+    assert!(
+        matches!(
+            error,
+            db::DbError::SchemaNotReady(db::SchemaMismatch::NeverMigrated { .. })
+        ),
+        "the refusal must be the typed one: {error}"
+    );
+    assert!(
+        error.to_string().contains("audit"),
+        "the refusal must name the schema: {error}"
+    );
+
+    // Apply mode is the zero-config path, and it repairs what verify refused.
+    settings.migrate = db::MigrationMode::Apply;
+    db::prepare(&settings, &pool)
+        .await
+        .expect("apply mode migrates");
+    db::verify_migrations(&pool)
+        .await
+        .expect("and the database then verifies");
+}
+
+/// A migration recorded from different source text is a stale database, not an
+/// acceptable one: verify mode refuses it rather than serving against a schema
+/// it cannot reason about.
+#[tokio::test]
+async fn verify_mode_refuses_a_database_whose_migration_text_diverged() {
+    let testdb = testkit::db().await.expect("testkit database");
+    let pool = testdb.pool();
+
+    sqlx::query("UPDATE audit._sqlx_migrations SET checksum = '\\x00'::bytea WHERE version = 1")
+        .execute(&pool)
+        .await
+        .expect("forge the recorded checksum");
+
+    let error = db::verify_migrations(&pool)
+        .await
+        .expect_err("a diverged migration must be refused");
+    assert!(
+        matches!(
+            error,
+            db::DbError::SchemaNotReady(db::SchemaMismatch::ChecksumMismatch { .. })
+        ),
+        "the refusal must be the typed one: {error}"
+    );
+}
+
+/// The batched drain path writes through the same trigger, so a batch is
+/// chained record by record rather than left unprotected.
+#[tokio::test]
+async fn the_batched_write_path_is_chained_too() {
+    let testdb = testkit::db().await.expect("testkit database");
+    let pool = testdb.pool();
+    let store = AuditStore::new(pool.clone());
+
+    let mut batch = Vec::new();
+    for n in 0..5_u32 {
+        let event = read_event(Timestamp::now(), &format!("8fa1::ferroehr::{n}"));
+        let rendered = fhir::to_fhir(&event, &ctx(), None).expect("render");
+        batch.push((event, None, Some(rendered)));
+    }
+    store.insert_batch(&batch).await.expect("batch insert");
+
+    let positions: Vec<i64> =
+        sqlx::query("SELECT chain_seq FROM audit.audit_event ORDER BY chain_seq")
+            .fetch_all(&pool)
+            .await
+            .expect("positions")
+            .into_iter()
+            .map(|row| row.get::<i64, _>("chain_seq"))
+            .collect();
+    assert_eq!(positions, vec![1, 2, 3, 4, 5]);
+    assert!(store.verify_chain().await.expect("verify").is_empty());
+}

--- a/app/ferroehr/tests/it/main.rs
+++ b/app/ferroehr/tests/it/main.rs
@@ -23,6 +23,7 @@ mod adl14_knowledge_archetypes;
 mod adl2_fixture;
 mod adl2_vetdf;
 mod aql_planner;
+mod audit_chain;
 mod audit_feed;
 mod audit_store;
 mod canonical_json_literals;

--- a/app/ferroehr/tests/it/service_dump_load.rs
+++ b/app/ferroehr/tests/it/service_dump_load.rs
@@ -1278,6 +1278,7 @@ async fn attestations_round_trip_and_the_restored_signature_verifies() {
         key_path: None,
         key_passphrase: None,
         key_passphrase_file: None,
+        retired_key_paths: Vec::new(),
         verify_on_read: Some(VerifyOnRead::Strict),
     };
     let src_db = testkit::db().await.expect("testkit database");

--- a/app/ferroehr/tests/it/service_import.rs
+++ b/app/ferroehr/tests/it/service_import.rs
@@ -851,6 +851,7 @@ async fn a_signed_import_signs_the_wrapper_and_the_read_verifies_it() {
         key_path: None,
         key_passphrase: None,
         key_passphrase_file: None,
+        retired_key_paths: Vec::new(),
         verify_on_read: Some(VerifyOnRead::Strict),
     };
     let signer = Signer::from_config(&config).expect("digest signer");

--- a/app/ferroehr/tests/it/service_signing.rs
+++ b/app/ferroehr/tests/it/service_signing.rs
@@ -370,6 +370,7 @@ async fn strict_verify_on_read_rejects_a_tampered_row() {
         key_path: None,
         key_passphrase: None,
         key_passphrase_file: None,
+        retired_key_paths: Vec::new(),
         verify_on_read: Some(VerifyOnRead::Strict),
     };
     let signer = Signer::from_config(&config).expect("strict signer");
@@ -468,6 +469,7 @@ fn service_with_verify(pool: PgPool, policy: VerifyOnRead) -> FerroEhrService {
         key_path: None,
         key_passphrase: None,
         key_passphrase_file: None,
+        retired_key_paths: Vec::new(),
         verify_on_read: Some(policy),
     };
     let signer = Signer::from_config(&config).expect("signer");
@@ -575,6 +577,7 @@ fn signing_disabled(pool: PgPool) -> FerroEhrService {
         key_path: None,
         key_passphrase: None,
         key_passphrase_file: None,
+        retired_key_paths: Vec::new(),
         verify_on_read: Some(VerifyOnRead::Off),
     };
     let signer = Signer::from_config(&config).expect("disabled signer");

--- a/app/ferroehr/tests/it/signing_pgp.rs
+++ b/app/ferroehr/tests/it/signing_pgp.rs
@@ -19,7 +19,9 @@ use ferroehr::versioning::signature::config::{Mode, SigningConfig, VerifyOnRead}
 use ferroehr::versioning::signature::key::KeyError;
 use ferroehr::versioning::signature::signer::{Signer, SigningError};
 use ferroehr::versioning::signature::verify::Verdict;
-use pgp::composed::{ArmorOptions, KeyType, SecretKeyParamsBuilder, SignedSecretKey};
+use pgp::composed::{
+    ArmorOptions, KeyType, SecretKeyParamsBuilder, SignedSecretKey, SubkeyParamsBuilder,
+};
 use rand::rngs::OsRng;
 
 /// A short openEHR-canonical-form-like string to sign in the tests.
@@ -59,6 +61,7 @@ fn pgp_signer(armored_key: &str, passphrase: Option<&str>) -> Result<Signer, Sig
         key_path: Some(temp_file(armored_key)),
         key_passphrase: passphrase.map(ferroehr::config::secret::Secret::new),
         key_passphrase_file: None,
+        retired_key_paths: Vec::new(),
         verify_on_read: Some(VerifyOnRead::Strict),
     };
     Signer::from_config(&config)
@@ -118,6 +121,7 @@ fn boot_fails_when_key_path_missing() {
         key_path: None,
         key_passphrase: None,
         key_passphrase_file: None,
+        retired_key_paths: Vec::new(),
         verify_on_read: Some(VerifyOnRead::Off),
     };
     assert!(matches!(
@@ -156,6 +160,7 @@ fn boot_fails_on_missing_key_file() {
         key_path: Some(PathBuf::from("/nonexistent/ferroehr-signing/key.asc")),
         key_passphrase: None,
         key_passphrase_file: None,
+        retired_key_paths: Vec::new(),
         verify_on_read: Some(VerifyOnRead::Off),
     };
     assert!(matches!(
@@ -173,6 +178,7 @@ fn digest_mode_verify_matches_and_mismatches() {
         key_path: None,
         key_passphrase: None,
         key_passphrase_file: None,
+        retired_key_paths: Vec::new(),
         verify_on_read: Some(VerifyOnRead::Strict),
     };
     let signer = Signer::from_config(&config).expect("digest signer");
@@ -188,4 +194,179 @@ fn digest_mode_verify_matches_and_mismatches() {
     let pgp_signer = pgp_signer(&pgp_key, None).expect("pgp signer");
     let pgp_sig = pgp_signer.sign(CANONICAL).expect("pgp sign");
     assert_eq!(signer.verify(CANONICAL, &pgp_sig), Verdict::ClientForeign);
+}
+
+/// Generate a key and return `(armored secret, armored PUBLIC certificate)` —
+/// the public half is what a retired key is configured as.
+fn generate_key_pair() -> (String, String) {
+    let mut builder = SecretKeyParamsBuilder::default();
+    builder
+        .key_type(KeyType::Ed25519Legacy)
+        .can_sign(true)
+        .primary_user_id("ferroehr-signing rotation <rotation@ferroehr.local>".into());
+    let params = builder.build().expect("build key params");
+    let key: SignedSecretKey = params.generate(OsRng).expect("generate key");
+    let secret = key
+        .to_armored_string(ArmorOptions::default())
+        .expect("armor secret key");
+    let public = key
+        .to_public_key()
+        .to_armored_string(ArmorOptions::default())
+        .expect("armor public certificate");
+    (secret, public)
+}
+
+/// A `pgp`-mode signer whose `active` key signs and whose `retired` public
+/// certificates are kept for verification only.
+fn signer_with_retired(active: &str, retired: &[&str]) -> Signer {
+    let config = SigningConfig {
+        enabled: true,
+        mode: Mode::Pgp,
+        key_path: Some(temp_file(active)),
+        key_passphrase: None,
+        key_passphrase_file: None,
+        retired_key_paths: retired.iter().map(|cert| temp_file(cert)).collect(),
+        verify_on_read: Some(VerifyOnRead::Strict),
+    };
+    Signer::from_config(&config).expect("build signer")
+}
+
+/// The rotation property: a version signed before a key rotation still
+/// verifies afterwards, provided the retired certificate is retained.
+///
+/// A `VERSION.signature` is an immutable committed fact (RM common master06
+/// §Digital Signature) and carries no key identifier, so re-signing history is
+/// not available — retaining the old public key is the only mechanism.
+#[test]
+fn a_version_signed_before_a_rotation_still_verifies() {
+    let (old_secret, old_public) = generate_key_pair();
+    let (new_secret, _) = generate_key_pair();
+
+    let signature = signer_with_retired(&old_secret, &[])
+        .sign(CANONICAL)
+        .expect("sign with the pre-rotation key");
+
+    let rotated = signer_with_retired(&new_secret, &[&old_public]);
+    assert_eq!(
+        rotated.verify(CANONICAL, &signature),
+        Verdict::PgpValid,
+        "a version signed before the rotation must still verify against the retained certificate"
+    );
+
+    // And this is the defect the retained certificate exists to prevent: with
+    // the old key discarded, reading that same intact record is an integrity
+    // failure under the default strict policy.
+    let discarded = signer_with_retired(&new_secret, &[]);
+    assert_eq!(
+        discarded.verify(CANONICAL, &signature),
+        Verdict::PgpInvalid,
+        "without the retired certificate the pre-rotation signature cannot verify"
+    );
+}
+
+/// Retaining retired keys must not make verification permissive: a signature
+/// matching neither the active key nor any retired one still fails, and so does
+/// tampered content.
+#[test]
+fn a_retired_certificate_does_not_make_verification_permissive() {
+    let (_, old_public) = generate_key_pair();
+    let (new_secret, _) = generate_key_pair();
+    let (stranger_secret, _) = generate_key_pair();
+
+    let rotated = signer_with_retired(&new_secret, &[&old_public]);
+
+    let foreign = signer_with_retired(&stranger_secret, &[])
+        .sign(CANONICAL)
+        .expect("sign with an unrelated key");
+    assert_eq!(
+        rotated.verify(CANONICAL, &foreign),
+        Verdict::PgpInvalid,
+        "a signature by a key in neither the active nor the retired set must fail"
+    );
+
+    let own = rotated.sign(CANONICAL).expect("sign with the active key");
+    assert_eq!(
+        rotated.verify(&format!("{CANONICAL} "), &own),
+        Verdict::PgpInvalid,
+        "tampered content must fail even though the signing key is trusted"
+    );
+}
+
+/// Generate a certificate whose SIGNING happens on a subkey, returning
+/// `(armored secret, armored PUBLIC certificate)`.
+///
+/// This is the OpenPGP-native rotation shape (RFC 9580 §5.2.1.8): the primary
+/// key certifies, a subkey signs, and rotating the subkey leaves the
+/// certificate — and therefore every past signature — intact.
+fn generate_key_pair_with_signing_subkey() -> (String, String) {
+    let mut builder = SecretKeyParamsBuilder::default();
+    builder
+        .key_type(KeyType::Ed25519Legacy)
+        .can_certify(true)
+        .can_sign(false)
+        .primary_user_id("ferroehr-signing subkey <subkey@ferroehr.local>".into())
+        .subkey(
+            SubkeyParamsBuilder::default()
+                .key_type(KeyType::Ed25519Legacy)
+                .can_sign(true)
+                .passphrase(None)
+                .build()
+                .expect("build subkey params"),
+        );
+    let params = builder.build().expect("build key params");
+    let key: SignedSecretKey = params.generate(OsRng).expect("generate key");
+    let secret = key
+        .to_armored_string(ArmorOptions::default())
+        .expect("armor secret key");
+    let public = key
+        .to_public_key()
+        .to_armored_string(ArmorOptions::default())
+        .expect("armor public certificate");
+    (secret, public)
+}
+
+/// Signing goes through a signing-capable SUBKEY when the certificate has one,
+/// and the result verifies — which requires the verifier to walk subkeys, since
+/// `rpgp` checks only the primary key by default.
+#[test]
+fn a_certificate_with_a_signing_subkey_signs_and_verifies_through_it() {
+    let (secret, _) = generate_key_pair_with_signing_subkey();
+    let signer = signer_with_retired(&secret, &[]);
+
+    let signature = signer.sign(CANONICAL).expect("sign via the signing subkey");
+    assert_eq!(
+        signer.verify(CANONICAL, &signature),
+        Verdict::PgpValid,
+        "a subkey signature must verify against its own certificate"
+    );
+    assert_eq!(
+        signer.verify(&format!("{CANONICAL} "), &signature),
+        Verdict::PgpInvalid,
+        "tampered content must still fail when the signature came from a subkey"
+    );
+}
+
+/// The point of subkey signing: a signature made before a rotation verifies
+/// afterwards with **no** retired-keyring entry, because the certificate itself
+/// carries both subkeys.
+///
+/// The retired keyring stays for the case a whole certificate is replaced; this
+/// is the ordinary path, and it needs no operator ceremony at all.
+#[test]
+fn a_subkey_signature_verifies_against_the_certificate_that_retains_it() {
+    let (secret, public) = generate_key_pair_with_signing_subkey();
+    let signature = signer_with_retired(&secret, &[])
+        .sign(CANONICAL)
+        .expect("sign via the signing subkey");
+
+    // A verifier configured with a DIFFERENT active key still accepts it once
+    // the signing certificate is present — here as a retired entry, which is
+    // how a replaced certificate is carried.
+    let (other_secret, _) = generate_key_pair();
+    let rotated = signer_with_retired(&other_secret, &[&public]);
+    assert_eq!(
+        rotated.verify(CANONICAL, &signature),
+        Verdict::PgpValid,
+        "a subkey signature must verify against a retained certificate, not just the active one"
+    );
 }

--- a/deploy/helm/ci/all-features-values.yaml
+++ b/deploy/helm/ci/all-features-values.yaml
@@ -6,8 +6,12 @@ database:
   existingSecretKey: FERROEHR__DB__URL
 
 secrets:
-  authOidcHmacSecret: dev-hmac-secret
-  signingKeyPassphrase: dev-passphrase
+  # 40 bytes of obvious filler. RFC 8725 §3.5 puts a 32-byte floor under a
+  # keyed-MAC key and the server enforces it at boot, so a short "dev-hmac-secret"
+  # renders fine and refuses to start. Low-entropy on purpose: it must read as a
+  # fixture to a human and to a secret scanner alike.
+  authOidcHmacSecret: ci-fixture-not-a-secret-0000000000000000
+  signingKeyPassphrase: ci-fixture-not-a-secret-passphrase
   eventsUrl: amqps://user:pass@rabbitmq:5671/%2f
   fhirOutboundUrl: amqps://user:pass@rabbitmq:5671/%2f
   auditFhirFeedUrl: https://arr:arr-password@arr.example.com/fhir
@@ -52,7 +56,11 @@ config:
     oidc:
       issuer: https://keycloak.example.com/realms/ferroehr
       audiences: [ferroehr]
-      algorithms: [RS256]
+      # HS256, not the RS256 default, because this overlay carries
+      # secrets.authOidcHmacSecret to exercise that route: the server binds the
+      # accepted algorithm set to the key source (RFC 8725 §3.1), so a symmetric
+      # key plus RS256 is refused as the algorithm-confusion setup it is.
+      algorithms: [HS256]
   authz:
     rbac:
       enabled: true
@@ -74,8 +82,28 @@ config:
     header: X-FerroEHR-Tenant
   smart:
     enabled: true
+    # Required whenever SMART is on: the launch context's service URLs are
+    # absolute, so the server has to be told the origin clients reach it at —
+    # it cannot infer one from a request. Matches the ingress host below.
+    public_base_url: https://ferroehr.example.com
     ehr_id_claim: ehrId
     patient_claim: patient
+    # Published verbatim at /.well-known/smart-configuration, so these are
+    # boot-validated rather than free text: absolute https endpoints, a
+    # non-empty response/auth-method set, PKCE S256 (SMART App Launch §7.2),
+    # and an `issuer` equal to auth.oidc.issuer above — one says where apps get
+    # tokens, the other says which tokens this server accepts.
+    endpoints:
+      issuer: https://keycloak.example.com/realms/ferroehr
+      jwks_uri: https://keycloak.example.com/realms/ferroehr/protocol/openid-connect/certs
+      authorization_endpoint: https://keycloak.example.com/realms/ferroehr/protocol/openid-connect/auth
+      token_endpoint: https://keycloak.example.com/realms/ferroehr/protocol/openid-connect/token
+      token_endpoint_auth_methods_supported: [client_secret_basic, private_key_jwt]
+      grant_types_supported: [authorization_code, client_credentials]
+      response_types_supported: [code]
+      code_challenge_methods_supported: [S256]
+      scopes_supported: [openid, fhirUser, launch, "patient/*.rs"]
+      capabilities: [launch-ehr, sso-openid-connect]
   management:
     enabled: true
     base_path: /management

--- a/deploy/helm/ci/basic-auth-values.yaml
+++ b/deploy/helm/ci/basic-auth-values.yaml
@@ -14,7 +14,13 @@ database:
 
 secrets:
   basicUserPasswordHashes:
-    clinician: "$argon2id$v=19$m=19456,t=2,p=1$c2FsdA$hash"
+    # The Argon2id hash of the password "ferroehr" — the same published
+    # development fixture docker/ferroehr.dev.toml and the quickstart compose
+    # file ship, reused here so no new credential-shaped string enters the tree.
+    # It has to be a REAL PHC string: the server parses every password_hash at
+    # boot and refuses the file otherwise, so a "$argon2id$…$hash" placeholder
+    # renders fine and deploys nothing.
+    clinician: "$argon2id$v=19$m=19456,t=2,p=1$ZmVycm9laHJEZXZTYWx0$be5nPwWjfUl1qvSrvkvqvdMOuCgM0VFcN/VN4MFLjT8"
 
 config:
   auth:

--- a/deploy/helm/ci/boot-check.sh
+++ b/deploy/helm/ci/boot-check.sh
@@ -1,0 +1,294 @@
+#!/usr/bin/env bash
+#
+# Boot every committed values overlay against a real ferroehr image.
+#
+# WHY this exists separately from deploy/helm/validate.sh: that script proves a
+# render is well-formed, hardened and byte-stable, and none of those properties
+# imply the server ACCEPTS what was rendered. Issue #2159 is the whole argument —
+# all three overlays rendered clean, passed lint, matched their goldens, and not
+# one of them produced a configuration the server would start on. The only thing
+# that can tell you is the server, so this runs it.
+#
+# What it replays, per overlay — the complete delivery surface, not just the file:
+#   * the ConfigMap's ferroehr.toml (and, when the configuration holds a secret
+#     the chart cannot route, the Secret's copy instead) mounted at /etc/ferroehr;
+#   * every `config.files` entry beside it;
+#   * every file-shaped key of the chart's Secret, with its REAL rendered value,
+#     mounted at /etc/ferroehr-secrets — an overlay's own credential fixtures are
+#     the thing under test (a 15-byte HMAC secret is a boot failure, and a
+#     placeholder written in its place would hide exactly that);
+#   * every FERROEHR__* environment variable the Deployment declares, resolving
+#     `valueFrom.secretKeyRef` against the chart's Secret.
+# The one value that is synthesized is the DSN, which by design comes from a
+# Secret the operator owns and this repository therefore does not carry.
+#
+# What it does NOT do: reach a database, an issuer, a broker or an object store.
+# `config check` loads, merges and validates; it opens no socket. A live install
+# is the k8s-test skill (.claude/skills/k8s-test/).
+#
+# Usage:
+#   deploy/helm/ci/boot-check.sh                       # every deployment overlay
+#   deploy/helm/ci/boot-check.sh path/to/values.yaml   # just this one
+#   FERROEHR_IMAGE=ferroehr:local deploy/helm/ci/boot-check.sh
+#
+# FERROEHR_SKEW_UNSET is the one escape, for judging the chart against a
+# RELEASED image between releases: a comma-separated list of `config.*` paths to
+# unset, for keys the chart carries that the image predates. It is loud, it is
+# never used by CI (which builds the image from the tree, so no key can be too
+# new), and it can only REMOVE configuration — it cannot make a bad value pass.
+#   FERROEHR_IMAGE=ghcr.io/rubentalstra/ferroehr:3.17.3 \
+#   FERROEHR_SKEW_UNSET=config.db.migrate deploy/helm/ci/boot-check.sh
+#
+# Requires docker and helm. The CI lane is `chart-boot` in .github/workflows/ci.yml.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="$(cd "${SCRIPT_DIR}/../ferroehr" && pwd)"
+CI_DIR="$SCRIPT_DIR"
+IMAGE="${FERROEHR_IMAGE:-ghcr.io/rubentalstra/ferroehr:develop}"
+RELEASE_NAME="ferroehr"
+NAMESPACE="ferroehr"
+
+# Overlays that are NOT deployments and are therefore not booted. Each one is
+# named with its reason: an unaccounted values file is an error below, so a new
+# overlay cannot be added and silently skipped — which is the recurrence this
+# whole lane exists to prevent.
+#
+#   secret-leak-values.yaml — a search fixture for validate.sh's secret-leak
+#   gate. Its values are deliberately unusable sentinels (`$argon2id$SENTINEL…`
+#   is not a PHC string), because the gate greps for them; making it bootable
+#   would mean giving it real credentials and losing the attribution the
+#   sentinels buy.
+declare -a NOT_A_DEPLOYMENT=(
+  "secret-leak-values.yaml"
+)
+
+declare -a SKEW_ARGS=()
+if [[ -n "${FERROEHR_SKEW_UNSET:-}" ]]; then
+  IFS=',' read -r -a SKEW_PATHS <<< "$FERROEHR_SKEW_UNSET"
+  for skew_path in "${SKEW_PATHS[@]}"; do
+    SKEW_ARGS+=(--set "${skew_path}=null")
+  done
+fi
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+bold()  { printf '\033[1m%s\033[0m\n' "$*"; }
+
+command -v helm   >/dev/null 2>&1 || { red "helm not found on PATH";   exit 1; }
+command -v docker >/dev/null 2>&1 || { red "docker not found on PATH"; exit 1; }
+
+# ── Split a rendered Secret/ConfigMap into one file per key ──────────────────
+# Handles both scalar (`key: "value"`) and block (`key: |`) entries, keyed by the
+# object's metadata.name so an external Secret is never confused with the
+# chart's own. There is no Python in this repo and no yq on a bare runner.
+split_data() {
+  local rendered="$1" want_name="$2" outdir="$3"
+  mkdir -p "$outdir"
+  awk -v want="$want_name" -v outdir="$outdir" '
+    function unquote(s) {
+      if (s ~ /^".*"$/) {
+        s = substr(s, 2, length(s) - 2)
+        gsub(/\\"/, "\"", s)
+        gsub(/\\\\/, "\\", s)
+      }
+      return s
+    }
+    /^---[[:space:]]*$/ { name = ""; indata = 0; key = ""; next }
+    /^  name: / && !indata { name = $2; next }
+    /^(stringData|data):[[:space:]]*$/ { indata = (name == want); key = ""; next }
+    # Any other top-level key closes the data block.
+    /^[^[:space:]]/ { indata = 0; key = "" }
+    indata {
+      # A comment inside the data block is not a key. Only inside: a comment in
+      # a block scalar is content and is indented past this test.
+      if (!block && $0 ~ /^  #/) { next }
+      if (match($0, /^  [^ #][^:]*:/)) {
+        k = substr($0, 3, RLENGTH - 3)
+        rest = substr($0, RLENGTH + 1)
+        sub(/^[[:space:]]+/, "", rest)
+        if (rest == "|" || rest == "|-" || rest == "|+" || rest == ">" || rest == ">-") {
+          key = k; printf "" > (outdir "/" key)
+          block = 1
+        } else {
+          key = k; block = 0
+          printf "%s", unquote(rest) > (outdir "/" key)
+          close(outdir "/" key)
+          key = ""
+        }
+        next
+      }
+      if (key != "" && block && match($0, /^    /)) {
+        print substr($0, 5) >> (outdir "/" key)
+        next
+      }
+      if (key != "") { close(outdir "/" key); key = "" }
+    }
+  ' "$rendered"
+}
+
+boot_one() {
+  local values="$1"
+  local label; label="$(basename "$values" .yaml)"
+  bold "── ${label} ──────────────────────────────────────────────"
+
+  local work; work="$(mktemp -d)"
+  local cfgdir="${work}/etc-ferroehr"
+  local secdir="${work}/etc-ferroehr-secrets"
+  mkdir -p "$cfgdir" "$secdir"
+
+  local all="${work}/all.yaml"
+  if ! helm template "$RELEASE_NAME" "$CHART_DIR" -n "$NAMESPACE" -f "$values" \
+       ${SKEW_ARGS[@]+"${SKEW_ARGS[@]}"} > "$all" 2>"${work}/render.err"; then
+    red "  render FAILED — this is a chart/values error, not a boot failure:"
+    sed 's/^/    /' "${work}/render.err"
+    return 1
+  fi
+
+  # /etc/ferroehr — the ConfigMap's ferroehr.toml, or the Secret's copy when the
+  # configuration holds something the chart could not route out of it.
+  split_data "$all" "$RELEASE_NAME" "$cfgdir"
+  split_data "$all" "${RELEASE_NAME}-config" "$cfgdir"
+  if [[ ! -s "${cfgdir}/ferroehr.toml" ]]; then
+    red "  no ferroehr.toml was rendered by either the ConfigMap or the config Secret"
+    return 1
+  fi
+
+  # /etc/ferroehr-secrets — the chart's own file-shaped secret keys, at their
+  # real rendered values. A `FERROEHR__…`-spelled key is environment, not a file.
+  split_data "$all" "${RELEASE_NAME}-env" "$secdir"
+  local f
+  for f in "$secdir"/FERROEHR__*; do
+    [[ -e "$f" ]] && rm -f "$f"
+  done
+
+  # The Deployment's declared environment. `value:` literals pass through;
+  # `valueFrom.secretKeyRef` resolves against the chart Secret already split
+  # above, so a key that only exists as environment still arrives.
+  #
+  # Any OTHER env source is refused rather than ignored: the strict boot-time
+  # sweep refuses an unknown FERROEHR_ variable, so an unreplayed source is a
+  # variable this check never presents — a silent hole of exactly the kind that
+  # let #2159 through. Adding a source here means teaching this parser about it.
+  if grep -qE '^ +(envFrom:|.*(configMapKeyRef|fieldRef|resourceFieldRef):)' "$all"; then
+    red "  the Deployment declares an environment source this check cannot replay"
+    red "  (envFrom / configMapKeyRef / fieldRef); teach boot-check.sh about it"
+    return 1
+  fi
+  local envlist="${work}/env"
+  awk '
+    /^          env:/ { inenv = 1; next }
+    inenv && /^          [a-zA-Z]/ { inenv = 0 }
+    !inenv { next }
+    /^            - name: / { name = $3; pending = "" ; next }
+    /^              value: / {
+      v = $0; sub(/^              value: /, "", v)
+      if (v ~ /^".*"$/) { v = substr(v, 2, length(v) - 2) }
+      print name "\tliteral\t" v; name = ""; next
+    }
+    /^                  key: / { if (name != "") { print name "\tsecret\t" $2; name = "" } }
+  ' "$all" > "$envlist"
+
+  local -a docker_env=()
+  local name kind value
+  while IFS=$'\t' read -r name kind value; do
+    [[ -n "$name" ]] || continue
+    case "$kind" in
+      literal) docker_env+=(-e "${name}=${value}") ;;
+      secret)
+        if [[ -f "${secdir}/${value}" ]]; then
+          docker_env+=(-e "${name}=$(cat "${secdir}/${value}")")
+          rm -f "${secdir}/${value}"
+        else
+          # An EXTERNAL Secret the operator owns; the chart never rendered it.
+          docker_env+=(-e "${name}=ci-boot-check-external-secret-value")
+        fi
+        ;;
+    esac
+  done < "$envlist"
+
+  # Every `*_FILE` path the environment or the TOML points at must exist. The
+  # DSN is the one the chart deliberately does not carry.
+  local paths
+  paths="$( { grep -oE '/etc/ferroehr-secrets/[A-Za-z0-9._-]+' "$envlist" "${cfgdir}/ferroehr.toml" || true; } | sed 's#.*/etc/ferroehr-secrets/#/etc/ferroehr-secrets/#' | sort -u)"
+  local p base
+  for p in $paths; do
+    base="$(basename "$p")"
+    [[ -e "${secdir}/${base}" ]] && continue
+    case "$base" in
+      db.url) printf 'postgres://ferroehr_app:pw@postgres:5432/ferroehr' > "${secdir}/${base}" ;;
+      *)
+        red "  ${p} is referenced but no rendered Secret key supplies it"
+        return 1
+        ;;
+    esac
+  done
+
+  echo "  config files:  $(find "$cfgdir" -type f -exec basename {} \; | tr '\n' ' ')"
+  echo "  secret files:  $(find "$secdir" -type f -exec basename {} \; | tr '\n' ' ')"
+  echo "  environment:   $(cut -f1 "$envlist" | tr '\n' ' ')"
+
+  local log="${work}/check.log"
+  # `${a[@]+"${a[@]}"}`: macOS ships bash 3.2, where expanding an EMPTY array
+  # under `set -u` is an unbound-variable error rather than nothing.
+  if docker run --rm \
+       -v "${cfgdir}:/etc/ferroehr:ro" \
+       -v "${secdir}:/etc/ferroehr-secrets:ro" \
+       ${docker_env[@]+"${docker_env[@]}"} \
+       --entrypoint /usr/local/bin/ferroehr "$IMAGE" config check > "$log" 2>&1; then
+    green "  ${IMAGE} accepts ${label}"
+    sed 's/^/    /' "$log"
+    rm -rf "$work"
+    return 0
+  fi
+  red "  ${IMAGE} REFUSES ${label} — a deployment with these values crash-loops:"
+  sed 's/^/    /' "$log"
+  if grep -q 'unknown configuration key' "$log"; then
+    red "  'unknown configuration key' is usually SKEW, not a bad overlay: the chart"
+    red "  carries a key this image predates. Re-run against an image built from this"
+    red "  tree before changing the chart."
+  fi
+  red "  rendered configuration kept at ${work}"
+  return 1
+}
+
+bold "image: ${IMAGE}"
+if [[ "${#SKEW_ARGS[@]}" -gt 0 ]]; then
+  red "SKEW MODE: unsetting ${FERROEHR_SKEW_UNSET} — those keys are NOT judged."
+  red "  Only correct against an image that genuinely predates them; CI never does this."
+fi
+docker image inspect "$IMAGE" >/dev/null 2>&1 || docker pull -q "$IMAGE" >/dev/null || {
+  red "could not obtain ${IMAGE}; set FERROEHR_IMAGE to an image that exists"
+  exit 1
+}
+
+declare -a TARGETS=()
+if [[ $# -gt 0 ]]; then
+  TARGETS=("$@")
+else
+  # Enumerate rather than list: a values file added to ci/ is booted, or is
+  # declared not-a-deployment above with a reason. Nothing is skipped silently.
+  for f in "$CI_DIR"/*-values.yaml; do
+    skip=0
+    for excluded in "${NOT_A_DEPLOYMENT[@]}"; do
+      [[ "$(basename "$f")" == "$excluded" ]] && skip=1
+    done
+    [[ "$skip" -eq 1 ]] || TARGETS+=("$f")
+  done
+  echo "not booted (declared not a deployment): ${NOT_A_DEPLOYMENT[*]}"
+fi
+[[ "${#TARGETS[@]}" -gt 0 ]] || { red "no values files to boot"; exit 1; }
+
+FAILED=()
+for values in "${TARGETS[@]}"; do
+  boot_one "$values" || FAILED+=("$(basename "$values")")
+done
+
+echo
+if [[ "${#FAILED[@]}" -eq 0 ]]; then
+  green "ALL ${#TARGETS[@]} OVERLAY(S) BOOT"
+  exit 0
+fi
+red "REFUSED BY THE SERVER: ${FAILED[*]}"
+exit 1

--- a/deploy/helm/ci/default-values.yaml
+++ b/deploy/helm/ci/default-values.yaml
@@ -1,6 +1,26 @@
 # Minimal realistic production overlay: chart defaults (all optional
-# integrations OFF) plus the one thing every real deployment must supply — the
-# app-role DSN from an existing Secret. Used as the "default" golden render.
+# integrations OFF) plus the only two things every real deployment must supply —
+# the app-role DSN from an existing Secret, and an identity provider. Used as
+# the "default" golden render, and booted against the image by
+# deploy/helm/ci/boot-check.sh.
+#
+# Nothing here is a credential. The DSN comes from a Secret the operator already
+# owns, and the OIDC block below carries no key material at all: with neither
+# `hmac_secret` nor `jwks_json` set, the server resolves signing keys from the
+# issuer's discovery document at first use, so an issuer URL and the audience
+# this deployment answers to are the whole configuration.
 database:
   existingSecret: ferroehr-db
   existingSecretKey: FERROEHR__DB__URL
+
+config:
+  auth:
+    # `auth.enabled` is true in the chart defaults and a server with no
+    # mechanism refuses to boot (RFC 9110 §11.6.1 — a 401 challenge must name a
+    # scheme the server implements), so an overlay that claims to be
+    # production-minimal has to name one. An IdP is the mechanism a real
+    # deployment supplies; Basic would mean shipping a password hash, which
+    # this file has no business carrying.
+    oidc:
+      issuer: https://idp.example.com/realms/ferroehr
+      audiences: [ferroehr]

--- a/deploy/helm/ferroehr/README.md
+++ b/deploy/helm/ferroehr/README.md
@@ -134,6 +134,7 @@ Kubernetes: `>=1.25.0-0`
 | config.authz.rbac.user_role | string | `"USER"` |  |
 | config.db.acquire_timeout_secs | int | `30` |  |
 | config.db.max_connections | int | `10` |  |
+| config.db.migrate | string | `"apply"` |  |
 | config.db.min_connections | int | `0` |  |
 | config.db.statement_timeout_ms | int | `60000` |  |
 | config.events.enabled | bool | `false` |  |
@@ -208,7 +209,17 @@ Kubernetes: `>=1.25.0-0`
 | metrics.serviceMonitor.labels | object | `{}` | Extra labels, for the `serviceMonitorSelector` your Prometheus matches on. |
 | metrics.serviceMonitor.namespace | string | `""` | Namespace for the ServiceMonitor; empty = the release namespace. |
 | metrics.serviceMonitor.scrapeTimeout | string | `"10s"` |  |
-| migrations.runByMigratorRole | bool | `true` | Purely informational marker rendered into NOTES for the operator; the chart never runs migrations itself. |
+| migrations.job.activeDeadlineSeconds | int | `600` | Hard ceiling on the migration step; a migration blocked behind live traffic must fail the release rather than hang it. |
+| migrations.job.backoffLimit | int | `3` | Retries before the Job (and therefore the release) is declared failed. |
+| migrations.job.enabled | bool | `false` | Run the migrations as a pre-install/pre-upgrade hook Job under the migrator DSN. Pair it with config.db.migrate=verify and an app-role-only runtime DSN for the least-privilege posture. |
+| migrations.job.existingSecret | string | `""` | REQUIRED when enabled: an existing Secret holding the MIGRATOR DSN (`postgres://ferroehr_migrator:...@host:5432/ferroehr`). Deliberately a different credential from `database.*`, which carries the runtime app-role DSN — rendering fails if it is empty. |
+| migrations.job.existingSecretKey | string | `"FERROEHR__DB__URL"` | Key WITHIN existingSecret holding the migrator DSN. Mounted as a file; only its PATH reaches the pod's environment. |
+| migrations.job.nodeSelector | object | `{}` | Node selector for the migration pod. |
+| migrations.job.podAnnotations | object | `{}` | Extra annotations on the migration pod. |
+| migrations.job.resources | object | `{}` | Resource requests/limits for the migration pod. |
+| migrations.job.tolerations | list | `[]` | Tolerations for the migration pod. |
+| migrations.job.ttlSecondsAfterFinished | int | `600` | How long the finished Job's pod is kept for its logs. |
+| migrations.runByMigratorRole | bool | `true` | Purely informational marker rendered into NOTES for the operator. |
 | nameOverride | string | `""` | Override the chart name portion of resource names. |
 | networkPolicy.egress.database | object | `{"port":5432,"to":[]}` | The database, which is NOT optional: the server cannot pass readiness without it. Rendering an egress policy with no database destination is a refusal, not a warning (see the template) — an egress policy that forgets the DSN is a total outage that looks like a database failure. `to` takes raw NetworkPolicyPeer entries: a `podSelector`/ `namespaceSelector` for an in-cluster database, or an `ipBlock` for a managed one. `port` is the DSN's port. |
 | networkPolicy.egress.enabled | bool | `false` | Refuse all outbound traffic except DNS, `database` and `rules`. |

--- a/deploy/helm/ferroehr/templates/NOTES.txt
+++ b/deploy/helm/ferroehr/templates/NOTES.txt
@@ -44,12 +44,28 @@ as the unprivileged app role.
      config.db and will crash-loop against a cluster. Set database.existingSecret
      (preferred) or database.url.
 {{ end }}
-Migrations are append-only and MUST be applied by the `ferroehr_migrator` role,
-NOT the runtime app role. Either grant the runtime DSN the migrator role, or
-run migrations out-of-band with a migrator DSN (recommended). Wrap that step
-in a short lock_timeout so DDL blocked behind live traffic fails fast instead
-of queueing, and pin the image by digest so a rollback cannot outrun the
-schema.
+Migrations are append-only DDL and MUST be applied by the `ferroehr_migrator`
+role, NOT the runtime app role.
+{{ if .Values.migrations.job.enabled -}}
+  Migration step: pre-install/pre-upgrade Job, DSN from Secret
+  "{{ .Values.migrations.job.existingSecret }}" key "{{ .Values.migrations.job.existingSecretKey }}"  [OK]
+  {{ if eq (.Values.config.db.migrate | default "apply") "verify" -}}
+  Server posture: config.db.migrate=verify — the server issues no DDL, so its
+  own DSN can be ferroehr_app only.  [least privilege]
+  {{ else -}}
+  ⚠  config.db.migrate is "apply": the server still migrates itself at boot, so
+     its DSN must hold DDL rights and the Job buys you nothing. Set
+     config.db.migrate=verify and give the server an app-role-only DSN.
+  {{ end -}}
+{{ else -}}
+  ⚠  No migration Job. The server migrates itself at boot, so the runtime DSN
+     must be a member of ferroehr_migrator — a process holding DDL rights on
+     the clinical schema. For production set migrations.job.enabled=true with a
+     migrator DSN and config.db.migrate=verify.
+{{ end }}
+Wrap the migration step in a short lock_timeout so DDL blocked behind live
+traffic fails fast instead of queueing, and pin the image by digest so a
+rollback cannot outrun the schema.
 
 ────────────────────────────────────────────────────────────────────────────
 SECURITY POSTURE

--- a/deploy/helm/ferroehr/templates/migration-job.yaml
+++ b/deploy/helm/ferroehr/templates/migration-job.yaml
@@ -1,0 +1,97 @@
+{{- if .Values.migrations.job.enabled }}
+{{- if not .Values.migrations.job.existingSecret }}
+{{- fail "migrations.job.enabled requires migrations.job.existingSecret: the migration step authenticates as ferroehr_migrator, which is a DIFFERENT credential from the runtime database.* DSN — that separation is the whole point of the job" }}
+{{- end }}
+# Out-of-band schema migration, as a Helm pre-install/pre-upgrade hook Job.
+#
+# Migrations are DDL, so whoever applies them can rewrite the schema. Running
+# them here — as `ferroehr_migrator`, in a pod that exits — lets the SERVER run
+# as `ferroehr_app` with no DDL rights at all, which is what
+# config.db.migrate=verify then enforces (it refuses to boot against a database
+# this job has not migrated, rather than migrating it itself).
+#
+# As a hook, Helm creates it before the Deployment and WAITS for it: a failed
+# migration fails the release instead of rolling pods against a schema that was
+# never applied. Deliberately lean — the migration step needs the DSN and
+# nothing else, so it mounts no ConfigMap and runs on the built-in defaults.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "ferroehr.fullname" . }}-migrate
+  labels:
+    {{- include "ferroehr.labels" . | nindent 4 }}
+    app.kubernetes.io/component: migration
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.migrations.job.backoffLimit }}
+  ttlSecondsAfterFinished: {{ .Values.migrations.job.ttlSecondsAfterFinished }}
+  activeDeadlineSeconds: {{ .Values.migrations.job.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        {{- include "ferroehr.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: migration
+      {{- with .Values.migrations.job.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      restartPolicy: Never
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "ferroehr.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      # Same reason as the Deployment: the kubelet's per-Service link variables
+      # land inside the server's reserved FERROEHR_ namespace and the strict
+      # boot-time env sweep then refuses to start.
+      enableServiceLinks: false
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: migrate
+          image: "{{ include "ferroehr.image" . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          args: ["db", "migrate"]
+          env:
+            # The migrator DSN, as a mounted file rather than an environment
+            # value (readable through /proc/<pid>/environ and inherited by every
+            # child process — OWASP Kubernetes Security Cheat Sheet).
+            - name: FERROEHR__DB__URL_FILE
+              value: {{ printf "%s/db.url" (include "ferroehr.secretMountPath" .) | quote }}
+            # This pod's job IS the DDL, whatever the server's posture is.
+            - name: FERROEHR__DB__MIGRATE
+              value: apply
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: migrator-secret
+              mountPath: {{ include "ferroehr.secretMountPath" . }}
+              readOnly: true
+          resources:
+            {{- toYaml .Values.migrations.job.resources | nindent 12 }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: migrator-secret
+          secret:
+            secretName: {{ .Values.migrations.job.existingSecret }}
+            defaultMode: 0440
+            items:
+              - key: {{ .Values.migrations.job.existingSecretKey }}
+                path: db.url
+      {{- with .Values.migrations.job.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.migrations.job.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/helm/ferroehr/values.yaml
+++ b/deploy/helm/ferroehr/values.yaml
@@ -124,22 +124,53 @@ database:
 # ─────────────────────────────────────────────────────────────────────────────
 # Migrations: who runs the schema.
 #
-# Migrations are append-only and are applied by the `ferroehr_migrator` role, NOT
-# by the runtime app role. The app binary DOES call run_migrations on boot, so
-# for that to be safe you EITHER:
-#   (a) grant the runtime DSN the migrator role (simplest; single-tenant), OR
-#   (b) disable in-app migration and run them out-of-band as a Job/CI step with
-#       a migrator DSN (recommended for least-privilege prod).
-# This chart does not ship a migration Job. Run the out-of-band flow with a
-# migrator DSN and a short `lock_timeout`, so DDL blocked behind live traffic
-# fails fast instead of queueing (PostgreSQL 18 docs, "Client Connection
-# Defaults" § lock_timeout:
+# Migrations are append-only DDL, so whoever applies them can rewrite the
+# schema. Two postures, and the choice is yours:
+#   (a) The server migrates itself at boot (config.db.migrate=apply, the
+#       default). Simplest, and the runtime DSN must then be a member of
+#       ferroehr_migrator — i.e. the running process holds DDL rights.
+#   (b) A separate migration step under a migrator DSN, with the server on
+#       config.db.migrate=verify and a DSN that is ferroehr_app ONLY. The server
+#       then issues no DDL at all and refuses to boot against a database that
+#       has not been migrated. Recommended for production.
+# Setting migrations.job.enabled runs (b) for you as a pre-install/pre-upgrade
+# hook Job that Helm waits on, so a failed migration fails the release. Point
+# its migrator DSN at a short `lock_timeout` (`?options=-c%20lock_timeout%3D5s`)
+# so DDL blocked behind live traffic fails fast instead of queueing (PostgreSQL
+# 18 docs, "Client Connection Defaults" § lock_timeout:
 # https://www.postgresql.org/docs/18/runtime-config-client.html).
 # ─────────────────────────────────────────────────────────────────────────────
 migrations:
-  # -- Purely informational marker rendered into NOTES for the operator; the
-  # chart never runs migrations itself.
+  # -- Purely informational marker rendered into NOTES for the operator.
   runByMigratorRole: true
+  job:
+    # -- Run the migrations as a pre-install/pre-upgrade hook Job under the
+    # migrator DSN. Pair it with config.db.migrate=verify and an app-role-only
+    # runtime DSN for the least-privilege posture.
+    enabled: false
+    # -- REQUIRED when enabled: an existing Secret holding the MIGRATOR DSN
+    # (`postgres://ferroehr_migrator:...@host:5432/ferroehr`). Deliberately a
+    # different credential from `database.*`, which carries the runtime app-role
+    # DSN — rendering fails if it is empty.
+    existingSecret: ""
+    # -- Key WITHIN existingSecret holding the migrator DSN. Mounted as a file;
+    # only its PATH reaches the pod's environment.
+    existingSecretKey: FERROEHR__DB__URL
+    # -- Retries before the Job (and therefore the release) is declared failed.
+    backoffLimit: 3
+    # -- How long the finished Job's pod is kept for its logs.
+    ttlSecondsAfterFinished: 600
+    # -- Hard ceiling on the migration step; a migration blocked behind live
+    # traffic must fail the release rather than hang it.
+    activeDeadlineSeconds: 600
+    # -- Resource requests/limits for the migration pod.
+    resources: {}
+    # -- Extra annotations on the migration pod.
+    podAnnotations: {}
+    # -- Node selector for the migration pod.
+    nodeSelector: {}
+    # -- Tolerations for the migration pod.
+    tolerations: []
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Secret values carried by a chart-managed Secret. Anything set here is rendered
@@ -284,6 +315,11 @@ config:
 
   # [db] — pool bounds (the DSN itself is the FERROEHR__DB__URL secret, above).
   db:
+    # apply | verify — whether the server runs its embedded migrations at boot.
+    # `verify` issues no DDL and refuses to boot against a database that has not
+    # been migrated, which is what lets the runtime DSN be ferroehr_app only.
+    # Pair it with migrations.job.enabled (see the Migrations section above).
+    migrate: apply
     max_connections: 10
     min_connections: 0
     acquire_timeout_secs: 30

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -140,8 +140,8 @@ metadata:
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
 stringData:
-  auth.oidc.hmac_secret: "dev-hmac-secret"
-  signing.key_passphrase: "dev-passphrase"
+  auth.oidc.hmac_secret: "ci-fixture-not-a-secret-0000000000000000"
+  signing.key_passphrase: "ci-fixture-not-a-secret-passphrase"
   multimedia.secret_access_key: "s3-secret"
   terminology.external.oauth2_clients.tx.client_secret: "tx-client-secret"
   events.url: "amqps://user:pass@rabbitmq:5671/%2f"
@@ -219,7 +219,7 @@ data:
     [auth]
       enabled = true
       [auth.oidc]
-        algorithms = ["RS256"]
+        algorithms = ["HS256"]
         audiences = ["ferroehr"]
         issuer = "https://keycloak.example.com/realms/ferroehr"
     
@@ -240,6 +240,7 @@ data:
     [db]
       acquire_timeout_secs = 30.0
       max_connections = 10.0
+      migrate = "apply"
       min_connections = 0.0
       statement_timeout_ms = 60000.0
     
@@ -314,6 +315,18 @@ data:
       ehr_id_claim = "ehrId"
       enabled = true
       patient_claim = "patient"
+      public_base_url = "https://ferroehr.example.com"
+      [smart.endpoints]
+        authorization_endpoint = "https://keycloak.example.com/realms/ferroehr/protocol/openid-connect/auth"
+        capabilities = ["launch-ehr", "sso-openid-connect"]
+        code_challenge_methods_supported = ["S256"]
+        grant_types_supported = ["authorization_code", "client_credentials"]
+        issuer = "https://keycloak.example.com/realms/ferroehr"
+        jwks_uri = "https://keycloak.example.com/realms/ferroehr/protocol/openid-connect/certs"
+        response_types_supported = ["code"]
+        scopes_supported = ["openid", "fhirUser", "launch", "patient/*.rs"]
+        token_endpoint = "https://keycloak.example.com/realms/ferroehr/protocol/openid-connect/token"
+        token_endpoint_auth_methods_supported = ["client_secret_basic", "private_key_jwt"]
     
     [subject_proxy]
       [subject_proxy.systems]
@@ -406,7 +419,7 @@ spec:
         # secret values. Hashing the ConfigMap template alone missed the last two,
         # so a rotated passphrase or an edited Cedar policy propagated into the
         # volume while every pod kept running on the value it read at startup.
-        checksum/config: a165250dd7f8359264f7760c12f03dad3a89fdb2e09b95517b2a5b17b8b24674
+        checksum/config: 90f50521ae6482cacb9e62c525f405147839440a91e4f0b39e59e5cfe9d86b01
         prometheus.io/scrape: "true"
         prometheus.io/port: "9100"
         prometheus.io/path: "/management/prometheus"

--- a/deploy/helm/golden/basic-auth.yaml
+++ b/deploy/helm/golden/basic-auth.yaml
@@ -92,7 +92,7 @@ metadata:
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
 stringData:
-  auth.basic.users.clinician.password_hash: "$argon2id$v=19$m=19456,t=2,p=1$c2FsdA$hash"
+  auth.basic.users.clinician.password_hash: "$argon2id$v=19$m=19456,t=2,p=1$ZmVycm9laHJEZXZTYWx0$be5nPwWjfUl1qvSrvkvqvdMOuCgM0VFcN/VN4MFLjT8"
 ---
 # Source: ferroehr/templates/configmap.yaml
 apiVersion: v1
@@ -150,6 +150,7 @@ data:
     [db]
       acquire_timeout_secs = 30.0
       max_connections = 10.0
+      migrate = "apply"
       min_connections = 0.0
       statement_timeout_ms = 60000.0
     
@@ -275,7 +276,7 @@ spec:
         # secret values. Hashing the ConfigMap template alone missed the last two,
         # so a rotated passphrase or an edited Cedar policy propagated into the
         # volume while every pod kept running on the value it read at startup.
-        checksum/config: e34520697a2234e54ea2295b6ea425d93e699736cff3d583583e93e235426109
+        checksum/config: 6050744bc3cc2188305172b951c54e904764777ef0c9acddeb5d0f219734c93a
       labels:
         app.kubernetes.io/name: ferroehr
         app.kubernetes.io/instance: ferroehr

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -100,6 +100,9 @@ data:
     
     [auth]
       enabled = true
+      [auth.oidc]
+        audiences = ["ferroehr"]
+        issuer = "https://idp.example.com/realms/ferroehr"
     
     [authz]
       [authz.abac]
@@ -113,6 +116,7 @@ data:
     [db]
       acquire_timeout_secs = 30.0
       max_connections = 10.0
+      migrate = "apply"
       min_connections = 0.0
       statement_timeout_ms = 60000.0
     
@@ -238,7 +242,7 @@ spec:
         # secret values. Hashing the ConfigMap template alone missed the last two,
         # so a rotated passphrase or an edited Cedar policy propagated into the
         # volume while every pod kept running on the value it read at startup.
-        checksum/config: 56b27677dacb10e12e8d9eb5499de9c36f77975a644aeb63d03b6c19eea478d8
+        checksum/config: 9e0f0e003bae3028c5c76181b6ba5eacaa1a38897acdda085ee44b281e22a02f
       labels:
         app.kubernetes.io/name: ferroehr
         app.kubernetes.io/instance: ferroehr

--- a/deploy/helm/validate.sh
+++ b/deploy/helm/validate.sh
@@ -17,6 +17,13 @@
 #   5. kubeconform     — schema-validate the manifests IF kubeconform is on PATH
 #                        (optional; skipped with a note when absent/offline)
 #
+# What it does NOT check is printed at the end of every run, and is not a
+# footnote: every one of those properties has failed while this script was green
+# (#2159 — all three overlays rendered, linted and matched their goldens while
+# producing configurations the server refuses to start on). A green run here
+# means the MANIFESTS are well-formed, hardened and unchanged. It says nothing
+# about whether the deployment works.
+#
 # Usage:
 #   deploy/helm/validate.sh            # validate (fails on lint/render/golden drift)
 #   deploy/helm/validate.sh --update   # regenerate the golden renders, then validate
@@ -383,9 +390,39 @@ else
   printf '%s\n' "helm-docs: not installed — skipping the chart README drift check"
 fi
 
+# ── What a green run above does NOT mean ─────────────────────────────────────
+# Printed unconditionally, on success and on failure. It is the direct answer to
+# #2159: every committed overlay was rendering, linting and matching its golden
+# while none of them produced a configuration the server accepts, and the reason
+# nobody noticed is that a green run here reads like a working deployment.
+bold "── not checked by this script ───────────────────────────"
+cat <<'BOUNDARY'
+  This script renders. It never runs the server, and never talks to a cluster.
+  It therefore cannot tell you any of the following, and a green result above
+  must not be read as evidence of them:
+
+    * that the server ACCEPTS the rendered ferroehr.toml — the keys it carries,
+      their types, and the semantic rules validated at boot (an auth mechanism,
+      the RFC 8725 32-byte HMAC floor, a real Argon2id PHC string, the SMART
+      requirements). Run: deploy/helm/ci/boot-check.sh   [CI: chart-boot]
+    * that the image the chart selects UNDERSTANDS those keys. `appVersion` and
+      the chart's config defaults move on different clocks, so a key added
+      in-tree can be rejected by the released image.
+      Run: FERROEHR_IMAGE=ghcr.io/rubentalstra/ferroehr:<tag> \
+             deploy/helm/ci/boot-check.sh   [CI: publish-chart.yml, on a tag]
+    * that a pod STARTS, migrates the database, passes its probes and serves a
+      request — config validation opens no socket. Run: the k8s-test skill
+      (.claude/skills/k8s-test/) against a real cluster.
+    * that the values are semantically sensible for a real deployment: that the
+      issuer exists, the broker is reachable, the S3 bucket resolves, the
+      NetworkPolicy egress rules actually match the peers in use.
+    * anything about the CHART's behaviour under `helm upgrade`, or about
+      resource sizing, scheduling or autoscaling behaviour under load.
+BOUNDARY
+
 echo
 if [[ "$FAIL" -eq 0 ]]; then
-  green "ALL CHECKS PASSED"
+  green "ALL RENDER CHECKS PASSED (see 'not checked' above)"
 else
   red "VALIDATION FAILED"
   exit 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -263,12 +263,21 @@ services:
 
   # SeaweedFS S3 gateway for DV_MULTIMEDIA externalization — DEV/TEST ONLY,
   # behind the `s3` profile (off by default; externalization is OFF by default,
-  # so the app does NOT depend on this). To try it:
-  #   docker compose --profile s3 up
-  #   FERROEHR__MULTIMEDIA__ENABLED=true
-  #   FERROEHR__MULTIMEDIA__ENDPOINT=http://seaweedfs:8333
-  #   FERROEHR__MULTIMEDIA__BUCKET=openehr-multimedia
-  #   FERROEHR__MULTIMEDIA__ALLOW_HTTP=true          # dev only; prod S3 is HTTPS
+  # so the app does NOT depend on this). To try it — three steps, none skippable:
+  #   1. docker compose --profile s3 up -d --wait ferroehr seaweedfs
+  #   2. curl -X PUT http://localhost:8333/openehr-multimedia
+  #      The gateway starts with NO buckets and nothing creates one; S3 answers a
+  #      PUT into a missing bucket with 403 AccessDenied, so the first multimedia
+  #      commit would fail 500 with a message that looks like a credentials
+  #      problem and is not.
+  #   3. add these FOUR keys to the `ferroehr` service's environment: block above
+  #      and re-up. Exporting them in your shell does NOTHING — Compose passes
+  #      through only the variables this file names.
+  #        FERROEHR__MULTIMEDIA__ENABLED: "true"
+  #        FERROEHR__MULTIMEDIA__ENDPOINT: http://seaweedfs:8333
+  #        FERROEHR__MULTIMEDIA__BUCKET: openehr-multimedia
+  #        FERROEHR__MULTIMEDIA__ALLOW_HTTP: "true"   # dev only; prod S3 is HTTPS
+  #      Verify with `curl -s -u ferroehr:ferroehr localhost:8080/management/env`.
   # With no AWS keys the gateway runs in unauthenticated "allow-all" mode
   # (dev/test only). In production point FERROEHR__MULTIMEDIA__* at a real,
   # credentialed, HTTPS S3 endpoint (AWS S3 / MinIO / etc.) instead of this.

--- a/docker/postgres/initdb/10-ferroehr-init.sh
+++ b/docker/postgres/initdb/10-ferroehr-init.sh
@@ -67,6 +67,8 @@ fi
 psql_app <<SQL
 CREATE SCHEMA IF NOT EXISTS ehr AUTHORIZATION "${APP_USER}";
 CREATE SCHEMA IF NOT EXISTS ext AUTHORIZATION "${APP_USER}";
+-- The local IHE ATNA Audit Record Repository, deliberately its own schema.
+CREATE SCHEMA IF NOT EXISTS audit AUTHORIZATION "${APP_USER}";
 
 -- Installed by the superuser so the app role never needs it.
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA ext;
@@ -75,9 +77,10 @@ CREATE EXTENSION IF NOT EXISTS pg_trgm    WITH SCHEMA ext;
 -- Required by the temporal vo_version PRIMARY KEY (... WITHOUT OVERLAPS).
 CREATE EXTENSION IF NOT EXISTS btree_gist WITH SCHEMA ext;
 
--- The app role owns both schemas already; make the intent explicit.
-GRANT ALL ON SCHEMA ehr TO "${APP_USER}";
-GRANT ALL ON SCHEMA ext TO "${APP_USER}";
+-- The app role owns the schemas already; make the intent explicit.
+GRANT ALL ON SCHEMA ehr   TO "${APP_USER}";
+GRANT ALL ON SCHEMA ext   TO "${APP_USER}";
+GRANT ALL ON SCHEMA audit TO "${APP_USER}";
 SQL
 
 echo "ferroehr init: done"

--- a/website/book/src/audit.md
+++ b/website/book/src/audit.md
@@ -47,7 +47,7 @@ Records fan out to independently configured sinks (`[audit]` in
 
 | Sink | Default | What it does |
 |---|---|---|
-| `[audit.store]` | **on** | The local **Audit Record Repository**: records persist in the dedicated `audit` PostgreSQL schema (append-only, strictly outside the EHR content), served back via the ITI-81 search below. `retention_days` prunes old records hourly (`0` = keep forever). |
+| `[audit.store]` | **on** | The local **Audit Record Repository**: records persist in the dedicated `audit` PostgreSQL schema (append-only and tamper-evident, strictly outside the EHR content), served back via the ITI-81 search below. `retention_days` prunes old records hourly (`0` = keep forever). |
 | `[audit.syslog]` | off | The classic ATNA feed: DICOM PS3.15 XML over syslog (RFC 5424; UDP or TLS transport) to an external ARR, per IHE ITI-20. |
 | `[audit.fhir_feed]` | off | The RESTful-ATNA feed (ITI-20 **ATX: FHIR Feed**): each FHIR `AuditEvent` is `POST`ed to an external FHIR ARR. With the local store on, delivery is **outbox-driven**: an ARR outage loses nothing, pending records ship on recovery. |
 
@@ -57,6 +57,54 @@ answer `503 Service Unavailable` until a write succeeds again — no un-audited
 PHI access. (`open`, the default, drops-and-meters instead; every loss path
 is metered — see the `atna_audit_*` counters in
 [Operations](operations.md).)
+
+## Tamper evidence
+
+An audit trail that anything with the application's database password can
+quietly rewrite is a log, not an accountability record. The local store is
+therefore tamper-**evident**: every record is linked into a SHA-256 hash chain
+maintained inside PostgreSQL, so each record commits to its predecessor and to
+its own content. The chain is built by the database itself, not by the server,
+which means it covers every writer — the per-event insert, the batched drain,
+and any statement typed by hand.
+
+Three controls sit on top of it, and they are separate on purpose:
+
+- **The table refuses the ordinary rewrite paths outright.** The only permitted
+  change to a stored record is the per-sink forwarding stamp; an `UPDATE` of any
+  other column, a `DELETE`, and a `TRUNCATE` are refused by the database.
+  Retention pruning goes through the one sanctioned deletion path, which records
+  *which* records it removed and what the surviving chain must link back to — so
+  reaping does not look like tampering, and tampering does not look like
+  reaping.
+- **The privileges are narrow.** The runtime role may record an event, stamp it
+  forwarded, and read the trail back. It holds nothing that can rewrite a
+  record, remove one, or alter the chain's own bookkeeping. That posture is only
+  fully in force with `db.migrate = "verify"` — see
+  [Operations](operations.md#database-roles-and-least-privilege), because a
+  self-migrating server owns the schema and can therefore turn the enforcement
+  off.
+- **Verification is a query you can run yourself.** It recomputes every digest,
+  re-walks every link, and checks both ends of the chain:
+
+  ```sql
+  SELECT * FROM audit.verify_audit_chain();
+  ```
+
+  An empty result means the trail is intact. Any row names one record — its
+  chain position, its id, when it was recorded — and what is wrong with it:
+  content modified after it was written, records deleted with no retention
+  record for the removal, or records removed from the end of the chain where no
+  successor would have noticed. Run it on a schedule and alert on any output.
+
+> [!IMPORTANT]
+> This is **detection, not prevention**, and the boundary is worth stating
+> plainly. The chain is unkeyed, so a party with unrestricted write access to
+> the `audit` schema — the database owner, or a superuser — can delete a record
+> and recompute every hash after it. What closes that case is not a bigger hash:
+> it is keeping the trail somewhere that party does not control. Enable
+> `[audit.syslog]` or `[audit.fhir_feed]` so records leave the box as they are
+> written, and give the server an app-role-only DSN so it is not that party.
 
 ## Retrieving audit records (ITI-81)
 

--- a/website/book/src/beyond-core/s3-multimedia.md
+++ b/website/book/src/beyond-core/s3-multimedia.md
@@ -23,8 +23,9 @@ Offload is a commit-path transformation applied to `DV_MULTIMEDIA` nodes
    no-op if the key already exists.
 3. The node is rewritten in place: its inline `data` is removed and replaced
    with a `uri` of the form `s3://<bucket>/<hash>`, plus an `integrity_check`
-   (the SHA-256 digest), an `integrity_check_algorithm` code phrase (`SHA-256`),
-   and the original `size`.
+   (the same SHA-256 digest — carried as RM `List<Byte>`, so canonical JSON
+   renders it **base64**, while the `uri` spells it lowercase hex), an
+   `integrity_check_algorithm` code phrase (`SHA-256`), and the original `size`.
 
 Uploads happen before anything is persisted, so a failed upload aborts the
 commit — a record is never half-stored.
@@ -45,6 +46,28 @@ treated as its own; foreign `https://` or other-bucket references are left
 alone), **verifies the SHA-256 hash of the fetched bytes against the key**, and
 only then re-inlines the `data`. A hash mismatch is a hard error, so a
 corrupted or tampered blob is never silently served.
+
+If the object store is unreachable, both halves of the path fail loudly rather
+than losing content: a commit that needs to offload is refused `500` and
+nothing is written (the version count is unchanged), and an expanded read of an
+already-offloaded record is refused `500`. A read **without** `expand_multimedia`
+still answers `200` — it never touches the store.
+
+## Turning it back off
+
+Switching `enabled` back to `false` changes two things, and one of them is a
+trap worth knowing before you flip it:
+
+- New commits keep large `DV_MULTIMEDIA` **inline**, byte-identical, with no
+  dependency on the object store. Nothing else about the request or the record
+  changes.
+- Records that were **already** offloaded keep their `s3://` reference, and
+  `?expand_multimedia=true` on them is **ignored**: the read answers `200` with
+  the compact reference and no error. The bytes are still in the bucket, but the
+  API will not return them until the integration is switched back on.
+
+So disable the integration only after you have decided what happens to the blobs
+already in the bucket.
 
 ## Enabling it
 
@@ -67,6 +90,16 @@ If both the access key and secret are unset, the client runs unsigned
 (anonymous) — the mode a local development SeaweedFS accepts with no
 credentials. Set both to use signed requests against a real store.
 
+> [!WARNING]
+> **The bucket must already exist.** The server never creates it, and a store
+> that is reachable but has no such bucket is not a distinguishable condition on
+> the wire: S3 answers a `PUT` into a missing bucket with `403 AccessDenied`, so
+> every multimedia commit fails `500` and the log says `Access Denied` — which
+> reads like a credentials problem and is not. Create the bucket before you
+> enable the integration (the SeaweedFS recipe below shows the one-liner), and
+> leave `endpoint` either unset or a full absolute URL — an **empty** endpoint
+> string is accepted at startup and then fails the request.
+
 > [!NOTE]
 > Externalization is also a **cargo feature** (`multimedia`), on in the
 > published images and any default build. A slim `--no-default-features` build
@@ -86,7 +119,18 @@ credentials. Set both to use signed requests against a real store.
 
 Any S3-compatible store works (AWS S3, MinIO, SeaweedFS). SeaweedFS is a light
 option for development and testing — its S3 gateway needs no credentials.
-Point the server at the gateway and allow plain HTTP for local use:
+
+**Step 1 — create the bucket.** The gateway starts with no buckets at all, and
+nothing creates one for you. Against an unauthenticated development gateway a
+bare `PUT` on the bucket path is enough:
+
+```bash
+curl -X PUT http://127.0.0.1:8333/openehr-multimedia
+curl -s http://127.0.0.1:8333/            # the bucket now appears in ListAllMyBuckets
+```
+
+**Step 2 — point the server at the gateway** and allow plain HTTP for local
+use. For a server you start yourself (from source, or a binary on the host):
 
 ```bash
 export FERROEHR__MULTIMEDIA__ENABLED=true
@@ -95,8 +139,36 @@ export FERROEHR__MULTIMEDIA__BUCKET=openehr-multimedia
 export FERROEHR__MULTIMEDIA__ALLOW_HTTP=true
 ```
 
-With the feature enabled and the bucket reachable, large `DV_MULTIMEDIA` values
+For the [Compose stack](../installation/compose.md), exporting these in your
+shell does **nothing** — Compose passes only the variables the file names, and
+the multimedia keys are not among them. Add them to the `ferroehr` service's
+`environment:` block instead, using the in-network hostname:
+
+```yaml
+  ferroehr:
+    environment:
+      FERROEHR__MULTIMEDIA__ENABLED: "true"
+      FERROEHR__MULTIMEDIA__ENDPOINT: http://seaweedfs:8333
+      FERROEHR__MULTIMEDIA__BUCKET: openehr-multimedia
+      FERROEHR__MULTIMEDIA__ALLOW_HTTP: "true"
+```
+
+**Step 3 — check what the server actually took.** `/management/env` reports the
+effective configuration, which is the quickest way to catch a variable that
+never arrived:
+
+```bash
+curl -s -u ferroehr:ferroehr http://localhost:8080/management/env | jq .multimedia
+```
+
+With the feature enabled and the bucket present, large `DV_MULTIMEDIA` values
 committed through the normal composition APIs (see
 [Using the API](../using-the-api/index.md)) are offloaded automatically; nothing
 about the request or the stored record changes except the size of what lives in
 the database.
+
+> [!NOTE]
+> Base64 inflates a blob by about a third on the wire, and the whole request
+> body is still subject to `[server.limits] body_bytes` (16 MiB by default) —
+> a composition that exceeds it is refused `413` before offload is ever
+> considered. See [`[server.limits]`](../installation/configuration.md).

--- a/website/book/src/installation/compose.md
+++ b/website/book/src/installation/compose.md
@@ -22,7 +22,7 @@ FerroEHR publishes three container images to GHCR:
 | Image | Contents |
 |---|---|
 | `ghcr.io/rubentalstra/ferroehr` | The `ferroehr` server binary. A distroless, non-root, shell-less multi-arch image (amd64 + arm64). Configured via `FERROEHR_*` environment variables and/or a mounted TOML file. |
-| `ghcr.io/rubentalstra/ferroehr-postgres` | `postgres:18.4` with the application role, the layered group roles (`ferroehr_migrator`, `ferroehr_app`, `ferroehr_reader`), database, schemas (`ehr`, `ext`), and required extensions (`uuid-ossp`, `pgcrypto`, `pg_trgm`, `btree_gist`) pre-created, so the app role never needs superuser. The role the server connects as owns the database and belongs to **both** `ferroehr_migrator` and `ferroehr_app`, which is what lets it apply migrations at boot — a least-privilege deployment that connects as `ferroehr_app` alone must run migrations out of band (see [Operations](../operations.md)). |
+| `ghcr.io/rubentalstra/ferroehr-postgres` | `postgres:18.4` with the application role, the layered group roles (`ferroehr_migrator`, `ferroehr_app`, `ferroehr_reader`), database, schemas (`ehr`, `ext`, `audit`), and required extensions (`uuid-ossp`, `pgcrypto`, `pg_trgm`, `btree_gist`) pre-created, so the app role never needs superuser. The role the server connects as owns the database and belongs to **both** `ferroehr_migrator` and `ferroehr_app`, which is what lets it apply migrations at boot — a least-privilege deployment sets `db.migrate = "verify"`, connects as `ferroehr_app` alone, and runs `ferroehr db migrate` out of band under the migrator DSN (see [Operations](../operations.md)). |
 | `ghcr.io/rubentalstra/ferroehr-admin-ui` | The [admin console](../admin-ui/index.md) — a standalone web application that talks to the CDR strictly over ITS-REST. Optional; see the `admin-ui` profile below. |
 
 Each image is published under several tags:
@@ -169,12 +169,35 @@ you ask for them:
   ```
 
 - **`seaweedfs`** (`--profile s3`) — an S3 gateway for large `DV_MULTIMEDIA`
-  externalization (development/test only). Start it with
-  `docker compose --profile s3 up`, then set `FERROEHR__MULTIMEDIA__ENABLED=true`,
-  `FERROEHR__MULTIMEDIA__ENDPOINT=http://seaweedfs:8333`,
-  `FERROEHR__MULTIMEDIA__BUCKET=openehr-multimedia`, and (dev only)
-  `FERROEHR__MULTIMEDIA__ALLOW_HTTP=true`. In production, point the multimedia
-  settings at a real, credentialed, HTTPS S3 endpoint instead.
+  externalization (development/test only). Three steps, and none of them can be
+  skipped:
+
+  ```shell
+  # 1. start the gateway beside the server
+  docker compose --profile s3 up -d --wait ferroehr seaweedfs
+
+  # 2. create the bucket — the gateway starts empty and nothing creates it
+  curl -X PUT http://localhost:8333/openehr-multimedia
+  ```
+
+  ```yaml
+  # 3. add these to the `ferroehr` service's environment: block, then re-up.
+  #    Exporting them in your shell has no effect — Compose passes through only
+  #    the variables this file names, and the multimedia keys are not among them.
+      FERROEHR__MULTIMEDIA__ENABLED: "true"
+      FERROEHR__MULTIMEDIA__ENDPOINT: http://seaweedfs:8333
+      FERROEHR__MULTIMEDIA__BUCKET: openehr-multimedia
+      FERROEHR__MULTIMEDIA__ALLOW_HTTP: "true"
+  ```
+
+  Confirm the server took them with
+  `curl -s -u ferroehr:ferroehr http://localhost:8080/management/env | jq .multimedia`
+  — `"enabled": true` and a non-empty `endpoint` mean the wiring is right.
+  Without the bucket, the first composition carrying a large `DV_MULTIMEDIA`
+  fails `500` and the log reports `Access Denied`, which looks like a
+  credentials problem and is not. In production, point the multimedia settings
+  at a real, credentialed, HTTPS S3 endpoint instead; see
+  [S3 multimedia](../beyond-core/s3-multimedia.md).
 
 Two things that used to be profiles of this file are not any more. Both have to
 *change* the server's configuration to be useful, which a profile cannot do — so

--- a/website/book/src/installation/configuration.md
+++ b/website/book/src/installation/configuration.md
@@ -366,18 +366,22 @@ PostgreSQL connection.
 ```toml
 [db]
 url = "postgres://ferroehr:ferroehr@localhost:5432/ferroehr"
+migrate = "apply"
 max_connections = 20
 min_connections = 2
 acquire_timeout_secs = 30
+statement_timeout_ms = 60000
 ```
 
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `url` | secret URL | `postgres://ferroehr:ferroehr@localhost:5432/ferroehr` | Connection DSN. The default suits a local from-source run against a localhost PostgreSQL (the compose stacks set `FERROEHR__DB__URL` explicitly); **production MUST set it**. Credentials are redacted from every rendering. `DATABASE_URL` is a recognized lower-priority alias. |
 | `url_file` | path | unset | Read the DSN from a file instead of the key above, for a mounted secret. Preferred over the environment form in Kubernetes: an environment value is readable through `/proc/<pid>/environ` and inherited by every child process. At most one of the pair, where the built-in dev default does not count as "set". |
+| `migrate` | enum{apply,verify} | `apply` | Whether the server applies its embedded migrations at boot. `apply` is what makes an empty configuration boot against an empty database. `verify` issues **no DDL at all**: it checks that the database already carries exactly this build's migrations and refuses to start otherwise, so the DSN can authenticate as a role with no DDL rights. See [Operations](../operations.md#applying-migrations). |
 | `max_connections` | int | `20` | Pool ceiling. Write-heavy deployments benefit from 50+. |
 | `min_connections` | int | `2` | Idle connections kept open (avoids cold-reopen churn). |
 | `acquire_timeout_secs` | int | `30` | Seconds to wait for a free connection before failing. |
+| `statement_timeout_ms` | int | `60000` | `statement_timeout` applied to every pooled connection; `0` leaves the server default. The backstop the HTTP request timeout cannot be — dropping a handler future does not cancel the statement PostgreSQL is running. Keep it above `query.timeout_ms` so the AQL engine's own typed refusal fires first. |
 
 ## `[log]`
 

--- a/website/book/src/installation/from-source.md
+++ b/website/book/src/installation/from-source.md
@@ -68,9 +68,12 @@ target/release/ferroehr
 ```
 
 It runs its schema migrations at boot and then serves on the configured bind
-address (default `0.0.0.0:8080`).
+address (default `0.0.0.0:8080`). That boot-time migration is a setting, not a
+fixture: `db.migrate = "verify"` makes the server issue no DDL at all, for a
+deployment whose database role has none of those rights (see
+[Operations](../operations.md#applying-migrations)).
 
-Three global flags and two subcommands round the CLI out:
+Two global flags and three subcommand groups round the CLI out:
 
 - `--config <path>` points at a configuration file, overriding the search
   order (`FERROEHR_CONFIG`, `./ferroehr.toml`, `/etc/ferroehr/ferroehr.toml`);
@@ -82,6 +85,10 @@ Three global flags and two subcommands round the CLI out:
 - `ferroehr config default` writes the annotated default configuration
   template to stdout, which is the reference every key in the
   [configuration reference](configuration.md) is drawn from;
+- `ferroehr db migrate` applies the embedded migrations and exits — the
+  out-of-band schema step, run under a `ferroehr_migrator` DSN;
+- `ferroehr db verify` checks, without issuing any DDL, that the database
+  carries exactly this build's migrations, exiting 0 when it does;
 - `ferroehr healthcheck` (used by the container healthcheck and Kubernetes
   exec probes) probes the status endpoint and exits 0 or 1. It defaults to
   `http://127.0.0.1:8080/ferroehr/rest/status`; override with `--url` or

--- a/website/book/src/installation/kubernetes-hardening.md
+++ b/website/book/src/installation/kubernetes-hardening.md
@@ -1198,50 +1198,79 @@ kubectl -n ferroehr rollout restart deploy/ferroehr
 | S3 credentials | update → restart | or remove them entirely with IRSA/Workload Identity |
 | Audit repository URL | update → restart | still an environment value (no `*_file` sibling) |
 | Basic user password hash | update → restart | rotate the password, re-hash at the OWASP floor |
-| **Version signing key** | **read the next section first** | not a restart-and-forget operation |
+| **Version signing key** | **read the next section first** | rotate the signing SUBKEY, not the certificate — see below |
 
-### The signing key is the one that does not simply rotate
+### Rotating the version signing key
 
 In the default `digest` mode there is no key: `VERSION.signature` is
 `sha256:` + the hash of the canonical form, recomputed at read time. Nothing to
 rotate, and nothing breaks.
 
-In `pgp` mode, rotation has a consequence the other credentials do not:
+In `pgp` mode there are two mechanisms, and the first is the one to reach for.
 
-> [!WARNING]
-> **Replacing the PGP key makes every previously-signed version fail
-> verification.** The stored signature carries no key identifier — the schema
-> holds `signature text` and nothing else — so read-time verification checks an
-> armored PGP signature against *the currently configured key*, and there is only
-> one (`signing.key_path`; the chart mounts a single key, and there is no
-> keyring). After a rotation, versions signed by the old key verify as
-> `pgp_invalid`, which with the default `verify_on_read: strict` is an **integrity
-> failure served as a 5xx** on reading historical data.
+**The ordinary path: rotate the signing subkey.** OpenPGP is built for this. A
+certificate is a primary key plus its subkeys ([RFC 9580
+§10.1](https://www.rfc-editor.org/rfc/rfc9580.html)), the primary key certifies
+while a subkey signs, and rotating means issuing a *new signing subkey* on the
+same certificate. The retired subkey stays in the certificate, so every version
+it signed keeps verifying — with no configuration change, no second key file,
+and no window where history is unreadable. It is also the only path that keeps
+the primary key's identity intact; replacing a primary key discards everything
+that has ever been said about it.
 
-The signatures themselves cannot be re-issued: a `VERSION`'s signature is an
-immutable, committed fact — re-signing would mean rewriting change-controlled
-history, which openEHR's append-only model does not permit and which would destroy
-the property the signature exists to provide.
+```console
+# add a fresh signing subkey to the existing certificate
+gpg --quick-add-key <FINGERPRINT> ed25519 sign 1y
+# revoke or expire the previous one, then re-export BOTH halves
+gpg --export-secret-keys --armor <FINGERPRINT> > signing.asc
+```
 
-So the options, none of which is "rotate and move on":
+Update the mounted Secret and `rollout restart`. The server signs with the
+newest signing-capable subkey and verifies against every subkey the certificate
+carries, so the switch is invisible to readers.
 
-1. **Treat the PGP signing key as long-lived**, protected accordingly (an HSM or a
-   secret manager rather than a chart value), and rotate it only when it is
-   actually compromised.
-2. **If you must rotate**, set `signing.verify_on_read: warn` before doing so.
-   Verification failures are then logged and metered
-   (`version_signature_invalid_total{verdict="pgp_invalid"}`) rather than
-   returned as 5xx, so historical reads keep working while remaining visible. This
-   is a deliberate, recorded reduction in an integrity guarantee — not a setting
-   to leave on by default and forget.
-3. **Use `digest` mode** where the requirement is tamper-evidence rather than
-   attributable authorship. It detects modification of stored content, needs no
-   key, and has no rotation problem.
+**The exception: a whole certificate is replaced.** A compromised primary key,
+an organisational change, or migrating from a different signer means a genuinely
+new certificate — and then the old one must be retained, because a stored
+signature carries no key identifier and a `VERSION` signature is an immutable
+committed fact that cannot be re-issued. Keep the retired **public** key:
 
-There is no multi-key or keyring support, so "verify old signatures with the old
-public key while signing new ones with the new key" is not currently expressible.
-If your governance requires periodic signing-key rotation with historical
-verifiability, that is a gap to raise before choosing `pgp` mode.
+```toml
+[signing]
+mode = "pgp"
+key_path = "/etc/ferroehr/signing.asc"                  # the new certificate
+retired_key_paths = ["/etc/ferroehr/signing-2025.pub.asc"]   # public, verify-only
+```
+
+Under Helm these are `config.signing.key_path` and
+`config.signing.retired_key_paths`, with the files mounted through
+`config.files`.
+
+> [!NOTE]
+> Retired entries are **public** keys, which is what makes the safety property
+> structural rather than a promise: no secret key is loaded for them, so a
+> retired certificate can verify and can never sign again. Verification does not
+> become permissive either — a signature matching neither the active certificate
+> nor any retired one still fails, and tampered content still fails.
+
+This is the same mechanism Debian uses for its archive: `debian-archive-keyring`
+ships current *and* retired keys so packages signed under an older key stay
+verifiable ([Debian archive keys](https://ftp-master.debian.org/keys.html)).
+
+**What neither mechanism covers.** Key *expiry* and *revocation* are a different
+problem: a strict verifier arguably should accept a signature made while the key
+was valid and reject one made after, and nothing in a detached signature proves
+*when* it was made. Solving that needs trusted timestamps (RFC 3161), the
+approach [Sigstore](https://docs.sigstore.dev/about/security/) takes with
+short-lived keys and a timestamp authority. FerroEHR does not implement it, so
+treat an expired signing key as a certificate replacement and use
+`retired_key_paths`.
+
+If you are mid-rotation and need reads to keep working before either mechanism
+is in place, `signing.verify_on_read: warn` downgrades a verification failure
+from a 5xx to a logged and metered event
+(`version_signature_invalid_total{verdict="pgp_invalid"}`). That is a deliberate,
+recorded reduction in an integrity guarantee — not a setting to leave on.
 
 ## Logging: two streams that are not interchangeable
 

--- a/website/book/src/installation/kubernetes.md
+++ b/website/book/src/installation/kubernetes.md
@@ -187,17 +187,48 @@ a superuser:
 | `ferroehr_app` | day-to-day reads and writes — **the running pod connects as this** |
 | `ferroehr_reader` | read-only, for replicas and reporting |
 
-The binary calls its migrations on boot, so you choose one of two flows:
+Migrations are DDL, so whoever applies them can rewrite the schema. Two flows,
+and `config.db.migrate` is where you choose:
 
-- **(a) Grant the runtime DSN the migrator role** — simplest for single-tenant
-  or small deployments; the pod migrates itself at startup.
-- **(b) Run migrations out of band** with a migrator DSN (a CI step or a
-  one-shot `Job`), then start the pods with the lower-privileged `ferroehr_app`
-  DSN — recommended for least-privilege production. Gate the Deployment rollout
-  on the migration step so two server versions never race the schema.
+- **(a) The pod migrates itself** (`config.db.migrate: apply`, the default).
+  Simplest for single-tenant or small deployments — and the runtime DSN must
+  then be a member of `ferroehr_migrator`, so the serving process holds DDL
+  rights on the clinical schema for its whole life.
+- **(b) A separate migration step** (`config.db.migrate: verify`) under a
+  migrator DSN, with the pods on a DSN that is `ferroehr_app` **only**. The
+  server issues no DDL at all and refuses to boot against a database that has
+  not been migrated to its build, so the two versions cannot race the schema.
+  Recommended for production.
 
-The chart does not ship a migration Job; `migrations.runByMigratorRole` is an
-informational marker surfaced in the install NOTES.
+Set `migrations.job.enabled` and the chart runs (b) for you as a
+`pre-install,pre-upgrade` hook `Job`. Helm creates it before the Deployment and
+waits for it, so a failed migration fails the release rather than rolling pods
+against a schema that was never applied. The Job authenticates from its **own**
+Secret — deliberately a different credential from `database.existingSecret` —
+and rendering is refused if you enable it without one:
+
+```yaml
+database:
+  existingSecret: ferroehr-db            # postgres://ferroehr_app:…
+migrations:
+  job:
+    enabled: true
+    existingSecret: ferroehr-db-migrator # postgres://ferroehr_migrator:…
+config:
+  db:
+    migrate: verify
+```
+
+Give the migrator DSN a short `lock_timeout`
+(`?options=-c%20lock_timeout%3D5s`) so DDL blocked behind live traffic fails
+fast instead of queueing. `migrations.runByMigratorRole` remains an
+informational marker surfaced in the install NOTES, which also tell you when
+the Job is enabled but `config.db.migrate` is still `apply` — a combination
+that buys nothing, because the server would migrate itself anyway.
+
+You can check the posture from outside the cluster at any time: `ferroehr db
+verify` exits 0 only when the database carries exactly that build's migrations,
+and issues no DDL doing it.
 
 ## Secrets and mounted config
 
@@ -440,3 +471,32 @@ gate — the helm-version pin, the secret-leak gate, lint, render, the
 security-field assertions and the golden-render diff. It is the same gate CI runs
 on every change to the chart, so a local run and a pull request agree by
 construction.
+
+### Check your values before you deploy them
+
+A render that lints is not a deployment that boots. `validate.sh` never runs the
+server, so it cannot see a configuration the server refuses — a missing
+authentication mechanism, an HMAC secret under the 32-byte floor, a password
+hash that is not a real Argon2id PHC string, SMART enabled without its public
+base URL. Every one of those renders perfectly and crash-loops the pod. The
+script now prints exactly which properties it does not check, so a green run is
+not mistaken for a working deployment.
+
+The check that closes that gap runs the image against your rendered
+configuration:
+
+```shell
+FERROEHR_IMAGE=ghcr.io/rubentalstra/ferroehr:3.17.3 \
+  deploy/helm/ci/boot-check.sh my-values.yaml
+```
+
+It renders the chart, mounts the ConfigMap and the Secret exactly as the
+Deployment does — with their real values, not placeholders — replays the
+declared environment, and runs `ferroehr config check` inside the image. Point
+`FERROEHR_IMAGE` at the tag you intend to deploy: the answer is specific to that
+image, since a key your values carry may be newer than the server that has to
+read it.
+
+It validates configuration only; it opens no socket, so it cannot tell you the
+issuer resolves, the broker is reachable or the database accepts the DSN. CI
+runs the same script over every values overlay the chart ships.

--- a/website/book/src/operations.md
+++ b/website/book/src/operations.md
@@ -34,26 +34,49 @@ not the migrator or the owner.
 `ferroehr_app` holds `SELECT`/`INSERT`/`UPDATE`/`DELETE` on the clinical tables
 and `EXECUTE` on the `ext` helper functions, and nothing else: it is not a
 superuser, does not bypass row-level security, and cannot create, alter or drop
-a table, index, schema or role. That posture is only reachable when the
-migrations are applied out of band, because the server applies its embedded
-migrations on every boot (see the next section) and those are DDL — a
-self-migrating deployment necessarily runs as a role that can execute it. The
-single-container quickstart takes that path: its DSN authenticates as a
-non-superuser role that owns the database and is a member of both
-`ferroehr_migrator` and `ferroehr_app`.
+a table, index, schema or role. On the audit trail it is narrower still — it may
+record an event and stamp it forwarded, and it holds no privilege that can
+rewrite or remove one (see [Audit](audit.md)).
+
+Which posture you actually get depends on `db.migrate`, because the server's
+embedded migrations are DDL: a self-migrating deployment necessarily runs as a
+role that can execute DDL. The single-container quickstart takes that path — its
+DSN authenticates as a non-superuser role that owns the database and is a member
+of both `ferroehr_migrator` and `ferroehr_app`.
 
 ## Applying migrations
 
-The binary applies its embedded migrations on boot, so you choose how
-migrations run:
+`db.migrate` decides who runs the schema:
 
-- **Grant the runtime DSN the migrator role** — simplest, for single-tenant or
-  small deployments; the server migrates itself at startup. Least isolation.
-- **Run migrations out of band** with a migrator DSN, then start the server
-  with the lower-privileged `ferroehr_app` DSN — recommended for
-  least-privilege production. Run the migration as a CI/CD step or a one-shot
-  job with the migrator credential _before_ rolling the deployment, and gate
-  the rollout so two versions never race the schema.
+- **`apply`** (the default) — the server applies its embedded migrations at
+  boot. This is what makes a fresh checkout and an empty database work with no
+  configuration at all, and it is the right choice for development and for
+  small single-tenant deployments. The runtime DSN must be a member of
+  `ferroehr_migrator`, so the serving process holds DDL rights for its whole
+  life. Least isolation.
+- **`verify`** — the server issues **no DDL at all**. At boot it checks that the
+  database carries exactly this build's migrations and refuses to start
+  otherwise, naming the schema and what is wrong with it. The DSN can then be
+  `ferroehr_app` only, which is the least-privilege production posture: an
+  application-level SQL flaw can then reach rows, never the schema.
+
+With `verify`, something else has to run the migrations first. Use the binary's
+own subcommand under the migrator DSN — a CI/CD stage, a one-shot job, or the
+Helm chart's `migrations.job.enabled` hook Job, which Helm waits on so a failed
+migration fails the release:
+
+```shell
+FERROEHR__DB__URL='postgres://ferroehr_migrator:***@pg:5432/ferroehr' \
+  ferroehr db migrate     # applies; exits when done
+FERROEHR__DB__URL='postgres://ferroehr_app:***@pg:5432/ferroehr' \
+  ferroehr db verify      # read-only check; exit 0 iff the schema is current
+```
+
+Gate the rollout on the migration step so two server versions never race the
+schema. Note the difference in failure shape: a `verify` server refuses to boot
+against an unmigrated database (loud, immediate), while an `apply` server that
+loses its schema later stays up and reports readiness `DOWN` — the warning
+below.
 
 > [!WARNING]
 > **Migration is a boot step, and nothing re-runs it.** A running instance whose

--- a/website/book/src/security.md
+++ b/website/book/src/security.md
@@ -552,9 +552,16 @@ the RESTful-ATNA **ITI-81** FHIR search, and optionally forwarded to an
 external ARR over syslog and/or the ITI-20 FHIR feed. Node authentication
 (ITI-19) is available as native mutual TLS on the listener.
 
-The full chapter — record content, sinks, the ITI-81 search, fail-mode
-semantics, and mTLS — is **[Audit trail (IHE ATNA)](audit.md)**; every
-`[audit]` key is in the
+Stored records are **tamper-evident**: each is linked into a SHA-256 hash
+chain maintained by the database, the table refuses every rewrite path except
+the forwarding stamp, and `SELECT * FROM audit.verify_audit_chain()` names any
+record that was modified or removed. That is detection, not prevention — the
+controls that make it hard to forge wholesale are the least-privilege database
+role and the off-box sinks.
+
+The full chapter — record content, sinks, tamper evidence, the ITI-81 search,
+fail-mode semantics, and mTLS — is **[Audit trail (IHE ATNA)](audit.md)**;
+every `[audit]` key is in the
 [configuration reference](installation/configuration.md#audit).
 
 > [!NOTE]


### PR DESCRIPTION
Closes #2122. Closes #2172. Closes #2154. Closes #2127. Closes #2049. Closes #2059. Closes #2051. Closes #2159.

Eight per-issue commits. Two of them started as one issue and turned into something larger once the prior art was read.

## Signing rotation (#2122 + #2172) — the research changed the answer

Rotating a PGP key made every previously-signed version verify as `pgp_invalid` — a 5xx while reading intact clinical records. Looking at how this is already solved found a defect underneath the issue: **OpenPGP provides the mechanism and we could not use it.** RFC 9580 §10.1 defines a transferable public key as a primary key *plus its subkeys*, and rotation means rotating the signing **subkey**, keeping the primary key's accumulated trust. Both ends were unavailable — `pgp` 0.20's `VerifyingKey for SignedPublicKey` consults `self.primary_key` alone and never walks `public_subkeys`, and we signed with the primary key.

So two layers now:

| layer | covers | mechanism |
|---|---|---|
| **subkey signing + full-certificate verification** | ordinary rotation | selected by RFC 9580 §5.2.3.29 key flag `0x02` — by **capability**, never position; verification tries the primary key then every subkey |
| **`signing.retired_key_paths`** | compromise, org change, migrating signers | verify-only **public** keys — no secret is loaded, so a retired certificate structurally *cannot* sign again |

The second is Debian's model for its own archive ([keys](https://ftp-master.debian.org/keys.html)), which is the closest analogue: a long-lived archive of signed artefacts that must stay verifiable across key changes.

Four tests pinning properties, not implementation. The one that earns its place is `a_certificate_with_a_signing_subkey_signs_and_verifies_through_it`: its primary key is `can_sign(false)`, so signing fails the fail-closed boot check if the subkey is not selected, **and** verification fails if subkeys are not walked — one test, both layers. The rotation test asserts both halves: verifies **with** the retained certificate and fails **without** it, so it proves the mechanism rather than its mere presence.

**Not solved, stated rather than implied:** key expiry and revocation. Nothing in a detached signature proves *when* it was made, so a verifier cannot separate "signed while valid" from "signed after expiry". That needs RFC 3161 timestamps — [Sigstore's](https://docs.sigstore.dev/about/security/) approach — and is not implemented.

The hardening chapter's rotation section documented three *workarounds* because no procedure existed; it now leads with subkey rotation.

## Config template completeness (#2154)

`template_parses_to_default` passes on a template missing any number of keys, and `template_mentions_every_section` checks sections — present the moment one key is. Six keys had shipped undiscoverable to `ferroehr config default`, **five of them the file-indirection form of a secret**, mentioned only inside another key's trailing comment.

The new walk over the serialized default is total for concrete fields with no hand-maintained list. Optional fields serialize away, so a second test takes its field list **from serde itself** (`deny_unknown_fields` answers with `expected one of …`) — with a guard that fails loudly if that message format changes, because a test silently checking nothing is worse than none. Mutation-proven both ways.

## Authentication (#2127) — and a leak found on the way

`TokenRejection` gives 20 variants with the `jsonwebtoken` error as a real `source()` — `#[error("{0}")]`, not `transparent`, which forwards `source()` and would erase the inner error. RFC 6750 §3.1 was read first-hand: `invalid_token` covers "expired, revoked, malformed" — one wire code for all — so the wire is correct and unchanged.

**The 401 body was an oracle.** It rendered the rejection to an unauthenticated caller (`invalid bearer token: ExpiredSignature` vs `… InvalidSignature`), separating "a real token, just stale" from "my forgery was caught". Nothing pinned it — no CNF case, no test, verified before changing — so the body is now generic and the reason moves to the log.

## Database trustworthiness (#2049 + #2059)

The runtime role held DDL rights because migrations ran at boot; `db.migrate = verify` never issues DDL and refuses to serve against a database that is not exactly this build's schema. The audit trail was append-only *by convention*; it now carries a hash chain.

**Eight tests against a real PostgreSQL**, asserting properties: a modified record detected **and named**; a deletion caught mid-chain **and at the end** (the case a naive chain misses); the application role refused DDL; `verify` refusing a database whose migration *text* diverged; and the **batched** write path chained too — the path that would otherwise be the hole.

## Console CSP (#2051)

`script-src` is nonce-only, fresh per request, stamped on the wasm bootstrap. Five tests including *the rendered nonce is the one the header authorizes* (they must agree or the page is broken, not merely unprotected) and *every response carries a fresh nonce*. `style-src` keeps its inline allowance and the test **says so by name** rather than leaving it to be discovered.

## Chart values that boot (#2159) — the release blocker

None of the committed `deploy/helm/ci/` files produced an acceptable configuration: no auth mechanism, a placeholder failing the Argon2 PHC check, a 15-byte HMAC against the RFC 8725 32-byte floor. These represent our own recommended deployments and they crash-loop; the tag lane boots them, so this failed the next cut. It survived because `validate.sh` renders and lints and nothing ever *started* one — `boot-check.sh` now does, on every PR rather than only on a tag.

## Gates

- `cargo clippy -p ferroehr -p ferroehr-rest --all-targets --all-features -- -D warnings` — clean
- `cargo clippy -p ferroehr-admin-ui` on **both** targets (ssr + wasm32) — clean
- `cargo nextest run -p ferroehr-admin-ui --features ssr` — **277 passed** (the feature matters: without it the nonce tests do not compile, which is also how CI runs it)
- `cargo nextest run -p ferroehr -E 'test(/audit_chain/)'` — 8 passed against a real database
- `cargo nextest run -p ferroehr -E 'test(/signing_pgp/)'` — 14 passed
- `comment-style`, `typed-status`, `default-style`, `error-hygiene`, `sql-string-building`, `docs-claims`, `image-labels` — all OK at `--all`
- `deploy/helm/validate.sh` — all render checks passed
- Full `--workspace` run in progress at time of writing; one earlier failure (`events_amqp::broker_down_then_up_delivers_without_loss`) was **resource contention** from ten live validation stacks, and passes in isolation — recorded rather than dismissed as flaky.
