### PR TITLE
fix(multimedia,keycloak): an empty endpoint refuses at boot instead of panicking, and the OIDC overlay works

### DIFF
--- a/app/ferroehr-ext/Cargo.toml
+++ b/app/ferroehr-ext/Cargo.toml
@@ -41,6 +41,7 @@ multimedia = [
     "dep:serde_json",
     "dep:sha2",
     "dep:thiserror",
+    "dep:url",
 ]
 
 [lints]
@@ -65,6 +66,7 @@ serde = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }
+url = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/app/ferroehr-ext/src/multimedia/store.rs
+++ b/app/ferroehr-ext/src/multimedia/store.rs
@@ -77,6 +77,33 @@ impl BlobStore {
             .with_region(&params.region)
             .with_allow_http(params.allow_http);
         if let Some(endpoint) = &params.endpoint {
+            // A blank or relative endpoint is refused HERE rather than passed
+            // to the builder, which accepts it and leaves object_store to
+            // panic on `RelativeUrlWithoutBase` at the first request — a panic
+            // on a request path from a configuration value the server took
+            // (#2167). `${VAR:-}` in a compose file and an empty Helm value
+            // both produce exactly this.
+            let endpoint = endpoint.trim();
+            if endpoint.is_empty() {
+                return Err(MultimediaError::Config(
+                    "multimedia.endpoint is set but empty — give an absolute URL \
+                     (e.g. http://seaweedfs:8333) or unset it to use default AWS \
+                     endpoint resolution"
+                        .to_owned(),
+                ));
+            }
+            let parsed = url::Url::parse(endpoint).map_err(|e| {
+                MultimediaError::Config(format!(
+                    "multimedia.endpoint {endpoint:?} is not an absolute URL: {e}"
+                ))
+            })?;
+            if !matches!(parsed.scheme(), "http" | "https") {
+                return Err(MultimediaError::Config(format!(
+                    "multimedia.endpoint {endpoint:?} has scheme {:?} — an S3 endpoint \
+                     must be http or https",
+                    parsed.scheme()
+                )));
+            }
             builder = builder.with_endpoint(endpoint);
         }
         match (&params.access_key_id, &params.secret_access_key) {
@@ -221,5 +248,45 @@ mod tests {
         assert!(!s.exists("k").await.unwrap());
         // delete of an absent key is idempotent.
         s.delete("k").await.unwrap();
+    }
+
+    /// A blank or scheme-less endpoint is a typed configuration error, never a
+    /// panic on the first request (#2167). This is the second line of defence:
+    /// the platform refuses it at boot, and this refuses it if it ever gets
+    /// past that.
+    #[test]
+    fn a_blank_or_schemeless_endpoint_is_a_typed_error_not_a_panic() {
+        for bad in ["", "   ", "seaweedfs:8333", "/bucket"] {
+            let params = BlobStoreParams {
+                endpoint: Some(bad.to_owned()),
+                bucket: "b".to_owned(),
+                region: "us-east-1".to_owned(),
+                access_key_id: None,
+                secret_access_key: None,
+                allow_http: true,
+            };
+            let err = BlobStore::from_params(params)
+                .err()
+                .unwrap_or_else(|| panic!("endpoint {bad:?} must be refused"));
+            assert!(
+                matches!(err, MultimediaError::Config(_)),
+                "endpoint {bad:?} must be a typed Config error, got {err:?}"
+            );
+        }
+    }
+
+    /// An absolute http(s) endpoint still builds, so the check above is not a
+    /// blanket refusal.
+    #[test]
+    fn an_absolute_http_endpoint_still_builds() {
+        let params = BlobStoreParams {
+            endpoint: Some("http://seaweedfs:8333".to_owned()),
+            bucket: "b".to_owned(),
+            region: "us-east-1".to_owned(),
+            access_key_id: None,
+            secret_access_key: None,
+            allow_http: true,
+        };
+        assert!(BlobStore::from_params(params).is_ok());
     }
 }

--- a/app/ferroehr/src/config/mod.rs
+++ b/app/ferroehr/src/config/mod.rs
@@ -214,6 +214,7 @@ impl FerroEhrConfig {
                     .to_owned(),
             ));
         }
+        errors.extend(multimedia_endpoint_errors(&self.multimedia));
         // management.port must differ from the server.bind port.
         if let Some(port) = self.management.port
             && server_bind_port(&self.server.bind) == Some(port)
@@ -444,6 +445,49 @@ pub fn discover_file(
     env: &HashMap<String, String>,
 ) -> Result<Option<PathBuf>, ConfigErrors> {
     loader::discover_file(cli_config, env)
+}
+
+/// The `multimedia.endpoint` semantic checks.
+///
+/// An enabled integration with a blank or scheme-less endpoint used to boot
+/// clean and then fail on the first `DV_MULTIMEDIA` commit (#2167) — a
+/// `${VAR:-}` compose pass-through and an empty Helm value both produce
+/// exactly that, so it is refused at boot where an operator can still act.
+fn multimedia_endpoint_errors(
+    config: &crate::extensions::multimedia::config::MultimediaConfig,
+) -> Vec<ConfigError> {
+    if !config.enabled {
+        return Vec::new();
+    }
+    let Some(endpoint) = &config.endpoint else {
+        return Vec::new();
+    };
+    let trimmed = endpoint.trim();
+    if trimmed.is_empty() {
+        return vec![ConfigError::semantic(
+            "multimedia.endpoint is set but empty — give an absolute URL \
+             (e.g. http://seaweedfs:8333) or remove the key to use default \
+             AWS endpoint resolution"
+                .to_owned(),
+        )];
+    }
+    match url::Url::parse(trimmed) {
+        // `seaweedfs:8333` parses as a URL (scheme `seaweedfs`, path `8333`),
+        // so syntax alone does not catch the common "host:port with no scheme"
+        // mistake — an S3 endpoint is http or https, and nothing else reaches
+        // a bucket.
+        Ok(url) if !matches!(url.scheme(), "http" | "https") => {
+            vec![ConfigError::semantic(format!(
+                "multimedia.endpoint {trimmed:?} has scheme {:?} — an S3 endpoint \
+                 must be http or https (did you mean \"http://{trimmed}\"?)",
+                url.scheme()
+            ))]
+        }
+        Ok(_) => Vec::new(),
+        Err(e) => vec![ConfigError::semantic(format!(
+            "multimedia.endpoint {trimmed:?} is not an absolute URL: {e}"
+        ))],
+    }
 }
 
 #[cfg(test)]
@@ -1090,6 +1134,34 @@ mod tests {
             "the template declares no key line for: {}",
             missing.join(", ")
         );
+    }
+
+    /// An enabled multimedia integration with a blank or relative endpoint is a
+    /// BOOT error, not a panic on the first commit (#2167).
+    #[test]
+    fn an_enabled_multimedia_integration_refuses_a_blank_or_relative_endpoint() {
+        for bad in ["", "   ", "seaweedfs:8333", "/bucket"] {
+            let mut c = FerroEhrConfig::default();
+            c.multimedia.enabled = true;
+            c.multimedia.endpoint = Some(bad.to_owned());
+            let errors = c.validate().expect_err("a bad endpoint must be refused");
+            assert!(
+                format!("{errors:?}").contains("multimedia.endpoint"),
+                "the refusal must name the key so an operator can act on it, got: {errors:?}"
+            );
+        }
+    }
+
+    /// An absent endpoint is legitimate (default AWS resolution) and an
+    /// absolute one is accepted, so the check above cannot be a blanket refusal.
+    #[test]
+    fn an_absent_or_absolute_multimedia_endpoint_is_accepted() {
+        let mut c = FerroEhrConfig::default();
+        c.multimedia.enabled = true;
+        c.multimedia.endpoint = None;
+        assert!(c.validate().is_ok(), "an absent endpoint is legitimate");
+        c.multimedia.endpoint = Some("http://seaweedfs:8333".to_owned());
+        assert!(c.validate().is_ok(), "an absolute endpoint is accepted");
     }
 
     // ── 7. Semantic validation ────────────────────────────────────────────────

--- a/docker-compose.keycloak.yml
+++ b/docker-compose.keycloak.yml
@@ -86,7 +86,12 @@ services:
         - "exec 3<>/dev/tcp/127.0.0.1/8081; printf 'GET /auth/realms/ferroehr/.well-known/openid-configuration HTTP/1.1\\r\\nHost: 127.0.0.1\\r\\nConnection: close\\r\\n\\r\\n' >&3; grep -q '^HTTP/1.1 200' <&3"
       interval: 10s
       timeout: 5s
-      retries: 30
+      # A COLD start is slow and the budget must cover it, because `ferroehr`
+      # gates on this probe: Quarkus augmentation plus the dev-database schema
+      # import was measured at 9m31s on a busy machine, which overran the
+      # previous 30-retry (~5m20s) budget and made `up` fail with "dependency
+      # failed to start" — the CDR then never starts at all.
+      retries: 90
       start_period: 20s
 
 configs:
@@ -97,6 +102,11 @@ configs:
   # (ferroehr / ferroehr) carrying the ADMIN + USER realm roles — Keycloak's
   # default client scopes put realm roles into the token's
   # `realm_access.roles`, which is the CDR's default role claim.
+  # The client's `oidc-audience-mapper` is LOAD-BEARING, not decoration: this
+  # overlay sets FERROEHR__AUTH__OIDC__AUDIENCES=ferroehr, and Keycloak puts a
+  # client into `aud` only when a mapper says so or the token carries that
+  # client's own roles. Without it the realm emits no `ferroehr` audience and
+  # every bearer call is refused 401 (RFC 7519 §4.1.3 audience validation).
   keycloak-realm:
     content: |
       {
@@ -137,7 +147,19 @@ configs:
             "directAccessGrantsEnabled": true,
             "serviceAccountsEnabled": true,
             "redirectUris": [ "*" ],
-            "webOrigins": [ "*" ]
+            "webOrigins": [ "*" ],
+            "protocolMappers": [
+              {
+                "name": "ferroehr-audience",
+                "protocol": "openid-connect",
+                "protocolMapper": "oidc-audience-mapper",
+                "config": {
+                  "included.client.audience": "ferroehr",
+                  "access.token.claim": "true",
+                  "id.token.claim": "false"
+                }
+              }
+            ]
           }
         ]
       }


### PR DESCRIPTION
Closes #2167. Contributes to #2176, #2161, #2158.

## #2167 — a panic on a request path, from a value the server accepted

`multimedia.enabled = true` with `endpoint = ""` booted clean, reported the setting back through `/management/env`, and then panicked in `object_store` on `RelativeUrlWithoutBase` at the first `DV_MULTIMEDIA` commit above the offload threshold. The caller got a 500 from an unwrap.

This is reachable by accident: a `${VAR:-}` compose pass-through, an empty Helm value, and an empty ConfigMap entry all produce exactly it.

**Refused at both ends**, because either alone leaves a hole — boot rejects it where an operator can still act on it, and `BlobStore::from_params` returns a typed `MultimediaError::Config` if it ever gets past boot. Verified against the reproduction's exact configuration:

```
$ ferroehr --config /tmp/mm.toml config check
Error: 1 configuration error(s):
  - multimedia.endpoint is set but empty — give an absolute URL (e.g. http://seaweedfs:8333)
    or remove the key to use default AWS endpoint resolution
```

**The check is not "does it parse".** `seaweedfs:8333` *is* a valid URL — scheme `seaweedfs`, path `8333` — so URL syntax alone misses the commonest mistake there is, a host:port with no scheme. An S3 endpoint is http or https and nothing else reaches a bucket, so the scheme is checked and the message suggests the correction. I only found this because the first version of the test failed on that input.

Four cases each side (`""`, `"   "`, `"seaweedfs:8333"`, `"/bucket"`), **plus** a test that an absent endpoint (default AWS resolution) and an absolute one still work — a guard that refuses everything passes the first test and breaks every real deployment.

`validate()` went over the 100-line clippy limit, so the check is its own `multimedia_endpoint_errors` function, which is the better shape regardless.

## #2176 (partly) — the documented OIDC quickstart returned 401

The demo realm never emitted `ferroehr` in `aud` while the same overlay required that audience: absent `aud` → `Missing required claim: aud`, `aud=account` → `InvalidAudience`. Both shapes were exercised live. The realm now carries an `oidc-audience-mapper`, proven to turn the documented command into `201 Created`.

The healthcheck budget also moves: a cold Keycloak start was measured at **9m31s** against a ~5m20s budget, and the CDR gates on Keycloak's health, so the whole stack never came up. That is the defect behind "the documented setup does not work" as much as the audience is.

## Gates

- `cargo clippy -p ferroehr -p ferroehr-ext --all-targets --all-features -- -D warnings` — clean
- `cargo nextest run -p ferroehr -p ferroehr-ext --all-features -E 'test(/multimedia/) or test(/endpoint/) or test(/config::tests/)'` — 86 passed
- `comment-style`, `error-hygiene`, `default-style` at `--all`, `compose-hardening` — all OK
- `docker compose config -q` on the Keycloak overlay — OK

## Why this kept happening — #2178

Filed alongside: **#2178**, a deployment conformance instrument. Ten defects were found today by driving live systems and **zero** by the 4447-test suite, which was green throughout. Every one of them lives in the gap between "the code is correct" and "the thing we ship to an operator works", and that gap has no instrument — `cnf-runner` measures the wire, and nothing measures the deployment. #2178 asks for the analogue, with every defect in that list becoming a probe that fails on the unfixed code, so today's sweep becomes a permanent net rather than a one-off.
