### PR TITLE
fix(telemetry): metrics_push says what it does not carry, instead of looking complete

### DIFF
--- a/app/ferroehr/src/telemetry/mod.rs
+++ b/app/ferroehr/src/telemetry/mod.rs
@@ -92,6 +92,7 @@ pub fn init(cfg: &TelemetryConfig, build: &BuildInfo) -> Result<TelemetryGuard, 
             opentelemetry::global::set_meter_provider(mp.clone());
             meter = Some(opentelemetry::global::meter(SCOPE));
             meter_provider = Some(mp);
+            warn_metrics_push_is_partial();
         }
 
         // W3C context propagation for ingress/egress correlation.
@@ -117,6 +118,30 @@ pub fn init(cfg: &TelemetryConfig, build: &BuildInfo) -> Result<TelemetryGuard, 
         sampler: None,
         shut: false,
     })
+}
+
+/// Announce, at the moment `metrics_push` is enabled, which families it does
+/// NOT carry.
+///
+/// The server keeps two metric systems: the `OpenTelemetry` SDK's own
+/// instruments, which the OTLP push exports, and the `metrics`-crate recorder
+/// behind `/management/prometheus`, which it does not (#2175). An operator who
+/// enables the push sees metrics appear in their collector and reasonably
+/// concludes the wiring is complete — while the build identity, the request
+/// latency histogram and the audit counters are silently absent. A partial
+/// export that looks complete is worse than one that fails, so it says so.
+///
+/// The list is derived from the catalogue rather than written out, so a metric
+/// added later cannot quietly fall out of this warning.
+fn warn_metrics_push_is_partial() {
+    let scrape_only: Vec<&str> = prometheus::catalog().iter().map(|spec| spec.name).collect();
+    tracing::warn!(
+        families = %scrape_only.join(", "),
+        "telemetry.metrics_push exports the OpenTelemetry SDK instruments ONLY. The families \
+         listed here are recorded through the metrics-crate recorder and reach /management/\
+         prometheus by scrape alone — they will NOT appear in your OTLP collector. Scrape \
+         /management/prometheus as well if you need them (see #2175)."
+    );
 }
 
 /// The `OTel` resource attributes (`service.name`/`service.version` + git sha,

--- a/website/book/src/installation/configuration.md
+++ b/website/book/src/installation/configuration.md
@@ -407,7 +407,7 @@ OpenTelemetry export. Unset `otlp_endpoint` ⇒ the OTel layer is not installed
 | `service_name` | string | `ferroehr` | `service.name` resource attribute. |
 | `environment` | string | `dev` | `deployment.environment` resource attribute. |
 | `traces_sample_ratio` | float | `1.0` | Head-sampling ratio (`0.1` is a common prod start). |
-| `metrics_push` | bool | `false` | Also push metrics over OTLP alongside the Prometheus pull surface. |
+| `metrics_push` | bool | `false` | Push the **OpenTelemetry SDK instruments** over OTLP alongside the Prometheus pull surface. **Partial by design today:** the families recorded through the `metrics`-crate recorder — `ferroehr_build_info`, the HTTP request histogram, active requests, the ATNA audit counters, process start time — reach `/management/prometheus` by scrape only and do **not** appear in an OTLP collector. The server warns at boot listing exactly which families are affected. Scrape `/management/prometheus` as well if you need them ([#2175](https://github.com/rubentalstra/FerroEHR/issues/2175)). |
 | `flame_file` | path | unset ⇒ layer not installed | Span-timing flamegraph capture (`tracing-flame`): write folded stack samples of every span to this file; render offline with `inferno-flamegraph < file > flame.svg`. For diagnostic sessions, not a standing posture — the file grows with span traffic. |
 
 ## `[auth]`


### PR DESCRIPTION
Closes #2175.

`metrics_push` exports **4 of the 10** families `/management/prometheus` exposes, and none of the ones an operator watches — `ferroehr_build_info`, the HTTP request histogram, active requests, the ATNA audit counters and process start time never leave the process over OTLP.

The cause is two metric systems: the OpenTelemetry SDK's own instruments are what the push exports; everything registered through the `metrics`-crate recorder behind `/management/prometheus` is not.

**The harm is not the gap — it is that the gap is invisible.** Metrics appear in the collector, so the wiring looks correct, while the build identity and the latency histogram are silently missing. A partial export that looks complete is worse than one that fails.

So it announces itself at the moment it is enabled, and the configuration reference says the same thing. The family list is **derived from the metric catalogue** rather than written out, so a metric added later cannot quietly fall out of the warning and turn it into a lie.

## Why the completion is not in this PR

Two follow-ups, and the second is the better one:

- **#2180** — bridge the `metrics` crate to OTLP. Verified compatible: `metrics-exporter-opentelemetry` 0.2.1 wants `opentelemetry ^0.31`, `opentelemetry_sdk ^0.31`, `metrics ^0.24.2`, exactly our pins. Smaller change, but keeps two metrics vocabularies.
- **#2181** — **one** `MeterProvider` with two readers (OTLP + `opentelemetry-prometheus`), so both surfaces carry every family by construction. This removes the cause rather than bridging the symptom, and is the recommended path.

I had the maturity argument backwards initially and corrected it on the issues: the project's status table lists **Metrics-API and Metrics-SDK as Stable** while **Traces are Beta throughout** — and we already run OTel traces in production, so consolidating metrics onto OTel moves them onto a *more* mature foundation than what we already depend on. A search result claiming `opentelemetry-prometheus` was discontinued at 0.29 was stale: 0.32.0 shipped 2026-05-08 and no longer depends on `protobuf`.

Neither belongs in a release-day change — #2181 needs a lockstep bump of the whole `opentelemetry*` set and a call-site migration that must preserve histogram bucket boundaries exactly, or every existing dashboard and alert silently changes meaning. The operator-visible harm is removed without them.

## Gates

- `cargo clippy -p ferroehr --all-targets --all-features -- -D warnings` — clean
- `docs-claims.sh --all` — OK
